### PR TITLE
Remove `S-waiting-on-bors` after a PR is merged

### DIFF
--- a/rust-bors.toml
+++ b/rust-bors.toml
@@ -55,7 +55,8 @@ try_failed = [
     "-S-waiting-on-crater"
 ]
 auto_build_succeeded = [
-    "+merged-by-bors"
+    "+merged-by-bors",
+    "-S-waiting-on-bors"
 ]
 auto_build_failed = [
     "+S-waiting-on-review",


### PR DESCRIPTION
I just noticed that we have 50k+ PRs marked as waiting on bors, even though they have been merged, lol.
