### PR TITLE
x86: support passing `u128`/`i128` to inline assembly

### DIFF
--- a/compiler/rustc_target/src/asm/mod.rs
+++ b/compiler/rustc_target/src/asm/mod.rs
@@ -614,7 +614,7 @@ impl InlineAsmRegClass {
         allow_experimental_reg: bool,
     ) -> &'static [(InlineAsmType, Option<Symbol>)] {
         match self {
-            Self::X86(r) => r.supported_types(arch),
+            Self::X86(r) => r.supported_types(arch, allow_experimental_reg),
             Self::Arm(r) => r.supported_types(arch),
             Self::AArch64(r) => r.supported_types(arch),
             Self::RiscV(r) => r.supported_types(arch),

--- a/compiler/rustc_target/src/asm/x86.rs
+++ b/compiler/rustc_target/src/asm/x86.rs
@@ -105,6 +105,7 @@ impl X86InlineAsmRegClass {
     pub fn supported_types(
         self,
         arch: InlineAsmArch,
+        allow_experimental_reg: bool,
     ) -> &'static [(InlineAsmType, Option<Symbol>)] {
         match self {
             Self::reg | Self::reg_abcd => {
@@ -115,21 +116,52 @@ impl X86InlineAsmRegClass {
                 }
             }
             Self::reg_byte => types! { _: I8; },
-            Self::xmm_reg => types! {
-                sse: I32, I64, F16, F32, F64, F128,
-                  VecI8(16), VecI16(8), VecI32(4), VecI64(2), VecF16(8), VecF32(4), VecF64(2);
-            },
-            Self::ymm_reg => types! {
-                avx: I32, I64, F16, F32, F64, F128,
-                    VecI8(16), VecI16(8), VecI32(4), VecI64(2), VecF16(8), VecF32(4), VecF64(2),
-                    VecI8(32), VecI16(16), VecI32(8), VecI64(4), VecF16(16), VecF32(8), VecF64(4);
-            },
-            Self::zmm_reg => types! {
-                avx512f: I32, I64, F16, F32, F64, F128,
-                    VecI8(16), VecI16(8), VecI32(4), VecI64(2), VecF16(8), VecF32(4), VecF64(2),
-                    VecI8(32), VecI16(16), VecI32(8), VecI64(4), VecF16(16), VecF32(8), VecF64(4),
-                    VecI8(64), VecI16(32), VecI32(16), VecI64(8), VecF16(32), VecF32(16), VecF64(8);
-            },
+            Self::xmm_reg => {
+                if allow_experimental_reg {
+                    types! {
+                        sse: I32, I64, I128, F16, F32, F64, F128,
+                          VecI8(16), VecI16(8), VecI32(4), VecI64(2), VecF16(8), VecF32(4), VecF64(2);
+                    }
+                } else {
+                    types! {
+                        sse: I32, I64, F16, F32, F64, F128,
+                          VecI8(16), VecI16(8), VecI32(4), VecI64(2), VecF16(8), VecF32(4), VecF64(2);
+                    }
+                }
+            }
+            Self::ymm_reg => {
+                if allow_experimental_reg {
+                    types! {
+                        avx: I32, I64, I128, F16, F32, F64, F128,
+                            VecI8(16), VecI16(8), VecI32(4), VecI64(2), VecF16(8), VecF32(4), VecF64(2),
+                            VecI8(32), VecI16(16), VecI32(8), VecI64(4), VecF16(16), VecF32(8), VecF64(4);
+                    }
+                } else {
+                    types! {
+                        avx: I32, I64, F16, F32, F64, F128,
+                            VecI8(16), VecI16(8), VecI32(4), VecI64(2), VecF16(8), VecF32(4), VecF64(2),
+                            VecI8(32), VecI16(16), VecI32(8), VecI64(4), VecF16(16), VecF32(8), VecF64(4);
+                    }
+                }
+            }
+            Self::zmm_reg => {
+                if allow_experimental_reg {
+                    types! {
+                        avx512f: I32, I64, I128, F16, F32, F64, F128,
+                            VecI8(16), VecI16(8), VecI32(4), VecI64(2), VecF16(8), VecF32(4), VecF64(2),
+                            VecI8(32), VecI16(16), VecI32(8), VecI64(4), VecF16(16), VecF32(8), VecF64(4),
+                            VecI8(64), VecI16(32), VecI32(16), VecI64(8), VecF16(32), VecF32(16), VecF64(8);
+                    }
+                } else {
+                    types! {
+                    avx512f: I32, I64, F16, F32, F64, F128,
+                        VecI8(16), VecI16(8), VecI32(4), VecI64(2), VecF16(8), VecF32(4), VecF64(2),
+                        VecI8(32), VecI16(16), VecI32(8), VecI64(4), VecF16(16), VecF32(8), VecF64(4),
+                        VecI8(64), VecI16(32), VecI32(16), VecI64(8), VecF16(32), VecF32(16), VecF64(8);
+                    }
+                }
+            }
+
             Self::kreg => types! {
                 avx512f: I8, I16;
                 avx512bw: I32, I64;

--- a/src/doc/unstable-book/src/language-features/asm-experimental-reg.md
+++ b/src/doc/unstable-book/src/language-features/asm-experimental-reg.md
@@ -22,6 +22,9 @@ This tracks support for additional registers in architectures where inline assem
 | Architecture | Register class | Target feature | Allowed types |
 | ------------ | -------------- | -------------- | ------------- |
 | s390x | `vreg` | `vector` | `i32`, `f32`, `i64`, `f64`, `i128`, `f128`, `i8x16`, `i16x8`, `i32x4`, `i64x2`, `f32x4`, `f64x2` |
+| x86 | `xmm_reg` | `sse` | `i128` |
+| x86 | `ymm_reg` | `avx` | `i128` |
+| x86 | `zmm_reg` | `avx512f` | `i128` |
 
 ## Register aliases
 

--- a/tests/auxiliary/minicore.rs
+++ b/tests/auxiliary/minicore.rs
@@ -62,6 +62,10 @@ pub trait MetaSized: PointeeSized {}
 )]
 pub trait Sized: MetaSized {}
 
+#[lang = "destruct"]
+#[rustc_on_unimplemented(message = "can't drop `{Self}`", append_const_msg)]
+pub trait Destruct: PointeeSized {}
+
 #[lang = "legacy_receiver"]
 pub trait LegacyReceiver {}
 impl<T: PointeeSized> LegacyReceiver for &T {}

--- a/tests/ui/asm/x86_64/bad-reg.experimental_reg.stderr
+++ b/tests/ui/asm/x86_64/bad-reg.experimental_reg.stderr
@@ -1,0 +1,220 @@
+error: invalid register class `foo`: unknown register class
+  --> $DIR/bad-reg.rs:20:20
+   |
+LL |         asm!("{}", in(foo) foo);
+   |                    ^^^^^^^^^^^
+   |
+   = note: the following register classes are supported on this target: `reg`, `reg_abcd`, `reg_byte`, `xmm_reg`, `ymm_reg`, `zmm_reg`, `kreg`, `kreg0`, `mmx_reg`, `x87_reg`, `tmm_reg`
+
+error: invalid register `foo`: unknown register
+  --> $DIR/bad-reg.rs:22:18
+   |
+LL |         asm!("", in("foo") foo);
+   |                  ^^^^^^^^^^^^^
+
+error: invalid asm template modifier for this register class
+  --> $DIR/bad-reg.rs:24:15
+   |
+LL |         asm!("{:z}", in(reg) foo);
+   |               ^^^^   ----------- argument
+   |               |
+   |               template modifier
+   |
+   = note: the `reg` register class supports the following template modifiers: `l`, `x`, `e`, `r`
+
+error: invalid asm template modifier for this register class
+  --> $DIR/bad-reg.rs:26:15
+   |
+LL |         asm!("{:r}", in(xmm_reg) foo);
+   |               ^^^^   --------------- argument
+   |               |
+   |               template modifier
+   |
+   = note: the `xmm_reg` register class supports the following template modifiers: `x`, `y`, `z`
+
+error: asm template modifiers are not allowed for `const` arguments
+  --> $DIR/bad-reg.rs:28:15
+   |
+LL |         asm!("{:a}", const 0);
+   |               ^^^^   ------- argument
+   |               |
+   |               template modifier
+
+error: asm template modifiers are not allowed for `sym` arguments
+  --> $DIR/bad-reg.rs:30:15
+   |
+LL |         asm!("{:a}", sym main);
+   |               ^^^^   -------- argument
+   |               |
+   |               template modifier
+
+error: invalid register `ebp`: the frame pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:32:18
+   |
+LL |         asm!("", in("ebp") foo);
+   |                  ^^^^^^^^^^^^^
+
+error: invalid register `rsp`: the stack pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:34:18
+   |
+LL |         asm!("", in("rsp") foo);
+   |                  ^^^^^^^^^^^^^
+
+error: invalid register `ip`: the instruction pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:36:18
+   |
+LL |         asm!("", in("ip") foo);
+   |                  ^^^^^^^^^^^^
+
+error: register class `x87_reg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:39:18
+   |
+LL |         asm!("", in("st(2)") foo);
+   |                  ^^^^^^^^^^^^^^^
+
+error: register class `mmx_reg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:42:18
+   |
+LL |         asm!("", in("mm0") foo);
+   |                  ^^^^^^^^^^^^^
+
+error: register class `kreg0` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:45:18
+   |
+LL |         asm!("", in("k0") foo);
+   |                  ^^^^^^^^^^^^
+
+error: register class `x87_reg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:50:20
+   |
+LL |         asm!("{}", in(x87_reg) foo);
+   |                    ^^^^^^^^^^^^^^^
+
+error: register class `mmx_reg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:53:20
+   |
+LL |         asm!("{}", in(mmx_reg) foo);
+   |                    ^^^^^^^^^^^^^^^
+
+error: register class `x87_reg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:56:20
+   |
+LL |         asm!("{}", out(x87_reg) _);
+   |                    ^^^^^^^^^^^^^^
+
+error: register class `mmx_reg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:58:20
+   |
+LL |         asm!("{}", out(mmx_reg) _);
+   |                    ^^^^^^^^^^^^^^
+
+error: register `al` conflicts with register `eax`
+  --> $DIR/bad-reg.rs:64:33
+   |
+LL |         asm!("", in("eax") foo, in("al") bar);
+   |                  -------------  ^^^^^^^^^^^^ register `al`
+   |                  |
+   |                  register `eax`
+
+error: register `rax` conflicts with register `rax`
+  --> $DIR/bad-reg.rs:67:33
+   |
+LL |         asm!("", in("rax") foo, out("rax") bar);
+   |                  -------------  ^^^^^^^^^^^^^^ register `rax`
+   |                  |
+   |                  register `rax`
+   |
+help: use `lateout` instead of `out` to avoid conflict
+  --> $DIR/bad-reg.rs:67:18
+   |
+LL |         asm!("", in("rax") foo, out("rax") bar);
+   |                  ^^^^^^^^^^^^^
+
+error: register `ymm0` conflicts with register `xmm0`
+  --> $DIR/bad-reg.rs:72:34
+   |
+LL |         asm!("", in("xmm0") foo, in("ymm0") bar);
+   |                  --------------  ^^^^^^^^^^^^^^ register `ymm0`
+   |                  |
+   |                  register `xmm0`
+
+error: register `ymm0` conflicts with register `xmm0`
+  --> $DIR/bad-reg.rs:74:34
+   |
+LL |         asm!("", in("xmm0") foo, out("ymm0") bar);
+   |                  --------------  ^^^^^^^^^^^^^^^ register `ymm0`
+   |                  |
+   |                  register `xmm0`
+   |
+help: use `lateout` instead of `out` to avoid conflict
+  --> $DIR/bad-reg.rs:74:18
+   |
+LL |         asm!("", in("xmm0") foo, out("ymm0") bar);
+   |                  ^^^^^^^^^^^^^^
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:39:30
+   |
+LL |         asm!("", in("st(2)") foo);
+   |                              ^^^
+   |
+   = note: register class `x87_reg` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:42:28
+   |
+LL |         asm!("", in("mm0") foo);
+   |                            ^^^
+   |
+   = note: register class `mmx_reg` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:45:27
+   |
+LL |         asm!("", in("k0") foo);
+   |                           ^^^
+   |
+   = note: register class `kreg0` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:50:32
+   |
+LL |         asm!("{}", in(x87_reg) foo);
+   |                                ^^^
+   |
+   = note: register class `x87_reg` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:53:32
+   |
+LL |         asm!("{}", in(mmx_reg) foo);
+   |                                ^^^
+   |
+   = note: register class `mmx_reg` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:64:42
+   |
+LL |         asm!("", in("eax") foo, in("al") bar);
+   |                                          ^^^
+   |
+   = note: register class `reg_byte` supports these types: i8
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:69:27
+   |
+LL |         asm!("", in("al") foo, lateout("al") bar);
+   |                           ^^^
+   |
+   = note: register class `reg_byte` supports these types: i8
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:69:46
+   |
+LL |         asm!("", in("al") foo, lateout("al") bar);
+   |                                              ^^^
+   |
+   = note: register class `reg_byte` supports these types: i8
+
+error: aborting due to 28 previous errors
+

--- a/tests/ui/asm/x86_64/bad-reg.stable.stderr
+++ b/tests/ui/asm/x86_64/bad-reg.stable.stderr
@@ -1,5 +1,5 @@
 error: invalid register class `foo`: unknown register class
-  --> $DIR/bad-reg.rs:12:20
+  --> $DIR/bad-reg.rs:20:20
    |
 LL |         asm!("{}", in(foo) foo);
    |                    ^^^^^^^^^^^
@@ -7,13 +7,13 @@ LL |         asm!("{}", in(foo) foo);
    = note: the following register classes are supported on this target: `reg`, `reg_abcd`, `reg_byte`, `xmm_reg`, `ymm_reg`, `zmm_reg`, `kreg`, `kreg0`, `mmx_reg`, `x87_reg`, `tmm_reg`
 
 error: invalid register `foo`: unknown register
-  --> $DIR/bad-reg.rs:14:18
+  --> $DIR/bad-reg.rs:22:18
    |
 LL |         asm!("", in("foo") foo);
    |                  ^^^^^^^^^^^^^
 
 error: invalid asm template modifier for this register class
-  --> $DIR/bad-reg.rs:16:15
+  --> $DIR/bad-reg.rs:24:15
    |
 LL |         asm!("{:z}", in(reg) foo);
    |               ^^^^   ----------- argument
@@ -23,7 +23,7 @@ LL |         asm!("{:z}", in(reg) foo);
    = note: the `reg` register class supports the following template modifiers: `l`, `x`, `e`, `r`
 
 error: invalid asm template modifier for this register class
-  --> $DIR/bad-reg.rs:18:15
+  --> $DIR/bad-reg.rs:26:15
    |
 LL |         asm!("{:r}", in(xmm_reg) foo);
    |               ^^^^   --------------- argument
@@ -33,7 +33,7 @@ LL |         asm!("{:r}", in(xmm_reg) foo);
    = note: the `xmm_reg` register class supports the following template modifiers: `x`, `y`, `z`
 
 error: asm template modifiers are not allowed for `const` arguments
-  --> $DIR/bad-reg.rs:20:15
+  --> $DIR/bad-reg.rs:28:15
    |
 LL |         asm!("{:a}", const 0);
    |               ^^^^   ------- argument
@@ -41,7 +41,7 @@ LL |         asm!("{:a}", const 0);
    |               template modifier
 
 error: asm template modifiers are not allowed for `sym` arguments
-  --> $DIR/bad-reg.rs:22:15
+  --> $DIR/bad-reg.rs:30:15
    |
 LL |         asm!("{:a}", sym main);
    |               ^^^^   -------- argument
@@ -49,67 +49,67 @@ LL |         asm!("{:a}", sym main);
    |               template modifier
 
 error: invalid register `ebp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:24:18
+  --> $DIR/bad-reg.rs:32:18
    |
 LL |         asm!("", in("ebp") foo);
    |                  ^^^^^^^^^^^^^
 
 error: invalid register `rsp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:26:18
+  --> $DIR/bad-reg.rs:34:18
    |
 LL |         asm!("", in("rsp") foo);
    |                  ^^^^^^^^^^^^^
 
 error: invalid register `ip`: the instruction pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:28:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", in("ip") foo);
    |                  ^^^^^^^^^^^^
 
 error: register class `x87_reg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:31:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", in("st(2)") foo);
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `mmx_reg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:34:18
+  --> $DIR/bad-reg.rs:42:18
    |
 LL |         asm!("", in("mm0") foo);
    |                  ^^^^^^^^^^^^^
 
 error: register class `kreg0` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:45:18
    |
 LL |         asm!("", in("k0") foo);
    |                  ^^^^^^^^^^^^
 
 error: register class `x87_reg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:42:20
+  --> $DIR/bad-reg.rs:50:20
    |
 LL |         asm!("{}", in(x87_reg) foo);
    |                    ^^^^^^^^^^^^^^^
 
 error: register class `mmx_reg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:45:20
+  --> $DIR/bad-reg.rs:53:20
    |
 LL |         asm!("{}", in(mmx_reg) foo);
    |                    ^^^^^^^^^^^^^^^
 
 error: register class `x87_reg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:48:20
+  --> $DIR/bad-reg.rs:56:20
    |
 LL |         asm!("{}", out(x87_reg) _);
    |                    ^^^^^^^^^^^^^^
 
 error: register class `mmx_reg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:50:20
+  --> $DIR/bad-reg.rs:58:20
    |
 LL |         asm!("{}", out(mmx_reg) _);
    |                    ^^^^^^^^^^^^^^
 
 error: register `al` conflicts with register `eax`
-  --> $DIR/bad-reg.rs:56:33
+  --> $DIR/bad-reg.rs:64:33
    |
 LL |         asm!("", in("eax") foo, in("al") bar);
    |                  -------------  ^^^^^^^^^^^^ register `al`
@@ -117,7 +117,7 @@ LL |         asm!("", in("eax") foo, in("al") bar);
    |                  register `eax`
 
 error: register `rax` conflicts with register `rax`
-  --> $DIR/bad-reg.rs:59:33
+  --> $DIR/bad-reg.rs:67:33
    |
 LL |         asm!("", in("rax") foo, out("rax") bar);
    |                  -------------  ^^^^^^^^^^^^^^ register `rax`
@@ -125,13 +125,13 @@ LL |         asm!("", in("rax") foo, out("rax") bar);
    |                  register `rax`
    |
 help: use `lateout` instead of `out` to avoid conflict
-  --> $DIR/bad-reg.rs:59:18
+  --> $DIR/bad-reg.rs:67:18
    |
 LL |         asm!("", in("rax") foo, out("rax") bar);
    |                  ^^^^^^^^^^^^^
 
 error: register `ymm0` conflicts with register `xmm0`
-  --> $DIR/bad-reg.rs:64:34
+  --> $DIR/bad-reg.rs:72:34
    |
 LL |         asm!("", in("xmm0") foo, in("ymm0") bar);
    |                  --------------  ^^^^^^^^^^^^^^ register `ymm0`
@@ -139,7 +139,7 @@ LL |         asm!("", in("xmm0") foo, in("ymm0") bar);
    |                  register `xmm0`
 
 error: register `ymm0` conflicts with register `xmm0`
-  --> $DIR/bad-reg.rs:66:34
+  --> $DIR/bad-reg.rs:74:34
    |
 LL |         asm!("", in("xmm0") foo, out("ymm0") bar);
    |                  --------------  ^^^^^^^^^^^^^^^ register `ymm0`
@@ -147,13 +147,13 @@ LL |         asm!("", in("xmm0") foo, out("ymm0") bar);
    |                  register `xmm0`
    |
 help: use `lateout` instead of `out` to avoid conflict
-  --> $DIR/bad-reg.rs:66:18
+  --> $DIR/bad-reg.rs:74:18
    |
 LL |         asm!("", in("xmm0") foo, out("ymm0") bar);
    |                  ^^^^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:31:30
+  --> $DIR/bad-reg.rs:39:30
    |
 LL |         asm!("", in("st(2)") foo);
    |                              ^^^
@@ -161,7 +161,7 @@ LL |         asm!("", in("st(2)") foo);
    = note: register class `x87_reg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:34:28
+  --> $DIR/bad-reg.rs:42:28
    |
 LL |         asm!("", in("mm0") foo);
    |                            ^^^
@@ -169,7 +169,7 @@ LL |         asm!("", in("mm0") foo);
    = note: register class `mmx_reg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:37:27
+  --> $DIR/bad-reg.rs:45:27
    |
 LL |         asm!("", in("k0") foo);
    |                           ^^^
@@ -177,7 +177,7 @@ LL |         asm!("", in("k0") foo);
    = note: register class `kreg0` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:42:32
+  --> $DIR/bad-reg.rs:50:32
    |
 LL |         asm!("{}", in(x87_reg) foo);
    |                                ^^^
@@ -185,7 +185,7 @@ LL |         asm!("{}", in(x87_reg) foo);
    = note: register class `x87_reg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:45:32
+  --> $DIR/bad-reg.rs:53:32
    |
 LL |         asm!("{}", in(mmx_reg) foo);
    |                                ^^^
@@ -193,7 +193,7 @@ LL |         asm!("{}", in(mmx_reg) foo);
    = note: register class `mmx_reg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:56:42
+  --> $DIR/bad-reg.rs:64:42
    |
 LL |         asm!("", in("eax") foo, in("al") bar);
    |                                          ^^^
@@ -201,7 +201,7 @@ LL |         asm!("", in("eax") foo, in("al") bar);
    = note: register class `reg_byte` supports these types: i8
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:61:27
+  --> $DIR/bad-reg.rs:69:27
    |
 LL |         asm!("", in("al") foo, lateout("al") bar);
    |                           ^^^
@@ -209,12 +209,73 @@ LL |         asm!("", in("al") foo, lateout("al") bar);
    = note: register class `reg_byte` supports these types: i8
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:61:46
+  --> $DIR/bad-reg.rs:69:46
    |
 LL |         asm!("", in("al") foo, lateout("al") bar);
    |                                              ^^^
    |
    = note: register class `reg_byte` supports these types: i8
 
-error: aborting due to 28 previous errors
+error[E0658]: type `u128` cannot be used with this register class in stable
+  --> $DIR/bad-reg.rs:81:40
+   |
+LL |         asm!("/* {:x} */", in(xmm_reg) xmmword); // requires asm_experimental_reg
+   |                                        ^^^^^^^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error[E0658]: type `u128` cannot be used with this register class in stable
+  --> $DIR/bad-reg.rs:83:41
+   |
+LL |         asm!("/* {:x} */", out(xmm_reg) xmmword); // requires asm_experimental_reg
+   |                                         ^^^^^^^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: type `u128` cannot be used with this register class in stable
+  --> $DIR/bad-reg.rs:86:40
+   |
+LL |         asm!("/* {:y} */", in(ymm_reg) xmmword); // requires asm_experimental_reg
+   |                                        ^^^^^^^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: type `u128` cannot be used with this register class in stable
+  --> $DIR/bad-reg.rs:88:41
+   |
+LL |         asm!("/* {:y} */", out(ymm_reg) xmmword); // requires asm_experimental_reg
+   |                                         ^^^^^^^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: type `u128` cannot be used with this register class in stable
+  --> $DIR/bad-reg.rs:91:40
+   |
+LL |         asm!("/* {:z} */", in(zmm_reg) xmmword); // requires asm_experimental_reg
+   |                                        ^^^^^^^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: type `u128` cannot be used with this register class in stable
+  --> $DIR/bad-reg.rs:93:41
+   |
+LL |         asm!("/* {:z} */", out(zmm_reg) xmmword); // requires asm_experimental_reg
+   |                                         ^^^^^^^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 34 previous errors
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/133416

Seems like an oversight. LLVM has supported this since 2019, see https://github.com/llvm/llvm-project/issues/42502. I've put this under `asm_experimental_reg`.

cc @taiki-e 
r? @Amanieu 
