### PR TITLE
Rename `rust.use-lld` to `rust.bootstrap-override-lld` in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -97,7 +97,7 @@ See [the rustc-dev-guide for more info][sysllvm].
       --set llvm.ninja=false \
       --set rust.debug-assertions=false \
       --set rust.jemalloc \
-      --set rust.use-lld=true \
+      --set rust.bootstrap-override-lld=true \
       --set rust.lto=thin \
       --set rust.codegen-units=1
    ```


### PR DESCRIPTION
I was trying to follow the example configure command in `INSTALL.md` and found that it gives error after `rust.use-lld` is renamed by 852aa20c90cca64426516f46c3d89cfd57086ae8.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
