### PR TITLE
Generate macro expansion for rust compiler crates docs

### DIFF
--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -932,6 +932,7 @@ impl Step for Rustc {
         // see https://github.com/rust-lang/rust/pull/122066#issuecomment-1983049222
         // If there is any bug, please comment out the next line.
         cargo.rustdocflag("--generate-link-to-definition");
+        cargo.rustdocflag("--generate-macro-expansion");
 
         compile::rustc_cargo(builder, &mut cargo, target, &build_compiler, &self.crates);
         cargo.arg("-Zskip-rustdoc-fingerprint");

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -932,7 +932,13 @@ impl Step for Rustc {
         // see https://github.com/rust-lang/rust/pull/122066#issuecomment-1983049222
         // If there is any bug, please comment out the next line.
         cargo.rustdocflag("--generate-link-to-definition");
-        cargo.rustdocflag("--generate-macro-expansion");
+        // FIXME: Currently, `--generate-macro-expansion` option is buggy in `beta` rustdoc. To
+        // allow CI to pass, we only enable the option in stage 2 and higher.
+        // cfg(bootstrap)
+        // ^ Adding this so it's not forgotten when the new release is done.
+        if builder.top_stage > 1 {
+            cargo.rustdocflag("--generate-macro-expansion");
+        }
 
         compile::rustc_cargo(builder, &mut cargo, target, &build_compiler, &self.crates);
         cargo.arg("-Zskip-rustdoc-fingerprint");


### PR DESCRIPTION
Re-enable https://github.com/rust-lang/rust/pull/150022, which was disabled in https://github.com/rust-lang/rust/pull/149831 because some fixes hadn't been merged then.

r? @jieyouxu 