### PR TITLE
fix: Do not delay E0107 when there exists an assoc ty with the same name

### DIFF
--- a/tests/ui/traits/associated_type_bound/assoc-type-bounds-with-the-same-name-with-lacking-generic-arg-148121.rs
+++ b/tests/ui/traits/associated_type_bound/assoc-type-bounds-with-the-same-name-with-lacking-generic-arg-148121.rs
@@ -1,0 +1,17 @@
+// A regression test for https://github.com/rust-lang/rust/issues/148121
+
+pub trait Super<X> {
+    type X;
+}
+
+pub trait Zelf<X>: Super<X> {}
+
+pub trait A {}
+
+impl A for dyn Super<X = ()> {}
+//~^ ERROR: trait takes 1 generic argument but 0 generic arguments were supplied
+
+impl A for dyn Zelf<X = ()> {}
+//~^ ERROR: trait takes 1 generic argument but 0 generic arguments were supplied
+
+fn main() {}

--- a/tests/ui/traits/associated_type_bound/assoc-type-bounds-with-the-same-name-with-lacking-generic-arg-148121.stderr
+++ b/tests/ui/traits/associated_type_bound/assoc-type-bounds-with-the-same-name-with-lacking-generic-arg-148121.stderr
@@ -1,0 +1,35 @@
+error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
+  --> $DIR/assoc-type-bounds-with-the-same-name-with-lacking-generic-arg-148121.rs:11:16
+   |
+LL | impl A for dyn Super<X = ()> {}
+   |                ^^^^^ expected 1 generic argument
+   |
+note: trait defined here, with 1 generic parameter: `X`
+  --> $DIR/assoc-type-bounds-with-the-same-name-with-lacking-generic-arg-148121.rs:3:11
+   |
+LL | pub trait Super<X> {
+   |           ^^^^^ -
+help: add missing generic argument
+   |
+LL | impl A for dyn Super<X, X = ()> {}
+   |                      ++
+
+error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
+  --> $DIR/assoc-type-bounds-with-the-same-name-with-lacking-generic-arg-148121.rs:14:16
+   |
+LL | impl A for dyn Zelf<X = ()> {}
+   |                ^^^^ expected 1 generic argument
+   |
+note: trait defined here, with 1 generic parameter: `X`
+  --> $DIR/assoc-type-bounds-with-the-same-name-with-lacking-generic-arg-148121.rs:7:11
+   |
+LL | pub trait Zelf<X>: Super<X> {}
+   |           ^^^^ -
+help: add missing generic argument
+   |
+LL | impl A for dyn Zelf<X, X = ()> {}
+   |                     ++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0107`.


### PR DESCRIPTION
Fixes rust-lang/rust#148121 

When we have the following code:

```rust
trait Foo<T> {}

impl Foo<T: Default> for String {}
```

we delay `E0107: wrong number of generic args` to suggest moving `T: Default` bound to the impl block's param declaration.

The delay is determined by whether all the missing generic parameters are mentioned by those *wrong* assoc item constraints.

But this delay is wrong when there exist any *correct* assoc item constraints, i.e. when we have an assoc type whose identifier is same with a missing generic parameter like in the following code:

```rust
pub trait Super<X> {
    type X;
}
pub trait A {}
impl A for dyn Super<X = ()> {}
```