### PR TITLE
MGCA: Fix incorrect pretty printing of valtree arrays

### DIFF
--- a/compiler/rustc_middle/src/ty/consts/valtree.rs
+++ b/compiler/rustc_middle/src/ty/consts/valtree.rs
@@ -147,7 +147,12 @@ impl<'tcx> Value<'tcx> {
             _ => return None,
         }
 
-        Some(tcx.arena.alloc_from_iter(self.to_branch().into_iter().map(|ct| ct.to_leaf().to_u8())))
+        // We create an iterator that yields `Option<u8>`
+        let iterator = self.to_branch().into_iter().map(|ct| Some(ct.try_to_leaf()?.to_u8()));
+        // If there is `None` in the iterator, then the array is not a valid array of u8s and we return `None`
+        let bytes: Vec<u8> = iterator.collect::<Option<Vec<u8>>>()?;
+
+        Some(tcx.arena.alloc_from_iter(bytes))
     }
 
     /// Converts to a `ValTreeKind::Leaf` value, `panic`'ing

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1911,14 +1911,16 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                     return Ok(());
                 }
             },
-            (ty::ValTreeKind::Branch(_), ty::Array(t, _)) if t == u8_type => {
-                let bytes = cv.try_to_raw_bytes(self.tcx()).unwrap_or_else(|| {
-                    bug!("expected to convert valtree to raw bytes for type {:?}", t)
-                });
+            // If it is a branch with an array, and this array can be printed as raw bytes, then dump its bytes
+            (ty::ValTreeKind::Branch(_), ty::Array(t, _))
+                if t == u8_type
+                    && let Some(bytes) = cv.try_to_raw_bytes(self.tcx()) =>
+            {
                 write!(self, "*")?;
                 self.pretty_print_byte_str(bytes)?;
                 return Ok(());
             }
+            // Otherwise, print the array separated by commas (or if it's a tuple)
             (ty::ValTreeKind::Branch(fields), ty::Array(..) | ty::Tuple(..)) => {
                 let fields_iter = fields.iter().copied();
 

--- a/tests/ui/const-generics/mgca/wrong_type_const_arr_diag.rs
+++ b/tests/ui/const-generics/mgca/wrong_type_const_arr_diag.rs
@@ -1,0 +1,13 @@
+// This test causes ERROR: mismatched types [E0308]
+// and makes rustc to print array from const arguments
+#![feature(min_generic_const_args, adt_const_params)]
+#![allow(incomplete_features)]
+
+struct TakesArr<const N: [u8; 1]>;
+
+fn foo<const N: u8>() {
+    let _: TakesArr<{ [N] }> = TakesArr::<{ [1] }>;
+    //~^ ERROR: mismatched types [E0308]
+}
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/wrong_type_const_arr_diag.stderr
+++ b/tests/ui/const-generics/mgca/wrong_type_const_arr_diag.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/wrong_type_const_arr_diag.rs:9:32
+   |
+LL |     let _: TakesArr<{ [N] }> = TakesArr::<{ [1] }>;
+   |            -----------------   ^^^^^^^^^^^^^^^^^^^ expected `[N]`, found `*b"\x01"`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `TakesArr<[N]>`
+              found struct `TakesArr<*b"\x01">`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/mgca/wrong_type_const_arr_diag_trait.rs
+++ b/tests/ui/const-generics/mgca/wrong_type_const_arr_diag_trait.rs
@@ -1,0 +1,21 @@
+// This test causes ERROR: mismatched types [E0308]
+// and makes rustc to print array from const arguments
+#![feature(min_generic_const_args, adt_const_params, trivial_bounds)]
+#![allow(incomplete_features)]
+
+trait Trait {
+    #[type_const]
+    const ASSOC: u8;
+}
+
+struct TakesArr<const N: [u8; 1]>;
+
+fn foo<const N: u8>()
+where
+    u8: Trait
+{
+    let _: TakesArr<{ [<u8 as Trait>::ASSOC] }> = TakesArr::<{ [1] }>;
+    //~^ ERROR: mismatched types [E0308]
+}
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/wrong_type_const_arr_diag_trait.stderr
+++ b/tests/ui/const-generics/mgca/wrong_type_const_arr_diag_trait.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/wrong_type_const_arr_diag_trait.rs:17:51
+   |
+LL |     let _: TakesArr<{ [<u8 as Trait>::ASSOC] }> = TakesArr::<{ [1] }>;
+   |            ------------------------------------   ^^^^^^^^^^^^^^^^^^^ expected `[<u8 as Trait>::ASSOC]`, found `*b"\x01"`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `TakesArr<[<u8 as Trait>::ASSOC]>`
+              found struct `TakesArr<*b"\x01">`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes rust-lang/rust#151126 

- **add failing test**
- **fix: additional check whether const array could be printed as raw bytes**

As I figured out, the problem was in `pretty_print_const_valtree`, where it tried to print unevaluated consts as if they were evaluated, which resulted in ICE. 