### PR TITLE
Omit standard copyright notice

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -53,7 +53,7 @@ path = [
 ]
 precedence = "override"
 SPDX-FileCopyrightText = "The Rust Project Developers (see https://thanks.rust-lang.org)"
-SPDX-License-Identifier = "MIT or Apache-2.0"
+SPDX-License-Identifier = "MIT OR Apache-2.0"
 
 [[annotations]]
 path = "compiler/rustc_llvm/llvm-wrapper/SymbolWrapper.cpp"

--- a/compiler/rustc_codegen_gcc/example/alloc_system.rs
+++ b/compiler/rustc_codegen_gcc/example/alloc_system.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
-// SPDX-FileCopyrightText: The Rust Project Developers (see https://thanks.rust-lang.org)
-
 #![no_std]
 #![feature(allocator_api, rustc_private)]
 

--- a/src/doc/rustc-dev-guide/src/conventions.md
+++ b/src/doc/rustc-dev-guide/src/conventions.md
@@ -76,8 +76,7 @@ These use a pinned version of `ruff`, to avoid relying on the local environment.
 <!-- REUSE-IgnoreEnd -->
 
 In the past, files began with a copyright and license notice.
-Please **omit** this notice for new files licensed under the standard terms (dual
-MIT/Apache-2.0).
+Please **omit** this notice for new files licensed under the standard terms (MIT OR Apache-2.0).
 
 All of the copyright notices should be gone by now, but if you come across one
 in the rust-lang/rust repo, feel free to open a PR to remove it.

--- a/src/tools/miri/tests/pass/intrinsics/integer.rs
+++ b/src/tools/miri/tests/pass/intrinsics/integer.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
-// SPDX-FileCopyrightText: The Rust Project Developers (see https://thanks.rust-lang.org)
-
 #![feature(core_intrinsics, funnel_shifts)]
 use std::intrinsics::*;
 

--- a/src/tools/miri/tests/pass/issues/issue-30530.rs
+++ b/src/tools/miri/tests/pass/issues/issue-30530.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
-// SPDX-FileCopyrightText: The Rust Project Developers (see https://thanks.rust-lang.org)
-
 // Regression test for Issue #30530: alloca's created for storing
 // intermediate scratch values during brace-less match arms need to be
 // initialized with their drop-flag set to "dropped" (or else we end

--- a/src/tools/miri/tests/pass/tag-align-dyn-u64.rs
+++ b/src/tools/miri/tests/pass/tag-align-dyn-u64.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
-// SPDX-FileCopyrightText: The Rust Project Developers (see https://thanks.rust-lang.org)
-
 use std::mem;
 
 enum Tag<A> {


### PR DESCRIPTION
Remove copyright notices for files licensed under the standard terms (MIT OR Apache-2.0).
