### PR TITLE
os allow missing_docs

### DIFF
--- a/library/core/src/os/mod.rs
+++ b/library/core/src/os/mod.rs
@@ -1,6 +1,7 @@
 //! OS-specific functionality.
 
 #![unstable(feature = "darwin_objc", issue = "145496")]
+#![allow(missing_docs)]
 
 #[cfg(all(
     doc,


### PR DESCRIPTION
Resolves rustc build faliure.

Discovered in https://github.com/NixOS/nixpkgs/pull/470993

```
rustc>  Documenting core v0.0.0 (/nix/var/nix/builds/nix-78118-1377149852/rustc-1.92.0-src/library/core)
rustc> error: missing documentation for a module
rustc>   --> library/core/src/os/mod.rs:13:1
rustc>    |
rustc> 13 | pub mod darwin {}
rustc>    | ^^^^^^^^^^^^^^
rustc>    |
rustc>    = note: `-D missing-docs` implied by `-D warnings`
rustc>    = help: to override `-D warnings` add `#[allow(missing_docs)]`
rustc>
rustc>     Checking compiler_builtins v0.1.160 (/nix/var/nix/builds/nix-78118-1377149852/rustc-1.92.0-src/library/compiler-builtins/compiler-builtins)
rustc> error: could not document `core`
rustc> warning: build failed, waiting for other jobs to finish...
rustc> Command `/nix/store/h499wcc6pl9whxa2kznjm76wy4f3lcm0-cargo-bootstrap-1.92.0/bin/cargo doc --target wasm32-unknown-unknown -Zbinary-dep-depinfo -j 10 -Zroot-dir=/nix/var/nix/builds/nix-78118-1377149852/rustc-1.92.0-src --frozen --release -p alloc -p compiler_builtins -p core -p panic_abort -p panic_unwind -p proc_macro -p rustc-std-workspace-core -p std -p std_detect -p sysroot -p test -p unwind --features 'backtrace panic-unwind' --manifest-path /nix/var/nix/builds/nix-78118-1377149852/rustc-1.92.0-src/library/sysroot/Cargo.toml --no-deps --target-dir /nix/var/nix/builds/nix-78118-1377149852/rustc-1.92.0-src/build/aarch64-apple-darwin/stage1-std/wasm32-unknown-unknown/doc -Zskip-rustdoc-fingerprint -Zrustdoc-map [workdir=/nix/var/nix/builds/nix-78118-1377149852/rustc-1.92.0-src]` failed with exit code 101
rustc> Created at: src/bootstrap/src/core/build_steps/doc.rs:781:21
rustc> Executed at: src/bootstrap/src/core/build_steps/doc.rs:814:22
rustc>
rustc> Command has failed. Rerun with -v to see more details.
```