### PR TITLE
THIR patterns: Explicitly distinguish `&pin` from plain `&`/`&mut`

### DIFF
--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -807,12 +807,22 @@ pub enum PatKind<'tcx> {
         subpatterns: Vec<FieldPat<'tcx>>,
     },
 
-    /// `box P`, `&P`, `&mut P`, etc.
+    /// Explicit or implicit `&P` or `&mut P`, for some subpattern `P`.
+    ///
+    /// Implicit `&`/`&mut` patterns can be inserted by match-ergonomics.
+    ///
+    /// With `feature(pin_ergonomics)`, this can also be `&pin const P` or
+    /// `&pin mut P`, as indicated by the `pin` field.
     Deref {
+        #[type_visitable(ignore)]
+        pin: hir::Pinnedness,
         subpattern: Box<Pat<'tcx>>,
     },
 
-    /// Deref pattern, written `box P` for now.
+    /// Explicit or implicit `deref!(..)` pattern, under `feature(deref_patterns)`.
+    /// Represents a call to `Deref` or `DerefMut`, or a deref-move of `Box`.
+    ///
+    /// `box P` patterns also lower to this, under `feature(box_patterns)`.
     DerefPattern {
         subpattern: Box<Pat<'tcx>>,
         /// Whether the pattern scrutinee needs to be borrowed in order to call `Deref::deref` or

--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -268,7 +268,7 @@ pub(crate) fn for_each_immediate_subpat<'a, 'tcx>(
         | PatKind::Error(_) => {}
 
         PatKind::Binding { subpattern: Some(subpattern), .. }
-        | PatKind::Deref { subpattern }
+        | PatKind::Deref { subpattern, .. }
         | PatKind::DerefPattern { subpattern, .. } => callback(subpattern),
 
         PatKind::Variant { subpatterns, .. } | PatKind::Leaf { subpatterns } => {

--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -294,8 +294,12 @@ impl<'tcx> ConstToPat<'tcx> {
                     || pointee_ty.is_slice()
                     || pointee_ty.is_sized(tcx, self.typing_env)
                 {
-                    // References have the same valtree representation as their pointee.
                     PatKind::Deref {
+                        // This node has type `ty::Ref`, so it's not a pin-deref.
+                        pin: hir::Pinnedness::Not,
+                        // Lower the valtree to a pattern as the pointee type.
+                        // This works because references have the same valtree
+                        // representation as their pointee.
                         subpattern: self.valtree_to_pat(ty::Value { ty: *pointee_ty, valtree }),
                     }
                 } else {

--- a/compiler/rustc_mir_build/src/thir/print.rs
+++ b/compiler/rustc_mir_build/src/thir/print.rs
@@ -774,8 +774,9 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
                 print_indented!(self, "]", depth_lvl + 2);
                 print_indented!(self, "}", depth_lvl + 1);
             }
-            PatKind::Deref { subpattern } => {
+            PatKind::Deref { pin, subpattern } => {
                 print_indented!(self, "Deref { ", depth_lvl + 1);
+                print_indented!(self, format_args!("pin: {pin:?}"), depth_lvl + 2);
                 print_indented!(self, "subpattern:", depth_lvl + 2);
                 self.print_pat(subpattern, depth_lvl + 2);
                 print_indented!(self, "}", depth_lvl + 1);

--- a/compiler/rustc_pattern_analysis/src/lib.rs
+++ b/compiler/rustc_pattern_analysis/src/lib.rs
@@ -4,6 +4,7 @@
 
 // tidy-alphabetical-start
 #![allow(unused_crate_dependencies)]
+#![cfg_attr(feature = "rustc", feature(if_let_guard))]
 // tidy-alphabetical-end
 
 pub(crate) mod checks;

--- a/tests/ui/pin-ergonomics/user-type-projection.rs
+++ b/tests/ui/pin-ergonomics/user-type-projection.rs
@@ -1,0 +1,19 @@
+#![crate_type = "rlib"]
+#![feature(pin_ergonomics)]
+#![expect(incomplete_features)]
+//@ edition: 2024
+//@ check-pass
+
+// Test that we don't ICE when projecting user-type-annotations through a `&pin` pattern.
+//
+// Historically, this could occur when the code handling those projections did not know
+// about `&pin` patterns, and incorrectly treated them as plain `&`/`&mut` patterns instead.
+
+struct Data {
+    x: u32
+}
+
+pub fn project_user_type_through_pin() -> u32 {
+    let &pin const Data { x }: &pin const Data = &pin const Data { x: 30 };
+    x
+}

--- a/tests/ui/thir-print/str-patterns.stdout
+++ b/tests/ui/thir-print/str-patterns.stdout
@@ -10,6 +10,7 @@ Thir {
                 span: $DIR/str-patterns.rs:11:9: 11:16 (#0),
                 extra: None,
                 kind: Deref {
+                    pin: Not,
                     subpattern: Pat {
                         ty: str,
                         span: $DIR/str-patterns.rs:11:9: 11:16 (#0),
@@ -50,6 +51,7 @@ Thir {
                     },
                 ),
                 kind: Deref {
+                    pin: Not,
                     subpattern: Pat {
                         ty: str,
                         span: $DIR/str-patterns.rs:12:9: 12:17 (#0),


### PR DESCRIPTION
Currently, `thir::PatKind::Deref` is used for ordinary `&`/`&mut` patterns, and also for `&pin const` and `&pin mut` patterns under `feature(pin_ergonomics)`. The only way to distinguish between them is by inspecting the `Ty` attached to the pattern node.

That's non-obvious, making it easy to miss, and is also a bit confusing to read when it does occur.

This PR therefore adds an explicit `pin: hir::Pinnedness` field to `thir::PatKind::Deref`, to explicitly distinguish pin-deref nodes from ordinary builtin-deref nodes.

(I'm not deeply familiar with the future of pin-patterns, so I'm not sure whether that information is best carried as a field or as a separate `PatKind`, but I think this approach is at least an improvement over the status quo.)

r? Nadrieril (or compiler)