### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/polonius/typeck_constraints.rs
+++ b/compiler/rustc_borrowck/src/polonius/typeck_constraints.rs
@@ -142,14 +142,12 @@ fn localize_terminator_constraint<'tcx>(
     universal_regions: &UniversalRegions<'tcx>,
 ) -> LocalizedOutlivesConstraint {
     // FIXME: check if other terminators need the same handling as `Call`s, in particular
-    // Assert/Yield/Drop. A handful of tests are failing with Drop related issues, as well as some
-    // coroutine tests, and that may be why.
+    // Assert/Yield/Drop.
     match &terminator.kind {
         // FIXME: also handle diverging calls.
         TerminatorKind::Call { destination, target: Some(target), .. } => {
-            // Calls are similar to assignments, and thus follow the same pattern. If there is a
-            // target for the call we also relate what flows into the destination here to entry to
-            // that successor.
+            // If there is a target for the call we also relate what flows into the destination here
+            // to entry to that successor.
             let destination_ty = destination.ty(&body.local_decls, tcx);
             let successor_location = Location { block: *target, statement_index: 0 };
             let successor_point = liveness.point_from_location(successor_location);


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#149639 (inline constant localized typeck constraint computation)
 - rust-lang/rust#151525 (update enzyme, includes an extra patch to fix MacOS builds in CI)

r? @ghost

<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=149639,151525)
<!-- homu-ignore:end -->

