### PR TITLE
Skip unused_allocation lint when method takes &Box<Self>

### DIFF
--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -1782,7 +1782,7 @@ declare_lint! {
 declare_lint_pass!(UnusedAllocation => [UNUSED_ALLOCATION]);
 
 impl<'tcx> LateLintPass<'tcx> for UnusedAllocation {
-    fn check_expr(&mut self, cx: &LateContext<'_>, e: &hir::Expr<'_>) {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, e: &hir::Expr<'_>) {
         match e.kind {
             hir::ExprKind::Call(path_expr, [_])
                 if let hir::ExprKind::Path(qpath) = &path_expr.kind
@@ -1793,6 +1793,12 @@ impl<'tcx> LateLintPass<'tcx> for UnusedAllocation {
 
         for adj in cx.typeck_results().expr_adjustments(e) {
             if let adjustment::Adjust::Borrow(adjustment::AutoBorrow::Ref(m)) = adj.kind {
+                if let ty::Ref(_, inner_ty, _) = adj.target.kind()
+                    && inner_ty.is_box()
+                {
+                    // If the target type is `&Box<T>` or `&mut Box<T>`, the allocation is necessary
+                    continue;
+                }
                 match m {
                     adjustment::AutoBorrowMutability::Not => {
                         cx.emit_span_lint(UNUSED_ALLOCATION, e.span, UnusedAllocationDiag);

--- a/tests/ui/lint/unused/unused-allocation-box-ref-issue-151846.rs
+++ b/tests/ui/lint/unused/unused-allocation-box-ref-issue-151846.rs
@@ -1,0 +1,54 @@
+//@ check-pass
+// Test for issue #151846: unused_allocation warning should ignore
+// allocations to pass Box to things taking self: &Box
+
+#![deny(unused_allocation)]
+
+struct MyStruct;
+
+trait TraitTakesBoxRef {
+    fn trait_takes_box_ref(&self);
+}
+
+impl TraitTakesBoxRef for Box<MyStruct> {
+    fn trait_takes_box_ref(&self) {}
+}
+
+impl MyStruct {
+    fn inherent_takes_box_ref(self: &Box<Self>) {}
+}
+
+fn takes_box_ref(_: &Box<MyStruct>) {}
+
+trait TraitTakesBoxVal {
+    fn trait_takes_box_val(self);
+}
+
+impl TraitTakesBoxVal for Box<MyStruct> {
+    fn trait_takes_box_val(self) {}
+}
+
+impl MyStruct {
+    fn inherent_takes_box_val(self: Box<Self>) {}
+}
+
+fn takes_box_val(_: Box<MyStruct>) {}
+
+pub fn foo() {
+    // These should NOT warn - the allocation is necessary because
+    // the method takes &Box<Self>
+    Box::new(MyStruct).trait_takes_box_ref();
+    Box::new(MyStruct).inherent_takes_box_ref();
+    takes_box_ref(&Box::new(MyStruct));
+
+    // These already don't warn - the allocation is necessary
+    Box::new(MyStruct).trait_takes_box_val();
+    Box::new(MyStruct).inherent_takes_box_val();
+    takes_box_val(Box::new(MyStruct));
+
+    // Fully-qualified syntax also does not warn:
+    <Box<MyStruct> as TraitTakesBoxRef>::trait_takes_box_ref(&Box::new(MyStruct));
+    MyStruct::inherent_takes_box_ref(&Box::new(MyStruct));
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes rust-lang/rust#151846