### PR TITLE
std: use 64-bit `clock_nanosleep` on GNU/Linux if available

### DIFF
--- a/src/tools/miri/src/shims/extern_static.rs
+++ b/src/tools/miri/src/shims/extern_static.rs
@@ -55,7 +55,7 @@ impl<'tcx> MiriMachine<'tcx> {
             Os::Linux => {
                 Self::null_ptr_extern_statics(
                     ecx,
-                    &["__cxa_thread_atexit_impl", "__clock_gettime64"],
+                    &["__cxa_thread_atexit_impl", "__clock_gettime64", "__clock_nanosleep_time64"],
                 )?;
                 Self::weak_symbol_extern_statics(ecx, &["getrandom", "gettid", "statx"])?;
             }


### PR DESCRIPTION
glibc 2.31 added support for both 64-bit `clock_gettime` and 64-bit `clock_nanosleep`. Thus, if [`__clock_nanosleep_time64`](https://sourceware.org/git/?p=glibc.git;a=blob;f=include/time.h;h=22b29ca583549488a0e5395cb820f55ec6e38e5f;hb=e14a91e59d35bf2fa649a9726ccce838b8c6e4b7#l322) and the underlying syscall are available, use them for implementing `sleep_until` to avoid having to fall back to `nanosleep` for long-duration sleeps.