### PR TITLE
Export LLVM symbols for autodiff on Apple

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -796,6 +796,14 @@ impl<'a> Linker for GccLinker<'a> {
             }
         }
 
+        if crate_type == CrateType::Dylib
+            && self.sess.target.is_like_darwin
+            && self.sess.opts.unstable_opts.export_llvm_symbols
+            && self.sess.opts.crate_name.as_deref() == Some("rustc_driver")
+        {
+            return;
+        }
+
         // We manually create a list of exported symbols to ensure we don't expose any more.
         // The object files have far more public symbols than we actually want to export,
         // so we hide them all here.

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -796,6 +796,9 @@ impl<'a> Linker for GccLinker<'a> {
             }
         }
 
+        // On Apple, exporting LLVM symbols from rustc_driver allows the Enzyme
+        // submodule to find LLVM in rustc.
+        // Related: https://github.com/rust-lang/enzyme/pull/31
         if crate_type == CrateType::Dylib
             && self.sess.target.is_like_darwin
             && self.sess.opts.unstable_opts.export_llvm_symbols

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -797,7 +797,9 @@ impl<'a> Linker for GccLinker<'a> {
         }
 
         // On Apple, exporting LLVM symbols from rustc_driver allows the Enzyme
-        // submodule to find LLVM in rustc.
+        // submodule to find LLVM in rustc. Currently we only need this on
+        // Apple; keep the scope narrow to avoid exporting extra symbols on
+        // other targets.
         // Related: https://github.com/rust-lang/enzyme/pull/31
         if crate_type == CrateType::Dylib
             && self.sess.target.is_like_darwin

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2365,6 +2365,8 @@ options! {
         "enable default bounds for experimental group of auto traits"),
     export_executable_symbols: bool = (false, parse_bool, [TRACKED],
         "export symbols from executables, as if they were dynamic libraries"),
+    export_llvm_symbols: bool = (false, parse_bool, [TRACKED],
+        "export LLVM symbols from rustc_driver on darwin"),
     external_clangrt: bool = (false, parse_bool, [UNTRACKED],
         "rely on user specified linker commands to find clangrt"),
     extra_const_ub_checks: bool = (false, parse_bool, [TRACKED],

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1261,6 +1261,9 @@ pub fn rustc_cargo(
         cargo.rustflag("-Zdefault-visibility=protected");
     }
 
+    // On Apple, Enzyme can hang if rustc and Enzyme each embed their own LLVM.
+    // Export LLVM symbols from rustc_driver so Enzyme reuses rustc's LLVM.
+    // Related: https://github.com/rust-lang/enzyme/pull/31
     if builder.config.llvm_enzyme && target.contains("apple") && build_compiler.stage != 0 {
         cargo.rustflag("-Zexport-llvm-symbols");
     }

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1261,6 +1261,10 @@ pub fn rustc_cargo(
         cargo.rustflag("-Zdefault-visibility=protected");
     }
 
+    if builder.config.llvm_enzyme && target.contains("apple") && build_compiler.stage != 0 {
+        cargo.rustflag("-Zexport-llvm-symbols");
+    }
+
     if is_lto_stage(build_compiler) {
         match builder.config.rust_lto {
             RustcLto::Thin | RustcLto::Fat => {


### PR DESCRIPTION
Export LLVM symbols from `rustc_driver` on Apple when autodiff is enabled.

On Apple targets, Enzyme can hang if rustc and Enzyme each embed their own LLVM. Exporting LLVM symbols from `rustc_driver` lets Enzyme reuse

dependencies: https://github.com/rust-lang/enzyme/pull/31
This PR can be merged after https://github.com/rust-lang/enzyme/pull/31 has been merged and enzyme submodule has been updated.

I applied diffs on this PR to https://github.com/rust-lang/rust/pull/151063 then produced artifacts at https://github.com/rust-lang/rust/actions/runs/21091289355

I confirmed that `/path/to/rustc -Zautodiff=Enable -Clto=fat test.rs` successfully finished when I used those artifacts↑

r? @ZuseZ4 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
