### PR TITLE
Add new `byte_value` and `char_value` methods to `proc_macro::Literal`

### DIFF
--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -54,7 +54,9 @@ use std::{error, fmt};
 pub use diagnostic::{Diagnostic, Level, MultiSpan};
 #[unstable(feature = "proc_macro_value", issue = "136652")]
 pub use rustc_literal_escaper::EscapeError;
-use rustc_literal_escaper::{MixedUnit, unescape_byte_str, unescape_c_str, unescape_str};
+use rustc_literal_escaper::{
+    MixedUnit, unescape_byte, unescape_byte_str, unescape_c_str, unescape_char, unescape_str,
+};
 #[unstable(feature = "proc_macro_totokens", issue = "130977")]
 pub use to_tokens::ToTokens;
 
@@ -1440,6 +1442,28 @@ impl Literal {
             bridge::LitKind::Integer | bridge::LitKind::Float | bridge::LitKind::ErrWithGuar => {
                 f(&[symbol, suffix])
             }
+        })
+    }
+
+    /// Returns the unescaped char value if the current literal is a char.
+    #[unstable(feature = "proc_macro_value", issue = "136652")]
+    pub fn byte_value(&self) -> Result<u8, ConversionErrorKind> {
+        self.0.symbol.with(|symbol| match self.0.kind {
+            bridge::LitKind::Char => {
+                unescape_byte(symbol).map_err(ConversionErrorKind::FailedToUnescape)
+            }
+            _ => Err(ConversionErrorKind::InvalidLiteralKind),
+        })
+    }
+
+    /// Returns the unescaped char value if the current literal is a char.
+    #[unstable(feature = "proc_macro_value", issue = "136652")]
+    pub fn char_value(&self) -> Result<char, ConversionErrorKind> {
+        self.0.symbol.with(|symbol| match self.0.kind {
+            bridge::LitKind::Char => {
+                unescape_char(symbol).map_err(ConversionErrorKind::FailedToUnescape)
+            }
+            _ => Err(ConversionErrorKind::InvalidLiteralKind),
         })
     }
 

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -1445,9 +1445,9 @@ impl Literal {
         })
     }
 
-    /// Returns the unescaped char value if the current literal is a char.
+    /// Returns the unescaped character value if the current literal is a byte character literal.
     #[unstable(feature = "proc_macro_value", issue = "136652")]
-    pub fn byte_value(&self) -> Result<u8, ConversionErrorKind> {
+    pub fn byte_character_value(&self) -> Result<u8, ConversionErrorKind> {
         self.0.symbol.with(|symbol| match self.0.kind {
             bridge::LitKind::Char => {
                 unescape_byte(symbol).map_err(ConversionErrorKind::FailedToUnescape)
@@ -1456,9 +1456,9 @@ impl Literal {
         })
     }
 
-    /// Returns the unescaped char value if the current literal is a char.
+    /// Returns the unescaped character value if the current literal is a character literal.
     #[unstable(feature = "proc_macro_value", issue = "136652")]
-    pub fn char_value(&self) -> Result<char, ConversionErrorKind> {
+    pub fn character_value(&self) -> Result<char, ConversionErrorKind> {
         self.0.symbol.with(|symbol| match self.0.kind {
             bridge::LitKind::Char => {
                 unescape_char(symbol).map_err(ConversionErrorKind::FailedToUnescape)


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/136652.

It adds two more methods to get unescaped `u8` and `char` from `proc_macro::Literal`.

r? @Amanieu 