### PR TITLE
Support slices in type reflection

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -362,6 +362,7 @@ symbols! {
         Send,
         SeqCst,
         Sized,
+        Slice,
         SliceIndex,
         SliceIter,
         Some,

--- a/library/core/src/mem/type_info.rs
+++ b/library/core/src/mem/type_info.rs
@@ -45,6 +45,8 @@ pub enum TypeKind {
     Tuple(Tuple),
     /// Arrays.
     Array(Array),
+    /// Slices.
+    Slice(Slice),
     /// Primitive boolean type.
     Bool(Bool),
     /// Primitive character type.
@@ -92,6 +94,15 @@ pub struct Array {
     pub element_ty: TypeId,
     /// The length of the array.
     pub len: usize,
+}
+
+/// Compile-time type information about slices.
+#[derive(Debug)]
+#[non_exhaustive]
+#[unstable(feature = "type_info", issue = "146922")]
+pub struct Slice {
+    /// The type of each element in the slice.
+    pub element_ty: TypeId,
 }
 
 /// Compile-time type information about `bool`.

--- a/library/coretests/tests/mem/type_info.rs
+++ b/library/coretests/tests/mem/type_info.rs
@@ -23,6 +23,14 @@ fn test_arrays() {
 }
 
 #[test]
+fn test_slices() {
+    match const { Type::of::<[usize]>() }.kind {
+        TypeKind::Slice(slice) => assert_eq!(slice.element_ty, TypeId::of::<usize>()),
+        _ => unreachable!(),
+    }
+}
+
+#[test]
 fn test_tuples() {
     fn assert_tuple_arity<T: 'static, const N: usize>() {
         match const { Type::of::<T>() }.kind {

--- a/tests/ui/reflection/dump.bit32.run.stdout
+++ b/tests/ui/reflection/dump.bit32.run.stdout
@@ -194,7 +194,11 @@ Type {
     size: None,
 }
 Type {
-    kind: Other,
+    kind: Slice(
+        Slice {
+            element_ty: TypeId(0x0596b48cc04376e64d5c788c2aa46bdb),
+        },
+    ),
     size: None,
 }
 Type {

--- a/tests/ui/reflection/dump.bit64.run.stdout
+++ b/tests/ui/reflection/dump.bit64.run.stdout
@@ -194,7 +194,11 @@ Type {
     size: None,
 }
 Type {
-    kind: Other,
+    kind: Slice(
+        Slice {
+            element_ty: TypeId(0x0596b48cc04376e64d5c788c2aa46bdb),
+        },
+    ),
     size: None,
 }
 Type {


### PR DESCRIPTION
Tracking issue: rust-lang/rust#146922 

This PR adds support for inspecting slices `[T]` through type reflection. It does so by adding the new `Slice` struct + variant, which is very similar to `Array` but without the `len` field:

```rust
pub struct Slice {
    pub element_ty: TypeId,
}
```

Here is an example reflecting a slice:

```rust
match const { Type::of::<[u8]>() }.kind {
    TypeKind::Slice(slice) => assert_eq!(slice.element_ty, TypeId::of::<u8>()),
    _ => unreachable!(),
}
```

In addition to this, I also re-arranged the type info unit tests.

r? @oli-obk