### PR TITLE
Fix Hexagon ABI calling convention for small aggregates

### DIFF
--- a/compiler/rustc_target/src/callconv/hexagon.rs
+++ b/compiler/rustc_target/src/callconv/hexagon.rs
@@ -1,36 +1,74 @@
-use rustc_abi::TyAbiInterface;
+use rustc_abi::{HasDataLayout, TyAbiInterface};
 
-use crate::callconv::{ArgAbi, FnAbi};
+use crate::callconv::{ArgAbi, FnAbi, Reg, Uniform};
 
-fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
-    if ret.layout.is_aggregate() && ret.layout.size.bits() > 64 {
-        ret.make_indirect();
-    } else {
-        ret.extend_integer_width_to(32);
+fn classify_ret<'a, Ty, C>(_cx: &C, ret: &mut ArgAbi<'a, Ty>)
+where
+    Ty: TyAbiInterface<'a, C> + Copy,
+    C: HasDataLayout,
+{
+    if !ret.layout.is_sized() {
+        return;
     }
+    if !ret.layout.is_aggregate() {
+        ret.extend_integer_width_to(32);
+        return;
+    }
+
+    let size = ret.layout.size;
+    let bits = size.bits();
+
+    // Aggregates larger than 64 bits are returned indirectly
+    if bits > 64 {
+        ret.make_indirect();
+        return;
+    }
+
+    // Small aggregates are returned in registers
+    // Cast to appropriate register type to ensure proper ABI
+    let align = ret.layout.align.bytes();
+    ret.cast_to(Uniform::consecutive(if align <= 4 { Reg::i32() } else { Reg::i64() }, size));
 }
 
 fn classify_arg<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>)
 where
     Ty: TyAbiInterface<'a, C> + Copy,
+    C: HasDataLayout,
 {
+    if !arg.layout.is_sized() {
+        return;
+    }
     if arg.layout.pass_indirectly_in_non_rustic_abis(cx) {
         arg.make_indirect();
         return;
     }
-    if arg.layout.is_aggregate() && arg.layout.size.bits() > 64 {
-        arg.make_indirect();
-    } else {
+    if !arg.layout.is_aggregate() {
         arg.extend_integer_width_to(32);
+        return;
     }
+
+    let size = arg.layout.size;
+    let bits = size.bits();
+
+    // Aggregates larger than 64 bits are passed indirectly
+    if bits > 64 {
+        arg.make_indirect();
+        return;
+    }
+
+    // Small aggregates are passed in registers
+    // Cast to consecutive register-sized chunks to match the C ABI
+    let align = arg.layout.align.bytes();
+    arg.cast_to(Uniform::consecutive(if align <= 4 { Reg::i32() } else { Reg::i64() }, size));
 }
 
 pub(crate) fn compute_abi_info<'a, Ty, C>(cx: &C, fn_abi: &mut FnAbi<'a, Ty>)
 where
     Ty: TyAbiInterface<'a, C> + Copy,
+    C: HasDataLayout,
 {
     if !fn_abi.ret.is_ignore() {
-        classify_ret(&mut fn_abi.ret);
+        classify_ret(cx, &mut fn_abi.ret);
     }
 
     for arg in fn_abi.args.iter_mut() {


### PR DESCRIPTION
Small structs (<= 64 bits) were being passed with their fields split into separate arguments instead of being packed into register-sized chunks. This caused ABI mismatches.

The fix properly casts small aggregates to consecutive register-sized chunks using Uniform::consecutive(), matching the Hexagon C ABI where small structs are packed into R1:0 register pair.

This fixes tests like extern-pass-TwoU16s.rs and extern-pass-TwoU8s.rs.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
