### PR TITLE
compiletest: Don't look for Dylib if no-prefer-dynamic

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1412,7 +1412,7 @@ impl<'test> TestCx<'test> {
         } else if aux_type.is_some() {
             panic!("aux_type {aux_type:?} not expected");
         } else if aux_props.no_prefer_dynamic {
-            (AuxType::Dylib, None)
+            (AuxType::Lib, None)
         } else if self.config.target.contains("emscripten")
             || (self.config.target.contains("musl")
                 && !aux_props.force_host


### PR DESCRIPTION
Since it does not make sense to do so. If someone prefers no dynamic linking, it is much more likely that they want to link with a Lib instead.

Unblocks:
- https://github.com/rust-lang/rust/pull/150591 because its `//@ no-prefer-dynamic` tests must actually link statically because of https://github.com/rust-lang/rust/issues/151271.

Blocked by:
- https://github.com/rust-lang/rust/pull/151258