### PR TITLE
Deduplicate diagnostics for const trait supertraits

### DIFF
--- a/tests/ui/consts/issue-94675.rs
+++ b/tests/ui/consts/issue-94675.rs
@@ -10,7 +10,6 @@ impl<'a> Foo<'a> {
     const fn spam(&mut self, baz: &mut Vec<u32>) {
         self.bar[0] = baz.len();
         //~^ ERROR: `Vec<usize>: [const] Index<_>` is not satisfied
-        //~| ERROR: `Vec<usize>: [const] Index<usize>` is not satisfied
         //~| ERROR: `Vec<usize>: [const] IndexMut<usize>` is not satisfied
     }
 }

--- a/tests/ui/consts/issue-94675.stderr
+++ b/tests/ui/consts/issue-94675.stderr
@@ -16,17 +16,6 @@ LL |         self.bar[0] = baz.len();
 note: trait `IndexMut` is implemented but not `const`
   --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 
-error[E0277]: the trait bound `Vec<usize>: [const] Index<usize>` is not satisfied
-  --> $DIR/issue-94675.rs:11:9
-   |
-LL |         self.bar[0] = baz.len();
-   |         ^^^^^^^^^^^
-   |
-note: trait `Index` is implemented but not `const`
-  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
-note: required by a bound in `std::ops::IndexMut::index_mut`
-  --> $SRC_DIR/core/src/ops/index.rs:LL:COL
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/const-traits/call.rs
+++ b/tests/ui/traits/const-traits/call.rs
@@ -6,7 +6,6 @@
 const _: () = {
     assert!((const || true)());
     //~^ ERROR }: [const] Fn()` is not satisfied
-    //~| ERROR }: [const] FnMut()` is not satisfied
 };
 
 fn main() {}

--- a/tests/ui/traits/const-traits/call.stderr
+++ b/tests/ui/traits/const-traits/call.stderr
@@ -4,15 +4,6 @@ error[E0277]: the trait bound `{closure@$DIR/call.rs:7:14: 7:22}: [const] Fn()` 
 LL |     assert!((const || true)());
    |             ^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `{closure@$DIR/call.rs:7:14: 7:22}: [const] FnMut()` is not satisfied
-  --> $DIR/call.rs:7:13
-   |
-LL |     assert!((const || true)());
-   |             ^^^^^^^^^^^^^^^^^
-   |
-note: required by a bound in `call`
-  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/const-traits/const_closure-const_trait_impl-ice-113381.stderr
+++ b/tests/ui/traits/const-traits/const_closure-const_trait_impl-ice-113381.stderr
@@ -4,15 +4,6 @@ error[E0277]: the trait bound `{closure@$DIR/const_closure-const_trait_impl-ice-
 LL |     (const || (()).foo())();
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `{closure@$DIR/const_closure-const_trait_impl-ice-113381.rs:15:6: 15:14}: [const] FnMut()` is not satisfied
-  --> $DIR/const_closure-const_trait_impl-ice-113381.rs:15:5
-   |
-LL |     (const || (()).foo())();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: required by a bound in `call`
-  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/const-traits/non-const-op-const-closure-non-const-outer.rs
+++ b/tests/ui/traits/const-traits/non-const-op-const-closure-non-const-outer.rs
@@ -10,7 +10,8 @@ impl Foo for () {
 }
 
 fn main() {
+    // #150052 deduplicate diagnostics for const trait supertraits
+    // so we only get one error here
     (const || { (()).foo() })();
     //~^ ERROR: }: [const] Fn()` is not satisfied
-    //~| ERROR: }: [const] FnMut()` is not satisfied
 }

--- a/tests/ui/traits/const-traits/non-const-op-const-closure-non-const-outer.stderr
+++ b/tests/ui/traits/const-traits/non-const-op-const-closure-non-const-outer.stderr
@@ -1,18 +1,9 @@
-error[E0277]: the trait bound `{closure@$DIR/non-const-op-const-closure-non-const-outer.rs:13:6: 13:14}: [const] Fn()` is not satisfied
-  --> $DIR/non-const-op-const-closure-non-const-outer.rs:13:5
+error[E0277]: the trait bound `{closure@$DIR/non-const-op-const-closure-non-const-outer.rs:15:6: 15:14}: [const] Fn()` is not satisfied
+  --> $DIR/non-const-op-const-closure-non-const-outer.rs:15:5
    |
 LL |     (const || { (()).foo() })();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `{closure@$DIR/non-const-op-const-closure-non-const-outer.rs:13:6: 13:14}: [const] FnMut()` is not satisfied
-  --> $DIR/non-const-op-const-closure-non-const-outer.rs:13:5
-   |
-LL |     (const || { (()).foo() })();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: required by a bound in `call`
-  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes rust-lang/rust#150052
