### PR TITLE
resolve: Use `Macros20NormalizedIdent` in more interfaces

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1187,7 +1187,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                 .get(&expn_id)
                                 .into_iter()
                                 .flatten()
-                                .map(|(ident, _)| TypoSuggestion::typo_from_ident(*ident, res)),
+                                .map(|(ident, _)| TypoSuggestion::typo_from_ident(ident.0, res)),
                         );
                     }
                 }
@@ -1199,7 +1199,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         let res = macro_rules_def.decl.res();
                         if filter_fn(res) {
                             suggestions
-                                .push(TypoSuggestion::typo_from_ident(macro_rules_def.ident, res))
+                                .push(TypoSuggestion::typo_from_ident(macro_rules_def.ident.0, res))
                         }
                     }
                 }
@@ -2892,7 +2892,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             return None;
         }
 
-        let binding_key = BindingKey::new(ident, MacroNS);
+        let binding_key = BindingKey::new(Macros20NormalizedIdent::new(ident), MacroNS);
         let binding = self.resolution(crate_module, binding_key)?.binding()?;
         let Res::Def(DefKind::Macro(kinds), _) = binding.res() else {
             return None;

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -20,7 +20,7 @@ use rustc_session::lint::builtin::{
 use rustc_session::parse::feature_err;
 use rustc_span::edit_distance::find_best_match_for_name;
 use rustc_span::hygiene::LocalExpnId;
-use rustc_span::{Ident, Span, Symbol, kw, sym};
+use rustc_span::{Ident, Macros20NormalizedIdent, Span, Symbol, kw, sym};
 use tracing::debug;
 
 use crate::Namespace::{self, *};
@@ -330,13 +330,13 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     pub(crate) fn try_plant_decl_into_local_module(
         &mut self,
         module: Module<'ra>,
-        ident: Ident,
+        ident: Macros20NormalizedIdent,
         ns: Namespace,
         decl: Decl<'ra>,
         warn_ambiguity: bool,
     ) -> Result<(), Decl<'ra>> {
         let res = decl.res();
-        self.check_reserved_macro_name(ident, res);
+        self.check_reserved_macro_name(ident.0, res);
         self.set_decl_parent_module(decl, module);
         // Even if underscore names cannot be looked up, we still need to add them to modules,
         // because they can be fetched by glob imports from those modules, and bring traits
@@ -474,7 +474,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 let import_decl = self.new_import_decl(binding, *import);
                 let _ = self.try_plant_decl_into_local_module(
                     import.parent_scope.module,
-                    ident.0,
+                    ident,
                     key.ns,
                     import_decl,
                     warn_ambiguity,
@@ -496,11 +496,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             let dummy_decl = self.new_import_decl(dummy_decl, import);
             self.per_ns(|this, ns| {
                 let module = import.parent_scope.module;
-                let _ =
-                    this.try_plant_decl_into_local_module(module, target, ns, dummy_decl, false);
+                let ident = Macros20NormalizedIdent::new(target);
+                let _ = this.try_plant_decl_into_local_module(module, ident, ns, dummy_decl, false);
                 // Don't remove underscores from `single_imports`, they were never added.
                 if target.name != kw::Underscore {
-                    let key = BindingKey::new(target, ns);
+                    let key = BindingKey::new(ident, ns);
                     this.update_local_resolution(module, key, false, |_, resolution| {
                         resolution.single_imports.swap_remove(&import);
                     })
@@ -879,7 +879,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         let import_decl = this.new_import_decl(binding, import);
                         this.get_mut_unchecked().plant_decl_into_local_module(
                             parent,
-                            target,
+                            Macros20NormalizedIdent::new(target),
                             ns,
                             import_decl,
                         );
@@ -888,7 +888,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     Err(Determinacy::Determined) => {
                         // Don't remove underscores from `single_imports`, they were never added.
                         if target.name != kw::Underscore {
-                            let key = BindingKey::new(target, ns);
+                            let key = BindingKey::new(Macros20NormalizedIdent::new(target), ns);
                             this.get_mut_unchecked().update_local_resolution(
                                 parent,
                                 key,
@@ -1504,7 +1504,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     .is_some_and(|binding| binding.warn_ambiguity_recursive());
                 let _ = self.try_plant_decl_into_local_module(
                     import.parent_scope.module,
-                    key.ident.0,
+                    key.ident,
                     key.ns,
                     import_decl,
                     warn_ambiguity,

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -37,7 +37,9 @@ use rustc_session::config::{CrateType, ResolveDocLinks};
 use rustc_session::lint;
 use rustc_session::parse::feature_err;
 use rustc_span::source_map::{Spanned, respan};
-use rustc_span::{BytePos, DUMMY_SP, Ident, Span, Symbol, SyntaxContext, kw, sym};
+use rustc_span::{
+    BytePos, DUMMY_SP, Ident, Macros20NormalizedIdent, Span, Symbol, SyntaxContext, kw, sym,
+};
 use smallvec::{SmallVec, smallvec};
 use thin_vec::ThinVec;
 use tracing::{debug, instrument, trace};
@@ -3629,7 +3631,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
             return;
         };
         ident.span.normalize_to_macros_2_0_and_adjust(module.expansion);
-        let key = BindingKey::new(ident, ns);
+        let key = BindingKey::new(Macros20NormalizedIdent::new(ident), ns);
         let mut decl = self.r.resolution(module, key).and_then(|r| r.best_decl());
         debug!(?decl);
         if decl.is_none() {
@@ -3640,7 +3642,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 TypeNS => ValueNS,
                 _ => ns,
             };
-            let key = BindingKey::new(ident, ns);
+            let key = BindingKey::new(Macros20NormalizedIdent::new(ident), ns);
             decl = self.r.resolution(module, key).and_then(|r| r.best_decl());
             debug!(?decl);
         }

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -572,17 +572,17 @@ struct BindingKey {
 }
 
 impl BindingKey {
-    fn new(ident: Ident, ns: Namespace) -> Self {
-        BindingKey { ident: Macros20NormalizedIdent::new(ident), ns, disambiguator: 0 }
+    fn new(ident: Macros20NormalizedIdent, ns: Namespace) -> Self {
+        BindingKey { ident, ns, disambiguator: 0 }
     }
 
     fn new_disambiguated(
-        ident: Ident,
+        ident: Macros20NormalizedIdent,
         ns: Namespace,
         disambiguator: impl FnOnce() -> u32,
     ) -> BindingKey {
         let disambiguator = if ident.name == kw::Underscore { disambiguator() } else { 0 };
-        BindingKey { ident: Macros20NormalizedIdent::new(ident), ns, disambiguator }
+        BindingKey { ident, ns, disambiguator }
     }
 }
 
@@ -1076,7 +1076,7 @@ impl ExternPreludeEntry<'_> {
 
 struct DeriveData {
     resolutions: Vec<DeriveResolution>,
-    helper_attrs: Vec<(usize, Ident)>,
+    helper_attrs: Vec<(usize, Macros20NormalizedIdent)>,
     has_derive_copy: bool,
 }
 
@@ -1241,7 +1241,7 @@ pub struct Resolver<'ra, 'tcx> {
     /// `macro_rules` scopes produced by `macro_rules` item definitions.
     macro_rules_scopes: FxHashMap<LocalDefId, MacroRulesScopeRef<'ra>>,
     /// Helper attributes that are in scope for the given expansion.
-    helper_attrs: FxHashMap<LocalExpnId, Vec<(Ident, Decl<'ra>)>>,
+    helper_attrs: FxHashMap<LocalExpnId, Vec<(Macros20NormalizedIdent, Decl<'ra>)>>,
     /// Ready or in-progress results of resolving paths inside the `#[derive(...)]` attribute
     /// with the given `ExpnId`.
     derive_data: FxHashMap<LocalExpnId, DeriveData>,
@@ -2251,20 +2251,24 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
     fn extern_prelude_get_item<'r>(
         mut self: CmResolver<'r, 'ra, 'tcx>,
-        ident: Ident,
+        ident: Macros20NormalizedIdent,
         finalize: bool,
     ) -> Option<Decl<'ra>> {
-        let entry = self.extern_prelude.get(&Macros20NormalizedIdent::new(ident));
-        entry.and_then(|entry| entry.item_decl).map(|(binding, _)| {
+        let entry = self.extern_prelude.get(&ident);
+        entry.and_then(|entry| entry.item_decl).map(|(decl, _)| {
             if finalize {
-                self.get_mut().record_use(ident, binding, Used::Scope);
+                self.get_mut().record_use(ident.0, decl, Used::Scope);
             }
-            binding
+            decl
         })
     }
 
-    fn extern_prelude_get_flag(&self, ident: Ident, finalize: bool) -> Option<Decl<'ra>> {
-        let entry = self.extern_prelude.get(&Macros20NormalizedIdent::new(ident));
+    fn extern_prelude_get_flag(
+        &self,
+        ident: Macros20NormalizedIdent,
+        finalize: bool,
+    ) -> Option<Decl<'ra>> {
+        let entry = self.extern_prelude.get(&ident);
         entry.and_then(|entry| entry.flag_decl.as_ref()).and_then(|flag_decl| {
             let (pending_decl, finalized) = flag_decl.get();
             let decl = match pending_decl {

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -29,7 +29,7 @@ use rustc_session::parse::feature_err;
 use rustc_span::edit_distance::find_best_match_for_name;
 use rustc_span::edition::Edition;
 use rustc_span::hygiene::{self, AstPass, ExpnData, ExpnKind, LocalExpnId, MacroKind};
-use rustc_span::{DUMMY_SP, Ident, Span, Symbol, kw, sym};
+use rustc_span::{DUMMY_SP, Ident, Macros20NormalizedIdent, Span, Symbol, kw, sym};
 
 use crate::Namespace::*;
 use crate::errors::{
@@ -52,7 +52,7 @@ pub(crate) struct MacroRulesDecl<'ra> {
     pub(crate) decl: Decl<'ra>,
     /// `macro_rules` scope into which the `macro_rules` item was planted.
     pub(crate) parent_macro_rules_scope: MacroRulesScopeRef<'ra>,
-    pub(crate) ident: Ident,
+    pub(crate) ident: Macros20NormalizedIdent,
 }
 
 /// The scope introduced by a `macro_rules!` macro.
@@ -403,13 +403,10 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
                     ) {
                         Ok((Some(ext), _)) => {
                             if !ext.helper_attrs.is_empty() {
-                                let last_seg = resolution.path.segments.last().unwrap();
-                                let span = last_seg.ident.span.normalize_to_macros_2_0();
-                                entry.helper_attrs.extend(
-                                    ext.helper_attrs
-                                        .iter()
-                                        .map(|name| (i, Ident::new(*name, span))),
-                                );
+                                let span = resolution.path.segments.last().unwrap().ident.span;
+                                entry.helper_attrs.extend(ext.helper_attrs.iter().map(|name| {
+                                    (i, Macros20NormalizedIdent::new(Ident::new(*name, span)))
+                                }));
                             }
                             entry.has_derive_copy |= ext.builtin_name == Some(sym::Copy);
                             ext
@@ -530,7 +527,7 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
         target_trait.for_each_child(self, |this, ident, ns, _binding| {
             // FIXME: Adjust hygiene for idents from globs, like for glob imports.
             if let Some(overriding_keys) = this.impl_binding_keys.get(&impl_def_id)
-                && overriding_keys.contains(&BindingKey::new(ident.0, ns))
+                && overriding_keys.contains(&BindingKey::new(ident, ns))
             {
                 // The name is overridden, do not produce it from the glob delegation.
             } else {

--- a/tests/ui/proc-macro/generate-mod.stderr
+++ b/tests/ui/proc-macro/generate-mod.stderr
@@ -47,7 +47,6 @@ LL | #[derive(generate_mod::CheckDerive)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
    = note: `#[deny(proc_macro_derive_resolution_fallback)]` (part of `#[deny(future_incompatible)]`) on by default
-   = note: this error originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot find type `OuterDerive` in this scope
   --> $DIR/generate-mod.rs:18:10
@@ -57,7 +56,6 @@ LL | #[derive(generate_mod::CheckDerive)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
-   = note: this error originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot find type `FromOutside` in this scope
   --> $DIR/generate-mod.rs:25:14
@@ -67,7 +65,6 @@ LL |     #[derive(generate_mod::CheckDerive)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
-   = note: this error originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot find type `OuterDerive` in this scope
   --> $DIR/generate-mod.rs:25:14
@@ -77,7 +74,6 @@ LL |     #[derive(generate_mod::CheckDerive)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
-   = note: this error originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 8 previous errors
 
@@ -92,7 +88,6 @@ LL | #[derive(generate_mod::CheckDerive)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
    = note: `#[deny(proc_macro_derive_resolution_fallback)]` (part of `#[deny(future_incompatible)]`) on by default
-   = note: this error originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 Future breakage diagnostic:
 error: cannot find type `OuterDerive` in this scope
@@ -104,7 +99,6 @@ LL | #[derive(generate_mod::CheckDerive)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
    = note: `#[deny(proc_macro_derive_resolution_fallback)]` (part of `#[deny(future_incompatible)]`) on by default
-   = note: this error originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 Future breakage diagnostic:
 error: cannot find type `FromOutside` in this scope
@@ -116,7 +110,6 @@ LL |     #[derive(generate_mod::CheckDerive)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
    = note: `#[deny(proc_macro_derive_resolution_fallback)]` (part of `#[deny(future_incompatible)]`) on by default
-   = note: this error originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 Future breakage diagnostic:
 error: cannot find type `OuterDerive` in this scope
@@ -128,7 +121,6 @@ LL |     #[derive(generate_mod::CheckDerive)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
    = note: `#[deny(proc_macro_derive_resolution_fallback)]` (part of `#[deny(future_incompatible)]`) on by default
-   = note: this error originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 Future breakage diagnostic:
 warning: cannot find type `FromOutside` in this scope
@@ -139,7 +131,6 @@ LL | #[derive(generate_mod::CheckDeriveLint)] // OK, lint is suppressed
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
-   = note: this warning originates in the derive macro `generate_mod::CheckDeriveLint` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 Future breakage diagnostic:
 warning: cannot find type `OuterDeriveLint` in this scope
@@ -150,5 +141,4 @@ LL | #[derive(generate_mod::CheckDeriveLint)] // OK, lint is suppressed
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
-   = note: this warning originates in the derive macro `generate_mod::CheckDeriveLint` (in Nightly builds, run with -Z macro-backtrace for more info)
 


### PR DESCRIPTION
It allows to avoid expensive double normalization in some cases.
This is an attempt to fix the perf regressions from https://github.com/rust-lang/rust/pull/149681.