### PR TITLE
Normalize type_const items even with feature `generic_const_exprs`

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/normalize.rs
@@ -433,7 +433,12 @@ impl<'a, 'b, 'tcx> TypeFolder<TyCtxt<'tcx>> for AssocTypeNormalizer<'a, 'b, 'tcx
     #[instrument(skip(self), level = "debug")]
     fn fold_const(&mut self, ct: ty::Const<'tcx>) -> ty::Const<'tcx> {
         let tcx = self.selcx.tcx();
-        if tcx.features().generic_const_exprs() || !needs_normalization(self.selcx.infcx, &ct) {
+
+        if tcx.features().generic_const_exprs()
+            // Normalize type_const items even with feature `generic_const_exprs`.
+            && !matches!(ct.kind(), ty::ConstKind::Unevaluated(uv) if tcx.is_type_const(uv.def))
+            || !needs_normalization(self.selcx.infcx, &ct)
+        {
             return ct;
         }
 

--- a/tests/crashes/138089.rs
+++ b/tests/crashes/138089.rs
@@ -1,4 +1,6 @@
 //@ known-bug: #138089
+//@ needs-rustc-debug-assertions
+
 #![feature(generic_const_exprs)]
 #![feature(min_generic_const_args)]
 #![feature(inherent_associated_types)]

--- a/tests/ui/const-generics/mgca/cyclic-type-const-151251.rs
+++ b/tests/ui/const-generics/mgca/cyclic-type-const-151251.rs
@@ -1,0 +1,11 @@
+//@ needs-rustc-debug-assertions
+
+#![feature(min_generic_const_args)]
+#![feature(generic_const_exprs)]
+#![expect(incomplete_features)]
+
+#[type_const]
+const A: u8 = A;
+//~^ ERROR overflow normalizing the unevaluated constant `A`
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/cyclic-type-const-151251.stderr
+++ b/tests/ui/const-generics/mgca/cyclic-type-const-151251.stderr
@@ -1,0 +1,11 @@
+error[E0275]: overflow normalizing the unevaluated constant `A`
+  --> $DIR/cyclic-type-const-151251.rs:8:1
+   |
+LL | const A: u8 = A;
+   | ^^^^^^^^^^^
+   |
+   = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0275`.


### PR DESCRIPTION
Fixes rust-lang/rust#151251

With feature `generic_const_exprs` enabled, consts with `#[type_const]` won't be normalized even if they need. Then ICE happens when CTFE tries to evaluate such const without body.

Fix this by normalizing such consts even with feature `generic_const_exprs` enabled.

r? @BoxyUwU 