### PR TITLE
Show break type expectation cause for let-else

### DIFF
--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -605,6 +605,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         parent_id = self.tcx.parent_hir_id(*hir_id);
                         parent
                     }
+                    hir::Node::Stmt(hir::Stmt { hir_id, kind: hir::StmtKind::Let(_), .. }) => {
+                        parent_id = self.tcx.parent_hir_id(*hir_id);
+                        parent
+                    }
+                    hir::Node::LetStmt(hir::LetStmt { hir_id, .. }) => {
+                        parent_id = self.tcx.parent_hir_id(*hir_id);
+                        parent
+                    }
                     hir::Node::Block(_) => {
                         parent_id = self.tcx.parent_hir_id(parent_id);
                         parent

--- a/tests/ui/let-else/let-else-break-help-issue-142602.rs
+++ b/tests/ui/let-else/let-else-break-help-issue-142602.rs
@@ -1,0 +1,23 @@
+// testcase from https://github.com/rust-lang/rust/issues/142602
+
+pub fn main() {
+    // Case 1: break before let-else
+    let _a = loop {
+        if true {
+            break;
+        }
+        let Some(_) = Some(5) else {
+            break 3; //~ ERROR mismatched types
+        };
+    };
+
+    // Case 2: two let-else statements
+    let _b = loop {
+        let Some(_) = Some(5) else {
+            break;
+        };
+        let Some(_) = Some(4) else {
+            break 3; //~ ERROR mismatched types
+        };
+    };
+}

--- a/tests/ui/let-else/let-else-break-help-issue-142602.stderr
+++ b/tests/ui/let-else/let-else-break-help-issue-142602.stderr
@@ -1,0 +1,21 @@
+error[E0308]: mismatched types
+  --> $DIR/let-else-break-help-issue-142602.rs:10:19
+   |
+LL |             break;
+   |             ----- expected because of this `break`
+...
+LL |             break 3;
+   |                   ^ expected `()`, found integer
+
+error[E0308]: mismatched types
+  --> $DIR/let-else-break-help-issue-142602.rs:20:19
+   |
+LL |             break;
+   |             ----- expected because of this `break`
+...
+LL |             break 3;
+   |                   ^ expected `()`, found integer
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes rust-lang/rust#142602