### PR TITLE
Check proj's parent is trait or not when checking dyn compatibility

### DIFF
--- a/tests/ui/const-generics/mgca/type-const-used-in-trait.rs
+++ b/tests/ui/const-generics/mgca/type-const-used-in-trait.rs
@@ -1,0 +1,13 @@
+//@ check-pass
+
+#![feature(min_generic_const_args)]
+#![expect(incomplete_features)]
+
+#[type_const]
+const N: usize = 2;
+
+trait CollectArray<A> {
+    fn inner_array(&mut self) -> [A; N];
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/151708

When checking dyn compatibility, `proj` here may point to free const whose parent is not trait. Then `TraitRef::from_assoc` will call `generics_of` on the wrong parent.

After this change, the following case without `#[type_const]` will still emit ICE same to https://github.com/rust-lang/rust/issues/149066, but different to the ICE reported in https://github.com/rust-lang/rust/issues/151708
```rust
#![feature(min_generic_const_args)]

// #[type_const]
const N: usize = 2;

trait CollectArray {
    fn inner_array(&self) -> [i32; N];
}
```

r? @BoxyUwU 