### PR TITLE
The aarch64-unknown-none target requires NEON, so the docs were wrong.

### DIFF
--- a/src/doc/rustc/src/platform-support/aarch64-unknown-none.md
+++ b/src/doc/rustc/src/platform-support/aarch64-unknown-none.md
@@ -29,14 +29,15 @@ You may prefer the `-softfloat` target when writing a kernel or interfacing with
 pre-compiled binaries that use the soft-float ABI.
 
 When using the hardfloat targets, the minimum floating-point features assumed
-are those of the `fp-armv8`, which excludes NEON SIMD support. If your
+are [`FEAT_AdvSIMD`][feat-advsimd], which means NEON SIMD support. If your
 processor supports a different set of floating-point features than the default
-expectations of `fp-armv8`, then these should also be enabled or disabled as
-needed with `-C target-feature=(+/-)`. It is also possible to tell Rust (or
+expectations of `FEAT_AdvSIMD`, then these should also be enabled or disabled
+as needed with `-C target-feature=(+/-)`. It is also possible to tell Rust (or
 LLVM) that you have a specific model of Arm processor, using the
 [`-Ctarget-cpu`][target-cpu] option. Doing so may change the default set of
 target-features enabled.
 
+[feat-advsimd]: https://developer.arm.com/documentation/109697/2025_12/Feature-descriptions/The-Armv8-0-architecture-extension?lang=en
 [target-cpu]: https://doc.rust-lang.org/rustc/codegen-options/index.html#target-cpu
 [target-feature]: https://doc.rust-lang.org/rustc/codegen-options/index.html#target-feature
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

As discussed [on zulip](https://rust-lang.zulipchat.com/#narrow/channel/242906-t-compiler.2Farm/topic/aarch64-unknown-none.20platform.20docs/with/567045743), we think the docs for the aarch64-unknown-none target don't match the target spec.