### PR TITLE
tests: fix loongarch test for new LLVM 23 codegen

### DIFF
--- a/tests/assembly-llvm/asm/loongarch-type.rs
+++ b/tests/assembly-llvm/asm/loongarch-type.rs
@@ -28,8 +28,10 @@ extern "C" {
 
 // CHECK-LABEL: sym_fn:
 // CHECK: #APP
-// CHECK: pcalau12i $t0, %got_pc_hi20(extern_func)
-// CHECK: ld.{{[wd]}} $t0, $t0, %got_pc_lo12(extern_func)
+// loongarch64: pcalau12i $t0, %got_pc_hi20(extern_func)
+// loongarch64: ld.d $t0, $t0, %got_pc_lo12(extern_func)
+// loongarch32: pca{{(lau|ddu)}}12i $t0, %got_pc{{(add)?}}_hi20(extern_func)
+// loongarch32: ld.w $t0, $t0, %got_pc{{(add)?}}_lo12({{(extern_func|\.Lpcadd_hi0)}})
 // CHECK: #NO_APP
 #[no_mangle]
 pub unsafe fn sym_fn() {
@@ -38,8 +40,10 @@ pub unsafe fn sym_fn() {
 
 // CHECK-LABEL: sym_static:
 // CHECK: #APP
-// CHECK: pcalau12i $t0, %got_pc_hi20(extern_static)
-// CHECK: ld.{{[wd]}} $t0, $t0, %got_pc_lo12(extern_static)
+// loongarch64: pcalau12i $t0, %got_pc_hi20(extern_static)
+// loongarch64: ld.d $t0, $t0, %got_pc_lo12(extern_static)
+// loongarch32: pca{{(lau|ddu)}}12i $t0, %got_pc{{(add)?}}_hi20(extern_static)
+// loongarch32: ld.w $t0, $t0, %got_pc{{(add)?}}_lo12({{(extern_static|\.Lpcadd_hi1)}})
 // CHECK: #NO_APP
 #[no_mangle]
 pub unsafe fn sym_static() {


### PR DESCRIPTION
It looks like the behavior only changed for loongarch32, so maybe the better path would be to split the test into 32 and 64 bit files, and then the 32 bit one could use revisions for LLVM versions, which would obviate the need for the goofy regular expression dancing. I'm not really sure what the best outcome is for this test, so I'm very open to suggestions.

@rustbot label llvm-main

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
