### PR TITLE
Add FileCheck annotations to simplify_match.rs

### DIFF
--- a/tests/mir-opt/simplify_match.rs
+++ b/tests/mir-opt/simplify_match.rs
@@ -1,9 +1,15 @@
-// skip-filecheck
+//! Test that GVN propagates the constant `false` and eliminates the match.
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
+
 #[inline(never)]
 fn noop() {}
 
 // EMIT_MIR simplify_match.main.GVN.diff
+// CHECK-LABEL: fn main(
+// CHECK: debug x => const false;
+// CHECK-NOT: switchInt
+// CHECK: bb0: {
+// CHECK-NEXT: return;
 fn main() {
     match {
         let x = false;


### PR DESCRIPTION
Remove `skip-filecheck` and add FileCheck directives to verify that GVN propagates the constant `false` and eliminates the match entirely.

The test now verifies:
- The debug info shows `x` as `const false` (constant propagation)
- No `switchInt` remains (match elimination)
- The function body is just `return` (dead code elimination)

Part of rust-lang/rust#116971.

r? cjgillot