### PR TITLE
Implement `TryFrom<OsString>` for `String`

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -287,6 +287,7 @@
 #![feature(f128)]
 #![feature(ffi_const)]
 #![feature(formatting_options)]
+#![feature(from_utf8_error_internals)]
 #![feature(funnel_shifts)]
 #![feature(if_let_guard)]
 #![feature(intra_doc_pointers)]


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/151822)*
<!-- homu-ignore:end -->

**This is draft because I was unable to compile locally, it will be probably broken for a few iterations.**

Being able to generically convert strings can be beneficial for argument parsing code and similar situations especially in case of conditional conversions. The standard library already provided this converion, just not via a trait. This commit fills the gap by adding the impl.

This addition was approved in [ACP 732]. It was requested that `FromUtf8Error` should be made generic over the input and this commit obeys the request. However some challenges were encountered:

* The fields were private and the type had no constructor - solved by making the fields public but unstable and `#[doc(hidden)]`.
* There is a method to perform lossy conversion and it looks like it should be provided for `OsString` as well - this is not yet resolved.
* `into_os_string` method was requested but the types are in different crates - solved with `#[rustc_allow_incoherent_impl]`.

[ACP 732]: https://github.com/rust-lang/libs-team/issues/732

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
