### PR TITLE
remove `#[deprecated]` from unstable & internal `SipHasher13` and `24` types

### DIFF
--- a/library/alloctests/tests/c_str2.rs
+++ b/library/alloctests/tests/c_str2.rs
@@ -3,9 +3,7 @@ use alloc::rc::Rc;
 use alloc::sync::Arc;
 use core::assert_matches::assert_matches;
 use core::ffi::{CStr, FromBytesUntilNulError, c_char};
-#[allow(deprecated)]
-use core::hash::SipHasher13 as DefaultHasher;
-use core::hash::{Hash, Hasher};
+use core::hash::{Hash, Hasher, SipHasher13 as DefaultHasher};
 
 #[test]
 fn c_to_rust() {
@@ -57,11 +55,9 @@ fn equal_hash() {
     let ptr = data.as_ptr() as *const c_char;
     let cstr: &'static CStr = unsafe { CStr::from_ptr(ptr) };
 
-    #[allow(deprecated)]
     let mut s = DefaultHasher::new();
     cstr.hash(&mut s);
     let cstr_hash = s.finish();
-    #[allow(deprecated)]
     let mut s = DefaultHasher::new();
     CString::new(&data[..data.len() - 1]).unwrap().hash(&mut s);
     let cstring_hash = s.finish();

--- a/library/core/src/hash/mod.rs
+++ b/library/core/src/hash/mod.rs
@@ -87,7 +87,6 @@
 #[allow(deprecated)]
 pub use self::sip::SipHasher;
 #[unstable(feature = "hashmap_internals", issue = "none")]
-#[allow(deprecated)]
 #[doc(hidden)]
 pub use self::sip::SipHasher13;
 use crate::{fmt, marker};

--- a/library/core/src/hash/sip.rs
+++ b/library/core/src/hash/sip.rs
@@ -11,8 +11,11 @@ use crate::{cmp, ptr};
 /// (e.g., `collections::HashMap` uses it by default).
 ///
 /// See: <https://github.com/veorq/SipHash>
-#[unstable(feature = "hashmap_internals", issue = "none")]
-#[deprecated(since = "1.13.0", note = "use `std::hash::DefaultHasher` instead")]
+#[unstable(
+    feature = "hashmap_internals",
+    issue = "none",
+    reason = "use `std::hash::DefaultHasher` instead"
+)]
 #[derive(Debug, Clone, Default)]
 #[doc(hidden)]
 pub struct SipHasher13 {
@@ -23,7 +26,6 @@ pub struct SipHasher13 {
 ///
 /// See: <https://github.com/veorq/SipHash>
 #[unstable(feature = "hashmap_internals", issue = "none")]
-#[deprecated(since = "1.13.0", note = "use `std::hash::DefaultHasher` instead")]
 #[derive(Debug, Clone, Default)]
 struct SipHasher24 {
     hasher: Hasher<Sip24Rounds>,
@@ -137,8 +139,7 @@ unsafe fn u8to64_le(buf: &[u8], start: usize, len: usize) -> u64 {
         out |= (unsafe { *buf.get_unchecked(start + i) } as u64) << (i * 8);
         i += 1;
     }
-    //FIXME(fee1-dead): use debug_assert_eq
-    debug_assert!(i == len);
+    debug_assert_eq!(i, len);
     out
 }
 
@@ -167,7 +168,6 @@ impl SipHasher13 {
     #[inline]
     #[unstable(feature = "hashmap_internals", issue = "none")]
     #[rustc_const_unstable(feature = "const_default", issue = "143894")]
-    #[deprecated(since = "1.13.0", note = "use `std::hash::DefaultHasher` instead")]
     pub const fn new() -> SipHasher13 {
         SipHasher13::new_with_keys(0, 0)
     }
@@ -176,7 +176,6 @@ impl SipHasher13 {
     #[inline]
     #[unstable(feature = "hashmap_internals", issue = "none")]
     #[rustc_const_unstable(feature = "const_default", issue = "143894")]
-    #[deprecated(since = "1.13.0", note = "use `std::hash::DefaultHasher` instead")]
     pub const fn new_with_keys(key0: u64, key1: u64) -> SipHasher13 {
         SipHasher13 { hasher: Hasher::new_with_keys(key0, key1) }
     }

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1354,7 +1354,7 @@ impl<T, E> Result<T, E> {
     /// let s: String = only_good_news().into_ok();
     /// println!("{s}");
     /// ```
-    #[unstable(feature = "unwrap_infallible", reason = "newly added", issue = "61695")]
+    #[unstable(feature = "unwrap_infallible", issue = "61695")]
     #[inline]
     #[rustc_allow_const_fn_unstable(const_precise_live_drops)]
     #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
@@ -1391,7 +1391,7 @@ impl<T, E> Result<T, E> {
     /// let error: String = only_bad_news().into_err();
     /// println!("{error}");
     /// ```
-    #[unstable(feature = "unwrap_infallible", reason = "newly added", issue = "61695")]
+    #[unstable(feature = "unwrap_infallible", issue = "61695")]
     #[inline]
     #[rustc_allow_const_fn_unstable(const_precise_live_drops)]
     #[rustc_const_unstable(feature = "const_convert", issue = "143773")]

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -2520,7 +2520,7 @@ impl<T> [T] {
     /// )));
     /// assert_eq!(s.split_once(|&x| x == 0), None);
     /// ```
-    #[unstable(feature = "slice_split_once", reason = "newly added", issue = "112811")]
+    #[unstable(feature = "slice_split_once", issue = "112811")]
     #[inline]
     pub fn split_once<F>(&self, pred: F) -> Option<(&[T], &[T])>
     where
@@ -2548,7 +2548,7 @@ impl<T> [T] {
     /// )));
     /// assert_eq!(s.rsplit_once(|&x| x == 0), None);
     /// ```
-    #[unstable(feature = "slice_split_once", reason = "newly added", issue = "112811")]
+    #[unstable(feature = "slice_split_once", issue = "112811")]
     #[inline]
     pub fn rsplit_once<F>(&self, pred: F) -> Option<(&[T], &[T])>
     where

--- a/library/std/src/hash/random.rs
+++ b/library/std/src/hash/random.rs
@@ -7,7 +7,6 @@
 //!
 //! [`collections`]: crate::collections
 
-#[allow(deprecated)]
 use super::{BuildHasher, Hasher, SipHasher13};
 use crate::cell::Cell;
 use crate::fmt;
@@ -81,7 +80,6 @@ impl RandomState {
 impl BuildHasher for RandomState {
     type Hasher = DefaultHasher;
     #[inline]
-    #[allow(deprecated)]
     fn build_hasher(&self) -> DefaultHasher {
         DefaultHasher(SipHasher13::new_with_keys(self.k0, self.k1))
     }
@@ -91,7 +89,6 @@ impl BuildHasher for RandomState {
 ///
 /// The internal algorithm is not specified, and so it and its hashes should
 /// not be relied upon over releases.
-#[allow(deprecated)]
 #[derive(Clone, Debug)]
 #[stable(feature = "hashmap_build_hasher", since = "1.7.0")]
 pub struct DefaultHasher(SipHasher13);
@@ -104,7 +101,6 @@ impl DefaultHasher {
     /// instances created through `new` or `default`.
     #[stable(feature = "hashmap_default_hasher", since = "1.13.0")]
     #[inline]
-    #[allow(deprecated)]
     #[rustc_const_unstable(feature = "const_default", issue = "143894")]
     #[must_use]
     pub const fn new() -> DefaultHasher {

--- a/library/std/tests/env_modify.rs
+++ b/library/std/tests/env_modify.rs
@@ -99,7 +99,6 @@ fn test_env_set_var() {
 
 #[test]
 #[cfg_attr(not(any(unix, windows)), ignore, allow(unused))]
-#[allow(deprecated)]
 fn env_home_dir() {
     use std::path::PathBuf;
 

--- a/library/test/src/term/terminfo/searcher.rs
+++ b/library/test/src/term/terminfo/searcher.rs
@@ -9,7 +9,6 @@ use std::{env, fs};
 mod tests;
 
 /// Returns path to database entry for `term`
-#[allow(deprecated)]
 pub(crate) fn get_dbpath_for_term(term: &str) -> Option<PathBuf> {
     let mut dirs_to_search = Vec::new();
     let first_char = term.chars().next()?;


### PR DESCRIPTION
These types are unstable and `doc(hidden)` (under the internal feature `hashmap_internals`). Deprecating them only adds noise (`#[allow(deprecated)]`) to all places where they are used, so this PR removes the deprecation attributes from them. 

It also includes a few other small cleanups in separate commits, including one I overlooked in rust-lang/rust#151228.