### PR TITLE
ui: add test for normalizing const projections with assoc const equality

### DIFF
--- a/tests/ui/const-generics/associated-const-bindings/normalization-via-param-env.rs
+++ b/tests/ui/const-generics/associated-const-bindings/normalization-via-param-env.rs
@@ -1,0 +1,18 @@
+//@ check-pass
+#![feature(min_generic_const_args)]
+#![allow(incomplete_features)]
+
+// Regression test for normalizing const projections
+// with associated const equality bounds.
+
+trait Trait {
+    #[type_const]
+    const C: usize;
+}
+
+fn f<T: Trait<C = 1>>() {
+    // This must normalize <T as Trait>::C to 1
+    let _: [(); T::C] = [()];
+}
+
+fn main() {}


### PR DESCRIPTION
This adds a UI test to associated-const-bindings (created new) directory to  ensure that constant projections with associated const equality bounds are correctly normalized.

File added:
- `tests/ui/const-generics/associated-const-bindings/normalization-via-param-env.rs`

r? @fmease
r? @camelid


Fixes rust-lang/rust#120905
