### PR TITLE
Fix ICE when parsing frontmatter without newline

### DIFF
--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -623,7 +623,7 @@ impl<'psess, 'src> Lexer<'psess, 'src> {
             self.dcx().emit_err(errors::FrontmatterInvalidInfostring { span });
         }
 
-        let last_line_start = real_s.rfind('\n').map_or(0, |i| i + 1);
+        let last_line_start = real_s.rfind('\n').map_or(line_end, |i| i + 1);
 
         let content = &real_s[line_end..last_line_start];
         if let Some(cr_offset) = content.find('\r') {

--- a/tests/run-make/frontmatter-no-trailing-newline/rmake.rs
+++ b/tests/run-make/frontmatter-no-trailing-newline/rmake.rs
@@ -1,0 +1,19 @@
+// Regression test for issue #151882
+// See https://github.com/rust-lang/rust/issues/151882
+
+//@ only-nightly
+//@ needs-target-std
+
+use run_make_support::{rfs, rustc};
+
+fn main() {
+    rfs::write("test.rs", b"----");
+
+    // Ensure rustc does not ICE when parsing a file with frontmatter syntax
+    // that has no trailing newline
+    rustc()
+        .input("test.rs")
+        .run_fail()
+        .assert_stderr_contains("invalid infostring for frontmatter")
+        .assert_stderr_not_contains("unexpectedly panicked");
+}


### PR DESCRIPTION
Fixes rust-lang/rust#151882  

we can not add a normal test case for it:
- no newline at the end of file, we can bypass this with change test file name with `ignore-tidy`
- multiple errors in stderr, this conflicts with the previous bypass, seems we can not add multiple error annotations in one line

anyway, I added a `run-make` test for it.
