### PR TITLE
Add functions to `GrowableBitSet`

### DIFF
--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -1336,11 +1336,27 @@ impl<T: Idx> GrowableBitSet<T> {
         self.bit_set.insert(elem)
     }
 
+    #[inline]
+    pub fn insert_range(&mut self, elems: Range<T>) {
+        self.ensure(elems.end.index());
+        self.bit_set.insert_range(elems);
+    }
+
     /// Returns `true` if the set has changed.
     #[inline]
     pub fn remove(&mut self, elem: T) -> bool {
         self.ensure(elem.index() + 1);
         self.bit_set.remove(elem)
+    }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        self.bit_set.clear();
+    }
+
+    #[inline]
+    pub fn count(&self) -> usize {
+        self.bit_set.count()
     }
 
     #[inline]
@@ -1352,6 +1368,14 @@ impl<T: Idx> GrowableBitSet<T> {
     pub fn contains(&self, elem: T) -> bool {
         let (word_index, mask) = word_index_and_mask(elem);
         self.bit_set.words.get(word_index).is_some_and(|word| (word & mask) != 0)
+    }
+
+    #[inline]
+    pub fn contains_any(&self, elems: Range<T>) -> bool {
+        elems.start.index() < self.bit_set.domain_size
+            && self
+                .bit_set
+                .contains_any(elems.start..T::new(elems.end.index().min(self.bit_set.domain_size)))
     }
 
     #[inline]


### PR DESCRIPTION
Only really need `insert_range` for clippy, but may as well add the others. Using `Range` instead of `RangeBounds` since an end bound is needed for this to make sense and there aren't any traits to enforce that.