### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/intrinsics/simd.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics/simd.rs
@@ -60,6 +60,15 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 }
                 self.copy_op(&self.project_index(&input, index)?, &dest)?;
             }
+            sym::simd_splat => {
+                let elem = &args[0];
+                let (dest, dest_len) = self.project_to_simd(&dest)?;
+
+                for i in 0..dest_len {
+                    let place = self.project_index(&dest, i)?;
+                    self.copy_op(elem, &place)?;
+                }
+            }
             sym::simd_neg
             | sym::simd_fabs
             | sym::simd_ceil

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -746,6 +746,7 @@ pub(crate) fn check_intrinsic_type(
         sym::simd_extract | sym::simd_extract_dyn => {
             (2, 0, vec![param(0), tcx.types.u32], param(1))
         }
+        sym::simd_splat => (2, 0, vec![param(1)], param(0)),
         sym::simd_cast
         | sym::simd_as
         | sym::simd_cast_ptr

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2140,6 +2140,7 @@ symbols! {
         simd_shr,
         simd_shuffle,
         simd_shuffle_const_generic,
+        simd_splat,
         simd_sub,
         simd_trunc,
         simd_with_exposed_provenance,

--- a/library/core/src/intrinsics/simd.rs
+++ b/library/core/src/intrinsics/simd.rs
@@ -59,6 +59,13 @@ pub unsafe fn simd_extract_dyn<T, U>(x: T, idx: u32) -> U {
     unsafe { (&raw const x).cast::<U>().add(idx as usize).read() }
 }
 
+/// Creates a vector where every lane has the provided value.
+///
+/// `T` must be a vector with element type `U`.
+#[rustc_nounwind]
+#[rustc_intrinsic]
+pub const unsafe fn simd_splat<T, U>(value: U) -> T;
+
 /// Adds two simd vectors elementwise.
 ///
 /// `T` must be a vector of integers or floats.

--- a/src/doc/rustc-dev-guide/src/tests/compiletest.md
+++ b/src/doc/rustc-dev-guide/src/tests/compiletest.md
@@ -655,7 +655,9 @@ to link to the extern crate to make the crate be available as an extern prelude.
 That allows you to specify the additional syntax of the `--extern` flag, such as
 renaming a dependency. For example, `//@ aux-crate:foo=bar.rs` will compile
 `auxiliary/bar.rs` and make it available under then name `foo` within the test.
-This is similar to how Cargo does dependency renaming.
+This is similar to how Cargo does dependency renaming. It is also possible to
+specify [`--extern` modifiers](https://github.com/rust-lang/rust/issues/98405).
+For example, `//@ aux-crate:noprelude:foo=bar.rs`.
 
 `aux-bin` is similar to `aux-build` but will build a binary instead of a
 library. The binary will be available in `auxiliary/bin` relative to the working

--- a/src/doc/rustc-dev-guide/src/tests/directives.md
+++ b/src/doc/rustc-dev-guide/src/tests/directives.md
@@ -53,14 +53,14 @@ Directives can generally be found by browsing the
 
 See [Building auxiliary crates](compiletest.html#building-auxiliary-crates)
 
-| Directive             | Explanation                                                                                           | Supported test suites                  | Possible values                               |
-|-----------------------|-------------------------------------------------------------------------------------------------------|----------------------------------------|-----------------------------------------------|
-| `aux-bin`             | Build a aux binary, made available in `auxiliary/bin` relative to test directory                      | All except `run-make`/`run-make-cargo` | Path to auxiliary `.rs` file                  |
-| `aux-build`           | Build a separate crate from the named source file                                                     | All except `run-make`/`run-make-cargo` | Path to auxiliary `.rs` file                  |
-| `aux-crate`           | Like `aux-build` but makes available as extern prelude                                                | All except `run-make`/`run-make-cargo` | `<extern_prelude_name>=<path/to/aux/file.rs>` |
-| `aux-codegen-backend` | Similar to `aux-build` but pass the compiled dylib to `-Zcodegen-backend` when building the main file | `ui-fulldeps`                          | Path to codegen backend file                  |
-| `proc-macro`          | Similar to `aux-build`, but for aux forces host and don't use `-Cprefer-dynamic`[^pm].                | All except `run-make`/`run-make-cargo` | Path to auxiliary proc-macro `.rs` file       |
-| `build-aux-docs`      | Build docs for auxiliaries as well.  Note that this only works with `aux-build`, not `aux-crate`.     | All except `run-make`/`run-make-cargo` | N/A                                           |
+| Directive             | Explanation                                                                                           | Supported test suites                  | Possible values                                                    |
+|-----------------------|-------------------------------------------------------------------------------------------------------|----------------------------------------|--------------------------------------------------------------------|
+| `aux-bin`             | Build a aux binary, made available in `auxiliary/bin` relative to test directory                      | All except `run-make`/`run-make-cargo` | Path to auxiliary `.rs` file                                       |
+| `aux-build`           | Build a separate crate from the named source file                                                     | All except `run-make`/`run-make-cargo` | Path to auxiliary `.rs` file                                       |
+| `aux-crate`           | Like `aux-build` but makes available as extern prelude                                                | All except `run-make`/`run-make-cargo` | `[<extern_modifiers>:]<extern_prelude_name>=<path/to/aux/file.rs>` |
+| `aux-codegen-backend` | Similar to `aux-build` but pass the compiled dylib to `-Zcodegen-backend` when building the main file | `ui-fulldeps`                          | Path to codegen backend file                                       |
+| `proc-macro`          | Similar to `aux-build`, but for aux forces host and don't use `-Cprefer-dynamic`[^pm].                | All except `run-make`/`run-make-cargo` | Path to auxiliary proc-macro `.rs` file                            |
+| `build-aux-docs`      | Build docs for auxiliaries as well.  Note that this only works with `aux-build`, not `aux-crate`.     | All except `run-make`/`run-make-cargo` | N/A                                                                |
 
 [^pm]: please see the [Auxiliary proc-macro section](compiletest.html#auxiliary-proc-macro) in the compiletest chapter for specifics.
 

--- a/src/tools/compiletest/src/directives/auxiliary.rs
+++ b/src/tools/compiletest/src/directives/auxiliary.rs
@@ -6,12 +6,20 @@ use std::iter;
 use super::directives::{AUX_BIN, AUX_BUILD, AUX_CODEGEN_BACKEND, AUX_CRATE, PROC_MACRO};
 use crate::common::Config;
 use crate::directives::DirectiveLine;
+use crate::util::static_regex;
+
+#[cfg(test)]
+mod tests;
 
 /// The value of an `aux-crate` directive.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AuxCrate {
+    /// Contains `--extern` modifiers, if any. See the tracking issue for more
+    /// info: <https://github.com/rust-lang/rust/issues/98405>
+    /// With `aux-crate: noprelude:foo=bar.rs` this will be `noprelude`.
+    pub extern_modifiers: Option<String>,
     /// With `aux-crate: foo=bar.rs` this will be `foo`.
-    /// With `aux-crate: noprelude:foo=bar.rs` this will be `noprelude:foo`.
+    /// With `aux-crate: noprelude:foo=bar.rs` this will be `foo`.
     pub name: String,
     /// With `aux-crate: foo=bar.rs` this will be `bar.rs`.
     pub path: String,
@@ -74,9 +82,20 @@ pub(super) fn parse_and_update_aux(
 }
 
 fn parse_aux_crate(r: String) -> AuxCrate {
-    let mut parts = r.trim().splitn(2, '=');
-    AuxCrate {
-        name: parts.next().expect("missing aux-crate name (e.g. log=log.rs)").to_string(),
-        path: parts.next().expect("missing aux-crate value (e.g. log=log.rs)").to_string(),
-    }
+    let r = r.trim();
+
+    // Matches:
+    //   name=path
+    //   modifiers:name=path
+    let caps = static_regex!(r"^(?:(?<modifiers>[^=]*?):)?(?<name>[^=]*)=(?<path>.*)$")
+        .captures(r)
+        .unwrap_or_else(|| {
+            panic!("couldn't parse aux-crate value `{r}` (should be e.g. `log=log.rs`)")
+        });
+
+    let modifiers = caps.name("modifiers").map(|m| m.as_str().to_string());
+    let name = caps["name"].to_string();
+    let path = caps["path"].to_string();
+
+    AuxCrate { extern_modifiers: modifiers, name, path }
 }

--- a/src/tools/compiletest/src/directives/auxiliary/tests.rs
+++ b/src/tools/compiletest/src/directives/auxiliary/tests.rs
@@ -1,0 +1,27 @@
+use super::*;
+
+#[test]
+fn test_aux_crate_value_no_modifiers() {
+    assert_eq!(
+        AuxCrate { extern_modifiers: None, name: "foo".to_string(), path: "foo.rs".to_string() },
+        parse_aux_crate("foo=foo.rs".to_string())
+    );
+}
+
+#[test]
+fn test_aux_crate_value_with_modifiers() {
+    assert_eq!(
+        AuxCrate {
+            extern_modifiers: Some("noprelude".to_string()),
+            name: "foo".to_string(),
+            path: "foo.rs".to_string()
+        },
+        parse_aux_crate("noprelude:foo=foo.rs".to_string())
+    );
+}
+
+#[test]
+#[should_panic(expected = "couldn't parse aux-crate value `foo.rs` (should be e.g. `log=log.rs`)")]
+fn test_aux_crate_value_invalid() {
+    parse_aux_crate("foo.rs".to_string());
+}

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1277,23 +1277,36 @@ impl<'test> TestCx<'test> {
                 .replace('-', "_")
         };
 
-        let add_extern =
-            |rustc: &mut Command, aux_name: &str, aux_path: &str, aux_type: AuxType| {
-                let lib_name = get_lib_name(&path_to_crate_name(aux_path), aux_type);
-                if let Some(lib_name) = lib_name {
-                    rustc.arg("--extern").arg(format!("{}={}/{}", aux_name, aux_dir, lib_name));
-                }
-            };
+        let add_extern = |rustc: &mut Command,
+                          extern_modifiers: Option<&str>,
+                          aux_name: &str,
+                          aux_path: &str,
+                          aux_type: AuxType| {
+            let lib_name = get_lib_name(&path_to_crate_name(aux_path), aux_type);
+            if let Some(lib_name) = lib_name {
+                let modifiers_and_name = match extern_modifiers {
+                    Some(modifiers) => format!("{modifiers}:{aux_name}"),
+                    None => aux_name.to_string(),
+                };
+                rustc.arg("--extern").arg(format!("{modifiers_and_name}={aux_dir}/{lib_name}"));
+            }
+        };
 
-        for AuxCrate { name, path } in &self.props.aux.crates {
+        for AuxCrate { extern_modifiers, name, path } in &self.props.aux.crates {
             let aux_type = self.build_auxiliary(&path, &aux_dir, None);
-            add_extern(rustc, name, path, aux_type);
+            add_extern(rustc, extern_modifiers.as_deref(), name, path, aux_type);
         }
 
         for proc_macro in &self.props.aux.proc_macros {
             self.build_auxiliary(proc_macro, &aux_dir, Some(AuxType::ProcMacro));
             let crate_name = path_to_crate_name(proc_macro);
-            add_extern(rustc, &crate_name, proc_macro, AuxType::ProcMacro);
+            add_extern(
+                rustc,
+                None, // `extern_modifiers`
+                &crate_name,
+                proc_macro,
+                AuxType::ProcMacro,
+            );
         }
 
         // Build any `//@ aux-codegen-backend`, and pass the resulting library

--- a/tests/assembly-llvm/cstring-merging.rs
+++ b/tests/assembly-llvm/cstring-merging.rs
@@ -1,5 +1,6 @@
 // MIPS assembler uses the label prefix `$anon.` for local anonymous variables
 // other architectures (including ARM and x86-64) use the prefix `.Lanon.`
+// Hexagon uses `.string` instead of `.asciz` for null-terminated strings
 //@ only-linux
 //@ assembly-output: emit-asm
 //@ compile-flags: --crate-type=lib -Copt-level=3 -Cllvm-args=-enable-global-merge=0
@@ -9,13 +10,13 @@ use std::ffi::CStr;
 
 // CHECK: .section .rodata.str1.{{[12]}},"aMS"
 // CHECK: {{(\.L|\$)}}anon.{{.+}}:
-// CHECK-NEXT: .asciz "foo"
+// CHECK-NEXT: .{{asciz|string}} "foo"
 #[unsafe(no_mangle)]
 static CSTR: &[u8; 4] = b"foo\0";
 
 // CHECK-NOT: .section
 // CHECK: {{(\.L|\$)}}anon.{{.+}}:
-// CHECK-NEXT: .asciz "bar"
+// CHECK-NEXT: .{{asciz|string}} "bar"
 #[unsafe(no_mangle)]
 pub fn cstr() -> &'static CStr {
     c"bar"
@@ -23,7 +24,7 @@ pub fn cstr() -> &'static CStr {
 
 // CHECK-NOT: .section
 // CHECK: {{(\.L|\$)}}anon.{{.+}}:
-// CHECK-NEXT: .asciz "baz"
+// CHECK-NEXT: .{{asciz|string}} "baz"
 #[unsafe(no_mangle)]
 pub fn manual_cstr() -> &'static str {
     "baz\0"

--- a/tests/codegen-llvm/simd/splat.rs
+++ b/tests/codegen-llvm/simd/splat.rs
@@ -1,0 +1,32 @@
+#![crate_type = "lib"]
+#![no_std]
+#![feature(repr_simd, core_intrinsics)]
+use core::intrinsics::simd::simd_splat;
+
+#[path = "../../auxiliary/minisimd.rs"]
+mod minisimd;
+use minisimd::*;
+
+// Test that `simd_splat` produces the canonical LLVM splat sequence.
+
+#[no_mangle]
+unsafe fn int(x: u16) -> u16x2 {
+    // CHECK-LABEL: int
+    // CHECK: start:
+    // CHECK-NEXT: %0 = insertelement <2 x i16> poison, i16 %x, i64 0
+    // CHECK-NEXT: %1 = shufflevector <2 x i16> %0, <2 x i16> poison, <2 x i32> zeroinitializer
+    // CHECK-NEXT: store
+    // CHECK-NEXT: ret
+    simd_splat(x)
+}
+
+#[no_mangle]
+unsafe fn float(x: f32) -> f32x4 {
+    // CHECK-LABEL: float
+    // CHECK: start:
+    // CHECK-NEXT: %0 = insertelement <4 x float> poison, float %x, i64 0
+    // CHECK-NEXT: %1 = shufflevector <4 x float> %0, <4 x float> poison, <4 x i32> zeroinitializer
+    // CHECK-NEXT: store
+    // CHECK-NEXT: ret
+    simd_splat(x)
+}

--- a/tests/codegen-llvm/simd/splat.rs
+++ b/tests/codegen-llvm/simd/splat.rs
@@ -1,3 +1,4 @@
+//@ compile-flags: -Copt-level=3
 #![crate_type = "lib"]
 #![no_std]
 #![feature(repr_simd, core_intrinsics)]

--- a/tests/ui/simd/intrinsic/splat.rs
+++ b/tests/ui/simd/intrinsic/splat.rs
@@ -1,0 +1,52 @@
+//@ run-pass
+#![feature(repr_simd, core_intrinsics)]
+
+#[path = "../../../auxiliary/minisimd.rs"]
+mod minisimd;
+use minisimd::*;
+
+use std::intrinsics::simd::simd_splat;
+
+fn main() {
+    unsafe {
+        let x: Simd<u32, 1> = simd_splat(123u32);
+        let y: Simd<u32, 1> = const { simd_splat(123u32) };
+        assert_eq!(x.into_array(), [123; 1]);
+        assert_eq!(x.into_array(), y.into_array());
+
+        let x: u16x2 = simd_splat(42u16);
+        let y: u16x2 = const { simd_splat(42u16) };
+        assert_eq!(x.into_array(), [42; 2]);
+        assert_eq!(x.into_array(), y.into_array());
+
+        let x: u128x4 = simd_splat(42u128);
+        let y: u128x4 = const { simd_splat(42u128) };
+        assert_eq!(x.into_array(), [42; 4]);
+        assert_eq!(x.into_array(), y.into_array());
+
+        let x: i32x4 = simd_splat(-7i32);
+        let y: i32x4 = const { simd_splat(-7i32) };
+        assert_eq!(x.into_array(), [-7; 4]);
+        assert_eq!(x.into_array(), y.into_array());
+
+        let x: f32x4 = simd_splat(42.0f32);
+        let y: f32x4 = const { simd_splat(42.0f32) };
+        assert_eq!(x.into_array(), [42.0; 4]);
+        assert_eq!(x.into_array(), y.into_array());
+
+        let x: f64x2 = simd_splat(42.0f64);
+        let y: f64x2 = const { simd_splat(42.0f64) };
+        assert_eq!(x.into_array(), [42.0; 2]);
+        assert_eq!(x.into_array(), y.into_array());
+
+        static ZERO: u8 = 0u8;
+        let x: Simd<*const u8, 2> = simd_splat(&raw const ZERO);
+        assert_eq!(x.into_array(), [&raw const ZERO; 2]);
+
+        // FIXME: this hits "could not evaluate shuffle_indices at compile time",
+        // emitted in `immediate_const_vector`. const-eval should be able to handle
+        // this though I think? `const { [&raw const ZERO; 2] }` appears to work.
+        // let y: Simd<*const u8, 2> = const { simd_splat(&raw const ZERO) };
+        // assert_eq!(x.into_array(), y.into_array());
+    }
+}

--- a/tests/ui/simd/intrinsic/splat.rs
+++ b/tests/ui/simd/intrinsic/splat.rs
@@ -41,12 +41,8 @@ fn main() {
 
         static ZERO: u8 = 0u8;
         let x: Simd<*const u8, 2> = simd_splat(&raw const ZERO);
+        let y: Simd<*const u8, 2> = const { simd_splat(&raw const ZERO) };
         assert_eq!(x.into_array(), [&raw const ZERO; 2]);
-
-        // FIXME: this hits "could not evaluate shuffle_indices at compile time",
-        // emitted in `immediate_const_vector`. const-eval should be able to handle
-        // this though I think? `const { [&raw const ZERO; 2] }` appears to work.
-        // let y: Simd<*const u8, 2> = const { simd_splat(&raw const ZERO) };
-        // assert_eq!(x.into_array(), y.into_array());
+        assert_eq!(x.into_array(), y.into_array());
     }
 }


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#151346 (add `simd_splat` intrinsic)
 - rust-lang/rust#151353 (compiletest: Make `aux-crate` directive explicitly handle `--extern` modifiers)
 - rust-lang/rust#151571 (Fix cstring-merging test for Hexagon target)

r? @ghost

<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=151346,151353,151571)
<!-- homu-ignore:end -->

