### PR TITLE
[WIP,perf] A structure for keeping conditionally extracted syntax contexts

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -30,7 +30,7 @@ use rustc_session::lint::builtin::{
 use rustc_session::utils::was_invoked_from_cargo;
 use rustc_span::edit_distance::find_best_match_for_name;
 use rustc_span::edition::Edition;
-use rustc_span::hygiene::MacroKind;
+use rustc_span::hygiene::{MacroKind, PackagedSyntaxContext};
 use rustc_span::source_map::{SourceMap, Spanned};
 use rustc_span::{
     BytePos, DUMMY_SP, Ident, Macros20NormalizedIdent, Span, Symbol, SyntaxContext, kw, sym,
@@ -1180,7 +1180,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         ctxt: SyntaxContext,
         filter_fn: &impl Fn(Res) -> bool,
     ) {
-        let ctxt = DUMMY_SP.with_ctxt(ctxt);
+        let ctxt = PackagedSyntaxContext::new(DUMMY_SP.with_ctxt(ctxt));
         self.cm().visit_scopes(scope_set, ps, ctxt, None, |this, scope, use_prelude, _| {
             match scope {
                 Scope::DeriveHelpers(expn_id) => {

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -37,7 +37,9 @@ use rustc_session::config::{CrateType, ResolveDocLinks};
 use rustc_session::lint;
 use rustc_session::parse::feature_err;
 use rustc_span::source_map::{Spanned, respan};
-use rustc_span::{BytePos, DUMMY_SP, Ident, Macros20NormalizedIdent, Span, Symbol, kw, sym};
+use rustc_span::{
+    BytePos, DUMMY_SP, Ident, Macros20NormalizedIdent, PackagedSyntaxContext, Span, Symbol, kw, sym,
+};
 use smallvec::{SmallVec, smallvec};
 use thin_vec::ThinVec;
 use tracing::{debug, instrument, trace};
@@ -5222,7 +5224,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
         self.r.traits_in_scope(
             self.current_trait_ref.as_ref().map(|(module, _)| *module),
             &self.parent_scope,
-            ident.span,
+            PackagedSyntaxContext::new(ident.span),
             Some((ident.name, ns)),
         )
     }
@@ -5321,7 +5323,12 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 .entry(self.parent_scope.module.nearest_parent_mod().expect_local())
                 .or_insert_with(|| {
                     self.r
-                        .traits_in_scope(None, &self.parent_scope, DUMMY_SP, None)
+                        .traits_in_scope(
+                            None,
+                            &self.parent_scope,
+                            PackagedSyntaxContext::new(DUMMY_SP),
+                            None,
+                        )
                         .into_iter()
                         .filter_map(|tr| {
                             if self.is_invalid_proc_macro_item_for_doc(tr.def_id) {

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -74,7 +74,9 @@ use rustc_middle::ty::{
 use rustc_query_system::ich::StableHashingContext;
 use rustc_session::config::CrateType;
 use rustc_session::lint::builtin::PRIVATE_MACRO_USE;
-use rustc_span::hygiene::{ExpnId, LocalExpnId, MacroKind, SyntaxContext, Transparency};
+use rustc_span::hygiene::{
+    ExpnId, LocalExpnId, MacroKind, PackagedSyntaxContext, SyntaxContext, Transparency,
+};
 use rustc_span::{DUMMY_SP, Ident, Macros20NormalizedIdent, Span, Symbol, kw, sym};
 use smallvec::{SmallVec, smallvec};
 use tracing::debug;
@@ -1885,7 +1887,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         &mut self,
         current_trait: Option<Module<'ra>>,
         parent_scope: &ParentScope<'ra>,
-        ctxt: Span,
+        ctxt: PackagedSyntaxContext,
         assoc_item: Option<(Symbol, Namespace)>,
     ) -> Vec<TraitCandidate> {
         let mut found_traits = Vec::new();

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -52,7 +52,8 @@ use edition::Edition;
 pub mod hygiene;
 use hygiene::Transparency;
 pub use hygiene::{
-    DesugaringKind, ExpnData, ExpnHash, ExpnId, ExpnKind, LocalExpnId, MacroKind, SyntaxContext,
+    DesugaringKind, ExpnData, ExpnHash, ExpnId, ExpnKind, LocalExpnId, MacroKind,
+    PackagedSyntaxContext, SyntaxContext,
 };
 use rustc_data_structures::stable_hasher::HashingControls;
 pub mod def_id;


### PR DESCRIPTION
An implementation for the suggestion from https://github.com/rust-lang/rust/pull/150982#issuecomment-3750228673.

I won't even benchmark it, just submitting for history.
The problem of having both packed and unpacked spans in different places is real, but this isn't the way to solve it, see some thoughts in the next comment.