### PR TITLE
Stabilise `EULER_GAMMA` and `GOLDEN_RATIO` constants for `f32` and `f64`.

### DIFF
--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -34,13 +34,13 @@ pub mod consts {
 
     /// The golden ratio (φ)
     #[unstable(feature = "f128", issue = "116909")]
-    // Also, #[unstable(feature = "more_float_constants", issue = "146939")]
-    pub const PHI: f128 = 1.61803398874989484820458683436563811772030917980576286213545_f128;
+    pub const GOLDEN_RATIO: f128 =
+        1.61803398874989484820458683436563811772030917980576286213545_f128;
 
     /// The Euler-Mascheroni constant (γ)
     #[unstable(feature = "f128", issue = "116909")]
-    // Also, #[unstable(feature = "more_float_constants", issue = "146939")]
-    pub const EGAMMA: f128 = 0.577215664901532860606512090082402431042159335939923598805767_f128;
+    pub const EULER_GAMMA: f128 =
+        0.577215664901532860606512090082402431042159335939923598805767_f128;
 
     /// π/2
     #[unstable(feature = "f128", issue = "116909")]

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -36,13 +36,11 @@ pub mod consts {
 
     /// The golden ratio (φ)
     #[unstable(feature = "f16", issue = "116909")]
-    // Also, #[unstable(feature = "more_float_constants", issue = "146939")]
-    pub const PHI: f16 = 1.618033988749894848204586834365638118_f16;
+    pub const GOLDEN_RATIO: f16 = 1.618033988749894848204586834365638118_f16;
 
     /// The Euler-Mascheroni constant (γ)
     #[unstable(feature = "f16", issue = "116909")]
-    // Also, #[unstable(feature = "more_float_constants", issue = "146939")]
-    pub const EGAMMA: f16 = 0.577215664901532860606512090082402431_f16;
+    pub const EULER_GAMMA: f16 = 0.577215664901532860606512090082402431_f16;
 
     /// π/2
     #[unstable(feature = "f16", issue = "116909")]

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -292,12 +292,12 @@ pub mod consts {
     pub const TAU: f32 = 6.28318530717958647692528676655900577_f32;
 
     /// The golden ratio (φ)
-    #[unstable(feature = "more_float_constants", issue = "146939")]
-    pub const PHI: f32 = 1.618033988749894848204586834365638118_f32;
+    #[stable(feature = "euler_gamma_golden_ratio", since = "CURRENT_RUSTC_VERSION")]
+    pub const GOLDEN_RATIO: f32 = 1.618033988749894848204586834365638118_f32;
 
     /// The Euler-Mascheroni constant (γ)
-    #[unstable(feature = "more_float_constants", issue = "146939")]
-    pub const EGAMMA: f32 = 0.577215664901532860606512090082402431_f32;
+    #[stable(feature = "euler_gamma_golden_ratio", since = "CURRENT_RUSTC_VERSION")]
+    pub const EULER_GAMMA: f32 = 0.577215664901532860606512090082402431_f32;
 
     /// π/2
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -292,12 +292,12 @@ pub mod consts {
     pub const TAU: f64 = 6.28318530717958647692528676655900577_f64;
 
     /// The golden ratio (φ)
-    #[unstable(feature = "more_float_constants", issue = "146939")]
-    pub const PHI: f64 = 1.618033988749894848204586834365638118_f64;
+    #[stable(feature = "euler_gamma_golden_ratio", since = "CURRENT_RUSTC_VERSION")]
+    pub const GOLDEN_RATIO: f64 = 1.618033988749894848204586834365638118_f64;
 
     /// The Euler-Mascheroni constant (γ)
-    #[unstable(feature = "more_float_constants", issue = "146939")]
-    pub const EGAMMA: f64 = 0.577215664901532860606512090082402431_f64;
+    #[stable(feature = "euler_gamma_golden_ratio", since = "CURRENT_RUSTC_VERSION")]
+    pub const EULER_GAMMA: f64 = 0.577215664901532860606512090082402431_f64;
 
     /// π/2
     #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
Tracking issue: rust-lang/rust#146939

This PR renames the `EGAMMA` and `PHI` constants to `EULER_GAMMA` and `GOLDEN_RATIO` – respectively – and stabilises them under these names for `f32` and `f64`:

```rust
// core::f16::consts

pub const GOLDEN_RATIO: f16;

pub const EULER_GAMMA: f16;

// core::f32::consts

pub const GOLDEN_RATIO: f32;

pub const EULER_GAMMA: f32;

// core::f64::consts

pub const GOLDEN_RATIO: f64;

pub const EULER_GAMMA: f64;

// core::f128::consts

pub const GOLDEN_RATIO: f128;

pub const EULER_GAMMA: f128;
```

The feature gate for the stabilised items is also changed to `euler_gamma_golden_ratio`.