### PR TITLE
Roll bootstrap reviewers for `src/tools/build-manifest`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -499,6 +499,7 @@ trigger_files = [
     "bootstrap.example.toml",
     "src/bootstrap",
     "src/build_helper",
+    "src/tools/build-manifest",
     "src/tools/rust-installer",
     "src/tools/x",
     "src/stage0",

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1657,6 +1657,7 @@ dep-bumps = [
 "/tests/rustdoc-json" =                                  ["@aDotInTheVoid"]
 "/tests/rustdoc-ui" =                                    ["rustdoc"]
 "/tests/ui" =                                            ["compiler"]
+"/src/tools/build-manifest" =                            ["bootstrap"]
 "/src/tools/cargo" =                                     ["@ehuss"]
 "/src/tools/compiletest" =                               ["bootstrap", "@wesleywiser", "@oli-obk", "@jieyouxu"]
 "/src/tools/linkchecker" =                               ["@ehuss"]


### PR DESCRIPTION
I honestly don't know who's supposed to be maintaining this tool, but maybe bootstrap? 🤷 

r? @Kobzol (maybe)