### PR TITLE
Add an additional help note to the ambiguity lint error

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -2064,9 +2064,24 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         };
         let (b1_note, b1_help_msgs) = could_refer_to(b1, scope1, "");
         let (b2_note, b2_help_msgs) = could_refer_to(b2, scope2, " also");
+        let help = if kind == AmbiguityKind::GlobVsGlob
+            && b1
+                .parent_module
+                .and_then(|m| m.opt_def_id())
+                .map(|d| !d.is_local())
+                .unwrap_or_default()
+        {
+            Some(&[
+                "consider updating this dependency to resolve this error",
+                "if updating the dependency does not resolve the problem report the problem to the author of the relevant crate",
+            ] as &[_])
+        } else {
+            None
+        };
 
         errors::Ambiguity {
             ident,
+            help,
             kind: kind.descr(),
             b1_note,
             b1_help_msgs,

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -1464,6 +1464,7 @@ pub(crate) struct UnknownDiagnosticAttributeTypoSugg {
 pub(crate) struct Ambiguity {
     pub ident: Ident,
     pub kind: &'static str,
+    pub help: Option<&'static [&'static str]>,
     pub b1_note: Spanned<String>,
     pub b1_help_msgs: Vec<String>,
     pub b2_note: Spanned<String>,
@@ -1476,6 +1477,11 @@ impl Ambiguity {
         diag.span_label(self.ident.span, "ambiguous name");
         diag.note(format!("ambiguous because of {}", self.kind));
         diag.span_note(self.b1_note.span, self.b1_note.node);
+        if let Some(help) = self.help {
+            for help in help {
+                diag.help(*help);
+            }
+        }
         for help_msg in self.b1_help_msgs {
             diag.help(help_msg);
         }

--- a/tests/ui/imports/ambiguous-2.stderr
+++ b/tests/ui/imports/ambiguous-2.stderr
@@ -12,6 +12,8 @@ note: `id` could refer to the function defined here
    |
 LL |     pub use self::evp::*;
    |             ^^^^^^^^^
+   = help: consider updating this dependency to resolve this error
+   = help: if updating the dependency does not resolve the problem report the problem to the author of the relevant crate
 note: `id` could also refer to the function defined here
   --> $DIR/auxiliary/../ambiguous-1.rs:15:13
    |
@@ -36,6 +38,8 @@ note: `id` could refer to the function defined here
    |
 LL |     pub use self::evp::*;
    |             ^^^^^^^^^
+   = help: consider updating this dependency to resolve this error
+   = help: if updating the dependency does not resolve the problem report the problem to the author of the relevant crate
 note: `id` could also refer to the function defined here
   --> $DIR/auxiliary/../ambiguous-1.rs:15:13
    |

--- a/tests/ui/imports/ambiguous-4.stderr
+++ b/tests/ui/imports/ambiguous-4.stderr
@@ -12,6 +12,8 @@ note: `id` could refer to the function defined here
    |
 LL | pub use evp::*;
    |         ^^^
+   = help: consider updating this dependency to resolve this error
+   = help: if updating the dependency does not resolve the problem report the problem to the author of the relevant crate
 note: `id` could also refer to the function defined here
   --> $DIR/auxiliary/../ambiguous-4-extern.rs:14:9
    |
@@ -36,6 +38,8 @@ note: `id` could refer to the function defined here
    |
 LL | pub use evp::*;
    |         ^^^
+   = help: consider updating this dependency to resolve this error
+   = help: if updating the dependency does not resolve the problem report the problem to the author of the relevant crate
 note: `id` could also refer to the function defined here
   --> $DIR/auxiliary/../ambiguous-4-extern.rs:14:9
    |

--- a/tests/ui/imports/glob-conflict-cross-crate-1.stderr
+++ b/tests/ui/imports/glob-conflict-cross-crate-1.stderr
@@ -12,6 +12,8 @@ note: `f` could refer to the function defined here
    |
 LL | pub use m1::*;
    |         ^^
+   = help: consider updating this dependency to resolve this error
+   = help: if updating the dependency does not resolve the problem report the problem to the author of the relevant crate
 note: `f` could also refer to the function defined here
   --> $DIR/auxiliary/glob-conflict.rs:13:9
    |
@@ -33,6 +35,8 @@ note: `f` could refer to the function defined here
    |
 LL | pub use m1::*;
    |         ^^
+   = help: consider updating this dependency to resolve this error
+   = help: if updating the dependency does not resolve the problem report the problem to the author of the relevant crate
 note: `f` could also refer to the function defined here
   --> $DIR/auxiliary/glob-conflict.rs:13:9
    |
@@ -56,6 +60,8 @@ note: `f` could refer to the function defined here
    |
 LL | pub use m1::*;
    |         ^^
+   = help: consider updating this dependency to resolve this error
+   = help: if updating the dependency does not resolve the problem report the problem to the author of the relevant crate
 note: `f` could also refer to the function defined here
   --> $DIR/auxiliary/glob-conflict.rs:13:9
    |
@@ -78,6 +84,8 @@ note: `f` could refer to the function defined here
    |
 LL | pub use m1::*;
    |         ^^
+   = help: consider updating this dependency to resolve this error
+   = help: if updating the dependency does not resolve the problem report the problem to the author of the relevant crate
 note: `f` could also refer to the function defined here
   --> $DIR/auxiliary/glob-conflict.rs:13:9
    |

--- a/tests/ui/imports/glob-conflict-cross-crate-2.stderr
+++ b/tests/ui/imports/glob-conflict-cross-crate-2.stderr
@@ -12,6 +12,8 @@ note: `C` could refer to the type alias defined here
    |
 LL | pub use a::*;
    |         ^
+   = help: consider updating this dependency to resolve this error
+   = help: if updating the dependency does not resolve the problem report the problem to the author of the relevant crate
 note: `C` could also refer to the type alias defined here
   --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:10:9
    |
@@ -36,6 +38,8 @@ note: `C` could refer to the type alias defined here
    |
 LL | pub use a::*;
    |         ^
+   = help: consider updating this dependency to resolve this error
+   = help: if updating the dependency does not resolve the problem report the problem to the author of the relevant crate
 note: `C` could also refer to the type alias defined here
   --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:10:9
    |

--- a/tests/ui/imports/glob-conflict-cross-crate-3.stderr
+++ b/tests/ui/imports/glob-conflict-cross-crate-3.stderr
@@ -12,6 +12,8 @@ note: `C` could refer to the type alias defined here
    |
 LL | pub use a::*;
    |         ^
+   = help: consider updating this dependency to resolve this error
+   = help: if updating the dependency does not resolve the problem report the problem to the author of the relevant crate
 note: `C` could also refer to the type alias defined here
   --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:10:9
    |
@@ -58,6 +60,8 @@ note: `C` could refer to the type alias defined here
    |
 LL | pub use a::*;
    |         ^
+   = help: consider updating this dependency to resolve this error
+   = help: if updating the dependency does not resolve the problem report the problem to the author of the relevant crate
 note: `C` could also refer to the type alias defined here
   --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:10:9
    |

--- a/tests/ui/imports/issue-114682-2.stderr
+++ b/tests/ui/imports/issue-114682-2.stderr
@@ -12,6 +12,8 @@ note: `max` could refer to the type alias defined here
    |
 LL | pub use self::e::*;
    |         ^^^^^^^
+   = help: consider updating this dependency to resolve this error
+   = help: if updating the dependency does not resolve the problem report the problem to the author of the relevant crate
 note: `max` could also refer to the module defined here
   --> $DIR/auxiliary/issue-114682-2-extern.rs:16:9
    |
@@ -33,6 +35,8 @@ note: `max` could refer to the type alias defined here
    |
 LL | pub use self::e::*;
    |         ^^^^^^^
+   = help: consider updating this dependency to resolve this error
+   = help: if updating the dependency does not resolve the problem report the problem to the author of the relevant crate
 note: `max` could also refer to the module defined here
   --> $DIR/auxiliary/issue-114682-2-extern.rs:16:9
    |
@@ -56,6 +60,8 @@ note: `max` could refer to the type alias defined here
    |
 LL | pub use self::e::*;
    |         ^^^^^^^
+   = help: consider updating this dependency to resolve this error
+   = help: if updating the dependency does not resolve the problem report the problem to the author of the relevant crate
 note: `max` could also refer to the module defined here
   --> $DIR/auxiliary/issue-114682-2-extern.rs:16:9
    |
@@ -78,6 +84,8 @@ note: `max` could refer to the type alias defined here
    |
 LL | pub use self::e::*;
    |         ^^^^^^^
+   = help: consider updating this dependency to resolve this error
+   = help: if updating the dependency does not resolve the problem report the problem to the author of the relevant crate
 note: `max` could also refer to the module defined here
   --> $DIR/auxiliary/issue-114682-2-extern.rs:16:9
    |

--- a/tests/ui/imports/issue-114682-4.stderr
+++ b/tests/ui/imports/issue-114682-4.stderr
@@ -12,6 +12,8 @@ note: `Result` could refer to the type alias defined here
    |
 LL | pub use a::*;
    |         ^
+   = help: consider updating this dependency to resolve this error
+   = help: if updating the dependency does not resolve the problem report the problem to the author of the relevant crate
 note: `Result` could also refer to the type alias defined here
   --> $DIR/auxiliary/issue-114682-4-extern.rs:10:9
    |
@@ -51,6 +53,8 @@ note: `Result` could refer to the type alias defined here
    |
 LL | pub use a::*;
    |         ^
+   = help: consider updating this dependency to resolve this error
+   = help: if updating the dependency does not resolve the problem report the problem to the author of the relevant crate
 note: `Result` could also refer to the type alias defined here
   --> $DIR/auxiliary/issue-114682-4-extern.rs:10:9
    |

--- a/tests/ui/imports/issue-114682-5.stderr
+++ b/tests/ui/imports/issue-114682-5.stderr
@@ -40,6 +40,8 @@ note: `issue_114682_5_extern_1` could refer to the module defined here
    |
 LL |     pub use crate::types::*;
    |             ^^^^^^^^^^^^
+   = help: consider updating this dependency to resolve this error
+   = help: if updating the dependency does not resolve the problem report the problem to the author of the relevant crate
 note: `issue_114682_5_extern_1` could also refer to the crate defined here
   --> $DIR/auxiliary/issue-114682-5-extern-2.rs:7:13
    |
@@ -67,6 +69,8 @@ note: `issue_114682_5_extern_1` could refer to the module defined here
    |
 LL |     pub use crate::types::*;
    |             ^^^^^^^^^^^^
+   = help: consider updating this dependency to resolve this error
+   = help: if updating the dependency does not resolve the problem report the problem to the author of the relevant crate
 note: `issue_114682_5_extern_1` could also refer to the crate defined here
   --> $DIR/auxiliary/issue-114682-5-extern-2.rs:7:13
    |

--- a/tests/ui/imports/issue-114682-6.stderr
+++ b/tests/ui/imports/issue-114682-6.stderr
@@ -12,6 +12,8 @@ note: `log` could refer to the function defined here
    |
 LL | pub use self::a::*;
    |         ^^^^^^^
+   = help: consider updating this dependency to resolve this error
+   = help: if updating the dependency does not resolve the problem report the problem to the author of the relevant crate
 note: `log` could also refer to the function defined here
   --> $DIR/auxiliary/issue-114682-6-extern.rs:9:9
    |
@@ -36,6 +38,8 @@ note: `log` could refer to the function defined here
    |
 LL | pub use self::a::*;
    |         ^^^^^^^
+   = help: consider updating this dependency to resolve this error
+   = help: if updating the dependency does not resolve the problem report the problem to the author of the relevant crate
 note: `log` could also refer to the function defined here
   --> $DIR/auxiliary/issue-114682-6-extern.rs:9:9
    |


### PR DESCRIPTION
This PR adds an additional help note to the ambiguity lint error output to ask users updating their dependencies. This hopefully helps with cases like rust-lang/rust#149845 where newer crate versions are fixed.

r? @petrochenkov 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
