### PR TITLE
bootstrap: minimal fix for ./x install src with build.docs = false

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -87,6 +87,12 @@ impl Step for Docs {
         // from a shared directory.
         builder.run_default_doc_steps();
 
+        // In case no default doc steps are run for host, it is possible that `<host>/doc` directory
+        // is never created.
+        if !builder.config.dry_run() {
+            t!(fs::create_dir_all(builder.doc_out(host)));
+        }
+
         let dest = "share/doc/rust/html";
 
         let mut tarball = Tarball::new(builder, "rust-docs", &host.triple);


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/150845)*
<!-- homu-ignore:end -->

`run_default_doc_steps()` is called to ensure the documentation is built by `Docs::run()` and it should build the documentation if it isn't already built.

When running the `install src` command I'm seeing failures as the `builder.doc_out(host)` directory does not exist. This is because `match_paths_to_steps_and_run()` doesn't actually build any documentation as the `paths.is_empty()` causes an early return. This results in install failures as the `*/doc` src directory doesn't exist.

This patch passes the paths to `run_step_descriptions()` when building documentation to ensure it is correctly built.

This fixes installing the Rust source code in OpenEmbedded.