### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/compiler/rustc_arena/src/lib.rs
+++ b/compiler/rustc_arena/src/lib.rs
@@ -618,7 +618,7 @@ impl DroplessArena {
 /// - Types that are `!Copy` and `Drop`: these must be specified in the
 ///   arguments. The `TypedArena` will be used for them.
 ///
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro declare_arena([$($a:tt $name:ident: $ty:ty,)*]) {
     #[derive(Default)]
     pub struct Arena<'tcx> {

--- a/compiler/rustc_attr_parsing/src/attributes/transparency.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/transparency.rs
@@ -15,7 +15,7 @@ impl<S: Stage> SingleAttributeParser<S> for TransparencyParser {
     });
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::MacroDef)]);
     const TEMPLATE: AttributeTemplate =
-        template!(NameValueStr: ["transparent", "semitransparent", "opaque"]);
+        template!(NameValueStr: ["transparent", "semiopaque", "opaque"]);
 
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(nv) = args.name_value() else {
@@ -24,12 +24,12 @@ impl<S: Stage> SingleAttributeParser<S> for TransparencyParser {
         };
         match nv.value_as_str() {
             Some(sym::transparent) => Some(Transparency::Transparent),
-            Some(sym::semiopaque | sym::semitransparent) => Some(Transparency::SemiOpaque),
+            Some(sym::semiopaque) => Some(Transparency::SemiOpaque),
             Some(sym::opaque) => Some(Transparency::Opaque),
             Some(_) => {
                 cx.expected_specific_argument_strings(
                     nv.value_span,
-                    &[sym::transparent, sym::semitransparent, sym::opaque],
+                    &[sym::transparent, sym::semiopaque, sym::opaque],
                 );
                 None
             }

--- a/compiler/rustc_builtin_macros/messages.ftl
+++ b/compiler/rustc_builtin_macros/messages.ftl
@@ -182,6 +182,8 @@ builtin_macros_expected_other = expected operand, {$is_inline_asm ->
 
 builtin_macros_export_macro_rules = cannot export macro_rules! macros from a `proc-macro` crate type currently
 
+builtin_macros_format_add_missing_colon = add a colon before the format specifier
+
 builtin_macros_format_duplicate_arg = duplicate argument named `{$ident}`
     .label1 = previously here
     .label2 = duplicate argument

--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -643,6 +643,15 @@ pub(crate) enum InvalidFormatStringSuggestion {
         span: Span,
         replacement: String,
     },
+    #[suggestion(
+        builtin_macros_format_add_missing_colon,
+        code = ":?",
+        applicability = "machine-applicable"
+    )]
+    AddMissingColon {
+        #[primary_span]
+        span: Span,
+    },
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -329,6 +329,10 @@ fn make_format_args(
                     replacement,
                 });
             }
+            parse::Suggestion::AddMissingColon(span) => {
+                let span = fmt_span.from_inner(InnerSpan::new(span.start, span.end));
+                e.sugg_ = Some(errors::InvalidFormatStringSuggestion::AddMissingColon { span });
+            }
         }
         let guar = ecx.dcx().emit_err(e);
         return ExpandResult::Ready(Err(guar));

--- a/compiler/rustc_codegen_cranelift/example/mini_core.rs
+++ b/compiler/rustc_codegen_cranelift/example/mini_core.rs
@@ -744,43 +744,43 @@ unsafe extern "C" {
 pub struct VaList<'a>(&'a mut VaListImpl);
 
 #[rustc_builtin_macro]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro stringify($($t:tt)*) {
     /* compiler built-in */
 }
 
 #[rustc_builtin_macro]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro file() {
     /* compiler built-in */
 }
 
 #[rustc_builtin_macro]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro line() {
     /* compiler built-in */
 }
 
 #[rustc_builtin_macro]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro cfg() {
     /* compiler built-in */
 }
 
 #[rustc_builtin_macro]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro asm() {
     /* compiler built-in */
 }
 
 #[rustc_builtin_macro]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro global_asm() {
     /* compiler built-in */
 }
 
 #[rustc_builtin_macro]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro naked_asm() {
     /* compiler built-in */
 }

--- a/compiler/rustc_codegen_cranelift/src/global_asm.rs
+++ b/compiler/rustc_codegen_cranelift/src/global_asm.rs
@@ -233,7 +233,7 @@ pub(crate) fn compile_global_asm(
                 #![allow(internal_features)]
                 #![no_core]
                 #[rustc_builtin_macro]
-                #[rustc_macro_transparency = "semitransparent"]
+                #[rustc_macro_transparency = "semiopaque"]
                 macro global_asm() { /* compiler built-in */ }
                 global_asm!(r###"
                 "####,

--- a/compiler/rustc_codegen_gcc/example/mini_core.rs
+++ b/compiler/rustc_codegen_gcc/example/mini_core.rs
@@ -748,25 +748,25 @@ extern "C" {
 pub struct VaList<'a>(&'a mut VaListImpl);
 
 #[rustc_builtin_macro]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro stringify($($t:tt)*) {
     /* compiler built-in */
 }
 
 #[rustc_builtin_macro]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro file() {
     /* compiler built-in */
 }
 
 #[rustc_builtin_macro]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro line() {
     /* compiler built-in */
 }
 
 #[rustc_builtin_macro]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro cfg() {
     /* compiler built-in */
 }

--- a/compiler/rustc_middle/src/ty/consts/valtree.rs
+++ b/compiler/rustc_middle/src/ty/consts/valtree.rs
@@ -191,8 +191,7 @@ impl<'tcx> Value<'tcx> {
         }
     }
 
-    /// Destructures array, ADT or tuple constants into the constants
-    /// of their fields.
+    /// Destructures ADT constants into the constants of their fields.
     pub fn destructure_adt_const(&self) -> ty::DestructuredAdtConst<'tcx> {
         let fields = self.to_branch();
 

--- a/compiler/rustc_mir_dataflow/src/move_paths/mod.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/mod.rs
@@ -177,8 +177,9 @@ pub struct MoveData<'tcx> {
     pub rev_lookup: MovePathLookup<'tcx>,
     pub inits: IndexVec<InitIndex, Init>,
     /// Each Location `l` is mapped to the Inits that are effects
-    /// of executing the code at `l`.
-    pub init_loc_map: LocationMap<SmallVec<[InitIndex; 4]>>,
+    /// of executing the code at `l`. Only very rarely (e.g. inline asm)
+    /// is there more than one Init at any `l`.
+    pub init_loc_map: LocationMap<SmallVec<[InitIndex; 1]>>,
     pub init_path_map: IndexVec<MovePathIndex, SmallVec<[InitIndex; 4]>>,
 }
 

--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -184,6 +184,9 @@ pub enum Suggestion {
     /// `format!("{foo:?x}")` -> `format!("{foo:x?}")`
     /// `format!("{foo:?X}")` -> `format!("{foo:X?}")`
     ReorderFormatParameter(Range<usize>, String),
+    /// Add missing colon:
+    /// `format!("{foo?}")` -> `format!("{foo:?}")`
+    AddMissingColon(Range<usize>),
 }
 
 /// The parser structure for interpreting the input format string. This is
@@ -453,10 +456,11 @@ impl<'input> Parser<'input> {
             suggestion: Suggestion::None,
         });
 
-        if let Some((_, _, c)) = self.peek() {
-            match c {
-                '?' => self.suggest_format_debug(),
-                '<' | '^' | '>' => self.suggest_format_align(c),
+        if let (Some((_, _, c)), Some((_, _, nc))) = (self.peek(), self.peek_ahead()) {
+            match (c, nc) {
+                ('?', '}') => self.missing_colon_before_debug_formatter(),
+                ('?', _) => self.suggest_format_debug(),
+                ('<' | '^' | '>', _) => self.suggest_format_align(c),
                 _ => self.suggest_positional_arg_instead_of_captured_arg(arg),
             }
         }
@@ -844,6 +848,23 @@ impl<'input> Parser<'input> {
                     span: range,
                     secondary_label: None,
                     suggestion: Suggestion::None,
+                },
+            );
+        }
+    }
+
+    fn missing_colon_before_debug_formatter(&mut self) {
+        if let Some((range, _)) = self.consume_pos('?') {
+            let span = range.clone();
+            self.errors.insert(
+                0,
+                ParseError {
+                    description: "expected `}`, found `?`".to_owned(),
+                    note: Some(format!("to print `{{`, you can escape it using `{{{{`",)),
+                    label: "expected `:` before `?` to format with `Debug`".to_owned(),
+                    span: range,
+                    secondary_label: None,
+                    suggestion: Suggestion::AddMissingColon(span),
                 },
             );
         }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2041,7 +2041,6 @@ symbols! {
         self_in_typedefs,
         self_struct_ctor,
         semiopaque,
-        semitransparent,
         sha2,
         sha3,
         sha512_sm_x86,

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -1053,27 +1053,49 @@ impl<'a, 'tcx> TypeVisitor<TyCtxt<'tcx>> for WfPredicates<'a, 'tcx> {
             }
             ty::ConstKind::Value(val) => {
                 // FIXME(mgca): no need to feature-gate once valtree lifetimes are not erased
-                if tcx.features().min_generic_const_args()
-                    && let ty::Adt(adt_def, args) = val.ty.kind()
-                {
-                    let adt_val = val.destructure_adt_const();
-                    let variant_def = adt_def.variant(adt_val.variant);
-                    let cause = self.cause(ObligationCauseCode::WellFormed(None));
-                    self.out.extend(variant_def.fields.iter().zip(adt_val.fields).map(
-                        |(field_def, &field_val)| {
-                            let field_ty = tcx.type_of(field_def.did).instantiate(tcx, args);
-                            let predicate = ty::PredicateKind::Clause(
-                                ty::ClauseKind::ConstArgHasType(field_val, field_ty),
-                            );
-                            traits::Obligation::with_depth(
-                                tcx,
-                                cause.clone(),
-                                self.recursion_depth,
-                                self.param_env,
-                                predicate,
-                            )
-                        },
-                    ));
+                if tcx.features().min_generic_const_args() {
+                    match val.ty.kind() {
+                        ty::Adt(adt_def, args) => {
+                            let adt_val = val.destructure_adt_const();
+                            let variant_def = adt_def.variant(adt_val.variant);
+                            let cause = self.cause(ObligationCauseCode::WellFormed(None));
+                            self.out.extend(variant_def.fields.iter().zip(adt_val.fields).map(
+                                |(field_def, &field_val)| {
+                                    let field_ty =
+                                        tcx.type_of(field_def.did).instantiate(tcx, args);
+                                    let predicate = ty::PredicateKind::Clause(
+                                        ty::ClauseKind::ConstArgHasType(field_val, field_ty),
+                                    );
+                                    traits::Obligation::with_depth(
+                                        tcx,
+                                        cause.clone(),
+                                        self.recursion_depth,
+                                        self.param_env,
+                                        predicate,
+                                    )
+                                },
+                            ));
+                        }
+                        ty::Tuple(field_tys) => {
+                            let field_vals = val.to_branch();
+                            let cause = self.cause(ObligationCauseCode::WellFormed(None));
+                            self.out.extend(field_tys.iter().zip(field_vals).map(
+                                |(field_ty, &field_val)| {
+                                    let predicate = ty::PredicateKind::Clause(
+                                        ty::ClauseKind::ConstArgHasType(field_val, field_ty),
+                                    );
+                                    traits::Obligation::with_depth(
+                                        tcx,
+                                        cause.clone(),
+                                        self.recursion_depth,
+                                        self.param_env,
+                                        predicate,
+                                    )
+                                },
+                            ));
+                        }
+                        _ => {}
+                    }
                 }
 
                 // FIXME: Enforce that values are structurally-matchable.

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -1051,7 +1051,31 @@ impl<'a, 'tcx> TypeVisitor<TyCtxt<'tcx>> for WfPredicates<'a, 'tcx> {
             | ty::ConstKind::Placeholder(..) => {
                 // These variants are trivially WF, so nothing to do here.
             }
-            ty::ConstKind::Value(..) => {
+            ty::ConstKind::Value(val) => {
+                // FIXME(mgca): no need to feature-gate once valtree lifetimes are not erased
+                if tcx.features().min_generic_const_args()
+                    && let ty::Adt(adt_def, args) = val.ty.kind()
+                {
+                    let adt_val = val.destructure_adt_const();
+                    let variant_def = adt_def.variant(adt_val.variant);
+                    let cause = self.cause(ObligationCauseCode::WellFormed(None));
+                    self.out.extend(variant_def.fields.iter().zip(adt_val.fields).map(
+                        |(field_def, &field_val)| {
+                            let field_ty = tcx.type_of(field_def.did).instantiate(tcx, args);
+                            let predicate = ty::PredicateKind::Clause(
+                                ty::ClauseKind::ConstArgHasType(field_val, field_ty),
+                            );
+                            traits::Obligation::with_depth(
+                                tcx,
+                                cause.clone(),
+                                self.recursion_depth,
+                                self.param_env,
+                                predicate,
+                            )
+                        },
+                    ));
+                }
+
                 // FIXME: Enforce that values are structurally-matchable.
             }
         }

--- a/library/alloctests/tests/lib.rs
+++ b/library/alloctests/tests/lib.rs
@@ -20,6 +20,8 @@
 #![feature(binary_heap_into_iter_sorted)]
 #![feature(binary_heap_drain_sorted)]
 #![feature(slice_ptr_get)]
+#![feature(slice_range)]
+#![feature(slice_partial_sort_unstable)]
 #![feature(inplace_iteration)]
 #![feature(iter_advance_by)]
 #![feature(iter_next_chunk)]

--- a/library/alloctests/tests/sort/mod.rs
+++ b/library/alloctests/tests/sort/mod.rs
@@ -12,6 +12,7 @@ pub trait Sort {
 
 mod ffi_types;
 mod known_good_stable_sort;
+mod partial;
 mod patterns;
 mod tests;
 mod zipf;

--- a/library/alloctests/tests/sort/partial.rs
+++ b/library/alloctests/tests/sort/partial.rs
@@ -1,0 +1,84 @@
+use std::fmt::Debug;
+use std::ops::{Range, RangeBounds};
+use std::slice;
+
+use super::patterns;
+
+fn check_is_partial_sorted<T: Ord + Clone + Debug, R: RangeBounds<usize>>(v: &mut [T], range: R) {
+    let Range { start, end } = slice::range(range, ..v.len());
+    v.partial_sort_unstable(start..end);
+
+    let max_before = v[..start].iter().max().into_iter();
+    let sorted_range = v[start..end].into_iter();
+    let min_after = v[end..].iter().min().into_iter();
+    let seq = max_before.chain(sorted_range).chain(min_after);
+    assert!(seq.is_sorted());
+}
+
+fn check_is_partial_sorted_ranges<T: Ord + Clone + Debug>(v: &[T]) {
+    let len = v.len();
+
+    check_is_partial_sorted::<T, _>(&mut v.to_vec(), ..);
+    check_is_partial_sorted::<T, _>(&mut v.to_vec(), 0..0);
+    check_is_partial_sorted::<T, _>(&mut v.to_vec(), len..len);
+
+    if len > 0 {
+        check_is_partial_sorted::<T, _>(&mut v.to_vec(), len - 1..len - 1);
+        check_is_partial_sorted::<T, _>(&mut v.to_vec(), 0..1);
+        check_is_partial_sorted::<T, _>(&mut v.to_vec(), len - 1..len);
+
+        for mid in 1..len {
+            check_is_partial_sorted::<T, _>(&mut v.to_vec(), 0..mid);
+            check_is_partial_sorted::<T, _>(&mut v.to_vec(), mid..len);
+            check_is_partial_sorted::<T, _>(&mut v.to_vec(), mid..mid);
+            check_is_partial_sorted::<T, _>(&mut v.to_vec(), mid - 1..mid + 1);
+            check_is_partial_sorted::<T, _>(&mut v.to_vec(), mid - 1..mid);
+            check_is_partial_sorted::<T, _>(&mut v.to_vec(), mid..mid + 1);
+        }
+
+        let quarters = [0, len / 4, len / 2, (3 * len) / 4, len];
+        for &start in &quarters {
+            for &end in &quarters {
+                if start < end {
+                    check_is_partial_sorted::<T, _>(&mut v.to_vec(), start..end);
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn basic_impl() {
+    check_is_partial_sorted::<i32, _>(&mut [], ..);
+    check_is_partial_sorted::<(), _>(&mut [], ..);
+    check_is_partial_sorted::<(), _>(&mut [()], ..);
+    check_is_partial_sorted::<(), _>(&mut [(), ()], ..);
+    check_is_partial_sorted::<(), _>(&mut [(), (), ()], ..);
+    check_is_partial_sorted::<i32, _>(&mut [], ..);
+
+    check_is_partial_sorted::<i32, _>(&mut [77], ..);
+    check_is_partial_sorted::<i32, _>(&mut [2, 3], ..);
+    check_is_partial_sorted::<i32, _>(&mut [2, 3, 6], ..);
+    check_is_partial_sorted::<i32, _>(&mut [2, 3, 99, 6], ..);
+    check_is_partial_sorted::<i32, _>(&mut [2, 7709, 400, 90932], ..);
+    check_is_partial_sorted::<i32, _>(&mut [15, -1, 3, -1, -3, -1, 7], ..);
+
+    check_is_partial_sorted::<i32, _>(&mut [15, -1, 3, -1, -3, -1, 7], 0..0);
+    check_is_partial_sorted::<i32, _>(&mut [15, -1, 3, -1, -3, -1, 7], 0..1);
+    check_is_partial_sorted::<i32, _>(&mut [15, -1, 3, -1, -3, -1, 7], 0..5);
+    check_is_partial_sorted::<i32, _>(&mut [15, -1, 3, -1, -3, -1, 7], 0..7);
+    check_is_partial_sorted::<i32, _>(&mut [15, -1, 3, -1, -3, -1, 7], 7..7);
+    check_is_partial_sorted::<i32, _>(&mut [15, -1, 3, -1, -3, -1, 7], 6..7);
+    check_is_partial_sorted::<i32, _>(&mut [15, -1, 3, -1, -3, -1, 7], 5..7);
+    check_is_partial_sorted::<i32, _>(&mut [15, -1, 3, -1, -3, -1, 7], 5..5);
+    check_is_partial_sorted::<i32, _>(&mut [15, -1, 3, -1, -3, -1, 7], 4..5);
+    check_is_partial_sorted::<i32, _>(&mut [15, -1, 3, -1, -3, -1, 7], 4..6);
+}
+
+#[test]
+fn random_patterns() {
+    check_is_partial_sorted_ranges(&patterns::random(10));
+    check_is_partial_sorted_ranges(&patterns::random(50));
+    check_is_partial_sorted_ranges(&patterns::random(100));
+    check_is_partial_sorted_ranges(&patterns::random(1000));
+}

--- a/library/core/src/iter/traits/double_ended.rs
+++ b/library/core/src/iter/traits/double_ended.rs
@@ -334,8 +334,18 @@ pub trait DoubleEndedIterator: Iterator {
     /// ```
     /// let a = [1, 2, 3];
     ///
-    /// assert_eq!(a.iter().rfind(|&&x| x == 2), Some(&2));
+    /// assert_eq!(a.into_iter().rfind(|&x| x == 2), Some(2));
+    /// assert_eq!(a.into_iter().rfind(|&x| x == 5), None);
+    /// ```
     ///
+    /// Iterating over references:
+    ///
+    /// ```
+    /// let a = [1, 2, 3];
+    ///
+    /// // `iter()` yields references i.e. `&i32` and `rfind()` takes a
+    /// // reference to each element.
+    /// assert_eq!(a.iter().rfind(|&&x| x == 2), Some(&2));
     /// assert_eq!(a.iter().rfind(|&&x| x == 5), None);
     /// ```
     ///

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -2858,6 +2858,17 @@ pub trait Iterator {
     /// assert_eq!(a.into_iter().find(|&x| x == 5), None);
     /// ```
     ///
+    /// Iterating over references:
+    ///
+    /// ```
+    /// let a = [1, 2, 3];
+    ///
+    /// // `iter()` yields references i.e. `&i32` and `find()` takes a
+    /// // reference to each element.
+    /// assert_eq!(a.iter().find(|&&x| x == 2), Some(&2));
+    /// assert_eq!(a.iter().find(|&&x| x == 5), None);
+    /// ```
+    ///
     /// Stopping at the first `true`:
     ///
     /// ```

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -168,7 +168,7 @@ macro_rules! assert_ne {
 /// ```
 #[unstable(feature = "assert_matches", issue = "82775")]
 #[allow_internal_unstable(panic_internals)]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro assert_matches {
     ($left:expr, $(|)? $( $pattern:pat_param )|+ $( if $guard: expr )? $(,)?) => {
         match $left {
@@ -401,7 +401,7 @@ macro_rules! debug_assert_ne {
 /// ```
 #[unstable(feature = "assert_matches", issue = "82775")]
 #[allow_internal_unstable(assert_matches)]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro debug_assert_matches($($arg:tt)*) {
     if $crate::cfg!(debug_assertions) {
         $crate::assert_matches::assert_matches!($($arg)*);

--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -20,7 +20,7 @@ use crate::any::Any;
 #[unstable(feature = "edition_panic", issue = "none", reason = "use panic!() instead")]
 #[allow_internal_unstable(panic_internals, const_format_args)]
 #[rustc_diagnostic_item = "core_panic_2015_macro"]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro panic_2015 {
     () => (
         $crate::panicking::panic("explicit panic")
@@ -47,7 +47,7 @@ pub macro panic_2015 {
 #[unstable(feature = "edition_panic", issue = "none", reason = "use panic!() instead")]
 #[allow_internal_unstable(panic_internals, const_format_args)]
 #[rustc_diagnostic_item = "core_panic_2021_macro"]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro panic_2021 {
     () => (
         $crate::panicking::panic("explicit panic")
@@ -67,7 +67,7 @@ pub macro panic_2021 {
 #[unstable(feature = "edition_panic", issue = "none", reason = "use unreachable!() instead")]
 #[allow_internal_unstable(panic_internals)]
 #[rustc_diagnostic_item = "unreachable_2015_macro"]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro unreachable_2015 {
     () => (
         $crate::panicking::panic("internal error: entered unreachable code")
@@ -85,7 +85,7 @@ pub macro unreachable_2015 {
 #[doc(hidden)]
 #[unstable(feature = "edition_panic", issue = "none", reason = "use unreachable!() instead")]
 #[allow_internal_unstable(panic_internals)]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro unreachable_2021 {
     () => (
         $crate::panicking::panic("internal error: entered unreachable code")

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -2027,7 +2027,7 @@ unsafe impl<T: ?Sized> PinCoerceUnsized for *mut T {}
 ///
 /// [`Box::pin`]: ../../std/boxed/struct.Box.html#method.pin
 #[stable(feature = "pin_macro", since = "1.68.0")]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 #[allow_internal_unstable(super_let)]
 #[rustc_diagnostic_item = "pin_macro"]
 // `super` gets removed by rustfmt

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -2662,7 +2662,7 @@ impl<F: FnPtr> fmt::Debug for F {
 /// same requirements apply to field projections, even inside `addr_of!`. (In particular, it makes
 /// no difference whether the pointer is null or dangling.)
 #[stable(feature = "raw_ref_macros", since = "1.51.0")]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro addr_of($place:expr) {
     &raw const $place
 }
@@ -2752,7 +2752,7 @@ pub macro addr_of($place:expr) {
 /// same requirements apply to field projections, even inside `addr_of_mut!`. (In particular, it
 /// makes no difference whether the pointer is null or dangling.)
 #[stable(feature = "raw_ref_macros", since = "1.51.0")]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro addr_of_mut($place:expr) {
     &raw mut $place
 }

--- a/library/core/src/task/ready.rs
+++ b/library/core/src/task/ready.rs
@@ -46,7 +46,7 @@
 /// # }
 /// ```
 #[stable(feature = "ready_macro", since = "1.64.0")]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro ready($e:expr) {
     match $e {
         $crate::task::Poll::Ready(t) => t,

--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -187,7 +187,7 @@ pub struct SimpleMessage {
 ///     Err(FAIL)
 /// }
 /// ```
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 #[unstable(feature = "io_const_error", issue = "133448")]
 #[allow_internal_unstable(hint_must_use, io_const_error_internals)]
 pub macro const_error($kind:expr, $message:expr $(,)?) {

--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -1287,4 +1287,4 @@ pub fn _eprint(args: fmt::Arguments<'_>) {
 }
 
 #[cfg(test)]
-pub use realstd::io::{_eprint, _print};
+pub use realstd::test_internals::{_eprint, _print};

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -255,7 +255,18 @@
 #![allow(unused_features)]
 //
 // Features:
-#![cfg_attr(test, feature(internal_output_capture, print_internals, update_panic_count, rt))]
+#![cfg_attr(
+    test,
+    feature(
+        internal_output_capture,
+        print_internals,
+        update_panic_count,
+        rt,
+        thread_current_internals,
+        thread_local_internals,
+        thread_local_internal_pointer
+    )
+)]
 #![cfg_attr(
     all(target_vendor = "fortanix", target_env = "sgx"),
     feature(slice_index_methods, coerce_unsized, sgx_platform)
@@ -361,6 +372,7 @@
 #![feature(str_internals)]
 #![feature(sync_unsafe_cell)]
 #![feature(temporary_niche_types)]
+#![feature(test_internals)]
 #![feature(ub_checks)]
 #![feature(used_with_arg)]
 // tidy-alphabetical-end
@@ -758,3 +770,8 @@ mod sealed {
 #[cfg(test)]
 #[allow(dead_code)] // Not used in all configurations.
 pub(crate) mod test_helpers;
+
+#[doc(hidden)]
+#[unstable(feature = "test_internals", issue = "none")]
+#[cfg(not(test))]
+pub mod test_internals;

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -212,7 +212,7 @@ impl fmt::Display for PanicHookInfo<'_> {
 #[unstable(feature = "edition_panic", issue = "none", reason = "use panic!() instead")]
 #[allow_internal_unstable(libstd_sys_internals, const_format_args, panic_internals, rt)]
 #[cfg_attr(not(test), rustc_diagnostic_item = "std_panic_2015_macro")]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro panic_2015 {
     () => ({
         $crate::rt::begin_panic("explicit panic")

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -14,7 +14,7 @@ use core::panic::{Location, PanicPayload};
 // make sure to use the stderr output configured
 // by libtest in the real copy of std
 #[cfg(test)]
-use realstd::io::try_set_output_capture;
+use realstd::test_internals::try_set_output_capture;
 
 use crate::any::Any;
 #[cfg(not(test))]
@@ -487,7 +487,7 @@ pub mod panic_count {
 }
 
 #[cfg(test)]
-pub use realstd::rt::panic_count;
+pub use realstd::test_internals::panic_count;
 
 /// Invoke a closure, capturing the cause of an unwinding panic if one occurs.
 #[cfg(panic = "immediate-abort")]

--- a/library/std/src/sys/thread_local/native/mod.rs
+++ b/library/std/src/sys/thread_local/native/mod.rs
@@ -47,7 +47,7 @@ pub use lazy::Storage as LazyStorage;
 )]
 #[allow_internal_unsafe]
 #[unstable(feature = "thread_local_internals", issue = "none")]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro thread_local_inner {
     // NOTE: we cannot import `LocalKey`, `LazyStorage` or `EagerStorage` with a `use` because that
     // can shadow user provided type or type alias with a matching name. Please update the shadowing
@@ -110,7 +110,7 @@ pub macro thread_local_inner {
     }},
 }
 
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub(crate) macro local_pointer {
     () => {},
     ($vis:vis static $name:ident; $($rest:tt)*) => {

--- a/library/std/src/sys/thread_local/native/mod.rs
+++ b/library/std/src/sys/thread_local/native/mod.rs
@@ -114,13 +114,17 @@ pub macro thread_local_inner {
 pub(crate) macro local_pointer {
     () => {},
     ($vis:vis static $name:ident; $($rest:tt)*) => {
+
+        #[doc(hidden)]
+        #[unstable(feature = "thread_local_internal_pointer", issue = "none")]
         #[thread_local]
         $vis static $name: $crate::sys::thread_local::LocalPointer = $crate::sys::thread_local::LocalPointer::__new();
         $crate::sys::thread_local::local_pointer! { $($rest)* }
     },
 }
 
-pub(crate) struct LocalPointer {
+#[allow(missing_debug_implementations)]
+pub struct LocalPointer {
     p: Cell<*mut ()>,
 }
 

--- a/library/std/src/sys/thread_local/no_threads.rs
+++ b/library/std/src/sys/thread_local/no_threads.rs
@@ -9,7 +9,7 @@ use crate::ptr;
 #[allow_internal_unstable(thread_local_internals)]
 #[allow_internal_unsafe]
 #[unstable(feature = "thread_local_internals", issue = "none")]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro thread_local_inner {
     // used to generate the `LocalKey` value for const-initialized thread locals
     (@key $t:ty, $(#[$align_attr:meta])*, const $init:expr) => {{
@@ -119,7 +119,7 @@ impl<T> LazyStorage<T> {
 // SAFETY: the target doesn't have threads.
 unsafe impl<T> Sync for LazyStorage<T> {}
 
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub(crate) macro local_pointer {
     () => {},
     ($vis:vis static $name:ident; $($rest:tt)*) => {

--- a/library/std/src/sys/thread_local/no_threads.rs
+++ b/library/std/src/sys/thread_local/no_threads.rs
@@ -123,12 +123,15 @@ unsafe impl<T> Sync for LazyStorage<T> {}
 pub(crate) macro local_pointer {
     () => {},
     ($vis:vis static $name:ident; $($rest:tt)*) => {
+        #[doc(hidden)]
+        #[unstable(feature = "thread_local_internal_pointer", issue = "none")]
         $vis static $name: $crate::sys::thread_local::LocalPointer = $crate::sys::thread_local::LocalPointer::__new();
         $crate::sys::thread_local::local_pointer! { $($rest)* }
     },
 }
 
-pub(crate) struct LocalPointer {
+#[allow(missing_debug_implementations)]
+pub struct LocalPointer {
     p: Cell<*mut ()>,
 }
 

--- a/library/std/src/sys/thread_local/os.rs
+++ b/library/std/src/sys/thread_local/os.rs
@@ -12,7 +12,7 @@ use crate::ptr::{self, NonNull};
 #[allow_internal_unstable(thread_local_internals)]
 #[allow_internal_unsafe]
 #[unstable(feature = "thread_local_internals", issue = "none")]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro thread_local_inner {
     // NOTE: we cannot import `Storage` or `LocalKey` with a `use` because that can shadow user
     // provided type or type alias with a matching name. Please update the shadowing test in
@@ -261,7 +261,7 @@ unsafe extern "C" fn destroy_value<T: 'static, const ALIGN: usize>(ptr: *mut u8)
     });
 }
 
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub(crate) macro local_pointer {
     () => {},
     ($vis:vis static $name:ident; $($rest:tt)*) => {

--- a/library/std/src/sys/thread_local/os.rs
+++ b/library/std/src/sys/thread_local/os.rs
@@ -265,12 +265,15 @@ unsafe extern "C" fn destroy_value<T: 'static, const ALIGN: usize>(ptr: *mut u8)
 pub(crate) macro local_pointer {
     () => {},
     ($vis:vis static $name:ident; $($rest:tt)*) => {
+        #[doc(hidden)]
+        #[unstable(feature = "thread_local_internal_pointer", issue = "none")]
         $vis static $name: $crate::sys::thread_local::LocalPointer = $crate::sys::thread_local::LocalPointer::__new();
         $crate::sys::thread_local::local_pointer! { $($rest)* }
     },
 }
 
-pub(crate) struct LocalPointer {
+#[allow(missing_debug_implementations)]
+pub struct LocalPointer {
     key: LazyKey,
 }
 

--- a/library/std/src/test_internals.rs
+++ b/library/std/src/test_internals.rs
@@ -1,0 +1,21 @@
+/// A collection of common re-exports to be used by the test version of this crate.
+pub use crate::thread::current::CURRENT as CURRENT_THREAD;
+
+cfg_select! {
+    target_thread_local => {
+        pub use crate::thread::current::id::ID as CURRENT_THREAD_ID;
+    }
+    target_pointer_width = "16" => {
+        pub use crate::thread::current::id::ID0 as CURRENT_THREAD_ID0;
+        pub use crate::thread::current::id::ID16 as CURRENT_THREAD_ID16;
+        pub use crate::thread::current::id::ID32 as CURRENT_THREAD_ID32;
+        pub use crate::thread::current::id::ID48 as CURRENT_THREAD_ID48;
+    }
+    target_pointer_width = "32" => {
+        pub use crate::thread::current::id::ID0 as CURRENT_THREAD_ID0;
+        pub use crate::thread::current::id::ID32 as CURRENT_THREAD_ID32;
+    }
+    _ => {
+        pub use crate::thread::current::id::ID as CURRENT_THREAD_ID;
+    }
+}

--- a/library/std/src/test_internals.rs
+++ b/library/std/src/test_internals.rs
@@ -1,4 +1,6 @@
 /// A collection of common re-exports to be used by the test version of this crate.
+pub use crate::io::{_eprint, _print, try_set_output_capture};
+pub use crate::rt::panic_count;
 pub use crate::thread::current::CURRENT as CURRENT_THREAD;
 
 cfg_select! {

--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -140,7 +140,7 @@ impl<T: 'static> fmt::Debug for LocalKey<T> {
 #[doc(hidden)]
 #[allow_internal_unstable(thread_local_internals)]
 #[unstable(feature = "thread_local_internals", issue = "none")]
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 pub macro thread_local_process_attrs {
 
     // Parse `cfg_attr` to figure out whether it's a `rustc_align_static`.

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -161,7 +161,9 @@ use crate::any::Any;
 #[macro_use]
 mod local;
 mod builder;
-mod current;
+#[doc(hidden)]
+#[unstable(feature = "thread_current_internals", issue = "none")]
+pub(crate) mod current;
 mod functions;
 mod id;
 mod join_handle;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "browser-ui-test": "^0.23.0",
+    "browser-ui-test": "^0.23.1",
     "es-check": "^9.4.4",
     "eslint": "^8.57.1",
     "typescript": "^5.8.3"

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1200,9 +1200,11 @@ nav.sub {
 	display: initial;
 }
 .anchor {
+	--anchor-link-shift: 0.5em;
 	display: none;
 	position: absolute;
-	left: -0.5em;
+	left: calc(var(--anchor-link-shift) * -1);
+	padding-right: var(--anchor-link-shift);
 	background: none !important;
 }
 .anchor.field {

--- a/src/tools/rust-analyzer/crates/hir-def/src/expr_store/expander.rs
+++ b/src/tools/rust-analyzer/crates/hir-def/src/expr_store/expander.rs
@@ -61,7 +61,7 @@ impl Expander {
     pub(super) fn hygiene_for_range(&self, db: &dyn DefDatabase, range: TextRange) -> HygieneId {
         match self.span_map.as_ref() {
             hir_expand::span_map::SpanMapRef::ExpansionSpanMap(span_map) => {
-                HygieneId::new(span_map.span_at(range.start()).ctx.opaque_and_semitransparent(db))
+                HygieneId::new(span_map.span_at(range.start()).ctx.opaque_and_semiopaque(db))
             }
             hir_expand::span_map::SpanMapRef::RealSpanMap(_) => HygieneId::ROOT,
         }

--- a/src/tools/rust-analyzer/crates/hir-def/src/expr_store/lower.rs
+++ b/src/tools/rust-analyzer/crates/hir-def/src/expr_store/lower.rs
@@ -2546,7 +2546,7 @@ impl<'db> ExprCollector<'db> {
                         // Therefore, if we got to the rib of its declaration, give up its hygiene
                         // and use its parent expansion.
 
-                        hygiene_id = HygieneId::new(parent_ctx.opaque_and_semitransparent(self.db));
+                        hygiene_id = HygieneId::new(parent_ctx.opaque_and_semiopaque(self.db));
                         hygiene_info = parent_ctx.outer_expn(self.db).map(|expansion| {
                             let expansion = self.db.lookup_intern_macro_call(expansion.into());
                             (parent_ctx.parent(self.db), expansion.def)

--- a/src/tools/rust-analyzer/crates/hir-def/src/resolver.rs
+++ b/src/tools/rust-analyzer/crates/hir-def/src/resolver.rs
@@ -936,7 +936,7 @@ fn handle_macro_def_scope(
         // A macro is allowed to refer to variables from before its declaration.
         // Therefore, if we got to the rib of its declaration, give up its hygiene
         // and use its parent expansion.
-        *hygiene_id = HygieneId::new(parent_ctx.opaque_and_semitransparent(db));
+        *hygiene_id = HygieneId::new(parent_ctx.opaque_and_semiopaque(db));
         *hygiene_info = parent_ctx.outer_expn(db).map(|expansion| {
             let expansion = db.lookup_intern_macro_call(expansion.into());
             (parent_ctx.parent(db), expansion.def)

--- a/src/tools/rust-analyzer/crates/hir-expand/src/declarative.rs
+++ b/src/tools/rust-analyzer/crates/hir-expand/src/declarative.rs
@@ -100,7 +100,8 @@ impl DeclarativeMacroExpander {
                     {
                         match &*value {
                             "transparent" => ControlFlow::Break(Transparency::Transparent),
-                            "semitransparent" => ControlFlow::Break(Transparency::SemiTransparent),
+                            // "semitransparent" is for old rustc versions.
+                            "semiopaque" | "semitransparent" => ControlFlow::Break(Transparency::SemiOpaque),
                             "opaque" => ControlFlow::Break(Transparency::Opaque),
                             _ => ControlFlow::Continue(()),
                         }
@@ -140,7 +141,7 @@ impl DeclarativeMacroExpander {
                     )),
                 },
                 transparency(ast::AnyHasAttrs::from(macro_rules))
-                    .unwrap_or(Transparency::SemiTransparent),
+                    .unwrap_or(Transparency::SemiOpaque),
             ),
             ast::Macro::MacroDef(macro_def) => (
                 match macro_def.body() {

--- a/src/tools/rust-analyzer/crates/hir-expand/src/hygiene.rs
+++ b/src/tools/rust-analyzer/crates/hir-expand/src/hygiene.rs
@@ -54,7 +54,7 @@ pub fn span_with_mixed_site_ctxt(
     expn_id: MacroCallId,
     edition: Edition,
 ) -> Span {
-    span_with_ctxt_from_mark(db, span, expn_id, Transparency::SemiTransparent, edition)
+    span_with_ctxt_from_mark(db, span, expn_id, Transparency::SemiOpaque, edition)
 }
 
 fn span_with_ctxt_from_mark(
@@ -82,7 +82,7 @@ pub(super) fn apply_mark(
     }
 
     let call_site_ctxt = db.lookup_intern_macro_call(call_id.into()).ctxt;
-    let mut call_site_ctxt = if transparency == Transparency::SemiTransparent {
+    let mut call_site_ctxt = if transparency == Transparency::SemiOpaque {
         call_site_ctxt.normalize_to_macros_2_0(db)
     } else {
         call_site_ctxt.normalize_to_macro_rules(db)
@@ -117,16 +117,16 @@ fn apply_mark_internal(
     let call_id = Some(call_id);
 
     let mut opaque = ctxt.opaque(db);
-    let mut opaque_and_semitransparent = ctxt.opaque_and_semitransparent(db);
+    let mut opaque_and_semiopaque = ctxt.opaque_and_semiopaque(db);
 
     if transparency >= Transparency::Opaque {
         let parent = opaque;
         opaque = SyntaxContext::new(db, call_id, transparency, edition, parent, identity, identity);
     }
 
-    if transparency >= Transparency::SemiTransparent {
-        let parent = opaque_and_semitransparent;
-        opaque_and_semitransparent =
+    if transparency >= Transparency::SemiOpaque {
+        let parent = opaque_and_semiopaque;
+        opaque_and_semiopaque =
             SyntaxContext::new(db, call_id, transparency, edition, parent, |_| opaque, identity);
     }
 
@@ -138,6 +138,6 @@ fn apply_mark_internal(
         edition,
         parent,
         |_| opaque,
-        |_| opaque_and_semitransparent,
+        |_| opaque_and_semiopaque,
     )
 }

--- a/src/tools/rust-analyzer/crates/hir-expand/src/inert_attr_macro.rs
+++ b/src/tools/rust-analyzer/crates/hir-expand/src/inert_attr_macro.rs
@@ -429,7 +429,7 @@ pub const INERT_ATTRIBUTES: &[BuiltinAttribute] = &[
     rustc_attr!(rustc_proc_macro_decls, Normal, template!(Word), WarnFollowing, INTERNAL_UNSTABLE),
     rustc_attr!(
         rustc_macro_transparency, Normal,
-        template!(NameValueStr: "transparent|semitransparent|opaque"), ErrorFollowing,
+        template!(NameValueStr: "transparent|semiopaque|opaque"), ErrorFollowing,
         "used internally for testing macro hygiene",
     ),
 

--- a/src/tools/rust-analyzer/crates/hir-expand/src/mod_path.rs
+++ b/src/tools/rust-analyzer/crates/hir-expand/src/mod_path.rs
@@ -401,8 +401,8 @@ pub fn resolve_crate_root(db: &dyn ExpandDatabase, mut ctxt: SyntaxContext) -> O
         result_mark = Some(mark);
         iter.next();
     }
-    // Then find the last semi-transparent mark from the end if it exists.
-    while let Some((mark, Transparency::SemiTransparent)) = iter.next() {
+    // Then find the last semi-opaque mark from the end if it exists.
+    while let Some((mark, Transparency::SemiOpaque)) = iter.next() {
         result_mark = Some(mark);
     }
 

--- a/src/tools/rust-analyzer/crates/hir-ty/src/tests/simple.rs
+++ b/src/tools/rust-analyzer/crates/hir-ty/src/tests/simple.rs
@@ -3708,7 +3708,7 @@ fn main() {
 }
 
 #[test]
-fn macro_semitransparent_hygiene() {
+fn macro_semiopaque_hygiene() {
     check_types(
         r#"
 macro_rules! m {

--- a/src/tools/rust-analyzer/crates/hir/src/source_analyzer.rs
+++ b/src/tools/rust-analyzer/crates/hir/src/source_analyzer.rs
@@ -1808,5 +1808,5 @@ pub(crate) fn name_hygiene(db: &dyn HirDatabase, name: InFile<&SyntaxNode>) -> H
     };
     let span_map = db.expansion_span_map(macro_file);
     let ctx = span_map.span_at(name.value.text_range().start()).ctx;
-    HygieneId::new(ctx.opaque_and_semitransparent(db))
+    HygieneId::new(ctx.opaque_and_semiopaque(db))
 }

--- a/src/tools/rust-analyzer/crates/intern/src/symbol/symbols.rs
+++ b/src/tools/rust-analyzer/crates/intern/src/symbol/symbols.rs
@@ -442,7 +442,6 @@ define_symbols! {
     rustc_skip_array_during_method_dispatch,
     rustc_skip_during_method_dispatch,
     rustc_force_inline,
-    semitransparent,
     shl_assign,
     shl,
     shr_assign,

--- a/src/tools/rust-analyzer/crates/test-utils/src/minicore.rs
+++ b/src/tools/rust-analyzer/crates/test-utils/src/minicore.rs
@@ -546,11 +546,11 @@ pub mod ptr {
     // endregion:non_null
 
     // region:addr_of
-    #[rustc_macro_transparency = "semitransparent"]
+    #[rustc_macro_transparency = "semiopaque"]
     pub macro addr_of($place:expr) {
         &raw const $place
     }
-    #[rustc_macro_transparency = "semitransparent"]
+    #[rustc_macro_transparency = "semiopaque"]
     pub macro addr_of_mut($place:expr) {
         &raw mut $place
     }

--- a/tests/assembly-llvm/rust-abi-arg-attr.rs
+++ b/tests/assembly-llvm/rust-abi-arg-attr.rs
@@ -1,3 +1,4 @@
+//@ add-minicore
 //@ assembly-output: emit-asm
 //@ revisions: riscv64 riscv64-zbb loongarch64
 //@ compile-flags: -C opt-level=3
@@ -14,45 +15,8 @@
 #![no_std]
 #![no_core]
 // FIXME: Migrate these code after PR #130693 is landed.
-
-#[lang = "pointee_sized"]
-pub trait PointeeSized {}
-
-#[lang = "meta_sized"]
-pub trait MetaSized: PointeeSized {}
-
-#[lang = "sized"]
-pub trait Sized: MetaSized {}
-
-#[lang = "copy"]
-trait Copy {}
-
-impl Copy for i8 {}
-impl Copy for u32 {}
-impl Copy for i32 {}
-
-#[lang = "neg"]
-trait Neg {
-    type Output;
-
-    fn neg(self) -> Self::Output;
-}
-
-impl Neg for i8 {
-    type Output = i8;
-
-    fn neg(self) -> Self::Output {
-        -self
-    }
-}
-
-#[lang = "Ordering"]
-#[repr(i8)]
-enum Ordering {
-    Less = -1,
-    Equal = 0,
-    Greater = 1,
-}
+extern crate minicore;
+use minicore::*;
 
 #[rustc_intrinsic]
 fn three_way_compare<T: Copy>(lhs: T, rhs: T) -> Ordering;

--- a/tests/auxiliary/minicore.rs
+++ b/tests/auxiliary/minicore.rs
@@ -210,6 +210,14 @@ impl Neg for isize {
     }
 }
 
+impl Neg for i8 {
+    type Output = i8;
+
+    fn neg(self) -> i8 {
+        loop {}
+    }
+}
+
 #[lang = "sync"]
 trait Sync {}
 impl_marker_trait!(
@@ -279,6 +287,16 @@ pub enum c_void {
     __variant1,
     __variant2,
 }
+
+#[lang = "Ordering"]
+#[repr(i8)]
+pub enum Ordering {
+    Less = -1,
+    Equal = 0,
+    Greater = 1,
+}
+
+impl Copy for Ordering {}
 
 #[lang = "const_param_ty"]
 #[diagnostic::on_unimplemented(message = "`{Self}` can't be used as a const parameter type")]

--- a/tests/rustdoc-gui/anchor-navigable.goml
+++ b/tests/rustdoc-gui/anchor-navigable.goml
@@ -7,5 +7,5 @@
 go-to: "file://" + |DOC_PATH| + "/test_docs/struct.Foo.html"
 // We check that ".item-info" is bigger than its content.
 move-cursor-to: ".impl"
-assert-property: (".impl > a.anchor", {"offsetWidth": "8"})
+assert-property: (".impl > a.anchor", {"offsetWidth": "16"})
 assert-css: (".impl > a.anchor", {"left": "-8px"})

--- a/tests/rustdoc-gui/anchors.goml
+++ b/tests/rustdoc-gui/anchors.goml
@@ -45,6 +45,22 @@ define-function: (
             {"color": |src_link_color|, "text-decoration": "none"},
         )
 
+        // Now we ensure that the `§` anchor is "reachable" for users on trait methods.
+        // To ensure the anchor is not hovered, we move the cursor to another item.
+        move-cursor-to: "#search-button"
+        // By default, the anchor is not displayed.
+        wait-for-css: ("#method\.vroum .anchor", {"display": "none"})
+        // Once we move the cursor to the method, the anchor should appear.
+        move-cursor-to: "#method\.vroum .code-header"
+        assert-css-false: ("#method\.vroum .anchor", {"display": "none"})
+        // Now we move the cursor to the anchor to check there is no gap between the method and the
+        // anchor, making the anchor disappear and preventing users to click on it.
+        // To make it work, we need to first move it between the method and the anchor.
+        store-position: ("#method\.vroum .code-header", {"x": method_x, "y": method_y})
+        move-cursor-to: (|method_x| - 2, |method_y|)
+        // Anchor should still be displayed.
+        assert-css-false: ("#method\.vroum .anchor", {"display": "none"})
+
         go-to: "file://" + |DOC_PATH| + "/test_docs/struct.HeavilyDocumentedStruct.html"
         // Since we changed page, we need to set the theme again.
         call-function: ("switch-theme", {"theme": |theme|})

--- a/tests/rustdoc-gui/anchors.goml
+++ b/tests/rustdoc-gui/anchors.goml
@@ -14,9 +14,9 @@ define-function: (
         assert-css: ("#toggle-all-docs", {"color": |main_color|})
         assert-css: (".main-heading h1 span", {"color": |main_heading_type_color|})
         assert-css: (
-             ".rightside a.src",
-             {"color": |src_link_color|, "text-decoration": "none"},
-             ALL,
+            ".rightside a.src",
+            {"color": |src_link_color|, "text-decoration": "none"},
+            ALL,
         )
         compare-elements-css: (
             ".rightside a.src",
@@ -31,25 +31,23 @@ define-function: (
 
         move-cursor-to: ".main-heading a.src"
         assert-css: (
-             ".main-heading a.src",
-             {"color": |src_link_color|, "text-decoration": "underline"},
+            ".main-heading a.src",
+            {"color": |src_link_color|, "text-decoration": "underline"},
         )
         move-cursor-to: ".impl-items .rightside a.src"
         assert-css: (
-             ".impl-items .rightside a.src",
-             {"color": |src_link_color|, "text-decoration": "none"},
+            ".impl-items .rightside a.src",
+            {"color": |src_link_color|, "text-decoration": "none"},
         )
         move-cursor-to: ".impl-items a.rightside.src"
         assert-css: (
-             ".impl-items a.rightside.src",
-             {"color": |src_link_color|, "text-decoration": "none"},
+            ".impl-items a.rightside.src",
+            {"color": |src_link_color|, "text-decoration": "none"},
         )
 
         go-to: "file://" + |DOC_PATH| + "/test_docs/struct.HeavilyDocumentedStruct.html"
         // Since we changed page, we need to set the theme again.
-        set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
-        // We reload the page so the local storage settings are being used.
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
 
         assert-css: ("#top-doc-prose-title", {"color": |title_color|})
 

--- a/tests/rustdoc-gui/copy-code.goml
+++ b/tests/rustdoc-gui/copy-code.goml
@@ -1,5 +1,6 @@
 // Checks that the "copy code" button is not triggering JS error and its display
 // isn't broken.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/fn.foo.html"
 
 define-function: (
@@ -47,15 +48,15 @@ assert: |copy_height| > 0 && |copy_width| > 0
 
 // First we ensure that the clipboard is empty.
 assert-clipboard: ""
+
 // We make the line numbers appear.
-click: "rustdoc-toolbar .settings-menu"
-wait-for-css: ("#settings", {"display": "block"})
-// We make the line numbers appear.
+call-function: ("open-settings-menu", {})
 click: "#line-numbers"
 wait-for-local-storage: {"rustdoc-line-numbers": "true" }
+
 // We close the settings menu.
-click: "rustdoc-toolbar .settings-menu"
-wait-for-css-false: ("#settings", {"display": "block"})
+call-function: ("close-settings-menu", {})
+
 // We ensure that there are actually line numbers generated in the DOM.
 assert-text: (".example-wrap pre.rust code span[data-nosnippet]", "1")
 // We make the copy button appear.

--- a/tests/rustdoc-gui/font-serif-change.goml
+++ b/tests/rustdoc-gui/font-serif-change.goml
@@ -1,4 +1,5 @@
 // Ensures that the font serif change is working as expected.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 
 // By default, it should be the serif fonts.
@@ -8,8 +9,7 @@ assert-css: ("body", {"font-family": |serif_font|})
 assert-css: ("p code", {"font-family": |serif_code_font|})
 
 // We now switch to the sans serif font
-click: "main .settings-menu"
-wait-for: "#sans-serif-fonts"
+call-function: ("open-settings-menu", {})
 click: "#sans-serif-fonts"
 
 store-value: (font, '"Fira Sans", sans-serif')
@@ -23,8 +23,7 @@ assert-css: ("body", {"font-family": |font|})
 assert-css: ("p code", {"font-family": |code_font|})
 
 // We switch back to the serif font
-click: "main .settings-menu"
-wait-for: "#sans-serif-fonts"
+call-function: ("open-settings-menu", {})
 click: "#sans-serif-fonts"
 
 assert-css: ("body", {"font-family": |serif_font|})

--- a/tests/rustdoc-gui/notable-trait.goml
+++ b/tests/rustdoc-gui/notable-trait.goml
@@ -82,15 +82,15 @@ call-function: ("check-notable-tooltip-position", {
     "i_x": 528,
 })
 
+go-to: "file://" + |DOC_PATH| + "/test_docs/struct.NotableStructWithLongName.html"
+// This is needed to ensure that the text color is computed.
+show-text: true
+
 // Now check the colors.
 define-function: (
     "check-colors",
     [theme, header_color, content_color, type_color, trait_color, link_color],
     block {
-        go-to: "file://" + |DOC_PATH| + "/test_docs/struct.NotableStructWithLongName.html"
-        // This is needed to ensure that the text color is computed.
-        show-text: true
-
         call-function: ("switch-theme", {"theme": |theme|})
 
         assert-css: (
@@ -251,7 +251,6 @@ reload:
 assert-count: ("//*[@class='tooltip popover']", 0)
 click: "//*[@id='method.create_an_iterator_from_read']//*[@class='tooltip']"
 assert-count: ("//*[@class='tooltip popover']", 1)
-click: "rustdoc-toolbar .settings-menu a"
-wait-for: "#settings"
+call-function: ("open-settings-menu", {})
 assert-count: ("//*[@class='tooltip popover']", 0)
 assert-false: "#method\.create_an_iterator_from_read .tooltip:focus"

--- a/tests/rustdoc-gui/search-filter.goml
+++ b/tests/rustdoc-gui/search-filter.goml
@@ -70,9 +70,7 @@ assert-css: ("#crate-search", {
 })
 
 // We now check the dark theme.
-click: "rustdoc-toolbar .settings-menu"
-wait-for: "#settings"
-click: "#theme-dark"
+call-function: ("switch-theme", {"theme": "dark"})
 wait-for-css: ("#crate-search", {
     "border": "1px solid #e0e0e0",
     "color": "#ddd",
@@ -80,7 +78,7 @@ wait-for-css: ("#crate-search", {
 })
 
 // And finally we check the ayu theme.
-click: "#theme-ayu"
+call-function: ("switch-theme", {"theme": "ayu"})
 wait-for-css: ("#crate-search", {
     "border": "1px solid #5c6773",
     "color": "#c5c5c5",

--- a/tests/rustdoc-gui/setting-auto-hide-content-large-items.goml
+++ b/tests/rustdoc-gui/setting-auto-hide-content-large-items.goml
@@ -1,6 +1,8 @@
 // This test ensures that the "Auto-hide item contents for large items" setting is working as
 // expected.
 
+include: "utils.goml"
+
 // We need to disable this check because `trait.impl/test_docs/trait.Iterator.js` doesn't exist.
 fail-on-request-error: false
 
@@ -9,8 +11,7 @@ define-function: (
     [storage_value, setting_attribute_value, toggle_attribute_value],
     block {
         assert-local-storage: {"rustdoc-auto-hide-large-items": |storage_value|}
-        click: "rustdoc-toolbar .settings-menu"
-        wait-for: "#settings"
+        call-function: ("open-settings-menu", {})
         assert-property: ("#auto-hide-large-items", {"checked": |setting_attribute_value|})
         assert-attribute: (".item-decl .type-contents-toggle", {"open": |toggle_attribute_value|})
     }

--- a/tests/rustdoc-gui/setting-auto-hide-item-methods-docs.goml
+++ b/tests/rustdoc-gui/setting-auto-hide-item-methods-docs.goml
@@ -1,13 +1,14 @@
 // This test ensures that the "Auto-hide item methods' documentation" setting is working as
 // expected.
 
+include: "utils.goml"
+
 define-function: (
     "check-setting",
     [storage_value, setting_attribute_value, toggle_attribute_value],
     block {
         assert-local-storage: {"rustdoc-auto-hide-method-docs": |storage_value|}
-        click: "rustdoc-toolbar .settings-menu"
-        wait-for: "#settings"
+        call-function: ("open-settings-menu", {})
         assert-property: ("#auto-hide-method-docs", {"checked": |setting_attribute_value|})
         assert-attribute: (".toggle.method-toggle", {"open": |toggle_attribute_value|})
     }

--- a/tests/rustdoc-gui/setting-auto-hide-trait-implementations.goml
+++ b/tests/rustdoc-gui/setting-auto-hide-trait-implementations.goml
@@ -1,12 +1,13 @@
 // Checks that the setting "auto hide trait implementations" is working as expected.
 
+include: "utils.goml"
+
 define-function: (
     "check-setting",
     [storage_value, setting_attribute_value, toggle_attribute_value],
     block {
         assert-local-storage: {"rustdoc-auto-hide-trait-implementations": |storage_value|}
-        click: "rustdoc-toolbar .settings-menu"
-        wait-for: "#settings"
+        call-function: ("open-settings-menu", {})
         assert-property: ("#auto-hide-trait-implementations", {"checked": |setting_attribute_value|})
         assert-attribute: ("#trait-implementations-list > details", {"open": |toggle_attribute_value|}, ALL)
     }

--- a/tests/rustdoc-gui/setting-go-to-only-result.goml
+++ b/tests/rustdoc-gui/setting-go-to-only-result.goml
@@ -1,12 +1,14 @@
-// Checks that the setting "Directly go to item in search if there is only one result " is working as expected.
+// Checks that the setting "Directly go to item in search if there is only one result " is working
+// as expected.
+
+include: "utils.goml"
 
 define-function: (
     "check-setting",
     [storage_value, setting_attribute_value],
     block {
         assert-local-storage: {"rustdoc-go-to-only-result": |storage_value|}
-        click: "rustdoc-toolbar .settings-menu"
-        wait-for: "#settings"
+        call-function: ("open-settings-menu", {})
         assert-property: ("#go-to-only-result", {"checked": |setting_attribute_value|})
     }
 )
@@ -25,8 +27,7 @@ wait-for: "#search"
 assert-document-property: ({"URL": "/lib2/index.html"}, CONTAINS)
 
 // Now we change its value.
-click: "rustdoc-toolbar .settings-menu"
-wait-for: "#settings"
+call-function: ("open-settings-menu", {})
 click: "#go-to-only-result"
 assert-local-storage: {"rustdoc-go-to-only-result": "true"}
 

--- a/tests/rustdoc-gui/settings.goml
+++ b/tests/rustdoc-gui/settings.goml
@@ -1,20 +1,18 @@
 // This test ensures that the settings menu display is working as expected and that
 // the settings page is also rendered as expected.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 show-text: true // needed when we check for colors below.
 // First, we check that the settings page doesn't exist.
 assert-false: "#settings"
-// We now click on the settings button.
-click: "rustdoc-toolbar .settings-menu"
-wait-for: "#settings"
+call-function: ("open-settings-menu", {})
 assert-css: ("#settings", {"display": "block"})
 
 // Store the line margin to compare with the settings.html later.
 store-css: (".setting-line", {"margin": setting_line_margin})
 
 // Let's close it by clicking on the same button.
-click: "rustdoc-toolbar .settings-menu"
-wait-for-css: ("#settings", {"display": "none"})
+call-function: ("close-settings-menu", {})
 
 // Let's check that pressing "ESCAPE" is closing it.
 click: "rustdoc-toolbar .settings-menu"
@@ -28,8 +26,7 @@ write: "test"
 // To be SURE that the search will be run.
 press-key: 'Enter'
 wait-for: "#alternative-display #search"
-click: "rustdoc-toolbar .settings-menu"
-wait-for-css: ("#settings", {"display": "block"})
+call-function: ("open-settings-menu", {})
 // Ensure that the search is still displayed.
 wait-for: "#alternative-display #search"
 assert: "#main-content.hidden"
@@ -41,8 +38,7 @@ set-local-storage: {"rustdoc-theme": "dark", "rustdoc-use-system-theme": "false"
 // We reload the page so the local storage settings are being used.
 reload:
 
-click: "rustdoc-toolbar .settings-menu"
-wait-for: "#settings"
+call-function: ("open-settings-menu", {})
 
 // We check that the "Use system theme" is disabled.
 assert-property: ("#theme-system-preference", {"checked": "false"})

--- a/tests/rustdoc-gui/sidebar-mobile.goml
+++ b/tests/rustdoc-gui/sidebar-mobile.goml
@@ -65,8 +65,7 @@ define-function: (
     "check-colors",
     [theme, color, background],
     block {
-        call-function: ("switch-theme-mobile", {"theme": |theme|})
-        reload:
+        call-function: ("switch-theme", {"theme": |theme|})
 
         // Open the sidebar menu.
         click: ".sidebar-menu-toggle"
@@ -85,14 +84,4 @@ call-function: ("check-colors", {
     "theme": "ayu",
     "color": "#c5c5c5",
     "background": "#14191f",
-})
-call-function: ("check-colors", {
-    "theme": "dark",
-    "color": "#ddd",
-    "background": "#505050",
-})
-call-function: ("check-colors", {
-    "theme": "light",
-    "color": "black",
-    "background": "#F5F5F5",
 })

--- a/tests/rustdoc-gui/sidebar-resize-close-popover.goml
+++ b/tests/rustdoc-gui/sidebar-resize-close-popover.goml
@@ -1,9 +1,9 @@
 // Checks sidebar resizing close the Settings popover
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 assert-property: (".sidebar", {"clientWidth": "199"})
 show-text: true
-click: "rustdoc-toolbar .settings-menu"
-wait-for: "#settings"
+call-function: ("open-settings-menu", {})
 assert-css: ("#settings", {"display": "block"})
 // normal resizing
 drag-and-drop: ((205, 100), (185, 100))
@@ -12,8 +12,7 @@ assert-css: ("#settings", {"display": "none"})
 
 // Now same thing, but for source code
 go-to: "file://" + |DOC_PATH| + "/src/test_docs/lib.rs.html"
-click: "rustdoc-toolbar .settings-menu"
-wait-for: "#settings"
+call-function: ("open-settings-menu", {})
 assert-css: ("#settings", {"display": "block"})
 assert-property: (".sidebar", {"clientWidth": "49"})
 drag-and-drop: ((52, 100), (185, 100))

--- a/tests/rustdoc-gui/sidebar-resize-setting.goml
+++ b/tests/rustdoc-gui/sidebar-resize-setting.goml
@@ -1,11 +1,11 @@
 // Checks sidebar resizing stays synced with the setting
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 assert-property: (".sidebar", {"clientWidth": "199"})
 show-text: true
 
 // Verify that the "hide" option is unchecked
-click: "rustdoc-toolbar .settings-menu"
-wait-for: "#settings"
+call-function: ("open-settings-menu", {})
 assert-css: ("#settings", {"display": "block"})
 assert-property: ("#hide-sidebar", {"checked": "false"})
 press-key: "Escape"

--- a/tests/rustdoc-gui/source-code-wrapping.goml
+++ b/tests/rustdoc-gui/source-code-wrapping.goml
@@ -1,4 +1,5 @@
 // Checks that the interactions with the source code pages are working as expected.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/src/test_docs/lib.rs.html"
 show-text: true
 set-window-size: (1000, 1000)
@@ -13,8 +14,7 @@ define-function: (
 )
 
 store-size: (".rust code", {"width": width, "height": height})
-click: "main .settings-menu"
-wait-for: "#settings"
+call-function: ("open-settings-menu", {})
 call-function: ("click-code-wrapping", {"expected": "true"})
 wait-for-size-false: (".rust code", {"width": |width|, "height": |height|})
 store-size: (".rust code", {"width": new_width, "height": new_height})
@@ -28,8 +28,7 @@ assert-size: (".rust code", {"width": |width|, "height": |height|})
 
 // Now let's check in docs code examples.
 go-to: "file://" + |DOC_PATH| + "/test_docs/trait_bounds/index.html"
-click: "main .settings-menu"
-wait-for: "#settings"
+call-function: ("open-settings-menu", {})
 
 store-property: (".example-wrap .rust code", {"scrollWidth": rust_width, "scrollHeight": rust_height})
 store-property: (".example-wrap .language-text code", {"scrollWidth": txt_width, "scrollHeight": txt_height})

--- a/tests/rustdoc-gui/src/staged_api/lib.rs
+++ b/tests/rustdoc-gui/src/staged_api/lib.rs
@@ -4,6 +4,10 @@
 #![stable(feature = "some_feature", since = "1.3.5")]
 #![doc(rust_logo)]
 
+pub trait X {
+    fn vroum();
+}
+
 #[stable(feature = "some_feature", since = "1.3.5")]
 pub struct Foo {}
 
@@ -12,4 +16,8 @@ impl Foo {
     pub fn bar() {}
     #[stable(feature = "some_other_feature", since = "1.3.6")]
     pub fn yo() {}
+}
+
+impl X for Foo {
+    fn vroum() {}
 }

--- a/tests/rustdoc-gui/theme-change.goml
+++ b/tests/rustdoc-gui/theme-change.goml
@@ -7,8 +7,7 @@ store-value: (background_light, "white")
 store-value: (background_dark, "#353535")
 store-value: (background_ayu, "#0f1419")
 
-click: "rustdoc-toolbar .settings-menu"
-wait-for: "#theme-ayu"
+call-function: ("open-settings-menu", {})
 click: "#theme-ayu"
 // should be the ayu theme so let's check the color.
 wait-for-css: ("body", { "background-color": |background_ayu| })
@@ -22,10 +21,6 @@ click: "#theme-dark"
 wait-for-css: ("body", { "background-color": |background_dark| })
 assert-local-storage: { "rustdoc-theme": "dark" }
 
-set-local-storage: {
-    "rustdoc-preferred-light-theme": "light",
-    "rustdoc-preferred-dark-theme": "light",
-}
 go-to: "file://" + |DOC_PATH| + "/settings.html"
 
 wait-for: "#settings"
@@ -75,8 +70,7 @@ store-value: (background_dark, "#353535")
 store-value: (background_ayu, "#0f1419")
 store-value: (background_custom_theme, "red")
 
-click: "rustdoc-toolbar .settings-menu"
-wait-for: "#theme-ayu"
+call-function: ("open-settings-menu", {})
 click: "#theme-ayu"
 // should be the ayu theme so let's check the color.
 wait-for-css: ("body", { "background-color": |background_ayu| })

--- a/tests/rustdoc-gui/theme-defaults.goml
+++ b/tests/rustdoc-gui/theme-defaults.goml
@@ -1,7 +1,7 @@
 // Ensure that the theme picker always starts with the actual defaults.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
-click: "rustdoc-toolbar .settings-menu"
-wait-for: "#theme-system-preference"
+call-function: ("open-settings-menu", {})
 assert: "#theme-system-preference:checked"
 assert: "#preferred-light-theme-light:checked"
 assert: "#preferred-dark-theme-dark:checked"
@@ -16,8 +16,7 @@ set-local-storage: {
     "rustdoc-theme": "ayu"
 }
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
-click: "rustdoc-toolbar .settings-menu"
-wait-for: "#theme-system-preference"
+call-function: ("open-settings-menu", {})
 assert: "#theme-system-preference:checked"
 assert: "#preferred-light-theme-light:checked"
 assert-false: "#preferred-dark-theme-dark:checked"

--- a/tests/rustdoc-gui/utils.goml
+++ b/tests/rustdoc-gui/utils.goml
@@ -1,11 +1,35 @@
 // This file contains code to be re-used by other tests.
 
 define-function: (
+    "click-settings-button",
+    [],
+    block {
+        store-count: ("rustdoc-topbar", __topbar_count)
+        store-value: (__topbar_display, "none")
+        // The `rustdoc-topbar` element is created with JS when the window size is below a given
+        // size, however if the window size gets bigger again, the element isn't deleted, just
+        // hidden, so we need to check for both that it exists and is visible.
+        if: (|__topbar_count| != 0, block {
+            store-css: ("rustdoc-topbar", {"display": __topbar_display})
+        })
+
+        // Open the settings menu.
+        if: (|__topbar_display| != "none", block {
+            // In mobile mode, this is instead the "topbar" the settings button is located into.
+            click: "rustdoc-topbar .settings-menu"
+        })
+        else: block {
+            // We're not in mobile mode so clicking on the "normal" sidebar.
+            click: "rustdoc-toolbar .settings-menu"
+        }
+    }
+)
+
+define-function: (
     "open-settings-menu",
     [],
     block {
-        // Open the settings menu.
-        click: "rustdoc-toolbar .settings-menu"
+        call-function: ("click-settings-button", {})
         // Wait for the popover to appear...
         wait-for-css: ("#settings", {"display": "block"})
     }
@@ -15,7 +39,8 @@ define-function: (
     "close-settings-menu",
     [],
     block {
-        click: "rustdoc-toolbar .settings-menu"
+        call-function: ("click-settings-button", {})
+        // Wait for the popover to disappear...
         wait-for-css-false: ("#settings", {"display": "block"})
     }
 )
@@ -29,24 +54,6 @@ define-function: (
         // Change the setting.
         click: "#theme-"+ |theme|
         call-function: ("close-settings-menu", {})
-        // Ensure that the local storage was correctly updated.
-        assert-local-storage: {"rustdoc-theme": |theme|}
-    },
-)
-
-// FIXME: To be removed once `browser-ui-test` has conditions.
-define-function: (
-    "switch-theme-mobile",
-    [theme],
-    block {
-        // Open the settings menu.
-        click: "rustdoc-topbar .settings-menu"
-        // Wait for the popover to appear...
-        wait-for-css: ("#settings", {"display": "block"})
-        // Change the setting.
-        click: "#theme-"+ |theme|
-        click: "rustdoc-topbar .settings-menu"
-        wait-for-css-false: ("#settings", {"display": "block"})
         // Ensure that the local storage was correctly updated.
         assert-local-storage: {"rustdoc-theme": |theme|}
     },

--- a/tests/rustdoc-html/macro/macro_pub_in_module.rs
+++ b/tests/rustdoc-html/macro/macro_pub_in_module.rs
@@ -33,7 +33,7 @@ pub mod inner {
     // Make sure the logic is not affected by re-exports.
     mod unrenamed {
         //@ !has krate/macro.unrenamed.html
-        #[rustc_macro_transparency = "semitransparent"]
+        #[rustc_macro_transparency = "semiopaque"]
         pub macro unrenamed() {}
     }
     //@ has krate/inner/macro.unrenamed.html

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -223,8 +223,8 @@ help: try changing it to one of the following valid forms of the attribute
    |
 LL | #[rustc_macro_transparency = "opaque"]
    |                            ++++++++++
-LL | #[rustc_macro_transparency = "semitransparent"]
-   |                            +++++++++++++++++++
+LL | #[rustc_macro_transparency = "semiopaque"]
+   |                            ++++++++++++++
 LL | #[rustc_macro_transparency = "transparent"]
    |                            +++++++++++++++
 

--- a/tests/ui/const-generics/mgca/adt_expr_arg_simple.rs
+++ b/tests/ui/const-generics/mgca/adt_expr_arg_simple.rs
@@ -12,7 +12,7 @@ fn foo<const N: Option<u32>>() {}
 
 trait Trait {
     #[type_const]
-    const ASSOC: usize;
+    const ASSOC: u32;
 }
 
 fn bar<T: Trait, const N: u32>() {

--- a/tests/ui/const-generics/mgca/adt_expr_arg_tuple_expr_fail.rs
+++ b/tests/ui/const-generics/mgca/adt_expr_arg_tuple_expr_fail.rs
@@ -1,0 +1,26 @@
+#![feature(min_generic_const_args, adt_const_params, unsized_const_params)]
+#![expect(incomplete_features)]
+
+trait Trait {
+    #[type_const]
+    const ASSOC: usize;
+}
+
+fn takes_tuple<const A: (u32, u32)>() {}
+fn takes_nested_tuple<const A: (u32, (u32, u32))>() {}
+
+fn generic_caller<T: Trait, const N: usize, const N2: u32>() {
+    takes_tuple::<{ (N, N2) }>();
+    //~^ ERROR the constant `N` is not of type `u32`
+    takes_tuple::<{ (N, T::ASSOC) }>();
+    //~^ ERROR the constant `N` is not of type `u32`
+    //~| ERROR the constant `<T as Trait>::ASSOC` is not of type `u32`
+
+    takes_nested_tuple::<{ (N, (N, N2)) }>();
+    //~^ ERROR the constant `N` is not of type `u32`
+    takes_nested_tuple::<{ (N, (N, T::ASSOC)) }>();
+    //~^ ERROR the constant `N` is not of type `u32`
+    //~| ERROR the constant `<T as Trait>::ASSOC` is not of type `u32`
+}
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/adt_expr_arg_tuple_expr_fail.stderr
+++ b/tests/ui/const-generics/mgca/adt_expr_arg_tuple_expr_fail.stderr
@@ -1,0 +1,38 @@
+error: the constant `N` is not of type `u32`
+  --> $DIR/adt_expr_arg_tuple_expr_fail.rs:13:21
+   |
+LL |     takes_tuple::<{ (N, N2) }>();
+   |                     ^^^^^^^ expected `u32`, found `usize`
+
+error: the constant `N` is not of type `u32`
+  --> $DIR/adt_expr_arg_tuple_expr_fail.rs:15:21
+   |
+LL |     takes_tuple::<{ (N, T::ASSOC) }>();
+   |                     ^^^^^^^^^^^^^ expected `u32`, found `usize`
+
+error: the constant `<T as Trait>::ASSOC` is not of type `u32`
+  --> $DIR/adt_expr_arg_tuple_expr_fail.rs:15:21
+   |
+LL |     takes_tuple::<{ (N, T::ASSOC) }>();
+   |                     ^^^^^^^^^^^^^ expected `u32`, found `usize`
+
+error: the constant `N` is not of type `u32`
+  --> $DIR/adt_expr_arg_tuple_expr_fail.rs:19:28
+   |
+LL |     takes_nested_tuple::<{ (N, (N, N2)) }>();
+   |                            ^^^^^^^^^^^^ expected `u32`, found `usize`
+
+error: the constant `N` is not of type `u32`
+  --> $DIR/adt_expr_arg_tuple_expr_fail.rs:21:28
+   |
+LL |     takes_nested_tuple::<{ (N, (N, T::ASSOC)) }>();
+   |                            ^^^^^^^^^^^^^^^^^^ expected `u32`, found `usize`
+
+error: the constant `<T as Trait>::ASSOC` is not of type `u32`
+  --> $DIR/adt_expr_arg_tuple_expr_fail.rs:21:28
+   |
+LL |     takes_nested_tuple::<{ (N, (N, T::ASSOC)) }>();
+   |                            ^^^^^^^^^^^^^^^^^^ expected `u32`, found `usize`
+
+error: aborting due to 6 previous errors
+

--- a/tests/ui/const-generics/mgca/adt_expr_arg_tuple_expr_simple.rs
+++ b/tests/ui/const-generics/mgca/adt_expr_arg_tuple_expr_simple.rs
@@ -5,7 +5,7 @@
 
 trait Trait {
     #[type_const]
-    const ASSOC: usize;
+    const ASSOC: u32;
 }
 
 fn takes_tuple<const A: (u32, u32)>() {}

--- a/tests/ui/const-generics/mgca/adt_expr_fields_type_check.rs
+++ b/tests/ui/const-generics/mgca/adt_expr_fields_type_check.rs
@@ -1,17 +1,38 @@
-//@ check-pass
-// FIXME(mgca): This should error
-
 #![feature(min_generic_const_args, adt_const_params)]
 #![expect(incomplete_features)]
 
 #[derive(Eq, PartialEq, std::marker::ConstParamTy)]
-struct Foo<T> { field: T }
+struct S1<T> {
+    f1: T,
+    f2: isize,
+}
 
-fn accepts<const N: Foo<u8>>() {}
+#[derive(Eq, PartialEq, std::marker::ConstParamTy)]
+struct S2<T>(T, isize);
+
+#[derive(Eq, PartialEq, std::marker::ConstParamTy)]
+enum En<T> {
+    Var1(bool, T),
+    Var2 { field: i64 },
+}
+
+fn accepts_1<const N: S1<u8>>() {}
+fn accepts_2<const N: S2<u8>>() {}
+fn accepts_3<const N: En<u8>>() {}
 
 fn bar<const N: bool>() {
-    // `N` is not of type `u8` but we don't actually check this anywhere yet
-    accepts::<{ Foo::<u8> { field: N }}>();
+    accepts_1::<{ S1::<u8> { f1: N, f2: N } }>();
+    //~^ ERROR the constant `N` is not of type `u8`
+    //~| ERROR the constant `N` is not of type `isize`
+    accepts_2::<{ S2::<u8>(N, N) }>();
+    //~^ ERROR the constant `N` is not of type `u8`
+    //~| ERROR the constant `N` is not of type `isize`
+    accepts_3::<{ En::Var1::<u8>(N, N) }>();
+    //~^ ERROR the constant `N` is not of type `u8`
+    accepts_3::<{ En::Var2::<u8> { field: N } }>();
+    //~^ ERROR the constant `N` is not of type `i64`
+    accepts_3::<{ En::Var2::<u8> { field: const { false } } }>();
+    //~^ ERROR mismatched types
 }
 
 fn main() {}

--- a/tests/ui/const-generics/mgca/adt_expr_fields_type_check.stderr
+++ b/tests/ui/const-generics/mgca/adt_expr_fields_type_check.stderr
@@ -1,0 +1,45 @@
+error: the constant `N` is not of type `u8`
+  --> $DIR/adt_expr_fields_type_check.rs:24:19
+   |
+LL |     accepts_1::<{ S1::<u8> { f1: N, f2: N } }>();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `bool`
+
+error: the constant `N` is not of type `isize`
+  --> $DIR/adt_expr_fields_type_check.rs:24:19
+   |
+LL |     accepts_1::<{ S1::<u8> { f1: N, f2: N } }>();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `isize`, found `bool`
+
+error: the constant `N` is not of type `u8`
+  --> $DIR/adt_expr_fields_type_check.rs:27:19
+   |
+LL |     accepts_2::<{ S2::<u8>(N, N) }>();
+   |                   ^^^^^^^^^^^^^^ expected `u8`, found `bool`
+
+error: the constant `N` is not of type `isize`
+  --> $DIR/adt_expr_fields_type_check.rs:27:19
+   |
+LL |     accepts_2::<{ S2::<u8>(N, N) }>();
+   |                   ^^^^^^^^^^^^^^ expected `isize`, found `bool`
+
+error: the constant `N` is not of type `u8`
+  --> $DIR/adt_expr_fields_type_check.rs:30:19
+   |
+LL |     accepts_3::<{ En::Var1::<u8>(N, N) }>();
+   |                   ^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `bool`
+
+error: the constant `N` is not of type `i64`
+  --> $DIR/adt_expr_fields_type_check.rs:32:19
+   |
+LL |     accepts_3::<{ En::Var2::<u8> { field: N } }>();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `i64`, found `bool`
+
+error[E0308]: mismatched types
+  --> $DIR/adt_expr_fields_type_check.rs:34:51
+   |
+LL |     accepts_3::<{ En::Var2::<u8> { field: const { false } } }>();
+   |                                                   ^^^^^ expected `i64`, found `bool`
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/mgca/printing_valtrees_supports_non_values.rs
+++ b/tests/ui/const-generics/mgca/printing_valtrees_supports_non_values.rs
@@ -9,7 +9,7 @@ struct Foo;
 
 trait Trait {
     #[type_const]
-    const ASSOC: usize;
+    const ASSOC: u32;
 }
 
 fn foo<const N: Foo>() {}
@@ -27,7 +27,7 @@ fn baz<T: Trait>() {
 fn main() {}
 
 fn test_ice_missing_bound<T>() {
-    foo::<{Option::Some::<u32>{0: <T as Trait>::ASSOC}}>();
+    foo::<{ Option::Some::<u32> { 0: <T as Trait>::ASSOC } }>();
     //~^ ERROR the trait bound `T: Trait` is not satisfied
     //~| ERROR the constant `Option::<u32>::Some(_)` is not of type `Foo`
 }

--- a/tests/ui/const-generics/mgca/printing_valtrees_supports_non_values.stderr
+++ b/tests/ui/const-generics/mgca/printing_valtrees_supports_non_values.stderr
@@ -25,8 +25,8 @@ LL | fn foo<const N: Foo>() {}
 error[E0277]: the trait bound `T: Trait` is not satisfied
   --> $DIR/printing_valtrees_supports_non_values.rs:30:5
    |
-LL |     foo::<{Option::Some::<u32>{0: <T as Trait>::ASSOC}}>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `T`
+LL |     foo::<{ Option::Some::<u32> { 0: <T as Trait>::ASSOC } }>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `T`
    |
 help: consider restricting type parameter `T` with trait `Trait`
    |
@@ -34,10 +34,10 @@ LL | fn test_ice_missing_bound<T: Trait>() {
    |                            +++++++
 
 error: the constant `Option::<u32>::Some(_)` is not of type `Foo`
-  --> $DIR/printing_valtrees_supports_non_values.rs:30:12
+  --> $DIR/printing_valtrees_supports_non_values.rs:30:13
    |
-LL |     foo::<{Option::Some::<u32>{0: <T as Trait>::ASSOC}}>();
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Foo`, found `Option<u32>`
+LL |     foo::<{ Option::Some::<u32> { 0: <T as Trait>::ASSOC } }>();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Foo`, found `Option<u32>`
    |
 note: required by a const generic parameter in `foo`
   --> $DIR/printing_valtrees_supports_non_values.rs:15:8

--- a/tests/ui/fmt/format-string-error-2.rs
+++ b/tests/ui/fmt/format-string-error-2.rs
@@ -83,4 +83,7 @@ raw  { \n
 
     println!(r#"\x7B}\u8 {"#, 1);
     //~^ ERROR invalid format string: unmatched `}` found
+
+    println!("{x?}, world!",);
+    //~^ ERROR invalid format string: expected `}`, found `?`
 }

--- a/tests/ui/fmt/format-string-error-2.stderr
+++ b/tests/ui/fmt/format-string-error-2.stderr
@@ -177,5 +177,16 @@ LL |     println!(r#"\x7B}\u8 {"#, 1);
    |
    = note: if you intended to print `}`, you can escape it using `}}`
 
-error: aborting due to 18 previous errors
+error: invalid format string: expected `}`, found `?`
+  --> $DIR/format-string-error-2.rs:87:17
+   |
+LL |     println!("{x?}, world!",);
+   |                 ^
+   |                 |
+   |                 expected `:` before `?` to format with `Debug` in format string
+   |                 help: add a colon before the format specifier: `:?`
+   |
+   = note: to print `{`, you can escape it using `{{`
+
+error: aborting due to 19 previous errors
 

--- a/tests/ui/hygiene/duplicate_lifetimes.rs
+++ b/tests/ui/hygiene/duplicate_lifetimes.rs
@@ -3,7 +3,7 @@
 
 #![feature(decl_macro, rustc_attrs)]
 
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 macro m($a:lifetime) {
     fn g<$a, 'a>() {} //~ ERROR the name `'a` is already used for a generic parameter
 }

--- a/tests/ui/hygiene/generic_params.rs
+++ b/tests/ui/hygiene/generic_params.rs
@@ -11,7 +11,7 @@ mod type_params {
         }
     }
 
-    #[rustc_macro_transparency = "semitransparent"]
+    #[rustc_macro_transparency = "semiopaque"]
     macro n($T:ident) {
         fn g<$T: Clone>(t1: $T, t2: T) -> (T, $T) {
             (t1.clone(), t2.clone())
@@ -43,7 +43,7 @@ mod lifetime_params {
         }
     }
 
-    #[rustc_macro_transparency = "semitransparent"]
+    #[rustc_macro_transparency = "semiopaque"]
     macro n($a:lifetime) {
         fn g<$a>(t1: &$a(), t2: &'a ()) -> (&'a (), &$a ()) {
             (t1, t2)
@@ -75,7 +75,7 @@ mod const_params {
         }
     }
 
-    #[rustc_macro_transparency = "semitransparent"]
+    #[rustc_macro_transparency = "semiopaque"]
     macro n($C:ident) {
         fn g<const $C: usize>(t1: [(); $C], t2: [(); C]) -> ([(); C], [(); $C]) {
             (t1, t2)

--- a/tests/ui/hygiene/rustc-macro-transparency.rs
+++ b/tests/ui/hygiene/rustc-macro-transparency.rs
@@ -5,7 +5,7 @@ macro transparent() {
     struct Transparent;
     let transparent = 0;
 }
-#[rustc_macro_transparency = "semitransparent"]
+#[rustc_macro_transparency = "semiopaque"]
 macro semiopaque() {
     struct SemiOpaque;
     let semiopaque = 0;

--- a/tests/ui/single-use-lifetime/issue-104440.rs
+++ b/tests/ui/single-use-lifetime/issue-104440.rs
@@ -8,7 +8,7 @@ mod type_params {
         }
     }
 
-    #[rustc_macro_transparency = "semitransparent"]
+    #[rustc_macro_transparency = "semiopaque"]
     macro n($T:ident) {
         fn g<$T: Clone>(t1: $T, t2: T) -> (T, $T) {
             (t1.clone(), t2.clone())
@@ -40,7 +40,7 @@ mod lifetime_params {
         }
     }
 
-    #[rustc_macro_transparency = "semitransparent"]
+    #[rustc_macro_transparency = "semiopaque"]
     macro n($a:lifetime) {
         fn g<$a>(t1: &$a(), t2: &'a ()) -> (&'a (), &$a ()) {
             (t1, t2)
@@ -72,7 +72,7 @@ mod const_params {
         }
     }
 
-    #[rustc_macro_transparency = "semitransparent"]
+    #[rustc_macro_transparency = "semiopaque"]
     macro n($C:ident) {
         fn g<const $C: usize>(t1: [(); $C], t2: [(); C]) -> ([(); C], [(); $C]) {
             (t1, t2)


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#149318 (Implement partial_sort_unstable for slice)
 - rust-lang/rust#150131 (Use realstd current thread static variables in tests)
 - rust-lang/rust#150272 (docs(core): update `find()` and `rfind()` examples)
 - rust-lang/rust#150368 (adding Ordering enum to minicore.rs, importing minicore in "tests/assembly-llvm/rust-abi-arg-attr.rs" test file)
 - rust-lang/rust#150561 (Finish transition from `semitransparent` to `semiopaque` for `rustc_macro_transparency`)
 - rust-lang/rust#150574 (Clarify `MoveData::init_loc_map`.)
 - rust-lang/rust#150713 (mgca: Type-check fields of struct expr const args)
 - rust-lang/rust#150762 (Use functions more in rustdoc GUI tests)
 - rust-lang/rust#150765 (rustc_parse_format: improve error for missing `:` before `?` in format args)
 - rust-lang/rust#150816 (Fix trait method anchor disappearing before user can click on it)

r? @ghost

<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=149318,150131,150368,150713,150762,150765,150272,150561,150574,150816)
<!-- homu-ignore:end -->

