### PR TITLE
Query associated_item_def_ids when needed

### DIFF
--- a/compiler/rustc_hir_analysis/src/coherence/inherent_impls.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/inherent_impls.rs
@@ -79,13 +79,12 @@ impl<'tcx> InherentCollect<'tcx> {
         }
 
         if self.tcx.features().rustc_attrs() {
-            let items = self.tcx.associated_item_def_ids(impl_def_id);
-
             if !self.tcx.has_attr(ty_def_id, sym::rustc_has_incoherent_inherent_impls) {
                 let impl_span = self.tcx.def_span(impl_def_id);
                 return Err(self.tcx.dcx().emit_err(errors::InherentTyOutside { span: impl_span }));
             }
 
+            let items = self.tcx.associated_item_def_ids(impl_def_id);
             for &impl_item in items {
                 if !find_attr!(
                     self.tcx.get_all_attrs(impl_item),


### PR DESCRIPTION
This commit moves a query to `associated_item_defs` from above an error condition caused independently of it to below it.

It looks generally cleaner and might potentially save some runtime in case the error condition is met, rendering `items` to be left unused, yet still queried.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
