### PR TITLE
Document platform-specific behavior of `current_exe`, including that Linux can add `" (deleted)"`

### DIFF
--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -716,6 +716,11 @@ pub fn temp_dir() -> PathBuf {
 /// If the executable is renamed while it is running, platforms may return the
 /// path at the time it was loaded instead of the new path.
 ///
+/// On Linux, if the executable is deleted while it is running, this function
+/// may return the path with the string `" (deleted)"` appended.
+///
+/// Note that the platform-specific behavior [may change in the future][changes].
+///
 /// # Errors
 ///
 /// Acquiring the path of the current executable is a platform-specific operation
@@ -751,6 +756,8 @@ pub fn temp_dir() -> PathBuf {
 ///     Err(e) => println!("failed to get current exe path: {e}"),
 /// };
 /// ```
+///
+/// [changes]: crate::io#platform-specific-behavior
 #[stable(feature = "env", since = "1.0.0")]
 pub fn current_exe() -> io::Result<PathBuf> {
     paths_imp::current_exe()


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/150824)*
<!-- homu-ignore:end -->

This documents one other OS-specific behavior that might be surprising to some users. The underlying behavior is documented in for example <https://man7.org/linux/man-pages/man5/proc_pid_exe.5.html>.

Rust std docs can't and shouldn't try to cover every single OS quirk but this seems reasonably in line with telling people how to use this function, and with the text above about what happens when the exe has been renamed. 

This came up in the context of https://github.com/zed-industries/zed/pull/46367

Fixes rust-lang/rust#69343 (by documenting the behavior)