### PR TITLE
Support GPR pair in RISC-V inline assembly

### DIFF
--- a/compiler/rustc_codegen_gcc/src/asm.rs
+++ b/compiler/rustc_codegen_gcc/src/asm.rs
@@ -723,6 +723,7 @@ fn reg_class_to_gcc(reg_class: InlineAsmRegClass) -> &'static str {
             unreachable!("clobber-only")
         }
         InlineAsmRegClass::RiscV(RiscVInlineAsmRegClass::reg) => "r",
+        InlineAsmRegClass::RiscV(RiscVInlineAsmRegClass::reg_pair) => "R",
         InlineAsmRegClass::RiscV(RiscVInlineAsmRegClass::freg) => "f",
         InlineAsmRegClass::RiscV(RiscVInlineAsmRegClass::vreg) => {
             unreachable!("clobber-only")
@@ -807,6 +808,13 @@ fn dummy_output_type<'gcc, 'tcx>(cx: &CodegenCx<'gcc, 'tcx>, reg: InlineAsmRegCl
             unreachable!("clobber-only")
         }
         InlineAsmRegClass::RiscV(RiscVInlineAsmRegClass::reg) => cx.type_i32(),
+        InlineAsmRegClass::RiscV(RiscVInlineAsmRegClass::reg_pair) => {
+            if cx.tcx.sess.asm_arch.unwrap() == InlineAsmArch::RiscV64 {
+                cx.type_i128()
+            } else {
+                cx.type_i64()
+            }
+        }
         InlineAsmRegClass::RiscV(RiscVInlineAsmRegClass::freg) => cx.type_f32(),
         InlineAsmRegClass::RiscV(RiscVInlineAsmRegClass::vreg) => {
             unreachable!("clobber-only")
@@ -983,6 +991,7 @@ fn modifier_to_gcc(
         }
         InlineAsmRegClass::PowerPC(_) => None,
         InlineAsmRegClass::RiscV(RiscVInlineAsmRegClass::reg)
+        | InlineAsmRegClass::RiscV(RiscVInlineAsmRegClass::reg_pair)
         | InlineAsmRegClass::RiscV(RiscVInlineAsmRegClass::freg) => None,
         InlineAsmRegClass::RiscV(RiscVInlineAsmRegClass::vreg) => {
             unreachable!("clobber-only")

--- a/compiler/rustc_target/src/asm/mod.rs
+++ b/compiler/rustc_target/src/asm/mod.rs
@@ -617,7 +617,7 @@ impl InlineAsmRegClass {
             Self::X86(r) => r.supported_types(arch),
             Self::Arm(r) => r.supported_types(arch),
             Self::AArch64(r) => r.supported_types(arch),
-            Self::RiscV(r) => r.supported_types(arch),
+            Self::RiscV(r) => r.supported_types(arch, allow_experimental_reg),
             Self::Nvptx(r) => r.supported_types(arch),
             Self::PowerPC(r) => r.supported_types(arch),
             Self::Hexagon(r) => r.supported_types(arch),

--- a/compiler/rustc_target/src/asm/riscv.rs
+++ b/compiler/rustc_target/src/asm/riscv.rs
@@ -9,6 +9,7 @@ use crate::spec::{RelocModel, Target};
 def_reg_class! {
     RiscV RiscVInlineAsmRegClass {
         reg,
+        reg_pair,
         freg,
         vreg,
     }
@@ -38,6 +39,7 @@ impl RiscVInlineAsmRegClass {
     pub fn supported_types(
         self,
         arch: InlineAsmArch,
+        allow_experimental_reg: bool,
     ) -> &'static [(InlineAsmType, Option<Symbol>)] {
         match self {
             Self::reg => {
@@ -45,6 +47,18 @@ impl RiscVInlineAsmRegClass {
                     types! { _: I8, I16, I32, I64, F16, F32, F64; }
                 } else {
                     types! { _: I8, I16, I32, F16, F32; }
+                }
+            }
+            Self::reg_pair => {
+                if allow_experimental_reg {
+                    // register pair support is unstable.
+                    if arch == InlineAsmArch::RiscV64 {
+                        types! { _: I128; }
+                    } else {
+                        types! { _: I64; }
+                    }
+                } else {
+                    &[]
                 }
             }
             // FIXME(f128): Add `q: F128;` once LLVM support the `Q` extension.

--- a/src/doc/unstable-book/src/language-features/asm-experimental-reg.md
+++ b/src/doc/unstable-book/src/language-features/asm-experimental-reg.md
@@ -13,6 +13,7 @@ This tracks support for additional registers in architectures where inline assem
 | Architecture | Register class | Registers | LLVM constraint code |
 | ------------ | -------------- | --------- | -------------------- |
 | s390x | `vreg` | `v[0-31]` | `v` |
+| RISC-V | `reg_pair` | | `R` |
 
 > **Notes**:
 > - s390x `vreg` is clobber-only in stable.
@@ -22,6 +23,8 @@ This tracks support for additional registers in architectures where inline assem
 | Architecture | Register class | Target feature | Allowed types |
 | ------------ | -------------- | -------------- | ------------- |
 | s390x | `vreg` | `vector` | `i32`, `f32`, `i64`, `f64`, `i128`, `f128`, `i8x16`, `i16x8`, `i32x4`, `i64x2`, `f32x4`, `f64x2` |
+| RISC-V32 | `reg_pair` | | `i64` |
+| RISC-V64 | `reg_pair` | | `i128` |
 
 ## Register aliases
 
@@ -38,3 +41,4 @@ This tracks support for additional registers in architectures where inline assem
 | Architecture | Register class | Modifier | Example output | LLVM modifier |
 | ------------ | -------------- | -------- | -------------- | ------------- |
 | s390x | `vreg` | None | `%v0` | None |
+| RISC-V | `reg_pair` | None | `a0` | None |

--- a/tests/assembly-llvm/asm/riscv-types.rs
+++ b/tests/assembly-llvm/asm/riscv-types.rs
@@ -30,7 +30,7 @@
 //@ compile-flags: -C target-feature=+d
 //@ compile-flags: -Zmerge-functions=disabled
 
-#![feature(no_core, f16)]
+#![feature(no_core, f16, asm_experimental_reg)]
 #![crate_type = "rlib"]
 #![no_core]
 #![allow(asm_sub_register)]
@@ -135,6 +135,20 @@ check!(reg_f64 f64 reg "mv");
 // CHECK: mv {{[a-z0-9]+}}, {{[a-z0-9]+}}
 // CHECK: #NO_APP
 check!(reg_ptr ptr reg "mv");
+
+// riscv32-LABEL: reg_pair_i64:
+// riscv32: #APP
+// riscv32: mv {{[a-z0-9]+[02468]}}, {{[a-z0-9]+[02468]}}
+// riscv32: #NO_APP
+#[cfg(riscv32)]
+check!(reg_pair_i64 i64 reg_pair "mv");
+
+// riscv64-LABEL: reg_pair_i128:
+// riscv64: #APP
+// riscv64: mv {{[a-z0-9]+[02468]}}, {{[a-z0-9]+[02468]}}
+// riscv64: #NO_APP
+#[cfg(riscv64)]
+check!(reg_pair_i128 i128 reg_pair "mv");
 
 // CHECK-LABEL: freg_f16:
 // zfhmin-NOT: or

--- a/tests/ui/asm/riscv/bad-reg.riscv32e.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv32e.stderr
@@ -1,185 +1,185 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:33:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:35:18
+  --> $DIR/bad-reg.rs:45:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:47:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:39:18
+  --> $DIR/bad-reg.rs:49:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:41:18
+  --> $DIR/bad-reg.rs:51:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:43:18
+  --> $DIR/bad-reg.rs:53:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:94:18
+  --> $DIR/bad-reg.rs:118:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:97:18
+  --> $DIR/bad-reg.rs:121:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:100:26
+  --> $DIR/bad-reg.rs:124:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:26
+  --> $DIR/bad-reg.rs:127:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: cannot use register `x16`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:56:18
    |
 LL |         asm!("", out("x16") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x17`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:48:18
+  --> $DIR/bad-reg.rs:58:18
    |
 LL |         asm!("", out("x17") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x18`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:50:18
+  --> $DIR/bad-reg.rs:60:18
    |
 LL |         asm!("", out("x18") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x19`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:52:18
+  --> $DIR/bad-reg.rs:62:18
    |
 LL |         asm!("", out("x19") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x20`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:54:18
+  --> $DIR/bad-reg.rs:64:18
    |
 LL |         asm!("", out("x20") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x21`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:56:18
+  --> $DIR/bad-reg.rs:66:18
    |
 LL |         asm!("", out("x21") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x22`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:58:18
+  --> $DIR/bad-reg.rs:68:18
    |
 LL |         asm!("", out("x22") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x23`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:60:18
+  --> $DIR/bad-reg.rs:70:18
    |
 LL |         asm!("", out("x23") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x24`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:62:18
+  --> $DIR/bad-reg.rs:72:18
    |
 LL |         asm!("", out("x24") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x25`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:64:18
+  --> $DIR/bad-reg.rs:74:18
    |
 LL |         asm!("", out("x25") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x26`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:66:18
+  --> $DIR/bad-reg.rs:76:18
    |
 LL |         asm!("", out("x26") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x27`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:68:18
+  --> $DIR/bad-reg.rs:78:18
    |
 LL |         asm!("", out("x27") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x28`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:70:18
+  --> $DIR/bad-reg.rs:80:18
    |
 LL |         asm!("", out("x28") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x29`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:72:18
+  --> $DIR/bad-reg.rs:82:18
    |
 LL |         asm!("", out("x29") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x30`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:74:18
+  --> $DIR/bad-reg.rs:84:18
    |
 LL |         asm!("", out("x30") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x31`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:76:18
+  --> $DIR/bad-reg.rs:86:18
    |
 LL |         asm!("", out("x31") _);
    |                  ^^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:80:26
+  --> $DIR/bad-reg.rs:104:26
    |
 LL |         asm!("/* {} */", in(freg) f);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:82:26
+  --> $DIR/bad-reg.rs:106:26
    |
 LL |         asm!("/* {} */", out(freg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:84:26
+  --> $DIR/bad-reg.rs:108:26
    |
 LL |         asm!("/* {} */", in(freg) d);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:87:26
+  --> $DIR/bad-reg.rs:111:26
    |
 LL |         asm!("/* {} */", out(freg) d);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:94:27
+  --> $DIR/bad-reg.rs:118:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -187,7 +187,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:97:28
+  --> $DIR/bad-reg.rs:121:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -195,7 +195,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:100:35
+  --> $DIR/bad-reg.rs:124:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.riscv32gc.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv32gc.stderr
@@ -1,65 +1,65 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:33:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:35:18
+  --> $DIR/bad-reg.rs:45:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:47:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:39:18
+  --> $DIR/bad-reg.rs:49:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:41:18
+  --> $DIR/bad-reg.rs:51:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:43:18
+  --> $DIR/bad-reg.rs:53:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:94:18
+  --> $DIR/bad-reg.rs:118:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:97:18
+  --> $DIR/bad-reg.rs:121:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:100:26
+  --> $DIR/bad-reg.rs:124:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:26
+  --> $DIR/bad-reg.rs:127:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:94:27
+  --> $DIR/bad-reg.rs:118:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -67,7 +67,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:97:28
+  --> $DIR/bad-reg.rs:121:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -75,7 +75,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:100:35
+  --> $DIR/bad-reg.rs:124:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.riscv32gc_stable.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv32gc_stable.stderr
@@ -1,0 +1,137 @@
+error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:43:18
+   |
+LL |         asm!("", out("s1") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:45:18
+   |
+LL |         asm!("", out("fp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:47:18
+   |
+LL |         asm!("", out("sp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:49:18
+   |
+LL |         asm!("", out("gp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:51:18
+   |
+LL |         asm!("", out("tp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:53:18
+   |
+LL |         asm!("", out("zero") _);
+   |                  ^^^^^^^^^^^^^
+
+error[E0658]: register class `reg_pair` can only be used as a clobber in stable
+  --> $DIR/bad-reg.rs:91:26
+   |
+LL |         asm!("/* {} */", in(reg_pair) pair); // requires asm_experimental_reg
+   |                          ^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: register class `reg_pair` can only be used as a clobber in stable
+  --> $DIR/bad-reg.rs:95:26
+   |
+LL |         asm!("/* {} */", out(reg_pair) pair); // requires asm_experimental_reg
+   |                          ^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: register class `reg_pair` can only be used as a clobber in stable
+  --> $DIR/bad-reg.rs:99:26
+   |
+LL |         asm!("/* {} */", out(reg_pair) _); // requires asm_experimental_reg
+   |                          ^^^^^^^^^^^^^^^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:118:18
+   |
+LL |         asm!("", in("v0") x);
+   |                  ^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:121:18
+   |
+LL |         asm!("", out("v0") x);
+   |                  ^^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:124:26
+   |
+LL |         asm!("/* {} */", in(vreg) x);
+   |                          ^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:127:26
+   |
+LL |         asm!("/* {} */", out(vreg) _);
+   |                          ^^^^^^^^^^^
+
+error[E0658]: type `i64` cannot be used with this register class in stable
+  --> $DIR/bad-reg.rs:91:39
+   |
+LL |         asm!("/* {} */", in(reg_pair) pair); // requires asm_experimental_reg
+   |                                       ^^^^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: type `i64` cannot be used with this register class in stable
+  --> $DIR/bad-reg.rs:95:40
+   |
+LL |         asm!("/* {} */", out(reg_pair) pair); // requires asm_experimental_reg
+   |                                        ^^^^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:118:27
+   |
+LL |         asm!("", in("v0") x);
+   |                           ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:121:28
+   |
+LL |         asm!("", out("v0") x);
+   |                            ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:124:35
+   |
+LL |         asm!("/* {} */", in(vreg) x);
+   |                                   ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: aborting due to 18 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/asm/riscv/bad-reg.riscv32i.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv32i.stderr
@@ -1,89 +1,89 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:33:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:35:18
+  --> $DIR/bad-reg.rs:45:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:47:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:39:18
+  --> $DIR/bad-reg.rs:49:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:41:18
+  --> $DIR/bad-reg.rs:51:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:43:18
+  --> $DIR/bad-reg.rs:53:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:94:18
+  --> $DIR/bad-reg.rs:118:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:97:18
+  --> $DIR/bad-reg.rs:121:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:100:26
+  --> $DIR/bad-reg.rs:124:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:26
+  --> $DIR/bad-reg.rs:127:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:80:26
+  --> $DIR/bad-reg.rs:104:26
    |
 LL |         asm!("/* {} */", in(freg) f);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:82:26
+  --> $DIR/bad-reg.rs:106:26
    |
 LL |         asm!("/* {} */", out(freg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:84:26
+  --> $DIR/bad-reg.rs:108:26
    |
 LL |         asm!("/* {} */", in(freg) d);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:87:26
+  --> $DIR/bad-reg.rs:111:26
    |
 LL |         asm!("/* {} */", out(freg) d);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:94:27
+  --> $DIR/bad-reg.rs:118:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -91,7 +91,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:97:28
+  --> $DIR/bad-reg.rs:121:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -99,7 +99,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:100:35
+  --> $DIR/bad-reg.rs:124:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.riscv32imafc.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv32imafc.stderr
@@ -1,65 +1,65 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:33:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:35:18
+  --> $DIR/bad-reg.rs:45:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:47:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:39:18
+  --> $DIR/bad-reg.rs:49:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:41:18
+  --> $DIR/bad-reg.rs:51:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:43:18
+  --> $DIR/bad-reg.rs:53:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:94:18
+  --> $DIR/bad-reg.rs:118:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:97:18
+  --> $DIR/bad-reg.rs:121:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:100:26
+  --> $DIR/bad-reg.rs:124:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:26
+  --> $DIR/bad-reg.rs:127:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: `d` target feature is not enabled
-  --> $DIR/bad-reg.rs:84:35
+  --> $DIR/bad-reg.rs:108:35
    |
 LL |         asm!("/* {} */", in(freg) d);
    |                                   ^
@@ -67,7 +67,7 @@ LL |         asm!("/* {} */", in(freg) d);
    = note: this is required to use type `f64` with register class `freg`
 
 error: `d` target feature is not enabled
-  --> $DIR/bad-reg.rs:87:36
+  --> $DIR/bad-reg.rs:111:36
    |
 LL |         asm!("/* {} */", out(freg) d);
    |                                    ^
@@ -75,7 +75,7 @@ LL |         asm!("/* {} */", out(freg) d);
    = note: this is required to use type `f64` with register class `freg`
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:94:27
+  --> $DIR/bad-reg.rs:118:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -83,7 +83,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:97:28
+  --> $DIR/bad-reg.rs:121:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -91,7 +91,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:100:35
+  --> $DIR/bad-reg.rs:124:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.riscv64gc.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv64gc.stderr
@@ -1,65 +1,65 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:33:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:35:18
+  --> $DIR/bad-reg.rs:45:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:47:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:39:18
+  --> $DIR/bad-reg.rs:49:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:41:18
+  --> $DIR/bad-reg.rs:51:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:43:18
+  --> $DIR/bad-reg.rs:53:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:94:18
+  --> $DIR/bad-reg.rs:118:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:97:18
+  --> $DIR/bad-reg.rs:121:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:100:26
+  --> $DIR/bad-reg.rs:124:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:26
+  --> $DIR/bad-reg.rs:127:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:94:27
+  --> $DIR/bad-reg.rs:118:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -67,7 +67,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:97:28
+  --> $DIR/bad-reg.rs:121:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -75,7 +75,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:100:35
+  --> $DIR/bad-reg.rs:124:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.riscv64gc_stable.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv64gc_stable.stderr
@@ -1,0 +1,137 @@
+error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:43:18
+   |
+LL |         asm!("", out("s1") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:45:18
+   |
+LL |         asm!("", out("fp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:47:18
+   |
+LL |         asm!("", out("sp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:49:18
+   |
+LL |         asm!("", out("gp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:51:18
+   |
+LL |         asm!("", out("tp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:53:18
+   |
+LL |         asm!("", out("zero") _);
+   |                  ^^^^^^^^^^^^^
+
+error[E0658]: register class `reg_pair` can only be used as a clobber in stable
+  --> $DIR/bad-reg.rs:91:26
+   |
+LL |         asm!("/* {} */", in(reg_pair) pair); // requires asm_experimental_reg
+   |                          ^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: register class `reg_pair` can only be used as a clobber in stable
+  --> $DIR/bad-reg.rs:95:26
+   |
+LL |         asm!("/* {} */", out(reg_pair) pair); // requires asm_experimental_reg
+   |                          ^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: register class `reg_pair` can only be used as a clobber in stable
+  --> $DIR/bad-reg.rs:99:26
+   |
+LL |         asm!("/* {} */", out(reg_pair) _); // requires asm_experimental_reg
+   |                          ^^^^^^^^^^^^^^^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:118:18
+   |
+LL |         asm!("", in("v0") x);
+   |                  ^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:121:18
+   |
+LL |         asm!("", out("v0") x);
+   |                  ^^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:124:26
+   |
+LL |         asm!("/* {} */", in(vreg) x);
+   |                          ^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:127:26
+   |
+LL |         asm!("/* {} */", out(vreg) _);
+   |                          ^^^^^^^^^^^
+
+error[E0658]: type `i128` cannot be used with this register class in stable
+  --> $DIR/bad-reg.rs:91:39
+   |
+LL |         asm!("/* {} */", in(reg_pair) pair); // requires asm_experimental_reg
+   |                                       ^^^^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: type `i128` cannot be used with this register class in stable
+  --> $DIR/bad-reg.rs:95:40
+   |
+LL |         asm!("/* {} */", out(reg_pair) pair); // requires asm_experimental_reg
+   |                                        ^^^^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:118:27
+   |
+LL |         asm!("", in("v0") x);
+   |                           ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:121:28
+   |
+LL |         asm!("", out("v0") x);
+   |                            ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:124:35
+   |
+LL |         asm!("/* {} */", in(vreg) x);
+   |                                   ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: aborting due to 18 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/asm/riscv/bad-reg.riscv64imac.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv64imac.stderr
@@ -1,89 +1,89 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:33:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:35:18
+  --> $DIR/bad-reg.rs:45:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:47:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:39:18
+  --> $DIR/bad-reg.rs:49:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:41:18
+  --> $DIR/bad-reg.rs:51:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:43:18
+  --> $DIR/bad-reg.rs:53:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:94:18
+  --> $DIR/bad-reg.rs:118:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:97:18
+  --> $DIR/bad-reg.rs:121:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:100:26
+  --> $DIR/bad-reg.rs:124:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:26
+  --> $DIR/bad-reg.rs:127:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:80:26
+  --> $DIR/bad-reg.rs:104:26
    |
 LL |         asm!("/* {} */", in(freg) f);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:82:26
+  --> $DIR/bad-reg.rs:106:26
    |
 LL |         asm!("/* {} */", out(freg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:84:26
+  --> $DIR/bad-reg.rs:108:26
    |
 LL |         asm!("/* {} */", in(freg) d);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:87:26
+  --> $DIR/bad-reg.rs:111:26
    |
 LL |         asm!("/* {} */", out(freg) d);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:94:27
+  --> $DIR/bad-reg.rs:118:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -91,7 +91,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:97:28
+  --> $DIR/bad-reg.rs:121:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -99,7 +99,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:100:35
+  --> $DIR/bad-reg.rs:124:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^


### PR DESCRIPTION
This supports RISC-V even-odd GPR pair as `reg_pair` class under `asm_experimental_reg` feature (https://github.com/rust-lang/rust/issues/133416).

Both LLVM (20+) and GCC support this as `R` constraint, and this is useful for using AMOCAS.D on RV32 and AMOCAS.Q on RV64 instructions (currently, we need to [split the value and pass it by specifying the specific register name](https://github.com/taiki-e/portable-atomic/blob/2a697d276efffa570b496e9b9ab7bfb3f1031dc5/src/imp/atomic128/riscv64.rs#L318-L323)).

Note: For now, this only implements register class and support for explicitly specifying register names is not implemented. (What name should we choose?)

| Architecture | Register class | Target feature | Allowed types |
| ------------ | -------------- | -------------- | ------------- |
| RISC-V32 | `reg_pair` | | `i64` |
| RISC-V64 | `reg_pair` | | `i128` |

Refs:
- https://github.com/riscv-non-isa/riscv-c-api-doc/pull/92
- https://github.com/llvm/llvm-project/pull/112983

r? @Amanieu 

@rustbot label +A-inline-assembly +O-riscv