### PR TITLE
Fix flakyness issue with `tests/rustdoc-gui/globals.goml` test

### DIFF
--- a/tests/rustdoc-gui/globals.goml
+++ b/tests/rustdoc-gui/globals.goml
@@ -4,14 +4,14 @@
 include: "utils.goml"
 
 // URL query
-go-to: "file://" + |DOC_PATH| + "/test_docs/index.html?search=sa'%3Bda'%3Bds"
+go-to: "file://" + |DOC_PATH| + "/test_docs/index.html?search=sa"
 wait-for: "#search-tabs"
 assert-window-property-false: {"searchIndex": null}
 
 // Form input
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 call-function: ("perform-search", {"query": "Foo"})
-assert-window-property-false: {"searchIndex": null}
+wait-for-window-property-false: {"searchIndex": null}
 
 // source sidebar
 go-to: "file://" + |DOC_PATH| + "/src/test_docs/lib.rs.html"


### PR DESCRIPTION
Should help with https://github.com/rust-lang/rust/issues/93784.

Just realized that when the search input is wrong, sometime we don't even load the search index (which is logical). Since we want to check that the search index is loaded, turned the query into something that works.

r? ghost