### PR TITLE
Fix: On wasm targets, call `panic_in_cleanup` if panic occurs in cleanup

### DIFF
--- a/compiler/rustc_codegen_gcc/src/builder.rs
+++ b/compiler/rustc_codegen_gcc/src/builder.rs
@@ -1653,6 +1653,10 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
         unimplemented!();
     }
 
+    fn get_funclet_cleanuppad(&self, _funclet: &Funclet) -> RValue<'gcc> {
+        unimplemented!();
+    }
+
     // Atomic Operations
     fn atomic_cmpxchg(
         &mut self,

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -1309,6 +1309,10 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         ret
     }
 
+    fn get_funclet_cleanuppad(&self, funclet: &Funclet<'ll>) -> &'ll Value {
+        funclet.cleanuppad()
+    }
+
     // Atomic Operations
     fn atomic_cmpxchg(
         &mut self,

--- a/compiler/rustc_codegen_ssa/src/traits/builder.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/builder.rs
@@ -552,12 +552,12 @@ pub trait BuilderMethods<'a, 'tcx>:
 
     fn set_personality_fn(&mut self, personality: Self::Function);
 
-    // These are used by everyone except msvc
+    // These are used by everyone except msvc and wasm EH
     fn cleanup_landing_pad(&mut self, pers_fn: Self::Function) -> (Self::Value, Self::Value);
     fn filter_landing_pad(&mut self, pers_fn: Self::Function);
     fn resume(&mut self, exn0: Self::Value, exn1: Self::Value);
 
-    // These are used only by msvc
+    // These are used by msvc and wasm EH
     fn cleanup_pad(&mut self, parent: Option<Self::Value>, args: &[Self::Value]) -> Self::Funclet;
     fn cleanup_ret(&mut self, funclet: &Self::Funclet, unwind: Option<Self::BasicBlock>);
     fn catch_pad(&mut self, parent: Self::Value, args: &[Self::Value]) -> Self::Funclet;
@@ -567,6 +567,7 @@ pub trait BuilderMethods<'a, 'tcx>:
         unwind: Option<Self::BasicBlock>,
         handlers: &[Self::BasicBlock],
     ) -> Self::Value;
+    fn get_funclet_cleanuppad(&self, funclet: &Self::Funclet) -> Self::Value;
 
     fn atomic_cmpxchg(
         &mut self,

--- a/tests/codegen-llvm/double_panic_wasm.rs
+++ b/tests/codegen-llvm/double_panic_wasm.rs
@@ -1,0 +1,34 @@
+//@ compile-flags: -C panic=unwind -Copt-level=0
+//@ needs-unwind
+//@ only-wasm32
+
+#![crate_type = "lib"]
+
+// Test that `panic_in_cleanup` is called on webassembly targets when a panic
+// occurs in a destructor during unwinding.
+
+extern "Rust" {
+    fn may_panic();
+}
+
+struct PanicOnDrop;
+
+impl Drop for PanicOnDrop {
+    fn drop(&mut self) {
+        unsafe { may_panic() }
+    }
+}
+
+// CHECK-LABEL: @double_panic
+// CHECK: invoke void @may_panic()
+// CHECK: invoke void @{{.+}}drop_in_place{{.+}}
+// CHECK: unwind label %[[TERMINATE:.*]]
+//
+// CHECK: [[TERMINATE]]:
+// CHECK: call void @{{.*panic_in_cleanup}}
+// CHECK: unreachable
+#[no_mangle]
+pub fn double_panic() {
+    let _guard = PanicOnDrop;
+    unsafe { may_panic() }
+}

--- a/tests/codegen-llvm/terminating-catchpad.rs
+++ b/tests/codegen-llvm/terminating-catchpad.rs
@@ -9,6 +9,10 @@
 // Ensure a catch-all generates:
 // - `catchpad ... [ptr null]` on Wasm (otherwise LLVM gets confused)
 // - `catchpad ... [ptr null, i32 64, ptr null]` on Windows (otherwise we catch SEH exceptions)
+//
+// Unlike on windows, on Wasm, we specifically do want to catch foreign
+// exceptions. To catch only C++ exceptions we'd need to call
+// @llvm.wasm.get.exception and @llvm.wasm.get.ehselector in the catchpad.
 
 #![feature(no_core, lang_items, rustc_attrs)]
 #![crate_type = "lib"]
@@ -36,8 +40,14 @@ fn panic_cannot_unwind() -> ! {
 #[no_mangle]
 #[rustc_nounwind]
 pub fn doesnt_unwind() {
+    // CHECK: catchswitch within none [label %{{.*}}] unwind to caller
     // emscripten: %catchpad = catchpad within %catchswitch [ptr null]
     // wasi: %catchpad = catchpad within %catchswitch [ptr null]
     // seh: %catchpad = catchpad within %catchswitch [ptr null, i32 64, ptr null]
+    //
+    // We don't call these intrinsics on wasm targets so we generate a catch_all
+    // instruction which also picks up foreign exceptions
+    // NOT: @llvm.wasm.get.exception
+    // NOT: @llvm.wasm.get.ehselector
     unwinds();
 }


### PR DESCRIPTION
Previously this was not correctly implemented. Each funclet may need its own terminate block, so this changes the `terminate_block` into a `terminate_blocks` `IndexVec` which can have a terminate_block for each funclet. We key on the first basic block of the funclet -- in particular, this is the start block for the old case of the top level terminate function.

I also fixed the `terminate` handler to not be invoked when a foreign exception is raised, mimicking the behavior from msvc. On wasm, in order to avoid generating a `catch_all` we need to call `llvm.wasm.get.exception` and `llvm.wasm.get.ehselector`.