### PR TITLE
Bump `std`'s `backtrace`'s `rustc-demangle`

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -274,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 dependencies = [
  "rustc-std-workspace-core",
 ]

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -26,7 +26,7 @@ hashbrown = { version = "0.16.1", default-features = false, features = [
 std_detect = { path = "../std_detect", public = true }
 
 # Dependencies of the `backtrace` crate
-rustc-demangle = { version = "0.1.24", features = ['rustc-dep-of-std'] }
+rustc-demangle = { version = "0.1.27", features = ['rustc-dep-of-std'] }
 
 [target.'cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))'.dependencies]
 miniz_oxide = { version = "0.8.0", optional = true, default-features = false }


### PR DESCRIPTION
Alternative to https://github.com/rust-lang/rust/pull/151659.

Fixes rust-lang/rust#151548.