### PR TITLE
Fix trait method anchor disappearing before user can click on it

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1200,9 +1200,11 @@ nav.sub {
 	display: initial;
 }
 .anchor {
+	--anchor-link-shift: 0.5em;
 	display: none;
 	position: absolute;
-	left: -0.5em;
+	left: calc(var(--anchor-link-shift) * -1);
+	padding-right: var(--anchor-link-shift);
 	background: none !important;
 }
 .anchor.field {

--- a/tests/rustdoc-gui/anchor-navigable.goml
+++ b/tests/rustdoc-gui/anchor-navigable.goml
@@ -7,5 +7,5 @@
 go-to: "file://" + |DOC_PATH| + "/test_docs/struct.Foo.html"
 // We check that ".item-info" is bigger than its content.
 move-cursor-to: ".impl"
-assert-property: (".impl > a.anchor", {"offsetWidth": "8"})
+assert-property: (".impl > a.anchor", {"offsetWidth": "16"})
 assert-css: (".impl > a.anchor", {"left": "-8px"})

--- a/tests/rustdoc-gui/anchors.goml
+++ b/tests/rustdoc-gui/anchors.goml
@@ -45,6 +45,22 @@ define-function: (
             {"color": |src_link_color|, "text-decoration": "none"},
         )
 
+        // Now we ensure that the `§` anchor is "reachable" for users on trait methods.
+        // To ensure the anchor is not hovered, we move the cursor to another item.
+        move-cursor-to: "#search-button"
+        // By default, the anchor is not displayed.
+        wait-for-css: ("#method\.vroum .anchor", {"display": "none"})
+        // Once we move the cursor to the method, the anchor should appear.
+        move-cursor-to: "#method\.vroum .code-header"
+        assert-css-false: ("#method\.vroum .anchor", {"display": "none"})
+        // Now we move the cursor to the anchor to check there is no gap between the method and the
+        // anchor, making the anchor disappear and preventing users to click on it.
+        // To make it work, we need to first move it between the method and the anchor.
+        store-position: ("#method\.vroum .code-header", {"x": method_x, "y": method_y})
+        move-cursor-to: (|method_x| - 2, |method_y|)
+        // Anchor should still be displayed.
+        assert-css-false: ("#method\.vroum .anchor", {"display": "none"})
+
         go-to: "file://" + |DOC_PATH| + "/test_docs/struct.HeavilyDocumentedStruct.html"
         // Since we changed page, we need to set the theme again.
         call-function: ("switch-theme", {"theme": |theme|})

--- a/tests/rustdoc-gui/anchors.goml
+++ b/tests/rustdoc-gui/anchors.goml
@@ -14,9 +14,9 @@ define-function: (
         assert-css: ("#toggle-all-docs", {"color": |main_color|})
         assert-css: (".main-heading h1 span", {"color": |main_heading_type_color|})
         assert-css: (
-             ".rightside a.src",
-             {"color": |src_link_color|, "text-decoration": "none"},
-             ALL,
+            ".rightside a.src",
+            {"color": |src_link_color|, "text-decoration": "none"},
+            ALL,
         )
         compare-elements-css: (
             ".rightside a.src",
@@ -31,25 +31,23 @@ define-function: (
 
         move-cursor-to: ".main-heading a.src"
         assert-css: (
-             ".main-heading a.src",
-             {"color": |src_link_color|, "text-decoration": "underline"},
+            ".main-heading a.src",
+            {"color": |src_link_color|, "text-decoration": "underline"},
         )
         move-cursor-to: ".impl-items .rightside a.src"
         assert-css: (
-             ".impl-items .rightside a.src",
-             {"color": |src_link_color|, "text-decoration": "none"},
+            ".impl-items .rightside a.src",
+            {"color": |src_link_color|, "text-decoration": "none"},
         )
         move-cursor-to: ".impl-items a.rightside.src"
         assert-css: (
-             ".impl-items a.rightside.src",
-             {"color": |src_link_color|, "text-decoration": "none"},
+            ".impl-items a.rightside.src",
+            {"color": |src_link_color|, "text-decoration": "none"},
         )
 
         go-to: "file://" + |DOC_PATH| + "/test_docs/struct.HeavilyDocumentedStruct.html"
         // Since we changed page, we need to set the theme again.
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        // We reload the page so the local storage settings are being used.
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
 
         assert-css: ("#top-doc-prose-title", {"color": |title_color|})
 

--- a/tests/rustdoc-gui/src/staged_api/lib.rs
+++ b/tests/rustdoc-gui/src/staged_api/lib.rs
@@ -4,6 +4,10 @@
 #![stable(feature = "some_feature", since = "1.3.5")]
 #![doc(rust_logo)]
 
+pub trait X {
+    fn vroum();
+}
+
 #[stable(feature = "some_feature", since = "1.3.5")]
 pub struct Foo {}
 
@@ -12,4 +16,8 @@ impl Foo {
     pub fn bar() {}
     #[stable(feature = "some_other_feature", since = "1.3.6")]
     pub fn yo() {}
+}
+
+impl X for Foo {
+    fn vroum() {}
 }


### PR DESCRIPTION
A good example of this bug is going to https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir_analysis/collect/struct.ItemCtxt.html#impl-HirTyLowerer%3C'tcx%3E-for-ItemCtxt%3C'tcx%3E, and then try to click on the `§` anchor of the `tcx` method.

The solution to this bug is to simply "glue" the anchor to the method, so when the mouse cursor moves to it, there is no gap between the two, preventing the anchor to disappear (hopefully this explanation doesn't make sense only to me ^^').

First commit fixes the bug by expanding the anchor size.
Second commit is a small clean-up of the GUI test.
Third commit actually adds the GUI regression test.

cc @BoxyUwU 
r? @camelid 