### PR TITLE
Fix broken documentation links to SipHash

### DIFF
--- a/library/core/src/hash/sip.rs
+++ b/library/core/src/hash/sip.rs
@@ -10,7 +10,7 @@ use crate::{cmp, ptr};
 /// This is currently the default hashing function used by standard library
 /// (e.g., `collections::HashMap` uses it by default).
 ///
-/// See: <https://131002.net/siphash>
+/// See: <https://github.com/veorq/SipHash>
 #[unstable(feature = "hashmap_internals", issue = "none")]
 #[deprecated(since = "1.13.0", note = "use `std::hash::DefaultHasher` instead")]
 #[derive(Debug, Clone, Default)]
@@ -21,7 +21,7 @@ pub struct SipHasher13 {
 
 /// An implementation of SipHash 2-4.
 ///
-/// See: <https://131002.net/siphash/>
+/// See: <https://github.com/veorq/SipHash>
 #[unstable(feature = "hashmap_internals", issue = "none")]
 #[deprecated(since = "1.13.0", note = "use `std::hash::DefaultHasher` instead")]
 #[derive(Debug, Clone, Default)]
@@ -31,7 +31,7 @@ struct SipHasher24 {
 
 /// An implementation of SipHash 2-4.
 ///
-/// See: <https://131002.net/siphash/>
+/// See: <https://github.com/veorq/SipHash>
 ///
 /// SipHash is a general-purpose hashing function: it runs at a good
 /// speed (competitive with Spooky and City) and permits strong _keyed_


### PR DESCRIPTION
The documentation of `SipHasher` previously linked to a page about SipHash on https://131002.net, a domain registered to Jean-Philippe Aumasson, one of the co-authors of the original SipHash paper (alongside Daniel J Bernstein).

That domain now redirects to another of Mr Aumasson's domains, https://www.aumasson.jp, but which does not host a similar page dedicated to SipHash.  Instead, his site links to a GitHub repository containing a C implementation together with links to the original research paper.  Mr Bernstein's own site, https://cr.yp.to, only hosts a copy of the research paper.

Therefore the GitHub repository appears to be the most official and complete reference to which we can link.

Fixes rust-lang/rust#150806
r? reddevilmidzy