### PR TITLE
Handle transient ENOMEM in statx probing

### DIFF
--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -196,6 +196,7 @@ cfg_has_statx! {{
             //
             // See: https://github.com/rust-lang/rust/issues/65662
             //
+            // FIXME what about transient conditions like `ENOMEM`?
 
             let err2 = cvt(statx(0, ptr::null(), 0, libc::STATX_BASIC_STATS | libc::STATX_BTIME, ptr::null_mut()))
                 .err()

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -195,6 +195,8 @@ cfg_has_statx! {{
             // if the syscall is usable.
             //
             // See: https://github.com/rust-lang/rust/issues/65662
+            //
+
             let err2 = cvt(statx(0, ptr::null(), 0, libc::STATX_BASIC_STATS | libc::STATX_BTIME, ptr::null_mut()))
                 .err()
                 .and_then(|e| e.raw_os_error());

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -195,8 +195,6 @@ cfg_has_statx! {{
             // if the syscall is usable.
             //
             // See: https://github.com/rust-lang/rust/issues/65662
-            //
-
             let err2 = cvt(statx(0, ptr::null(), 0, libc::STATX_BASIC_STATS | libc::STATX_BTIME, ptr::null_mut()))
                 .err()
                 .and_then(|e| e.raw_os_error());


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/151641)*
<!-- homu-ignore:end -->

Fixes a FIXME in `sys/fs/unix.rs`.

Currently, if the `statx` availability probe fails with `ENOMEM`, `statx` is permanently disabled for the process. Since `ENOMEM` is transient, this change allows falling back to `stat` for the current call without updating `STATX_SAVED_STATE` to `Unavailable`, permitting `statx` to be retried later.