### PR TITLE
Fixes for LLVM 22 compatibility

### DIFF
--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -1788,6 +1788,9 @@ impl<'a, 'll, 'tcx> Builder<'a, 'll, 'tcx> {
         }
 
         if crate::llvm_util::get_version() >= (22, 0, 0) {
+            // LLVM 22 requires the lifetime intrinsic to act directly on the alloca,
+            // there can't be an addrspacecast in between.
+            let ptr = unsafe { llvm::LLVMRustStripPointerCasts(ptr) };
             self.call_intrinsic(intrinsic, &[self.val_ty(ptr)], &[ptr]);
         } else {
             self.call_intrinsic(intrinsic, &[self.val_ty(ptr)], &[self.cx.const_u64(size), ptr]);

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -215,6 +215,11 @@ pub(crate) unsafe fn create_module<'ll>(
             // LLVM 22 updated the ABI alignment for double on AIX: https://github.com/llvm/llvm-project/pull/144673
             target_data_layout = target_data_layout.replace("-f64:32:64", "");
         }
+        if sess.target.arch == Arch::AmdGpu {
+            // LLVM 22 specified ELF mangling in the amdgpu data layout:
+            // https://github.com/llvm/llvm-project/pull/163011
+            target_data_layout = target_data_layout.replace("-m:e", "");
+        }
     }
 
     // Ensure the data-layout values hardcoded remain the defaults.

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -1967,6 +1967,7 @@ unsafe extern "C" {
         Metadata: &'a Metadata,
     );
     pub(crate) fn LLVMRustIsNonGVFunctionPointerTy(Val: &Value) -> bool;
+    pub(crate) fn LLVMRustStripPointerCasts<'a>(Val: &'a Value) -> &'a Value;
 
     // Operations on scalar constants
     pub(crate) fn LLVMRustConstIntGetZExtValue(ConstantVal: &ConstantInt, Value: &mut u64) -> bool;

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -287,12 +287,12 @@ pub(crate) fn to_llvm_features<'a>(sess: &Session, s: &'a str) -> Option<LLVMFea
                 "cmpxchg16b" => Some(LLVMFeature::new("cx16")),
                 "lahfsahf" => Some(LLVMFeature::new("sahf")),
                 // Enable the evex512 target feature if an avx512 target feature is enabled.
-                s if s.starts_with("avx512") => Some(LLVMFeature::with_dependencies(
+                s if s.starts_with("avx512") && major < 22 => Some(LLVMFeature::with_dependencies(
                     s,
                     smallvec![TargetFeatureFoldStrength::EnableOnly("evex512")],
                 )),
-                "avx10.1" => Some(LLVMFeature::new("avx10.1-512")),
-                "avx10.2" => Some(LLVMFeature::new("avx10.2-512")),
+                "avx10.1" if major < 22 => Some(LLVMFeature::new("avx10.1-512")),
+                "avx10.2" if major < 22 => Some(LLVMFeature::new("avx10.2-512")),
                 "apxf" => Some(LLVMFeature::with_dependencies(
                     "egpr",
                     smallvec![

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -1760,6 +1760,10 @@ extern "C" bool LLVMRustIsNonGVFunctionPointerTy(LLVMValueRef V) {
   return false;
 }
 
+extern "C" LLVMValueRef LLVMRustStripPointerCasts(LLVMValueRef V) {
+  return wrap(unwrap(V)->stripPointerCasts());
+}
+
 extern "C" bool LLVMRustLLVMHasZlibCompression() {
   return llvm::compression::zlib::isAvailable();
 }

--- a/compiler/rustc_target/src/spec/targets/amdgcn_amd_amdhsa.rs
+++ b/compiler/rustc_target/src/spec/targets/amdgcn_amd_amdhsa.rs
@@ -5,7 +5,7 @@ use crate::spec::{
 pub(crate) fn target() -> Target {
     Target {
         arch: Arch::AmdGpu,
-        data_layout: "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-p7:160:256:256:32-p8:128:128:128:48-p9:192:256:256:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7:8:9".into(),
+        data_layout: "e-m:e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-p7:160:256:256:32-p8:128:128:128:48-p9:192:256:256:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7:8:9".into(),
         llvm_target: "amdgcn-amd-amdhsa".into(),
         metadata: TargetMetadata {
             description: Some("AMD GPU".into()),

--- a/tests/codegen-llvm/amdgpu-addrspacecast.rs
+++ b/tests/codegen-llvm/amdgpu-addrspacecast.rs
@@ -1,16 +1,25 @@
 // Check that pointers are casted to addrspace(0) before they are used
 
-//@ compile-flags: --crate-type=rlib --target=amdgcn-amd-amdhsa -Ctarget-cpu=gfx900
+//@ compile-flags: --crate-type=rlib --target=amdgcn-amd-amdhsa -Ctarget-cpu=gfx900 -O
 //@ needs-llvm-components: amdgpu
 //@ add-minicore
+//@ revisions: LLVM21 LLVM22
+//@ [LLVM21] max-llvm-major-version: 21
+//@ [LLVM22] min-llvm-version: 22
 #![feature(no_core)]
 #![no_core]
 
 extern crate minicore;
 
+// Make sure that on LLVM 22, the alloca is passed directly to the lifetime intrinsics,
+// not the addrspacecast.
+
 // CHECK-LABEL: @ref_of_local
 // CHECK: [[alloca:%[0-9]]] = alloca
 // CHECK: %i = addrspacecast ptr addrspace(5) [[alloca]] to ptr
+// LLVM22: call void @llvm.lifetime.start.p5(ptr addrspace(5) [[alloca]])
+// CHECK: call void %f(ptr{{.*}}%i)
+// LLVM22: call void @llvm.lifetime.end.p5(ptr addrspace(5) [[alloca]])
 #[no_mangle]
 pub fn ref_of_local(f: fn(&i32)) {
     let i = 0;


### PR DESCRIPTION
This includes three fixes for LLVM 22 compatibility:

 * Update the AMDGPU data layout.
 * Update AVX512 target feature handling. `evex512` is no longer used and `avx10.[12]-512` are now just `avx10.[12]`, matching the Rust feature name.
 * Strip address space casts when emitting lifetime intrinsics. These are now required to directly work on the alloca.

r? @cuviper 