### PR TITLE
Improve error message for assert!() macro in functions returning bool

### DIFF
--- a/tests/ui/consts/control-flow/issue-50577.rs
+++ b/tests/ui/consts/control-flow/issue-50577.rs
@@ -1,6 +1,6 @@
 fn main() {
     enum Foo {
         Drop = assert_eq!(1, 1),
-        //~^ ERROR `if` may be missing an `else` clause
+        //~^ ERROR mismatched types [E0308]
     }
 }

--- a/tests/ui/consts/control-flow/issue-50577.stderr
+++ b/tests/ui/consts/control-flow/issue-50577.stderr
@@ -1,13 +1,11 @@
-error[E0317]: `if` may be missing an `else` clause
+error[E0308]: mismatched types
   --> $DIR/issue-50577.rs:3:16
    |
 LL |         Drop = assert_eq!(1, 1),
    |                ^^^^^^^^^^^^^^^^ expected `isize`, found `()`
    |
-   = note: `if` expressions without `else` evaluate to `()`
-   = help: consider adding an `else` block that evaluates to the expected type
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0317`.
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/expr/if/assert-macro-without-else.rs
+++ b/tests/ui/expr/if/assert-macro-without-else.rs
@@ -1,0 +1,34 @@
+//@ dont-require-annotations: NOTE
+
+fn f() -> bool {
+    assert!(1 < 2)
+    //~^ ERROR mismatched types [E0308]
+}
+
+fn g() -> i32 {
+    assert_eq!(1, 1)
+    //~^ ERROR mismatched types [E0308]
+}
+
+fn h() -> bool {
+    assert_ne!(1, 2)
+    //~^ ERROR mismatched types [E0308]
+}
+
+// Test nested macros
+macro_rules! g {
+    () => {
+        f!()
+    };
+}
+macro_rules! f {
+    () => {
+        assert!(1 < 2)
+        //~^ ERROR mismatched types [E0308]
+    };
+}
+fn nested() -> bool {
+    g!()
+}
+
+fn main() {}

--- a/tests/ui/expr/if/assert-macro-without-else.stderr
+++ b/tests/ui/expr/if/assert-macro-without-else.stderr
@@ -1,0 +1,40 @@
+error[E0308]: mismatched types
+  --> $DIR/assert-macro-without-else.rs:4:5
+   |
+LL | fn f() -> bool {
+   |           ---- expected `bool` because of this return type
+LL |     assert!(1 < 2)
+   |     ^^^^^^^^^^^^^^ expected `bool`, found `()`
+
+error[E0308]: mismatched types
+  --> $DIR/assert-macro-without-else.rs:9:5
+   |
+LL |     assert_eq!(1, 1)
+   |     ^^^^^^^^^^^^^^^^ expected `i32`, found `()`
+   |
+   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> $DIR/assert-macro-without-else.rs:14:5
+   |
+LL |     assert_ne!(1, 2)
+   |     ^^^^^^^^^^^^^^^^ expected `bool`, found `()`
+   |
+   = note: this error originates in the macro `assert_ne` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> $DIR/assert-macro-without-else.rs:26:9
+   |
+LL |         assert!(1 < 2)
+   |         ^^^^^^^^^^^^^^ expected `bool`, found `()`
+...
+LL | fn nested() -> bool {
+   |                ---- expected `bool` because of this return type
+LL |     g!()
+   |     ---- in this macro invocation
+   |
+   = note: this error originates in the macro `assert` which comes from the expansion of the macro `g` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Detect `assert!()` macro in error messages and provide clearer diagnostics

When `assert!()` is used in a function returning a value, show a message explaining that `assert!()` doesn't return a value, instead of the generic "if may be missing an else clause" error.

Fixes rust-lang/rust#151446