### PR TITLE
added support for s390x target features `soft-float` and `packed-stack`

### DIFF
--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -311,6 +311,18 @@ fn backchain_attr<'ll>(cx: &SimpleCx<'ll>, sess: &Session) -> Option<&'ll Attrib
     if found_positive { Some(llvm::CreateAttrString(cx.llcx, "backchain")) } else { None }
 }
 
+fn packed_stack_attr<'ll>(cx: &SimpleCx<'ll>, sess: &Session) -> Option<&'ll Attribute> {
+    if sess.target.arch != Arch::S390x {
+        return None;
+    }
+
+    if sess.opts.cg.packed_stack {
+        Some(llvm::CreateAttrString(cx.llcx, "packed-stack"))
+    } else {
+        None
+    }
+}
+
 pub(crate) fn target_cpu_attr<'ll>(cx: &SimpleCx<'ll>, sess: &Session) -> &'ll Attribute {
     let target_cpu = llvm_util::target_cpu(sess);
     llvm::CreateAttrStringValue(cx.llcx, "target-cpu", target_cpu)
@@ -525,6 +537,10 @@ pub(crate) fn llfn_attrs_from_instance<'ll, 'tcx>(
     if let Some(backchain) = backchain_attr(cx, sess) {
         to_add.push(backchain);
     }
+    if let Some(packed_stack) = packed_stack_attr(cx, sess) {
+        to_add.push(packed_stack);
+    }
+
     to_add.extend(patchable_function_entry_attrs(
         cx,
         sess,

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2182,8 +2182,6 @@ options! {
     #[rustc_lint_opt_deny_field_access("use `Session::overflow_checks` instead of this field")]
     overflow_checks: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "use overflow checks for integer arithmetic"),
-    packed_stack: bool = (false, parse_bool, [TRACKED],
-        "use packed stack frames (s390x only) (default: no)"),
     #[rustc_lint_opt_deny_field_access("use `Session::panic_strategy` instead of this field")]
     panic: Option<PanicStrategy> = (None, parse_opt_panic_strategy, [TRACKED],
         "panic strategy to compile crate with"),
@@ -2553,6 +2551,8 @@ options! {
         "pass `-install_name @rpath/...` to the macOS linker (default: no)"),
     packed_bundled_libs: bool = (false, parse_bool, [TRACKED],
         "change rlib format to store native libraries as archives"),
+    packed_stack: bool = (false, parse_bool, [TRACKED],
+        "use packed stack frames (s390x only) (default: no)"),
     panic_abort_tests: bool = (false, parse_bool, [TRACKED],
         "support compiling tests with panic=abort (default: no)"),
     panic_in_drop: PanicStrategy = (PanicStrategy::Unwind, parse_panic_strategy, [TRACKED],

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2182,6 +2182,8 @@ options! {
     #[rustc_lint_opt_deny_field_access("use `Session::overflow_checks` instead of this field")]
     overflow_checks: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "use overflow checks for integer arithmetic"),
+    packed_stack: bool = (false, parse_bool, [TRACKED],
+        "use packed stack frames (s390x only) (default: no)"),
     #[rustc_lint_opt_deny_field_access("use `Session::panic_strategy` instead of this field")]
     panic: Option<PanicStrategy> = (None, parse_opt_panic_strategy, [TRACKED],
         "panic strategy to compile crate with"),

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -3242,6 +3242,17 @@ impl Target {
                     ));
                 }
             }
+
+            // If both `packed-stack` and `backchain` are set we need to use soft-float ABI.
+            if self.arch == Arch::S390x
+                && features_enabled.contains("packed-stack")
+                && features_enabled.contains("backchain")
+                && !matches!(self.abi, Abi::SoftFloat)
+            {
+                return Err(format!(
+                    "Enabling both, `packed-stack` and `backchain` attributes is incompatible with the hard-float ABI. Enable soft-float ABI to use these attributes."
+                ));
+            }
         }
 
         Ok(())

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -3250,7 +3250,7 @@ impl Target {
                 && !matches!(self.abi, Abi::SoftFloat)
             {
                 return Err(format!(
-                    "Enabling both, `packed-stack` and `backchain` attributes is incompatible with the hard-float ABI. Enable soft-float ABI to use these attributes."
+                    "Enabling both `packed-stack` and `backchain` attributes is incompatible with the hard-float ABI. Enable soft-float ABI to use these attributes."
                 ));
             }
         }

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -1211,11 +1211,13 @@ impl Target {
                 }
             }
             Arch::S390x => {
-                // We don't currently support a softfloat target on this architecture.
-                // As usual, we have to reject swapping the `soft-float` target feature.
-                // The "vector" target feature does not affect the ABI for floats
-                // because the vector and float registers overlap.
-                FeatureConstraints { required: &[], incompatible: &["soft-float"] }
+                // On s390x only the hard-float ABI is valid. However for kernel compilation we need to
+                // allow soft-float if and only if the ABI is explicitly set to soft-float.
+                if matches!(self.abi, Abi::SoftFloat) {
+                    FeatureConstraints { required: &["soft-float"], incompatible: &[] }
+                } else {
+                    FeatureConstraints { required: &[], incompatible: &["soft-float"] }
+                }
             }
             _ => NOTHING,
         }

--- a/src/doc/rustc/src/codegen-options/index.md
+++ b/src/doc/rustc/src/codegen-options/index.md
@@ -487,6 +487,11 @@ one of the following values:
 If not specified, overflow checks are enabled if
 [debug-assertions](#debug-assertions) are enabled, disabled otherwise.
 
+## packed-stack
+
+This flag enables packed StackFrames on s390x.
+If backchain is also enabled, switch to the soft-float ABI.
+
 ## panic
 
 This option lets you control what happens when the code panics.

--- a/src/doc/rustc/src/codegen-options/index.md
+++ b/src/doc/rustc/src/codegen-options/index.md
@@ -489,8 +489,9 @@ If not specified, overflow checks are enabled if
 
 ## packed-stack
 
-This flag enables packed StackFrames on s390x.
-If backchain is also enabled, switch to the soft-float ABI.
+This flag enables packed StackFrames on s390x. Enabling both `packed-stack` and
+`backchain` attributes is incompatible with the default hard-float ABI.
+Enable soft-float ABI to use these attributes.
 
 ## panic
 


### PR DESCRIPTION
as we want to enable `rust in kernel` on s390x we need to do some things:

- allow the use of soft-float feature **only** if also soft-float ABI is enabled
- add a `-packed-stack` `rustc` option. this adds the `packed-stack` function-attribute to every function call. I implemented it the same way as it is implemented in clang[^1][^2]. In clang this is a cli argument. **It is not** a part of the target feature. Therefore we cannot pass it via the `features` field in the `target.json`.
- added a check for `packed-stack && backchain** && !soft-float` as this combination should never occur. However I don't know if I put it in the right spot. [^3]


[^1]: https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-mpacked-stack
[^2]: https://github.com/llvm/llvm-project/blob/release/20/clang/lib/CodeGen/CodeGenFunction.cpp#L1202-L1208
[^3]: [compiler/rustc_target/src/spec/mod.rs](https://github.com/rust-lang/rust/compare/main...fneddy:rust:new_target_s390x_softfloat?expand=1#diff-aa810a3be0834da891b171a8b04b09d0d3bbb76ac27c757cd232235099e062d2)