### PR TITLE
Pass on the `feedable` query modifier to macros

### DIFF
--- a/compiler/rustc_macros/src/query.rs
+++ b/compiler/rustc_macros/src/query.rs
@@ -373,6 +373,7 @@ pub(super) fn rustc_queries(input: TokenStream) -> TokenStream {
             no_hash,
             anon,
             eval_always,
+            feedable,
             depth_limit,
             separate_provide_extern,
             return_result_from_ensure_ok,


### PR DESCRIPTION
This passes on the `feedable` query modifier to macros so `QueryConfig.feedable` gives the correct result. Currently it's always false even for feedable queries.

Fixing this bug enables some consistency checks for feedable queries that were previously not being performed, which has a perf impact.