### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/intrinsics/simd.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics/simd.rs
@@ -60,6 +60,15 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 }
                 self.copy_op(&self.project_index(&input, index)?, &dest)?;
             }
+            sym::simd_splat => {
+                let elem = &args[0];
+                let (dest, dest_len) = self.project_to_simd(&dest)?;
+
+                for i in 0..dest_len {
+                    let place = self.project_index(&dest, i)?;
+                    self.copy_op(elem, &place)?;
+                }
+            }
             sym::simd_neg
             | sym::simd_fabs
             | sym::simd_ceil

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -746,6 +746,7 @@ pub(crate) fn check_intrinsic_type(
         sym::simd_extract | sym::simd_extract_dyn => {
             (2, 0, vec![param(0), tcx.types.u32], param(1))
         }
+        sym::simd_splat => (2, 0, vec![param(1)], param(0)),
         sym::simd_cast
         | sym::simd_as
         | sym::simd_cast_ptr

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2140,6 +2140,7 @@ symbols! {
         simd_shr,
         simd_shuffle,
         simd_shuffle_const_generic,
+        simd_splat,
         simd_sub,
         simd_trunc,
         simd_with_exposed_provenance,

--- a/library/core/src/intrinsics/simd.rs
+++ b/library/core/src/intrinsics/simd.rs
@@ -59,6 +59,13 @@ pub unsafe fn simd_extract_dyn<T, U>(x: T, idx: u32) -> U {
     unsafe { (&raw const x).cast::<U>().add(idx as usize).read() }
 }
 
+/// Creates a vector where every lane has the provided value.
+///
+/// `T` must be a vector with element type `U`.
+#[rustc_nounwind]
+#[rustc_intrinsic]
+pub const unsafe fn simd_splat<T, U>(value: U) -> T;
+
 /// Adds two simd vectors elementwise.
 ///
 /// `T` must be a vector of integers or floats.

--- a/tests/assembly-llvm/cstring-merging.rs
+++ b/tests/assembly-llvm/cstring-merging.rs
@@ -1,5 +1,6 @@
 // MIPS assembler uses the label prefix `$anon.` for local anonymous variables
 // other architectures (including ARM and x86-64) use the prefix `.Lanon.`
+// Hexagon uses `.string` instead of `.asciz` for null-terminated strings
 //@ only-linux
 //@ assembly-output: emit-asm
 //@ compile-flags: --crate-type=lib -Copt-level=3 -Cllvm-args=-enable-global-merge=0
@@ -9,13 +10,13 @@ use std::ffi::CStr;
 
 // CHECK: .section .rodata.str1.{{[12]}},"aMS"
 // CHECK: {{(\.L|\$)}}anon.{{.+}}:
-// CHECK-NEXT: .asciz "foo"
+// CHECK-NEXT: .{{asciz|string}} "foo"
 #[unsafe(no_mangle)]
 static CSTR: &[u8; 4] = b"foo\0";
 
 // CHECK-NOT: .section
 // CHECK: {{(\.L|\$)}}anon.{{.+}}:
-// CHECK-NEXT: .asciz "bar"
+// CHECK-NEXT: .{{asciz|string}} "bar"
 #[unsafe(no_mangle)]
 pub fn cstr() -> &'static CStr {
     c"bar"
@@ -23,7 +24,7 @@ pub fn cstr() -> &'static CStr {
 
 // CHECK-NOT: .section
 // CHECK: {{(\.L|\$)}}anon.{{.+}}:
-// CHECK-NEXT: .asciz "baz"
+// CHECK-NEXT: .{{asciz|string}} "baz"
 #[unsafe(no_mangle)]
 pub fn manual_cstr() -> &'static str {
     "baz\0"

--- a/tests/codegen-llvm/simd/splat.rs
+++ b/tests/codegen-llvm/simd/splat.rs
@@ -1,0 +1,32 @@
+#![crate_type = "lib"]
+#![no_std]
+#![feature(repr_simd, core_intrinsics)]
+use core::intrinsics::simd::simd_splat;
+
+#[path = "../../auxiliary/minisimd.rs"]
+mod minisimd;
+use minisimd::*;
+
+// Test that `simd_splat` produces the canonical LLVM splat sequence.
+
+#[no_mangle]
+unsafe fn int(x: u16) -> u16x2 {
+    // CHECK-LABEL: int
+    // CHECK: start:
+    // CHECK-NEXT: %0 = insertelement <2 x i16> poison, i16 %x, i64 0
+    // CHECK-NEXT: %1 = shufflevector <2 x i16> %0, <2 x i16> poison, <2 x i32> zeroinitializer
+    // CHECK-NEXT: store
+    // CHECK-NEXT: ret
+    simd_splat(x)
+}
+
+#[no_mangle]
+unsafe fn float(x: f32) -> f32x4 {
+    // CHECK-LABEL: float
+    // CHECK: start:
+    // CHECK-NEXT: %0 = insertelement <4 x float> poison, float %x, i64 0
+    // CHECK-NEXT: %1 = shufflevector <4 x float> %0, <4 x float> poison, <4 x i32> zeroinitializer
+    // CHECK-NEXT: store
+    // CHECK-NEXT: ret
+    simd_splat(x)
+}

--- a/tests/codegen-llvm/simd/splat.rs
+++ b/tests/codegen-llvm/simd/splat.rs
@@ -1,3 +1,4 @@
+//@ compile-flags: -Copt-level=3
 #![crate_type = "lib"]
 #![no_std]
 #![feature(repr_simd, core_intrinsics)]

--- a/tests/ui/simd/intrinsic/splat.rs
+++ b/tests/ui/simd/intrinsic/splat.rs
@@ -1,0 +1,52 @@
+//@ run-pass
+#![feature(repr_simd, core_intrinsics)]
+
+#[path = "../../../auxiliary/minisimd.rs"]
+mod minisimd;
+use minisimd::*;
+
+use std::intrinsics::simd::simd_splat;
+
+fn main() {
+    unsafe {
+        let x: Simd<u32, 1> = simd_splat(123u32);
+        let y: Simd<u32, 1> = const { simd_splat(123u32) };
+        assert_eq!(x.into_array(), [123; 1]);
+        assert_eq!(x.into_array(), y.into_array());
+
+        let x: u16x2 = simd_splat(42u16);
+        let y: u16x2 = const { simd_splat(42u16) };
+        assert_eq!(x.into_array(), [42; 2]);
+        assert_eq!(x.into_array(), y.into_array());
+
+        let x: u128x4 = simd_splat(42u128);
+        let y: u128x4 = const { simd_splat(42u128) };
+        assert_eq!(x.into_array(), [42; 4]);
+        assert_eq!(x.into_array(), y.into_array());
+
+        let x: i32x4 = simd_splat(-7i32);
+        let y: i32x4 = const { simd_splat(-7i32) };
+        assert_eq!(x.into_array(), [-7; 4]);
+        assert_eq!(x.into_array(), y.into_array());
+
+        let x: f32x4 = simd_splat(42.0f32);
+        let y: f32x4 = const { simd_splat(42.0f32) };
+        assert_eq!(x.into_array(), [42.0; 4]);
+        assert_eq!(x.into_array(), y.into_array());
+
+        let x: f64x2 = simd_splat(42.0f64);
+        let y: f64x2 = const { simd_splat(42.0f64) };
+        assert_eq!(x.into_array(), [42.0; 2]);
+        assert_eq!(x.into_array(), y.into_array());
+
+        static ZERO: u8 = 0u8;
+        let x: Simd<*const u8, 2> = simd_splat(&raw const ZERO);
+        assert_eq!(x.into_array(), [&raw const ZERO; 2]);
+
+        // FIXME: this hits "could not evaluate shuffle_indices at compile time",
+        // emitted in `immediate_const_vector`. const-eval should be able to handle
+        // this though I think? `const { [&raw const ZERO; 2] }` appears to work.
+        // let y: Simd<*const u8, 2> = const { simd_splat(&raw const ZERO) };
+        // assert_eq!(x.into_array(), y.into_array());
+    }
+}

--- a/tests/ui/simd/intrinsic/splat.rs
+++ b/tests/ui/simd/intrinsic/splat.rs
@@ -41,12 +41,8 @@ fn main() {
 
         static ZERO: u8 = 0u8;
         let x: Simd<*const u8, 2> = simd_splat(&raw const ZERO);
+        let y: Simd<*const u8, 2> = const { simd_splat(&raw const ZERO) };
         assert_eq!(x.into_array(), [&raw const ZERO; 2]);
-
-        // FIXME: this hits "could not evaluate shuffle_indices at compile time",
-        // emitted in `immediate_const_vector`. const-eval should be able to handle
-        // this though I think? `const { [&raw const ZERO; 2] }` appears to work.
-        // let y: Simd<*const u8, 2> = const { simd_splat(&raw const ZERO) };
-        // assert_eq!(x.into_array(), y.into_array());
+        assert_eq!(x.into_array(), y.into_array());
     }
 }


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#151346 (add `simd_splat` intrinsic)
 - rust-lang/rust#151571 (Fix cstring-merging test for Hexagon target)

r? @ghost

<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=151346,151571)
<!-- homu-ignore:end -->

