### PR TITLE
`f16`: remove s390x fixme

### DIFF
--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -443,15 +443,12 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # // FIXME(f16_f128): LLVM crashes on s390x, llvm/llvm-project#50374
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
     ///
     /// let f = 7.0_f16;
     /// let g = -7.0_f16;
     ///
     /// assert!(f.is_sign_positive());
     /// assert!(!g.is_sign_positive());
-    /// # }
     /// ```
     #[inline]
     #[must_use]
@@ -472,15 +469,12 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # // FIXME(f16_f128): LLVM crashes on s390x, llvm/llvm-project#50374
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
     ///
     /// let f = 7.0_f16;
     /// let g = -7.0_f16;
     ///
     /// assert!(!f.is_sign_negative());
     /// assert!(g.is_sign_negative());
-    /// # }
     /// ```
     #[inline]
     #[must_use]
@@ -965,12 +959,9 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # // FIXME(f16_f128): LLVM crashes on s390x, llvm/llvm-project#50374
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
     ///
     /// let bytes = 12.5f16.to_be_bytes();
     /// assert_eq!(bytes, [0x4a, 0x40]);
-    /// # }
     /// ```
     #[inline]
     #[unstable(feature = "f16", issue = "116909")]
@@ -989,12 +980,9 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # // FIXME(f16_f128): LLVM crashes on s390x, llvm/llvm-project#50374
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
     ///
     /// let bytes = 12.5f16.to_le_bytes();
     /// assert_eq!(bytes, [0x40, 0x4a]);
-    /// # }
     /// ```
     #[inline]
     #[unstable(feature = "f16", issue = "116909")]
@@ -1019,8 +1007,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # // FIXME(f16_f128): LLVM crashes on s390x, llvm/llvm-project#50374
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
     ///
     /// let bytes = 12.5f16.to_ne_bytes();
     /// assert_eq!(
@@ -1031,7 +1017,6 @@ impl f16 {
     ///         [0x40, 0x4a]
     ///     }
     /// );
-    /// # }
     /// ```
     #[inline]
     #[unstable(feature = "f16", issue = "116909")]


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/116909

The fix for https://github.com/llvm/llvm-project/issues/50374 made it into LLVM 21, so these examples work now.

https://rust.godbolt.org/z/qTzMG4ffc

But the doc tests only ran on x86_64 linux before, so removing the `cfg` makes them suddenly run on many more targets, some of which might still fail. We may need to wait until we're on LLVM 22 if other issues do pop up.  

r? @tgross35