### PR TITLE
fix(doc): remove incorrect “available on 64-bit only” portability note on [iu]size

### DIFF
--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1329,95 +1329,99 @@ impl u128 {
     carrying_carryless_mul_impl! { u128, u256 }
 }
 
-#[cfg(target_pointer_width = "16")]
 impl usize {
     uint_impl! {
         Self = usize,
-        ActualT = u16,
         SignedT = isize,
-        BITS = 16,
-        BITS_MINUS_ONE = 15,
-        MAX = 65535,
-        rot = 4,
-        rot_op = "0xa003",
-        rot_result = "0x3a",
-        fsh_op = "0x2de",
-        fshl_result = "0x30",
-        fshr_result = "0x302d",
-        clmul_lhs = "0x9012",
-        clmul_rhs = "0xcd34",
-        clmul_result = "0x928",
-        swap_op = "0x1234",
-        swapped = "0x3412",
-        reversed = "0x2c48",
-        le_bytes = "[0x34, 0x12]",
-        be_bytes = "[0x12, 0x34]",
-        to_xe_bytes_doc = usize_isize_to_xe_bytes_doc!(),
-        from_xe_bytes_doc = usize_isize_from_xe_bytes_doc!(),
-        bound_condition = " on 16-bit targets",
+
+        #[cfg(target_pointer_width = "16")] {
+            ActualT = u16,
+            BITS = 16,
+            BITS_MINUS_ONE = 15,
+            MAX = 65535,
+            rot = 4,
+            rot_op = "0xa003",
+            rot_result = "0x3a",
+            fsh_op = "0x2de",
+            fshl_result = "0x30",
+            fshr_result = "0x302d",
+            clmul_lhs = "0x9012",
+            clmul_rhs = "0xcd34",
+            clmul_result = "0x928",
+            swap_op = "0x1234",
+            swapped = "0x3412",
+            reversed = "0x2c48",
+            le_bytes = "[0x34, 0x12]",
+            be_bytes = "[0x12, 0x34]",
+            to_xe_bytes_doc = usize_isize_to_xe_bytes_doc!(),
+            from_xe_bytes_doc = usize_isize_from_xe_bytes_doc!(),
+            bound_condition = " on 16-bit targets",
+        },
+
+        #[cfg(target_pointer_width = "32")] {
+            ActualT = u32,
+            BITS = 32,
+            BITS_MINUS_ONE = 31,
+            MAX = 4294967295,
+            rot = 8,
+            rot_op = "0x10000b3",
+            rot_result = "0xb301",
+            fsh_op = "0x2fe78e45",
+            fshl_result = "0xb32f",
+            fshr_result = "0xb32fe78e",
+            clmul_lhs = "0x56789012",
+            clmul_rhs = "0xf52ecd34",
+            clmul_result = "0x9b980928",
+            swap_op = "0x12345678",
+            swapped = "0x78563412",
+            reversed = "0x1e6a2c48",
+            le_bytes = "[0x78, 0x56, 0x34, 0x12]",
+            be_bytes = "[0x12, 0x34, 0x56, 0x78]",
+            to_xe_bytes_doc = usize_isize_to_xe_bytes_doc!(),
+            from_xe_bytes_doc = usize_isize_from_xe_bytes_doc!(),
+            bound_condition = " on 32-bit targets",
+        },
+
+        #[cfg(target_pointer_width = "64")] {
+            ActualT = u64,
+            BITS = 64,
+            BITS_MINUS_ONE = 63,
+            MAX = 18446744073709551615,
+            rot = 12,
+            rot_op = "0xaa00000000006e1",
+            rot_result = "0x6e10aa",
+            fsh_op = "0x2fe78e45983acd98",
+            fshl_result = "0x6e12fe",
+            fshr_result = "0x6e12fe78e45983ac",
+            clmul_lhs = "0x7890123456789012",
+            clmul_rhs = "0xdd358416f52ecd34",
+            clmul_result = "0xa6299579b980928",
+            swap_op = "0x1234567890123456",
+            swapped = "0x5634129078563412",
+            reversed = "0x6a2c48091e6a2c48",
+            le_bytes = "[0x56, 0x34, 0x12, 0x90, 0x78, 0x56, 0x34, 0x12]",
+            be_bytes = "[0x12, 0x34, 0x56, 0x78, 0x90, 0x12, 0x34, 0x56]",
+            to_xe_bytes_doc = usize_isize_to_xe_bytes_doc!(),
+            from_xe_bytes_doc = usize_isize_from_xe_bytes_doc!(),
+            bound_condition = " on 64-bit targets",
+        }
     }
+}
+
+#[cfg(target_pointer_width = "16")]
+impl usize {
     midpoint_impl! { usize, u32, unsigned }
     carrying_carryless_mul_impl! { usize, u32 }
 }
 
 #[cfg(target_pointer_width = "32")]
 impl usize {
-    uint_impl! {
-        Self = usize,
-        ActualT = u32,
-        SignedT = isize,
-        BITS = 32,
-        BITS_MINUS_ONE = 31,
-        MAX = 4294967295,
-        rot = 8,
-        rot_op = "0x10000b3",
-        rot_result = "0xb301",
-        fsh_op = "0x2fe78e45",
-        fshl_result = "0xb32f",
-        fshr_result = "0xb32fe78e",
-        clmul_lhs = "0x56789012",
-        clmul_rhs = "0xf52ecd34",
-        clmul_result = "0x9b980928",
-        swap_op = "0x12345678",
-        swapped = "0x78563412",
-        reversed = "0x1e6a2c48",
-        le_bytes = "[0x78, 0x56, 0x34, 0x12]",
-        be_bytes = "[0x12, 0x34, 0x56, 0x78]",
-        to_xe_bytes_doc = usize_isize_to_xe_bytes_doc!(),
-        from_xe_bytes_doc = usize_isize_from_xe_bytes_doc!(),
-        bound_condition = " on 32-bit targets",
-    }
     midpoint_impl! { usize, u64, unsigned }
     carrying_carryless_mul_impl! { usize, u64 }
 }
 
 #[cfg(target_pointer_width = "64")]
 impl usize {
-    uint_impl! {
-        Self = usize,
-        ActualT = u64,
-        SignedT = isize,
-        BITS = 64,
-        BITS_MINUS_ONE = 63,
-        MAX = 18446744073709551615,
-        rot = 12,
-        rot_op = "0xaa00000000006e1",
-        rot_result = "0x6e10aa",
-        fsh_op = "0x2fe78e45983acd98",
-        fshl_result = "0x6e12fe",
-        fshr_result = "0x6e12fe78e45983ac",
-        clmul_lhs = "0x7890123456789012",
-        clmul_rhs = "0xdd358416f52ecd34",
-        clmul_result = "0xa6299579b980928",
-        swap_op = "0x1234567890123456",
-        swapped = "0x5634129078563412",
-        reversed = "0x6a2c48091e6a2c48",
-        le_bytes = "[0x56, 0x34, 0x12, 0x90, 0x78, 0x56, 0x34, 0x12]",
-        be_bytes = "[0x12, 0x34, 0x56, 0x78, 0x90, 0x12, 0x34, 0x56]",
-        to_xe_bytes_doc = usize_isize_to_xe_bytes_doc!(),
-        from_xe_bytes_doc = usize_isize_from_xe_bytes_doc!(),
-        bound_condition = " on 64-bit targets",
-    }
     midpoint_impl! { usize, u128, unsigned }
     carrying_carryless_mul_impl! { usize, u128 }
 }

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -29,6 +29,69 @@ macro_rules! uint_impl {
         from_xe_bytes_doc = $from_xe_bytes_doc:expr,
         bound_condition = $bound_condition:literal,
     ) => {
+        uint_impl! {
+            Self = $SelfT,
+            SignedT = $SignedT,
+
+            #[cfg(true)] {
+                ActualT = $ActualT,
+                BITS = $BITS,
+                BITS_MINUS_ONE = $BITS_MINUS_ONE,
+                MAX = $MaxV,
+                rot = $rot,
+                rot_op = $rot_op,
+                rot_result = $rot_result,
+                fsh_op = $fsh_op,
+                fshl_result = $fshl_result,
+                fshr_result = $fshr_result,
+                clmul_lhs = $clmul_lhs,
+                clmul_rhs = $clmul_rhs,
+                clmul_result = $clmul_result,
+                swap_op = $swap_op,
+                swapped = $swapped,
+                reversed = $reversed,
+                le_bytes = $le_bytes,
+                be_bytes = $be_bytes,
+                to_xe_bytes_doc = $to_xe_bytes_doc,
+                from_xe_bytes_doc = $from_xe_bytes_doc,
+                bound_condition = $bound_condition,
+            }
+        }
+    };
+
+    (
+        Self = $SelfT:ty,
+        SignedT = $SignedT:ident,
+
+        $(#[cfg($Pred:expr)] {
+            ActualT = $ActualT:ident,
+
+            // These are all for use *only* in doc comments.
+            // As such, they're all passed as literals -- passing them as a string
+            // literal is fine if they need to be multiple code tokens.
+            // In non-comments, use the associated constants rather than these.
+            BITS = $BITS:literal,
+            BITS_MINUS_ONE = $BITS_MINUS_ONE:literal,
+            MAX = $MaxV:literal,
+            rot = $rot:literal,
+            rot_op = $rot_op:literal,
+            rot_result = $rot_result:literal,
+            fsh_op = $fsh_op:literal,
+            fshl_result = $fshl_result:literal,
+            fshr_result = $fshr_result:literal,
+            clmul_lhs = $clmul_lhs:literal,
+            clmul_rhs = $clmul_rhs:literal,
+            clmul_result = $clmul_result:literal,
+            swap_op = $swap_op:literal,
+            swapped = $swapped:literal,
+            reversed = $reversed:literal,
+            le_bytes = $le_bytes:literal,
+            be_bytes = $be_bytes:literal,
+            to_xe_bytes_doc = $to_xe_bytes_doc:expr,
+            from_xe_bytes_doc = $from_xe_bytes_doc:expr,
+            bound_condition = $bound_condition:literal,
+        }),+
+    ) => {
         /// The smallest value that can be represented by this integer type.
         ///
         /// # Examples

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -214,7 +214,9 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline(always)]
         pub const fn leading_zeros(self) -> u32 {
-            return intrinsics::ctlz(self as $ActualT);
+            $(#[cfg($Pred)] {
+                return intrinsics::ctlz(self as $ActualT);
+            })+
         }
 
         /// Returns the number of trailing zeros in the binary representation
@@ -563,11 +565,13 @@ macro_rules! uint_impl {
         #[inline(always)]
         #[track_caller]
         pub const unsafe fn unchecked_funnel_shl(self, low: Self, n: u32) -> Self {
-            assert_unsafe_precondition!(
-                check_language_ub,
-                concat!(stringify!($SelfT), "::unchecked_funnel_shl cannot overflow"),
-                (n: u32 = n) => n < <$ActualT>::BITS,
-            );
+            $(#[cfg($Pred)] {
+                assert_unsafe_precondition!(
+                    check_language_ub,
+                    concat!(stringify!($SelfT), "::unchecked_funnel_shl cannot overflow"),
+                    (n: u32 = n) => n < <$ActualT>::BITS,
+                );
+            })+
 
             // SAFETY: this is guaranteed to be safe by the caller.
             unsafe {
@@ -590,11 +594,13 @@ macro_rules! uint_impl {
         #[inline(always)]
         #[track_caller]
         pub const unsafe fn unchecked_funnel_shr(self, low: Self, n: u32) -> Self {
-            assert_unsafe_precondition!(
-                check_language_ub,
-                concat!(stringify!($SelfT), "::unchecked_funnel_shr cannot overflow"),
-                (n: u32 = n) => n < <$ActualT>::BITS,
-            );
+            $(#[cfg($Pred)] {
+                assert_unsafe_precondition!(
+                    check_language_ub,
+                    concat!(stringify!($SelfT), "::unchecked_funnel_shr cannot overflow"),
+                    (n: u32 = n) => n < <$ActualT>::BITS,
+                );
+            })+
 
             // SAFETY: this is guaranteed to be safe by the caller.
             unsafe {
@@ -674,7 +680,9 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline(always)]
         pub const fn swap_bytes(self) -> Self {
-            intrinsics::bswap(self as $ActualT) as Self
+            $(#[cfg($Pred)] {
+                intrinsics::bswap(self as $ActualT) as Self
+            })+
         }
 
         /// Returns an integer with the bit locations specified by `mask` packed
@@ -691,7 +699,9 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline]
         pub const fn extract_bits(self, mask: Self) -> Self {
-            imp::int_bits::$ActualT::extract_impl(self as $ActualT, mask as $ActualT) as $SelfT
+            $(#[cfg($Pred)] {
+                imp::int_bits::$ActualT::extract_impl(self as $ActualT, mask as $ActualT) as $SelfT
+            })+
         }
 
         /// Returns an integer with the least significant bits of `self`
@@ -708,7 +718,9 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline]
         pub const fn deposit_bits(self, mask: Self) -> Self {
-            imp::int_bits::$ActualT::deposit_impl(self as $ActualT, mask as $ActualT) as $SelfT
+            $(#[cfg($Pred)] {
+                imp::int_bits::$ActualT::deposit_impl(self as $ActualT, mask as $ActualT) as $SelfT
+            })+
         }
 
         /// Reverses the order of bits in the integer. The least significant bit becomes the most significant bit,
@@ -729,7 +741,9 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline(always)]
         pub const fn reverse_bits(self) -> Self {
-            intrinsics::bitreverse(self as $ActualT) as Self
+            $(#[cfg($Pred)] {
+                intrinsics::bitreverse(self as $ActualT) as Self
+            })+
         }
 
         /// Converts an integer from big endian to the target's endianness.
@@ -2020,13 +2034,15 @@ macro_rules! uint_impl {
         #[inline(always)]
         #[track_caller]
         pub const unsafe fn unchecked_shl(self, rhs: u32) -> Self {
-            assert_unsafe_precondition!(
-                check_language_ub,
-                concat!(stringify!($SelfT), "::unchecked_shl cannot overflow"),
-                (
-                    rhs: u32 = rhs,
-                ) => rhs < <$ActualT>::BITS,
-            );
+            $(#[cfg($Pred)] {
+                assert_unsafe_precondition!(
+                    check_language_ub,
+                    concat!(stringify!($SelfT), "::unchecked_shl cannot overflow"),
+                    (
+                        rhs: u32 = rhs,
+                    ) => rhs < <$ActualT>::BITS,
+                );
+            })+
 
             // SAFETY: this is guaranteed to be safe by the caller.
             unsafe {
@@ -2205,13 +2221,15 @@ macro_rules! uint_impl {
         #[inline(always)]
         #[track_caller]
         pub const unsafe fn unchecked_shr(self, rhs: u32) -> Self {
-            assert_unsafe_precondition!(
-                check_language_ub,
-                concat!(stringify!($SelfT), "::unchecked_shr cannot overflow"),
-                (
-                    rhs: u32 = rhs,
-                ) => rhs < <$ActualT>::BITS,
-            );
+            $(#[cfg($Pred)] {
+                assert_unsafe_precondition!(
+                    check_language_ub,
+                    concat!(stringify!($SelfT), "::unchecked_shr cannot overflow"),
+                    (
+                        rhs: u32 = rhs,
+                    ) => rhs < <$ActualT>::BITS,
+                );
+            })+
 
             // SAFETY: this is guaranteed to be safe by the caller.
             unsafe {
@@ -2943,8 +2961,10 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline(always)]
         pub const fn overflowing_add(self, rhs: Self) -> (Self, bool) {
-            let (a, b) = intrinsics::add_with_overflow(self as $ActualT, rhs as $ActualT);
-            (a as Self, b)
+            $(#[cfg($Pred)] {
+                let (a, b) = intrinsics::add_with_overflow(self as $ActualT, rhs as $ActualT);
+                (a as Self, b)
+            })+
         }
 
         /// Calculates `self` + `rhs` + `carry` and returns a tuple containing
@@ -3042,8 +3062,10 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline(always)]
         pub const fn overflowing_sub(self, rhs: Self) -> (Self, bool) {
-            let (a, b) = intrinsics::sub_with_overflow(self as $ActualT, rhs as $ActualT);
-            (a as Self, b)
+            $(#[cfg($Pred)] {
+                let (a, b) = intrinsics::sub_with_overflow(self as $ActualT, rhs as $ActualT);
+                (a as Self, b)
+            })+
         }
 
         /// Calculates `self` &minus; `rhs` &minus; `borrow` and returns a tuple
@@ -3165,8 +3187,10 @@ macro_rules! uint_impl {
                           without modifying the original"]
         #[inline(always)]
         pub const fn overflowing_mul(self, rhs: Self) -> (Self, bool) {
-            let (a, b) = intrinsics::mul_with_overflow(self as $ActualT, rhs as $ActualT);
-            (a as Self, b)
+            $(#[cfg($Pred)] {
+                let (a, b) = intrinsics::mul_with_overflow(self as $ActualT, rhs as $ActualT);
+                (a as Self, b)
+            })+
         }
 
         /// Calculates the complete double-width product `self * rhs`.
@@ -3658,24 +3682,26 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline]
         pub const fn isqrt(self) -> Self {
-            let result = imp::int_sqrt::$ActualT(self as $ActualT) as $SelfT;
+            $(#[cfg($Pred)] {
+                let result = imp::int_sqrt::$ActualT(self as $ActualT) as $SelfT;
 
-            // Inform the optimizer what the range of outputs is. If testing
-            // `core` crashes with no panic message and a `num::int_sqrt::u*`
-            // test failed, it's because your edits caused these assertions or
-            // the assertions in `fn isqrt` of `nonzero.rs` to become false.
-            //
-            // SAFETY: Integer square root is a monotonically nondecreasing
-            // function, which means that increasing the input will never
-            // cause the output to decrease. Thus, since the input for unsigned
-            // integers is bounded by `[0, <$ActualT>::MAX]`, sqrt(n) will be
-            // bounded by `[sqrt(0), sqrt(<$ActualT>::MAX)]`.
-            unsafe {
-                const MAX_RESULT: $SelfT = imp::int_sqrt::$ActualT(<$ActualT>::MAX) as $SelfT;
-                crate::hint::assert_unchecked(result <= MAX_RESULT);
-            }
+                // Inform the optimizer what the range of outputs is. If testing
+                // `core` crashes with no panic message and a `num::int_sqrt::u*`
+                // test failed, it's because your edits caused these assertions or
+                // the assertions in `fn isqrt` of `nonzero.rs` to become false.
+                //
+                // SAFETY: Integer square root is a monotonically nondecreasing
+                // function, which means that increasing the input will never
+                // cause the output to decrease. Thus, since the input for unsigned
+                // integers is bounded by `[0, <$ActualT>::MAX]`, sqrt(n) will be
+                // bounded by `[sqrt(0), sqrt(<$ActualT>::MAX)]`.
+                unsafe {
+                    const MAX_RESULT: $SelfT = imp::int_sqrt::$ActualT(<$ActualT>::MAX) as $SelfT;
+                    crate::hint::assert_unchecked(result <= MAX_RESULT);
+                }
 
-            result
+                result
+            })+
         }
 
         /// Performs Euclidean division.

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -103,12 +103,12 @@ macro_rules! uint_impl {
         pub const MIN: Self = 0;
 
         /// The largest value that can be represented by this integer type
-        #[doc = concat!("(2<sup>", $BITS, "</sup> &minus; 1", $bound_condition, ").")]
+        $(#[cfg_attr($Pred, doc = concat!("(2<sup>", $BITS, "</sup> &minus; 1", $bound_condition, ")."))])+
         ///
         /// # Examples
         ///
         /// ```
-        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX, ", stringify!($MaxV), ");")]
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX, ", stringify!($MaxV), ");"))])+
         /// ```
         #[stable(feature = "assoc_int_consts", since = "1.43.0")]
         pub const MAX: Self = !0;
@@ -118,7 +118,7 @@ macro_rules! uint_impl {
         /// # Examples
         ///
         /// ```
-        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::BITS, ", stringify!($BITS), ");")]
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(", stringify!($SelfT), "::BITS, ", stringify!($BITS), ");"))])+
         /// ```
         #[stable(feature = "int_bits_const", since = "1.53.0")]
         pub const BITS: u32 = Self::MAX.count_ones();
@@ -132,7 +132,7 @@ macro_rules! uint_impl {
         /// assert_eq!(n.count_ones(), 3);
         ///
         #[doc = concat!("let max = ", stringify!($SelfT),"::MAX;")]
-        #[doc = concat!("assert_eq!(max.count_ones(), ", stringify!($BITS), ");")]
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(max.count_ones(), ", stringify!($BITS), ");"))])+
         ///
         #[doc = concat!("let zero = 0", stringify!($SelfT), ";")]
         /// assert_eq!(zero.count_ones(), 0);
@@ -154,7 +154,7 @@ macro_rules! uint_impl {
         ///
         /// ```
         #[doc = concat!("let zero = 0", stringify!($SelfT), ";")]
-        #[doc = concat!("assert_eq!(zero.count_zeros(), ", stringify!($BITS), ");")]
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(zero.count_zeros(), ", stringify!($BITS), ");"))])+
         ///
         #[doc = concat!("let max = ", stringify!($SelfT),"::MAX;")]
         /// assert_eq!(max.count_zeros(), 0);
@@ -179,7 +179,7 @@ macro_rules! uint_impl {
         /// the type you're using in the call rather than method syntax:
         /// ```
         /// let small = 1;
-        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::count_zeros(small), ", stringify!($BITS_MINUS_ONE) ,");")]
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(", stringify!($SelfT), "::count_zeros(small), ", stringify!($BITS_MINUS_ONE) ,");"))])+
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_stable(feature = "const_math", since = "1.32.0")]
@@ -202,7 +202,7 @@ macro_rules! uint_impl {
         /// assert_eq!(n.leading_zeros(), 2);
         ///
         #[doc = concat!("let zero = 0", stringify!($SelfT), ";")]
-        #[doc = concat!("assert_eq!(zero.leading_zeros(), ", stringify!($BITS), ");")]
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(zero.leading_zeros(), ", stringify!($BITS), ");"))])+
         ///
         #[doc = concat!("let max = ", stringify!($SelfT),"::MAX;")]
         /// assert_eq!(max.leading_zeros(), 0);
@@ -227,7 +227,7 @@ macro_rules! uint_impl {
         /// assert_eq!(n.trailing_zeros(), 3);
         ///
         #[doc = concat!("let zero = 0", stringify!($SelfT), ";")]
-        #[doc = concat!("assert_eq!(zero.trailing_zeros(), ", stringify!($BITS), ");")]
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(zero.trailing_zeros(), ", stringify!($BITS), ");"))])+
         ///
         #[doc = concat!("let max = ", stringify!($SelfT),"::MAX;")]
         #[doc = concat!("assert_eq!(max.trailing_zeros(), 0);")]
@@ -253,7 +253,7 @@ macro_rules! uint_impl {
         /// assert_eq!(zero.leading_ones(), 0);
         ///
         #[doc = concat!("let max = ", stringify!($SelfT),"::MAX;")]
-        #[doc = concat!("assert_eq!(max.leading_ones(), ", stringify!($BITS), ");")]
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(max.leading_ones(), ", stringify!($BITS), ");"))])+
         /// ```
         #[stable(feature = "leading_trailing_ones", since = "1.46.0")]
         #[rustc_const_stable(feature = "leading_trailing_ones", since = "1.46.0")]
@@ -277,7 +277,7 @@ macro_rules! uint_impl {
         /// assert_eq!(zero.trailing_ones(), 0);
         ///
         #[doc = concat!("let max = ", stringify!($SelfT),"::MAX;")]
-        #[doc = concat!("assert_eq!(max.trailing_ones(), ", stringify!($BITS), ");")]
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(max.trailing_ones(), ", stringify!($BITS), ");"))])+
         /// ```
         #[stable(feature = "leading_trailing_ones", since = "1.46.0")]
         #[rustc_const_stable(feature = "leading_trailing_ones", since = "1.46.0")]
@@ -300,7 +300,7 @@ macro_rules! uint_impl {
         #[doc = concat!("assert_eq!(0_", stringify!($SelfT), ".bit_width(), 0);")]
         #[doc = concat!("assert_eq!(0b111_", stringify!($SelfT), ".bit_width(), 3);")]
         #[doc = concat!("assert_eq!(0b1110_", stringify!($SelfT), ".bit_width(), 4);")]
-        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX.bit_width(), ", stringify!($BITS), ");")]
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX.bit_width(), ", stringify!($BITS), ");"))])+
         /// ```
         #[unstable(feature = "uint_bit_width", issue = "142326")]
         #[must_use = "this returns the result of the operation, \
@@ -433,10 +433,10 @@ macro_rules! uint_impl {
         /// # Examples
         ///
         /// ```
-        #[doc = concat!("let n = ", $rot_op, stringify!($SelfT), ";")]
-        #[doc = concat!("let m = ", $rot_result, ";")]
+        $(#[cfg_attr($Pred, doc = concat!("let n = ", $rot_op, stringify!($SelfT), ";"))])+
+        $(#[cfg_attr($Pred, doc = concat!("let m = ", $rot_result, ";"))])+
         ///
-        #[doc = concat!("assert_eq!(n.rotate_left(", $rot, "), m);")]
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(n.rotate_left(", $rot, "), m);"))])+
         #[doc = concat!("assert_eq!(n.rotate_left(1024), n);")]
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
@@ -462,10 +462,10 @@ macro_rules! uint_impl {
         /// # Examples
         ///
         /// ```
-        #[doc = concat!("let n = ", $rot_result, stringify!($SelfT), ";")]
-        #[doc = concat!("let m = ", $rot_op, ";")]
+        $(#[cfg_attr($Pred, doc = concat!("let n = ", $rot_result, stringify!($SelfT), ";"))])+
+        $(#[cfg_attr($Pred, doc = concat!("let m = ", $rot_op, ";"))])+
         ///
-        #[doc = concat!("assert_eq!(n.rotate_right(", $rot, "), m);")]
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(n.rotate_right(", $rot, "), m);"))])+
         #[doc = concat!("assert_eq!(n.rotate_right(1024), n);")]
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
@@ -496,11 +496,11 @@ macro_rules! uint_impl {
         ///
         /// ```
         /// #![feature(funnel_shifts)]
-        #[doc = concat!("let a = ", $rot_op, stringify!($SelfT), ";")]
-        #[doc = concat!("let b = ", $fsh_op, stringify!($SelfT), ";")]
-        #[doc = concat!("let m = ", $fshl_result, ";")]
+        $(#[cfg_attr($Pred, doc = concat!("let a = ", $rot_op, stringify!($SelfT), ";"))])+
+        $(#[cfg_attr($Pred, doc = concat!("let b = ", $fsh_op, stringify!($SelfT), ";"))])+
+        $(#[cfg_attr($Pred, doc = concat!("let m = ", $fshl_result, ";"))])+
         ///
-        #[doc = concat!("assert_eq!(a.funnel_shl(b, ", $rot, "), m);")]
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(a.funnel_shl(b, ", $rot, "), m);"))])+
         /// ```
         #[rustc_const_unstable(feature = "funnel_shifts", issue = "145686")]
         #[unstable(feature = "funnel_shifts", issue = "145686")]
@@ -531,11 +531,11 @@ macro_rules! uint_impl {
         ///
         /// ```
         /// #![feature(funnel_shifts)]
-        #[doc = concat!("let a = ", $rot_op, stringify!($SelfT), ";")]
-        #[doc = concat!("let b = ", $fsh_op, stringify!($SelfT), ";")]
-        #[doc = concat!("let m = ", $fshr_result, ";")]
+        $(#[cfg_attr($Pred, doc = concat!("let a = ", $rot_op, stringify!($SelfT), ";"))])+
+        $(#[cfg_attr($Pred, doc = concat!("let b = ", $fsh_op, stringify!($SelfT), ";"))])+
+        $(#[cfg_attr($Pred, doc = concat!("let m = ", $fshr_result, ";"))])+
         ///
-        #[doc = concat!("assert_eq!(a.funnel_shr(b, ", $rot, "), m);")]
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(a.funnel_shr(b, ", $rot, "), m);"))])+
         /// ```
         #[rustc_const_unstable(feature = "funnel_shifts", issue = "145686")]
         #[unstable(feature = "funnel_shifts", issue = "145686")]
@@ -643,10 +643,10 @@ macro_rules! uint_impl {
         /// ```
         /// #![feature(uint_carryless_mul)]
         ///
-        #[doc = concat!("let a = ", $clmul_lhs, stringify!($SelfT), ";")]
-        #[doc = concat!("let b = ", $clmul_rhs, stringify!($SelfT), ";")]
+        $(#[cfg_attr($Pred, doc = concat!("let a = ", $clmul_lhs, stringify!($SelfT), ";"))])+
+        $(#[cfg_attr($Pred, doc = concat!("let b = ", $clmul_rhs, stringify!($SelfT), ";"))])+
         ///
-        #[doc = concat!("assert_eq!(a.carryless_mul(b), ", $clmul_result, ");")]
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(a.carryless_mul(b), ", $clmul_result, ");"))])+
         /// ```
         #[rustc_const_unstable(feature = "uint_carryless_mul", issue = "152080")]
         #[doc(alias = "clmul")]
@@ -663,10 +663,10 @@ macro_rules! uint_impl {
         /// # Examples
         ///
         /// ```
-        #[doc = concat!("let n = ", $swap_op, stringify!($SelfT), ";")]
+        $(#[cfg_attr($Pred, doc = concat!("let n = ", $swap_op, stringify!($SelfT), ";"))])+
         /// let m = n.swap_bytes();
         ///
-        #[doc = concat!("assert_eq!(m, ", $swapped, ");")]
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(m, ", $swapped, ");"))])+
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_stable(feature = "const_math", since = "1.32.0")]
@@ -717,10 +717,10 @@ macro_rules! uint_impl {
         /// # Examples
         ///
         /// ```
-        #[doc = concat!("let n = ", $swap_op, stringify!($SelfT), ";")]
+        $(#[cfg_attr($Pred, doc = concat!("let n = ", $swap_op, stringify!($SelfT), ";"))])+
         /// let m = n.reverse_bits();
         ///
-        #[doc = concat!("assert_eq!(m, ", $reversed, ");")]
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(m, ", $reversed, ");"))])+
         #[doc = concat!("assert_eq!(0, 0", stringify!($SelfT), ".reverse_bits());")]
         /// ```
         #[stable(feature = "reverse_bits", since = "1.37.0")]
@@ -1955,7 +1955,7 @@ macro_rules! uint_impl {
         /// ```
         #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".checked_shl(4), Some(0x10));")]
         #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".checked_shl(129), None);")]
-        #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".checked_shl(", stringify!($BITS_MINUS_ONE), "), Some(0));")]
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".checked_shl(", stringify!($BITS_MINUS_ONE), "), Some(0));"))])+
         /// ```
         #[stable(feature = "wrapping", since = "1.7.0")]
         #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.47.0")]
@@ -2047,8 +2047,8 @@ macro_rules! uint_impl {
         #[doc = concat!("assert_eq!(0b101_", stringify!($SelfT), ".unbounded_shl(0), 0b101);")]
         #[doc = concat!("assert_eq!(0b101_", stringify!($SelfT), ".unbounded_shl(1), 0b1010);")]
         #[doc = concat!("assert_eq!(0b101_", stringify!($SelfT), ".unbounded_shl(2), 0b10100);")]
-        #[doc = concat!("assert_eq!(42_", stringify!($SelfT), ".unbounded_shl(", stringify!($BITS), "), 0);")]
-        #[doc = concat!("assert_eq!(42_", stringify!($SelfT), ".unbounded_shl(1).unbounded_shl(", stringify!($BITS_MINUS_ONE), "), 0);")]
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(42_", stringify!($SelfT), ".unbounded_shl(", stringify!($BITS), "), 0);"))])+
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(42_", stringify!($SelfT), ".unbounded_shl(1).unbounded_shl(", stringify!($BITS_MINUS_ONE), "), 0);"))])+
         ///
         #[doc = concat!("let start : ", stringify!($SelfT), " = 13;")]
         /// let mut running = start;
@@ -2056,7 +2056,7 @@ macro_rules! uint_impl {
         ///     // The unbounded shift left by i is the same as `<< 1` i times
         ///     assert_eq!(running, start.unbounded_shl(i));
         ///     // Which is not always the case for a wrapping shift
-        #[doc = concat!("    assert_eq!(running == start.wrapping_shl(i), i < ", stringify!($BITS), ");")]
+        $(#[cfg_attr($Pred, doc = concat!("    assert_eq!(running == start.wrapping_shl(i), i < ", stringify!($BITS), ");"))])+
         ///
         ///     running <<= 1;
         /// }
@@ -2232,8 +2232,8 @@ macro_rules! uint_impl {
         #[doc = concat!("assert_eq!(0b1010_", stringify!($SelfT), ".unbounded_shr(0), 0b1010);")]
         #[doc = concat!("assert_eq!(0b1010_", stringify!($SelfT), ".unbounded_shr(1), 0b101);")]
         #[doc = concat!("assert_eq!(0b1010_", stringify!($SelfT), ".unbounded_shr(2), 0b10);")]
-        #[doc = concat!("assert_eq!(42_", stringify!($SelfT), ".unbounded_shr(", stringify!($BITS), "), 0);")]
-        #[doc = concat!("assert_eq!(42_", stringify!($SelfT), ".unbounded_shr(1).unbounded_shr(", stringify!($BITS_MINUS_ONE), "), 0);")]
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(42_", stringify!($SelfT), ".unbounded_shr(", stringify!($BITS), "), 0);"))])+
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(42_", stringify!($SelfT), ".unbounded_shr(1).unbounded_shr(", stringify!($BITS_MINUS_ONE), "), 0);"))])+
         ///
         #[doc = concat!("let start = ", stringify!($SelfT), "::rotate_right(13, 4);")]
         /// let mut running = start;
@@ -2241,7 +2241,7 @@ macro_rules! uint_impl {
         ///     // The unbounded shift right by i is the same as `>> 1` i times
         ///     assert_eq!(running, start.unbounded_shr(i));
         ///     // Which is not always the case for a wrapping shift
-        #[doc = concat!("    assert_eq!(running == start.wrapping_shr(i), i < ", stringify!($BITS), ");")]
+        $(#[cfg_attr($Pred, doc = concat!("    assert_eq!(running == start.wrapping_shr(i), i < ", stringify!($BITS), ");"))])+
         ///
         ///     running >>= 1;
         /// }
@@ -2809,8 +2809,8 @@ macro_rules! uint_impl {
         #[doc = concat!("assert_eq!(0b101_", stringify!($SelfT), ".wrapping_shl(1), 0b1010);")]
         #[doc = concat!("assert_eq!(0b101_", stringify!($SelfT), ".wrapping_shl(2), 0b10100);")]
         #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX.wrapping_shl(2), ", stringify!($SelfT), "::MAX - 3);")]
-        #[doc = concat!("assert_eq!(42_", stringify!($SelfT), ".wrapping_shl(", stringify!($BITS), "), 42);")]
-        #[doc = concat!("assert_eq!(42_", stringify!($SelfT), ".wrapping_shl(1).wrapping_shl(", stringify!($BITS_MINUS_ONE), "), 0);")]
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(42_", stringify!($SelfT), ".wrapping_shl(", stringify!($BITS), "), 42);"))])+
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(42_", stringify!($SelfT), ".wrapping_shl(1).wrapping_shl(", stringify!($BITS_MINUS_ONE), "), 0);"))])+
         #[doc = concat!("assert_eq!(1_", stringify!($SelfT), ".wrapping_shl(128), 1);")]
         #[doc = concat!("assert_eq!(5_", stringify!($SelfT), ".wrapping_shl(1025), 10);")]
         /// ```
@@ -2853,8 +2853,8 @@ macro_rules! uint_impl {
         #[doc = concat!("assert_eq!(0b1010_", stringify!($SelfT), ".wrapping_shr(1), 0b101);")]
         #[doc = concat!("assert_eq!(0b1010_", stringify!($SelfT), ".wrapping_shr(2), 0b10);")]
         #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX.wrapping_shr(1), ", stringify!($SignedT), "::MAX.cast_unsigned());")]
-        #[doc = concat!("assert_eq!(42_", stringify!($SelfT), ".wrapping_shr(", stringify!($BITS), "), 42);")]
-        #[doc = concat!("assert_eq!(42_", stringify!($SelfT), ".wrapping_shr(1).wrapping_shr(", stringify!($BITS_MINUS_ONE), "), 0);")]
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(42_", stringify!($SelfT), ".wrapping_shr(", stringify!($BITS), "), 42);"))])+
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(42_", stringify!($SelfT), ".wrapping_shr(1).wrapping_shr(", stringify!($BITS_MINUS_ONE), "), 0);"))])+
         #[doc = concat!("assert_eq!(128_", stringify!($SelfT), ".wrapping_shr(128), 128);")]
         #[doc = concat!("assert_eq!(10_", stringify!($SelfT), ".wrapping_shr(1025), 5);")]
         /// ```
@@ -2955,7 +2955,7 @@ macro_rules! uint_impl {
         /// chaining together multiple additions to create a wider addition, and
         /// can be useful for bignum addition.
         ///
-        #[doc = concat!("This can be thought of as a ", stringify!($BITS), "-bit \"full adder\", in the electronics sense.")]
+        $(#[cfg_attr($Pred, doc = concat!("This can be thought of as a ", stringify!($BITS), "-bit \"full adder\", in the electronics sense."))])+
         ///
         /// If the input carry is false, this method is equivalent to
         /// [`overflowing_add`](Self::overflowing_add), and the output carry is
@@ -2966,10 +2966,10 @@ macro_rules! uint_impl {
         /// # Examples
         ///
         /// ```
-        #[doc = concat!("//    3  MAX    (a = 3 × 2^", stringify!($BITS), " + 2^", stringify!($BITS), " - 1)")]
-        #[doc = concat!("// +  5    7    (b = 5 × 2^", stringify!($BITS), " + 7)")]
+        $(#[cfg_attr($Pred, doc = concat!("//    3  MAX    (a = 3 × 2^", stringify!($BITS), " + 2^", stringify!($BITS), " - 1)"))])+
+        $(#[cfg_attr($Pred, doc = concat!("// +  5    7    (b = 5 × 2^", stringify!($BITS), " + 7)"))])+
         /// // ---------
-        #[doc = concat!("//    9    6    (sum = 9 × 2^", stringify!($BITS), " + 6)")]
+        $(#[cfg_attr($Pred, doc = concat!("//    9    6    (sum = 9 × 2^", stringify!($BITS), " + 6)"))])+
         ///
         #[doc = concat!("let (a1, a0): (", stringify!($SelfT), ", ", stringify!($SelfT), ") = (3, ", stringify!($SelfT), "::MAX);")]
         #[doc = concat!("let (b1, b0): (", stringify!($SelfT), ", ", stringify!($SelfT), ") = (5, 7);")]
@@ -3058,10 +3058,10 @@ macro_rules! uint_impl {
         /// # Examples
         ///
         /// ```
-        #[doc = concat!("//    9    6    (a = 9 × 2^", stringify!($BITS), " + 6)")]
-        #[doc = concat!("// -  5    7    (b = 5 × 2^", stringify!($BITS), " + 7)")]
+        $(#[cfg_attr($Pred, doc = concat!("//    9    6    (a = 9 × 2^", stringify!($BITS), " + 6)"))])+
+        $(#[cfg_attr($Pred, doc = concat!("// -  5    7    (b = 5 × 2^", stringify!($BITS), " + 7)"))])+
         /// // ---------
-        #[doc = concat!("//    3  MAX    (diff = 3 × 2^", stringify!($BITS), " + 2^", stringify!($BITS), " - 1)")]
+        $(#[cfg_attr($Pred, doc = concat!("//    3  MAX    (diff = 3 × 2^", stringify!($BITS), " + 2^", stringify!($BITS), " - 1)"))])+
         ///
         #[doc = concat!("let (a1, a0): (", stringify!($SelfT), ", ", stringify!($SelfT), ") = (9, 6);")]
         #[doc = concat!("let (b1, b0): (", stringify!($SelfT), ", ", stringify!($SelfT), ") = (5, 7);")]
@@ -3195,10 +3195,10 @@ macro_rules! uint_impl {
         /// Compared to other `*_mul` methods:
         /// ```
         /// #![feature(widening_mul)]
-        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::widening_mul(1 << ", stringify!($BITS_MINUS_ONE), ", 6), (0, 3));")]
-        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::overflowing_mul(1 << ", stringify!($BITS_MINUS_ONE), ", 6), (0, true));")]
-        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::wrapping_mul(1 << ", stringify!($BITS_MINUS_ONE), ", 6), 0);")]
-        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::checked_mul(1 << ", stringify!($BITS_MINUS_ONE), ", 6), None);")]
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(", stringify!($SelfT), "::widening_mul(1 << ", stringify!($BITS_MINUS_ONE), ", 6), (0, 3));"))])+
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(", stringify!($SelfT), "::overflowing_mul(1 << ", stringify!($BITS_MINUS_ONE), ", 6), (0, true));"))])+
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(", stringify!($SelfT), "::wrapping_mul(1 << ", stringify!($BITS_MINUS_ONE), ", 6), 0);"))])+
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(", stringify!($SelfT), "::checked_mul(1 << ", stringify!($BITS_MINUS_ONE), ", 6), None);"))])+
         /// ```
         ///
         /// Please note that this example is shared among integer types, which is why `u32` is used.
@@ -3512,7 +3512,7 @@ macro_rules! uint_impl {
         /// ```
         #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".overflowing_shl(4), (0x10, false));")]
         #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".overflowing_shl(132), (0x10, true));")]
-        #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".overflowing_shl(", stringify!($BITS_MINUS_ONE), "), (0, false));")]
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".overflowing_shl(", stringify!($BITS_MINUS_ONE), "), (0, false));"))])+
         /// ```
         #[stable(feature = "wrapping", since = "1.7.0")]
         #[rustc_const_stable(feature = "const_wrapping_math", since = "1.32.0")]
@@ -3969,13 +3969,13 @@ macro_rules! uint_impl {
         /// Returns the memory representation of this integer as a byte array in
         /// big-endian (network) byte order.
         ///
-        #[doc = $to_xe_bytes_doc]
+        $(#[cfg_attr($Pred, doc = $to_xe_bytes_doc)])+
         ///
         /// # Examples
         ///
         /// ```
-        #[doc = concat!("let bytes = ", $swap_op, stringify!($SelfT), ".to_be_bytes();")]
-        #[doc = concat!("assert_eq!(bytes, ", $be_bytes, ");")]
+        $(#[cfg_attr($Pred, doc = concat!("let bytes = ", $swap_op, stringify!($SelfT), ".to_be_bytes();"))])+
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(bytes, ", $be_bytes, ");"))])+
         /// ```
         #[stable(feature = "int_to_from_bytes", since = "1.32.0")]
         #[rustc_const_stable(feature = "const_int_conversion", since = "1.44.0")]
@@ -3989,13 +3989,13 @@ macro_rules! uint_impl {
         /// Returns the memory representation of this integer as a byte array in
         /// little-endian byte order.
         ///
-        #[doc = $to_xe_bytes_doc]
+        $(#[cfg_attr($Pred, doc = $to_xe_bytes_doc)])+
         ///
         /// # Examples
         ///
         /// ```
-        #[doc = concat!("let bytes = ", $swap_op, stringify!($SelfT), ".to_le_bytes();")]
-        #[doc = concat!("assert_eq!(bytes, ", $le_bytes, ");")]
+        $(#[cfg_attr($Pred, doc = concat!("let bytes = ", $swap_op, stringify!($SelfT), ".to_le_bytes();"))])+
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(bytes, ", $le_bytes, ");"))])+
         /// ```
         #[stable(feature = "int_to_from_bytes", since = "1.32.0")]
         #[rustc_const_stable(feature = "const_int_conversion", since = "1.44.0")]
@@ -4013,7 +4013,7 @@ macro_rules! uint_impl {
         /// should use [`to_be_bytes`] or [`to_le_bytes`], as appropriate,
         /// instead.
         ///
-        #[doc = $to_xe_bytes_doc]
+        $(#[cfg_attr($Pred, doc = $to_xe_bytes_doc)])+
         ///
         /// [`to_be_bytes`]: Self::to_be_bytes
         /// [`to_le_bytes`]: Self::to_le_bytes
@@ -4021,13 +4021,13 @@ macro_rules! uint_impl {
         /// # Examples
         ///
         /// ```
-        #[doc = concat!("let bytes = ", $swap_op, stringify!($SelfT), ".to_ne_bytes();")]
+        $(#[cfg_attr($Pred, doc = concat!("let bytes = ", $swap_op, stringify!($SelfT), ".to_ne_bytes();"))])+
         /// assert_eq!(
         ///     bytes,
         ///     if cfg!(target_endian = "big") {
-        #[doc = concat!("        ", $be_bytes)]
+        $(#[cfg_attr($Pred, doc = concat!("        ", $be_bytes))])+
         ///     } else {
-        #[doc = concat!("        ", $le_bytes)]
+        $(#[cfg_attr($Pred, doc = concat!("        ", $le_bytes))])+
         ///     }
         /// );
         /// ```
@@ -4048,13 +4048,13 @@ macro_rules! uint_impl {
         /// Creates a native endian integer value from its representation
         /// as a byte array in big endian.
         ///
-        #[doc = $from_xe_bytes_doc]
+        $(#[cfg_attr($Pred, doc = $from_xe_bytes_doc)])+
         ///
         /// # Examples
         ///
         /// ```
-        #[doc = concat!("let value = ", stringify!($SelfT), "::from_be_bytes(", $be_bytes, ");")]
-        #[doc = concat!("assert_eq!(value, ", $swap_op, ");")]
+        $(#[cfg_attr($Pred, doc = concat!("let value = ", stringify!($SelfT), "::from_be_bytes(", $be_bytes, ");"))])+
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(value, ", $swap_op, ");"))])+
         /// ```
         ///
         /// When starting from a slice rather than an array, fallible conversion APIs can be used:
@@ -4077,13 +4077,13 @@ macro_rules! uint_impl {
         /// Creates a native endian integer value from its representation
         /// as a byte array in little endian.
         ///
-        #[doc = $from_xe_bytes_doc]
+        $(#[cfg_attr($Pred, doc = $from_xe_bytes_doc)])+
         ///
         /// # Examples
         ///
         /// ```
-        #[doc = concat!("let value = ", stringify!($SelfT), "::from_le_bytes(", $le_bytes, ");")]
-        #[doc = concat!("assert_eq!(value, ", $swap_op, ");")]
+        $(#[cfg_attr($Pred, doc = concat!("let value = ", stringify!($SelfT), "::from_le_bytes(", $le_bytes, ");"))])+
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(value, ", $swap_op, ");"))])+
         /// ```
         ///
         /// When starting from a slice rather than an array, fallible conversion APIs can be used:
@@ -4113,17 +4113,17 @@ macro_rules! uint_impl {
         /// [`from_be_bytes`]: Self::from_be_bytes
         /// [`from_le_bytes`]: Self::from_le_bytes
         ///
-        #[doc = $from_xe_bytes_doc]
+        $(#[cfg_attr($Pred, doc = $from_xe_bytes_doc)])+
         ///
         /// # Examples
         ///
         /// ```
         #[doc = concat!("let value = ", stringify!($SelfT), "::from_ne_bytes(if cfg!(target_endian = \"big\") {")]
-        #[doc = concat!("    ", $be_bytes, "")]
+        $(#[cfg_attr($Pred, doc = concat!("    ", $be_bytes, ""))])+
         /// } else {
-        #[doc = concat!("    ", $le_bytes, "")]
+        $(#[cfg_attr($Pred, doc = concat!("    ", $le_bytes, ""))])+
         /// });
-        #[doc = concat!("assert_eq!(value, ", $swap_op, ");")]
+        $(#[cfg_attr($Pred, doc = concat!("assert_eq!(value, ", $swap_op, ");"))])+
         /// ```
         ///
         /// When starting from a slice rather than an array, fallible conversion APIs can be used:


### PR DESCRIPTION
Fixes rust-lang/rust#149786; the portability note is now shown on stable docs:
<https://doc.rust-lang.org/1.93.0/std/primitive.usize.html#impl-usize>

Tried to look for others cases, surprisingly others aren't marked as only available on 64-bit:
[https://doc.rust-lang.org/1.93.0/std/primitive.u8.html#impl-TryFrom\<usize\>-for-u8](https://doc.rust-lang.org/1.93.0/std/primitive.u8.html#impl-TryFrom%3Cusize%3E-for-u8)
https://github.com/rust-lang/rust/blob/254b59607d4417e9dffbc307138ae5c86280fe4c/library/core/src/convert/num.rs#L428-L432

And looking for `cfg` directly followed by an `impl` (regex: `#\[cfg\(target_pointer_width = "\d{2}"\)\]\s*impl `) only matches i/usize.

@rustbot label +A-docs