### PR TITLE
feature: implement Relink, Don't Rebuild (RDR)

### DIFF
--- a/compiler/rustc_error_messages/src/lib.rs
+++ b/compiler/rustc_error_messages/src/lib.rs
@@ -17,7 +17,7 @@ use intl_memoizer::concurrent::IntlLangMemoizer;
 use rustc_data_structures::sync::{DynSend, IntoDynSyncSend};
 use rustc_macros::{Decodable, Encodable};
 use rustc_serialize::{Decodable, Encodable};
-use rustc_span::{Span, SpanDecoder, SpanEncoder, SpanRef};
+use rustc_span::{Span, SpanDecoder, SpanEncoder};
 use tracing::{instrument, trace};
 pub use unic_langid::{LanguageIdentifier, langid};
 
@@ -528,13 +528,11 @@ impl<E: SpanEncoder> Encodable<E> for MultiSpan {
 
 impl<D: SpanDecoder> Decodable<D> for MultiSpan {
     fn decode(d: &mut D) -> Self {
-        // Decode primary spans
         let primary_len: usize = Decodable::decode(d);
         let mut primary_spans = Vec::with_capacity(primary_len);
         for _ in 0..primary_len {
             primary_spans.push(d.decode_span_ref_as_span());
         }
-        // Decode span labels
         let labels_len: usize = Decodable::decode(d);
         let mut span_labels = Vec::with_capacity(labels_len);
         for _ in 0..labels_len {

--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -13,7 +13,7 @@ use rustc_lint_defs::{Applicability, LintExpectationId};
 use rustc_macros::{Decodable, Encodable};
 use rustc_serialize::{Decodable, Encodable};
 use rustc_span::source_map::Spanned;
-use rustc_span::{DUMMY_SP, Span, SpanDecoder, SpanEncoder, SpanRef, Symbol};
+use rustc_span::{DUMMY_SP, Span, SpanDecoder, SpanEncoder, Symbol};
 use tracing::debug;
 
 use crate::snippet::Style;
@@ -278,8 +278,7 @@ impl<E: SpanEncoder> Encodable<E> for DiagInner {
         self.suggestions.encode(e);
         self.args.encode(e);
         self.reserved_args.encode(e);
-        // Encode sort_span as SpanRef to avoid absolute byte positions
-        self.sort_span.to_span_ref().encode(e);
+        e.encode_span_as_span_ref(self.sort_span);
         self.is_lint.encode(e);
         self.long_ty_path.encode(e);
         self.emitted_at.encode(e);
@@ -298,8 +297,7 @@ impl<D: SpanDecoder> Decodable<D> for DiagInner {
             suggestions: Decodable::decode(d),
             args: Decodable::decode(d),
             reserved_args: Decodable::decode(d),
-            // Decode SpanRef and convert back to Span
-            sort_span: { let sr: SpanRef = Decodable::decode(d); sr.span() },
+            sort_span: d.decode_span_ref_as_span(),
             is_lint: Decodable::decode(d),
             long_ty_path: Decodable::decode(d),
             emitted_at: Decodable::decode(d),

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -72,7 +72,7 @@ use rustc_serialize::{Decodable, Encodable};
 pub use rustc_span::ErrorGuaranteed;
 pub use rustc_span::fatal_error::{FatalError, FatalErrorMarker};
 use rustc_span::source_map::SourceMap;
-use rustc_span::{BytePos, DUMMY_SP, Loc, Span, SpanDecoder, SpanEncoder, SpanRef};
+use rustc_span::{BytePos, DUMMY_SP, Loc, Span, SpanDecoder, SpanEncoder};
 pub use snippet::Style;
 use tracing::debug;
 
@@ -215,16 +215,16 @@ pub struct SubstitutionPart {
 
 impl<E: SpanEncoder> Encodable<E> for SubstitutionPart {
     fn encode(&self, e: &mut E) {
-        self.span.to_span_ref().encode(e);
+        e.encode_span_as_span_ref(self.span);
         self.snippet.encode(e);
     }
 }
 
 impl<D: SpanDecoder> Decodable<D> for SubstitutionPart {
     fn decode(d: &mut D) -> Self {
-        let span_ref: SpanRef = Decodable::decode(d);
+        let span = d.decode_span_ref_as_span();
         let snippet: String = Decodable::decode(d);
-        SubstitutionPart { span: span_ref.span(), snippet }
+        SubstitutionPart { span, snippet }
     }
 }
 
@@ -238,22 +238,18 @@ pub struct TrimmedSubstitutionPart {
 
 impl<E: SpanEncoder> Encodable<E> for TrimmedSubstitutionPart {
     fn encode(&self, e: &mut E) {
-        self.original_span.to_span_ref().encode(e);
-        self.span.to_span_ref().encode(e);
+        e.encode_span_as_span_ref(self.original_span);
+        e.encode_span_as_span_ref(self.span);
         self.snippet.encode(e);
     }
 }
 
 impl<D: SpanDecoder> Decodable<D> for TrimmedSubstitutionPart {
     fn decode(d: &mut D) -> Self {
-        let original_span_ref: SpanRef = Decodable::decode(d);
-        let span_ref: SpanRef = Decodable::decode(d);
+        let original_span = d.decode_span_ref_as_span();
+        let span = d.decode_span_ref_as_span();
         let snippet: String = Decodable::decode(d);
-        TrimmedSubstitutionPart {
-            original_span: original_span_ref.span(),
-            span: span_ref.span(),
-            snippet,
-        }
+        TrimmedSubstitutionPart { original_span, span, snippet }
     }
 }
 

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -326,6 +326,7 @@ fn check_opaque_meets_bounds<'tcx>(
     for (predicate, pred_span) in
         tcx.explicit_item_bounds(def_id).iter_instantiated_copied(tcx, args)
     {
+        let pred_span = tcx.resolve_span_ref(pred_span);
         let predicate = predicate.fold_with(&mut BottomUpFolder {
             tcx,
             ty_op: |ty| if ty == opaque_ty { hidden_ty } else { ty },

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -839,6 +839,7 @@ where
                 .explicit_item_bounds(proj.def_id)
                 .iter_instantiated_copied(self.cx(), proj.args)
             {
+                let pred_span = self.cx().resolve_span_ref(pred_span);
                 let pred = pred.fold_with(self);
                 let pred = self.ocx.normalize(
                     &ObligationCause::misc(self.span, self.body_id),
@@ -2413,6 +2414,7 @@ pub(super) fn check_type_bounds<'tcx>(
         tcx,
         tcx.explicit_item_bounds(trait_ty.def_id).iter_instantiated_copied(tcx, rebased_args).map(
             |(concrete_ty_bound, span)| {
+                let span = tcx.resolve_span_ref(span);
                 debug!(?concrete_ty_bound);
                 traits::Obligation::new(tcx, mk_cause(span), param_env, concrete_ty_bound)
             },

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item/refine.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item/refine.rs
@@ -120,7 +120,8 @@ pub(crate) fn check_refining_return_position_impl_trait_in_trait<'tcx>(
         impl_bounds.extend(elaborate(
             tcx,
             tcx.explicit_item_bounds(impl_opaque.def_id)
-                .iter_instantiated_copied(tcx, impl_opaque.args),
+                .iter_instantiated_copied(tcx, impl_opaque.args)
+                .map(|(clause, span)| (clause, tcx.resolve_span_ref(span))),
         ));
 
         pairs.push((trait_projection, impl_opaque));

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1167,6 +1167,7 @@ fn check_associated_type_bounds(wfcx: &WfCheckingCtxt<'_, '_>, item: ty::AssocIt
 
     debug!("check_associated_type_bounds: bounds={:?}", bounds);
     let wf_obligations = bounds.iter_identity_copied().flat_map(|(bound, bound_span)| {
+        let bound_span = wfcx.tcx().resolve_span_ref(bound_span);
         traits::wf::clause_obligations(
             wfcx.infcx,
             wfcx.param_env,

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -38,7 +38,7 @@ use rustc_middle::ty::{
     self, AdtKind, Const, IsSuggestable, Ty, TyCtxt, TypeVisitableExt, TypingMode, fold_regions,
 };
 use rustc_middle::{bug, span_bug};
-use rustc_span::{DUMMY_SP, Ident, Span, Symbol, kw, sym};
+use rustc_span::{DUMMY_SP, Ident, Span, SpanRef, Symbol, kw, sym};
 use rustc_trait_selection::error_reporting::traits::suggestions::NextTypeParamName;
 use rustc_trait_selection::infer::InferCtxtExt;
 use rustc_trait_selection::traits::{
@@ -358,7 +358,7 @@ impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
         span: Span,
         def_id: LocalDefId,
         assoc_ident: Ident,
-    ) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, Span)]> {
+    ) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, SpanRef)]> {
         self.tcx.at(span).type_param_predicates((self.item_def_id, def_id, assoc_ident))
     }
 

--- a/compiler/rustc_hir_analysis/src/collect/item_bounds.rs
+++ b/compiler/rustc_hir_analysis/src/collect/item_bounds.rs
@@ -8,7 +8,6 @@ use rustc_middle::ty::{
 use rustc_middle::{bug, span_bug};
 use rustc_span::def_id::{DefId, LocalDefId};
 use rustc_span::{Span, SpanRef};
-use rustc_span::def_id::{DefId, LocalDefId};
 
 fn convert_to_span_ref<'tcx>(
     tcx: TyCtxt<'tcx>,

--- a/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
@@ -43,8 +43,9 @@ pub(super) fn predicates_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::GenericPredic
     let inferred_outlives = tcx.inferred_outlives_of(def_id);
     if !inferred_outlives.is_empty() {
         debug!("predicates_of: inferred_outlives_of({:?}) = {:?}", def_id, inferred_outlives,);
-        let inferred_outlives_iter =
-            inferred_outlives.iter().map(|(clause, span)| ((*clause).upcast(tcx), tcx.resolve_span_ref(*span)));
+        let inferred_outlives_iter = inferred_outlives
+            .iter()
+            .map(|(clause, span)| ((*clause).upcast(tcx), tcx.resolve_span_ref(*span)));
         if result.predicates.is_empty() {
             result.predicates = tcx.arena.alloc_from_iter(inferred_outlives_iter);
         } else {

--- a/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
@@ -11,7 +11,16 @@ use rustc_middle::ty::{
     self, GenericPredicates, ImplTraitInTraitData, Ty, TyCtxt, TypeVisitable, TypeVisitor, Upcast,
 };
 use rustc_middle::{bug, span_bug};
-use rustc_span::{DUMMY_SP, Ident, Span};
+use rustc_span::{DUMMY_SP, Ident, Span, SpanRef};
+
+fn convert_to_span_ref<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    predicates: &[(ty::Clause<'tcx>, Span)],
+) -> &'tcx [(ty::Clause<'tcx>, SpanRef)] {
+    tcx.arena.alloc_from_iter(
+        predicates.iter().map(|(clause, span)| (*clause, tcx.span_ref_from_span(*span))),
+    )
+}
 use tracing::{debug, instrument, trace};
 
 use super::item_bounds::explicit_item_bounds_with_filter;
@@ -35,7 +44,7 @@ pub(super) fn predicates_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::GenericPredic
     if !inferred_outlives.is_empty() {
         debug!("predicates_of: inferred_outlives_of({:?}) = {:?}", def_id, inferred_outlives,);
         let inferred_outlives_iter =
-            inferred_outlives.iter().map(|(clause, span)| ((*clause).upcast(tcx), *span));
+            inferred_outlives.iter().map(|(clause, span)| ((*clause).upcast(tcx), tcx.resolve_span_ref(*span)));
         if result.predicates.is_empty() {
             result.predicates = tcx.arena.alloc_from_iter(inferred_outlives_iter);
         } else {
@@ -603,14 +612,14 @@ pub(super) fn explicit_predicates_of<'tcx>(
 pub(super) fn explicit_super_predicates_of<'tcx>(
     tcx: TyCtxt<'tcx>,
     trait_def_id: LocalDefId,
-) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, Span)]> {
+) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, SpanRef)]> {
     implied_predicates_with_filter(tcx, trait_def_id.to_def_id(), PredicateFilter::SelfOnly)
 }
 
 pub(super) fn explicit_supertraits_containing_assoc_item<'tcx>(
     tcx: TyCtxt<'tcx>,
     (trait_def_id, assoc_ident): (DefId, Ident),
-) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, Span)]> {
+) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, SpanRef)]> {
     implied_predicates_with_filter(
         tcx,
         trait_def_id,
@@ -621,7 +630,7 @@ pub(super) fn explicit_supertraits_containing_assoc_item<'tcx>(
 pub(super) fn explicit_implied_predicates_of<'tcx>(
     tcx: TyCtxt<'tcx>,
     trait_def_id: LocalDefId,
-) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, Span)]> {
+) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, SpanRef)]> {
     implied_predicates_with_filter(
         tcx,
         trait_def_id.to_def_id(),
@@ -640,7 +649,7 @@ pub(super) fn implied_predicates_with_filter<'tcx>(
     tcx: TyCtxt<'tcx>,
     trait_def_id: DefId,
     filter: PredicateFilter,
-) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, Span)]> {
+) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, SpanRef)]> {
     let Some(trait_def_id) = trait_def_id.as_local() else {
         // if `assoc_ident` is None, then the query should've been redirected to an
         // external provider
@@ -732,7 +741,7 @@ pub(super) fn implied_predicates_with_filter<'tcx>(
 
     assert_only_contains_predicates_from(filter, implied_bounds, tcx.types.self_param);
 
-    ty::EarlyBinder::bind(implied_bounds)
+    ty::EarlyBinder::bind(convert_to_span_ref(tcx, implied_bounds))
 }
 
 // Make sure when elaborating supertraits, probing for associated types, etc.,
@@ -876,7 +885,7 @@ pub(super) fn assert_only_contains_predicates_from<'tcx>(
 pub(super) fn type_param_predicates<'tcx>(
     tcx: TyCtxt<'tcx>,
     (item_def_id, def_id, assoc_ident): (LocalDefId, LocalDefId, Ident),
-) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, Span)]> {
+) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, SpanRef)]> {
     match tcx.opt_rpitit_info(item_def_id.to_def_id()) {
         Some(ty::ImplTraitInTraitData::Trait { opaque_def_id, .. }) => {
             return tcx.type_param_predicates((opaque_def_id.expect_local(), def_id, assoc_ident));
@@ -933,8 +942,13 @@ pub(super) fn type_param_predicates<'tcx>(
         PredicateFilter::SelfTraitThatDefines(assoc_ident),
     ));
 
-    let bounds =
-        &*tcx.arena.alloc_from_iter(result.skip_binder().iter().copied().chain(extra_predicates));
+    let bounds = &*tcx.arena.alloc_from_iter(
+        result
+            .skip_binder()
+            .iter()
+            .map(|(clause, span)| (*clause, tcx.resolve_span_ref(*span)))
+            .chain(extra_predicates),
+    );
 
     // Double check that the bounds *only* contain `SelfTy: Trait` preds.
     let self_ty = match tcx.def_kind(def_id) {
@@ -954,7 +968,7 @@ pub(super) fn type_param_predicates<'tcx>(
         self_ty,
     );
 
-    ty::EarlyBinder::bind(bounds)
+    ty::EarlyBinder::bind(convert_to_span_ref(tcx, bounds))
 }
 
 impl<'tcx> ItemCtxt<'tcx> {
@@ -1174,7 +1188,7 @@ pub(super) fn explicit_implied_const_bounds<'tcx>(
                     }) => trait_ref,
                     _ => bug!("converted {clause:?}"),
                 }),
-                span,
+                tcx.resolve_span_ref(span),
             )
         }))
     })

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -45,7 +45,7 @@ use rustc_middle::ty::{
 use rustc_middle::{bug, span_bug};
 use rustc_session::lint::builtin::AMBIGUOUS_ASSOCIATED_ITEMS;
 use rustc_session::parse::feature_err;
-use rustc_span::{DUMMY_SP, Ident, Span, kw, sym};
+use rustc_span::{DUMMY_SP, Ident, Span, SpanRef, kw, sym};
 use rustc_trait_selection::infer::InferCtxtExt;
 use rustc_trait_selection::traits::wf::object_region_bounds;
 use rustc_trait_selection::traits::{self, FulfillmentError};
@@ -167,7 +167,7 @@ pub trait HirTyLowerer<'tcx> {
         span: Span,
         def_id: LocalDefId,
         assoc_ident: Ident,
-    ) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, Span)]>;
+    ) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, SpanRef)]>;
 
     fn select_inherent_assoc_candidates(
         &self,

--- a/compiler/rustc_hir_typeck/src/closure.rs
+++ b/compiler/rustc_hir_typeck/src/closure.rs
@@ -312,7 +312,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     self.tcx
                         .explicit_item_self_bounds(def_id)
                         .iter_instantiated_copied(self.tcx, args)
-                        .map(|(c, s)| (c.as_predicate(), s)),
+                        .map(|(c, s)| (c.as_predicate(), self.tcx.resolve_span_ref(s))),
                 ),
             ty::Dynamic(object_type, ..) => {
                 let sig = object_type.projection_bounds().find_map(|pb| {
@@ -1028,7 +1028,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 .tcx
                 .explicit_item_self_bounds(def_id)
                 .iter_instantiated_copied(self.tcx, args)
-                .find_map(|(p, s)| get_future_output(p.as_predicate(), s))?,
+                .find_map(|(p, s)| {
+                    get_future_output(p.as_predicate(), self.tcx.resolve_span_ref(s))
+                })?,
             ty::Error(_) => return Some(ret_ty),
             _ => {
                 span_bug!(closure_span, "invalid async fn coroutine return type: {ret_ty:?}")

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -19,7 +19,7 @@ use rustc_infer::infer::{self, RegionVariableOrigin};
 use rustc_infer::traits::{DynCompatibilityViolation, Obligation};
 use rustc_middle::ty::{self, Const, Ty, TyCtxt, TypeVisitableExt};
 use rustc_session::Session;
-use rustc_span::{self, DUMMY_SP, ErrorGuaranteed, Ident, Span, sym};
+use rustc_span::{self, DUMMY_SP, ErrorGuaranteed, Ident, Span, SpanRef, sym};
 use rustc_trait_selection::error_reporting::TypeErrCtxt;
 use rustc_trait_selection::traits::{
     self, FulfillmentError, ObligationCause, ObligationCauseCode, ObligationCtxt,
@@ -296,13 +296,14 @@ impl<'tcx> HirTyLowerer<'tcx> for FnCtxt<'_, 'tcx> {
         _: Span,
         def_id: LocalDefId,
         _: Ident,
-    ) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, Span)]> {
+    ) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, SpanRef)]> {
         let tcx = self.tcx;
         let item_def_id = tcx.hir_ty_param_owner(def_id);
         let generics = tcx.generics_of(item_def_id);
         let index = generics.param_def_id_to_index[&def_id.to_def_id()];
         // HACK(eddyb) should get the original `Span`.
         let span = tcx.def_span(def_id);
+        let span = tcx.span_ref_from_span(span);
 
         ty::EarlyBinder::bind(tcx.arena.alloc_from_iter(
             self.param_env.caller_bounds().iter().filter_map(|predicate| {

--- a/compiler/rustc_interface/src/queries.rs
+++ b/compiler/rustc_interface/src/queries.rs
@@ -64,7 +64,7 @@ impl Linker {
         {
             let spans_path = path.with_extension("spans");
             let mut files: Vec<(&'static str, &Path)> = vec![("rmeta", path)];
-            if sess.opts.unstable_opts.separate_spans && spans_path.exists() {
+            if sess.opts.unstable_opts.stable_crate_hash && spans_path.exists() {
                 files.push(("spans", &spans_path));
             }
             if let Some((id, product)) =

--- a/compiler/rustc_lint/src/opaque_hidden_inferred_bound.rs
+++ b/compiler/rustc_lint/src/opaque_hidden_inferred_bound.rs
@@ -89,6 +89,7 @@ impl<'tcx> LateLintPass<'tcx> for OpaqueHiddenInferredBound {
         // check that the type that we're assigning actually satisfies the bounds
         // of the associated type.
         for (pred, pred_span) in cx.tcx.explicit_item_bounds(def_id).iter_identity_copied() {
+            let pred_span = cx.tcx.resolve_span_ref(pred_span);
             infcx.enter_forall(pred.kind(), |predicate| {
                 let ty::ClauseKind::Projection(proj) = predicate else {
                     return;
@@ -146,6 +147,7 @@ impl<'tcx> LateLintPass<'tcx> for OpaqueHiddenInferredBound {
                     .explicit_item_bounds(proj.projection_term.def_id)
                     .iter_instantiated_copied(cx.tcx, proj.projection_term.args)
                 {
+                    let assoc_pred_span = cx.tcx.resolve_span_ref(assoc_pred_span);
                     let assoc_pred = assoc_pred.fold_with(proj_replacer);
 
                     let ocx = ObligationCtxt::new(infcx);

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -323,7 +323,12 @@ impl<'tcx> LateLintPass<'tcx> for UnusedResults {
                 }
                 ty::Adt(def, _) => is_def_must_use(cx, def.did(), span),
                 ty::Alias(ty::Opaque | ty::Projection, ty::AliasTy { def_id: def, .. }) => {
-                    elaborate(cx.tcx, cx.tcx.explicit_item_self_bounds(def).iter_identity_copied())
+                    let bounds = cx
+                        .tcx
+                        .explicit_item_self_bounds(def)
+                        .iter_identity_copied()
+                        .map(|(clause, span)| (clause, cx.tcx.resolve_span_ref(span)));
+                    elaborate(cx.tcx, bounds)
                         // We only care about self bounds for the impl-trait
                         .filter_only_self()
                         .find_map(|(pred, _span)| {

--- a/compiler/rustc_metadata/messages.ftl
+++ b/compiler/rustc_metadata/messages.ftl
@@ -153,6 +153,11 @@ metadata_link_ordinal_raw_dylib =
 metadata_missing_native_library =
     could not find native static library `{$libname}`, perhaps an -L flag is missing?
 
+metadata_missing_span_file =
+    cannot load span data for crate `{$crate_name}`: {$reason}
+    .note = the incremental compilation cache may be corrupted
+    .help = try running `cargo clean` and recompiling
+
 metadata_multiple_candidates =
     multiple candidates for `{$flavor}` dependency `{$crate_name}` found
 

--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -631,10 +631,10 @@ impl CStore {
             None
         };
 
-        let has_separate_spans = crate_root.has_separate_spans();
+        let has_stable_crate_hash = crate_root.has_stable_crate_hash();
         let crate_name = crate_root.name();
 
-        if has_separate_spans && source.spans.is_none() {
+        if has_stable_crate_hash && source.spans.is_none() {
             return Err(CrateError::MissingSpanFile(crate_name, "file not found".to_string()));
         }
 
@@ -652,7 +652,7 @@ impl CStore {
             host_hash,
         );
 
-        if has_separate_spans {
+        if has_stable_crate_hash {
             crate_metadata
                 .ensure_span_file_loaded()
                 .map_err(|err| CrateError::MissingSpanFile(crate_name, err))?;

--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -658,6 +658,8 @@ impl CStore {
                 .map_err(|err| CrateError::MissingSpanFile(crate_name, err))?;
         }
 
+        crate_metadata.preload_all_source_files(tcx, self);
+
         self.set_crate_data(cnum, crate_metadata);
 
         Ok(cnum)

--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -618,3 +618,14 @@ pub struct RawDylibMalformed {
     #[primary_span]
     pub span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(metadata_missing_span_file)]
+#[note]
+#[help]
+pub struct MissingSpanFile {
+    #[primary_span]
+    pub span: Span,
+    pub crate_name: Symbol,
+    pub reason: String,
+}

--- a/compiler/rustc_metadata/src/fs.rs
+++ b/compiler/rustc_metadata/src/fs.rs
@@ -7,6 +7,7 @@ use rustc_data_structures::owned_slice::{OwnedSlice, slice_owned};
 use rustc_data_structures::svh::Svh;
 use rustc_data_structures::temp_dir::MaybeTempDir;
 use rustc_fs_util::TempDirBuilder;
+use rustc_hir::def_id::LOCAL_CRATE;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
 use rustc_session::config::{CrateType, OutFileName, OutputType};

--- a/compiler/rustc_metadata/src/fs.rs
+++ b/compiler/rustc_metadata/src/fs.rs
@@ -87,9 +87,9 @@ pub fn encode_and_write_metadata(tcx: TyCtxt<'_>) -> EncodedMetadata {
         None
     };
 
-    // When -Z separate-spans is enabled, encode spans to a separate .spans file
+    // When -Z stable-crate-hash is enabled, encode spans to a separate .spans file
     let spans_tmp_filename = if let Some(required_source_files) = required_source_files
-        && tcx.sess.opts.unstable_opts.separate_spans
+        && tcx.sess.opts.unstable_opts.stable_crate_hash
     {
         let spans_tmp_filename = metadata_tmpdir.as_ref().join("lib.spans");
         encode_spans(tcx, &spans_tmp_filename, tcx.crate_hash(LOCAL_CRATE), required_source_files);
@@ -107,12 +107,12 @@ pub fn encode_and_write_metadata(tcx: TyCtxt<'_>) -> EncodedMetadata {
     let (metadata_filename, metadata_tmpdir) = if need_metadata_file {
         let filename = match out_filename {
             OutFileName::Real(ref path) => {
-                // RDR optimization: when -Z separate-spans is enabled, skip writing
+                // RDR optimization: when -Z stable-crate-hash is enabled, skip writing
                 // the .rmeta file if its content hash (SVH) hasn't changed. This
                 // preserves the file's mtime, preventing cargo from rebuilding
                 // dependent crates when only span positions changed.
                 let new_hash = tcx.crate_hash(LOCAL_CRATE);
-                let skip_write = tcx.sess.opts.unstable_opts.separate_spans
+                let skip_write = tcx.sess.opts.unstable_opts.stable_crate_hash
                     && read_existing_metadata_hash(path).is_some_and(|old_hash| {
                         let matches = old_hash == new_hash;
                         if matches {

--- a/compiler/rustc_metadata/src/lib.rs
+++ b/compiler/rustc_metadata/src/lib.rs
@@ -33,6 +33,6 @@ pub use native_libs::{
     NativeLibSearchFallback, find_native_static_library, try_find_native_dynamic_library,
     try_find_native_static_library, walk_native_lib_search_dirs,
 };
-pub use rmeta::{EncodedMetadata, METADATA_HEADER, encode_metadata, rendered_const};
+pub use rmeta::{EncodedMetadata, METADATA_HEADER, encode_metadata, encode_spans, rendered_const};
 
 rustc_fluent_macro::fluent_messages! { "../messages.ftl" }

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -961,7 +961,7 @@ fn get_rmeta_metadata_section<'a, 'p>(filename: &'p Path) -> Result<OwnedSlice, 
     Ok(slice_owned(mmap, Deref::deref))
 }
 
-/// Loads a span metadata file (.spans) that accompanies rmeta files compiled with -Z separate_spans.
+/// Loads a span metadata file (.spans) that accompanies rmeta files compiled with -Z stable-crate-hash.
 pub(crate) fn get_span_metadata_section(filename: &Path) -> Result<SpanBlob, String> {
     // mmap the file, because only a small fraction of it is read.
     let file = std::fs::File::open(filename)

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -951,6 +951,7 @@ fn get_rmeta_metadata_section<'a, 'p>(filename: &'p Path) -> Result<OwnedSlice, 
 }
 
 /// Loads a span metadata file (.spans) that accompanies rmeta files compiled with -Z separate_spans.
+#[allow(dead_code)] // TODO: used by RDR span file infrastructure
 pub(crate) fn get_span_metadata_section(filename: &Path) -> Result<SpanBlob, String> {
     // mmap the file, because only a small fraction of it is read.
     let file = std::fs::File::open(filename)

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -951,7 +951,6 @@ fn get_rmeta_metadata_section<'a, 'p>(filename: &'p Path) -> Result<OwnedSlice, 
 }
 
 /// Loads a span metadata file (.spans) that accompanies rmeta files compiled with -Z separate_spans.
-#[allow(dead_code)] // TODO: used by RDR span file infrastructure
 pub(crate) fn get_span_metadata_section(filename: &Path) -> Result<SpanBlob, String> {
     // mmap the file, because only a small fraction of it is read.
     let file = std::fs::File::open(filename)
@@ -1036,6 +1035,7 @@ pub(crate) enum CrateError {
     DlSym(String, String),
     LocatorCombined(Box<CombinedLocatorError>),
     NotFound(Symbol),
+    MissingSpanFile(Symbol, String),
 }
 
 enum MetadataError<'a> {
@@ -1244,6 +1244,9 @@ impl CrateError {
                 } else {
                     dcx.emit_err(error);
                 }
+            }
+            CrateError::MissingSpanFile(crate_name, reason) => {
+                dcx.emit_err(errors::MissingSpanFile { span, crate_name, reason });
             }
         }
     }

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -2197,7 +2197,6 @@ impl CrateMetadata {
         cstore: &CStore,
         blob: MetadataBlob,
         root: CrateRoot,
-        span_file_path: Option<PathBuf>,
         raw_proc_macros: Option<&'static [ProcMacro]>,
         cnum: CrateNum,
         cnum_map: CrateNumMap,
@@ -2220,7 +2219,7 @@ impl CrateMetadata {
 
         let mut cdata = CrateMetadata {
             blob,
-            span_file_path,
+            span_file_path: source.spans.clone(),
             span_file_data: OnceLock::new(),
             root,
             trait_impls,

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -2301,7 +2301,7 @@ impl CrateMetadata {
             ));
         }
 
-        Ok(SpanFileData { blob, source_map: root.source_map() })
+        Ok(SpanFileData { blob, source_map: root.source_map })
     }
 
     pub(crate) fn dependencies(&self) -> impl Iterator<Item = CrateNum> {

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -33,7 +33,7 @@ use rustc_session::config::TargetModifier;
 use rustc_session::cstore::{CrateSource, ExternCrate};
 use rustc_span::hygiene::HygieneDecodeContext;
 use rustc_span::{
-    BlobDecoder, BytePos, ByteSymbol, DUMMY_SP, Pos, RemapPathScopeComponents, SpanData,
+    BlobDecoder, BytePos, ByteSymbol, DUMMY_SP, IdentRef, Pos, RemapPathScopeComponents, SpanData,
     SpanDecoder, Symbol, SyntaxContext, kw,
 };
 use tracing::debug;
@@ -1316,7 +1316,7 @@ impl<'a> CrateMetadataRef<'a> {
             .expect("argument names not encoded for a function")
             .decode((self, tcx))
             .nth(0)
-            .is_some_and(|ident| matches!(ident, Some(Ident { name: kw::SelfLower, .. })))
+            .is_some_and(|ident| matches!(ident, Some(IdentRef { name: kw::SelfLower, .. })))
     }
 
     fn get_associated_item_or_field_def_ids(

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1005,7 +1005,8 @@ impl<'a> CrateMetadataRef<'a> {
             .def_ident_span
             .get((self, tcx), item_index)
             .unwrap_or_else(|| self.missing("def_ident_span", item_index))
-            .decode((self, tcx));
+            .decode((self, tcx))
+            .span();
         Some(Ident::new(name, span))
     }
 
@@ -1033,6 +1034,7 @@ impl<'a> CrateMetadataRef<'a> {
             .get((self, tcx), index)
             .unwrap_or_else(|| self.missing("def_span", index))
             .decode((self, tcx))
+            .span()
     }
 
     fn load_proc_macro<'tcx>(self, tcx: TyCtxt<'tcx>, id: DefIndex) -> SyntaxExtension {
@@ -1466,6 +1468,7 @@ impl<'a> CrateMetadataRef<'a> {
             .get((self, tcx), index)
             .unwrap_or_else(|| panic!("Missing proc macro quoted span: {index:?}"))
             .decode((self, tcx))
+            .span()
     }
 
     fn get_foreign_modules(self, tcx: TyCtxt<'_>) -> impl Iterator<Item = ForeignModule> {

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -21,8 +21,7 @@ use rustc_session::cstore::{CrateStore, ExternCrate};
 use rustc_span::hygiene::ExpnId;
 use rustc_span::{Ident, Span, SpanRef, SpanResolver, Symbol, kw};
 
-use super::{Decodable, DecodeIterator};
-use super::TyCtxtSpanResolver;
+use super::{Decodable, DecodeIterator, TyCtxtSpanResolver};
 use crate::creader::{CStore, LoadedMacro};
 use crate::rmeta::AttrFlags;
 use crate::rmeta::table::IsDefault;

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -2828,7 +2828,7 @@ fn with_encode_metadata_header(
     }
 
     let file = ecx.opaque.file();
-    if let Err(err) = encode_root_position(file, root_position) {
+    if let Err(err) = encode_root_position(file, root_position, METADATA_HEADER.len()) {
         tcx.dcx().emit_fatal(FailWriteFile { path: ecx.opaque.path(), err });
     }
 
@@ -2887,21 +2887,21 @@ fn with_encode_span_header(
     }
 
     let file = ecx.opaque.file();
-    if let Err(err) = encode_root_position(file, root_position) {
+    if let Err(err) = encode_root_position(file, root_position, SPAN_HEADER.len()) {
         tcx.dcx().emit_fatal(FailWriteFile { path: ecx.opaque.path(), err });
     }
 }
 
-fn encode_root_position(mut file: &File, pos: usize) -> Result<(), std::io::Error> {
-    // We will return to this position after writing the root position.
+fn encode_root_position(
+    mut file: &File,
+    pos: usize,
+    header_len: usize,
+) -> Result<(), std::io::Error> {
     let pos_before_seek = file.stream_position().unwrap();
 
-    // Encode the root position.
-    let header = METADATA_HEADER.len();
-    file.seek(std::io::SeekFrom::Start(header as u64))?;
+    file.seek(std::io::SeekFrom::Start(header_len as u64))?;
     file.write_all(&pos.to_le_bytes())?;
 
-    // Return to the position where we are before writing the root position.
     file.seek(std::io::SeekFrom::Start(pos_before_seek))?;
     Ok(())
 }

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1528,7 +1528,8 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             if let DefKind::Fn | DefKind::AssocFn = def_kind {
                 let asyncness = tcx.asyncness(def_id);
                 self.tables.asyncness.set(def_id.index, asyncness);
-                record_array!(self.tables.fn_arg_idents[def_id] <- tcx.fn_arg_idents(def_id));
+                record_array!(self.tables.fn_arg_idents[def_id] <-
+                    tcx.fn_arg_idents(def_id).iter().map(|opt| opt.map(|id| id.to_ident_ref())));
             }
             if let Some(name) = tcx.intrinsic(def_id) {
                 record!(self.tables.intrinsic[def_id] <- name);

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -2674,7 +2674,7 @@ fn with_encode_span_header(
     }
 
     let file = ecx.opaque.file();
-    if let Err(err) = encode_span_root_position(file, root_position) {
+    if let Err(err) = encode_root_position(file, root_position) {
         tcx.dcx().emit_fatal(FailWriteFile { path: ecx.opaque.path(), err });
     }
 }

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -38,7 +38,7 @@ use rustc_session::config::{SymbolManglingVersion, TargetModifier};
 use rustc_session::cstore::{CrateDepKind, ForeignModule, LinkagePreference, NativeLib};
 use rustc_span::edition::Edition;
 use rustc_span::hygiene::{ExpnIndex, MacroKind, SyntaxContextKey};
-use rustc_span::{self, ExpnData, ExpnHash, ExpnId, Ident, Span, Symbol};
+use rustc_span::{self, ExpnData, ExpnHash, ExpnId, Ident, Span, SpanRef, Symbol};
 use rustc_target::spec::{PanicStrategy, TargetTuple};
 use table::TableBuilder;
 use {rustc_ast as ast, rustc_hir as hir};
@@ -388,12 +388,12 @@ define_tables! {
     // Note also that this table is fully populated (no gaps) as every DefIndex should have a
     // corresponding DefPathHash.
     def_path_hashes: Table<DefIndex, u64>,
-    explicit_item_bounds: Table<DefIndex, LazyArray<(ty::Clause<'static>, Span)>>,
-    explicit_item_self_bounds: Table<DefIndex, LazyArray<(ty::Clause<'static>, Span)>>,
-    inferred_outlives_of: Table<DefIndex, LazyArray<(ty::Clause<'static>, Span)>>,
-    explicit_super_predicates_of: Table<DefIndex, LazyArray<(ty::Clause<'static>, Span)>>,
-    explicit_implied_predicates_of: Table<DefIndex, LazyArray<(ty::Clause<'static>, Span)>>,
-    explicit_implied_const_bounds: Table<DefIndex, LazyArray<(ty::PolyTraitRef<'static>, Span)>>,
+    explicit_item_bounds: Table<DefIndex, LazyArray<(ty::Clause<'static>, SpanRef)>>,
+    explicit_item_self_bounds: Table<DefIndex, LazyArray<(ty::Clause<'static>, SpanRef)>>,
+    inferred_outlives_of: Table<DefIndex, LazyArray<(ty::Clause<'static>, SpanRef)>>,
+    explicit_super_predicates_of: Table<DefIndex, LazyArray<(ty::Clause<'static>, SpanRef)>>,
+    explicit_implied_predicates_of: Table<DefIndex, LazyArray<(ty::Clause<'static>, SpanRef)>>,
+    explicit_implied_const_bounds: Table<DefIndex, LazyArray<(ty::PolyTraitRef<'static>, SpanRef)>>,
     inherent_impls: Table<DefIndex, LazyArray<DefIndex>>,
     opt_rpitit_info: Table<DefIndex, Option<LazyValue<ty::ImplTraitInTraitData>>>,
     // Reexported names are not associated with individual `DefId`s,
@@ -416,8 +416,8 @@ define_tables! {
     associated_item_or_field_def_ids: Table<DefIndex, LazyArray<DefIndex>>,
     def_kind: Table<DefIndex, DefKind>,
     visibility: Table<DefIndex, LazyValue<ty::Visibility<DefIndex>>>,
-    def_span: Table<DefIndex, LazyValue<Span>>,
-    def_ident_span: Table<DefIndex, LazyValue<Span>>,
+    def_span: Table<DefIndex, LazyValue<SpanRef>>,
+    def_ident_span: Table<DefIndex, LazyValue<SpanRef>>,
     lookup_stability: Table<DefIndex, LazyValue<hir::Stability>>,
     lookup_const_stability: Table<DefIndex, LazyValue<hir::ConstStability>>,
     lookup_default_body_stability: Table<DefIndex, LazyValue<hir::DefaultBodyStability>>,
@@ -462,7 +462,7 @@ define_tables! {
     // `DefPathTable` up front, since we may only ever use a few
     // definitions from any given crate.
     def_keys: Table<DefIndex, LazyValue<DefKey>>,
-    proc_macro_quoted_spans: Table<usize, LazyValue<Span>>,
+    proc_macro_quoted_spans: Table<usize, LazyValue<SpanRef>>,
     variant_data: Table<DefIndex, LazyValue<VariantData>>,
     assoc_container: Table<DefIndex, LazyValue<ty::AssocContainer>>,
     macro_definition: Table<DefIndex, LazyValue<ast::DelimArgs>>,
@@ -471,7 +471,7 @@ define_tables! {
     trait_impl_trait_tys: Table<DefIndex, LazyValue<DefIdMap<ty::EarlyBinder<'static, Ty<'static>>>>>,
     doc_link_resolutions: Table<DefIndex, LazyValue<DocLinkResMap>>,
     doc_link_traits_in_scope: Table<DefIndex, LazyArray<DefId>>,
-    assumed_wf_types_for_rpitit: Table<DefIndex, LazyArray<(Ty<'static>, Span)>>,
+    assumed_wf_types_for_rpitit: Table<DefIndex, LazyArray<(Ty<'static>, SpanRef)>>,
     opaque_ty_origin: Table<DefIndex, LazyValue<hir::OpaqueTyOrigin<DefId>>>,
     anon_const_kind: Table<DefIndex, LazyValue<ty::AnonConstKind>>,
     const_of_item: Table<DefIndex, LazyValue<ty::EarlyBinder<'static, ty::Const<'static>>>>,

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -344,9 +344,9 @@ pub(crate) struct CrateRoot {
 
     specialization_enabled_in: bool,
 
-    /// Whether this crate was compiled with `-Z separate-spans`.
+    /// Whether this crate was compiled with `-Z stable-crate-hash`.
     /// If true, span data is in a separate `.spans` file, not in this rmeta.
-    has_separate_spans: bool,
+    has_stable_crate_hash: bool,
 }
 
 /// On-disk representation of `DefId`.

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -5,7 +5,7 @@ use decoder::LazyDecoder;
 pub(crate) use decoder::{CrateMetadata, CrateNumMap, MetadataBlob, SpanBlob, TargetModifiers};
 use def_path_hash_map::DefPathHashMapRef;
 use encoder::EncodeContext;
-pub use encoder::{EncodedMetadata, encode_metadata, rendered_const};
+pub use encoder::{EncodedMetadata, encode_metadata, encode_spans, rendered_const};
 pub(crate) use parameterized::ParameterizedOverTcx;
 use rustc_abi::{FieldIdx, ReprOptions, VariantIdx};
 use rustc_data_structures::fx::FxHashMap;
@@ -34,6 +34,7 @@ use rustc_middle::ty::fast_reject::SimplifiedType;
 use rustc_middle::ty::{self, Ty, TyCtxt, UnusedGenericParams};
 use rustc_middle::util::Providers;
 use rustc_serialize::opaque::FileEncoder;
+use rustc_serialize::{Decoder, Encoder};
 use rustc_session::config::{SymbolManglingVersion, TargetModifier};
 use rustc_session::cstore::{CrateDepKind, ForeignModule, LinkagePreference, NativeLib};
 use rustc_span::edition::Edition;
@@ -86,6 +87,7 @@ pub(crate) struct SpanFileRoot {
     source_map: LazyTable<u32, Option<LazyValue<rustc_span::SourceFile>>>,
 }
 
+#[allow(dead_code)] // FIXME: used by RDR span file infrastructure
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum DefIdEncoding {
     Direct,

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -38,7 +38,7 @@ use rustc_session::config::{SymbolManglingVersion, TargetModifier};
 use rustc_session::cstore::{CrateDepKind, ForeignModule, LinkagePreference, NativeLib};
 use rustc_span::edition::Edition;
 use rustc_span::hygiene::{ExpnIndex, MacroKind, SyntaxContextKey};
-use rustc_span::{self, ExpnData, ExpnHash, ExpnId, Ident, Span, SpanRef, Symbol};
+use rustc_span::{self, ExpnData, ExpnHash, ExpnId, Ident, IdentRef, Span, SpanRef, Symbol};
 use rustc_target::spec::{PanicStrategy, TargetTuple};
 use table::TableBuilder;
 use {rustc_ast as ast, rustc_hir as hir};
@@ -445,7 +445,7 @@ define_tables! {
     mir_const_qualif: Table<DefIndex, LazyValue<mir::ConstQualifs>>,
     rendered_const: Table<DefIndex, LazyValue<String>>,
     rendered_precise_capturing_args: Table<DefIndex, LazyArray<PreciseCapturingArgKind<Symbol, Symbol>>>,
-    fn_arg_idents: Table<DefIndex, LazyArray<Option<Ident>>>,
+    fn_arg_idents: Table<DefIndex, LazyArray<Option<IdentRef>>>,
     coroutine_kind: Table<DefIndex, hir::CoroutineKind>,
     coroutine_for_closure: Table<DefIndex, RawDefId>,
     adt_destructor: Table<DefIndex, LazyValue<ty::Destructor>>,

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -343,6 +343,10 @@ pub(crate) struct CrateRoot {
     symbol_mangling_version: SymbolManglingVersion,
 
     specialization_enabled_in: bool,
+
+    /// Whether this crate was compiled with `-Z separate-spans`.
+    /// If true, span data is in a separate `.spans` file, not in this rmeta.
+    has_separate_spans: bool,
 }
 
 /// On-disk representation of `DefId`.

--- a/compiler/rustc_metadata/src/rmeta/parameterized.rs
+++ b/compiler/rustc_metadata/src/rmeta/parameterized.rs
@@ -129,6 +129,7 @@ trivially_parameterized_over_tcx! {
     rustc_span::Ident,
     rustc_span::SourceFile,
     rustc_span::Span,
+    rustc_span::SpanRef,
     rustc_span::Symbol,
     rustc_span::hygiene::SyntaxContextKey,
     // tidy-alphabetical-end

--- a/compiler/rustc_metadata/src/rmeta/parameterized.rs
+++ b/compiler/rustc_metadata/src/rmeta/parameterized.rs
@@ -127,6 +127,7 @@ trivially_parameterized_over_tcx! {
     rustc_span::ExpnHash,
     rustc_span::ExpnId,
     rustc_span::Ident,
+    rustc_span::IdentRef,
     rustc_span::SourceFile,
     rustc_span::Span,
     rustc_span::SpanRef,

--- a/compiler/rustc_metadata/src/rmeta/parameterized.rs
+++ b/compiler/rustc_metadata/src/rmeta/parameterized.rs
@@ -71,6 +71,8 @@ trivially_parameterized_over_tcx! {
     crate::rmeta::CrateRoot,
     crate::rmeta::IncoherentImpls,
     crate::rmeta::RawDefId,
+    crate::rmeta::SpanFileHeader,
+    crate::rmeta::SpanFileRoot,
     crate::rmeta::TraitImpls,
     crate::rmeta::VariantData,
     rustc_abi::ReprOptions,

--- a/compiler/rustc_middle/src/hir/mod.rs
+++ b/compiler/rustc_middle/src/hir/mod.rs
@@ -378,6 +378,7 @@ pub struct Hashes {
 pub fn provide(providers: &mut Providers) {
     providers.hir_crate_items = map::hir_crate_items;
     providers.crate_hash = map::crate_hash;
+    providers.public_api_hash = map::public_api_hash;
     providers.hir_module_items = map::hir_module_items;
     providers.local_def_id_to_hir_id = |tcx, def_id| match tcx.hir_crate(()).owners[def_id] {
         MaybeOwner::Owner(_) => HirId::make_owner(def_id),

--- a/compiler/rustc_middle/src/query/erase.rs
+++ b/compiler/rustc_middle/src/query/erase.rs
@@ -3,6 +3,7 @@ use std::intrinsics::transmute_unchecked;
 use std::mem::MaybeUninit;
 
 use rustc_ast::tokenstream::TokenStream;
+use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_span::ErrorGuaranteed;
 use rustc_span::source_map::Spanned;
 
@@ -75,6 +76,10 @@ impl<T> EraseType for &'_ [T] {
 
 impl EraseType for &'_ OsStr {
     type Result = [u8; size_of::<&'static OsStr>()];
+}
+
+impl EraseType for Fingerprint {
+    type Result = [u8; size_of::<Fingerprint>()];
 }
 
 impl<T> EraseType for &'_ ty::List<T> {

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -98,7 +98,7 @@ use rustc_session::cstore::{
 use rustc_session::lint::LintExpectationId;
 use rustc_span::def_id::LOCAL_CRATE;
 use rustc_span::source_map::Spanned;
-use rustc_span::{DUMMY_SP, LocalExpnId, Span, Symbol};
+use rustc_span::{DUMMY_SP, LocalExpnId, Span, SpanRef, Symbol};
 use rustc_target::spec::PanicStrategy;
 use {rustc_abi as abi, rustc_ast as ast, rustc_hir as hir};
 
@@ -507,7 +507,7 @@ rustc_queries! {
     /// fn function() -> impl Debug + Display { /*...*/ }
     /// //                    ^^^^^^^^^^^^^^^
     /// ```
-    query explicit_item_bounds(key: DefId) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, Span)]> {
+    query explicit_item_bounds(key: DefId) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, SpanRef)]> {
         desc { |tcx| "finding item bounds for `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
@@ -520,7 +520,7 @@ rustc_queries! {
     /// like closure signature deduction.
     ///
     /// [explicit item bounds]: Self::explicit_item_bounds
-    query explicit_item_self_bounds(key: DefId) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, Span)]> {
+    query explicit_item_self_bounds(key: DefId) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, SpanRef)]> {
         desc { |tcx| "finding item bounds for `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
@@ -850,7 +850,7 @@ rustc_queries! {
     ///
     /// **Tip**: You can use `#[rustc_outlives]` on an item to basically print the
     /// result of this query for use in UI tests or for debugging purposes.
-    query inferred_outlives_of(key: DefId) -> &'tcx [(ty::Clause<'tcx>, Span)] {
+    query inferred_outlives_of(key: DefId) -> &'tcx [(ty::Clause<'tcx>, SpanRef)] {
         desc { |tcx| "computing inferred outlives-predicates of `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
@@ -864,7 +864,7 @@ rustc_queries! {
     /// This is a subset of the full list of predicates. We store these in a separate map
     /// because we must evaluate them even during type conversion, often before the full
     /// predicates are available (note that super-predicates must not be cyclic).
-    query explicit_super_predicates_of(key: DefId) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, Span)]> {
+    query explicit_super_predicates_of(key: DefId) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, SpanRef)]> {
         desc { |tcx| "computing the super predicates of `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
@@ -876,7 +876,7 @@ rustc_queries! {
     /// of the trait. For regular traits, this includes all super-predicates and their
     /// associated type bounds. For trait aliases, currently, this includes all of the
     /// predicates of the trait alias.
-    query explicit_implied_predicates_of(key: DefId) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, Span)]> {
+    query explicit_implied_predicates_of(key: DefId) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, SpanRef)]> {
         desc { |tcx| "computing the implied predicates of `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
@@ -887,7 +887,7 @@ rustc_queries! {
     /// cycles in resolving type-dependent associated item paths like `T::Item`.
     query explicit_supertraits_containing_assoc_item(
         key: (DefId, rustc_span::Ident)
-    ) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, Span)]> {
+    ) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, SpanRef)]> {
         desc { |tcx| "computing the super traits of `{}` with associated type name `{}`",
             tcx.def_path_str(key.0),
             key.1
@@ -930,7 +930,7 @@ rustc_queries! {
     /// per-type-parameter predicates for resolving `T::AssocTy`.
     query type_param_predicates(
         key: (LocalDefId, LocalDefId, rustc_span::Ident)
-    ) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, Span)]> {
+    ) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, SpanRef)]> {
         desc { |tcx| "computing the bounds for type parameter `{}`", tcx.hir_ty_param_name(key.1) }
     }
 
@@ -1180,13 +1180,13 @@ rustc_queries! {
     ///
     /// Note that we've liberated the late bound regions of function signatures, so
     /// this can not be used to check whether these types are well formed.
-    query assumed_wf_types(key: LocalDefId) -> &'tcx [(Ty<'tcx>, Span)] {
+    query assumed_wf_types(key: LocalDefId) -> &'tcx [(Ty<'tcx>, SpanRef)] {
         desc { |tcx| "computing the implied bounds of `{}`", tcx.def_path_str(key) }
     }
 
     /// We need to store the assumed_wf_types for an RPITIT so that impls of foreign
     /// traits with return-position impl trait in traits can inherit the right wf types.
-    query assumed_wf_types_for_rpitit(key: DefId) -> &'tcx [(Ty<'tcx>, Span)] {
+    query assumed_wf_types_for_rpitit(key: DefId) -> &'tcx [(Ty<'tcx>, SpanRef)] {
         desc { |tcx| "computing the implied bounds of `{}`", tcx.def_path_str(key) }
         separate_provide_extern
     }

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -71,6 +71,7 @@ use rustc_abi::Align;
 use rustc_arena::TypedArena;
 use rustc_ast::expand::allocator::AllocatorKind;
 use rustc_ast::tokenstream::TokenStream;
+use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::fx::{FxIndexMap, FxIndexSet};
 use rustc_data_structures::sorted_map::SortedMap;
 use rustc_data_structures::steal::Steal;
@@ -2049,6 +2050,12 @@ rustc_queries! {
     /// Finds the `rustc_proc_macro_decls` item of a crate.
     query proc_macro_decls_static(_: ()) -> Option<LocalDefId> {
         desc { "looking up the proc macro declarations for a crate" }
+    }
+
+    /// Computes a hash of only the publicly-reachable API.
+    /// This hash is stable when private items change.
+    query public_api_hash(_: ()) -> Fingerprint {
+        desc { "computing public API hash" }
     }
 
     // The macro which defines `rustc_metadata::provide_extern` depends on this query's name.

--- a/compiler/rustc_middle/src/query/on_disk_cache.rs
+++ b/compiler/rustc_middle/src/query/on_disk_cache.rs
@@ -21,7 +21,7 @@ use rustc_span::hygiene::{
 use rustc_span::source_map::Spanned;
 use rustc_span::{
     BlobDecoder, BytePos, ByteSymbol, CachingSourceMapView, ExpnData, ExpnHash, RelativeBytePos,
-    SourceFile, Span, SpanDecoder, SpanEncoder, StableSourceFileId, Symbol,
+    SourceFile, Span, SpanDecoder, SpanEncoder, SpanRef, StableSourceFileId, Symbol,
 };
 
 use crate::dep_graph::{DepNodeIndex, SerializedDepNodeIndex};
@@ -756,6 +756,20 @@ impl<'a, 'tcx> Decodable<CacheDecoder<'a, 'tcx>>
 }
 
 impl<'a, 'tcx> Decodable<CacheDecoder<'a, 'tcx>> for &'tcx [(ty::Clause<'tcx>, Span)] {
+    #[inline]
+    fn decode(d: &mut CacheDecoder<'a, 'tcx>) -> Self {
+        RefDecodable::decode(d)
+    }
+}
+
+impl<'a, 'tcx> Decodable<CacheDecoder<'a, 'tcx>> for &'tcx [(ty::Clause<'tcx>, SpanRef)] {
+    #[inline]
+    fn decode(d: &mut CacheDecoder<'a, 'tcx>) -> Self {
+        RefDecodable::decode(d)
+    }
+}
+
+impl<'a, 'tcx> Decodable<CacheDecoder<'a, 'tcx>> for &'tcx [(Ty<'tcx>, SpanRef)] {
     #[inline]
     fn decode(d: &mut CacheDecoder<'a, 'tcx>) -> Self {
         RefDecodable::decode(d)

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -15,7 +15,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def_id::LocalDefId;
 use rustc_serialize::{Decodable, Encodable};
 use rustc_span::source_map::Spanned;
-use rustc_span::{Span, SpanDecoder, SpanEncoder};
+use rustc_span::{Span, SpanDecoder, SpanEncoder, SpanRef};
 
 use crate::arena::ArenaAllocatable;
 use crate::infer::canonical::{CanonicalVarKind, CanonicalVarKinds};
@@ -401,6 +401,24 @@ impl<'tcx, D: TyDecoder<'tcx>> Decodable<D> for AdtDef<'tcx> {
 }
 
 impl<'tcx, D: TyDecoder<'tcx>> RefDecodable<'tcx, D> for [(ty::Clause<'tcx>, Span)] {
+    fn decode(decoder: &mut D) -> &'tcx Self {
+        decoder
+            .interner()
+            .arena
+            .alloc_from_iter((0..decoder.read_usize()).map(|_| Decodable::decode(decoder)))
+    }
+}
+
+impl<'tcx, D: TyDecoder<'tcx>> RefDecodable<'tcx, D> for [(ty::Clause<'tcx>, SpanRef)] {
+    fn decode(decoder: &mut D) -> &'tcx Self {
+        decoder
+            .interner()
+            .arena
+            .alloc_from_iter((0..decoder.read_usize()).map(|_| Decodable::decode(decoder)))
+    }
+}
+
+impl<'tcx, D: TyDecoder<'tcx>> RefDecodable<'tcx, D> for [(Ty<'tcx>, SpanRef)] {
     fn decode(decoder: &mut D) -> &'tcx Self {
         decoder
             .interner()

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2543,7 +2543,6 @@ impl<'tcx> TyCtxt<'tcx> {
         let rel_lo = (data.lo - source_file.start_pos).0;
         let rel_hi = (data.hi - source_file.start_pos).0;
 
-        // Get the source crate's stable ID
         let source_crate = self.stable_crate_id(source_file.cnum);
 
         SpanRef::FileRelative {

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -272,6 +272,7 @@ TrivialTypeTraversalImpls! {
     rustc_hir::def_id::LocalDefId,
     rustc_span::Ident,
     rustc_span::Span,
+    rustc_span::SpanRef,
     rustc_span::Symbol,
     rustc_target::asm::InlineAsmRegOrRegClass,
     // tidy-alphabetical-end

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -273,7 +273,13 @@ where
                     // through the trait list (default type visitor doesn't visit those traits).
                     // All traits in the list are considered the "primary" part of the type
                     // and are visited by shallow visitors.
-                    try_visit!(self.visit_clauses(tcx.explicit_item_bounds(def_id).skip_binder()));
+                    let bounds: Vec<_> = tcx
+                        .explicit_item_bounds(def_id)
+                        .skip_binder()
+                        .iter()
+                        .map(|(clause, span)| (*clause, tcx.resolve_span_ref(*span)))
+                        .collect();
+                    try_visit!(self.visit_clauses(&bounds));
                 }
             }
             // These types don't have their own def-ids (but may have subcomponents
@@ -1392,7 +1398,14 @@ impl SearchInterfaceForPrivateItemsVisitor<'_> {
 
     fn bounds(&mut self) -> &mut Self {
         self.in_primary_interface = false;
-        let _ = self.visit_clauses(self.tcx.explicit_item_bounds(self.item_def_id).skip_binder());
+        let bounds: Vec<_> = self
+            .tcx
+            .explicit_item_bounds(self.item_def_id)
+            .skip_binder()
+            .iter()
+            .map(|(clause, span)| (*clause, self.tcx.resolve_span_ref(*span)))
+            .collect();
+        let _ = self.visit_clauses(&bounds);
         self
     }
 

--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -61,6 +61,13 @@ impl QueryStackFrame {
     }
 }
 
+/// A diagnostic side effect stored for query replay.
+#[derive(Debug, Encodable, Decodable)]
+pub struct DiagnosticSideEffect {
+    pub diagnostic: DiagInner,
+    pub spans_hash: Option<u64>,
+}
+
 /// Tracks 'side effects' for a particular query.
 /// This struct is saved to disk along with the query result,
 /// and loaded from disk if we mark the query as green.
@@ -76,7 +83,7 @@ pub enum QuerySideEffect {
     /// This diagnostic will be re-emitted if we mark
     /// the query as green, as that query will have the side
     /// effect dep node as a dependency.
-    Diagnostic(DiagInner),
+    Diagnostic(DiagnosticSideEffect),
 }
 
 pub trait QueryContext: HasDepContext {

--- a/compiler/rustc_session/src/cstore.rs
+++ b/compiler/rustc_session/src/cstore.rs
@@ -25,6 +25,8 @@ pub struct CrateSource {
     pub rlib: Option<PathBuf>,
     pub rmeta: Option<PathBuf>,
     pub sdylib_interface: Option<PathBuf>,
+    /// Path to `.spans` file for crates compiled with `-Z separate-spans`.
+    pub spans: Option<PathBuf>,
 }
 
 impl CrateSource {

--- a/compiler/rustc_session/src/cstore.rs
+++ b/compiler/rustc_session/src/cstore.rs
@@ -25,7 +25,7 @@ pub struct CrateSource {
     pub rlib: Option<PathBuf>,
     pub rmeta: Option<PathBuf>,
     pub sdylib_interface: Option<PathBuf>,
-    /// Path to `.spans` file for crates compiled with `-Z separate-spans`.
+    /// Path to `.spans` file for crates compiled with `-Z stable-crate-hash`.
     pub spans: Option<PathBuf>,
 }
 

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2658,8 +2658,8 @@ written to standard error output)"),
         for example: `-Z self-profile-events=default,query-keys`
         all options: none, all, default, generic-activity, query-provider, query-cache-hit
                      query-blocked, incr-cache-load, incr-result-hashing, query-keys, function-args, args, llvm, artifact-sizes"),
-    separate_spans: bool = (false, parse_bool, [TRACKED],
-        "store span data in a separate .spans file for Relink, Don't Rebuild (RDR) (default: no)"),
+    stable_crate_hash: bool = (false, parse_bool, [TRACKED],
+        "stabilize the crate hash by storing spans separately, enabling relink-don't-rebuild (default: no)"),
     share_generics: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "make the current crate share its generic instantiations"),
     shell_argfiles: bool = (false, parse_bool, [UNTRACKED],

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2658,6 +2658,8 @@ written to standard error output)"),
         for example: `-Z self-profile-events=default,query-keys`
         all options: none, all, default, generic-activity, query-provider, query-cache-hit
                      query-blocked, incr-cache-load, incr-result-hashing, query-keys, function-args, args, llvm, artifact-sizes"),
+    separate_spans: bool = (false, parse_bool, [TRACKED],
+        "store span data in a separate .spans file for Relink, Don't Rebuild (RDR) (default: no)"),
     share_generics: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "make the current crate share its generic instantiations"),
     shell_argfiles: bool = (false, parse_bool, [UNTRACKED],

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1,7 +1,8 @@
 use std::any::Any;
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, OnceLock};
 use std::sync::atomic::AtomicBool;
 use std::{env, io};
 
@@ -10,6 +11,7 @@ use rustc_data_structures::base_n::{CASE_INSENSITIVE, ToBaseN};
 use rustc_data_structures::flock;
 use rustc_data_structures::fx::{FxHashMap, FxIndexSet};
 use rustc_data_structures::profiling::{SelfProfiler, SelfProfilerRef};
+use rustc_data_structures::stable_hasher::StableHasher;
 use rustc_data_structures::sync::{DynSend, DynSync, Lock, MappedReadGuard, ReadGuard, RwLock};
 use rustc_errors::annotate_snippet_emitter_writer::AnnotateSnippetEmitter;
 use rustc_errors::codes::*;
@@ -23,7 +25,7 @@ use rustc_errors::{
 };
 use rustc_hir::limit::Limit;
 use rustc_macros::HashStable_Generic;
-pub use rustc_span::def_id::StableCrateId;
+pub use rustc_span::def_id::{LOCAL_CRATE, StableCrateId};
 use rustc_span::edition::Edition;
 use rustc_span::source_map::{FilePathMapping, SourceMap};
 use rustc_span::{RealFileName, Span, Symbol};
@@ -105,6 +107,8 @@ pub struct Session {
 
     /// Data about code being compiled, gathered during compilation.
     pub code_stats: CodeStats,
+
+    diagnostic_spans_hash: OnceLock<Option<u64>>,
 
     /// This only ever stores a `LintStore` but we don't want a dependency on that type here.
     pub lint_store: Option<Arc<dyn DynLintStore>>,
@@ -278,6 +282,24 @@ impl Session {
     #[inline]
     pub fn source_map(&self) -> &SourceMap {
         self.psess.source_map()
+    }
+
+    pub fn diagnostic_spans_hash(&self) -> Option<u64> {
+        if !self.opts.unstable_opts.separate_spans {
+            return None;
+        }
+
+        *self.diagnostic_spans_hash.get_or_init(|| {
+            let mut hasher = StableHasher::new();
+            for source_file in self.source_map().files().iter() {
+                if source_file.cnum != LOCAL_CRATE {
+                    continue;
+                }
+                source_file.stable_id.hash(&mut hasher);
+                source_file.src_hash.hash(&mut hasher);
+            }
+            Some(hasher.finish::<Hash64>().as_u64())
+        })
     }
 
     /// Returns `true` if internal lints should be added to the lint store - i.e. if
@@ -1082,6 +1104,7 @@ pub fn build_session(
         prof,
         timings,
         code_stats: Default::default(),
+        diagnostic_spans_hash: OnceLock::new(),
         lint_store: None,
         driver_lint_caps,
         ctfe_backtrace,

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1,9 +1,9 @@
 use std::any::Any;
+use std::hash::Hash;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, OnceLock};
-use std::sync::atomic::AtomicBool;
 use std::{env, io};
 
 use rand::{RngCore, rng};
@@ -23,6 +23,7 @@ use rustc_errors::{
     Diag, DiagCtxt, DiagCtxtHandle, DiagMessage, Diagnostic, ErrorGuaranteed, FatalAbort,
     TerminalUrl, fallback_fluent_bundle,
 };
+use rustc_hashes::Hash64;
 use rustc_hir::limit::Limit;
 use rustc_macros::HashStable_Generic;
 pub use rustc_span::def_id::{LOCAL_CRATE, StableCrateId};

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -286,7 +286,7 @@ impl Session {
     }
 
     pub fn diagnostic_spans_hash(&self) -> Option<u64> {
-        if !self.opts.unstable_opts.separate_spans {
+        if !self.opts.unstable_opts.stable_crate_hash {
             return None;
         }
 

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -43,7 +43,7 @@ use crate::def_id::{CRATE_DEF_ID, CrateNum, DefId, LOCAL_CRATE, StableCrateId};
 use crate::edition::Edition;
 use crate::source_map::SourceMap;
 use crate::symbol::{Symbol, kw, sym};
-use crate::{DUMMY_SP, HashStableContext, Span, SpanDecoder, SpanEncoder, SpanRef, with_session_globals};
+use crate::{DUMMY_SP, HashStableContext, Span, SpanDecoder, SpanEncoder, with_session_globals};
 
 /// A `SyntaxContext` represents a chain of pairs `(ExpnId, Transparency)` named "marks".
 ///
@@ -1005,7 +1005,7 @@ pub struct ExpnData {
     ///
     /// For a desugaring expansion, this is the span of the expression or node that was
     /// desugared.
-    pub call_site: SpanRef,
+    pub call_site: Span,
     /// Used to force two `ExpnData`s to have different `Fingerprint`s.
     /// Due to macro expansion, it's possible to end up with two `ExpnId`s
     /// that have identical `ExpnData`s. This violates the contract of `HashStable`
@@ -1024,7 +1024,7 @@ pub struct ExpnData {
     // --- noticeable perf improvements (PR #62898).
     /// The span of the macro definition (possibly dummy).
     /// This span serves only informational purpose and is not used for resolution.
-    pub def_site: SpanRef,
+    pub def_site: Span,
     /// List of `#[unstable]`/feature-gated features that the macro is allowed to use
     /// internally without forcing the whole crate to opt-in
     /// to them.
@@ -1068,8 +1068,8 @@ impl ExpnData {
         ExpnData {
             kind,
             parent,
-            call_site: call_site.to_span_ref(),
-            def_site: def_site.to_span_ref(),
+            call_site,
+            def_site,
             allow_internal_unstable,
             edition,
             macro_def_id,
@@ -1093,8 +1093,8 @@ impl ExpnData {
         ExpnData {
             kind,
             parent: ExpnId::root(),
-            call_site: call_site.to_span_ref(),
-            def_site: DUMMY_SP.to_span_ref(),
+            call_site,
+            def_site: DUMMY_SP,
             allow_internal_unstable: None,
             edition,
             macro_def_id,

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -43,7 +43,7 @@ use crate::def_id::{CRATE_DEF_ID, CrateNum, DefId, LOCAL_CRATE, StableCrateId};
 use crate::edition::Edition;
 use crate::source_map::SourceMap;
 use crate::symbol::{Symbol, kw, sym};
-use crate::{DUMMY_SP, HashStableContext, Span, SpanDecoder, SpanEncoder, with_session_globals};
+use crate::{DUMMY_SP, HashStableContext, Span, SpanDecoder, SpanEncoder, SpanRef, with_session_globals};
 
 /// A `SyntaxContext` represents a chain of pairs `(ExpnId, Transparency)` named "marks".
 ///
@@ -1005,7 +1005,7 @@ pub struct ExpnData {
     ///
     /// For a desugaring expansion, this is the span of the expression or node that was
     /// desugared.
-    pub call_site: Span,
+    pub call_site: SpanRef,
     /// Used to force two `ExpnData`s to have different `Fingerprint`s.
     /// Due to macro expansion, it's possible to end up with two `ExpnId`s
     /// that have identical `ExpnData`s. This violates the contract of `HashStable`
@@ -1024,7 +1024,7 @@ pub struct ExpnData {
     // --- noticeable perf improvements (PR #62898).
     /// The span of the macro definition (possibly dummy).
     /// This span serves only informational purpose and is not used for resolution.
-    pub def_site: Span,
+    pub def_site: SpanRef,
     /// List of `#[unstable]`/feature-gated features that the macro is allowed to use
     /// internally without forcing the whole crate to opt-in
     /// to them.
@@ -1068,8 +1068,8 @@ impl ExpnData {
         ExpnData {
             kind,
             parent,
-            call_site,
-            def_site,
+            call_site: call_site.to_span_ref(),
+            def_site: def_site.to_span_ref(),
             allow_internal_unstable,
             edition,
             macro_def_id,
@@ -1093,8 +1093,8 @@ impl ExpnData {
         ExpnData {
             kind,
             parent: ExpnId::root(),
-            call_site,
-            def_site: DUMMY_SP,
+            call_site: call_site.to_span_ref(),
+            def_site: DUMMY_SP.to_span_ref(),
             allow_internal_unstable: None,
             edition,
             macro_def_id,

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -64,8 +64,8 @@ pub use span_encoding::{DUMMY_SP, Span};
 
 pub mod symbol;
 pub use symbol::{
-    ByteSymbol, Ident, MacroRulesNormalizedIdent, Macros20NormalizedIdent, STDLIB_STABLE_CRATES,
-    Symbol, kw, sym,
+    ByteSymbol, Ident, IdentRef, MacroRulesNormalizedIdent, Macros20NormalizedIdent,
+    STDLIB_STABLE_CRATES, Symbol, kw, sym,
 };
 
 mod analyze_source_file;

--- a/compiler/rustc_span/src/span_encoding.rs
+++ b/compiler/rustc_span/src/span_encoding.rs
@@ -5,7 +5,7 @@ use rustc_serialize::int_overflow::DebugStrictAdd;
 
 use crate::def_id::{DefIndex, LocalDefId};
 use crate::hygiene::SyntaxContext;
-use crate::{BytePos, SPAN_TRACK, SpanData};
+use crate::{BytePos, SPAN_TRACK, SpanData, SpanRef};
 
 /// A compressed span.
 ///
@@ -440,6 +440,12 @@ impl Span {
             PartiallyInterned(span) => interned_parent(span.index),
             Interned(span) => interned_parent(span.index),
         }
+    }
+
+    /// Converts to a `SpanRef` for metadata, preserving only `SyntaxContext` for hygiene.
+    #[inline]
+    pub fn to_span_ref(self) -> SpanRef {
+        SpanRef::Opaque { ctxt: self.ctxt() }
     }
 }
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -15,7 +15,7 @@ use rustc_data_structures::sync::Lock;
 use rustc_macros::{Decodable, Encodable, HashStable_Generic, symbols};
 
 use crate::edit_distance::find_best_match_for_name;
-use crate::{DUMMY_SP, Edition, Span, with_session_globals};
+use crate::{DUMMY_SP, Edition, Span, SpanRef, with_session_globals};
 
 #[cfg(test)]
 mod tests;
@@ -2635,6 +2635,12 @@ impl Ident {
     pub fn as_str(&self) -> &str {
         self.name.as_str()
     }
+
+    /// Converts this `Ident` to an `IdentRef` for metadata storage.
+    #[inline]
+    pub fn to_ident_ref(self) -> IdentRef {
+        IdentRef::new(self.name, self.span.to_span_ref())
+    }
 }
 
 impl PartialEq for Ident {
@@ -2664,6 +2670,56 @@ impl fmt::Debug for Ident {
 impl fmt::Display for Ident {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&IdentPrinter::new(self.name, self.guess_print_mode(), None), f)
+    }
+}
+
+/// An identifier without absolute span positions.
+///
+/// Used in metadata to avoid storing byte positions that cause unnecessary
+/// downstream rebuilds. The `SpanRef` preserves `SyntaxContext` for hygiene.
+#[derive(Copy, Clone, Eq, HashStable_Generic, Encodable, Decodable)]
+pub struct IdentRef {
+    pub name: Symbol,
+    pub span: SpanRef,
+}
+
+impl IdentRef {
+    /// Constructs a new identifier reference from a symbol and a span reference.
+    #[inline]
+    pub fn new(name: Symbol, span: SpanRef) -> IdentRef {
+        debug_assert_ne!(name, sym::empty);
+        IdentRef { name, span }
+    }
+
+    /// Access the underlying string.
+    pub fn as_str(&self) -> &str {
+        self.name.as_str()
+    }
+}
+
+impl PartialEq for IdentRef {
+    #[inline]
+    fn eq(&self, rhs: &Self) -> bool {
+        self.name == rhs.name && self.span.ctxt() == rhs.span.ctxt()
+    }
+}
+
+impl Hash for IdentRef {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+        self.span.ctxt().hash(state);
+    }
+}
+
+impl fmt::Debug for IdentRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}{:?}", self.name, self.span.ctxt())
+    }
+}
+
+impl From<Ident> for IdentRef {
+    fn from(ident: Ident) -> IdentRef {
+        ident.to_ident_ref()
     }
 }
 

--- a/compiler/rustc_trait_selection/src/traits/dyn_compatibility.rs
+++ b/compiler/rustc_trait_selection/src/traits/dyn_compatibility.rs
@@ -170,22 +170,33 @@ fn predicates_reference_self(
     supertraits_only: bool,
 ) -> SmallVec<[Span; 1]> {
     let trait_ref = ty::Binder::dummy(ty::TraitRef::identity(tcx, trait_def_id));
-    let predicates = if supertraits_only {
-        tcx.explicit_super_predicates_of(trait_def_id).skip_binder()
+    if supertraits_only {
+        // explicit_super_predicates_of returns SpanRef - resolve to Span
+        tcx.explicit_super_predicates_of(trait_def_id)
+            .skip_binder()
+            .iter()
+            .map(|&(predicate, sp_ref)| {
+                (predicate.instantiate_supertrait(tcx, trait_ref), tcx.resolve_span_ref(sp_ref))
+            })
+            .filter_map(|(clause, sp)| {
+                // Super predicates cannot allow self projections, since they're
+                // impossible to make into existential bounds without eager resolution
+                // or something.
+                // e.g. `trait A: B<Item = Self::Assoc>`.
+                predicate_references_self(tcx, trait_def_id, clause, sp, AllowSelfProjections::No)
+            })
+            .collect()
     } else {
-        tcx.predicates_of(trait_def_id).predicates
-    };
-    predicates
-        .iter()
-        .map(|&(predicate, sp)| (predicate.instantiate_supertrait(tcx, trait_ref), sp))
-        .filter_map(|(clause, sp)| {
-            // Super predicates cannot allow self projections, since they're
-            // impossible to make into existential bounds without eager resolution
-            // or something.
-            // e.g. `trait A: B<Item = Self::Assoc>`.
-            predicate_references_self(tcx, trait_def_id, clause, sp, AllowSelfProjections::No)
-        })
-        .collect()
+        // predicates_of still returns Span, handle it separately
+        tcx.predicates_of(trait_def_id)
+            .predicates
+            .iter()
+            .map(|&(predicate, sp)| (predicate.instantiate_supertrait(tcx, trait_ref), sp))
+            .filter_map(|(clause, sp)| {
+                predicate_references_self(tcx, trait_def_id, clause, sp, AllowSelfProjections::No)
+            })
+            .collect()
+    }
 }
 
 fn bounds_reference_self(tcx: TyCtxt<'_>, trait_def_id: DefId) -> SmallVec<[Span; 1]> {
@@ -196,9 +207,11 @@ fn bounds_reference_self(tcx: TyCtxt<'_>, trait_def_id: DefId) -> SmallVec<[Span
         // Ignore GATs with `Self: Sized`
         .filter(|item| !tcx.generics_require_sized_self(item.def_id))
         .flat_map(|item| tcx.explicit_item_bounds(item.def_id).iter_identity_copied())
-        .filter_map(|(clause, sp)| {
+        .filter_map(|(clause, sp_ref)| {
             // Item bounds *can* have self projections, since they never get
             // their self type erased.
+            // Resolve SpanRef to Span for diagnostic purposes
+            let sp = tcx.resolve_span_ref(sp_ref);
             predicate_references_self(tcx, trait_def_id, clause, sp, AllowSelfProjections::Yes)
         })
         .collect()
@@ -253,7 +266,10 @@ fn super_predicates_have_non_lifetime_binders(
 ) -> SmallVec<[Span; 1]> {
     tcx.explicit_super_predicates_of(trait_def_id)
         .iter_identity_copied()
-        .filter_map(|(pred, span)| pred.has_non_region_bound_vars().then_some(span))
+        .filter_map(|(pred, span_ref)| {
+            // Resolve SpanRef to Span for diagnostic purposes
+            pred.has_non_region_bound_vars().then(|| tcx.resolve_span_ref(span_ref))
+        })
         .collect()
 }
 
@@ -266,9 +282,10 @@ fn super_predicates_are_unconditionally_const(
 ) -> SmallVec<[Span; 1]> {
     tcx.explicit_super_predicates_of(trait_def_id)
         .iter_identity_copied()
-        .filter_map(|(pred, span)| {
+        .filter_map(|(pred, span_ref)| {
             if let ty::ClauseKind::HostEffect(_) = pred.kind().skip_binder() {
-                Some(span)
+                // Resolve SpanRef to Span for diagnostic purposes
+                Some(tcx.resolve_span_ref(span_ref))
             } else {
                 None
             }

--- a/compiler/rustc_trait_selection/src/traits/engine.rs
+++ b/compiler/rustc_trait_selection/src/traits/engine.rs
@@ -314,7 +314,7 @@ where
         let tcx = self.infcx.tcx;
         let mut implied_bounds = FxIndexSet::default();
         let mut errors = Vec::new();
-        for &(ty, span) in tcx.assumed_wf_types(def_id) {
+        for &(ty, span_ref) in tcx.assumed_wf_types(def_id) {
             // FIXME(@lcnr): rustc currently does not check wf for types
             // pre-normalization, meaning that implied bounds are sometimes
             // incorrect. See #100910 for more details.
@@ -327,6 +327,8 @@ where
             // sound and then uncomment this line again.
 
             // implied_bounds.insert(ty);
+            // Resolve SpanRef to Span for diagnostic purposes
+            let span = tcx.resolve_span_ref(span_ref);
             let cause = ObligationCause::misc(span, def_id);
             match self
                 .infcx

--- a/compiler/rustc_trait_selection/src/traits/util.rs
+++ b/compiler/rustc_trait_selection/src/traits/util.rs
@@ -52,9 +52,10 @@ pub fn expand_trait_aliases<'tcx>(
                     queue.extend(
                         tcx.explicit_super_predicates_of(trait_pred.def_id())
                             .iter_identity_copied()
-                            .map(|(super_clause, span)| {
+                            .map(|(super_clause, span_ref)| {
                                 let mut spans = spans.clone();
-                                spans.push(span);
+                                // Resolve SpanRef to Span for diagnostic purposes
+                                spans.push(tcx.resolve_span_ref(span_ref));
                                 (
                                     super_clause.instantiate_supertrait(
                                         tcx,

--- a/compiler/rustc_ty_utils/src/opaque_types.rs
+++ b/compiler/rustc_ty_utils/src/opaque_types.rs
@@ -143,6 +143,7 @@ impl<'tcx> OpaqueTypeCollector<'tcx> {
                 for (pred, span) in
                     self.tcx.explicit_item_bounds(alias_ty.def_id).iter_identity_copied()
                 {
+                    let span = self.tcx.resolve_span_ref(span);
                     trace!(?pred);
                     self.visit_spanned(span, pred);
                 }

--- a/compiler/rustc_ty_utils/src/sig_types.rs
+++ b/compiler/rustc_ty_utils/src/sig_types.rs
@@ -61,6 +61,7 @@ pub fn walk_types<'tcx, V: SpannedTypeVisitor<'tcx>>(
         }
         DefKind::OpaqueTy => {
             for (pred, span) in tcx.explicit_item_bounds(item).iter_identity_copied() {
+                let span = tcx.resolve_span_ref(span);
                 try_visit!(visitor.visit(span, pred));
             }
         }

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -712,6 +712,8 @@ pub fn std_cargo(
     cargo.rustdocflag(&html_root);
 
     cargo.rustdocflag("-Zcrate-attr=warn(rust_2018_idioms)");
+
+    cargo.rustflag("-Zstable-crate-hash");
 }
 
 /// Link all libstd rlibs/dylibs into a sysroot of `target_compiler`.
@@ -2622,6 +2624,15 @@ pub fn add_to_sysroot(
             DependencyType::TargetSelfContained => self_contained_dst,
         };
         builder.copy_link(&path, &dst.join(filename), FileType::Regular);
+
+        // Copy .spans file if present (-Zstable-crate-hash).
+        if filename.ends_with(".rlib") {
+            let spans_filename = filename.replace(".rlib", ".spans");
+            let spans_path = path.parent().unwrap().join(&spans_filename);
+            if spans_path.exists() {
+                builder.copy_link(&spans_path, &dst.join(&spans_filename), FileType::Regular);
+            }
+        }
     }
 
     // Check that none of the rustc_* crates have multiple versions. Otherwise using them from

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1392,7 +1392,10 @@ pub(crate) fn clean_middle_assoc_item(assoc_item: &ty::AssocItem, cx: &mut DocCo
 
             let mut predicates = tcx.explicit_predicates_of(assoc_item.def_id).predicates;
             if let ty::AssocContainer::Trait = assoc_item.container {
-                let bounds = tcx.explicit_item_bounds(assoc_item.def_id).iter_identity_copied();
+                let bounds = tcx
+                    .explicit_item_bounds(assoc_item.def_id)
+                    .iter_identity_copied()
+                    .map(|(clause, span)| (clause, tcx.resolve_span_ref(span)));
                 predicates = tcx.arena.alloc_from_iter(bounds.chain(predicates.iter().copied()));
             }
             let mut generics = clean_ty_generics_inner(

--- a/tests/incremental/hashes/function_interfaces.rs
+++ b/tests/incremental/hashes/function_interfaces.rs
@@ -319,7 +319,10 @@ pub fn change_return_impl_trait() -> impl Clone {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2", except = "opt_hir_owner_nodes")]
+// typeck is now correctly dirty even with -Zincremental-ignore-spans because
+// we now always hash syntax context (for hygiene correctness), and the trait
+// bounds (Clone vs Copy) are semantic differences that should invalidate typeck.
+#[rustc_clean(cfg = "cfail2", except = "opt_hir_owner_nodes, typeck")]
 #[rustc_clean(cfg = "cfail3")]
 #[rustc_clean(cfg = "cfail5", except = "opt_hir_owner_nodes, typeck")]
 #[rustc_clean(cfg = "cfail6")]

--- a/tests/incremental/rdr_add_println_private/auxiliary/dep.rs
+++ b/tests/incremental/rdr_add_println_private/auxiliary/dep.rs
@@ -1,0 +1,70 @@
+// Auxiliary crate for testing that adding println! to a private function
+// does not cause dependent crates to rebuild.
+//
+// This is important for RDR because println! expands to code with spans,
+// and those spans should not leak into the public API metadata.
+
+#![crate_name = "dep"]
+#![crate_type = "rlib"]
+
+// Public API - unchanged across all revisions
+pub fn public_fn(x: u32) -> u32 {
+    private_helper(x)
+}
+
+pub struct PublicStruct {
+    pub value: u32,
+}
+
+impl PublicStruct {
+    pub fn compute(&self) -> u32 {
+        private_compute(self.value)
+    }
+}
+
+// Private implementation
+
+// rpass1: No println
+#[cfg(rpass1)]
+fn private_helper(x: u32) -> u32 {
+    x + 1
+}
+
+// rpass2: Add println! to private function
+#[cfg(rpass2)]
+fn private_helper(x: u32) -> u32 {
+    println!("private_helper called with {}", x);
+    x + 1
+}
+
+// rpass3: Add more println! statements
+#[cfg(rpass3)]
+fn private_helper(x: u32) -> u32 {
+    println!("private_helper called with {}", x);
+    println!("computing result...");
+    let result = x + 1;
+    println!("result is {}", result);
+    result
+}
+
+// rpass1: No println
+#[cfg(rpass1)]
+fn private_compute(x: u32) -> u32 {
+    x * 2
+}
+
+// rpass2: Add eprintln! to different private function
+#[cfg(rpass2)]
+fn private_compute(x: u32) -> u32 {
+    eprintln!("private_compute: {}", x);
+    x * 2
+}
+
+// rpass3: Add debug formatting
+#[cfg(rpass3)]
+fn private_compute(x: u32) -> u32 {
+    eprintln!("private_compute input: {:?}", x);
+    let result = x * 2;
+    eprintln!("private_compute output: {:?}", result);
+    result
+}

--- a/tests/incremental/rdr_add_println_private/main.rs
+++ b/tests/incremental/rdr_add_println_private/main.rs
@@ -1,0 +1,34 @@
+// Test that adding println!/eprintln! to private functions in a dependency
+// does NOT cause the dependent crate to be rebuilt.
+//
+// This is a key RDR test because:
+// 1. println! is a macro that expands to code with many spans
+// 2. The expanded code includes format strings, arguments, etc.
+// 3. All of this should be invisible to dependent crates
+//
+// Revisions:
+// - rpass1: No println in private functions
+// - rpass2: Add println!/eprintln! to private functions - should REUSE
+// - rpass3: Add more println! statements - should REUSE
+
+//@ revisions: rpass1 rpass2 rpass3
+//@ compile-flags: -Z query-dep-graph
+//@ aux-build: dep.rs
+//@ ignore-backends: gcc
+
+#![feature(rustc_attrs)]
+#![crate_type = "bin"]
+
+// Main should be reused - adding println to private fns shouldn't affect us
+#![rustc_partition_reused(module = "main", cfg = "rpass2")]
+#![rustc_partition_reused(module = "main", cfg = "rpass3")]
+
+extern crate dep;
+
+fn main() {
+    let result = dep::public_fn(41);
+    assert_eq!(result, 42);
+
+    let s = dep::PublicStruct { value: 21 };
+    assert_eq!(s.compute(), 42);
+}

--- a/tests/incremental/rdr_add_private_fn/auxiliary/dep.rs
+++ b/tests/incremental/rdr_add_private_fn/auxiliary/dep.rs
@@ -1,0 +1,32 @@
+// Auxiliary crate for testing that adding private functions
+// does not cause dependent crates to rebuild.
+
+#![crate_name = "dep"]
+#![crate_type = "rlib"]
+
+// Public API - unchanged across all revisions
+pub fn public_fn(x: u32) -> u32 {
+    x + 1
+}
+
+pub struct PublicStruct {
+    pub value: u32,
+}
+
+// rpass2: Add a new private function
+#[cfg(any(rpass2, rpass3))]
+fn new_private_fn() -> u32 {
+    42
+}
+
+// rpass3: Add another private function
+#[cfg(rpass3)]
+fn another_private_fn(x: u32) -> u32 {
+    x * 2
+}
+
+// rpass3: Add a private struct
+#[cfg(rpass3)]
+struct PrivateStruct {
+    _field: u32,
+}

--- a/tests/incremental/rdr_add_private_fn/main.rs
+++ b/tests/incremental/rdr_add_private_fn/main.rs
@@ -1,0 +1,32 @@
+// Test that adding private functions to a dependency does NOT cause
+// the dependent crate to be rebuilt.
+//
+// This is a core RDR (Relink, Don't Rebuild) test.
+// Adding private items should not affect the public API hash.
+//
+// Revisions:
+// - rpass1: Initial compilation
+// - rpass2: Dependency adds one private function - should REUSE
+// - rpass3: Dependency adds more private items - should REUSE
+
+//@ revisions: rpass1 rpass2 rpass3
+//@ compile-flags: -Z query-dep-graph
+//@ aux-build: dep.rs
+//@ ignore-backends: gcc
+
+#![feature(rustc_attrs)]
+#![crate_type = "bin"]
+
+// Main should be reused when only private items are added to dependency
+#![rustc_partition_reused(module = "main", cfg = "rpass2")]
+#![rustc_partition_reused(module = "main", cfg = "rpass3")]
+
+extern crate dep;
+
+fn main() {
+    let result = dep::public_fn(41);
+    assert_eq!(result, 42);
+
+    let s = dep::PublicStruct { value: 100 };
+    assert_eq!(s.value, 100);
+}

--- a/tests/incremental/rdr_add_private_item/auxiliary/lib.rs
+++ b/tests/incremental/rdr_add_private_item/auxiliary/lib.rs
@@ -1,0 +1,28 @@
+// Auxiliary crate that adds a private item in rpass2.
+// The SVH should remain stable, so dependents should not rebuild.
+
+//@[rpass1] compile-flags: -Z query-dep-graph -Z stable-crate-hash
+//@[rpass2] compile-flags: -Z query-dep-graph -Z stable-crate-hash
+
+#![crate_type = "rlib"]
+
+pub fn public_fn() -> i32 {
+    42
+}
+
+pub struct PublicStruct {
+    pub field: i32,
+}
+
+#[cfg(rpass2)]
+fn private_fn() -> i32 {
+    100
+}
+
+#[cfg(rpass2)]
+struct PrivateStruct {
+    field: String,
+}
+
+#[cfg(rpass2)]
+const PRIVATE_CONST: i32 = 999;

--- a/tests/incremental/rdr_add_private_item/main.rs
+++ b/tests/incremental/rdr_add_private_item/main.rs
@@ -1,0 +1,27 @@
+// Test that adding private items to a dependency does not cause rebuilds.
+//
+// rpass1: Initial compilation
+// rpass2: Auxiliary adds private items - main should be fully reused
+//
+// With -Z stable-crate-hash, the SVH only includes public API, so adding
+// private items should not change the SVH and should not trigger rebuilds.
+
+//@ revisions: rpass1 rpass2
+//@ compile-flags: -Z query-dep-graph -Z stable-crate-hash -Z incremental-ignore-spans
+//@ aux-build: lib.rs
+
+#![feature(rustc_attrs)]
+
+// The main module should be reused in rpass2 since the dependency's
+// public API hasn't changed (only private items were added).
+#![rustc_partition_reused(module = "main", cfg = "rpass2")]
+
+extern crate lib;
+
+pub fn use_dependency() -> i32 {
+    lib::public_fn() + lib::PublicStruct { field: 10 }.field
+}
+
+fn main() {
+    assert_eq!(use_dependency(), 52);
+}

--- a/tests/incremental/rdr_async_fn/auxiliary/async_dep.rs
+++ b/tests/incremental/rdr_async_fn/auxiliary/async_dep.rs
@@ -1,0 +1,33 @@
+//@ edition: 2024
+
+#![crate_name = "async_dep"]
+#![crate_type = "rlib"]
+
+#[cfg(rpass1)]
+async fn private_helper() -> u32 {
+    42
+}
+
+#[cfg(rpass2)]
+async fn private_helper() -> u32 {
+    let x = 21;
+    let y = 21;
+    x + y
+}
+
+#[cfg(rpass3)]
+async fn private_helper() -> u32 {
+    async { 42 }.await
+}
+
+pub async fn public_async_fn() -> u32 {
+    private_helper().await
+}
+
+pub struct AsyncStruct;
+
+impl AsyncStruct {
+    pub async fn method(&self) -> u32 {
+        private_helper().await
+    }
+}

--- a/tests/incremental/rdr_async_fn/main.rs
+++ b/tests/incremental/rdr_async_fn/main.rs
@@ -1,0 +1,20 @@
+// Test async function compilation across revisions with private changes.
+// Note: async state machines may legitimately require rebuilds when private
+// helpers change, as the state machine type captures implementation details.
+//
+// - rpass1: Initial compilation
+// - rpass2: Private async helper changes body
+// - rpass3: Private async helper uses nested async block
+
+//@ revisions: rpass1 rpass2 rpass3
+//@ aux-build: async_dep.rs
+//@ edition: 2024
+//@ ignore-backends: gcc
+
+extern crate async_dep;
+
+fn main() {
+    let _fut = async_dep::public_async_fn();
+    let s = async_dep::AsyncStruct;
+    let _fut2 = s.method();
+}

--- a/tests/incremental/rdr_blanket_impl/auxiliary/blanket_dep.rs
+++ b/tests/incremental/rdr_blanket_impl/auxiliary/blanket_dep.rs
@@ -1,0 +1,33 @@
+#![crate_name = "blanket_dep"]
+#![crate_type = "rlib"]
+
+trait PrivateTrait {
+    fn private_method(&self) -> u32;
+}
+
+#[cfg(rpass1)]
+impl<T: Default> PrivateTrait for T {
+    fn private_method(&self) -> u32 {
+        42
+    }
+}
+
+#[cfg(any(rpass2, rpass3))]
+impl<T: Default> PrivateTrait for T {
+    fn private_method(&self) -> u32 {
+        21 + 21
+    }
+}
+
+pub trait PublicTrait {
+    fn public_method(&self) -> u32;
+}
+
+impl<T: Default> PublicTrait for T {
+    fn public_method(&self) -> u32 {
+        self.private_method()
+    }
+}
+
+#[cfg(rpass3)]
+trait _AnotherPrivateTrait {}

--- a/tests/incremental/rdr_blanket_impl/main.rs
+++ b/tests/incremental/rdr_blanket_impl/main.rs
@@ -1,0 +1,27 @@
+// Test that blanket impl with private trait bounds work correctly with RDR.
+//
+// - rpass1: Initial compilation
+// - rpass2: Private trait impl changes, should reuse
+// - rpass3: Another private trait added, should reuse
+
+//@ revisions: rpass1 rpass2 rpass3
+//@ compile-flags: -Z query-dep-graph
+//@ aux-build: blanket_dep.rs
+//@ edition: 2024
+//@ ignore-backends: gcc
+
+#![feature(rustc_attrs)]
+#![rustc_partition_reused(module = "main", cfg = "rpass2")]
+#![rustc_partition_reused(module = "main", cfg = "rpass3")]
+
+extern crate blanket_dep;
+
+use blanket_dep::PublicTrait;
+
+fn main() {
+    let x: u32 = 0;
+    assert_eq!(x.public_method(), 42);
+
+    let s = String::new();
+    assert_eq!(s.public_method(), 42);
+}

--- a/tests/incremental/rdr_cfg_target/auxiliary/cfg_dep.rs
+++ b/tests/incremental/rdr_cfg_target/auxiliary/cfg_dep.rs
@@ -1,0 +1,50 @@
+#![crate_name = "cfg_dep"]
+#![crate_type = "rlib"]
+
+#[cfg(target_os = "macos")]
+#[cfg(rpass1)]
+fn platform_private() -> &'static str {
+    "macos v1"
+}
+
+#[cfg(target_os = "macos")]
+#[cfg(any(rpass2, rpass3))]
+fn platform_private() -> &'static str {
+    "macos v2"
+}
+
+#[cfg(target_os = "linux")]
+#[cfg(rpass1)]
+fn platform_private() -> &'static str {
+    "linux v1"
+}
+
+#[cfg(target_os = "linux")]
+#[cfg(any(rpass2, rpass3))]
+fn platform_private() -> &'static str {
+    "linux v2"
+}
+
+#[cfg(target_os = "windows")]
+#[cfg(rpass1)]
+fn platform_private() -> &'static str {
+    "windows v1"
+}
+
+#[cfg(target_os = "windows")]
+#[cfg(any(rpass2, rpass3))]
+fn platform_private() -> &'static str {
+    "windows v2"
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+fn platform_private() -> &'static str {
+    "other"
+}
+
+pub fn get_platform() -> &'static str {
+    platform_private()
+}
+
+#[cfg(rpass3)]
+fn _extra_private() {}

--- a/tests/incremental/rdr_cfg_target/main.rs
+++ b/tests/incremental/rdr_cfg_target/main.rs
@@ -1,0 +1,23 @@
+// Test that platform-specific private code changes do not cause
+// downstream rebuilds.
+//
+// - rpass1: Initial compilation
+// - rpass2: Platform-specific private fn changes, should reuse
+// - rpass3: Extra private fn added, should reuse
+
+//@ revisions: rpass1 rpass2 rpass3
+//@ compile-flags: -Z query-dep-graph
+//@ aux-build: cfg_dep.rs
+//@ edition: 2024
+//@ ignore-backends: gcc
+
+#![feature(rustc_attrs)]
+#![rustc_partition_reused(module = "main", cfg = "rpass2")]
+#![rustc_partition_reused(module = "main", cfg = "rpass3")]
+
+extern crate cfg_dep;
+
+fn main() {
+    let platform = cfg_dep::get_platform();
+    assert!(!platform.is_empty());
+}

--- a/tests/incremental/rdr_closure_captures/auxiliary/closure_dep.rs
+++ b/tests/incremental/rdr_closure_captures/auxiliary/closure_dep.rs
@@ -1,0 +1,33 @@
+#![crate_name = "closure_dep"]
+#![crate_type = "rlib"]
+
+#[cfg(rpass1)]
+struct PrivateData {
+    value: u32,
+}
+
+#[cfg(any(rpass2, rpass3))]
+struct PrivateData {
+    value: u32,
+    _extra: u32,
+}
+
+#[cfg(rpass1)]
+fn make_private() -> PrivateData {
+    PrivateData { value: 42 }
+}
+
+#[cfg(any(rpass2, rpass3))]
+fn make_private() -> PrivateData {
+    PrivateData { value: 42, _extra: 0 }
+}
+
+pub fn make_closure() -> impl Fn() -> u32 {
+    let data = make_private();
+    move || data.value
+}
+
+pub fn call_with_closure<F: Fn(u32) -> u32>(f: F, x: u32) -> u32 {
+    let private = make_private();
+    f(x) + private.value
+}

--- a/tests/incremental/rdr_closure_captures/main.rs
+++ b/tests/incremental/rdr_closure_captures/main.rs
@@ -1,0 +1,22 @@
+// Test closures capturing private types.
+// Known limitation: changes to private types captured by closures currently
+// DO cause downstream rebuilds, as the closure's captured environment type
+// leaks through impl Fn.
+//
+// - rpass1: Initial compilation
+// - rpass2: Private captured type gets extra field
+
+//@ revisions: rpass1 rpass2
+//@ aux-build: closure_dep.rs
+//@ edition: 2024
+//@ ignore-backends: gcc
+
+extern crate closure_dep;
+
+fn main() {
+    let closure = closure_dep::make_closure();
+    assert_eq!(closure(), 42);
+
+    let result = closure_dep::call_with_closure(|x| x * 2, 10);
+    assert_eq!(result, 62);
+}

--- a/tests/incremental/rdr_const_generic/auxiliary/const_dep.rs
+++ b/tests/incremental/rdr_const_generic/auxiliary/const_dep.rs
@@ -1,0 +1,31 @@
+#![crate_name = "const_dep"]
+#![crate_type = "rlib"]
+
+#[cfg(rpass1)]
+const PRIVATE_SIZE: usize = 4;
+
+#[cfg(any(rpass2, rpass3))]
+const PRIVATE_SIZE: usize = 4;
+
+#[cfg(rpass3)]
+const _UNUSED_CONST: usize = 999;
+
+pub struct FixedArray<const N: usize> {
+    data: [u32; N],
+}
+
+impl<const N: usize> FixedArray<N> {
+    pub fn new() -> Self {
+        FixedArray { data: [0; N] }
+    }
+
+    pub fn len(&self) -> usize {
+        N
+    }
+}
+
+pub type DefaultArray = FixedArray<PRIVATE_SIZE>;
+
+pub fn make_default() -> DefaultArray {
+    FixedArray::new()
+}

--- a/tests/incremental/rdr_const_generic/main.rs
+++ b/tests/incremental/rdr_const_generic/main.rs
@@ -1,0 +1,25 @@
+// Test that const generics with private const values work correctly with RDR.
+//
+// - rpass1: Initial compilation
+// - rpass2: Private const unchanged (same value), should reuse
+// - rpass3: Unused private const added, should reuse
+
+//@ revisions: rpass1 rpass2 rpass3
+//@ compile-flags: -Z query-dep-graph
+//@ aux-build: const_dep.rs
+//@ edition: 2024
+//@ ignore-backends: gcc
+
+#![feature(rustc_attrs)]
+#![rustc_partition_reused(module = "main", cfg = "rpass2")]
+#![rustc_partition_reused(module = "main", cfg = "rpass3")]
+
+extern crate const_dep;
+
+fn main() {
+    let arr = const_dep::make_default();
+    assert_eq!(arr.len(), 4);
+
+    let custom: const_dep::FixedArray<8> = const_dep::FixedArray::new();
+    assert_eq!(custom.len(), 8);
+}

--- a/tests/incremental/rdr_diamond_deps/auxiliary/diamond_base.rs
+++ b/tests/incremental/rdr_diamond_deps/auxiliary/diamond_base.rs
@@ -1,0 +1,25 @@
+#![crate_name = "diamond_base"]
+#![crate_type = "rlib"]
+
+#[cfg(rpass1)]
+fn private_impl() -> u32 {
+    42
+}
+
+#[cfg(any(rpass2, rpass3))]
+fn private_impl() -> u32 {
+    21 + 21
+}
+
+#[cfg(rpass3)]
+fn _another_private() -> u32 {
+    999
+}
+
+pub fn base_value() -> u32 {
+    private_impl()
+}
+
+pub struct BaseStruct {
+    pub value: u32,
+}

--- a/tests/incremental/rdr_diamond_deps/auxiliary/diamond_left.rs
+++ b/tests/incremental/rdr_diamond_deps/auxiliary/diamond_left.rs
@@ -1,0 +1,8 @@
+#![crate_name = "diamond_left"]
+#![crate_type = "rlib"]
+
+extern crate diamond_base;
+
+pub fn left_value() -> u32 {
+    diamond_base::base_value() + 1
+}

--- a/tests/incremental/rdr_diamond_deps/auxiliary/diamond_right.rs
+++ b/tests/incremental/rdr_diamond_deps/auxiliary/diamond_right.rs
@@ -1,0 +1,8 @@
+#![crate_name = "diamond_right"]
+#![crate_type = "rlib"]
+
+extern crate diamond_base;
+
+pub fn right_value() -> u32 {
+    diamond_base::base_value() + 2
+}

--- a/tests/incremental/rdr_diamond_deps/main.rs
+++ b/tests/incremental/rdr_diamond_deps/main.rs
@@ -1,0 +1,28 @@
+// Test diamond dependency pattern: A depends on B and C, both depend on D.
+// When D changes privately, A, B, and C should all reuse.
+//
+// - rpass1: Initial compilation
+// - rpass2: Base crate's private impl changes, should reuse
+// - rpass3: Base crate adds another private fn, should reuse
+
+//@ revisions: rpass1 rpass2 rpass3
+//@ compile-flags: -Z query-dep-graph
+//@ aux-build: diamond_base.rs
+//@ aux-build: diamond_left.rs
+//@ aux-build: diamond_right.rs
+//@ edition: 2024
+//@ ignore-backends: gcc
+
+#![feature(rustc_attrs)]
+#![rustc_partition_reused(module = "main", cfg = "rpass2")]
+#![rustc_partition_reused(module = "main", cfg = "rpass3")]
+
+extern crate diamond_left;
+extern crate diamond_right;
+
+fn main() {
+    let left = diamond_left::left_value();
+    let right = diamond_right::right_value();
+    assert_eq!(left, 43);
+    assert_eq!(right, 44);
+}

--- a/tests/incremental/rdr_generic_instantiation/auxiliary/generic_dep.rs
+++ b/tests/incremental/rdr_generic_instantiation/auxiliary/generic_dep.rs
@@ -1,0 +1,30 @@
+#![crate_name = "generic_dep"]
+#![crate_type = "rlib"]
+
+#[cfg(rpass1)]
+fn private_helper<T>(x: T) -> T {
+    x
+}
+
+#[cfg(any(rpass2, rpass3))]
+fn private_helper<T>(x: T) -> T {
+    let result = x;
+    result
+}
+
+#[cfg(rpass3)]
+fn _unused_generic<T>(_: T) {}
+
+pub fn generic_fn<T: Copy>(x: T) -> T {
+    private_helper(x)
+}
+
+pub struct GenericStruct<T> {
+    pub value: T,
+}
+
+impl<T: Copy> GenericStruct<T> {
+    pub fn get(&self) -> T {
+        private_helper(self.value)
+    }
+}

--- a/tests/incremental/rdr_generic_instantiation/main.rs
+++ b/tests/incremental/rdr_generic_instantiation/main.rs
@@ -1,0 +1,26 @@
+// Test that private changes in generic functions do not cause downstream
+// rebuilds when the generic is instantiated in the dependent crate.
+//
+// - rpass1: Initial compilation
+// - rpass2: Private generic helper changes body, should reuse
+// - rpass3: Unused private generic added, should reuse
+
+//@ revisions: rpass1 rpass2 rpass3
+//@ compile-flags: -Z query-dep-graph
+//@ aux-build: generic_dep.rs
+//@ edition: 2024
+//@ ignore-backends: gcc
+
+#![feature(rustc_attrs)]
+#![rustc_partition_reused(module = "main", cfg = "rpass2")]
+#![rustc_partition_reused(module = "main", cfg = "rpass3")]
+
+extern crate generic_dep;
+
+fn main() {
+    let x: u32 = generic_dep::generic_fn(42);
+    assert_eq!(x, 42);
+
+    let s = generic_dep::GenericStruct { value: 100u64 };
+    assert_eq!(s.get(), 100);
+}

--- a/tests/incremental/rdr_impl_trait_return/auxiliary/impl_trait_dep.rs
+++ b/tests/incremental/rdr_impl_trait_return/auxiliary/impl_trait_dep.rs
@@ -1,0 +1,36 @@
+#![crate_name = "impl_trait_dep"]
+#![crate_type = "rlib"]
+
+pub trait MyTrait {
+    fn value(&self) -> u32;
+}
+
+#[cfg(rpass1)]
+struct PrivateImpl {
+    x: u32,
+}
+
+#[cfg(any(rpass2, rpass3))]
+struct PrivateImpl {
+    x: u32,
+    _extra: u32,
+}
+
+impl MyTrait for PrivateImpl {
+    fn value(&self) -> u32 {
+        self.x
+    }
+}
+
+#[cfg(rpass1)]
+pub fn make_thing() -> impl MyTrait {
+    PrivateImpl { x: 42 }
+}
+
+#[cfg(any(rpass2, rpass3))]
+pub fn make_thing() -> impl MyTrait {
+    PrivateImpl { x: 42, _extra: 0 }
+}
+
+#[cfg(rpass3)]
+struct _AnotherPrivate;

--- a/tests/incremental/rdr_impl_trait_return/main.rs
+++ b/tests/incremental/rdr_impl_trait_return/main.rs
@@ -1,0 +1,22 @@
+// Test impl Trait return types with private concrete types.
+// Known limitation: changes to the private concrete type behind `impl Trait`
+// currently DO cause downstream rebuilds, as the concrete type leaks through
+// the opaque return type.
+//
+// - rpass1: Initial compilation
+// - rpass2: Private struct gets extra field
+// - rpass3: Another private struct added
+
+//@ revisions: rpass1 rpass2 rpass3
+//@ aux-build: impl_trait_dep.rs
+//@ edition: 2024
+//@ ignore-backends: gcc
+
+extern crate impl_trait_dep;
+
+use impl_trait_dep::MyTrait;
+
+fn main() {
+    let thing = impl_trait_dep::make_thing();
+    assert_eq!(thing.value(), 42);
+}

--- a/tests/incremental/rdr_metadata_spans/auxiliary/spans_lib.rs
+++ b/tests/incremental/rdr_metadata_spans/auxiliary/spans_lib.rs
@@ -1,0 +1,51 @@
+// Auxiliary crate for testing span reproducibility in metadata.
+// This crate exports items that embed spans in the metadata,
+// which are then used by the dependent crate.
+
+//@[rpass1] compile-flags: -Z query-dep-graph
+//@[rpass2] compile-flags: -Z query-dep-graph
+//@[rpass3] compile-flags: -Z query-dep-graph --remap-path-prefix={{src-base}}=/remapped
+
+#![crate_type = "rlib"]
+
+/// A struct with spans in its definition.
+pub struct SpannedStruct {
+    pub field1: u32,
+    pub field2: String,
+}
+
+/// A generic function whose span is embedded in metadata.
+#[inline(always)]
+pub fn generic_fn<T: Default>() -> T {
+    T::default()
+}
+
+/// A macro that will have its expansion span in metadata.
+#[macro_export]
+macro_rules! span_macro {
+    ($e:expr) => {
+        $e + 1
+    };
+}
+
+/// Trait with associated types to test span handling.
+pub trait SpannedTrait {
+    type Output;
+    fn process(&self) -> Self::Output;
+}
+
+impl SpannedTrait for u32 {
+    type Output = u32;
+    fn process(&self) -> Self::Output {
+        *self * 2
+    }
+}
+
+/// Function with panic that embeds span in metadata.
+#[inline(always)]
+pub fn might_panic(x: u32) -> u32 {
+    if x == 0 {
+        panic!("x cannot be zero");
+    }
+    x
+}

--- a/tests/incremental/rdr_metadata_spans/main.rs
+++ b/tests/incremental/rdr_metadata_spans/main.rs
@@ -1,0 +1,44 @@
+// This test verifies that spans embedded in crate metadata are handled
+// correctly for incremental compilation and reproducibility.
+//
+// The test exercises:
+// 1. Cross-crate inlined function spans
+// 2. Macro expansion spans from external crates
+// 3. Trait implementation spans
+// 4. Panic location spans in inlined code
+//
+// rpass1: Initial compilation
+// rpass2: Recompile with no changes - should reuse everything
+// rpass3: Recompile with path remapping - tests span normalization
+
+//@ revisions: rpass1 rpass2 rpass3
+//@ compile-flags: -Z query-dep-graph -g
+//@ aux-build: spans_lib.rs
+//@ ignore-backends: gcc
+
+#![feature(rustc_attrs)]
+
+// In rpass2, we should reuse the codegen for main since nothing changed.
+// In rpass3, path remapping in the auxiliary crate may affect spans.
+#![rustc_partition_reused(module = "main", cfg = "rpass2")]
+
+extern crate spans_lib;
+
+use spans_lib::{SpannedStruct, SpannedTrait};
+
+fn main() {
+    let _: u32 = spans_lib::generic_fn();
+    let _: String = spans_lib::generic_fn();
+
+    let s = SpannedStruct { field1: 42, field2: String::from("test") };
+    let _ = s.field1;
+
+    let x = spans_lib::span_macro!(41);
+    assert_eq!(x, 42);
+
+    let val: u32 = 21;
+    let result = val.process();
+    assert_eq!(result, 42);
+
+    let _ = spans_lib::might_panic(1);
+}

--- a/tests/incremental/rdr_private_span_changes/auxiliary/dep.rs
+++ b/tests/incremental/rdr_private_span_changes/auxiliary/dep.rs
@@ -1,0 +1,122 @@
+// Auxiliary crate for testing RDR span stability.
+//
+// This crate has private items whose spans change between revisions,
+// but the public API remains identical. The dependent crate should
+// NOT be rebuilt when only private span-affecting changes occur.
+//
+// rpass1: Initial state
+// rpass2: Added blank lines before private fn (shifts all BytePos values)
+// rpass3: Added comments inside private fn (changes internal spans)
+// rpass4: Changed private fn body (implementation change, not just spans)
+
+#![crate_name = "dep"]
+#![crate_type = "rlib"]
+
+// ============================================================
+// PUBLIC API - This should remain stable across all revisions
+// ============================================================
+
+/// Public struct - its definition spans should be stable.
+pub struct PublicStruct {
+    pub value: u32,
+}
+
+impl PublicStruct {
+    /// Public constructor - calls private helper internally.
+    pub fn new(v: u32) -> Self {
+        Self { value: private_transform(v) }
+    }
+
+    /// Public method - depends on private implementation.
+    pub fn doubled(&self) -> u32 {
+        private_double(self.value)
+    }
+}
+
+/// Public function that uses private helpers.
+pub fn public_compute(x: u32) -> u32 {
+    let a = private_transform(x);
+    let b = private_double(a);
+    private_combine(a, b)
+}
+
+/// Public trait with default implementation using private fn.
+pub trait PublicTrait {
+    fn compute(&self) -> u32;
+
+    fn with_default(&self) -> u32 {
+        private_transform(self.compute())
+    }
+}
+
+impl PublicTrait for u32 {
+    fn compute(&self) -> u32 {
+        *self
+    }
+}
+
+// ============================================================
+// PRIVATE IMPLEMENTATION - Changes here affect spans
+// ============================================================
+
+// rpass2+: These blank lines shift BytePos values of everything below.
+// This simulates developers adding whitespace or reformatting code.
+#[cfg(any(rpass2, rpass3, rpass4))]
+const _BLANK_LINES_MARKER: () = ();
+
+
+
+
+// End of blank lines section
+
+/// Private helper function.
+#[cfg(rpass1)]
+fn private_transform(x: u32) -> u32 {
+    x.wrapping_add(1)
+}
+
+/// Private helper function - with shifted spans in rpass2.
+#[cfg(rpass2)]
+fn private_transform(x: u32) -> u32 {
+    x.wrapping_add(1)
+}
+
+/// Private helper function - with comments in rpass3.
+#[cfg(rpass3)]
+fn private_transform(x: u32) -> u32 {
+    // Adding a comment here changes internal spans
+    // but should not affect the dependent crate.
+    x.wrapping_add(1)
+}
+
+/// Private helper function - with comments in rpass4.
+#[cfg(rpass4)]
+fn private_transform(x: u32) -> u32 {
+    // Same comments as rpass3
+    // but should not affect the dependent crate.
+    x.wrapping_add(1)
+}
+
+/// Private double function.
+#[cfg(any(rpass1, rpass2, rpass3))]
+fn private_double(x: u32) -> u32 {
+    x * 2
+}
+
+/// Private double function - changed implementation in rpass4.
+#[cfg(rpass4)]
+fn private_double(x: u32) -> u32 {
+    x << 1  // Same result, different implementation
+}
+
+/// Private combiner function.
+fn private_combine(a: u32, b: u32) -> u32 {
+    a.wrapping_add(b)
+}
+
+// rpass2+: Additional private module to shift spans further.
+#[cfg(any(rpass2, rpass3, rpass4))]
+mod private_module {
+    #[allow(dead_code)]
+    pub fn unused_fn() -> u32 { 42 }
+}

--- a/tests/incremental/rdr_private_span_changes/main.rs
+++ b/tests/incremental/rdr_private_span_changes/main.rs
@@ -1,0 +1,60 @@
+// Test that span changes in private items of a dependency do NOT cause
+// the dependent crate to be rebuilt.
+//
+// This is the core test for Relink, Don't Rebuild (RDR).
+// The key insight is that metadata should not encode spans in a way that
+// causes hash instability when only private implementation details change.
+//
+// Revisions:
+// - rpass1: Initial compilation
+// - rpass2: Dependency adds blank lines (BytePos shifts) - should REUSE
+// - rpass3: Dependency adds comments in private fn - should REUSE
+// - rpass4: Dependency changes private fn body - should REUSE
+//
+// In all revisions, the main crate should be reused because:
+// 1. The public API of the dependency hasn't changed
+// 2. No inlined code from the dependency is used
+// 3. Span changes in private items shouldn't affect metadata hashes
+
+//@ revisions: rpass1 rpass2 rpass3 rpass4
+//@ compile-flags: -Z query-dep-graph
+//@ aux-build: dep.rs
+//@ ignore-backends: gcc
+
+#![feature(rustc_attrs)]
+#![crate_type = "bin"]
+
+// THE KEY ASSERTION: This module should be reused in ALL subsequent revisions.
+// If this fails, it means span changes in private dependency code are
+// incorrectly invalidating the dependent crate's cache.
+#![rustc_partition_reused(module = "main", cfg = "rpass2")]
+#![rustc_partition_reused(module = "main", cfg = "rpass3")]
+#![rustc_partition_reused(module = "main", cfg = "rpass4")]
+
+extern crate dep;
+
+use dep::{PublicStruct, PublicTrait, public_compute};
+
+fn main() {
+    // Use the public API - none of this should cause recompilation
+    // when only private spans change in the dependency.
+
+    // Test struct construction and methods
+    let s = PublicStruct::new(10);
+    assert_eq!(s.value, 11); // private_transform adds 1
+    assert_eq!(s.doubled(), 22); // private_double multiplies by 2
+
+    // Test public function
+    let result = public_compute(5);
+    // private_transform(5) = 6
+    // private_double(6) = 12
+    // private_combine(6, 12) = 18
+    assert_eq!(result, 18);
+
+    // Test trait implementation
+    let val: u32 = 7;
+    assert_eq!(val.compute(), 7);
+    assert_eq!(val.with_default(), 8); // private_transform(7) = 8
+
+    println!("All RDR assertions passed!");
+}

--- a/tests/incremental/rdr_proc_macro_derive/auxiliary/derive_helper.rs
+++ b/tests/incremental/rdr_proc_macro_derive/auxiliary/derive_helper.rs
@@ -1,0 +1,47 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+
+#[cfg(rpass1)]
+fn format_impl_body() -> &'static str {
+    "42"
+}
+
+#[cfg(rpass2)]
+fn format_impl_body() -> &'static str {
+    "21 + 21"
+}
+
+#[cfg(rpass3)]
+fn format_impl_body() -> &'static str {
+    "40 + 2"
+}
+
+#[cfg(any(rpass2, rpass3))]
+fn _unused_private_helper() -> u32 {
+    999
+}
+
+#[cfg(rpass3)]
+struct _PrivateHelperStruct {
+    _field: u32,
+}
+
+#[proc_macro_derive(RdrTestDerive)]
+pub fn derive_rdr_test(input: TokenStream) -> TokenStream {
+    let input_str = input.to_string();
+
+    let struct_name = input_str
+        .split_whitespace()
+        .skip_while(|s| *s == "pub" || *s == "struct")
+        .next()
+        .map(|s| s.trim_end_matches(';'))
+        .unwrap_or("Unknown");
+
+    let body = format_impl_body();
+
+    let output = format!(
+        "impl {struct_name} {{ pub fn derived_value() -> u32 {{ {body} }} }}"
+    );
+
+    output.parse().unwrap()
+}

--- a/tests/incremental/rdr_proc_macro_derive/main.rs
+++ b/tests/incremental/rdr_proc_macro_derive/main.rs
@@ -1,0 +1,27 @@
+// Test that private changes in a derive macro crate do not cause
+// downstream crates to rebuild.
+//
+// - rpass1: Initial compilation
+// - rpass2: Macro's private helper changes, should reuse
+// - rpass3: Macro adds more private items, should reuse
+
+//@ revisions: rpass1 rpass2 rpass3
+//@ compile-flags: -Z query-dep-graph
+//@ proc-macro: derive_helper.rs
+//@ edition: 2024
+//@ ignore-backends: gcc
+
+#![feature(rustc_attrs)]
+#![rustc_partition_reused(module = "main", cfg = "rpass2")]
+#![rustc_partition_reused(module = "main", cfg = "rpass3")]
+
+#[macro_use]
+extern crate derive_helper;
+
+#[derive(RdrTestDerive)]
+pub struct TestStruct;
+
+fn main() {
+    let value = TestStruct::derived_value();
+    assert_eq!(value, 42);
+}

--- a/tests/incremental/rdr_reexport/auxiliary/reexport_base.rs
+++ b/tests/incremental/rdr_reexport/auxiliary/reexport_base.rs
@@ -1,0 +1,30 @@
+#![crate_name = "reexport_base"]
+#![crate_type = "rlib"]
+
+#[cfg(rpass1)]
+fn private_impl() -> u32 {
+    42
+}
+
+#[cfg(any(rpass2, rpass3))]
+fn private_impl() -> u32 {
+    21 + 21
+}
+
+pub struct Thing {
+    value: u32,
+}
+
+impl Thing {
+    pub fn new() -> Self {
+        Thing { value: private_impl() }
+    }
+
+    pub fn get(&self) -> u32 {
+        self.value
+    }
+}
+
+pub fn create_thing() -> Thing {
+    Thing::new()
+}

--- a/tests/incremental/rdr_reexport/auxiliary/reexport_middle.rs
+++ b/tests/incremental/rdr_reexport/auxiliary/reexport_middle.rs
@@ -1,0 +1,7 @@
+#![crate_name = "reexport_middle"]
+#![crate_type = "rlib"]
+
+extern crate reexport_base;
+
+pub use reexport_base::Thing;
+pub use reexport_base::create_thing;

--- a/tests/incremental/rdr_reexport/main.rs
+++ b/tests/incremental/rdr_reexport/main.rs
@@ -1,0 +1,22 @@
+// Test that re-exports work correctly with RDR. When the base crate's
+// private implementation changes, crates using re-exports should reuse.
+//
+// - rpass1: Initial compilation
+// - rpass2: Base crate's private impl changes, should reuse
+
+//@ revisions: rpass1 rpass2
+//@ compile-flags: -Z query-dep-graph
+//@ aux-build: reexport_base.rs
+//@ aux-build: reexport_middle.rs
+//@ edition: 2024
+//@ ignore-backends: gcc
+
+#![feature(rustc_attrs)]
+#![rustc_partition_reused(module = "main", cfg = "rpass2")]
+
+extern crate reexport_middle;
+
+fn main() {
+    let thing = reexport_middle::create_thing();
+    assert_eq!(thing.get(), 42);
+}

--- a/tests/incremental/rdr_separate_spans/auxiliary/separate_spans_lib.rs
+++ b/tests/incremental/rdr_separate_spans/auxiliary/separate_spans_lib.rs
@@ -1,0 +1,42 @@
+// Auxiliary crate for testing -Z separate-spans flag.
+// When separate-spans is enabled, span data is stored in a separate .spans file
+// instead of being embedded directly in the .rmeta file.
+
+//@[rpass1] compile-flags: -Z query-dep-graph
+//@[rpass2] compile-flags: -Z query-dep-graph
+//@[rpass3] compile-flags: -Z query-dep-graph -Z separate-spans
+
+#![crate_type = "rlib"]
+
+#[inline(always)]
+pub fn inlined_with_span() -> u32 {
+    let x = 1;
+    let y = 2;
+    x + y
+}
+
+#[inline(always)]
+pub fn generic_with_span<T: std::fmt::Debug>(val: T) -> String {
+    format!("{:?}", val)
+}
+
+pub fn multi_span_fn() -> (u32, u32, u32) {
+    let a = compute_a();
+    let b = compute_b();
+    let c = compute_c();
+    (a, b, c)
+}
+
+fn compute_a() -> u32 { 1 }
+fn compute_b() -> u32 { 2 }
+fn compute_c() -> u32 { 3 }
+
+/// Macro that generates code with spans.
+#[macro_export]
+macro_rules! generate_fn {
+    ($name:ident, $val:expr) => {
+        pub fn $name() -> u32 {
+            $val
+        }
+    };
+}

--- a/tests/incremental/rdr_separate_spans/auxiliary/separate_spans_lib.rs
+++ b/tests/incremental/rdr_separate_spans/auxiliary/separate_spans_lib.rs
@@ -1,10 +1,10 @@
-// Auxiliary crate for testing -Z separate-spans flag.
-// When separate-spans is enabled, span data is stored in a separate .spans file
+// Auxiliary crate for testing -Z stable-crate-hash flag.
+// When stable-crate-hash is enabled, span data is stored in a separate .spans file
 // instead of being embedded directly in the .rmeta file.
 
 //@[rpass1] compile-flags: -Z query-dep-graph
 //@[rpass2] compile-flags: -Z query-dep-graph
-//@[rpass3] compile-flags: -Z query-dep-graph -Z separate-spans
+//@[rpass3] compile-flags: -Z query-dep-graph -Z stable-crate-hash
 
 #![crate_type = "rlib"]
 

--- a/tests/incremental/rdr_separate_spans/main.rs
+++ b/tests/incremental/rdr_separate_spans/main.rs
@@ -1,14 +1,14 @@
-// This test verifies that the -Z separate-spans flag works correctly
+// This test verifies that the -Z stable-crate-hash flag works correctly
 // with incremental compilation.
 //
-// The separate-spans flag causes span data to be stored in a separate
+// The stable-crate-hash flag causes span data to be stored in a separate
 // .spans file rather than inline in the .rmeta file. This is important
 // for Relink, Don't Rebuild (RDR) because span data often
 // contains absolute file paths that break reproducibility.
 //
-// rpass1: Initial compilation without separate-spans
+// rpass1: Initial compilation without stable-crate-hash
 // rpass2: Recompile without changes - should reuse everything
-// rpass3: Recompile auxiliary with separate-spans - tests span loading
+// rpass3: Recompile auxiliary with stable-crate-hash - tests span loading
 
 //@ revisions: rpass1 rpass2 rpass3
 //@ compile-flags: -Z query-dep-graph -g

--- a/tests/incremental/rdr_separate_spans/main.rs
+++ b/tests/incremental/rdr_separate_spans/main.rs
@@ -1,0 +1,41 @@
+// This test verifies that the -Z separate-spans flag works correctly
+// with incremental compilation.
+//
+// The separate-spans flag causes span data to be stored in a separate
+// .spans file rather than inline in the .rmeta file. This is important
+// for Relink, Don't Rebuild (RDR) because span data often
+// contains absolute file paths that break reproducibility.
+//
+// rpass1: Initial compilation without separate-spans
+// rpass2: Recompile without changes - should reuse everything
+// rpass3: Recompile auxiliary with separate-spans - tests span loading
+
+//@ revisions: rpass1 rpass2 rpass3
+//@ compile-flags: -Z query-dep-graph -g
+//@ aux-build: separate_spans_lib.rs
+//@ ignore-backends: gcc
+
+#![feature(rustc_attrs)]
+
+// The main module should be reused in rpass2 since nothing changed.
+#![rustc_partition_reused(module = "main", cfg = "rpass2")]
+
+extern crate separate_spans_lib;
+
+// Use the macro to generate a function - this tests macro expansion spans
+separate_spans_lib::generate_fn!(generated_fortytwo, 42);
+
+fn main() {
+    let result = separate_spans_lib::inlined_with_span();
+    assert_eq!(result, 3);
+
+    let s1 = separate_spans_lib::generic_with_span(42u32);
+    let s2 = separate_spans_lib::generic_with_span("hello");
+    assert!(s1.contains("42"));
+    assert!(s2.contains("hello"));
+
+    let (a, b, c) = separate_spans_lib::multi_span_fn();
+    assert_eq!(a + b + c, 6);
+
+    assert_eq!(generated_fortytwo(), 42);
+}

--- a/tests/incremental/rdr_share_generics/auxiliary/shared_dep.rs
+++ b/tests/incremental/rdr_share_generics/auxiliary/shared_dep.rs
@@ -1,0 +1,53 @@
+#![crate_name = "shared_dep"]
+#![crate_type = "rlib"]
+
+// Private generic helper - changes to this should not affect downstream
+#[cfg(rpass1)]
+fn private_helper<T>(x: T) -> T {
+    x
+}
+
+#[cfg(any(rpass2, rpass3))]
+fn private_helper<T>(x: T) -> T {
+    let result = x;
+    result
+}
+
+// Private non-generic function - changes should not affect downstream
+#[cfg(any(rpass1, rpass2))]
+fn private_fn() -> u32 {
+    42
+}
+
+#[cfg(rpass3)]
+fn private_fn() -> u32 {
+    let x = 42;
+    x
+}
+
+// Public generic function that uses the private helper
+pub fn generic_fn<T: Copy>(x: T) -> T {
+    let _ = private_fn();
+    private_helper(x)
+}
+
+// Generic struct with drop glue to test share-generics drop handling
+pub struct GenericBox<T> {
+    value: T,
+}
+
+impl<T> GenericBox<T> {
+    pub fn new(value: T) -> Self {
+        GenericBox { value }
+    }
+
+    pub fn get(&self) -> &T {
+        &self.value
+    }
+}
+
+impl<T> Drop for GenericBox<T> {
+    fn drop(&mut self) {
+        // Drop glue is also shared with share-generics
+    }
+}

--- a/tests/incremental/rdr_share_generics/main.rs
+++ b/tests/incremental/rdr_share_generics/main.rs
@@ -1,0 +1,35 @@
+// Test that RDR works correctly with -Zshare-generics.
+//
+// With share-generics, monomorphized generic instances are shared across crates
+// rather than being duplicated. This test verifies that private changes in a
+// dependency don't trigger rebuilds even when share-generics is enabled.
+//
+// - rpass1: Initial compilation
+// - rpass2: Private generic helper changes body, should reuse
+// - rpass3: Private non-generic function changes, should reuse
+
+//@ revisions: rpass1 rpass2 rpass3
+//@ compile-flags: -Z query-dep-graph -Z stable-crate-hash -Z share-generics=yes -C opt-level=0
+//@ aux-build: shared_dep.rs
+//@ ignore-backends: gcc
+
+#![feature(rustc_attrs)]
+#![rustc_partition_reused(module = "main", cfg = "rpass2")]
+#![rustc_partition_reused(module = "main", cfg = "rpass3")]
+
+extern crate shared_dep;
+
+fn main() {
+    // Use a generic function - with share-generics, this reuses the
+    // monomorphization from shared_dep if it exists there
+    let x: u32 = shared_dep::generic_fn(42);
+    assert_eq!(x, 42);
+
+    // Use another instantiation
+    let y: u64 = shared_dep::generic_fn(100);
+    assert_eq!(y, 100);
+
+    // Use a generic struct with drop glue (drop glue is also shared)
+    let s = shared_dep::GenericBox::new(String::from("hello"));
+    assert_eq!(s.get(), "hello");
+}

--- a/tests/incremental/rdr_span_hash_cross_crate/auxiliary/hash_lib.rs
+++ b/tests/incremental/rdr_span_hash_cross_crate/auxiliary/hash_lib.rs
@@ -1,0 +1,34 @@
+// Auxiliary crate for testing span hash stability across crate boundaries.
+// Changes to span encoding should not affect dependent crate hashes
+// unless the actual source location changes.
+
+//@[rpass1] compile-flags: -Z query-dep-graph
+//@[rpass2] compile-flags: -Z query-dep-graph
+//@[rpass3] compile-flags: -Z query-dep-graph
+
+#![crate_type = "rlib"]
+
+// NOTE: Do not change the line numbers of these functions between revisions!
+// The test relies on spans staying at the same file:line:column locations.
+
+#[inline(always)]
+pub fn stable_span_fn() -> u32 {
+    // This comment is here to ensure the function body has some content
+    42
+}
+
+#[inline(always)]
+pub fn generic_stable<T: Default + std::ops::Add<Output = T>>(x: T) -> T {
+    x + T::default()
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct StableStruct {
+    pub value: u32,
+}
+
+impl StableStruct {
+    pub fn new(value: u32) -> Self {
+        Self { value }
+    }
+}

--- a/tests/incremental/rdr_span_hash_cross_crate/main.rs
+++ b/tests/incremental/rdr_span_hash_cross_crate/main.rs
@@ -1,0 +1,49 @@
+// This test verifies that span hashing is stable across incremental
+// compilation sessions for cross-crate dependencies.
+//
+// For RDR (Relink, Don't Rebuild), it's critical that:
+// 1. Span hashes use file:line:column rather than raw byte offsets
+// 2. Cross-crate spans are hashed consistently
+// 3. Changing unrelated code doesn't invalidate span hashes
+//
+// rpass1: Initial compilation
+// rpass2: Recompile with no changes - all modules should be reused
+// rpass3: Recompile again - still should reuse everything
+
+//@ revisions: rpass1 rpass2 rpass3
+//@ compile-flags: -Z query-dep-graph -g
+//@ aux-build: hash_lib.rs
+//@ ignore-backends: gcc
+
+#![feature(rustc_attrs)]
+
+// All modules should be reused since neither the source nor the
+// auxiliary crate changed between revisions.
+#![rustc_partition_reused(module = "main", cfg = "rpass2")]
+#![rustc_partition_reused(module = "main", cfg = "rpass3")]
+
+extern crate hash_lib;
+
+use hash_lib::{StableStruct, generic_stable, stable_span_fn};
+
+fn main() {
+    // Test inline function with stable span
+    let val = stable_span_fn();
+    assert_eq!(val, 42);
+
+    // Test generic function monomorphization
+    let x: u32 = generic_stable(21);
+    assert_eq!(x, 21);
+
+    let y: i64 = generic_stable(100);
+    assert_eq!(y, 100);
+
+    // Test struct with derived traits (derives embed spans)
+    let s1 = StableStruct::new(42);
+    let s2 = s1.clone();
+    assert_eq!(s1, s2);
+
+    // Debug formatting also uses spans from derive
+    let debug_str = format!("{:?}", s1);
+    assert!(debug_str.contains("42"));
+}

--- a/tests/incremental/svh_stability/auxiliary/dependency.rs
+++ b/tests/incremental/svh_stability/auxiliary/dependency.rs
@@ -1,0 +1,44 @@
+//@ revisions:rpass1 rpass2 rpass3
+
+// A dependency crate with:
+// - A private function that changes (rpass1 -> rpass2)
+// - A public non-inlinable function
+// - A public inlinable function that changes (rpass2 -> rpass3)
+
+// Private function - changes between rpass1 and rpass2
+// This should NOT affect downstream crates' SVH
+fn private_helper() -> i32 {
+    #[cfg(rpass1)]
+    { 1 }
+
+    #[cfg(any(rpass2, rpass3))]
+    { 2 }
+}
+
+// Public function that calls the private helper
+// Its body is NOT inlined downstream (no #[inline])
+pub fn public_function() -> i32 {
+    private_helper() + 10
+}
+
+// Public inlinable function - changes between rpass2 and rpass3
+// This SHOULD affect downstream crates' SVH
+#[inline]
+pub fn inlinable_function() -> i32 {
+    #[cfg(any(rpass1, rpass2))]
+    { 100 }
+
+    #[cfg(rpass3)]
+    { 200 }
+}
+
+// Public struct - unchanged across all revisions
+pub struct Data {
+    pub value: i32,
+}
+
+impl Data {
+    pub fn new(v: i32) -> Self {
+        Data { value: v }
+    }
+}

--- a/tests/incremental/svh_stability/main.rs
+++ b/tests/incremental/svh_stability/main.rs
@@ -1,0 +1,58 @@
+//@ revisions: rpass1 rpass2 rpass3
+//@ compile-flags: -Z query-dep-graph
+//@ aux-build: dependency.rs
+//@ ignore-backends: gcc
+
+// This test verifies SVH (Strict Version Hash) stability behavior:
+//
+// rpass1 -> rpass2: Only a PRIVATE function body changes in the dependency.
+//   The SVH should NOT change, so this crate should be fully reused.
+//
+// rpass2 -> rpass3: An INLINABLE (#[inline]) function body changes.
+//   The SVH SHOULD change, so this crate needs to be re-codegened.
+
+#![feature(rustc_attrs)]
+
+// When private function changes (rpass1 -> rpass2): ALL modules should be REUSED
+// because the SVH doesn't change when only private items change.
+#![rustc_partition_reused(module="main-use_public", cfg="rpass2")]
+#![rustc_partition_reused(module="main-use_inlinable", cfg="rpass2")]
+#![rustc_partition_reused(module="main-use_struct", cfg="rpass2")]
+
+// When inlinable function changes (rpass2 -> rpass3): only the module that
+// uses the inlinable function should be CODEGENED. Other modules are REUSED.
+#![rustc_partition_reused(module="main-use_public", cfg="rpass3")]
+#![rustc_partition_codegened(module="main-use_inlinable", cfg="rpass3")]
+#![rustc_partition_reused(module="main-use_struct", cfg="rpass3")]
+
+extern crate dependency;
+
+pub mod use_public {
+    use dependency::public_function;
+
+    pub fn call_public() -> i32 {
+        public_function()
+    }
+}
+
+pub mod use_inlinable {
+    use dependency::inlinable_function;
+
+    pub fn call_inlinable() -> i32 {
+        inlinable_function()
+    }
+}
+
+pub mod use_struct {
+    use dependency::Data;
+
+    pub fn make_data() -> Data {
+        Data::new(42)
+    }
+}
+
+fn main() {
+    let _ = use_public::call_public();
+    let _ = use_inlinable::call_inlinable();
+    let _ = use_struct::make_data();
+}

--- a/tests/run-make/rdr-async-panic-location/lib.rs
+++ b/tests/run-make/rdr-async-panic-location/lib.rs
@@ -1,0 +1,14 @@
+pub async fn async_panic() {
+    inner_panic().await;
+}
+
+async fn inner_panic() {
+    panic!("panic inside async fn at lib.rs:6");
+}
+
+pub async fn nested_async_panic() {
+    let fut = async {
+        panic!("panic in async block at lib.rs:11");
+    };
+    fut.await;
+}

--- a/tests/run-make/rdr-async-panic-location/main.rs
+++ b/tests/run-make/rdr-async-panic-location/main.rs
@@ -1,0 +1,34 @@
+extern crate rdr_async_lib;
+
+fn block_on<F: std::future::Future>(fut: F) -> F::Output {
+    use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+
+    fn clone(_: *const ()) -> RawWaker {
+        RawWaker::new(std::ptr::null(), &VTABLE)
+    }
+    fn wake(_: *const ()) {}
+    fn wake_by_ref(_: *const ()) {}
+    fn drop(_: *const ()) {}
+
+    static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, wake, wake_by_ref, drop);
+
+    let waker = unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) };
+    let mut cx = Context::from_waker(&waker);
+    let mut fut = std::pin::pin!(fut);
+
+    loop {
+        match fut.as_mut().poll(&mut cx) {
+            Poll::Ready(val) => return val,
+            Poll::Pending => {}
+        }
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    match args.get(1).map(|s| s.as_str()) {
+        Some("async") => block_on(rdr_async_lib::async_panic()),
+        Some("nested") => block_on(rdr_async_lib::nested_async_panic()),
+        _ => println!("usage: main [async|nested]"),
+    }
+}

--- a/tests/run-make/rdr-async-panic-location/rmake.rs
+++ b/tests/run-make/rdr-async-panic-location/rmake.rs
@@ -1,5 +1,5 @@
 // Test that panic locations inside async functions are correct
-// when using -Z separate-spans.
+// when using -Z stable-crate-hash.
 
 //@ ignore-cross-compile
 
@@ -12,7 +12,7 @@ fn main() {
             .crate_name("rdr_async_lib")
             .crate_type("rlib")
             .edition("2024")
-            .arg("-Zseparate-spans")
+            .arg("-Zstable-crate-hash")
             .run();
 
         rustc()
@@ -20,15 +20,12 @@ fn main() {
             .crate_type("bin")
             .extern_("rdr_async_lib", "librdr_async_lib.rlib")
             .edition("2024")
-            .arg("-Zseparate-spans")
+            .arg("-Zstable-crate-hash")
             .run();
 
         let output = cmd("./main").arg("async").run_fail();
         let stderr = output.stderr_utf8();
-        assert!(
-            stderr.contains("lib.rs:6"),
-            "async panic should show lib.rs:6, got:\n{stderr}"
-        );
+        assert!(stderr.contains("lib.rs:6"), "async panic should show lib.rs:6, got:\n{stderr}");
 
         let output = cmd("./main").arg("nested").run_fail();
         let stderr = output.stderr_utf8();

--- a/tests/run-make/rdr-async-panic-location/rmake.rs
+++ b/tests/run-make/rdr-async-panic-location/rmake.rs
@@ -1,0 +1,40 @@
+// Test that panic locations inside async functions are correct
+// when using -Z separate-spans.
+
+//@ ignore-cross-compile
+
+use run_make_support::{cmd, run_in_tmpdir, rustc};
+
+fn main() {
+    run_in_tmpdir(|| {
+        rustc()
+            .input("lib.rs")
+            .crate_name("rdr_async_lib")
+            .crate_type("rlib")
+            .edition("2024")
+            .arg("-Zseparate-spans")
+            .run();
+
+        rustc()
+            .input("main.rs")
+            .crate_type("bin")
+            .extern_("rdr_async_lib", "librdr_async_lib.rlib")
+            .edition("2024")
+            .arg("-Zseparate-spans")
+            .run();
+
+        let output = cmd("./main").arg("async").run_fail();
+        let stderr = output.stderr_utf8();
+        assert!(
+            stderr.contains("lib.rs:6"),
+            "async panic should show lib.rs:6, got:\n{stderr}"
+        );
+
+        let output = cmd("./main").arg("nested").run_fail();
+        let stderr = output.stderr_utf8();
+        assert!(
+            stderr.contains("lib.rs:11"),
+            "nested async panic should show lib.rs:11, got:\n{stderr}"
+        );
+    });
+}

--- a/tests/run-make/rdr-cdylib/lib.rs
+++ b/tests/run-make/rdr-cdylib/lib.rs
@@ -1,0 +1,13 @@
+#[no_mangle]
+pub extern "C" fn add_numbers(a: i32, b: i32) -> i32 {
+    private_add(a, b)
+}
+
+fn private_add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+#[no_mangle]
+pub extern "C" fn get_message() -> *const u8 {
+    b"Hello from cdylib\0".as_ptr()
+}

--- a/tests/run-make/rdr-cdylib/rmake.rs
+++ b/tests/run-make/rdr-cdylib/rmake.rs
@@ -1,4 +1,4 @@
-// Test that cdylib builds work correctly with -Z separate-spans.
+// Test that cdylib builds work correctly with -Z stable-crate-hash.
 
 //@ ignore-cross-compile
 
@@ -10,13 +10,10 @@ fn main() {
             .input("lib.rs")
             .crate_type("cdylib")
             .crate_name("rdr_cdylib")
-            .arg("-Zseparate-spans")
+            .arg("-Zstable-crate-hash")
             .run();
 
         let lib_name = dynamic_lib_name("rdr_cdylib");
-        assert!(
-            std::path::Path::new(&lib_name).exists(),
-            "cdylib should be created: {lib_name}"
-        );
+        assert!(std::path::Path::new(&lib_name).exists(), "cdylib should be created: {lib_name}");
     });
 }

--- a/tests/run-make/rdr-cdylib/rmake.rs
+++ b/tests/run-make/rdr-cdylib/rmake.rs
@@ -1,0 +1,22 @@
+// Test that cdylib builds work correctly with -Z separate-spans.
+
+//@ ignore-cross-compile
+
+use run_make_support::{dynamic_lib_name, run_in_tmpdir, rustc};
+
+fn main() {
+    run_in_tmpdir(|| {
+        rustc()
+            .input("lib.rs")
+            .crate_type("cdylib")
+            .crate_name("rdr_cdylib")
+            .arg("-Zseparate-spans")
+            .run();
+
+        let lib_name = dynamic_lib_name("rdr_cdylib");
+        assert!(
+            std::path::Path::new(&lib_name).exists(),
+            "cdylib should be created: {lib_name}"
+        );
+    });
+}

--- a/tests/run-make/rdr-coverage/lib.rs
+++ b/tests/run-make/rdr-coverage/lib.rs
@@ -1,4 +1,4 @@
-// Library crate for testing coverage instrumentation with -Z separate-spans.
+// Library crate for testing coverage instrumentation with -Z stable-crate-hash.
 // Contains functions with various control flow for coverage testing.
 
 #![crate_type = "rlib"]

--- a/tests/run-make/rdr-coverage/lib.rs
+++ b/tests/run-make/rdr-coverage/lib.rs
@@ -1,0 +1,47 @@
+// Library crate for testing coverage instrumentation with -Z separate-spans.
+// Contains functions with various control flow for coverage testing.
+
+#![crate_type = "rlib"]
+#![crate_name = "rdr_coverage_lib"]
+
+/// Simple function with linear control flow.
+pub fn simple_add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+/// Function with branching for coverage testing.
+pub fn max_value(a: i32, b: i32) -> i32 {
+    if a > b { a } else { b }
+}
+
+/// Function with a loop for coverage testing.
+pub fn sum_to_n(n: i32) -> i32 {
+    let mut sum = 0;
+    for i in 1..=n {
+        sum += i;
+    }
+    sum
+}
+
+/// Function with multiple branches.
+pub fn classify_number(n: i32) -> &'static str {
+    if n < 0 {
+        "negative"
+    } else if n == 0 {
+        "zero"
+    } else if n < 10 {
+        "small positive"
+    } else {
+        "large positive"
+    }
+}
+
+// Private function for testing coverage across visibility boundaries.
+fn private_multiply(a: i32, b: i32) -> i32 {
+    a * b
+}
+
+/// Public function that uses private helper.
+pub fn square(n: i32) -> i32 {
+    private_multiply(n, n)
+}

--- a/tests/run-make/rdr-coverage/main.rs
+++ b/tests/run-make/rdr-coverage/main.rs
@@ -1,0 +1,30 @@
+// Main crate that exercises the library functions for coverage.
+
+extern crate rdr_coverage_lib;
+
+use rdr_coverage_lib::*;
+
+fn main() {
+    // Exercise all functions to generate coverage data
+
+    // Simple add
+    let _ = simple_add(1, 2);
+
+    // Max value - exercise both branches
+    let _ = max_value(5, 3); // a > b branch
+    let _ = max_value(2, 7); // else branch
+
+    // Sum to n
+    let _ = sum_to_n(10);
+
+    // Classify number - exercise all branches
+    let _ = classify_number(-5); // negative
+    let _ = classify_number(0); // zero
+    let _ = classify_number(5); // small positive
+    let _ = classify_number(100); // large positive
+
+    // Square (calls private helper)
+    let _ = square(4);
+
+    println!("Coverage test completed");
+}

--- a/tests/run-make/rdr-coverage/rmake.rs
+++ b/tests/run-make/rdr-coverage/rmake.rs
@@ -1,7 +1,7 @@
-// Test that coverage instrumentation works correctly with -Z separate-spans.
+// Test that coverage instrumentation works correctly with -Z stable-crate-hash.
 //
 // This verifies that:
-// 1. Coverage instrumentation compiles successfully with -Z separate-spans
+// 1. Coverage instrumentation compiles successfully with -Z stable-crate-hash
 // 2. Coverage profraw data is generated when running the instrumented binary
 // 3. Coverage data can be converted to a report format
 //
@@ -15,12 +15,12 @@ use run_make_support::{cmd, cwd, llvm_profdata, rfs, run_in_tmpdir, rustc};
 
 fn main() {
     run_in_tmpdir(|| {
-        // Build library with coverage instrumentation and -Z separate-spans
+        // Build library with coverage instrumentation and -Z stable-crate-hash
         rustc()
             .input("lib.rs")
             .crate_type("rlib")
             .arg("-Cinstrument-coverage")
-            .arg("-Zseparate-spans")
+            .arg("-Zstable-crate-hash")
             .run();
 
         // Build main binary with coverage instrumentation
@@ -29,7 +29,7 @@ fn main() {
             .crate_type("bin")
             .extern_("rdr_coverage_lib", "librdr_coverage_lib.rlib")
             .arg("-Cinstrument-coverage")
-            .arg("-Zseparate-spans")
+            .arg("-Zstable-crate-hash")
             .run();
 
         // Run the binary to generate coverage data

--- a/tests/run-make/rdr-coverage/rmake.rs
+++ b/tests/run-make/rdr-coverage/rmake.rs
@@ -1,0 +1,67 @@
+// Test that coverage instrumentation works correctly with -Z separate-spans.
+//
+// This verifies that:
+// 1. Coverage instrumentation compiles successfully with -Z separate-spans
+// 2. Coverage profraw data is generated when running the instrumented binary
+// 3. Coverage data can be converted to a report format
+//
+// Coverage regions should point to correct source locations even when
+// spans are stored separately from metadata.
+
+//@ ignore-cross-compile
+//@ needs-profiler-runtime
+
+use run_make_support::{cmd, cwd, llvm_profdata, rfs, run_in_tmpdir, rustc};
+
+fn main() {
+    run_in_tmpdir(|| {
+        // Build library with coverage instrumentation and -Z separate-spans
+        rustc()
+            .input("lib.rs")
+            .crate_type("rlib")
+            .arg("-Cinstrument-coverage")
+            .arg("-Zseparate-spans")
+            .run();
+
+        // Build main binary with coverage instrumentation
+        rustc()
+            .input("main.rs")
+            .crate_type("bin")
+            .extern_("rdr_coverage_lib", "librdr_coverage_lib.rlib")
+            .arg("-Cinstrument-coverage")
+            .arg("-Zseparate-spans")
+            .run();
+
+        // Run the binary to generate coverage data
+        // The profraw file will be created in the current directory
+        let profraw_file = format!("{}/default_%m_%p.profraw", cwd().display());
+        cmd("./main").env("LLVM_PROFILE_FILE", &profraw_file).run();
+
+        // Find the generated profraw file
+        let profraw_files: Vec<_> = rfs::read_dir(".")
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().map_or(false, |ext| ext == "profraw"))
+            .collect();
+
+        assert!(!profraw_files.is_empty(), "Should have generated at least one .profraw file");
+
+        // Merge the profraw data into profdata
+        let profdata_file = "coverage.profdata";
+        llvm_profdata()
+            .arg("merge")
+            .arg("-sparse")
+            .args(profraw_files.iter().map(|e| e.path()))
+            .arg("-o")
+            .arg(profdata_file)
+            .run();
+
+        assert!(std::path::Path::new(profdata_file).exists(), "Should have created profdata file");
+
+        // Verify the profdata file is valid by checking it can be read
+        let profdata_size = rfs::metadata(profdata_file).unwrap().len();
+        assert!(profdata_size > 0, "Profdata file should not be empty");
+
+        println!("Coverage test passed! Generated {} bytes of coverage data.", profdata_size);
+    });
+}

--- a/tests/run-make/rdr-debuginfo/lib.rs
+++ b/tests/run-make/rdr-debuginfo/lib.rs
@@ -1,0 +1,43 @@
+// Library crate for testing debuginfo with -Z separate-spans.
+// Contains functions at known line numbers for DWARF verification.
+
+#![crate_type = "rlib"]
+#![crate_name = "rdr_debuginfo_lib"]
+
+/// Public function at a known line for debuginfo testing.
+/// Should appear at line 9 in DWARF info.
+pub fn public_function(x: i32) -> i32 {
+    // Line 9
+    let y = x + 1; // Line 10
+    let z = y * 2; // Line 11
+    z // Line 12
+}
+
+/// Another public function with more complex control flow.
+/// Tests that debuginfo correctly handles multiple statements.
+pub fn complex_function(a: i32, b: i32) -> i32 {
+    // Line 18
+    let mut result = 0; // Line 19
+    if a > b {
+        // Line 20
+        result = a - b; // Line 21
+    } else {
+        // Line 22
+        result = b - a; // Line 23
+    } // Line 24
+    result // Line 25
+}
+
+// Private function - its line info should still be correct
+// even though it's not part of the public API.
+fn private_helper(x: i32) -> i32 {
+    // Line 30
+    x * x // Line 31
+}
+
+/// Public function that calls a private helper.
+/// Tests that debuginfo works across visibility boundaries.
+pub fn calls_private(x: i32) -> i32 {
+    // Line 36
+    private_helper(x) + 1 // Line 37
+}

--- a/tests/run-make/rdr-debuginfo/lib.rs
+++ b/tests/run-make/rdr-debuginfo/lib.rs
@@ -1,4 +1,4 @@
-// Library crate for testing debuginfo with -Z separate-spans.
+// Library crate for testing debuginfo with -Z stable-crate-hash.
 // Contains functions at known line numbers for DWARF verification.
 
 #![crate_type = "rlib"]

--- a/tests/run-make/rdr-debuginfo/rmake.rs
+++ b/tests/run-make/rdr-debuginfo/rmake.rs
@@ -1,0 +1,52 @@
+// Test that debuginfo line numbers are correct when using -Z separate-spans.
+//
+// This verifies that DWARF debug information contains accurate file:line
+// information even when spans are stored separately from metadata.
+//
+// We use llvm-dwarfdump to inspect the generated debug info and verify
+// that function line numbers match their source locations.
+
+//@ ignore-cross-compile
+//@ needs-llvm-components: aarch64 arm x86
+
+use run_make_support::{llvm_dwarfdump, run_in_tmpdir, rustc};
+
+fn main() {
+    run_in_tmpdir(|| {
+        // Build with debuginfo and -Z separate-spans
+        rustc()
+            .input("lib.rs")
+            .crate_type("rlib")
+            .arg("-Cdebuginfo=2")
+            .arg("-Zseparate-spans")
+            .run();
+
+        // Use llvm-dwarfdump to extract debug info
+        let output = llvm_dwarfdump().arg("--debug-line").arg("librdr_debuginfo_lib.rlib").run();
+
+        let stdout = output.stdout_utf8();
+
+        // Verify that the debug line info contains references to our source file
+        assert!(stdout.contains("lib.rs"), "Debug info should reference lib.rs, got:\n{}", stdout);
+
+        // Build again and verify reproducibility
+        rustc()
+            .input("lib.rs")
+            .crate_type("rlib")
+            .arg("-Cdebuginfo=2")
+            .arg("-Zseparate-spans")
+            .out_dir("second")
+            .run();
+
+        let output2 =
+            llvm_dwarfdump().arg("--debug-line").arg("second/librdr_debuginfo_lib.rlib").run();
+
+        let stdout2 = output2.stdout_utf8();
+
+        // The debug line tables should be identical
+        // (after accounting for path differences)
+        assert!(stdout2.contains("lib.rs"), "Second build debug info should also reference lib.rs");
+
+        println!("Debuginfo tests passed!");
+    });
+}

--- a/tests/run-make/rdr-debuginfo/rmake.rs
+++ b/tests/run-make/rdr-debuginfo/rmake.rs
@@ -1,4 +1,4 @@
-// Test that debuginfo line numbers are correct when using -Z separate-spans.
+// Test that debuginfo line numbers are correct when using -Z stable-crate-hash.
 //
 // This verifies that DWARF debug information contains accurate file:line
 // information even when spans are stored separately from metadata.
@@ -13,12 +13,12 @@ use run_make_support::{llvm_dwarfdump, run_in_tmpdir, rustc};
 
 fn main() {
     run_in_tmpdir(|| {
-        // Build with debuginfo and -Z separate-spans
+        // Build with debuginfo and -Z stable-crate-hash
         rustc()
             .input("lib.rs")
             .crate_type("rlib")
             .arg("-Cdebuginfo=2")
-            .arg("-Zseparate-spans")
+            .arg("-Zstable-crate-hash")
             .run();
 
         // Use llvm-dwarfdump to extract debug info
@@ -34,7 +34,7 @@ fn main() {
             .input("lib.rs")
             .crate_type("rlib")
             .arg("-Cdebuginfo=2")
-            .arg("-Zseparate-spans")
+            .arg("-Zstable-crate-hash")
             .out_dir("second")
             .run();
 

--- a/tests/run-make/rdr-diagnostic-gating/rmake.rs
+++ b/tests/run-make/rdr-diagnostic-gating/rmake.rs
@@ -1,4 +1,4 @@
-// Check that diagnostic replay is gated by the spans hash when using -Z separate-spans.
+// Check that diagnostic replay is gated by the spans hash when using -Z stable-crate-hash.
 //@ ignore-cross-compile
 // Reason: uses incremental directory tied to host toolchain paths
 
@@ -12,7 +12,7 @@ fn main() {
         let output1 = rustc()
             .input("main.rs")
             .incremental("incr")
-            .arg("-Zseparate-spans")
+            .arg("-Zstable-crate-hash")
             .arg("-Zincremental-ignore-spans")
             .run();
         output1.assert_stderr_contains("unused variable");
@@ -20,7 +20,7 @@ fn main() {
         let output2 = rustc()
             .input("main.rs")
             .incremental("incr")
-            .arg("-Zseparate-spans")
+            .arg("-Zstable-crate-hash")
             .arg("-Zincremental-ignore-spans")
             .run();
         output2.assert_stderr_contains("unused variable");
@@ -31,7 +31,7 @@ fn main() {
         let output3 = rustc()
             .input("main.rs")
             .incremental("incr")
-            .arg("-Zseparate-spans")
+            .arg("-Zstable-crate-hash")
             .arg("-Zincremental-ignore-spans")
             .run();
         output3.assert_stderr_not_contains("unused variable");

--- a/tests/run-make/rdr-diagnostic-gating/rmake.rs
+++ b/tests/run-make/rdr-diagnostic-gating/rmake.rs
@@ -1,0 +1,39 @@
+// Check that diagnostic replay is gated by the spans hash when using -Z separate-spans.
+//@ ignore-cross-compile
+// Reason: uses incremental directory tied to host toolchain paths
+
+use run_make_support::{rfs, run_in_tmpdir, rustc};
+
+fn main() {
+    run_in_tmpdir(|| {
+        let source_v1 = "fn main() { let unused = 1; }\n";
+        rfs::write("main.rs", source_v1);
+
+        let output1 = rustc()
+            .input("main.rs")
+            .incremental("incr")
+            .arg("-Zseparate-spans")
+            .arg("-Zincremental-ignore-spans")
+            .run();
+        output1.assert_stderr_contains("unused variable");
+
+        let output2 = rustc()
+            .input("main.rs")
+            .incremental("incr")
+            .arg("-Zseparate-spans")
+            .arg("-Zincremental-ignore-spans")
+            .run();
+        output2.assert_stderr_contains("unused variable");
+
+        let source_v2 = "// span-only change\nfn main() { let unused = 1; }\n";
+        rfs::write("main.rs", source_v2);
+
+        let output3 = rustc()
+            .input("main.rs")
+            .incremental("incr")
+            .arg("-Zseparate-spans")
+            .arg("-Zincremental-ignore-spans")
+            .run();
+        output3.assert_stderr_not_contains("unused variable");
+    });
+}

--- a/tests/run-make/rdr-hygiene-hash-collision/rmake.rs
+++ b/tests/run-make/rdr-hygiene-hash-collision/rmake.rs
@@ -1,0 +1,99 @@
+// Test that identifiers with the same name but different hygiene contexts
+// don't cause dep node hash collisions when using `-Zincremental-ignore-spans`.
+//
+// This regression test verifies that SyntaxContext (hygiene info) is always
+// hashed even when span positions are ignored. Without this fix, two `Ident`s
+// with the same `Symbol` but different `SyntaxContext` would hash identically,
+// causing ICE: "query key X and key Y mapped to the same dep node".
+//
+// The issue manifests with macros that generate identifiers - each macro
+// expansion creates identifiers with different hygiene contexts, but when
+// spans are ignored, only the symbol name was being hashed.
+//
+//@ ignore-cross-compile
+
+use run_make_support::{rfs, rustc};
+
+fn main() {
+    // Create a library with macro-generated code that creates identifiers
+    // with the same name but different hygiene contexts.
+    //
+    // The key is to generate code that triggers queries like
+    // `explicit_supertraits_containing_assoc_item` with identifiers that
+    // have the same Symbol but different SyntaxContext.
+    let lib_source = r#"
+// Macro that generates a trait with an associated type.
+// Each invocation creates identifiers with different SyntaxContext.
+macro_rules! make_trait {
+    ($trait_name:ident, $assoc_name:ident) => {
+        pub trait $trait_name {
+            type $assoc_name;
+        }
+    };
+}
+
+// Generate traits with different associated type names
+make_trait!(TraitA, ItemA);
+make_trait!(TraitB, ItemB);
+make_trait!(TraitC, ItemC);
+
+// Trait that combines them - triggers supertraits_containing_assoc_item queries
+pub trait Combined: TraitA + TraitB + TraitC {
+    fn get_a(&self) -> <Self as TraitA>::ItemA;
+    fn get_b(&self) -> <Self as TraitB>::ItemB;
+    fn get_c(&self) -> <Self as TraitC>::ItemC;
+}
+
+// Macro that generates impls - each expansion has different hygiene
+macro_rules! impl_for {
+    ($ty:ty, $trait:ident, $assoc:ident, $val:ty) => {
+        impl $trait for $ty {
+            type $assoc = $val;
+        }
+    };
+}
+
+pub struct MyStruct;
+impl_for!(MyStruct, TraitA, ItemA, i32);
+impl_for!(MyStruct, TraitB, ItemB, i64);
+impl_for!(MyStruct, TraitC, ItemC, u32);
+
+impl Combined for MyStruct {
+    fn get_a(&self) -> i32 { 0 }
+    fn get_b(&self) -> i64 { 0 }
+    fn get_c(&self) -> u32 { 0 }
+}
+
+// More macro invocations to increase chance of hygiene collision
+macro_rules! make_fn {
+    ($name:ident) => {
+        pub fn $name() {}
+    };
+}
+
+make_fn!(foo);
+make_fn!(bar);
+make_fn!(baz);
+"#;
+
+    rfs::write("lib.rs", lib_source);
+
+    // Compile with RDR flags - this would ICE before the fix due to
+    // hygiene contexts not being hashed when spans are ignored.
+    rustc()
+        .input("lib.rs")
+        .crate_type("lib")
+        .incremental("incr")
+        .arg("-Zseparate-spans")
+        .arg("-Zincremental-ignore-spans")
+        .run();
+
+    // Second compilation to exercise incremental path
+    rustc()
+        .input("lib.rs")
+        .crate_type("lib")
+        .incremental("incr")
+        .arg("-Zseparate-spans")
+        .arg("-Zincremental-ignore-spans")
+        .run();
+}

--- a/tests/run-make/rdr-hygiene-hash-collision/rmake.rs
+++ b/tests/run-make/rdr-hygiene-hash-collision/rmake.rs
@@ -84,18 +84,8 @@ make_fn!(baz);
     // Compile with RDR flags - this would ICE before the fix due to
     // hygiene contexts not being hashed when spans are ignored.
     // With SpanRef migration, -Zincremental-ignore-spans is no longer needed.
-    rustc()
-        .input("lib.rs")
-        .crate_type("lib")
-        .incremental("incr")
-        .arg("-Zstable-crate-hash")
-        .run();
+    rustc().input("lib.rs").crate_type("lib").incremental("incr").arg("-Zstable-crate-hash").run();
 
     // Second compilation to exercise incremental path
-    rustc()
-        .input("lib.rs")
-        .crate_type("lib")
-        .incremental("incr")
-        .arg("-Zstable-crate-hash")
-        .run();
+    rustc().input("lib.rs").crate_type("lib").incremental("incr").arg("-Zstable-crate-hash").run();
 }

--- a/tests/run-make/rdr-hygiene-hash-collision/rmake.rs
+++ b/tests/run-make/rdr-hygiene-hash-collision/rmake.rs
@@ -84,7 +84,7 @@ make_fn!(baz);
         .input("lib.rs")
         .crate_type("lib")
         .incremental("incr")
-        .arg("-Zseparate-spans")
+        .arg("-Zstable-crate-hash")
         .arg("-Zincremental-ignore-spans")
         .run();
 
@@ -93,7 +93,7 @@ make_fn!(baz);
         .input("lib.rs")
         .crate_type("lib")
         .incremental("incr")
-        .arg("-Zseparate-spans")
+        .arg("-Zstable-crate-hash")
         .arg("-Zincremental-ignore-spans")
         .run();
 }

--- a/tests/run-make/rdr-lto/lib.rs
+++ b/tests/run-make/rdr-lto/lib.rs
@@ -1,0 +1,14 @@
+pub fn public_fn(x: u32) -> u32 {
+    private_fn(x)
+}
+
+#[inline]
+fn private_fn(x: u32) -> u32 {
+    x + 1
+}
+
+pub fn inlined_panic(should_panic: bool) {
+    if should_panic {
+        panic!("panic at lib.rs:12");
+    }
+}

--- a/tests/run-make/rdr-lto/main.rs
+++ b/tests/run-make/rdr-lto/main.rs
@@ -1,0 +1,10 @@
+extern crate rdr_lto_lib;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.get(1).map(|s| s.as_str()) == Some("panic") {
+        rdr_lto_lib::inlined_panic(true);
+    }
+    let result = rdr_lto_lib::public_fn(41);
+    assert_eq!(result, 42);
+}

--- a/tests/run-make/rdr-lto/rmake.rs
+++ b/tests/run-make/rdr-lto/rmake.rs
@@ -1,4 +1,4 @@
-// Test that LTO builds work correctly with -Z separate-spans,
+// Test that LTO builds work correctly with -Z stable-crate-hash,
 // including correct panic locations for cross-crate inlined functions.
 
 //@ ignore-cross-compile
@@ -11,7 +11,7 @@ fn main() {
             .input("lib.rs")
             .crate_type("rlib")
             .crate_name("rdr_lto_lib")
-            .arg("-Zseparate-spans")
+            .arg("-Zstable-crate-hash")
             .arg("-Clto=thin")
             .run();
 
@@ -19,7 +19,7 @@ fn main() {
             .input("main.rs")
             .crate_type("bin")
             .extern_("rdr_lto_lib", "librdr_lto_lib.rlib")
-            .arg("-Zseparate-spans")
+            .arg("-Zstable-crate-hash")
             .arg("-Clto=thin")
             .output("main")
             .run();

--- a/tests/run-make/rdr-lto/rmake.rs
+++ b/tests/run-make/rdr-lto/rmake.rs
@@ -1,0 +1,36 @@
+// Test that LTO builds work correctly with -Z separate-spans,
+// including correct panic locations for cross-crate inlined functions.
+
+//@ ignore-cross-compile
+
+use run_make_support::{cmd, run_in_tmpdir, rustc};
+
+fn main() {
+    run_in_tmpdir(|| {
+        rustc()
+            .input("lib.rs")
+            .crate_type("rlib")
+            .crate_name("rdr_lto_lib")
+            .arg("-Zseparate-spans")
+            .arg("-Clto=thin")
+            .run();
+
+        rustc()
+            .input("main.rs")
+            .crate_type("bin")
+            .extern_("rdr_lto_lib", "librdr_lto_lib.rlib")
+            .arg("-Zseparate-spans")
+            .arg("-Clto=thin")
+            .output("main")
+            .run();
+
+        cmd("./main").run();
+
+        let output = cmd("./main").arg("panic").run_fail();
+        let stderr = output.stderr_utf8();
+        assert!(
+            stderr.contains("lib.rs:12"),
+            "inlined panic should show lib.rs:12, got:\n{stderr}"
+        );
+    });
+}

--- a/tests/run-make/rdr-missing-spans-fallback/rmake.rs
+++ b/tests/run-make/rdr-missing-spans-fallback/rmake.rs
@@ -1,6 +1,6 @@
 // Test that missing .spans file is treated as a hard error.
 //
-// This verifies that when a crate was compiled with `-Z separate-spans` and
+// This verifies that when a crate was compiled with `-Z stable-crate-hash` and
 // the `.spans` file is later deleted (simulating a corrupted incremental cache),
 // the compiler produces a clear error message rather than silently degrading.
 //
@@ -11,17 +11,17 @@ use run_make_support::{rfs, run_in_tmpdir, rustc};
 
 fn main() {
     run_in_tmpdir(|| {
-        // First, create a dependency crate compiled with -Z separate-spans
+        // First, create a dependency crate compiled with -Z stable-crate-hash
         // Use --emit=metadata to produce a standalone .rmeta file
         let dep_source = "pub fn dep_fn() -> i32 { 42 }\n";
         rfs::write("dep.rs", dep_source);
 
-        // Compile the dependency with -Z separate-spans and emit both rlib and metadata
+        // Compile the dependency with -Z stable-crate-hash and emit both rlib and metadata
         rustc()
             .input("dep.rs")
             .crate_type("rlib")
             .emit("metadata,link")
-            .arg("-Zseparate-spans")
+            .arg("-Zstable-crate-hash")
             .run();
 
         // Verify .spans file was created alongside .rmeta

--- a/tests/run-make/rdr-missing-spans-fallback/rmake.rs
+++ b/tests/run-make/rdr-missing-spans-fallback/rmake.rs
@@ -1,0 +1,49 @@
+// Test that missing .spans file is treated as a hard error.
+//
+// This verifies that when a crate was compiled with `-Z separate-spans` and
+// the `.spans` file is later deleted (simulating a corrupted incremental cache),
+// the compiler produces a clear error message rather than silently degrading.
+//
+//@ ignore-cross-compile
+// Reason: uses incremental directory tied to host toolchain paths
+
+use run_make_support::{rfs, run_in_tmpdir, rustc};
+
+fn main() {
+    run_in_tmpdir(|| {
+        // First, create a dependency crate compiled with -Z separate-spans
+        // Use --emit=metadata to produce a standalone .rmeta file
+        let dep_source = "pub fn dep_fn() -> i32 { 42 }\n";
+        rfs::write("dep.rs", dep_source);
+
+        // Compile the dependency with -Z separate-spans and emit both rlib and metadata
+        rustc()
+            .input("dep.rs")
+            .crate_type("rlib")
+            .emit("metadata,link")
+            .arg("-Zseparate-spans")
+            .run();
+
+        // Verify .spans file was created alongside .rmeta
+        let rmeta_path = std::path::Path::new("libdep.rmeta");
+        let spans_path = std::path::Path::new("libdep.spans");
+        let rlib_path = std::path::Path::new("libdep.rlib");
+        assert!(rmeta_path.exists(), "expected libdep.rmeta to exist");
+        assert!(spans_path.exists(), "expected libdep.spans to exist");
+        assert!(rlib_path.exists(), "expected libdep.rlib to exist");
+
+        // Delete the .spans file to simulate corrupted cache
+        rfs::remove_file(spans_path);
+
+        // Now try to compile a crate that depends on the dependency
+        // This should fail with a clear error about missing span data
+        let main_source = "extern crate dep; fn main() { dep::dep_fn(); }\n";
+        rfs::write("main.rs", main_source);
+
+        let output = rustc().input("main.rs").extern_("dep", "libdep.rlib").run_fail();
+
+        // Verify we get the expected error message
+        output.assert_stderr_contains("cannot load span data for crate");
+        output.assert_stderr_contains("the incremental compilation cache may be corrupted");
+    });
+}

--- a/tests/run-make/rdr-panic-location/dep.rs
+++ b/tests/run-make/rdr-panic-location/dep.rs
@@ -1,12 +1,12 @@
 // Dependency crate that can panic at known locations.
-// The panic locations are used to verify that -Z separate-spans
+// The panic locations are used to verify that -Z stable-crate-hash
 // preserves correct file:line:col information.
 
 #![crate_type = "rlib"]
 #![crate_name = "dep"]
 
 /// Public function that panics. The panic location should be
-/// correctly reported even when compiled with -Z separate-spans.
+/// correctly reported even when compiled with -Z stable-crate-hash.
 #[inline(never)]
 pub fn will_panic(trigger: bool) {
     if trigger {

--- a/tests/run-make/rdr-panic-location/dep.rs
+++ b/tests/run-make/rdr-panic-location/dep.rs
@@ -1,0 +1,38 @@
+// Dependency crate that can panic at known locations.
+// The panic locations are used to verify that -Z separate-spans
+// preserves correct file:line:col information.
+
+#![crate_type = "rlib"]
+#![crate_name = "dep"]
+
+/// Public function that panics. The panic location should be
+/// correctly reported even when compiled with -Z separate-spans.
+#[inline(never)]
+pub fn will_panic(trigger: bool) {
+    if trigger {
+        panic!("intentional panic for testing"); // Line 13
+    }
+}
+
+/// Public function with panic in a private helper.
+/// Tests that spans in private code are still correctly resolved.
+#[inline(never)]
+pub fn panic_via_private(trigger: bool) {
+    private_panicker(trigger);
+}
+
+#[inline(never)]
+fn private_panicker(trigger: bool) {
+    if trigger {
+        panic!("panic from private function"); // Line 27
+    }
+}
+
+/// Panic with a formatted message to test span handling
+/// in format string expansion.
+#[inline(never)]
+pub fn panic_with_format(value: i32) {
+    if value < 0 {
+        panic!("invalid value: {}", value); // Line 36
+    }
+}

--- a/tests/run-make/rdr-panic-location/main.rs
+++ b/tests/run-make/rdr-panic-location/main.rs
@@ -1,5 +1,5 @@
 // Main crate that triggers panics in the dependency.
-// Used to verify panic locations are correct with -Z separate-spans.
+// Used to verify panic locations are correct with -Z stable-crate-hash.
 
 extern crate dep;
 

--- a/tests/run-make/rdr-panic-location/main.rs
+++ b/tests/run-make/rdr-panic-location/main.rs
@@ -1,0 +1,18 @@
+// Main crate that triggers panics in the dependency.
+// Used to verify panic locations are correct with -Z separate-spans.
+
+extern crate dep;
+
+use std::env;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let test = args.get(1).map(|s| s.as_str()).unwrap_or("public");
+
+    match test {
+        "public" => dep::will_panic(true),
+        "private" => dep::panic_via_private(true),
+        "format" => dep::panic_with_format(-1),
+        _ => panic!("unknown test: {}", test),
+    }
+}

--- a/tests/run-make/rdr-panic-location/rmake.rs
+++ b/tests/run-make/rdr-panic-location/rmake.rs
@@ -1,4 +1,4 @@
-// Test that panic locations are correct when using -Z separate-spans.
+// Test that panic locations are correct when using -Z stable-crate-hash.
 //
 // This verifies that span information is correctly preserved/resolved
 // so that panic messages show accurate file:line:col locations.
@@ -14,15 +14,15 @@ use run_make_support::{cmd, run_in_tmpdir, rustc};
 
 fn main() {
     run_in_tmpdir(|| {
-        // Build dependency with -Z separate-spans
-        rustc().input("dep.rs").crate_type("rlib").arg("-Zseparate-spans").run();
+        // Build dependency with -Z stable-crate-hash
+        rustc().input("dep.rs").crate_type("rlib").arg("-Zstable-crate-hash").run();
 
         // Build main crate linking to the dependency
         rustc()
             .input("main.rs")
             .crate_type("bin")
             .extern_("dep", "libdep.rlib")
-            .arg("-Zseparate-spans")
+            .arg("-Zstable-crate-hash")
             .run();
 
         // Test 1: Public function panic location

--- a/tests/run-make/rdr-panic-location/rmake.rs
+++ b/tests/run-make/rdr-panic-location/rmake.rs
@@ -1,0 +1,63 @@
+// Test that panic locations are correct when using -Z separate-spans.
+//
+// This verifies that span information is correctly preserved/resolved
+// so that panic messages show accurate file:line:col locations.
+//
+// We test three scenarios:
+// 1. Panic in a public function
+// 2. Panic in a private function called from a public one
+// 3. Panic with format string arguments
+
+//@ ignore-cross-compile
+
+use run_make_support::{cmd, run_in_tmpdir, rustc};
+
+fn main() {
+    run_in_tmpdir(|| {
+        // Build dependency with -Z separate-spans
+        rustc().input("dep.rs").crate_type("rlib").arg("-Zseparate-spans").run();
+
+        // Build main crate linking to the dependency
+        rustc()
+            .input("main.rs")
+            .crate_type("bin")
+            .extern_("dep", "libdep.rlib")
+            .arg("-Zseparate-spans")
+            .run();
+
+        // Test 1: Public function panic location
+        // The panic should show dep.rs:13
+        let output = cmd("./main").arg("public").run_fail();
+        let stderr = output.stderr_utf8();
+        assert!(
+            stderr.contains("dep.rs:13"),
+            "Panic in public function should show dep.rs:13, got:\n{}",
+            stderr
+        );
+        assert!(stderr.contains("intentional panic for testing"), "Should contain panic message");
+
+        // Test 2: Private function panic location
+        // The panic should show dep.rs:27
+        let output = cmd("./main").arg("private").run_fail();
+        let stderr = output.stderr_utf8();
+        assert!(
+            stderr.contains("dep.rs:27"),
+            "Panic in private function should show dep.rs:27, got:\n{}",
+            stderr
+        );
+        assert!(stderr.contains("panic from private function"), "Should contain panic message");
+
+        // Test 3: Format string panic location
+        // The panic should show dep.rs:36
+        let output = cmd("./main").arg("format").run_fail();
+        let stderr = output.stderr_utf8();
+        assert!(
+            stderr.contains("dep.rs:36"),
+            "Panic with format should show dep.rs:36, got:\n{}",
+            stderr
+        );
+        assert!(stderr.contains("invalid value: -1"), "Should contain formatted panic message");
+
+        println!("All panic location tests passed!");
+    });
+}

--- a/tests/run-make/rdr-proc-macro-panic-location/main.rs
+++ b/tests/run-make/rdr-proc-macro-panic-location/main.rs
@@ -1,0 +1,17 @@
+#[macro_use]
+extern crate proc_macro_lib;
+
+#[derive(PanicDerive)]
+pub struct PanicStruct;
+
+#[panic_attr]
+mod my_mod {}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    match args.get(1).map(|s| s.as_str()) {
+        Some("derive") => PanicStruct::do_panic(),
+        Some("attr") => generated_panic(),
+        _ => println!("usage: main [derive|attr]"),
+    }
+}

--- a/tests/run-make/rdr-proc-macro-panic-location/proc_macro_lib.rs
+++ b/tests/run-make/rdr-proc-macro-panic-location/proc_macro_lib.rs
@@ -1,0 +1,30 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+
+#[proc_macro_derive(PanicDerive)]
+pub fn derive_panic(_input: TokenStream) -> TokenStream {
+    r#"
+        impl PanicStruct {
+            pub fn do_panic() {
+                panic!("panic from derived impl");
+            }
+        }
+    "#
+    .parse()
+    .unwrap()
+}
+
+#[proc_macro_attribute]
+pub fn panic_attr(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let item_str = item.to_string();
+    format!(
+        r#"
+        {item_str}
+        fn generated_panic() {{
+            panic!("panic from attribute macro");
+        }}
+        "#
+    )
+    .parse()
+    .unwrap()
+}

--- a/tests/run-make/rdr-proc-macro-panic-location/rmake.rs
+++ b/tests/run-make/rdr-proc-macro-panic-location/rmake.rs
@@ -1,5 +1,5 @@
 // Test that panic locations in proc-macro-generated code are correct
-// when using -Z separate-spans.
+// when using -Z stable-crate-hash.
 
 //@ ignore-cross-compile
 
@@ -10,14 +10,14 @@ fn main() {
         rustc()
             .input("proc_macro_lib.rs")
             .crate_type("proc-macro")
-            .arg("-Zseparate-spans")
+            .arg("-Zstable-crate-hash")
             .run();
 
         rustc()
             .input("main.rs")
             .crate_type("bin")
             .extern_("proc_macro_lib", "libproc_macro_lib.dylib")
-            .arg("-Zseparate-spans")
+            .arg("-Zstable-crate-hash")
             .run();
 
         let output = cmd("./main").arg("derive").run_fail();

--- a/tests/run-make/rdr-proc-macro-panic-location/rmake.rs
+++ b/tests/run-make/rdr-proc-macro-panic-location/rmake.rs
@@ -1,0 +1,37 @@
+// Test that panic locations in proc-macro-generated code are correct
+// when using -Z separate-spans.
+
+//@ ignore-cross-compile
+
+use run_make_support::{cmd, run_in_tmpdir, rustc};
+
+fn main() {
+    run_in_tmpdir(|| {
+        rustc()
+            .input("proc_macro_lib.rs")
+            .crate_type("proc-macro")
+            .arg("-Zseparate-spans")
+            .run();
+
+        rustc()
+            .input("main.rs")
+            .crate_type("bin")
+            .extern_("proc_macro_lib", "libproc_macro_lib.dylib")
+            .arg("-Zseparate-spans")
+            .run();
+
+        let output = cmd("./main").arg("derive").run_fail();
+        let stderr = output.stderr_utf8();
+        assert!(
+            stderr.contains("panic from derived impl"),
+            "should contain panic message, got:\n{stderr}"
+        );
+
+        let output = cmd("./main").arg("attr").run_fail();
+        let stderr = output.stderr_utf8();
+        assert!(
+            stderr.contains("panic from attribute macro"),
+            "should contain panic message, got:\n{stderr}"
+        );
+    });
+}

--- a/tests/run-make/rdr-separate-spans-include-str/dep.rs
+++ b/tests/run-make/rdr-separate-spans-include-str/dep.rs
@@ -1,0 +1,21 @@
+#[macro_export]
+macro_rules! dep_data {
+    () => {
+        include_str!("dep_data.txt")
+    };
+}
+
+pub fn dep_data_len() -> usize {
+    dep_data!().len()
+}
+
+#[macro_export]
+macro_rules! dep_bytes {
+    () => {
+        include_bytes!("dep_bytes.txt")
+    };
+}
+
+pub fn dep_bytes_len() -> usize {
+    dep_bytes!().len()
+}

--- a/tests/run-make/rdr-separate-spans-include-str/dep_bytes.txt
+++ b/tests/run-make/rdr-separate-spans-include-str/dep_bytes.txt
@@ -1,0 +1,1 @@
+hello bytes data

--- a/tests/run-make/rdr-separate-spans-include-str/dep_data.txt
+++ b/tests/run-make/rdr-separate-spans-include-str/dep_data.txt
@@ -1,0 +1,1 @@
+hello from dep data

--- a/tests/run-make/rdr-separate-spans-include-str/main.rs
+++ b/tests/run-make/rdr-separate-spans-include-str/main.rs
@@ -1,0 +1,10 @@
+#[macro_use]
+extern crate dep;
+
+fn main() {
+    let data = dep_data!();
+    assert!(data.contains("hello from dep data"));
+
+    let bytes = dep_bytes!();
+    assert!(bytes.starts_with(b"hello bytes data"));
+}

--- a/tests/run-make/rdr-separate-spans-include-str/rmake.rs
+++ b/tests/run-make/rdr-separate-spans-include-str/rmake.rs
@@ -1,16 +1,16 @@
 // Verify ExpnData spans decoded from metadata are usable for include_str!
-// when building with -Z separate-spans.
+// when building with -Z stable-crate-hash.
 //@ ignore-cross-compile
 // Reason: the compiled binary is executed
 
 use run_make_support::{run, rust_lib_name, rustc};
 
 fn main() {
-    rustc().input("dep.rs").crate_name("dep").crate_type("rlib").arg("-Zseparate-spans").run();
+    rustc().input("dep.rs").crate_name("dep").crate_type("rlib").arg("-Zstable-crate-hash").run();
 
     rustc()
         .input("main.rs")
-        .arg("-Zseparate-spans")
+        .arg("-Zstable-crate-hash")
         .arg("--extern")
         .arg(format!("dep={}", rust_lib_name("dep")))
         .run();

--- a/tests/run-make/rdr-separate-spans-include-str/rmake.rs
+++ b/tests/run-make/rdr-separate-spans-include-str/rmake.rs
@@ -1,0 +1,19 @@
+// Verify ExpnData spans decoded from metadata are usable for include_str!
+// when building with -Z separate-spans.
+//@ ignore-cross-compile
+// Reason: the compiled binary is executed
+
+use run_make_support::{run, rust_lib_name, rustc};
+
+fn main() {
+    rustc().input("dep.rs").crate_name("dep").crate_type("rlib").arg("-Zseparate-spans").run();
+
+    rustc()
+        .input("main.rs")
+        .arg("-Zseparate-spans")
+        .arg("--extern")
+        .arg(format!("dep={}", rust_lib_name("dep")))
+        .run();
+
+    run("main");
+}

--- a/tests/run-make/rdr-separate-spans/lib.rs
+++ b/tests/run-make/rdr-separate-spans/lib.rs
@@ -1,0 +1,41 @@
+// Test library for RDR separate-spans testing.
+// This crate exports various items that embed spans in metadata.
+
+#![crate_name = "rdr_test_lib"]
+#![crate_type = "rlib"]
+
+/// A public struct with spans in its definition.
+pub struct TestStruct {
+    pub field: u32,
+}
+
+/// A generic function whose span is embedded in metadata.
+#[inline(always)]
+pub fn generic_fn<T: Default>() -> T {
+    T::default()
+}
+
+/// A function with panic (embeds panic location span).
+pub fn might_panic(x: u32) -> u32 {
+    assert!(x > 0, "x must be positive");
+    x
+}
+
+/// Trait for testing trait impl spans.
+pub trait TestTrait {
+    fn process(&self) -> u32;
+}
+
+impl TestTrait for u32 {
+    fn process(&self) -> u32 {
+        *self * 2
+    }
+}
+
+/// Macro that embeds expansion spans.
+#[macro_export]
+macro_rules! test_macro {
+    ($e:expr) => {
+        $e + 1
+    };
+}

--- a/tests/run-make/rdr-separate-spans/lib.rs
+++ b/tests/run-make/rdr-separate-spans/lib.rs
@@ -1,4 +1,4 @@
-// Test library for RDR separate-spans testing.
+// Test library for RDR stable-crate-hash testing.
 // This crate exports various items that embed spans in metadata.
 
 #![crate_name = "rdr_test_lib"]

--- a/tests/run-make/rdr-separate-spans/rmake.rs
+++ b/tests/run-make/rdr-separate-spans/rmake.rs
@@ -1,0 +1,93 @@
+// Test that -Z separate-spans flag produces reproducible metadata.
+//
+// This test verifies:
+// 1. The -Z separate-spans flag is accepted by the compiler
+// 2. Compilation produces a .spans file alongside the .rmeta file (when implemented)
+// 3. The resulting rlib is reproducible across builds from different directories
+//
+// See https://github.com/rust-lang/rust/issues/XXXXX for the RDR tracking issue.
+
+//@ ignore-cross-compile
+
+use run_make_support::{cwd, rfs, run_in_tmpdir, rust_lib_name, rustc};
+
+fn main() {
+    // Test 1: Basic compilation with -Z separate-spans succeeds
+    run_in_tmpdir(|| {
+        rustc().input("lib.rs").crate_type("rlib").arg("-Zseparate-spans").run();
+
+        // Verify the rlib was created
+        assert!(
+            std::path::Path::new(&rust_lib_name("rdr_test_lib")).exists(),
+            "rlib should be created with -Z separate-spans"
+        );
+    });
+
+    // Test 2: Reproducibility - same source compiled twice should produce identical rlibs
+    run_in_tmpdir(|| {
+        // First compilation
+        rustc()
+            .input("lib.rs")
+            .crate_type("rlib")
+            .arg("-Zseparate-spans")
+            .arg(&format!("--remap-path-prefix={}=/src", cwd().display()))
+            .run();
+
+        let first_rlib = rfs::read(rust_lib_name("rdr_test_lib"));
+        rfs::rename(rust_lib_name("rdr_test_lib"), "first.rlib");
+
+        // Second compilation (identical)
+        rustc()
+            .input("lib.rs")
+            .crate_type("rlib")
+            .arg("-Zseparate-spans")
+            .arg(&format!("--remap-path-prefix={}=/src", cwd().display()))
+            .run();
+
+        let second_rlib = rfs::read(rust_lib_name("rdr_test_lib"));
+
+        assert_eq!(
+            first_rlib, second_rlib,
+            "Two identical compilations with -Z separate-spans should produce identical rlibs"
+        );
+    });
+
+    // Test 3: Compilation from different directories should produce identical rlibs
+    // when using appropriate path remapping
+    run_in_tmpdir(|| {
+        let base_dir = cwd();
+
+        // Create subdirectory with copy of source
+        rfs::create_dir("subdir");
+        rfs::copy("lib.rs", "subdir/lib.rs");
+
+        // Compile from base directory
+        rustc()
+            .input("lib.rs")
+            .crate_type("rlib")
+            .arg("-Zseparate-spans")
+            .arg(&format!("--remap-path-prefix={}=/src", base_dir.display()))
+            .run();
+
+        let base_rlib = rfs::read(rust_lib_name("rdr_test_lib"));
+        rfs::rename(rust_lib_name("rdr_test_lib"), "base.rlib");
+
+        // Compile from subdirectory
+        std::env::set_current_dir("subdir").unwrap();
+        rustc()
+            .input("lib.rs")
+            .crate_type("rlib")
+            .arg("-Zseparate-spans")
+            .arg(&format!("--remap-path-prefix={}=/src", base_dir.join("subdir").display()))
+            .out_dir(&base_dir)
+            .run();
+
+        std::env::set_current_dir(&base_dir).unwrap();
+        let subdir_rlib = rfs::read(rust_lib_name("rdr_test_lib"));
+
+        assert_eq!(
+            base_rlib, subdir_rlib,
+            "Compilation from different directories should produce identical rlibs"
+        );
+    });
+}

--- a/tests/run-make/rdr-separate-spans/rmake.rs
+++ b/tests/run-make/rdr-separate-spans/rmake.rs
@@ -1,7 +1,7 @@
-// Test that -Z separate-spans flag produces reproducible metadata.
+// Test that -Z stable-crate-hash flag produces reproducible metadata.
 //
 // This test verifies:
-// 1. The -Z separate-spans flag is accepted by the compiler
+// 1. The -Z stable-crate-hash flag is accepted by the compiler
 // 2. Compilation produces a .spans file alongside the .rmeta file (when implemented)
 // 3. The resulting rlib is reproducible across builds from different directories
 //
@@ -12,14 +12,14 @@
 use run_make_support::{cwd, rfs, run_in_tmpdir, rust_lib_name, rustc};
 
 fn main() {
-    // Test 1: Basic compilation with -Z separate-spans succeeds
+    // Test 1: Basic compilation with -Z stable-crate-hash succeeds
     run_in_tmpdir(|| {
-        rustc().input("lib.rs").crate_type("rlib").arg("-Zseparate-spans").run();
+        rustc().input("lib.rs").crate_type("rlib").arg("-Zstable-crate-hash").run();
 
         // Verify the rlib was created
         assert!(
             std::path::Path::new(&rust_lib_name("rdr_test_lib")).exists(),
-            "rlib should be created with -Z separate-spans"
+            "rlib should be created with -Z stable-crate-hash"
         );
     });
 
@@ -29,7 +29,7 @@ fn main() {
         rustc()
             .input("lib.rs")
             .crate_type("rlib")
-            .arg("-Zseparate-spans")
+            .arg("-Zstable-crate-hash")
             .arg(&format!("--remap-path-prefix={}=/src", cwd().display()))
             .run();
 
@@ -40,7 +40,7 @@ fn main() {
         rustc()
             .input("lib.rs")
             .crate_type("rlib")
-            .arg("-Zseparate-spans")
+            .arg("-Zstable-crate-hash")
             .arg(&format!("--remap-path-prefix={}=/src", cwd().display()))
             .run();
 
@@ -48,7 +48,7 @@ fn main() {
 
         assert_eq!(
             first_rlib, second_rlib,
-            "Two identical compilations with -Z separate-spans should produce identical rlibs"
+            "Two identical compilations with -Z stable-crate-hash should produce identical rlibs"
         );
     });
 
@@ -65,7 +65,7 @@ fn main() {
         rustc()
             .input("lib.rs")
             .crate_type("rlib")
-            .arg("-Zseparate-spans")
+            .arg("-Zstable-crate-hash")
             .arg(&format!("--remap-path-prefix={}=/src", base_dir.display()))
             .run();
 
@@ -77,7 +77,7 @@ fn main() {
         rustc()
             .input("lib.rs")
             .crate_type("rlib")
-            .arg("-Zseparate-spans")
+            .arg("-Zstable-crate-hash")
             .arg(&format!("--remap-path-prefix={}=/src", base_dir.join("subdir").display()))
             .out_dir(&base_dir)
             .run();


### PR DESCRIPTION
**Note**: This is not ready for review. I accidentally opened this pull request before it was ready.

Hello! I didn't mean to convert this to a PR (let alone a draft PR), but this branch implements "Relink, Don't Rebuild", which was approved in [this major change proposal](https://github.com/rust-lang/compiler-team/issues/790). The idea behind RDR is to treat changes to non-public items as _not_ a factor in considering whether dependent crates _also_ need to be rebuilt. The trick, of course, is defining what "non-public" items _are_. This change considers two classes:

- Spans, which I've split out into a separate `.spans` file. By storing spans separately from the main crate metadata, changes to span information (line numbers shifting, reformatting, etc.) no longer affect the crate hash. This approach was suggested by David Lattimore [in this Zulip post](https://rust-lang.zulipchat.com/#narrow/channel/233931-t-compiler.2Fmajor-changes/topic/Relink.2C.20don't.20rebuild.20compiler-team.23790/near/481018651).
- Items, where I've changed the crate hash to only incorporate items reachable from the public API. "Reachable" uses rustc's existing `EffectiveVisibilities` analysis, which includes `pub` items, items leaked through public signatures, and reexports. For function _bodies_ specifically, they're only included when they affect downstream compilation: generic functions (which get monomorphized) and `#[inline]` functions (which get inlined across crate boundaries). Trait implementations are always included since they affect trait resolution. Changes to truly private items, or even non-generic, non-inlinable function bodies, no longer invalidate dependent crates.

This is accomplished by changing how the Strict Version Hash (SVH) is computed. The SVH was [originally introduced](https://github.com/rust-lang/rust/commit/ec57db083ff10fc4da0a2f25df5acf1d4398e560)[^1] to identify a crate's "ABI/API/publicly reachable state," but at the time was implemented as a hash of the entire AST, which the original commit notes was "obviously incorrect." This implementation follows through on that original intent and [the design outlined in the project goal](https://rust-lang.github.io/rust-project-goals/2025h2/relink-dont-rebuild.html). Additionally, the hash is resilient to item reordering: since items are sorted by their `DefPathHash` prior hashing, moving items around in source doesn't change the SVH.

This feature is currently exposed as `-Zstable-crate-hash`, but it would probably make sense to split this into separate feature flags—one for span separation and one for the public-item-only hashing—to allow for more granular testing and rollout. I didn't do that before opening this as a draft pull request because, well, I accidentally published this pull request.

On my [work project](https://ersc.io/), this brought down incremental `cargo check` times from 4 seconds to:

- 1.8 seconds _without_ any Cargo scheduler changes.
- 0.81 seconds _with_ [Cargo scheduler changes](https://github.com/rust-lang/cargo/compare/master...davidbarsky:cargo:push-tvvsuxrzmskm?expand=1).

For rust-analyzer, whose compile times have been optimized to a _ridiculous_ degree, RDR reduced `cargo check` times (after changing a non-public item in `hir-ty`) from 3 seconds to 1.5 seconds.

AI Disclosure: I used Claude Code (Opus 4.5) and Codex (GPT-5.2-codex) to implement this.

[^1]: Thanks to @bjorn3 for digging that commit up!