### PR TITLE
compiler: Require `mir_opt_level > 1` for `SingleUseConsts` MIR pass

### DIFF
--- a/compiler/rustc_mir_transform/src/single_use_consts.rs
+++ b/compiler/rustc_mir_transform/src/single_use_consts.rs
@@ -23,7 +23,7 @@ pub(super) struct SingleUseConsts;
 
 impl<'tcx> crate::MirPass<'tcx> for SingleUseConsts {
     fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.mir_opt_level() > 0
+        sess.mir_opt_level() > 1
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {

--- a/tests/debuginfo/basic-stepping.rs
+++ b/tests/debuginfo/basic-stepping.rs
@@ -10,10 +10,6 @@
 // Debugger tests need debuginfo
 //@ compile-flags: -g
 
-// FIXME(#128945): SingleUseConsts shouldn't need to be disabled.
-//@ revisions: default-mir-passes no-SingleUseConsts-mir-pass
-//@ [no-SingleUseConsts-mir-pass] compile-flags: -Zmir-enable-passes=-SingleUseConsts
-
 //@ gdb-command: run
 // FIXME(#97083): Should we be able to break on initialization of zero-sized types?
 // FIXME(#97083): Right now the first breakable line is:
@@ -21,12 +17,12 @@
 //@ gdb-command: next
 //@ gdb-check:   let d = c = 99;
 //@ gdb-command: next
-//@ [no-SingleUseConsts-mir-pass] gdb-check:   let e = "hi bob";
-//@ [no-SingleUseConsts-mir-pass] gdb-command: next
-//@ [no-SingleUseConsts-mir-pass] gdb-check:   let f = b"hi bob";
-//@ [no-SingleUseConsts-mir-pass] gdb-command: next
-//@ [no-SingleUseConsts-mir-pass] gdb-check:   let g = b'9';
-//@ [no-SingleUseConsts-mir-pass] gdb-command: next
+//@ gdb-check:   let e = "hi bob";
+//@ gdb-command: next
+//@ gdb-check:   let f = b"hi bob";
+//@ gdb-command: next
+//@ gdb-check:   let g = b'9';
+//@ gdb-command: next
 //@ gdb-check:   let h = ["whatever"; 8];
 //@ gdb-command: next
 //@ gdb-check:   let i = [1,2,3,4];

--- a/tests/debuginfo/macro-stepping.rs
+++ b/tests/debuginfo/macro-stepping.rs
@@ -16,9 +16,6 @@
 extern crate macro_stepping; // exports new_scope!()
 
 //@ compile-flags: -g
-// FIXME(#128945): SingleUseConsts shouldn't need to be disabled.
-//@ revisions: default-mir-passes no-SingleUseConsts-mir-pass
-//@ [no-SingleUseConsts-mir-pass] compile-flags: -Zmir-enable-passes=-SingleUseConsts
 
 // === GDB TESTS ===================================================================================
 
@@ -51,7 +48,7 @@ extern crate macro_stepping; // exports new_scope!()
 //@ gdb-check:[...]#inc-loc2[...]
 //@ gdb-command:next
 //@ gdb-command:frame
-//@ [no-SingleUseConsts-mir-pass] gdb-check:[...]#inc-loc3[...]
+//@ gdb-check:[...]#inc-loc3[...]
 
 // === LLDB TESTS ==================================================================================
 


### PR DESCRIPTION
The default MIR opt level is 1 for non-optimized builds:
https://github.com/rust-lang/rust/blob/0db0acd6993cbdf84384b00773d7509df6bc20fb/compiler/rustc_session/src/session.rs#L581

Require `mir_opt_level > 1` for `SingleUseConsts` MIR pass to make `tests/debuginfo/basic-stepping.rs` work again which builds with debuginfo but without optimizations. That test [regressed](https://github.com/rust-lang/rust/issues/33013#issuecomment-3121579216) when a precursor to `SingleUseConsts` was [enabled](https://github.com/rust-lang/rust/commit/4e8b642646f4e36ad23313d5ecf3332adb3e6f21). Well, the test didn't exist back then (I added it in rust-lang/rust#144876), but _if_ it had existed, it would have regressed. The pass was first called `ConstDebugInfo` before it was [rebirthed](https://github.com/rust-lang/rust/pull/125910) as `SingleUseConsts`.

This takes us one step closer towards closing rust-lang/rust#33013.
