### PR TITLE
Underscore-prefixed bindings are explicitly allowed to be unused

### DIFF
--- a/compiler/rustc_mir_transform/src/liveness.rs
+++ b/compiler/rustc_mir_transform/src/liveness.rs
@@ -1086,6 +1086,11 @@ impl<'a, 'tcx> AssignmentResult<'a, 'tcx> {
 
             let Some((name, decl_span)) = self.checked_places.names[index] else { continue };
 
+            // By convention, underscore-prefixed bindings are explicitly allowed to be unused.
+            if name.as_str().starts_with('_') {
+                continue;
+            }
+
             let is_maybe_drop_guard = maybe_drop_guard(
                 tcx,
                 self.typing_env,

--- a/tests/ui/lint/unused/underscore-capture-issue-149889.rs
+++ b/tests/ui/lint/unused/underscore-capture-issue-149889.rs
@@ -1,0 +1,29 @@
+//@ check-pass
+#![deny(unused_assignments)]
+
+fn lock() -> impl Drop {
+    struct Handle;
+
+    impl Drop for Handle {
+        fn drop(&mut self) {}
+    }
+
+    Handle
+}
+
+fn bar(_f: impl FnMut(bool)) {}
+
+pub fn foo() {
+    let mut _handle = None;
+    bar(move |l| {
+        if l {
+            _handle = Some(lock());
+        } else {
+            _handle = None;
+        }
+    })
+}
+
+fn main() {
+    foo();
+}


### PR DESCRIPTION
Fixes rust-lang/rust#149889
