### PR TITLE
THIR patterns: Replace `AscribeUserType` and `ExpandedConstant` wrappers with per-node data

### DIFF
--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -778,11 +778,6 @@ pub enum PatKind<'tcx> {
     /// A wildcard pattern: `_`.
     Wild,
 
-    AscribeUserType {
-        ascription: Ascription<'tcx>,
-        subpattern: Box<Pat<'tcx>>,
-    },
-
     /// `x`, `ref x`, `x @ P`, etc.
     Binding {
         name: Symbol,
@@ -845,21 +840,6 @@ pub enum PatKind<'tcx> {
     ///   error.
     Constant {
         value: ty::Value<'tcx>,
-    },
-
-    /// Wrapper node representing a named constant that was lowered to a pattern
-    /// using `const_to_pat`.
-    ///
-    /// This is used by some diagnostics for non-exhaustive matches, to map
-    /// the pattern node back to the `DefId` of its original constant.
-    ///
-    /// FIXME(#150498): Can we make this an `Option<DefId>` field on `Pat`
-    /// instead, so that non-diagnostic code can ignore it more easily?
-    ExpandedConstant {
-        /// [DefId] of the constant item.
-        def_id: DefId,
-        /// The pattern that the constant lowered to.
-        subpattern: Box<Pat<'tcx>>,
     },
 
     Range(Arc<PatRange<'tcx>>),

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -643,10 +643,26 @@ pub struct FieldPat<'tcx> {
     pub pattern: Pat<'tcx>,
 }
 
+/// Additional per-node data that is not present on most THIR pattern nodes.
+#[derive(Clone, Debug, Default, HashStable, TypeVisitable)]
+pub struct PatExtra<'tcx> {
+    /// If present, this node represents a named constant that was lowered to
+    /// a pattern using `const_to_pat`.
+    ///
+    /// This is used by some diagnostics for non-exhaustive matches, to map
+    /// the pattern node back to the `DefId` of its original constant.
+    pub expanded_const: Option<DefId>,
+
+    /// User-written types that must be preserved into MIR so that they can be
+    /// checked.
+    pub ascriptions: Vec<Ascription<'tcx>>,
+}
+
 #[derive(Clone, Debug, HashStable, TypeVisitable)]
 pub struct Pat<'tcx> {
     pub ty: Ty<'tcx>,
     pub span: Span,
+    pub extra: Option<Box<PatExtra<'tcx>>>,
     pub kind: PatKind<'tcx>,
 }
 
@@ -1119,7 +1135,7 @@ mod size_asserts {
     static_assert_size!(Block, 48);
     static_assert_size!(Expr<'_>, 64);
     static_assert_size!(ExprKind<'_>, 40);
-    static_assert_size!(Pat<'_>, 64);
+    static_assert_size!(Pat<'_>, 72);
     static_assert_size!(PatKind<'_>, 48);
     static_assert_size!(Stmt<'_>, 48);
     static_assert_size!(StmtKind<'_>, 48);

--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -259,7 +259,7 @@ pub(crate) fn for_each_immediate_subpat<'a, 'tcx>(
     pat: &'a Pat<'tcx>,
     mut callback: impl FnMut(&'a Pat<'tcx>),
 ) {
-    let Pat { kind, ty: _, span: _ } = pat;
+    let Pat { kind, ty: _, span: _, extra: _ } = pat;
     match kind {
         PatKind::Missing
         | PatKind::Wild

--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -269,11 +269,9 @@ pub(crate) fn for_each_immediate_subpat<'a, 'tcx>(
         | PatKind::Never
         | PatKind::Error(_) => {}
 
-        PatKind::AscribeUserType { subpattern, .. }
-        | PatKind::Binding { subpattern: Some(subpattern), .. }
+        PatKind::Binding { subpattern: Some(subpattern), .. }
         | PatKind::Deref { subpattern }
-        | PatKind::DerefPattern { subpattern, .. }
-        | PatKind::ExpandedConstant { subpattern, .. } => callback(subpattern),
+        | PatKind::DerefPattern { subpattern, .. } => callback(subpattern),
 
         PatKind::Variant { subpatterns, .. } | PatKind::Leaf { subpatterns } => {
             for field_pat in subpatterns {

--- a/compiler/rustc_mir_build/src/builder/custom/parse.rs
+++ b/compiler/rustc_mir_build/src/builder/custom/parse.rs
@@ -287,22 +287,14 @@ impl<'a, 'tcx> ParseCtxt<'a, 'tcx> {
         self.parse_var(pattern)
     }
 
-    fn parse_var(&mut self, mut pat: &Pat<'tcx>) -> PResult<(LocalVarId, Ty<'tcx>, Span)> {
-        // Make sure we throw out any `AscribeUserType` we find
-        loop {
-            match &pat.kind {
-                PatKind::Binding { var, ty, .. } => break Ok((*var, *ty, pat.span)),
-                PatKind::AscribeUserType { subpattern, .. } => {
-                    pat = subpattern;
-                }
-                _ => {
-                    break Err(ParseError {
-                        span: pat.span,
-                        item_description: format!("{:?}", pat.kind),
-                        expected: "local".to_string(),
-                    });
-                }
-            }
+    fn parse_var(&mut self, pat: &Pat<'tcx>) -> PResult<(LocalVarId, Ty<'tcx>, Span)> {
+        match &pat.kind {
+            PatKind::Binding { var, ty, .. } => Ok((*var, *ty, pat.span)),
+            _ => Err(ParseError {
+                span: pat.span,
+                item_description: format!("{:?}", pat.kind),
+                expected: "local".to_string(),
+            }),
         }
     }
 

--- a/compiler/rustc_mir_build/src/builder/custom/parse/instruction.rs
+++ b/compiler/rustc_mir_build/src/builder/custom/parse/instruction.rs
@@ -144,11 +144,6 @@ impl<'a, 'tcx> ParseCtxt<'a, 'tcx> {
             let arm = &self.thir[*arm];
             let value = match arm.pattern.kind {
                 PatKind::Constant { value } => value,
-                PatKind::ExpandedConstant { ref subpattern, def_id: _ }
-                    if let PatKind::Constant { value } = subpattern.kind =>
-                {
-                    value
-                }
                 _ => {
                     return Err(ParseError {
                         span: arm.pattern.span,

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -342,8 +342,6 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
                 PatKind::Wild |
                 // these just wrap other patterns, which we recurse on below.
                 PatKind::Or { .. } |
-                PatKind::ExpandedConstant { .. } |
-                PatKind::AscribeUserType { .. } |
                 PatKind::Error(_) => {}
             }
         };

--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -90,7 +90,7 @@ impl<'tcx> ConstToPat<'tcx> {
                 );
             }
         }
-        Box::new(Pat { span: self.span, ty, kind: PatKind::Error(err.emit()) })
+        Box::new(Pat { span: self.span, ty, kind: PatKind::Error(err.emit()), extra: None })
     }
 
     fn unevaluated_to_pat(
@@ -192,6 +192,7 @@ impl<'tcx> ConstToPat<'tcx> {
             ty: thir_pat.ty,
             span: thir_pat.span,
             kind: PatKind::ExpandedConstant { def_id: uv.def, subpattern: thir_pat },
+            extra: None,
         });
         thir_pat
     }
@@ -355,7 +356,7 @@ impl<'tcx> ConstToPat<'tcx> {
             }
         };
 
-        Box::new(Pat { span, ty, kind })
+        Box::new(Pat { span, ty, kind, extra: None })
     }
 }
 

--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -186,14 +186,9 @@ impl<'tcx> ConstToPat<'tcx> {
             }
         }
 
-        // Wrap the pattern in a marker node to indicate that it is the result of lowering a
+        // Mark the pattern to indicate that it is the result of lowering a named
         // constant. This is used for diagnostics.
-        thir_pat = Box::new(Pat {
-            ty: thir_pat.ty,
-            span: thir_pat.span,
-            kind: PatKind::ExpandedConstant { def_id: uv.def, subpattern: thir_pat },
-            extra: None,
-        });
+        thir_pat.extra.get_or_insert_default().expanded_const = Some(uv.def);
         thir_pat
     }
 

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -167,9 +167,10 @@ impl<'tcx> PatCtxt<'tcx> {
         // Return None in that case; the caller will use NegInfinity or PosInfinity instead.
         let Some(expr) = expr else { return Ok(None) };
 
-        // Lower the endpoint into a temporary `PatKind` that will then be
+        // Lower the endpoint into a temporary `thir::Pat` that will then be
         // deconstructed to obtain the constant value and other data.
-        let mut kind: PatKind<'tcx> = self.lower_pat_expr(pat, expr);
+        let endpoint_pat: Box<Pat<'tcx>> = self.lower_pat_expr(pat, expr);
+        let box Pat { mut kind, .. } = endpoint_pat;
 
         // Unpeel any ascription or inline-const wrapper nodes.
         loop {
@@ -250,7 +251,7 @@ impl<'tcx> PatCtxt<'tcx> {
         lo_expr: Option<&'tcx hir::PatExpr<'tcx>>,
         hi_expr: Option<&'tcx hir::PatExpr<'tcx>>,
         end: RangeEnd,
-    ) -> Result<PatKind<'tcx>, ErrorGuaranteed> {
+    ) -> Result<Box<Pat<'tcx>>, ErrorGuaranteed> {
         let ty = self.typeck_results.node_type(pat.hir_id);
         let span = pat.span;
 
@@ -306,27 +307,34 @@ impl<'tcx> PatCtxt<'tcx> {
                 return Err(e);
             }
         }
+        let mut thir_pat = Box::new(Pat { ty, span, kind });
 
         // If we are handling a range with associated constants (e.g.
         // `Foo::<'a>::A..=Foo::B`), we need to put the ascriptions for the associated
         // constants somewhere. Have them on the range pattern.
         for ascription in ascriptions {
-            let subpattern = Box::new(Pat { span, ty, kind });
-            kind = PatKind::AscribeUserType { ascription, subpattern };
+            thir_pat = Box::new(Pat {
+                ty,
+                span,
+                kind: PatKind::AscribeUserType { ascription, subpattern: thir_pat },
+            });
         }
         // `PatKind::ExpandedConstant` wrappers from range endpoints used to
         // also be preserved here, but that was only needed for unsafeck of
         // inline `const { .. }` patterns, which were removed by
         // <https://github.com/rust-lang/rust/pull/138492>.
 
-        Ok(kind)
+        Ok(thir_pat)
     }
 
     #[instrument(skip(self), level = "debug")]
     fn lower_pattern_unadjusted(&mut self, pat: &'tcx hir::Pat<'tcx>) -> Box<Pat<'tcx>> {
-        let mut ty = self.typeck_results.node_type(pat.hir_id);
-        let mut span = pat.span;
+        let ty = self.typeck_results.node_type(pat.hir_id);
+        let span = pat.span;
 
+        // Some of these match arms return a `Box<Pat>` early, while others
+        // evaluate to a `PatKind` that will become a `Box<Pat>` at the end of
+        // this function.
         let kind = match pat.kind {
             hir::PatKind::Missing => PatKind::Missing,
 
@@ -334,10 +342,13 @@ impl<'tcx> PatCtxt<'tcx> {
 
             hir::PatKind::Never => PatKind::Never,
 
-            hir::PatKind::Expr(value) => self.lower_pat_expr(pat, value),
+            hir::PatKind::Expr(value) => return self.lower_pat_expr(pat, value),
 
             hir::PatKind::Range(lo_expr, hi_expr, end) => {
-                self.lower_pattern_range(pat, lo_expr, hi_expr, end).unwrap_or_else(PatKind::Error)
+                match self.lower_pattern_range(pat, lo_expr, hi_expr, end) {
+                    Ok(thir_pat) => return thir_pat,
+                    Err(e) => PatKind::Error(e),
+                }
             }
 
             hir::PatKind::Deref(subpattern) => {
@@ -360,7 +371,7 @@ impl<'tcx> PatCtxt<'tcx> {
             },
 
             hir::PatKind::Slice(prefix, slice, suffix) => {
-                self.slice_or_array_pattern(pat, prefix, slice, suffix)
+                return self.slice_or_array_pattern(pat, prefix, slice, suffix);
             }
 
             hir::PatKind::Tuple(pats, ddpos) => {
@@ -372,8 +383,9 @@ impl<'tcx> PatCtxt<'tcx> {
             }
 
             hir::PatKind::Binding(explicit_ba, id, ident, sub) => {
+                let mut thir_pat_span = span;
                 if let Some(ident_span) = ident.span.find_ancestor_inside(span) {
-                    span = span.with_hi(ident_span.hi());
+                    thir_pat_span = span.with_hi(ident_span.hi());
                 }
 
                 let mode = *self
@@ -389,22 +401,23 @@ impl<'tcx> PatCtxt<'tcx> {
                 // A ref x pattern is the same node used for x, and as such it has
                 // x's type, which is &T, where we want T (the type being matched).
                 let var_ty = ty;
+                let mut thir_pat_ty = ty;
                 if let hir::ByRef::Yes(pinnedness, _) = mode.0 {
                     match pinnedness {
                         hir::Pinnedness::Pinned
                             if let Some(pty) = ty.pinned_ty()
                                 && let &ty::Ref(_, rty, _) = pty.kind() =>
                         {
-                            ty = rty;
+                            thir_pat_ty = rty;
                         }
                         hir::Pinnedness::Not if let &ty::Ref(_, rty, _) = ty.kind() => {
-                            ty = rty;
+                            thir_pat_ty = rty;
                         }
                         _ => bug!("`ref {}` has wrong type {}", ident, ty),
                     }
                 };
 
-                PatKind::Binding {
+                let kind = PatKind::Binding {
                     mode,
                     name: ident.name,
                     var: LocalVarId(id),
@@ -412,7 +425,10 @@ impl<'tcx> PatCtxt<'tcx> {
                     subpattern: self.lower_opt_pattern(sub),
                     is_primary: id == pat.hir_id,
                     is_shorthand: false,
-                }
+                };
+                // We might have modified the type or span, so use the modified
+                // values in the THIR pattern node.
+                return Box::new(Pat { ty: thir_pat_ty, span: thir_pat_span, kind });
             }
 
             hir::PatKind::TupleStruct(ref qpath, pats, ddpos) => {
@@ -422,7 +438,7 @@ impl<'tcx> PatCtxt<'tcx> {
                 };
                 let variant_def = adt_def.variant_of_res(res);
                 let subpatterns = self.lower_tuple_subpats(pats, variant_def.fields.len(), ddpos);
-                self.lower_variant_or_leaf(pat, None, res, subpatterns)
+                return self.lower_variant_or_leaf(pat, None, res, subpatterns);
             }
 
             hir::PatKind::Struct(ref qpath, fields, _) => {
@@ -439,7 +455,7 @@ impl<'tcx> PatCtxt<'tcx> {
                     })
                     .collect();
 
-                self.lower_variant_or_leaf(pat, None, res, subpatterns)
+                return self.lower_variant_or_leaf(pat, None, res, subpatterns);
             }
 
             hir::PatKind::Or(pats) => PatKind::Or { pats: self.lower_patterns(pats) },
@@ -450,6 +466,8 @@ impl<'tcx> PatCtxt<'tcx> {
             hir::PatKind::Err(guar) => PatKind::Error(guar),
         };
 
+        // For pattern kinds that haven't already returned, create a `thir::Pat`
+        // with the HIR pattern node's type and span.
         Box::new(Pat { span, ty, kind })
     }
 
@@ -482,13 +500,14 @@ impl<'tcx> PatCtxt<'tcx> {
         prefix: &'tcx [hir::Pat<'tcx>],
         slice: Option<&'tcx hir::Pat<'tcx>>,
         suffix: &'tcx [hir::Pat<'tcx>],
-    ) -> PatKind<'tcx> {
+    ) -> Box<Pat<'tcx>> {
         let ty = self.typeck_results.node_type(pat.hir_id);
+        let span = pat.span;
 
         let prefix = self.lower_patterns(prefix);
         let slice = self.lower_opt_pattern(slice);
         let suffix = self.lower_patterns(suffix);
-        match ty.kind() {
+        let kind = match ty.kind() {
             // Matching a slice, `[T]`.
             ty::Slice(..) => PatKind::Slice { prefix, slice, suffix },
             // Fixed-length array, `[T; len]`.
@@ -499,8 +518,9 @@ impl<'tcx> PatCtxt<'tcx> {
                 assert!(len >= prefix.len() as u64 + suffix.len() as u64);
                 PatKind::Array { prefix, slice, suffix }
             }
-            _ => span_bug!(pat.span, "bad slice pattern type {ty:?}"),
-        }
+            _ => span_bug!(span, "bad slice pattern type {ty:?}"),
+        };
+        Box::new(Pat { ty, span, kind })
     }
 
     fn lower_variant_or_leaf(
@@ -509,7 +529,7 @@ impl<'tcx> PatCtxt<'tcx> {
         expr: Option<&'tcx hir::PatExpr<'tcx>>,
         res: Res,
         subpatterns: Vec<FieldPat<'tcx>>,
-    ) -> PatKind<'tcx> {
+    ) -> Box<Pat<'tcx>> {
         // Check whether the caller should have provided an `expr` for this pattern kind.
         assert_matches!(
             (pat.kind, expr),
@@ -533,7 +553,7 @@ impl<'tcx> PatCtxt<'tcx> {
             res => res,
         };
 
-        let mut kind = match res {
+        let kind = match res {
             Res::Def(DefKind::Variant, variant_id) => {
                 let enum_id = self.tcx.parent(variant_id);
                 let adt_def = self.tcx.adt_def(enum_id);
@@ -542,7 +562,7 @@ impl<'tcx> PatCtxt<'tcx> {
                         ty::Adt(_, args) | ty::FnDef(_, args) => args,
                         ty::Error(e) => {
                             // Avoid ICE (#50585)
-                            return PatKind::Error(*e);
+                            return Box::new(Pat { ty, span, kind: PatKind::Error(*e) });
                         }
                         _ => bug!("inappropriate type for def: {:?}", ty),
                     };
@@ -583,21 +603,26 @@ impl<'tcx> PatCtxt<'tcx> {
                 PatKind::Error(e)
             }
         };
+        let mut thir_pat = Box::new(Pat { ty, span, kind });
 
         if let Some(user_ty) = self.user_args_applied_to_ty_of_hir_id(hir_id) {
-            debug!("lower_variant_or_leaf: kind={:?} user_ty={:?} span={:?}", kind, user_ty, span);
+            debug!(?thir_pat, ?user_ty, ?span, "lower_variant_or_leaf: applying ascription");
             let annotation = CanonicalUserTypeAnnotation {
                 user_ty: Box::new(user_ty),
                 span,
                 inferred_ty: self.typeck_results.node_type(hir_id),
             };
-            kind = PatKind::AscribeUserType {
-                subpattern: Box::new(Pat { span, ty, kind }),
-                ascription: Ascription { annotation, variance: ty::Covariant },
-            };
+            thir_pat = Box::new(Pat {
+                ty,
+                span,
+                kind: PatKind::AscribeUserType {
+                    subpattern: thir_pat,
+                    ascription: Ascription { annotation, variance: ty::Covariant },
+                },
+            });
         }
 
-        kind
+        thir_pat
     }
 
     fn user_args_applied_to_ty_of_hir_id(
@@ -632,8 +657,7 @@ impl<'tcx> PatCtxt<'tcx> {
             _ => {
                 // The path isn't the name of a constant, so it must actually
                 // be a unit struct or unit variant (e.g. `Option::None`).
-                let kind = self.lower_variant_or_leaf(pat, Some(expr), res, vec![]);
-                return Box::new(Pat { span, ty, kind });
+                return self.lower_variant_or_leaf(pat, Some(expr), res, vec![]);
             }
         };
 
@@ -674,10 +698,10 @@ impl<'tcx> PatCtxt<'tcx> {
         &mut self,
         pat: &'tcx hir::Pat<'tcx>, // Pattern that directly contains `expr`
         expr: &'tcx hir::PatExpr<'tcx>,
-    ) -> PatKind<'tcx> {
+    ) -> Box<Pat<'tcx>> {
         assert_matches!(pat.kind, hir::PatKind::Expr(..) | hir::PatKind::Range(..));
         match &expr.kind {
-            hir::PatExprKind::Path(qpath) => self.lower_path(pat, expr, qpath).kind,
+            hir::PatExprKind::Path(qpath) => self.lower_path(pat, expr, qpath),
             hir::PatExprKind::Lit { lit, negated } => {
                 // We handle byte string literal patterns by using the pattern's type instead of the
                 // literal's type in `const_to_pat`: if the literal `b"..."` matches on a slice reference,
@@ -691,7 +715,7 @@ impl<'tcx> PatCtxt<'tcx> {
                 let pat_ty = self.typeck_results.node_type(pat.hir_id);
                 let lit_input = LitToConstInput { lit: lit.node, ty: pat_ty, neg: *negated };
                 let constant = self.tcx.at(expr.span).lit_to_const(lit_input);
-                self.const_to_pat(constant, pat_ty, expr.hir_id, lit.span).kind
+                self.const_to_pat(constant, pat_ty, expr.hir_id, lit.span)
             }
         }
     }

--- a/compiler/rustc_mir_build/src/thir/print.rs
+++ b/compiler/rustc_mir_build/src/thir/print.rs
@@ -725,13 +725,6 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
             PatKind::Never => {
                 print_indented!(self, "Never", depth_lvl + 1);
             }
-            PatKind::AscribeUserType { ascription, subpattern } => {
-                print_indented!(self, "AscribeUserType: {", depth_lvl + 1);
-                print_indented!(self, format!("ascription: {:?}", ascription), depth_lvl + 2);
-                print_indented!(self, "subpattern: ", depth_lvl + 2);
-                self.print_pat(subpattern, depth_lvl + 3);
-                print_indented!(self, "}", depth_lvl + 1);
-            }
             PatKind::Binding { name, mode, var, ty, subpattern, is_primary, is_shorthand } => {
                 print_indented!(self, "Binding {", depth_lvl + 1);
                 print_indented!(self, format!("name: {:?}", name), depth_lvl + 2);
@@ -794,13 +787,6 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
             PatKind::Constant { value } => {
                 print_indented!(self, "Constant {", depth_lvl + 1);
                 print_indented!(self, format!("value: {}", value), depth_lvl + 2);
-                print_indented!(self, "}", depth_lvl + 1);
-            }
-            PatKind::ExpandedConstant { def_id, subpattern } => {
-                print_indented!(self, "ExpandedConstant {", depth_lvl + 1);
-                print_indented!(self, format!("def_id: {def_id:?}"), depth_lvl + 2);
-                print_indented!(self, "subpattern:", depth_lvl + 2);
-                self.print_pat(subpattern, depth_lvl + 2);
                 print_indented!(self, "}", depth_lvl + 1);
             }
             PatKind::Range(pat_range) => {

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -462,8 +462,6 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
         let arity;
         let fields: Vec<_>;
         match &pat.kind {
-            PatKind::AscribeUserType { subpattern, .. }
-            | PatKind::ExpandedConstant { subpattern, .. } => return self.lower_pat(subpattern),
             PatKind::Binding { subpattern: Some(subpat), .. } => return self.lower_pat(subpat),
             PatKind::Missing | PatKind::Binding { subpattern: None, .. } | PatKind::Wild => {
                 ctor = Wildcard;


### PR DESCRIPTION
This PR removes the `AscribeUserType` and `ExpandedConstant` variants from `thir::PatKind`, and replaces them with an `Option<Box<PatExtra>>` field attached to every `thir::Pat`.

### Why remove these variants?

Unlike other THIR pattern kinds, these variants are mere “wrappers” that exist to attach some additional information to an underlying pattern node.

There are several places where code that consumes THIR patterns needs to carefully “unpeel” any wrapper nodes, in order to match on the underlying pattern. This is clunky, and easy to forget to do, especially since it's not always obvious where the wrapper nodes can and can't appear.

Attaching the data to an optional per-node field makes it easier for consuming code to simply ignore the extra data when it is not relevant.

(One downside is that it is now easier to accidentally ignore the extra data when it *is* relevant, but I think that's generally a favourable tradeoff.)

### Impact

After this change, THIR pattern trees should be “logically identical” to the previous THIR pattern trees, in the sense that information that was carried by wrapper nodes should now be directly attached to the non-wrapper nodes that were being wrapped. Types and spans associated with THIR pattern nodes should (hopefully!) still be accurate.

There should be no change to the output of THIR-based checks or MIR building.