### PR TITLE
Make `--print=check-cfg` output compatible `--check-cfg` arguments

### DIFF
--- a/src/doc/unstable-book/src/compiler-flags/print-check-cfg.md
+++ b/src/doc/unstable-book/src/compiler-flags/print-check-cfg.md
@@ -9,23 +9,28 @@ This option of the `--print` flag print the list of all the expected cfgs.
 This is related to the [`--check-cfg` flag][check-cfg] which allows specifying arbitrary expected
 names and values.
 
-This print option works similarly to `--print=cfg` (modulo check-cfg specifics).
+This print option outputs compatible `--check-cfg` arguments with a reduced syntax where all the
+expected values are on the same line and `values(...)` is always explicit.
 
-| `--check-cfg`                     | `--print=check-cfg`         |
-|-----------------------------------|-----------------------------|
-| `cfg(foo)`                        | `foo`                       |
-| `cfg(foo, values("bar"))`         | `foo="bar"`                 |
-| `cfg(foo, values(none(), "bar"))` | `foo` & `foo="bar"`         |
-|                                   | *check-cfg specific syntax* |
-| `cfg(foo, values(any())`          | `foo=any()`                 |
-| `cfg(foo, values())`              | `foo=`                      |
-| `cfg(any())`                      | `any()`                     |
-| *none*                            | `any()=any()`               |
+| `--check-cfg`                     | `--print=check-cfg`               |
+|-----------------------------------|-----------------------------------|
+| `cfg(foo)`                        | `cfg(foo, values(none()))         |
+| `cfg(foo, values("bar"))`         | `cfg(foo, values("bar"))`         |
+| `cfg(foo, values(none(), "bar"))` | `cfg(foo, values(none(), "bar"))` |
+| `cfg(foo, values(any())`          | `cfg(foo, values(any())`          |
+| `cfg(foo, values())`              | `cfg(foo, values())`              |
+| `cfg(any())`                      | `cfg(any())`                      |
+| *nothing*                         | *nothing*                         |
+
+The print option includes well known cfgs.
 
 To be used like this:
 
 ```bash
 rustc --print=check-cfg -Zunstable-options lib.rs
 ```
+
+> **Note:** Users should be resilient when parsing, in particular against new predicates that
+may be added in the future.
 
 [check-cfg]: https://doc.rust-lang.org/nightly/rustc/check-cfg.html

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -1065,9 +1065,25 @@ fn builtin_cfg_names(config: &Config) -> HashSet<String> {
         Default::default(),
     )
     .lines()
-    .map(|l| if let Some((name, _)) = l.split_once('=') { name.to_string() } else { l.to_string() })
+    .map(|l| extract_cfg_name(&l).unwrap().to_string())
     .chain(std::iter::once(String::from("test")))
     .collect()
+}
+
+/// Extract the cfg name from `cfg(name, values(...))` lines
+fn extract_cfg_name(check_cfg_line: &str) -> Result<&str, &'static str> {
+    let trimmed = check_cfg_line.trim();
+
+    #[rustfmt::skip]
+    let inner = trimmed
+        .strip_prefix("cfg(")
+        .ok_or("missing cfg(")?
+        .strip_suffix(")")
+        .ok_or("missing )")?;
+
+    let first_comma = inner.find(',').ok_or("no comma found")?;
+
+    Ok(inner[..first_comma].trim())
 }
 
 pub const KNOWN_CRATE_TYPES: &[&str] =


### PR DESCRIPTION
This PR changes significantly the output of the unstable `--print=check-cfg` option.

Specifically it removes the ad-hoc resemblance with `--print=cfg` in order to output a simplified but still compatible `--check-cfg` arguments.

The goal is to future proof the output of `--print=check-cfg` like `--check-cfg` is, and the best way to do that is to use it's syntax.

This is particularly relevant for [RFC3905](https://github.com/rust-lang/rfcs/pull/3905) which wants to introduce a new predicate: `version(...)`.