### PR TITLE
Update libc to v0.2.183

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.178"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 dependencies = [
  "rustc-std-workspace-core",
 ]

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -33,7 +33,7 @@ miniz_oxide = { version = "0.8.0", optional = true, default-features = false }
 addr2line = { version = "0.25.0", optional = true, default-features = false }
 
 [target.'cfg(not(all(windows, target_env = "msvc")))'.dependencies]
-libc = { version = "0.2.178", default-features = false, features = [
+libc = { version = "0.2.183", default-features = false, features = [
     'rustc-dep-of-std',
 ], public = true }
 

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -1872,7 +1872,12 @@ fn file_time_to_timespec(time: Option<SystemTime>) -> io::Result<libc::timespec>
             io::ErrorKind::InvalidInput,
             "timestamp is too small to set as a file time",
         )),
-        None => Ok(libc::timespec { tv_sec: 0, tv_nsec: libc::UTIME_OMIT as _ }),
+        None => Ok({
+            let mut ts = libc::timespec::default();
+            ts.tv_sec = 0;
+            ts.tv_nsec = libc::UTIME_OMIT as _;
+            ts
+        }),
     }
 }
 

--- a/library/std/src/sys/pal/unix/time.rs
+++ b/library/std/src/sys/pal/unix/time.rs
@@ -1,3 +1,4 @@
+use core::mem;
 use core::num::niche_types::Nanoseconds;
 
 use crate::io;
@@ -6,8 +7,12 @@ use crate::time::Duration;
 const NSEC_PER_SEC: u64 = 1_000_000_000;
 
 #[allow(dead_code)] // Used for pthread condvar timeouts
-pub const TIMESPEC_MAX: libc::timespec =
-    libc::timespec { tv_sec: <libc::time_t>::MAX, tv_nsec: 1_000_000_000 - 1 };
+pub const TIMESPEC_MAX: libc::timespec = {
+    let mut ts = unsafe { mem::zeroed::<libc::timespec>() };
+    ts.tv_sec = <libc::time_t>::MAX;
+    ts.tv_nsec = 1_000_000_000 - 1;
+    ts
+};
 
 // This additional constant is only used when calling
 // `libc::pthread_cond_timedwait`.
@@ -164,9 +169,11 @@ impl Timespec {
 
     #[allow(dead_code)]
     pub fn to_timespec(&self) -> Option<libc::timespec> {
-        Some(libc::timespec {
-            tv_sec: self.tv_sec.try_into().ok()?,
-            tv_nsec: self.tv_nsec.as_inner().try_into().ok()?,
+        Some({
+            let mut ts = libc::timespec::default();
+            ts.tv_sec = self.tv_sec.try_into().ok()?;
+            ts.tv_nsec = self.tv_nsec.as_inner().try_into().ok()?;
+            ts
         })
     }
 

--- a/library/std/src/sys/thread/unix.rs
+++ b/library/std/src/sys/thread/unix.rs
@@ -570,10 +570,10 @@ pub fn sleep(dur: Duration) {
     // nanosleep will fill in `ts` with the remaining time.
     unsafe {
         while secs > 0 || nsecs > 0 {
-            let mut ts = libc::timespec {
-                tv_sec: cmp::min(libc::time_t::MAX as u64, secs) as libc::time_t,
-                tv_nsec: nsecs,
-            };
+            let mut ts = libc::timespec::default();
+            ts.tv_sec = cmp::min(libc::time_t::MAX as u64, secs) as libc::time_t;
+            ts.tv_nsec = nsecs;
+
             secs -= ts.tv_sec as u64;
             let ts_ptr = &raw mut ts;
             let r = nanosleep(ts_ptr, ts_ptr);


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/150752)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Follow-up of https://github.com/rust-lang/rust/pull/150484.
This PR updates libc to include the latest patches to make rtems target (and probably others) compile again.