### PR TITLE
Fix ICE: can't type-check body of DefId  for issue #148729

### DIFF
--- a/compiler/rustc_const_eval/src/check_consts/qualifs.rs
+++ b/compiler/rustc_const_eval/src/check_consts/qualifs.rs
@@ -6,9 +6,7 @@
 // having basically only two use-cases that act in different ways.
 
 use rustc_errors::ErrorGuaranteed;
-use rustc_hir::attrs::AttributeKind;
-use rustc_hir::def::DefKind;
-use rustc_hir::{LangItem, find_attr};
+use rustc_hir::LangItem;
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::mir::*;
 use rustc_middle::ty::{self, AdtDef, Ty};
@@ -366,14 +364,10 @@ where
         // check performed after the promotion. Verify that with an assertion.
         assert!(promoted.is_none() || Q::ALLOW_PROMOTED);
 
-        // Avoid looking at attrs of anon consts as that will ICE
-        let is_type_const_item =
-            matches!(cx.tcx.def_kind(def), DefKind::Const | DefKind::AssocConst)
-                && find_attr!(cx.tcx.get_all_attrs(def), AttributeKind::TypeConst(_));
-
         // Don't peak inside trait associated constants, also `#[type_const] const` items
         // don't have bodies so there's nothing to look at
-        if promoted.is_none() && cx.tcx.trait_of_assoc(def).is_none() && !is_type_const_item {
+        if promoted.is_none() && cx.tcx.trait_of_assoc(def).is_none() && !cx.tcx.is_type_const(def)
+        {
             let qualifs = cx.tcx.at(constant.span).mir_const_qualif(def);
 
             if !Q::in_qualifs(&qualifs) {

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1891,6 +1891,12 @@ impl<'tcx> TyCtxt<'tcx> {
         self.is_lang_item(self.parent(def_id), LangItem::AsyncDropInPlace)
     }
 
+    /// Check if the given `def_id` is a const with the `#[type_const]` attribute.
+    pub fn is_type_const(self, def_id: DefId) -> bool {
+        matches!(self.def_kind(def_id), DefKind::Const | DefKind::AssocConst)
+            && find_attr!(self.get_all_attrs(def_id), AttributeKind::TypeConst(_))
+    }
+
     /// Returns the movability of the coroutine of `def_id`, or panics
     /// if given a `def_id` that is not a coroutine.
     pub fn coroutine_movability(self, def_id: DefId) -> hir::Movability {

--- a/tests/ui/const-generics/mgca/type_const-array-return.rs
+++ b/tests/ui/const-generics/mgca/type_const-array-return.rs
@@ -1,0 +1,26 @@
+//@ check-pass
+// This test should compile without an ICE.
+#![expect(incomplete_features)]
+#![feature(min_generic_const_args)]
+
+pub struct A;
+
+pub trait Array {
+    #[type_const]
+    const LEN: usize;
+    fn arr() -> [u8; Self::LEN];
+}
+
+impl Array for A {
+    #[type_const]
+    const LEN: usize = 4;
+
+    #[allow(unused_braces)]
+    fn arr() -> [u8; const { Self::LEN }] {
+        return [0u8; const { Self::LEN }];
+    }
+}
+
+fn main() {
+    let _ = A::arr();
+}

--- a/tests/ui/const-generics/mgca/type_const-inherent-const-omitted-type.rs
+++ b/tests/ui/const-generics/mgca/type_const-inherent-const-omitted-type.rs
@@ -1,0 +1,12 @@
+#![expect(incomplete_features)]
+#![feature(min_generic_const_args)]
+
+struct A;
+
+impl A {
+    #[type_const]
+    const B = 4;
+    //~^ ERROR: missing type for `const` item
+}
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/type_const-inherent-const-omitted-type.stderr
+++ b/tests/ui/const-generics/mgca/type_const-inherent-const-omitted-type.stderr
@@ -1,0 +1,13 @@
+error: missing type for `const` item
+  --> $DIR/type_const-inherent-const-omitted-type.rs:8:12
+   |
+LL |     const B = 4;
+   |            ^
+   |
+help: provide a type for the item
+   |
+LL |     const B: <type> = 4;
+   |            ++++++++
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/const-generics/mgca/type_const-only-in-impl-omitted-type.rs
+++ b/tests/ui/const-generics/mgca/type_const-only-in-impl-omitted-type.rs
@@ -1,0 +1,22 @@
+#![expect(incomplete_features)]
+#![feature(min_generic_const_args)]
+
+trait BadTr {
+    const NUM: usize;
+}
+
+struct GoodS;
+
+impl BadTr for GoodS {
+    #[type_const]
+    const NUM: = 84;
+    //~^ ERROR: missing type for `const` item
+
+}
+
+fn accept_bad_tr<const N: usize, T: BadTr<NUM = { N }>>(_x: &T) {}
+//~^ ERROR use of trait associated const without `#[type_const]`
+
+fn main() {
+    accept_bad_tr::<84, _>(&GoodS);
+}

--- a/tests/ui/const-generics/mgca/type_const-only-in-impl-omitted-type.stderr
+++ b/tests/ui/const-generics/mgca/type_const-only-in-impl-omitted-type.stderr
@@ -1,0 +1,16 @@
+error: missing type for `const` item
+  --> $DIR/type_const-only-in-impl-omitted-type.rs:12:15
+   |
+LL |     const NUM: = 84;
+   |               ^ help: provide a type for the associated constant: `usize`
+
+error: use of trait associated const without `#[type_const]`
+  --> $DIR/type_const-only-in-impl-omitted-type.rs:17:43
+   |
+LL | fn accept_bad_tr<const N: usize, T: BadTr<NUM = { N }>>(_x: &T) {}
+   |                                           ^^^^^^^^^^^
+   |
+   = note: the declaration in the trait must be marked with `#[type_const]`
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/const-generics/mgca/type_const-recursive.rs
+++ b/tests/ui/const-generics/mgca/type_const-recursive.rs
@@ -1,0 +1,8 @@
+#![expect(incomplete_features)]
+#![feature(min_generic_const_args)]
+
+#[type_const]
+const A: u8 = A;
+//~^ ERROR: overflow normalizing the unevaluated constant `A` [E0275]
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/type_const-recursive.stderr
+++ b/tests/ui/const-generics/mgca/type_const-recursive.stderr
@@ -1,0 +1,11 @@
+error[E0275]: overflow normalizing the unevaluated constant `A`
+  --> $DIR/type_const-recursive.rs:5:1
+   |
+LL | const A: u8 = A;
+   | ^^^^^^^^^^^
+   |
+   = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/const-generics/mgca/type_const-use.rs
+++ b/tests/ui/const-generics/mgca/type_const-use.rs
@@ -1,0 +1,13 @@
+//@ check-pass
+// This test should compile without an ICE.
+#![expect(incomplete_features)]
+#![feature(min_generic_const_args)]
+
+#[type_const]
+const CONST: usize = 1;
+
+fn uses_const() {
+    CONST;
+}
+
+fn main() {}


### PR DESCRIPTION
This commit fixes https://github.com/rust-lang/rust/issues/148729 for min_const_generic_args https://github.com/rust-lang/rust/issues/132980. 

It's pretty small PR. The first commit makes sure that the `type_const`s are made into normal consts in const expressions.

The next one just handles the case https://github.com/rust-lang/rust/issues/148729 of where the type of the const was omitted at which point it was trying to treat a `type_const` again as a regular const. That obviously will fail since a type_const does not have a body. 


@rustbot label +F-associated_const_equality +F-min_generic_const_args +I-ICE