### PR TITLE
Add missing documentation for globs feature

### DIFF
--- a/compiler/rustc_feature/src/accepted.rs
+++ b/compiler/rustc_feature/src/accepted.rs
@@ -235,7 +235,7 @@ declare_features! (
     (accepted, generic_param_attrs, "1.27.0", Some(48848)),
     /// Allows the `#[global_allocator]` attribute.
     (accepted, global_allocator, "1.28.0", Some(27389)),
-    // FIXME: explain `globs`.
+    /// Allows globs imports (`use module::*;`) to import all public items from a module.
     (accepted, globs, "1.0.0", None),
     /// Allows using `..=X` as a pattern.
     (accepted, half_open_range_patterns, "1.66.0", Some(67264)),


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->


Fixes FIXME by documenting that globs enables wildcard imports (use module::*;).
