### PR TITLE
rustc_parse_format: improve diagnostics for unsupported debug = syntax

### DIFF
--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -678,6 +678,18 @@ pub(crate) enum InvalidFormatStringSuggestion {
         #[primary_span]
         span: Span,
     },
+
+    #[suggestion(
+        "use rust debug printing macro",
+        code = "{replacement}",
+        style = "verbose",
+        applicability = "machine-applicable"
+    )]
+    UseRustDebugPrintingMacro {
+        #[primary_span]
+        macro_span: Span,
+        replacement: String,
+    },
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -187,6 +187,9 @@ pub enum Suggestion {
     /// Add missing colon:
     /// `format!("{foo?}")` -> `format!("{foo:?}")`
     AddMissingColon(Range<usize>),
+    /// Use Rust format string:
+    /// `format!("{x=}")` -> `dbg!(x)`
+    UseRustDebugPrintingMacro,
 }
 
 /// The parser structure for interpreting the input format string. This is
@@ -462,6 +465,7 @@ impl<'input> Parser<'input> {
                 ('?', _) => self.suggest_format_debug(),
                 ('<' | '^' | '>', _) => self.suggest_format_align(c),
                 (',', _) => self.suggest_unsupported_python_numeric_grouping(),
+                ('=', '}') => self.suggest_rust_debug_printing_macro(),
                 _ => self.suggest_positional_arg_instead_of_captured_arg(arg),
             }
         }
@@ -866,6 +870,27 @@ impl<'input> Parser<'input> {
                     span: range,
                     secondary_label: None,
                     suggestion: Suggestion::AddMissingColon(span),
+                },
+            );
+        }
+    }
+
+    fn suggest_rust_debug_printing_macro(&mut self) {
+        if let Some((range, _)) = self.consume_pos('=') {
+            self.errors.insert(
+                0,
+                ParseError {
+                    description:
+                        "python's f-string debug `=` is not supported in rust, use `dbg(x)` instead"
+                            .to_owned(),
+                    note: Some(format!("to print `{{`, you can escape it using `{{{{`",)),
+                    label: "expected `}`".to_owned(),
+                    span: range,
+                    secondary_label: self
+                        .last_open_brace
+                        .clone()
+                        .map(|sp| ("because of this opening brace".to_owned(), sp)),
+                    suggestion: Suggestion::UseRustDebugPrintingMacro,
                 },
             );
         }

--- a/tests/ui/fmt/format-string-error-2.rs
+++ b/tests/ui/fmt/format-string-error-2.rs
@@ -88,4 +88,7 @@ raw  { \n
     //~^ ERROR invalid format string: expected `}`, found `?`
     println!("{x,}, world!",);
     //~^ ERROR invalid format string: python's numeric grouping `,` is not supported in rust format strings
+
+    println!("{x=}");
+    //~^ ERROR invalid format string: python's f-string debug `=` is not supported in rust, use `dbg(x)` instead
 }

--- a/tests/ui/fmt/format-string-error-2.stderr
+++ b/tests/ui/fmt/format-string-error-2.stderr
@@ -198,5 +198,15 @@ LL |     println!("{x,}, world!",);
    |
    = note: to print `{`, you can escape it using `{{`
 
-error: aborting due to 20 previous errors
+error: invalid format string: python's f-string debug `=` is not supported in rust, use `dbg(x)` instead
+  --> $DIR/format-string-error-2.rs:92:17
+   |
+LL |     println!("{x=}");
+   |               - ^ expected `}` in format string
+   |               |
+   |               because of this opening brace
+   |
+   = note: to print `{`, you can escape it using `{{`
+
+error: aborting due to 21 previous errors
 

--- a/tests/ui/fmt/format-string-error-3.fixed
+++ b/tests/ui/fmt/format-string-error-3.fixed
@@ -1,0 +1,5 @@
+//@ run-rustfix
+fn main() {
+    let x = 32;
+    dbg!(x); //~ ERROR invalid format string: python's f-string debug
+}

--- a/tests/ui/fmt/format-string-error-3.rs
+++ b/tests/ui/fmt/format-string-error-3.rs
@@ -1,0 +1,5 @@
+//@ run-rustfix
+fn main() {
+    let x = 32;
+    println!("{=}", x); //~ ERROR invalid format string: python's f-string debug
+}

--- a/tests/ui/fmt/format-string-error-3.stderr
+++ b/tests/ui/fmt/format-string-error-3.stderr
@@ -1,0 +1,17 @@
+error: invalid format string: python's f-string debug `=` is not supported in rust, use `dbg(x)` instead
+  --> $DIR/format-string-error-3.rs:4:16
+   |
+LL |     println!("{=}", x);
+   |               -^ expected `}` in format string
+   |               |
+   |               because of this opening brace
+   |
+   = note: to print `{`, you can escape it using `{{`
+help: use rust debug printing macro
+   |
+LL -     println!("{=}", x);
+LL +     dbg!(x);
+   |
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Detect Python-style f-string debug syntax in format strings and emit a
clear diagnostic explaining that it is not supported in Rust. When the
intended operation can be inferred, suggest the corresponding Rust
alternative (e.g. `dbg!` for `{x=}`).
