### PR TITLE
also handle ENOTTY ioctl errors when checking pidfd -> pid support

### DIFF
--- a/library/std/src/sys/pal/unix/linux/pidfd.rs
+++ b/library/std/src/sys/pal/unix/linux/pidfd.rs
@@ -33,7 +33,7 @@ impl PidFd {
         match cvt(unsafe { libc::ioctl(self.0.as_raw_fd(), libc::PIDFD_GET_INFO, &mut pidfd_info) })
         {
             Ok(_) => {}
-            Err(e) if e.raw_os_error() == Some(libc::EINVAL) => {
+            Err(e) if matches!(e.raw_os_error(), Some(libc::EINVAL | libc::ENOTTY)) => {
                 // kernel doesn't support that ioctl, try the glibc helper that looks at procfs
                 weak!(
                     fn pidfd_getpid(pidfd: RawFd) -> libc::pid_t;


### PR DESCRIPTION
Otherwise the std testsuite fails on older kernels.

Reported in https://github.com/rust-lang/rust/pull/150412#issuecomment-3744390883

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
