### PR TITLE
Disable `dump-ice-to-disk` on `i686-pc-windows-msvc`

### DIFF
--- a/tests/run-make/dump-ice-to-disk/rmake.rs
+++ b/tests/run-make/dump-ice-to-disk/rmake.rs
@@ -18,13 +18,16 @@
 //! # Test history
 //!
 //! The previous rmake.rs iteration of this test was flaky for unknown reason on
-//! `i686-pc-windows-gnu` *specifically*, so assertion failures in this test was made extremely
-//! verbose to help diagnose why the ICE messages was different. It appears that backtraces on
-//! `i686-pc-windows-gnu` specifically are quite unpredictable in how many backtrace frames are
-//! involved.
+//! `i686-pc-windows-gnu`, so assertion failures in this test was made extremely verbose to help
+//! diagnose why the ICE messages was different. It appears that backtraces on `i686-pc-windows-gnu`
+//! specifically are quite unpredictable in how many backtrace frames are involved.
+//!
+//! Disabled on `i686-pc-windows-msvc` as well, because sometimes the middle portion of the ICE
+//! backtrace becomes `<unknown>`.
 
 //@ ignore-cross-compile (exercising ICE dump on host)
 //@ ignore-i686-pc-windows-gnu (unwind mechanism produces unpredictable backtraces)
+//@ ignore-i686-pc-windows-msvc (sometimes partial backtrace becomes `<unknown>`)
 
 use std::cell::OnceCell;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
Sometimes the middle frames of the ICE backtrace becomes `<unknown>` on `i686-pc-windows-msvc` which then makes this test flaky. Noticed in https://github.com/rust-lang/rust/pull/150925#issuecomment-3754504924.

Originally expanded in rust-lang/rust#142563 to see if it's still flaky for other `*-windows-*` targets, unfortunately the answer is yes for `i686-pc-windows-msvc` as well.

r? @dianqk (or compiler or anyone really)