### PR TITLE
fix(build-manifest): enable docs target fallback for `rustc-docs`

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -14,11 +14,11 @@ use crate::versions::{PkgType, Versions};
 
 include!(concat!(env!("OUT_DIR"), "/targets.rs"));
 
-/// This allows the manifest to contain rust-docs for hosts that don't build
-/// docs.
+/// This allows the manifest to contain rust-docs and rustc-docs for hosts
+/// that don't build certain docs.
 ///
 /// Tuples of `(host_partial, host_instead)`. If the host does not have the
-/// rust-docs component available, then if the host name contains
+/// corresponding docs component available, then if the host name contains
 /// `host_partial`, it will use the docs from `host_instead` instead.
 ///
 /// The order here matters, more specific entries should be first.
@@ -392,9 +392,9 @@ impl Builder {
                     let t = Target::from_compressed_tar(self, &tarball_name!(fallback_target));
                     // Fallbacks should typically be available on 'production' builds
                     // but may not be available for try builds, which only build one target by
-                    // default. Ideally we'd gate this being a hard error on whether we're in a
-                    // production build or not, but it's not information that's readily available
-                    // here.
+                    // default. It is also possible that `rust-docs` and `rustc-docs` differ in
+                    // availability per target. Thus, we take the first available fallback we can
+                    // find.
                     if !t.available {
                         eprintln!(
                             "{:?} not available for fallback",

--- a/src/tools/build-manifest/src/versions.rs
+++ b/src/tools/build-manifest/src/versions.rs
@@ -133,10 +133,7 @@ impl PkgType {
 
     /// Whether to package these target-specific docs for another similar target.
     pub(crate) fn use_docs_fallback(&self) -> bool {
-        match self {
-            PkgType::JsonDocs | PkgType::HtmlDocs => true,
-            _ => false,
-        }
+        matches!(self, PkgType::JsonDocs | PkgType::HtmlDocs | PkgType::RustcDocs)
     }
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->

Part of https://github.com/rust-lang/rustup/issues/3717.

Closes https://github.com/rust-lang/rust/issues/150598 by reusing the existing "target fallback" mechanism prepared for `rust-docs` for `rustc-docs` as well.

This decision is made because the consensus in both the issue thread and the [Zulip thread](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/rustc.20docs.20dist.20path/with/565443290) seems to be that it's okay to distribute a existing prebuilt `rustc-docs` component in the place of `rustc-docs-<host-target>` when the latter isn't directly available.

Adjusted the docstrings accordingly following my understanding of the current logic.

cc @jieyouxu 

### Concerns

- [ ] Can we properly test the effects of this patch before shipping so that I can make sure this is doing the right thing?

<!-- homu-ignore:end -->
