### PR TITLE
Fix typo: 'occured' -> 'occurred' in clippy test

### DIFF
--- a/src/tools/clippy/tests/ui/significant_drop_tightening.fixed
+++ b/src/tools/clippy/tests/ui/significant_drop_tightening.fixed
@@ -160,7 +160,7 @@ fn issue15574() {
     
     //~^ significant_drop_tightening
     if stdin.read_line(&mut buffer).is_err() {
-        eprintln!("An error has occured while reading.");
+        eprintln!("An error has occurred while reading.");
         return;
     }
     drop(stdin);

--- a/src/tools/clippy/tests/ui/significant_drop_tightening.rs
+++ b/src/tools/clippy/tests/ui/significant_drop_tightening.rs
@@ -155,7 +155,7 @@ fn issue15574() {
     let mut stdin = stdin.take(40);
     //~^ significant_drop_tightening
     if stdin.read_line(&mut buffer).is_err() {
-        eprintln!("An error has occured while reading.");
+        eprintln!("An error has occurred while reading.");
         return;
     }
     println!("Our string has a capacity of {}", buffer.capacity());


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
