### PR TITLE
armv7-unknown-linux-uclibceabihf.md: Fix bootstrap.toml syntax

### DIFF
--- a/src/doc/rustc/src/platform-support/armv7-unknown-linux-uclibceabihf.md
+++ b/src/doc/rustc/src/platform-support/armv7-unknown-linux-uclibceabihf.md
@@ -21,7 +21,7 @@ This target is cross compiled, and requires a cross toolchain.  You can find sui
 
 Compiling rust for this target has been tested on `x86_64` linux hosts.  Other host types have not been tested, but may work, if you can find a suitable cross compilation toolchain for them.
 
-If you don't already have a suitable toolchain, download one [here](https://toolchains.bootlin.com/downloads/releases/toolchains/armv7-eabihf/tarballs/armv7-eabihf--uclibc--bleeding-edge-2021.11-1.tar.bz2), and unpack it into a directory.
+If you don't already have a suitable toolchain, download one [here](https://toolchains.bootlin.com/downloads/releases/toolchains/armv7-eabihf/tarballs/armv7-eabihf--uclibc--bleeding-edge-2025.08-1.tar.xz), and unpack it into a directory.
 
 ### Configure rust
 

--- a/src/doc/rustc/src/platform-support/armv7-unknown-linux-uclibceabihf.md
+++ b/src/doc/rustc/src/platform-support/armv7-unknown-linux-uclibceabihf.md
@@ -30,7 +30,7 @@ The target can be built by enabling it for a `rustc` build, by placing the follo
 ```toml
 [build]
 target = ["armv7-unknown-linux-uclibceabihf"]
-stage = 2
+build-stage = 2
 
 [target.armv7-unknown-linux-uclibceabihf]
 # ADJUST THIS PATH TO POINT AT YOUR TOOLCHAIN


### PR DESCRIPTION
With the suggested value we were getting instead:

```
ERROR: Failed to parse '/tmp/rust/bootstrap.toml': unknown field `stage`, expected one of `build`, `description`, `host`, `target`, `build-dir`, `cargo`, `rustc`, `rustfmt`, `cargo-clippy`, `docs`, `compiler-docs`, `library-docs-private-items`, `docs-minification`, `submodules`, `gdb`, `lldb`, `nodejs`, `npm`, `yarn`, `python`, `windows-rc`, `reuse`, `locked-deps`, `vendor`, `full-bootstrap`, `bootstrap-cache-path`, `extended`, `tools`, `tool`, `verbose`, `sanitizers`, `profiler`, `cargo-native-static`, `low-priority`, `configure-args`, `local-rebuild`, `print-step-timings`, `print-step-rusage`, `check-stage`, `doc-stage`, `build-stage`, `test-stage`, `install-stage`, `dist-stage`, `bench-stage`, `patch-binaries-for-nix`, `metrics`, `android-ndk`, `optimized-compiler-builtins`, `jobs`, `compiletest-diff-tool`, `compiletest-allow-stage0`, `compiletest-use-stage0-libtest`, `tidy-extra-checks`, `ccache`, `exclude` for key `build`
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
