### PR TITLE
Compile bootstrap with -Zbinary-dep-depinfo

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -1147,6 +1147,8 @@ class RustBuild(object):
             args += ["-Zwarnings"]
             env["CARGO_BUILD_WARNINGS"] = "deny"
 
+        env["RUSTFLAGS"] += " -Zbinary-dep-depinfo"
+
         # Add RUSTFLAGS_BOOTSTRAP to RUSTFLAGS for bootstrap compilation.
         # Note that RUSTFLAGS_BOOTSTRAP should always be added to the end of
         # RUSTFLAGS, since that causes RUSTFLAGS_BOOTSTRAP to override RUSTFLAGS.


### PR DESCRIPTION
In cg_clif's test framework it is possible for the standard library to change in an ABI incompatible way without the rustc binary changing. In that case rustc wouldn't rebuild all bootstrap dependencies, causing compilation to fail. Passing -Zbinary-dep-depinfo fixes this.