### PR TITLE
fix: thread creation failed on the wasm32-wasip1-threads target.

### DIFF
--- a/library/std/src/sys/thread/unix.rs
+++ b/library/std/src/sys/thread/unix.rs
@@ -49,7 +49,7 @@ impl Thread {
         // WASI does not support threading via pthreads. While wasi-libc provides
         // pthread stubs, pthread_create returns EAGAIN, which causes confusing
         // errors. We return UNSUPPORTED_PLATFORM directly instead.
-        if cfg!(target_os = "wasi") {
+        if cfg!(all(target_os = "wasi", not(target_feature = "atomics"))) {
             return Err(io::Error::UNSUPPORTED_PLATFORM);
         }
 


### PR DESCRIPTION
wasm32-wasip1-threads target cannot create thread since nightly-2026-01-16.
This commit (c1bcae06384b1e6e0c1ddb25970df5eb77024084) broken it.
It in https://github.com/rust-lang/rust/pull/151016

This pull-request fix that issue.