### PR TITLE
Fix ICE: Don't try to evaluate type_consts when eagerly collecting items

### DIFF
--- a/tests/ui/const-generics/mgca/type_const-incemental-compile.rs
+++ b/tests/ui/const-generics/mgca/type_const-incemental-compile.rs
@@ -1,0 +1,11 @@
+//@ check-pass
+//@compile-flags: -Clink-dead-code=true
+// link-dead-code tries to eagerly monomorphize and collect items
+// This lead to collector.rs to try and evaluate a type_const
+// which will fail since they do not have bodies.
+#![expect(incomplete_features)]
+#![feature(min_generic_const_args)]
+
+#[type_const]
+const TYPE_CONST: usize = 0;
+fn main() {}


### PR DESCRIPTION
This fixes https://github.com/rust-lang/rust/issues/151246

The change is pretty straightforward if the Monomorphization strategy is eager which `-Clink-dead-code=true` sets. This then would lead to the existing code to try and evaluate a `type const` which does not have a body to evaluate leading to an ICE. The change is pretty straight forward just skip over type consts.

This also seems like a sensible choice to me since a MonoItem can only be a Fn, Static, or Asm. A type const is none of the aforementioned. 

And even if it was added to the MonoItems list it would then later fail this check:
https://github.com/rust-lang/rust/blob/fe98ddcfcfb6f185dbf4adeaf439d8a756da0273/compiler/rustc_monomorphize/src/collector.rs#L438-L440
Since that explicitly checks that the MonoItem's `DefKind` is static and not anything else.

One more change is the addition of a simple test of the example code from https://github.com/rust-lang/rust/issues/151246 that checks that code compiles successfully with `-Clink-dead-code=true`.

The only other change was to make the guard checks a little easier to read by making the logic more linear instead of one big if statement. 

r? @BoxyUwU 
@rustbot label +F-associated_const_equality +F-min_generic_const_args