### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -62,19 +62,9 @@ jobs:
           rustup toolchain install --no-self-update --profile minimal $TOOLCHAIN
           rustup default $TOOLCHAIN
 
-      - name: cargo update compiler & tools
-        # Remove first line that always just says "Updating crates.io index"
-        run: |
-          echo -e "\ncompiler & tools dependencies:" >> cargo_update.log
-          cargo update 2>&1 | sed '/crates.io index/d' | tee -a cargo_update.log
-      - name: cargo update library
-        run: |
-          echo -e "\nlibrary dependencies:" >> cargo_update.log
-          cargo update --manifest-path library/Cargo.toml 2>&1 | sed '/crates.io index/d' | tee -a cargo_update.log
-      - name: cargo update rustbook
-        run: |
-          echo -e "\nrustbook dependencies:" >> cargo_update.log
-          cargo update --manifest-path src/tools/rustbook/Cargo.toml 2>&1 | sed '/crates.io index/d' | tee -a cargo_update.log
+      - name: cargo update
+        run: ./src/tools/update-lockfile.sh
+
       - name: upload Cargo.lock artifact for use in PR
         uses: actions/upload-artifact@v4
         with:

--- a/compiler/rustc_codegen_llvm/src/builder/gpu_offload.rs
+++ b/compiler/rustc_codegen_llvm/src/builder/gpu_offload.rs
@@ -55,6 +55,10 @@ impl<'ll> OffloadGlobals<'ll> {
         let init_ty = cx.type_func(&[], cx.type_void());
         let init_rtls = declare_offload_fn(cx, "__tgt_init_all_rtls", init_ty);
 
+        // We want LLVM's openmp-opt pass to pick up and optimize this module, since it covers both
+        // openmp and offload optimizations.
+        llvm::add_module_flag_u32(cx.llmod(), llvm::ModuleFlagMergeBehavior::Max, "openmp", 51);
+
         OffloadGlobals {
             launcher_fn,
             launcher_ty,

--- a/src/tools/update-lockfile.sh
+++ b/src/tools/update-lockfile.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Updates the workspaces in `.`, `library` and `src/tools/rustbook`
+# Logs are written to `cargo_update.log`
+# Used as part of regular dependency bumps
+
+set -euo pipefail
+
+echo -e "\ncompiler & tools dependencies:" > cargo_update.log
+# Remove first line that always just says "Updating crates.io index"
+cargo update 2>&1 | sed '/crates.io index/d' | \
+    tee -a cargo_update.log
+echo -e "\nlibrary dependencies:" >> cargo_update.log
+cargo update --manifest-path library/Cargo.toml 2>&1 | sed '/crates.io index/d' | \
+    tee -a cargo_update.log
+echo -e "\nrustbook dependencies:" >> cargo_update.log
+cargo update --manifest-path src/tools/rustbook/Cargo.toml 2>&1 | sed '/crates.io index/d' | \
+    tee -a cargo_update.log

--- a/tests/codegen-llvm/gpu_offload/gpu_host.rs
+++ b/tests/codegen-llvm/gpu_offload/gpu_host.rs
@@ -104,3 +104,5 @@ pub fn _kernel_1(x: &mut [f32; 256]) {
 // CHECK-NEXT:   call void @__tgt_unregister_lib(ptr nonnull %EmptyDesc)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
+
+// CHECK: !{i32 7, !"openmp", i32 51}

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
@@ -384,7 +384,7 @@ error: derive(Diagnostic): diagnostic slug not specified
 LL | #[lint(no_crate_example, code = E0123)]
    | ^
    |
-   = help: specify the slug as the first argument to the attribute, such as `#[diag(compiletest_example)]`
+   = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: derive(Diagnostic): attribute specified multiple times
   --> $DIR/diagnostic-derive.rs:613:53

--- a/tests/ui/lint/unused/unused_assignments_across_match_guards.rs
+++ b/tests/ui/lint/unused/unused_assignments_across_match_guards.rs
@@ -1,0 +1,19 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/138069>
+// This test ensures that unused_assignments does not report assignments used in a match.
+//@ check-pass
+
+fn pnk(x: usize) -> &'static str {
+    let mut k1 = "k1";
+    let mut h1 = "h1";
+    match x & 3 {
+        3 if { k1 = "unused?"; false } => (),
+        _ if { h1 = k1; true } => (),
+        _ => (),
+    }
+    h1
+}
+
+#[deny(unused_assignments)]
+fn main() {
+    pnk(3);
+}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#151071 (Generate openmp metadata)
 - rust-lang/rust#151302 (add lint test)
 - rust-lang/rust#151338 (Factor out diagnostic slug checking from `DiagnosticDerive` )
 - rust-lang/rust#151354 (ci: Move lockfile updates to a script)

r? @ghost

<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=151071,151302,151338,151354)
<!-- homu-ignore:end -->

