### PR TITLE
Make `Type::of` support unsized types

### DIFF
--- a/library/core/src/mem/type_info.rs
+++ b/library/core/src/mem/type_info.rs
@@ -31,7 +31,7 @@ impl Type {
     #[unstable(feature = "type_info", issue = "146922")]
     #[rustc_const_unstable(feature = "type_info", issue = "146922")]
     // FIXME(reflection): don't require the 'static bound
-    pub const fn of<T: 'static>() -> Self {
+    pub const fn of<T: ?Sized + 'static>() -> Self {
         const { TypeId::of::<T>().info() }
     }
 }

--- a/tests/ui/reflection/dump.rs
+++ b/tests/ui/reflection/dump.rs
@@ -27,4 +27,6 @@ fn main() {
     println!("{:#?}", const { Type::of::<&Unsized>() }.kind);
     println!("{:#?}", const { Type::of::<&str>() }.kind);
     println!("{:#?}", const { Type::of::<&[u8]>() }.kind);
+    println!("{:#?}", const { Type::of::<str>() }.kind);
+    println!("{:#?}", const { Type::of::<[u8]>() }.kind);
 }

--- a/tests/ui/reflection/dump.run.stdout
+++ b/tests/ui/reflection/dump.run.stdout
@@ -21,3 +21,5 @@ Other
 Other
 Other
 Other
+Other
+Other


### PR DESCRIPTION
Tracking issue: rust-lang/rust#146922
Fixes rust-lang/rust#151018

`Type::of` is a utility function for getting type reflection information, and internally just calls `TypeId::of::<T>().info()`. `Type::of` does not support unsized types like `str` and `[u8]` because it is missing a `?Sized` bound. I believe this is an oversight rather than an intentional decision, as `TypeId::of` _does_ support unsized types and `Type::size` is an `Option` to support types without sizes.

This PR adds a `?Sized` bound to `Type::of` and extends the `dump.rs` test to ensure unsized types work in the future.

r? @oli-obk 