### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/tests/codegen-llvm/loongarch-abi/call-llvm-intrinsics.rs
+++ b/tests/codegen-llvm/loongarch-abi/call-llvm-intrinsics.rs
@@ -23,9 +23,7 @@ pub fn do_call() {
 
     unsafe {
         // Ensure that we `call` LLVM intrinsics instead of trying to `invoke` them
-        // CHECK: store float 4.000000e+00, ptr %{{.}}, align 4
-        // CHECK: load float, ptr %{{.}}, align 4
-        // CHECK: call float @llvm.sqrt.f32(float %{{.}}
+        // CHECK: call float @llvm.sqrt.f32(float 4.000000e+00)
         sqrt(4.0);
     }
 }

--- a/tests/codegen-llvm/loongarch/direct-access-external-data.rs
+++ b/tests/codegen-llvm/loongarch/direct-access-external-data.rs
@@ -1,6 +1,4 @@
-//@ ignore-loongarch64 (handles dso_local differently)
-//@ ignore-powerpc64 (handles dso_local differently)
-//@ ignore-apple (handles dso_local differently)
+//@ only-loongarch64
 
 //@ revisions: DEFAULT PIE DIRECT INDIRECT
 //@ [DEFAULT] compile-flags: -C relocation-model=static
@@ -13,7 +11,7 @@
 
 unsafe extern "C" {
     // CHECK: @VAR = external
-    // DEFAULT-SAME: dso_local
+    // DEFAULT-NOT: dso_local
     // PIE-NOT: dso_local
     // DIRECT-SAME: dso_local
     // INDIRECT-NOT: dso_local
@@ -23,7 +21,7 @@ unsafe extern "C" {
     // When "linkage" is used, we generate an indirection global.
     // Check dso_local is still applied to the actual global.
     // CHECK: @EXTERNAL = external
-    // DEFAULT-SAME: dso_local
+    // DEFAULT-NOT: dso_local
     // PIE-NOT: dso_local
     // DIRECT-SAME: dso_local
     // INDIRECT-NOT: dso_local
@@ -32,7 +30,7 @@ unsafe extern "C" {
     safe static EXTERNAL: *const u32;
 
     // CHECK: @WEAK = extern_weak
-    // DEFAULT-SAME: dso_local
+    // DEFAULT-NOT: dso_local
     // PIE-NOT: dso_local
     // DIRECT-SAME: dso_local
     // INDIRECT-NOT: dso_local


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#151404 (LoongArch: Fix direct-access-external-data test)
 - rust-lang/rust#151405 (LoongArch: Fix call-llvm-intrinsics test)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=151404,151405)
<!-- homu-ignore:end -->

