### PR TITLE
Add rulers to editor config templates

### DIFF
--- a/src/bootstrap/src/core/build_steps/setup.rs
+++ b/src/bootstrap/src/core/build_steps/setup.rs
@@ -584,7 +584,7 @@ Select which editor you would like to set up [default: None]: ";
         }
     }
 
-    /// A list of historical hashes of each LSP settings file
+    /// A list of historical Sha256 hashes of each LSP settings file
     /// New entries should be appended whenever this is updated so we can detect
     /// outdated vs. user-modified settings files.
     fn hashes(&self) -> &'static [&'static str] {
@@ -607,6 +607,7 @@ Select which editor you would like to set up [default: None]: ";
                 "1c43ead340b20792b91d02b08494ee68708e7e09f56b6766629b4b72079208f1",
                 "eec09a09452682060afd23dd5d3536ccac5615b3cdbf427366446901215fb9f6",
                 "cb653043852d9d5ff4a5be56407b859ff9928be055ad3f307eb309aad04765e6",
+                "4ccdfb2a78d2b390dc96a88ca9b633fb04e6bc5d17f25bd63c0294bff5473f54",
             ],
             EditorKind::Vim | EditorKind::VsCode => &[
                 "ea67e259dedf60d4429b6c349a564ffcd1563cf41c920a856d1f5b16b4701ac8",
@@ -626,6 +627,7 @@ Select which editor you would like to set up [default: None]: ";
                 "02a49ac2d31f00ef6e4531c44e00dac51cea895112e480553f1ba060b3942a47",
                 "0aa4748848de0d1cb7ece92a0123c8897fef6de2f58aff8fda1426f098b7a798",
                 "e5e357862e5d6d0d9da335e9823c07b8a7dc42bbf18d72cc5206ad1049cd8fcc",
+                "5e83d1bed1cf6d90eb1b01a194f5dbecc8ba85c88f543f79e5e34586fb2abf92",
             ],
             EditorKind::Zed => &[
                 "bbce727c269d1bd0c98afef4d612eb4ce27aea3c3a8968c5f10b31affbc40b6c",
@@ -636,6 +638,7 @@ Select which editor you would like to set up [default: None]: ";
                 "5ef83292111d9a8bb63b6afc3abf42d0bc78fe24985f0d2e039e73258b5dab8f",
                 "74420c13094b530a986b37c4f1d23cb58c0e8e2295f5858ded129fb1574e66f9",
                 "2d3b592c089b2ad2c528686a1e371af49922edad1c59accd5d5f31612a441568",
+                "c676b1bde629aee3e612cec0e35e2676a13fd570ead0a3d14bca405a9971286f",
             ],
         }
     }

--- a/src/etc/rust_analyzer_helix.toml
+++ b/src/etc/rust_analyzer_helix.toml
@@ -69,3 +69,4 @@ RUSTUP_TOOLCHAIN = "nightly"
 [[language]]
 name = "rust"
 file-types = ["rs", "fixed", "pp", "mir"]
+rulers = [100]

--- a/src/etc/rust_analyzer_settings.json
+++ b/src/etc/rust_analyzer_settings.json
@@ -46,5 +46,6 @@
         "*.fixed": "rust",
         "*.pp": "rust",
         "*.mir": "rust"
-    }
+    },
+    "editor.rulers": [100]
 }

--- a/src/etc/rust_analyzer_zed.json
+++ b/src/etc/rust_analyzer_zed.json
@@ -63,5 +63,7 @@
   },
   "file_types": {
     "Rust": ["fixed", "pp", "mir"]
-  }
+  },
+  "wrap_guides": [100],
+  "show_wrap_guides": true
 }


### PR DESCRIPTION
Adds a ruler at 100 columns to VS Code, Helix and Zed, which should make it a little easier to stick within tidy limits

Not 100% sure if this is correct for coc, and I'm not sure of the syntax for emacs