### PR TITLE
llvm: Update `reliable_f16` configuration for LLVM22

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -379,19 +379,19 @@ fn update_target_reliable_float_cfg(sess: &Session, cfg: &mut TargetConfig) {
         {
             false
         }
-        // Unsupported <https://github.com/llvm/llvm-project/issues/94434>
-        (Arch::Arm64EC, _) => false,
+        // Unsupported <https://github.com/llvm/llvm-project/issues/94434> (fixed in llvm22)
+        (Arch::Arm64EC, _) if major < 22 => false,
         // Selection failure <https://github.com/llvm/llvm-project/issues/50374> (fixed in llvm21)
         (Arch::S390x, _) if major < 21 => false,
         // MinGW ABI bugs <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115054>
         (Arch::X86_64, Os::Windows) if *target_env == Env::Gnu && *target_abi != Abi::Llvm => false,
         // Infinite recursion <https://github.com/llvm/llvm-project/issues/97981>
-        (Arch::CSky, _) => false,
+        (Arch::CSky, _) if major < 22 => false, // (fixed in llvm22)
         (Arch::Hexagon, _) if major < 21 => false, // (fixed in llvm21)
         (Arch::LoongArch32 | Arch::LoongArch64, _) if major < 21 => false, // (fixed in llvm21)
-        (Arch::PowerPC | Arch::PowerPC64, _) => false,
-        (Arch::Sparc | Arch::Sparc64, _) => false,
-        (Arch::Wasm32 | Arch::Wasm64, _) => false,
+        (Arch::PowerPC | Arch::PowerPC64, _) if major < 22 => false, // (fixed in llvm22)
+        (Arch::Sparc | Arch::Sparc64, _) if major < 22 => false, // (fixed in llvm22)
+        (Arch::Wasm32 | Arch::Wasm64, _) if major < 22 => false, // (fixed in llvm22)
         // `f16` support only requires that symbols converting to and from `f32` are available. We
         // provide these in `compiler-builtins`, so `f16` should be available on all platforms that
         // do not have other ABI issues or LLVM crashes.


### PR DESCRIPTION
Since yesterday, the LLVM `main` branch should have working `f16` on all platforms that Rust supports; this will be LLVM version 22, so update how `cfg(target_has_reliable_f16)` is set to reflect this.

Within the rust-lang organization, this currently has no effect. The goal is to start catching problems as early as possible in external CI that runs top-of-tree rust against top-of-tree LLVM, and once testing for the rust-lang bump to LLVM 22 starts. Hopefully this will mean that we can fix any problems that show up before the bump actually happens, meaning `f16` will be about ready for stabilization at that point (with some considerations for the GCC patch at [1] propagating).

References:

* https://github.com/llvm/llvm-project/commit/919021b0df8c91417784bfd84a6ad4869a0d2206
* https://github.com/llvm/llvm-project/commit/054ee2f8706b582859fcf96d1771aa68c37d9e6a
* https://github.com/llvm/llvm-project/commit/db26ce5c5572a1a54ce307c762689ab63e5c5485
* https://github.com/llvm/llvm-project/commit/549d7c4f35a99598a269004ee13b237d2565b5ec
* https://github.com/llvm/llvm-project/commit/4903c6260cbd781881906007f9c82aceb71fd7c7

[1]: https://github.com/gcc-mirror/gcc/commit/8b6a18ecaf44553230b90bf28adfb9fe9c9d5ab9

<!-- homu-ignore:start -->
r? @nikic
<!-- homu-ignore:end -->
