### PR TITLE
Revert `QueryStackFrame` split

### DIFF
--- a/compiler/rustc_macros/src/query.rs
+++ b/compiler/rustc_macros/src/query.rs
@@ -93,7 +93,7 @@ struct QueryModifiers {
     cache: Option<(Option<Pat>, Block)>,
 
     /// A cycle error for this query aborting the compilation with a fatal error.
-    fatal_cycle: Option<Ident>,
+    cycle_fatal: Option<Ident>,
 
     /// A cycle error results in a delay_bug call
     cycle_delay_bug: Option<Ident>,
@@ -136,7 +136,7 @@ fn parse_query_modifiers(input: ParseStream<'_>) -> Result<QueryModifiers> {
     let mut arena_cache = None;
     let mut cache = None;
     let mut desc = None;
-    let mut fatal_cycle = None;
+    let mut cycle_fatal = None;
     let mut cycle_delay_bug = None;
     let mut cycle_stash = None;
     let mut no_hash = None;
@@ -189,8 +189,8 @@ fn parse_query_modifiers(input: ParseStream<'_>) -> Result<QueryModifiers> {
             try_insert!(cache = (args, block));
         } else if modifier == "arena_cache" {
             try_insert!(arena_cache = modifier);
-        } else if modifier == "fatal_cycle" {
-            try_insert!(fatal_cycle = modifier);
+        } else if modifier == "cycle_fatal" {
+            try_insert!(cycle_fatal = modifier);
         } else if modifier == "cycle_delay_bug" {
             try_insert!(cycle_delay_bug = modifier);
         } else if modifier == "cycle_stash" {
@@ -220,7 +220,7 @@ fn parse_query_modifiers(input: ParseStream<'_>) -> Result<QueryModifiers> {
         arena_cache,
         cache,
         desc,
-        fatal_cycle,
+        cycle_fatal,
         cycle_delay_bug,
         cycle_stash,
         no_hash,
@@ -366,8 +366,8 @@ pub(super) fn rustc_queries(input: TokenStream) -> TokenStream {
         }
 
         passthrough!(
-            fatal_cycle,
             arena_cache,
+            cycle_fatal,
             cycle_delay_bug,
             cycle_stash,
             no_hash,

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -28,7 +28,7 @@
 //! - `desc { ... }`: Sets the human-readable description for diagnostics and profiling. Required for every query.
 //! - `arena_cache`: Use an arena for in-memory caching of the query result.
 //! - `cache_on_disk_if { ... }`: Cache the query result to disk if the provided block evaluates to true.
-//! - `fatal_cycle`: If a dependency cycle is detected, abort compilation with a fatal error.
+//! - `cycle_fatal`: If a dependency cycle is detected, abort compilation with a fatal error.
 //! - `cycle_delay_bug`: If a dependency cycle is detected, emit a delayed bug instead of aborting immediately.
 //! - `cycle_stash`: If a dependency cycle is detected, stash the error for later handling.
 //! - `no_hash`: Do not hash the query result for incremental compilation; just mark as dirty if recomputed.
@@ -160,7 +160,7 @@ pub mod plumbing;
 // The result type of each query must implement `Clone`, and additionally
 // `ty::query::values::Value`, which produces an appropriate placeholder
 // (error) value if the query resulted in a query cycle.
-// Queries marked with `fatal_cycle` do not need the latter implementation,
+// Queries marked with `cycle_fatal` do not need the latter implementation,
 // as they will raise an fatal error on query cycles instead.
 rustc_queries! {
     /// This exists purely for testing the interactions between delayed bugs and incremental.
@@ -584,7 +584,7 @@ rustc_queries! {
     }
 
     query is_panic_runtime(_: CrateNum) -> bool {
-        fatal_cycle
+        cycle_fatal
         desc { "checking if the crate is_panic_runtime" }
         separate_provide_extern
     }
@@ -1315,7 +1315,7 @@ rustc_queries! {
     /// Return the set of (transitive) callees that may result in a recursive call to `key`,
     /// if we were able to walk all callees.
     query mir_callgraph_cyclic(key: LocalDefId) -> &'tcx Option<UnordSet<LocalDefId>> {
-        fatal_cycle
+        cycle_fatal
         arena_cache
         desc { |tcx|
             "computing (transitive) callees of `{}` that may recurse",
@@ -1326,7 +1326,7 @@ rustc_queries! {
 
     /// Obtain all the calls into other local functions
     query mir_inliner_callees(key: ty::InstanceKind<'tcx>) -> &'tcx [(DefId, GenericArgsRef<'tcx>)] {
-        fatal_cycle
+        cycle_fatal
         desc { |tcx|
             "computing all local function calls in `{}`",
             tcx.def_path_str(key.def_id()),
@@ -1822,31 +1822,31 @@ rustc_queries! {
     }
 
     query is_compiler_builtins(_: CrateNum) -> bool {
-        fatal_cycle
+        cycle_fatal
         desc { "checking if the crate is_compiler_builtins" }
         separate_provide_extern
     }
     query has_global_allocator(_: CrateNum) -> bool {
         // This query depends on untracked global state in CStore
         eval_always
-        fatal_cycle
+        cycle_fatal
         desc { "checking if the crate has_global_allocator" }
         separate_provide_extern
     }
     query has_alloc_error_handler(_: CrateNum) -> bool {
         // This query depends on untracked global state in CStore
         eval_always
-        fatal_cycle
+        cycle_fatal
         desc { "checking if the crate has_alloc_error_handler" }
         separate_provide_extern
     }
     query has_panic_handler(_: CrateNum) -> bool {
-        fatal_cycle
+        cycle_fatal
         desc { "checking if the crate has_panic_handler" }
         separate_provide_extern
     }
     query is_profiler_runtime(_: CrateNum) -> bool {
-        fatal_cycle
+        cycle_fatal
         desc { "checking if a crate is `#![profiler_runtime]`" }
         separate_provide_extern
     }
@@ -1855,22 +1855,22 @@ rustc_queries! {
         cache_on_disk_if { true }
     }
     query required_panic_strategy(_: CrateNum) -> Option<PanicStrategy> {
-        fatal_cycle
+        cycle_fatal
         desc { "getting a crate's required panic strategy" }
         separate_provide_extern
     }
     query panic_in_drop_strategy(_: CrateNum) -> PanicStrategy {
-        fatal_cycle
+        cycle_fatal
         desc { "getting a crate's configured panic-in-drop strategy" }
         separate_provide_extern
     }
     query is_no_builtins(_: CrateNum) -> bool {
-        fatal_cycle
+        cycle_fatal
         desc { "getting whether a crate has `#![no_builtins]`" }
         separate_provide_extern
     }
     query symbol_mangling_version(_: CrateNum) -> SymbolManglingVersion {
-        fatal_cycle
+        cycle_fatal
         desc { "getting a crate's symbol mangling version" }
         separate_provide_extern
     }

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -87,7 +87,7 @@ use rustc_index::IndexVec;
 use rustc_lint_defs::LintId;
 use rustc_macros::rustc_queries;
 use rustc_query_system::ich::StableHashingContext;
-use rustc_query_system::query::{QueryMode, QueryStackDeferred, QueryState};
+use rustc_query_system::query::{QueryMode, QueryState};
 use rustc_session::Limits;
 use rustc_session::config::{EntryFnType, OptLevel, OutputFilenames, SymbolManglingVersion};
 use rustc_session::cstore::{

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -532,7 +532,7 @@ macro_rules! define_feedable {
 // The result type of each query must implement `Clone`, and additionally
 // `ty::query::values::Value`, which produces an appropriate placeholder
 // (error) value if the query resulted in a query cycle.
-// Queries marked with `fatal_cycle` do not need the latter implementation,
+// Queries marked with `cycle_fatal` do not need the latter implementation,
 // as they will raise an fatal error on query cycles instead.
 
 mod sealed {

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -431,7 +431,7 @@ macro_rules! define_callbacks {
         #[derive(Default)]
         pub struct QueryStates<'tcx> {
             $(
-                pub $name: QueryState<$($K)*, QueryStackDeferred<'tcx>>,
+                pub $name: QueryState<$($K)*>,
             )*
         }
 

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -278,7 +278,7 @@ macro_rules! define_callbacks {
                     ($V)
                 );
 
-                /// This function takes `ProvidedValue` and coverts it to an erased `Value` by
+                /// This function takes `ProvidedValue` and converts it to an erased `Value` by
                 /// allocating it on an arena if the query has the `arena_cache` modifier. The
                 /// value is then erased and returned. This will happen when computing the query
                 /// using a provider or decoding a stored result.

--- a/compiler/rustc_middle/src/values.rs
+++ b/compiler/rustc_middle/src/values.rs
@@ -88,7 +88,7 @@ impl<'tcx> Value<TyCtxt<'tcx>> for Representability {
             if info.query.dep_kind == dep_kinds::representability
                 && let Some(field_id) = info.query.def_id
                 && let Some(field_id) = field_id.as_local()
-                && let Some(DefKind::Field) = info.query.info.def_kind
+                && let Some(DefKind::Field) = info.query.def_kind
             {
                 let parent_id = tcx.parent(field_id.to_def_id());
                 let item_id = match tcx.def_kind(parent_id) {
@@ -224,7 +224,7 @@ impl<'tcx, T> Value<TyCtxt<'tcx>> for Result<T, &'_ ty::layout::LayoutError<'_>>
                             continue;
                         };
                         let frame_span =
-                            frame.query.info.default_span(cycle[(i + 1) % cycle.len()].span);
+                            frame.query.default_span(cycle[(i + 1) % cycle.len()].span);
                         if frame_span.is_dummy() {
                             continue;
                         }

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -21,8 +21,8 @@ use rustc_middle::ty::TyCtxt;
 use rustc_query_system::dep_graph::SerializedDepNodeIndex;
 use rustc_query_system::ich::StableHashingContext;
 use rustc_query_system::query::{
-    CycleError, HashResult, QueryCache, QueryConfig, QueryMap, QueryMode, QueryStackDeferred,
-    QueryState, get_query_incr, get_query_non_incr,
+    CycleError, HashResult, QueryCache, QueryConfig, QueryMap, QueryMode, QueryState,
+    get_query_incr, get_query_non_incr,
 };
 use rustc_query_system::{HandleCycleError, Value};
 use rustc_span::{ErrorGuaranteed, Span};
@@ -79,10 +79,7 @@ where
     }
 
     #[inline(always)]
-    fn query_state<'a>(
-        self,
-        qcx: QueryCtxt<'tcx>,
-    ) -> &'a QueryState<Self::Key, QueryStackDeferred<'tcx>>
+    fn query_state<'a>(self, qcx: QueryCtxt<'tcx>) -> &'a QueryState<Self::Key>
     where
         QueryCtxt<'tcx>: 'a,
     {
@@ -91,7 +88,7 @@ where
         unsafe {
             &*(&qcx.tcx.query_system.states as *const QueryStates<'tcx>)
                 .byte_add(self.dynamic.query_state)
-                .cast::<QueryState<Self::Key, QueryStackDeferred<'tcx>>>()
+                .cast::<QueryState<Self::Key>>()
         }
     }
 

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -6,7 +6,6 @@ use std::num::NonZero;
 
 use rustc_data_structures::jobserver::Proxy;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
-use rustc_data_structures::sync::{DynSend, DynSync};
 use rustc_data_structures::unord::UnordMap;
 use rustc_hashes::Hash64;
 use rustc_hir::limit::Limit;
@@ -27,8 +26,8 @@ use rustc_middle::ty::{self, TyCtxt};
 use rustc_query_system::dep_graph::{DepNodeParams, HasDepContext};
 use rustc_query_system::ich::StableHashingContext;
 use rustc_query_system::query::{
-    QueryCache, QueryConfig, QueryContext, QueryJobId, QueryMap, QuerySideEffect,
-    QueryStackDeferred, QueryStackFrame, QueryStackFrameExtra, force_query,
+    QueryCache, QueryConfig, QueryContext, QueryJobId, QueryMap, QuerySideEffect, QueryStackFrame,
+    force_query,
 };
 use rustc_query_system::{QueryOverflow, QueryOverflowNote};
 use rustc_serialize::{Decodable, Encodable};
@@ -67,9 +66,7 @@ impl<'tcx> HasDepContext for QueryCtxt<'tcx> {
     }
 }
 
-impl<'tcx> QueryContext for QueryCtxt<'tcx> {
-    type QueryInfo = QueryStackDeferred<'tcx>;
-
+impl QueryContext for QueryCtxt<'_> {
     #[inline]
     fn jobserver_proxy(&self) -> &Proxy {
         &*self.jobserver_proxy
@@ -98,10 +95,7 @@ impl<'tcx> QueryContext for QueryCtxt<'tcx> {
     /// Prefer passing `false` to `require_complete` to avoid potential deadlocks,
     /// especially when called from within a deadlock handler, unless a
     /// complete map is needed and no deadlock is possible at this call site.
-    fn collect_active_jobs(
-        self,
-        require_complete: bool,
-    ) -> Result<QueryMap<QueryStackDeferred<'tcx>>, QueryMap<QueryStackDeferred<'tcx>>> {
+    fn collect_active_jobs(self, require_complete: bool) -> Result<QueryMap, QueryMap> {
         let mut jobs = QueryMap::default();
         let mut complete = true;
 
@@ -112,13 +106,6 @@ impl<'tcx> QueryContext for QueryCtxt<'tcx> {
         }
 
         if complete { Ok(jobs) } else { Err(jobs) }
-    }
-
-    fn lift_query_info(
-        self,
-        info: &QueryStackDeferred<'tcx>,
-    ) -> rustc_query_system::query::QueryStackFrameExtra {
-        info.extract()
     }
 
     // Interactions with on_disk_cache
@@ -181,10 +168,7 @@ impl<'tcx> QueryContext for QueryCtxt<'tcx> {
 
         self.sess.dcx().emit_fatal(QueryOverflow {
             span: info.job.span,
-            note: QueryOverflowNote {
-                desc: self.lift_query_info(&info.query.info).description,
-                depth,
-            },
+            note: QueryOverflowNote { desc: info.query.description, depth },
             suggested_limit,
             crate_name: self.crate_name(LOCAL_CRATE),
         });
@@ -321,17 +305,16 @@ macro_rules! should_ever_cache_on_disk {
     };
 }
 
-fn create_query_frame_extra<'tcx, K: Key + Copy + 'tcx>(
-    (tcx, key, kind, name, do_describe): (
-        TyCtxt<'tcx>,
-        K,
-        DepKind,
-        &'static str,
-        fn(TyCtxt<'tcx>, K) -> String,
-    ),
-) -> QueryStackFrameExtra {
-    let def_id = key.key_as_def_id();
-
+pub(crate) fn create_query_frame<
+    'tcx,
+    K: Copy + Key + for<'a> HashStable<StableHashingContext<'a>>,
+>(
+    tcx: TyCtxt<'tcx>,
+    do_describe: fn(TyCtxt<'tcx>, K) -> String,
+    key: K,
+    kind: DepKind,
+    name: &'static str,
+) -> QueryStackFrame {
     // If reduced queries are requested, we may be printing a query stack due
     // to a panic. Avoid using `default_span` and `def_kind` in that case.
     let reduce_queries = with_reduced_queries();
@@ -343,6 +326,7 @@ fn create_query_frame_extra<'tcx, K: Key + Copy + 'tcx>(
     } else {
         description
     };
+
     let span = if kind == dep_graph::dep_kinds::def_span || reduce_queries {
         // The `def_span` query is used to calculate `default_span`,
         // so exit to avoid infinite recursion.
@@ -351,41 +335,25 @@ fn create_query_frame_extra<'tcx, K: Key + Copy + 'tcx>(
         Some(key.default_span(tcx))
     };
 
+    let def_id = key.key_as_def_id();
+
     let def_kind = if kind == dep_graph::dep_kinds::def_kind || reduce_queries {
         // Try to avoid infinite recursion.
         None
     } else {
         def_id.and_then(|def_id| def_id.as_local()).map(|def_id| tcx.def_kind(def_id))
     };
-    QueryStackFrameExtra::new(description, span, def_kind)
-}
 
-pub(crate) fn create_query_frame<
-    'tcx,
-    K: Copy + DynSend + DynSync + Key + for<'a> HashStable<StableHashingContext<'a>> + 'tcx,
->(
-    tcx: TyCtxt<'tcx>,
-    do_describe: fn(TyCtxt<'tcx>, K) -> String,
-    key: K,
-    kind: DepKind,
-    name: &'static str,
-) -> QueryStackFrame<QueryStackDeferred<'tcx>> {
-    let def_id = key.key_as_def_id();
-
-    let hash = || {
-        tcx.with_stable_hashing_context(|mut hcx| {
-            let mut hasher = StableHasher::new();
-            kind.as_usize().hash_stable(&mut hcx, &mut hasher);
-            key.hash_stable(&mut hcx, &mut hasher);
-            hasher.finish::<Hash64>()
-        })
-    };
     let def_id_for_ty_in_cycle = key.def_id_for_ty_in_cycle();
 
-    let info =
-        QueryStackDeferred::new((tcx, key, kind, name, do_describe), create_query_frame_extra);
+    let hash = tcx.with_stable_hashing_context(|mut hcx| {
+        let mut hasher = StableHasher::new();
+        kind.as_usize().hash_stable(&mut hcx, &mut hasher);
+        key.hash_stable(&mut hcx, &mut hasher);
+        hasher.finish::<Hash64>()
+    });
 
-    QueryStackFrame::new(info, kind, hash, def_id, def_id_for_ty_in_cycle)
+    QueryStackFrame::new(description, span, def_id, def_kind, kind, def_id_for_ty_in_cycle, hash)
 }
 
 pub(crate) fn encode_query_results<'a, 'tcx, Q>(
@@ -737,7 +705,7 @@ macro_rules! define_queries {
 
             pub(crate) fn collect_active_jobs<'tcx>(
                 tcx: TyCtxt<'tcx>,
-                qmap: &mut QueryMap<QueryStackDeferred<'tcx>>,
+                qmap: &mut QueryMap,
                 require_complete: bool,
             ) -> Option<()> {
                 let make_query = |tcx, key| {
@@ -821,7 +789,7 @@ macro_rules! define_queries {
         // These arrays are used for iteration and can't be indexed by `DepKind`.
 
         const COLLECT_ACTIVE_JOBS: &[
-            for<'tcx> fn(TyCtxt<'tcx>, &mut QueryMap<QueryStackDeferred<'tcx>>, bool) -> Option<()>
+            for<'tcx> fn(TyCtxt<'tcx>, &mut QueryMap, bool) -> Option<()>
         ] =
             &[$(query_impl::$name::collect_active_jobs),*];
 

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -327,21 +327,23 @@ pub(crate) fn create_query_frame<
         description
     };
 
-    let span = if kind == dep_graph::dep_kinds::def_span || reduce_queries {
+    let span = if reduce_queries {
         // The `def_span` query is used to calculate `default_span`,
         // so exit to avoid infinite recursion.
         None
     } else {
-        Some(key.default_span(tcx))
+        Some(tcx.with_reduced_queries(|| key.default_span(tcx)))
     };
 
     let def_id = key.key_as_def_id();
 
-    let def_kind = if kind == dep_graph::dep_kinds::def_kind || reduce_queries {
+    let def_kind = if reduce_queries {
         // Try to avoid infinite recursion.
         None
     } else {
-        def_id.and_then(|def_id| def_id.as_local()).map(|def_id| tcx.def_kind(def_id))
+        def_id
+            .and_then(|def_id| def_id.as_local())
+            .map(|def_id| tcx.with_reduced_queries(|| tcx.def_kind(def_id)))
     };
 
     let def_id_for_ty_in_cycle = key.def_id_for_ty_in_cycle();

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -219,7 +219,7 @@ macro_rules! handle_cycle_error {
     ([]) => {{
         rustc_query_system::HandleCycleError::Error
     }};
-    ([(fatal_cycle) $($rest:tt)*]) => {{
+    ([(cycle_fatal) $($rest:tt)*]) => {{
         rustc_query_system::HandleCycleError::Fatal
     }};
     ([(cycle_stash) $($rest:tt)*]) => {{

--- a/compiler/rustc_query_system/src/query/config.rs
+++ b/compiler/rustc_query_system/src/query/config.rs
@@ -6,7 +6,6 @@ use std::hash::Hash;
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_span::ErrorGuaranteed;
 
-use super::QueryStackFrameExtra;
 use crate::dep_graph::{DepKind, DepNode, DepNodeParams, SerializedDepNodeIndex};
 use crate::error::HandleCycleError;
 use crate::ich::StableHashingContext;
@@ -28,7 +27,7 @@ pub trait QueryConfig<Qcx: QueryContext>: Copy {
     fn format_value(self) -> fn(&Self::Value) -> String;
 
     // Don't use this method to access query results, instead use the methods on TyCtxt
-    fn query_state<'a>(self, tcx: Qcx) -> &'a QueryState<Self::Key, Qcx::QueryInfo>
+    fn query_state<'a>(self, tcx: Qcx) -> &'a QueryState<Self::Key>
     where
         Qcx: 'a;
 
@@ -58,7 +57,7 @@ pub trait QueryConfig<Qcx: QueryContext>: Copy {
     fn value_from_cycle_error(
         self,
         tcx: Qcx::DepContext,
-        cycle_error: &CycleError<QueryStackFrameExtra>,
+        cycle_error: &CycleError,
         guar: ErrorGuaranteed,
     ) -> Self::Value;
 

--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -1,23 +1,4 @@
-mod plumbing;
-use std::fmt::Debug;
-use std::marker::PhantomData;
-use std::mem::transmute;
-use std::sync::Arc;
-
-pub use self::plumbing::*;
-
-mod job;
-pub use self::job::{
-    QueryInfo, QueryJob, QueryJobId, QueryJobInfo, QueryMap, break_query_cycles, print_query_stack,
-    report_cycle,
-};
-
-mod caches;
-pub use self::caches::{DefIdCache, DefaultCache, QueryCache, SingleCache, VecCache};
-
-mod config;
 use rustc_data_structures::jobserver::Proxy;
-use rustc_data_structures::sync::{DynSend, DynSync};
 use rustc_errors::DiagInner;
 use rustc_hashes::Hash64;
 use rustc_hir::def::DefKind;
@@ -25,66 +6,49 @@ use rustc_macros::{Decodable, Encodable};
 use rustc_span::Span;
 use rustc_span::def_id::DefId;
 
+pub use self::caches::{DefIdCache, DefaultCache, QueryCache, SingleCache, VecCache};
 pub use self::config::{HashResult, QueryConfig};
+pub use self::job::{
+    QueryInfo, QueryJob, QueryJobId, QueryJobInfo, QueryMap, break_query_cycles, print_query_stack,
+    report_cycle,
+};
+pub use self::plumbing::*;
 use crate::dep_graph::{DepKind, DepNodeIndex, HasDepContext, SerializedDepNodeIndex};
+
+mod caches;
+mod config;
+mod job;
+mod plumbing;
 
 /// Description of a frame in the query stack.
 ///
 /// This is mostly used in case of cycles for error reporting.
 #[derive(Clone, Debug)]
-pub struct QueryStackFrame<I> {
-    /// This field initially stores a `QueryStackDeferred` during collection,
-    /// but can later be changed to `QueryStackFrameExtra` containing concrete information
-    /// by calling `lift`. This is done so that collecting query does not need to invoke
-    /// queries, instead `lift` will call queries in a more appropriate location.
-    pub info: I,
-
+pub struct QueryStackFrame {
+    pub description: String,
+    span: Option<Span>,
+    pub def_id: Option<DefId>,
+    pub def_kind: Option<DefKind>,
+    /// A def-id that is extracted from a `Ty` in a query key
+    pub def_id_for_ty_in_cycle: Option<DefId>,
     pub dep_kind: DepKind,
     /// This hash is used to deterministically pick
     /// a query to remove cycles in the parallel compiler.
     hash: Hash64,
-    pub def_id: Option<DefId>,
-    /// A def-id that is extracted from a `Ty` in a query key
-    pub def_id_for_ty_in_cycle: Option<DefId>,
 }
 
-impl<I> QueryStackFrame<I> {
+impl QueryStackFrame {
     #[inline]
     pub fn new(
-        info: I,
-        dep_kind: DepKind,
-        hash: impl FnOnce() -> Hash64,
+        description: String,
+        span: Option<Span>,
         def_id: Option<DefId>,
+        def_kind: Option<DefKind>,
+        dep_kind: DepKind,
         def_id_for_ty_in_cycle: Option<DefId>,
+        hash: Hash64,
     ) -> Self {
-        Self { info, def_id, dep_kind, hash: hash(), def_id_for_ty_in_cycle }
-    }
-
-    fn lift<Qcx: QueryContext<QueryInfo = I>>(
-        &self,
-        qcx: Qcx,
-    ) -> QueryStackFrame<QueryStackFrameExtra> {
-        QueryStackFrame {
-            info: qcx.lift_query_info(&self.info),
-            dep_kind: self.dep_kind,
-            hash: self.hash,
-            def_id: self.def_id,
-            def_id_for_ty_in_cycle: self.def_id_for_ty_in_cycle,
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct QueryStackFrameExtra {
-    pub description: String,
-    span: Option<Span>,
-    pub def_kind: Option<DefKind>,
-}
-
-impl QueryStackFrameExtra {
-    #[inline]
-    pub fn new(description: String, span: Option<Span>, def_kind: Option<DefKind>) -> Self {
-        Self { description, span, def_kind }
+        Self { description, span, def_id, def_kind, def_id_for_ty_in_cycle, dep_kind, hash }
     }
 
     // FIXME(eddyb) Get more valid `Span`s on queries.
@@ -94,40 +58,6 @@ impl QueryStackFrameExtra {
             return span;
         }
         self.span.unwrap_or(span)
-    }
-}
-
-/// Track a 'side effect' for a particular query.
-/// This is used to hold a closure which can create `QueryStackFrameExtra`.
-#[derive(Clone)]
-pub struct QueryStackDeferred<'tcx> {
-    _dummy: PhantomData<&'tcx ()>,
-
-    // `extract` may contain references to 'tcx, but we can't tell drop checking that it won't
-    // access it in the destructor.
-    extract: Arc<dyn Fn() -> QueryStackFrameExtra + DynSync + DynSend>,
-}
-
-impl<'tcx> QueryStackDeferred<'tcx> {
-    pub fn new<C: Copy + DynSync + DynSend + 'tcx>(
-        context: C,
-        extract: fn(C) -> QueryStackFrameExtra,
-    ) -> Self {
-        let extract: Arc<dyn Fn() -> QueryStackFrameExtra + DynSync + DynSend + 'tcx> =
-            Arc::new(move || extract(context));
-        // SAFETY: The `extract` closure does not access 'tcx in its destructor as the only
-        // captured variable is `context` which is Copy and cannot have a destructor.
-        Self { _dummy: PhantomData, extract: unsafe { transmute(extract) } }
-    }
-
-    pub fn extract(&self) -> QueryStackFrameExtra {
-        (self.extract)()
-    }
-}
-
-impl<'tcx> Debug for QueryStackDeferred<'tcx> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("QueryStackDeferred")
     }
 }
 
@@ -150,8 +80,6 @@ pub enum QuerySideEffect {
 }
 
 pub trait QueryContext: HasDepContext {
-    type QueryInfo: Clone;
-
     /// Gets a jobserver reference which is used to release then acquire
     /// a token while waiting on a query.
     fn jobserver_proxy(&self) -> &Proxy;
@@ -161,12 +89,7 @@ pub trait QueryContext: HasDepContext {
     /// Get the query information from the TLS context.
     fn current_query_job(self) -> Option<QueryJobId>;
 
-    fn collect_active_jobs(
-        self,
-        require_complete: bool,
-    ) -> Result<QueryMap<Self::QueryInfo>, QueryMap<Self::QueryInfo>>;
-
-    fn lift_query_info(self, info: &Self::QueryInfo) -> QueryStackFrameExtra;
+    fn collect_active_jobs(self, require_complete: bool) -> Result<QueryMap, QueryMap>;
 
     /// Load a side effect associated to the node in the previous session.
     fn load_side_effect(

--- a/tests/ui/resolve/query-cycle-issue-124901.rs
+++ b/tests/ui/resolve/query-cycle-issue-124901.rs
@@ -1,0 +1,24 @@
+//~ ERROR: cycle detected when looking up span for `Default`
+trait Default {
+    type Id;
+
+    fn intu(&self) -> &Self::Id;
+}
+
+impl<T: Default<Id = U>, U: Copy> Default for U {
+    default type Id = T;
+    fn intu(&self) -> &Self::Id {
+        self
+    }
+}
+
+fn specialization<T>(t: T) -> U {
+    *t.intu()
+}
+
+use std::num::NonZero;
+
+fn main() {
+    let assert_eq = NonZero::<u8, Option<NonZero<u8>>>(0);
+    assert_eq!(specialization, None);
+}

--- a/tests/ui/resolve/query-cycle-issue-124901.rs
+++ b/tests/ui/resolve/query-cycle-issue-124901.rs
@@ -1,4 +1,4 @@
-//~ ERROR: cycle detected when looking up span for `Default`
+//~ ERROR: cycle detected when getting HIR ID of `Default`
 trait Default {
     type Id;
 

--- a/tests/ui/resolve/query-cycle-issue-124901.stderr
+++ b/tests/ui/resolve/query-cycle-issue-124901.stderr
@@ -1,0 +1,9 @@
+error[E0391]: cycle detected when looking up span for `Default`
+   |
+   = note: ...which immediately requires looking up span for `Default` again
+   = note: cycle used when perform lints prior to AST lowering
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/resolve/query-cycle-issue-124901.stderr
+++ b/tests/ui/resolve/query-cycle-issue-124901.stderr
@@ -1,7 +1,10 @@
-error[E0391]: cycle detected when looking up span for `Default`
+error[E0391]: cycle detected when getting HIR ID of `Default`
    |
-   = note: ...which immediately requires looking up span for `Default` again
-   = note: cycle used when perform lints prior to AST lowering
+   = note: ...which requires getting the crate HIR...
+   = note: ...which requires perform lints prior to AST lowering...
+   = note: ...which requires looking up span for `Default`...
+   = note: ...which again requires getting HIR ID of `Default`, completing the cycle
+   = note: cycle used when getting the resolver for lowering
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
PR rust-lang/rust#138672 fixed a query cycle OOM reported in rust-lang/rust#124901. The fix involved delaying computation of some query stack frame elements and was very complex. It involved the addition of two new types, the addition of a generic `I` parameter to eleven(!) other types, a `PhantomData` field, and even required an unsafe transmute of a closure. [This comment](https://github.com/rust-lang/rust/issues/124901#issuecomment-2104852065) had suggested a much simpler fix, but it was ignored. The PR also failed to add a test case.

This PR adds a test case, reverts the complex fix, applies the simpler fix, and does a few other minor cleanups.

r? @oli-obk
