### PR TITLE
Disable append-elements.rs test with debug assertions

### DIFF
--- a/tests/codegen-llvm/lib-optimizations/append-elements.rs
+++ b/tests/codegen-llvm/lib-optimizations/append-elements.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -O -Zmerge-functions=disabled
 //@ needs-deterministic-layouts
 //@ min-llvm-version: 21
+//@ ignore-std-debug-assertions (causes different value naming)
 #![crate_type = "lib"]
 
 //! Check that a temporary intermediate allocations can eliminated and replaced


### PR DESCRIPTION
The IR is a bit different (in particular wrt naming) if debug-assertions-std is enabled. Peculiarly, the issue goes away if overflow-check-std is also enabled, which is why CI did not catch this.

r? @the8472 