### PR TITLE
Parse ident with allowing recovery when trying to diagnose

### DIFF
--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -2264,7 +2264,7 @@ impl<'a> Parser<'a> {
             && self.look_ahead(1, |t| *t == token::Comma || *t == token::CloseParen)
         {
             // `fn foo(String s) {}`
-            let ident = self.parse_ident().unwrap();
+            let ident = self.parse_ident_common(true).unwrap();
             let span = pat.span.with_hi(ident.span.hi());
 
             err.span_suggestion(

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -408,12 +408,11 @@ impl<'a> Parser<'a> {
         let insert_span = ident_span.shrink_to_lo();
 
         let ident = if self.token.is_ident()
-            && self.token.is_non_reserved_ident()
             && (!is_const || self.look_ahead(1, |t| *t == token::OpenParen))
             && self.look_ahead(1, |t| {
                 matches!(t.kind, token::Lt | token::OpenBrace | token::OpenParen)
             }) {
-            self.parse_ident().unwrap()
+            self.parse_ident_common(true).unwrap()
         } else {
             return Ok(());
         };

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -469,7 +469,7 @@ impl<'a> Parser<'a> {
         self.parse_ident_common(self.may_recover())
     }
 
-    fn parse_ident_common(&mut self, recover: bool) -> PResult<'a, Ident> {
+    pub(crate) fn parse_ident_common(&mut self, recover: bool) -> PResult<'a, Ident> {
         let (ident, is_raw) = self.ident_or_err(recover)?;
 
         if is_raw == IdentIsRaw::No && ident.is_reserved() {

--- a/tests/ui/parser/macro/kw-in-const-item-pos-recovery-149692.rs
+++ b/tests/ui/parser/macro/kw-in-const-item-pos-recovery-149692.rs
@@ -6,6 +6,7 @@ macro_rules! m {
 }
 
 m!(const Self());
-//~^ ERROR expected one of `!` or `::`, found `(`
+//~^ ERROR expected identifier, found keyword `Self`
+//~^^ ERROR missing `fn` or `struct` for function or struct definition
 
 fn main() {}

--- a/tests/ui/parser/macro/kw-in-const-item-pos-recovery-149692.stderr
+++ b/tests/ui/parser/macro/kw-in-const-item-pos-recovery-149692.stderr
@@ -1,11 +1,22 @@
-error: expected one of `!` or `::`, found `(`
-  --> $DIR/kw-in-const-item-pos-recovery-149692.rs:8:14
+error: expected identifier, found keyword `Self`
+  --> $DIR/kw-in-const-item-pos-recovery-149692.rs:8:10
+   |
+LL | m!(const Self());
+   |          ^^^^ expected identifier, found keyword
+
+error: missing `fn` or `struct` for function or struct definition
+  --> $DIR/kw-in-const-item-pos-recovery-149692.rs:8:10
    |
 LL |     (const $id:item()) => {}
    |            -------- while parsing argument for this `item` macro fragment
 ...
 LL | m!(const Self());
-   |              ^ expected one of `!` or `::`
+   |          ^^^^
+   |
+help: if you meant to call a macro, try
+   |
+LL | m!(const Self!());
+   |              +
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/macro/kw-in-item-pos-recovery-149692.rs
+++ b/tests/ui/parser/macro/kw-in-item-pos-recovery-149692.rs
@@ -8,12 +8,15 @@ macro_rules! m {
 }
 
 m!(Self());
-//~^ ERROR expected one of `!` or `::`, found `(`
+//~^ ERROR expected identifier, found keyword `Self`
+//~^^ ERROR missing `fn` or `struct` for function or struct definition
 
 m!(Self{});
-//~^ ERROR expected one of `!` or `::`, found `{`
+//~^ ERROR expected identifier, found keyword `Self`
+//~^^ ERROR missing `enum` or `struct` for enum or struct definition
 
 m!(crate());
-//~^ ERROR expected one of `!` or `::`, found `(`
+//~^ ERROR expected identifier, found keyword `crate`
+//~^^ ERROR missing `fn` or `struct` for function or struct definition
 
 fn main() {}

--- a/tests/ui/parser/macro/kw-in-item-pos-recovery-149692.stderr
+++ b/tests/ui/parser/macro/kw-in-item-pos-recovery-149692.stderr
@@ -1,29 +1,57 @@
-error: expected one of `!` or `::`, found `(`
-  --> $DIR/kw-in-item-pos-recovery-149692.rs:10:8
+error: expected identifier, found keyword `Self`
+  --> $DIR/kw-in-item-pos-recovery-149692.rs:10:4
+   |
+LL | m!(Self());
+   |    ^^^^ expected identifier, found keyword
+
+error: missing `fn` or `struct` for function or struct definition
+  --> $DIR/kw-in-item-pos-recovery-149692.rs:10:4
    |
 LL |     ($id:item()) => {}
    |      -------- while parsing argument for this `item` macro fragment
 ...
 LL | m!(Self());
-   |        ^ expected one of `!` or `::`
+   |    ^^^^
+   |
+help: if you meant to call a macro, try
+   |
+LL | m!(Self!());
+   |        +
 
-error: expected one of `!` or `::`, found `{`
-  --> $DIR/kw-in-item-pos-recovery-149692.rs:13:8
+error: expected identifier, found keyword `Self`
+  --> $DIR/kw-in-item-pos-recovery-149692.rs:14:4
+   |
+LL | m!(Self{});
+   |    ^^^^ expected identifier, found keyword
+
+error: missing `enum` or `struct` for enum or struct definition
+  --> $DIR/kw-in-item-pos-recovery-149692.rs:14:4
    |
 LL |     ($id:item()) => {}
    |      -------- while parsing argument for this `item` macro fragment
 ...
 LL | m!(Self{});
-   |        ^ expected one of `!` or `::`
+   |    ^^^^
 
-error: expected one of `!` or `::`, found `(`
-  --> $DIR/kw-in-item-pos-recovery-149692.rs:16:9
+error: expected identifier, found keyword `crate`
+  --> $DIR/kw-in-item-pos-recovery-149692.rs:18:4
+   |
+LL | m!(crate());
+   |    ^^^^^ expected identifier, found keyword
+
+error: missing `fn` or `struct` for function or struct definition
+  --> $DIR/kw-in-item-pos-recovery-149692.rs:18:4
    |
 LL |     ($id:item()) => {}
    |      -------- while parsing argument for this `item` macro fragment
 ...
 LL | m!(crate());
-   |         ^ expected one of `!` or `::`
+   |    ^^^^^
+   |
+help: if you meant to call a macro, try
+   |
+LL | m!(crate!());
+   |         +
 
-error: aborting due to 3 previous errors
+error: aborting due to 6 previous errors
 

--- a/tests/ui/parser/macro/kw-in-item-pos-recovery-151238.rs
+++ b/tests/ui/parser/macro/kw-in-item-pos-recovery-151238.rs
@@ -1,0 +1,13 @@
+//@ edition: 2021
+
+macro_rules! x {
+    ($ty : item) => {};
+}
+x! {
+  trait MyTrait { fn bar(c self) }
+  //~^ ERROR expected identifier, found keyword `self`
+  //~^^ ERROR expected one of `:`, `@`, or `|`, found keyword `self`
+  //~^^^ ERROR expected one of `->`, `;`, `where`, or `{`, found `}`
+}
+
+fn main() {}

--- a/tests/ui/parser/macro/kw-in-item-pos-recovery-151238.stderr
+++ b/tests/ui/parser/macro/kw-in-item-pos-recovery-151238.stderr
@@ -1,0 +1,25 @@
+error: expected identifier, found keyword `self`
+  --> $DIR/kw-in-item-pos-recovery-151238.rs:7:28
+   |
+LL |   trait MyTrait { fn bar(c self) }
+   |                            ^^^^ expected identifier, found keyword
+
+error: expected one of `:`, `@`, or `|`, found keyword `self`
+  --> $DIR/kw-in-item-pos-recovery-151238.rs:7:28
+   |
+LL |   trait MyTrait { fn bar(c self) }
+   |                          --^^^^
+   |                          | |
+   |                          | expected one of `:`, `@`, or `|`
+   |                          help: declare the type after the parameter binding: `<identifier>: <type>`
+
+error: expected one of `->`, `;`, `where`, or `{`, found `}`
+  --> $DIR/kw-in-item-pos-recovery-151238.rs:7:34
+   |
+LL |   trait MyTrait { fn bar(c self) }
+   |                      ---         ^ expected one of `->`, `;`, `where`, or `{`
+   |                      |
+   |                      while parsing this `fn`
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Fixes rust-lang/rust#151238

rust-lang/rust#146978 made parsing ident not always allowed-recovery ([change](https://github.com/rust-lang/rust/pull/146978/changes#diff-ef8d6186dc7fb1d03a71446d0c9e6cc9e72158ec6896703dcf05686ee7dc83fcL469-R469)), so when matching macro with `NoopTracker`, which has `Recovery::Forbidden`, ICE happens when trying to parse kw as ident and then unwraping it.

This PR recovers the behavior that parsing ident with allowing recovery when trying to diagnose. Then errors will behave like previous.

r? @petrochenkov