### PR TITLE
Tweak matching on niched enums to better match the stored tags

### DIFF
--- a/compiler/rustc_mir_transform/src/adjust_discriminant_switches.rs
+++ b/compiler/rustc_mir_transform/src/adjust_discriminant_switches.rs
@@ -1,0 +1,108 @@
+//! This pass lowers calls to core::slice::len to just PtrMetadata op.
+//! It should run before inlining!
+
+use rustc_abi as abi;
+use rustc_middle::bug;
+use rustc_middle::mir::interpret::Scalar;
+use rustc_middle::mir::*;
+use rustc_middle::ty::TyCtxt;
+use tracing::trace;
+
+/// Look for `switchInt(Discriminant(place))` where `place` is a niched enum with more than two variants,
+/// and update to `switchInt(Discriminant(place) + DELTA)` when that will simplify codegen later.
+///
+/// Notably, niched enums when calculating `Discriminant(_)` need to adjust the stored tag to produce the
+/// discriminant values, so we can adjust the values in the `switchInt` to better match that tag.
+pub(super) struct AdjustDiscriminantSwitches;
+
+impl<'tcx> crate::MirPass<'tcx> for AdjustDiscriminantSwitches {
+    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
+        sess.mir_opt_level() > 0
+    }
+
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        let def_id = body.source.def_id();
+        if tcx.is_coroutine(def_id) {
+            trace!("Skipped for coroutine {:?}", def_id);
+            return;
+        }
+
+        let mut was_modified = false;
+        let typing_env = body.typing_env(tcx);
+        for block in body.basic_blocks.as_mut_preserves_cfg() {
+            let terminator = block.terminator.as_mut().unwrap();
+            if let Some(last) = block.statements.last()
+                && let TerminatorKind::SwitchInt { discr: switched_op, targets } =
+                    &mut terminator.kind
+                && let Some(switched_place) = switched_op.place()
+                && let StatementKind::Assign(place_and_value) = &last.kind
+                && let Rvalue::Discriminant(inspected_place) = place_and_value.1
+                && let discr_place = place_and_value.0
+                && discr_place == switched_place
+                && let ty = inspected_place.ty(&body.local_decls, tcx).ty
+                && let Ok(layout) = tcx.layout_of(typing_env.as_query_input(ty))
+                && let abi::Variants::Multiple { tag_encoding, .. } = &layout.variants
+                && let abi::TagEncoding::Niche { niche_start, niche_variants, .. } = tag_encoding
+                && niche_variants.clone().count() > 1
+            {
+                let discr_ty = discr_place.ty(&body.local_decls, tcx).ty;
+                let discr_layout = tcx.layout_of(typing_env.as_query_input(discr_ty)).unwrap();
+                let abi::BackendRepr::Scalar(discr_scalar) = discr_layout.backend_repr else {
+                    bug!()
+                };
+                let discr_size = discr_scalar.size(&tcx);
+                let mask = discr_size.unsigned_int_max();
+
+                let delta = niche_start.wrapping_sub(niche_variants.start().as_u32().into()) & mask;
+                if delta == 0 {
+                    continue;
+                }
+                let delta_scalar = Scalar::from_uint(delta, discr_size);
+
+                // No matter what value we use for `delta` this is always sound,
+                // since we adjust the scrutinee and targets in the same way.
+                //
+                // It's just only useful if it allows simplification later.
+
+                was_modified = true;
+
+                let source_info = terminator.source_info;
+                let decl = LocalDecl::with_source_info(discr_ty, source_info);
+                let local = body.local_decls.push(decl);
+                block.statements.push(Statement::new(
+                    source_info,
+                    StatementKind::Assign(Box::new((
+                        Place::from(local),
+                        Rvalue::BinaryOp(
+                            BinOp::Add,
+                            Box::new((
+                                switched_op.clone(),
+                                Operand::const_from_scalar(
+                                    tcx,
+                                    discr_ty,
+                                    delta_scalar,
+                                    source_info.span,
+                                ),
+                            )),
+                        ),
+                    ))),
+                ));
+                *switched_op = Operand::Move(Place::from(local));
+
+                for value in targets.all_values_mut() {
+                    *value = (value.0.wrapping_add(delta) & mask).into();
+                }
+            }
+        }
+
+        // It's unclear to me whether this is needed since we didn't change the *targets*,
+        // but since we did change which *value* goes where, this is safer.
+        if was_modified {
+            body.basic_blocks.invalidate_cfg_cache();
+        }
+    }
+
+    fn is_required(&self) -> bool {
+        false
+    }
+}

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -117,6 +117,7 @@ declare_passes! {
     mod add_moves_for_packed_drops : AddMovesForPackedDrops;
     mod add_retag : AddRetag;
     mod add_subtyping_projections : Subtyper;
+    mod adjust_discriminant_switches : AdjustDiscriminantSwitches;
     mod check_inline : CheckForceInline;
     mod check_call_recursion : CheckCallRecursion, CheckDropRecursion;
     mod check_inline_always_target_features: CheckInlineAlwaysTargetFeature;
@@ -751,6 +752,7 @@ pub(crate) fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'
             &o1(simplify_branches::SimplifyConstCondition::Final),
             &o1(remove_noop_landing_pads::RemoveNoopLandingPads),
             &o1(simplify::SimplifyCfg::Final),
+            &adjust_discriminant_switches::AdjustDiscriminantSwitches,
             // After the last SimplifyCfg, because this wants one-block functions.
             &strip_debuginfo::StripDebugInfo,
             &copy_prop::CopyProp,

--- a/tests/mir-opt/adjust_switchint.niched_1.AdjustDiscriminantSwitches.diff
+++ b/tests/mir-opt/adjust_switchint.niched_1.AdjustDiscriminantSwitches.diff
@@ -1,0 +1,55 @@
+- // MIR for `niched_1` before AdjustDiscriminantSwitches
++ // MIR for `niched_1` after AdjustDiscriminantSwitches
+  
+  fn niched_1(_1: Niched1) -> u32 {
+      debug e => _1;
+      let mut _0: u32;
+      let mut _2: isize;
+      let _3: bool;
+      let mut _4: u32;
+      let mut _5: bool;
++     let mut _6: isize;
+      scope 1 {
+          debug b => _3;
+      }
+  
+      bb0: {
+          _2 = discriminant(_1);
+-         switchInt(move _2) -> [0: bb4, 1: bb3, 2: bb2, otherwise: bb1];
++         _6 = Add(move _2, const 2_isize);
++         switchInt(move _6) -> [2: bb4, 3: bb3, 4: bb2, otherwise: bb1];
+      }
+  
+      bb1: {
+          unreachable;
+      }
+  
+      bb2: {
+          _0 = const 42_u32;
+          goto -> bb5;
+      }
+  
+      bb3: {
+          StorageLive(_3);
+          _3 = copy ((_1 as B).0: bool);
+          StorageLive(_4);
+          StorageLive(_5);
+          _5 = copy _3;
+          _4 = move _5 as u32 (IntToInt);
+          _0 = copy _4;
+          StorageDead(_5);
+          StorageDead(_4);
+          StorageDead(_3);
+          goto -> bb5;
+      }
+  
+      bb4: {
+          _0 = const 7_u32;
+          goto -> bb5;
+      }
+  
+      bb5: {
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/adjust_switchint.rs
+++ b/tests/mir-opt/adjust_switchint.rs
@@ -1,0 +1,23 @@
+//@ test-mir-pass: AdjustDiscriminantSwitches
+
+pub enum Niched1 {
+    A,
+    B(bool),
+    C,
+}
+
+// EMIT_MIR adjust_switchint.niched_1.AdjustDiscriminantSwitches.diff
+pub fn niched_1(e: Niched1) -> u32 {
+    // CHECK: [[DISCR:_.+]] = discriminant(_1);
+    // CHECK: [[ADJ:_.+]] = Add(move [[DISCR]], const 2_isize);
+    // CHECK: switchInt(move [[ADJ]]) -> [2: {{bb.+}}, 3: {{bb.+}}, 4: {{bb.+}}, otherwise: {{bb.+}}];
+    match e {
+        Niched1::A => 7,
+        Niched1::B(b) => b as _,
+        Niched1::C => 42,
+    }
+}
+
+pub fn main() {
+    niched_1(Niched1::A);
+}


### PR DESCRIPTION
In MIR the `Discriminant` Rvalue has to return the *discriminant* (unsurprisingly), but when the enum is niched, that discriminant often doesn't actually match the value *stored*.

However, for concrete enums (where we have layout info) we know how far off the discriminant is from the stored tag, and this PR adds a pass to adjust `switchInt(Discriminant(P))` to `switchInt(Discriminant(P) + D)` so that the values in the switch match what's stored, reducing the transformations needed at runtime.

To take an example from the codegen tests, in `opt-level=3` instead of <https://rust.godbolt.org/z/xodzGTznT>
```llvm
define noundef range(i8 0, 101) i8 @match1(i8 noundef range(i8 0, 4) %0) unnamed_addr {
start:
  %1 = icmp samesign ugt i8 %0, 1
  %2 = zext nneg i8 %0 to i64
  %3 = add nsw i64 %2, -1
  %_2 = select i1 %1, i64 %3, i64 0
  switch i64 %_2, label %bb1 [
    i64 0, label %bb4
    i64 1, label %bb5
    i64 2, label %bb2
  ]
```
ends up being
```llvm
define noundef range(i8 0, 101) i8 @match1(i8 noundef range(i8 0, 4) %0) unnamed_addr #0 {
start:
  %narrow = tail call i8 @llvm.umax.i8(i8 %0, i8 1)
  switch i8 %narrow, label %default.unreachable [
    i8 1, label %bb4
    i8 2, label %bb5
    i8 3, label %bb2
  ]
```
where notably that extra `add` no longer exists thanks to the `switch` values changing appropriately, and as a result LLVM was also able to eliminate the `zext` so it's switching on `i8` (the actual size of the input) instead of `i64` (from isize).
