### PR TITLE
Assume the effects of RUSTC_BOOTSTRAP in sysroot

### DIFF
--- a/compiler/rustc_feature/src/tests.rs
+++ b/compiler/rustc_feature/src/tests.rs
@@ -4,7 +4,7 @@ use super::UnstableFeatures;
 fn rustc_bootstrap_parsing() {
     let is_bootstrap = |env: &str, krate: Option<&str>| {
         matches!(
-            UnstableFeatures::from_environment_value(krate, Ok(env.to_string())),
+            UnstableFeatures::from_environment_value(krate, Ok(env.to_string()), false),
             UnstableFeatures::Cheat
         )
     };
@@ -23,10 +23,22 @@ fn rustc_bootstrap_parsing() {
     // `RUSTC_BOOTSTRAP=0` is not recognized.
     assert!(!is_bootstrap("0", None));
 
+    let is_bootstrap = |env: &str, krate: Option<&str>, input_in_sysroot: bool| {
+        matches!(
+            UnstableFeatures::from_environment_value(krate, Ok(env.to_string()), input_in_sysroot),
+            UnstableFeatures::Cheat
+        )
+    };
+    // Whether RUSTC_BOOTSTRAP is set or unset, when input_in_sysroot is_bootstrap should be true
+    assert!(is_bootstrap("1", None, true));
+    assert!(is_bootstrap("0", None, true));
+    // Even when input_in_sysroot, disabling RUSTC_BOOTSTRAP is honoured.
+    assert!(!is_bootstrap("-1", None, true));
+
     // `RUSTC_BOOTSTRAP=-1` is force-stable, no unstable features allowed.
     let is_force_stable = |krate: Option<&str>| {
         matches!(
-            UnstableFeatures::from_environment_value(krate, Ok("-1".to_string())),
+            UnstableFeatures::from_environment_value(krate, Ok("-1".to_string()), false),
             UnstableFeatures::Disallow
         )
     };

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -9,7 +9,7 @@ use std::collections::btree_map::{
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsStr;
 use std::hash::Hash;
-use std::path::{Path, PathBuf};
+use std::path::{Path, PathBuf, absolute};
 use std::str::{self, FromStr};
 use std::sync::LazyLock;
 use std::{cmp, fmt, fs, iter};
@@ -2434,7 +2434,10 @@ pub fn build_session_options(early_dcx: &mut EarlyDiagCtxt, matches: &getopts::M
     let edition = parse_crate_edition(early_dcx, matches);
 
     let crate_name = matches.opt_str("crate-name");
-    let unstable_features = UnstableFeatures::from_environment(crate_name.as_deref());
+    let unstable_features = UnstableFeatures::from_environment_check_in_sysroot(
+        crate_name.as_deref(),
+        input_in_sysroot(matches),
+    );
     let JsonConfig {
         json_rendered,
         json_color,
@@ -2863,10 +2866,26 @@ pub fn parse_crate_types_from_list(list_list: Vec<String>) -> Result<Vec<CrateTy
     Ok(crate_types)
 }
 
+pub fn input_in_sysroot(matches: &getopts::Matches) -> bool {
+    let sysroot = Sysroot::new(matches.opt_str("sysroot").map(PathBuf::from));
+    // Input parsing derived from the make_input function. If there are multiple files, or stdin input, then
+    // input_in_sysroot is either irrelevant, or false.
+    let Some((Ok(input), Ok(sysroot))) = matches
+        .free
+        .as_slice()
+        .first()
+        .map(|path| (absolute(Path::new(path)), absolute(sysroot.path())))
+    else {
+        return false;
+    };
+
+    input.starts_with(sysroot)
+}
+
 pub mod nightly_options {
     use rustc_feature::UnstableFeatures;
 
-    use super::{OptionStability, RustcOptGroup};
+    use super::{OptionStability, RustcOptGroup, input_in_sysroot};
     use crate::EarlyDiagCtxt;
 
     pub fn is_unstable_enabled(matches: &getopts::Matches) -> bool {
@@ -2875,11 +2894,12 @@ pub mod nightly_options {
     }
 
     pub fn match_is_nightly_build(matches: &getopts::Matches) -> bool {
-        is_nightly_build(matches.opt_str("crate-name").as_deref())
+        is_nightly_build(matches.opt_str("crate-name").as_deref(), input_in_sysroot(matches))
     }
 
-    fn is_nightly_build(krate: Option<&str>) -> bool {
-        UnstableFeatures::from_environment(krate).is_nightly_build()
+    fn is_nightly_build(krate: Option<&str>, input_in_sysroot: bool) -> bool {
+        UnstableFeatures::from_environment_check_in_sysroot(krate, input_in_sysroot)
+            .is_nightly_build()
     }
 
     pub fn check_nightly_options(


### PR DESCRIPTION
cc rust-lang/rfcs#3874

In the [*build-std: always* RFC](https://github.com/davidtwco/rfcs/blob/build-std-part-two-always/text/3874-build-std-always.md), it is proposed that `RUSTC_BOOTSTRAP` should be implied for compilation of any crate located in the sysroot. As such, Cargo would not need to set `RUSTC_BOOTSTRAP` for build-std, but also external projects like Rust for Linux that build `core` from the `rust-src` component could do so on a stable toolchain. 

This functionality is only intended for use with unmodified standard library sources, and that should probably be document somewhere but I'm not sure where - `RUSTC_BOOTSTRAP` is mentioned in the unstable book, maybe with that? It might make more sense in the rustc book but there's not an obvious spot.

As rust-lang/rfcs#3874 is not yet accepted, if this warrants an MCP to be implemented in the interim, then I'd be happy to submit one.

It is unclear exactly how to test this, as it would require rustc be from a stable toolchain to test the relevant behaviours, and that's not how the test suite is set up. None of the current tests for `RUSTC_BOOTSTRAP` can be adapted for this.

r? @wesleywiser