### PR TITLE
Rename `HandleCycleError` to `CycleErrorHandling`

### DIFF
--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -4,10 +4,9 @@ use rustc_data_structures::sync::{AtomicU64, WorkerLocal};
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::hir_id::OwnerId;
 use rustc_macros::HashStable;
-use rustc_query_system::HandleCycleError;
 use rustc_query_system::dep_graph::{DepNodeIndex, SerializedDepNodeIndex};
 pub(crate) use rustc_query_system::query::QueryJobId;
-use rustc_query_system::query::*;
+use rustc_query_system::query::{CycleError, CycleErrorHandling, HashResult, QueryCache};
 use rustc_span::{ErrorGuaranteed, Span};
 pub use sealed::IntoQueryParam;
 
@@ -23,7 +22,8 @@ pub struct DynamicQuery<'tcx, C: QueryCache> {
     pub name: &'static str,
     pub eval_always: bool,
     pub dep_kind: DepKind,
-    pub handle_cycle_error: HandleCycleError,
+    /// How this query deals with query cycle errors.
+    pub cycle_error_handling: CycleErrorHandling,
     // Offset of this query's state field in the QueryStates struct
     pub query_state: usize,
     // Offset of this query's cache field in the QueryCaches struct

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -18,13 +18,13 @@ use rustc_middle::query::{
     queries,
 };
 use rustc_middle::ty::TyCtxt;
+use rustc_query_system::Value;
 use rustc_query_system::dep_graph::SerializedDepNodeIndex;
 use rustc_query_system::ich::StableHashingContext;
 use rustc_query_system::query::{
-    CycleError, HashResult, QueryCache, QueryConfig, QueryMap, QueryMode, QueryState,
-    get_query_incr, get_query_non_incr,
+    CycleError, CycleErrorHandling, HashResult, QueryCache, QueryConfig, QueryMap, QueryMode,
+    QueryState, get_query_incr, get_query_non_incr,
 };
-use rustc_query_system::{HandleCycleError, Value};
 use rustc_span::{ErrorGuaranteed, Span};
 
 use crate::plumbing::{__rust_begin_short_backtrace, encode_all_query_results, try_mark_green};
@@ -181,8 +181,8 @@ where
     }
 
     #[inline(always)]
-    fn handle_cycle_error(self) -> HandleCycleError {
-        self.dynamic.handle_cycle_error
+    fn cycle_error_handling(self) -> CycleErrorHandling {
+        self.dynamic.cycle_error_handling
     }
 
     #[inline(always)]

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -199,21 +199,21 @@ pub fn query_key_hash_verify_all<'tcx>(tcx: TyCtxt<'tcx>) {
     }
 }
 
-macro_rules! handle_cycle_error {
+macro_rules! cycle_error_handling {
     ([]) => {{
-        rustc_query_system::HandleCycleError::Error
+        rustc_query_system::query::CycleErrorHandling::Error
     }};
     ([(cycle_fatal) $($rest:tt)*]) => {{
-        rustc_query_system::HandleCycleError::Fatal
+        rustc_query_system::query::CycleErrorHandling::Fatal
     }};
     ([(cycle_stash) $($rest:tt)*]) => {{
-        rustc_query_system::HandleCycleError::Stash
+        rustc_query_system::query::CycleErrorHandling::Stash
     }};
     ([(cycle_delay_bug) $($rest:tt)*]) => {{
-        rustc_query_system::HandleCycleError::DelayBug
+        rustc_query_system::query::CycleErrorHandling::DelayBug
     }};
     ([$other:tt $($modifiers:tt)*]) => {
-        handle_cycle_error!([$($modifiers)*])
+        cycle_error_handling!([$($modifiers)*])
     };
 }
 
@@ -618,7 +618,7 @@ macro_rules! define_queries {
                     name: stringify!($name),
                     eval_always: is_eval_always!([$($modifiers)*]),
                     dep_kind: dep_graph::dep_kinds::$name,
-                    handle_cycle_error: handle_cycle_error!([$($modifiers)*]),
+                    cycle_error_handling: cycle_error_handling!([$($modifiers)*]),
                     query_state: std::mem::offset_of!(QueryStates<'tcx>, $name),
                     query_cache: std::mem::offset_of!(QueryCaches<'tcx>, $name),
                     cache_on_disk: |tcx, key| ::rustc_middle::query::cached::$name(tcx, key),

--- a/compiler/rustc_query_system/src/error.rs
+++ b/compiler/rustc_query_system/src/error.rs
@@ -11,14 +11,6 @@ pub(crate) struct CycleStack {
     pub desc: String,
 }
 
-#[derive(Copy, Clone)]
-pub enum HandleCycleError {
-    Error,
-    Fatal,
-    DelayBug,
-    Stash,
-}
-
 #[derive(Subdiagnostic)]
 pub(crate) enum StackCount {
     #[note(query_system_cycle_stack_single)]

--- a/compiler/rustc_query_system/src/lib.rs
+++ b/compiler/rustc_query_system/src/lib.rs
@@ -12,7 +12,7 @@ pub mod ich;
 pub mod query;
 mod values;
 
-pub use error::{HandleCycleError, QueryOverflow, QueryOverflowNote};
+pub use error::{QueryOverflow, QueryOverflowNote};
 pub use values::Value;
 
 rustc_fluent_macro::fluent_messages! { "../messages.ftl" }

--- a/compiler/rustc_query_system/src/query/config.rs
+++ b/compiler/rustc_query_system/src/query/config.rs
@@ -7,10 +7,9 @@ use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_span::ErrorGuaranteed;
 
 use crate::dep_graph::{DepKind, DepNode, DepNodeParams, SerializedDepNodeIndex};
-use crate::error::HandleCycleError;
 use crate::ich::StableHashingContext;
 use crate::query::caches::QueryCache;
-use crate::query::{CycleError, DepNodeIndex, QueryContext, QueryState};
+use crate::query::{CycleError, CycleErrorHandling, DepNodeIndex, QueryContext, QueryState};
 
 pub type HashResult<V> = Option<fn(&mut StableHashingContext<'_>, &V) -> Fingerprint>;
 
@@ -67,7 +66,7 @@ pub trait QueryConfig<Qcx: QueryContext>: Copy {
     fn feedable(self) -> bool;
 
     fn dep_kind(self) -> DepKind;
-    fn handle_cycle_error(self) -> HandleCycleError;
+    fn cycle_error_handling(self) -> CycleErrorHandling;
     fn hash_result(self) -> HashResult<Self::Value>;
 
     // Just here for convenience and checking that the key matches the kind, don't override this.

--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -20,6 +20,18 @@ mod config;
 mod job;
 mod plumbing;
 
+/// How a particular query deals with query cycle errors.
+///
+/// Inspected by the code that actually handles cycle errors, to decide what
+/// approach to use.
+#[derive(Copy, Clone)]
+pub enum CycleErrorHandling {
+    Error,
+    Fatal,
+    DelayBug,
+    Stash,
+}
+
 /// Description of a frame in the query stack.
 ///
 /// This is mostly used in case of cycles for error reporting.


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/101303, the `handle_cycle_error` field was changed from a macro-generated closure to a macro-selected enum variant. But it was not renamed to reflect the fact that it now holds data, not code.

Renaming the field and its associated enum to `cycle_error_handling: CycleErrorHandling` should make the relevant code less confusing to read.

This PR also moves the enum out of `rustc_query_system::error`, where it was easily confused with diagnostic structs.

There should be no change to compiler behaviour.