### PR TITLE
Use the old homu bors e-mail address again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,7 +289,7 @@ jobs:
           fi
 
           # Get closest bors merge commit
-          PARENT_COMMIT=`git rev-list --author='122020455+rust-bors\[bot\]@users.noreply.github.com' -n1 --first-parent HEAD^1`
+          PARENT_COMMIT=`git rev-list --author='bors@rust-lang.org' --author='122020455+rust-bors\[bot\]@users.noreply.github.com' -n1 --first-parent HEAD^1`
 
           ./build/citool/debug/citool postprocess-metrics \
               --job-name ${CI_JOB_NAME} \

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -29,7 +29,7 @@ jobs:
           sleep 60
 
           # Get closest bors merge commit
-          PARENT_COMMIT=`git rev-list --author='122020455+rust-bors\[bot\]@users.noreply.github.com' -n1 --first-parent HEAD^1`
+          PARENT_COMMIT=`git rev-list --author='bors@rust-lang.org' --author='122020455+rust-bors\[bot\]@users.noreply.github.com' -n1 --first-parent HEAD^1`
           echo "Parent: ${PARENT_COMMIT}"
 
           # Find PR for the current commit

--- a/src/build_helper/src/git.rs
+++ b/src/build_helper/src/git.rs
@@ -152,7 +152,10 @@ pub fn has_changed_since(git_dir: &Path, base: &str, paths: &[&str]) -> bool {
     })
 }
 
-const LEGACY_BORS_EMAIL: &str = "bors@rust-lang.org";
+// Temporary e-mail used by new bors for merge commits for a few days, until it learned how to reuse
+// the original homu e-mail
+// FIXME: remove in Q2 2026
+const TEMPORARY_BORS_EMAIL: &str = "122020455+rust-bors[bot]@users.noreply.github.com";
 
 /// Escape characters from the git user e-mail, so that git commands do not interpret it as regex
 /// special characters.
@@ -193,10 +196,9 @@ fn get_latest_upstream_commit_that_modified_files(
         &escape_email_git_regex(git_config.git_merge_commit_email),
     ]);
 
-    // Also search for legacy bors account, before we accrue enough commits to
-    // have changes to all relevant file paths done by new bors.
-    if git_config.git_merge_commit_email != LEGACY_BORS_EMAIL {
-        git.args(["--author", LEGACY_BORS_EMAIL]);
+    // Also search for temporary bors account
+    if git_config.git_merge_commit_email != TEMPORARY_BORS_EMAIL {
+        git.args(["--author", &escape_email_git_regex(TEMPORARY_BORS_EMAIL)]);
     }
 
     if !target_paths.is_empty() {
@@ -248,10 +250,9 @@ pub fn get_closest_upstream_commit(
         base,
     ]);
 
-    // Also search for legacy bors account, before we accrue enough commits to
-    // have changes to all relevant file paths done by new bors.
-    if config.git_merge_commit_email != LEGACY_BORS_EMAIL {
-        git.args(["--author", LEGACY_BORS_EMAIL]);
+    // Also search for temporary bors account
+    if config.git_merge_commit_email != TEMPORARY_BORS_EMAIL {
+        git.args(["--author", &escape_email_git_regex(TEMPORARY_BORS_EMAIL)]);
     }
 
     let output = output_result(&mut git)?.trim().to_owned();

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -152,8 +152,8 @@ try:
   - <<: *job-dist-x86_64-linux
 
 # Jobs that only run when explicitly invoked in one of the following ways:
-# - comment `@bors2 try jobs=<job-name>`
-# - `try-job: <job-name>` in the PR description and comment `@bors try` or `@bors2 try`.
+# - comment `@bors try jobs=<job-name>`
+# - `try-job: <job-name>` in the PR description and comment `@bors try`.
 optional:
   # This job is used just to test optional jobs.
   # It will be replaced by tier 2 and tier 3 jobs in the future.

--- a/src/stage0
+++ b/src/stage0
@@ -1,7 +1,7 @@
 dist_server=https://static.rust-lang.org
 artifacts_server=https://ci-artifacts.rust-lang.org/rustc-builds
 artifacts_with_llvm_assertions_server=https://ci-artifacts.rust-lang.org/rustc-builds-alt
-git_merge_commit_email=122020455+rust-bors[bot]@users.noreply.github.com
+git_merge_commit_email=bors@rust-lang.org
 nightly_branch=main
 
 # The configuration above this comment is editable, and can be changed


### PR DESCRIPTION
Now that new bors knows how to use the old homu e-mail address (https://github.com/rust-lang/bors/pull/614), we can revert to the old address. I modified the code to keep compatibility with both addresses, so that everything should still work for every merged commit in the past few days. In a few weeks/months, we could remove the temporary bors e-mail address, as at that point no one will likely care about these few merged commits anymore.

Should not be merged until https://github.com/rust-lang/bors/pull/614 is deployed, although the current version in `main` should already mostly work with both addresses, except for CI postprocessing statistics.

Should be backported.
