### PR TITLE
    Reduce generics use in the query system.

### DIFF
--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -88,7 +88,7 @@ use rustc_index::IndexVec;
 use rustc_lint_defs::LintId;
 use rustc_macros::rustc_queries;
 use rustc_query_system::ich::StableHashingContext;
-use rustc_query_system::query::{QueryMode, QueryStackDeferred, QueryState};
+use rustc_query_system::query::{QueryMode, QueryState};
 use rustc_session::Limits;
 use rustc_session::config::{EntryFnType, OptLevel, OutputFilenames, SymbolManglingVersion};
 use rustc_session::cstore::{

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -440,7 +440,7 @@ macro_rules! define_callbacks {
         #[derive(Default)]
         pub struct QueryStates<'tcx> {
             $(
-                pub $name: QueryState<$($K)*, QueryStackDeferred<'tcx>>,
+                pub $name: QueryState<'tcx, $($K)*>,
             )*
         }
 

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -322,7 +322,7 @@ macro_rules! should_ever_cache_on_disk {
     };
 }
 
-fn create_query_frame_extra<'tcx, K: Key + Copy + 'tcx>(
+fn mk_query_stack_frame_extra<'tcx, K: Key + Copy + 'tcx>(
     (tcx, key, kind, name, do_describe): (
         TyCtxt<'tcx>,
         K,
@@ -382,7 +382,7 @@ pub(crate) fn create_query_frame<
     let def_id_for_ty_in_cycle = key.def_id_for_ty_in_cycle();
 
     let info =
-        QueryStackDeferred::new((tcx, key, kind, name, do_describe), create_query_frame_extra);
+        QueryStackDeferred::new((tcx, key, kind, name, do_describe), mk_query_stack_frame_extra);
 
     QueryStackFrame::new(info, kind, hash, def_id, def_id_for_ty_in_cycle)
 }

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -373,14 +373,12 @@ pub(crate) fn create_query_frame<
 ) -> QueryStackFrame<QueryStackDeferred<'tcx>> {
     let def_id = key.key_as_def_id();
 
-    let hash = || {
-        tcx.with_stable_hashing_context(|mut hcx| {
-            let mut hasher = StableHasher::new();
-            kind.as_usize().hash_stable(&mut hcx, &mut hasher);
-            key.hash_stable(&mut hcx, &mut hasher);
-            hasher.finish::<Hash64>()
-        })
-    };
+    let hash = tcx.with_stable_hashing_context(|mut hcx| {
+        let mut hasher = StableHasher::new();
+        kind.as_usize().hash_stable(&mut hcx, &mut hasher);
+        key.hash_stable(&mut hcx, &mut hasher);
+        hasher.finish::<Hash64>()
+    });
     let def_id_for_ty_in_cycle = key.def_id_for_ty_in_cycle();
 
     let info =

--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -519,7 +519,11 @@ impl<D: Deps> DepGraph<D> {
     /// This encodes a diagnostic by creating a node with an unique index and associating
     /// `diagnostic` with it, for use in the next session.
     #[inline]
-    pub fn record_diagnostic<Qcx: QueryContext>(&self, qcx: Qcx, diagnostic: &DiagInner) {
+    pub fn record_diagnostic<'tcx, Qcx: QueryContext<'tcx>>(
+        &self,
+        qcx: Qcx,
+        diagnostic: &DiagInner,
+    ) {
         if let Some(ref data) = self.data {
             D::read_deps(|task_deps| match task_deps {
                 TaskDepsRef::EvalAlways | TaskDepsRef::Ignore => return,
@@ -532,7 +536,7 @@ impl<D: Deps> DepGraph<D> {
     /// This forces a diagnostic node green by running its side effect. `prev_index` would
     /// refer to a node created used `encode_diagnostic` in the previous session.
     #[inline]
-    pub fn force_diagnostic_node<Qcx: QueryContext>(
+    pub fn force_diagnostic_node<'tcx, Qcx: QueryContext<'tcx>>(
         &self,
         qcx: Qcx,
         prev_index: SerializedDepNodeIndex,
@@ -669,7 +673,7 @@ impl<D: Deps> DepGraphData<D> {
     /// This encodes a diagnostic by creating a node with an unique index and associating
     /// `diagnostic` with it, for use in the next session.
     #[inline]
-    fn encode_diagnostic<Qcx: QueryContext>(
+    fn encode_diagnostic<'tcx, Qcx: QueryContext<'tcx>>(
         &self,
         qcx: Qcx,
         diagnostic: &DiagInner,
@@ -693,7 +697,7 @@ impl<D: Deps> DepGraphData<D> {
     /// This forces a diagnostic node green by running its side effect. `prev_index` would
     /// refer to a node created used `encode_diagnostic` in the previous session.
     #[inline]
-    fn force_diagnostic_node<Qcx: QueryContext>(
+    fn force_diagnostic_node<'tcx, Qcx: QueryContext<'tcx>>(
         &self,
         qcx: Qcx,
         prev_index: SerializedDepNodeIndex,
@@ -843,7 +847,7 @@ impl<D: Deps> DepGraph<D> {
         DepNodeColor::Unknown
     }
 
-    pub fn try_mark_green<Qcx: QueryContext<Deps = D>>(
+    pub fn try_mark_green<'tcx, Qcx: QueryContext<'tcx, Deps = D>>(
         &self,
         qcx: Qcx,
         dep_node: &DepNode,
@@ -858,7 +862,7 @@ impl<D: Deps> DepGraphData<D> {
     /// A node will have an index, when it's already been marked green, or when we can mark it
     /// green. This function will mark the current task as a reader of the specified node, when
     /// a node index can be found for that node.
-    pub(crate) fn try_mark_green<Qcx: QueryContext<Deps = D>>(
+    pub(crate) fn try_mark_green<'tcx, Qcx: QueryContext<'tcx, Deps = D>>(
         &self,
         qcx: Qcx,
         dep_node: &DepNode,
@@ -883,7 +887,7 @@ impl<D: Deps> DepGraphData<D> {
     }
 
     #[instrument(skip(self, qcx, parent_dep_node_index, frame), level = "debug")]
-    fn try_mark_parent_green<Qcx: QueryContext<Deps = D>>(
+    fn try_mark_parent_green<'tcx, Qcx: QueryContext<'tcx, Deps = D>>(
         &self,
         qcx: Qcx,
         parent_dep_node_index: SerializedDepNodeIndex,
@@ -973,7 +977,7 @@ impl<D: Deps> DepGraphData<D> {
 
     /// Try to mark a dep-node which existed in the previous compilation session as green.
     #[instrument(skip(self, qcx, prev_dep_node_index, frame), level = "debug")]
-    fn try_mark_previous_green<Qcx: QueryContext<Deps = D>>(
+    fn try_mark_previous_green<'tcx, Qcx: QueryContext<'tcx, Deps = D>>(
         &self,
         qcx: Qcx,
         prev_dep_node_index: SerializedDepNodeIndex,

--- a/compiler/rustc_query_system/src/query/dispatcher.rs
+++ b/compiler/rustc_query_system/src/query/dispatcher.rs
@@ -14,8 +14,8 @@ pub type HashResult<V> = Option<fn(&mut StableHashingContext<'_>, &V) -> Fingerp
 
 /// Unambiguous shorthand for `<This::Qcx as HasDepContext>::DepContext`.
 #[expect(type_alias_bounds)]
-type DepContextOf<This: QueryDispatcher> =
-    <<This as QueryDispatcher>::Qcx as HasDepContext>::DepContext;
+type DepContextOf<'tcx, This: QueryDispatcher<'tcx>> =
+    <<This as QueryDispatcher<'tcx>>::Qcx as HasDepContext>::DepContext;
 
 /// Trait that can be used as a vtable for a single query, providing operations
 /// and metadata for that query.
@@ -25,15 +25,15 @@ type DepContextOf<This: QueryDispatcher> =
 /// Those types are not visible from this `rustc_query_system` crate.
 ///
 /// "Dispatcher" should be understood as a near-synonym of "vtable".
-pub trait QueryDispatcher: Copy {
+pub trait QueryDispatcher<'tcx>: Copy {
     fn name(self) -> &'static str;
 
     /// Query context used by this dispatcher, i.e. `rustc_query_impl::QueryCtxt`.
-    type Qcx: QueryContext;
+    type Qcx: QueryContext<'tcx>;
 
     // `Key` and `Value` are `Copy` instead of `Clone` to ensure copying them stays cheap,
     // but it isn't necessary.
-    type Key: DepNodeParams<DepContextOf<Self>> + Eq + Hash + Copy + Debug;
+    type Key: DepNodeParams<DepContextOf<'tcx, Self>> + Eq + Hash + Copy + Debug;
     type Value: Copy;
 
     type Cache: QueryCache<Key = Self::Key, Value = Self::Value>;
@@ -41,18 +41,15 @@ pub trait QueryDispatcher: Copy {
     fn format_value(self) -> fn(&Self::Value) -> String;
 
     // Don't use this method to access query results, instead use the methods on TyCtxt
-    fn query_state<'a>(
-        self,
-        tcx: Self::Qcx,
-    ) -> &'a QueryState<Self::Key, <Self::Qcx as QueryContext>::QueryInfo>;
+    fn query_state<'a>(self, tcx: Self::Qcx) -> &'a QueryState<'tcx, Self::Key>;
 
     // Don't use this method to access query results, instead use the methods on TyCtxt
     fn query_cache<'a>(self, tcx: Self::Qcx) -> &'a Self::Cache;
 
-    fn cache_on_disk(self, tcx: DepContextOf<Self>, key: &Self::Key) -> bool;
+    fn cache_on_disk(self, tcx: DepContextOf<'tcx, Self>, key: &Self::Key) -> bool;
 
     // Don't use this method to compute query results, instead use the methods on TyCtxt
-    fn execute_query(self, tcx: DepContextOf<Self>, k: Self::Key) -> Self::Value;
+    fn execute_query(self, tcx: DepContextOf<'tcx, Self>, k: Self::Key) -> Self::Value;
 
     fn compute(self, tcx: Self::Qcx, key: Self::Key) -> Self::Value;
 
@@ -74,7 +71,7 @@ pub trait QueryDispatcher: Copy {
     /// Synthesize an error value to let compilation continue after a cycle.
     fn value_from_cycle_error(
         self,
-        tcx: DepContextOf<Self>,
+        tcx: DepContextOf<'tcx, Self>,
         cycle_error: &CycleError<QueryStackFrameExtra>,
         guar: ErrorGuaranteed,
     ) -> Self::Value;
@@ -89,7 +86,7 @@ pub trait QueryDispatcher: Copy {
     fn hash_result(self) -> HashResult<Self::Value>;
 
     // Just here for convenience and checking that the key matches the kind, don't override this.
-    fn construct_dep_node(self, tcx: DepContextOf<Self>, key: &Self::Key) -> DepNode {
+    fn construct_dep_node(self, tcx: DepContextOf<'tcx, Self>, key: &Self::Key) -> DepNode {
         DepNode::construct(tcx, self.dep_kind(), key)
     }
 }

--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -63,11 +63,11 @@ impl<I> QueryStackFrame<I> {
     pub fn new(
         info: I,
         dep_kind: DepKind,
-        hash: impl FnOnce() -> Hash64,
+        hash: Hash64,
         def_id: Option<DefId>,
         def_id_for_ty_in_cycle: Option<DefId>,
     ) -> Self {
-        Self { info, def_id, dep_kind, hash: hash(), def_id_for_ty_in_cycle }
+        Self { info, def_id, dep_kind, hash, def_id_for_ty_in_cycle }
     }
 
     fn lift<Qcx: QueryContext<QueryInfo = I>>(

--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -58,10 +58,10 @@ pub struct QueryStackFrame<I> {
     pub def_id_for_ty_in_cycle: Option<DefId>,
 }
 
-impl<I> QueryStackFrame<I> {
+impl<'tcx> QueryStackFrame<QueryStackDeferred<'tcx>> {
     #[inline]
     pub fn new(
-        info: I,
+        info: QueryStackDeferred<'tcx>,
         dep_kind: DepKind,
         hash: Hash64,
         def_id: Option<DefId>,
@@ -70,10 +70,7 @@ impl<I> QueryStackFrame<I> {
         Self { info, def_id, dep_kind, hash, def_id_for_ty_in_cycle }
     }
 
-    fn lift<Qcx: QueryContext<QueryInfo = I>>(
-        &self,
-        qcx: Qcx,
-    ) -> QueryStackFrame<QueryStackFrameExtra> {
+    fn lift<Qcx: QueryContext<'tcx>>(&self, qcx: Qcx) -> QueryStackFrame<QueryStackFrameExtra> {
         QueryStackFrame {
             info: qcx.lift_query_info(&self.info),
             dep_kind: self.dep_kind,
@@ -159,9 +156,7 @@ pub enum QuerySideEffect {
     Diagnostic(DiagInner),
 }
 
-pub trait QueryContext: HasDepContext {
-    type QueryInfo: Clone;
-
+pub trait QueryContext<'tcx>: HasDepContext {
     /// Gets a jobserver reference which is used to release then acquire
     /// a token while waiting on a query.
     fn jobserver_proxy(&self) -> &Proxy;
@@ -171,12 +166,9 @@ pub trait QueryContext: HasDepContext {
     /// Get the query information from the TLS context.
     fn current_query_job(self) -> Option<QueryJobId>;
 
-    fn collect_active_jobs(
-        self,
-        require_complete: bool,
-    ) -> Result<QueryMap<Self::QueryInfo>, QueryMap<Self::QueryInfo>>;
+    fn collect_active_jobs(self, require_complete: bool) -> Result<QueryMap<'tcx>, QueryMap<'tcx>>;
 
-    fn lift_query_info(self, info: &Self::QueryInfo) -> QueryStackFrameExtra;
+    fn lift_query_info(self, info: &QueryStackDeferred<'tcx>) -> QueryStackFrameExtra;
 
     /// Load a side effect associated to the node in the previous session.
     fn load_side_effect(


### PR DESCRIPTION
In rust-lang/rust#151203 I tried and failed to simplify `QueryStackFrame`. This is an alternative approach. There is no functional change, just tweaking of some names and types to make things clearer. Best reviewed one commit at a time.

r? @oli-obk 