### PR TITLE
Ignore `rustc-src-gpl` in fast try builds

### DIFF
--- a/src/tools/opt-dist/src/main.rs
+++ b/src/tools/opt-dist/src/main.rs
@@ -450,6 +450,7 @@ fn main() -> anyhow::Result<()> {
             "rust-docs-json",
             "rust-analyzer",
             "rustc-src",
+            "rustc-src-gpl",
             "extended",
             "clippy",
             "miri",


### PR DESCRIPTION
I noticed that fast try builds now build this new component (unnecessarily).
