### PR TITLE
privacy: Fix privacy lints in RPITITs

### DIFF
--- a/tests/ui/associated-type-bounds/duplicate-bound-err.stderr
+++ b/tests/ui/associated-type-bounds/duplicate-bound-err.stderr
@@ -108,6 +108,18 @@ LL |     fn foo() -> impl Iterator<Item = i32, Item = u32> {
 LL |         [2u32].into_iter()
    |         ------------------ return type was inferred to be `std::array::IntoIter<u32, 1>` here
 
+error[E0271]: expected `impl Iterator<Item = u32>` to be an iterator that yields `i32`, but it yields `u32`
+  --> $DIR/duplicate-bound-err.rs:111:17
+   |
+LL |     fn foo() -> impl Iterator<Item = i32, Item = u32> {
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `i32`, found `u32`
+   |
+note: required by a bound in `Trait3::foo::{anon_assoc#0}`
+  --> $DIR/duplicate-bound-err.rs:107:31
+   |
+LL |     fn foo() -> impl Iterator<Item = i32, Item = u32>;
+   |                               ^^^^^^^^^^ required by this bound in `Trait3::foo::{anon_assoc#0}`
+
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate-bound-err.rs:87:42
    |
@@ -157,18 +169,6 @@ LL | type MustFail4 = dyn Trait2<ASSOC = 3u32, ASSOC = 3u32>;
    |                             ------------  ^^^^^^^^^^^^ re-bound here
    |                             |
    |                             `ASSOC` bound here first
-
-error[E0271]: expected `impl Iterator<Item = u32>` to be an iterator that yields `i32`, but it yields `u32`
-  --> $DIR/duplicate-bound-err.rs:111:17
-   |
-LL |     fn foo() -> impl Iterator<Item = i32, Item = u32> {
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `i32`, found `u32`
-   |
-note: required by a bound in `Trait3::foo::{anon_assoc#0}`
-  --> $DIR/duplicate-bound-err.rs:107:31
-   |
-LL |     fn foo() -> impl Iterator<Item = i32, Item = u32>;
-   |                               ^^^^^^^^^^ required by this bound in `Trait3::foo::{anon_assoc#0}`
 
 error[E0271]: expected `Empty<u32>` to be an iterator that yields `i32`, but it yields `u32`
   --> $DIR/duplicate-bound-err.rs:119:16

--- a/tests/ui/delegation/unsupported.current.stderr
+++ b/tests/ui/delegation/unsupported.current.stderr
@@ -29,11 +29,7 @@ note: ...which requires comparing an impl and trait method signature, inferring 
 LL |         reuse ToReuse::opaque_ret;
    |                        ^^^^^^^^^^
    = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret::{anon_assoc#0}`, completing the cycle
-note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret` is compatible with trait definition
-  --> $DIR/unsupported.rs:33:24
-   |
-LL |         reuse ToReuse::opaque_ret;
-   |                        ^^^^^^^^^^
+   = note: cycle used when checking effective visibilities
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error[E0283]: type annotations needed

--- a/tests/ui/delegation/unsupported.next.stderr
+++ b/tests/ui/delegation/unsupported.next.stderr
@@ -25,7 +25,7 @@ note: ...which requires comparing an impl and trait method signature, inferring 
 LL |         reuse ToReuse::opaque_ret;
    |                        ^^^^^^^^^^
    = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret::{anon_assoc#0}`, completing the cycle
-   = note: cycle used when computing implied outlives bounds for `<u16 as opaque::ToReuse>::opaque_ret::{anon_assoc#0}` (hack disabled = false)
+   = note: cycle used when checking effective visibilities
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error[E0283]: type annotations needed

--- a/tests/ui/lint/lint-stability-deprecated.stderr
+++ b/tests/ui/lint/lint-stability-deprecated.stderr
@@ -1,19 +1,13 @@
-warning: use of deprecated associated type `lint_stability::TraitWithAssociatedTypes::TypeDeprecated`: text
-  --> $DIR/lint-stability-deprecated.rs:97:48
+warning: use of deprecated function `lint_stability::deprecated`: text
+  --> $DIR/lint-stability-deprecated.rs:24:9
    |
-LL |         struct S2<T: TraitWithAssociatedTypes>(T::TypeDeprecated);
-   |                                                ^^^^^^^^^^^^^^^^^
+LL |         deprecated();
+   |         ^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/lint-stability-deprecated.rs:6:9
    |
 LL | #![warn(deprecated)]
-   |         ^^^^^^^^^^
-
-warning: use of deprecated function `lint_stability::deprecated`: text
-  --> $DIR/lint-stability-deprecated.rs:24:9
-   |
-LL |         deprecated();
    |         ^^^^^^^^^^
 
 warning: use of deprecated method `lint_stability::Trait::trait_deprecated`: text
@@ -321,6 +315,12 @@ warning: use of deprecated function `this_crate::MethodTester::test_method_body:
    |
 LL |             fn_in_body();
    |             ^^^^^^^^^^
+
+warning: use of deprecated associated type `lint_stability::TraitWithAssociatedTypes::TypeDeprecated`: text
+  --> $DIR/lint-stability-deprecated.rs:97:48
+   |
+LL |         struct S2<T: TraitWithAssociatedTypes>(T::TypeDeprecated);
+   |                                                ^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated associated type `lint_stability::TraitWithAssociatedTypes::TypeDeprecated`: text
   --> $DIR/lint-stability-deprecated.rs:101:13

--- a/tests/ui/lint/lint-stability.stderr
+++ b/tests/ui/lint/lint-stability.stderr
@@ -1,13 +1,4 @@
 error[E0658]: use of unstable library feature `unstable_test_feature`
-  --> $DIR/lint-stability.rs:88:48
-   |
-LL |         struct S1<T: TraitWithAssociatedTypes>(T::TypeUnstable);
-   |                                                ^^^^^^^^^^^^^^^
-   |
-   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:17:5
    |
 LL |     extern crate stability_cfg2;
@@ -372,6 +363,15 @@ error[E0658]: use of unstable library feature `unstable_test_feature`
    |
 LL |         let _ = Unstable::StableVariant;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: use of unstable library feature `unstable_test_feature`
+  --> $DIR/lint-stability.rs:88:48
+   |
+LL |         struct S1<T: TraitWithAssociatedTypes>(T::TypeUnstable);
+   |                                                ^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date

--- a/tests/ui/privacy/auxiliary/missing-mir-priv-bounds-extern-2.rs
+++ b/tests/ui/privacy/auxiliary/missing-mir-priv-bounds-extern-2.rs
@@ -1,0 +1,46 @@
+// Doesn't involve `impl Trait` unlike missing-mir-priv-bounds-extern.rs
+
+pub trait ToPriv {
+    type AssocPriv;
+}
+
+pub trait PubTr {
+    #[expect(private_bounds)]
+    type Assoc: ToPriv<AssocPriv = Priv>;
+}
+
+// Dummy and DummyToPriv are only used in call_handler
+struct Dummy;
+struct DummyToPriv;
+impl PubTr for Dummy {
+    type Assoc = DummyToPriv;
+}
+impl ToPriv for DummyToPriv {
+    type AssocPriv = Priv;
+}
+
+pub trait PubTrHandler {
+    fn handle<T: PubTr>();
+}
+pub fn call_handler<T: PubTrHandler>() {
+    T::handle::<Dummy>();
+}
+
+struct Priv;
+
+pub trait GetUnreachable {
+    type Assoc;
+}
+
+mod m {
+    pub struct Unreachable;
+
+    impl Unreachable {
+        #[expect(dead_code)]
+        pub fn generic<T>() {}
+    }
+
+    impl crate::GetUnreachable for crate::Priv {
+        type Assoc = Unreachable;
+    }
+}

--- a/tests/ui/privacy/auxiliary/missing-mir-priv-bounds-extern-3.rs
+++ b/tests/ui/privacy/auxiliary/missing-mir-priv-bounds-extern-3.rs
@@ -1,0 +1,35 @@
+struct Priv;
+
+pub trait Super {
+    type AssocSuper: GetUnreachable;
+}
+#[expect(private_bounds)]
+pub trait Sub: Super<AssocSuper = Priv> {}
+
+// This Dummy type is only used in call_handler
+struct Dummy;
+impl Super for Dummy {
+    type AssocSuper = Priv;
+}
+impl Sub for Dummy {}
+
+pub trait SubHandler {
+    fn handle<T: Sub>();
+}
+pub fn call_handler<T: SubHandler>() {
+    <T as SubHandler>::handle::<Dummy>();
+}
+
+pub trait GetUnreachable {
+    type Assoc;
+}
+mod m {
+    pub struct Unreachable;
+    impl Unreachable {
+        #[expect(dead_code)]
+        pub fn generic<T>() {}
+    }
+    impl crate::GetUnreachable for crate::Priv {
+        type Assoc = Unreachable;
+    }
+}

--- a/tests/ui/privacy/auxiliary/missing-mir-priv-bounds-extern.rs
+++ b/tests/ui/privacy/auxiliary/missing-mir-priv-bounds-extern.rs
@@ -1,0 +1,40 @@
+pub trait ToPriv {
+    type AssocPriv;
+}
+
+pub trait PubTr {
+    #[expect(private_bounds)]
+    type Assoc: ToPriv<AssocPriv = Priv>;
+}
+
+struct Dummy;
+struct DummyToPriv;
+impl PubTr for Dummy {
+    type Assoc = DummyToPriv;
+}
+impl ToPriv for DummyToPriv {
+    type AssocPriv = Priv;
+}
+
+pub fn get_dummy() -> impl PubTr {
+    Dummy
+}
+
+struct Priv;
+
+pub trait GetUnreachable {
+    type Assoc;
+}
+
+mod m {
+    pub struct Unreachable;
+
+    impl Unreachable {
+        #[expect(dead_code)]
+        pub fn generic<T>() {}
+    }
+
+    impl crate::GetUnreachable for crate::Priv {
+        type Assoc = Unreachable;
+    }
+}

--- a/tests/ui/privacy/missing-mir-priv-bounds-2.rs
+++ b/tests/ui/privacy/missing-mir-priv-bounds-2.rs
@@ -1,0 +1,29 @@
+// Test case from issue #151284.
+// A private associated type bound allows to leak another private type and result in missing MIR.
+
+//@ build-fail
+//@ aux-crate:dep=missing-mir-priv-bounds-extern-2.rs
+
+extern crate dep;
+use dep::{GetUnreachable, PubTr, PubTrHandler, ToPriv, call_handler};
+
+fn main() {
+    call_handler::<Handler>();
+}
+
+struct Handler;
+impl PubTrHandler for Handler {
+    fn handle<T: PubTr>() {
+        <T as Access>::AccessAssoc::generic::<i32>();
+    }
+}
+
+trait Access: PubTr {
+    type AccessAssoc;
+}
+
+impl<T: PubTr> Access for T {
+    type AccessAssoc = <<T::Assoc as ToPriv>::AssocPriv as GetUnreachable>::Assoc;
+}
+
+//~? ERROR missing optimized MIR

--- a/tests/ui/privacy/missing-mir-priv-bounds-2.stderr
+++ b/tests/ui/privacy/missing-mir-priv-bounds-2.stderr
@@ -1,0 +1,10 @@
+error: missing optimized MIR for `dep::m::Unreachable::generic::<i32>` in the crate `missing_mir_priv_bounds_extern_2`
+   |
+note: missing optimized MIR for this item (was the crate `missing_mir_priv_bounds_extern_2` compiled with `--emit=metadata`?)
+  --> $DIR/auxiliary/missing-mir-priv-bounds-extern-2.rs:40:9
+   |
+LL |         pub fn generic<T>() {}
+   |         ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/privacy/missing-mir-priv-bounds-3.rs
+++ b/tests/ui/privacy/missing-mir-priv-bounds-3.rs
@@ -1,0 +1,30 @@
+// Test case from issue #151479.
+// A private associated type bound allows to leak another private type and result in missing MIR.
+
+//@ build-fail
+//@ aux-crate:dep=missing-mir-priv-bounds-extern-3.rs
+
+extern crate dep;
+use dep::{GetUnreachable, Sub, SubHandler, Super, call_handler};
+
+fn main() {
+    call_handler::<Handler>();
+}
+
+struct Handler;
+impl SubHandler for Handler {
+    fn handle<T: Sub>() {
+        <T as Access>::AccessAssoc::generic::<i32>();
+    }
+}
+
+// Without this indirection, Handler::handle notices that
+// it's mentioning dep::Priv.
+trait Access: Super {
+    type AccessAssoc;
+}
+impl<T: Super> Access for T {
+    type AccessAssoc = <<T as Super>::AssocSuper as GetUnreachable>::Assoc;
+}
+
+//~? ERROR missing optimized MIR

--- a/tests/ui/privacy/missing-mir-priv-bounds-3.stderr
+++ b/tests/ui/privacy/missing-mir-priv-bounds-3.stderr
@@ -1,0 +1,10 @@
+error: missing optimized MIR for `dep::m::Unreachable::generic::<i32>` in the crate `missing_mir_priv_bounds_extern_3`
+   |
+note: missing optimized MIR for this item (was the crate `missing_mir_priv_bounds_extern_3` compiled with `--emit=metadata`?)
+  --> $DIR/auxiliary/missing-mir-priv-bounds-extern-3.rs:30:9
+   |
+LL |         pub fn generic<T>() {}
+   |         ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/privacy/missing-mir-priv-bounds.rs
+++ b/tests/ui/privacy/missing-mir-priv-bounds.rs
@@ -1,0 +1,26 @@
+// Test case from issue #151284.
+// A private associated type bound allows to leak another private type and result in missing MIR.
+
+//@ build-fail
+//@ aux-crate:dep=missing-mir-priv-bounds-extern.rs
+
+extern crate dep;
+use dep::{GetUnreachable, PubTr, ToPriv, get_dummy};
+
+fn main() {
+    wut(get_dummy());
+}
+
+fn wut<T: PubTr>(_: T) {
+    <T as Access>::AccessAssoc::generic::<i32>();
+}
+
+trait Access: PubTr {
+    type AccessAssoc;
+}
+
+impl<T: PubTr> Access for T {
+    type AccessAssoc = <<T::Assoc as ToPriv>::AssocPriv as GetUnreachable>::Assoc;
+}
+
+//~? ERROR missing optimized MIR

--- a/tests/ui/privacy/missing-mir-priv-bounds.stderr
+++ b/tests/ui/privacy/missing-mir-priv-bounds.stderr
@@ -1,0 +1,10 @@
+error: missing optimized MIR for `dep::m::Unreachable::generic::<i32>` in the crate `missing_mir_priv_bounds_extern`
+   |
+note: missing optimized MIR for this item (was the crate `missing_mir_priv_bounds_extern` compiled with `--emit=metadata`?)
+  --> $DIR/auxiliary/missing-mir-priv-bounds-extern.rs:34:9
+   |
+LL |         pub fn generic<T>() {}
+   |         ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/privacy/private-in-public-warn.rs
+++ b/tests/ui/privacy/private-in-public-warn.rs
@@ -49,7 +49,10 @@ mod traits {
         fn f<T: PrivTr>(arg: T) {}
         //~^ ERROR trait `traits::PrivTr` is more private than the item `traits::Tr3::f`
         fn g() -> impl PrivTr;
+        //~^ ERROR trait `traits::PrivTr` is more private than the item `traits::Tr3::g::{anon_assoc#0}`
         fn h() -> impl PrivTr {}
+        //~^ ERROR trait `traits::PrivTr` is more private than the item `traits::Tr3::h::{anon_assoc#0}`
+        //~| ERROR trait `traits::PrivTr` is more private than the item `traits::Tr3::h::{anon_assoc#0}`
     }
     impl<T: PrivTr> Pub<T> {} //~ ERROR trait `traits::PrivTr` is more private than the item `traits::Pub<T>`
     impl<T: PrivTr> PubTr for Pub<T> {} // OK, trait impl predicates
@@ -89,7 +92,13 @@ mod generics {
 
     pub trait Tr5 {
         fn required() -> impl PrivTr<Priv<()>>;
+        //~^ ERROR trait `generics::PrivTr<generics::Priv<()>>` is more private than the item `Tr5::required::{anon_assoc#0}`
+        //~| ERROR type `generics::Priv<()>` is more private than the item `Tr5::required::{anon_assoc#0}`
         fn provided() -> impl PrivTr<Priv<()>> {}
+        //~^ ERROR trait `generics::PrivTr<generics::Priv<()>>` is more private than the item `Tr5::provided::{anon_assoc#0}`
+        //~| ERROR type `generics::Priv<()>` is more private than the item `Tr5::provided::{anon_assoc#0}`
+        //~| ERROR trait `generics::PrivTr<generics::Priv<()>>` is more private than the item `Tr5::provided::{anon_assoc#0}`
+        //~| ERROR type `generics::Priv<()>` is more private than the item `Tr5::provided::{anon_assoc#0}`
     }
 }
 

--- a/tests/ui/privacy/private-in-public-warn.rs
+++ b/tests/ui/privacy/private-in-public-warn.rs
@@ -50,6 +50,7 @@ mod traits {
         //~^ ERROR trait `traits::PrivTr` is more private than the item `traits::Tr3::f`
         fn g() -> impl PrivTr;
         //~^ ERROR trait `traits::PrivTr` is more private than the item `traits::Tr3::g::{anon_assoc#0}`
+        //~| ERROR trait `traits::PrivTr` is more private than the item `traits::Tr3::g::{anon_assoc#0}`
         fn h() -> impl PrivTr {}
         //~^ ERROR trait `traits::PrivTr` is more private than the item `traits::Tr3::h::{anon_assoc#0}`
         //~| ERROR trait `traits::PrivTr` is more private than the item `traits::Tr3::h::{anon_assoc#0}`
@@ -93,6 +94,8 @@ mod generics {
     pub trait Tr5 {
         fn required() -> impl PrivTr<Priv<()>>;
         //~^ ERROR trait `generics::PrivTr<generics::Priv<()>>` is more private than the item `Tr5::required::{anon_assoc#0}`
+        //~| ERROR type `generics::Priv<()>` is more private than the item `Tr5::required::{anon_assoc#0}`
+        //~| ERROR trait `generics::PrivTr<generics::Priv<()>>` is more private than the item `Tr5::required::{anon_assoc#0}`
         //~| ERROR type `generics::Priv<()>` is more private than the item `Tr5::required::{anon_assoc#0}`
         fn provided() -> impl PrivTr<Priv<()>> {}
         //~^ ERROR trait `generics::PrivTr<generics::Priv<()>>` is more private than the item `Tr5::provided::{anon_assoc#0}`

--- a/tests/ui/privacy/private-in-public-warn.stderr
+++ b/tests/ui/privacy/private-in-public-warn.stderr
@@ -206,8 +206,20 @@ note: but trait `traits::PrivTr` is only usable at visibility `pub(self)`
 LL |     trait PrivTr {}
    |     ^^^^^^^^^^^^
 
+error: trait `traits::PrivTr` is more private than the item `traits::Tr3::g::{anon_assoc#0}`
+  --> $DIR/private-in-public-warn.rs:51:19
+   |
+LL |         fn g() -> impl PrivTr;
+   |                   ^^^^^^^^^^^ opaque type `traits::Tr3::g::{anon_assoc#0}` is reachable at visibility `pub(crate)`
+   |
+note: but trait `traits::PrivTr` is only usable at visibility `pub(self)`
+  --> $DIR/private-in-public-warn.rs:37:5
+   |
+LL |     trait PrivTr {}
+   |     ^^^^^^^^^^^^
+
 error: trait `traits::PrivTr` is more private than the item `traits::Tr3::h::{anon_assoc#0}`
-  --> $DIR/private-in-public-warn.rs:53:19
+  --> $DIR/private-in-public-warn.rs:54:19
    |
 LL |         fn h() -> impl PrivTr {}
    |                   ^^^^^^^^^^^ opaque type `traits::Tr3::h::{anon_assoc#0}` is reachable at visibility `pub(crate)`
@@ -219,7 +231,7 @@ LL |     trait PrivTr {}
    |     ^^^^^^^^^^^^
 
 error: trait `traits::PrivTr` is more private than the item `traits::Tr3::h::{anon_assoc#0}`
-  --> $DIR/private-in-public-warn.rs:53:19
+  --> $DIR/private-in-public-warn.rs:54:19
    |
 LL |         fn h() -> impl PrivTr {}
    |                   ^^^^^^^^^^^ opaque type `traits::Tr3::h::{anon_assoc#0}` is reachable at visibility `pub(crate)`
@@ -231,7 +243,7 @@ LL |     trait PrivTr {}
    |     ^^^^^^^^^^^^
 
 error: trait `traits::PrivTr` is more private than the item `traits::Pub<T>`
-  --> $DIR/private-in-public-warn.rs:57:5
+  --> $DIR/private-in-public-warn.rs:58:5
    |
 LL |     impl<T: PrivTr> Pub<T> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^ implementation `traits::Pub<T>` is reachable at visibility `pub(crate)`
@@ -243,175 +255,199 @@ LL |     trait PrivTr {}
    |     ^^^^^^^^^^^^
 
 error: trait `traits_where::PrivTr` is more private than the item `traits_where::Alias`
-  --> $DIR/private-in-public-warn.rs:66:5
+  --> $DIR/private-in-public-warn.rs:67:5
    |
 LL |     pub type Alias<T> where T: PrivTr = T;
    |     ^^^^^^^^^^^^^^^^^ type alias `traits_where::Alias` is reachable at visibility `pub(crate)`
    |
 note: but trait `traits_where::PrivTr` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:62:5
+  --> $DIR/private-in-public-warn.rs:63:5
    |
 LL |     trait PrivTr {}
    |     ^^^^^^^^^^^^
 
 error: trait `traits_where::PrivTr` is more private than the item `traits_where::Tr2`
-  --> $DIR/private-in-public-warn.rs:69:5
+  --> $DIR/private-in-public-warn.rs:70:5
    |
 LL |     pub trait Tr2<T> where T: PrivTr {}
    |     ^^^^^^^^^^^^^^^^ trait `traits_where::Tr2` is reachable at visibility `pub(crate)`
    |
 note: but trait `traits_where::PrivTr` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:62:5
+  --> $DIR/private-in-public-warn.rs:63:5
    |
 LL |     trait PrivTr {}
    |     ^^^^^^^^^^^^
 
 error: trait `traits_where::PrivTr` is more private than the item `traits_where::Tr3::f`
-  --> $DIR/private-in-public-warn.rs:72:9
+  --> $DIR/private-in-public-warn.rs:73:9
    |
 LL |         fn f<T>(arg: T) where T: PrivTr {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ associated function `traits_where::Tr3::f` is reachable at visibility `pub(crate)`
    |
 note: but trait `traits_where::PrivTr` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:62:5
+  --> $DIR/private-in-public-warn.rs:63:5
    |
 LL |     trait PrivTr {}
    |     ^^^^^^^^^^^^
 
 error: trait `traits_where::PrivTr` is more private than the item `traits_where::Pub<T>`
-  --> $DIR/private-in-public-warn.rs:75:5
+  --> $DIR/private-in-public-warn.rs:76:5
    |
 LL |     impl<T> Pub<T> where T: PrivTr {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation `traits_where::Pub<T>` is reachable at visibility `pub(crate)`
    |
 note: but trait `traits_where::PrivTr` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:62:5
+  --> $DIR/private-in-public-warn.rs:63:5
    |
 LL |     trait PrivTr {}
    |     ^^^^^^^^^^^^
 
 error: trait `generics::PrivTr<generics::Pub>` is more private than the item `generics::Tr1`
-  --> $DIR/private-in-public-warn.rs:87:5
+  --> $DIR/private-in-public-warn.rs:88:5
    |
 LL |     pub trait Tr1: PrivTr<Pub> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ trait `generics::Tr1` is reachable at visibility `pub(crate)`
    |
 note: but trait `generics::PrivTr<generics::Pub>` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:83:5
+  --> $DIR/private-in-public-warn.rs:84:5
    |
 LL |     trait PrivTr<T> {}
    |     ^^^^^^^^^^^^^^^
 
 error: type `generics::Priv` is more private than the item `generics::Tr2`
-  --> $DIR/private-in-public-warn.rs:89:5
+  --> $DIR/private-in-public-warn.rs:90:5
    |
 LL |     pub trait Tr2: PubTr<Priv> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ trait `generics::Tr2` is reachable at visibility `pub(crate)`
    |
 note: but type `generics::Priv` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:81:5
+  --> $DIR/private-in-public-warn.rs:82:5
    |
 LL |     struct Priv<T = u8>(T);
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: type `generics::Priv` is more private than the item `generics::Tr3`
-  --> $DIR/private-in-public-warn.rs:90:5
+  --> $DIR/private-in-public-warn.rs:91:5
    |
 LL |     pub trait Tr3: PubTr<[Priv; 1]> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait `generics::Tr3` is reachable at visibility `pub(crate)`
    |
 note: but type `generics::Priv` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:81:5
+  --> $DIR/private-in-public-warn.rs:82:5
    |
 LL |     struct Priv<T = u8>(T);
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: type `generics::Priv` is more private than the item `Tr4`
-  --> $DIR/private-in-public-warn.rs:91:5
+  --> $DIR/private-in-public-warn.rs:92:5
    |
 LL |     pub trait Tr4: PubTr<Pub<Priv>> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait `Tr4` is reachable at visibility `pub(crate)`
    |
 note: but type `generics::Priv` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:81:5
+  --> $DIR/private-in-public-warn.rs:82:5
    |
 LL |     struct Priv<T = u8>(T);
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: trait `generics::PrivTr<generics::Priv<()>>` is more private than the item `Tr5::required::{anon_assoc#0}`
-  --> $DIR/private-in-public-warn.rs:94:26
+  --> $DIR/private-in-public-warn.rs:95:26
    |
 LL |         fn required() -> impl PrivTr<Priv<()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^ opaque type `Tr5::required::{anon_assoc#0}` is reachable at visibility `pub(crate)`
    |
 note: but trait `generics::PrivTr<generics::Priv<()>>` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:83:5
+  --> $DIR/private-in-public-warn.rs:84:5
    |
 LL |     trait PrivTr<T> {}
    |     ^^^^^^^^^^^^^^^
 
 error: type `generics::Priv<()>` is more private than the item `Tr5::required::{anon_assoc#0}`
-  --> $DIR/private-in-public-warn.rs:94:26
+  --> $DIR/private-in-public-warn.rs:95:26
    |
 LL |         fn required() -> impl PrivTr<Priv<()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^ opaque type `Tr5::required::{anon_assoc#0}` is reachable at visibility `pub(crate)`
    |
 note: but type `generics::Priv<()>` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:81:5
+  --> $DIR/private-in-public-warn.rs:82:5
+   |
+LL |     struct Priv<T = u8>(T);
+   |     ^^^^^^^^^^^^^^^^^^^
+
+error: trait `generics::PrivTr<generics::Priv<()>>` is more private than the item `Tr5::required::{anon_assoc#0}`
+  --> $DIR/private-in-public-warn.rs:95:26
+   |
+LL |         fn required() -> impl PrivTr<Priv<()>>;
+   |                          ^^^^^^^^^^^^^^^^^^^^^ opaque type `Tr5::required::{anon_assoc#0}` is reachable at visibility `pub(crate)`
+   |
+note: but trait `generics::PrivTr<generics::Priv<()>>` is only usable at visibility `pub(self)`
+  --> $DIR/private-in-public-warn.rs:84:5
+   |
+LL |     trait PrivTr<T> {}
+   |     ^^^^^^^^^^^^^^^
+
+error: type `generics::Priv<()>` is more private than the item `Tr5::required::{anon_assoc#0}`
+  --> $DIR/private-in-public-warn.rs:95:26
+   |
+LL |         fn required() -> impl PrivTr<Priv<()>>;
+   |                          ^^^^^^^^^^^^^^^^^^^^^ opaque type `Tr5::required::{anon_assoc#0}` is reachable at visibility `pub(crate)`
+   |
+note: but type `generics::Priv<()>` is only usable at visibility `pub(self)`
+  --> $DIR/private-in-public-warn.rs:82:5
    |
 LL |     struct Priv<T = u8>(T);
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: trait `generics::PrivTr<generics::Priv<()>>` is more private than the item `Tr5::provided::{anon_assoc#0}`
-  --> $DIR/private-in-public-warn.rs:97:26
+  --> $DIR/private-in-public-warn.rs:100:26
    |
 LL |         fn provided() -> impl PrivTr<Priv<()>> {}
    |                          ^^^^^^^^^^^^^^^^^^^^^ opaque type `Tr5::provided::{anon_assoc#0}` is reachable at visibility `pub(crate)`
    |
 note: but trait `generics::PrivTr<generics::Priv<()>>` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:83:5
+  --> $DIR/private-in-public-warn.rs:84:5
    |
 LL |     trait PrivTr<T> {}
    |     ^^^^^^^^^^^^^^^
 
 error: type `generics::Priv<()>` is more private than the item `Tr5::provided::{anon_assoc#0}`
-  --> $DIR/private-in-public-warn.rs:97:26
+  --> $DIR/private-in-public-warn.rs:100:26
    |
 LL |         fn provided() -> impl PrivTr<Priv<()>> {}
    |                          ^^^^^^^^^^^^^^^^^^^^^ opaque type `Tr5::provided::{anon_assoc#0}` is reachable at visibility `pub(crate)`
    |
 note: but type `generics::Priv<()>` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:81:5
+  --> $DIR/private-in-public-warn.rs:82:5
    |
 LL |     struct Priv<T = u8>(T);
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: trait `generics::PrivTr<generics::Priv<()>>` is more private than the item `Tr5::provided::{anon_assoc#0}`
-  --> $DIR/private-in-public-warn.rs:97:26
+  --> $DIR/private-in-public-warn.rs:100:26
    |
 LL |         fn provided() -> impl PrivTr<Priv<()>> {}
    |                          ^^^^^^^^^^^^^^^^^^^^^ opaque type `Tr5::provided::{anon_assoc#0}` is reachable at visibility `pub(crate)`
    |
 note: but trait `generics::PrivTr<generics::Priv<()>>` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:83:5
+  --> $DIR/private-in-public-warn.rs:84:5
    |
 LL |     trait PrivTr<T> {}
    |     ^^^^^^^^^^^^^^^
 
 error: type `generics::Priv<()>` is more private than the item `Tr5::provided::{anon_assoc#0}`
-  --> $DIR/private-in-public-warn.rs:97:26
+  --> $DIR/private-in-public-warn.rs:100:26
    |
 LL |         fn provided() -> impl PrivTr<Priv<()>> {}
    |                          ^^^^^^^^^^^^^^^^^^^^^ opaque type `Tr5::provided::{anon_assoc#0}` is reachable at visibility `pub(crate)`
    |
 note: but type `generics::Priv<()>` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:81:5
+  --> $DIR/private-in-public-warn.rs:82:5
    |
 LL |     struct Priv<T = u8>(T);
    |     ^^^^^^^^^^^^^^^^^^^
 
 error[E0446]: private type `impls::Priv` in public interface
-  --> $DIR/private-in-public-warn.rs:128:9
+  --> $DIR/private-in-public-warn.rs:131:9
    |
 LL |     struct Priv;
    |     ----------- `impls::Priv` declared as private
@@ -420,25 +456,16 @@ LL |         type Alias = Priv;
    |         ^^^^^^^^^^ can't leak private type
 
 error: type `aliases_pub::Priv` is more private than the item `aliases_pub::<impl Pub2>::f`
-  --> $DIR/private-in-public-warn.rs:199:9
+  --> $DIR/private-in-public-warn.rs:202:9
    |
 LL |         pub fn f(arg: Priv) {}
    |         ^^^^^^^^^^^^^^^^^^^ associated function `aliases_pub::<impl Pub2>::f` is reachable at visibility `pub(crate)`
    |
 note: but type `aliases_pub::Priv` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:172:5
+  --> $DIR/private-in-public-warn.rs:175:5
    |
 LL |     struct Priv;
    |     ^^^^^^^^^^^
-
-error[E0446]: private type `aliases_pub::Priv` in public interface
-  --> $DIR/private-in-public-warn.rs:202:9
-   |
-LL |     struct Priv;
-   |     ----------- `aliases_pub::Priv` declared as private
-...
-LL |         type Check = Priv;
-   |         ^^^^^^^^^^ can't leak private type
 
 error[E0446]: private type `aliases_pub::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:205:9
@@ -467,38 +494,47 @@ LL |     struct Priv;
 LL |         type Check = Priv;
    |         ^^^^^^^^^^ can't leak private type
 
+error[E0446]: private type `aliases_pub::Priv` in public interface
+  --> $DIR/private-in-public-warn.rs:214:9
+   |
+LL |     struct Priv;
+   |     ----------- `aliases_pub::Priv` declared as private
+...
+LL |         type Check = Priv;
+   |         ^^^^^^^^^^ can't leak private type
+
 error: trait `PrivTr1` is more private than the item `aliases_priv::Tr1`
-  --> $DIR/private-in-public-warn.rs:241:5
+  --> $DIR/private-in-public-warn.rs:244:5
    |
 LL |     pub trait Tr1: PrivUseAliasTr {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait `aliases_priv::Tr1` is reachable at visibility `pub(crate)`
    |
 note: but trait `PrivTr1` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:227:5
+  --> $DIR/private-in-public-warn.rs:230:5
    |
 LL |     trait PrivTr1<T = u8> {
    |     ^^^^^^^^^^^^^^^^^^^^^
 
 error: trait `PrivTr1<Priv2>` is more private than the item `aliases_priv::Tr2`
-  --> $DIR/private-in-public-warn.rs:243:5
+  --> $DIR/private-in-public-warn.rs:246:5
    |
 LL |     pub trait Tr2: PrivUseAliasTr<PrivAlias> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait `aliases_priv::Tr2` is reachable at visibility `pub(crate)`
    |
 note: but trait `PrivTr1<Priv2>` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:227:5
+  --> $DIR/private-in-public-warn.rs:230:5
    |
 LL |     trait PrivTr1<T = u8> {
    |     ^^^^^^^^^^^^^^^^^^^^^
 
 error: type `Priv2` is more private than the item `aliases_priv::Tr2`
-  --> $DIR/private-in-public-warn.rs:243:5
+  --> $DIR/private-in-public-warn.rs:246:5
    |
 LL |     pub trait Tr2: PrivUseAliasTr<PrivAlias> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait `aliases_priv::Tr2` is reachable at visibility `pub(crate)`
    |
 note: but type `Priv2` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:225:5
+  --> $DIR/private-in-public-warn.rs:228:5
    |
 LL |     struct Priv2;
    |     ^^^^^^^^^^^^
@@ -518,7 +554,7 @@ LL |     pub type Alias<T: PrivTr> = T;
    = note: `#[warn(type_alias_bounds)]` on by default
 
 warning: where clauses on type aliases are not enforced
-  --> $DIR/private-in-public-warn.rs:66:29
+  --> $DIR/private-in-public-warn.rs:67:29
    |
 LL |     pub type Alias<T> where T: PrivTr = T;
    |                       ------^^^^^^^^^
@@ -530,6 +566,6 @@ LL |     pub type Alias<T> where T: PrivTr = T;
            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics
 
-error: aborting due to 43 previous errors; 2 warnings emitted
+error: aborting due to 46 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0446`.

--- a/tests/ui/privacy/private-in-public-warn.stderr
+++ b/tests/ui/privacy/private-in-public-warn.stderr
@@ -194,8 +194,44 @@ note: but trait `traits::PrivTr` is only usable at visibility `pub(self)`
 LL |     trait PrivTr {}
    |     ^^^^^^^^^^^^
 
+error: trait `traits::PrivTr` is more private than the item `traits::Tr3::g::{anon_assoc#0}`
+  --> $DIR/private-in-public-warn.rs:51:19
+   |
+LL |         fn g() -> impl PrivTr;
+   |                   ^^^^^^^^^^^ opaque type `traits::Tr3::g::{anon_assoc#0}` is reachable at visibility `pub(crate)`
+   |
+note: but trait `traits::PrivTr` is only usable at visibility `pub(self)`
+  --> $DIR/private-in-public-warn.rs:37:5
+   |
+LL |     trait PrivTr {}
+   |     ^^^^^^^^^^^^
+
+error: trait `traits::PrivTr` is more private than the item `traits::Tr3::h::{anon_assoc#0}`
+  --> $DIR/private-in-public-warn.rs:53:19
+   |
+LL |         fn h() -> impl PrivTr {}
+   |                   ^^^^^^^^^^^ opaque type `traits::Tr3::h::{anon_assoc#0}` is reachable at visibility `pub(crate)`
+   |
+note: but trait `traits::PrivTr` is only usable at visibility `pub(self)`
+  --> $DIR/private-in-public-warn.rs:37:5
+   |
+LL |     trait PrivTr {}
+   |     ^^^^^^^^^^^^
+
+error: trait `traits::PrivTr` is more private than the item `traits::Tr3::h::{anon_assoc#0}`
+  --> $DIR/private-in-public-warn.rs:53:19
+   |
+LL |         fn h() -> impl PrivTr {}
+   |                   ^^^^^^^^^^^ opaque type `traits::Tr3::h::{anon_assoc#0}` is reachable at visibility `pub(crate)`
+   |
+note: but trait `traits::PrivTr` is only usable at visibility `pub(self)`
+  --> $DIR/private-in-public-warn.rs:37:5
+   |
+LL |     trait PrivTr {}
+   |     ^^^^^^^^^^^^
+
 error: trait `traits::PrivTr` is more private than the item `traits::Pub<T>`
-  --> $DIR/private-in-public-warn.rs:54:5
+  --> $DIR/private-in-public-warn.rs:57:5
    |
 LL |     impl<T: PrivTr> Pub<T> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^ implementation `traits::Pub<T>` is reachable at visibility `pub(crate)`
@@ -207,103 +243,175 @@ LL |     trait PrivTr {}
    |     ^^^^^^^^^^^^
 
 error: trait `traits_where::PrivTr` is more private than the item `traits_where::Alias`
-  --> $DIR/private-in-public-warn.rs:63:5
+  --> $DIR/private-in-public-warn.rs:66:5
    |
 LL |     pub type Alias<T> where T: PrivTr = T;
    |     ^^^^^^^^^^^^^^^^^ type alias `traits_where::Alias` is reachable at visibility `pub(crate)`
    |
 note: but trait `traits_where::PrivTr` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:59:5
+  --> $DIR/private-in-public-warn.rs:62:5
    |
 LL |     trait PrivTr {}
    |     ^^^^^^^^^^^^
 
 error: trait `traits_where::PrivTr` is more private than the item `traits_where::Tr2`
-  --> $DIR/private-in-public-warn.rs:66:5
+  --> $DIR/private-in-public-warn.rs:69:5
    |
 LL |     pub trait Tr2<T> where T: PrivTr {}
    |     ^^^^^^^^^^^^^^^^ trait `traits_where::Tr2` is reachable at visibility `pub(crate)`
    |
 note: but trait `traits_where::PrivTr` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:59:5
+  --> $DIR/private-in-public-warn.rs:62:5
    |
 LL |     trait PrivTr {}
    |     ^^^^^^^^^^^^
 
 error: trait `traits_where::PrivTr` is more private than the item `traits_where::Tr3::f`
-  --> $DIR/private-in-public-warn.rs:69:9
+  --> $DIR/private-in-public-warn.rs:72:9
    |
 LL |         fn f<T>(arg: T) where T: PrivTr {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ associated function `traits_where::Tr3::f` is reachable at visibility `pub(crate)`
    |
 note: but trait `traits_where::PrivTr` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:59:5
+  --> $DIR/private-in-public-warn.rs:62:5
    |
 LL |     trait PrivTr {}
    |     ^^^^^^^^^^^^
 
 error: trait `traits_where::PrivTr` is more private than the item `traits_where::Pub<T>`
-  --> $DIR/private-in-public-warn.rs:72:5
+  --> $DIR/private-in-public-warn.rs:75:5
    |
 LL |     impl<T> Pub<T> where T: PrivTr {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation `traits_where::Pub<T>` is reachable at visibility `pub(crate)`
    |
 note: but trait `traits_where::PrivTr` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:59:5
+  --> $DIR/private-in-public-warn.rs:62:5
    |
 LL |     trait PrivTr {}
    |     ^^^^^^^^^^^^
 
 error: trait `generics::PrivTr<generics::Pub>` is more private than the item `generics::Tr1`
-  --> $DIR/private-in-public-warn.rs:84:5
+  --> $DIR/private-in-public-warn.rs:87:5
    |
 LL |     pub trait Tr1: PrivTr<Pub> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ trait `generics::Tr1` is reachable at visibility `pub(crate)`
    |
 note: but trait `generics::PrivTr<generics::Pub>` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:80:5
+  --> $DIR/private-in-public-warn.rs:83:5
    |
 LL |     trait PrivTr<T> {}
    |     ^^^^^^^^^^^^^^^
 
 error: type `generics::Priv` is more private than the item `generics::Tr2`
-  --> $DIR/private-in-public-warn.rs:86:5
+  --> $DIR/private-in-public-warn.rs:89:5
    |
 LL |     pub trait Tr2: PubTr<Priv> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ trait `generics::Tr2` is reachable at visibility `pub(crate)`
    |
 note: but type `generics::Priv` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:78:5
+  --> $DIR/private-in-public-warn.rs:81:5
    |
 LL |     struct Priv<T = u8>(T);
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: type `generics::Priv` is more private than the item `generics::Tr3`
-  --> $DIR/private-in-public-warn.rs:87:5
+  --> $DIR/private-in-public-warn.rs:90:5
    |
 LL |     pub trait Tr3: PubTr<[Priv; 1]> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait `generics::Tr3` is reachable at visibility `pub(crate)`
    |
 note: but type `generics::Priv` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:78:5
+  --> $DIR/private-in-public-warn.rs:81:5
    |
 LL |     struct Priv<T = u8>(T);
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: type `generics::Priv` is more private than the item `Tr4`
-  --> $DIR/private-in-public-warn.rs:88:5
+  --> $DIR/private-in-public-warn.rs:91:5
    |
 LL |     pub trait Tr4: PubTr<Pub<Priv>> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait `Tr4` is reachable at visibility `pub(crate)`
    |
 note: but type `generics::Priv` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:78:5
+  --> $DIR/private-in-public-warn.rs:81:5
+   |
+LL |     struct Priv<T = u8>(T);
+   |     ^^^^^^^^^^^^^^^^^^^
+
+error: trait `generics::PrivTr<generics::Priv<()>>` is more private than the item `Tr5::required::{anon_assoc#0}`
+  --> $DIR/private-in-public-warn.rs:94:26
+   |
+LL |         fn required() -> impl PrivTr<Priv<()>>;
+   |                          ^^^^^^^^^^^^^^^^^^^^^ opaque type `Tr5::required::{anon_assoc#0}` is reachable at visibility `pub(crate)`
+   |
+note: but trait `generics::PrivTr<generics::Priv<()>>` is only usable at visibility `pub(self)`
+  --> $DIR/private-in-public-warn.rs:83:5
+   |
+LL |     trait PrivTr<T> {}
+   |     ^^^^^^^^^^^^^^^
+
+error: type `generics::Priv<()>` is more private than the item `Tr5::required::{anon_assoc#0}`
+  --> $DIR/private-in-public-warn.rs:94:26
+   |
+LL |         fn required() -> impl PrivTr<Priv<()>>;
+   |                          ^^^^^^^^^^^^^^^^^^^^^ opaque type `Tr5::required::{anon_assoc#0}` is reachable at visibility `pub(crate)`
+   |
+note: but type `generics::Priv<()>` is only usable at visibility `pub(self)`
+  --> $DIR/private-in-public-warn.rs:81:5
+   |
+LL |     struct Priv<T = u8>(T);
+   |     ^^^^^^^^^^^^^^^^^^^
+
+error: trait `generics::PrivTr<generics::Priv<()>>` is more private than the item `Tr5::provided::{anon_assoc#0}`
+  --> $DIR/private-in-public-warn.rs:97:26
+   |
+LL |         fn provided() -> impl PrivTr<Priv<()>> {}
+   |                          ^^^^^^^^^^^^^^^^^^^^^ opaque type `Tr5::provided::{anon_assoc#0}` is reachable at visibility `pub(crate)`
+   |
+note: but trait `generics::PrivTr<generics::Priv<()>>` is only usable at visibility `pub(self)`
+  --> $DIR/private-in-public-warn.rs:83:5
+   |
+LL |     trait PrivTr<T> {}
+   |     ^^^^^^^^^^^^^^^
+
+error: type `generics::Priv<()>` is more private than the item `Tr5::provided::{anon_assoc#0}`
+  --> $DIR/private-in-public-warn.rs:97:26
+   |
+LL |         fn provided() -> impl PrivTr<Priv<()>> {}
+   |                          ^^^^^^^^^^^^^^^^^^^^^ opaque type `Tr5::provided::{anon_assoc#0}` is reachable at visibility `pub(crate)`
+   |
+note: but type `generics::Priv<()>` is only usable at visibility `pub(self)`
+  --> $DIR/private-in-public-warn.rs:81:5
+   |
+LL |     struct Priv<T = u8>(T);
+   |     ^^^^^^^^^^^^^^^^^^^
+
+error: trait `generics::PrivTr<generics::Priv<()>>` is more private than the item `Tr5::provided::{anon_assoc#0}`
+  --> $DIR/private-in-public-warn.rs:97:26
+   |
+LL |         fn provided() -> impl PrivTr<Priv<()>> {}
+   |                          ^^^^^^^^^^^^^^^^^^^^^ opaque type `Tr5::provided::{anon_assoc#0}` is reachable at visibility `pub(crate)`
+   |
+note: but trait `generics::PrivTr<generics::Priv<()>>` is only usable at visibility `pub(self)`
+  --> $DIR/private-in-public-warn.rs:83:5
+   |
+LL |     trait PrivTr<T> {}
+   |     ^^^^^^^^^^^^^^^
+
+error: type `generics::Priv<()>` is more private than the item `Tr5::provided::{anon_assoc#0}`
+  --> $DIR/private-in-public-warn.rs:97:26
+   |
+LL |         fn provided() -> impl PrivTr<Priv<()>> {}
+   |                          ^^^^^^^^^^^^^^^^^^^^^ opaque type `Tr5::provided::{anon_assoc#0}` is reachable at visibility `pub(crate)`
+   |
+note: but type `generics::Priv<()>` is only usable at visibility `pub(self)`
+  --> $DIR/private-in-public-warn.rs:81:5
    |
 LL |     struct Priv<T = u8>(T);
    |     ^^^^^^^^^^^^^^^^^^^
 
 error[E0446]: private type `impls::Priv` in public interface
-  --> $DIR/private-in-public-warn.rs:119:9
+  --> $DIR/private-in-public-warn.rs:128:9
    |
 LL |     struct Priv;
    |     ----------- `impls::Priv` declared as private
@@ -312,43 +420,16 @@ LL |         type Alias = Priv;
    |         ^^^^^^^^^^ can't leak private type
 
 error: type `aliases_pub::Priv` is more private than the item `aliases_pub::<impl Pub2>::f`
-  --> $DIR/private-in-public-warn.rs:190:9
+  --> $DIR/private-in-public-warn.rs:199:9
    |
 LL |         pub fn f(arg: Priv) {}
    |         ^^^^^^^^^^^^^^^^^^^ associated function `aliases_pub::<impl Pub2>::f` is reachable at visibility `pub(crate)`
    |
 note: but type `aliases_pub::Priv` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:163:5
+  --> $DIR/private-in-public-warn.rs:172:5
    |
 LL |     struct Priv;
    |     ^^^^^^^^^^^
-
-error[E0446]: private type `aliases_pub::Priv` in public interface
-  --> $DIR/private-in-public-warn.rs:193:9
-   |
-LL |     struct Priv;
-   |     ----------- `aliases_pub::Priv` declared as private
-...
-LL |         type Check = Priv;
-   |         ^^^^^^^^^^ can't leak private type
-
-error[E0446]: private type `aliases_pub::Priv` in public interface
-  --> $DIR/private-in-public-warn.rs:196:9
-   |
-LL |     struct Priv;
-   |     ----------- `aliases_pub::Priv` declared as private
-...
-LL |         type Check = Priv;
-   |         ^^^^^^^^^^ can't leak private type
-
-error[E0446]: private type `aliases_pub::Priv` in public interface
-  --> $DIR/private-in-public-warn.rs:199:9
-   |
-LL |     struct Priv;
-   |     ----------- `aliases_pub::Priv` declared as private
-...
-LL |         type Check = Priv;
-   |         ^^^^^^^^^^ can't leak private type
 
 error[E0446]: private type `aliases_pub::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:202:9
@@ -359,38 +440,65 @@ LL |     struct Priv;
 LL |         type Check = Priv;
    |         ^^^^^^^^^^ can't leak private type
 
+error[E0446]: private type `aliases_pub::Priv` in public interface
+  --> $DIR/private-in-public-warn.rs:205:9
+   |
+LL |     struct Priv;
+   |     ----------- `aliases_pub::Priv` declared as private
+...
+LL |         type Check = Priv;
+   |         ^^^^^^^^^^ can't leak private type
+
+error[E0446]: private type `aliases_pub::Priv` in public interface
+  --> $DIR/private-in-public-warn.rs:208:9
+   |
+LL |     struct Priv;
+   |     ----------- `aliases_pub::Priv` declared as private
+...
+LL |         type Check = Priv;
+   |         ^^^^^^^^^^ can't leak private type
+
+error[E0446]: private type `aliases_pub::Priv` in public interface
+  --> $DIR/private-in-public-warn.rs:211:9
+   |
+LL |     struct Priv;
+   |     ----------- `aliases_pub::Priv` declared as private
+...
+LL |         type Check = Priv;
+   |         ^^^^^^^^^^ can't leak private type
+
 error: trait `PrivTr1` is more private than the item `aliases_priv::Tr1`
-  --> $DIR/private-in-public-warn.rs:232:5
+  --> $DIR/private-in-public-warn.rs:241:5
    |
 LL |     pub trait Tr1: PrivUseAliasTr {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait `aliases_priv::Tr1` is reachable at visibility `pub(crate)`
    |
 note: but trait `PrivTr1` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:218:5
+  --> $DIR/private-in-public-warn.rs:227:5
    |
 LL |     trait PrivTr1<T = u8> {
    |     ^^^^^^^^^^^^^^^^^^^^^
 
 error: trait `PrivTr1<Priv2>` is more private than the item `aliases_priv::Tr2`
-  --> $DIR/private-in-public-warn.rs:234:5
+  --> $DIR/private-in-public-warn.rs:243:5
    |
 LL |     pub trait Tr2: PrivUseAliasTr<PrivAlias> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait `aliases_priv::Tr2` is reachable at visibility `pub(crate)`
    |
 note: but trait `PrivTr1<Priv2>` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:218:5
+  --> $DIR/private-in-public-warn.rs:227:5
    |
 LL |     trait PrivTr1<T = u8> {
    |     ^^^^^^^^^^^^^^^^^^^^^
 
 error: type `Priv2` is more private than the item `aliases_priv::Tr2`
-  --> $DIR/private-in-public-warn.rs:234:5
+  --> $DIR/private-in-public-warn.rs:243:5
    |
 LL |     pub trait Tr2: PrivUseAliasTr<PrivAlias> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait `aliases_priv::Tr2` is reachable at visibility `pub(crate)`
    |
 note: but type `Priv2` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:216:5
+  --> $DIR/private-in-public-warn.rs:225:5
    |
 LL |     struct Priv2;
    |     ^^^^^^^^^^^^
@@ -410,7 +518,7 @@ LL |     pub type Alias<T: PrivTr> = T;
    = note: `#[warn(type_alias_bounds)]` on by default
 
 warning: where clauses on type aliases are not enforced
-  --> $DIR/private-in-public-warn.rs:63:29
+  --> $DIR/private-in-public-warn.rs:66:29
    |
 LL |     pub type Alias<T> where T: PrivTr = T;
    |                       ------^^^^^^^^^
@@ -422,6 +530,6 @@ LL |     pub type Alias<T> where T: PrivTr = T;
            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics
 
-error: aborting due to 34 previous errors; 2 warnings emitted
+error: aborting due to 43 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0446`.

--- a/tests/ui/privacy/pub-priv-dep/pub-priv1.rs
+++ b/tests/ui/privacy/pub-priv-dep/pub-priv1.rs
@@ -74,8 +74,11 @@ pub trait MyPubTrait {
     //~^ ERROR trait `OtherTrait` from private dependency 'priv_dep' in public interface
 
     fn required_impl_trait() -> impl OtherTrait;
+    //~^ ERROR trait `OtherTrait` from private dependency 'priv_dep' in public interface
 
     fn provided_impl_trait() -> impl OtherTrait { OtherType }
+    //~^ ERROR trait `OtherTrait` from private dependency 'priv_dep' in public interface
+    //~| ERROR trait `OtherTrait` from private dependency 'priv_dep' in public interface
 
     fn required_concrete() -> OtherType;
     //~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface

--- a/tests/ui/privacy/pub-priv-dep/pub-priv1.rs
+++ b/tests/ui/privacy/pub-priv-dep/pub-priv1.rs
@@ -75,6 +75,7 @@ pub trait MyPubTrait {
 
     fn required_impl_trait() -> impl OtherTrait;
     //~^ ERROR trait `OtherTrait` from private dependency 'priv_dep' in public interface
+    //~| ERROR trait `OtherTrait` from private dependency 'priv_dep' in public interface
 
     fn provided_impl_trait() -> impl OtherTrait { OtherType }
     //~^ ERROR trait `OtherTrait` from private dependency 'priv_dep' in public interface

--- a/tests/ui/privacy/pub-priv-dep/pub-priv1.stderr
+++ b/tests/ui/privacy/pub-priv-dep/pub-priv1.stderr
@@ -11,55 +11,55 @@ LL | #![deny(exported_private_dependencies)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: macro `m` from private dependency 'priv_dep' is re-exported
-  --> $DIR/pub-priv1.rs:156:9
+  --> $DIR/pub-priv1.rs:159:9
    |
 LL | pub use priv_dep::m;
    |         ^^^^^^^^^^^
 
 error: macro `fn_like` from private dependency 'pm' is re-exported
-  --> $DIR/pub-priv1.rs:158:9
+  --> $DIR/pub-priv1.rs:161:9
    |
 LL | pub use pm::fn_like;
    |         ^^^^^^^^^^^
 
 error: derive macro `PmDerive` from private dependency 'pm' is re-exported
-  --> $DIR/pub-priv1.rs:160:9
+  --> $DIR/pub-priv1.rs:163:9
    |
 LL | pub use pm::PmDerive;
    |         ^^^^^^^^^^^^
 
 error: attribute macro `pm_attr` from private dependency 'pm' is re-exported
-  --> $DIR/pub-priv1.rs:162:9
+  --> $DIR/pub-priv1.rs:165:9
    |
 LL | pub use pm::pm_attr;
    |         ^^^^^^^^^^^
 
 error: variant `V1` from private dependency 'priv_dep' is re-exported
-  --> $DIR/pub-priv1.rs:165:9
+  --> $DIR/pub-priv1.rs:168:9
    |
 LL | pub use priv_dep::E::V1;
    |         ^^^^^^^^^^^^^^^
 
 error: type alias `Unit` from private dependency 'priv_dep' is re-exported
-  --> $DIR/pub-priv1.rs:168:9
+  --> $DIR/pub-priv1.rs:171:9
    |
 LL | pub use priv_dep::Unit;
    |         ^^^^^^^^^^^^^^
 
 error: type alias `PubPub` from private dependency 'priv_dep' is re-exported
-  --> $DIR/pub-priv1.rs:170:9
+  --> $DIR/pub-priv1.rs:173:9
    |
 LL | pub use priv_dep::PubPub;
    |         ^^^^^^^^^^^^^^^^
 
 error: type alias `PubPriv` from private dependency 'priv_dep' is re-exported
-  --> $DIR/pub-priv1.rs:172:9
+  --> $DIR/pub-priv1.rs:175:9
    |
 LL | pub use priv_dep::PubPriv;
    |         ^^^^^^^^^^^^^^^^^
 
 error: struct `Renamed` from private dependency 'priv_dep' is re-exported
-  --> $DIR/pub-priv1.rs:174:9
+  --> $DIR/pub-priv1.rs:177:9
    |
 LL | pub use priv_dep::OtherType as Renamed;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -124,92 +124,112 @@ error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
 LL |     type Foo: OtherTrait;
    |     ^^^^^^^^^^^^^^^^^^^^
 
+error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:76:33
+   |
+LL |     fn required_impl_trait() -> impl OtherTrait;
+   |                                 ^^^^^^^^^^^^^^^
+
+error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:79:33
+   |
+LL |     fn provided_impl_trait() -> impl OtherTrait { OtherType }
+   |                                 ^^^^^^^^^^^^^^^
+
+error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:79:33
+   |
+LL |     fn provided_impl_trait() -> impl OtherTrait { OtherType }
+   |                                 ^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:80:5
+  --> $DIR/pub-priv1.rs:83:5
    |
 LL |     fn required_concrete() -> OtherType;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:83:5
+  --> $DIR/pub-priv1.rs:86:5
    |
 LL |     fn provided_concrete() -> OtherType { OtherType }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:87:1
+  --> $DIR/pub-priv1.rs:90:1
    |
 LL | pub trait WithSuperTrait: OtherTrait {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:96:5
+  --> $DIR/pub-priv1.rs:99:5
    |
 LL |     type X = OtherType;
    |     ^^^^^^
 
 error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:100:1
+  --> $DIR/pub-priv1.rs:103:1
    |
 LL | pub fn in_bounds<T: OtherTrait>(x: T) { unimplemented!() }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:103:1
+  --> $DIR/pub-priv1.rs:106:1
    |
 LL | pub fn private_return_impl_trait() -> impl OtherTrait { OtherType }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:106:1
+  --> $DIR/pub-priv1.rs:109:1
    |
 LL | pub fn private_return() -> OtherType { OtherType }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:109:1
+  --> $DIR/pub-priv1.rs:112:1
    |
 LL | pub fn private_in_generic() -> std::num::Saturating<OtherType> { unimplemented!() }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:112:1
+  --> $DIR/pub-priv1.rs:115:1
    |
 LL | pub static STATIC: OtherType = OtherType;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:115:1
+  --> $DIR/pub-priv1.rs:118:1
    |
 LL | pub const CONST: OtherType = OtherType;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:118:1
+  --> $DIR/pub-priv1.rs:121:1
    |
 LL | pub type Alias = OtherType;
    | ^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:121:1
+  --> $DIR/pub-priv1.rs:124:1
    |
 LL | pub type AliasOfAlias = priv_dep::PubPub;
    | ^^^^^^^^^^^^^^^^^^^^^
 
 error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:126:1
+  --> $DIR/pub-priv1.rs:129:1
    |
 LL | impl OtherTrait for PublicWithPrivateImpl {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:131:1
+  --> $DIR/pub-priv1.rs:134:1
    |
 LL | impl PubTraitOnPrivate for OtherType {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:131:1
+  --> $DIR/pub-priv1.rs:134:1
    |
 LL | impl PubTraitOnPrivate for OtherType {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -217,25 +237,25 @@ LL | impl PubTraitOnPrivate for OtherType {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:137:1
+  --> $DIR/pub-priv1.rs:140:1
    |
 LL | impl From<OtherType> for PublicWithStdImpl {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:139:5
+  --> $DIR/pub-priv1.rs:142:5
    |
 LL |     fn from(val: OtherType) -> Self { Self }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:143:1
+  --> $DIR/pub-priv1.rs:146:1
    |
 LL | impl From<PublicWithStdImpl> for OtherType {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:143:1
+  --> $DIR/pub-priv1.rs:146:1
    |
 LL | impl From<PublicWithStdImpl> for OtherType {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -243,18 +263,18 @@ LL | impl From<PublicWithStdImpl> for OtherType {
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:146:5
+  --> $DIR/pub-priv1.rs:149:5
    |
 LL |     fn from(val: PublicWithStdImpl) -> Self { Self }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:146:5
+  --> $DIR/pub-priv1.rs:149:5
    |
 LL |     fn from(val: PublicWithStdImpl) -> Self { Self }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 41 previous errors
+error: aborting due to 44 previous errors
 

--- a/tests/ui/privacy/pub-priv-dep/pub-priv1.stderr
+++ b/tests/ui/privacy/pub-priv-dep/pub-priv1.stderr
@@ -11,55 +11,55 @@ LL | #![deny(exported_private_dependencies)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: macro `m` from private dependency 'priv_dep' is re-exported
-  --> $DIR/pub-priv1.rs:159:9
+  --> $DIR/pub-priv1.rs:160:9
    |
 LL | pub use priv_dep::m;
    |         ^^^^^^^^^^^
 
 error: macro `fn_like` from private dependency 'pm' is re-exported
-  --> $DIR/pub-priv1.rs:161:9
+  --> $DIR/pub-priv1.rs:162:9
    |
 LL | pub use pm::fn_like;
    |         ^^^^^^^^^^^
 
 error: derive macro `PmDerive` from private dependency 'pm' is re-exported
-  --> $DIR/pub-priv1.rs:163:9
+  --> $DIR/pub-priv1.rs:164:9
    |
 LL | pub use pm::PmDerive;
    |         ^^^^^^^^^^^^
 
 error: attribute macro `pm_attr` from private dependency 'pm' is re-exported
-  --> $DIR/pub-priv1.rs:165:9
+  --> $DIR/pub-priv1.rs:166:9
    |
 LL | pub use pm::pm_attr;
    |         ^^^^^^^^^^^
 
 error: variant `V1` from private dependency 'priv_dep' is re-exported
-  --> $DIR/pub-priv1.rs:168:9
+  --> $DIR/pub-priv1.rs:169:9
    |
 LL | pub use priv_dep::E::V1;
    |         ^^^^^^^^^^^^^^^
 
 error: type alias `Unit` from private dependency 'priv_dep' is re-exported
-  --> $DIR/pub-priv1.rs:171:9
+  --> $DIR/pub-priv1.rs:172:9
    |
 LL | pub use priv_dep::Unit;
    |         ^^^^^^^^^^^^^^
 
 error: type alias `PubPub` from private dependency 'priv_dep' is re-exported
-  --> $DIR/pub-priv1.rs:173:9
+  --> $DIR/pub-priv1.rs:174:9
    |
 LL | pub use priv_dep::PubPub;
    |         ^^^^^^^^^^^^^^^^
 
 error: type alias `PubPriv` from private dependency 'priv_dep' is re-exported
-  --> $DIR/pub-priv1.rs:175:9
+  --> $DIR/pub-priv1.rs:176:9
    |
 LL | pub use priv_dep::PubPriv;
    |         ^^^^^^^^^^^^^^^^^
 
 error: struct `Renamed` from private dependency 'priv_dep' is re-exported
-  --> $DIR/pub-priv1.rs:177:9
+  --> $DIR/pub-priv1.rs:178:9
    |
 LL | pub use priv_dep::OtherType as Renamed;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -131,13 +131,21 @@ LL |     fn required_impl_trait() -> impl OtherTrait;
    |                                 ^^^^^^^^^^^^^^^
 
 error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:79:33
+  --> $DIR/pub-priv1.rs:76:33
+   |
+LL |     fn required_impl_trait() -> impl OtherTrait;
+   |                                 ^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:80:33
    |
 LL |     fn provided_impl_trait() -> impl OtherTrait { OtherType }
    |                                 ^^^^^^^^^^^^^^^
 
 error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:79:33
+  --> $DIR/pub-priv1.rs:80:33
    |
 LL |     fn provided_impl_trait() -> impl OtherTrait { OtherType }
    |                                 ^^^^^^^^^^^^^^^
@@ -145,91 +153,91 @@ LL |     fn provided_impl_trait() -> impl OtherTrait { OtherType }
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:83:5
+  --> $DIR/pub-priv1.rs:84:5
    |
 LL |     fn required_concrete() -> OtherType;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:86:5
+  --> $DIR/pub-priv1.rs:87:5
    |
 LL |     fn provided_concrete() -> OtherType { OtherType }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:90:1
+  --> $DIR/pub-priv1.rs:91:1
    |
 LL | pub trait WithSuperTrait: OtherTrait {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:99:5
+  --> $DIR/pub-priv1.rs:100:5
    |
 LL |     type X = OtherType;
    |     ^^^^^^
 
 error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:103:1
+  --> $DIR/pub-priv1.rs:104:1
    |
 LL | pub fn in_bounds<T: OtherTrait>(x: T) { unimplemented!() }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:106:1
+  --> $DIR/pub-priv1.rs:107:1
    |
 LL | pub fn private_return_impl_trait() -> impl OtherTrait { OtherType }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:109:1
+  --> $DIR/pub-priv1.rs:110:1
    |
 LL | pub fn private_return() -> OtherType { OtherType }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:112:1
+  --> $DIR/pub-priv1.rs:113:1
    |
 LL | pub fn private_in_generic() -> std::num::Saturating<OtherType> { unimplemented!() }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:115:1
+  --> $DIR/pub-priv1.rs:116:1
    |
 LL | pub static STATIC: OtherType = OtherType;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:118:1
+  --> $DIR/pub-priv1.rs:119:1
    |
 LL | pub const CONST: OtherType = OtherType;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:121:1
+  --> $DIR/pub-priv1.rs:122:1
    |
 LL | pub type Alias = OtherType;
    | ^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:124:1
+  --> $DIR/pub-priv1.rs:125:1
    |
 LL | pub type AliasOfAlias = priv_dep::PubPub;
    | ^^^^^^^^^^^^^^^^^^^^^
 
 error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:129:1
+  --> $DIR/pub-priv1.rs:130:1
    |
 LL | impl OtherTrait for PublicWithPrivateImpl {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:134:1
+  --> $DIR/pub-priv1.rs:135:1
    |
 LL | impl PubTraitOnPrivate for OtherType {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:134:1
+  --> $DIR/pub-priv1.rs:135:1
    |
 LL | impl PubTraitOnPrivate for OtherType {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -237,25 +245,25 @@ LL | impl PubTraitOnPrivate for OtherType {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:140:1
+  --> $DIR/pub-priv1.rs:141:1
    |
 LL | impl From<OtherType> for PublicWithStdImpl {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:142:5
+  --> $DIR/pub-priv1.rs:143:5
    |
 LL |     fn from(val: OtherType) -> Self { Self }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:146:1
+  --> $DIR/pub-priv1.rs:147:1
    |
 LL | impl From<PublicWithStdImpl> for OtherType {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:146:1
+  --> $DIR/pub-priv1.rs:147:1
    |
 LL | impl From<PublicWithStdImpl> for OtherType {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -263,18 +271,18 @@ LL | impl From<PublicWithStdImpl> for OtherType {
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:149:5
+  --> $DIR/pub-priv1.rs:150:5
    |
 LL |     fn from(val: PublicWithStdImpl) -> Self { Self }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:149:5
+  --> $DIR/pub-priv1.rs:150:5
    |
 LL |     fn from(val: PublicWithStdImpl) -> Self { Self }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 44 previous errors
+error: aborting due to 45 previous errors
 


### PR DESCRIPTION
Visit RPITITs and report `private_interfaces`, `private_bounds` and `exported_private_dependencies` in them (these are regular, non-deprecation lints).
New hard errors are not reported, https://github.com/rust-lang/rust/pull/146470 is for hard errors.
So this PR doesn't contain any breakage or language changes.