### PR TITLE
Add `extern crate core` to diagnostic tests

### DIFF
--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-doc-comment-field.rs
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-doc-comment-field.rs
@@ -18,6 +18,7 @@ extern crate rustc_fluent_macro;
 extern crate rustc_macros;
 extern crate rustc_session;
 extern crate rustc_span;
+extern crate core;
 
 use rustc_errors::{Applicability, DiagMessage, SubdiagMessage};
 use rustc_macros::{Diagnostic, Subdiagnostic};

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-doc-comment-field.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-doc-comment-field.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `NotIntoDiagArg: IntoDiagArg` is not satisfied
-  --> $DIR/diagnostic-derive-doc-comment-field.rs:36:10
+  --> $DIR/diagnostic-derive-doc-comment-field.rs:37:10
    |
 LL | #[derive(Diagnostic)]
    |          ---------- required by a bound introduced by this call
@@ -8,7 +8,7 @@ LL |     arg: NotIntoDiagArg,
    |          ^^^^^^^^^^^^^^ unsatisfied trait bound
    |
 help: the nightly-only, unstable trait `IntoDiagArg` is not implemented for `NotIntoDiagArg`
-  --> $DIR/diagnostic-derive-doc-comment-field.rs:28:1
+  --> $DIR/diagnostic-derive-doc-comment-field.rs:29:1
    |
 LL | struct NotIntoDiagArg;
    | ^^^^^^^^^^^^^^^^^^^^^
@@ -21,7 +21,7 @@ note: required by a bound in `Diag::<'a, G>::arg`
    = note: this error originates in the macro `with_fn` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotIntoDiagArg: IntoDiagArg` is not satisfied
-  --> $DIR/diagnostic-derive-doc-comment-field.rs:46:10
+  --> $DIR/diagnostic-derive-doc-comment-field.rs:47:10
    |
 LL | #[derive(Subdiagnostic)]
    |          ------------- required by a bound introduced by this call
@@ -30,7 +30,7 @@ LL |     arg: NotIntoDiagArg,
    |          ^^^^^^^^^^^^^^ unsatisfied trait bound
    |
 help: the nightly-only, unstable trait `IntoDiagArg` is not implemented for `NotIntoDiagArg`
-  --> $DIR/diagnostic-derive-doc-comment-field.rs:28:1
+  --> $DIR/diagnostic-derive-doc-comment-field.rs:29:1
    |
 LL | struct NotIntoDiagArg;
    | ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
@@ -29,6 +29,8 @@ use rustc_errors::{Applicability, DiagMessage, ErrCode, MultiSpan, SubdiagMessag
 
 extern crate rustc_session;
 
+extern crate core;
+
 rustc_fluent_macro::fluent_messages! { "./example.ftl" }
 
 // E0123 and E0456 are no longer used, so we define our own constants here just for this test.
@@ -56,7 +58,7 @@ enum DiagnosticOnEnum {
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = E0123)]
 #[diag = "E0123"]
-//~^ ERROR failed to resolve: you might be missing crate `core`
+//~^ ERROR expected parentheses: #[diag(...)]
 struct WrongStructAttrStyle {}
 
 #[derive(Diagnostic)]
@@ -801,7 +803,7 @@ struct SuggestionsNoItem {
 struct SuggestionsInvalidItem {
     #[suggestion(code(foo))]
     //~^ ERROR `code(...)` must contain only string literals
-    //~| ERROR failed to resolve: you might be missing crate `core`
+    //~| ERROR unexpected token, expected `)`
     sub: Span,
 }
 
@@ -809,7 +811,7 @@ struct SuggestionsInvalidItem {
 #[diag(no_crate_example)]
 struct SuggestionsInvalidLiteral {
     #[suggestion(code = 3)]
-    //~^ ERROR failed to resolve: you might be missing crate `core`
+    //~^ ERROR expected string literal
     sub: Span,
 }
 

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
@@ -1,11 +1,11 @@
 error: derive(Diagnostic): unsupported type attribute for diagnostic derive enum
-  --> $DIR/diagnostic-derive.rs:47:1
+  --> $DIR/diagnostic-derive.rs:49:1
    |
 LL | #[diag(no_crate_example, code = E0123)]
    | ^
 
 error: derive(Diagnostic): diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:50:5
+  --> $DIR/diagnostic-derive.rs:52:5
    |
 LL |     Foo,
    |     ^^^
@@ -13,21 +13,27 @@ LL |     Foo,
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: derive(Diagnostic): diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:52:5
+  --> $DIR/diagnostic-derive.rs:54:5
    |
 LL |     Bar,
    |     ^^^
    |
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
+error: expected parentheses: #[diag(...)]
+  --> $DIR/diagnostic-derive.rs:60:8
+   |
+LL | #[diag = "E0123"]
+   |        ^
+
 error: derive(Diagnostic): `#[nonsense(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:63:1
+  --> $DIR/diagnostic-derive.rs:65:1
    |
 LL | #[nonsense(no_crate_example, code = E0123)]
    | ^
 
 error: derive(Diagnostic): diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:63:1
+  --> $DIR/diagnostic-derive.rs:65:1
    |
 LL | #[nonsense(no_crate_example, code = E0123)]
    | ^
@@ -35,7 +41,7 @@ LL | #[nonsense(no_crate_example, code = E0123)]
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: derive(Diagnostic): diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:70:1
+  --> $DIR/diagnostic-derive.rs:72:1
    |
 LL | #[diag(code = E0123)]
    | ^
@@ -43,13 +49,13 @@ LL | #[diag(code = E0123)]
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: derive(Diagnostic): diagnostic slug must be the first argument
-  --> $DIR/diagnostic-derive.rs:80:16
+  --> $DIR/diagnostic-derive.rs:82:16
    |
 LL | #[diag(nonsense("foo"), code = E0123, slug = "foo")]
    |                ^
 
 error: derive(Diagnostic): diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:80:1
+  --> $DIR/diagnostic-derive.rs:82:1
    |
 LL | #[diag(nonsense("foo"), code = E0123, slug = "foo")]
    | ^
@@ -57,7 +63,7 @@ LL | #[diag(nonsense("foo"), code = E0123, slug = "foo")]
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: derive(Diagnostic): unknown argument
-  --> $DIR/diagnostic-derive.rs:86:8
+  --> $DIR/diagnostic-derive.rs:88:8
    |
 LL | #[diag(nonsense = "...", code = E0123, slug = "foo")]
    |        ^^^^^^^^
@@ -65,7 +71,7 @@ LL | #[diag(nonsense = "...", code = E0123, slug = "foo")]
    = note: only the `code` parameter is valid after the slug
 
 error: derive(Diagnostic): diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:86:1
+  --> $DIR/diagnostic-derive.rs:88:1
    |
 LL | #[diag(nonsense = "...", code = E0123, slug = "foo")]
    | ^
@@ -73,7 +79,7 @@ LL | #[diag(nonsense = "...", code = E0123, slug = "foo")]
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: derive(Diagnostic): unknown argument
-  --> $DIR/diagnostic-derive.rs:92:8
+  --> $DIR/diagnostic-derive.rs:94:8
    |
 LL | #[diag(nonsense = 4, code = E0123, slug = "foo")]
    |        ^^^^^^^^
@@ -81,7 +87,7 @@ LL | #[diag(nonsense = 4, code = E0123, slug = "foo")]
    = note: only the `code` parameter is valid after the slug
 
 error: derive(Diagnostic): diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:92:1
+  --> $DIR/diagnostic-derive.rs:94:1
    |
 LL | #[diag(nonsense = 4, code = E0123, slug = "foo")]
    | ^
@@ -89,7 +95,7 @@ LL | #[diag(nonsense = 4, code = E0123, slug = "foo")]
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: derive(Diagnostic): unknown argument
-  --> $DIR/diagnostic-derive.rs:98:40
+  --> $DIR/diagnostic-derive.rs:100:40
    |
 LL | #[diag(no_crate_example, code = E0123, slug = "foo")]
    |                                        ^^^^
@@ -97,55 +103,55 @@ LL | #[diag(no_crate_example, code = E0123, slug = "foo")]
    = note: only the `code` parameter is valid after the slug
 
 error: derive(Diagnostic): `#[suggestion = ...]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:105:5
+  --> $DIR/diagnostic-derive.rs:107:5
    |
 LL |     #[suggestion = "bar"]
    |     ^
 
 error: derive(Diagnostic): attribute specified multiple times
-  --> $DIR/diagnostic-derive.rs:112:8
+  --> $DIR/diagnostic-derive.rs:114:8
    |
 LL | #[diag(no_crate_example, code = E0456)]
    |        ^^^^^^^^^^^^^^^^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:111:8
+  --> $DIR/diagnostic-derive.rs:113:8
    |
 LL | #[diag(no_crate_example, code = E0123)]
    |        ^^^^^^^^^^^^^^^^
 
 error: derive(Diagnostic): attribute specified multiple times
-  --> $DIR/diagnostic-derive.rs:112:26
+  --> $DIR/diagnostic-derive.rs:114:26
    |
 LL | #[diag(no_crate_example, code = E0456)]
    |                          ^^^^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:111:26
+  --> $DIR/diagnostic-derive.rs:113:26
    |
 LL | #[diag(no_crate_example, code = E0123)]
    |                          ^^^^
 
 error: derive(Diagnostic): attribute specified multiple times
-  --> $DIR/diagnostic-derive.rs:118:40
+  --> $DIR/diagnostic-derive.rs:120:40
    |
 LL | #[diag(no_crate_example, code = E0123, code = E0456)]
    |                                        ^^^^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:118:26
+  --> $DIR/diagnostic-derive.rs:120:26
    |
 LL | #[diag(no_crate_example, code = E0123, code = E0456)]
    |                          ^^^^
 
 error: derive(Diagnostic): diagnostic slug must be the first argument
-  --> $DIR/diagnostic-derive.rs:123:43
+  --> $DIR/diagnostic-derive.rs:125:43
    |
 LL | #[diag(no_crate_example, no_crate::example, code = E0123)]
    |                                           ^
 
 error: derive(Diagnostic): diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:128:1
+  --> $DIR/diagnostic-derive.rs:130:1
    |
 LL | struct KindNotProvided {}
    | ^^^^^^
@@ -153,7 +159,7 @@ LL | struct KindNotProvided {}
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: derive(Diagnostic): diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:131:1
+  --> $DIR/diagnostic-derive.rs:133:1
    |
 LL | #[diag(code = E0123)]
    | ^
@@ -161,31 +167,31 @@ LL | #[diag(code = E0123)]
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: derive(Diagnostic): the `#[primary_span]` attribute can only be applied to fields of type `Span` or `MultiSpan`
-  --> $DIR/diagnostic-derive.rs:142:5
+  --> $DIR/diagnostic-derive.rs:144:5
    |
 LL |     #[primary_span]
    |     ^
 
 error: derive(Diagnostic): `#[nonsense]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:150:5
+  --> $DIR/diagnostic-derive.rs:152:5
    |
 LL |     #[nonsense]
    |     ^
 
 error: derive(Diagnostic): the `#[label(...)]` attribute can only be applied to fields of type `Span` or `MultiSpan`
-  --> $DIR/diagnostic-derive.rs:167:5
+  --> $DIR/diagnostic-derive.rs:169:5
    |
 LL |     #[label(no_crate_label)]
    |     ^
 
 error: derive(Diagnostic): `name` doesn't refer to a field on this type
-  --> $DIR/diagnostic-derive.rs:175:46
+  --> $DIR/diagnostic-derive.rs:177:46
    |
 LL |     #[suggestion(no_crate_suggestion, code = "{name}")]
    |                                              ^^^^^^^^
 
 error: invalid format string: expected `}` but string was terminated
-  --> $DIR/diagnostic-derive.rs:180:10
+  --> $DIR/diagnostic-derive.rs:182:10
    |
 LL | #[derive(Diagnostic)]
    |          ^^^^^^^^^^ expected `}` in format string
@@ -194,7 +200,7 @@ LL | #[derive(Diagnostic)]
    = note: this error originates in the derive macro `Diagnostic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: invalid format string: unmatched `}` found
-  --> $DIR/diagnostic-derive.rs:190:10
+  --> $DIR/diagnostic-derive.rs:192:10
    |
 LL | #[derive(Diagnostic)]
    |          ^^^^^^^^^^ unmatched `}` in format string
@@ -203,19 +209,19 @@ LL | #[derive(Diagnostic)]
    = note: this error originates in the derive macro `Diagnostic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: derive(Diagnostic): the `#[label(...)]` attribute can only be applied to fields of type `Span` or `MultiSpan`
-  --> $DIR/diagnostic-derive.rs:210:5
+  --> $DIR/diagnostic-derive.rs:212:5
    |
 LL |     #[label(no_crate_label)]
    |     ^
 
 error: derive(Diagnostic): suggestion without `code = "..."`
-  --> $DIR/diagnostic-derive.rs:229:5
+  --> $DIR/diagnostic-derive.rs:231:5
    |
 LL |     #[suggestion(no_crate_suggestion)]
    |     ^
 
 error: derive(Diagnostic): invalid nested attribute
-  --> $DIR/diagnostic-derive.rs:237:18
+  --> $DIR/diagnostic-derive.rs:239:18
    |
 LL |     #[suggestion(nonsense = "bar")]
    |                  ^^^^^^^^
@@ -223,13 +229,13 @@ LL |     #[suggestion(nonsense = "bar")]
    = help: only `no_span`, `style`, `code` and `applicability` are valid nested attributes
 
 error: derive(Diagnostic): suggestion without `code = "..."`
-  --> $DIR/diagnostic-derive.rs:237:5
+  --> $DIR/diagnostic-derive.rs:239:5
    |
 LL |     #[suggestion(nonsense = "bar")]
    |     ^
 
 error: derive(Diagnostic): invalid nested attribute
-  --> $DIR/diagnostic-derive.rs:246:18
+  --> $DIR/diagnostic-derive.rs:248:18
    |
 LL |     #[suggestion(msg = "bar")]
    |                  ^^^
@@ -237,13 +243,13 @@ LL |     #[suggestion(msg = "bar")]
    = help: only `no_span`, `style`, `code` and `applicability` are valid nested attributes
 
 error: derive(Diagnostic): suggestion without `code = "..."`
-  --> $DIR/diagnostic-derive.rs:246:5
+  --> $DIR/diagnostic-derive.rs:248:5
    |
 LL |     #[suggestion(msg = "bar")]
    |     ^
 
 error: derive(Diagnostic): wrong field type for suggestion
-  --> $DIR/diagnostic-derive.rs:269:5
+  --> $DIR/diagnostic-derive.rs:271:5
    |
 LL |     #[suggestion(no_crate_suggestion, code = "This is suggested code")]
    |     ^
@@ -251,79 +257,79 @@ LL |     #[suggestion(no_crate_suggestion, code = "This is suggested code")]
    = help: `#[suggestion(...)]` should be applied to fields of type `Span` or `(Span, Applicability)`
 
 error: derive(Diagnostic): attribute specified multiple times
-  --> $DIR/diagnostic-derive.rs:285:24
+  --> $DIR/diagnostic-derive.rs:287:24
    |
 LL |     suggestion: (Span, Span, Applicability),
    |                        ^^^^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:285:18
+  --> $DIR/diagnostic-derive.rs:287:18
    |
 LL |     suggestion: (Span, Span, Applicability),
    |                  ^^^^
 
 error: derive(Diagnostic): attribute specified multiple times
-  --> $DIR/diagnostic-derive.rs:293:33
+  --> $DIR/diagnostic-derive.rs:295:33
    |
 LL |     suggestion: (Applicability, Applicability, Span),
    |                                 ^^^^^^^^^^^^^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:293:18
+  --> $DIR/diagnostic-derive.rs:295:18
    |
 LL |     suggestion: (Applicability, Applicability, Span),
    |                  ^^^^^^^^^^^^^
 
 error: derive(Diagnostic): `#[label = ...]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:300:5
+  --> $DIR/diagnostic-derive.rs:302:5
    |
 LL |     #[label = "bar"]
    |     ^
 
 error: derive(Diagnostic): attribute specified multiple times
-  --> $DIR/diagnostic-derive.rs:451:5
+  --> $DIR/diagnostic-derive.rs:453:5
    |
 LL |     #[suggestion(no_crate_suggestion, code = "...", applicability = "maybe-incorrect")]
    |     ^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:453:24
+  --> $DIR/diagnostic-derive.rs:455:24
    |
 LL |     suggestion: (Span, Applicability),
    |                        ^^^^^^^^^^^^^
 
 error: derive(Diagnostic): invalid applicability
-  --> $DIR/diagnostic-derive.rs:459:69
+  --> $DIR/diagnostic-derive.rs:461:69
    |
 LL |     #[suggestion(no_crate_suggestion, code = "...", applicability = "batman")]
    |                                                                     ^^^^^^^^
 
 error: derive(Diagnostic): the `#[help(...)]` attribute can only be applied to fields of type `Span`, `MultiSpan`, `bool` or `()`
-  --> $DIR/diagnostic-derive.rs:526:5
+  --> $DIR/diagnostic-derive.rs:528:5
    |
 LL |     #[help(no_crate_help)]
    |     ^
 
 error: derive(Diagnostic): a diagnostic slug must be the first argument to the attribute
-  --> $DIR/diagnostic-derive.rs:535:32
+  --> $DIR/diagnostic-derive.rs:537:32
    |
 LL |     #[label(no_crate_label, foo)]
    |                                ^
 
 error: derive(Diagnostic): only `no_span` is a valid nested attribute
-  --> $DIR/diagnostic-derive.rs:543:29
+  --> $DIR/diagnostic-derive.rs:545:29
    |
 LL |     #[label(no_crate_label, foo = "...")]
    |                             ^^^
 
 error: derive(Diagnostic): only `no_span` is a valid nested attribute
-  --> $DIR/diagnostic-derive.rs:551:29
+  --> $DIR/diagnostic-derive.rs:553:29
    |
 LL |     #[label(no_crate_label, foo("..."))]
    |                             ^^^
 
 error: derive(Diagnostic): `#[primary_span]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:563:5
+  --> $DIR/diagnostic-derive.rs:565:5
    |
 LL |     #[primary_span]
    |     ^
@@ -331,13 +337,13 @@ LL |     #[primary_span]
    = help: the `primary_span` field attribute is not valid for lint diagnostics
 
 error: derive(Diagnostic): `#[error(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:583:1
+  --> $DIR/diagnostic-derive.rs:585:1
    |
 LL | #[error(no_crate_example, code = E0123)]
    | ^
 
 error: derive(Diagnostic): diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:583:1
+  --> $DIR/diagnostic-derive.rs:585:1
    |
 LL | #[error(no_crate_example, code = E0123)]
    | ^
@@ -345,13 +351,13 @@ LL | #[error(no_crate_example, code = E0123)]
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: derive(Diagnostic): `#[warn_(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:590:1
+  --> $DIR/diagnostic-derive.rs:592:1
    |
 LL | #[warn_(no_crate_example, code = E0123)]
    | ^
 
 error: derive(Diagnostic): diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:590:1
+  --> $DIR/diagnostic-derive.rs:592:1
    |
 LL | #[warn_(no_crate_example, code = E0123)]
    | ^
@@ -359,13 +365,13 @@ LL | #[warn_(no_crate_example, code = E0123)]
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: derive(Diagnostic): `#[lint(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:597:1
+  --> $DIR/diagnostic-derive.rs:599:1
    |
 LL | #[lint(no_crate_example, code = E0123)]
    | ^
 
 error: derive(Diagnostic): diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:597:1
+  --> $DIR/diagnostic-derive.rs:599:1
    |
 LL | #[lint(no_crate_example, code = E0123)]
    | ^
@@ -373,13 +379,13 @@ LL | #[lint(no_crate_example, code = E0123)]
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: derive(Diagnostic): `#[lint(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:604:1
+  --> $DIR/diagnostic-derive.rs:606:1
    |
 LL | #[lint(no_crate_example, code = E0123)]
    | ^
 
 error: derive(Diagnostic): diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:604:1
+  --> $DIR/diagnostic-derive.rs:606:1
    |
 LL | #[lint(no_crate_example, code = E0123)]
    | ^
@@ -387,19 +393,19 @@ LL | #[lint(no_crate_example, code = E0123)]
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: derive(Diagnostic): attribute specified multiple times
-  --> $DIR/diagnostic-derive.rs:613:53
+  --> $DIR/diagnostic-derive.rs:615:53
    |
 LL |     #[suggestion(no_crate_suggestion, code = "...", code = ",,,")]
    |                                                     ^^^^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:613:39
+  --> $DIR/diagnostic-derive.rs:615:39
    |
 LL |     #[suggestion(no_crate_suggestion, code = "...", code = ",,,")]
    |                                       ^^^^
 
 error: derive(Diagnostic): wrong types for suggestion
-  --> $DIR/diagnostic-derive.rs:622:24
+  --> $DIR/diagnostic-derive.rs:624:24
    |
 LL |     suggestion: (Span, usize),
    |                        ^^^^^
@@ -407,7 +413,7 @@ LL |     suggestion: (Span, usize),
    = help: `#[suggestion(...)]` on a tuple field must be applied to fields of type `(Span, Applicability)`
 
 error: derive(Diagnostic): wrong types for suggestion
-  --> $DIR/diagnostic-derive.rs:630:17
+  --> $DIR/diagnostic-derive.rs:632:17
    |
 LL |     suggestion: (Span,),
    |                 ^^^^^^^
@@ -415,13 +421,13 @@ LL |     suggestion: (Span,),
    = help: `#[suggestion(...)]` on a tuple field must be applied to fields of type `(Span, Applicability)`
 
 error: derive(Diagnostic): suggestion without `code = "..."`
-  --> $DIR/diagnostic-derive.rs:637:5
+  --> $DIR/diagnostic-derive.rs:639:5
    |
 LL |     #[suggestion(no_crate_suggestion)]
    |     ^
 
 error: derive(Diagnostic): `#[multipart_suggestion(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:644:1
+  --> $DIR/diagnostic-derive.rs:646:1
    |
 LL | #[multipart_suggestion(no_crate_suggestion)]
    | ^
@@ -429,7 +435,7 @@ LL | #[multipart_suggestion(no_crate_suggestion)]
    = help: consider creating a `Subdiagnostic` instead
 
 error: derive(Diagnostic): `#[multipart_suggestion(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:647:1
+  --> $DIR/diagnostic-derive.rs:649:1
    |
 LL | #[multipart_suggestion()]
    | ^
@@ -437,7 +443,7 @@ LL | #[multipart_suggestion()]
    = help: consider creating a `Subdiagnostic` instead
 
 error: derive(Diagnostic): `#[multipart_suggestion(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:651:5
+  --> $DIR/diagnostic-derive.rs:653:5
    |
 LL |     #[multipart_suggestion(no_crate_suggestion)]
    |     ^
@@ -445,7 +451,7 @@ LL |     #[multipart_suggestion(no_crate_suggestion)]
    = help: consider creating a `Subdiagnostic` instead
 
 error: derive(Diagnostic): `#[suggestion(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:659:1
+  --> $DIR/diagnostic-derive.rs:661:1
    |
 LL | #[suggestion(no_crate_suggestion, code = "...")]
    | ^
@@ -453,7 +459,7 @@ LL | #[suggestion(no_crate_suggestion, code = "...")]
    = help: `#[label]` and `#[suggestion]` can only be applied to fields
 
 error: derive(Diagnostic): `#[label]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:668:1
+  --> $DIR/diagnostic-derive.rs:670:1
    |
 LL | #[label]
    | ^
@@ -461,61 +467,73 @@ LL | #[label]
    = help: `#[label]` and `#[suggestion]` can only be applied to fields
 
 error: derive(Diagnostic): `#[subdiagnostic(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:702:5
+  --> $DIR/diagnostic-derive.rs:704:5
    |
 LL |     #[subdiagnostic(bad)]
    |     ^
 
 error: derive(Diagnostic): `#[subdiagnostic = ...]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:710:5
+  --> $DIR/diagnostic-derive.rs:712:5
    |
 LL |     #[subdiagnostic = "bad"]
    |     ^
 
 error: derive(Diagnostic): `#[subdiagnostic(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:718:5
+  --> $DIR/diagnostic-derive.rs:720:5
    |
 LL |     #[subdiagnostic(bad, bad)]
    |     ^
 
 error: derive(Diagnostic): `#[subdiagnostic(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:726:5
+  --> $DIR/diagnostic-derive.rs:728:5
    |
 LL |     #[subdiagnostic("bad")]
    |     ^
 
 error: derive(Diagnostic): `#[subdiagnostic(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:734:5
+  --> $DIR/diagnostic-derive.rs:736:5
    |
 LL |     #[subdiagnostic(eager)]
    |     ^
 
 error: derive(Diagnostic): `#[subdiagnostic(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:742:5
+  --> $DIR/diagnostic-derive.rs:744:5
    |
 LL |     #[subdiagnostic(eager)]
    |     ^
 
 error: derive(Diagnostic): `#[subdiagnostic(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:763:5
+  --> $DIR/diagnostic-derive.rs:765:5
    |
 LL |     #[subdiagnostic(eager)]
    |     ^
 
 error: derive(Diagnostic): expected at least one string literal for `code(...)`
-  --> $DIR/diagnostic-derive.rs:794:23
+  --> $DIR/diagnostic-derive.rs:796:23
    |
 LL |     #[suggestion(code())]
    |                       ^
 
 error: derive(Diagnostic): `code(...)` must contain only string literals
-  --> $DIR/diagnostic-derive.rs:802:23
+  --> $DIR/diagnostic-derive.rs:804:23
    |
 LL |     #[suggestion(code(foo))]
    |                       ^^^
 
+error: unexpected token, expected `)`
+  --> $DIR/diagnostic-derive.rs:804:23
+   |
+LL |     #[suggestion(code(foo))]
+   |                       ^^^
+
+error: expected string literal
+  --> $DIR/diagnostic-derive.rs:813:25
+   |
+LL |     #[suggestion(code = 3)]
+   |                         ^
+
 error: derive(Diagnostic): `#[suggestion(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:826:5
+  --> $DIR/diagnostic-derive.rs:828:5
    |
 LL |     #[suggestion(no_crate_suggestion, code = "")]
    |     ^
@@ -524,38 +542,20 @@ LL |     #[suggestion(no_crate_suggestion, code = "")]
    = help: to show a suggestion consisting of multiple parts, use a `Subdiagnostic` annotated with `#[multipart_suggestion(...)]`
    = help: to show a variable set of suggestions, use a `Vec` of `Subdiagnostic`s annotated with `#[suggestion(...)]`
 
-error[E0433]: failed to resolve: you might be missing crate `core`
-  --> $DIR/diagnostic-derive.rs:58:8
-   |
-LL | #[diag = "E0123"]
-   |        ^ you might be missing crate `core`
-
-error[E0433]: failed to resolve: you might be missing crate `core`
-  --> $DIR/diagnostic-derive.rs:802:23
-   |
-LL |     #[suggestion(code(foo))]
-   |                       ^^^ you might be missing crate `core`
-
-error[E0433]: failed to resolve: you might be missing crate `core`
-  --> $DIR/diagnostic-derive.rs:811:25
-   |
-LL |     #[suggestion(code = 3)]
-   |                         ^ you might be missing crate `core`
-
 error: cannot find attribute `nonsense` in this scope
-  --> $DIR/diagnostic-derive.rs:63:3
+  --> $DIR/diagnostic-derive.rs:65:3
    |
 LL | #[nonsense(no_crate_example, code = E0123)]
    |   ^^^^^^^^
 
 error: cannot find attribute `nonsense` in this scope
-  --> $DIR/diagnostic-derive.rs:150:7
+  --> $DIR/diagnostic-derive.rs:152:7
    |
 LL |     #[nonsense]
    |       ^^^^^^^^
 
 error: cannot find attribute `error` in this scope
-  --> $DIR/diagnostic-derive.rs:583:3
+  --> $DIR/diagnostic-derive.rs:585:3
    |
 LL | #[error(no_crate_example, code = E0123)]
    |   ^^^^^
@@ -567,7 +567,7 @@ LL | struct ErrorAttribute {}
    |
 
 error: cannot find attribute `warn_` in this scope
-  --> $DIR/diagnostic-derive.rs:590:3
+  --> $DIR/diagnostic-derive.rs:592:3
    |
 LL | #[warn_(no_crate_example, code = E0123)]
    |   ^^^^^
@@ -579,7 +579,7 @@ LL + #[warn(no_crate_example, code = E0123)]
    |
 
 error: cannot find attribute `lint` in this scope
-  --> $DIR/diagnostic-derive.rs:597:3
+  --> $DIR/diagnostic-derive.rs:599:3
    |
 LL | #[lint(no_crate_example, code = E0123)]
    |   ^^^^
@@ -591,7 +591,7 @@ LL + #[link(no_crate_example, code = E0123)]
    |
 
 error: cannot find attribute `lint` in this scope
-  --> $DIR/diagnostic-derive.rs:604:3
+  --> $DIR/diagnostic-derive.rs:606:3
    |
 LL | #[lint(no_crate_example, code = E0123)]
    |   ^^^^
@@ -603,7 +603,7 @@ LL + #[link(no_crate_example, code = E0123)]
    |
 
 error: cannot find attribute `multipart_suggestion` in this scope
-  --> $DIR/diagnostic-derive.rs:644:3
+  --> $DIR/diagnostic-derive.rs:646:3
    |
 LL | #[multipart_suggestion(no_crate_suggestion)]
    |   ^^^^^^^^^^^^^^^^^^^^
@@ -615,7 +615,7 @@ LL | struct MultipartSuggestion {
    |
 
 error: cannot find attribute `multipart_suggestion` in this scope
-  --> $DIR/diagnostic-derive.rs:647:3
+  --> $DIR/diagnostic-derive.rs:649:3
    |
 LL | #[multipart_suggestion()]
    |   ^^^^^^^^^^^^^^^^^^^^
@@ -627,7 +627,7 @@ LL | struct MultipartSuggestion {
    |
 
 error: cannot find attribute `multipart_suggestion` in this scope
-  --> $DIR/diagnostic-derive.rs:651:7
+  --> $DIR/diagnostic-derive.rs:653:7
    |
 LL |     #[multipart_suggestion(no_crate_suggestion)]
    |       ^^^^^^^^^^^^^^^^^^^^
@@ -635,13 +635,13 @@ LL |     #[multipart_suggestion(no_crate_suggestion)]
    = note: `multipart_suggestion` is an attribute that can be used by the derive macro `Subdiagnostic`, you might be missing a `derive` attribute
 
 error[E0425]: cannot find value `nonsense` in module `crate::fluent_generated`
-  --> $DIR/diagnostic-derive.rs:75:8
+  --> $DIR/diagnostic-derive.rs:77:8
    |
 LL | #[diag(nonsense, code = E0123)]
    |        ^^^^^^^^ not found in `crate::fluent_generated`
 
 error[E0425]: cannot find value `__code_34` in this scope
-  --> $DIR/diagnostic-derive.rs:808:10
+  --> $DIR/diagnostic-derive.rs:810:10
    |
 LL | #[derive(Diagnostic)]
    |          ^^^^^^^^^^ not found in this scope
@@ -649,7 +649,7 @@ LL | #[derive(Diagnostic)]
    = note: this error originates in the derive macro `Diagnostic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Hello: IntoDiagArg` is not satisfied
-  --> $DIR/diagnostic-derive.rs:349:12
+  --> $DIR/diagnostic-derive.rs:351:12
    |
 LL | #[derive(Diagnostic)]
    |          ---------- required by a bound introduced by this call
@@ -658,7 +658,7 @@ LL |     other: Hello,
    |            ^^^^^ unsatisfied trait bound
    |
 help: the nightly-only, unstable trait `IntoDiagArg` is not implemented for `Hello`
-  --> $DIR/diagnostic-derive.rs:40:1
+  --> $DIR/diagnostic-derive.rs:42:1
    |
 LL | struct Hello {}
    | ^^^^^^^^^^^^
@@ -672,5 +672,5 @@ note: required by a bound in `Diag::<'a, G>::arg`
 
 error: aborting due to 85 previous errors
 
-Some errors have detailed explanations: E0277, E0425, E0433.
+Some errors have detailed explanations: E0277, E0425.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui-fulldeps/session-diagnostic/subdiagnostic-derive-2.rs
+++ b/tests/ui-fulldeps/session-diagnostic/subdiagnostic-derive-2.rs
@@ -1,0 +1,37 @@
+//@ check-fail
+// Tests error conditions for specifying subdiagnostics using #[derive(Subdiagnostic)].
+// This test is split off from the main `subdiagnostic-derive`,
+// because this error is generated post-expansion.
+
+// The proc_macro2 crate handles spans differently when on beta/stable release rather than nightly,
+// changing the output of this test. Since Subdiagnostic is strictly internal to the compiler
+// the test is just ignored on stable and beta:
+//@ ignore-stage1
+//@ ignore-beta
+//@ ignore-stable
+
+#![feature(rustc_private)]
+#![crate_type = "lib"]
+
+extern crate rustc_errors;
+extern crate rustc_fluent_macro;
+extern crate rustc_macros;
+extern crate rustc_session;
+extern crate rustc_span;
+extern crate core;
+
+use rustc_errors::{Applicability, DiagMessage, SubdiagMessage};
+use rustc_macros::Subdiagnostic;
+use rustc_span::Span;
+
+rustc_fluent_macro::fluent_messages! { "./example.ftl" }
+
+#[derive(Subdiagnostic)]
+#[label(slug)]
+//~^ ERROR cannot find value `slug` in module `crate::fluent_generated`
+//~^^ NOTE not found in `crate::fluent_generated`
+struct L {
+    #[primary_span]
+    span: Span,
+    var: String,
+}

--- a/tests/ui-fulldeps/session-diagnostic/subdiagnostic-derive-2.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/subdiagnostic-derive-2.stderr
@@ -1,0 +1,9 @@
+error[E0425]: cannot find value `slug` in module `crate::fluent_generated`
+  --> $DIR/subdiagnostic-derive-2.rs:30:9
+   |
+LL | #[label(slug)]
+   |         ^^^^ not found in `crate::fluent_generated`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui-fulldeps/session-diagnostic/subdiagnostic-derive.rs
+++ b/tests/ui-fulldeps/session-diagnostic/subdiagnostic-derive.rs
@@ -123,16 +123,6 @@ struct K {
 }
 
 #[derive(Subdiagnostic)]
-#[label(slug)]
-//~^ ERROR cannot find value `slug` in module `crate::fluent_generated`
-//~^^ NOTE not found in `crate::fluent_generated`
-struct L {
-    #[primary_span]
-    span: Span,
-    var: String,
-}
-
-#[derive(Subdiagnostic)]
 #[label()]
 //~^ ERROR diagnostic slug must be first argument of a `#[label(...)]` attribute
 struct M {
@@ -707,9 +697,6 @@ struct BP {
 }
 
 #[derive(Subdiagnostic)]
-//~^ ERROR cannot find value `__code_29` in this scope
-//~| NOTE in this expansion
-//~| NOTE not found in this scope
 #[multipart_suggestion(no_crate_example)]
 struct BQ {
     #[suggestion_part(code = 3)]

--- a/tests/ui-fulldeps/session-diagnostic/subdiagnostic-derive.rs
+++ b/tests/ui-fulldeps/session-diagnostic/subdiagnostic-derive.rs
@@ -16,6 +16,7 @@ extern crate rustc_fluent_macro;
 extern crate rustc_macros;
 extern crate rustc_session;
 extern crate rustc_span;
+extern crate core;
 
 use rustc_errors::{Applicability, DiagMessage, SubdiagMessage};
 use rustc_macros::Subdiagnostic;
@@ -94,8 +95,7 @@ struct G {
 
 #[derive(Subdiagnostic)]
 #[label("...")]
-//~^ ERROR failed to resolve: you might be missing crate `core`
-//~| NOTE you might be missing crate `core`
+//~^ ERROR unexpected literal in nested attribute, expected ident
 struct H {
     #[primary_span]
     span: Span,
@@ -310,8 +310,7 @@ struct AB {
 
 #[derive(Subdiagnostic)]
 union AC {
-    //~^ ERROR failed to resolve: you might be missing crate `core`
-    //~| NOTE you might be missing crate `core`
+    //~^ ERROR unexpected unsupported untagged union
     span: u32,
     b: u64,
 }
@@ -581,8 +580,7 @@ struct BD {
     span2: Span,
     #[suggestion_part(foo = "bar")]
     //~^ ERROR `code` is the only valid nested attribute
-    //~| ERROR failed to resolve: you might be missing crate `core`
-    //~| NOTE you might be missing crate `core`
+    //~| ERROR expected `,`
     span4: Span,
     #[suggestion_part(code = "...")]
     //~^ ERROR the `#[suggestion_part(...)]` attribute can only be applied to fields of type `Span` or `MultiSpan`
@@ -674,8 +672,7 @@ enum BL {
 struct BM {
     #[suggestion_part(code("foo"))]
     //~^ ERROR expected exactly one string literal for `code = ...`
-    //~| ERROR failed to resolve: you might be missing crate `core`
-    //~| NOTE you might be missing crate `core`
+    //~| ERROR unexpected token, expected `)`
     span: Span,
     r#type: String,
 }
@@ -685,8 +682,7 @@ struct BM {
 struct BN {
     #[suggestion_part(code("foo", "bar"))]
     //~^ ERROR expected exactly one string literal for `code = ...`
-    //~| ERROR failed to resolve: you might be missing crate `core`
-    //~| NOTE you might be missing crate `core`
+    //~| ERROR unexpected token, expected `)`
     span: Span,
     r#type: String,
 }
@@ -696,8 +692,7 @@ struct BN {
 struct BO {
     #[suggestion_part(code(3))]
     //~^ ERROR expected exactly one string literal for `code = ...`
-    //~| ERROR failed to resolve: you might be missing crate `core`
-    //~| NOTE you might be missing crate `core`
+    //~| ERROR unexpected token, expected `)`
     span: Span,
     r#type: String,
 }
@@ -718,8 +713,7 @@ struct BP {
 #[multipart_suggestion(no_crate_example)]
 struct BQ {
     #[suggestion_part(code = 3)]
-    //~^ ERROR failed to resolve: you might be missing crate `core`
-    //~| NOTE you might be missing crate `core`
+    //~^ ERROR expected string literal
     span: Span,
     r#type: String,
 }
@@ -811,8 +805,7 @@ struct SuggestionStyleInvalid3 {
 #[derive(Subdiagnostic)]
 #[suggestion(no_crate_example, code = "", style("foo"))]
 //~^ ERROR expected `= "xxx"`
-//~| ERROR failed to resolve: you might be missing crate `core`
-//~| NOTE you might be missing crate `core`
+//~| ERROR expected `,`
 struct SuggestionStyleInvalid4 {
     #[primary_span]
     sub: Span,

--- a/tests/ui-fulldeps/session-diagnostic/subdiagnostic-derive.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/subdiagnostic-derive.stderr
@@ -1,38 +1,44 @@
 error: derive(Diagnostic): label without `#[primary_span]` field
-  --> $DIR/subdiagnostic-derive.rs:51:1
+  --> $DIR/subdiagnostic-derive.rs:52:1
    |
 LL | #[label(no_crate_example)]
    | ^
 
 error: derive(Diagnostic): diagnostic slug must be first argument of a `#[label(...)]` attribute
-  --> $DIR/subdiagnostic-derive.rs:58:1
+  --> $DIR/subdiagnostic-derive.rs:59:1
    |
 LL | #[label]
    | ^
 
 error: derive(Diagnostic): `#[foo]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive.rs:67:1
+  --> $DIR/subdiagnostic-derive.rs:68:1
    |
 LL | #[foo]
    | ^
 
 error: derive(Diagnostic): `#[label = ...]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive.rs:77:1
+  --> $DIR/subdiagnostic-derive.rs:78:1
    |
 LL | #[label = "..."]
    | ^
 
 error: derive(Diagnostic): only `no_span` is a valid nested attribute
-  --> $DIR/subdiagnostic-derive.rs:86:9
+  --> $DIR/subdiagnostic-derive.rs:87:9
    |
 LL | #[label(bug = "...")]
    |         ^^^
 
 error: derive(Diagnostic): diagnostic slug must be first argument of a `#[label(...)]` attribute
-  --> $DIR/subdiagnostic-derive.rs:86:1
+  --> $DIR/subdiagnostic-derive.rs:87:1
    |
 LL | #[label(bug = "...")]
    | ^
+
+error: unexpected literal in nested attribute, expected ident
+  --> $DIR/subdiagnostic-derive.rs:97:9
+   |
+LL | #[label("...")]
+   |         ^^^^^
 
 error: derive(Diagnostic): only `no_span` is a valid nested attribute
   --> $DIR/subdiagnostic-derive.rs:106:9
@@ -59,85 +65,85 @@ LL | #[label(slug("..."))]
    | ^
 
 error: derive(Diagnostic): diagnostic slug must be first argument of a `#[label(...)]` attribute
-  --> $DIR/subdiagnostic-derive.rs:136:1
+  --> $DIR/subdiagnostic-derive.rs:126:1
    |
 LL | #[label()]
    | ^
 
 error: derive(Diagnostic): only `no_span` is a valid nested attribute
-  --> $DIR/subdiagnostic-derive.rs:145:27
+  --> $DIR/subdiagnostic-derive.rs:135:27
    |
 LL | #[label(no_crate_example, code = "...")]
    |                           ^^^^
 
 error: derive(Diagnostic): only `no_span` is a valid nested attribute
-  --> $DIR/subdiagnostic-derive.rs:154:27
+  --> $DIR/subdiagnostic-derive.rs:144:27
    |
 LL | #[label(no_crate_example, applicability = "machine-applicable")]
    |                           ^^^^^^^^^^^^^
 
 error: derive(Diagnostic): unsupported type attribute for subdiagnostic enum
-  --> $DIR/subdiagnostic-derive.rs:163:1
+  --> $DIR/subdiagnostic-derive.rs:153:1
    |
 LL | #[foo]
    | ^
 
 error: derive(Diagnostic): `#[bar]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive.rs:177:5
+  --> $DIR/subdiagnostic-derive.rs:167:5
    |
 LL |     #[bar]
    |     ^
 
 error: derive(Diagnostic): `#[bar = ...]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive.rs:189:5
+  --> $DIR/subdiagnostic-derive.rs:179:5
    |
 LL |     #[bar = "..."]
    |     ^
 
 error: derive(Diagnostic): `#[bar = ...]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive.rs:201:5
+  --> $DIR/subdiagnostic-derive.rs:191:5
    |
 LL |     #[bar = 4]
    |     ^
 
 error: derive(Diagnostic): `#[bar(...)]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive.rs:213:5
+  --> $DIR/subdiagnostic-derive.rs:203:5
    |
 LL |     #[bar("...")]
    |     ^
 
 error: derive(Diagnostic): only `no_span` is a valid nested attribute
-  --> $DIR/subdiagnostic-derive.rs:225:13
+  --> $DIR/subdiagnostic-derive.rs:215:13
    |
 LL |     #[label(code = "...")]
    |             ^^^^
 
 error: derive(Diagnostic): diagnostic slug must be first argument of a `#[label(...)]` attribute
-  --> $DIR/subdiagnostic-derive.rs:225:5
+  --> $DIR/subdiagnostic-derive.rs:215:5
    |
 LL |     #[label(code = "...")]
    |     ^
 
 error: derive(Diagnostic): the `#[primary_span]` attribute can only be applied to fields of type `Span` or `MultiSpan`
-  --> $DIR/subdiagnostic-derive.rs:254:5
+  --> $DIR/subdiagnostic-derive.rs:244:5
    |
 LL |     #[primary_span]
    |     ^
 
 error: derive(Diagnostic): label without `#[primary_span]` field
-  --> $DIR/subdiagnostic-derive.rs:251:1
+  --> $DIR/subdiagnostic-derive.rs:241:1
    |
 LL | #[label(no_crate_example)]
    | ^
 
 error: derive(Diagnostic): `#[applicability]` is only valid on suggestions
-  --> $DIR/subdiagnostic-derive.rs:264:5
+  --> $DIR/subdiagnostic-derive.rs:254:5
    |
 LL |     #[applicability]
    |     ^
 
 error: derive(Diagnostic): `#[bar]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive.rs:274:5
+  --> $DIR/subdiagnostic-derive.rs:264:5
    |
 LL |     #[bar]
    |     ^
@@ -145,111 +151,121 @@ LL |     #[bar]
    = help: only `primary_span`, `applicability` and `skip_arg` are valid field attributes
 
 error: derive(Diagnostic): `#[bar = ...]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive.rs:285:5
+  --> $DIR/subdiagnostic-derive.rs:275:5
    |
 LL |     #[bar = "..."]
    |     ^
 
 error: derive(Diagnostic): `#[bar(...)]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive.rs:296:5
+  --> $DIR/subdiagnostic-derive.rs:286:5
    |
 LL |     #[bar("...")]
    |     ^
    |
    = help: only `primary_span`, `applicability` and `skip_arg` are valid field attributes
 
+error: unexpected unsupported untagged union
+  --> $DIR/subdiagnostic-derive.rs:302:1
+   |
+LL | / union AC {
+LL | |
+LL | |     span: u32,
+LL | |     b: u64,
+LL | | }
+   | |_^
+
 error: derive(Diagnostic): a diagnostic slug must be the first argument to the attribute
-  --> $DIR/subdiagnostic-derive.rs:328:44
+  --> $DIR/subdiagnostic-derive.rs:317:44
    |
 LL | #[label(no_crate_example, no_crate::example)]
    |                                            ^
 
 error: derive(Diagnostic): attribute specified multiple times
-  --> $DIR/subdiagnostic-derive.rs:341:5
+  --> $DIR/subdiagnostic-derive.rs:330:5
    |
 LL |     #[primary_span]
    |     ^
    |
 note: previously specified here
-  --> $DIR/subdiagnostic-derive.rs:338:5
+  --> $DIR/subdiagnostic-derive.rs:327:5
    |
 LL |     #[primary_span]
    |     ^
 
 error: derive(Diagnostic): subdiagnostic kind not specified
-  --> $DIR/subdiagnostic-derive.rs:347:8
+  --> $DIR/subdiagnostic-derive.rs:336:8
    |
 LL | struct AG {
    |        ^^
 
 error: derive(Diagnostic): attribute specified multiple times
-  --> $DIR/subdiagnostic-derive.rs:384:46
+  --> $DIR/subdiagnostic-derive.rs:373:46
    |
 LL | #[suggestion(no_crate_example, code = "...", code = "...")]
    |                                              ^^^^
    |
 note: previously specified here
-  --> $DIR/subdiagnostic-derive.rs:384:32
+  --> $DIR/subdiagnostic-derive.rs:373:32
    |
 LL | #[suggestion(no_crate_example, code = "...", code = "...")]
    |                                ^^^^
 
 error: derive(Diagnostic): attribute specified multiple times
-  --> $DIR/subdiagnostic-derive.rs:402:5
+  --> $DIR/subdiagnostic-derive.rs:391:5
    |
 LL |     #[applicability]
    |     ^
    |
 note: previously specified here
-  --> $DIR/subdiagnostic-derive.rs:399:5
+  --> $DIR/subdiagnostic-derive.rs:388:5
    |
 LL |     #[applicability]
    |     ^
 
 error: derive(Diagnostic): the `#[applicability]` attribute can only be applied to fields of type `Applicability`
-  --> $DIR/subdiagnostic-derive.rs:412:5
+  --> $DIR/subdiagnostic-derive.rs:401:5
    |
 LL |     #[applicability]
    |     ^
 
 error: derive(Diagnostic): suggestion without `code = "..."`
-  --> $DIR/subdiagnostic-derive.rs:425:1
+  --> $DIR/subdiagnostic-derive.rs:414:1
    |
 LL | #[suggestion(no_crate_example)]
    | ^
 
 error: derive(Diagnostic): invalid applicability
-  --> $DIR/subdiagnostic-derive.rs:435:62
+  --> $DIR/subdiagnostic-derive.rs:424:62
    |
 LL | #[suggestion(no_crate_example, code = "...", applicability = "foo")]
    |                                                              ^^^^^
 
 error: derive(Diagnostic): suggestion without `#[primary_span]` field
-  --> $DIR/subdiagnostic-derive.rs:453:1
+  --> $DIR/subdiagnostic-derive.rs:442:1
    |
 LL | #[suggestion(no_crate_example, code = "...")]
    | ^
 
 error: derive(Diagnostic): unsupported type attribute for subdiagnostic enum
-  --> $DIR/subdiagnostic-derive.rs:467:1
+  --> $DIR/subdiagnostic-derive.rs:456:1
    |
 LL | #[label]
    | ^
 
 error: derive(Diagnostic): `var` doesn't refer to a field on this type
-  --> $DIR/subdiagnostic-derive.rs:487:39
+  --> $DIR/subdiagnostic-derive.rs:476:39
    |
 LL | #[suggestion(no_crate_example, code = "{var}", applicability = "machine-applicable")]
    |                                       ^^^^^^^
 
 error: derive(Diagnostic): `var` doesn't refer to a field on this type
-  --> $DIR/subdiagnostic-derive.rs:506:43
+  --> $DIR/subdiagnostic-derive.rs:495:43
    |
 LL |     #[suggestion(no_crate_example, code = "{var}", applicability = "machine-applicable")]
    |                                           ^^^^^^^
 
 error: derive(Diagnostic): `#[suggestion_part]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive.rs:529:5
+  --> $DIR/subdiagnostic-derive.rs:518:5
    |
 LL |     #[suggestion_part]
    |     ^
@@ -257,7 +273,7 @@ LL |     #[suggestion_part]
    = help: `#[suggestion_part(...)]` is only valid in multipart suggestions, use `#[primary_span]` instead
 
 error: derive(Diagnostic): `#[suggestion_part(...)]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive.rs:532:5
+  --> $DIR/subdiagnostic-derive.rs:521:5
    |
 LL |     #[suggestion_part(code = "...")]
    |     ^
@@ -265,13 +281,13 @@ LL |     #[suggestion_part(code = "...")]
    = help: `#[suggestion_part(...)]` is only valid in multipart suggestions
 
 error: derive(Diagnostic): suggestion without `#[primary_span]` field
-  --> $DIR/subdiagnostic-derive.rs:526:1
+  --> $DIR/subdiagnostic-derive.rs:515:1
    |
 LL | #[suggestion(no_crate_example, code = "...")]
    | ^
 
 error: derive(Diagnostic): invalid nested attribute
-  --> $DIR/subdiagnostic-derive.rs:541:42
+  --> $DIR/subdiagnostic-derive.rs:530:42
    |
 LL | #[multipart_suggestion(no_crate_example, code = "...", applicability = "machine-applicable")]
    |                                          ^^^^
@@ -279,25 +295,25 @@ LL | #[multipart_suggestion(no_crate_example, code = "...", applicability = "mac
    = help: only `no_span`, `style` and `applicability` are valid nested attributes
 
 error: derive(Diagnostic): multipart suggestion without any `#[suggestion_part(...)]` fields
-  --> $DIR/subdiagnostic-derive.rs:541:1
+  --> $DIR/subdiagnostic-derive.rs:530:1
    |
 LL | #[multipart_suggestion(no_crate_example, code = "...", applicability = "machine-applicable")]
    | ^
 
 error: derive(Diagnostic): `#[suggestion_part(...)]` attribute without `code = "..."`
-  --> $DIR/subdiagnostic-derive.rs:551:5
+  --> $DIR/subdiagnostic-derive.rs:540:5
    |
 LL |     #[suggestion_part]
    |     ^
 
 error: derive(Diagnostic): `#[suggestion_part(...)]` attribute without `code = "..."`
-  --> $DIR/subdiagnostic-derive.rs:559:5
+  --> $DIR/subdiagnostic-derive.rs:548:5
    |
 LL |     #[suggestion_part()]
    |     ^
 
 error: derive(Diagnostic): `#[primary_span]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive.rs:568:5
+  --> $DIR/subdiagnostic-derive.rs:557:5
    |
 LL |     #[primary_span]
    |     ^
@@ -305,97 +321,127 @@ LL |     #[primary_span]
    = help: multipart suggestions use one or more `#[suggestion_part]`s rather than one `#[primary_span]`
 
 error: derive(Diagnostic): multipart suggestion without any `#[suggestion_part(...)]` fields
-  --> $DIR/subdiagnostic-derive.rs:565:1
+  --> $DIR/subdiagnostic-derive.rs:554:1
    |
 LL | #[multipart_suggestion(no_crate_example)]
    | ^
 
 error: derive(Diagnostic): `#[suggestion_part(...)]` attribute without `code = "..."`
-  --> $DIR/subdiagnostic-derive.rs:576:5
+  --> $DIR/subdiagnostic-derive.rs:565:5
    |
 LL |     #[suggestion_part]
    |     ^
 
 error: derive(Diagnostic): `#[suggestion_part(...)]` attribute without `code = "..."`
-  --> $DIR/subdiagnostic-derive.rs:579:5
+  --> $DIR/subdiagnostic-derive.rs:568:5
    |
 LL |     #[suggestion_part()]
    |     ^
 
 error: derive(Diagnostic): `code` is the only valid nested attribute
-  --> $DIR/subdiagnostic-derive.rs:582:23
+  --> $DIR/subdiagnostic-derive.rs:571:23
    |
 LL |     #[suggestion_part(foo = "bar")]
    |                       ^^^
 
 error: derive(Diagnostic): the `#[suggestion_part(...)]` attribute can only be applied to fields of type `Span` or `MultiSpan`
-  --> $DIR/subdiagnostic-derive.rs:587:5
+  --> $DIR/subdiagnostic-derive.rs:575:5
    |
 LL |     #[suggestion_part(code = "...")]
    |     ^
 
 error: derive(Diagnostic): the `#[suggestion_part(...)]` attribute can only be applied to fields of type `Span` or `MultiSpan`
-  --> $DIR/subdiagnostic-derive.rs:590:5
+  --> $DIR/subdiagnostic-derive.rs:578:5
    |
 LL |     #[suggestion_part()]
    |     ^
 
+error: expected `,`
+  --> $DIR/subdiagnostic-derive.rs:571:27
+   |
+LL |     #[suggestion_part(foo = "bar")]
+   |                           ^
+
 error: derive(Diagnostic): attribute specified multiple times
-  --> $DIR/subdiagnostic-derive.rs:598:37
+  --> $DIR/subdiagnostic-derive.rs:586:37
    |
 LL |     #[suggestion_part(code = "...", code = ",,,")]
    |                                     ^^^^
    |
 note: previously specified here
-  --> $DIR/subdiagnostic-derive.rs:598:23
+  --> $DIR/subdiagnostic-derive.rs:586:23
    |
 LL |     #[suggestion_part(code = "...", code = ",,,")]
    |                       ^^^^
 
 error: derive(Diagnostic): `#[applicability]` has no effect if all `#[suggestion]`/`#[multipart_suggestion]` attributes have a static `applicability = "..."`
-  --> $DIR/subdiagnostic-derive.rs:627:5
+  --> $DIR/subdiagnostic-derive.rs:615:5
    |
 LL |     #[applicability]
    |     ^
 
 error: derive(Diagnostic): expected exactly one string literal for `code = ...`
-  --> $DIR/subdiagnostic-derive.rs:675:34
+  --> $DIR/subdiagnostic-derive.rs:663:34
    |
 LL |     #[suggestion_part(code("foo"))]
    |                                  ^
 
+error: unexpected token, expected `)`
+  --> $DIR/subdiagnostic-derive.rs:663:28
+   |
+LL |     #[suggestion_part(code("foo"))]
+   |                            ^^^^^
+
 error: derive(Diagnostic): expected exactly one string literal for `code = ...`
-  --> $DIR/subdiagnostic-derive.rs:686:41
+  --> $DIR/subdiagnostic-derive.rs:673:41
    |
 LL |     #[suggestion_part(code("foo", "bar"))]
    |                                         ^
 
+error: unexpected token, expected `)`
+  --> $DIR/subdiagnostic-derive.rs:673:28
+   |
+LL |     #[suggestion_part(code("foo", "bar"))]
+   |                            ^^^^^
+
 error: derive(Diagnostic): expected exactly one string literal for `code = ...`
-  --> $DIR/subdiagnostic-derive.rs:697:30
+  --> $DIR/subdiagnostic-derive.rs:683:30
    |
 LL |     #[suggestion_part(code(3))]
    |                              ^
 
+error: unexpected token, expected `)`
+  --> $DIR/subdiagnostic-derive.rs:683:28
+   |
+LL |     #[suggestion_part(code(3))]
+   |                            ^
+
 error: derive(Diagnostic): expected exactly one string literal for `code = ...`
-  --> $DIR/subdiagnostic-derive.rs:708:29
+  --> $DIR/subdiagnostic-derive.rs:693:29
    |
 LL |     #[suggestion_part(code())]
    |                             ^
 
+error: expected string literal
+  --> $DIR/subdiagnostic-derive.rs:702:30
+   |
+LL |     #[suggestion_part(code = 3)]
+   |                              ^
+
 error: derive(Diagnostic): attribute specified multiple times
-  --> $DIR/subdiagnostic-derive.rs:763:1
+  --> $DIR/subdiagnostic-derive.rs:744:1
    |
 LL | #[suggestion(no_crate_example, code = "", style = "hidden", style = "normal")]
    | ^
    |
 note: previously specified here
-  --> $DIR/subdiagnostic-derive.rs:763:1
+  --> $DIR/subdiagnostic-derive.rs:744:1
    |
 LL | #[suggestion(no_crate_example, code = "", style = "hidden", style = "normal")]
    | ^
 
 error: derive(Diagnostic): `#[suggestion_hidden(...)]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive.rs:772:1
+  --> $DIR/subdiagnostic-derive.rs:753:1
    |
 LL | #[suggestion_hidden(no_crate_example, code = "")]
    | ^
@@ -403,7 +449,7 @@ LL | #[suggestion_hidden(no_crate_example, code = "")]
    = help: Use `#[suggestion(..., style = "hidden")]` instead
 
 error: derive(Diagnostic): `#[suggestion_hidden(...)]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive.rs:780:1
+  --> $DIR/subdiagnostic-derive.rs:761:1
    |
 LL | #[suggestion_hidden(no_crate_example, code = "", style = "normal")]
    | ^
@@ -411,7 +457,7 @@ LL | #[suggestion_hidden(no_crate_example, code = "", style = "normal")]
    = help: Use `#[suggestion(..., style = "hidden")]` instead
 
 error: derive(Diagnostic): invalid suggestion style
-  --> $DIR/subdiagnostic-derive.rs:788:51
+  --> $DIR/subdiagnostic-derive.rs:769:51
    |
 LL | #[suggestion(no_crate_example, code = "", style = "foo")]
    |                                                   ^^^^^
@@ -419,25 +465,31 @@ LL | #[suggestion(no_crate_example, code = "", style = "foo")]
    = help: valid styles are `normal`, `short`, `hidden`, `verbose` and `tool-only`
 
 error: derive(Diagnostic): expected `= "xxx"`
-  --> $DIR/subdiagnostic-derive.rs:796:49
+  --> $DIR/subdiagnostic-derive.rs:777:49
    |
 LL | #[suggestion(no_crate_example, code = "", style = 42)]
    |                                                 ^
 
 error: derive(Diagnostic): a diagnostic slug must be the first argument to the attribute
-  --> $DIR/subdiagnostic-derive.rs:804:48
+  --> $DIR/subdiagnostic-derive.rs:785:48
    |
 LL | #[suggestion(no_crate_example, code = "", style)]
    |                                                ^
 
 error: derive(Diagnostic): expected `= "xxx"`
-  --> $DIR/subdiagnostic-derive.rs:812:48
+  --> $DIR/subdiagnostic-derive.rs:793:48
+   |
+LL | #[suggestion(no_crate_example, code = "", style("foo"))]
+   |                                                ^
+
+error: expected `,`
+  --> $DIR/subdiagnostic-derive.rs:793:48
    |
 LL | #[suggestion(no_crate_example, code = "", style("foo"))]
    |                                                ^
 
 error: derive(Diagnostic): `#[primary_span]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive.rs:825:5
+  --> $DIR/subdiagnostic-derive.rs:805:5
    |
 LL |     #[primary_span]
    |     ^
@@ -446,128 +498,64 @@ LL |     #[primary_span]
    = help: to create a suggestion with multiple spans, use `#[multipart_suggestion]` instead
 
 error: derive(Diagnostic): suggestion without `#[primary_span]` field
-  --> $DIR/subdiagnostic-derive.rs:822:1
+  --> $DIR/subdiagnostic-derive.rs:802:1
    |
 LL | #[suggestion(no_crate_example, code = "")]
    | ^
 
-error[E0433]: failed to resolve: you might be missing crate `core`
-  --> $DIR/subdiagnostic-derive.rs:96:9
-   |
-LL | #[label("...")]
-   |         ^^^^^ you might be missing crate `core`
-
-error[E0433]: failed to resolve: you might be missing crate `core`
-  --> $DIR/subdiagnostic-derive.rs:312:1
-   |
-LL | union AC {
-   | ^^^^^ you might be missing crate `core`
-
-error[E0433]: failed to resolve: you might be missing crate `core`
-  --> $DIR/subdiagnostic-derive.rs:582:27
-   |
-LL |     #[suggestion_part(foo = "bar")]
-   |                           ^ you might be missing crate `core`
-
-error[E0433]: failed to resolve: you might be missing crate `core`
-  --> $DIR/subdiagnostic-derive.rs:675:28
-   |
-LL |     #[suggestion_part(code("foo"))]
-   |                            ^^^^^ you might be missing crate `core`
-
-error[E0433]: failed to resolve: you might be missing crate `core`
-  --> $DIR/subdiagnostic-derive.rs:686:28
-   |
-LL |     #[suggestion_part(code("foo", "bar"))]
-   |                            ^^^^^ you might be missing crate `core`
-
-error[E0433]: failed to resolve: you might be missing crate `core`
-  --> $DIR/subdiagnostic-derive.rs:697:28
-   |
-LL |     #[suggestion_part(code(3))]
-   |                            ^ you might be missing crate `core`
-
-error[E0433]: failed to resolve: you might be missing crate `core`
-  --> $DIR/subdiagnostic-derive.rs:720:30
-   |
-LL |     #[suggestion_part(code = 3)]
-   |                              ^ you might be missing crate `core`
-
-error[E0433]: failed to resolve: you might be missing crate `core`
-  --> $DIR/subdiagnostic-derive.rs:812:48
-   |
-LL | #[suggestion(no_crate_example, code = "", style("foo"))]
-   |                                                ^ you might be missing crate `core`
-
 error: cannot find attribute `foo` in this scope
-  --> $DIR/subdiagnostic-derive.rs:67:3
+  --> $DIR/subdiagnostic-derive.rs:68:3
    |
 LL | #[foo]
    |   ^^^
 
 error: cannot find attribute `foo` in this scope
-  --> $DIR/subdiagnostic-derive.rs:163:3
+  --> $DIR/subdiagnostic-derive.rs:153:3
    |
 LL | #[foo]
    |   ^^^
 
 error: cannot find attribute `bar` in this scope
-  --> $DIR/subdiagnostic-derive.rs:177:7
+  --> $DIR/subdiagnostic-derive.rs:167:7
    |
 LL |     #[bar]
    |       ^^^
 
 error: cannot find attribute `bar` in this scope
-  --> $DIR/subdiagnostic-derive.rs:189:7
+  --> $DIR/subdiagnostic-derive.rs:179:7
    |
 LL |     #[bar = "..."]
    |       ^^^
 
 error: cannot find attribute `bar` in this scope
-  --> $DIR/subdiagnostic-derive.rs:201:7
+  --> $DIR/subdiagnostic-derive.rs:191:7
    |
 LL |     #[bar = 4]
    |       ^^^
 
 error: cannot find attribute `bar` in this scope
-  --> $DIR/subdiagnostic-derive.rs:213:7
+  --> $DIR/subdiagnostic-derive.rs:203:7
    |
 LL |     #[bar("...")]
    |       ^^^
 
 error: cannot find attribute `bar` in this scope
-  --> $DIR/subdiagnostic-derive.rs:274:7
+  --> $DIR/subdiagnostic-derive.rs:264:7
    |
 LL |     #[bar]
    |       ^^^
 
 error: cannot find attribute `bar` in this scope
-  --> $DIR/subdiagnostic-derive.rs:285:7
+  --> $DIR/subdiagnostic-derive.rs:275:7
    |
 LL |     #[bar = "..."]
    |       ^^^
 
 error: cannot find attribute `bar` in this scope
-  --> $DIR/subdiagnostic-derive.rs:296:7
+  --> $DIR/subdiagnostic-derive.rs:286:7
    |
 LL |     #[bar("...")]
    |       ^^^
 
-error[E0425]: cannot find value `slug` in module `crate::fluent_generated`
-  --> $DIR/subdiagnostic-derive.rs:126:9
-   |
-LL | #[label(slug)]
-   |         ^^^^ not found in `crate::fluent_generated`
+error: aborting due to 84 previous errors
 
-error[E0425]: cannot find value `__code_29` in this scope
-  --> $DIR/subdiagnostic-derive.rs:714:10
-   |
-LL | #[derive(Subdiagnostic)]
-   |          ^^^^^^^^^^^^^ not found in this scope
-   |
-   = note: this error originates in the derive macro `Subdiagnostic` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: aborting due to 86 previous errors
-
-Some errors have detailed explanations: E0425, E0433.
-For more information about an error, try `rustc --explain E0425`.


### PR DESCRIPTION
We do this to solve the `failed to resolve: you might be missing crate core` messages that were previously visible in the stderr.
We also split off `subdiagnostic-derive-2` from the main `subdiagnostic-derive`, because the error for this test is now generated post-expansion.