### PR TITLE
Fix deprecated attribute intra-doc link not resolved in the right location on reexported item

### DIFF
--- a/tests/rustdoc-html/intra-doc/ice-deprecated-note-on-reexport.rs
+++ b/tests/rustdoc-html/intra-doc/ice-deprecated-note-on-reexport.rs
@@ -1,0 +1,11 @@
+// This test ensures that the intra-doc link in `deprecated` note is resolved at the correct
+// location (ie in the current crate and not in the reexported item's location/crate) and
+// therefore doesn't crash.
+//
+// This is a regression test for <https://github.com/rust-lang/rust/issues/151028>.
+
+#![crate_name = "foo"]
+
+#[deprecated(note = "use [`std::mem::forget`]")]
+#[doc(inline)]
+pub use std::mem::drop;


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/151028.
Follow-up of https://github.com/rust-lang/rust/pull/150721.

So when we resolve an intra-doc link, its current context (the module from which we resolve in short) is very important. However, when we use an intra-doc link in a `#[deprecated]` attribute on a reexported item, we were using the context of the reexported item and not of the `use` itself. Meaning that if you have an intra-doc link `std::mem::drop` on an item from another crate (let's say `core`), then the import will simply fail since there is no `std` dependency.

Now comes the not so funny fix: at this point, we don't know anymore where the attribute came from (ie, from the reexport or from the reexported item) since we already merged the attribute at this point. The solution I found to go around this problem is to check if the item span contains the attribute, and if not, then we use the `inline_stmt_id` as context instead of the item's ID. I'm not super happy and I'm sure we'll find corner cases in the future (like with macros), however there are a few things that mitigate this fix:
1. The only way to generate an attribute with a macro with its item while having different spans is by using proc-macros. In that case, we can always default to the `inline_stmt_id` as context and be fine, but I guess we'll see when get there.
2. It only concerns reexports, so the area of the problem is quite restricted.

Hopefully this explanation made sense. :)

cc @folkertdev 
r? @lolbinarycat 