### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -97,6 +97,21 @@ impl<'a, 'll, CX: Borrow<SCx<'ll>>> GenericBuilder<'a, 'll, CX> {
         GenericBuilder { llbuilder, cx: scx }
     }
 
+    pub(crate) fn append_block(
+        cx: &'a GenericCx<'ll, CX>,
+        llfn: &'ll Value,
+        name: &str,
+    ) -> &'ll BasicBlock {
+        unsafe {
+            let name = SmallCStr::new(name);
+            llvm::LLVMAppendBasicBlockInContext(cx.llcx(), llfn, name.as_ptr())
+        }
+    }
+
+    pub(crate) fn trunc(&mut self, val: &'ll Value, dest_ty: &'ll Type) -> &'ll Value {
+        unsafe { llvm::LLVMBuildTrunc(self.llbuilder, val, dest_ty, UNNAMED) }
+    }
+
     pub(crate) fn bitcast(&mut self, val: &'ll Value, dest_ty: &'ll Type) -> &'ll Value {
         unsafe { llvm::LLVMBuildBitCast(self.llbuilder, val, dest_ty, UNNAMED) }
     }

--- a/compiler/rustc_codegen_llvm/src/builder/gpu_offload.rs
+++ b/compiler/rustc_codegen_llvm/src/builder/gpu_offload.rs
@@ -2,6 +2,7 @@ use std::ffi::CString;
 
 use llvm::Linkage::*;
 use rustc_abi::Align;
+use rustc_codegen_ssa::common::TypeKind;
 use rustc_codegen_ssa::mir::operand::{OperandRef, OperandValue};
 use rustc_codegen_ssa::traits::{BaseTypeCodegenMethods, BuilderMethods};
 use rustc_middle::bug;
@@ -357,7 +358,6 @@ pub(crate) fn add_global<'ll>(
 pub(crate) fn gen_define_handling<'ll>(
     cx: &CodegenCx<'ll, '_>,
     metadata: &[OffloadMetadata],
-    types: &[&'ll Type],
     symbol: String,
     offload_globals: &OffloadGlobals<'ll>,
 ) -> OffloadKernelGlobals<'ll> {
@@ -367,25 +367,18 @@ pub(crate) fn gen_define_handling<'ll>(
 
     let offload_entry_ty = offload_globals.offload_entry_ty;
 
-    // It seems like non-pointer values are automatically mapped. So here, we focus on pointer (or
-    // reference) types.
-    let ptr_meta = types.iter().zip(metadata).filter_map(|(&x, meta)| match cx.type_kind(x) {
-        rustc_codegen_ssa::common::TypeKind::Pointer => Some(meta),
-        _ => None,
-    });
-
     // FIXME(Sa4dUs): add `OMP_MAP_TARGET_PARAM = 0x20` only if necessary
-    let (ptr_sizes, ptr_transfer): (Vec<_>, Vec<_>) =
-        ptr_meta.map(|m| (m.payload_size, m.mode.bits() | 0x20)).unzip();
+    let (sizes, transfer): (Vec<_>, Vec<_>) =
+        metadata.iter().map(|m| (m.payload_size, m.mode.bits() | 0x20)).unzip();
 
-    let offload_sizes = add_priv_unnamed_arr(&cx, &format!(".offload_sizes.{symbol}"), &ptr_sizes);
+    let offload_sizes = add_priv_unnamed_arr(&cx, &format!(".offload_sizes.{symbol}"), &sizes);
     // Here we figure out whether something needs to be copied to the gpu (=1), from the gpu (=2),
     // or both to and from the gpu (=3). Other values shouldn't affect us for now.
     // A non-mutable reference or pointer will be 1, an array that's not read, but fully overwritten
     // will be 2. For now, everything is 3, until we have our frontend set up.
     // 1+2+32: 1 (MapTo), 2 (MapFrom), 32 (Add one extra input ptr per function, to be used later).
     let memtransfer_types =
-        add_priv_unnamed_arr(&cx, &format!(".offload_maptypes.{symbol}"), &ptr_transfer);
+        add_priv_unnamed_arr(&cx, &format!(".offload_maptypes.{symbol}"), &transfer);
 
     // Next: For each function, generate these three entries. A weak constant,
     // the llvm.rodata entry name, and  the llvm_offload_entries value
@@ -441,11 +434,24 @@ fn declare_offload_fn<'ll>(
     )
 }
 
+pub(crate) fn scalar_width<'ll>(cx: &'ll SimpleCx<'_>, ty: &'ll Type) -> u64 {
+    match cx.type_kind(ty) {
+        TypeKind::Half
+        | TypeKind::Float
+        | TypeKind::Double
+        | TypeKind::X86_FP80
+        | TypeKind::FP128
+        | TypeKind::PPC_FP128 => cx.float_width(ty) as u64,
+        TypeKind::Integer => cx.int_width(ty),
+        other => bug!("scalar_width was called on a non scalar type {other:?}"),
+    }
+}
+
 // For each kernel *call*, we now use some of our previous declared globals to move data to and from
 // the gpu. For now, we only handle the data transfer part of it.
 // If two consecutive kernels use the same memory, we still move it to the host and back to the gpu.
 // Since in our frontend users (by default) don't have to specify data transfer, this is something
-// we should optimize in the future! In some cases we can directly zero-allocate ont he device and
+// we should optimize in the future! In some cases we can directly zero-allocate on the device and
 // only move data back, or if something is immutable, we might only copy it to the device.
 //
 // Current steps:
@@ -533,8 +539,34 @@ pub(crate) fn gen_call_handling<'ll, 'tcx>(
     let mut geps = vec![];
     let i32_0 = cx.get_const_i32(0);
     for &v in args {
-        let gep = builder.inbounds_gep(cx.type_f32(), v, &[i32_0]);
-        vals.push(v);
+        let ty = cx.val_ty(v);
+        let ty_kind = cx.type_kind(ty);
+        let (base_val, gep_base) = match ty_kind {
+            TypeKind::Pointer => (v, v),
+            TypeKind::Half | TypeKind::Float | TypeKind::Double | TypeKind::Integer => {
+                // FIXME(Sa4dUs): check for `f128` support, latest NVIDIA cards support it
+                let num_bits = scalar_width(cx, ty);
+
+                let bb = builder.llbb();
+                unsafe {
+                    llvm::LLVMRustPositionBuilderPastAllocas(builder.llbuilder, builder.llfn());
+                }
+                let addr = builder.direct_alloca(cx.type_i64(), Align::EIGHT, "addr");
+                unsafe {
+                    llvm::LLVMPositionBuilderAtEnd(builder.llbuilder, bb);
+                }
+
+                let cast = builder.bitcast(v, cx.type_ix(num_bits));
+                let value = builder.zext(cast, cx.type_i64());
+                builder.store(value, addr, Align::EIGHT);
+                (value, addr)
+            }
+            other => bug!("offload does not support {other:?}"),
+        };
+
+        let gep = builder.inbounds_gep(cx.type_f32(), gep_base, &[i32_0]);
+
+        vals.push(base_val);
         geps.push(gep);
     }
 

--- a/compiler/rustc_codegen_llvm/src/builder/gpu_offload.rs
+++ b/compiler/rustc_codegen_llvm/src/builder/gpu_offload.rs
@@ -445,9 +445,8 @@ fn declare_offload_fn<'ll>(
 // the gpu. For now, we only handle the data transfer part of it.
 // If two consecutive kernels use the same memory, we still move it to the host and back to the gpu.
 // Since in our frontend users (by default) don't have to specify data transfer, this is something
-// we should optimize in the future! We also assume that everything should be copied back and forth,
-// but sometimes we can directly zero-allocate on the device and only move back, or if something is
-// immutable, we might only copy it to the device, but not back.
+// we should optimize in the future! In some cases we can directly zero-allocate ont he device and
+// only move data back, or if something is immutable, we might only copy it to the device.
 //
 // Current steps:
 // 0. Alloca some variables for the following steps

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -1388,7 +1388,7 @@ fn codegen_offload<'ll, 'tcx>(
     let args = get_args_from_tuple(bx, args[3], fn_target);
     let target_symbol = symbol_name_for_instance_in_crate(tcx, fn_target, LOCAL_CRATE);
 
-    let sig = tcx.fn_sig(fn_target.def_id()).instantiate_identity();
+    let sig = tcx.fn_sig(fn_target.def_id()).skip_binder();
     let sig = tcx.instantiate_bound_regions_with_erased(sig);
     let inputs = sig.inputs();
 
@@ -1404,7 +1404,7 @@ fn codegen_offload<'ll, 'tcx>(
             return;
         }
     };
-    let offload_data = gen_define_handling(&cx, &metadata, &types, target_symbol, offload_globals);
+    let offload_data = gen_define_handling(&cx, &metadata, target_symbol, offload_globals);
     gen_call_handling(bx, &offload_data, &args, &types, &metadata, offload_globals, &offload_dims);
 }
 

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -1388,7 +1388,8 @@ fn codegen_offload<'ll, 'tcx>(
     let args = get_args_from_tuple(bx, args[3], fn_target);
     let target_symbol = symbol_name_for_instance_in_crate(tcx, fn_target, LOCAL_CRATE);
 
-    let sig = tcx.fn_sig(fn_target.def_id()).skip_binder().skip_binder();
+    let sig = tcx.fn_sig(fn_target.def_id()).instantiate_identity();
+    let sig = tcx.instantiate_bound_regions_with_erased(sig);
     let inputs = sig.inputs();
 
     let metadata = inputs.iter().map(|ty| OffloadMetadata::from_ty(tcx, *ty)).collect::<Vec<_>>();

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -1675,7 +1675,11 @@ mod Offload {
             _M: &'a Module,
             _host_out: *const c_char,
         ) -> bool;
-        pub(crate) fn LLVMRustOffloadMapper<'a>(OldFn: &'a Value, NewFn: &'a Value);
+        pub(crate) fn LLVMRustOffloadMapper<'a>(
+            OldFn: &'a Value,
+            NewFn: &'a Value,
+            RebuiltArgs: *const &Value,
+        );
     }
 }
 
@@ -1702,7 +1706,11 @@ mod Offload_fallback {
         unimplemented!("This rustc version was not built with LLVM Offload support!");
     }
     #[allow(unused_unsafe)]
-    pub(crate) unsafe fn LLVMRustOffloadMapper<'a>(_OldFn: &'a Value, _NewFn: &'a Value) {
+    pub(crate) unsafe fn LLVMRustOffloadMapper<'a>(
+        _OldFn: &'a Value,
+        _NewFn: &'a Value,
+        _RebuiltArgs: *const &Value,
+    ) {
         unimplemented!("This rustc version was not built with LLVM Offload support!");
     }
 }

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -223,7 +223,12 @@ extern "C" bool LLVMRustOffloadEmbedBufferInModule(LLVMModuleRef HostM,
   return true;
 }
 
-extern "C" void LLVMRustOffloadMapper(LLVMValueRef OldFn, LLVMValueRef NewFn) {
+// Clone OldFn into NewFn, remapping its arguments to RebuiltArgs.
+// Each arg of OldFn is replaced with the corresponding value in RebuiltArgs.
+// For scalars, RebuiltArgs contains the value cast and/or truncated to the
+// original type.
+extern "C" void LLVMRustOffloadMapper(LLVMValueRef OldFn, LLVMValueRef NewFn,
+                                      const LLVMValueRef *RebuiltArgs) {
   llvm::Function *oldFn = llvm::unwrap<llvm::Function>(OldFn);
   llvm::Function *newFn = llvm::unwrap<llvm::Function>(NewFn);
 
@@ -232,15 +237,25 @@ extern "C" void LLVMRustOffloadMapper(LLVMValueRef OldFn, LLVMValueRef NewFn) {
   llvm::ValueToValueMapTy vmap;
   auto newArgIt = newFn->arg_begin();
   newArgIt->setName("dyn_ptr");
-  ++newArgIt; // skip %dyn_ptr
+
+  unsigned i = 0;
   for (auto &oldArg : oldFn->args()) {
-    vmap[&oldArg] = &*newArgIt++;
+    vmap[&oldArg] = unwrap<Value>(RebuiltArgs[i++]);
   }
 
   llvm::SmallVector<llvm::ReturnInst *, 8> returns;
   llvm::CloneFunctionInto(newFn, oldFn, vmap,
                           llvm::CloneFunctionChangeType::LocalChangesOnly,
                           returns);
+
+  BasicBlock &entry = newFn->getEntryBlock();
+  BasicBlock &clonedEntry = *std::next(newFn->begin());
+
+  if (entry.getTerminator())
+    entry.getTerminator()->eraseFromParent();
+
+  IRBuilder<> B(&entry);
+  B.CreateBr(&clonedEntry);
 }
 #endif
 

--- a/compiler/rustc_middle/src/ty/offload_meta.rs
+++ b/compiler/rustc_middle/src/ty/offload_meta.rs
@@ -78,16 +78,13 @@ impl MappingFlags {
         use rustc_ast::Mutability::*;
 
         match ty.kind() {
-            ty::Bool
-            | ty::Char
-            | ty::Int(_)
-            | ty::Uint(_)
-            | ty::Float(_)
-            | ty::Adt(_, _)
-            | ty::Tuple(_)
-            | ty::Array(_, _)
-            | ty::Alias(_, _)
-            | ty::Param(_) => MappingFlags::TO,
+            ty::Bool | ty::Char | ty::Int(_) | ty::Uint(_) | ty::Float(_) => {
+                MappingFlags::LITERAL | MappingFlags::IMPLICIT
+            }
+
+            ty::Adt(_, _) | ty::Tuple(_) | ty::Array(_, _) | ty::Alias(_, _) | ty::Param(_) => {
+                MappingFlags::TO
+            }
 
             ty::RawPtr(_, Not) | ty::Ref(_, _, Not) => MappingFlags::TO,
 

--- a/compiler/rustc_mir_transform/src/coverage/mod.rs
+++ b/compiler/rustc_mir_transform/src/coverage/mod.rs
@@ -73,12 +73,13 @@ fn instrument_function_for_coverage<'tcx>(tcx: TyCtxt<'tcx>, mir_body: &mut mir:
     ////////////////////////////////////////////////////
     // Extract coverage spans and other mapping info from MIR.
     let ExtractedMappings { mappings } =
-        mappings::extract_mappings_from_mir(tcx, mir_body, &hir_info, &graph);
-    if mappings.is_empty() {
-        // No spans could be converted into valid mappings, so skip this function.
-        debug!("no spans could be converted into valid mappings; skipping");
-        return;
-    }
+        match mappings::extract_mappings_from_mir(tcx, mir_body, &hir_info, &graph) {
+            Ok(m) => m,
+            Err(error) => {
+                tracing::debug!(?error, "mapping extraction failed; skipping this function");
+                return;
+            }
+        };
 
     // Use the coverage graph to prepare intermediate data that will eventually
     // be used to assign physical counters and counter expressions to points in

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -5,7 +5,6 @@
 #![feature(const_type_name)]
 #![feature(cow_is_borrowed)]
 #![feature(file_buffered)]
-#![feature(gen_blocks)]
 #![feature(if_let_guard)]
 #![feature(impl_trait_in_assoc_type)]
 #![feature(try_blocks)]

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -17,6 +17,7 @@ use std::{env, fs};
 use build_helper::exit;
 use build_helper::git::PathFreshness;
 
+use crate::core::build_steps::llvm;
 use crate::core::builder::{Builder, RunConfig, ShouldRun, Step, StepMetadata};
 use crate::core::config::{Config, TargetSelection};
 use crate::utils::build_stamp::{BuildStamp, generate_smart_stamp_hash};
@@ -1077,13 +1078,28 @@ impl Step for OmpOffload {
     }
 }
 
+#[derive(Clone)]
+pub struct BuiltEnzyme {
+    /// Path to the libEnzyme dylib.
+    enzyme: PathBuf,
+}
+
+impl BuiltEnzyme {
+    pub fn enzyme_path(&self) -> PathBuf {
+        self.enzyme.clone()
+    }
+    pub fn enzyme_filename(&self) -> String {
+        self.enzyme.file_name().unwrap().to_str().unwrap().to_owned()
+    }
+}
+
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Enzyme {
     pub target: TargetSelection,
 }
 
 impl Step for Enzyme {
-    type Output = PathBuf;
+    type Output = BuiltEnzyme;
     const IS_HOST: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
@@ -1095,16 +1111,16 @@ impl Step for Enzyme {
     }
 
     /// Compile Enzyme for `target`.
-    fn run(self, builder: &Builder<'_>) -> PathBuf {
+    fn run(self, builder: &Builder<'_>) -> Self::Output {
         builder.require_submodule(
             "src/tools/enzyme",
             Some("The Enzyme sources are required for autodiff."),
         );
-        if builder.config.dry_run() {
-            let out_dir = builder.enzyme_out(self.target);
-            return out_dir;
-        }
         let target = self.target;
+
+        if builder.config.dry_run() {
+            return BuiltEnzyme { enzyme: builder.config.tempdir().join("enzyme-dryrun") };
+        }
 
         let LlvmResult { host_llvm_config, llvm_cmake_dir } = builder.ensure(Llvm { target });
 
@@ -1120,6 +1136,12 @@ impl Step for Enzyme {
         let out_dir = builder.enzyme_out(target);
         let stamp = BuildStamp::new(&out_dir).with_prefix("enzyme").add_stamp(smart_stamp_hash);
 
+        let llvm_version_major = llvm::get_llvm_version_major(builder, &host_llvm_config);
+        let lib_ext = std::env::consts::DLL_EXTENSION;
+        let libenzyme = format!("libEnzyme-{llvm_version_major}");
+        let build_dir = out_dir.join("lib");
+        let dylib = build_dir.join(&libenzyme).with_extension(lib_ext);
+
         trace!("checking build stamp to see if we need to rebuild enzyme artifacts");
         if stamp.is_up_to_date() {
             trace!(?out_dir, "enzyme build artifacts are up to date");
@@ -1133,7 +1155,7 @@ impl Step for Enzyme {
                     stamp.path().display()
                 ));
             }
-            return out_dir;
+            return BuiltEnzyme { enzyme: dylib };
         }
 
         if !builder.config.dry_run() && !llvm_cmake_dir.is_dir() {
@@ -1149,7 +1171,6 @@ impl Step for Enzyme {
         let _time = helpers::timeit(builder);
         t!(fs::create_dir_all(&out_dir));
 
-        builder.config.update_submodule("src/tools/enzyme");
         let mut cfg = cmake::Config::new(builder.src.join("src/tools/enzyme/enzyme/"));
         // Enzyme devs maintain upstream compatibility, but only fix deprecations when they are about
         // to turn into a hard error. As such, Enzyme generates various warnings which could make it
@@ -1178,8 +1199,18 @@ impl Step for Enzyme {
 
         cfg.build();
 
+        // At this point, `out_dir` should contain the built libEnzyme-<LLVM-version>.<dylib-ext>
+        // file.
+        if !dylib.exists() {
+            eprintln!(
+                "`{libenzyme}` not found in `{}`. Either the build has failed or Enzyme was built with a wrong version of LLVM",
+                build_dir.display()
+            );
+            exit!(1);
+        }
+
         t!(stamp.write());
-        out_dir
+        BuiltEnzyme { enzyme: dylib }
     }
 }
 

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -980,6 +980,7 @@ impl<'a> Builder<'a> {
                 dist::LlvmTools,
                 dist::LlvmBitcodeLinker,
                 dist::RustDev,
+                dist::Enzyme,
                 dist::Bootstrap,
                 dist::Extended,
                 // It seems that PlainSourceTarball somehow changes how some of the tools

--- a/src/bootstrap/src/utils/tarball.rs
+++ b/src/bootstrap/src/utils/tarball.rs
@@ -28,6 +28,7 @@ pub(crate) enum OverlayKind {
     RustcCodegenGcc,
     Gcc,
     LlvmBitcodeLinker,
+    Enzyme,
 }
 
 impl OverlayKind {
@@ -37,6 +38,7 @@ impl OverlayKind {
             OverlayKind::Llvm => {
                 &["src/llvm-project/llvm/LICENSE.TXT", "src/llvm-project/llvm/README.txt"]
             }
+            OverlayKind::Enzyme => &["src/tools/enzyme/LICENSE", "src/tools/enzyme/Readme.md"],
             OverlayKind::Cargo => &[
                 "src/tools/cargo/README.md",
                 "src/tools/cargo/LICENSE-MIT",
@@ -111,6 +113,7 @@ impl OverlayKind {
             OverlayKind::RustcCodegenGcc => builder.rust_version(),
             OverlayKind::LlvmBitcodeLinker => builder.rust_version(),
             OverlayKind::Gcc => builder.rust_version(),
+            OverlayKind::Enzyme => builder.rust_version(),
         }
     }
 }

--- a/src/doc/rustc-dev-guide/src/SUMMARY.md
+++ b/src/doc/rustc-dev-guide/src/SUMMARY.md
@@ -140,7 +140,7 @@
 
 - [Command-line arguments](./cli.md)
 - [rustc_driver and rustc_interface](./rustc-driver/intro.md)
-    - [Remarks on perma-unstable features](./rustc-driver/remarks-on-perma-unstable-features.md)
+    - [External rustc_drivers](./rustc-driver/external-rustc-drivers.md)
     - [Example: Type checking](./rustc-driver/interacting-with-the-ast.md)
     - [Example: Getting diagnostics](./rustc-driver/getting-diagnostics.md)
 - [Errors and lints](diagnostics.md)

--- a/src/doc/rustc-dev-guide/src/about-this-guide.md
+++ b/src/doc/rustc-dev-guide/src/about-this-guide.md
@@ -103,9 +103,9 @@ You might also find the following sites useful:
 [tlgba]: https://tomlee.co/2014/04/a-more-detailed-tour-of-the-rust-compiler/
 [ro]: https://www.rustaceans.org/
 [rctd]: tests/intro.md
-[cheatsheet]: https://bors.rust-lang.org/
+[cheatsheet]: https://bors.rust-lang.org/help
 [Miri]: https://github.com/rust-lang/miri
-[@bors]: https://github.com/bors
+[@bors]: https://github.com/rust-lang/bors
 [a GitHub repository]: https://github.com/rust-lang/rustc-dev-guide/
 [rustc API docs]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle
 [Forge]: https://forge.rust-lang.org/

--- a/src/doc/rustc-dev-guide/src/building/suggested.md
+++ b/src/doc/rustc-dev-guide/src/building/suggested.md
@@ -97,7 +97,7 @@ for two reasons:
   additional rebuilds in some cases.
 
 To avoid these problems:
-- Add `--build-dir=build/rust-analyzer` to all of the custom `x` commands in
+- Add `--build-dir=build-rust-analyzer` to all of the custom `x` commands in
   your editor's rust-analyzer configuration.
   (Feel free to choose a different directory name if desired.)
 - Modify the `rust-analyzer.rustfmt.overrideCommand` setting so that it points

--- a/src/doc/rustc-dev-guide/src/compiler-team.md
+++ b/src/doc/rustc-dev-guide/src/compiler-team.md
@@ -96,9 +96,9 @@ Once you have made a number of individual PRs to rustc, we will often
 offer r+ privileges. This means that you have the right to instruct
 "bors" (the robot that manages which PRs get landed into rustc) to
 merge a PR
-([here are some instructions for how to talk to bors][homu-guide]).
+([here are some instructions for how to talk to bors][bors-guide]).
 
-[homu-guide]: https://bors.rust-lang.org/
+[bors-guide]: https://bors.rust-lang.org/
 
 The guidelines for reviewers are as follows:
 

--- a/src/doc/rustc-dev-guide/src/contributing.md
+++ b/src/doc/rustc-dev-guide/src/contributing.md
@@ -283,7 +283,7 @@ this can take a while and the queue can sometimes be long.
 Also, note that PRs are never merged by hand.
 
 [@rustbot]: https://github.com/rustbot
-[@bors]: https://github.com/bors
+[@bors]: https://github.com/rust-lang/bors
 
 ### Opening a PR
 

--- a/src/doc/rustc-dev-guide/src/getting-started.md
+++ b/src/doc/rustc-dev-guide/src/getting-started.md
@@ -96,7 +96,7 @@ For example:
 Not all important or beginner work has issue labels.
 See below for how to find work that isn't labelled.
 
-[help-wanted-search]: https://github.com/issues?q=is%3Aopen%20is%3Aissue%20org%3Arust-lang%20no%3Aassignee%20label%3AE-easy%2CE-medium%2CE-help-wanted%2CE-mentor%20-label%3AS-blocked%20-linked%3Apr
+[help-wanted-search]: https://github.com/rust-lang/rust/issues?q=is%3Aopen%20is%3Aissue%20org%3Arust-lang%20no%3Aassignee%20label%3AE-easy%2CE-medium%2CE-help-wanted%2CE-mentor%20-label%3AS-blocked%20-linked%3Apr
 [Triage]: ./contributing.md#issue-triage
 
 ### Recurring work

--- a/src/doc/rustc-dev-guide/src/git.md
+++ b/src/doc/rustc-dev-guide/src/git.md
@@ -495,6 +495,14 @@ command to check it out locally. See <https://cli.github.com/> for more info.
 
 ![`gh` suggestion](./img/github-cli.png)
 
+### Using GitHub dev
+
+As an alternative to the GitHub web UI, GitHub Dev provides a web-based editor for browsing
+repository and PRs. It can be opened by replacing `github.com` with `github.dev` in the URL
+or by pressing `.` on a GitHub page.
+See [the docs for github.dev editor](https://docs.github.com/en/codespaces/the-githubdev-web-based-editor)
+for more details.
+
 ### Moving large sections of code
 
 Git and Github's default diff view for large moves *within* a file is quite poor; it will show each

--- a/src/doc/rustc-dev-guide/src/rustc-driver/external-rustc-drivers.md
+++ b/src/doc/rustc-dev-guide/src/rustc-driver/external-rustc-drivers.md
@@ -1,4 +1,4 @@
-# Remarks on perma unstable features
+# External `rustc_driver`s
 
 ## `rustc_private`
 

--- a/src/doc/rustc-dev-guide/src/rustc-driver/remarks-on-perma-unstable-features.md
+++ b/src/doc/rustc-dev-guide/src/rustc-driver/remarks-on-perma-unstable-features.md
@@ -49,6 +49,29 @@ For custom-built toolchains or environments not using rustup, additional configu
    ```
 3. **Check version compatibility**: Ensure your LLVM version is compatible with your Rust toolchain
 
+### Configuring `rust-analyzer` for Out-of-Tree Projects
+
+When developing out-of-tree projects that use `rustc_private` crates, you can configure `rust-analyzer` to recognize these crates.
+
+#### Configuration Steps
+
+1. **Set rust-analyzer configuration**
+   Configure `rust-analyzer.rustc.source` to `"discover"` in your editor settings.  
+   For VS Code, add to `rust_analyzer_settings.json`:
+   ```json
+   {
+       "rust-analyzer.rustc.source": "discover"
+   }
+   ```
+2. **Add metadata to Cargo.toml**  
+   Add the following to the `Cargo.toml` of every crate that uses `rustc_private`:
+   ```toml
+   [package.metadata.rust-analyzer]
+   rustc_private = true
+   ```
+
+This configuration allows `rust-analyzer` to properly recognize and provide IDE support for `rustc_private` crates in out-of-tree projects. 
+
 ### Additional Resources
 
 - [GitHub Issue #137421](https://github.com/rust-lang/rust/issues/137421): Explains that `rustc_private` linker failures often occur because `llvm-tools` is not installed

--- a/src/doc/rustc-dev-guide/src/solve/candidate-preference.md
+++ b/src/doc/rustc-dev-guide/src/solve/candidate-preference.md
@@ -260,66 +260,6 @@ We prefer builtin trait object impls over user-written impls. This is **unsound*
 
 The candidate preference behavior during normalization is implemented in [`fn assemble_and_merge_candidates`].
 
-### Trait where-bounds shadow impls
-
-Normalization of associated items does not consider impls if the corresponding trait goal has been proven via a `ParamEnv` or `AliasBound` candidate.
-This means that for where-bounds which do not constrain associated types, the associated types remain *rigid*.
-
-#### Using impls results in different region constraints
-
-This is necessary to avoid unnecessary region constraints from applying impls.
-```rust
-trait Trait<'a> {
-    type Assoc;
-}
-impl Trait<'static> for u32 {
-    type Assoc = u32;
-}
-
-fn bar<'b, T: Trait<'b>>() -> T::Assoc { todo!() }
-fn foo<'a>()
-where
-    u32: Trait<'a>,
-{
-    // Normalizing the return type would use the impl, proving
-    // the `T: Trait` where-bound would use the where-bound, resulting
-    // in different region constraints.
-    bar::<'_, u32>();
-}
-```
-
-#### RPITIT `type_of` cycles
-
-We currently have to avoid impl candidates if there are where-bounds to avoid query cycles for RPITIT, see [#139762]. It feels desirable to me to stop relying on auto-trait leakage of during RPITIT computation to remove this issue, see [#139788].
-
-```rust
-use std::future::Future;
-pub trait ReactiveFunction: Send {
-    type Output;
-
-    fn invoke(self) -> Self::Output;
-}
-
-trait AttributeValue {
-    fn resolve(self) -> impl Future<Output = ()> + Send;
-}
-
-impl<F, V> AttributeValue for F
-where
-    F: ReactiveFunction<Output = V>,
-    V: AttributeValue,
-{
-    async fn resolve(self) {
-        // We're awaiting `<V as AttributeValue>::{synthetic#0}` here.
-        // Normalizing that one via the the impl we're currently in
-        // relies on `collect_return_position_impl_trait_in_trait_tys` which
-        // ends up relying on auto-trait leakage when checking that the
-        // opaque return type of this function implements the `Send` item
-        // bound of the trait definition.
-        self.invoke().resolve().await
-    }
-}
-```
 
 ### We always consider `AliasBound` candidates
 
@@ -450,6 +390,67 @@ where
 {
     trait_bound::<&'a u32>(); // ok, proven via impl
     normalize::<&'a u32>(); // error, proven via where-bound
+}
+```
+
+### Trait where-bounds shadow impls
+
+Normalization of associated items does not consider impls if the corresponding trait goal has been proven via a `ParamEnv` or `AliasBound` candidate.
+This means that for where-bounds which do not constrain associated types, the associated types remain *rigid*.
+
+#### Using impls results in different region constraints
+
+This is necessary to avoid unnecessary region constraints from applying impls.
+```rust
+trait Trait<'a> {
+    type Assoc;
+}
+impl Trait<'static> for u32 {
+    type Assoc = u32;
+}
+
+fn bar<'b, T: Trait<'b>>() -> T::Assoc { todo!() }
+fn foo<'a>()
+where
+    u32: Trait<'a>,
+{
+    // Normalizing the return type would use the impl, proving
+    // the `T: Trait` where-bound would use the where-bound, resulting
+    // in different region constraints.
+    bar::<'_, u32>();
+}
+```
+
+#### RPITIT `type_of` cycles
+
+We currently have to avoid impl candidates if there are where-bounds to avoid query cycles for RPITIT, see [#139762]. It feels desirable to me to stop relying on auto-trait leakage of during RPITIT computation to remove this issue, see [#139788].
+
+```rust
+use std::future::Future;
+pub trait ReactiveFunction: Send {
+    type Output;
+
+    fn invoke(self) -> Self::Output;
+}
+
+trait AttributeValue {
+    fn resolve(self) -> impl Future<Output = ()> + Send;
+}
+
+impl<F, V> AttributeValue for F
+where
+    F: ReactiveFunction<Output = V>,
+    V: AttributeValue,
+{
+    async fn resolve(self) {
+        // We're awaiting `<V as AttributeValue>::{synthetic#0}` here.
+        // Normalizing that one via the the impl we're currently in
+        // relies on `collect_return_position_impl_trait_in_trait_tys` which
+        // ends up relying on auto-trait leakage when checking that the
+        // opaque return type of this function implements the `Send` item
+        // bound of the trait definition.
+        self.invoke().resolve().await
+    }
 }
 ```
 

--- a/src/doc/rustc-dev-guide/src/solve/candidate-preference.md
+++ b/src/doc/rustc-dev-guide/src/solve/candidate-preference.md
@@ -260,10 +260,12 @@ We prefer builtin trait object impls over user-written impls. This is **unsound*
 
 The candidate preference behavior during normalization is implemented in [`fn assemble_and_merge_candidates`].
 
-### Where-bounds shadow impls
+### Trait where-bounds shadow impls
 
 Normalization of associated items does not consider impls if the corresponding trait goal has been proven via a `ParamEnv` or `AliasBound` candidate.
 This means that for where-bounds which do not constrain associated types, the associated types remain *rigid*.
+
+#### Using impls results in different region constraints
 
 This is necessary to avoid unnecessary region constraints from applying impls.
 ```rust
@@ -283,6 +285,39 @@ where
     // the `T: Trait` where-bound would use the where-bound, resulting
     // in different region constraints.
     bar::<'_, u32>();
+}
+```
+
+#### RPITIT `type_of` cycles
+
+We currently have to avoid impl candidates if there are where-bounds to avoid query cycles for RPITIT, see [#139762]. It feels desirable to me to stop relying on auto-trait leakage of during RPITIT computation to remove this issue, see [#139788].
+
+```rust
+use std::future::Future;
+pub trait ReactiveFunction: Send {
+    type Output;
+
+    fn invoke(self) -> Self::Output;
+}
+
+trait AttributeValue {
+    fn resolve(self) -> impl Future<Output = ()> + Send;
+}
+
+impl<F, V> AttributeValue for F
+where
+    F: ReactiveFunction<Output = V>,
+    V: AttributeValue,
+{
+    async fn resolve(self) {
+        // We're awaiting `<V as AttributeValue>::{synthetic#0}` here.
+        // Normalizing that one via the the impl we're currently in
+        // relies on `collect_return_position_impl_trait_in_trait_tys` which
+        // ends up relying on auto-trait leakage when checking that the
+        // opaque return type of this function implements the `Send` item
+        // bound of the trait definition.
+        self.invoke().resolve().await
+    }
 }
 ```
 
@@ -425,3 +460,5 @@ where
 [trait-system-refactor-initiative#76]: https://github.com/rust-lang/trait-system-refactor-initiative/issues/76
 [#24066]: https://github.com/rust-lang/rust/issues/24066
 [#133044]: https://github.com/rust-lang/rust/issues/133044
+[#139762]: https://github.com/rust-lang/rust/pull/139762
+[#139788]: https://github.com/rust-lang/rust/issues/139788

--- a/src/doc/rustc-dev-guide/src/tests/ci.md
+++ b/src/doc/rustc-dev-guide/src/tests/ci.md
@@ -198,7 +198,7 @@ to help make the perf comparison as fair as possible.
 >
 > 3. Run the prescribed try jobs with `@bors try`. As aforementioned, this
 >    requires the user to either (1) have `try` permissions or (2) be delegated
->    with `try` permissions by `@bors delegate` by someone who has `try`
+>    with `try` permissions by `@bors delegate=try` by someone who has `try`
 >    permissions.
 >
 > Note that this is usually easier to do than manually edit [`jobs.yml`].
@@ -213,10 +213,7 @@ the corresponding PR.
 Multiple try builds can execute concurrently across different PRs, but there can be at most
 a single try build running on a single PR at any given time.
 
-Note that try builds are handled using the [new bors] implementation.
-
 [rustc-perf]: https://github.com/rust-lang/rustc-perf
-[new bors]: https://github.com/rust-lang/bors
 
 ### Modifying CI jobs
 
@@ -281,8 +278,7 @@ Breakages like these usually happen when another, incompatible PR is merged
 after the build happened.
 
 To ensure a `main` branch that works all the time, we forbid manual merges.
-Instead, all PRs have to be approved through our bot, [bors] (the software
-behind it is called [homu]).
+Instead, all PRs have to be approved through our bot, [bors].
 All the approved PRs are put in a [merge queue]
 (sorted by priority and creation date) and are automatically tested one at the time.
 If all the builders are green, the PR is merged, otherwise the failure is
@@ -465,8 +461,7 @@ To do this:
 [`jobs.yml`]: https://github.com/rust-lang/rust/blob/HEAD/src/ci/github-actions/jobs.yml
 [`.github/workflows/ci.yml`]: https://github.com/rust-lang/rust/blob/HEAD/.github/workflows/ci.yml
 [`src/ci/citool`]: https://github.com/rust-lang/rust/blob/HEAD/src/ci/citool
-[bors]: https://github.com/bors
-[homu]: https://github.com/rust-lang/homu
+[bors]: https://github.com/rust-lang/bors
 [merge queue]: https://bors.rust-lang.org/queue/rust
 [dist-x86_64-linux]: https://github.com/rust-lang/rust/blob/HEAD/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
 [the GitHub Actions workflows page]: https://github.com/rust-lang/rust/actions

--- a/src/doc/rustc-dev-guide/src/tests/ui.md
+++ b/src/doc/rustc-dev-guide/src/tests/ui.md
@@ -139,6 +139,10 @@ prefixing each source line are replaced with `LL`). In extremely rare
 situations, this mode can be disabled with the directive `//@
 compile-flags: -Z ui-testing=no`.
 
+When using `-Z ui-testing=no` the `--diagnostic-width` argument should also
+be set to avoid tests failing or passing depending on the width of the terminal
+from which the UI test suite is being run.
+
 Note: The line and column numbers for `-->` lines pointing to the test are *not*
 normalized, and left as-is. This ensures that the compiler continues to point to
 the correct location, and keeps the stderr files readable. Ideally all

--- a/src/doc/rustc-dev-guide/triagebot.toml
+++ b/src/doc/rustc-dev-guide/triagebot.toml
@@ -86,3 +86,6 @@ rustc-dev-guide = [
     "@jyn514",
     "@tshepang",
 ]
+
+# Make rebases more easy to read: https://forge.rust-lang.org/triagebot/range-diff.html
+[range-diff]

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -126,6 +126,7 @@ fn synthesize_auto_trait_impl<'tcx>(
                 items: Vec::new(),
                 polarity,
                 kind: clean::ImplKind::Auto,
+                is_deprecated: false,
             })),
             item_id: clean::ItemId::Auto { trait_: trait_def_id, for_: item_def_id },
             cfg: None,

--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -117,6 +117,9 @@ pub(crate) fn synthesize_blanket_impls(
                             None,
                             None,
                         ))),
+                        is_deprecated: tcx
+                            .lookup_deprecation(impl_def_id)
+                            .is_some_and(|deprecation| deprecation.is_in_effect()),
                     })),
                     cfg: None,
                     inline_stmt_id: None,

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -645,6 +645,9 @@ pub(crate) fn build_impl(
             } else {
                 ImplKind::Normal
             },
+            is_deprecated: tcx
+                .lookup_deprecation(did)
+                .is_some_and(|deprecation| deprecation.is_in_effect()),
         })),
         merged_attrs,
         cfg,

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2882,6 +2882,9 @@ fn clean_impl<'tcx>(
             )),
             _ => None,
         });
+    let is_deprecated = tcx
+        .lookup_deprecation(def_id.to_def_id())
+        .is_some_and(|deprecation| deprecation.is_in_effect());
     let mut make_item = |trait_: Option<Path>, for_: Type, items: Vec<Item>| {
         let kind = ImplItem(Box::new(Impl {
             safety: match impl_.of_trait {
@@ -2902,6 +2905,7 @@ fn clean_impl<'tcx>(
             } else {
                 ImplKind::Normal
             },
+            is_deprecated,
         }));
         Item::from_def_id_and_parts(def_id.to_def_id(), None, kind, cx)
     };

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -427,6 +427,10 @@ impl Item {
         })
     }
 
+    pub(crate) fn is_deprecated(&self, tcx: TyCtxt<'_>) -> bool {
+        self.deprecation(tcx).is_some_and(|deprecation| deprecation.is_in_effect())
+    }
+
     pub(crate) fn inner_docs(&self, tcx: TyCtxt<'_>) -> bool {
         self.item_id.as_def_id().map(|did| inner_docs(tcx.get_all_attrs(did))).unwrap_or(false)
     }
@@ -1269,6 +1273,9 @@ impl Trait {
     }
     pub(crate) fn is_dyn_compatible(&self, tcx: TyCtxt<'_>) -> bool {
         tcx.is_dyn_compatible(self.def_id)
+    }
+    pub(crate) fn is_deprecated(&self, tcx: TyCtxt<'_>) -> bool {
+        tcx.lookup_deprecation(self.def_id).is_some_and(|deprecation| deprecation.is_in_effect())
     }
 }
 
@@ -2254,6 +2261,7 @@ pub(crate) struct Impl {
     pub(crate) items: Vec<Item>,
     pub(crate) polarity: ty::ImplPolarity,
     pub(crate) kind: ImplKind,
+    pub(crate) is_deprecated: bool,
 }
 
 impl Impl {

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -593,7 +593,7 @@ fn add_item_to_search_index(tcx: TyCtxt<'_>, cache: &mut Cache, item: &clean::It
         cache,
     );
     let aliases = item.attrs.get_doc_aliases();
-    let deprecation = item.deprecation(tcx);
+    let is_deprecated = item.is_deprecated(tcx);
     let index_item = IndexItem {
         ty: item.type_(),
         defid: Some(defid),
@@ -608,7 +608,7 @@ fn add_item_to_search_index(tcx: TyCtxt<'_>, cache: &mut Cache, item: &clean::It
         impl_id,
         search_type,
         aliases,
-        deprecation,
+        is_deprecated,
     };
 
     cache.search_index.push(index_item);

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -141,7 +141,7 @@ pub(crate) struct IndexItem {
     pub(crate) impl_id: Option<DefId>,
     pub(crate) search_type: Option<IndexItemFunctionType>,
     pub(crate) aliases: Box<[Symbol]>,
-    pub(crate) deprecation: Option<Deprecation>,
+    pub(crate) is_deprecated: bool,
 }
 
 /// A type used for the search index.

--- a/src/librustdoc/html/render/search_index.rs
+++ b/src/librustdoc/html/render/search_index.rs
@@ -1282,7 +1282,7 @@ pub(crate) fn build_index(
                     cache,
                 ),
                 aliases: item.attrs.get_doc_aliases(),
-                deprecation: item.deprecation(tcx),
+                is_deprecated: item.is_deprecated(tcx),
             });
         }
     }
@@ -1519,7 +1519,7 @@ pub(crate) fn build_index(
                 trait_parent: item.trait_parent_idx,
                 module_path,
                 exact_module_path,
-                deprecated: item.deprecation.is_some(),
+                deprecated: item.is_deprecated,
                 associated_item_disambiguator: if let Some(impl_id) = item.impl_id
                     && let Some(parent_idx) = item.parent_idx
                     && associated_item_duplicates

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -20,6 +20,7 @@
 	--src-sidebar-width: 300px;
 	--desktop-sidebar-z-index: 100;
 	--sidebar-elems-left-padding: 24px;
+	--popover-top-margin: 7px;
 	/* clipboard <https://github.com/rust-lang/crates.io/commits/main/public/assets/copy.svg> */
 	--clipboard-image: url('data:image/svg+xml,<svg width="19" height="18" viewBox="0 0 24 25" \
 xmlns="http://www.w3.org/2000/svg" aria-label="Copy to clipboard">\
@@ -1435,7 +1436,7 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	top: 100%;
 	right: 0;
 	z-index: calc(var(--desktop-sidebar-z-index) + 1);
-	margin-top: 7px;
+	margin-top: var(--popover-top-margin);
 	border-radius: 3px;
 	border: 1px solid var(--border-color);
 	background-color: var(--main-background-color);
@@ -2650,6 +2651,7 @@ in src-script.js and main.js
 @media (max-width: 700px) {
 	:root {
 		--impl-items-indent: 0.7em;
+		--topbar-height: 45px;
 	}
 
 	/* When linking to an item with an `id` (for instance, by clicking a link in the sidebar,
@@ -2657,7 +2659,7 @@ in src-script.js and main.js
 	   by the topbar. Anything with an `id` gets scroll-margin-top equal to rustdoc-topbar's size.
 	*/
 	*[id] {
-		scroll-margin-top: 45px;
+		scroll-margin-top: var(--topbar-height);
 	}
 
 	/* We don't display this button on mobile devices. */
@@ -2689,13 +2691,22 @@ in src-script.js and main.js
 		background: var(--main-background-color);
 		border-radius: 0;
 	}
-	#settings.popover {
+	#settings.popover, #help.popover {
 		top: 32px;
+		/* The `+ 1px` part is for the bottom border to be visible. */
+		height: calc(100vh - var(--topbar-height) + var(--popover-top-margin) - 1px);
+	}
+	#settings.popover {
 		--popover-arrow-offset: 48px;
 	}
 	#help.popover {
-		top: 32px;
 		--popover-arrow-offset: 12px;
+	}
+	/* The `overflow-y` property is used on an internal content instead of the top one otherwise the
+	   little arrow at the top can't be displayed. */
+	#settings.popover .settings, #help.popover .content {
+		overflow-y: scroll;
+		height: 100%;
 	}
 
 	.rustdoc {
@@ -2719,13 +2730,13 @@ in src-script.js and main.js
 
 	.sidebar {
 		position: fixed;
-		top: 45px;
+		top: var(--topbar-height);
 		/* Hide the sidebar offscreen while not in use. Doing this instead of display: none means
 		   the sidebar stays visible for screen readers, which is useful for navigation. */
 		left: -1000px;
 		z-index: 11;
 		/* Reduce height slightly to account for mobile topbar. */
-		height: calc(100vh - 45px);
+		height: calc(100vh - var(--topbar-height));
 		/* resize indicator: hide this when on touch or mobile */
 		border-right: none;
 		width: 100%;
@@ -2790,7 +2801,7 @@ in src-script.js and main.js
 		flex-direction: row;
 		position: sticky;
 		z-index: 10;
-		height: 45px;
+		height: var(--topbar-height);
 		width: 100%;
 		left: 0;
 		top: 0;

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -2642,6 +2642,15 @@ However, it's not needed with smaller screen width because the doc/code block is
 	}
 }
 
+/* Items on module pages */
+.hide-deprecated-items dt.deprecated,
+.hide-deprecated-items dt.deprecated + dd,
+/* Items on item pages */
+.hide-deprecated-items .deprecated,
+.hide-deprecated-items .deprecated + .item-info {
+	display: none;
+}
+
 /*
 WARNING: RUSTDOC_MOBILE_BREAKPOINT MEDIA QUERY
 If you update this line, then you also need to update the line with the same warning

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -64,7 +64,7 @@ xmlns="http://www.w3.org/2000/svg" fill="black" height="18px">\
 		<path d="M3,5h16M3,11h16M3,17h16" stroke-width="2.75"/></svg>');
 }
 
-:root.sans-serif {
+:root.sans-serif-fonts {
 	--font-family: "Fira Sans", sans-serif;
 	--font-family-code: "Fira Mono", monospace;
 }

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -1692,7 +1692,7 @@ function preLoadCss(cssUrl) {
 
         const container = document.createElement("div");
         if (!isHelpPage) {
-            container.className = "popover content";
+            container.className = "popover";
         }
         container.id = "help";
 
@@ -1701,9 +1701,14 @@ function preLoadCss(cssUrl) {
         side_by_side.appendChild(div_shortcuts);
         side_by_side.appendChild(div_infos);
 
-        container.appendChild(book_info);
-        container.appendChild(side_by_side);
-        container.appendChild(rustdoc_version);
+        const content = document.createElement("div");
+        content.className = "content";
+
+        content.appendChild(book_info);
+        content.appendChild(side_by_side);
+        content.appendChild(rustdoc_version);
+
+        container.appendChild(content);
 
         if (isHelpPage) {
             const help_section = document.createElement("section");

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -4920,6 +4920,9 @@ async function addTab(results, query, display, finishedCallback, isTypeSearch) {
 
         const link = document.createElement("a");
         link.className = "result-" + type;
+        if (obj.item.deprecated) {
+            link.className += " deprecated";
+        }
         link.href = obj.href;
 
         const resultName = document.createElement("span");

--- a/src/librustdoc/html/static/js/settings.js
+++ b/src/librustdoc/html/static/js/settings.js
@@ -78,6 +78,12 @@
                     removeClass(document.documentElement, "word-wrap-source-code");
                 }
                 break;
+            case "hide-deprecated-items":
+                if (value === true) {
+                    addClass(document.documentElement, "hide-deprecated-items");
+                } else {
+                    removeClass(document.documentElement, "hide-deprecated-items");
+                }
         }
     }
 
@@ -272,6 +278,11 @@
             {
                 "name": "Word wrap source code",
                 "js_name": "word-wrap-source-code",
+                "default": false,
+            },
+            {
+                "name": "Hide deprecated items",
+                "js_name": "hide-deprecated-items",
                 "default": false,
             },
         ];

--- a/src/librustdoc/html/static/js/settings.js
+++ b/src/librustdoc/html/static/js/settings.js
@@ -43,27 +43,6 @@
                     }
                 }
                 break;
-            case "hide-sidebar":
-                if (value === true) {
-                    addClass(document.documentElement, "hide-sidebar");
-                } else {
-                    removeClass(document.documentElement, "hide-sidebar");
-                }
-                break;
-            case "hide-toc":
-                if (value === true) {
-                    addClass(document.documentElement, "hide-toc");
-                } else {
-                    removeClass(document.documentElement, "hide-toc");
-                }
-                break;
-            case "hide-modnav":
-                if (value === true) {
-                    addClass(document.documentElement, "hide-modnav");
-                } else {
-                    removeClass(document.documentElement, "hide-modnav");
-                }
-                break;
             case "sans-serif-fonts":
                 if (value === true) {
                     addClass(document.documentElement, "sans-serif");
@@ -71,18 +50,15 @@
                     removeClass(document.documentElement, "sans-serif");
                 }
                 break;
+            case "hide-sidebar":
+            case "hide-toc":
+            case "hide-modnav":
             case "word-wrap-source-code":
-                if (value === true) {
-                    addClass(document.documentElement, "word-wrap-source-code");
-                } else {
-                    removeClass(document.documentElement, "word-wrap-source-code");
-                }
-                break;
             case "hide-deprecated-items":
                 if (value === true) {
-                    addClass(document.documentElement, "hide-deprecated-items");
+                    addClass(document.documentElement, settingName);
                 } else {
-                    removeClass(document.documentElement, "hide-deprecated-items");
+                    removeClass(document.documentElement, settingName);
                 }
         }
     }

--- a/src/librustdoc/html/static/js/settings.js
+++ b/src/librustdoc/html/static/js/settings.js
@@ -44,12 +44,6 @@
                 }
                 break;
             case "sans-serif-fonts":
-                if (value === true) {
-                    addClass(document.documentElement, "sans-serif");
-                } else {
-                    removeClass(document.documentElement, "sans-serif");
-                }
-                break;
             case "hide-sidebar":
             case "hide-toc":
             case "hide-modnav":

--- a/src/librustdoc/html/static/js/storage.js
+++ b/src/librustdoc/html/static/js/storage.js
@@ -319,24 +319,24 @@ updateTheme();
 if (getSettingValue("source-sidebar-show") === "true") {
     addClass(document.documentElement, "src-sidebar-expanded");
 }
-if (getSettingValue("hide-sidebar") === "true") {
-    addClass(document.documentElement, "hide-sidebar");
-}
-if (getSettingValue("hide-toc") === "true") {
-    addClass(document.documentElement, "hide-toc");
-}
-if (getSettingValue("hide-modnav") === "true") {
-    addClass(document.documentElement, "hide-modnav");
-}
 if (getSettingValue("sans-serif-fonts") === "true") {
     addClass(document.documentElement, "sans-serif");
 }
-if (getSettingValue("word-wrap-source-code") === "true") {
-    addClass(document.documentElement, "word-wrap-source-code");
-}
-if (getSettingValue("hide-deprecated-items") === "true") {
-    addClass(document.documentElement, "hide-deprecated-items");
-}
+(function() {
+    const settings = [
+        "hide-sidebar",
+        "hide-toc",
+        "hide-modnav",
+        "word-wrap-source-code",
+        "hide-deprecated-items",
+    ];
+    for (const setting of settings) {
+        if (getSettingValue(setting) === "true") {
+            addClass(document.documentElement, setting);
+        }
+    }
+})();
+
 function updateSidebarWidth() {
     const desktopSidebarWidth = getSettingValue("desktop-sidebar-width");
     if (desktopSidebarWidth && desktopSidebarWidth !== "null") {

--- a/src/librustdoc/html/static/js/storage.js
+++ b/src/librustdoc/html/static/js/storage.js
@@ -319,9 +319,6 @@ updateTheme();
 if (getSettingValue("source-sidebar-show") === "true") {
     addClass(document.documentElement, "src-sidebar-expanded");
 }
-if (getSettingValue("sans-serif-fonts") === "true") {
-    addClass(document.documentElement, "sans-serif");
-}
 (function() {
     const settings = [
         "hide-sidebar",
@@ -329,6 +326,7 @@ if (getSettingValue("sans-serif-fonts") === "true") {
         "hide-modnav",
         "word-wrap-source-code",
         "hide-deprecated-items",
+        "sans-serif-fonts",
     ];
     for (const setting of settings) {
         if (getSettingValue(setting) === "true") {

--- a/src/librustdoc/html/static/js/storage.js
+++ b/src/librustdoc/html/static/js/storage.js
@@ -334,6 +334,9 @@ if (getSettingValue("sans-serif-fonts") === "true") {
 if (getSettingValue("word-wrap-source-code") === "true") {
     addClass(document.documentElement, "word-wrap-source-code");
 }
+if (getSettingValue("hide-deprecated-items") === "true") {
+    addClass(document.documentElement, "hide-deprecated-items");
+}
 function updateSidebarWidth() {
     const desktopSidebarWidth = getSettingValue("desktop-sidebar-width");
     if (desktopSidebarWidth && desktopSidebarWidth !== "null") {

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -711,7 +711,8 @@ impl FromClean<clean::PolyTrait> for PolyTrait {
 impl FromClean<clean::Impl> for Impl {
     fn from_clean(impl_: &clean::Impl, renderer: &JsonRenderer<'_>) -> Self {
         let provided_trait_methods = impl_.provided_trait_methods(renderer.tcx);
-        let clean::Impl { safety, generics, trait_, for_, items, polarity, kind } = impl_;
+        let clean::Impl { safety, generics, trait_, for_, items, polarity, kind, is_deprecated: _ } =
+            impl_;
         // FIXME: use something like ImplKind in JSON?
         let (is_synthetic, blanket_impl) = match kind {
             clean::ImplKind::Normal | clean::ImplKind::FakeVariadic => (false, None),

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -11,10 +11,11 @@ use rustc_ast::util::comments::may_have_doc_links;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_data_structures::intern::Interned;
 use rustc_errors::{Applicability, Diag, DiagMessage};
+use rustc_hir::attrs::AttributeKind;
 use rustc_hir::def::Namespace::*;
 use rustc_hir::def::{DefKind, MacroKinds, Namespace, PerNS};
 use rustc_hir::def_id::{CRATE_DEF_ID, DefId, LOCAL_CRATE};
-use rustc_hir::{Mutability, Safety};
+use rustc_hir::{Attribute, Mutability, Safety};
 use rustc_middle::ty::{Ty, TyCtxt};
 use rustc_middle::{bug, span_bug, ty};
 use rustc_resolve::rustdoc::pulldown_cmark::LinkType;
@@ -1108,10 +1109,8 @@ impl LinkCollector<'_, '_> {
 
         // Also resolve links in the note text of `#[deprecated]`.
         for attr in &item.attrs.other_attrs {
-            let rustc_hir::Attribute::Parsed(rustc_hir::attrs::AttributeKind::Deprecation {
-                span,
-                deprecation,
-            }) = attr
+            let Attribute::Parsed(AttributeKind::Deprecation { span: depr_span, deprecation }) =
+                attr
             else {
                 continue;
             };
@@ -1128,8 +1127,14 @@ impl LinkCollector<'_, '_> {
             // inlined item.
             // <https://github.com/rust-lang/rust/pull/151120>
             let item_id = if let Some(inline_stmt_id) = item.inline_stmt_id
-                && item.span(tcx).is_none_or(|item_span| !item_span.inner().contains(*span))
-            {
+                && tcx.get_all_attrs(inline_stmt_id).iter().any(|attr| {
+                    matches!(
+                        attr,
+                        Attribute::Parsed(AttributeKind::Deprecation {
+                            span: attr_span, ..
+                        }) if attr_span == depr_span,
+                    )
+                }) {
                 inline_stmt_id.to_def_id()
             } else {
                 item.item_id.expect_def_id()

--- a/tests/codegen-llvm/gpu_offload/scalar_device.rs
+++ b/tests/codegen-llvm/gpu_offload/scalar_device.rs
@@ -1,0 +1,36 @@
+//@ add-minicore
+//@ revisions: amdgpu nvptx
+//@[nvptx] compile-flags: -Copt-level=0 -Zunstable-options -Zoffload=Device --target nvptx64-nvidia-cuda --crate-type=rlib
+//@[nvptx] needs-llvm-components: nvptx
+//@[amdgpu] compile-flags: -Copt-level=0 -Zunstable-options -Zoffload=Device --target amdgcn-amd-amdhsa -Ctarget-cpu=gfx900 --crate-type=rlib
+//@[amdgpu] needs-llvm-components: amdgpu
+//@ no-prefer-dynamic
+//@ needs-offload
+
+// This test verifies that the offload intrinsic is properly handling scalar args on the device,
+// replacing the args by i64 and then trunc and cast them to the original type
+
+#![feature(abi_gpu_kernel, rustc_attrs, no_core)]
+#![no_core]
+
+extern crate minicore;
+
+// CHECK: ; Function Attrs
+// nvptx-NEXT: define ptx_kernel void @foo(ptr %dyn_ptr, ptr %0, i64 %1)
+// amdgpu-NEXT: define amdgpu_kernel void @foo(ptr %dyn_ptr, ptr %0, i64 %1)
+// CHECK-NEXT: entry:
+// CHECK-NEXT: %2 = trunc i64 %1 to i32
+// CHECK-NEXT: %3 = bitcast i32 %2 to float
+// CHECK-NEXT: br label %start
+// CHECK: start:
+// CHECK-NEXT: store float %3, ptr %0, align 4
+// CHECK-NEXT: ret void
+// CHECK-NEXT: }
+
+#[unsafe(no_mangle)]
+#[rustc_offload_kernel]
+pub unsafe extern "gpu-kernel" fn foo(x: *mut f32, k: f32) {
+    unsafe {
+        *x = k;
+    };
+}

--- a/tests/codegen-llvm/gpu_offload/scalar_host.rs
+++ b/tests/codegen-llvm/gpu_offload/scalar_host.rs
@@ -1,0 +1,37 @@
+//@ compile-flags: -Zoffload=Test -Zunstable-options -C opt-level=1 -Clto=fat
+//@ no-prefer-dynamic
+//@ needs-offload
+
+// This test verifies that the offload intrinsic is properly handling scalar args, passing them to
+// the kernel as i64
+
+#![feature(abi_gpu_kernel)]
+#![feature(rustc_attrs)]
+#![feature(core_intrinsics)]
+#![no_main]
+
+// CHECK: define{{( dso_local)?}} void @main()
+// CHECK-NOT: define
+// CHECK: %addr = alloca i64, align 8
+// CHECK: store double 4.200000e+01, ptr %0, align 8
+// CHECK: %_0.i = load double, ptr %0, align 8
+// CHECK: store double %_0.i, ptr %addr, align 8
+// CHECK: %1 = getelementptr inbounds nuw i8, ptr %.offload_baseptrs, i64 8
+// CHECK-NEXT: store double %_0.i, ptr %1, align 8
+// CHECK-NEXT: %2 = getelementptr inbounds nuw i8, ptr %.offload_ptrs, i64 8
+// CHECK-NEXT: store ptr %addr, ptr %2, align 8
+// CHECK-NEXT: %3 = getelementptr inbounds nuw i8, ptr %.offload_sizes, i64 8
+// CHECK-NEXT: store i64 4, ptr %3, align 8
+// CHECK-NEXT: call void @__tgt_target_data_begin_mapper
+
+#[unsafe(no_mangle)]
+fn main() {
+    let mut x = 0.0;
+    let k = core::hint::black_box(42.0);
+
+    core::intrinsics::offload::<_, _, ()>(foo, [1, 1, 1], [1, 1, 1], (&mut x, k));
+}
+
+unsafe extern "C" {
+    pub fn foo(x: *mut f32, k: f32);
+}

--- a/tests/coverage/macros/pass-through.cov-map
+++ b/tests/coverage/macros/pass-through.cov-map
@@ -1,0 +1,57 @@
+Function name: pass_through::uses_inner_macro
+Raw bytes (51): 0x[01, 01, 01, 01, 05, 09, 01, 24, 01, 00, 16, 01, 01, 08, 00, 1d, 05, 01, 09, 00, 0c, 05, 00, 0d, 00, 21, 05, 01, 09, 00, 15, 05, 01, 09, 00, 0c, 05, 00, 0d, 00, 20, 02, 01, 05, 00, 06, 01, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/pass-through.rs
+Number of expressions: 1
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+Number of file 0 mappings: 9
+- Code(Counter(0)) at (prev + 36, 1) to (start + 0, 22)
+- Code(Counter(0)) at (prev + 1, 8) to (start + 0, 29)
+- Code(Counter(1)) at (prev + 1, 9) to (start + 0, 12)
+- Code(Counter(1)) at (prev + 0, 13) to (start + 0, 33)
+- Code(Counter(1)) at (prev + 1, 9) to (start + 0, 21)
+- Code(Counter(1)) at (prev + 1, 9) to (start + 0, 12)
+- Code(Counter(1)) at (prev + 0, 13) to (start + 0, 32)
+- Code(Expression(0, Sub)) at (prev + 1, 5) to (start + 0, 6)
+    = (c0 - c1)
+- Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)
+Highest counter ID seen: c1
+
+Function name: pass_through::uses_middle_macro
+Raw bytes (51): 0x[01, 01, 01, 01, 05, 09, 01, 2c, 01, 00, 17, 01, 01, 08, 00, 1d, 05, 01, 09, 00, 0c, 05, 00, 0d, 00, 22, 05, 01, 09, 00, 16, 05, 01, 09, 00, 0c, 05, 00, 0d, 00, 21, 02, 01, 05, 00, 06, 01, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/pass-through.rs
+Number of expressions: 1
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+Number of file 0 mappings: 9
+- Code(Counter(0)) at (prev + 44, 1) to (start + 0, 23)
+- Code(Counter(0)) at (prev + 1, 8) to (start + 0, 29)
+- Code(Counter(1)) at (prev + 1, 9) to (start + 0, 12)
+- Code(Counter(1)) at (prev + 0, 13) to (start + 0, 34)
+- Code(Counter(1)) at (prev + 1, 9) to (start + 0, 22)
+- Code(Counter(1)) at (prev + 1, 9) to (start + 0, 12)
+- Code(Counter(1)) at (prev + 0, 13) to (start + 0, 33)
+- Code(Expression(0, Sub)) at (prev + 1, 5) to (start + 0, 6)
+    = (c0 - c1)
+- Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)
+Highest counter ID seen: c1
+
+Function name: pass_through::uses_outer_macro
+Raw bytes (51): 0x[01, 01, 01, 01, 05, 09, 01, 34, 01, 00, 16, 01, 01, 08, 00, 1d, 05, 01, 09, 00, 0c, 05, 00, 0d, 00, 21, 05, 01, 09, 00, 15, 05, 01, 09, 00, 0c, 05, 00, 0d, 00, 20, 02, 01, 05, 00, 06, 01, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/pass-through.rs
+Number of expressions: 1
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+Number of file 0 mappings: 9
+- Code(Counter(0)) at (prev + 52, 1) to (start + 0, 22)
+- Code(Counter(0)) at (prev + 1, 8) to (start + 0, 29)
+- Code(Counter(1)) at (prev + 1, 9) to (start + 0, 12)
+- Code(Counter(1)) at (prev + 0, 13) to (start + 0, 33)
+- Code(Counter(1)) at (prev + 1, 9) to (start + 0, 21)
+- Code(Counter(1)) at (prev + 1, 9) to (start + 0, 12)
+- Code(Counter(1)) at (prev + 0, 13) to (start + 0, 32)
+- Code(Expression(0, Sub)) at (prev + 1, 5) to (start + 0, 6)
+    = (c0 - c1)
+- Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)
+Highest counter ID seen: c1
+

--- a/tests/coverage/macros/pass-through.coverage
+++ b/tests/coverage/macros/pass-through.coverage
@@ -1,0 +1,71 @@
+   LL|       |#![feature(coverage_attribute)]
+   LL|       |//@ edition: 2024
+   LL|       |
+   LL|       |// Test that when a macro expands to another macro, without any significant
+   LL|       |// spans of its own, that this doesn't cause coverage instrumentation to give
+   LL|       |// up and ignore the inner spans.
+   LL|       |
+   LL|       |macro_rules! inner_macro {
+   LL|       |    () => {
+   LL|       |        if core::hint::black_box(true) {
+   LL|       |            say("true");
+   LL|       |        } else {
+   LL|       |            say("false");
+   LL|       |        }
+   LL|       |    };
+   LL|       |}
+   LL|       |
+   LL|       |macro_rules! middle_macro {
+   LL|       |    () => {
+   LL|       |        inner_macro!()
+   LL|       |    };
+   LL|       |}
+   LL|       |
+   LL|       |macro_rules! outer_macro {
+   LL|       |    () => {
+   LL|       |        middle_macro!()
+   LL|       |    };
+   LL|       |}
+   LL|       |
+   LL|       |// In each of these three functions, the macro call should be instrumented,
+   LL|       |// and should have an execution count of 1.
+   LL|       |//
+   LL|       |// Each function contains some extra code to ensure that control flow is
+   LL|       |// non-trivial.
+   LL|       |
+   LL|      1|fn uses_inner_macro() {
+   LL|      1|    if core::hint::black_box(true) {
+   LL|      1|        say("before inner_macro");
+   LL|      1|        inner_macro!();
+   LL|      1|        say("after inner_macro");
+   LL|      0|    }
+   LL|      1|}
+   LL|       |
+   LL|      1|fn uses_middle_macro() {
+   LL|      1|    if core::hint::black_box(true) {
+   LL|      1|        say("before middle_macro");
+   LL|      1|        middle_macro!();
+   LL|      1|        say("after middle_macro")
+   LL|      0|    }
+   LL|      1|}
+   LL|       |
+   LL|      1|fn uses_outer_macro() {
+   LL|      1|    if core::hint::black_box(true) {
+   LL|      1|        say("before outer_macro");
+   LL|      1|        outer_macro!();
+   LL|      1|        say("after outer_macro");
+   LL|      0|    }
+   LL|      1|}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |fn main() {
+   LL|       |    uses_inner_macro();
+   LL|       |    uses_middle_macro();
+   LL|       |    uses_outer_macro();
+   LL|       |}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |fn say(message: &str) {
+   LL|       |    println!("{message}");
+   LL|       |}
+

--- a/tests/coverage/macros/pass-through.rs
+++ b/tests/coverage/macros/pass-through.rs
@@ -1,0 +1,70 @@
+#![feature(coverage_attribute)]
+//@ edition: 2024
+
+// Test that when a macro expands to another macro, without any significant
+// spans of its own, that this doesn't cause coverage instrumentation to give
+// up and ignore the inner spans.
+
+macro_rules! inner_macro {
+    () => {
+        if core::hint::black_box(true) {
+            say("true");
+        } else {
+            say("false");
+        }
+    };
+}
+
+macro_rules! middle_macro {
+    () => {
+        inner_macro!()
+    };
+}
+
+macro_rules! outer_macro {
+    () => {
+        middle_macro!()
+    };
+}
+
+// In each of these three functions, the macro call should be instrumented,
+// and should have an execution count of 1.
+//
+// Each function contains some extra code to ensure that control flow is
+// non-trivial.
+
+fn uses_inner_macro() {
+    if core::hint::black_box(true) {
+        say("before inner_macro");
+        inner_macro!();
+        say("after inner_macro");
+    }
+}
+
+fn uses_middle_macro() {
+    if core::hint::black_box(true) {
+        say("before middle_macro");
+        middle_macro!();
+        say("after middle_macro")
+    }
+}
+
+fn uses_outer_macro() {
+    if core::hint::black_box(true) {
+        say("before outer_macro");
+        outer_macro!();
+        say("after outer_macro");
+    }
+}
+
+#[coverage(off)]
+fn main() {
+    uses_inner_macro();
+    uses_middle_macro();
+    uses_outer_macro();
+}
+
+#[coverage(off)]
+fn say(message: &str) {
+    println!("{message}");
+}

--- a/tests/rustdoc-gui/mobile-topbar-menu-popovers.goml
+++ b/tests/rustdoc-gui/mobile-topbar-menu-popovers.goml
@@ -1,0 +1,33 @@
+// Ensure that topbar popover menus content can be scrolled on mobile.
+go-to: "file://" + |DOC_PATH| + "/lib2/index.html"
+store-value: (window_height, 500)
+set-window-size: (400, |window_height|)
+
+include: "utils.goml"
+
+// We open the settings menu
+call-function: ("open-settings-menu", {})
+// We ensure it's not scrolled down yet.
+assert-property: ("#settings .settings", {"scrollTop": 0})
+// We ensure its height is smaller than the window's, but its content's height is bigger.
+store-property: ("#settings .settings", {"offsetHeight": menu_height, "scrollHeight": scroll_height})
+assert: |menu_height| < |window_height| && |scroll_height| > |window_height|
+
+// We scroll to the last element of the menu.
+scroll-to: "#settings .setting-line:last-of-type input"
+// The item should be visible now, and so the Y scroll value should have changed.
+assert-property: ("#settings .settings", {"scrollTop": 295})
+
+// Now we open the help menu.
+click: ".help-menu a"
+wait-for: "#help"
+// We ensure it's not scrolled down yet.
+assert-property: ("#help .content", {"scrollTop": 0})
+// We ensure its height is smaller than the window's, but its content's height is bigger.
+store-property: ("#help .content", {"offsetHeight": menu_height, "scrollHeight": scroll_height})
+assert: |menu_height| < |window_height| && |scroll_height| > |window_height|
+
+// We scroll to the last element of the menu.
+scroll-to: "#help .infos > :last-child"
+// The item should be visible now, and so the Y scroll value should have changed.
+assert-property: ("#help .content", {"scrollTop": 339})

--- a/tests/rustdoc-gui/setting-hide-deprecated.goml
+++ b/tests/rustdoc-gui/setting-hide-deprecated.goml
@@ -1,0 +1,83 @@
+// Test that the "hide deprecated" setting is correctly handled.
+
+include: "utils.goml"
+
+go-to: "file://" + |DOC_PATH| + "/lib2/deprecated/index.html"
+
+// There should be two deprecated items listed on the module page:
+// `DeprecatedStruct` and `DeprecatedTrait`.
+assert-count: ("dt.deprecated", 2)
+// `DeprecatedStruct` and `DeprecatedTrait` should be displayed for now.
+assert-css: ("dt.deprecated", {"display": "block"}, ALL)
+
+// We enable the "hide deprecated items" setting.
+call-function: ("open-settings-menu", {})
+click: "#hide-deprecated-items"
+// None of them should be displayed anymore.
+wait-for-css: ("dt.deprecated", {"display": "none"}, ALL)
+
+// We disable the setting.
+click: "#hide-deprecated-items"
+// All of them should be displayed back.
+wait-for-css: ("dt.deprecated", {"display": "block"}, ALL)
+
+// Now we go to a trait with a deprecated method and a deprecated associated const.
+go-to: "file://" + |DOC_PATH| + "/lib2/deprecated/trait.NormalTrait.html"
+
+// There should be two deprecated items.
+assert-count: ("details.deprecated", 2)
+// They should be displayed for now.
+assert-css: ("details.deprecated", {"display": "block"}, ALL)
+
+// We enable the "hide deprecated items" setting.
+call-function: ("open-settings-menu", {})
+click: "#hide-deprecated-items"
+
+// They shouldn't be displayed anymore.
+wait-for-css: ("details.deprecated", {"display": "none"}, ALL)
+
+// We disable the setting.
+click: "#hide-deprecated-items"
+// All of them should be displayed back.
+wait-for-css: ("details.deprecated", {"display": "block"}, ALL)
+
+// We now go to a struct with a deprecated method which implements a deprecated trait and a trait
+// with deprecated associated items.
+go-to: "file://" + |DOC_PATH| + "/lib2/deprecated/struct.NonDeprecatedStruct.html"
+
+// There should be five deprecated items (six minus one "future" deprecated)...
+assert-count: ("details.deprecated", 5)
+// One of which being a deprecated impl because the trait itself is deprecated.
+assert-count: ("details.implementors-toggle.deprecated", 1)
+// And another has `since = "TBD"` and should NOT have the `deprecated` class.
+assert: "details:not(.deprecated) #method\.future_deprecated_fn"
+// They should all be displayed for now.
+assert-css: ("details.deprecated", {"display": "block"}, ALL)
+
+// We enable the "hide deprecated items" setting.
+call-function: ("open-settings-menu", {})
+click: "#hide-deprecated-items"
+
+// They shouldn't be displayed anymore.
+wait-for-css: ("details.deprecated", {"display": "none"}, ALL)
+
+// We disable the setting.
+click: "#hide-deprecated-items"
+// All of them should be displayed back.
+wait-for-css: ("details.deprecated", {"display": "block"}, ALL)
+
+// And now we check with the search results.
+call-function: ("perform-search", {"query": "deprecated::depr"})
+// There should at least 7 results.
+store-count: ("#results ul.search-results.active > a", nb_search_results)
+assert: |nb_search_results| >= 7
+// There should be at least 5 deprecated items.
+store-count: ("#results ul.search-results.active > a.deprecated", nb_deprecated_results)
+assert: |nb_search_results| >= 5
+// Deprecated items should all be displayed.
+assert-css: ("#results ul.search-results.active > a.deprecated", {"display": "grid"}, ALL)
+// We enable the "hide deprecated items" setting.
+call-function: ("open-settings-menu", {})
+click: "#hide-deprecated-items"
+// None of them should be displayed anymore.
+wait-for-css: ("#results ul.search-results.active > a.deprecated", {"display": "none"}, ALL)

--- a/tests/rustdoc-gui/setting-hide-deprecated.goml
+++ b/tests/rustdoc-gui/setting-hide-deprecated.goml
@@ -3,68 +3,69 @@
 include: "utils.goml"
 
 go-to: "file://" + |DOC_PATH| + "/lib2/deprecated/index.html"
+store-value: (deprecated_class, ".deprecated")
 
 // There should be two deprecated items listed on the module page:
 // `DeprecatedStruct` and `DeprecatedTrait`.
-assert-count: ("dt.deprecated", 2)
+assert-count: ("dt" + |deprecated_class|, 2)
 // `DeprecatedStruct` and `DeprecatedTrait` should be displayed for now.
-assert-css: ("dt.deprecated", {"display": "block"}, ALL)
+assert-css: ("dt" + |deprecated_class|, {"display": "block"}, ALL)
 
 // We enable the "hide deprecated items" setting.
 call-function: ("open-settings-menu", {})
 click: "#hide-deprecated-items"
 // None of them should be displayed anymore.
-wait-for-css: ("dt.deprecated", {"display": "none"}, ALL)
+wait-for-css: ("dt" + |deprecated_class|, {"display": "none"}, ALL)
 
 // We disable the setting.
 click: "#hide-deprecated-items"
 // All of them should be displayed back.
-wait-for-css: ("dt.deprecated", {"display": "block"}, ALL)
+wait-for-css: ("dt" + |deprecated_class|, {"display": "block"}, ALL)
 
 // Now we go to a trait with a deprecated method and a deprecated associated const.
 go-to: "file://" + |DOC_PATH| + "/lib2/deprecated/trait.NormalTrait.html"
 
 // There should be two deprecated items.
-assert-count: ("details.deprecated", 2)
+assert-count: ("details" + |deprecated_class|, 2)
 // They should be displayed for now.
-assert-css: ("details.deprecated", {"display": "block"}, ALL)
+assert-css: ("details" + |deprecated_class|, {"display": "block"}, ALL)
 
 // We enable the "hide deprecated items" setting.
 call-function: ("open-settings-menu", {})
 click: "#hide-deprecated-items"
 
 // They shouldn't be displayed anymore.
-wait-for-css: ("details.deprecated", {"display": "none"}, ALL)
+wait-for-css: ("details" + |deprecated_class|, {"display": "none"}, ALL)
 
 // We disable the setting.
 click: "#hide-deprecated-items"
 // All of them should be displayed back.
-wait-for-css: ("details.deprecated", {"display": "block"}, ALL)
+wait-for-css: ("details" + |deprecated_class|, {"display": "block"}, ALL)
 
 // We now go to a struct with a deprecated method which implements a deprecated trait and a trait
 // with deprecated associated items.
 go-to: "file://" + |DOC_PATH| + "/lib2/deprecated/struct.NonDeprecatedStruct.html"
 
 // There should be five deprecated items (six minus one "future" deprecated)...
-assert-count: ("details.deprecated", 5)
+assert-count: ("details" + |deprecated_class|, 5)
 // One of which being a deprecated impl because the trait itself is deprecated.
-assert-count: ("details.implementors-toggle.deprecated", 1)
+assert-count: ("details.implementors-toggle" + |deprecated_class|, 1)
 // And another has `since = "TBD"` and should NOT have the `deprecated` class.
-assert: "details:not(.deprecated) #method\.future_deprecated_fn"
+assert: "details:not(" + |deprecated_class| + ") #method\.future_deprecated_fn"
 // They should all be displayed for now.
-assert-css: ("details.deprecated", {"display": "block"}, ALL)
+assert-css: ("details" + |deprecated_class|, {"display": "block"}, ALL)
 
 // We enable the "hide deprecated items" setting.
 call-function: ("open-settings-menu", {})
 click: "#hide-deprecated-items"
 
 // They shouldn't be displayed anymore.
-wait-for-css: ("details.deprecated", {"display": "none"}, ALL)
+wait-for-css: ("details" + |deprecated_class|, {"display": "none"}, ALL)
 
 // We disable the setting.
 click: "#hide-deprecated-items"
 // All of them should be displayed back.
-wait-for-css: ("details.deprecated", {"display": "block"}, ALL)
+wait-for-css: ("details" + |deprecated_class|, {"display": "block"}, ALL)
 
 // And now we check with the search results.
 call-function: ("perform-search", {"query": "deprecated::depr"})
@@ -72,12 +73,24 @@ call-function: ("perform-search", {"query": "deprecated::depr"})
 store-count: ("#results ul.search-results.active > a", nb_search_results)
 assert: |nb_search_results| >= 7
 // There should be at least 5 deprecated items.
-store-count: ("#results ul.search-results.active > a.deprecated", nb_deprecated_results)
+store-count: ("#results ul.search-results.active > a" + |deprecated_class|, nb_deprecated_results)
 assert: |nb_search_results| >= 5
 // Deprecated items should all be displayed.
-assert-css: ("#results ul.search-results.active > a.deprecated", {"display": "grid"}, ALL)
+assert-css: ("#results ul.search-results.active > a" + |deprecated_class|, {"display": "grid"}, ALL)
 // We enable the "hide deprecated items" setting.
 call-function: ("open-settings-menu", {})
 click: "#hide-deprecated-items"
 // None of them should be displayed anymore.
-wait-for-css: ("#results ul.search-results.active > a.deprecated", {"display": "none"}, ALL)
+wait-for-css: (
+    "#results ul.search-results.active > a" + |deprecated_class|,
+    {"display": "none"},
+    ALL,
+)
+
+// Finally we check that the future deprecated item doesn't have the deprecated class in the search
+// and therefore isn't impact by the setting.
+call-function: ("perform-search", {"query": "deprecated::future_deprecated"})
+assert-text: (
+    "#results ul.search-results.active > a:not(" + |deprecated_class| + ") .path",
+    " lib2::deprecated::NonDeprecatedStruct::future_deprecated_fn",
+)

--- a/tests/rustdoc-gui/src/lib2/lib.rs
+++ b/tests/rustdoc-gui/src/lib2/lib.rs
@@ -368,3 +368,46 @@ impl std::ops::Deref for Derefer {
         &self.0
     }
 }
+
+pub mod deprecated {
+    #[deprecated(since = "1.26.0", note = "deprecated")]
+    pub struct DeprecatedStruct;
+
+    pub struct NonDeprecatedStruct;
+
+    pub trait NormalTrait {
+        #[deprecated(since = "1.26.0", note = "deprecated")]
+        /// doc
+        const X: usize = 12;
+
+        #[deprecated(since = "1.26.0", note = "deprecated")]
+        /// doc
+        fn normal_deprecated_fn();
+    }
+
+    #[deprecated(since = "1.26.0", note = "deprecated")]
+    pub trait DeprecatedTrait {
+        fn depr_deprecated_fn();
+    }
+
+    impl NonDeprecatedStruct {
+        #[deprecated(since = "1.26.0", note = "deprecated")]
+        /// doc
+        pub fn deprecated_fn() {}
+
+        /// doc
+        pub fn non_deprecated_fn() {}
+
+        #[deprecated(since = "TBD", note = "deprecated")]
+        /// doc
+        pub fn future_deprecated_fn() {}
+    }
+
+    impl NormalTrait for NonDeprecatedStruct {
+        fn normal_deprecated_fn() {}
+    }
+
+    impl DeprecatedTrait for NonDeprecatedStruct {
+        fn depr_deprecated_fn() {}
+    }
+}

--- a/tests/rustdoc-gui/utils.goml
+++ b/tests/rustdoc-gui/utils.goml
@@ -63,15 +63,25 @@ define-function: (
     "open-search",
     [],
     block {
-        // Block requests with doubled `//`.
-        // Amazon S3 doesn't support them, but other web hosts do,
-        // and so do file:/// URLs, which means we need to block
-        // it here if we want to avoid breaking the main docs site.
-        // https://github.com/rust-lang/rust/issues/145646
-        block-network-request: "file://*//*"
-        // Perform search
-        click: "#search-button"
-        wait-for: ".search-input"
+        store-count: (".search-input", __search_input_count)
+        if: (|__search_input_count| != 0, block {
+            store-css: ("#alternative-display", {"display": __search_input_display})
+        })
+        else: block {
+            // Block requests with doubled `//`.
+            // Amazon S3 doesn't support them, but other web hosts do,
+            // and so do file:/// URLs, which means we need to block
+            // it here if we want to avoid breaking the main docs site.
+            // https://github.com/rust-lang/rust/issues/145646
+            block-network-request: "file://*//*"
+            store-value: (__search_input_display, "none")
+        }
+
+        if: (|__search_input_display| == "none", block {
+            // Open search
+            click: "#search-button"
+            wait-for: ".search-input"
+        })
     }
 )
 
@@ -80,6 +90,9 @@ define-function: (
     [query],
     block {
         call-function: ("open-search", {})
+        // We empty the search input in case it wasn't empty.
+        set-property: (".search-input", {"value": ""})
+        // We write the actual query.
         write-into: (".search-input", |query|)
         press-key: 'Enter'
         // wait for the search to start

--- a/tests/rustdoc-gui/utils.goml
+++ b/tests/rustdoc-gui/utils.goml
@@ -60,8 +60,8 @@ define-function: (
 )
 
 define-function: (
-    "perform-search",
-    [query],
+    "open-search",
+    [],
     block {
         // Block requests with doubled `//`.
         // Amazon S3 doesn't support them, but other web hosts do,
@@ -72,6 +72,14 @@ define-function: (
         // Perform search
         click: "#search-button"
         wait-for: ".search-input"
+    }
+)
+
+define-function: (
+    "perform-search",
+    [query],
+    block {
+        call-function: ("open-search", {})
         write-into: (".search-input", |query|)
         press-key: 'Enter'
         // wait for the search to start

--- a/tests/rustdoc-ui/intra-doc/deprecated-note-from-reexported.rs
+++ b/tests/rustdoc-ui/intra-doc/deprecated-note-from-reexported.rs
@@ -1,0 +1,16 @@
+// This test ensures that the intra-doc link from reexported deprecated attribute note
+// are resolved where they are declared.
+
+#![deny(rustdoc::broken_intra_doc_links)]
+
+#[doc(inline)]
+pub use bar::sql_function_proc as sql_function;
+
+pub fn define_sql_function() {}
+
+pub mod bar {
+    #[deprecated(note = "Use [`define_sql_function`] instead")]
+    //~^ ERROR: unresolved link
+    //~| ERROR: unresolved link
+    pub fn sql_function_proc() {}
+}

--- a/tests/rustdoc-ui/intra-doc/deprecated-note-from-reexported.stderr
+++ b/tests/rustdoc-ui/intra-doc/deprecated-note-from-reexported.stderr
@@ -1,0 +1,34 @@
+error: unresolved link to `define_sql_function`
+  --> $DIR/deprecated-note-from-reexported.rs:12:25
+   |
+LL |     #[deprecated(note = "Use [`define_sql_function`] instead")]
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the link appears in this line:
+           
+           Use [`define_sql_function`] instead
+                ^^^^^^^^^^^^^^^^^^^^^
+   = note: no item named `define_sql_function` in scope
+   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+note: the lint level is defined here
+  --> $DIR/deprecated-note-from-reexported.rs:4:9
+   |
+LL | #![deny(rustdoc::broken_intra_doc_links)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: unresolved link to `define_sql_function`
+  --> $DIR/deprecated-note-from-reexported.rs:12:25
+   |
+LL |     #[deprecated(note = "Use [`define_sql_function`] instead")]
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the link appears in this line:
+           
+           Use [`define_sql_function`] instead
+                ^^^^^^^^^^^^^^^^^^^^^
+   = note: no item named `define_sql_function` in scope
+   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/compiletest-self-test/ui-testing-optout.rs
+++ b/tests/ui/compiletest-self-test/ui-testing-optout.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Z ui-testing=no
+//@ compile-flags: -Z ui-testing=no --diagnostic-width=80
 
 // Line number < 10
 type A = B; //~ ERROR

--- a/tests/ui/consts/missing_span_in_backtrace.rs
+++ b/tests/ui/consts/missing_span_in_backtrace.rs
@@ -1,6 +1,6 @@
 //! Check what happens when the error occurs inside a std function that we can't print the span of.
 //@ ignore-backends: gcc
-//@ compile-flags: -Z ui-testing=no
+//@ compile-flags: -Z ui-testing=no --diagnostic-width=80
 
 use std::{
     mem::{self, MaybeUninit},

--- a/tests/ui/consts/missing_span_in_backtrace.stderr
+++ b/tests/ui/consts/missing_span_in_backtrace.stderr
@@ -1,12 +1,12 @@
 error[E0080]: memory access failed: attempting to access 1 byte, but got ALLOC0+0x4 which is at or beyond the end of the allocation of size 4 bytes
   --> $DIR/missing_span_in_backtrace.rs:16:9
    |
-16 | /         ptr::swap_nonoverlapping(
-17 | |             &mut x1 as *mut _ as *mut MaybeUninit<u8>,
-18 | |             &mut x2 as *mut _ as *mut MaybeUninit<u8>,
-19 | |             10,
-20 | |         );
-   | |_________^ evaluation of `X` failed inside this call
+16 | / ...   ptr::swap_nonoverlapping(
+17 | | ...       &mut x1 as *mut _ as *mut MaybeUninit<u8>,
+18 | | ...       &mut x2 as *mut _ as *mut MaybeUninit<u8>,
+19 | | ...       10,
+20 | | ...   );
+   | |_______^ evaluation of `X` failed inside this call
    |
 note: inside `swap_nonoverlapping::compiletime::<MaybeUninit<u8>>`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL

--- a/tests/ui/error-emitter/trimmed_multiline_suggestion.rs
+++ b/tests/ui/error-emitter/trimmed_multiline_suggestion.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Z ui-testing=no
+//@ compile-flags: -Z ui-testing=no --diagnostic-width=80
 fn function_with_lots_of_arguments(a: i32, b: char, c: i32, d: i32, e: i32, f: i32) {}
 
 fn main() {

--- a/tests/ui/error-emitter/trimmed_multiline_suggestion.stderr
+++ b/tests/ui/error-emitter/trimmed_multiline_suggestion.stderr
@@ -10,7 +10,7 @@ error[E0061]: this function takes 6 arguments but 5 arguments were supplied
 note: function defined here
  --> $DIR/trimmed_multiline_suggestion.rs:2:4
   |
-2 | fn function_with_lots_of_arguments(a: i32, b: char, c: i32, d: i32, e: i32, f: i32) {}
+2 | fn function_with_lots_of_arguments(a: i32, b: char, c: i32, d: i32, e: i3...
   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^         -------
 help: provide the argument
   |

--- a/tests/ui/modules/issue-107649.rs
+++ b/tests/ui/modules/issue-107649.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Z ui-testing=no
+//@ compile-flags: -Z ui-testing=no --diagnostic-width=80
 #[path = "auxiliary/dummy_lib.rs"]
 mod lib;
 

--- a/tests/ui/proc-macro/auxiliary/api/proc_macro_api_tests.rs
+++ b/tests/ui/proc-macro/auxiliary/api/proc_macro_api_tests.rs
@@ -8,6 +8,7 @@ extern crate proc_macro;
 mod cmp;
 mod ident;
 mod literal;
+mod tokenstream;
 
 use proc_macro::TokenStream;
 
@@ -18,6 +19,7 @@ pub fn run(input: TokenStream) -> TokenStream {
     cmp::test();
     ident::test();
     literal::test();
+    tokenstream::test();
 
     TokenStream::new()
 }

--- a/tests/ui/proc-macro/auxiliary/api/tokenstream.rs
+++ b/tests/ui/proc-macro/auxiliary/api/tokenstream.rs
@@ -1,0 +1,28 @@
+use proc_macro::*;
+
+fn assert_eq(l: TokenStream, r: TokenStream) {
+    assert_eq!(l.to_string(), r.to_string());
+    for (lt, rt) in l.into_iter().zip(r) {
+        assert_eq!(lt.to_string(), rt.to_string());
+    }
+}
+
+pub fn test() {
+    assert_eq(TokenStream::new(), TokenStream::new());
+    let mut stream = TokenStream::new();
+    assert!(stream.is_empty());
+    stream.extend(TokenStream::new());
+    assert_eq(stream.clone(), TokenStream::new());
+
+    let old = stream.clone();
+    stream.extend(vec![TokenTree::Ident(Ident::new("foo", Span::call_site()))]);
+    assert!(!stream.is_empty());
+    assert!(old.is_empty());
+
+    let stream2 = stream
+        .clone()
+        .into_iter()
+        .inspect(|tree| assert_eq!(tree.to_string(), "foo"))
+        .collect::<TokenStream>();
+    assert_eq(stream.clone(), stream2);
+}

--- a/tests/ui/span/issue-71363.rs
+++ b/tests/ui/span/issue-71363.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Z ui-testing=no
+//@ compile-flags: -Z ui-testing=no --diagnostic-width=80
 
 struct MyError;
 impl std::error::Error for MyError {}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#149587 (coverage: Sort the expansion tree to help choose a single BCB for child expansions)
 - rust-lang/rust#150071 (Add dist step for Enzyme)
 - rust-lang/rust#150288 (Add scalar support for offload)
 - rust-lang/rust#151091 (Add new "hide deprecated items" setting in rustdoc)
 - rust-lang/rust#151216 ([rustdoc] Make popover menus content scrollable on mobile devices)
 - rust-lang/rust#151255 (rustdoc: Fix ICE when deprecated note is not resolved on the correct `DefId`)
 - rust-lang/rust#151375 (Fix terminal  width dependent tests)
 - rust-lang/rust#151384 (add basic `TokenStream` api tests)
 - rust-lang/rust#151391 (rustc-dev-guide subtree update)

r? @ghost

<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=149587,150071,150288,151091,151216,151255,151375,151384,151391)
<!-- homu-ignore:end -->

