### PR TITLE
Cleanup of `#[derive(Diagnostic)]` attribute parsers

### DIFF
--- a/compiler/rustc_macros/src/diagnostics/diagnostic_builder.rs
+++ b/compiler/rustc_macros/src/diagnostics/diagnostic_builder.rs
@@ -192,7 +192,7 @@ impl DiagnosticDeriveVariantBuilder {
             SubdiagnosticKind::MultipartSuggestion { .. } => unreachable!(),
         });
 
-        Ok(Some((subdiag.kind, slug, subdiag.no_span)))
+        Ok(Some((subdiag.kind, slug, false)))
     }
 
     /// Establishes state in the `DiagnosticDeriveBuilder` resulting from the struct

--- a/compiler/rustc_macros/src/diagnostics/diagnostic_builder.rs
+++ b/compiler/rustc_macros/src/diagnostics/diagnostic_builder.rs
@@ -12,7 +12,7 @@ use crate::diagnostics::error::{
     DiagnosticDeriveError, span_err, throw_invalid_attr, throw_span_err,
 };
 use crate::diagnostics::utils::{
-    FieldInfo, FieldInnerTy, FieldMap, HasFieldMap, SetOnce, SpannedOption, SubdiagnosticKind,
+    FieldInfo, FieldInnerTy, FieldMap, SetOnce, SpannedOption, SubdiagnosticKind,
     build_field_mapping, is_doc_comment, report_error_if_not_applied_to_span, report_type_error,
     should_generate_arg, type_is_bool, type_is_unit, type_matches_path,
 };
@@ -48,12 +48,6 @@ pub(crate) struct DiagnosticDeriveVariantBuilder {
     /// Error codes are a optional part of the struct attribute - this is only set to detect
     /// multiple specifications.
     pub code: SpannedOption<()>,
-}
-
-impl HasFieldMap for DiagnosticDeriveVariantBuilder {
-    fn get_field_binding(&self, field: &String) -> Option<&TokenStream> {
-        self.field_map.get(field)
-    }
 }
 
 impl DiagnosticDeriveKind {
@@ -170,7 +164,7 @@ impl DiagnosticDeriveVariantBuilder {
         &self,
         attr: &Attribute,
     ) -> Result<Option<(SubdiagnosticKind, Path, bool)>, DiagnosticDeriveError> {
-        let Some(subdiag) = SubdiagnosticVariant::from_attr(attr, self)? else {
+        let Some(subdiag) = SubdiagnosticVariant::from_attr(attr, &self.field_map)? else {
             // Some attributes aren't errors - like documentation comments - but also aren't
             // subdiagnostics.
             return Ok(None);

--- a/compiler/rustc_macros/src/diagnostics/subdiagnostic.rs
+++ b/compiler/rustc_macros/src/diagnostics/subdiagnostic.rs
@@ -12,10 +12,10 @@ use crate::diagnostics::error::{
     DiagnosticDeriveError, invalid_attr, span_err, throw_invalid_attr, throw_span_err,
 };
 use crate::diagnostics::utils::{
-    AllowMultipleAlternatives, FieldInfo, FieldInnerTy, FieldMap, HasFieldMap, SetOnce,
-    SpannedOption, SubdiagnosticKind, build_field_mapping, build_suggestion_code, is_doc_comment,
-    new_code_ident, report_error_if_not_applied_to_applicability,
-    report_error_if_not_applied_to_span, should_generate_arg,
+    AllowMultipleAlternatives, FieldInfo, FieldInnerTy, FieldMap, SetOnce, SpannedOption,
+    SubdiagnosticKind, build_field_mapping, build_suggestion_code, is_doc_comment, new_code_ident,
+    report_error_if_not_applied_to_applicability, report_error_if_not_applied_to_span,
+    should_generate_arg,
 };
 
 /// The central struct for constructing the `add_to_diag` method from an annotated struct.
@@ -143,12 +143,6 @@ struct SubdiagnosticDeriveVariantBuilder<'parent, 'a> {
     is_enum: bool,
 }
 
-impl<'parent, 'a> HasFieldMap for SubdiagnosticDeriveVariantBuilder<'parent, 'a> {
-    fn get_field_binding(&self, field: &String) -> Option<&TokenStream> {
-        self.fields.get(field)
-    }
-}
-
 /// Provides frequently-needed information about the diagnostic kinds being derived for this type.
 #[derive(Clone, Copy, Debug)]
 struct KindsStatistics {
@@ -193,7 +187,7 @@ impl<'parent, 'a> SubdiagnosticDeriveVariantBuilder<'parent, 'a> {
 
         for attr in self.variant.ast().attrs {
             let Some(SubdiagnosticVariant { kind, slug }) =
-                SubdiagnosticVariant::from_attr(attr, self)?
+                SubdiagnosticVariant::from_attr(attr, &self.fields)?
             else {
                 // Some attributes aren't errors - like documentation comments - but also aren't
                 // subdiagnostics.
@@ -445,7 +439,7 @@ impl<'parent, 'a> SubdiagnosticDeriveVariantBuilder<'parent, 'a> {
                                 let formatting_init = build_suggestion_code(
                                     &code_field,
                                     input,
-                                    self,
+                                    &self.fields,
                                     AllowMultipleAlternatives::No,
                                 )?;
                                 code.set_once(

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
@@ -80,20 +80,17 @@ struct InvalidNestedStructAttr {}
 
 #[derive(Diagnostic)]
 #[diag(nonsense("foo"), code = E0123, slug = "foo")]
-//~^ ERROR diagnostic slug must be the first argument
-//~| ERROR diagnostic slug not specified
+//~^ ERROR derive(Diagnostic): diagnostic slug not specified
 struct InvalidNestedStructAttr1 {}
 
 #[derive(Diagnostic)]
 #[diag(nonsense = "...", code = E0123, slug = "foo")]
-//~^ ERROR unknown argument
-//~| ERROR diagnostic slug not specified
+//~^ ERROR diagnostic slug not specified
 struct InvalidNestedStructAttr2 {}
 
 #[derive(Diagnostic)]
 #[diag(nonsense = 4, code = E0123, slug = "foo")]
-//~^ ERROR unknown argument
-//~| ERROR diagnostic slug not specified
+//~^ ERROR diagnostic slug not specified
 struct InvalidNestedStructAttr3 {}
 
 #[derive(Diagnostic)]
@@ -113,7 +110,6 @@ struct WrongPlaceField {
 #[diag(no_crate_example, code = E0123)]
 #[diag(no_crate_example, code = E0456)]
 //~^ ERROR specified multiple times
-//~^^ ERROR specified multiple times
 struct DiagSpecifiedTwice {}
 
 #[derive(Diagnostic)]

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
@@ -539,7 +539,7 @@ struct LabelWithTrailingPath {
 #[diag(no_crate_example, code = E0123)]
 struct LabelWithTrailingNameValue {
     #[label(no_crate_label, foo = "...")]
-    //~^ ERROR only `no_span` is a valid nested attribute
+    //~^ ERROR no nested attribute expected here
     span: Span,
 }
 
@@ -547,7 +547,7 @@ struct LabelWithTrailingNameValue {
 #[diag(no_crate_example, code = E0123)]
 struct LabelWithTrailingList {
     #[label(no_crate_label, foo("..."))]
-    //~^ ERROR only `no_span` is a valid nested attribute
+    //~^ ERROR no nested attribute expected here
     span: Span,
 }
 

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
@@ -803,7 +803,7 @@ struct SuggestionsInvalidItem {
     sub: Span,
 }
 
-#[derive(Diagnostic)] //~ ERROR cannot find value `__code_34` in this scope
+#[derive(Diagnostic)]
 #[diag(no_crate_example)]
 struct SuggestionsInvalidLiteral {
     #[suggestion(code = 3)]

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
@@ -277,10 +277,10 @@ LL |     #[help(no_crate_help)]
    |     ^
 
 error: derive(Diagnostic): a diagnostic slug must be the first argument to the attribute
-  --> $DIR/diagnostic-derive.rs:533:32
+  --> $DIR/diagnostic-derive.rs:533:29
    |
 LL |     #[label(no_crate_label, foo)]
-   |                                ^
+   |                             ^^^
 
 error: derive(Diagnostic): only `no_span` is a valid nested attribute
   --> $DIR/diagnostic-derive.rs:541:29
@@ -606,14 +606,6 @@ error[E0425]: cannot find value `nonsense` in module `crate::fluent_generated`
 LL | #[diag(nonsense, code = E0123)]
    |        ^^^^^^^^ not found in `crate::fluent_generated`
 
-error[E0425]: cannot find value `__code_34` in this scope
-  --> $DIR/diagnostic-derive.rs:806:10
-   |
-LL | #[derive(Diagnostic)]
-   |          ^^^^^^^^^^ not found in this scope
-   |
-   = note: this error originates in the derive macro `Diagnostic` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0277]: the trait bound `Hello: IntoDiagArg` is not satisfied
   --> $DIR/diagnostic-derive.rs:347:12
    |
@@ -636,7 +628,7 @@ note: required by a bound in `Diag::<'a, G>::arg`
    = note: in this macro invocation
    = note: this error originates in the macro `with_fn` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 81 previous errors
+error: aborting due to 80 previous errors
 
 Some errors have detailed explanations: E0277, E0425.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
@@ -48,12 +48,6 @@ LL | #[diag(code = E0123)]
    |
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
-error: derive(Diagnostic): diagnostic slug must be the first argument
-  --> $DIR/diagnostic-derive.rs:82:16
-   |
-LL | #[diag(nonsense("foo"), code = E0123, slug = "foo")]
-   |                ^
-
 error: derive(Diagnostic): diagnostic slug not specified
   --> $DIR/diagnostic-derive.rs:82:1
    |
@@ -62,32 +56,16 @@ LL | #[diag(nonsense("foo"), code = E0123, slug = "foo")]
    |
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
-error: derive(Diagnostic): unknown argument
-  --> $DIR/diagnostic-derive.rs:88:8
-   |
-LL | #[diag(nonsense = "...", code = E0123, slug = "foo")]
-   |        ^^^^^^^^
-   |
-   = note: only the `code` parameter is valid after the slug
-
 error: derive(Diagnostic): diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:88:1
+  --> $DIR/diagnostic-derive.rs:87:1
    |
 LL | #[diag(nonsense = "...", code = E0123, slug = "foo")]
    | ^
    |
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
-error: derive(Diagnostic): unknown argument
-  --> $DIR/diagnostic-derive.rs:94:8
-   |
-LL | #[diag(nonsense = 4, code = E0123, slug = "foo")]
-   |        ^^^^^^^^
-   |
-   = note: only the `code` parameter is valid after the slug
-
 error: derive(Diagnostic): diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:94:1
+  --> $DIR/diagnostic-derive.rs:92:1
    |
 LL | #[diag(nonsense = 4, code = E0123, slug = "foo")]
    | ^
@@ -95,7 +73,7 @@ LL | #[diag(nonsense = 4, code = E0123, slug = "foo")]
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: derive(Diagnostic): unknown argument
-  --> $DIR/diagnostic-derive.rs:100:40
+  --> $DIR/diagnostic-derive.rs:97:40
    |
 LL | #[diag(no_crate_example, code = E0123, slug = "foo")]
    |                                        ^^^^
@@ -103,55 +81,43 @@ LL | #[diag(no_crate_example, code = E0123, slug = "foo")]
    = note: only the `code` parameter is valid after the slug
 
 error: derive(Diagnostic): `#[suggestion = ...]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:107:5
+  --> $DIR/diagnostic-derive.rs:104:5
    |
 LL |     #[suggestion = "bar"]
    |     ^
 
 error: derive(Diagnostic): attribute specified multiple times
-  --> $DIR/diagnostic-derive.rs:114:8
-   |
-LL | #[diag(no_crate_example, code = E0456)]
-   |        ^^^^^^^^^^^^^^^^
-   |
-note: previously specified here
-  --> $DIR/diagnostic-derive.rs:113:8
-   |
-LL | #[diag(no_crate_example, code = E0123)]
-   |        ^^^^^^^^^^^^^^^^
-
-error: derive(Diagnostic): attribute specified multiple times
-  --> $DIR/diagnostic-derive.rs:114:26
+  --> $DIR/diagnostic-derive.rs:111:26
    |
 LL | #[diag(no_crate_example, code = E0456)]
    |                          ^^^^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:113:26
+  --> $DIR/diagnostic-derive.rs:110:26
    |
 LL | #[diag(no_crate_example, code = E0123)]
    |                          ^^^^
 
 error: derive(Diagnostic): attribute specified multiple times
-  --> $DIR/diagnostic-derive.rs:120:40
+  --> $DIR/diagnostic-derive.rs:116:40
    |
 LL | #[diag(no_crate_example, code = E0123, code = E0456)]
    |                                        ^^^^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:120:26
+  --> $DIR/diagnostic-derive.rs:116:26
    |
 LL | #[diag(no_crate_example, code = E0123, code = E0456)]
    |                          ^^^^
 
 error: derive(Diagnostic): diagnostic slug must be the first argument
-  --> $DIR/diagnostic-derive.rs:125:43
+  --> $DIR/diagnostic-derive.rs:121:26
    |
 LL | #[diag(no_crate_example, no_crate::example, code = E0123)]
-   |                                           ^
+   |                          ^^^^^^^^
 
 error: derive(Diagnostic): diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:130:1
+  --> $DIR/diagnostic-derive.rs:126:1
    |
 LL | struct KindNotProvided {}
    | ^^^^^^
@@ -159,7 +125,7 @@ LL | struct KindNotProvided {}
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: derive(Diagnostic): diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:133:1
+  --> $DIR/diagnostic-derive.rs:129:1
    |
 LL | #[diag(code = E0123)]
    | ^
@@ -167,31 +133,31 @@ LL | #[diag(code = E0123)]
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: derive(Diagnostic): the `#[primary_span]` attribute can only be applied to fields of type `Span` or `MultiSpan`
-  --> $DIR/diagnostic-derive.rs:144:5
+  --> $DIR/diagnostic-derive.rs:140:5
    |
 LL |     #[primary_span]
    |     ^
 
 error: derive(Diagnostic): `#[nonsense]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:152:5
+  --> $DIR/diagnostic-derive.rs:148:5
    |
 LL |     #[nonsense]
    |     ^
 
 error: derive(Diagnostic): the `#[label(...)]` attribute can only be applied to fields of type `Span` or `MultiSpan`
-  --> $DIR/diagnostic-derive.rs:169:5
+  --> $DIR/diagnostic-derive.rs:165:5
    |
 LL |     #[label(no_crate_label)]
    |     ^
 
 error: derive(Diagnostic): `name` doesn't refer to a field on this type
-  --> $DIR/diagnostic-derive.rs:177:46
+  --> $DIR/diagnostic-derive.rs:173:46
    |
 LL |     #[suggestion(no_crate_suggestion, code = "{name}")]
    |                                              ^^^^^^^^
 
 error: invalid format string: expected `}` but string was terminated
-  --> $DIR/diagnostic-derive.rs:182:10
+  --> $DIR/diagnostic-derive.rs:178:10
    |
 LL | #[derive(Diagnostic)]
    |          ^^^^^^^^^^ expected `}` in format string
@@ -200,7 +166,7 @@ LL | #[derive(Diagnostic)]
    = note: this error originates in the derive macro `Diagnostic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: invalid format string: unmatched `}` found
-  --> $DIR/diagnostic-derive.rs:192:10
+  --> $DIR/diagnostic-derive.rs:188:10
    |
 LL | #[derive(Diagnostic)]
    |          ^^^^^^^^^^ unmatched `}` in format string
@@ -209,19 +175,19 @@ LL | #[derive(Diagnostic)]
    = note: this error originates in the derive macro `Diagnostic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: derive(Diagnostic): the `#[label(...)]` attribute can only be applied to fields of type `Span` or `MultiSpan`
-  --> $DIR/diagnostic-derive.rs:212:5
+  --> $DIR/diagnostic-derive.rs:208:5
    |
 LL |     #[label(no_crate_label)]
    |     ^
 
 error: derive(Diagnostic): suggestion without `code = "..."`
-  --> $DIR/diagnostic-derive.rs:231:5
+  --> $DIR/diagnostic-derive.rs:227:5
    |
 LL |     #[suggestion(no_crate_suggestion)]
    |     ^
 
 error: derive(Diagnostic): invalid nested attribute
-  --> $DIR/diagnostic-derive.rs:239:18
+  --> $DIR/diagnostic-derive.rs:235:18
    |
 LL |     #[suggestion(nonsense = "bar")]
    |                  ^^^^^^^^
@@ -229,13 +195,13 @@ LL |     #[suggestion(nonsense = "bar")]
    = help: only `no_span`, `style`, `code` and `applicability` are valid nested attributes
 
 error: derive(Diagnostic): suggestion without `code = "..."`
-  --> $DIR/diagnostic-derive.rs:239:5
+  --> $DIR/diagnostic-derive.rs:235:5
    |
 LL |     #[suggestion(nonsense = "bar")]
    |     ^
 
 error: derive(Diagnostic): invalid nested attribute
-  --> $DIR/diagnostic-derive.rs:248:18
+  --> $DIR/diagnostic-derive.rs:244:18
    |
 LL |     #[suggestion(msg = "bar")]
    |                  ^^^
@@ -243,13 +209,13 @@ LL |     #[suggestion(msg = "bar")]
    = help: only `no_span`, `style`, `code` and `applicability` are valid nested attributes
 
 error: derive(Diagnostic): suggestion without `code = "..."`
-  --> $DIR/diagnostic-derive.rs:248:5
+  --> $DIR/diagnostic-derive.rs:244:5
    |
 LL |     #[suggestion(msg = "bar")]
    |     ^
 
 error: derive(Diagnostic): wrong field type for suggestion
-  --> $DIR/diagnostic-derive.rs:271:5
+  --> $DIR/diagnostic-derive.rs:267:5
    |
 LL |     #[suggestion(no_crate_suggestion, code = "This is suggested code")]
    |     ^
@@ -257,79 +223,79 @@ LL |     #[suggestion(no_crate_suggestion, code = "This is suggested code")]
    = help: `#[suggestion(...)]` should be applied to fields of type `Span` or `(Span, Applicability)`
 
 error: derive(Diagnostic): attribute specified multiple times
-  --> $DIR/diagnostic-derive.rs:287:24
+  --> $DIR/diagnostic-derive.rs:283:24
    |
 LL |     suggestion: (Span, Span, Applicability),
    |                        ^^^^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:287:18
+  --> $DIR/diagnostic-derive.rs:283:18
    |
 LL |     suggestion: (Span, Span, Applicability),
    |                  ^^^^
 
 error: derive(Diagnostic): attribute specified multiple times
-  --> $DIR/diagnostic-derive.rs:295:33
+  --> $DIR/diagnostic-derive.rs:291:33
    |
 LL |     suggestion: (Applicability, Applicability, Span),
    |                                 ^^^^^^^^^^^^^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:295:18
+  --> $DIR/diagnostic-derive.rs:291:18
    |
 LL |     suggestion: (Applicability, Applicability, Span),
    |                  ^^^^^^^^^^^^^
 
 error: derive(Diagnostic): `#[label = ...]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:302:5
+  --> $DIR/diagnostic-derive.rs:298:5
    |
 LL |     #[label = "bar"]
    |     ^
 
 error: derive(Diagnostic): attribute specified multiple times
-  --> $DIR/diagnostic-derive.rs:453:5
+  --> $DIR/diagnostic-derive.rs:449:5
    |
 LL |     #[suggestion(no_crate_suggestion, code = "...", applicability = "maybe-incorrect")]
    |     ^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:455:24
+  --> $DIR/diagnostic-derive.rs:451:24
    |
 LL |     suggestion: (Span, Applicability),
    |                        ^^^^^^^^^^^^^
 
 error: derive(Diagnostic): invalid applicability
-  --> $DIR/diagnostic-derive.rs:461:69
+  --> $DIR/diagnostic-derive.rs:457:69
    |
 LL |     #[suggestion(no_crate_suggestion, code = "...", applicability = "batman")]
    |                                                                     ^^^^^^^^
 
 error: derive(Diagnostic): the `#[help(...)]` attribute can only be applied to fields of type `Span`, `MultiSpan`, `bool` or `()`
-  --> $DIR/diagnostic-derive.rs:528:5
+  --> $DIR/diagnostic-derive.rs:524:5
    |
 LL |     #[help(no_crate_help)]
    |     ^
 
 error: derive(Diagnostic): a diagnostic slug must be the first argument to the attribute
-  --> $DIR/diagnostic-derive.rs:537:32
+  --> $DIR/diagnostic-derive.rs:533:32
    |
 LL |     #[label(no_crate_label, foo)]
    |                                ^
 
 error: derive(Diagnostic): only `no_span` is a valid nested attribute
-  --> $DIR/diagnostic-derive.rs:545:29
+  --> $DIR/diagnostic-derive.rs:541:29
    |
 LL |     #[label(no_crate_label, foo = "...")]
    |                             ^^^
 
 error: derive(Diagnostic): only `no_span` is a valid nested attribute
-  --> $DIR/diagnostic-derive.rs:553:29
+  --> $DIR/diagnostic-derive.rs:549:29
    |
 LL |     #[label(no_crate_label, foo("..."))]
    |                             ^^^
 
 error: derive(Diagnostic): `#[primary_span]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:565:5
+  --> $DIR/diagnostic-derive.rs:561:5
    |
 LL |     #[primary_span]
    |     ^
@@ -337,13 +303,13 @@ LL |     #[primary_span]
    = help: the `primary_span` field attribute is not valid for lint diagnostics
 
 error: derive(Diagnostic): `#[error(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:585:1
+  --> $DIR/diagnostic-derive.rs:581:1
    |
 LL | #[error(no_crate_example, code = E0123)]
    | ^
 
 error: derive(Diagnostic): diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:585:1
+  --> $DIR/diagnostic-derive.rs:581:1
    |
 LL | #[error(no_crate_example, code = E0123)]
    | ^
@@ -351,13 +317,13 @@ LL | #[error(no_crate_example, code = E0123)]
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: derive(Diagnostic): `#[warn_(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:592:1
+  --> $DIR/diagnostic-derive.rs:588:1
    |
 LL | #[warn_(no_crate_example, code = E0123)]
    | ^
 
 error: derive(Diagnostic): diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:592:1
+  --> $DIR/diagnostic-derive.rs:588:1
    |
 LL | #[warn_(no_crate_example, code = E0123)]
    | ^
@@ -365,13 +331,13 @@ LL | #[warn_(no_crate_example, code = E0123)]
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: derive(Diagnostic): `#[lint(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:599:1
+  --> $DIR/diagnostic-derive.rs:595:1
    |
 LL | #[lint(no_crate_example, code = E0123)]
    | ^
 
 error: derive(Diagnostic): diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:599:1
+  --> $DIR/diagnostic-derive.rs:595:1
    |
 LL | #[lint(no_crate_example, code = E0123)]
    | ^
@@ -379,13 +345,13 @@ LL | #[lint(no_crate_example, code = E0123)]
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: derive(Diagnostic): `#[lint(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:606:1
+  --> $DIR/diagnostic-derive.rs:602:1
    |
 LL | #[lint(no_crate_example, code = E0123)]
    | ^
 
 error: derive(Diagnostic): diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:606:1
+  --> $DIR/diagnostic-derive.rs:602:1
    |
 LL | #[lint(no_crate_example, code = E0123)]
    | ^
@@ -393,19 +359,19 @@ LL | #[lint(no_crate_example, code = E0123)]
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: derive(Diagnostic): attribute specified multiple times
-  --> $DIR/diagnostic-derive.rs:615:53
+  --> $DIR/diagnostic-derive.rs:611:53
    |
 LL |     #[suggestion(no_crate_suggestion, code = "...", code = ",,,")]
    |                                                     ^^^^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:615:39
+  --> $DIR/diagnostic-derive.rs:611:39
    |
 LL |     #[suggestion(no_crate_suggestion, code = "...", code = ",,,")]
    |                                       ^^^^
 
 error: derive(Diagnostic): wrong types for suggestion
-  --> $DIR/diagnostic-derive.rs:624:24
+  --> $DIR/diagnostic-derive.rs:620:24
    |
 LL |     suggestion: (Span, usize),
    |                        ^^^^^
@@ -413,7 +379,7 @@ LL |     suggestion: (Span, usize),
    = help: `#[suggestion(...)]` on a tuple field must be applied to fields of type `(Span, Applicability)`
 
 error: derive(Diagnostic): wrong types for suggestion
-  --> $DIR/diagnostic-derive.rs:632:17
+  --> $DIR/diagnostic-derive.rs:628:17
    |
 LL |     suggestion: (Span,),
    |                 ^^^^^^^
@@ -421,13 +387,13 @@ LL |     suggestion: (Span,),
    = help: `#[suggestion(...)]` on a tuple field must be applied to fields of type `(Span, Applicability)`
 
 error: derive(Diagnostic): suggestion without `code = "..."`
-  --> $DIR/diagnostic-derive.rs:639:5
+  --> $DIR/diagnostic-derive.rs:635:5
    |
 LL |     #[suggestion(no_crate_suggestion)]
    |     ^
 
 error: derive(Diagnostic): `#[multipart_suggestion(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:646:1
+  --> $DIR/diagnostic-derive.rs:642:1
    |
 LL | #[multipart_suggestion(no_crate_suggestion)]
    | ^
@@ -435,7 +401,7 @@ LL | #[multipart_suggestion(no_crate_suggestion)]
    = help: consider creating a `Subdiagnostic` instead
 
 error: derive(Diagnostic): `#[multipart_suggestion(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:649:1
+  --> $DIR/diagnostic-derive.rs:645:1
    |
 LL | #[multipart_suggestion()]
    | ^
@@ -443,7 +409,7 @@ LL | #[multipart_suggestion()]
    = help: consider creating a `Subdiagnostic` instead
 
 error: derive(Diagnostic): `#[multipart_suggestion(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:653:5
+  --> $DIR/diagnostic-derive.rs:649:5
    |
 LL |     #[multipart_suggestion(no_crate_suggestion)]
    |     ^
@@ -451,7 +417,7 @@ LL |     #[multipart_suggestion(no_crate_suggestion)]
    = help: consider creating a `Subdiagnostic` instead
 
 error: derive(Diagnostic): `#[suggestion(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:661:1
+  --> $DIR/diagnostic-derive.rs:657:1
    |
 LL | #[suggestion(no_crate_suggestion, code = "...")]
    | ^
@@ -459,7 +425,7 @@ LL | #[suggestion(no_crate_suggestion, code = "...")]
    = help: `#[label]` and `#[suggestion]` can only be applied to fields
 
 error: derive(Diagnostic): `#[label]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:670:1
+  --> $DIR/diagnostic-derive.rs:666:1
    |
 LL | #[label]
    | ^
@@ -467,73 +433,73 @@ LL | #[label]
    = help: `#[label]` and `#[suggestion]` can only be applied to fields
 
 error: derive(Diagnostic): `#[subdiagnostic(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:704:5
+  --> $DIR/diagnostic-derive.rs:700:5
    |
 LL |     #[subdiagnostic(bad)]
    |     ^
 
 error: derive(Diagnostic): `#[subdiagnostic = ...]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:712:5
+  --> $DIR/diagnostic-derive.rs:708:5
    |
 LL |     #[subdiagnostic = "bad"]
    |     ^
 
 error: derive(Diagnostic): `#[subdiagnostic(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:720:5
+  --> $DIR/diagnostic-derive.rs:716:5
    |
 LL |     #[subdiagnostic(bad, bad)]
    |     ^
 
 error: derive(Diagnostic): `#[subdiagnostic(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:728:5
+  --> $DIR/diagnostic-derive.rs:724:5
    |
 LL |     #[subdiagnostic("bad")]
    |     ^
 
 error: derive(Diagnostic): `#[subdiagnostic(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:736:5
+  --> $DIR/diagnostic-derive.rs:732:5
    |
 LL |     #[subdiagnostic(eager)]
    |     ^
 
 error: derive(Diagnostic): `#[subdiagnostic(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:744:5
+  --> $DIR/diagnostic-derive.rs:740:5
    |
 LL |     #[subdiagnostic(eager)]
    |     ^
 
 error: derive(Diagnostic): `#[subdiagnostic(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:765:5
+  --> $DIR/diagnostic-derive.rs:761:5
    |
 LL |     #[subdiagnostic(eager)]
    |     ^
 
 error: derive(Diagnostic): expected at least one string literal for `code(...)`
-  --> $DIR/diagnostic-derive.rs:796:23
+  --> $DIR/diagnostic-derive.rs:792:23
    |
 LL |     #[suggestion(code())]
    |                       ^
 
 error: derive(Diagnostic): `code(...)` must contain only string literals
-  --> $DIR/diagnostic-derive.rs:804:23
+  --> $DIR/diagnostic-derive.rs:800:23
    |
 LL |     #[suggestion(code(foo))]
    |                       ^^^
 
 error: unexpected token, expected `)`
-  --> $DIR/diagnostic-derive.rs:804:23
+  --> $DIR/diagnostic-derive.rs:800:23
    |
 LL |     #[suggestion(code(foo))]
    |                       ^^^
 
 error: expected string literal
-  --> $DIR/diagnostic-derive.rs:813:25
+  --> $DIR/diagnostic-derive.rs:809:25
    |
 LL |     #[suggestion(code = 3)]
    |                         ^
 
 error: derive(Diagnostic): `#[suggestion(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:828:5
+  --> $DIR/diagnostic-derive.rs:824:5
    |
 LL |     #[suggestion(no_crate_suggestion, code = "")]
    |     ^
@@ -549,13 +515,13 @@ LL | #[nonsense(no_crate_example, code = E0123)]
    |   ^^^^^^^^
 
 error: cannot find attribute `nonsense` in this scope
-  --> $DIR/diagnostic-derive.rs:152:7
+  --> $DIR/diagnostic-derive.rs:148:7
    |
 LL |     #[nonsense]
    |       ^^^^^^^^
 
 error: cannot find attribute `error` in this scope
-  --> $DIR/diagnostic-derive.rs:585:3
+  --> $DIR/diagnostic-derive.rs:581:3
    |
 LL | #[error(no_crate_example, code = E0123)]
    |   ^^^^^
@@ -567,7 +533,7 @@ LL | struct ErrorAttribute {}
    |
 
 error: cannot find attribute `warn_` in this scope
-  --> $DIR/diagnostic-derive.rs:592:3
+  --> $DIR/diagnostic-derive.rs:588:3
    |
 LL | #[warn_(no_crate_example, code = E0123)]
    |   ^^^^^
@@ -579,7 +545,7 @@ LL + #[warn(no_crate_example, code = E0123)]
    |
 
 error: cannot find attribute `lint` in this scope
-  --> $DIR/diagnostic-derive.rs:599:3
+  --> $DIR/diagnostic-derive.rs:595:3
    |
 LL | #[lint(no_crate_example, code = E0123)]
    |   ^^^^
@@ -591,7 +557,7 @@ LL + #[link(no_crate_example, code = E0123)]
    |
 
 error: cannot find attribute `lint` in this scope
-  --> $DIR/diagnostic-derive.rs:606:3
+  --> $DIR/diagnostic-derive.rs:602:3
    |
 LL | #[lint(no_crate_example, code = E0123)]
    |   ^^^^
@@ -603,7 +569,7 @@ LL + #[link(no_crate_example, code = E0123)]
    |
 
 error: cannot find attribute `multipart_suggestion` in this scope
-  --> $DIR/diagnostic-derive.rs:646:3
+  --> $DIR/diagnostic-derive.rs:642:3
    |
 LL | #[multipart_suggestion(no_crate_suggestion)]
    |   ^^^^^^^^^^^^^^^^^^^^
@@ -615,7 +581,7 @@ LL | struct MultipartSuggestion {
    |
 
 error: cannot find attribute `multipart_suggestion` in this scope
-  --> $DIR/diagnostic-derive.rs:649:3
+  --> $DIR/diagnostic-derive.rs:645:3
    |
 LL | #[multipart_suggestion()]
    |   ^^^^^^^^^^^^^^^^^^^^
@@ -627,7 +593,7 @@ LL | struct MultipartSuggestion {
    |
 
 error: cannot find attribute `multipart_suggestion` in this scope
-  --> $DIR/diagnostic-derive.rs:653:7
+  --> $DIR/diagnostic-derive.rs:649:7
    |
 LL |     #[multipart_suggestion(no_crate_suggestion)]
    |       ^^^^^^^^^^^^^^^^^^^^
@@ -641,7 +607,7 @@ LL | #[diag(nonsense, code = E0123)]
    |        ^^^^^^^^ not found in `crate::fluent_generated`
 
 error[E0425]: cannot find value `__code_34` in this scope
-  --> $DIR/diagnostic-derive.rs:810:10
+  --> $DIR/diagnostic-derive.rs:806:10
    |
 LL | #[derive(Diagnostic)]
    |          ^^^^^^^^^^ not found in this scope
@@ -649,7 +615,7 @@ LL | #[derive(Diagnostic)]
    = note: this error originates in the derive macro `Diagnostic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Hello: IntoDiagArg` is not satisfied
-  --> $DIR/diagnostic-derive.rs:351:12
+  --> $DIR/diagnostic-derive.rs:347:12
    |
 LL | #[derive(Diagnostic)]
    |          ---------- required by a bound introduced by this call
@@ -670,7 +636,7 @@ note: required by a bound in `Diag::<'a, G>::arg`
    = note: in this macro invocation
    = note: this error originates in the macro `with_fn` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 85 previous errors
+error: aborting due to 81 previous errors
 
 Some errors have detailed explanations: E0277, E0425.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
@@ -192,7 +192,7 @@ error: derive(Diagnostic): invalid nested attribute
 LL |     #[suggestion(nonsense = "bar")]
    |                  ^^^^^^^^
    |
-   = help: only `no_span`, `style`, `code` and `applicability` are valid nested attributes
+   = help: only `style`, `code` and `applicability` are valid nested attributes
 
 error: derive(Diagnostic): suggestion without `code = "..."`
   --> $DIR/diagnostic-derive.rs:235:5
@@ -206,7 +206,7 @@ error: derive(Diagnostic): invalid nested attribute
 LL |     #[suggestion(msg = "bar")]
    |                  ^^^
    |
-   = help: only `no_span`, `style`, `code` and `applicability` are valid nested attributes
+   = help: only `style`, `code` and `applicability` are valid nested attributes
 
 error: derive(Diagnostic): suggestion without `code = "..."`
   --> $DIR/diagnostic-derive.rs:244:5
@@ -282,13 +282,13 @@ error: derive(Diagnostic): a diagnostic slug must be the first argument to the a
 LL |     #[label(no_crate_label, foo)]
    |                             ^^^
 
-error: derive(Diagnostic): only `no_span` is a valid nested attribute
+error: derive(Diagnostic): no nested attribute expected here
   --> $DIR/diagnostic-derive.rs:541:29
    |
 LL |     #[label(no_crate_label, foo = "...")]
    |                             ^^^
 
-error: derive(Diagnostic): only `no_span` is a valid nested attribute
+error: derive(Diagnostic): no nested attribute expected here
   --> $DIR/diagnostic-derive.rs:549:29
    |
 LL |     #[label(no_crate_label, foo("..."))]

--- a/tests/ui-fulldeps/session-diagnostic/subdiagnostic-derive.rs
+++ b/tests/ui-fulldeps/session-diagnostic/subdiagnostic-derive.rs
@@ -95,7 +95,7 @@ struct G {
 
 #[derive(Subdiagnostic)]
 #[label("...")]
-//~^ ERROR unexpected literal in nested attribute, expected ident
+//~^ ERROR expected identifier
 struct H {
     #[primary_span]
     span: Span,
@@ -775,7 +775,7 @@ struct SuggestionStyleInvalid1 {
 
 #[derive(Subdiagnostic)]
 #[suggestion(no_crate_example, code = "", style = 42)]
-//~^ ERROR expected `= "xxx"`
+//~^ ERROR expected string literal
 struct SuggestionStyleInvalid2 {
     #[primary_span]
     sub: Span,
@@ -791,8 +791,7 @@ struct SuggestionStyleInvalid3 {
 
 #[derive(Subdiagnostic)]
 #[suggestion(no_crate_example, code = "", style("foo"))]
-//~^ ERROR expected `= "xxx"`
-//~| ERROR expected `,`
+//~^ ERROR expected `=`
 struct SuggestionStyleInvalid4 {
     #[primary_span]
     sub: Span,

--- a/tests/ui-fulldeps/session-diagnostic/subdiagnostic-derive.rs
+++ b/tests/ui-fulldeps/session-diagnostic/subdiagnostic-derive.rs
@@ -85,7 +85,7 @@ struct F {
 
 #[derive(Subdiagnostic)]
 #[label(bug = "...")]
-//~^ ERROR only `no_span` is a valid nested attribute
+//~^ ERROR no nested attribute expected here
 //~| ERROR diagnostic slug must be first argument
 struct G {
     #[primary_span]
@@ -104,7 +104,7 @@ struct H {
 
 #[derive(Subdiagnostic)]
 #[label(slug = 4)]
-//~^ ERROR only `no_span` is a valid nested attribute
+//~^ ERROR no nested attribute expected here
 //~| ERROR diagnostic slug must be first argument
 struct J {
     #[primary_span]
@@ -114,7 +114,7 @@ struct J {
 
 #[derive(Subdiagnostic)]
 #[label(slug("..."))]
-//~^ ERROR only `no_span` is a valid nested attribute
+//~^ ERROR no nested attribute expected here
 //~| ERROR diagnostic slug must be first argument
 struct K {
     #[primary_span]
@@ -133,7 +133,7 @@ struct M {
 
 #[derive(Subdiagnostic)]
 #[label(no_crate_example, code = "...")]
-//~^ ERROR only `no_span` is a valid nested attribute
+//~^ ERROR no nested attribute expected here
 struct N {
     #[primary_span]
     span: Span,
@@ -142,7 +142,7 @@ struct N {
 
 #[derive(Subdiagnostic)]
 #[label(no_crate_example, applicability = "machine-applicable")]
-//~^ ERROR only `no_span` is a valid nested attribute
+//~^ ERROR no nested attribute expected here
 struct O {
     #[primary_span]
     span: Span,
@@ -214,7 +214,7 @@ enum T {
 enum U {
     #[label(code = "...")]
     //~^ ERROR diagnostic slug must be first argument of a `#[label(...)]` attribute
-    //~| ERROR only `no_span` is a valid nested attribute
+    //~| ERROR no nested attribute expected here
     A {
         #[primary_span]
         span: Span,

--- a/tests/ui-fulldeps/session-diagnostic/subdiagnostic-derive.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/subdiagnostic-derive.stderr
@@ -22,7 +22,7 @@ error: derive(Diagnostic): `#[label = ...]` is not a valid attribute
 LL | #[label = "..."]
    | ^
 
-error: derive(Diagnostic): only `no_span` is a valid nested attribute
+error: derive(Diagnostic): no nested attribute expected here
   --> $DIR/subdiagnostic-derive.rs:87:9
    |
 LL | #[label(bug = "...")]
@@ -40,7 +40,7 @@ error: expected identifier
 LL | #[label("...")]
    |         ^^^^^
 
-error: derive(Diagnostic): only `no_span` is a valid nested attribute
+error: derive(Diagnostic): no nested attribute expected here
   --> $DIR/subdiagnostic-derive.rs:106:9
    |
 LL | #[label(slug = 4)]
@@ -52,7 +52,7 @@ error: derive(Diagnostic): diagnostic slug must be first argument of a `#[label(
 LL | #[label(slug = 4)]
    | ^
 
-error: derive(Diagnostic): only `no_span` is a valid nested attribute
+error: derive(Diagnostic): no nested attribute expected here
   --> $DIR/subdiagnostic-derive.rs:116:9
    |
 LL | #[label(slug("..."))]
@@ -70,13 +70,13 @@ error: derive(Diagnostic): diagnostic slug must be first argument of a `#[label(
 LL | #[label()]
    | ^
 
-error: derive(Diagnostic): only `no_span` is a valid nested attribute
+error: derive(Diagnostic): no nested attribute expected here
   --> $DIR/subdiagnostic-derive.rs:135:27
    |
 LL | #[label(no_crate_example, code = "...")]
    |                           ^^^^
 
-error: derive(Diagnostic): only `no_span` is a valid nested attribute
+error: derive(Diagnostic): no nested attribute expected here
   --> $DIR/subdiagnostic-derive.rs:144:27
    |
 LL | #[label(no_crate_example, applicability = "machine-applicable")]
@@ -112,7 +112,7 @@ error: derive(Diagnostic): `#[bar(...)]` is not a valid attribute
 LL |     #[bar("...")]
    |     ^
 
-error: derive(Diagnostic): only `no_span` is a valid nested attribute
+error: derive(Diagnostic): no nested attribute expected here
   --> $DIR/subdiagnostic-derive.rs:215:13
    |
 LL |     #[label(code = "...")]
@@ -292,7 +292,7 @@ error: derive(Diagnostic): invalid nested attribute
 LL | #[multipart_suggestion(no_crate_example, code = "...", applicability = "machine-applicable")]
    |                                          ^^^^
    |
-   = help: only `no_span`, `style` and `applicability` are valid nested attributes
+   = help: only `style` and `applicability` are valid nested attributes
 
 error: derive(Diagnostic): multipart suggestion without any `#[suggestion_part(...)]` fields
   --> $DIR/subdiagnostic-derive.rs:530:1

--- a/tests/ui-fulldeps/session-diagnostic/subdiagnostic-derive.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/subdiagnostic-derive.stderr
@@ -34,7 +34,7 @@ error: derive(Diagnostic): diagnostic slug must be first argument of a `#[label(
 LL | #[label(bug = "...")]
    | ^
 
-error: unexpected literal in nested attribute, expected ident
+error: expected identifier
   --> $DIR/subdiagnostic-derive.rs:97:9
    |
 LL | #[label("...")]
@@ -175,10 +175,10 @@ LL | | }
    | |_^
 
 error: derive(Diagnostic): a diagnostic slug must be the first argument to the attribute
-  --> $DIR/subdiagnostic-derive.rs:317:44
+  --> $DIR/subdiagnostic-derive.rs:317:27
    |
 LL | #[label(no_crate_example, no_crate::example)]
-   |                                            ^
+   |                           ^^^^^^^^
 
 error: derive(Diagnostic): attribute specified multiple times
   --> $DIR/subdiagnostic-derive.rs:330:5
@@ -381,10 +381,10 @@ LL |     #[applicability]
    |     ^
 
 error: derive(Diagnostic): expected exactly one string literal for `code = ...`
-  --> $DIR/subdiagnostic-derive.rs:663:34
+  --> $DIR/subdiagnostic-derive.rs:663:28
    |
 LL |     #[suggestion_part(code("foo"))]
-   |                                  ^
+   |                            ^^^^^
 
 error: unexpected token, expected `)`
   --> $DIR/subdiagnostic-derive.rs:663:28
@@ -393,10 +393,10 @@ LL |     #[suggestion_part(code("foo"))]
    |                            ^^^^^
 
 error: derive(Diagnostic): expected exactly one string literal for `code = ...`
-  --> $DIR/subdiagnostic-derive.rs:673:41
+  --> $DIR/subdiagnostic-derive.rs:673:28
    |
 LL |     #[suggestion_part(code("foo", "bar"))]
-   |                                         ^
+   |                            ^^^^^
 
 error: unexpected token, expected `)`
   --> $DIR/subdiagnostic-derive.rs:673:28
@@ -405,10 +405,10 @@ LL |     #[suggestion_part(code("foo", "bar"))]
    |                            ^^^^^
 
 error: derive(Diagnostic): expected exactly one string literal for `code = ...`
-  --> $DIR/subdiagnostic-derive.rs:683:30
+  --> $DIR/subdiagnostic-derive.rs:683:28
    |
 LL |     #[suggestion_part(code(3))]
-   |                              ^
+   |                            ^
 
 error: unexpected token, expected `)`
   --> $DIR/subdiagnostic-derive.rs:683:28
@@ -417,10 +417,10 @@ LL |     #[suggestion_part(code(3))]
    |                            ^
 
 error: derive(Diagnostic): expected exactly one string literal for `code = ...`
-  --> $DIR/subdiagnostic-derive.rs:693:29
+  --> $DIR/subdiagnostic-derive.rs:693:28
    |
 LL |     #[suggestion_part(code())]
-   |                             ^
+   |                            ^
 
 error: expected string literal
   --> $DIR/subdiagnostic-derive.rs:702:30
@@ -464,32 +464,26 @@ LL | #[suggestion(no_crate_example, code = "", style = "foo")]
    |
    = help: valid styles are `normal`, `short`, `hidden`, `verbose` and `tool-only`
 
-error: derive(Diagnostic): expected `= "xxx"`
-  --> $DIR/subdiagnostic-derive.rs:777:49
+error: expected string literal
+  --> $DIR/subdiagnostic-derive.rs:777:51
    |
 LL | #[suggestion(no_crate_example, code = "", style = 42)]
-   |                                                 ^
+   |                                                   ^^
 
 error: derive(Diagnostic): a diagnostic slug must be the first argument to the attribute
-  --> $DIR/subdiagnostic-derive.rs:785:48
+  --> $DIR/subdiagnostic-derive.rs:785:43
    |
 LL | #[suggestion(no_crate_example, code = "", style)]
-   |                                                ^
+   |                                           ^^^^^
 
-error: derive(Diagnostic): expected `= "xxx"`
-  --> $DIR/subdiagnostic-derive.rs:793:48
-   |
-LL | #[suggestion(no_crate_example, code = "", style("foo"))]
-   |                                                ^
-
-error: expected `,`
+error: expected `=`
   --> $DIR/subdiagnostic-derive.rs:793:48
    |
 LL | #[suggestion(no_crate_example, code = "", style("foo"))]
    |                                                ^
 
 error: derive(Diagnostic): `#[primary_span]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive.rs:805:5
+  --> $DIR/subdiagnostic-derive.rs:804:5
    |
 LL |     #[primary_span]
    |     ^
@@ -498,7 +492,7 @@ LL |     #[primary_span]
    = help: to create a suggestion with multiple spans, use `#[multipart_suggestion]` instead
 
 error: derive(Diagnostic): suggestion without `#[primary_span]` field
-  --> $DIR/subdiagnostic-derive.rs:802:1
+  --> $DIR/subdiagnostic-derive.rs:801:1
    |
 LL | #[suggestion(no_crate_example, code = "")]
    | ^
@@ -557,5 +551,5 @@ error: cannot find attribute `bar` in this scope
 LL |     #[bar("...")]
    |       ^^^
 
-error: aborting due to 84 previous errors
+error: aborting due to 83 previous errors
 


### PR DESCRIPTION
This PR does a lot of refactoring on the implementation of `#[derive(Diagnostic)]`. It should have no observable effect other than error messages for incorrect usage of the attributes. In general, I think the error messages got better.

This PR can be reviewed commit by commit, each commit passes the tests.
- [Convert parse_nested_meta to parse_args_with for #[diagnostic]](https://github.com/rust-lang/rust/pull/151657/changes/9e61014a8a0bb1f1d7911511c303a7ae2a9c2a7d)
  Start parsing `#[diagnostic]` using `syn`'s `parse_args_with` function instead of `parse_nested_meta`. This improves error messages and prepares for the new syntax needed for https://github.com/rust-lang/rust/issues/151366 which cannot be parsed using `parse_args_with`.
- [Convert parse_nested_meta to parse_args_with for #[subdiagnostic]](https://github.com/rust-lang/rust/pull/151657/changes/5d21a21695d56b74ea249f269ee10195251008b7)
  Same as above but for `#[subdiagnostic]`
- [Remove unused no_span option](https://github.com/rust-lang/rust/pull/151657/changes/0bf3f5d51cb853884240792818d81e70daec6ab7)
  Removes the `no_span` option of `#[suggestion]`, which there were no tests for and which seems to have been unused. If needed again in the future, this can be re-added pretty easily, but I find that unlikely.
- [Remove HasFieldMap trait in favour of passing FieldMap directly](https://github.com/rust-lang/rust/pull/151657/changes/2e8347abf4147d2bffe4d7989a21b17ae04cdb57)
  Removes the `HasFieldMap` trait, because I don't really see the point of having a trait "has a field map" if we can just pass the fieldmap itself instead.

r? @Kivooeo 
(Thanks for reviewing my PRs so far :3)