### PR TITLE
Enable reproducible binary builds with debuginfo on Linux

### DIFF
--- a/tests/run-make/reproducible-build/rmake.rs
+++ b/tests/run-make/reproducible-build/rmake.rs
@@ -205,7 +205,7 @@ fn diff_dir_test(crate_type: CrateType, remap_type: RemapType) {
                 // See https://github.com/rust-lang/rust/issues/89911
                 // FIXME(#129117): Windows rlib + `-Cdebuginfo=2` + `-Z remap-cwd-prefix=.` seems
                 // to be unreproducible.
-                if !matches!(crate_type, CrateType::Bin) && !is_windows() {
+                if !is_windows() {
                     compiler1.arg("-Cdebuginfo=2");
                     compiler2.arg("-Cdebuginfo=2");
                 }

--- a/tests/run-make/reproducible-build/rmake.rs
+++ b/tests/run-make/reproducible-build/rmake.rs
@@ -199,10 +199,6 @@ fn diff_dir_test(crate_type: CrateType, remap_type: RemapType) {
                     .arg(format!("--remap-path-prefix={}=/b", base_dir.join("test").display()));
             }
             RemapType::Cwd { is_empty } => {
-                // FIXME(Oneirical): Building with crate type set to `bin` AND having -Cdebuginfo=2
-                // (or `-g`, the shorthand form) enabled will cause reproducibility failures
-                // for multiple platforms.
-                // See https://github.com/rust-lang/rust/issues/89911
                 // FIXME(#129117): Windows rlib + `-Cdebuginfo=2` + `-Z remap-cwd-prefix=.` seems
                 // to be unreproducible.
                 if !is_windows() {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Fixes rust-lang/rust#89911 

This PR enables `-Cdebuginfo=2` for binary crate types in the `reproducible-build` run-make test on Linux platforms.

- Removed the `!matches!(crate_type, CrateType::Bin)` check in `diff_dir_test()`
- SHA256 hashes match: `932be0d950f4ffae62451f7b4c8391eb458a68583feb11193dd501551b6201d4`

This scenario was previously disabled due to rust-lang/rust#89911. I have verified locally on Linux (WSL) with LLVM 21 that the regression reported in that issue appears to be resolved, and the tests now pass with debug info enabled.