### PR TITLE
remote-test-server: Fix header in batch mode

### DIFF
--- a/src/tools/remote-test-server/src/main.rs
+++ b/src/tools/remote-test-server/src/main.rs
@@ -387,7 +387,7 @@ fn batch_copy(buf: &[u8], which: u8, dst: &Mutex<dyn Write>) {
     if n > 0 {
         t!(dst.write_all(buf));
         // Marking buf finished
-        t!(dst.write_all(&[which, 0, 0, 0, 0,]));
+        t!(dst.write_all(&create_header(which, 0)));
     }
 }
 


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/119999, the length field of the header was changed from 4 bytes to 8. One of the headers in `batch_copy` was missed though, so it sends the wrong size. Fix by switching to `create_header` in that spot too.