### PR TITLE
Do not return incorrectly constrained opaques in `method_autoderef_steps`

### DIFF
--- a/compiler/rustc_infer/src/infer/canonical/query_response.rs
+++ b/compiler/rustc_infer/src/infer/canonical/query_response.rs
@@ -24,7 +24,8 @@ use crate::infer::canonical::{
 };
 use crate::infer::region_constraints::RegionConstraintData;
 use crate::infer::{
-    DefineOpaqueTypes, InferCtxt, InferOk, InferResult, SubregionOrigin, TypeOutlivesConstraint,
+    DefineOpaqueTypes, InferCtxt, InferOk, InferResult, OpaqueTypeStorageEntries, SubregionOrigin,
+    TypeOutlivesConstraint,
 };
 use crate::traits::query::NoSolution;
 use crate::traits::{ObligationCause, PredicateObligations, ScrubbedTraitError, TraitEngine};
@@ -81,6 +82,7 @@ impl<'tcx> InferCtxt<'tcx> {
         &self,
         inference_vars: CanonicalVarValues<'tcx>,
         answer: T,
+        prev_entries: OpaqueTypeStorageEntries,
     ) -> Canonical<'tcx, QueryResponse<'tcx, T>>
     where
         T: Debug + TypeFoldable<TyCtxt<'tcx>>,
@@ -96,7 +98,7 @@ impl<'tcx> InferCtxt<'tcx> {
             self.inner
                 .borrow_mut()
                 .opaque_type_storage
-                .iter_opaque_types()
+                .opaque_types_added_since(prev_entries)
                 .map(|(k, v)| (k, v.ty))
                 .collect()
         } else {

--- a/tests/ui/traits/next-solver/opaques/method_autoderef_constraints.rs
+++ b/tests/ui/traits/next-solver/opaques/method_autoderef_constraints.rs
@@ -1,0 +1,38 @@
+//@ compile-flags: -Znext-solver
+
+// Regression test for trait-system-refactor-initiative/issues/263
+// Previously `method_auto_deref_steps` would also return opaque
+// types which have already been defined in the parent context.
+//
+// We then handled these opaque types by emitting `AliasRelate` goals
+// when instantiating its result, assuming that operation to be infallible.
+// By returning opaque type constraints from the parent context and
+// constraining the hidden type without reproving the item bounds of
+// the opaque, this ended up causing ICE.
+
+use std::ops::Deref;
+trait Trait {}
+struct Inv<T>(*mut T);
+impl Trait for i32 {}
+impl Deref for Inv<u32> {
+    type Target = u32;
+    fn deref(&self) -> &Self::Target {
+        todo!()
+    }
+}
+
+fn mk<T>() -> T { todo!() }
+fn foo() -> Inv<impl Trait> {
+    //~^ ERROR: the trait bound `u32: Trait` is not satisfied [E0277]
+    let mut x: Inv<_> = mk();
+    if false {
+        return x;
+        //~^ ERROR: the trait bound `u32: Trait` is not satisfied [E0277]
+    }
+
+    x.count_ones();
+    x
+    //~^ ERROR: mismatched types [E0308]
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/opaques/method_autoderef_constraints.stderr
+++ b/tests/ui/traits/next-solver/opaques/method_autoderef_constraints.stderr
@@ -1,0 +1,43 @@
+error[E0277]: the trait bound `u32: Trait` is not satisfied
+  --> $DIR/method_autoderef_constraints.rs:29:16
+   |
+LL |         return x;
+   |                ^ the trait `Trait` is not implemented for `u32`
+   |
+help: the trait `Trait` is implemented for `i32`
+  --> $DIR/method_autoderef_constraints.rs:16:1
+   |
+LL | impl Trait for i32 {}
+   | ^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/method_autoderef_constraints.rs:34:5
+   |
+LL | fn foo() -> Inv<impl Trait> {
+   |             ---------------
+   |             |   |
+   |             |   the expected opaque type
+   |             expected `Inv<impl Trait>` because of return type
+...
+LL |     x
+   |     ^ types differ
+   |
+   = note: expected struct `Inv<impl Trait>`
+              found struct `Inv<u32>`
+
+error[E0277]: the trait bound `u32: Trait` is not satisfied
+  --> $DIR/method_autoderef_constraints.rs:25:1
+   |
+LL | fn foo() -> Inv<impl Trait> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `u32`
+   |
+help: the trait `Trait` is implemented for `i32`
+  --> $DIR/method_autoderef_constraints.rs:16:1
+   |
+LL | impl Trait for i32 {}
+   | ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0277, E0308.
+For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Fixes https://github.com/rust-lang/trait-system-refactor-initiative/issues/263

r? @lcnr 
