### PR TITLE
Use `repeat_packed` when calculating layouts in `RawVec`

### DIFF
--- a/library/alloc/src/raw_vec/mod.rs
+++ b/library/alloc/src/raw_vec/mod.rs
@@ -865,9 +865,13 @@ const fn handle_error(e: TryReserveError) -> ! {
 #[inline]
 #[rustc_const_unstable(feature = "const_heap", issue = "79597")]
 const fn layout_array(cap: usize, elem_layout: Layout) -> Result<Layout, TryReserveError> {
+    // This is only used with `elem_layout`s which are those of real rust types,
+    // which lets us use the much-simpler `repeat_packed`.
+    debug_assert!(elem_layout.size() == elem_layout.pad_to_align().size());
+
     // FIXME(const-hack) return to using `map` and `map_err` once `const_closures` is implemented
-    match elem_layout.repeat(cap) {
-        Ok((layout, _pad)) => Ok(layout),
+    match elem_layout.repeat_packed(cap) {
+        Ok(layout) => Ok(layout),
         Err(_) => Err(CapacityOverflow.into()),
     }
 }

--- a/tests/codegen-llvm/iter-repeat-n-trivial-drop.rs
+++ b/tests/codegen-llvm/iter-repeat-n-trivial-drop.rs
@@ -47,7 +47,7 @@ pub fn iter_repeat_n_next(it: &mut std::iter::RepeatN<NotCopy>) -> Option<NotCop
 #[no_mangle]
 // CHECK-LABEL: @vec_extend_via_iter_repeat_n
 pub fn vec_extend_via_iter_repeat_n() -> Vec<u8> {
-    // CHECK: %[[ADDR:.+]] = tail call {{(noalias )?}}noundef dereferenceable_or_null(1234) ptr @{{.*}}__rust_alloc(i64 noundef {{(range\(i64 1, 0\) )?}}1234, i64 noundef {{(range\(i64 1, -9223372036854775807\) )?}}1)
+    // CHECK: %[[ADDR:.+]] = tail call {{(noalias )?}}noundef dereferenceable_or_null(1234) ptr @{{.*}}__rust_alloc(i64 noundef {{(range\(i64 0, -9223372036854775808\) )?}}1234, i64 noundef {{(range\(i64 1, -9223372036854775807\) )?}}1)
     // CHECK: tail call void @llvm.memset.p0.i64(ptr noundef nonnull align 1 dereferenceable(1234) %[[ADDR]], i8 42, i64 1234,
 
     let n = 1234_usize;


### PR DESCRIPTION
Seeing whether this helps the icounts seen in https://github.com/rust-lang/rust/pull/148769#issuecomment-3769921666