### PR TITLE
Fix -Zmir-enable-passes to detect unregistered enum names in declare_passes macro

### DIFF
--- a/tests/ui/lint/invalid_value-polymorphic.rs
+++ b/tests/ui/lint/invalid_value-polymorphic.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --crate-type=lib -Zmir-enable-passes=+InstSimplify
+//@ compile-flags: --crate-type=lib -Zmir-enable-passes=+InstSimplify-before-inline
 //@ build-pass
 
 #![feature(core_intrinsics)]

--- a/tests/ui/mir/enable_passes_validation.enum_not_in_pass_names.stderr
+++ b/tests/ui/mir/enable_passes_validation.enum_not_in_pass_names.stderr
@@ -1,0 +1,8 @@
+warning: MIR pass `SimplifyCfg` is unknown and will be ignored
+
+warning: MIR pass `SimplifyCfg` is unknown and will be ignored
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: 2 warnings emitted
+

--- a/tests/ui/mir/enable_passes_validation.rs
+++ b/tests/ui/mir/enable_passes_validation.rs
@@ -1,4 +1,5 @@
 //@ revisions: empty unprefixed all_unknown all_known mixed
+//@ revisions: enum_not_in_pass_names enum_in_pass_names
 
 //@[empty] compile-flags: -Zmir-enable-passes=
 
@@ -13,6 +14,12 @@
 //@[mixed] check-pass
 //@[mixed] compile-flags: -Zmir-enable-passes=+ThisPassDoesNotExist,+CheckAlignment
 
+//@[enum_not_in_pass_names] check-pass
+//@[enum_not_in_pass_names] compile-flags: -Zmir-enable-passes=+SimplifyCfg
+
+//@[enum_in_pass_names] check-pass
+//@[enum_in_pass_names] compile-flags: -Zmir-enable-passes=+AddCallGuards
+
 fn main() {}
 
 //[empty]~? ERROR incorrect value `` for unstable option `mir-enable-passes`
@@ -23,3 +30,5 @@ fn main() {}
 //[all_unknown]~? WARN MIR pass `DoesNotExist` is unknown and will be ignored
 //[all_unknown]~? WARN MIR pass `ThisPass` is unknown and will be ignored
 //[all_unknown]~? WARN MIR pass `DoesNotExist` is unknown and will be ignored
+//[enum_not_in_pass_names]~? WARN MIR pass `SimplifyCfg` is unknown and will be ignored
+//[enum_not_in_pass_names]~? WARN MIR pass `SimplifyCfg` is unknown and will be ignored


### PR DESCRIPTION
related: https://github.com/rust-lang/rust/issues/150910

I fixed declare_passes macro to detect unregistered enum names

### UI Results
+nightly --> before: no warnings
+stage1 --> after: detect SimplifyCfg as an unknown pass

<img width="591" height="199" alt="スクリーンショット 2026-01-24 23 53 41" src="https://github.com/user-attachments/assets/ddabaa58-b4c6-4e80-a3c9-f40d866db273" />


<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
