### PR TITLE
Refine dummy_span.rs test

### DIFF
--- a/tests/debuginfo/dummy_span.rs
+++ b/tests/debuginfo/dummy_span.rs
@@ -1,13 +1,11 @@
 //@ min-lldb-version: 310
 
 //@ compile-flags:-g
-// FIXME: Investigate why test fails without SimplifyComparisonIntegral pass.
-//@ compile-flags: -Zmir-enable-passes=+SimplifyComparisonIntegral
 //@ ignore-backends: gcc
 
 // === GDB TESTS ===================================================================================
 
-//@ gdb-command:run 7
+//@ gdb-command:run
 
 //@ gdb-command:next
 //@ gdb-command:next
@@ -17,7 +15,7 @@
 
 // === LLDB TESTS ==================================================================================
 
-//@ lldb-command:run 7
+//@ lldb-command:run
 
 //@ lldb-command:next
 //@ lldb-command:next
@@ -30,10 +28,15 @@
 use std::env;
 use std::num::ParseIntError;
 
+struct Foo;
+
+impl Drop for Foo {
+    fn drop(&mut self) {}
+}
+
 fn main() -> Result<(), ParseIntError> {
-    let args = env::args();
-    let number_str = args.skip(1).next().unwrap();
-    let number = number_str.parse::<i32>()?;
+    let foo = Foo;
+    let number = Ok(7)?;
     zzz(); // #break
     if number % 7 == 0 {
         // This generates code with a dummy span for
@@ -41,7 +44,6 @@ fn main() -> Result<(), ParseIntError> {
         // test will not test what it wants to test.
         return Ok(()); // #loc1
     }
-    println!("{}", number);
     Ok(())
 } // #loc2
 


### PR DESCRIPTION
The test that is introduced in https://github.com/rust-lang/rust/pull/128627 is a BBs order problem in LLVM. I'm not 100% confident in the following investigation, but I think this is presumably the result.

Per the following content that is mentioned at https://llvm.org/docs/KeyInstructionsDebugInfo.html:

> DWARF provides a helpful tool the compiler can employ to mitigate this jumpiness, the `is_stmt` flag, which indicates that an instruction is a recommended breakpoint location. However, LLVM’s current approach to deciding `is_stmt` placement essentially reduces down to “is the associated line number different to the previous instruction’s?”.

Taking the example from https://rust.godbolt.org/z/GvToxj6vh. The partial assembly code with `SimplifyComparisonIntegral` is:

```asm
.LBB40_21:
        .loc    6 14 16 is_stmt 1
; RET = Ok(())
        mov     byte ptr [rsp + 79], 5
        .loc    6 0 0 is_stmt 0
        jmp     .LBB40_23
...
.LBB40_23:
        .loc    6 18 1 is_stmt 1
        lea     rdi, [rsp + 112]
; drop(number_str)
        call    qword ptr [rip + core[270d1373c8f6a07d]::ptr::drop_in_place::<alloc[206d51544a00c3e8]::string::String>@GOTPCREL]
        jmp     .LBB40_27
```

without `SimplifyComparisonIntegral`:

```asm
.LBB40_22:
        .loc    6 14 16 is_stmt 1
; RET = Ok(())
        mov     byte ptr [rsp + 79], 5
        .loc    6 0 0 is_stmt 0
        jmp     .LBB40_27
...
.LBB40_26:
        .loc    6 18 2 is_stmt 0
        mov     al, byte ptr [rsp + 79]
        .loc    6 18 2 epilogue_begin
        add     rsp, 360
        .cfi_def_cfa_offset 8
        ret
.LBB40_27:
; same line number to the previous instruction, so don't place `is_stmt` flag.
; this flag is `is_stmt 0` that will follow the flag of `.LBB40_26`.
        .loc    6 18 1
        lea     rdi, [rsp + 112]
; drop(number_str)
        call    qword ptr [rip + core[270d1373c8f6a07d]::ptr::drop_in_place::<alloc[206d51544a00c3e8]::string::String>@GOTPCREL]
        jmp     .LBB40_26
```

GDB doesn't step to `LBB40_27` due to `is_stmt 0`, so the next step is `__rust_begin_short_backtrace`. I have verified the new test works well with or without ``SimplifyComparisonIntegral`.