### PR TITLE
Add missing closing brackets to THIR output.

### DIFF
--- a/compiler/rustc_mir_build/src/thir/print.rs
+++ b/compiler/rustc_mir_build/src/thir/print.rs
@@ -618,8 +618,8 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
         print_indented!(self, format!("args: {:?}", adt_expr.args), depth_lvl + 1);
         print_indented!(self, format!("user_ty: {:?}", adt_expr.user_ty), depth_lvl + 1);
 
-        for (i, field_expr) in adt_expr.fields.iter().enumerate() {
-            print_indented!(self, format!("field {}:", i), depth_lvl + 1);
+        for field_expr in adt_expr.fields.iter() {
+            print_indented!(self, format!("field {}:", field_expr.name.as_u32()), depth_lvl + 1);
             self.print_expr(field_expr.expr, depth_lvl + 2);
         }
 
@@ -643,6 +643,7 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
         print_indented!(self, format!("variants: {:?}", adt_def.variants()), depth_lvl + 1);
         print_indented!(self, format!("flags: {:?}", adt_def.flags()), depth_lvl + 1);
         print_indented!(self, format!("repr: {:?}", adt_def.repr()), depth_lvl + 1);
+        print_indented!(self, "}", depth_lvl);
     }
 
     fn print_fru_info(&mut self, fru_info: &FruInfo<'tcx>, depth_lvl: usize) {
@@ -653,6 +654,7 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
         for ty in fru_info.field_types.iter() {
             print_indented!(self, format!("ty: {:?}", ty), depth_lvl + 2);
         }
+        print_indented!(self, "]", depth_lvl + 1);
         print_indented!(self, "}", depth_lvl);
     }
 
@@ -683,7 +685,7 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
     fn print_pat(&mut self, pat: &Pat<'tcx>, depth_lvl: usize) {
         let &Pat { ty, span, ref kind, ref extra } = pat;
 
-        print_indented!(self, "Pat: {", depth_lvl);
+        print_indented!(self, "Pat {", depth_lvl);
         print_indented!(self, format!("ty: {:?}", ty), depth_lvl + 1);
         print_indented!(self, format!("span: {:?}", span), depth_lvl + 1);
         self.print_pat_extra(extra.as_deref(), depth_lvl + 1);
@@ -913,6 +915,8 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
 
         print_indented!(self, format!("options: {:?}", options), depth_lvl + 1);
         print_indented!(self, format!("line_spans: {:?}", line_spans), depth_lvl + 1);
+
+        print_indented!(self, "}", depth_lvl);
     }
 
     fn print_inline_operand(&mut self, operand: &InlineAsmOperand<'tcx>, depth_lvl: usize) {

--- a/tests/ui/thir-print/c-variadic.stdout
+++ b/tests/ui/thir-print/c-variadic.stdout
@@ -6,7 +6,7 @@ params: [
         self_kind: None
         hir_id: Some(HirId(DefId(0:3 ~ c_variadic[a5de]::foo).1))
         param: Some( 
-            Pat: {
+            Pat {
                 ty: i32
                 span: $DIR/c-variadic.rs:7:26: 7:27 (#0)
                 kind: PatKind {
@@ -21,7 +21,7 @@ params: [
         self_kind: None
         hir_id: Some(HirId(DefId(0:3 ~ c_variadic[a5de]::foo).3))
         param: Some( 
-            Pat: {
+            Pat {
                 ty: std::ffi::VaList<'{erased}>
                 span: $DIR/c-variadic.rs:7:34: 7:37 (#0)
                 kind: PatKind {

--- a/tests/ui/thir-print/offset_of.stdout
+++ b/tests/ui/thir-print/offset_of.stdout
@@ -27,7 +27,7 @@ body:
                                             remainder_scope: Remainder { block: 1, first_statement_index: 0}
                                             init_scope: Node(2)
                                             pattern: 
-                                                Pat: {
+                                                Pat {
                                                     ty: usize
                                                     span: $DIR/offset_of.rs:37:9: 37:10 (#0)
                                                     kind: PatKind {
@@ -76,7 +76,7 @@ body:
                                             remainder_scope: Remainder { block: 1, first_statement_index: 1}
                                             init_scope: Node(12)
                                             pattern: 
-                                                Pat: {
+                                                Pat {
                                                     ty: usize
                                                     span: $DIR/offset_of.rs:38:9: 38:10 (#0)
                                                     kind: PatKind {
@@ -125,7 +125,7 @@ body:
                                             remainder_scope: Remainder { block: 1, first_statement_index: 2}
                                             init_scope: Node(22)
                                             pattern: 
-                                                Pat: {
+                                                Pat {
                                                     ty: usize
                                                     span: $DIR/offset_of.rs:39:9: 39:10 (#0)
                                                     kind: PatKind {
@@ -174,7 +174,7 @@ body:
                                             remainder_scope: Remainder { block: 1, first_statement_index: 3}
                                             init_scope: Node(32)
                                             pattern: 
-                                                Pat: {
+                                                Pat {
                                                     ty: usize
                                                     span: $DIR/offset_of.rs:40:9: 40:11 (#0)
                                                     kind: PatKind {
@@ -223,7 +223,7 @@ body:
                                             remainder_scope: Remainder { block: 1, first_statement_index: 4}
                                             init_scope: Node(42)
                                             pattern: 
-                                                Pat: {
+                                                Pat {
                                                     ty: usize
                                                     span: $DIR/offset_of.rs:41:9: 41:11 (#0)
                                                     kind: PatKind {
@@ -823,7 +823,7 @@ body:
                                             remainder_scope: Remainder { block: 1, first_statement_index: 0}
                                             init_scope: Node(2)
                                             pattern: 
-                                                Pat: {
+                                                Pat {
                                                     ty: usize
                                                     span: $DIR/offset_of.rs:45:9: 45:11 (#0)
                                                     kind: PatKind {
@@ -872,7 +872,7 @@ body:
                                             remainder_scope: Remainder { block: 1, first_statement_index: 1}
                                             init_scope: Node(14)
                                             pattern: 
-                                                Pat: {
+                                                Pat {
                                                     ty: usize
                                                     span: $DIR/offset_of.rs:46:9: 46:11 (#0)
                                                     kind: PatKind {
@@ -921,7 +921,7 @@ body:
                                             remainder_scope: Remainder { block: 1, first_statement_index: 2}
                                             init_scope: Node(26)
                                             pattern: 
-                                                Pat: {
+                                                Pat {
                                                     ty: usize
                                                     span: $DIR/offset_of.rs:47:9: 47:11 (#0)
                                                     kind: PatKind {
@@ -970,7 +970,7 @@ body:
                                             remainder_scope: Remainder { block: 1, first_statement_index: 3}
                                             init_scope: Node(38)
                                             pattern: 
-                                                Pat: {
+                                                Pat {
                                                     ty: usize
                                                     span: $DIR/offset_of.rs:48:9: 48:11 (#0)
                                                     kind: PatKind {

--- a/tests/ui/thir-print/thir-tree-field-expr-index.rs
+++ b/tests/ui/thir-print/thir-tree-field-expr-index.rs
@@ -1,0 +1,25 @@
+//@ check-pass
+//@ compile-flags: -Zunpretty=thir-tree
+
+struct S {
+    a: u32,
+    b: u32,
+    c: u32,
+    d: u32,
+    e: u32,
+}
+
+fn update(x: u32) {
+  let s = S { a: x, b: x, c: x, d: x, e: x };
+
+  S { a: x , ..s };
+  S { b: x , ..s };
+  S { c: x , ..s };
+  S { d: x , ..s };
+  S { e: x , ..s };
+
+  S { b: x, d: x, ..s };
+  S { a: x, c: x, e: x, ..s };
+}
+
+fn main() {}

--- a/tests/ui/thir-print/thir-tree-field-expr-index.stdout
+++ b/tests/ui/thir-print/thir-tree-field-expr-index.stdout
@@ -1,0 +1,921 @@
+DefId(0:9 ~ thir_tree_field_expr_index[5059]::update):
+params: [
+    Param {
+        ty: u32
+        ty_span: Some($DIR/thir-tree-field-expr-index.rs:12:14: 12:17 (#0))
+        self_kind: None
+        hir_id: Some(HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).1))
+        param: Some( 
+            Pat {
+                ty: u32
+                span: $DIR/thir-tree-field-expr-index.rs:12:11: 12:12 (#0)
+                kind: PatKind {
+                    Binding {
+                        name: "x"
+                        mode: BindingMode(No, Not)
+                        var: LocalVarId(HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).2))
+                        ty: u32
+                        is_primary: true
+                        is_shorthand: false
+                        subpattern: None
+                    }
+                }
+            }
+        )
+    }
+]
+body:
+    Expr {
+        ty: ()
+        temp_scope_id: 89
+        span: $DIR/thir-tree-field-expr-index.rs:12:19: 23:2 (#0)
+        kind: 
+            Scope {
+                region_scope: Node(89)
+                hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).89)
+                value:
+                    Expr {
+                        ty: ()
+                        temp_scope_id: 89
+                        span: $DIR/thir-tree-field-expr-index.rs:12:19: 23:2 (#0)
+                        kind: 
+                            Block {
+                                targeted_by_break: false
+                                span: $DIR/thir-tree-field-expr-index.rs:12:19: 23:2 (#0)
+                                region_scope: Node(3)
+                                safety_mode: Safe
+                                stmts: [
+                                    Stmt {
+                                        kind: Let {
+                                            remainder_scope: Remainder { block: 3, first_statement_index: 0}
+                                            init_scope: Node(4)
+                                            pattern: 
+                                                Pat {
+                                                    ty: S
+                                                    span: $DIR/thir-tree-field-expr-index.rs:13:7: 13:8 (#0)
+                                                    kind: PatKind {
+                                                        Binding {
+                                                            name: "s"
+                                                            mode: BindingMode(No, Not)
+                                                            var: LocalVarId(HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).23))
+                                                            ty: S
+                                                            is_primary: true
+                                                            is_shorthand: false
+                                                            subpattern: None
+                                                        }
+                                                    }
+                                                }
+                                            ,
+                                            initializer: Some(
+                                                Expr {
+                                                    ty: S
+                                                    temp_scope_id: 5
+                                                    span: $DIR/thir-tree-field-expr-index.rs:13:11: 13:45 (#0)
+                                                    kind: 
+                                                        Scope {
+                                                            region_scope: Node(5)
+                                                            hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).5)
+                                                            value:
+                                                                Expr {
+                                                                    ty: S
+                                                                    temp_scope_id: 5
+                                                                    span: $DIR/thir-tree-field-expr-index.rs:13:11: 13:45 (#0)
+                                                                    kind: 
+                                                                        Adt {
+                                                                            adt_def:
+                                                                                AdtDef {
+                                                                                    did: DefId(0:3 ~ thir_tree_field_expr_index[5059]::S)
+                                                                                    variants: [VariantDef { def_id: DefId(0:3 ~ thir_tree_field_expr_index[5059]::S), ctor: None, name: "S", discr: Relative(0), fields: [FieldDef { did: DefId(0:4 ~ thir_tree_field_expr_index[5059]::S::a), name: "a", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:5 ~ thir_tree_field_expr_index[5059]::S::b), name: "b", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:6 ~ thir_tree_field_expr_index[5059]::S::c), name: "c", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:7 ~ thir_tree_field_expr_index[5059]::S::d), name: "d", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:8 ~ thir_tree_field_expr_index[5059]::S::e), name: "e", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }], tainted: None, flags:  }]
+                                                                                    flags: IS_STRUCT
+                                                                                    repr: ReprOptions { int: None, align: None, pack: None, flags: , scalable: None, field_shuffle_seed: 7076349371981215213 }
+                                                                                }
+                                                                                variant_index: 0
+                                                                                args: []
+                                                                                user_ty: None
+                                                                                field 0:
+                                                                                    Expr {
+                                                                                        ty: u32
+                                                                                        temp_scope_id: 8
+                                                                                        span: $DIR/thir-tree-field-expr-index.rs:13:18: 13:19 (#0)
+                                                                                        kind: 
+                                                                                            Scope {
+                                                                                                region_scope: Node(8)
+                                                                                                hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).8)
+                                                                                                value:
+                                                                                                    Expr {
+                                                                                                        ty: u32
+                                                                                                        temp_scope_id: 8
+                                                                                                        span: $DIR/thir-tree-field-expr-index.rs:13:18: 13:19 (#0)
+                                                                                                        kind: 
+                                                                                                            VarRef {
+                                                                                                                id: LocalVarId(HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).2))
+                                                                                                            }
+                                                                                                    }
+                                                                                            }
+                                                                                    }
+                                                                                field 1:
+                                                                                    Expr {
+                                                                                        ty: u32
+                                                                                        temp_scope_id: 11
+                                                                                        span: $DIR/thir-tree-field-expr-index.rs:13:24: 13:25 (#0)
+                                                                                        kind: 
+                                                                                            Scope {
+                                                                                                region_scope: Node(11)
+                                                                                                hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).11)
+                                                                                                value:
+                                                                                                    Expr {
+                                                                                                        ty: u32
+                                                                                                        temp_scope_id: 11
+                                                                                                        span: $DIR/thir-tree-field-expr-index.rs:13:24: 13:25 (#0)
+                                                                                                        kind: 
+                                                                                                            VarRef {
+                                                                                                                id: LocalVarId(HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).2))
+                                                                                                            }
+                                                                                                    }
+                                                                                            }
+                                                                                    }
+                                                                                field 2:
+                                                                                    Expr {
+                                                                                        ty: u32
+                                                                                        temp_scope_id: 14
+                                                                                        span: $DIR/thir-tree-field-expr-index.rs:13:30: 13:31 (#0)
+                                                                                        kind: 
+                                                                                            Scope {
+                                                                                                region_scope: Node(14)
+                                                                                                hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).14)
+                                                                                                value:
+                                                                                                    Expr {
+                                                                                                        ty: u32
+                                                                                                        temp_scope_id: 14
+                                                                                                        span: $DIR/thir-tree-field-expr-index.rs:13:30: 13:31 (#0)
+                                                                                                        kind: 
+                                                                                                            VarRef {
+                                                                                                                id: LocalVarId(HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).2))
+                                                                                                            }
+                                                                                                    }
+                                                                                            }
+                                                                                    }
+                                                                                field 3:
+                                                                                    Expr {
+                                                                                        ty: u32
+                                                                                        temp_scope_id: 17
+                                                                                        span: $DIR/thir-tree-field-expr-index.rs:13:36: 13:37 (#0)
+                                                                                        kind: 
+                                                                                            Scope {
+                                                                                                region_scope: Node(17)
+                                                                                                hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).17)
+                                                                                                value:
+                                                                                                    Expr {
+                                                                                                        ty: u32
+                                                                                                        temp_scope_id: 17
+                                                                                                        span: $DIR/thir-tree-field-expr-index.rs:13:36: 13:37 (#0)
+                                                                                                        kind: 
+                                                                                                            VarRef {
+                                                                                                                id: LocalVarId(HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).2))
+                                                                                                            }
+                                                                                                    }
+                                                                                            }
+                                                                                    }
+                                                                                field 4:
+                                                                                    Expr {
+                                                                                        ty: u32
+                                                                                        temp_scope_id: 20
+                                                                                        span: $DIR/thir-tree-field-expr-index.rs:13:42: 13:43 (#0)
+                                                                                        kind: 
+                                                                                            Scope {
+                                                                                                region_scope: Node(20)
+                                                                                                hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).20)
+                                                                                                value:
+                                                                                                    Expr {
+                                                                                                        ty: u32
+                                                                                                        temp_scope_id: 20
+                                                                                                        span: $DIR/thir-tree-field-expr-index.rs:13:42: 13:43 (#0)
+                                                                                                        kind: 
+                                                                                                            VarRef {
+                                                                                                                id: LocalVarId(HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).2))
+                                                                                                            }
+                                                                                                    }
+                                                                                            }
+                                                                                    }
+                                                                                base: None
+                                                                        }
+                                                                }
+                                                        }
+                                                }
+                                            )
+                                            else_block: None
+                                            hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).22)
+                                            span: $DIR/thir-tree-field-expr-index.rs:13:3: 13:45 (#0)
+                                        }
+                                    }
+                                    Stmt {
+                                        kind: Expr {
+                                            scope: Node(31)
+                                            expr:
+                                                Expr {
+                                                    ty: S
+                                                    temp_scope_id: 24
+                                                    span: $DIR/thir-tree-field-expr-index.rs:15:3: 15:19 (#0)
+                                                    kind: 
+                                                        Scope {
+                                                            region_scope: Node(24)
+                                                            hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).24)
+                                                            value:
+                                                                Expr {
+                                                                    ty: S
+                                                                    temp_scope_id: 24
+                                                                    span: $DIR/thir-tree-field-expr-index.rs:15:3: 15:19 (#0)
+                                                                    kind: 
+                                                                        Adt {
+                                                                            adt_def:
+                                                                                AdtDef {
+                                                                                    did: DefId(0:3 ~ thir_tree_field_expr_index[5059]::S)
+                                                                                    variants: [VariantDef { def_id: DefId(0:3 ~ thir_tree_field_expr_index[5059]::S), ctor: None, name: "S", discr: Relative(0), fields: [FieldDef { did: DefId(0:4 ~ thir_tree_field_expr_index[5059]::S::a), name: "a", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:5 ~ thir_tree_field_expr_index[5059]::S::b), name: "b", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:6 ~ thir_tree_field_expr_index[5059]::S::c), name: "c", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:7 ~ thir_tree_field_expr_index[5059]::S::d), name: "d", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:8 ~ thir_tree_field_expr_index[5059]::S::e), name: "e", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }], tainted: None, flags:  }]
+                                                                                    flags: IS_STRUCT
+                                                                                    repr: ReprOptions { int: None, align: None, pack: None, flags: , scalable: None, field_shuffle_seed: 7076349371981215213 }
+                                                                                }
+                                                                                variant_index: 0
+                                                                                args: []
+                                                                                user_ty: None
+                                                                                field 0:
+                                                                                    Expr {
+                                                                                        ty: u32
+                                                                                        temp_scope_id: 29
+                                                                                        span: $DIR/thir-tree-field-expr-index.rs:15:10: 15:11 (#0)
+                                                                                        kind: 
+                                                                                            Scope {
+                                                                                                region_scope: Node(29)
+                                                                                                hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).29)
+                                                                                                value:
+                                                                                                    Expr {
+                                                                                                        ty: u32
+                                                                                                        temp_scope_id: 29
+                                                                                                        span: $DIR/thir-tree-field-expr-index.rs:15:10: 15:11 (#0)
+                                                                                                        kind: 
+                                                                                                            VarRef {
+                                                                                                                id: LocalVarId(HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).2))
+                                                                                                            }
+                                                                                                    }
+                                                                                            }
+                                                                                    }
+                                                                                base:
+                                                                                    FruInfo {
+                                                                                        base: 
+                                                                                            Expr {
+                                                                                                ty: S
+                                                                                                temp_scope_id: 25
+                                                                                                span: $DIR/thir-tree-field-expr-index.rs:15:16: 15:17 (#0)
+                                                                                                kind: 
+                                                                                                    Scope {
+                                                                                                        region_scope: Node(25)
+                                                                                                        hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).25)
+                                                                                                        value:
+                                                                                                            Expr {
+                                                                                                                ty: S
+                                                                                                                temp_scope_id: 25
+                                                                                                                span: $DIR/thir-tree-field-expr-index.rs:15:16: 15:17 (#0)
+                                                                                                                kind: 
+                                                                                                                    VarRef {
+                                                                                                                        id: LocalVarId(HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).23))
+                                                                                                                    }
+                                                                                                            }
+                                                                                                    }
+                                                                                            }
+                                                                                        field_types: [
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                        ]
+                                                                                    }
+                                                                        }
+                                                                }
+                                                        }
+                                                }
+                                        }
+                                    }
+                                    Stmt {
+                                        kind: Expr {
+                                            scope: Node(39)
+                                            expr:
+                                                Expr {
+                                                    ty: S
+                                                    temp_scope_id: 32
+                                                    span: $DIR/thir-tree-field-expr-index.rs:16:3: 16:19 (#0)
+                                                    kind: 
+                                                        Scope {
+                                                            region_scope: Node(32)
+                                                            hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).32)
+                                                            value:
+                                                                Expr {
+                                                                    ty: S
+                                                                    temp_scope_id: 32
+                                                                    span: $DIR/thir-tree-field-expr-index.rs:16:3: 16:19 (#0)
+                                                                    kind: 
+                                                                        Adt {
+                                                                            adt_def:
+                                                                                AdtDef {
+                                                                                    did: DefId(0:3 ~ thir_tree_field_expr_index[5059]::S)
+                                                                                    variants: [VariantDef { def_id: DefId(0:3 ~ thir_tree_field_expr_index[5059]::S), ctor: None, name: "S", discr: Relative(0), fields: [FieldDef { did: DefId(0:4 ~ thir_tree_field_expr_index[5059]::S::a), name: "a", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:5 ~ thir_tree_field_expr_index[5059]::S::b), name: "b", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:6 ~ thir_tree_field_expr_index[5059]::S::c), name: "c", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:7 ~ thir_tree_field_expr_index[5059]::S::d), name: "d", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:8 ~ thir_tree_field_expr_index[5059]::S::e), name: "e", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }], tainted: None, flags:  }]
+                                                                                    flags: IS_STRUCT
+                                                                                    repr: ReprOptions { int: None, align: None, pack: None, flags: , scalable: None, field_shuffle_seed: 7076349371981215213 }
+                                                                                }
+                                                                                variant_index: 0
+                                                                                args: []
+                                                                                user_ty: None
+                                                                                field 1:
+                                                                                    Expr {
+                                                                                        ty: u32
+                                                                                        temp_scope_id: 37
+                                                                                        span: $DIR/thir-tree-field-expr-index.rs:16:10: 16:11 (#0)
+                                                                                        kind: 
+                                                                                            Scope {
+                                                                                                region_scope: Node(37)
+                                                                                                hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).37)
+                                                                                                value:
+                                                                                                    Expr {
+                                                                                                        ty: u32
+                                                                                                        temp_scope_id: 37
+                                                                                                        span: $DIR/thir-tree-field-expr-index.rs:16:10: 16:11 (#0)
+                                                                                                        kind: 
+                                                                                                            VarRef {
+                                                                                                                id: LocalVarId(HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).2))
+                                                                                                            }
+                                                                                                    }
+                                                                                            }
+                                                                                    }
+                                                                                base:
+                                                                                    FruInfo {
+                                                                                        base: 
+                                                                                            Expr {
+                                                                                                ty: S
+                                                                                                temp_scope_id: 33
+                                                                                                span: $DIR/thir-tree-field-expr-index.rs:16:16: 16:17 (#0)
+                                                                                                kind: 
+                                                                                                    Scope {
+                                                                                                        region_scope: Node(33)
+                                                                                                        hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).33)
+                                                                                                        value:
+                                                                                                            Expr {
+                                                                                                                ty: S
+                                                                                                                temp_scope_id: 33
+                                                                                                                span: $DIR/thir-tree-field-expr-index.rs:16:16: 16:17 (#0)
+                                                                                                                kind: 
+                                                                                                                    VarRef {
+                                                                                                                        id: LocalVarId(HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).23))
+                                                                                                                    }
+                                                                                                            }
+                                                                                                    }
+                                                                                            }
+                                                                                        field_types: [
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                        ]
+                                                                                    }
+                                                                        }
+                                                                }
+                                                        }
+                                                }
+                                        }
+                                    }
+                                    Stmt {
+                                        kind: Expr {
+                                            scope: Node(47)
+                                            expr:
+                                                Expr {
+                                                    ty: S
+                                                    temp_scope_id: 40
+                                                    span: $DIR/thir-tree-field-expr-index.rs:17:3: 17:19 (#0)
+                                                    kind: 
+                                                        Scope {
+                                                            region_scope: Node(40)
+                                                            hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).40)
+                                                            value:
+                                                                Expr {
+                                                                    ty: S
+                                                                    temp_scope_id: 40
+                                                                    span: $DIR/thir-tree-field-expr-index.rs:17:3: 17:19 (#0)
+                                                                    kind: 
+                                                                        Adt {
+                                                                            adt_def:
+                                                                                AdtDef {
+                                                                                    did: DefId(0:3 ~ thir_tree_field_expr_index[5059]::S)
+                                                                                    variants: [VariantDef { def_id: DefId(0:3 ~ thir_tree_field_expr_index[5059]::S), ctor: None, name: "S", discr: Relative(0), fields: [FieldDef { did: DefId(0:4 ~ thir_tree_field_expr_index[5059]::S::a), name: "a", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:5 ~ thir_tree_field_expr_index[5059]::S::b), name: "b", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:6 ~ thir_tree_field_expr_index[5059]::S::c), name: "c", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:7 ~ thir_tree_field_expr_index[5059]::S::d), name: "d", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:8 ~ thir_tree_field_expr_index[5059]::S::e), name: "e", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }], tainted: None, flags:  }]
+                                                                                    flags: IS_STRUCT
+                                                                                    repr: ReprOptions { int: None, align: None, pack: None, flags: , scalable: None, field_shuffle_seed: 7076349371981215213 }
+                                                                                }
+                                                                                variant_index: 0
+                                                                                args: []
+                                                                                user_ty: None
+                                                                                field 2:
+                                                                                    Expr {
+                                                                                        ty: u32
+                                                                                        temp_scope_id: 45
+                                                                                        span: $DIR/thir-tree-field-expr-index.rs:17:10: 17:11 (#0)
+                                                                                        kind: 
+                                                                                            Scope {
+                                                                                                region_scope: Node(45)
+                                                                                                hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).45)
+                                                                                                value:
+                                                                                                    Expr {
+                                                                                                        ty: u32
+                                                                                                        temp_scope_id: 45
+                                                                                                        span: $DIR/thir-tree-field-expr-index.rs:17:10: 17:11 (#0)
+                                                                                                        kind: 
+                                                                                                            VarRef {
+                                                                                                                id: LocalVarId(HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).2))
+                                                                                                            }
+                                                                                                    }
+                                                                                            }
+                                                                                    }
+                                                                                base:
+                                                                                    FruInfo {
+                                                                                        base: 
+                                                                                            Expr {
+                                                                                                ty: S
+                                                                                                temp_scope_id: 41
+                                                                                                span: $DIR/thir-tree-field-expr-index.rs:17:16: 17:17 (#0)
+                                                                                                kind: 
+                                                                                                    Scope {
+                                                                                                        region_scope: Node(41)
+                                                                                                        hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).41)
+                                                                                                        value:
+                                                                                                            Expr {
+                                                                                                                ty: S
+                                                                                                                temp_scope_id: 41
+                                                                                                                span: $DIR/thir-tree-field-expr-index.rs:17:16: 17:17 (#0)
+                                                                                                                kind: 
+                                                                                                                    VarRef {
+                                                                                                                        id: LocalVarId(HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).23))
+                                                                                                                    }
+                                                                                                            }
+                                                                                                    }
+                                                                                            }
+                                                                                        field_types: [
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                        ]
+                                                                                    }
+                                                                        }
+                                                                }
+                                                        }
+                                                }
+                                        }
+                                    }
+                                    Stmt {
+                                        kind: Expr {
+                                            scope: Node(55)
+                                            expr:
+                                                Expr {
+                                                    ty: S
+                                                    temp_scope_id: 48
+                                                    span: $DIR/thir-tree-field-expr-index.rs:18:3: 18:19 (#0)
+                                                    kind: 
+                                                        Scope {
+                                                            region_scope: Node(48)
+                                                            hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).48)
+                                                            value:
+                                                                Expr {
+                                                                    ty: S
+                                                                    temp_scope_id: 48
+                                                                    span: $DIR/thir-tree-field-expr-index.rs:18:3: 18:19 (#0)
+                                                                    kind: 
+                                                                        Adt {
+                                                                            adt_def:
+                                                                                AdtDef {
+                                                                                    did: DefId(0:3 ~ thir_tree_field_expr_index[5059]::S)
+                                                                                    variants: [VariantDef { def_id: DefId(0:3 ~ thir_tree_field_expr_index[5059]::S), ctor: None, name: "S", discr: Relative(0), fields: [FieldDef { did: DefId(0:4 ~ thir_tree_field_expr_index[5059]::S::a), name: "a", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:5 ~ thir_tree_field_expr_index[5059]::S::b), name: "b", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:6 ~ thir_tree_field_expr_index[5059]::S::c), name: "c", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:7 ~ thir_tree_field_expr_index[5059]::S::d), name: "d", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:8 ~ thir_tree_field_expr_index[5059]::S::e), name: "e", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }], tainted: None, flags:  }]
+                                                                                    flags: IS_STRUCT
+                                                                                    repr: ReprOptions { int: None, align: None, pack: None, flags: , scalable: None, field_shuffle_seed: 7076349371981215213 }
+                                                                                }
+                                                                                variant_index: 0
+                                                                                args: []
+                                                                                user_ty: None
+                                                                                field 3:
+                                                                                    Expr {
+                                                                                        ty: u32
+                                                                                        temp_scope_id: 53
+                                                                                        span: $DIR/thir-tree-field-expr-index.rs:18:10: 18:11 (#0)
+                                                                                        kind: 
+                                                                                            Scope {
+                                                                                                region_scope: Node(53)
+                                                                                                hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).53)
+                                                                                                value:
+                                                                                                    Expr {
+                                                                                                        ty: u32
+                                                                                                        temp_scope_id: 53
+                                                                                                        span: $DIR/thir-tree-field-expr-index.rs:18:10: 18:11 (#0)
+                                                                                                        kind: 
+                                                                                                            VarRef {
+                                                                                                                id: LocalVarId(HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).2))
+                                                                                                            }
+                                                                                                    }
+                                                                                            }
+                                                                                    }
+                                                                                base:
+                                                                                    FruInfo {
+                                                                                        base: 
+                                                                                            Expr {
+                                                                                                ty: S
+                                                                                                temp_scope_id: 49
+                                                                                                span: $DIR/thir-tree-field-expr-index.rs:18:16: 18:17 (#0)
+                                                                                                kind: 
+                                                                                                    Scope {
+                                                                                                        region_scope: Node(49)
+                                                                                                        hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).49)
+                                                                                                        value:
+                                                                                                            Expr {
+                                                                                                                ty: S
+                                                                                                                temp_scope_id: 49
+                                                                                                                span: $DIR/thir-tree-field-expr-index.rs:18:16: 18:17 (#0)
+                                                                                                                kind: 
+                                                                                                                    VarRef {
+                                                                                                                        id: LocalVarId(HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).23))
+                                                                                                                    }
+                                                                                                            }
+                                                                                                    }
+                                                                                            }
+                                                                                        field_types: [
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                        ]
+                                                                                    }
+                                                                        }
+                                                                }
+                                                        }
+                                                }
+                                        }
+                                    }
+                                    Stmt {
+                                        kind: Expr {
+                                            scope: Node(63)
+                                            expr:
+                                                Expr {
+                                                    ty: S
+                                                    temp_scope_id: 56
+                                                    span: $DIR/thir-tree-field-expr-index.rs:19:3: 19:19 (#0)
+                                                    kind: 
+                                                        Scope {
+                                                            region_scope: Node(56)
+                                                            hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).56)
+                                                            value:
+                                                                Expr {
+                                                                    ty: S
+                                                                    temp_scope_id: 56
+                                                                    span: $DIR/thir-tree-field-expr-index.rs:19:3: 19:19 (#0)
+                                                                    kind: 
+                                                                        Adt {
+                                                                            adt_def:
+                                                                                AdtDef {
+                                                                                    did: DefId(0:3 ~ thir_tree_field_expr_index[5059]::S)
+                                                                                    variants: [VariantDef { def_id: DefId(0:3 ~ thir_tree_field_expr_index[5059]::S), ctor: None, name: "S", discr: Relative(0), fields: [FieldDef { did: DefId(0:4 ~ thir_tree_field_expr_index[5059]::S::a), name: "a", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:5 ~ thir_tree_field_expr_index[5059]::S::b), name: "b", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:6 ~ thir_tree_field_expr_index[5059]::S::c), name: "c", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:7 ~ thir_tree_field_expr_index[5059]::S::d), name: "d", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:8 ~ thir_tree_field_expr_index[5059]::S::e), name: "e", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }], tainted: None, flags:  }]
+                                                                                    flags: IS_STRUCT
+                                                                                    repr: ReprOptions { int: None, align: None, pack: None, flags: , scalable: None, field_shuffle_seed: 7076349371981215213 }
+                                                                                }
+                                                                                variant_index: 0
+                                                                                args: []
+                                                                                user_ty: None
+                                                                                field 4:
+                                                                                    Expr {
+                                                                                        ty: u32
+                                                                                        temp_scope_id: 61
+                                                                                        span: $DIR/thir-tree-field-expr-index.rs:19:10: 19:11 (#0)
+                                                                                        kind: 
+                                                                                            Scope {
+                                                                                                region_scope: Node(61)
+                                                                                                hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).61)
+                                                                                                value:
+                                                                                                    Expr {
+                                                                                                        ty: u32
+                                                                                                        temp_scope_id: 61
+                                                                                                        span: $DIR/thir-tree-field-expr-index.rs:19:10: 19:11 (#0)
+                                                                                                        kind: 
+                                                                                                            VarRef {
+                                                                                                                id: LocalVarId(HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).2))
+                                                                                                            }
+                                                                                                    }
+                                                                                            }
+                                                                                    }
+                                                                                base:
+                                                                                    FruInfo {
+                                                                                        base: 
+                                                                                            Expr {
+                                                                                                ty: S
+                                                                                                temp_scope_id: 57
+                                                                                                span: $DIR/thir-tree-field-expr-index.rs:19:16: 19:17 (#0)
+                                                                                                kind: 
+                                                                                                    Scope {
+                                                                                                        region_scope: Node(57)
+                                                                                                        hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).57)
+                                                                                                        value:
+                                                                                                            Expr {
+                                                                                                                ty: S
+                                                                                                                temp_scope_id: 57
+                                                                                                                span: $DIR/thir-tree-field-expr-index.rs:19:16: 19:17 (#0)
+                                                                                                                kind: 
+                                                                                                                    VarRef {
+                                                                                                                        id: LocalVarId(HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).23))
+                                                                                                                    }
+                                                                                                            }
+                                                                                                    }
+                                                                                            }
+                                                                                        field_types: [
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                        ]
+                                                                                    }
+                                                                        }
+                                                                }
+                                                        }
+                                                }
+                                        }
+                                    }
+                                    Stmt {
+                                        kind: Expr {
+                                            scope: Node(74)
+                                            expr:
+                                                Expr {
+                                                    ty: S
+                                                    temp_scope_id: 64
+                                                    span: $DIR/thir-tree-field-expr-index.rs:21:3: 21:24 (#0)
+                                                    kind: 
+                                                        Scope {
+                                                            region_scope: Node(64)
+                                                            hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).64)
+                                                            value:
+                                                                Expr {
+                                                                    ty: S
+                                                                    temp_scope_id: 64
+                                                                    span: $DIR/thir-tree-field-expr-index.rs:21:3: 21:24 (#0)
+                                                                    kind: 
+                                                                        Adt {
+                                                                            adt_def:
+                                                                                AdtDef {
+                                                                                    did: DefId(0:3 ~ thir_tree_field_expr_index[5059]::S)
+                                                                                    variants: [VariantDef { def_id: DefId(0:3 ~ thir_tree_field_expr_index[5059]::S), ctor: None, name: "S", discr: Relative(0), fields: [FieldDef { did: DefId(0:4 ~ thir_tree_field_expr_index[5059]::S::a), name: "a", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:5 ~ thir_tree_field_expr_index[5059]::S::b), name: "b", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:6 ~ thir_tree_field_expr_index[5059]::S::c), name: "c", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:7 ~ thir_tree_field_expr_index[5059]::S::d), name: "d", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:8 ~ thir_tree_field_expr_index[5059]::S::e), name: "e", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }], tainted: None, flags:  }]
+                                                                                    flags: IS_STRUCT
+                                                                                    repr: ReprOptions { int: None, align: None, pack: None, flags: , scalable: None, field_shuffle_seed: 7076349371981215213 }
+                                                                                }
+                                                                                variant_index: 0
+                                                                                args: []
+                                                                                user_ty: None
+                                                                                field 1:
+                                                                                    Expr {
+                                                                                        ty: u32
+                                                                                        temp_scope_id: 69
+                                                                                        span: $DIR/thir-tree-field-expr-index.rs:21:10: 21:11 (#0)
+                                                                                        kind: 
+                                                                                            Scope {
+                                                                                                region_scope: Node(69)
+                                                                                                hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).69)
+                                                                                                value:
+                                                                                                    Expr {
+                                                                                                        ty: u32
+                                                                                                        temp_scope_id: 69
+                                                                                                        span: $DIR/thir-tree-field-expr-index.rs:21:10: 21:11 (#0)
+                                                                                                        kind: 
+                                                                                                            VarRef {
+                                                                                                                id: LocalVarId(HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).2))
+                                                                                                            }
+                                                                                                    }
+                                                                                            }
+                                                                                    }
+                                                                                field 3:
+                                                                                    Expr {
+                                                                                        ty: u32
+                                                                                        temp_scope_id: 72
+                                                                                        span: $DIR/thir-tree-field-expr-index.rs:21:16: 21:17 (#0)
+                                                                                        kind: 
+                                                                                            Scope {
+                                                                                                region_scope: Node(72)
+                                                                                                hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).72)
+                                                                                                value:
+                                                                                                    Expr {
+                                                                                                        ty: u32
+                                                                                                        temp_scope_id: 72
+                                                                                                        span: $DIR/thir-tree-field-expr-index.rs:21:16: 21:17 (#0)
+                                                                                                        kind: 
+                                                                                                            VarRef {
+                                                                                                                id: LocalVarId(HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).2))
+                                                                                                            }
+                                                                                                    }
+                                                                                            }
+                                                                                    }
+                                                                                base:
+                                                                                    FruInfo {
+                                                                                        base: 
+                                                                                            Expr {
+                                                                                                ty: S
+                                                                                                temp_scope_id: 65
+                                                                                                span: $DIR/thir-tree-field-expr-index.rs:21:21: 21:22 (#0)
+                                                                                                kind: 
+                                                                                                    Scope {
+                                                                                                        region_scope: Node(65)
+                                                                                                        hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).65)
+                                                                                                        value:
+                                                                                                            Expr {
+                                                                                                                ty: S
+                                                                                                                temp_scope_id: 65
+                                                                                                                span: $DIR/thir-tree-field-expr-index.rs:21:21: 21:22 (#0)
+                                                                                                                kind: 
+                                                                                                                    VarRef {
+                                                                                                                        id: LocalVarId(HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).23))
+                                                                                                                    }
+                                                                                                            }
+                                                                                                    }
+                                                                                            }
+                                                                                        field_types: [
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                        ]
+                                                                                    }
+                                                                        }
+                                                                }
+                                                        }
+                                                }
+                                        }
+                                    }
+                                    Stmt {
+                                        kind: Expr {
+                                            scope: Node(88)
+                                            expr:
+                                                Expr {
+                                                    ty: S
+                                                    temp_scope_id: 75
+                                                    span: $DIR/thir-tree-field-expr-index.rs:22:3: 22:30 (#0)
+                                                    kind: 
+                                                        Scope {
+                                                            region_scope: Node(75)
+                                                            hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).75)
+                                                            value:
+                                                                Expr {
+                                                                    ty: S
+                                                                    temp_scope_id: 75
+                                                                    span: $DIR/thir-tree-field-expr-index.rs:22:3: 22:30 (#0)
+                                                                    kind: 
+                                                                        Adt {
+                                                                            adt_def:
+                                                                                AdtDef {
+                                                                                    did: DefId(0:3 ~ thir_tree_field_expr_index[5059]::S)
+                                                                                    variants: [VariantDef { def_id: DefId(0:3 ~ thir_tree_field_expr_index[5059]::S), ctor: None, name: "S", discr: Relative(0), fields: [FieldDef { did: DefId(0:4 ~ thir_tree_field_expr_index[5059]::S::a), name: "a", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:5 ~ thir_tree_field_expr_index[5059]::S::b), name: "b", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:6 ~ thir_tree_field_expr_index[5059]::S::c), name: "c", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:7 ~ thir_tree_field_expr_index[5059]::S::d), name: "d", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }, FieldDef { did: DefId(0:8 ~ thir_tree_field_expr_index[5059]::S::e), name: "e", vis: Restricted(DefId(0:0 ~ thir_tree_field_expr_index[5059])), safety: Safe, value: None }], tainted: None, flags:  }]
+                                                                                    flags: IS_STRUCT
+                                                                                    repr: ReprOptions { int: None, align: None, pack: None, flags: , scalable: None, field_shuffle_seed: 7076349371981215213 }
+                                                                                }
+                                                                                variant_index: 0
+                                                                                args: []
+                                                                                user_ty: None
+                                                                                field 0:
+                                                                                    Expr {
+                                                                                        ty: u32
+                                                                                        temp_scope_id: 80
+                                                                                        span: $DIR/thir-tree-field-expr-index.rs:22:10: 22:11 (#0)
+                                                                                        kind: 
+                                                                                            Scope {
+                                                                                                region_scope: Node(80)
+                                                                                                hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).80)
+                                                                                                value:
+                                                                                                    Expr {
+                                                                                                        ty: u32
+                                                                                                        temp_scope_id: 80
+                                                                                                        span: $DIR/thir-tree-field-expr-index.rs:22:10: 22:11 (#0)
+                                                                                                        kind: 
+                                                                                                            VarRef {
+                                                                                                                id: LocalVarId(HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).2))
+                                                                                                            }
+                                                                                                    }
+                                                                                            }
+                                                                                    }
+                                                                                field 2:
+                                                                                    Expr {
+                                                                                        ty: u32
+                                                                                        temp_scope_id: 83
+                                                                                        span: $DIR/thir-tree-field-expr-index.rs:22:16: 22:17 (#0)
+                                                                                        kind: 
+                                                                                            Scope {
+                                                                                                region_scope: Node(83)
+                                                                                                hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).83)
+                                                                                                value:
+                                                                                                    Expr {
+                                                                                                        ty: u32
+                                                                                                        temp_scope_id: 83
+                                                                                                        span: $DIR/thir-tree-field-expr-index.rs:22:16: 22:17 (#0)
+                                                                                                        kind: 
+                                                                                                            VarRef {
+                                                                                                                id: LocalVarId(HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).2))
+                                                                                                            }
+                                                                                                    }
+                                                                                            }
+                                                                                    }
+                                                                                field 4:
+                                                                                    Expr {
+                                                                                        ty: u32
+                                                                                        temp_scope_id: 86
+                                                                                        span: $DIR/thir-tree-field-expr-index.rs:22:22: 22:23 (#0)
+                                                                                        kind: 
+                                                                                            Scope {
+                                                                                                region_scope: Node(86)
+                                                                                                hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).86)
+                                                                                                value:
+                                                                                                    Expr {
+                                                                                                        ty: u32
+                                                                                                        temp_scope_id: 86
+                                                                                                        span: $DIR/thir-tree-field-expr-index.rs:22:22: 22:23 (#0)
+                                                                                                        kind: 
+                                                                                                            VarRef {
+                                                                                                                id: LocalVarId(HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).2))
+                                                                                                            }
+                                                                                                    }
+                                                                                            }
+                                                                                    }
+                                                                                base:
+                                                                                    FruInfo {
+                                                                                        base: 
+                                                                                            Expr {
+                                                                                                ty: S
+                                                                                                temp_scope_id: 76
+                                                                                                span: $DIR/thir-tree-field-expr-index.rs:22:27: 22:28 (#0)
+                                                                                                kind: 
+                                                                                                    Scope {
+                                                                                                        region_scope: Node(76)
+                                                                                                        hir_id: HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).76)
+                                                                                                        value:
+                                                                                                            Expr {
+                                                                                                                ty: S
+                                                                                                                temp_scope_id: 76
+                                                                                                                span: $DIR/thir-tree-field-expr-index.rs:22:27: 22:28 (#0)
+                                                                                                                kind: 
+                                                                                                                    VarRef {
+                                                                                                                        id: LocalVarId(HirId(DefId(0:9 ~ thir_tree_field_expr_index[5059]::update).23))
+                                                                                                                    }
+                                                                                                            }
+                                                                                                    }
+                                                                                            }
+                                                                                        field_types: [
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                            ty: u32
+                                                                                        ]
+                                                                                    }
+                                                                        }
+                                                                }
+                                                        }
+                                                }
+                                        }
+                                    }
+                                ]
+                                expr: []
+                            }
+                    }
+            }
+    }
+
+
+DefId(0:10 ~ thir_tree_field_expr_index[5059]::main):
+params: [
+]
+body:
+    Expr {
+        ty: ()
+        temp_scope_id: 2
+        span: $DIR/thir-tree-field-expr-index.rs:25:11: 25:13 (#0)
+        kind: 
+            Scope {
+                region_scope: Node(2)
+                hir_id: HirId(DefId(0:10 ~ thir_tree_field_expr_index[5059]::main).2)
+                value:
+                    Expr {
+                        ty: ()
+                        temp_scope_id: 2
+                        span: $DIR/thir-tree-field-expr-index.rs:25:11: 25:13 (#0)
+                        kind: 
+                            Block {
+                                targeted_by_break: false
+                                span: $DIR/thir-tree-field-expr-index.rs:25:11: 25:13 (#0)
+                                region_scope: Node(1)
+                                safety_mode: Safe
+                                stmts: []
+                                expr: []
+                            }
+                    }
+            }
+    }
+
+

--- a/tests/ui/thir-print/thir-tree-loop-match.stdout
+++ b/tests/ui/thir-print/thir-tree-loop-match.stdout
@@ -6,7 +6,7 @@ params: [
         self_kind: None
         hir_id: Some(HirId(DefId(0:3 ~ thir_tree_loop_match[3c53]::boolean).1))
         param: Some( 
-            Pat: {
+            Pat {
                 ty: bool
                 span: $DIR/thir-tree-loop-match.rs:7:12: 7:21 (#0)
                 kind: PatKind {
@@ -117,7 +117,7 @@ body:
                                                                                         arms: [
                                                                                             Arm {
                                                                                                 pattern: 
-                                                                                                    Pat: {
+                                                                                                    Pat {
                                                                                                         ty: bool
                                                                                                         span: $DIR/thir-tree-loop-match.rs:12:17: 12:21 (#0)
                                                                                                         kind: PatKind {
@@ -215,7 +215,7 @@ body:
                                                                                             }
                                                                                             Arm {
                                                                                                 pattern: 
-                                                                                                    Pat: {
+                                                                                                    Pat {
                                                                                                         ty: bool
                                                                                                         span: $DIR/thir-tree-loop-match.rs:16:17: 16:22 (#0)
                                                                                                         kind: PatKind {

--- a/tests/ui/thir-print/thir-tree-match.stdout
+++ b/tests/ui/thir-print/thir-tree-match.stdout
@@ -6,7 +6,7 @@ params: [
         self_kind: None
         hir_id: Some(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).1))
         param: Some( 
-            Pat: {
+            Pat {
                 ty: Foo
                 span: $DIR/thir-tree-match.rs:15:14: 15:17 (#0)
                 kind: PatKind {
@@ -85,7 +85,7 @@ body:
                                                                 arms: [
                                                                     Arm {
                                                                         pattern: 
-                                                                            Pat: {
+                                                                            Pat {
                                                                                 ty: Foo
                                                                                 span: $DIR/thir-tree-match.rs:17:9: 17:32 (#0)
                                                                                 kind: PatKind {
@@ -96,10 +96,11 @@ body:
                                                                                                 variants: [VariantDef { def_id: DefId(0:11 ~ thir_tree_match[fcf8]::Foo::FooOne), ctor: Some((Fn, DefId(0:12 ~ thir_tree_match[fcf8]::Foo::FooOne::{constructor#0}))), name: "FooOne", discr: Relative(0), fields: [FieldDef { did: DefId(0:13 ~ thir_tree_match[fcf8]::Foo::FooOne::0), name: "0", vis: Restricted(DefId(0:0 ~ thir_tree_match[fcf8])), safety: Safe, value: None }], tainted: None, flags:  }, VariantDef { def_id: DefId(0:14 ~ thir_tree_match[fcf8]::Foo::FooTwo), ctor: Some((Const, DefId(0:15 ~ thir_tree_match[fcf8]::Foo::FooTwo::{constructor#0}))), name: "FooTwo", discr: Relative(1), fields: [], tainted: None, flags:  }]
                                                                                                 flags: IS_ENUM
                                                                                                 repr: ReprOptions { int: None, align: None, pack: None, flags: , scalable: None, field_shuffle_seed: 13397682652773712997 }
+                                                                                            }
                                                                                         args: []
                                                                                         variant_index: 0
                                                                                         subpatterns: [
-                                                                                            Pat: {
+                                                                                            Pat {
                                                                                                 ty: Bar
                                                                                                 span: $DIR/thir-tree-match.rs:17:21: 17:31 (#0)
                                                                                                 kind: PatKind {
@@ -110,6 +111,7 @@ body:
                                                                                                                 variants: [VariantDef { def_id: DefId(0:4 ~ thir_tree_match[fcf8]::Bar::First), ctor: Some((Const, DefId(0:5 ~ thir_tree_match[fcf8]::Bar::First::{constructor#0}))), name: "First", discr: Relative(0), fields: [], tainted: None, flags:  }, VariantDef { def_id: DefId(0:6 ~ thir_tree_match[fcf8]::Bar::Second), ctor: Some((Const, DefId(0:7 ~ thir_tree_match[fcf8]::Bar::Second::{constructor#0}))), name: "Second", discr: Relative(1), fields: [], tainted: None, flags:  }, VariantDef { def_id: DefId(0:8 ~ thir_tree_match[fcf8]::Bar::Third), ctor: Some((Const, DefId(0:9 ~ thir_tree_match[fcf8]::Bar::Third::{constructor#0}))), name: "Third", discr: Relative(2), fields: [], tainted: None, flags:  }]
                                                                                                                 flags: IS_ENUM
                                                                                                                 repr: ReprOptions { int: None, align: None, pack: None, flags: , scalable: None, field_shuffle_seed: 7908585036048874241 }
+                                                                                                            }
                                                                                                         args: []
                                                                                                         variant_index: 0
                                                                                                         subpatterns: []
@@ -147,7 +149,7 @@ body:
                                                                     }
                                                                     Arm {
                                                                         pattern: 
-                                                                            Pat: {
+                                                                            Pat {
                                                                                 ty: Foo
                                                                                 span: $DIR/thir-tree-match.rs:18:9: 18:23 (#0)
                                                                                 kind: PatKind {
@@ -158,10 +160,11 @@ body:
                                                                                                 variants: [VariantDef { def_id: DefId(0:11 ~ thir_tree_match[fcf8]::Foo::FooOne), ctor: Some((Fn, DefId(0:12 ~ thir_tree_match[fcf8]::Foo::FooOne::{constructor#0}))), name: "FooOne", discr: Relative(0), fields: [FieldDef { did: DefId(0:13 ~ thir_tree_match[fcf8]::Foo::FooOne::0), name: "0", vis: Restricted(DefId(0:0 ~ thir_tree_match[fcf8])), safety: Safe, value: None }], tainted: None, flags:  }, VariantDef { def_id: DefId(0:14 ~ thir_tree_match[fcf8]::Foo::FooTwo), ctor: Some((Const, DefId(0:15 ~ thir_tree_match[fcf8]::Foo::FooTwo::{constructor#0}))), name: "FooTwo", discr: Relative(1), fields: [], tainted: None, flags:  }]
                                                                                                 flags: IS_ENUM
                                                                                                 repr: ReprOptions { int: None, align: None, pack: None, flags: , scalable: None, field_shuffle_seed: 13397682652773712997 }
+                                                                                            }
                                                                                         args: []
                                                                                         variant_index: 0
                                                                                         subpatterns: [
-                                                                                            Pat: {
+                                                                                            Pat {
                                                                                                 ty: Bar
                                                                                                 span: $DIR/thir-tree-match.rs:18:21: 18:22 (#0)
                                                                                                 kind: PatKind {
@@ -199,7 +202,7 @@ body:
                                                                     }
                                                                     Arm {
                                                                         pattern: 
-                                                                            Pat: {
+                                                                            Pat {
                                                                                 ty: Foo
                                                                                 span: $DIR/thir-tree-match.rs:19:9: 19:20 (#0)
                                                                                 kind: PatKind {
@@ -210,6 +213,7 @@ body:
                                                                                                 variants: [VariantDef { def_id: DefId(0:11 ~ thir_tree_match[fcf8]::Foo::FooOne), ctor: Some((Fn, DefId(0:12 ~ thir_tree_match[fcf8]::Foo::FooOne::{constructor#0}))), name: "FooOne", discr: Relative(0), fields: [FieldDef { did: DefId(0:13 ~ thir_tree_match[fcf8]::Foo::FooOne::0), name: "0", vis: Restricted(DefId(0:0 ~ thir_tree_match[fcf8])), safety: Safe, value: None }], tainted: None, flags:  }, VariantDef { def_id: DefId(0:14 ~ thir_tree_match[fcf8]::Foo::FooTwo), ctor: Some((Const, DefId(0:15 ~ thir_tree_match[fcf8]::Foo::FooTwo::{constructor#0}))), name: "FooTwo", discr: Relative(1), fields: [], tainted: None, flags:  }]
                                                                                                 flags: IS_ENUM
                                                                                                 repr: ReprOptions { int: None, align: None, pack: None, flags: , scalable: None, field_shuffle_seed: 13397682652773712997 }
+                                                                                            }
                                                                                         args: []
                                                                                         variant_index: 1
                                                                                         subpatterns: []

--- a/tests/ui/unpretty/box.stdout
+++ b/tests/ui/unpretty/box.stdout
@@ -27,7 +27,7 @@ body:
                                             remainder_scope: Remainder { block: 1, first_statement_index: 0}
                                             init_scope: Node(2)
                                             pattern: 
-                                                Pat: {
+                                                Pat {
                                                     ty: std::boxed::Box<i32, std::alloc::Global>
                                                     span: $DIR/box.rs:7:9: 7:10 (#0)
                                                     kind: PatKind {


### PR DESCRIPTION
Closing brackets were missing on AdtDef, the field_types list in FruInfo, and InlineAsmExpr, breaking folding in some editors; Fields were incorrectly (?) indexed in the list for functional update syntax, showing the (implicit, irrelevant) iteration index instead of the field index; also spurious colon after Pat.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
