### PR TITLE
Suggest ignore returning value inside macro for unused_must_use lint

### DIFF
--- a/tests/ui/lint/unused/lint-unsed-in-macro-issue-151269.rs
+++ b/tests/ui/lint/unused/lint-unsed-in-macro-issue-151269.rs
@@ -1,0 +1,15 @@
+#![deny(unused_must_use)]
+
+fn error() -> Result<(), ()> {
+    Err(())
+}
+
+macro_rules! foo {
+    () => {{
+        error();
+    }};
+}
+
+fn main() {
+    let _ = foo!(); //~ ERROR unused `Result` that must be used
+}

--- a/tests/ui/lint/unused/lint-unsed-in-macro-issue-151269.stderr
+++ b/tests/ui/lint/unused/lint-unsed-in-macro-issue-151269.stderr
@@ -1,0 +1,19 @@
+error: unused `Result` that must be used
+  --> $DIR/lint-unsed-in-macro-issue-151269.rs:14:13
+   |
+LL |     let _ = foo!();
+   |             ^^^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+note: the lint level is defined here
+  --> $DIR/lint-unsed-in-macro-issue-151269.rs:1:9
+   |
+LL | #![deny(unused_must_use)]
+   |         ^^^^^^^^^^^^^^^
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |         let _ = error();
+   |         +++++++
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes rust-lang/rust#151269

The first commit fix the original issue,  
the second commit is a code refactoring in this lint.