### PR TITLE
Avoid should-fail in two ui tests and a codegen-llvm test

### DIFF
--- a/tests/codegen-llvm/option-niche-unfixed/option-nonzero-eq.rs
+++ b/tests/codegen-llvm/option-niche-unfixed/option-nonzero-eq.rs
@@ -1,6 +1,5 @@
-//@ should-fail
+//@ known-bug: #49892
 //@ compile-flags: -Copt-level=3 -Zmerge-functions=disabled
-//! FIXME(#49892)
 //! Test that the derived implementation of `PartialEq` for `Option` is not fully
 //! optimized by LLVM. If this starts passing, the test and manual impl should
 //! be removed.
@@ -18,7 +17,7 @@ pub enum Option<T> {
 #[no_mangle]
 pub fn non_zero_eq(l: Option<NonZero<u32>>, r: Option<NonZero<u32>>) -> bool {
     // CHECK: start:
-    // CHECK-NEXT: icmp eq i32
-    // CHECK-NEXT: ret i1
+    // COMMENTEDCHECK-NEXT: icmp eq i32
+    // COMMENTEDCHECK-NEXT: ret i1
     l == r
 }

--- a/tests/ui/borrowck/two-phase-reservation-sharing-interference.rs
+++ b/tests/ui/borrowck/two-phase-reservation-sharing-interference.rs
@@ -3,7 +3,7 @@
 // The nll_beyond revision is disabled due to missing support from two-phase beyond autorefs
 //@ unused-revision-names: nll_beyond
 //@[nll_beyond]compile-flags: -Z two-phase-beyond-autoref
-//@[nll_beyond]should-fail
+//@[nll_beyond]check-fail
 
 // This is a corner case that the current implementation is (probably)
 // treating more conservatively than is necessary. But it also does

--- a/tests/ui/type-inference/box_has_sigdrop.rs
+++ b/tests/ui/type-inference/box_has_sigdrop.rs
@@ -1,4 +1,4 @@
-//@ should-fail
+//@ known-bug: unknown
 //@ compile-flags: -Wrust-2021-incompatible-closure-captures
 // Inference, canonicalization, and significant drops should work nicely together.
 // Related issue: #86868


### PR DESCRIPTION
`should-fail` is only meant for testing the compiletest framework itself. It checks that the test runner itself panicked.

With this there are still a bunch of rustdoc-html tests that use it due to this test suite not supporting anything like `//@ doc-fail`.