### PR TITLE
Enable rustdoc `link to definition` feature on std crates

### DIFF
--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -812,7 +812,8 @@ fn doc_std(
         .rustdocflag("std_detect=https://docs.rs/std_detect/latest/")
         .rustdocflag("--extern-html-root-takes-precedence")
         .rustdocflag("--resource-suffix")
-        .rustdocflag(&builder.version);
+        .rustdocflag(&builder.version)
+        .rustdocflag("--generate-link-to-definition");
     for arg in extra_args {
         cargo.rustdocflag(arg);
     }


### PR DESCRIPTION
This (nightly) feature has been around for a while now. I think it'd be a nice addition for the std docs source code pages to have it enabled.

r? @Kobzol 