### PR TITLE
remove unnecessary unsafe block code in Buffer's read_more method

### DIFF
--- a/library/std/src/io/buffered/bufreader/buffer.rs
+++ b/library/std/src/io/buffered/bufreader/buffer.rs
@@ -111,9 +111,6 @@ impl Buffer {
     pub fn read_more(&mut self, mut reader: impl Read) -> io::Result<usize> {
         let mut buf = BorrowedBuf::from(&mut self.buf[self.filled..]);
         let old_init = self.initialized - self.filled;
-        unsafe {
-            buf.set_init(old_init);
-        }
         reader.read_buf(buf.unfilled())?;
         self.filled += buf.len();
         self.initialized += buf.init_len() - old_init;


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Out of curiosity, I was taking a look at the BufReader's `peek()` method and ended up checking out the code for Buffer's `read_more()` method. For reference, this is original code of Buffer's `read_more()` method.
```rust
    /// Read more bytes into the buffer without discarding any of its contents
    pub fn read_more(&mut self, mut reader: impl Read) -> io::Result<usize> {
        let mut buf = BorrowedBuf::from(&mut self.buf[self.filled..]);
        let old_init = self.initialized - self.filled;
        unsafe {
             buf.set_init(old_init);
        }
        reader.read_buf(buf.unfilled())?;
        self.filled += buf.len();
        self.initialized += buf.init_len() - old_init;
        Ok(buf.len())
    }
```
I think the unsafe block in the `read_more()` might be unused because I was taking a look into what `reader.read_buf()` does and it seems to already be setting the BorrowBuf's `init` field to another value.

```rust
fn read_buf(&mut self, buf: BorrowedCursor<'_>) -> Result<()> {
        default_read_buf(|b| self.read(b), buf)
}

pub(crate) fn default_read_buf<F>(read: F, mut cursor: BorrowedCursor<'_>) -> Result<()>
where
    F: FnOnce(&mut [u8]) -> Result<usize>,
{
    let n = read(cursor.ensure_init().init_mut())?;
    cursor.advance(n);
    Ok(())
}

/// Initializes all bytes in the cursor.
#[inline]
pub fn ensure_init(&mut self) -> &mut Self {
    // SAFETY: always in bounds and we never uninitialize these bytes.
    let uninit = unsafe { self.buf.buf.get_unchecked_mut(self.buf.init..) };

    // SAFETY: 0 is a valid value for MaybeUninit<u8> and the length matches the allocation
    // since it is comes from a slice reference.
    unsafe {
        ptr::write_bytes(uninit.as_mut_ptr(), 0, uninit.len());
    }
    self.buf.init = self.buf.capacity();

    self
}
```
It seems like the init field is reassigned inside the `ensure_init()` function, which would make the buf.set_init(old_init) code not useful. I know that the `buf.unfilled()` that is passed into `reader.read_buf()` is a `BorrowedCursor<'this>`, but as far as I am aware, a `BorrowCursor<'this>` is a wrapper around the unfilled portion of `BorrowedBuf<'_>`:
```rust
#[derive(Debug)]
pub struct BorrowedCursor<'a> {
    /// The underlying buffer.
    // Safety invariant: we treat the type of buf as covariant in the lifetime of `BorrowedBuf` when
    // we create a `BorrowedCursor`. This is only safe if we never replace `buf` by assigning into
    // it, so don't do that!
    buf: &'a mut BorrowedBuf<'a>,
}
```
If I'm understanding things correctly, I believe it's fine to get rid of the unsafe block code in this function.