### PR TITLE
Port `rustc_layout` to attribute parser

### DIFF
--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -75,7 +75,7 @@ use crate::attributes::rustc_dump::{
     RustcDumpVtable,
 };
 use crate::attributes::rustc_internal::{
-    RustcHasIncoherentInherentImplsParser, RustcLayoutScalarValidRangeEndParser,
+    RustcHasIncoherentInherentImplsParser, RustcLayoutParser, RustcLayoutScalarValidRangeEndParser,
     RustcLayoutScalarValidRangeStartParser, RustcLegacyConstGenericsParser,
     RustcLintOptDenyFieldAccessParser, RustcLintOptTyParser, RustcLintQueryInstabilityParser,
     RustcLintUntrackedQueryInformationParser, RustcMainParser, RustcMustImplementOneOfParser,
@@ -198,6 +198,7 @@ attribute_parsers!(
         Combine<ForceTargetFeatureParser>,
         Combine<LinkParser>,
         Combine<ReprParser>,
+        Combine<RustcLayoutParser>,
         Combine<TargetFeatureParser>,
         Combine<UnstableFeatureBoundParser>,
         // tidy-alphabetical-end

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -690,6 +690,15 @@ impl IntoDiagArg for CrateType {
     }
 }
 
+#[derive(Clone, Debug, HashStable_Generic, Encodable, Decodable, PrintAttribute)]
+pub enum RustcLayoutType {
+    Abi,
+    Align,
+    Size,
+    HomogenousAggregate,
+    Debug,
+}
+
 /// Represents parsed *built-in* inert attributes.
 ///
 /// ## Overview
@@ -1047,6 +1056,9 @@ pub enum AttributeKind {
 
     /// Represents `#[rustc_has_incoherent_inherent_impls]`
     RustcHasIncoherentInherentImpls,
+
+    /// Represents `#[rustc_layout]`
+    RustcLayout(ThinVec<RustcLayoutType>),
 
     /// Represents `#[rustc_layout_scalar_valid_range_end]`.
     RustcLayoutScalarValidRangeEnd(Box<u128>, Span),

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -111,6 +111,7 @@ impl AttributeKind {
             RustcDumpVtable(..) => No,
             RustcDynIncompatibleTrait(..) => No,
             RustcHasIncoherentInherentImpls => Yes,
+            RustcLayout(..) => No,
             RustcLayoutScalarValidRangeEnd(..) => Yes,
             RustcLayoutScalarValidRangeStart(..) => Yes,
             RustcLegacyConstGenerics { .. } => Yes,

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -302,8 +302,6 @@ passes_layout_align =
     align: {$align}
 passes_layout_homogeneous_aggregate =
     homogeneous_aggregate: {$homogeneous_aggregate}
-passes_layout_invalid_attribute =
-    `#[rustc_layout]` can only be applied to `struct`/`enum`/`union` declarations and type aliases
 passes_layout_of =
     layout_of({$normalized_ty}) = {$ty_layout}
 passes_layout_size =

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -299,6 +299,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     | AttributeKind::RustcDumpVtable(..)
                     | AttributeKind::RustcDynIncompatibleTrait(..)
                     | AttributeKind::RustcHasIncoherentInherentImpls
+                    | AttributeKind::RustcLayout(..)
                     | AttributeKind::RustcLayoutScalarValidRangeEnd(..)
                     | AttributeKind::RustcLayoutScalarValidRangeStart(..)
                     | AttributeKind::RustcLintOptDenyFieldAccess { .. }

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -520,13 +520,6 @@ pub(crate) struct LayoutOf<'tcx> {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes_layout_invalid_attribute)]
-pub(crate) struct LayoutInvalidAttribute {
-    #[primary_span]
-    pub span: Span,
-}
-
-#[derive(Diagnostic)]
 #[diag(passes_abi_of)]
 pub(crate) struct AbiOf {
     #[primary_span]

--- a/tests/ui/layout/debug.rs
+++ b/tests/ui/layout/debug.rs
@@ -68,12 +68,12 @@ union P5 { zst: [u16; 0], byte: u8 } //~ ERROR: layout_of
 #[rustc_layout(debug)]
 type X = std::mem::MaybeUninit<u8>; //~ ERROR: layout_of
 
-#[rustc_layout(debug)]
-const C: () = (); //~ ERROR: can only be applied to
+#[rustc_layout(debug)] //~ ERROR: cannot be used on constants
+const C: () = ();
 
 impl S {
-    #[rustc_layout(debug)]
-    const C: () = (); //~ ERROR: can only be applied to
+    #[rustc_layout(debug)] //~ ERROR: cannot be used on associated consts
+    const C: () = ();
 }
 
 #[rustc_layout(debug)]

--- a/tests/ui/layout/debug.stderr
+++ b/tests/ui/layout/debug.stderr
@@ -4,6 +4,22 @@ error: unions cannot have zero fields
 LL | union EmptyUnion {}
    | ^^^^^^^^^^^^^^^^^^^
 
+error: `#[rustc_layout]` attribute cannot be used on constants
+  --> $DIR/debug.rs:71:1
+   |
+LL | #[rustc_layout(debug)]
+   | ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_layout]` can be applied to data types and type aliases
+
+error: `#[rustc_layout]` attribute cannot be used on associated consts
+  --> $DIR/debug.rs:75:5
+   |
+LL |     #[rustc_layout(debug)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_layout]` can be applied to data types and type aliases
+
 error: layout_of(E) = Layout {
            size: Size(12 bytes),
            align: AbiAlign {
@@ -577,12 +593,6 @@ error: layout_of(MaybeUninit<u8>) = Layout {
 LL | type X = std::mem::MaybeUninit<u8>;
    | ^^^^^^
 
-error: `#[rustc_layout]` can only be applied to `struct`/`enum`/`union` declarations and type aliases
-  --> $DIR/debug.rs:72:1
-   |
-LL | const C: () = ();
-   | ^^^^^^^^^^^
-
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/debug.rs:80:19
    |
@@ -603,12 +613,6 @@ error: the type `T` does not have a fixed layout
    |
 LL | type TooGeneric<T> = T;
    | ^^^^^^^^^^^^^^^^^^
-
-error: `#[rustc_layout]` can only be applied to `struct`/`enum`/`union` declarations and type aliases
-  --> $DIR/debug.rs:76:5
-   |
-LL |     const C: () = ();
-   |     ^^^^^^^^^^^
 
 error: aborting due to 20 previous errors
 


### PR DESCRIPTION
Tracking issue: rust-lang/rust#131229

Uses rust-lang/rust#151827

r? jdonszelmann 