### PR TITLE
don't use env with infer vars

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -505,15 +505,12 @@ fn impl_intersection_has_negative_obligation(
     assert_eq!(root_universe, ty::UniverseIndex::ROOT);
 
     let impl1_header = fresh_impl_header(infcx, impl1_def_id, is_of_trait);
-    let param_env =
-        ty::EarlyBinder::bind(tcx.param_env(impl1_def_id)).instantiate(tcx, impl1_header.impl_args);
-
     let impl2_header = fresh_impl_header(infcx, impl2_def_id, is_of_trait);
 
     // Equate the headers to find their intersection (the general type, with infer vars,
     // that may apply both impls).
     let Some(equate_obligations) =
-        equate_impl_headers(infcx, param_env, &impl1_header, &impl2_header)
+        equate_impl_headers(infcx, ty::ParamEnv::empty(), &impl1_header, &impl2_header)
     else {
         return false;
     };
@@ -531,7 +528,11 @@ fn impl_intersection_has_negative_obligation(
         root_universe,
         (impl1_header.impl_args, impl2_header.impl_args),
     );
-    let param_env = infcx.resolve_vars_if_possible(param_env);
+
+    assert!(!impl1_header.impl_args.has_non_region_infer());
+    let impl1_header_args = infcx.resolve_vars_if_possible(impl1_header.impl_args);
+    let param_env =
+        ty::EarlyBinder::bind(tcx.param_env(impl1_def_id)).instantiate(tcx, impl1_header_args);
 
     util::elaborate(tcx, tcx.predicates_of(impl2_def_id).instantiate(tcx, impl2_header.impl_args))
         .elaborate_sized()

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -498,8 +498,8 @@ fn impl_intersection_has_negative_obligation(
 ) -> bool {
     debug!("negative_impl(impl1_def_id={:?}, impl2_def_id={:?})", impl1_def_id, impl2_def_id);
 
-    // N.B. We need to unify impl headers *with* intercrate mode, even if proving negative predicates
-    // do not need intercrate mode enabled.
+    // N.B. We need to unify impl headers *with* `TypingMode::Coherence`,
+    // even if proving negative predicates doesn't need `TypingMode::Coherence`.
     let ref infcx = tcx.infer_ctxt().with_next_trait_solver(true).build(TypingMode::Coherence);
     let root_universe = infcx.universe();
     assert_eq!(root_universe, ty::UniverseIndex::ROOT);
@@ -529,8 +529,13 @@ fn impl_intersection_has_negative_obligation(
         (impl1_header.impl_args, impl2_header.impl_args),
     );
 
-    assert!(!impl1_header.impl_args.has_non_region_infer());
+    // Right above we plug inference variables with placeholders,
+    // this gets us new impl1_header_args with the inference variables actually resolved
+    // to those placeholders.
     let impl1_header_args = infcx.resolve_vars_if_possible(impl1_header.impl_args);
+    // So there are no infer variables left now, except regions which aren't resolved by `resolve_vars_if_possible`.
+    assert!(!impl1_header_args.has_non_region_infer());
+
     let param_env =
         ty::EarlyBinder::bind(tcx.param_env(impl1_def_id)).instantiate(tcx, impl1_header_args);
 


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/151871)*

This is a change lcnr added on top of https://github.com/rust-lang/rust/pull/151746/changes/5bd20bbd0ba6c0285664e55a1ffc677d7487c98b but we decided that it's a separate change for a separate problem. So, filed as a separate PR. Lcnr asked me to r? @BoxyUwU to take a look so hiii boxy :3