### PR TITLE
Fix debug assertion ICE in suggest_remove_deref with empty span

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -2858,13 +2858,17 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 && tcx.is_lang_item(pred.def_id(), LangItem::Sized)
                 && let hir::ExprKind::Unary(hir::UnOp::Deref, inner) = expr.kind
             {
-                err.span_suggestion_verbose(
-                    expr.span.until(inner.span),
-                    "references are always `Sized`, even if they point to unsized data; consider \
-                     not dereferencing the expression",
-                    String::new(),
-                    Applicability::MaybeIncorrect,
-                );
+                // Empty suggestions with empty spans ICE with debug assertions
+                let span = expr.span.until(inner.span);
+                if !span.is_empty() {
+                    err.span_suggestion_verbose(
+                        span,
+                        "references are always `Sized`, even if they point to unsized data; consider \
+                         not dereferencing the expression",
+                        String::new(),
+                        Applicability::MaybeIncorrect,
+                    );
+                }
             }
         };
         match *cause_code {

--- a/tests/ui/proc-macro/auxiliary/same-span-deref.rs
+++ b/tests/ui/proc-macro/auxiliary/same-span-deref.rs
@@ -1,0 +1,21 @@
+extern crate proc_macro;
+use proc_macro::{Punct, Spacing, TokenStream, TokenTree};
+
+#[proc_macro]
+pub fn same_span_deref(input: TokenStream) -> TokenStream {
+    let mut result = Vec::new();
+
+    let first_token = input.clone().into_iter().next().expect("need at least one token");
+    let span = first_token.span();
+
+    // Create a `*` with the same span as the input expression.
+    // This makes expr.span.lo == inner.span.lo, so `expr.span.until(inner.span)`
+    // produces an empty span.
+    let mut star = Punct::new('*', Spacing::Alone);
+    star.set_span(span);
+
+    result.push(TokenTree::Punct(star));
+    result.extend(input);
+
+    result.into_iter().collect()
+}

--- a/tests/ui/proc-macro/same-span-deref-ice.rs
+++ b/tests/ui/proc-macro/same-span-deref-ice.rs
@@ -1,0 +1,11 @@
+//@ proc-macro: same-span-deref.rs
+
+extern crate same_span_deref;
+
+fn needs_sized<T: Sized>(_: T) {}
+
+fn main() {
+    let s: &str = "hello";
+    needs_sized(same_span_deref::same_span_deref!(s));
+    //~^ ERROR the size for values of type `str` cannot be known at compilation time
+}

--- a/tests/ui/proc-macro/same-span-deref-ice.stderr
+++ b/tests/ui/proc-macro/same-span-deref-ice.stderr
@@ -1,0 +1,18 @@
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/same-span-deref-ice.rs:9:51
+   |
+LL |     needs_sized(same_span_deref::same_span_deref!(s));
+   |     -----------                                   ^ doesn't have a size known at compile-time
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `str`
+note: required by a bound in `needs_sized`
+  --> $DIR/same-span-deref-ice.rs:5:19
+   |
+LL | fn needs_sized<T: Sized>(_: T) {}
+   |                   ^^^^^ required by this bound in `needs_sized`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
This fixes a debug assertion ICE in `suggest_remove_deref` when a proc macro creates a dereference expression with overlapping spans.

When the `*` token shares the same span as the inner expression, `expr.span.until(inner.span)` produces an empty span, which combined with an empty suggestion string triggers the debug assertion in `diagnostic.rs`.

This can be triggered with a proc macro like:

```rust
#[proc_macro]
pub fn same_span_deref(input: TokenStream) -> TokenStream {
    let first_token = input.clone().into_iter().next().unwrap();
    let span = first_token.span();
    let mut star = Punct::new('*', Spacing::Alone);
    star.set_span(span); // * now has same span as inner expr

    let mut result = vec![TokenTree::Punct(star)];
    result.extend(input);
    result.into_iter().collect()
}
```

And the following code:

```rust
fn needs_sized<T: Sized>(_: T) {}

fn main() {
    let s: &str = "hello";
    needs_sized(same_span_deref!(s)); // ICE: "Span must not be empty and have no suggestion"
}
```

The fix adds an `is_empty()` guard following several existing guards in the same file:
https://github.com/rust-lang/rust/blob/0f145634fc31775477c538c532307213109599ac/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs#L686-L689

 I can provide a full runnable PoC if needed.

Thanks for looking into this!
