### PR TITLE
Add tracking issue for `feature(multiple_supertrait_upcastable)`

### DIFF
--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -233,8 +233,6 @@ declare_features! (
     (internal, link_cfg, "1.14.0", None),
     /// Allows using `?Trait` trait bounds in more contexts.
     (internal, more_maybe_bounds, "1.82.0", None),
-    /// Allows the `multiple_supertrait_upcastable` lint.
-    (unstable, multiple_supertrait_upcastable, "1.69.0", None),
     /// Allow negative trait bounds. This is an internal-only feature for testing the trait solver!
     (internal, negative_bounds, "1.71.0", None),
     /// Set the maximum pattern complexity allowed (not limited by default).
@@ -569,6 +567,8 @@ declare_features! (
     (unstable, more_qualified_paths, "1.54.0", Some(86935)),
     /// The `movrs` target feature on x86.
     (unstable, movrs_target_feature, "1.88.0", Some(137976)),
+    /// Allows the `multiple_supertrait_upcastable` lint.
+    (unstable, multiple_supertrait_upcastable, "1.69.0", Some(150833)),
     /// Allows the `#[must_not_suspend]` attribute.
     (unstable, must_not_suspend, "1.57.0", Some(83310)),
     /// Allows `mut ref` and `mut ref mut` identifier patterns.

--- a/tests/ui/feature-gates/feature-gate-multiple_supertrait_upcastable.stderr
+++ b/tests/ui/feature-gates/feature-gate-multiple_supertrait_upcastable.stderr
@@ -5,6 +5,7 @@ LL | #![deny(multiple_supertrait_upcastable)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the `multiple_supertrait_upcastable` lint is unstable
+   = note: see issue #150833 <https://github.com/rust-lang/rust/issues/150833> for more information
    = help: add `#![feature(multiple_supertrait_upcastable)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: `#[warn(unknown_lints)]` on by default
@@ -16,6 +17,7 @@ LL | #![warn(multiple_supertrait_upcastable)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the `multiple_supertrait_upcastable` lint is unstable
+   = note: see issue #150833 <https://github.com/rust-lang/rust/issues/150833> for more information
    = help: add `#![feature(multiple_supertrait_upcastable)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 


### PR DESCRIPTION
Move feature(multiple_supertrait_upcastable) to the actual feature gates section (from the internal feature gates section) and give it a tracking issue.

Tracking issue: rust-lang/rust#150833 

Fixes https://github.com/rust-lang/rust/issues/150773

This feature is for the `multiple_supertrait_upcastable` lint, which was added as `unstable` without a tracking issue, but was placed in the internal feature gates section. This PR moves its listing to the actual feature gates section and gives it a tracking issue.

If the lint is intended to stay internal-only, then this can be changed to instead mark it as `internal` (and maybe close the tracking issue).

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
