### PR TITLE
Avoid serde dependency in build_helper when not necessary

### DIFF
--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -6,7 +6,7 @@ build = "build.rs"
 default-run = "bootstrap"
 
 [features]
-build-metrics = ["sysinfo"]
+build-metrics = ["dep:sysinfo", "build_helper/metrics"]
 tracing = ["dep:tracing", "dep:tracing-chrome", "dep:tracing-subscriber", "dep:chrono", "dep:tempfile"]
 
 [lib]

--- a/src/build_helper/Cargo.toml
+++ b/src/build_helper/Cargo.toml
@@ -6,5 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = "1"
-serde_derive = "1"
+serde = { version = "1", optional = true }
+serde_derive = { version = "1", optional = true }
+
+[features]
+metrics = ["dep:serde", "dep:serde_derive"]

--- a/src/build_helper/src/lib.rs
+++ b/src/build_helper/src/lib.rs
@@ -4,6 +4,7 @@ pub mod ci;
 pub mod drop_bomb;
 pub mod fs;
 pub mod git;
+#[cfg(feature = "metrics")]
 pub mod metrics;
 pub mod npm;
 pub mod stage0_parser;

--- a/src/ci/citool/Cargo.toml
+++ b/src/ci/citool/Cargo.toml
@@ -15,7 +15,7 @@ serde_yaml = "0.9"
 serde_json = "1"
 ureq = { version = "3", features = ["json"] }
 
-build_helper = { path = "../../build_helper" }
+build_helper = { path = "../../build_helper", features = ["metrics"] }
 
 [dev-dependencies]
 insta = "1"

--- a/src/tools/opt-dist/Cargo.toml
+++ b/src/tools/opt-dist/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-build_helper = { path = "../../build_helper" }
+build_helper = { path = "../../build_helper", features = ["metrics"] }
 env_logger = "0.11"
 log = "0.4"
 anyhow = "1"


### PR DESCRIPTION
Run-make-support doesn't need the metrics code to be pulled in ever. And bootstrap only needs it in CI where build metrics support is enabled.