### PR TITLE
Suggest changing `iter`/`into_iter` when the other was meant

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -270,6 +270,7 @@ symbols! {
         Into,
         IntoFuture,
         IntoIterator,
+        IntoIteratorItem,
         IoBufRead,
         IoLines,
         IoRead,

--- a/library/core/src/iter/traits/collect.rs
+++ b/library/core/src/iter/traits/collect.rs
@@ -281,6 +281,7 @@ pub trait FromIterator<A>: Sized {
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait IntoIterator {
     /// The type of the elements being iterated over.
+    #[rustc_diagnostic_item = "IntoIteratorItem"]
     #[stable(feature = "rust1", since = "1.0.0")]
     type Item;
 

--- a/tests/ui/iterators/into_iter-when-iter-was-intended.fixed
+++ b/tests/ui/iterators/into_iter-when-iter-was-intended.fixed
@@ -1,0 +1,10 @@
+//@ run-rustfix
+//@ edition:2021
+// Suggest using the right `IntoIterator` method. #68095
+fn main() {
+    let _a = [0, 1, 2].iter().chain([3, 4, 5].iter()); //~ ERROR E0271
+    let _b = [0, 1, 2].into_iter().chain([3, 4, 5].into_iter()); //~ ERROR E0271
+    // These don't have appropriate suggestions yet.
+    // let c = [0, 1, 2].iter().chain([3, 4, 5]);
+    // let d = [0, 1, 2].iter().chain(vec![3, 4, 5]);
+}

--- a/tests/ui/iterators/into_iter-when-iter-was-intended.rs
+++ b/tests/ui/iterators/into_iter-when-iter-was-intended.rs
@@ -1,0 +1,10 @@
+//@ run-rustfix
+//@ edition:2021
+// Suggest using the right `IntoIterator` method. #68095
+fn main() {
+    let _a = [0, 1, 2].iter().chain([3, 4, 5].into_iter()); //~ ERROR E0271
+    let _b = [0, 1, 2].into_iter().chain([3, 4, 5].iter()); //~ ERROR E0271
+    // These don't have appropriate suggestions yet.
+    // let c = [0, 1, 2].iter().chain([3, 4, 5]);
+    // let d = [0, 1, 2].iter().chain(vec![3, 4, 5]);
+}

--- a/tests/ui/iterators/into_iter-when-iter-was-intended.stderr
+++ b/tests/ui/iterators/into_iter-when-iter-was-intended.stderr
@@ -1,0 +1,48 @@
+error[E0271]: type mismatch resolving `<IntoIter<{integer}, 3> as IntoIterator>::Item == &{integer}`
+  --> $DIR/into_iter-when-iter-was-intended.rs:5:37
+   |
+LL |     let _a = [0, 1, 2].iter().chain([3, 4, 5].into_iter());
+   |                               ----- ^^^^^^^^^^^^^^^^^^^^^ expected `&{integer}`, found integer
+   |                               |
+   |                               required by a bound introduced by this call
+   |
+note: the method call chain might not have had the expected associated types
+  --> $DIR/into_iter-when-iter-was-intended.rs:5:47
+   |
+LL |     let _a = [0, 1, 2].iter().chain([3, 4, 5].into_iter());
+   |                                     --------- ^^^^^^^^^^^ `IntoIterator::Item` is `{integer}` here
+   |                                     |
+   |                                     this expression has type `[{integer}; 3]`
+note: required by a bound in `std::iter::Iterator::chain`
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+help: consider not consuming the `[{integer}; 3]` to construct the `Iterator`
+   |
+LL -     let _a = [0, 1, 2].iter().chain([3, 4, 5].into_iter());
+LL +     let _a = [0, 1, 2].iter().chain([3, 4, 5].iter());
+   |
+
+error[E0271]: type mismatch resolving `<Iter<'_, {integer}> as IntoIterator>::Item == {integer}`
+  --> $DIR/into_iter-when-iter-was-intended.rs:6:42
+   |
+LL |     let _b = [0, 1, 2].into_iter().chain([3, 4, 5].iter());
+   |                                    ----- ^^^^^^^^^^^^^^^^ expected integer, found `&{integer}`
+   |                                    |
+   |                                    required by a bound introduced by this call
+   |
+note: the method call chain might not have had the expected associated types
+  --> $DIR/into_iter-when-iter-was-intended.rs:6:52
+   |
+LL |     let _b = [0, 1, 2].into_iter().chain([3, 4, 5].iter());
+   |                                          --------- ^^^^^^ `IntoIterator::Item` is `&{integer}` here
+   |                                          |
+   |                                          this expression has type `[{integer}; 3]`
+note: required by a bound in `std::iter::Iterator::chain`
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+help: consider consuming the `&[{integer}]` to construct the `Iterator`
+   |
+LL |     let _b = [0, 1, 2].into_iter().chain([3, 4, 5].into_iter());
+   |                                                    +++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0271`.


### PR DESCRIPTION
When encountering a call to `iter` that should have been `into_iter` and vice-versa, provide a structured suggestion:

```
error[E0271]: type mismatch resolving `<IntoIter<{integer}, 3> as IntoIterator>::Item == &{integer}`
  --> $DIR/into_iter-when-iter-was-intended.rs:5:37
   |
LL |     let _a = [0, 1, 2].iter().chain([3, 4, 5].into_iter());
   |                               ----- ^^^^^^^^^^^^^^^^^^^^^ expected `&{integer}`, found integer
   |                               |
   |                               required by a bound introduced by this call
   |
note: the method call chain might not have had the expected associated types
  --> $DIR/into_iter-when-iter-was-intended.rs:5:47
   |
LL |     let _a = [0, 1, 2].iter().chain([3, 4, 5].into_iter());
   |                                     --------- ^^^^^^^^^^^ `IntoIterator::Item` is `{integer}` here
   |                                     |
   |                                     this expression has type `[{integer}; 3]`
note: required by a bound in `std::iter::Iterator::chain`
  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
help: consider not consuming the `[{integer}, 3]` to construct the `Iterator`
   |
LL -     let _a = [0, 1, 2].iter().chain([3, 4, 5].into_iter());
LL +     let _a = [0, 1, 2].iter().chain([3, 4, 5].iter());
   |
```

Finish addressing the original case in rust-lang/rust#68095. Only the case of chaining a `Vec` or `[]` is left unhandled.