### PR TITLE
Make verify-channel.sh script compatible with new bors

### DIFF
--- a/src/ci/scripts/verify-channel.sh
+++ b/src/ci/scripts/verify-channel.sh
@@ -8,7 +8,8 @@ IFS=$'\n\t'
 
 source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
 
-if isCiBranch auto || isCiBranch try || isCiBranch try-perf || isCiBranch automation/bors/try; then
+if isCiBranch auto || isCiBranch try || isCiBranch try-perf || \
+   isCiBranch automation/bors/try || isCiBranch automation/bors/auto; then
     echo "channel verification is only executed on PR builds"
     exit
 fi


### PR DESCRIPTION
It only dealt with the `auto` branch before.
