### PR TITLE
Update to_uppercase docs to avoid ß->SS example

### DIFF
--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1147,7 +1147,7 @@ impl char {
     /// As an iterator:
     ///
     /// ```
-    /// for c in 'ß'.to_uppercase() {
+    /// for c in 'ﬃ'.to_uppercase() {
     ///     print!("{c}");
     /// }
     /// println!();
@@ -1156,13 +1156,13 @@ impl char {
     /// Using `println!` directly:
     ///
     /// ```
-    /// println!("{}", 'ß'.to_uppercase());
+    /// println!("{}", 'ﬃ'.to_uppercase());
     /// ```
     ///
     /// Both are equivalent to:
     ///
     /// ```
-    /// println!("SS");
+    /// println!("FFI");
     /// ```
     ///
     /// Using [`to_string`](../std/string/trait.ToString.html#tymethod.to_string):
@@ -1171,7 +1171,7 @@ impl char {
     /// assert_eq!('c'.to_uppercase().to_string(), "C");
     ///
     /// // Sometimes the result is more than one character:
-    /// assert_eq!('ß'.to_uppercase().to_string(), "SS");
+    /// assert_eq!('ﬃ'.to_uppercase().to_string(), "FFI");
     ///
     /// // Characters that do not have both uppercase and lowercase
     /// // convert into themselves.

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1143,6 +1143,7 @@ impl char {
     /// [Unicode Standard]: https://www.unicode.org/versions/latest/
     ///
     /// # Examples
+    /// `'ﬃ'` (U+FB03) is a single Unicode code point (a ligature) that maps to "FFI" in uppercase.
     ///
     /// As an iterator:
     ///

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1143,12 +1143,12 @@ impl char {
     /// [Unicode Standard]: https://www.unicode.org/versions/latest/
     ///
     /// # Examples
-    /// `'ﬃ'` (U+FB03) is a single Unicode code point (a ligature) that maps to "FFI" in uppercase.
+    /// `'ﬅ'` (U+FB05) is a single Unicode code point (a ligature) that maps to "ST" in uppercase.
     ///
     /// As an iterator:
     ///
     /// ```
-    /// for c in 'ﬃ'.to_uppercase() {
+    /// for c in 'ﬅ'.to_uppercase() {
     ///     print!("{c}");
     /// }
     /// println!();
@@ -1157,13 +1157,13 @@ impl char {
     /// Using `println!` directly:
     ///
     /// ```
-    /// println!("{}", 'ﬃ'.to_uppercase());
+    /// println!("{}", 'ﬅ'.to_uppercase());
     /// ```
     ///
     /// Both are equivalent to:
     ///
     /// ```
-    /// println!("FFI");
+    /// println!("ST");
     /// ```
     ///
     /// Using [`to_string`](../std/string/trait.ToString.html#tymethod.to_string):
@@ -1172,7 +1172,7 @@ impl char {
     /// assert_eq!('c'.to_uppercase().to_string(), "C");
     ///
     /// // Sometimes the result is more than one character:
-    /// assert_eq!('ﬃ'.to_uppercase().to_string(), "FFI");
+    /// assert_eq!('ﬅ'.to_uppercase().to_string(), "ST");
     ///
     /// // Characters that do not have both uppercase and lowercase
     /// // convert into themselves.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#150888 

Updates the `to_uppercase` documentation examples to avoid relying on the ß → "SS" mapping and instead uses a stable multi-character case-mapping example ('ﬃ' → "FFI").

Note: the example uses U+FB03 (LATIN SMALL LIGATURE FFI), not the ASCII string "ffi".