### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -986,16 +986,6 @@ impl<'a> MethodDef<'a> {
         f(cx, span, &substructure)
     }
 
-    fn get_ret_ty(
-        &self,
-        cx: &ExtCtxt<'_>,
-        trait_: &TraitDef<'_>,
-        generics: &Generics,
-        type_ident: Ident,
-    ) -> Box<ast::Ty> {
-        self.ret_ty.to_ty(cx, trait_.span, type_ident, generics)
-    }
-
     fn is_static(&self) -> bool {
         !self.explicit_self
     }
@@ -1068,10 +1058,14 @@ impl<'a> MethodDef<'a> {
             self_arg.into_iter().chain(nonself_args).collect()
         };
 
-        let ret_type = self.get_ret_ty(cx, trait_, generics, type_ident);
+        let ret_type = if let Ty::Unit = &self.ret_ty {
+            ast::FnRetTy::Default(span)
+        } else {
+            ast::FnRetTy::Ty(self.ret_ty.to_ty(cx, span, type_ident, generics))
+        };
 
         let method_ident = Ident::new(self.name, span);
-        let fn_decl = cx.fn_decl(args, ast::FnRetTy::Ty(ret_type));
+        let fn_decl = cx.fn_decl(args, ret_type);
         let body_block = body.into_block(cx, span);
 
         let trait_lo_sp = span.shrink_to_lo();

--- a/compiler/rustc_codegen_ssa/src/traits/builder.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/builder.rs
@@ -600,10 +600,13 @@ pub trait BuilderMethods<'a, 'tcx>:
     ///
     /// ## Arguments
     ///
-    /// The `fn_attrs`, `fn_abi`, and `instance` arguments are Options because they are advisory.
-    /// They relate to optional codegen enhancements like LLVM CFI, and do not affect ABI per se.
-    /// Any ABI-related transformations should be handled by different, earlier stages of codegen.
-    /// For instance, in the caller of `BuilderMethods::call`.
+    /// `caller_attrs` are the attributes of the surrounding caller; they have nothing to do with
+    /// the callee.
+    ///
+    /// The `caller_attrs`, `fn_abi`, and `callee_instance` arguments are Options because they are
+    /// advisory. They relate to optional codegen enhancements like LLVM CFI, and do not affect ABI
+    /// per se. Any ABI-related transformations should be handled by different, earlier stages of
+    /// codegen. For instance, in the caller of `BuilderMethods::call`.
     ///
     /// This means that a codegen backend which disregards `fn_attrs`, `fn_abi`, and `instance`
     /// should still do correct codegen, and code should not be miscompiled if they are omitted.
@@ -620,23 +623,23 @@ pub trait BuilderMethods<'a, 'tcx>:
     fn call(
         &mut self,
         llty: Self::Type,
-        fn_attrs: Option<&CodegenFnAttrs>,
+        caller_attrs: Option<&CodegenFnAttrs>,
         fn_abi: Option<&FnAbi<'tcx, Ty<'tcx>>>,
         fn_val: Self::Value,
         args: &[Self::Value],
         funclet: Option<&Self::Funclet>,
-        instance: Option<Instance<'tcx>>,
+        callee_instance: Option<Instance<'tcx>>,
     ) -> Self::Value;
 
     fn tail_call(
         &mut self,
         llty: Self::Type,
-        fn_attrs: Option<&CodegenFnAttrs>,
+        caller_attrs: Option<&CodegenFnAttrs>,
         fn_abi: &FnAbi<'tcx, Ty<'tcx>>,
         llfn: Self::Value,
         args: &[Self::Value],
         funclet: Option<&Self::Funclet>,
-        instance: Option<Instance<'tcx>>,
+        callee_instance: Option<Instance<'tcx>>,
     );
 
     fn zext(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value;

--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -42,8 +42,11 @@
 // have to worry about it being moved to a different module in std during stabilization.
 // FIXME(#151359): Remove this when `feature(assert_matches)` is stable in stage0.
 // (This doesn't necessarily need to be fixed during the beta bump itself.)
+#[cfg(bootstrap)]
 pub use std::assert_matches::{assert_matches, debug_assert_matches};
 use std::fmt;
+#[cfg(not(bootstrap))]
+pub use std::{assert_matches, debug_assert_matches};
 
 pub use atomic_ref::AtomicRef;
 pub use ena::{snapshot_vec, undo_log, unify};

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -528,6 +528,12 @@ LLVMRustCreateAttrNoValue(LLVMContextRef C, LLVMRustAttributeKind RustAttr) {
                                 CaptureComponents::ReadProvenance)));
   }
 #endif
+#if LLVM_VERSION_GE(23, 0)
+  if (RustAttr == LLVMRustAttributeKind::DeadOnReturn) {
+    return wrap(Attribute::getWithDeadOnReturnInfo(*unwrap(C),
+                                                   llvm::DeadOnReturnInfo()));
+  }
+#endif
   return wrap(Attribute::get(*unwrap(C), fromRust(RustAttr)));
 }
 

--- a/compiler/rustc_middle/src/ty/consts/valtree.rs
+++ b/compiler/rustc_middle/src/ty/consts/valtree.rs
@@ -147,7 +147,12 @@ impl<'tcx> Value<'tcx> {
             _ => return None,
         }
 
-        Some(tcx.arena.alloc_from_iter(self.to_branch().into_iter().map(|ct| ct.to_leaf().to_u8())))
+        // We create an iterator that yields `Option<u8>`
+        let iterator = self.to_branch().into_iter().map(|ct| Some(ct.try_to_leaf()?.to_u8()));
+        // If there is `None` in the iterator, then the array is not a valid array of u8s and we return `None`
+        let bytes: Vec<u8> = iterator.collect::<Option<Vec<u8>>>()?;
+
+        Some(tcx.arena.alloc_from_iter(bytes))
     }
 
     /// Converts to a `ValTreeKind::Leaf` value, `panic`'ing

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1911,14 +1911,16 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                     return Ok(());
                 }
             },
-            (ty::ValTreeKind::Branch(_), ty::Array(t, _)) if t == u8_type => {
-                let bytes = cv.try_to_raw_bytes(self.tcx()).unwrap_or_else(|| {
-                    bug!("expected to convert valtree to raw bytes for type {:?}", t)
-                });
+            // If it is a branch with an array, and this array can be printed as raw bytes, then dump its bytes
+            (ty::ValTreeKind::Branch(_), ty::Array(t, _))
+                if t == u8_type
+                    && let Some(bytes) = cv.try_to_raw_bytes(self.tcx()) =>
+            {
                 write!(self, "*")?;
                 self.pretty_print_byte_str(bytes)?;
                 return Ok(());
             }
+            // Otherwise, print the array separated by commas (or if it's a tuple)
             (ty::ValTreeKind::Branch(fields), ty::Array(..) | ty::Tuple(..)) => {
                 let fields_iter = fields.iter().copied();
 

--- a/library/alloc/src/collections/btree/map/tests.rs
+++ b/library/alloc/src/collections/btree/map/tests.rs
@@ -1,4 +1,4 @@
-use core::assert_matches::assert_matches;
+use core::assert_matches;
 use std::iter;
 use std::ops::Bound::{Excluded, Included, Unbounded};
 use std::panic::{AssertUnwindSafe, catch_unwind};

--- a/library/alloctests/tests/c_str2.rs
+++ b/library/alloctests/tests/c_str2.rs
@@ -1,7 +1,7 @@
 use alloc::ffi::CString;
 use alloc::rc::Rc;
 use alloc::sync::Arc;
-use core::assert_matches::assert_matches;
+use core::assert_matches;
 use core::ffi::{CStr, FromBytesUntilNulError, c_char};
 #[allow(deprecated)]
 use core::hash::SipHasher13 as DefaultHasher;

--- a/library/alloctests/tests/str.rs
+++ b/library/alloctests/tests/str.rs
@@ -1,6 +1,6 @@
 #![allow(invalid_from_utf8)]
 
-use std::assert_matches::assert_matches;
+use std::assert_matches;
 use std::borrow::Cow;
 use std::cmp::Ordering::{Equal, Greater, Less};
 use std::str::{from_utf8, from_utf8_unchecked};

--- a/library/alloctests/tests/string.rs
+++ b/library/alloctests/tests/string.rs
@@ -1,10 +1,9 @@
-use std::assert_matches::assert_matches;
 use std::borrow::Cow;
 use std::cell::Cell;
 use std::collections::TryReserveErrorKind::*;
 use std::ops::Bound::*;
 use std::ops::{Bound, RangeBounds};
-use std::{panic, str};
+use std::{assert_matches, panic, str};
 
 pub trait IntoCow<'a, B: ?Sized>
 where

--- a/library/alloctests/tests/vec.rs
+++ b/library/alloctests/tests/vec.rs
@@ -3,12 +3,10 @@ use core::num::NonZero;
 use core::ptr::NonNull;
 use core::{assert_eq, assert_ne};
 use std::alloc::System;
-use std::assert_matches::assert_matches;
 use std::borrow::Cow;
 use std::cell::Cell;
 use std::collections::TryReserveErrorKind::*;
 use std::fmt::Debug;
-use std::hint;
 use std::iter::InPlaceIterable;
 use std::mem::swap;
 use std::ops::Bound::*;
@@ -16,6 +14,7 @@ use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::vec::{Drain, IntoIter, PeekMut};
+use std::{assert_matches, hint};
 
 use crate::testing::macros::struct_with_counted_drop;
 

--- a/library/alloctests/tests/vec_deque.rs
+++ b/library/alloctests/tests/vec_deque.rs
@@ -1,6 +1,6 @@
 use core::cell::Cell;
 use core::num::NonZero;
-use std::assert_matches::assert_matches;
+use std::assert_matches;
 use std::collections::TryReserveErrorKind::*;
 use std::collections::VecDeque;
 use std::collections::vec_deque::Drain;

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -55,7 +55,7 @@
 #![allow(missing_docs)]
 
 use crate::ffi::va_list::{VaArgSafe, VaList};
-use crate::marker::{ConstParamTy, Destruct, DiscriminantKind, PointeeSized, Tuple};
+use crate::marker::{ConstParamTy, DiscriminantKind, PointeeSized, Tuple};
 use crate::{mem, ptr};
 
 mod bounds;
@@ -482,11 +482,14 @@ pub const fn unlikely(b: bool) -> bool {
 #[rustc_nounwind]
 #[miri::intrinsic_fallback_is_spec]
 #[inline]
-pub const fn select_unpredictable<T>(b: bool, true_val: T, false_val: T) -> T
-where
-    T: [const] Destruct,
-{
-    if b { true_val } else { false_val }
+pub const fn select_unpredictable<T>(b: bool, true_val: T, false_val: T) -> T {
+    if b {
+        forget(false_val);
+        true_val
+    } else {
+        forget(true_val);
+        false_val
+    }
 }
 
 /// A guard for unsafe functions that cannot ever be executed if `T` is uninhabited:

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -223,11 +223,7 @@ use prelude::rust_2024::*;
 mod macros;
 
 #[unstable(feature = "assert_matches", issue = "82775")]
-/// Unstable module containing the unstable `assert_matches` macro.
-pub mod assert_matches {
-    #[unstable(feature = "assert_matches", issue = "82775")]
-    pub use crate::macros::{assert_matches, debug_assert_matches};
-}
+pub use crate::macros::{assert_matches, debug_assert_matches};
 
 #[unstable(feature = "derive_from", issue = "144889")]
 /// Unstable module containing the unstable `From` derive macro.

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -124,6 +124,8 @@ macro_rules! assert_ne {
     };
 }
 
+// FIXME add back debug_assert_matches doc link after bootstrap.
+
 /// Asserts that an expression matches the provided pattern.
 ///
 /// This macro is generally preferable to `assert!(matches!(value, pattern))`, because it can print
@@ -135,10 +137,8 @@ macro_rules! assert_ne {
 /// otherwise this macro will panic.
 ///
 /// Assertions are always checked in both debug and release builds, and cannot
-/// be disabled. See [`debug_assert_matches!`] for assertions that are disabled in
+/// be disabled. See `debug_assert_matches!` for assertions that are disabled in
 /// release builds by default.
-///
-/// [`debug_assert_matches!`]: crate::assert_matches::debug_assert_matches
 ///
 /// On panic, this macro will print the value of the expression with its debug representation.
 ///
@@ -149,7 +149,7 @@ macro_rules! assert_ne {
 /// ```
 /// #![feature(assert_matches)]
 ///
-/// use std::assert_matches::assert_matches;
+/// use std::assert_matches;
 ///
 /// let a = Some(345);
 /// let b = Some(56);
@@ -382,7 +382,7 @@ macro_rules! debug_assert_ne {
 /// ```
 /// #![feature(assert_matches)]
 ///
-/// use std::assert_matches::debug_assert_matches;
+/// use std::debug_assert_matches;
 ///
 /// let a = Some(345);
 /// let b = Some(56);
@@ -404,7 +404,7 @@ macro_rules! debug_assert_ne {
 #[rustc_macro_transparency = "semiopaque"]
 pub macro debug_assert_matches($($arg:tt)*) {
     if $crate::cfg!(debug_assertions) {
-        $crate::assert_matches::assert_matches!($($arg)*);
+        $crate::assert_matches!($($arg)*);
     }
 }
 

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -443,8 +443,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # // FIXME(f16_f128): LLVM crashes on s390x, llvm/llvm-project#50374
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let f = 7.0_f16;
     /// let g = -7.0_f16;
@@ -472,8 +471,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # // FIXME(f16_f128): LLVM crashes on s390x, llvm/llvm-project#50374
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let f = 7.0_f16;
     /// let g = -7.0_f16;
@@ -507,8 +505,7 @@ impl f16 {
     ///
     /// ```rust
     /// #![feature(f16)]
-    /// # // FIXME(f16_f128): ABI issues on MSVC
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// // f16::EPSILON is the difference between 1.0 and the next number up.
     /// assert_eq!(1.0f16.next_up(), 1.0 + f16::EPSILON);
@@ -562,8 +559,7 @@ impl f16 {
     ///
     /// ```rust
     /// #![feature(f16)]
-    /// # // FIXME(f16_f128): ABI issues on MSVC
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let x = 1.0f16;
     /// // Clamp value into range [0, 1).
@@ -606,8 +602,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # // FIXME(f16_f128): extendhfsf2, truncsfhf2, __gnu_h2f_ieee, __gnu_f2h_ieee missing for many platforms
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let x = 2.0_f16;
     /// let abs_difference = (x.recip() - (1.0 / x)).abs();
@@ -633,8 +628,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # // FIXME(f16_f128): extendhfsf2, truncsfhf2, __gnu_h2f_ieee, __gnu_f2h_ieee missing for many platforms
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let angle = std::f16::consts::PI;
     ///
@@ -663,8 +657,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # // FIXME(f16_f128): extendhfsf2, truncsfhf2, __gnu_h2f_ieee, __gnu_f2h_ieee missing for many platforms
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let angle = 180.0f16;
     ///
@@ -697,7 +690,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(target_arch = "aarch64")] { // FIXME(f16_F128): rust-lang/rust#123885
+    /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let x = 1.0f16;
     /// let y = 2.0f16;
@@ -728,7 +721,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(target_arch = "aarch64")] { // FIXME(f16_F128): rust-lang/rust#123885
+    /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let x = 1.0f16;
     /// let y = 2.0f16;
@@ -760,7 +753,7 @@ impl f16 {
     /// ```
     /// #![feature(f16)]
     /// #![feature(float_minimum_maximum)]
-    /// # #[cfg(target_arch = "aarch64")] { // FIXME(f16_F128): rust-lang/rust#123885
+    /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let x = 1.0f16;
     /// let y = 2.0f16;
@@ -792,7 +785,7 @@ impl f16 {
     /// ```
     /// #![feature(f16)]
     /// #![feature(float_minimum_maximum)]
-    /// # #[cfg(target_arch = "aarch64")] { // FIXME(f16_F128): rust-lang/rust#123885
+    /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let x = 1.0f16;
     /// let y = 2.0f16;
@@ -818,7 +811,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(target_arch = "aarch64")] { // FIXME(f16_F128): rust-lang/rust#123885
+    /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// assert_eq!(1f16.midpoint(4.0), 2.5);
     /// assert_eq!((-5.5f16).midpoint(8.0), 1.25);
@@ -965,8 +958,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # // FIXME(f16_f128): LLVM crashes on s390x, llvm/llvm-project#50374
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let bytes = 12.5f16.to_be_bytes();
     /// assert_eq!(bytes, [0x4a, 0x40]);
@@ -989,8 +981,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # // FIXME(f16_f128): LLVM crashes on s390x, llvm/llvm-project#50374
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let bytes = 12.5f16.to_le_bytes();
     /// assert_eq!(bytes, [0x40, 0x4a]);
@@ -1019,8 +1010,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # // FIXME(f16_f128): LLVM crashes on s390x, llvm/llvm-project#50374
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let bytes = 12.5f16.to_ne_bytes();
     /// assert_eq!(
@@ -1150,8 +1140,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # // FIXME(f16_f128): extendhfsf2, truncsfhf2, __gnu_h2f_ieee, __gnu_f2h_ieee missing for many platforms
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// struct GoodBoy {
     ///     name: &'static str,

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -1298,7 +1298,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let x = 3.5_f16;
     /// let y = -3.5_f16;
@@ -1314,8 +1314,7 @@ impl f16 {
     #[rustc_const_unstable(feature = "f16", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub const fn abs(self) -> Self {
-        // FIXME(f16_f128): replace with `intrinsics::fabsf16` when available
-        Self::from_bits(self.to_bits() & !(1 << 15))
+        intrinsics::fabsf16(self)
     }
 
     /// Returns a number that represents the sign of `self`.

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -132,6 +132,7 @@ pub mod consts {
     pub const LN_10: f16 = 2.30258509299404568401799145468436421_f16;
 }
 
+#[doc(test(attr(feature(cfg_target_has_reliable_f16_f128), allow(internal_features))))]
 impl f16 {
     // FIXME(f16_f128): almost all methods in this `impl` are missing examples and a const
     // implementation. Add these once we can run code on all platforms and have f16/f128 in CTFE.
@@ -272,7 +273,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let nan = f16::NAN;
     /// let f = 7.0_f16;
@@ -294,7 +295,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let f = 7.0f16;
     /// let inf = f16::INFINITY;
@@ -319,7 +320,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let f = 7.0f16;
     /// let inf: f16 = f16::INFINITY;
@@ -347,7 +348,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let min = f16::MIN_POSITIVE; // 6.1035e-5
     /// let max = f16::MAX;
@@ -376,7 +377,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let min = f16::MIN_POSITIVE; // 6.1035e-5
     /// let max = f16::MAX;
@@ -407,7 +408,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// use std::num::FpCategory;
     ///
@@ -443,7 +444,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let f = 7.0_f16;
     /// let g = -7.0_f16;
@@ -471,7 +472,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let f = 7.0_f16;
     /// let g = -7.0_f16;
@@ -505,7 +506,7 @@ impl f16 {
     ///
     /// ```rust
     /// #![feature(f16)]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// // f16::EPSILON is the difference between 1.0 and the next number up.
     /// assert_eq!(1.0f16.next_up(), 1.0 + f16::EPSILON);
@@ -559,7 +560,7 @@ impl f16 {
     ///
     /// ```rust
     /// #![feature(f16)]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let x = 1.0f16;
     /// // Clamp value into range [0, 1).
@@ -602,7 +603,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let x = 2.0_f16;
     /// let abs_difference = (x.recip() - (1.0 / x)).abs();
@@ -628,7 +629,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let angle = std::f16::consts::PI;
     ///
@@ -657,7 +658,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let angle = 180.0f16;
     ///
@@ -690,7 +691,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let x = 1.0f16;
     /// let y = 2.0f16;
@@ -721,7 +722,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let x = 1.0f16;
     /// let y = 2.0f16;
@@ -753,7 +754,7 @@ impl f16 {
     /// ```
     /// #![feature(f16)]
     /// #![feature(float_minimum_maximum)]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let x = 1.0f16;
     /// let y = 2.0f16;
@@ -785,7 +786,7 @@ impl f16 {
     /// ```
     /// #![feature(f16)]
     /// #![feature(float_minimum_maximum)]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let x = 1.0f16;
     /// let y = 2.0f16;
@@ -811,7 +812,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// assert_eq!(1f16.midpoint(4.0), 2.5);
     /// assert_eq!((-5.5f16).midpoint(8.0), 1.25);
@@ -841,7 +842,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let value = 4.6_f16;
     /// let rounded = unsafe { value.to_int_unchecked::<u16>() };
@@ -884,7 +885,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// # // FIXME(f16_f128): enable this once const casting works
     /// # // assert_ne!((1f16).to_bits(), 1f16 as u128); // to_bits() is not casting!
@@ -932,7 +933,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let v = f16::from_bits(0x4a40);
     /// assert_eq!(v, 12.5);
@@ -958,7 +959,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let bytes = 12.5f16.to_be_bytes();
     /// assert_eq!(bytes, [0x4a, 0x40]);
@@ -981,7 +982,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let bytes = 12.5f16.to_le_bytes();
     /// assert_eq!(bytes, [0x40, 0x4a]);
@@ -1010,7 +1011,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let bytes = 12.5f16.to_ne_bytes();
     /// assert_eq!(
@@ -1039,7 +1040,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let value = f16::from_be_bytes([0x4a, 0x40]);
     /// assert_eq!(value, 12.5);
@@ -1061,7 +1062,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let value = f16::from_le_bytes([0x40, 0x4a]);
     /// assert_eq!(value, 12.5);
@@ -1090,7 +1091,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let value = f16::from_ne_bytes(if cfg!(target_endian = "big") {
     ///     [0x4a, 0x40]
@@ -1140,7 +1141,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// struct GoodBoy {
     ///     name: &'static str,
@@ -1223,7 +1224,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// assert!((-3.0f16).clamp(-2.0, 1.0) == -2.0);
     /// assert!((0.0f16).clamp(-2.0, 1.0) == 0.0);
@@ -1274,7 +1275,7 @@ impl f16 {
     /// ```
     /// #![feature(f16)]
     /// #![feature(clamp_magnitude)]
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16)] {
     /// assert_eq!(5.0f16.clamp_magnitude(3.0), 3.0);
     /// assert_eq!((-5.0f16).clamp_magnitude(3.0), -3.0);
     /// assert_eq!(2.0f16.clamp_magnitude(3.0), 2.0);
@@ -1327,7 +1328,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let f = 3.5_f16;
     ///
@@ -1363,7 +1364,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(all(target_arch = "x86_64", target_os = "linux"))] {
+    /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let f = 3.5_f16;
     ///
@@ -1453,7 +1454,7 @@ impl f16 {
     /// ```
     /// #![feature(f16)]
     /// # #[cfg(not(miri))]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let f = 3.7_f16;
     /// let g = 3.0_f16;
@@ -1482,7 +1483,7 @@ impl f16 {
     /// ```
     /// #![feature(f16)]
     /// # #[cfg(not(miri))]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let f = 3.01_f16;
     /// let g = 4.0_f16;
@@ -1511,7 +1512,7 @@ impl f16 {
     /// ```
     /// #![feature(f16)]
     /// # #[cfg(not(miri))]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let f = 3.3_f16;
     /// let g = -3.3_f16;
@@ -1545,7 +1546,7 @@ impl f16 {
     /// ```
     /// #![feature(f16)]
     /// # #[cfg(not(miri))]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let f = 3.3_f16;
     /// let g = -3.3_f16;
@@ -1577,7 +1578,7 @@ impl f16 {
     /// ```
     /// #![feature(f16)]
     /// # #[cfg(not(miri))]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let f = 3.7_f16;
     /// let g = 3.0_f16;
@@ -1607,7 +1608,7 @@ impl f16 {
     /// ```
     /// #![feature(f16)]
     /// # #[cfg(not(miri))]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let x = 3.6_f16;
     /// let y = -3.6_f16;
@@ -1646,7 +1647,7 @@ impl f16 {
     /// ```
     /// #![feature(f16)]
     /// # #[cfg(not(miri))]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let m = 10.0_f16;
     /// let x = 4.0_f16;
@@ -1691,7 +1692,7 @@ impl f16 {
     /// ```
     /// #![feature(f16)]
     /// # #[cfg(not(miri))]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let a: f16 = 7.0;
     /// let b = 4.0;
@@ -1735,7 +1736,7 @@ impl f16 {
     /// ```
     /// #![feature(f16)]
     /// # #[cfg(not(miri))]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let a: f16 = 7.0;
     /// let b = 4.0;
@@ -1778,7 +1779,7 @@ impl f16 {
     /// ```
     /// #![feature(f16)]
     /// # #[cfg(not(miri))]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let x = 2.0_f16;
     /// let abs_difference = (x.powi(2) - (x * x)).abs();
@@ -1811,7 +1812,7 @@ impl f16 {
     /// ```
     /// #![feature(f16)]
     /// # #[cfg(not(miri))]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let positive = 4.0_f16;
     /// let negative = -4.0_f16;
@@ -1846,7 +1847,7 @@ impl f16 {
     /// ```
     /// #![feature(f16)]
     /// # #[cfg(not(miri))]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let x = 8.0f16;
     ///

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -2103,10 +2103,7 @@ impl<T> Option<&T> {
     where
         T: Clone,
     {
-        match self {
-            Some(t) => Some(t.clone()),
-            None => None,
-        }
+        self.map(T::clone)
     }
 }
 
@@ -2154,10 +2151,7 @@ impl<T> Option<&mut T> {
     where
         T: Clone,
     {
-        match self {
-            Some(t) => Some(t.clone()),
-            None => None,
-        }
+        self.as_deref().map(T::clone)
     }
 }
 

--- a/library/std/src/collections/hash/map/tests.rs
+++ b/library/std/src/collections/hash/map/tests.rs
@@ -3,7 +3,7 @@ use realstd::collections::TryReserveErrorKind::*;
 
 use super::Entry::{Occupied, Vacant};
 use super::HashMap;
-use crate::assert_matches::assert_matches;
+use crate::assert_matches;
 use crate::cell::RefCell;
 use crate::hash::{BuildHasher, BuildHasherDefault, DefaultHasher, RandomState};
 use crate::test_helpers::test_rng;

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -2,7 +2,6 @@ use rand::RngCore;
 
 #[cfg(not(miri))]
 use super::Dir;
-use crate::assert_matches::assert_matches;
 use crate::fs::{self, File, FileTimes, OpenOptions, TryLockError};
 #[cfg(not(miri))]
 use crate::io;
@@ -21,7 +20,7 @@ use crate::path::Path;
 use crate::sync::Arc;
 use crate::test_helpers::{TempDir, tmpdir};
 use crate::time::{Duration, Instant, SystemTime};
-use crate::{env, str, thread};
+use crate::{assert_matches, env, str, thread};
 
 macro_rules! check {
     ($e:expr) => {

--- a/library/std/src/io/error/tests.rs
+++ b/library/std/src/io/error/tests.rs
@@ -1,7 +1,6 @@
 use super::{Custom, Error, ErrorData, ErrorKind, Repr, SimpleMessage, const_error};
-use crate::assert_matches::assert_matches;
 use crate::sys::io::{decode_error_kind, error_string};
-use crate::{error, fmt};
+use crate::{assert_matches, error, fmt};
 
 #[test]
 fn test_size() {

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -711,9 +711,9 @@ pub use core::todo;
 // Re-export built-in macros defined through core.
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 pub use core::{
-    assert, assert_matches, cfg, column, compile_error, concat, const_format_args, env, file,
-    format_args, format_args_nl, include, include_bytes, include_str, line, log_syntax,
-    module_path, option_env, stringify, trace_macros,
+    assert, cfg, column, compile_error, concat, const_format_args, env, file, format_args,
+    format_args_nl, include, include_bytes, include_str, line, log_syntax, module_path, option_env,
+    stringify, trace_macros,
 };
 // Re-export macros defined in core.
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -722,6 +722,8 @@ pub use core::{
     assert_eq, assert_ne, debug_assert, debug_assert_eq, debug_assert_ne, r#try, unimplemented,
     unreachable, write, writeln,
 };
+#[unstable(feature = "assert_matches", issue = "82775")]
+pub use core::{assert_matches, debug_assert_matches};
 
 // Re-export unstable derive macro defined through core.
 #[unstable(feature = "derive_from", issue = "144889")]

--- a/library/std/src/sys/pal/unix/linux/pidfd/tests.rs
+++ b/library/std/src/sys/pal/unix/linux/pidfd/tests.rs
@@ -1,5 +1,5 @@
 use super::PidFd as InternalPidFd;
-use crate::assert_matches::assert_matches;
+use crate::assert_matches;
 use crate::os::fd::AsRawFd;
 use crate::os::linux::process::{ChildExt, CommandExt as _};
 use crate::os::unix::process::{CommandExt as _, ExitStatusExt};

--- a/library/std/src/sys/process/unix/unix.rs
+++ b/library/std/src/sys/process/unix/unix.rs
@@ -524,7 +524,7 @@ impl Command {
                             return Ok(None);
                         }
                     }
-                    core::assert_matches::debug_assert_matches!(support, SPAWN | NO);
+                    core::debug_assert_matches!(support, SPAWN | NO);
                 }
             }
             _ => {

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -1,4 +1,7 @@
-use std::assert_matches::debug_assert_matches;
+#[cfg(bootstrap)]
+pub use std::assert_matches::debug_assert_matches;
+#[cfg(not(bootstrap))]
+pub use std::debug_assert_matches;
 use std::fmt::{self, Display, Write as _};
 use std::sync::LazyLock as Lazy;
 use std::{ascii, mem};

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -1390,10 +1390,6 @@ impl clean::FnDecl {
 
 pub(crate) fn visibility_print_with_space(item: &clean::Item, cx: &Context<'_>) -> impl Display {
     fmt::from_fn(move |f| {
-        if item.is_doc_hidden() {
-            f.write_str("#[doc(hidden)] ")?;
-        }
-
         let Some(vis) = item.visibility(cx.tcx()) else {
             return Ok(());
         };

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1075,6 +1075,7 @@ fn assoc_type(
     cx: &Context<'_>,
 ) -> impl fmt::Display {
     fmt::from_fn(move |w| {
+        render_attributes_in_code(w, it, &" ".repeat(indent), cx)?;
         write!(
             w,
             "{indent}{vis}type <a{href} class=\"associatedtype\">{name}</a>{generics}",
@@ -2931,6 +2932,21 @@ fn render_attributes_in_code(
     prefix: &str,
     cx: &Context<'_>,
 ) -> fmt::Result {
+    render_attributes_in_code_with_options(w, item, prefix, cx, true, "")
+}
+
+pub(super) fn render_attributes_in_code_with_options(
+    w: &mut impl fmt::Write,
+    item: &clean::Item,
+    prefix: &str,
+    cx: &Context<'_>,
+    render_doc_hidden: bool,
+    open_tag: &str,
+) -> fmt::Result {
+    w.write_str(open_tag)?;
+    if render_doc_hidden && item.is_doc_hidden() {
+        render_code_attribute(prefix, "#[doc(hidden)]", w)?;
+    }
     for attr in &item.attrs.other_attrs {
         let hir::Attribute::Parsed(kind) = attr else { continue };
         let attr = match kind {

--- a/src/tools/clippy/clippy_utils/src/ty/mod.rs
+++ b/src/tools/clippy/clippy_utils/src/ty/mod.rs
@@ -29,7 +29,10 @@ use rustc_span::{DUMMY_SP, Span, Symbol, sym};
 use rustc_trait_selection::traits::query::evaluate_obligation::InferCtxtExt as _;
 use rustc_trait_selection::traits::query::normalize::QueryNormalizeExt;
 use rustc_trait_selection::traits::{Obligation, ObligationCause};
+#[cfg(bootstrap)]
 use std::assert_matches::debug_assert_matches;
+#[cfg(not(bootstrap))]
+use std::debug_assert_matches;
 use std::collections::hash_map::Entry;
 use std::{iter, mem};
 

--- a/src/tools/miri/tests/pass/intrinsics/select-unpredictable-drop.rs
+++ b/src/tools/miri/tests/pass/intrinsics/select-unpredictable-drop.rs
@@ -1,0 +1,19 @@
+//! Check that `select_unpredictable` properly forgets the value it does not select.
+#![feature(core_intrinsics)]
+use std::cell::Cell;
+use std::intrinsics::select_unpredictable;
+
+fn main() {
+    let (true_val, false_val) = (Cell::new(false), Cell::new(false));
+    _ = select_unpredictable(true, TraceDrop(&true_val), TraceDrop(&false_val));
+    assert!(true_val.get());
+    assert!(!false_val.get());
+}
+
+struct TraceDrop<'a>(&'a Cell<bool>);
+
+impl<'a> Drop for TraceDrop<'a> {
+    fn drop(&mut self) {
+        self.0.set(true);
+    }
+}

--- a/tests/codegen-llvm/addr-of-mutate.rs
+++ b/tests/codegen-llvm/addr-of-mutate.rs
@@ -5,7 +5,7 @@
 // Test for the absence of `readonly` on the argument when it is mutated via `&raw const`.
 // See <https://github.com/rust-lang/rust/issues/111502>.
 
-// CHECK: i8 @foo(ptr{{( dead_on_return)?}} noalias noundef align 1{{( captures\(address\))?}} dereferenceable(128) %x)
+// CHECK: i8 @foo(ptr{{( dead_on_return)?}} noalias noundef align 1{{( captures\(address\))?}}{{( dead_on_return)?}} dereferenceable(128) %x)
 #[no_mangle]
 pub fn foo(x: [u8; 128]) -> u8 {
     let ptr = core::ptr::addr_of!(x).cast_mut();
@@ -15,7 +15,7 @@ pub fn foo(x: [u8; 128]) -> u8 {
     x[0]
 }
 
-// CHECK: i1 @second(ptr{{( dead_on_return)?}} noalias noundef align {{[0-9]+}}{{( captures\(address\))?}} dereferenceable({{[0-9]+}}) %a_ptr_and_b)
+// CHECK: i1 @second(ptr{{( dead_on_return)?}} noalias noundef align {{[0-9]+}}{{( captures\(address\))?}}{{( dead_on_return)?}} dereferenceable({{[0-9]+}}) %a_ptr_and_b)
 #[no_mangle]
 pub unsafe fn second(a_ptr_and_b: (*mut (i32, bool), (i64, bool))) -> bool {
     let b_bool_ptr = core::ptr::addr_of!(a_ptr_and_b.1.1).cast_mut();
@@ -24,7 +24,7 @@ pub unsafe fn second(a_ptr_and_b: (*mut (i32, bool), (i64, bool))) -> bool {
 }
 
 // If going through a deref (and there are no other mutating accesses), then `readonly` is fine.
-// CHECK: i1 @third(ptr{{( dead_on_return)?}} noalias noundef readonly align {{[0-9]+}}{{( captures\(none\))?}} dereferenceable({{[0-9]+}}) %a_ptr_and_b)
+// CHECK: i1 @third(ptr{{( dead_on_return)?}} noalias noundef readonly align {{[0-9]+}}{{( captures\(none\))?}}{{( dead_on_return)?}} dereferenceable({{[0-9]+}}) %a_ptr_and_b)
 #[no_mangle]
 pub unsafe fn third(a_ptr_and_b: (*mut (i32, bool), (i64, bool))) -> bool {
     let b_bool_ptr = core::ptr::addr_of!((*a_ptr_and_b.0).1).cast_mut();

--- a/tests/codegen-llvm/function-arguments.rs
+++ b/tests/codegen-llvm/function-arguments.rs
@@ -134,7 +134,7 @@ pub fn mutable_notunpin_borrow(_: &mut NotUnpin) {}
 #[no_mangle]
 pub fn notunpin_borrow(_: &NotUnpin) {}
 
-// CHECK: @indirect_struct(ptr{{( dead_on_return)?}} noalias noundef readonly align 4{{( captures\(none\))?}} dereferenceable(32) %_1)
+// CHECK: @indirect_struct(ptr{{( dead_on_return)?}} noalias noundef readonly align 4{{( captures\(none\))?}}{{( dead_on_return)?}} dereferenceable(32) %_1)
 #[no_mangle]
 pub fn indirect_struct(_: S) {}
 

--- a/tests/codegen-llvm/loongarch-abi/loongarch64-lp64d-abi.rs
+++ b/tests/codegen-llvm/loongarch-abi/loongarch64-lp64d-abi.rs
@@ -256,7 +256,7 @@ pub struct IntDoubleInt {
     c: i32,
 }
 
-// CHECK: define void @f_int_double_int_s_arg(ptr{{( dead_on_return)?}} noalias noundef align 8{{( captures\(address\))?}} dereferenceable(24) %a)
+// CHECK: define void @f_int_double_int_s_arg(ptr{{( dead_on_return)?}} noalias noundef align 8{{( captures\(address\))?}}{{( dead_on_return)?}} dereferenceable(24) %a)
 #[no_mangle]
 pub extern "C" fn f_int_double_int_s_arg(a: IntDoubleInt) {}
 

--- a/tests/rustdoc-html/display-hidden-items.rs
+++ b/tests/rustdoc-html/display-hidden-items.rs
@@ -5,25 +5,32 @@
 #![crate_name = "foo"]
 
 //@ has 'foo/index.html'
-//@ has - '//dt/span[@title="Hidden item"]' '👻'
 
-//@ has - '//*[@id="reexport.hidden_reexport"]/code' '#[doc(hidden)] pub use hidden::inside_hidden as hidden_reexport;'
+//@ matches - '//dt[code]' 'pub extern crate .*hidden_core;.*👻'
+//@ has - '//dt/code' 'pub extern crate core as hidden_core;'
+#[doc(hidden)]
+pub extern crate core as hidden_core;
+
+//@ has - '//*[@id="reexport.hidden_reexport"]/span[@title="Hidden item"]' '👻'
+//@ has - '//*[@id="reexport.hidden_reexport"]/code' 'pub use hidden::inside_hidden as hidden_reexport;'
 #[doc(hidden)]
 pub use hidden::inside_hidden as hidden_reexport;
 
 //@ has - '//dt/a[@class="trait"]' 'TraitHidden'
 //@ has 'foo/trait.TraitHidden.html'
-//@ has - '//code' '#[doc(hidden)] pub trait TraitHidden'
+//@ has 'foo/trait.TraitHidden.html' '//*[@class="rust item-decl"]//*[@class="code-attribute"]' '#[doc(hidden)]'
+//@ has 'foo/trait.TraitHidden.html' '//*[@class="rust item-decl"]/code' 'pub trait TraitHidden'
 #[doc(hidden)]
 pub trait TraitHidden {}
 
 //@ has 'foo/index.html' '//dt/a[@class="trait"]' 'Trait'
 pub trait Trait {
     //@ has 'foo/trait.Trait.html'
-    //@ has - '//*[@id="associatedconstant.BAR"]/*[@class="code-header"]' '#[doc(hidden)] const BAR: u32 = 0'
+    //@ has - '//*[@id="associatedconstant.BAR"]/*[@class="code-header"]/*[@class="code-attribute"]' '#[doc(hidden)]'
     #[doc(hidden)]
     const BAR: u32 = 0;
 
+    //@ has - '//*[@id="method.foo"]/*[@class="code-header"]/*[@class="code-attribute"]' '#[doc(hidden)]'
     //@ has - '//*[@id="method.foo"]/*[@class="code-header"]' 'fn foo()'
     #[doc(hidden)]
     fn foo() {}
@@ -44,15 +51,16 @@ impl Struct {
 }
 
 impl Trait for Struct {
-    //@ has - '//*[@id="associatedconstant.BAR"]/*[@class="code-header"]' '#[doc(hidden)] const BAR: u32 = 0'
-    //@ has - '//*[@id="method.foo"]/*[@class="code-header"]' '#[doc(hidden)] fn foo()'
+    //@ has - '//*[@id="associatedconstant.BAR"]/*[@class="code-header"]/*[@class="code-attribute"]' '#[doc(hidden)]'
+    //@ has - '//*[@id="method.foo"]/*[@class="code-header"]/*[@class="code-attribute"]' '#[doc(hidden)]'
 }
 //@ has - '//*[@id="impl-TraitHidden-for-Struct"]/*[@class="code-header"]' 'impl TraitHidden for Struct'
 impl TraitHidden for Struct {}
 
 //@ has 'foo/index.html' '//dt/a[@class="enum"]' 'HiddenEnum'
 //@ has 'foo/enum.HiddenEnum.html'
-//@ has - '//code' '#[doc(hidden)] pub enum HiddenEnum'
+//@ has 'foo/enum.HiddenEnum.html' '//*[@class="rust item-decl"]//*[@class="code-attribute"]' '#[doc(hidden)]'
+//@ has 'foo/enum.HiddenEnum.html' '//*[@class="rust item-decl"]/code' 'pub enum HiddenEnum'
 #[doc(hidden)]
 pub enum HiddenEnum {
     A,
@@ -60,6 +68,7 @@ pub enum HiddenEnum {
 
 //@ has 'foo/index.html' '//dt/a[@class="enum"]' 'Enum'
 pub enum Enum {
+    //@ has 'foo/enum.Enum.html' '//*[@id="variant.A"]/*[@class="code-header"]/*[@class="code-attribute"]' '#[doc(hidden)]'
     //@ has 'foo/enum.Enum.html' '//*[@id="variant.A"]/*[@class="code-header"]' 'A'
     #[doc(hidden)]
     A,

--- a/tests/ui-fulldeps/rustc_public/check_abi.rs
+++ b/tests/ui-fulldeps/rustc_public/check_abi.rs
@@ -25,7 +25,7 @@ use rustc_public::mir::mono::Instance;
 use rustc_public::target::MachineInfo;
 use rustc_public::ty::{AdtDef, RigidTy, Ty, TyKind};
 use rustc_public::{CrateDef, CrateItem, CrateItems, ItemKind};
-use std::assert_matches::assert_matches;
+use std::assert_matches;
 use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::io::Write;

--- a/tests/ui-fulldeps/rustc_public/check_allocation.rs
+++ b/tests/ui-fulldeps/rustc_public/check_allocation.rs
@@ -20,7 +20,7 @@ extern crate rustc_interface;
 extern crate rustc_public;
 
 use std::ascii::Char;
-use std::assert_matches::assert_matches;
+use std::assert_matches;
 use std::cmp::{max, min};
 use std::collections::HashMap;
 use std::ffi::CStr;

--- a/tests/ui-fulldeps/rustc_public/check_defs.rs
+++ b/tests/ui-fulldeps/rustc_public/check_defs.rs
@@ -19,7 +19,7 @@ use mir::{TerminatorKind::*, mono::Instance};
 use rustc_public::mir::mono::InstanceKind;
 use rustc_public::ty::{RigidTy, Ty, TyKind, UintTy};
 use rustc_public::*;
-use std::assert_matches::assert_matches;
+use std::assert_matches;
 use std::io::Write;
 use std::ops::ControlFlow;
 

--- a/tests/ui-fulldeps/rustc_public/check_foreign.rs
+++ b/tests/ui-fulldeps/rustc_public/check_foreign.rs
@@ -20,7 +20,7 @@ use rustc_public::{
     ty::{Abi, ForeignItemKind},
     *,
 };
-use std::assert_matches::assert_matches;
+use std::assert_matches;
 use std::io::Write;
 use std::ops::ControlFlow;
 

--- a/tests/ui-fulldeps/rustc_public/check_intrinsics.rs
+++ b/tests/ui-fulldeps/rustc_public/check_intrinsics.rs
@@ -24,7 +24,7 @@ use rustc_public::mir::mono::{Instance, InstanceKind};
 use rustc_public::mir::visit::{Location, MirVisitor};
 use rustc_public::mir::{LocalDecl, Terminator, TerminatorKind};
 use rustc_public::ty::{FnDef, GenericArgs, RigidTy, TyKind};
-use std::assert_matches::assert_matches;
+use std::assert_matches;
 use std::convert::TryFrom;
 use std::io::Write;
 use std::ops::ControlFlow;

--- a/tests/ui-fulldeps/rustc_public/crate-info.rs
+++ b/tests/ui-fulldeps/rustc_public/crate-info.rs
@@ -22,7 +22,7 @@ use rustc_public::ItemKind;
 use rustc_public::crate_def::CrateDef;
 use rustc_public::mir::mono::Instance;
 use rustc_public::ty::{RigidTy, TyKind};
-use std::assert_matches::assert_matches;
+use std::assert_matches;
 use std::io::Write;
 use std::ops::ControlFlow;
 

--- a/tests/ui-fulldeps/rustc_public/projections.rs
+++ b/tests/ui-fulldeps/rustc_public/projections.rs
@@ -21,7 +21,7 @@ use rustc_public::ItemKind;
 use rustc_public::crate_def::CrateDef;
 use rustc_public::mir::{ProjectionElem, Rvalue, StatementKind};
 use rustc_public::ty::{RigidTy, TyKind, UintTy};
-use std::assert_matches::assert_matches;
+use std::assert_matches;
 use std::io::Write;
 use std::ops::ControlFlow;
 

--- a/tests/ui/const-generics/mgca/type_const-incemental-compile.rs
+++ b/tests/ui/const-generics/mgca/type_const-incemental-compile.rs
@@ -1,0 +1,11 @@
+//@ check-pass
+//@compile-flags: -Clink-dead-code=true
+// link-dead-code tries to eagerly monomorphize and collect items
+// This lead to collector.rs to try and evaluate a type_const
+// which will fail since they do not have bodies.
+#![expect(incomplete_features)]
+#![feature(min_generic_const_args)]
+
+#[type_const]
+const TYPE_CONST: usize = 0;
+fn main() {}

--- a/tests/ui/const-generics/mgca/type_const-pub.rs
+++ b/tests/ui/const-generics/mgca/type_const-pub.rs
@@ -7,4 +7,6 @@
 
 #[type_const]
 pub const TYPE_CONST : usize = 1;
-fn main() {}
+fn main() {
+    print!("{}", TYPE_CONST)
+}

--- a/tests/ui/const-generics/mgca/wrong_type_const_arr_diag.rs
+++ b/tests/ui/const-generics/mgca/wrong_type_const_arr_diag.rs
@@ -1,0 +1,13 @@
+// This test causes ERROR: mismatched types [E0308]
+// and makes rustc to print array from const arguments
+#![feature(min_generic_const_args, adt_const_params)]
+#![allow(incomplete_features)]
+
+struct TakesArr<const N: [u8; 1]>;
+
+fn foo<const N: u8>() {
+    let _: TakesArr<{ [N] }> = TakesArr::<{ [1] }>;
+    //~^ ERROR: mismatched types [E0308]
+}
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/wrong_type_const_arr_diag.stderr
+++ b/tests/ui/const-generics/mgca/wrong_type_const_arr_diag.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/wrong_type_const_arr_diag.rs:9:32
+   |
+LL |     let _: TakesArr<{ [N] }> = TakesArr::<{ [1] }>;
+   |            -----------------   ^^^^^^^^^^^^^^^^^^^ expected `[N]`, found `*b"\x01"`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `TakesArr<[N]>`
+              found struct `TakesArr<*b"\x01">`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/mgca/wrong_type_const_arr_diag_trait.rs
+++ b/tests/ui/const-generics/mgca/wrong_type_const_arr_diag_trait.rs
@@ -1,0 +1,21 @@
+// This test causes ERROR: mismatched types [E0308]
+// and makes rustc to print array from const arguments
+#![feature(min_generic_const_args, adt_const_params, trivial_bounds)]
+#![allow(incomplete_features)]
+
+trait Trait {
+    #[type_const]
+    const ASSOC: u8;
+}
+
+struct TakesArr<const N: [u8; 1]>;
+
+fn foo<const N: u8>()
+where
+    u8: Trait
+{
+    let _: TakesArr<{ [<u8 as Trait>::ASSOC] }> = TakesArr::<{ [1] }>;
+    //~^ ERROR: mismatched types [E0308]
+}
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/wrong_type_const_arr_diag_trait.stderr
+++ b/tests/ui/const-generics/mgca/wrong_type_const_arr_diag_trait.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/wrong_type_const_arr_diag_trait.rs:17:51
+   |
+LL |     let _: TakesArr<{ [<u8 as Trait>::ASSOC] }> = TakesArr::<{ [1] }>;
+   |            ------------------------------------   ^^^^^^^^^^^^^^^^^^^ expected `[<u8 as Trait>::ASSOC]`, found `*b"\x01"`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `TakesArr<[<u8 as Trait>::ASSOC]>`
+              found struct `TakesArr<*b"\x01">`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/coroutine/uninhabited-field.rs
+++ b/tests/ui/coroutine/uninhabited-field.rs
@@ -5,7 +5,7 @@
 #![feature(coroutine_trait)]
 #![feature(coroutines, stmt_expr_attributes)]
 #![feature(never_type)]
-use std::assert_matches::assert_matches;
+use std::assert_matches;
 use std::ops::Coroutine;
 use std::ops::CoroutineState;
 use std::pin::Pin;

--- a/tests/ui/deriving/deriving-all-codegen.stdout
+++ b/tests/ui/deriving/deriving-all-codegen.stdout
@@ -51,7 +51,7 @@ impl ::core::default::Default for Empty {
 #[automatically_derived]
 impl ::core::hash::Hash for Empty {
     #[inline]
-    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {}
+    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) {}
 }
 #[automatically_derived]
 impl ::core::marker::StructuralPartialEq for Empty { }
@@ -65,7 +65,7 @@ impl ::core::cmp::Eq for Empty {
     #[inline]
     #[doc(hidden)]
     #[coverage(off)]
-    fn assert_receiver_is_total_eq(&self) -> () {}
+    fn assert_receiver_is_total_eq(&self) {}
 }
 #[automatically_derived]
 impl ::core::cmp::PartialOrd for Empty {
@@ -123,7 +123,7 @@ impl ::core::default::Default for Point {
 #[automatically_derived]
 impl ::core::hash::Hash for Point {
     #[inline]
-    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {
+    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) {
         ::core::hash::Hash::hash(&self.x, state);
         ::core::hash::Hash::hash(&self.y, state)
     }
@@ -142,7 +142,7 @@ impl ::core::cmp::Eq for Point {
     #[inline]
     #[doc(hidden)]
     #[coverage(off)]
-    fn assert_receiver_is_total_eq(&self) -> () {
+    fn assert_receiver_is_total_eq(&self) {
         let _: ::core::cmp::AssertParamIsEq<u32>;
     }
 }
@@ -211,7 +211,7 @@ impl ::core::default::Default for PackedPoint {
 #[automatically_derived]
 impl ::core::hash::Hash for PackedPoint {
     #[inline]
-    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {
+    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) {
         ::core::hash::Hash::hash(&{ self.x }, state);
         ::core::hash::Hash::hash(&{ self.y }, state)
     }
@@ -230,7 +230,7 @@ impl ::core::cmp::Eq for PackedPoint {
     #[inline]
     #[doc(hidden)]
     #[coverage(off)]
-    fn assert_receiver_is_total_eq(&self) -> () {
+    fn assert_receiver_is_total_eq(&self) {
         let _: ::core::cmp::AssertParamIsEq<u32>;
     }
 }
@@ -297,7 +297,7 @@ impl ::core::convert::From<u32> for TupleSingleField {
 #[automatically_derived]
 impl ::core::hash::Hash for TupleSingleField {
     #[inline]
-    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {
+    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) {
         ::core::hash::Hash::hash(&self.0, state)
     }
 }
@@ -313,7 +313,7 @@ impl ::core::cmp::Eq for TupleSingleField {
     #[inline]
     #[doc(hidden)]
     #[coverage(off)]
-    fn assert_receiver_is_total_eq(&self) -> () {
+    fn assert_receiver_is_total_eq(&self) {
         let _: ::core::cmp::AssertParamIsEq<u32>;
     }
 }
@@ -372,7 +372,7 @@ impl ::core::convert::From<bool> for SingleField {
 #[automatically_derived]
 impl ::core::hash::Hash for SingleField {
     #[inline]
-    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {
+    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) {
         ::core::hash::Hash::hash(&self.foo, state)
     }
 }
@@ -388,7 +388,7 @@ impl ::core::cmp::Eq for SingleField {
     #[inline]
     #[doc(hidden)]
     #[coverage(off)]
-    fn assert_receiver_is_total_eq(&self) -> () {
+    fn assert_receiver_is_total_eq(&self) {
         let _: ::core::cmp::AssertParamIsEq<bool>;
     }
 }
@@ -465,7 +465,7 @@ impl ::core::default::Default for Big {
 #[automatically_derived]
 impl ::core::hash::Hash for Big {
     #[inline]
-    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {
+    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) {
         ::core::hash::Hash::hash(&self.b1, state);
         ::core::hash::Hash::hash(&self.b2, state);
         ::core::hash::Hash::hash(&self.b3, state);
@@ -493,7 +493,7 @@ impl ::core::cmp::Eq for Big {
     #[inline]
     #[doc(hidden)]
     #[coverage(off)]
-    fn assert_receiver_is_total_eq(&self) -> () {
+    fn assert_receiver_is_total_eq(&self) {
         let _: ::core::cmp::AssertParamIsEq<u32>;
     }
 }
@@ -741,7 +741,7 @@ impl ::core::convert::From<[u32]> for Unsized {
 #[automatically_derived]
 impl ::core::hash::Hash for Unsized {
     #[inline]
-    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {
+    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) {
         ::core::hash::Hash::hash(&self.0, state)
     }
 }
@@ -757,7 +757,7 @@ impl ::core::cmp::Eq for Unsized {
     #[inline]
     #[doc(hidden)]
     #[coverage(off)]
-    fn assert_receiver_is_total_eq(&self) -> () {
+    fn assert_receiver_is_total_eq(&self) {
         let _: ::core::cmp::AssertParamIsEq<[u32]>;
     }
 }
@@ -829,7 +829,7 @@ impl<T: ::core::default::Default + Trait, U: ::core::default::Default>
 impl<T: ::core::hash::Hash + Trait, U: ::core::hash::Hash> ::core::hash::Hash
     for Generic<T, U> where T::A: ::core::hash::Hash {
     #[inline]
-    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {
+    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) {
         ::core::hash::Hash::hash(&self.t, state);
         ::core::hash::Hash::hash(&self.ta, state);
         ::core::hash::Hash::hash(&self.u, state)
@@ -852,7 +852,7 @@ impl<T: ::core::cmp::Eq + Trait, U: ::core::cmp::Eq> ::core::cmp::Eq for
     #[inline]
     #[doc(hidden)]
     #[coverage(off)]
-    fn assert_receiver_is_total_eq(&self) -> () {
+    fn assert_receiver_is_total_eq(&self) {
         let _: ::core::cmp::AssertParamIsEq<T>;
         let _: ::core::cmp::AssertParamIsEq<T::A>;
         let _: ::core::cmp::AssertParamIsEq<U>;
@@ -946,7 +946,7 @@ impl<T: ::core::hash::Hash + ::core::marker::Copy + Trait,
     PackedGeneric<T, U> where T::A: ::core::hash::Hash + ::core::marker::Copy
     {
     #[inline]
-    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {
+    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) {
         ::core::hash::Hash::hash(&{ self.0 }, state);
         ::core::hash::Hash::hash(&{ self.1 }, state);
         ::core::hash::Hash::hash(&{ self.2 }, state)
@@ -974,7 +974,7 @@ impl<T: ::core::cmp::Eq + ::core::marker::Copy + Trait, U: ::core::cmp::Eq +
     #[inline]
     #[doc(hidden)]
     #[coverage(off)]
-    fn assert_receiver_is_total_eq(&self) -> () {
+    fn assert_receiver_is_total_eq(&self) {
         let _: ::core::cmp::AssertParamIsEq<T>;
         let _: ::core::cmp::AssertParamIsEq<T::A>;
         let _: ::core::cmp::AssertParamIsEq<U>;
@@ -1043,7 +1043,7 @@ impl ::core::fmt::Debug for Enum0 {
 #[automatically_derived]
 impl ::core::hash::Hash for Enum0 {
     #[inline]
-    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {
+    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) {
         match *self {}
     }
 }
@@ -1059,7 +1059,7 @@ impl ::core::cmp::Eq for Enum0 {
     #[inline]
     #[doc(hidden)]
     #[coverage(off)]
-    fn assert_receiver_is_total_eq(&self) -> () {}
+    fn assert_receiver_is_total_eq(&self) {}
 }
 #[automatically_derived]
 impl ::core::cmp::PartialOrd for Enum0 {
@@ -1105,7 +1105,7 @@ impl ::core::fmt::Debug for Enum1 {
 #[automatically_derived]
 impl ::core::hash::Hash for Enum1 {
     #[inline]
-    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {
+    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) {
         match self {
             Enum1::Single { x: __self_0 } =>
                 ::core::hash::Hash::hash(__self_0, state),
@@ -1129,7 +1129,7 @@ impl ::core::cmp::Eq for Enum1 {
     #[inline]
     #[doc(hidden)]
     #[coverage(off)]
-    fn assert_receiver_is_total_eq(&self) -> () {
+    fn assert_receiver_is_total_eq(&self) {
         let _: ::core::cmp::AssertParamIsEq<u32>;
     }
 }
@@ -1181,7 +1181,7 @@ impl ::core::default::Default for Fieldless1 {
 #[automatically_derived]
 impl ::core::hash::Hash for Fieldless1 {
     #[inline]
-    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {}
+    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) {}
 }
 #[automatically_derived]
 impl ::core::marker::StructuralPartialEq for Fieldless1 { }
@@ -1195,7 +1195,7 @@ impl ::core::cmp::Eq for Fieldless1 {
     #[inline]
     #[doc(hidden)]
     #[coverage(off)]
-    fn assert_receiver_is_total_eq(&self) -> () {}
+    fn assert_receiver_is_total_eq(&self) {}
 }
 #[automatically_derived]
 impl ::core::cmp::PartialOrd for Fieldless1 {
@@ -1251,7 +1251,7 @@ impl ::core::default::Default for Fieldless {
 #[automatically_derived]
 impl ::core::hash::Hash for Fieldless {
     #[inline]
-    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {
+    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) {
         let __self_discr = ::core::intrinsics::discriminant_value(self);
         ::core::hash::Hash::hash(&__self_discr, state)
     }
@@ -1272,7 +1272,7 @@ impl ::core::cmp::Eq for Fieldless {
     #[inline]
     #[doc(hidden)]
     #[coverage(off)]
-    fn assert_receiver_is_total_eq(&self) -> () {}
+    fn assert_receiver_is_total_eq(&self) {}
 }
 #[automatically_derived]
 impl ::core::cmp::PartialOrd for Fieldless {
@@ -1345,7 +1345,7 @@ impl ::core::default::Default for Mixed {
 #[automatically_derived]
 impl ::core::hash::Hash for Mixed {
     #[inline]
-    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {
+    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) {
         let __self_discr = ::core::intrinsics::discriminant_value(self);
         ::core::hash::Hash::hash(&__self_discr, state);
         match self {
@@ -1382,7 +1382,7 @@ impl ::core::cmp::Eq for Mixed {
     #[inline]
     #[doc(hidden)]
     #[coverage(off)]
-    fn assert_receiver_is_total_eq(&self) -> () {
+    fn assert_receiver_is_total_eq(&self) {
         let _: ::core::cmp::AssertParamIsEq<u32>;
         let _: ::core::cmp::AssertParamIsEq<Option<u32>>;
         let _: ::core::cmp::AssertParamIsEq<Option<i32>>;
@@ -1545,7 +1545,7 @@ impl ::core::fmt::Debug for Fielded {
 #[automatically_derived]
 impl ::core::hash::Hash for Fielded {
     #[inline]
-    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {
+    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) {
         let __self_discr = ::core::intrinsics::discriminant_value(self);
         ::core::hash::Hash::hash(&__self_discr, state);
         match self {
@@ -1580,7 +1580,7 @@ impl ::core::cmp::Eq for Fielded {
     #[inline]
     #[doc(hidden)]
     #[coverage(off)]
-    fn assert_receiver_is_total_eq(&self) -> () {
+    fn assert_receiver_is_total_eq(&self) {
         let _: ::core::cmp::AssertParamIsEq<u32>;
         let _: ::core::cmp::AssertParamIsEq<bool>;
         let _: ::core::cmp::AssertParamIsEq<Option<i32>>;
@@ -1666,7 +1666,7 @@ impl<T: ::core::fmt::Debug, U: ::core::fmt::Debug> ::core::fmt::Debug for
 impl<T: ::core::hash::Hash, U: ::core::hash::Hash> ::core::hash::Hash for
     EnumGeneric<T, U> {
     #[inline]
-    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) -> () {
+    fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) {
         let __self_discr = ::core::intrinsics::discriminant_value(self);
         ::core::hash::Hash::hash(&__self_discr, state);
         match self {
@@ -1702,7 +1702,7 @@ impl<T: ::core::cmp::Eq, U: ::core::cmp::Eq> ::core::cmp::Eq for
     #[inline]
     #[doc(hidden)]
     #[coverage(off)]
-    fn assert_receiver_is_total_eq(&self) -> () {
+    fn assert_receiver_is_total_eq(&self) {
         let _: ::core::cmp::AssertParamIsEq<T>;
         let _: ::core::cmp::AssertParamIsEq<U>;
     }

--- a/tests/ui/macros/assert-matches-macro-msg.rs
+++ b/tests/ui/macros/assert-matches-macro-msg.rs
@@ -6,7 +6,7 @@
 
 #![feature(assert_matches)]
 
-use std::assert_matches::assert_matches;
+use std::assert_matches;
 
 fn main() {
     assert_matches!(1 + 1, 3, "1 + 1 definitely should be 3");

--- a/tests/ui/stats/macro-stats.stderr
+++ b/tests/ui/stats/macro-stats.stderr
@@ -4,11 +4,11 @@ macro-stats Macro Name                         Uses      Lines  Avg Lines      B
 macro-stats -----------------------------------------------------------------------------------
 macro-stats #[derive(Clone)]                      8         67        8.4      1_879      234.9
 macro-stats #[derive(PartialOrd)]                 1         17       17.0        675      675.0
-macro-stats #[derive(Hash)]                       2         17        8.5        577      288.5
+macro-stats #[derive(Hash)]                       2         17        8.5        565      282.5
 macro-stats q!                                    1         26       26.0        519      519.0
 macro-stats #[derive(Ord)]                        1         15       15.0        503      503.0
 macro-stats #[derive(Default)]                    2         16        8.0        403      201.5
-macro-stats #[derive(Eq)]                         1         11       11.0        325      325.0
+macro-stats #[derive(Eq)]                         1         11       11.0        319      319.0
 macro-stats #[derive(Debug)]                      1          8        8.0        277      277.0
 macro-stats #[derive(PartialEq)]                  1          9        9.0        267      267.0
 macro-stats #[derive(Copy)]                       1          2        2.0         61       61.0

--- a/tests/ui/stdlib-unit-tests/matches2021.rs
+++ b/tests/ui/stdlib-unit-tests/matches2021.rs
@@ -5,7 +5,7 @@
 
 #![feature(assert_matches)]
 
-use std::assert_matches::assert_matches;
+use std::assert_matches;
 
 fn main() {
     assert!(matches!((), ()));


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#151001 (rustdoc: render doc(hidden) as a code attribute)
 - rust-lang/rust#151042 (fix fallback impl for select_unpredictable intrinsic)
 - rust-lang/rust#151220 (option: Use Option::map in Option::cloned)
 - rust-lang/rust#151260 (Handle unevaluated ConstKind in in_operand)
 - rust-lang/rust#151296 (MGCA: Fix incorrect pretty printing of valtree arrays)
 - rust-lang/rust#151423 (Move assert_matches to planned stable path)
 - rust-lang/rust#151441 (Fix ICE: Don't try to evaluate type_consts when eagerly collecting items)
 - rust-lang/rust#151465 (codegen: clarify some variable names around function calls)
 - rust-lang/rust#151468 (fix `f16` doctest FIXMEs)
 - rust-lang/rust#151469 (llvm: Tolerate dead_on_return attribute changes)
 - rust-lang/rust#151476 (Avoid `-> ()` in derived functions.)

r? @ghost

<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=151220,151423,151001,151042,151260,151296,151441,151465,151468,151469,151476)
<!-- homu-ignore:end -->

