### PR TITLE
Take care to use MSG_EOR with SOCK_SEQPACKET sockets

### DIFF
--- a/library/std/src/sys/process/unix/unix.rs
+++ b/library/std/src/sys/process/unix/unix.rs
@@ -881,7 +881,7 @@ impl Command {
 
             // we send the 0-length message even if we failed to acquire the pidfd
             // so we get a consistent SEQPACKET order
-            match cvt_r(|| libc::sendmsg(sock.as_raw(), &msg, 0)) {
+            match cvt_r(|| libc::sendmsg(sock.as_raw(), &msg, libc::MSG_EOR)) {
                 Ok(0) => {}
                 other => rtabort!("failed to communicate with parent process. {:?}", other),
             }


### PR DESCRIPTION
The current Linux driver treats every sendmsg call as a separate record. That is, it behaves as though MSG_EOR is always set.  But that might not be true forever.  And the current FreeBSD driver does _not_ do that, so setting MSG_EOR is important for portability.

r? @the8472 

