### PR TITLE
refactor: remove `Ty::pinned_ref` in favor of `Ty::maybe_pinned_ref`

### DIFF
--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -2841,7 +2841,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // the bad interactions of the given hack detailed in (note_1).
                 debug!("check_pat_ref: expected={:?}", expected);
                 match expected.maybe_pinned_ref() {
-                    Some((r_ty, r_pinned, r_mutbl))
+                    Some((r_ty, r_pinned, r_mutbl, _))
                         if ((ref_pat_matches_mut_ref && r_mutbl >= pat_mutbl)
                             || r_mutbl == pat_mutbl)
                             && pat_pinned == r_pinned =>

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1336,25 +1336,17 @@ impl<'tcx> Ty<'tcx> {
         }
     }
 
-    pub fn pinned_ref(self) -> Option<(Ty<'tcx>, ty::Mutability)> {
-        if let Adt(def, args) = self.kind()
-            && def.is_pin()
-            && let &ty::Ref(_, ty, mutbl) = args.type_at(0).kind()
-        {
-            return Some((ty, mutbl));
-        }
-        None
-    }
-
-    pub fn maybe_pinned_ref(self) -> Option<(Ty<'tcx>, ty::Pinnedness, ty::Mutability)> {
-        match *self.kind() {
+    pub fn maybe_pinned_ref(
+        self,
+    ) -> Option<(Ty<'tcx>, ty::Pinnedness, ty::Mutability, Region<'tcx>)> {
+        match self.kind() {
             Adt(def, args)
                 if def.is_pin()
-                    && let ty::Ref(_, ty, mutbl) = *args.type_at(0).kind() =>
+                    && let &ty::Ref(region, ty, mutbl) = args.type_at(0).kind() =>
             {
-                Some((ty, ty::Pinnedness::Pinned, mutbl))
+                Some((ty, ty::Pinnedness::Pinned, mutbl, region))
             }
-            ty::Ref(_, ty, mutbl) => Some((ty, ty::Pinnedness::Not, mutbl)),
+            &Ref(region, ty, mutbl) => Some((ty, ty::Pinnedness::Not, mutbl, region)),
             _ => None,
         }
     }


### PR DESCRIPTION
Also returns the `Region` of the reference type in `Ty::maybe_pinned_Ref`.

Part of rust-lang/rust#149130.

r? jackh726

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
