### PR TITLE
Unit types are always "passed" directly

### DIFF
--- a/compiler/rustc_mir_transform/src/deduce_param_attrs.rs
+++ b/compiler/rustc_mir_transform/src/deduce_param_attrs.rs
@@ -139,17 +139,18 @@ impl<'tcx> Visitor<'tcx> for DeduceParamAttrs {
 
 /// Returns true if values of a given type will never be passed indirectly, regardless of ABI.
 fn type_will_always_be_passed_directly(ty: Ty<'_>) -> bool {
-    matches!(
-        ty.kind(),
-        ty::Bool
-            | ty::Char
-            | ty::Float(..)
-            | ty::Int(..)
-            | ty::RawPtr(..)
-            | ty::Ref(..)
-            | ty::Slice(..)
-            | ty::Uint(..)
-    )
+    ty.is_unit()
+        || matches!(
+            ty.kind(),
+            ty::Bool
+                | ty::Char
+                | ty::Float(..)
+                | ty::Int(..)
+                | ty::RawPtr(..)
+                | ty::Ref(..)
+                | ty::Slice(..)
+                | ty::Uint(..)
+        )
 }
 
 /// Returns the deduced parameter attributes for a function.

--- a/tests/ui/abi/optimized-failure.rs
+++ b/tests/ui/abi/optimized-failure.rs
@@ -1,0 +1,21 @@
+//! Unit parameter/return types should always be considered passed directly.
+//!
+//! Regression test for https://github.com/rust-lang/rust/issues/151748
+//@ compile-flags: -O
+//@ edition: 2018
+//@ check-pass
+
+fn main() {
+    let _ = async || {};
+    spawn(pattern_match());
+}
+
+fn spawn<F: Send>(_: F) {}
+
+async fn pattern_match() {
+    let COMPLEX_CONSTANT = ();
+}
+
+const fn do_nothing() {}
+
+const COMPLEX_CONSTANT: () = do_nothing();

--- a/tests/ui/abi/optimized-failure2.rs
+++ b/tests/ui/abi/optimized-failure2.rs
@@ -1,0 +1,16 @@
+//! Unit parameter/return types should always be considered passed directly.
+//!
+//! Regression test for https://github.com/rust-lang/rust/issues/151748
+//@ compile-flags: -O
+//@ edition: 2018
+//@ check-pass
+
+fn main() {
+    let _ = async || {
+        let COMPLEX_CONSTANT = ();
+    };
+}
+
+const fn do_nothing() {}
+
+const COMPLEX_CONSTANT: () = do_nothing();


### PR DESCRIPTION
Addresses minimisations of a user-reported stable-to-stable regression in rust-lang/rust#151748.

r? compiler