### PR TITLE
Fix ICE in valtree_to_const_value for invalid types

### DIFF
--- a/tests/ui/const-generics/adt-const-param-ice-150969-gcc.rs
+++ b/tests/ui/const-generics/adt-const-param-ice-150969-gcc.rs
@@ -1,0 +1,14 @@
+//@ ignore-backends: llvm
+#![feature(generic_const_exprs)]
+//~^ WARN the feature `generic_const_exprs` is incomplete
+#![feature(min_generic_const_args)]
+//~^ WARN the feature `min_generic_const_args` is incomplete
+
+fn pass_enum<const N : usize, const M : usize = const {N}>() {
+    //~^ ERROR defaults for generic parameters are not allowed here
+    //~| ERROR constructing invalid value: encountered uninitialized memory
+    pass_enum::<{None}>();
+    //~^ ERROR missing generics for enum `Option`
+}
+
+fn main() {}

--- a/tests/ui/const-generics/adt-const-param-ice-150969-gcc.stderr
+++ b/tests/ui/const-generics/adt-const-param-ice-150969-gcc.stderr
@@ -1,0 +1,49 @@
+warning: the feature `generic_const_exprs` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/adt-const-param-ice-150969-gcc.rs:2:12
+   |
+LL | #![feature(generic_const_exprs)]
+   |            ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: the feature `min_generic_const_args` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/adt-const-param-ice-150969-gcc.rs:4:12
+   |
+LL | #![feature(min_generic_const_args)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+
+error: defaults for generic parameters are not allowed here
+  --> $DIR/adt-const-param-ice-150969-gcc.rs:7:31
+   |
+LL | fn pass_enum<const N : usize, const M : usize = const {N}>() {
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0107]: missing generics for enum `Option`
+  --> $DIR/adt-const-param-ice-150969-gcc.rs:10:18
+   |
+LL |     pass_enum::<{None}>();
+   |                  ^^^^ expected 1 generic argument
+   |
+help: add missing generic argument
+   |
+LL |     pass_enum::<{None<T>}>();
+   |                      +++
+
+error[E0080]: constructing invalid value: encountered uninitialized memory, but expected an integer
+  --> $DIR/adt-const-param-ice-150969-gcc.rs:7:49
+   |
+LL | fn pass_enum<const N : usize, const M : usize = const {N}>() {
+   |                                                 ^^^^^^^^^ it is undefined behavior to use this value
+   |
+   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 8, align: 8) {
+               __ __ __ __ __ __ __ __                         │ ░░░░░░░░
+           }
+
+error: aborting due to 3 previous errors; 2 warnings emitted
+
+Some errors have detailed explanations: E0080, E0107.
+For more information about an error, try `rustc --explain E0080`.

--- a/tests/ui/const-generics/adt-const-param-ice-150969.rs
+++ b/tests/ui/const-generics/adt-const-param-ice-150969.rs
@@ -1,0 +1,13 @@
+//@ ignore-backends: gcc
+#![feature(generic_const_exprs)]
+//~^ WARN the feature `generic_const_exprs` is incomplete
+#![feature(min_generic_const_args)]
+//~^ WARN the feature `min_generic_const_args` is incomplete
+
+fn pass_enum<const N : usize, const M : usize = const {N}>() {
+    //~^ ERROR defaults for generic parameters are not allowed here
+    pass_enum::<{None}>();
+    //~^ ERROR missing generics for enum `Option`
+}
+
+fn main() {}

--- a/tests/ui/const-generics/adt-const-param-ice-150969.stderr
+++ b/tests/ui/const-generics/adt-const-param-ice-150969.stderr
@@ -1,0 +1,37 @@
+warning: the feature `generic_const_exprs` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/adt-const-param-ice-150969.rs:2:12
+   |
+LL | #![feature(generic_const_exprs)]
+   |            ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: the feature `min_generic_const_args` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/adt-const-param-ice-150969.rs:4:12
+   |
+LL | #![feature(min_generic_const_args)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+
+error: defaults for generic parameters are not allowed here
+  --> $DIR/adt-const-param-ice-150969.rs:7:31
+   |
+LL | fn pass_enum<const N : usize, const M : usize = const {N}>() {
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0107]: missing generics for enum `Option`
+  --> $DIR/adt-const-param-ice-150969.rs:9:18
+   |
+LL |     pass_enum::<{None}>();
+   |                  ^^^^ expected 1 generic argument
+   |
+help: add missing generic argument
+   |
+LL |     pass_enum::<{None<T>}>();
+   |                      +++
+
+error: aborting due to 2 previous errors; 2 warnings emitted
+
+For more information about this error, try `rustc --explain E0107`.


### PR DESCRIPTION
the compiler was causing an ice because it was unwrapping `layout_of` during valtree-to-const conversion. this happened when the type had errors, like missing generic arguments.

i changed the `unwrap()` to a safe check. now if the layout fails due to type errors, it gracefully returns `ConstValue::ZeroSized` so we get proper error reporting instead of a crash

Fixes rust-lang/rust#150969 
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
