### PR TITLE
make attrs actually use `Target::GenericParam`

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1986,8 +1986,9 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         let (name, kind) = self.lower_generic_param_kind(param, source);
 
         let hir_id = self.lower_node_id(param.id);
-        self.lower_attrs(hir_id, &param.attrs, param.span(), Target::Param);
-        hir::GenericParam {
+        let param_attrs = &param.attrs;
+        let param_span = param.span();
+        let param = hir::GenericParam {
             hir_id,
             def_id: self.local_def_id(param.id),
             name,
@@ -1996,7 +1997,9 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             kind,
             colon_span: param.colon_span.map(|s| self.lower_span(s)),
             source,
-        }
+        };
+        self.lower_attrs(hir_id, param_attrs, param_span, Target::from_generic_param(&param));
+        param
     }
 
     fn lower_generic_param_kind(

--- a/compiler/rustc_attr_parsing/src/attributes/stability.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/stability.rs
@@ -1,6 +1,7 @@
 use std::num::NonZero;
 
 use rustc_errors::ErrorGuaranteed;
+use rustc_hir::target::GenericParamKind;
 use rustc_hir::{
     DefaultBodyStability, MethodKind, PartialConstStability, Stability, StabilityLevel,
     StableSince, Target, UnstableReason, VERSION_PLACEHOLDER,
@@ -43,7 +44,7 @@ const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
     Allow(Target::TyAlias),
     Allow(Target::Variant),
     Allow(Target::Field),
-    Allow(Target::Param),
+    Allow(Target::GenericParam { kind: GenericParamKind::Type, has_default: true }),
     Allow(Target::Static),
     Allow(Target::ForeignFn),
     Allow(Target::ForeignStatic),

--- a/compiler/rustc_attr_parsing/src/target_checking.rs
+++ b/compiler/rustc_attr_parsing/src/target_checking.rs
@@ -310,5 +310,29 @@ pub(crate) const ALL_TARGETS: &'static [Policy] = {
         Allow(Target::Crate),
         Allow(Target::Delegation { mac: false }),
         Allow(Target::Delegation { mac: true }),
+        Allow(Target::GenericParam {
+            kind: rustc_hir::target::GenericParamKind::Const,
+            has_default: false,
+        }),
+        Allow(Target::GenericParam {
+            kind: rustc_hir::target::GenericParamKind::Const,
+            has_default: true,
+        }),
+        Allow(Target::GenericParam {
+            kind: rustc_hir::target::GenericParamKind::Lifetime,
+            has_default: false,
+        }),
+        Allow(Target::GenericParam {
+            kind: rustc_hir::target::GenericParamKind::Lifetime,
+            has_default: true,
+        }),
+        Allow(Target::GenericParam {
+            kind: rustc_hir::target::GenericParamKind::Type,
+            has_default: false,
+        }),
+        Allow(Target::GenericParam {
+            kind: rustc_hir::target::GenericParamKind::Type,
+            has_default: true,
+        }),
     ]
 };

--- a/compiler/rustc_hir/src/lib.rs
+++ b/compiler/rustc_hir/src/lib.rs
@@ -32,7 +32,7 @@ pub mod lints;
 pub mod pat_util;
 mod stability;
 mod stable_hash_impls;
-mod target;
+pub mod target;
 pub mod weak_lang_items;
 
 #[cfg(test)]

--- a/tests/ui/const-generics/invalid-attributes-on-const-params-78957.stderr
+++ b/tests/ui/const-generics/invalid-attributes-on-const-params-78957.stderr
@@ -1,4 +1,4 @@
-error: `#[inline]` attribute cannot be used on function params
+error: `#[inline]` attribute cannot be used on const parameters
   --> $DIR/invalid-attributes-on-const-params-78957.rs:6:16
    |
 LL | pub struct Foo<#[inline] const N: usize>;
@@ -6,7 +6,7 @@ LL | pub struct Foo<#[inline] const N: usize>;
    |
    = help: `#[inline]` can only be applied to functions
 
-error: `#[inline]` attribute cannot be used on function params
+error: `#[inline]` attribute cannot be used on lifetime parameters
   --> $DIR/invalid-attributes-on-const-params-78957.rs:14:17
    |
 LL | pub struct Foo2<#[inline] 'a>(PhantomData<&'a ()>);
@@ -14,7 +14,7 @@ LL | pub struct Foo2<#[inline] 'a>(PhantomData<&'a ()>);
    |
    = help: `#[inline]` can only be applied to functions
 
-error: `#[inline]` attribute cannot be used on function params
+error: `#[inline]` attribute cannot be used on type parameters
   --> $DIR/invalid-attributes-on-const-params-78957.rs:22:17
    |
 LL | pub struct Foo3<#[inline] T>(PhantomData<T>);
@@ -40,7 +40,7 @@ error[E0517]: attribute should be applied to a struct, enum, or union
 LL | pub struct Baz3<#[repr(C)] T>(PhantomData<T>);
    |                        ^   - not a struct, enum, or union
 
-error: `#[cold]` attribute cannot be used on function params
+error: `#[cold]` attribute cannot be used on const parameters
   --> $DIR/invalid-attributes-on-const-params-78957.rs:8:16
    |
 LL | pub struct Bar<#[cold] const N: usize>;
@@ -54,7 +54,7 @@ note: the lint level is defined here
 LL | #![deny(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
-error: `#[cold]` attribute cannot be used on function params
+error: `#[cold]` attribute cannot be used on lifetime parameters
   --> $DIR/invalid-attributes-on-const-params-78957.rs:16:17
    |
 LL | pub struct Bar2<#[cold] 'a>(PhantomData<&'a ()>);
@@ -63,7 +63,7 @@ LL | pub struct Bar2<#[cold] 'a>(PhantomData<&'a ()>);
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = help: `#[cold]` can only be applied to functions
 
-error: `#[cold]` attribute cannot be used on function params
+error: `#[cold]` attribute cannot be used on type parameters
   --> $DIR/invalid-attributes-on-const-params-78957.rs:24:17
    |
 LL | pub struct Bar3<#[cold] T>(PhantomData<T>);

--- a/tests/ui/force-inlining/invalid.stderr
+++ b/tests/ui/force-inlining/invalid.stderr
@@ -152,7 +152,7 @@ LL | #[rustc_force_inline]
    |
    = help: `#[rustc_force_inline]` can only be applied to functions
 
-error: `#[rustc_force_inline]` attribute cannot be used on function params
+error: `#[rustc_force_inline]` attribute cannot be used on type parameters
   --> $DIR/invalid.rs:72:10
    |
 LL | enum Bar<#[rustc_force_inline] T> {

--- a/tests/ui/lint/unused/unused_attributes-must_use.stderr
+++ b/tests/ui/lint/unused/unused_attributes-must_use.stderr
@@ -93,7 +93,7 @@ LL | #[must_use]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = help: `#[must_use]` can be applied to data types, functions, traits, and unions
 
-error: `#[must_use]` attribute cannot be used on function params
+error: `#[must_use]` attribute cannot be used on type parameters
   --> $DIR/unused_attributes-must_use.rs:77:8
    |
 LL | fn qux<#[must_use] T>(_: T) {}

--- a/tests/ui/pin-ergonomics/pin_v2-attr.rs
+++ b/tests/ui/pin-ergonomics/pin_v2-attr.rs
@@ -25,8 +25,8 @@ union Union {
 // disallowed
 
 enum Foo<#[pin_v2] T, #[pin_v2] U = ()> {
-    //~^ ERROR `#[pin_v2]` attribute cannot be used on function params
-    //~| ERROR `#[pin_v2]` attribute cannot be used on function params
+    //~^ ERROR `#[pin_v2]` attribute cannot be used on type parameters
+    //~| ERROR `#[pin_v2]` attribute cannot be used on type parameters
     #[pin_v2] //~ ERROR `#[pin_v2]` attribute cannot be used on enum variants
     UnitVariant,
     TupleVariant(#[pin_v2] T), //~ ERROR `#[pin_v2]` attribute cannot be used on struct fields

--- a/tests/ui/pin-ergonomics/pin_v2-attr.stderr
+++ b/tests/ui/pin-ergonomics/pin_v2-attr.stderr
@@ -20,7 +20,7 @@ LL | #![pin_v2]
    |
    = help: `#[pin_v2]` can be applied to data types and unions
 
-error: `#[pin_v2]` attribute cannot be used on function params
+error: `#[pin_v2]` attribute cannot be used on type parameters
   --> $DIR/pin_v2-attr.rs:27:10
    |
 LL | enum Foo<#[pin_v2] T, #[pin_v2] U = ()> {
@@ -28,7 +28,7 @@ LL | enum Foo<#[pin_v2] T, #[pin_v2] U = ()> {
    |
    = help: `#[pin_v2]` can be applied to data types and unions
 
-error: `#[pin_v2]` attribute cannot be used on function params
+error: `#[pin_v2]` attribute cannot be used on type parameters
   --> $DIR/pin_v2-attr.rs:27:23
    |
 LL | enum Foo<#[pin_v2] T, #[pin_v2] U = ()> {

--- a/tests/ui/scalable-vectors/invalid.rs
+++ b/tests/ui/scalable-vectors/invalid.rs
@@ -48,7 +48,7 @@ type Foo = u32;
 #[rustc_scalable_vector(4)]
 //~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on enums
 enum Bar<#[rustc_scalable_vector(4)] T> {
-//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on function params
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on type parameters
     #[rustc_scalable_vector(4)]
 //~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on enum variants
     Baz(std::marker::PhantomData<T>),

--- a/tests/ui/scalable-vectors/invalid.stderr
+++ b/tests/ui/scalable-vectors/invalid.stderr
@@ -92,7 +92,7 @@ LL | #[rustc_scalable_vector(4)]
    |
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
-error: `#[rustc_scalable_vector]` attribute cannot be used on function params
+error: `#[rustc_scalable_vector]` attribute cannot be used on type parameters
   --> $DIR/invalid.rs:50:10
    |
 LL | enum Bar<#[rustc_scalable_vector(4)] T> {


### PR DESCRIPTION
currently attributes lower `GenericParam` -> `Target::Param` this PR fixes this, so that `GenericParam` is lowered to `Target::GenericParam`

r? @JonathanBrouwer 