### PR TITLE
Add `const Default` impls for `HashSet` and `HashMap` with custom `Hasher`

### DIFF
--- a/library/core/src/hash/mod.rs
+++ b/library/core/src/hash/mod.rs
@@ -784,7 +784,8 @@ impl<H> Clone for BuildHasherDefault<H> {
 }
 
 #[stable(since = "1.7.0", feature = "build_hasher")]
-impl<H> Default for BuildHasherDefault<H> {
+#[rustc_const_unstable(feature = "const_default", issue = "143894")]
+impl<H> const Default for BuildHasherDefault<H> {
     fn default() -> BuildHasherDefault<H> {
         Self::new()
     }

--- a/library/core/src/hash/sip.rs
+++ b/library/core/src/hash/sip.rs
@@ -166,16 +166,18 @@ impl SipHasher13 {
     /// Creates a new `SipHasher13` with the two initial keys set to 0.
     #[inline]
     #[unstable(feature = "hashmap_internals", issue = "none")]
+    #[rustc_const_unstable(feature = "const_default", issue = "143894")]
     #[deprecated(since = "1.13.0", note = "use `std::hash::DefaultHasher` instead")]
-    pub fn new() -> SipHasher13 {
+    pub const fn new() -> SipHasher13 {
         SipHasher13::new_with_keys(0, 0)
     }
 
     /// Creates a `SipHasher13` that is keyed off the provided keys.
     #[inline]
     #[unstable(feature = "hashmap_internals", issue = "none")]
+    #[rustc_const_unstable(feature = "const_default", issue = "143894")]
     #[deprecated(since = "1.13.0", note = "use `std::hash::DefaultHasher` instead")]
-    pub fn new_with_keys(key0: u64, key1: u64) -> SipHasher13 {
+    pub const fn new_with_keys(key0: u64, key1: u64) -> SipHasher13 {
         SipHasher13 { hasher: Hasher::new_with_keys(key0, key1) }
     }
 }
@@ -338,7 +340,8 @@ impl<S: Sip> Clone for Hasher<S> {
     }
 }
 
-impl<S: Sip> Default for Hasher<S> {
+#[rustc_const_unstable(feature = "const_default", issue = "143894")]
+impl<S: Sip> const Default for Hasher<S> {
     /// Creates a `Hasher<S>` with the two initial keys set to 0.
     #[inline]
     fn default() -> Hasher<S> {

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -1444,9 +1444,10 @@ where
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<K, V, S> Default for HashMap<K, V, S>
+#[rustc_const_unstable(feature = "const_default", issue = "143894")]
+impl<K, V, S> const Default for HashMap<K, V, S>
 where
-    S: Default,
+    S: [const] Default,
 {
     /// Creates an empty `HashMap<K, V, S>`, with the `Default` value for the hasher.
     #[inline]

--- a/library/std/src/collections/hash/map/tests.rs
+++ b/library/std/src/collections/hash/map/tests.rs
@@ -1053,4 +1053,7 @@ fn const_with_hasher() {
     assert_eq!(y.len(), 0);
     y.insert((), ());
     assert_eq!(y.len(), 1);
+
+    const Z: HashMap<(), (), BuildHasherDefault<DefaultHasher>> = Default::default();
+    assert_eq!(X, Z);
 }

--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -1236,14 +1236,15 @@ where
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T, S> Default for HashSet<T, S>
+#[rustc_const_unstable(feature = "const_default", issue = "143894")]
+impl<T, S> const Default for HashSet<T, S>
 where
-    S: Default,
+    S: [const] Default,
 {
     /// Creates an empty `HashSet<T, S>` with the `Default` value for the hasher.
     #[inline]
     fn default() -> HashSet<T, S> {
-        HashSet { base: Default::default() }
+        HashSet { base: base::HashSet::with_hasher(Default::default()) }
     }
 }
 

--- a/library/std/src/collections/hash/set/tests.rs
+++ b/library/std/src/collections/hash/set/tests.rs
@@ -504,7 +504,9 @@ fn from_array() {
 #[test]
 fn const_with_hasher() {
     const X: HashSet<(), ()> = HashSet::with_hasher(());
+    const Y: HashSet<(), ()> = Default::default();
     assert_eq!(X.len(), 0);
+    assert_eq!(Y.len(), 0);
 }
 
 #[test]

--- a/library/std/src/hash/random.rs
+++ b/library/std/src/hash/random.rs
@@ -105,14 +105,16 @@ impl DefaultHasher {
     #[stable(feature = "hashmap_default_hasher", since = "1.13.0")]
     #[inline]
     #[allow(deprecated)]
+    #[rustc_const_unstable(feature = "const_default", issue = "143894")]
     #[must_use]
-    pub fn new() -> DefaultHasher {
+    pub const fn new() -> DefaultHasher {
         DefaultHasher(SipHasher13::new_with_keys(0, 0))
     }
 }
 
 #[stable(feature = "hashmap_default_hasher", since = "1.13.0")]
-impl Default for DefaultHasher {
+#[rustc_const_unstable(feature = "const_default", issue = "143894")]
+impl const Default for DefaultHasher {
     /// Creates a new `DefaultHasher` using [`new`].
     /// See its documentation for more.
     ///


### PR DESCRIPTION
Follow up to rust-lang/rust#134628. Tracking issue rust-lang/rust#143894.

r? @fmease

cc @fee1-dead @oli-obk

This doesn't allow for `const H: HashSet<()> = Default::default();`, but would allow for it to work with a custom hasher, which would enable the `Fx*` family to work.