### PR TITLE
Fix std::fs::copy on WASI by setting proper OpenOptions flags

### DIFF
--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -2296,7 +2296,11 @@ fn open_to_and_set_permissions(
     _reader_metadata: &crate::fs::Metadata,
 ) -> io::Result<(crate::fs::File, crate::fs::Metadata)> {
     use crate::fs::OpenOptions;
-    let writer = OpenOptions::new().open(to)?;
+    let writer = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(to)?;
     let writer_metadata = writer.metadata()?;
     Ok((writer, writer_metadata))
 }

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -2296,11 +2296,7 @@ fn open_to_and_set_permissions(
     _reader_metadata: &crate::fs::Metadata,
 ) -> io::Result<(crate::fs::File, crate::fs::Metadata)> {
     use crate::fs::OpenOptions;
-    let writer = OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .open(to)?;
+    let writer = OpenOptions::new().write(true).create(true).truncate(true).open(to)?;
     let writer_metadata = writer.metadata()?;
     Ok((writer, writer_metadata))
 }


### PR DESCRIPTION
When PR rust-lang/rust#147572 switched WASI to use Unix-style filesystem APIs, the open_to_and_set_permissions function for WASI was implemented to call OpenOptions::new().open() without setting any access mode flags.

This causes std::fs::copy to fail with the error:
"must specify at least one of read, write, or append access"

The fix is to explicitly set .write(true), .create(true), and .truncate(true) on the OpenOptions, matching the behavior of the non-WASI Unix implementation but without the permission handling that WASI doesn't support.

Minimal reproduction:
```rs
    fn main() {
        std::fs::write("/src.txt", b"test").unwrap();
        match std::fs::copy("/src.txt", "/dst.txt") {
            Ok(_) => println!("PASS: fs::copy works!"),
            Err(e) => println!("FAIL: {}", e),
        }
    }
```
    # Compile and run:
    rustc +nightly --target wasm32-wasip2 test.rs -o test.wasm
    wasmtime -S cli --dir . test.wasm

    # Before fix: FAIL: must specify at least one of read, write, or append access
    # After fix:  PASS: fs::copy works!

Note: The existing test library/std/src/fs/tests.rs::copy_file_ok would have caught this regression if the std test suite ran on WASI targets. Currently std tests don't compile for wasm32-wasip2 due to Unix-specific test code in library/std/src/sys/fd/unix/tests.rs.

Fixes the regression introduced in nightly-2025-12-10.

r? @alexcrichton
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
