### PR TITLE
rename the `derive_{eq, clone_copy}` features to `*_internals`

### DIFF
--- a/library/core/src/clone.rs
+++ b/library/core/src/clone.rs
@@ -285,7 +285,7 @@ pub const unsafe trait TrivialClone: [const] Clone {}
 /// Derive macro generating an impl of the trait `Clone`.
 #[rustc_builtin_macro]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
-#[allow_internal_unstable(core_intrinsics, derive_clone_copy, trivial_clone)]
+#[allow_internal_unstable(core_intrinsics, derive_clone_copy_internals, trivial_clone)]
 pub macro Clone($item:item) {
     /* compiler built-in */
 }
@@ -350,7 +350,7 @@ impl_use_cloned! {
 #[doc(hidden)]
 #[allow(missing_debug_implementations)]
 #[unstable(
-    feature = "derive_clone_copy",
+    feature = "derive_clone_copy_internals",
     reason = "deriving hack, should not be public",
     issue = "none"
 )]
@@ -360,7 +360,7 @@ pub struct AssertParamIsClone<T: Clone + PointeeSized> {
 #[doc(hidden)]
 #[allow(missing_debug_implementations)]
 #[unstable(
-    feature = "derive_clone_copy",
+    feature = "derive_clone_copy_internals",
     reason = "deriving hack, should not be public",
     issue = "none"
 )]

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -351,7 +351,7 @@ pub const trait Eq: [const] PartialEq<Self> + PointeeSized {
 /// Derive macro generating an impl of the trait [`Eq`].
 #[rustc_builtin_macro]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
-#[allow_internal_unstable(core_intrinsics, derive_eq, structural_match)]
+#[allow_internal_unstable(core_intrinsics, derive_eq_internals, structural_match)]
 #[allow_internal_unstable(coverage_attribute)]
 pub macro Eq($item:item) {
     /* compiler built-in */
@@ -363,7 +363,11 @@ pub macro Eq($item:item) {
 // This struct should never appear in user code.
 #[doc(hidden)]
 #[allow(missing_debug_implementations)]
-#[unstable(feature = "derive_eq", reason = "deriving hack, should not be public", issue = "none")]
+#[unstable(
+    feature = "derive_eq_internals",
+    reason = "deriving hack, should not be public",
+    issue = "none"
+)]
 pub struct AssertParamIsEq<T: Eq + PointeeSized> {
     _field: crate::marker::PhantomData<T>,
 }

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -466,7 +466,7 @@ pub trait Copy: Clone {
 /// Derive macro generating an impl of the trait `Copy`.
 #[rustc_builtin_macro]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
-#[allow_internal_unstable(core_intrinsics, derive_clone_copy)]
+#[allow_internal_unstable(core_intrinsics, derive_clone_copy_internals)]
 pub macro Copy($item:item) {
     /* compiler built-in */
 }

--- a/src/doc/unstable-book/src/library-features/derive-clone-copy-internals.md
+++ b/src/doc/unstable-book/src/library-features/derive-clone-copy-internals.md
@@ -1,4 +1,4 @@
-# `derive_clone_copy`
+# `derive_clone_copy_internals`
 
 This feature is internal to the Rust compiler and is not intended for general use.
 

--- a/src/doc/unstable-book/src/library-features/derive-eq-internals.md
+++ b/src/doc/unstable-book/src/library-features/derive-eq-internals.md
@@ -1,4 +1,4 @@
-# `derive_eq`
+# `derive_eq_internals`
 
 This feature is internal to the Rust compiler and is not intended for general use.
 


### PR DESCRIPTION
Features like `derive_from` and `derive_coerce_pointee` refer to actual unstable derive macros, but the `derive_eq` and `derive_clone_copy` features are internal hacks. Rename them accordingly by adding the suffix `_internals`.