### PR TITLE
Avoid ICEs after bad patterns, for the other syntactic variants

### DIFF
--- a/tests/ui/pattern/type_mismatch.rs
+++ b/tests/ui/pattern/type_mismatch.rs
@@ -1,4 +1,4 @@
-//! This test used to ICE: rust-lang/rust#109812
+//! These tests used to ICE: rust-lang/rust#109812, rust-lang/rust#150507
 //! Instead of actually analyzing the erroneous patterns,
 //! we instead stop after typeck where errors are already
 //! reported.
@@ -8,11 +8,20 @@
 enum Either {
     One(X),
     Two(X),
+    Three { a: X },
 }
 
 struct X(Y);
 
 struct Y;
+
+struct Z(*const i32);
+unsafe impl Send for Z {}
+
+enum Meow {
+    A { a: Z },
+    B(Z),
+}
 
 fn consume_fnmut(_: impl FnMut()) {}
 
@@ -25,6 +34,58 @@ fn move_into_fnmut() {
 
         let X(mut _t) = x;
     });
+
+    consume_fnmut(|| {
+        let Either::Three { a: ref mut _t } = x;
+        //~^ ERROR: mismatched types
+
+        let X(mut _t) = x;
+    });
+}
+
+fn tuple_against_array() {
+    let variant: [();1] = [()];
+
+    || match variant {
+        (2,) => (),
+        //~^ ERROR: mismatched types
+        _ => {}
+    };
+
+    || {
+        let ((2,) | _) = variant;
+        //~^ ERROR: mismatched types
+    };
+}
+
+// Reproducer that triggers the compatibility lint more reliably, instead of relying on the fact
+// that at the time of writing, an unresolved integer type variable does not implement any
+// auto-traits.
+//
+// The @_ makes this example also reproduce ICE #150507 before PR #138961
+fn arcane() {
+    let variant: [();1] = [()];
+
+    || {
+        match variant {
+            (Z(y@_),) => {}
+            //~^ ERROR: mismatched types
+        }
+    };
+
+    || {
+        match variant {
+            Meow::A { a: Z(y@_) } => {}
+            //~^ ERROR: mismatched types
+        }
+    };
+
+    || {
+        match variant {
+            Meow::B(Z(y@_)) => {}
+            //~^ ERROR: mismatched types
+        }
+    };
 }
 
 fn main() {}

--- a/tests/ui/pattern/type_mismatch.stderr
+++ b/tests/ui/pattern/type_mismatch.stderr
@@ -1,11 +1,68 @@
 error[E0308]: mismatched types
-  --> $DIR/type_mismatch.rs:23:13
+  --> $DIR/type_mismatch.rs:32:13
    |
 LL |         let Either::Two(ref mut _t) = x;
    |             ^^^^^^^^^^^^^^^^^^^^^^^   - this expression has type `X`
    |             |
    |             expected `X`, found `Either`
 
-error: aborting due to 1 previous error
+error[E0308]: mismatched types
+  --> $DIR/type_mismatch.rs:39:13
+   |
+LL |         let Either::Three { a: ref mut _t } = x;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   - this expression has type `X`
+   |             |
+   |             expected `X`, found `Either`
+
+error[E0308]: mismatched types
+  --> $DIR/type_mismatch.rs:50:9
+   |
+LL |     || match variant {
+   |              ------- this expression has type `[(); 1]`
+LL |         (2,) => (),
+   |         ^^^^ expected `[(); 1]`, found `(_,)`
+   |
+   = note: expected array `[(); 1]`
+              found tuple `(_,)`
+
+error[E0308]: mismatched types
+  --> $DIR/type_mismatch.rs:56:14
+   |
+LL |         let ((2,) | _) = variant;
+   |              ^^^^        ------- this expression has type `[(); 1]`
+   |              |
+   |              expected `[(); 1]`, found `(_,)`
+   |
+   = note: expected array `[(); 1]`
+              found tuple `(_,)`
+
+error[E0308]: mismatched types
+  --> $DIR/type_mismatch.rs:71:13
+   |
+LL |         match variant {
+   |               ------- this expression has type `[(); 1]`
+LL |             (Z(y@_),) => {}
+   |             ^^^^^^^^^ expected `[(); 1]`, found `(_,)`
+   |
+   = note: expected array `[(); 1]`
+              found tuple `(_,)`
+
+error[E0308]: mismatched types
+  --> $DIR/type_mismatch.rs:78:13
+   |
+LL |         match variant {
+   |               ------- this expression has type `[(); 1]`
+LL |             Meow::A { a: Z(y@_) } => {}
+   |             ^^^^^^^^^^^^^^^^^^^^^ expected `[(); 1]`, found `Meow`
+
+error[E0308]: mismatched types
+  --> $DIR/type_mismatch.rs:85:13
+   |
+LL |         match variant {
+   |               ------- this expression has type `[(); 1]`
+LL |             Meow::B(Z(y@_)) => {}
+   |             ^^^^^^^^^^^^^^^ expected `[(); 1]`, found `Meow`
+
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
This PR introduces changes equivalent to the ones in rust-lang/rust#126320, but also for struct and tuple patterns, instead of tuple struct patterns only.

Fixes rust-lang/rust#150507.