### PR TITLE
HIR typeck cleanup: clarify and re-style `check_expr_unop`

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -437,39 +437,29 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let oprnd_t = self.check_expr_with_expectation(oprnd, expected_inner);
 
         if let Err(guar) = oprnd_t.error_reported() {
-            Ty::new_error(tcx, guar)
-        } else {
-            let oprnd_t = self.structurally_resolve_type(expr.span, oprnd_t);
-            match unop {
-                hir::UnOp::Deref => {
-                    if let Some(ty) = self.lookup_derefing(expr, oprnd, oprnd_t) {
-                        ty
-                    } else {
-                        let mut err =
-                            self.dcx().create_err(CantDereference { span: expr.span, ty: oprnd_t });
-                        let sp = tcx.sess.source_map().start_point(expr.span).with_parent(None);
-                        if let Some(sp) =
-                            tcx.sess.psess.ambiguous_block_expr_parse.borrow().get(&sp)
-                        {
-                            err.subdiagnostic(ExprParenthesesNeeded::surrounding(*sp));
-                        }
-                        Ty::new_error(tcx, err.emit())
-                    }
+            return Ty::new_error(tcx, guar);
+        }
+
+        let oprnd_t = self.structurally_resolve_type(expr.span, oprnd_t);
+        match unop {
+            hir::UnOp::Deref => self.lookup_derefing(expr, oprnd, oprnd_t).unwrap_or_else(|| {
+                let mut err =
+                    self.dcx().create_err(CantDereference { span: expr.span, ty: oprnd_t });
+                let sp = tcx.sess.source_map().start_point(expr.span).with_parent(None);
+                if let Some(sp) = tcx.sess.psess.ambiguous_block_expr_parse.borrow().get(&sp) {
+                    err.subdiagnostic(ExprParenthesesNeeded::surrounding(*sp));
                 }
-                hir::UnOp::Not => {
-                    let result = self.check_user_unop(expr, oprnd_t, unop, expected_inner);
-                    // If it's builtin, we can reuse the type, this helps inference.
-                    if oprnd_t.is_integral() || *oprnd_t.kind() == ty::Bool {
-                        oprnd_t
-                    } else {
-                        result
-                    }
-                }
-                hir::UnOp::Neg => {
-                    let result = self.check_user_unop(expr, oprnd_t, unop, expected_inner);
-                    // If it's builtin, we can reuse the type, this helps inference.
-                    if oprnd_t.is_numeric() { oprnd_t } else { result }
-                }
+                Ty::new_error(tcx, err.emit())
+            }),
+            hir::UnOp::Not => {
+                let result = self.check_user_unop(expr, oprnd_t, unop, expected_inner);
+                // If it's builtin, we can reuse the type, this helps inference.
+                if oprnd_t.is_integral() || *oprnd_t.kind() == ty::Bool { oprnd_t } else { result }
+            }
+            hir::UnOp::Neg => {
+                let result = self.check_user_unop(expr, oprnd_t, unop, expected_inner);
+                // If it's builtin, we can reuse the type, this helps inference.
+                if oprnd_t.is_numeric() { oprnd_t } else { result }
             }
         }
     }

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -434,14 +434,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             hir::UnOp::Not | hir::UnOp::Neg => expected,
             hir::UnOp::Deref => NoExpectation,
         };
-        let mut oprnd_t = self.check_expr_with_expectation(oprnd, expected_inner);
+        let oprnd_t = self.check_expr_with_expectation(oprnd, expected_inner);
 
-        if !oprnd_t.references_error() {
-            oprnd_t = self.structurally_resolve_type(expr.span, oprnd_t);
+        if let Err(guar) = oprnd_t.error_reported() {
+            Ty::new_error(tcx, guar)
+        } else {
+            let oprnd_t = self.structurally_resolve_type(expr.span, oprnd_t);
             match unop {
                 hir::UnOp::Deref => {
                     if let Some(ty) = self.lookup_derefing(expr, oprnd, oprnd_t) {
-                        oprnd_t = ty;
+                        ty
                     } else {
                         let mut err =
                             self.dcx().create_err(CantDereference { span: expr.span, ty: oprnd_t });
@@ -451,26 +453,25 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         {
                             err.subdiagnostic(ExprParenthesesNeeded::surrounding(*sp));
                         }
-                        oprnd_t = Ty::new_error(tcx, err.emit());
+                        Ty::new_error(tcx, err.emit())
                     }
                 }
                 hir::UnOp::Not => {
                     let result = self.check_user_unop(expr, oprnd_t, unop, expected_inner);
                     // If it's builtin, we can reuse the type, this helps inference.
-                    if !(oprnd_t.is_integral() || *oprnd_t.kind() == ty::Bool) {
-                        oprnd_t = result;
+                    if oprnd_t.is_integral() || *oprnd_t.kind() == ty::Bool {
+                        oprnd_t
+                    } else {
+                        result
                     }
                 }
                 hir::UnOp::Neg => {
                     let result = self.check_user_unop(expr, oprnd_t, unop, expected_inner);
                     // If it's builtin, we can reuse the type, this helps inference.
-                    if !oprnd_t.is_numeric() {
-                        oprnd_t = result;
-                    }
+                    if oprnd_t.is_numeric() { oprnd_t } else { result }
                 }
             }
         }
-        oprnd_t
     }
 
     fn check_expr_addr_of(


### PR DESCRIPTION
Two small cleanups:
- The `oprnd_t` variable was previously used both for the type of unary operators' operands and for the type of the operator expression as a whole. I found this confusing, so I've changed it to only be used for the operand type. This also allowed for removing some negations from `if` conditions.
- I did a bit of re-styling in the second commit to remove some indentation levels, which also means fewer things have to be spread across multiple lines. This part is more to-taste; I'd be fine dropping it if it doesn't actually help.