### PR TITLE
std: remove at-least guarantee from `sleep`

### DIFF
--- a/library/std/src/thread/functions.rs
+++ b/library/std/src/thread/functions.rs
@@ -217,58 +217,40 @@ pub fn panicking() -> bool {
     panicking::panicking()
 }
 
-/// Uses [`sleep`].
+/// Puts the current thread to sleep for the specified amount of time.
 ///
-/// Puts the current thread to sleep for at least the specified amount of time.
-///
-/// The thread may sleep longer than the duration specified due to scheduling
-/// specifics or platform-dependent functionality. It will never sleep less.
-///
-/// This function is blocking, and should not be used in `async` functions.
-///
-/// # Platform-specific behavior
-///
-/// On Unix platforms, the underlying syscall may be interrupted by a
-/// spurious wakeup or signal handler. To ensure the sleep occurs for at least
-/// the specified duration, this function may invoke that system call multiple
-/// times.
-///
-/// # Examples
-///
-/// ```no_run
-/// use std::thread;
-///
-/// // Let's sleep for 2 seconds:
-/// thread::sleep_ms(2000);
-/// ```
+/// Use [`sleep`] and [`Duration::from_millis`] instead.
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "1.6.0", note = "replaced by `std::thread::sleep`")]
 pub fn sleep_ms(ms: u32) {
     sleep(Duration::from_millis(ms as u64))
 }
 
-/// Puts the current thread to sleep for at least the specified amount of time.
+/// Puts the current thread to sleep for the specified amount of time.
 ///
-/// The thread may sleep longer than the duration specified due to scheduling
-/// specifics or platform-dependent functionality. It will never sleep less.
+/// The actual duration slept may be slightly shorter or longer than specified
+/// due to scheduling specifics or platform-dependent functionality. In particular,
+/// this function might use a different clock source than the one used by [`Instant`].
+/// Consider using [`sleep_until`] with an absolute timestamp if you need to ensure
+/// that a specific amount of time (as measured using [`Instant`]) has elapsed.
 ///
 /// This function is blocking, and should not be used in `async` functions.
 ///
 /// # Platform-specific behavior
 ///
-/// On Unix platforms, the underlying syscall may be interrupted by a
-/// spurious wakeup or signal handler. To ensure the sleep occurs for at least
-/// the specified duration, this function may invoke that system call multiple
-/// times.
-/// Platforms which do not support nanosecond precision for sleeping will
-/// have `dur` rounded up to the nearest granularity of time they can sleep for.
+/// Note that, like with all of `std`'s abstractions, the choice of syscall used
+/// is [subject to change].
+///
+/// On Unix platforms, the underlying syscall ([`nanosleep`]) may be interrupted
+/// by a spurious wakeup or signal handler, in which case this function will
+/// restart the syscall to achieve better timing precision.
 ///
 /// Currently, specifying a zero duration on Unix platforms returns immediately
-/// without invoking the underlying [`nanosleep`] syscall, whereas on Windows
-/// platforms the underlying [`Sleep`] syscall is always invoked.
-/// If the intention is to yield the current time-slice you may want to use
-/// [`yield_now`] instead.
+/// without invoking the underlying syscall, whereas on Windows platforms the
+/// underlying [`Sleep`] syscall is always invoked. If the intention is to yield
+/// the current time-slice you may want to use [`yield_now`] instead.
 ///
+/// [currently]: crate::io#platform-specific-behavior
 /// [`nanosleep`]: https://linux.die.net/man/2/nanosleep
 /// [`Sleep`]: https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-sleep
 ///
@@ -282,7 +264,7 @@ pub fn sleep_ms(ms: u32) {
 ///
 /// thread::sleep(ten_millis);
 ///
-/// assert!(now.elapsed() >= ten_millis);
+/// println!("{:?}", now.elapsed()); // ca. 10 ms.
 /// ```
 #[stable(feature = "thread_sleep", since = "1.4.0")]
 pub fn sleep(dur: Duration) {

--- a/library/std/src/thread/tests.rs
+++ b/library/std/src/thread/tests.rs
@@ -334,6 +334,16 @@ fn sleep_ms_smoke() {
 }
 
 #[test]
+fn sleep_accurate() {
+    let now = Instant::now();
+    thread::sleep(Duration::from_millis(20));
+
+    // We should try our best to make sure that the duration slept is somewhat
+    // accurate. If this test fails, you might need to increase the leeway here.
+    assert!(now.elapsed() >= Duration::from_millis(18));
+}
+
+#[test]
 fn test_size_of_option_thread_id() {
     assert_eq!(size_of::<Option<ThreadId>>(), size_of::<ThreadId>());
 }


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/149935 demonstrates an issue with `thread::sleep` on Windows where `sleep` returns early, before the given duration has elapsed. The proposed fix (https://github.com/rust-lang/rust/pull/150842) only addresses parts of the problem however – the fundamental issue is that the Windows timers all use a different clock source than the performance counter used by `Instant`, necessitating conversions that cannot always be performed accurately: If `QueryPerformanceFrequency` overestimates the frequency, time as measured by `Instant` will advance slower than the time used for [`SetWaitableTimer`](https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-setwaitabletimer), resulting in `sleep` returning early for very long duration sleeps.

This problem is not even Windows-specific, e.g. `nanosleep` is actually [specified](https://manned.org/man/arch/nanosleep.2#head7) to use `CLOCK_REALTIME`, but without respecting clock adjustments, so if `CLOCK_MONOTONIC` has a slight drift, `nanosleep` might return early on some UNIXes as well (Linux actually uses `CLOCK_MONOTONIC` for `nanosleep` so it is not affected). Actually, most our lower-tier targets don't guarantee any synchronicity between their sleep syscall and their time syscall.

It is of course possible to remediate this problem by implementing `sleep` as e.g.
```rust
fn sleep(duration: Duration) {
    let deadline = Instant::now() + duration;
    while let Some(remaining) = deadline.checked_sub(Instant::now()) {
        platform_sleep(remaining);
    }
}
```
However, this adds a lot of overhead to what is supposed to be a simple function. Most users call `sleep` with the intention of just sleeping for a bit and don't care about precise timing guarantees – or else they would have noticed these issues.

Thus, I'd like to propose that we remove the guarantee that
> It [the thread] will never sleep less.

from `sleep` and recommend that users use `sleep_until` (rust-lang/rust#113752) if they need specific timing guarantees[^1]. `sleep_until` is very much built for precise timing, uses the same clock as `Instant` on most UNIXes and is not affected by issues like oversleeping due to a high number of signals[^2] or not being scheduled for a long time.

This is actually not really a breaking change: The current `sleep` documentation does not specify the clock used[^3], so the change in this PR could also be phrased as saying that the clock used for `sleep` is not guaranteed to be the same as that of `Instant`. I just find it clearer to remove the guarantee, as the guarantee is basically worthless without specifying a time source.

r? libs-api
@rustbot label +I-libs-api-nominated

[^1]: Which should be stabilised ASAP if this PR is merged.
[^2]: See https://manned.org/man/arch/nanosleep.2#head10
[^3]: It is however implied by the example that it is the same as that of `Instant`.