### PR TITLE
citool: report debuginfo test statistics

### DIFF
--- a/src/build_helper/src/metrics.rs
+++ b/src/build_helper/src/metrics.rs
@@ -111,6 +111,29 @@ pub struct JsonStepSystemStats {
     pub cpu_utilization_percent: f64,
 }
 
+#[derive(Eq, Hash, PartialEq, Debug)]
+pub enum DebuggerKind {
+    Gdb,
+    Lldb,
+    Cdb,
+}
+
+impl DebuggerKind {
+    pub fn debuginfo_kind(name: &str) -> Option<DebuggerKind> {
+        let name = name.to_ascii_lowercase();
+
+        if name.contains("debuginfo-gdb") {
+            Some(DebuggerKind::Gdb)
+        } else if name.contains("debuginfo-lldb") {
+            Some(DebuggerKind::Lldb)
+        } else if name.contains("debuginfo-cdb") {
+            Some(DebuggerKind::Cdb)
+        } else {
+            None
+        }
+    }
+}
+
 fn null_as_f64_nan<'de, D: serde::Deserializer<'de>>(d: D) -> Result<f64, D::Error> {
     use serde::Deserialize as _;
     Option::<f64>::deserialize(d).map(|f| f.unwrap_or(f64::NAN))

--- a/src/ci/citool/src/analysis.rs
+++ b/src/ci/citool/src/analysis.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use std::time::Duration;
 
 use build_helper::metrics::{
-    BuildStep, JsonRoot, TestOutcome, TestSuite, TestSuiteMetadata, escape_step_name,
+    BuildStep, DebuggerKind, JsonRoot, TestOutcome, TestSuite, TestSuiteMetadata, escape_step_name,
     format_build_steps,
 };
 
@@ -139,8 +139,36 @@ fn record_test_suites(metrics: &JsonRoot) {
         let table = render_table(aggregated);
         println!("\n# Test results\n");
         println!("{table}");
+        report_debuginfo_statistics(&suites);
     } else {
         eprintln!("No test suites found in metrics");
+    }
+}
+
+fn report_debuginfo_statistics(suites: &[&TestSuite]) {
+    let mut debugger_test_record: HashMap<DebuggerKind, TestSuiteRecord> = HashMap::new();
+    for suite in suites {
+        if let TestSuiteMetadata::Compiletest { .. } = suite.metadata {
+            for test in &suite.tests {
+                if let Some(kind) = DebuggerKind::debuginfo_kind(&test.name) {
+                    let record =
+                        debugger_test_record.entry(kind).or_insert(TestSuiteRecord::default());
+                    match test.outcome {
+                        TestOutcome::Passed => record.passed += 1,
+                        TestOutcome::Ignored { .. } => record.ignored += 1,
+                        TestOutcome::Failed => record.failed += 1,
+                    }
+                }
+            }
+        }
+    }
+
+    println!("## DebugInfo Test Statistics");
+    for (kind, record) in debugger_test_record {
+        println!(
+            "- {:?}: Passed ✅={}, Failed ❌={}, Ignored 🚫={}",
+            kind, record.passed, record.failed, record.ignored
+        );
     }
 }
 


### PR DESCRIPTION
Extend CI postprocessing to aggregate pass/fail/ignored counts for debuginfo tests. Tests are identified via their reported suite names (e.g. debuginfo-gdb, debuginfo-lldb or debuginfo-cdb).

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? Kobzol
-->
<!-- homu-ignore:end -->
