### PR TITLE
Fix contrast ratio for `Since` element in rustdoc dark theme

### DIFF
--- a/src/librustdoc/html/static/css/noscript.css
+++ b/src/librustdoc/html/static/css/noscript.css
@@ -163,7 +163,7 @@ nav.sub {
 		--headings-border-bottom-color: #d2d2d2;
 		--border-color: #e0e0e0;
 		--button-background-color: #f0f0f0;
-		--right-side-color: grey;
+		--right-side-color: #d0d0d0;
 		--code-attribute-color: #999;
 		--toggles-color: #999;
 		--toggle-filter: invert(100%);

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -3286,7 +3286,7 @@ by default.
 	--headings-border-bottom-color: #d2d2d2;
 	--border-color: #e0e0e0;
 	--button-background-color: #f0f0f0;
-	--right-side-color: grey;
+	--right-side-color: #d0d0d0;
 	--code-attribute-color: #999;
 	--toggles-color: #999;
 	--toggle-filter: invert(100%);

--- a/tests/rustdoc-gui/headings.goml
+++ b/tests/rustdoc-gui/headings.goml
@@ -221,14 +221,14 @@ call-function: (
 
 define-function: (
     "check-since-color",
-    [theme],
+    [theme, color],
     block {
         call-function: ("switch-theme", {"theme": |theme|})
-        assert-css: (".since", {"color": "#808080"}, ALL)
+        assert-css: (".since", {"color": |color|}, ALL)
     },
 )
 
 go-to: "file://" + |DOC_PATH| + "/staged_api/struct.Foo.html"
-call-function: ("check-since-color", {"theme": "ayu"})
-call-function: ("check-since-color", {"theme": "dark"})
-call-function: ("check-since-color", {"theme": "light"})
+call-function: ("check-since-color", {"theme": "ayu", "color": "#808080"})
+call-function: ("check-since-color", {"theme": "dark", "color": "#d0d0d0"})
+call-function: ("check-since-color", {"theme": "light", "color": "#808080"})


### PR DESCRIPTION
Changed `--right-side-color` from `#808080` to `#ababab` in the dark theme.

<img width="742" height="784" alt="Screenshot 2026-01-25 at 8 04 29 PM" src="https://github.com/user-attachments/assets/38c5f0b9-2034-429f-87db-8a0ed8209b5d" />

Verified visually in dark theme, it's now more readable:

<img width="174" height="96" alt="Screenshot 2026-01-25 at 8 41 02 PM" src="https://github.com/user-attachments/assets/d0c30409-4374-48c4-ae9c-a0aec48e8957" />

Part of https://github.com/rust-lang/rust/issues/59845
Fixes rust-lang/rust#151422 