### PR TITLE
fix: more descriptive error message for enum to integer

### DIFF
--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -291,12 +291,32 @@ impl<'a, 'tcx> CastCheck<'tcx> {
             CastError::NeedViaThinPtr | CastError::NeedViaPtr => {
                 let mut err =
                     make_invalid_casting_error(self.span, self.expr_ty, self.cast_ty, fcx);
+
                 if self.cast_ty.is_integral() {
-                    err.help(format!("cast through {} first", match e {
-                        CastError::NeedViaPtr => "a raw pointer",
-                        CastError::NeedViaThinPtr => "a thin pointer",
-                        e => unreachable!("control flow means we should never encounter a {e:?}"),
-                    }));
+                    if !matches!(self.expr.kind, ExprKind::AddrOf(..))
+                        && let ty::Ref(_, inner_ty, _) = *self.expr_ty.kind()
+                        && let ty::Adt(adt_def, _) = *inner_ty.kind()
+                        && adt_def.is_enum()
+                        && adt_def.is_payloadfree()
+                    {
+                        err.span_suggestion_verbose(
+                            self.expr_span.shrink_to_lo(),
+                            "dereference the expression",
+                            "*",
+                            Applicability::MachineApplicable,
+                        );
+                    } else {
+                        err.help(format!(
+                            "cast through {} first",
+                            match e {
+                                CastError::NeedViaPtr => "a raw pointer",
+                                CastError::NeedViaThinPtr => "a thin pointer",
+                                e => unreachable!(
+                                    "control flow means we should never encounter a {e:?}"
+                                ),
+                            }
+                        ));
+                    }
                 }
 
                 self.try_suggest_collection_to_bool(fcx, &mut err);

--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -303,7 +303,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                             self.expr_span.shrink_to_lo(),
                             "dereference the expression",
                             "*",
-                            Applicability::MachineApplicable,
+                            Applicability::MaybeIncorrect,
                         );
                     } else {
                         err.help(format!(

--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -301,10 +301,18 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                     {
                         err.span_suggestion_verbose(
                             self.expr_span.shrink_to_lo(),
-                            "dereference the expression",
+                            "try dereferencing before the cast",
                             "*",
                             Applicability::MaybeIncorrect,
                         );
+                        if !fcx.type_is_copy_modulo_regions(fcx.param_env, inner_ty) {
+                            err.span_suggestion_verbose(
+                                fcx.tcx.def_span(adt_def.did()).shrink_to_lo(),
+                                "add `#[derive(Copy, Clone)]` to the enum definition",
+                                "#[derive(Copy, Clone)]\n",
+                                Applicability::MaybeIncorrect,
+                            );
+                        }
                     } else {
                         err.help(format!(
                             "cast through {} first",

--- a/tests/ui/cast/cast-enum-to-int-issue-151116.rs
+++ b/tests/ui/cast/cast-enum-to-int-issue-151116.rs
@@ -8,4 +8,5 @@ enum Priority {
 fn main() {
     let priority = &Priority::Normal;
     let priority = priority as u8; //~ ERROR casting `&Priority` as `u8` is invalid
+    //~| HELP: dereference the expression
 }

--- a/tests/ui/cast/cast-enum-to-int-issue-151116.rs
+++ b/tests/ui/cast/cast-enum-to-int-issue-151116.rs
@@ -1,0 +1,11 @@
+#[repr(u8)]
+enum Priority {
+    High = 255,
+    Normal = 127,
+    Low = 1,
+}
+
+fn main() {
+    let priority = &Priority::Normal;
+    let priority = priority as u8; //~ ERROR casting `&Priority` as `u8` is invalid
+}

--- a/tests/ui/cast/cast-enum-to-int-issue-151116.rs
+++ b/tests/ui/cast/cast-enum-to-int-issue-151116.rs
@@ -9,4 +9,7 @@ fn main() {
     let priority = &Priority::Normal;
     let priority = priority as u8; //~ ERROR casting `&Priority` as `u8` is invalid
     //~| HELP: dereference the expression
+
+    let priority = &Priority::Normal as u8; //~ ERROR casting `&Priority` as `u8` is invalid
+    //~| HELP: cast through a raw pointer first
 }

--- a/tests/ui/cast/cast-enum-to-int-issue-151116.rs
+++ b/tests/ui/cast/cast-enum-to-int-issue-151116.rs
@@ -5,6 +5,14 @@ enum Priority { //~ HELP: add `#[derive(Copy, Clone)]` to the enum definition
     Low = 1,
 }
 
+#[repr(u8)]
+#[derive(Copy, Clone)]
+enum CopyPriority {
+    High = 255,
+    Normal = 127,
+    Low = 1,
+}
+
 fn main() {
     let priority = &Priority::Normal;
     let priority = priority as u8; //~ ERROR casting `&Priority` as `u8` is invalid
@@ -12,4 +20,8 @@ fn main() {
 
     let priority = &Priority::Normal as u8; //~ ERROR casting `&Priority` as `u8` is invalid
     //~| HELP: cast through a raw pointer first
+
+    let priority = &CopyPriority::Normal;
+    let priority = priority as u8; //~ ERROR casting `&CopyPriority` as `u8` is invalid
+    //~| HELP: try dereferencing before the cast
 }

--- a/tests/ui/cast/cast-enum-to-int-issue-151116.rs
+++ b/tests/ui/cast/cast-enum-to-int-issue-151116.rs
@@ -1,5 +1,5 @@
 #[repr(u8)]
-enum Priority {
+enum Priority { //~ HELP: add `#[derive(Copy, Clone)]` to the enum definition
     High = 255,
     Normal = 127,
     Low = 1,
@@ -8,7 +8,7 @@ enum Priority {
 fn main() {
     let priority = &Priority::Normal;
     let priority = priority as u8; //~ ERROR casting `&Priority` as `u8` is invalid
-    //~| HELP: dereference the expression
+    //~| HELP: try dereferencing before the cast
 
     let priority = &Priority::Normal as u8; //~ ERROR casting `&Priority` as `u8` is invalid
     //~| HELP: cast through a raw pointer first

--- a/tests/ui/cast/cast-enum-to-int-issue-151116.stderr
+++ b/tests/ui/cast/cast-enum-to-int-issue-151116.stderr
@@ -1,0 +1,14 @@
+error[E0606]: casting `&Priority` as `u8` is invalid
+  --> $DIR/cast-enum-to-int-issue-151116.rs:10:20
+   |
+LL |     let priority = priority as u8;
+   |                    ^^^^^^^^^^^^^^
+   |
+help: dereference the expression
+   |
+LL |     let priority = *priority as u8;
+   |                    +
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0606`.

--- a/tests/ui/cast/cast-enum-to-int-issue-151116.stderr
+++ b/tests/ui/cast/cast-enum-to-int-issue-151116.stderr
@@ -9,6 +9,14 @@ help: dereference the expression
 LL |     let priority = *priority as u8;
    |                    +
 
-error: aborting due to 1 previous error
+error[E0606]: casting `&Priority` as `u8` is invalid
+  --> $DIR/cast-enum-to-int-issue-151116.rs:13:20
+   |
+LL |     let priority = &Priority::Normal as u8;
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: cast through a raw pointer first
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0606`.

--- a/tests/ui/cast/cast-enum-to-int-issue-151116.stderr
+++ b/tests/ui/cast/cast-enum-to-int-issue-151116.stderr
@@ -4,10 +4,15 @@ error[E0606]: casting `&Priority` as `u8` is invalid
 LL |     let priority = priority as u8;
    |                    ^^^^^^^^^^^^^^
    |
-help: dereference the expression
+help: try dereferencing before the cast
    |
 LL |     let priority = *priority as u8;
    |                    +
+help: add `#[derive(Copy, Clone)]` to the enum definition
+   |
+LL + #[derive(Copy, Clone)]
+LL | enum Priority {
+   |
 
 error[E0606]: casting `&Priority` as `u8` is invalid
   --> $DIR/cast-enum-to-int-issue-151116.rs:13:20

--- a/tests/ui/cast/cast-enum-to-int-issue-151116.stderr
+++ b/tests/ui/cast/cast-enum-to-int-issue-151116.stderr
@@ -1,5 +1,5 @@
 error[E0606]: casting `&Priority` as `u8` is invalid
-  --> $DIR/cast-enum-to-int-issue-151116.rs:10:20
+  --> $DIR/cast-enum-to-int-issue-151116.rs:18:20
    |
 LL |     let priority = priority as u8;
    |                    ^^^^^^^^^^^^^^
@@ -15,13 +15,24 @@ LL | enum Priority {
    |
 
 error[E0606]: casting `&Priority` as `u8` is invalid
-  --> $DIR/cast-enum-to-int-issue-151116.rs:13:20
+  --> $DIR/cast-enum-to-int-issue-151116.rs:21:20
    |
 LL |     let priority = &Priority::Normal as u8;
    |                    ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: cast through a raw pointer first
 
-error: aborting due to 2 previous errors
+error[E0606]: casting `&CopyPriority` as `u8` is invalid
+  --> $DIR/cast-enum-to-int-issue-151116.rs:25:20
+   |
+LL |     let priority = priority as u8;
+   |                    ^^^^^^^^^^^^^^
+   |
+help: try dereferencing before the cast
+   |
+LL |     let priority = *priority as u8;
+   |                    +
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0606`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/151122)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Fixes rust-lang/rust#151116
A  more descriptive error message when casting an enum to an Integer. Please review issue linked above.