### PR TITLE
Reenable GCC CI download

### DIFF
--- a/src/bootstrap/download-ci-gcc-stamp
+++ b/src/bootstrap/download-ci-gcc-stamp
@@ -1,4 +1,4 @@
 Change this file to make users of the `download-ci-gcc` configuration download
 a new version of GCC from CI, even if the GCC submodule hasn’t changed.
 
-Last change is for: https://github.com/rust-lang/rust/pull/138051
+Last change is for: https://github.com/rust-lang/rust/pull/150873

--- a/src/bootstrap/src/core/download.rs
+++ b/src/bootstrap/src/core/download.rs
@@ -396,7 +396,7 @@ impl Config {
     ";
             self.download_file(&format!("{base}/{gcc_sha}/{filename}"), &tarball, help_on_error);
         }
-        self.unpack(&tarball, root_dir, "gcc");
+        self.unpack(&tarball, root_dir, "gcc-dev");
     }
 }
 

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -187,9 +187,8 @@ else
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set llvm.static-libstdcpp"
   fi
 
-  # Download GCC from CI on test builders (temporarily disabled because the CI gcc component
-  # was renamed).
-  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set gcc.download-ci-gcc=false"
+  # Download GCC from CI on test builders
+  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set gcc.download-ci-gcc=true"
 
   # download-rustc seems to be broken on CI after the stage0 redesign
   # Disable it until these issues are debugged and resolved


### PR DESCRIPTION
Now that we have the `gcc-dev` artifacts on CI. However, I forgot to bump download-ci-gcc-stamp before :facepalm: So I will also have to bump it for this PR.
