### PR TITLE
Tweak bounds check in `DepNodeColorMap.get`

### DIFF
--- a/compiler/rustc_middle/src/dep_graph/graph.rs
+++ b/compiler/rustc_middle/src/dep_graph/graph.rs
@@ -1447,7 +1447,7 @@ impl DepNodeColorMap {
         let value = self.values[index].load(Ordering::Acquire);
         // Green is by far the most common case. Check for that first so we can succeed with a
         // single comparison.
-        if value < COMPRESSED_RED {
+        if value <= DepNodeIndex::MAX_AS_U32 {
             DepNodeColor::Green(DepNodeIndex::from_u32(value))
         } else if value == COMPRESSED_RED {
             DepNodeColor::Red


### PR DESCRIPTION
This aligns the outer bounds check for a green color in `DepNodeColorMap.get` with the bounds check in `DepNodeIndex::from_u32`, allowing the latter to be optimized out.