### PR TITLE
Add new "hide deprecated items" setting in rustdoc

### DIFF
--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -126,6 +126,7 @@ fn synthesize_auto_trait_impl<'tcx>(
                 items: Vec::new(),
                 polarity,
                 kind: clean::ImplKind::Auto,
+                is_deprecated: false,
             })),
             item_id: clean::ItemId::Auto { trait_: trait_def_id, for_: item_def_id },
             cfg: None,

--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -117,6 +117,9 @@ pub(crate) fn synthesize_blanket_impls(
                             None,
                             None,
                         ))),
+                        is_deprecated: tcx
+                            .lookup_deprecation(impl_def_id)
+                            .is_some_and(|deprecation| deprecation.is_in_effect()),
                     })),
                     cfg: None,
                     inline_stmt_id: None,

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -645,6 +645,9 @@ pub(crate) fn build_impl(
             } else {
                 ImplKind::Normal
             },
+            is_deprecated: tcx
+                .lookup_deprecation(did)
+                .is_some_and(|deprecation| deprecation.is_in_effect()),
         })),
         merged_attrs,
         cfg,

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2882,6 +2882,9 @@ fn clean_impl<'tcx>(
             )),
             _ => None,
         });
+    let is_deprecated = tcx
+        .lookup_deprecation(def_id.to_def_id())
+        .is_some_and(|deprecation| deprecation.is_in_effect());
     let mut make_item = |trait_: Option<Path>, for_: Type, items: Vec<Item>| {
         let kind = ImplItem(Box::new(Impl {
             safety: match impl_.of_trait {
@@ -2902,6 +2905,7 @@ fn clean_impl<'tcx>(
             } else {
                 ImplKind::Normal
             },
+            is_deprecated,
         }));
         Item::from_def_id_and_parts(def_id.to_def_id(), None, kind, cx)
     };

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -427,6 +427,10 @@ impl Item {
         })
     }
 
+    pub(crate) fn is_deprecated(&self, tcx: TyCtxt<'_>) -> bool {
+        self.deprecation(tcx).is_some_and(|deprecation| deprecation.is_in_effect())
+    }
+
     pub(crate) fn inner_docs(&self, tcx: TyCtxt<'_>) -> bool {
         self.item_id.as_def_id().map(|did| inner_docs(tcx.get_all_attrs(did))).unwrap_or(false)
     }
@@ -1269,6 +1273,9 @@ impl Trait {
     }
     pub(crate) fn is_dyn_compatible(&self, tcx: TyCtxt<'_>) -> bool {
         tcx.is_dyn_compatible(self.def_id)
+    }
+    pub(crate) fn is_deprecated(&self, tcx: TyCtxt<'_>) -> bool {
+        tcx.lookup_deprecation(self.def_id).is_some_and(|deprecation| deprecation.is_in_effect())
     }
 }
 
@@ -2254,6 +2261,7 @@ pub(crate) struct Impl {
     pub(crate) items: Vec<Item>,
     pub(crate) polarity: ty::ImplPolarity,
     pub(crate) kind: ImplKind,
+    pub(crate) is_deprecated: bool,
 }
 
 impl Impl {

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -593,7 +593,7 @@ fn add_item_to_search_index(tcx: TyCtxt<'_>, cache: &mut Cache, item: &clean::It
         cache,
     );
     let aliases = item.attrs.get_doc_aliases();
-    let deprecation = item.deprecation(tcx);
+    let is_deprecated = item.is_deprecated(tcx);
     let index_item = IndexItem {
         ty: item.type_(),
         defid: Some(defid),
@@ -608,7 +608,7 @@ fn add_item_to_search_index(tcx: TyCtxt<'_>, cache: &mut Cache, item: &clean::It
         impl_id,
         search_type,
         aliases,
-        deprecation,
+        is_deprecated,
     };
 
     cache.search_index.push(index_item);

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -141,7 +141,7 @@ pub(crate) struct IndexItem {
     pub(crate) impl_id: Option<DefId>,
     pub(crate) search_type: Option<IndexItemFunctionType>,
     pub(crate) aliases: Box<[Symbol]>,
-    pub(crate) deprecation: Option<Deprecation>,
+    pub(crate) is_deprecated: bool,
 }
 
 /// A type used for the search index.

--- a/src/librustdoc/html/render/search_index.rs
+++ b/src/librustdoc/html/render/search_index.rs
@@ -1282,7 +1282,7 @@ pub(crate) fn build_index(
                     cache,
                 ),
                 aliases: item.attrs.get_doc_aliases(),
-                deprecation: item.deprecation(tcx),
+                is_deprecated: item.is_deprecated(tcx),
             });
         }
     }
@@ -1519,7 +1519,7 @@ pub(crate) fn build_index(
                 trait_parent: item.trait_parent_idx,
                 module_path,
                 exact_module_path,
-                deprecated: item.deprecation.is_some(),
+                deprecated: item.is_deprecated,
                 associated_item_disambiguator: if let Some(impl_id) = item.impl_id
                     && let Some(parent_idx) = item.parent_idx
                     && associated_item_duplicates

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -2642,6 +2642,15 @@ However, it's not needed with smaller screen width because the doc/code block is
 	}
 }
 
+/* Items on module pages */
+.hide-deprecated-items dt.deprecated,
+.hide-deprecated-items dt.deprecated + dd,
+/* Items on item pages */
+.hide-deprecated-items .deprecated,
+.hide-deprecated-items .deprecated + .item-info {
+	display: none;
+}
+
 /*
 WARNING: RUSTDOC_MOBILE_BREAKPOINT MEDIA QUERY
 If you update this line, then you also need to update the line with the same warning

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -64,7 +64,7 @@ xmlns="http://www.w3.org/2000/svg" fill="black" height="18px">\
 		<path d="M3,5h16M3,11h16M3,17h16" stroke-width="2.75"/></svg>');
 }
 
-:root.sans-serif {
+:root.sans-serif-fonts {
 	--font-family: "Fira Sans", sans-serif;
 	--font-family-code: "Fira Mono", monospace;
 }

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -4920,6 +4920,9 @@ async function addTab(results, query, display, finishedCallback, isTypeSearch) {
 
         const link = document.createElement("a");
         link.className = "result-" + type;
+        if (obj.item.deprecated) {
+            link.className += " deprecated";
+        }
         link.href = obj.href;
 
         const resultName = document.createElement("span");

--- a/src/librustdoc/html/static/js/settings.js
+++ b/src/librustdoc/html/static/js/settings.js
@@ -78,6 +78,12 @@
                     removeClass(document.documentElement, "word-wrap-source-code");
                 }
                 break;
+            case "hide-deprecated-items":
+                if (value === true) {
+                    addClass(document.documentElement, "hide-deprecated-items");
+                } else {
+                    removeClass(document.documentElement, "hide-deprecated-items");
+                }
         }
     }
 
@@ -272,6 +278,11 @@
             {
                 "name": "Word wrap source code",
                 "js_name": "word-wrap-source-code",
+                "default": false,
+            },
+            {
+                "name": "Hide deprecated items",
+                "js_name": "hide-deprecated-items",
                 "default": false,
             },
         ];

--- a/src/librustdoc/html/static/js/settings.js
+++ b/src/librustdoc/html/static/js/settings.js
@@ -43,27 +43,6 @@
                     }
                 }
                 break;
-            case "hide-sidebar":
-                if (value === true) {
-                    addClass(document.documentElement, "hide-sidebar");
-                } else {
-                    removeClass(document.documentElement, "hide-sidebar");
-                }
-                break;
-            case "hide-toc":
-                if (value === true) {
-                    addClass(document.documentElement, "hide-toc");
-                } else {
-                    removeClass(document.documentElement, "hide-toc");
-                }
-                break;
-            case "hide-modnav":
-                if (value === true) {
-                    addClass(document.documentElement, "hide-modnav");
-                } else {
-                    removeClass(document.documentElement, "hide-modnav");
-                }
-                break;
             case "sans-serif-fonts":
                 if (value === true) {
                     addClass(document.documentElement, "sans-serif");
@@ -71,18 +50,15 @@
                     removeClass(document.documentElement, "sans-serif");
                 }
                 break;
+            case "hide-sidebar":
+            case "hide-toc":
+            case "hide-modnav":
             case "word-wrap-source-code":
-                if (value === true) {
-                    addClass(document.documentElement, "word-wrap-source-code");
-                } else {
-                    removeClass(document.documentElement, "word-wrap-source-code");
-                }
-                break;
             case "hide-deprecated-items":
                 if (value === true) {
-                    addClass(document.documentElement, "hide-deprecated-items");
+                    addClass(document.documentElement, settingName);
                 } else {
-                    removeClass(document.documentElement, "hide-deprecated-items");
+                    removeClass(document.documentElement, settingName);
                 }
         }
     }

--- a/src/librustdoc/html/static/js/settings.js
+++ b/src/librustdoc/html/static/js/settings.js
@@ -44,12 +44,6 @@
                 }
                 break;
             case "sans-serif-fonts":
-                if (value === true) {
-                    addClass(document.documentElement, "sans-serif");
-                } else {
-                    removeClass(document.documentElement, "sans-serif");
-                }
-                break;
             case "hide-sidebar":
             case "hide-toc":
             case "hide-modnav":

--- a/src/librustdoc/html/static/js/storage.js
+++ b/src/librustdoc/html/static/js/storage.js
@@ -319,24 +319,24 @@ updateTheme();
 if (getSettingValue("source-sidebar-show") === "true") {
     addClass(document.documentElement, "src-sidebar-expanded");
 }
-if (getSettingValue("hide-sidebar") === "true") {
-    addClass(document.documentElement, "hide-sidebar");
-}
-if (getSettingValue("hide-toc") === "true") {
-    addClass(document.documentElement, "hide-toc");
-}
-if (getSettingValue("hide-modnav") === "true") {
-    addClass(document.documentElement, "hide-modnav");
-}
 if (getSettingValue("sans-serif-fonts") === "true") {
     addClass(document.documentElement, "sans-serif");
 }
-if (getSettingValue("word-wrap-source-code") === "true") {
-    addClass(document.documentElement, "word-wrap-source-code");
-}
-if (getSettingValue("hide-deprecated-items") === "true") {
-    addClass(document.documentElement, "hide-deprecated-items");
-}
+(function() {
+    const settings = [
+        "hide-sidebar",
+        "hide-toc",
+        "hide-modnav",
+        "word-wrap-source-code",
+        "hide-deprecated-items",
+    ];
+    for (const setting of settings) {
+        if (getSettingValue(setting) === "true") {
+            addClass(document.documentElement, setting);
+        }
+    }
+})();
+
 function updateSidebarWidth() {
     const desktopSidebarWidth = getSettingValue("desktop-sidebar-width");
     if (desktopSidebarWidth && desktopSidebarWidth !== "null") {

--- a/src/librustdoc/html/static/js/storage.js
+++ b/src/librustdoc/html/static/js/storage.js
@@ -319,9 +319,6 @@ updateTheme();
 if (getSettingValue("source-sidebar-show") === "true") {
     addClass(document.documentElement, "src-sidebar-expanded");
 }
-if (getSettingValue("sans-serif-fonts") === "true") {
-    addClass(document.documentElement, "sans-serif");
-}
 (function() {
     const settings = [
         "hide-sidebar",
@@ -329,6 +326,7 @@ if (getSettingValue("sans-serif-fonts") === "true") {
         "hide-modnav",
         "word-wrap-source-code",
         "hide-deprecated-items",
+        "sans-serif-fonts",
     ];
     for (const setting of settings) {
         if (getSettingValue(setting) === "true") {

--- a/src/librustdoc/html/static/js/storage.js
+++ b/src/librustdoc/html/static/js/storage.js
@@ -334,6 +334,9 @@ if (getSettingValue("sans-serif-fonts") === "true") {
 if (getSettingValue("word-wrap-source-code") === "true") {
     addClass(document.documentElement, "word-wrap-source-code");
 }
+if (getSettingValue("hide-deprecated-items") === "true") {
+    addClass(document.documentElement, "hide-deprecated-items");
+}
 function updateSidebarWidth() {
     const desktopSidebarWidth = getSettingValue("desktop-sidebar-width");
     if (desktopSidebarWidth && desktopSidebarWidth !== "null") {

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -711,7 +711,8 @@ impl FromClean<clean::PolyTrait> for PolyTrait {
 impl FromClean<clean::Impl> for Impl {
     fn from_clean(impl_: &clean::Impl, renderer: &JsonRenderer<'_>) -> Self {
         let provided_trait_methods = impl_.provided_trait_methods(renderer.tcx);
-        let clean::Impl { safety, generics, trait_, for_, items, polarity, kind } = impl_;
+        let clean::Impl { safety, generics, trait_, for_, items, polarity, kind, is_deprecated: _ } =
+            impl_;
         // FIXME: use something like ImplKind in JSON?
         let (is_synthetic, blanket_impl) = match kind {
             clean::ImplKind::Normal | clean::ImplKind::FakeVariadic => (false, None),

--- a/tests/rustdoc-gui/setting-hide-deprecated.goml
+++ b/tests/rustdoc-gui/setting-hide-deprecated.goml
@@ -1,0 +1,83 @@
+// Test that the "hide deprecated" setting is correctly handled.
+
+include: "utils.goml"
+
+go-to: "file://" + |DOC_PATH| + "/lib2/deprecated/index.html"
+
+// There should be two deprecated items listed on the module page:
+// `DeprecatedStruct` and `DeprecatedTrait`.
+assert-count: ("dt.deprecated", 2)
+// `DeprecatedStruct` and `DeprecatedTrait` should be displayed for now.
+assert-css: ("dt.deprecated", {"display": "block"}, ALL)
+
+// We enable the "hide deprecated items" setting.
+call-function: ("open-settings-menu", {})
+click: "#hide-deprecated-items"
+// None of them should be displayed anymore.
+wait-for-css: ("dt.deprecated", {"display": "none"}, ALL)
+
+// We disable the setting.
+click: "#hide-deprecated-items"
+// All of them should be displayed back.
+wait-for-css: ("dt.deprecated", {"display": "block"}, ALL)
+
+// Now we go to a trait with a deprecated method and a deprecated associated const.
+go-to: "file://" + |DOC_PATH| + "/lib2/deprecated/trait.NormalTrait.html"
+
+// There should be two deprecated items.
+assert-count: ("details.deprecated", 2)
+// They should be displayed for now.
+assert-css: ("details.deprecated", {"display": "block"}, ALL)
+
+// We enable the "hide deprecated items" setting.
+call-function: ("open-settings-menu", {})
+click: "#hide-deprecated-items"
+
+// They shouldn't be displayed anymore.
+wait-for-css: ("details.deprecated", {"display": "none"}, ALL)
+
+// We disable the setting.
+click: "#hide-deprecated-items"
+// All of them should be displayed back.
+wait-for-css: ("details.deprecated", {"display": "block"}, ALL)
+
+// We now go to a struct with a deprecated method which implements a deprecated trait and a trait
+// with deprecated associated items.
+go-to: "file://" + |DOC_PATH| + "/lib2/deprecated/struct.NonDeprecatedStruct.html"
+
+// There should be five deprecated items (six minus one "future" deprecated)...
+assert-count: ("details.deprecated", 5)
+// One of which being a deprecated impl because the trait itself is deprecated.
+assert-count: ("details.implementors-toggle.deprecated", 1)
+// And another has `since = "TBD"` and should NOT have the `deprecated` class.
+assert: "details:not(.deprecated) #method\.future_deprecated_fn"
+// They should all be displayed for now.
+assert-css: ("details.deprecated", {"display": "block"}, ALL)
+
+// We enable the "hide deprecated items" setting.
+call-function: ("open-settings-menu", {})
+click: "#hide-deprecated-items"
+
+// They shouldn't be displayed anymore.
+wait-for-css: ("details.deprecated", {"display": "none"}, ALL)
+
+// We disable the setting.
+click: "#hide-deprecated-items"
+// All of them should be displayed back.
+wait-for-css: ("details.deprecated", {"display": "block"}, ALL)
+
+// And now we check with the search results.
+call-function: ("perform-search", {"query": "deprecated::depr"})
+// There should at least 7 results.
+store-count: ("#results ul.search-results.active > a", nb_search_results)
+assert: |nb_search_results| >= 7
+// There should be at least 5 deprecated items.
+store-count: ("#results ul.search-results.active > a.deprecated", nb_deprecated_results)
+assert: |nb_search_results| >= 5
+// Deprecated items should all be displayed.
+assert-css: ("#results ul.search-results.active > a.deprecated", {"display": "grid"}, ALL)
+// We enable the "hide deprecated items" setting.
+call-function: ("open-settings-menu", {})
+click: "#hide-deprecated-items"
+// None of them should be displayed anymore.
+wait-for-css: ("#results ul.search-results.active > a.deprecated", {"display": "none"}, ALL)

--- a/tests/rustdoc-gui/setting-hide-deprecated.goml
+++ b/tests/rustdoc-gui/setting-hide-deprecated.goml
@@ -3,68 +3,69 @@
 include: "utils.goml"
 
 go-to: "file://" + |DOC_PATH| + "/lib2/deprecated/index.html"
+store-value: (deprecated_class, ".deprecated")
 
 // There should be two deprecated items listed on the module page:
 // `DeprecatedStruct` and `DeprecatedTrait`.
-assert-count: ("dt.deprecated", 2)
+assert-count: ("dt" + |deprecated_class|, 2)
 // `DeprecatedStruct` and `DeprecatedTrait` should be displayed for now.
-assert-css: ("dt.deprecated", {"display": "block"}, ALL)
+assert-css: ("dt" + |deprecated_class|, {"display": "block"}, ALL)
 
 // We enable the "hide deprecated items" setting.
 call-function: ("open-settings-menu", {})
 click: "#hide-deprecated-items"
 // None of them should be displayed anymore.
-wait-for-css: ("dt.deprecated", {"display": "none"}, ALL)
+wait-for-css: ("dt" + |deprecated_class|, {"display": "none"}, ALL)
 
 // We disable the setting.
 click: "#hide-deprecated-items"
 // All of them should be displayed back.
-wait-for-css: ("dt.deprecated", {"display": "block"}, ALL)
+wait-for-css: ("dt" + |deprecated_class|, {"display": "block"}, ALL)
 
 // Now we go to a trait with a deprecated method and a deprecated associated const.
 go-to: "file://" + |DOC_PATH| + "/lib2/deprecated/trait.NormalTrait.html"
 
 // There should be two deprecated items.
-assert-count: ("details.deprecated", 2)
+assert-count: ("details" + |deprecated_class|, 2)
 // They should be displayed for now.
-assert-css: ("details.deprecated", {"display": "block"}, ALL)
+assert-css: ("details" + |deprecated_class|, {"display": "block"}, ALL)
 
 // We enable the "hide deprecated items" setting.
 call-function: ("open-settings-menu", {})
 click: "#hide-deprecated-items"
 
 // They shouldn't be displayed anymore.
-wait-for-css: ("details.deprecated", {"display": "none"}, ALL)
+wait-for-css: ("details" + |deprecated_class|, {"display": "none"}, ALL)
 
 // We disable the setting.
 click: "#hide-deprecated-items"
 // All of them should be displayed back.
-wait-for-css: ("details.deprecated", {"display": "block"}, ALL)
+wait-for-css: ("details" + |deprecated_class|, {"display": "block"}, ALL)
 
 // We now go to a struct with a deprecated method which implements a deprecated trait and a trait
 // with deprecated associated items.
 go-to: "file://" + |DOC_PATH| + "/lib2/deprecated/struct.NonDeprecatedStruct.html"
 
 // There should be five deprecated items (six minus one "future" deprecated)...
-assert-count: ("details.deprecated", 5)
+assert-count: ("details" + |deprecated_class|, 5)
 // One of which being a deprecated impl because the trait itself is deprecated.
-assert-count: ("details.implementors-toggle.deprecated", 1)
+assert-count: ("details.implementors-toggle" + |deprecated_class|, 1)
 // And another has `since = "TBD"` and should NOT have the `deprecated` class.
-assert: "details:not(.deprecated) #method\.future_deprecated_fn"
+assert: "details:not(" + |deprecated_class| + ") #method\.future_deprecated_fn"
 // They should all be displayed for now.
-assert-css: ("details.deprecated", {"display": "block"}, ALL)
+assert-css: ("details" + |deprecated_class|, {"display": "block"}, ALL)
 
 // We enable the "hide deprecated items" setting.
 call-function: ("open-settings-menu", {})
 click: "#hide-deprecated-items"
 
 // They shouldn't be displayed anymore.
-wait-for-css: ("details.deprecated", {"display": "none"}, ALL)
+wait-for-css: ("details" + |deprecated_class|, {"display": "none"}, ALL)
 
 // We disable the setting.
 click: "#hide-deprecated-items"
 // All of them should be displayed back.
-wait-for-css: ("details.deprecated", {"display": "block"}, ALL)
+wait-for-css: ("details" + |deprecated_class|, {"display": "block"}, ALL)
 
 // And now we check with the search results.
 call-function: ("perform-search", {"query": "deprecated::depr"})
@@ -72,12 +73,24 @@ call-function: ("perform-search", {"query": "deprecated::depr"})
 store-count: ("#results ul.search-results.active > a", nb_search_results)
 assert: |nb_search_results| >= 7
 // There should be at least 5 deprecated items.
-store-count: ("#results ul.search-results.active > a.deprecated", nb_deprecated_results)
+store-count: ("#results ul.search-results.active > a" + |deprecated_class|, nb_deprecated_results)
 assert: |nb_search_results| >= 5
 // Deprecated items should all be displayed.
-assert-css: ("#results ul.search-results.active > a.deprecated", {"display": "grid"}, ALL)
+assert-css: ("#results ul.search-results.active > a" + |deprecated_class|, {"display": "grid"}, ALL)
 // We enable the "hide deprecated items" setting.
 call-function: ("open-settings-menu", {})
 click: "#hide-deprecated-items"
 // None of them should be displayed anymore.
-wait-for-css: ("#results ul.search-results.active > a.deprecated", {"display": "none"}, ALL)
+wait-for-css: (
+    "#results ul.search-results.active > a" + |deprecated_class|,
+    {"display": "none"},
+    ALL,
+)
+
+// Finally we check that the future deprecated item doesn't have the deprecated class in the search
+// and therefore isn't impact by the setting.
+call-function: ("perform-search", {"query": "deprecated::future_deprecated"})
+assert-text: (
+    "#results ul.search-results.active > a:not(" + |deprecated_class| + ") .path",
+    " lib2::deprecated::NonDeprecatedStruct::future_deprecated_fn",
+)

--- a/tests/rustdoc-gui/src/lib2/lib.rs
+++ b/tests/rustdoc-gui/src/lib2/lib.rs
@@ -368,3 +368,46 @@ impl std::ops::Deref for Derefer {
         &self.0
     }
 }
+
+pub mod deprecated {
+    #[deprecated(since = "1.26.0", note = "deprecated")]
+    pub struct DeprecatedStruct;
+
+    pub struct NonDeprecatedStruct;
+
+    pub trait NormalTrait {
+        #[deprecated(since = "1.26.0", note = "deprecated")]
+        /// doc
+        const X: usize = 12;
+
+        #[deprecated(since = "1.26.0", note = "deprecated")]
+        /// doc
+        fn normal_deprecated_fn();
+    }
+
+    #[deprecated(since = "1.26.0", note = "deprecated")]
+    pub trait DeprecatedTrait {
+        fn depr_deprecated_fn();
+    }
+
+    impl NonDeprecatedStruct {
+        #[deprecated(since = "1.26.0", note = "deprecated")]
+        /// doc
+        pub fn deprecated_fn() {}
+
+        /// doc
+        pub fn non_deprecated_fn() {}
+
+        #[deprecated(since = "TBD", note = "deprecated")]
+        /// doc
+        pub fn future_deprecated_fn() {}
+    }
+
+    impl NormalTrait for NonDeprecatedStruct {
+        fn normal_deprecated_fn() {}
+    }
+
+    impl DeprecatedTrait for NonDeprecatedStruct {
+        fn depr_deprecated_fn() {}
+    }
+}

--- a/tests/rustdoc-gui/utils.goml
+++ b/tests/rustdoc-gui/utils.goml
@@ -63,15 +63,25 @@ define-function: (
     "open-search",
     [],
     block {
-        // Block requests with doubled `//`.
-        // Amazon S3 doesn't support them, but other web hosts do,
-        // and so do file:/// URLs, which means we need to block
-        // it here if we want to avoid breaking the main docs site.
-        // https://github.com/rust-lang/rust/issues/145646
-        block-network-request: "file://*//*"
-        // Perform search
-        click: "#search-button"
-        wait-for: ".search-input"
+        store-count: (".search-input", __search_input_count)
+        if: (|__search_input_count| != 0, block {
+            store-css: ("#alternative-display", {"display": __search_input_display})
+        })
+        else: block {
+            // Block requests with doubled `//`.
+            // Amazon S3 doesn't support them, but other web hosts do,
+            // and so do file:/// URLs, which means we need to block
+            // it here if we want to avoid breaking the main docs site.
+            // https://github.com/rust-lang/rust/issues/145646
+            block-network-request: "file://*//*"
+            store-value: (__search_input_display, "none")
+        }
+
+        if: (|__search_input_display| == "none", block {
+            // Open search
+            click: "#search-button"
+            wait-for: ".search-input"
+        })
     }
 )
 
@@ -80,6 +90,9 @@ define-function: (
     [query],
     block {
         call-function: ("open-search", {})
+        // We empty the search input in case it wasn't empty.
+        set-property: (".search-input", {"value": ""})
+        // We write the actual query.
         write-into: (".search-input", |query|)
         press-key: 'Enter'
         // wait for the search to start

--- a/tests/rustdoc-gui/utils.goml
+++ b/tests/rustdoc-gui/utils.goml
@@ -60,8 +60,8 @@ define-function: (
 )
 
 define-function: (
-    "perform-search",
-    [query],
+    "open-search",
+    [],
     block {
         // Block requests with doubled `//`.
         // Amazon S3 doesn't support them, but other web hosts do,
@@ -72,6 +72,14 @@ define-function: (
         // Perform search
         click: "#search-button"
         wait-for: ".search-input"
+    }
+)
+
+define-function: (
+    "perform-search",
+    [query],
+    block {
+        call-function: ("open-search", {})
         write-into: (".search-input", |query|)
         press-key: 'Enter'
         // wait for the search to start


### PR DESCRIPTION
This PR adds a new JS setting which allows the JS to hide deprecated items. This is especially useful for crates like `std` which accumulates deprecated items but never removes them.

Nicely enough, the "deprecation" information was already in the search index, meaning I didn't need to change anything there. Before this PR, it was only used to make the deprecated items rank lower. Well now it's also used to generate an extra CSS class, allowing the JS setting to work.

This is taking over https://github.com/rust-lang/rust/pull/149551.

This feature got approved by the rustdoc team in the [meeting of december](https://rust-lang.zulipchat.com/#narrow/channel/393423-t-rustdoc.2Fmeetings/topic/2025-12-08/near/562553156).

You can give it a try [here](https://rustdoc.crud.net/imperio/hide-deprecated-items/foo/index.html).

r? @lolbinarycat 