### PR TITLE
Use functions more in rustdoc GUI tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "browser-ui-test": "^0.23.0",
+    "browser-ui-test": "^0.23.1",
     "es-check": "^9.4.4",
     "eslint": "^8.57.1",
     "typescript": "^5.8.3"

--- a/tests/rustdoc-gui/copy-code.goml
+++ b/tests/rustdoc-gui/copy-code.goml
@@ -1,5 +1,6 @@
 // Checks that the "copy code" button is not triggering JS error and its display
 // isn't broken.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/fn.foo.html"
 
 define-function: (
@@ -47,15 +48,15 @@ assert: |copy_height| > 0 && |copy_width| > 0
 
 // First we ensure that the clipboard is empty.
 assert-clipboard: ""
+
 // We make the line numbers appear.
-click: "rustdoc-toolbar .settings-menu"
-wait-for-css: ("#settings", {"display": "block"})
-// We make the line numbers appear.
+call-function: ("open-settings-menu", {})
 click: "#line-numbers"
 wait-for-local-storage: {"rustdoc-line-numbers": "true" }
+
 // We close the settings menu.
-click: "rustdoc-toolbar .settings-menu"
-wait-for-css-false: ("#settings", {"display": "block"})
+call-function: ("close-settings-menu", {})
+
 // We ensure that there are actually line numbers generated in the DOM.
 assert-text: (".example-wrap pre.rust code span[data-nosnippet]", "1")
 // We make the copy button appear.

--- a/tests/rustdoc-gui/font-serif-change.goml
+++ b/tests/rustdoc-gui/font-serif-change.goml
@@ -1,4 +1,5 @@
 // Ensures that the font serif change is working as expected.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 
 // By default, it should be the serif fonts.
@@ -8,8 +9,7 @@ assert-css: ("body", {"font-family": |serif_font|})
 assert-css: ("p code", {"font-family": |serif_code_font|})
 
 // We now switch to the sans serif font
-click: "main .settings-menu"
-wait-for: "#sans-serif-fonts"
+call-function: ("open-settings-menu", {})
 click: "#sans-serif-fonts"
 
 store-value: (font, '"Fira Sans", sans-serif')
@@ -23,8 +23,7 @@ assert-css: ("body", {"font-family": |font|})
 assert-css: ("p code", {"font-family": |code_font|})
 
 // We switch back to the serif font
-click: "main .settings-menu"
-wait-for: "#sans-serif-fonts"
+call-function: ("open-settings-menu", {})
 click: "#sans-serif-fonts"
 
 assert-css: ("body", {"font-family": |serif_font|})

--- a/tests/rustdoc-gui/notable-trait.goml
+++ b/tests/rustdoc-gui/notable-trait.goml
@@ -82,15 +82,15 @@ call-function: ("check-notable-tooltip-position", {
     "i_x": 528,
 })
 
+go-to: "file://" + |DOC_PATH| + "/test_docs/struct.NotableStructWithLongName.html"
+// This is needed to ensure that the text color is computed.
+show-text: true
+
 // Now check the colors.
 define-function: (
     "check-colors",
     [theme, header_color, content_color, type_color, trait_color, link_color],
     block {
-        go-to: "file://" + |DOC_PATH| + "/test_docs/struct.NotableStructWithLongName.html"
-        // This is needed to ensure that the text color is computed.
-        show-text: true
-
         call-function: ("switch-theme", {"theme": |theme|})
 
         assert-css: (
@@ -251,7 +251,6 @@ reload:
 assert-count: ("//*[@class='tooltip popover']", 0)
 click: "//*[@id='method.create_an_iterator_from_read']//*[@class='tooltip']"
 assert-count: ("//*[@class='tooltip popover']", 1)
-click: "rustdoc-toolbar .settings-menu a"
-wait-for: "#settings"
+call-function: ("open-settings-menu", {})
 assert-count: ("//*[@class='tooltip popover']", 0)
 assert-false: "#method\.create_an_iterator_from_read .tooltip:focus"

--- a/tests/rustdoc-gui/search-filter.goml
+++ b/tests/rustdoc-gui/search-filter.goml
@@ -70,9 +70,7 @@ assert-css: ("#crate-search", {
 })
 
 // We now check the dark theme.
-click: "rustdoc-toolbar .settings-menu"
-wait-for: "#settings"
-click: "#theme-dark"
+call-function: ("switch-theme", {"theme": "dark"})
 wait-for-css: ("#crate-search", {
     "border": "1px solid #e0e0e0",
     "color": "#ddd",
@@ -80,7 +78,7 @@ wait-for-css: ("#crate-search", {
 })
 
 // And finally we check the ayu theme.
-click: "#theme-ayu"
+call-function: ("switch-theme", {"theme": "ayu"})
 wait-for-css: ("#crate-search", {
     "border": "1px solid #5c6773",
     "color": "#c5c5c5",

--- a/tests/rustdoc-gui/setting-auto-hide-content-large-items.goml
+++ b/tests/rustdoc-gui/setting-auto-hide-content-large-items.goml
@@ -1,6 +1,8 @@
 // This test ensures that the "Auto-hide item contents for large items" setting is working as
 // expected.
 
+include: "utils.goml"
+
 // We need to disable this check because `trait.impl/test_docs/trait.Iterator.js` doesn't exist.
 fail-on-request-error: false
 
@@ -9,8 +11,7 @@ define-function: (
     [storage_value, setting_attribute_value, toggle_attribute_value],
     block {
         assert-local-storage: {"rustdoc-auto-hide-large-items": |storage_value|}
-        click: "rustdoc-toolbar .settings-menu"
-        wait-for: "#settings"
+        call-function: ("open-settings-menu", {})
         assert-property: ("#auto-hide-large-items", {"checked": |setting_attribute_value|})
         assert-attribute: (".item-decl .type-contents-toggle", {"open": |toggle_attribute_value|})
     }

--- a/tests/rustdoc-gui/setting-auto-hide-item-methods-docs.goml
+++ b/tests/rustdoc-gui/setting-auto-hide-item-methods-docs.goml
@@ -1,13 +1,14 @@
 // This test ensures that the "Auto-hide item methods' documentation" setting is working as
 // expected.
 
+include: "utils.goml"
+
 define-function: (
     "check-setting",
     [storage_value, setting_attribute_value, toggle_attribute_value],
     block {
         assert-local-storage: {"rustdoc-auto-hide-method-docs": |storage_value|}
-        click: "rustdoc-toolbar .settings-menu"
-        wait-for: "#settings"
+        call-function: ("open-settings-menu", {})
         assert-property: ("#auto-hide-method-docs", {"checked": |setting_attribute_value|})
         assert-attribute: (".toggle.method-toggle", {"open": |toggle_attribute_value|})
     }

--- a/tests/rustdoc-gui/setting-auto-hide-trait-implementations.goml
+++ b/tests/rustdoc-gui/setting-auto-hide-trait-implementations.goml
@@ -1,12 +1,13 @@
 // Checks that the setting "auto hide trait implementations" is working as expected.
 
+include: "utils.goml"
+
 define-function: (
     "check-setting",
     [storage_value, setting_attribute_value, toggle_attribute_value],
     block {
         assert-local-storage: {"rustdoc-auto-hide-trait-implementations": |storage_value|}
-        click: "rustdoc-toolbar .settings-menu"
-        wait-for: "#settings"
+        call-function: ("open-settings-menu", {})
         assert-property: ("#auto-hide-trait-implementations", {"checked": |setting_attribute_value|})
         assert-attribute: ("#trait-implementations-list > details", {"open": |toggle_attribute_value|}, ALL)
     }

--- a/tests/rustdoc-gui/setting-go-to-only-result.goml
+++ b/tests/rustdoc-gui/setting-go-to-only-result.goml
@@ -1,12 +1,14 @@
-// Checks that the setting "Directly go to item in search if there is only one result " is working as expected.
+// Checks that the setting "Directly go to item in search if there is only one result " is working
+// as expected.
+
+include: "utils.goml"
 
 define-function: (
     "check-setting",
     [storage_value, setting_attribute_value],
     block {
         assert-local-storage: {"rustdoc-go-to-only-result": |storage_value|}
-        click: "rustdoc-toolbar .settings-menu"
-        wait-for: "#settings"
+        call-function: ("open-settings-menu", {})
         assert-property: ("#go-to-only-result", {"checked": |setting_attribute_value|})
     }
 )
@@ -25,8 +27,7 @@ wait-for: "#search"
 assert-document-property: ({"URL": "/lib2/index.html"}, CONTAINS)
 
 // Now we change its value.
-click: "rustdoc-toolbar .settings-menu"
-wait-for: "#settings"
+call-function: ("open-settings-menu", {})
 click: "#go-to-only-result"
 assert-local-storage: {"rustdoc-go-to-only-result": "true"}
 

--- a/tests/rustdoc-gui/settings.goml
+++ b/tests/rustdoc-gui/settings.goml
@@ -1,20 +1,18 @@
 // This test ensures that the settings menu display is working as expected and that
 // the settings page is also rendered as expected.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 show-text: true // needed when we check for colors below.
 // First, we check that the settings page doesn't exist.
 assert-false: "#settings"
-// We now click on the settings button.
-click: "rustdoc-toolbar .settings-menu"
-wait-for: "#settings"
+call-function: ("open-settings-menu", {})
 assert-css: ("#settings", {"display": "block"})
 
 // Store the line margin to compare with the settings.html later.
 store-css: (".setting-line", {"margin": setting_line_margin})
 
 // Let's close it by clicking on the same button.
-click: "rustdoc-toolbar .settings-menu"
-wait-for-css: ("#settings", {"display": "none"})
+call-function: ("close-settings-menu", {})
 
 // Let's check that pressing "ESCAPE" is closing it.
 click: "rustdoc-toolbar .settings-menu"
@@ -28,8 +26,7 @@ write: "test"
 // To be SURE that the search will be run.
 press-key: 'Enter'
 wait-for: "#alternative-display #search"
-click: "rustdoc-toolbar .settings-menu"
-wait-for-css: ("#settings", {"display": "block"})
+call-function: ("open-settings-menu", {})
 // Ensure that the search is still displayed.
 wait-for: "#alternative-display #search"
 assert: "#main-content.hidden"
@@ -41,8 +38,7 @@ set-local-storage: {"rustdoc-theme": "dark", "rustdoc-use-system-theme": "false"
 // We reload the page so the local storage settings are being used.
 reload:
 
-click: "rustdoc-toolbar .settings-menu"
-wait-for: "#settings"
+call-function: ("open-settings-menu", {})
 
 // We check that the "Use system theme" is disabled.
 assert-property: ("#theme-system-preference", {"checked": "false"})

--- a/tests/rustdoc-gui/sidebar-mobile.goml
+++ b/tests/rustdoc-gui/sidebar-mobile.goml
@@ -65,8 +65,7 @@ define-function: (
     "check-colors",
     [theme, color, background],
     block {
-        call-function: ("switch-theme-mobile", {"theme": |theme|})
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
 
         // Open the sidebar menu.
         click: ".sidebar-menu-toggle"
@@ -85,14 +84,4 @@ call-function: ("check-colors", {
     "theme": "ayu",
     "color": "#c5c5c5",
     "background": "#14191f",
-})
-call-function: ("check-colors", {
-    "theme": "dark",
-    "color": "#ddd",
-    "background": "#505050",
-})
-call-function: ("check-colors", {
-    "theme": "light",
-    "color": "black",
-    "background": "#F5F5F5",
 })

--- a/tests/rustdoc-gui/sidebar-resize-close-popover.goml
+++ b/tests/rustdoc-gui/sidebar-resize-close-popover.goml
@@ -1,9 +1,9 @@
 // Checks sidebar resizing close the Settings popover
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 assert-property: (".sidebar", {"clientWidth": "199"})
 show-text: true
-click: "rustdoc-toolbar .settings-menu"
-wait-for: "#settings"
+call-function: ("open-settings-menu", {})
 assert-css: ("#settings", {"display": "block"})
 // normal resizing
 drag-and-drop: ((205, 100), (185, 100))
@@ -12,8 +12,7 @@ assert-css: ("#settings", {"display": "none"})
 
 // Now same thing, but for source code
 go-to: "file://" + |DOC_PATH| + "/src/test_docs/lib.rs.html"
-click: "rustdoc-toolbar .settings-menu"
-wait-for: "#settings"
+call-function: ("open-settings-menu", {})
 assert-css: ("#settings", {"display": "block"})
 assert-property: (".sidebar", {"clientWidth": "49"})
 drag-and-drop: ((52, 100), (185, 100))

--- a/tests/rustdoc-gui/sidebar-resize-setting.goml
+++ b/tests/rustdoc-gui/sidebar-resize-setting.goml
@@ -1,11 +1,11 @@
 // Checks sidebar resizing stays synced with the setting
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 assert-property: (".sidebar", {"clientWidth": "199"})
 show-text: true
 
 // Verify that the "hide" option is unchecked
-click: "rustdoc-toolbar .settings-menu"
-wait-for: "#settings"
+call-function: ("open-settings-menu", {})
 assert-css: ("#settings", {"display": "block"})
 assert-property: ("#hide-sidebar", {"checked": "false"})
 press-key: "Escape"

--- a/tests/rustdoc-gui/source-code-wrapping.goml
+++ b/tests/rustdoc-gui/source-code-wrapping.goml
@@ -1,4 +1,5 @@
 // Checks that the interactions with the source code pages are working as expected.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/src/test_docs/lib.rs.html"
 show-text: true
 set-window-size: (1000, 1000)
@@ -13,8 +14,7 @@ define-function: (
 )
 
 store-size: (".rust code", {"width": width, "height": height})
-click: "main .settings-menu"
-wait-for: "#settings"
+call-function: ("open-settings-menu", {})
 call-function: ("click-code-wrapping", {"expected": "true"})
 wait-for-size-false: (".rust code", {"width": |width|, "height": |height|})
 store-size: (".rust code", {"width": new_width, "height": new_height})
@@ -28,8 +28,7 @@ assert-size: (".rust code", {"width": |width|, "height": |height|})
 
 // Now let's check in docs code examples.
 go-to: "file://" + |DOC_PATH| + "/test_docs/trait_bounds/index.html"
-click: "main .settings-menu"
-wait-for: "#settings"
+call-function: ("open-settings-menu", {})
 
 store-property: (".example-wrap .rust code", {"scrollWidth": rust_width, "scrollHeight": rust_height})
 store-property: (".example-wrap .language-text code", {"scrollWidth": txt_width, "scrollHeight": txt_height})

--- a/tests/rustdoc-gui/theme-change.goml
+++ b/tests/rustdoc-gui/theme-change.goml
@@ -7,8 +7,7 @@ store-value: (background_light, "white")
 store-value: (background_dark, "#353535")
 store-value: (background_ayu, "#0f1419")
 
-click: "rustdoc-toolbar .settings-menu"
-wait-for: "#theme-ayu"
+call-function: ("open-settings-menu", {})
 click: "#theme-ayu"
 // should be the ayu theme so let's check the color.
 wait-for-css: ("body", { "background-color": |background_ayu| })
@@ -22,10 +21,6 @@ click: "#theme-dark"
 wait-for-css: ("body", { "background-color": |background_dark| })
 assert-local-storage: { "rustdoc-theme": "dark" }
 
-set-local-storage: {
-    "rustdoc-preferred-light-theme": "light",
-    "rustdoc-preferred-dark-theme": "light",
-}
 go-to: "file://" + |DOC_PATH| + "/settings.html"
 
 wait-for: "#settings"
@@ -75,8 +70,7 @@ store-value: (background_dark, "#353535")
 store-value: (background_ayu, "#0f1419")
 store-value: (background_custom_theme, "red")
 
-click: "rustdoc-toolbar .settings-menu"
-wait-for: "#theme-ayu"
+call-function: ("open-settings-menu", {})
 click: "#theme-ayu"
 // should be the ayu theme so let's check the color.
 wait-for-css: ("body", { "background-color": |background_ayu| })

--- a/tests/rustdoc-gui/theme-defaults.goml
+++ b/tests/rustdoc-gui/theme-defaults.goml
@@ -1,7 +1,7 @@
 // Ensure that the theme picker always starts with the actual defaults.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
-click: "rustdoc-toolbar .settings-menu"
-wait-for: "#theme-system-preference"
+call-function: ("open-settings-menu", {})
 assert: "#theme-system-preference:checked"
 assert: "#preferred-light-theme-light:checked"
 assert: "#preferred-dark-theme-dark:checked"
@@ -16,8 +16,7 @@ set-local-storage: {
     "rustdoc-theme": "ayu"
 }
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
-click: "rustdoc-toolbar .settings-menu"
-wait-for: "#theme-system-preference"
+call-function: ("open-settings-menu", {})
 assert: "#theme-system-preference:checked"
 assert: "#preferred-light-theme-light:checked"
 assert-false: "#preferred-dark-theme-dark:checked"

--- a/tests/rustdoc-gui/utils.goml
+++ b/tests/rustdoc-gui/utils.goml
@@ -1,11 +1,35 @@
 // This file contains code to be re-used by other tests.
 
 define-function: (
+    "click-settings-button",
+    [],
+    block {
+        store-count: ("rustdoc-topbar", __topbar_count)
+        store-value: (__topbar_display, "none")
+        // The `rustdoc-topbar` element is created with JS when the window size is below a given
+        // size, however if the window size gets bigger again, the element isn't deleted, just
+        // hidden, so we need to check for both that it exists and is visible.
+        if: (|__topbar_count| != 0, block {
+            store-css: ("rustdoc-topbar", {"display": __topbar_display})
+        })
+
+        // Open the settings menu.
+        if: (|__topbar_display| != "none", block {
+            // In mobile mode, this is instead the "topbar" the settings button is located into.
+            click: "rustdoc-topbar .settings-menu"
+        })
+        else: block {
+            // We're not in mobile mode so clicking on the "normal" sidebar.
+            click: "rustdoc-toolbar .settings-menu"
+        }
+    }
+)
+
+define-function: (
     "open-settings-menu",
     [],
     block {
-        // Open the settings menu.
-        click: "rustdoc-toolbar .settings-menu"
+        call-function: ("click-settings-button", {})
         // Wait for the popover to appear...
         wait-for-css: ("#settings", {"display": "block"})
     }
@@ -15,7 +39,8 @@ define-function: (
     "close-settings-menu",
     [],
     block {
-        click: "rustdoc-toolbar .settings-menu"
+        call-function: ("click-settings-button", {})
+        // Wait for the popover to disappear...
         wait-for-css-false: ("#settings", {"display": "block"})
     }
 )
@@ -29,24 +54,6 @@ define-function: (
         // Change the setting.
         click: "#theme-"+ |theme|
         call-function: ("close-settings-menu", {})
-        // Ensure that the local storage was correctly updated.
-        assert-local-storage: {"rustdoc-theme": |theme|}
-    },
-)
-
-// FIXME: To be removed once `browser-ui-test` has conditions.
-define-function: (
-    "switch-theme-mobile",
-    [theme],
-    block {
-        // Open the settings menu.
-        click: "rustdoc-topbar .settings-menu"
-        // Wait for the popover to appear...
-        wait-for-css: ("#settings", {"display": "block"})
-        // Change the setting.
-        click: "#theme-"+ |theme|
-        click: "rustdoc-topbar .settings-menu"
-        wait-for-css-false: ("#settings", {"display": "block"})
         // Ensure that the local storage was correctly updated.
         assert-local-storage: {"rustdoc-theme": |theme|}
     },


### PR DESCRIPTION
Now that conditions are supported in `browser-ui-test`, we can start simplify some parts of the tests. This is a first cleanup, but I guess a lot more could be simplified. For follow-ups I guess. :)

I made some improvements in backtrace display in `browser-ui-test`, hence the version update once more.

r? @lolbinarycat 