### PR TITLE
fix(build-manifest)!: limit `rustc-docs` to current host target in the manifest

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -301,11 +301,12 @@ impl Builder {
                 | PkgType::LlvmTools
                 | PkgType::RustAnalysis
                 | PkgType::JsonDocs
+                | PkgType::RustcDocs
                 | PkgType::RustcCodegenCranelift
                 | PkgType::LlvmBitcodeLinker => {
                     extensions.push(host_component(pkg));
                 }
-                PkgType::RustcDev | PkgType::RustcDocs => {
+                PkgType::RustcDev => {
                     extensions.extend(HOSTS.iter().map(|target| Component::from_pkg(pkg, target)));
                 }
                 PkgType::RustSrc => {


### PR DESCRIPTION
<!-- homu-ignore:start -->
Part of https://github.com/rust-lang/rustup/pull/3717.

This is a continuation of https://github.com/rust-lang/rust/pull/151080, where enabling "target fallback" allows `rustup +nightly component add rustc-docs` to execute correctly on all major hosts, but as a byproduct of this change, today we have:

```
> rustc +nightly --version
rustc 1.95.0-nightly (d940e5684 2026-01-19)

> rustup +nightly component list | rg rustc-docs
rustc-docs-aarch64-apple-darwin
rustc-docs-aarch64-pc-windows-gnullvm
rustc-docs-aarch64-pc-windows-msvc
rustc-docs-aarch64-unknown-linux-gnu
[..]
rustc-docs-x86_64-unknown-linux-gnu
rustc-docs-x86_64-unknown-linux-musl
rustc-docs-x86_64-unknown-netbsd
```

This is actually okay because most of them are just aliases to `rustc-docs-(x86_64|aarch64)-unknown-linux-gnu` (so no extra components are being precompiled), but technically it could still be considered as an unintentional spam.

r? t-bootstrap

<!-- homu-ignore:end -->
