### PR TITLE
Try to reduce rustdoc GUI tests flakyness

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "browser-ui-test": "^0.23.1",
+    "browser-ui-test": "^0.23.2",
     "es-check": "^9.4.4",
     "eslint": "^8.57.1",
     "typescript": "^5.8.3"

--- a/tests/rustdoc-gui/utils.goml
+++ b/tests/rustdoc-gui/utils.goml
@@ -110,6 +110,7 @@ define-function: (
         call-function: ("open-search", {})
         // We empty the search input in case it wasn't empty.
         set-property: (".search-input", {"value": ""})
+        focus: ".search-input"
         // We write the actual query.
         write-into: (".search-input", |query|)
         press-key: 'Enter'


### PR DESCRIPTION
Should help with https://github.com/rust-lang/rust/issues/93784.

I replaced a use of `puppeteer.wait` function with a loop instead (like the rest of `browser-ui-test`).

r? @jieyouxu 