### PR TITLE
Fix ICE in transmutability error reporting when type aliases are normalized

### DIFF
--- a/tests/ui/transmutability/type-alias-normalization.rs
+++ b/tests/ui/transmutability/type-alias-normalization.rs
@@ -1,0 +1,31 @@
+//! regression test for https://github.com/rust-lang/rust/issues/151462
+//@compile-flags: -Znext-solver=globally
+#![feature(lazy_type_alias, transmutability)]
+#![allow(incomplete_features)]
+mod assert {
+    use std::mem::{Assume, TransmuteFrom};
+
+    pub fn is_maybe_transmutable<Src, Dst>()
+    where
+        Src: TransmuteFrom<
+            Src,
+            {
+                Assume {
+                    alignment: true,
+                    lifetimes: true,
+                    safety: true,
+                    validity: true,
+                }
+            },
+        >,
+    {
+    }
+}
+
+fn test() {
+    type JustUnit = ();
+    assert::is_maybe_transmutable::<JustUnit, ()>();
+    //~^ ERROR `JustUnit` cannot be safely transmuted into `JustUnit`
+}
+
+fn main() {}

--- a/tests/ui/transmutability/type-alias-normalization.stderr
+++ b/tests/ui/transmutability/type-alias-normalization.stderr
@@ -1,0 +1,29 @@
+error[E0277]: `JustUnit` cannot be safely transmuted into `JustUnit`
+  --> $DIR/type-alias-normalization.rs:27:37
+   |
+LL |     assert::is_maybe_transmutable::<JustUnit, ()>();
+   |                                     ^^^^^^^^ analyzing the transmutability of `JustUnit` is not yet supported
+   |
+note: required by a bound in `is_maybe_transmutable`
+  --> $DIR/type-alias-normalization.rs:10:14
+   |
+LL |       pub fn is_maybe_transmutable<Src, Dst>()
+   |              --------------------- required by a bound in this function
+LL |       where
+LL |           Src: TransmuteFrom<
+   |  ______________^
+LL | |             Src,
+LL | |             {
+LL | |                 Assume {
+...  |
+LL | |             },
+LL | |         >,
+   | |_________^ required by this bound in `is_maybe_transmutable`
+help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
+   |
+LL | fn test() where (): TransmuteFrom<(), Assume { alignment: true, lifetimes: true, safety: true, validity: true }> {
+   |           ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes rust-lang/rust#151462

Transmutability error reporting hit an ICE when type aliases were normalized for diagnostics. For example, when type
 `JustUnit = ()` normalizes to `()`, the check passes unexpectedly even though the original check with `JustUnit` failed.

Fixed by adding a retry in the `Answer::Yes` arm that checks with the root obligation's types before panicking. The retry only occurs when the root obligation differs and is a Transmute trait predicate.

Also added a test that reproduces the original ICE.