### PR TITLE
Fix `alloc_error_handler` signature mismatch

### DIFF
--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -6,7 +6,8 @@ use std::time::{Duration, Instant};
 use itertools::Itertools;
 use rustc_abi::FIRST_VARIANT;
 use rustc_ast::expand::allocator::{
-    ALLOC_ERROR_HANDLER, ALLOCATOR_METHODS, AllocatorKind, AllocatorMethod, AllocatorTy,
+    ALLOC_ERROR_HANDLER, ALLOCATOR_METHODS, AllocatorKind, AllocatorMethod, AllocatorMethodInput,
+    AllocatorTy,
 };
 use rustc_data_structures::fx::{FxHashMap, FxIndexSet};
 use rustc_data_structures::profiling::{get_resident_set_size, print_time_passes_entry};
@@ -671,7 +672,7 @@ pub fn allocator_shim_contents(tcx: TyCtxt<'_>, kind: AllocatorKind) -> Vec<Allo
         methods.push(AllocatorMethod {
             name: ALLOC_ERROR_HANDLER,
             special: None,
-            inputs: &[],
+            inputs: &[AllocatorMethodInput { name: "layout", ty: AllocatorTy::Layout }],
             output: AllocatorTy::Never,
         });
     }


### PR DESCRIPTION
Commit https://github.com/rust-lang/rust/pull/147526 removed the following code and replaced it with the `AllocatorMethod`. However, its input is empty, resulting in behavior inconsistent with the previous code.

```rust
  create_wrapper_function(
      tcx,
      &cx,
      &mangle_internal_symbol(tcx, "__rust_alloc_error_handler"),
      Some(&mangle_internal_symbol(tcx, alloc_error_handler_name(alloc_error_handler_kind))),
      &[usize, usize], // size, align
      None,
      true,
      &CodegenFnAttrs::new(),
  );
  ```
  
  resolves https://github.com/rust-lang/rust/issues/150755