### PR TITLE
Document enum types used as values for E0423

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0423.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0423.md
@@ -45,15 +45,13 @@ fn h1() -> i32 {
 }
 ```
 
-
-
 ### Enum types used as values
 
 Enums are types and cannot be used directly as values.
 
 ```compile_fail,E0423
-fn main() {
+fn main(){
     let x = Option::<i32>;
-    //~^ ERROR expected value, found enum `Option`
+    //~^ ERROR expected value,found enum `Option`
 }
 ```

--- a/compiler/rustc_error_codes/src/error_codes/E0423.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0423.md
@@ -44,3 +44,16 @@ fn h1() -> i32 {
     // did you mean `a::I`?
 }
 ```
+
+
+
+### Enum types used as values
+
+Enums are types and cannot be used directly as values.
+
+```compile_fail,E0423
+fn main() {
+    let x = Option::<i32>;
+    //~^ ERROR expected value, found enum `Option`
+}
+```


### PR DESCRIPTION
### Problem

The E0423 error explanation did not include an example for enum types being used
as values, which is a common source of confusion for users. 

For example, the following code:

```rust
fn main() {
    let x = Option::<i32>;
}
```