### PR TITLE
[rustdoc] Remove special-case preventing `Destruct` trait to be displayed in generic bounds

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -226,13 +226,6 @@ fn clean_generic_bound<'tcx>(
     Some(match bound {
         hir::GenericBound::Outlives(lt) => GenericBound::Outlives(clean_lifetime(lt, cx)),
         hir::GenericBound::Trait(t) => {
-            // `T: [const] Destruct` is hidden because `T: Destruct` is a no-op.
-            if let hir::BoundConstness::Maybe(_) = t.modifiers.constness
-                && cx.tcx.lang_items().destruct_trait() == Some(t.trait_ref.trait_def_id().unwrap())
-            {
-                return None;
-            }
-
             GenericBound::TraitBound(clean_poly_trait_ref(t, cx), t.modifiers)
         }
         hir::GenericBound::Use(args, ..) => {

--- a/tests/rustdoc-html/const-trait-impl.rs
+++ b/tests/rustdoc-html/const-trait-impl.rs
@@ -1,0 +1,20 @@
+// This test ensures that all const trait bounds are displayed, in particular `Destruct`.
+
+#![feature(const_trait_impl)]
+#![crate_name = "foo"]
+
+use std::marker::Destruct;
+
+pub const trait Foo {}
+
+//@ has 'foo/fn.f.html'
+//@ matches - '//*[@class="rust item-decl"]//*[@class="where"]' '^where\s+T: Foo,$'
+pub const fn f<T>(_: &T)
+where T: [const] Foo
+{}
+
+//@ has 'foo/fn.f2.html'
+//@ matches - '//*[@class="rust item-decl"]//*[@class="where"]' '^where\s+T: Destruct,$'
+pub const fn f2<T>(_: &T)
+where T: [const] Destruct
+{}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/151502.

Since you're the one who added this code (I think, based on what I found with `git blame`), I'll set you as reviewer @oli-obk.

r? @oli-obk 