### PR TITLE
Fix cstring-merging test for Hexagon target

### DIFF
--- a/tests/assembly-llvm/cstring-merging.rs
+++ b/tests/assembly-llvm/cstring-merging.rs
@@ -1,5 +1,6 @@
 // MIPS assembler uses the label prefix `$anon.` for local anonymous variables
 // other architectures (including ARM and x86-64) use the prefix `.Lanon.`
+// Hexagon uses `.string` instead of `.asciz` for null-terminated strings
 //@ only-linux
 //@ assembly-output: emit-asm
 //@ compile-flags: --crate-type=lib -Copt-level=3 -Cllvm-args=-enable-global-merge=0
@@ -9,13 +10,13 @@ use std::ffi::CStr;
 
 // CHECK: .section .rodata.str1.{{[12]}},"aMS"
 // CHECK: {{(\.L|\$)}}anon.{{.+}}:
-// CHECK-NEXT: .asciz "foo"
+// CHECK-NEXT: .{{asciz|string}} "foo"
 #[unsafe(no_mangle)]
 static CSTR: &[u8; 4] = b"foo\0";
 
 // CHECK-NOT: .section
 // CHECK: {{(\.L|\$)}}anon.{{.+}}:
-// CHECK-NEXT: .asciz "bar"
+// CHECK-NEXT: .{{asciz|string}} "bar"
 #[unsafe(no_mangle)]
 pub fn cstr() -> &'static CStr {
     c"bar"
@@ -23,7 +24,7 @@ pub fn cstr() -> &'static CStr {
 
 // CHECK-NOT: .section
 // CHECK: {{(\.L|\$)}}anon.{{.+}}:
-// CHECK-NEXT: .asciz "baz"
+// CHECK-NEXT: .{{asciz|string}} "baz"
 #[unsafe(no_mangle)]
 pub fn manual_cstr() -> &'static str {
     "baz\0"


### PR DESCRIPTION
Hexagon assembler uses `.string` directive instead of `.asciz` for null-terminated strings. Both are equivalent but the test was only checking for `.asciz`.

Update the CHECK patterns to accept both directives using `.{{asciz|string}}` regex pattern.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
