### PR TITLE
constify boolean methods

### DIFF
--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -1,5 +1,7 @@
 //! impl bool {}
 
+use crate::marker::Destruct;
+
 impl bool {
     /// Returns `Some(t)` if the `bool` is [`true`](../std/keyword.true.html),
     /// or `None` otherwise.
@@ -29,8 +31,9 @@ impl bool {
     /// assert_eq!(a, 2);
     /// ```
     #[stable(feature = "bool_to_option", since = "1.62.0")]
+    #[rustc_const_unstable(feature = "const_bool", issue = "151531")]
     #[inline]
-    pub fn then_some<T>(self, t: T) -> Option<T> {
+    pub const fn then_some<T: [const] Destruct>(self, t: T) -> Option<T> {
         if self { Some(t) } else { None }
     }
 
@@ -57,8 +60,9 @@ impl bool {
     #[doc(alias = "then_with")]
     #[stable(feature = "lazy_bool_to_option", since = "1.50.0")]
     #[rustc_diagnostic_item = "bool_then"]
+    #[rustc_const_unstable(feature = "const_bool", issue = "151531")]
     #[inline]
-    pub fn then<T, F: FnOnce() -> T>(self, f: F) -> Option<T> {
+    pub const fn then<T, F: [const] FnOnce() -> T + [const] Destruct>(self, f: F) -> Option<T> {
         if self { Some(f()) } else { None }
     }
 
@@ -94,8 +98,9 @@ impl bool {
     /// assert_eq!(a, 2);
     /// ```
     #[unstable(feature = "bool_to_result", issue = "142748")]
+    #[rustc_const_unstable(feature = "const_bool", issue = "151531")]
     #[inline]
-    pub fn ok_or<E>(self, err: E) -> Result<(), E> {
+    pub const fn ok_or<E: [const] Destruct>(self, err: E) -> Result<(), E> {
         if self { Ok(()) } else { Err(err) }
     }
 
@@ -124,8 +129,12 @@ impl bool {
     /// assert_eq!(a, 1);
     /// ```
     #[unstable(feature = "bool_to_result", issue = "142748")]
+    #[rustc_const_unstable(feature = "const_bool", issue = "151531")]
     #[inline]
-    pub fn ok_or_else<E, F: FnOnce() -> E>(self, f: F) -> Result<(), E> {
+    pub const fn ok_or_else<E, F: [const] FnOnce() -> E + [const] Destruct>(
+        self,
+        f: F,
+    ) -> Result<(), E> {
         if self { Ok(()) } else { Err(f()) }
     }
 }

--- a/library/coretests/tests/bool.rs
+++ b/library/coretests/tests/bool.rs
@@ -82,16 +82,16 @@ pub fn test_bool_not() {
     }
 }
 
+const fn zero() -> i32 {
+    0
+}
+
 #[test]
 fn test_bool_to_option() {
     assert_eq!(false.then_some(0), None);
     assert_eq!(true.then_some(0), Some(0));
     assert_eq!(false.then(|| 0), None);
     assert_eq!(true.then(|| 0), Some(0));
-
-    const fn zero() -> i32 {
-        0
-    }
 
     const A: Option<i32> = false.then_some(0);
     const B: Option<i32> = true.then_some(0);

--- a/library/coretests/tests/bool.rs
+++ b/library/coretests/tests/bool.rs
@@ -89,7 +89,6 @@ fn test_bool_to_option() {
     assert_eq!(false.then(|| 0), None);
     assert_eq!(true.then(|| 0), Some(0));
 
-    /* FIXME(#110395)
     const fn zero() -> i32 {
         0
     }
@@ -103,7 +102,6 @@ fn test_bool_to_option() {
     assert_eq!(B, Some(0));
     assert_eq!(C, None);
     assert_eq!(D, Some(0));
-    */
 }
 
 #[test]
@@ -112,4 +110,14 @@ fn test_bool_to_result() {
     assert_eq!(true.ok_or(0), Ok(()));
     assert_eq!(false.ok_or_else(|| 0), Err(0));
     assert_eq!(true.ok_or_else(|| 0), Ok(()));
+
+    const A: Result<(), i32> = false.ok_or(0);
+    const B: Result<(), i32> = true.ok_or(0);
+    const C: Result<(), i32> = false.ok_or_else(zero);
+    const D: Result<(), i32> = true.ok_or_else(zero);
+
+    assert_eq!(A, Err(0));
+    assert_eq!(B, Ok(()));
+    assert_eq!(C, Err(0));
+    assert_eq!(D, Ok(()));
 }

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -17,6 +17,7 @@
 #![feature(clamp_magnitude)]
 #![feature(clone_to_uninit)]
 #![feature(const_array)]
+#![feature(const_bool)]
 #![feature(const_cell_traits)]
 #![feature(const_clone)]
 #![feature(const_cmp)]


### PR DESCRIPTION
```rs
// core::bool

impl bool {
    pub const fn then_some<T: [const] Destruct>(self, t: T) -> Option<T>;
    pub const fn then<T, F: [const] FnOnce() -> T + [const] Destruct>(self, f: F) -> Option<T>;
    pub const fn ok_or<E: [const] Destruct>(self, err: E) -> Result<(), E>;
    pub const fn ok_or_else<E, F: [const] FnOnce() -> E + [const] Destruct>;
}
```

will make tracking issue if pr liked