### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_infer/src/infer/canonical/query_response.rs
+++ b/compiler/rustc_infer/src/infer/canonical/query_response.rs
@@ -24,7 +24,8 @@ use crate::infer::canonical::{
 };
 use crate::infer::region_constraints::RegionConstraintData;
 use crate::infer::{
-    DefineOpaqueTypes, InferCtxt, InferOk, InferResult, SubregionOrigin, TypeOutlivesConstraint,
+    DefineOpaqueTypes, InferCtxt, InferOk, InferResult, OpaqueTypeStorageEntries, SubregionOrigin,
+    TypeOutlivesConstraint,
 };
 use crate::traits::query::NoSolution;
 use crate::traits::{ObligationCause, PredicateObligations, ScrubbedTraitError, TraitEngine};
@@ -81,6 +82,7 @@ impl<'tcx> InferCtxt<'tcx> {
         &self,
         inference_vars: CanonicalVarValues<'tcx>,
         answer: T,
+        prev_entries: OpaqueTypeStorageEntries,
     ) -> Canonical<'tcx, QueryResponse<'tcx, T>>
     where
         T: Debug + TypeFoldable<TyCtxt<'tcx>>,
@@ -96,7 +98,7 @@ impl<'tcx> InferCtxt<'tcx> {
             self.inner
                 .borrow_mut()
                 .opaque_type_storage
-                .iter_opaque_types()
+                .opaque_types_added_since(prev_entries)
                 .map(|(k, v)| (k, v.ty))
                 .collect()
         } else {

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -35,6 +35,8 @@ use rustc_span::def_id::LOCAL_CRATE;
 
 use crate::QueryConfigRestored;
 
+/// Implements [`QueryContext`] for use by [`rustc_query_system`], since that
+/// crate does not have direct access to [`TyCtxt`].
 #[derive(Copy, Clone)]
 pub struct QueryCtxt<'tcx> {
     pub tcx: TyCtxt<'tcx>,
@@ -44,15 +46,6 @@ impl<'tcx> QueryCtxt<'tcx> {
     #[inline]
     pub fn new(tcx: TyCtxt<'tcx>) -> Self {
         QueryCtxt { tcx }
-    }
-}
-
-impl<'tcx> std::ops::Deref for QueryCtxt<'tcx> {
-    type Target = TyCtxt<'tcx>;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        &self.tcx
     }
 }
 
@@ -69,14 +62,16 @@ impl<'tcx> HasDepContext for QueryCtxt<'tcx> {
 impl QueryContext for QueryCtxt<'_> {
     #[inline]
     fn jobserver_proxy(&self) -> &Proxy {
-        &*self.jobserver_proxy
+        &self.tcx.jobserver_proxy
     }
 
     #[inline]
     fn next_job_id(self) -> QueryJobId {
         QueryJobId(
-            NonZero::new(self.query_system.jobs.fetch_add(1, std::sync::atomic::Ordering::Relaxed))
-                .unwrap(),
+            NonZero::new(
+                self.tcx.query_system.jobs.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+            )
+            .unwrap(),
         )
     }
 
@@ -113,7 +108,8 @@ impl QueryContext for QueryCtxt<'_> {
         self,
         prev_dep_node_index: SerializedDepNodeIndex,
     ) -> Option<QuerySideEffect> {
-        self.query_system
+        self.tcx
+            .query_system
             .on_disk_cache
             .as_ref()
             .and_then(|c| c.load_side_effect(self.tcx, prev_dep_node_index))
@@ -122,7 +118,7 @@ impl QueryContext for QueryCtxt<'_> {
     #[inline(never)]
     #[cold]
     fn store_side_effect(self, dep_node_index: DepNodeIndex, side_effect: QuerySideEffect) {
-        if let Some(c) = self.query_system.on_disk_cache.as_ref() {
+        if let Some(c) = self.tcx.query_system.on_disk_cache.as_ref() {
             c.store_side_effect(dep_node_index, side_effect)
         }
     }
@@ -140,7 +136,9 @@ impl QueryContext for QueryCtxt<'_> {
         // as `self`, so we use `with_related_context` to relate the 'tcx lifetimes
         // when accessing the `ImplicitCtxt`.
         tls::with_related_context(self.tcx, move |current_icx| {
-            if depth_limit && !self.recursion_limit().value_within_limit(current_icx.query_depth) {
+            if depth_limit
+                && !self.tcx.recursion_limit().value_within_limit(current_icx.query_depth)
+            {
                 self.depth_limit_error(token);
             }
 
@@ -161,16 +159,16 @@ impl QueryContext for QueryCtxt<'_> {
         let query_map = self.collect_active_jobs(true).expect("failed to collect active queries");
         let (info, depth) = job.find_dep_kind_root(query_map);
 
-        let suggested_limit = match self.recursion_limit() {
+        let suggested_limit = match self.tcx.recursion_limit() {
             Limit(0) => Limit(2),
             limit => limit * 2,
         };
 
-        self.sess.dcx().emit_fatal(QueryOverflow {
+        self.tcx.sess.dcx().emit_fatal(QueryOverflow {
             span: info.job.span,
             note: QueryOverflowNote { desc: info.query.description, depth },
             suggested_limit,
-            crate_name: self.crate_name(LOCAL_CRATE),
+            crate_name: self.tcx.crate_name(LOCAL_CRATE),
         });
     }
 }
@@ -367,7 +365,7 @@ pub(crate) fn encode_query_results<'a, 'tcx, Q>(
     Q: super::QueryConfigRestored<'tcx>,
     Q::RestoredValue: Encodable<CacheEncoder<'a, 'tcx>>,
 {
-    let _timer = qcx.profiler().generic_activity_with_arg("encode_query_results_for", query.name());
+    let _timer = qcx.tcx.prof.generic_activity_with_arg("encode_query_results_for", query.name());
 
     assert!(query.query_state(qcx).all_inactive());
     let cache = query.query_cache(qcx);
@@ -389,8 +387,7 @@ pub(crate) fn query_key_hash_verify<'tcx>(
     query: impl QueryConfig<QueryCtxt<'tcx>>,
     qcx: QueryCtxt<'tcx>,
 ) {
-    let _timer =
-        qcx.profiler().generic_activity_with_arg("query_key_hash_verify_for", query.name());
+    let _timer = qcx.tcx.prof.generic_activity_with_arg("query_key_hash_verify_for", query.name());
 
     let mut map = UnordMap::default();
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -270,6 +270,7 @@ symbols! {
         Into,
         IntoFuture,
         IntoIterator,
+        IntoIteratorItem,
         IoBufRead,
         IoLines,
         IoRead,

--- a/library/core/src/iter/traits/collect.rs
+++ b/library/core/src/iter/traits/collect.rs
@@ -281,6 +281,7 @@ pub trait FromIterator<A>: Sized {
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait IntoIterator {
     /// The type of the elements being iterated over.
+    #[rustc_diagnostic_item = "IntoIteratorItem"]
     #[stable(feature = "rust1", since = "1.0.0")]
     type Item;
 

--- a/tests/ui/iterators/into_iter-when-iter-was-intended.fixed
+++ b/tests/ui/iterators/into_iter-when-iter-was-intended.fixed
@@ -1,0 +1,10 @@
+//@ run-rustfix
+//@ edition:2021
+// Suggest using the right `IntoIterator` method. #68095
+fn main() {
+    let _a = [0, 1, 2].iter().chain([3, 4, 5].iter()); //~ ERROR E0271
+    let _b = [0, 1, 2].into_iter().chain([3, 4, 5].into_iter()); //~ ERROR E0271
+    // These don't have appropriate suggestions yet.
+    // let c = [0, 1, 2].iter().chain([3, 4, 5]);
+    // let d = [0, 1, 2].iter().chain(vec![3, 4, 5]);
+}

--- a/tests/ui/iterators/into_iter-when-iter-was-intended.rs
+++ b/tests/ui/iterators/into_iter-when-iter-was-intended.rs
@@ -1,0 +1,10 @@
+//@ run-rustfix
+//@ edition:2021
+// Suggest using the right `IntoIterator` method. #68095
+fn main() {
+    let _a = [0, 1, 2].iter().chain([3, 4, 5].into_iter()); //~ ERROR E0271
+    let _b = [0, 1, 2].into_iter().chain([3, 4, 5].iter()); //~ ERROR E0271
+    // These don't have appropriate suggestions yet.
+    // let c = [0, 1, 2].iter().chain([3, 4, 5]);
+    // let d = [0, 1, 2].iter().chain(vec![3, 4, 5]);
+}

--- a/tests/ui/iterators/into_iter-when-iter-was-intended.stderr
+++ b/tests/ui/iterators/into_iter-when-iter-was-intended.stderr
@@ -1,0 +1,48 @@
+error[E0271]: type mismatch resolving `<IntoIter<{integer}, 3> as IntoIterator>::Item == &{integer}`
+  --> $DIR/into_iter-when-iter-was-intended.rs:5:37
+   |
+LL |     let _a = [0, 1, 2].iter().chain([3, 4, 5].into_iter());
+   |                               ----- ^^^^^^^^^^^^^^^^^^^^^ expected `&{integer}`, found integer
+   |                               |
+   |                               required by a bound introduced by this call
+   |
+note: the method call chain might not have had the expected associated types
+  --> $DIR/into_iter-when-iter-was-intended.rs:5:47
+   |
+LL |     let _a = [0, 1, 2].iter().chain([3, 4, 5].into_iter());
+   |                                     --------- ^^^^^^^^^^^ `IntoIterator::Item` is `{integer}` here
+   |                                     |
+   |                                     this expression has type `[{integer}; 3]`
+note: required by a bound in `std::iter::Iterator::chain`
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+help: consider not consuming the `[{integer}; 3]` to construct the `Iterator`
+   |
+LL -     let _a = [0, 1, 2].iter().chain([3, 4, 5].into_iter());
+LL +     let _a = [0, 1, 2].iter().chain([3, 4, 5].iter());
+   |
+
+error[E0271]: type mismatch resolving `<Iter<'_, {integer}> as IntoIterator>::Item == {integer}`
+  --> $DIR/into_iter-when-iter-was-intended.rs:6:42
+   |
+LL |     let _b = [0, 1, 2].into_iter().chain([3, 4, 5].iter());
+   |                                    ----- ^^^^^^^^^^^^^^^^ expected integer, found `&{integer}`
+   |                                    |
+   |                                    required by a bound introduced by this call
+   |
+note: the method call chain might not have had the expected associated types
+  --> $DIR/into_iter-when-iter-was-intended.rs:6:52
+   |
+LL |     let _b = [0, 1, 2].into_iter().chain([3, 4, 5].iter());
+   |                                          --------- ^^^^^^ `IntoIterator::Item` is `&{integer}` here
+   |                                          |
+   |                                          this expression has type `[{integer}; 3]`
+note: required by a bound in `std::iter::Iterator::chain`
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+help: consider consuming the `&[{integer}]` to construct the `Iterator`
+   |
+LL |     let _b = [0, 1, 2].into_iter().chain([3, 4, 5].into_iter());
+   |                                                    +++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0271`.

--- a/tests/ui/traits/next-solver/opaques/method_autoderef_constraints.rs
+++ b/tests/ui/traits/next-solver/opaques/method_autoderef_constraints.rs
@@ -1,0 +1,38 @@
+//@ compile-flags: -Znext-solver
+
+// Regression test for trait-system-refactor-initiative/issues/263
+// Previously `method_auto_deref_steps` would also return opaque
+// types which have already been defined in the parent context.
+//
+// We then handled these opaque types by emitting `AliasRelate` goals
+// when instantiating its result, assuming that operation to be infallible.
+// By returning opaque type constraints from the parent context and
+// constraining the hidden type without reproving the item bounds of
+// the opaque, this ended up causing ICE.
+
+use std::ops::Deref;
+trait Trait {}
+struct Inv<T>(*mut T);
+impl Trait for i32 {}
+impl Deref for Inv<u32> {
+    type Target = u32;
+    fn deref(&self) -> &Self::Target {
+        todo!()
+    }
+}
+
+fn mk<T>() -> T { todo!() }
+fn foo() -> Inv<impl Trait> {
+    //~^ ERROR: the trait bound `u32: Trait` is not satisfied [E0277]
+    let mut x: Inv<_> = mk();
+    if false {
+        return x;
+        //~^ ERROR: the trait bound `u32: Trait` is not satisfied [E0277]
+    }
+
+    x.count_ones();
+    x
+    //~^ ERROR: mismatched types [E0308]
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/opaques/method_autoderef_constraints.stderr
+++ b/tests/ui/traits/next-solver/opaques/method_autoderef_constraints.stderr
@@ -1,0 +1,43 @@
+error[E0277]: the trait bound `u32: Trait` is not satisfied
+  --> $DIR/method_autoderef_constraints.rs:29:16
+   |
+LL |         return x;
+   |                ^ the trait `Trait` is not implemented for `u32`
+   |
+help: the trait `Trait` is implemented for `i32`
+  --> $DIR/method_autoderef_constraints.rs:16:1
+   |
+LL | impl Trait for i32 {}
+   | ^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/method_autoderef_constraints.rs:34:5
+   |
+LL | fn foo() -> Inv<impl Trait> {
+   |             ---------------
+   |             |   |
+   |             |   the expected opaque type
+   |             expected `Inv<impl Trait>` because of return type
+...
+LL |     x
+   |     ^ types differ
+   |
+   = note: expected struct `Inv<impl Trait>`
+              found struct `Inv<u32>`
+
+error[E0277]: the trait bound `u32: Trait` is not satisfied
+  --> $DIR/method_autoderef_constraints.rs:25:1
+   |
+LL | fn foo() -> Inv<impl Trait> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `u32`
+   |
+help: the trait `Trait` is implemented for `i32`
+  --> $DIR/method_autoderef_constraints.rs:16:1
+   |
+LL | impl Trait for i32 {}
+   | ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0277, E0308.
+For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#151676 (Do not return incorrectly constrained opaques in `method_autoderef_steps`)
 - rust-lang/rust#151626 (Remove `Deref<Target = TyCtxt>` from `QueryCtxt`)
 - rust-lang/rust#151661 (Suggest changing `iter`/`into_iter` when the other was meant)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=151676,151626,151661)
<!-- homu-ignore:end -->

