### PR TITLE
fix refining_impl_trait suggestion with return_type_notation

### DIFF
--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1122,7 +1122,7 @@ pub(crate) struct UnusedAssociatedTypeBounds {
 #[note(
     "we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information"
 )]
-pub(crate) struct ReturnPositionImplTraitInTraitRefined<'tcx> {
+pub(crate) struct ReturnPositionImplTraitInTraitRefined {
     #[suggestion(
         "replace the return type so that it matches the trait",
         applicability = "maybe-incorrect",
@@ -1136,7 +1136,7 @@ pub(crate) struct ReturnPositionImplTraitInTraitRefined<'tcx> {
 
     pub pre: &'static str,
     pub post: &'static str,
-    pub return_ty: Ty<'tcx>,
+    pub return_ty: String,
 }
 
 #[derive(LintDiagnostic)]

--- a/tests/ui/async-await/in-trait/async-example-desugared-boxed.stderr
+++ b/tests/ui/async-await/in-trait/async-example-desugared-boxed.stderr
@@ -18,7 +18,7 @@ LL |     #[warn(refining_impl_trait)]
 help: replace the return type so that it matches the trait
    |
 LL -     fn foo(&self) -> Pin<Box<dyn Future<Output = i32> + '_>> {
-LL +     fn foo(&self) -> impl Future<Output = i32> {
+LL +     fn foo(&self) -> impl std::future::Future<Output = i32> {
    |
 
 warning: 1 warning emitted

--- a/tests/ui/async-await/in-trait/async-example-desugared-manual.stderr
+++ b/tests/ui/async-await/in-trait/async-example-desugared-manual.stderr
@@ -18,7 +18,7 @@ LL |     #[warn(refining_impl_trait)]
 help: replace the return type so that it matches the trait
    |
 LL -     fn foo(&self) -> MyFuture {
-LL +     fn foo(&self) -> impl Future<Output = i32> {
+LL +     fn foo(&self) -> impl std::future::Future<Output = i32> {
    |
 
 warning: 1 warning emitted

--- a/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.stderr
+++ b/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.stderr
@@ -29,7 +29,7 @@ LL |     fn iter(&self) -> impl 'a + Iterator<Item = I::Item<'a>> {
 help: replace the return type so that it matches the trait
    |
 LL -     fn iter(&self) -> impl 'a + Iterator<Item = I::Item<'a>> {
-LL +     fn iter(&self) -> impl Iterator<Item = <Self as Iterable>::Item<'_>> + '_ {
+LL +     fn iter(&self) -> impl std::iter::Iterator<Item = <Self as Iterable>::Item<'_>> + '_ {
    |
 
 error: aborting due to 1 previous error; 1 warning emitted

--- a/tests/ui/impl-trait/in-trait/expeced-refree-to-map-to-reearlybound-ice-108580.stderr
+++ b/tests/ui/impl-trait/in-trait/expeced-refree-to-map-to-reearlybound-ice-108580.stderr
@@ -12,8 +12,9 @@ LL |     fn bar(&self) -> impl Iterator + '_ {
    = note: `#[warn(refining_impl_trait_internal)]` (part of `#[warn(refining_impl_trait)]`) on by default
 help: replace the return type so that it matches the trait
    |
-LL |     fn bar(&self) -> impl Iterator<Item = impl Sized> + '_ {
-   |                                   +++++++++++++++++++
+LL -     fn bar(&self) -> impl Iterator + '_ {
+LL +     fn bar(&self) -> impl std::iter::Iterator<Item = impl Sized> + '_ {
+   |
 
 warning: 1 warning emitted
 

--- a/tests/ui/impl-trait/in-trait/foreign.stderr
+++ b/tests/ui/impl-trait/in-trait/foreign.stderr
@@ -15,7 +15,7 @@ LL |     #[warn(refining_impl_trait)]
 help: replace the return type so that it matches the trait
    |
 LL -     fn bar(self) -> Arc<String> {
-LL +     fn bar(self) -> impl Deref<Target = impl Sized> {
+LL +     fn bar(self) -> impl std::ops::Deref<Target = impl Sized> {
    |
 
 warning: impl trait in impl method signature does not match trait method signature
@@ -34,7 +34,7 @@ LL |     #[warn(refining_impl_trait)]
 help: replace the return type so that it matches the trait
    |
 LL -     fn bar(self) -> Arc<String> {
-LL +     fn bar(self) -> impl Deref<Target = impl Sized> {
+LL +     fn bar(self) -> impl std::ops::Deref<Target = impl Sized> {
    |
 
 warning: 2 warnings emitted

--- a/tests/ui/impl-trait/in-trait/refine-return-type-notation.rs
+++ b/tests/ui/impl-trait/in-trait/refine-return-type-notation.rs
@@ -1,0 +1,13 @@
+#![feature(return_type_notation)]
+#![deny(refining_impl_trait)]
+
+trait Trait {
+    fn f() -> impl Sized;
+}
+
+impl Trait for () {
+    fn f() {}
+    //~^ ERROR impl trait in impl method signature does not match trait method signature
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/refine-return-type-notation.stderr
+++ b/tests/ui/impl-trait/in-trait/refine-return-type-notation.stderr
@@ -1,0 +1,24 @@
+error: impl trait in impl method signature does not match trait method signature
+  --> $DIR/refine-return-type-notation.rs:9:5
+   |
+LL |     fn f() -> impl Sized;
+   |               ---------- return type from trait method defined here
+...
+LL |     fn f() {}
+   |     ^^^^^^
+   |
+   = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
+   = note: we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
+note: the lint level is defined here
+  --> $DIR/refine-return-type-notation.rs:2:9
+   |
+LL | #![deny(refining_impl_trait)]
+   |         ^^^^^^^^^^^^^^^^^^^
+   = note: `#[deny(refining_impl_trait_internal)]` implied by `#[deny(refining_impl_trait)]`
+help: replace the return type so that it matches the trait
+   |
+LL |     fn f()-> impl Sized  {}
+   |           +++++++++++++
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
using `#![feature(return_type_notation)] `on top of `refining_impl_trait` made the lint suggest a pretty wild “wrap the body in `<Self as Trait>::f(..)”` fix instead of the simple “just copy the return type from the trait”. this patch makes the lint always suggest the plain return-type replacement based on the trait signature (by grabbing the original snippet when possible), so you don’t get RTN-style desugarings in the help

new test here 

fixes rust-lang/rust#151663