### PR TITLE
Various refactors to the proc_macro bridge

### DIFF
--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -566,19 +566,19 @@ impl server::Server for Rustc<'_, '_> {
         diag.emit();
     }
 
-    fn tt_drop(&mut self, stream: Self::TokenStream) {
+    fn ts_drop(&mut self, stream: Self::TokenStream) {
         drop(stream);
     }
 
-    fn tt_clone(&mut self, stream: &Self::TokenStream) -> Self::TokenStream {
+    fn ts_clone(&mut self, stream: &Self::TokenStream) -> Self::TokenStream {
         stream.clone()
     }
 
-    fn tt_is_empty(&mut self, stream: &Self::TokenStream) -> bool {
+    fn ts_is_empty(&mut self, stream: &Self::TokenStream) -> bool {
         stream.is_empty()
     }
 
-    fn tt_from_str(&mut self, src: &str) -> Self::TokenStream {
+    fn ts_from_str(&mut self, src: &str) -> Self::TokenStream {
         unwrap_or_emit_fatal(source_str_to_stream(
             self.psess(),
             FileName::proc_macro_source_code(src),
@@ -587,11 +587,11 @@ impl server::Server for Rustc<'_, '_> {
         ))
     }
 
-    fn tt_to_string(&mut self, stream: &Self::TokenStream) -> String {
+    fn ts_to_string(&mut self, stream: &Self::TokenStream) -> String {
         pprust::tts_to_string(stream)
     }
 
-    fn tt_expand_expr(&mut self, stream: &Self::TokenStream) -> Result<Self::TokenStream, ()> {
+    fn ts_expand_expr(&mut self, stream: &Self::TokenStream) -> Result<Self::TokenStream, ()> {
         // Parse the expression from our tokenstream.
         let expr: PResult<'_, _> = try {
             let mut p = Parser::new(self.psess(), stream.clone(), Some("proc_macro expand expr"));
@@ -652,14 +652,14 @@ impl server::Server for Rustc<'_, '_> {
         }
     }
 
-    fn tt_from_token_tree(
+    fn ts_from_token_tree(
         &mut self,
         tree: TokenTree<Self::TokenStream, Self::Span, Self::Symbol>,
     ) -> Self::TokenStream {
         Self::TokenStream::new((tree, &mut *self).to_internal().into_iter().collect::<Vec<_>>())
     }
 
-    fn tt_concat_trees(
+    fn ts_concat_trees(
         &mut self,
         base: Option<Self::TokenStream>,
         trees: Vec<TokenTree<Self::TokenStream, Self::Span, Self::Symbol>>,
@@ -673,7 +673,7 @@ impl server::Server for Rustc<'_, '_> {
         stream
     }
 
-    fn tt_concat_streams(
+    fn ts_concat_streams(
         &mut self,
         base: Option<Self::TokenStream>,
         streams: Vec<Self::TokenStream>,
@@ -685,7 +685,7 @@ impl server::Server for Rustc<'_, '_> {
         stream
     }
 
-    fn tt_into_trees(
+    fn ts_into_trees(
         &mut self,
         stream: Self::TokenStream,
     ) -> Vec<TokenTree<Self::TokenStream, Self::Span, Self::Symbol>> {

--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -844,12 +844,6 @@ impl server::FreeFunctions for Rustc<'_, '_> {
     }
 }
 
-impl server::TokenStream for Rustc<'_, '_> {}
-
-impl server::Span for Rustc<'_, '_> {}
-
-impl server::Symbol for Rustc<'_, '_> {}
-
 impl server::Server for Rustc<'_, '_> {
     fn globals(&mut self) -> ExpnGlobals<Self::Span> {
         ExpnGlobals {

--- a/library/proc_macro/src/bridge/client.rs
+++ b/library/proc_macro/src/bridge/client.rs
@@ -6,87 +6,66 @@ use std::sync::atomic::AtomicU32;
 
 use super::*;
 
-macro_rules! define_client_handles {
-    (
-        'owned: $($oty:ident,)*
-        'interned: $($ity:ident,)*
-    ) => {
-        #[repr(C)]
-        #[allow(non_snake_case)]
-        pub(super) struct HandleCounters {
-            $(pub(super) $oty: AtomicU32,)*
-            $(pub(super) $ity: AtomicU32,)*
-        }
+#[repr(C)]
+pub(super) struct HandleCounters {
+    pub(super) token_stream: AtomicU32,
+    pub(super) span: AtomicU32,
+}
 
-        static COUNTERS: HandleCounters = HandleCounters {
-            $($oty: AtomicU32::new(1),)*
-            $($ity: AtomicU32::new(1),)*
-        };
+static COUNTERS: HandleCounters =
+    HandleCounters { token_stream: AtomicU32::new(1), span: AtomicU32::new(1) };
 
-        $(
-            pub(crate) struct $oty {
-                handle: handle::Handle,
-            }
+pub(crate) struct TokenStream {
+    handle: handle::Handle,
+}
 
-            impl !Send for $oty {}
-            impl !Sync for $oty {}
+impl !Send for TokenStream {}
+impl !Sync for TokenStream {}
 
-            // Forward `Drop::drop` to the inherent `drop` method.
-            impl Drop for $oty {
-                fn drop(&mut self) {
-                    $oty {
-                        handle: self.handle,
-                    }.drop();
-                }
-            }
-
-            impl<S> Encode<S> for $oty {
-                fn encode(self, w: &mut Writer, s: &mut S) {
-                    mem::ManuallyDrop::new(self).handle.encode(w, s);
-                }
-            }
-
-            impl<S> Encode<S> for &$oty {
-                fn encode(self, w: &mut Writer, s: &mut S) {
-                    self.handle.encode(w, s);
-                }
-            }
-
-            impl<S> Decode<'_, '_, S> for $oty {
-                fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
-                    $oty {
-                        handle: handle::Handle::decode(r, s),
-                    }
-                }
-            }
-        )*
-
-        $(
-            #[derive(Copy, Clone, PartialEq, Eq, Hash)]
-            pub(crate) struct $ity {
-                handle: handle::Handle,
-            }
-
-            impl !Send for $ity {}
-            impl !Sync for $ity {}
-
-            impl<S> Encode<S> for $ity {
-                fn encode(self, w: &mut Writer, s: &mut S) {
-                    self.handle.encode(w, s);
-                }
-            }
-
-            impl<S> Decode<'_, '_, S> for $ity {
-                fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
-                    $ity {
-                        handle: handle::Handle::decode(r, s),
-                    }
-                }
-            }
-        )*
+// Forward `Drop::drop` to the inherent `drop` method.
+impl Drop for TokenStream {
+    fn drop(&mut self) {
+        TokenStream { handle: self.handle }.drop();
     }
 }
-with_api_handle_types!(define_client_handles);
+
+impl<S> Encode<S> for TokenStream {
+    fn encode(self, w: &mut Writer, s: &mut S) {
+        mem::ManuallyDrop::new(self).handle.encode(w, s);
+    }
+}
+
+impl<S> Encode<S> for &TokenStream {
+    fn encode(self, w: &mut Writer, s: &mut S) {
+        self.handle.encode(w, s);
+    }
+}
+
+impl<S> Decode<'_, '_, S> for TokenStream {
+    fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
+        TokenStream { handle: handle::Handle::decode(r, s) }
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct Span {
+    handle: handle::Handle,
+}
+
+impl !Send for Span {}
+impl !Sync for Span {}
+
+impl<S> Encode<S> for Span {
+    fn encode(self, w: &mut Writer, s: &mut S) {
+        self.handle.encode(w, s);
+    }
+}
+
+impl<S> Decode<'_, '_, S> for Span {
+    fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
+        Span { handle: handle::Handle::decode(r, s) }
+    }
+}
 
 // FIXME(eddyb) generate these impls by pattern-matching on the
 // names of methods - also could use the presence of `fn drop`

--- a/library/proc_macro/src/bridge/client.rs
+++ b/library/proc_macro/src/bridge/client.rs
@@ -103,16 +103,19 @@ pub(crate) use super::FreeFunctions;
 pub(crate) use super::symbol::Symbol;
 
 macro_rules! define_client_side {
-    ($($name:ident {
-        $(fn $method:ident($($arg:ident: $arg_ty:ty),* $(,)?) $(-> $ret_ty:ty)?;)*
-    }),* $(,)?) => {
-        $(impl $name {
+    (
+        FreeFunctions {
+            $(fn $method:ident($($arg:ident: $arg_ty:ty),* $(,)?) $(-> $ret_ty:ty)*;)*
+        },
+        $($name:ident),* $(,)?
+    ) => {
+        impl FreeFunctions {
             $(pub(crate) fn $method($($arg: $arg_ty),*) $(-> $ret_ty)? {
                 Bridge::with(|bridge| {
                     let mut buf = bridge.cached_buffer.take();
 
                     buf.clear();
-                    api_tags::Method::$name(api_tags::$name::$method).encode(&mut buf, &mut ());
+                    api_tags::Method::$method.encode(&mut buf, &mut ());
                     $($arg.encode(&mut buf, &mut ());)*
 
                     buf = bridge.dispatch.call(buf);
@@ -124,7 +127,7 @@ macro_rules! define_client_side {
                     r.unwrap_or_else(|e| panic::resume_unwind(e.into()))
                 })
             })*
-        })*
+        }
     }
 }
 with_api!(self, self, define_client_side);

--- a/library/proc_macro/src/bridge/client.rs
+++ b/library/proc_macro/src/bridge/client.rs
@@ -25,7 +25,7 @@ impl !Sync for TokenStream {}
 // Forward `Drop::drop` to the inherent `drop` method.
 impl Drop for TokenStream {
     fn drop(&mut self) {
-        Methods::tt_drop(TokenStream { handle: self.handle });
+        Methods::ts_drop(TokenStream { handle: self.handle });
     }
 }
 
@@ -75,7 +75,7 @@ impl<S> Decode<'_, '_, S> for Span {
 
 impl Clone for TokenStream {
     fn clone(&self) -> Self {
-        Methods::tt_clone(self)
+        Methods::ts_clone(self)
     }
 }
 

--- a/library/proc_macro/src/bridge/client.rs
+++ b/library/proc_macro/src/bridge/client.rs
@@ -52,12 +52,6 @@ macro_rules! define_client_handles {
                 }
             }
 
-            impl<S> Encode<S> for &mut $oty {
-                fn encode(self, w: &mut Writer, s: &mut S) {
-                    self.handle.encode(w, s);
-                }
-            }
-
             impl<S> Decode<'_, '_, S> for $oty {
                 fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
                     $oty {

--- a/library/proc_macro/src/bridge/client.rs
+++ b/library/proc_macro/src/bridge/client.rs
@@ -25,7 +25,7 @@ impl !Sync for TokenStream {}
 // Forward `Drop::drop` to the inherent `drop` method.
 impl Drop for TokenStream {
     fn drop(&mut self) {
-        FreeFunctions::tt_drop(TokenStream { handle: self.handle });
+        Methods::tt_drop(TokenStream { handle: self.handle });
     }
 }
 
@@ -75,7 +75,7 @@ impl<S> Decode<'_, '_, S> for Span {
 
 impl Clone for TokenStream {
     fn clone(&self) -> Self {
-        FreeFunctions::tt_clone(self)
+        Methods::tt_clone(self)
     }
 }
 
@@ -95,21 +95,21 @@ impl Span {
 
 impl fmt::Debug for Span {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&FreeFunctions::span_debug(*self))
+        f.write_str(&Methods::span_debug(*self))
     }
 }
 
-pub(crate) use super::FreeFunctions;
+pub(crate) use super::Methods;
 pub(crate) use super::symbol::Symbol;
 
 macro_rules! define_client_side {
     (
-        FreeFunctions {
+        Methods {
             $(fn $method:ident($($arg:ident: $arg_ty:ty),* $(,)?) $(-> $ret_ty:ty)*;)*
         },
         $($name:ident),* $(,)?
     ) => {
-        impl FreeFunctions {
+        impl Methods {
             $(pub(crate) fn $method($($arg: $arg_ty),*) $(-> $ret_ty)? {
                 Bridge::with(|bridge| {
                     let mut buf = bridge.cached_buffer.take();

--- a/library/proc_macro/src/bridge/client.rs
+++ b/library/proc_macro/src/bridge/client.rs
@@ -25,7 +25,7 @@ impl !Sync for TokenStream {}
 // Forward `Drop::drop` to the inherent `drop` method.
 impl Drop for TokenStream {
     fn drop(&mut self) {
-        TokenStream { handle: self.handle }.drop();
+        FreeFunctions::tt_drop(TokenStream { handle: self.handle });
     }
 }
 
@@ -75,7 +75,7 @@ impl<S> Decode<'_, '_, S> for Span {
 
 impl Clone for TokenStream {
     fn clone(&self) -> Self {
-        self.clone()
+        FreeFunctions::tt_clone(self)
     }
 }
 
@@ -95,7 +95,7 @@ impl Span {
 
 impl fmt::Debug for Span {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.debug())
+        f.write_str(&FreeFunctions::span_debug(*self))
     }
 }
 

--- a/library/proc_macro/src/bridge/client.rs
+++ b/library/proc_macro/src/bridge/client.rs
@@ -120,6 +120,7 @@ impl fmt::Debug for Span {
     }
 }
 
+pub(crate) use super::FreeFunctions;
 pub(crate) use super::symbol::Symbol;
 
 macro_rules! define_client_side {

--- a/library/proc_macro/src/bridge/handle.rs
+++ b/library/proc_macro/src/bridge/handle.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 use std::hash::Hash;
 use std::num::NonZero;
-use std::ops::{Index, IndexMut};
+use std::ops::Index;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use super::fxhash::FxHashMap;
@@ -44,12 +44,6 @@ impl<T> Index<Handle> for OwnedStore<T> {
     type Output = T;
     fn index(&self, h: Handle) -> &T {
         self.data.get(&h).expect("use-after-free in `proc_macro` handle")
-    }
-}
-
-impl<T> IndexMut<Handle> for OwnedStore<T> {
-    fn index_mut(&mut self, h: Handle) -> &mut T {
-        self.data.get_mut(&h).expect("use-after-free in `proc_macro` handle")
     }
 }
 

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -21,7 +21,7 @@ use crate::{Delimiter, Level, Spacing};
 /// `with_api!(MySelf, my_self, my_macro)` expands to:
 /// ```rust,ignore (pseudo-code)
 /// my_macro! {
-///     FreeFunctions {
+///     Methods {
 ///         // ...
 ///         fn lit_character(ch: char) -> MySelf::Literal;
 ///         // ...
@@ -49,7 +49,7 @@ use crate::{Delimiter, Level, Spacing};
 macro_rules! with_api {
     ($S:ident, $self:ident, $m:ident) => {
         $m! {
-            FreeFunctions {
+            Methods {
                 fn injected_env_var(var: &str) -> Option<String>;
                 fn track_env_var(var: &str, value: Option<&str>);
                 fn track_path(path: &str);
@@ -103,7 +103,7 @@ macro_rules! with_api {
     };
 }
 
-pub(crate) struct FreeFunctions;
+pub(crate) struct Methods;
 
 #[allow(unsafe_code)]
 mod arena;
@@ -158,7 +158,7 @@ mod api_tags {
 
     macro_rules! declare_tags {
         (
-            FreeFunctions {
+            Methods {
                 $(fn $method:ident($($arg:ident: $arg_ty:ty),* $(,)?) $(-> $ret_ty:ty)*;)*
             },
             $($name:ident),* $(,)?

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -102,22 +102,6 @@ macro_rules! with_api {
     };
 }
 
-// Similar to `with_api`, but only lists the types requiring handles, and they
-// are divided into the two storage categories.
-macro_rules! with_api_handle_types {
-    ($m:ident) => {
-        $m! {
-            'owned:
-            // FreeFunctions is handled manually
-            TokenStream,
-
-            'interned:
-            Span,
-            // Symbol is handled manually
-        }
-    };
-}
-
 pub(crate) struct FreeFunctions;
 
 #[allow(unsafe_code)]

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -56,24 +56,24 @@ macro_rules! with_api {
                 fn literal_from_str(s: &str) -> Result<Literal<$S::Span, $S::Symbol>, ()>;
                 fn emit_diagnostic(diagnostic: Diagnostic<$S::Span>);
 
-                fn tt_drop(stream: $S::TokenStream);
-                fn tt_clone(stream: &$S::TokenStream) -> $S::TokenStream;
-                fn tt_is_empty(stream: &$S::TokenStream) -> bool;
-                fn tt_expand_expr(stream: &$S::TokenStream) -> Result<$S::TokenStream, ()>;
-                fn tt_from_str(src: &str) -> $S::TokenStream;
-                fn tt_to_string(stream: &$S::TokenStream) -> String;
-                fn tt_from_token_tree(
+                fn ts_drop(stream: $S::TokenStream);
+                fn ts_clone(stream: &$S::TokenStream) -> $S::TokenStream;
+                fn ts_is_empty(stream: &$S::TokenStream) -> bool;
+                fn ts_expand_expr(stream: &$S::TokenStream) -> Result<$S::TokenStream, ()>;
+                fn ts_from_str(src: &str) -> $S::TokenStream;
+                fn ts_to_string(stream: &$S::TokenStream) -> String;
+                fn ts_from_token_tree(
                     tree: TokenTree<$S::TokenStream, $S::Span, $S::Symbol>,
                 ) -> $S::TokenStream;
-                fn tt_concat_trees(
+                fn ts_concat_trees(
                     base: Option<$S::TokenStream>,
                     trees: Vec<TokenTree<$S::TokenStream, $S::Span, $S::Symbol>>,
                 ) -> $S::TokenStream;
-                fn tt_concat_streams(
+                fn ts_concat_streams(
                     base: Option<$S::TokenStream>,
                     streams: Vec<$S::TokenStream>,
                 ) -> $S::TokenStream;
-                fn tt_into_trees(
+                fn ts_into_trees(
                     stream: $S::TokenStream
                 ) -> Vec<TokenTree<$S::TokenStream, $S::Span, $S::Symbol>>;
 

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -49,7 +49,6 @@ macro_rules! with_api {
     ($S:ident, $self:ident, $m:ident) => {
         $m! {
             FreeFunctions {
-                fn drop($self: $S::FreeFunctions);
                 fn injected_env_var(var: &str) -> Option<String>;
                 fn track_env_var(var: &str, value: Option<&str>);
                 fn track_path(path: &str);
@@ -109,7 +108,7 @@ macro_rules! with_api_handle_types {
     ($m:ident) => {
         $m! {
             'owned:
-            FreeFunctions,
+            // FreeFunctions is handled manually
             TokenStream,
 
             'interned:
@@ -118,6 +117,8 @@ macro_rules! with_api_handle_types {
         }
     };
 }
+
+pub(crate) struct FreeFunctions;
 
 #[allow(unsafe_code)]
 mod arena;

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -21,14 +21,15 @@ use crate::{Delimiter, Level, Spacing};
 /// `with_api!(MySelf, my_self, my_macro)` expands to:
 /// ```rust,ignore (pseudo-code)
 /// my_macro! {
-///     // ...
-///     Literal {
+///     FreeFunctions {
 ///         // ...
-///         fn character(ch: char) -> MySelf::Literal;
+///         fn lit_character(ch: char) -> MySelf::Literal;
 ///         // ...
-///         fn span(my_self: &MySelf::Literal) -> MySelf::Span;
-///         fn set_span(my_self: &mut MySelf::Literal, span: MySelf::Span);
+///         fn lit_span(my_self: &MySelf::Literal) -> MySelf::Span;
+///         fn lit_set_span(my_self: &mut MySelf::Literal, span: MySelf::Span);
 ///     },
+///     Literal,
+///     Span,
 ///     // ...
 /// }
 /// ```
@@ -95,9 +96,9 @@ macro_rules! with_api {
 
                 fn symbol_normalize_and_validate_ident(string: &str) -> Result<$S::Symbol, ()>;
             },
-            TokenStream {},
-            Span {},
-            Symbol {},
+            TokenStream,
+            Span,
+            Symbol,
         }
     };
 }
@@ -160,18 +161,12 @@ mod api_tags {
             FreeFunctions {
                 $(fn $method:ident($($arg:ident: $arg_ty:ty),* $(,)?) $(-> $ret_ty:ty)*;)*
             },
-            $($name:ident { $($x:tt)* }),* $(,)?
+            $($name:ident),* $(,)?
         ) => {
-            pub(super) enum FreeFunctions {
+            pub(super) enum Method {
                 $($method),*
             }
-            rpc_encode_decode!(enum FreeFunctions { $($method),* });
-
-
-            pub(super) enum Method {
-                FreeFunctions(FreeFunctions),
-            }
-            rpc_encode_decode!(enum Method { FreeFunctions(m) });
+            rpc_encode_decode!(enum Method { $($method),* });
         }
     }
     with_api!(self, self, declare_tags);

--- a/library/proc_macro/src/bridge/server.rs
+++ b/library/proc_macro/src/bridge/server.rs
@@ -47,17 +47,6 @@ macro_rules! define_server_handles {
                     &s.$oty[handle::Handle::decode(r, &mut ())]
                 }
             }
-
-            impl<'s, S: Types> Decode<'_, 's, HandleStore<MarkedTypes<S>>>
-                for &'s mut Marked<S::$oty, client::$oty>
-            {
-                fn decode(
-                    r: &mut Reader<'_>,
-                    s: &'s mut HandleStore<MarkedTypes<S>>
-                ) -> Self {
-                    &mut s.$oty[handle::Handle::decode(r, &mut ())]
-                }
-            }
         )*
 
         $(

--- a/library/proc_macro/src/bridge/symbol.rs
+++ b/library/proc_macro/src/bridge/symbol.rs
@@ -46,7 +46,7 @@ impl Symbol {
         if string.is_ascii() {
             Err(())
         } else {
-            client::Symbol::normalize_and_validate_ident(string)
+            client::FreeFunctions::symbol_normalize_and_validate_ident(string)
         }
         .unwrap_or_else(|_| panic!("`{:?}` is not a valid identifier", string))
     }

--- a/library/proc_macro/src/bridge/symbol.rs
+++ b/library/proc_macro/src/bridge/symbol.rs
@@ -46,7 +46,7 @@ impl Symbol {
         if string.is_ascii() {
             Err(())
         } else {
-            client::FreeFunctions::symbol_normalize_and_validate_ident(string)
+            client::Methods::symbol_normalize_and_validate_ident(string)
         }
         .unwrap_or_else(|_| panic!("`{:?}` is not a valid identifier", string))
     }

--- a/library/proc_macro/src/bridge/symbol.rs
+++ b/library/proc_macro/src/bridge/symbol.rs
@@ -99,18 +99,14 @@ impl<S> Encode<S> for Symbol {
     }
 }
 
-impl<S: server::Server> Decode<'_, '_, server::HandleStore<server::MarkedTypes<S>>>
-    for Marked<S::Symbol, Symbol>
-{
-    fn decode(r: &mut Reader<'_>, s: &mut server::HandleStore<server::MarkedTypes<S>>) -> Self {
+impl<S: server::Server> Decode<'_, '_, server::HandleStore<S>> for Marked<S::Symbol, Symbol> {
+    fn decode(r: &mut Reader<'_>, s: &mut server::HandleStore<S>) -> Self {
         Mark::mark(S::intern_symbol(<&str>::decode(r, s)))
     }
 }
 
-impl<S: server::Server> Encode<server::HandleStore<server::MarkedTypes<S>>>
-    for Marked<S::Symbol, Symbol>
-{
-    fn encode(self, w: &mut Writer, s: &mut server::HandleStore<server::MarkedTypes<S>>) {
+impl<S: server::Server> Encode<server::HandleStore<S>> for Marked<S::Symbol, Symbol> {
+    fn encode(self, w: &mut Writer, s: &mut server::HandleStore<S>) {
         S::with_symbol_string(&self.unmark(), |sym| sym.encode(w, s))
     }
 }

--- a/library/proc_macro/src/diagnostic.rs
+++ b/library/proc_macro/src/diagnostic.rs
@@ -170,6 +170,6 @@ impl Diagnostic {
             }
         }
 
-        crate::bridge::client::FreeFunctions::emit_diagnostic(to_internal(self));
+        crate::bridge::client::Methods::emit_diagnostic(to_internal(self));
     }
 }

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -158,7 +158,7 @@ impl TokenStream {
     /// Checks if this `TokenStream` is empty.
     #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
     pub fn is_empty(&self) -> bool {
-        self.0.as_ref().map(|h| bridge::client::FreeFunctions::tt_is_empty(h)).unwrap_or(true)
+        self.0.as_ref().map(|h| bridge::client::Methods::tt_is_empty(h)).unwrap_or(true)
     }
 
     /// Parses this `TokenStream` as an expression and attempts to expand any
@@ -174,7 +174,7 @@ impl TokenStream {
     #[unstable(feature = "proc_macro_expand", issue = "90765")]
     pub fn expand_expr(&self) -> Result<TokenStream, ExpandError> {
         let stream = self.0.as_ref().ok_or(ExpandError)?;
-        match bridge::client::FreeFunctions::tt_expand_expr(stream) {
+        match bridge::client::Methods::tt_expand_expr(stream) {
             Ok(stream) => Ok(TokenStream(Some(stream))),
             Err(_) => Err(ExpandError),
         }
@@ -193,7 +193,7 @@ impl FromStr for TokenStream {
     type Err = LexError;
 
     fn from_str(src: &str) -> Result<TokenStream, LexError> {
-        Ok(TokenStream(Some(bridge::client::FreeFunctions::tt_from_str(src))))
+        Ok(TokenStream(Some(bridge::client::Methods::tt_from_str(src))))
     }
 }
 
@@ -212,7 +212,7 @@ impl FromStr for TokenStream {
 impl fmt::Display for TokenStream {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.0 {
-            Some(ts) => write!(f, "{}", bridge::client::FreeFunctions::tt_to_string(ts)),
+            Some(ts) => write!(f, "{}", bridge::client::Methods::tt_to_string(ts)),
             None => Ok(()),
         }
     }
@@ -252,9 +252,7 @@ fn tree_to_bridge_tree(
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl From<TokenTree> for TokenStream {
     fn from(tree: TokenTree) -> TokenStream {
-        TokenStream(Some(bridge::client::FreeFunctions::tt_from_token_tree(tree_to_bridge_tree(
-            tree,
-        ))))
+        TokenStream(Some(bridge::client::Methods::tt_from_token_tree(tree_to_bridge_tree(tree))))
     }
 }
 
@@ -283,7 +281,7 @@ impl ConcatTreesHelper {
         if self.trees.is_empty() {
             TokenStream(None)
         } else {
-            TokenStream(Some(bridge::client::FreeFunctions::tt_concat_trees(None, self.trees)))
+            TokenStream(Some(bridge::client::Methods::tt_concat_trees(None, self.trees)))
         }
     }
 
@@ -291,7 +289,7 @@ impl ConcatTreesHelper {
         if self.trees.is_empty() {
             return;
         }
-        stream.0 = Some(bridge::client::FreeFunctions::tt_concat_trees(stream.0.take(), self.trees))
+        stream.0 = Some(bridge::client::Methods::tt_concat_trees(stream.0.take(), self.trees))
     }
 }
 
@@ -316,7 +314,7 @@ impl ConcatStreamsHelper {
         if self.streams.len() <= 1 {
             TokenStream(self.streams.pop())
         } else {
-            TokenStream(Some(bridge::client::FreeFunctions::tt_concat_streams(None, self.streams)))
+            TokenStream(Some(bridge::client::Methods::tt_concat_streams(None, self.streams)))
         }
     }
 
@@ -328,7 +326,7 @@ impl ConcatStreamsHelper {
         if base.is_none() && self.streams.len() == 1 {
             stream.0 = self.streams.pop();
         } else {
-            stream.0 = Some(bridge::client::FreeFunctions::tt_concat_streams(base, self.streams));
+            stream.0 = Some(bridge::client::Methods::tt_concat_streams(base, self.streams));
         }
     }
 }
@@ -441,7 +439,7 @@ pub mod token_stream {
         fn into_iter(self) -> IntoIter {
             IntoIter(
                 self.0
-                    .map(|v| bridge::client::FreeFunctions::tt_into_trees(v))
+                    .map(|v| bridge::client::Methods::tt_into_trees(v))
                     .unwrap_or_default()
                     .into_iter(),
             )
@@ -516,7 +514,7 @@ impl Span {
     /// `self` was generated from, if any.
     #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn parent(&self) -> Option<Span> {
-        bridge::client::FreeFunctions::span_parent(self.0).map(Span)
+        bridge::client::Methods::span_parent(self.0).map(Span)
     }
 
     /// The span for the origin source code that `self` was generated from. If
@@ -524,25 +522,25 @@ impl Span {
     /// value is the same as `*self`.
     #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn source(&self) -> Span {
-        Span(bridge::client::FreeFunctions::span_source(self.0))
+        Span(bridge::client::Methods::span_source(self.0))
     }
 
     /// Returns the span's byte position range in the source file.
     #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn byte_range(&self) -> Range<usize> {
-        bridge::client::FreeFunctions::span_byte_range(self.0)
+        bridge::client::Methods::span_byte_range(self.0)
     }
 
     /// Creates an empty span pointing to directly before this span.
     #[stable(feature = "proc_macro_span_location", since = "1.88.0")]
     pub fn start(&self) -> Span {
-        Span(bridge::client::FreeFunctions::span_start(self.0))
+        Span(bridge::client::Methods::span_start(self.0))
     }
 
     /// Creates an empty span pointing to directly after this span.
     #[stable(feature = "proc_macro_span_location", since = "1.88.0")]
     pub fn end(&self) -> Span {
-        Span(bridge::client::FreeFunctions::span_end(self.0))
+        Span(bridge::client::Methods::span_end(self.0))
     }
 
     /// The one-indexed line of the source file where the span starts.
@@ -550,7 +548,7 @@ impl Span {
     /// To obtain the line of the span's end, use `span.end().line()`.
     #[stable(feature = "proc_macro_span_location", since = "1.88.0")]
     pub fn line(&self) -> usize {
-        bridge::client::FreeFunctions::span_line(self.0)
+        bridge::client::Methods::span_line(self.0)
     }
 
     /// The one-indexed column of the source file where the span starts.
@@ -558,7 +556,7 @@ impl Span {
     /// To obtain the column of the span's end, use `span.end().column()`.
     #[stable(feature = "proc_macro_span_location", since = "1.88.0")]
     pub fn column(&self) -> usize {
-        bridge::client::FreeFunctions::span_column(self.0)
+        bridge::client::Methods::span_column(self.0)
     }
 
     /// The path to the source file in which this span occurs, for display purposes.
@@ -567,7 +565,7 @@ impl Span {
     /// It might be remapped (e.g. `"/src/lib.rs"`) or an artificial path (e.g. `"<command line>"`).
     #[stable(feature = "proc_macro_span_file", since = "1.88.0")]
     pub fn file(&self) -> String {
-        bridge::client::FreeFunctions::span_file(self.0)
+        bridge::client::Methods::span_file(self.0)
     }
 
     /// The path to the source file in which this span occurs on the local file system.
@@ -577,7 +575,7 @@ impl Span {
     /// This path should not be embedded in the output of the macro; prefer `file()` instead.
     #[stable(feature = "proc_macro_span_file", since = "1.88.0")]
     pub fn local_file(&self) -> Option<PathBuf> {
-        bridge::client::FreeFunctions::span_local_file(self.0).map(PathBuf::from)
+        bridge::client::Methods::span_local_file(self.0).map(PathBuf::from)
     }
 
     /// Creates a new span encompassing `self` and `other`.
@@ -585,14 +583,14 @@ impl Span {
     /// Returns `None` if `self` and `other` are from different files.
     #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn join(&self, other: Span) -> Option<Span> {
-        bridge::client::FreeFunctions::span_join(self.0, other.0).map(Span)
+        bridge::client::Methods::span_join(self.0, other.0).map(Span)
     }
 
     /// Creates a new span with the same line/column information as `self` but
     /// that resolves symbols as though it were at `other`.
     #[stable(feature = "proc_macro_span_resolved_at", since = "1.45.0")]
     pub fn resolved_at(&self, other: Span) -> Span {
-        Span(bridge::client::FreeFunctions::span_resolved_at(self.0, other.0))
+        Span(bridge::client::Methods::span_resolved_at(self.0, other.0))
     }
 
     /// Creates a new span with the same name resolution behavior as `self` but
@@ -617,21 +615,21 @@ impl Span {
     /// be used for diagnostics only.
     #[stable(feature = "proc_macro_source_text", since = "1.66.0")]
     pub fn source_text(&self) -> Option<String> {
-        bridge::client::FreeFunctions::span_source_text(self.0)
+        bridge::client::Methods::span_source_text(self.0)
     }
 
     // Used by the implementation of `Span::quote`
     #[doc(hidden)]
     #[unstable(feature = "proc_macro_internals", issue = "27812")]
     pub fn save_span(&self) -> usize {
-        bridge::client::FreeFunctions::span_save_span(self.0)
+        bridge::client::Methods::span_save_span(self.0)
     }
 
     // Used by the implementation of `Span::quote`
     #[doc(hidden)]
     #[unstable(feature = "proc_macro_internals", issue = "27812")]
     pub fn recover_proc_macro_span(id: usize) -> Span {
-        Span(bridge::client::FreeFunctions::span_recover_proc_macro_span(id))
+        Span(bridge::client::Methods::span_recover_proc_macro_span(id))
     }
 
     diagnostic_method!(error, Level::Error);
@@ -1396,7 +1394,7 @@ impl Literal {
     // was 'c' or whether it was '\u{63}'.
     #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn subspan<R: RangeBounds<usize>>(&self, range: R) -> Option<Span> {
-        bridge::client::FreeFunctions::span_subspan(
+        bridge::client::Methods::span_subspan(
             self.0.span,
             range.start_bound().cloned(),
             range.end_bound().cloned(),
@@ -1571,7 +1569,7 @@ impl FromStr for Literal {
     type Err = LexError;
 
     fn from_str(src: &str) -> Result<Self, LexError> {
-        match bridge::client::FreeFunctions::literal_from_str(src) {
+        match bridge::client::Methods::literal_from_str(src) {
             Ok(literal) => Ok(Literal(literal)),
             Err(()) => Err(LexError),
         }
@@ -1626,9 +1624,9 @@ pub mod tracked {
     #[unstable(feature = "proc_macro_tracked_env", issue = "99515")]
     pub fn env_var<K: AsRef<OsStr> + AsRef<str>>(key: K) -> Result<String, VarError> {
         let key: &str = key.as_ref();
-        let value = crate::bridge::client::FreeFunctions::injected_env_var(key)
-            .map_or_else(|| env::var(key), Ok);
-        crate::bridge::client::FreeFunctions::track_env_var(key, value.as_deref().ok());
+        let value =
+            crate::bridge::client::Methods::injected_env_var(key).map_or_else(|| env::var(key), Ok);
+        crate::bridge::client::Methods::track_env_var(key, value.as_deref().ok());
         value
     }
 
@@ -1638,6 +1636,6 @@ pub mod tracked {
     #[unstable(feature = "proc_macro_tracked_path", issue = "99515")]
     pub fn path<P: AsRef<Path>>(path: P) {
         let path: &str = path.as_ref().to_str().unwrap();
-        crate::bridge::client::FreeFunctions::track_path(path);
+        crate::bridge::client::Methods::track_path(path);
     }
 }

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -58,6 +58,7 @@ use rustc_literal_escaper::{MixedUnit, unescape_byte_str, unescape_c_str, unesca
 #[unstable(feature = "proc_macro_totokens", issue = "130977")]
 pub use to_tokens::ToTokens;
 
+use crate::bridge::client::Methods as BridgeMethods;
 use crate::escape::{EscapeOptions, escape_bytes};
 
 /// Errors returned when trying to retrieve a literal unescaped value.
@@ -158,7 +159,7 @@ impl TokenStream {
     /// Checks if this `TokenStream` is empty.
     #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
     pub fn is_empty(&self) -> bool {
-        self.0.as_ref().map(|h| bridge::client::Methods::tt_is_empty(h)).unwrap_or(true)
+        self.0.as_ref().map(|h| BridgeMethods::ts_is_empty(h)).unwrap_or(true)
     }
 
     /// Parses this `TokenStream` as an expression and attempts to expand any
@@ -174,7 +175,7 @@ impl TokenStream {
     #[unstable(feature = "proc_macro_expand", issue = "90765")]
     pub fn expand_expr(&self) -> Result<TokenStream, ExpandError> {
         let stream = self.0.as_ref().ok_or(ExpandError)?;
-        match bridge::client::Methods::tt_expand_expr(stream) {
+        match BridgeMethods::ts_expand_expr(stream) {
             Ok(stream) => Ok(TokenStream(Some(stream))),
             Err(_) => Err(ExpandError),
         }
@@ -193,7 +194,7 @@ impl FromStr for TokenStream {
     type Err = LexError;
 
     fn from_str(src: &str) -> Result<TokenStream, LexError> {
-        Ok(TokenStream(Some(bridge::client::Methods::tt_from_str(src))))
+        Ok(TokenStream(Some(BridgeMethods::ts_from_str(src))))
     }
 }
 
@@ -212,7 +213,7 @@ impl FromStr for TokenStream {
 impl fmt::Display for TokenStream {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.0 {
-            Some(ts) => write!(f, "{}", bridge::client::Methods::tt_to_string(ts)),
+            Some(ts) => write!(f, "{}", BridgeMethods::ts_to_string(ts)),
             None => Ok(()),
         }
     }
@@ -252,7 +253,7 @@ fn tree_to_bridge_tree(
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl From<TokenTree> for TokenStream {
     fn from(tree: TokenTree) -> TokenStream {
-        TokenStream(Some(bridge::client::Methods::tt_from_token_tree(tree_to_bridge_tree(tree))))
+        TokenStream(Some(BridgeMethods::ts_from_token_tree(tree_to_bridge_tree(tree))))
     }
 }
 
@@ -281,7 +282,7 @@ impl ConcatTreesHelper {
         if self.trees.is_empty() {
             TokenStream(None)
         } else {
-            TokenStream(Some(bridge::client::Methods::tt_concat_trees(None, self.trees)))
+            TokenStream(Some(BridgeMethods::ts_concat_trees(None, self.trees)))
         }
     }
 
@@ -289,7 +290,7 @@ impl ConcatTreesHelper {
         if self.trees.is_empty() {
             return;
         }
-        stream.0 = Some(bridge::client::Methods::tt_concat_trees(stream.0.take(), self.trees))
+        stream.0 = Some(BridgeMethods::ts_concat_trees(stream.0.take(), self.trees))
     }
 }
 
@@ -314,7 +315,7 @@ impl ConcatStreamsHelper {
         if self.streams.len() <= 1 {
             TokenStream(self.streams.pop())
         } else {
-            TokenStream(Some(bridge::client::Methods::tt_concat_streams(None, self.streams)))
+            TokenStream(Some(BridgeMethods::ts_concat_streams(None, self.streams)))
         }
     }
 
@@ -326,7 +327,7 @@ impl ConcatStreamsHelper {
         if base.is_none() && self.streams.len() == 1 {
             stream.0 = self.streams.pop();
         } else {
-            stream.0 = Some(bridge::client::Methods::tt_concat_streams(base, self.streams));
+            stream.0 = Some(BridgeMethods::ts_concat_streams(base, self.streams));
         }
     }
 }
@@ -377,7 +378,7 @@ impl Extend<TokenStream> for TokenStream {
 macro_rules! extend_items {
     ($($item:ident)*) => {
         $(
-            #[stable(feature = "token_stream_extend_tt_items", since = "1.92.0")]
+            #[stable(feature = "token_stream_extend_ts_items", since = "1.92.0")]
             impl Extend<$item> for TokenStream {
                 fn extend<T: IntoIterator<Item = $item>>(&mut self, iter: T) {
                     self.extend(iter.into_iter().map(TokenTree::$item));
@@ -392,7 +393,7 @@ extend_items!(Group Literal Punct Ident);
 /// Public implementation details for the `TokenStream` type, such as iterators.
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 pub mod token_stream {
-    use crate::{Group, Ident, Literal, Punct, TokenStream, TokenTree, bridge};
+    use crate::{BridgeMethods, Group, Ident, Literal, Punct, TokenStream, TokenTree, bridge};
 
     /// An iterator over `TokenStream`'s `TokenTree`s.
     /// The iteration is "shallow", e.g., the iterator doesn't recurse into delimited groups,
@@ -438,10 +439,7 @@ pub mod token_stream {
 
         fn into_iter(self) -> IntoIter {
             IntoIter(
-                self.0
-                    .map(|v| bridge::client::Methods::tt_into_trees(v))
-                    .unwrap_or_default()
-                    .into_iter(),
+                self.0.map(|v| BridgeMethods::ts_into_trees(v)).unwrap_or_default().into_iter(),
             )
         }
     }
@@ -514,7 +512,7 @@ impl Span {
     /// `self` was generated from, if any.
     #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn parent(&self) -> Option<Span> {
-        bridge::client::Methods::span_parent(self.0).map(Span)
+        BridgeMethods::span_parent(self.0).map(Span)
     }
 
     /// The span for the origin source code that `self` was generated from. If
@@ -522,25 +520,25 @@ impl Span {
     /// value is the same as `*self`.
     #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn source(&self) -> Span {
-        Span(bridge::client::Methods::span_source(self.0))
+        Span(BridgeMethods::span_source(self.0))
     }
 
     /// Returns the span's byte position range in the source file.
     #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn byte_range(&self) -> Range<usize> {
-        bridge::client::Methods::span_byte_range(self.0)
+        BridgeMethods::span_byte_range(self.0)
     }
 
     /// Creates an empty span pointing to directly before this span.
     #[stable(feature = "proc_macro_span_location", since = "1.88.0")]
     pub fn start(&self) -> Span {
-        Span(bridge::client::Methods::span_start(self.0))
+        Span(BridgeMethods::span_start(self.0))
     }
 
     /// Creates an empty span pointing to directly after this span.
     #[stable(feature = "proc_macro_span_location", since = "1.88.0")]
     pub fn end(&self) -> Span {
-        Span(bridge::client::Methods::span_end(self.0))
+        Span(BridgeMethods::span_end(self.0))
     }
 
     /// The one-indexed line of the source file where the span starts.
@@ -548,7 +546,7 @@ impl Span {
     /// To obtain the line of the span's end, use `span.end().line()`.
     #[stable(feature = "proc_macro_span_location", since = "1.88.0")]
     pub fn line(&self) -> usize {
-        bridge::client::Methods::span_line(self.0)
+        BridgeMethods::span_line(self.0)
     }
 
     /// The one-indexed column of the source file where the span starts.
@@ -556,7 +554,7 @@ impl Span {
     /// To obtain the column of the span's end, use `span.end().column()`.
     #[stable(feature = "proc_macro_span_location", since = "1.88.0")]
     pub fn column(&self) -> usize {
-        bridge::client::Methods::span_column(self.0)
+        BridgeMethods::span_column(self.0)
     }
 
     /// The path to the source file in which this span occurs, for display purposes.
@@ -565,7 +563,7 @@ impl Span {
     /// It might be remapped (e.g. `"/src/lib.rs"`) or an artificial path (e.g. `"<command line>"`).
     #[stable(feature = "proc_macro_span_file", since = "1.88.0")]
     pub fn file(&self) -> String {
-        bridge::client::Methods::span_file(self.0)
+        BridgeMethods::span_file(self.0)
     }
 
     /// The path to the source file in which this span occurs on the local file system.
@@ -575,7 +573,7 @@ impl Span {
     /// This path should not be embedded in the output of the macro; prefer `file()` instead.
     #[stable(feature = "proc_macro_span_file", since = "1.88.0")]
     pub fn local_file(&self) -> Option<PathBuf> {
-        bridge::client::Methods::span_local_file(self.0).map(PathBuf::from)
+        BridgeMethods::span_local_file(self.0).map(PathBuf::from)
     }
 
     /// Creates a new span encompassing `self` and `other`.
@@ -583,14 +581,14 @@ impl Span {
     /// Returns `None` if `self` and `other` are from different files.
     #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn join(&self, other: Span) -> Option<Span> {
-        bridge::client::Methods::span_join(self.0, other.0).map(Span)
+        BridgeMethods::span_join(self.0, other.0).map(Span)
     }
 
     /// Creates a new span with the same line/column information as `self` but
     /// that resolves symbols as though it were at `other`.
     #[stable(feature = "proc_macro_span_resolved_at", since = "1.45.0")]
     pub fn resolved_at(&self, other: Span) -> Span {
-        Span(bridge::client::Methods::span_resolved_at(self.0, other.0))
+        Span(BridgeMethods::span_resolved_at(self.0, other.0))
     }
 
     /// Creates a new span with the same name resolution behavior as `self` but
@@ -615,21 +613,21 @@ impl Span {
     /// be used for diagnostics only.
     #[stable(feature = "proc_macro_source_text", since = "1.66.0")]
     pub fn source_text(&self) -> Option<String> {
-        bridge::client::Methods::span_source_text(self.0)
+        BridgeMethods::span_source_text(self.0)
     }
 
     // Used by the implementation of `Span::quote`
     #[doc(hidden)]
     #[unstable(feature = "proc_macro_internals", issue = "27812")]
     pub fn save_span(&self) -> usize {
-        bridge::client::Methods::span_save_span(self.0)
+        BridgeMethods::span_save_span(self.0)
     }
 
     // Used by the implementation of `Span::quote`
     #[doc(hidden)]
     #[unstable(feature = "proc_macro_internals", issue = "27812")]
     pub fn recover_proc_macro_span(id: usize) -> Span {
-        Span(bridge::client::Methods::span_recover_proc_macro_span(id))
+        Span(BridgeMethods::span_recover_proc_macro_span(id))
     }
 
     diagnostic_method!(error, Level::Error);
@@ -1394,7 +1392,7 @@ impl Literal {
     // was 'c' or whether it was '\u{63}'.
     #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn subspan<R: RangeBounds<usize>>(&self, range: R) -> Option<Span> {
-        bridge::client::Methods::span_subspan(
+        BridgeMethods::span_subspan(
             self.0.span,
             range.start_bound().cloned(),
             range.end_bound().cloned(),
@@ -1569,7 +1567,7 @@ impl FromStr for Literal {
     type Err = LexError;
 
     fn from_str(src: &str) -> Result<Self, LexError> {
-        match bridge::client::Methods::literal_from_str(src) {
+        match BridgeMethods::literal_from_str(src) {
             Ok(literal) => Ok(Literal(literal)),
             Err(()) => Err(LexError),
         }
@@ -1611,10 +1609,11 @@ impl fmt::Debug for Literal {
 )]
 /// Functionality for adding environment state to the build dependency info.
 pub mod tracked {
-
     use std::env::{self, VarError};
     use std::ffi::OsStr;
     use std::path::Path;
+
+    use crate::BridgeMethods;
 
     /// Retrieve an environment variable and add it to build dependency info.
     /// The build system executing the compiler will know that the variable was accessed during
@@ -1624,9 +1623,8 @@ pub mod tracked {
     #[unstable(feature = "proc_macro_tracked_env", issue = "99515")]
     pub fn env_var<K: AsRef<OsStr> + AsRef<str>>(key: K) -> Result<String, VarError> {
         let key: &str = key.as_ref();
-        let value =
-            crate::bridge::client::Methods::injected_env_var(key).map_or_else(|| env::var(key), Ok);
-        crate::bridge::client::Methods::track_env_var(key, value.as_deref().ok());
+        let value = BridgeMethods::injected_env_var(key).map_or_else(|| env::var(key), Ok);
+        BridgeMethods::track_env_var(key, value.as_deref().ok());
         value
     }
 
@@ -1636,6 +1634,6 @@ pub mod tracked {
     #[unstable(feature = "proc_macro_tracked_path", issue = "99515")]
     pub fn path<P: AsRef<Path>>(path: P) {
         let path: &str = path.as_ref().to_str().unwrap();
-        crate::bridge::client::Methods::track_path(path);
+        BridgeMethods::track_path(path);
     }
 }

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -509,6 +509,12 @@ impl Step for RustAnalyzer {
         cargo.arg("--workspace");
         cargo.arg("--exclude=xtask");
 
+        if build_compiler.stage == 0 {
+            // This builds a proc macro against the bootstrap libproc_macro, which is not ABI
+            // compatible with the ABI proc-macro-srv expects to load.
+            cargo.arg("--exclude=proc-macro-srv");
+        }
+
         let mut skip_tests = vec![];
 
         // NOTE: the following test skips is a bit cheeky in that it assumes there are no

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/bridge.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/bridge.rs
@@ -1,6 +1,6 @@
 //! `proc_macro::bridge` newtypes.
 
-use proc_macro::bridge as pm_bridge;
+use rustc_proc_macro::bridge as pm_bridge;
 
 pub use pm_bridge::{DelimSpan, Diagnostic, ExpnGlobals, LitKind};
 

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/dylib.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/dylib.rs
@@ -3,7 +3,7 @@
 mod proc_macros;
 mod version;
 
-use proc_macro::bridge;
+use rustc_proc_macro::bridge;
 use std::{fmt, fs, io, time::SystemTime};
 use temp_dir::TempDir;
 

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/dylib/proc_macros.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/dylib/proc_macros.rs
@@ -1,6 +1,6 @@
 //! Proc macro ABI
 use crate::{ProcMacroClientHandle, ProcMacroKind, ProcMacroSrvSpan, token_stream::TokenStream};
-use proc_macro::bridge;
+use rustc_proc_macro::bridge;
 
 #[repr(transparent)]
 pub(crate) struct ProcMacros([bridge::client::ProcMacro]);

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/lib.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/lib.rs
@@ -22,9 +22,9 @@
 )]
 #![deny(deprecated_safe, clippy::undocumented_unsafe_blocks)]
 
-extern crate proc_macro;
 #[cfg(feature = "in-rust-tree")]
 extern crate rustc_driver as _;
+extern crate rustc_proc_macro;
 
 #[cfg(not(feature = "in-rust-tree"))]
 extern crate ra_ap_rustc_lexer as rustc_lexer;
@@ -52,7 +52,7 @@ use temp_dir::TempDir;
 
 pub use crate::server_impl::token_id::SpanId;
 
-pub use proc_macro::Delimiter;
+pub use rustc_proc_macro::Delimiter;
 pub use span;
 
 pub use crate::bridge::*;
@@ -181,7 +181,9 @@ impl ProcMacroSrv<'_> {
 }
 
 pub trait ProcMacroSrvSpan: Copy + Send + Sync {
-    type Server<'a>: proc_macro::bridge::server::Server<TokenStream = crate::token_stream::TokenStream<Self>>;
+    type Server<'a>: rustc_proc_macro::bridge::server::Server<
+            TokenStream = crate::token_stream::TokenStream<Self>,
+        >;
     fn make_server<'a>(
         call_site: Self,
         def_site: Self,

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/server_impl/rust_analyzer_span.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/server_impl/rust_analyzer_span.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use intern::Symbol;
-use proc_macro::bridge::server;
+use rustc_proc_macro::bridge::server;
 use span::{FIXUP_ERASED_FILE_AST_ID_MARKER, Span, TextRange, TextSize};
 
 use crate::{

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/server_impl/rust_analyzer_span.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/server_impl/rust_analyzer_span.rs
@@ -72,18 +72,18 @@ impl server::Server for RaSpanServer<'_> {
         // FIXME handle diagnostic
     }
 
-    fn tt_drop(&mut self, stream: Self::TokenStream) {
+    fn ts_drop(&mut self, stream: Self::TokenStream) {
         drop(stream);
     }
 
-    fn tt_clone(&mut self, stream: &Self::TokenStream) -> Self::TokenStream {
+    fn ts_clone(&mut self, stream: &Self::TokenStream) -> Self::TokenStream {
         stream.clone()
     }
 
-    fn tt_is_empty(&mut self, stream: &Self::TokenStream) -> bool {
+    fn ts_is_empty(&mut self, stream: &Self::TokenStream) -> bool {
         stream.is_empty()
     }
-    fn tt_from_str(&mut self, src: &str) -> Self::TokenStream {
+    fn ts_from_str(&mut self, src: &str) -> Self::TokenStream {
         Self::TokenStream::from_str(src, self.call_site).unwrap_or_else(|e| {
             Self::TokenStream::from_str(
                 &format!("compile_error!(\"failed to parse str to token stream: {e}\")"),
@@ -92,15 +92,15 @@ impl server::Server for RaSpanServer<'_> {
             .unwrap()
         })
     }
-    fn tt_to_string(&mut self, stream: &Self::TokenStream) -> String {
+    fn ts_to_string(&mut self, stream: &Self::TokenStream) -> String {
         stream.to_string()
     }
 
-    fn tt_from_token_tree(&mut self, tree: TokenTree<Self::Span>) -> Self::TokenStream {
+    fn ts_from_token_tree(&mut self, tree: TokenTree<Self::Span>) -> Self::TokenStream {
         Self::TokenStream::new(vec![tree])
     }
 
-    fn tt_expand_expr(&mut self, self_: &Self::TokenStream) -> Result<Self::TokenStream, ()> {
+    fn ts_expand_expr(&mut self, self_: &Self::TokenStream) -> Result<Self::TokenStream, ()> {
         // FIXME: requires db, more importantly this requires name resolution so we would need to
         // eagerly expand this proc-macro, but we can't know that this proc-macro is eager until we
         // expand it ...
@@ -109,7 +109,7 @@ impl server::Server for RaSpanServer<'_> {
         Ok(self_.clone())
     }
 
-    fn tt_concat_trees(
+    fn ts_concat_trees(
         &mut self,
         base: Option<Self::TokenStream>,
         trees: Vec<TokenTree<Self::Span>>,
@@ -125,7 +125,7 @@ impl server::Server for RaSpanServer<'_> {
         }
     }
 
-    fn tt_concat_streams(
+    fn ts_concat_streams(
         &mut self,
         base: Option<Self::TokenStream>,
         streams: Vec<Self::TokenStream>,
@@ -137,7 +137,7 @@ impl server::Server for RaSpanServer<'_> {
         stream
     }
 
-    fn tt_into_trees(&mut self, stream: Self::TokenStream) -> Vec<TokenTree<Self::Span>> {
+    fn ts_into_trees(&mut self, stream: Self::TokenStream) -> Vec<TokenTree<Self::Span>> {
         (*stream.0).clone()
     }
 

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/server_impl/rust_analyzer_span.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/server_impl/rust_analyzer_span.rs
@@ -58,13 +58,19 @@ impl server::FreeFunctions for RaSpanServer<'_> {
     fn emit_diagnostic(&mut self, _: Diagnostic<Self::Span>) {
         // FIXME handle diagnostic
     }
-}
 
-impl server::TokenStream for RaSpanServer<'_> {
-    fn is_empty(&mut self, stream: &Self::TokenStream) -> bool {
+    fn tt_drop(&mut self, stream: Self::TokenStream) {
+        drop(stream);
+    }
+
+    fn tt_clone(&mut self, stream: &Self::TokenStream) -> Self::TokenStream {
+        stream.clone()
+    }
+
+    fn tt_is_empty(&mut self, stream: &Self::TokenStream) -> bool {
         stream.is_empty()
     }
-    fn from_str(&mut self, src: &str) -> Self::TokenStream {
+    fn tt_from_str(&mut self, src: &str) -> Self::TokenStream {
         Self::TokenStream::from_str(src, self.call_site).unwrap_or_else(|e| {
             Self::TokenStream::from_str(
                 &format!("compile_error!(\"failed to parse str to token stream: {e}\")"),
@@ -73,15 +79,15 @@ impl server::TokenStream for RaSpanServer<'_> {
             .unwrap()
         })
     }
-    fn to_string(&mut self, stream: &Self::TokenStream) -> String {
+    fn tt_to_string(&mut self, stream: &Self::TokenStream) -> String {
         stream.to_string()
     }
 
-    fn from_token_tree(&mut self, tree: TokenTree<Self::Span>) -> Self::TokenStream {
+    fn tt_from_token_tree(&mut self, tree: TokenTree<Self::Span>) -> Self::TokenStream {
         Self::TokenStream::new(vec![tree])
     }
 
-    fn expand_expr(&mut self, self_: &Self::TokenStream) -> Result<Self::TokenStream, ()> {
+    fn tt_expand_expr(&mut self, self_: &Self::TokenStream) -> Result<Self::TokenStream, ()> {
         // FIXME: requires db, more importantly this requires name resolution so we would need to
         // eagerly expand this proc-macro, but we can't know that this proc-macro is eager until we
         // expand it ...
@@ -90,7 +96,7 @@ impl server::TokenStream for RaSpanServer<'_> {
         Ok(self_.clone())
     }
 
-    fn concat_trees(
+    fn tt_concat_trees(
         &mut self,
         base: Option<Self::TokenStream>,
         trees: Vec<TokenTree<Self::Span>>,
@@ -106,7 +112,7 @@ impl server::TokenStream for RaSpanServer<'_> {
         }
     }
 
-    fn concat_streams(
+    fn tt_concat_streams(
         &mut self,
         base: Option<Self::TokenStream>,
         streams: Vec<Self::TokenStream>,
@@ -118,28 +124,26 @@ impl server::TokenStream for RaSpanServer<'_> {
         stream
     }
 
-    fn into_trees(&mut self, stream: Self::TokenStream) -> Vec<TokenTree<Self::Span>> {
+    fn tt_into_trees(&mut self, stream: Self::TokenStream) -> Vec<TokenTree<Self::Span>> {
         (*stream.0).clone()
     }
-}
 
-impl server::Span for RaSpanServer<'_> {
-    fn debug(&mut self, span: Self::Span) -> String {
+    fn span_debug(&mut self, span: Self::Span) -> String {
         format!("{:?}", span)
     }
-    fn file(&mut self, span: Self::Span) -> String {
+    fn span_file(&mut self, span: Self::Span) -> String {
         self.callback.as_mut().map(|cb| cb.file(span.anchor.file_id.file_id())).unwrap_or_default()
     }
-    fn local_file(&mut self, span: Self::Span) -> Option<String> {
+    fn span_local_file(&mut self, span: Self::Span) -> Option<String> {
         self.callback.as_mut().and_then(|cb| cb.local_file(span.anchor.file_id.file_id()))
     }
-    fn save_span(&mut self, _span: Self::Span) -> usize {
+    fn span_save_span(&mut self, _span: Self::Span) -> usize {
         // FIXME, quote is incompatible with third-party tools
         // This is called by the quote proc-macro which is expanded when the proc-macro is compiled
         // As such, r-a will never observe this
         0
     }
-    fn recover_proc_macro_span(&mut self, _id: usize) -> Self::Span {
+    fn span_recover_proc_macro_span(&mut self, _id: usize) -> Self::Span {
         // FIXME, quote is incompatible with third-party tools
         // This is called by the expansion of quote!, r-a will observe this, but we don't have
         // access to the spans that were encoded
@@ -149,23 +153,23 @@ impl server::Span for RaSpanServer<'_> {
     ///
     /// See PR:
     /// https://github.com/rust-lang/rust/pull/55780
-    fn source_text(&mut self, span: Self::Span) -> Option<String> {
+    fn span_source_text(&mut self, span: Self::Span) -> Option<String> {
         self.callback.as_mut()?.source_text(span)
     }
 
-    fn parent(&mut self, _span: Self::Span) -> Option<Self::Span> {
+    fn span_parent(&mut self, _span: Self::Span) -> Option<Self::Span> {
         // FIXME requires db, looks up the parent call site
         None
     }
-    fn source(&mut self, span: Self::Span) -> Self::Span {
+    fn span_source(&mut self, span: Self::Span) -> Self::Span {
         // FIXME requires db, returns the top level call site
         span
     }
-    fn byte_range(&mut self, span: Self::Span) -> Range<usize> {
+    fn span_byte_range(&mut self, span: Self::Span) -> Range<usize> {
         // FIXME requires db to resolve the ast id, THIS IS NOT INCREMENTAL
         Range { start: span.range.start().into(), end: span.range.end().into() }
     }
-    fn join(&mut self, first: Self::Span, second: Self::Span) -> Option<Self::Span> {
+    fn span_join(&mut self, first: Self::Span, second: Self::Span) -> Option<Self::Span> {
         // We can't modify the span range for fixup spans, those are meaningful to fixup, so just
         // prefer the non-fixup span.
         if first.anchor.ast_id == FIXUP_ERASED_FILE_AST_ID_MARKER {
@@ -193,7 +197,7 @@ impl server::Span for RaSpanServer<'_> {
             ctx: second.ctx,
         })
     }
-    fn subspan(
+    fn span_subspan(
         &mut self,
         span: Self::Span,
         start: Bound<usize>,
@@ -237,11 +241,11 @@ impl server::Span for RaSpanServer<'_> {
         })
     }
 
-    fn resolved_at(&mut self, span: Self::Span, at: Self::Span) -> Self::Span {
+    fn span_resolved_at(&mut self, span: Self::Span, at: Self::Span) -> Self::Span {
         Span { ctx: at.ctx, ..span }
     }
 
-    fn end(&mut self, span: Self::Span) -> Self::Span {
+    fn span_end(&mut self, span: Self::Span) -> Self::Span {
         // We can't modify the span range for fixup spans, those are meaningful to fixup.
         if span.anchor.ast_id == FIXUP_ERASED_FILE_AST_ID_MARKER {
             return span;
@@ -249,7 +253,7 @@ impl server::Span for RaSpanServer<'_> {
         Span { range: TextRange::empty(span.range.end()), ..span }
     }
 
-    fn start(&mut self, span: Self::Span) -> Self::Span {
+    fn span_start(&mut self, span: Self::Span) -> Self::Span {
         // We can't modify the span range for fixup spans, those are meaningful to fixup.
         if span.anchor.ast_id == FIXUP_ERASED_FILE_AST_ID_MARKER {
             return span;
@@ -257,23 +261,27 @@ impl server::Span for RaSpanServer<'_> {
         Span { range: TextRange::empty(span.range.start()), ..span }
     }
 
-    fn line(&mut self, _span: Self::Span) -> usize {
+    fn span_line(&mut self, _span: Self::Span) -> usize {
         // FIXME requires db to resolve line index, THIS IS NOT INCREMENTAL
         1
     }
 
-    fn column(&mut self, _span: Self::Span) -> usize {
+    fn span_column(&mut self, _span: Self::Span) -> usize {
         // FIXME requires db to resolve line index, THIS IS NOT INCREMENTAL
         1
     }
-}
 
-impl server::Symbol for RaSpanServer<'_> {
-    fn normalize_and_validate_ident(&mut self, string: &str) -> Result<Self::Symbol, ()> {
+    fn symbol_normalize_and_validate_ident(&mut self, string: &str) -> Result<Self::Symbol, ()> {
         // FIXME: nfc-normalize and validate idents
         Ok(<Self as server::Server>::intern_symbol(string))
     }
 }
+
+impl server::TokenStream for RaSpanServer<'_> {}
+
+impl server::Span for RaSpanServer<'_> {}
+
+impl server::Symbol for RaSpanServer<'_> {}
 
 impl server::Server for RaSpanServer<'_> {
     fn globals(&mut self) -> ExpnGlobals<Self::Span> {

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/server_impl/rust_analyzer_span.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/server_impl/rust_analyzer_span.rs
@@ -277,12 +277,6 @@ impl server::FreeFunctions for RaSpanServer<'_> {
     }
 }
 
-impl server::TokenStream for RaSpanServer<'_> {}
-
-impl server::Span for RaSpanServer<'_> {}
-
-impl server::Symbol for RaSpanServer<'_> {}
-
 impl server::Server for RaSpanServer<'_> {
     fn globals(&mut self) -> ExpnGlobals<Self::Span> {
         ExpnGlobals {

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/server_impl/token_id.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/server_impl/token_id.rs
@@ -196,12 +196,6 @@ impl server::FreeFunctions for SpanIdServer<'_> {
     }
 }
 
-impl server::TokenStream for SpanIdServer<'_> {}
-
-impl server::Span for SpanIdServer<'_> {}
-
-impl server::Symbol for SpanIdServer<'_> {}
-
 impl server::Server for SpanIdServer<'_> {
     fn globals(&mut self) -> ExpnGlobals<Self::Span> {
         ExpnGlobals {

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/server_impl/token_id.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/server_impl/token_id.rs
@@ -75,18 +75,18 @@ impl server::Server for SpanIdServer<'_> {
 
     fn emit_diagnostic(&mut self, _: Diagnostic<Self::Span>) {}
 
-    fn tt_drop(&mut self, stream: Self::TokenStream) {
+    fn ts_drop(&mut self, stream: Self::TokenStream) {
         drop(stream);
     }
 
-    fn tt_clone(&mut self, stream: &Self::TokenStream) -> Self::TokenStream {
+    fn ts_clone(&mut self, stream: &Self::TokenStream) -> Self::TokenStream {
         stream.clone()
     }
 
-    fn tt_is_empty(&mut self, stream: &Self::TokenStream) -> bool {
+    fn ts_is_empty(&mut self, stream: &Self::TokenStream) -> bool {
         stream.is_empty()
     }
-    fn tt_from_str(&mut self, src: &str) -> Self::TokenStream {
+    fn ts_from_str(&mut self, src: &str) -> Self::TokenStream {
         Self::TokenStream::from_str(src, self.call_site).unwrap_or_else(|e| {
             Self::TokenStream::from_str(
                 &format!("compile_error!(\"failed to parse str to token stream: {e}\")"),
@@ -95,18 +95,18 @@ impl server::Server for SpanIdServer<'_> {
             .unwrap()
         })
     }
-    fn tt_to_string(&mut self, stream: &Self::TokenStream) -> String {
+    fn ts_to_string(&mut self, stream: &Self::TokenStream) -> String {
         stream.to_string()
     }
-    fn tt_from_token_tree(&mut self, tree: TokenTree<Self::Span>) -> Self::TokenStream {
+    fn ts_from_token_tree(&mut self, tree: TokenTree<Self::Span>) -> Self::TokenStream {
         Self::TokenStream::new(vec![tree])
     }
 
-    fn tt_expand_expr(&mut self, self_: &Self::TokenStream) -> Result<Self::TokenStream, ()> {
+    fn ts_expand_expr(&mut self, self_: &Self::TokenStream) -> Result<Self::TokenStream, ()> {
         Ok(self_.clone())
     }
 
-    fn tt_concat_trees(
+    fn ts_concat_trees(
         &mut self,
         base: Option<Self::TokenStream>,
         trees: Vec<TokenTree<Self::Span>>,
@@ -122,7 +122,7 @@ impl server::Server for SpanIdServer<'_> {
         }
     }
 
-    fn tt_concat_streams(
+    fn ts_concat_streams(
         &mut self,
         base: Option<Self::TokenStream>,
         streams: Vec<Self::TokenStream>,
@@ -134,7 +134,7 @@ impl server::Server for SpanIdServer<'_> {
         stream
     }
 
-    fn tt_into_trees(&mut self, stream: Self::TokenStream) -> Vec<TokenTree<Self::Span>> {
+    fn ts_into_trees(&mut self, stream: Self::TokenStream) -> Vec<TokenTree<Self::Span>> {
         (*stream.0).clone()
     }
 

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/server_impl/token_id.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/server_impl/token_id.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use intern::Symbol;
-use proc_macro::bridge::server;
+use rustc_proc_macro::bridge::server;
 
 use crate::{
     ProcMacroClientHandle,

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/token_stream.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/token_stream.rs
@@ -4,8 +4,8 @@ use core::fmt;
 use std::{mem, sync::Arc};
 
 use intern::Symbol;
-use proc_macro::Delimiter;
 use rustc_lexer::{DocStyle, LiteralKind};
+use rustc_proc_macro::Delimiter;
 
 use crate::bridge::{DelimSpan, Group, Ident, LitKind, Literal, Punct, TokenTree};
 
@@ -52,7 +52,7 @@ impl<S> TokenStream<S> {
         S: SpanLike + Copy,
     {
         let mut groups = Vec::new();
-        groups.push((proc_macro::Delimiter::None, 0..0, vec![]));
+        groups.push((rustc_proc_macro::Delimiter::None, 0..0, vec![]));
         let mut offset = 0;
         let mut tokens = rustc_lexer::tokenize(s, rustc_lexer::FrontmatterAllowed::No).peekable();
         while let Some(token) = tokens.next() {
@@ -102,7 +102,7 @@ impl<S> TokenStream<S> {
             };
             match token.kind {
                 rustc_lexer::TokenKind::OpenParen => {
-                    groups.push((proc_macro::Delimiter::Parenthesis, range, vec![]))
+                    groups.push((rustc_proc_macro::Delimiter::Parenthesis, range, vec![]))
                 }
                 rustc_lexer::TokenKind::CloseParen if *open_delim != Delimiter::Parenthesis => {
                     return if *open_delim == Delimiter::None {
@@ -130,7 +130,7 @@ impl<S> TokenStream<S> {
                     );
                 }
                 rustc_lexer::TokenKind::OpenBrace => {
-                    groups.push((proc_macro::Delimiter::Brace, range, vec![]))
+                    groups.push((rustc_proc_macro::Delimiter::Brace, range, vec![]))
                 }
                 rustc_lexer::TokenKind::CloseBrace if *open_delim != Delimiter::Brace => {
                     return if *open_delim == Delimiter::None {
@@ -158,7 +158,7 @@ impl<S> TokenStream<S> {
                     );
                 }
                 rustc_lexer::TokenKind::OpenBracket => {
-                    groups.push((proc_macro::Delimiter::Bracket, range, vec![]))
+                    groups.push((rustc_proc_macro::Delimiter::Bracket, range, vec![]))
                 }
                 rustc_lexer::TokenKind::CloseBracket if *open_delim != Delimiter::Bracket => {
                     return if *open_delim == Delimiter::None {
@@ -460,10 +460,10 @@ fn display_token_tree<S>(
                 f,
                 "{}",
                 match delimiter {
-                    proc_macro::Delimiter::Parenthesis => "(",
-                    proc_macro::Delimiter::Brace => "{",
-                    proc_macro::Delimiter::Bracket => "[",
-                    proc_macro::Delimiter::None => "",
+                    rustc_proc_macro::Delimiter::Parenthesis => "(",
+                    rustc_proc_macro::Delimiter::Brace => "{",
+                    rustc_proc_macro::Delimiter::Bracket => "[",
+                    rustc_proc_macro::Delimiter::None => "",
                 }
             )?;
             if let Some(stream) = stream {
@@ -473,10 +473,10 @@ fn display_token_tree<S>(
                 f,
                 "{}",
                 match delimiter {
-                    proc_macro::Delimiter::Parenthesis => ")",
-                    proc_macro::Delimiter::Brace => "}",
-                    proc_macro::Delimiter::Bracket => "]",
-                    proc_macro::Delimiter::None => "",
+                    rustc_proc_macro::Delimiter::Parenthesis => ")",
+                    rustc_proc_macro::Delimiter::Brace => "}",
+                    rustc_proc_macro::Delimiter::Bracket => "]",
+                    rustc_proc_macro::Delimiter::None => "",
                 }
             )?;
         }
@@ -587,16 +587,16 @@ fn debug_token_tree<S: fmt::Debug>(
                 f,
                 "GROUP {}{} {:#?} {:#?} {:#?}",
                 match delimiter {
-                    proc_macro::Delimiter::Parenthesis => "(",
-                    proc_macro::Delimiter::Brace => "{",
-                    proc_macro::Delimiter::Bracket => "[",
-                    proc_macro::Delimiter::None => "$",
+                    rustc_proc_macro::Delimiter::Parenthesis => "(",
+                    rustc_proc_macro::Delimiter::Brace => "{",
+                    rustc_proc_macro::Delimiter::Bracket => "[",
+                    rustc_proc_macro::Delimiter::None => "$",
                 },
                 match delimiter {
-                    proc_macro::Delimiter::Parenthesis => ")",
-                    proc_macro::Delimiter::Brace => "}",
-                    proc_macro::Delimiter::Bracket => "]",
-                    proc_macro::Delimiter::None => "$",
+                    rustc_proc_macro::Delimiter::Parenthesis => ")",
+                    rustc_proc_macro::Delimiter::Brace => "}",
+                    rustc_proc_macro::Delimiter::Bracket => "]",
+                    rustc_proc_macro::Delimiter::None => "$",
                 },
                 span.open,
                 span.close,


### PR DESCRIPTION
This reduces the amount of types, traits and other abstractions that are involved with the bridge, which should make it easier to understand and modify. This should also help a bit with getting rid of the type marking hack, which is complicating the code a fair bit.

Fixes: rust-lang/rust#139810