### PR TITLE
chore: Remove redundant conversion

### DIFF
--- a/library/std/src/sys/process/windows.rs
+++ b/library/std/src/sys/process/windows.rs
@@ -818,7 +818,7 @@ impl From<u8> for ExitCode {
 
 impl From<u32> for ExitCode {
     fn from(code: u32) -> Self {
-        ExitCode(u32::from(code))
+        ExitCode(code)
     }
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

The type of `code` is `u32`, so this `u32::from` is not necessary.