### PR TITLE
Remove unused method `DroplessArena::contains_slice`

### DIFF
--- a/compiler/rustc_arena/src/lib.rs
+++ b/compiler/rustc_arena/src/lib.rs
@@ -510,19 +510,6 @@ impl DroplessArena {
         }
     }
 
-    /// Used by `Lift` to check whether this slice is allocated
-    /// in this arena.
-    #[inline]
-    pub fn contains_slice<T>(&self, slice: &[T]) -> bool {
-        for chunk in self.chunks.borrow_mut().iter_mut() {
-            let ptr = slice.as_ptr().cast::<u8>().cast_mut();
-            if chunk.start() <= ptr && chunk.end() >= ptr {
-                return true;
-            }
-        }
-        false
-    }
-
     /// Allocates a string slice that is copied into the `DroplessArena`, returning a
     /// reference to it. Will panic if passed an empty string.
     ///


### PR DESCRIPTION
- This method was added for https://github.com/rust-lang/rust/pull/120128.
- It became unused in https://github.com/rust-lang/rust/pull/136593.

Checking whether a particular slice is within an arena is a bit of a sketchy operation, so if there's no pressing need for it then I think we're better off not having it lying around.