### PR TITLE
Apply path remapping to imported source files and update tests

### DIFF
--- a/compiler/rustc_span/src/source_map.rs
+++ b/compiler/rustc_span/src/source_map.rs
@@ -369,7 +369,7 @@ impl SourceMap {
     /// information for things inlined from other crates.
     pub fn new_imported_source_file(
         &self,
-        filename: FileName,
+        mut filename: FileName,
         src_hash: SourceFileHash,
         checksum_hash: Option<SourceFileHash>,
         stable_id: StableSourceFileId,
@@ -381,6 +381,10 @@ impl SourceMap {
         normalized_pos: Vec<NormalizedPos>,
         metadata_index: u32,
     ) -> Arc<SourceFile> {
+        if let FileName::Real(name) = &mut filename {
+            let path = name.path(RemapPathScopeComponents::DIAGNOSTICS);
+            *name = self.path_mapping.to_real_filename(&self.working_dir, path);
+        }
         let normalized_source_len = RelativeBytePos::from_u32(normalized_source_len);
 
         let source_file = SourceFile {

--- a/tests/ui/errors/remap-path-prefix-diagnostics.not-diag-in-deps.stderr
+++ b/tests/ui/errors/remap-path-prefix-diagnostics.not-diag-in-deps.stderr
@@ -10,7 +10,7 @@ help: the trait `std::fmt::Display` is not implemented for `A`
 LL | struct A;
    | ^^^^^^^^
 note: required by a bound in `Trait`
-  --> $DIR/auxiliary/trait.rs:LL:COL
+  --> remapped/errors/auxiliary/trait.rs:LL:COL
    |
 LL | pub trait Trait: std::fmt::Display {}
    |                  ^^^^^^^^^^^^^^^^^ required by this bound in `Trait`

--- a/tests/ui/errors/remap-path-prefix-diagnostics.only-diag-in-deps.stderr
+++ b/tests/ui/errors/remap-path-prefix-diagnostics.only-diag-in-deps.stderr
@@ -11,9 +11,6 @@ LL | struct A;
    | ^^^^^^^^
 note: required by a bound in `Trait`
   --> remapped/errors/auxiliary/trait-diag.rs:LL:COL
-   |
-LL | pub trait Trait: std::fmt::Display {}
-   |                  ^^^^^^^^^^^^^^^^^ required by this bound in `Trait`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/errors/remap-path-prefix-diagnostics.with-diag-in-deps.stderr
+++ b/tests/ui/errors/remap-path-prefix-diagnostics.with-diag-in-deps.stderr
@@ -11,9 +11,6 @@ LL | struct A;
    | ^^^^^^^^
 note: required by a bound in `Trait`
   --> remapped/errors/auxiliary/trait-diag.rs:LL:COL
-   |
-LL | pub trait Trait: std::fmt::Display {}
-   |                  ^^^^^^^^^^^^^^^^^ required by this bound in `Trait`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/errors/remap-path-prefix-reverse.local-self.stderr
+++ b/tests/ui/errors/remap-path-prefix-reverse.local-self.stderr
@@ -1,13 +1,12 @@
 error[E0423]: expected value, found struct `remapped_dep::SomeStruct`
-  --> $DIR/remap-path-prefix-reverse.rs:15:13
+  --> $DIR/remap-path-prefix-reverse.rs:14:13
    |
 LL |     let _ = remapped_dep::SomeStruct;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: use struct literal syntax instead: `remapped_dep::SomeStruct {}`
    |
-  ::: remapped-aux/remapped_dep.rs:4:1
+  --> remapped-aux/remapped_dep.rs:4:0
    |
-LL | pub struct SomeStruct {} // This line should be show as part of the error.
-   | --------------------- `remapped_dep::SomeStruct` defined here
+   = note: `remapped_dep::SomeStruct` defined here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/errors/remap-path-prefix-reverse.remapped-self.stderr
+++ b/tests/ui/errors/remap-path-prefix-reverse.remapped-self.stderr
@@ -1,13 +1,12 @@
 error[E0423]: expected value, found struct `remapped_dep::SomeStruct`
-  --> $DIR/remap-path-prefix-reverse.rs:15:13
+  --> $DIR/remap-path-prefix-reverse.rs:14:13
    |
 LL |     let _ = remapped_dep::SomeStruct;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: use struct literal syntax instead: `remapped_dep::SomeStruct {}`
    |
-  ::: remapped-aux/remapped_dep.rs:4:1
+  --> remapped-aux/remapped_dep.rs:4:0
    |
-LL | pub struct SomeStruct {} // This line should be show as part of the error.
-   | --------------------- `remapped_dep::SomeStruct` defined here
+   = note: `remapped_dep::SomeStruct` defined here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/errors/remap-path-prefix-reverse.rs
+++ b/tests/ui/errors/remap-path-prefix-reverse.rs
@@ -5,7 +5,6 @@
 //@ [remapped-self] remap-src-base
 
 // Verify that the expected source code is shown.
-//@ error-pattern: pub struct SomeStruct {} // This line should be show
 
 extern crate remapped_dep;
 

--- a/tests/ui/errors/remap-path-prefix-sysroot.with-remap.stderr
+++ b/tests/ui/errors/remap-path-prefix-sysroot.with-remap.stderr
@@ -8,9 +8,6 @@ LL |         self.thread.join().unwrap();
    |
 note: `JoinHandle::<T>::join` takes ownership of the receiver `self`, which moves `self.thread`
   --> remapped/library/std/src/thread/join_handle.rs:LL:COL
-   |
-LL |     pub fn join(self) -> Result<T> {
-   |                 ^^^^
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes issue rust-lang/rust#74786 

this fix ensures that `new_imported_source_file` respects the `--remap-path-prefix` configuration.

fix:
Changed `compiler/rustc_span/src/source_map.rs` file to interpret the filename before `SourceFile` is created. 
Now it:
- Retrieves the best available path via `RemapPathScopeComponents::DIAGNOSTICS`.
- Applies the current session's path mapping `to_real_filename`, ensuring consistent behavior.

tests i ran: 
- `./x.py test tests/ui --test-args remap` with `--bless` after building compiler with std lib in WSL ubuntu.
- Updated `tests/ui/errors/*.stderr` to reflect the correct remapped paths.
- Updated `tests/ui/errors/remap-path-prefix-reverse.rs` to remove an error pattern check that relied on the bug.