### PR TITLE
Re-export `hashbrown::hash_table` from `rustc_data_structures`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4354,7 +4354,6 @@ name = "rustc_mir_transform"
 version = "0.0.0"
 dependencies = [
  "either",
- "hashbrown 0.16.1",
  "itertools",
  "rustc_abi",
  "rustc_arena",
@@ -4565,7 +4564,6 @@ dependencies = [
 name = "rustc_query_system"
 version = "0.0.0"
 dependencies = [
- "hashbrown 0.16.1",
  "parking_lot",
  "rustc_abi",
  "rustc_ast",

--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -49,6 +49,10 @@ pub use std::{assert_matches, debug_assert_matches};
 
 pub use atomic_ref::AtomicRef;
 pub use ena::{snapshot_vec, undo_log, unify};
+// Re-export `hashbrown::hash_table`, because it's part of our API
+// (via `ShardedHashMap`), and because it lets other compiler crates use the
+// lower-level `HashTable` API without a tricky `hashbrown` dependency.
+pub use hashbrown::hash_table;
 pub use rustc_index::static_assert_size;
 // Re-export some data-structure crates which are part of our public API.
 pub use {either, indexmap, smallvec, thin_vec};

--- a/compiler/rustc_data_structures/src/sharded.rs
+++ b/compiler/rustc_data_structures/src/sharded.rs
@@ -3,7 +3,7 @@ use std::hash::{Hash, Hasher};
 use std::{iter, mem};
 
 use either::Either;
-use hashbrown::hash_table::{Entry, HashTable};
+use hashbrown::hash_table::{self, Entry, HashTable};
 
 use crate::fx::FxHasher;
 use crate::sync::{CacheAligned, Lock, LockGuard, Mode, is_dyn_thread_safe};
@@ -140,7 +140,7 @@ pub fn shards() -> usize {
     1
 }
 
-pub type ShardedHashMap<K, V> = Sharded<HashTable<(K, V)>>;
+pub type ShardedHashMap<K, V> = Sharded<hash_table::HashTable<(K, V)>>;
 
 impl<K: Eq, V> ShardedHashMap<K, V> {
     pub fn with_capacity(cap: usize) -> Self {

--- a/compiler/rustc_mir_transform/Cargo.toml
+++ b/compiler/rustc_mir_transform/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2024"
 [dependencies]
 # tidy-alphabetical-start
 either = "1"
-hashbrown = { version = "0.16.1", default-features = false }
 itertools = "0.12"
 rustc_abi = { path = "../rustc_abi" }
 rustc_arena = { path = "../rustc_arena" }

--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -88,7 +88,6 @@ use std::borrow::Cow;
 use std::hash::{Hash, Hasher};
 
 use either::Either;
-use hashbrown::hash_table::{Entry, HashTable};
 use itertools::Itertools as _;
 use rustc_abi::{self as abi, BackendRepr, FIRST_VARIANT, FieldIdx, Primitive, Size, VariantIdx};
 use rustc_arena::DroplessArena;
@@ -99,6 +98,7 @@ use rustc_const_eval::interpret::{
 };
 use rustc_data_structures::fx::FxHasher;
 use rustc_data_structures::graph::dominators::Dominators;
+use rustc_data_structures::hash_table::{Entry, HashTable};
 use rustc_hir::def::DefKind;
 use rustc_index::bit_set::DenseBitSet;
 use rustc_index::{IndexVec, newtype_index};

--- a/compiler/rustc_query_system/Cargo.toml
+++ b/compiler/rustc_query_system/Cargo.toml
@@ -23,8 +23,3 @@ rustc_thread_pool = { path = "../rustc_thread_pool" }
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
 tracing = "0.1"
 # tidy-alphabetical-end
-
-[dependencies.hashbrown]
-version = "0.16.1"
-default-features = false
-features = ["nightly"] # for may_dangle

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -7,9 +7,8 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::mem;
 
-use hashbrown::HashTable;
-use hashbrown::hash_table::Entry;
 use rustc_data_structures::fingerprint::Fingerprint;
+use rustc_data_structures::hash_table::{self, Entry, HashTable};
 use rustc_data_structures::sharded::{self, Sharded};
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_data_structures::sync::LockGuard;
@@ -35,7 +34,7 @@ fn equivalent_key<K: Eq, V>(k: &K) -> impl Fn(&(K, V)) -> bool + '_ {
 }
 
 pub struct QueryState<'tcx, K> {
-    active: Sharded<hashbrown::HashTable<(K, QueryResult<'tcx>)>>,
+    active: Sharded<hash_table::HashTable<(K, QueryResult<'tcx>)>>,
 }
 
 /// Indicates the state of a query for a given key in a query map.


### PR DESCRIPTION
We don't always re-export shared dependencies, but for `hashbrown::hash_table` I think it makes sense, for a few reasons:

- The lower-level `HashTable` type is already part of the public API of `rustc_data_structures` via the `ShardedHashMap` type alias, and other compiler crates currently depend on being able to access its internal hash tables.
- The `Cargo.toml` entry for `hashbrown` is non-trivial, making it harder to keep in sync and harder to move between crates as needed.
  - [And we currently aren't using `[workspace.dependencies]` for various reasons.](https://github.com/rust-lang/rust/pull/146113)
- It's fine for other compiler crates to use `hash_table` specifically (with care), but they probably shouldn't be using the higher-level `hashbrown::HashMap` and `hashbrown::HashSet` types directly, because they should prefer the various map/set aliases defined by `rustc_data_structures`. Re-exporting only `hash_table` helps to discourage use of those other types.

There should be no change to compiler behaviour.