### PR TITLE
std: use `ByteStr`'s `Display` for `OsStr`

### DIFF
--- a/library/std/src/sys/os_str/bytes.rs
+++ b/library/std/src/sys/os_str/bytes.rs
@@ -4,8 +4,8 @@
 use core::clone::CloneToUninit;
 
 use crate::borrow::Cow;
+use crate::bstr::ByteStr;
 use crate::collections::TryReserveError;
-use crate::fmt::Write;
 use crate::rc::Rc;
 use crate::sync::Arc;
 use crate::sys::{AsInner, FromInner, IntoInner};
@@ -64,25 +64,7 @@ impl fmt::Debug for Slice {
 
 impl fmt::Display for Slice {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // If we're the empty string then our iterator won't actually yield
-        // anything, so perform the formatting manually
-        if self.inner.is_empty() {
-            return "".fmt(f);
-        }
-
-        for chunk in self.inner.utf8_chunks() {
-            let valid = chunk.valid();
-            // If we successfully decoded the whole chunk as a valid string then
-            // we can return a direct formatting of the string which will also
-            // respect various formatting flags if possible.
-            if chunk.invalid().is_empty() {
-                return valid.fmt(f);
-            }
-
-            f.write_str(valid)?;
-            f.write_char(char::REPLACEMENT_CHARACTER)?;
-        }
-        Ok(())
+        fmt::Display::fmt(ByteStr::new(&self.inner), f)
     }
 }
 


### PR DESCRIPTION
Besides reducing duplication, this also results in formatting parameters like padding, align and fill being respected.