### PR TITLE
Use `default_field_values` more in `Resolver`

### DIFF
--- a/compiler/rustc_data_structures/src/fx.rs
+++ b/compiler/rustc_data_structures/src/fx.rs
@@ -28,3 +28,18 @@ macro_rules! define_stable_id_collections {
         pub type $entry_name<'a, T> = $crate::fx::IndexEntry<'a, $key, T>;
     };
 }
+
+pub mod default {
+    use super::{FxBuildHasher, FxHashMap, FxHashSet};
+
+    // FIXME: These two functions will become unnecessary after
+    // <https://github.com/rust-lang/rustc-hash/pull/63> lands and we start using the corresponding
+    // `rustc-hash` version. After that we can use `Default::default()` instead.
+    pub const fn fx_hash_map<K, V>() -> FxHashMap<K, V> {
+        FxHashMap::with_hasher(FxBuildHasher)
+    }
+
+    pub const fn fx_hash_set<V>() -> FxHashSet<V> {
+        FxHashSet::with_hasher(FxBuildHasher)
+    }
+}

--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -18,6 +18,8 @@
 #![feature(assert_matches)]
 #![feature(auto_traits)]
 #![feature(cfg_select)]
+#![feature(const_default)]
+#![feature(const_trait_impl)]
 #![feature(core_intrinsics)]
 #![feature(dropck_eyepatch)]
 #![feature(extend_one)]

--- a/compiler/rustc_data_structures/src/unord.rs
+++ b/compiler/rustc_data_structures/src/unord.rs
@@ -8,7 +8,7 @@ use std::hash::Hash;
 use std::iter::{Product, Sum};
 use std::ops::Index;
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use rustc_macros::{Decodable_NoContext, Encodable_NoContext};
 
 use crate::fingerprint::Fingerprint;
@@ -241,10 +241,10 @@ pub struct UnordSet<V: Eq + Hash> {
 
 impl<V: Eq + Hash> UnordCollection for UnordSet<V> {}
 
-impl<V: Eq + Hash> Default for UnordSet<V> {
+impl<V: Eq + Hash> const Default for UnordSet<V> {
     #[inline]
     fn default() -> Self {
-        Self { inner: FxHashSet::default() }
+        Self { inner: FxHashSet::with_hasher(FxBuildHasher) }
     }
 }
 
@@ -438,10 +438,10 @@ pub struct UnordMap<K: Eq + Hash, V> {
 
 impl<K: Eq + Hash, V> UnordCollection for UnordMap<K, V> {}
 
-impl<K: Eq + Hash, V> Default for UnordMap<K, V> {
+impl<K: Eq + Hash, V> const Default for UnordMap<K, V> {
     #[inline]
     fn default() -> Self {
-        Self { inner: FxHashMap::default() }
+        Self { inner: FxHashMap::with_hasher(FxBuildHasher) }
     }
 }
 

--- a/compiler/rustc_hir/src/definitions.rs
+++ b/compiler/rustc_hir/src/definitions.rs
@@ -103,7 +103,7 @@ pub struct DisambiguatorState {
 }
 
 impl DisambiguatorState {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self { next: Default::default() }
     }
 

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1237,7 +1237,7 @@ pub struct Resolver<'ra, 'tcx> {
         CmRefCell<Vec<(Ident, MacroKind, ParentScope<'ra>, Option<Decl<'ra>>, Option<Span>)>>,
     multi_segment_macro_resolutions:
         CmRefCell<Vec<(Vec<Segment>, Span, MacroKind, ParentScope<'ra>, Option<Res>, Namespace)>>,
-    builtin_attrs: Vec<(Ident, ParentScope<'ra>)>,
+    builtin_attrs: Vec<(Ident, ParentScope<'ra>)> = Vec::new(),
     /// `derive(Copy)` marks items they are applied to so they are treated specially later.
     /// Derive macros cannot modify the item themselves and have to store the markers in the global
     /// context, so they attach the markers to derive container IDs using this resolver table.
@@ -1274,7 +1274,7 @@ pub struct Resolver<'ra, 'tcx> {
 
     node_id_to_def_id: NodeMap<Feed<'tcx, LocalDefId>>,
 
-    disambiguator: DisambiguatorState,
+    disambiguator: DisambiguatorState = DisambiguatorState::new(),
 
     /// Indices of unnamed struct or variant fields with unresolved attributes.
     placeholder_field_indices: FxHashMap<NodeId, usize> = default::fx_hash_map(),
@@ -1641,10 +1641,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             unused_macro_rules: Default::default(),
             single_segment_macro_resolutions: Default::default(),
             multi_segment_macro_resolutions: Default::default(),
-            builtin_attrs: Default::default(),
             lint_buffer: LintBuffer::default(),
             node_id_to_def_id,
-            disambiguator: DisambiguatorState::new(),
             invocation_parents,
             trait_impls: Default::default(),
             confused_type_with_std_module: Default::default(),

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -13,6 +13,8 @@
 #![feature(arbitrary_self_types)]
 #![feature(assert_matches)]
 #![feature(box_patterns)]
+#![feature(const_default)]
+#![feature(const_trait_impl)]
 #![feature(control_flow_into_value)]
 #![feature(decl_macro)]
 #![feature(default_field_values)]
@@ -1113,7 +1115,7 @@ pub struct Resolver<'ra, 'tcx> {
     tcx: TyCtxt<'tcx>,
 
     /// Item with a given `LocalDefId` was defined during macro expansion with ID `ExpnId`.
-    expn_that_defined: UnordMap<LocalDefId, ExpnId>,
+    expn_that_defined: UnordMap<LocalDefId, ExpnId> = Default::default(),
 
     graph_root: Module<'ra>,
 
@@ -1124,8 +1126,8 @@ pub struct Resolver<'ra, 'tcx> {
     extern_prelude: FxIndexMap<Macros20NormalizedIdent, ExternPreludeEntry<'ra>>,
 
     /// N.B., this is used only for better diagnostics, not name resolution itself.
-    field_names: LocalDefIdMap<Vec<Ident>>,
-    field_defaults: LocalDefIdMap<Vec<Symbol>>,
+    field_names: LocalDefIdMap<Vec<Ident>> = Default::default(),
+    field_defaults: LocalDefIdMap<Vec<Symbol>> = Default::default(),
 
     /// Span of the privacy modifier in fields of an item `DefId` accessible with dot syntax.
     /// Used for hints during error reporting.
@@ -1155,9 +1157,9 @@ pub struct Resolver<'ra, 'tcx> {
     extra_lifetime_params_map: NodeMap<Vec<(Ident, NodeId, LifetimeRes)>>,
 
     /// `CrateNum` resolutions of `extern crate` items.
-    extern_crate_map: UnordMap<LocalDefId, CrateNum>,
-    module_children: LocalDefIdMap<Vec<ModChild>>,
-    ambig_module_children: LocalDefIdMap<Vec<AmbigModChild>>,
+    extern_crate_map: UnordMap<LocalDefId, CrateNum> = Default::default(),
+    module_children: LocalDefIdMap<Vec<ModChild>> = Default::default(),
+    ambig_module_children: LocalDefIdMap<Vec<AmbigModChild>> = Default::default(),
     trait_map: NodeMap<Vec<TraitCandidate>>,
 
     /// A map from nodes to anonymous modules.
@@ -1264,7 +1266,7 @@ pub struct Resolver<'ra, 'tcx> {
     /// Table for mapping struct IDs into struct constructor IDs,
     /// it's not used during normal resolution, only for better error reporting.
     /// Also includes of list of each fields visibility
-    struct_constructors: LocalDefIdMap<(Res, Visibility<DefId>, Vec<Visibility<DefId>>)>,
+    struct_constructors: LocalDefIdMap<(Res, Visibility<DefId>, Vec<Visibility<DefId>>)> = Default::default(),
 
     lint_buffer: LintBuffer,
 
@@ -1283,8 +1285,8 @@ pub struct Resolver<'ra, 'tcx> {
 
     /// Amount of lifetime parameters for each item in the crate.
     item_generics_num_lifetimes: FxHashMap<LocalDefId, usize> = default::fx_hash_map(),
-    delegation_fn_sigs: LocalDefIdMap<DelegationFnSig>,
-    delegation_infos: LocalDefIdMap<DelegationInfo>,
+    delegation_fn_sigs: LocalDefIdMap<DelegationFnSig> = Default::default(),
+    delegation_infos: LocalDefIdMap<DelegationInfo> = Default::default(),
 
     main_def: Option<MainDefinition> = None,
     trait_impls: FxIndexMap<DefId, Vec<LocalDefId>>,
@@ -1301,7 +1303,7 @@ pub struct Resolver<'ra, 'tcx> {
     effective_visibilities: EffectiveVisibilities,
     doc_link_resolutions: FxIndexMap<LocalDefId, DocLinkResMap>,
     doc_link_traits_in_scope: FxIndexMap<LocalDefId, Vec<DefId>>,
-    all_macro_rules: UnordSet<Symbol>,
+    all_macro_rules: UnordSet<Symbol> = Default::default(),
 
     /// Invocation ids of all glob delegations.
     glob_delegation_invoc_ids: FxHashSet<LocalExpnId> = default::fx_hash_set(),
@@ -1587,8 +1589,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         let mut resolver = Resolver {
             tcx,
 
-            expn_that_defined: Default::default(),
-
             // The outermost module has def ID 0; this is not reflected in the
             // AST.
             graph_root,
@@ -1596,18 +1596,12 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             prelude: None,
             extern_prelude,
 
-            field_names: Default::default(),
-            field_defaults: Default::default(),
-
             pat_span_map: Default::default(),
             partial_res_map: Default::default(),
             import_res_map: Default::default(),
             label_res_map: Default::default(),
             lifetimes_res_map: Default::default(),
             extra_lifetime_params_map: Default::default(),
-            extern_crate_map: Default::default(),
-            module_children: Default::default(),
-            ambig_module_children: Default::default(),
             trait_map: NodeMap::default(),
             empty_module,
             local_modules,
@@ -1651,7 +1645,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             dummy_ext_derive: Arc::new(SyntaxExtension::dummy_derive(edition)),
             non_macro_attr: arenas
                 .alloc_macro(MacroData::new(Arc::new(SyntaxExtension::non_macro_attr(edition)))),
-            struct_constructors: Default::default(),
             unused_macros: Default::default(),
             unused_macro_rules: Default::default(),
             single_segment_macro_resolutions: Default::default(),
@@ -1667,10 +1660,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             effective_visibilities: Default::default(),
             doc_link_resolutions: Default::default(),
             doc_link_traits_in_scope: Default::default(),
-            all_macro_rules: Default::default(),
-            delegation_fn_sigs: Default::default(),
             current_crate_outer_attr_insert_span,
-            delegation_infos: Default::default(),
             ..
         };
 

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1593,7 +1593,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             // AST.
             graph_root,
             assert_speculative: false, // Only set/cleared in Resolver::resolve_imports for now
-            prelude: None,
             extern_prelude,
 
             empty_module,

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -45,7 +45,7 @@ use rustc_ast::{
     self as ast, AngleBracketedArg, CRATE_NODE_ID, Crate, Expr, ExprKind, GenericArg, GenericArgs,
     NodeId, Path, attr,
 };
-use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap, FxIndexSet};
+use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap, FxIndexSet, default};
 use rustc_data_structures::intern::Interned;
 use rustc_data_structures::steal::Steal;
 use rustc_data_structures::sync::{FreezeReadGuard, FreezeWriteGuard};
@@ -1129,7 +1129,7 @@ pub struct Resolver<'ra, 'tcx> {
 
     /// Span of the privacy modifier in fields of an item `DefId` accessible with dot syntax.
     /// Used for hints during error reporting.
-    field_visibility_spans: FxHashMap<DefId, Vec<Span>>,
+    field_visibility_spans: FxHashMap<DefId, Vec<Span>> = default::fx_hash_map(),
 
     /// All imports known to succeed or fail.
     determined_imports: Vec<Import<'ra>> = Vec::new(),
@@ -1146,7 +1146,7 @@ pub struct Resolver<'ra, 'tcx> {
     /// Resolutions for import nodes, which have multiple resolutions in different namespaces.
     import_res_map: NodeMap<PerNS<Option<Res>>>,
     /// An import will be inserted into this map if it has been used.
-    import_use_map: FxHashMap<Import<'ra>, Used>,
+    import_use_map: FxHashMap<Import<'ra>, Used> = default::fx_hash_map(),
     /// Resolutions for labels (node IDs of their corresponding blocks or loops).
     label_res_map: NodeMap<NodeId>,
     /// Resolutions for lifetimes.
@@ -1190,7 +1190,7 @@ pub struct Resolver<'ra, 'tcx> {
     glob_map: FxIndexMap<LocalDefId, FxIndexSet<Symbol>>,
     glob_error: Option<ErrorGuaranteed> = None,
     visibilities_for_hashing: Vec<(LocalDefId, Visibility)> = Vec::new(),
-    used_imports: FxHashSet<NodeId>,
+    used_imports: FxHashSet<NodeId> = default::fx_hash_set(),
     maybe_unused_trait_imports: FxIndexSet<LocalDefId>,
 
     /// Privacy errors are delayed until the end in order to deduplicate them.
@@ -1206,30 +1206,30 @@ pub struct Resolver<'ra, 'tcx> {
     /// When a type is re-exported that has an inaccessible constructor because it has fields that
     /// are inaccessible from the import's scope, we mark that as the type won't be able to be built
     /// through the re-export. We use this information to extend the existing diagnostic.
-    inaccessible_ctor_reexport: FxHashMap<Span, Span>,
+    inaccessible_ctor_reexport: FxHashMap<Span, Span> = default::fx_hash_map(),
 
     arenas: &'ra ResolverArenas<'ra>,
     dummy_decl: Decl<'ra>,
     builtin_type_decls: FxHashMap<Symbol, Decl<'ra>>,
     builtin_attr_decls: FxHashMap<Symbol, Decl<'ra>>,
     registered_tool_decls: FxHashMap<Ident, Decl<'ra>>,
-    macro_names: FxHashSet<Ident>,
-    builtin_macros: FxHashMap<Symbol, SyntaxExtensionKind>,
+    macro_names: FxHashSet<Ident> = default::fx_hash_set(),
+    builtin_macros: FxHashMap<Symbol, SyntaxExtensionKind> = default::fx_hash_map(),
     registered_tools: &'tcx RegisteredTools,
     macro_use_prelude: FxIndexMap<Symbol, Decl<'ra>>,
     /// Eagerly populated map of all local macro definitions.
-    local_macro_map: FxHashMap<LocalDefId, &'ra MacroData>,
+    local_macro_map: FxHashMap<LocalDefId, &'ra MacroData> = default::fx_hash_map(),
     /// Lazily populated cache of macro definitions loaded from external crates.
     extern_macro_map: CacheRefCell<FxHashMap<DefId, &'ra MacroData>>,
     dummy_ext_bang: Arc<SyntaxExtension>,
     dummy_ext_derive: Arc<SyntaxExtension>,
     non_macro_attr: &'ra MacroData,
-    local_macro_def_scopes: FxHashMap<LocalDefId, Module<'ra>>,
-    ast_transform_scopes: FxHashMap<LocalExpnId, Module<'ra>>,
+    local_macro_def_scopes: FxHashMap<LocalDefId, Module<'ra>> = default::fx_hash_map(),
+    ast_transform_scopes: FxHashMap<LocalExpnId, Module<'ra>> = default::fx_hash_map(),
     unused_macros: FxIndexMap<LocalDefId, (NodeId, Ident)>,
     /// A map from the macro to all its potentially unused arms.
     unused_macro_rules: FxIndexMap<NodeId, DenseBitSet<usize>>,
-    proc_macro_stubs: FxHashSet<LocalDefId>,
+    proc_macro_stubs: FxHashSet<LocalDefId> = default::fx_hash_set(),
     /// Traces collected during macro resolution and validated when it's complete.
     single_segment_macro_resolutions:
         CmRefCell<Vec<(Ident, MacroKind, ParentScope<'ra>, Option<Decl<'ra>>, Option<Span>)>>,
@@ -1239,23 +1239,23 @@ pub struct Resolver<'ra, 'tcx> {
     /// `derive(Copy)` marks items they are applied to so they are treated specially later.
     /// Derive macros cannot modify the item themselves and have to store the markers in the global
     /// context, so they attach the markers to derive container IDs using this resolver table.
-    containers_deriving_copy: FxHashSet<LocalExpnId>,
+    containers_deriving_copy: FxHashSet<LocalExpnId> = default::fx_hash_set(),
     /// Parent scopes in which the macros were invoked.
     /// FIXME: `derives` are missing in these parent scopes and need to be taken from elsewhere.
-    invocation_parent_scopes: FxHashMap<LocalExpnId, ParentScope<'ra>>,
+    invocation_parent_scopes: FxHashMap<LocalExpnId, ParentScope<'ra>> = default::fx_hash_map(),
     /// `macro_rules` scopes *produced* by expanding the macro invocations,
     /// include all the `macro_rules` items and other invocations generated by them.
-    output_macro_rules_scopes: FxHashMap<LocalExpnId, MacroRulesScopeRef<'ra>>,
+    output_macro_rules_scopes: FxHashMap<LocalExpnId, MacroRulesScopeRef<'ra>> = default::fx_hash_map(),
     /// `macro_rules` scopes produced by `macro_rules` item definitions.
-    macro_rules_scopes: FxHashMap<LocalDefId, MacroRulesScopeRef<'ra>>,
+    macro_rules_scopes: FxHashMap<LocalDefId, MacroRulesScopeRef<'ra>> = default::fx_hash_map(),
     /// Helper attributes that are in scope for the given expansion.
-    helper_attrs: FxHashMap<LocalExpnId, Vec<(Macros20NormalizedIdent, Decl<'ra>)>>,
+    helper_attrs: FxHashMap<LocalExpnId, Vec<(Macros20NormalizedIdent, Decl<'ra>)>> = default::fx_hash_map(),
     /// Ready or in-progress results of resolving paths inside the `#[derive(...)]` attribute
     /// with the given `ExpnId`.
-    derive_data: FxHashMap<LocalExpnId, DeriveData>,
+    derive_data: FxHashMap<LocalExpnId, DeriveData> = default::fx_hash_map(),
 
     /// Avoid duplicated errors for "name already defined".
-    name_already_seen: FxHashMap<Symbol, Span>,
+    name_already_seen: FxHashMap<Symbol, Span> = default::fx_hash_map(),
 
     potentially_unused_imports: Vec<Import<'ra>> = Vec::new(),
 
@@ -1275,14 +1275,14 @@ pub struct Resolver<'ra, 'tcx> {
     disambiguator: DisambiguatorState,
 
     /// Indices of unnamed struct or variant fields with unresolved attributes.
-    placeholder_field_indices: FxHashMap<NodeId, usize>,
+    placeholder_field_indices: FxHashMap<NodeId, usize> = default::fx_hash_map(),
     /// When collecting definitions from an AST fragment produced by a macro invocation `ExpnId`
     /// we know what parent node that fragment should be attached to thanks to this table,
     /// and how the `impl Trait` fragments were introduced.
     invocation_parents: FxHashMap<LocalExpnId, InvocationParent>,
 
     /// Amount of lifetime parameters for each item in the crate.
-    item_generics_num_lifetimes: FxHashMap<LocalDefId, usize>,
+    item_generics_num_lifetimes: FxHashMap<LocalDefId, usize> = default::fx_hash_map(),
     delegation_fn_sigs: LocalDefIdMap<DelegationFnSig>,
     delegation_infos: LocalDefIdMap<DelegationInfo>,
 
@@ -1293,7 +1293,7 @@ pub struct Resolver<'ra, 'tcx> {
     proc_macros: Vec<LocalDefId> = Vec::new(),
     confused_type_with_std_module: FxIndexMap<Span, Span>,
     /// Whether lifetime elision was successful.
-    lifetime_elision_allowed: FxHashSet<NodeId>,
+    lifetime_elision_allowed: FxHashSet<NodeId> = default::fx_hash_set(),
 
     /// Names of items that were stripped out via cfg with their corresponding cfg meta item.
     stripped_cfg_items: Vec<StrippedCfgItem<NodeId>> = Vec::new(),
@@ -1304,19 +1304,19 @@ pub struct Resolver<'ra, 'tcx> {
     all_macro_rules: UnordSet<Symbol>,
 
     /// Invocation ids of all glob delegations.
-    glob_delegation_invoc_ids: FxHashSet<LocalExpnId>,
+    glob_delegation_invoc_ids: FxHashSet<LocalExpnId> = default::fx_hash_set(),
     /// Analogue of module `unexpanded_invocations` but in trait impls, excluding glob delegations.
     /// Needed because glob delegations wait for all other neighboring macros to expand.
-    impl_unexpanded_invocations: FxHashMap<LocalDefId, FxHashSet<LocalExpnId>>,
+    impl_unexpanded_invocations: FxHashMap<LocalDefId, FxHashSet<LocalExpnId>> = default::fx_hash_map(),
     /// Simplified analogue of module `resolutions` but in trait impls, excluding glob delegations.
     /// Needed because glob delegations exclude explicitly defined names.
-    impl_binding_keys: FxHashMap<LocalDefId, FxHashSet<BindingKey>>,
+    impl_binding_keys: FxHashMap<LocalDefId, FxHashSet<BindingKey>> = default::fx_hash_map(),
 
     /// This is the `Span` where an `extern crate foo;` suggestion would be inserted, if `foo`
     /// could be a crate that wasn't imported. For diagnostics use only.
     current_crate_outer_attr_insert_span: Span,
 
-    mods_with_parse_errors: FxHashSet<DefId>,
+    mods_with_parse_errors: FxHashSet<DefId> = default::fx_hash_set(),
 
     /// Whether `Resolver::register_macros_for_all_crates` has been called once already, as we
     /// don't need to run it more than once.
@@ -1325,7 +1325,7 @@ pub struct Resolver<'ra, 'tcx> {
     // Stores pre-expansion and pre-placeholder-fragment-insertion names for `impl Trait` types
     // that were encountered during resolution. These names are used to generate item names
     // for APITs, so we don't want to leak details of resolution into these names.
-    impl_trait_names: FxHashMap<NodeId, Symbol>,
+    impl_trait_names: FxHashMap<NodeId, Symbol> = default::fx_hash_map(),
 }
 
 /// This provides memory for the rest of the crate. The `'ra` lifetime that is
@@ -1598,12 +1598,10 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
             field_names: Default::default(),
             field_defaults: Default::default(),
-            field_visibility_spans: FxHashMap::default(),
 
             pat_span_map: Default::default(),
             partial_res_map: Default::default(),
             import_res_map: Default::default(),
-            import_use_map: Default::default(),
             label_res_map: Default::default(),
             lifetimes_res_map: Default::default(),
             extra_lifetime_params_map: Default::default(),
@@ -1616,12 +1614,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             local_module_map,
             extern_module_map: Default::default(),
             block_map: Default::default(),
-            ast_transform_scopes: FxHashMap::default(),
 
             glob_map: Default::default(),
-            used_imports: FxHashSet::default(),
             maybe_unused_trait_imports: Default::default(),
-            inaccessible_ctor_reexport: Default::default(),
 
             arenas,
             dummy_decl: arenas.new_pub_def_decl(Res::Err, DUMMY_SP, LocalExpnId::ROOT),
@@ -1649,52 +1644,32 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     (*ident, decl)
                 })
                 .collect(),
-            macro_names: FxHashSet::default(),
-            builtin_macros: Default::default(),
             registered_tools,
             macro_use_prelude: Default::default(),
-            local_macro_map: Default::default(),
             extern_macro_map: Default::default(),
             dummy_ext_bang: Arc::new(SyntaxExtension::dummy_bang(edition)),
             dummy_ext_derive: Arc::new(SyntaxExtension::dummy_derive(edition)),
             non_macro_attr: arenas
                 .alloc_macro(MacroData::new(Arc::new(SyntaxExtension::non_macro_attr(edition)))),
-            invocation_parent_scopes: Default::default(),
-            output_macro_rules_scopes: Default::default(),
-            macro_rules_scopes: Default::default(),
-            helper_attrs: Default::default(),
-            derive_data: Default::default(),
-            local_macro_def_scopes: FxHashMap::default(),
-            name_already_seen: FxHashMap::default(),
             struct_constructors: Default::default(),
             unused_macros: Default::default(),
             unused_macro_rules: Default::default(),
-            proc_macro_stubs: Default::default(),
             single_segment_macro_resolutions: Default::default(),
             multi_segment_macro_resolutions: Default::default(),
             builtin_attrs: Default::default(),
-            containers_deriving_copy: Default::default(),
             lint_buffer: LintBuffer::default(),
             node_id_to_def_id,
             disambiguator: DisambiguatorState::new(),
-            placeholder_field_indices: Default::default(),
             invocation_parents,
-            item_generics_num_lifetimes: Default::default(),
             trait_impls: Default::default(),
             confused_type_with_std_module: Default::default(),
-            lifetime_elision_allowed: Default::default(),
             stripped_cfg_items: Default::default(),
             effective_visibilities: Default::default(),
             doc_link_resolutions: Default::default(),
             doc_link_traits_in_scope: Default::default(),
             all_macro_rules: Default::default(),
             delegation_fn_sigs: Default::default(),
-            glob_delegation_invoc_ids: Default::default(),
-            impl_unexpanded_invocations: Default::default(),
-            impl_binding_keys: Default::default(),
             current_crate_outer_attr_insert_span,
-            mods_with_parse_errors: Default::default(),
-            impl_trait_names: Default::default(),
             delegation_infos: Default::default(),
             ..
         };

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1141,26 +1141,26 @@ pub struct Resolver<'ra, 'tcx> {
 
     // Spans for local variables found during pattern resolution.
     // Used for suggestions during error reporting.
-    pat_span_map: NodeMap<Span>,
+    pat_span_map: NodeMap<Span> = Default::default(),
 
     /// Resolutions for nodes that have a single resolution.
-    partial_res_map: NodeMap<PartialRes>,
+    partial_res_map: NodeMap<PartialRes> = Default::default(),
     /// Resolutions for import nodes, which have multiple resolutions in different namespaces.
-    import_res_map: NodeMap<PerNS<Option<Res>>>,
+    import_res_map: NodeMap<PerNS<Option<Res>>> = Default::default(),
     /// An import will be inserted into this map if it has been used.
     import_use_map: FxHashMap<Import<'ra>, Used> = default::fx_hash_map(),
     /// Resolutions for labels (node IDs of their corresponding blocks or loops).
-    label_res_map: NodeMap<NodeId>,
+    label_res_map: NodeMap<NodeId> = Default::default(),
     /// Resolutions for lifetimes.
-    lifetimes_res_map: NodeMap<LifetimeRes>,
+    lifetimes_res_map: NodeMap<LifetimeRes> = Default::default(),
     /// Lifetime parameters that lowering will have to introduce.
-    extra_lifetime_params_map: NodeMap<Vec<(Ident, NodeId, LifetimeRes)>>,
+    extra_lifetime_params_map: NodeMap<Vec<(Ident, NodeId, LifetimeRes)>> = Default::default(),
 
     /// `CrateNum` resolutions of `extern crate` items.
     extern_crate_map: UnordMap<LocalDefId, CrateNum> = Default::default(),
     module_children: LocalDefIdMap<Vec<ModChild>> = Default::default(),
     ambig_module_children: LocalDefIdMap<Vec<AmbigModChild>> = Default::default(),
-    trait_map: NodeMap<Vec<TraitCandidate>>,
+    trait_map: NodeMap<Vec<TraitCandidate>> = Default::default(),
 
     /// A map from nodes to anonymous modules.
     /// Anonymous modules are pseudo-modules that are implicitly created around items
@@ -1176,7 +1176,7 @@ pub struct Resolver<'ra, 'tcx> {
     ///
     /// There will be an anonymous module created around `g` with the ID of the
     /// entry block for `f`.
-    block_map: NodeMap<Module<'ra>>,
+    block_map: NodeMap<Module<'ra>> = Default::default(),
     /// A fake module that contains no definition and no prelude. Used so that
     /// some AST passes can generate identifiers that only resolve to local or
     /// lang items.
@@ -1596,18 +1596,10 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             prelude: None,
             extern_prelude,
 
-            pat_span_map: Default::default(),
-            partial_res_map: Default::default(),
-            import_res_map: Default::default(),
-            label_res_map: Default::default(),
-            lifetimes_res_map: Default::default(),
-            extra_lifetime_params_map: Default::default(),
-            trait_map: NodeMap::default(),
             empty_module,
             local_modules,
             local_module_map,
             extern_module_map: Default::default(),
-            block_map: Default::default(),
 
             glob_map: Default::default(),
             maybe_unused_trait_imports: Default::default(),


### PR DESCRIPTION
Extend more ways of building `FxHashSet`, `FxHashMap`, `UnordSet`, `UnordMap` and `DisambiguatorState` in `const` contexts to allow for more fields in `Resolver` to have a default value. `FxIndexSet`/`FxIndexMap` are still outstanding and not const-buildable.

r? @petrochenkov 