### PR TITLE
remove lcnr from compiler review rotation

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1458,7 +1458,6 @@ compiler = [
     "@jieyouxu",
     "@jdonszelmann",
     "@JonathanBrouwer",
-    "@lcnr",
     "@madsmtm",
     "@mati865",
     "@Nadrieril",


### PR DESCRIPTION
Have been feeling somewhat swamped by review and mentoring work and want to focus my review time on involved type system changes. I am very much available to review specific changes, but don't want to be auto-assigned to general compiler changes.

