### PR TITLE
Handle transient ENOMEM in statx probing

### DIFF
--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -203,6 +203,10 @@ cfg_has_statx! {{
             if err2 == Some(libc::EFAULT) {
                 STATX_SAVED_STATE.store(STATX_STATE::Present as u8, Ordering::Relaxed);
                 return Some(Err(err));
+            } else if err2 == Some(libc::ENOMEM) {
+                // ENOMEM is transient, so don't permanently disable statx.
+                // Fallback to stat64 for this call.
+                return None;
             } else {
                 STATX_SAVED_STATE.store(STATX_STATE::Unavailable as u8, Ordering::Relaxed);
                 return None;


### PR DESCRIPTION
Fixes a FIXME in [sys/fs/unix.rs](cci:7://file:///home/centauri/open-source/rust/rust/library/std/src/sys/fs/unix.rs:0:0-0:0).

Currently, if the `statx` availability probe fails with `ENOMEM`, `statx` is permanently disabled for the process. Since `ENOMEM` is transient, this change allows falling back to [stat](cci:1://file:///home/centauri/open-source/rust/rust/library/std/src/sys/fs/unix.rs:2153:0-2168:1) for the current call without updating `STATX_SAVED_STATE` to `Unavailable`, permitting `statx` to be retried later.