### PR TITLE
Silence unused type param error on struct parse error

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -4525,6 +4525,26 @@ impl ItemKind<'_> {
             _ => return None,
         })
     }
+
+    pub fn recovered(&self) -> bool {
+        match self {
+            ItemKind::Struct(
+                _,
+                _,
+                VariantData::Struct { recovered: ast::Recovered::Yes(_), .. },
+            ) => true,
+            ItemKind::Union(
+                _,
+                _,
+                VariantData::Struct { recovered: ast::Recovered::Yes(_), .. },
+            ) => true,
+            ItemKind::Enum(_, _, def) => def.variants.iter().any(|v| match v.data {
+                VariantData::Struct { recovered: ast::Recovered::Yes(_), .. } => true,
+                _ => false,
+            }),
+            _ => false,
+        }
+    }
 }
 
 // The bodies for items are stored "out of line", in a separate

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -2160,7 +2160,12 @@ fn report_bivariance<'tcx>(
         const_param_help,
     });
     diag.code(E0392);
-    diag.emit()
+    if item.kind.recovered() {
+        // Silence potentially redundant error, as the item had a parse error.
+        diag.delay_as_bug()
+    } else {
+        diag.emit()
+    }
 }
 
 /// Detects cases where an ADT/LTA is trivially cyclical -- we want to detect this so

--- a/tests/ui/structs/parse-error-with-type-param.fixed
+++ b/tests/ui/structs/parse-error-with-type-param.fixed
@@ -1,0 +1,14 @@
+//@ run-rustfix
+// #141403
+#![allow(dead_code)]
+
+#[derive(Clone)]
+struct B<T> {
+    a: A<(T, u32)>, // <- note, comma is missing here
+    /// asdf
+    //~^ ERROR found a documentation comment that doesn't document anything
+    b: u32,
+}
+#[derive(Clone)]
+struct A<T>(T);
+fn main() {}

--- a/tests/ui/structs/parse-error-with-type-param.rs
+++ b/tests/ui/structs/parse-error-with-type-param.rs
@@ -1,0 +1,14 @@
+//@ run-rustfix
+// #141403
+#![allow(dead_code)]
+
+#[derive(Clone)]
+struct B<T> {
+    a: A<(T, u32)> // <- note, comma is missing here
+    /// asdf
+    //~^ ERROR found a documentation comment that doesn't document anything
+    b: u32,
+}
+#[derive(Clone)]
+struct A<T>(T);
+fn main() {}

--- a/tests/ui/structs/parse-error-with-type-param.stderr
+++ b/tests/ui/structs/parse-error-with-type-param.stderr
@@ -1,0 +1,18 @@
+error[E0585]: found a documentation comment that doesn't document anything
+  --> $DIR/parse-error-with-type-param.rs:8:5
+   |
+LL | struct B<T> {
+   |        - while parsing this struct
+LL |     a: A<(T, u32)> // <- note, comma is missing here
+LL |     /// asdf
+   |     ^^^^^^^^
+   |
+   = help: doc comments must come before what they document, if a comment was intended use `//`
+help: missing comma here
+   |
+LL |     a: A<(T, u32)>, // <- note, comma is missing here
+   |                   +
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0585`.


### PR DESCRIPTION
Given

```
#[derive(Clone)]
struct B<T> {
    a: A<(T, u32)> // <- note, comma is missing here
    /// asdf
    b: u32,
}
```

do not emit unnecessary "unused `T`" error.

Fix rust-lang/rust#141403.