### PR TITLE
Fix copy-n-paste error in `vtable_for` docs

### DIFF
--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2738,10 +2738,6 @@ pub unsafe fn vtable_align(ptr: *const ()) -> usize;
 /// Determining whether `T` can be coerced to the trait object type `U` requires trait resolution by the compiler.
 /// In some cases, that resolution can exceed the recursion limit,
 /// and compilation will fail instead of this function returning `None`.
-///
-/// # Safety
-///
-/// `ptr` must point to a vtable.
 #[rustc_nounwind]
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_intrinsic]


### PR DESCRIPTION
This is a safe function, which doesn't take a `ptr` parameter.