### PR TITLE
target: fix destabilising target-spec-json

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -3352,6 +3352,9 @@ impl Target {
 
                 Err(format!("could not find specification for target {target_tuple:?}"))
             }
+            TargetTuple::TargetJson { ref contents, .. } if !unstable_options => {
+                Err("custom targets are unstable and require `-Zunstable-options`".to_string())
+            }
             TargetTuple::TargetJson { ref contents, .. } => Target::from_json(contents),
         }
     }

--- a/src/ci/docker/scripts/rfl-build.sh
+++ b/src/ci/docker/scripts/rfl-build.sh
@@ -2,8 +2,8 @@
 
 set -euo pipefail
 
-# https://github.com/rust-lang/rust/pull/145974
-LINUX_VERSION=842cfd8e5aff3157cb25481b2900b49c188d628a
+# https://github.com/rust-lang/rust/pull/151534
+LINUX_VERSION=eb268c7972f65fa0b11b051c5ef2b92747bb2b62
 
 # Build rustc, rustdoc, cargo, clippy-driver and rustfmt
 ../x.py build --stage 2 library rustdoc clippy rustfmt

--- a/tests/run-make/rust-lld-custom-target/rmake.rs
+++ b/tests/run-make/rust-lld-custom-target/rmake.rs
@@ -15,7 +15,11 @@ fn main() {
     // Compile to a custom target spec with rust-lld enabled by default. We'll check that by asking
     // the linker to display its version number with a link-arg.
     assert_rustc_uses_lld(
-        rustc().crate_type("cdylib").target("custom-target.json").input("lib.rs"),
+        rustc()
+            .crate_type("cdylib")
+            .target("custom-target.json")
+            .arg("-Zunstable-options")
+            .input("lib.rs"),
     );
 
     // But it can also be disabled via linker features.

--- a/tests/run-make/rustdoc-target-spec-json-path/rmake.rs
+++ b/tests/run-make/rustdoc-target-spec-json-path/rmake.rs
@@ -5,8 +5,14 @@ use run_make_support::{cwd, rustc, rustdoc};
 
 fn main() {
     let out_dir = "rustdoc-target-spec-json-path";
-    rustc().crate_type("lib").input("dummy_core.rs").target("target.json").run();
+    rustc()
+        .arg("-Zunstable-options")
+        .crate_type("lib")
+        .input("dummy_core.rs")
+        .target("target.json")
+        .run();
     rustdoc()
+        .arg("-Zunstable-options")
         .input("my_crate.rs")
         .out_dir(out_dir)
         .library_search_path(cwd())

--- a/tests/run-make/target-specs/rmake.rs
+++ b/tests/run-make/target-specs/rmake.rs
@@ -20,9 +20,16 @@ fn main() {
         .target("my-incomplete-platform.json")
         .run_fail()
         .assert_stderr_contains("missing field `llvm-target`");
-    let test_platform = rustc()
+    let _ = rustc()
         .input("foo.rs")
         .target("my-x86_64-unknown-linux-gnu-platform")
+        .crate_type("lib")
+        .emit("asm")
+        .run_fail()
+        .assert_stderr_contains("custom targets are unstable and require `-Zunstable-options`");
+    let _ = rustc()
+        .input("foo.rs")
+        .target("my-awesome-platform.json")
         .crate_type("lib")
         .emit("asm")
         .run_fail()

--- a/tests/ui/check-cfg/values-target-json.rs
+++ b/tests/ui/check-cfg/values-target-json.rs
@@ -4,7 +4,8 @@
 //@ check-pass
 //@ no-auto-check-cfg
 //@ needs-llvm-components: x86
-//@ compile-flags: --crate-type=lib --check-cfg=cfg() --target={{src-base}}/check-cfg/my-awesome-platform.json
+//@ compile-flags: --crate-type=lib --check-cfg=cfg()
+//@ compile-flags: -Zunstable-options --target={{src-base}}/check-cfg/my-awesome-platform.json
 //@ ignore-backends: gcc
 
 #![feature(lang_items, no_core, auto_traits, rustc_attrs)]


### PR DESCRIPTION
cc rust-lang/rust#151528 

rust-lang/rust#150151 missed a case and didn't entirely destabilise target-spec-json - this patch corrects that.

Closes https://github.com/rust-lang/rust/issues/71009