### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -2312,12 +2312,12 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
             tcx: TyCtxt<'hir>,
             issue_span: Span,
             expr_span: Span,
-            body_expr: Option<&'hir hir::Expr<'hir>>,
-            loop_bind: Option<&'hir Ident>,
-            loop_span: Option<Span>,
-            head_span: Option<Span>,
-            pat_span: Option<Span>,
-            head: Option<&'hir hir::Expr<'hir>>,
+            body_expr: Option<&'hir hir::Expr<'hir>> = None,
+            loop_bind: Option<&'hir Ident> = None,
+            loop_span: Option<Span> = None,
+            head_span: Option<Span> = None,
+            pat_span: Option<Span> = None,
+            head: Option<&'hir hir::Expr<'hir>> = None,
         }
         impl<'hir> Visitor<'hir> for ExprFinder<'hir> {
             fn visit_expr(&mut self, ex: &'hir hir::Expr<'hir>) {
@@ -2383,17 +2383,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 hir::intravisit::walk_expr(self, ex);
             }
         }
-        let mut finder = ExprFinder {
-            tcx,
-            expr_span: span,
-            issue_span,
-            loop_bind: None,
-            body_expr: None,
-            head_span: None,
-            loop_span: None,
-            pat_span: None,
-            head: None,
-        };
+        let mut finder = ExprFinder { tcx, expr_span: span, issue_span, .. };
         finder.visit_expr(tcx.hir_body(body_id).value);
 
         if let Some(body_expr) = finder.body_expr
@@ -2628,13 +2618,13 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
 
         struct ExpressionFinder<'tcx> {
             capture_span: Span,
-            closure_change_spans: Vec<Span>,
-            closure_arg_span: Option<Span>,
-            in_closure: bool,
-            suggest_arg: String,
+            closure_change_spans: Vec<Span> = vec![],
+            closure_arg_span: Option<Span> = None,
+            in_closure: bool = false,
+            suggest_arg: String = String::new(),
             tcx: TyCtxt<'tcx>,
-            closure_local_id: Option<hir::HirId>,
-            closure_call_changes: Vec<(Span, String)>,
+            closure_local_id: Option<hir::HirId> = None,
+            closure_call_changes: Vec<(Span, String)> = vec![],
         }
         impl<'hir> Visitor<'hir> for ExpressionFinder<'hir> {
             fn visit_expr(&mut self, e: &'hir hir::Expr<'hir>) {
@@ -2715,16 +2705,8 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         }) = self.infcx.tcx.hir_node(self.mir_hir_id())
             && let hir::Node::Expr(expr) = self.infcx.tcx.hir_node(body_id.hir_id)
         {
-            let mut finder = ExpressionFinder {
-                capture_span: *capture_kind_span,
-                closure_change_spans: vec![],
-                closure_arg_span: None,
-                in_closure: false,
-                suggest_arg: String::new(),
-                closure_local_id: None,
-                closure_call_changes: vec![],
-                tcx: self.infcx.tcx,
-            };
+            let mut finder =
+                ExpressionFinder { capture_span: *capture_kind_span, tcx: self.infcx.tcx, .. };
             finder.visit_expr(expr);
 
             if finder.closure_change_spans.is_empty() || finder.closure_call_changes.is_empty() {

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -4,6 +4,7 @@
 #![allow(internal_features)]
 #![feature(assert_matches)]
 #![feature(box_patterns)]
+#![feature(default_field_values)]
 #![feature(file_buffered)]
 #![feature(if_let_guard)]
 #![feature(negative_impls)]

--- a/compiler/rustc_hir_analysis/src/hir_wf_check.rs
+++ b/compiler/rustc_hir_analysis/src/hir_wf_check.rs
@@ -51,12 +51,12 @@ pub(super) fn diagnostic_hir_wf_check<'tcx>(
     struct HirWfCheck<'tcx> {
         tcx: TyCtxt<'tcx>,
         predicate: ty::Predicate<'tcx>,
-        cause: Option<ObligationCause<'tcx>>,
-        cause_depth: usize,
+        cause: Option<ObligationCause<'tcx>> = None,
+        cause_depth: usize = 0,
         icx: ItemCtxt<'tcx>,
         def_id: LocalDefId,
         param_env: ty::ParamEnv<'tcx>,
-        depth: usize,
+        depth: usize = 0,
     }
 
     impl<'tcx> Visitor<'tcx> for HirWfCheck<'tcx> {
@@ -124,16 +124,8 @@ pub(super) fn diagnostic_hir_wf_check<'tcx>(
         }
     }
 
-    let mut visitor = HirWfCheck {
-        tcx,
-        predicate,
-        cause: None,
-        cause_depth: 0,
-        icx,
-        def_id,
-        param_env: tcx.param_env(def_id.to_def_id()),
-        depth: 0,
-    };
+    let param_env = tcx.param_env(def_id.to_def_id());
+    let mut visitor = HirWfCheck { tcx, predicate, icx, def_id, param_env, .. };
 
     // Get the starting `hir::Ty` using our `WellFormedLoc`.
     // We will walk 'into' this type to try to find

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -59,6 +59,7 @@ This API is completely unstable and subject to change.
 #![allow(rustc::diagnostic_outside_of_impl)]
 #![allow(rustc::untranslatable_diagnostic)]
 #![feature(assert_matches)]
+#![feature(default_field_values)]
 #![feature(gen_blocks)]
 #![feature(if_let_guard)]
 #![feature(iter_intersperse)]

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -1345,11 +1345,7 @@ enum TestKind<'tcx> {
     },
 
     /// Tests the place against a constant using scalar equality.
-    ScalarEq {
-        value: ty::Value<'tcx>,
-        /// Type of the corresponding pattern node.
-        pat_ty: Ty<'tcx>,
-    },
+    ScalarEq { value: ty::Value<'tcx> },
 
     /// Test whether the value falls within an inclusive or exclusive range.
     Range(Arc<PatRange<'tcx>>),

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -1339,11 +1339,9 @@ enum TestKind<'tcx> {
 
     /// Tests the place against a string constant using string equality.
     StringEq {
-        /// Constant `&str` value to test against.
+        /// Constant string value to test against.
+        /// Note that this value has type `str` (not `&str`).
         value: ty::Value<'tcx>,
-        /// Type of the corresponding pattern node. Usually `&str`, but could
-        /// be `str` for patterns like `deref!("..."): String`.
-        pat_ty: Ty<'tcx>,
     },
 
     /// Tests the place against a constant using scalar equality.

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -583,19 +583,13 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
                         fields = vec![];
                         arity = 0;
                     }
-                    ty::Ref(_, t, _) if t.is_str() => {
-                        // We want a `&str` constant to behave like a `Deref` pattern, to be compatible
-                        // with other `Deref` patterns. This could have been done in `const_to_pat`,
-                        // but that causes issues with the rest of the matching code.
-                        // So here, the constructor for a `"foo"` pattern is `&` (represented by
-                        // `Ref`), and has one field. That field has constructor `Str(value)` and no
-                        // subfields.
-                        // Note: `t` is `str`, not `&str`.
-                        let ty = self.reveal_opaque_ty(*t);
-                        let subpattern = DeconstructedPat::new(Str(*value), Vec::new(), 0, ty, pat);
-                        ctor = Ref;
-                        fields = vec![subpattern.at_index(0)];
-                        arity = 1;
+                    ty::Str => {
+                        // For constant/literal patterns of type `&str`, the THIR
+                        // pattern is a `PatKind::Deref` of type `&str` wrapping a
+                        // `PatKind::Const` of type `str`.
+                        ctor = Str(*value);
+                        fields = vec![];
+                        arity = 0;
                     }
                     // All constants that can be structurally matched have already been expanded
                     // into the corresponding `Pat`s by `const_to_pat`. Constants that remain are

--- a/tests/mir-opt/building/match/sort_candidates.constant_eq.SimplifyCfg-initial.after.mir
+++ b/tests/mir-opt/building/match/sort_candidates.constant_eq.SimplifyCfg-initial.after.mir
@@ -7,11 +7,14 @@ fn constant_eq(_1: &str, _2: bool) -> u32 {
     let mut _3: (&str, bool);
     let mut _4: &str;
     let mut _5: bool;
-    let mut _6: &&str;
-    let mut _7: &bool;
-    let mut _8: bool;
-    let mut _9: bool;
+    let mut _6: &str;
+    let mut _7: &&str;
+    let mut _8: &bool;
+    let mut _9: &str;
     let mut _10: bool;
+    let mut _11: &str;
+    let mut _12: bool;
+    let mut _13: bool;
 
     bb0: {
         StorageLive(_3);
@@ -23,7 +26,8 @@ fn constant_eq(_1: &str, _2: bool) -> u32 {
         StorageDead(_5);
         StorageDead(_4);
         PlaceMention(_3);
-        _9 = <str as PartialEq>::eq(copy (_3.0: &str), const "a") -> [return: bb9, unwind: bb19];
+        _11 = &(*(_3.0: &str));
+        _12 = <str as PartialEq>::eq(copy _11, const "a") -> [return: bb9, unwind: bb19];
     }
 
     bb1: {
@@ -43,7 +47,8 @@ fn constant_eq(_1: &str, _2: bool) -> u32 {
     }
 
     bb5: {
-        _8 = <str as PartialEq>::eq(copy (_3.0: &str), const "b") -> [return: bb8, unwind: bb19];
+        _9 = &(*(_3.0: &str));
+        _10 = <str as PartialEq>::eq(copy _9, const "b") -> [return: bb8, unwind: bb19];
     }
 
     bb6: {
@@ -55,11 +60,11 @@ fn constant_eq(_1: &str, _2: bool) -> u32 {
     }
 
     bb8: {
-        switchInt(move _8) -> [0: bb1, otherwise: bb6];
+        switchInt(move _10) -> [0: bb1, otherwise: bb6];
     }
 
     bb9: {
-        switchInt(move _9) -> [0: bb5, otherwise: bb2];
+        switchInt(move _12) -> [0: bb5, otherwise: bb2];
     }
 
     bb10: {
@@ -87,23 +92,25 @@ fn constant_eq(_1: &str, _2: bool) -> u32 {
     }
 
     bb15: {
-        _6 = &fake shallow (_3.0: &str);
-        _7 = &fake shallow (_3.1: bool);
-        StorageLive(_10);
-        _10 = const true;
-        switchInt(move _10) -> [0: bb17, otherwise: bb16];
+        _6 = &fake shallow (*(_3.0: &str));
+        _7 = &fake shallow (_3.0: &str);
+        _8 = &fake shallow (_3.1: bool);
+        StorageLive(_13);
+        _13 = const true;
+        switchInt(move _13) -> [0: bb17, otherwise: bb16];
     }
 
     bb16: {
-        StorageDead(_10);
+        StorageDead(_13);
         FakeRead(ForMatchGuard, _6);
         FakeRead(ForMatchGuard, _7);
+        FakeRead(ForMatchGuard, _8);
         _0 = const 1_u32;
         goto -> bb18;
     }
 
     bb17: {
-        StorageDead(_10);
+        StorageDead(_13);
         falseEdge -> [real: bb3, imaginary: bb5];
     }
 

--- a/tests/run-make/dump-ice-to-disk/rmake.rs
+++ b/tests/run-make/dump-ice-to-disk/rmake.rs
@@ -18,13 +18,16 @@
 //! # Test history
 //!
 //! The previous rmake.rs iteration of this test was flaky for unknown reason on
-//! `i686-pc-windows-gnu` *specifically*, so assertion failures in this test was made extremely
-//! verbose to help diagnose why the ICE messages was different. It appears that backtraces on
-//! `i686-pc-windows-gnu` specifically are quite unpredictable in how many backtrace frames are
-//! involved.
+//! `i686-pc-windows-gnu`, so assertion failures in this test was made extremely verbose to help
+//! diagnose why the ICE messages was different. It appears that backtraces on `i686-pc-windows-gnu`
+//! specifically are quite unpredictable in how many backtrace frames are involved.
+//!
+//! Disabled on `i686-pc-windows-msvc` as well, because sometimes the middle portion of the ICE
+//! backtrace becomes `<unknown>`.
 
 //@ ignore-cross-compile (exercising ICE dump on host)
 //@ ignore-i686-pc-windows-gnu (unwind mechanism produces unpredictable backtraces)
+//@ ignore-i686-pc-windows-msvc (sometimes partial backtrace becomes `<unknown>`)
 
 use std::cell::OnceCell;
 use std::path::{Path, PathBuf};

--- a/tests/ui/thir-print/str-patterns.rs
+++ b/tests/ui/thir-print/str-patterns.rs
@@ -1,0 +1,17 @@
+#![crate_type = "rlib"]
+//@ edition: 2024
+//@ compile-flags: -Zunpretty=thir-flat
+//@ check-pass
+
+// Snapshot test capturing the THIR pattern structure produced by
+// string-literal and string-constant patterns.
+
+pub fn hello_world(x: &str) {
+    match x {
+        "hello" => {}
+        CONSTANT => {}
+        _ => {}
+    }
+}
+
+const CONSTANT: &str = "constant";

--- a/tests/ui/thir-print/str-patterns.stdout
+++ b/tests/ui/thir-print/str-patterns.stdout
@@ -9,18 +9,25 @@ Thir {
                 ty: &'{erased} str,
                 span: $DIR/str-patterns.rs:11:9: 11:16 (#0),
                 extra: None,
-                kind: Constant {
-                    value: Value {
-                        ty: &'{erased} str,
-                        valtree: Branch(
-                            [
-                                104_u8,
-                                101_u8,
-                                108_u8,
-                                108_u8,
-                                111_u8,
-                            ],
-                        ),
+                kind: Deref {
+                    subpattern: Pat {
+                        ty: str,
+                        span: $DIR/str-patterns.rs:11:9: 11:16 (#0),
+                        extra: None,
+                        kind: Constant {
+                            value: Value {
+                                ty: str,
+                                valtree: Branch(
+                                    [
+                                        104_u8,
+                                        101_u8,
+                                        108_u8,
+                                        108_u8,
+                                        111_u8,
+                                    ],
+                                ),
+                            },
+                        },
                     },
                 },
             },
@@ -42,21 +49,28 @@ Thir {
                         ascriptions: [],
                     },
                 ),
-                kind: Constant {
-                    value: Value {
-                        ty: &'{erased} str,
-                        valtree: Branch(
-                            [
-                                99_u8,
-                                111_u8,
-                                110_u8,
-                                115_u8,
-                                116_u8,
-                                97_u8,
-                                110_u8,
-                                116_u8,
-                            ],
-                        ),
+                kind: Deref {
+                    subpattern: Pat {
+                        ty: str,
+                        span: $DIR/str-patterns.rs:12:9: 12:17 (#0),
+                        extra: None,
+                        kind: Constant {
+                            value: Value {
+                                ty: str,
+                                valtree: Branch(
+                                    [
+                                        99_u8,
+                                        111_u8,
+                                        110_u8,
+                                        115_u8,
+                                        116_u8,
+                                        97_u8,
+                                        110_u8,
+                                        116_u8,
+                                    ],
+                                ),
+                            },
+                        },
                     },
                 },
             },

--- a/tests/ui/thir-print/str-patterns.stdout
+++ b/tests/ui/thir-print/str-patterns.stdout
@@ -1,0 +1,310 @@
+DefId(0:3 ~ str_patterns[fc71]::hello_world):
+Thir {
+    body_type: Fn(
+        fn(&'{erased} str),
+    ),
+    arms: [
+        Arm {
+            pattern: Pat {
+                ty: &'{erased} str,
+                span: $DIR/str-patterns.rs:11:9: 11:16 (#0),
+                extra: None,
+                kind: Constant {
+                    value: Value {
+                        ty: &'{erased} str,
+                        valtree: Branch(
+                            [
+                                104_u8,
+                                101_u8,
+                                108_u8,
+                                108_u8,
+                                111_u8,
+                            ],
+                        ),
+                    },
+                },
+            },
+            guard: None,
+            body: e3,
+            hir_id: HirId(DefId(0:3 ~ str_patterns[fc71]::hello_world).9),
+            scope: Node(9),
+            span: $DIR/str-patterns.rs:11:9: 11:22 (#0),
+        },
+        Arm {
+            pattern: Pat {
+                ty: &'{erased} str,
+                span: $DIR/str-patterns.rs:12:9: 12:17 (#0),
+                extra: Some(
+                    PatExtra {
+                        expanded_const: Some(
+                            DefId(0:4 ~ str_patterns[fc71]::CONSTANT),
+                        ),
+                        ascriptions: [],
+                    },
+                ),
+                kind: Constant {
+                    value: Value {
+                        ty: &'{erased} str,
+                        valtree: Branch(
+                            [
+                                99_u8,
+                                111_u8,
+                                110_u8,
+                                115_u8,
+                                116_u8,
+                                97_u8,
+                                110_u8,
+                                116_u8,
+                            ],
+                        ),
+                    },
+                },
+            },
+            guard: None,
+            body: e5,
+            hir_id: HirId(DefId(0:3 ~ str_patterns[fc71]::hello_world).15),
+            scope: Node(15),
+            span: $DIR/str-patterns.rs:12:9: 12:23 (#0),
+        },
+        Arm {
+            pattern: Pat {
+                ty: &'{erased} str,
+                span: $DIR/str-patterns.rs:13:9: 13:10 (#0),
+                extra: None,
+                kind: Wild,
+            },
+            guard: None,
+            body: e7,
+            hir_id: HirId(DefId(0:3 ~ str_patterns[fc71]::hello_world).19),
+            scope: Node(19),
+            span: $DIR/str-patterns.rs:13:9: 13:16 (#0),
+        },
+    ],
+    blocks: [
+        Block {
+            targeted_by_break: false,
+            region_scope: Node(11),
+            span: $DIR/str-patterns.rs:11:20: 11:22 (#0),
+            stmts: [],
+            expr: None,
+            safety_mode: Safe,
+        },
+        Block {
+            targeted_by_break: false,
+            region_scope: Node(17),
+            span: $DIR/str-patterns.rs:12:21: 12:23 (#0),
+            stmts: [],
+            expr: None,
+            safety_mode: Safe,
+        },
+        Block {
+            targeted_by_break: false,
+            region_scope: Node(21),
+            span: $DIR/str-patterns.rs:13:14: 13:16 (#0),
+            stmts: [],
+            expr: None,
+            safety_mode: Safe,
+        },
+        Block {
+            targeted_by_break: false,
+            region_scope: Node(3),
+            span: $DIR/str-patterns.rs:9:29: 15:2 (#0),
+            stmts: [],
+            expr: Some(
+                e9,
+            ),
+            safety_mode: Safe,
+        },
+    ],
+    exprs: [
+        Expr {
+            kind: VarRef {
+                id: LocalVarId(
+                    HirId(DefId(0:3 ~ str_patterns[fc71]::hello_world).2),
+                ),
+            },
+            ty: &'{erased} str,
+            temp_scope_id: 5,
+            span: $DIR/str-patterns.rs:10:11: 10:12 (#0),
+        },
+        Expr {
+            kind: Scope {
+                region_scope: Node(5),
+                hir_id: HirId(DefId(0:3 ~ str_patterns[fc71]::hello_world).5),
+                value: e0,
+            },
+            ty: &'{erased} str,
+            temp_scope_id: 5,
+            span: $DIR/str-patterns.rs:10:11: 10:12 (#0),
+        },
+        Expr {
+            kind: Block {
+                block: b0,
+            },
+            ty: (),
+            temp_scope_id: 10,
+            span: $DIR/str-patterns.rs:11:20: 11:22 (#0),
+        },
+        Expr {
+            kind: Scope {
+                region_scope: Node(10),
+                hir_id: HirId(DefId(0:3 ~ str_patterns[fc71]::hello_world).10),
+                value: e2,
+            },
+            ty: (),
+            temp_scope_id: 10,
+            span: $DIR/str-patterns.rs:11:20: 11:22 (#0),
+        },
+        Expr {
+            kind: Block {
+                block: b1,
+            },
+            ty: (),
+            temp_scope_id: 16,
+            span: $DIR/str-patterns.rs:12:21: 12:23 (#0),
+        },
+        Expr {
+            kind: Scope {
+                region_scope: Node(16),
+                hir_id: HirId(DefId(0:3 ~ str_patterns[fc71]::hello_world).16),
+                value: e4,
+            },
+            ty: (),
+            temp_scope_id: 16,
+            span: $DIR/str-patterns.rs:12:21: 12:23 (#0),
+        },
+        Expr {
+            kind: Block {
+                block: b2,
+            },
+            ty: (),
+            temp_scope_id: 20,
+            span: $DIR/str-patterns.rs:13:14: 13:16 (#0),
+        },
+        Expr {
+            kind: Scope {
+                region_scope: Node(20),
+                hir_id: HirId(DefId(0:3 ~ str_patterns[fc71]::hello_world).20),
+                value: e6,
+            },
+            ty: (),
+            temp_scope_id: 20,
+            span: $DIR/str-patterns.rs:13:14: 13:16 (#0),
+        },
+        Expr {
+            kind: Match {
+                scrutinee: e1,
+                arms: [
+                    a0,
+                    a1,
+                    a2,
+                ],
+                match_source: Normal,
+            },
+            ty: (),
+            temp_scope_id: 4,
+            span: $DIR/str-patterns.rs:10:5: 14:6 (#0),
+        },
+        Expr {
+            kind: Scope {
+                region_scope: Node(4),
+                hir_id: HirId(DefId(0:3 ~ str_patterns[fc71]::hello_world).4),
+                value: e8,
+            },
+            ty: (),
+            temp_scope_id: 4,
+            span: $DIR/str-patterns.rs:10:5: 14:6 (#0),
+        },
+        Expr {
+            kind: Block {
+                block: b3,
+            },
+            ty: (),
+            temp_scope_id: 22,
+            span: $DIR/str-patterns.rs:9:29: 15:2 (#0),
+        },
+        Expr {
+            kind: Scope {
+                region_scope: Node(22),
+                hir_id: HirId(DefId(0:3 ~ str_patterns[fc71]::hello_world).22),
+                value: e10,
+            },
+            ty: (),
+            temp_scope_id: 22,
+            span: $DIR/str-patterns.rs:9:29: 15:2 (#0),
+        },
+    ],
+    stmts: [],
+    params: [
+        Param {
+            pat: Some(
+                Pat {
+                    ty: &'{erased} str,
+                    span: $DIR/str-patterns.rs:9:20: 9:21 (#0),
+                    extra: None,
+                    kind: Binding {
+                        name: "x",
+                        mode: BindingMode(
+                            No,
+                            Not,
+                        ),
+                        var: LocalVarId(
+                            HirId(DefId(0:3 ~ str_patterns[fc71]::hello_world).2),
+                        ),
+                        ty: &'{erased} str,
+                        subpattern: None,
+                        is_primary: true,
+                        is_shorthand: false,
+                    },
+                },
+            ),
+            ty: &'{erased} str,
+            ty_span: Some(
+                $DIR/str-patterns.rs:9:23: 9:27 (#0),
+            ),
+            self_kind: None,
+            hir_id: Some(
+                HirId(DefId(0:3 ~ str_patterns[fc71]::hello_world).1),
+            ),
+        },
+    ],
+}
+
+DefId(0:4 ~ str_patterns[fc71]::CONSTANT):
+Thir {
+    body_type: Const(
+        &'{erased} str,
+    ),
+    arms: [],
+    blocks: [],
+    exprs: [
+        Expr {
+            kind: Literal {
+                lit: Spanned {
+                    node: Str(
+                        "constant",
+                        Cooked,
+                    ),
+                    span: $DIR/str-patterns.rs:17:24: 17:34 (#0),
+                },
+                neg: false,
+            },
+            ty: &'{erased} str,
+            temp_scope_id: 5,
+            span: $DIR/str-patterns.rs:17:24: 17:34 (#0),
+        },
+        Expr {
+            kind: Scope {
+                region_scope: Node(5),
+                hir_id: HirId(DefId(0:4 ~ str_patterns[fc71]::CONSTANT).5),
+                value: e0,
+            },
+            ty: &'{erased} str,
+            temp_scope_id: 5,
+            span: $DIR/str-patterns.rs:17:24: 17:34 (#0),
+        },
+    ],
+    stmts: [],
+    params: [],
+}
+

--- a/tests/ui/traits/associated_type_bound/assoc-type-bounds-with-the-same-name-with-lacking-generic-arg-148121.rs
+++ b/tests/ui/traits/associated_type_bound/assoc-type-bounds-with-the-same-name-with-lacking-generic-arg-148121.rs
@@ -1,0 +1,17 @@
+// A regression test for https://github.com/rust-lang/rust/issues/148121
+
+pub trait Super<X> {
+    type X;
+}
+
+pub trait Zelf<X>: Super<X> {}
+
+pub trait A {}
+
+impl A for dyn Super<X = ()> {}
+//~^ ERROR: trait takes 1 generic argument but 0 generic arguments were supplied
+
+impl A for dyn Zelf<X = ()> {}
+//~^ ERROR: trait takes 1 generic argument but 0 generic arguments were supplied
+
+fn main() {}

--- a/tests/ui/traits/associated_type_bound/assoc-type-bounds-with-the-same-name-with-lacking-generic-arg-148121.stderr
+++ b/tests/ui/traits/associated_type_bound/assoc-type-bounds-with-the-same-name-with-lacking-generic-arg-148121.stderr
@@ -1,0 +1,35 @@
+error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
+  --> $DIR/assoc-type-bounds-with-the-same-name-with-lacking-generic-arg-148121.rs:11:16
+   |
+LL | impl A for dyn Super<X = ()> {}
+   |                ^^^^^ expected 1 generic argument
+   |
+note: trait defined here, with 1 generic parameter: `X`
+  --> $DIR/assoc-type-bounds-with-the-same-name-with-lacking-generic-arg-148121.rs:3:11
+   |
+LL | pub trait Super<X> {
+   |           ^^^^^ -
+help: add missing generic argument
+   |
+LL | impl A for dyn Super<X, X = ()> {}
+   |                      ++
+
+error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
+  --> $DIR/assoc-type-bounds-with-the-same-name-with-lacking-generic-arg-148121.rs:14:16
+   |
+LL | impl A for dyn Zelf<X = ()> {}
+   |                ^^^^ expected 1 generic argument
+   |
+note: trait defined here, with 1 generic parameter: `X`
+  --> $DIR/assoc-type-bounds-with-the-same-name-with-lacking-generic-arg-148121.rs:7:11
+   |
+LL | pub trait Zelf<X>: Super<X> {}
+   |           ^^^^ -
+help: add missing generic argument
+   |
+LL | impl A for dyn Zelf<X, X = ()> {}
+   |                     ++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0107`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#151155 (THIR patterns: Always use type `str` for string-constant-value nodes)
 - rust-lang/rust#151166 (fix: Do not delay E0107 when there exists an assoc ty with the same name)
 - rust-lang/rust#151172 (Use default field values in a few more cases)
 - rust-lang/rust#151185 (Disable `dump-ice-to-disk` on `i686-pc-windows-msvc`)

r? @ghost

<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=151155,151166,151172,151185)
<!-- homu-ignore:end -->

