### PR TITLE
Fix ICE in const eval of packed SIMD types with non-power-of-two element counts

### DIFF
--- a/tests/ui/consts/const-eval/simd/simd-packed-non-pow2.rs
+++ b/tests/ui/consts/const-eval/simd/simd-packed-non-pow2.rs
@@ -1,0 +1,18 @@
+//@ check-pass
+// Fixes #151537
+#![feature(portable_simd, core_intrinsics)]
+use std::intrinsics::simd::SimdAlign;
+use std::{ptr::null, simd::prelude::*};
+
+const _: () = {
+    let c = Simd::from_array([0; 3]);
+    unsafe {
+        core::intrinsics::simd::simd_masked_store::<_, _, _, { SimdAlign::Element }>(
+            c,
+            null::<i32>(),
+            c,
+        )
+    };
+};
+
+fn main() {}


### PR DESCRIPTION
fixes rust-lang/rust#151537

const evaluation of packed SIMD types with non-power-of-two element counts (like `Simd<_, 3>`) was hitting an ICE. the issue was in `check_simd_ptr_alignment` - it asserted that `backend_repr` must be `BackendRepr::SimdVector`, but for packed SIMD types with non-power-of-two counts the compiler uses `BackendRepr::Memory` instead (as mentioned in `rustc_abi/src/layout.rs:1511`).

was fixed by making `check_simd_ptr_alignment` accept both `BackendRepr::SimdVector` and `BackendRepr::Memory` for SIMD types. added a check to ensure we're dealing with a SIMD type, and the alignment logic works the same for both representations.

also i added a test that reproduces the original ICE.

