### PR TITLE
resolve: Replace `Macros20NormalizedIdent` with `IdentKey`

### DIFF
--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -26,7 +26,7 @@ use rustc_middle::metadata::{ModChild, Reexport};
 use rustc_middle::ty::{Feed, Visibility};
 use rustc_middle::{bug, span_bug};
 use rustc_span::hygiene::{ExpnId, LocalExpnId, MacroKind};
-use rustc_span::{Ident, Macros20NormalizedIdent, Span, Symbol, kw, sym};
+use rustc_span::{Ident, Span, Symbol, kw, sym};
 use thin_vec::ThinVec;
 use tracing::debug;
 
@@ -36,9 +36,9 @@ use crate::imports::{ImportData, ImportKind};
 use crate::macros::{MacroRulesDecl, MacroRulesScope, MacroRulesScopeRef};
 use crate::ref_mut::CmCell;
 use crate::{
-    BindingKey, Decl, DeclData, DeclKind, ExternPreludeEntry, Finalize, MacroData, Module,
-    ModuleKind, ModuleOrUniformRoot, ParentScope, PathResult, ResolutionError, Resolver, Segment,
-    Used, VisResolutionError, errors,
+    BindingKey, Decl, DeclData, DeclKind, ExternPreludeEntry, Finalize, IdentKey, MacroData,
+    Module, ModuleKind, ModuleOrUniformRoot, ParentScope, PathResult, ResolutionError, Resolver,
+    Segment, Used, VisResolutionError, errors,
 };
 
 type Res = def::Res<NodeId>;
@@ -48,12 +48,15 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     /// and report an error in case of a collision.
     pub(crate) fn plant_decl_into_local_module(
         &mut self,
-        ident: Macros20NormalizedIdent,
+        ident: IdentKey,
+        orig_ident_span: Span,
         ns: Namespace,
         decl: Decl<'ra>,
     ) {
-        if let Err(old_decl) = self.try_plant_decl_into_local_module(ident, ns, decl, false) {
-            self.report_conflict(ident.0, ns, old_decl, decl);
+        if let Err(old_decl) =
+            self.try_plant_decl_into_local_module(ident, orig_ident_span, ns, decl, false)
+        {
+            self.report_conflict(ident, ns, old_decl, decl);
         }
     }
 
@@ -61,7 +64,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     fn define_local(
         &mut self,
         parent: Module<'ra>,
-        ident: Ident,
+        orig_ident: Ident,
         ns: Namespace,
         res: Res,
         vis: Visibility,
@@ -69,15 +72,16 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         expn_id: LocalExpnId,
     ) {
         let decl = self.arenas.new_def_decl(res, vis.to_def_id(), span, expn_id, Some(parent));
-        let ident = Macros20NormalizedIdent::new(ident);
-        self.plant_decl_into_local_module(ident, ns, decl);
+        let ident = IdentKey::new(orig_ident);
+        self.plant_decl_into_local_module(ident, orig_ident.span, ns, decl);
     }
 
     /// Create a name definitinon from the given components, and put it into the extern module.
     fn define_extern(
         &self,
         parent: Module<'ra>,
-        ident: Macros20NormalizedIdent,
+        ident: IdentKey,
+        orig_ident_span: Span,
         ns: Namespace,
         child_index: usize,
         res: Res,
@@ -102,7 +106,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         let key =
             BindingKey::new_disambiguated(ident, ns, || (child_index + 1).try_into().unwrap()); // 0 indicates no underscore
         if self
-            .resolution_or_default(parent, key)
+            .resolution_or_default(parent, key, orig_ident_span)
             .borrow_mut_unchecked()
             .non_glob_decl
             .replace(decl)
@@ -279,8 +283,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     .unwrap_or_else(|| res.def_id()),
             )
         };
-        let ModChild { ident, res, vis, ref reexport_chain } = *child;
-        let ident = Macros20NormalizedIdent::new(ident);
+        let ModChild { ident: orig_ident, res, vis, ref reexport_chain } = *child;
+        let ident = IdentKey::new(orig_ident);
         let span = child_span(self, reexport_chain, res);
         let res = res.expect_non_local();
         let expansion = parent_scope.expansion;
@@ -293,7 +297,18 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
         // Record primary definitions.
         let define_extern = |ns| {
-            self.define_extern(parent, ident, ns, child_index, res, vis, span, expansion, ambig)
+            self.define_extern(
+                parent,
+                ident,
+                orig_ident.span,
+                ns,
+                child_index,
+                res,
+                vis,
+                span,
+                expansion,
+                ambig,
+            )
         };
         match res {
             Res::Def(
@@ -533,8 +548,8 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
                 if target.name != kw::Underscore {
                     self.r.per_ns(|this, ns| {
                         if !type_ns_only || ns == TypeNS {
-                            let key = BindingKey::new(Macros20NormalizedIdent::new(target), ns);
-                            this.resolution_or_default(current_module, key)
+                            let key = BindingKey::new(IdentKey::new(target), ns);
+                            this.resolution_or_default(current_module, key, target.span)
                                 .borrow_mut(this)
                                 .single_imports
                                 .insert(import);
@@ -974,7 +989,7 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
         &mut self,
         orig_name: Option<Symbol>,
         item: &Item,
-        ident: Ident,
+        orig_ident: Ident,
         local_def_id: LocalDefId,
         vis: Visibility,
     ) {
@@ -983,7 +998,7 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
         let parent = parent_scope.module;
         let expansion = parent_scope.expansion;
 
-        let (used, module, decl) = if orig_name.is_none() && ident.name == kw::SelfLower {
+        let (used, module, decl) = if orig_name.is_none() && orig_ident.name == kw::SelfLower {
             self.r.dcx().emit_err(errors::ExternCrateSelfRequiresRenaming { span: sp });
             return;
         } else if orig_name == Some(kw::SelfLower) {
@@ -1008,7 +1023,7 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
         })
         .unwrap_or((true, None, self.r.dummy_decl));
         let import = self.r.arenas.alloc_import(ImportData {
-            kind: ImportKind::ExternCrate { source: orig_name, target: ident, id: item.id },
+            kind: ImportKind::ExternCrate { source: orig_name, target: orig_ident, id: item.id },
             root_id: item.id,
             parent_scope,
             imported_module: CmCell::new(module),
@@ -1026,7 +1041,7 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
         }
         self.r.potentially_unused_imports.push(import);
         let import_decl = self.r.new_import_decl(decl, import);
-        let ident = Macros20NormalizedIdent::new(ident);
+        let ident = IdentKey::new(orig_ident);
         if ident.name != kw::Underscore && parent == self.r.graph_root {
             // FIXME: this error is technically unnecessary now when extern prelude is split into
             // two scopes, remove it with lang team approval.
@@ -1045,20 +1060,20 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
                 Entry::Occupied(mut occupied) => {
                     let entry = occupied.get_mut();
                     if entry.item_decl.is_some() {
-                        let msg = format!("extern crate `{ident}` already in extern prelude");
+                        let msg = format!("extern crate `{orig_ident}` already in extern prelude");
                         self.r.tcx.dcx().span_delayed_bug(item.span, msg);
                     } else {
-                        entry.item_decl = Some((import_decl, orig_name.is_some()));
+                        entry.item_decl = Some((import_decl, orig_ident.span, orig_name.is_some()));
                     }
                     entry
                 }
                 Entry::Vacant(vacant) => vacant.insert(ExternPreludeEntry {
-                    item_decl: Some((import_decl, true)),
+                    item_decl: Some((import_decl, orig_ident.span, true)),
                     flag_decl: None,
                 }),
             };
         }
-        self.r.plant_decl_into_local_module(ident, TypeNS, import_decl);
+        self.r.plant_decl_into_local_module(ident, orig_ident.span, TypeNS, import_decl);
     }
 
     /// Constructs the reduced graph for one foreign item.
@@ -1159,7 +1174,7 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
         if let Some(span) = import_all {
             let import = macro_use_import(self, span, false);
             self.r.potentially_unused_imports.push(import);
-            module.for_each_child_mut(self, |this, ident, ns, binding| {
+            module.for_each_child_mut(self, |this, ident, _, ns, binding| {
                 if ns == MacroNS {
                     let import =
                         if this.r.is_accessible_from(binding.vis(), this.parent_scope.module) {
@@ -1270,7 +1285,7 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
         let expansion = parent_scope.expansion;
         let feed = self.r.feed(item.id);
         let def_id = feed.key();
-        let (res, ident, span, macro_rules) = match &item.kind {
+        let (res, orig_ident, span, macro_rules) = match &item.kind {
             ItemKind::MacroDef(ident, def) => {
                 (self.res(def_id), *ident, item.span, def.macro_rules)
             }
@@ -1293,8 +1308,8 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
         self.r.local_macro_def_scopes.insert(def_id, parent_scope.module);
 
         if macro_rules {
-            let ident = Macros20NormalizedIdent::new(ident);
-            self.r.macro_names.insert(ident.0);
+            let ident = IdentKey::new(orig_ident);
+            self.r.macro_names.insert(ident);
             let is_macro_export = ast::attr::contains_name(&item.attrs, sym::macro_export);
             let vis = if is_macro_export {
                 Visibility::Public
@@ -1326,10 +1341,10 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
                 });
                 self.r.import_use_map.insert(import, Used::Other);
                 let import_decl = self.r.new_import_decl(decl, import);
-                self.r.plant_decl_into_local_module(ident, MacroNS, import_decl);
+                self.r.plant_decl_into_local_module(ident, orig_ident.span, MacroNS, import_decl);
             } else {
-                self.r.check_reserved_macro_name(ident.0, res);
-                self.insert_unused_macro(ident.0, def_id, item.id);
+                self.r.check_reserved_macro_name(ident.name, orig_ident.span, res);
+                self.insert_unused_macro(orig_ident, def_id, item.id);
             }
             self.r.feed_visibility(feed, vis);
             let scope = self.r.arenas.alloc_macro_rules_scope(MacroRulesScope::Def(
@@ -1337,6 +1352,7 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
                     parent_macro_rules_scope: parent_scope.macro_rules,
                     decl,
                     ident,
+                    orig_ident_span: orig_ident.span,
                 }),
             ));
             self.r.macro_rules_scopes.insert(def_id, scope);
@@ -1352,9 +1368,9 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
                 _ => self.resolve_visibility(&item.vis),
             };
             if !vis.is_public() {
-                self.insert_unused_macro(ident, def_id, item.id);
+                self.insert_unused_macro(orig_ident, def_id, item.id);
             }
-            self.r.define_local(module, ident, MacroNS, res, vis, span, expansion);
+            self.r.define_local(module, orig_ident, MacroNS, res, vis, span, expansion);
             self.r.feed_visibility(feed, vis);
             self.parent_scope.macro_rules
         }
@@ -1496,7 +1512,7 @@ impl<'a, 'ra, 'tcx> Visitor<'a> for BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
         {
             // Don't add underscore names, they cannot be looked up anyway.
             let impl_def_id = self.r.tcx.local_parent(local_def_id);
-            let key = BindingKey::new(Macros20NormalizedIdent::new(ident), ns);
+            let key = BindingKey::new(IdentKey::new(ident), ns);
             self.r.impl_binding_keys.entry(impl_def_id).or_default().insert(key);
         }
 

--- a/compiler/rustc_resolve/src/check_unused.rs
+++ b/compiler/rustc_resolve/src/check_unused.rs
@@ -33,10 +33,10 @@ use rustc_session::lint::BuiltinLintDiag;
 use rustc_session::lint::builtin::{
     MACRO_USE_EXTERN_CRATE, UNUSED_EXTERN_CRATES, UNUSED_IMPORTS, UNUSED_QUALIFICATIONS,
 };
-use rustc_span::{DUMMY_SP, Ident, Macros20NormalizedIdent, Span, kw};
+use rustc_span::{DUMMY_SP, Ident, Span, kw};
 
 use crate::imports::{Import, ImportKind};
-use crate::{DeclKind, LateDecl, Resolver, module_to_string};
+use crate::{DeclKind, IdentKey, LateDecl, Resolver, module_to_string};
 
 struct UnusedImport {
     use_tree: ast::UseTree,
@@ -203,7 +203,7 @@ impl<'a, 'ra, 'tcx> UnusedImportCheckVisitor<'a, 'ra, 'tcx> {
             if self
                 .r
                 .extern_prelude
-                .get(&Macros20NormalizedIdent::new(extern_crate.ident))
+                .get(&IdentKey::new(extern_crate.ident))
                 .is_none_or(|entry| entry.introduced_by_item())
             {
                 continue;

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -601,7 +601,7 @@ pub(crate) struct ProcMacroDeriveResolutionFallback {
     #[label]
     pub span: Span,
     pub ns_descr: &'static str,
-    pub ident: Ident,
+    pub ident: Symbol,
 }
 
 #[derive(LintDiagnostic)]
@@ -1151,7 +1151,7 @@ pub(crate) struct CannotUseThroughAnImport {
 pub(crate) struct NameReservedInAttributeNamespace {
     #[primary_span]
     pub(crate) span: Span,
-    pub(crate) ident: Ident,
+    pub(crate) ident: Symbol,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -20,7 +20,7 @@ use rustc_session::lint::builtin::{
 use rustc_session::parse::feature_err;
 use rustc_span::edit_distance::find_best_match_for_name;
 use rustc_span::hygiene::LocalExpnId;
-use rustc_span::{Ident, Macros20NormalizedIdent, Span, Symbol, kw, sym};
+use rustc_span::{Ident, Span, Symbol, kw, sym};
 use tracing::debug;
 
 use crate::Namespace::{self, *};
@@ -33,8 +33,8 @@ use crate::errors::{
 use crate::ref_mut::CmCell;
 use crate::{
     AmbiguityError, BindingKey, CmResolver, Decl, DeclData, DeclKind, Determinacy, Finalize,
-    ImportSuggestion, Module, ModuleOrUniformRoot, ParentScope, PathResult, PerNS, ResolutionError,
-    Resolver, ScopeSet, Segment, Used, module_to_string, names_to_string,
+    IdentKey, ImportSuggestion, Module, ModuleOrUniformRoot, ParentScope, PathResult, PerNS,
+    ResolutionError, Resolver, ScopeSet, Segment, Used, module_to_string, names_to_string,
 };
 
 type Res = def::Res<NodeId>;
@@ -239,18 +239,23 @@ impl<'ra> ImportData<'ra> {
 }
 
 /// Records information about the resolution of a name in a namespace of a module.
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct NameResolution<'ra> {
     /// Single imports that may define the name in the namespace.
     /// Imports are arena-allocated, so it's ok to use pointers as keys.
     pub single_imports: FxIndexSet<Import<'ra>>,
     /// The non-glob declaration for this name, if it is known to exist.
-    pub non_glob_decl: Option<Decl<'ra>>,
+    pub non_glob_decl: Option<Decl<'ra>> = None,
     /// The glob declaration for this name, if it is known to exist.
-    pub glob_decl: Option<Decl<'ra>>,
+    pub glob_decl: Option<Decl<'ra>> = None,
+    pub orig_ident_span: Span,
 }
 
 impl<'ra> NameResolution<'ra> {
+    pub(crate) fn new(orig_ident_span: Span) -> Self {
+        NameResolution { single_imports: FxIndexSet::default(), orig_ident_span, .. }
+    }
+
     /// Returns the binding for the name if it is known or None if it not known.
     pub(crate) fn binding(&self) -> Option<Decl<'ra>> {
         self.best_decl().and_then(|binding| {
@@ -417,14 +422,15 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     /// and return existing declaration if there is a collision.
     pub(crate) fn try_plant_decl_into_local_module(
         &mut self,
-        ident: Macros20NormalizedIdent,
+        ident: IdentKey,
+        orig_ident_span: Span,
         ns: Namespace,
         decl: Decl<'ra>,
         warn_ambiguity: bool,
     ) -> Result<(), Decl<'ra>> {
         let module = decl.parent_module.unwrap();
         let res = decl.res();
-        self.check_reserved_macro_name(ident.0, res);
+        self.check_reserved_macro_name(ident.name, orig_ident_span, res);
         // Even if underscore names cannot be looked up, we still need to add them to modules,
         // because they can be fetched by glob imports from those modules, and bring traits
         // into scope both directly and through glob imports.
@@ -432,46 +438,52 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             module.underscore_disambiguator.update_unchecked(|d| d + 1);
             module.underscore_disambiguator.get()
         });
-        self.update_local_resolution(module, key, warn_ambiguity, |this, resolution| {
-            if let Some(old_decl) = resolution.best_decl() {
-                assert_ne!(decl, old_decl);
-                assert!(!decl.warn_ambiguity.get());
-                if res == Res::Err && old_decl.res() != Res::Err {
-                    // Do not override real declarations with `Res::Err`s from error recovery.
-                    return Ok(());
-                }
-                match (old_decl.is_glob_import(), decl.is_glob_import()) {
-                    (true, true) => {
-                        resolution.glob_decl =
-                            Some(this.select_glob_decl(old_decl, decl, warn_ambiguity));
+        self.update_local_resolution(
+            module,
+            key,
+            orig_ident_span,
+            warn_ambiguity,
+            |this, resolution| {
+                if let Some(old_decl) = resolution.best_decl() {
+                    assert_ne!(decl, old_decl);
+                    assert!(!decl.warn_ambiguity.get());
+                    if res == Res::Err && old_decl.res() != Res::Err {
+                        // Do not override real declarations with `Res::Err`s from error recovery.
+                        return Ok(());
                     }
-                    (old_glob @ true, false) | (old_glob @ false, true) => {
-                        let (glob_decl, non_glob_decl) =
-                            if old_glob { (old_decl, decl) } else { (decl, old_decl) };
-                        resolution.non_glob_decl = Some(non_glob_decl);
-                        if let Some(old_glob_decl) = resolution.glob_decl
-                            && old_glob_decl != glob_decl
-                        {
+                    match (old_decl.is_glob_import(), decl.is_glob_import()) {
+                        (true, true) => {
                             resolution.glob_decl =
-                                Some(this.select_glob_decl(old_glob_decl, glob_decl, false));
-                        } else {
-                            resolution.glob_decl = Some(glob_decl);
+                                Some(this.select_glob_decl(old_decl, decl, warn_ambiguity));
+                        }
+                        (old_glob @ true, false) | (old_glob @ false, true) => {
+                            let (glob_decl, non_glob_decl) =
+                                if old_glob { (old_decl, decl) } else { (decl, old_decl) };
+                            resolution.non_glob_decl = Some(non_glob_decl);
+                            if let Some(old_glob_decl) = resolution.glob_decl
+                                && old_glob_decl != glob_decl
+                            {
+                                resolution.glob_decl =
+                                    Some(this.select_glob_decl(old_glob_decl, glob_decl, false));
+                            } else {
+                                resolution.glob_decl = Some(glob_decl);
+                            }
+                        }
+                        (false, false) => {
+                            return Err(old_decl);
                         }
                     }
-                    (false, false) => {
-                        return Err(old_decl);
+                } else {
+                    if decl.is_glob_import() {
+                        resolution.glob_decl = Some(decl);
+                    } else {
+                        resolution.non_glob_decl = Some(decl);
                     }
                 }
-            } else {
-                if decl.is_glob_import() {
-                    resolution.glob_decl = Some(decl);
-                } else {
-                    resolution.non_glob_decl = Some(decl);
-                }
-            }
 
-            Ok(())
-        })
+                Ok(())
+            },
+        )
     }
 
     // Use `f` to mutate the resolution of the name in the module.
@@ -480,6 +492,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         &mut self,
         module: Module<'ra>,
         key: BindingKey,
+        orig_ident_span: Span,
         warn_ambiguity: bool,
         f: F,
     ) -> T
@@ -489,7 +502,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         // Ensure that `resolution` isn't borrowed when defining in the module's glob importers,
         // during which the resolution might end up getting re-defined via a glob cycle.
         let (binding, t, warn_ambiguity) = {
-            let resolution = &mut *self.resolution_or_default(module, key).borrow_mut_unchecked();
+            let resolution = &mut *self
+                .resolution_or_default(module, key, orig_ident_span)
+                .borrow_mut_unchecked();
             let old_decl = resolution.binding();
 
             let t = f(self, resolution);
@@ -510,7 +525,10 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         // Define or update `binding` in `module`s glob importers.
         for import in glob_importers.iter() {
             let mut ident = key.ident;
-            let scope = match ident.0.span.reverse_glob_adjust(module.expansion, import.span) {
+            let scope = match ident
+                .ctxt
+                .update_unchecked(|ctxt| ctxt.reverse_glob_adjust(module.expansion, import.span))
+            {
                 Some(Some(def)) => self.expn_def_scope(def),
                 Some(None) => import.parent_scope.module,
                 None => continue,
@@ -519,6 +537,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 let import_decl = self.new_import_decl(binding, *import);
                 let _ = self.try_plant_decl_into_local_module(
                     ident,
+                    orig_ident_span,
                     key.ns,
                     import_decl,
                     warn_ambiguity,
@@ -540,14 +559,26 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             let dummy_decl = self.new_import_decl(dummy_decl, import);
             self.per_ns(|this, ns| {
                 let module = import.parent_scope.module;
-                let ident = Macros20NormalizedIdent::new(target);
-                let _ = this.try_plant_decl_into_local_module(ident, ns, dummy_decl, false);
+                let ident = IdentKey::new(target);
+                let _ = this.try_plant_decl_into_local_module(
+                    ident,
+                    target.span,
+                    ns,
+                    dummy_decl,
+                    false,
+                );
                 // Don't remove underscores from `single_imports`, they were never added.
                 if target.name != kw::Underscore {
                     let key = BindingKey::new(ident, ns);
-                    this.update_local_resolution(module, key, false, |_, resolution| {
-                        resolution.single_imports.swap_remove(&import);
-                    })
+                    this.update_local_resolution(
+                        module,
+                        key,
+                        target.span,
+                        false,
+                        |_, resolution| {
+                            resolution.single_imports.swap_remove(&import);
+                        },
+                    )
                 }
             });
             self.record_use(target, dummy_decl, Used::Other);
@@ -687,7 +718,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         import.root_id,
                         import.root_span,
                         BuiltinLintDiag::AmbiguousGlobReexports {
-                            name: key.ident.to_string(),
+                            name: key.ident.name.to_string(),
                             namespace: key.ns.descr().to_string(),
                             first_reexport_span: import.root_span,
                             duplicate_reexport_span: amb_binding.span,
@@ -922,7 +953,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         // We need the `target`, `source` can be extracted.
                         let import_decl = this.new_import_decl(binding, import);
                         this.get_mut_unchecked().plant_decl_into_local_module(
-                            Macros20NormalizedIdent::new(target),
+                            IdentKey::new(target),
+                            target.span,
                             ns,
                             import_decl,
                         );
@@ -931,10 +963,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     Err(Determinacy::Determined) => {
                         // Don't remove underscores from `single_imports`, they were never added.
                         if target.name != kw::Underscore {
-                            let key = BindingKey::new(Macros20NormalizedIdent::new(target), ns);
+                            let key = BindingKey::new(IdentKey::new(target), ns);
                             this.get_mut_unchecked().update_local_resolution(
                                 parent,
                                 key,
+                                target.span,
                                 false,
                                 |_, resolution| {
                                     resolution.single_imports.swap_remove(&import);
@@ -1531,15 +1564,19 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             .borrow()
             .iter()
             .filter_map(|(key, resolution)| {
-                resolution.borrow().binding().map(|binding| (*key, binding))
+                let resolution = resolution.borrow();
+                resolution.binding().map(|binding| (*key, binding, resolution.orig_ident_span))
             })
             .collect::<Vec<_>>();
-        for (mut key, binding) in bindings {
-            let scope = match key.ident.0.span.reverse_glob_adjust(module.expansion, import.span) {
-                Some(Some(def)) => self.expn_def_scope(def),
-                Some(None) => import.parent_scope.module,
-                None => continue,
-            };
+        for (mut key, binding, orig_ident_span) in bindings {
+            let scope =
+                match key.ident.ctxt.update_unchecked(|ctxt| {
+                    ctxt.reverse_glob_adjust(module.expansion, import.span)
+                }) {
+                    Some(Some(def)) => self.expn_def_scope(def),
+                    Some(None) => import.parent_scope.module,
+                    None => continue,
+                };
             if self.is_accessible_from(binding.vis(), scope) {
                 let import_decl = self.new_import_decl(binding, import);
                 let warn_ambiguity = self
@@ -1548,6 +1585,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     .is_some_and(|binding| binding.warn_ambiguity_recursive());
                 let _ = self.try_plant_decl_into_local_module(
                     key.ident,
+                    orig_ident_span,
                     key.ns,
                     import_decl,
                     warn_ambiguity,
@@ -1575,19 +1613,16 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         let mut children = Vec::new();
         let mut ambig_children = Vec::new();
 
-        module.for_each_child(self, |this, ident, _, binding| {
+        module.for_each_child(self, |this, ident, orig_ident_span, _, binding| {
             let res = binding.res().expect_non_local();
             if res != def::Res::Err {
-                let child = |reexport_chain| ModChild {
-                    ident: ident.0,
-                    res,
-                    vis: binding.vis(),
-                    reexport_chain,
-                };
+                let ident = ident.orig(orig_ident_span);
+                let child =
+                    |reexport_chain| ModChild { ident, res, vis: binding.vis(), reexport_chain };
                 if let Some((ambig_binding1, ambig_binding2)) = binding.descent_to_ambiguity() {
                     let main = child(ambig_binding1.reexport_chain(this));
                     let second = ModChild {
-                        ident: ident.0,
+                        ident,
                         res: ambig_binding2.res().expect_non_local(),
                         vis: ambig_binding2.vis(),
                         reexport_chain: ambig_binding2.reexport_chain(this),

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -37,15 +37,15 @@ use rustc_session::config::{CrateType, ResolveDocLinks};
 use rustc_session::lint;
 use rustc_session::parse::feature_err;
 use rustc_span::source_map::{Spanned, respan};
-use rustc_span::{BytePos, DUMMY_SP, Ident, Macros20NormalizedIdent, Span, Symbol, kw, sym};
+use rustc_span::{BytePos, DUMMY_SP, Ident, Span, Symbol, kw, sym};
 use smallvec::{SmallVec, smallvec};
 use thin_vec::ThinVec;
 use tracing::{debug, instrument, trace};
 
 use crate::{
-    BindingError, BindingKey, Decl, Finalize, LateDecl, Module, ModuleOrUniformRoot, ParentScope,
-    PathResult, ResolutionError, Resolver, Segment, Stage, TyCtxt, UseError, Used, errors,
-    path_names_to_string, rustdoc,
+    BindingError, BindingKey, Decl, Finalize, IdentKey, LateDecl, Module, ModuleOrUniformRoot,
+    ParentScope, PathResult, ResolutionError, Resolver, Segment, Stage, TyCtxt, UseError, Used,
+    errors, path_names_to_string, rustdoc,
 };
 
 mod diagnostics;
@@ -3650,7 +3650,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
             return;
         };
         ident.span.normalize_to_macros_2_0_and_adjust(module.expansion);
-        let key = BindingKey::new(Macros20NormalizedIdent::new(ident), ns);
+        let key = BindingKey::new(IdentKey::new(ident), ns);
         let mut decl = self.r.resolution(module, key).and_then(|r| r.best_decl());
         debug!(?decl);
         if decl.is_none() {
@@ -3661,7 +3661,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 TypeNS => ValueNS,
                 _ => ns,
             };
-            let key = BindingKey::new(Macros20NormalizedIdent::new(ident), ns);
+            let key = BindingKey::new(IdentKey::new(ident), ns);
             decl = self.r.resolution(module, key).and_then(|r| r.best_decl());
             debug!(?decl);
         }

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -29,16 +29,17 @@ use rustc_session::parse::feature_err;
 use rustc_span::edit_distance::find_best_match_for_name;
 use rustc_span::edition::Edition;
 use rustc_span::hygiene::{self, AstPass, ExpnData, ExpnKind, LocalExpnId, MacroKind};
-use rustc_span::{DUMMY_SP, Ident, Macros20NormalizedIdent, Span, Symbol, kw, sym};
+use rustc_span::{DUMMY_SP, Ident, Span, Symbol, kw, sym};
 
 use crate::Namespace::*;
 use crate::errors::{
     self, AddAsNonDerive, CannotDetermineMacroResolution, CannotFindIdentInThisScope,
     MacroExpectedFound, RemoveSurroundingDerive,
 };
+use crate::hygiene::Macros20NormalizedSyntaxContext;
 use crate::imports::Import;
 use crate::{
-    BindingKey, CacheCell, CmResolver, Decl, DeclKind, DeriveData, Determinacy, Finalize,
+    BindingKey, CacheCell, CmResolver, Decl, DeclKind, DeriveData, Determinacy, Finalize, IdentKey,
     InvocationParent, MacroData, ModuleKind, ModuleOrUniformRoot, ParentScope, PathResult,
     ResolutionError, Resolver, ScopeSet, Segment, Used,
 };
@@ -52,7 +53,8 @@ pub(crate) struct MacroRulesDecl<'ra> {
     pub(crate) decl: Decl<'ra>,
     /// `macro_rules` scope into which the `macro_rules` item was planted.
     pub(crate) parent_macro_rules_scope: MacroRulesScopeRef<'ra>,
-    pub(crate) ident: Macros20NormalizedIdent,
+    pub(crate) ident: IdentKey,
+    pub(crate) orig_ident_span: Span,
 }
 
 /// The scope introduced by a `macro_rules!` macro.
@@ -412,9 +414,12 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
                         Ok((Some(ext), _)) => {
                             if !ext.helper_attrs.is_empty() {
                                 let span = resolution.path.segments.last().unwrap().ident.span;
-                                entry.helper_attrs.extend(ext.helper_attrs.iter().map(|name| {
-                                    (i, Macros20NormalizedIdent::new(Ident::new(*name, span)))
-                                }));
+                                let ctxt = Macros20NormalizedSyntaxContext::new(span.ctxt());
+                                entry.helper_attrs.extend(
+                                    ext.helper_attrs
+                                        .iter()
+                                        .map(|&name| (i, IdentKey { name, ctxt }, span)),
+                                );
                             }
                             entry.has_derive_copy |= ext.builtin_name == Some(sym::Copy);
                             ext
@@ -430,13 +435,14 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
             }
         }
         // Sort helpers in a stable way independent from the derive resolution order.
-        entry.helper_attrs.sort_by_key(|(i, _)| *i);
+        entry.helper_attrs.sort_by_key(|(i, ..)| *i);
         let helper_attrs = entry
             .helper_attrs
             .iter()
-            .map(|(_, ident)| {
+            .map(|&(_, ident, orig_ident_span)| {
                 let res = Res::NonMacroAttr(NonMacroAttrKind::DeriveHelper);
-                (*ident, self.arenas.new_pub_def_decl(res, ident.span, expn_id))
+                let decl = self.arenas.new_pub_def_decl(res, orig_ident_span, expn_id);
+                (ident, orig_ident_span, decl)
             })
             .collect();
         self.helper_attrs.insert(expn_id, helper_attrs);
@@ -532,14 +538,14 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
         }
 
         let mut idents = Vec::new();
-        target_trait.for_each_child(self, |this, ident, ns, _binding| {
+        target_trait.for_each_child(self, |this, ident, orig_ident_span, ns, _binding| {
             // FIXME: Adjust hygiene for idents from globs, like for glob imports.
             if let Some(overriding_keys) = this.impl_binding_keys.get(&impl_def_id)
                 && overriding_keys.contains(&BindingKey::new(ident, ns))
             {
                 // The name is overridden, do not produce it from the glob delegation.
             } else {
-                idents.push((ident.0, None));
+                idents.push((ident.orig(orig_ident_span), None));
             }
         });
         Ok(idents)
@@ -1145,14 +1151,13 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         }
     }
 
-    pub(crate) fn check_reserved_macro_name(&self, ident: Ident, res: Res) {
+    pub(crate) fn check_reserved_macro_name(&self, name: Symbol, span: Span, res: Res) {
         // Reserve some names that are not quite covered by the general check
         // performed on `Resolver::builtin_attrs`.
-        if ident.name == sym::cfg || ident.name == sym::cfg_attr {
+        if name == sym::cfg || name == sym::cfg_attr {
             let macro_kinds = self.get_macro(res).map(|macro_data| macro_data.ext.macro_kinds());
             if macro_kinds.is_some() && sub_namespace_match(macro_kinds, Some(MacroKind::Attr)) {
-                self.dcx()
-                    .emit_err(errors::NameReservedInAttributeNamespace { span: ident.span, ident });
+                self.dcx().emit_err(errors::NameReservedInAttributeNamespace { span, ident: name });
             }
         }
     }

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -837,11 +837,7 @@ impl SyntaxContext {
     /// ```
     /// This returns `None` if the context cannot be glob-adjusted.
     /// Otherwise, it returns the scope to use when privacy checking (see `adjust` for details).
-    pub(crate) fn glob_adjust(
-        &mut self,
-        expn_id: ExpnId,
-        glob_span: Span,
-    ) -> Option<Option<ExpnId>> {
+    pub fn glob_adjust(&mut self, expn_id: ExpnId, glob_span: Span) -> Option<Option<ExpnId>> {
         HygieneData::with(|data| {
             let mut scope = None;
             let mut glob_ctxt = data.normalize_to_macros_2_0(glob_span.ctxt());
@@ -865,7 +861,7 @@ impl SyntaxContext {
     ///     assert!(self.glob_adjust(expansion, glob_ctxt) == Some(privacy_checking_scope));
     /// }
     /// ```
-    pub(crate) fn reverse_glob_adjust(
+    pub fn reverse_glob_adjust(
         &mut self,
         expn_id: ExpnId,
         glob_span: Span,

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -63,8 +63,7 @@ pub use span_encoding::{DUMMY_SP, Span};
 
 pub mod symbol;
 pub use symbol::{
-    ByteSymbol, Ident, MacroRulesNormalizedIdent, Macros20NormalizedIdent, STDLIB_STABLE_CRATES,
-    Symbol, kw, sym,
+    ByteSymbol, Ident, MacroRulesNormalizedIdent, STDLIB_STABLE_CRATES, Symbol, kw, sym,
 };
 
 mod analyze_source_file;
@@ -1307,30 +1306,6 @@ impl Span {
         let mut mark = None;
         *self = self.map_ctxt(|mut ctxt| {
             mark = ctxt.normalize_to_macros_2_0_and_adjust(expn_id);
-            ctxt
-        });
-        mark
-    }
-
-    #[inline]
-    pub fn glob_adjust(&mut self, expn_id: ExpnId, glob_span: Span) -> Option<Option<ExpnId>> {
-        let mut mark = None;
-        *self = self.map_ctxt(|mut ctxt| {
-            mark = ctxt.glob_adjust(expn_id, glob_span);
-            ctxt
-        });
-        mark
-    }
-
-    #[inline]
-    pub fn reverse_glob_adjust(
-        &mut self,
-        expn_id: ExpnId,
-        glob_span: Span,
-    ) -> Option<Option<ExpnId>> {
-        let mut mark = None;
-        *self = self.map_ctxt(|mut ctxt| {
-            mark = ctxt.reverse_glob_adjust(expn_id, glob_span);
             ctxt
         });
         mark

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -3,7 +3,6 @@
 //! type, and vice versa.
 
 use std::hash::{Hash, Hasher};
-use std::ops::Deref;
 use std::{fmt, str};
 
 use rustc_arena::DroplessArena;
@@ -2748,7 +2747,7 @@ impl fmt::Display for IdentPrinter {
     }
 }
 
-/// An newtype around `Ident` that calls [Ident::normalize_to_macro_rules] on
+/// A newtype around `Ident` that calls [Ident::normalize_to_macro_rules] on
 /// construction for "local variable hygiene" comparisons.
 ///
 /// Use this type when you need to compare identifiers according to macro_rules hygiene.
@@ -2772,48 +2771,6 @@ impl fmt::Debug for MacroRulesNormalizedIdent {
 impl fmt::Display for MacroRulesNormalizedIdent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
-    }
-}
-
-/// An newtype around `Ident` that calls [Ident::normalize_to_macros_2_0] on
-/// construction for "item hygiene" comparisons.
-///
-/// Identifiers with same string value become same if they came from the same macro 2.0 macro
-/// (e.g., `macro` item, but not `macro_rules` item) and stay different if they came from
-/// different macro 2.0 macros.
-#[derive(Copy, Clone, Eq, PartialEq, Hash)]
-pub struct Macros20NormalizedIdent(pub Ident);
-
-impl Macros20NormalizedIdent {
-    #[inline]
-    pub fn new(ident: Ident) -> Self {
-        Macros20NormalizedIdent(ident.normalize_to_macros_2_0())
-    }
-
-    // dummy_span does not need to be normalized, so we can use `Ident` directly
-    pub fn with_dummy_span(name: Symbol) -> Self {
-        Macros20NormalizedIdent(Ident::with_dummy_span(name))
-    }
-}
-
-impl fmt::Debug for Macros20NormalizedIdent {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(&self.0, f)
-    }
-}
-
-impl fmt::Display for Macros20NormalizedIdent {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.0, f)
-    }
-}
-
-/// By impl Deref, we can access the wrapped Ident as if it were a normal Ident
-/// such as `norm_ident.name` instead of `norm_ident.0.name`.
-impl Deref for Macros20NormalizedIdent {
-    type Target = Ident;
-    fn deref(&self) -> &Self::Target {
-        &self.0
     }
 }
 

--- a/tests/ui/hygiene/cross-crate-name-hiding-2.stderr
+++ b/tests/ui/hygiene/cross-crate-name-hiding-2.stderr
@@ -1,13 +1,11 @@
 error[E0422]: cannot find struct, variant or union type `MyStruct` in this scope
   --> $DIR/cross-crate-name-hiding-2.rs:13:13
    |
+LL | my_struct!(define);
+   | ------------------ you might have meant to refer to this struct
+...
 LL |     let x = MyStruct {};
    |             ^^^^^^^^ not found in this scope
-   |
-  ::: $DIR/auxiliary/use_by_macro.rs:7:24
-   |
-LL |             pub struct MyStruct;
-   |                        -------- you might have meant to refer to this struct
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lint/unused/unused-macros.stderr
+++ b/tests/ui/lint/unused/unused-macros.stderr
@@ -15,6 +15,11 @@ error: unused macro definition: `m`
    |
 LL |         macro_rules! m {
    |                      ^
+...
+LL | create_macro!();
+   | --------------- in this macro invocation
+   |
+   = note: this error originates in the macro `create_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unused macro definition: `unused`
   --> $DIR/unused-macros.rs:26:18

--- a/tests/ui/proc-macro/dollar-crate-issue-62325.stdout
+++ b/tests/ui/proc-macro/dollar-crate-issue-62325.stdout
@@ -57,54 +57,54 @@ PRINT-ATTR INPUT (DISPLAY): struct B(identity! ($crate :: S));
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/auxiliary/dollar-crate-external.rs:21:5: 21:11 (#11),
+        span: $DIR/auxiliary/dollar-crate-external.rs:21:5: 21:11 (#12),
     },
     Ident {
         ident: "B",
-        span: $DIR/auxiliary/dollar-crate-external.rs:21:12: 21:13 (#11),
+        span: $DIR/auxiliary/dollar-crate-external.rs:21:12: 21:13 (#12),
     },
     Group {
         delimiter: Parenthesis,
         stream: TokenStream [
             Ident {
                 ident: "identity",
-                span: $DIR/auxiliary/dollar-crate-external.rs:21:14: 21:22 (#11),
+                span: $DIR/auxiliary/dollar-crate-external.rs:21:14: 21:22 (#12),
             },
             Punct {
                 ch: '!',
                 spacing: Alone,
-                span: $DIR/auxiliary/dollar-crate-external.rs:21:22: 21:23 (#11),
+                span: $DIR/auxiliary/dollar-crate-external.rs:21:22: 21:23 (#12),
             },
             Group {
                 delimiter: Parenthesis,
                 stream: TokenStream [
                     Ident {
                         ident: "$crate",
-                        span: $DIR/auxiliary/dollar-crate-external.rs:21:24: 21:30 (#11),
+                        span: $DIR/auxiliary/dollar-crate-external.rs:21:24: 21:30 (#12),
                     },
                     Punct {
                         ch: ':',
                         spacing: Joint,
-                        span: $DIR/auxiliary/dollar-crate-external.rs:21:30: 21:31 (#11),
+                        span: $DIR/auxiliary/dollar-crate-external.rs:21:30: 21:31 (#12),
                     },
                     Punct {
                         ch: ':',
                         spacing: Alone,
-                        span: $DIR/auxiliary/dollar-crate-external.rs:21:31: 21:32 (#11),
+                        span: $DIR/auxiliary/dollar-crate-external.rs:21:31: 21:32 (#12),
                     },
                     Ident {
                         ident: "S",
-                        span: $DIR/auxiliary/dollar-crate-external.rs:21:32: 21:33 (#11),
+                        span: $DIR/auxiliary/dollar-crate-external.rs:21:32: 21:33 (#12),
                     },
                 ],
-                span: $DIR/auxiliary/dollar-crate-external.rs:21:23: 21:34 (#11),
+                span: $DIR/auxiliary/dollar-crate-external.rs:21:23: 21:34 (#12),
             },
         ],
-        span: $DIR/auxiliary/dollar-crate-external.rs:21:13: 21:35 (#11),
+        span: $DIR/auxiliary/dollar-crate-external.rs:21:13: 21:35 (#12),
     },
     Punct {
         ch: ';',
         spacing: Alone,
-        span: $DIR/auxiliary/dollar-crate-external.rs:21:35: 21:36 (#11),
+        span: $DIR/auxiliary/dollar-crate-external.rs:21:35: 21:36 (#12),
     },
 ]

--- a/tests/ui/proc-macro/dollar-crate.stdout
+++ b/tests/ui/proc-macro/dollar-crate.stdout
@@ -122,119 +122,119 @@ PRINT-BANG INPUT (DISPLAY): struct M($crate :: S);
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/auxiliary/dollar-crate-external.rs:7:13: 7:19 (#14),
+        span: $DIR/auxiliary/dollar-crate-external.rs:7:13: 7:19 (#15),
     },
     Ident {
         ident: "M",
-        span: $DIR/auxiliary/dollar-crate-external.rs:7:20: 7:21 (#14),
+        span: $DIR/auxiliary/dollar-crate-external.rs:7:20: 7:21 (#15),
     },
     Group {
         delimiter: Parenthesis,
         stream: TokenStream [
             Ident {
                 ident: "$crate",
-                span: $DIR/auxiliary/dollar-crate-external.rs:7:22: 7:28 (#14),
+                span: $DIR/auxiliary/dollar-crate-external.rs:7:22: 7:28 (#15),
             },
             Punct {
                 ch: ':',
                 spacing: Joint,
-                span: $DIR/auxiliary/dollar-crate-external.rs:7:28: 7:29 (#14),
+                span: $DIR/auxiliary/dollar-crate-external.rs:7:28: 7:29 (#15),
             },
             Punct {
                 ch: ':',
                 spacing: Alone,
-                span: $DIR/auxiliary/dollar-crate-external.rs:7:29: 7:30 (#14),
+                span: $DIR/auxiliary/dollar-crate-external.rs:7:29: 7:30 (#15),
             },
             Ident {
                 ident: "S",
-                span: $DIR/auxiliary/dollar-crate-external.rs:7:30: 7:31 (#14),
+                span: $DIR/auxiliary/dollar-crate-external.rs:7:30: 7:31 (#15),
             },
         ],
-        span: $DIR/auxiliary/dollar-crate-external.rs:7:21: 7:32 (#14),
+        span: $DIR/auxiliary/dollar-crate-external.rs:7:21: 7:32 (#15),
     },
     Punct {
         ch: ';',
         spacing: Alone,
-        span: $DIR/auxiliary/dollar-crate-external.rs:7:32: 7:33 (#14),
+        span: $DIR/auxiliary/dollar-crate-external.rs:7:32: 7:33 (#15),
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): struct A($crate :: S);
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/auxiliary/dollar-crate-external.rs:11:9: 11:15 (#14),
+        span: $DIR/auxiliary/dollar-crate-external.rs:11:9: 11:15 (#15),
     },
     Ident {
         ident: "A",
-        span: $DIR/auxiliary/dollar-crate-external.rs:11:16: 11:17 (#14),
+        span: $DIR/auxiliary/dollar-crate-external.rs:11:16: 11:17 (#15),
     },
     Group {
         delimiter: Parenthesis,
         stream: TokenStream [
             Ident {
                 ident: "$crate",
-                span: $DIR/auxiliary/dollar-crate-external.rs:11:18: 11:24 (#14),
+                span: $DIR/auxiliary/dollar-crate-external.rs:11:18: 11:24 (#15),
             },
             Punct {
                 ch: ':',
                 spacing: Joint,
-                span: $DIR/auxiliary/dollar-crate-external.rs:11:24: 11:25 (#14),
+                span: $DIR/auxiliary/dollar-crate-external.rs:11:24: 11:25 (#15),
             },
             Punct {
                 ch: ':',
                 spacing: Alone,
-                span: $DIR/auxiliary/dollar-crate-external.rs:11:25: 11:26 (#14),
+                span: $DIR/auxiliary/dollar-crate-external.rs:11:25: 11:26 (#15),
             },
             Ident {
                 ident: "S",
-                span: $DIR/auxiliary/dollar-crate-external.rs:11:26: 11:27 (#14),
+                span: $DIR/auxiliary/dollar-crate-external.rs:11:26: 11:27 (#15),
             },
         ],
-        span: $DIR/auxiliary/dollar-crate-external.rs:11:17: 11:28 (#14),
+        span: $DIR/auxiliary/dollar-crate-external.rs:11:17: 11:28 (#15),
     },
     Punct {
         ch: ';',
         spacing: Alone,
-        span: $DIR/auxiliary/dollar-crate-external.rs:11:28: 11:29 (#14),
+        span: $DIR/auxiliary/dollar-crate-external.rs:11:28: 11:29 (#15),
     },
 ]
 PRINT-DERIVE INPUT (DISPLAY): struct D($crate :: S);
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/auxiliary/dollar-crate-external.rs:14:9: 14:15 (#14),
+        span: $DIR/auxiliary/dollar-crate-external.rs:14:9: 14:15 (#15),
     },
     Ident {
         ident: "D",
-        span: $DIR/auxiliary/dollar-crate-external.rs:14:16: 14:17 (#14),
+        span: $DIR/auxiliary/dollar-crate-external.rs:14:16: 14:17 (#15),
     },
     Group {
         delimiter: Parenthesis,
         stream: TokenStream [
             Ident {
                 ident: "$crate",
-                span: $DIR/auxiliary/dollar-crate-external.rs:14:18: 14:24 (#14),
+                span: $DIR/auxiliary/dollar-crate-external.rs:14:18: 14:24 (#15),
             },
             Punct {
                 ch: ':',
                 spacing: Joint,
-                span: $DIR/auxiliary/dollar-crate-external.rs:14:24: 14:25 (#14),
+                span: $DIR/auxiliary/dollar-crate-external.rs:14:24: 14:25 (#15),
             },
             Punct {
                 ch: ':',
                 spacing: Alone,
-                span: $DIR/auxiliary/dollar-crate-external.rs:14:25: 14:26 (#14),
+                span: $DIR/auxiliary/dollar-crate-external.rs:14:25: 14:26 (#15),
             },
             Ident {
                 ident: "S",
-                span: $DIR/auxiliary/dollar-crate-external.rs:14:26: 14:27 (#14),
+                span: $DIR/auxiliary/dollar-crate-external.rs:14:26: 14:27 (#15),
             },
         ],
-        span: $DIR/auxiliary/dollar-crate-external.rs:14:17: 14:28 (#14),
+        span: $DIR/auxiliary/dollar-crate-external.rs:14:17: 14:28 (#15),
     },
     Punct {
         ch: ';',
         spacing: Alone,
-        span: $DIR/auxiliary/dollar-crate-external.rs:14:28: 14:29 (#14),
+        span: $DIR/auxiliary/dollar-crate-external.rs:14:28: 14:29 (#15),
     },
 ]

--- a/tests/ui/proc-macro/generate-mod.stderr
+++ b/tests/ui/proc-macro/generate-mod.stderr
@@ -47,6 +47,7 @@ LL | #[derive(generate_mod::CheckDerive)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
    = note: `#[deny(proc_macro_derive_resolution_fallback)]` (part of `#[deny(future_incompatible)]`) on by default
+   = note: this error originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot find type `OuterDerive` in this scope
   --> $DIR/generate-mod.rs:18:10
@@ -56,6 +57,7 @@ LL | #[derive(generate_mod::CheckDerive)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
+   = note: this error originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot find type `FromOutside` in this scope
   --> $DIR/generate-mod.rs:25:14
@@ -65,6 +67,7 @@ LL |     #[derive(generate_mod::CheckDerive)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
+   = note: this error originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot find type `OuterDerive` in this scope
   --> $DIR/generate-mod.rs:25:14
@@ -74,6 +77,7 @@ LL |     #[derive(generate_mod::CheckDerive)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
+   = note: this error originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 8 previous errors
 
@@ -88,6 +92,7 @@ LL | #[derive(generate_mod::CheckDerive)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
    = note: `#[deny(proc_macro_derive_resolution_fallback)]` (part of `#[deny(future_incompatible)]`) on by default
+   = note: this error originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 Future breakage diagnostic:
 error: cannot find type `OuterDerive` in this scope
@@ -99,6 +104,7 @@ LL | #[derive(generate_mod::CheckDerive)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
    = note: `#[deny(proc_macro_derive_resolution_fallback)]` (part of `#[deny(future_incompatible)]`) on by default
+   = note: this error originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 Future breakage diagnostic:
 error: cannot find type `FromOutside` in this scope
@@ -110,6 +116,7 @@ LL |     #[derive(generate_mod::CheckDerive)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
    = note: `#[deny(proc_macro_derive_resolution_fallback)]` (part of `#[deny(future_incompatible)]`) on by default
+   = note: this error originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 Future breakage diagnostic:
 error: cannot find type `OuterDerive` in this scope
@@ -121,6 +128,7 @@ LL |     #[derive(generate_mod::CheckDerive)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
    = note: `#[deny(proc_macro_derive_resolution_fallback)]` (part of `#[deny(future_incompatible)]`) on by default
+   = note: this error originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 Future breakage diagnostic:
 warning: cannot find type `FromOutside` in this scope
@@ -131,6 +139,7 @@ LL | #[derive(generate_mod::CheckDeriveLint)] // OK, lint is suppressed
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
+   = note: this warning originates in the derive macro `generate_mod::CheckDeriveLint` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 Future breakage diagnostic:
 warning: cannot find type `OuterDeriveLint` in this scope
@@ -141,4 +150,5 @@ LL | #[derive(generate_mod::CheckDeriveLint)] // OK, lint is suppressed
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
+   = note: this warning originates in the derive macro `generate_mod::CheckDeriveLint` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/proc-macro/nested-macro-rules.stdout
+++ b/tests/ui/proc-macro/nested-macro-rules.stdout
@@ -2,45 +2,45 @@ PRINT-BANG INPUT (DISPLAY): FirstStruct
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "FirstStruct",
-        span: $DIR/auxiliary/nested-macro-rules.rs:16:14: 16:25 (#6),
+        span: $DIR/auxiliary/nested-macro-rules.rs:16:14: 16:25 (#7),
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): struct FirstAttrStruct {}
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/auxiliary/nested-macro-rules.rs:10:32: 10:38 (#5),
+        span: $DIR/auxiliary/nested-macro-rules.rs:10:32: 10:38 (#6),
     },
     Ident {
         ident: "FirstAttrStruct",
-        span: $DIR/auxiliary/nested-macro-rules.rs:16:27: 16:42 (#6),
+        span: $DIR/auxiliary/nested-macro-rules.rs:16:27: 16:42 (#7),
     },
     Group {
         delimiter: Brace,
         stream: TokenStream [],
-        span: $DIR/auxiliary/nested-macro-rules.rs:10:57: 10:59 (#5),
+        span: $DIR/auxiliary/nested-macro-rules.rs:10:57: 10:59 (#6),
     },
 ]
 PRINT-BANG INPUT (DISPLAY): SecondStruct
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "SecondStruct",
-        span: $DIR/nested-macro-rules.rs:23:38: 23:50 (#15),
+        span: $DIR/nested-macro-rules.rs:23:38: 23:50 (#16),
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): struct SecondAttrStruct {}
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: $DIR/auxiliary/nested-macro-rules.rs:10:32: 10:38 (#14),
+        span: $DIR/auxiliary/nested-macro-rules.rs:10:32: 10:38 (#15),
     },
     Ident {
         ident: "SecondAttrStruct",
-        span: $DIR/nested-macro-rules.rs:23:52: 23:68 (#15),
+        span: $DIR/nested-macro-rules.rs:23:52: 23:68 (#16),
     },
     Group {
         delimiter: Brace,
         stream: TokenStream [],
-        span: $DIR/auxiliary/nested-macro-rules.rs:10:57: 10:59 (#14),
+        span: $DIR/auxiliary/nested-macro-rules.rs:10:57: 10:59 (#15),
     },
 ]


### PR DESCRIPTION
This is a continuation of https://github.com/rust-lang/rust/pull/150741 and https://github.com/rust-lang/rust/pull/150982 based on the ideas from https://github.com/rust-lang/rust/pull/151491#issuecomment-3784421866.

Before this PR `Macros20NormalizedIdent` was used as a key in various "identifier -> its resolution" maps in `rustc_resolve`.
`Macros20NormalizedIdent` is a newtype around `Ident` in which `SyntaxContext` (packed inside `Span`) is guaranteed to be normalized using `normalize_to_macros_2_0`.
This type is also used in a number of functions looking up identifiers in those maps.
`Macros20NormalizedIdent` still contains span locations, which are useless and ignored during hash map lookups and comparisons due to `Ident`'s special `PartialEq` and `Hash` impls.

This PR replaces `Macros20NormalizedIdent` with a new type called `IdentKey`, which contains only a symbol and a normalized unpacked syntax context. (E.g. `IdentKey` == `Macros20NormalizedIdent` minus span locations.)
So we avoid keeping additional data and doing some syntax context packing/unpacking.

Along with `IdentKey` you can often see `orig_ident_span: Span` being passed around.
This is an unnormalized span of the original `Ident` from which `IdentKey` was obtained.
It is not used in map keys, but it is used in a number of other scenarios:
- diagnostics
- edition checks
- `allow_unstable` checks

This is because `normalize_to_macros_2_0` normalization is lossy and the normalized spans / syntax contexts no longer contain parts of macro backtraces, while the original span contains everything.