### PR TITLE
Stabilize `slice::element_offset`

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -4809,8 +4809,6 @@ impl<T> [T] {
     /// # Examples
     /// Basic usage:
     /// ```
-    /// #![feature(substr_range)]
-    ///
     /// let nums: &[u32] = &[1, 7, 1, 1];
     /// let num = &nums[2];
     ///
@@ -4819,8 +4817,6 @@ impl<T> [T] {
     /// ```
     /// Returning `None` with an unaligned element:
     /// ```
-    /// #![feature(substr_range)]
-    ///
     /// let arr: &[[u32; 2]] = &[[0, 1], [2, 3]];
     /// let flat_arr: &[u32] = arr.as_flattened();
     ///
@@ -4834,7 +4830,7 @@ impl<T> [T] {
     /// assert_eq!(arr.element_offset(weird_elm), None); // Points between element 0 and 1
     /// ```
     #[must_use]
-    #[unstable(feature = "substr_range", issue = "126769")]
+    #[stable(feature = "element_offset", since = "CURRENT_RUSTC_VERSION")]
     pub fn element_offset(&self, element: &T) -> Option<usize> {
         if T::IS_ZST {
             panic!("elements are zero-sized");


### PR DESCRIPTION
[slice::element_offset](https://doc.rust-lang.org/std/primitive.slice.html#method.element_offset)

Partially stabilizes rust-lang/rust#126769 (substr_range).

[FCP completed](https://github.com/rust-lang/rust/issues/126769#issuecomment-3458159941)

The other methods are [stalled because of the new range types](https://github.com/rust-lang/rust/issues/126769#issuecomment-3599721663), but this method doesn't use ranges.

@rustbot label +relnotes