### PR TITLE
Emit an error for linking staticlibs on BPF

### DIFF
--- a/compiler/rustc_codegen_ssa/messages.ftl
+++ b/compiler/rustc_codegen_ssa/messages.ftl
@@ -10,6 +10,8 @@ codegen_ssa_archive_build_failure = failed to build archive at `{$path}`: {$erro
 
 codegen_ssa_binary_output_to_tty = option `-o` or `--emit` is used to write binary output type `{$shorthand}` to stdout, but stdout is a tty
 
+codegen_ssa_bpf_staticlib_not_supported = linking static libraries is not supported for BPF
+
 codegen_ssa_cgu_not_recorded =
     CGU-reuse for `{$cgu_user_name}` is (mangled: `{$cgu_name}`) was not recorded
 

--- a/compiler/rustc_codegen_ssa/src/back/archive.rs
+++ b/compiler/rustc_codegen_ssa/src/back/archive.rs
@@ -22,10 +22,11 @@ use tracing::trace;
 
 use super::metadata::{create_compressed_metadata_file, search_for_section};
 use crate::common;
-// Re-exporting for rustc_codegen_llvm::back::archive
-pub use crate::errors::{ArchiveBuildFailure, ExtractBundledLibsError, UnknownArchiveKind};
+// Public for ArchiveBuilderBuilder::extract_bundled_libs
+pub use crate::errors::ExtractBundledLibsError;
 use crate::errors::{
-    DlltoolFailImportLibrary, ErrorCallingDllTool, ErrorCreatingImportLibrary, ErrorWritingDEFFile,
+    ArchiveBuildFailure, DlltoolFailImportLibrary, ErrorCallingDllTool, ErrorCreatingImportLibrary,
+    ErrorWritingDEFFile, UnknownArchiveKind,
 };
 
 /// An item to be included in an import library.

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -2075,7 +2075,7 @@ impl<'a> Linker for BpfLinker<'a> {
     }
 
     fn link_staticlib_by_name(&mut self, _name: &str, _verbatim: bool, _whole_archive: bool) {
-        panic!("staticlibs not supported")
+        self.sess.dcx().emit_fatal(errors::BpfStaticlibNotSupported)
     }
 
     fn link_staticlib_by_path(&mut self, path: &Path, _whole_archive: bool) {

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -714,6 +714,10 @@ pub struct UnknownArchiveKind<'a> {
 }
 
 #[derive(Diagnostic)]
+#[diag(codegen_ssa_bpf_staticlib_not_supported)]
+pub(crate) struct BpfStaticlibNotSupported;
+
+#[derive(Diagnostic)]
 #[diag(codegen_ssa_multiple_main_functions)]
 #[help]
 pub(crate) struct MultipleMainFunctions {

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -661,7 +661,7 @@ pub(crate) struct RlibArchiveBuildFailure {
 }
 
 #[derive(Diagnostic)]
-// Public for rustc_codegen_llvm::back::archive
+// Public for ArchiveBuilderBuilder::extract_bundled_libs
 pub enum ExtractBundledLibsError<'a> {
     #[diag(codegen_ssa_extract_bundled_libs_open_file)]
     OpenFile { rlib: &'a Path, error: Box<dyn std::error::Error> },
@@ -700,16 +700,14 @@ pub(crate) struct UnsupportedLinkSelfContained;
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_archive_build_failure)]
-// Public for rustc_codegen_llvm::back::archive
-pub struct ArchiveBuildFailure {
+pub(crate) struct ArchiveBuildFailure {
     pub path: PathBuf,
     pub error: std::io::Error,
 }
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_unknown_archive_kind)]
-// Public for rustc_codegen_llvm::back::archive
-pub struct UnknownArchiveKind<'a> {
+pub(crate) struct UnknownArchiveKind<'a> {
     pub kind: &'a str,
 }
 


### PR DESCRIPTION
Rather than panicking. Also a drive-by diagnostic type visibility reduction.

Fixes https://github.com/rust-lang/rust/issues/149432