### PR TITLE
compiler: Make Externally Implementable Item (eii) macros "semiopaque"

### DIFF
--- a/compiler/rustc_builtin_macros/src/eii.rs
+++ b/compiler/rustc_builtin_macros/src/eii.rs
@@ -425,6 +425,9 @@ fn generate_attribute_macro_to_implement(
     // errors for eii's in std.
     macro_attrs.extend_from_slice(attrs_from_decl);
 
+    // Avoid "missing stability attribute" errors for eiis in std. See #146993.
+    macro_attrs.push(ecx.attr_name_value_str(sym::rustc_macro_transparency, sym::semiopaque, span));
+
     // #[builtin_macro(eii_shared_macro)]
     macro_attrs.push(ecx.attr_nested_word(sym::rustc_builtin_macro, sym::eii_shared_macro, span));
 


### PR DESCRIPTION
Otherwise eiis defined by std will produce large amounts of `missing stability attribute` errors. This problem is not eii specific, as can be seen in https://github.com/rust-lang/rust/issues/146993 and which is demonstrated in https://github.com/rust-lang/rust/pull/151022.

As can be seen with

```console
$ git grep rustc_macro_transparency
compiler/rustc_arena/src/lib.rs:#[rustc_macro_transparency = "semiopaque"]
[...]
```

it is very common for macros to use `"semiopaque"`.

r? @jdonszelmann 

Tracking issue: https://github.com/rust-lang/rust/issues/125418

Needed for: https://github.com/rust-lang/rust/issues/150588