### PR TITLE
Fix terminal  width dependent tests

### DIFF
--- a/src/doc/rustc-dev-guide/src/tests/ui.md
+++ b/src/doc/rustc-dev-guide/src/tests/ui.md
@@ -139,6 +139,10 @@ prefixing each source line are replaced with `LL`). In extremely rare
 situations, this mode can be disabled with the directive `//@
 compile-flags: -Z ui-testing=no`.
 
+When using `-Z ui-testing=no` the `--diagnostic-width` argument should also
+be set to avoid tests failing or passing depending on the width of the terminal
+from which the UI test suite is being run.
+
 Note: The line and column numbers for `-->` lines pointing to the test are *not*
 normalized, and left as-is. This ensures that the compiler continues to point to
 the correct location, and keeps the stderr files readable. Ideally all

--- a/tests/ui/compiletest-self-test/ui-testing-optout.rs
+++ b/tests/ui/compiletest-self-test/ui-testing-optout.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Z ui-testing=no
+//@ compile-flags: -Z ui-testing=no --diagnostic-width=80
 
 // Line number < 10
 type A = B; //~ ERROR

--- a/tests/ui/consts/missing_span_in_backtrace.rs
+++ b/tests/ui/consts/missing_span_in_backtrace.rs
@@ -1,6 +1,6 @@
 //! Check what happens when the error occurs inside a std function that we can't print the span of.
 //@ ignore-backends: gcc
-//@ compile-flags: -Z ui-testing=no
+//@ compile-flags: -Z ui-testing=no --diagnostic-width=80
 
 use std::{
     mem::{self, MaybeUninit},

--- a/tests/ui/consts/missing_span_in_backtrace.stderr
+++ b/tests/ui/consts/missing_span_in_backtrace.stderr
@@ -1,12 +1,12 @@
 error[E0080]: memory access failed: attempting to access 1 byte, but got ALLOC0+0x4 which is at or beyond the end of the allocation of size 4 bytes
   --> $DIR/missing_span_in_backtrace.rs:16:9
    |
-16 | /         ptr::swap_nonoverlapping(
-17 | |             &mut x1 as *mut _ as *mut MaybeUninit<u8>,
-18 | |             &mut x2 as *mut _ as *mut MaybeUninit<u8>,
-19 | |             10,
-20 | |         );
-   | |_________^ evaluation of `X` failed inside this call
+16 | / ...   ptr::swap_nonoverlapping(
+17 | | ...       &mut x1 as *mut _ as *mut MaybeUninit<u8>,
+18 | | ...       &mut x2 as *mut _ as *mut MaybeUninit<u8>,
+19 | | ...       10,
+20 | | ...   );
+   | |_______^ evaluation of `X` failed inside this call
    |
 note: inside `swap_nonoverlapping::compiletime::<MaybeUninit<u8>>`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL

--- a/tests/ui/error-emitter/trimmed_multiline_suggestion.rs
+++ b/tests/ui/error-emitter/trimmed_multiline_suggestion.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Z ui-testing=no
+//@ compile-flags: -Z ui-testing=no --diagnostic-width=80
 fn function_with_lots_of_arguments(a: i32, b: char, c: i32, d: i32, e: i32, f: i32) {}
 
 fn main() {

--- a/tests/ui/error-emitter/trimmed_multiline_suggestion.stderr
+++ b/tests/ui/error-emitter/trimmed_multiline_suggestion.stderr
@@ -10,7 +10,7 @@ error[E0061]: this function takes 6 arguments but 5 arguments were supplied
 note: function defined here
  --> $DIR/trimmed_multiline_suggestion.rs:2:4
   |
-2 | fn function_with_lots_of_arguments(a: i32, b: char, c: i32, d: i32, e: i32, f: i32) {}
+2 | fn function_with_lots_of_arguments(a: i32, b: char, c: i32, d: i32, e: i3...
   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^         -------
 help: provide the argument
   |

--- a/tests/ui/modules/issue-107649.rs
+++ b/tests/ui/modules/issue-107649.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Z ui-testing=no
+//@ compile-flags: -Z ui-testing=no --diagnostic-width=80
 #[path = "auxiliary/dummy_lib.rs"]
 mod lib;
 

--- a/tests/ui/span/issue-71363.rs
+++ b/tests/ui/span/issue-71363.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Z ui-testing=no
+//@ compile-flags: -Z ui-testing=no --diagnostic-width=80
 
 struct MyError;
 impl std::error::Error for MyError {}


### PR DESCRIPTION
[#t-compiler > What is -Zui-testing=no and why are we using it](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/What.20is.20-Zui-testing.3Dno.20and.20why.20are.20we.20using.20it/with/568842970)

See zulip thread. I've verified locally that this lets me run the ui test suite without problems even with a very thin terminal :laughing: