### PR TITLE
Stabilize `core::hint::cold_path`

### DIFF
--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -724,7 +724,6 @@ pub const fn unlikely(b: bool) -> bool {
 /// # Examples
 ///
 /// ```
-/// #![feature(cold_path)]
 /// use core::hint::cold_path;
 ///
 /// fn foo(x: &[i32]) {
@@ -750,7 +749,6 @@ pub const fn unlikely(b: bool) -> bool {
 /// than the branch:
 ///
 /// ```
-/// #![feature(cold_path)]
 /// use core::hint::cold_path;
 ///
 /// #[inline(always)]
@@ -777,7 +775,8 @@ pub const fn unlikely(b: bool) -> bool {
 ///     }
 /// }
 /// ```
-#[unstable(feature = "cold_path", issue = "136873")]
+#[stable(feature = "cold_path", since = "CURRENT_RUSTC_VERSION")]
+#[rustc_const_stable(feature = "cold_path", since = "CURRENT_RUSTC_VERSION")]
 #[inline(always)]
 pub const fn cold_path() {
     crate::intrinsics::cold_path()

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -409,8 +409,7 @@ pub const unsafe fn assume(b: bool) {
 /// Therefore, implementations must not require the user to uphold
 /// any safety invariants.
 ///
-/// This intrinsic does not have a stable counterpart.
-#[unstable(feature = "core_intrinsics", issue = "none")]
+/// The stabilized version of this intrinsic is [`core::hint::cold_path`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
 #[miri::intrinsic_fallback_is_spec]

--- a/tests/codegen-llvm/hint/cold_path.rs
+++ b/tests/codegen-llvm/hint/cold_path.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -Copt-level=3
 #![crate_type = "lib"]
-#![feature(cold_path)]
 
 use std::hint::cold_path;
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/151576)*
<!-- homu-ignore:end -->

`cold_path` has been around unstably for a while and is a rather useful tool to have. It does what it is supposed to and there are no known remaining issues, so stabilize it here (including const).

Newly stable API:

```rust
// in core::hint
pub const fn cold_path();
```

I have opted to exclude `likely` and `unlikely` for now since they have had some concerns about ease of use that `cold_path` doesn't suffer from. `cold_path` is also significantly more flexible; in addition to working with boolean `if` conditions, it can be used in `match` arms, `if let`, closures, and other control flow blocks. `likely` and `unlikely` are also possible to implement in user code via `cold_path`, if desired.

Closes: https://github.com/rust-lang/rust/issues/136873 (tracking issue)

---

There has been some design and implementation work for making `#[cold]` function in more places, such as `if` arms, `match` arms, and closure bodies. Considering a stable `cold_path` will cover all of these usecases, it does not seem worth pursuing a more powerful `#[cold]` as an alternative way to do the same thing. If the lang team agrees, then:

Closes: https://github.com/rust-lang/rust/issues/26179
Closes: https://github.com/rust-lang/rust/pull/120193

<!-- homu-ignore:start -->
Cc @rust-lang/lang
Cc @rust-lang/libs-api
Cc @rust-lang/wg-const-eval 
<!-- homu-ignore:end -->