### PR TITLE
Fix `x fix`, again

### DIFF
--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -87,7 +87,7 @@ impl Step for Std {
             Mode::Std,
             SourceType::InTree,
             target,
-            Kind::Check,
+            builder.config.cmd.kind(),
         );
 
         std_cargo(builder, target, &mut cargo, &self.crates);
@@ -97,7 +97,7 @@ impl Step for Std {
         }
 
         let _guard = builder.msg(
-            Kind::Check,
+            builder.config.cmd.kind(),
             format_args!("library artifacts{}", crate_description(&self.crates)),
             Mode::Std,
             build_compiler,


### PR DESCRIPTION
This was refactored incorrectly at some point and would run `cargo check` even for `x fix`.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
