### PR TITLE
Fix ICE: When Trying to check visibility of a #[type_const], check RHS instead.

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -394,8 +394,10 @@ fn eval_in_interpreter<'tcx, R: InterpretationResult<'tcx>>(
     typing_env: ty::TypingEnv<'tcx>,
 ) -> Result<R, ErrorHandled> {
     let def = cid.instance.def.def_id();
-    let is_static = tcx.is_static(def);
+    // #[type_const] don't have bodys
+    debug_assert!(!tcx.is_type_const(def), "CTFE tried to evaluate type-const: {:?}", def);
 
+    let is_static = tcx.is_static(def);
     let mut ecx = InterpCx::new(
         tcx,
         tcx.def_span(def),

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1379,9 +1379,8 @@ fn should_encode_const(def_kind: DefKind) -> bool {
 }
 
 fn should_encode_const_of_item<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, def_kind: DefKind) -> bool {
-    matches!(def_kind, DefKind::Const | DefKind::AssocConst)
-        && find_attr!(tcx.get_all_attrs(def_id), AttributeKind::TypeConst(_))
-        // AssocConst ==> assoc item has value
+    // AssocConst ==> assoc item has value
+    tcx.is_type_const(def_id)
         && (!matches!(def_kind, DefKind::AssocConst) || assoc_item_has_value(tcx, def_id))
 }
 

--- a/compiler/rustc_mir_build/src/thir/cx/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/mod.rs
@@ -18,6 +18,8 @@ pub(crate) fn thir_body(
     tcx: TyCtxt<'_>,
     owner_def: LocalDefId,
 ) -> Result<(&Steal<Thir<'_>>, ExprId), ErrorGuaranteed> {
+    debug_assert!(!tcx.is_type_const(owner_def.to_def_id()), "thir_body queried for type_const");
+
     let body = tcx.hir_body_owned_by(owner_def);
     let mut cx = ThirBuildCx::new(tcx, owner_def);
     if let Some(reported) = cx.typeck_results.tainted_by_errors {

--- a/compiler/rustc_passes/src/reachable.rs
+++ b/compiler/rustc_passes/src/reachable.rs
@@ -209,7 +209,10 @@ impl<'tcx> ReachableContext<'tcx> {
                             self.visit_nested_body(body);
                         }
                     }
-
+                    // For #[type_const] we want to evaluate the RHS.
+                    hir::ItemKind::Const(_, _, _, init @ hir::ConstItemRhs::TypeConst(_)) => {
+                        self.visit_const_item_rhs(init);
+                    }
                     hir::ItemKind::Const(_, _, _, init) => {
                         // Only things actually ending up in the final constant value are reachable
                         // for codegen. Everything else is only needed during const-eval, so even if

--- a/tests/ui/const-generics/mgca/type_const-pub.rs
+++ b/tests/ui/const-generics/mgca/type_const-pub.rs
@@ -1,0 +1,10 @@
+//@ check-pass
+// This previously caused an ICE when checking reachability of a pub const item
+// This is because reachability also tried to evaluate the #[type_const] which
+// requires the item have a body. #[type_const] do not have bodies.
+#![expect(incomplete_features)]
+#![feature(min_generic_const_args)]
+
+#[type_const]
+pub const TYPE_CONST : usize = 1;
+fn main() {}


### PR DESCRIPTION
This PR fixes https://github.com/rust-lang/rust/issues/150956 for min_const_generic_args https://github.com/rust-lang/rust/issues/132980. 

The first part of this PR checks in `reachable.rs` if we have a type const use `visit_const_item_rhs(init);` instead of calling `const_eval_poly_to_alloc()`

The second part is I noticed that if `const_eval_poly_to_alloc()` returns a `ErrorHandled::TooGeneric` then switches to `visit_const_item_rhs()`. So further up `const_eval_poly_to_alloc()` call order it eventual gets to `eval_in_interpreter()`. So I added a debug_assert in `eval_in_interpreter()` if we happen to try and run CTFE on a `type_const`.

The other bit is just a test case, and some duplicated code I noticed.

While the PR does get rid of the ICE for a type_const with `pub` visibility. If I try using the const though it will ICE with the following:
```
error: internal compiler error: /home/keith/GitHub/rust_kc/compiler/rustc_const_eval/src/check_consts/qualifs.rs:355:13: expected ConstKind::Param or ConstKind::Value here, found UnevaluatedConst { def: DefId(20:4 ~ colorkit[c783]::TYPE_CONST), args: [] }


thread 'rustc' (819687) panicked at /home/keith/GitHub/rust_kc/compiler/rustc_const_eval/src/check_consts/qualifs.rs:355:13:
```

I suspect it is a similar issue to inherent associated consts. Since if I apply the same fix I had here:
https://github.com/rust-lang/rust/pull/150799#discussion_r2676504639

I then can use the const  internally and in external crates without any issues.
Although, did not include that fix since if it is a similar issue it would need to be addressed elsewhere.

r? @BoxyUwU 
@rustbot label +F-associated_const_equality +F-min_generic_const_args