### PR TITLE
[EXPERIMENT] Remove static booleans from `rustc_query_impl::DynamicConfig`

### DIFF
--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -20,7 +20,12 @@ use crate::ty::TyCtxt;
 
 pub struct DynamicQuery<'tcx, C: QueryCache> {
     pub name: &'static str,
-    pub eval_always: bool,
+
+    pub is_anon: bool,
+    pub is_depth_limit: bool,
+    pub is_eval_always: bool,
+    pub is_feedable: bool,
+
     pub dep_kind: DepKind,
     /// How this query deals with query cycle errors.
     pub cycle_error_handling: CycleErrorHandling,

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -37,30 +37,18 @@ pub use crate::plumbing::{QueryCtxt, query_key_hash_verify_all};
 mod profiling_support;
 pub use self::profiling_support::alloc_self_profile_query_strings;
 
-struct DynamicConfig<
-    'tcx,
-    C: QueryCache,
-    const ANON: bool,
-    const DEPTH_LIMIT: bool,
-    const FEEDABLE: bool,
-> {
+struct DynamicConfig<'tcx, C: QueryCache> {
     dynamic: &'tcx DynamicQuery<'tcx, C>,
 }
 
-impl<'tcx, C: QueryCache, const ANON: bool, const DEPTH_LIMIT: bool, const FEEDABLE: bool> Copy
-    for DynamicConfig<'tcx, C, ANON, DEPTH_LIMIT, FEEDABLE>
-{
-}
-impl<'tcx, C: QueryCache, const ANON: bool, const DEPTH_LIMIT: bool, const FEEDABLE: bool> Clone
-    for DynamicConfig<'tcx, C, ANON, DEPTH_LIMIT, FEEDABLE>
-{
+impl<'tcx, C: QueryCache> Copy for DynamicConfig<'tcx, C> {}
+impl<'tcx, C: QueryCache> Clone for DynamicConfig<'tcx, C> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'tcx, C: QueryCache, const ANON: bool, const DEPTH_LIMIT: bool, const FEEDABLE: bool>
-    QueryConfig<QueryCtxt<'tcx>> for DynamicConfig<'tcx, C, ANON, DEPTH_LIMIT, FEEDABLE>
+impl<'tcx, C: QueryCache> QueryConfig<QueryCtxt<'tcx>> for DynamicConfig<'tcx, C>
 where
     for<'a> C::Key: HashStable<StableHashingContext<'a>>,
 {
@@ -157,22 +145,22 @@ where
 
     #[inline(always)]
     fn anon(self) -> bool {
-        ANON
+        self.dynamic.is_anon
     }
 
     #[inline(always)]
     fn eval_always(self) -> bool {
-        self.dynamic.eval_always
+        self.dynamic.is_eval_always
     }
 
     #[inline(always)]
     fn depth_limit(self) -> bool {
-        DEPTH_LIMIT
+        self.dynamic.is_depth_limit
     }
 
     #[inline(always)]
     fn feedable(self) -> bool {
-        FEEDABLE
+        self.dynamic.is_feedable
     }
 
     #[inline(always)]

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -616,7 +616,12 @@ macro_rules! define_queries {
             {
                 DynamicQuery {
                     name: stringify!($name),
-                    eval_always: is_eval_always!([$($modifiers)*]),
+
+                    is_anon: is_anon!([$($modifiers)*]),
+                    is_depth_limit: depth_limit!([$($modifiers)*]),
+                    is_eval_always: is_eval_always!([$($modifiers)*]),
+                    is_feedable: feedable!([$($modifiers)*]),
+
                     dep_kind: dep_graph::dep_kinds::$name,
                     cycle_error_handling: cycle_error_handling!([$($modifiers)*]),
                     query_state: std::mem::offset_of!(QueryStates<'tcx>, $name),
@@ -685,9 +690,6 @@ macro_rules! define_queries {
                 type Config = DynamicConfig<
                     'tcx,
                     queries::$name::Storage<'tcx>,
-                    { is_anon!([$($modifiers)*]) },
-                    { depth_limit!([$($modifiers)*]) },
-                    { feedable!([$($modifiers)*]) },
                 >;
 
                 const NAME: &'static &'static str = &stringify!($name);


### PR DESCRIPTION
Checking the bootstrap-perf and compiler-perf implications of getting rid of the intermediate `DynamicConfig` layer.

r? ghost