### PR TITLE
compiletest: Support `--extern` modifiers with `proc-macro` directive

### DIFF
--- a/src/tools/compiletest/src/directives/auxiliary/tests.rs
+++ b/src/tools/compiletest/src/directives/auxiliary/tests.rs
@@ -25,3 +25,19 @@ fn test_aux_crate_value_with_modifiers() {
 fn test_aux_crate_value_invalid() {
     parse_aux_crate("foo.rs".to_string());
 }
+
+#[test]
+fn test_proc_macro_value_no_modifiers() {
+    assert_eq!(
+        ProcMacro { extern_modifiers: None, path: "foo.rs".to_string() },
+        parse_proc_macro("foo.rs".to_string())
+    );
+}
+
+#[test]
+fn test_proc_macro_value_with_modifiers() {
+    assert_eq!(
+        ProcMacro { extern_modifiers: Some("noprelude".to_string()), path: "foo.rs".to_string() },
+        parse_proc_macro("noprelude:foo.rs".to_string())
+    );
+}

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1302,7 +1302,7 @@ impl<'test> TestCx<'test> {
             let crate_name = path_to_crate_name(&proc_macro.path);
             add_extern(
                 rustc,
-                None, // `extern_modifiers`
+                proc_macro.extern_modifiers.as_deref(),
                 &crate_name,
                 &proc_macro.path,
                 AuxType::ProcMacro,

--- a/tests/ui/privacy/pub-priv-dep/auxiliary/pm.rs
+++ b/tests/ui/privacy/pub-priv-dep/auxiliary/pm.rs
@@ -1,8 +1,3 @@
-//@ force-host
-//@ no-prefer-dynamic
-
-#![crate_type = "proc-macro"]
-
 extern crate proc_macro;
 use proc_macro::TokenStream;
 

--- a/tests/ui/privacy/pub-priv-dep/pub-priv1.rs
+++ b/tests/ui/privacy/pub-priv-dep/pub-priv1.rs
@@ -1,6 +1,6 @@
 //@ aux-crate:priv:priv_dep=priv_dep.rs
 //@ aux-build:pub_dep.rs
-//@ aux-crate:priv:pm=pm.rs
+//@ proc-macro:priv:pm.rs
 //@ compile-flags: -Zunstable-options
 
 // Basic behavior check of exported_private_dependencies from either a public


### PR DESCRIPTION
So that the `src/tools/compiletest/src/directives/auxiliary/tests.rs` test does not have to (ab)use the `aux-crate` directive for this purpose.

This is very edge-casey so I don't think we should document this in rustc-dev-guide. Mentioning it will confuse more than it helps. If someone needs to do this they will look at the code and easily find the functionality.

This is a bit hacky since `--extern priv:pm.rs` is not valid, but we can make our directives work however we want. And I think this is a fine pragmatic approach. Doing it "the right way" would be a lot of work for not much gain. Plus, that work can be done incrementally in small steps in the future if wanted.

r? @Zalathar

---

Follow-up to:

- https://github.com/rust-lang/rust/pull/151353
- https://github.com/rust-lang/rust/pull/151670

### Unblocks:
- https://github.com/rust-lang/rust/pull/151691, because without this fix that test fails (see https://github.com/rust-lang/rust/pull/151691#issuecomment-3800315302)