### PR TITLE
Fix the connect_error test on FreeBSD 15+

### DIFF
--- a/library/std/src/net/tcp/tests.rs
+++ b/library/std/src/net/tcp/tests.rs
@@ -37,7 +37,8 @@ fn connect_error() {
             e.kind() == ErrorKind::ConnectionRefused
                 || e.kind() == ErrorKind::InvalidInput
                 || e.kind() == ErrorKind::AddrInUse
-                || e.kind() == ErrorKind::AddrNotAvailable,
+                || e.kind() == ErrorKind::AddrNotAvailable
+                || e.kind() == ErrorKind::NetworkUnreachable,
             "bad error: {} {:?}",
             e,
             e.kind()


### PR DESCRIPTION
On FreeBSD 15, the error code returned in this situation changed.  It's now ENETUNREACH.  I think that error code is reasonable, and it's documented for connect(2), so we should expect that it might be returned.