### PR TITLE
Completely list all unparsed attributes

### DIFF
--- a/compiler/rustc_attr_parsing/src/interface.rs
+++ b/compiler/rustc_attr_parsing/src/interface.rs
@@ -442,7 +442,17 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
 
     /// Returns whether there is a parser for an attribute with this name
     pub fn is_parsed_attribute(path: &[Symbol]) -> bool {
-        Late::parsers().accepters.contains_key(path) || EARLY_PARSED_ATTRIBUTES.contains(&path)
+        /// The list of attributes that are parsed attributes,
+        /// even though they don't have a parser in `Late::parsers()`
+        const SPECIAL_ATTRIBUTES: &[&[Symbol]] = &[
+            // Cfg attrs are removed after being early-parsed, so don't need to be in the parser list
+            &[sym::cfg],
+            &[sym::cfg_attr],
+        ];
+
+        Late::parsers().accepters.contains_key(path)
+            || EARLY_PARSED_ATTRIBUTES.contains(&path)
+            || SPECIAL_ATTRIBUTES.contains(&path)
     }
 
     fn lower_attr_args(&self, args: &ast::AttrArgs, lower_span: impl Fn(Span) -> Span) -> AttrArgs {

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -346,7 +346,54 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                             | sym::panic_handler
                             | sym::lang
                             | sym::needs_allocator
-                            | sym::default_lib_allocator,
+                            | sym::default_lib_allocator
+                            | sym::rustc_diagnostic_item
+                            | sym::rustc_no_mir_inline
+                            | sym::rustc_insignificant_dtor
+                            | sym::rustc_nonnull_optimization_guaranteed
+                            | sym::rustc_intrinsic
+                            | sym::rustc_inherit_overflow_checks
+                            | sym::rustc_intrinsic_const_stable_indirect
+                            | sym::rustc_trivial_field_reads
+                            | sym::rustc_on_unimplemented
+                            | sym::rustc_do_not_const_check
+                            | sym::rustc_reservation_impl
+                            | sym::rustc_doc_primitive
+                            | sym::rustc_allocator
+                            | sym::rustc_deallocator
+                            | sym::rustc_reallocator
+                            | sym::rustc_conversion_suggestion
+                            | sym::rustc_allocator_zeroed
+                            | sym::rustc_allocator_zeroed_variant
+                            | sym::rustc_deprecated_safe_2024
+                            | sym::rustc_test_marker
+                            | sym::rustc_abi
+                            | sym::rustc_layout
+                            | sym::rustc_proc_macro_decls
+                            | sym::rustc_dump_def_parents
+                            | sym::rustc_never_type_options
+                            | sym::rustc_autodiff
+                            | sym::rustc_capture_analysis
+                            | sym::rustc_regions
+                            | sym::rustc_strict_coherence
+                            | sym::rustc_dump_predicates
+                            | sym::rustc_variance
+                            | sym::rustc_variance_of_opaques
+                            | sym::rustc_hidden_type_of_opaques
+                            | sym::rustc_mir
+                            | sym::rustc_dump_user_args
+                            | sym::rustc_effective_visibility
+                            | sym::rustc_outlives
+                            | sym::rustc_symbol_name
+                            | sym::rustc_evaluate_where_clauses
+                            | sym::rustc_dump_vtable
+                            | sym::rustc_delayed_bug_from_inside_query
+                            | sym::rustc_dump_item_bounds
+                            | sym::rustc_def_path
+                            | sym::rustc_partition_reused
+                            | sym::rustc_partition_codegened
+                            | sym::rustc_expected_cgu_reuse
+                            | sym::rustc_nounwind,
                             ..
                         ] => {}
                         [name, rest@..] => {
@@ -361,15 +408,10 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                                         continue
                                     }
 
-                                    // FIXME: differentiate between unstable and internal attributes just
-                                    // like we do with features instead of just accepting `rustc_`
-                                    // attributes by name. That should allow trimming the above list, too.
-                                    if !name.as_str().starts_with("rustc_") {
-                                        span_bug!(
-                                            attr.span(),
-                                            "builtin attribute {name:?} not handled by `CheckAttrVisitor`"
-                                        )
-                                    }
+                                    span_bug!(
+                                        attr.span(),
+                                        "builtin attribute {name:?} not handled by `CheckAttrVisitor`"
+                                    )
                                 }
                                 None => (),
                             }

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -338,8 +338,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                             | sym::warn
                             | sym::deny
                             | sym::forbid
-                            | sym::cfg
-                            | sym::cfg_attr
                             // need to be fixed
                             | sym::patchable_function_entry // FIXME(patchable_function_entry)
                             | sym::deprecated_safe // FIXME(deprecated_safe)


### PR DESCRIPTION
Also introduce a `SPECIAL_ATTRIBUTES` list, since `cfg` was incorrectly being detected as an unparsed attribute in `check_attr`.

I will also update https://github.com/rust-lang/rust/issues/131229#issuecomment-2971351163

r? @jdonszelmann 