### PR TITLE
Fix an ICE on transmute goals with placeholders in `param_env`

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -659,7 +659,7 @@ where
         }
 
         // `rustc_transmute` does not have support for type or const params
-        if goal.has_non_region_placeholders() {
+        if goal.predicate.has_non_region_placeholders() {
             return Err(NoSolution);
         }
 

--- a/tests/ui/transmutability/transmute-with-type-params.rs
+++ b/tests/ui/transmutability/transmute-with-type-params.rs
@@ -1,0 +1,21 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@ [next] compile-flags: -Znext-solver
+//@ check-pass
+
+// A regression test for https://github.com/rust-lang/rust/issues/151300
+
+#![feature(transmutability)]
+use std::mem::TransmuteFrom;
+
+pub fn is_maybe_transmutable<Src, Dst>()
+where
+    Dst: TransmuteFrom<Src>,
+{
+}
+
+fn function_with_generic<T>() {
+    is_maybe_transmutable::<(), ()>();
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes rust-lang/rust#151300 

The next solver short-circuits `consider_builtin_transmute_candidate` when the goal contains non-region placeholders, since `rustc_transmute` does not support type parameters.
However, this check should likely be refined to apply only to the predicate itself: excess bounds with type params in the param env can cause the goal to be rejected even when its predicate trivially holds.

r? types