### PR TITLE
rustc_codegen_ssa: fix pre_link_args order

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1868,11 +1868,11 @@ fn add_post_link_objects(
 /// Add arbitrary "pre-link" args defined by the target spec or from command line.
 /// FIXME: Determine where exactly these args need to be inserted.
 fn add_pre_link_args(cmd: &mut dyn Linker, sess: &Session, flavor: LinkerFlavor) {
+    cmd.verbatim_args(&sess.opts.unstable_opts.pre_link_args);
+
     if let Some(args) = sess.target.pre_link_args.get(&flavor) {
         cmd.verbatim_args(args.iter().map(Deref::deref));
     }
-
-    cmd.verbatim_args(&sess.opts.unstable_opts.pre_link_args);
 }
 
 /// Add a link script embedded in the target, if applicable.
@@ -2219,6 +2219,12 @@ fn linker_with_args(
 
     // ------------ Early order-dependent options ------------
 
+    // Can be used for adding custom CRT objects or overriding order-dependent options above.
+    // FIXME: In practice built-in target specs use this for arbitrary order-independent options,
+    // introduce a target spec option for order-independent linker options and migrate built-in
+    // specs to it.
+    add_pre_link_args(cmd, sess, flavor);
+
     // If we're building something like a dynamic library then some platforms
     // need to make sure that all symbols are exported correctly from the
     // dynamic library.
@@ -2229,12 +2235,6 @@ fn linker_with_args(
         crate_type,
         &codegen_results.crate_info.exported_symbols[&crate_type],
     );
-
-    // Can be used for adding custom CRT objects or overriding order-dependent options above.
-    // FIXME: In practice built-in target specs use this for arbitrary order-independent options,
-    // introduce a target spec option for order-independent linker options and migrate built-in
-    // specs to it.
-    add_pre_link_args(cmd, sess, flavor);
 
     // ------------ Object code and libraries, order-dependent ------------
 


### PR DESCRIPTION
Hi,

We had an [issue](https://lists.openembedded.org/g/openembedded-core/topic/patch_v2_08_15/116997869) while compiling the linux kernel with a composite linker command in Yocto when activating the rust parts of the kernel.

Kernel Makefiles run rustc with `-Clinker=$(HOSTCC)` ([scripts/Makefile.host](https://git.yoctoproject.org/linux-yocto/tree/scripts/Makefile.host?h=v6.18.1#n94), [rust/Makefile](https://git.yoctoproject.org/linux-yocto/tree/rust/Makefile?h=v6.18.1#n425))

But, `HOSTCC` can be something like `<my-wrapper-tool> <my-cc-as-arg>` (in our yocto case `ccache gcc`), which is incompatible with the way rustc handles `-Clinker`, it is handled as a `PathBuf`, used directly as a `Command` name, [but the `Command` constructor doesn't accept arguments](https://doc.rust-lang.org/std/process/struct.Command.html#method.new).

We could split `HOSTCC` to `START_HOSTCC` and `END_HOSTCC` to do something like `-Clinker=$(START_HOSTCC) -Zpre-link-args='$(END_HOSTCC)'`, but a rustc limitation occurs.

Indeed, some linker arguments given by target files (ex: `-m64` from [a target file](https://github.com/rust-lang/rust/blob/a6acf0f07f0ed1c12e26dc0db3b9bf1d0504a0bb/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnu.rs#L10)) and from the function `export_symbols` (ex: `--no-undefined-version` [here](https://github.com/rust-lang/rust/blob/a6acf0f07f0ed1c12e26dc0db3b9bf1d0504a0bb/compiler/rustc_codegen_ssa/src/back/linker.rs#L883)) where added to the command before the `pre-link-args`.

Therefore, we could end up with a generated call like `<my-wrapper-tool> -m64 <my-cc-as-arg> ...` (in our case `ccache -m64 gcc ...`), which is broken.

This PR mitigates this issue sorting pre-link-args calls before target files pre-link-args, and before the call to `export_symbols`, which allow to use any wrapper tool around the actual linker.

Please make me know if I should rewrite it in another way (a new argument parameter ? directly split the PathBuf into arguments ?).

I could write some tests if needed, but I'm not sure about the best way to test it in the repository.

Thanks for reading, regards,

Alban  