### PR TITLE
x86 soft-float feature: mark it as forbidden rather than unstable

### DIFF
--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -466,9 +466,7 @@ static X86_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     ("sha512", Stable, &["avx2"]),
     ("sm3", Stable, &["avx"]),
     ("sm4", Stable, &["avx2"]),
-    // This cannot actually be toggled, the ABI always fixes it, so it'd make little sense to
-    // stabilize. It must be in this list for the ABI check to be able to use it.
-    ("soft-float", Stability::Unstable(sym::x87_target_feature), &[]),
+    ("soft-float", Stability::Forbidden { reason: "use a soft-float target instead" }, &[]),
     ("sse", Stable, &[]),
     ("sse2", Stable, &["sse"]),
     ("sse3", Stable, &["sse2"]),

--- a/tests/ui/target-feature/abi-incompatible-target-feature-attribute.x86.stderr
+++ b/tests/ui/target-feature/abi-incompatible-target-feature-attribute.x86.stderr
@@ -1,4 +1,4 @@
-error: target feature `soft-float` cannot be enabled with `#[target_feature]`: this feature is incompatible with the target ABI
+error: target feature `soft-float` cannot be enabled with `#[target_feature]`: use a soft-float target instead
   --> $DIR/abi-incompatible-target-feature-attribute.rs:17:32
    |
 LL | #[cfg_attr(x86, target_feature(enable = "soft-float"))] #[cfg_attr(riscv, target_feature(enable = "d"))]

--- a/tests/ui/target-feature/abi-incompatible-target-feature-flag-enable.rs
+++ b/tests/ui/target-feature/abi-incompatible-target-feature-flag-enable.rs
@@ -19,4 +19,5 @@ extern crate minicore;
 use minicore::*;
 
 //~? WARN must be disabled to ensure that the ABI of the current target can be implemented correctly
-//~? WARN unstable feature specified for `-Ctarget-feature`
+//[riscv]~? WARN unstable feature specified for `-Ctarget-feature`
+//[x86]~? WARN use a soft-float target instead

--- a/tests/ui/target-feature/abi-incompatible-target-feature-flag-enable.x86.stderr
+++ b/tests/ui/target-feature/abi-incompatible-target-feature-flag-enable.x86.stderr
@@ -1,6 +1,7 @@
-warning: unstable feature specified for `-Ctarget-feature`: `soft-float`
+warning: target feature `soft-float` cannot be enabled with `-Ctarget-feature`: use a soft-float target instead
    |
-   = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
 
 warning: target feature `soft-float` must be disabled to ensure that the ABI of the current target can be implemented correctly
    |

--- a/tests/ui/target-feature/x86-soft-float-cfg.rs
+++ b/tests/ui/target-feature/x86-soft-float-cfg.rs
@@ -1,0 +1,17 @@
+//! The soft-float target feature is *not* exposed as `cfg` on x86.
+//@ revisions: soft hard
+//@[hard] compile-flags: --target=x86_64-unknown-linux-gnu --crate-type=lib
+//@[hard] needs-llvm-components: x86
+//@[soft] compile-flags: --target=x86_64-unknown-none --crate-type=lib
+//@[soft] needs-llvm-components: x86
+//@ check-pass
+//@ ignore-backends: gcc
+//@ add-minicore
+#![feature(no_core)]
+#![no_core]
+#![allow(unexpected_cfgs)]
+
+// The compile_error macro does not exist, so if the `cfg` evaluates to `true` this
+// complains about the missing macro rather than showing the error... but that's good enough.
+#[cfg(target_feature = "soft-float")]
+compile_error!("the soft-float feature should NOT be exposed in `cfg`");


### PR DESCRIPTION
I am not sure why I made it "unstable" in https://github.com/rust-lang/rust/commit/f755f4cd1a2450da62b53f98f662d445f1f048b2; I think at the time "forbidden" did not work for some reason.

Making it "forbidden" instead has no significant effect on `-Ctarget-feature` use, it just changes the warning. It *does* have the effect that one cannot query this using `cfg(target_feature)` on nightly any more, but that seems fine to me. It only ever worked as an accidental side-effect of f755f4cd1a2450da62b53f98f662d445f1f048b2 anyway.

r? @workingjubilee 