### PR TITLE
Use `rand` crate more idiomatically

### DIFF
--- a/library/alloctests/benches/btree/map.rs
+++ b/library/alloctests/benches/btree/map.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::ops::RangeBounds;
 
 use rand::Rng;
+use rand::distr::{Distribution, Uniform};
 use rand::seq::SliceRandom;
 use test::{Bencher, black_box};
 
@@ -106,7 +107,8 @@ macro_rules! map_find_rand_bench {
 
             // setup
             let mut rng = crate::bench_rng();
-            let mut keys: Vec<_> = (0..n).map(|_| rng.random::<u32>() % n).collect();
+            let mut keys: Vec<_> =
+                Uniform::new(0, n).unwrap().sample_iter(&mut rng).take(n as usize).collect();
 
             for &k in &keys {
                 map.insert(k, k);

--- a/library/alloctests/tests/sort/patterns.rs
+++ b/library/alloctests/tests/sort/patterns.rs
@@ -27,21 +27,20 @@ where
 {
     // :.:.:.::
 
-    let mut rng: XorShiftRng = rand::SeedableRng::seed_from_u64(get_or_init_rand_seed());
+    let rng: XorShiftRng = rand::SeedableRng::seed_from_u64(get_or_init_rand_seed());
 
     // Abstracting over ranges in Rust :(
     let dist = Uniform::try_from(range).unwrap();
-    (0..len).map(|_| dist.sample(&mut rng)).collect()
+    rng.sample_iter(dist).take(len).collect()
 }
 
 pub fn random_zipf(len: usize, exponent: f64) -> Vec<i32> {
     // https://en.wikipedia.org/wiki/Zipf's_law
 
-    let mut rng: XorShiftRng = rand::SeedableRng::seed_from_u64(get_or_init_rand_seed());
+    let rng: XorShiftRng = rand::SeedableRng::seed_from_u64(get_or_init_rand_seed());
 
-    // Abstracting over ranges in Rust :(
     let dist = ZipfDistribution::new(len, exponent).unwrap();
-    (0..len).map(|_| dist.sample(&mut rng) as i32).collect()
+    rng.sample_iter(dist).map(|val| val as i32).take(len).collect()
 }
 
 pub fn random_sorted(len: usize, sorted_percent: f64) -> Vec<i32> {
@@ -68,7 +67,7 @@ pub fn all_equal(len: usize) -> Vec<i32> {
     // ......
     // ::::::
 
-    (0..len).map(|_| 66).collect::<Vec<_>>()
+    vec![66; len]
 }
 
 pub fn ascending(len: usize) -> Vec<i32> {
@@ -206,6 +205,6 @@ fn rand_root_seed() -> u64 {
 }
 
 fn random_vec(len: usize) -> Vec<i32> {
-    let mut rng: XorShiftRng = rand::SeedableRng::seed_from_u64(get_or_init_rand_seed());
-    (0..len).map(|_| rng.random::<i32>()).collect()
+    let rng: XorShiftRng = rand::SeedableRng::seed_from_u64(get_or_init_rand_seed());
+    rng.random_iter().take(len).collect()
 }

--- a/library/coretests/benches/num/int_bits/mod.rs
+++ b/library/coretests/benches/num/int_bits/mod.rs
@@ -4,11 +4,12 @@ macro_rules! bench_template {
     ($op:path, $name:ident, $mask:expr) => {
         #[bench]
         fn $name(bench: &mut ::test::Bencher) {
-            use ::rand::Rng;
+            use ::rand::distr::{Distribution, Uniform};
             let mut rng = crate::bench_rng();
             let mut dst = vec![0; ITERATIONS];
-            let src1: Vec<U> = (0..ITERATIONS).map(|_| rng.random_range(0..=U::MAX)).collect();
-            let mut src2: Vec<U> = (0..ITERATIONS).map(|_| rng.random_range(0..=U::MAX)).collect();
+            let distr = &Uniform::try_from(0..=U::MAX).unwrap();
+            let src1: Vec<U> = distr.sample_iter(&mut rng).take(ITERATIONS).collect();
+            let mut src2: Vec<U> = distr.sample_iter(&mut rng).take(ITERATIONS).collect();
             // Fix the loop invariant mask
             src2[0] = U::MAX / 3;
             let dst = dst.first_chunk_mut().unwrap();

--- a/library/coretests/benches/num/int_sqrt/mod.rs
+++ b/library/coretests/benches/num/int_sqrt/mod.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use rand::Rng;
 use test::{Bencher, black_box};
 
@@ -20,7 +22,9 @@ macro_rules! int_sqrt_bench {
             let mut rng = crate::bench_rng();
             /* Exponentially distributed random numbers from the whole range of the type.  */
             let numbers: Vec<$t> =
-                (0..256).map(|_| rng.random::<$t>() >> rng.random_range(0..<$t>::BITS)).collect();
+                iter::repeat_with(|| rng.random::<$t>() >> rng.random_range(0..<$t>::BITS))
+                    .take(256)
+                    .collect();
             bench.iter(|| {
                 for x in &numbers {
                     black_box(black_box(x).isqrt());
@@ -32,9 +36,10 @@ macro_rules! int_sqrt_bench {
         fn $random_small(bench: &mut Bencher) {
             let mut rng = crate::bench_rng();
             /* Exponentially distributed random numbers from the range 0..256.  */
-            let numbers: Vec<$t> = (0..256)
-                .map(|_| (rng.random::<u8>() >> rng.random_range(0..u8::BITS)) as $t)
-                .collect();
+            let numbers: Vec<$t> =
+                iter::repeat_with(|| (rng.random::<u8>() >> rng.random_range(0..u8::BITS)) as $t)
+                    .take(256)
+                    .collect();
             bench.iter(|| {
                 for x in &numbers {
                     black_box(black_box(x).isqrt());
@@ -44,9 +49,9 @@ macro_rules! int_sqrt_bench {
 
         #[bench]
         fn $random_uniform(bench: &mut Bencher) {
-            let mut rng = crate::bench_rng();
+            let rng = crate::bench_rng();
             /* Exponentially distributed random numbers from the whole range of the type.  */
-            let numbers: Vec<$t> = (0..256).map(|_| rng.random::<$t>()).collect();
+            let numbers: Vec<$t> = rng.random_iter().take(256).collect();
             bench.iter(|| {
                 for x in &numbers {
                     black_box(black_box(x).isqrt());


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Small cleanup, found while working on something else.
We were using `rand` un-idiomatically in a couple of places, and it was bugging me...