### PR TITLE
build-manifest: Add `rust-mingw` also as extension for "pc-windows-gnu" hosts.

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -282,6 +282,14 @@ impl Builder {
                 PkgType::RustMingw => {
                     if host.contains("pc-windows-gnu") {
                         components.push(host_component(pkg));
+                        extensions.extend(
+                            TARGETS
+                                .iter()
+                                .filter(|&&target| {
+                                    target.contains("pc-windows-gnu") && target != host
+                                })
+                                .map(|target| Component::from_pkg(pkg, target)),
+                        );
                     }
                 }
                 // Tools are always present in the manifest,


### PR DESCRIPTION
This should enable `rustup component add --target aarch64-pc-windows-gnullvm rust-mingw` when running an `x86_64-pc-windows-gnullvm` toolchain (and vice-versa).

Which itself enables proper cross-compiling of Windows ARM64 binaries on a Windows x64 host without using commercial MSVC.

CC @mati865 