### PR TITLE
Borrowck: simplify diagnostics for placeholders

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
@@ -24,7 +24,6 @@ use rustc_traits::{type_op_ascribe_user_type_with_span, type_op_prove_predicate_
 use tracing::{debug, instrument};
 
 use crate::MirBorrowckCtxt;
-use crate::region_infer::values::RegionElement;
 use crate::session_diagnostics::{
     HigherRankedErrorCause, HigherRankedLifetimeError, HigherRankedSubtypeError,
 };
@@ -49,11 +48,12 @@ impl<'tcx> UniverseInfo<'tcx> {
         UniverseInfo::RelateTys { expected, found }
     }
 
+    /// Report an error where an element erroneously made its way into `placeholder`.
     pub(crate) fn report_erroneous_element(
         &self,
         mbcx: &mut MirBorrowckCtxt<'_, '_, 'tcx>,
         placeholder: ty::PlaceholderRegion<'tcx>,
-        error_element: RegionElement<'tcx>,
+        error_element: Option<ty::PlaceholderRegion<'tcx>>,
         cause: ObligationCause<'tcx>,
     ) {
         match *self {
@@ -146,14 +146,14 @@ pub(crate) trait TypeOpInfo<'tcx> {
     ) -> Option<Diag<'infcx>>;
 
     /// Constraints require that `error_element` appear in the
-    ///  values of `placeholder`, but this cannot be proven to
+    /// values of `placeholder`, but this cannot be proven to
     /// hold. Report an error.
     #[instrument(level = "debug", skip(self, mbcx))]
     fn report_erroneous_element(
         &self,
         mbcx: &mut MirBorrowckCtxt<'_, '_, 'tcx>,
         placeholder: ty::PlaceholderRegion<'tcx>,
-        error_element: RegionElement<'tcx>,
+        error_element: Option<ty::PlaceholderRegion<'tcx>>,
         cause: ObligationCause<'tcx>,
     ) {
         let tcx = mbcx.infcx.tcx;
@@ -172,19 +172,17 @@ pub(crate) trait TypeOpInfo<'tcx> {
             ty::PlaceholderRegion::new(adjusted_universe.into(), placeholder.bound),
         );
 
-        let error_region =
-            if let RegionElement::PlaceholderRegion(error_placeholder) = error_element {
-                let adjusted_universe =
-                    error_placeholder.universe.as_u32().checked_sub(base_universe.as_u32());
-                adjusted_universe.map(|adjusted| {
-                    ty::Region::new_placeholder(
-                        tcx,
-                        ty::PlaceholderRegion::new(adjusted.into(), error_placeholder.bound),
-                    )
-                })
-            } else {
-                None
-            };
+        // FIXME: one day this should just be error_element,
+        // and this method shouldn't do anything.
+        let error_region = error_element.and_then(|e| {
+            let adjusted_universe = e.universe.as_u32().checked_sub(base_universe.as_u32());
+            adjusted_universe.map(|adjusted| {
+                ty::Region::new_placeholder(
+                    tcx,
+                    ty::PlaceholderRegion::new(adjusted.into(), e.bound),
+                )
+            })
+        });
 
         debug!(?placeholder_region);
 

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -29,7 +29,6 @@ use tracing::{debug, instrument, trace};
 
 use super::{OutlivesSuggestionBuilder, RegionName, RegionNameSource};
 use crate::nll::ConstraintDescription;
-use crate::region_infer::values::RegionElement;
 use crate::region_infer::{BlameConstraint, TypeTest};
 use crate::session_diagnostics::{
     FnMutError, FnMutReturnTypeErr, GenericDoesNotLiveLongEnough, LifetimeOutliveErr,
@@ -104,15 +103,9 @@ pub(crate) enum RegionErrorKind<'tcx> {
     /// A generic bound failure for a type test (`T: 'a`).
     TypeTestError { type_test: TypeTest<'tcx> },
 
-    /// Higher-ranked subtyping error.
-    BoundUniversalRegionError {
-        /// The placeholder free region.
-        longer_fr: RegionVid,
-        /// The region element that erroneously must be outlived by `longer_fr`.
-        error_element: RegionElement<'tcx>,
-        /// The placeholder region.
-        placeholder: ty::PlaceholderRegion<'tcx>,
-    },
+    /// 'p outlives 'r, which does not hold. 'p is always a placeholder
+    /// and 'r is some other region.
+    PlaceholderOutlivesIllegalRegion { longer_fr: RegionVid, illegally_outlived_r: RegionVid },
 
     /// Any other lifetime error.
     RegionError {
@@ -360,28 +353,11 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                     }
                 }
 
-                RegionErrorKind::BoundUniversalRegionError {
+                RegionErrorKind::PlaceholderOutlivesIllegalRegion {
                     longer_fr,
-                    placeholder,
-                    error_element,
+                    illegally_outlived_r,
                 } => {
-                    let error_vid = self.regioncx.region_from_element(longer_fr, &error_element);
-
-                    // Find the code to blame for the fact that `longer_fr` outlives `error_fr`.
-                    let cause = self
-                        .regioncx
-                        .best_blame_constraint(
-                            longer_fr,
-                            NllRegionVariableOrigin::Placeholder(placeholder),
-                            error_vid,
-                        )
-                        .0
-                        .cause;
-
-                    let universe = placeholder.universe;
-                    let universe_info = self.regioncx.universe_info(universe);
-
-                    universe_info.report_erroneous_element(self, placeholder, error_element, cause);
+                    self.report_erroneous_rvid_reaches_placeholder(longer_fr, illegally_outlived_r)
                 }
 
                 RegionErrorKind::RegionError { fr_origin, longer_fr, shorter_fr, is_reported } => {
@@ -410,6 +386,43 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
 
         // Emit one outlives suggestions for each MIR def we borrowck
         outlives_suggestion.add_suggestion(self);
+    }
+
+    /// Report that `longer_fr: error_vid`, which doesn't hold,
+    /// where `longer_fr` is a placeholder.
+    fn report_erroneous_rvid_reaches_placeholder(
+        &mut self,
+        longer_fr: RegionVid,
+        error_vid: RegionVid,
+    ) {
+        use NllRegionVariableOrigin::*;
+
+        let origin_longer = self.regioncx.definitions[longer_fr].origin;
+
+        let Placeholder(placeholder) = origin_longer else {
+            bug!("Expected {longer_fr:?} to come from placeholder!");
+        };
+
+        // FIXME: Is throwing away the existential region really the best here?
+        let error_region = match self.regioncx.definitions[error_vid].origin {
+            FreeRegion | Existential { .. } => None,
+            Placeholder(other_placeholder) => Some(other_placeholder),
+        };
+
+        // Find the code to blame for the fact that `longer_fr` outlives `error_fr`.
+        let cause =
+            self.regioncx.best_blame_constraint(longer_fr, origin_longer, error_vid).0.cause;
+
+        // FIXME these methods should have better names, and also probably not be this generic.
+        // FIXME note that we *throw away* the error element here! We probably want to
+        // thread it through the computation further down and use it, but there currently isn't
+        // anything there to receive it.
+        self.regioncx.universe_info(placeholder.universe).report_erroneous_element(
+            self,
+            placeholder,
+            error_region,
+            cause,
+        );
     }
 
     /// Report an error because the universal region `fr` was required to outlive

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -1379,11 +1379,11 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             .elements_contained_in(longer_fr_scc)
             .find(|e| *e != RegionElement::PlaceholderRegion(placeholder))
         {
+            let illegally_outlived_r = self.region_from_element(longer_fr, &error_element);
             // Stop after the first error, it gets too noisy otherwise, and does not provide more information.
-            errors_buffer.push(RegionErrorKind::BoundUniversalRegionError {
+            errors_buffer.push(RegionErrorKind::PlaceholderOutlivesIllegalRegion {
                 longer_fr,
-                error_element,
-                placeholder,
+                illegally_outlived_r,
             });
         } else {
             debug!("check_bound_universal_region: all bounds satisfied");
@@ -1572,7 +1572,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     }
 
     /// Get the region outlived by `longer_fr` and live at `element`.
-    pub(crate) fn region_from_element(
+    fn region_from_element(
         &self,
         longer_fr: RegionVid,
         element: &RegionElement<'tcx>,


### PR DESCRIPTION
This folds the call to `region_from_element` into `RegionInferenceContext`, and simplifies the error variant for this case to only talk about regions as opposed to elements. This is the only case where a `RegionElement` leaks out of region inference, so now they can be considered internal to region inference (though that currently isn't expressed). It also clarifies the type information on the methods called to emphasise the fact that they only ever use placeholder regions in the diagnostics completely ignore any other element.

It also adds a bunch of FIXMEs to some fishy statements that conjure universes from what seems like arbitrary integers.

This was lifted from rust-lang/rust#142623.

r? @lcnr 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
