### PR TITLE
Fix ICE in inline always warning emission.

### DIFF
--- a/compiler/rustc_mir_transform/src/errors.rs
+++ b/compiler/rustc_mir_transform/src/errors.rs
@@ -19,14 +19,14 @@ pub(crate) fn emit_inline_always_target_feature_diagnostic<'a, 'tcx>(
     caller_def_id: DefId,
     callee_only: &[&'a str],
 ) {
-    let callee = tcx.def_path_str(callee_def_id);
-    let caller = tcx.def_path_str(caller_def_id);
-
     tcx.node_span_lint(
         lint::builtin::INLINE_ALWAYS_MISMATCHING_TARGET_FEATURES,
         tcx.local_def_id_to_hir_id(caller_def_id.as_local().unwrap()),
         call_span,
         |lint| {
+            let callee = tcx.def_path_str(callee_def_id);
+            let caller = tcx.def_path_str(caller_def_id);
+
             lint.primary_message(format!(
                 "call to `#[inline(always)]`-annotated `{callee}` \
                 requires the same target features to be inlined"


### PR DESCRIPTION
The calls to `def_path_str` were outside the decorate callback in `node_span_lint` which caused an ICE when the warning was an allowed warning due to the call to `def_path_str` being executed but the warning not actually being emitted.

r? @davidtwco