### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,7 +1,7 @@
-Version 1.93 (2026-01-22)
+Version 1.93.0 (2026-01-22)
 ==========================
 
-<a id="1.93-Language"></a>
+<a id="1.93.0-Language"></a>
 
 Language
 --------
@@ -16,13 +16,13 @@ Language
 - [Add warn-by-default `function_casts_as_integer` lint](https://github.com/rust-lang/rust/pull/141470)
 
 
-<a id="1.93-Compiler"></a>
+<a id="1.93.0-Compiler"></a>
 
 Compiler
 --------
 - [Stabilize `-Cjump-tables=bool`](https://github.com/rust-lang/rust/pull/145974). The flag was previously called `-Zno-jump-tables`.
 
-<a id="1.93-Platform-Support"></a>
+<a id="1.93.0-Platform-Support"></a>
 
 Platform Support
 ----------------
@@ -34,7 +34,7 @@ for more information on Rust's tiered platform support.
 
 [platform-support-doc]: https://doc.rust-lang.org/rustc/platform-support.html
 
-<a id="1.93-Libraries"></a>
+<a id="1.93.0-Libraries"></a>
 
 Libraries
 ---------
@@ -44,7 +44,7 @@ Libraries
 - [Don't require `T: RefUnwindSafe` for `vec::IntoIter<T>: UnwindSafe`](https://github.com/rust-lang/rust/pull/145665)
 
 
-<a id="1.93-Stabilized-APIs"></a>
+<a id="1.93.0-Stabilized-APIs"></a>
 
 Stabilized APIs
 ---------------
@@ -74,7 +74,7 @@ Stabilized APIs
 - [`std::fmt::FromFn`](https://doc.rust-lang.org/stable/std/fmt/struct.FromFn.html)
 
 
-<a id="1.93-Cargo"></a>
+<a id="1.93.0-Cargo"></a>
 
 Cargo
 -----
@@ -82,7 +82,7 @@ Cargo
 - [In `cargo tree`, support long forms for `--format` variables](https://github.com/rust-lang/cargo/pull/16204/)
 - [Add `--workspace` to `cargo clean`](https://github.com/rust-lang/cargo/pull/16263/)
 
-<a id="1.93-Rustdoc"></a>
+<a id="1.93.0-Rustdoc"></a>
 
 Rustdoc
 -----
@@ -92,7 +92,7 @@ Rustdoc
 - [Validate usage of crate-level doc attributes](https://github.com/rust-lang/rust/pull/149197).  This means if any of `html_favicon_url`, `html_logo_url`, `html_playground_url`, `issue_tracker_base_url`, or `html_no_source` either has a missing value, an unexpected value, or a value of the wrong type, rustdoc will emit the deny-by-default lint `rustdoc::invalid_doc_attributes`.
 
 
-<a id="1.93-Compatibility-Notes"></a>
+<a id="1.93.0-Compatibility-Notes"></a>
 
 Compatibility Notes
 -------------------

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -1788,6 +1788,9 @@ impl<'a, 'll, 'tcx> Builder<'a, 'll, 'tcx> {
         }
 
         if crate::llvm_util::get_version() >= (22, 0, 0) {
+            // LLVM 22 requires the lifetime intrinsic to act directly on the alloca,
+            // there can't be an addrspacecast in between.
+            let ptr = unsafe { llvm::LLVMRustStripPointerCasts(ptr) };
             self.call_intrinsic(intrinsic, &[self.val_ty(ptr)], &[ptr]);
         } else {
             self.call_intrinsic(intrinsic, &[self.val_ty(ptr)], &[self.cx.const_u64(size), ptr]);

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -215,6 +215,11 @@ pub(crate) unsafe fn create_module<'ll>(
             // LLVM 22 updated the ABI alignment for double on AIX: https://github.com/llvm/llvm-project/pull/144673
             target_data_layout = target_data_layout.replace("-f64:32:64", "");
         }
+        if sess.target.arch == Arch::AmdGpu {
+            // LLVM 22 specified ELF mangling in the amdgpu data layout:
+            // https://github.com/llvm/llvm-project/pull/163011
+            target_data_layout = target_data_layout.replace("-m:e", "");
+        }
     }
 
     // Ensure the data-layout values hardcoded remain the defaults.

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -1967,6 +1967,7 @@ unsafe extern "C" {
         Metadata: &'a Metadata,
     );
     pub(crate) fn LLVMRustIsNonGVFunctionPointerTy(Val: &Value) -> bool;
+    pub(crate) fn LLVMRustStripPointerCasts<'a>(Val: &'a Value) -> &'a Value;
 
     // Operations on scalar constants
     pub(crate) fn LLVMRustConstIntGetZExtValue(ConstantVal: &ConstantInt, Value: &mut u64) -> bool;

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -287,12 +287,12 @@ pub(crate) fn to_llvm_features<'a>(sess: &Session, s: &'a str) -> Option<LLVMFea
                 "cmpxchg16b" => Some(LLVMFeature::new("cx16")),
                 "lahfsahf" => Some(LLVMFeature::new("sahf")),
                 // Enable the evex512 target feature if an avx512 target feature is enabled.
-                s if s.starts_with("avx512") => Some(LLVMFeature::with_dependencies(
+                s if s.starts_with("avx512") && major < 22 => Some(LLVMFeature::with_dependencies(
                     s,
                     smallvec![TargetFeatureFoldStrength::EnableOnly("evex512")],
                 )),
-                "avx10.1" => Some(LLVMFeature::new("avx10.1-512")),
-                "avx10.2" => Some(LLVMFeature::new("avx10.2-512")),
+                "avx10.1" if major < 22 => Some(LLVMFeature::new("avx10.1-512")),
+                "avx10.2" if major < 22 => Some(LLVMFeature::new("avx10.2-512")),
                 "apxf" => Some(LLVMFeature::with_dependencies(
                     "egpr",
                     smallvec![

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -1760,6 +1760,10 @@ extern "C" bool LLVMRustIsNonGVFunctionPointerTy(LLVMValueRef V) {
   return false;
 }
 
+extern "C" LLVMValueRef LLVMRustStripPointerCasts(LLVMValueRef V) {
+  return wrap(unwrap(V)->stripPointerCasts());
+}
+
 extern "C" bool LLVMRustLLVMHasZlibCompression() {
   return llvm::compression::zlib::isAvailable();
 }

--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -659,7 +659,7 @@ where
         }
 
         // `rustc_transmute` does not have support for type or const params
-        if goal.has_non_region_placeholders() {
+        if goal.predicate.has_non_region_placeholders() {
             return Err(NoSolution);
         }
 

--- a/compiler/rustc_target/src/spec/targets/amdgcn_amd_amdhsa.rs
+++ b/compiler/rustc_target/src/spec/targets/amdgcn_amd_amdhsa.rs
@@ -5,7 +5,7 @@ use crate::spec::{
 pub(crate) fn target() -> Target {
     Target {
         arch: Arch::AmdGpu,
-        data_layout: "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-p7:160:256:256:32-p8:128:128:128:48-p9:192:256:256:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7:8:9".into(),
+        data_layout: "e-m:e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-p7:160:256:256:32-p8:128:128:128:48-p9:192:256:256:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7:8:9".into(),
         llvm_target: "amdgcn-amd-amdhsa".into(),
         metadata: TargetMetadata {
             description: Some("AMD GPU".into()),

--- a/library/std/src/sys/io/error/windows.rs
+++ b/library/std/src/sys/io/error/windows.rs
@@ -126,7 +126,7 @@ pub fn error_string(mut errnum: i32) -> String {
         match String::from_utf16(&buf[..res]) {
             Ok(mut msg) => {
                 // Trim trailing CRLF inserted by FormatMessageW
-                let len = msg.trim_end().len();
+                let len = msg.trim_ascii_end().len();
                 msg.truncate(len);
                 msg
             }

--- a/library/std/src/sys/process/windows.rs
+++ b/library/std/src/sys/process/windows.rs
@@ -818,7 +818,7 @@ impl From<u8> for ExitCode {
 
 impl From<u32> for ExitCode {
     fn from(code: u32) -> Self {
-        ExitCode(u32::from(code))
+        ExitCode(code)
     }
 }
 

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -20,6 +20,7 @@
 	--src-sidebar-width: 300px;
 	--desktop-sidebar-z-index: 100;
 	--sidebar-elems-left-padding: 24px;
+	--popover-top-margin: 7px;
 	/* clipboard <https://github.com/rust-lang/crates.io/commits/main/public/assets/copy.svg> */
 	--clipboard-image: url('data:image/svg+xml,<svg width="19" height="18" viewBox="0 0 24 25" \
 xmlns="http://www.w3.org/2000/svg" aria-label="Copy to clipboard">\
@@ -1435,7 +1436,7 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	top: 100%;
 	right: 0;
 	z-index: calc(var(--desktop-sidebar-z-index) + 1);
-	margin-top: 7px;
+	margin-top: var(--popover-top-margin);
 	border-radius: 3px;
 	border: 1px solid var(--border-color);
 	background-color: var(--main-background-color);
@@ -2659,6 +2660,7 @@ in src-script.js and main.js
 @media (max-width: 700px) {
 	:root {
 		--impl-items-indent: 0.7em;
+		--topbar-height: 45px;
 	}
 
 	/* When linking to an item with an `id` (for instance, by clicking a link in the sidebar,
@@ -2666,7 +2668,7 @@ in src-script.js and main.js
 	   by the topbar. Anything with an `id` gets scroll-margin-top equal to rustdoc-topbar's size.
 	*/
 	*[id] {
-		scroll-margin-top: 45px;
+		scroll-margin-top: var(--topbar-height);
 	}
 
 	/* We don't display this button on mobile devices. */
@@ -2698,13 +2700,22 @@ in src-script.js and main.js
 		background: var(--main-background-color);
 		border-radius: 0;
 	}
-	#settings.popover {
+	#settings.popover, #help.popover {
 		top: 32px;
+		/* The `+ 1px` part is for the bottom border to be visible. */
+		height: calc(100vh - var(--topbar-height) + var(--popover-top-margin) - 1px);
+	}
+	#settings.popover {
 		--popover-arrow-offset: 48px;
 	}
 	#help.popover {
-		top: 32px;
 		--popover-arrow-offset: 12px;
+	}
+	/* The `overflow-y` property is used on an internal content instead of the top one otherwise the
+	   little arrow at the top can't be displayed. */
+	#settings.popover .settings, #help.popover .content {
+		overflow-y: scroll;
+		height: 100%;
 	}
 
 	.rustdoc {
@@ -2728,13 +2739,13 @@ in src-script.js and main.js
 
 	.sidebar {
 		position: fixed;
-		top: 45px;
+		top: var(--topbar-height);
 		/* Hide the sidebar offscreen while not in use. Doing this instead of display: none means
 		   the sidebar stays visible for screen readers, which is useful for navigation. */
 		left: -1000px;
 		z-index: 11;
 		/* Reduce height slightly to account for mobile topbar. */
-		height: calc(100vh - 45px);
+		height: calc(100vh - var(--topbar-height));
 		/* resize indicator: hide this when on touch or mobile */
 		border-right: none;
 		width: 100%;
@@ -2799,7 +2810,7 @@ in src-script.js and main.js
 		flex-direction: row;
 		position: sticky;
 		z-index: 10;
-		height: 45px;
+		height: var(--topbar-height);
 		width: 100%;
 		left: 0;
 		top: 0;

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -1692,7 +1692,7 @@ function preLoadCss(cssUrl) {
 
         const container = document.createElement("div");
         if (!isHelpPage) {
-            container.className = "popover content";
+            container.className = "popover";
         }
         container.id = "help";
 
@@ -1701,9 +1701,14 @@ function preLoadCss(cssUrl) {
         side_by_side.appendChild(div_shortcuts);
         side_by_side.appendChild(div_infos);
 
-        container.appendChild(book_info);
-        container.appendChild(side_by_side);
-        container.appendChild(rustdoc_version);
+        const content = document.createElement("div");
+        content.className = "content";
+
+        content.appendChild(book_info);
+        content.appendChild(side_by_side);
+        content.appendChild(rustdoc_version);
+
+        container.appendChild(content);
 
         if (isHelpPage) {
             const help_section = document.createElement("section");

--- a/tests/codegen-llvm/amdgpu-addrspacecast.rs
+++ b/tests/codegen-llvm/amdgpu-addrspacecast.rs
@@ -1,16 +1,25 @@
 // Check that pointers are casted to addrspace(0) before they are used
 
-//@ compile-flags: --crate-type=rlib --target=amdgcn-amd-amdhsa -Ctarget-cpu=gfx900
+//@ compile-flags: --crate-type=rlib --target=amdgcn-amd-amdhsa -Ctarget-cpu=gfx900 -O
 //@ needs-llvm-components: amdgpu
 //@ add-minicore
+//@ revisions: LLVM21 LLVM22
+//@ [LLVM21] max-llvm-major-version: 21
+//@ [LLVM22] min-llvm-version: 22
 #![feature(no_core)]
 #![no_core]
 
 extern crate minicore;
 
+// Make sure that on LLVM 22, the alloca is passed directly to the lifetime intrinsics,
+// not the addrspacecast.
+
 // CHECK-LABEL: @ref_of_local
 // CHECK: [[alloca:%[0-9]]] = alloca
 // CHECK: %i = addrspacecast ptr addrspace(5) [[alloca]] to ptr
+// LLVM22: call void @llvm.lifetime.start.p5(ptr addrspace(5) [[alloca]])
+// CHECK: call void %f(ptr{{.*}}%i)
+// LLVM22: call void @llvm.lifetime.end.p5(ptr addrspace(5) [[alloca]])
 #[no_mangle]
 pub fn ref_of_local(f: fn(&i32)) {
     let i = 0;

--- a/tests/rustdoc-gui/mobile-topbar-menu-popovers.goml
+++ b/tests/rustdoc-gui/mobile-topbar-menu-popovers.goml
@@ -16,7 +16,8 @@ assert: |menu_height| < |window_height| && |scroll_height| > |window_height|
 // We scroll to the last element of the menu.
 scroll-to: "#settings .setting-line:last-of-type input"
 // The item should be visible now, and so the Y scroll value should have changed.
-assert-property: ("#settings .settings", {"scrollTop": 295})
+// Note: The `scrollTop` value will change if settings are added or removed.
+assert-property: ("#settings .settings", {"scrollTop": 335})
 
 // Now we open the help menu.
 click: ".help-menu a"

--- a/tests/rustdoc-gui/mobile-topbar-menu-popovers.goml
+++ b/tests/rustdoc-gui/mobile-topbar-menu-popovers.goml
@@ -1,0 +1,33 @@
+// Ensure that topbar popover menus content can be scrolled on mobile.
+go-to: "file://" + |DOC_PATH| + "/lib2/index.html"
+store-value: (window_height, 500)
+set-window-size: (400, |window_height|)
+
+include: "utils.goml"
+
+// We open the settings menu
+call-function: ("open-settings-menu", {})
+// We ensure it's not scrolled down yet.
+assert-property: ("#settings .settings", {"scrollTop": 0})
+// We ensure its height is smaller than the window's, but its content's height is bigger.
+store-property: ("#settings .settings", {"offsetHeight": menu_height, "scrollHeight": scroll_height})
+assert: |menu_height| < |window_height| && |scroll_height| > |window_height|
+
+// We scroll to the last element of the menu.
+scroll-to: "#settings .setting-line:last-of-type input"
+// The item should be visible now, and so the Y scroll value should have changed.
+assert-property: ("#settings .settings", {"scrollTop": 295})
+
+// Now we open the help menu.
+click: ".help-menu a"
+wait-for: "#help"
+// We ensure it's not scrolled down yet.
+assert-property: ("#help .content", {"scrollTop": 0})
+// We ensure its height is smaller than the window's, but its content's height is bigger.
+store-property: ("#help .content", {"offsetHeight": menu_height, "scrollHeight": scroll_height})
+assert: |menu_height| < |window_height| && |scroll_height| > |window_height|
+
+// We scroll to the last element of the menu.
+scroll-to: "#help .infos > :last-child"
+// The item should be visible now, and so the Y scroll value should have changed.
+assert-property: ("#help .content", {"scrollTop": 339})

--- a/tests/ui/delegation/unresolved-delegation-ice-151356.rs
+++ b/tests/ui/delegation/unresolved-delegation-ice-151356.rs
@@ -1,0 +1,11 @@
+#![allow(incomplete_features)]
+#![feature(fn_delegation)]
+
+extern "C" {
+    fn a() {
+        //~^ ERROR incorrect function inside `extern` block
+        reuse foo {}
+    }
+}
+
+pub fn main() {}

--- a/tests/ui/delegation/unresolved-delegation-ice-151356.stderr
+++ b/tests/ui/delegation/unresolved-delegation-ice-151356.stderr
@@ -1,0 +1,19 @@
+error: incorrect function inside `extern` block
+  --> $DIR/unresolved-delegation-ice-151356.rs:5:8
+   |
+LL |   extern "C" {
+   |   ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
+LL |       fn a() {
+   |  ________^___-
+   | |        |
+   | |        cannot have a body
+LL | |
+LL | |         reuse foo {}
+LL | |     }
+   | |_____- help: remove the invalid body: `;`
+   |
+   = help: you might have meant to write a function accessible through FFI, which can be done by writing `extern fn` outside of the `extern` block
+   = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/transmutability/transmute-with-type-params.rs
+++ b/tests/ui/transmutability/transmute-with-type-params.rs
@@ -1,0 +1,21 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@ [next] compile-flags: -Znext-solver
+//@ check-pass
+
+// A regression test for https://github.com/rust-lang/rust/issues/151300
+
+#![feature(transmutability)]
+use std::mem::TransmuteFrom;
+
+pub fn is_maybe_transmutable<Src, Dst>()
+where
+    Dst: TransmuteFrom<Src>,
+{
+}
+
+fn function_with_generic<T>() {
+    is_maybe_transmutable::<(), ()>();
+}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#151216 ([rustdoc] Make popover menus content scrollable on mobile devices)
 - rust-lang/rust#151373 (Fix an ICE on transmute goals with placeholders in `param_env`)
 - rust-lang/rust#151399 (Generate error delegation when delegation is not resolved)
 - rust-lang/rust#151406 (Use version 1.93.0 in `RELEASES.md` instead of 1.93)
 - rust-lang/rust#151410 (Fixes for LLVM 22 compatibility)
 - rust-lang/rust#151415 (chore: Remove redundant conversion)
 - rust-lang/rust#151418 (Avoid pulling in unicode when calling io::Error::kind)

r? @ghost

<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=151399,151216,151373,151406,151410,151415,151418)
<!-- homu-ignore:end -->

