### PR TITLE
std: sys: net: uefi: Make TcpStream Send

### DIFF
--- a/library/std/src/sys/net/connection/uefi/tcp.rs
+++ b/library/std/src/sys/net/connection/uefi/tcp.rs
@@ -9,6 +9,9 @@ pub(crate) enum Tcp {
     V4(tcp4::Tcp4),
 }
 
+// SAFETY: UEFI has no threads.
+unsafe impl Send for Tcp {}
+
 impl Tcp {
     pub(crate) fn connect(addr: &SocketAddr, timeout: Option<Duration>) -> io::Result<Self> {
         match addr {


### PR DESCRIPTION
- Since UEFI has no threads, this should be safe.
- Makes compiling remote-test-server simpler.
