### PR TITLE
Split the `dec2flt::RawFloat` trait for easier reuse

### DIFF
--- a/library/core/src/num/imp/dec2flt/decimal.rs
+++ b/library/core/src/num/imp/dec2flt/decimal.rs
@@ -1,8 +1,9 @@
 //! Representation of a float as the significant digits and exponent.
 
-use crate::num::imp::dec2flt;
-use dec2flt::float::Lemire;
+use dec2flt::Lemire;
 use dec2flt::fpu::set_precision;
+
+use crate::num::imp::dec2flt;
 
 const INT_POW10: [u64; 16] = [
     1,

--- a/library/core/src/num/imp/dec2flt/decimal.rs
+++ b/library/core/src/num/imp/dec2flt/decimal.rs
@@ -1,9 +1,8 @@
 //! Representation of a float as the significant digits and exponent.
 
-use dec2flt::float::RawFloat;
-use dec2flt::fpu::set_precision;
-
 use crate::num::imp::dec2flt;
+use dec2flt::float::Lemire;
+use dec2flt::fpu::set_precision;
 
 const INT_POW10: [u64; 16] = [
     1,
@@ -36,7 +35,7 @@ pub struct Decimal {
 impl Decimal {
     /// Detect if the float can be accurately reconstructed from native floats.
     #[inline]
-    fn can_use_fast_path<F: RawFloat>(&self) -> bool {
+    fn can_use_fast_path<F: Lemire>(&self) -> bool {
         F::MIN_EXPONENT_FAST_PATH <= self.exponent
             && self.exponent <= F::MAX_EXPONENT_DISGUISED_FAST_PATH
             && self.mantissa <= F::MAX_MANTISSA_FAST_PATH
@@ -53,7 +52,7 @@ impl Decimal {
     ///
     /// There is an exception: disguised fast-path cases, where we can shift
     /// powers-of-10 from the exponent to the significant digits.
-    pub fn try_fast_path<F: RawFloat>(&self) -> Option<F> {
+    pub fn try_fast_path<F: Lemire>(&self) -> Option<F> {
         // Here we need to work around <https://github.com/rust-lang/rust/issues/114479>.
         // The fast path crucially depends on arithmetic being rounded to the correct number of bits
         // without any intermediate rounding. On x86 (without SSE or SSE2) this requires the precision

--- a/library/core/src/num/imp/dec2flt/float.rs
+++ b/library/core/src/num/imp/dec2flt/float.rs
@@ -12,7 +12,7 @@ pub trait CastInto<T: Copy>: Copy {
 }
 
 /// Collection of traits that allow us to be generic over integer size.
-pub trait Integer:
+pub trait Int:
     Sized
     + Clone
     + Copy
@@ -37,7 +37,7 @@ macro_rules! int {
                 }
             }
 
-            impl Integer for $ty {
+            impl Int for $ty {
                 const ZERO: Self = 0;
                 const ONE: Self = 1;
             }
@@ -68,7 +68,7 @@ pub trait RawFloat:
     + Debug
 {
     /// The unsigned integer with the same size as the float
-    type Int: Integer + Into<u64>;
+    type Int: Int + Into<u64>;
 
     /* general constants */
 

--- a/library/core/src/num/imp/dec2flt/lemire.rs
+++ b/library/core/src/num/imp/dec2flt/lemire.rs
@@ -1,7 +1,7 @@
 //! Implementation of the Eisel-Lemire algorithm.
 
 use dec2flt::common::BiasedFp;
-use dec2flt::float::RawFloat;
+use dec2flt::float::Float;
 use dec2flt::table::{LARGEST_POWER_OF_FIVE, POWER_OF_FIVE_128, SMALLEST_POWER_OF_FIVE};
 
 use crate::num::imp::dec2flt;
@@ -24,7 +24,7 @@ use crate::num::imp::dec2flt;
 /// at a Gigabyte per Second" in section 5, "Fast Algorithm", and
 /// section 6, "Exact Numbers And Ties", available online:
 /// <https://arxiv.org/abs/2101.11408.pdf>.
-pub fn compute_float<F: RawFloat>(q: i64, mut w: u64) -> BiasedFp {
+pub fn compute_float<F: Float>(q: i64, mut w: u64) -> BiasedFp {
     let fp_zero = BiasedFp::zero_pow2(0);
     let fp_inf = BiasedFp::zero_pow2(F::INFINITE_POWER);
     let fp_error = BiasedFp::zero_pow2(-1);

--- a/library/core/src/num/imp/dec2flt/lemire.rs
+++ b/library/core/src/num/imp/dec2flt/lemire.rs
@@ -1,10 +1,9 @@
 //! Implementation of the Eisel-Lemire algorithm.
 
 use dec2flt::common::BiasedFp;
-use dec2flt::float::Float;
 use dec2flt::table::{LARGEST_POWER_OF_FIVE, POWER_OF_FIVE_128, SMALLEST_POWER_OF_FIVE};
 
-use crate::num::imp::dec2flt;
+use crate::num::imp::{Float, dec2flt};
 
 /// Compute w * 10^q using an extended-precision float representation.
 ///

--- a/library/core/src/num/imp/dec2flt/mod.rs
+++ b/library/core/src/num/imp/dec2flt/mod.rs
@@ -88,7 +88,7 @@
 )]
 
 use common::BiasedFp;
-use float::RawFloat;
+use float::{FloatExt, Lemire};
 use lemire::compute_float;
 use parse::{parse_inf_nan, parse_number};
 use slow::parse_long_mantissa;
@@ -120,7 +120,7 @@ pub fn pfe_invalid() -> ParseFloatError {
 }
 
 /// Converts a `BiasedFp` to the closest machine float type.
-fn biased_fp_to_float<F: RawFloat>(x: BiasedFp) -> F {
+fn biased_fp_to_float<F: FloatExt>(x: BiasedFp) -> F {
     let mut word = x.m;
     word |= (x.p_biased as u64) << F::SIG_BITS;
     F::from_u64_bits(word)
@@ -128,7 +128,7 @@ fn biased_fp_to_float<F: RawFloat>(x: BiasedFp) -> F {
 
 /// Converts a decimal string into a floating point number.
 #[inline(always)] // Will be inlined into a function with `#[inline(never)]`, see above
-pub fn dec2flt<F: RawFloat>(s: &str) -> Result<F, ParseFloatError> {
+pub fn dec2flt<F: Lemire>(s: &str) -> Result<F, ParseFloatError> {
     let mut s = s.as_bytes();
     let Some(&c) = s.first() else { return Err(pfe_empty()) };
     let negative = c == b'-';

--- a/library/core/src/num/imp/dec2flt/parse.rs
+++ b/library/core/src/num/imp/dec2flt/parse.rs
@@ -2,7 +2,7 @@
 
 use dec2flt::common::{ByteSlice, is_8digits};
 use dec2flt::decimal::Decimal;
-use dec2flt::float::RawFloat;
+use dec2flt::float::Float;
 
 use crate::num::imp::dec2flt;
 
@@ -197,7 +197,7 @@ pub fn parse_number(s: &[u8]) -> Option<Decimal> {
 }
 
 /// Try to parse a special, non-finite float.
-pub(crate) fn parse_inf_nan<F: RawFloat>(s: &[u8], negative: bool) -> Option<F> {
+pub(crate) fn parse_inf_nan<F: Float>(s: &[u8], negative: bool) -> Option<F> {
     // Since a valid string has at most the length 8, we can load
     // all relevant characters into a u64 and work from there.
     // This also generates much better code.

--- a/library/core/src/num/imp/dec2flt/parse.rs
+++ b/library/core/src/num/imp/dec2flt/parse.rs
@@ -2,9 +2,8 @@
 
 use dec2flt::common::{ByteSlice, is_8digits};
 use dec2flt::decimal::Decimal;
-use dec2flt::float::Float;
 
-use crate::num::imp::dec2flt;
+use crate::num::imp::{Float, dec2flt};
 
 const MIN_19DIGIT_INT: u64 = 100_0000_0000_0000_0000;
 

--- a/library/core/src/num/imp/dec2flt/slow.rs
+++ b/library/core/src/num/imp/dec2flt/slow.rs
@@ -2,7 +2,7 @@
 
 use dec2flt::common::BiasedFp;
 use dec2flt::decimal_seq::{DecimalSeq, parse_decimal_seq};
-use dec2flt::float::RawFloat;
+use dec2flt::float::Float;
 
 use crate::num::imp::dec2flt;
 
@@ -25,7 +25,7 @@ use crate::num::imp::dec2flt;
 ///
 /// The algorithms described here are based on "Processing Long Numbers Quickly",
 /// available here: <https://arxiv.org/pdf/2101.11408.pdf#section.11>.
-pub(crate) fn parse_long_mantissa<F: RawFloat>(s: &[u8]) -> BiasedFp {
+pub(crate) fn parse_long_mantissa<F: Float>(s: &[u8]) -> BiasedFp {
     const MAX_SHIFT: usize = 60;
     const NUM_POWERS: usize = 19;
     const POWERS: [u8; 19] =

--- a/library/core/src/num/imp/dec2flt/slow.rs
+++ b/library/core/src/num/imp/dec2flt/slow.rs
@@ -2,9 +2,8 @@
 
 use dec2flt::common::BiasedFp;
 use dec2flt::decimal_seq::{DecimalSeq, parse_decimal_seq};
-use dec2flt::float::Float;
 
-use crate::num::imp::dec2flt;
+use crate::num::imp::{Float, dec2flt};
 
 /// Parse the significant digits and biased, binary exponent of a float.
 ///

--- a/library/core/src/num/imp/flt2dec/decoder.rs
+++ b/library/core/src/num/imp/flt2dec/decoder.rs
@@ -1,7 +1,7 @@
 //! Decodes a floating-point value into individual parts and error ranges.
 
 use crate::num::FpCategory;
-use crate::num::imp::dec2flt::float::FloatExt;
+use crate::num::imp::FloatExt;
 
 /// Decoded unsigned finite value, such that:
 ///

--- a/library/core/src/num/imp/flt2dec/decoder.rs
+++ b/library/core/src/num/imp/flt2dec/decoder.rs
@@ -1,7 +1,7 @@
 //! Decodes a floating-point value into individual parts and error ranges.
 
 use crate::num::FpCategory;
-use crate::num::imp::dec2flt::float::RawFloat;
+use crate::num::imp::dec2flt::float::FloatExt;
 
 /// Decoded unsigned finite value, such that:
 ///
@@ -40,7 +40,7 @@ pub enum FullDecoded {
 }
 
 /// A floating point type which can be `decode`d.
-pub trait DecodableFloat: RawFloat + Copy {
+pub trait DecodableFloat: FloatExt + Copy {
     /// The minimum positive normalized value.
     fn min_pos_norm_value() -> Self;
 }

--- a/library/core/src/num/imp/mod.rs
+++ b/library/core/src/num/imp/mod.rs
@@ -16,3 +16,6 @@ pub(crate) mod int_log10;
 pub(crate) mod int_sqrt;
 pub(crate) mod libm;
 pub(crate) mod overflow_panic;
+mod traits;
+
+pub use traits::{Float, FloatExt, Int};

--- a/library/core/src/num/imp/traits.rs
+++ b/library/core/src/num/imp/traits.rs
@@ -1,10 +1,14 @@
-//! Helper trait for generic float types.
+//! Numeric traits used for internal implementations.
 
-use core::f64;
+#![doc(hidden)]
+#![unstable(
+    feature = "num_internals",
+    reason = "internal routines only exposed for testing",
+    issue = "none"
+)]
 
-use crate::fmt::{Debug, LowerExp};
 use crate::num::FpCategory;
-use crate::ops::{self, Add, Div, Mul, Neg};
+use crate::{f64, fmt, ops};
 
 /// Lossy `as` casting between two types.
 pub trait CastInto<T: Copy>: Copy {
@@ -16,7 +20,7 @@ pub trait Int:
     Sized
     + Clone
     + Copy
-    + Debug
+    + fmt::Debug
     + ops::Shr<u32, Output = Self>
     + ops::Shl<u32, Output = Self>
     + ops::BitAnd<Output = Self>
@@ -51,17 +55,16 @@ int!(u16, u32, u64);
 #[doc(hidden)]
 pub trait Float:
     Sized
-    + Div<Output = Self>
-    + Neg<Output = Self>
-    + Mul<Output = Self>
-    + Add<Output = Self>
-    + LowerExp
+    + ops::Div<Output = Self>
+    + ops::Neg<Output = Self>
+    + ops::Mul<Output = Self>
+    + ops::Add<Output = Self>
+    + fmt::Debug
     + PartialEq
     + PartialOrd
     + Default
     + Clone
     + Copy
-    + Debug
 {
     /// The unsigned integer with the same size as the float
     type Int: Int + Into<u64>;
@@ -184,41 +187,6 @@ pub trait FloatExt: Float {
     }
 }
 
-/// Extension to `Float` that are necessary for parsing using the Lemire method.
-///
-/// See the parent module's doc comment for why this is necessary.
-///
-/// Not intended for use outside of the `dec2flt` module.
-#[doc(hidden)]
-pub trait Lemire: FloatExt {
-    /// Maximum exponent for a fast path case, or `⌊(SIG_BITS+1)/log2(5)⌋`
-    // assuming FLT_EVAL_METHOD = 0
-    const MAX_EXPONENT_FAST_PATH: i64 = {
-        let log2_5 = f64::consts::LOG2_10 - 1.0;
-        (Self::SIG_TOTAL_BITS as f64 / log2_5) as i64
-    };
-
-    /// Minimum exponent for a fast path case, or `-⌊(SIG_BITS+1)/log2(5)⌋`
-    const MIN_EXPONENT_FAST_PATH: i64 = -Self::MAX_EXPONENT_FAST_PATH;
-
-    /// Maximum exponent that can be represented for a disguised-fast path case.
-    /// This is `MAX_EXPONENT_FAST_PATH + ⌊(SIG_BITS+1)/log2(10)⌋`
-    const MAX_EXPONENT_DISGUISED_FAST_PATH: i64 =
-        Self::MAX_EXPONENT_FAST_PATH + (Self::SIG_TOTAL_BITS as f64 / f64::consts::LOG2_10) as i64;
-
-    /// Maximum mantissa for the fast-path (`1 << 53` for f64).
-    const MAX_MANTISSA_FAST_PATH: u64 = 1 << Self::SIG_TOTAL_BITS;
-
-    /// Gets a small power-of-ten for fast-path multiplication.
-    fn pow10_fast_path(exponent: usize) -> Self;
-
-    /// Converts integer into float through an as cast.
-    /// This is only called in the fast-path algorithm, and therefore
-    /// will not lose precision, since the value will always have
-    /// only if the value is <= Self::MAX_MANTISSA_FAST_PATH.
-    fn from_u64(v: u64) -> Self;
-}
-
 /// Solve for `b` in `10^b = 2^a`
 const fn pow2_to_pow10(a: i64) -> i64 {
     let res = (a as f64) / f64::consts::LOG2_10;
@@ -260,21 +228,6 @@ impl FloatExt for f16 {
     }
 }
 
-#[cfg(target_has_reliable_f16)]
-impl Lemire for f16 {
-    fn pow10_fast_path(exponent: usize) -> Self {
-        #[allow(clippy::use_self)]
-        const TABLE: [f16; 8] = [1e0, 1e1, 1e2, 1e3, 1e4, 0.0, 0.0, 0.];
-        TABLE[exponent & 7]
-    }
-
-    #[inline]
-    fn from_u64(v: u64) -> Self {
-        debug_assert!(v <= Self::MAX_MANTISSA_FAST_PATH);
-        v as _
-    }
-}
-
 impl Float for f32 {
     type Int = u32;
 
@@ -308,21 +261,6 @@ impl FloatExt for f32 {
     }
 }
 
-impl Lemire for f32 {
-    fn pow10_fast_path(exponent: usize) -> Self {
-        #[allow(clippy::use_self)]
-        const TABLE: [f32; 16] =
-            [1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9, 1e10, 0., 0., 0., 0., 0.];
-        TABLE[exponent & 15]
-    }
-
-    #[inline]
-    fn from_u64(v: u64) -> Self {
-        debug_assert!(v <= Self::MAX_MANTISSA_FAST_PATH);
-        v as _
-    }
-}
-
 impl Float for f64 {
     type Int = u64;
 
@@ -353,21 +291,5 @@ impl FloatExt for f64 {
     #[inline]
     fn from_u64_bits(v: u64) -> Self {
         f64::from_bits(v)
-    }
-}
-
-impl Lemire for f64 {
-    fn pow10_fast_path(exponent: usize) -> Self {
-        const TABLE: [f64; 32] = [
-            1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9, 1e10, 1e11, 1e12, 1e13, 1e14, 1e15,
-            1e16, 1e17, 1e18, 1e19, 1e20, 1e21, 1e22, 0., 0., 0., 0., 0., 0., 0., 0., 0.,
-        ];
-        TABLE[exponent & 31]
-    }
-
-    #[inline]
-    fn from_u64(v: u64) -> Self {
-        debug_assert!(v <= Self::MAX_MANTISSA_FAST_PATH);
-        v as _
     }
 }

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -88,6 +88,7 @@
 #![feature(next_index)]
 #![feature(non_exhaustive_omitted_patterns_lint)]
 #![feature(nonzero_from_str_radix)]
+#![feature(num_internals)]
 #![feature(numfmt)]
 #![feature(one_sided_range)]
 #![feature(panic_internals)]

--- a/library/coretests/tests/num/dec2flt/float.rs
+++ b/library/coretests/tests/num/dec2flt/float.rs
@@ -1,4 +1,4 @@
-use core::num::imp::dec2flt::float::RawFloat;
+use core::num::imp::dec2flt::float::{Float, FloatExt, Lemire};
 
 use crate::num::{ldexp_f32, ldexp_f64};
 
@@ -56,57 +56,60 @@ fn test_f64_integer_decode() {
 #[test]
 #[cfg(target_has_reliable_f16)]
 fn test_f16_consts() {
-    assert_eq!(<f16 as RawFloat>::INFINITY, f16::INFINITY);
-    assert_eq!(<f16 as RawFloat>::NEG_INFINITY, -f16::INFINITY);
-    assert_eq!(<f16 as RawFloat>::NAN.to_bits(), f16::NAN.to_bits());
-    assert_eq!(<f16 as RawFloat>::NEG_NAN.to_bits(), (-f16::NAN).to_bits());
-    assert_eq!(<f16 as RawFloat>::SIG_BITS, 10);
-    assert_eq!(<f16 as RawFloat>::MIN_EXPONENT_ROUND_TO_EVEN, -22);
-    assert_eq!(<f16 as RawFloat>::MAX_EXPONENT_ROUND_TO_EVEN, 5);
-    assert_eq!(<f16 as RawFloat>::MIN_EXPONENT_FAST_PATH, -4);
-    assert_eq!(<f16 as RawFloat>::MAX_EXPONENT_FAST_PATH, 4);
-    assert_eq!(<f16 as RawFloat>::MAX_EXPONENT_DISGUISED_FAST_PATH, 7);
-    assert_eq!(<f16 as RawFloat>::EXP_MIN, -14);
-    assert_eq!(<f16 as RawFloat>::EXP_SAT, 0x1f);
-    assert_eq!(<f16 as RawFloat>::SMALLEST_POWER_OF_TEN, -27);
-    assert_eq!(<f16 as RawFloat>::LARGEST_POWER_OF_TEN, 4);
-    assert_eq!(<f16 as RawFloat>::MAX_MANTISSA_FAST_PATH, 2048);
+    assert_eq!(<f16 as Float>::INFINITY, f16::INFINITY);
+    assert_eq!(<f16 as Float>::NEG_INFINITY, -f16::INFINITY);
+    assert_eq!(<f16 as Float>::NAN.to_bits(), f16::NAN.to_bits());
+    assert_eq!(<f16 as Float>::NEG_NAN.to_bits(), (-f16::NAN).to_bits());
+    assert_eq!(<f16 as Float>::SIG_BITS, 10);
+    assert_eq!(<f16 as Float>::MIN_EXPONENT_ROUND_TO_EVEN, -22);
+    assert_eq!(<f16 as Float>::MAX_EXPONENT_ROUND_TO_EVEN, 5);
+    assert_eq!(<f16 as Float>::EXP_MIN, -14);
+    assert_eq!(<f16 as Float>::EXP_SAT, 0x1f);
+    assert_eq!(<f16 as Float>::SMALLEST_POWER_OF_TEN, -27);
+    assert_eq!(<f16 as Float>::LARGEST_POWER_OF_TEN, 4);
+
+    assert_eq!(<f16 as Lemire>::MIN_EXPONENT_FAST_PATH, -4);
+    assert_eq!(<f16 as Lemire>::MAX_EXPONENT_FAST_PATH, 4);
+    assert_eq!(<f16 as Lemire>::MAX_EXPONENT_DISGUISED_FAST_PATH, 7);
+    assert_eq!(<f16 as Lemire>::MAX_MANTISSA_FAST_PATH, 2048);
 }
 
 #[test]
 fn test_f32_consts() {
-    assert_eq!(<f32 as RawFloat>::INFINITY, f32::INFINITY);
-    assert_eq!(<f32 as RawFloat>::NEG_INFINITY, -f32::INFINITY);
-    assert_eq!(<f32 as RawFloat>::NAN.to_bits(), f32::NAN.to_bits());
-    assert_eq!(<f32 as RawFloat>::NEG_NAN.to_bits(), (-f32::NAN).to_bits());
-    assert_eq!(<f32 as RawFloat>::SIG_BITS, 23);
-    assert_eq!(<f32 as RawFloat>::MIN_EXPONENT_ROUND_TO_EVEN, -17);
-    assert_eq!(<f32 as RawFloat>::MAX_EXPONENT_ROUND_TO_EVEN, 10);
-    assert_eq!(<f32 as RawFloat>::MIN_EXPONENT_FAST_PATH, -10);
-    assert_eq!(<f32 as RawFloat>::MAX_EXPONENT_FAST_PATH, 10);
-    assert_eq!(<f32 as RawFloat>::MAX_EXPONENT_DISGUISED_FAST_PATH, 17);
-    assert_eq!(<f32 as RawFloat>::EXP_MIN, -126);
-    assert_eq!(<f32 as RawFloat>::EXP_SAT, 0xff);
-    assert_eq!(<f32 as RawFloat>::SMALLEST_POWER_OF_TEN, -65);
-    assert_eq!(<f32 as RawFloat>::LARGEST_POWER_OF_TEN, 38);
-    assert_eq!(<f32 as RawFloat>::MAX_MANTISSA_FAST_PATH, 16777216);
+    assert_eq!(<f32 as Float>::INFINITY, f32::INFINITY);
+    assert_eq!(<f32 as Float>::NEG_INFINITY, -f32::INFINITY);
+    assert_eq!(<f32 as Float>::NAN.to_bits(), f32::NAN.to_bits());
+    assert_eq!(<f32 as Float>::NEG_NAN.to_bits(), (-f32::NAN).to_bits());
+    assert_eq!(<f32 as Float>::SIG_BITS, 23);
+    assert_eq!(<f32 as Float>::MIN_EXPONENT_ROUND_TO_EVEN, -17);
+    assert_eq!(<f32 as Float>::MAX_EXPONENT_ROUND_TO_EVEN, 10);
+    assert_eq!(<f32 as Float>::EXP_MIN, -126);
+    assert_eq!(<f32 as Float>::EXP_SAT, 0xff);
+    assert_eq!(<f32 as Float>::SMALLEST_POWER_OF_TEN, -65);
+    assert_eq!(<f32 as Float>::LARGEST_POWER_OF_TEN, 38);
+
+    assert_eq!(<f32 as Lemire>::MIN_EXPONENT_FAST_PATH, -10);
+    assert_eq!(<f32 as Lemire>::MAX_EXPONENT_FAST_PATH, 10);
+    assert_eq!(<f32 as Lemire>::MAX_EXPONENT_DISGUISED_FAST_PATH, 17);
+    assert_eq!(<f32 as Lemire>::MAX_MANTISSA_FAST_PATH, 16777216);
 }
 
 #[test]
 fn test_f64_consts() {
-    assert_eq!(<f64 as RawFloat>::INFINITY, f64::INFINITY);
-    assert_eq!(<f64 as RawFloat>::NEG_INFINITY, -f64::INFINITY);
-    assert_eq!(<f64 as RawFloat>::NAN.to_bits(), f64::NAN.to_bits());
-    assert_eq!(<f64 as RawFloat>::NEG_NAN.to_bits(), (-f64::NAN).to_bits());
-    assert_eq!(<f64 as RawFloat>::SIG_BITS, 52);
-    assert_eq!(<f64 as RawFloat>::MIN_EXPONENT_ROUND_TO_EVEN, -4);
-    assert_eq!(<f64 as RawFloat>::MAX_EXPONENT_ROUND_TO_EVEN, 23);
-    assert_eq!(<f64 as RawFloat>::MIN_EXPONENT_FAST_PATH, -22);
-    assert_eq!(<f64 as RawFloat>::MAX_EXPONENT_FAST_PATH, 22);
-    assert_eq!(<f64 as RawFloat>::MAX_EXPONENT_DISGUISED_FAST_PATH, 37);
-    assert_eq!(<f64 as RawFloat>::EXP_MIN, -1022);
-    assert_eq!(<f64 as RawFloat>::EXP_SAT, 0x7ff);
-    assert_eq!(<f64 as RawFloat>::SMALLEST_POWER_OF_TEN, -342);
-    assert_eq!(<f64 as RawFloat>::LARGEST_POWER_OF_TEN, 308);
-    assert_eq!(<f64 as RawFloat>::MAX_MANTISSA_FAST_PATH, 9007199254740992);
+    assert_eq!(<f64 as Float>::INFINITY, f64::INFINITY);
+    assert_eq!(<f64 as Float>::NEG_INFINITY, -f64::INFINITY);
+    assert_eq!(<f64 as Float>::NAN.to_bits(), f64::NAN.to_bits());
+    assert_eq!(<f64 as Float>::NEG_NAN.to_bits(), (-f64::NAN).to_bits());
+    assert_eq!(<f64 as Float>::SIG_BITS, 52);
+    assert_eq!(<f64 as Float>::MIN_EXPONENT_ROUND_TO_EVEN, -4);
+    assert_eq!(<f64 as Float>::MAX_EXPONENT_ROUND_TO_EVEN, 23);
+    assert_eq!(<f64 as Float>::EXP_MIN, -1022);
+    assert_eq!(<f64 as Float>::EXP_SAT, 0x7ff);
+    assert_eq!(<f64 as Float>::SMALLEST_POWER_OF_TEN, -342);
+    assert_eq!(<f64 as Float>::LARGEST_POWER_OF_TEN, 308);
+
+    assert_eq!(<f64 as Lemire>::MIN_EXPONENT_FAST_PATH, -22);
+    assert_eq!(<f64 as Lemire>::MAX_EXPONENT_FAST_PATH, 22);
+    assert_eq!(<f64 as Lemire>::MAX_EXPONENT_DISGUISED_FAST_PATH, 37);
+    assert_eq!(<f64 as Lemire>::MAX_MANTISSA_FAST_PATH, 9007199254740992);
 }

--- a/library/coretests/tests/num/dec2flt/float.rs
+++ b/library/coretests/tests/num/dec2flt/float.rs
@@ -1,4 +1,5 @@
-use core::num::imp::dec2flt::float::{Float, FloatExt, Lemire};
+use core::num::imp::dec2flt::Lemire;
+use core::num::imp::{Float, FloatExt};
 
 use crate::num::{ldexp_f32, ldexp_f64};
 

--- a/library/coretests/tests/num/dec2flt/lemire.rs
+++ b/library/coretests/tests/num/dec2flt/lemire.rs
@@ -1,6 +1,6 @@
 use core::num::imp::dec2flt;
 
-use dec2flt::float::RawFloat;
+use dec2flt::float::Float;
 use dec2flt::lemire::compute_float;
 
 #[cfg(target_has_reliable_f16)]

--- a/library/coretests/tests/num/dec2flt/lemire.rs
+++ b/library/coretests/tests/num/dec2flt/lemire.rs
@@ -1,6 +1,5 @@
-use core::num::imp::dec2flt;
+use core::num::imp::{Float, dec2flt};
 
-use dec2flt::float::Float;
 use dec2flt::lemire::compute_float;
 
 #[cfg(target_has_reliable_f16)]


### PR DESCRIPTION
`RawFloat` is an internal trait with quite a few useful float properties. It currently resides in the `dec2flt` module but is also used in parsing, and would be nice to reuse other places. Unfortunately it cannot be implemented on `f128` because of limitations with how the parsing API is implemented (mantissa must fit into a u64).

To make the trait easier to work with, split it into the following:

* `Float`: Anything that is reasonably applicable to all floating point types.
* `FloatExt`: Items that should be part of `Float` but don't work for all float types. This will eventually be merged back into `Float` once it can be implemented on f128.
* `Lemire`: Items that are specific to the Lemire dec2flt algorithm.

These traits are then moved to places that make sense.

Builds on top of https://github.com/rust-lang/rust/pull/151900