### PR TITLE
fix undefined behavior in VecDeque::splice

### DIFF
--- a/library/alloc/src/collections/vec_deque/splice.rs
+++ b/library/alloc/src/collections/vec_deque/splice.rs
@@ -143,7 +143,11 @@ impl<T, A: Allocator> Drain<'_, T, A> {
 
         let new_tail_start = tail_start + additional;
         unsafe {
-            deque.wrap_copy(tail_start, new_tail_start, self.tail_len);
+            deque.wrap_copy(
+                deque.to_physical_idx(tail_start),
+                deque.to_physical_idx(new_tail_start),
+                self.tail_len,
+            );
         }
         self.drain_len += additional;
     }

--- a/library/alloctests/tests/vec_deque.rs
+++ b/library/alloctests/tests/vec_deque.rs
@@ -2336,3 +2336,14 @@ fn test_splice_forget() {
     std::mem::forget(v.splice(2..4, a));
     assert_eq!(v, &[1, 2]);
 }
+
+#[test]
+fn test_splice_wrapping() {
+    let mut vec = VecDeque::with_capacity(10);
+    vec.push_front(7u8);
+    vec.push_back(9);
+
+    vec.splice(1..1, [8]);
+
+    assert_eq!(Vec::from(vec), [7, 8, 9]);
+}


### PR DESCRIPTION
closes rust-lang/rust#151758

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
