### PR TITLE
resolve: Remove `force` parameter from `resolve_ident_in_scope`

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1709,7 +1709,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 ScopeSet::All(ns),
                 parent_scope,
                 None,
-                false,
                 None,
                 None,
             ) else {
@@ -2546,7 +2545,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                             ScopeSet::All(ns_to_try),
                             parent_scope,
                             None,
-                            false,
                             ignore_decl,
                             ignore_import,
                         )
@@ -2650,7 +2648,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 ScopeSet::All(ValueNS),
                 parent_scope,
                 None,
-                false,
                 ignore_decl,
                 ignore_import,
             ) {

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -1498,7 +1498,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     ScopeSet::All(ns),
                     &import.parent_scope,
                     None,
-                    false,
                     decls[ns].get().decl(),
                     None,
                 ) {

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -799,10 +799,12 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 ScopeSet::Macro(kind),
                 parent_scope,
                 None,
-                force,
                 None,
                 None,
             );
+            let binding = binding.map_err(|determinacy| {
+                Determinacy::determined(determinacy == Determinacy::Determined || force)
+            });
             if let Err(Determinacy::Undetermined) = binding {
                 return Err(Determinacy::Undetermined);
             }
@@ -958,7 +960,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 ScopeSet::Macro(kind),
                 &parent_scope,
                 Some(Finalize::new(ast::CRATE_NODE_ID, ident.span)),
-                true,
                 None,
                 None,
             ) {
@@ -1013,7 +1014,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 ScopeSet::Macro(MacroKind::Attr),
                 &parent_scope,
                 Some(Finalize::new(ast::CRATE_NODE_ID, ident.span)),
-                true,
                 None,
                 None,
             );
@@ -1117,7 +1117,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 ScopeSet::Macro(MacroKind::Bang),
                 &ParentScope { macro_rules: no_macro_rules, ..*parent_scope },
                 None,
-                false,
                 None,
                 None,
             );

--- a/tests/ui/macros/macro-rules-as-derive-or-attr-issue-132928.rs
+++ b/tests/ui/macros/macro-rules-as-derive-or-attr-issue-132928.rs
@@ -5,5 +5,4 @@ macro_rules! sample { () => {} }
 #[sample]           //~ ERROR cannot find attribute `sample` in this scope
 #[derive(sample)]   //~ ERROR cannot find derive macro `sample` in this scope
                     //~| ERROR cannot find derive macro `sample` in this scope
-                    //~| ERROR cannot find derive macro `sample` in this scope
 pub struct S {}

--- a/tests/ui/macros/macro-rules-as-derive-or-attr-issue-132928.stderr
+++ b/tests/ui/macros/macro-rules-as-derive-or-attr-issue-132928.stderr
@@ -1,12 +1,3 @@
-error: cannot find derive macro `sample` in this scope
-  --> $DIR/macro-rules-as-derive-or-attr-issue-132928.rs:6:10
-   |
-LL | macro_rules! sample { () => {} }
-   |              ------ `sample` exists, but has no `derive` rules
-...
-LL | #[derive(sample)]
-   |          ^^^^^^
-
 error: cannot find attribute `sample` in this scope
   --> $DIR/macro-rules-as-derive-or-attr-issue-132928.rs:5:3
    |
@@ -24,8 +15,6 @@ LL | macro_rules! sample { () => {} }
 ...
 LL | #[derive(sample)]
    |          ^^^^^^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: cannot find derive macro `sample` in this scope
   --> $DIR/macro-rules-as-derive-or-attr-issue-132928.rs:6:10
@@ -38,5 +27,5 @@ LL | #[derive(sample)]
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
`force == true` is used for turning `Determinacy::Undetermined` into `Determinacy::Determined` during error recovery.
It's only needed in two places:
- `resolve_macro_or_delegation_path` - the normal case
- `resolve_path_with_ribs` - obscure case, only when resolving visibilities and only for improving diagnostics in `tests\ui\resolve\visibility-indeterminate.rs`, I'm not actually sure if we should keep it

In other cases `Determinacy::Undetermined` is just ignored or can be propagated.