### PR TITLE
rustc-dev-guide subtree update

### DIFF
--- a/src/doc/rustc-dev-guide/src/SUMMARY.md
+++ b/src/doc/rustc-dev-guide/src/SUMMARY.md
@@ -140,7 +140,7 @@
 
 - [Command-line arguments](./cli.md)
 - [rustc_driver and rustc_interface](./rustc-driver/intro.md)
-    - [Remarks on perma-unstable features](./rustc-driver/remarks-on-perma-unstable-features.md)
+    - [External rustc_drivers](./rustc-driver/external-rustc-drivers.md)
     - [Example: Type checking](./rustc-driver/interacting-with-the-ast.md)
     - [Example: Getting diagnostics](./rustc-driver/getting-diagnostics.md)
 - [Errors and lints](diagnostics.md)

--- a/src/doc/rustc-dev-guide/src/about-this-guide.md
+++ b/src/doc/rustc-dev-guide/src/about-this-guide.md
@@ -103,9 +103,9 @@ You might also find the following sites useful:
 [tlgba]: https://tomlee.co/2014/04/a-more-detailed-tour-of-the-rust-compiler/
 [ro]: https://www.rustaceans.org/
 [rctd]: tests/intro.md
-[cheatsheet]: https://bors.rust-lang.org/
+[cheatsheet]: https://bors.rust-lang.org/help
 [Miri]: https://github.com/rust-lang/miri
-[@bors]: https://github.com/bors
+[@bors]: https://github.com/rust-lang/bors
 [a GitHub repository]: https://github.com/rust-lang/rustc-dev-guide/
 [rustc API docs]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle
 [Forge]: https://forge.rust-lang.org/

--- a/src/doc/rustc-dev-guide/src/building/suggested.md
+++ b/src/doc/rustc-dev-guide/src/building/suggested.md
@@ -97,7 +97,7 @@ for two reasons:
   additional rebuilds in some cases.
 
 To avoid these problems:
-- Add `--build-dir=build/rust-analyzer` to all of the custom `x` commands in
+- Add `--build-dir=build-rust-analyzer` to all of the custom `x` commands in
   your editor's rust-analyzer configuration.
   (Feel free to choose a different directory name if desired.)
 - Modify the `rust-analyzer.rustfmt.overrideCommand` setting so that it points

--- a/src/doc/rustc-dev-guide/src/compiler-team.md
+++ b/src/doc/rustc-dev-guide/src/compiler-team.md
@@ -96,9 +96,9 @@ Once you have made a number of individual PRs to rustc, we will often
 offer r+ privileges. This means that you have the right to instruct
 "bors" (the robot that manages which PRs get landed into rustc) to
 merge a PR
-([here are some instructions for how to talk to bors][homu-guide]).
+([here are some instructions for how to talk to bors][bors-guide]).
 
-[homu-guide]: https://bors.rust-lang.org/
+[bors-guide]: https://bors.rust-lang.org/
 
 The guidelines for reviewers are as follows:
 

--- a/src/doc/rustc-dev-guide/src/contributing.md
+++ b/src/doc/rustc-dev-guide/src/contributing.md
@@ -283,7 +283,7 @@ this can take a while and the queue can sometimes be long.
 Also, note that PRs are never merged by hand.
 
 [@rustbot]: https://github.com/rustbot
-[@bors]: https://github.com/bors
+[@bors]: https://github.com/rust-lang/bors
 
 ### Opening a PR
 

--- a/src/doc/rustc-dev-guide/src/getting-started.md
+++ b/src/doc/rustc-dev-guide/src/getting-started.md
@@ -96,7 +96,7 @@ For example:
 Not all important or beginner work has issue labels.
 See below for how to find work that isn't labelled.
 
-[help-wanted-search]: https://github.com/issues?q=is%3Aopen%20is%3Aissue%20org%3Arust-lang%20no%3Aassignee%20label%3AE-easy%2CE-medium%2CE-help-wanted%2CE-mentor%20-label%3AS-blocked%20-linked%3Apr
+[help-wanted-search]: https://github.com/rust-lang/rust/issues?q=is%3Aopen%20is%3Aissue%20org%3Arust-lang%20no%3Aassignee%20label%3AE-easy%2CE-medium%2CE-help-wanted%2CE-mentor%20-label%3AS-blocked%20-linked%3Apr
 [Triage]: ./contributing.md#issue-triage
 
 ### Recurring work

--- a/src/doc/rustc-dev-guide/src/git.md
+++ b/src/doc/rustc-dev-guide/src/git.md
@@ -495,6 +495,14 @@ command to check it out locally. See <https://cli.github.com/> for more info.
 
 ![`gh` suggestion](./img/github-cli.png)
 
+### Using GitHub dev
+
+As an alternative to the GitHub web UI, GitHub Dev provides a web-based editor for browsing
+repository and PRs. It can be opened by replacing `github.com` with `github.dev` in the URL
+or by pressing `.` on a GitHub page.
+See [the docs for github.dev editor](https://docs.github.com/en/codespaces/the-githubdev-web-based-editor)
+for more details.
+
 ### Moving large sections of code
 
 Git and Github's default diff view for large moves *within* a file is quite poor; it will show each

--- a/src/doc/rustc-dev-guide/src/rustc-driver/external-rustc-drivers.md
+++ b/src/doc/rustc-dev-guide/src/rustc-driver/external-rustc-drivers.md
@@ -1,4 +1,4 @@
-# Remarks on perma unstable features
+# External `rustc_driver`s
 
 ## `rustc_private`
 

--- a/src/doc/rustc-dev-guide/src/rustc-driver/remarks-on-perma-unstable-features.md
+++ b/src/doc/rustc-dev-guide/src/rustc-driver/remarks-on-perma-unstable-features.md
@@ -49,6 +49,29 @@ For custom-built toolchains or environments not using rustup, additional configu
    ```
 3. **Check version compatibility**: Ensure your LLVM version is compatible with your Rust toolchain
 
+### Configuring `rust-analyzer` for Out-of-Tree Projects
+
+When developing out-of-tree projects that use `rustc_private` crates, you can configure `rust-analyzer` to recognize these crates.
+
+#### Configuration Steps
+
+1. **Set rust-analyzer configuration**
+   Configure `rust-analyzer.rustc.source` to `"discover"` in your editor settings.  
+   For VS Code, add to `rust_analyzer_settings.json`:
+   ```json
+   {
+       "rust-analyzer.rustc.source": "discover"
+   }
+   ```
+2. **Add metadata to Cargo.toml**  
+   Add the following to the `Cargo.toml` of every crate that uses `rustc_private`:
+   ```toml
+   [package.metadata.rust-analyzer]
+   rustc_private = true
+   ```
+
+This configuration allows `rust-analyzer` to properly recognize and provide IDE support for `rustc_private` crates in out-of-tree projects. 
+
 ### Additional Resources
 
 - [GitHub Issue #137421](https://github.com/rust-lang/rust/issues/137421): Explains that `rustc_private` linker failures often occur because `llvm-tools` is not installed

--- a/src/doc/rustc-dev-guide/src/solve/candidate-preference.md
+++ b/src/doc/rustc-dev-guide/src/solve/candidate-preference.md
@@ -260,66 +260,6 @@ We prefer builtin trait object impls over user-written impls. This is **unsound*
 
 The candidate preference behavior during normalization is implemented in [`fn assemble_and_merge_candidates`].
 
-### Trait where-bounds shadow impls
-
-Normalization of associated items does not consider impls if the corresponding trait goal has been proven via a `ParamEnv` or `AliasBound` candidate.
-This means that for where-bounds which do not constrain associated types, the associated types remain *rigid*.
-
-#### Using impls results in different region constraints
-
-This is necessary to avoid unnecessary region constraints from applying impls.
-```rust
-trait Trait<'a> {
-    type Assoc;
-}
-impl Trait<'static> for u32 {
-    type Assoc = u32;
-}
-
-fn bar<'b, T: Trait<'b>>() -> T::Assoc { todo!() }
-fn foo<'a>()
-where
-    u32: Trait<'a>,
-{
-    // Normalizing the return type would use the impl, proving
-    // the `T: Trait` where-bound would use the where-bound, resulting
-    // in different region constraints.
-    bar::<'_, u32>();
-}
-```
-
-#### RPITIT `type_of` cycles
-
-We currently have to avoid impl candidates if there are where-bounds to avoid query cycles for RPITIT, see [#139762]. It feels desirable to me to stop relying on auto-trait leakage of during RPITIT computation to remove this issue, see [#139788].
-
-```rust
-use std::future::Future;
-pub trait ReactiveFunction: Send {
-    type Output;
-
-    fn invoke(self) -> Self::Output;
-}
-
-trait AttributeValue {
-    fn resolve(self) -> impl Future<Output = ()> + Send;
-}
-
-impl<F, V> AttributeValue for F
-where
-    F: ReactiveFunction<Output = V>,
-    V: AttributeValue,
-{
-    async fn resolve(self) {
-        // We're awaiting `<V as AttributeValue>::{synthetic#0}` here.
-        // Normalizing that one via the the impl we're currently in
-        // relies on `collect_return_position_impl_trait_in_trait_tys` which
-        // ends up relying on auto-trait leakage when checking that the
-        // opaque return type of this function implements the `Send` item
-        // bound of the trait definition.
-        self.invoke().resolve().await
-    }
-}
-```
 
 ### We always consider `AliasBound` candidates
 
@@ -450,6 +390,67 @@ where
 {
     trait_bound::<&'a u32>(); // ok, proven via impl
     normalize::<&'a u32>(); // error, proven via where-bound
+}
+```
+
+### Trait where-bounds shadow impls
+
+Normalization of associated items does not consider impls if the corresponding trait goal has been proven via a `ParamEnv` or `AliasBound` candidate.
+This means that for where-bounds which do not constrain associated types, the associated types remain *rigid*.
+
+#### Using impls results in different region constraints
+
+This is necessary to avoid unnecessary region constraints from applying impls.
+```rust
+trait Trait<'a> {
+    type Assoc;
+}
+impl Trait<'static> for u32 {
+    type Assoc = u32;
+}
+
+fn bar<'b, T: Trait<'b>>() -> T::Assoc { todo!() }
+fn foo<'a>()
+where
+    u32: Trait<'a>,
+{
+    // Normalizing the return type would use the impl, proving
+    // the `T: Trait` where-bound would use the where-bound, resulting
+    // in different region constraints.
+    bar::<'_, u32>();
+}
+```
+
+#### RPITIT `type_of` cycles
+
+We currently have to avoid impl candidates if there are where-bounds to avoid query cycles for RPITIT, see [#139762]. It feels desirable to me to stop relying on auto-trait leakage of during RPITIT computation to remove this issue, see [#139788].
+
+```rust
+use std::future::Future;
+pub trait ReactiveFunction: Send {
+    type Output;
+
+    fn invoke(self) -> Self::Output;
+}
+
+trait AttributeValue {
+    fn resolve(self) -> impl Future<Output = ()> + Send;
+}
+
+impl<F, V> AttributeValue for F
+where
+    F: ReactiveFunction<Output = V>,
+    V: AttributeValue,
+{
+    async fn resolve(self) {
+        // We're awaiting `<V as AttributeValue>::{synthetic#0}` here.
+        // Normalizing that one via the the impl we're currently in
+        // relies on `collect_return_position_impl_trait_in_trait_tys` which
+        // ends up relying on auto-trait leakage when checking that the
+        // opaque return type of this function implements the `Send` item
+        // bound of the trait definition.
+        self.invoke().resolve().await
+    }
 }
 ```
 

--- a/src/doc/rustc-dev-guide/src/solve/candidate-preference.md
+++ b/src/doc/rustc-dev-guide/src/solve/candidate-preference.md
@@ -260,10 +260,12 @@ We prefer builtin trait object impls over user-written impls. This is **unsound*
 
 The candidate preference behavior during normalization is implemented in [`fn assemble_and_merge_candidates`].
 
-### Where-bounds shadow impls
+### Trait where-bounds shadow impls
 
 Normalization of associated items does not consider impls if the corresponding trait goal has been proven via a `ParamEnv` or `AliasBound` candidate.
 This means that for where-bounds which do not constrain associated types, the associated types remain *rigid*.
+
+#### Using impls results in different region constraints
 
 This is necessary to avoid unnecessary region constraints from applying impls.
 ```rust
@@ -283,6 +285,39 @@ where
     // the `T: Trait` where-bound would use the where-bound, resulting
     // in different region constraints.
     bar::<'_, u32>();
+}
+```
+
+#### RPITIT `type_of` cycles
+
+We currently have to avoid impl candidates if there are where-bounds to avoid query cycles for RPITIT, see [#139762]. It feels desirable to me to stop relying on auto-trait leakage of during RPITIT computation to remove this issue, see [#139788].
+
+```rust
+use std::future::Future;
+pub trait ReactiveFunction: Send {
+    type Output;
+
+    fn invoke(self) -> Self::Output;
+}
+
+trait AttributeValue {
+    fn resolve(self) -> impl Future<Output = ()> + Send;
+}
+
+impl<F, V> AttributeValue for F
+where
+    F: ReactiveFunction<Output = V>,
+    V: AttributeValue,
+{
+    async fn resolve(self) {
+        // We're awaiting `<V as AttributeValue>::{synthetic#0}` here.
+        // Normalizing that one via the the impl we're currently in
+        // relies on `collect_return_position_impl_trait_in_trait_tys` which
+        // ends up relying on auto-trait leakage when checking that the
+        // opaque return type of this function implements the `Send` item
+        // bound of the trait definition.
+        self.invoke().resolve().await
+    }
 }
 ```
 
@@ -425,3 +460,5 @@ where
 [trait-system-refactor-initiative#76]: https://github.com/rust-lang/trait-system-refactor-initiative/issues/76
 [#24066]: https://github.com/rust-lang/rust/issues/24066
 [#133044]: https://github.com/rust-lang/rust/issues/133044
+[#139762]: https://github.com/rust-lang/rust/pull/139762
+[#139788]: https://github.com/rust-lang/rust/issues/139788

--- a/src/doc/rustc-dev-guide/src/tests/ci.md
+++ b/src/doc/rustc-dev-guide/src/tests/ci.md
@@ -198,7 +198,7 @@ to help make the perf comparison as fair as possible.
 >
 > 3. Run the prescribed try jobs with `@bors try`. As aforementioned, this
 >    requires the user to either (1) have `try` permissions or (2) be delegated
->    with `try` permissions by `@bors delegate` by someone who has `try`
+>    with `try` permissions by `@bors delegate=try` by someone who has `try`
 >    permissions.
 >
 > Note that this is usually easier to do than manually edit [`jobs.yml`].
@@ -213,10 +213,7 @@ the corresponding PR.
 Multiple try builds can execute concurrently across different PRs, but there can be at most
 a single try build running on a single PR at any given time.
 
-Note that try builds are handled using the [new bors] implementation.
-
 [rustc-perf]: https://github.com/rust-lang/rustc-perf
-[new bors]: https://github.com/rust-lang/bors
 
 ### Modifying CI jobs
 
@@ -281,8 +278,7 @@ Breakages like these usually happen when another, incompatible PR is merged
 after the build happened.
 
 To ensure a `main` branch that works all the time, we forbid manual merges.
-Instead, all PRs have to be approved through our bot, [bors] (the software
-behind it is called [homu]).
+Instead, all PRs have to be approved through our bot, [bors].
 All the approved PRs are put in a [merge queue]
 (sorted by priority and creation date) and are automatically tested one at the time.
 If all the builders are green, the PR is merged, otherwise the failure is
@@ -465,8 +461,7 @@ To do this:
 [`jobs.yml`]: https://github.com/rust-lang/rust/blob/HEAD/src/ci/github-actions/jobs.yml
 [`.github/workflows/ci.yml`]: https://github.com/rust-lang/rust/blob/HEAD/.github/workflows/ci.yml
 [`src/ci/citool`]: https://github.com/rust-lang/rust/blob/HEAD/src/ci/citool
-[bors]: https://github.com/bors
-[homu]: https://github.com/rust-lang/homu
+[bors]: https://github.com/rust-lang/bors
 [merge queue]: https://bors.rust-lang.org/queue/rust
 [dist-x86_64-linux]: https://github.com/rust-lang/rust/blob/HEAD/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
 [the GitHub Actions workflows page]: https://github.com/rust-lang/rust/actions

--- a/src/doc/rustc-dev-guide/triagebot.toml
+++ b/src/doc/rustc-dev-guide/triagebot.toml
@@ -86,3 +86,6 @@ rustc-dev-guide = [
     "@jyn514",
     "@tshepang",
 ]
+
+# Make rebases more easy to read: https://forge.rust-lang.org/triagebot/range-diff.html
+[range-diff]


### PR DESCRIPTION
Subtree update of `rustc-dev-guide` to https://github.com/rust-lang/rustc-dev-guide/commit/64f0f77d34cec035f115abaf312bbc393508908a.

Created using https://github.com/rust-lang/josh-sync.

r? @ghost