### PR TITLE
rustdoc: assoc const bounds from supertraits

### DIFF
--- a/tests/rustdoc-ui/assoc-const-bounds-supertrait.rs
+++ b/tests/rustdoc-ui/assoc-const-bounds-supertrait.rs
@@ -1,0 +1,25 @@
+// Regression test for issue #151511.
+// Ensure that rustdoc doesn't ICE when encountering assoc const eq bounds
+// where the assoc const comes from a supertrait.
+
+#![feature(
+    min_generic_const_args,
+    adt_const_params,
+    unsized_const_params,
+    generic_const_parameter_types
+)]
+#![allow(incomplete_features)]
+
+use std::marker::ConstParamTy_;
+
+trait Trait: SuperTrait {}
+trait SuperTrait: SuperSuperTrait<i32> {}
+trait SuperSuperTrait<T: ConstParamTy_> {
+    #[type_const]
+    const K: T;
+}
+
+fn take(_: impl Trait<K = 0>) {}
+//~^ ERROR anonymous constants referencing generics are not yet supported
+
+fn main() {}

--- a/tests/rustdoc-ui/assoc-const-bounds-supertrait.stderr
+++ b/tests/rustdoc-ui/assoc-const-bounds-supertrait.stderr
@@ -1,0 +1,8 @@
+error: anonymous constants referencing generics are not yet supported
+  --> $DIR/assoc-const-bounds-supertrait.rs:22:27
+   |
+LL | fn take(_: impl Trait<K = 0>) {}
+   |                           ^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
When documenting code with associated const equality bounds where the const is defined in a supertrait, `rustdoc` would panic with "called `Option::unwrap()` on a `None` value" because it only searched for the associated item in the immediate trait.

This can be fixed by adding a recursive helper function that searched through the traits supertrait hierarchy to find the associated item.

Fixes rust-lang/rust#151511

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
