### PR TITLE
remove multiple unhelpful `reason = "..."` values from `#[unstable(...)]` invocations

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1313,7 +1313,7 @@ impl<T: ?Sized> Box<T> {
     /// ```
     ///
     /// [memory layout]: self#memory-layout
-    #[unstable(feature = "box_vec_non_null", reason = "new API", issue = "130364")]
+    #[unstable(feature = "box_vec_non_null", issue = "130364")]
     #[inline]
     #[must_use = "call `drop(Box::from_non_null(ptr))` if you intend to drop the `Box`"]
     pub unsafe fn from_non_null(ptr: NonNull<T>) -> Self {
@@ -1431,7 +1431,7 @@ impl<T: ?Sized> Box<T> {
     ///
     /// [memory layout]: self#memory-layout
     #[must_use = "losing the pointer will leak memory"]
-    #[unstable(feature = "box_vec_non_null", reason = "new API", issue = "130364")]
+    #[unstable(feature = "box_vec_non_null", issue = "130364")]
     #[inline]
     pub fn into_non_null(b: Self) -> NonNull<T> {
         // SAFETY: `Box` is guaranteed to be non-null.
@@ -1540,7 +1540,7 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     ///
     /// [memory layout]: self#memory-layout
     #[unstable(feature = "allocator_api", issue = "32838")]
-    // #[unstable(feature = "box_vec_non_null", reason = "new API", issue = "130364")]
+    // #[unstable(feature = "box_vec_non_null", issue = "130364")]
     #[inline]
     pub unsafe fn from_non_null_in(raw: NonNull<T>, alloc: A) -> Self {
         // SAFETY: guaranteed by the caller.
@@ -1655,7 +1655,7 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// [memory layout]: self#memory-layout
     #[must_use = "losing the pointer will leak memory"]
     #[unstable(feature = "allocator_api", issue = "32838")]
-    // #[unstable(feature = "box_vec_non_null", reason = "new API", issue = "130364")]
+    // #[unstable(feature = "box_vec_non_null", issue = "130364")]
     #[inline]
     pub fn into_non_null_with_allocator(b: Self) -> (NonNull<T>, A) {
         let (ptr, alloc) = Box::into_raw_with_allocator(b);

--- a/library/alloc/src/collections/mod.rs
+++ b/library/alloc/src/collections/mod.rs
@@ -156,7 +156,7 @@ impl const From<TryReserveErrorKind> for TryReserveError {
     }
 }
 
-#[unstable(feature = "try_reserve_kind", reason = "new API", issue = "48043")]
+#[unstable(feature = "try_reserve_kind", issue = "48043")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 #[cfg(not(test))]
 impl const From<LayoutError> for TryReserveErrorKind {

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -1563,7 +1563,7 @@ impl String {
     /// assert_eq!("bna", s);
     /// ```
     #[cfg(not(no_global_oom_handling))]
-    #[unstable(feature = "string_remove_matches", reason = "new API", issue = "72826")]
+    #[unstable(feature = "string_remove_matches", issue = "72826")]
     pub fn remove_matches<P: Pattern>(&mut self, pat: P) {
         use core::str::pattern::Searcher;
 

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -743,7 +743,7 @@ impl<T> Vec<T> {
     /// }
     /// ```
     #[inline]
-    #[unstable(feature = "box_vec_non_null", reason = "new API", issue = "130364")]
+    #[unstable(feature = "box_vec_non_null", issue = "130364")]
     pub unsafe fn from_parts(ptr: NonNull<T>, length: usize, capacity: usize) -> Self {
         unsafe { Self::from_parts_in(ptr, length, capacity, Global) }
     }
@@ -793,7 +793,7 @@ impl<T> Vec<T> {
     /// ```
     #[cfg(not(no_global_oom_handling))]
     #[inline]
-    #[unstable(feature = "vec_from_fn", reason = "new API", issue = "149698")]
+    #[unstable(feature = "vec_from_fn", issue = "149698")]
     pub fn from_fn<F>(length: usize, f: F) -> Self
     where
         F: FnMut(usize) -> T,
@@ -878,7 +878,7 @@ impl<T> Vec<T> {
     /// assert_eq!(rebuilt, [4294967295, 0, 1]);
     /// ```
     #[must_use = "losing the pointer will leak memory"]
-    #[unstable(feature = "box_vec_non_null", reason = "new API", issue = "130364")]
+    #[unstable(feature = "box_vec_non_null", issue = "130364")]
     pub fn into_parts(self) -> (NonNull<T>, usize, usize) {
         let (ptr, len, capacity) = self.into_raw_parts();
         // SAFETY: A `Vec` always has a non-null pointer.
@@ -1291,7 +1291,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// }
     /// ```
     #[inline]
-    #[unstable(feature = "allocator_api", reason = "new API", issue = "32838")]
+    #[unstable(feature = "allocator_api", issue = "32838")]
     // #[unstable(feature = "box_vec_non_null", issue = "130364")]
     pub unsafe fn from_parts_in(ptr: NonNull<T>, length: usize, capacity: usize, alloc: A) -> Self {
         ub_checks::assert_unsafe_precondition!(
@@ -1390,7 +1390,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// ```
     #[must_use = "losing the pointer will leak memory"]
     #[unstable(feature = "allocator_api", issue = "32838")]
-    // #[unstable(feature = "box_vec_non_null", reason = "new API", issue = "130364")]
+    // #[unstable(feature = "box_vec_non_null", issue = "130364")]
     pub fn into_parts_with_alloc(self) -> (NonNull<T>, usize, usize, A) {
         let (ptr, len, capacity, alloc) = self.into_raw_parts_with_alloc();
         // SAFETY: A `Vec` always has a non-null pointer.
@@ -1994,8 +1994,8 @@ impl<T, A: Allocator> Vec<T, A> {
     /// [`as_mut_ptr`]: Vec::as_mut_ptr
     /// [`as_ptr`]: Vec::as_ptr
     /// [`as_non_null`]: Vec::as_non_null
-    #[unstable(feature = "box_vec_non_null", reason = "new API", issue = "130364")]
-    #[rustc_const_unstable(feature = "box_vec_non_null", reason = "new API", issue = "130364")]
+    #[unstable(feature = "box_vec_non_null", issue = "130364")]
+    #[rustc_const_unstable(feature = "box_vec_non_null", issue = "130364")]
     #[inline]
     pub const fn as_non_null(&mut self) -> NonNull<T> {
         self.buf.non_null()

--- a/library/core/src/iter/adapters/array_chunks.rs
+++ b/library/core/src/iter/adapters/array_chunks.rs
@@ -15,7 +15,7 @@ use crate::ops::{ControlFlow, NeverShortCircuit, Try};
 /// method on [`Iterator`]. See its documentation for more.
 #[derive(Debug, Clone)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
-#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
+#[unstable(feature = "iter_array_chunks", issue = "100450")]
 pub struct ArrayChunks<I: Iterator, const N: usize> {
     iter: I,
     remainder: Option<array::IntoIter<I::Item, N>>,
@@ -44,7 +44,7 @@ where
     /// assert_eq!(rem.next(), Some(5));
     /// assert_eq!(rem.next(), None);
     /// ```
-    #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
+    #[unstable(feature = "iter_array_chunks", issue = "100450")]
     #[inline]
     pub fn into_remainder(mut self) -> array::IntoIter<I::Item, N> {
         if self.remainder.is_none() {
@@ -54,7 +54,7 @@ where
     }
 }
 
-#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
+#[unstable(feature = "iter_array_chunks", issue = "100450")]
 impl<I, const N: usize> Iterator for ArrayChunks<I, N>
 where
     I: Iterator,
@@ -108,7 +108,7 @@ where
     }
 }
 
-#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
+#[unstable(feature = "iter_array_chunks", issue = "100450")]
 impl<I, const N: usize> DoubleEndedIterator for ArrayChunks<I, N>
 where
     I: DoubleEndedIterator + ExactSizeIterator,
@@ -173,13 +173,13 @@ where
     }
 }
 
-#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
+#[unstable(feature = "iter_array_chunks", issue = "100450")]
 impl<I, const N: usize> FusedIterator for ArrayChunks<I, N> where I: FusedIterator {}
 
 #[unstable(issue = "none", feature = "trusted_fused")]
 unsafe impl<I, const N: usize> TrustedFused for ArrayChunks<I, N> where I: TrustedFused + Iterator {}
 
-#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
+#[unstable(feature = "iter_array_chunks", issue = "100450")]
 impl<I, const N: usize> ExactSizeIterator for ArrayChunks<I, N>
 where
     I: ExactSizeIterator,

--- a/library/core/src/iter/adapters/intersperse.rs
+++ b/library/core/src/iter/adapters/intersperse.rs
@@ -5,7 +5,7 @@ use crate::iter::{Fuse, FusedIterator};
 ///
 /// This `struct` is created by [`Iterator::intersperse`]. See its documentation
 /// for more information.
-#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
+#[unstable(feature = "iter_intersperse", issue = "79524")]
 #[derive(Debug, Clone)]
 pub struct Intersperse<I: Iterator>
 where
@@ -17,7 +17,7 @@ where
     iter: Fuse<I>,
 }
 
-#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
+#[unstable(feature = "iter_intersperse", issue = "79524")]
 impl<I> FusedIterator for Intersperse<I>
 where
     I: FusedIterator,
@@ -34,7 +34,7 @@ where
     }
 }
 
-#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
+#[unstable(feature = "iter_intersperse", issue = "79524")]
 impl<I> Iterator for Intersperse<I>
 where
     I: Iterator,
@@ -87,7 +87,7 @@ where
 ///
 /// This `struct` is created by [`Iterator::intersperse_with`]. See its
 /// documentation for more information.
-#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
+#[unstable(feature = "iter_intersperse", issue = "79524")]
 pub struct IntersperseWith<I, G>
 where
     I: Iterator,
@@ -98,7 +98,7 @@ where
     iter: Fuse<I>,
 }
 
-#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
+#[unstable(feature = "iter_intersperse", issue = "79524")]
 impl<I, G> FusedIterator for IntersperseWith<I, G>
 where
     I: FusedIterator,
@@ -106,7 +106,7 @@ where
 {
 }
 
-#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
+#[unstable(feature = "iter_intersperse", issue = "79524")]
 impl<I, G> fmt::Debug for IntersperseWith<I, G>
 where
     I: Iterator + fmt::Debug,
@@ -123,7 +123,7 @@ where
     }
 }
 
-#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
+#[unstable(feature = "iter_intersperse", issue = "79524")]
 impl<I, G> Clone for IntersperseWith<I, G>
 where
     I: Iterator + Clone,
@@ -150,7 +150,7 @@ where
     }
 }
 
-#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
+#[unstable(feature = "iter_intersperse", issue = "79524")]
 impl<I, G> Iterator for IntersperseWith<I, G>
 where
     I: Iterator,

--- a/library/core/src/iter/adapters/map_windows.rs
+++ b/library/core/src/iter/adapters/map_windows.rs
@@ -7,7 +7,7 @@ use crate::{fmt, ptr};
 /// This `struct` is created by the [`Iterator::map_windows`]. See its
 /// documentation for more information.
 #[must_use = "iterators are lazy and do nothing unless consumed"]
-#[unstable(feature = "iter_map_windows", reason = "recently added", issue = "87155")]
+#[unstable(feature = "iter_map_windows", issue = "87155")]
 pub struct MapWindows<I: Iterator, F, const N: usize> {
     f: F,
     inner: MapWindowsInner<I, N>,
@@ -234,7 +234,7 @@ impl<T, const N: usize> Drop for Buffer<T, N> {
     }
 }
 
-#[unstable(feature = "iter_map_windows", reason = "recently added", issue = "87155")]
+#[unstable(feature = "iter_map_windows", issue = "87155")]
 impl<I, F, R, const N: usize> Iterator for MapWindows<I, F, N>
 where
     I: Iterator,
@@ -255,7 +255,7 @@ where
 
 // Note that even if the inner iterator not fused, the `MapWindows` is still fused,
 // because we don't allow "holes" in the mapping window.
-#[unstable(feature = "iter_map_windows", reason = "recently added", issue = "87155")]
+#[unstable(feature = "iter_map_windows", issue = "87155")]
 impl<I, F, R, const N: usize> FusedIterator for MapWindows<I, F, N>
 where
     I: Iterator,
@@ -263,7 +263,7 @@ where
 {
 }
 
-#[unstable(feature = "iter_map_windows", reason = "recently added", issue = "87155")]
+#[unstable(feature = "iter_map_windows", issue = "87155")]
 impl<I, F, R, const N: usize> ExactSizeIterator for MapWindows<I, F, N>
 where
     I: ExactSizeIterator,
@@ -271,14 +271,14 @@ where
 {
 }
 
-#[unstable(feature = "iter_map_windows", reason = "recently added", issue = "87155")]
+#[unstable(feature = "iter_map_windows", issue = "87155")]
 impl<I: Iterator + fmt::Debug, F, const N: usize> fmt::Debug for MapWindows<I, F, N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MapWindows").field("iter", &self.inner.iter).finish()
     }
 }
 
-#[unstable(feature = "iter_map_windows", reason = "recently added", issue = "87155")]
+#[unstable(feature = "iter_map_windows", issue = "87155")]
 impl<I, F, const N: usize> Clone for MapWindows<I, F, N>
 where
     I: Iterator + Clone,

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -28,7 +28,7 @@ mod take;
 mod take_while;
 mod zip;
 
-#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
+#[unstable(feature = "iter_array_chunks", issue = "100450")]
 pub use self::array_chunks::ArrayChunks;
 #[unstable(feature = "std_internals", issue = "none")]
 pub use self::by_ref_sized::ByRefSized;
@@ -40,11 +40,11 @@ pub use self::cloned::Cloned;
 pub use self::copied::Copied;
 #[stable(feature = "iterator_flatten", since = "1.29.0")]
 pub use self::flatten::Flatten;
-#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
+#[unstable(feature = "iter_intersperse", issue = "79524")]
 pub use self::intersperse::{Intersperse, IntersperseWith};
 #[stable(feature = "iter_map_while", since = "1.57.0")]
 pub use self::map_while::MapWhile;
-#[unstable(feature = "iter_map_windows", reason = "recently added", issue = "87155")]
+#[unstable(feature = "iter_map_windows", issue = "87155")]
 pub use self::map_windows::MapWindows;
 #[stable(feature = "iterator_step_by", since = "1.28.0")]
 pub use self::step_by::StepBy;

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -382,7 +382,7 @@ macro_rules! impl_fold_via_try_fold {
     };
 }
 
-#[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
+#[unstable(feature = "iter_array_chunks", issue = "100450")]
 pub use self::adapters::ArrayChunks;
 #[unstable(feature = "std_internals", issue = "none")]
 pub use self::adapters::ByRefSized;
@@ -394,7 +394,7 @@ pub use self::adapters::Copied;
 pub use self::adapters::Flatten;
 #[stable(feature = "iter_map_while", since = "1.57.0")]
 pub use self::adapters::MapWhile;
-#[unstable(feature = "iter_map_windows", reason = "recently added", issue = "87155")]
+#[unstable(feature = "iter_map_windows", issue = "87155")]
 pub use self::adapters::MapWindows;
 #[unstable(feature = "inplace_iteration", issue = "none")]
 pub use self::adapters::SourceIter;
@@ -414,7 +414,7 @@ pub use self::adapters::{
     Chain, Cycle, Enumerate, Filter, FilterMap, FlatMap, Fuse, Inspect, Map, Peekable, Rev, Scan,
     Skip, SkipWhile, Take, TakeWhile, Zip,
 };
-#[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
+#[unstable(feature = "iter_intersperse", issue = "79524")]
 pub use self::adapters::{Intersperse, IntersperseWith};
 #[unstable(
     feature = "step_trait",

--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -254,7 +254,7 @@ macro_rules! step_integer_impls {
     } => {
         $(
             #[allow(unreachable_patterns)]
-            #[unstable(feature = "step_trait", reason = "recently redesigned", issue = "42168")]
+            #[unstable(feature = "step_trait", issue = "42168")]
             impl Step for $u_narrower {
                 step_identical_methods!();
                 step_unsigned_methods!();
@@ -288,7 +288,7 @@ macro_rules! step_integer_impls {
             }
 
             #[allow(unreachable_patterns)]
-            #[unstable(feature = "step_trait", reason = "recently redesigned", issue = "42168")]
+            #[unstable(feature = "step_trait", issue = "42168")]
             impl Step for $i_narrower {
                 step_identical_methods!();
                 step_signed_methods!($u_narrower);
@@ -354,7 +354,7 @@ macro_rules! step_integer_impls {
 
         $(
             #[allow(unreachable_patterns)]
-            #[unstable(feature = "step_trait", reason = "recently redesigned", issue = "42168")]
+            #[unstable(feature = "step_trait", issue = "42168")]
             impl Step for $u_wider {
                 step_identical_methods!();
                 step_unsigned_methods!();
@@ -384,7 +384,7 @@ macro_rules! step_integer_impls {
             }
 
             #[allow(unreachable_patterns)]
-            #[unstable(feature = "step_trait", reason = "recently redesigned", issue = "42168")]
+            #[unstable(feature = "step_trait", issue = "42168")]
             impl Step for $i_wider {
                 step_identical_methods!();
                 step_signed_methods!($u_wider);
@@ -441,7 +441,7 @@ step_integer_impls! {
     wider than usize: [u32 i32], [u64 i64], [u128 i128];
 }
 
-#[unstable(feature = "step_trait", reason = "recently redesigned", issue = "42168")]
+#[unstable(feature = "step_trait", issue = "42168")]
 impl Step for char {
     #[inline]
     fn steps_between(&start: &char, &end: &char) -> (usize, Option<usize>) {
@@ -528,7 +528,7 @@ impl Step for char {
     }
 }
 
-#[unstable(feature = "step_trait", reason = "recently redesigned", issue = "42168")]
+#[unstable(feature = "step_trait", issue = "42168")]
 impl Step for AsciiChar {
     #[inline]
     fn steps_between(&start: &AsciiChar, &end: &AsciiChar) -> (usize, Option<usize>) {
@@ -570,7 +570,7 @@ impl Step for AsciiChar {
     }
 }
 
-#[unstable(feature = "step_trait", reason = "recently redesigned", issue = "42168")]
+#[unstable(feature = "step_trait", issue = "42168")]
 impl Step for Ipv4Addr {
     #[inline]
     fn steps_between(&start: &Ipv4Addr, &end: &Ipv4Addr) -> (usize, Option<usize>) {
@@ -602,7 +602,7 @@ impl Step for Ipv4Addr {
     }
 }
 
-#[unstable(feature = "step_trait", reason = "recently redesigned", issue = "42168")]
+#[unstable(feature = "step_trait", issue = "42168")]
 impl Step for Ipv6Addr {
     #[inline]
     fn steps_between(&start: &Ipv6Addr, &end: &Ipv6Addr) -> (usize, Option<usize>) {

--- a/library/core/src/iter/traits/double_ended.rs
+++ b/library/core/src/iter/traits/double_ended.rs
@@ -134,7 +134,7 @@ pub trait DoubleEndedIterator: Iterator {
     /// [`Ok(())`]: Ok
     /// [`Err(k)`]: Err
     #[inline]
-    #[unstable(feature = "iter_advance_by", reason = "recently added", issue = "77404")]
+    #[unstable(feature = "iter_advance_by", issue = "77404")]
     fn advance_back_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
         for i in 0..n {
             if self.next_back().is_none() {

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -2177,7 +2177,7 @@ pub trait Iterator {
     /// assert_eq!(vec, vec![1, 2, 3, 1, 2, 3]);
     /// ```
     #[inline]
-    #[unstable(feature = "iter_collect_into", reason = "new API", issue = "94780")]
+    #[unstable(feature = "iter_collect_into", issue = "94780")]
     fn collect_into<E: Extend<Self::Item>>(self, collection: &mut E) -> &mut E
     where
         Self: Sized,
@@ -2271,7 +2271,7 @@ pub trait Iterator {
     /// assert!(a[..i].iter().all(|n| n % 2 == 0)); // evens
     /// assert!(a[i..].iter().all(|n| n % 2 == 1)); // odds
     /// ```
-    #[unstable(feature = "iter_partition_in_place", reason = "new API", issue = "62543")]
+    #[unstable(feature = "iter_partition_in_place", issue = "62543")]
     fn partition_in_place<'a, T: 'a, P>(mut self, ref mut predicate: P) -> usize
     where
         Self: Sized + DoubleEndedIterator<Item = &'a mut T>,
@@ -2328,7 +2328,7 @@ pub trait Iterator {
     /// assert!("Iterator".chars().is_partitioned(char::is_uppercase));
     /// assert!(!"IntoIterator".chars().is_partitioned(char::is_uppercase));
     /// ```
-    #[unstable(feature = "iter_is_partitioned", reason = "new API", issue = "62544")]
+    #[unstable(feature = "iter_is_partitioned", issue = "62544")]
     fn is_partitioned<P>(mut self, mut predicate: P) -> bool
     where
         Self: Sized,
@@ -2707,7 +2707,7 @@ pub trait Iterator {
     /// assert_eq!(max, Ok(Some("5")));
     /// ```
     #[inline]
-    #[unstable(feature = "iterator_try_reduce", reason = "new API", issue = "87053")]
+    #[unstable(feature = "iterator_try_reduce", issue = "87053")]
     fn try_reduce<R>(
         &mut self,
         f: impl FnMut(Self::Item, Self::Item) -> R,
@@ -2980,7 +2980,7 @@ pub trait Iterator {
     /// assert_eq!(result, None);
     /// ```
     #[inline]
-    #[unstable(feature = "try_find", reason = "new API", issue = "63178")]
+    #[unstable(feature = "try_find", issue = "63178")]
     fn try_find<R>(
         &mut self,
         f: impl FnMut(&Self::Item) -> R,

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -106,7 +106,7 @@ pub trait Iterator {
     /// assert_eq!(third, "those");
     /// ```
     #[inline]
-    #[unstable(feature = "iter_next_chunk", reason = "recently added", issue = "98326")]
+    #[unstable(feature = "iter_next_chunk", issue = "98326")]
     fn next_chunk<const N: usize>(
         &mut self,
     ) -> Result<[Self::Item; N], array::IntoIter<Self::Item, N>>
@@ -297,7 +297,7 @@ pub trait Iterator {
     /// assert_eq!(iter.advance_by(100), Err(NonZero::new(99).unwrap())); // only `4` was skipped
     /// ```
     #[inline]
-    #[unstable(feature = "iter_advance_by", reason = "recently added", issue = "77404")]
+    #[unstable(feature = "iter_advance_by", issue = "77404")]
     fn advance_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
         /// Helper trait to specialize `advance_by` via `try_fold` for `Sized` iterators.
         trait SpecAdvanceBy {
@@ -656,7 +656,7 @@ pub trait Iterator {
     /// [`Clone`]: crate::clone::Clone
     /// [`intersperse_with`]: Iterator::intersperse_with
     #[inline]
-    #[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
+    #[unstable(feature = "iter_intersperse", issue = "79524")]
     fn intersperse(self, separator: Self::Item) -> Intersperse<Self>
     where
         Self: Sized,
@@ -714,7 +714,7 @@ pub trait Iterator {
     /// [`Clone`]: crate::clone::Clone
     /// [`intersperse`]: Iterator::intersperse
     #[inline]
-    #[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
+    #[unstable(feature = "iter_intersperse", issue = "79524")]
     fn intersperse_with<G>(self, separator: G) -> IntersperseWith<Self, G>
     where
         Self: Sized,
@@ -1713,7 +1713,7 @@ pub trait Iterator {
     /// assert_eq!(iter.next(), None);
     /// ```
     #[inline]
-    #[unstable(feature = "iter_map_windows", reason = "recently added", issue = "87155")]
+    #[unstable(feature = "iter_map_windows", issue = "87155")]
     fn map_windows<F, R, const N: usize>(self, f: F) -> MapWindows<Self, F, N>
     where
         Self: Sized,
@@ -3554,7 +3554,7 @@ pub trait Iterator {
     /// }
     /// ```
     #[track_caller]
-    #[unstable(feature = "iter_array_chunks", reason = "recently added", issue = "100450")]
+    #[unstable(feature = "iter_array_chunks", issue = "100450")]
     fn array_chunks<const N: usize>(self) -> ArrayChunks<Self, N>
     where
         Self: Sized,

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2431,7 +2431,7 @@ pub trait BufRead: Read {
     /// }
     /// # std::io::Result::Ok(())
     /// ```
-    #[unstable(feature = "buf_read_has_data_left", reason = "recently added", issue = "86423")]
+    #[unstable(feature = "buf_read_has_data_left", issue = "86423")]
     fn has_data_left(&mut self) -> Result<bool> {
         self.fill_buf().map(|b| !b.is_empty())
     }

--- a/library/std/src/os/unix/io/mod.rs
+++ b/library/std/src/os/unix/io/mod.rs
@@ -102,7 +102,7 @@ use crate::sys::cvt;
 #[cfg(test)]
 mod tests;
 
-#[unstable(feature = "stdio_swap", issue = "150667", reason = "recently added")]
+#[unstable(feature = "stdio_swap", issue = "150667")]
 pub trait StdioExt: crate::sealed::Sealed {
     /// Redirects the stdio file descriptor to point to the file description underpinning `fd`.
     ///
@@ -159,7 +159,7 @@ pub trait StdioExt: crate::sealed::Sealed {
 }
 
 macro io_ext_impl($stdio_ty:ty, $stdio_lock_ty:ty, $writer:literal) {
-    #[unstable(feature = "stdio_swap", issue = "150667", reason = "recently added")]
+    #[unstable(feature = "stdio_swap", issue = "150667")]
     impl StdioExt for $stdio_ty {
         fn set_fd<T: Into<OwnedFd>>(&mut self, fd: T) -> io::Result<()> {
             self.lock().set_fd(fd)
@@ -174,7 +174,7 @@ macro io_ext_impl($stdio_ty:ty, $stdio_lock_ty:ty, $writer:literal) {
         }
     }
 
-    #[unstable(feature = "stdio_swap", issue = "150667", reason = "recently added")]
+    #[unstable(feature = "stdio_swap", issue = "150667")]
     impl StdioExt for $stdio_lock_ty {
         fn set_fd<T: Into<OwnedFd>>(&mut self, fd: T) -> io::Result<()> {
             #[cfg($writer)]

--- a/library/std/src/os/unix/net/mod.rs
+++ b/library/std/src/os/unix/net/mod.rs
@@ -47,5 +47,5 @@ pub use self::stream::*;
     target_vendor = "apple",
     target_os = "cygwin",
 ))]
-#[unstable(feature = "peer_credentials_unix_socket", issue = "42839", reason = "unstable")]
+#[unstable(feature = "peer_credentials_unix_socket", issue = "42839")]
 pub use self::ucred::*;

--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -251,7 +251,7 @@ impl UnixStream {
     ///     Ok(())
     /// }
     /// ```
-    #[unstable(feature = "peer_credentials_unix_socket", issue = "42839", reason = "unstable")]
+    #[unstable(feature = "peer_credentials_unix_socket", issue = "42839")]
     #[cfg(any(
         target_os = "android",
         target_os = "linux",

--- a/library/std/src/os/unix/net/ucred.rs
+++ b/library/std/src/os/unix/net/ucred.rs
@@ -7,7 +7,7 @@
 use libc::{gid_t, pid_t, uid_t};
 
 /// Credentials for a UNIX process for credentials passing.
-#[unstable(feature = "peer_credentials_unix_socket", issue = "42839", reason = "unstable")]
+#[unstable(feature = "peer_credentials_unix_socket", issue = "42839")]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct UCred {
     /// The UID part of the peer credential. This is the effective UID of the process at the domain

--- a/library/std/src/sys/net/connection/socket/windows.rs
+++ b/library/std/src/sys/net/connection/socket/windows.rs
@@ -451,7 +451,6 @@ impl Socket {
     }
 }
 
-#[unstable(reason = "not public", issue = "none", feature = "fd_read")]
 impl<'a> Read for &'a Socket {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         (**self).read(buf)

--- a/src/doc/unstable-book/src/library-features/fd-read.md
+++ b/src/doc/unstable-book/src/library-features/fd-read.md
@@ -1,5 +1,0 @@
-# `fd_read`
-
-This feature is internal to the Rust compiler and is not intended for general use.
-
-------------------------


### PR DESCRIPTION
The vast majority of `#[unstable()]` attributes already has no explicit reason specified. This PR removes the `reason = "..."` value for the following unhelpful or meaningless reasons: 
* "recently added"
* "new API"
* "recently redesigned"
* "unstable"

An example of how the message looks with and without a reason:

```rust
fn main() {
    Vec::<()>::into_parts;
    Vec::<()>::const_make_global;
}
```

```
error[E0658]: use of unstable library feature `box_vec_non_null`: new API
 --> src/main.rs:2:5
  |
2 |     Vec::<()>::into_parts;
  |     ^^^^^^^^^^^^^^^^^^^^^
  |
  = note: see issue #130364 <https://github.com/rust-lang/rust/issues/130364> for more information
  = help: add `#![feature(box_vec_non_null)]` to the crate attributes to enable
  = note: this compiler was built on 2026-01-15; consider upgrading it if it is out of date

error[E0658]: use of unstable library feature `const_heap`
 --> src/main.rs:3:5
  |
3 |     Vec::<()>::const_make_global;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: see issue #79597 <https://github.com/rust-lang/rust/issues/79597> for more information
  = help: add `#![feature(const_heap)]` to the crate attributes to enable
  = note: this compiler was built on 2026-01-15; consider upgrading it if it is out of date
```

Most of the remaining reasons after this are something similar to "this is an implementation detail for XYZ" or "this is not public". If this PR is approved, I'll look into those next. 

The PR also removes the `fd_read` feature gate. It only consists of one attribute applied to an implementation inside a module that is already private and unstable and should not be needed.
