### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,9 +184,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "askama"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03341eae1125472b0672fbf35cc9aa7b74cd8e0c3d02f02c28a04678f12aaa7a"
+checksum = "10a800c6f7c005e5bcb76ff0b9e61c9e54ad379ce4e83a88ed14ff487a73776d"
 dependencies = [
  "askama_macros",
  "itoa",
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "askama_derive"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "461bd78f3da90b5e44eee4272cfb1c4832aa3dcdb6c370aedd3eb253d2b9e3ca"
+checksum = "0cb7657165bac49b5c533850e7cd67c1c60059aefc31088f89aa431c8a90d5d9"
 dependencies = [
  "askama_parser",
  "basic-toml",
@@ -214,18 +214,18 @@ dependencies = [
 
 [[package]]
 name = "askama_macros"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba49fb22ee3074574b8510abd9495d4f0bb9b8f87e8e45ee31e2cee508f7a8e5"
+checksum = "e55eacd3e54d32483cd10d0a881a0f28a40f3a763704ac9b8693edc39d7321c7"
 dependencies = [
  "askama_derive",
 ]
 
 [[package]]
 name = "askama_parser"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e33eb7484958aaa1f27e9adb556f5d557331cd891bdbb33781bc1f9550b6f6e"
+checksum = "20c3df8886ab5acdcd76eee93b3e2df1ef734251438b5b942b5fea22c50d2a0f"
 dependencies = [
  "rustc-hash 2.1.1",
  "serde",

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -67,11 +67,11 @@ impl<'tcx, C: QueryCache, const ANON: bool, const DEPTH_LIMIT: bool, const FEEDA
 
 // This is `impl QueryDispatcher for SemiDynamicQueryDispatcher`.
 impl<'tcx, C: QueryCache, const ANON: bool, const DEPTH_LIMIT: bool, const FEEDABLE: bool>
-    QueryDispatcher<QueryCtxt<'tcx>>
-    for SemiDynamicQueryDispatcher<'tcx, C, ANON, DEPTH_LIMIT, FEEDABLE>
+    QueryDispatcher for SemiDynamicQueryDispatcher<'tcx, C, ANON, DEPTH_LIMIT, FEEDABLE>
 where
     for<'a> C::Key: HashStable<StableHashingContext<'a>>,
 {
+    type Qcx = QueryCtxt<'tcx>;
     type Key = C::Key;
     type Value = C::Value;
     type Cache = C;
@@ -104,10 +104,7 @@ where
     }
 
     #[inline(always)]
-    fn query_cache<'a>(self, qcx: QueryCtxt<'tcx>) -> &'a Self::Cache
-    where
-        'tcx: 'a,
-    {
+    fn query_cache<'a>(self, qcx: QueryCtxt<'tcx>) -> &'a Self::Cache {
         // Safety:
         // This is just manually doing the subfield referencing through pointer math.
         unsafe {
@@ -215,15 +212,13 @@ where
 /// on the type `rustc_query_impl::query_impl::$name::QueryType`.
 trait QueryDispatcherUnerased<'tcx> {
     type UnerasedValue;
-    type Dispatcher: QueryDispatcher<QueryCtxt<'tcx>>;
+    type Dispatcher: QueryDispatcher<Qcx = QueryCtxt<'tcx>>;
 
     const NAME: &'static &'static str;
 
     fn query_dispatcher(tcx: TyCtxt<'tcx>) -> Self::Dispatcher;
 
-    fn restore_val(
-        value: <Self::Dispatcher as QueryDispatcher<QueryCtxt<'tcx>>>::Value,
-    ) -> Self::UnerasedValue;
+    fn restore_val(value: <Self::Dispatcher as QueryDispatcher>::Value) -> Self::UnerasedValue;
 }
 
 pub fn query_system<'a>(

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -414,7 +414,7 @@ pub(crate) fn encode_query_results<'a, 'tcx, Q>(
 }
 
 pub(crate) fn query_key_hash_verify<'tcx>(
-    query: impl QueryDispatcher<QueryCtxt<'tcx>>,
+    query: impl QueryDispatcher<Qcx = QueryCtxt<'tcx>>,
     qcx: QueryCtxt<'tcx>,
 ) {
     let _timer = qcx.tcx.prof.generic_activity_with_arg("query_key_hash_verify_for", query.name());
@@ -442,7 +442,7 @@ pub(crate) fn query_key_hash_verify<'tcx>(
 
 fn try_load_from_on_disk_cache<'tcx, Q>(query: Q, tcx: TyCtxt<'tcx>, dep_node: DepNode)
 where
-    Q: QueryDispatcher<QueryCtxt<'tcx>>,
+    Q: QueryDispatcher<Qcx = QueryCtxt<'tcx>>,
 {
     debug_assert!(tcx.dep_graph.is_green(&dep_node));
 
@@ -488,7 +488,7 @@ where
 
 fn force_from_dep_node<'tcx, Q>(query: Q, tcx: TyCtxt<'tcx>, dep_node: DepNode) -> bool
 where
-    Q: QueryDispatcher<QueryCtxt<'tcx>>,
+    Q: QueryDispatcher<Qcx = QueryCtxt<'tcx>>,
 {
     // We must avoid ever having to call `force_from_dep_node()` for a
     // `DepNode::codegen_unit`:
@@ -523,8 +523,7 @@ pub(crate) fn make_dep_kind_vtable_for_query<'tcx, Q>(
 where
     Q: QueryDispatcherUnerased<'tcx>,
 {
-    let fingerprint_style =
-        <Q::Dispatcher as QueryDispatcher<QueryCtxt<'tcx>>>::Key::fingerprint_style();
+    let fingerprint_style = <Q::Dispatcher as QueryDispatcher>::Key::fingerprint_style();
 
     if is_anon || !fingerprint_style.reconstructible() {
         return DepKindVTable {
@@ -731,7 +730,7 @@ macro_rules! define_queries {
                 }
 
                 #[inline(always)]
-                fn restore_val(value: <Self::Dispatcher as QueryDispatcher<QueryCtxt<'tcx>>>::Value) -> Self::UnerasedValue {
+                fn restore_val(value: <Self::Dispatcher as QueryDispatcher>::Value) -> Self::UnerasedValue {
                     restore::<queries::$name::Value<'tcx>>(value)
                 }
             }

--- a/compiler/rustc_query_system/src/query/dispatcher.rs
+++ b/compiler/rustc_query_system/src/query/dispatcher.rs
@@ -5,12 +5,17 @@ use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_span::ErrorGuaranteed;
 
 use super::QueryStackFrameExtra;
-use crate::dep_graph::{DepKind, DepNode, DepNodeParams, SerializedDepNodeIndex};
+use crate::dep_graph::{DepKind, DepNode, DepNodeParams, HasDepContext, SerializedDepNodeIndex};
 use crate::ich::StableHashingContext;
 use crate::query::caches::QueryCache;
 use crate::query::{CycleError, CycleErrorHandling, DepNodeIndex, QueryContext, QueryState};
 
 pub type HashResult<V> = Option<fn(&mut StableHashingContext<'_>, &V) -> Fingerprint>;
+
+/// Unambiguous shorthand for `<This::Qcx as HasDepContext>::DepContext`.
+#[expect(type_alias_bounds)]
+type DepContextOf<This: QueryDispatcher> =
+    <<This as QueryDispatcher>::Qcx as HasDepContext>::DepContext;
 
 /// Trait that can be used as a vtable for a single query, providing operations
 /// and metadata for that query.
@@ -20,12 +25,15 @@ pub type HashResult<V> = Option<fn(&mut StableHashingContext<'_>, &V) -> Fingerp
 /// Those types are not visible from this `rustc_query_system` crate.
 ///
 /// "Dispatcher" should be understood as a near-synonym of "vtable".
-pub trait QueryDispatcher<Qcx: QueryContext>: Copy {
+pub trait QueryDispatcher: Copy {
     fn name(self) -> &'static str;
+
+    /// Query context used by this dispatcher, i.e. `rustc_query_impl::QueryCtxt`.
+    type Qcx: QueryContext;
 
     // `Key` and `Value` are `Copy` instead of `Clone` to ensure copying them stays cheap,
     // but it isn't necessary.
-    type Key: DepNodeParams<Qcx::DepContext> + Eq + Hash + Copy + Debug;
+    type Key: DepNodeParams<DepContextOf<Self>> + Eq + Hash + Copy + Debug;
     type Value: Copy;
 
     type Cache: QueryCache<Key = Self::Key, Value = Self::Value>;
@@ -33,36 +41,40 @@ pub trait QueryDispatcher<Qcx: QueryContext>: Copy {
     fn format_value(self) -> fn(&Self::Value) -> String;
 
     // Don't use this method to access query results, instead use the methods on TyCtxt
-    fn query_state<'a>(self, tcx: Qcx) -> &'a QueryState<Self::Key, Qcx::QueryInfo>
-    where
-        Qcx: 'a;
+    fn query_state<'a>(
+        self,
+        tcx: Self::Qcx,
+    ) -> &'a QueryState<Self::Key, <Self::Qcx as QueryContext>::QueryInfo>;
 
     // Don't use this method to access query results, instead use the methods on TyCtxt
-    fn query_cache<'a>(self, tcx: Qcx) -> &'a Self::Cache
-    where
-        Qcx: 'a;
+    fn query_cache<'a>(self, tcx: Self::Qcx) -> &'a Self::Cache;
 
-    fn cache_on_disk(self, tcx: Qcx::DepContext, key: &Self::Key) -> bool;
+    fn cache_on_disk(self, tcx: DepContextOf<Self>, key: &Self::Key) -> bool;
 
     // Don't use this method to compute query results, instead use the methods on TyCtxt
-    fn execute_query(self, tcx: Qcx::DepContext, k: Self::Key) -> Self::Value;
+    fn execute_query(self, tcx: DepContextOf<Self>, k: Self::Key) -> Self::Value;
 
-    fn compute(self, tcx: Qcx, key: Self::Key) -> Self::Value;
+    fn compute(self, tcx: Self::Qcx, key: Self::Key) -> Self::Value;
 
     fn try_load_from_disk(
         self,
-        tcx: Qcx,
+        tcx: Self::Qcx,
         key: &Self::Key,
         prev_index: SerializedDepNodeIndex,
         index: DepNodeIndex,
     ) -> Option<Self::Value>;
 
-    fn loadable_from_disk(self, qcx: Qcx, key: &Self::Key, idx: SerializedDepNodeIndex) -> bool;
+    fn loadable_from_disk(
+        self,
+        qcx: Self::Qcx,
+        key: &Self::Key,
+        idx: SerializedDepNodeIndex,
+    ) -> bool;
 
     /// Synthesize an error value to let compilation continue after a cycle.
     fn value_from_cycle_error(
         self,
-        tcx: Qcx::DepContext,
+        tcx: DepContextOf<Self>,
         cycle_error: &CycleError<QueryStackFrameExtra>,
         guar: ErrorGuaranteed,
     ) -> Self::Value;
@@ -77,7 +89,7 @@ pub trait QueryDispatcher<Qcx: QueryContext>: Copy {
     fn hash_result(self) -> HashResult<Self::Value>;
 
     // Just here for convenience and checking that the key matches the kind, don't override this.
-    fn construct_dep_node(self, tcx: Qcx::DepContext, key: &Self::Key) -> DepNode {
+    fn construct_dep_node(self, tcx: DepContextOf<Self>, key: &Self::Key) -> DepNode {
         DepNode::construct(tcx, self.dep_kind(), key)
     }
 }

--- a/src/ci/citool/Cargo.toml
+++ b/src/ci/citool/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1"
-askama = "0.15.2"
+askama = "0.15.3"
 clap = { version = "4.5", features = ["derive"] }
 csv = "1"
 diff = "0.1"

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -10,7 +10,7 @@ path = "lib.rs"
 [dependencies]
 # tidy-alphabetical-start
 arrayvec = { version = "0.7", default-features = false }
-askama = { version = "0.15.2", default-features = false, features = ["alloc", "config", "derive"] }
+askama = { version = "0.15.3", default-features = false, features = ["alloc", "config", "derive"] }
 base64 = "0.21.7"
 indexmap = { version = "2", features = ["serde"] }
 itertools = "0.12"

--- a/src/librustdoc/html/static/css/noscript.css
+++ b/src/librustdoc/html/static/css/noscript.css
@@ -163,7 +163,7 @@ nav.sub {
 		--headings-border-bottom-color: #d2d2d2;
 		--border-color: #e0e0e0;
 		--button-background-color: #f0f0f0;
-		--right-side-color: grey;
+		--right-side-color: #d0d0d0;
 		--code-attribute-color: #999;
 		--toggles-color: #999;
 		--toggle-filter: invert(100%);

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -2656,6 +2656,10 @@ However, it's not needed with smaller screen width because the doc/code block is
 .deprecated-count {
 	display: none;
 }
+/*
+The `:not(:empty)` is a little trick to not have to add conditions in JS to hide/show the marker.
+It's entirely based on whether it has content and if the setting is enabled.
+*/
 .hide-deprecated-items .deprecated-count:not(:empty) {
 	display: block;
 	margin: 10px 0;

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -341,7 +341,8 @@ summary.hideme,
 .rustdoc-breadcrumbs,
 .search-switcher,
 /* This selector is for the items listed in the "all items" page. */
-ul.all-items {
+ul.all-items,
+.deprecated-count {
 	font-family: "Fira Sans", Arial, NanumBarunGothic, sans-serif;
 }
 
@@ -2650,6 +2651,14 @@ However, it's not needed with smaller screen width because the doc/code block is
 .hide-deprecated-items .deprecated,
 .hide-deprecated-items .deprecated + .item-info {
 	display: none;
+}
+
+.deprecated-count {
+	display: none;
+}
+.hide-deprecated-items .deprecated-count:not(:empty) {
+	display: block;
+	margin: 10px 0;
 }
 
 /*

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -3286,7 +3286,7 @@ by default.
 	--headings-border-bottom-color: #d2d2d2;
 	--border-color: #e0e0e0;
 	--button-background-color: #f0f0f0;
-	--right-side-color: grey;
+	--right-side-color: #d0d0d0;
 	--code-attribute-color: #999;
 	--toggles-color: #999;
 	--toggle-filter: invert(100%);

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -158,6 +158,7 @@ const REGEX_INVALID_TYPE_FILTER = /[^a-z]/ui;
 
 const MAX_RESULTS = 200;
 const NO_TYPE_FILTER = -1;
+const DEPRECATED_COUNT_SELECTOR = "deprecated-count";
 
 /**
  * The [edit distance] is a metric for measuring the difference between two strings.
@@ -4904,7 +4905,12 @@ async function addTab(results, query, display, finishedCallback, isTypeSearch) {
     let output = document.createElement("ul");
     output.className = "search-results " + extraClass;
 
+    const deprecatedCountElem = document.createElement("span");
+    deprecatedCountElem.className = DEPRECATED_COUNT_SELECTOR;
+    output.appendChild(deprecatedCountElem);
+
     let count = 0;
+    let deprecatedCount = 0;
 
     /** @type {Promise<string|null>[]} */
     const descList = [];
@@ -4922,6 +4928,10 @@ async function addTab(results, query, display, finishedCallback, isTypeSearch) {
         link.className = "result-" + type;
         if (obj.item.deprecated) {
             link.className += " deprecated";
+            deprecatedCount += 1;
+            const plural = deprecatedCount > 1 ? "s" : "";
+            deprecatedCountElem.innerText =
+                `${deprecatedCount} deprecated item${plural} hidden by setting`;
         }
         link.href = obj.href;
 
@@ -5411,7 +5421,7 @@ function registerSearchEvents() {
             const active = document.activeElement;
             if (active) {
                 const previous = active.previousElementSibling;
-                if (previous) {
+                if (previous && previous.className !== DEPRECATED_COUNT_SELECTOR) {
                     // @ts-expect-error
                     previous.focus();
                 } else {

--- a/src/tools/generate-copyright/Cargo.toml
+++ b/src/tools/generate-copyright/Cargo.toml
@@ -8,7 +8,7 @@ description = "Produces a manifest of all the copyrighted materials in the Rust 
 
 [dependencies]
 anyhow = "1.0.65"
-askama = "0.15.2"
+askama = "0.15.3"
 cargo_metadata = "0.21"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.85"

--- a/tests/rustdoc-gui/headings.goml
+++ b/tests/rustdoc-gui/headings.goml
@@ -221,14 +221,14 @@ call-function: (
 
 define-function: (
     "check-since-color",
-    [theme],
+    [theme, color],
     block {
         call-function: ("switch-theme", {"theme": |theme|})
-        assert-css: (".since", {"color": "#808080"}, ALL)
+        assert-css: (".since", {"color": |color|}, ALL)
     },
 )
 
 go-to: "file://" + |DOC_PATH| + "/staged_api/struct.Foo.html"
-call-function: ("check-since-color", {"theme": "ayu"})
-call-function: ("check-since-color", {"theme": "dark"})
-call-function: ("check-since-color", {"theme": "light"})
+call-function: ("check-since-color", {"theme": "ayu", "color": "#808080"})
+call-function: ("check-since-color", {"theme": "dark", "color": "#d0d0d0"})
+call-function: ("check-since-color", {"theme": "light", "color": "#808080"})

--- a/tests/rustdoc-gui/setting-hide-deprecated.goml
+++ b/tests/rustdoc-gui/setting-hide-deprecated.goml
@@ -69,7 +69,7 @@ wait-for-css: ("details" + |deprecated_class|, {"display": "block"}, ALL)
 
 // And now we check with the search results.
 call-function: ("perform-search", {"query": "deprecated::depr"})
-// There should at least 7 results.
+// There should be at least 7 results.
 store-count: ("#results ul.search-results.active > a", nb_search_results)
 assert: |nb_search_results| >= 7
 // There should be at least 5 deprecated items.
@@ -77,6 +77,12 @@ store-count: ("#results ul.search-results.active > a" + |deprecated_class|, nb_d
 assert: |nb_search_results| >= 5
 // Deprecated items should all be displayed.
 assert-css: ("#results ul.search-results.active > a" + |deprecated_class|, {"display": "grid"}, ALL)
+// The "X deprecated items hidden by setting" element should not be displayed.
+assert-text: (
+    "#results ul.search-results.active .deprecated-count",
+    "5 deprecated items hidden by setting",
+)
+assert-css: ("#results ul.search-results.active .deprecated-count", {"display": "none"})
 // We enable the "hide deprecated items" setting.
 call-function: ("open-settings-menu", {})
 click: "#hide-deprecated-items"
@@ -86,11 +92,16 @@ wait-for-css: (
     {"display": "none"},
     ALL,
 )
+// The "X deprecated items hidden by setting" element should be displayed.
+assert-css: ("#results ul.search-results.active .deprecated-count", {"display": "block"})
 
 // Finally we check that the future deprecated item doesn't have the deprecated class in the search
-// and therefore isn't impact by the setting.
-call-function: ("perform-search", {"query": "deprecated::future_deprecated"})
+// and therefore isn't impacted by the setting.
+call-function: ("perform-search", {"query": '"future_deprecated_fn"'})
 assert-text: (
     "#results ul.search-results.active > a:not(" + |deprecated_class| + ") .path",
     " lib2::deprecated::NonDeprecatedStruct::future_deprecated_fn",
 )
+// The "X deprecated items hidden by setting" element should now be empty, and therefore not displayed.
+assert-text: ("#results ul.search-results.active .deprecated-count", "")
+assert-css: ("#results ul.search-results.active .deprecated-count", {"display": "none"})

--- a/tests/ui/README.md
+++ b/tests/ui/README.md
@@ -10,17 +10,17 @@ These tests deal with *Application Binary Interfaces* (ABI), mostly relating to 
 
 Tests for unsupported ABIs can be made cross-platform by using the `extern "rust-invalid"` ABI, which is considered unsupported on every platform.
 
-## `tests/ui/allocator`
-
-These tests exercise `#![feature(allocator_api)]` and the `#[global_allocator]` attribute.
-
-See [Allocator traits and `std::heap` #32838](https://github.com/rust-lang/rust/issues/32838).
-
 ## `tests/ui/alloc-error`
 
 These tests exercise alloc error handling.
 
 See <https://doc.rust-lang.org/std/alloc/fn.handle_alloc_error.html>.
+
+## `tests/ui/allocator`
+
+These tests exercise `#![feature(allocator_api)]` and the `#[global_allocator]` attribute.
+
+See [Allocator traits and `std::heap` #32838](https://github.com/rust-lang/rust/issues/32838).
 
 ## `tests/ui/annotate-moves`
 
@@ -52,13 +52,13 @@ These tests exercise rustc reading command line arguments from an externally pro
 
 See [Implement `@argsfile` to read arguments from command line #63576](https://github.com/rust-lang/rust/issues/63576).
 
-## `tests/ui/array-slice-vec`: Arrays, slices and vectors
-
-Exercises various aspects surrounding basic collection types `[]`, `&[]` and `Vec`. E.g. type-checking, out-of-bounds indices, attempted instructions which are allowed in other programming languages, and more.
-
 ## `tests/ui/argument-suggestions`: Argument suggestions
 
 Calling a function with the wrong number of arguments causes a compilation failure, but the compiler is able to, in some cases, provide suggestions on how to fix the error, such as which arguments to add or delete. These tests exercise the quality of such diagnostics.
+
+## `tests/ui/array-slice-vec`: Arrays, slices and vectors
+
+Exercises various aspects surrounding basic collection types `[]`, `&[]` and `Vec`. E.g. type-checking, out-of-bounds indices, attempted instructions which are allowed in other programming languages, and more.
 
 ## `tests/ui/asm`: `asm!` macro
 
@@ -184,6 +184,10 @@ See [RFC 3729: Hierarchy of Sized traits](https://github.com/rust-lang/rfcs/pull
 
 Defining custom auto traits with the `auto` keyword belongs to `tests/ui/auto-traits/` instead.
 
+## `tests/ui/c-variadic`: C Variadic Function
+
+Tests for FFI with C varargs (`va_list`).
+
 ## `tests/ui/cast/`: Type Casting
 
 Tests for type casting using the `as` operator. Includes tests for valid/invalid casts between primitive types, trait objects, and custom types. For example, check that trying to cast `i32` into `bool` results in a helpful error message.
@@ -202,15 +206,15 @@ Tests for the `--check-cfg` compiler mechanism  for checking cfg configurations,
 
 See [Checking conditional configurations | The rustc book](https://doc.rust-lang.org/rustc/check-cfg.html).
 
-## `tests/ui/closure_context/`: Closure type inference in context
-
-Tests for closure type inference with respect to surrounding scopes, mostly quality of diagnostics.
-
 ## `tests/ui/closure-expected-type/`: Closure type inference
 
 Tests targeted at how we deduce the types of closure arguments. This process is a result of some heuristics which take into account the *expected type* we have alongside the *actual types* that we get from inputs.
 
 **FIXME**: Appears to have significant overlap with `tests/ui/closure_context` and `tests/ui/functions-closures/closure-expected-type`. Needs further investigation.
+
+## `tests/ui/closure_context`: Closure type inference in context
+
+Tests for closure type inference with respect to surrounding scopes, mostly quality of diagnostics.
 
 ## `tests/ui/closures/`: General Closure Tests
 
@@ -305,10 +309,6 @@ See:
 - [Tracking Issue for complex generic constants: `feature(generic_const_exprs)` #76560](https://github.com/rust-lang/rust/issues/76560)
 - [Const generics | Reference](https://doc.rust-lang.org/reference/items/generics.html#const-generics)
 
-## `tests/ui/const_prop/`: Constant Propagation
-
-Tests exercising `ConstProp` mir-opt pass (mostly regression tests). See <https://blog.rust-lang.org/inside-rust/2019/12/02/const-prop-on-by-default/>.
-
 ## `tests/ui/const-ptr/`: Constant Pointers
 
 Tests exercise const raw pointers. E.g. pointer arithmetic, casting and dereferencing, always with a `const`.
@@ -318,6 +318,10 @@ See:
 - [`std::primitive::pointer`](https://doc.rust-lang.org/std/primitive.pointer.html)
 - [`std::ptr`](https://doc.rust-lang.org/std/ptr/index.html)
 - [Pointer types | Reference](https://doc.rust-lang.org/reference/types/pointer.html)
+
+## `tests/ui/const_prop`: Constant Propagation
+
+Tests exercising `ConstProp` mir-opt pass (mostly regression tests). See <https://blog.rust-lang.org/inside-rust/2019/12/02/const-prop-on-by-default/>.
 
 ## `tests/ui/consts/`: General Constant Evaluation
 
@@ -360,10 +364,6 @@ Tests for `#[bench]`, `#[test_case]` attributes and the `custom_test_frameworks`
 
 See [Tracking issue for eRFC 2318, Custom test frameworks #50297](https://github.com/rust-lang/rust/issues/50297).
 
-## `tests/ui/c-variadic/`: C Variadic Function
-
-Tests for FFI with C varargs (`va_list`).
-
 ## `tests/ui/cycle-trait/`: Trait Cycle Detection
 
 Tests for detection and handling of cyclic trait dependencies.
@@ -400,15 +400,15 @@ These tests use the unstable command line option `query-dep-graph` to examine th
 
 Tests for `#[deprecated]` attribute and `deprecated_in_future` internal lint.
 
+## `tests/ui/deref`
+
+Tests for `Deref` and `DerefMut` traits.
+
 ## `tests/ui/deref-patterns`: `#![feature(deref_patterns)]` and `#![feature(string_deref_patterns)]`
 
 Tests for `#![feature(deref_patterns)]` and `#![feature(string_deref_patterns)]`. See [Deref patterns | The Unstable book](https://doc.rust-lang.org/nightly/unstable-book/language-features/deref-patterns.html).
 
 **FIXME**: May have some overlap with `tests/ui/pattern/deref-patterns`.
-
-## `tests/ui/deref`
-
-Tests for `Deref` and `DerefMut` traits.
 
 See [`std::ops::Deref`](https://doc.rust-lang.org/std/ops/trait.Deref.html) and [`std::ops::DerefMut`](https://doc.rust-lang.org/std/ops/trait.DerefMut.html)
 
@@ -438,6 +438,10 @@ These tests revolve around command-line flags which change the way error/warning
 
 **FIXME**: Check redundancy with `annotate-snippet`, which is another emitter.
 
+## `tests/ui/diagnostic-width`: `--diagnostic-width`
+
+Everything to do with `--diagnostic-width`.
+
 ## `tests/ui/diagnostic_namespace/`
 
 Exercises `#[diagnostic::*]` namespaced attributes. See [RFC 3368 Diagnostic attribute namespace](https://github.com/rust-lang/rfcs/blob/master/text/3368-diagnostic-attribute-namespace.md).
@@ -445,10 +449,6 @@ Exercises `#[diagnostic::*]` namespaced attributes. See [RFC 3368 Diagnostic att
 ## `tests/ui/diagnostics-infra`
 
 This directory contains tests and infrastructure related to the diagnostics system, including support for translatable diagnostics
-
-## `tests/ui/diagnostic-width/`: `--diagnostic-width`
-
-Everything to do with `--diagnostic-width`.
 
 ## `tests/ui/did_you_mean/`
 
@@ -497,10 +497,6 @@ Tests for dynamically-sized types (DSTs). See [Dynamically Sized Types | Referen
 
 Tests about duplicated symbol names and associated errors, such as using the `#[export_name]` attribute to rename a function with the same name as another function.
 
-## `tests/ui/dynamically-sized-types/`: Dynamically Sized Types
-
-**FIXME**: should be coalesced with `tests/ui/dst`.
-
 ## `tests/ui/dyn-compatibility/`: Dyn-compatibility
 
 Tests for dyn-compatibility of traits.
@@ -521,6 +517,10 @@ Previously known as "object safety".
 The `dyn` keyword is used to highlight that calls to methods on the associated Trait are dynamically dispatched. To use the trait this way, it must be dyn-compatible - tests about dyn-compatibility belong in `tests/ui/dyn-compatibility/`, while more general tests on dynamic dispatch belong here.
 
 See [`dyn` keyword](https://doc.rust-lang.org/std/keyword.dyn.html).
+
+## `tests/ui/dynamically-sized-types`: Dynamically Sized Types
+
+**FIXME**: should be coalesced with `tests/ui/dst`.
 
 ## `tests/ui/editions/`: Rust edition-specific peculiarities
 
@@ -627,6 +627,12 @@ A broad category of tests on functions.
 
 Tests for `#![feature(fn_traits)]`. See [`fn_traits` | The Unstable book](https://doc.rust-lang.org/nightly/unstable-book/library-features/fn-traits.html).
 
+## `tests/ui/for-loop-while`
+
+Anything to do with loops and `for`, `loop` and `while` keywords to express them.
+
+**FIXME**: After `ui/for` is merged into this, also carry over its SUMMARY text.
+
 ## `tests/ui/force-inlining/`: `#[rustc_force_inline]`
 
 Tests for `#[rustc_force_inline]`, which will force a function to always be labelled as inline by the compiler (it will be inserted at the point of its call instead of being used as a normal function call.) If the compiler is unable to inline the function, an error will be reported. See <https://github.com/rust-lang/rust/pull/134082>.
@@ -637,12 +643,6 @@ Tests for `extern "C"` and `extern "Rust`.
 
 **FIXME**: Check for potential overlap/merge with `ui/c-variadic` and/or `ui/extern`.
 
-## `tests/ui/for-loop-while/`
-
-Anything to do with loops and `for`, `loop` and `while` keywords to express them.
-
-**FIXME**: After `ui/for` is merged into this, also carry over its SUMMARY text.
-
 ## `tests/ui/frontmatter/`
 
 Tests for `#![feature(frontmatter)]`. See [Tracking Issue for `frontmatter` #136889](https://github.com/rust-lang/rust/issues/136889).
@@ -650,12 +650,6 @@ Tests for `#![feature(frontmatter)]`. See [Tracking Issue for `frontmatter` #136
 ## `tests/ui/fully-qualified-type/`
 
 Tests for diagnostics when there may be identically named types that need further qualifications to disambiguate.
-
-## `tests/ui/functional-struct-update/`
-
-Functional Struct Update is the name for the idiom by which one can write `..<expr>` at the end of a struct literal expression to fill in all remaining fields of the struct literal by using `<expr>` as the source for them.
-
-See [RFC 0736 Privacy-respecting Functional Struct Update](https://github.com/rust-lang/rfcs/blob/master/text/0736-privacy-respecting-fru.md).
 
 ## `tests/ui/function-pointer/`
 
@@ -665,6 +659,12 @@ See:
 
 - [Function pointer types | Reference](https://doc.rust-lang.org/reference/types/function-pointer.html)
 - [Higher-ranked trait bounds | Nomicon](https://doc.rust-lang.org/nomicon/hrtb.html)
+
+## `tests/ui/functional-struct-update/`
+
+Functional Struct Update is the name for the idiom by which one can write `..<expr>` at the end of a struct literal expression to fill in all remaining fields of the struct literal by using `<expr>` as the source for them.
+
+See [RFC 0736 Privacy-respecting Functional Struct Update](https://github.com/rust-lang/rfcs/blob/master/text/0736-privacy-respecting-fru.md).
 
 ## `tests/ui/functions-closures/`
 
@@ -721,13 +721,13 @@ This test category revolves around trait objects with `Sized` having illegal ope
 
 Tests on lifetime elision in impl function signatures. See [Lifetime elision | Nomicon](https://doc.rust-lang.org/nomicon/lifetime-elision.html).
 
-## `tests/ui/implied-bounds/`
-
-See [Implied bounds | Reference](https://doc.rust-lang.org/reference/trait-bounds.html#implied-bounds).
-
 ## `tests/ui/impl-trait/`
 
 Tests for trait impls.
+
+## `tests/ui/implied-bounds/`
+
+See [Implied bounds | Reference](https://doc.rust-lang.org/reference/trait-bounds.html#implied-bounds).
 
 ## `tests/ui/imports/`
 
@@ -854,6 +854,12 @@ Broad directory on lifetimes, including proper specifiers, lifetimes not living 
 
 These tests exercises numerical limits, such as `[[u8; 1518599999]; 1518600000]`.
 
+## `tests/ui/link-native-libs/`
+
+Tests for `#[link(name = "", kind = "")]` and `-l` command line flag.
+
+See [Tracking Issue for linking modifiers for native libraries #81490](https://github.com/rust-lang/rust/issues/81490).
+
 ## `tests/ui/linkage-attr/`
 
 Tests for the linkage attribute `#[linkage]` of `#![feature(linkage)]`.
@@ -865,12 +871,6 @@ Tests for the linkage attribute `#[linkage]` of `#![feature(linkage)]`.
 Tests on code which fails during the linking stage, or which contain arguments and lines that have been known to cause unjustified errors in the past, such as specifying an unusual `#[export_name]`.
 
 See [Linkage | Reference](https://doc.rust-lang.org/reference/linkage.html).
-
-## `tests/ui/link-native-libs/`
-
-Tests for `#[link(name = "", kind = "")]` and `-l` command line flag.
-
-See [Tracking Issue for linking modifiers for native libraries #81490](https://github.com/rust-lang/rust/issues/81490).
 
 ## `tests/ui/lint/`
 
@@ -997,6 +997,10 @@ See [RFC 3550 New Range](https://github.com/rust-lang/rfcs/blob/master/text/3550
 
 Tests for Non-lexical lifetimes. See [RFC 2094 NLL](https://rust-lang.github.io/rfcs/2094-nll.html).
 
+## `tests/ui/no_std/`
+
+Tests for where the standard library is disabled through `#![no_std]`.
+
 ## `tests/ui/non_modrs_mods/`
 
 Despite the size of the directory, this is a single test, spawning a sprawling `mod` dependency tree and checking its successful build.
@@ -1008,10 +1012,6 @@ Despite the size of the directory, this is a single test, spawning a sprawling `
 A very similar principle as `non_modrs_mods`, but with an added inline `mod` statement inside another `mod`'s code block.
 
 **FIXME**: Consider merge with `tests/ui/modules/`, keeping the directory structure.
-
-## `tests/ui/no_std/`
-
-Tests for where the standard library is disabled through `#![no_std]`.
 
 ## `tests/ui/not-panic/`
 
@@ -1134,6 +1134,10 @@ Exercises the `-Z print-type-sizes` flag.
 
 Exercises on name privacy. E.g. the meaning of `pub`, `pub(crate)`, etc.
 
+## `tests/ui/proc-macro/`
+
+Broad category of tests on proc-macros. See [Procedural Macros | Reference](https://doc.rust-lang.org/reference/procedural-macros.html).
+
 ## `tests/ui/process/`
 
 Some standard library process tests which are hard to write within standard library crate tests.
@@ -1141,10 +1145,6 @@ Some standard library process tests which are hard to write within standard libr
 ## `tests/ui/process-termination/`
 
 Some standard library process termination tests which are hard to write within standard library crate tests.
-
-## `tests/ui/proc-macro/`
-
-Broad category of tests on proc-macros. See [Procedural Macros | Reference](https://doc.rust-lang.org/reference/procedural-macros.html).
 
 ## `tests/ui/ptr_ops/`: Using operations on a pointer
 
@@ -1260,6 +1260,10 @@ Tests that exercise behaviors and features specific to the Rust 2024 edition.
 
 Tests on environmental variables that affect `rustc`.
 
+## `tests/ui/rustc_public-ir-print`
+
+Some tests for pretty printing of rustc_public's IR.
+
 ## `tests/ui/rustdoc`
 
 Hybrid tests that exercises `rustdoc`, and also some joint `rustdoc`/`rustc` interactions.
@@ -1339,10 +1343,6 @@ Stability attributes used internally by the standard library: `#[stable()]` and 
 ## `tests/ui/stack-probes`
 
 **FIXME**: Contains a single test, should likely be rehomed to `tests/ui/abi`.
-
-## `tests/ui/rustc_public-ir-print/`
-
-Some tests for pretty printing of rustc_public's IR.
 
 ## `tests/ui/stack-protector/`: `-Z stack-protector` command line flag
 
@@ -1512,13 +1512,13 @@ Tests for `type` aliases in the context of `enum` variants, such as that applied
 
 `#![feature(type_alias_impl_trait)]`. See [Type Alias Impl Trait | The Unstable book](https://doc.rust-lang.org/nightly/unstable-book/language-features/type-alias-impl-trait.html).
 
-## `tests/ui/typeck/`
-
-General collection of type checking related tests.
-
 ## `tests/ui/type-inference/`
 
 General collection of type inference related tests.
+
+## `tests/ui/typeck`
+
+General collection of type checking related tests.
 
 ## `tests/ui/ufcs/`
 
@@ -1598,13 +1598,13 @@ See:
 
 **FIXME**: Seems to also contain more generic tests that fit in `tests/ui/unsized/`.
 
-## `tests/ui/unused-crate-deps/`
-
-Exercises the `unused_crate_dependencies` lint.
-
 ## `tests/ui/unstable-feature-bound`
 
 Tests for gating and diagnostics when unstable features are used.
+
+## `tests/ui/unused-crate-deps`
+
+Exercises the `unused_crate_dependencies` lint.
 
 ## `tests/ui/unwind-abis/`
 

--- a/tests/ui/README.md
+++ b/tests/ui/README.md
@@ -22,6 +22,12 @@ These tests exercise alloc error handling.
 
 See <https://doc.rust-lang.org/std/alloc/fn.handle_alloc_error.html>.
 
+## `tests/ui/annotate-moves`
+
+These tests exercise the `annotate-moves` feature.
+
+See [`annotate-moves` | The Unstable book](https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/annotate-moves.html)
+
 ## `tests/ui/annotate-snippet`
 
 These tests exercise the [`annotate-snippets`]-based emitter implementation.
@@ -33,6 +39,12 @@ These tests exercise the [`annotate-snippets`]-based emitter implementation.
 ## `tests/ui/anon-params`
 
 These tests deal with anonymous parameters (no name, only type), a deprecated feature that becomes a hard error in Edition 2018.
+
+## `tests/ui/any`
+
+These tests exercise the `try_as_dyn` feature.
+
+See [`core::any::try_as_dyn`](https://doc.rust-lang.org/nightly/core/any/fn.try_as_dyn.html)
 
 ## `tests/ui/argfile`: External files providing command line arguments
 
@@ -244,6 +256,14 @@ See:
 
 This directory only contains one highly specific test. Other coinduction tests can be found down the deeply located `tests/ui/traits/next-solver/cycles/coinduction/` subdirectory.
 
+## `tests/ui/collections`
+
+These tests exercise the `collections` library.
+
+See [`std::collections`](https://doc.rust-lang.org/std/collections/index.html)
+
+**FIXME**: consider merge with `tests/ui/btreemap` and `tests/ui/hashmap`
+
 ## `tests/ui/command/`: `std::process::Command`
 
 This directory is actually for the standard library [`std::process::Command`](https://doc.rust-lang.org/std/process/struct.Command.html) type, where some tests are too difficult or inconvenient to write as unit tests or integration tests within the standard library itself.
@@ -380,6 +400,18 @@ These tests use the unstable command line option `query-dep-graph` to examine th
 
 Tests for `#[deprecated]` attribute and `deprecated_in_future` internal lint.
 
+## `tests/ui/deref-patterns`: `#![feature(deref_patterns)]` and `#![feature(string_deref_patterns)]`
+
+Tests for `#![feature(deref_patterns)]` and `#![feature(string_deref_patterns)]`. See [Deref patterns | The Unstable book](https://doc.rust-lang.org/nightly/unstable-book/language-features/deref-patterns.html).
+
+**FIXME**: May have some overlap with `tests/ui/pattern/deref-patterns`.
+
+## `tests/ui/deref`
+
+Tests for `Deref` and `DerefMut` traits.
+
+See [`std::ops::Deref`](https://doc.rust-lang.org/std/ops/trait.Deref.html) and [`std::ops::DerefMut`](https://doc.rust-lang.org/std/ops/trait.DerefMut.html)
+
 ## `tests/ui/derived-errors/`: Derived Error Messages
 
 Tests for quality of diagnostics involving suppression of cascading errors in some cases to avoid overwhelming the user.
@@ -429,6 +461,10 @@ Exercises diagnostics for when a code block attempts to gain ownership of a non-
 ## `tests/ui/disallowed-deconstructing/`: Incorrect struct deconstruction
 
 Exercises diagnostics for disallowed struct destructuring.
+
+## `tests/ui/dist`
+
+Tests that require distribution artifacts.
 
 ## `tests/ui/dollar-crate/`: `$crate` used with the `use` keyword
 
@@ -491,6 +527,10 @@ See [`dyn` keyword](https://doc.rust-lang.org/std/keyword.dyn.html).
 These tests run in specific Rust editions, such as Rust 2015 or Rust 2018, and check errors and functionality related to specific now-deprecated idioms and features.
 
 **FIXME**: Maybe regroup `rust-2018`, `rust-2021` and `rust-2024` under this umbrella?
+
+## `tests/ui/eii`: Externally Implementable Items
+
+Exercises `eii` keyword.
 
 ## `tests/ui/empty/`: Various tests related to the concept of "empty"
 
@@ -571,6 +611,10 @@ See:
 - [`ffi_const` | The Unstable book](https://doc.rust-lang.org/unstable-book/language-features/ffi-const.html)
 - [`ffi_pure` | The Unstable book](https://doc.rust-lang.org/beta/unstable-book/language-features/ffi-pure.html)
 
+## `tests/ui/float`
+
+See: [Tracking Issue for `f16` and `f128` float types #116909](https://github.com/rust-lang/rust/issues/116909)
+
 ## `tests/ui/fmt/`
 
 Exercises the `format!` macro.
@@ -578,6 +622,10 @@ Exercises the `format!` macro.
 ## `tests/ui/fn/`
 
 A broad category of tests on functions.
+
+## `tests/ui/fn_traits`
+
+Tests for `#![feature(fn_traits)]`. See [`fn_traits` | The Unstable book](https://doc.rust-lang.org/nightly/unstable-book/library-features/fn-traits.html).
 
 ## `tests/ui/force-inlining/`: `#[rustc_force_inline]`
 
@@ -652,6 +700,10 @@ See:
 
 - [Higher-ranked trait bounds | rustc-dev-guide](https://rustc-dev-guide.rust-lang.org/traits/hrtb.html)
 - [Higher-ranked trait bounds | Nomicon](https://doc.rust-lang.org/nomicon/hrtb.html)
+
+## `tests/ui/higher-ranked-trait-bounds`
+
+**FIXME**: move to `tests/ui/higher-ranked/trait-bounds`
 
 ## `tests/ui/hygiene/`
 
@@ -835,6 +887,10 @@ Tests exercising analysis for unused variables, unreachable statements, function
 
 **FIXME**: This seems unrelated to "liveness" as defined in the rustc compiler guide. Is this misleadingly named? https://rustc-dev-guide.rust-lang.org/borrow_check/region_inference/lifetime_parameters.html#liveness-and-universal-regions
 
+## `tests/ui/loop-match`
+
+Tests for `loop` with `match` expressions.
+
 ## `tests/ui/loops/`
 
 Tests on the `loop` construct.
@@ -981,6 +1037,15 @@ Contains a single test. Check that we reject the ancient Rust syntax `x <- y` an
 
 **FIXME**: Definitely should be rehomed, maybe to `tests/ui/deprecation/`.
 
+## `tests/ui/offload`
+
+Exercises the offload feature.
+
+See:
+
+- [`std::offload` | rustc-dev-guide](https://rustc-dev-guide.rust-lang.org/offload/internals.html)
+- [Tracking Issue for GPU-offload #131513](https://github.com/rust-lang/rust/issues/131513)
+
 ## `tests/ui/offset-of/`
 
 Exercises the [`std::mem::offset_of` macro](https://doc.rust-lang.org/beta/std/mem/macro.offset_of.html).
@@ -1038,6 +1103,16 @@ See [Patchable function entry | The Unstable book](https://doc.rust-lang.org/uns
 Broad category of tests surrounding patterns. See [Patterns | Reference](https://doc.rust-lang.org/reference/patterns.html).
 
 **FIXME**: Some overlap with `tests/ui/match/`.
+
+## `tests/ui/pin`
+
+**FIXME**: Consider merging with `tests/ui/pin-macro`.
+
+## `tests/ui/pin-ergonomics`
+
+Exercises the `#![feature(pin_ergonomics)]` feature.
+
+See [Tracking issue for pin ergonomics #130494](https://github.com/rust-lang/rust/issues/130494)
 
 ## `tests/ui/pin-macro/`
 
@@ -1103,6 +1178,12 @@ Reachability tests, primarily unreachable code and coercions into the never type
 
 **FIXME**: Check for overlap with `ui/liveness`.
 
+## `tests/ui/reborrow`
+
+Exercises the `#![feature(reborrow)]` feature.
+
+See [Tracking Issue for Reborrow trait lang experiment #145612](https://github.com/rust-lang/rust/issues/145612)
+
 ## `tests/ui/recursion/`
 
 Broad category of tests exercising recursions (compile test and run time), in functions, macros, `type` definitions, and more.
@@ -1114,6 +1195,12 @@ Also exercises the `#![recursion_limit = ""]` attribute.
 Sets a recursion limit on recursive code.
 
 **FIXME**: Should be merged with `tests/ui/recursion/`.
+
+## `tests/ui/reflection/`
+
+Exercises the `#![feature(type_info)]` feature.
+
+See [Tracking Issue for type_info #146922](https://github.com/rust-lang/rust/issues/146922)
 
 ## `tests/ui/regions/`
 
@@ -1157,9 +1244,17 @@ Exercises `.rmeta` crate metadata and the `--emit=metadata` cli flag.
 
 Tests for runtime environment on which Rust programs are executed. E.g. Unix `SIGPIPE`.
 
-## `tests/ui/rust-{2018,2021,2024}/`
+## `tests/ui/rust-2018`
 
-Tests that exercise behaviors and features that are specific to editions.
+Tests that exercise behaviors and features specific to the Rust 2018 edition.
+
+## `tests/ui/rust-2021`
+
+Tests that exercise behaviors and features specific to the Rust 2021 edition.
+
+## `tests/ui/rust-2024`
+
+Tests that exercise behaviors and features specific to the Rust 2024 edition.
 
 ## `tests/ui/rustc-env`
 
@@ -1169,9 +1264,19 @@ Tests on environmental variables that affect `rustc`.
 
 Hybrid tests that exercises `rustdoc`, and also some joint `rustdoc`/`rustc` interactions.
 
+## `tests/ui/sanitize-attr`
+
+Tests for the `#![feature(sanitize)]` attribute.
+
+See [Sanitize | The Unstable Book](https://doc.rust-lang.org/unstable-book/language-features/sanitize.html).
+
 ## `tests/ui/sanitizer/`
 
 Exercises sanitizer support. See [Sanitizer | The rustc book](https://doc.rust-lang.org/unstable-book/compiler-flags/sanitizer.html).
+
+## `tests/ui/scalable-vectors`
+
+See [Tracking Issue for Scalable Vectors #145052](https://github.com/rust-lang/rust/issues/145052)
 
 ## `tests/ui/self/`: `self` keyword
 
@@ -1211,6 +1316,12 @@ This is a test directory for the specific error case where a lifetime never gets
 
 While many tests here involve the `Sized` trait directly, some instead test, for example the slight variations between returning a zero-sized `Vec` and a `Vec` with one item, where one has no known type and the other does.
 
+## `tests/ui/sized-hierarchy`
+
+Tests for `#![feature(sized_hierarchy)]` attribute.
+
+See [Tracking Issue for Sized Hierarchy #144404](https://github.com/rust-lang/rust/issues/144404)
+
 ## `tests/ui/span/`
 
 An assorted collection of tests that involves specific diagnostic spans.
@@ -1224,6 +1335,10 @@ See [Tracking issue for specialization (RFC 1210) #31844](https://github.com/rus
 ## `tests/ui/stability-attribute/`
 
 Stability attributes used internally by the standard library: `#[stable()]` and `#[unstable()]`.
+
+## `tests/ui/stack-probes`
+
+**FIXME**: Contains a single test, should likely be rehomed to `tests/ui/abi`.
 
 ## `tests/ui/rustc_public-ir-print/`
 
@@ -1359,6 +1474,10 @@ Tests surrounding [`std::mem::transmute`](https://doc.rust-lang.org/std/mem/fn.t
 
 Exercises compiler development support flag `-Z treat-err-as-bug`.
 
+## `tests/ui/trimmed-paths/`
+
+Tests for the `#[doc(hidden)]` items.
+
 ## `tests/ui/trivial-bounds/`
 
 `#![feature(trivial_bounds)]`. See [RFC 2056 Allow trivial where clause constraints](https://github.com/rust-lang/rfcs/blob/master/text/2056-allow-trivial-where-clause-constraints.md).
@@ -1400,10 +1519,6 @@ General collection of type checking related tests.
 ## `tests/ui/type-inference/`
 
 General collection of type inference related tests.
-
-## `tests/ui/typeof/`
-
-`typeof` keyword, reserved but unimplemented.
 
 ## `tests/ui/ufcs/`
 
@@ -1486,6 +1601,10 @@ See:
 ## `tests/ui/unused-crate-deps/`
 
 Exercises the `unused_crate_dependencies` lint.
+
+## `tests/ui/unstable-feature-bound`
+
+Tests for gating and diagnostics when unstable features are used.
 
 ## `tests/ui/unwind-abis/`
 

--- a/tests/ui/async-await/async-closures/move-from-async-fn-bound.rs
+++ b/tests/ui/async-await/async-closures/move-from-async-fn-bound.rs
@@ -1,0 +1,13 @@
+//@ edition:2021
+// Test that a by-ref `AsyncFn` closure gets an error when it tries to
+// consume a value, with a helpful diagnostic pointing to the bound.
+
+fn call<F>(_: F) where F: AsyncFn() {}
+
+fn main() {
+    let y = vec![format!("World")];
+    call(async || {
+        //~^ ERROR cannot move out of `y`, a captured variable in an `AsyncFn` closure
+        y.into_iter();
+    });
+}

--- a/tests/ui/async-await/async-closures/move-from-async-fn-bound.stderr
+++ b/tests/ui/async-await/async-closures/move-from-async-fn-bound.stderr
@@ -1,0 +1,30 @@
+error[E0507]: cannot move out of `y`, a captured variable in an `AsyncFn` closure
+  --> $DIR/move-from-async-fn-bound.rs:9:10
+   |
+LL |     let y = vec![format!("World")];
+   |         - captured outer variable
+LL |     call(async || {
+   |          ^^^^^^^^
+   |          |
+   |          captured by this `AsyncFn` closure
+   |          `y` is moved here
+LL |
+LL |         y.into_iter();
+   |         -
+   |         |
+   |         variable moved due to use in coroutine
+   |         move occurs because `y` has type `Vec<String>`, which does not implement the `Copy` trait
+   |
+help: `AsyncFn` and `AsyncFnMut` closures require captured values to be able to be consumed multiple times, but `AsyncFnOnce` closures may consume them only once
+  --> $DIR/move-from-async-fn-bound.rs:5:27
+   |
+LL | fn call<F>(_: F) where F: AsyncFn() {}
+   |                           ^^^^^^^^^
+help: consider cloning the value if the performance cost is acceptable
+   |
+LL |         y.clone().into_iter();
+   |          ++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0507`.

--- a/tests/ui/lint/invalid_value-polymorphic.rs
+++ b/tests/ui/lint/invalid_value-polymorphic.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --crate-type=lib -Zmir-enable-passes=+InstSimplify
+//@ compile-flags: --crate-type=lib -Zmir-enable-passes=+InstSimplify-before-inline
 //@ build-pass
 
 #![feature(core_intrinsics)]

--- a/tests/ui/mir/enable_passes_validation.enum_not_in_pass_names.stderr
+++ b/tests/ui/mir/enable_passes_validation.enum_not_in_pass_names.stderr
@@ -1,0 +1,8 @@
+warning: MIR pass `SimplifyCfg` is unknown and will be ignored
+
+warning: MIR pass `SimplifyCfg` is unknown and will be ignored
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: 2 warnings emitted
+

--- a/tests/ui/mir/enable_passes_validation.rs
+++ b/tests/ui/mir/enable_passes_validation.rs
@@ -1,4 +1,5 @@
 //@ revisions: empty unprefixed all_unknown all_known mixed
+//@ revisions: enum_not_in_pass_names enum_in_pass_names
 
 //@[empty] compile-flags: -Zmir-enable-passes=
 
@@ -13,6 +14,12 @@
 //@[mixed] check-pass
 //@[mixed] compile-flags: -Zmir-enable-passes=+ThisPassDoesNotExist,+CheckAlignment
 
+//@[enum_not_in_pass_names] check-pass
+//@[enum_not_in_pass_names] compile-flags: -Zmir-enable-passes=+SimplifyCfg
+
+//@[enum_in_pass_names] check-pass
+//@[enum_in_pass_names] compile-flags: -Zmir-enable-passes=+AddCallGuards
+
 fn main() {}
 
 //[empty]~? ERROR incorrect value `` for unstable option `mir-enable-passes`
@@ -23,3 +30,5 @@ fn main() {}
 //[all_unknown]~? WARN MIR pass `DoesNotExist` is unknown and will be ignored
 //[all_unknown]~? WARN MIR pass `ThisPass` is unknown and will be ignored
 //[all_unknown]~? WARN MIR pass `DoesNotExist` is unknown and will be ignored
+//[enum_not_in_pass_names]~? WARN MIR pass `SimplifyCfg` is unknown and will be ignored
+//[enum_not_in_pass_names]~? WARN MIR pass `SimplifyCfg` is unknown and will be ignored

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1182,11 +1182,11 @@ cc = ["@Muscraft"]
 
 [mentions."compiler/rustc_errors/src/translation.rs"]
 message = "`rustc_errors::translation` was changed"
-cc = ["@davidtwco", "@TaKO8Ki"]
+cc = ["@davidtwco", "@TaKO8Ki", "@JonathanBrouwer"]
 
 [mentions."compiler/rustc_macros/src/diagnostics"]
 message = "`rustc_macros::diagnostics` was changed"
-cc = ["@davidtwco", "@TaKO8Ki"]
+cc = ["@davidtwco", "@TaKO8Ki", "@JonathanBrouwer"]
 
 [mentions."compiler/rustc_public"]
 message = "This PR changes rustc_public"


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#150474 (Tidy: detect ui tests subdirectory changes so `tests/ui/README.md` stays in sync)
 - rust-lang/rust#150572 (Improve move error diagnostic for `AsyncFn` closures)
 - rust-lang/rust#151596 (Fix -Zmir-enable-passes to detect unregistered enum names in declare_passes macro)
 - rust-lang/rust#151802 (Make `QueryDispatcher::Qcx` an associated type)
 - rust-lang/rust#151559 ([rustdoc] Add a marker to tell users that there are hidden (deprecated) items in the search results)
 - rust-lang/rust#151665 (Fix contrast ratio for `Since` element in rustodoc dark theme)
 - rust-lang/rust#151798 (Update `askama` to `0.15.3`)
 - rust-lang/rust#151800 (Subscribe myself to translation diagnostics)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=150474,150572,151596,151802,151559,151665,151798,151800)
<!-- homu-ignore:end -->

