### PR TITLE
FIX: UdpSocket result from libc

### DIFF
--- a/library/std/src/sys/net/connection/socket/unix.rs
+++ b/library/std/src/sys/net/connection/socket/unix.rs
@@ -293,6 +293,11 @@ impl Socket {
                 flags,
             )
         })?;
+
+        if ret == 0 && buf.capacity() == 0 {
+            return Err(io::const_error!(io::ErrorKind::InvalidInput, "0-byte buffer requested"))
+        }
+
         unsafe {
             buf.advance_unchecked(ret as usize);
         }

--- a/library/std/src/sys/net/connection/socket/unix.rs
+++ b/library/std/src/sys/net/connection/socket/unix.rs
@@ -295,7 +295,7 @@ impl Socket {
         })?;
 
         if ret == 0 && buf.capacity() == 0 {
-            return Err(io::const_error!(io::ErrorKind::InvalidInput, "0-byte buffer requested"))
+            return Err(io::const_error!(io::ErrorKind::InvalidInput, "0-byte buffer requested"));
         }
 
         unsafe {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Issue:

rust-lang/rust#149392

Additional:
libc recv function returns zero in cases when 0 bytes requested or client disconnected gracefully, I think sometimes need to handle this