### PR TITLE
Recognize potential `impl<const N: usize>` to `impl<N>` mistake

### DIFF
--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -868,6 +868,19 @@ pub(crate) struct UnexpectedResChangeTyToConstParamSugg {
 }
 
 #[derive(Subdiagnostic)]
+#[multipart_suggestion(
+    resolve_unexpected_res_change_ty_to_const_param_sugg,
+    applicability = "has-placeholders",
+    style = "verbose"
+)]
+pub(crate) struct UnexpectedResChangeTyParamToConstParamSugg {
+    #[suggestion_part(code = "const ")]
+    pub before: Span,
+    #[suggestion_part(code = ": /* Type */")]
+    pub after: Span,
+}
+
+#[derive(Subdiagnostic)]
 #[suggestion(
     resolve_unexpected_res_use_at_op_in_slice_pat_with_range_sugg,
     code = "{snippet}",

--- a/tests/ui/const-generics/generic_const_exprs/issue-69654.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-69654.stderr
@@ -5,6 +5,11 @@ LL | impl<T> Bar<T> for [u8; T] {}
    |      -                  ^ not a value
    |      |
    |      found this type parameter
+   |
+help: you might have meant to write a const parameter here
+   |
+LL | impl<const T: /* Type */> Bar<T> for [u8; T] {}
+   |      +++++  ++++++++++++
 
 error[E0599]: the function or associated item `foo` exists for struct `Foo<_>`, but its trait bounds were not satisfied
   --> $DIR/issue-69654.rs:17:10


### PR DESCRIPTION
When encountering code like `impl<N> Bar<N> for [u8; N]`, suggest `impl<const N: Type> Bar<N> for [u8; N]` as a possibility.

```
error[E0423]: expected value, found type parameter `T`
  --> $DIR/issue-69654.rs:5:25
   |
LL | impl<T> Bar<T> for [u8; T] {}
   |      -                  ^ not a value
   |      |
   |      found this type parameter
   |
help: you might have meant to write a const parameter here
   |
LL | impl<const T: Type> Bar<T> for [u8; T] {}
   |      +++++  ++++++
```

Addresses "case 3" from rust-lang/rust#84327.