### PR TITLE
Don't suggest replacing closure parameter with type name

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -5323,12 +5323,9 @@ fn hint_missing_borrow<'tcx>(
                     ty = mut_ty.ty;
                     left -= 1;
                 }
-                let sugg = if left == 0 {
-                    (span, String::new())
-                } else {
-                    (arg.span, expected_arg.to_string())
-                };
-                remove_borrow.push(sugg);
+                if left == 0 {
+                    remove_borrow.push((span, String::new()));
+                }
             }
         }
     }

--- a/tests/ui/closures/multiple-fn-bounds.stderr
+++ b/tests/ui/closures/multiple-fn-bounds.stderr
@@ -19,11 +19,6 @@ note: required by a bound in `foo`
    |
 LL | fn foo<F: Fn(&char) -> bool + Fn(char) -> bool>(f: F) {
    |                               ^^^^^^^^^^^^^^^^ required by this bound in `foo`
-help: consider adjusting the signature so it does not borrow its argument
-   |
-LL -     foo(move |x| v);
-LL +     foo(move |char| v);
-   |
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
When a closure has an inferred parameter type like `|ch|` and the expected type differs in borrowing (e.g., `char` vs `&char`), the suggestion would incorrectly propose `|char|` instead of something valid like `|ch: char|`.

This happened because the code couldn't walk explicit `&` references in the HIR when the type is inferred, and fell back to replacing the entire parameter span with the expected type name.

Fix by only emitting the suggestion when we can properly identify the `&` syntax to remove.

Fixes rust-lang/rust#150693