### PR TITLE
rustdoc: Always document `#[repr(transparent)]` if `#[rustc_pub_transparent]` is applied

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -3083,10 +3083,16 @@ fn repr_attribute<'tcx>(
         (cache.document_private || field.vis.is_public()) && is_visible(field.did)
     };
 
+    // The transparent repr is public if
+    // - the non-1-ZST field is public and visible or
+    // - at least one field is public and visible if *all* fields are 1-ZSTs or
+    // - the item is annotated with internal attribute `#[rustc_pub_transparent]`
     if repr.transparent() {
-        // The transparent repr is public iff the non-1-ZST field is public and visible or
-        // – in case all fields are 1-ZST fields — at least one field is public and visible.
         let is_public = 'is_public: {
+            if hir::find_attr!(tcx, def_id, AttributeKind::RustcPubTransparent(_)) {
+                break 'is_public true;
+            }
+
             // `#[repr(transparent)]` can only be applied to structs and single-variant enums.
             let var = adt.variant(rustc_abi::FIRST_VARIANT); // the first and only variant
 

--- a/tests/rustdoc-html/repr.rs
+++ b/tests/rustdoc-html/repr.rs
@@ -1,5 +1,6 @@
 // Test the rendering of `#[repr]` on ADTs.
 #![feature(repr_simd)] // only used for the `ReprSimd` test case
+#![feature(rustc_attrs)] // only used for the `RustcPubTransparent` test case
 
 // Check the "local case" (HIR cleaning) //
 
@@ -145,6 +146,15 @@ pub enum ReprTransparentEnumHidden1ZstField {
         #[doc(hidden)]
         field: u64, // ...since the non-1-ZST field is public
     },
+}
+
+//@ has 'repr/struct.RustcPubTransparent.html'
+//@ has - '//*[@class="rust item-decl"]//*[@class="code-attribute"]' '#[repr(transparent)]'
+#[rustc_pub_transparent]
+#[repr(transparent)]
+pub struct RustcPubTransparent {
+    // Private, but `rustc_pub_transparent` means we should document the repr
+    field: u64,
 }
 
 struct Marker; // 1-ZST

--- a/tests/rustdoc-html/repr.rs
+++ b/tests/rustdoc-html/repr.rs
@@ -1,5 +1,6 @@
 // Test the rendering of `#[repr]` on ADTs.
 #![feature(repr_simd)] // only used for the `ReprSimd` test case
+#![feature(rustc_attrs)] // only used for the `RustcPubTransparent` test case
 
 // Check the "local case" (HIR cleaning) //
 
@@ -145,6 +146,16 @@ pub enum ReprTransparentEnumHidden1ZstField {
         #[doc(hidden)]
         field: u64, // ...since the non-1-ZST field is public
     },
+}
+
+// Regression test for <https://github.com/rust-lang/rust/issues/150919>.
+//@ has 'repr/struct.RustcPubTransparent.html'
+//@ has - '//*[@class="rust item-decl"]//*[@class="code-attribute"]' '#[repr(transparent)]'
+#[repr(transparent)] // public...
+#[rustc_pub_transparent] // ...since this attribute was applied
+pub struct RustcPubTransparent {
+    // ...despite this field being private
+    field: u64,
 }
 
 struct Marker; // 1-ZST


### PR DESCRIPTION
Fixes rust-lang/rust#150919