### PR TITLE
[beta] backports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,7 +289,7 @@ jobs:
           fi
 
           # Get closest bors merge commit
-          PARENT_COMMIT=`git rev-list --author='bors <bors@rust-lang.org>' -n1 --first-parent HEAD^1`
+          PARENT_COMMIT=`git rev-list --author='bors@rust-lang.org' --author='122020455+rust-bors\[bot\]@users.noreply.github.com' -n1 --first-parent HEAD^1`
 
           ./build/citool/debug/citool postprocess-metrics \
               --job-name ${CI_JOB_NAME} \

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -29,7 +29,7 @@ jobs:
           sleep 60
 
           # Get closest bors merge commit
-          PARENT_COMMIT=`git rev-list --author='122020455+rust-bors\[bot\]@users.noreply.github.com' -n1 --first-parent HEAD^1`
+          PARENT_COMMIT=`git rev-list --author='bors@rust-lang.org' --author='122020455+rust-bors\[bot\]@users.noreply.github.com' -n1 --first-parent HEAD^1`
           echo "Parent: ${PARENT_COMMIT}"
 
           # Find PR for the current commit

--- a/compiler/rustc_mir_transform/src/simplify_comparison_integral.rs
+++ b/compiler/rustc_mir_transform/src/simplify_comparison_integral.rs
@@ -27,7 +27,7 @@ pub(super) struct SimplifyComparisonIntegral;
 
 impl<'tcx> crate::MirPass<'tcx> for SimplifyComparisonIntegral {
     fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.mir_opt_level() > 0
+        sess.mir_opt_level() > 0 && sess.opts.unstable_opts.unsound_mir_opts
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {

--- a/src/build_helper/src/git.rs
+++ b/src/build_helper/src/git.rs
@@ -152,7 +152,10 @@ pub fn has_changed_since(git_dir: &Path, base: &str, paths: &[&str]) -> bool {
     })
 }
 
-const LEGACY_BORS_EMAIL: &str = "bors@rust-lang.org";
+// Temporary e-mail used by new bors for merge commits for a few days, until it learned how to reuse
+// the original homu e-mail
+// FIXME: remove in Q2 2026
+const TEMPORARY_BORS_EMAIL: &str = "122020455+rust-bors[bot]@users.noreply.github.com";
 
 /// Escape characters from the git user e-mail, so that git commands do not interpret it as regex
 /// special characters.
@@ -193,10 +196,9 @@ fn get_latest_upstream_commit_that_modified_files(
         &escape_email_git_regex(git_config.git_merge_commit_email),
     ]);
 
-    // Also search for legacy bors account, before we accrue enough commits to
-    // have changes to all relevant file paths done by new bors.
-    if git_config.git_merge_commit_email != LEGACY_BORS_EMAIL {
-        git.args(["--author", LEGACY_BORS_EMAIL]);
+    // Also search for temporary bors account
+    if git_config.git_merge_commit_email != TEMPORARY_BORS_EMAIL {
+        git.args(["--author", &escape_email_git_regex(TEMPORARY_BORS_EMAIL)]);
     }
 
     if !target_paths.is_empty() {
@@ -248,10 +250,9 @@ pub fn get_closest_upstream_commit(
         base,
     ]);
 
-    // Also search for legacy bors account, before we accrue enough commits to
-    // have changes to all relevant file paths done by new bors.
-    if config.git_merge_commit_email != LEGACY_BORS_EMAIL {
-        git.args(["--author", LEGACY_BORS_EMAIL]);
+    // Also search for temporary bors account
+    if config.git_merge_commit_email != TEMPORARY_BORS_EMAIL {
+        git.args(["--author", &escape_email_git_regex(TEMPORARY_BORS_EMAIL)]);
     }
 
     let output = output_result(&mut git)?.trim().to_owned();

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -152,8 +152,8 @@ try:
   - <<: *job-dist-x86_64-linux
 
 # Jobs that only run when explicitly invoked in one of the following ways:
-# - comment `@bors2 try jobs=<job-name>`
-# - `try-job: <job-name>` in the PR description and comment `@bors try` or `@bors2 try`.
+# - comment `@bors try jobs=<job-name>`
+# - `try-job: <job-name>` in the PR description and comment `@bors try`.
 optional:
   # This job is used just to test optional jobs.
   # It will be replaced by tier 2 and tier 3 jobs in the future.

--- a/src/stage0
+++ b/src/stage0
@@ -1,7 +1,7 @@
 dist_server=https://static.rust-lang.org
 artifacts_server=https://ci-artifacts.rust-lang.org/rustc-builds
 artifacts_with_llvm_assertions_server=https://ci-artifacts.rust-lang.org/rustc-builds-alt
-git_merge_commit_email=122020455+rust-bors[bot]@users.noreply.github.com
+git_merge_commit_email=bors@rust-lang.org
 nightly_branch=main
 
 # The configuration above this comment is editable, and can be changed

--- a/tests/codegen-llvm/hint/likely.rs
+++ b/tests/codegen-llvm/hint/likely.rs
@@ -70,7 +70,7 @@ pub fn test4(x: u64) {
     }
 
     // CHECK-LABEL: @test4(
-    // CHECK: br i1 %0, label %bb3, label %bb2, !prof ![[NUM2:[0-9]+]]
+    // CHECK: br i1 %_2.not, label %bb3, label %bb2, !prof ![[NUM2:[0-9]+]]
     // CHECK: bb3:
     // CHECK: path_a
     // CHECK: bb2:

--- a/tests/codegen-llvm/hint/unlikely.rs
+++ b/tests/codegen-llvm/hint/unlikely.rs
@@ -70,7 +70,7 @@ pub fn test4(x: u64) {
     }
 
     // CHECK-LABEL: @test4(
-    // CHECK: br i1 %0, label %bb4, label %bb2, !prof ![[NUM2:[0-9]+]]
+    // CHECK: br i1 %_2.not, label %bb4, label %bb2, !prof ![[NUM2:[0-9]+]]
     // CHECK: bb4:
     // CHECK: path_a
     // CHECK: bb2:

--- a/tests/debuginfo/dummy_span.rs
+++ b/tests/debuginfo/dummy_span.rs
@@ -1,6 +1,6 @@
 //@ min-lldb-version: 310
 
-//@ compile-flags:-g
+//@ compile-flags:-g -Zunsound-mir-opts
 //@ ignore-backends: gcc
 
 // === GDB TESTS ===================================================================================

--- a/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.32bit.panic-abort.diff
@@ -29,10 +29,11 @@
                   debug precision => _8;
                   let _8: usize;
                   scope 5 (inlined Formatter::<'_>::precision) {
-                      let mut _22: u32;
+                      let mut _22: bool;
                       let mut _23: u32;
-                      let mut _24: usize;
-                      let mut _25: u16;
+                      let mut _24: u32;
+                      let mut _25: usize;
+                      let mut _26: u16;
                   }
               }
           }
@@ -71,10 +72,12 @@
           StorageLive(_6);
           StorageLive(_22);
           StorageLive(_23);
-          _23 = copy (((*_1).0: std::fmt::FormattingOptions).0: u32);
-          _22 = BitAnd(move _23, const core::fmt::flags::PRECISION_FLAG);
-          StorageDead(_23);
-          switchInt(move _22) -> [0: bb10, otherwise: bb11];
+          StorageLive(_24);
+          _24 = copy (((*_1).0: std::fmt::FormattingOptions).0: u32);
+          _23 = BitAnd(move _24, const core::fmt::flags::PRECISION_FLAG);
+          StorageDead(_24);
+          _22 = Eq(move _23, const 0_u32);
+          switchInt(move _22) -> [0: bb10, otherwise: bb9];
       }
   
       bb4: {
@@ -142,26 +145,27 @@
       }
   
       bb9: {
-          _7 = discriminant(_6);
-          switchInt(move _7) -> [1: bb4, 0: bb6, otherwise: bb12];
+          StorageDead(_23);
+          _6 = const Option::<usize>::None;
+          goto -> bb11;
       }
   
       bb10: {
-          StorageDead(_22);
-          _6 = const Option::<usize>::None;
-          goto -> bb9;
+          StorageDead(_23);
+          StorageLive(_25);
+          StorageLive(_26);
+          _26 = copy (((*_1).0: std::fmt::FormattingOptions).2: u16);
+          _25 = move _26 as usize (IntToInt);
+          StorageDead(_26);
+          _6 = Option::<usize>::Some(move _25);
+          StorageDead(_25);
+          goto -> bb11;
       }
   
       bb11: {
           StorageDead(_22);
-          StorageLive(_24);
-          StorageLive(_25);
-          _25 = copy (((*_1).0: std::fmt::FormattingOptions).2: u16);
-          _24 = move _25 as usize (IntToInt);
-          StorageDead(_25);
-          _6 = Option::<usize>::Some(move _24);
-          StorageDead(_24);
-          goto -> bb9;
+          _7 = discriminant(_6);
+          switchInt(move _7) -> [1: bb4, 0: bb6, otherwise: bb12];
       }
   
       bb12: {

--- a/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.32bit.panic-unwind.diff
@@ -29,10 +29,11 @@
                   debug precision => _8;
                   let _8: usize;
                   scope 5 (inlined Formatter::<'_>::precision) {
-                      let mut _22: u32;
+                      let mut _22: bool;
                       let mut _23: u32;
-                      let mut _24: usize;
-                      let mut _25: u16;
+                      let mut _24: u32;
+                      let mut _25: usize;
+                      let mut _26: u16;
                   }
               }
           }
@@ -71,10 +72,12 @@
           StorageLive(_6);
           StorageLive(_22);
           StorageLive(_23);
-          _23 = copy (((*_1).0: std::fmt::FormattingOptions).0: u32);
-          _22 = BitAnd(move _23, const core::fmt::flags::PRECISION_FLAG);
-          StorageDead(_23);
-          switchInt(move _22) -> [0: bb10, otherwise: bb11];
+          StorageLive(_24);
+          _24 = copy (((*_1).0: std::fmt::FormattingOptions).0: u32);
+          _23 = BitAnd(move _24, const core::fmt::flags::PRECISION_FLAG);
+          StorageDead(_24);
+          _22 = Eq(move _23, const 0_u32);
+          switchInt(move _22) -> [0: bb10, otherwise: bb9];
       }
   
       bb4: {
@@ -142,26 +145,27 @@
       }
   
       bb9: {
-          _7 = discriminant(_6);
-          switchInt(move _7) -> [1: bb4, 0: bb6, otherwise: bb12];
+          StorageDead(_23);
+          _6 = const Option::<usize>::None;
+          goto -> bb11;
       }
   
       bb10: {
-          StorageDead(_22);
-          _6 = const Option::<usize>::None;
-          goto -> bb9;
+          StorageDead(_23);
+          StorageLive(_25);
+          StorageLive(_26);
+          _26 = copy (((*_1).0: std::fmt::FormattingOptions).2: u16);
+          _25 = move _26 as usize (IntToInt);
+          StorageDead(_26);
+          _6 = Option::<usize>::Some(move _25);
+          StorageDead(_25);
+          goto -> bb11;
       }
   
       bb11: {
           StorageDead(_22);
-          StorageLive(_24);
-          StorageLive(_25);
-          _25 = copy (((*_1).0: std::fmt::FormattingOptions).2: u16);
-          _24 = move _25 as usize (IntToInt);
-          StorageDead(_25);
-          _6 = Option::<usize>::Some(move _24);
-          StorageDead(_24);
-          goto -> bb9;
+          _7 = discriminant(_6);
+          switchInt(move _7) -> [1: bb4, 0: bb6, otherwise: bb12];
       }
   
       bb12: {

--- a/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.64bit.panic-abort.diff
@@ -29,10 +29,11 @@
                   debug precision => _8;
                   let _8: usize;
                   scope 5 (inlined Formatter::<'_>::precision) {
-                      let mut _22: u32;
+                      let mut _22: bool;
                       let mut _23: u32;
-                      let mut _24: usize;
-                      let mut _25: u16;
+                      let mut _24: u32;
+                      let mut _25: usize;
+                      let mut _26: u16;
                   }
               }
           }
@@ -71,10 +72,12 @@
           StorageLive(_6);
           StorageLive(_22);
           StorageLive(_23);
-          _23 = copy (((*_1).0: std::fmt::FormattingOptions).0: u32);
-          _22 = BitAnd(move _23, const core::fmt::flags::PRECISION_FLAG);
-          StorageDead(_23);
-          switchInt(move _22) -> [0: bb10, otherwise: bb11];
+          StorageLive(_24);
+          _24 = copy (((*_1).0: std::fmt::FormattingOptions).0: u32);
+          _23 = BitAnd(move _24, const core::fmt::flags::PRECISION_FLAG);
+          StorageDead(_24);
+          _22 = Eq(move _23, const 0_u32);
+          switchInt(move _22) -> [0: bb10, otherwise: bb9];
       }
   
       bb4: {
@@ -142,26 +145,27 @@
       }
   
       bb9: {
-          _7 = discriminant(_6);
-          switchInt(move _7) -> [1: bb4, 0: bb6, otherwise: bb12];
+          StorageDead(_23);
+          _6 = const Option::<usize>::None;
+          goto -> bb11;
       }
   
       bb10: {
-          StorageDead(_22);
-          _6 = const Option::<usize>::None;
-          goto -> bb9;
+          StorageDead(_23);
+          StorageLive(_25);
+          StorageLive(_26);
+          _26 = copy (((*_1).0: std::fmt::FormattingOptions).2: u16);
+          _25 = move _26 as usize (IntToInt);
+          StorageDead(_26);
+          _6 = Option::<usize>::Some(move _25);
+          StorageDead(_25);
+          goto -> bb11;
       }
   
       bb11: {
           StorageDead(_22);
-          StorageLive(_24);
-          StorageLive(_25);
-          _25 = copy (((*_1).0: std::fmt::FormattingOptions).2: u16);
-          _24 = move _25 as usize (IntToInt);
-          StorageDead(_25);
-          _6 = Option::<usize>::Some(move _24);
-          StorageDead(_24);
-          goto -> bb9;
+          _7 = discriminant(_6);
+          switchInt(move _7) -> [1: bb4, 0: bb6, otherwise: bb12];
       }
   
       bb12: {

--- a/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.64bit.panic-unwind.diff
@@ -29,10 +29,11 @@
                   debug precision => _8;
                   let _8: usize;
                   scope 5 (inlined Formatter::<'_>::precision) {
-                      let mut _22: u32;
+                      let mut _22: bool;
                       let mut _23: u32;
-                      let mut _24: usize;
-                      let mut _25: u16;
+                      let mut _24: u32;
+                      let mut _25: usize;
+                      let mut _26: u16;
                   }
               }
           }
@@ -71,10 +72,12 @@
           StorageLive(_6);
           StorageLive(_22);
           StorageLive(_23);
-          _23 = copy (((*_1).0: std::fmt::FormattingOptions).0: u32);
-          _22 = BitAnd(move _23, const core::fmt::flags::PRECISION_FLAG);
-          StorageDead(_23);
-          switchInt(move _22) -> [0: bb10, otherwise: bb11];
+          StorageLive(_24);
+          _24 = copy (((*_1).0: std::fmt::FormattingOptions).0: u32);
+          _23 = BitAnd(move _24, const core::fmt::flags::PRECISION_FLAG);
+          StorageDead(_24);
+          _22 = Eq(move _23, const 0_u32);
+          switchInt(move _22) -> [0: bb10, otherwise: bb9];
       }
   
       bb4: {
@@ -142,26 +145,27 @@
       }
   
       bb9: {
-          _7 = discriminant(_6);
-          switchInt(move _7) -> [1: bb4, 0: bb6, otherwise: bb12];
+          StorageDead(_23);
+          _6 = const Option::<usize>::None;
+          goto -> bb11;
       }
   
       bb10: {
-          StorageDead(_22);
-          _6 = const Option::<usize>::None;
-          goto -> bb9;
+          StorageDead(_23);
+          StorageLive(_25);
+          StorageLive(_26);
+          _26 = copy (((*_1).0: std::fmt::FormattingOptions).2: u16);
+          _25 = move _26 as usize (IntToInt);
+          StorageDead(_26);
+          _6 = Option::<usize>::Some(move _25);
+          StorageDead(_25);
+          goto -> bb11;
       }
   
       bb11: {
           StorageDead(_22);
-          StorageLive(_24);
-          StorageLive(_25);
-          _25 = copy (((*_1).0: std::fmt::FormattingOptions).2: u16);
-          _24 = move _25 as usize (IntToInt);
-          StorageDead(_25);
-          _6 = Option::<usize>::Some(move _24);
-          StorageDead(_24);
-          goto -> bb9;
+          _7 = discriminant(_6);
+          switchInt(move _7) -> [1: bb4, 0: bb6, otherwise: bb12];
       }
   
       bb12: {

--- a/tests/mir-opt/issue_76432.rs
+++ b/tests/mir-opt/issue_76432.rs
@@ -1,6 +1,7 @@
 // skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // Check that we do not insert StorageDead at each target if StorageDead was never seen
+//@ compile-flags: -Zunsound-mir-opts
 
 use std::fmt::Debug;
 

--- a/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.32bit.panic-abort.mir
+++ b/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.32bit.panic-abort.mir
@@ -3,7 +3,8 @@
 fn num_to_digit(_1: char) -> u32 {
     debug num => _1;
     let mut _0: u32;
-    let mut _4: std::option::Option<u32>;
+    let mut _4: bool;
+    let mut _5: std::option::Option<u32>;
     scope 1 (inlined char::methods::<impl char>::is_digit) {
         let _2: std::option::Option<u32>;
         scope 2 (inlined Option::<u32>::is_some) {
@@ -13,13 +14,14 @@ fn num_to_digit(_1: char) -> u32 {
         }
     }
     scope 4 (inlined #[track_caller] Option::<u32>::unwrap) {
-        let mut _5: isize;
-        let mut _6: !;
+        let mut _6: isize;
+        let mut _7: !;
         scope 5 {
         }
     }
 
     bb0: {
+        StorageLive(_4);
         StorageLive(_2);
         _2 = char::methods::<impl char>::to_digit(copy _1, const 8_u32) -> [return: bb1, unwind unreachable];
     }
@@ -27,44 +29,45 @@ fn num_to_digit(_1: char) -> u32 {
     bb1: {
         StorageLive(_3);
         _3 = discriminant(_2);
+        _4 = Eq(copy _3, const 1_isize);
+        StorageDead(_3);
         StorageDead(_2);
-        switchInt(move _3) -> [1: bb2, otherwise: bb7];
+        switchInt(move _4) -> [0: bb2, otherwise: bb3];
     }
 
     bb2: {
-        StorageDead(_3);
-        StorageLive(_4);
-        _4 = char::methods::<impl char>::to_digit(move _1, const 8_u32) -> [return: bb3, unwind unreachable];
+        _0 = const 0_u32;
+        goto -> bb7;
     }
 
     bb3: {
         StorageLive(_5);
-        _5 = discriminant(_4);
-        switchInt(move _5) -> [0: bb4, 1: bb5, otherwise: bb6];
+        _5 = char::methods::<impl char>::to_digit(move _1, const 8_u32) -> [return: bb4, unwind unreachable];
     }
 
     bb4: {
-        _6 = option::unwrap_failed() -> unwind unreachable;
+        StorageLive(_6);
+        _6 = discriminant(_5);
+        switchInt(move _6) -> [0: bb5, 1: bb6, otherwise: bb8];
     }
 
     bb5: {
-        _0 = move ((_4 as Some).0: u32);
-        StorageDead(_5);
-        StorageDead(_4);
-        goto -> bb8;
+        _7 = option::unwrap_failed() -> unwind unreachable;
     }
 
     bb6: {
-        unreachable;
+        _0 = move ((_5 as Some).0: u32);
+        StorageDead(_6);
+        StorageDead(_5);
+        goto -> bb7;
     }
 
     bb7: {
-        StorageDead(_3);
-        _0 = const 0_u32;
-        goto -> bb8;
+        StorageDead(_4);
+        return;
     }
 
     bb8: {
-        return;
+        unreachable;
     }
 }

--- a/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.32bit.panic-unwind.mir
+++ b/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.32bit.panic-unwind.mir
@@ -3,7 +3,8 @@
 fn num_to_digit(_1: char) -> u32 {
     debug num => _1;
     let mut _0: u32;
-    let mut _4: std::option::Option<u32>;
+    let mut _4: bool;
+    let mut _5: std::option::Option<u32>;
     scope 1 (inlined char::methods::<impl char>::is_digit) {
         let _2: std::option::Option<u32>;
         scope 2 (inlined Option::<u32>::is_some) {
@@ -13,13 +14,14 @@ fn num_to_digit(_1: char) -> u32 {
         }
     }
     scope 4 (inlined #[track_caller] Option::<u32>::unwrap) {
-        let mut _5: isize;
-        let mut _6: !;
+        let mut _6: isize;
+        let mut _7: !;
         scope 5 {
         }
     }
 
     bb0: {
+        StorageLive(_4);
         StorageLive(_2);
         _2 = char::methods::<impl char>::to_digit(copy _1, const 8_u32) -> [return: bb1, unwind continue];
     }
@@ -27,44 +29,45 @@ fn num_to_digit(_1: char) -> u32 {
     bb1: {
         StorageLive(_3);
         _3 = discriminant(_2);
+        _4 = Eq(copy _3, const 1_isize);
+        StorageDead(_3);
         StorageDead(_2);
-        switchInt(move _3) -> [1: bb2, otherwise: bb7];
+        switchInt(move _4) -> [0: bb2, otherwise: bb3];
     }
 
     bb2: {
-        StorageDead(_3);
-        StorageLive(_4);
-        _4 = char::methods::<impl char>::to_digit(move _1, const 8_u32) -> [return: bb3, unwind continue];
+        _0 = const 0_u32;
+        goto -> bb7;
     }
 
     bb3: {
         StorageLive(_5);
-        _5 = discriminant(_4);
-        switchInt(move _5) -> [0: bb4, 1: bb5, otherwise: bb6];
+        _5 = char::methods::<impl char>::to_digit(move _1, const 8_u32) -> [return: bb4, unwind continue];
     }
 
     bb4: {
-        _6 = option::unwrap_failed() -> unwind continue;
+        StorageLive(_6);
+        _6 = discriminant(_5);
+        switchInt(move _6) -> [0: bb5, 1: bb6, otherwise: bb8];
     }
 
     bb5: {
-        _0 = move ((_4 as Some).0: u32);
-        StorageDead(_5);
-        StorageDead(_4);
-        goto -> bb8;
+        _7 = option::unwrap_failed() -> unwind continue;
     }
 
     bb6: {
-        unreachable;
+        _0 = move ((_5 as Some).0: u32);
+        StorageDead(_6);
+        StorageDead(_5);
+        goto -> bb7;
     }
 
     bb7: {
-        StorageDead(_3);
-        _0 = const 0_u32;
-        goto -> bb8;
+        StorageDead(_4);
+        return;
     }
 
     bb8: {
-        return;
+        unreachable;
     }
 }

--- a/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.64bit.panic-abort.mir
+++ b/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.64bit.panic-abort.mir
@@ -3,7 +3,8 @@
 fn num_to_digit(_1: char) -> u32 {
     debug num => _1;
     let mut _0: u32;
-    let mut _4: std::option::Option<u32>;
+    let mut _4: bool;
+    let mut _5: std::option::Option<u32>;
     scope 1 (inlined char::methods::<impl char>::is_digit) {
         let _2: std::option::Option<u32>;
         scope 2 (inlined Option::<u32>::is_some) {
@@ -13,13 +14,14 @@ fn num_to_digit(_1: char) -> u32 {
         }
     }
     scope 4 (inlined #[track_caller] Option::<u32>::unwrap) {
-        let mut _5: isize;
-        let mut _6: !;
+        let mut _6: isize;
+        let mut _7: !;
         scope 5 {
         }
     }
 
     bb0: {
+        StorageLive(_4);
         StorageLive(_2);
         _2 = char::methods::<impl char>::to_digit(copy _1, const 8_u32) -> [return: bb1, unwind unreachable];
     }
@@ -27,44 +29,45 @@ fn num_to_digit(_1: char) -> u32 {
     bb1: {
         StorageLive(_3);
         _3 = discriminant(_2);
+        _4 = Eq(copy _3, const 1_isize);
+        StorageDead(_3);
         StorageDead(_2);
-        switchInt(move _3) -> [1: bb2, otherwise: bb7];
+        switchInt(move _4) -> [0: bb2, otherwise: bb3];
     }
 
     bb2: {
-        StorageDead(_3);
-        StorageLive(_4);
-        _4 = char::methods::<impl char>::to_digit(move _1, const 8_u32) -> [return: bb3, unwind unreachable];
+        _0 = const 0_u32;
+        goto -> bb7;
     }
 
     bb3: {
         StorageLive(_5);
-        _5 = discriminant(_4);
-        switchInt(move _5) -> [0: bb4, 1: bb5, otherwise: bb6];
+        _5 = char::methods::<impl char>::to_digit(move _1, const 8_u32) -> [return: bb4, unwind unreachable];
     }
 
     bb4: {
-        _6 = option::unwrap_failed() -> unwind unreachable;
+        StorageLive(_6);
+        _6 = discriminant(_5);
+        switchInt(move _6) -> [0: bb5, 1: bb6, otherwise: bb8];
     }
 
     bb5: {
-        _0 = move ((_4 as Some).0: u32);
-        StorageDead(_5);
-        StorageDead(_4);
-        goto -> bb8;
+        _7 = option::unwrap_failed() -> unwind unreachable;
     }
 
     bb6: {
-        unreachable;
+        _0 = move ((_5 as Some).0: u32);
+        StorageDead(_6);
+        StorageDead(_5);
+        goto -> bb7;
     }
 
     bb7: {
-        StorageDead(_3);
-        _0 = const 0_u32;
-        goto -> bb8;
+        StorageDead(_4);
+        return;
     }
 
     bb8: {
-        return;
+        unreachable;
     }
 }

--- a/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.64bit.panic-unwind.mir
+++ b/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.64bit.panic-unwind.mir
@@ -3,7 +3,8 @@
 fn num_to_digit(_1: char) -> u32 {
     debug num => _1;
     let mut _0: u32;
-    let mut _4: std::option::Option<u32>;
+    let mut _4: bool;
+    let mut _5: std::option::Option<u32>;
     scope 1 (inlined char::methods::<impl char>::is_digit) {
         let _2: std::option::Option<u32>;
         scope 2 (inlined Option::<u32>::is_some) {
@@ -13,13 +14,14 @@ fn num_to_digit(_1: char) -> u32 {
         }
     }
     scope 4 (inlined #[track_caller] Option::<u32>::unwrap) {
-        let mut _5: isize;
-        let mut _6: !;
+        let mut _6: isize;
+        let mut _7: !;
         scope 5 {
         }
     }
 
     bb0: {
+        StorageLive(_4);
         StorageLive(_2);
         _2 = char::methods::<impl char>::to_digit(copy _1, const 8_u32) -> [return: bb1, unwind continue];
     }
@@ -27,44 +29,45 @@ fn num_to_digit(_1: char) -> u32 {
     bb1: {
         StorageLive(_3);
         _3 = discriminant(_2);
+        _4 = Eq(copy _3, const 1_isize);
+        StorageDead(_3);
         StorageDead(_2);
-        switchInt(move _3) -> [1: bb2, otherwise: bb7];
+        switchInt(move _4) -> [0: bb2, otherwise: bb3];
     }
 
     bb2: {
-        StorageDead(_3);
-        StorageLive(_4);
-        _4 = char::methods::<impl char>::to_digit(move _1, const 8_u32) -> [return: bb3, unwind continue];
+        _0 = const 0_u32;
+        goto -> bb7;
     }
 
     bb3: {
         StorageLive(_5);
-        _5 = discriminant(_4);
-        switchInt(move _5) -> [0: bb4, 1: bb5, otherwise: bb6];
+        _5 = char::methods::<impl char>::to_digit(move _1, const 8_u32) -> [return: bb4, unwind continue];
     }
 
     bb4: {
-        _6 = option::unwrap_failed() -> unwind continue;
+        StorageLive(_6);
+        _6 = discriminant(_5);
+        switchInt(move _6) -> [0: bb5, 1: bb6, otherwise: bb8];
     }
 
     bb5: {
-        _0 = move ((_4 as Some).0: u32);
-        StorageDead(_5);
-        StorageDead(_4);
-        goto -> bb8;
+        _7 = option::unwrap_failed() -> unwind continue;
     }
 
     bb6: {
-        unreachable;
+        _0 = move ((_5 as Some).0: u32);
+        StorageDead(_6);
+        StorageDead(_5);
+        goto -> bb7;
     }
 
     bb7: {
-        StorageDead(_3);
-        _0 = const 0_u32;
-        goto -> bb8;
+        StorageDead(_4);
+        return;
     }
 
     bb8: {
-        return;
+        unreachable;
     }
 }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-abort.mir
@@ -8,7 +8,8 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
             let _2: std::ptr::NonNull<[T]>;
             let mut _3: *mut [T];
             let mut _4: *const [T];
-            let _11: ();
+            let mut _9: bool;
+            let _12: ();
             scope 3 {
                 let _8: std::ptr::alignment::AlignmentEnum;
                 scope 4 {
@@ -25,13 +26,13 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                         }
                     }
                     scope 18 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                        let mut _9: *mut u8;
+                        let mut _10: *mut u8;
                         scope 19 (inlined Layout::size) {
                         }
                         scope 20 (inlined NonNull::<u8>::as_ptr) {
                         }
                         scope 21 (inlined std::alloc::dealloc) {
-                            let mut _10: usize;
+                            let mut _11: usize;
                             scope 22 (inlined Layout::size) {
                             }
                             scope 23 (inlined Layout::align) {
@@ -80,20 +81,21 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
         StorageDead(_7);
         StorageDead(_6);
         StorageDead(_4);
-        switchInt(copy _5) -> [0: bb4, otherwise: bb2];
+        _9 = Ne(copy _5, const 0_usize);
+        switchInt(copy _9) -> [0: bb4, otherwise: bb2];
     }
 
     bb2: {
-        StorageLive(_9);
-        _9 = copy _3 as *mut u8 (PtrToPtr);
         StorageLive(_10);
-        _10 = discriminant(_8);
-        _11 = alloc::alloc::__rust_dealloc(move _9, move _5, move _10) -> [return: bb3, unwind unreachable];
+        _10 = copy _3 as *mut u8 (PtrToPtr);
+        StorageLive(_11);
+        _11 = discriminant(_8);
+        _12 = alloc::alloc::__rust_dealloc(move _10, move _5, move _11) -> [return: bb3, unwind unreachable];
     }
 
     bb3: {
+        StorageDead(_11);
         StorageDead(_10);
-        StorageDead(_9);
         goto -> bb4;
     }
 

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-unwind.mir
@@ -8,7 +8,8 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
             let _2: std::ptr::NonNull<[T]>;
             let mut _3: *mut [T];
             let mut _4: *const [T];
-            let _11: ();
+            let mut _9: bool;
+            let _12: ();
             scope 3 {
                 let _8: std::ptr::alignment::AlignmentEnum;
                 scope 4 {
@@ -25,13 +26,13 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                         }
                     }
                     scope 18 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                        let mut _9: *mut u8;
+                        let mut _10: *mut u8;
                         scope 19 (inlined Layout::size) {
                         }
                         scope 20 (inlined NonNull::<u8>::as_ptr) {
                         }
                         scope 21 (inlined std::alloc::dealloc) {
-                            let mut _10: usize;
+                            let mut _11: usize;
                             scope 22 (inlined Layout::size) {
                             }
                             scope 23 (inlined Layout::align) {
@@ -80,20 +81,21 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
         StorageDead(_7);
         StorageDead(_6);
         StorageDead(_4);
-        switchInt(copy _5) -> [0: bb4, otherwise: bb2];
+        _9 = Ne(copy _5, const 0_usize);
+        switchInt(copy _9) -> [0: bb4, otherwise: bb2];
     }
 
     bb2: {
-        StorageLive(_9);
-        _9 = copy _3 as *mut u8 (PtrToPtr);
         StorageLive(_10);
-        _10 = discriminant(_8);
-        _11 = alloc::alloc::__rust_dealloc(move _9, move _5, move _10) -> [return: bb3, unwind unreachable];
+        _10 = copy _3 as *mut u8 (PtrToPtr);
+        StorageLive(_11);
+        _11 = discriminant(_8);
+        _12 = alloc::alloc::__rust_dealloc(move _10, move _5, move _11) -> [return: bb3, unwind unreachable];
     }
 
     bb3: {
+        StorageDead(_11);
         StorageDead(_10);
-        StorageDead(_9);
         goto -> bb4;
     }
 

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
@@ -8,7 +8,8 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
             let _2: std::ptr::NonNull<[T]>;
             let mut _3: *mut [T];
             let mut _4: *const [T];
-            let _11: ();
+            let mut _9: bool;
+            let _12: ();
             scope 3 {
                 let _8: std::ptr::alignment::AlignmentEnum;
                 scope 4 {
@@ -25,13 +26,13 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                         }
                     }
                     scope 18 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                        let mut _9: *mut u8;
+                        let mut _10: *mut u8;
                         scope 19 (inlined Layout::size) {
                         }
                         scope 20 (inlined NonNull::<u8>::as_ptr) {
                         }
                         scope 21 (inlined std::alloc::dealloc) {
-                            let mut _10: usize;
+                            let mut _11: usize;
                             scope 22 (inlined Layout::size) {
                             }
                             scope 23 (inlined Layout::align) {
@@ -80,20 +81,21 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
         StorageDead(_7);
         StorageDead(_6);
         StorageDead(_4);
-        switchInt(copy _5) -> [0: bb4, otherwise: bb2];
+        _9 = Ne(copy _5, const 0_usize);
+        switchInt(copy _9) -> [0: bb4, otherwise: bb2];
     }
 
     bb2: {
-        StorageLive(_9);
-        _9 = copy _3 as *mut u8 (PtrToPtr);
         StorageLive(_10);
-        _10 = discriminant(_8);
-        _11 = alloc::alloc::__rust_dealloc(move _9, move _5, move _10) -> [return: bb3, unwind unreachable];
+        _10 = copy _3 as *mut u8 (PtrToPtr);
+        StorageLive(_11);
+        _11 = discriminant(_8);
+        _12 = alloc::alloc::__rust_dealloc(move _10, move _5, move _11) -> [return: bb3, unwind unreachable];
     }
 
     bb3: {
+        StorageDead(_11);
         StorageDead(_10);
-        StorageDead(_9);
         goto -> bb4;
     }
 

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-unwind.mir
@@ -8,7 +8,8 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
             let _2: std::ptr::NonNull<[T]>;
             let mut _3: *mut [T];
             let mut _4: *const [T];
-            let _11: ();
+            let mut _9: bool;
+            let _12: ();
             scope 3 {
                 let _8: std::ptr::alignment::AlignmentEnum;
                 scope 4 {
@@ -25,13 +26,13 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                         }
                     }
                     scope 18 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                        let mut _9: *mut u8;
+                        let mut _10: *mut u8;
                         scope 19 (inlined Layout::size) {
                         }
                         scope 20 (inlined NonNull::<u8>::as_ptr) {
                         }
                         scope 21 (inlined std::alloc::dealloc) {
-                            let mut _10: usize;
+                            let mut _11: usize;
                             scope 22 (inlined Layout::size) {
                             }
                             scope 23 (inlined Layout::align) {
@@ -80,20 +81,21 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
         StorageDead(_7);
         StorageDead(_6);
         StorageDead(_4);
-        switchInt(copy _5) -> [0: bb4, otherwise: bb2];
+        _9 = Ne(copy _5, const 0_usize);
+        switchInt(copy _9) -> [0: bb4, otherwise: bb2];
     }
 
     bb2: {
-        StorageLive(_9);
-        _9 = copy _3 as *mut u8 (PtrToPtr);
         StorageLive(_10);
-        _10 = discriminant(_8);
-        _11 = alloc::alloc::__rust_dealloc(move _9, move _5, move _10) -> [return: bb3, unwind unreachable];
+        _10 = copy _3 as *mut u8 (PtrToPtr);
+        StorageLive(_11);
+        _11 = discriminant(_8);
+        _12 = alloc::alloc::__rust_dealloc(move _10, move _5, move _11) -> [return: bb3, unwind unreachable];
     }
 
     bb3: {
+        StorageDead(_11);
         StorageDead(_10);
-        StorageDead(_9);
         goto -> bb4;
     }
 

--- a/tests/mir-opt/pre-codegen/loops.vec_move.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.vec_move.PreCodegen.after.mir
@@ -3,316 +3,72 @@
 fn vec_move(_1: Vec<impl Sized>) -> () {
     debug v => _1;
     let mut _0: ();
-    let mut _21: std::vec::IntoIter<impl Sized>;
-    let mut _22: std::vec::IntoIter<impl Sized>;
-    let mut _23: &mut std::vec::IntoIter<impl Sized>;
-    let mut _24: std::option::Option<impl Sized>;
-    let mut _25: isize;
-    let _27: ();
+    let mut _2: std::vec::IntoIter<impl Sized>;
+    let mut _3: std::vec::IntoIter<impl Sized>;
+    let mut _4: &mut std::vec::IntoIter<impl Sized>;
+    let mut _5: std::option::Option<impl Sized>;
+    let mut _6: isize;
+    let _8: ();
     scope 1 {
-        debug iter => _22;
-        let _26: impl Sized;
+        debug iter => _3;
+        let _7: impl Sized;
         scope 2 {
-            debug x => _26;
-        }
-    }
-    scope 3 (inlined <Vec<impl Sized> as IntoIterator>::into_iter) {
-        debug self => _1;
-        let _2: std::mem::ManuallyDrop<std::vec::Vec<impl Sized>>;
-        let mut _3: *const std::alloc::Global;
-        let mut _8: usize;
-        let mut _10: *mut impl Sized;
-        let mut _11: *const impl Sized;
-        let mut _12: usize;
-        let _28: &std::vec::Vec<impl Sized>;
-        let mut _29: &std::mem::ManuallyDrop<std::vec::Vec<impl Sized>>;
-        let mut _30: &alloc::raw_vec::RawVec<impl Sized>;
-        let mut _31: &std::mem::ManuallyDrop<std::vec::Vec<impl Sized>>;
-        let _32: &std::vec::Vec<impl Sized>;
-        let mut _33: &std::mem::ManuallyDrop<std::vec::Vec<impl Sized>>;
-        let _34: &std::vec::Vec<impl Sized>;
-        let mut _35: &std::mem::ManuallyDrop<std::vec::Vec<impl Sized>>;
-        let mut _36: &alloc::raw_vec::RawVec<impl Sized>;
-        let mut _37: &std::mem::ManuallyDrop<std::vec::Vec<impl Sized>>;
-        scope 4 {
-            debug me => _2;
-            scope 5 {
-                debug alloc => const ManuallyDrop::<std::alloc::Global> {{ value: std::alloc::Global }};
-                let _6: std::ptr::NonNull<impl Sized>;
-                scope 6 {
-                    debug buf => _6;
-                    let _7: *mut impl Sized;
-                    scope 7 {
-                        debug begin => _7;
-                        scope 8 {
-                            debug end => _11;
-                            let _19: usize;
-                            scope 9 {
-                                debug cap => _19;
-                            }
-                            scope 39 (inlined <ManuallyDrop<Vec<impl Sized>> as Deref>::deref) {
-                                debug self => _37;
-                            }
-                            scope 40 (inlined alloc::raw_vec::RawVec::<impl Sized>::capacity) {
-                                debug self => _36;
-                                let mut _38: &alloc::raw_vec::RawVecInner;
-                                scope 41 (inlined std::mem::size_of::<impl Sized>) {
-                                }
-                                scope 42 (inlined alloc::raw_vec::RawVecInner::capacity) {
-                                    debug self => _38;
-                                    debug elem_size => const <impl Sized as std::mem::SizedTypeProperties>::SIZE;
-                                    let mut _20: core::num::niche_types::UsizeNoHighBit;
-                                    scope 43 (inlined core::num::niche_types::UsizeNoHighBit::as_inner) {
-                                        debug self => _20;
-                                    }
-                                }
-                            }
-                        }
-                        scope 25 (inlined <ManuallyDrop<Vec<impl Sized>> as Deref>::deref) {
-                            debug self => _33;
-                        }
-                        scope 26 (inlined Vec::<impl Sized>::len) {
-                            debug self => _32;
-                            let mut _13: bool;
-                            scope 27 {
-                            }
-                        }
-                        scope 28 (inlined std::ptr::mut_ptr::<impl *mut impl Sized>::wrapping_byte_add) {
-                            debug self => _7;
-                            debug count => _12;
-                            let mut _14: *mut u8;
-                            let mut _18: *mut u8;
-                            scope 29 (inlined std::ptr::mut_ptr::<impl *mut impl Sized>::cast::<u8>) {
-                                debug self => _7;
-                            }
-                            scope 30 (inlined std::ptr::mut_ptr::<impl *mut u8>::wrapping_add) {
-                                debug self => _14;
-                                debug count => _12;
-                                let mut _15: isize;
-                                scope 31 (inlined std::ptr::mut_ptr::<impl *mut u8>::wrapping_offset) {
-                                    debug self => _14;
-                                    debug count => _15;
-                                    let mut _16: *const u8;
-                                    let mut _17: *const u8;
-                                }
-                            }
-                            scope 32 (inlined std::ptr::mut_ptr::<impl *mut u8>::with_metadata_of::<impl Sized>) {
-                                debug self => _18;
-                                debug meta => _5;
-                                scope 33 (inlined std::ptr::metadata::<impl Sized>) {
-                                    debug ptr => _5;
-                                }
-                                scope 34 (inlined std::ptr::from_raw_parts_mut::<impl Sized, ()>) {
-                                }
-                            }
-                        }
-                        scope 35 (inlined <ManuallyDrop<Vec<impl Sized>> as Deref>::deref) {
-                            debug self => _35;
-                        }
-                        scope 36 (inlined Vec::<impl Sized>::len) {
-                            debug self => _34;
-                            let mut _9: bool;
-                            scope 37 {
-                            }
-                        }
-                        scope 38 (inlined #[track_caller] std::ptr::mut_ptr::<impl *mut impl Sized>::add) {
-                            debug self => _7;
-                            debug count => _8;
-                        }
-                    }
-                    scope 24 (inlined NonNull::<impl Sized>::as_ptr) {
-                        debug self => _6;
-                    }
-                }
-                scope 17 (inlined <ManuallyDrop<Vec<impl Sized>> as Deref>::deref) {
-                    debug self => _31;
-                }
-                scope 18 (inlined alloc::raw_vec::RawVec::<impl Sized>::non_null) {
-                    debug self => _30;
-                    scope 19 (inlined alloc::raw_vec::RawVecInner::non_null::<impl Sized>) {
-                        let mut _4: std::ptr::NonNull<u8>;
-                        scope 20 (inlined Unique::<u8>::cast::<impl Sized>) {
-                            scope 21 (inlined NonNull::<u8>::cast::<impl Sized>) {
-                                let mut _5: *const impl Sized;
-                                scope 22 (inlined NonNull::<u8>::as_ptr) {
-                                }
-                            }
-                        }
-                        scope 23 (inlined Unique::<impl Sized>::as_non_null_ptr) {
-                        }
-                    }
-                }
-            }
-            scope 11 (inlined <ManuallyDrop<Vec<impl Sized>> as Deref>::deref) {
-                debug self => _29;
-            }
-            scope 12 (inlined Vec::<impl Sized>::allocator) {
-                debug self => _28;
-                scope 13 (inlined alloc::raw_vec::RawVec::<impl Sized>::allocator) {
-                    scope 14 (inlined alloc::raw_vec::RawVecInner::allocator) {
-                    }
-                }
-            }
-            scope 15 (inlined #[track_caller] std::ptr::read::<std::alloc::Global>) {
-                debug src => _3;
-            }
-            scope 16 (inlined ManuallyDrop::<std::alloc::Global>::new) {
-                debug value => const std::alloc::Global;
-            }
-        }
-        scope 10 (inlined ManuallyDrop::<Vec<impl Sized>>::new) {
-            debug value => _1;
+            debug x => _7;
         }
     }
 
     bb0: {
-        StorageLive(_21);
-        StorageLive(_6);
-        StorageLive(_7);
-        StorageLive(_11);
-        StorageLive(_19);
-        StorageLive(_5);
-        StorageLive(_4);
-        StorageLive(_17);
         StorageLive(_2);
-        _2 = ManuallyDrop::<Vec<impl Sized>> { value: copy _1 };
-        StorageLive(_3);
-        // DBG: _29 = &_2;
-        // DBG: _28 = &(_2.0: std::vec::Vec<impl Sized>);
-        _3 = &raw const ((((_2.0: std::vec::Vec<impl Sized>).0: alloc::raw_vec::RawVec<impl Sized>).0: alloc::raw_vec::RawVecInner).2: std::alloc::Global);
-        StorageDead(_3);
-        // DBG: _31 = &_2;
-        // DBG: _30 = &((_2.0: std::vec::Vec<impl Sized>).0: alloc::raw_vec::RawVec<impl Sized>);
-        _4 = copy (((((_2.0: std::vec::Vec<impl Sized>).0: alloc::raw_vec::RawVec<impl Sized>).0: alloc::raw_vec::RawVecInner).0: std::ptr::Unique<u8>).0: std::ptr::NonNull<u8>);
-        _5 = copy _4 as *const impl Sized (Transmute);
-        _6 = NonNull::<impl Sized> { pointer: copy _5 };
-        _7 = copy _4 as *mut impl Sized (Transmute);
-        switchInt(const <impl Sized as std::mem::SizedTypeProperties>::IS_ZST) -> [0: bb1, otherwise: bb2];
+        _2 = <Vec<impl Sized> as IntoIterator>::into_iter(move _1) -> [return: bb1, unwind continue];
     }
 
     bb1: {
-        StorageLive(_10);
-        StorageLive(_8);
-        // DBG: _35 = &_2;
-        // DBG: _34 = &(_2.0: std::vec::Vec<impl Sized>);
-        _8 = copy ((_2.0: std::vec::Vec<impl Sized>).1: usize);
-        StorageLive(_9);
-        _9 = Le(copy _8, const <impl Sized as std::mem::SizedTypeProperties>::MAX_SLICE_LEN);
-        assume(move _9);
-        StorageDead(_9);
-        _10 = Offset(copy _7, copy _8);
-        _11 = copy _10 as *const impl Sized (PtrToPtr);
-        StorageDead(_8);
-        StorageDead(_10);
-        goto -> bb4;
+        StorageLive(_3);
+        _3 = move _2;
+        goto -> bb2;
     }
 
     bb2: {
-        StorageLive(_12);
-        // DBG: _33 = &_2;
-        // DBG: _32 = &(_2.0: std::vec::Vec<impl Sized>);
-        _12 = copy ((_2.0: std::vec::Vec<impl Sized>).1: usize);
-        StorageLive(_13);
-        _13 = Le(copy _12, const <impl Sized as std::mem::SizedTypeProperties>::MAX_SLICE_LEN);
-        assume(move _13);
-        StorageDead(_13);
-        StorageLive(_18);
-        StorageLive(_14);
-        _14 = copy _4 as *mut u8 (Transmute);
-        StorageLive(_15);
-        _15 = copy _12 as isize (IntToInt);
-        StorageLive(_16);
-        _16 = copy _4 as *const u8 (Transmute);
-        _17 = arith_offset::<u8>(move _16, move _15) -> [return: bb3, unwind unreachable];
+        StorageLive(_5);
+        _4 = &mut _3;
+        _5 = <std::vec::IntoIter<impl Sized> as Iterator>::next(move _4) -> [return: bb3, unwind: bb9];
     }
 
     bb3: {
-        StorageDead(_16);
-        _18 = copy _17 as *mut u8 (PtrToPtr);
-        StorageDead(_15);
-        StorageDead(_14);
-        StorageDead(_18);
-        StorageDead(_12);
-        _11 = copy _17 as *const impl Sized (PtrToPtr);
-        goto -> bb4;
+        _6 = discriminant(_5);
+        switchInt(move _6) -> [0: bb4, 1: bb6, otherwise: bb8];
     }
 
     bb4: {
-        // DBG: _37 = &_2;
-        // DBG: _36 = &((_2.0: std::vec::Vec<impl Sized>).0: alloc::raw_vec::RawVec<impl Sized>);
-        // DBG: _38 = &(((_2.0: std::vec::Vec<impl Sized>).0: alloc::raw_vec::RawVec<impl Sized>).0: alloc::raw_vec::RawVecInner);
-        switchInt(const <impl Sized as std::mem::SizedTypeProperties>::SIZE) -> [0: bb5, otherwise: bb6];
+        StorageDead(_5);
+        drop(_3) -> [return: bb5, unwind continue];
     }
 
     bb5: {
-        _19 = const usize::MAX;
-        goto -> bb7;
-    }
-
-    bb6: {
-        StorageLive(_20);
-        _20 = copy ((((_2.0: std::vec::Vec<impl Sized>).0: alloc::raw_vec::RawVec<impl Sized>).0: alloc::raw_vec::RawVecInner).1: core::num::niche_types::UsizeNoHighBit);
-        _19 = copy _20 as usize (Transmute);
-        StorageDead(_20);
-        goto -> bb7;
-    }
-
-    bb7: {
-        _21 = std::vec::IntoIter::<impl Sized> { buf: copy _6, phantom: const ZeroSized: PhantomData<impl Sized>, cap: move _19, alloc: const ManuallyDrop::<std::alloc::Global> {{ value: std::alloc::Global }}, ptr: copy _6, end: copy _11 };
+        StorageDead(_3);
         StorageDead(_2);
-        StorageDead(_17);
-        StorageDead(_4);
-        StorageDead(_5);
-        StorageDead(_19);
-        StorageDead(_11);
-        StorageDead(_7);
-        StorageDead(_6);
-        StorageLive(_22);
-        _22 = move _21;
-        goto -> bb8;
-    }
-
-    bb8: {
-        StorageLive(_24);
-        _23 = &mut _22;
-        _24 = <std::vec::IntoIter<impl Sized> as Iterator>::next(move _23) -> [return: bb9, unwind: bb15];
-    }
-
-    bb9: {
-        _25 = discriminant(_24);
-        switchInt(move _25) -> [0: bb10, 1: bb12, otherwise: bb14];
-    }
-
-    bb10: {
-        StorageDead(_24);
-        drop(_22) -> [return: bb11, unwind continue];
-    }
-
-    bb11: {
-        StorageDead(_22);
-        StorageDead(_21);
         return;
     }
 
-    bb12: {
-        _26 = move ((_24 as Some).0: impl Sized);
-        _27 = opaque::<impl Sized>(move _26) -> [return: bb13, unwind: bb15];
+    bb6: {
+        _7 = move ((_5 as Some).0: impl Sized);
+        _8 = opaque::<impl Sized>(move _7) -> [return: bb7, unwind: bb9];
     }
 
-    bb13: {
-        StorageDead(_24);
-        goto -> bb8;
+    bb7: {
+        StorageDead(_5);
+        goto -> bb2;
     }
 
-    bb14: {
+    bb8: {
         unreachable;
     }
 
-    bb15 (cleanup): {
-        drop(_22) -> [return: bb16, unwind terminate(cleanup)];
+    bb9 (cleanup): {
+        drop(_3) -> [return: bb10, unwind terminate(cleanup)];
     }
 
-    bb16 (cleanup): {
+    bb10 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-abort.mir
@@ -5,27 +5,27 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
     debug f => _2;
     let mut _0: ();
     let mut _10: usize;
-    let mut _28: std::option::Option<(usize, &T)>;
-    let mut _31: &impl Fn(usize, &T);
-    let mut _32: (usize, &T);
-    let _33: ();
+    let mut _29: std::option::Option<(usize, &T)>;
+    let mut _32: &impl Fn(usize, &T);
+    let mut _33: (usize, &T);
+    let _34: ();
     scope 1 {
         debug (((iter: Enumerate<std::slice::Iter<'_, T>>).0: std::slice::Iter<'_, T>).0: std::ptr::NonNull<T>) => _6;
         debug (((iter: Enumerate<std::slice::Iter<'_, T>>).0: std::slice::Iter<'_, T>).1: *const T) => _9;
         debug (((iter: Enumerate<std::slice::Iter<'_, T>>).0: std::slice::Iter<'_, T>).2: std::marker::PhantomData<&T>) => const ZeroSized: PhantomData<&T>;
         debug ((iter: Enumerate<std::slice::Iter<'_, T>>).1: usize) => _10;
-        let _29: usize;
-        let _30: &T;
+        let _30: usize;
+        let _31: &T;
         scope 2 {
-            debug i => _29;
-            debug x => _30;
+            debug i => _30;
+            debug x => _31;
         }
         scope 18 (inlined <Enumerate<std::slice::Iter<'_, T>> as Iterator>::next) {
-            let mut _23: std::option::Option<&T>;
-            let mut _26: (usize, bool);
-            let mut _27: (usize, &T);
+            let mut _24: std::option::Option<&T>;
+            let mut _27: (usize, bool);
+            let mut _28: (usize, &T);
             scope 19 {
-                let _25: usize;
+                let _26: usize;
                 scope 24 {
                 }
             }
@@ -40,7 +40,7 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
                 }
             }
             scope 25 (inlined <Option<&T> as Try>::branch) {
-                let _24: &T;
+                let _25: &T;
                 scope 26 {
                 }
             }
@@ -49,8 +49,9 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
                 let _11: std::ptr::NonNull<T>;
                 let _13: std::ptr::NonNull<T>;
                 let mut _16: bool;
-                let mut _20: usize;
-                let _22: &T;
+                let mut _20: bool;
+                let mut _21: usize;
+                let _23: &T;
                 scope 29 {
                     let _12: *const T;
                     scope 30 {
@@ -84,7 +85,7 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
                             }
                         }
                         scope 43 (inlined NonNull::<T>::as_ref::<'_>) {
-                            let _21: *const T;
+                            let _22: *const T;
                             scope 44 (inlined NonNull::<T>::as_ptr) {
                             }
                             scope 45 (inlined std::ptr::mut_ptr::<impl *mut T>::cast_const) {
@@ -169,16 +170,16 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
     }
 
     bb4: {
-        StorageLive(_28);
-        StorageLive(_25);
+        StorageLive(_29);
         StorageLive(_26);
-        StorageLive(_23);
+        StorageLive(_27);
+        StorageLive(_24);
         StorageLive(_11);
         StorageLive(_12);
         StorageLive(_19);
-        StorageLive(_20);
+        StorageLive(_21);
         StorageLive(_13);
-        StorageLive(_22);
+        StorageLive(_23);
         _11 = copy _6;
         _12 = copy _9;
         switchInt(const <T as std::mem::SizedTypeProperties>::IS_ZST) -> [0: bb5, otherwise: bb8];
@@ -206,88 +207,92 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
         StorageDead(_17);
         _6 = NonNull::<T> { pointer: copy _18 };
         StorageDead(_18);
-        goto -> bb13;
+        goto -> bb10;
     }
 
     bb7: {
         StorageDead(_16);
-        goto -> bb10;
+        goto -> bb14;
     }
 
     bb8: {
         _19 = copy _12 as usize (Transmute);
-        switchInt(copy _19) -> [0: bb9, otherwise: bb12];
+        StorageLive(_20);
+        _20 = Eq(copy _19, const 0_usize);
+        switchInt(move _20) -> [0: bb9, otherwise: bb13];
     }
 
     bb9: {
+        StorageDead(_20);
+        _21 = SubUnchecked(copy _19, const 1_usize);
+        _9 = copy _21 as *const T (Transmute);
         goto -> bb10;
     }
 
     bb10: {
+        StorageLive(_22);
+        _22 = copy _11 as *const T (Transmute);
+        _23 = &(*_22);
         StorageDead(_22);
+        _24 = Option::<&T>::Some(copy _23);
+        StorageDead(_23);
         StorageDead(_13);
-        StorageDead(_20);
+        StorageDead(_21);
         StorageDead(_19);
         StorageDead(_12);
         StorageDead(_11);
-        StorageDead(_23);
-        StorageDead(_26);
-        StorageDead(_25);
-        StorageDead(_28);
-        StorageDead(_10);
-        drop(_2) -> [return: bb11, unwind unreachable];
+        _25 = copy ((_24 as Some).0: &T);
+        StorageDead(_24);
+        _26 = copy _10;
+        _27 = AddWithOverflow(copy _10, const 1_usize);
+        assert(!move (_27.1: bool), "attempt to compute `{} + {}`, which would overflow", copy _10, const 1_usize) -> [success: bb11, unwind unreachable];
     }
 
     bb11: {
-        return;
+        _10 = move (_27.0: usize);
+        StorageLive(_28);
+        _28 = (copy _26, copy _25);
+        _29 = Option::<(usize, &T)>::Some(move _28);
+        StorageDead(_28);
+        StorageDead(_27);
+        StorageDead(_26);
+        _30 = copy (((_29 as Some).0: (usize, &T)).0: usize);
+        _31 = copy (((_29 as Some).0: (usize, &T)).1: &T);
+        StorageLive(_32);
+        _32 = &_2;
+        StorageLive(_33);
+        _33 = (copy _30, copy _31);
+        _34 = <impl Fn(usize, &T) as Fn<(usize, &T)>>::call(move _32, move _33) -> [return: bb12, unwind unreachable];
     }
 
     bb12: {
-        _20 = SubUnchecked(copy _19, const 1_usize);
-        _9 = copy _20 as *const T (Transmute);
-        goto -> bb13;
+        StorageDead(_33);
+        StorageDead(_32);
+        StorageDead(_29);
+        goto -> bb4;
     }
 
     bb13: {
-        StorageLive(_21);
-        _21 = copy _11 as *const T (Transmute);
-        _22 = &(*_21);
-        StorageDead(_21);
-        _23 = Option::<&T>::Some(copy _22);
-        StorageDead(_22);
-        StorageDead(_13);
         StorageDead(_20);
-        StorageDead(_19);
-        StorageDead(_12);
-        StorageDead(_11);
-        _24 = copy ((_23 as Some).0: &T);
-        StorageDead(_23);
-        _25 = copy _10;
-        _26 = AddWithOverflow(copy _10, const 1_usize);
-        assert(!move (_26.1: bool), "attempt to compute `{} + {}`, which would overflow", copy _10, const 1_usize) -> [success: bb14, unwind unreachable];
+        goto -> bb14;
     }
 
     bb14: {
-        _10 = move (_26.0: usize);
-        StorageLive(_27);
-        _27 = (copy _25, copy _24);
-        _28 = Option::<(usize, &T)>::Some(move _27);
+        StorageDead(_23);
+        StorageDead(_13);
+        StorageDead(_21);
+        StorageDead(_19);
+        StorageDead(_12);
+        StorageDead(_11);
+        StorageDead(_24);
         StorageDead(_27);
         StorageDead(_26);
-        StorageDead(_25);
-        _29 = copy (((_28 as Some).0: (usize, &T)).0: usize);
-        _30 = copy (((_28 as Some).0: (usize, &T)).1: &T);
-        StorageLive(_31);
-        _31 = &_2;
-        StorageLive(_32);
-        _32 = (copy _29, copy _30);
-        _33 = <impl Fn(usize, &T) as Fn<(usize, &T)>>::call(move _31, move _32) -> [return: bb15, unwind unreachable];
+        StorageDead(_29);
+        StorageDead(_10);
+        drop(_2) -> [return: bb15, unwind unreachable];
     }
 
     bb15: {
-        StorageDead(_32);
-        StorageDead(_31);
-        StorageDead(_28);
-        goto -> bb4;
+        return;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-abort.mir
@@ -4,25 +4,26 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
     debug slice => _1;
     debug f => _2;
     let mut _0: ();
-    let mut _22: std::option::Option<&T>;
-    let mut _24: &impl Fn(&T);
-    let mut _25: (&T,);
-    let _26: ();
+    let mut _23: std::option::Option<&T>;
+    let mut _25: &impl Fn(&T);
+    let mut _26: (&T,);
+    let _27: ();
     scope 1 {
         debug ((iter: std::slice::Iter<'_, T>).0: std::ptr::NonNull<T>) => _6;
         debug ((iter: std::slice::Iter<'_, T>).1: *const T) => _9;
         debug ((iter: std::slice::Iter<'_, T>).2: std::marker::PhantomData<&T>) => const ZeroSized: PhantomData<&T>;
-        let _23: &T;
+        let _24: &T;
         scope 2 {
-            debug x => _23;
+            debug x => _24;
         }
         scope 16 (inlined <std::slice::Iter<'_, T> as Iterator>::next) {
             let mut _6: std::ptr::NonNull<T>;
             let _10: std::ptr::NonNull<T>;
             let _12: std::ptr::NonNull<T>;
             let mut _15: bool;
-            let mut _19: usize;
-            let _21: &T;
+            let mut _19: bool;
+            let mut _20: usize;
+            let _22: &T;
             scope 17 {
                 let _11: *const T;
                 scope 18 {
@@ -56,7 +57,7 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                         }
                     }
                     scope 31 (inlined NonNull::<T>::as_ref::<'_>) {
-                        let _20: *const T;
+                        let _21: *const T;
                         scope 32 (inlined NonNull::<T>::as_ptr) {
                         }
                         scope 33 (inlined std::ptr::mut_ptr::<impl *mut T>::cast_const) {
@@ -134,13 +135,13 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
     }
 
     bb4: {
-        StorageLive(_22);
+        StorageLive(_23);
         StorageLive(_10);
         StorageLive(_11);
         StorageLive(_18);
-        StorageLive(_19);
+        StorageLive(_20);
         StorageLive(_12);
-        StorageLive(_21);
+        StorageLive(_22);
         _10 = copy _6;
         _11 = copy _9;
         switchInt(const <T as std::mem::SizedTypeProperties>::IS_ZST) -> [0: bb5, otherwise: bb8];
@@ -168,68 +169,72 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         StorageDead(_16);
         _6 = NonNull::<T> { pointer: copy _17 };
         StorageDead(_17);
-        goto -> bb13;
+        goto -> bb10;
     }
 
     bb7: {
         StorageDead(_15);
-        goto -> bb10;
+        goto -> bb13;
     }
 
     bb8: {
         _18 = copy _11 as usize (Transmute);
-        switchInt(copy _18) -> [0: bb9, otherwise: bb12];
+        StorageLive(_19);
+        _19 = Eq(copy _18, const 0_usize);
+        switchInt(move _19) -> [0: bb9, otherwise: bb12];
     }
 
     bb9: {
+        StorageDead(_19);
+        _20 = SubUnchecked(copy _18, const 1_usize);
+        _9 = copy _20 as *const T (Transmute);
         goto -> bb10;
     }
 
     bb10: {
+        StorageLive(_21);
+        _21 = copy _10 as *const T (Transmute);
+        _22 = &(*_21);
         StorageDead(_21);
+        _23 = Option::<&T>::Some(copy _22);
+        StorageDead(_22);
         StorageDead(_12);
-        StorageDead(_19);
+        StorageDead(_20);
         StorageDead(_18);
         StorageDead(_11);
         StorageDead(_10);
-        StorageDead(_22);
-        drop(_2) -> [return: bb11, unwind unreachable];
+        _24 = copy ((_23 as Some).0: &T);
+        StorageLive(_25);
+        _25 = &_2;
+        StorageLive(_26);
+        _26 = (copy _24,);
+        _27 = <impl Fn(&T) as Fn<(&T,)>>::call(move _25, move _26) -> [return: bb11, unwind unreachable];
     }
 
     bb11: {
-        return;
+        StorageDead(_26);
+        StorageDead(_25);
+        StorageDead(_23);
+        goto -> bb4;
     }
 
     bb12: {
-        _19 = SubUnchecked(copy _18, const 1_usize);
-        _9 = copy _19 as *const T (Transmute);
+        StorageDead(_19);
         goto -> bb13;
     }
 
     bb13: {
-        StorageLive(_20);
-        _20 = copy _10 as *const T (Transmute);
-        _21 = &(*_20);
-        StorageDead(_20);
-        _22 = Option::<&T>::Some(copy _21);
-        StorageDead(_21);
+        StorageDead(_22);
         StorageDead(_12);
-        StorageDead(_19);
+        StorageDead(_20);
         StorageDead(_18);
         StorageDead(_11);
         StorageDead(_10);
-        _23 = copy ((_22 as Some).0: &T);
-        StorageLive(_24);
-        _24 = &_2;
-        StorageLive(_25);
-        _25 = (copy _23,);
-        _26 = <impl Fn(&T) as Fn<(&T,)>>::call(move _24, move _25) -> [return: bb14, unwind unreachable];
+        StorageDead(_23);
+        drop(_2) -> [return: bb14, unwind unreachable];
     }
 
     bb14: {
-        StorageDead(_25);
-        StorageDead(_24);
-        StorageDead(_22);
-        goto -> bb4;
+        return;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-unwind.mir
@@ -4,25 +4,26 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
     debug slice => _1;
     debug f => _2;
     let mut _0: ();
-    let mut _22: std::option::Option<&T>;
-    let mut _24: &impl Fn(&T);
-    let mut _25: (&T,);
-    let _26: ();
+    let mut _23: std::option::Option<&T>;
+    let mut _25: &impl Fn(&T);
+    let mut _26: (&T,);
+    let _27: ();
     scope 1 {
         debug ((iter: std::slice::Iter<'_, T>).0: std::ptr::NonNull<T>) => _6;
         debug ((iter: std::slice::Iter<'_, T>).1: *const T) => _9;
         debug ((iter: std::slice::Iter<'_, T>).2: std::marker::PhantomData<&T>) => const ZeroSized: PhantomData<&T>;
-        let _23: &T;
+        let _24: &T;
         scope 2 {
-            debug x => _23;
+            debug x => _24;
         }
         scope 16 (inlined <std::slice::Iter<'_, T> as Iterator>::next) {
             let mut _6: std::ptr::NonNull<T>;
             let _10: std::ptr::NonNull<T>;
             let _12: std::ptr::NonNull<T>;
             let mut _15: bool;
-            let mut _19: usize;
-            let _21: &T;
+            let mut _19: bool;
+            let mut _20: usize;
+            let _22: &T;
             scope 17 {
                 let _11: *const T;
                 scope 18 {
@@ -56,7 +57,7 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                         }
                     }
                     scope 31 (inlined NonNull::<T>::as_ref::<'_>) {
-                        let _20: *const T;
+                        let _21: *const T;
                         scope 32 (inlined NonNull::<T>::as_ptr) {
                         }
                         scope 33 (inlined std::ptr::mut_ptr::<impl *mut T>::cast_const) {
@@ -134,13 +135,13 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
     }
 
     bb4: {
-        StorageLive(_22);
+        StorageLive(_23);
         StorageLive(_10);
         StorageLive(_11);
         StorageLive(_18);
-        StorageLive(_19);
+        StorageLive(_20);
         StorageLive(_12);
-        StorageLive(_21);
+        StorageLive(_22);
         _10 = copy _6;
         _11 = copy _9;
         switchInt(const <T as std::mem::SizedTypeProperties>::IS_ZST) -> [0: bb5, otherwise: bb8];
@@ -168,76 +169,80 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         StorageDead(_16);
         _6 = NonNull::<T> { pointer: copy _17 };
         StorageDead(_17);
-        goto -> bb13;
+        goto -> bb10;
     }
 
     bb7: {
         StorageDead(_15);
-        goto -> bb10;
+        goto -> bb15;
     }
 
     bb8: {
         _18 = copy _11 as usize (Transmute);
-        switchInt(copy _18) -> [0: bb9, otherwise: bb12];
+        StorageLive(_19);
+        _19 = Eq(copy _18, const 0_usize);
+        switchInt(move _19) -> [0: bb9, otherwise: bb14];
     }
 
     bb9: {
+        StorageDead(_19);
+        _20 = SubUnchecked(copy _18, const 1_usize);
+        _9 = copy _20 as *const T (Transmute);
         goto -> bb10;
     }
 
     bb10: {
+        StorageLive(_21);
+        _21 = copy _10 as *const T (Transmute);
+        _22 = &(*_21);
         StorageDead(_21);
+        _23 = Option::<&T>::Some(copy _22);
+        StorageDead(_22);
         StorageDead(_12);
-        StorageDead(_19);
+        StorageDead(_20);
         StorageDead(_18);
         StorageDead(_11);
         StorageDead(_10);
-        StorageDead(_22);
-        drop(_2) -> [return: bb11, unwind continue];
+        _24 = copy ((_23 as Some).0: &T);
+        StorageLive(_25);
+        _25 = &_2;
+        StorageLive(_26);
+        _26 = (copy _24,);
+        _27 = <impl Fn(&T) as Fn<(&T,)>>::call(move _25, move _26) -> [return: bb11, unwind: bb12];
     }
 
     bb11: {
-        return;
-    }
-
-    bb12: {
-        _19 = SubUnchecked(copy _18, const 1_usize);
-        _9 = copy _19 as *const T (Transmute);
-        goto -> bb13;
-    }
-
-    bb13: {
-        StorageLive(_20);
-        _20 = copy _10 as *const T (Transmute);
-        _21 = &(*_20);
-        StorageDead(_20);
-        _22 = Option::<&T>::Some(copy _21);
-        StorageDead(_21);
-        StorageDead(_12);
-        StorageDead(_19);
-        StorageDead(_18);
-        StorageDead(_11);
-        StorageDead(_10);
-        _23 = copy ((_22 as Some).0: &T);
-        StorageLive(_24);
-        _24 = &_2;
-        StorageLive(_25);
-        _25 = (copy _23,);
-        _26 = <impl Fn(&T) as Fn<(&T,)>>::call(move _24, move _25) -> [return: bb14, unwind: bb15];
-    }
-
-    bb14: {
+        StorageDead(_26);
         StorageDead(_25);
-        StorageDead(_24);
-        StorageDead(_22);
+        StorageDead(_23);
         goto -> bb4;
     }
 
-    bb15 (cleanup): {
-        drop(_2) -> [return: bb16, unwind terminate(cleanup)];
+    bb12 (cleanup): {
+        drop(_2) -> [return: bb13, unwind terminate(cleanup)];
     }
 
-    bb16 (cleanup): {
+    bb13 (cleanup): {
         resume;
+    }
+
+    bb14: {
+        StorageDead(_19);
+        goto -> bb15;
+    }
+
+    bb15: {
+        StorageDead(_22);
+        StorageDead(_12);
+        StorageDead(_20);
+        StorageDead(_18);
+        StorageDead(_11);
+        StorageDead(_10);
+        StorageDead(_23);
+        drop(_2) -> [return: bb16, unwind continue];
+    }
+
+    bb16: {
+        return;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_iter.slice_iter_next.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.slice_iter_next.PreCodegen.after.panic-abort.mir
@@ -8,8 +8,9 @@ fn slice_iter_next(_1: &mut std::slice::Iter<'_, T>) -> Option<&T> {
         let _4: std::ptr::NonNull<T>;
         let mut _7: bool;
         let mut _10: std::ptr::NonNull<T>;
-        let mut _12: usize;
-        let _14: &T;
+        let mut _12: bool;
+        let mut _13: usize;
+        let _15: &T;
         scope 2 {
             let _3: *const T;
             scope 3 {
@@ -43,7 +44,7 @@ fn slice_iter_next(_1: &mut std::slice::Iter<'_, T>) -> Option<&T> {
                     }
                 }
                 scope 16 (inlined NonNull::<T>::as_ref::<'_>) {
-                    let _13: *const T;
+                    let _14: *const T;
                     scope 17 (inlined NonNull::<T>::as_ptr) {
                     }
                     scope 18 (inlined std::ptr::mut_ptr::<impl *mut T>::cast_const) {
@@ -57,9 +58,9 @@ fn slice_iter_next(_1: &mut std::slice::Iter<'_, T>) -> Option<&T> {
         StorageLive(_2);
         StorageLive(_3);
         StorageLive(_11);
-        StorageLive(_12);
+        StorageLive(_13);
         StorageLive(_4);
-        StorageLive(_14);
+        StorageLive(_15);
         _2 = copy ((*_1).0: std::ptr::NonNull<T>);
         _3 = copy ((*_1).1: *const T);
         switchInt(const <T as std::mem::SizedTypeProperties>::IS_ZST) -> [0: bb1, otherwise: bb4];
@@ -90,7 +91,7 @@ fn slice_iter_next(_1: &mut std::slice::Iter<'_, T>) -> Option<&T> {
         StorageDead(_9);
         ((*_1).0: std::ptr::NonNull<T>) = move _10;
         StorageDead(_10);
-        goto -> bb7;
+        goto -> bb6;
     }
 
     bb3: {
@@ -101,33 +102,37 @@ fn slice_iter_next(_1: &mut std::slice::Iter<'_, T>) -> Option<&T> {
 
     bb4: {
         _11 = copy _3 as usize (Transmute);
-        switchInt(copy _11) -> [0: bb5, otherwise: bb6];
+        StorageLive(_12);
+        _12 = Eq(copy _11, const 0_usize);
+        switchInt(move _12) -> [0: bb5, otherwise: bb7];
     }
 
     bb5: {
-        _0 = const {transmute(0x0000000000000000): Option<&T>};
-        goto -> bb8;
+        StorageDead(_12);
+        _13 = SubUnchecked(copy _11, const 1_usize);
+        ((*_1).1: *const T) = copy _13 as *const T (Transmute);
+        goto -> bb6;
     }
 
     bb6: {
-        _12 = SubUnchecked(copy _11, const 1_usize);
-        ((*_1).1: *const T) = copy _12 as *const T (Transmute);
-        goto -> bb7;
+        StorageLive(_14);
+        _14 = copy _2 as *const T (Transmute);
+        _15 = &(*_14);
+        StorageDead(_14);
+        _0 = Option::<&T>::Some(copy _15);
+        goto -> bb8;
     }
 
     bb7: {
-        StorageLive(_13);
-        _13 = copy _2 as *const T (Transmute);
-        _14 = &(*_13);
-        StorageDead(_13);
-        _0 = Option::<&T>::Some(copy _14);
+        _0 = const {transmute(0x0000000000000000): Option<&T>};
+        StorageDead(_12);
         goto -> bb8;
     }
 
     bb8: {
-        StorageDead(_14);
+        StorageDead(_15);
         StorageDead(_4);
-        StorageDead(_12);
+        StorageDead(_13);
         StorageDead(_11);
         StorageDead(_3);
         StorageDead(_2);

--- a/tests/mir-opt/pre-codegen/slice_iter.slice_iter_next.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.slice_iter_next.PreCodegen.after.panic-unwind.mir
@@ -8,8 +8,9 @@ fn slice_iter_next(_1: &mut std::slice::Iter<'_, T>) -> Option<&T> {
         let _4: std::ptr::NonNull<T>;
         let mut _7: bool;
         let mut _10: std::ptr::NonNull<T>;
-        let mut _12: usize;
-        let _14: &T;
+        let mut _12: bool;
+        let mut _13: usize;
+        let _15: &T;
         scope 2 {
             let _3: *const T;
             scope 3 {
@@ -43,7 +44,7 @@ fn slice_iter_next(_1: &mut std::slice::Iter<'_, T>) -> Option<&T> {
                     }
                 }
                 scope 16 (inlined NonNull::<T>::as_ref::<'_>) {
-                    let _13: *const T;
+                    let _14: *const T;
                     scope 17 (inlined NonNull::<T>::as_ptr) {
                     }
                     scope 18 (inlined std::ptr::mut_ptr::<impl *mut T>::cast_const) {
@@ -57,9 +58,9 @@ fn slice_iter_next(_1: &mut std::slice::Iter<'_, T>) -> Option<&T> {
         StorageLive(_2);
         StorageLive(_3);
         StorageLive(_11);
-        StorageLive(_12);
+        StorageLive(_13);
         StorageLive(_4);
-        StorageLive(_14);
+        StorageLive(_15);
         _2 = copy ((*_1).0: std::ptr::NonNull<T>);
         _3 = copy ((*_1).1: *const T);
         switchInt(const <T as std::mem::SizedTypeProperties>::IS_ZST) -> [0: bb1, otherwise: bb4];
@@ -90,7 +91,7 @@ fn slice_iter_next(_1: &mut std::slice::Iter<'_, T>) -> Option<&T> {
         StorageDead(_9);
         ((*_1).0: std::ptr::NonNull<T>) = move _10;
         StorageDead(_10);
-        goto -> bb7;
+        goto -> bb6;
     }
 
     bb3: {
@@ -101,33 +102,37 @@ fn slice_iter_next(_1: &mut std::slice::Iter<'_, T>) -> Option<&T> {
 
     bb4: {
         _11 = copy _3 as usize (Transmute);
-        switchInt(copy _11) -> [0: bb5, otherwise: bb6];
+        StorageLive(_12);
+        _12 = Eq(copy _11, const 0_usize);
+        switchInt(move _12) -> [0: bb5, otherwise: bb7];
     }
 
     bb5: {
-        _0 = const {transmute(0x0000000000000000): Option<&T>};
-        goto -> bb8;
+        StorageDead(_12);
+        _13 = SubUnchecked(copy _11, const 1_usize);
+        ((*_1).1: *const T) = copy _13 as *const T (Transmute);
+        goto -> bb6;
     }
 
     bb6: {
-        _12 = SubUnchecked(copy _11, const 1_usize);
-        ((*_1).1: *const T) = copy _12 as *const T (Transmute);
-        goto -> bb7;
+        StorageLive(_14);
+        _14 = copy _2 as *const T (Transmute);
+        _15 = &(*_14);
+        StorageDead(_14);
+        _0 = Option::<&T>::Some(copy _15);
+        goto -> bb8;
     }
 
     bb7: {
-        StorageLive(_13);
-        _13 = copy _2 as *const T (Transmute);
-        _14 = &(*_13);
-        StorageDead(_13);
-        _0 = Option::<&T>::Some(copy _14);
+        _0 = const {transmute(0x0000000000000000): Option<&T>};
+        StorageDead(_12);
         goto -> bb8;
     }
 
     bb8: {
-        StorageDead(_14);
+        StorageDead(_15);
         StorageDead(_4);
-        StorageDead(_12);
+        StorageDead(_13);
         StorageDead(_11);
         StorageDead(_3);
         StorageDead(_2);


### PR DESCRIPTION
*  [beta] Disable SimplifyComparisonIntegral rust-lang/rust#151267 
*  Use the old homu bors e-mail address again rust-lang/rust#150959 

Does not backport other nominated PRs:

* Only use SSA locals in SimplifyComparisonIntegral rust-lang/rust#150925  (replaced with the disablement PR)
* Don't try to evaluate const blocks during constant promotion rust-lang/rust#150557 (backport essentially denied at this point)
* Use realstd current thread static variables in tests rust-lang/rust#150131 (as far as I can tell, this only affects internal std tests and hasn't landed in time for backport)

r? @Mark-Simulacrum 