### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -342,12 +342,18 @@ macro_rules! define_callbacks {
             })*
         }
 
+        /// Holds per-query arenas for queries with the `arena_cache` modifier.
         #[derive(Default)]
         pub struct QueryArenas<'tcx> {
-            $($(#[$attr])* pub $name: query_if_arena!([$($modifiers)*]
-                (TypedArena<<$V as $crate::query::arena_cached::ArenaCached<'tcx>>::Allocated>)
-                ()
-            ),)*
+            $(
+                $(#[$attr])*
+                pub $name: query_if_arena!([$($modifiers)*]
+                    // Use the `ArenaCached` helper trait to determine the arena's value type.
+                    (TypedArena<<$V as $crate::query::arena_cached::ArenaCached<'tcx>>::Allocated>)
+                    // No arena for this query, so the field type is `()`.
+                    ()
+                ),
+            )*
         }
 
         #[derive(Default)]

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -342,22 +342,12 @@ macro_rules! define_callbacks {
             })*
         }
 
+        #[derive(Default)]
         pub struct QueryArenas<'tcx> {
             $($(#[$attr])* pub $name: query_if_arena!([$($modifiers)*]
                 (TypedArena<<$V as $crate::query::arena_cached::ArenaCached<'tcx>>::Allocated>)
                 ()
             ),)*
-        }
-
-        impl Default for QueryArenas<'_> {
-            fn default() -> Self {
-                Self {
-                    $($name: query_if_arena!([$($modifiers)*]
-                        (Default::default())
-                        ()
-                    ),)*
-                }
-            }
         }
 
         #[derive(Default)]

--- a/tests/debuginfo/basic-stepping.rs
+++ b/tests/debuginfo/basic-stepping.rs
@@ -10,6 +10,10 @@
 // Debugger tests need debuginfo
 //@ compile-flags: -g
 
+// FIXME(#128945): SingleUseConsts shouldn't need to be disabled.
+//@ revisions: default-mir-passes no-SingleUseConsts-mir-pass
+//@ [no-SingleUseConsts-mir-pass] compile-flags: -Zmir-enable-passes=-SingleUseConsts
+
 //@ gdb-command: run
 // FIXME(#97083): Should we be able to break on initialization of zero-sized types?
 // FIXME(#97083): Right now the first breakable line is:
@@ -17,12 +21,12 @@
 //@ gdb-command: next
 //@ gdb-check:   let d = c = 99;
 //@ gdb-command: next
-// FIXME(#33013): gdb-check:   let e = "hi bob";
-// FIXME(#33013): gdb-command: next
-// FIXME(#33013): gdb-check:   let f = b"hi bob";
-// FIXME(#33013): gdb-command: next
-// FIXME(#33013): gdb-check:   let g = b'9';
-// FIXME(#33013): gdb-command: next
+//@ [no-SingleUseConsts-mir-pass] gdb-check:   let e = "hi bob";
+//@ [no-SingleUseConsts-mir-pass] gdb-command: next
+//@ [no-SingleUseConsts-mir-pass] gdb-check:   let f = b"hi bob";
+//@ [no-SingleUseConsts-mir-pass] gdb-command: next
+//@ [no-SingleUseConsts-mir-pass] gdb-check:   let g = b'9';
+//@ [no-SingleUseConsts-mir-pass] gdb-command: next
 //@ gdb-check:   let h = ["whatever"; 8];
 //@ gdb-command: next
 //@ gdb-check:   let i = [1,2,3,4];

--- a/tests/debuginfo/basic-stepping.rs
+++ b/tests/debuginfo/basic-stepping.rs
@@ -5,8 +5,10 @@
 //@ ignore-aarch64: Doesn't work yet.
 //@ ignore-loongarch64: Doesn't work yet.
 //@ ignore-riscv64: Doesn't work yet.
-//@ compile-flags: -g
 //@ ignore-backends: gcc
+
+// Debugger tests need debuginfo
+//@ compile-flags: -g
 
 //@ gdb-command: run
 // FIXME(#97083): Should we be able to break on initialization of zero-sized types?


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#147426 ( tests/debuginfo/basic-stepping.rs: Add revisions `default-mir-passes`, `no-SingleUseConsts-mir-pass`)
 - rust-lang/rust#151445 (Derive `Default` for `QueryArenas`)

r? @ghost

<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=147426,151445)
<!-- homu-ignore:end -->

