### PR TITLE
make `simd_insert_dyn` and `simd_extract_dyn` const

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/intrinsics/simd.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics/simd.rs
@@ -30,7 +30,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         let dest = dest.force_mplace(self)?;
 
         match intrinsic_name {
-            sym::simd_insert => {
+            sym::simd_insert | sym::simd_insert_dyn => {
                 let index = u64::from(self.read_scalar(&args[1])?.to_u32()?);
                 let elem = &args[2];
                 let (input, input_len) = self.project_to_simd(&args[0])?;
@@ -39,7 +39,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 // Bounds are not checked by typeck so we have to do it ourselves.
                 if index >= input_len {
                     throw_ub_format!(
-                        "`simd_insert` index {index} is out-of-bounds of vector with length {input_len}"
+                        "`{intrinsic_name}` index {index} is out-of-bounds of vector with length {input_len}"
                     );
                 }
 
@@ -50,13 +50,13 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                     self.copy_op(&value, &place)?;
                 }
             }
-            sym::simd_extract => {
+            sym::simd_extract | sym::simd_extract_dyn => {
                 let index = u64::from(self.read_scalar(&args[1])?.to_u32()?);
                 let (input, input_len) = self.project_to_simd(&args[0])?;
                 // Bounds are not checked by typeck so we have to do it ourselves.
                 if index >= input_len {
                     throw_ub_format!(
-                        "`simd_extract` index {index} is out-of-bounds of vector with length {input_len}"
+                        "`{intrinsic_name}` index {index} is out-of-bounds of vector with length {input_len}"
                     );
                 }
                 self.copy_op(&self.project_index(&input, index)?, &dest)?;

--- a/library/core/src/intrinsics/simd.rs
+++ b/library/core/src/intrinsics/simd.rs
@@ -37,11 +37,7 @@ pub const unsafe fn simd_extract<T, U>(x: T, idx: u32) -> U;
 /// `idx` must be in-bounds of the vector.
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub unsafe fn simd_insert_dyn<T, U>(mut x: T, idx: u32, val: U) -> T {
-    // SAFETY: `idx` must be in-bounds
-    unsafe { (&raw mut x).cast::<U>().add(idx as usize).write(val) }
-    x
-}
+pub const unsafe fn simd_insert_dyn<T, U>(x: T, idx: u32, val: U) -> T;
 
 /// Extracts an element from a vector.
 ///
@@ -54,10 +50,7 @@ pub unsafe fn simd_insert_dyn<T, U>(mut x: T, idx: u32, val: U) -> T {
 /// `idx` must be in-bounds of the vector.
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub unsafe fn simd_extract_dyn<T, U>(x: T, idx: u32) -> U {
-    // SAFETY: `idx` must be in-bounds
-    unsafe { (&raw const x).cast::<U>().add(idx as usize).read() }
-}
+pub const unsafe fn simd_extract_dyn<T, U>(x: T, idx: u32) -> U;
 
 /// Adds two simd vectors elementwise.
 ///

--- a/tests/ui/simd/intrinsic/generic-elements-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-elements-pass.rs
@@ -25,7 +25,7 @@ macro_rules! all_eq {
     }};
 }
 
-fn extract_insert_dyn() {
+const fn extract_insert_dyn() {
     let x2 = i32x2::from_array([20, 21]);
     let x4 = i32x4::from_array([40, 41, 42, 43]);
     let x8 = i32x8::from_array([80, 81, 82, 83, 84, 85, 86, 87]);
@@ -141,6 +141,7 @@ const fn swizzle() {
 }
 
 fn main() {
+    const { extract_insert_dyn() };
     extract_insert_dyn();
     const { swizzle() };
     swizzle();


### PR DESCRIPTION
For use in `stdarch`. We currently use an equivalent of the fallback body here, but on some targets the intrinsic generate better code.

r? RalfJung 
