### PR TITLE
Do not emit inference errors after encountering `mod` parse errors

### DIFF
--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -795,6 +795,10 @@ fn resolver_for_lowering_raw<'tcx>(
     );
     let krate = configure_and_expand(krate, &pre_configured_attrs, &mut resolver);
 
+    if resolver.encountered_mod_parse_error() {
+        *tcx.encountered_mod_parse_error.write() = true;
+    }
+
     // Make sure we don't mutate the cstore from here on.
     tcx.untracked().cstore.freeze();
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1613,6 +1613,10 @@ pub struct GlobalCtxt<'tcx> {
     /// Stores memory for globals (statics/consts).
     pub(crate) alloc_map: interpret::AllocMap<'tcx>,
 
+    /// Set to `true` when `resolve` has encountered any `mod` with parse errors. Used to signal
+    /// inference not to emit knock-down diagnostics.
+    pub encountered_mod_parse_error: Arc<RwLock<bool>>,
+
     current_gcx: CurrentGcx,
 
     /// A jobserver reference used to release then acquire a token while waiting on a query.
@@ -1842,6 +1846,7 @@ impl<'tcx> TyCtxt<'tcx> {
             clauses_cache: Default::default(),
             data_layout,
             alloc_map: interpret::AllocMap::new(),
+            encountered_mod_parse_error: Default::default(),
             current_gcx,
             jobserver_proxy,
         });

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -2474,6 +2474,10 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         }
         self.main_def = Some(MainDefinition { res, is_import, span });
     }
+
+    pub fn encountered_mod_parse_error(&self) -> bool {
+        !self.mods_with_parse_errors.is_empty()
+    }
 }
 
 fn names_to_string(names: impl Iterator<Item = Symbol>) -> String {

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
@@ -508,7 +508,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 false
             };
             let mut err = self.bad_inference_failure_err(failure_span, arg_data, error_code);
-            if silence {
+            if silence || *self.tcx.encountered_mod_parse_error.read() {
                 err.downgrade_to_delayed_bug();
             }
             return err;
@@ -676,7 +676,9 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             }),
         };
         *err.long_ty_path() = long_ty_path;
-        if let InferSourceKind::ClosureArg { kind: PatKind::Err(_), .. } = kind {
+        if matches!(kind, InferSourceKind::ClosureArg { kind: PatKind::Err(_), .. })
+            || *self.tcx.encountered_mod_parse_error.read()
+        {
             // We will have already emitted an error about this pattern.
             err.downgrade_to_delayed_bug();
         }


### PR DESCRIPTION
Even in the face of parse recovery of a `mod`, when encountering parse errors silence knock-down inference errors.

For context, in the repro project from rust-lang/rust#105618 with a single parse error goes from emitting 69 diagnostics to 1.

Fix rust-lang/rust#105618.