### PR TITLE
Don't use default build-script fingerprinting in `test`

### DIFF
--- a/library/test/build.rs
+++ b/library/test/build.rs
@@ -1,4 +1,5 @@
 fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rustc-check-cfg=cfg(enable_unstable_features)");
 
     let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".into());


### PR DESCRIPTION
This changes the `test` build script so that it does not use the default fingerprinting mechanism in cargo which causes a full scan of the package every time it runs. This build script does not depend on any of the files in the package.

This is the recommended approach for writing build scripts.
