### PR TITLE
Supress unused_parens lint for guard patterns

### DIFF
--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -1190,6 +1190,8 @@ impl UnusedParens {
                 // `&(a..=b)`, there is a recursive `check_pat` on `a` and `b`, but we will assume
                 // that if there are unnecessary parens they serve a purpose of readability.
                 PatKind::Range(..) => return,
+                // Parentheses may be necessary to disambiguate precedence in guard patterns.
+                PatKind::Guard(..) => return,
                 // Avoid `p0 | .. | pn` if we should.
                 PatKind::Or(..) if avoid_or => return,
                 // Avoid `mut x` and `mut x @ p` if we should:

--- a/tests/ui/lint/unused/unused_parens/parens-around-guard-patterns-not-unused.rs
+++ b/tests/ui/lint/unused/unused_parens/parens-around-guard-patterns-not-unused.rs
@@ -1,0 +1,13 @@
+//! Guard patterns require parentheses to disambiguate precedence
+//!
+//! Regression test for https://github.com/rust-lang/rust/issues/149594
+
+//@ check-pass
+
+#![feature(guard_patterns)]
+#![expect(incomplete_features)]
+#![warn(unused_parens)]
+
+fn main() {
+    let (_ if false) = ();
+}

--- a/tests/ui/reachable/guard_read_for_never.rs
+++ b/tests/ui/reachable/guard_read_for_never.rs
@@ -2,7 +2,7 @@
 //
 //@ check-pass
 #![feature(guard_patterns, never_type)]
-#![expect(incomplete_features, unused_parens)]
+#![expect(incomplete_features)]
 #![deny(unreachable_code)]
 
 fn main() {


### PR DESCRIPTION
Fixes rust-lang/rust#149594