### PR TITLE
Deny #[cfg_attr(pred, type_const)]

### DIFF
--- a/compiler/rustc_expand/messages.ftl
+++ b/compiler/rustc_expand/messages.ftl
@@ -194,6 +194,9 @@ expand_trailing_semi_macro = trailing semicolon in macro used in expression posi
     .note1 = macro invocations at the end of a block are treated as expressions
     .note2 = to ignore the value produced by the macro, add a semicolon after the invocation of `{$name}`
 
+expand_type_const_in_cfg_attr =
+    `type_const` within an `#[cfg_attr]` attribute is forbidden
+
 expand_unknown_macro_variable = unknown macro variable `{$name}`
 
 expand_unsupported_key_value =

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -440,6 +440,13 @@ pub(crate) struct CrateTypeInCfgAttr {
 }
 
 #[derive(Diagnostic)]
+#[diag(expand_type_const_in_cfg_attr)]
+pub(crate) struct TypeConstInCfgAttr {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(expand_glob_delegation_traitless_qpath)]
 pub(crate) struct GlobDelegationTraitlessQpath {
     #[primary_span]

--- a/tests/ui/const-generics/mgca/type-const-within-cfg-attr.rs
+++ b/tests/ui/const-generics/mgca/type-const-within-cfg-attr.rs
@@ -1,0 +1,16 @@
+//@ needs-rustc-debug-assertions
+
+#![feature(min_generic_const_args)]
+#![expect(incomplete_features)]
+
+pub trait Foo {
+    #[cfg_attr(true, type_const)] //~ ERROR `type_const` within an `#[cfg_attr]` attribute is forbidden
+    const N: usize;
+}
+
+impl Foo for u32 {
+    #[cfg_attr(true, type_const)] //~ ERROR `type_const` within an `#[cfg_attr]` attribute is forbidden
+    const N: usize = 99;
+}
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/type-const-within-cfg-attr.stderr
+++ b/tests/ui/const-generics/mgca/type-const-within-cfg-attr.stderr
@@ -1,0 +1,14 @@
+error: `type_const` within an `#[cfg_attr]` attribute is forbidden
+  --> $DIR/type-const-within-cfg-attr.rs:7:22
+   |
+LL |     #[cfg_attr(true, type_const)]
+   |                      ^^^^^^^^^^
+
+error: `type_const` within an `#[cfg_attr]` attribute is forbidden
+  --> $DIR/type-const-within-cfg-attr.rs:12:22
+   |
+LL |     #[cfg_attr(true, type_const)]
+   |                      ^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes rust-lang/rust#151273

As https://github.com/rust-lang/rust/issues/151273#issuecomment-3765026568 shows, I think emitting error when meeting `#[cfg_attr(pred, type_const)]` is good enough for now.

r? @BoxyUwU 