### PR TITLE
Derive `Default` for `QueryArenas`

### DIFF
--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -342,12 +342,18 @@ macro_rules! define_callbacks {
             })*
         }
 
+        /// Holds per-query arenas for queries with the `arena_cache` modifier.
         #[derive(Default)]
         pub struct QueryArenas<'tcx> {
-            $($(#[$attr])* pub $name: query_if_arena!([$($modifiers)*]
-                (TypedArena<<$V as $crate::query::arena_cached::ArenaCached<'tcx>>::Allocated>)
-                ()
-            ),)*
+            $(
+                $(#[$attr])*
+                pub $name: query_if_arena!([$($modifiers)*]
+                    // Use the `ArenaCached` helper trait to determine the arena's value type.
+                    (TypedArena<<$V as $crate::query::arena_cached::ArenaCached<'tcx>>::Allocated>)
+                    // No arena for this query, so the field type is `()`.
+                    ()
+                ),
+            )*
         }
 
         #[derive(Default)]

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -342,22 +342,12 @@ macro_rules! define_callbacks {
             })*
         }
 
+        #[derive(Default)]
         pub struct QueryArenas<'tcx> {
             $($(#[$attr])* pub $name: query_if_arena!([$($modifiers)*]
                 (TypedArena<<$V as $crate::query::arena_cached::ArenaCached<'tcx>>::Allocated>)
                 ()
             ),)*
-        }
-
-        impl Default for QueryArenas<'_> {
-            fn default() -> Self {
-                Self {
-                    $($name: query_if_arena!([$($modifiers)*]
-                        (Default::default())
-                        ()
-                    ),)*
-                }
-            }
         }
 
         #[derive(Default)]


### PR DESCRIPTION
There's no need to manually implement Default for this struct, because the fields are all `TypeArena<_>` or `()`, which both implement Default already.

This lets us avoid one occurrence of the `query_if_arena!` macro.