### PR TITLE
Do not emit errors on non-metaitem diagnostic attr input

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -360,7 +360,8 @@ fn parse_cfg_attr_internal<'a>(
 ) -> PResult<'a, (CfgEntry, Vec<(ast::AttrItem, Span)>)> {
     // Parse cfg predicate
     let pred_start = parser.token.span;
-    let meta = MetaItemOrLitParser::parse_single(parser, ShouldEmit::ErrorsAndLints)?;
+    let meta =
+        MetaItemOrLitParser::parse_single(parser, ShouldEmit::ErrorsAndLints { recover: true })?;
     let pred_span = pred_start.with_hi(parser.token.span.hi());
 
     let cfg_predicate = AttributeParser::parse_single_args(
@@ -375,7 +376,7 @@ fn parse_cfg_attr_internal<'a>(
         CRATE_NODE_ID,
         Target::Crate,
         features,
-        ShouldEmit::ErrorsAndLints,
+        ShouldEmit::ErrorsAndLints { recover: true },
         &meta,
         parse_cfg_entry,
         &CFG_ATTR_TEMPLATE,

--- a/compiler/rustc_attr_parsing/src/attributes/cfg_select.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg_select.rs
@@ -78,8 +78,9 @@ pub fn parse_cfg_select(
                 }
             }
         } else {
-            let meta = MetaItemOrLitParser::parse_single(p, ShouldEmit::ErrorsAndLints)
-                .map_err(|diag| diag.emit())?;
+            let meta =
+                MetaItemOrLitParser::parse_single(p, ShouldEmit::ErrorsAndLints { recover: true })
+                    .map_err(|diag| diag.emit())?;
             let cfg_span = meta.span();
             let cfg = AttributeParser::parse_single_args(
                 sess,
@@ -94,7 +95,7 @@ pub fn parse_cfg_select(
                 // Doesn't matter what the target actually is here.
                 Target::Crate,
                 features,
-                ShouldEmit::ErrorsAndLints,
+                ShouldEmit::ErrorsAndLints { recover: true },
                 &meta,
                 parse_cfg_entry,
                 &AttributeTemplate::default(),

--- a/compiler/rustc_builtin_macros/src/cfg.rs
+++ b/compiler/rustc_builtin_macros/src/cfg.rs
@@ -40,8 +40,11 @@ fn parse_cfg(cx: &ExtCtxt<'_>, span: Span, tts: TokenStream) -> Result<CfgEntry,
         return Err(cx.dcx().emit_err(errors::RequiresCfgPattern { span }));
     }
 
-    let meta = MetaItemOrLitParser::parse_single(&mut parser, ShouldEmit::ErrorsAndLints)
-        .map_err(|diag| diag.emit())?;
+    let meta = MetaItemOrLitParser::parse_single(
+        &mut parser,
+        ShouldEmit::ErrorsAndLints { recover: true },
+    )
+    .map_err(|diag| diag.emit())?;
     let cfg = AttributeParser::parse_single_args(
         cx.sess,
         span,
@@ -55,7 +58,7 @@ fn parse_cfg(cx: &ExtCtxt<'_>, span: Span, tts: TokenStream) -> Result<CfgEntry,
         // Doesn't matter what the target actually is here.
         Target::Crate,
         Some(cx.ecfg.features),
-        ShouldEmit::ErrorsAndLints,
+        ShouldEmit::ErrorsAndLints { recover: true },
         &meta,
         parse_cfg_entry,
         &CFG_TEMPLATE,

--- a/compiler/rustc_expand/src/config.rs
+++ b/compiler/rustc_expand/src/config.rs
@@ -393,9 +393,10 @@ impl<'a> StripUnconfigured<'a> {
 
     /// Determines if a node with the given attributes should be included in this configuration.
     fn in_cfg(&self, attrs: &[Attribute]) -> bool {
-        attrs
-            .iter()
-            .all(|attr| !is_cfg(attr) || self.cfg_true(attr, ShouldEmit::ErrorsAndLints).as_bool())
+        attrs.iter().all(|attr| {
+            !is_cfg(attr)
+                || self.cfg_true(attr, ShouldEmit::ErrorsAndLints { recover: true }).as_bool()
+        })
     }
 
     pub(crate) fn cfg_true(&self, attr: &Attribute, emit_errors: ShouldEmit) -> EvalConfigResult {

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -2170,7 +2170,7 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
                 call.span(),
                 self.cx.current_expansion.lint_node_id,
                 Some(self.cx.ecfg.features),
-                ShouldEmit::ErrorsAndLints,
+                ShouldEmit::ErrorsAndLints { recover: true },
             );
 
             let current_span = if let Some(sp) = span { sp.to(attr.span) } else { attr.span };
@@ -2220,7 +2220,7 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
             // Target doesn't matter for `cfg` parsing.
             Target::Crate,
             self.cfg().features,
-            ShouldEmit::ErrorsAndLints,
+            ShouldEmit::ErrorsAndLints { recover: true },
             parse_cfg,
             &CFG_TEMPLATE,
         ) else {


### PR DESCRIPTION
This unblocks porting over diagnostic attributes by properly addressing https://github.com/rust-lang/rust/pull/151056#discussion_r2688179459 

r? @JonathanBrouwer 
