### PR TITLE
Use `find_attr` instead of `attr::contains_name` in `lower_const_item_rhs`

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -2384,7 +2384,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             Some(ConstItemRhs::TypeConst(anon)) => {
                 hir::ConstItemRhs::TypeConst(self.lower_anon_const_to_const_arg_and_alloc(anon))
             }
-            None if attr::contains_name(attrs, sym::type_const) => {
+            None if find_attr!(attrs, AttributeKind::TypeConst(_)) => {
                 let const_arg = ConstArg {
                     hir_id: self.next_id(),
                     kind: hir::ConstArgKind::Error(

--- a/tests/ui/const-generics/mgca/type-const-assoc-const-without-body.rs
+++ b/tests/ui/const-generics/mgca/type-const-assoc-const-without-body.rs
@@ -1,0 +1,19 @@
+//@ needs-rustc-debug-assertions
+
+#![feature(min_generic_const_args)]
+#![expect(incomplete_features)]
+
+trait Tr {
+    #[type_const]
+    const SIZE: usize;
+}
+
+struct T;
+
+impl Tr for T {
+    #[type_const]
+    const SIZE: usize;
+    //~^ ERROR associated constant in `impl` without body
+}
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/type-const-assoc-const-without-body.stderr
+++ b/tests/ui/const-generics/mgca/type-const-assoc-const-without-body.stderr
@@ -1,0 +1,10 @@
+error: associated constant in `impl` without body
+  --> $DIR/type-const-assoc-const-without-body.rs:15:5
+   |
+LL |     const SIZE: usize;
+   |     ^^^^^^^^^^^^^^^^^-
+   |                      |
+   |                      help: provide a definition for the constant: `= <expr>;`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/const-generics/mgca/type-const-inherent-assoc-const-without-body.rs
+++ b/tests/ui/const-generics/mgca/type-const-inherent-assoc-const-without-body.rs
@@ -1,0 +1,12 @@
+//@ needs-rustc-debug-assertions
+
+#![feature(min_generic_const_args)]
+#![expect(incomplete_features)]
+
+impl S { //~ ERROR cannot find type `S` in this scope
+    #[type_const]
+    const SIZE: usize;
+    //~^ ERROR associated constant in `impl` without body
+}
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/type-const-inherent-assoc-const-without-body.stderr
+++ b/tests/ui/const-generics/mgca/type-const-inherent-assoc-const-without-body.stderr
@@ -1,0 +1,17 @@
+error: associated constant in `impl` without body
+  --> $DIR/type-const-inherent-assoc-const-without-body.rs:8:5
+   |
+LL |     const SIZE: usize;
+   |     ^^^^^^^^^^^^^^^^^-
+   |                      |
+   |                      help: provide a definition for the constant: `= <expr>;`
+
+error[E0425]: cannot find type `S` in this scope
+  --> $DIR/type-const-inherent-assoc-const-without-body.rs:6:6
+   |
+LL | impl S {
+   |      ^ not found in this scope
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
Fixes rust-lang/rust#151250

`attr::contains_name` uses `AttributeExt::name()` to filter, but for `hir::Attribute::Parsed`, this method will return `None`, and then `attr::contains_name` will return `false` here. So that the previous logic cannot work as expected.

r? @BoxyUwU 