### PR TITLE
Fix(lib/win/net): Remove hostname support under Win7

### DIFF
--- a/library/std/src/net/hostname.rs
+++ b/library/std/src/net/hostname.rs
@@ -8,10 +8,10 @@ use crate::ffi::OsString;
 ///
 /// # Underlying system calls
 ///
-/// | Platform | System call                                                                                             |
-/// |----------|---------------------------------------------------------------------------------------------------------|
-/// | UNIX     | [`gethostname`](https://www.man7.org/linux/man-pages/man2/gethostname.2.html)                           |
-/// | Windows  | [`GetHostNameW`](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-gethostnamew) |
+/// | Platform     | System call                                                                                             |
+/// |--------------|---------------------------------------------------------------------------------------------------------|
+/// | UNIX         | [`gethostname`](https://www.man7.org/linux/man-pages/man2/gethostname.2.html)                           |
+/// | Windows (8+) | [`GetHostNameW`](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-gethostnamew) |
 ///
 /// Note that platform-specific behavior [may change in the future][changes].
 ///

--- a/library/std/src/sys/net/hostname/mod.rs
+++ b/library/std/src/sys/net/hostname/mod.rs
@@ -3,7 +3,8 @@ cfg_select! {
         mod unix;
         pub use unix::hostname;
     }
-    target_os = "windows" => {
+    // `GetHostNameW` is only available starting with Windows 8.
+    all(target_os = "windows", not(target_vendor = "win7")) => {
         mod windows;
         pub use windows::hostname;
     }

--- a/library/std/src/sys/pal/windows/c.rs
+++ b/library/std/src/sys/pal/windows/c.rs
@@ -237,3 +237,7 @@ cfg_select! {
     }
     _ => {}
 }
+
+// Only available starting with Windows 8.
+#[cfg(not(target_vendor = "win7"))]
+windows_targets::link!("ws2_32.dll" "system" fn GetHostNameW(name : PWSTR, namelen : i32) -> i32);

--- a/library/std/src/sys/pal/windows/c/bindings.txt
+++ b/library/std/src/sys/pal/windows/c/bindings.txt
@@ -2170,7 +2170,6 @@ GetFileType
 GETFINALPATHNAMEBYHANDLE_FLAGS
 GetFinalPathNameByHandleW
 GetFullPathNameW
-GetHostNameW
 GetLastError
 GetModuleFileNameW
 GetModuleHandleA

--- a/library/std/src/sys/pal/windows/c/windows_sys.rs
+++ b/library/std/src/sys/pal/windows/c/windows_sys.rs
@@ -49,7 +49,6 @@ windows_targets::link!("kernel32.dll" "system" fn GetFileSizeEx(hfile : HANDLE, 
 windows_targets::link!("kernel32.dll" "system" fn GetFileType(hfile : HANDLE) -> FILE_TYPE);
 windows_targets::link!("kernel32.dll" "system" fn GetFinalPathNameByHandleW(hfile : HANDLE, lpszfilepath : PWSTR, cchfilepath : u32, dwflags : GETFINALPATHNAMEBYHANDLE_FLAGS) -> u32);
 windows_targets::link!("kernel32.dll" "system" fn GetFullPathNameW(lpfilename : PCWSTR, nbufferlength : u32, lpbuffer : PWSTR, lpfilepart : *mut PWSTR) -> u32);
-windows_targets::link!("ws2_32.dll" "system" fn GetHostNameW(name : PWSTR, namelen : i32) -> i32);
 windows_targets::link!("kernel32.dll" "system" fn GetLastError() -> WIN32_ERROR);
 windows_targets::link!("kernel32.dll" "system" fn GetModuleFileNameW(hmodule : HMODULE, lpfilename : PWSTR, nsize : u32) -> u32);
 windows_targets::link!("kernel32.dll" "system" fn GetModuleHandleA(lpmodulename : PCSTR) -> HMODULE);


### PR DESCRIPTION
Fixes rust-lang/rust#150896. `GetHostNameW` is not available under Windows 7, leading to dynamic linking failures upon program executions. For now, as it is still unstable, this therefore appropriately cfg-gates the feature in order to mark the Win7 as unsupported with regards to this particular feature. Porting the functionality for Windows 7 would require changing the underlying system call and so more work for the immediate need.

@rustbot label C-bug O-windows-7 T-libs A-io