### PR TITLE
Clarify `Vec::extend_from_slice` doc

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -3413,9 +3413,9 @@ impl<T: Clone, A: Allocator> Vec<T, A> {
     /// Iterates over the slice `other`, clones each element, and then appends
     /// it to this `Vec`. The `other` slice is traversed in-order.
     ///
-    /// Note that this function is the same as [`extend`],
-    /// except that it also works with slice elements that are Clone but not Copy.
-    /// If Rust gets specialization this function may be deprecated.
+    /// Note that this function is the same as [`extend`]:
+    /// `vec.extend(slice.iter().cloned())` achieves the same result with the
+    /// same performance.
     ///
     /// # Panics
     ///
@@ -3433,7 +3433,7 @@ impl<T: Clone, A: Allocator> Vec<T, A> {
     #[cfg(not(no_global_oom_handling))]
     #[stable(feature = "vec_extend_from_slice", since = "1.6.0")]
     pub fn extend_from_slice(&mut self, other: &[T]) {
-        self.spec_extend(other.iter())
+        self.extend(other.iter().cloned())
     }
 
     /// Given a range `src`, clones a slice of elements in that range and appends it to the end.
@@ -3866,7 +3866,7 @@ impl<'a, T, A: Allocator> IntoIterator for &'a mut Vec<T, A> {
 impl<T, A: Allocator> Extend<T> for Vec<T, A> {
     #[inline]
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
-        <Self as SpecExtend<T, I::IntoIter>>::spec_extend(self, iter.into_iter())
+        <Self as SpecExtend<I::IntoIter>>::spec_extend(self, iter.into_iter())
     }
 
     #[inline]

--- a/library/alloc/src/vec/spec_extend.rs
+++ b/library/alloc/src/vec/spec_extend.rs
@@ -1,16 +1,16 @@
 use core::clone::TrivialClone;
-use core::iter::TrustedLen;
-use core::slice::{self};
+use core::iter::{Cloned, TrustedLen};
+use core::slice;
 
 use super::{IntoIter, Vec};
 use crate::alloc::Allocator;
 
 // Specialization trait used for Vec::extend
-pub(super) trait SpecExtend<T, I> {
+pub(super) trait SpecExtend<I> {
     fn spec_extend(&mut self, iter: I);
 }
 
-impl<T, I, A: Allocator> SpecExtend<T, I> for Vec<T, A>
+impl<T, I, A: Allocator> SpecExtend<I> for Vec<T, A>
 where
     I: Iterator<Item = T>,
 {
@@ -19,7 +19,7 @@ where
     }
 }
 
-impl<T, I, A: Allocator> SpecExtend<T, I> for Vec<T, A>
+impl<T, I, A: Allocator> SpecExtend<I> for Vec<T, A>
 where
     I: TrustedLen<Item = T>,
 {
@@ -28,7 +28,7 @@ where
     }
 }
 
-impl<T, A1: Allocator, A2: Allocator> SpecExtend<T, IntoIter<T, A2>> for Vec<T, A1> {
+impl<T, A1: Allocator, A2: Allocator> SpecExtend<IntoIter<T, A2>> for Vec<T, A1> {
     fn spec_extend(&mut self, mut iterator: IntoIter<T, A2>) {
         unsafe {
             self.append_elements(iterator.as_slice() as _);
@@ -37,22 +37,13 @@ impl<T, A1: Allocator, A2: Allocator> SpecExtend<T, IntoIter<T, A2>> for Vec<T, 
     }
 }
 
-impl<'a, T: 'a, I, A: Allocator> SpecExtend<&'a T, I> for Vec<T, A>
-where
-    I: Iterator<Item = &'a T>,
-    T: Clone,
-{
-    default fn spec_extend(&mut self, iterator: I) {
-        self.spec_extend(iterator.cloned())
-    }
-}
-
-impl<'a, T: 'a, A: Allocator> SpecExtend<&'a T, slice::Iter<'a, T>> for Vec<T, A>
+impl<'a, T: 'a, I, A: Allocator> SpecExtend<Cloned<slice::Iter<'a, T>>> for Vec<T, A>
 where
     T: TrivialClone,
 {
-    fn spec_extend(&mut self, iterator: slice::Iter<'a, T>) {
+    fn spec_extend(&mut self, mut iterator: Cloned<slice::Iter<'a, T>>) {
+        let inner: &mut slice::Iter<'a, T> = unsafe { iterator.as_inner() };
         let slice = iterator.as_slice();
-        unsafe { self.append_elements(slice) };
+        unsafe { self.append_elements(slice); }
     }
 }


### PR DESCRIPTION
Calling `vec.extend(slice.iter().cloned())` calls the same code thanks to specialization.

I don't know of any plans to deprecate this method.