### PR TITLE
Fix no results when searching for == in doc

### DIFF
--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -4749,11 +4749,16 @@ class DocSearch {
                 })(),
                 "query": parsedQuery,
             };
-        } else if (parsedQuery.error !== null) {
+        } else if (parsedQuery.error !== null || parsedQuery.foundElems === 0) {
+            // Symbol-only queries like `==` do not parse into type elements,
+            // but can still match exact item names or doc aliases.
+            const others = parsedQuery.userQuery.length === 0 ?
+                (async function*() {})() :
+                innerRunNameQuery(currentCrate);
             return {
                 "in_args": (async function*() {})(),
                 "returned": (async function*() {})(),
-                "others": innerRunNameQuery(currentCrate),
+                "others": others,
                 "query": parsedQuery,
             };
         } else {
@@ -4764,14 +4769,12 @@ class DocSearch {
             return {
                 "in_args": (async function*() {})(),
                 "returned": (async function*() {})(),
-                "others": parsedQuery.foundElems === 0 ?
-                    (async function*() {})() :
-                    innerRunTypeQuery(
-                        parsedQuery.elems,
-                        parsedQuery.returned,
-                        typeInfo,
-                        currentCrate,
-                    ),
+                "others": innerRunTypeQuery(
+                    parsedQuery.elems,
+                    parsedQuery.returned,
+                    typeInfo,
+                    currentCrate,
+                ),
                 "query": parsedQuery,
             };
         }

--- a/tests/rustdoc-js-std/doc-alias-symbols-150921.js
+++ b/tests/rustdoc-js-std/doc-alias-symbols-150921.js
@@ -1,0 +1,24 @@
+// exact-check
+// Regression test for <https://github.com/rust-lang/rust/issues/150921>.
+
+const EXPECTED = [
+    {
+        'query': '==',
+        'others': [
+            {
+                'path': 'std::cmp',
+                'name': 'Eq',
+                'alias': '==',
+                'href': '../std/cmp/trait.Eq.html',
+                'is_alias': true,
+            },
+            {
+                'path': 'std::cmp',
+                'name': 'PartialEq',
+                'alias': '==',
+                'href': '../std/cmp/trait.PartialEq.html',
+                'is_alias': true,
+            },
+        ],
+    },
+];

--- a/tests/rustdoc-js/doc-alias-symbols-150921.js
+++ b/tests/rustdoc-js/doc-alias-symbols-150921.js
@@ -1,0 +1,29 @@
+// exact-check
+// Regression test for <https://github.com/rust-lang/rust/issues/150921>.
+
+const EXPECTED = [
+    {
+        'query': '==',
+        'others': [
+            {
+                'path': 'doc_alias_symbols_150921',
+                'name': 'OperatorEqEqAlias',
+                'alias': '==',
+                'href': '../doc_alias_symbols_150921/struct.OperatorEqEqAlias.html',
+                'is_alias': true,
+            },
+        ],
+    },
+    {
+        'query': '!=',
+        'others': [
+            {
+                'path': 'doc_alias_symbols_150921',
+                'name': 'OperatorNotEqAlias',
+                'alias': '!=',
+                'href': '../doc_alias_symbols_150921/struct.OperatorNotEqAlias.html',
+                'is_alias': true,
+            },
+        ],
+    },
+];

--- a/tests/rustdoc-js/doc-alias-symbols-150921.rs
+++ b/tests/rustdoc-js/doc-alias-symbols-150921.rs
@@ -1,0 +1,7 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/150921>.
+
+#[doc(alias = "==")]
+pub struct OperatorEqEqAlias;
+
+#[doc(alias = "!=")]
+pub struct OperatorNotEqAlias;


### PR DESCRIPTION
Fixes rust-lang/rust#150921

r? @GuillaumeGomez

