### PR TITLE
Only run finalizers of accepted attributes

### DIFF
--- a/tests/pretty/delegation-inherit-attributes.pp
+++ b/tests/pretty/delegation-inherit-attributes.pp
@@ -21,8 +21,8 @@ mod to_reuse {
     #[attr = Cold]
     fn foo_no_reason(x: usize) -> usize { x }
 
-    #[attr = Deprecation {deprecation: Deprecation {since: Unspecified}}]
     #[attr = Cold]
+    #[attr = Deprecation {deprecation: Deprecation {since: Unspecified}}]
     fn bar(x: usize) -> usize { x }
 }
 

--- a/tests/pretty/delegation-inline-attribute.pp
+++ b/tests/pretty/delegation-inline-attribute.pp
@@ -44,9 +44,9 @@ impl Trait for S {
                 fn foo0(arg0: _) -> _ { to_reuse::foo(self + 1) }
 
                 // Check that #[inline(hint)] is added when other attributes present in inner reuse
-                #[attr = Deprecation {deprecation: Deprecation {since: Unspecified}}]
-                #[attr = MustUse]
                 #[attr = Cold]
+                #[attr = MustUse]
+                #[attr = Deprecation {deprecation: Deprecation {since: Unspecified}}]
                 #[attr = Inline(Hint)]
                 fn foo1(arg0: _) -> _ { to_reuse::foo(self / 2) }
 
@@ -59,18 +59,18 @@ impl Trait for S {
                 fn foo3(arg0: _) -> _ { to_reuse::foo(self / 2) }
 
                 // Check that #[inline(never)] is preserved when there are other attributes in inner reuse
-                #[attr = Deprecation {deprecation: Deprecation {since: Unspecified}}]
-                #[attr = Inline(Never)]
-                #[attr = MustUse]
                 #[attr = Cold]
+                #[attr = MustUse]
+                #[attr = Inline(Never)]
+                #[attr = Deprecation {deprecation: Deprecation {since: Unspecified}}]
                 fn foo4(arg0: _) -> _ { to_reuse::foo(self / 2) }
             }.foo()
     }
 
     // Check that #[inline(hint)] is added when there are other attributes present in trait reuse
-    #[attr = Deprecation {deprecation: Deprecation {since: Unspecified}}]
-    #[attr = MustUse]
     #[attr = Cold]
+    #[attr = MustUse]
+    #[attr = Deprecation {deprecation: Deprecation {since: Unspecified}}]
     #[attr = Inline(Hint)]
     fn foo1(self: _) -> _ { self.0.foo1() }
 
@@ -83,10 +83,10 @@ impl Trait for S {
     fn foo3(self: _) -> _ { self.0.foo3() }
 
     // Check that #[inline(never)] is preserved when there are other attributes in trait reuse
-    #[attr = Deprecation {deprecation: Deprecation {since: Unspecified}}]
-    #[attr = Inline(Never)]
-    #[attr = MustUse]
     #[attr = Cold]
+    #[attr = MustUse]
+    #[attr = Inline(Never)]
+    #[attr = Deprecation {deprecation: Deprecation {since: Unspecified}}]
     fn foo4(self: _) -> _ { self.0.foo4() }
 }
 

--- a/tests/ui/feature-gates/unstable-attribute-rejects-already-stable-features.stderr
+++ b/tests/ui/feature-gates/unstable-attribute-rejects-already-stable-features.stderr
@@ -1,18 +1,4 @@
 error: can't mark as unstable using an already stable feature
-  --> $DIR/unstable-attribute-rejects-already-stable-features.rs:7:1
-   |
-LL | #[rustc_const_unstable(feature = "arbitrary_enum_discriminant", issue = "42")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this feature is already stable
-LL | const fn my_fun() {}
-   | -------------------- the stability attribute annotates this item
-   |
-help: consider removing the attribute
-  --> $DIR/unstable-attribute-rejects-already-stable-features.rs:7:1
-   |
-LL | #[rustc_const_unstable(feature = "arbitrary_enum_discriminant", issue = "42")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: can't mark as unstable using an already stable feature
   --> $DIR/unstable-attribute-rejects-already-stable-features.rs:6:1
    |
 LL | #[unstable(feature = "arbitrary_enum_discriminant", issue = "42")]
@@ -26,6 +12,20 @@ help: consider removing the attribute
    |
 LL | #[unstable(feature = "arbitrary_enum_discriminant", issue = "42")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: can't mark as unstable using an already stable feature
+  --> $DIR/unstable-attribute-rejects-already-stable-features.rs:7:1
+   |
+LL | #[rustc_const_unstable(feature = "arbitrary_enum_discriminant", issue = "42")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this feature is already stable
+LL | const fn my_fun() {}
+   | -------------------- the stability attribute annotates this item
+   |
+help: consider removing the attribute
+  --> $DIR/unstable-attribute-rejects-already-stable-features.rs:7:1
+   |
+LL | #[rustc_const_unstable(feature = "arbitrary_enum_discriminant", issue = "42")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/loop-match/invalid-attribute.stderr
+++ b/tests/ui/loop-match/invalid-attribute.stderr
@@ -94,14 +94,6 @@ LL |     #[const_continue]
    |
    = help: `#[const_continue]` can be applied to 
 
-error: `#[const_continue]` should be applied to a break expression
-  --> $DIR/invalid-attribute.rs:40:9
-   |
-LL |         #[const_continue]
-   |         ^^^^^^^^^^^^^^^^^
-LL |         5
-   |         - not a break expression
-
 error: `#[loop_match]` should be applied to a loop
   --> $DIR/invalid-attribute.rs:39:9
    |
@@ -110,6 +102,14 @@ LL |         #[loop_match]
 LL |         #[const_continue]
 LL |         5
    |         - not a loop
+
+error: `#[const_continue]` should be applied to a break expression
+  --> $DIR/invalid-attribute.rs:40:9
+   |
+LL |         #[const_continue]
+   |         ^^^^^^^^^^^^^^^^^
+LL |         5
+   |         - not a break expression
 
 error: aborting due to 14 previous errors
 


### PR DESCRIPTION
Locally this had insanely good perf, but lets see what reality thinks about this
r? @jdonszelmann 

Attribute parsing consists of two stages:

- All attribute are "accepted" by one or more parsers, which means the unparsed attribute is parsed, information about it is stored in the attr parser struct
- After all attributes are parsed, we "finalize" all parsers, producing a single parsed attribute representation from the parser struct.

This two-stage process exist so multiple attributes can get merged into one parser representation. For example if you have two repr attributes `#[repr(C)]` `#[repr(packed)]` it will only produce one parsed `Repr` attribue.

The dumb thing we did was we would "finalize" all parsers, even the ones that never accepted an attribute. This PR only calls finalize on the parsers that accepted at least one attribute.
