### PR TITLE
Make `ambiguous_glob_reexports` an FCW at deny

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -3197,8 +3197,12 @@ declare_lint! {
     /// `bar::X` would cause compilation errors in downstream crates because `X` is defined
     /// multiple times in the same namespace of `this_crate`.
     pub AMBIGUOUS_GLOB_REEXPORTS,
-    Warn,
+    Deny,
     "ambiguous glob re-exports",
+    @future_incompatible = FutureIncompatibleInfo {
+        reason: fcw!(FutureReleaseError #107880), // TODO.
+        report_in_deps: true,
+    };
 }
 
 declare_lint! {


### PR DESCRIPTION
Is there any good reason for someone to intentionally create an ambiguous glob reexport?  No such reasons come to mind offhand.

We lint strongly against use of these ambiguous glob reexports, so not linting strongly at the def-site pushes cost, relatively, to users rather than upstreams.  It'd be better to push this cost upstream.

Let's make `ambiguous_glob_reexports` an FCW that lints at deny-by-default and that warns in dependencies.

TODO: I'm not fixing the tests at this point as I just want to do a crater run.

### Related

- https://github.com/rust-lang/rust/pull/107880
- https://github.com/rust-lang/rust/issues/107563
- https://github.com/rust-lang/rust/issues/149845
- https://github.com/rust-lang/rust/issues/114095
- https://github.com/rust-lang/rust/pull/147984