### PR TITLE
remove `TokenStream` from the bridge

### DIFF
--- a/library/proc_macro/src/bridge/handle.rs
+++ b/library/proc_macro/src/bridge/handle.rs
@@ -3,7 +3,6 @@
 use std::collections::BTreeMap;
 use std::hash::Hash;
 use std::num::NonZero;
-use std::ops::Index;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use super::fxhash::FxHashMap;
@@ -11,59 +10,32 @@ use super::fxhash::FxHashMap;
 pub(super) type Handle = NonZero<u32>;
 
 /// A store that associates values of type `T` with numeric handles. A value can
-/// be looked up using its handle.
-pub(super) struct OwnedStore<T: 'static> {
+/// be looked up using its handle. Avoids storing any value more than once.
+pub(super) struct InternedStore<T: 'static> {
     counter: &'static AtomicU32,
     data: BTreeMap<Handle, T>,
-}
-
-impl<T> OwnedStore<T> {
-    pub(super) fn new(counter: &'static AtomicU32) -> Self {
-        // Ensure the handle counter isn't 0, which would panic later,
-        // when `NonZero::new` (aka `Handle::new`) is called in `alloc`.
-        assert_ne!(counter.load(Ordering::Relaxed), 0);
-
-        OwnedStore { counter, data: BTreeMap::new() }
-    }
-}
-
-impl<T> OwnedStore<T> {
-    pub(super) fn alloc(&mut self, x: T) -> Handle {
-        let counter = self.counter.fetch_add(1, Ordering::Relaxed);
-        let handle = Handle::new(counter).expect("`proc_macro` handle counter overflowed");
-        assert!(self.data.insert(handle, x).is_none());
-        handle
-    }
-
-    pub(super) fn take(&mut self, h: Handle) -> T {
-        self.data.remove(&h).expect("use-after-free in `proc_macro` handle")
-    }
-}
-
-impl<T> Index<Handle> for OwnedStore<T> {
-    type Output = T;
-    fn index(&self, h: Handle) -> &T {
-        self.data.get(&h).expect("use-after-free in `proc_macro` handle")
-    }
-}
-
-/// Like `OwnedStore`, but avoids storing any value more than once.
-pub(super) struct InternedStore<T: 'static> {
-    owned: OwnedStore<T>,
     interner: FxHashMap<T, Handle>,
 }
 
 impl<T: Copy + Eq + Hash> InternedStore<T> {
     pub(super) fn new(counter: &'static AtomicU32) -> Self {
-        InternedStore { owned: OwnedStore::new(counter), interner: FxHashMap::default() }
+        // Ensure the handle counter isn't 0, which would panic later,
+        // when `NonZero::new` (aka `Handle::new`) is called in `alloc`.
+        assert_ne!(counter.load(Ordering::Relaxed), 0);
+
+        InternedStore { counter, data: BTreeMap::new(), interner: FxHashMap::default() }
     }
 
     pub(super) fn alloc(&mut self, x: T) -> Handle {
-        let owned = &mut self.owned;
-        *self.interner.entry(x).or_insert_with(|| owned.alloc(x))
+        *self.interner.entry(x).or_insert_with(|| {
+            let counter = self.counter.fetch_add(1, Ordering::Relaxed);
+            let handle = Handle::new(counter).expect("`proc_macro` handle counter overflowed");
+            assert!(self.data.insert(handle, x).is_none());
+            handle
+        })
     }
 
     pub(super) fn copy(&mut self, h: Handle) -> T {
-        self.owned[h]
+        *self.data.get(&h).expect("use-after-free in `proc_macro` handle")
     }
 }

--- a/library/proc_macro/src/bridge/symbol.rs
+++ b/library/proc_macro/src/bridge/symbol.rs
@@ -94,7 +94,7 @@ impl fmt::Display for Symbol {
 }
 
 impl<S> Encode<S> for Symbol {
-    fn encode(self, w: &mut Buffer, s: &mut S) {
+    fn encode(&self, w: &mut Buffer, s: &mut S) {
         self.with(|sym| sym.encode(w, s))
     }
 }
@@ -106,8 +106,8 @@ impl<S: server::Server> Decode<'_, '_, server::HandleStore<S>> for server::Marke
 }
 
 impl<S: server::Server> Encode<server::HandleStore<S>> for server::MarkedSymbol<S> {
-    fn encode(self, w: &mut Buffer, s: &mut server::HandleStore<S>) {
-        S::with_symbol_string(&self.unmark(), |sym| sym.encode(w, s))
+    fn encode(&self, w: &mut Buffer, s: &mut server::HandleStore<S>) {
+        S::with_symbol_string(&self.value, |sym| sym.encode(w, s))
     }
 }
 

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/bridge.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/bridge.rs
@@ -4,9 +4,10 @@ use rustc_proc_macro::bridge as pm_bridge;
 
 pub use pm_bridge::{DelimSpan, Diagnostic, ExpnGlobals, LitKind};
 
+pub type TokenStream<S> = pm_bridge::TokenStream<S, intern::Symbol>;
 pub type TokenTree<S> =
-    pm_bridge::TokenTree<crate::token_stream::TokenStream<S>, S, intern::Symbol>;
+    pm_bridge::TokenTree<S, intern::Symbol>;
 pub type Literal<S> = pm_bridge::Literal<S, intern::Symbol>;
-pub type Group<S> = pm_bridge::Group<crate::token_stream::TokenStream<S>, S>;
+pub type Group<S> = pm_bridge::Group<S, intern::Symbol>;
 pub type Punct<S> = pm_bridge::Punct<S>;
 pub type Ident<S> = pm_bridge::Ident<S, intern::Symbol>;

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/dylib.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/dylib.rs
@@ -3,7 +3,6 @@
 mod proc_macros;
 mod version;
 
-use rustc_proc_macro::bridge;
 use std::{fmt, fs, io, time::SystemTime};
 use temp_dir::TempDir;
 
@@ -46,10 +45,7 @@ impl Expander {
         call_site: S,
         mixed_site: S,
         callback: Option<ProcMacroClientHandle<'_>>,
-    ) -> Result<TokenStream<S>, PanicMessage>
-    where
-        <S::Server<'a> as bridge::server::Server>::TokenStream: Default,
-    {
+    ) -> Result<TokenStream<S>, PanicMessage> {
         self.inner
             .proc_macros
             .expand(macro_name, macro_body, attribute, def_site, call_site, mixed_site, callback)

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/dylib/proc_macros.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/dylib/proc_macros.rs
@@ -32,29 +32,29 @@ impl ProcMacros {
                     let res = client.run(
                         &bridge::server::SAME_THREAD,
                         S::make_server(call_site, def_site, mixed_site, callback),
-                        macro_body,
+                        macro_body.into_bridge(),
                         cfg!(debug_assertions),
                     );
-                    return res.map_err(crate::PanicMessage::from);
+                    return res.map(TokenStream::from_bridge).map_err(crate::PanicMessage::from);
                 }
                 bridge::client::ProcMacro::Bang { name, client } if *name == macro_name => {
                     let res = client.run(
                         &bridge::server::SAME_THREAD,
                         S::make_server(call_site, def_site, mixed_site, callback),
-                        macro_body,
+                        macro_body.into_bridge(),
                         cfg!(debug_assertions),
                     );
-                    return res.map_err(crate::PanicMessage::from);
+                    return res.map(TokenStream::from_bridge).map_err(crate::PanicMessage::from);
                 }
                 bridge::client::ProcMacro::Attr { name, client } if *name == macro_name => {
                     let res = client.run(
                         &bridge::server::SAME_THREAD,
                         S::make_server(call_site, def_site, mixed_site, callback),
-                        parsed_attributes,
-                        macro_body,
+                        parsed_attributes.into_bridge(),
+                        macro_body.into_bridge(),
                         cfg!(debug_assertions),
                     );
-                    return res.map_err(crate::PanicMessage::from);
+                    return res.map(TokenStream::from_bridge).map_err(crate::PanicMessage::from);
                 }
                 _ => continue,
             }

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/lib.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/lib.rs
@@ -61,7 +61,7 @@ pub use span;
 
 pub use crate::bridge::*;
 pub use crate::server_impl::literal_from_str;
-pub use crate::token_stream::{TokenStream, TokenStreamIter, literal_to_string};
+pub use crate::token_stream::{TokenStream, TokenTree, Group, TokenStreamIter, literal_to_string};
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum ProcMacroKind {
@@ -235,9 +235,7 @@ impl ProcMacroSrv<'_> {
 }
 
 pub trait ProcMacroSrvSpan: Copy + Send + Sync {
-    type Server<'a>: rustc_proc_macro::bridge::server::Server<
-            TokenStream = crate::token_stream::TokenStream<Self>,
-        >;
+    type Server<'a>: rustc_proc_macro::bridge::server::Server<Span = Self, Symbol = intern::Symbol>;
     fn make_server<'a>(
         call_site: Self,
         def_site: Self,

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/server_impl/rust_analyzer_span.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/server_impl/rust_analyzer_span.rs
@@ -15,7 +15,7 @@ use span::{FIXUP_ERASED_FILE_AST_ID_MARKER, Span, TextRange, TextSize};
 
 use crate::{
     ProcMacroClientHandle,
-    bridge::{Diagnostic, ExpnGlobals, Literal, TokenTree},
+    bridge::{Diagnostic, ExpnGlobals, Literal},
     server_impl::literal_from_str,
 };
 
@@ -30,8 +30,10 @@ pub struct RaSpanServer<'a> {
     pub callback: Option<ProcMacroClientHandle<'a>>,
 }
 
+type TokenStream = crate::token_stream::TokenStream<Span>;
+type BridgeTokenStream = crate::bridge::TokenStream<Span>;
+
 impl server::Server for RaSpanServer<'_> {
-    type TokenStream = crate::token_stream::TokenStream<Span>;
     type Span = Span;
     type Symbol = Symbol;
 
@@ -71,68 +73,22 @@ impl server::Server for RaSpanServer<'_> {
         // FIXME handle diagnostic
     }
 
-    fn ts_drop(&mut self, stream: Self::TokenStream) {
-        drop(stream);
-    }
-
-    fn ts_clone(&mut self, stream: &Self::TokenStream) -> Self::TokenStream {
-        stream.clone()
-    }
-
-    fn ts_is_empty(&mut self, stream: &Self::TokenStream) -> bool {
-        stream.is_empty()
-    }
-    fn ts_from_str(&mut self, src: &str) -> Result<Self::TokenStream, String> {
-        Self::TokenStream::from_str(src, self.call_site)
+    fn ts_from_str(&mut self, src: &str) -> Result<BridgeTokenStream, String> {
+        TokenStream::from_str(src, self.call_site)
             .map_err(|e| format!("failed to parse str to token stream: {e}"))
+            .map(TokenStream::into_bridge)
     }
-    fn ts_to_string(&mut self, stream: &Self::TokenStream) -> String {
-        stream.to_string()
-    }
-
-    fn ts_from_token_tree(&mut self, tree: TokenTree<Self::Span>) -> Self::TokenStream {
-        Self::TokenStream::new(vec![tree])
+    fn ts_to_string(&mut self, stream: BridgeTokenStream) -> String {
+        TokenStream::from_bridge(stream).to_string()
     }
 
-    fn ts_expand_expr(&mut self, self_: &Self::TokenStream) -> Result<Self::TokenStream, ()> {
+    fn ts_expand_expr(&mut self, self_: BridgeTokenStream) -> Result<BridgeTokenStream, ()> {
         // FIXME: requires db, more importantly this requires name resolution so we would need to
         // eagerly expand this proc-macro, but we can't know that this proc-macro is eager until we
         // expand it ...
         // This calls for some kind of marker that a proc-macro wants to access this eager API,
         // otherwise we need to treat every proc-macro eagerly / or not support this.
-        Ok(self_.clone())
-    }
-
-    fn ts_concat_trees(
-        &mut self,
-        base: Option<Self::TokenStream>,
-        trees: Vec<TokenTree<Self::Span>>,
-    ) -> Self::TokenStream {
-        match base {
-            Some(mut base) => {
-                for tt in trees {
-                    base.push_tree(tt);
-                }
-                base
-            }
-            None => Self::TokenStream::new(trees),
-        }
-    }
-
-    fn ts_concat_streams(
-        &mut self,
-        base: Option<Self::TokenStream>,
-        streams: Vec<Self::TokenStream>,
-    ) -> Self::TokenStream {
-        let mut stream = base.unwrap_or_default();
-        for s in streams {
-            stream.push_stream(s);
-        }
-        stream
-    }
-
-    fn ts_into_trees(&mut self, stream: Self::TokenStream) -> Vec<TokenTree<Self::Span>> {
-        (*stream.0).clone()
+        Ok(self_)
     }
 
     fn span_debug(&mut self, span: Self::Span) -> String {

--- a/tests/ui/async-await/issues/issue-60674.stdout
+++ b/tests/ui/async-await/issues/issue-60674.stdout
@@ -1,3 +1,3 @@
-async fn f(mut x: u8) {}
-async fn g((mut x, y, mut z): (u8, u8, u8)) {}
-async fn g(mut x: u8, (a, mut b, c): (u8, u8, u8), y: u8) {}
+async fn f(mut x : u8) {}
+async fn g((mut x, y, mut z) : (u8, u8, u8)) {}
+async fn g(mut x : u8, (a, mut b, c) : (u8, u8, u8), y : u8) {}

--- a/tests/ui/proc-macro/allowed-attr-stmt-expr.stdout
+++ b/tests/ui/proc-macro/allowed-attr-stmt-expr.stdout
@@ -87,8 +87,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
         span: $DIR/allowed-attr-stmt-expr.rs:57:33: 57:34 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): #[expect_my_macro_stmt] my_macro!("{}", string);
-PRINT-ATTR RE-COLLECTED (DISPLAY): #[expect_my_macro_stmt] my_macro! ("{}", string);
+PRINT-ATTR INPUT (DISPLAY): #[expect_my_macro_stmt] my_macro! ("{}", string);
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',
@@ -141,8 +140,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
         span: $DIR/allowed-attr-stmt-expr.rs:61:28: 61:29 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): second_make_stmt!(#[allow(dead_code)] struct Bar {});
-PRINT-ATTR RE-COLLECTED (DISPLAY): second_make_stmt! (#[allow(dead_code)] struct Bar {});
+PRINT-ATTR INPUT (DISPLAY): second_make_stmt! (#[allow(dead_code)] struct Bar {});
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "second_make_stmt",

--- a/tests/ui/proc-macro/attr-complex-fn.stdout
+++ b/tests/ui/proc-macro/attr-complex-fn.stdout
@@ -1,5 +1,4 @@
-PRINT-ATTR INPUT (DISPLAY): fn foo<T: MyTrait<MyStruct<{ true }>>>() {}
-PRINT-ATTR RE-COLLECTED (DISPLAY): fn foo < T : MyTrait < MyStruct < { true } >>> () {}
+PRINT-ATTR INPUT (DISPLAY): fn foo < T : MyTrait < MyStruct < { true } >>> () {}
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "fn",
@@ -77,9 +76,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
         span: $DIR/attr-complex-fn.rs:19:42: 19:44 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): impl<T> MyTrait<T> for MyStruct<{true}> { #![rustc_dummy] }
-PRINT-ATTR RE-COLLECTED (DISPLAY): impl < T > MyTrait < T > for MyStruct < { true } > { #![rustc_dummy] }
-PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): impl < T > MyTrait < T > for MyStruct < { true } > { #! [rustc_dummy] }
+PRINT-ATTR INPUT (DISPLAY): impl < T > MyTrait < T > for MyStruct < { true } > { #! [rustc_dummy] }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "impl",

--- a/tests/ui/proc-macro/attr-stmt-expr.stdout
+++ b/tests/ui/proc-macro/attr-stmt-expr.stdout
@@ -71,8 +71,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
         span: $DIR/attr-stmt-expr.rs:49:33: 49:34 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): #[expect_my_macro_stmt] my_macro!("{}", string);
-PRINT-ATTR RE-COLLECTED (DISPLAY): #[expect_my_macro_stmt] my_macro! ("{}", string);
+PRINT-ATTR INPUT (DISPLAY): #[expect_my_macro_stmt] my_macro! ("{}", string);
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',
@@ -125,8 +124,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
         span: $DIR/attr-stmt-expr.rs:53:28: 53:29 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): second_make_stmt!(#[allow(dead_code)] struct Bar {});
-PRINT-ATTR RE-COLLECTED (DISPLAY): second_make_stmt! (#[allow(dead_code)] struct Bar {});
+PRINT-ATTR INPUT (DISPLAY): second_make_stmt! (#[allow(dead_code)] struct Bar {});
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "second_make_stmt",

--- a/tests/ui/proc-macro/attribute-after-derive.stdout
+++ b/tests/ui/proc-macro/attribute-after-derive.stdout
@@ -1,5 +1,4 @@
-PRINT-ATTR INPUT (DISPLAY): #[derive(Print)] struct AttributeDerive { #[cfg(false)] field: u8, }
-PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): #[derive(Print)] struct AttributeDerive { #[cfg(false)] field : u8, }
+PRINT-ATTR INPUT (DISPLAY): #[derive(Print)] struct AttributeDerive { #[cfg(false)] field : u8, }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',
@@ -131,8 +130,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         span: $DIR/attribute-after-derive.rs:23:24: 26:2 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): struct DeriveAttribute { #[cfg(false)] field: u8, }
-PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): struct DeriveAttribute { #[cfg(false)] field : u8, }
+PRINT-ATTR INPUT (DISPLAY): struct DeriveAttribute { #[cfg(false)] field : u8, }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",

--- a/tests/ui/proc-macro/attribute-spans-preserved.stdout
+++ b/tests/ui/proc-macro/attribute-spans-preserved.stdout
@@ -1,1 +1,1 @@
-fn main() { let y : u32 = "z"; { let x: u32 = "y"; } }
+fn main() { let y : u32 = "z"; { let x : u32 = "y"; } }

--- a/tests/ui/proc-macro/auxiliary/attr-stmt-expr-rpass.rs
+++ b/tests/ui/proc-macro/auxiliary/attr-stmt-expr-rpass.rs
@@ -12,7 +12,7 @@ pub fn expect_let(attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn expect_print_stmt(attr: TokenStream, item: TokenStream) -> TokenStream {
     assert!(attr.to_string().is_empty());
-    assert_eq!(item.to_string(), "println!(\"{}\", string);");
+    assert_eq!(item.to_string(), "println! (\"{}\", string);");
     item
 }
 
@@ -26,7 +26,7 @@ pub fn expect_expr(attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn expect_print_expr(attr: TokenStream, item: TokenStream) -> TokenStream {
     assert!(attr.to_string().is_empty());
-    assert_eq!(item.to_string(), "println!(\"{}\", string)");
+    assert_eq!(item.to_string(), "println! (\"{}\", string)");
     item
 }
 

--- a/tests/ui/proc-macro/auxiliary/attr-stmt-expr.rs
+++ b/tests/ui/proc-macro/auxiliary/attr-stmt-expr.rs
@@ -26,7 +26,7 @@ pub fn expect_expr(attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn expect_my_macro_expr(attr: TokenStream, item: TokenStream) -> TokenStream {
     assert!(attr.to_string().is_empty());
-    assert_eq!(item.to_string(), "my_macro!(\"{}\", string)");
+    assert_eq!(item.to_string(), "my_macro! (\"{}\", string)");
     item
 }
 

--- a/tests/ui/proc-macro/auxiliary/derive-b-rpass.rs
+++ b/tests/ui/proc-macro/auxiliary/derive-b-rpass.rs
@@ -5,7 +5,7 @@ use proc_macro::TokenStream;
 #[proc_macro_derive(B, attributes(B, C))]
 pub fn derive(input: TokenStream) -> TokenStream {
     let input = input.to_string();
-    assert!(input.contains("#[B[arbitrary tokens]]"));
+    assert!(input.contains("#[B [arbitrary tokens]]"));
     assert!(input.contains("struct B {"));
     assert!(input.contains("#[C]"));
     "".parse().unwrap()

--- a/tests/ui/proc-macro/auxiliary/derive-union.rs
+++ b/tests/ui/proc-macro/auxiliary/derive-union.rs
@@ -7,7 +7,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
     let input = input.to_string();
     assert!(input.contains("#[repr(C)]"));
     assert!(input.contains("union Test {"));
-    assert!(input.contains("a: u8,"));
+    assert!(input.contains("a : u8,"));
     assert!(input.contains("}"));
     "".parse().unwrap()
 }

--- a/tests/ui/proc-macro/auxiliary/test-macros.rs
+++ b/tests/ui/proc-macro/auxiliary/test-macros.rs
@@ -72,60 +72,22 @@ pub fn recollect_derive(input: TokenStream) -> TokenStream {
     input.into_iter().collect()
 }
 
-// Macros that print their input in the original and re-collected forms (if they differ).
+// Macros that print their input.
 
 fn print_helper(input: TokenStream, kind: &str) -> TokenStream {
     print_helper_ext(input, kind, true)
 }
 
-fn deep_recollect(input: TokenStream) -> TokenStream {
-    input.into_iter().map(|tree| {
-        match tree {
-            TokenTree::Group(group) => {
-                let inner = deep_recollect(group.stream());
-                let mut new_group = TokenTree::Group(
-                    proc_macro::Group::new(group.delimiter(), inner)
-                );
-                new_group.set_span(group.span());
-                new_group
-            }
-            _ => tree,
-        }
-    }).collect()
-}
-
 fn print_helper_ext(input: TokenStream, kind: &str, debug: bool) -> TokenStream {
     let input_display = format!("{}", input);
     let input_debug = format!("{:#?}", input);
-    let recollected = input.clone().into_iter().collect();
-    let recollected_display = format!("{}", recollected);
-    let recollected_debug = format!("{:#?}", recollected);
-
-    let deep_recollected = deep_recollect(input);
-    let deep_recollected_display = format!("{}", deep_recollected);
-    let deep_recollected_debug = format!("{:#?}", deep_recollected);
-
-
 
     println!("PRINT-{} INPUT (DISPLAY): {}", kind, input_display);
-    if recollected_display != input_display {
-        println!("PRINT-{} RE-COLLECTED (DISPLAY): {}", kind, recollected_display);
-    }
-
-    if deep_recollected_display != recollected_display {
-        println!("PRINT-{} DEEP-RE-COLLECTED (DISPLAY): {}", kind, deep_recollected_display);
-    }
 
     if debug {
         println!("PRINT-{} INPUT (DEBUG): {}", kind, input_debug);
-        if recollected_debug != input_debug {
-            println!("PRINT-{} RE-COLLECTED (DEBUG): {}", kind, recollected_debug);
-        }
-        if deep_recollected_debug != recollected_debug {
-            println!("PRINT-{} DEEP-RE-COLLETED (DEBUG): {}", kind, deep_recollected_debug);
-        }
     }
-    recollected
+    input
 }
 
 #[proc_macro]

--- a/tests/ui/proc-macro/capture-macro-rules-invoke.stdout
+++ b/tests/ui/proc-macro/capture-macro-rules-invoke.stdout
@@ -12,8 +12,6 @@ PRINT-BANG INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-BANG INPUT (DISPLAY): 1 + 1, { "a" }, let a = 1, String, my_name, 'a, my_val = 30,
-std::option::Option, pub(in some::path), [a b c], -30
-PRINT-BANG DEEP-RE-COLLECTED (DISPLAY): 1 + 1, { "a" }, let a = 1, String, my_name, 'a, my_val = 30,
 std :: option :: Option, pub(in some :: path), [a b c], - 30
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Group {

--- a/tests/ui/proc-macro/capture-unglued-token.stdout
+++ b/tests/ui/proc-macro/capture-unglued-token.stdout
@@ -1,5 +1,4 @@
-PRINT-BANG INPUT (DISPLAY): Vec<u8>
-PRINT-BANG DEEP-RE-COLLECTED (DISPLAY): Vec < u8 >
+PRINT-BANG INPUT (DISPLAY): Vec < u8 >
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Group {
         delimiter: None,

--- a/tests/ui/proc-macro/cfg-attr-trace.stdout
+++ b/tests/ui/proc-macro/cfg-attr-trace.stdout
@@ -1,5 +1,4 @@
-PRINT-ATTR INPUT (DISPLAY): #[test_macros::print_attr] struct S;
-PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): #[test_macros :: print_attr] struct S;
+PRINT-ATTR INPUT (DISPLAY): #[test_macros :: print_attr] struct S;
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',

--- a/tests/ui/proc-macro/cfg-eval-inner.stdout
+++ b/tests/ui/proc-macro/cfg-eval-inner.stdout
@@ -1,16 +1,4 @@
-PRINT-ATTR INPUT (DISPLAY): impl
-Foo<[u8;
-{
-    #![rustc_dummy(cursed_inner)] #![allow(unused)] struct Inner
-    { field: [u8; { #![rustc_dummy(another_cursed_inner)] 1 }] } 0
-}]> { #![rustc_dummy(evaluated_attr)] fn bar() {} }
-PRINT-ATTR RE-COLLECTED (DISPLAY): impl Foo <
-[u8;
-{
-    #![rustc_dummy(cursed_inner)] #![allow(unused)] struct Inner
-    { field: [u8; { #![rustc_dummy(another_cursed_inner)] 1 }] } 0
-}] > { #![rustc_dummy(evaluated_attr)] fn bar() {} }
-PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): impl Foo <
+PRINT-ATTR INPUT (DISPLAY): impl Foo <
 [u8;
 {
     #! [rustc_dummy(cursed_inner)] #! [allow(unused)] struct Inner

--- a/tests/ui/proc-macro/cfg-eval.stdout
+++ b/tests/ui/proc-macro/cfg-eval.stdout
@@ -1,5 +1,4 @@
-PRINT-ATTR INPUT (DISPLAY): struct S1 { #[cfg(true)] #[allow()] field_true: u8, }
-PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): struct S1 { #[cfg(true)] #[allow()] field_true : u8, }
+PRINT-ATTR INPUT (DISPLAY): struct S1 { #[cfg(true)] #[allow()] field_true : u8, }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",

--- a/tests/ui/proc-macro/doc-comment-preserved.stdout
+++ b/tests/ui/proc-macro/doc-comment-preserved.stdout
@@ -1,12 +1,4 @@
-PRINT-BANG INPUT (DISPLAY): /**
-*******
-* DOC *
-* DOC *
-* DOC *
-*******
-*/
- pub struct S;
-PRINT-BANG RE-COLLECTED (DISPLAY): #[doc = "\n*******\n* DOC *\n* DOC *\n* DOC *\n*******\n"] pub struct S;
+PRINT-BANG INPUT (DISPLAY): #[doc = "\n*******\n* DOC *\n* DOC *\n* DOC *\n*******\n"] pub struct S;
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',

--- a/tests/ui/proc-macro/expand-to-derive.stdout
+++ b/tests/ui/proc-macro/expand-to-derive.stdout
@@ -1,11 +1,6 @@
 PRINT-DERIVE INPUT (DISPLAY): struct Foo
 {
     field :
-    [bool; { #[rustc_dummy] struct Inner { other_inner_field: u8, } 0 }]
-}
-PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): struct Foo
-{
-    field :
     [bool; { #[rustc_dummy] struct Inner { other_inner_field : u8, } 0 }]
 }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [

--- a/tests/ui/proc-macro/inert-attribute-order.stdout
+++ b/tests/ui/proc-macro/inert-attribute-order.stdout
@@ -1,11 +1,4 @@
-PRINT-ATTR INPUT (DISPLAY): /// 1
-#[rustfmt::attr2] #[doc = "3"] #[doc = "4"] #[rustfmt::attr5] /// 6
-#[print_attr(nodebug)] struct S;
-PRINT-ATTR RE-COLLECTED (DISPLAY): #[doc = " 1"] #[rustfmt::attr2] #[doc = "3"] #[doc = "4"] #[rustfmt::attr5]
-#[doc = " 6"] #[print_attr(nodebug)] struct S;
-PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): #[doc = " 1"] #[rustfmt :: attr2] #[doc = "3"] #[doc = "4"]
+PRINT-ATTR INPUT (DISPLAY): #[doc = " 1"] #[rustfmt :: attr2] #[doc = "3"] #[doc = "4"]
 #[rustfmt :: attr5] #[doc = " 6"] #[print_attr(nodebug)] struct S;
-PRINT-ATTR INPUT (DISPLAY): #[doc = " 1"] #[rustfmt::attr2] #[doc = "3"] #[doc = "4"] #[rustfmt::attr5]
-#[doc = " 6"] struct S;
-PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): #[doc = " 1"] #[rustfmt :: attr2] #[doc = "3"] #[doc = "4"]
+PRINT-ATTR INPUT (DISPLAY): #[doc = " 1"] #[rustfmt :: attr2] #[doc = "3"] #[doc = "4"]
 #[rustfmt :: attr5] #[doc = " 6"] struct S;

--- a/tests/ui/proc-macro/inner-attr-file-mod.stdout
+++ b/tests/ui/proc-macro/inner-attr-file-mod.stdout
@@ -1,5 +1,4 @@
-PRINT-ATTR INPUT (DISPLAY): #[deny(unused_attributes)] mod module_with_attrs { #![rustfmt::skip] }
-PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): #[deny(unused_attributes)] mod module_with_attrs { #! [rustfmt :: skip] }
+PRINT-ATTR INPUT (DISPLAY): #[deny(unused_attributes)] mod module_with_attrs { #! [rustfmt :: skip] }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',

--- a/tests/ui/proc-macro/inner-attrs.stdout
+++ b/tests/ui/proc-macro/inner-attrs.stdout
@@ -6,8 +6,6 @@ PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): #[print_target_and_args(second)] fn foo()
-{ #![print_target_and_args(third)] #![print_target_and_args(fourth)] }
-PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): #[print_target_and_args(second)] fn foo()
 { #! [print_target_and_args(third)] #! [print_target_and_args(fourth)] }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
@@ -123,8 +121,6 @@ PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): fn foo()
-{ #![print_target_and_args(third)] #![print_target_and_args(fourth)] }
-PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): fn foo()
 { #! [print_target_and_args(third)] #! [print_target_and_args(fourth)] }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
@@ -214,8 +210,7 @@ PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
         span: $DIR/inner-attrs.rs:20:30: 20:35 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): fn foo() { #![print_target_and_args(fourth)] }
-PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): fn foo() { #! [print_target_and_args(fourth)] }
+PRINT-ATTR INPUT (DISPLAY): fn foo() { #! [print_target_and_args(fourth)] }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "fn",
@@ -303,8 +298,6 @@ PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): #[print_target_and_args(mod_second)] mod inline_mod
-{ #![print_target_and_args(mod_third)] #![print_target_and_args(mod_fourth)] }
-PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): #[print_target_and_args(mod_second)] mod inline_mod
 {
     #! [print_target_and_args(mod_third)] #!
     [print_target_and_args(mod_fourth)]
@@ -418,8 +411,6 @@ PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): mod inline_mod
-{ #![print_target_and_args(mod_third)] #![print_target_and_args(mod_fourth)] }
-PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): mod inline_mod
 {
     #! [print_target_and_args(mod_third)] #!
     [print_target_and_args(mod_fourth)]
@@ -507,8 +498,7 @@ PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
         span: $DIR/inner-attrs.rs:27:30: 27:39 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): mod inline_mod { #![print_target_and_args(mod_fourth)] }
-PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): mod inline_mod { #! [print_target_and_args(mod_fourth)] }
+PRINT-ATTR INPUT (DISPLAY): mod inline_mod { #! [print_target_and_args(mod_fourth)] }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "mod",
@@ -579,8 +569,6 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-DERIVE INPUT (DISPLAY): struct MyDerivePrint
-{ field: [u8; { match true { _ => { #![rustc_dummy(third)] true } }; 0 }] }
-PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): struct MyDerivePrint
 { field : [u8; { match true { _ => { #! [rustc_dummy(third)] true } }; 0 }] }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
@@ -714,8 +702,7 @@ PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
         span: $DIR/inner-attrs.rs:49:29: 49:40 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): (3, 4, { #![cfg_attr(not(FALSE), rustc_dummy(innermost))] 5 });
-PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): (3, 4, { #! [cfg_attr(not(FALSE), rustc_dummy(innermost))] 5 });
+PRINT-ATTR INPUT (DISPLAY): (3, 4, { #! [cfg_attr(not(FALSE), rustc_dummy(innermost))] 5 });
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Group {
         delimiter: Parenthesis,
@@ -829,8 +816,7 @@ PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
         span: $DIR/inner-attrs.rs:56:29: 56:40 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): (3, 4, { #![cfg_attr(not(FALSE), rustc_dummy(innermost))] 5 });
-PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): (3, 4, { #! [cfg_attr(not(FALSE), rustc_dummy(innermost))] 5 });
+PRINT-ATTR INPUT (DISPLAY): (3, 4, { #! [cfg_attr(not(FALSE), rustc_dummy(innermost))] 5 });
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Group {
         delimiter: Parenthesis,

--- a/tests/ui/proc-macro/issue-75734-pp-paren.stdout
+++ b/tests/ui/proc-macro/issue-75734-pp-paren.stdout
@@ -1,5 +1,4 @@
-PRINT-ATTR INPUT (DISPLAY): fn main() { &|_: u8| {}; mul_2!(1 + 1); }
-PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): fn main() { &| _ : u8 | {}; mul_2! (1 + 1); }
+PRINT-ATTR INPUT (DISPLAY): fn main() { &| _ : u8 | {}; mul_2! (1 + 1); }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "fn",

--- a/tests/ui/proc-macro/issue-75930-derive-cfg.stdout
+++ b/tests/ui/proc-macro/issue-75930-derive-cfg.stdout
@@ -1,52 +1,4 @@
 PRINT-ATTR INPUT (DISPLAY): #[print_helper(a)] #[allow(dead_code)] #[derive(Print)] #[print_helper(b)]
-struct Foo<#[cfg(false)] A, B>
-{
-    #[cfg(false)] first: String, #[cfg_attr(FALSE, deny(warnings))] second:
-    bool, third:
-    [u8;
-    {
-        #[cfg(false)] struct Bar; #[cfg(not(FALSE))] struct Inner;
-        #[cfg(false)] let a = 25; match true
-        {
-            #[cfg(false)] true => {}, #[cfg_attr(not(FALSE), allow(warnings))]
-            false => {}, _ => {}
-        }; #[print_helper(should_be_removed)] fn removed_fn()
-        { #![cfg(false)] } #[print_helper(c)] #[cfg(not(FALSE))] fn kept_fn()
-        { #![cfg(not(FALSE))] let my_val = true; } enum TupleEnum
-        {
-            Foo(#[cfg(false)] u8, #[cfg(false)] bool, #[cfg(not(FALSE))] i32,
-            #[cfg(false)] String, u8)
-        } struct
-        TupleStruct(#[cfg(false)] String, #[cfg(not(FALSE))] i32,
-        #[cfg(false)] bool, u8); fn plain_removed_fn()
-        { #![cfg_attr(not(FALSE), cfg(false))] } 0
-    }], #[print_helper(d)] fourth: B
-}
-PRINT-ATTR RE-COLLECTED (DISPLAY): #[print_helper(a)] #[allow(dead_code)] #[derive(Print)] #[print_helper(b)]
-struct Foo <#[cfg(false)] A, B >
-{
-    #[cfg(false)] first: String, #[cfg_attr(FALSE, deny(warnings))] second:
-    bool, third:
-    [u8;
-    {
-        #[cfg(false)] struct Bar; #[cfg(not(FALSE))] struct Inner;
-        #[cfg(false)] let a = 25; match true
-        {
-            #[cfg(false)] true => {}, #[cfg_attr(not(FALSE), allow(warnings))]
-            false => {}, _ => {}
-        }; #[print_helper(should_be_removed)] fn removed_fn()
-        { #![cfg(false)] } #[print_helper(c)] #[cfg(not(FALSE))] fn kept_fn()
-        { #![cfg(not(FALSE))] let my_val = true; } enum TupleEnum
-        {
-            Foo(#[cfg(false)] u8, #[cfg(false)] bool, #[cfg(not(FALSE))] i32,
-            #[cfg(false)] String, u8)
-        } struct
-        TupleStruct(#[cfg(false)] String, #[cfg(not(FALSE))] i32,
-        #[cfg(false)] bool, u8); fn plain_removed_fn()
-        { #![cfg_attr(not(FALSE), cfg(false))] } 0
-    }], #[print_helper(d)] fourth: B
-}
-PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): #[print_helper(a)] #[allow(dead_code)] #[derive(Print)] #[print_helper(b)]
 struct Foo <#[cfg(false)] A, B >
 {
     #[cfg(false)] first : String, #[cfg_attr(FALSE, deny(warnings))] second :
@@ -1321,19 +1273,6 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-DERIVE INPUT (DISPLAY): #[print_helper(a)] #[allow(dead_code)] #[print_helper(b)] struct Foo <B >
-{
-    second: bool, third:
-    [u8;
-    {
-        #[cfg(not(FALSE))] struct Inner; match true
-        { #[allow(warnings)] false => {}, _ => {} }; #[print_helper(c)]
-        #[cfg(not(FALSE))] fn kept_fn()
-        { #![cfg(not(FALSE))] let my_val = true; } enum TupleEnum
-        { Foo(#[cfg(not(FALSE))] i32, u8) } struct
-        TupleStruct(#[cfg(not(FALSE))] i32, u8); 0
-    }], #[print_helper(d)] fourth: B
-}
-PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): #[print_helper(a)] #[allow(dead_code)] #[print_helper(b)] struct Foo <B >
 {
     second : bool, third :
     [u8;

--- a/tests/ui/proc-macro/issue-78675-captured-inner-attrs.stdout
+++ b/tests/ui/proc-macro/issue-78675-captured-inner-attrs.stdout
@@ -1,5 +1,4 @@
-PRINT-BANG INPUT (DISPLAY): foo! { #[fake_attr] mod bar { #![doc = r" Foo"] } }
-PRINT-BANG DEEP-RE-COLLECTED (DISPLAY): foo! { #[fake_attr] mod bar { #! [doc = r" Foo"] } }
+PRINT-BANG INPUT (DISPLAY): foo! { #[fake_attr] mod bar { #! [doc = r" Foo"] } }
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "foo",

--- a/tests/ui/proc-macro/keep-expr-tokens.stdout
+++ b/tests/ui/proc-macro/keep-expr-tokens.stdout
@@ -1,5 +1,4 @@
-PRINT-ATTR INPUT (DISPLAY): #[rustc_dummy] { 1 +1; }
-PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): #[rustc_dummy] { 1 + 1; }
+PRINT-ATTR INPUT (DISPLAY): #[rustc_dummy] { 1 + 1; }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',

--- a/tests/ui/proc-macro/macro-rules-derive-cfg.stdout
+++ b/tests/ui/proc-macro/macro-rules-derive-cfg.stdout
@@ -1,8 +1,5 @@
 PRINT-DERIVE INPUT (DISPLAY): struct
 Foo([bool; #[rustc_dummy(first)]
-#[rustc_dummy(second)] { #![rustc_dummy(third)] #[rustc_dummy(fourth)] 30 }]);
-PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): struct
-Foo([bool; #[rustc_dummy(first)]
 #[rustc_dummy(second)]
 { #! [rustc_dummy(third)] #[rustc_dummy(fourth)] 30 }]);
 PRINT-DERIVE INPUT (DEBUG): TokenStream [

--- a/tests/ui/proc-macro/nested-derive-cfg.stdout
+++ b/tests/ui/proc-macro/nested-derive-cfg.stdout
@@ -1,6 +1,4 @@
 PRINT-DERIVE INPUT (DISPLAY): struct Foo
-{ my_array: [bool; { struct Inner { non_removed_inner_field: usize } 0 }] }
-PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): struct Foo
 { my_array : [bool; { struct Inner { non_removed_inner_field : usize } 0 }] }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {

--- a/tests/ui/proc-macro/nonterminal-expansion.stdout
+++ b/tests/ui/proc-macro/nonterminal-expansion.stdout
@@ -1,5 +1,4 @@
-PRINT-ATTR_ARGS INPUT (DISPLAY): a, line!(), b
-PRINT-ATTR_ARGS DEEP-RE-COLLECTED (DISPLAY): a, line! (), b
+PRINT-ATTR_ARGS INPUT (DISPLAY): a, line! (), b
 PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
     Ident {
         ident: "a",

--- a/tests/ui/proc-macro/pretty-print-tts.stdout
+++ b/tests/ui/proc-macro/pretty-print-tts.stdout
@@ -1,5 +1,4 @@
-PRINT-BANG INPUT (DISPLAY): { #![rustc_dummy] let a = "hello".len(); matches!(a, 5); }
-PRINT-BANG DEEP-RE-COLLECTED (DISPLAY): { #! [rustc_dummy] let a = "hello".len(); matches! (a, 5); }
+PRINT-BANG INPUT (DISPLAY): { #! [rustc_dummy] let a = "hello".len(); matches! (a, 5); }
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Group {
         delimiter: Brace,

--- a/tests/ui/proc-macro/trailing-plus.stdout
+++ b/tests/ui/proc-macro/trailing-plus.stdout
@@ -1,5 +1,4 @@
-PRINT-ATTR INPUT (DISPLAY): fn foo<T>() where T: Copy + {}
-PRINT-ATTR RE-COLLECTED (DISPLAY): fn foo < T > () where T : Copy + {}
+PRINT-ATTR INPUT (DISPLAY): fn foo < T > () where T : Copy + {}
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "fn",

--- a/tests/ui/proc-macro/weird-braces.stdout
+++ b/tests/ui/proc-macro/weird-braces.stdout
@@ -5,18 +5,7 @@ PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
         span: $DIR/weird-braces.rs:16:25: 16:36 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): #[print_target_and_args(second_outer)] impl Bar<{1 > 0}> for Foo<{true}>
-{
-    #![print_target_and_args(first_inner)]
-    #![print_target_and_args(second_inner)]
-}
-PRINT-ATTR RE-COLLECTED (DISPLAY): #[print_target_and_args(second_outer)] impl Bar < { 1 > 0 } > for Foo <
-{ true } >
-{
-    #![print_target_and_args(first_inner)]
-    #![print_target_and_args(second_inner)]
-}
-PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): #[print_target_and_args(second_outer)] impl Bar < { 1 > 0 } > for Foo <
+PRINT-ATTR INPUT (DISPLAY): #[print_target_and_args(second_outer)] impl Bar < { 1 > 0 } > for Foo <
 { true } >
 {
     #! [print_target_and_args(first_inner)] #!
@@ -191,17 +180,7 @@ PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
         span: $DIR/weird-braces.rs:17:25: 17:37 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): impl Bar<{1 > 0}> for Foo<{true}>
-{
-    #![print_target_and_args(first_inner)]
-    #![print_target_and_args(second_inner)]
-}
-PRINT-ATTR RE-COLLECTED (DISPLAY): impl Bar < { 1 > 0 } > for Foo < { true } >
-{
-    #![print_target_and_args(first_inner)]
-    #![print_target_and_args(second_inner)]
-}
-PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): impl Bar < { 1 > 0 } > for Foo < { true } >
+PRINT-ATTR INPUT (DISPLAY): impl Bar < { 1 > 0 } > for Foo < { true } >
 {
     #! [print_target_and_args(first_inner)] #!
     [print_target_and_args(second_inner)]
@@ -350,10 +329,7 @@ PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
         span: $DIR/weird-braces.rs:19:30: 19:41 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): impl Bar<{1 > 0}> for Foo<{true}> { #![print_target_and_args(second_inner)] }
-PRINT-ATTR RE-COLLECTED (DISPLAY): impl Bar < { 1 > 0 } > for Foo < { true } >
-{ #![print_target_and_args(second_inner)] }
-PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): impl Bar < { 1 > 0 } > for Foo < { true } >
+PRINT-ATTR INPUT (DISPLAY): impl Bar < { 1 > 0 } > for Foo < { true } >
 { #! [print_target_and_args(second_inner)] }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
@@ -469,8 +445,7 @@ PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
         span: $DIR/weird-braces.rs:20:30: 20:42 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): impl Bar<{1 > 0}> for Foo<{true}> {}
-PRINT-ATTR RE-COLLECTED (DISPLAY): impl Bar < { 1 > 0 } > for Foo < { true } > {}
+PRINT-ATTR INPUT (DISPLAY): impl Bar < { 1 > 0 } > for Foo < { true } > {}
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "impl",

--- a/tests/ui/rfcs/rfc-2565-param-attrs/auxiliary/param-attrs.rs
+++ b/tests/ui/rfcs/rfc-2565-param-attrs/auxiliary/param-attrs.rs
@@ -12,26 +12,27 @@ macro_rules! checker {
     }
 }
 
-checker!(attr_extern, r#"extern "C" { fn ffi(#[a1] arg1: i32, #[a2] ...); }"#);
-checker!(attr_extern_cvar, r#"unsafe extern "C" fn cvar(arg1: i32, #[a1] mut args: ...) {}"#);
+checker!(attr_extern, r#"extern "C" { fn ffi(#[a1] arg1 : i32, #[a2] ...); }"#);
+checker!(attr_extern_cvar, r#"unsafe extern "C" fn cvar(arg1 : i32, #[a1] mut args : ...) {}"#);
 checker!(attr_alias, "type Alias = fn(#[a1] u8, #[a2] ...);");
-checker!(attr_free, "fn free(#[a1] arg1: u8) { let lam = |#[a2] W(x), #[a3] y| (); }");
-checker!(attr_inherent_1, "fn inherent1(#[a1] self, #[a2] arg1: u8) {}");
-checker!(attr_inherent_2, "fn inherent2(#[a1] &self, #[a2] arg1: u8) {}");
-checker!(attr_inherent_3, "fn inherent3<'a>(#[a1] &'a mut self, #[a2] arg1: u8) {}");
-checker!(attr_inherent_4, "fn inherent4<'a>(#[a1] self: Box<Self>, #[a2] arg1: u8) {}");
-checker!(attr_inherent_issue_64682, "fn inherent5(#[a1] #[a2] arg1: u8, #[a3] arg2: u8) {}");
-checker!(attr_trait_1, "fn trait1(#[a1] self, #[a2] arg1: u8);");
-checker!(attr_trait_2, "fn trait2(#[a1] &self, #[a2] arg1: u8);");
-checker!(attr_trait_3, "fn trait3<'a>(#[a1] &'a mut self, #[a2] arg1: u8);");
-checker!(attr_trait_4, r#"fn trait4<'a>(#[a1] self: Box<Self>, #[a2] arg1: u8, #[a3] Vec<u8>);"#);
-checker!(attr_trait_issue_64682, "fn trait5(#[a1] #[a2] arg1: u8, #[a3] arg2: u8);");
+checker!(attr_free, "fn free(#[a1] arg1 : u8) { let lam = |#[a2] W(x), #[a3] y | (); }");
+checker!(attr_inherent_1, "fn inherent1(#[a1] self, #[a2] arg1 : u8) {}");
+checker!(attr_inherent_2, "fn inherent2(#[a1] & self, #[a2] arg1 : u8) {}");
+checker!(attr_inherent_3, "fn inherent3 < 'a > (#[a1] & 'a mut self, #[a2] arg1 : u8) {}");
+checker!(attr_inherent_4, "fn inherent4 < 'a > (#[a1] self : Box < Self >, #[a2] arg1 : u8) {}");
+checker!(attr_inherent_issue_64682, "fn inherent5(#[a1] #[a2] arg1 : u8, #[a3] arg2 : u8) {}");
+checker!(attr_trait_1, "fn trait1(#[a1] self, #[a2] arg1 : u8);");
+checker!(attr_trait_2, "fn trait2(#[a1] & self, #[a2] arg1 : u8);");
+checker!(attr_trait_3, "fn trait3 < 'a > (#[a1] & 'a mut self, #[a2] arg1 : u8);");
+checker!(attr_trait_4, r#"fn trait4 < 'a >
+(#[a1] self : Box < Self >, #[a2] arg1 : u8, #[a3] Vec < u8 >);"#);
+checker!(attr_trait_issue_64682, "fn trait5(#[a1] #[a2] arg1 : u8, #[a3] arg2 : u8);");
 checker!(rename_params, r#"impl Foo
 {
-    fn hello(#[angery(true)] a: i32, #[a2] b: i32, #[what = "how"] c: u32) {}
-    fn
-    hello2(#[a1] #[a2] a: i32, #[what = "how"] b: i32, #[angery(true)] c: u32)
+    fn hello(#[angery(true)] a : i32, #[a2] b : i32, #[what = "how"] c : u32)
     {} fn
-    hello_self(#[a1] #[a2] &self, #[a1] #[a2] a: i32, #[what = "how"] b: i32,
-    #[angery(true)] c: u32) {}
+    hello2(#[a1] #[a2] a : i32, #[what = "how"] b : i32, #[angery(true)] c :
+    u32) {} fn
+    hello_self(#[a1] #[a2] & self, #[a1] #[a2] a : i32, #[what = "how"] b :
+    i32, #[angery(true)] c : u32) {}
 }"#);


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/151830)*

This PR replaces the handle-based management of `TokenStream`s in `proc_macro` with a new type that is just a `Rc<Vec<TokenTree>>`. This type is very similar to the current `TokenStream`  types in rustc and rust-analyzer, which are roughly `Arc<Vec<TokenTree>>`. This comes with some gains and drawbacks:

### Improvements
* A significant part of `proc_macro::bridge` can be removed.
* Simple `TokenStream` operations are faster now since they do not need to use RPC anymore. This should be especially helpful for r-a.
* The `token-stream-stress` test is much faster now, which is hopefully representative for large proc macros.
* This is a significant improvement towards making `proc_macro` usable in regular crates (https://github.com/rust-lang/rust/issues/130856).

### Regressions
* `TokenStream` now has a worse `Display` implementation now that adds whitespace between most tokens. This is is theory allowed by the documentation of this implementation:

> Note: the exact form of the output is subject to change, e.g. there might
> be changes in the whitespace used between tokens. Therefore, you should
> *not* do any kind of simple substring matching on the output string (as
> produced by `to_string`) to implement a proc macro, because that matching
> might stop working if such changes happen. Instead, you should work at the
> `TokenTree` level, e.g. matching against `TokenTree::Ident`,
> `TokenTree::Punct`, or `TokenTree::Literal`.

but might still cause too much breakage to be acceptable. This needs a crater run.
* Instruction counts for `clap_derive` and `serde_derive` are higher now. This is somewhat expected since LLVM can now understand what a `TokenStream` really is and perform some optimizations based on that.

related: rust-lang/rust#101419