### PR TITLE
Use an associated type default for `Key::Cache`.

### DIFF
--- a/compiler/rustc_middle/src/query/keys.rs
+++ b/compiler/rustc_middle/src/query/keys.rs
@@ -29,15 +29,7 @@ pub trait Key: Sized {
     /// constraint is not enforced here.
     ///
     /// [`QueryCache`]: rustc_query_system::query::QueryCache
-    // N.B. Most of the keys down below have `type Cache<V> = DefaultCache<Self, V>;`,
-    //      it would be reasonable to use associated type defaults, to remove the duplication...
-    //
-    //      ...But r-a doesn't support them yet and using a default here causes r-a to not infer
-    //      return types of queries which is very annoying. Thus, until r-a support associated
-    //      type defaults, please restrain from using them here <3
-    //
-    //      r-a issue: <https://github.com/rust-lang/rust-analyzer/issues/13693>
-    type Cache<V>;
+    type Cache<V> = DefaultCache<Self, V>;
 
     /// In the event that a cycle occurs, if no explicit span has been
     /// given for a query with key `self`, what span should we use?
@@ -72,8 +64,6 @@ impl Key for () {
 }
 
 impl<'tcx> Key for ty::InstanceKind<'tcx> {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         tcx.def_span(self.def_id())
     }
@@ -89,32 +79,24 @@ impl<'tcx> AsLocalKey for ty::InstanceKind<'tcx> {
 }
 
 impl<'tcx> Key for ty::Instance<'tcx> {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         tcx.def_span(self.def_id())
     }
 }
 
 impl<'tcx> Key for mir::interpret::GlobalId<'tcx> {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         self.instance.default_span(tcx)
     }
 }
 
 impl<'tcx> Key for (Ty<'tcx>, Option<ty::ExistentialTraitRef<'tcx>>) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, _: TyCtxt<'_>) -> Span {
         DUMMY_SP
     }
 }
 
 impl<'tcx> Key for mir::interpret::LitToConstInput<'tcx> {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, _tcx: TyCtxt<'_>) -> Span {
         DUMMY_SP
     }
@@ -184,8 +166,6 @@ impl AsLocalKey for DefId {
 }
 
 impl Key for LocalModDefId {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         tcx.def_span(*self)
     }
@@ -197,8 +177,6 @@ impl Key for LocalModDefId {
 }
 
 impl Key for ModDefId {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         tcx.def_span(*self)
     }
@@ -219,56 +197,42 @@ impl AsLocalKey for ModDefId {
 }
 
 impl Key for SimplifiedType {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, _: TyCtxt<'_>) -> Span {
         DUMMY_SP
     }
 }
 
 impl Key for (DefId, DefId) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         self.1.default_span(tcx)
     }
 }
 
 impl<'tcx> Key for (ty::Instance<'tcx>, LocalDefId) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         self.0.default_span(tcx)
     }
 }
 
 impl Key for (DefId, LocalDefId) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         self.1.default_span(tcx)
     }
 }
 
 impl Key for (LocalDefId, DefId) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         self.0.default_span(tcx)
     }
 }
 
 impl Key for (LocalDefId, LocalDefId) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         self.0.default_span(tcx)
     }
 }
 
 impl Key for (DefId, Ident) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         tcx.def_span(self.0)
     }
@@ -280,16 +244,12 @@ impl Key for (DefId, Ident) {
 }
 
 impl Key for (LocalDefId, LocalDefId, Ident) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         self.1.default_span(tcx)
     }
 }
 
 impl Key for (CrateNum, DefId) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         self.1.default_span(tcx)
     }
@@ -305,8 +265,6 @@ impl AsLocalKey for (CrateNum, DefId) {
 }
 
 impl Key for (CrateNum, SimplifiedType) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, _: TyCtxt<'_>) -> Span {
         DUMMY_SP
     }
@@ -322,120 +280,90 @@ impl AsLocalKey for (CrateNum, SimplifiedType) {
 }
 
 impl Key for (DefId, SimplifiedType) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         self.0.default_span(tcx)
     }
 }
 
 impl Key for (DefId, ty::SizedTraitKind) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         self.0.default_span(tcx)
     }
 }
 
 impl<'tcx> Key for GenericArgsRef<'tcx> {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, _: TyCtxt<'_>) -> Span {
         DUMMY_SP
     }
 }
 
 impl<'tcx> Key for (DefId, GenericArgsRef<'tcx>) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         self.0.default_span(tcx)
     }
 }
 
 impl<'tcx> Key for (ty::UnevaluatedConst<'tcx>, ty::UnevaluatedConst<'tcx>) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         (self.0).def.default_span(tcx)
     }
 }
 
 impl<'tcx> Key for (LocalDefId, DefId, GenericArgsRef<'tcx>) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         self.0.default_span(tcx)
     }
 }
 
 impl<'tcx> Key for (ty::ParamEnv<'tcx>, ty::TraitRef<'tcx>) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         tcx.def_span(self.1.def_id)
     }
 }
 
 impl<'tcx> Key for ty::ParamEnvAnd<'tcx, Ty<'tcx>> {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, _tcx: TyCtxt<'_>) -> Span {
         DUMMY_SP
     }
 }
 
 impl<'tcx> Key for ty::TraitRef<'tcx> {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         tcx.def_span(self.def_id)
     }
 }
 
 impl<'tcx> Key for ty::PolyTraitRef<'tcx> {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         tcx.def_span(self.def_id())
     }
 }
 
 impl<'tcx> Key for ty::PolyExistentialTraitRef<'tcx> {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         tcx.def_span(self.def_id())
     }
 }
 
 impl<'tcx> Key for (ty::PolyTraitRef<'tcx>, ty::PolyTraitRef<'tcx>) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         tcx.def_span(self.0.def_id())
     }
 }
 
 impl<'tcx> Key for GenericArg<'tcx> {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, _: TyCtxt<'_>) -> Span {
         DUMMY_SP
     }
 }
 
 impl<'tcx> Key for ty::Const<'tcx> {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, _: TyCtxt<'_>) -> Span {
         DUMMY_SP
     }
 }
 
 impl<'tcx> Key for Ty<'tcx> {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, _: TyCtxt<'_>) -> Span {
         DUMMY_SP
     }
@@ -450,40 +378,30 @@ impl<'tcx> Key for Ty<'tcx> {
 }
 
 impl<'tcx> Key for TyAndLayout<'tcx> {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, _: TyCtxt<'_>) -> Span {
         DUMMY_SP
     }
 }
 
 impl<'tcx> Key for (Ty<'tcx>, Ty<'tcx>) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, _: TyCtxt<'_>) -> Span {
         DUMMY_SP
     }
 }
 
 impl<'tcx> Key for ty::Clauses<'tcx> {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, _: TyCtxt<'_>) -> Span {
         DUMMY_SP
     }
 }
 
 impl<'tcx> Key for ty::ParamEnv<'tcx> {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, _: TyCtxt<'_>) -> Span {
         DUMMY_SP
     }
 }
 
 impl<'tcx, T: Key> Key for ty::PseudoCanonicalInput<'tcx, T> {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         self.value.default_span(tcx)
     }
@@ -494,24 +412,18 @@ impl<'tcx, T: Key> Key for ty::PseudoCanonicalInput<'tcx, T> {
 }
 
 impl Key for Symbol {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, _tcx: TyCtxt<'_>) -> Span {
         DUMMY_SP
     }
 }
 
 impl Key for Option<Symbol> {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, _tcx: TyCtxt<'_>) -> Span {
         DUMMY_SP
     }
 }
 
 impl<'tcx> Key for &'tcx OsStr {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, _tcx: TyCtxt<'_>) -> Span {
         DUMMY_SP
     }
@@ -520,80 +432,60 @@ impl<'tcx> Key for &'tcx OsStr {
 /// Canonical query goals correspond to abstract trait operations that
 /// are not tied to any crate in particular.
 impl<'tcx, T: Clone> Key for CanonicalQueryInput<'tcx, T> {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, _tcx: TyCtxt<'_>) -> Span {
         DUMMY_SP
     }
 }
 
 impl<'tcx, T: Clone> Key for (CanonicalQueryInput<'tcx, T>, bool) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, _tcx: TyCtxt<'_>) -> Span {
         DUMMY_SP
     }
 }
 
 impl Key for (Symbol, u32, u32) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, _tcx: TyCtxt<'_>) -> Span {
         DUMMY_SP
     }
 }
 
 impl<'tcx> Key for (DefId, Ty<'tcx>, GenericArgsRef<'tcx>, ty::ParamEnv<'tcx>) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, _tcx: TyCtxt<'_>) -> Span {
         DUMMY_SP
     }
 }
 
 impl<'tcx> Key for (Ty<'tcx>, rustc_abi::VariantIdx) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, _tcx: TyCtxt<'_>) -> Span {
         DUMMY_SP
     }
 }
 
 impl<'tcx> Key for (ty::Predicate<'tcx>, traits::WellFormedLoc) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, _tcx: TyCtxt<'_>) -> Span {
         DUMMY_SP
     }
 }
 
 impl<'tcx> Key for (ty::PolyFnSig<'tcx>, &'tcx ty::List<Ty<'tcx>>) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, _: TyCtxt<'_>) -> Span {
         DUMMY_SP
     }
 }
 
 impl<'tcx> Key for (ty::Instance<'tcx>, &'tcx ty::List<Ty<'tcx>>) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         self.0.default_span(tcx)
     }
 }
 
 impl<'tcx> Key for ty::Value<'tcx> {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, _: TyCtxt<'_>) -> Span {
         DUMMY_SP
     }
 }
 
 impl Key for HirId {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         tcx.hir_span(*self)
     }
@@ -605,8 +497,6 @@ impl Key for HirId {
 }
 
 impl Key for (LocalDefId, HirId) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         tcx.hir_span(self.1)
     }
@@ -631,8 +521,6 @@ impl<'tcx> Key for (LocalExpnId, &'tcx TokenStream) {
 }
 
 impl<'tcx> Key for (ValidityRequirement, ty::PseudoCanonicalInput<'tcx, Ty<'tcx>>) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     // Just forward to `Ty<'tcx>`
 
     fn default_span(&self, _: TyCtxt<'_>) -> Span {
@@ -648,8 +536,6 @@ impl<'tcx> Key for (ValidityRequirement, ty::PseudoCanonicalInput<'tcx, Ty<'tcx>
 }
 
 impl<'tcx> Key for (ty::Instance<'tcx>, CollectionMode) {
-    type Cache<V> = DefaultCache<Self, V>;
-
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         self.0.default_span(tcx)
     }


### PR DESCRIPTION
They currently aren't used because r-a didn't support them, but r-a support was recently merged in
https://github.com/rust-lang/rust-analyzer/pull/21243.

r? @Noratrieb 