### PR TITLE
Updated slice tests to pass for big endian hosts for `multiple-option-or-permutations.rs`

### DIFF
--- a/src/tools/compiletest/src/directives/directive_names.rs
+++ b/src/tools/compiletest/src/directives/directive_names.rs
@@ -218,6 +218,7 @@ pub(crate) const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "only-eabihf",
     "only-elf",
     "only-emscripten",
+    "only-endian-big",
     "only-gnu",
     "only-i686-pc-windows-gnu",
     "only-i686-pc-windows-msvc",

--- a/tests/codegen-llvm/issues/multiple-option-or-permutations.rs
+++ b/tests/codegen-llvm/issues/multiple-option-or-permutations.rs
@@ -70,9 +70,9 @@ pub fn if_some_u8(opta: Option<u8>, optb: Option<u8>) -> Option<u8> {
 #[no_mangle]
 pub fn or_match_slice_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Option<[u8; 1]> {
     // CHECK: start:
-    // CHECK-NEXT: [[SOME_A:%.+]] = trunc i16 %0 to i1
-    // CHECK-NEXT: [[R:%.+]] = select i1 [[SOME_A]], i16 %0, i16 %1
-    // CHECK: ret i16 [[R]]
+    // CHECK-DAG: [[SOME_A:%.+]] = trunc i16 {{.*}} to i1
+    // CHECK-DAG: select i1 [[SOME_A]], i16 %0, i16 %1
+    // CHECK: ret i16 {{.*}}
     match opta {
         Some(x) => Some(x),
         None => optb,
@@ -84,9 +84,9 @@ pub fn or_match_slice_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Option
 #[no_mangle]
 pub fn or_match_slice_alt_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Option<[u8; 1]> {
     // CHECK: start:
-    // CHECK-NEXT: [[SOME_A:%.+]] = trunc i16 %0 to i1
-    // CHECK-NEXT: [[R:%.+]] = select i1 [[SOME_A]], i16 %0, i16 %1
-    // CHECK: ret i16 [[R]]
+    // CHECK-DAG: [[SOME_A:%.+]] = trunc i16 {{.*}} to i1
+    // CHECK-DAG: select i1 [[SOME_A]], i16 %0, i16 %1
+    // CHECK: ret i16 {{.*}}
     match opta {
         Some(_) => opta,
         None => optb,
@@ -98,9 +98,9 @@ pub fn or_match_slice_alt_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Op
 #[no_mangle]
 pub fn option_or_slice_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Option<[u8; 1]> {
     // CHECK: start:
-    // CHECK-NEXT: [[SOME_A:%.+]] = trunc i16 %0 to i1
-    // CHECK-NEXT: [[R:%.+]] = select i1 [[SOME_A]], i16 %0, i16 %1
-    // CHECK: ret i16 [[R]]
+    // CHECK-DAG: [[SOME_A:%.+]] = trunc i16 {{.*}} to i1
+    // CHECK-DAG: select i1 [[SOME_A]], i16 %0, i16 %1
+    // CHECK: ret i16 {{.*}}
     opta.or(optb)
 }
 
@@ -109,9 +109,9 @@ pub fn option_or_slice_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Optio
 #[no_mangle]
 pub fn if_some_slice_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Option<[u8; 1]> {
     // CHECK: start:
-    // CHECK-NEXT: [[SOME_A:%.+]] = trunc i16 %0 to i1
-    // CHECK-NEXT: [[R:%.+]] = select i1 [[SOME_A]], i16 %0, i16 %1
-    // CHECK: ret i16 [[R]]
+    // CHECK-DAG: [[SOME_A:%.+]] = trunc i16 {{.*}} to i1
+    // CHECK-DAG: select i1 [[SOME_A]], i16 %0, i16 %1
+    // CHECK: ret i16 {{.*}}
     if opta.is_some() { opta } else { optb }
 }
 

--- a/tests/codegen-llvm/issues/multiple-option-or-permutations.rs
+++ b/tests/codegen-llvm/issues/multiple-option-or-permutations.rs
@@ -1,4 +1,7 @@
 // Tests output of multiple permutations of `Option::or`
+//@ revisions: LITTLE BIG
+//@ [BIG] only-endian-big
+//@ [LITTLE] ignore-endian-big
 //@ compile-flags: -Copt-level=3 -Zmerge-functions=disabled
 
 #![crate_type = "lib"]
@@ -70,9 +73,17 @@ pub fn if_some_u8(opta: Option<u8>, optb: Option<u8>) -> Option<u8> {
 #[no_mangle]
 pub fn or_match_slice_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Option<[u8; 1]> {
     // CHECK: start:
-    // CHECK-DAG: [[SOME_A:%.+]] = trunc i16 {{.*}} to i1
-    // CHECK-DAG: select i1 [[SOME_A]], i16 %0, i16 %1
-    // CHECK: ret i16 {{.*}}
+    // LITTLE-NEXT: [[SOME_A:%.+]] = trunc i16 %0 to i1
+    // LITTLE-NEXT: [[R:%.+]] = select i1 [[SOME_A]], i16 %0, i16 %1
+    // BIG-NEXT: [[OPT_A:%.+]] = lshr i16 %0, 8
+    // BIG-NEXT: [[SOME_A:%.+]] = trunc i16 [[OPT_A]] to i1
+    // BIG-NEXT: [[OPT_B:%.+]] = lshr i16 %1, 8
+    // BIG-NEXT: [[A_OR_B:%.+]] = select i1 [[SOME_A]], i16 [[OPT_A]], i16 [[OPT_B]]
+    // BIG-NEXT: [[AGGREGATE:%.+]] = select i1 [[SOME_A]], i16 %0, i16 %1
+    // BIG-NEXT: [[R_LOWER:%.+]] = and i16 [[AGGREGATE]], 255
+    // BIG-NEXT: [[R_UPPER:%.+]] = shl nuw i16 [[A_OR_B]], 8
+    // BIG-NEXT: [[R:%.+]] = or disjoint i16 [[R_UPPER]], [[R_LOWER]]
+    // CHECK: ret i16 [[R]]
     match opta {
         Some(x) => Some(x),
         None => optb,
@@ -84,9 +95,17 @@ pub fn or_match_slice_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Option
 #[no_mangle]
 pub fn or_match_slice_alt_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Option<[u8; 1]> {
     // CHECK: start:
-    // CHECK-DAG: [[SOME_A:%.+]] = trunc i16 {{.*}} to i1
-    // CHECK-DAG: select i1 [[SOME_A]], i16 %0, i16 %1
-    // CHECK: ret i16 {{.*}}
+    // LITTLE-NEXT: [[SOME_A:%.+]] = trunc i16 %0 to i1
+    // LITTLE-NEXT: [[R:%.+]] = select i1 [[SOME_A]], i16 %0, i16 %1
+    // BIG-NEXT: [[OPT_A:%.+]] = lshr i16 %0, 8
+    // BIG-NEXT: [[SOME_A:%.+]] = trunc i16 [[OPT_A]] to i1
+    // BIG-NEXT: [[OPT_B:%.+]] = lshr i16 %1, 8
+    // BIG-NEXT: [[A_OR_B:%.+]] = select i1 [[SOME_A]], i16 [[OPT_A]], i16 [[OPT_B]]
+    // BIG-NEXT: [[AGGREGATE:%.+]] = select i1 [[SOME_A]], i16 %0, i16 %1
+    // BIG-NEXT: [[R_LOWER:%.+]] = and i16 [[AGGREGATE]], 255
+    // BIG-NEXT: [[R_UPPER:%.+]] = shl nuw i16 [[A_OR_B]], 8
+    // BIG-NEXT: [[R:%.+]] = or disjoint i16 [[R_UPPER]], [[R_LOWER]]
+    // CHECK: ret i16 [[R]]
     match opta {
         Some(_) => opta,
         None => optb,
@@ -98,9 +117,17 @@ pub fn or_match_slice_alt_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Op
 #[no_mangle]
 pub fn option_or_slice_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Option<[u8; 1]> {
     // CHECK: start:
-    // CHECK-DAG: [[SOME_A:%.+]] = trunc i16 {{.*}} to i1
-    // CHECK-DAG: select i1 [[SOME_A]], i16 %0, i16 %1
-    // CHECK: ret i16 {{.*}}
+    // LITTLE-NEXT: [[SOME_A:%.+]] = trunc i16 %0 to i1
+    // LITTLE-NEXT: [[R:%.+]] = select i1 [[SOME_A]], i16 %0, i16 %1
+    // BIG-NEXT: [[OPT_A:%.+]] = lshr i16 %0, 8
+    // BIG-NEXT: [[SOME_A:%.+]] = trunc i16 [[OPT_A]] to i1
+    // BIG-NEXT: [[OPT_B:%.+]] = lshr i16 %1, 8
+    // BIG-NEXT: [[A_OR_B:%.+]] = select i1 [[SOME_A]], i16 [[OPT_A]], i16 [[OPT_B]]
+    // BIG-NEXT: [[AGGREGATE:%.+]] = select i1 [[SOME_A]], i16 %0, i16 %1
+    // BIG-NEXT: [[R_LOWER:%.+]] = and i16 [[AGGREGATE]], 255
+    // BIG-NEXT: [[R_UPPER:%.+]] = shl nuw i16 [[A_OR_B]], 8
+    // BIG-NEXT: [[R:%.+]] = or disjoint i16 [[R_UPPER]], [[R_LOWER]]
+    // CHECK: ret i16 [[R]]
     opta.or(optb)
 }
 
@@ -109,9 +136,17 @@ pub fn option_or_slice_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Optio
 #[no_mangle]
 pub fn if_some_slice_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Option<[u8; 1]> {
     // CHECK: start:
-    // CHECK-DAG: [[SOME_A:%.+]] = trunc i16 {{.*}} to i1
-    // CHECK-DAG: select i1 [[SOME_A]], i16 %0, i16 %1
-    // CHECK: ret i16 {{.*}}
+    // LITTLE-NEXT: [[SOME_A:%.+]] = trunc i16 %0 to i1
+    // LITTLE-NEXT: [[R:%.+]] = select i1 [[SOME_A]], i16 %0, i16 %1
+    // BIG-NEXT: [[OPT_A:%.+]] = lshr i16 %0, 8
+    // BIG-NEXT: [[SOME_A:%.+]] = trunc i16 [[OPT_A]] to i1
+    // BIG-NEXT: [[OPT_B:%.+]] = lshr i16 %1, 8
+    // BIG-NEXT: [[A_OR_B:%.+]] = select i1 [[SOME_A]], i16 [[OPT_A]], i16 [[OPT_B]]
+    // BIG-NEXT: [[AGGREGATE:%.+]] = select i1 [[SOME_A]], i16 %0, i16 %1
+    // BIG-NEXT: [[R_LOWER:%.+]] = and i16 [[AGGREGATE]], 255
+    // BIG-NEXT: [[R_UPPER:%.+]] = shl nuw i16 [[A_OR_B]], 8
+    // BIG-NEXT: [[R:%.+]] = or disjoint i16 [[R_UPPER]], [[R_LOWER]]
+    // CHECK: ret i16 [[R]]
     if opta.is_some() { opta } else { optb }
 }
 


### PR DESCRIPTION
It was discovered that the FileCheck tests when performing an `Option::or` operation on a slice was failing when tested on a big endian host.

The compiler explorer link is here outlining the codegen output differences - https://rust.godbolt.org/z/qdE7d3G4f

This MR relaxes the constraints for the `*slice_u8` variants of the test (by changing `CHECK-NEXT` to `CHECK-DAG`), whilst still maintaining the check for the necessary `or` logic.

Huge thanks to @Gelbpunkt for identifying this issue! It has been confirmed that this fix passes on a big endian target now as well.

Closes rust-lang/rust#151718 