### PR TITLE
Document, sort, and tweak spellcheck entries in `typos.toml`

### DIFF
--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -60,7 +60,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         }
     }
 
-    /// Create a name definitinon from the given components, and put it into the local module.
+    /// Create a name definition from the given components, and put it into the local module.
     fn define_local(
         &mut self,
         parent: Module<'ra>,
@@ -76,7 +76,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         self.plant_decl_into_local_module(ident, orig_ident.span, ns, decl);
     }
 
-    /// Create a name definitinon from the given components, and put it into the extern module.
+    /// Create a name definition from the given components, and put it into the extern module.
     fn define_extern(
         &self,
         parent: Module<'ra>,

--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -32,6 +32,7 @@ fn main() {
     let npm: PathBuf = env::args_os().nth(5).expect("need name/path of npm command").into();
 
     let root_manifest = root_path.join("Cargo.toml");
+    let typos_toml = root_path.join("typos.toml");
     let src_path = root_path.join("src");
     let tests_path = root_path.join("tests");
     let library_path = root_path.join("library");
@@ -143,6 +144,7 @@ fn main() {
         check!(edition, &library_path);
 
         check!(alphabetical, &root_manifest);
+        check!(alphabetical, &typos_toml);
         check!(alphabetical, &src_path);
         check!(alphabetical, &tests_path);
         check!(alphabetical, &compiler_path);

--- a/typos.toml
+++ b/typos.toml
@@ -1,3 +1,6 @@
+# Config for the `typos` crate, used by `./x test tidy --extra-checks=spellcheck`.
+# See also: https://github.com/crate-ci/typos/blob/v1.28.2/docs/reference.md
+
 [files]
 extend-exclude = [
     # exclude git (sub)modules and generated content
@@ -13,9 +16,10 @@ extend-exclude = [
 ]
 
 [default.extend-words]
-# Add exclusions here, lines should be like `x = "x"`, where `x` is excluded word.
+# Allowlist for words that look like typos but are not, or aren't worth fixing
+# right now. Entries should look like `mipsel = "mipsel"`.
 #
-# Also see docs: https://github.com/crate-ci/typos/blob/v1.28.2/docs/reference.md
+# tidy-alphabetical-start
 arange = "arange"
 childs = "childs"
 clonable = "clonable"
@@ -24,6 +28,7 @@ leafs = "leafs"
 makro = "makro"
 misformed = "misformed"
 moreso = "moreso"
+numer = "numer"
 optin = "optin"
 publically = "publically"
 rplace = "rplace"
@@ -33,33 +38,42 @@ targetting = "targetting"
 unparseable = "unparseable"
 unstability = "unstability"
 unstalled = "unstalled"
-numer = "numer"
+# tidy-alphabetical-end
+
+# Denylist to forbid misspelled words that aren't detected by the built-in
+# dictionary. Entries should look like `mipsel = ""` or `mipsel = "misspell"`;
+# the non-empty form can be automatically fixed by `--bless`.
+#
+# tidy-alphabetical-start
+# tidy-alphabetical-end
 
 [default.extend-identifiers]
-# An entry goes here if the typo is part of some existing ident
-# where you want to keep it, but don't want to allow
-# such typos everywhere.
+# Allowlist for specific identifiers that should be permitted even though they
+# appear to contain typos that would be forbidden in other identifiers.
 #
-# I.e. you don't want (or can't) fix some constant name, like
-# `DNS_ERROR_INVAILD_VIRTUALIZATION_INSTANCE_NAME` but actually
-# want to see `INVAILD` typo fixed in other places.
-debug_aranges = "debug_aranges"
+# For example, you might want to allow a specific constant like
+# `DNS_ERROR_INVAILD_VIRTUALIZATION_INSTANCE_NAME`, but still want to forbid
+# the typo `INVAILD` in other places.
+#
+# tidy-alphabetical-start
 DNS_ERROR_INVAILD_VIRTUALIZATION_INSTANCE_NAME = "DNS_ERROR_INVAILD_VIRTUALIZATION_INSTANCE_NAME"
-EnzymeTypeTreeShiftIndiciesEq = "EnzymeTypeTreeShiftIndiciesEq"
-EnzymeTypeTreeShiftIndiciesEqFn = "EnzymeTypeTreeShiftIndiciesEqFn"
-shift_indicies_eq = "shift_indicies_eq"
 ERRNO_ACCES = "ERRNO_ACCES"
 ERROR_DS_FILTER_USES_CONTRUCTED_ATTRS = "ERROR_DS_FILTER_USES_CONTRUCTED_ATTRS"
 ERROR_DS_NOT_AUTHORITIVE_FOR_DST_NC = "ERROR_DS_NOT_AUTHORITIVE_FOR_DST_NC"
 ERROR_FILENAME_EXCED_RANGE = "ERROR_FILENAME_EXCED_RANGE"
 ERROR_MCA_OCCURED = "ERROR_MCA_OCCURED"
 ERROR_REQ_NOT_ACCEP = "ERROR_REQ_NOT_ACCEP"
+EnzymeTypeTreeShiftIndiciesEq = "EnzymeTypeTreeShiftIndiciesEq"
+EnzymeTypeTreeShiftIndiciesEqFn = "EnzymeTypeTreeShiftIndiciesEqFn"
 Oppen = "Oppen"
 # typos treats this as two different camelcase words (`SETTIN` and `Gs`)
 # Tracked in: https://github.com/crate-ci/typos/issues/745
 SETTINGs = "SETTINGs"
+debug_aranges = "debug_aranges"
 key_smove = "key_smove" # shifted move key, used by terminfo
+shift_indicies_eq = "shift_indicies_eq"
 tolen = "tolen"
+# tidy-alphabetical-end
 
 [default]
 extend-ignore-words-re = [

--- a/typos.toml
+++ b/typos.toml
@@ -20,24 +20,24 @@ extend-exclude = [
 # right now. Entries should look like `mipsel = "mipsel"`.
 #
 # tidy-alphabetical-start
-arange = "arange"
+arange = "arange" # short for A-range
 childs = "childs"
 clonable = "clonable"
-filetimes = "filetimes"
+filetimes = "filetimes" # short for "file times", not a typo for "lifetimes"
 leafs = "leafs"
-makro = "makro"
+makro = "makro" # deliberate misspelling to avoid `macro` keyword
 misformed = "misformed"
 moreso = "moreso"
-numer = "numer"
-optin = "optin"
+numer = "numer" # short for numerator, not a typo for "number"
+optin = "optin" # short for opt-in
 publically = "publically"
-rplace = "rplace"
+rplace = "rplace" # short for R-place
 splitted = "splitted"
-taits = "taits"
+taits = "taits" # lowercase for TAITs (type alias impl trait)
 targetting = "targetting"
 unparseable = "unparseable"
 unstability = "unstability"
-unstalled = "unstalled"
+unstalled = "unstalled" # short for un-stalled
 # tidy-alphabetical-end
 
 # Denylist to forbid misspelled words that aren't detected by the built-in
@@ -65,14 +65,14 @@ ERROR_MCA_OCCURED = "ERROR_MCA_OCCURED"
 ERROR_REQ_NOT_ACCEP = "ERROR_REQ_NOT_ACCEP"
 EnzymeTypeTreeShiftIndiciesEq = "EnzymeTypeTreeShiftIndiciesEq"
 EnzymeTypeTreeShiftIndiciesEqFn = "EnzymeTypeTreeShiftIndiciesEqFn"
-Oppen = "Oppen"
+Oppen = "Oppen" # Derek C. Oppen, author of "Pretty Printing" (1979)
 # typos treats this as two different camelcase words (`SETTIN` and `Gs`)
 # Tracked in: https://github.com/crate-ci/typos/issues/745
 SETTINGs = "SETTINGs"
-debug_aranges = "debug_aranges"
+debug_aranges = "debug_aranges" # debug A-ranges
 key_smove = "key_smove" # shifted move key, used by terminfo
 shift_indicies_eq = "shift_indicies_eq"
-tolen = "tolen"
+tolen = "tolen" # length of "to" buffer, used by `sendto` in Windows sockets
 # tidy-alphabetical-end
 
 [default]

--- a/typos.toml
+++ b/typos.toml
@@ -19,7 +19,6 @@ extend-exclude = [
 arange = "arange"
 childs = "childs"
 clonable = "clonable"
-Datas = "Datas"
 filetimes = "filetimes"
 leafs = "leafs"
 makro = "makro"
@@ -28,7 +27,6 @@ moreso = "moreso"
 optin = "optin"
 publically = "publically"
 rplace = "rplace"
-smove = "smove"
 splitted = "splitted"
 taits = "taits"
 targetting = "targetting"
@@ -36,9 +34,6 @@ unparseable = "unparseable"
 unstability = "unstability"
 unstalled = "unstalled"
 numer = "numer"
-
-# this can be valid word, depends on dictionary edition
-#matcheable = "matcheable"
 
 [default.extend-identifiers]
 # An entry goes here if the typo is part of some existing ident
@@ -63,6 +58,7 @@ Oppen = "Oppen"
 # typos treats this as two different camelcase words (`SETTIN` and `Gs`)
 # Tracked in: https://github.com/crate-ci/typos/issues/745
 SETTINGs = "SETTINGs"
+key_smove = "key_smove" # shifted move key, used by terminfo
 tolen = "tolen"
 
 [default]

--- a/typos.toml
+++ b/typos.toml
@@ -45,6 +45,7 @@ unstalled = "unstalled" # short for un-stalled
 # the non-empty form can be automatically fixed by `--bless`.
 #
 # tidy-alphabetical-start
+definitinon = "definition"
 # tidy-alphabetical-end
 
 [default.extend-identifiers]


### PR DESCRIPTION
- This grew out of rust-lang/rust#151781, which was originally a simple typo fix.