### PR TITLE
Treat unions as 'data types' in attr parsing diagnostics

### DIFF
--- a/compiler/rustc_attr_parsing/src/target_checking.rs
+++ b/compiler/rustc_attr_parsing/src/target_checking.rs
@@ -205,7 +205,7 @@ pub(crate) fn allowed_targets_applied(
     ];
     const IMPL_LIKE: &[Target] =
         &[Target::Impl { of_trait: false }, Target::Impl { of_trait: true }];
-    const ADT_LIKE: &[Target] = &[Target::Struct, Target::Enum];
+    const ADT_LIKE: &[Target] = &[Target::Struct, Target::Enum, Target::Union];
 
     let mut added_fake_targets = Vec::new();
     filter_targets(

--- a/tests/ui/attributes/attr-on-mac-call.stderr
+++ b/tests/ui/attributes/attr-on-mac-call.stderr
@@ -55,7 +55,7 @@ LL |     #[deprecated]
    |     ^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, unions, and use statements
+   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, and use statements
 
 warning: `#[inline]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:24:5
@@ -136,7 +136,7 @@ LL |     #[deprecated]
    |     ^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, unions, and use statements
+   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, and use statements
 
 warning: `#[automatically_derived]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:51:5
@@ -163,7 +163,7 @@ LL |     #[must_use]
    |     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on macro calls
   --> $DIR/attr-on-mac-call.rs:60:5

--- a/tests/ui/deprecation/deprecated-expr-precedence.stderr
+++ b/tests/ui/deprecation/deprecated-expr-precedence.stderr
@@ -5,7 +5,7 @@ LL |     #[deprecated] 0
    |     ^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, unions, and use statements
+   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, and use statements
    = note: requested on the command line with `-W unused-attributes`
 
 error[E0308]: mismatched types

--- a/tests/ui/deprecation/deprecation-sanity.stderr
+++ b/tests/ui/deprecation/deprecation-sanity.stderr
@@ -83,7 +83,7 @@ LL | #[deprecated = "hello"]
    | ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, unions, and use statements
+   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, and use statements
    = note: `#[deny(useless_deprecated)]` on by default
 
 error: aborting due to 10 previous errors

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
@@ -1055,7 +1055,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 warning: `#[must_use]` attribute cannot be used on modules
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:766:17
@@ -1064,7 +1064,7 @@ LL |     mod inner { #![must_use] }
    |                 ^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 warning: `#[must_use]` attribute cannot be used on type aliases
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:775:5
@@ -1073,7 +1073,7 @@ LL |     #[must_use] type T = S;
    |     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 warning: `#[must_use]` attribute cannot be used on inherent impl blocks
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:780:5
@@ -1082,7 +1082,7 @@ LL |     #[must_use] impl S { }
    |     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![windows_subsystem]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:786:1
@@ -1635,7 +1635,7 @@ LL | #![must_use]
    | ^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 warning: 175 warnings emitted
 

--- a/tests/ui/lint/fn_must_use.stderr
+++ b/tests/ui/lint/fn_must_use.stderr
@@ -5,7 +5,7 @@ LL |     #[must_use]
    |     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, foreign functions, functions, inherent methods, provided trait methods, required trait methods, traits, and unions
+   = help: `#[must_use]` can be applied to data types, foreign functions, functions, inherent methods, provided trait methods, required trait methods, and traits
    = note: requested on the command line with `-W unused-attributes`
 
 warning: unused return value of `need_to_use_this_value` that must be used

--- a/tests/ui/lint/must_not_suspend/other_items.stderr
+++ b/tests/ui/lint/must_not_suspend/other_items.stderr
@@ -4,7 +4,7 @@ error: `#[must_not_suspend]` attribute cannot be used on modules
 LL | #[must_not_suspend]
    | ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[must_not_suspend]` can be applied to data types, traits, and unions
+   = help: `#[must_not_suspend]` can be applied to data types and traits
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lint/must_not_suspend/return.stderr
+++ b/tests/ui/lint/must_not_suspend/return.stderr
@@ -4,7 +4,7 @@ error: `#[must_not_suspend]` attribute cannot be used on functions
 LL | #[must_not_suspend]
    | ^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[must_not_suspend]` can be applied to data types, traits, and unions
+   = help: `#[must_not_suspend]` can be applied to data types and traits
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lint/unused/unused_attributes-must_use.stderr
+++ b/tests/ui/lint/unused/unused_attributes-must_use.stderr
@@ -5,7 +5,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 note: the lint level is defined here
   --> $DIR/unused_attributes-must_use.rs:4:9
    |
@@ -19,7 +19,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 error: `#[must_use]` attribute cannot be used on modules
   --> $DIR/unused_attributes-must_use.rs:11:1
@@ -28,7 +28,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 error: `#[must_use]` attribute cannot be used on use statements
   --> $DIR/unused_attributes-must_use.rs:15:1
@@ -37,7 +37,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 error: `#[must_use]` attribute cannot be used on constants
   --> $DIR/unused_attributes-must_use.rs:19:1
@@ -46,7 +46,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 error: `#[must_use]` attribute cannot be used on statics
   --> $DIR/unused_attributes-must_use.rs:22:1
@@ -55,7 +55,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 error: `#[must_use]` attribute cannot be used on inherent impl blocks
   --> $DIR/unused_attributes-must_use.rs:40:1
@@ -64,7 +64,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 error: `#[must_use]` attribute cannot be used on foreign modules
   --> $DIR/unused_attributes-must_use.rs:55:1
@@ -73,7 +73,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 error: `#[must_use]` attribute cannot be used on foreign statics
   --> $DIR/unused_attributes-must_use.rs:59:5
@@ -82,7 +82,7 @@ LL |     #[must_use]
    |     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 error: `#[must_use]` attribute cannot be used on type aliases
   --> $DIR/unused_attributes-must_use.rs:73:1
@@ -91,7 +91,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 error: `#[must_use]` attribute cannot be used on type parameters
   --> $DIR/unused_attributes-must_use.rs:77:8
@@ -100,7 +100,7 @@ LL | fn qux<#[must_use] T>(_: T) {}
    |        ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 error: `#[must_use]` attribute cannot be used on associated consts
   --> $DIR/unused_attributes-must_use.rs:82:5
@@ -109,7 +109,7 @@ LL |     #[must_use]
    |     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 error: `#[must_use]` attribute cannot be used on associated types
   --> $DIR/unused_attributes-must_use.rs:85:5
@@ -118,7 +118,7 @@ LL |     #[must_use]
    |     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 error: `#[must_use]` attribute cannot be used on trait impl blocks
   --> $DIR/unused_attributes-must_use.rs:95:1
@@ -127,7 +127,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 error: `#[must_use]` attribute cannot be used on trait methods in impl blocks
   --> $DIR/unused_attributes-must_use.rs:100:5
@@ -136,7 +136,7 @@ LL |     #[must_use]
    |     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, foreign functions, functions, inherent methods, provided trait methods, required trait methods, traits, and unions
+   = help: `#[must_use]` can be applied to data types, foreign functions, functions, inherent methods, provided trait methods, required trait methods, and traits
 
 error: `#[must_use]` attribute cannot be used on trait aliases
   --> $DIR/unused_attributes-must_use.rs:107:1
@@ -145,7 +145,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 error: `#[must_use]` attribute cannot be used on macro defs
   --> $DIR/unused_attributes-must_use.rs:111:1
@@ -154,7 +154,7 @@ LL | #[must_use]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 error: `#[must_use]` attribute cannot be used on statements
   --> $DIR/unused_attributes-must_use.rs:120:5
@@ -163,7 +163,7 @@ LL |     #[must_use]
    |     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 error: `#[must_use]` attribute cannot be used on closures
   --> $DIR/unused_attributes-must_use.rs:125:13
@@ -172,7 +172,7 @@ LL |     let x = #[must_use]
    |             ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, foreign functions, functions, methods, traits, and unions
+   = help: `#[must_use]` can be applied to data types, foreign functions, functions, methods, and traits
 
 error: `#[must_use]` attribute cannot be used on match arms
   --> $DIR/unused_attributes-must_use.rs:148:9
@@ -181,7 +181,7 @@ LL |         #[must_use]
    |         ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 error: `#[must_use]` attribute cannot be used on struct fields
   --> $DIR/unused_attributes-must_use.rs:157:28
@@ -190,7 +190,7 @@ LL |     let s = PatternField { #[must_use]  foo: 123 };
    |                            ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 error: `#[must_use]` attribute cannot be used on pattern fields
   --> $DIR/unused_attributes-must_use.rs:159:24
@@ -199,7 +199,7 @@ LL |     let PatternField { #[must_use] foo } = s;
    |                        ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 error: unused `X` that must be used
   --> $DIR/unused_attributes-must_use.rs:130:5

--- a/tests/ui/pin-ergonomics/pin_v2-attr.stderr
+++ b/tests/ui/pin-ergonomics/pin_v2-attr.stderr
@@ -4,7 +4,7 @@ error: `#[pin_v2]` attribute cannot be used on macro calls
 LL | #[pin_v2]
    | ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
   --> $DIR/pin_v2-attr.rs:84:12
@@ -18,7 +18,7 @@ error: `#[pin_v2]` attribute cannot be used on crates
 LL | #![pin_v2]
    | ^^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on type parameters
   --> $DIR/pin_v2-attr.rs:27:10
@@ -26,7 +26,7 @@ error: `#[pin_v2]` attribute cannot be used on type parameters
 LL | enum Foo<#[pin_v2] T, #[pin_v2] U = ()> {
    |          ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on type parameters
   --> $DIR/pin_v2-attr.rs:27:23
@@ -34,7 +34,7 @@ error: `#[pin_v2]` attribute cannot be used on type parameters
 LL | enum Foo<#[pin_v2] T, #[pin_v2] U = ()> {
    |                       ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on enum variants
   --> $DIR/pin_v2-attr.rs:30:5
@@ -42,7 +42,7 @@ error: `#[pin_v2]` attribute cannot be used on enum variants
 LL |     #[pin_v2]
    |     ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on struct fields
   --> $DIR/pin_v2-attr.rs:32:18
@@ -50,7 +50,7 @@ error: `#[pin_v2]` attribute cannot be used on struct fields
 LL |     TupleVariant(#[pin_v2] T),
    |                  ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on struct fields
   --> $DIR/pin_v2-attr.rs:34:9
@@ -58,7 +58,7 @@ error: `#[pin_v2]` attribute cannot be used on struct fields
 LL |         #[pin_v2]
    |         ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on traits
   --> $DIR/pin_v2-attr.rs:39:1
@@ -66,7 +66,7 @@ error: `#[pin_v2]` attribute cannot be used on traits
 LL | #[pin_v2]
    | ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on associated consts
   --> $DIR/pin_v2-attr.rs:41:5
@@ -74,7 +74,7 @@ error: `#[pin_v2]` attribute cannot be used on associated consts
 LL |     #[pin_v2]
    |     ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on associated types
   --> $DIR/pin_v2-attr.rs:43:5
@@ -82,7 +82,7 @@ error: `#[pin_v2]` attribute cannot be used on associated types
 LL |     #[pin_v2]
    |     ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on required trait methods
   --> $DIR/pin_v2-attr.rs:46:5
@@ -90,7 +90,7 @@ error: `#[pin_v2]` attribute cannot be used on required trait methods
 LL |     #[pin_v2]
    |     ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on provided trait methods
   --> $DIR/pin_v2-attr.rs:48:5
@@ -98,7 +98,7 @@ error: `#[pin_v2]` attribute cannot be used on provided trait methods
 LL |     #[pin_v2]
    |     ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on trait aliases
   --> $DIR/pin_v2-attr.rs:52:1
@@ -106,7 +106,7 @@ error: `#[pin_v2]` attribute cannot be used on trait aliases
 LL | #[pin_v2]
    | ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on inherent impl blocks
   --> $DIR/pin_v2-attr.rs:55:1
@@ -114,7 +114,7 @@ error: `#[pin_v2]` attribute cannot be used on inherent impl blocks
 LL | #[pin_v2]
    | ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on delegations
   --> $DIR/pin_v2-attr.rs:58:5
@@ -122,7 +122,7 @@ error: `#[pin_v2]` attribute cannot be used on delegations
 LL |     #[pin_v2]
    |     ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on inherent methods
   --> $DIR/pin_v2-attr.rs:61:5
@@ -130,7 +130,7 @@ error: `#[pin_v2]` attribute cannot be used on inherent methods
 LL |     #[pin_v2]
    |     ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on trait impl blocks
   --> $DIR/pin_v2-attr.rs:65:1
@@ -138,7 +138,7 @@ error: `#[pin_v2]` attribute cannot be used on trait impl blocks
 LL | #[pin_v2]
    | ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on trait methods in impl blocks
   --> $DIR/pin_v2-attr.rs:67:5
@@ -146,7 +146,7 @@ error: `#[pin_v2]` attribute cannot be used on trait methods in impl blocks
 LL |     #[pin_v2]
    |     ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on extern crates
   --> $DIR/pin_v2-attr.rs:71:1
@@ -154,7 +154,7 @@ error: `#[pin_v2]` attribute cannot be used on extern crates
 LL | #[pin_v2]
    | ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on use statements
   --> $DIR/pin_v2-attr.rs:74:1
@@ -162,7 +162,7 @@ error: `#[pin_v2]` attribute cannot be used on use statements
 LL | #[pin_v2]
    | ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on statics
   --> $DIR/pin_v2-attr.rs:77:1
@@ -170,7 +170,7 @@ error: `#[pin_v2]` attribute cannot be used on statics
 LL | #[pin_v2]
    | ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on constants
   --> $DIR/pin_v2-attr.rs:80:1
@@ -178,7 +178,7 @@ error: `#[pin_v2]` attribute cannot be used on constants
 LL | #[pin_v2]
    | ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on functions
   --> $DIR/pin_v2-attr.rs:83:1
@@ -186,7 +186,7 @@ error: `#[pin_v2]` attribute cannot be used on functions
 LL | #[pin_v2]
    | ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on function params
   --> $DIR/pin_v2-attr.rs:84:12
@@ -194,7 +194,7 @@ error: `#[pin_v2]` attribute cannot be used on function params
 LL | fn f<T, U>(#[pin_v2] param: Foo<T, U>)
    |            ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on closures
   --> $DIR/pin_v2-attr.rs:92:5
@@ -202,7 +202,7 @@ error: `#[pin_v2]` attribute cannot be used on closures
 LL |     #[pin_v2]
    |     ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on expressions
   --> $DIR/pin_v2-attr.rs:94:5
@@ -210,7 +210,7 @@ error: `#[pin_v2]` attribute cannot be used on expressions
 LL |     #[pin_v2]
    |     ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on struct fields
   --> $DIR/pin_v2-attr.rs:98:9
@@ -218,7 +218,7 @@ error: `#[pin_v2]` attribute cannot be used on struct fields
 LL |         #[pin_v2]
    |         ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on statements
   --> $DIR/pin_v2-attr.rs:96:5
@@ -226,7 +226,7 @@ error: `#[pin_v2]` attribute cannot be used on statements
 LL |     #[pin_v2]
    |     ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on match arms
   --> $DIR/pin_v2-attr.rs:102:9
@@ -234,7 +234,7 @@ error: `#[pin_v2]` attribute cannot be used on match arms
 LL |         #[pin_v2]
    |         ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on pattern fields
   --> $DIR/pin_v2-attr.rs:106:13
@@ -242,7 +242,7 @@ error: `#[pin_v2]` attribute cannot be used on pattern fields
 LL |             #[pin_v2]
    |             ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on where predicates
   --> $DIR/pin_v2-attr.rs:88:5
@@ -250,7 +250,7 @@ error: `#[pin_v2]` attribute cannot be used on where predicates
 LL |     #[pin_v2]
    |     ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on modules
   --> $DIR/pin_v2-attr.rs:112:1
@@ -258,7 +258,7 @@ error: `#[pin_v2]` attribute cannot be used on modules
 LL | #[pin_v2]
    | ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on foreign modules
   --> $DIR/pin_v2-attr.rs:115:1
@@ -266,7 +266,7 @@ error: `#[pin_v2]` attribute cannot be used on foreign modules
 LL | #[pin_v2]
    | ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on foreign types
   --> $DIR/pin_v2-attr.rs:117:5
@@ -274,7 +274,7 @@ error: `#[pin_v2]` attribute cannot be used on foreign types
 LL |     #[pin_v2]
    |     ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on foreign statics
   --> $DIR/pin_v2-attr.rs:120:5
@@ -282,7 +282,7 @@ error: `#[pin_v2]` attribute cannot be used on foreign statics
 LL |     #[pin_v2]
    |     ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on foreign functions
   --> $DIR/pin_v2-attr.rs:123:5
@@ -290,7 +290,7 @@ error: `#[pin_v2]` attribute cannot be used on foreign functions
 LL |     #[pin_v2]
    |     ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on type aliases
   --> $DIR/pin_v2-attr.rs:127:1
@@ -298,7 +298,7 @@ error: `#[pin_v2]` attribute cannot be used on type aliases
 LL | #[pin_v2]
    | ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: `#[pin_v2]` attribute cannot be used on macro defs
   --> $DIR/pin_v2-attr.rs:130:1
@@ -306,7 +306,7 @@ error: `#[pin_v2]` attribute cannot be used on macro defs
 LL | #[pin_v2]
    | ^^^^^^^^^
    |
-   = help: `#[pin_v2]` can be applied to data types and unions
+   = help: `#[pin_v2]` can only be applied to data types
 
 error: aborting due to 39 previous errors
 

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/invalid-attribute.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/invalid-attribute.stderr
@@ -21,7 +21,7 @@ error: `#[non_exhaustive]` attribute cannot be used on unions
 LL | #[non_exhaustive]
    | ^^^^^^^^^^^^^^^^^
    |
-   = help: `#[non_exhaustive]` can be applied to data types and enum variants
+   = help: `#[non_exhaustive]` can be applied to enum variants, enums, and structs
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/rfcs/rfc-2565-param-attrs/param-attrs-builtin-attrs.stderr
+++ b/tests/ui/rfcs/rfc-2565-param-attrs/param-attrs-builtin-attrs.stderr
@@ -389,7 +389,7 @@ LL |     #[must_use]
    |     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
    = note: requested on the command line with `-W unused-attributes`
 
 warning: `#[no_mangle]` attribute cannot be used on function params
@@ -408,7 +408,7 @@ LL |         #[must_use]
    |         ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 warning: `#[no_mangle]` attribute cannot be used on function params
   --> $DIR/param-attrs-builtin-attrs.rs:70:9
@@ -426,7 +426,7 @@ LL |         #[must_use]
    |         ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 warning: `#[no_mangle]` attribute cannot be used on function params
   --> $DIR/param-attrs-builtin-attrs.rs:89:9
@@ -444,7 +444,7 @@ LL |         #[must_use]
    |         ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 warning: `#[no_mangle]` attribute cannot be used on function params
   --> $DIR/param-attrs-builtin-attrs.rs:114:9
@@ -462,7 +462,7 @@ LL |         #[must_use]
    |         ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 warning: `#[no_mangle]` attribute cannot be used on function params
   --> $DIR/param-attrs-builtin-attrs.rs:137:9
@@ -480,7 +480,7 @@ LL |         #[must_use]
    |         ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 warning: `#[no_mangle]` attribute cannot be used on function params
   --> $DIR/param-attrs-builtin-attrs.rs:156:9
@@ -498,7 +498,7 @@ LL |         #[must_use]
    |         ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 warning: `#[no_mangle]` attribute cannot be used on function params
   --> $DIR/param-attrs-builtin-attrs.rs:180:9
@@ -516,7 +516,7 @@ LL |         #[must_use]
    |         ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = help: `#[must_use]` can be applied to data types, functions, traits, and unions
+   = help: `#[must_use]` can be applied to data types, functions, and traits
 
 warning: `#[no_mangle]` attribute cannot be used on function params
   --> $DIR/param-attrs-builtin-attrs.rs:201:9

--- a/tests/ui/where-clauses/unsupported_attribute.stderr
+++ b/tests/ui/where-clauses/unsupported_attribute.stderr
@@ -64,7 +64,7 @@ error: `#[deprecated]` attribute cannot be used on where predicates
 LL |     #[deprecated] T: Trait,
    |     ^^^^^^^^^^^^^
    |
-   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, unions, and use statements
+   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, and use statements
 
 error: `#[deprecated]` attribute cannot be used on where predicates
   --> $DIR/unsupported_attribute.rs:25:5
@@ -72,7 +72,7 @@ error: `#[deprecated]` attribute cannot be used on where predicates
 LL |     #[deprecated] 'a: 'static,
    |     ^^^^^^^^^^^^^
    |
-   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, unions, and use statements
+   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, and use statements
 
 error: `#[automatically_derived]` attribute cannot be used on where predicates
   --> $DIR/unsupported_attribute.rs:26:5


### PR DESCRIPTION
I found 'data types _and_ unions' to be a little surprising