### PR TITLE
Improve span for "unresolved intra doc link" on `deprecated` attribute

### DIFF
--- a/compiler/rustc_ast/src/attr/mod.rs
+++ b/compiler/rustc_ast/src/attr/mod.rs
@@ -235,14 +235,14 @@ impl AttributeExt for Attribute {
         }
     }
 
-    fn deprecation_note(&self) -> Option<Symbol> {
+    fn deprecation_note(&self) -> Option<Ident> {
         match &self.kind {
             AttrKind::Normal(normal) if normal.item.path == sym::deprecated => {
                 let meta = &normal.item;
 
                 // #[deprecated = "..."]
                 if let Some(s) = meta.value_str() {
-                    return Some(s);
+                    return Some(Ident { name: s, span: meta.span() });
                 }
 
                 // #[deprecated(note = "...")]
@@ -252,7 +252,7 @@ impl AttributeExt for Attribute {
                             && mi.path == sym::note
                             && let Some(s) = mi.value_str()
                         {
-                            return Some(s);
+                            return Some(Ident { name: s, span: mi.span });
                         }
                     }
                 }
@@ -905,7 +905,7 @@ pub trait AttributeExt: Debug {
     /// Returns the deprecation note if this is deprecation attribute.
     /// * `#[deprecated = "note"]` returns `Some("note")`.
     /// * `#[deprecated(note = "note", ...)]` returns `Some("note")`.
-    fn deprecation_note(&self) -> Option<Symbol>;
+    fn deprecation_note(&self) -> Option<Ident>;
 
     fn is_proc_macro_attr(&self) -> bool {
         [sym::proc_macro, sym::proc_macro_attribute, sym::proc_macro_derive]

--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -322,6 +322,13 @@ impl NameValueParser {
         self.value_as_lit().kind.str()
     }
 
+    /// If the value is a string literal, it will return its value associated with its span (an
+    /// `Ident` in short).
+    pub fn value_as_ident(&self) -> Option<Ident> {
+        let meta_item = self.value_as_lit();
+        meta_item.kind.str().map(|name| Ident { name, span: meta_item.span })
+    }
+
     pub fn args_span(&self) -> Span {
         self.eq_span.to(self.value_span)
     }

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -123,7 +123,7 @@ pub enum IntType {
 pub struct Deprecation {
     pub since: DeprecatedSince,
     /// The note to issue a reason.
-    pub note: Option<Symbol>,
+    pub note: Option<Ident>,
     /// A text snippet used to completely replace any use of the deprecated item in an expression.
     ///
     /// This is currently unstable.

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1402,7 +1402,7 @@ impl AttributeExt for Attribute {
     }
 
     #[inline]
-    fn deprecation_note(&self) -> Option<Symbol> {
+    fn deprecation_note(&self) -> Option<Ident> {
         match &self {
             Attribute::Parsed(AttributeKind::Deprecation { deprecation, .. }) => deprecation.note,
             _ => None,

--- a/compiler/rustc_middle/src/middle/stability.rs
+++ b/compiler/rustc_middle/src/middle/stability.rs
@@ -185,7 +185,7 @@ pub fn early_report_macro_deprecation(
     let diag = BuiltinLintDiag::DeprecatedMacro {
         suggestion: depr.suggestion,
         suggestion_span: span,
-        note: depr.note,
+        note: depr.note.map(|ident| ident.name),
         path,
         since_kind: deprecated_since_kind(is_in_effect, depr.since),
     };
@@ -228,7 +228,7 @@ fn late_report_deprecation(
         }),
         kind: def_kind.to_owned(),
         path: def_path,
-        note: depr.note,
+        note: depr.note.map(|ident| ident.name),
         since_kind: deprecated_since_kind(is_in_effect, depr.since),
     };
     tcx.emit_node_span_lint(lint, hir_id, method_span, diag);

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -26,7 +26,7 @@ use rustc_resolve::rustdoc::{
 use rustc_session::Session;
 use rustc_span::hygiene::MacroKind;
 use rustc_span::symbol::{Symbol, kw, sym};
-use rustc_span::{DUMMY_SP, FileName, Loc, RemapPathScopeComponents};
+use rustc_span::{DUMMY_SP, FileName, Ident, Loc, RemapPathScopeComponents};
 use tracing::{debug, trace};
 use {rustc_ast as ast, rustc_hir as hir};
 
@@ -418,7 +418,7 @@ impl Item {
             {
                 Some(Deprecation {
                     since: DeprecatedSince::Unspecified,
-                    note: Some(note),
+                    note: Some(Ident { name: note, span: DUMMY_SP }),
                     suggestion: None,
                 })
             } else {
@@ -455,7 +455,7 @@ impl Item {
             .attrs
             .other_attrs
             .iter()
-            .filter_map(|attr| attr.deprecation_note().map(|_| attr.span()));
+            .filter_map(|attr| attr.deprecation_note().map(|note| note.span));
 
         span_of_fragments(&self.attrs.doc_strings)
             .into_iter()

--- a/tests/rustdoc-ui/intra-doc/deprecated.stderr
+++ b/tests/rustdoc-ui/intra-doc/deprecated.stderr
@@ -1,8 +1,8 @@
 error: unresolved link to `TypeAlias::hoge`
-  --> $DIR/deprecated.rs:3:1
+  --> $DIR/deprecated.rs:3:16
    |
 LL | #[deprecated = "[broken cross-reference](TypeAlias::hoge)"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the link appears in this line:
            
@@ -16,10 +16,10 @@ LL | #![deny(rustdoc::broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unresolved link to `TypeAlias::hoge`
-  --> $DIR/deprecated.rs:6:1
+  --> $DIR/deprecated.rs:6:38
    |
 LL | #[deprecated(since = "0.0.0", note = "[broken cross-reference](TypeAlias::hoge)")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the link appears in this line:
            
@@ -28,10 +28,10 @@ LL | #[deprecated(since = "0.0.0", note = "[broken cross-reference](TypeAlias::h
    = note: no item named `TypeAlias` in scope
 
 error: unresolved link to `TypeAlias::hoge`
-  --> $DIR/deprecated.rs:9:1
+  --> $DIR/deprecated.rs:9:21
    |
 LL | #[deprecated(note = "[broken cross-reference](TypeAlias::hoge)", since = "0.0.0")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the link appears in this line:
            

--- a/tests/ui/unpretty/deprecated-attr.stdout
+++ b/tests/ui/unpretty/deprecated-attr.stdout
@@ -10,19 +10,19 @@ use ::std::prelude::rust_2015::*;
 struct PlainDeprecated;
 
 #[attr = Deprecation {deprecation: Deprecation {since: Unspecified,
-note: "here's why this is deprecated"}}]
+note: here's why this is deprecated#0}}]
 struct DirectNote;
 
 #[attr = Deprecation {deprecation: Deprecation {since: Unspecified,
-note: "here's why this is deprecated"}}]
+note: here's why this is deprecated#0}}]
 struct ExplicitNote;
 
 #[attr = Deprecation {deprecation: Deprecation {since: NonStandard("1.2.3"),
-note: "here's why this is deprecated"}}]
+note: here's why this is deprecated#0}}]
 struct SinceAndNote;
 
 #[attr = Deprecation {deprecation: Deprecation {since: NonStandard("1.2.3"),
-note: "here's why this is deprecated"}}]
+note: here's why this is deprecated#0}}]
 struct FlippedOrder;
 
 fn f() {


### PR DESCRIPTION
Follow-up of rust-lang/rust#150721.

To make this work, I replaced the `Symbol` by an `Ident` to keep the `Span` information.

cc @folkertdev 
r? @camelid 