### PR TITLE
Fix broken Xtensa installation link

### DIFF
--- a/src/doc/rustc/src/platform-support/xtensa.md
+++ b/src/doc/rustc/src/platform-support/xtensa.md
@@ -24,4 +24,4 @@ Xtensa targets that support `std` are documented in the [ESP-IDF platform suppor
 
 ## Building the targets
 
-The targets can be built by installing the [Xtensa enabled Rust channel](https://github.com/esp-rs/rust/). See instructions in the [RISC-V and Xtensa Targets section of The Rust on ESP Book](https://docs.espressif.com/projects/rust/book/installation/index.html).
+The targets can be built by installing the [Xtensa enabled Rust channel](https://github.com/esp-rs/rust/). See instructions in the [RISC-V and Xtensa Targets section of The Rust on ESP Book](https://docs.espressif.com/projects/rust/book/getting-started/toolchain.html).


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
### Location (URL)
https://doc.rust-lang.org/rustc/platform-support/xtensa.html

<img width="800" alt="image" src="https://github.com/user-attachments/assets/dbf1fea5-e65f-4bb2-beea-bf3267b12aff" />


### Summary
The Xtensa platform documentation currently links to an outdated Rust on ESP Book installation page that no longer exists.

The Rust on ESP Book has been reorganized, and the installation instructions previously referenced under `/book/installation/` are now located under the Getting Started section.

The link is updated to reference the current Toolchain Installation page, which contains the up-to-date instructions for building Xtensa targets.