### PR TITLE
Bump `diesel` to the most recent commit in `cargotest`

### DIFF
--- a/src/tools/cargotest/main.rs
+++ b/src/tools/cargotest/main.rs
@@ -84,7 +84,7 @@ const TEST_REPOS: &[Test] = &[
     Test {
         name: "diesel",
         repo: "https://github.com/diesel-rs/diesel",
-        sha: "91493fe47175076f330ce5fc518f0196c0476f56",
+        sha: "3db7c17c5b069656ed22750e84d6498c8ab5b81d",
         lock: None,
         packages: &[],
         // Test the embedded sqlite variant of diesel


### PR DESCRIPTION
`cargotest` can only detect the worst offenders (like tests failing, or hard compiler errors / ICEs), but regardless, bumping `diesel` to a way more recent version hopefully contributes slightly towards helping us not break `diesel` if at all possible.

That is, AFAIUI, this will not help catch [#t-compiler/prioritization/alerts > #149845 Diesel stops building with nightly-2025-12-10 @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/245100-t-compiler.2Fprioritization.2Falerts/topic/.23149845.20Diesel.20stops.20building.20with.20nightly-2025-12-10/near/566975273) because we cap-lints to `warn` in `cargotest`.

Most recent commit as of the time of this PR anyway.
