### PR TITLE
Fix capitalization of diag messages

### DIFF
--- a/compiler/rustc_attr_parsing/messages.ftl
+++ b/compiler/rustc_attr_parsing/messages.ftl
@@ -230,7 +230,7 @@ attr_parsing_unstable_cfg_target_compact =
     compact `cfg(target(..))` is experimental and subject to change
 
 attr_parsing_unstable_feature_bound_incompatible_stability = item annotated with `#[unstable_feature_bound]` should not be stable
-    .help = If this item is meant to be stable, do not use any functions annotated with `#[unstable_feature_bound]`. Otherwise, mark this item as unstable with `#[unstable]`
+    .help = if this item is meant to be stable, do not use any functions annotated with `#[unstable_feature_bound]`. Otherwise, mark this item as unstable with `#[unstable]`
 
 attr_parsing_unsupported_instruction_set = target `{$current_target}` does not support `#[instruction_set({$instruction_set}::*)]`
 

--- a/compiler/rustc_const_eval/messages.ftl
+++ b/compiler/rustc_const_eval/messages.ftl
@@ -140,9 +140,9 @@ const_eval_incompatible_return_types =
 const_eval_interior_mutable_borrow_escaping =
     interior mutable shared borrows of temporaries that have their lifetime extended until the end of the program are not allowed
     .label = this borrow of an interior mutable value refers to such a temporary
-    .note = Temporaries in constants and statics can have their lifetime extended until the end of the program
-    .note2 = To avoid accidentally creating global mutable state, such temporaries must be immutable
-    .help = If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+    .note = temporaries in constants and statics can have their lifetime extended until the end of the program
+    .note2 = to avoid accidentally creating global mutable state, such temporaries must be immutable
+    .help = if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 const_eval_intern_kind = {$kind ->
     [static] static
@@ -225,9 +225,9 @@ const_eval_modified_global =
 const_eval_mutable_borrow_escaping =
     mutable borrows of temporaries that have their lifetime extended until the end of the program are not allowed
     .label = this mutable borrow refers to such a temporary
-    .note = Temporaries in constants and statics can have their lifetime extended until the end of the program
-    .note2 = To avoid accidentally creating global mutable state, such temporaries must be immutable
-    .help = If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+    .note = temporaries in constants and statics can have their lifetime extended until the end of the program
+    .note2 = to avoid accidentally creating global mutable state, such temporaries must be immutable
+    .help = if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 const_eval_mutable_ptr_in_final = encountered mutable pointer in final value of {const_eval_intern_kind}
 

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -542,7 +542,7 @@ lint_invalid_style = {$is_used_as_inner ->
         [false] crate-level attribute should be an inner attribute: add an exclamation mark: `#![{$name}]`
         *[other] the `#![{$name}]` attribute can only be used at the crate root
     }
-    .note = This attribute does not have an `!`, which means it is applied to this {$target}
+    .note = this attribute does not have an `!`, which means it is applied to this {$target}
 
 lint_invalid_target = `#[{$name}]` attribute cannot be used on {$target}
     .warn = {-lint_previously_accepted}

--- a/compiler/rustc_monomorphize/messages.ftl
+++ b/compiler/rustc_monomorphize/messages.ftl
@@ -62,7 +62,7 @@ monomorphize_encountered_error_while_instantiating_global_asm =
 monomorphize_large_assignments =
     moving {$size} bytes
     .label = value moved from here
-    .note = The current maximum size is {$limit}, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+    .note = the current maximum size is {$limit}, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 
 monomorphize_no_optimized_mir =
     missing optimized MIR for `{$instance}` in the crate `{$crate_name}`

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -376,7 +376,7 @@ passes_no_main_function =
     }
     .consider_adding_main_to_file = consider adding a `main` function to `{$filename}`
     .consider_adding_main_at_crate = consider adding a `main` function at the crate level
-    .teach_note = If you don't know the basics of Rust, you can go look to the Rust Book to get started: https://doc.rust-lang.org/book/
+    .teach_note = if you don't know the basics of Rust, you can go look to the Rust Book to get started: https://doc.rust-lang.org/book/
     .non_function_main = non-function item at `crate::main` is found
 
 passes_non_exhaustive_with_default_field_values =

--- a/tests/ui/attributes/crate-only-as-outer.stderr
+++ b/tests/ui/attributes/crate-only-as-outer.stderr
@@ -4,7 +4,7 @@ error: crate-level attribute should be an inner attribute: add an exclamation ma
 LL | #[crate_name = "owo"]
    | ^^^^^^^^^^^^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this function
+note: this attribute does not have an `!`, which means it is applied to this function
   --> $DIR/crate-only-as-outer.rs:5:1
    |
 LL | fn main() {}

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -771,7 +771,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL | #[crate_name]
    | ^^^^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this function
+note: this attribute does not have an `!`, which means it is applied to this function
   --> $DIR/malformed-attrs.rs:116:1
    |
 LL | / fn test() {

--- a/tests/ui/attributes/malformed-no-std.stderr
+++ b/tests/ui/attributes/malformed-no-std.stderr
@@ -58,7 +58,7 @@ error: crate-level attribute should be an inner attribute: add an exclamation ma
 LL | #[no_std]
    | ^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this extern crate
+note: this attribute does not have an `!`, which means it is applied to this extern crate
   --> $DIR/malformed-no-std.rs:26:1
    |
 LL | extern crate core;
@@ -75,7 +75,7 @@ error: crate-level attribute should be an inner attribute: add an exclamation ma
 LL | #[no_core]
    | ^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this extern crate
+note: this attribute does not have an `!`, which means it is applied to this extern crate
   --> $DIR/malformed-no-std.rs:26:1
    |
 LL | extern crate core;

--- a/tests/ui/consts/const-mut-refs/issue-76510.stderr
+++ b/tests/ui/consts/const-mut-refs/issue-76510.stderr
@@ -4,9 +4,9 @@ error[E0764]: mutable borrows of temporaries that have their lifetime extended u
 LL | const S: &'static mut str = &mut " hello ";
    |                             ^^^^^^^^^^^^^^ this mutable borrow refers to such a temporary
    |
-   = note: Temporaries in constants and statics can have their lifetime extended until the end of the program
-   = note: To avoid accidentally creating global mutable state, such temporaries must be immutable
-   = help: If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+   = note: temporaries in constants and statics can have their lifetime extended until the end of the program
+   = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
+   = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-mut-refs/mut_ref_in_final.stderr
+++ b/tests/ui/consts/const-mut-refs/mut_ref_in_final.stderr
@@ -4,9 +4,9 @@ error[E0764]: mutable borrows of temporaries that have their lifetime extended u
 LL | const B: *mut i32 = &mut 4;
    |                     ^^^^^^ this mutable borrow refers to such a temporary
    |
-   = note: Temporaries in constants and statics can have their lifetime extended until the end of the program
-   = note: To avoid accidentally creating global mutable state, such temporaries must be immutable
-   = help: If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+   = note: temporaries in constants and statics can have their lifetime extended until the end of the program
+   = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
+   = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error[E0764]: mutable borrows of temporaries that have their lifetime extended until the end of the program are not allowed
   --> $DIR/mut_ref_in_final.rs:21:35
@@ -14,9 +14,9 @@ error[E0764]: mutable borrows of temporaries that have their lifetime extended u
 LL | const B3: Option<&mut i32> = Some(&mut 42);
    |                                   ^^^^^^^ this mutable borrow refers to such a temporary
    |
-   = note: Temporaries in constants and statics can have their lifetime extended until the end of the program
-   = note: To avoid accidentally creating global mutable state, such temporaries must be immutable
-   = help: If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+   = note: temporaries in constants and statics can have their lifetime extended until the end of the program
+   = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
+   = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/mut_ref_in_final.rs:24:42
@@ -86,9 +86,9 @@ error[E0764]: mutable borrows of temporaries that have their lifetime extended u
 LL | static RAW_MUT_CAST_S: SyncPtr<i32> = SyncPtr { x : &mut 42 as *mut _ as *const _ };
    |                                                     ^^^^^^^ this mutable borrow refers to such a temporary
    |
-   = note: Temporaries in constants and statics can have their lifetime extended until the end of the program
-   = note: To avoid accidentally creating global mutable state, such temporaries must be immutable
-   = help: If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+   = note: temporaries in constants and statics can have their lifetime extended until the end of the program
+   = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
+   = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error[E0764]: mutable borrows of temporaries that have their lifetime extended until the end of the program are not allowed
   --> $DIR/mut_ref_in_final.rs:73:54
@@ -96,9 +96,9 @@ error[E0764]: mutable borrows of temporaries that have their lifetime extended u
 LL | static RAW_MUT_COERCE_S: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    |                                                      ^^^^^^ this mutable borrow refers to such a temporary
    |
-   = note: Temporaries in constants and statics can have their lifetime extended until the end of the program
-   = note: To avoid accidentally creating global mutable state, such temporaries must be immutable
-   = help: If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+   = note: temporaries in constants and statics can have their lifetime extended until the end of the program
+   = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
+   = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error[E0764]: mutable borrows of temporaries that have their lifetime extended until the end of the program are not allowed
   --> $DIR/mut_ref_in_final.rs:75:52
@@ -106,9 +106,9 @@ error[E0764]: mutable borrows of temporaries that have their lifetime extended u
 LL | const RAW_MUT_CAST_C: SyncPtr<i32> = SyncPtr { x : &mut 42 as *mut _ as *const _ };
    |                                                    ^^^^^^^ this mutable borrow refers to such a temporary
    |
-   = note: Temporaries in constants and statics can have their lifetime extended until the end of the program
-   = note: To avoid accidentally creating global mutable state, such temporaries must be immutable
-   = help: If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+   = note: temporaries in constants and statics can have their lifetime extended until the end of the program
+   = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
+   = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error[E0764]: mutable borrows of temporaries that have their lifetime extended until the end of the program are not allowed
   --> $DIR/mut_ref_in_final.rs:77:53
@@ -116,9 +116,9 @@ error[E0764]: mutable borrows of temporaries that have their lifetime extended u
 LL | const RAW_MUT_COERCE_C: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    |                                                     ^^^^^^ this mutable borrow refers to such a temporary
    |
-   = note: Temporaries in constants and statics can have their lifetime extended until the end of the program
-   = note: To avoid accidentally creating global mutable state, such temporaries must be immutable
-   = help: If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+   = note: temporaries in constants and statics can have their lifetime extended until the end of the program
+   = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
+   = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error[E0080]: constructing invalid value at .<enum-variant(Some)>.0: encountered a dangling reference (0x2a[noalloc] has no provenance)
   --> $DIR/mut_ref_in_final.rs:86:5

--- a/tests/ui/consts/const-promoted-opaque.atomic.stderr
+++ b/tests/ui/consts/const-promoted-opaque.atomic.stderr
@@ -13,9 +13,9 @@ error[E0492]: interior mutable shared borrows of temporaries that have their lif
 LL | const BAZ: &Foo = &FOO;
    |                   ^^^^ this borrow of an interior mutable value refers to such a temporary
    |
-   = note: Temporaries in constants and statics can have their lifetime extended until the end of the program
-   = note: To avoid accidentally creating global mutable state, such temporaries must be immutable
-   = help: If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+   = note: temporaries in constants and statics can have their lifetime extended until the end of the program
+   = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
+   = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-promoted-opaque.rs:40:26

--- a/tests/ui/consts/issue-17718-const-bad-values.stderr
+++ b/tests/ui/consts/issue-17718-const-bad-values.stderr
@@ -4,9 +4,9 @@ error[E0764]: mutable borrows of temporaries that have their lifetime extended u
 LL | const C1: &'static mut [usize] = &mut [];
    |                                  ^^^^^^^ this mutable borrow refers to such a temporary
    |
-   = note: Temporaries in constants and statics can have their lifetime extended until the end of the program
-   = note: To avoid accidentally creating global mutable state, such temporaries must be immutable
-   = help: If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+   = note: temporaries in constants and statics can have their lifetime extended until the end of the program
+   = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
+   = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/issue-17718-const-borrow.stderr
+++ b/tests/ui/consts/issue-17718-const-borrow.stderr
@@ -4,9 +4,9 @@ error[E0492]: interior mutable shared borrows of temporaries that have their lif
 LL | const B: &'static UnsafeCell<usize> = &A;
    |                                       ^^ this borrow of an interior mutable value refers to such a temporary
    |
-   = note: Temporaries in constants and statics can have their lifetime extended until the end of the program
-   = note: To avoid accidentally creating global mutable state, such temporaries must be immutable
-   = help: If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+   = note: temporaries in constants and statics can have their lifetime extended until the end of the program
+   = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
+   = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error[E0492]: interior mutable shared borrows of temporaries that have their lifetime extended until the end of the program are not allowed
   --> $DIR/issue-17718-const-borrow.rs:9:39
@@ -14,9 +14,9 @@ error[E0492]: interior mutable shared borrows of temporaries that have their lif
 LL | const E: &'static UnsafeCell<usize> = &D.a;
    |                                       ^^^^ this borrow of an interior mutable value refers to such a temporary
    |
-   = note: Temporaries in constants and statics can have their lifetime extended until the end of the program
-   = note: To avoid accidentally creating global mutable state, such temporaries must be immutable
-   = help: If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+   = note: temporaries in constants and statics can have their lifetime extended until the end of the program
+   = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
+   = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error[E0492]: interior mutable shared borrows of temporaries that have their lifetime extended until the end of the program are not allowed
   --> $DIR/issue-17718-const-borrow.rs:11:23
@@ -24,9 +24,9 @@ error[E0492]: interior mutable shared borrows of temporaries that have their lif
 LL | const F: &'static C = &D;
    |                       ^^ this borrow of an interior mutable value refers to such a temporary
    |
-   = note: Temporaries in constants and statics can have their lifetime extended until the end of the program
-   = note: To avoid accidentally creating global mutable state, such temporaries must be immutable
-   = help: If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+   = note: temporaries in constants and statics can have their lifetime extended until the end of the program
+   = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
+   = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/consts/partial_qualif.stderr
+++ b/tests/ui/consts/partial_qualif.stderr
@@ -4,9 +4,9 @@ error[E0492]: interior mutable shared borrows of temporaries that have their lif
 LL |     &{a}
    |     ^^^^ this borrow of an interior mutable value refers to such a temporary
    |
-   = note: Temporaries in constants and statics can have their lifetime extended until the end of the program
-   = note: To avoid accidentally creating global mutable state, such temporaries must be immutable
-   = help: If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+   = note: temporaries in constants and statics can have their lifetime extended until the end of the program
+   = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
+   = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/qualif_overwrite.stderr
+++ b/tests/ui/consts/qualif_overwrite.stderr
@@ -4,9 +4,9 @@ error[E0492]: interior mutable shared borrows of temporaries that have their lif
 LL |     &{a}
    |     ^^^^ this borrow of an interior mutable value refers to such a temporary
    |
-   = note: Temporaries in constants and statics can have their lifetime extended until the end of the program
-   = note: To avoid accidentally creating global mutable state, such temporaries must be immutable
-   = help: If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+   = note: temporaries in constants and statics can have their lifetime extended until the end of the program
+   = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
+   = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/qualif_overwrite_2.stderr
+++ b/tests/ui/consts/qualif_overwrite_2.stderr
@@ -4,9 +4,9 @@ error[E0492]: interior mutable shared borrows of temporaries that have their lif
 LL |     &{a.0}
    |     ^^^^^^ this borrow of an interior mutable value refers to such a temporary
    |
-   = note: Temporaries in constants and statics can have their lifetime extended until the end of the program
-   = note: To avoid accidentally creating global mutable state, such temporaries must be immutable
-   = help: If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+   = note: temporaries in constants and statics can have their lifetime extended until the end of the program
+   = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
+   = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/refs-to-cell-in-final.stderr
+++ b/tests/ui/consts/refs-to-cell-in-final.stderr
@@ -4,9 +4,9 @@ error[E0492]: interior mutable shared borrows of temporaries that have their lif
 LL | static RAW_SYNC_S: SyncPtr<Cell<i32>> = SyncPtr { x: &Cell::new(42) };
    |                                                      ^^^^^^^^^^^^^^ this borrow of an interior mutable value refers to such a temporary
    |
-   = note: Temporaries in constants and statics can have their lifetime extended until the end of the program
-   = note: To avoid accidentally creating global mutable state, such temporaries must be immutable
-   = help: If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+   = note: temporaries in constants and statics can have their lifetime extended until the end of the program
+   = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
+   = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error[E0492]: interior mutable shared borrows of temporaries that have their lifetime extended until the end of the program are not allowed
   --> $DIR/refs-to-cell-in-final.rs:15:53
@@ -14,9 +14,9 @@ error[E0492]: interior mutable shared borrows of temporaries that have their lif
 LL | const RAW_SYNC_C: SyncPtr<Cell<i32>> = SyncPtr { x: &Cell::new(42) };
    |                                                     ^^^^^^^^^^^^^^ this borrow of an interior mutable value refers to such a temporary
    |
-   = note: Temporaries in constants and statics can have their lifetime extended until the end of the program
-   = note: To avoid accidentally creating global mutable state, such temporaries must be immutable
-   = help: If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+   = note: temporaries in constants and statics can have their lifetime extended until the end of the program
+   = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
+   = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error[E0492]: interior mutable shared borrows of temporaries that have their lifetime extended until the end of the program are not allowed
   --> $DIR/refs-to-cell-in-final.rs:41:57
@@ -31,9 +31,9 @@ LL | |     x
 LL | | };
    | |_^ this borrow of an interior mutable value refers to such a temporary
    |
-   = note: Temporaries in constants and statics can have their lifetime extended until the end of the program
-   = note: To avoid accidentally creating global mutable state, such temporaries must be immutable
-   = help: If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+   = note: temporaries in constants and statics can have their lifetime extended until the end of the program
+   = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
+   = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/consts/write_to_static_via_mut_ref.stderr
+++ b/tests/ui/consts/write_to_static_via_mut_ref.stderr
@@ -4,9 +4,9 @@ error[E0764]: mutable borrows of temporaries that have their lifetime extended u
 LL | static OH_NO: &mut i32 = &mut 42;
    |                          ^^^^^^^ this mutable borrow refers to such a temporary
    |
-   = note: Temporaries in constants and statics can have their lifetime extended until the end of the program
-   = note: To avoid accidentally creating global mutable state, such temporaries must be immutable
-   = help: If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+   = note: temporaries in constants and statics can have their lifetime extended until the end of the program
+   = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
+   = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error[E0594]: cannot assign to `*OH_NO`, as `OH_NO` is an immutable static item
   --> $DIR/write_to_static_via_mut_ref.rs:4:5

--- a/tests/ui/error-codes/E0017.stderr
+++ b/tests/ui/error-codes/E0017.stderr
@@ -19,9 +19,9 @@ error[E0764]: mutable borrows of temporaries that have their lifetime extended u
 LL | const CR: &'static mut i32 = &mut C;
    |                              ^^^^^^ this mutable borrow refers to such a temporary
    |
-   = note: Temporaries in constants and statics can have their lifetime extended until the end of the program
-   = note: To avoid accidentally creating global mutable state, such temporaries must be immutable
-   = help: If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+   = note: temporaries in constants and statics can have their lifetime extended until the end of the program
+   = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
+   = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error[E0596]: cannot borrow immutable static item `X` as mutable
   --> $DIR/E0017.rs:11:39
@@ -52,9 +52,9 @@ error[E0764]: mutable borrows of temporaries that have their lifetime extended u
 LL | static CONST_REF: &'static mut i32 = &mut C;
    |                                      ^^^^^^ this mutable borrow refers to such a temporary
    |
-   = note: Temporaries in constants and statics can have their lifetime extended until the end of the program
-   = note: To avoid accidentally creating global mutable state, such temporaries must be immutable
-   = help: If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+   = note: temporaries in constants and statics can have their lifetime extended until the end of the program
+   = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
+   = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error: aborting due to 3 previous errors; 2 warnings emitted
 

--- a/tests/ui/error-codes/E0492.stderr
+++ b/tests/ui/error-codes/E0492.stderr
@@ -4,9 +4,9 @@ error[E0492]: interior mutable shared borrows of temporaries that have their lif
 LL | const B: &'static AtomicUsize = &A;
    |                                 ^^ this borrow of an interior mutable value refers to such a temporary
    |
-   = note: Temporaries in constants and statics can have their lifetime extended until the end of the program
-   = note: To avoid accidentally creating global mutable state, such temporaries must be immutable
-   = help: If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+   = note: temporaries in constants and statics can have their lifetime extended until the end of the program
+   = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
+   = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error[E0492]: interior mutable shared borrows of temporaries that have their lifetime extended until the end of the program are not allowed
   --> $DIR/E0492.rs:5:34
@@ -14,9 +14,9 @@ error[E0492]: interior mutable shared borrows of temporaries that have their lif
 LL | static C: &'static AtomicUsize = &A;
    |                                  ^^ this borrow of an interior mutable value refers to such a temporary
    |
-   = note: Temporaries in constants and statics can have their lifetime extended until the end of the program
-   = note: To avoid accidentally creating global mutable state, such temporaries must be immutable
-   = help: If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+   = note: temporaries in constants and statics can have their lifetime extended until the end of the program
+   = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
+   = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.rs
@@ -525,25 +525,25 @@ mod macro_escape {
 #[no_std]
 //~^ WARN crate-level attribute should be an inner attribute
 mod no_std {
-    //~^ NOTE This attribute does not have an `!`, which means it is applied to this module
+    //~^ NOTE this attribute does not have an `!`, which means it is applied to this module
     mod inner { #![no_std] }
 //~^ WARN the `#![no_std]` attribute can only be used at the crate root
 
     #[no_std] fn f() { }
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| NOTE This attribute does not have an `!`, which means it is applied to this function
+    //~| NOTE this attribute does not have an `!`, which means it is applied to this function
 
     #[no_std] struct S;
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| NOTE This attribute does not have an `!`, which means it is applied to this struct
+    //~| NOTE this attribute does not have an `!`, which means it is applied to this struct
 
     #[no_std] type T = S;
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| NOTE This attribute does not have an `!`, which means it is applied to this type alias
+    //~| NOTE this attribute does not have an `!`, which means it is applied to this type alias
 
     #[no_std] impl S { }
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| NOTE This attribute does not have an `!`, which means it is applied to this implementation block
+    //~| NOTE this attribute does not have an `!`, which means it is applied to this implementation block
 }
 
 // At time of authorship, #[proc_macro_derive = "2500"] signals error
@@ -786,25 +786,25 @@ mod must_use {
 #[windows_subsystem = "windows"]
 //~^ WARN crate-level attribute should be an inner attribute
 mod windows_subsystem {
-    //~^ NOTE This attribute does not have an `!`, which means it is applied to this module
+    //~^ NOTE this attribute does not have an `!`, which means it is applied to this module
     mod inner { #![windows_subsystem="windows"] }
     //~^ WARN the `#![windows_subsystem]` attribute can only be used at the crate root
 
     #[windows_subsystem = "windows"] fn f() { }
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| NOTE This attribute does not have an `!`, which means it is applied to this function
+    //~| NOTE this attribute does not have an `!`, which means it is applied to this function
 
     #[windows_subsystem = "windows"] struct S;
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| NOTE This attribute does not have an `!`, which means it is applied to this struct
+    //~| NOTE this attribute does not have an `!`, which means it is applied to this struct
 
     #[windows_subsystem = "windows"] type T = S;
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| NOTE This attribute does not have an `!`, which means it is applied to this type alias
+    //~| NOTE this attribute does not have an `!`, which means it is applied to this type alias
 
     #[windows_subsystem = "windows"] impl S { }
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| NOTE This attribute does not have an `!`, which means it is applied to this implementation block
+    //~| NOTE this attribute does not have an `!`, which means it is applied to this implementation block
 }
 
 // BROKEN USES OF CRATE-LEVEL BUILT-IN ATTRIBUTES
@@ -812,25 +812,25 @@ mod windows_subsystem {
 #[crate_name = "0900"]
 //~^ WARN crate-level attribute should be an inner attribute
 mod crate_name {
-//~^ NOTE This attribute does not have an `!`, which means it is applied to this module
+//~^ NOTE this attribute does not have an `!`, which means it is applied to this module
     mod inner { #![crate_name="0900"] }
 //~^ WARN the `#![crate_name]` attribute can only be used at the crate root
 
     #[crate_name = "0900"] fn f() { }
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| NOTE This attribute does not have an `!`, which means it is applied to this function
+    //~| NOTE this attribute does not have an `!`, which means it is applied to this function
 
     #[crate_name = "0900"] struct S;
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| NOTE This attribute does not have an `!`, which means it is applied to this struct
+    //~| NOTE this attribute does not have an `!`, which means it is applied to this struct
 
     #[crate_name = "0900"] type T = S;
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| NOTE This attribute does not have an `!`, which means it is applied to this type alias
+    //~| NOTE this attribute does not have an `!`, which means it is applied to this type alias
 
     #[crate_name = "0900"] impl S { }
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| NOTE This attribute does not have an `!`, which means it is applied to this implementation block
+    //~| NOTE this attribute does not have an `!`, which means it is applied to this implementation block
 }
 
 #[crate_type = "0800"]
@@ -885,25 +885,25 @@ mod feature {
 #[no_main]
 //~^ WARN crate-level attribute should be an inner attribute
 mod no_main_1 {
-    //~^ NOTE: This attribute does not have an `!`, which means it is applied to this module
+    //~^ NOTE: this attribute does not have an `!`, which means it is applied to this module
     mod inner { #![no_main] }
     //~^ WARN the `#![no_main]` attribute can only be used at the crate root
 
     #[no_main] fn f() { }
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| NOTE This attribute does not have an `!`, which means it is applied to this function
+    //~| NOTE this attribute does not have an `!`, which means it is applied to this function
 
     #[no_main] struct S;
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| NOTE This attribute does not have an `!`, which means it is applied to this struct
+    //~| NOTE this attribute does not have an `!`, which means it is applied to this struct
 
     #[no_main] type T = S;
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| NOTE This attribute does not have an `!`, which means it is applied to this type alias
+    //~| NOTE this attribute does not have an `!`, which means it is applied to this type alias
 
     #[no_main] impl S { }
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| NOTE This attribute does not have an `!`, which means it is applied to this implementation
+    //~| NOTE this attribute does not have an `!`, which means it is applied to this implementation
 }
 
 #[no_builtins]
@@ -933,49 +933,49 @@ mod no_builtins {
 #[recursion_limit="0200"]
 //~^ WARN crate-level attribute should be an inner attribute
 mod recursion_limit {
-    //~^ NOTE This attribute does not have an `!`, which means it is applied to this module
+    //~^ NOTE this attribute does not have an `!`, which means it is applied to this module
     mod inner { #![recursion_limit="0200"] }
 //~^ WARN the `#![recursion_limit]` attribute can only be used at the crate root
 
     #[recursion_limit="0200"] fn f() { }
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| NOTE This attribute does not have an `!`, which means it is applied to this function
+    //~| NOTE this attribute does not have an `!`, which means it is applied to this function
 
     #[recursion_limit="0200"] struct S;
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| NOTE This attribute does not have an `!`, which means it is applied to this struct
+    //~| NOTE this attribute does not have an `!`, which means it is applied to this struct
 
     #[recursion_limit="0200"] type T = S;
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| NOTE This attribute does not have an `!`, which means it is applied to this type alias
+    //~| NOTE this attribute does not have an `!`, which means it is applied to this type alias
 
     #[recursion_limit="0200"] impl S { }
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| NOTE This attribute does not have an `!`, which means it is applied to this implementation block
+    //~| NOTE this attribute does not have an `!`, which means it is applied to this implementation block
 }
 
 #[type_length_limit="0100"]
 //~^ WARN crate-level attribute should be an inner attribute
 mod type_length_limit {
-    //~^ NOTE This attribute does not have an `!`, which means it is applied to this module
+    //~^ NOTE this attribute does not have an `!`, which means it is applied to this module
     mod inner { #![type_length_limit="0100"] }
 //~^ WARN the `#![type_length_limit]` attribute can only be used at the crate root
 
     #[type_length_limit="0100"] fn f() { }
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| NOTE This attribute does not have an `!`, which means it is applied to this function
+    //~| NOTE this attribute does not have an `!`, which means it is applied to this function
 
     #[type_length_limit="0100"] struct S;
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| NOTE This attribute does not have an `!`, which means it is applied to this struct
+    //~| NOTE this attribute does not have an `!`, which means it is applied to this struct
 
     #[type_length_limit="0100"] type T = S;
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| NOTE This attribute does not have an `!`, which means it is applied to this type alias
+    //~| NOTE this attribute does not have an `!`, which means it is applied to this type alias
 
     #[type_length_limit="0100"] impl S { }
     //~^ WARN crate-level attribute should be an inner attribute
-    //~| NOTE This attribute does not have an `!`, which means it is applied to this implementation block
+    //~| NOTE this attribute does not have an `!`, which means it is applied to this implementation block
 }
 
 fn main() {}

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
@@ -935,7 +935,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL | #[no_std]
    | ^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this module
+note: this attribute does not have an `!`, which means it is applied to this module
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:527:1
    |
 LL | / mod no_std {
@@ -957,7 +957,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL |     #[no_std] fn f() { }
    |     ^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this function
+note: this attribute does not have an `!`, which means it is applied to this function
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:532:15
    |
 LL |     #[no_std] fn f() { }
@@ -969,7 +969,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL |     #[no_std] struct S;
    |     ^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this struct
+note: this attribute does not have an `!`, which means it is applied to this struct
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:536:15
    |
 LL |     #[no_std] struct S;
@@ -981,7 +981,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL |     #[no_std] type T = S;
    |     ^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this type alias
+note: this attribute does not have an `!`, which means it is applied to this type alias
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:540:15
    |
 LL |     #[no_std] type T = S;
@@ -993,7 +993,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL |     #[no_std] impl S { }
    |     ^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this implementation block
+note: this attribute does not have an `!`, which means it is applied to this implementation block
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:544:15
    |
 LL |     #[no_std] impl S { }
@@ -1212,7 +1212,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL | #[windows_subsystem = "windows"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this module
+note: this attribute does not have an `!`, which means it is applied to this module
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:788:1
    |
 LL | / mod windows_subsystem {
@@ -1234,7 +1234,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL |     #[windows_subsystem = "windows"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this function
+note: this attribute does not have an `!`, which means it is applied to this function
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:793:38
    |
 LL |     #[windows_subsystem = "windows"] fn f() { }
@@ -1246,7 +1246,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL |     #[windows_subsystem = "windows"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this struct
+note: this attribute does not have an `!`, which means it is applied to this struct
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:797:38
    |
 LL |     #[windows_subsystem = "windows"] struct S;
@@ -1258,7 +1258,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL |     #[windows_subsystem = "windows"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this type alias
+note: this attribute does not have an `!`, which means it is applied to this type alias
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:801:38
    |
 LL |     #[windows_subsystem = "windows"] type T = S;
@@ -1270,7 +1270,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL |     #[windows_subsystem = "windows"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this implementation block
+note: this attribute does not have an `!`, which means it is applied to this implementation block
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:805:38
    |
 LL |     #[windows_subsystem = "windows"] impl S { }
@@ -1282,7 +1282,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL | #[crate_name = "0900"]
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this module
+note: this attribute does not have an `!`, which means it is applied to this module
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:814:1
    |
 LL | / mod crate_name {
@@ -1304,7 +1304,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL |     #[crate_name = "0900"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this function
+note: this attribute does not have an `!`, which means it is applied to this function
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:819:28
    |
 LL |     #[crate_name = "0900"] fn f() { }
@@ -1316,7 +1316,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL |     #[crate_name = "0900"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this struct
+note: this attribute does not have an `!`, which means it is applied to this struct
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:823:28
    |
 LL |     #[crate_name = "0900"] struct S;
@@ -1328,7 +1328,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL |     #[crate_name = "0900"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this type alias
+note: this attribute does not have an `!`, which means it is applied to this type alias
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:827:28
    |
 LL |     #[crate_name = "0900"] type T = S;
@@ -1340,7 +1340,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL |     #[crate_name = "0900"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this implementation block
+note: this attribute does not have an `!`, which means it is applied to this implementation block
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:831:28
    |
 LL |     #[crate_name = "0900"] impl S { }
@@ -1352,7 +1352,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL | #[no_main]
    | ^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this module
+note: this attribute does not have an `!`, which means it is applied to this module
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:887:1
    |
 LL | / mod no_main_1 {
@@ -1374,7 +1374,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL |     #[no_main] fn f() { }
    |     ^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this function
+note: this attribute does not have an `!`, which means it is applied to this function
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:892:16
    |
 LL |     #[no_main] fn f() { }
@@ -1386,7 +1386,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL |     #[no_main] struct S;
    |     ^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this struct
+note: this attribute does not have an `!`, which means it is applied to this struct
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:896:16
    |
 LL |     #[no_main] struct S;
@@ -1398,7 +1398,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL |     #[no_main] type T = S;
    |     ^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this type alias
+note: this attribute does not have an `!`, which means it is applied to this type alias
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:900:16
    |
 LL |     #[no_main] type T = S;
@@ -1410,7 +1410,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL |     #[no_main] impl S { }
    |     ^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this implementation block
+note: this attribute does not have an `!`, which means it is applied to this implementation block
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:904:16
    |
 LL |     #[no_main] impl S { }
@@ -1422,7 +1422,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL | #[recursion_limit="0200"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this module
+note: this attribute does not have an `!`, which means it is applied to this module
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:935:1
    |
 LL | / mod recursion_limit {
@@ -1444,7 +1444,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL |     #[recursion_limit="0200"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this function
+note: this attribute does not have an `!`, which means it is applied to this function
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:940:31
    |
 LL |     #[recursion_limit="0200"] fn f() { }
@@ -1456,7 +1456,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL |     #[recursion_limit="0200"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this struct
+note: this attribute does not have an `!`, which means it is applied to this struct
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:944:31
    |
 LL |     #[recursion_limit="0200"] struct S;
@@ -1468,7 +1468,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL |     #[recursion_limit="0200"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this type alias
+note: this attribute does not have an `!`, which means it is applied to this type alias
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:948:31
    |
 LL |     #[recursion_limit="0200"] type T = S;
@@ -1480,7 +1480,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL |     #[recursion_limit="0200"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this implementation block
+note: this attribute does not have an `!`, which means it is applied to this implementation block
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:952:31
    |
 LL |     #[recursion_limit="0200"] impl S { }
@@ -1492,7 +1492,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL | #[type_length_limit="0100"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this module
+note: this attribute does not have an `!`, which means it is applied to this module
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:959:1
    |
 LL | / mod type_length_limit {
@@ -1514,7 +1514,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL |     #[type_length_limit="0100"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this function
+note: this attribute does not have an `!`, which means it is applied to this function
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:964:33
    |
 LL |     #[type_length_limit="0100"] fn f() { }
@@ -1526,7 +1526,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL |     #[type_length_limit="0100"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this struct
+note: this attribute does not have an `!`, which means it is applied to this struct
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:968:33
    |
 LL |     #[type_length_limit="0100"] struct S;
@@ -1538,7 +1538,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL |     #[type_length_limit="0100"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this type alias
+note: this attribute does not have an `!`, which means it is applied to this type alias
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:972:33
    |
 LL |     #[type_length_limit="0100"] type T = S;
@@ -1550,7 +1550,7 @@ warning: crate-level attribute should be an inner attribute: add an exclamation 
 LL |     #[type_length_limit="0100"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this implementation block
+note: this attribute does not have an `!`, which means it is applied to this implementation block
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:976:33
    |
 LL |     #[type_length_limit="0100"] impl S { }

--- a/tests/ui/issues/issue-46604.stderr
+++ b/tests/ui/issues/issue-46604.stderr
@@ -4,9 +4,9 @@ error[E0764]: mutable borrows of temporaries that have their lifetime extended u
 LL | static buf: &mut [u8] = &mut [1u8,2,3,4,5,7];
    |                         ^^^^^^^^^^^^^^^^^^^^ this mutable borrow refers to such a temporary
    |
-   = note: Temporaries in constants and statics can have their lifetime extended until the end of the program
-   = note: To avoid accidentally creating global mutable state, such temporaries must be immutable
-   = help: If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+   = note: temporaries in constants and statics can have their lifetime extended until the end of the program
+   = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
+   = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error[E0594]: cannot assign to `buf[_]`, as `buf` is an immutable static item
   --> $DIR/issue-46604.rs:6:5

--- a/tests/ui/lint/large_assignments/copy_into_box_rc_arc.stderr
+++ b/tests/ui/lint/large_assignments/copy_into_box_rc_arc.stderr
@@ -4,7 +4,7 @@ error: moving 9999 bytes
 LL |     let _ = NotBox::new(data);
    |                         ^^^^ value moved from here
    |
-   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+   = note: the current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 note: the lint level is defined here
   --> $DIR/copy_into_box_rc_arc.rs:1:9
    |
@@ -19,7 +19,7 @@ LL | |             data,
 LL | |         }
    | |_________^ value moved from here
    |
-   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+   = note: the current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lint/large_assignments/copy_into_fn.stderr
+++ b/tests/ui/lint/large_assignments/copy_into_fn.stderr
@@ -4,7 +4,7 @@ error: moving 9999 bytes
 LL |     one_arg(Data([0; 9999]));
    |             ^^^^^^^^^^^^^^^ value moved from here
    |
-   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+   = note: the current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 note: the lint level is defined here
   --> $DIR/copy_into_fn.rs:5:9
    |
@@ -17,7 +17,7 @@ error: moving 9999 bytes
 LL |     many_args(Data([0; 9999]), true, Data([0; 9999]));
    |               ^^^^^^^^^^^^^^^ value moved from here
    |
-   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+   = note: the current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 
 error: moving 9999 bytes
   --> $DIR/copy_into_fn.rs:17:38
@@ -25,7 +25,7 @@ error: moving 9999 bytes
 LL |     many_args(Data([0; 9999]), true, Data([0; 9999]));
    |                                      ^^^^^^^^^^^^^^^ value moved from here
    |
-   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+   = note: the current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/lint/large_assignments/inline_mir.stderr
+++ b/tests/ui/lint/large_assignments/inline_mir.stderr
@@ -4,7 +4,7 @@ error: moving 9999 bytes
 LL |     let cell = std::cell::UnsafeCell::new(data);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ value moved from here
    |
-   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+   = note: the current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 note: the lint level is defined here
   --> $DIR/inline_mir.rs:2:9
    |
@@ -17,7 +17,7 @@ error: moving 9999 bytes
 LL |     std::hint::black_box(cell);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ value moved from here
    |
-   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+   = note: the current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lint/large_assignments/large_future.attribute.stderr
+++ b/tests/ui/lint/large_assignments/large_future.attribute.stderr
@@ -4,7 +4,7 @@ error: moving 10024 bytes
 LL |     let z = (x, 42);
    |              ^ value moved from here
    |
-   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+   = note: the current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 note: the lint level is defined here
   --> $DIR/large_future.rs:1:9
    |
@@ -17,7 +17,7 @@ error: moving 10024 bytes
 LL |     let a = z.0;
    |             ^^^ value moved from here
    |
-   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+   = note: the current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lint/large_assignments/large_future.option.stderr
+++ b/tests/ui/lint/large_assignments/large_future.option.stderr
@@ -4,7 +4,7 @@ error: moving 10024 bytes
 LL |     let z = (x, 42);
    |              ^ value moved from here
    |
-   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+   = note: the current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 note: the lint level is defined here
   --> $DIR/large_future.rs:1:9
    |
@@ -17,7 +17,7 @@ error: moving 10024 bytes
 LL |     let a = z.0;
    |             ^^^ value moved from here
    |
-   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+   = note: the current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lint/large_assignments/move_into_box_rc_arc.stderr
+++ b/tests/ui/lint/large_assignments/move_into_box_rc_arc.stderr
@@ -4,7 +4,7 @@ error: moving 9999 bytes
 LL |             data,
    |             ^^^^ value moved from here
    |
-   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+   = note: the current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 note: the lint level is defined here
   --> $DIR/move_into_box_rc_arc.rs:1:9
    |

--- a/tests/ui/lint/large_assignments/move_into_fn.stderr
+++ b/tests/ui/lint/large_assignments/move_into_fn.stderr
@@ -4,7 +4,7 @@ error: moving 9999 bytes
 LL |     let data = Data([100; 9999]);
    |                ^^^^^^^^^^^^^^^^^ value moved from here
    |
-   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+   = note: the current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 note: the lint level is defined here
   --> $DIR/move_into_fn.rs:5:9
    |
@@ -17,7 +17,7 @@ error: moving 9999 bytes
 LL |     take_data(data);
    |               ^^^^ value moved from here
    |
-   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+   = note: the current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lint/unused/concat-in-crate-name-issue-137687.stderr
+++ b/tests/ui/lint/unused/concat-in-crate-name-issue-137687.stderr
@@ -17,7 +17,7 @@ error: crate-level attribute should be an inner attribute: add an exclamation ma
 LL | #[crate_name = concat !()]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this macro def
+note: this attribute does not have an `!`, which means it is applied to this macro def
   --> $DIR/concat-in-crate-name-issue-137687.rs:5:1
    |
 LL | / macro_rules! a {

--- a/tests/ui/lint/unused/unused-attr-macro-rules.stderr
+++ b/tests/ui/lint/unused/unused-attr-macro-rules.stderr
@@ -27,7 +27,7 @@ error: crate-level attribute should be an inner attribute: add an exclamation ma
 LL | #[recursion_limit="1"]
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
-note: This attribute does not have an `!`, which means it is applied to this macro def
+note: this attribute does not have an `!`, which means it is applied to this macro def
   --> $DIR/unused-attr-macro-rules.rs:12:1
    |
 LL | / macro_rules! foo {

--- a/tests/ui/statics/check-immutable-mut-slices.stderr
+++ b/tests/ui/statics/check-immutable-mut-slices.stderr
@@ -4,9 +4,9 @@ error[E0764]: mutable borrows of temporaries that have their lifetime extended u
 LL | static TEST: &'static mut [isize] = &mut [];
    |                                     ^^^^^^^ this mutable borrow refers to such a temporary
    |
-   = note: Temporaries in constants and statics can have their lifetime extended until the end of the program
-   = note: To avoid accidentally creating global mutable state, such temporaries must be immutable
-   = help: If you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
+   = note: temporaries in constants and statics can have their lifetime extended until the end of the program
+   = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
+   = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/unstable-feature-bound/unstable_feature_bound_incompatible_stability.stderr
+++ b/tests/ui/unstable-feature-bound/unstable_feature_bound_incompatible_stability.stderr
@@ -4,7 +4,7 @@ error: item annotated with `#[unstable_feature_bound]` should not be stable
 LL | fn bar() {}
    | ^^^^^^^^^^^
    |
-   = help: If this item is meant to be stable, do not use any functions annotated with `#[unstable_feature_bound]`. Otherwise, mark this item as unstable with `#[unstable]`
+   = help: if this item is meant to be stable, do not use any functions annotated with `#[unstable_feature_bound]`. Otherwise, mark this item as unstable with `#[unstable]`
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Per https://rustc-dev-guide.rust-lang.org/diagnostics.html#diagnostic-output-style-guide
> Error, Warning, Note, and Help messages start with a lowercase letter and do not end with punctuation.
