### PR TITLE
Feature-gate `mut ref` patterns in struct pattern field shorthand

### DIFF
--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -1750,6 +1750,12 @@ impl<'a> Parser<'a> {
             hi = self.prev_token.span;
             let ann = BindingMode(by_ref, mutability);
             let fieldpat = self.mk_pat_ident(boxed_span.to(hi), ann, fieldname);
+            if matches!(
+                fieldpat.kind,
+                PatKind::Ident(BindingMode(ByRef::Yes(..), Mutability::Mut), ..)
+            ) {
+                self.psess.gated_spans.gate(sym::mut_ref, fieldpat.span);
+            }
             let subpat = if is_box {
                 self.mk_pat(lo.to(hi), PatKind::Box(Box::new(fieldpat)))
             } else {

--- a/tests/ui/feature-gates/feature-gate-mut-ref.rs
+++ b/tests/ui/feature-gates/feature-gate-mut-ref.rs
@@ -10,4 +10,7 @@ fn main() {
     let mut ref x = 10; //~  ERROR [E0658]
     #[cfg(false)]
     let mut ref mut y = 10; //~  ERROR [E0658]
+
+    struct Foo { x: i32 }
+    let Foo { mut ref x } = Foo { x: 10 };
 }

--- a/tests/ui/feature-gates/feature-gate-mut-ref.rs
+++ b/tests/ui/feature-gates/feature-gate-mut-ref.rs
@@ -12,5 +12,5 @@ fn main() {
     let mut ref mut y = 10; //~  ERROR [E0658]
 
     struct Foo { x: i32 }
-    let Foo { mut ref x } = Foo { x: 10 };
+    let Foo { mut ref x } = Foo { x: 10 }; //~  ERROR [E0658]
 }

--- a/tests/ui/feature-gates/feature-gate-mut-ref.stderr
+++ b/tests/ui/feature-gates/feature-gate-mut-ref.stderr
@@ -38,6 +38,16 @@ LL |     let mut ref mut y = 10;
    = help: add `#![feature(mut_ref)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 4 previous errors
+error[E0658]: mutable by-reference bindings are experimental
+  --> $DIR/feature-gate-mut-ref.rs:15:15
+   |
+LL |     let Foo { mut ref x } = Foo { x: 10 };
+   |               ^^^^^^^^^
+   |
+   = note: see issue #123076 <https://github.com/rust-lang/rust/issues/123076> for more information
+   = help: add `#![feature(mut_ref)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Tracking issue for `mut_ref` (and other parts of Match Ergonomics 2024): https://github.com/rust-lang/rust/issues/123076

https://github.com/rust-lang/rust/pull/123080 introduced `mut ref`[^1] patterns (for by-reference bindings where the binding itself is mutable), feature-gated behind the `mut_ref` feature, except for in struct pattern shorthand, where the feature gating was missing. Thus, `mut ref` patterns in struct pattern shorthand has been unintentionally stable for ~18 months (since 1.79.0 ([compiler explorer](https://rust.godbolt.org/z/4WTrvhboT))).

This PR adds feature-gating for `mut ref` patterns in struct pattern shorthand. Since this is reverting an accidental stabilization, this probably needs a crater run and a T-lang FCP?

Some alternative possibilities:

* Do nothing (let the inconsistency exist until `feature(mut_ref)` is stabilized)
* Document the existing behavior
* Do a FCW instead of fully feature-gating
* Stabilize `feature(mut_ref)`


CC https://github.com/rust-lang/rust/pull/123080#issuecomment-3746793632

CC @Nadrieril 

[^1]: everything in this description also applies analogously to `mut ref mut` patterns.