### PR TITLE
Remove `Deref<Target = TyCtxt>` from `QueryCtxt`

### DIFF
--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -35,6 +35,8 @@ use rustc_span::def_id::LOCAL_CRATE;
 
 use crate::QueryConfigRestored;
 
+/// Implements [`QueryContext`] for use by [`rustc_query_system`], since that
+/// crate does not have direct access to [`TyCtxt`].
 #[derive(Copy, Clone)]
 pub struct QueryCtxt<'tcx> {
     pub tcx: TyCtxt<'tcx>,
@@ -44,15 +46,6 @@ impl<'tcx> QueryCtxt<'tcx> {
     #[inline]
     pub fn new(tcx: TyCtxt<'tcx>) -> Self {
         QueryCtxt { tcx }
-    }
-}
-
-impl<'tcx> std::ops::Deref for QueryCtxt<'tcx> {
-    type Target = TyCtxt<'tcx>;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        &self.tcx
     }
 }
 
@@ -69,14 +62,16 @@ impl<'tcx> HasDepContext for QueryCtxt<'tcx> {
 impl QueryContext for QueryCtxt<'_> {
     #[inline]
     fn jobserver_proxy(&self) -> &Proxy {
-        &*self.jobserver_proxy
+        &self.tcx.jobserver_proxy
     }
 
     #[inline]
     fn next_job_id(self) -> QueryJobId {
         QueryJobId(
-            NonZero::new(self.query_system.jobs.fetch_add(1, std::sync::atomic::Ordering::Relaxed))
-                .unwrap(),
+            NonZero::new(
+                self.tcx.query_system.jobs.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+            )
+            .unwrap(),
         )
     }
 
@@ -113,7 +108,8 @@ impl QueryContext for QueryCtxt<'_> {
         self,
         prev_dep_node_index: SerializedDepNodeIndex,
     ) -> Option<QuerySideEffect> {
-        self.query_system
+        self.tcx
+            .query_system
             .on_disk_cache
             .as_ref()
             .and_then(|c| c.load_side_effect(self.tcx, prev_dep_node_index))
@@ -122,7 +118,7 @@ impl QueryContext for QueryCtxt<'_> {
     #[inline(never)]
     #[cold]
     fn store_side_effect(self, dep_node_index: DepNodeIndex, side_effect: QuerySideEffect) {
-        if let Some(c) = self.query_system.on_disk_cache.as_ref() {
+        if let Some(c) = self.tcx.query_system.on_disk_cache.as_ref() {
             c.store_side_effect(dep_node_index, side_effect)
         }
     }
@@ -140,7 +136,9 @@ impl QueryContext for QueryCtxt<'_> {
         // as `self`, so we use `with_related_context` to relate the 'tcx lifetimes
         // when accessing the `ImplicitCtxt`.
         tls::with_related_context(self.tcx, move |current_icx| {
-            if depth_limit && !self.recursion_limit().value_within_limit(current_icx.query_depth) {
+            if depth_limit
+                && !self.tcx.recursion_limit().value_within_limit(current_icx.query_depth)
+            {
                 self.depth_limit_error(token);
             }
 
@@ -161,16 +159,16 @@ impl QueryContext for QueryCtxt<'_> {
         let query_map = self.collect_active_jobs(true).expect("failed to collect active queries");
         let (info, depth) = job.find_dep_kind_root(query_map);
 
-        let suggested_limit = match self.recursion_limit() {
+        let suggested_limit = match self.tcx.recursion_limit() {
             Limit(0) => Limit(2),
             limit => limit * 2,
         };
 
-        self.sess.dcx().emit_fatal(QueryOverflow {
+        self.tcx.sess.dcx().emit_fatal(QueryOverflow {
             span: info.job.span,
             note: QueryOverflowNote { desc: info.query.description, depth },
             suggested_limit,
-            crate_name: self.crate_name(LOCAL_CRATE),
+            crate_name: self.tcx.crate_name(LOCAL_CRATE),
         });
     }
 }
@@ -367,7 +365,7 @@ pub(crate) fn encode_query_results<'a, 'tcx, Q>(
     Q: super::QueryConfigRestored<'tcx>,
     Q::RestoredValue: Encodable<CacheEncoder<'a, 'tcx>>,
 {
-    let _timer = qcx.profiler().generic_activity_with_arg("encode_query_results_for", query.name());
+    let _timer = qcx.tcx.prof.generic_activity_with_arg("encode_query_results_for", query.name());
 
     assert!(query.query_state(qcx).all_inactive());
     let cache = query.query_cache(qcx);
@@ -389,8 +387,7 @@ pub(crate) fn query_key_hash_verify<'tcx>(
     query: impl QueryConfig<QueryCtxt<'tcx>>,
     qcx: QueryCtxt<'tcx>,
 ) {
-    let _timer =
-        qcx.profiler().generic_activity_with_arg("query_key_hash_verify_for", query.name());
+    let _timer = qcx.tcx.prof.generic_activity_with_arg("query_key_hash_verify_for", query.name());
 
     let mut map = UnordMap::default();
 


### PR DESCRIPTION
Explicitly writing `self.tcx` is easy enough, and lets us remove a bit of non-essential deref magic.

