### PR TITLE
Refactor artifact keep mode in bootstrap

### DIFF
--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -4,7 +4,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::core::build_steps::compile::{
-    add_to_sysroot, run_cargo, rustc_cargo, rustc_cargo_env, std_cargo, std_crates_for_run_make,
+    ArtifactKeepMode, add_to_sysroot, run_cargo, rustc_cargo, rustc_cargo_env, std_cargo,
+    std_crates_for_run_make,
 };
 use crate::core::build_steps::tool;
 use crate::core::build_steps::tool::{
@@ -111,8 +112,7 @@ impl Step for Std {
             builder.config.free_args.clone(),
             &check_stamp,
             vec![],
-            true,
-            false,
+            ArtifactKeepMode::OnlyRmeta,
         );
 
         drop(_guard);
@@ -148,7 +148,14 @@ impl Step for Std {
             build_compiler,
             target,
         );
-        run_cargo(builder, cargo, builder.config.free_args.clone(), &stamp, vec![], true, false);
+        run_cargo(
+            builder,
+            cargo,
+            builder.config.free_args.clone(),
+            &stamp,
+            vec![],
+            ArtifactKeepMode::OnlyRmeta,
+        );
         check_stamp
     }
 
@@ -368,7 +375,14 @@ impl Step for Rustc {
         let stamp =
             build_stamp::librustc_stamp(builder, build_compiler, target).with_prefix("check");
 
-        run_cargo(builder, cargo, builder.config.free_args.clone(), &stamp, vec![], true, false);
+        run_cargo(
+            builder,
+            cargo,
+            builder.config.free_args.clone(),
+            &stamp,
+            vec![],
+            ArtifactKeepMode::OnlyRmeta,
+        );
 
         stamp
     }
@@ -568,7 +582,14 @@ impl Step for CraneliftCodegenBackend {
         )
         .with_prefix("check");
 
-        run_cargo(builder, cargo, builder.config.free_args.clone(), &stamp, vec![], true, false);
+        run_cargo(
+            builder,
+            cargo,
+            builder.config.free_args.clone(),
+            &stamp,
+            vec![],
+            ArtifactKeepMode::OnlyRmeta,
+        );
     }
 
     fn metadata(&self) -> Option<StepMetadata> {
@@ -639,7 +660,14 @@ impl Step for GccCodegenBackend {
         )
         .with_prefix("check");
 
-        run_cargo(builder, cargo, builder.config.free_args.clone(), &stamp, vec![], true, false);
+        run_cargo(
+            builder,
+            cargo,
+            builder.config.free_args.clone(),
+            &stamp,
+            vec![],
+            ArtifactKeepMode::OnlyRmeta,
+        );
     }
 
     fn metadata(&self) -> Option<StepMetadata> {
@@ -777,7 +805,14 @@ fn run_tool_check_step(
         .with_prefix(&format!("{display_name}-check"));
 
     let _guard = builder.msg(builder.kind, display_name, mode, build_compiler, target);
-    run_cargo(builder, cargo, builder.config.free_args.clone(), &stamp, vec![], true, false);
+    run_cargo(
+        builder,
+        cargo,
+        builder.config.free_args.clone(),
+        &stamp,
+        vec![],
+        ArtifactKeepMode::OnlyRmeta,
+    );
 }
 
 tool_check_step!(Rustdoc {

--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -15,7 +15,7 @@
 
 use build_helper::exit;
 
-use super::compile::{run_cargo, rustc_cargo, std_cargo};
+use super::compile::{ArtifactKeepMode, run_cargo, rustc_cargo, std_cargo};
 use super::tool::{SourceType, prepare_tool_cargo};
 use crate::builder::{Builder, ShouldRun};
 use crate::core::build_steps::check::{CompilerForCheck, prepare_compiler_for_check};
@@ -214,8 +214,7 @@ impl Step for Std {
             lint_args(builder, &self.config, IGNORED_RULES_FOR_STD_AND_RUSTC),
             &build_stamp::libstd_stamp(builder, build_compiler, target),
             vec![],
-            true,
-            false,
+            ArtifactKeepMode::OnlyRmeta,
         );
     }
 
@@ -309,8 +308,7 @@ impl Step for Rustc {
             lint_args(builder, &self.config, IGNORED_RULES_FOR_STD_AND_RUSTC),
             &build_stamp::librustc_stamp(builder, build_compiler, target),
             vec![],
-            true,
-            false,
+            ArtifactKeepMode::OnlyRmeta,
         );
     }
 
@@ -380,7 +378,7 @@ impl Step for CodegenGcc {
             .with_prefix("rustc_codegen_gcc-check");
 
         let args = lint_args(builder, &self.config, &[]);
-        run_cargo(builder, cargo, args.clone(), &stamp, vec![], true, false);
+        run_cargo(builder, cargo, args.clone(), &stamp, vec![], ArtifactKeepMode::OnlyRmeta);
 
         // Same but we disable the features enabled by default.
         let mut cargo = prepare_tool_cargo(
@@ -396,7 +394,7 @@ impl Step for CodegenGcc {
         self.build_compiler.configure_cargo(&mut cargo);
         println!("Now running clippy on `rustc_codegen_gcc` with `--no-default-features`");
         cargo.arg("--no-default-features");
-        run_cargo(builder, cargo, args, &stamp, vec![], true, false);
+        run_cargo(builder, cargo, args, &stamp, vec![], ArtifactKeepMode::OnlyRmeta);
     }
 
     fn metadata(&self) -> Option<StepMetadata> {
@@ -478,8 +476,7 @@ macro_rules! lint_any {
                     lint_args(builder, &self.config, &[]),
                     &stamp,
                     vec![],
-                    true,
-                    false,
+                    ArtifactKeepMode::OnlyRmeta
                 );
             }
 

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -14,7 +14,7 @@ use std::{env, fs, iter};
 
 use build_helper::exit;
 
-use crate::core::build_steps::compile::{Std, run_cargo};
+use crate::core::build_steps::compile::{ArtifactKeepMode, Std, run_cargo};
 use crate::core::build_steps::doc::{DocumentationFormat, prepare_doc_compiler};
 use crate::core::build_steps::gcc::{Gcc, GccTargetPair, add_cg_gcc_cargo_flags};
 use crate::core::build_steps::llvm::get_llvm_version;
@@ -2587,7 +2587,8 @@ impl BookTest {
                 let stamp = BuildStamp::new(&builder.cargo_out(test_compiler, mode, target))
                     .with_prefix(PathBuf::from(dep).file_name().and_then(|v| v.to_str()).unwrap());
 
-                let output_paths = run_cargo(builder, cargo, vec![], &stamp, vec![], false, false);
+                let output_paths =
+                    run_cargo(builder, cargo, vec![], &stamp, vec![], ArtifactKeepMode::OnlyRlib);
                 let directories = output_paths
                     .into_iter()
                     .filter_map(|p| p.parent().map(ToOwned::to_owned))


### PR DESCRIPTION
This makes it easier to understand which artifacts will be stored in the build stamp. Should help with https://github.com/rust-lang/rust/pull/145343.

Before, there were two booleans (keep .rmeta files and a special mode for rustc). I created an explicit enum for it instead. The mapping is:
- `(false, false)` => `ArtifactKeepMode::OnlyRlib`
- `(true, false)` => `ArtifactKeepMode::OnlyRmeta` (used for check/clippy builds)
- `(false, true)` => special rustc mode

r? @bjorn3