### PR TITLE
fix: don't suggest .into_iter() for .cloned()/.copied() on owned items

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -70,12 +70,26 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         return Some(projection.to_ty(self.tcx));
     }
 
+    fn is_cloned_on_non_ref_into_iter(&self, ty: Ty<'tcx>, method_name: Symbol) -> bool {
+        // Only care about `.cloned()` / `.copied()`
+        if !matches!(method_name.as_str(), "cloned" | "copied") {
+            return false;
+        }
+
+        // We only want to trigger when the receiver implements IntoIterator
+        // and its Item is NOT a reference.
+        let Some(item_ty) = self.into_iterator_item_ty(ty) else {
+            return false;
+        };
+
+        !item_ty.is_ref()
+    }
+
     fn impl_into_iterator_should_be_iterator(
         &self,
         ty: Ty<'tcx>,
         span: Span,
         unsatisfied_predicates: &UnsatisfiedPredicates<'tcx>,
-        method_name: Symbol,
     ) -> bool {
         fn predicate_bounds_generic_param<'tcx>(
             predicate: ty::Predicate<'_>,
@@ -123,15 +137,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let obligation = Obligation::new(self.tcx, self.misc(span), self.param_env, trait_ref);
         if !self.predicate_must_hold_modulo_regions(&obligation) {
             return false;
-        }
-
-        // Don't suggest .into_iter() for .cloned() or .copied() if the items are not already references.
-        if matches!(method_name.as_str(), "cloned" | "copied") {
-            if let Some(item_ty) = self.into_iterator_item_ty(ty)
-                && !item_ty.is_ref()
-            {
-                return false;
-            }
         }
 
         match *ty.peel_refs().kind() {
@@ -826,12 +831,21 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     "`count` is defined on `{iterator_trait}`, which `{rcvr_ty}` does not implement"
                 ));
             }
-        } else if self.impl_into_iterator_should_be_iterator(
-            rcvr_ty,
-            span,
-            unsatisfied_predicates,
-            item_ident.name,
-        ) {
+        } else if self.is_cloned_on_non_ref_into_iter(rcvr_ty, item_ident.name) {
+            err.note(format!("this is already an `{}`", rcvr_ty));
+
+            if !span.in_external_macro(self.tcx.sess.source_map()) {
+                err.span_suggestion_short(
+                    span,
+                    format!("delete the call to `{}`", item_ident.name),
+                    "",
+                    Applicability::MachineApplicable,
+                );
+            }
+
+            return Err(());
+        } else if self.impl_into_iterator_should_be_iterator(rcvr_ty, span, unsatisfied_predicates)
+        {
             err.span_label(span, format!("`{rcvr_ty}` is not an iterator"));
             if !span.in_external_macro(self.tcx.sess.source_map()) {
                 err.multipart_suggestion_verbose(

--- a/tests/ui/suggestions/into-iter-on-cloned.rs
+++ b/tests/ui/suggestions/into-iter-on-cloned.rs
@@ -1,11 +1,13 @@
 pub fn test_cloned(x: Option<i32>) {
     let _: i32 = x.cloned().unwrap();
-    //~^ ERROR `Option<i32>` is not an iterator
+    //~^ ERROR no method named `cloned`
+    //~| HELP delete the call to `cloned`
 }
 
 pub fn test_copied(x: Option<i32>) {
     let _: i32 = x.copied().unwrap();
-    //~^ ERROR `Option<i32>` is not an iterator
+    //~^ ERROR no method named `copied`
+    //~| HELP delete the call to `copied`
 }
 
 fn main() {}

--- a/tests/ui/suggestions/into-iter-on-cloned.rs
+++ b/tests/ui/suggestions/into-iter-on-cloned.rs
@@ -1,0 +1,11 @@
+pub fn test_cloned(x: Option<i32>) {
+    let _: i32 = x.cloned().unwrap();
+    //~^ ERROR `Option<i32>` is not an iterator
+}
+
+pub fn test_copied(x: Option<i32>) {
+    let _: i32 = x.copied().unwrap();
+    //~^ ERROR `Option<i32>` is not an iterator
+}
+
+fn main() {}

--- a/tests/ui/suggestions/into-iter-on-cloned.stderr
+++ b/tests/ui/suggestions/into-iter-on-cloned.stderr
@@ -1,0 +1,23 @@
+error[E0599]: `Option<i32>` is not an iterator
+  --> $DIR/into-iter-on-cloned.rs:2:20
+   |
+LL |     let _: i32 = x.cloned().unwrap();
+   |                    ^^^^^^ `Option<i32>` is not an iterator
+   |
+   = note: the following trait bounds were not satisfied:
+           `Option<i32>: Iterator`
+           which is required by `&mut Option<i32>: Iterator`
+
+error[E0599]: `Option<i32>` is not an iterator
+  --> $DIR/into-iter-on-cloned.rs:7:20
+   |
+LL |     let _: i32 = x.copied().unwrap();
+   |                    ^^^^^^ `Option<i32>` is not an iterator
+   |
+   = note: the following trait bounds were not satisfied:
+           `Option<i32>: Iterator`
+           which is required by `&mut Option<i32>: Iterator`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0599`.

--- a/tests/ui/suggestions/into-iter-on-cloned.stderr
+++ b/tests/ui/suggestions/into-iter-on-cloned.stderr
@@ -1,22 +1,18 @@
-error[E0599]: `Option<i32>` is not an iterator
+error[E0599]: no method named `cloned` found for enum `Option<i32>` in the current scope
   --> $DIR/into-iter-on-cloned.rs:2:20
    |
 LL |     let _: i32 = x.cloned().unwrap();
-   |                    ^^^^^^ `Option<i32>` is not an iterator
+   |                    ^^^^^^ help: delete the call to `cloned`
    |
-   = note: the following trait bounds were not satisfied:
-           `Option<i32>: Iterator`
-           which is required by `&mut Option<i32>: Iterator`
+   = note: this is already an `Option<i32>`
 
-error[E0599]: `Option<i32>` is not an iterator
-  --> $DIR/into-iter-on-cloned.rs:7:20
+error[E0599]: no method named `copied` found for enum `Option<i32>` in the current scope
+  --> $DIR/into-iter-on-cloned.rs:8:20
    |
 LL |     let _: i32 = x.copied().unwrap();
-   |                    ^^^^^^ `Option<i32>` is not an iterator
+   |                    ^^^^^^ help: delete the call to `copied`
    |
-   = note: the following trait bounds were not satisfied:
-           `Option<i32>: Iterator`
-           which is required by `&mut Option<i32>: Iterator`
+   = note: this is already an `Option<i32>`
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Issue: rust-lang/rust#151147 
Prevents the compiler from suggesting `IntoIterator` when `.cloned()` or `.copied()` is called on a collection that doesn't contain references. This avoids misleading suggestions where the fix would still result in a type error.