### PR TITLE
rustc_parse: improve the error diagnostic for "missing let in let chain"

### DIFF
--- a/tests/ui/expr/if/bad-if-let-suggestion.rs
+++ b/tests/ui/expr/if/bad-if-let-suggestion.rs
@@ -1,8 +1,6 @@
 fn a() {
     if let x = 1 && i = 2 {}
-    //~^ ERROR cannot find value `i` in this scope
-    //~| ERROR mismatched types
-    //~| ERROR expected expression, found `let` statement
+    //~^ ERROR expected expression, found `let` statement
 }
 
 fn b() {

--- a/tests/ui/expr/if/bad-if-let-suggestion.stderr
+++ b/tests/ui/expr/if/bad-if-let-suggestion.stderr
@@ -15,13 +15,7 @@ LL |     if let x = 1 && i == 2 {}
    |                        +
 
 error[E0425]: cannot find value `i` in this scope
-  --> $DIR/bad-if-let-suggestion.rs:2:21
-   |
-LL |     if let x = 1 && i = 2 {}
-   |                     ^ not found in this scope
-
-error[E0425]: cannot find value `i` in this scope
-  --> $DIR/bad-if-let-suggestion.rs:9:9
+  --> $DIR/bad-if-let-suggestion.rs:7:9
    |
 LL | fn a() {
    | ------ similarly named function `a` defined here
@@ -36,7 +30,7 @@ LL +     if (a + j) = i {}
    |
 
 error[E0425]: cannot find value `j` in this scope
-  --> $DIR/bad-if-let-suggestion.rs:9:13
+  --> $DIR/bad-if-let-suggestion.rs:7:13
    |
 LL | fn a() {
    | ------ similarly named function `a` defined here
@@ -51,7 +45,7 @@ LL +     if (i + a) = i {}
    |
 
 error[E0425]: cannot find value `i` in this scope
-  --> $DIR/bad-if-let-suggestion.rs:9:18
+  --> $DIR/bad-if-let-suggestion.rs:7:18
    |
 LL | fn a() {
    | ------ similarly named function `a` defined here
@@ -66,7 +60,7 @@ LL +     if (i + j) = a {}
    |
 
 error[E0425]: cannot find value `x` in this scope
-  --> $DIR/bad-if-let-suggestion.rs:16:8
+  --> $DIR/bad-if-let-suggestion.rs:14:8
    |
 LL | fn a() {
    | ------ similarly named function `a` defined here
@@ -80,18 +74,6 @@ LL -     if x[0] = 1 {}
 LL +     if a[0] = 1 {}
    |
 
-error[E0308]: mismatched types
-  --> $DIR/bad-if-let-suggestion.rs:2:8
-   |
-LL |     if let x = 1 && i = 2 {}
-   |        ^^^^^^^^^^^^^^^^^^ expected `bool`, found `()`
-   |
-help: you might have meant to compare for equality
-   |
-LL |     if let x = 1 && i == 2 {}
-   |                        +
+error: aborting due to 5 previous errors
 
-error: aborting due to 7 previous errors
-
-Some errors have detailed explanations: E0308, E0425.
-For more information about an error, try `rustc --explain E0308`.
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/missing/missing-let.rs
+++ b/tests/ui/missing/missing-let.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let x = Some(42);
+    if let Some(_) = x
+        && Some(x) = x //~^ ERROR expected expression, found `let` statement
+    {}
+}

--- a/tests/ui/missing/missing-let.stderr
+++ b/tests/ui/missing/missing-let.stderr
@@ -1,0 +1,18 @@
+error: expected expression, found `let` statement
+  --> $DIR/missing-let.rs:3:8
+   |
+LL |     if let Some(_) = x
+   |        ^^^^^^^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
+help: you might have meant to continue the let-chain
+   |
+LL |         && let Some(x) = x
+   |            +++
+help: you might have meant to compare for equality
+   |
+LL |         && Some(x) == x
+   |                     +
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
