### PR TITLE
Ship LLVM (`rust-dev`) in fast try builds again

### DIFF
--- a/src/tools/opt-dist/src/main.rs
+++ b/src/tools/opt-dist/src/main.rs
@@ -442,11 +442,12 @@ fn main() -> anyhow::Result<()> {
     // Skip components that are not needed for fast try builds to speed them up
     if is_fast_try_build() {
         log::info!("Skipping building of unimportant components for a fast try build");
+        // Note for future onlookers: do not ignore rust-dev here. We need it for try builds when
+        // a PR makes a change to how LLVM is built.
         for target in [
             "rust-docs",
             "rustc-docs",
             "rustc-dev",
-            "rust-dev",
             "rust-docs-json",
             "rust-analyzer",
             "rustc-src",


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/142963 stopped shipping `rust-dev` in fast try builds, which was not actually correct, because if a PR modifies the LLVM submodule, we should provide the prebuilt LLVM for rustc-perf even in a (fast) try build. So why didn't we find out about this earlier? Well, because soon before that PR landed, we started using new bors for try builds, which actually broke bootstrap's git change detection logic, because new bors used a different e-mail address for merge commits.

So the two bugs kind of masked each other out. Recently, we fixed the e-mail address and git change detection with new bors, since it's now also used for auto builds, but that in turn broke fast try builds that modify LLVM (https://github.com/rust-lang/rust/pull/150722#issuecomment-3756545084), because rustc-perf saw that LLVM was modified in the try build, and it (correctly!) tried to download `rust-dev` for the given try build commit, but that was (incorrectly!) missing on CI, due to being skipped.

This PR restored building the `rust-dev` component in fast try builds. In theory, we could use the same git detection logic that bootstrap uses and only do this if LLVM is actually modified in the given commit, but I'd rather do the correct thing here, than introduce additional opportunities for the git detection to desync.