### PR TITLE
Avoid pulling in unicode when calling io::Error::kind

### DIFF
--- a/library/std/src/sys/io/error/windows.rs
+++ b/library/std/src/sys/io/error/windows.rs
@@ -126,7 +126,7 @@ pub fn error_string(mut errnum: i32) -> String {
         match String::from_utf16(&buf[..res]) {
             Ok(mut msg) => {
                 // Trim trailing CRLF inserted by FormatMessageW
-                let len = msg.trim_end().len();
+                let len = msg.trim_ascii_end().len();
                 msg.truncate(len);
                 msg
             }


### PR DESCRIPTION
Reduces binary size by ~1KB.