### PR TITLE
Emit error instead of delayed bug when meeting mismatch type for const array

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -2415,11 +2415,10 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         };
 
         let ty::Array(elem_ty, _) = ty.kind() else {
-            return Const::new_error_with_message(
-                tcx,
-                array_expr.span,
-                "const array must have an array type",
-            );
+            let e = tcx
+                .dcx()
+                .span_err(array_expr.span, format!("expected `{}`, found const array", ty));
+            return Const::new_error(tcx, e);
         };
 
         let elems = array_expr

--- a/tests/ui/const-generics/mgca/array-expr-type-mismatch-in-where-bound.rs
+++ b/tests/ui/const-generics/mgca/array-expr-type-mismatch-in-where-bound.rs
@@ -1,0 +1,21 @@
+//! regression test for <https://github.com/rust-lang/rust/issues/151024>
+#![feature(min_generic_const_args)]
+#![feature(adt_const_params)]
+#![expect(incomplete_features)]
+
+trait Trait1<const N: usize> {}
+trait Trait2<const N: [u8; 3]> {}
+
+fn foo<T>()
+where
+    T: Trait1<{ [] }>, //~ ERROR: expected `usize`, found const array
+{
+}
+
+fn bar<T>()
+where
+    T: Trait2<3>, //~ ERROR: mismatched types
+{
+}
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/array-expr-type-mismatch-in-where-bound.stderr
+++ b/tests/ui/const-generics/mgca/array-expr-type-mismatch-in-where-bound.stderr
@@ -1,0 +1,15 @@
+error: expected `usize`, found const array
+  --> $DIR/array-expr-type-mismatch-in-where-bound.rs:11:17
+   |
+LL |     T: Trait1<{ [] }>,
+   |                 ^^
+
+error[E0308]: mismatched types
+  --> $DIR/array-expr-type-mismatch-in-where-bound.rs:17:15
+   |
+LL |     T: Trait2<3>,
+   |               ^ expected `[u8; 3]`, found integer
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
r? BoxyUwU

resolve: rust-lang/rust#151024 

cc: https://github.com/rust-lang/rust/pull/150869