### PR TITLE
optimize `vec.extend(slice.to_vec())`, take 2

### DIFF
--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -444,13 +444,16 @@ impl<T> [T] {
         impl<T: TrivialClone> ConvertVec for T {
             #[inline]
             fn to_vec<A: Allocator>(s: &[Self], alloc: A) -> Vec<Self, A> {
-                let mut v = Vec::with_capacity_in(s.len(), alloc);
+                let len = s.len();
+                let mut v = Vec::with_capacity_in(len, alloc);
                 // SAFETY:
                 // allocated above with the capacity of `s`, and initialize to `s.len()` in
                 // ptr::copy_to_non_overlapping below.
-                unsafe {
-                    s.as_ptr().copy_to_nonoverlapping(v.as_mut_ptr(), s.len());
-                    v.set_len(s.len());
+                if len > 0 {
+                    unsafe {
+                        s.as_ptr().copy_to_nonoverlapping(v.as_mut_ptr(), len);
+                        v.set_len(len);
+                    }
                 }
                 v
             }

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -2818,7 +2818,11 @@ impl<T, A: Allocator> Vec<T, A> {
         let count = other.len();
         self.reserve(count);
         let len = self.len();
-        unsafe { ptr::copy_nonoverlapping(other as *const T, self.as_mut_ptr().add(len), count) };
+        if count > 0 {
+            unsafe {
+                ptr::copy_nonoverlapping(other as *const T, self.as_mut_ptr().add(len), count)
+            };
+        }
         self.len += count;
     }
 

--- a/tests/codegen-llvm/lib-optimizations/append-elements.rs
+++ b/tests/codegen-llvm/lib-optimizations/append-elements.rs
@@ -1,0 +1,33 @@
+//@ compile-flags: -O -Zmerge-functions=disabled
+//@ needs-deterministic-layouts
+//@ min-llvm-version: 21
+#![crate_type = "lib"]
+
+//! Check that a temporary intermediate allocations can eliminated and replaced
+//! with memcpy forwarding.
+//! This requires Vec code to be structured in a way that avoids phi nodes from the
+//! zero-capacity length flowing into the memcpy arguments.
+
+// CHECK-LABEL: @vec_append_with_temp_alloc
+// CHECK-SAME: ptr{{.*}}[[DST:%[a-z]+]]{{.*}}ptr{{.*}}[[SRC:%[a-z]+]]
+#[no_mangle]
+pub fn vec_append_with_temp_alloc(dst: &mut Vec<u8>, src: &[u8]) {
+    // CHECK-NOT: call void @llvm.memcpy
+    // CHECK: call void @llvm.memcpy.{{.*}}[[DST]].i{{.*}}[[SRC]]
+    // CHECK-NOT: call void @llvm.memcpy
+    let temp = src.to_vec();
+    dst.extend(&temp);
+    // CHECK: ret
+}
+
+// CHECK-LABEL: @string_append_with_temp_alloc
+// CHECK-SAME: ptr{{.*}}[[DST:%[a-z]+]]{{.*}}ptr{{.*}}[[SRC:%[a-z]+]]
+#[no_mangle]
+pub fn string_append_with_temp_alloc(dst: &mut String, src: &str) {
+    // CHECK-NOT: call void @llvm.memcpy
+    // CHECK: call void @llvm.memcpy.{{.*}}[[DST]].i{{.*}}[[SRC]]
+    // CHECK-NOT: call void @llvm.memcpy
+    let temp = src.to_string();
+    dst.push_str(&temp);
+    // CHECK: ret
+}


### PR DESCRIPTION
Redoing https://github.com/rust-lang/rust/pull/130998
It was reverted in https://github.com/rust-lang/rust/pull/151150 due to flakiness. I have traced this to layout randomization perturbing the test (the failure reproduces locally with layout randomization), which is now excluded.