### PR TITLE
compiler: Forward attributes to eii-expanded macros

### DIFF
--- a/compiler/rustc_builtin_macros/src/eii.rs
+++ b/compiler/rustc_builtin_macros/src/eii.rs
@@ -133,6 +133,7 @@ fn eii_(
         macro_name,
         foreign_item_name,
         impl_unsafe,
+        &attrs_from_decl,
     )));
 
     return_items.into_iter().map(wrap_item).collect()
@@ -416,8 +417,13 @@ fn generate_attribute_macro_to_implement(
     macro_name: Ident,
     foreign_item_name: Ident,
     impl_unsafe: bool,
+    attrs_from_decl: &[Attribute],
 ) -> ast::Item {
     let mut macro_attrs = ThinVec::new();
+
+    // To avoid e.g. `error: attribute macro has missing stability attribute`
+    // errors for eii's in std.
+    macro_attrs.extend_from_slice(attrs_from_decl);
 
     // #[builtin_macro(eii_shared_macro)]
     macro_attrs.push(ecx.attr_nested_word(sym::rustc_builtin_macro, sym::eii_shared_macro, span));


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/150592 is quite complicated to reason about I figured it would be good to split it up in smaller pieces that are easier to digest. Here is the attribute fix in isolation.

## The Problem

With this eii in **library/std/src/io/mod.rs**:
```rs
/// Foo
#[eii(on_broken_pipe)]
#[unstable(feature = "on_broken_pipe", issue = "150588")]
pub fn on_broken_pipe() -> OnBrokenPipe {
    OnBrokenPipe::BackwardsCompatible
}
```

you currently get this compilation error:

```
error: attribute macro has missing stability attribute
    --> library/std/src/io/mod.rs:2269:1
     |
2269 | #[eii(on_broken_pipe)]
     | ^^^^^^^^^^^^^^^^^^^^--
     | |
     | in this attribute macro expansion
     |
    ::: library/core/src/macros/mod.rs:1899:5
     |
1899 |     pub macro eii($item:item) {
     |     ------------- in this expansion of `#[eii]`
```

because with ` MAGIC_EXTRA_RUSTFLAGS=-Zunpretty=expanded ./x build library/std` we can see that a pub item in the expanded code is indeed missing that attribute:

```rs
const _: () =
    {
        #[on_broken_pipe]
        fn on_broken_pipe() -> OnBrokenPipe {
            OnBrokenPipe::BackwardsCompatible
        }
    };
unsafe extern "Rust" {
    /// Foo
    #[unstable(feature = "on_broken_pipe", issue = "150588")]
    #[rustc_eii_extern_item]
    pub safe fn on_broken_pipe()
    -> OnBrokenPipe;
}
#[rustc_builtin_macro(eii_shared_macro)]
#[eii_extern_target(on_broken_pipe)]
pub macro on_broken_pipe { () => {} }
```

## The Solution

With the fix, that error goes away because we get this expanded code instead:

```rs
const _: () =
    {
        #[on_broken_pipe]
        fn on_broken_pipe() -> OnBrokenPipe {
            OnBrokenPipe::BackwardsCompatible
        }
    };
unsafe extern "Rust" {
    /// Foo
    #[unstable(feature = "on_broken_pipe", issue = "150588")]
    #[rustc_eii_extern_item]
    pub safe fn on_broken_pipe()
    -> OnBrokenPipe;
}
/// Foo
#[unstable(feature = "on_broken_pipe", issue = "150588")]
#[rustc_builtin_macro(eii_shared_macro)]
#[eii_extern_target(on_broken_pipe)]
pub macro on_broken_pipe { () => {} }
```

Note that we also need to forward the docs, otherwise get get (fatal) warnings like these:

```
warning: missing documentation for an attribute macro
    --> library/std/src/io/mod.rs:2269:1
```

r? @jdonszelmann 

Tracking issues:
- https://github.com/rust-lang/rust/issues/125418
- https://github.com/rust-lang/rust/issues/150588

### What about a test?

https://github.com/rust-lang/rust/pull/150591 will prevent regressions once it lands since it does not build without this fix. I think it is overkill to add a temporary eii to std before that.
