### PR TITLE
missing colon after the compile-flags directive

### DIFF
--- a/tests/ui/instrument-coverage/coverage-options.rs
+++ b/tests/ui/instrument-coverage/coverage-options.rs
@@ -1,5 +1,5 @@
 //@ revisions: block branch condition bad
-//@ compile-flags -Cinstrument-coverage -Zno-profiler-runtime
+//@ compile-flags: -Cinstrument-coverage -Zno-profiler-runtime
 
 //@ [block] check-pass
 //@ [block] compile-flags: -Zcoverage-options=block


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This is a trivial issue as the title suggests. All tests in the `ui` test suite have a colon after the `compile-flags` directive except for this one.