### PR TITLE
Prevent auto-trailing-glob insertion from confusing `cargo` and `cargotest` mentions

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1113,7 +1113,7 @@ cc = [
     "@obi1kenobi",
 ]
 
-[mentions."src/tools/cargo"]
+[mentions."src/tools/cargo/"]
 cc = ["@ehuss"]
 
 [mentions."src/tools/clippy"]


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/150812#issuecomment-3726643216 where the change to `src/tools/cargotest/` pinged Eric even though Eric's mention is for `src/tools/cargo/`.
