### PR TITLE
Rename `DepKindStruct` to `DepKindVTable`

### DIFF
--- a/compiler/rustc_interface/src/callbacks.rs
+++ b/compiler/rustc_interface/src/callbacks.rs
@@ -72,7 +72,7 @@ fn def_id_debug(def_id: rustc_hir::def_id::DefId, f: &mut fmt::Formatter<'_>) ->
 pub fn dep_kind_debug(kind: DepKind, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     tls::with_opt(|opt_tcx| {
         if let Some(tcx) = opt_tcx {
-            write!(f, "{}", tcx.dep_kind_info(kind).name)
+            write!(f, "{}", tcx.dep_kind_vtable(kind).name)
         } else {
             default_dep_kind_debug(kind, f)
         }

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -992,7 +992,7 @@ pub fn create_and_enter_global_ctxt<T, F: for<'tcx> FnOnce(TyCtxt<'tcx>) -> T>(
             hir_arena,
             untracked,
             dep_graph,
-            rustc_query_impl::query_callbacks(arena),
+            rustc_query_impl::make_dep_kind_vtables(arena),
             rustc_query_impl::query_system(
                 providers.queries,
                 providers.extern_queries,

--- a/compiler/rustc_middle/src/arena.rs
+++ b/compiler/rustc_middle/src/arena.rs
@@ -104,7 +104,7 @@ macro_rules! arena_types {
             [decode] is_late_bound_map: rustc_data_structures::fx::FxIndexSet<rustc_hir::ItemLocalId>,
             [decode] impl_source: rustc_middle::traits::ImplSource<'tcx, ()>,
 
-            [] dep_kind: rustc_middle::dep_graph::DepKindStruct<'tcx>,
+            [] dep_kind_vtable: rustc_middle::dep_graph::DepKindVTable<'tcx>,
 
             [decode] trait_impl_trait_tys:
                 rustc_data_structures::unord::UnordMap<

--- a/compiler/rustc_middle/src/dep_graph/mod.rs
+++ b/compiler/rustc_middle/src/dep_graph/mod.rs
@@ -18,7 +18,7 @@ pub use rustc_query_system::dep_graph::{
 
 pub type DepGraph = rustc_query_system::dep_graph::DepGraph<DepsType>;
 
-pub type DepKindStruct<'tcx> = rustc_query_system::dep_graph::DepKindStruct<TyCtxt<'tcx>>;
+pub type DepKindVTable<'tcx> = rustc_query_system::dep_graph::DepKindVTable<TyCtxt<'tcx>>;
 
 pub struct DepsType;
 
@@ -79,8 +79,8 @@ impl<'tcx> DepContext for TyCtxt<'tcx> {
     }
 
     #[inline]
-    fn dep_kind_info(&self, dk: DepKind) -> &DepKindStruct<'tcx> {
-        &self.query_kinds[dk.as_usize()]
+    fn dep_kind_vtable(&self, dk: DepKind) -> &DepKindVTable<'tcx> {
+        &self.dep_kind_vtables[dk.as_usize()]
     }
 
     fn with_reduced_queries<T>(self, f: impl FnOnce() -> T) -> T {

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -59,7 +59,7 @@ use rustc_type_ir::{
 use tracing::{debug, instrument};
 
 use crate::arena::Arena;
-use crate::dep_graph::{DepGraph, DepKindStruct};
+use crate::dep_graph::{DepGraph, DepKindVTable};
 use crate::infer::canonical::{CanonicalParamEnvCache, CanonicalVarKind, CanonicalVarKinds};
 use crate::lint::lint_level;
 use crate::metadata::ModChild;
@@ -1580,7 +1580,7 @@ pub struct GlobalCtxt<'tcx> {
     untracked: Untracked,
 
     pub query_system: QuerySystem<'tcx>,
-    pub(crate) query_kinds: &'tcx [DepKindStruct<'tcx>],
+    pub(crate) dep_kind_vtables: &'tcx [DepKindVTable<'tcx>],
 
     // Internal caches for metadata decoding. No need to track deps on this.
     pub ty_rcache: Lock<FxHashMap<ty::CReaderCacheKey, Ty<'tcx>>>,
@@ -1801,7 +1801,7 @@ impl<'tcx> TyCtxt<'tcx> {
         hir_arena: &'tcx WorkerLocal<hir::Arena<'tcx>>,
         untracked: Untracked,
         dep_graph: DepGraph,
-        query_kinds: &'tcx [DepKindStruct<'tcx>],
+        dep_kind_vtables: &'tcx [DepKindVTable<'tcx>],
         query_system: QuerySystem<'tcx>,
         hooks: crate::hooks::Providers,
         current_gcx: CurrentGcx,
@@ -1831,7 +1831,7 @@ impl<'tcx> TyCtxt<'tcx> {
             consts: common_consts,
             untracked,
             query_system,
-            query_kinds,
+            dep_kind_vtables,
             ty_rcache: Default::default(),
             selection_cache: Default::default(),
             evaluation_cache: Default::default(),

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -9,7 +9,7 @@
 use rustc_data_structures::stable_hasher::HashStable;
 use rustc_data_structures::sync::AtomicU64;
 use rustc_middle::arena::Arena;
-use rustc_middle::dep_graph::{self, DepKind, DepKindStruct, DepNodeIndex};
+use rustc_middle::dep_graph::{self, DepKind, DepKindVTable, DepNodeIndex};
 use rustc_middle::query::erase::{Erase, erase, restore};
 use rustc_middle::query::on_disk_cache::{CacheEncoder, EncodedDepNodeIndex, OnDiskCache};
 use rustc_middle::query::plumbing::{DynamicQuery, QuerySystem, QuerySystemFns};

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -12,7 +12,7 @@ use rustc_hir::limit::Limit;
 use rustc_index::Idx;
 use rustc_middle::bug;
 use rustc_middle::dep_graph::{
-    self, DepContext, DepKind, DepKindStruct, DepNode, DepNodeIndex, SerializedDepNodeIndex,
+    self, DepContext, DepKind, DepKindVTable, DepNode, DepNodeIndex, SerializedDepNodeIndex,
     dep_kinds,
 };
 use rustc_middle::query::Key;
@@ -489,14 +489,17 @@ where
     }
 }
 
-pub(crate) fn query_callback<'tcx, Q>(is_anon: bool, is_eval_always: bool) -> DepKindStruct<'tcx>
+pub(crate) fn make_dep_kind_vtable_for_query<'tcx, Q>(
+    is_anon: bool,
+    is_eval_always: bool,
+) -> DepKindVTable<'tcx>
 where
     Q: QueryConfigRestored<'tcx>,
 {
     let fingerprint_style = <Q::Config as QueryConfig<QueryCtxt<'tcx>>>::Key::fingerprint_style();
 
     if is_anon || !fingerprint_style.reconstructible() {
-        return DepKindStruct {
+        return DepKindVTable {
             is_anon,
             is_eval_always,
             fingerprint_style,
@@ -506,7 +509,7 @@ where
         };
     }
 
-    DepKindStruct {
+    DepKindVTable {
         is_anon,
         is_eval_always,
         fingerprint_style,
@@ -811,15 +814,19 @@ macro_rules! define_queries {
             for<'tcx> fn(TyCtxt<'tcx>)
         ] = &[$(query_impl::$name::query_key_hash_verify),*];
 
-        #[allow(nonstandard_style)]
-        mod query_callbacks {
+        /// Module containing a named function for each dep kind (including queries)
+        /// that creates a `DepKindVTable`.
+        ///
+        /// Consumed via `make_dep_kind_array!` to create a list of vtables.
+        #[expect(non_snake_case)]
+        mod _dep_kind_vtable_ctors {
             use super::*;
             use rustc_middle::bug;
             use rustc_query_system::dep_graph::FingerprintStyle;
 
             // We use this for most things when incr. comp. is turned off.
-            pub(crate) fn Null<'tcx>() -> DepKindStruct<'tcx> {
-                DepKindStruct {
+            pub(crate) fn Null<'tcx>() -> DepKindVTable<'tcx> {
+                DepKindVTable {
                     is_anon: false,
                     is_eval_always: false,
                     fingerprint_style: FingerprintStyle::Unit,
@@ -830,8 +837,8 @@ macro_rules! define_queries {
             }
 
             // We use this for the forever-red node.
-            pub(crate) fn Red<'tcx>() -> DepKindStruct<'tcx> {
-                DepKindStruct {
+            pub(crate) fn Red<'tcx>() -> DepKindVTable<'tcx> {
+                DepKindVTable {
                     is_anon: false,
                     is_eval_always: false,
                     fingerprint_style: FingerprintStyle::Unit,
@@ -841,8 +848,8 @@ macro_rules! define_queries {
                 }
             }
 
-            pub(crate) fn SideEffect<'tcx>() -> DepKindStruct<'tcx> {
-                DepKindStruct {
+            pub(crate) fn SideEffect<'tcx>() -> DepKindVTable<'tcx> {
+                DepKindVTable {
                     is_anon: false,
                     is_eval_always: false,
                     fingerprint_style: FingerprintStyle::Unit,
@@ -855,8 +862,8 @@ macro_rules! define_queries {
                 }
             }
 
-            pub(crate) fn AnonZeroDeps<'tcx>() -> DepKindStruct<'tcx> {
-                DepKindStruct {
+            pub(crate) fn AnonZeroDeps<'tcx>() -> DepKindVTable<'tcx> {
+                DepKindVTable {
                     is_anon: true,
                     is_eval_always: false,
                     fingerprint_style: FingerprintStyle::Opaque,
@@ -866,8 +873,8 @@ macro_rules! define_queries {
                 }
             }
 
-            pub(crate) fn TraitSelect<'tcx>() -> DepKindStruct<'tcx> {
-                DepKindStruct {
+            pub(crate) fn TraitSelect<'tcx>() -> DepKindVTable<'tcx> {
+                DepKindVTable {
                     is_anon: true,
                     is_eval_always: false,
                     fingerprint_style: FingerprintStyle::Unit,
@@ -877,8 +884,8 @@ macro_rules! define_queries {
                 }
             }
 
-            pub(crate) fn CompileCodegenUnit<'tcx>() -> DepKindStruct<'tcx> {
-                DepKindStruct {
+            pub(crate) fn CompileCodegenUnit<'tcx>() -> DepKindVTable<'tcx> {
+                DepKindVTable {
                     is_anon: false,
                     is_eval_always: false,
                     fingerprint_style: FingerprintStyle::Opaque,
@@ -888,8 +895,8 @@ macro_rules! define_queries {
                 }
             }
 
-            pub(crate) fn CompileMonoItem<'tcx>() -> DepKindStruct<'tcx> {
-                DepKindStruct {
+            pub(crate) fn CompileMonoItem<'tcx>() -> DepKindVTable<'tcx> {
+                DepKindVTable {
                     is_anon: false,
                     is_eval_always: false,
                     fingerprint_style: FingerprintStyle::Opaque,
@@ -899,8 +906,8 @@ macro_rules! define_queries {
                 }
             }
 
-            pub(crate) fn Metadata<'tcx>() -> DepKindStruct<'tcx> {
-                DepKindStruct {
+            pub(crate) fn Metadata<'tcx>() -> DepKindVTable<'tcx> {
+                DepKindVTable {
                     is_anon: false,
                     is_eval_always: false,
                     fingerprint_style: FingerprintStyle::Unit,
@@ -910,16 +917,17 @@ macro_rules! define_queries {
                 }
             }
 
-            $(pub(crate) fn $name<'tcx>()-> DepKindStruct<'tcx> {
-                $crate::plumbing::query_callback::<query_impl::$name::QueryType<'tcx>>(
+            $(pub(crate) fn $name<'tcx>() -> DepKindVTable<'tcx> {
+                use $crate::query_impl::$name::QueryType;
+                $crate::plumbing::make_dep_kind_vtable_for_query::<QueryType<'tcx>>(
                     is_anon!([$($modifiers)*]),
                     is_eval_always!([$($modifiers)*]),
                 )
             })*
         }
 
-        pub fn query_callbacks<'tcx>(arena: &'tcx Arena<'tcx>) -> &'tcx [DepKindStruct<'tcx>] {
-            arena.alloc_from_iter(rustc_middle::make_dep_kind_array!(query_callbacks))
+        pub fn make_dep_kind_vtables<'tcx>(arena: &'tcx Arena<'tcx>) -> &'tcx [DepKindVTable<'tcx>] {
+            arena.alloc_from_iter(rustc_middle::make_dep_kind_array!(_dep_kind_vtable_ctors))
         }
     }
 }

--- a/compiler/rustc_query_system/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_query_system/src/dep_graph/dep_node.rs
@@ -221,12 +221,12 @@ where
     }
 }
 
-/// This struct stores metadata about each DepKind.
+/// This struct stores function pointers and other metadata for a particular DepKind.
 ///
 /// Information is retrieved by indexing the `DEP_KINDS` array using the integer value
 /// of the `DepKind`. Overall, this allows to implement `DepContext` using this manual
 /// jump table instead of large matches.
-pub struct DepKindStruct<Tcx: DepContext> {
+pub struct DepKindVTable<Tcx: DepContext> {
     /// Anonymous queries cannot be replayed from one compiler invocation to the next.
     /// When their result is needed, it is recomputed. They are useful for fine-grained
     /// dependency tracking, and caching within one compiler invocation.

--- a/compiler/rustc_query_system/src/query/job.rs
+++ b/compiler/rustc_query_system/src/query/job.rs
@@ -626,7 +626,7 @@ pub fn print_query_stack<Qcx: QueryContext>(
                 file,
                 "#{} [{}] {}",
                 count_total,
-                qcx.dep_context().dep_kind_info(query_info.query.dep_kind).name,
+                qcx.dep_context().dep_kind_vtable(query_info.query.dep_kind).name,
                 query_info.query.description
             );
         }


### PR DESCRIPTION
This type is used by dependency-tracking code in the query system, for looking up function pointers and other metadata associated with a particular `DepKind`.

Calling it “struct” is not particularly helpful, whereas calling it a “vtable” at least gives some basic intuition for what it is and how it is used.

Some associated identifiers have also drifted a bit over time, and this PR adjusts those as well.

There should be no change to compiler behaviour.

r? nnethercote (or compiler)