### PR TITLE
Use updated indexes to build reverse map for delegation generics

### DIFF
--- a/compiler/rustc_hir_analysis/src/delegation.rs
+++ b/compiler/rustc_hir_analysis/src/delegation.rs
@@ -135,9 +135,6 @@ fn build_generics<'tcx>(
     // }
     own_params.sort_by_key(|key| key.kind.is_ty_or_const());
 
-    let param_def_id_to_index =
-        own_params.iter().map(|param| (param.def_id, param.index)).collect();
-
     let (parent_count, has_self) = if let Some(def_id) = parent {
         let parent_generics = tcx.generics_of(def_id);
         let parent_kind = tcx.def_kind(def_id);
@@ -161,6 +158,9 @@ fn build_generics<'tcx>(
             *has_default = false;
         }
     }
+
+    let param_def_id_to_index =
+        own_params.iter().map(|param| (param.def_id, param.index)).collect();
 
     ty::Generics {
         parent,

--- a/tests/ui/delegation/ice-issue-150673.rs
+++ b/tests/ui/delegation/ice-issue-150673.rs
@@ -1,0 +1,21 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+mod to_reuse {
+    pub fn foo<T>() -> T {
+        unimplemented!()
+    }
+}
+
+struct S<T>(T);
+
+trait Trait {
+    reuse to_reuse::foo;
+}
+
+impl Trait for S {
+//~^ ERROR: missing generics for struct `S`
+    reuse Trait::foo;
+}
+
+fn main() {}

--- a/tests/ui/delegation/ice-issue-150673.stderr
+++ b/tests/ui/delegation/ice-issue-150673.stderr
@@ -1,0 +1,19 @@
+error[E0107]: missing generics for struct `S`
+  --> $DIR/ice-issue-150673.rs:16:16
+   |
+LL | impl Trait for S {
+   |                ^ expected 1 generic argument
+   |
+note: struct defined here, with 1 generic parameter: `T`
+  --> $DIR/ice-issue-150673.rs:10:8
+   |
+LL | struct S<T>(T);
+   |        ^ -
+help: add missing generic argument
+   |
+LL | impl Trait for S<T> {
+   |                 +++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0107`.


### PR DESCRIPTION
Fixes rust-lang/rust#150673.

This was a bug that built the `param_def_id_to_index` map with indexes before the new generics were renumbered.

r? @petrochenkov