### PR TITLE
Don't expose redundant information in `rustc_public`'s `LayoutShape`

### DIFF
--- a/compiler/rustc_public/src/abi.rs
+++ b/compiler/rustc_public/src/abi.rs
@@ -188,8 +188,25 @@ pub enum VariantsShape {
         tag: Scalar,
         tag_encoding: TagEncoding,
         tag_field: usize,
-        variants: Vec<LayoutShape>,
+        variants: Vec<VariantFields>,
     },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
+pub struct VariantFields {
+    /// Offsets for the first byte of each field,
+    /// ordered to match the source definition order.
+    /// I.e.: It follows the same order as [super::ty::VariantDef::fields()].
+    /// This vector does not go in increasing order.
+    pub offsets: Vec<Size>,
+}
+
+impl VariantFields {
+    pub fn fields_by_offset_order(&self) -> Vec<FieldIdx> {
+        let mut indices = (0..self.offsets.len()).collect::<Vec<_>>();
+        indices.sort_by_key(|idx| self.offsets[*idx]);
+        indices
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]

--- a/compiler/rustc_public/src/unstable/convert/stable/abi.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/abi.rs
@@ -11,7 +11,7 @@ use rustc_target::callconv;
 use crate::abi::{
     AddressSpace, ArgAbi, CallConvention, FieldsShape, FloatLength, FnAbi, IntegerLength,
     IntegerType, Layout, LayoutShape, PassMode, Primitive, ReprFlags, ReprOptions, Scalar,
-    TagEncoding, TyAndLayout, ValueAbi, VariantsShape, WrappingRange,
+    TagEncoding, TyAndLayout, ValueAbi, VariantFields, VariantsShape, WrappingRange,
 };
 use crate::compiler_interface::BridgeTys;
 use crate::target::MachineSize as Size;
@@ -212,7 +212,15 @@ impl<'tcx> Stable<'tcx> for rustc_abi::Variants<rustc_abi::FieldIdx, rustc_abi::
                     tag: tag.stable(tables, cx),
                     tag_encoding: tag_encoding.stable(tables, cx),
                     tag_field: tag_field.stable(tables, cx),
-                    variants: variants.iter().as_slice().stable(tables, cx),
+                    variants: variants
+                        .iter()
+                        .map(|v| match &v.fields {
+                            rustc_abi::FieldsShape::Arbitrary { offsets, .. } => VariantFields {
+                                offsets: offsets.iter().as_slice().stable(tables, cx),
+                            },
+                            _ => panic!("variant layout should be Arbitrary"),
+                        })
+                        .collect(),
                 }
             }
         }


### PR DESCRIPTION
Enum variant layouts don't need to store a full `LayoutShape`; just storing the fields offsets is enough and all other information can be inferred from the parent layout:
- size, align and ABI don't make much sense for individual variants and should generally be taken from the parent layout instead;
- variants always have `fields: FieldsShape::Arbitrary { .. }` and `variant: VariantShape::Single { .. }`.

In principle, the same refactor could be done on `rustc_abi::Layout` (see [this comment](https://github.com/rust-lang/rust/issues/113988#issuecomment-1646982272)) but I prefer starting with this smaller change first.