### PR TITLE
Use fewer intermediate functions for short backtraces in queries

### DIFF
--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -45,7 +45,7 @@ pub struct QueryVTable<'tcx, C: QueryCache> {
     pub query_cache: usize,
     pub will_cache_on_disk_for_key_fn: Option<WillCacheOnDiskForKeyFn<'tcx, C::Key>>,
     pub execute_query: fn(tcx: TyCtxt<'tcx>, k: C::Key) -> C::Value,
-    pub compute: fn(tcx: TyCtxt<'tcx>, key: C::Key) -> C::Value,
+    pub compute_fn: fn(tcx: TyCtxt<'tcx>, key: C::Key) -> C::Value,
     pub try_load_from_disk_fn: Option<TryLoadFromDiskFn<'tcx, C::Key, C::Value>>,
     pub is_loadable_from_disk_fn: Option<IsLoadableFromDiskFn<'tcx, C::Key>>,
     pub hash_result: HashResult<C::Value>,

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -29,7 +29,7 @@ use rustc_query_system::query::{
 };
 use rustc_span::{ErrorGuaranteed, Span};
 
-use crate::plumbing::{__rust_begin_short_backtrace, encode_all_query_results, try_mark_green};
+use crate::plumbing::{encode_all_query_results, try_mark_green};
 use crate::profiling_support::QueryKeyStringCache;
 
 #[macro_use]
@@ -123,7 +123,7 @@ where
 
     #[inline(always)]
     fn compute(self, qcx: QueryCtxt<'tcx>, key: Self::Key) -> Self::Value {
-        (self.vtable.compute)(qcx.tcx, key)
+        (self.vtable.compute_fn)(qcx.tcx, key)
     }
 
     #[inline(always)]

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -566,18 +566,6 @@ macro_rules! expand_if_cached {
     };
 }
 
-/// Don't show the backtrace for query system by default
-/// use `RUST_BACKTRACE=full` to show all the backtraces
-#[inline(never)]
-pub(crate) fn __rust_begin_short_backtrace<F, T>(f: F) -> T
-where
-    F: FnOnce() -> T,
-{
-    let result = f();
-    std::hint::black_box(());
-    result
-}
-
 // NOTE: `$V` isn't used here, but we still need to match on it so it can be passed to other macros
 // invoked by `rustc_with_all_queries`.
 macro_rules! define_queries {
@@ -636,6 +624,32 @@ macro_rules! define_queries {
                 }
             }
 
+            /// Defines a `compute` function for this query, to be used as a
+            /// function pointer in the query's vtable.
+            mod compute_fn {
+                use super::*;
+                use ::rustc_middle::queries::$name::{Key, Value, provided_to_erased};
+
+                /// This function would be named `compute`, but we also want it
+                /// to mark the boundaries of an omitted region in backtraces.
+                #[inline(never)]
+                pub(crate) fn __rust_begin_short_backtrace<'tcx>(
+                    tcx: TyCtxt<'tcx>,
+                    key: Key<'tcx>,
+                ) -> Erased<Value<'tcx>> {
+                    #[cfg(debug_assertions)]
+                    let _guard = tracing::span!(tracing::Level::TRACE, stringify!($name), ?key).entered();
+
+                    // Call the actual provider function for this query.
+                    let provided_value = call_provider!([$($modifiers)*][tcx, $name, key]);
+                    rustc_middle::ty::print::with_reduced_queries!({
+                        tracing::trace!(?provided_value);
+                    });
+
+                    provided_to_erased(tcx, provided_value)
+                }
+            }
+
             pub(crate) fn make_query_vtable<'tcx>()
                 -> QueryVTable<'tcx, queries::$name::Storage<'tcx>>
             {
@@ -652,22 +666,7 @@ macro_rules! define_queries {
                         None
                     }),
                     execute_query: |tcx, key| erase::erase_val(tcx.$name(key)),
-                    compute: |tcx, key| {
-                        #[cfg(debug_assertions)]
-                        let _guard = tracing::span!(tracing::Level::TRACE, stringify!($name), ?key).entered();
-                        __rust_begin_short_backtrace(||
-                            queries::$name::provided_to_erased(
-                                tcx,
-                                {
-                                    let ret = call_provider!([$($modifiers)*][tcx, $name, key]);
-                                    rustc_middle::ty::print::with_reduced_queries!({
-                                        tracing::trace!(?ret);
-                                    });
-                                    ret
-                                }
-                            )
-                        )
-                    },
+                    compute_fn: self::compute_fn::__rust_begin_short_backtrace,
                     try_load_from_disk_fn: should_ever_cache_on_disk!([$($modifiers)*] {
                         Some(|tcx, key, prev_index, index| {
                             // Check the `cache_on_disk_if` condition for this key.

--- a/src/tools/run-make-support/src/lib.rs
+++ b/src/tools/run-make-support/src/lib.rs
@@ -47,6 +47,7 @@ pub use crate::assertion_helpers::{
     assert_contains, assert_contains_regex, assert_count_is, assert_dirs_are_equal, assert_equals,
     assert_not_contains, assert_not_contains_regex,
 };
+pub use crate::command::CompletedProcess;
 // `diff` is implemented in terms of the [similar] library.
 //
 // [similar]: https://github.com/mitsuhiko/similar


### PR DESCRIPTION
If we make sure that `compute_fn` in the query's vtable is actually named `__rust_begin_short_backtrace`, we can avoid the need for some additional intermediate functions and stack frames.

This is similar to how the `get_query_incr` and `get_query_non_incr` functions are actually named `__rust_end_short_backtrace`.

---

Before/after comparison: https://github.com/rust-lang/rust/pull/151739#issuecomment-3815432527

---

- Earlier draft of this PR: https://github.com/rust-lang/rust/pull/151719
- Introduction of this backtrace-trimming: https://github.com/rust-lang/rust/pull/108938