### PR TITLE
Stabilize `VecDeque::retain_back` from `truncate_front`

### DIFF
--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -1366,6 +1366,7 @@ impl<T, A: Allocator> VecDeque<T, A> {
     /// buf.truncate(1);
     /// assert_eq!(buf, [5]);
     /// ```
+    #[doc(alias = "retain_front")]
     #[stable(feature = "deque_extras", since = "1.16.0")]
     pub fn truncate(&mut self, len: usize) {
         /// Runs the destructor for all items in the slice when it gets dropped (normally or
@@ -1420,7 +1421,6 @@ impl<T, A: Allocator> VecDeque<T, A> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(vec_deque_truncate_front)]
     /// use std::collections::VecDeque;
     ///
     /// let mut buf = VecDeque::new();
@@ -1429,11 +1429,12 @@ impl<T, A: Allocator> VecDeque<T, A> {
     /// buf.push_front(15);
     /// assert_eq!(buf, [15, 10, 5]);
     /// assert_eq!(buf.as_slices(), (&[15, 10, 5][..], &[][..]));
-    /// buf.truncate_front(1);
+    /// buf.retain_back(1);
     /// assert_eq!(buf.as_slices(), (&[5][..], &[][..]));
     /// ```
-    #[unstable(feature = "vec_deque_truncate_front", issue = "140667")]
-    pub fn truncate_front(&mut self, len: usize) {
+    #[doc(alias = "truncate_front")]
+    #[stable(feature = "vec_deque_truncate_front", since = "CURRENT_RUSTC_VERSION")]
+    pub fn retain_back(&mut self, len: usize) {
         /// Runs the destructor for all items in the slice when it gets dropped (normally or
         /// during unwinding).
         struct Dropper<'a, T>(&'a mut [T]);

--- a/library/alloctests/tests/lib.rs
+++ b/library/alloctests/tests/lib.rs
@@ -36,7 +36,6 @@
 #![feature(str_as_str)]
 #![feature(strict_provenance_lints)]
 #![feature(string_replace_in_place)]
-#![feature(vec_deque_truncate_front)]
 #![feature(unique_rc_arc)]
 #![feature(macro_metavar_expr_concat)]
 #![feature(vec_peek_mut)]

--- a/library/alloctests/tests/vec_deque.rs
+++ b/library/alloctests/tests/vec_deque.rs
@@ -1635,7 +1635,7 @@ fn truncate_leak() {
 
 #[test]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
-fn truncate_front_leak() {
+fn retain_back_leak() {
     struct_with_counted_drop!(D(bool), DROPS => |this: &D| if this.0 { panic!("panic in `drop`"); } );
 
     let mut q = VecDeque::new();
@@ -1648,7 +1648,7 @@ fn truncate_front_leak() {
     q.push_front(D(false));
     q.push_front(D(false));
 
-    catch_unwind(AssertUnwindSafe(|| q.truncate_front(1))).ok();
+    catch_unwind(AssertUnwindSafe(|| q.retain_back(1))).ok();
 
     assert_eq!(DROPS.get(), 7);
 }
@@ -1817,20 +1817,20 @@ fn test_collect_from_into_iter_keeps_allocation() {
 }
 
 #[test]
-fn test_truncate_front() {
+fn test_retain_back() {
     let mut v = VecDeque::with_capacity(13);
     v.extend(0..7);
     assert_eq!(v.as_slices(), ([0, 1, 2, 3, 4, 5, 6].as_slice(), [].as_slice()));
-    v.truncate_front(10);
+    v.retain_back(10);
     assert_eq!(v.len(), 7);
     assert_eq!(v.as_slices(), ([0, 1, 2, 3, 4, 5, 6].as_slice(), [].as_slice()));
-    v.truncate_front(7);
+    v.retain_back(7);
     assert_eq!(v.len(), 7);
     assert_eq!(v.as_slices(), ([0, 1, 2, 3, 4, 5, 6].as_slice(), [].as_slice()));
-    v.truncate_front(3);
+    v.retain_back(3);
     assert_eq!(v.as_slices(), ([4, 5, 6].as_slice(), [].as_slice()));
     assert_eq!(v.len(), 3);
-    v.truncate_front(0);
+    v.retain_back(0);
     assert_eq!(v.as_slices(), ([].as_slice(), [].as_slice()));
     assert_eq!(v.len(), 0);
 
@@ -1841,13 +1841,13 @@ fn test_truncate_front() {
     v.push_front(8);
     v.push_front(7);
     assert_eq!(v.as_slices(), ([7, 8, 9].as_slice(), [0, 1, 2, 3, 4, 5, 6].as_slice()));
-    v.truncate_front(12);
+    v.retain_back(12);
     assert_eq!(v.as_slices(), ([7, 8, 9].as_slice(), [0, 1, 2, 3, 4, 5, 6].as_slice()));
-    v.truncate_front(10);
+    v.retain_back(10);
     assert_eq!(v.as_slices(), ([7, 8, 9].as_slice(), [0, 1, 2, 3, 4, 5, 6].as_slice()));
-    v.truncate_front(8);
+    v.retain_back(8);
     assert_eq!(v.as_slices(), ([9].as_slice(), [0, 1, 2, 3, 4, 5, 6].as_slice()));
-    v.truncate_front(5);
+    v.retain_back(5);
     assert_eq!(v.as_slices(), ([2, 3, 4, 5, 6].as_slice(), [].as_slice()));
 }
 
@@ -1855,7 +1855,7 @@ fn test_truncate_front() {
 fn test_extend_from_within() {
     let mut v = VecDeque::with_capacity(8);
     v.extend(0..6);
-    v.truncate_front(4);
+    v.retain_back(4);
     assert_eq!(v, [2, 3, 4, 5]);
     v.extend_from_within(1..4);
     assert_eq!(v, [2, 3, 4, 5, 3, 4, 5]);
@@ -1915,7 +1915,7 @@ fn test_extend_from_within_clone() {
         panic: false,
     }));
     // remove the dummy elements
-    v.truncate_front(4);
+    v.retain_back(4);
     assert_eq!(v.iter().map(|tr| tr.id).collect::<Vec<_>>(), [0, 1, 2, 3]);
 
     v.extend_from_within(2..);
@@ -1947,7 +1947,7 @@ fn test_extend_from_within_clone_panic() {
         panic: false,
     }));
     // remove the dummy elements
-    v.truncate_front(4);
+    v.retain_back(4);
     assert_eq!(v.iter().map(|tr| tr.id).collect::<Vec<_>>(), [0, 1, 2, 3]);
 
     // panic after wrapping
@@ -1963,7 +1963,7 @@ fn test_extend_from_within_clone_panic() {
     // nothing should have been dropped
     assert_eq!(drop_count.get(), 0);
 
-    v.truncate_front(2);
+    v.retain_back(2);
     assert_eq!(drop_count.get(), 4);
     assert_eq!(v.iter().map(|tr| tr.id).collect::<Vec<_>>(), [0, 1]);
 
@@ -1985,7 +1985,7 @@ fn test_extend_from_within_clone_panic() {
 fn test_prepend_from_within() {
     let mut v = VecDeque::with_capacity(8);
     v.extend(0..6);
-    v.truncate_front(4);
+    v.retain_back(4);
     v.prepend_from_within(..=0);
     assert_eq!(v.as_slices(), ([2, 2, 3, 4, 5].as_slice(), [].as_slice()));
     v.prepend_from_within(2..);
@@ -2007,7 +2007,7 @@ fn test_prepend_from_within_clone() {
         panic: false,
     }));
     // remove the dummy elements
-    v.truncate_front(4);
+    v.retain_back(4);
     assert_eq!(v.iter().map(|tr| tr.id).collect::<Vec<_>>(), [0, 1, 2, 3]);
 
     v.prepend_from_within(..2);
@@ -2034,7 +2034,7 @@ fn test_prepend_from_within_clone_panic() {
         panic: false,
     }));
     // remove the dummy elements
-    v.truncate_front(4);
+    v.retain_back(4);
     assert_eq!(v.iter().map(|tr| tr.id).collect::<Vec<_>>(), [0, 1, 2, 3]);
 
     // panic after wrapping
@@ -2050,7 +2050,7 @@ fn test_prepend_from_within_clone_panic() {
     // nothing should have been dropped
     assert_eq!(drop_count.get(), 0);
 
-    v.truncate_front(2);
+    v.retain_back(2);
     assert_eq!(drop_count.get(), 4);
     assert_eq!(v.iter().map(|tr| tr.id).collect::<Vec<_>>(), [2, 3]);
 
@@ -2071,7 +2071,7 @@ fn test_prepend_from_within_clone_panic() {
 #[test]
 fn test_extend_and_prepend_from_within() {
     let mut v = ('0'..='9').map(String::from).collect::<VecDeque<_>>();
-    v.truncate_front(5);
+    v.retain_back(5);
     v.extend_from_within(4..);
     v.prepend_from_within(..2);
     assert_eq!(v.iter().map(|s| &**s).collect::<String>(), "56567899");
@@ -2095,7 +2095,7 @@ fn test_extend_front() {
     let mut v = VecDeque::with_capacity(8);
     let cap = v.capacity();
     v.extend(0..4);
-    v.truncate_front(2);
+    v.retain_back(2);
     v.extend_front(4..8);
     assert_eq!(v.as_slices(), ([7, 6].as_slice(), [5, 4, 2, 3].as_slice()));
     assert_eq!(v.capacity(), cap);


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/151379)*
<!-- homu-ignore:end -->

Tracking issue: rust-lang/rust#140667
Closes: rust-lang/rust#140667

@rustbot label -T-libs +T-libs-api +needs-fcp +S-waiting-on-fcp

r? t-libs-api

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
