### PR TITLE
Fix ICE when using zero-length SIMD type in extern static

### DIFF
--- a/tests/ui/simd/extern-static-zero-length.rs
+++ b/tests/ui/simd/extern-static-zero-length.rs
@@ -1,0 +1,13 @@
+#![feature(repr_simd)]
+
+#[repr(simd)]
+struct Simd<T, const N: usize>([T; N]);
+
+unsafe extern "C" {
+    static VAR: Simd<u8, 0>;
+    //~^ ERROR the SIMD type `Simd<u8, 0>` has zero elements
+    static VAR2: Simd<u8, 1_000_000>;
+    //~^ ERROR the SIMD type `Simd<u8, 1000000>` has more elements than the limit 32768
+}
+
+fn main() {}

--- a/tests/ui/simd/extern-static-zero-length.stderr
+++ b/tests/ui/simd/extern-static-zero-length.stderr
@@ -1,0 +1,14 @@
+error: the SIMD type `Simd<u8, 0>` has zero elements
+  --> $DIR/extern-static-zero-length.rs:7:17
+   |
+LL |     static VAR: Simd<u8, 0>;
+   |                 ^^^^^^^^^^^
+
+error: the SIMD type `Simd<u8, 1000000>` has more elements than the limit 32768
+  --> $DIR/extern-static-zero-length.rs:9:18
+   |
+LL |     static VAR2: Simd<u8, 1_000_000>;
+   |                  ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
before my fix using a zero-length SIMD type in an extern static would cause an internal compiler error. now it properly shows a diagnostic error instead of panicking. it was because `LayoutError::InvalidSimd` wasn't handled in `check_static_inhabited` and fell through to a generic `delayed_bug`.

i added handling for `InvalidSimd` in `check_static_inhabited` (similar to `SizeOverflow`): when a SIMD type has an invalid layout, we call `emit_err` with `Spanned` to emit a normal error instead of an ICE. compiler now emits a clear error `"the SIMD type Simd<u8, 0> has zero elements"` with the correct span on the type, matching expected compiler behavior.

fixes rust-lang/rust#151451