### PR TITLE
Couple of improvements to rustc_fluent_macros

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -88,7 +88,7 @@ mod pat;
 mod path;
 pub mod stability;
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }
 
 struct LoweringContext<'a, 'hir> {
     tcx: TyCtxt<'hir>,

--- a/compiler/rustc_ast_passes/src/lib.rs
+++ b/compiler/rustc_ast_passes/src/lib.rs
@@ -12,4 +12,4 @@ pub mod ast_validation;
 mod errors;
 pub mod feature_gate;
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }

--- a/compiler/rustc_attr_parsing/src/lib.rs
+++ b/compiler/rustc_attr_parsing/src/lib.rs
@@ -114,4 +114,4 @@ pub use context::{Early, Late, OmitDoc, ShouldEmit};
 pub use interface::AttributeParser;
 pub use session_diagnostics::ParsedDescription;
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -98,7 +98,7 @@ mod used_muts;
 /// A public API provided for the Rust compiler consumers.
 pub mod consumers;
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }
 
 /// Associate some local constants with the `'tcx` lifetime
 struct TyCtxtConsts<'tcx>(PhantomData<&'tcx ()>);

--- a/compiler/rustc_builtin_macros/src/lib.rs
+++ b/compiler/rustc_builtin_macros/src/lib.rs
@@ -59,7 +59,7 @@ pub mod standard_library_imports;
 pub mod test_harness;
 pub mod util;
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }
 
 pub fn register_builtin_macros(resolver: &mut dyn ResolverExpand) {
     let mut register = |name, kind| resolver.register_builtin_macro(name, kind);

--- a/compiler/rustc_codegen_gcc/src/lib.rs
+++ b/compiler/rustc_codegen_gcc/src/lib.rs
@@ -105,7 +105,7 @@ use tempfile::TempDir;
 use crate::back::lto::ModuleBuffer;
 use crate::gcc_util::{target_cpu, to_gcc_features};
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }
 
 pub struct PrintOnPanic<F: Fn() -> String>(pub F);
 

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -73,7 +73,7 @@ mod typetree;
 mod va_arg;
 mod value;
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }
 
 pub(crate) use macros::TryFromU32;
 

--- a/compiler/rustc_codegen_ssa/src/lib.rs
+++ b/compiler/rustc_codegen_ssa/src/lib.rs
@@ -57,7 +57,7 @@ pub mod size_of_val;
 pub mod target_features;
 pub mod traits;
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }
 
 pub struct ModuleCodegen<M> {
     /// The name of the module. When the crate may be saved between

--- a/compiler/rustc_const_eval/src/lib.rs
+++ b/compiler/rustc_const_eval/src/lib.rs
@@ -27,7 +27,7 @@ use rustc_middle::util::Providers;
 
 pub use self::errors::ReportErrorExt;
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }
 
 pub fn provide(providers: &mut Providers) {
     const_eval::provide(providers);

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -106,7 +106,7 @@ use crate::session_diagnostics::{
     RLinkWrongFileType, RlinkCorruptFile, RlinkNotAFile, RlinkUnableToRead, UnstableFeatureUsage,
 };
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }
 
 pub fn default_translator() -> Translator {
     Translator::with_fallback_bundle(DEFAULT_LOCALE_RESOURCES.to_vec(), false)

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -99,7 +99,7 @@ pub mod translation;
 
 pub type PResult<'a, T> = Result<T, Diag<'a>>;
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }
 
 // `PResult` is used a lot. Make sure it doesn't unintentionally get bigger.
 #[cfg(target_pointer_width = "64")]

--- a/compiler/rustc_expand/src/lib.rs
+++ b/compiler/rustc_expand/src/lib.rs
@@ -29,4 +29,4 @@ pub mod module;
 #[allow(rustc::untranslatable_diagnostic)]
 pub mod proc_macro;
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -103,7 +103,7 @@ use rustc_trait_selection::traits;
 pub use crate::collect::suggest_impl_trait;
 use crate::hir_ty_lowering::{FeedConstTy, HirTyLowerer};
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }
 
 fn check_c_variadic_abi(tcx: TyCtxt<'_>, decl: &hir::FnDecl<'_>, abi: ExternAbi, span: Span) {
     if !decl.c_variadic {

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -67,7 +67,7 @@ use crate::expectation::Expectation;
 use crate::fn_ctxt::LoweredTy;
 use crate::gather_locals::GatherLocalsVisitor;
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }
 
 #[macro_export]
 macro_rules! type_error_struct {

--- a/compiler/rustc_incremental/src/lib.rs
+++ b/compiler/rustc_incremental/src/lib.rs
@@ -22,4 +22,4 @@ pub fn provide(providers: &mut Providers) {
         |tcx| tcx.sess.time("serialize_dep_graph", || persist::save_dep_graph(tcx));
 }
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }

--- a/compiler/rustc_infer/src/lib.rs
+++ b/compiler/rustc_infer/src/lib.rs
@@ -23,4 +23,4 @@ mod errors;
 pub mod infer;
 pub mod traits;
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }

--- a/compiler/rustc_interface/src/lib.rs
+++ b/compiler/rustc_interface/src/lib.rs
@@ -22,4 +22,4 @@ pub use queries::Linker;
 #[cfg(test)]
 mod tests;
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -140,7 +140,7 @@ pub use rustc_errors::BufferedEarlyLint;
 pub use rustc_session::lint::Level::{self, *};
 pub use rustc_session::lint::{FutureIncompatibleInfo, Lint, LintId, LintPass, LintVec};
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }
 
 pub fn provide(providers: &mut Providers) {
     levels::provide(providers);

--- a/compiler/rustc_metadata/src/lib.rs
+++ b/compiler/rustc_metadata/src/lib.rs
@@ -35,4 +35,4 @@ pub use native_libs::{
 };
 pub use rmeta::{EncodedMetadata, METADATA_HEADER, encode_metadata, rendered_const};
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }

--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -94,4 +94,4 @@ pub mod dep_graph;
 // Allows macros to refer to this crate as `::rustc_middle`
 extern crate self as rustc_middle;
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }

--- a/compiler/rustc_mir_build/src/lib.rs
+++ b/compiler/rustc_mir_build/src/lib.rs
@@ -20,7 +20,7 @@ pub mod thir;
 
 use rustc_middle::util::Providers;
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }
 
 pub fn provide(providers: &mut Providers) {
     providers.check_match = thir::pattern::check_match;

--- a/compiler/rustc_mir_dataflow/src/lib.rs
+++ b/compiler/rustc_mir_dataflow/src/lib.rs
@@ -34,7 +34,7 @@ pub mod rustc_peek;
 mod un_derefer;
 pub mod value_analysis;
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }
 
 pub struct MoveDataTypingEnv<'tcx> {
     pub move_data: MoveData<'tcx>,

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -203,7 +203,7 @@ declare_passes! {
     mod validate : Validator;
 }
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }
 
 pub fn provide(providers: &mut Providers) {
     coverage::query::provide(providers);

--- a/compiler/rustc_monomorphize/src/lib.rs
+++ b/compiler/rustc_monomorphize/src/lib.rs
@@ -21,7 +21,7 @@ mod mono_checks;
 mod partitioning;
 mod util;
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }
 
 fn custom_coerce_unsize_info<'tcx>(
     tcx: TyCtxtAt<'tcx>,

--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -77,7 +77,7 @@ const _: () = {
     }
 };
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }
 
 // Unwrap the result if `Ok`, otherwise emit the diagnostics and abort.
 pub fn unwrap_or_emit_fatal<T>(expr: Result<T, Vec<Diag<'_>>>) -> T {

--- a/compiler/rustc_passes/src/lib.rs
+++ b/compiler/rustc_passes/src/lib.rs
@@ -30,7 +30,7 @@ pub mod stability;
 mod upvars;
 mod weak_lang_items;
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }
 
 pub fn provide(providers: &mut Providers) {
     check_attr::provide(providers);

--- a/compiler/rustc_pattern_analysis/src/lib.rs
+++ b/compiler/rustc_pattern_analysis/src/lib.rs
@@ -21,7 +21,7 @@ pub mod rustc;
 pub mod usefulness;
 
 #[cfg(feature = "rustc")]
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }
 
 use std::fmt;
 

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -38,7 +38,7 @@ use rustc_span::hygiene::Transparency;
 use rustc_span::{Ident, Span, Symbol, sym};
 use tracing::debug;
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }
 
 ////////////////////////////////////////////////////////////////////////////////
 // Generic infrastructure used to implement specific visitors below.

--- a/compiler/rustc_query_system/src/lib.rs
+++ b/compiler/rustc_query_system/src/lib.rs
@@ -15,4 +15,4 @@ mod values;
 pub use error::{HandleCycleError, QueryOverflow, QueryOverflowNote};
 pub use values::Value;
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -98,7 +98,7 @@ pub use macros::registered_tools_ast;
 
 use crate::ref_mut::{CmCell, CmRefCell};
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 enum Determinacy {

--- a/compiler/rustc_session/src/lib.rs
+++ b/compiler/rustc_session/src/lib.rs
@@ -32,7 +32,7 @@ pub mod output;
 
 pub use getopts;
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }
 
 /// Requirements for a `StableHashingContext` to be used in this crate.
 /// This is a hack to allow using the `HashStable_Generic` derive macro

--- a/compiler/rustc_trait_selection/src/lib.rs
+++ b/compiler/rustc_trait_selection/src/lib.rs
@@ -37,4 +37,4 @@ pub mod regions;
 pub mod solve;
 pub mod traits;
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }

--- a/compiler/rustc_ty_utils/src/lib.rs
+++ b/compiler/rustc_ty_utils/src/lib.rs
@@ -31,7 +31,7 @@ pub mod sig_types;
 mod structural_match;
 mod ty;
 
-rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
+rustc_fluent_macro::fluent_messages! { "messages.ftl" }
 
 pub fn provide(providers: &mut Providers) {
     abi::provide(providers);

--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -661,6 +661,7 @@ impl Config {
         // Trim whitespace from the name, so that `//@ exec-env: FOO=BAR`
         // sees the name as `FOO` and not ` FOO`.
         let name = name.trim();
+        let value = value.replace("$ROOT", std::env::current_dir().unwrap().to_str().unwrap());
         (name.to_owned(), value.to_owned())
     }
 

--- a/tests/ui-fulldeps/fluent-messages/test.rs
+++ b/tests/ui-fulldeps/fluent-messages/test.rs
@@ -1,4 +1,5 @@
 //@ normalize-stderr: "could not open Fluent resource:.*" -> "could not open Fluent resource: os-specific message"
+//@ rustc-env: CARGO_MANIFEST_DIR=$ROOT/tests/ui-fulldeps/fluent-messages
 
 #![feature(rustc_private)]
 #![crate_type = "lib"]

--- a/tests/ui-fulldeps/fluent-messages/test.stderr
+++ b/tests/ui-fulldeps/fluent-messages/test.stderr
@@ -1,17 +1,17 @@
 error: could not open Fluent resource: os-specific message
-  --> $DIR/test.rs:21:44
+  --> $DIR/test.rs:22:44
    |
 LL |     rustc_fluent_macro::fluent_messages! { "/definitely_does_not_exist.ftl" }
    |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: could not open Fluent resource: os-specific message
-  --> $DIR/test.rs:26:44
+  --> $DIR/test.rs:27:44
    |
 LL |     rustc_fluent_macro::fluent_messages! { "../definitely_does_not_exist.ftl" }
    |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: could not parse Fluent resource
-  --> $DIR/test.rs:31:44
+  --> $DIR/test.rs:32:44
    |
 LL |     rustc_fluent_macro::fluent_messages! { "./missing-message.ftl" }
    |                                            ^^^^^^^^^^^^^^^^^^^^^^^
@@ -19,20 +19,20 @@ LL |     rustc_fluent_macro::fluent_messages! { "./missing-message.ftl" }
    = help: see additional errors emitted
 
 error: expected a message field for "no_crate_missing_message"
- --> ./missing-message.ftl:1:1
+ --> $DIR/./missing-message.ftl:1:1
   |
 1 | no_crate_missing_message =
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
 
 error: overrides existing message: `no_crate_a_b_key`
-  --> $DIR/test.rs:36:44
+  --> $DIR/test.rs:37:44
    |
 LL |     rustc_fluent_macro::fluent_messages! { "./duplicate.ftl" }
    |                                            ^^^^^^^^^^^^^^^^^
 
 error: name `no_crate_this-slug-has-hyphens` contains a '-' character
-  --> $DIR/test.rs:41:44
+  --> $DIR/test.rs:42:44
    |
 LL |     rustc_fluent_macro::fluent_messages! { "./slug-with-hyphens.ftl" }
    |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -40,7 +40,7 @@ LL |     rustc_fluent_macro::fluent_messages! { "./slug-with-hyphens.ftl" }
    = help: replace any '-'s with '_'s
 
 error: attribute `label-has-hyphens` contains a '-' character
-  --> $DIR/test.rs:46:44
+  --> $DIR/test.rs:47:44
    |
 LL |     rustc_fluent_macro::fluent_messages! { "./label-with-hyphens.ftl" }
    |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -48,7 +48,7 @@ LL |     rustc_fluent_macro::fluent_messages! { "./label-with-hyphens.ftl" }
    = help: replace any '-'s with '_'s
 
 error: name `with-hyphens` contains a '-' character
-  --> $DIR/test.rs:59:44
+  --> $DIR/test.rs:60:44
    |
 LL |     rustc_fluent_macro::fluent_messages! { "./missing-crate-name.ftl" }
    |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -56,7 +56,7 @@ LL |     rustc_fluent_macro::fluent_messages! { "./missing-crate-name.ftl" }
    = help: replace any '-'s with '_'s
 
 error: name `with-hyphens` does not start with the crate name
-  --> $DIR/test.rs:59:44
+  --> $DIR/test.rs:60:44
    |
 LL |     rustc_fluent_macro::fluent_messages! { "./missing-crate-name.ftl" }
    |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -64,7 +64,7 @@ LL |     rustc_fluent_macro::fluent_messages! { "./missing-crate-name.ftl" }
    = help: prepend `no_crate_` to the slug name: `no_crate_with_hyphens`
 
 error: name `no-crate_foo` contains a '-' character
-  --> $DIR/test.rs:59:44
+  --> $DIR/test.rs:60:44
    |
 LL |     rustc_fluent_macro::fluent_messages! { "./missing-crate-name.ftl" }
    |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -72,7 +72,7 @@ LL |     rustc_fluent_macro::fluent_messages! { "./missing-crate-name.ftl" }
    = help: replace any '-'s with '_'s
 
 error: referenced message `message` does not exist (in message `no_crate_missing_message_ref`)
-  --> $DIR/test.rs:73:44
+  --> $DIR/test.rs:74:44
    |
 LL |     rustc_fluent_macro::fluent_messages! { "./missing-message-ref.ftl" }
    |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -80,7 +80,7 @@ LL |     rustc_fluent_macro::fluent_messages! { "./missing-message-ref.ftl" }
    = help: you may have meant to use a variable reference (`{$message}`)
 
 error: invalid escape `\n` in Fluent resource
-  --> $DIR/test.rs:78:44
+  --> $DIR/test.rs:79:44
    |
 LL |     rustc_fluent_macro::fluent_messages! { "./invalid-escape.ftl" }
    |                                            ^^^^^^^^^^^^^^^^^^^^^^
@@ -88,7 +88,7 @@ LL |     rustc_fluent_macro::fluent_messages! { "./invalid-escape.ftl" }
    = note: Fluent does not interpret these escape sequences (<https://projectfluent.org/fluent/guide/special.html>)
 
 error: invalid escape `\"` in Fluent resource
-  --> $DIR/test.rs:78:44
+  --> $DIR/test.rs:79:44
    |
 LL |     rustc_fluent_macro::fluent_messages! { "./invalid-escape.ftl" }
    |                                            ^^^^^^^^^^^^^^^^^^^^^^
@@ -96,7 +96,7 @@ LL |     rustc_fluent_macro::fluent_messages! { "./invalid-escape.ftl" }
    = note: Fluent does not interpret these escape sequences (<https://projectfluent.org/fluent/guide/special.html>)
 
 error: invalid escape `\'` in Fluent resource
-  --> $DIR/test.rs:78:44
+  --> $DIR/test.rs:79:44
    |
 LL |     rustc_fluent_macro::fluent_messages! { "./invalid-escape.ftl" }
    |                                            ^^^^^^^^^^^^^^^^^^^^^^
@@ -104,7 +104,7 @@ LL |     rustc_fluent_macro::fluent_messages! { "./invalid-escape.ftl" }
    = note: Fluent does not interpret these escape sequences (<https://projectfluent.org/fluent/guide/special.html>)
 
 error: could not parse Fluent resource
-  --> $DIR/test.rs:85:44
+  --> $DIR/test.rs:86:44
    |
 LL |     rustc_fluent_macro::fluent_messages! { "./many-lines.ftl" }
    |                                            ^^^^^^^^^^^^^^^^^^
@@ -112,7 +112,7 @@ LL |     rustc_fluent_macro::fluent_messages! { "./many-lines.ftl" }
    = help: see additional errors emitted
 
 error: expected a message field for "no_crate_bar"
- --> ./many-lines.ftl:8:1
+ --> $DIR/./many-lines.ftl:8:1
   |
 8 | no_crate_bar =
   | ^^^^^^^^^^^^^^

--- a/tests/ui-fulldeps/session-diagnostic/invalid-variable.rs
+++ b/tests/ui-fulldeps/session-diagnostic/invalid-variable.rs
@@ -1,5 +1,6 @@
 //@ run-fail
 //@ compile-flags: --test
+//@ rustc-env: CARGO_MANIFEST_DIR=$ROOT/tests/ui-fulldeps/session-diagnostic
 // test that messages referencing non-existent fields cause test failures
 
 #![feature(rustc_private)]


### PR DESCRIPTION
Workaround a feature used by `fluent_messages!` that isn't supported by rust-analyzer. And significantly reduce cascading errors when the translation file fails to parse.