### PR TITLE
Reduce flakyness for `tests/rustdoc-gui/notable-trait.goml`

### DIFF
--- a/tests/rustdoc-gui/notable-trait.goml
+++ b/tests/rustdoc-gui/notable-trait.goml
@@ -250,7 +250,7 @@ set-window-size: (1100, 600)
 reload:
 assert-count: ("//*[@class='tooltip popover']", 0)
 click: "//*[@id='method.create_an_iterator_from_read']//*[@class='tooltip']"
-assert-count: ("//*[@class='tooltip popover']", 1)
+wait-for-count: ("//*[@class='tooltip popover']", 1)
 call-function: ("open-settings-menu", {})
-assert-count: ("//*[@class='tooltip popover']", 0)
+wait-for-count: ("//*[@class='tooltip popover']", 0)
 assert-false: "#method\.create_an_iterator_from_read .tooltip:focus"


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/151006 (hopefully).

Instead of asserting right away, it waits for the element count to be the one expected.

r? @jieyouxu 