### PR TITLE
Fix outdated Debian Ports ISO reference

### DIFF
--- a/src/doc/rustc/src/platform-support/m68k-unknown-linux-gnu.md
+++ b/src/doc/rustc/src/platform-support/m68k-unknown-linux-gnu.md
@@ -52,7 +52,7 @@ Atari systems or emulated environments such as QEMU version 4.2 or newer or ARAn
 ISO images for installation are provided by the Debian Ports team and can be obtained
 from the Debian CD image server available at:
 
-[https://cdimage.debian.org/cdimage/ports/](https://cdimage.debian.org/cdimage/ports/)
+[https://cdimage.debian.org/cdimage/ports/12.0/m68k/](https://cdimage.debian.org/cdimage/ports/12.0/m68k/)
 
 Documentation for Debian/m68k is available on the Debian Wiki at:
 

--- a/src/doc/rustc/src/platform-support/m68k-unknown-linux-gnu.md
+++ b/src/doc/rustc/src/platform-support/m68k-unknown-linux-gnu.md
@@ -52,7 +52,7 @@ Atari systems or emulated environments such as QEMU version 4.2 or newer or ARAn
 ISO images for installation are provided by the Debian Ports team and can be obtained
 from the Debian CD image server available at:
 
-[https://cdimage.debian.org/cdimage/ports/current](https://cdimage.debian.org/cdimage/ports/current/)
+[https://cdimage.debian.org/cdimage/ports/](https://cdimage.debian.org/cdimage/ports/)
 
 Documentation for Debian/m68k is available on the Debian Wiki at:
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
### Location (URL)
https://doc.rust-lang.org/rustc/platform-support/m68k-unknown-none-elf.html

<img width="800" alt="image" src="https://github.com/user-attachments/assets/328a032e-c4ff-4f9a-a832-eefe1944e2b8" />


### Summary
The referenced Debian Ports ISO link is outdated and no longer accessible.

This updates the link to the current Debian CD image location so readers can easily find the correct installation media.