### PR TITLE
add test for issue 61463

### DIFF
--- a/tests/ui/reserved/meta-is-not-reserved.rs
+++ b/tests/ui/reserved/meta-is-not-reserved.rs
@@ -1,0 +1,7 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/61463>
+// A test for the issue where the variable meta is mistakenly treated as a reserved keyword.
+
+fn main() {
+    let xyz = meta;
+    //~^ ERROR cannot find value `meta` in this scope [E0425]
+}

--- a/tests/ui/reserved/meta-is-not-reserved.stderr
+++ b/tests/ui/reserved/meta-is-not-reserved.stderr
@@ -1,0 +1,9 @@
+error[E0425]: cannot find value `meta` in this scope
+  --> $DIR/meta-is-not-reserved.rs:5:15
+   |
+LL |     let xyz = meta;
+   |               ^^^^ not found in this scope
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
A test for the issue where the variable meta is mistakenly treated as a reserved keyword.

close rust-lang/rust#61463 
