### PR TITLE
Borrowck: Simplify SCC annotation computation, placeholder rewriting

### DIFF
--- a/compiler/rustc_data_structures/src/graph/scc/tests.rs
+++ b/compiler/rustc_data_structures/src/graph/scc/tests.rs
@@ -32,12 +32,12 @@ impl Maxes {
 }
 
 impl Annotation for MaxReached {
-    fn merge_scc(self, other: Self) -> Self {
-        Self(std::cmp::max(other.0, self.0))
+    fn update_scc(&mut self, other: &Self) {
+        self.0 = self.0.max(other.0);
     }
 
-    fn merge_reached(self, other: Self) -> Self {
-        Self(std::cmp::max(other.0, self.0))
+    fn update_reachable(&mut self, other: &Self) {
+        self.0 = self.0.max(other.0);
     }
 }
 
@@ -75,13 +75,12 @@ impl Annotations<usize> for MinMaxes {
 }
 
 impl Annotation for MinMaxIn {
-    fn merge_scc(self, other: Self) -> Self {
-        Self { min: std::cmp::min(self.min, other.min), max: std::cmp::max(self.max, other.max) }
+    fn update_scc(&mut self, other: &Self) {
+        self.min = self.min.min(other.min);
+        self.max = self.max.max(other.max);
     }
 
-    fn merge_reached(self, _other: Self) -> Self {
-        self
-    }
+    fn update_reachable(&mut self, _other: &Self) {}
 }
 
 #[test]


### PR DESCRIPTION
This change backports some changes from the now abandoned rust-lang/rust#142623.

Notably, it simplifies the `PlaceholderReachability` `enum` by replacing the case when no placeholders were reached with a standard `Option::None`.

It also rewrites the API for `scc::Annotations` to be update-mut rather than a more Functional programming style. This showed some slight performance impact in early tests of the PR and definitely makes the implementation simpler.

This probably wants a perf run just for good measure.

r? @lcnr

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
