### PR TITLE
fix fallback impl for select_unpredictable intrinsic

### DIFF
--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -55,7 +55,7 @@
 #![allow(missing_docs)]
 
 use crate::ffi::va_list::{VaArgSafe, VaList};
-use crate::marker::{ConstParamTy, Destruct, DiscriminantKind, PointeeSized, Tuple};
+use crate::marker::{ConstParamTy, DiscriminantKind, PointeeSized, Tuple};
 use crate::{mem, ptr};
 
 mod bounds;
@@ -482,11 +482,14 @@ pub const fn unlikely(b: bool) -> bool {
 #[rustc_nounwind]
 #[miri::intrinsic_fallback_is_spec]
 #[inline]
-pub const fn select_unpredictable<T>(b: bool, true_val: T, false_val: T) -> T
-where
-    T: [const] Destruct,
-{
-    if b { true_val } else { false_val }
+pub const fn select_unpredictable<T>(b: bool, true_val: T, false_val: T) -> T {
+    if b {
+        forget(false_val);
+        true_val
+    } else {
+        forget(true_val);
+        false_val
+    }
 }
 
 /// A guard for unsafe functions that cannot ever be executed if `T` is uninhabited:

--- a/src/tools/miri/tests/pass/intrinsics/select-unpredictable-drop.rs
+++ b/src/tools/miri/tests/pass/intrinsics/select-unpredictable-drop.rs
@@ -1,0 +1,19 @@
+//! Check that `select_unpredictable` properly forgets the value it does not select.
+#![feature(core_intrinsics)]
+use std::cell::Cell;
+use std::intrinsics::select_unpredictable;
+
+fn main() {
+    let (true_val, false_val) = (Cell::new(false), Cell::new(false));
+    _ = select_unpredictable(true, TraceDrop(&true_val), TraceDrop(&false_val));
+    assert!(true_val.get());
+    assert!(!false_val.get());
+}
+
+struct TraceDrop<'a>(&'a Cell<bool>);
+
+impl<'a> Drop for TraceDrop<'a> {
+    fn drop(&mut self) {
+        self.0.set(true);
+    }
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

`intrinsics::select_unpredictable` does not drop the value that is not selected, but the fallback impl did not consider this behavior. This creates an observable difference between Miri and actual execution, and possibly does not play well with the `core::hint` version which has extra logic to drop the value that was not selected.
```rust
#![feature(core_intrinsics)]

fn main() {
    core::intrinsics::select_unpredictable(true, LoudDrop(0), LoudDrop(1));
    // cargo run: "0"; cargo miri run: "1 0"
}

struct LoudDrop(u8);

impl Drop for LoudDrop {
    fn drop(&mut self) {
        print!("{} ", self.0);
    }
}
```

This change let me remove the `T: [const] Destruct` bound as well, since the destructor is no longer relevant.