### PR TITLE
[rustdoc] Add a marker to tell users that there are hidden (deprecated) items in the search results

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -2656,6 +2656,10 @@ However, it's not needed with smaller screen width because the doc/code block is
 .deprecated-count {
 	display: none;
 }
+/*
+The `:not(:empty)` is a little trick to not have to add conditions in JS to hide/show the marker.
+It's entirely based on whether it has content and if the setting is enabled.
+*/
 .hide-deprecated-items .deprecated-count:not(:empty) {
 	display: block;
 	margin: 10px 0;

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -341,7 +341,8 @@ summary.hideme,
 .rustdoc-breadcrumbs,
 .search-switcher,
 /* This selector is for the items listed in the "all items" page. */
-ul.all-items {
+ul.all-items,
+.deprecated-count {
 	font-family: "Fira Sans", Arial, NanumBarunGothic, sans-serif;
 }
 
@@ -2650,6 +2651,14 @@ However, it's not needed with smaller screen width because the doc/code block is
 .hide-deprecated-items .deprecated,
 .hide-deprecated-items .deprecated + .item-info {
 	display: none;
+}
+
+.deprecated-count {
+	display: none;
+}
+.hide-deprecated-items .deprecated-count:not(:empty) {
+	display: block;
+	margin: 10px 0;
 }
 
 /*

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -158,6 +158,7 @@ const REGEX_INVALID_TYPE_FILTER = /[^a-z]/ui;
 
 const MAX_RESULTS = 200;
 const NO_TYPE_FILTER = -1;
+const DEPRECATED_COUNT_SELECTOR = "deprecated-count";
 
 /**
  * The [edit distance] is a metric for measuring the difference between two strings.
@@ -4904,7 +4905,12 @@ async function addTab(results, query, display, finishedCallback, isTypeSearch) {
     let output = document.createElement("ul");
     output.className = "search-results " + extraClass;
 
+    const deprecatedCountElem = document.createElement("span");
+    deprecatedCountElem.className = DEPRECATED_COUNT_SELECTOR;
+    output.appendChild(deprecatedCountElem);
+
     let count = 0;
+    let deprecatedCount = 0;
 
     /** @type {Promise<string|null>[]} */
     const descList = [];
@@ -4922,6 +4928,10 @@ async function addTab(results, query, display, finishedCallback, isTypeSearch) {
         link.className = "result-" + type;
         if (obj.item.deprecated) {
             link.className += " deprecated";
+            deprecatedCount += 1;
+            const plural = deprecatedCount > 1 ? "s" : "";
+            deprecatedCountElem.innerText =
+                `${deprecatedCount} deprecated item${plural} hidden by setting`;
         }
         link.href = obj.href;
 
@@ -5411,7 +5421,7 @@ function registerSearchEvents() {
             const active = document.activeElement;
             if (active) {
                 const previous = active.previousElementSibling;
-                if (previous) {
+                if (previous && previous.className !== DEPRECATED_COUNT_SELECTOR) {
                     // @ts-expect-error
                     previous.focus();
                 } else {

--- a/tests/rustdoc-gui/setting-hide-deprecated.goml
+++ b/tests/rustdoc-gui/setting-hide-deprecated.goml
@@ -69,7 +69,7 @@ wait-for-css: ("details" + |deprecated_class|, {"display": "block"}, ALL)
 
 // And now we check with the search results.
 call-function: ("perform-search", {"query": "deprecated::depr"})
-// There should at least 7 results.
+// There should be at least 7 results.
 store-count: ("#results ul.search-results.active > a", nb_search_results)
 assert: |nb_search_results| >= 7
 // There should be at least 5 deprecated items.
@@ -77,6 +77,12 @@ store-count: ("#results ul.search-results.active > a" + |deprecated_class|, nb_d
 assert: |nb_search_results| >= 5
 // Deprecated items should all be displayed.
 assert-css: ("#results ul.search-results.active > a" + |deprecated_class|, {"display": "grid"}, ALL)
+// The "X deprecated items hidden by setting" element should not be displayed.
+assert-text: (
+    "#results ul.search-results.active .deprecated-count",
+    "5 deprecated items hidden by setting",
+)
+assert-css: ("#results ul.search-results.active .deprecated-count", {"display": "none"})
 // We enable the "hide deprecated items" setting.
 call-function: ("open-settings-menu", {})
 click: "#hide-deprecated-items"
@@ -86,11 +92,16 @@ wait-for-css: (
     {"display": "none"},
     ALL,
 )
+// The "X deprecated items hidden by setting" element should be displayed.
+assert-css: ("#results ul.search-results.active .deprecated-count", {"display": "block"})
 
 // Finally we check that the future deprecated item doesn't have the deprecated class in the search
-// and therefore isn't impact by the setting.
-call-function: ("perform-search", {"query": "deprecated::future_deprecated"})
+// and therefore isn't impacted by the setting.
+call-function: ("perform-search", {"query": '"future_deprecated_fn"'})
 assert-text: (
     "#results ul.search-results.active > a:not(" + |deprecated_class| + ") .path",
     " lib2::deprecated::NonDeprecatedStruct::future_deprecated_fn",
 )
+// The "X deprecated items hidden by setting" element should now be empty, and therefore not displayed.
+assert-text: ("#results ul.search-results.active .deprecated-count", "")
+assert-css: ("#results ul.search-results.active .deprecated-count", {"display": "none"})


### PR DESCRIPTION
Someone on mastodon rightfully pointed out that having a visual indication that some search results were hidden would be a good idea if the "hide deprecated items" setting is enabled. In particular if no results are displayed.

It looks like this:

<img width="861" height="228" alt="Screenshot From 2026-01-24 00-26-33" src="https://github.com/user-attachments/assets/93aeef11-a550-47dc-9c78-219ea4fd822c" />

r? @lolbinarycat