### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,7 +289,7 @@ jobs:
           fi
 
           # Get closest bors merge commit
-          PARENT_COMMIT=`git rev-list --author='bors <bors@rust-lang.org>' -n1 --first-parent HEAD^1`
+          PARENT_COMMIT=`git rev-list --author='122020455+rust-bors\[bot\]@users.noreply.github.com' -n1 --first-parent HEAD^1`
 
           ./build/citool/debug/citool postprocess-metrics \
               --job-name ${CI_JOB_NAME} \

--- a/compiler/rustc_builtin_macros/messages.ftl
+++ b/compiler/rustc_builtin_macros/messages.ftl
@@ -182,6 +182,8 @@ builtin_macros_expected_other = expected operand, {$is_inline_asm ->
 
 builtin_macros_export_macro_rules = cannot export macro_rules! macros from a `proc-macro` crate type currently
 
+builtin_macros_format_add_missing_colon = add a colon before the format specifier
+
 builtin_macros_format_duplicate_arg = duplicate argument named `{$ident}`
     .label1 = previously here
     .label2 = duplicate argument

--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -643,6 +643,15 @@ pub(crate) enum InvalidFormatStringSuggestion {
         span: Span,
         replacement: String,
     },
+    #[suggestion(
+        builtin_macros_format_add_missing_colon,
+        code = ":?",
+        applicability = "machine-applicable"
+    )]
+    AddMissingColon {
+        #[primary_span]
+        span: Span,
+    },
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -329,6 +329,10 @@ fn make_format_args(
                     replacement,
                 });
             }
+            parse::Suggestion::AddMissingColon(span) => {
+                let span = fmt_span.from_inner(InnerSpan::new(span.start, span.end));
+                e.sugg_ = Some(errors::InvalidFormatStringSuggestion::AddMissingColon { span });
+            }
         }
         let guar = ecx.dcx().emit_err(e);
         return ExpandResult::Ready(Err(guar));

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -54,7 +54,7 @@ use rustc_middle::ty::adjustment::{
 };
 use rustc_middle::ty::error::TypeError;
 use rustc_middle::ty::{self, Ty, TyCtxt, TypeVisitableExt};
-use rustc_span::{BytePos, DUMMY_SP, DesugaringKind, Span};
+use rustc_span::{BytePos, DUMMY_SP, Span};
 use rustc_trait_selection::infer::InferCtxtExt as _;
 use rustc_trait_selection::solve::inspect::{self, InferCtxtProofTreeExt, ProofTreeVisitor};
 use rustc_trait_selection::solve::{Certainty, Goal, NoSolution};
@@ -1828,10 +1828,9 @@ impl<'tcx> CoerceMany<'tcx> {
                 // If the block is from an external macro or try (`?`) desugaring, then
                 // do not suggest adding a semicolon, because there's nowhere to put it.
                 // See issues #81943 and #87051.
-                && matches!(
-                    cond_expr.span.desugaring_kind(),
-                    None | Some(DesugaringKind::WhileLoop)
-                )
+                // Similarly, if the block is from a loop desugaring, then also do not
+                // suggest adding a semicolon. See issue #150850.
+                && cond_expr.span.desugaring_kind().is_none()
                 && !cond_expr.span.in_external_macro(fcx.tcx.sess.source_map())
                 && !matches!(
                     cond_expr.kind,

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -1190,6 +1190,8 @@ impl UnusedParens {
                 // `&(a..=b)`, there is a recursive `check_pat` on `a` and `b`, but we will assume
                 // that if there are unnecessary parens they serve a purpose of readability.
                 PatKind::Range(..) => return,
+                // Parentheses may be necessary to disambiguate precedence in guard patterns.
+                PatKind::Guard(..) => return,
                 // Avoid `p0 | .. | pn` if we should.
                 PatKind::Or(..) if avoid_or => return,
                 // Avoid `mut x` and `mut x @ p` if we should:

--- a/compiler/rustc_middle/src/ty/consts/valtree.rs
+++ b/compiler/rustc_middle/src/ty/consts/valtree.rs
@@ -191,8 +191,7 @@ impl<'tcx> Value<'tcx> {
         }
     }
 
-    /// Destructures array, ADT or tuple constants into the constants
-    /// of their fields.
+    /// Destructures ADT constants into the constants of their fields.
     pub fn destructure_adt_const(&self) -> ty::DestructuredAdtConst<'tcx> {
         let fields = self.to_branch();
 

--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -184,6 +184,9 @@ pub enum Suggestion {
     /// `format!("{foo:?x}")` -> `format!("{foo:x?}")`
     /// `format!("{foo:?X}")` -> `format!("{foo:X?}")`
     ReorderFormatParameter(Range<usize>, String),
+    /// Add missing colon:
+    /// `format!("{foo?}")` -> `format!("{foo:?}")`
+    AddMissingColon(Range<usize>),
 }
 
 /// The parser structure for interpreting the input format string. This is
@@ -453,10 +456,11 @@ impl<'input> Parser<'input> {
             suggestion: Suggestion::None,
         });
 
-        if let Some((_, _, c)) = self.peek() {
-            match c {
-                '?' => self.suggest_format_debug(),
-                '<' | '^' | '>' => self.suggest_format_align(c),
+        if let (Some((_, _, c)), Some((_, _, nc))) = (self.peek(), self.peek_ahead()) {
+            match (c, nc) {
+                ('?', '}') => self.missing_colon_before_debug_formatter(),
+                ('?', _) => self.suggest_format_debug(),
+                ('<' | '^' | '>', _) => self.suggest_format_align(c),
                 _ => self.suggest_positional_arg_instead_of_captured_arg(arg),
             }
         }
@@ -844,6 +848,23 @@ impl<'input> Parser<'input> {
                     span: range,
                     secondary_label: None,
                     suggestion: Suggestion::None,
+                },
+            );
+        }
+    }
+
+    fn missing_colon_before_debug_formatter(&mut self) {
+        if let Some((range, _)) = self.consume_pos('?') {
+            let span = range.clone();
+            self.errors.insert(
+                0,
+                ParseError {
+                    description: "expected `}`, found `?`".to_owned(),
+                    note: Some(format!("to print `{{`, you can escape it using `{{{{`",)),
+                    label: "expected `:` before `?` to format with `Debug`".to_owned(),
+                    span: range,
+                    secondary_label: None,
+                    suggestion: Suggestion::AddMissingColon(span),
                 },
             );
         }

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -1053,27 +1053,49 @@ impl<'a, 'tcx> TypeVisitor<TyCtxt<'tcx>> for WfPredicates<'a, 'tcx> {
             }
             ty::ConstKind::Value(val) => {
                 // FIXME(mgca): no need to feature-gate once valtree lifetimes are not erased
-                if tcx.features().min_generic_const_args()
-                    && let ty::Adt(adt_def, args) = val.ty.kind()
-                {
-                    let adt_val = val.destructure_adt_const();
-                    let variant_def = adt_def.variant(adt_val.variant);
-                    let cause = self.cause(ObligationCauseCode::WellFormed(None));
-                    self.out.extend(variant_def.fields.iter().zip(adt_val.fields).map(
-                        |(field_def, &field_val)| {
-                            let field_ty = tcx.type_of(field_def.did).instantiate(tcx, args);
-                            let predicate = ty::PredicateKind::Clause(
-                                ty::ClauseKind::ConstArgHasType(field_val, field_ty),
-                            );
-                            traits::Obligation::with_depth(
-                                tcx,
-                                cause.clone(),
-                                self.recursion_depth,
-                                self.param_env,
-                                predicate,
-                            )
-                        },
-                    ));
+                if tcx.features().min_generic_const_args() {
+                    match val.ty.kind() {
+                        ty::Adt(adt_def, args) => {
+                            let adt_val = val.destructure_adt_const();
+                            let variant_def = adt_def.variant(adt_val.variant);
+                            let cause = self.cause(ObligationCauseCode::WellFormed(None));
+                            self.out.extend(variant_def.fields.iter().zip(adt_val.fields).map(
+                                |(field_def, &field_val)| {
+                                    let field_ty =
+                                        tcx.type_of(field_def.did).instantiate(tcx, args);
+                                    let predicate = ty::PredicateKind::Clause(
+                                        ty::ClauseKind::ConstArgHasType(field_val, field_ty),
+                                    );
+                                    traits::Obligation::with_depth(
+                                        tcx,
+                                        cause.clone(),
+                                        self.recursion_depth,
+                                        self.param_env,
+                                        predicate,
+                                    )
+                                },
+                            ));
+                        }
+                        ty::Tuple(field_tys) => {
+                            let field_vals = val.to_branch();
+                            let cause = self.cause(ObligationCauseCode::WellFormed(None));
+                            self.out.extend(field_tys.iter().zip(field_vals).map(
+                                |(field_ty, &field_val)| {
+                                    let predicate = ty::PredicateKind::Clause(
+                                        ty::ClauseKind::ConstArgHasType(field_val, field_ty),
+                                    );
+                                    traits::Obligation::with_depth(
+                                        tcx,
+                                        cause.clone(),
+                                        self.recursion_depth,
+                                        self.param_env,
+                                        predicate,
+                                    )
+                                },
+                            ));
+                        }
+                        _ => {}
+                    }
                 }
 
                 // FIXME: Enforce that values are structurally-matchable.

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -1051,7 +1051,31 @@ impl<'a, 'tcx> TypeVisitor<TyCtxt<'tcx>> for WfPredicates<'a, 'tcx> {
             | ty::ConstKind::Placeholder(..) => {
                 // These variants are trivially WF, so nothing to do here.
             }
-            ty::ConstKind::Value(..) => {
+            ty::ConstKind::Value(val) => {
+                // FIXME(mgca): no need to feature-gate once valtree lifetimes are not erased
+                if tcx.features().min_generic_const_args()
+                    && let ty::Adt(adt_def, args) = val.ty.kind()
+                {
+                    let adt_val = val.destructure_adt_const();
+                    let variant_def = adt_def.variant(adt_val.variant);
+                    let cause = self.cause(ObligationCauseCode::WellFormed(None));
+                    self.out.extend(variant_def.fields.iter().zip(adt_val.fields).map(
+                        |(field_def, &field_val)| {
+                            let field_ty = tcx.type_of(field_def.did).instantiate(tcx, args);
+                            let predicate = ty::PredicateKind::Clause(
+                                ty::ClauseKind::ConstArgHasType(field_val, field_ty),
+                            );
+                            traits::Obligation::with_depth(
+                                tcx,
+                                cause.clone(),
+                                self.recursion_depth,
+                                self.param_env,
+                                predicate,
+                            )
+                        },
+                    ));
+                }
+
                 // FIXME: Enforce that values are structurally-matchable.
             }
         }

--- a/library/core/src/hash/sip.rs
+++ b/library/core/src/hash/sip.rs
@@ -10,7 +10,7 @@ use crate::{cmp, ptr};
 /// This is currently the default hashing function used by standard library
 /// (e.g., `collections::HashMap` uses it by default).
 ///
-/// See: <https://131002.net/siphash>
+/// See: <https://github.com/veorq/SipHash>
 #[unstable(feature = "hashmap_internals", issue = "none")]
 #[deprecated(since = "1.13.0", note = "use `std::hash::DefaultHasher` instead")]
 #[derive(Debug, Clone, Default)]
@@ -21,7 +21,7 @@ pub struct SipHasher13 {
 
 /// An implementation of SipHash 2-4.
 ///
-/// See: <https://131002.net/siphash/>
+/// See: <https://github.com/veorq/SipHash>
 #[unstable(feature = "hashmap_internals", issue = "none")]
 #[deprecated(since = "1.13.0", note = "use `std::hash::DefaultHasher` instead")]
 #[derive(Debug, Clone, Default)]
@@ -31,7 +31,7 @@ struct SipHasher24 {
 
 /// An implementation of SipHash 2-4.
 ///
-/// See: <https://131002.net/siphash/>
+/// See: <https://github.com/veorq/SipHash>
 ///
 /// SipHash is a general-purpose hashing function: it runs at a good
 /// speed (competitive with Spooky and City) and permits strong _keyed_

--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -4,7 +4,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::core::build_steps::compile::{
-    add_to_sysroot, run_cargo, rustc_cargo, rustc_cargo_env, std_cargo, std_crates_for_run_make,
+    ArtifactKeepMode, add_to_sysroot, run_cargo, rustc_cargo, rustc_cargo_env, std_cargo,
+    std_crates_for_run_make,
 };
 use crate::core::build_steps::tool;
 use crate::core::build_steps::tool::{
@@ -111,8 +112,7 @@ impl Step for Std {
             builder.config.free_args.clone(),
             &check_stamp,
             vec![],
-            true,
-            false,
+            ArtifactKeepMode::OnlyRmeta,
         );
 
         drop(_guard);
@@ -148,7 +148,14 @@ impl Step for Std {
             build_compiler,
             target,
         );
-        run_cargo(builder, cargo, builder.config.free_args.clone(), &stamp, vec![], true, false);
+        run_cargo(
+            builder,
+            cargo,
+            builder.config.free_args.clone(),
+            &stamp,
+            vec![],
+            ArtifactKeepMode::OnlyRmeta,
+        );
         check_stamp
     }
 
@@ -368,7 +375,14 @@ impl Step for Rustc {
         let stamp =
             build_stamp::librustc_stamp(builder, build_compiler, target).with_prefix("check");
 
-        run_cargo(builder, cargo, builder.config.free_args.clone(), &stamp, vec![], true, false);
+        run_cargo(
+            builder,
+            cargo,
+            builder.config.free_args.clone(),
+            &stamp,
+            vec![],
+            ArtifactKeepMode::OnlyRmeta,
+        );
 
         stamp
     }
@@ -568,7 +582,14 @@ impl Step for CraneliftCodegenBackend {
         )
         .with_prefix("check");
 
-        run_cargo(builder, cargo, builder.config.free_args.clone(), &stamp, vec![], true, false);
+        run_cargo(
+            builder,
+            cargo,
+            builder.config.free_args.clone(),
+            &stamp,
+            vec![],
+            ArtifactKeepMode::OnlyRmeta,
+        );
     }
 
     fn metadata(&self) -> Option<StepMetadata> {
@@ -639,7 +660,14 @@ impl Step for GccCodegenBackend {
         )
         .with_prefix("check");
 
-        run_cargo(builder, cargo, builder.config.free_args.clone(), &stamp, vec![], true, false);
+        run_cargo(
+            builder,
+            cargo,
+            builder.config.free_args.clone(),
+            &stamp,
+            vec![],
+            ArtifactKeepMode::OnlyRmeta,
+        );
     }
 
     fn metadata(&self) -> Option<StepMetadata> {
@@ -777,7 +805,14 @@ fn run_tool_check_step(
         .with_prefix(&format!("{display_name}-check"));
 
     let _guard = builder.msg(builder.kind, display_name, mode, build_compiler, target);
-    run_cargo(builder, cargo, builder.config.free_args.clone(), &stamp, vec![], true, false);
+    run_cargo(
+        builder,
+        cargo,
+        builder.config.free_args.clone(),
+        &stamp,
+        vec![],
+        ArtifactKeepMode::OnlyRmeta,
+    );
 }
 
 tool_check_step!(Rustdoc {

--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -15,7 +15,7 @@
 
 use build_helper::exit;
 
-use super::compile::{run_cargo, rustc_cargo, std_cargo};
+use super::compile::{ArtifactKeepMode, run_cargo, rustc_cargo, std_cargo};
 use super::tool::{SourceType, prepare_tool_cargo};
 use crate::builder::{Builder, ShouldRun};
 use crate::core::build_steps::check::{CompilerForCheck, prepare_compiler_for_check};
@@ -214,8 +214,7 @@ impl Step for Std {
             lint_args(builder, &self.config, IGNORED_RULES_FOR_STD_AND_RUSTC),
             &build_stamp::libstd_stamp(builder, build_compiler, target),
             vec![],
-            true,
-            false,
+            ArtifactKeepMode::OnlyRmeta,
         );
     }
 
@@ -309,8 +308,7 @@ impl Step for Rustc {
             lint_args(builder, &self.config, IGNORED_RULES_FOR_STD_AND_RUSTC),
             &build_stamp::librustc_stamp(builder, build_compiler, target),
             vec![],
-            true,
-            false,
+            ArtifactKeepMode::OnlyRmeta,
         );
     }
 
@@ -380,7 +378,7 @@ impl Step for CodegenGcc {
             .with_prefix("rustc_codegen_gcc-check");
 
         let args = lint_args(builder, &self.config, &[]);
-        run_cargo(builder, cargo, args.clone(), &stamp, vec![], true, false);
+        run_cargo(builder, cargo, args.clone(), &stamp, vec![], ArtifactKeepMode::OnlyRmeta);
 
         // Same but we disable the features enabled by default.
         let mut cargo = prepare_tool_cargo(
@@ -396,7 +394,7 @@ impl Step for CodegenGcc {
         self.build_compiler.configure_cargo(&mut cargo);
         println!("Now running clippy on `rustc_codegen_gcc` with `--no-default-features`");
         cargo.arg("--no-default-features");
-        run_cargo(builder, cargo, args, &stamp, vec![], true, false);
+        run_cargo(builder, cargo, args, &stamp, vec![], ArtifactKeepMode::OnlyRmeta);
     }
 
     fn metadata(&self) -> Option<StepMetadata> {
@@ -478,8 +476,7 @@ macro_rules! lint_any {
                     lint_args(builder, &self.config, &[]),
                     &stamp,
                     vec![],
-                    true,
-                    false,
+                    ArtifactKeepMode::OnlyRmeta
                 );
             }
 

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -14,7 +14,7 @@ use std::{env, fs, iter};
 
 use build_helper::exit;
 
-use crate::core::build_steps::compile::{Std, run_cargo};
+use crate::core::build_steps::compile::{ArtifactKeepMode, Std, run_cargo};
 use crate::core::build_steps::doc::{DocumentationFormat, prepare_doc_compiler};
 use crate::core::build_steps::gcc::{Gcc, GccTargetPair, add_cg_gcc_cargo_flags};
 use crate::core::build_steps::llvm::get_llvm_version;
@@ -2587,7 +2587,8 @@ impl BookTest {
                 let stamp = BuildStamp::new(&builder.cargo_out(test_compiler, mode, target))
                     .with_prefix(PathBuf::from(dep).file_name().and_then(|v| v.to_str()).unwrap());
 
-                let output_paths = run_cargo(builder, cargo, vec![], &stamp, vec![], false, false);
+                let output_paths =
+                    run_cargo(builder, cargo, vec![], &stamp, vec![], ArtifactKeepMode::OnlyRlib);
                 let directories = output_paths
                     .into_iter()
                     .filter_map(|p| p.parent().map(ToOwned::to_owned))

--- a/src/doc/rustc-dev-guide/src/external-repos.md
+++ b/src/doc/rustc-dev-guide/src/external-repos.md
@@ -22,6 +22,7 @@ The following external projects are managed using some form of a `subtree`:
 * [rustfmt](https://github.com/rust-lang/rustfmt)
 * [rust-analyzer](https://github.com/rust-lang/rust-analyzer)
 * [rustc_codegen_cranelift](https://github.com/rust-lang/rustc_codegen_cranelift)
+* [rustc_codegen_gcc](https://github.com/rust-lang/rustc_codegen_gcc)
 * [rustc-dev-guide](https://github.com/rust-lang/rustc-dev-guide)
 * [compiler-builtins](https://github.com/rust-lang/compiler-builtins)
 * [stdarch](https://github.com/rust-lang/stdarch)
@@ -40,6 +41,7 @@ implement a new tool feature or test, that should happen in one collective rustc
     * `portable-simd` ([sync script](https://github.com/rust-lang/portable-simd/blob/master/subtree-sync.sh))
     * `rustfmt`
     * `rustc_codegen_cranelift` ([sync script](https://github.com/rust-lang/rustc_codegen_cranelift/blob/113af154d459e41b3dc2c5d7d878e3d3a8f33c69/scripts/rustup.sh#L7))
+    * `rustc_codegen_gcc` ([sync guide](https://github.com/rust-lang/rustc_codegen_gcc/blob/master/doc/subtree.md))
 * Using the [josh](#synchronizing-a-josh-subtree) tool
     * `miri`
     * `rust-analyzer`

--- a/src/doc/rustc/src/platform-support/nvptx64-nvidia-cuda.md
+++ b/src/doc/rustc/src/platform-support/nvptx64-nvidia-cuda.md
@@ -7,7 +7,6 @@ platform.
 
 ## Target maintainers
 
-[@RDambrosio016](https://github.com/RDambrosio016)
 [@kjetilkjeka](https://github.com/kjetilkjeka)
 
 ## Requirements

--- a/src/tools/opt-dist/src/main.rs
+++ b/src/tools/opt-dist/src/main.rs
@@ -450,6 +450,7 @@ fn main() -> anyhow::Result<()> {
             "rust-docs-json",
             "rust-analyzer",
             "rustc-src",
+            "rustc-src-gpl",
             "extended",
             "clippy",
             "miri",

--- a/tests/ui/block-result/block-must-not-have-result-while.stderr
+++ b/tests/ui/block-result/block-must-not-have-result-while.stderr
@@ -9,12 +9,8 @@ LL |     while true {
 error[E0308]: mismatched types
   --> $DIR/block-must-not-have-result-while.rs:5:9
    |
-LL | /     while true {
-LL | |         true
-   | |         ^^^^ expected `()`, found `bool`
-LL | |
-LL | |     }
-   | |_____- expected this to be `()`
+LL |         true
+   |         ^^^^ expected `()`, found `bool`
 
 error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/const-generics/mgca/adt_expr_arg_simple.rs
+++ b/tests/ui/const-generics/mgca/adt_expr_arg_simple.rs
@@ -12,7 +12,7 @@ fn foo<const N: Option<u32>>() {}
 
 trait Trait {
     #[type_const]
-    const ASSOC: usize;
+    const ASSOC: u32;
 }
 
 fn bar<T: Trait, const N: u32>() {

--- a/tests/ui/const-generics/mgca/adt_expr_arg_tuple_expr_fail.rs
+++ b/tests/ui/const-generics/mgca/adt_expr_arg_tuple_expr_fail.rs
@@ -1,0 +1,26 @@
+#![feature(min_generic_const_args, adt_const_params, unsized_const_params)]
+#![expect(incomplete_features)]
+
+trait Trait {
+    #[type_const]
+    const ASSOC: usize;
+}
+
+fn takes_tuple<const A: (u32, u32)>() {}
+fn takes_nested_tuple<const A: (u32, (u32, u32))>() {}
+
+fn generic_caller<T: Trait, const N: usize, const N2: u32>() {
+    takes_tuple::<{ (N, N2) }>();
+    //~^ ERROR the constant `N` is not of type `u32`
+    takes_tuple::<{ (N, T::ASSOC) }>();
+    //~^ ERROR the constant `N` is not of type `u32`
+    //~| ERROR the constant `<T as Trait>::ASSOC` is not of type `u32`
+
+    takes_nested_tuple::<{ (N, (N, N2)) }>();
+    //~^ ERROR the constant `N` is not of type `u32`
+    takes_nested_tuple::<{ (N, (N, T::ASSOC)) }>();
+    //~^ ERROR the constant `N` is not of type `u32`
+    //~| ERROR the constant `<T as Trait>::ASSOC` is not of type `u32`
+}
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/adt_expr_arg_tuple_expr_fail.stderr
+++ b/tests/ui/const-generics/mgca/adt_expr_arg_tuple_expr_fail.stderr
@@ -1,0 +1,38 @@
+error: the constant `N` is not of type `u32`
+  --> $DIR/adt_expr_arg_tuple_expr_fail.rs:13:21
+   |
+LL |     takes_tuple::<{ (N, N2) }>();
+   |                     ^^^^^^^ expected `u32`, found `usize`
+
+error: the constant `N` is not of type `u32`
+  --> $DIR/adt_expr_arg_tuple_expr_fail.rs:15:21
+   |
+LL |     takes_tuple::<{ (N, T::ASSOC) }>();
+   |                     ^^^^^^^^^^^^^ expected `u32`, found `usize`
+
+error: the constant `<T as Trait>::ASSOC` is not of type `u32`
+  --> $DIR/adt_expr_arg_tuple_expr_fail.rs:15:21
+   |
+LL |     takes_tuple::<{ (N, T::ASSOC) }>();
+   |                     ^^^^^^^^^^^^^ expected `u32`, found `usize`
+
+error: the constant `N` is not of type `u32`
+  --> $DIR/adt_expr_arg_tuple_expr_fail.rs:19:28
+   |
+LL |     takes_nested_tuple::<{ (N, (N, N2)) }>();
+   |                            ^^^^^^^^^^^^ expected `u32`, found `usize`
+
+error: the constant `N` is not of type `u32`
+  --> $DIR/adt_expr_arg_tuple_expr_fail.rs:21:28
+   |
+LL |     takes_nested_tuple::<{ (N, (N, T::ASSOC)) }>();
+   |                            ^^^^^^^^^^^^^^^^^^ expected `u32`, found `usize`
+
+error: the constant `<T as Trait>::ASSOC` is not of type `u32`
+  --> $DIR/adt_expr_arg_tuple_expr_fail.rs:21:28
+   |
+LL |     takes_nested_tuple::<{ (N, (N, T::ASSOC)) }>();
+   |                            ^^^^^^^^^^^^^^^^^^ expected `u32`, found `usize`
+
+error: aborting due to 6 previous errors
+

--- a/tests/ui/const-generics/mgca/adt_expr_arg_tuple_expr_simple.rs
+++ b/tests/ui/const-generics/mgca/adt_expr_arg_tuple_expr_simple.rs
@@ -5,7 +5,7 @@
 
 trait Trait {
     #[type_const]
-    const ASSOC: usize;
+    const ASSOC: u32;
 }
 
 fn takes_tuple<const A: (u32, u32)>() {}

--- a/tests/ui/const-generics/mgca/adt_expr_fields_type_check.rs
+++ b/tests/ui/const-generics/mgca/adt_expr_fields_type_check.rs
@@ -1,17 +1,38 @@
-//@ check-pass
-// FIXME(mgca): This should error
-
 #![feature(min_generic_const_args, adt_const_params)]
 #![expect(incomplete_features)]
 
 #[derive(Eq, PartialEq, std::marker::ConstParamTy)]
-struct Foo<T> { field: T }
+struct S1<T> {
+    f1: T,
+    f2: isize,
+}
 
-fn accepts<const N: Foo<u8>>() {}
+#[derive(Eq, PartialEq, std::marker::ConstParamTy)]
+struct S2<T>(T, isize);
+
+#[derive(Eq, PartialEq, std::marker::ConstParamTy)]
+enum En<T> {
+    Var1(bool, T),
+    Var2 { field: i64 },
+}
+
+fn accepts_1<const N: S1<u8>>() {}
+fn accepts_2<const N: S2<u8>>() {}
+fn accepts_3<const N: En<u8>>() {}
 
 fn bar<const N: bool>() {
-    // `N` is not of type `u8` but we don't actually check this anywhere yet
-    accepts::<{ Foo::<u8> { field: N }}>();
+    accepts_1::<{ S1::<u8> { f1: N, f2: N } }>();
+    //~^ ERROR the constant `N` is not of type `u8`
+    //~| ERROR the constant `N` is not of type `isize`
+    accepts_2::<{ S2::<u8>(N, N) }>();
+    //~^ ERROR the constant `N` is not of type `u8`
+    //~| ERROR the constant `N` is not of type `isize`
+    accepts_3::<{ En::Var1::<u8>(N, N) }>();
+    //~^ ERROR the constant `N` is not of type `u8`
+    accepts_3::<{ En::Var2::<u8> { field: N } }>();
+    //~^ ERROR the constant `N` is not of type `i64`
+    accepts_3::<{ En::Var2::<u8> { field: const { false } } }>();
+    //~^ ERROR mismatched types
 }
 
 fn main() {}

--- a/tests/ui/const-generics/mgca/adt_expr_fields_type_check.stderr
+++ b/tests/ui/const-generics/mgca/adt_expr_fields_type_check.stderr
@@ -1,0 +1,45 @@
+error: the constant `N` is not of type `u8`
+  --> $DIR/adt_expr_fields_type_check.rs:24:19
+   |
+LL |     accepts_1::<{ S1::<u8> { f1: N, f2: N } }>();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `bool`
+
+error: the constant `N` is not of type `isize`
+  --> $DIR/adt_expr_fields_type_check.rs:24:19
+   |
+LL |     accepts_1::<{ S1::<u8> { f1: N, f2: N } }>();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `isize`, found `bool`
+
+error: the constant `N` is not of type `u8`
+  --> $DIR/adt_expr_fields_type_check.rs:27:19
+   |
+LL |     accepts_2::<{ S2::<u8>(N, N) }>();
+   |                   ^^^^^^^^^^^^^^ expected `u8`, found `bool`
+
+error: the constant `N` is not of type `isize`
+  --> $DIR/adt_expr_fields_type_check.rs:27:19
+   |
+LL |     accepts_2::<{ S2::<u8>(N, N) }>();
+   |                   ^^^^^^^^^^^^^^ expected `isize`, found `bool`
+
+error: the constant `N` is not of type `u8`
+  --> $DIR/adt_expr_fields_type_check.rs:30:19
+   |
+LL |     accepts_3::<{ En::Var1::<u8>(N, N) }>();
+   |                   ^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `bool`
+
+error: the constant `N` is not of type `i64`
+  --> $DIR/adt_expr_fields_type_check.rs:32:19
+   |
+LL |     accepts_3::<{ En::Var2::<u8> { field: N } }>();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `i64`, found `bool`
+
+error[E0308]: mismatched types
+  --> $DIR/adt_expr_fields_type_check.rs:34:51
+   |
+LL |     accepts_3::<{ En::Var2::<u8> { field: const { false } } }>();
+   |                                                   ^^^^^ expected `i64`, found `bool`
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/mgca/printing_valtrees_supports_non_values.rs
+++ b/tests/ui/const-generics/mgca/printing_valtrees_supports_non_values.rs
@@ -9,7 +9,7 @@ struct Foo;
 
 trait Trait {
     #[type_const]
-    const ASSOC: usize;
+    const ASSOC: u32;
 }
 
 fn foo<const N: Foo>() {}
@@ -27,7 +27,7 @@ fn baz<T: Trait>() {
 fn main() {}
 
 fn test_ice_missing_bound<T>() {
-    foo::<{Option::Some::<u32>{0: <T as Trait>::ASSOC}}>();
+    foo::<{ Option::Some::<u32> { 0: <T as Trait>::ASSOC } }>();
     //~^ ERROR the trait bound `T: Trait` is not satisfied
     //~| ERROR the constant `Option::<u32>::Some(_)` is not of type `Foo`
 }

--- a/tests/ui/const-generics/mgca/printing_valtrees_supports_non_values.stderr
+++ b/tests/ui/const-generics/mgca/printing_valtrees_supports_non_values.stderr
@@ -25,8 +25,8 @@ LL | fn foo<const N: Foo>() {}
 error[E0277]: the trait bound `T: Trait` is not satisfied
   --> $DIR/printing_valtrees_supports_non_values.rs:30:5
    |
-LL |     foo::<{Option::Some::<u32>{0: <T as Trait>::ASSOC}}>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `T`
+LL |     foo::<{ Option::Some::<u32> { 0: <T as Trait>::ASSOC } }>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `T`
    |
 help: consider restricting type parameter `T` with trait `Trait`
    |
@@ -34,10 +34,10 @@ LL | fn test_ice_missing_bound<T: Trait>() {
    |                            +++++++
 
 error: the constant `Option::<u32>::Some(_)` is not of type `Foo`
-  --> $DIR/printing_valtrees_supports_non_values.rs:30:12
+  --> $DIR/printing_valtrees_supports_non_values.rs:30:13
    |
-LL |     foo::<{Option::Some::<u32>{0: <T as Trait>::ASSOC}}>();
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Foo`, found `Option<u32>`
+LL |     foo::<{ Option::Some::<u32> { 0: <T as Trait>::ASSOC } }>();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Foo`, found `Option<u32>`
    |
 note: required by a const generic parameter in `foo`
   --> $DIR/printing_valtrees_supports_non_values.rs:15:8

--- a/tests/ui/fmt/format-string-error-2.rs
+++ b/tests/ui/fmt/format-string-error-2.rs
@@ -83,4 +83,7 @@ raw  { \n
 
     println!(r#"\x7B}\u8 {"#, 1);
     //~^ ERROR invalid format string: unmatched `}` found
+
+    println!("{x?}, world!",);
+    //~^ ERROR invalid format string: expected `}`, found `?`
 }

--- a/tests/ui/fmt/format-string-error-2.stderr
+++ b/tests/ui/fmt/format-string-error-2.stderr
@@ -177,5 +177,16 @@ LL |     println!(r#"\x7B}\u8 {"#, 1);
    |
    = note: if you intended to print `}`, you can escape it using `}}`
 
-error: aborting due to 18 previous errors
+error: invalid format string: expected `}`, found `?`
+  --> $DIR/format-string-error-2.rs:87:17
+   |
+LL |     println!("{x?}, world!",);
+   |                 ^
+   |                 |
+   |                 expected `:` before `?` to format with `Debug` in format string
+   |                 help: add a colon before the format specifier: `:?`
+   |
+   = note: to print `{`, you can escape it using `{{`
+
+error: aborting due to 19 previous errors
 

--- a/tests/ui/for-loop-while/dont-suggest-break-from-unbreakable-loops.rs
+++ b/tests/ui/for-loop-while/dont-suggest-break-from-unbreakable-loops.rs
@@ -1,0 +1,39 @@
+//! Don't suggest breaking with value from `for` or `while` loops
+//!
+//! Regression test for https://github.com/rust-lang/rust/issues/150850
+
+fn returns_i32() -> i32 { 0 }
+
+fn suggest_breaking_from_loop() {
+    let _ = loop {
+        returns_i32() //~ ERROR mismatched types
+        //~^ SUGGESTION ;
+        //~| SUGGESTION break
+    };
+}
+
+fn dont_suggest_breaking_from_for() {
+    let _ = for _ in 0.. {
+        returns_i32() //~ ERROR mismatched types
+        //~^ SUGGESTION ;
+    };
+}
+
+fn dont_suggest_breaking_from_while() {
+    let cond = true;
+    let _ = while cond {
+        returns_i32() //~ ERROR mismatched types
+        //~^ SUGGESTION ;
+    };
+}
+
+fn dont_suggest_breaking_from_for_nested_in_loop() {
+    let _ = loop {
+        for _ in 0.. {
+            returns_i32() //~ ERROR mismatched types
+            //~^ SUGGESTION ;
+        }
+    };
+}
+
+fn main() {}

--- a/tests/ui/for-loop-while/dont-suggest-break-from-unbreakable-loops.stderr
+++ b/tests/ui/for-loop-while/dont-suggest-break-from-unbreakable-loops.stderr
@@ -1,0 +1,42 @@
+error[E0308]: mismatched types
+  --> $DIR/dont-suggest-break-from-unbreakable-loops.rs:9:9
+   |
+LL |         returns_i32()
+   |         ^^^^^^^^^^^^^ expected `()`, found `i32`
+   |
+help: consider using a semicolon here
+   |
+LL |         returns_i32();
+   |                      +
+help: you might have meant to break the loop with this value
+   |
+LL |         break returns_i32();
+   |         +++++              +
+
+error[E0308]: mismatched types
+  --> $DIR/dont-suggest-break-from-unbreakable-loops.rs:17:9
+   |
+LL |         returns_i32()
+   |         ^^^^^^^^^^^^^- help: consider using a semicolon here: `;`
+   |         |
+   |         expected `()`, found `i32`
+
+error[E0308]: mismatched types
+  --> $DIR/dont-suggest-break-from-unbreakable-loops.rs:25:9
+   |
+LL |         returns_i32()
+   |         ^^^^^^^^^^^^^- help: consider using a semicolon here: `;`
+   |         |
+   |         expected `()`, found `i32`
+
+error[E0308]: mismatched types
+  --> $DIR/dont-suggest-break-from-unbreakable-loops.rs:33:13
+   |
+LL |             returns_i32()
+   |             ^^^^^^^^^^^^^- help: consider using a semicolon here: `;`
+   |             |
+   |             expected `()`, found `i32`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/lint/unused/unused_parens/parens-around-guard-patterns-not-unused.rs
+++ b/tests/ui/lint/unused/unused_parens/parens-around-guard-patterns-not-unused.rs
@@ -1,0 +1,13 @@
+//! Guard patterns require parentheses to disambiguate precedence
+//!
+//! Regression test for https://github.com/rust-lang/rust/issues/149594
+
+//@ check-pass
+
+#![feature(guard_patterns)]
+#![expect(incomplete_features)]
+#![warn(unused_parens)]
+
+fn main() {
+    let (_ if false) = ();
+}

--- a/tests/ui/reachable/guard_read_for_never.rs
+++ b/tests/ui/reachable/guard_read_for_never.rs
@@ -2,7 +2,7 @@
 //
 //@ check-pass
 #![feature(guard_patterns, never_type)]
-#![expect(incomplete_features, unused_parens)]
+#![expect(incomplete_features)]
 #![deny(unreachable_code)]
 
 fn main() {


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#150269 (Remove inactive nvptx maintainer)
 - rust-lang/rust#150713 (mgca: Type-check fields of struct expr const args)
 - rust-lang/rust#150765 (rustc_parse_format: improve error for missing `:` before `?` in format args)
 - rust-lang/rust#150847 (Fix broken documentation links to SipHash)
 - rust-lang/rust#150867 (rustdoc_json: Remove one call to `std::mem::take` in `after_krate`)
 - rust-lang/rust#150872 (Fix some loop block coercion diagnostics)
 - rust-lang/rust#150874 (Ignore `rustc-src-gpl` in fast try builds)
 - rust-lang/rust#150875 (Refactor artifact keep mode in bootstrap)
 - rust-lang/rust#150876 (Mention that `rustc_codegen_gcc` is a subtree in `rustc-dev-guide`)
 - rust-lang/rust#150882 (Supress unused_parens lint for guard patterns)
 - rust-lang/rust#150884 (Update bors email in CI postprocessing step)

Failed merges:

 - rust-lang/rust#150869 (Emit error instead of delayed bug when meeting mismatch type for const tuple)

r? @ghost

<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=150713,150765,150875,150269,150847,150867,150869,150872,150874,150876,150882,150884)
<!-- homu-ignore:end -->

