### PR TITLE
REPRODUCER: Change `thread_local_inner` macro transparency to "opaque"

### DIFF
--- a/library/std/src/sys/thread_local/native/mod.rs
+++ b/library/std/src/sys/thread_local/native/mod.rs
@@ -47,7 +47,7 @@ pub use lazy::Storage as LazyStorage;
 )]
 #[allow_internal_unsafe]
 #[unstable(feature = "thread_local_internals", issue = "none")]
-#[rustc_macro_transparency = "semiopaque"]
+#[rustc_macro_transparency = "opaque"]
 pub macro thread_local_inner {
     // NOTE: we cannot import `LocalKey`, `LazyStorage` or `EagerStorage` with a `use` because that
     // can shadow user provided type or type alias with a matching name. Please update the shadowing


### PR DESCRIPTION
This PR demonstrates that macro transparency `"opaque"` triggers `missing stability attribute` errors for other macros in std, not only for Externally Implementable Items (eii) in std. This problem was known before eii. See https://github.com/rust-lang/rust/issues/146993.

This PR has this diff:

```diff
diff --git a/library/std/src/sys/thread_local/native/mod.rs b/library/std/src/sys/thread_local/native/mod.rs
index 4dad81685a9..dec20a2565d 100644
--- a/library/std/src/sys/thread_local/native/mod.rs
+++ b/library/std/src/sys/thread_local/native/mod.rs
@@ -47,7 +47,7 @@
 )]
 #[allow_internal_unsafe]
 #[unstable(feature = "thread_local_internals", issue = "none")]
-#[rustc_macro_transparency = "semiopaque"]
+#[rustc_macro_transparency = "opaque"]
 pub macro thread_local_inner {
     // NOTE: we cannot import `LocalKey`, `LazyStorage` or `EagerStorage` with a `use` because that
     // can shadow user provided type or type alias with a matching name. Please update the shadowing
```

and as can be seen below gives build errors like these:

```
error: function has missing stability attribute
  --> library/std/src/sys/helpers/mod.rs:23:1
   |
23 | pub fn mul_div_u64(value: u64, numerator: u64, denom: u64) -> u64 {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: function has missing stability attribute
  --> library/std/src/sys/helpers/mod.rs:33:1
   |
33 | pub fn ignore_notfound<T>(result: crate::io::Result<T>) -> crate::io::Result<()> {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

[...]
```
