### PR TITLE
lint: Use rustc_apfloat for `overflowing_literals`, add f16 and f128

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4170,6 +4170,7 @@ version = "0.0.0"
 dependencies = [
  "bitflags",
  "rustc_abi",
+ "rustc_apfloat",
  "rustc_ast",
  "rustc_ast_pretty",
  "rustc_attr_parsing",

--- a/compiler/rustc_lint/Cargo.toml
+++ b/compiler/rustc_lint/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 # tidy-alphabetical-start
 bitflags = "2.4.1"
 rustc_abi = { path = "../rustc_abi" }
+rustc_apfloat = "0.2.0"
 rustc_ast = { path = "../rustc_ast" }
 rustc_ast_pretty = { path = "../rustc_ast_pretty" }
 rustc_attr_parsing = { path = "../rustc_attr_parsing" }

--- a/library/core/src/fmt/float.rs
+++ b/library/core/src/fmt/float.rs
@@ -13,8 +13,14 @@ macro_rules! impl_general_format {
     ($($t:ident)*) => {
         $(impl GeneralFormat for $t {
             fn already_rounded_value_should_use_exponential(&self) -> bool {
+                // `max_abs` rounds to infinity for `f16`. This is fine to save us from a more
+                // complex macro, it just means a positive-exponent `f16` will never print as
+                // scientific notation by default (reasonably, the max is 65504.0).
+                #[allow(overflowing_literals)]
+                let max_abs = 1e+16;
+
                 let abs = $t::abs(*self);
-                (abs != 0.0 && abs < 1e-4) || abs >= 1e+16
+                (abs != 0.0 && abs < 1e-4) || abs >= max_abs
             }
         })*
     }

--- a/tests/ui/lint/lint-type-overflow2.rs
+++ b/tests/ui/lint/lint-type-overflow2.rs
@@ -1,13 +1,19 @@
 //@ compile-flags: -O
 
+#![feature(f16)]
+#![feature(f128)]
 #![deny(overflowing_literals)]
 
 fn main() {
     let x2: i8 = --128; //~ ERROR literal out of range for `i8`
     //~| WARN use of a double negation
 
+    let x = -65520.0_f16; //~ ERROR literal out of range for `f16`
+    let x =  65520.0_f16; //~ ERROR literal out of range for `f16`
     let x = -3.40282357e+38_f32; //~ ERROR literal out of range for `f32`
     let x =  3.40282357e+38_f32; //~ ERROR literal out of range for `f32`
     let x = -1.7976931348623159e+308_f64; //~ ERROR literal out of range for `f64`
     let x =  1.7976931348623159e+308_f64; //~ ERROR literal out of range for `f64`
+    let x = -1.1897314953572317650857593266280075e+4932_f128; //~ ERROR literal out of range for `f128`
+    let x =  1.1897314953572317650857593266280075e+4932_f128; //~ ERROR literal out of range for `f128`
 }

--- a/tests/ui/lint/lint-type-overflow2.stderr
+++ b/tests/ui/lint/lint-type-overflow2.stderr
@@ -1,5 +1,5 @@
 warning: use of a double negation
-  --> $DIR/lint-type-overflow2.rs:6:18
+  --> $DIR/lint-type-overflow2.rs:8:18
    |
 LL |     let x2: i8 = --128;
    |                  ^^^^^
@@ -13,7 +13,7 @@ LL |     let x2: i8 = -(-128);
    |                   +    +
 
 error: literal out of range for `i8`
-  --> $DIR/lint-type-overflow2.rs:6:20
+  --> $DIR/lint-type-overflow2.rs:8:20
    |
 LL |     let x2: i8 = --128;
    |                    ^^^
@@ -21,13 +21,29 @@ LL |     let x2: i8 = --128;
    = note: the literal `128` does not fit into the type `i8` whose range is `-128..=127`
    = help: consider using the type `u8` instead
 note: the lint level is defined here
-  --> $DIR/lint-type-overflow2.rs:3:9
+  --> $DIR/lint-type-overflow2.rs:5:9
    |
 LL | #![deny(overflowing_literals)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
+error: literal out of range for `f16`
+  --> $DIR/lint-type-overflow2.rs:11:14
+   |
+LL |     let x = -65520.0_f16;
+   |              ^^^^^^^^^^^
+   |
+   = note: the literal `65520.0_f16` does not fit into the type `f16` and will be converted to `f16::INFINITY`
+
+error: literal out of range for `f16`
+  --> $DIR/lint-type-overflow2.rs:12:14
+   |
+LL |     let x =  65520.0_f16;
+   |              ^^^^^^^^^^^
+   |
+   = note: the literal `65520.0_f16` does not fit into the type `f16` and will be converted to `f16::INFINITY`
+
 error: literal out of range for `f32`
-  --> $DIR/lint-type-overflow2.rs:9:14
+  --> $DIR/lint-type-overflow2.rs:13:14
    |
 LL |     let x = -3.40282357e+38_f32;
    |              ^^^^^^^^^^^^^^^^^^
@@ -35,7 +51,7 @@ LL |     let x = -3.40282357e+38_f32;
    = note: the literal `3.40282357e+38_f32` does not fit into the type `f32` and will be converted to `f32::INFINITY`
 
 error: literal out of range for `f32`
-  --> $DIR/lint-type-overflow2.rs:10:14
+  --> $DIR/lint-type-overflow2.rs:14:14
    |
 LL |     let x =  3.40282357e+38_f32;
    |              ^^^^^^^^^^^^^^^^^^
@@ -43,7 +59,7 @@ LL |     let x =  3.40282357e+38_f32;
    = note: the literal `3.40282357e+38_f32` does not fit into the type `f32` and will be converted to `f32::INFINITY`
 
 error: literal out of range for `f64`
-  --> $DIR/lint-type-overflow2.rs:11:14
+  --> $DIR/lint-type-overflow2.rs:15:14
    |
 LL |     let x = -1.7976931348623159e+308_f64;
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -51,12 +67,28 @@ LL |     let x = -1.7976931348623159e+308_f64;
    = note: the literal `1.7976931348623159e+308_f64` does not fit into the type `f64` and will be converted to `f64::INFINITY`
 
 error: literal out of range for `f64`
-  --> $DIR/lint-type-overflow2.rs:12:14
+  --> $DIR/lint-type-overflow2.rs:16:14
    |
 LL |     let x =  1.7976931348623159e+308_f64;
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the literal `1.7976931348623159e+308_f64` does not fit into the type `f64` and will be converted to `f64::INFINITY`
 
-error: aborting due to 5 previous errors; 1 warning emitted
+error: literal out of range for `f128`
+  --> $DIR/lint-type-overflow2.rs:17:14
+   |
+LL |     let x = -1.1897314953572317650857593266280075e+4932_f128;
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the literal `1.1897314953572317650857593266280075e+4932_f128` does not fit into the type `f128` and will be converted to `f128::INFINITY`
+
+error: literal out of range for `f128`
+  --> $DIR/lint-type-overflow2.rs:18:14
+   |
+LL |     let x =  1.1897314953572317650857593266280075e+4932_f128;
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the literal `1.1897314953572317650857593266280075e+4932_f128` does not fit into the type `f128` and will be converted to `f128::INFINITY`
+
+error: aborting due to 9 previous errors; 1 warning emitted
 


### PR DESCRIPTION
Switch to parsing float literals for overflow checks using `rustc_apfloat` rather than host floats. This avoids small variations in platform support and makes it possible to start checking `f16` and `f128` as well.

Using APFloat matches what we try to do elsewhere to avoid platform inconsistencies.