### PR TITLE
Fix flakyness issue with `tests/rustdoc-gui/globals.goml` test

### DIFF
--- a/tests/rustdoc-gui/globals.goml
+++ b/tests/rustdoc-gui/globals.goml
@@ -11,7 +11,7 @@ assert-window-property-false: {"searchIndex": null}
 // Form input
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 call-function: ("perform-search", {"query": "Foo"})
-assert-window-property-false: {"searchIndex": null}
+wait-for-window-property-false: {"searchIndex": null}
 
 // source sidebar
 go-to: "file://" + |DOC_PATH| + "/src/test_docs/lib.rs.html"


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/93784.

It fixes this error:

```
[ERROR] line 14: The following errors happened: [Property named `"searchIndex"` doesn't exist]: for command `assert-window-property-false: {"searchIndex": null}`
    at <file:///checkout/obj/build/x86_64-unknown-linux-gnu/test/rustdoc-gui/doc/test_docs/index.html?search=Foo>
```

r? ghost