### PR TITLE
Handle unevaluated ConstKind in in_operand

### DIFF
--- a/tests/ui/const-generics/mgca/type_const-pub.rs
+++ b/tests/ui/const-generics/mgca/type_const-pub.rs
@@ -7,4 +7,6 @@
 
 #[type_const]
 pub const TYPE_CONST : usize = 1;
-fn main() {}
+fn main() {
+    print!("{}", TYPE_CONST)
+}


### PR DESCRIPTION
fix: rust-lang/rust#151248


r? BoxyUwU
~~I can't reproduce rust-lang/rust#151246 in my local(x86_64-pc-windows-msvc) even before this change. 🤔
create a draft and test it in different environments.~~
