### PR TITLE
add lint test

### DIFF
--- a/tests/ui/lint/unused/unused_assignments_across_match_guards.rs
+++ b/tests/ui/lint/unused/unused_assignments_across_match_guards.rs
@@ -1,0 +1,19 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/138069>
+// This test ensures that unused_assignments does not report assignments used in a match.
+//@ check-pass
+
+fn pnk(x: usize) -> &'static str {
+    let mut k1 = "k1";
+    let mut h1 = "h1";
+    match x & 3 {
+        3 if { k1 = "unused?"; false } => (),
+        _ if { h1 = k1; true } => (),
+        _ => (),
+    }
+    h1
+}
+
+#[deny(unused_assignments)]
+fn main() {
+    pnk(3);
+}


### PR DESCRIPTION
closes rust-lang/rust#138069, which was already fixed.
