### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/tests/run-make/dump-ice-to-disk/rmake.rs
+++ b/tests/run-make/dump-ice-to-disk/rmake.rs
@@ -18,13 +18,16 @@
 //! # Test history
 //!
 //! The previous rmake.rs iteration of this test was flaky for unknown reason on
-//! `i686-pc-windows-gnu` *specifically*, so assertion failures in this test was made extremely
-//! verbose to help diagnose why the ICE messages was different. It appears that backtraces on
-//! `i686-pc-windows-gnu` specifically are quite unpredictable in how many backtrace frames are
-//! involved.
+//! `i686-pc-windows-gnu`, so assertion failures in this test was made extremely verbose to help
+//! diagnose why the ICE messages was different. It appears that backtraces on `i686-pc-windows-gnu`
+//! specifically are quite unpredictable in how many backtrace frames are involved.
+//!
+//! Disabled on `i686-pc-windows-msvc` as well, because sometimes the middle portion of the ICE
+//! backtrace becomes `<unknown>`.
 
 //@ ignore-cross-compile (exercising ICE dump on host)
 //@ ignore-i686-pc-windows-gnu (unwind mechanism produces unpredictable backtraces)
+//@ ignore-i686-pc-windows-msvc (sometimes partial backtrace becomes `<unknown>`)
 
 use std::cell::OnceCell;
 use std::path::{Path, PathBuf};

--- a/tests/ui/traits/associated_type_bound/assoc-type-bounds-with-the-same-name-with-lacking-generic-arg-148121.rs
+++ b/tests/ui/traits/associated_type_bound/assoc-type-bounds-with-the-same-name-with-lacking-generic-arg-148121.rs
@@ -1,0 +1,17 @@
+// A regression test for https://github.com/rust-lang/rust/issues/148121
+
+pub trait Super<X> {
+    type X;
+}
+
+pub trait Zelf<X>: Super<X> {}
+
+pub trait A {}
+
+impl A for dyn Super<X = ()> {}
+//~^ ERROR: trait takes 1 generic argument but 0 generic arguments were supplied
+
+impl A for dyn Zelf<X = ()> {}
+//~^ ERROR: trait takes 1 generic argument but 0 generic arguments were supplied
+
+fn main() {}

--- a/tests/ui/traits/associated_type_bound/assoc-type-bounds-with-the-same-name-with-lacking-generic-arg-148121.stderr
+++ b/tests/ui/traits/associated_type_bound/assoc-type-bounds-with-the-same-name-with-lacking-generic-arg-148121.stderr
@@ -1,0 +1,35 @@
+error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
+  --> $DIR/assoc-type-bounds-with-the-same-name-with-lacking-generic-arg-148121.rs:11:16
+   |
+LL | impl A for dyn Super<X = ()> {}
+   |                ^^^^^ expected 1 generic argument
+   |
+note: trait defined here, with 1 generic parameter: `X`
+  --> $DIR/assoc-type-bounds-with-the-same-name-with-lacking-generic-arg-148121.rs:3:11
+   |
+LL | pub trait Super<X> {
+   |           ^^^^^ -
+help: add missing generic argument
+   |
+LL | impl A for dyn Super<X, X = ()> {}
+   |                      ++
+
+error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
+  --> $DIR/assoc-type-bounds-with-the-same-name-with-lacking-generic-arg-148121.rs:14:16
+   |
+LL | impl A for dyn Zelf<X = ()> {}
+   |                ^^^^ expected 1 generic argument
+   |
+note: trait defined here, with 1 generic parameter: `X`
+  --> $DIR/assoc-type-bounds-with-the-same-name-with-lacking-generic-arg-148121.rs:7:11
+   |
+LL | pub trait Zelf<X>: Super<X> {}
+   |           ^^^^ -
+help: add missing generic argument
+   |
+LL | impl A for dyn Zelf<X, X = ()> {}
+   |                     ++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0107`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#151166 (fix: Do not delay E0107 when there exists an assoc ty with the same name)
 - rust-lang/rust#151185 (Disable `dump-ice-to-disk` on `i686-pc-windows-msvc`)

r? @ghost

<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=151166,151185)
<!-- homu-ignore:end -->

