### PR TITLE
resolve: Split `extern_ambiguous_glob_imports` to a separate lint

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -41,6 +41,7 @@ declare_lint_pass! {
         ELIDED_LIFETIMES_IN_PATHS,
         EXPLICIT_BUILTIN_CFGS_IN_FLAGS,
         EXPORTED_PRIVATE_DEPENDENCIES,
+        EXTERN_AMBIGUOUS_GLOB_IMPORTS,
         FFI_UNWIND_CALLS,
         FORBIDDEN_LINT_GROUPS,
         FUNCTION_ITEM_REFERENCES,
@@ -4431,6 +4432,7 @@ declare_lint! {
     Warn,
     "detects diagnostic attribute with malformed diagnostic format literals",
 }
+
 declare_lint! {
     /// The `ambiguous_glob_imports` lint detects glob imports that should report ambiguity
     /// errors, but previously didn't do that due to rustc bugs.
@@ -4470,6 +4472,42 @@ declare_lint! {
     @future_incompatible = FutureIncompatibleInfo {
         reason: fcw!(FutureReleaseError #114095),
         report_in_deps: true,
+    };
+}
+
+declare_lint! {
+    /// Same as `ambiguous_glob_imports`, but when the ambiguous import comes from another crate.
+    /// Split to a separate lint to soften the migration.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,ignore (needs extern crate)
+    /// // crate A
+    /// mod mod1 { pub const C: u32 = 1; }
+    /// mod mod2 { pub const C: u32 = 2; }
+    ///
+    /// pub use mod1::*;
+    /// pub use mod2::*;
+    ///
+    /// // crate B
+    /// let c = crate_a::C; // ERROR: `C` is ambiguous
+    /// ```
+    ///
+    /// ### Explanation
+    ///
+    /// Previous versions of Rust compiled it successfully because inforation about ambiguous
+    /// imports weren't properly recorded into crate metadata.
+    ///
+    /// This is a [future-incompatible] lint to transition this to a
+    /// hard error in the future.
+    ///
+    /// [future-incompatible]: ../index.md#future-incompatible-lints
+    pub EXTERN_AMBIGUOUS_GLOB_IMPORTS,
+    Warn,
+    "detects certain glob imports that require reporting an ambiguity error",
+    @future_incompatible = FutureIncompatibleInfo {
+        reason: fcw!(FutureReleaseError #114095),
+        report_in_deps: false,
     };
 }
 

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -91,7 +91,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         let decl = self.arenas.alloc_decl(DeclData {
             kind: DeclKind::Def(res),
             ambiguity: CmCell::new(ambiguity),
-            // External ambiguities always report the `AMBIGUOUS_GLOB_IMPORTS` lint at the moment.
+            // External ambiguities always report the `EXTERN_AMBIGUOUS_GLOB_IMPORTS` lint at the moment.
             warn_ambiguity: CmCell::new(true),
             vis: CmCell::new(vis),
             span,

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -25,7 +25,7 @@ use rustc_session::Session;
 use rustc_session::lint::BuiltinLintDiag;
 use rustc_session::lint::builtin::{
     ABSOLUTE_PATHS_NOT_STARTING_WITH_CRATE, AMBIGUOUS_GLOB_IMPORTS, AMBIGUOUS_PANIC_IMPORTS,
-    MACRO_EXPANDED_MACRO_EXPORTS_ACCESSED_BY_ABSOLUTE_PATHS,
+    EXTERN_AMBIGUOUS_GLOB_IMPORTS, MACRO_EXPANDED_MACRO_EXPORTS_ACCESSED_BY_ABSOLUTE_PATHS,
 };
 use rustc_session::utils::was_invoked_from_cargo;
 use rustc_span::edit_distance::find_best_match_for_name;
@@ -154,6 +154,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 };
 
                 let lint = match ambiguity_warning {
+                    AmbiguityWarning::GlobImport if node_id == CRATE_NODE_ID => {
+                        EXTERN_AMBIGUOUS_GLOB_IMPORTS
+                    }
                     AmbiguityWarning::GlobImport => AMBIGUOUS_GLOB_IMPORTS,
                     AmbiguityWarning::PanicImport => AMBIGUOUS_PANIC_IMPORTS,
                 };

--- a/tests/ui/imports/ambiguous-2.rs
+++ b/tests/ui/imports/ambiguous-2.rs
@@ -1,9 +1,10 @@
+//@ check-pass
 //@ aux-build: ../ambiguous-1.rs
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1633574396
 
 extern crate ambiguous_1;
 
 fn main() {
-    ambiguous_1::id(); //~ ERROR `id` is ambiguous
+    ambiguous_1::id(); //~ WARN `id` is ambiguous
                        //~| WARN this was previously accepted
 }

--- a/tests/ui/imports/ambiguous-2.stderr
+++ b/tests/ui/imports/ambiguous-2.stderr
@@ -1,5 +1,5 @@
-error: `id` is ambiguous
-  --> $DIR/ambiguous-2.rs:7:18
+warning: `id` is ambiguous
+  --> $DIR/ambiguous-2.rs:8:18
    |
 LL |     ambiguous_1::id();
    |                  ^^ ambiguous name
@@ -17,29 +17,7 @@ note: `id` could also refer to the function defined here
    |
 LL |     pub use self::handwritten::*;
    |             ^^^^^^^^^^^^^^^^^
-   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+   = note: `#[warn(extern_ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
 
-error: aborting due to 1 previous error
-
-Future incompatibility report: Future breakage diagnostic:
-error: `id` is ambiguous
-  --> $DIR/ambiguous-2.rs:7:18
-   |
-LL |     ambiguous_1::id();
-   |                  ^^ ambiguous name
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
-   = note: ambiguous because of multiple glob imports of a name in the same module
-note: `id` could refer to the function defined here
-  --> $DIR/auxiliary/../ambiguous-1.rs:13:13
-   |
-LL |     pub use self::evp::*;
-   |             ^^^^^^^^^
-note: `id` could also refer to the function defined here
-  --> $DIR/auxiliary/../ambiguous-1.rs:15:13
-   |
-LL |     pub use self::handwritten::*;
-   |             ^^^^^^^^^^^^^^^^^
-   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+warning: 1 warning emitted
 

--- a/tests/ui/imports/ambiguous-4.rs
+++ b/tests/ui/imports/ambiguous-4.rs
@@ -1,9 +1,10 @@
+//@ check-pass
 //@ edition:2015
 //@ aux-build: ../ambiguous-4-extern.rs
 
 extern crate ambiguous_4_extern;
 
 fn main() {
-    ambiguous_4_extern::id(); //~ ERROR `id` is ambiguous
+    ambiguous_4_extern::id(); //~ WARN `id` is ambiguous
                               //~| WARN this was previously accepted
 }

--- a/tests/ui/imports/ambiguous-4.stderr
+++ b/tests/ui/imports/ambiguous-4.stderr
@@ -1,5 +1,5 @@
-error: `id` is ambiguous
-  --> $DIR/ambiguous-4.rs:7:25
+warning: `id` is ambiguous
+  --> $DIR/ambiguous-4.rs:8:25
    |
 LL |     ambiguous_4_extern::id();
    |                         ^^ ambiguous name
@@ -17,29 +17,7 @@ note: `id` could also refer to the function defined here
    |
 LL | pub use handwritten::*;
    |         ^^^^^^^^^^^
-   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+   = note: `#[warn(extern_ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
 
-error: aborting due to 1 previous error
-
-Future incompatibility report: Future breakage diagnostic:
-error: `id` is ambiguous
-  --> $DIR/ambiguous-4.rs:7:25
-   |
-LL |     ambiguous_4_extern::id();
-   |                         ^^ ambiguous name
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
-   = note: ambiguous because of multiple glob imports of a name in the same module
-note: `id` could refer to the function defined here
-  --> $DIR/auxiliary/../ambiguous-4-extern.rs:13:9
-   |
-LL | pub use evp::*;
-   |         ^^^
-note: `id` could also refer to the function defined here
-  --> $DIR/auxiliary/../ambiguous-4-extern.rs:14:9
-   |
-LL | pub use handwritten::*;
-   |         ^^^^^^^^^^^
-   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+warning: 1 warning emitted
 

--- a/tests/ui/imports/glob-conflict-cross-crate-1.rs
+++ b/tests/ui/imports/glob-conflict-cross-crate-1.rs
@@ -1,11 +1,12 @@
+//@ check-pass
 //@ edition:2015
 //@ aux-build:glob-conflict.rs
 
 extern crate glob_conflict;
 
 fn main() {
-    glob_conflict::f(); //~ ERROR `f` is ambiguous
+    glob_conflict::f(); //~ WARN `f` is ambiguous
                         //~| WARN this was previously accepted
-    glob_conflict::glob::f(); //~ ERROR `f` is ambiguous
+    glob_conflict::glob::f(); //~ WARN `f` is ambiguous
                               //~| WARN this was previously accepted
 }

--- a/tests/ui/imports/glob-conflict-cross-crate-1.stderr
+++ b/tests/ui/imports/glob-conflict-cross-crate-1.stderr
@@ -1,5 +1,5 @@
-error: `f` is ambiguous
-  --> $DIR/glob-conflict-cross-crate-1.rs:7:20
+warning: `f` is ambiguous
+  --> $DIR/glob-conflict-cross-crate-1.rs:8:20
    |
 LL |     glob_conflict::f();
    |                    ^ ambiguous name
@@ -17,10 +17,10 @@ note: `f` could also refer to the function defined here
    |
 LL | pub use m2::*;
    |         ^^
-   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+   = note: `#[warn(extern_ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
 
-error: `f` is ambiguous
-  --> $DIR/glob-conflict-cross-crate-1.rs:9:26
+warning: `f` is ambiguous
+  --> $DIR/glob-conflict-cross-crate-1.rs:10:26
    |
 LL |     glob_conflict::glob::f();
    |                          ^ ambiguous name
@@ -39,49 +39,5 @@ note: `f` could also refer to the function defined here
 LL | pub use m2::*;
    |         ^^
 
-error: aborting due to 2 previous errors
-
-Future incompatibility report: Future breakage diagnostic:
-error: `f` is ambiguous
-  --> $DIR/glob-conflict-cross-crate-1.rs:7:20
-   |
-LL |     glob_conflict::f();
-   |                    ^ ambiguous name
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
-   = note: ambiguous because of multiple glob imports of a name in the same module
-note: `f` could refer to the function defined here
-  --> $DIR/auxiliary/glob-conflict.rs:12:9
-   |
-LL | pub use m1::*;
-   |         ^^
-note: `f` could also refer to the function defined here
-  --> $DIR/auxiliary/glob-conflict.rs:13:9
-   |
-LL | pub use m2::*;
-   |         ^^
-   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
-
-Future breakage diagnostic:
-error: `f` is ambiguous
-  --> $DIR/glob-conflict-cross-crate-1.rs:9:26
-   |
-LL |     glob_conflict::glob::f();
-   |                          ^ ambiguous name
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
-   = note: ambiguous because of multiple glob imports of a name in the same module
-note: `f` could refer to the function defined here
-  --> $DIR/auxiliary/glob-conflict.rs:12:9
-   |
-LL | pub use m1::*;
-   |         ^^
-note: `f` could also refer to the function defined here
-  --> $DIR/auxiliary/glob-conflict.rs:13:9
-   |
-LL | pub use m2::*;
-   |         ^^
-   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+warning: 2 warnings emitted
 

--- a/tests/ui/imports/glob-conflict-cross-crate-2.rs
+++ b/tests/ui/imports/glob-conflict-cross-crate-2.rs
@@ -1,3 +1,5 @@
+//@ check-pass
+//@ edition:2015
 //@ aux-build:glob-conflict-cross-crate-2-extern.rs
 
 extern crate glob_conflict_cross_crate_2_extern;
@@ -5,6 +7,6 @@ extern crate glob_conflict_cross_crate_2_extern;
 use glob_conflict_cross_crate_2_extern::*;
 
 fn main() {
-    let _a: C = 1; //~ ERROR `C` is ambiguous
+    let _a: C = 1; //~ WARN `C` is ambiguous
                    //~| WARN this was previously accepted
 }

--- a/tests/ui/imports/glob-conflict-cross-crate-2.stderr
+++ b/tests/ui/imports/glob-conflict-cross-crate-2.stderr
@@ -1,5 +1,5 @@
-error: `C` is ambiguous
-  --> $DIR/glob-conflict-cross-crate-2.rs:8:13
+warning: `C` is ambiguous
+  --> $DIR/glob-conflict-cross-crate-2.rs:10:13
    |
 LL |     let _a: C = 1;
    |             ^ ambiguous name
@@ -17,29 +17,7 @@ note: `C` could also refer to the type alias defined here
    |
 LL | pub use b::*;
    |         ^
-   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+   = note: `#[warn(extern_ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
 
-error: aborting due to 1 previous error
-
-Future incompatibility report: Future breakage diagnostic:
-error: `C` is ambiguous
-  --> $DIR/glob-conflict-cross-crate-2.rs:8:13
-   |
-LL |     let _a: C = 1;
-   |             ^ ambiguous name
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
-   = note: ambiguous because of multiple glob imports of a name in the same module
-note: `C` could refer to the type alias defined here
-  --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:9:9
-   |
-LL | pub use a::*;
-   |         ^
-note: `C` could also refer to the type alias defined here
-  --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:10:9
-   |
-LL | pub use b::*;
-   |         ^
-   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+warning: 1 warning emitted
 

--- a/tests/ui/imports/glob-conflict-cross-crate-3.rs
+++ b/tests/ui/imports/glob-conflict-cross-crate-3.rs
@@ -12,7 +12,7 @@ use a::*;
 fn main() {
     let _a: C = 1;
     //~^ ERROR `C` is ambiguous
-    //~| ERROR `C` is ambiguous
+    //~| WARN `C` is ambiguous
     //~| WARN this was previously accepted
     //~| WARN this was previously accepted
 }

--- a/tests/ui/imports/glob-conflict-cross-crate-3.stderr
+++ b/tests/ui/imports/glob-conflict-cross-crate-3.stderr
@@ -1,4 +1,4 @@
-error: `C` is ambiguous
+warning: `C` is ambiguous
   --> $DIR/glob-conflict-cross-crate-3.rs:13:13
    |
 LL |     let _a: C = 1;
@@ -17,7 +17,7 @@ note: `C` could also refer to the type alias defined here
    |
 LL | pub use b::*;
    |         ^
-   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+   = note: `#[warn(extern_ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
 
 error: `C` is ambiguous
   --> $DIR/glob-conflict-cross-crate-3.rs:13:13
@@ -40,32 +40,11 @@ note: `C` could also refer to the type alias imported here
 LL | use a::*;
    |     ^^^^
    = help: consider adding an explicit import of `C` to disambiguate
-
-error: aborting due to 2 previous errors
-
-Future incompatibility report: Future breakage diagnostic:
-error: `C` is ambiguous
-  --> $DIR/glob-conflict-cross-crate-3.rs:13:13
-   |
-LL |     let _a: C = 1;
-   |             ^ ambiguous name
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
-   = note: ambiguous because of multiple glob imports of a name in the same module
-note: `C` could refer to the type alias defined here
-  --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:9:9
-   |
-LL | pub use a::*;
-   |         ^
-note: `C` could also refer to the type alias defined here
-  --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:10:9
-   |
-LL | pub use b::*;
-   |         ^
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-Future breakage diagnostic:
+error: aborting due to 1 previous error; 1 warning emitted
+
+Future incompatibility report: Future breakage diagnostic:
 error: `C` is ambiguous
   --> $DIR/glob-conflict-cross-crate-3.rs:13:13
    |

--- a/tests/ui/imports/issue-114682-2.rs
+++ b/tests/ui/imports/issue-114682-2.rs
@@ -1,12 +1,13 @@
+//@ check-pass
 //@ aux-build: issue-114682-2-extern.rs
 // https://github.com/rust-lang/rust/pull/114682#issuecomment-1879998900
 
 extern crate issue_114682_2_extern;
 
-use issue_114682_2_extern::max; //~ ERROR `max` is ambiguous
+use issue_114682_2_extern::max; //~ WARN `max` is ambiguous
                                 //~| WARN this was previously accepted
 
-type A = issue_114682_2_extern::max; //~ ERROR `max` is ambiguous
+type A = issue_114682_2_extern::max; //~ WARN `max` is ambiguous
                                      //~| WARN this was previously accepted
 
 fn main() {}

--- a/tests/ui/imports/issue-114682-2.stderr
+++ b/tests/ui/imports/issue-114682-2.stderr
@@ -1,5 +1,5 @@
-error: `max` is ambiguous
-  --> $DIR/issue-114682-2.rs:6:28
+warning: `max` is ambiguous
+  --> $DIR/issue-114682-2.rs:7:28
    |
 LL | use issue_114682_2_extern::max;
    |                            ^^^ ambiguous name
@@ -17,10 +17,10 @@ note: `max` could also refer to the module defined here
    |
 LL | pub use self::d::*;
    |         ^^^^^^^
-   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+   = note: `#[warn(extern_ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
 
-error: `max` is ambiguous
-  --> $DIR/issue-114682-2.rs:9:33
+warning: `max` is ambiguous
+  --> $DIR/issue-114682-2.rs:10:33
    |
 LL | type A = issue_114682_2_extern::max;
    |                                 ^^^ ambiguous name
@@ -39,49 +39,5 @@ note: `max` could also refer to the module defined here
 LL | pub use self::d::*;
    |         ^^^^^^^
 
-error: aborting due to 2 previous errors
-
-Future incompatibility report: Future breakage diagnostic:
-error: `max` is ambiguous
-  --> $DIR/issue-114682-2.rs:6:28
-   |
-LL | use issue_114682_2_extern::max;
-   |                            ^^^ ambiguous name
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
-   = note: ambiguous because of multiple glob imports of a name in the same module
-note: `max` could refer to the type alias defined here
-  --> $DIR/auxiliary/issue-114682-2-extern.rs:17:9
-   |
-LL | pub use self::e::*;
-   |         ^^^^^^^
-note: `max` could also refer to the module defined here
-  --> $DIR/auxiliary/issue-114682-2-extern.rs:16:9
-   |
-LL | pub use self::d::*;
-   |         ^^^^^^^
-   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
-
-Future breakage diagnostic:
-error: `max` is ambiguous
-  --> $DIR/issue-114682-2.rs:9:33
-   |
-LL | type A = issue_114682_2_extern::max;
-   |                                 ^^^ ambiguous name
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
-   = note: ambiguous because of multiple glob imports of a name in the same module
-note: `max` could refer to the type alias defined here
-  --> $DIR/auxiliary/issue-114682-2-extern.rs:17:9
-   |
-LL | pub use self::e::*;
-   |         ^^^^^^^
-note: `max` could also refer to the module defined here
-  --> $DIR/auxiliary/issue-114682-2-extern.rs:16:9
-   |
-LL | pub use self::d::*;
-   |         ^^^^^^^
-   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+warning: 2 warnings emitted
 

--- a/tests/ui/imports/issue-114682-4.rs
+++ b/tests/ui/imports/issue-114682-4.rs
@@ -6,7 +6,7 @@ extern crate issue_114682_4_extern;
 use issue_114682_4_extern::*;
 
 //~v ERROR type alias takes 1 generic argument but 2 generic arguments were supplied
-fn a() -> Result<i32, ()> { //~ ERROR `Result` is ambiguous
+fn a() -> Result<i32, ()> { //~ WARN `Result` is ambiguous
                             //~| WARN this was previously accepted
     Ok(1)
 }

--- a/tests/ui/imports/issue-114682-4.stderr
+++ b/tests/ui/imports/issue-114682-4.stderr
@@ -1,4 +1,4 @@
-error: `Result` is ambiguous
+warning: `Result` is ambiguous
   --> $DIR/issue-114682-4.rs:9:11
    |
 LL | fn a() -> Result<i32, ()> {
@@ -17,7 +17,7 @@ note: `Result` could also refer to the type alias defined here
    |
 LL | pub use b::*;
    |         ^
-   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+   = note: `#[warn(extern_ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
 
 error[E0107]: type alias takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/issue-114682-4.rs:9:11
@@ -33,28 +33,6 @@ note: type alias defined here, with 1 generic parameter: `T`
 LL |     pub type Result<T> = std::result::Result<T, ()>;
    |              ^^^^^^ -
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0107`.
-Future incompatibility report: Future breakage diagnostic:
-error: `Result` is ambiguous
-  --> $DIR/issue-114682-4.rs:9:11
-   |
-LL | fn a() -> Result<i32, ()> {
-   |           ^^^^^^ ambiguous name
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
-   = note: ambiguous because of multiple glob imports of a name in the same module
-note: `Result` could refer to the type alias defined here
-  --> $DIR/auxiliary/issue-114682-4-extern.rs:9:9
-   |
-LL | pub use a::*;
-   |         ^
-note: `Result` could also refer to the type alias defined here
-  --> $DIR/auxiliary/issue-114682-4-extern.rs:10:9
-   |
-LL | pub use b::*;
-   |         ^
-   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
-

--- a/tests/ui/imports/issue-114682-5.rs
+++ b/tests/ui/imports/issue-114682-5.rs
@@ -9,7 +9,7 @@ extern crate issue_114682_5_extern_2;
 use issue_114682_5_extern_2::p::*;
 use issue_114682_5_extern_1::Url;
 //~^ ERROR `issue_114682_5_extern_1` is ambiguous
-//~| ERROR `issue_114682_5_extern_1` is ambiguous
+//~| WARN `issue_114682_5_extern_1` is ambiguous
 //~| ERROR unresolved import `issue_114682_5_extern_1::Url`
 //~| WARN this was previously accepted
 

--- a/tests/ui/imports/issue-114682-5.stderr
+++ b/tests/ui/imports/issue-114682-5.stderr
@@ -26,7 +26,7 @@ LL | use issue_114682_5_extern_2::p::*;
    = help: consider adding an explicit import of `issue_114682_5_extern_1` to disambiguate
    = help: or use `crate::issue_114682_5_extern_1` to refer to this module unambiguously
 
-error: `issue_114682_5_extern_1` is ambiguous
+warning: `issue_114682_5_extern_1` is ambiguous
   --> $DIR/issue-114682-5.rs:10:5
    |
 LL | use issue_114682_5_extern_1::Url;
@@ -46,32 +46,9 @@ note: `issue_114682_5_extern_1` could also refer to the crate defined here
 LL |     pub use crate::*;
    |             ^^^^^
    = help: use `::issue_114682_5_extern_1` to refer to this crate unambiguously
-   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+   = note: `#[warn(extern_ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0432, E0659.
 For more information about an error, try `rustc --explain E0432`.
-Future incompatibility report: Future breakage diagnostic:
-error: `issue_114682_5_extern_1` is ambiguous
-  --> $DIR/issue-114682-5.rs:10:5
-   |
-LL | use issue_114682_5_extern_1::Url;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ ambiguous name
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
-   = note: ambiguous because of multiple glob imports of a name in the same module
-note: `issue_114682_5_extern_1` could refer to the module defined here
-  --> $DIR/auxiliary/issue-114682-5-extern-2.rs:6:13
-   |
-LL |     pub use crate::types::*;
-   |             ^^^^^^^^^^^^
-note: `issue_114682_5_extern_1` could also refer to the crate defined here
-  --> $DIR/auxiliary/issue-114682-5-extern-2.rs:7:13
-   |
-LL |     pub use crate::*;
-   |             ^^^^^
-   = help: use `::issue_114682_5_extern_1` to refer to this crate unambiguously
-   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
-

--- a/tests/ui/imports/issue-114682-6.rs
+++ b/tests/ui/imports/issue-114682-6.rs
@@ -1,3 +1,4 @@
+//@ check-pass
 //@ aux-build: issue-114682-6-extern.rs
 // https://github.com/rust-lang/rust/pull/114682#issuecomment-1880755441
 
@@ -6,7 +7,7 @@ extern crate issue_114682_6_extern;
 use issue_114682_6_extern::*;
 
 fn main() {
-    let log = 2; //~ ERROR `log` is ambiguous
+    let log = 2; //~ WARN `log` is ambiguous
                  //~| WARN this was previously accepted
     let _ = log;
 }

--- a/tests/ui/imports/issue-114682-6.stderr
+++ b/tests/ui/imports/issue-114682-6.stderr
@@ -1,5 +1,5 @@
-error: `log` is ambiguous
-  --> $DIR/issue-114682-6.rs:9:9
+warning: `log` is ambiguous
+  --> $DIR/issue-114682-6.rs:10:9
    |
 LL |     let log = 2;
    |         ^^^ ambiguous name
@@ -17,29 +17,7 @@ note: `log` could also refer to the function defined here
    |
 LL | pub use self::b::*;
    |         ^^^^^^^
-   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+   = note: `#[warn(extern_ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
 
-error: aborting due to 1 previous error
-
-Future incompatibility report: Future breakage diagnostic:
-error: `log` is ambiguous
-  --> $DIR/issue-114682-6.rs:9:9
-   |
-LL |     let log = 2;
-   |         ^^^ ambiguous name
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
-   = note: ambiguous because of multiple glob imports of a name in the same module
-note: `log` could refer to the function defined here
-  --> $DIR/auxiliary/issue-114682-6-extern.rs:8:9
-   |
-LL | pub use self::a::*;
-   |         ^^^^^^^
-note: `log` could also refer to the function defined here
-  --> $DIR/auxiliary/issue-114682-6-extern.rs:9:9
-   |
-LL | pub use self::b::*;
-   |         ^^^^^^^
-   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+warning: 1 warning emitted
 


### PR DESCRIPTION
from `ambiguous_glob_imports`, which is only reported for crate-local cases now.
The new lint is weaker than `ambiguous_glob_imports` - it's warn-by-default and not reported in dependencies.

This is a potential course of action for https://github.com/rust-lang/rust/issues/149845.
Another alternative (besides not doing anything) would be to weaken `ambiguous_glob_imports` itself for 1-2 release cycles.