### PR TITLE
`rustc_queries!`: Don't push the `(cache)` modifier twice

### DIFF
--- a/compiler/rustc_macros/src/query.rs
+++ b/compiler/rustc_macros/src/query.rs
@@ -378,9 +378,6 @@ pub(super) fn rustc_queries(input: TokenStream) -> TokenStream {
             return_result_from_ensure_ok,
         );
 
-        if modifiers.cache.is_some() {
-            attributes.push(quote! { (cache) });
-        }
         // Pass on the cache modifier
         if modifiers.cache.is_some() {
             attributes.push(quote! { (cache) });


### PR DESCRIPTION
Due to some kind of merge/rebase mishap in https://github.com/rust-lang/rust/pull/101307 and https://github.com/rust-lang/rust/pull/101173, we ended up with two copies of this query modifier.

Thankfully the redundant copy was harmless.

- https://github.com/rust-lang/rust/pull/101307
- https://github.com/rust-lang/rust/pull/101173