### PR TITLE
Bump submodule `backtrace`

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -274,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 dependencies = [
  "rustc-std-workspace-core",
 ]

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -26,7 +26,7 @@ hashbrown = { version = "0.16.1", default-features = false, features = [
 std_detect = { path = "../std_detect", public = true }
 
 # Dependencies of the `backtrace` crate
-rustc-demangle = { version = "0.1.24", features = ['rustc-dep-of-std'] }
+rustc-demangle = { version = "0.1.27", features = ['rustc-dep-of-std'] }
 
 [target.'cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))'.dependencies]
 miniz_oxide = { version = "0.8.0", optional = true, default-features = false }


### PR DESCRIPTION
Updates git submodule `backtrace` mainly to include the changes from PR https://github.com/rust-lang/backtrace-rs/pull/746. Note that these changes haven't been released yet, although that shouldn't really matter or do you see it as a requirement?

Locally I've confirmed that it fixes rust-lang/rust#151548. I don't think it warrants a regression test (esp. since backtrace tests are rather fragile aren't they?).

I'm actually not sure if only bumping the version of `rustc-demangle` in `library/std/Cargo.toml` for `backtrace` would've sufficed 😅. I went to great lengths updating `backtrace` since I had to face "package version conflicts" and similar back in PR rust-lang/rust#150843 when I pointed `rustc-demangle` and `backtrace` to my personal forks. In hindsight though I guess these errors occurred for other reasons.

r? workingjubilee (rust-lang/backtrace-rs#746) or reassign