### PR TITLE
Update bors email in CI postprocessing step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,7 +289,7 @@ jobs:
           fi
 
           # Get closest bors merge commit
-          PARENT_COMMIT=`git rev-list --author='bors <bors@rust-lang.org>' -n1 --first-parent HEAD^1`
+          PARENT_COMMIT=`git rev-list --author='122020455+rust-bors\[bot\]@users.noreply.github.com' -n1 --first-parent HEAD^1`
 
           ./build/citool/debug/citool postprocess-metrics \
               --job-name ${CI_JOB_NAME} \


### PR DESCRIPTION
This was breaking CI job summaries. I don't think we have to backport it, should be mostly harmless.
