### PR TITLE
Better handle when trying to iterate on a `Range` of a type that isn't `Step`

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -681,7 +681,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     // Ambiguous predicates should never error
                     | ty::PredicateKind::Ambiguous
                     // We never return Err when proving UnstableFeature goal.
-                    | ty::PredicateKind::Clause(ty::ClauseKind::UnstableFeature{ .. })
+                    | ty::PredicateKind::Clause(ty::ClauseKind::UnstableFeature { .. })
                     | ty::PredicateKind::NormalizesTo { .. }
                     | ty::PredicateKind::AliasRelate { .. }
                     | ty::PredicateKind::Clause(ty::ClauseKind::ConstArgHasType { .. }) => {

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -5515,7 +5515,14 @@ pub(super) fn get_explanation_based_on_obligation<'tcx>(
         };
         if let ty::PredicatePolarity::Positive = trait_predicate.polarity() {
             format!(
-                "{pre_message}the trait `{}` is not implemented for{desc} `{}`",
+                "{pre_message}the {}trait `{}` is not implemented for{desc} `{}`",
+                if tcx.lookup_stability(trait_predicate.def_id()).map(|s| s.level.is_stable())
+                    == Some(false)
+                {
+                    "nightly-only, unstable "
+                } else {
+                    ""
+                },
                 trait_predicate.print_modifiers_and_trait_path(),
                 tcx.short_string(trait_predicate.self_ty().skip_binder(), long_ty_path),
             )

--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -21,6 +21,11 @@ unsafe_impl_trusted_step![AsciiChar char i8 i16 i32 i64 i128 isize u8 u16 u32 u6
 /// The *successor* operation moves towards values that compare greater.
 /// The *predecessor* operation moves towards values that compare lesser.
 #[rustc_diagnostic_item = "range_step"]
+#[rustc_on_unimplemented(
+    note = "`Range` only implements `Iterator` for select types in the standard library, \
+            particularly integers; to see the full list of types, see the documentation for the \
+            unstable `Step` trait"
+)]
 #[unstable(feature = "step_trait", issue = "42168")]
 pub trait Step: Clone + PartialOrd + Sized {
     /// Returns the bounds on the number of *successor* steps required to get from `start` to `end`

--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -23,7 +23,7 @@ unsafe_impl_trusted_step![AsciiChar char i8 i16 i32 i64 i128 isize u8 u16 u32 u6
 #[rustc_diagnostic_item = "range_step"]
 #[rustc_on_unimplemented(
     message = "`std::ops::Range<{Self}>` is not an iterator",
-    label = "not an iterator",
+    label = "`Range<{Self}>` is not an iterator",
     note = "`Range` only implements `Iterator` for select types in the standard library, \
             particularly integers; to see the full list of types, see the documentation for the \
             unstable `Step` trait"

--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -22,6 +22,7 @@ unsafe_impl_trusted_step![AsciiChar char i8 i16 i32 i64 i128 isize u8 u16 u32 u6
 /// The *predecessor* operation moves towards values that compare lesser.
 #[rustc_diagnostic_item = "range_step"]
 #[rustc_on_unimplemented(
+    message = "`std::ops::Range<{Self}>` is not an iterator",
     note = "`Range` only implements `Iterator` for select types in the standard library, \
             particularly integers; to see the full list of types, see the documentation for the \
             unstable `Step` trait"

--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -23,6 +23,7 @@ unsafe_impl_trusted_step![AsciiChar char i8 i16 i32 i64 i128 isize u8 u16 u32 u6
 #[rustc_diagnostic_item = "range_step"]
 #[rustc_on_unimplemented(
     message = "`std::ops::Range<{Self}>` is not an iterator",
+    label = "not an iterator",
     note = "`Range` only implements `Iterator` for select types in the standard library, \
             particularly integers; to see the full list of types, see the documentation for the \
             unstable `Step` trait"

--- a/tests/run-make/missing-unstable-trait-bound/missing-bound.stderr
+++ b/tests/run-make/missing-unstable-trait-bound/missing-bound.stderr
@@ -2,7 +2,7 @@ error[E0277]: `std::ops::Range<T>` is not an iterator
  --> missing-bound.rs:2:14
   |
 2 |     for _ in t {}
-  |              ^ not an iterator
+  |              ^ `Range<T>` is not an iterator
   |
   = note: `Range` only implements `Iterator` for select types in the standard library, particularly integers; to see the full list of types, see the documentation for the unstable `Step` trait
   = note: required for `std::ops::Range<T>` to implement `Iterator`

--- a/tests/run-make/missing-unstable-trait-bound/missing-bound.stderr
+++ b/tests/run-make/missing-unstable-trait-bound/missing-bound.stderr
@@ -2,7 +2,7 @@ error[E0277]: `std::ops::Range<T>` is not an iterator
  --> missing-bound.rs:2:14
   |
 2 |     for _ in t {}
-  |              ^ the nightly-only, unstable trait `Step` is not implemented for `T`
+  |              ^ not an iterator
   |
   = note: `Range` only implements `Iterator` for select types in the standard library, particularly integers; to see the full list of types, see the documentation for the unstable `Step` trait
   = note: required for `std::ops::Range<T>` to implement `Iterator`

--- a/tests/run-make/missing-unstable-trait-bound/missing-bound.stderr
+++ b/tests/run-make/missing-unstable-trait-bound/missing-bound.stderr
@@ -1,9 +1,10 @@
-error[E0277]: the trait bound `T: Step` is not satisfied
+error[E0277]: `std::ops::Range<T>` is not an iterator
  --> missing-bound.rs:2:14
   |
 2 |     for _ in t {}
-  |              ^ the trait `Step` is not implemented for `T`
+  |              ^ the nightly-only, unstable trait `Step` is not implemented for `T`
   |
+  = note: `Range` only implements `Iterator` for select types in the standard library, particularly integers; to see the full list of types, see the documentation for the unstable `Step` trait
   = note: required for `std::ops::Range<T>` to implement `Iterator`
   = note: required for `std::ops::Range<T>` to implement `IntoIterator`
 

--- a/tests/ui-fulldeps/rustc-dev-remap.only-remap.stderr
+++ b/tests/ui-fulldeps/rustc-dev-remap.only-remap.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `NotAValidResultType: VisitorResult` is not satisf
 LL |     type Result = NotAValidResultType;
    |                   ^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
-help: the trait `VisitorResult` is not implemented for `NotAValidResultType`
+help: the nightly-only, unstable trait `VisitorResult` is not implemented for `NotAValidResultType`
   --> $DIR/rustc-dev-remap.rs:LL:COL
    |
 LL | struct NotAValidResultType;

--- a/tests/ui-fulldeps/rustc-dev-remap.remap-unremap.stderr
+++ b/tests/ui-fulldeps/rustc-dev-remap.remap-unremap.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `NotAValidResultType: VisitorResult` is not satisf
 LL |     type Result = NotAValidResultType;
    |                   ^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
-help: the trait `VisitorResult` is not implemented for `NotAValidResultType`
+help: the nightly-only, unstable trait `VisitorResult` is not implemented for `NotAValidResultType`
   --> $DIR/rustc-dev-remap.rs:LL:COL
    |
 LL | struct NotAValidResultType;

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-doc-comment-field.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-doc-comment-field.stderr
@@ -7,7 +7,7 @@ LL | #[derive(Diagnostic)]
 LL |     arg: NotIntoDiagArg,
    |          ^^^^^^^^^^^^^^ unsatisfied trait bound
    |
-help: the trait `IntoDiagArg` is not implemented for `NotIntoDiagArg`
+help: the nightly-only, unstable trait `IntoDiagArg` is not implemented for `NotIntoDiagArg`
   --> $DIR/diagnostic-derive-doc-comment-field.rs:28:1
    |
 LL | struct NotIntoDiagArg;
@@ -29,7 +29,7 @@ LL | #[derive(Subdiagnostic)]
 LL |     arg: NotIntoDiagArg,
    |          ^^^^^^^^^^^^^^ unsatisfied trait bound
    |
-help: the trait `IntoDiagArg` is not implemented for `NotIntoDiagArg`
+help: the nightly-only, unstable trait `IntoDiagArg` is not implemented for `NotIntoDiagArg`
   --> $DIR/diagnostic-derive-doc-comment-field.rs:28:1
    |
 LL | struct NotIntoDiagArg;

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
@@ -657,7 +657,7 @@ LL | #[derive(Diagnostic)]
 LL |     other: Hello,
    |            ^^^^^ unsatisfied trait bound
    |
-help: the trait `IntoDiagArg` is not implemented for `Hello`
+help: the nightly-only, unstable trait `IntoDiagArg` is not implemented for `Hello`
   --> $DIR/diagnostic-derive.rs:40:1
    |
 LL | struct Hello {}

--- a/tests/ui/abi/issues/issue-22565-rust-call.stderr
+++ b/tests/ui/abi/issues/issue-22565-rust-call.stderr
@@ -2,7 +2,7 @@ error[E0277]: functions with the "rust-call" ABI must take a single non-self tup
   --> $DIR/issue-22565-rust-call.rs:3:1
    |
 LL | extern "rust-call" fn b(_i: i32) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Tuple` is not implemented for `i32`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the nightly-only, unstable trait `std::marker::Tuple` is not implemented for `i32`
 
 error: functions with the "rust-call" ABI must take a single non-self tuple argument
   --> $DIR/issue-22565-rust-call.rs:17:5
@@ -32,7 +32,7 @@ error[E0277]: functions with the "rust-call" ABI must take a single non-self tup
   --> $DIR/issue-22565-rust-call.rs:27:7
    |
 LL |     b(10);
-   |       ^^ the trait `std::marker::Tuple` is not implemented for `i32`
+   |       ^^ the nightly-only, unstable trait `std::marker::Tuple` is not implemented for `i32`
 
 error: functions with the "rust-call" ABI must take a single non-self tuple argument
   --> $DIR/issue-22565-rust-call.rs:29:5

--- a/tests/ui/async-await/coroutine-not-future.stderr
+++ b/tests/ui/async-await/coroutine-not-future.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `impl Future<Output = ()>: Coroutine<_>` is not sa
   --> $DIR/coroutine-not-future.rs:36:21
    |
 LL |     takes_coroutine(async_fn());
-   |     --------------- ^^^^^^^^^^ the trait `Coroutine<_>` is not implemented for `impl Future<Output = ()>`
+   |     --------------- ^^^^^^^^^^ the nightly-only, unstable trait `Coroutine<_>` is not implemented for `impl Future<Output = ()>`
    |     |
    |     required by a bound introduced by this call
    |
@@ -16,7 +16,7 @@ error[E0277]: the trait bound `impl Future<Output = ()>: Coroutine<_>` is not sa
   --> $DIR/coroutine-not-future.rs:38:21
    |
 LL |     takes_coroutine(returns_async_block());
-   |     --------------- ^^^^^^^^^^^^^^^^^^^^^ the trait `Coroutine<_>` is not implemented for `impl Future<Output = ()>`
+   |     --------------- ^^^^^^^^^^^^^^^^^^^^^ the nightly-only, unstable trait `Coroutine<_>` is not implemented for `impl Future<Output = ()>`
    |     |
    |     required by a bound introduced by this call
    |
@@ -30,7 +30,7 @@ error[E0277]: the trait bound `{async block@$DIR/coroutine-not-future.rs:40:21: 
   --> $DIR/coroutine-not-future.rs:40:21
    |
 LL |     takes_coroutine(async {});
-   |     --------------- ^^^^^^^^ the trait `Coroutine<_>` is not implemented for `{async block@$DIR/coroutine-not-future.rs:40:21: 40:26}`
+   |     --------------- ^^^^^^^^ the nightly-only, unstable trait `Coroutine<_>` is not implemented for `{async block@$DIR/coroutine-not-future.rs:40:21: 40:26}`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/async-await/issue-61076.rs
+++ b/tests/ui/async-await/issue-61076.rs
@@ -4,7 +4,7 @@ use core::future::Future;
 use core::pin::Pin;
 use core::task::{Context, Poll};
 
-struct T; //~ HELP the trait `Try` is not implemented for `T`
+struct T; //~ HELP the nightly-only, unstable trait `Try` is not implemented for `T`
 
 struct Tuple(i32);
 
@@ -41,7 +41,7 @@ async fn foo() -> Result<(), ()> {
 async fn bar() -> Result<(), ()> {
     foo()?; //~ ERROR the `?` operator can only be applied to values that implement `Try`
     //~^ NOTE the `?` operator cannot be applied to type `impl Future<Output = Result<(), ()>>`
-    //~| HELP the trait `Try` is not implemented for `impl Future<Output = Result<(), ()>>`
+    //~| HELP the nightly-only, unstable trait `Try` is not implemented for `impl Future<Output = Result<(), ()>>`
     //~| HELP consider `await`ing on the `Future`
     //~| NOTE in this expansion of desugaring of operator `?`
     //~| NOTE in this expansion of desugaring of operator `?`

--- a/tests/ui/async-await/issue-61076.stderr
+++ b/tests/ui/async-await/issue-61076.stderr
@@ -4,7 +4,7 @@ error[E0277]: the `?` operator can only be applied to values that implement `Try
 LL |     foo()?;
    |     ^^^^^^ the `?` operator cannot be applied to type `impl Future<Output = Result<(), ()>>`
    |
-   = help: the trait `Try` is not implemented for `impl Future<Output = Result<(), ()>>`
+   = help: the nightly-only, unstable trait `Try` is not implemented for `impl Future<Output = Result<(), ()>>`
 help: consider `await`ing on the `Future`
    |
 LL |     foo().await?;
@@ -16,7 +16,7 @@ error[E0277]: the `?` operator can only be applied to values that implement `Try
 LL |     t?;
    |     ^^ the `?` operator cannot be applied to type `T`
    |
-help: the trait `Try` is not implemented for `T`
+help: the nightly-only, unstable trait `Try` is not implemented for `T`
   --> $DIR/issue-61076.rs:7:1
    |
 LL | struct T;

--- a/tests/ui/async-await/issue-84841.stderr
+++ b/tests/ui/async-await/issue-84841.stderr
@@ -4,7 +4,7 @@ error[E0277]: the `?` operator can only be applied to values that implement `Try
 LL |     test()?;
    |     ^^^^^^^ the `?` operator cannot be applied to type `impl Future<Output = ()>`
    |
-   = help: the trait `Try` is not implemented for `impl Future<Output = ()>`
+   = help: the nightly-only, unstable trait `Try` is not implemented for `impl Future<Output = ()>`
 
 error[E0277]: the `?` operator can only be used in an async function that returns `Result` or `Option` (or another type that implements `FromResidual`)
   --> $DIR/issue-84841.rs:9:11

--- a/tests/ui/async-await/try-in-sync.stderr
+++ b/tests/ui/async-await/try-in-sync.stderr
@@ -4,7 +4,7 @@ error[E0277]: the `?` operator can only be applied to values that implement `Try
 LL |     foo()?;
    |     ^^^^^^ the `?` operator cannot be applied to type `impl Future<Output = Result<(), ()>>`
    |
-   = help: the trait `Try` is not implemented for `impl Future<Output = Result<(), ()>>`
+   = help: the nightly-only, unstable trait `Try` is not implemented for `impl Future<Output = Result<(), ()>>`
 note: this implements `Future` and its output type supports `?`, but the future cannot be awaited in a synchronous function
   --> $DIR/try-in-sync.rs:6:10
    |

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_bad.stderr
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_bad.stderr
@@ -2,7 +2,7 @@ error[E0277]: `fn() {main}` can't be used as a const parameter type
   --> $DIR/const_param_ty_bad.rs:7:11
    |
 LL |     check(main);
-   |     ----- ^^^^ the trait `ConstParamTy_` is not implemented for fn item `fn() {main}`
+   |     ----- ^^^^ the nightly-only, unstable trait `ConstParamTy_` is not implemented for fn item `fn() {main}`
    |     |
    |     required by a bound introduced by this call
    |
@@ -24,7 +24,7 @@ LL |     check(|| {});
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `ConstParamTy_` is not implemented for closure `{closure@$DIR/const_param_ty_bad.rs:8:11: 8:13}`
+   = help: the nightly-only, unstable trait `ConstParamTy_` is not implemented for closure `{closure@$DIR/const_param_ty_bad.rs:8:11: 8:13}`
 note: required by a bound in `check`
   --> $DIR/const_param_ty_bad.rs:4:18
    |
@@ -40,7 +40,7 @@ error[E0277]: `fn()` can't be used as a const parameter type
   --> $DIR/const_param_ty_bad.rs:9:11
    |
 LL |     check(main as fn());
-   |     ----- ^^^^^^^^^^^^ the trait `ConstParamTy_` is not implemented for `fn()`
+   |     ----- ^^^^^^^^^^^^ the nightly-only, unstable trait `ConstParamTy_` is not implemented for `fn()`
    |     |
    |     required by a bound introduced by this call
    |
@@ -58,7 +58,7 @@ error[E0277]: `&mut ()` can't be used as a const parameter type
   --> $DIR/const_param_ty_bad.rs:10:11
    |
 LL |     check(&mut ());
-   |     ----- ^^^^^^^ the trait `ConstParamTy_` is not implemented for `&mut ()`
+   |     ----- ^^^^^^^ the nightly-only, unstable trait `ConstParamTy_` is not implemented for `&mut ()`
    |     |
    |     required by a bound introduced by this call
    |
@@ -78,7 +78,7 @@ error[E0277]: `*mut ()` can't be used as a const parameter type
   --> $DIR/const_param_ty_bad.rs:11:11
    |
 LL |     check(&mut () as *mut ());
-   |     ----- ^^^^^^^^^^^^^^^^^^ the trait `ConstParamTy_` is not implemented for `*mut ()`
+   |     ----- ^^^^^^^^^^^^^^^^^^ the nightly-only, unstable trait `ConstParamTy_` is not implemented for `*mut ()`
    |     |
    |     required by a bound introduced by this call
    |
@@ -98,7 +98,7 @@ error[E0277]: `*const ()` can't be used as a const parameter type
   --> $DIR/const_param_ty_bad.rs:12:11
    |
 LL |     check(&() as *const ());
-   |     ----- ^^^^^^^^^^^^^^^^ the trait `ConstParamTy_` is not implemented for `*const ()`
+   |     ----- ^^^^^^^^^^^^^^^^ the nightly-only, unstable trait `ConstParamTy_` is not implemented for `*const ()`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_bad_empty_array.stderr
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_bad_empty_array.stderr
@@ -4,7 +4,7 @@ error[E0277]: `NotParam` can't be used as a const parameter type
 LL |     check::<[NotParam; 0]>();
    |             ^^^^^^^^^^^^^ unsatisfied trait bound
    |
-help: the trait `ConstParamTy_` is not implemented for `NotParam`
+help: the nightly-only, unstable trait `ConstParamTy_` is not implemented for `NotParam`
   --> $DIR/const_param_ty_bad_empty_array.rs:5:1
    |
 LL | struct NotParam;

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_generic_bounds_do_not_hold.stderr
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_generic_bounds_do_not_hold.stderr
@@ -4,7 +4,7 @@ error[E0277]: `NotParam` can't be used as a const parameter type
 LL |     check::<&NotParam>();
    |             ^^^^^^^^^ unsatisfied trait bound
    |
-help: the trait `ConstParamTy_` is not implemented for `NotParam`
+help: the nightly-only, unstable trait `ConstParamTy_` is not implemented for `NotParam`
   --> $DIR/const_param_ty_generic_bounds_do_not_hold.rs:5:1
    |
 LL | struct NotParam;
@@ -22,7 +22,7 @@ error[E0277]: `NotParam` can't be used as a const parameter type
 LL |     check::<[NotParam]>();
    |             ^^^^^^^^^^ unsatisfied trait bound
    |
-help: the trait `ConstParamTy_` is not implemented for `NotParam`
+help: the nightly-only, unstable trait `ConstParamTy_` is not implemented for `NotParam`
   --> $DIR/const_param_ty_generic_bounds_do_not_hold.rs:5:1
    |
 LL | struct NotParam;
@@ -40,7 +40,7 @@ error[E0277]: `NotParam` can't be used as a const parameter type
 LL |     check::<[NotParam; 17]>();
    |             ^^^^^^^^^^^^^^ unsatisfied trait bound
    |
-help: the trait `ConstParamTy_` is not implemented for `NotParam`
+help: the nightly-only, unstable trait `ConstParamTy_` is not implemented for `NotParam`
   --> $DIR/const_param_ty_generic_bounds_do_not_hold.rs:5:1
    |
 LL | struct NotParam;

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_impl_no_structural_eq.stderr
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_impl_no_structural_eq.stderr
@@ -18,7 +18,7 @@ error[E0277]: the type `CantParam` does not `#[derive(PartialEq)]`
 LL | impl std::marker::ConstParamTy_ for CantParam {}
    |                                     ^^^^^^^^^ unsatisfied trait bound
    |
-help: the trait `StructuralPartialEq` is not implemented for `CantParam`
+help: the nightly-only, unstable trait `StructuralPartialEq` is not implemented for `CantParam`
   --> $DIR/const_param_ty_impl_no_structural_eq.rs:8:1
    |
 LL | struct CantParam(ImplementsConstParamTy);
@@ -46,7 +46,7 @@ error[E0277]: the type `CantParamDerive` does not `#[derive(PartialEq)]`
 LL | #[derive(std::marker::ConstParamTy)]
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
-help: the trait `StructuralPartialEq` is not implemented for `CantParamDerive`
+help: the nightly-only, unstable trait `StructuralPartialEq` is not implemented for `CantParamDerive`
   --> $DIR/const_param_ty_impl_no_structural_eq.rs:17:1
    |
 LL | struct CantParamDerive(ImplementsConstParamTy);

--- a/tests/ui/coroutine/gen_block_is_coro.stderr
+++ b/tests/ui/coroutine/gen_block_is_coro.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `{gen block@$DIR/gen_block_is_coro.rs:8:5: 8:8}: C
   --> $DIR/gen_block_is_coro.rs:7:13
    |
 LL | fn foo() -> impl Coroutine<Yield = u32, Return = ()> {
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Coroutine` is not implemented for `{gen block@$DIR/gen_block_is_coro.rs:8:5: 8:8}`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the nightly-only, unstable trait `Coroutine` is not implemented for `{gen block@$DIR/gen_block_is_coro.rs:8:5: 8:8}`
 LL |     gen { yield 42 }
    |     ---------------- return type was inferred to be `{gen block@$DIR/gen_block_is_coro.rs:8:5: 8:8}` here
 
@@ -10,7 +10,7 @@ error[E0277]: the trait bound `{gen block@$DIR/gen_block_is_coro.rs:12:5: 12:8}:
   --> $DIR/gen_block_is_coro.rs:11:13
    |
 LL | fn bar() -> impl Coroutine<Yield = i64, Return = ()> {
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Coroutine` is not implemented for `{gen block@$DIR/gen_block_is_coro.rs:12:5: 12:8}`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the nightly-only, unstable trait `Coroutine` is not implemented for `{gen block@$DIR/gen_block_is_coro.rs:12:5: 12:8}`
 LL |     gen { yield 42 }
    |     ---------------- return type was inferred to be `{gen block@$DIR/gen_block_is_coro.rs:12:5: 12:8}` here
 
@@ -18,7 +18,7 @@ error[E0277]: the trait bound `{gen block@$DIR/gen_block_is_coro.rs:16:5: 16:8}:
   --> $DIR/gen_block_is_coro.rs:15:13
    |
 LL | fn baz() -> impl Coroutine<Yield = i32, Return = ()> {
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Coroutine` is not implemented for `{gen block@$DIR/gen_block_is_coro.rs:16:5: 16:8}`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the nightly-only, unstable trait `Coroutine` is not implemented for `{gen block@$DIR/gen_block_is_coro.rs:16:5: 16:8}`
 LL |     gen { yield 42 }
    |     ---------------- return type was inferred to be `{gen block@$DIR/gen_block_is_coro.rs:16:5: 16:8}` here
 

--- a/tests/ui/error-codes/E0059.stderr
+++ b/tests/ui/error-codes/E0059.stderr
@@ -2,7 +2,7 @@ error[E0059]: type parameter to bare `Fn` trait must be a tuple
   --> $DIR/E0059.rs:3:11
    |
 LL | fn foo<F: Fn<i32>>(f: F) -> F::Output { f(3) }
-   |           ^^^^^^^ the trait `std::marker::Tuple` is not implemented for `i32`
+   |           ^^^^^^^ the nightly-only, unstable trait `std::marker::Tuple` is not implemented for `i32`
    |
 note: required by a bound in `Fn`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
@@ -11,7 +11,7 @@ error[E0277]: `i32` is not a tuple
   --> $DIR/E0059.rs:3:41
    |
 LL | fn foo<F: Fn<i32>>(f: F) -> F::Output { f(3) }
-   |                                         ^^^^ the trait `std::marker::Tuple` is not implemented for `i32`
+   |                                         ^^^^ the nightly-only, unstable trait `std::marker::Tuple` is not implemented for `i32`
 
 error[E0059]: cannot use call notation; the first type parameter for the function trait is neither a tuple nor unit
   --> $DIR/E0059.rs:3:41

--- a/tests/ui/extern/extern-types-unsized.stderr
+++ b/tests/ui/extern/extern-types-unsized.stderr
@@ -65,7 +65,7 @@ error[E0277]: the size for values of type `A` cannot be known
 LL |     assert_sized::<Bar<A>>();
    |                    ^^^^^^ doesn't have a known size
    |
-   = help: the trait `MetaSized` is not implemented for `A`
+   = help: the nightly-only, unstable trait `MetaSized` is not implemented for `A`
 note: required by a bound in `Bar`
   --> $DIR/extern-types-unsized.rs:14:12
    |
@@ -100,7 +100,7 @@ error[E0277]: the size for values of type `A` cannot be known
 LL |     assert_sized::<Bar<Bar<A>>>();
    |                    ^^^^^^^^^^^ doesn't have a known size
    |
-   = help: the trait `MetaSized` is not implemented for `A`
+   = help: the nightly-only, unstable trait `MetaSized` is not implemented for `A`
 note: required by a bound in `Bar`
   --> $DIR/extern-types-unsized.rs:14:12
    |

--- a/tests/ui/extern/unsized-extern-derefmove.stderr
+++ b/tests/ui/extern/unsized-extern-derefmove.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `Device` cannot be known
 LL | unsafe fn make_device() -> Box<Device> {
    |                            ^^^^^^^^^^^ doesn't have a known size
    |
-   = help: the trait `MetaSized` is not implemented for `Device`
+   = help: the nightly-only, unstable trait `MetaSized` is not implemented for `Device`
 note: required by a bound in `Box`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
 
@@ -32,7 +32,7 @@ error[E0277]: the size for values of type `Device` cannot be known
 LL |     Box::from_raw(0 as *mut _)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a known size
    |
-   = help: the trait `MetaSized` is not implemented for `Device`
+   = help: the nightly-only, unstable trait `MetaSized` is not implemented for `Device`
 note: required by a bound in `Box`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
 
@@ -55,7 +55,7 @@ error[E0277]: the size for values of type `Device` cannot be known
 LL |     let d: Device = unsafe { *make_device() };
    |                               ^^^^^^^^^^^^^ doesn't have a known size
    |
-   = help: the trait `MetaSized` is not implemented for `Device`
+   = help: the nightly-only, unstable trait `MetaSized` is not implemented for `Device`
 note: required by a bound in `Box`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
 

--- a/tests/ui/feature-gates/feature-gate-sized-hierarchy.stderr
+++ b/tests/ui/feature-gates/feature-gate-sized-hierarchy.stderr
@@ -17,7 +17,7 @@ error[E0277]: the size for values of type `main::Foo` cannot be known
 LL |     needs_metasized::<Foo>();
    |                       ^^^ doesn't have a known size
    |
-   = help: the trait `MetaSized` is not implemented for `main::Foo`
+   = help: the nightly-only, unstable trait `MetaSized` is not implemented for `main::Foo`
 note: required by a bound in `needs_metasized`
   --> $DIR/feature-gate-sized-hierarchy.rs:7:23
    |

--- a/tests/ui/layout/rust-call-abi-not-a-tuple-ice-81974.stderr
+++ b/tests/ui/layout/rust-call-abi-not-a-tuple-ice-81974.stderr
@@ -2,7 +2,7 @@ error[E0059]: type parameter to bare `FnOnce` trait must be a tuple
   --> $DIR/rust-call-abi-not-a-tuple-ice-81974.rs:31:5
    |
 LL |     extern "rust-call" fn call_once(mut self, a: A) -> Self::Output {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Tuple` is not implemented for `A`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the nightly-only, unstable trait `std::marker::Tuple` is not implemented for `A`
    |
 note: required by a bound in `FnOnce`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
@@ -15,7 +15,7 @@ error[E0059]: type parameter to bare `FnOnce` trait must be a tuple
   --> $DIR/rust-call-abi-not-a-tuple-ice-81974.rs:24:12
    |
 LL | impl<A, B> FnOnce<A> for CachedFun<A, B>
-   |            ^^^^^^^^^ the trait `std::marker::Tuple` is not implemented for `A`
+   |            ^^^^^^^^^ the nightly-only, unstable trait `std::marker::Tuple` is not implemented for `A`
    |
 note: required by a bound in `FnOnce`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
@@ -28,7 +28,7 @@ error[E0059]: type parameter to bare `FnOnce` trait must be a tuple
   --> $DIR/rust-call-abi-not-a-tuple-ice-81974.rs:45:5
    |
 LL |     extern "rust-call" fn call_mut(&mut self, a: A) -> Self::Output {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Tuple` is not implemented for `A`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the nightly-only, unstable trait `std::marker::Tuple` is not implemented for `A`
    |
 note: required by a bound in `FnOnce`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
@@ -41,7 +41,7 @@ error[E0059]: type parameter to bare `FnMut` trait must be a tuple
   --> $DIR/rust-call-abi-not-a-tuple-ice-81974.rs:39:12
    |
 LL | impl<A, B> FnMut<A> for CachedFun<A, B>
-   |            ^^^^^^^^ the trait `std::marker::Tuple` is not implemented for `A`
+   |            ^^^^^^^^ the nightly-only, unstable trait `std::marker::Tuple` is not implemented for `A`
    |
 note: required by a bound in `FnMut`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
@@ -54,7 +54,7 @@ error[E0277]: functions with the "rust-call" ABI must take a single non-self tup
   --> $DIR/rust-call-abi-not-a-tuple-ice-81974.rs:31:5
    |
 LL |     extern "rust-call" fn call_once(mut self, a: A) -> Self::Output {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Tuple` is not implemented for `A`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the nightly-only, unstable trait `std::marker::Tuple` is not implemented for `A`
    |
 help: consider further restricting type parameter `A` with unstable trait `Tuple`
    |
@@ -65,7 +65,7 @@ error[E0277]: functions with the "rust-call" ABI must take a single non-self tup
   --> $DIR/rust-call-abi-not-a-tuple-ice-81974.rs:45:5
    |
 LL |     extern "rust-call" fn call_mut(&mut self, a: A) -> Self::Output {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Tuple` is not implemented for `A`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the nightly-only, unstable trait `std::marker::Tuple` is not implemented for `A`
    |
 help: consider further restricting type parameter `A` with unstable trait `Tuple`
    |
@@ -76,7 +76,7 @@ error[E0277]: `A` is not a tuple
   --> $DIR/rust-call-abi-not-a-tuple-ice-81974.rs:34:19
    |
 LL |     self.call_mut(a)
-   |          -------- ^ the trait `std::marker::Tuple` is not implemented for `A`
+   |          -------- ^ the nightly-only, unstable trait `std::marker::Tuple` is not implemented for `A`
    |          |
    |          required by a bound introduced by this call
    |
@@ -91,7 +91,7 @@ error[E0277]: `i32` is not a tuple
   --> $DIR/rust-call-abi-not-a-tuple-ice-81974.rs:59:26
    |
 LL |     cachedcoso.call_once(1);
-   |                --------- ^ the trait `std::marker::Tuple` is not implemented for `i32`
+   |                --------- ^ the nightly-only, unstable trait `std::marker::Tuple` is not implemented for `i32`
    |                |
    |                required by a bound introduced by this call
    |

--- a/tests/ui/mir/validate/validate-unsize-cast.stderr
+++ b/tests/ui/mir/validate/validate-unsize-cast.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: Unsize<U>` is not satisfied
   --> $DIR/validate-unsize-cast.rs:10:42
    |
 LL | impl<T: ?Sized, U: ?Sized> CastTo<U> for T {}
-   |                                          ^ the trait `Unsize<U>` is not implemented for `T`
+   |                                          ^ the nightly-only, unstable trait `Unsize<U>` is not implemented for `T`
    |
    = note: all implementations of `Unsize` are provided automatically by the compiler, see <https://doc.rust-lang.org/stable/std/marker/trait.Unsize.html> for more information
 note: required by a bound in `CastTo`

--- a/tests/ui/overloaded/overloaded-calls-nontuple.stderr
+++ b/tests/ui/overloaded/overloaded-calls-nontuple.stderr
@@ -2,7 +2,7 @@ error[E0059]: type parameter to bare `FnMut` trait must be a tuple
   --> $DIR/overloaded-calls-nontuple.rs:10:6
    |
 LL | impl FnMut<isize> for S {
-   |      ^^^^^^^^^^^^ the trait `std::marker::Tuple` is not implemented for `isize`
+   |      ^^^^^^^^^^^^ the nightly-only, unstable trait `std::marker::Tuple` is not implemented for `isize`
    |
 note: required by a bound in `FnMut`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
@@ -11,7 +11,7 @@ error[E0059]: type parameter to bare `FnOnce` trait must be a tuple
   --> $DIR/overloaded-calls-nontuple.rs:18:6
    |
 LL | impl FnOnce<isize> for S {
-   |      ^^^^^^^^^^^^^ the trait `std::marker::Tuple` is not implemented for `isize`
+   |      ^^^^^^^^^^^^^ the nightly-only, unstable trait `std::marker::Tuple` is not implemented for `isize`
    |
 note: required by a bound in `FnOnce`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
@@ -20,19 +20,19 @@ error[E0277]: functions with the "rust-call" ABI must take a single non-self tup
   --> $DIR/overloaded-calls-nontuple.rs:12:5
    |
 LL |     extern "rust-call" fn call_mut(&mut self, z: isize) -> isize {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Tuple` is not implemented for `isize`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the nightly-only, unstable trait `std::marker::Tuple` is not implemented for `isize`
 
 error[E0277]: functions with the "rust-call" ABI must take a single non-self tuple argument
   --> $DIR/overloaded-calls-nontuple.rs:21:5
    |
 LL |     extern "rust-call" fn call_once(mut self, z: isize) -> isize {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Tuple` is not implemented for `isize`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the nightly-only, unstable trait `std::marker::Tuple` is not implemented for `isize`
 
 error[E0277]: `isize` is not a tuple
   --> $DIR/overloaded-calls-nontuple.rs:23:23
    |
 LL |         self.call_mut(z)
-   |              -------- ^ the trait `std::marker::Tuple` is not implemented for `isize`
+   |              -------- ^ the nightly-only, unstable trait `std::marker::Tuple` is not implemented for `isize`
    |              |
    |              required by a bound introduced by this call
    |
@@ -53,7 +53,7 @@ error[E0277]: `isize` is not a tuple
   --> $DIR/overloaded-calls-nontuple.rs:29:10
    |
 LL |     drop(s(3))
-   |          ^^^^ the trait `std::marker::Tuple` is not implemented for `isize`
+   |          ^^^^ the nightly-only, unstable trait `std::marker::Tuple` is not implemented for `isize`
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/pattern/deref-patterns/recursion-limit.stderr
+++ b/tests/ui/pattern/deref-patterns/recursion-limit.stderr
@@ -12,7 +12,7 @@ error[E0277]: the trait bound `Cyclic: DerefPure` is not satisfied
 LL |         () => {}
    |         ^^ unsatisfied trait bound
    |
-help: the trait `DerefPure` is not implemented for `Cyclic`
+help: the nightly-only, unstable trait `DerefPure` is not implemented for `Cyclic`
   --> $DIR/recursion-limit.rs:8:1
    |
 LL | struct Cyclic;

--- a/tests/ui/pattern/deref-patterns/unsatisfied-bounds.stderr
+++ b/tests/ui/pattern/deref-patterns/unsatisfied-bounds.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `MyPointer: DerefPure` is not satisfied
 LL |         () => {}
    |         ^^ unsatisfied trait bound
    |
-help: the trait `DerefPure` is not implemented for `MyPointer`
+help: the nightly-only, unstable trait `DerefPure` is not implemented for `MyPointer`
   --> $DIR/unsatisfied-bounds.rs:4:1
    |
 LL | struct MyPointer;

--- a/tests/ui/proc-macro/quote/not-quotable.stderr
+++ b/tests/ui/proc-macro/quote/not-quotable.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `Ipv4Addr: ToTokens` is not satisfied
 LL |     let _ = quote! { $ip };
    |             ^^^^^^^^^^^^^^
    |             |
-   |             the trait `ToTokens` is not implemented for `Ipv4Addr`
+   |             the nightly-only, unstable trait `ToTokens` is not implemented for `Ipv4Addr`
    |             required by a bound introduced by this call
    |
    = help: the following other types implement trait `ToTokens`:

--- a/tests/ui/range/range-1.rs
+++ b/tests/ui/range/range-1.rs
@@ -7,7 +7,7 @@ pub fn main() {
 
     // Bool => does not implement iterator.
     for i in false..true {}
-    //~^ ERROR `bool: Step` is not satisfied
+    //~^ ERROR `std::ops::Range<bool>` is not an iterator
 
     // Unsized type.
     let arr: &[_] = &[1, 2, 3];

--- a/tests/ui/range/range-1.stderr
+++ b/tests/ui/range/range-1.stderr
@@ -8,7 +8,7 @@ error[E0277]: `std::ops::Range<bool>` is not an iterator
   --> $DIR/range-1.rs:9:14
    |
 LL |     for i in false..true {}
-   |              ^^^^^^^^^^^ not an iterator
+   |              ^^^^^^^^^^^ `Range<bool>` is not an iterator
    |
    = help: the nightly-only, unstable trait `Step` is not implemented for `bool`
    = note: `Range` only implements `Iterator` for select types in the standard library, particularly integers; to see the full list of types, see the documentation for the unstable `Step` trait

--- a/tests/ui/range/range-1.stderr
+++ b/tests/ui/range/range-1.stderr
@@ -8,7 +8,7 @@ error[E0277]: the trait bound `bool: Step` is not satisfied
   --> $DIR/range-1.rs:9:14
    |
 LL |     for i in false..true {}
-   |              ^^^^^^^^^^^ the trait `Step` is not implemented for `bool`
+   |              ^^^^^^^^^^^ the nightly-only, unstable trait `Step` is not implemented for `bool`
    |
    = note: required for `std::ops::Range<bool>` to implement `Iterator`
    = note: required for `std::ops::Range<bool>` to implement `IntoIterator`

--- a/tests/ui/range/range-1.stderr
+++ b/tests/ui/range/range-1.stderr
@@ -10,6 +10,7 @@ error[E0277]: the trait bound `bool: Step` is not satisfied
 LL |     for i in false..true {}
    |              ^^^^^^^^^^^ the nightly-only, unstable trait `Step` is not implemented for `bool`
    |
+   = note: `Range` only implements `Iterator` for select types in the standard library, particularly integers; to see the full list of types, see the documentation for the unstable `Step` trait
    = note: required for `std::ops::Range<bool>` to implement `Iterator`
    = note: required for `std::ops::Range<bool>` to implement `IntoIterator`
 

--- a/tests/ui/range/range-1.stderr
+++ b/tests/ui/range/range-1.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL |     let _ = 0u32..10i32;
    |                   ^^^^^ expected `u32`, found `i32`
 
-error[E0277]: the trait bound `bool: Step` is not satisfied
+error[E0277]: `std::ops::Range<bool>` is not an iterator
   --> $DIR/range-1.rs:9:14
    |
 LL |     for i in false..true {}

--- a/tests/ui/range/range-1.stderr
+++ b/tests/ui/range/range-1.stderr
@@ -8,8 +8,9 @@ error[E0277]: `std::ops::Range<bool>` is not an iterator
   --> $DIR/range-1.rs:9:14
    |
 LL |     for i in false..true {}
-   |              ^^^^^^^^^^^ the nightly-only, unstable trait `Step` is not implemented for `bool`
+   |              ^^^^^^^^^^^ not an iterator
    |
+   = help: the nightly-only, unstable trait `Step` is not implemented for `bool`
    = note: `Range` only implements `Iterator` for select types in the standard library, particularly integers; to see the full list of types, see the documentation for the unstable `Step` trait
    = note: required for `std::ops::Range<bool>` to implement `Iterator`
    = note: required for `std::ops::Range<bool>` to implement `IntoIterator`

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/disallowed-positions.e2021.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/disallowed-positions.e2021.stderr
@@ -1137,7 +1137,7 @@ error[E0277]: the `?` operator can only be applied to values that implement `Try
 LL |         if let 0 = 0? {}
    |                    ^^ the `?` operator cannot be applied to type `{integer}`
    |
-   = help: the trait `Try` is not implemented for `{integer}`
+   = help: the nightly-only, unstable trait `Try` is not implemented for `{integer}`
 
 error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:224:11
@@ -1198,7 +1198,7 @@ error[E0277]: the `?` operator can only be applied to values that implement `Try
 LL |         while let 0 = 0? {}
    |                       ^^ the `?` operator cannot be applied to type `{integer}`
    |
-   = help: the trait `Try` is not implemented for `{integer}`
+   = help: the nightly-only, unstable trait `Try` is not implemented for `{integer}`
 
 error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:333:10
@@ -1217,7 +1217,7 @@ error[E0277]: the `?` operator can only be applied to values that implement `Try
 LL |         let 0 = 0?;
    |                 ^^ the `?` operator cannot be applied to type `{integer}`
    |
-   = help: the trait `Try` is not implemented for `{integer}`
+   = help: the nightly-only, unstable trait `Try` is not implemented for `{integer}`
 
 error: aborting due to 134 previous errors
 

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/disallowed-positions.e2024.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/disallowed-positions.e2024.stderr
@@ -1083,7 +1083,7 @@ error[E0277]: the `?` operator can only be applied to values that implement `Try
 LL |         if let 0 = 0? {}
    |                    ^^ the `?` operator cannot be applied to type `{integer}`
    |
-   = help: the trait `Try` is not implemented for `{integer}`
+   = help: the nightly-only, unstable trait `Try` is not implemented for `{integer}`
 
 error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:224:11
@@ -1144,7 +1144,7 @@ error[E0277]: the `?` operator can only be applied to values that implement `Try
 LL |         while let 0 = 0? {}
    |                       ^^ the `?` operator cannot be applied to type `{integer}`
    |
-   = help: the trait `Try` is not implemented for `{integer}`
+   = help: the nightly-only, unstable trait `Try` is not implemented for `{integer}`
 
 error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:333:10
@@ -1163,7 +1163,7 @@ error[E0277]: the `?` operator can only be applied to values that implement `Try
 LL |         let 0 = 0?;
    |                 ^^ the `?` operator cannot be applied to type `{integer}`
    |
-   = help: the trait `Try` is not implemented for `{integer}`
+   = help: the nightly-only, unstable trait `Try` is not implemented for `{integer}`
 
 error: aborting due to 125 previous errors
 

--- a/tests/ui/sized-hierarchy/default-bound.stderr
+++ b/tests/ui/sized-hierarchy/default-bound.stderr
@@ -76,7 +76,7 @@ error[E0277]: the size for values of type `main::Foo` cannot be known
 LL |     metasized::<Foo>();
    |                 ^^^ doesn't have a known size
    |
-   = help: the trait `MetaSized` is not implemented for `main::Foo`
+   = help: the nightly-only, unstable trait `MetaSized` is not implemented for `main::Foo`
 note: required by a bound in `metasized`
   --> $DIR/default-bound.rs:14:17
    |

--- a/tests/ui/sized-hierarchy/impls.stderr
+++ b/tests/ui/sized-hierarchy/impls.stderr
@@ -164,7 +164,7 @@ error[E0277]: the size for values of type `main::Foo` cannot be known
 LL |     needs_metasized::<Foo>();
    |                       ^^^ doesn't have a known size
    |
-   = help: the trait `MetaSized` is not implemented for `main::Foo`
+   = help: the nightly-only, unstable trait `MetaSized` is not implemented for `main::Foo`
 note: required by a bound in `needs_metasized`
   --> $DIR/impls.rs:16:23
    |
@@ -222,7 +222,7 @@ error[E0277]: the size for values of type `main::Foo` cannot be known
 LL |     needs_metasized::<(Foo, Foo)>();
    |                       ^^^^^^^^^^ doesn't have a known size
    |
-   = help: within `(main::Foo, main::Foo)`, the trait `MetaSized` is not implemented for `main::Foo`
+   = help: within `(main::Foo, main::Foo)`, the nightly-only, unstable trait `MetaSized` is not implemented for `main::Foo`
    = note: required because it appears within the type `(main::Foo, main::Foo)`
 note: required by a bound in `needs_metasized`
   --> $DIR/impls.rs:16:23
@@ -273,7 +273,7 @@ error[E0277]: the size for values of type `main::Foo` cannot be known
 LL |     needs_metasized::<(u32, Foo)>();
    |                       ^^^^^^^^^^ doesn't have a known size
    |
-   = help: within `(u32, main::Foo)`, the trait `MetaSized` is not implemented for `main::Foo`
+   = help: within `(u32, main::Foo)`, the nightly-only, unstable trait `MetaSized` is not implemented for `main::Foo`
    = note: required because it appears within the type `(u32, main::Foo)`
 note: required by a bound in `needs_metasized`
   --> $DIR/impls.rs:16:23
@@ -323,7 +323,7 @@ error[E0277]: the size for values of type `main::Foo` cannot be known
 LL |     needs_metasized::<StructAllFieldsUnsized>();
    |                       ^^^^^^^^^^^^^^^^^^^^^^ doesn't have a known size
    |
-   = help: within `StructAllFieldsUnsized`, the trait `MetaSized` is not implemented for `main::Foo`
+   = help: within `StructAllFieldsUnsized`, the nightly-only, unstable trait `MetaSized` is not implemented for `main::Foo`
 note: required because it appears within the type `StructAllFieldsUnsized`
   --> $DIR/impls.rs:243:12
    |
@@ -377,7 +377,7 @@ error[E0277]: the size for values of type `main::Foo` cannot be known
 LL |     needs_metasized::<StructLastFieldUnsized>();
    |                       ^^^^^^^^^^^^^^^^^^^^^^ doesn't have a known size
    |
-   = help: within `StructLastFieldUnsized`, the trait `MetaSized` is not implemented for `main::Foo`
+   = help: within `StructLastFieldUnsized`, the nightly-only, unstable trait `MetaSized` is not implemented for `main::Foo`
 note: required because it appears within the type `StructLastFieldUnsized`
   --> $DIR/impls.rs:259:12
    |

--- a/tests/ui/sized-hierarchy/pretty-print-opaque.stderr
+++ b/tests/ui/sized-hierarchy/pretty-print-opaque.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `impl Tr + PointeeSized` cannot be kno
 LL | pub fn pointeesized() -> Box<impl Tr + PointeeSized> {
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a known size
    |
-   = help: the trait `MetaSized` is not implemented for `impl Tr + PointeeSized`
+   = help: the nightly-only, unstable trait `MetaSized` is not implemented for `impl Tr + PointeeSized`
 note: required by a bound in `Box`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
 
@@ -32,7 +32,7 @@ error[E0277]: the size for values of type `impl Tr + PointeeSized` cannot be kno
 LL |         let x = pointeesized();
    |                 ^^^^^^^^^^^^^^ doesn't have a known size
    |
-   = help: the trait `MetaSized` is not implemented for `impl Tr + PointeeSized`
+   = help: the nightly-only, unstable trait `MetaSized` is not implemented for `impl Tr + PointeeSized`
 note: required by a bound in `Box`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
 
@@ -51,7 +51,7 @@ error[E0277]: the size for values of type `impl Tr + PointeeSized` cannot be kno
 LL |         let y: Box<dyn Tr> = x;
    |                              ^ doesn't have a known size
    |
-   = help: the trait `MetaSized` is not implemented for `impl Tr + PointeeSized`
+   = help: the nightly-only, unstable trait `MetaSized` is not implemented for `impl Tr + PointeeSized`
    = note: required for the cast from `Box<impl Tr + PointeeSized>` to `Box<dyn Tr>`
 
 error: aborting due to 6 previous errors

--- a/tests/ui/specialization/issue-44861.stderr
+++ b/tests/ui/specialization/issue-44861.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `(): CoerceUnsized<*const [u8]>` is not satisfied
   --> $DIR/issue-44861.rs:21:26
    |
 LL |     default type Data2 = ();
-   |                          ^^ the trait `CoerceUnsized<*const [u8]>` is not implemented for `()`
+   |                          ^^ the nightly-only, unstable trait `CoerceUnsized<*const [u8]>` is not implemented for `()`
    |
 note: required by a bound in `Smartass::Data2`
   --> $DIR/issue-44861.rs:12:17

--- a/tests/ui/suggestions/fn-trait-notation.stderr
+++ b/tests/ui/suggestions/fn-trait-notation.stderr
@@ -32,7 +32,7 @@ error[E0059]: type parameter to bare `Fn` trait must be a tuple
   --> $DIR/fn-trait-notation.rs:4:8
    |
 LL |     F: Fn<i32, Output = i32>,
-   |        ^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Tuple` is not implemented for `i32`
+   |        ^^^^^^^^^^^^^^^^^^^^^ the nightly-only, unstable trait `std::marker::Tuple` is not implemented for `i32`
    |
 note: required by a bound in `Fn`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
@@ -47,7 +47,7 @@ error[E0277]: `i32` is not a tuple
   --> $DIR/fn-trait-notation.rs:9:5
    |
 LL |     f(3);
-   |     ^^^^ the trait `std::marker::Tuple` is not implemented for `i32`
+   |     ^^^^ the nightly-only, unstable trait `std::marker::Tuple` is not implemented for `i32`
 
 error[E0308]: mismatched types
   --> $DIR/fn-trait-notation.rs:17:5

--- a/tests/ui/suggestions/issue-72766.stderr
+++ b/tests/ui/suggestions/issue-72766.stderr
@@ -4,7 +4,7 @@ error[E0277]: the `?` operator can only be applied to values that implement `Try
 LL |     SadGirl {}.call()?;
    |     ^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `impl Future<Output = Result<(), ()>>`
    |
-   = help: the trait `Try` is not implemented for `impl Future<Output = Result<(), ()>>`
+   = help: the nightly-only, unstable trait `Try` is not implemented for `impl Future<Output = Result<(), ()>>`
 help: consider `await`ing on the `Future`
    |
 LL |     SadGirl {}.call().await?;

--- a/tests/ui/suggestions/issue-97704.stderr
+++ b/tests/ui/suggestions/issue-97704.stderr
@@ -4,7 +4,7 @@ error[E0277]: the `?` operator can only be applied to values that implement `Try
 LL |     func(async { Ok::<_, i32>(()) })?;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `impl Future<Output = Result<(), i32>>`
    |
-   = help: the trait `Try` is not implemented for `impl Future<Output = Result<(), i32>>`
+   = help: the nightly-only, unstable trait `Try` is not implemented for `impl Future<Output = Result<(), i32>>`
 help: consider `await`ing on the `Future`
    |
 LL |     func(async { Ok::<_, i32>(()) }).await?;

--- a/tests/ui/trait-bounds/unstable-trait-suggestion.stderr
+++ b/tests/ui/trait-bounds/unstable-trait-suggestion.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: Unstable` is not satisfied
   --> $DIR/unstable-trait-suggestion.rs:13:9
    |
 LL |     foo(t)
-   |     --- ^ the trait `Unstable` is not implemented for `T`
+   |     --- ^ the nightly-only, unstable trait `Unstable` is not implemented for `T`
    |     |
    |     required by a bound introduced by this call
    |
@@ -20,7 +20,7 @@ error[E0277]: the trait bound `T: Step` is not satisfied
   --> $DIR/unstable-trait-suggestion.rs:17:14
    |
 LL |     for _ in t {}
-   |              ^ the trait `Step` is not implemented for `T`
+   |              ^ the nightly-only, unstable trait `Step` is not implemented for `T`
    |
    = note: required for `std::ops::Range<T>` to implement `Iterator`
    = note: required for `std::ops::Range<T>` to implement `IntoIterator`

--- a/tests/ui/trait-bounds/unstable-trait-suggestion.stderr
+++ b/tests/ui/trait-bounds/unstable-trait-suggestion.stderr
@@ -22,6 +22,7 @@ error[E0277]: the trait bound `T: Step` is not satisfied
 LL |     for _ in t {}
    |              ^ the nightly-only, unstable trait `Step` is not implemented for `T`
    |
+   = note: `Range` only implements `Iterator` for select types in the standard library, particularly integers; to see the full list of types, see the documentation for the unstable `Step` trait
    = note: required for `std::ops::Range<T>` to implement `Iterator`
    = note: required for `std::ops::Range<T>` to implement `IntoIterator`
 help: consider restricting type parameter `T` with unstable trait `Step`

--- a/tests/ui/trait-bounds/unstable-trait-suggestion.stderr
+++ b/tests/ui/trait-bounds/unstable-trait-suggestion.stderr
@@ -20,7 +20,7 @@ error[E0277]: `std::ops::Range<T>` is not an iterator
   --> $DIR/unstable-trait-suggestion.rs:17:14
    |
 LL |     for _ in t {}
-   |              ^ the nightly-only, unstable trait `Step` is not implemented for `T`
+   |              ^ not an iterator
    |
    = note: `Range` only implements `Iterator` for select types in the standard library, particularly integers; to see the full list of types, see the documentation for the unstable `Step` trait
    = note: required for `std::ops::Range<T>` to implement `Iterator`

--- a/tests/ui/trait-bounds/unstable-trait-suggestion.stderr
+++ b/tests/ui/trait-bounds/unstable-trait-suggestion.stderr
@@ -16,7 +16,7 @@ help: consider restricting type parameter `T` with unstable trait `Unstable`
 LL | pub fn bar<T: Unstable>(t: T) {
    |             ++++++++++
 
-error[E0277]: the trait bound `T: Step` is not satisfied
+error[E0277]: `std::ops::Range<T>` is not an iterator
   --> $DIR/unstable-trait-suggestion.rs:17:14
    |
 LL |     for _ in t {}

--- a/tests/ui/trait-bounds/unstable-trait-suggestion.stderr
+++ b/tests/ui/trait-bounds/unstable-trait-suggestion.stderr
@@ -20,7 +20,7 @@ error[E0277]: `std::ops::Range<T>` is not an iterator
   --> $DIR/unstable-trait-suggestion.rs:17:14
    |
 LL |     for _ in t {}
-   |              ^ not an iterator
+   |              ^ `Range<T>` is not an iterator
    |
    = note: `Range` only implements `Iterator` for select types in the standard library, particularly integers; to see the full list of types, see the documentation for the unstable `Step` trait
    = note: required for `std::ops::Range<T>` to implement `Iterator`

--- a/tests/ui/traits/issue-71036.rs
+++ b/tests/ui/traits/issue-71036.rs
@@ -10,7 +10,7 @@ struct Foo<'a, T: ?Sized> {
 
 impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<Foo<'a, U>> for Foo<'a, T> {}
 //~^ ERROR the trait bound `&'a T: Unsize<&'a U>` is not satisfied
-//~| NOTE the trait `Unsize<&'a U>` is not implemented for `&'a T`
+//~| NOTE the nightly-only, unstable trait `Unsize<&'a U>` is not implemented for `&'a T`
 //~| NOTE all implementations of `Unsize` are provided automatically by the compiler
 //~| NOTE required for
 

--- a/tests/ui/traits/issue-71036.stderr
+++ b/tests/ui/traits/issue-71036.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `&'a T: Unsize<&'a U>` is not satisfied
   --> $DIR/issue-71036.rs:11:1
    |
 LL | impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<Foo<'a, U>> for Foo<'a, T> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unsize<&'a U>` is not implemented for `&'a T`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the nightly-only, unstable trait `Unsize<&'a U>` is not implemented for `&'a T`
    |
    = note: all implementations of `Unsize` are provided automatically by the compiler, see <https://doc.rust-lang.org/stable/std/marker/trait.Unsize.html> for more information
    = note: required for `&'a &'a T` to implement `DispatchFromDyn<&'a &'a U>`

--- a/tests/ui/traits/next-solver/coroutine.fail.stderr
+++ b/tests/ui/traits/next-solver/coroutine.fail.stderr
@@ -8,7 +8,7 @@ LL | /         || {
 LL | |
 LL | |             yield ();
 LL | |         },
-   | |_________^ the trait `Coroutine<A>` is not implemented for `{coroutine@$DIR/coroutine.rs:20:9: 20:11}`
+   | |_________^ the nightly-only, unstable trait `Coroutine<A>` is not implemented for `{coroutine@$DIR/coroutine.rs:20:9: 20:11}`
    |
 note: required by a bound in `needs_coroutine`
   --> $DIR/coroutine.rs:14:28

--- a/tests/ui/traits/trait-upcasting/higher-ranked-upcasting-ub.next.stderr
+++ b/tests/ui/traits/trait-upcasting/higher-ranked-upcasting-ub.next.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `&dyn for<'a> Subtrait<'a, 'a>: CoerceUnsized<&dyn
   --> $DIR/higher-ranked-upcasting-ub.rs:22:5
    |
 LL |     x
-   |     ^ the trait `Unsize<dyn for<'a, 'b> Supertrait<'a, 'b>>` is not implemented for `dyn for<'a> Subtrait<'a, 'a>`
+   |     ^ the nightly-only, unstable trait `Unsize<dyn for<'a, 'b> Supertrait<'a, 'b>>` is not implemented for `dyn for<'a> Subtrait<'a, 'a>`
    |
    = note: all implementations of `Unsize` are provided automatically by the compiler, see <https://doc.rust-lang.org/stable/std/marker/trait.Unsize.html> for more information
    = note: required for `&dyn for<'a> Subtrait<'a, 'a>` to implement `CoerceUnsized<&dyn for<'a, 'b> Supertrait<'a, 'b>>`

--- a/tests/ui/traits/unsize-goal-escaping-bounds.current.stderr
+++ b/tests/ui/traits/unsize-goal-escaping-bounds.current.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `for<'a> (): Unsize<(dyn Trait + 'a)>` is not sati
   --> $DIR/unsize-goal-escaping-bounds.rs:20:5
    |
 LL |     foo();
-   |     ^^^^^ the trait `for<'a> Unsize<(dyn Trait + 'a)>` is not implemented for `()`
+   |     ^^^^^ the nightly-only, unstable trait `for<'a> Unsize<(dyn Trait + 'a)>` is not implemented for `()`
    |
    = note: all implementations of `Unsize` are provided automatically by the compiler, see <https://doc.rust-lang.org/stable/std/marker/trait.Unsize.html> for more information
 note: required by a bound in `foo`

--- a/tests/ui/transmutability/assoc-bound.stderr
+++ b/tests/ui/transmutability/assoc-bound.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `<T as A>::AssocA: TransmuteFrom<(), Assume { alig
 LL |     type AssocB = T::AssocA;
    |                   ^^^^^^^^^ unsatisfied trait bound
    |
-   = help: the trait `TransmuteFrom<(), Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `<T as A>::AssocA`
+   = help: the nightly-only, unstable trait `TransmuteFrom<(), Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `<T as A>::AssocA`
 note: required by a bound in `B::AssocB`
   --> $DIR/assoc-bound.rs:9:18
    |

--- a/tests/ui/transmutability/dont-assume-err-is-yes-issue-126377.stderr
+++ b/tests/ui/transmutability/dont-assume-err-is-yes-issue-126377.stderr
@@ -17,7 +17,7 @@ error[E0277]: the trait bound `(): TransmuteFrom<(), { Assume::SAFETY }>` is not
   --> $DIR/dont-assume-err-is-yes-issue-126377.rs:14:23
    |
 LL |     is_transmutable::<{}>();
-   |                       ^^ the trait `TransmuteFrom<(), { Assume::SAFETY }>` is not implemented for `()`
+   |                       ^^ the nightly-only, unstable trait `TransmuteFrom<(), { Assume::SAFETY }>` is not implemented for `()`
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/dont-assume-err-is-yes-issue-126377.rs:9:9

--- a/tests/ui/transmutability/references/unsafecell.stderr
+++ b/tests/ui/transmutability/references/unsafecell.stderr
@@ -2,7 +2,7 @@ error[E0277]: `&u8` cannot be safely transmuted into `&UnsafeCell<u8>`
   --> $DIR/unsafecell.rs:27:50
    |
 LL |     assert::is_maybe_transmutable::<&'static u8, &'static UnsafeCell<u8>>();
-   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Freeze` is not implemented for `UnsafeCell<u8>`
+   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^ the nightly-only, unstable trait `Freeze` is not implemented for `UnsafeCell<u8>`
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/unsafecell.rs:12:14
@@ -17,7 +17,7 @@ error[E0277]: `&UnsafeCell<u8>` cannot be safely transmuted into `&UnsafeCell<u8
   --> $DIR/unsafecell.rs:29:62
    |
 LL |     assert::is_maybe_transmutable::<&'static UnsafeCell<u8>, &'static UnsafeCell<u8>>();
-   |                                                              ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Freeze` is not implemented for `UnsafeCell<u8>`
+   |                                                              ^^^^^^^^^^^^^^^^^^^^^^^ the nightly-only, unstable trait `Freeze` is not implemented for `UnsafeCell<u8>`
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/unsafecell.rs:12:14
@@ -32,7 +32,7 @@ error[E0277]: `&mut bool` cannot be safely transmuted into `&UnsafeCell<u8>`
   --> $DIR/unsafecell.rs:45:56
    |
 LL |     assert::is_maybe_transmutable::<&'static mut bool, &'static UnsafeCell<u8>>();
-   |                                                        ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Freeze` is not implemented for `UnsafeCell<u8>`
+   |                                                        ^^^^^^^^^^^^^^^^^^^^^^^ the nightly-only, unstable trait `Freeze` is not implemented for `UnsafeCell<u8>`
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/unsafecell.rs:12:14
@@ -47,7 +47,7 @@ error[E0277]: `&mut UnsafeCell<bool>` cannot be safely transmuted into `&UnsafeC
   --> $DIR/unsafecell.rs:46:68
    |
 LL |     assert::is_maybe_transmutable::<&'static mut UnsafeCell<bool>, &'static UnsafeCell<u8>>();
-   |                                                                    ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Freeze` is not implemented for `UnsafeCell<u8>`
+   |                                                                    ^^^^^^^^^^^^^^^^^^^^^^^ the nightly-only, unstable trait `Freeze` is not implemented for `UnsafeCell<u8>`
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/unsafecell.rs:12:14

--- a/tests/ui/try-block/try-block-bad-type-heterogeneous.stderr
+++ b/tests/ui/try-block/try-block-bad-type-heterogeneous.stderr
@@ -30,7 +30,7 @@ error[E0277]: a `try` block must return `Result` or `Option` (or another type th
 LL |     let res = try bikeshed () { };
    |                                 ^ could not wrap the final value of the block as `()` doesn't implement `Try`
    |
-   = help: the trait `Try` is not implemented for `()`
+   = help: the nightly-only, unstable trait `Try` is not implemented for `()`
 
 error[E0277]: a `try` block must return `Result` or `Option` (or another type that implements `Try`)
   --> $DIR/try-block-bad-type-heterogeneous.rs:20:34
@@ -38,7 +38,7 @@ error[E0277]: a `try` block must return `Result` or `Option` (or another type th
 LL |     let res = try bikeshed i32 { 5 };
    |                                  ^ could not wrap the final value of the block as `i32` doesn't implement `Try`
    |
-   = help: the trait `Try` is not implemented for `i32`
+   = help: the nightly-only, unstable trait `Try` is not implemented for `i32`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/try-block/try-block-bad-type.stderr
+++ b/tests/ui/try-block/try-block-bad-type.stderr
@@ -29,7 +29,7 @@ error[E0277]: a `try` block must return `Result` or `Option` (or another type th
 LL |     let res: () = try { };
    |                         ^ could not wrap the final value of the block as `()` doesn't implement `Try`
    |
-   = help: the trait `Try` is not implemented for `()`
+   = help: the nightly-only, unstable trait `Try` is not implemented for `()`
 
 error[E0277]: a `try` block must return `Result` or `Option` (or another type that implements `Try`)
   --> $DIR/try-block-bad-type.rs:20:26
@@ -37,7 +37,7 @@ error[E0277]: a `try` block must return `Result` or `Option` (or another type th
 LL |     let res: i32 = try { 5 };
    |                          ^ could not wrap the final value of the block as `i32` doesn't implement `Try`
    |
-   = help: the trait `Try` is not implemented for `i32`
+   = help: the nightly-only, unstable trait `Try` is not implemented for `i32`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/try-block/try-block-in-while.stderr
+++ b/tests/ui/try-block/try-block-in-while.stderr
@@ -4,7 +4,7 @@ error[E0277]: a `try` block must return `Result` or `Option` (or another type th
 LL |     while try { false } {}
    |                 ^^^^^ could not wrap the final value of the block as `bool` doesn't implement `Try`
    |
-   = help: the trait `Try` is not implemented for `bool`
+   = help: the nightly-only, unstable trait `Try` is not implemented for `bool`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/try-trait/try-operator-on-main.stderr
+++ b/tests/ui/try-trait/try-operator-on-main.stderr
@@ -22,7 +22,7 @@ error[E0277]: the `?` operator can only be applied to values that implement `Try
 LL |     ()?;
    |     ^^^ the `?` operator cannot be applied to type `()`
    |
-   = help: the trait `Try` is not implemented for `()`
+   = help: the nightly-only, unstable trait `Try` is not implemented for `()`
 
 error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
   --> $DIR/try-operator-on-main.rs:10:7
@@ -37,7 +37,7 @@ error[E0277]: the trait bound `(): Try` is not satisfied
   --> $DIR/try-operator-on-main.rs:14:25
    |
 LL |     try_trait_generic::<()>();
-   |                         ^^ the trait `Try` is not implemented for `()`
+   |                         ^^ the nightly-only, unstable trait `Try` is not implemented for `()`
    |
 note: required by a bound in `try_trait_generic`
   --> $DIR/try-operator-on-main.rs:17:25
@@ -51,7 +51,7 @@ error[E0277]: the `?` operator can only be applied to values that implement `Try
 LL |     ()?;
    |     ^^^ the `?` operator cannot be applied to type `()`
    |
-   = help: the trait `Try` is not implemented for `()`
+   = help: the nightly-only, unstable trait `Try` is not implemented for `()`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/tuple/builtin-fail.stderr
+++ b/tests/ui/tuple/builtin-fail.stderr
@@ -2,7 +2,7 @@ error[E0277]: `T` is not a tuple
   --> $DIR/builtin-fail.rs:8:23
    |
 LL |     assert_is_tuple::<T>();
-   |                       ^ the trait `std::marker::Tuple` is not implemented for `T`
+   |                       ^ the nightly-only, unstable trait `std::marker::Tuple` is not implemented for `T`
    |
 note: required by a bound in `assert_is_tuple`
   --> $DIR/builtin-fail.rs:3:23
@@ -18,7 +18,7 @@ error[E0277]: `i32` is not a tuple
   --> $DIR/builtin-fail.rs:13:23
    |
 LL |     assert_is_tuple::<i32>();
-   |                       ^^^ the trait `std::marker::Tuple` is not implemented for `i32`
+   |                       ^^^ the nightly-only, unstable trait `std::marker::Tuple` is not implemented for `i32`
    |
 note: required by a bound in `assert_is_tuple`
   --> $DIR/builtin-fail.rs:3:23
@@ -30,7 +30,7 @@ error[E0277]: `i32` is not a tuple
   --> $DIR/builtin-fail.rs:15:24
    |
 LL |     assert_is_tuple::<(i32)>();
-   |                        ^^^ the trait `std::marker::Tuple` is not implemented for `i32`
+   |                        ^^^ the nightly-only, unstable trait `std::marker::Tuple` is not implemented for `i32`
    |
 note: required by a bound in `assert_is_tuple`
   --> $DIR/builtin-fail.rs:3:23
@@ -44,7 +44,7 @@ error[E0277]: `TupleStruct` is not a tuple
 LL |     assert_is_tuple::<TupleStruct>();
    |                       ^^^^^^^^^^^ unsatisfied trait bound
    |
-help: the trait `std::marker::Tuple` is not implemented for `TupleStruct`
+help: the nightly-only, unstable trait `std::marker::Tuple` is not implemented for `TupleStruct`
   --> $DIR/builtin-fail.rs:5:1
    |
 LL | struct TupleStruct(i32, i32);

--- a/tests/ui/type/pattern_types/nested.stderr
+++ b/tests/ui/type/pattern_types/nested.stderr
@@ -13,7 +13,7 @@ error[E0277]: `(u32) is 1..` is not a valid base type for range patterns
 LL | const BAD_NESTING: pattern_type!(pattern_type!(u32 is 1..) is 0..) = todo!();
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^ only integer types and `char` are supported
    |
-   = help: the trait `core::pat::RangePattern` is not implemented for `(u32) is 1..`
+   = help: the nightly-only, unstable trait `core::pat::RangePattern` is not implemented for `(u32) is 1..`
    = help: the following other types implement trait `core::pat::RangePattern`:
              char
              i128
@@ -31,7 +31,7 @@ error[E0277]: `(i32) is 1..` is not a valid base type for range patterns
 LL | const BAD_NESTING2: pattern_type!(pattern_type!(i32 is 1..) is ..=-1) = todo!();
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^ only integer types and `char` are supported
    |
-   = help: the trait `core::pat::RangePattern` is not implemented for `(i32) is 1..`
+   = help: the nightly-only, unstable trait `core::pat::RangePattern` is not implemented for `(i32) is 1..`
    = help: the following other types implement trait `core::pat::RangePattern`:
              char
              i128
@@ -55,7 +55,7 @@ error[E0277]: `(i32) is 1..` is not a valid base type for range patterns
 LL | const BAD_NESTING3: pattern_type!(pattern_type!(i32 is 1..) is ..0) = todo!();
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^ only integer types and `char` are supported
    |
-   = help: the trait `core::pat::RangePattern` is not implemented for `(i32) is 1..`
+   = help: the nightly-only, unstable trait `core::pat::RangePattern` is not implemented for `(i32) is 1..`
    = help: the following other types implement trait `core::pat::RangePattern`:
              char
              i128
@@ -92,7 +92,7 @@ error[E0277]: `(i32) is 1..` is not a valid base type for range patterns
 LL | const BAD_NESTING3: pattern_type!(pattern_type!(i32 is 1..) is ..0) = todo!();
    |                                                                  ^ only integer types and `char` are supported
    |
-   = help: the trait `core::pat::RangePattern` is not implemented for `(i32) is 1..`
+   = help: the nightly-only, unstable trait `core::pat::RangePattern` is not implemented for `(i32) is 1..`
    = help: the following other types implement trait `core::pat::RangePattern`:
              char
              i128
@@ -110,7 +110,7 @@ error[E0277]: `()` is not a valid base type for range patterns
 LL | const BAD_NESTING4: pattern_type!(() is ..0) = todo!();
    |                                   ^^ only integer types and `char` are supported
    |
-   = help: the trait `core::pat::RangePattern` is not implemented for `()`
+   = help: the nightly-only, unstable trait `core::pat::RangePattern` is not implemented for `()`
    = help: the following other types implement trait `core::pat::RangePattern`:
              char
              i128
@@ -145,7 +145,7 @@ error[E0277]: `()` is not a valid base type for range patterns
 LL | const BAD_NESTING4: pattern_type!(() is ..0) = todo!();
    |                                           ^ only integer types and `char` are supported
    |
-   = help: the trait `core::pat::RangePattern` is not implemented for `()`
+   = help: the nightly-only, unstable trait `core::pat::RangePattern` is not implemented for `()`
    = help: the following other types implement trait `core::pat::RangePattern`:
              char
              i128
@@ -163,7 +163,7 @@ error[E0277]: `f32` is not a valid base type for range patterns
 LL | const BAD_NESTING5: pattern_type!(f32 is 1.0 .. 2.0) = todo!();
    |                                                 ^^^ only integer types and `char` are supported
    |
-   = help: the trait `core::pat::RangePattern` is not implemented for `f32`
+   = help: the nightly-only, unstable trait `core::pat::RangePattern` is not implemented for `f32`
    = help: the following other types implement trait `core::pat::RangePattern`:
              i128
              i16

--- a/tests/ui/typeck/issue-57404.stderr
+++ b/tests/ui/typeck/issue-57404.stderr
@@ -2,7 +2,7 @@ error[E0277]: `&mut ()` is not a tuple
   --> $DIR/issue-57404.rs:6:41
    |
 LL |     handlers.unwrap().as_mut().call_mut(&mut ());
-   |                                -------- ^^^^^^^ the trait `std::marker::Tuple` is not implemented for `&mut ()`
+   |                                -------- ^^^^^^^ the nightly-only, unstable trait `std::marker::Tuple` is not implemented for `&mut ()`
    |                                |
    |                                required by a bound introduced by this call
    |

--- a/tests/ui/unboxed-closures/non-tupled-arg-mismatch.stderr
+++ b/tests/ui/unboxed-closures/non-tupled-arg-mismatch.stderr
@@ -2,7 +2,7 @@ error[E0059]: type parameter to bare `Fn` trait must be a tuple
   --> $DIR/non-tupled-arg-mismatch.rs:3:9
    |
 LL | fn a<F: Fn<usize>>(f: F) {}
-   |         ^^^^^^^^^ the trait `std::marker::Tuple` is not implemented for `usize`
+   |         ^^^^^^^^^ the nightly-only, unstable trait `std::marker::Tuple` is not implemented for `usize`
    |
 note: required by a bound in `Fn`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL


### PR DESCRIPTION
Mention when a trait bound corresponds to an unstable trait.

Mention `Range` when `Step` bound is unment, and explain that only some std types impl `Iterator` for `Range`.

CC rust-lang/rust#151026