### PR TITLE
Generate error delegation when delegation is not resolved

### DIFF
--- a/tests/ui/delegation/unresolved-delegation-ice-151356.rs
+++ b/tests/ui/delegation/unresolved-delegation-ice-151356.rs
@@ -1,0 +1,11 @@
+#![allow(incomplete_features)]
+#![feature(fn_delegation)]
+
+extern "C" {
+    fn a() {
+        //~^ ERROR incorrect function inside `extern` block
+        reuse foo {}
+    }
+}
+
+pub fn main() {}

--- a/tests/ui/delegation/unresolved-delegation-ice-151356.stderr
+++ b/tests/ui/delegation/unresolved-delegation-ice-151356.stderr
@@ -1,0 +1,19 @@
+error: incorrect function inside `extern` block
+  --> $DIR/unresolved-delegation-ice-151356.rs:5:8
+   |
+LL |   extern "C" {
+   |   ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
+LL |       fn a() {
+   |  ________^___-
+   | |        |
+   | |        cannot have a body
+LL | |
+LL | |         reuse foo {}
+LL | |     }
+   | |_____- help: remove the invalid body: `;`
+   |
+   = help: you might have meant to write a function accessible through FFI, which can be done by writing `extern fn` outside of the `extern` block
+   = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
This PR is a part of the delegation feature rust-lang/rust#118212 and fixes rust-lang/rust#151356.

r? @petrochenkov