### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2117,10 +2117,9 @@ pub struct MacroDef {
 
 #[derive(Clone, Encodable, Decodable, Debug, HashStable_Generic, Walkable)]
 pub struct EiiExternTarget {
-    /// path to the extern item we're targetting
+    /// path to the extern item we're targeting
     pub extern_item_path: Path,
     pub impl_unsafe: bool,
-    pub span: Span,
 }
 
 #[derive(Clone, Encodable, Decodable, Debug, Copy, Hash, Eq, PartialEq)]

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -3813,6 +3813,19 @@ pub struct Fn {
 pub struct EiiImpl {
     pub node_id: NodeId,
     pub eii_macro_path: Path,
+    /// This field is an implementation detail that prevents a lot of bugs.
+    /// See <https://github.com/rust-lang/rust/issues/149981> for an example.
+    ///
+    /// The problem is, that if we generate a declaration *together* with its default,
+    /// we generate both a declaration and an implementation. The generated implementation
+    /// uses the same mechanism to register itself as a user-defined implementation would,
+    /// despite being invisible to users. What does happen is a name resolution step.
+    /// The invisible default implementation has to find the declaration.
+    /// Both are generated at the same time, so we can skip that name resolution step.
+    ///
+    /// This field is that shortcut: we prefill the extern target to skip a name resolution step,
+    /// making sure it never fails. It'd be awful UX if we fail name resolution in code invisible to the user.
+    pub known_eii_macro_resolution: Option<EiiExternTarget>,
     pub impl_safety: Safety,
     pub span: Span,
     pub inner_span: Span,

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -2,7 +2,7 @@ use rustc_abi::ExternAbi;
 use rustc_ast::visit::AssocCtxt;
 use rustc_ast::*;
 use rustc_errors::{E0570, ErrorGuaranteed, struct_span_code_err};
-use rustc_hir::attrs::{AttributeKind, EiiDecl};
+use rustc_hir::attrs::{AttributeKind, EiiDecl, EiiImplResolution};
 use rustc_hir::def::{DefKind, PerNS, Res};
 use rustc_hir::def_id::{CRATE_DEF_ID, LocalDefId};
 use rustc_hir::{
@@ -134,6 +134,55 @@ impl<'hir> LoweringContext<'_, 'hir> {
         }
     }
 
+    fn lower_eii_extern_target(
+        &mut self,
+        id: NodeId,
+        EiiExternTarget { extern_item_path, impl_unsafe, span }: &EiiExternTarget,
+    ) -> Option<EiiDecl> {
+        self.lower_path_simple_eii(id, extern_item_path).map(|did| EiiDecl {
+            eii_extern_target: did,
+            impl_unsafe: *impl_unsafe,
+            span: self.lower_span(*span),
+        })
+    }
+
+    fn lower_eii_impl(
+        &mut self,
+        EiiImpl {
+            node_id,
+            eii_macro_path,
+            impl_safety,
+            span,
+            inner_span,
+            is_default,
+            known_eii_macro_resolution,
+        }: &EiiImpl,
+    ) -> hir::attrs::EiiImpl {
+        let resolution = if let Some(target) = known_eii_macro_resolution
+            && let Some(decl) = self.lower_eii_extern_target(*node_id, target)
+        {
+            EiiImplResolution::Known(
+                decl,
+                // the expect is ok here since we always generate this path in the eii macro.
+                eii_macro_path.segments.last().expect("at least one segment").ident.name,
+            )
+        } else if let Some(macro_did) = self.lower_path_simple_eii(*node_id, eii_macro_path) {
+            EiiImplResolution::Macro(macro_did)
+        } else {
+            EiiImplResolution::Error(
+                self.dcx().span_delayed_bug(*span, "eii never resolved without errors given"),
+            )
+        };
+
+        hir::attrs::EiiImpl {
+            span: self.lower_span(*span),
+            inner_span: self.lower_span(*inner_span),
+            impl_marked_unsafe: self.lower_safety(*impl_safety, hir::Safety::Safe).is_unsafe(),
+            is_default: *is_default,
+            resolution,
+        }
+    }
+
     fn generate_extra_attrs_for_item_kind(
         &mut self,
         id: NodeId,
@@ -143,49 +192,14 @@ impl<'hir> LoweringContext<'_, 'hir> {
             ItemKind::Fn(box Fn { eii_impls, .. }) if eii_impls.is_empty() => Vec::new(),
             ItemKind::Fn(box Fn { eii_impls, .. }) => {
                 vec![hir::Attribute::Parsed(AttributeKind::EiiImpls(
-                    eii_impls
-                        .iter()
-                        .flat_map(
-                            |EiiImpl {
-                                 node_id,
-                                 eii_macro_path,
-                                 impl_safety,
-                                 span,
-                                 inner_span,
-                                 is_default,
-                             }| {
-                                self.lower_path_simple_eii(*node_id, eii_macro_path).map(|did| {
-                                    hir::attrs::EiiImpl {
-                                        eii_macro: did,
-                                        span: self.lower_span(*span),
-                                        inner_span: self.lower_span(*inner_span),
-                                        impl_marked_unsafe: self
-                                            .lower_safety(*impl_safety, hir::Safety::Safe)
-                                            .is_unsafe(),
-                                        is_default: *is_default,
-                                    }
-                                })
-                            },
-                        )
-                        .collect(),
+                    eii_impls.iter().map(|i| self.lower_eii_impl(i)).collect(),
                 ))]
             }
-            ItemKind::MacroDef(
-                _,
-                MacroDef {
-                    eii_extern_target: Some(EiiExternTarget { extern_item_path, impl_unsafe, span }),
-                    ..
-                },
-            ) => self
-                .lower_path_simple_eii(id, extern_item_path)
-                .map(|did| {
-                    vec![hir::Attribute::Parsed(AttributeKind::EiiExternTarget(EiiDecl {
-                        eii_extern_target: did,
-                        impl_unsafe: *impl_unsafe,
-                        span: self.lower_span(*span),
-                    }))]
-                })
+            ItemKind::MacroDef(_, MacroDef { eii_extern_target: Some(target), .. }) => self
+                .lower_eii_extern_target(id, target)
+                .map(|decl| vec![hir::Attribute::Parsed(AttributeKind::EiiExternTarget(decl))])
                 .unwrap_or_default(),
+
             ItemKind::ExternCrate(..)
             | ItemKind::Use(..)
             | ItemKind::Static(..)

--- a/compiler/rustc_builtin_macros/src/eii.rs
+++ b/compiler/rustc_builtin_macros/src/eii.rs
@@ -103,8 +103,6 @@ fn eii_(
 
     // span of the declaring item without attributes
     let item_span = func.sig.span;
-    // span of the eii attribute and the item below it, i.e. the full declaration
-    let decl_span = eii_attr_span.to(item_span);
     let foreign_item_name = func.ident;
 
     let mut return_items = Vec::new();
@@ -134,7 +132,6 @@ fn eii_(
         macro_name,
         foreign_item_name,
         impl_unsafe,
-        decl_span,
     )));
 
     return_items.into_iter().map(wrap_item).collect()
@@ -213,7 +210,6 @@ fn generate_default_impl(
         known_eii_macro_resolution: Some(ast::EiiExternTarget {
             extern_item_path: ast::Path::from_ident(foreign_item_name),
             impl_unsafe,
-            span: item_span,
         }),
     });
 
@@ -359,7 +355,6 @@ fn generate_attribute_macro_to_implement(
     macro_name: Ident,
     foreign_item_name: Ident,
     impl_unsafe: bool,
-    decl_span: Span,
 ) -> ast::Item {
     let mut macro_attrs = ThinVec::new();
 
@@ -401,7 +396,6 @@ fn generate_attribute_macro_to_implement(
                 eii_extern_target: Some(ast::EiiExternTarget {
                     extern_item_path: ast::Path::from_ident(foreign_item_name),
                     impl_unsafe,
-                    span: decl_span,
                 }),
             },
         ),
@@ -458,7 +452,7 @@ pub(crate) fn eii_extern_target(
         false
     };
 
-    d.eii_extern_target = Some(EiiExternTarget { extern_item_path, impl_unsafe, span });
+    d.eii_extern_target = Some(EiiExternTarget { extern_item_path, impl_unsafe });
 
     // Return the original item and the new methods.
     vec![item]

--- a/compiler/rustc_builtin_macros/src/eii.rs
+++ b/compiler/rustc_builtin_macros/src/eii.rs
@@ -116,6 +116,7 @@ fn eii_(
             macro_name,
             eii_attr_span,
             item_span,
+            foreign_item_name,
         )))
     }
 
@@ -192,6 +193,7 @@ fn generate_default_impl(
     macro_name: Ident,
     eii_attr_span: Span,
     item_span: Span,
+    foreign_item_name: Ident,
 ) -> ast::Item {
     // FIXME: re-add some original attrs
     let attrs = ThinVec::new();
@@ -208,6 +210,11 @@ fn generate_default_impl(
         },
         span: eii_attr_span,
         is_default: true,
+        known_eii_macro_resolution: Some(ast::EiiExternTarget {
+            extern_item_path: ast::Path::from_ident(foreign_item_name),
+            impl_unsafe,
+            span: item_span,
+        }),
     });
 
     ast::Item {
@@ -508,6 +515,7 @@ pub(crate) fn eii_shared_macro(
         impl_safety: meta_item.unsafety,
         span,
         is_default,
+        known_eii_macro_resolution: None,
     });
 
     vec![item]

--- a/compiler/rustc_builtin_macros/src/eii.rs
+++ b/compiler/rustc_builtin_macros/src/eii.rs
@@ -109,6 +109,7 @@ fn eii_(
 
     if func.body.is_some() {
         return_items.push(Box::new(generate_default_impl(
+            ecx,
             &func,
             impl_unsafe,
             macro_name,
@@ -185,6 +186,7 @@ fn filter_attrs_for_multiple_eii_attr(
 }
 
 fn generate_default_impl(
+    ecx: &mut ExtCtxt<'_>,
     func: &ast::Fn,
     impl_unsafe: bool,
     macro_name: Ident,
@@ -208,7 +210,18 @@ fn generate_default_impl(
         span: eii_attr_span,
         is_default: true,
         known_eii_macro_resolution: Some(ast::EiiExternTarget {
-            extern_item_path: ast::Path::from_ident(foreign_item_name),
+            extern_item_path: ast::Path {
+                span: foreign_item_name.span,
+                segments: thin_vec![
+                    ast::PathSegment {
+                        ident: Ident::from_str_and_span("super", foreign_item_name.span,),
+                        id: DUMMY_NODE_ID,
+                        args: None
+                    },
+                    ast::PathSegment { ident: foreign_item_name, id: DUMMY_NODE_ID, args: None },
+                ],
+                tokens: None,
+            },
             impl_unsafe,
         }),
     });
@@ -239,18 +252,66 @@ fn generate_default_impl(
                         stmts: thin_vec![ast::Stmt {
                             id: DUMMY_NODE_ID,
                             kind: ast::StmtKind::Item(Box::new(ast::Item {
-                                attrs,
+                                attrs: ThinVec::new(),
                                 id: DUMMY_NODE_ID,
                                 span: item_span,
                                 vis: ast::Visibility {
-                                    span: eii_attr_span,
+                                    span: item_span,
                                     kind: ast::VisibilityKind::Inherited,
                                     tokens: None
                                 },
-                                kind: ItemKind::Fn(Box::new(default_func)),
+                                kind: ItemKind::Mod(
+                                    ast::Safety::Default,
+                                    Ident::from_str_and_span("dflt", item_span),
+                                    ast::ModKind::Loaded(
+                                        thin_vec![
+                                            Box::new(ast::Item {
+                                                attrs: thin_vec![ecx.attr_nested_word(
+                                                    sym::allow,
+                                                    sym::unused_imports,
+                                                    item_span
+                                                ),],
+                                                id: DUMMY_NODE_ID,
+                                                span: item_span,
+                                                vis: ast::Visibility {
+                                                    span: eii_attr_span,
+                                                    kind: ast::VisibilityKind::Inherited,
+                                                    tokens: None
+                                                },
+                                                kind: ItemKind::Use(ast::UseTree {
+                                                    prefix: ast::Path::from_ident(
+                                                        Ident::from_str_and_span(
+                                                            "super", item_span,
+                                                        )
+                                                    ),
+                                                    kind: ast::UseTreeKind::Glob,
+                                                    span: item_span,
+                                                }),
+                                                tokens: None,
+                                            }),
+                                            Box::new(ast::Item {
+                                                attrs,
+                                                id: DUMMY_NODE_ID,
+                                                span: item_span,
+                                                vis: ast::Visibility {
+                                                    span: eii_attr_span,
+                                                    kind: ast::VisibilityKind::Inherited,
+                                                    tokens: None
+                                                },
+                                                kind: ItemKind::Fn(Box::new(default_func)),
+                                                tokens: None,
+                                            }),
+                                        ],
+                                        ast::Inline::Yes,
+                                        ast::ModSpans {
+                                            inner_span: item_span,
+                                            inject_use_span: item_span,
+                                        }
+                                    )
+                                ),
                                 tokens: None,
                             })),
-                            span: eii_attr_span
+                            span: eii_attr_span,
                         }],
                         id: DUMMY_NODE_ID,
                         rules: ast::BlockCheckMode::Default,

--- a/compiler/rustc_codegen_llvm/src/mono_item.rs
+++ b/compiler/rustc_codegen_llvm/src/mono_item.rs
@@ -153,7 +153,7 @@ impl CodegenCx<'_, '_> {
             return false;
         }
 
-        // With pie relocation model calls of functions defined in the translation
+        // With pie relocation model, calls of functions defined in the translation
         // unit can use copy relocations.
         if self.tcx.sess.relocation_model() == RelocModel::Pie && !is_declaration {
             return true;

--- a/compiler/rustc_codegen_llvm/src/mono_item.rs
+++ b/compiler/rustc_codegen_llvm/src/mono_item.rs
@@ -111,7 +111,7 @@ impl CodegenCx<'_, '_> {
         }
     }
 
-    /// Whether a definition or declaration can be assumed to be local to a group of
+    /// A definition or declaration can be assumed to be local to a group of
     /// libraries that form a single DSO or executable.
     /// Marks the local as DSO if so.
     pub(crate) fn assume_dso_local(&self, llval: &llvm::Value, is_declaration: bool) -> bool {

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -301,7 +301,7 @@ fn process_builtin_attrs(
                                 };
                                 extern_item
                             }
-                            EiiImplResolution::Known(decl, _) => decl.eii_extern_target,
+                            EiiImplResolution::Known(decl) => decl.eii_extern_target,
                             EiiImplResolution::Error(_eg) => continue,
                         };
 

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -285,11 +285,16 @@ fn process_builtin_attrs(
                 }
                 AttributeKind::EiiImpls(impls) => {
                     for i in impls {
-                        let extern_item = find_attr!(
+                        let Some(extern_item) = find_attr!(
                             tcx.get_all_attrs(i.eii_macro),
                             AttributeKind::EiiExternTarget(target) => target.eii_extern_target
-                        )
-                        .expect("eii should have declaration macro with extern target attribute");
+                        ) else {
+                            tcx.dcx().span_delayed_bug(
+                                i.span,
+                                "resolved to something that's not an EII",
+                            );
+                            continue;
+                        };
 
                         // this is to prevent a bug where a single crate defines both the default and explicit implementation
                         // for an EII. In that case, both of them may be part of the same final object file. I'm not 100% sure

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -3,7 +3,9 @@ use std::str::FromStr;
 use rustc_abi::{Align, ExternAbi};
 use rustc_ast::expand::autodiff_attrs::{AutoDiffAttrs, DiffActivity, DiffMode};
 use rustc_ast::{LitKind, MetaItem, MetaItemInner, attr};
-use rustc_hir::attrs::{AttributeKind, InlineAttr, Linkage, RtsanSetting, UsedBy};
+use rustc_hir::attrs::{
+    AttributeKind, EiiImplResolution, InlineAttr, Linkage, RtsanSetting, UsedBy,
+};
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LOCAL_CRATE, LocalDefId};
 use rustc_hir::{self as hir, Attribute, LangItem, find_attr, lang_items};
@@ -285,15 +287,22 @@ fn process_builtin_attrs(
                 }
                 AttributeKind::EiiImpls(impls) => {
                     for i in impls {
-                        let Some(extern_item) = find_attr!(
-                            tcx.get_all_attrs(i.eii_macro),
-                            AttributeKind::EiiExternTarget(target) => target.eii_extern_target
-                        ) else {
-                            tcx.dcx().span_delayed_bug(
-                                i.span,
-                                "resolved to something that's not an EII",
-                            );
-                            continue;
+                        let extern_item = match i.resolution {
+                            EiiImplResolution::Macro(def_id) => {
+                                let Some(extern_item) = find_attr!(
+                                    tcx.get_all_attrs(def_id),
+                                    AttributeKind::EiiExternTarget(target) => target.eii_extern_target
+                                ) else {
+                                    tcx.dcx().span_delayed_bug(
+                                        i.span,
+                                        "resolved to something that's not an EII",
+                                    );
+                                    continue;
+                                };
+                                extern_item
+                            }
+                            EiiImplResolution::Known(decl, _) => decl.eii_extern_target,
+                            EiiImplResolution::Error(_eg) => continue,
                         };
 
                         // this is to prevent a bug where a single crate defines both the default and explicit implementation
@@ -307,7 +316,7 @@ fn process_builtin_attrs(
                             // iterate over all implementations *in the current crate*
                             // (this is ok since we generate codegen fn attrs in the local crate)
                             // if any of them is *not default* then don't emit the alias.
-                            && tcx.externally_implementable_items(LOCAL_CRATE).get(&i.eii_macro).expect("at least one").1.iter().any(|(_, imp)| !imp.is_default)
+                            && tcx.externally_implementable_items(LOCAL_CRATE).get(&extern_item).expect("at least one").1.iter().any(|(_, imp)| !imp.is_default)
                         {
                             continue;
                         }

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -27,7 +27,7 @@ pub enum EiiImplResolution {
     Macro(DefId),
     /// Sometimes though, we already know statically and can skip some name resolution.
     /// Stored together with the eii's name for diagnostics.
-    Known(EiiDecl, Symbol),
+    Known(EiiDecl),
     /// For when resolution failed, but we want to continue compilation
     Error(ErrorGuaranteed),
 }
@@ -46,7 +46,7 @@ pub struct EiiDecl {
     pub eii_extern_target: DefId,
     /// whether or not it is unsafe to implement this EII
     pub impl_unsafe: bool,
-    pub span: Span,
+    pub name: Ident,
 }
 
 #[derive(Copy, Clone, PartialEq, Encodable, Decodable, Debug, HashStable_Generic, PrintAttribute)]

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -11,7 +11,7 @@ use rustc_error_messages::{DiagArgValue, IntoDiagArg};
 use rustc_macros::{Decodable, Encodable, HashStable_Generic, PrintAttribute};
 use rustc_span::def_id::DefId;
 use rustc_span::hygiene::Transparency;
-use rustc_span::{Ident, Span, Symbol};
+use rustc_span::{ErrorGuaranteed, Ident, Span, Symbol};
 pub use rustc_target::spec::SanitizerSet;
 use thin_vec::ThinVec;
 
@@ -20,8 +20,21 @@ use crate::limit::Limit;
 use crate::{DefaultBodyStability, PartialConstStability, RustcVersion, Stability};
 
 #[derive(Copy, Clone, Debug, HashStable_Generic, Encodable, Decodable, PrintAttribute)]
+pub enum EiiImplResolution {
+    /// Usually, finding the extern item that an EII implementation implements means finding
+    /// the defid of the associated attribute macro, and looking at *its* attributes to find
+    /// what foreign item its associated with.
+    Macro(DefId),
+    /// Sometimes though, we already know statically and can skip some name resolution.
+    /// Stored together with the eii's name for diagnostics.
+    Known(EiiDecl, Symbol),
+    /// For when resolution failed, but we want to continue compilation
+    Error(ErrorGuaranteed),
+}
+
+#[derive(Copy, Clone, Debug, HashStable_Generic, Encodable, Decodable, PrintAttribute)]
 pub struct EiiImpl {
-    pub eii_macro: DefId,
+    pub resolution: EiiImplResolution,
     pub impl_marked_unsafe: bool,
     pub span: Span,
     pub inner_span: Span,

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1213,9 +1213,7 @@ fn check_eiis(tcx: TyCtxt<'_>, def_id: LocalDefId) {
                 *span,
             );
         } else {
-            panic!(
-                "EII impl macro {eii_macro:?} did not have an eii extern target attribute pointing to a foreign function"
-            )
+            tcx.dcx().span_delayed_bug(*span, "resolved to something that's not an EII");
         }
     }
 }

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -6,7 +6,7 @@ use rustc_abi::{ExternAbi, ScalableElt};
 use rustc_data_structures::fx::{FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_errors::codes::*;
 use rustc_errors::{Applicability, ErrorGuaranteed, pluralize, struct_span_code_err};
-use rustc_hir::attrs::{AttributeKind, EiiDecl, EiiImpl};
+use rustc_hir::attrs::{AttributeKind, EiiDecl, EiiImpl, EiiImplResolution};
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::lang_items::LangItem;
@@ -1196,25 +1196,28 @@ fn check_item_fn(
 fn check_eiis(tcx: TyCtxt<'_>, def_id: LocalDefId) {
     // does the function have an EiiImpl attribute? that contains the defid of a *macro*
     // that was used to mark the implementation. This is a two step process.
-    for EiiImpl { eii_macro, span, .. } in
+    for EiiImpl { resolution, span, .. } in
         find_attr!(tcx.get_all_attrs(def_id), AttributeKind::EiiImpls(impls) => impls)
             .into_iter()
             .flatten()
     {
-        // we expect this macro to have the `EiiMacroFor` attribute, that points to a function
-        // signature that we'd like to compare the function we're currently checking with
-        if let Some(eii_extern_target) = find_attr!(tcx.get_all_attrs(*eii_macro), AttributeKind::EiiExternTarget(EiiDecl {eii_extern_target, ..}) => *eii_extern_target)
-        {
-            let _ = compare_eii_function_types(
-                tcx,
-                def_id,
-                eii_extern_target,
-                tcx.item_name(*eii_macro),
-                *span,
-            );
-        } else {
-            tcx.dcx().span_delayed_bug(*span, "resolved to something that's not an EII");
-        }
+        let (foreign_item, name) = match resolution {
+            EiiImplResolution::Macro(def_id) => {
+                // we expect this macro to have the `EiiMacroFor` attribute, that points to a function
+                // signature that we'd like to compare the function we're currently checking with
+                if let Some(foreign_item) = find_attr!(tcx.get_all_attrs(*def_id), AttributeKind::EiiExternTarget(EiiDecl {eii_extern_target: t, ..}) => *t)
+                {
+                    (foreign_item, tcx.item_name(*def_id))
+                } else {
+                    tcx.dcx().span_delayed_bug(*span, "resolved to something that's not an EII");
+                    continue;
+                }
+            }
+            EiiImplResolution::Known(decl, name) => (decl.eii_extern_target, *name),
+            EiiImplResolution::Error(_eg) => continue,
+        };
+
+        let _ = compare_eii_function_types(tcx, def_id, foreign_item, name, *span);
     }
 }
 

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1213,7 +1213,7 @@ fn check_eiis(tcx: TyCtxt<'_>, def_id: LocalDefId) {
                     continue;
                 }
             }
-            EiiImplResolution::Known(decl, name) => (decl.eii_extern_target, *name),
+            EiiImplResolution::Known(decl) => (decl.eii_extern_target, decl.name.name),
             EiiImplResolution::Error(_eg) => continue,
         };
 

--- a/compiler/rustc_metadata/src/eii.rs
+++ b/compiler/rustc_metadata/src/eii.rs
@@ -40,7 +40,7 @@ pub(crate) fn collect<'tcx>(tcx: TyCtxt<'tcx>, LocalCrate: LocalCrate) -> EiiMap
                     };
                     decl
                 }
-                EiiImplResolution::Known(decl, _) => decl,
+                EiiImplResolution::Known(decl) => decl,
                 EiiImplResolution::Error(_eg) => continue,
             };
 

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1657,9 +1657,14 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         empty_proc_macro!(self);
         let externally_implementable_items = self.tcx.externally_implementable_items(LOCAL_CRATE);
 
-        self.lazy_array(externally_implementable_items.iter().map(|(decl_did, (decl, impls))| {
-            (*decl_did, (decl.clone(), impls.iter().map(|(impl_did, i)| (*impl_did, *i)).collect()))
-        }))
+        self.lazy_array(externally_implementable_items.iter().map(
+            |(foreign_item, (decl, impls))| {
+                (
+                    *foreign_item,
+                    (decl.clone(), impls.iter().map(|(impl_did, i)| (*impl_did, *i)).collect()),
+                )
+            },
+        ))
     }
 
     #[instrument(level = "trace", skip(self))]

--- a/compiler/rustc_mir_transform/src/errors.rs
+++ b/compiler/rustc_mir_transform/src/errors.rs
@@ -19,14 +19,14 @@ pub(crate) fn emit_inline_always_target_feature_diagnostic<'a, 'tcx>(
     caller_def_id: DefId,
     callee_only: &[&'a str],
 ) {
-    let callee = tcx.def_path_str(callee_def_id);
-    let caller = tcx.def_path_str(caller_def_id);
-
     tcx.node_span_lint(
         lint::builtin::INLINE_ALWAYS_MISMATCHING_TARGET_FEATURES,
         tcx.local_def_id_to_hir_id(caller_def_id.as_local().unwrap()),
         call_span,
         |lint| {
+            let callee = tcx.def_path_str(callee_def_id);
+            let caller = tcx.def_path_str(caller_def_id);
+
             lint.primary_message(format!(
                 "call to `#[inline(always)]`-annotated `{callee}` \
                 requires the same target features to be inlined"

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -761,7 +761,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     for i in impls {
                         let name = match i.resolution {
                             EiiImplResolution::Macro(def_id) => self.tcx.item_name(def_id),
-                            EiiImplResolution::Known(_, name) => name,
+                            EiiImplResolution::Known(decl) => decl.name.name,
                             EiiImplResolution::Error(_eg) => continue,
                         };
                         self.dcx().emit_err(errors::EiiWithTrackCaller {

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -21,8 +21,8 @@ use rustc_feature::{
     BuiltinAttribute,
 };
 use rustc_hir::attrs::{
-    AttributeKind, DocAttribute, DocInline, EiiDecl, EiiImpl, InlineAttr, MirDialect, MirPhase,
-    ReprAttr, SanitizerSet,
+    AttributeKind, DocAttribute, DocInline, EiiDecl, EiiImpl, EiiImplResolution, InlineAttr,
+    MirDialect, MirPhase, ReprAttr, SanitizerSet,
 };
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::LocalModDefId;
@@ -506,7 +506,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
     }
 
     fn check_eii_impl(&self, impls: &[EiiImpl], target: Target) {
-        for EiiImpl { span, inner_span, eii_macro, impl_marked_unsafe, is_default: _ } in impls {
+        for EiiImpl { span, inner_span, resolution, impl_marked_unsafe, is_default: _ } in impls {
             match target {
                 Target::Fn => {}
                 _ => {
@@ -514,7 +514,8 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 }
             }
 
-            if find_attr!(self.tcx.get_all_attrs(*eii_macro), AttributeKind::EiiExternTarget(EiiDecl { impl_unsafe, .. }) if *impl_unsafe)
+            if let EiiImplResolution::Macro(eii_macro) = resolution
+                && find_attr!(self.tcx.get_all_attrs(*eii_macro), AttributeKind::EiiExternTarget(EiiDecl { impl_unsafe, .. }) if *impl_unsafe)
                 && !impl_marked_unsafe
             {
                 self.dcx().emit_err(errors::EiiImplRequiresUnsafe {
@@ -758,9 +759,14 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 if let Some(impls) = find_attr!(attrs, AttributeKind::EiiImpls(impls) => impls) {
                     let sig = self.tcx.hir_node(hir_id).fn_sig().unwrap();
                     for i in impls {
+                        let name = match i.resolution {
+                            EiiImplResolution::Macro(def_id) => self.tcx.item_name(def_id),
+                            EiiImplResolution::Known(_, name) => name,
+                            EiiImplResolution::Error(_eg) => continue,
+                        };
                         self.dcx().emit_err(errors::EiiWithTrackCaller {
                             attr_span,
-                            name: self.tcx.item_name(i.eii_macro),
+                            name,
                             sig_span: sig.span,
                         });
                     }

--- a/compiler/rustc_passes/src/eii.rs
+++ b/compiler/rustc_passes/src/eii.rs
@@ -80,8 +80,6 @@ pub(crate) fn check_externally_implementable_items<'tcx>(tcx: TyCtxt<'tcx>, (): 
         }
     }
 
-    println!("{eiis:#?}");
-
     // now we have all eiis! For each of them, choose one we want to actually generate.
     for (foreign_item, FoundEii { decl, decl_crate, impls }) in eiis {
         let mut default_impls = Vec::new();

--- a/compiler/rustc_passes/src/eii.rs
+++ b/compiler/rustc_passes/src/eii.rs
@@ -80,6 +80,8 @@ pub(crate) fn check_externally_implementable_items<'tcx>(tcx: TyCtxt<'tcx>, (): 
         }
     }
 
+    println!("{eiis:#?}");
+
     // now we have all eiis! For each of them, choose one we want to actually generate.
     for (foreign_item, FoundEii { decl, decl_crate, impls }) in eiis {
         let mut default_impls = Vec::new();
@@ -97,7 +99,7 @@ pub(crate) fn check_externally_implementable_items<'tcx>(tcx: TyCtxt<'tcx>, (): 
         // is instantly an error.
         if explicit_impls.len() > 1 {
             tcx.dcx().emit_err(DuplicateEiiImpls {
-                name: tcx.item_name(foreign_item),
+                name: decl.name.name,
                 first_span: tcx.def_span(explicit_impls[0].0),
                 first_crate: tcx.crate_name(explicit_impls[0].1),
                 second_span: tcx.def_span(explicit_impls[1].0),
@@ -140,8 +142,8 @@ pub(crate) fn check_externally_implementable_items<'tcx>(tcx: TyCtxt<'tcx>, (): 
                         current_crate_name: tcx.crate_name(LOCAL_CRATE),
                         decl_crate_name: tcx.crate_name(decl_crate),
                         // FIXME: shouldn't call `item_name`
-                        name: tcx.item_name(foreign_item),
-                        span: decl.span,
+                        name: decl.name.name,
+                        span: decl.name.span,
                         help: (),
                     });
 

--- a/compiler/rustc_passes/src/eii.rs
+++ b/compiler/rustc_passes/src/eii.rs
@@ -81,7 +81,7 @@ pub(crate) fn check_externally_implementable_items<'tcx>(tcx: TyCtxt<'tcx>, (): 
     }
 
     // now we have all eiis! For each of them, choose one we want to actually generate.
-    for (decl_did, FoundEii { decl, decl_crate, impls }) in eiis {
+    for (foreign_item, FoundEii { decl, decl_crate, impls }) in eiis {
         let mut default_impls = Vec::new();
         let mut explicit_impls = Vec::new();
 
@@ -97,7 +97,7 @@ pub(crate) fn check_externally_implementable_items<'tcx>(tcx: TyCtxt<'tcx>, (): 
         // is instantly an error.
         if explicit_impls.len() > 1 {
             tcx.dcx().emit_err(DuplicateEiiImpls {
-                name: tcx.item_name(decl_did),
+                name: tcx.item_name(foreign_item),
                 first_span: tcx.def_span(explicit_impls[0].0),
                 first_crate: tcx.crate_name(explicit_impls[0].1),
                 second_span: tcx.def_span(explicit_impls[1].0),
@@ -116,7 +116,7 @@ pub(crate) fn check_externally_implementable_items<'tcx>(tcx: TyCtxt<'tcx>, (): 
         }
 
         if default_impls.len() > 1 {
-            let decl_span = tcx.def_ident_span(decl_did).unwrap();
+            let decl_span = tcx.def_ident_span(foreign_item).unwrap();
             tcx.dcx().span_delayed_bug(decl_span, "multiple not supported right now");
         }
 
@@ -139,7 +139,8 @@ pub(crate) fn check_externally_implementable_items<'tcx>(tcx: TyCtxt<'tcx>, (): 
                     tcx.dcx().emit_err(EiiWithoutImpl {
                         current_crate_name: tcx.crate_name(LOCAL_CRATE),
                         decl_crate_name: tcx.crate_name(decl_crate),
-                        name: tcx.item_name(decl_did),
+                        // FIXME: shouldn't call `item_name`
+                        name: tcx.item_name(foreign_item),
                         span: decl.span,
                         help: (),
                     });

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -2929,7 +2929,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                     self.parent_scope.macro_rules = self.r.macro_rules_scopes[&def_id];
                 }
 
-                if let Some(EiiExternTarget { extern_item_path, impl_unsafe: _, span: _ }) =
+                if let Some(EiiExternTarget { extern_item_path, impl_unsafe: _ }) =
                     &macro_def.eii_extern_target
                 {
                     self.smart_resolve_path(

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1069,8 +1069,20 @@ impl<'ast, 'ra, 'tcx> Visitor<'ast> for LateResolutionVisitor<'_, 'ast, 'ra, 'tc
         debug!("(resolving function) entering function");
 
         if let FnKind::Fn(_, _, f) = fn_kind {
-            for EiiImpl { node_id, eii_macro_path, .. } in &f.eii_impls {
-                self.smart_resolve_path(*node_id, &None, &eii_macro_path, PathSource::Macro);
+            for EiiImpl { node_id, eii_macro_path, known_eii_macro_resolution, .. } in &f.eii_impls
+            {
+                // See docs on the `known_eii_macro_resolution` field:
+                // if we already know the resolution statically, don't bother resolving it.
+                if let Some(target) = known_eii_macro_resolution {
+                    self.smart_resolve_path(
+                        *node_id,
+                        &None,
+                        &target.extern_item_path,
+                        PathSource::Expr(None),
+                    );
+                } else {
+                    self.smart_resolve_path(*node_id, &None, &eii_macro_path, PathSource::Macro);
+                }
             }
         }
 

--- a/compiler/rustc_span/src/def_id.rs
+++ b/compiler/rustc_span/src/def_id.rs
@@ -81,7 +81,7 @@ impl fmt::Display for CrateNum {
 /// because it depends on the set of crates in the entire crate graph of a
 /// compilation session. Again, using the same crate with a different version
 /// number would fix the issue with a high probability -- but that might be
-/// easier said then done if the crates in questions are dependencies of
+/// easier said than done if the crates in questions are dependencies of
 /// third-party crates.
 ///
 /// That being said, given a high quality hash function, the collision

--- a/library/alloctests/tests/lib.rs
+++ b/library/alloctests/tests/lib.rs
@@ -20,6 +20,8 @@
 #![feature(binary_heap_into_iter_sorted)]
 #![feature(binary_heap_drain_sorted)]
 #![feature(slice_ptr_get)]
+#![feature(slice_range)]
+#![feature(slice_partial_sort_unstable)]
 #![feature(inplace_iteration)]
 #![feature(iter_advance_by)]
 #![feature(iter_next_chunk)]

--- a/library/alloctests/tests/sort/mod.rs
+++ b/library/alloctests/tests/sort/mod.rs
@@ -12,6 +12,7 @@ pub trait Sort {
 
 mod ffi_types;
 mod known_good_stable_sort;
+mod partial;
 mod patterns;
 mod tests;
 mod zipf;

--- a/library/alloctests/tests/sort/partial.rs
+++ b/library/alloctests/tests/sort/partial.rs
@@ -1,0 +1,84 @@
+use std::fmt::Debug;
+use std::ops::{Range, RangeBounds};
+use std::slice;
+
+use super::patterns;
+
+fn check_is_partial_sorted<T: Ord + Clone + Debug, R: RangeBounds<usize>>(v: &mut [T], range: R) {
+    let Range { start, end } = slice::range(range, ..v.len());
+    v.partial_sort_unstable(start..end);
+
+    let max_before = v[..start].iter().max().into_iter();
+    let sorted_range = v[start..end].into_iter();
+    let min_after = v[end..].iter().min().into_iter();
+    let seq = max_before.chain(sorted_range).chain(min_after);
+    assert!(seq.is_sorted());
+}
+
+fn check_is_partial_sorted_ranges<T: Ord + Clone + Debug>(v: &[T]) {
+    let len = v.len();
+
+    check_is_partial_sorted::<T, _>(&mut v.to_vec(), ..);
+    check_is_partial_sorted::<T, _>(&mut v.to_vec(), 0..0);
+    check_is_partial_sorted::<T, _>(&mut v.to_vec(), len..len);
+
+    if len > 0 {
+        check_is_partial_sorted::<T, _>(&mut v.to_vec(), len - 1..len - 1);
+        check_is_partial_sorted::<T, _>(&mut v.to_vec(), 0..1);
+        check_is_partial_sorted::<T, _>(&mut v.to_vec(), len - 1..len);
+
+        for mid in 1..len {
+            check_is_partial_sorted::<T, _>(&mut v.to_vec(), 0..mid);
+            check_is_partial_sorted::<T, _>(&mut v.to_vec(), mid..len);
+            check_is_partial_sorted::<T, _>(&mut v.to_vec(), mid..mid);
+            check_is_partial_sorted::<T, _>(&mut v.to_vec(), mid - 1..mid + 1);
+            check_is_partial_sorted::<T, _>(&mut v.to_vec(), mid - 1..mid);
+            check_is_partial_sorted::<T, _>(&mut v.to_vec(), mid..mid + 1);
+        }
+
+        let quarters = [0, len / 4, len / 2, (3 * len) / 4, len];
+        for &start in &quarters {
+            for &end in &quarters {
+                if start < end {
+                    check_is_partial_sorted::<T, _>(&mut v.to_vec(), start..end);
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn basic_impl() {
+    check_is_partial_sorted::<i32, _>(&mut [], ..);
+    check_is_partial_sorted::<(), _>(&mut [], ..);
+    check_is_partial_sorted::<(), _>(&mut [()], ..);
+    check_is_partial_sorted::<(), _>(&mut [(), ()], ..);
+    check_is_partial_sorted::<(), _>(&mut [(), (), ()], ..);
+    check_is_partial_sorted::<i32, _>(&mut [], ..);
+
+    check_is_partial_sorted::<i32, _>(&mut [77], ..);
+    check_is_partial_sorted::<i32, _>(&mut [2, 3], ..);
+    check_is_partial_sorted::<i32, _>(&mut [2, 3, 6], ..);
+    check_is_partial_sorted::<i32, _>(&mut [2, 3, 99, 6], ..);
+    check_is_partial_sorted::<i32, _>(&mut [2, 7709, 400, 90932], ..);
+    check_is_partial_sorted::<i32, _>(&mut [15, -1, 3, -1, -3, -1, 7], ..);
+
+    check_is_partial_sorted::<i32, _>(&mut [15, -1, 3, -1, -3, -1, 7], 0..0);
+    check_is_partial_sorted::<i32, _>(&mut [15, -1, 3, -1, -3, -1, 7], 0..1);
+    check_is_partial_sorted::<i32, _>(&mut [15, -1, 3, -1, -3, -1, 7], 0..5);
+    check_is_partial_sorted::<i32, _>(&mut [15, -1, 3, -1, -3, -1, 7], 0..7);
+    check_is_partial_sorted::<i32, _>(&mut [15, -1, 3, -1, -3, -1, 7], 7..7);
+    check_is_partial_sorted::<i32, _>(&mut [15, -1, 3, -1, -3, -1, 7], 6..7);
+    check_is_partial_sorted::<i32, _>(&mut [15, -1, 3, -1, -3, -1, 7], 5..7);
+    check_is_partial_sorted::<i32, _>(&mut [15, -1, 3, -1, -3, -1, 7], 5..5);
+    check_is_partial_sorted::<i32, _>(&mut [15, -1, 3, -1, -3, -1, 7], 4..5);
+    check_is_partial_sorted::<i32, _>(&mut [15, -1, 3, -1, -3, -1, 7], 4..6);
+}
+
+#[test]
+fn random_patterns() {
+    check_is_partial_sorted_ranges(&patterns::random(10));
+    check_is_partial_sorted_ranges(&patterns::random(50));
+    check_is_partial_sorted_ranges(&patterns::random(100));
+    check_is_partial_sorted_ranges(&patterns::random(1000));
+}

--- a/library/std/src/sys/fs/uefi.rs
+++ b/library/std/src/sys/fs/uefi.rs
@@ -364,7 +364,7 @@ impl File {
     }
 
     pub fn tell(&self) -> io::Result<u64> {
-        unsupported()
+        self.0.position()
     }
 
     pub fn duplicate(&self) -> io::Result<File> {
@@ -732,6 +732,14 @@ mod uefi_fs {
             };
 
             if r.is_error() { Err(io::Error::from_raw_os_error(r.as_usize())) } else { Ok(()) }
+        }
+
+        pub(crate) fn position(&self) -> io::Result<u64> {
+            let file_ptr = self.protocol.as_ptr();
+            let mut pos = 0;
+
+            let r = unsafe { ((*file_ptr).get_position)(file_ptr, &mut pos) };
+            if r.is_error() { Err(io::Error::from_raw_os_error(r.as_usize())) } else { Ok(pos) }
         }
 
         pub(crate) fn delete(self) -> io::Result<()> {

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -2296,7 +2296,11 @@ fn open_to_and_set_permissions(
     _reader_metadata: &crate::fs::Metadata,
 ) -> io::Result<(crate::fs::File, crate::fs::Metadata)> {
     use crate::fs::OpenOptions;
-    let writer = OpenOptions::new().open(to)?;
+    let writer = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(to)?;
     let writer_metadata = writer.metadata()?;
     Ok((writer, writer_metadata))
 }

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -2296,11 +2296,7 @@ fn open_to_and_set_permissions(
     _reader_metadata: &crate::fs::Metadata,
 ) -> io::Result<(crate::fs::File, crate::fs::Metadata)> {
     use crate::fs::OpenOptions;
-    let writer = OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .open(to)?;
+    let writer = OpenOptions::new().write(true).create(true).truncate(true).open(to)?;
     let writer_metadata = writer.metadata()?;
     Ok((writer, writer_metadata))
 }

--- a/tests/ui/eii/duplicate/eii_conflict_with_macro.rs
+++ b/tests/ui/eii/duplicate/eii_conflict_with_macro.rs
@@ -1,4 +1,5 @@
 //@ compile-flags: --crate-type rlib
+//@ build-pass
 #![feature(extern_item_impls)]
 
 macro_rules! foo_impl { () => {} }

--- a/tests/ui/eii/duplicate/eii_conflict_with_macro.rs
+++ b/tests/ui/eii/duplicate/eii_conflict_with_macro.rs
@@ -1,0 +1,6 @@
+//@ compile-flags: --crate-type rlib
+#![feature(extern_item_impls)]
+
+macro_rules! foo_impl {}
+#[eii]
+fn foo_impl() {}

--- a/tests/ui/eii/duplicate/eii_conflict_with_macro.rs
+++ b/tests/ui/eii/duplicate/eii_conflict_with_macro.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: --crate-type rlib
 #![feature(extern_item_impls)]
 
-macro_rules! foo_impl {}
+macro_rules! foo_impl { () => {} }
 #[eii]
 fn foo_impl() {}

--- a/tests/ui/eii/privacy2.rs
+++ b/tests/ui/eii/privacy2.rs
@@ -1,5 +1,5 @@
 //@ aux-build:codegen3.rs
-// Tests whether name resulution respects privacy properly.
+// Tests whether name resolution respects privacy properly.
 #![feature(extern_item_impls)]
 
 extern crate codegen3 as codegen;

--- a/tests/ui/eii/privacy2.stderr
+++ b/tests/ui/eii/privacy2.stderr
@@ -17,18 +17,18 @@ LL | fn decl1(x: u64);
    | ^^^^^^^^^^^^^^^^^
 
 error: `#[eii2]` required, but not found
-  --> $DIR/auxiliary/codegen3.rs:9:1
+  --> $DIR/auxiliary/codegen3.rs:9:7
    |
 LL | #[eii(eii2)]
-   | ^^^^^^^^^^^^ expected because `#[eii2]` was declared here in crate `codegen3`
+   |       ^^^^ expected because `#[eii2]` was declared here in crate `codegen3`
    |
    = help: expected at least one implementation in crate `privacy2` or any of its dependencies
 
 error: `#[eii3]` required, but not found
-  --> $DIR/auxiliary/codegen3.rs:13:5
+  --> $DIR/auxiliary/codegen3.rs:13:11
    |
 LL |     #[eii(eii3)]
-   |     ^^^^^^^^^^^^ expected because `#[eii3]` was declared here in crate `codegen3`
+   |           ^^^^ expected because `#[eii3]` was declared here in crate `codegen3`
    |
    = help: expected at least one implementation in crate `privacy2` or any of its dependencies
 


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#149318 (Implement partial_sort_unstable for slice)
 - rust-lang/rust#150805 (Fix ICE in inline always warning emission.)
 - rust-lang/rust#150822 (Fix for ICE: eii: fn / macro rules None in find_attr())
 - rust-lang/rust#150853 (std: sys: fs: uefi: Implement File::read)
 - rust-lang/rust#150855 (std: sys: fs: uefi: Implement File::tell)
 - rust-lang/rust#150881 (Fix std::fs::copy on WASI by setting proper OpenOptions flags)
 - rust-lang/rust#150891 (Fix a trivial typo in def_id.rs)
 - rust-lang/rust#150892 (Don't check `[mentions]` paths in submodules from tidy)
 - rust-lang/rust#150894 (cg_llvm: add a pause to make comment less confusing)

r? @ghost

<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=149318,150805,150822,150853,150855,150881,150891,150892,150894)
<!-- homu-ignore:end -->

