### PR TITLE
Implement MVP for opaque generic const arguments

### DIFF
--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -951,6 +951,16 @@ pub(crate) struct IncompatibleFeatures {
 }
 
 #[derive(Diagnostic)]
+#[diag("`{$parent}` requires {$missing} to be enabled")]
+#[help("enable all of these features")]
+pub(crate) struct MissingDependentFeatures {
+    #[primary_span]
+    pub parent_span: Span,
+    pub parent: Symbol,
+    pub missing: String,
+}
+
+#[derive(Diagnostic)]
 #[diag("negative bounds are not supported")]
 pub(crate) struct NegativeBoundUnsupported {
     #[primary_span]

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -441,6 +441,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
 pub fn check_crate(krate: &ast::Crate, sess: &Session, features: &Features) {
     maybe_stage_features(sess, features, krate);
     check_incompatible_features(sess, features);
+    check_dependent_features(sess, features);
     check_new_solver_banned_features(sess, features);
 
     let mut visitor = PostExpansionVisitor { sess, features };
@@ -645,6 +646,27 @@ fn check_incompatible_features(sess: &Session, features: &Features) {
         {
             let spans = vec![f1_span, f2_span];
             sess.dcx().emit_err(errors::IncompatibleFeatures { spans, f1: f1_name, f2: f2_name });
+        }
+    }
+}
+
+fn check_dependent_features(sess: &Session, features: &Features) {
+    for &(parent, children) in
+        rustc_feature::DEPENDENT_FEATURES.iter().filter(|(parent, _)| features.enabled(*parent))
+    {
+        if children.iter().any(|f| !features.enabled(*f)) {
+            let parent_span = features
+                .enabled_features_iter_stable_order()
+                .find_map(|(name, span)| (name == parent).then_some(span))
+                .unwrap();
+            // FIXME: should probably format this in fluent instead of here
+            let missing = children
+                .iter()
+                .filter(|f| !features.enabled(**f))
+                .map(|s| format!("`{}`", s.as_str()))
+                .intersperse(String::from(", "))
+                .collect();
+            sess.dcx().emit_err(errors::MissingDependentFeatures { parent_span, parent, missing });
         }
     }
 }

--- a/compiler/rustc_ast_passes/src/lib.rs
+++ b/compiler/rustc_ast_passes/src/lib.rs
@@ -5,6 +5,7 @@
 // tidy-alphabetical-start
 #![feature(box_patterns)]
 #![feature(if_let_guard)]
+#![feature(iter_intersperse)]
 #![feature(iter_is_partitioned)]
 // tidy-alphabetical-end
 

--- a/compiler/rustc_feature/src/lib.rs
+++ b/compiler/rustc_feature/src/lib.rs
@@ -136,5 +136,6 @@ pub use builtin_attrs::{
 };
 pub use removed::REMOVED_LANG_FEATURES;
 pub use unstable::{
-    EnabledLangFeature, EnabledLibFeature, Features, INCOMPATIBLE_FEATURES, UNSTABLE_LANG_FEATURES,
+    DEPENDENT_FEATURES, EnabledLangFeature, EnabledLibFeature, Features, INCOMPATIBLE_FEATURES,
+    UNSTABLE_LANG_FEATURES,
 };

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -605,6 +605,8 @@ declare_features! (
     (unstable, offset_of_enum, "1.75.0", Some(120141)),
     /// Allows using fields with slice type in offset_of!
     (unstable, offset_of_slice, "1.81.0", Some(126151)),
+    /// Allows using generics in more complex const expressions, based on definitional equality.
+    (unstable, opaque_generic_const_args, "CURRENT_RUSTC_VERSION", Some(151972)),
     /// Allows using `#[optimize(X)]`.
     (unstable, optimize_attribute, "1.34.0", Some(54882)),
     /// Allows specifying nop padding on functions for dynamic patching.
@@ -781,4 +783,10 @@ pub const INCOMPATIBLE_FEATURES: &[(Symbol, Symbol)] = &[
     // Experimental match ergonomics rulesets are incompatible with each other, to simplify the
     // boolean logic required to tell which typing rules to use.
     (sym::ref_pat_eat_one_layer_2024, sym::ref_pat_eat_one_layer_2024_structural),
+];
+
+/// Some features require one or more other features to be enabled.
+pub const DEPENDENT_FEATURES: &[(Symbol, &[Symbol])] = &[
+    (sym::opaque_generic_const_args, &[sym::min_generic_const_args]),
+    (sym::unsized_const_params, &[sym::adt_const_params]),
 ];

--- a/compiler/rustc_hir_analysis/src/collect/generics_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/generics_of.rs
@@ -92,6 +92,8 @@ pub(super) fn generics_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Generics {
             match tcx.anon_const_kind(def_id) {
                 // Stable: anon consts are not able to use any generic parameters...
                 ty::AnonConstKind::MCG => None,
+                // OGCA anon consts inherit their parent's generics.
+                ty::AnonConstKind::OGCA => Some(parent_did),
                 // we provide generics to repeat expr counts as a backwards compatibility hack. #76200
                 ty::AnonConstKind::RepeatExprCount => Some(parent_did),
 

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -404,6 +404,11 @@ impl<'tcx> ForbidMCGParamUsesFolder<'tcx> {
                 diag.span_note(impl_.self_ty.span, "not a concrete type");
             }
         }
+        if self.tcx.features().min_generic_const_args()
+            && !self.tcx.features().opaque_generic_const_args()
+        {
+            diag.help("add `#![feature(opaque_generic_const_args)]` to allow generic expressions as the RHS of const items");
+        }
         diag.emit()
     }
 }

--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use rustc_data_structures::intern::Interned;
 use rustc_error_messages::MultiSpan;
-use rustc_macros::{HashStable, TyDecodable, TyEncodable};
+use rustc_macros::HashStable;
 use rustc_type_ir::walk::TypeWalker;
 use rustc_type_ir::{self as ir, TypeFlags, WithCachedTypeInfo};
 
@@ -334,17 +334,4 @@ impl<'tcx> Const<'tcx> {
     pub fn walk(self) -> TypeWalker<TyCtxt<'tcx>> {
         TypeWalker::new(self.into())
     }
-}
-
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, TyEncodable, TyDecodable, HashStable)]
-pub enum AnonConstKind {
-    /// `feature(generic_const_exprs)` anon consts are allowed to use arbitrary generic parameters in scope
-    GCE,
-    /// stable `min_const_generics` anon consts are not allowed to use any generic parameters
-    MCG,
-    /// anon consts used as the length of a repeat expr are syntactically allowed to use generic parameters
-    /// but must not depend on the actual instantiation. See #76200 for more information
-    RepeatExprCount,
-    /// anon consts outside of the type system, e.g. enum discriminants
-    NonTypeSystem,
 }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -238,6 +238,9 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
     fn const_of_item(self, def_id: DefId) -> ty::EarlyBinder<'tcx, Const<'tcx>> {
         self.const_of_item(def_id)
     }
+    fn anon_const_kind(self, def_id: DefId) -> ty::AnonConstKind {
+        self.anon_const_kind(def_id)
+    }
 
     type AdtDef = ty::AdtDef<'tcx>;
     fn adt_def(self, adt_def_id: DefId) -> Self::AdtDef {

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -76,8 +76,8 @@ pub use self::closure::{
     place_to_string_for_capture,
 };
 pub use self::consts::{
-    AnonConstKind, AtomicOrdering, Const, ConstInt, ConstKind, ConstToValTreeResult, Expr,
-    ExprKind, ScalarInt, SimdAlign, UnevaluatedConst, ValTree, ValTreeKindExt, Value,
+    AtomicOrdering, Const, ConstInt, ConstKind, ConstToValTreeResult, Expr, ExprKind, ScalarInt,
+    SimdAlign, UnevaluatedConst, ValTree, ValTreeKindExt, Value,
 };
 pub use self::context::{
     CtxtInterners, CurrentGcx, Feed, FreeRegionInfo, GlobalCtxt, Lift, TyCtxt, TyCtxtFeed, tls,

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/anon_const.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/anon_const.rs
@@ -1,4 +1,4 @@
-use rustc_type_ir::{self as ty, Interner};
+use rustc_type_ir::{self as ty, Interner, TypingMode};
 use tracing::instrument;
 
 use crate::delegate::SolverDelegate;
@@ -14,7 +14,18 @@ where
         &mut self,
         goal: Goal<I, ty::NormalizesTo<I>>,
     ) -> QueryResult<I> {
-        if let Some(normalized_const) = self.evaluate_const(
+        if self.typing_mode() == TypingMode::Coherence
+            && self.cx().anon_const_kind(goal.predicate.alias.def_id) == ty::AnonConstKind::OGCA
+        {
+            // During coherence, OGCA consts should be normalized ambiguously
+            // because they are opaque but eventually resolved to a real value.
+            // We don't want two OGCAs that have the same value to be treated
+            // as distinct for coherence purposes. (Just like opaque types.)
+            //
+            // We can't rely on evaluate_const below because that particular wrapper
+            // treats too-generic consts as a successful evaluation.
+            self.evaluate_added_goals_and_make_canonical_response(Certainty::AMBIGUOUS)
+        } else if let Some(normalized_const) = self.evaluate_const(
             goal.param_env,
             ty::UnevaluatedConst::new(
                 goal.predicate.alias.def_id.try_into().unwrap(),

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1551,7 +1551,9 @@ impl<'a> Parser<'a> {
 
         let rhs = if self.eat(exp!(Eq)) {
             if attr::contains_name(attrs, sym::type_const) {
-                Some(ConstItemRhs::TypeConst(self.parse_const_arg()?))
+                let ct =
+                    self.parse_expr_anon_const(|this, expr| this.mgca_direct_lit_hack(expr))?;
+                Some(ConstItemRhs::TypeConst(ct))
             } else {
                 Some(ConstItemRhs::Body(self.parse_expr()?))
             }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1628,6 +1628,7 @@ symbols! {
         on_const,
         on_unimplemented,
         opaque,
+        opaque_generic_const_args,
         opaque_module_name_placeholder: "<opaque>",
         open_options_new,
         ops,

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -681,6 +681,20 @@ pub fn try_evaluate_const<'tcx>(
 
                     (args, typing_env)
                 }
+                Some(ty::AnonConstKind::OGCA) => {
+                    if infcx.typing_mode() != TypingMode::PostAnalysis {
+                        // OGCA anon consts should be treated as always having generics
+                        // during anything before codegen (or maybe MIR opts too).
+                        return Err(EvaluateConstErr::HasGenericsOrInfers);
+                    }
+
+                    if uv.args.has_non_region_param() || uv.args.has_non_region_infer() {
+                        return Err(EvaluateConstErr::HasGenericsOrInfers);
+                    }
+
+                    let typing_env = ty::TypingEnv::fully_monomorphized();
+                    (uv.args, typing_env)
+                }
                 Some(ty::AnonConstKind::MCG) | Some(ty::AnonConstKind::NonTypeSystem) | None => {
                     // We are only dealing with "truly" generic/uninferred constants here:
                     // - GCEConsts have been handled separately

--- a/compiler/rustc_type_ir/src/const_kind.rs
+++ b/compiler/rustc_type_ir/src/const_kind.rs
@@ -200,3 +200,23 @@ impl<I: Interner> ValTreeKind<I> {
         }
     }
 }
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+#[cfg_attr(
+    feature = "nightly",
+    derive(Encodable_NoContext, Decodable_NoContext, HashStable_NoContext)
+)]
+pub enum AnonConstKind {
+    /// `feature(generic_const_exprs)` anon consts are allowed to use arbitrary generic parameters in scope
+    GCE,
+    /// stable `min_const_generics` anon consts are not allowed to use any generic parameters
+    MCG,
+    /// `feature(opaque_generic_const_args)` anon consts are allowed to use arbitrary
+    /// generic parameters in scope, but only if they syntactically reference them.
+    OGCA,
+    /// anon consts used as the length of a repeat expr are syntactically allowed to use generic parameters
+    /// but must not depend on the actual instantiation. See #76200 for more information
+    RepeatExprCount,
+    /// anon consts outside of the type system, e.g. enum discriminants
+    NonTypeSystem,
+}

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -205,6 +205,7 @@ pub trait Interner:
     fn type_of_opaque_hir_typeck(self, def_id: Self::LocalDefId)
     -> ty::EarlyBinder<Self, Self::Ty>;
     fn const_of_item(self, def_id: Self::DefId) -> ty::EarlyBinder<Self, Self::Const>;
+    fn anon_const_kind(self, def_id: Self::DefId) -> ty::AnonConstKind;
 
     type AdtDef: AdtDef<Self>;
     fn adt_def(self, adt_def_id: Self::AdtId) -> Self::AdtDef;

--- a/tests/ui/const-generics/adt_const_params/non_valtreeable_const_arg-2.rs
+++ b/tests/ui/const-generics/adt_const_params/non_valtreeable_const_arg-2.rs
@@ -1,4 +1,4 @@
-#![feature(generic_const_exprs, unsized_const_params)]
+#![feature(adt_const_params, generic_const_exprs, unsized_const_params)]
 #![allow(incomplete_features)]
 
 // Regression test for 128232

--- a/tests/ui/const-generics/adt_const_params/non_valtreeable_const_arg-2.stderr
+++ b/tests/ui/const-generics/adt_const_params/non_valtreeable_const_arg-2.stderr
@@ -9,13 +9,11 @@ help: you might be missing a const parameter
 LL | impl<const bar: /* Type */> Wrapper<{ bar() }> {
    |     +++++++++++++++++++++++
 
-error: using function pointers as const generic parameters is forbidden
+error[E0741]: using function pointers as const generic parameters is forbidden
   --> $DIR/non_valtreeable_const_arg-2.rs:8:25
    |
 LL | struct Wrapper<const F: fn()>;
    |                         ^^^^
-   |
-   = note: the only supported types are integers, `bool`, and `char`
 
 error[E0599]: the function or associated item `call` exists for struct `Wrapper<function>`, but its trait bounds were not satisfied
   --> $DIR/non_valtreeable_const_arg-2.rs:17:26
@@ -37,5 +35,5 @@ note: the trait `Fn` must be implemented
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0425, E0599.
+Some errors have detailed explanations: E0425, E0599, E0741.
 For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/const-generics/associated-const-bindings/ambiguity.rs
+++ b/tests/ui/const-generics/associated-const-bindings/ambiguity.rs
@@ -1,7 +1,7 @@
 // We used to say "ambiguous associated type" on ambiguous associated consts.
 // Ensure that we now use the correct label.
 
-#![feature(min_generic_const_args, unsized_const_params)]
+#![feature(adt_const_params, min_generic_const_args, unsized_const_params)]
 #![allow(incomplete_features)]
 
 trait Trait0: Parent0<i32> + Parent0<u32> {}

--- a/tests/ui/const-generics/associated-const-bindings/coexisting-with-type-binding.rs
+++ b/tests/ui/const-generics/associated-const-bindings/coexisting-with-type-binding.rs
@@ -5,7 +5,7 @@
 
 //@ check-pass
 
-#![feature(min_generic_const_args, unsized_const_params)]
+#![feature(adt_const_params, min_generic_const_args, unsized_const_params)]
 #![allow(incomplete_features)]
 
 trait Trait: SuperTrait {

--- a/tests/ui/const-generics/associated-const-bindings/dyn-compat-assoc-const-ty-mentions-self.rs
+++ b/tests/ui/const-generics/associated-const-bindings/dyn-compat-assoc-const-ty-mentions-self.rs
@@ -3,6 +3,7 @@
 
 //@ dont-require-annotations: NOTE
 
+#![feature(adt_const_params)]
 #![feature(generic_const_items)]
 #![feature(generic_const_parameter_types)]
 #![feature(min_generic_const_args)]

--- a/tests/ui/const-generics/associated-const-bindings/dyn-compat-assoc-const-ty-mentions-self.stderr
+++ b/tests/ui/const-generics/associated-const-bindings/dyn-compat-assoc-const-ty-mentions-self.stderr
@@ -1,12 +1,12 @@
 error[E0038]: the trait `Trait` is not dyn compatible
-  --> $DIR/dyn-compat-assoc-const-ty-mentions-self.rs:37:16
+  --> $DIR/dyn-compat-assoc-const-ty-mentions-self.rs:38:16
    |
 LL |     let _: dyn Trait;
    |                ^^^^^ `Trait` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/dyn-compat-assoc-const-ty-mentions-self.rs:17:11
+  --> $DIR/dyn-compat-assoc-const-ty-mentions-self.rs:18:11
    |
 LL | trait Trait {
    |       ----- this trait is not dyn compatible...

--- a/tests/ui/const-generics/associated-const-bindings/dyn-compat-self-const-projections-in-assoc-const-ty.rs
+++ b/tests/ui/const-generics/associated-const-bindings/dyn-compat-self-const-projections-in-assoc-const-ty.rs
@@ -4,17 +4,24 @@
 //              to the rest of the compiler and by extension the user via diagnostics.
 //@ known-bug: unknown
 
-#![feature(min_generic_const_args, unsized_const_params, generic_const_parameter_types)]
+#![feature(
+    adt_const_params,
+    min_generic_const_args,
+    unsized_const_params,
+    generic_const_parameter_types
+)]
 #![expect(incomplete_features)]
 
 trait A {
     type Ty: std::marker::ConstParamTy_;
-    #[type_const] const CT: Self::Ty;
+    #[type_const]
+    const CT: Self::Ty;
 }
 
 impl A for () {
     type Ty = i32;
-    #[type_const] const CT: i32 = 0;
+    #[type_const]
+    const CT: i32 = 0;
 }
 
 fn main() {

--- a/tests/ui/const-generics/associated-const-bindings/dyn-compat-self-const-projections-in-assoc-const-ty.stderr
+++ b/tests/ui/const-generics/associated-const-bindings/dyn-compat-self-const-projections-in-assoc-const-ty.stderr
@@ -1,23 +1,23 @@
 error[E0277]: the trait bound `FreshTy(0): A` is not satisfied
-  --> $DIR/dyn-compat-self-const-projections-in-assoc-const-ty.rs:27:33
+  --> $DIR/dyn-compat-self-const-projections-in-assoc-const-ty.rs:34:33
    |
 LL |     let _: dyn A<Ty = i32, CT = 0>;
    |                                 ^ the trait `A` is not implemented for `FreshTy(0)`
    |
 help: the trait `A` is implemented for `()`
-  --> $DIR/dyn-compat-self-const-projections-in-assoc-const-ty.rs:15:1
+  --> $DIR/dyn-compat-self-const-projections-in-assoc-const-ty.rs:21:1
    |
 LL | impl A for () {
    | ^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `FreshTy(0): A` is not satisfied
-  --> $DIR/dyn-compat-self-const-projections-in-assoc-const-ty.rs:29:34
+  --> $DIR/dyn-compat-self-const-projections-in-assoc-const-ty.rs:36:34
    |
 LL |     let _: &dyn A<Ty = i32, CT = 0> = &();
    |                                  ^ the trait `A` is not implemented for `FreshTy(0)`
    |
 help: the trait `A` is implemented for `()`
-  --> $DIR/dyn-compat-self-const-projections-in-assoc-const-ty.rs:15:1
+  --> $DIR/dyn-compat-self-const-projections-in-assoc-const-ty.rs:21:1
    |
 LL | impl A for () {
    | ^^^^^^^^^^^^^

--- a/tests/ui/const-generics/associated-const-bindings/esc-bound-var-in-ty.rs
+++ b/tests/ui/const-generics/associated-const-bindings/esc-bound-var-in-ty.rs
@@ -1,6 +1,7 @@
 // Detect and reject escaping late-bound generic params in
 // the type of assoc consts used in an equality bound.
 #![feature(
+    adt_const_params,
     min_generic_const_args,
     unsized_const_params,
     generic_const_parameter_types,

--- a/tests/ui/const-generics/associated-const-bindings/esc-bound-var-in-ty.stderr
+++ b/tests/ui/const-generics/associated-const-bindings/esc-bound-var-in-ty.stderr
@@ -1,5 +1,5 @@
 error: the type of the associated constant `K` cannot capture late-bound generic parameters
-  --> $DIR/esc-bound-var-in-ty.rs:15:35
+  --> $DIR/esc-bound-var-in-ty.rs:16:35
    |
 LL | fn take(_: impl for<'r> Trait<'r, K = const { &() }>) {}
    |                     --            ^ its type cannot capture the late-bound lifetime parameter `'r`

--- a/tests/ui/const-generics/mgca/adt_expr_arg_simple.stderr
+++ b/tests/ui/const-generics/mgca/adt_expr_arg_simple.stderr
@@ -9,6 +9,8 @@ error: generic parameters may not be used in const operations
    |
 LL |     foo::<{ Some::<u32> { 0: const { N + 1 } } }>();
    |                                      ^
+   |
+   = help: add `#![feature(opaque_generic_const_args)]` to allow generic expressions as the RHS of const items
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/mgca/early-bound-param-lt-bad.stderr
+++ b/tests/ui/const-generics/mgca/early-bound-param-lt-bad.stderr
@@ -3,6 +3,8 @@ error: generic parameters may not be used in const operations
    |
 LL |     T: Trait<const { let a: &'a (); 1 }>
    |                              ^^
+   |
+   = help: add `#![feature(opaque_generic_const_args)]` to allow generic expressions as the RHS of const items
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/mgca/explicit_anon_consts.stderr
+++ b/tests/ui/const-generics/mgca/explicit_anon_consts.stderr
@@ -39,42 +39,56 @@ error: generic parameters may not be used in const operations
    |
 LL | const ITEM3<const N: usize>: usize = const { N };
    |                                              ^
+   |
+   = help: add `#![feature(opaque_generic_const_args)]` to allow generic expressions as the RHS of const items
 
 error: generic parameters may not be used in const operations
   --> $DIR/explicit_anon_consts.rs:60:31
    |
 LL |     T3: Trait<ASSOC = const { N }>,
    |                               ^
+   |
+   = help: add `#![feature(opaque_generic_const_args)]` to allow generic expressions as the RHS of const items
 
 error: generic parameters may not be used in const operations
   --> $DIR/explicit_anon_consts.rs:69:58
    |
 LL | struct Default3<const N: usize, const M: usize = const { N }>;
    |                                                          ^
+   |
+   = help: add `#![feature(opaque_generic_const_args)]` to allow generic expressions as the RHS of const items
 
 error: generic parameters may not be used in const operations
   --> $DIR/explicit_anon_consts.rs:28:27
    |
 LL |     let _3 = [(); const { N }];
    |                           ^
+   |
+   = help: add `#![feature(opaque_generic_const_args)]` to allow generic expressions as the RHS of const items
 
 error: generic parameters may not be used in const operations
   --> $DIR/explicit_anon_consts.rs:33:26
    |
 LL |     let _6: [(); const { N }] = todo!();
    |                          ^
+   |
+   = help: add `#![feature(opaque_generic_const_args)]` to allow generic expressions as the RHS of const items
 
 error: generic parameters may not be used in const operations
   --> $DIR/explicit_anon_consts.rs:11:41
    |
 LL | type Adt3<const N: usize> = Foo<const { N }>;
    |                                         ^
+   |
+   = help: add `#![feature(opaque_generic_const_args)]` to allow generic expressions as the RHS of const items
 
 error: generic parameters may not be used in const operations
   --> $DIR/explicit_anon_consts.rs:19:42
    |
 LL | type Arr3<const N: usize> = [(); const { N }];
    |                                          ^
+   |
+   = help: add `#![feature(opaque_generic_const_args)]` to allow generic expressions as the RHS of const items
 
 error: aborting due to 13 previous errors
 

--- a/tests/ui/const-generics/mgca/selftyalias-containing-param.stderr
+++ b/tests/ui/const-generics/mgca/selftyalias-containing-param.stderr
@@ -9,6 +9,7 @@ note: not a concrete type
    |
 LL | impl<const N: usize> S<N> {
    |                      ^^^^
+   = help: add `#![feature(opaque_generic_const_args)]` to allow generic expressions as the RHS of const items
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/mgca/size-of-generic-ptr-in-array-len.stderr
+++ b/tests/ui/const-generics/mgca/size-of-generic-ptr-in-array-len.stderr
@@ -9,6 +9,8 @@ error: generic parameters may not be used in const operations
    |
 LL |     [0; const { size_of::<*mut T>() }];
    |                                ^
+   |
+   = help: add `#![feature(opaque_generic_const_args)]` to allow generic expressions as the RHS of const items
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/mgca/tuple_ctor_complex_args.stderr
+++ b/tests/ui/const-generics/mgca/tuple_ctor_complex_args.stderr
@@ -9,6 +9,8 @@ error: generic parameters may not be used in const operations
    |
 LL |     with_point::<{ Point(const { N + 1 }, N) }>();
    |                                  ^
+   |
+   = help: add `#![feature(opaque_generic_const_args)]` to allow generic expressions as the RHS of const items
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/mgca/tuple_expr_arg_complex.stderr
+++ b/tests/ui/const-generics/mgca/tuple_expr_arg_complex.stderr
@@ -21,6 +21,8 @@ error: generic parameters may not be used in const operations
    |
 LL |     takes_nested_tuple::<{ (N, (N, const { N + 1 })) }>();
    |                                            ^
+   |
+   = help: add `#![feature(opaque_generic_const_args)]` to allow generic expressions as the RHS of const items
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/const-generics/mgca/type_const-on-generic-expr.stderr
+++ b/tests/ui/const-generics/mgca/type_const-on-generic-expr.stderr
@@ -3,12 +3,16 @@ error: generic parameters may not be used in const operations
    |
 LL | const FREE1<T>: usize = const { std::mem::size_of::<T>() };
    |                                                     ^
+   |
+   = help: add `#![feature(opaque_generic_const_args)]` to allow generic expressions as the RHS of const items
 
 error: generic parameters may not be used in const operations
   --> $DIR/type_const-on-generic-expr.rs:8:46
    |
 LL | const FREE2<const I: usize>: usize = const { I + 1 };
    |                                              ^
+   |
+   = help: add `#![feature(opaque_generic_const_args)]` to allow generic expressions as the RHS of const items
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/mgca/type_const-on-generic_expr-2.stderr
+++ b/tests/ui/const-generics/mgca/type_const-on-generic_expr-2.stderr
@@ -3,18 +3,24 @@ error: generic parameters may not be used in const operations
    |
 LL |     const N1<T>: usize = const { std::mem::size_of::<T>() };
    |                                                      ^
+   |
+   = help: add `#![feature(opaque_generic_const_args)]` to allow generic expressions as the RHS of const items
 
 error: generic parameters may not be used in const operations
   --> $DIR/type_const-on-generic_expr-2.rs:20:47
    |
 LL |     const N2<const I: usize>: usize = const { I + 1 };
    |                                               ^
+   |
+   = help: add `#![feature(opaque_generic_const_args)]` to allow generic expressions as the RHS of const items
 
 error: generic parameters may not be used in const operations
   --> $DIR/type_const-on-generic_expr-2.rs:23:35
    |
 LL |     const N3: usize = const { 2 & X };
    |                                   ^
+   |
+   = help: add `#![feature(opaque_generic_const_args)]` to allow generic expressions as the RHS of const items
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/const-generics/mgca/unbraced_const_block_const_arg_gated.rs
+++ b/tests/ui/const-generics/mgca/unbraced_const_block_const_arg_gated.rs
@@ -35,7 +35,6 @@ const NON_TYPE_CONST: usize = const { 1 };
 #[type_const]
 //~^ ERROR: the `#[type_const]` attribute is an experimental feature
 const TYPE_CONST: usize = const { 1 };
-//~^ ERROR: unbraced const blocks as const args are experimental
 
 static STATIC: usize = const { 1 };
 

--- a/tests/ui/const-generics/mgca/unbraced_const_block_const_arg_gated.stderr
+++ b/tests/ui/const-generics/mgca/unbraced_const_block_const_arg_gated.stderr
@@ -48,16 +48,6 @@ LL |         generic::<const { 1 }>();
    = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: unbraced const blocks as const args are experimental
-  --> $DIR/unbraced_const_block_const_arg_gated.rs:37:27
-   |
-LL | const TYPE_CONST: usize = const { 1 };
-   |                           ^^^^^^^^^^^
-   |
-   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
-   = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error[E0658]: the `#[type_const]` attribute is an experimental feature
   --> $DIR/unbraced_const_block_const_arg_gated.rs:35:1
    |
@@ -68,6 +58,6 @@ LL | #[type_const]
    = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 7 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/const-generics/ogca/basic-fail.rs
+++ b/tests/ui/const-generics/ogca/basic-fail.rs
@@ -1,0 +1,22 @@
+#![feature(generic_const_items)]
+#![feature(min_generic_const_args)]
+#![feature(opaque_generic_const_args)]
+#![expect(incomplete_features)]
+
+#[type_const]
+const ADD1<const N: usize>: usize = const { N + 1 };
+
+#[type_const]
+const INC<const N: usize>: usize = const { N + 1 };
+
+#[type_const]
+const ONE: usize = ADD1::<0>;
+
+#[type_const]
+const OTHER_ONE: usize = INC::<0>;
+
+// Not definitionally equal.
+const ARR: [(); ADD1::<0>] = [(); INC::<0>];
+//~^ ERROR mismatched types
+
+fn main() {}

--- a/tests/ui/const-generics/ogca/basic-fail.stderr
+++ b/tests/ui/const-generics/ogca/basic-fail.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> $DIR/basic-fail.rs:19:30
+   |
+LL | const ARR: [(); ADD1::<0>] = [(); INC::<0>];
+   |                              ^^^^^^^^^^^^^^ expected an array with a size of const { N + 1 }, found one with a size of const { N + 1 }
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/ogca/basic.rs
+++ b/tests/ui/const-generics/ogca/basic.rs
@@ -1,0 +1,22 @@
+//@ check-pass
+
+#![feature(generic_const_items)]
+#![feature(min_generic_const_args)]
+#![feature(opaque_generic_const_args)]
+#![expect(incomplete_features)]
+
+#[type_const]
+const ADD1<const N: usize>: usize = const { N + 1 };
+
+#[type_const]
+const INC<const N: usize>: usize = ADD1::<N>;
+
+#[type_const]
+const ONE: usize = ADD1::<0>;
+
+#[type_const]
+const OTHER_ONE: usize = INC::<0>;
+
+const ARR: [(); ADD1::<0>] = [(); INC::<0>];
+
+fn main() {}

--- a/tests/ui/const-generics/ogca/coherence-ambiguous.rs
+++ b/tests/ui/const-generics/ogca/coherence-ambiguous.rs
@@ -1,0 +1,21 @@
+// FIXME(ogca): this should ERROR not pass!!
+//@ check-pass
+
+#![feature(generic_const_items, min_generic_const_args, opaque_generic_const_args)]
+#![expect(incomplete_features)]
+
+#[type_const]
+const FOO<const N: usize>: usize = const { N + 1 };
+
+#[type_const]
+const BAR<const N: usize>: usize = const { N + 1 };
+
+trait Trait {}
+
+impl Trait for [(); FOO::<1>] {}
+impl Trait for [(); BAR::<1>] {}
+// FIXME(ogca): this should ERROR!
+impl Trait for [(); BAR::<2>] {}
+// FIXME(ogca): this should ERROR!
+
+fn main() {}

--- a/tests/ui/const-generics/ogca/rhs-but-not-root.rs
+++ b/tests/ui/const-generics/ogca/rhs-but-not-root.rs
@@ -1,0 +1,14 @@
+#![feature(generic_const_items)]
+#![feature(min_generic_const_args)]
+#![feature(opaque_generic_const_args)]
+#![expect(incomplete_features)]
+
+// Anon consts must be the root of the RHS to be OGCA.
+#[type_const]
+const FOO<const N: usize>: usize = ID::<const { N + 1 }>;
+//~^ ERROR generic parameters may not be used in const operations
+
+#[type_const]
+const ID<const N: usize>: usize = N;
+
+fn main() {}

--- a/tests/ui/const-generics/ogca/rhs-but-not-root.stderr
+++ b/tests/ui/const-generics/ogca/rhs-but-not-root.stderr
@@ -1,0 +1,8 @@
+error: generic parameters may not be used in const operations
+  --> $DIR/rhs-but-not-root.rs:8:49
+   |
+LL | const FOO<const N: usize>: usize = ID::<const { N + 1 }>;
+   |                                                 ^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/feature-gates/feature-gate-opaque-generic-const-args.rs
+++ b/tests/ui/feature-gates/feature-gate-opaque-generic-const-args.rs
@@ -1,0 +1,9 @@
+#![feature(generic_const_items, min_generic_const_args)]
+#![expect(incomplete_features)]
+
+#[type_const]
+const INC<const N: usize>: usize = const { N + 1 };
+//~^ ERROR generic parameters may not be used in const operations
+//~| HELP add `#![feature(opaque_generic_const_args)]`
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-opaque-generic-const-args.stderr
+++ b/tests/ui/feature-gates/feature-gate-opaque-generic-const-args.stderr
@@ -1,8 +1,8 @@
 error: generic parameters may not be used in const operations
-  --> $DIR/selftyparam.rs:5:37
+  --> $DIR/feature-gate-opaque-generic-const-args.rs:5:44
    |
-LL |     fn foo() -> [(); const { let _: Self; 1 }];
-   |                                     ^^^^
+LL | const INC<const N: usize>: usize = const { N + 1 };
+   |                                            ^
    |
    = help: add `#![feature(opaque_generic_const_args)]` to allow generic expressions as the RHS of const items
 

--- a/tests/ui/generic-const-items/assoc-const-no-infer-ice-115806.rs
+++ b/tests/ui/generic-const-items/assoc-const-no-infer-ice-115806.rs
@@ -1,6 +1,6 @@
 // ICE: assertion failed: !value.has_infer()
 // issue: rust-lang/rust#115806
-#![feature(min_generic_const_args, unsized_const_params)]
+#![feature(adt_const_params, min_generic_const_args, unsized_const_params)]
 #![allow(incomplete_features)]
 
 pub struct NoPin;


### PR DESCRIPTION
This is meant to be the interim successor to generic const expressions.
Essentially, const item RHS's will be allowed to do arbitrary const
operations using generics. The limitation is that these const items will
be treated opaquely, like ADTs in nominal typing, such that uses of them
will only be equal if the same const item is referenced. In other words,
two const items with the exact same RHS will not be considered equal.

I also added some logic to check feature gates that depend on others
being enabled (like oGCA depending on mGCA).

### Coherence

During coherence, OGCA consts should be normalized ambiguously because
they are opaque but eventually resolved to a real value. We don't want
two OGCAs that have the same value to be treated as distinct for
coherence purposes. (Just like opaque types.)

This actually doesn't work yet because there are pre-existing
fundamental issues with equate relations involving consts that need to
be normalized. The problem is that we normalize only one layer of the
const item and don't actually process the resulting anon const. Normally
the created inference variable should be handled, which in this case
would cause us to hit the anon const, but that's not happening.
Specifically, `visit_const` on `Generalizer` should be updated to be
similar to `visit_ty`.

r? @BoxyUwU
