### PR TITLE
Port `#[collapse_debuginfo]` to the new attribute parsing system

### DIFF
--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -48,7 +48,8 @@ use crate::attributes::lint_helpers::{
 };
 use crate::attributes::loop_match::{ConstContinueParser, LoopMatchParser};
 use crate::attributes::macro_attrs::{
-    AllowInternalUnsafeParser, MacroEscapeParser, MacroExportParser, MacroUseParser,
+    AllowInternalUnsafeParser, CollapseDebugInfoParser, MacroEscapeParser, MacroExportParser,
+    MacroUseParser,
 };
 use crate::attributes::must_use::MustUseParser;
 use crate::attributes::no_implicit_prelude::NoImplicitPreludeParser;
@@ -191,6 +192,7 @@ attribute_parsers!(
 
         // tidy-alphabetical-start
         Single<CfiEncodingParser>,
+        Single<CollapseDebugInfoParser>,
         Single<CoverageParser>,
         Single<CrateNameParser>,
         Single<CustomMirParser>,

--- a/compiler/rustc_expand/messages.ftl
+++ b/compiler/rustc_expand/messages.ftl
@@ -5,9 +5,6 @@ expand_attributes_on_expressions_experimental =
 
 expand_cfg_attr_no_attributes = `#[cfg_attr]` does not expand to any attributes
 
-expand_collapse_debuginfo_illegal =
-    illegal value for attribute #[collapse_debuginfo(no|external|yes)]
-
 expand_count_repetition_misplaced =
     `count` can not be placed inside the innermost repetition
 

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -79,13 +79,6 @@ pub(crate) struct ResolveRelativePath {
 }
 
 #[derive(Diagnostic)]
-#[diag(expand_collapse_debuginfo_illegal)]
-pub(crate) struct CollapseMacroDebuginfoIllegal {
-    #[primary_span]
-    pub span: Span,
-}
-
-#[derive(Diagnostic)]
 #[diag(expand_macro_const_stability)]
 pub(crate) struct MacroConstStability {
     #[primary_span]

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -568,6 +568,26 @@ impl<E: rustc_span::SpanEncoder> rustc_serialize::Encodable<E> for DocAttribute 
     }
 }
 
+/// How to perform collapse macros debug info
+/// if-ext - if macro from different crate (related to callsite code)
+/// | cmd \ attr    | no  | (unspecified) | external | yes |
+/// | no            | no  | no            | no       | no  |
+/// | (unspecified) | no  | no            | if-ext   | yes |
+/// | external      | no  | if-ext        | if-ext   | yes |
+/// | yes           | yes | yes           | yes      | yes |
+#[derive(Copy, Clone, Debug, Hash, PartialEq)]
+#[derive(HashStable_Generic, Encodable, Decodable, PrintAttribute)]
+pub enum CollapseMacroDebuginfo {
+    /// Don't collapse debuginfo for the macro
+    No = 0,
+    /// Unspecified value
+    Unspecified = 1,
+    /// Collapse debuginfo if the macro comes from a different crate
+    External = 2,
+    /// Collapse debuginfo for the macro
+    Yes = 3,
+}
+
 /// Represents parsed *built-in* inert attributes.
 ///
 /// ## Overview
@@ -663,6 +683,9 @@ pub enum AttributeKind {
 
     /// Represents `#[cold]`.
     Cold(Span),
+
+    /// Represents `#[collapse_debuginfo]`.
+    CollapseDebugInfo(CollapseMacroDebuginfo),
 
     /// Represents `#[rustc_confusables]`.
     Confusables {

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -31,6 +31,7 @@ impl AttributeKind {
             CfiEncoding { .. } => Yes,
             Coinductive(..) => No,
             Cold(..) => No,
+            CollapseDebugInfo(..) => Yes,
             Confusables { .. } => Yes,
             ConstContinue(..) => No,
             ConstStability { .. } => Yes,

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -8,14 +8,14 @@ use rustc_abi::Align;
 use rustc_data_structures::profiling::TimePassesFormat;
 use rustc_errors::emitter::HumanReadableErrorType;
 use rustc_errors::{ColorConfig, registry};
-use rustc_hir::attrs::NativeLibKind;
+use rustc_hir::attrs::{CollapseMacroDebuginfo, NativeLibKind};
 use rustc_session::config::{
-    AnnotateMoves, AutoDiff, BranchProtection, CFGuard, Cfg, CollapseMacroDebuginfo, CoverageLevel,
-    CoverageOptions, DebugInfo, DumpMonoStatsFormat, ErrorOutputType, ExternEntry, ExternLocation,
-    Externs, FmtDebug, FunctionReturn, InliningThreshold, Input, InstrumentCoverage,
-    InstrumentXRay, LinkSelfContained, LinkerPluginLto, LocationDetail, LtoCli, MirIncludeSpans,
-    NextSolverConfig, Offload, Options, OutFileName, OutputType, OutputTypes, PAuthKey, PacRet,
-    Passes, PatchableFunctionEntry, Polonius, ProcMacroExecutionStrategy, Strip, SwitchWithOptPath,
+    AnnotateMoves, AutoDiff, BranchProtection, CFGuard, Cfg, CoverageLevel, CoverageOptions,
+    DebugInfo, DumpMonoStatsFormat, ErrorOutputType, ExternEntry, ExternLocation, Externs,
+    FmtDebug, FunctionReturn, InliningThreshold, Input, InstrumentCoverage, InstrumentXRay,
+    LinkSelfContained, LinkerPluginLto, LocationDetail, LtoCli, MirIncludeSpans, NextSolverConfig,
+    Offload, Options, OutFileName, OutputType, OutputTypes, PAuthKey, PacRet, Passes,
+    PatchableFunctionEntry, Polonius, ProcMacroExecutionStrategy, Strip, SwitchWithOptPath,
     SymbolManglingVersion, WasiExecModel, build_configuration, build_session_options,
     rustc_optgroups,
 };

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -55,10 +55,6 @@ passes_change_fields_to_be_of_unit_type =
      *[other] fields
     }
 
-passes_collapse_debuginfo =
-    `collapse_debuginfo` attribute should be applied to macro definitions
-    .label = not a macro definition
-
 passes_const_continue_attr =
     `#[const_continue]` should be applied to a break expression
     .label = not a break expression

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -229,6 +229,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     | AttributeKind::BodyStability { .. }
                     | AttributeKind::ConstStabilityIndirect
                     | AttributeKind::MacroTransparency(_)
+                    | AttributeKind::CollapseDebugInfo(..)
                     | AttributeKind::CfgTrace(..)
                     | AttributeKind::Pointee(..)
                     | AttributeKind::Dummy
@@ -323,7 +324,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                         | [sym::rustc_dirty, ..]
                         | [sym::rustc_if_this_changed, ..]
                         | [sym::rustc_then_this_would_need, ..] => self.check_rustc_dirty_clean(attr),
-                        [sym::collapse_debuginfo, ..] => self.check_collapse_debuginfo(attr, span, target),
                         [sym::must_not_suspend, ..] => self.check_must_not_suspend(attr, span, target),
                         [sym::rustc_has_incoherent_inherent_impls, ..] => {
                             self.check_has_incoherent_inherent_impls(attr, span, target)
@@ -715,18 +715,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     ObjectLifetimeDefault::Ambiguous => "Ambiguous".to_owned(),
                 };
                 tcx.dcx().emit_err(errors::ObjectLifetimeErr { span: p.span, repr });
-            }
-        }
-    }
-    /// Checks if `#[collapse_debuginfo]` is applied to a macro.
-    fn check_collapse_debuginfo(&self, attr: &Attribute, span: Span, target: Target) {
-        match target {
-            Target::MacroDef => {}
-            _ => {
-                self.tcx.dcx().emit_err(errors::CollapseDebuginfo {
-                    attr_span: attr.span(),
-                    defn_span: span,
-                });
             }
         }
     }

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -384,15 +384,6 @@ pub(crate) struct UnusedMultiple {
     pub name: Symbol,
 }
 
-#[derive(Diagnostic)]
-#[diag(passes_collapse_debuginfo)]
-pub(crate) struct CollapseDebuginfo {
-    #[primary_span]
-    pub attr_span: Span,
-    #[label]
-    pub defn_span: Span,
-}
-
 #[derive(LintDiagnostic)]
 #[diag(passes_deprecated_annotation_has_no_effect)]
 pub(crate) struct DeprecatedAnnotationHasNoEffect {

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -3065,6 +3065,7 @@ pub(crate) mod dep_tracking {
     use rustc_errors::LanguageIdentifier;
     use rustc_feature::UnstableFeatures;
     use rustc_hashes::Hash64;
+    use rustc_hir::attrs::CollapseMacroDebuginfo;
     use rustc_span::edition::Edition;
     use rustc_span::{RealFileName, RemapPathScopeComponents};
     use rustc_target::spec::{
@@ -3074,13 +3075,12 @@ pub(crate) mod dep_tracking {
     };
 
     use super::{
-        AnnotateMoves, AutoDiff, BranchProtection, CFGuard, CFProtection, CollapseMacroDebuginfo,
-        CoverageOptions, CrateType, DebugInfo, DebugInfoCompression, ErrorOutputType, FmtDebug,
-        FunctionReturn, InliningThreshold, InstrumentCoverage, InstrumentXRay, LinkerPluginLto,
-        LocationDetail, LtoCli, MirStripDebugInfo, NextSolverConfig, Offload, OptLevel,
-        OutFileName, OutputType, OutputTypes, PatchableFunctionEntry, Polonius, ResolveDocLinks,
-        SourceFileHashAlgorithm, SplitDwarfKind, SwitchWithOptPath, SymbolManglingVersion,
-        WasiExecModel,
+        AnnotateMoves, AutoDiff, BranchProtection, CFGuard, CFProtection, CoverageOptions,
+        CrateType, DebugInfo, DebugInfoCompression, ErrorOutputType, FmtDebug, FunctionReturn,
+        InliningThreshold, InstrumentCoverage, InstrumentXRay, LinkerPluginLto, LocationDetail,
+        LtoCli, MirStripDebugInfo, NextSolverConfig, Offload, OptLevel, OutFileName, OutputType,
+        OutputTypes, PatchableFunctionEntry, Polonius, ResolveDocLinks, SourceFileHashAlgorithm,
+        SplitDwarfKind, SwitchWithOptPath, SymbolManglingVersion, WasiExecModel,
     };
     use crate::lint;
     use crate::utils::NativeLib;
@@ -3297,25 +3297,6 @@ pub enum ProcMacroExecutionStrategy {
 
     /// Run the proc-macro code on a different thread.
     CrossThread,
-}
-
-/// How to perform collapse macros debug info
-/// if-ext - if macro from different crate (related to callsite code)
-/// | cmd \ attr    | no  | (unspecified) | external | yes |
-/// | no            | no  | no            | no       | no  |
-/// | (unspecified) | no  | no            | if-ext   | yes |
-/// | external      | no  | if-ext        | if-ext   | yes |
-/// | yes           | yes | yes           | yes      | yes |
-#[derive(Clone, Copy, PartialEq, Hash, Debug)]
-pub enum CollapseMacroDebuginfo {
-    /// Don't collapse debuginfo for the macro
-    No = 0,
-    /// Unspecified value
-    Unspecified = 1,
-    /// Collapse debuginfo if the macro comes from a different crate
-    External = 2,
-    /// Collapse debuginfo for the macro
-    Yes = 3,
 }
 
 /// Which format to use for `-Z dump-mono-stats`

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -10,6 +10,7 @@ use rustc_data_structures::stable_hasher::StableHasher;
 use rustc_errors::{ColorConfig, LanguageIdentifier, TerminalUrl};
 use rustc_feature::UnstableFeatures;
 use rustc_hashes::Hash64;
+use rustc_hir::attrs::CollapseMacroDebuginfo;
 use rustc_macros::{BlobDecodable, Encodable};
 use rustc_span::edition::Edition;
 use rustc_span::{RealFileName, RemapPathScopeComponents, SourceFileHashAlgorithm};

--- a/tests/ui/attributes/collapse-debuginfo-invalid.rs
+++ b/tests/ui/attributes/collapse-debuginfo-invalid.rs
@@ -5,80 +5,80 @@
 // Test that the `#[collapse_debuginfo]` attribute can only be used on macro definitions.
 
 #[collapse_debuginfo(yes)]
-//~^ ERROR `collapse_debuginfo` attribute should be applied to macro definitions
+//~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
 extern crate std;
 
 #[collapse_debuginfo(yes)]
-//~^ ERROR `collapse_debuginfo` attribute should be applied to macro definitions
+//~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
 use std::collections::HashMap;
 
 #[collapse_debuginfo(yes)]
-//~^ ERROR `collapse_debuginfo` attribute should be applied to macro definitions
+//~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
 static FOO: u32 = 3;
 
 #[collapse_debuginfo(yes)]
-//~^ ERROR `collapse_debuginfo` attribute should be applied to macro definitions
+//~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
 const BAR: u32 = 3;
 
 #[collapse_debuginfo(yes)]
-//~^ ERROR `collapse_debuginfo` attribute should be applied to macro definitions
+//~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
 fn foo() {
     let _ = #[collapse_debuginfo(yes)] || { };
-    //~^ ERROR `collapse_debuginfo` attribute should be applied to macro definitions
+    //~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
     #[collapse_debuginfo(yes)]
-    //~^ ERROR `collapse_debuginfo` attribute should be applied to macro definitions
+    //~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
     let _ = 3;
     let _ = #[collapse_debuginfo(yes)] 3;
-    //~^ ERROR `collapse_debuginfo` attribute should be applied to macro definitions
+    //~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
     match (3, 4) {
         #[collapse_debuginfo(yes)]
-        //~^ ERROR `collapse_debuginfo` attribute should be applied to macro definitions
+        //~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
         _ => (),
     }
 }
 
 #[collapse_debuginfo(yes)]
-//~^ ERROR `collapse_debuginfo` attribute should be applied to macro definitions
+//~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
 mod bar {
 }
 
 #[collapse_debuginfo(yes)]
-//~^ ERROR `collapse_debuginfo` attribute should be applied to macro definitions
+//~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
 type Map = HashMap<u32, u32>;
 
 #[collapse_debuginfo(yes)]
-//~^ ERROR `collapse_debuginfo` attribute should be applied to macro definitions
+//~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
 enum Foo {
     #[collapse_debuginfo(yes)]
-    //~^ ERROR `collapse_debuginfo` attribute should be applied to macro definitions
+    //~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
     Variant,
 }
 
 #[collapse_debuginfo(yes)]
-//~^ ERROR `collapse_debuginfo` attribute should be applied to macro definitions
+//~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
 struct Bar {
     #[collapse_debuginfo(yes)]
-    //~^ ERROR `collapse_debuginfo` attribute should be applied to macro definitions
+    //~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
     field: u32,
 }
 
 #[collapse_debuginfo(yes)]
-//~^ ERROR `collapse_debuginfo` attribute should be applied to macro definitions
+//~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
 union Qux {
     a: u32,
     b: u16
 }
 
 #[collapse_debuginfo(yes)]
-//~^ ERROR `collapse_debuginfo` attribute should be applied to macro definitions
+//~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
 trait Foobar {
     #[collapse_debuginfo(yes)]
-    //~^ ERROR `collapse_debuginfo` attribute should be applied to macro definitions
+    //~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
     type Bar;
 }
 
 #[collapse_debuginfo(yes)]
-//~^ ERROR `collapse_debuginfo` attribute should be applied to macro definitions
+//~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
 type AFoobar = impl Foobar;
 
 impl Foobar for Bar {
@@ -91,14 +91,14 @@ fn constraining() -> AFoobar {
 }
 
 #[collapse_debuginfo(yes)]
-//~^ ERROR `collapse_debuginfo` attribute should be applied to macro definitions
+//~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
 impl Bar {
     #[collapse_debuginfo(yes)]
-    //~^ ERROR `collapse_debuginfo` attribute should be applied to macro definitions
+    //~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
     const FOO: u32 = 3;
 
     #[collapse_debuginfo(yes)]
-    //~^ ERROR `collapse_debuginfo` attribute should be applied to macro definitions
+    //~^ ERROR `#[collapse_debuginfo]` attribute cannot be used on
     fn bar(&self) {}
 }
 

--- a/tests/ui/attributes/collapse-debuginfo-invalid.stderr
+++ b/tests/ui/attributes/collapse-debuginfo-invalid.stderr
@@ -1,221 +1,178 @@
-error: `collapse_debuginfo` attribute should be applied to macro definitions
+error: `#[collapse_debuginfo]` attribute cannot be used on extern crates
   --> $DIR/collapse-debuginfo-invalid.rs:7:1
    |
 LL | #[collapse_debuginfo(yes)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | extern crate std;
-   | ----------------- not a macro definition
+   |
+   = help: `#[collapse_debuginfo]` can only be applied to macro defs
 
-error: `collapse_debuginfo` attribute should be applied to macro definitions
+error: `#[collapse_debuginfo]` attribute cannot be used on use statements
   --> $DIR/collapse-debuginfo-invalid.rs:11:1
    |
 LL | #[collapse_debuginfo(yes)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | use std::collections::HashMap;
-   | ------------------------------ not a macro definition
+   |
+   = help: `#[collapse_debuginfo]` can only be applied to macro defs
 
-error: `collapse_debuginfo` attribute should be applied to macro definitions
+error: `#[collapse_debuginfo]` attribute cannot be used on statics
   --> $DIR/collapse-debuginfo-invalid.rs:15:1
    |
 LL | #[collapse_debuginfo(yes)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | static FOO: u32 = 3;
-   | -------------------- not a macro definition
+   |
+   = help: `#[collapse_debuginfo]` can only be applied to macro defs
 
-error: `collapse_debuginfo` attribute should be applied to macro definitions
+error: `#[collapse_debuginfo]` attribute cannot be used on constants
   --> $DIR/collapse-debuginfo-invalid.rs:19:1
    |
 LL | #[collapse_debuginfo(yes)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | const BAR: u32 = 3;
-   | ------------------- not a macro definition
+   |
+   = help: `#[collapse_debuginfo]` can only be applied to macro defs
 
-error: `collapse_debuginfo` attribute should be applied to macro definitions
+error: `#[collapse_debuginfo]` attribute cannot be used on functions
   --> $DIR/collapse-debuginfo-invalid.rs:23:1
    |
-LL |   #[collapse_debuginfo(yes)]
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | / fn foo() {
-LL | |     let _ = #[collapse_debuginfo(yes)] || { };
-LL | |
-LL | |     #[collapse_debuginfo(yes)]
-...  |
-LL | | }
-   | |_- not a macro definition
+LL | #[collapse_debuginfo(yes)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[collapse_debuginfo]` can only be applied to macro defs
 
-error: `collapse_debuginfo` attribute should be applied to macro definitions
+error: `#[collapse_debuginfo]` attribute cannot be used on closures
   --> $DIR/collapse-debuginfo-invalid.rs:26:13
    |
 LL |     let _ = #[collapse_debuginfo(yes)] || { };
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ ------ not a macro definition
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[collapse_debuginfo]` can only be applied to macro defs
 
-error: `collapse_debuginfo` attribute should be applied to macro definitions
+error: `#[collapse_debuginfo]` attribute cannot be used on statements
   --> $DIR/collapse-debuginfo-invalid.rs:28:5
    |
 LL |     #[collapse_debuginfo(yes)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL |     let _ = 3;
-   |     ---------- not a macro definition
+   |
+   = help: `#[collapse_debuginfo]` can only be applied to macro defs
 
-error: `collapse_debuginfo` attribute should be applied to macro definitions
+error: `#[collapse_debuginfo]` attribute cannot be used on expressions
   --> $DIR/collapse-debuginfo-invalid.rs:31:13
    |
 LL |     let _ = #[collapse_debuginfo(yes)] 3;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ - not a macro definition
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[collapse_debuginfo]` can only be applied to macro defs
 
-error: `collapse_debuginfo` attribute should be applied to macro definitions
+error: `#[collapse_debuginfo]` attribute cannot be used on match arms
   --> $DIR/collapse-debuginfo-invalid.rs:34:9
    |
 LL |         #[collapse_debuginfo(yes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL |         _ => (),
-   |         ------- not a macro definition
+   |
+   = help: `#[collapse_debuginfo]` can only be applied to macro defs
 
-error: `collapse_debuginfo` attribute should be applied to macro definitions
+error: `#[collapse_debuginfo]` attribute cannot be used on modules
   --> $DIR/collapse-debuginfo-invalid.rs:40:1
    |
-LL |   #[collapse_debuginfo(yes)]
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | / mod bar {
-LL | | }
-   | |_- not a macro definition
+LL | #[collapse_debuginfo(yes)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[collapse_debuginfo]` can only be applied to macro defs
 
-error: `collapse_debuginfo` attribute should be applied to macro definitions
+error: `#[collapse_debuginfo]` attribute cannot be used on type aliases
   --> $DIR/collapse-debuginfo-invalid.rs:45:1
    |
 LL | #[collapse_debuginfo(yes)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | type Map = HashMap<u32, u32>;
-   | ----------------------------- not a macro definition
+   |
+   = help: `#[collapse_debuginfo]` can only be applied to macro defs
 
-error: `collapse_debuginfo` attribute should be applied to macro definitions
+error: `#[collapse_debuginfo]` attribute cannot be used on enums
   --> $DIR/collapse-debuginfo-invalid.rs:49:1
    |
-LL |   #[collapse_debuginfo(yes)]
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | / enum Foo {
-LL | |     #[collapse_debuginfo(yes)]
-LL | |
-LL | |     Variant,
-LL | | }
-   | |_- not a macro definition
+LL | #[collapse_debuginfo(yes)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[collapse_debuginfo]` can only be applied to macro defs
 
-error: `collapse_debuginfo` attribute should be applied to macro definitions
+error: `#[collapse_debuginfo]` attribute cannot be used on enum variants
   --> $DIR/collapse-debuginfo-invalid.rs:52:5
    |
 LL |     #[collapse_debuginfo(yes)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL |     Variant,
-   |     ------- not a macro definition
+   |
+   = help: `#[collapse_debuginfo]` can only be applied to macro defs
 
-error: `collapse_debuginfo` attribute should be applied to macro definitions
+error: `#[collapse_debuginfo]` attribute cannot be used on structs
   --> $DIR/collapse-debuginfo-invalid.rs:57:1
    |
-LL |   #[collapse_debuginfo(yes)]
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | / struct Bar {
-LL | |     #[collapse_debuginfo(yes)]
-LL | |
-LL | |     field: u32,
-LL | | }
-   | |_- not a macro definition
+LL | #[collapse_debuginfo(yes)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[collapse_debuginfo]` can only be applied to macro defs
 
-error: `collapse_debuginfo` attribute should be applied to macro definitions
+error: `#[collapse_debuginfo]` attribute cannot be used on struct fields
   --> $DIR/collapse-debuginfo-invalid.rs:60:5
    |
 LL |     #[collapse_debuginfo(yes)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL |     field: u32,
-   |     ---------- not a macro definition
+   |
+   = help: `#[collapse_debuginfo]` can only be applied to macro defs
 
-error: `collapse_debuginfo` attribute should be applied to macro definitions
+error: `#[collapse_debuginfo]` attribute cannot be used on unions
   --> $DIR/collapse-debuginfo-invalid.rs:65:1
-   |
-LL |   #[collapse_debuginfo(yes)]
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | / union Qux {
-LL | |     a: u32,
-LL | |     b: u16
-LL | | }
-   | |_- not a macro definition
-
-error: `collapse_debuginfo` attribute should be applied to macro definitions
-  --> $DIR/collapse-debuginfo-invalid.rs:72:1
-   |
-LL |   #[collapse_debuginfo(yes)]
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | / trait Foobar {
-LL | |     #[collapse_debuginfo(yes)]
-LL | |
-LL | |     type Bar;
-LL | | }
-   | |_- not a macro definition
-
-error: `collapse_debuginfo` attribute should be applied to macro definitions
-  --> $DIR/collapse-debuginfo-invalid.rs:80:1
    |
 LL | #[collapse_debuginfo(yes)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | type AFoobar = impl Foobar;
-   | --------------------------- not a macro definition
-
-error: `collapse_debuginfo` attribute should be applied to macro definitions
-  --> $DIR/collapse-debuginfo-invalid.rs:93:1
    |
-LL |   #[collapse_debuginfo(yes)]
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | / impl Bar {
-LL | |     #[collapse_debuginfo(yes)]
-LL | |
-LL | |     const FOO: u32 = 3;
-...  |
-LL | |     fn bar(&self) {}
-LL | | }
-   | |_- not a macro definition
+   = help: `#[collapse_debuginfo]` can only be applied to macro defs
 
-error: `collapse_debuginfo` attribute should be applied to macro definitions
+error: `#[collapse_debuginfo]` attribute cannot be used on traits
+  --> $DIR/collapse-debuginfo-invalid.rs:72:1
+   |
+LL | #[collapse_debuginfo(yes)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[collapse_debuginfo]` can only be applied to macro defs
+
+error: `#[collapse_debuginfo]` attribute cannot be used on associated types
   --> $DIR/collapse-debuginfo-invalid.rs:75:5
    |
 LL |     #[collapse_debuginfo(yes)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL |     type Bar;
-   |     --------- not a macro definition
+   |
+   = help: `#[collapse_debuginfo]` can only be applied to macro defs
 
-error: `collapse_debuginfo` attribute should be applied to macro definitions
+error: `#[collapse_debuginfo]` attribute cannot be used on type aliases
+  --> $DIR/collapse-debuginfo-invalid.rs:80:1
+   |
+LL | #[collapse_debuginfo(yes)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[collapse_debuginfo]` can only be applied to macro defs
+
+error: `#[collapse_debuginfo]` attribute cannot be used on inherent impl blocks
+  --> $DIR/collapse-debuginfo-invalid.rs:93:1
+   |
+LL | #[collapse_debuginfo(yes)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[collapse_debuginfo]` can only be applied to macro defs
+
+error: `#[collapse_debuginfo]` attribute cannot be used on associated consts
   --> $DIR/collapse-debuginfo-invalid.rs:96:5
    |
 LL |     #[collapse_debuginfo(yes)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL |     const FOO: u32 = 3;
-   |     ------------------- not a macro definition
+   |
+   = help: `#[collapse_debuginfo]` can only be applied to macro defs
 
-error: `collapse_debuginfo` attribute should be applied to macro definitions
+error: `#[collapse_debuginfo]` attribute cannot be used on inherent methods
   --> $DIR/collapse-debuginfo-invalid.rs:100:5
    |
 LL |     #[collapse_debuginfo(yes)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL |     fn bar(&self) {}
-   |     ---------------- not a macro definition
+   |
+   = help: `#[collapse_debuginfo]` can only be applied to macro defs
 
 error: aborting due to 22 previous errors
 


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/131229

Felt like doing one again, has been a while :3

r? @jdonszelmann 