### PR TITLE
simplify words initialization using Rc::new_zeroed

### DIFF
--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -634,21 +634,11 @@ impl<T: Idx> ChunkedBitSet<T> {
         match *chunk {
             Zeros => {
                 if chunk_domain_size > 1 {
-                    #[cfg(feature = "nightly")]
                     let mut words = {
                         // We take some effort to avoid copying the words.
                         let words = Rc::<[Word; CHUNK_WORDS]>::new_zeroed();
                         // SAFETY: `words` can safely be all zeroes.
                         unsafe { words.assume_init() }
-                    };
-                    #[cfg(not(feature = "nightly"))]
-                    let mut words = {
-                        // FIXME: unconditionally use `Rc::new_zeroed` once it is stable (#129396).
-                        let words = mem::MaybeUninit::<[Word; CHUNK_WORDS]>::zeroed();
-                        // SAFETY: `words` can safely be all zeroes.
-                        let words = unsafe { words.assume_init() };
-                        // Unfortunate possibly-large copy
-                        Rc::new(words)
                     };
                     let words_ref = Rc::get_mut(&mut words).unwrap();
 
@@ -695,21 +685,11 @@ impl<T: Idx> ChunkedBitSet<T> {
             Zeros => false,
             Ones => {
                 if chunk_domain_size > 1 {
-                    #[cfg(feature = "nightly")]
                     let mut words = {
                         // We take some effort to avoid copying the words.
                         let words = Rc::<[Word; CHUNK_WORDS]>::new_zeroed();
                         // SAFETY: `words` can safely be all zeroes.
                         unsafe { words.assume_init() }
-                    };
-                    #[cfg(not(feature = "nightly"))]
-                    let mut words = {
-                        // FIXME: unconditionally use `Rc::new_zeroed` once it is stable (#129396).
-                        let words = mem::MaybeUninit::<[Word; CHUNK_WORDS]>::zeroed();
-                        // SAFETY: `words` can safely be all zeroes.
-                        let words = unsafe { words.assume_init() };
-                        // Unfortunate possibly-large copy
-                        Rc::new(words)
                     };
                     let words_ref = Rc::get_mut(&mut words).unwrap();
 


### PR DESCRIPTION
Now that Rc::new_zeroed is stable, remove the cfg(feature = "nightly") branch and the temporary zeroed array on stable. This avoids copying a potentially large [Word; CHUNK_WORDS] into the Rc.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
