### PR TITLE
Disallow eii in statement position

### DIFF
--- a/compiler/rustc_builtin_macros/messages.ftl
+++ b/compiler/rustc_builtin_macros/messages.ftl
@@ -161,6 +161,8 @@ builtin_macros_eii_only_once = `#[{$name}]` can only be specified once
 
 builtin_macros_eii_shared_macro_expected_function = `#[{$name}]` is only valid on functions
 builtin_macros_eii_shared_macro_expected_max_one_argument = `#[{$name}]` expected no arguments or a single argument: `#[{$name}(default)]`
+builtin_macros_eii_shared_macro_in_statement_position = `#[{$name}]` can only be used on functions inside a module
+    .label = `#[{$name}]` is used on this item, which is part of another item's local scope
 
 builtin_macros_env_not_defined = environment variable `{$var}` not defined at compile time
     .cargo = Cargo sets build script variables at run time. Use `std::env::var({$var_expr})` instead

--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -1040,6 +1040,16 @@ pub(crate) struct EiiSharedMacroExpectedFunction {
 }
 
 #[derive(Diagnostic)]
+#[diag(builtin_macros_eii_shared_macro_in_statement_position)]
+pub(crate) struct EiiSharedMacroInStatementPosition {
+    #[primary_span]
+    pub span: Span,
+    pub name: String,
+    #[label]
+    pub item_span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(builtin_macros_eii_only_once)]
 pub(crate) struct EiiOnlyOnce {
     #[primary_span]

--- a/tests/ui/eii/error_statement_position.rs
+++ b/tests/ui/eii/error_statement_position.rs
@@ -1,11 +1,6 @@
 #![feature(extern_item_impls)]
-// EIIs can, despite not being super useful, be declared in statement position
-// nested inside items. Items in statement position, when expanded as part of a macro,
-// need to be wrapped slightly differently (in an `ast::Statement`).
-// We did this on the happy path (no errors), but when there was an error, we'd
-// replace it with *just* an `ast::Item` not wrapped in an `ast::Statement`.
-// This caused an ICE (https://github.com/rust-lang/rust/issues/149980).
-// this test fails to build, but demonstrates that no ICE is produced.
+// EIIs cannot be used in statement position.
+// This is also a regression test for an ICE (https://github.com/rust-lang/rust/issues/149980).
 
 fn main() {
     struct Bar;
@@ -13,4 +8,10 @@ fn main() {
     #[eii]
     //~^ ERROR `#[eii]` is only valid on functions
     impl Bar {}
+
+
+    // Even on functions, eiis in statement position are rejected
+    #[eii]
+    //~^ ERROR `#[eii]` can only be used on functions inside a module
+    fn foo() {}
 }

--- a/tests/ui/eii/error_statement_position.stderr
+++ b/tests/ui/eii/error_statement_position.stderr
@@ -1,8 +1,17 @@
 error: `#[eii]` is only valid on functions
-  --> $DIR/error_statement_position.rs:13:5
+  --> $DIR/error_statement_position.rs:8:5
    |
 LL |     #[eii]
    |     ^^^^^^
 
-error: aborting due to 1 previous error
+error: `#[eii]` can only be used on functions inside a module
+  --> $DIR/error_statement_position.rs:14:5
+   |
+LL |     #[eii]
+   |     ^^^^^^
+LL |
+LL |     fn foo() {}
+   |        --- `#[eii]` is used on this item, which is part of another item's local scope
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
With how v2 macros resolve, and the name resolution of `super` works, I realized with @WaffleLapkin that there's actually no way to consistently expand EIIs in statement position.

r? @WaffleLapkin 