### PR TITLE
rustdoc: more js cleanup

### DIFF
--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -1018,7 +1018,6 @@ function preLoadCss(cssUrl) {
                 }
             }
             const template = document.createElement("template");
-            // @ts-expect-error
             template.innerHTML = text;
 
             onEachLazy(template.content.querySelectorAll("a"), elem => {

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -963,19 +963,19 @@ function preLoadCss(cssUrl) {
         const selfPath = script ? script.getAttribute("data-self-path") : null;
 
         // These sidebar blocks need filled in, too.
-        const mainContent = document.querySelector("#main-content");
-        const sidebarSection = document.querySelector(".sidebar section");
+        const mainContent = nonnull(document.querySelector("#main-content"));
+        const sidebarSection = nonnull(document.querySelector(".sidebar section"));
         let methods = document.querySelector(".sidebar .block.method");
         let associatedTypes = document.querySelector(".sidebar .block.associatedtype");
         let associatedConstants = document.querySelector(".sidebar .block.associatedconstant");
         let sidebarTraitList = document.querySelector(".sidebar .block.trait-implementation");
 
-        // @ts-expect-error
-        for (const impList of imp[window.currentCrate]) {
+        for (const impList of imp[nonnull(window.currentCrate)]) {
             const types = impList.slice(2);
             const text = impList[0];
             const isTrait = impList[1] !== 0;
             const traitName = impList[1];
+            // @ts-expect-error
             if (types.indexOf(selfPath) === -1) {
                 continue;
             }
@@ -999,33 +999,26 @@ function preLoadCss(cssUrl) {
                     h.appendChild(link);
                     trait_implementations = outputList;
                     trait_implementations_header = outputListHeader;
-                    // @ts-expect-error
                     sidebarSection.appendChild(h);
                     sidebarTraitList = document.createElement("ul");
                     sidebarTraitList.className = "block trait-implementation";
-                    // @ts-expect-error
                     sidebarSection.appendChild(sidebarTraitList);
-                    // @ts-expect-error
                     mainContent.appendChild(outputListHeader);
-                    // @ts-expect-error
                     mainContent.appendChild(outputList);
                 } else {
                     implementations = outputList;
                     if (trait_implementations) {
-                        // @ts-expect-error
                         mainContent.insertBefore(outputListHeader, trait_implementations_header);
-                        // @ts-expect-error
                         mainContent.insertBefore(outputList, trait_implementations_header);
                     } else {
-                        const mainContent = document.querySelector("#main-content");
-                        // @ts-expect-error
+                        const mainContent = nonnull(document.querySelector("#main-content"));
                         mainContent.appendChild(outputListHeader);
-                        // @ts-expect-error
                         mainContent.appendChild(outputList);
                     }
                 }
             }
             const template = document.createElement("template");
+            // @ts-expect-error
             template.innerHTML = text;
 
             onEachLazy(template.content.querySelectorAll("a"), elem => {
@@ -1065,8 +1058,8 @@ function preLoadCss(cssUrl) {
             if (isTrait) {
                 const li = document.createElement("li");
                 const a = document.createElement("a");
+                a.href = `#${nonnull(template.content.querySelector(".impl")).id}`;
                 // @ts-expect-error
-                a.href = `#${template.content.querySelector(".impl").id}`;
                 a.textContent = traitName;
                 li.appendChild(a);
                 // @ts-expect-error
@@ -1093,14 +1086,10 @@ function preLoadCss(cssUrl) {
                         const insertionReference = methods || sidebarTraitList;
                         if (insertionReference) {
                             const insertionReferenceH = insertionReference.previousElementSibling;
-                            // @ts-expect-error
                             sidebarSection.insertBefore(blockHeader, insertionReferenceH);
-                            // @ts-expect-error
                             sidebarSection.insertBefore(block, insertionReferenceH);
                         } else {
-                            // @ts-expect-error
                             sidebarSection.appendChild(blockHeader);
-                            // @ts-expect-error
                             sidebarSection.appendChild(block);
                         }
                         if (hasClass(item, "associatedtype")) {

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -619,8 +619,7 @@ function preLoadCss(cssUrl) {
      */
     function openParentDetails(elem) {
         while (elem) {
-            if (elem.tagName === "DETAILS") {
-                // @ts-expect-error
+            if (elem instanceof HTMLDetailsElement) {
                 elem.open = true;
             }
             elem = elem.parentElement;
@@ -656,10 +655,8 @@ function preLoadCss(cssUrl) {
         }
 
         if (document.activeElement &&
-            document.activeElement.tagName === "INPUT" &&
-            // @ts-expect-error
+            document.activeElement instanceof HTMLInputElement &&
             document.activeElement.type !== "checkbox" &&
-            // @ts-expect-error
             document.activeElement.type !== "radio") {
             switch (getVirtualKey(ev)) {
             case "Escape":

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -1011,7 +1011,6 @@ function preLoadCss(cssUrl) {
                         mainContent.insertBefore(outputListHeader, trait_implementations_header);
                         mainContent.insertBefore(outputList, trait_implementations_header);
                     } else {
-                        const mainContent = nonnull(document.querySelector("#main-content"));
                         mainContent.appendChild(outputListHeader);
                         mainContent.appendChild(outputList);
                     }

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -231,7 +231,6 @@ function preLoadCss(cssUrl) {
             // When loading settings.html as a standalone page, the equivalent HTML is
             // generated in context.rs.
             setTimeout(() => {
-                // @ts-expect-error
                 const themes = getVar("themes").split(",");
                 for (const theme of themes) {
                     // if there are no themes, do nothing
@@ -415,12 +414,10 @@ function preLoadCss(cssUrl) {
                     }
                     window.StringdexOnload.push(() => {
                         loadScript(
-                            // @ts-expect-error
                             getVar("static-root-path") + getVar("search-js"),
                             sendSearchForm,
                         );
                     });
-                    // @ts-expect-error
                     loadScript(getVar("static-root-path") + getVar("stringdex-js"), sendSearchForm);
                     loadScript(resourcePath("search.index/root", ".js"), sendSearchForm);
                 }

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -973,8 +973,8 @@ function preLoadCss(cssUrl) {
         for (const impList of imp[nonnull(window.currentCrate)]) {
             const types = impList.slice(2);
             const text = impList[0];
-            const isTrait = impList[1] !== 0;
             const traitName = impList[1];
+            const isTrait = typeof traitName === "string";
             // @ts-expect-error
             if (types.indexOf(selfPath) === -1) {
                 continue;
@@ -1057,7 +1057,6 @@ function preLoadCss(cssUrl) {
                 const li = document.createElement("li");
                 const a = document.createElement("a");
                 a.href = `#${nonnull(template.content.querySelector(".impl")).id}`;
-                // @ts-expect-error
                 a.textContent = traitName;
                 li.appendChild(a);
                 // @ts-expect-error

--- a/src/librustdoc/html/static/js/rustdoc.d.ts
+++ b/src/librustdoc/html/static/js/rustdoc.d.ts
@@ -576,4 +576,16 @@ declare namespace rustdoc {
         "typeNameIdOfHof": number,
         "typeNameIdOfNever": number,
     };
+
+    type VarName = "name"
+        | "root-path"
+        | "static-root-path"
+        | "current-crate"
+        | "themes"
+        | "resource-suffix"
+        | "rustdoc-version"
+        | "channel"
+        | "search-js"
+        | "stringdex-js"
+        | "settings-js";
 }

--- a/src/librustdoc/html/static/js/rustdoc.d.ts
+++ b/src/librustdoc/html/static/js/rustdoc.d.ts
@@ -524,7 +524,8 @@ declare namespace rustdoc {
     }
 
     type TypeImpls = {
-        [cratename: string]: Array<Array<string|0>>
+        /* [text, traitName (0 if not a trait), ...types] */
+        [cratename: string]: Array<[string, string|0, ...string[]]>
     }
 
     /**

--- a/src/librustdoc/html/static/js/storage.js
+++ b/src/librustdoc/html/static/js/storage.js
@@ -298,6 +298,8 @@ const updateTheme = (function() {
     return updateTheme;
 })();
 
+// typescript thinks we're forgetting to call window.matchMedia,
+// but we're checking browser support of media queries.
 // @ts-ignore
 if (getSettingValue("use-system-theme") !== "false" && window.matchMedia) {
     // update the preferred dark theme if the user is already using a dark theme

--- a/src/librustdoc/html/static/js/storage.js
+++ b/src/librustdoc/html/static/js/storage.js
@@ -199,12 +199,16 @@ function getCurrentValue(name) {
  * Get a value from the rustdoc-vars div, which is used to convey data from
  * Rust to the JS. If there is no such element, return null.
  *
- * @param {string} name
- * @returns {string|null}
+ * @param {rustdoc.VarName} name
+ * @returns {string}
  */
 function getVar(name) {
     const el = document.querySelector("head > meta[name='rustdoc-vars']");
-    return el ? el.getAttribute("data-" + name) : null;
+    const v = el ? el.getAttribute("data-" + name) : null;
+    if (v !== null) {
+        return v;
+    }
+    throw `rustdoc var "${name}" is missing`;
 }
 
 /**


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Continuing the effort of removing `@ts-expect-error` from the codebase wherever possible, this time focusing on `main.js`.  Found some oddities with `register_type_impls`, fixed most of them, but the one that I couldn't figure out is what's going on with `sidebarTraitList`.  It's queried, then if there are any trait imps, unconditionally overwritten, then latter code assumes that one of these two things has initialized it, but it's not obvious why this would be the case, or if there's a reason this wasn't done in a more straightforwards way.

r? @GuillaumeGomez 