### PR TITLE
Add GCC and the GCC codegen backend to build-manifest and rustup

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -30,7 +30,7 @@ use crate::core::build_steps::tool::{
 use crate::core::build_steps::vendor::{VENDOR_DIR, Vendor};
 use crate::core::build_steps::{compile, llvm};
 use crate::core::builder::{Builder, Kind, RunConfig, ShouldRun, Step, StepMetadata};
-use crate::core::config::TargetSelection;
+use crate::core::config::{GccCiMode, TargetSelection};
 use crate::utils::build_stamp::{self, BuildStamp};
 use crate::utils::channel::{self, Info};
 use crate::utils::exec::{BootstrapCommand, command};
@@ -3033,6 +3033,14 @@ impl Step for Gcc {
         if host != "x86_64-unknown-linux-gnu" {
             builder.info(&format!("host target `{host}` not supported by gcc. skipping"));
             return None;
+        }
+
+        if builder.config.is_running_on_ci {
+            assert_eq!(
+                builder.config.gcc_ci_mode,
+                GccCiMode::BuildLocally,
+                "Cannot use gcc.download-ci-gcc when distributing GCC on CI"
+            );
         }
 
         // We need the GCC sources to build GCC and also to add its license and README

--- a/src/bootstrap/src/core/config/mod.rs
+++ b/src/bootstrap/src/core/config/mod.rs
@@ -425,7 +425,7 @@ impl std::str::FromStr for RustcLto {
 }
 
 /// Determines how will GCC be provided.
-#[derive(Default, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub enum GccCiMode {
     /// Build GCC from the local `src/gcc` submodule.
     BuildLocally,

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -32,7 +32,7 @@ static DOCS_FALLBACK: &[(&str, &str)] = &[
 static PKG_INSTALLERS: &[&str] = &["x86_64-apple-darwin", "aarch64-apple-darwin"];
 
 static NIGHTLY_ONLY_COMPONENTS: &[PkgType] =
-    &[PkgType::Miri, PkgType::JsonDocs, PkgType::RustcCodegenCranelift];
+    &[PkgType::Miri, PkgType::JsonDocs, PkgType::RustcCodegenCranelift, PkgType::RustcCodegenGcc];
 
 macro_rules! t {
     ($e:expr) => {
@@ -302,6 +302,7 @@ impl Builder {
                 | PkgType::RustAnalysis
                 | PkgType::JsonDocs
                 | PkgType::RustcCodegenCranelift
+                | PkgType::RustcCodegenGcc
                 | PkgType::LlvmBitcodeLinker => {
                     extensions.push(host_component(pkg));
                 }

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -158,7 +158,7 @@ impl Builder {
     }
 
     fn add_packages_to(&mut self, manifest: &mut Manifest) {
-        for pkg in PkgType::all() {
+        for pkg in &PkgType::all() {
             self.package(pkg, &mut manifest.pkg);
         }
     }
@@ -227,7 +227,7 @@ impl Builder {
         };
         for pkg in PkgType::all() {
             if pkg.is_preview() {
-                rename(pkg.tarball_component_name(), &pkg.manifest_component_name());
+                rename(&pkg.tarball_component_name(), &pkg.manifest_component_name());
             }
         }
     }
@@ -263,7 +263,7 @@ impl Builder {
 
         let host_component = |pkg: &_| Component::from_pkg(pkg, host);
 
-        for pkg in PkgType::all() {
+        for pkg in &PkgType::all() {
             match pkg {
                 // rustc/rust-std/cargo/docs are all required
                 PkgType::Rustc | PkgType::Cargo | PkgType::HtmlDocs => {
@@ -303,6 +303,7 @@ impl Builder {
                 | PkgType::JsonDocs
                 | PkgType::RustcCodegenCranelift
                 | PkgType::RustcCodegenGcc
+                | PkgType::Gcc { .. }
                 | PkgType::LlvmBitcodeLinker => {
                     extensions.push(host_component(pkg));
                 }

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -31,8 +31,16 @@ static DOCS_FALLBACK: &[(&str, &str)] = &[
 
 static PKG_INSTALLERS: &[&str] = &["x86_64-apple-darwin", "aarch64-apple-darwin"];
 
-static NIGHTLY_ONLY_COMPONENTS: &[PkgType] =
-    &[PkgType::Miri, PkgType::JsonDocs, PkgType::RustcCodegenCranelift, PkgType::RustcCodegenGcc];
+fn is_nightly_only(pkg: &PkgType) -> bool {
+    match pkg {
+        PkgType::Miri
+        | PkgType::JsonDocs
+        | PkgType::RustcCodegenCranelift
+        | PkgType::RustcCodegenGcc
+        | PkgType::Gcc { .. } => true,
+        _ => false,
+    }
+}
 
 macro_rules! t {
     ($e:expr) => {
@@ -375,7 +383,7 @@ impl Builder {
         let mut is_present = version_info.present;
 
         // Never ship nightly-only components for other trains.
-        if self.versions.channel() != "nightly" && NIGHTLY_ONLY_COMPONENTS.contains(&pkg) {
+        if self.versions.channel() != "nightly" && is_nightly_only(&pkg) {
             is_present = false; // Pretend the component is entirely missing.
         }
 

--- a/src/tools/build-manifest/src/versions.rs
+++ b/src/tools/build-manifest/src/versions.rs
@@ -59,6 +59,7 @@ pkg_type! {
     JsonDocs = "rust-docs-json"; preview = true,
     RustcCodegenCranelift = "rustc-codegen-cranelift"; preview = true,
     LlvmBitcodeLinker = "llvm-bitcode-linker"; preview = true,
+    RustcCodegenGcc = "rustc-codegen-gcc"; preview = true,
 }
 
 impl PkgType {
@@ -82,6 +83,7 @@ impl PkgType {
             PkgType::LlvmTools => false,
             PkgType::Miri => false,
             PkgType::RustcCodegenCranelift => false,
+            PkgType::RustcCodegenGcc => false,
 
             PkgType::Rust => true,
             PkgType::RustStd => true,
@@ -111,6 +113,7 @@ impl PkgType {
             RustcDocs => HOSTS,
             Cargo => HOSTS,
             RustcCodegenCranelift => HOSTS,
+            RustcCodegenGcc => HOSTS,
             RustMingw => MINGW,
             RustStd => TARGETS,
             HtmlDocs => HOSTS,

--- a/src/tools/build-manifest/src/versions.rs
+++ b/src/tools/build-manifest/src/versions.rs
@@ -11,29 +11,54 @@ use xz2::read::XzDecoder;
 const DEFAULT_TARGET: &str = "x86_64-unknown-linux-gnu";
 
 macro_rules! pkg_type {
-    ( $($variant:ident = $component:literal $(; preview = true $(@$is_preview:tt)? )? ),+ $(,)? ) => {
+    ( $($variant:ident = $component:literal $(; preview = true $(@$is_preview:tt)? )? $(; suffixes = [$($suffixes:literal),+] $(@$is_suffixed:tt)? )? ),+ $(,)? ) => {
         #[derive(Debug, Hash, Eq, PartialEq, Clone)]
         pub(crate) enum PkgType {
-            $($variant,)+
+            $($variant $( $($is_suffixed)? { suffix: &'static str })?,)+
         }
 
         impl PkgType {
             pub(crate) fn is_preview(&self) -> bool {
                 match self {
-                    $( $( $($is_preview)? PkgType::$variant => true, )? )+
-                    _ => false,
+                    $( PkgType::$variant $($($is_suffixed)? { .. })? => false $( $($is_preview)? || true)?, )+
                 }
             }
 
-            /// First part of the tarball name.
-            pub(crate) fn tarball_component_name(&self) -> &str {
+            /// First part of the tarball name. May include a suffix, if the package has one.
+            pub(crate) fn tarball_component_name(&self) -> String {
                 match self {
-                    $( PkgType::$variant => $component,)+
+                    $( PkgType::$variant $($($is_suffixed)? { suffix })? => {
+                        #[allow(unused_mut)]
+                        let mut name = $component.to_owned();
+                        $($($is_suffixed)?
+                        name.push('-');
+                        name.push_str(suffix);
+                        )?
+                        name
+                    },)+
                 }
             }
 
-            pub(crate) fn all() -> &'static [PkgType] {
-                &[ $(PkgType::$variant),+ ]
+            pub(crate) fn all() -> Vec<PkgType> {
+                let mut packages = vec![];
+                $(
+                    // Push the single variant
+                    packages.push(PkgType::$variant $($($is_suffixed)? { suffix: "" })?);
+                    // Macro hell, we have to remove the fake empty suffix if we actually have
+                    // suffixes
+                    $(
+                        $($is_suffixed)?
+                        packages.pop();
+                    )?
+                    // And now add the suffixes, if any
+                    $(
+                        $($is_suffixed)?
+                        $(
+                            packages.push(PkgType::$variant { suffix: $suffixes });
+                        )+
+                    )?
+                )+
+                packages
             }
         }
     }
@@ -60,6 +85,9 @@ pkg_type! {
     RustcCodegenCranelift = "rustc-codegen-cranelift"; preview = true,
     LlvmBitcodeLinker = "llvm-bitcode-linker"; preview = true,
     RustcCodegenGcc = "rustc-codegen-gcc"; preview = true,
+    Gcc = "gcc"; preview = true; suffixes = [
+        "x86_64-unknown-linux-gnu"
+    ],
 }
 
 impl PkgType {
@@ -68,7 +96,7 @@ impl PkgType {
         if self.is_preview() {
             format!("{}-preview", self.tarball_component_name())
         } else {
-            self.tarball_component_name().to_string()
+            self.tarball_component_name()
         }
     }
 
@@ -84,6 +112,7 @@ impl PkgType {
             PkgType::Miri => false,
             PkgType::RustcCodegenCranelift => false,
             PkgType::RustcCodegenGcc => false,
+            PkgType::Gcc { suffix: _ } => false,
 
             PkgType::Rust => true,
             PkgType::RustStd => true,
@@ -114,6 +143,13 @@ impl PkgType {
             Cargo => HOSTS,
             RustcCodegenCranelift => HOSTS,
             RustcCodegenGcc => HOSTS,
+            // Gcc is "special", because we need a separate libgccjit.so for each
+            // (host, target) compilation pair. So it's even more special than stdlib, which has a
+            // separate component per target. This component thus hardcodes its compilation
+            // target in its name, and we thus ship it for HOSTS only. So we essentially have
+            // gcc-T1, gcc-T2, a separate *component/package* per each compilation target.
+            // So on host T1, if you want to compile for T2, you would install gcc-T2.
+            Gcc { suffix: _ } => HOSTS,
             RustMingw => MINGW,
             RustStd => TARGETS,
             HtmlDocs => HOSTS,


### PR DESCRIPTION
This PR adds the GCC codegen backend, and the GCC (libgccjit) component upon which it depends, to build-manifest, and thus also to (nightly) Rustup. I added both components in a single PR, because one can't work/isn't useful without the other.

Both components are marked as nightly-only and as `-preview`.

As a reminder, the GCC component is special; we need a separate component for every (host, target) compilation pair. This is not something that is really supported by rustup today, so we work around that by creating a separate component/package for each compilation target. So if we want to distribute GCC that can compile from {T1, T2} to {T2, T3}, we will create two separate components (`gcc-T2` and `gcc-T3`), and make both of them available on T1 and T2 hosts.

I tried to reuse the existing structure of `PkgType` in `build-manifest`, but added a target field to the `Gcc` package variant. This required some macro hackery, but at least it doesn't require making larger changes to `build-manifest`.

After this PR lands, unless I messed something up, starting with the following nightly, the following should work:
```bash
rustup +nightly component add rustc-codegen-gcc-preview gcc-x86_64-unknown-linux-gnu-preview
RUSTFLAGS="-Zcodegen-backend=gcc" cargo +nightly build
```

Note that it will work currently only on `x86_64-unknown-linux-gnu`, and only if not cross-compiling.

r? @Mark-Simulacrum
