### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -3300,8 +3300,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             };
             if let Some(diagnostic_name) = self.tcx.get_diagnostic_name(trait_pred.def_id()) {
                 let can_derive = match diagnostic_name {
-                    sym::Default => !adt.is_enum(),
-                    sym::Eq
+                    sym::Default
+                    | sym::Eq
                     | sym::PartialEq
                     | sym::Ord
                     | sym::PartialOrd

--- a/src/doc/rustc-dev-guide/src/debuginfo/lldb-visualizers.md
+++ b/src/doc/rustc-dev-guide/src/debuginfo/lldb-visualizers.md
@@ -2,7 +2,7 @@
 
 > NOTE: LLDB's C++<->Python FFI expects a version of python designated at the time LLDB was
 >compiled. LLDB is careful to correspond this version to the minimum in typical Linux and macOS
->distributions, but on Windows there is no easy solution. If you recieve an import error regarding
+>distributions, but on Windows there is no easy solution. If you receive an import error regarding
 >`_lldb` not existing, a mismatched Python version is likely the cause.
 >
 > LLDB is considering solutions this issue. For updates, see

--- a/tests/ui/simd/extern-static-zero-length.rs
+++ b/tests/ui/simd/extern-static-zero-length.rs
@@ -1,0 +1,13 @@
+#![feature(repr_simd)]
+
+#[repr(simd)]
+struct Simd<T, const N: usize>([T; N]);
+
+unsafe extern "C" {
+    static VAR: Simd<u8, 0>;
+    //~^ ERROR the SIMD type `Simd<u8, 0>` has zero elements
+    static VAR2: Simd<u8, 1_000_000>;
+    //~^ ERROR the SIMD type `Simd<u8, 1000000>` has more elements than the limit 32768
+}
+
+fn main() {}

--- a/tests/ui/simd/extern-static-zero-length.stderr
+++ b/tests/ui/simd/extern-static-zero-length.stderr
@@ -1,0 +1,14 @@
+error: the SIMD type `Simd<u8, 0>` has zero elements
+  --> $DIR/extern-static-zero-length.rs:7:17
+   |
+LL |     static VAR: Simd<u8, 0>;
+   |                 ^^^^^^^^^^^
+
+error: the SIMD type `Simd<u8, 1000000>` has more elements than the limit 32768
+  --> $DIR/extern-static-zero-length.rs:9:18
+   |
+LL |     static VAR2: Simd<u8, 1_000_000>;
+   |                  ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/suggestions/derive-trait-for-method-call.stderr
+++ b/tests/ui/suggestions/derive-trait-for-method-call.stderr
@@ -25,11 +25,14 @@ LL | impl<X: Clone + Default + , Y: Clone + Default> Foo<X, Y> {
    |         |       |                      unsatisfied trait bound introduced here
    |         |       unsatisfied trait bound introduced here
    |         unsatisfied trait bound introduced here
-note: the trait `Default` must be implemented
-  --> $SRC_DIR/core/src/default.rs:LL:COL
-help: consider annotating `Enum` with `#[derive(Clone)]`
+help: consider annotating `CloneEnum` with `#[derive(Default)]`
    |
-LL + #[derive(Clone)]
+LL + #[derive(Default)]
+LL | enum CloneEnum {
+   |
+help: consider annotating `Enum` with `#[derive(Clone, Default)]`
+   |
+LL + #[derive(Clone, Default)]
 LL | enum Enum {
    |
 

--- a/tests/ui/suggestions/suggest-derive-default-for-enums.rs
+++ b/tests/ui/suggestions/suggest-derive-default-for-enums.rs
@@ -1,0 +1,15 @@
+// A test showing that we suggest deriving `Default` for enums.
+enum MyEnum {
+    A,
+}
+
+trait Foo {
+    fn bar(&self) {}
+}
+impl<T: Default> Foo for T {}
+
+fn main() {
+    let x = MyEnum::A;
+    x.bar();
+    //~^ ERROR the method `bar` exists for enum `MyEnum`, but its trait bounds were not satisfied
+}

--- a/tests/ui/suggestions/suggest-derive-default-for-enums.stderr
+++ b/tests/ui/suggestions/suggest-derive-default-for-enums.stderr
@@ -1,0 +1,25 @@
+error[E0599]: the method `bar` exists for enum `MyEnum`, but its trait bounds were not satisfied
+  --> $DIR/suggest-derive-default-for-enums.rs:13:7
+   |
+LL | enum MyEnum {
+   | ----------- method `bar` not found for this enum because it doesn't satisfy `MyEnum: Default` or `MyEnum: Foo`
+...
+LL |     x.bar();
+   |       ^^^ method cannot be called on `MyEnum` due to unsatisfied trait bounds
+   |
+note: trait bound `MyEnum: Default` was not satisfied
+  --> $DIR/suggest-derive-default-for-enums.rs:9:9
+   |
+LL | impl<T: Default> Foo for T {}
+   |         ^^^^^^^  ---     -
+   |         |
+   |         unsatisfied trait bound introduced here
+help: consider annotating `MyEnum` with `#[derive(Default)]`
+   |
+LL + #[derive(Default)]
+LL | enum MyEnum {
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#151412 (diagnostics: suggest deriving Default for enums)
 - rust-lang/rust#151495 (Fix ICE when using zero-length SIMD type in extern static)
 - rust-lang/rust#151497 (Fix typo: 'recieve' -> 'receive' in lldb-visualizers.md)

r? @ghost

<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=151412,151495,151497)
<!-- homu-ignore:end -->

