### PR TITLE
Store defids instead of symbol names in the aliases list

### DIFF
--- a/compiler/rustc_codegen_llvm/src/mono_item.rs
+++ b/compiler/rustc_codegen_llvm/src/mono_item.rs
@@ -10,7 +10,6 @@ use rustc_middle::mir::mono::Visibility;
 use rustc_middle::ty::layout::{FnAbiOf, HasTypingEnv, LayoutOf};
 use rustc_middle::ty::{self, Instance, TypeVisitableExt};
 use rustc_session::config::CrateType;
-use rustc_span::Symbol;
 use rustc_target::spec::{Arch, RelocModel};
 use tracing::debug;
 
@@ -92,17 +91,19 @@ impl<'tcx> PreDefineCodegenMethods<'tcx> for CodegenCx<'_, 'tcx> {
 }
 
 impl CodegenCx<'_, '_> {
-    fn add_aliases(&self, aliasee: &llvm::Value, aliases: &[(Symbol, Linkage, Visibility)]) {
+    fn add_aliases(&self, aliasee: &llvm::Value, aliases: &[(DefId, Linkage, Visibility)]) {
         let ty = self.get_type_of_global(aliasee);
 
         for (alias, linkage, visibility) in aliases {
+            let symbol_name = self.tcx.symbol_name(Instance::mono(self.tcx, *alias));
+
             tracing::debug!("ALIAS: {alias:?} {linkage:?} {visibility:?}");
             let lldecl = llvm::add_alias(
                 self.llmod,
                 ty,
                 AddressSpace::ZERO,
                 aliasee,
-                &CString::new(alias.as_str()).unwrap(),
+                &CString::new(symbol_name.name).unwrap(),
             );
 
             llvm::set_visibility(lldecl, base::visibility_to_llvm(*visibility));

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -13,10 +13,10 @@ use rustc_middle::middle::codegen_fn_attrs::{
 use rustc_middle::mir::mono::Visibility;
 use rustc_middle::query::Providers;
 use rustc_middle::span_bug;
-use rustc_middle::ty::{self as ty, Instance, TyCtxt};
+use rustc_middle::ty::{self as ty, TyCtxt};
 use rustc_session::lint;
 use rustc_session::parse::feature_err;
-use rustc_span::{Span, Symbol, sym};
+use rustc_span::{Span, sym};
 use rustc_target::spec::Os;
 
 use crate::errors;
@@ -291,8 +291,6 @@ fn process_builtin_attrs(
                         )
                         .expect("eii should have declaration macro with extern target attribute");
 
-                        let symbol_name = tcx.symbol_name(Instance::mono(tcx, extern_item));
-
                         // this is to prevent a bug where a single crate defines both the default and explicit implementation
                         // for an EII. In that case, both of them may be part of the same final object file. I'm not 100% sure
                         // what happens, either rustc deduplicates the symbol or llvm, or it's random/order-dependent.
@@ -310,7 +308,7 @@ fn process_builtin_attrs(
                         }
 
                         codegen_fn_attrs.foreign_item_symbol_aliases.push((
-                            Symbol::intern(symbol_name.name),
+                            extern_item,
                             if i.is_default { Linkage::LinkOnceAny } else { Linkage::External },
                             Visibility::Default,
                         ));

--- a/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
+++ b/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 
 use rustc_abi::Align;
 use rustc_hir::attrs::{InlineAttr, InstructionSetAttr, Linkage, OptimizeAttr, RtsanSetting};
+use rustc_hir::def_id::DefId;
 use rustc_macros::{HashStable, TyDecodable, TyEncodable};
 use rustc_span::Symbol;
 use rustc_target::spec::SanitizerSet;
@@ -72,7 +73,7 @@ pub struct CodegenFnAttrs {
     /// generate this function under its real name,
     /// but *also* under the same name as this foreign function so that the foreign function has an implementation.
     // FIXME: make "SymbolName<'tcx>"
-    pub foreign_item_symbol_aliases: Vec<(Symbol, Linkage, Visibility)>,
+    pub foreign_item_symbol_aliases: Vec<(DefId, Linkage, Visibility)>,
     /// The `#[link_ordinal = "..."]` attribute, indicating an ordinal an
     /// imported function has in the dynamic library. Note that this must not
     /// be set when `link_name` is set. This is for foreign items with the


### PR DESCRIPTION
I was honestly surprised this worked in the past. This causes a cycle error since we now compute a symbol name in codegen_attrs, and then compute codegen attrs when we try to get the symbol name. 

It only worked when there weren't any codegen attributes to begin with, causing symbol name computation to skip the call to codegen_attrs.

Like this we won't have the same problem.

r? @bjorn3 