### PR TITLE
compiletest: Don't assume `aux-crate` becomes a `*.so` with `no-prefer-dynamic`

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1438,7 +1438,7 @@ impl<'test> TestCx<'test> {
         } else if aux_type.is_some() {
             panic!("aux_type {aux_type:?} not expected");
         } else if aux_props.no_prefer_dynamic {
-            (AuxType::Dylib, None)
+            (AuxType::Lib, None)
         } else if self.config.target.contains("emscripten")
             || (self.config.target.contains("musl")
                 && !aux_props.force_host

--- a/tests/ui/compiletest-self-test/auxiliary/no_prefer_dynamic_lib.rs
+++ b/tests/ui/compiletest-self-test/auxiliary/no_prefer_dynamic_lib.rs
@@ -1,0 +1,10 @@
+//@ no-prefer-dynamic
+
+//! Since this is `no-prefer-dynamic` we expect compiletest to _not_ look for
+//! this create as `libno_prefer_dynamic_lib.so`.
+
+#![crate_type = "rlib"]
+
+pub fn return_42() -> i32 {
+    42
+}

--- a/tests/ui/compiletest-self-test/no-prefer-dynamic-means-no-so.rs
+++ b/tests/ui/compiletest-self-test/no-prefer-dynamic-means-no-so.rs
@@ -1,0 +1,10 @@
+//! Since we and our `aux-crate` is `no-prefer-dynamic`, we expect compiletest
+//! to _not_ look for `libno_prefer_dynamic_lib.so`.
+
+//@ check-pass
+//@ no-prefer-dynamic
+//@ aux-crate: no_prefer_dynamic_lib=no_prefer_dynamic_lib.rs
+
+fn main() {
+    no_prefer_dynamic_lib::return_42();
+}


### PR DESCRIPTION
Since it does not make sense to do so. If someone prefers no dynamic stuff, the last thing they want to look for is an .so file. Also add a regression test. Without the fix, the test fails with:

    error: test compilation failed although it shouldn't!
    --- stderr -------------------------------
    error: extern location for no_prefer_dynamic_lib does not exist: .../auxiliary/libno_prefer_dynamic_lib.so
      --> .../no-prefer-dynamic-means-no-so.rs:9:5
       |
    LL |     no_prefer_dynamic_lib::return_42();
       |     ^^^^^^^^^^^^^^^^^^^^^

### Needed by:
-  https://github.com/rust-lang/rust/pull/150591 because of https://github.com/rust-lang/rust/issues/151271. But IMHO this PR makes sense on its own.

### Must wait for:
- [x] https://github.com/rust-lang/rust/pull/151695