### PR TITLE
Fix typo in `MaybeUninit` docs

### DIFF
--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -256,7 +256,7 @@ use crate::{fmt, intrinsics, ptr, slice};
 ///
 /// # Validity
 ///
-/// `MaybeUninit<T>` has no validity requirements –- any sequence of [bytes] of
+/// `MaybeUninit<T>` has no validity requirements – any sequence of [bytes] of
 /// the appropriate length, initialized or uninitialized, are a valid
 /// representation.
 ///


### PR DESCRIPTION
–- → – (extra ASCII minus after endash)

Introduced in https://github.com/rust-lang/rust/pull/140463 (11627f00c0599c5d033b3e38e3196786537c439b).