### PR TITLE
Add interior-mutability suggestion to `static_mut_refs`

### DIFF
--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -2669,6 +2669,12 @@ pub(crate) struct RefOfMutStatic<'a> {
         "mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives"
     )]
     pub mut_note: bool,
+    #[help(
+        "use a type that relies on \"interior mutability\" instead; to read more on this, visit <https://doc.rust-lang.org/reference/interior-mutability.html>"
+    )]
+    pub interior_mutability_help: bool,
+    #[subdiagnostic]
+    pub interior_mutability_sugg: Option<StaticMutRefsInteriorMutabilitySugg>,
 }
 
 #[derive(Subdiagnostic)]
@@ -2691,6 +2697,18 @@ pub(crate) enum MutRefSugg {
         #[suggestion_part(code = "&raw mut ")]
         span: Span,
     },
+}
+
+#[derive(Subdiagnostic)]
+#[suggestion(
+    "this type already provides \"interior mutability\", so its binding doesn't need to be declared as mutable",
+    style = "verbose",
+    applicability = "maybe-incorrect",
+    code = ""
+)]
+pub(crate) struct StaticMutRefsInteriorMutabilitySugg {
+    #[primary_span]
+    pub span: Span,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_lint/src/static_mut_refs.rs
+++ b/compiler/rustc_lint/src/static_mut_refs.rs
@@ -214,7 +214,7 @@ fn interior_mutability_suggestion(
 
     let sugg =
         static_mutability_span(cx, def_id).map(|span| StaticMutRefsInteriorMutabilitySugg { span });
-    (true, sugg)
+    (sugg.is_none(), sugg)
 }
 
 fn static_mutability_span(cx: &LateContext<'_>, def_id: DefId) -> Option<Span> {

--- a/compiler/rustc_lint/src/static_mut_refs.rs
+++ b/compiler/rustc_lint/src/static_mut_refs.rs
@@ -201,6 +201,10 @@ fn emit_static_mut_refs(
     );
 }
 
+// FIXME: This builds suggestion spans by handcrafting from source text.
+// Replace this with HIR-based handling once we can identify the `mut` token
+// in the static declaration that way.
+// Context: https://github.com/rust-lang/rust/pull/151362/changes#r3210767018
 fn interior_mutability_suggestion(
     cx: &LateContext<'_>,
     def_id: DefId,

--- a/tests/ui/lint/static-mut-refs-interior-mutability-no-sugg.rs
+++ b/tests/ui/lint/static-mut-refs-interior-mutability-no-sugg.rs
@@ -1,0 +1,18 @@
+//@ edition:2024
+// Ensure that we don't make structured suggestions for interior mutability note
+// when span is not available.
+
+use std::sync::Mutex;
+
+macro_rules! declare_mutex {
+    () => {
+        static mut MACRO_MUTEX: Mutex<bool> = Mutex::new(false);
+    };
+}
+
+declare_mutex!();
+
+fn main() {
+    let _lock = unsafe { MACRO_MUTEX.lock().unwrap() };
+    //~^ ERROR creating a shared reference to mutable static [static_mut_refs]
+}

--- a/tests/ui/lint/static-mut-refs-interior-mutability-no-sugg.stderr
+++ b/tests/ui/lint/static-mut-refs-interior-mutability-no-sugg.stderr
@@ -1,0 +1,13 @@
+error: creating a shared reference to mutable static
+  --> $DIR/static-mut-refs-interior-mutability-no-sugg.rs:16:26
+   |
+LL |     let _lock = unsafe { MACRO_MUTEX.lock().unwrap() };
+   |                          ^^^^^^^^^^^^^^^^^^ shared reference to mutable static
+   |
+   = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
+   = help: use a type that relies on "interior mutability" instead; to read more on this, visit <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
+   = note: `#[deny(static_mut_refs)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/lint/static-mut-refs-interior-mutability.fixed
+++ b/tests/ui/lint/static-mut-refs-interior-mutability.fixed
@@ -1,0 +1,13 @@
+//@ edition:2024
+//@ run-rustfix
+
+#![allow(unused_unsafe)]
+
+use std::sync::Mutex;
+
+static STDINOUT_MUTEX: Mutex<bool> = Mutex::new(false);
+
+fn main() {
+    let _lock = unsafe { STDINOUT_MUTEX.lock().unwrap() };
+    //~^ ERROR creating a shared reference to mutable static [static_mut_refs]
+}

--- a/tests/ui/lint/static-mut-refs-interior-mutability.rs
+++ b/tests/ui/lint/static-mut-refs-interior-mutability.rs
@@ -1,0 +1,13 @@
+//@ edition:2024
+//@ run-rustfix
+
+#![allow(unused_unsafe)]
+
+use std::sync::Mutex;
+
+static mut STDINOUT_MUTEX: Mutex<bool> = Mutex::new(false);
+
+fn main() {
+    let _lock = unsafe { STDINOUT_MUTEX.lock().unwrap() };
+    //~^ ERROR creating a shared reference to mutable static [static_mut_refs]
+}

--- a/tests/ui/lint/static-mut-refs-interior-mutability.stderr
+++ b/tests/ui/lint/static-mut-refs-interior-mutability.stderr
@@ -1,0 +1,18 @@
+error: creating a shared reference to mutable static
+  --> $DIR/static-mut-refs-interior-mutability.rs:11:26
+   |
+LL |     let _lock = unsafe { STDINOUT_MUTEX.lock().unwrap() };
+   |                          ^^^^^^^^^^^^^^^^^^^^^ shared reference to mutable static
+   |
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
+   = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
+   = help: use a type that relies on "interior mutability" instead; to read more on this, visit <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: `#[deny(static_mut_refs)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
+help: this type already provides "interior mutability", so its binding doesn't need to be declared as mutable
+   |
+LL - static mut STDINOUT_MUTEX: Mutex<bool> = Mutex::new(false);
+LL + static STDINOUT_MUTEX: Mutex<bool> = Mutex::new(false);
+   |
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/lint/static-mut-refs-interior-mutability.stderr
+++ b/tests/ui/lint/static-mut-refs-interior-mutability.stderr
@@ -4,9 +4,8 @@ error: creating a shared reference to mutable static
 LL |     let _lock = unsafe { STDINOUT_MUTEX.lock().unwrap() };
    |                          ^^^^^^^^^^^^^^^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
-   = help: use a type that relies on "interior mutability" instead; to read more on this, visit <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: `#[deny(static_mut_refs)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: this type already provides "interior mutability", so its binding doesn't need to be declared as mutable
    |

--- a/tests/ui/statics/static-lazy-init-with-arena-set.stderr
+++ b/tests/ui/statics/static-lazy-init-with-arena-set.stderr
@@ -10,8 +10,14 @@ LL | |             });
    | |______________^ shared reference to mutable static
    |
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
+   = help: use a type that relies on "interior mutability" instead; to read more on this, visit <https://doc.rust-lang.org/reference/interior-mutability.html>
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: `#[warn(static_mut_refs)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+help: this type already provides "interior mutability", so its binding doesn't need to be declared as mutable
+   |
+LL -             static mut ONCE: Once = Once::new();
+LL +             static ONCE: Once = Once::new();
+   |
 
 warning: 1 warning emitted
 

--- a/tests/ui/statics/static-lazy-init-with-arena-set.stderr
+++ b/tests/ui/statics/static-lazy-init-with-arena-set.stderr
@@ -10,7 +10,6 @@ LL | |             });
    | |______________^ shared reference to mutable static
    |
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
-   = help: use a type that relies on "interior mutability" instead; to read more on this, visit <https://doc.rust-lang.org/reference/interior-mutability.html>
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: `#[warn(static_mut_refs)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: this type already provides "interior mutability", so its binding doesn't need to be declared as mutable


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/151362)*
<!-- homu-ignore:end -->

Closes https://github.com/rust-lang/rust/issues/151131
r? @estebank 

I've skipped to expand catching below code as a mutable _reference_ shouldn't be involved (maybe a new lint would be needed?):
```rs
static mut COUNTER: u64 = 0;
fn main() {
    unsafe { COUNTER = 1 };
}
```
