### PR TITLE
compiletest: Support `--extern` options with `proc-macro` directive

### DIFF
--- a/tests/ui/privacy/pub-priv-dep/auxiliary/pm.rs
+++ b/tests/ui/privacy/pub-priv-dep/auxiliary/pm.rs
@@ -1,8 +1,3 @@
-//@ force-host
-//@ no-prefer-dynamic
-
-#![crate_type = "proc-macro"]
-
 extern crate proc_macro;
 use proc_macro::TokenStream;
 

--- a/tests/ui/privacy/pub-priv-dep/pub-priv1.rs
+++ b/tests/ui/privacy/pub-priv-dep/pub-priv1.rs
@@ -1,6 +1,6 @@
 //@ aux-crate:priv:priv_dep=priv_dep.rs
 //@ aux-build:pub_dep.rs
-//@ aux-crate:priv:pm=pm.rs
+//@ proc-macro:priv:pm.rs
 //@ compile-flags: -Zunstable-options
 
 // Basic behavior check of exported_private_dependencies from either a public


### PR DESCRIPTION
So that `pub-priv1.rs` test does not have to (ab)use the `aux-crate` directive for this purpose. Which in turn makes it possible to make `//@ no-prefer-dynamic` actually not try to link dynamically. See https://github.com/rust-lang/rust/pull/151257 and the [test failure](https://github.com/rust-lang/rust/pull/151257#issuecomment-3764130798).

This is very edge-casey so I don't think we should document this in rustc-dev-guide. If someone needs to do this they will look at the code and easily find the functionality.

This is a bit hacky since `--extern priv:pm.rs` is not valid, but we can make our directives work however we want. And I think this is a fine pragmatic balance. Doing it "the right way" would be a lot of work for not much gain. Plus, that work can be done incrementally in small steps in the future if needed and wanted.

Unblocks:
- https://github.com/rust-lang/rust/pull/151257