### PR TITLE
Simplify lookup of `DepKind` names in duplicate dep node check

### DIFF
--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -940,7 +940,7 @@ pub fn create_and_enter_global_ctxt<T, F: for<'tcx> FnOnce(TyCtxt<'tcx>) -> T>(
 
     let outputs = util::build_output_filenames(&pre_configured_attrs, sess);
 
-    let dep_type = DepsType { dep_names: rustc_query_impl::dep_kind_names() };
+    let dep_type = DepsType { dep_names: rustc_middle::dep_graph::DEP_KIND_NAMES };
     let dep_graph = setup_dep_graph(sess, crate_name, stable_crate_id, &dep_type);
 
     let cstore =

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -26,7 +26,6 @@ use rustc_lint::{BufferedEarlyLint, EarlyCheckNode, LintStore, unerased_lint_sto
 use rustc_metadata::EncodedMetadata;
 use rustc_metadata::creader::CStore;
 use rustc_middle::arena::Arena;
-use rustc_middle::dep_graph::DepsType;
 use rustc_middle::ty::{self, CurrentGcx, GlobalCtxt, RegisteredTools, TyCtxt};
 use rustc_middle::util::Providers;
 use rustc_parse::lexer::StripTokens;
@@ -940,8 +939,7 @@ pub fn create_and_enter_global_ctxt<T, F: for<'tcx> FnOnce(TyCtxt<'tcx>) -> T>(
 
     let outputs = util::build_output_filenames(&pre_configured_attrs, sess);
 
-    let dep_type = DepsType { dep_names: rustc_middle::dep_graph::DEP_KIND_NAMES };
-    let dep_graph = setup_dep_graph(sess, crate_name, stable_crate_id, &dep_type);
+    let dep_graph = setup_dep_graph(sess, crate_name, stable_crate_id);
 
     let cstore =
         FreezeLock::new(Box::new(CStore::new(compiler.codegen_backend.metadata_loader())) as _);

--- a/compiler/rustc_middle/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node.rs
@@ -61,7 +61,7 @@ macro_rules! define_dep_nodes {
 
         /// List containing the name of each dep kind as a static string,
         /// indexable by `DepKind`.
-        pub const DEP_KIND_NAMES: &[&str] = &[
+        pub(crate) const DEP_KIND_NAMES: &[&str] = &[
             $( self::label_strs::$variant, )*
         ];
 

--- a/compiler/rustc_middle/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node.rs
@@ -24,15 +24,6 @@ macro_rules! define_dep_nodes {
             ($mod:ident) => {[ $($mod::$variant()),* ]};
         }
 
-        #[macro_export]
-        macro_rules! make_dep_kind_name_array {
-            ($mod:ident) => {
-                vec! {
-                    $(*$mod::$variant().name),*
-                }
-            };
-        }
-
         /// This enum serves as an index into arrays built by `make_dep_kind_array`.
         // This enum has more than u8::MAX variants so we need some kind of multi-byte
         // encoding. The derived Encodable/Decodable uses leb128 encoding which is
@@ -68,20 +59,24 @@ macro_rules! define_dep_nodes {
             deps.len() as u16
         };
 
+        /// List containing the name of each dep kind as a static string,
+        /// indexable by `DepKind`.
+        pub const DEP_KIND_NAMES: &[&str] = &[
+            $( self::label_strs::$variant, )*
+        ];
+
         pub(super) fn dep_kind_from_label_string(label: &str) -> Result<DepKind, ()> {
             match label {
-                $(stringify!($variant) => Ok(dep_kinds::$variant),)*
+                $( self::label_strs::$variant => Ok(self::dep_kinds::$variant), )*
                 _ => Err(()),
             }
         }
 
         /// Contains variant => str representations for constructing
         /// DepNode groups for tests.
-        #[allow(dead_code, non_upper_case_globals)]
+        #[expect(non_upper_case_globals)]
         pub mod label_strs {
-           $(
-                pub const $variant: &str = stringify!($variant);
-            )*
+            $( pub const $variant: &str = stringify!($variant); )*
         }
     };
 }

--- a/compiler/rustc_middle/src/dep_graph/mod.rs
+++ b/compiler/rustc_middle/src/dep_graph/mod.rs
@@ -20,7 +20,6 @@ pub type DepGraph = rustc_query_system::dep_graph::DepGraph<DepsType>;
 
 pub type DepKindStruct<'tcx> = rustc_query_system::dep_graph::DepKindStruct<TyCtxt<'tcx>>;
 
-#[derive(Clone)]
 pub struct DepsType;
 
 impl Deps for DepsType {

--- a/compiler/rustc_middle/src/dep_graph/mod.rs
+++ b/compiler/rustc_middle/src/dep_graph/mod.rs
@@ -8,9 +8,7 @@ use crate::ty::{self, TyCtxt};
 #[macro_use]
 mod dep_node;
 
-pub use dep_node::{
-    DEP_KIND_NAMES, DepKind, DepNode, DepNodeExt, dep_kind_from_label, dep_kinds, label_strs,
-};
+pub use dep_node::{DepKind, DepNode, DepNodeExt, dep_kind_from_label, dep_kinds, label_strs};
 pub(crate) use dep_node::{make_compile_codegen_unit, make_compile_mono_item, make_metadata};
 pub use rustc_query_system::dep_graph::debug::{DepNodeFilter, EdgeFilter};
 pub use rustc_query_system::dep_graph::{
@@ -23,9 +21,7 @@ pub type DepGraph = rustc_query_system::dep_graph::DepGraph<DepsType>;
 pub type DepKindStruct<'tcx> = rustc_query_system::dep_graph::DepKindStruct<TyCtxt<'tcx>>;
 
 #[derive(Clone)]
-pub struct DepsType {
-    pub dep_names: &'static [&'static str],
-}
+pub struct DepsType;
 
 impl Deps for DepsType {
     fn with_deps<OP, R>(task_deps: TaskDepsRef<'_>, op: OP) -> R
@@ -49,8 +45,8 @@ impl Deps for DepsType {
         })
     }
 
-    fn name(&self, dep_kind: DepKind) -> &'static str {
-        self.dep_names[dep_kind.as_usize()]
+    fn name(dep_kind: DepKind) -> &'static str {
+        dep_node::DEP_KIND_NAMES[dep_kind.as_usize()]
     }
 
     const DEP_KIND_NULL: DepKind = dep_kinds::Null;

--- a/compiler/rustc_middle/src/dep_graph/mod.rs
+++ b/compiler/rustc_middle/src/dep_graph/mod.rs
@@ -8,7 +8,9 @@ use crate::ty::{self, TyCtxt};
 #[macro_use]
 mod dep_node;
 
-pub use dep_node::{DepKind, DepNode, DepNodeExt, dep_kind_from_label, dep_kinds, label_strs};
+pub use dep_node::{
+    DEP_KIND_NAMES, DepKind, DepNode, DepNodeExt, dep_kind_from_label, dep_kinds, label_strs,
+};
 pub(crate) use dep_node::{make_compile_codegen_unit, make_compile_mono_item, make_metadata};
 pub use rustc_query_system::dep_graph::debug::{DepNodeFilter, EdgeFilter};
 pub use rustc_query_system::dep_graph::{
@@ -22,7 +24,7 @@ pub type DepKindStruct<'tcx> = rustc_query_system::dep_graph::DepKindStruct<TyCt
 
 #[derive(Clone)]
 pub struct DepsType {
-    pub dep_names: Vec<&'static str>,
+    pub dep_names: &'static [&'static str],
 }
 
 impl Deps for DepsType {

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -921,9 +921,5 @@ macro_rules! define_queries {
         pub fn query_callbacks<'tcx>(arena: &'tcx Arena<'tcx>) -> &'tcx [DepKindStruct<'tcx>] {
             arena.alloc_from_iter(rustc_middle::make_dep_kind_array!(query_callbacks))
         }
-
-        pub fn dep_kind_names() -> Vec<&'static str> {
-            rustc_middle::make_dep_kind_name_array!(query_callbacks)
-        }
     }
 }

--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -28,7 +28,6 @@ use crate::dep_graph::edges::EdgesVec;
 use crate::ich::StableHashingContext;
 use crate::query::{QueryContext, QuerySideEffect};
 
-#[derive(Clone)]
 pub struct DepGraph<D: Deps> {
     data: Option<Arc<DepGraphData<D>>>,
 
@@ -37,6 +36,17 @@ pub struct DepGraph<D: Deps> {
     /// each task has a `DepNodeIndex` that uniquely identifies it. This unique
     /// ID is used for self-profiling.
     virtual_dep_node_index: Arc<AtomicU32>,
+}
+
+/// Manual clone impl that does not require `D: Clone`.
+impl<D: Deps> Clone for DepGraph<D> {
+    fn clone(&self) -> Self {
+        let Self { data, virtual_dep_node_index } = self;
+        Self {
+            data: Option::<Arc<_>>::clone(data),
+            virtual_dep_node_index: Arc::clone(virtual_dep_node_index),
+        }
+    }
 }
 
 rustc_index::newtype_index! {

--- a/compiler/rustc_query_system/src/dep_graph/mod.rs
+++ b/compiler/rustc_query_system/src/dep_graph/mod.rs
@@ -103,7 +103,7 @@ pub trait Deps: DynSync {
     where
         OP: for<'a> FnOnce(TaskDepsRef<'a>);
 
-    fn name(&self, dep_kind: DepKind) -> &'static str;
+    fn name(dep_kind: DepKind) -> &'static str;
 
     /// We use this for most things when incr. comp. is turned off.
     const DEP_KIND_NULL: DepKind;

--- a/compiler/rustc_query_system/src/dep_graph/serialized.rs
+++ b/compiler/rustc_query_system/src/dep_graph/serialized.rs
@@ -191,8 +191,8 @@ fn mask(bits: usize) -> usize {
 }
 
 impl SerializedDepGraph {
-    #[instrument(level = "debug", skip(d, deps))]
-    pub fn decode<D: Deps>(d: &mut MemDecoder<'_>, deps: &D) -> Arc<SerializedDepGraph> {
+    #[instrument(level = "debug", skip(d))]
+    pub fn decode<D: Deps>(d: &mut MemDecoder<'_>) -> Arc<SerializedDepGraph> {
         // The last 16 bytes are the node count and edge count.
         debug!("position: {:?}", d.position());
 
@@ -280,7 +280,7 @@ impl SerializedDepGraph {
             if index[node.kind.as_usize()].insert(node.hash, idx).is_some() {
                 // Empty nodes and side effect nodes can have duplicates
                 if node.kind != D::DEP_KIND_NULL && node.kind != D::DEP_KIND_SIDE_EFFECT {
-                    let name = deps.name(node.kind);
+                    let name = D::name(node.kind);
                     panic!(
                     "Error: A dep graph node ({name}) does not have an unique index. \
                      Running a clean build on a nightly compiler with `-Z incremental-verify-ich` \


### PR DESCRIPTION
This PR simplifies parts of the query system, by removing the `make_dep_kind_name_array!` macro, and removing much of the associated plumbing added by 68fd771bc1f186bfa7e825d8a87ac8f06a6efced.

Instead, we now create a `DEP_KIND_NAMES` constant in `define_dep_nodes!`, and look up names in that instead.