### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -210,6 +210,24 @@ body {
 	color: var(--main-color);
 }
 
+/* Skip navigation link for keyboard users (WCAG 2.4.1) */
+.skip-main-content {
+	position: absolute;
+	left: 0;
+	top: -100%;
+	z-index: 1000;
+	padding: 0.5rem 1rem;
+	background-color: var(--main-background-color);
+	color: var(--main-color);
+	text-decoration: none;
+	font-weight: 500;
+	border-bottom-right-radius: 4px;
+	outline: 2px solid var(--search-input-focused-border-color);
+}
+.skip-main-content:focus {
+	top: 0;
+}
+
 h1 {
 	font-size: 1.5rem; /* 24px */
 }
@@ -1114,6 +1132,7 @@ pre, .rustdoc.src .example-wrap, .example-wrap .src-line-numbers {
 
 #main-content {
 	position: relative;
+	outline: none;
 }
 
 .docblock table {

--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -66,6 +66,7 @@
     {{ layout.external_html.in_header|safe }}
 </head> {# #}
 <body class="rustdoc {{+page.css_class}}"> {# #}
+    <a class="skip-main-content" href="#main-content">Skip to main content</a> {# #}
     <!--[if lte IE 11]> {# #}
     <div class="warning"> {# #}
         This old browser is unsupported and will most likely display funky things. {# #}
@@ -109,7 +110,7 @@
     <div class="sidebar-resizer" title="Drag to resize sidebar"></div> {# #}
     <main>
         {% if page.css_class != "src" %}<div class="width-limiter">{% endif %}
-            <section id="main-content" class="content">{{ content|safe }}</section>
+            <section id="main-content" class="content" tabindex="-1">{{ content|safe }}</section>
         {% if page.css_class != "src" %}</div>{% endif %}
     </main>
     {{ layout.external_html.after_content|safe }}

--- a/tests/run-make/reproducible-build/rmake.rs
+++ b/tests/run-make/reproducible-build/rmake.rs
@@ -205,7 +205,7 @@ fn diff_dir_test(crate_type: CrateType, remap_type: RemapType) {
                 // See https://github.com/rust-lang/rust/issues/89911
                 // FIXME(#129117): Windows rlib + `-Cdebuginfo=2` + `-Z remap-cwd-prefix=.` seems
                 // to be unreproducible.
-                if !matches!(crate_type, CrateType::Bin) && !is_windows() {
+                if !is_windows() {
                     compiler1.arg("-Cdebuginfo=2");
                     compiler2.arg("-Cdebuginfo=2");
                 }

--- a/tests/run-make/reproducible-build/rmake.rs
+++ b/tests/run-make/reproducible-build/rmake.rs
@@ -199,10 +199,6 @@ fn diff_dir_test(crate_type: CrateType, remap_type: RemapType) {
                     .arg(format!("--remap-path-prefix={}=/b", base_dir.join("test").display()));
             }
             RemapType::Cwd { is_empty } => {
-                // FIXME(Oneirical): Building with crate type set to `bin` AND having -Cdebuginfo=2
-                // (or `-g`, the shorthand form) enabled will cause reproducibility failures
-                // for multiple platforms.
-                // See https://github.com/rust-lang/rust/issues/89911
                 // FIXME(#129117): Windows rlib + `-Cdebuginfo=2` + `-Z remap-cwd-prefix=.` seems
                 // to be unreproducible.
                 if !is_windows() {

--- a/tests/rustdoc-gui/skip-navigation.goml
+++ b/tests/rustdoc-gui/skip-navigation.goml
@@ -1,0 +1,19 @@
+// This test ensures that the "Skip to main content" link works correctly
+// for keyboard navigation (WCAG 2.4.1 compliance).
+go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
+
+// The skip link should be hidden initially (positioned off-screen above viewport)
+store-position: (".skip-main-content", {"y": y_before})
+store-size: (".skip-main-content", {"height": height_before})
+assert: |y_before| + |height_before| < 0
+
+// The skip link should be the first focusable element when pressing Tab
+press-key: "Tab"
+wait-for: ".skip-main-content:focus"
+
+// When focused, the link should be visible (top: 0px)
+assert-css: (".skip-main-content:focus", {"top": "0px"})
+
+// Pressing Enter on the skip link should move focus to main content
+press-key: "Enter"
+wait-for: "#main-content:focus"


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#151482 (Add "Skip to main content" link for keyboard navigation in rustdoc)
 - rust-lang/rust#151517 (Enable reproducible binary builds with debuginfo on Linux)

r? @ghost

<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=151517,151482)
<!-- homu-ignore:end -->

