### PR TITLE
Factor out diagnostic slug checking from `DiagnosticDerive` 

### DIFF
--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
@@ -384,7 +384,7 @@ error: derive(Diagnostic): diagnostic slug not specified
 LL | #[lint(no_crate_example, code = E0123)]
    | ^
    |
-   = help: specify the slug as the first argument to the attribute, such as `#[diag(compiletest_example)]`
+   = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: derive(Diagnostic): attribute specified multiple times
   --> $DIR/diagnostic-derive.rs:613:53


### PR DESCRIPTION
Doing some cleanup work in preparation for https://github.com/rust-lang/compiler-team/issues/959

r? @Kivooeo 