### PR TITLE
Fix missing syntax context in lifetime hygiene debug output

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1961,7 +1961,8 @@ impl<'a> State<'a> {
     }
 
     fn print_lifetime(&mut self, lifetime: ast::Lifetime) {
-        self.print_name(lifetime.ident.name)
+        self.word(lifetime.ident.name.to_string());
+        self.ann_post(lifetime.ident)
     }
 
     fn print_lifetime_bounds(&mut self, bounds: &ast::GenericBounds) {

--- a/tests/ui/hygiene/unpretty-debug-lifetimes.rs
+++ b/tests/ui/hygiene/unpretty-debug-lifetimes.rs
@@ -1,0 +1,18 @@
+//@ check-pass
+//@ compile-flags: -Zunpretty=expanded,hygiene
+
+// Regression test for lifetime hygiene annotations in -Zunpretty=expanded,hygiene
+// Previously, lifetimes were missing the #N syntax context suffix.
+
+// Don't break whenever Symbol numbering changes
+//@ normalize-stdout: "\d+#" -> "0#"
+
+#![feature(decl_macro)]
+#![feature(no_core)]
+#![no_core]
+
+macro lifetime_hygiene($f:ident<$a:lifetime>) {
+    fn $f<$a, 'a>() {}
+}
+
+lifetime_hygiene!(f<'a>);

--- a/tests/ui/hygiene/unpretty-debug-lifetimes.stdout
+++ b/tests/ui/hygiene/unpretty-debug-lifetimes.stdout
@@ -1,0 +1,31 @@
+//@ check-pass
+//@ compile-flags: -Zunpretty=expanded,hygiene
+
+// Regression test for lifetime hygiene annotations in -Zunpretty=expanded,hygiene
+// Previously, lifetimes were missing the #N syntax context suffix.
+
+// Don't break whenever Symbol numbering changes
+//@ normalize-stdout: "\d+#" -> "0#"
+
+#![feature /* 0#0 */(decl_macro)]
+#![feature /* 0#0 */(no_core)]
+#![no_core /* 0#0 */]
+
+macro lifetime_hygiene
+    /*
+    0#0
+    */ {
+    ($f:ident<$a:lifetime>) => { fn $f<$a, 'a>() {} }
+}
+fn f /* 0#0 */<'a /* 0#0 */, 'a /* 0#1 */>() {}
+
+
+/*
+Expansions:
+crate0::{{expn0}}: parent: crate0::{{expn0}}, call_site_ctxt: #0, def_site_ctxt: #0, kind: Root
+crate0::{{expn1}}: parent: crate0::{{expn0}}, call_site_ctxt: #0, def_site_ctxt: #0, kind: Macro(Bang, "lifetime_hygiene")
+
+SyntaxContexts:
+#0: parent: #0, outer_mark: (crate0::{{expn0}}, Opaque)
+#1: parent: #0, outer_mark: (crate0::{{expn1}}, Opaque)
+*/


### PR DESCRIPTION
`-Zunpretty=expanded,hygiene` was not printing the syntax context for lifetimes. For example, two macro-generated lifetimes `'a` with different hygiene would both print as `/* 2538 */` instead of `/* 2538#0 */` and `/* 2538#1 */`, making it impossible to distinguish them.

This was fixed by changing `print_lifetime` to call `ann_post()` with the full `Ident`, matching how regular identifiers are handled in `print_ident`.

Closes: rust-lang/rust#151797

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
