### PR TITLE
rustc_parse_format: improve diagnostics for unsupported python numeric grouping

### DIFF
--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -461,6 +461,7 @@ impl<'input> Parser<'input> {
                 ('?', '}') => self.missing_colon_before_debug_formatter(),
                 ('?', _) => self.suggest_format_debug(),
                 ('<' | '^' | '>', _) => self.suggest_format_align(c),
+                (',', _) => self.suggest_unsupported_python_numeric_grouping(),
                 _ => self.suggest_positional_arg_instead_of_captured_arg(arg),
             }
         }
@@ -932,6 +933,27 @@ impl<'input> Parser<'input> {
                     _ => {}
                 };
             }
+        }
+    }
+
+    fn suggest_unsupported_python_numeric_grouping(&mut self) {
+        if let Some((range, _)) = self.consume_pos(',') {
+            self.errors.insert(
+                0,
+                ParseError {
+                    description:
+                        "python's numeric grouping `,` is not supported in rust format strings"
+                            .to_owned(),
+                    note: Some(format!("to print `{{`, you can escape it using `{{{{`",)),
+                    label: "expected `}`".to_owned(),
+                    span: range,
+                    secondary_label: self
+                        .last_open_brace
+                        .clone()
+                        .map(|sp| ("because of this opening brace".to_owned(), sp)),
+                    suggestion: Suggestion::None,
+                },
+            );
         }
     }
 }

--- a/tests/ui/fmt/format-string-error-2.rs
+++ b/tests/ui/fmt/format-string-error-2.rs
@@ -86,4 +86,6 @@ raw  { \n
 
     println!("{x?}, world!",);
     //~^ ERROR invalid format string: expected `}`, found `?`
+    println!("{x,}, world!",);
+    //~^ ERROR invalid format string: python's numeric grouping `,` is not supported in rust format strings
 }

--- a/tests/ui/fmt/format-string-error-2.stderr
+++ b/tests/ui/fmt/format-string-error-2.stderr
@@ -188,5 +188,15 @@ LL |     println!("{x?}, world!",);
    |
    = note: to print `{`, you can escape it using `{{`
 
-error: aborting due to 19 previous errors
+error: invalid format string: python's numeric grouping `,` is not supported in rust format strings
+  --> $DIR/format-string-error-2.rs:89:17
+   |
+LL |     println!("{x,}, world!",);
+   |               - ^ expected `}` in format string
+   |               |
+   |               because of this opening brace
+   |
+   = note: to print `{`, you can escape it using `{{`
+
+error: aborting due to 20 previous errors
 


### PR DESCRIPTION
Detect Python-style numeric grouping syntax in format strings (e.g. `{x:,}`)
and emit a clear diagnostic explaining that it is not supported in Rust.
This helps users coming from Python understand the error without exposing
the full set of valid Rust format specifiers.