### PR TITLE
alloctests: Don't run the longer partial-sort tests under Miri

### DIFF
--- a/library/alloctests/tests/sort/partial.rs
+++ b/library/alloctests/tests/sort/partial.rs
@@ -79,6 +79,10 @@ fn basic_impl() {
 fn random_patterns() {
     check_is_partial_sorted_ranges(&patterns::random(10));
     check_is_partial_sorted_ranges(&patterns::random(50));
-    check_is_partial_sorted_ranges(&patterns::random(100));
-    check_is_partial_sorted_ranges(&patterns::random(1000));
+
+    // Longer tests would take hours to run under Miri.
+    if !cfg!(miri) {
+        check_is_partial_sorted_ranges(&patterns::random(100));
+        check_is_partial_sorted_ranges(&patterns::random(1000));
+    }
 }


### PR DESCRIPTION
These tests take hours to run in Miri, which greatly increases the duration of the `x86_64-gnu-aux` job, as observed in https://github.com/rust-lang/rust/pull/150900#issuecomment-3731837336.

- [Zulip thread in #t-infra](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/x86_64-gnu-aux.20job.20went.20from.20~2.20to.20~3.2E5.20hours/near/567354541)