### PR TITLE
Rollup of 15 pull requests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -96,6 +96,7 @@ boolean_coercion <booleancoercion@gmail.com>
 Boris Egorov <jightuse@gmail.com> <egorov@linux.com>
 bors <bors@rust-lang.org> bors[bot] <26634292+bors[bot]@users.noreply.github.com>
 bors <bors@rust-lang.org> bors[bot] <bors[bot]@users.noreply.github.com>
+bors <bors@rust-lang.org> <122020455+rust-bors[bot]@users.noreply.github.com>
 BoxyUwU <rust@boxyuwu.dev>
 BoxyUwU <rust@boxyuwu.dev> <supbscripter@gmail.com>
 Braden Nelson <moonheart08@users.noreply.github.com>

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -97,7 +97,7 @@ See [the rustc-dev-guide for more info][sysllvm].
       --set llvm.ninja=false \
       --set rust.debug-assertions=false \
       --set rust.jemalloc \
-      --set rust.use-lld=true \
+      --set rust.bootstrap-override-lld=true \
       --set rust.lto=thin \
       --set rust.codegen-units=1
    ```

--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -94,7 +94,6 @@ pub fn parse_cfg_entry<S: Stage>(
             LitKind::Bool(b) => CfgEntry::Bool(b, lit.span),
             _ => return Err(cx.expected_identifier(lit.span)),
         },
-        MetaItemOrLitParser::Err(_, err) => return Err(*err),
     })
 }
 

--- a/compiler/rustc_attr_parsing/src/attributes/doc.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/doc.rs
@@ -514,9 +514,6 @@ impl DocParser {
                         MetaItemOrLitParser::Lit(lit) => {
                             cx.unexpected_literal(lit.span);
                         }
-                        MetaItemOrLitParser::Err(..) => {
-                            // already had an error here, move on.
-                        }
                     }
                 }
             }
@@ -599,9 +596,6 @@ impl DocParser {
                         }
                         MetaItemOrLitParser::Lit(lit) => {
                             cx.expected_name_value(lit.span, None);
-                        }
-                        MetaItemOrLitParser::Err(..) => {
-                            // already had an error here, move on.
                         }
                     }
                 }

--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -18,7 +18,7 @@ use rustc_parse::exp;
 use rustc_parse::parser::{ForceCollect, Parser, PathStyle, token_descr};
 use rustc_session::errors::{create_lit_error, report_lit_error};
 use rustc_session::parse::ParseSess;
-use rustc_span::{ErrorGuaranteed, Ident, Span, Symbol, sym};
+use rustc_span::{Ident, Span, Symbol, sym};
 use thin_vec::ThinVec;
 
 use crate::ShouldEmit;
@@ -192,7 +192,6 @@ impl ArgParser {
 pub enum MetaItemOrLitParser {
     MetaItemParser(MetaItemParser),
     Lit(MetaItemLit),
-    Err(Span, ErrorGuaranteed),
 }
 
 impl MetaItemOrLitParser {
@@ -210,21 +209,20 @@ impl MetaItemOrLitParser {
                 generic_meta_item_parser.span()
             }
             MetaItemOrLitParser::Lit(meta_item_lit) => meta_item_lit.span,
-            MetaItemOrLitParser::Err(span, _) => *span,
         }
     }
 
     pub fn lit(&self) -> Option<&MetaItemLit> {
         match self {
             MetaItemOrLitParser::Lit(meta_item_lit) => Some(meta_item_lit),
-            _ => None,
+            MetaItemOrLitParser::MetaItemParser(_) => None,
         }
     }
 
     pub fn meta_item(&self) -> Option<&MetaItemParser> {
         match self {
             MetaItemOrLitParser::MetaItemParser(parser) => Some(parser),
-            _ => None,
+            MetaItemOrLitParser::Lit(_) => None,
         }
     }
 }

--- a/compiler/rustc_builtin_macros/messages.ftl
+++ b/compiler/rustc_builtin_macros/messages.ftl
@@ -161,6 +161,8 @@ builtin_macros_eii_only_once = `#[{$name}]` can only be specified once
 
 builtin_macros_eii_shared_macro_expected_function = `#[{$name}]` is only valid on functions
 builtin_macros_eii_shared_macro_expected_max_one_argument = `#[{$name}]` expected no arguments or a single argument: `#[{$name}(default)]`
+builtin_macros_eii_shared_macro_in_statement_position = `#[{$name}]` can only be used on functions inside a module
+    .label = `#[{$name}]` is used on this item, which is part of another item's local scope
 
 builtin_macros_env_not_defined = environment variable `{$var}` not defined at compile time
     .cargo = Cargo sets build script variables at run time. Use `std::env::var({$var_expr})` instead

--- a/compiler/rustc_builtin_macros/src/eii.rs
+++ b/compiler/rustc_builtin_macros/src/eii.rs
@@ -425,6 +425,9 @@ fn generate_attribute_macro_to_implement(
     // errors for eii's in std.
     macro_attrs.extend_from_slice(attrs_from_decl);
 
+    // Avoid "missing stability attribute" errors for eiis in std. See #146993.
+    macro_attrs.push(ecx.attr_name_value_str(sym::rustc_macro_transparency, sym::semiopaque, span));
+
     // #[builtin_macro(eii_shared_macro)]
     macro_attrs.push(ecx.attr_nested_word(sym::rustc_builtin_macro, sym::eii_shared_macro, span));
 

--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -1040,6 +1040,16 @@ pub(crate) struct EiiSharedMacroExpectedFunction {
 }
 
 #[derive(Diagnostic)]
+#[diag(builtin_macros_eii_shared_macro_in_statement_position)]
+pub(crate) struct EiiSharedMacroInStatementPosition {
+    #[primary_span]
+    pub span: Span,
+    pub name: String,
+    #[label]
+    pub item_span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(builtin_macros_eii_only_once)]
 pub(crate) struct EiiOnlyOnce {
     #[primary_span]

--- a/compiler/rustc_codegen_llvm/src/mono_item.rs
+++ b/compiler/rustc_codegen_llvm/src/mono_item.rs
@@ -144,7 +144,7 @@ impl CodegenCx<'_, '_> {
         }
 
         // PowerPC64 prefers TOC indirection to avoid copy relocations.
-        if matches!(self.tcx.sess.target.arch, Arch::PowerPC64 | Arch::PowerPC64LE) {
+        if self.tcx.sess.target.arch == Arch::PowerPC64 {
             return false;
         }
 

--- a/compiler/rustc_codegen_llvm/src/va_arg.rs
+++ b/compiler/rustc_codegen_llvm/src/va_arg.rs
@@ -1064,15 +1064,6 @@ pub(super) fn emit_va_arg<'ll, 'tcx>(
             AllowHigherAlign::Yes,
             ForceRightAdjust::Yes,
         ),
-        Arch::PowerPC64LE => emit_ptr_va_arg(
-            bx,
-            addr,
-            target_ty,
-            PassMode::Direct,
-            SlotSize::Bytes8,
-            AllowHigherAlign::Yes,
-            ForceRightAdjust::No,
-        ),
         Arch::LoongArch32 => emit_ptr_va_arg(
             bx,
             addr,

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -47,9 +47,7 @@ use rustc_trait_selection::traits::{
 use tracing::{debug, instrument};
 
 use crate::errors;
-use crate::hir_ty_lowering::{
-    FeedConstTy, HirTyLowerer, InherentAssocCandidate, RegionInferReason,
-};
+use crate::hir_ty_lowering::{HirTyLowerer, InherentAssocCandidate, RegionInferReason};
 
 pub(crate) mod dump;
 mod generics_of;
@@ -1499,7 +1497,7 @@ fn const_param_default<'tcx>(
 
     let ct = icx
         .lowerer()
-        .lower_const_arg(default_ct, FeedConstTy::with_type_of(tcx, def_id, identity_args));
+        .lower_const_arg(default_ct, tcx.type_of(def_id).instantiate(tcx, identity_args));
     ty::EarlyBinder::bind(ct)
 }
 
@@ -1557,7 +1555,7 @@ fn const_of_item<'tcx>(
     let identity_args = ty::GenericArgs::identity_for_item(tcx, def_id);
     let ct = icx
         .lowerer()
-        .lower_const_arg(ct_arg, FeedConstTy::with_type_of(tcx, def_id.to_def_id(), identity_args));
+        .lower_const_arg(ct_arg, tcx.type_of(def_id.to_def_id()).instantiate(tcx, identity_args));
     if let Err(e) = icx.check_tainted_by_errors()
         && !ct.references_error()
     {

--- a/compiler/rustc_hir_analysis/src/errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_hir_analysis/src/errors/wrong_number_of_generic_args.rs
@@ -988,6 +988,9 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
                     gen_arg_spans[self.num_expected_type_or_const_args() - 1]
                 };
             let span_hi_redundant_type_or_const_args = gen_arg_spans[gen_arg_spans.len() - 1];
+            if !span_lo_redundant_type_or_const_args.eq_ctxt(span_hi_redundant_type_or_const_args) {
+                return;
+            }
             let span_redundant_type_or_const_args = span_lo_redundant_type_or_const_args
                 .shrink_to_hi()
                 .to(span_hi_redundant_type_or_const_args);

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
@@ -20,7 +20,7 @@ use tracing::{debug, instrument};
 
 use crate::errors;
 use crate::hir_ty_lowering::{
-    AssocItemQSelf, FeedConstTy, GenericsArgsErrExtend, HirTyLowerer, ImpliedBoundsContext,
+    AssocItemQSelf, GenericsArgsErrExtend, HirTyLowerer, ImpliedBoundsContext,
     OverlappingAsssocItemConstraints, PredicateFilter, RegionInferReason,
 };
 
@@ -543,7 +543,6 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 let term = match term {
                     hir::Term::Ty(ty) => self.lower_ty(ty).into(),
                     hir::Term::Const(ct) => {
-                        // Provide the resolved type of the associated constant
                         let ty = projection_term.map_bound(|alias| {
                             tcx.type_of(alias.def_id).instantiate(tcx, alias.args)
                         });
@@ -554,7 +553,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                             constraint.hir_id,
                         );
 
-                        self.lower_const_arg(ct, FeedConstTy::WithTy(ty)).into()
+                        self.lower_const_arg(ct, ty).into()
                     }
                 };
 

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -253,35 +253,6 @@ impl AssocItemQSelf {
     }
 }
 
-/// In some cases, [`hir::ConstArg`]s that are being used in the type system
-/// through const generics need to have their type "fed" to them
-/// using the query system.
-///
-/// Use this enum with `<dyn HirTyLowerer>::lower_const_arg` to instruct it with the
-/// desired behavior.
-#[derive(Debug, Clone, Copy)]
-pub enum FeedConstTy<'tcx> {
-    /// Feed the type to the (anno) const arg.
-    WithTy(Ty<'tcx>),
-    /// Don't feed the type.
-    No,
-}
-
-impl<'tcx> FeedConstTy<'tcx> {
-    /// The `DefId` belongs to the const param that we are supplying
-    /// this (anon) const arg to.
-    ///
-    /// The list of generic args is used to instantiate the parameters
-    /// used by the type of the const param specified by `DefId`.
-    pub fn with_type_of(
-        tcx: TyCtxt<'tcx>,
-        def_id: DefId,
-        generic_args: &[ty::GenericArg<'tcx>],
-    ) -> Self {
-        Self::WithTy(tcx.type_of(def_id).instantiate(tcx, generic_args))
-    }
-}
-
 #[derive(Debug, Clone, Copy)]
 enum LowerTypeRelativePathMode {
     Type(PermitVariants),
@@ -733,7 +704,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                         // Ambig portions of `ConstArg` are handled in the match arm below
                         .lower_const_arg(
                             ct.as_unambig_ct(),
-                            FeedConstTy::with_type_of(tcx, param.def_id, preceding_args),
+                            tcx.type_of(param.def_id).instantiate(tcx, preceding_args),
                         )
                         .into(),
                     (&GenericParamDefKind::Const { .. }, GenericArg::Infer(inf)) => {
@@ -1322,7 +1293,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                                             constraint.hir_id,
                                         );
 
-                                        self.lower_const_arg(ct, FeedConstTy::WithTy(ty)).into()
+                                        self.lower_const_arg(ct, ty).into()
                                     }
                                 };
                                 if term.references_error() {
@@ -2347,16 +2318,10 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
 
     /// Lower a [`hir::ConstArg`] to a (type-level) [`ty::Const`](Const).
     #[instrument(skip(self), level = "debug")]
-    pub fn lower_const_arg(
-        &self,
-        const_arg: &hir::ConstArg<'tcx>,
-        feed: FeedConstTy<'tcx>,
-    ) -> Const<'tcx> {
+    pub fn lower_const_arg(&self, const_arg: &hir::ConstArg<'tcx>, ty: Ty<'tcx>) -> Const<'tcx> {
         let tcx = self.tcx();
 
-        if let FeedConstTy::WithTy(anon_const_type) = feed
-            && let hir::ConstArgKind::Anon(anon) = &const_arg.kind
-        {
+        if let hir::ConstArgKind::Anon(anon) = &const_arg.kind {
             // FIXME(generic_const_parameter_types): Ideally we remove these errors below when
             // we have the ability to intermix typeck of anon const const args with the parent
             // bodies typeck.
@@ -2366,7 +2331,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             // hir typeck was using equality but mir borrowck wound up using subtyping as that could
             // result in a non-infer in hir typeck but a region variable in borrowck.
             if tcx.features().generic_const_parameter_types()
-                && (anon_const_type.has_free_regions() || anon_const_type.has_erased_regions())
+                && (ty.has_free_regions() || ty.has_erased_regions())
             {
                 let e = self.dcx().span_err(
                     const_arg.span,
@@ -2378,7 +2343,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             // We must error if the instantiated type has any inference variables as we will
             // use this type to feed the `type_of` and query results must not contain inference
             // variables otherwise we will ICE.
-            if anon_const_type.has_non_region_infer() {
+            if ty.has_non_region_infer() {
                 let e = self.dcx().span_err(
                     const_arg.span,
                     "anonymous constants with inferred types are not yet supported",
@@ -2388,7 +2353,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             }
             // We error when the type contains unsubstituted generics since we do not currently
             // give the anon const any of the generics from the parent.
-            if anon_const_type.has_non_region_param() {
+            if ty.has_non_region_param() {
                 let e = self.dcx().span_err(
                     const_arg.span,
                     "anonymous constants referencing generics are not yet supported",
@@ -2397,12 +2362,12 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 return ty::Const::new_error(tcx, e);
             }
 
-            tcx.feed_anon_const_type(anon.def_id, ty::EarlyBinder::bind(anon_const_type));
+            tcx.feed_anon_const_type(anon.def_id, ty::EarlyBinder::bind(ty));
         }
 
         let hir_id = const_arg.hir_id;
         match const_arg.kind {
-            hir::ConstArgKind::Tup(exprs) => self.lower_const_arg_tup(exprs, feed, const_arg.span),
+            hir::ConstArgKind::Tup(exprs) => self.lower_const_arg_tup(exprs, ty, const_arg.span),
             hir::ConstArgKind::Path(hir::QPath::Resolved(maybe_qself, path)) => {
                 debug!(?maybe_qself, ?path);
                 let opt_self_ty = maybe_qself.as_ref().map(|qself| self.lower_ty(qself));
@@ -2426,16 +2391,12 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             hir::ConstArgKind::TupleCall(qpath, args) => {
                 self.lower_const_arg_tuple_call(hir_id, qpath, args, const_arg.span)
             }
-            hir::ConstArgKind::Array(array_expr) => self.lower_const_arg_array(array_expr, feed),
+            hir::ConstArgKind::Array(array_expr) => self.lower_const_arg_array(array_expr, ty),
             hir::ConstArgKind::Anon(anon) => self.lower_const_arg_anon(anon),
             hir::ConstArgKind::Infer(()) => self.ct_infer(None, const_arg.span),
             hir::ConstArgKind::Error(e) => ty::Const::new_error(tcx, e),
-            hir::ConstArgKind::Literal(kind) if let FeedConstTy::WithTy(anon_const_type) = feed => {
-                self.lower_const_arg_literal(&kind, anon_const_type, const_arg.span)
-            }
-            hir::ConstArgKind::Literal(..) => {
-                let e = self.dcx().span_err(const_arg.span, "literal of unknown type");
-                ty::Const::new_error(tcx, e)
+            hir::ConstArgKind::Literal(kind) => {
+                self.lower_const_arg_literal(&kind, ty, const_arg.span)
             }
         }
     }
@@ -2443,13 +2404,9 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
     fn lower_const_arg_array(
         &self,
         array_expr: &'tcx hir::ConstArgArrayExpr<'tcx>,
-        feed: FeedConstTy<'tcx>,
+        ty: Ty<'tcx>,
     ) -> Const<'tcx> {
         let tcx = self.tcx();
-
-        let FeedConstTy::WithTy(ty) = feed else {
-            return Const::new_error_with_message(tcx, array_expr.span, "unsupported const array");
-        };
 
         let ty::Array(elem_ty, _) = ty.kind() else {
             return Const::new_error_with_message(
@@ -2462,7 +2419,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         let elems = array_expr
             .elems
             .iter()
-            .map(|elem| self.lower_const_arg(elem, FeedConstTy::WithTy(*elem_ty)))
+            .map(|elem| self.lower_const_arg(elem, *elem_ty))
             .collect::<Vec<_>>();
 
         let valtree = ty::ValTree::from_branches(tcx, elems);
@@ -2545,7 +2502,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             .iter()
             .zip(args)
             .map(|(field_def, arg)| {
-                self.lower_const_arg(arg, FeedConstTy::with_type_of(tcx, field_def.did, adt_args))
+                self.lower_const_arg(arg, tcx.type_of(field_def.did).instantiate(tcx, adt_args))
             })
             .collect::<Vec<_>>();
 
@@ -2564,14 +2521,10 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
     fn lower_const_arg_tup(
         &self,
         exprs: &'tcx [&'tcx hir::ConstArg<'tcx>],
-        feed: FeedConstTy<'tcx>,
+        ty: Ty<'tcx>,
         span: Span,
     ) -> Const<'tcx> {
         let tcx = self.tcx();
-
-        let FeedConstTy::WithTy(ty) = feed else {
-            return Const::new_error_with_message(tcx, span, "const tuple lack type information");
-        };
 
         let ty::Tuple(tys) = ty.kind() else {
             let e = tcx.dcx().span_err(span, format!("expected `{}`, found const tuple", ty));
@@ -2581,7 +2534,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         let exprs = exprs
             .iter()
             .zip(tys.iter())
-            .map(|(expr, ty)| self.lower_const_arg(expr, FeedConstTy::WithTy(ty)))
+            .map(|(expr, ty)| self.lower_const_arg(expr, ty))
             .collect::<Vec<_>>();
 
         let valtree = ty::ValTree::from_branches(tcx, exprs);
@@ -2668,7 +2621,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
 
                         self.lower_const_arg(
                             expr.expr,
-                            FeedConstTy::with_type_of(tcx, field_def.did, adt_args),
+                            tcx.type_of(field_def.did).instantiate(tcx, adt_args),
                         )
                     }
                     None => {
@@ -3030,7 +2983,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 .unwrap_or_else(|guar| Ty::new_error(tcx, guar))
             }
             hir::TyKind::Array(ty, length) => {
-                let length = self.lower_const_arg(length, FeedConstTy::WithTy(tcx.types.usize));
+                let length = self.lower_const_arg(length, tcx.types.usize);
                 Ty::new_array_with_const_len(tcx, self.lower_ty(ty), length)
             }
             hir::TyKind::Infer(()) => {
@@ -3070,8 +3023,8 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                     // Keep this list of types in sync with the list of types that
                     // the `RangePattern` trait is implemented for.
                     ty::Int(_) | ty::Uint(_) | ty::Char => {
-                        let start = self.lower_const_arg(start, FeedConstTy::WithTy(ty));
-                        let end = self.lower_const_arg(end, FeedConstTy::WithTy(ty));
+                        let start = self.lower_const_arg(start, ty);
+                        let end = self.lower_const_arg(end, ty);
                         Ok(ty::PatternKind::Range { start, end })
                     }
                     _ => Err(self

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -1283,6 +1283,8 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                                             )
                                         });
 
+                                        // FIXME(mgca): code duplication with other places we lower
+                                        // the rhs' of associated const bindings
                                         let ty = projection_term.map_bound(|alias| {
                                             tcx.type_of(alias.def_id).instantiate(tcx, alias.args)
                                         });

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -101,7 +101,7 @@ use rustc_span::{ErrorGuaranteed, Span};
 use rustc_trait_selection::traits;
 
 pub use crate::collect::suggest_impl_trait;
-use crate::hir_ty_lowering::{FeedConstTy, HirTyLowerer};
+use crate::hir_ty_lowering::HirTyLowerer;
 
 rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
 
@@ -301,8 +301,8 @@ pub fn lower_ty<'tcx>(tcx: TyCtxt<'tcx>, hir_ty: &hir::Ty<'tcx>) -> Ty<'tcx> {
 pub fn lower_const_arg_for_rustdoc<'tcx>(
     tcx: TyCtxt<'tcx>,
     hir_ct: &hir::ConstArg<'tcx>,
-    feed: FeedConstTy<'tcx>,
+    ty: Ty<'tcx>,
 ) -> Const<'tcx> {
     let env_def_id = tcx.hir_get_parent_item(hir_ct.hir_id);
-    collect::ItemCtxt::new(tcx, env_def_id.def_id).lowerer().lower_const_arg(hir_ct, feed)
+    collect::ItemCtxt::new(tcx, env_def_id.def_id).lowerer().lower_const_arg(hir_ct, ty)
 }

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -21,7 +21,7 @@ use rustc_hir::def_id::DefId;
 use rustc_hir::lang_items::LangItem;
 use rustc_hir::{ExprKind, HirId, QPath, find_attr, is_range_literal};
 use rustc_hir_analysis::NoVariantNamed;
-use rustc_hir_analysis::hir_ty_lowering::{FeedConstTy, HirTyLowerer as _};
+use rustc_hir_analysis::hir_ty_lowering::HirTyLowerer as _;
 use rustc_infer::infer::{self, DefineOpaqueTypes, InferOk, RegionVariableOrigin};
 use rustc_infer::traits::query::NoSolution;
 use rustc_middle::ty::adjustment::{Adjust, Adjustment, AllowTwoPhase};
@@ -1749,10 +1749,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let count_span = count.span;
         let count = self.try_structurally_resolve_const(
             count_span,
-            self.normalize(
-                count_span,
-                self.lower_const_arg(count, FeedConstTy::WithTy(tcx.types.usize)),
-            ),
+            self.normalize(count_span, self.lower_const_arg(count, tcx.types.usize)),
         );
 
         if let Some(count) = count.try_to_target_usize(tcx) {

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -1749,7 +1749,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let count_span = count.span;
         let count = self.try_structurally_resolve_const(
             count_span,
-            self.normalize(count_span, self.lower_const_arg(count, FeedConstTy::No)),
+            self.normalize(
+                count_span,
+                self.lower_const_arg(count, FeedConstTy::WithTy(tcx.types.usize)),
+            ),
         );
 
         if let Some(count) = count.try_to_target_usize(tcx) {

--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -7,7 +7,7 @@ use rustc_hir_analysis::hir_ty_lowering::generics::{
     check_generic_arg_count_for_call, lower_generic_args,
 };
 use rustc_hir_analysis::hir_ty_lowering::{
-    FeedConstTy, GenericArgsLowerer, HirTyLowerer, IsMethodCall, RegionInferReason,
+    GenericArgsLowerer, HirTyLowerer, IsMethodCall, RegionInferReason,
 };
 use rustc_infer::infer::{
     BoundRegionConversionTime, DefineOpaqueTypes, InferOk, RegionVariableOrigin,
@@ -447,7 +447,10 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
                         // We handle the ambig portions of `ConstArg` in the match arms below
                         .lower_const_arg(
                             ct.as_unambig_ct(),
-                            FeedConstTy::with_type_of(self.cfcx.tcx, param.def_id, preceding_args),
+                            self.cfcx
+                                .tcx
+                                .type_of(param.def_id)
+                                .instantiate(self.cfcx.tcx, preceding_args),
                         )
                         .into(),
                     (GenericParamDefKind::Const { .. }, GenericArg::Infer(inf)) => {

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -408,6 +408,7 @@ impl<'a> Parser<'a> {
         let insert_span = ident_span.shrink_to_lo();
 
         let ident = if self.token.is_ident()
+            && self.token.is_non_reserved_ident()
             && (!is_const || self.look_ahead(1, |t| *t == token::OpenParen))
             && self.look_ahead(1, |t| {
                 matches!(t.kind, token::Lt | token::OpenBrace | token::OpenParen)

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -212,12 +212,12 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         &mut self,
         ident: Ident,
         ns: Namespace,
-        new_binding: Decl<'ra>,
         old_binding: Decl<'ra>,
+        new_binding: Decl<'ra>,
     ) {
         // Error on the second of two conflicting names
         if old_binding.span.lo() > new_binding.span.lo() {
-            return self.report_conflict(ident, ns, old_binding, new_binding);
+            return self.report_conflict(ident, ns, new_binding, old_binding);
         }
 
         let container = match old_binding.parent_module.unwrap().kind {

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -300,13 +300,13 @@ fn remove_same_import<'ra>(d1: Decl<'ra>, d2: Decl<'ra>) -> (Decl<'ra>, Decl<'ra
     if let DeclKind::Import { import: import1, source_decl: d1_next } = d1.kind
         && let DeclKind::Import { import: import2, source_decl: d2_next } = d2.kind
         && import1 == import2
-        && d1.warn_ambiguity.get() == d2.warn_ambiguity.get()
     {
         assert_eq!(d1.ambiguity.get(), d2.ambiguity.get());
-        assert!(!d1.warn_ambiguity.get());
         assert_eq!(d1.expansion, d2.expansion);
         assert_eq!(d1.span, d2.span);
-        assert_eq!(d1.vis(), d2.vis());
+        // Visibility of the new import declaration may be different,
+        // because it already incorporates the visibility of the source binding.
+        // `warn_ambiguity` of a re-fetched glob can also change in both directions.
         remove_same_import(d1_next, d2_next)
     } else {
         (d1, d2)

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -348,8 +348,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     /// decide which one to keep.
     fn select_glob_decl(
         &self,
-        glob_decl: Decl<'ra>,
         old_glob_decl: Decl<'ra>,
+        glob_decl: Decl<'ra>,
         warn_ambiguity: bool,
     ) -> Decl<'ra> {
         assert!(glob_decl.is_glob_import());
@@ -369,7 +369,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         // with the re-fetched decls.
         // This is probably incorrect in corner cases, and the outdated decls still get
         // propagated to other places and get stuck there, but that's what we have at the moment.
-        let (deep_decl, old_deep_decl) = remove_same_import(glob_decl, old_glob_decl);
+        let (old_deep_decl, deep_decl) = remove_same_import(old_glob_decl, glob_decl);
         if deep_decl != glob_decl {
             // Some import layers have been removed, need to overwrite.
             assert_ne!(old_deep_decl, old_glob_decl);
@@ -436,7 +436,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 match (old_decl.is_glob_import(), decl.is_glob_import()) {
                     (true, true) => {
                         resolution.glob_decl =
-                            Some(this.select_glob_decl(decl, old_decl, warn_ambiguity));
+                            Some(this.select_glob_decl(old_decl, decl, warn_ambiguity));
                     }
                     (old_glob @ true, false) | (old_glob @ false, true) => {
                         let (glob_decl, non_glob_decl) =
@@ -446,7 +446,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                             && old_glob_decl != glob_decl
                         {
                             resolution.glob_decl =
-                                Some(this.select_glob_decl(glob_decl, old_glob_decl, false));
+                                Some(this.select_glob_decl(old_glob_decl, glob_decl, false));
                         } else {
                             resolution.glob_decl = Some(glob_decl);
                         }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1723,7 +1723,6 @@ symbols! {
         postfix_match,
         powerpc,
         powerpc64,
-        powerpc64le,
         powerpc_target_feature,
         powf16,
         powf32,

--- a/compiler/rustc_target/src/asm/mod.rs
+++ b/compiler/rustc_target/src/asm/mod.rs
@@ -261,7 +261,7 @@ impl InlineAsmArch {
             Arch::Mips | Arch::Mips32r6 => Some(Self::Mips),
             Arch::Mips64 | Arch::Mips64r6 => Some(Self::Mips64),
             Arch::PowerPC => Some(Self::PowerPC),
-            Arch::PowerPC64 | Arch::PowerPC64LE => Some(Self::PowerPC64),
+            Arch::PowerPC64 => Some(Self::PowerPC64),
             Arch::S390x => Some(Self::S390x),
             Arch::Sparc => Some(Self::Sparc),
             Arch::Sparc64 => Some(Self::Sparc64),

--- a/compiler/rustc_target/src/callconv/mod.rs
+++ b/compiler/rustc_target/src/callconv/mod.rs
@@ -702,7 +702,7 @@ impl<'a, Ty> FnAbi<'a, Ty> {
             Arch::RiscV32 | Arch::RiscV64 => riscv::compute_abi_info(cx, self),
             Arch::Wasm32 | Arch::Wasm64 => wasm::compute_abi_info(cx, self),
             Arch::Bpf => bpf::compute_abi_info(cx, self),
-            arch @ (Arch::PowerPC64LE | Arch::SpirV | Arch::Other(_)) => {
+            arch @ (Arch::SpirV | Arch::Other(_)) => {
                 panic!("no lowering implemented for {arch}")
             }
         }

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1873,7 +1873,6 @@ crate::target_spec_enum! {
         Nvptx64 = "nvptx64",
         PowerPC = "powerpc",
         PowerPC64 = "powerpc64",
-        PowerPC64LE = "powerpc64le",
         RiscV32 = "riscv32",
         RiscV64 = "riscv64",
         S390x = "s390x",
@@ -1911,7 +1910,6 @@ impl Arch {
             Self::Nvptx64 => sym::nvptx64,
             Self::PowerPC => sym::powerpc,
             Self::PowerPC64 => sym::powerpc64,
-            Self::PowerPC64LE => sym::powerpc64le,
             Self::RiscV32 => sym::riscv32,
             Self::RiscV64 => sym::riscv64,
             Self::S390x => sym::s390x,
@@ -1940,8 +1938,8 @@ impl Arch {
 
             AArch64 | AmdGpu | Arm | Arm64EC | Avr | CSky | Hexagon | LoongArch32 | LoongArch64
             | M68k | Mips | Mips32r6 | Mips64 | Mips64r6 | Msp430 | Nvptx64 | PowerPC
-            | PowerPC64 | PowerPC64LE | RiscV32 | RiscV64 | S390x | Sparc | Sparc64 | Wasm32
-            | Wasm64 | X86 | X86_64 | Xtensa => true,
+            | PowerPC64 | RiscV32 | RiscV64 | S390x | Sparc | Sparc64 | Wasm32 | Wasm64 | X86
+            | X86_64 | Xtensa => true,
         }
     }
 }
@@ -3436,7 +3434,6 @@ impl Target {
             Arch::Arm64EC => (Architecture::Aarch64, Some(object::SubArchitecture::Arm64EC)),
             Arch::AmdGpu
             | Arch::Nvptx64
-            | Arch::PowerPC64LE
             | Arch::SpirV
             | Arch::Wasm32
             | Arch::Wasm64

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -986,7 +986,6 @@ impl Target {
             Arch::AmdGpu
             | Arch::Avr
             | Arch::Msp430
-            | Arch::PowerPC64LE
             | Arch::SpirV
             | Arch::Xtensa
             | Arch::Other(_) => &[],
@@ -1015,12 +1014,7 @@ impl Target {
             Arch::CSky => CSKY_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI,
             // FIXME: for some tier3 targets, we are overly cautious and always give warnings
             // when passing args in vector registers.
-            Arch::Avr
-            | Arch::Msp430
-            | Arch::PowerPC64LE
-            | Arch::SpirV
-            | Arch::Xtensa
-            | Arch::Other(_) => &[],
+            Arch::Avr | Arch::Msp430 | Arch::SpirV | Arch::Xtensa | Arch::Other(_) => &[],
         }
     }
 

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -6,7 +6,7 @@ build = "build.rs"
 default-run = "bootstrap"
 
 [features]
-build-metrics = ["sysinfo"]
+build-metrics = ["dep:sysinfo", "build_helper/metrics"]
 tracing = ["dep:tracing", "dep:tracing-chrome", "dep:tracing-subscriber", "dep:chrono", "dep:tempfile"]
 
 [lib]

--- a/src/build_helper/Cargo.toml
+++ b/src/build_helper/Cargo.toml
@@ -6,5 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = "1"
-serde_derive = "1"
+serde = { version = "1", optional = true }
+serde_derive = { version = "1", optional = true }
+
+[features]
+metrics = ["dep:serde", "dep:serde_derive"]

--- a/src/build_helper/src/lib.rs
+++ b/src/build_helper/src/lib.rs
@@ -4,6 +4,7 @@ pub mod ci;
 pub mod drop_bomb;
 pub mod fs;
 pub mod git;
+#[cfg(feature = "metrics")]
 pub mod metrics;
 pub mod npm;
 pub mod stage0_parser;

--- a/src/ci/citool/Cargo.toml
+++ b/src/ci/citool/Cargo.toml
@@ -15,7 +15,7 @@ serde_yaml = "0.9"
 serde_json = "1"
 ureq = { version = "3", features = ["json"] }
 
-build_helper = { path = "../../build_helper" }
+build_helper = { path = "../../build_helper", features = ["metrics"] }
 
 [dev-dependencies]
 insta = "1"

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -469,11 +469,23 @@ fn clean_middle_term<'tcx>(
     }
 }
 
-fn clean_hir_term<'tcx>(term: &hir::Term<'tcx>, cx: &mut DocContext<'tcx>) -> Term {
+fn clean_hir_term<'tcx>(
+    assoc_item: Option<DefId>,
+    term: &hir::Term<'tcx>,
+    span: rustc_span::Span,
+    cx: &mut DocContext<'tcx>,
+) -> Term {
     match term {
         hir::Term::Ty(ty) => Term::Type(clean_ty(ty, cx)),
         hir::Term::Const(c) => {
-            let ct = lower_const_arg_for_rustdoc(cx.tcx, c, FeedConstTy::No);
+            let ty = if let Some(assoc_item) = assoc_item {
+                // FIXME(generic_const_items): this should instantiate with the alias item's args
+                cx.tcx.type_of(assoc_item).instantiate_identity()
+            } else {
+                Ty::new_error_with_message(cx.tcx, span, "cannot find the associated constant")
+            };
+
+            let ct = lower_const_arg_for_rustdoc(cx.tcx, c, FeedConstTy::WithTy(ty));
             Term::Constant(clean_middle_const(ty::Binder::dummy(ct), cx))
         }
     }
@@ -650,7 +662,14 @@ fn clean_generic_param<'tcx>(
             GenericParamDefKind::Const {
                 ty: Box::new(clean_ty(ty, cx)),
                 default: default.map(|ct| {
-                    Box::new(lower_const_arg_for_rustdoc(cx.tcx, ct, FeedConstTy::No).to_string())
+                    Box::new(
+                        lower_const_arg_for_rustdoc(
+                            cx.tcx,
+                            ct,
+                            FeedConstTy::WithTy(lower_ty(cx.tcx, ty)),
+                        )
+                        .to_string(),
+                    )
                 }),
             },
         ),
@@ -1531,7 +1550,7 @@ fn first_non_private_clean_path<'tcx>(
         && path_last.args.is_some()
     {
         assert!(new_path_last.args.is_empty());
-        new_path_last.args = clean_generic_args(path_last_args, cx);
+        new_path_last.args = clean_generic_args(None, path_last_args, cx);
     }
     new_clean_path
 }
@@ -1812,7 +1831,11 @@ pub(crate) fn clean_ty<'tcx>(ty: &hir::Ty<'tcx>, cx: &mut DocContext<'tcx>) -> T
             let length = match const_arg.kind {
                 hir::ConstArgKind::Infer(..) | hir::ConstArgKind::Error(..) => "_".to_string(),
                 hir::ConstArgKind::Anon(hir::AnonConst { def_id, .. }) => {
-                    let ct = lower_const_arg_for_rustdoc(cx.tcx, const_arg, FeedConstTy::No);
+                    let ct = lower_const_arg_for_rustdoc(
+                        cx.tcx,
+                        const_arg,
+                        FeedConstTy::WithTy(cx.tcx.types.usize),
+                    );
                     let typing_env = ty::TypingEnv::post_analysis(cx.tcx, *def_id);
                     let ct = cx.tcx.normalize_erasing_regions(typing_env, ct);
                     print_const(cx, ct)
@@ -1823,7 +1846,11 @@ pub(crate) fn clean_ty<'tcx>(ty: &hir::Ty<'tcx>, cx: &mut DocContext<'tcx>) -> T
                 | hir::ConstArgKind::Tup(..)
                 | hir::ConstArgKind::Array(..)
                 | hir::ConstArgKind::Literal(..) => {
-                    let ct = lower_const_arg_for_rustdoc(cx.tcx, const_arg, FeedConstTy::No);
+                    let ct = lower_const_arg_for_rustdoc(
+                        cx.tcx,
+                        const_arg,
+                        FeedConstTy::WithTy(cx.tcx.types.usize),
+                    );
                     print_const(cx, ct)
                 }
             };
@@ -2516,6 +2543,7 @@ fn clean_path<'tcx>(path: &hir::Path<'tcx>, cx: &mut DocContext<'tcx>) -> Path {
 }
 
 fn clean_generic_args<'tcx>(
+    trait_did: Option<DefId>,
     generic_args: &hir::GenericArgs<'tcx>,
     cx: &mut DocContext<'tcx>,
 ) -> GenericArgs {
@@ -2539,7 +2567,13 @@ fn clean_generic_args<'tcx>(
             let constraints = generic_args
                 .constraints
                 .iter()
-                .map(|c| clean_assoc_item_constraint(c, cx))
+                .map(|c| {
+                    clean_assoc_item_constraint(
+                        trait_did.expect("only trait ref has constraints"),
+                        c,
+                        cx,
+                    )
+                })
                 .collect::<ThinVec<_>>();
             GenericArgs::AngleBracketed { args, constraints }
         }
@@ -2562,7 +2596,11 @@ fn clean_path_segment<'tcx>(
     path: &hir::PathSegment<'tcx>,
     cx: &mut DocContext<'tcx>,
 ) -> PathSegment {
-    PathSegment { name: path.ident.name, args: clean_generic_args(path.args(), cx) }
+    let trait_did = match path.res {
+        hir::def::Res::Def(DefKind::Trait | DefKind::TraitAlias, did) => Some(did),
+        _ => None,
+    };
+    PathSegment { name: path.ident.name, args: clean_generic_args(trait_did, path.args(), cx) }
 }
 
 fn clean_bare_fn_ty<'tcx>(
@@ -3126,17 +3164,29 @@ fn clean_maybe_renamed_foreign_item<'tcx>(
 }
 
 fn clean_assoc_item_constraint<'tcx>(
+    trait_did: DefId,
     constraint: &hir::AssocItemConstraint<'tcx>,
     cx: &mut DocContext<'tcx>,
 ) -> AssocItemConstraint {
     AssocItemConstraint {
         assoc: PathSegment {
             name: constraint.ident.name,
-            args: clean_generic_args(constraint.gen_args, cx),
+            args: clean_generic_args(None, constraint.gen_args, cx),
         },
         kind: match constraint.kind {
             hir::AssocItemConstraintKind::Equality { ref term } => {
-                AssocItemConstraintKind::Equality { term: clean_hir_term(term, cx) }
+                let assoc_tag = match term {
+                    hir::Term::Ty(_) => ty::AssocTag::Type,
+                    hir::Term::Const(_) => ty::AssocTag::Const,
+                };
+                let assoc_item = cx
+                    .tcx
+                    .associated_items(trait_did)
+                    .find_by_ident_and_kind(cx.tcx, constraint.ident, assoc_tag, trait_did)
+                    .map(|item| item.def_id);
+                AssocItemConstraintKind::Equality {
+                    term: clean_hir_term(assoc_item, term, constraint.span, cx),
+                }
             }
             hir::AssocItemConstraintKind::Bound { bounds } => AssocItemConstraintKind::Bound {
                 bounds: bounds.iter().filter_map(|b| clean_generic_bound(b, cx)).collect(),

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -614,7 +614,9 @@ impl<'tcx> LinkCollector<'_, 'tcx> {
                 // Resolve the link on the type the alias points to.
                 // FIXME: if the associated item is defined directly on the type alias,
                 // it will show up on its documentation page, we should link there instead.
-                let Some(res) = self.ty_to_res(tcx.type_of(did).instantiate_identity()) else { return Vec::new() };
+                let Some(res) = self.ty_to_res(tcx.type_of(did).instantiate_identity()) else {
+                    return Vec::new();
+                };
                 self.resolve_associated_item(res, item_name, ns, disambiguator, module_id)
             }
             Res::Def(
@@ -720,10 +722,7 @@ impl<'tcx> LinkCollector<'_, 'tcx> {
                 Ident::with_dummy_span(item_name),
                 ns,
             )
-            .map(|item| {
-                let res = Res::Def(item.as_def_kind(), item.def_id);
-                (res, item.def_id)
-            })
+            .map(|item| (root_res, item.def_id))
             .collect::<Vec<_>>(),
             _ => Vec::new(),
         }

--- a/src/tools/miri/src/shims/alloc.rs
+++ b/src/tools/miri/src/shims/alloc.rs
@@ -52,7 +52,6 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             | Arch::Bpf
             | Arch::Msp430
             | Arch::Nvptx64
-            | Arch::PowerPC64LE
             | Arch::SpirV
             | Arch::Other(_)) => bug!("unsupported target architecture for malloc: `{arch}`"),
         };

--- a/src/tools/opt-dist/Cargo.toml
+++ b/src/tools/opt-dist/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-build_helper = { path = "../../build_helper" }
+build_helper = { path = "../../build_helper", features = ["metrics"] }
 env_logger = "0.11"
 log = "0.4"
 anyhow = "1"

--- a/tests/rustdoc-html/intra-doc/adt-through-alias.rs
+++ b/tests/rustdoc-html/intra-doc/adt-through-alias.rs
@@ -3,12 +3,35 @@
 //! [`TheStructAlias::the_field`]
 //! [`TheEnumAlias::TheVariant`]
 //! [`TheEnumAlias::TheVariant::the_field`]
+//! [`TheUnionAlias::f1`]
+//!
+//! [`TheStruct::trait_`]
+//! [`TheStructAlias::trait_`]
+//! [`TheEnum::trait_`]
+//! [`TheEnumAlias::trait_`]
+//!
+//! [`TheStruct::inherent`]
+//! [`TheStructAlias::inherent`]
+//! [`TheEnum::inherent`]
+//! [`TheEnumAlias::inherent`]
 
-// FIXME: this should resolve to the alias's version
-//@ has foo/index.html '//a[@href="struct.TheStruct.html#structfield.the_field"]' 'TheStructAlias::the_field'
-// FIXME: this should resolve to the alias's version
-//@ has foo/index.html '//a[@href="enum.TheEnum.html#variant.TheVariant"]' 'TheEnumAlias::TheVariant'
+//@ has foo/index.html '//a[@href="type.TheStructAlias.html#structfield.the_field"]' 'TheStructAlias::the_field'
+//@ has foo/index.html '//a[@href="type.TheEnumAlias.html#variant.TheVariant"]' 'TheEnumAlias::TheVariant'
 //@ has foo/index.html '//a[@href="type.TheEnumAlias.html#variant.TheVariant.field.the_field"]' 'TheEnumAlias::TheVariant::the_field'
+//@ has foo/index.html '//a[@href="type.TheUnionAlias.html#structfield.f1"]' 'TheUnionAlias::f1'
+
+//@ has foo/index.html '//a[@href="struct.TheStruct.html#method.trait_"]' 'TheStruct::trait_'
+//@ has foo/index.html '//a[@href="struct.TheStruct.html#method.trait_"]' 'TheStructAlias::trait_'
+//@ has foo/index.html '//a[@href="enum.TheEnum.html#method.trait_"]' 'TheEnum::trait_'
+// FIXME: this one should resolve to alias since it's impl Trait for TheEnumAlias
+//@ has foo/index.html '//a[@href="enum.TheEnum.html#method.trait_"]' 'TheEnumAlias::trait_'
+
+//@ has foo/index.html '//a[@href="struct.TheStruct.html#method.inherent"]' 'TheStruct::inherent'
+// FIXME: this one should resolve to alias
+//@ has foo/index.html '//a[@href="struct.TheStruct.html#method.inherent"]' 'TheStructAlias::inherent'
+//@ has foo/index.html '//a[@href="enum.TheEnum.html#method.inherent"]' 'TheEnum::inherent'
+// FIXME: this one should resolve to alias
+//@ has foo/index.html '//a[@href="enum.TheEnum.html#method.inherent"]' 'TheEnumAlias::inherent'
 
 pub struct TheStruct {
     pub the_field: i32,
@@ -21,5 +44,28 @@ pub enum TheEnum {
 }
 
 pub type TheEnumAlias = TheEnum;
+
+pub trait Trait {
+    fn trait_() {}
+}
+
+impl Trait for TheStruct {}
+
+impl Trait for TheEnumAlias {}
+
+impl TheStruct {
+    pub fn inherent() {}
+}
+
+impl TheEnumAlias {
+    pub fn inherent() {}
+}
+
+pub union TheUnion {
+    pub f1: usize,
+    pub f2: isize,
+}
+
+pub type TheUnionAlias = TheUnion;
 
 fn main() {}

--- a/tests/rustdoc-html/intra-doc/adt-through-alias.rs
+++ b/tests/rustdoc-html/intra-doc/adt-through-alias.rs
@@ -1,0 +1,25 @@
+#![crate_name = "foo"]
+
+//! [`TheStructAlias::the_field`]
+//! [`TheEnumAlias::TheVariant`]
+//! [`TheEnumAlias::TheVariant::the_field`]
+
+// FIXME: this should resolve to the alias's version
+//@ has foo/index.html '//a[@href="struct.TheStruct.html#structfield.the_field"]' 'TheStructAlias::the_field'
+// FIXME: this should resolve to the alias's version
+//@ has foo/index.html '//a[@href="enum.TheEnum.html#variant.TheVariant"]' 'TheEnumAlias::TheVariant'
+//@ has foo/index.html '//a[@href="type.TheEnumAlias.html#variant.TheVariant.field.the_field"]' 'TheEnumAlias::TheVariant::the_field'
+
+pub struct TheStruct {
+    pub the_field: i32,
+}
+
+pub type TheStructAlias = TheStruct;
+
+pub enum TheEnum {
+    TheVariant { the_field: i32 },
+}
+
+pub type TheEnumAlias = TheEnum;
+
+fn main() {}

--- a/tests/rustdoc-html/intra-doc/associated-items.rs
+++ b/tests/rustdoc-html/intra-doc/associated-items.rs
@@ -13,7 +13,9 @@ pub fn foo() {}
 //@ has 'associated_items/struct.MyStruct.html' '//a[@href="struct.MyStruct.html#method.method"]' 'link from struct'
 //@ has 'associated_items/struct.MyStruct.html' '//a[@href="struct.MyStruct.html#method.clone"]' 'MyStruct::clone'
 //@ has 'associated_items/struct.MyStruct.html' '//a[@href="struct.MyStruct.html#associatedtype.Input"]' 'MyStruct::Input'
-pub struct MyStruct { foo: () }
+pub struct MyStruct {
+    foo: (),
+}
 
 impl Clone for MyStruct {
     fn clone(&self) -> Self {
@@ -31,8 +33,7 @@ impl T for MyStruct {
 
     /// [link from method][MyStruct::method] on method
     //@ has 'associated_items/struct.MyStruct.html' '//a[@href="struct.MyStruct.html#method.method"]' 'link from method'
-    fn method(i: usize) {
-    }
+    fn method(i: usize) {}
 }
 
 /// Ambiguity between which trait to use
@@ -57,7 +58,7 @@ impl T2 for S {
     fn ambiguous_method() {}
 }
 
-//@ has associated_items/enum.MyEnum.html '//a/@href' 'enum.MyEnum.html#variant.MyVariant'
+//@ has associated_items/enum.MyEnum.html '//a/@href' 'type.MyEnumAlias.html#variant.MyVariant'
 /// Link to [MyEnumAlias::MyVariant]
 pub enum MyEnum {
     MyVariant,

--- a/tests/ui/const-generics/associated-const-bindings/ambiguity.stderr
+++ b/tests/ui/const-generics/associated-const-bindings/ambiguity.stderr
@@ -27,6 +27,12 @@ LL |     const C: &'static str;
 ...
 LL | fn take1(_: impl Trait1<C = "?">) {}
    |                         ^^^^^^^ ambiguous associated constant `C`
+   |
+   = help: consider introducing a new type parameter `T` and adding `where` constraints:
+               where
+                   T: Trait1,
+                   T: Parent2::C = "?",
+                   T: Parent1::C = "?"
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/incorrect-const-param.rs
+++ b/tests/ui/const-generics/incorrect-const-param.rs
@@ -1,0 +1,45 @@
+// #84327
+
+struct VecWrapper<T>(Vec<T>);
+
+// Correct
+impl<T, const N: usize> From<[T; N]> for VecWrapper<T>
+where
+    T: Clone,
+{
+    fn from(slice: [T; N]) -> Self {
+        VecWrapper(slice.to_vec())
+    }
+}
+
+// Forgot const
+impl<T, N: usize> From<[T; N]> for VecWrapper<T> //~ ERROR expected value, found type parameter `N`
+where //~^ ERROR expected trait, found builtin type `usize`
+    T: Clone,
+{
+    fn from(slice: [T; N]) -> Self { //~ ERROR expected value, found type parameter `N`
+        VecWrapper(slice.to_vec())
+    }
+}
+
+// Forgot type
+impl<T, const N> From<[T; N]> for VecWrapper<T> //~ ERROR expected `:`, found `>`
+where
+    T: Clone,
+{
+    fn from(slice: [T; N]) -> Self {
+        VecWrapper(slice.to_vec())
+    }
+}
+
+// Forgot const and type
+impl<T, N> From<[T; N]> for VecWrapper<T> //~ ERROR expected value, found type parameter `N`
+where
+    T: Clone,
+{
+    fn from(slice: [T; N]) -> Self { //~ ERROR expected value, found type parameter `N`
+        VecWrapper(slice.to_vec())
+    }
+}
+
+fn main() {}

--- a/tests/ui/const-generics/incorrect-const-param.stderr
+++ b/tests/ui/const-generics/incorrect-const-param.stderr
@@ -1,0 +1,70 @@
+error: expected `:`, found `>`
+  --> $DIR/incorrect-const-param.rs:26:16
+   |
+LL | impl<T, const N> From<[T; N]> for VecWrapper<T>
+   |                ^ expected `:`
+   |
+help: you likely meant to write the type of the const parameter here
+   |
+LL | impl<T, const N: /* Type */> From<[T; N]> for VecWrapper<T>
+   |                ++++++++++++
+
+error[E0423]: expected value, found type parameter `N`
+  --> $DIR/incorrect-const-param.rs:16:28
+   |
+LL | impl<T, N: usize> From<[T; N]> for VecWrapper<T>
+   |         -                  ^ not a value
+   |         |
+   |         found this type parameter
+
+error[E0404]: expected trait, found builtin type `usize`
+  --> $DIR/incorrect-const-param.rs:16:12
+   |
+LL | impl<T, N: usize> From<[T; N]> for VecWrapper<T>
+   |            ^^^^^ not a trait
+   |
+help: you might have meant to write a const parameter here
+   |
+LL | impl<T, const N: usize> From<[T; N]> for VecWrapper<T>
+   |         +++++
+
+error[E0423]: expected value, found type parameter `N`
+  --> $DIR/incorrect-const-param.rs:20:24
+   |
+LL | impl<T, N: usize> From<[T; N]> for VecWrapper<T>
+   |         - found this type parameter
+...
+LL |     fn from(slice: [T; N]) -> Self {
+   |                        ^ not a value
+
+error[E0423]: expected value, found type parameter `N`
+  --> $DIR/incorrect-const-param.rs:36:21
+   |
+LL | impl<T, N> From<[T; N]> for VecWrapper<T>
+   |         -           ^ not a value
+   |         |
+   |         found this type parameter
+   |
+help: you might have meant to write a const parameter here
+   |
+LL | impl<T, const N: /* Type */> From<[T; N]> for VecWrapper<T>
+   |         +++++  ++++++++++++
+
+error[E0423]: expected value, found type parameter `N`
+  --> $DIR/incorrect-const-param.rs:40:24
+   |
+LL | impl<T, N> From<[T; N]> for VecWrapper<T>
+   |         - found this type parameter
+...
+LL |     fn from(slice: [T; N]) -> Self {
+   |                        ^ not a value
+   |
+help: you might have meant to write a const parameter here
+   |
+LL | impl<T, const N: /* Type */> From<[T; N]> for VecWrapper<T>
+   |         +++++  ++++++++++++
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0404, E0423.
+For more information about an error, try `rustc --explain E0404`.

--- a/tests/ui/const-generics/mgca/tuple_expr_arg_bad-issue-151048.rs
+++ b/tests/ui/const-generics/mgca/tuple_expr_arg_bad-issue-151048.rs
@@ -1,0 +1,8 @@
+#![feature(min_generic_const_args)]
+#![expect(incomplete_features)]
+
+struct Y {
+    stuff: [u8; { ([1, 2], 3, [4, 5]) }], //~ ERROR expected `usize`, found const tuple
+}
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/tuple_expr_arg_bad-issue-151048.stderr
+++ b/tests/ui/const-generics/mgca/tuple_expr_arg_bad-issue-151048.stderr
@@ -1,0 +1,8 @@
+error: expected `usize`, found const tuple
+  --> $DIR/tuple_expr_arg_bad-issue-151048.rs:5:19
+   |
+LL |     stuff: [u8; { ([1, 2], 3, [4, 5]) }],
+   |                   ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/eii/error_statement_position.rs
+++ b/tests/ui/eii/error_statement_position.rs
@@ -1,11 +1,6 @@
 #![feature(extern_item_impls)]
-// EIIs can, despite not being super useful, be declared in statement position
-// nested inside items. Items in statement position, when expanded as part of a macro,
-// need to be wrapped slightly differently (in an `ast::Statement`).
-// We did this on the happy path (no errors), but when there was an error, we'd
-// replace it with *just* an `ast::Item` not wrapped in an `ast::Statement`.
-// This caused an ICE (https://github.com/rust-lang/rust/issues/149980).
-// this test fails to build, but demonstrates that no ICE is produced.
+// EIIs cannot be used in statement position.
+// This is also a regression test for an ICE (https://github.com/rust-lang/rust/issues/149980).
 
 fn main() {
     struct Bar;
@@ -13,4 +8,10 @@ fn main() {
     #[eii]
     //~^ ERROR `#[eii]` is only valid on functions
     impl Bar {}
+
+
+    // Even on functions, eiis in statement position are rejected
+    #[eii]
+    //~^ ERROR `#[eii]` can only be used on functions inside a module
+    fn foo() {}
 }

--- a/tests/ui/eii/error_statement_position.stderr
+++ b/tests/ui/eii/error_statement_position.stderr
@@ -1,8 +1,17 @@
 error: `#[eii]` is only valid on functions
-  --> $DIR/error_statement_position.rs:13:5
+  --> $DIR/error_statement_position.rs:8:5
    |
 LL |     #[eii]
    |     ^^^^^^
 
-error: aborting due to 1 previous error
+error: `#[eii]` can only be used on functions inside a module
+  --> $DIR/error_statement_position.rs:14:5
+   |
+LL |     #[eii]
+   |     ^^^^^^
+LL |
+LL |     fn foo() {}
+   |        --- `#[eii]` is used on this item, which is part of another item's local scope
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/generics/wrong-number-of-args-in-macro.rs
+++ b/tests/ui/generics/wrong-number-of-args-in-macro.rs
@@ -1,0 +1,15 @@
+// Regression test for #149559
+
+struct Foo<T>; //~ ERROR type parameter `T` is never used
+
+macro_rules! foo_ty {
+    ($a:ty, $b:ty) => {
+        Foo<a, $b>
+        //~^ ERROR cannot find type `a` in this scope
+        //~| ERROR struct takes 1 generic argument but 2 generic arguments were supplied
+    };
+}
+
+fn foo<'a, 'b>() -> foo_ty!(&'b (), &'b ()) {}
+
+fn main() {}

--- a/tests/ui/generics/wrong-number-of-args-in-macro.stderr
+++ b/tests/ui/generics/wrong-number-of-args-in-macro.stderr
@@ -1,0 +1,44 @@
+error[E0425]: cannot find type `a` in this scope
+  --> $DIR/wrong-number-of-args-in-macro.rs:7:13
+   |
+LL |         Foo<a, $b>
+   |             ^ not found in this scope
+...
+LL | fn foo<'a, 'b>() -> foo_ty!(&'b (), &'b ()) {}
+   |                     ----------------------- in this macro invocation
+   |
+   = note: this error originates in the macro `foo_ty` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might be missing a type parameter
+   |
+LL | fn foo<'a, 'b, a>() -> foo_ty!(&'b (), &'b ()) {}
+   |              +++
+
+error[E0107]: struct takes 1 generic argument but 2 generic arguments were supplied
+  --> $DIR/wrong-number-of-args-in-macro.rs:7:9
+   |
+LL |         Foo<a, $b>
+   |         ^^^ expected 1 generic argument
+...
+LL | fn foo<'a, 'b>() -> foo_ty!(&'b (), &'b ()) {}
+   |                     ----------------------- in this macro invocation
+   |
+note: struct defined here, with 1 generic parameter: `T`
+  --> $DIR/wrong-number-of-args-in-macro.rs:3:8
+   |
+LL | struct Foo<T>;
+   |        ^^^ -
+   = note: this error originates in the macro `foo_ty` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0392]: type parameter `T` is never used
+  --> $DIR/wrong-number-of-args-in-macro.rs:3:12
+   |
+LL | struct Foo<T>;
+   |            ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0107, E0392, E0425.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/hygiene/cross-crate-redefine.rs
+++ b/tests/ui/hygiene/cross-crate-redefine.rs
@@ -8,7 +8,7 @@ extern crate use_by_macro;
 use use_by_macro::*;
 
 my_struct!(define);
-//~^ ERROR the name `MyStruct` is defined multiple times
 my_struct!(define);
+//~^ ERROR the name `MyStruct` is defined multiple times
 
 fn main() {}

--- a/tests/ui/hygiene/cross-crate-redefine.stderr
+++ b/tests/ui/hygiene/cross-crate-redefine.stderr
@@ -1,11 +1,10 @@
 error[E0428]: the name `MyStruct` is defined multiple times
-  --> $DIR/cross-crate-redefine.rs:10:1
+  --> $DIR/cross-crate-redefine.rs:11:1
    |
 LL | my_struct!(define);
-   | ^^^^^^^^^^^^^^^^^^ `MyStruct` redefined here
-LL |
-LL | my_struct!(define);
    | ------------------ previous definition of the type `MyStruct` here
+LL | my_struct!(define);
+   | ^^^^^^^^^^^^^^^^^^ `MyStruct` redefined here
    |
    = note: `MyStruct` must be defined only once in the type namespace of this module
    = note: this error originates in the macro `my_struct` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/imports/overwrite-deep-glob.rs
+++ b/tests/ui/imports/overwrite-deep-glob.rs
@@ -1,0 +1,22 @@
+//@ check-pass
+
+mod openssl {
+    pub use self::handwritten::*;
+
+    mod handwritten {
+        mod m1 {
+            pub struct S {}
+        }
+        mod m2 {
+            #[derive(Default)]
+            pub struct S {}
+        }
+
+        pub use self::m1::*; //~ WARN ambiguous glob re-exports
+        pub use self::m2::*;
+    }
+}
+
+pub use openssl::*;
+
+fn main() {}

--- a/tests/ui/imports/overwrite-deep-glob.stderr
+++ b/tests/ui/imports/overwrite-deep-glob.stderr
@@ -1,0 +1,12 @@
+warning: ambiguous glob re-exports
+  --> $DIR/overwrite-deep-glob.rs:15:17
+   |
+LL |         pub use self::m1::*;
+   |                 ^^^^^^^^^^^ the name `S` in the type namespace is first re-exported here
+LL |         pub use self::m2::*;
+   |                 ----------- but the name `S` in the type namespace is also re-exported here
+   |
+   = note: `#[warn(ambiguous_glob_reexports)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/imports/overwrite-different-ambig-2.rs
+++ b/tests/ui/imports/overwrite-different-ambig-2.rs
@@ -1,0 +1,24 @@
+mod m1 {
+    mod inner {
+        pub struct S {}
+    }
+    pub use self::inner::*;
+
+    #[derive(Debug)]
+    pub struct S {}
+}
+
+mod m2 {
+    pub struct S {}
+}
+
+// First we have a glob ambiguity in this glob (with `m2::*`).
+// Then we re-fetch `m1::*` because non-glob `m1::S` materializes from derive,
+// and we need to make sure that the glob ambiguity is not lost during re-fetching.
+use m1::*;
+use m2::*;
+
+fn main() {
+    let _: m1::S = S {}; //~ ERROR `S` is ambiguous
+                         //~| WARN this was previously accepted
+}

--- a/tests/ui/imports/overwrite-different-ambig-2.stderr
+++ b/tests/ui/imports/overwrite-different-ambig-2.stderr
@@ -1,0 +1,49 @@
+error: `S` is ambiguous
+  --> $DIR/overwrite-different-ambig-2.rs:22:20
+   |
+LL |     let _: m1::S = S {};
+   |                    ^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `S` could refer to the struct imported here
+  --> $DIR/overwrite-different-ambig-2.rs:18:5
+   |
+LL | use m1::*;
+   |     ^^^^^
+   = help: consider adding an explicit import of `S` to disambiguate
+note: `S` could also refer to the struct imported here
+  --> $DIR/overwrite-different-ambig-2.rs:19:5
+   |
+LL | use m2::*;
+   |     ^^^^^
+   = help: consider adding an explicit import of `S` to disambiguate
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+
+error: aborting due to 1 previous error
+
+Future incompatibility report: Future breakage diagnostic:
+error: `S` is ambiguous
+  --> $DIR/overwrite-different-ambig-2.rs:22:20
+   |
+LL |     let _: m1::S = S {};
+   |                    ^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `S` could refer to the struct imported here
+  --> $DIR/overwrite-different-ambig-2.rs:18:5
+   |
+LL | use m1::*;
+   |     ^^^^^
+   = help: consider adding an explicit import of `S` to disambiguate
+note: `S` could also refer to the struct imported here
+  --> $DIR/overwrite-different-ambig-2.rs:19:5
+   |
+LL | use m2::*;
+   |     ^^^^^
+   = help: consider adding an explicit import of `S` to disambiguate
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+

--- a/tests/ui/imports/overwrite-different-ambig.rs
+++ b/tests/ui/imports/overwrite-different-ambig.rs
@@ -1,0 +1,25 @@
+//@ check-pass
+//@ edition:2024
+
+mod a {
+    mod b {
+        mod c {
+            pub struct E;
+        }
+        mod d {
+            mod c {
+                pub struct E;
+            }
+            mod d {
+                #[derive(Debug)]
+                pub struct E;
+            }
+            pub use c::*;
+            use d::*;
+        }
+        use c::*;
+        use d::*;
+    }
+}
+
+fn main() {}

--- a/tests/ui/imports/overwrite-different-vis.rs
+++ b/tests/ui/imports/overwrite-different-vis.rs
@@ -1,0 +1,21 @@
+//@ check-pass
+
+mod b {
+    pub mod http {
+        pub struct HeaderMap;
+    }
+
+    pub(crate) use self::http::*;
+    #[derive(Debug)]
+    pub struct HeaderMap;
+}
+
+mod a {
+    pub use crate::b::*;
+
+    fn check_type() {
+        let _: HeaderMap = crate::b::HeaderMap;
+    }
+}
+
+fn main() {}

--- a/tests/ui/imports/overwrite-different-warn-ambiguity.rs
+++ b/tests/ui/imports/overwrite-different-warn-ambiguity.rs
@@ -1,0 +1,28 @@
+//@ check-pass
+//@ edition:2024
+
+mod framing {
+    mod public_message_in {
+        mod public_message {
+            mod public_message {
+                pub struct ConfirmedTranscriptHashInput;
+            }
+            mod public_message_in {
+                use super::*;
+                #[derive(Debug)]
+                pub struct ConfirmedTranscriptHashInput;
+            }
+            pub use public_message::*;
+            use public_message_in::*;
+        }
+        mod public_message_in {
+            #[derive(Debug)]
+            pub struct ConfirmedTranscriptHashInput;
+        }
+        pub use public_message::*;
+        use public_message_in::*;
+    }
+    use public_message_in::*;
+}
+
+fn main() {}

--- a/tests/ui/parser/macro/kw-in-const-item-pos-recovery-149692.rs
+++ b/tests/ui/parser/macro/kw-in-const-item-pos-recovery-149692.rs
@@ -1,0 +1,11 @@
+//! More test coverage for <https://github.com/rust-lang/rust/issues/149692>; this test is
+//! specifically for `const` items.
+
+macro_rules! m {
+    (const $id:item()) => {}
+}
+
+m!(const Self());
+//~^ ERROR expected one of `!` or `::`, found `(`
+
+fn main() {}

--- a/tests/ui/parser/macro/kw-in-const-item-pos-recovery-149692.stderr
+++ b/tests/ui/parser/macro/kw-in-const-item-pos-recovery-149692.stderr
@@ -1,0 +1,11 @@
+error: expected one of `!` or `::`, found `(`
+  --> $DIR/kw-in-const-item-pos-recovery-149692.rs:8:14
+   |
+LL |     (const $id:item()) => {}
+   |            -------- while parsing argument for this `item` macro fragment
+...
+LL | m!(const Self());
+   |              ^ expected one of `!` or `::`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/macro/kw-in-item-pos-recovery-149692.rs
+++ b/tests/ui/parser/macro/kw-in-item-pos-recovery-149692.rs
@@ -1,0 +1,19 @@
+//! Regression test for a diagnostic ICE where we tried to recover a keyword as the identifier when
+//! we are already trying to recover a missing keyword before item.
+//!
+//! See <https://github.com/rust-lang/rust/issues/149692>.
+
+macro_rules! m {
+    ($id:item()) => {}
+}
+
+m!(Self());
+//~^ ERROR expected one of `!` or `::`, found `(`
+
+m!(Self{});
+//~^ ERROR expected one of `!` or `::`, found `{`
+
+m!(crate());
+//~^ ERROR expected one of `!` or `::`, found `(`
+
+fn main() {}

--- a/tests/ui/parser/macro/kw-in-item-pos-recovery-149692.stderr
+++ b/tests/ui/parser/macro/kw-in-item-pos-recovery-149692.stderr
@@ -1,0 +1,29 @@
+error: expected one of `!` or `::`, found `(`
+  --> $DIR/kw-in-item-pos-recovery-149692.rs:10:8
+   |
+LL |     ($id:item()) => {}
+   |      -------- while parsing argument for this `item` macro fragment
+...
+LL | m!(Self());
+   |        ^ expected one of `!` or `::`
+
+error: expected one of `!` or `::`, found `{`
+  --> $DIR/kw-in-item-pos-recovery-149692.rs:13:8
+   |
+LL |     ($id:item()) => {}
+   |      -------- while parsing argument for this `item` macro fragment
+...
+LL | m!(Self{});
+   |        ^ expected one of `!` or `::`
+
+error: expected one of `!` or `::`, found `(`
+  --> $DIR/kw-in-item-pos-recovery-149692.rs:16:9
+   |
+LL |     ($id:item()) => {}
+   |      -------- while parsing argument for this `item` macro fragment
+...
+LL | m!(crate());
+   |         ^ expected one of `!` or `::`
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#150585 (Add a context-consistency check before emitting redundant generic-argument suggestions)
 - rust-lang/rust#150586 (rustdoc: Fix intra-doc link bugs involving type aliases and associated items)
 - rust-lang/rust#150590 (Don't try to recover keyword as non-keyword identifier )
 - rust-lang/rust#150817 (cleanup: remove borrowck handling for inline const patterns)
 - rust-lang/rust#150939 (resolve: Relax some asserts in glob overwriting and add tests)
 - rust-lang/rust#150962 (Remove `FeedConstTy` and provide ty when lowering const arg)
 - rust-lang/rust#150966 (rustc_target: Remove unused Arch::PowerPC64LE)
 - rust-lang/rust#150971 (Disallow eii in statement position)
 - rust-lang/rust#151016 (fix: WASI threading regression by disabling pthread usage)
 - rust-lang/rust#151046 (compiler: Make Externally Implementable Item (eii) macros "semiopaque")
 - rust-lang/rust#151099 (Recover parse gracefully from `<const N>`)
 - rust-lang/rust#151117 (Avoid serde dependency in build_helper when not necessary)
 - rust-lang/rust#151127 (Delete `MetaItemOrLitParser::Err`)
 - rust-lang/rust#151128 (Add temporary new bors e-mail address to the mailmap)
 - rust-lang/rust#151138 (Rename `rust.use-lld` to `rust.bootstrap-override-lld` in INSTALL.md)

r? @ghost

<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=150586,150590,150939,150962,150966,151016,150585,150817,150971,151046,151099,151117,151127,151128,151138)
<!-- homu-ignore:end -->

