### PR TITLE
Fix incorrect trailing comma suggested in no_accessible_fields

### DIFF
--- a/tests/ui/privacy/inaccessible-private-fields-trailing-comma-149787.fixed
+++ b/tests/ui/privacy/inaccessible-private-fields-trailing-comma-149787.fixed
@@ -1,0 +1,23 @@
+#![allow(dead_code)]
+#![allow(unused)]
+//@ run-rustfix
+
+mod m {
+    pub(crate) struct S {
+        pub(crate) visible: u64,
+        hidden: u64,
+    }
+
+    impl S {
+        pub(crate) fn new() -> Self {
+            loop {}
+        }
+    }
+}
+
+fn main() {
+    let m::S {
+        //~^ ERROR pattern requires `..` due to inaccessible fields
+        visible, ..
+    } = m::S::new();
+}

--- a/tests/ui/privacy/inaccessible-private-fields-trailing-comma-149787.rs
+++ b/tests/ui/privacy/inaccessible-private-fields-trailing-comma-149787.rs
@@ -1,0 +1,23 @@
+#![allow(dead_code)]
+#![allow(unused)]
+//@ run-rustfix
+
+mod m {
+    pub(crate) struct S {
+        pub(crate) visible: u64,
+        hidden: u64,
+    }
+
+    impl S {
+        pub(crate) fn new() -> Self {
+            loop {}
+        }
+    }
+}
+
+fn main() {
+    let m::S {
+        //~^ ERROR pattern requires `..` due to inaccessible fields
+        visible,
+    } = m::S::new();
+}

--- a/tests/ui/privacy/inaccessible-private-fields-trailing-comma-149787.stderr
+++ b/tests/ui/privacy/inaccessible-private-fields-trailing-comma-149787.stderr
@@ -1,0 +1,17 @@
+error: pattern requires `..` due to inaccessible fields
+  --> $DIR/inaccessible-private-fields-trailing-comma-149787.rs:19:9
+   |
+LL |       let m::S {
+   |  _________^
+LL | |
+LL | |         visible,
+LL | |     } = m::S::new();
+   | |_____^
+   |
+help: ignore the inaccessible and unused fields
+   |
+LL |         visible, ..
+   |                  ++
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes rust-lang/rust#149787

r? @estebank 

I think add new field for AST for it is too heavy change for this issue, here is a trivial fix with source_map, seems enough for it.