### PR TITLE
include `HirId`s directly in the THIR, not wrapped in `LintLevel`s

### DIFF
--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -236,8 +236,8 @@ pub enum StmtKind<'tcx> {
         /// `let pat: ty = <INIT> else { <ELSE> }`
         else_block: Option<BlockId>,
 
-        /// The lint level for this `let` statement.
-        lint_level: LintLevel,
+        /// The [`HirId`] for this `let` statement.
+        hir_id: HirId,
 
         /// Span of the `let <PAT> = <INIT>` part.
         span: Span,
@@ -271,7 +271,7 @@ pub enum ExprKind<'tcx> {
     /// and to track the `HirId` of the expressions within the scope.
     Scope {
         region_scope: region::Scope,
-        lint_level: LintLevel,
+        hir_id: HirId,
         value: ExprId,
     },
     /// A `box <value>` expression.
@@ -579,7 +579,7 @@ pub struct Arm<'tcx> {
     pub pattern: Box<Pat<'tcx>>,
     pub guard: Option<ExprId>,
     pub body: ExprId,
-    pub lint_level: LintLevel,
+    pub hir_id: HirId,
     pub scope: region::Scope,
     pub span: Span,
 }

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -116,12 +116,6 @@ pub struct Param<'tcx> {
     pub hir_id: Option<HirId>,
 }
 
-#[derive(Copy, Clone, Debug, HashStable)]
-pub enum LintLevel {
-    Inherited,
-    Explicit(HirId),
-}
-
 #[derive(Clone, Debug, HashStable)]
 pub struct Block {
     /// Whether the block itself has a label. Used by `label: {}`

--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -47,9 +47,7 @@ pub fn walk_expr<'thir, 'tcx: 'thir, V: Visitor<'thir, 'tcx>>(
     use ExprKind::*;
     let Expr { kind, ty: _, temp_scope_id: _, span: _ } = expr;
     match *kind {
-        Scope { value, region_scope: _, lint_level: _ } => {
-            visitor.visit_expr(&visitor.thir()[value])
-        }
+        Scope { value, region_scope: _, hir_id: _ } => visitor.visit_expr(&visitor.thir()[value]),
         Box { value } => visitor.visit_expr(&visitor.thir()[value]),
         If { cond, then, else_opt, if_then_scope: _ } => {
             visitor.visit_expr(&visitor.thir()[cond]);
@@ -205,7 +203,7 @@ pub fn walk_stmt<'thir, 'tcx: 'thir, V: Visitor<'thir, 'tcx>>(
             remainder_scope: _,
             init_scope: _,
             pattern,
-            lint_level: _,
+            hir_id: _,
             else_block,
             span: _,
         } => {
@@ -238,7 +236,7 @@ pub fn walk_arm<'thir, 'tcx: 'thir, V: Visitor<'thir, 'tcx>>(
     visitor: &mut V,
     arm: &'thir Arm<'tcx>,
 ) {
-    let Arm { guard, pattern, body, lint_level: _, span: _, scope: _ } = arm;
+    let Arm { guard, pattern, body, hir_id: _, span: _, scope: _ } = arm;
     if let Some(expr) = guard {
         visitor.visit_expr(&visitor.thir()[*expr])
     }

--- a/compiler/rustc_mir_build/src/builder/block.rs
+++ b/compiler/rustc_mir_build/src/builder/block.rs
@@ -7,6 +7,7 @@ use tracing::debug;
 
 use crate::builder::ForGuard::OutsideGuard;
 use crate::builder::matches::{DeclareLetBindings, ScheduleDrops};
+use crate::builder::scope::LintLevel;
 use crate::builder::{BlockAnd, BlockAndExtension, BlockFrame, Builder};
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {

--- a/compiler/rustc_mir_build/src/builder/block.rs
+++ b/compiler/rustc_mir_build/src/builder/block.rs
@@ -83,7 +83,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     init_scope,
                     pattern,
                     initializer: Some(initializer),
-                    lint_level,
+                    hir_id,
                     else_block: Some(else_block),
                     span: _,
                 } => {
@@ -191,7 +191,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
                     let initializer_span = this.thir[*initializer].span;
                     let scope = (*init_scope, source_info);
-                    let failure_and_block = this.in_scope(scope, *lint_level, |this| {
+                    let lint_level = LintLevel::Explicit(*hir_id);
+                    let failure_and_block = this.in_scope(scope, lint_level, |this| {
                         this.declare_bindings(
                             visibility_scope,
                             remainder_span,
@@ -232,7 +233,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     init_scope,
                     pattern,
                     initializer,
-                    lint_level,
+                    hir_id,
                     else_block: None,
                     span: _,
                 } => {
@@ -250,12 +251,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         Some(this.new_source_scope(remainder_span, LintLevel::Inherited));
 
                     // Evaluate the initializer, if present.
+                    let lint_level = LintLevel::Explicit(*hir_id);
                     if let Some(init) = *initializer {
                         let initializer_span = this.thir[init].span;
                         let scope = (*init_scope, source_info);
 
                         block = this
-                            .in_scope(scope, *lint_level, |this| {
+                            .in_scope(scope, lint_level, |this| {
                                 this.declare_bindings(
                                     visibility_scope,
                                     remainder_span,
@@ -269,7 +271,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             .into_block();
                     } else {
                         let scope = (*init_scope, source_info);
-                        let _: BlockAnd<()> = this.in_scope(scope, *lint_level, |this| {
+                        let _: BlockAnd<()> = this.in_scope(scope, lint_level, |this| {
                             this.declare_bindings(
                                 visibility_scope,
                                 remainder_span,

--- a/compiler/rustc_mir_build/src/builder/expr/as_constant.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_constant.rs
@@ -23,7 +23,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let tcx = this.tcx;
         let Expr { ty, temp_scope_id: _, span, ref kind } = *expr;
         match kind {
-            ExprKind::Scope { region_scope: _, lint_level: _, value } => {
+            ExprKind::Scope { region_scope: _, hir_id: _, value } => {
                 this.as_constant(&this.thir[*value])
             }
             _ => as_constant_inner(

--- a/compiler/rustc_mir_build/src/builder/expr/as_operand.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_operand.rs
@@ -122,10 +122,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let this = self; // See "LET_THIS_SELF".
 
         let expr = &this.thir[expr_id];
-        if let ExprKind::Scope { region_scope, lint_level, value } = expr.kind {
+        if let ExprKind::Scope { region_scope, hir_id, value } = expr.kind {
             let source_info = this.source_info(expr.span);
             let region_scope = (region_scope, source_info);
-            return this.in_scope(region_scope, lint_level, |this| {
+            return this.in_scope(region_scope, LintLevel::Explicit(hir_id), |this| {
                 this.as_operand(block, scope, value, local_info, needs_temporary)
             });
         }
@@ -165,10 +165,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let expr = &this.thir[expr_id];
         debug!("as_call_operand(block={:?}, expr={:?})", block, expr);
 
-        if let ExprKind::Scope { region_scope, lint_level, value } = expr.kind {
+        if let ExprKind::Scope { region_scope, hir_id, value } = expr.kind {
             let source_info = this.source_info(expr.span);
             let region_scope = (region_scope, source_info);
-            return this.in_scope(region_scope, lint_level, |this| {
+            return this.in_scope(region_scope, LintLevel::Explicit(hir_id), |this| {
                 this.as_call_operand(block, scope, value)
             });
         }

--- a/compiler/rustc_mir_build/src/builder/expr/as_operand.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_operand.rs
@@ -6,6 +6,7 @@ use rustc_middle::thir::*;
 use tracing::{debug, instrument};
 
 use crate::builder::expr::category::Category;
+use crate::builder::scope::LintLevel;
 use crate::builder::{BlockAnd, BlockAndExtension, Builder, NeedsTemporary};
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {

--- a/compiler/rustc_mir_build/src/builder/expr/as_place.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_place.rs
@@ -427,8 +427,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let expr_span = expr.span;
         let source_info = this.source_info(expr_span);
         match expr.kind {
-            ExprKind::Scope { region_scope, lint_level, value } => {
-                this.in_scope((region_scope, source_info), lint_level, |this| {
+            ExprKind::Scope { region_scope, hir_id, value } => {
+                this.in_scope((region_scope, source_info), LintLevel::Explicit(hir_id), |this| {
                     this.expr_as_place(block, value, mutability, fake_borrow_temps)
                 })
             }

--- a/compiler/rustc_mir_build/src/builder/expr/as_place.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_place.rs
@@ -16,6 +16,7 @@ use tracing::{debug, instrument, trace};
 
 use crate::builder::ForGuard::{OutsideGuard, RefWithinGuard};
 use crate::builder::expr::category::Category;
+use crate::builder::scope::LintLevel;
 use crate::builder::{BlockAnd, BlockAndExtension, Builder, Capture, CaptureMap};
 
 /// The "outermost" place that holds this value.

--- a/compiler/rustc_mir_build/src/builder/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_rvalue.rs
@@ -56,9 +56,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
         match expr.kind {
             ExprKind::ThreadLocalRef(did) => block.and(Rvalue::ThreadLocalRef(did)),
-            ExprKind::Scope { region_scope, lint_level, value } => {
+            ExprKind::Scope { region_scope, hir_id, value } => {
                 let region_scope = (region_scope, source_info);
-                this.in_scope(region_scope, lint_level, |this| this.as_rvalue(block, scope, value))
+                this.in_scope(region_scope, LintLevel::Explicit(hir_id), |this| {
+                    this.as_rvalue(block, scope, value)
+                })
             }
             ExprKind::Repeat { value, count } => {
                 if Some(0) == count.try_to_target_usize(this.tcx) {
@@ -657,7 +659,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     source: eid,
                     is_from_as_cast: _,
                 }
-                | &ExprKind::Scope { region_scope: _, lint_level: _, value: eid } => {
+                | &ExprKind::Scope { region_scope: _, hir_id: _, value: eid } => {
                     kind = &self.thir[eid].kind
                 }
                 _ => return matches!(Category::of(&kind), Some(Category::Constant)),

--- a/compiler/rustc_mir_build/src/builder/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_rvalue.rs
@@ -18,6 +18,7 @@ use tracing::debug;
 
 use crate::builder::expr::as_place::PlaceBase;
 use crate::builder::expr::category::{Category, RvalueFunc};
+use crate::builder::scope::LintLevel;
 use crate::builder::{BlockAnd, BlockAndExtension, Builder, NeedsTemporary};
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {

--- a/compiler/rustc_mir_build/src/builder/expr/as_temp.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_temp.rs
@@ -7,7 +7,7 @@ use rustc_middle::mir::*;
 use rustc_middle::thir::*;
 use tracing::{debug, instrument};
 
-use crate::builder::scope::DropKind;
+use crate::builder::scope::{DropKind, LintLevel};
 use crate::builder::{BlockAnd, BlockAndExtension, Builder};
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {

--- a/compiler/rustc_mir_build/src/builder/expr/as_temp.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_temp.rs
@@ -39,10 +39,12 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let expr = &this.thir[expr_id];
         let expr_span = expr.span;
         let source_info = this.source_info(expr_span);
-        if let ExprKind::Scope { region_scope, lint_level, value } = expr.kind {
-            return this.in_scope((region_scope, source_info), lint_level, |this| {
-                this.as_temp(block, temp_lifetime, value, mutability)
-            });
+        if let ExprKind::Scope { region_scope, hir_id, value } = expr.kind {
+            return this.in_scope(
+                (region_scope, source_info),
+                LintLevel::Explicit(hir_id),
+                |this| this.as_temp(block, temp_lifetime, value, mutability),
+            );
         }
 
         let expr_ty = expr.ty;

--- a/compiler/rustc_mir_build/src/builder/expr/into.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/into.rs
@@ -16,6 +16,7 @@ use tracing::{debug, instrument};
 
 use crate::builder::expr::category::{Category, RvalueFunc};
 use crate::builder::matches::{DeclareLetBindings, HasMatchGuard};
+use crate::builder::scope::LintLevel;
 use crate::builder::{BlockAnd, BlockAndExtension, BlockFrame, Builder, NeedsTemporary};
 use crate::errors::{LoopMatchArmWithGuard, LoopMatchUnsupportedType};
 

--- a/compiler/rustc_mir_build/src/builder/expr/into.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/into.rs
@@ -45,10 +45,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         }
 
         let block_and = match expr.kind {
-            ExprKind::Scope { region_scope, lint_level, value } => {
+            ExprKind::Scope { region_scope, hir_id, value } => {
                 let region_scope = (region_scope, source_info);
                 ensure_sufficient_stack(|| {
-                    this.in_scope(region_scope, lint_level, |this| {
+                    this.in_scope(region_scope, LintLevel::Explicit(hir_id), |this| {
                         this.expr_into_dest(destination, block, value)
                     })
                 })

--- a/compiler/rustc_mir_build/src/builder/expr/stmt.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/stmt.rs
@@ -5,7 +5,7 @@ use rustc_middle::thir::*;
 use rustc_span::source_map::Spanned;
 use tracing::debug;
 
-use crate::builder::scope::BreakableTarget;
+use crate::builder::scope::{BreakableTarget, LintLevel};
 use crate::builder::{BlockAnd, BlockAndExtension, BlockFrame, Builder};
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {

--- a/compiler/rustc_mir_build/src/builder/expr/stmt.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/stmt.rs
@@ -25,8 +25,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         // Handle a number of expressions that don't need a destination at all. This
         // avoids needing a mountain of temporary `()` variables.
         match expr.kind {
-            ExprKind::Scope { region_scope, lint_level, value } => {
-                this.in_scope((region_scope, source_info), lint_level, |this| {
+            ExprKind::Scope { region_scope, hir_id, value } => {
+                this.in_scope((region_scope, source_info), LintLevel::Explicit(hir_id), |this| {
                     this.stmt_expr(block, value, statement_scope)
                 })
             }
@@ -106,7 +106,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
             ExprKind::Become { value } => {
                 let v = &this.thir[value];
-                let ExprKind::Scope { value, lint_level, region_scope } = v.kind else {
+                let ExprKind::Scope { value, hir_id, region_scope } = v.kind else {
                     span_bug!(v.span, "`thir_check_tail_calls` should have disallowed this {v:?}")
                 };
 
@@ -115,7 +115,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     span_bug!(v.span, "`thir_check_tail_calls` should have disallowed this {v:?}")
                 };
 
-                this.in_scope((region_scope, source_info), lint_level, |this| {
+                this.in_scope((region_scope, source_info), LintLevel::Explicit(hir_id), |this| {
                     let fun = unpack!(block = this.as_local_operand(block, fun));
                     let args: Box<[_]> = args
                         .into_iter()

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -182,9 +182,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 this.break_for_else(success_block, args.variable_source_info);
                 failure_block.unit()
             }
-            ExprKind::Scope { region_scope, lint_level, value } => {
+            ExprKind::Scope { region_scope, hir_id, value } => {
                 let region_scope = (region_scope, this.source_info(expr_span));
-                this.in_scope(region_scope, lint_level, |this| {
+                this.in_scope(region_scope, LintLevel::Explicit(hir_id), |this| {
                     this.then_else_break_inner(block, value, args)
                 })
             }
@@ -434,7 +434,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let guard_scope = arm
                     .guard
                     .map(|_| region::Scope { data: region::ScopeData::MatchGuard, ..arm.scope });
-                self.in_scope(arm_scope, arm.lint_level, |this| {
+                self.in_scope(arm_scope, LintLevel::Explicit(arm.hir_id), |this| {
                     this.opt_in_scope(guard_scope.map(|scope| (scope, arm_source_info)), |this| {
                         // `if let` guard temps needing deduplicating will be in the guard scope.
                         let old_dedup_scope =

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -29,7 +29,7 @@ use crate::builder::ForGuard::{self, OutsideGuard, RefWithinGuard};
 use crate::builder::expr::as_place::PlaceBuilder;
 use crate::builder::matches::buckets::PartitionedCandidates;
 use crate::builder::matches::user_ty::ProjectedUserTypesNode;
-use crate::builder::scope::DropKind;
+use crate::builder::scope::{DropKind, LintLevel};
 use crate::builder::{
     BlockAnd, BlockAndExtension, Builder, GuardFrame, GuardFrameLocal, LocalsForNode,
 };

--- a/compiler/rustc_mir_build/src/builder/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/mod.rs
@@ -38,14 +38,14 @@ use rustc_infer::infer::{InferCtxt, TyCtxtInferExt};
 use rustc_middle::hir::place::PlaceBase as HirPlaceBase;
 use rustc_middle::middle::region;
 use rustc_middle::mir::*;
-use rustc_middle::thir::{self, ExprId, LintLevel, LocalVarId, Param, ParamId, PatKind, Thir};
+use rustc_middle::thir::{self, ExprId, LocalVarId, Param, ParamId, PatKind, Thir};
 use rustc_middle::ty::{self, ScalarInt, Ty, TyCtxt, TypeVisitableExt, TypingMode};
 use rustc_middle::{bug, span_bug};
 use rustc_session::lint;
 use rustc_span::{Span, Symbol, sym};
 
 use crate::builder::expr::as_place::PlaceBuilder;
-use crate::builder::scope::DropKind;
+use crate::builder::scope::{DropKind, LintLevel};
 use crate::errors;
 
 pub(crate) fn closure_saved_names_of_captured_variables<'tcx>(

--- a/compiler/rustc_mir_build/src/builder/scope.rs
+++ b/compiler/rustc_mir_build/src/builder/scope.rs
@@ -89,7 +89,7 @@ use rustc_hir::HirId;
 use rustc_index::{IndexSlice, IndexVec};
 use rustc_middle::middle::region;
 use rustc_middle::mir::{self, *};
-use rustc_middle::thir::{AdtExpr, AdtExprBase, ArmId, ExprId, ExprKind, LintLevel};
+use rustc_middle::thir::{AdtExpr, AdtExprBase, ArmId, ExprId, ExprKind};
 use rustc_middle::ty::{self, Ty, TyCtxt, TypeVisitableExt, ValTree};
 use rustc_middle::{bug, span_bug};
 use rustc_pattern_analysis::rustc::RustcPatCtxt;
@@ -520,6 +520,14 @@ impl<'tcx> Scopes<'tcx> {
     fn topmost(&self) -> region::Scope {
         self.scopes.last().expect("topmost_scope: no scopes present").region_scope
     }
+}
+
+/// Used by [`Builder::in_scope`] to create source scopes mapping from MIR back to HIR at points
+/// where lint levels change.
+#[derive(Copy, Clone, Debug)]
+pub(crate) enum LintLevel {
+    Inherited,
+    Explicit(HirId),
 }
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -478,7 +478,7 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
             }
         };
         match expr.kind {
-            ExprKind::Scope { value, lint_level: LintLevel::Explicit(hir_id), region_scope: _ } => {
+            ExprKind::Scope { value, hir_id, region_scope: _ } => {
                 let prev_id = self.hir_context;
                 self.hir_context = hir_id;
                 ensure_sufficient_stack(|| {

--- a/compiler/rustc_mir_build/src/thir/cx/block.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/block.rs
@@ -88,7 +88,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
                                 pattern,
                                 initializer: local.init.map(|init| self.mirror_expr(init)),
                                 else_block,
-                                lint_level: LintLevel::Explicit(local.hir_id),
+                                hir_id: local.hir_id,
                                 span,
                             },
                         };

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -77,7 +77,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
             kind: ExprKind::Scope {
                 region_scope: expr_scope,
                 value: self.thir.exprs.push(expr),
-                lint_level: LintLevel::Explicit(hir_expr.hir_id),
+                hir_id: hir_expr.hir_id,
             },
         };
 
@@ -1192,7 +1192,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
             pattern: self.pattern_from_hir(&arm.pat),
             guard: arm.guard.as_ref().map(|g| self.mirror_expr(g)),
             body: self.mirror_expr(arm.body),
-            lint_level: LintLevel::Explicit(arm.hir_id),
+            hir_id: arm.hir_id,
             scope: region::Scope { local_id: arm.hir_id.local_id, data: region::ScopeData::Node },
             span: arm.span,
         };

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -43,7 +43,7 @@ pub(crate) fn check_match(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Result<(), Err
         typeck_results,
         // FIXME(#132279): We're in a body, should handle opaques.
         typing_env: ty::TypingEnv::non_body_analysis(tcx, def_id),
-        lint_level: tcx.local_def_id_to_hir_id(def_id),
+        hir_source: tcx.local_def_id_to_hir_id(def_id),
         let_source: LetSource::None,
         pattern_arena: &pattern_arena,
         dropless_arena: &dropless_arena,
@@ -92,7 +92,7 @@ struct MatchVisitor<'p, 'tcx> {
     typing_env: ty::TypingEnv<'tcx>,
     typeck_results: &'tcx ty::TypeckResults<'tcx>,
     thir: &'p Thir<'tcx>,
-    lint_level: HirId,
+    hir_source: HirId,
     let_source: LetSource,
     pattern_arena: &'p TypedArena<DeconstructedPat<'p, 'tcx>>,
     dropless_arena: &'p DroplessArena,
@@ -111,7 +111,7 @@ impl<'p, 'tcx> Visitor<'p, 'tcx> for MatchVisitor<'p, 'tcx> {
 
     #[instrument(level = "trace", skip(self))]
     fn visit_arm(&mut self, arm: &'p Arm<'tcx>) {
-        self.with_lint_level(arm.lint_level, |this| {
+        self.with_hir_source(arm.hir_id, |this| {
             if let Some(expr) = arm.guard {
                 this.with_let_source(LetSource::IfLetGuard, |this| {
                     this.visit_expr(&this.thir[expr])
@@ -125,8 +125,8 @@ impl<'p, 'tcx> Visitor<'p, 'tcx> for MatchVisitor<'p, 'tcx> {
     #[instrument(level = "trace", skip(self))]
     fn visit_expr(&mut self, ex: &'p Expr<'tcx>) {
         match ex.kind {
-            ExprKind::Scope { value, lint_level, .. } => {
-                self.with_lint_level(lint_level, |this| {
+            ExprKind::Scope { value, hir_id, .. } => {
+                self.with_hir_source(hir_id, |this| {
                     this.visit_expr(&this.thir[value]);
                 });
                 return;
@@ -181,10 +181,8 @@ impl<'p, 'tcx> Visitor<'p, 'tcx> for MatchVisitor<'p, 'tcx> {
 
     fn visit_stmt(&mut self, stmt: &'p Stmt<'tcx>) {
         match stmt.kind {
-            StmtKind::Let {
-                box ref pattern, initializer, else_block, lint_level, span, ..
-            } => {
-                self.with_lint_level(lint_level, |this| {
+            StmtKind::Let { box ref pattern, initializer, else_block, hir_id, span, .. } => {
+                self.with_hir_source(hir_id, |this| {
                     let let_source =
                         if else_block.is_some() { LetSource::LetElse } else { LetSource::PlainLet };
                     this.with_let_source(let_source, |this| {
@@ -209,20 +207,12 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
         self.let_source = old_let_source;
     }
 
-    fn with_lint_level<T>(
-        &mut self,
-        new_lint_level: LintLevel,
-        f: impl FnOnce(&mut Self) -> T,
-    ) -> T {
-        if let LintLevel::Explicit(hir_id) = new_lint_level {
-            let old_lint_level = self.lint_level;
-            self.lint_level = hir_id;
-            let ret = f(self);
-            self.lint_level = old_lint_level;
-            ret
-        } else {
-            f(self)
-        }
+    fn with_hir_source<T>(&mut self, new_hir_source: HirId, f: impl FnOnce(&mut Self) -> T) -> T {
+        let old_hir_source = self.hir_source;
+        self.hir_source = new_hir_source;
+        let ret = f(self);
+        self.hir_source = old_hir_source;
+        ret
     }
 
     /// Visit a nested chain of `&&`. Used for if-let chains. This must call `visit_expr` on the
@@ -233,9 +223,9 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
         accumulator: &mut Vec<Option<(Span, RefutableFlag)>>,
     ) -> Result<(), ErrorGuaranteed> {
         match ex.kind {
-            ExprKind::Scope { value, lint_level, .. } => self.with_lint_level(lint_level, |this| {
-                this.visit_land(&this.thir[value], accumulator)
-            }),
+            ExprKind::Scope { value, hir_id, .. } => {
+                self.with_hir_source(hir_id, |this| this.visit_land(&this.thir[value], accumulator))
+            }
             ExprKind::LogicalOp { op: LogicalOp::And, lhs, rhs } => {
                 // We recurse into the lhs only, because `&&` chains associate to the left.
                 let res_lhs = self.visit_land(&self.thir[lhs], accumulator);
@@ -259,8 +249,8 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
         ex: &'p Expr<'tcx>,
     ) -> Result<Option<(Span, RefutableFlag)>, ErrorGuaranteed> {
         match ex.kind {
-            ExprKind::Scope { value, lint_level, .. } => {
-                self.with_lint_level(lint_level, |this| this.visit_land_rhs(&this.thir[value]))
+            ExprKind::Scope { value, hir_id, .. } => {
+                self.with_hir_source(hir_id, |this| this.visit_land_rhs(&this.thir[value]))
             }
             ExprKind::Let { box ref pat, expr } => {
                 let expr = &self.thir()[expr];
@@ -398,9 +388,9 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
             tcx: self.tcx,
             typeck_results: self.typeck_results,
             typing_env: self.typing_env,
-            module: self.tcx.parent_module(self.lint_level).to_def_id(),
+            module: self.tcx.parent_module(self.hir_source).to_def_id(),
             dropless_arena: self.dropless_arena,
-            match_lint_level: self.lint_level,
+            match_lint_level: self.hir_source,
             whole_match_span,
             scrut_span,
             refutable,
@@ -448,7 +438,7 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
             if matches!(refutability, Irrefutable) {
                 report_irrefutable_let_patterns(
                     self.tcx,
-                    self.lint_level,
+                    self.hir_source,
                     self.let_source,
                     1,
                     span,
@@ -470,10 +460,10 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
         let mut tarms = Vec::with_capacity(arms.len());
         for &arm in arms {
             let arm = &self.thir.arms[arm];
-            let got_error = self.with_lint_level(arm.lint_level, |this| {
+            let got_error = self.with_hir_source(arm.hir_id, |this| {
                 let Ok(pat) = this.lower_pattern(&cx, &arm.pattern) else { return true };
                 let arm =
-                    MatchArm { pat, arm_data: this.lint_level, has_guard: arm.guard.is_some() };
+                    MatchArm { pat, arm_data: this.hir_source, has_guard: arm.guard.is_some() };
                 tarms.push(arm);
                 false
             });
@@ -572,7 +562,7 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
             // The entire chain is made up of irrefutable `let` statements
             report_irrefutable_let_patterns(
                 self.tcx,
-                self.lint_level,
+                self.hir_source,
                 self.let_source,
                 chain_refutabilities.len(),
                 whole_chain_span,
@@ -605,7 +595,7 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
                 let count = prefix.len();
                 self.tcx.emit_node_span_lint(
                     IRREFUTABLE_LET_PATTERNS,
-                    self.lint_level,
+                    self.hir_source,
                     span,
                     LeadingIrrefutableLetPatterns { count },
                 );
@@ -624,7 +614,7 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
             let count = suffix.len();
             self.tcx.emit_node_span_lint(
                 IRREFUTABLE_LET_PATTERNS,
-                self.lint_level,
+                self.hir_source,
                 span,
                 TrailingIrrefutableLetPatterns { count },
             );
@@ -639,7 +629,7 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
     ) -> Result<(PatCtxt<'p, 'tcx>, UsefulnessReport<'p, 'tcx>), ErrorGuaranteed> {
         let cx = self.new_cx(refutability, None, scrut, pat.span);
         let pat = self.lower_pattern(&cx, pat)?;
-        let arms = [MatchArm { pat, arm_data: self.lint_level, has_guard: false }];
+        let arms = [MatchArm { pat, arm_data: self.hir_source, has_guard: false }];
         let report = self.analyze_patterns(&cx, &arms, pat.ty().inner())?;
         Ok((cx, report))
     }
@@ -893,7 +883,7 @@ fn check_for_bindings_named_same_as_variants(
         let ty_path = with_no_trimmed_paths!(cx.tcx.def_path_str(edef.did()));
         cx.tcx.emit_node_span_lint(
             BINDINGS_WITH_VARIANT_NAME,
-            cx.lint_level,
+            cx.hir_source,
             pat.span,
             BindingsWithVariantName {
                 // If this is an irrefutable pattern, and there's > 1 variant,

--- a/compiler/rustc_mir_build/src/thir/print.rs
+++ b/compiler/rustc_mir_build/src/thir/print.rs
@@ -142,7 +142,7 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
                 pattern,
                 initializer,
                 else_block,
-                lint_level,
+                hir_id,
                 span,
             } => {
                 print_indented!(self, "kind: Let {", depth_lvl + 1);
@@ -173,7 +173,7 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
                     print_indented!(self, "else_block: None", depth_lvl + 2);
                 }
 
-                print_indented!(self, format!("lint_level: {:?}", lint_level), depth_lvl + 2);
+                print_indented!(self, format!("hir_id: {:?}", hir_id), depth_lvl + 2);
                 print_indented!(self, format!("span: {:?}", span), depth_lvl + 2);
                 print_indented!(self, "}", depth_lvl + 1);
             }
@@ -197,10 +197,10 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
         use rustc_middle::thir::ExprKind::*;
 
         match expr_kind {
-            Scope { region_scope, value, lint_level } => {
+            Scope { region_scope, value, hir_id } => {
                 print_indented!(self, "Scope {", depth_lvl);
                 print_indented!(self, format!("region_scope: {:?}", region_scope), depth_lvl + 1);
-                print_indented!(self, format!("lint_level: {:?}", lint_level), depth_lvl + 1);
+                print_indented!(self, format!("hir_id: {:?}", hir_id), depth_lvl + 1);
                 print_indented!(self, "value:", depth_lvl + 1);
                 self.print_expr(*value, depth_lvl + 2);
                 print_indented!(self, "}", depth_lvl);
@@ -642,7 +642,7 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
         print_indented!(self, "Arm {", depth_lvl);
 
         let arm = &self.thir.arms[arm_id];
-        let Arm { pattern, guard, body, lint_level, scope, span } = arm;
+        let Arm { pattern, guard, body, hir_id, scope, span } = arm;
 
         print_indented!(self, "pattern: ", depth_lvl + 1);
         self.print_pat(pattern, depth_lvl + 2);
@@ -656,7 +656,7 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
 
         print_indented!(self, "body: ", depth_lvl + 1);
         self.print_expr(*body, depth_lvl + 2);
-        print_indented!(self, format!("lint_level: {:?}", lint_level), depth_lvl + 1);
+        print_indented!(self, format!("hir_id: {:?}", hir_id), depth_lvl + 1);
         print_indented!(self, format!("scope: {:?}", scope), depth_lvl + 1);
         print_indented!(self, format!("span: {:?}", span), depth_lvl + 1);
         print_indented!(self, "}", depth_lvl);

--- a/tests/ui/thir-print/c-variadic.stdout
+++ b/tests/ui/thir-print/c-variadic.stdout
@@ -39,7 +39,7 @@ body:
         kind: 
             Scope {
                 region_scope: Node(6)
-                lint_level: Explicit(HirId(DefId(0:3 ~ c_variadic[a5de]::foo).6))
+                hir_id: HirId(DefId(0:3 ~ c_variadic[a5de]::foo).6)
                 value:
                     Expr {
                         ty: ()

--- a/tests/ui/thir-print/offset_of.stdout
+++ b/tests/ui/thir-print/offset_of.stdout
@@ -9,7 +9,7 @@ body:
         kind: 
             Scope {
                 region_scope: Node(52)
-                lint_level: Explicit(HirId(DefId(offset_of::concrete).52))
+                hir_id: HirId(DefId(offset_of::concrete).52)
                 value:
                     Expr {
                         ty: ()
@@ -51,7 +51,7 @@ body:
                                                     kind: 
                                                         Scope {
                                                             region_scope: Node(3)
-                                                            lint_level: Explicit(HirId(DefId(offset_of::concrete).3))
+                                                            hir_id: HirId(DefId(offset_of::concrete).3)
                                                             value:
                                                                 Expr {
                                                                     ty: usize
@@ -67,7 +67,7 @@ body:
                                                 }
                                             )
                                             else_block: None
-                                            lint_level: Explicit(HirId(DefId(offset_of::concrete).10))
+                                            hir_id: HirId(DefId(offset_of::concrete).10)
                                             span: $DIR/offset_of.rs:37:5: 1440:57 (#0)
                                         }
                                     }
@@ -100,7 +100,7 @@ body:
                                                     kind: 
                                                         Scope {
                                                             region_scope: Node(13)
-                                                            lint_level: Explicit(HirId(DefId(offset_of::concrete).13))
+                                                            hir_id: HirId(DefId(offset_of::concrete).13)
                                                             value:
                                                                 Expr {
                                                                     ty: usize
@@ -116,7 +116,7 @@ body:
                                                 }
                                             )
                                             else_block: None
-                                            lint_level: Explicit(HirId(DefId(offset_of::concrete).20))
+                                            hir_id: HirId(DefId(offset_of::concrete).20)
                                             span: $DIR/offset_of.rs:38:5: 1440:57 (#0)
                                         }
                                     }
@@ -149,7 +149,7 @@ body:
                                                     kind: 
                                                         Scope {
                                                             region_scope: Node(23)
-                                                            lint_level: Explicit(HirId(DefId(offset_of::concrete).23))
+                                                            hir_id: HirId(DefId(offset_of::concrete).23)
                                                             value:
                                                                 Expr {
                                                                     ty: usize
@@ -165,7 +165,7 @@ body:
                                                 }
                                             )
                                             else_block: None
-                                            lint_level: Explicit(HirId(DefId(offset_of::concrete).30))
+                                            hir_id: HirId(DefId(offset_of::concrete).30)
                                             span: $DIR/offset_of.rs:39:5: 1440:57 (#0)
                                         }
                                     }
@@ -198,7 +198,7 @@ body:
                                                     kind: 
                                                         Scope {
                                                             region_scope: Node(33)
-                                                            lint_level: Explicit(HirId(DefId(offset_of::concrete).33))
+                                                            hir_id: HirId(DefId(offset_of::concrete).33)
                                                             value:
                                                                 Expr {
                                                                     ty: usize
@@ -214,7 +214,7 @@ body:
                                                 }
                                             )
                                             else_block: None
-                                            lint_level: Explicit(HirId(DefId(offset_of::concrete).40))
+                                            hir_id: HirId(DefId(offset_of::concrete).40)
                                             span: $DIR/offset_of.rs:40:5: 1440:57 (#0)
                                         }
                                     }
@@ -247,7 +247,7 @@ body:
                                                     kind: 
                                                         Scope {
                                                             region_scope: Node(43)
-                                                            lint_level: Explicit(HirId(DefId(offset_of::concrete).43))
+                                                            hir_id: HirId(DefId(offset_of::concrete).43)
                                                             value:
                                                                 Expr {
                                                                     ty: usize
@@ -263,7 +263,7 @@ body:
                                                 }
                                             )
                                             else_block: None
-                                            lint_level: Explicit(HirId(DefId(offset_of::concrete).50))
+                                            hir_id: HirId(DefId(offset_of::concrete).50)
                                             span: $DIR/offset_of.rs:41:5: 1440:57 (#0)
                                         }
                                     }
@@ -286,7 +286,7 @@ body:
         kind: 
             Scope {
                 region_scope: Node(5)
-                lint_level: Explicit(HirId(DefId(offset_of::concrete).5))
+                hir_id: HirId(DefId(offset_of::concrete).5)
                 value:
                     Expr {
                         ty: usize
@@ -307,7 +307,7 @@ body:
                                         kind: 
                                             Scope {
                                                 region_scope: Node(7)
-                                                lint_level: Explicit(HirId(DefId(offset_of::concrete).7))
+                                                hir_id: HirId(DefId(offset_of::concrete).7)
                                                 value:
                                                     Expr {
                                                         ty: usize
@@ -369,7 +369,7 @@ body:
         kind: 
             Scope {
                 region_scope: Node(15)
-                lint_level: Explicit(HirId(DefId(offset_of::concrete).15))
+                hir_id: HirId(DefId(offset_of::concrete).15)
                 value:
                     Expr {
                         ty: usize
@@ -390,7 +390,7 @@ body:
                                         kind: 
                                             Scope {
                                                 region_scope: Node(17)
-                                                lint_level: Explicit(HirId(DefId(offset_of::concrete).17))
+                                                hir_id: HirId(DefId(offset_of::concrete).17)
                                                 value:
                                                     Expr {
                                                         ty: usize
@@ -452,7 +452,7 @@ body:
         kind: 
             Scope {
                 region_scope: Node(25)
-                lint_level: Explicit(HirId(DefId(offset_of::concrete).25))
+                hir_id: HirId(DefId(offset_of::concrete).25)
                 value:
                     Expr {
                         ty: usize
@@ -473,7 +473,7 @@ body:
                                         kind: 
                                             Scope {
                                                 region_scope: Node(27)
-                                                lint_level: Explicit(HirId(DefId(offset_of::concrete).27))
+                                                hir_id: HirId(DefId(offset_of::concrete).27)
                                                 value:
                                                     Expr {
                                                         ty: usize
@@ -535,7 +535,7 @@ body:
         kind: 
             Scope {
                 region_scope: Node(35)
-                lint_level: Explicit(HirId(DefId(offset_of::concrete).35))
+                hir_id: HirId(DefId(offset_of::concrete).35)
                 value:
                     Expr {
                         ty: usize
@@ -556,7 +556,7 @@ body:
                                         kind: 
                                             Scope {
                                                 region_scope: Node(37)
-                                                lint_level: Explicit(HirId(DefId(offset_of::concrete).37))
+                                                hir_id: HirId(DefId(offset_of::concrete).37)
                                                 value:
                                                     Expr {
                                                         ty: usize
@@ -670,7 +670,7 @@ body:
         kind: 
             Scope {
                 region_scope: Node(45)
-                lint_level: Explicit(HirId(DefId(offset_of::concrete).45))
+                hir_id: HirId(DefId(offset_of::concrete).45)
                 value:
                     Expr {
                         ty: usize
@@ -691,7 +691,7 @@ body:
                                         kind: 
                                             Scope {
                                                 region_scope: Node(47)
-                                                lint_level: Explicit(HirId(DefId(offset_of::concrete).47))
+                                                hir_id: HirId(DefId(offset_of::concrete).47)
                                                 value:
                                                     Expr {
                                                         ty: usize
@@ -805,7 +805,7 @@ body:
         kind: 
             Scope {
                 region_scope: Node(50)
-                lint_level: Explicit(HirId(DefId(offset_of::generic).50))
+                hir_id: HirId(DefId(offset_of::generic).50)
                 value:
                     Expr {
                         ty: ()
@@ -847,7 +847,7 @@ body:
                                                     kind: 
                                                         Scope {
                                                             region_scope: Node(3)
-                                                            lint_level: Explicit(HirId(DefId(offset_of::generic).3))
+                                                            hir_id: HirId(DefId(offset_of::generic).3)
                                                             value:
                                                                 Expr {
                                                                     ty: usize
@@ -863,7 +863,7 @@ body:
                                                 }
                                             )
                                             else_block: None
-                                            lint_level: Explicit(HirId(DefId(offset_of::generic).12))
+                                            hir_id: HirId(DefId(offset_of::generic).12)
                                             span: $DIR/offset_of.rs:45:5: 1440:57 (#0)
                                         }
                                     }
@@ -896,7 +896,7 @@ body:
                                                     kind: 
                                                         Scope {
                                                             region_scope: Node(15)
-                                                            lint_level: Explicit(HirId(DefId(offset_of::generic).15))
+                                                            hir_id: HirId(DefId(offset_of::generic).15)
                                                             value:
                                                                 Expr {
                                                                     ty: usize
@@ -912,7 +912,7 @@ body:
                                                 }
                                             )
                                             else_block: None
-                                            lint_level: Explicit(HirId(DefId(offset_of::generic).24))
+                                            hir_id: HirId(DefId(offset_of::generic).24)
                                             span: $DIR/offset_of.rs:46:5: 1440:57 (#0)
                                         }
                                     }
@@ -945,7 +945,7 @@ body:
                                                     kind: 
                                                         Scope {
                                                             region_scope: Node(27)
-                                                            lint_level: Explicit(HirId(DefId(offset_of::generic).27))
+                                                            hir_id: HirId(DefId(offset_of::generic).27)
                                                             value:
                                                                 Expr {
                                                                     ty: usize
@@ -961,7 +961,7 @@ body:
                                                 }
                                             )
                                             else_block: None
-                                            lint_level: Explicit(HirId(DefId(offset_of::generic).36))
+                                            hir_id: HirId(DefId(offset_of::generic).36)
                                             span: $DIR/offset_of.rs:47:5: 1440:57 (#0)
                                         }
                                     }
@@ -994,7 +994,7 @@ body:
                                                     kind: 
                                                         Scope {
                                                             region_scope: Node(39)
-                                                            lint_level: Explicit(HirId(DefId(offset_of::generic).39))
+                                                            hir_id: HirId(DefId(offset_of::generic).39)
                                                             value:
                                                                 Expr {
                                                                     ty: usize
@@ -1010,7 +1010,7 @@ body:
                                                 }
                                             )
                                             else_block: None
-                                            lint_level: Explicit(HirId(DefId(offset_of::generic).48))
+                                            hir_id: HirId(DefId(offset_of::generic).48)
                                             span: $DIR/offset_of.rs:48:5: 1440:57 (#0)
                                         }
                                     }
@@ -1033,7 +1033,7 @@ body:
         kind: 
             Scope {
                 region_scope: Node(5)
-                lint_level: Explicit(HirId(DefId(offset_of::generic).5))
+                hir_id: HirId(DefId(offset_of::generic).5)
                 value:
                     Expr {
                         ty: usize
@@ -1054,7 +1054,7 @@ body:
                                         kind: 
                                             Scope {
                                                 region_scope: Node(7)
-                                                lint_level: Explicit(HirId(DefId(offset_of::generic).7))
+                                                hir_id: HirId(DefId(offset_of::generic).7)
                                                 value:
                                                     Expr {
                                                         ty: usize
@@ -1116,7 +1116,7 @@ body:
         kind: 
             Scope {
                 region_scope: Node(17)
-                lint_level: Explicit(HirId(DefId(offset_of::generic).17))
+                hir_id: HirId(DefId(offset_of::generic).17)
                 value:
                     Expr {
                         ty: usize
@@ -1137,7 +1137,7 @@ body:
                                         kind: 
                                             Scope {
                                                 region_scope: Node(19)
-                                                lint_level: Explicit(HirId(DefId(offset_of::generic).19))
+                                                hir_id: HirId(DefId(offset_of::generic).19)
                                                 value:
                                                     Expr {
                                                         ty: usize
@@ -1199,7 +1199,7 @@ body:
         kind: 
             Scope {
                 region_scope: Node(29)
-                lint_level: Explicit(HirId(DefId(offset_of::generic).29))
+                hir_id: HirId(DefId(offset_of::generic).29)
                 value:
                     Expr {
                         ty: usize
@@ -1220,7 +1220,7 @@ body:
                                         kind: 
                                             Scope {
                                                 region_scope: Node(31)
-                                                lint_level: Explicit(HirId(DefId(offset_of::generic).31))
+                                                hir_id: HirId(DefId(offset_of::generic).31)
                                                 value:
                                                     Expr {
                                                         ty: usize
@@ -1282,7 +1282,7 @@ body:
         kind: 
             Scope {
                 region_scope: Node(41)
-                lint_level: Explicit(HirId(DefId(offset_of::generic).41))
+                hir_id: HirId(DefId(offset_of::generic).41)
                 value:
                     Expr {
                         ty: usize
@@ -1303,7 +1303,7 @@ body:
                                         kind: 
                                             Scope {
                                                 region_scope: Node(43)
-                                                lint_level: Explicit(HirId(DefId(offset_of::generic).43))
+                                                hir_id: HirId(DefId(offset_of::generic).43)
                                                 value:
                                                     Expr {
                                                         ty: usize

--- a/tests/ui/thir-print/thir-flat-const-variant.stdout
+++ b/tests/ui/thir-print/thir-flat-const-variant.stdout
@@ -17,9 +17,7 @@ Thir {
         Expr {
             kind: Scope {
                 region_scope: Node(7),
-                lint_level: Explicit(
-                    HirId(DefId(0:8 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR1).7),
-                ),
+                hir_id: HirId(DefId(0:8 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR1).7),
                 value: e0,
             },
             ty: (),
@@ -49,9 +47,7 @@ Thir {
         Expr {
             kind: Scope {
                 region_scope: Node(3),
-                lint_level: Explicit(
-                    HirId(DefId(0:8 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR1).3),
-                ),
+                hir_id: HirId(DefId(0:8 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR1).3),
                 value: e2,
             },
             ty: Foo,
@@ -82,9 +78,7 @@ Thir {
         Expr {
             kind: Scope {
                 region_scope: Node(8),
-                lint_level: Explicit(
-                    HirId(DefId(0:9 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR2).8),
-                ),
+                hir_id: HirId(DefId(0:9 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR2).8),
                 value: e0,
             },
             ty: (),
@@ -114,9 +108,7 @@ Thir {
         Expr {
             kind: Scope {
                 region_scope: Node(3),
-                lint_level: Explicit(
-                    HirId(DefId(0:9 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR2).3),
-                ),
+                hir_id: HirId(DefId(0:9 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR2).3),
                 value: e2,
             },
             ty: Foo,
@@ -147,9 +139,7 @@ Thir {
         Expr {
             kind: Scope {
                 region_scope: Node(7),
-                lint_level: Explicit(
-                    HirId(DefId(0:10 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR3).7),
-                ),
+                hir_id: HirId(DefId(0:10 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR3).7),
                 value: e0,
             },
             ty: (),
@@ -179,9 +169,7 @@ Thir {
         Expr {
             kind: Scope {
                 region_scope: Node(3),
-                lint_level: Explicit(
-                    HirId(DefId(0:10 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR3).3),
-                ),
+                hir_id: HirId(DefId(0:10 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR3).3),
                 value: e2,
             },
             ty: Foo,
@@ -212,9 +200,7 @@ Thir {
         Expr {
             kind: Scope {
                 region_scope: Node(8),
-                lint_level: Explicit(
-                    HirId(DefId(0:11 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR4).8),
-                ),
+                hir_id: HirId(DefId(0:11 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR4).8),
                 value: e0,
             },
             ty: (),
@@ -244,9 +230,7 @@ Thir {
         Expr {
             kind: Scope {
                 region_scope: Node(3),
-                lint_level: Explicit(
-                    HirId(DefId(0:11 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR4).3),
-                ),
+                hir_id: HirId(DefId(0:11 ~ thir_flat_const_variant[1f54]::{impl#0}::BAR4).3),
                 value: e2,
             },
             ty: Foo,
@@ -286,9 +270,7 @@ Thir {
         Expr {
             kind: Scope {
                 region_scope: Node(2),
-                lint_level: Explicit(
-                    HirId(DefId(0:12 ~ thir_flat_const_variant[1f54]::main).2),
-                ),
+                hir_id: HirId(DefId(0:12 ~ thir_flat_const_variant[1f54]::main).2),
                 value: e0,
             },
             ty: (),

--- a/tests/ui/thir-print/thir-flat.stdout
+++ b/tests/ui/thir-print/thir-flat.stdout
@@ -26,9 +26,7 @@ Thir {
         Expr {
             kind: Scope {
                 region_scope: Node(2),
-                lint_level: Explicit(
-                    HirId(DefId(0:3 ~ thir_flat[7b97]::main).2),
-                ),
+                hir_id: HirId(DefId(0:3 ~ thir_flat[7b97]::main).2),
                 value: e0,
             },
             ty: (),

--- a/tests/ui/thir-print/thir-tree-loop-match.stdout
+++ b/tests/ui/thir-print/thir-tree-loop-match.stdout
@@ -32,7 +32,7 @@ body:
         kind: 
             Scope {
                 region_scope: Node(28)
-                lint_level: Explicit(HirId(DefId(0:3 ~ thir_tree_loop_match[3c53]::boolean).28))
+                hir_id: HirId(DefId(0:3 ~ thir_tree_loop_match[3c53]::boolean).28)
                 value:
                     Expr {
                         ty: bool
@@ -53,7 +53,7 @@ body:
                                         kind: 
                                             Scope {
                                                 region_scope: Node(4)
-                                                lint_level: Explicit(HirId(DefId(0:3 ~ thir_tree_loop_match[3c53]::boolean).4))
+                                                hir_id: HirId(DefId(0:3 ~ thir_tree_loop_match[3c53]::boolean).4)
                                                 value:
                                                     Expr {
                                                         ty: bool
@@ -76,7 +76,7 @@ body:
                                                                                         kind: 
                                                                                             Scope {
                                                                                                 region_scope: Node(7)
-                                                                                                lint_level: Explicit(HirId(DefId(0:3 ~ thir_tree_loop_match[3c53]::boolean).7))
+                                                                                                hir_id: HirId(DefId(0:3 ~ thir_tree_loop_match[3c53]::boolean).7)
                                                                                                 value:
                                                                                                     Expr {
                                                                                                         ty: bool
@@ -101,7 +101,7 @@ body:
                                                                                                 kind: 
                                                                                                     Scope {
                                                                                                         region_scope: Node(12)
-                                                                                                        lint_level: Explicit(HirId(DefId(0:3 ~ thir_tree_loop_match[3c53]::boolean).12))
+                                                                                                        hir_id: HirId(DefId(0:3 ~ thir_tree_loop_match[3c53]::boolean).12)
                                                                                                         value:
                                                                                                             Expr {
                                                                                                                 ty: bool
@@ -135,7 +135,7 @@ body:
                                                                                                         kind: 
                                                                                                             Scope {
                                                                                                                 region_scope: Node(17)
-                                                                                                                lint_level: Explicit(HirId(DefId(0:3 ~ thir_tree_loop_match[3c53]::boolean).17))
+                                                                                                                hir_id: HirId(DefId(0:3 ~ thir_tree_loop_match[3c53]::boolean).17)
                                                                                                                 value:
                                                                                                                     Expr {
                                                                                                                         ty: bool
@@ -166,7 +166,7 @@ body:
                                                                                                                                                                     kind: 
                                                                                                                                                                         Scope {
                                                                                                                                                                             region_scope: Node(19)
-                                                                                                                                                                            lint_level: Explicit(HirId(DefId(0:3 ~ thir_tree_loop_match[3c53]::boolean).19))
+                                                                                                                                                                            hir_id: HirId(DefId(0:3 ~ thir_tree_loop_match[3c53]::boolean).19)
                                                                                                                                                                             value:
                                                                                                                                                                                 Expr {
                                                                                                                                                                                     ty: !
@@ -183,7 +183,7 @@ body:
                                                                                                                                                                                                     kind: 
                                                                                                                                                                                                         Scope {
                                                                                                                                                                                                             region_scope: Node(20)
-                                                                                                                                                                                                            lint_level: Explicit(HirId(DefId(0:3 ~ thir_tree_loop_match[3c53]::boolean).20))
+                                                                                                                                                                                                            hir_id: HirId(DefId(0:3 ~ thir_tree_loop_match[3c53]::boolean).20)
                                                                                                                                                                                                             value:
                                                                                                                                                                                                                 Expr {
                                                                                                                                                                                                                     ty: bool
@@ -209,7 +209,7 @@ body:
                                                                                                                     }
                                                                                                             }
                                                                                                     }
-                                                                                                lint_level: Explicit(HirId(DefId(0:3 ~ thir_tree_loop_match[3c53]::boolean).16))
+                                                                                                hir_id: HirId(DefId(0:3 ~ thir_tree_loop_match[3c53]::boolean).16)
                                                                                                 scope: Node(16)
                                                                                                 span: $DIR/thir-tree-loop-match.rs:12:17: 15:18 (#0)
                                                                                             }
@@ -233,7 +233,7 @@ body:
                                                                                                         kind: 
                                                                                                             Scope {
                                                                                                                 region_scope: Node(25)
-                                                                                                                lint_level: Explicit(HirId(DefId(0:3 ~ thir_tree_loop_match[3c53]::boolean).25))
+                                                                                                                hir_id: HirId(DefId(0:3 ~ thir_tree_loop_match[3c53]::boolean).25)
                                                                                                                 value:
                                                                                                                     Expr {
                                                                                                                         ty: bool
@@ -256,7 +256,7 @@ body:
                                                                                                                                                         kind: 
                                                                                                                                                             Scope {
                                                                                                                                                                 region_scope: Node(26)
-                                                                                                                                                                lint_level: Explicit(HirId(DefId(0:3 ~ thir_tree_loop_match[3c53]::boolean).26))
+                                                                                                                                                                hir_id: HirId(DefId(0:3 ~ thir_tree_loop_match[3c53]::boolean).26)
                                                                                                                                                                 value:
                                                                                                                                                                     Expr {
                                                                                                                                                                         ty: bool
@@ -275,7 +275,7 @@ body:
                                                                                                                     }
                                                                                                             }
                                                                                                     }
-                                                                                                lint_level: Explicit(HirId(DefId(0:3 ~ thir_tree_loop_match[3c53]::boolean).24))
+                                                                                                hir_id: HirId(DefId(0:3 ~ thir_tree_loop_match[3c53]::boolean).24)
                                                                                                 scope: Node(24)
                                                                                                 span: $DIR/thir-tree-loop-match.rs:16:17: 16:38 (#0)
                                                                                             }
@@ -304,7 +304,7 @@ body:
         kind: 
             Scope {
                 region_scope: Node(2)
-                lint_level: Explicit(HirId(DefId(0:4 ~ thir_tree_loop_match[3c53]::main).2))
+                hir_id: HirId(DefId(0:4 ~ thir_tree_loop_match[3c53]::main).2)
                 value:
                     Expr {
                         ty: ()

--- a/tests/ui/thir-print/thir-tree-match.stdout
+++ b/tests/ui/thir-print/thir-tree-match.stdout
@@ -32,7 +32,7 @@ body:
         kind: 
             Scope {
                 region_scope: Node(28)
-                lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).28))
+                hir_id: HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).28)
                 value:
                     Expr {
                         ty: bool
@@ -53,7 +53,7 @@ body:
                                         kind: 
                                             Scope {
                                                 region_scope: Node(4)
-                                                lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).4))
+                                                hir_id: HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).4)
                                                 value:
                                                     Expr {
                                                         ty: bool
@@ -69,7 +69,7 @@ body:
                                                                         kind: 
                                                                             Scope {
                                                                                 region_scope: Node(5)
-                                                                                lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).5))
+                                                                                hir_id: HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).5)
                                                                                 value:
                                                                                     Expr {
                                                                                         ty: Foo
@@ -129,7 +129,7 @@ body:
                                                                                 kind: 
                                                                                     Scope {
                                                                                         region_scope: Node(15)
-                                                                                        lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).15))
+                                                                                        hir_id: HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).15)
                                                                                         value:
                                                                                             Expr {
                                                                                                 ty: bool
@@ -141,7 +141,7 @@ body:
                                                                                             }
                                                                                     }
                                                                             }
-                                                                        lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).14))
+                                                                        hir_id: HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).14)
                                                                         scope: Node(14)
                                                                         span: $DIR/thir-tree-match.rs:17:9: 17:40 (#0)
                                                                     }
@@ -181,7 +181,7 @@ body:
                                                                                 kind: 
                                                                                     Scope {
                                                                                         region_scope: Node(21)
-                                                                                        lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).21))
+                                                                                        hir_id: HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).21)
                                                                                         value:
                                                                                             Expr {
                                                                                                 ty: bool
@@ -193,7 +193,7 @@ body:
                                                                                             }
                                                                                     }
                                                                             }
-                                                                        lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).20))
+                                                                        hir_id: HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).20)
                                                                         scope: Node(20)
                                                                         span: $DIR/thir-tree-match.rs:18:9: 18:32 (#0)
                                                                     }
@@ -225,7 +225,7 @@ body:
                                                                                 kind: 
                                                                                     Scope {
                                                                                         region_scope: Node(27)
-                                                                                        lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).27))
+                                                                                        hir_id: HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).27)
                                                                                         value:
                                                                                             Expr {
                                                                                                 ty: bool
@@ -237,7 +237,7 @@ body:
                                                                                             }
                                                                                     }
                                                                             }
-                                                                        lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).26))
+                                                                        hir_id: HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).26)
                                                                         scope: Node(26)
                                                                         span: $DIR/thir-tree-match.rs:19:9: 19:28 (#0)
                                                                     }
@@ -263,7 +263,7 @@ body:
         kind: 
             Scope {
                 region_scope: Node(2)
-                lint_level: Explicit(HirId(DefId(0:17 ~ thir_tree_match[fcf8]::main).2))
+                hir_id: HirId(DefId(0:17 ~ thir_tree_match[fcf8]::main).2)
                 value:
                     Expr {
                         ty: ()

--- a/tests/ui/thir-print/thir-tree.stdout
+++ b/tests/ui/thir-print/thir-tree.stdout
@@ -9,7 +9,7 @@ body:
         kind: 
             Scope {
                 region_scope: Node(2)
-                lint_level: Explicit(HirId(DefId(0:3 ~ thir_tree[7aaa]::main).2))
+                hir_id: HirId(DefId(0:3 ~ thir_tree[7aaa]::main).2)
                 value:
                     Expr {
                         ty: ()

--- a/tests/ui/unpretty/box.stdout
+++ b/tests/ui/unpretty/box.stdout
@@ -9,7 +9,7 @@ body:
         kind: 
             Scope {
                 region_scope: Node(11)
-                lint_level: Explicit(HirId(DefId(0:3 ~ box[efb9]::main).11))
+                hir_id: HirId(DefId(0:3 ~ box[efb9]::main).11)
                 value:
                     Expr {
                         ty: ()
@@ -43,7 +43,7 @@ body:
                                                     kind: 
                                                         Scope {
                                                             region_scope: Node(3)
-                                                            lint_level: Explicit(HirId(DefId(0:3 ~ box[efb9]::main).3))
+                                                            hir_id: HirId(DefId(0:3 ~ box[efb9]::main).3)
                                                             value:
                                                                 Expr {
                                                                     ty: std::boxed::Box<i32, std::alloc::Global>
@@ -58,7 +58,7 @@ body:
                                                                                 kind: 
                                                                                     Scope {
                                                                                         region_scope: Node(8)
-                                                                                        lint_level: Explicit(HirId(DefId(0:3 ~ box[efb9]::main).8))
+                                                                                        hir_id: HirId(DefId(0:3 ~ box[efb9]::main).8)
                                                                                         value:
                                                                                             Expr {
                                                                                                 ty: i32
@@ -76,7 +76,7 @@ body:
                                                 }
                                             )
                                             else_block: None
-                                            lint_level: Explicit(HirId(DefId(0:3 ~ box[efb9]::main).9))
+                                            hir_id: HirId(DefId(0:3 ~ box[efb9]::main).9)
                                             span: $DIR/box.rs:7:5: 7:35 (#0)
                                         }
                                     }


### PR DESCRIPTION
Occurrences of `LintLevel` in the THIR were always `LintLevel::Explicit`, containing a `HirId`, so we don't need to make it possible to put `LintLevel::Inherited` there. Removing the unused case where `HirId`s aren't present in the THIR slightly simplifies diagnostics/lints/tools that want to map from the THIR back to the HIR, e.g. rust-lang/rust#145569.

Since `LintLevel` is no longer present in the THIR, I've moved it in the second commit to live in `rustc_mir_build`; that's where it's actually used. I'm not sure exactly where exactly it should live there, but I put it in the `builder::scope` module since it's used by `Builder::in_scope` for determining when to introduce source scopes.

r? lcnr as the reviewer of rust-lang/rust#145569, since this was discussed there