### PR TITLE
Remove out of date FIXME comment.

### DIFF
--- a/compiler/rustc_parse/src/parser/tests.rs
+++ b/compiler/rustc_parse/src/parser/tests.rs
@@ -2666,7 +2666,6 @@ fn look_ahead_non_outermost_stream() {
     });
 }
 
-// FIXME(nnethercote) All the output is currently wrong.
 #[test]
 fn debug_lookahead() {
     create_default_session_globals_then(|| {


### PR DESCRIPTION
In rust-lang/rust#127273 I added a test and a FIXME comment pointing out how it does the wrong thing. In the next commit I fixed the problem but forgot to remove the FIXME comment, whoops.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
