### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -605,6 +605,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         parent_id = self.tcx.parent_hir_id(*hir_id);
                         parent
                     }
+                    hir::Node::Stmt(hir::Stmt { hir_id, kind: hir::StmtKind::Let(_), .. }) => {
+                        parent_id = self.tcx.parent_hir_id(*hir_id);
+                        parent
+                    }
+                    hir::Node::LetStmt(hir::LetStmt { hir_id, .. }) => {
+                        parent_id = self.tcx.parent_hir_id(*hir_id);
+                        parent
+                    }
                     hir::Node::Block(_) => {
                         parent_id = self.tcx.parent_hir_id(parent_id);
                         parent

--- a/compiler/rustc_middle/src/query/inner.rs
+++ b/compiler/rustc_middle/src/query/inner.rs
@@ -10,7 +10,6 @@ use rustc_query_system::query::{QueryCache, QueryMode, try_get_cached};
 use rustc_span::{DUMMY_SP, ErrorGuaranteed, Span};
 
 use crate::dep_graph;
-use crate::query::IntoQueryParam;
 use crate::query::erase::{self, Erasable, Erased};
 use crate::ty::TyCtxt;
 
@@ -27,7 +26,6 @@ pub(crate) fn query_get_at<'tcx, Cache>(
 where
     Cache: QueryCache,
 {
-    let key = key.into_query_param();
     match try_get_cached(tcx, query_cache, &key) {
         Some(value) => value,
         None => execute_query(tcx, span, key, QueryMode::Get).unwrap(),
@@ -46,7 +44,6 @@ pub(crate) fn query_ensure<'tcx, Cache>(
 ) where
     Cache: QueryCache,
 {
-    let key = key.into_query_param();
     if try_get_cached(tcx, query_cache, &key).is_none() {
         execute_query(tcx, DUMMY_SP, key, QueryMode::Ensure { check_cache });
     }
@@ -66,7 +63,6 @@ where
     Cache: QueryCache<Value = Erased<Result<T, ErrorGuaranteed>>>,
     Result<T, ErrorGuaranteed>: Erasable,
 {
-    let key = key.into_query_param();
     if let Some(res) = try_get_cached(tcx, query_cache, &key) {
         erase::restore_val(res).map(drop)
     } else {

--- a/compiler/rustc_mir_transform/src/liveness.rs
+++ b/compiler/rustc_mir_transform/src/liveness.rs
@@ -1086,11 +1086,6 @@ impl<'a, 'tcx> AssignmentResult<'a, 'tcx> {
 
             let Some((name, decl_span)) = self.checked_places.names[index] else { continue };
 
-            // By convention, underscore-prefixed bindings are explicitly allowed to be unused.
-            if name.as_str().starts_with('_') {
-                continue;
-            }
-
             let is_maybe_drop_guard = maybe_drop_guard(
                 tcx,
                 self.typing_env,
@@ -1117,6 +1112,11 @@ impl<'a, 'tcx> AssignmentResult<'a, 'tcx> {
                 let Some(hir_id) = source_info.scope.lint_root(&self.body.source_scopes) else {
                     continue;
                 };
+
+                // By convention, underscore-prefixed bindings are allowed to be unused explicitly
+                if name.as_str().starts_with('_') {
+                    break;
+                }
 
                 match kind {
                     AccessKind::Assign => {

--- a/tests/codegen-llvm/lib-optimizations/append-elements.rs
+++ b/tests/codegen-llvm/lib-optimizations/append-elements.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -O -Zmerge-functions=disabled
 //@ needs-deterministic-layouts
 //@ min-llvm-version: 21
+//@ ignore-std-debug-assertions (causes different value naming)
 #![crate_type = "lib"]
 
 //! Check that a temporary intermediate allocations can eliminated and replaced

--- a/tests/ui/let-else/let-else-break-help-issue-142602.rs
+++ b/tests/ui/let-else/let-else-break-help-issue-142602.rs
@@ -1,0 +1,23 @@
+// testcase from https://github.com/rust-lang/rust/issues/142602
+
+pub fn main() {
+    // Case 1: break before let-else
+    let _a = loop {
+        if true {
+            break;
+        }
+        let Some(_) = Some(5) else {
+            break 3; //~ ERROR mismatched types
+        };
+    };
+
+    // Case 2: two let-else statements
+    let _b = loop {
+        let Some(_) = Some(5) else {
+            break;
+        };
+        let Some(_) = Some(4) else {
+            break 3; //~ ERROR mismatched types
+        };
+    };
+}

--- a/tests/ui/let-else/let-else-break-help-issue-142602.stderr
+++ b/tests/ui/let-else/let-else-break-help-issue-142602.stderr
@@ -1,0 +1,21 @@
+error[E0308]: mismatched types
+  --> $DIR/let-else-break-help-issue-142602.rs:10:19
+   |
+LL |             break;
+   |             ----- expected because of this `break`
+...
+LL |             break 3;
+   |                   ^ expected `()`, found integer
+
+error[E0308]: mismatched types
+  --> $DIR/let-else-break-help-issue-142602.rs:20:19
+   |
+LL |             break;
+   |             ----- expected because of this `break`
+...
+LL |             break 3;
+   |                   ^ expected `()`, found integer
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#151376 (Fix performance issue in liveness checking)
 - rust-lang/rust#151851 (Remove redundant `IntoQueryParam` calls from query plumbing)
 - rust-lang/rust#151854 (Show break type expectation cause for let-else)
 - rust-lang/rust#151859 (Disable append-elements.rs test with debug assertions)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=151376,151851,151854,151859)
<!-- homu-ignore:end -->

