### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -1782,7 +1782,7 @@ declare_lint! {
 declare_lint_pass!(UnusedAllocation => [UNUSED_ALLOCATION]);
 
 impl<'tcx> LateLintPass<'tcx> for UnusedAllocation {
-    fn check_expr(&mut self, cx: &LateContext<'_>, e: &hir::Expr<'_>) {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, e: &hir::Expr<'_>) {
         match e.kind {
             hir::ExprKind::Call(path_expr, [_])
                 if let hir::ExprKind::Path(qpath) = &path_expr.kind
@@ -1793,6 +1793,12 @@ impl<'tcx> LateLintPass<'tcx> for UnusedAllocation {
 
         for adj in cx.typeck_results().expr_adjustments(e) {
             if let adjustment::Adjust::Borrow(adjustment::AutoBorrow::Ref(m)) = adj.kind {
+                if let ty::Ref(_, inner_ty, _) = adj.target.kind()
+                    && inner_ty.is_box()
+                {
+                    // If the target type is `&Box<T>` or `&mut Box<T>`, the allocation is necessary
+                    continue;
+                }
                 match m {
                     adjustment::AutoBorrowMutability::Not => {
                         cx.emit_span_lint(UNUSED_ALLOCATION, e.span, UnusedAllocationDiag);

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -408,6 +408,12 @@ impl<Id: Into<DefId>> Visibility<Id> {
     }
 }
 
+impl<Id: Into<DefId> + Copy> Visibility<Id> {
+    pub fn min(self, vis: Visibility<Id>, tcx: TyCtxt<'_>) -> Visibility<Id> {
+        if self.is_at_least(vis, tcx) { vis } else { self }
+    }
+}
+
 impl Visibility<DefId> {
     pub fn expect_local(self) -> Visibility {
         self.map_id(|id| id.expect_local())

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -1750,6 +1750,12 @@ impl<'a> Parser<'a> {
             hi = self.prev_token.span;
             let ann = BindingMode(by_ref, mutability);
             let fieldpat = self.mk_pat_ident(boxed_span.to(hi), ann, fieldname);
+            if matches!(
+                fieldpat.kind,
+                PatKind::Ident(BindingMode(ByRef::Yes(..), Mutability::Mut), ..)
+            ) {
+                self.psess.gated_spans.gate(sym::mut_ref, fieldpat.span);
+            }
             let subpat = if is_box {
                 self.mk_pat(lo.to(hi), PatKind::Box(Box::new(fieldpat)))
             } else {

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -1463,6 +1463,7 @@ pub(crate) struct UnknownDiagnosticAttributeTypoSugg {
 // FIXME: Make this properly translatable.
 pub(crate) struct Ambiguity {
     pub ident: Ident,
+    pub ambig_vis: Option<String>,
     pub kind: &'static str,
     pub help: Option<&'static [&'static str]>,
     pub b1_note: Spanned<String>,
@@ -1473,8 +1474,12 @@ pub(crate) struct Ambiguity {
 
 impl Ambiguity {
     fn decorate<'a>(self, diag: &mut Diag<'a, impl EmissionGuarantee>) {
-        diag.primary_message(format!("`{}` is ambiguous", self.ident));
-        diag.span_label(self.ident.span, "ambiguous name");
+        if let Some(ambig_vis) = self.ambig_vis {
+            diag.primary_message(format!("ambiguous import visibility: {ambig_vis}"));
+        } else {
+            diag.primary_message(format!("`{}` is ambiguous", self.ident));
+            diag.span_label(self.ident.span, "ambiguous name");
+        }
         diag.note(format!("ambiguous because of {}", self.kind));
         diag.span_note(self.b1_note.span, self.b1_note.node);
         if let Some(help) = self.help {

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -1189,7 +1189,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     ident,
                     ns,
                     &import.parent_scope,
-                    Some(Finalize { report_private: false, ..finalize }),
+                    Some(Finalize {
+                        report_private: false,
+                        import_vis: Some(import.vis),
+                        ..finalize
+                    }),
                     bindings[ns].get().decl(),
                     Some(import),
                 );

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -963,6 +963,7 @@ enum AmbiguityWarning {
 
 struct AmbiguityError<'ra> {
     kind: AmbiguityKind,
+    ambig_vis: Option<(Visibility, Visibility)>,
     ident: Ident,
     b1: Decl<'ra>,
     b2: Decl<'ra>,
@@ -2080,6 +2081,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         if let Some(b2) = used_decl.ambiguity.get() {
             let ambiguity_error = AmbiguityError {
                 kind: AmbiguityKind::GlobVsGlob,
+                ambig_vis: None,
                 ident,
                 b1: used_decl,
                 b2,
@@ -2549,6 +2551,8 @@ struct Finalize {
     used: Used = Used::Other,
     /// Finalizing early or late resolution.
     stage: Stage = Stage::Early,
+    /// Nominal visibility of the import item, in case we are resolving an import's final segment.
+    import_vis: Option<Visibility> = None,
 }
 
 impl Finalize {

--- a/tests/ui/feature-gates/feature-gate-mut-ref.rs
+++ b/tests/ui/feature-gates/feature-gate-mut-ref.rs
@@ -10,4 +10,7 @@ fn main() {
     let mut ref x = 10; //~  ERROR [E0658]
     #[cfg(false)]
     let mut ref mut y = 10; //~  ERROR [E0658]
+
+    struct Foo { x: i32 }
+    let Foo { mut ref x } = Foo { x: 10 };
 }

--- a/tests/ui/feature-gates/feature-gate-mut-ref.rs
+++ b/tests/ui/feature-gates/feature-gate-mut-ref.rs
@@ -12,5 +12,5 @@ fn main() {
     let mut ref mut y = 10; //~  ERROR [E0658]
 
     struct Foo { x: i32 }
-    let Foo { mut ref x } = Foo { x: 10 };
+    let Foo { mut ref x } = Foo { x: 10 }; //~  ERROR [E0658]
 }

--- a/tests/ui/feature-gates/feature-gate-mut-ref.stderr
+++ b/tests/ui/feature-gates/feature-gate-mut-ref.stderr
@@ -38,6 +38,16 @@ LL |     let mut ref mut y = 10;
    = help: add `#![feature(mut_ref)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 4 previous errors
+error[E0658]: mutable by-reference bindings are experimental
+  --> $DIR/feature-gate-mut-ref.rs:15:15
+   |
+LL |     let Foo { mut ref x } = Foo { x: 10 };
+   |               ^^^^^^^^^
+   |
+   = note: see issue #123076 <https://github.com/rust-lang/rust/issues/123076> for more information
+   = help: add `#![feature(mut_ref)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/imports/ambiguous-import-visibility-macro.rs
+++ b/tests/ui/imports/ambiguous-import-visibility-macro.rs
@@ -1,0 +1,19 @@
+//@ check-pass
+//@ edition:2018
+//@ proc-macro: same-res-ambigious-extern-macro.rs
+
+macro_rules! globbing{
+    () => {
+        pub use same_res_ambigious_extern_macro::*;
+    }
+}
+
+#[macro_use] // this imports the `RustEmbed` macro with `pub(crate)` visibility
+extern crate same_res_ambigious_extern_macro;
+globbing! {} // this imports the same `RustEmbed` macro with `pub` visibility
+
+pub trait RustEmbed {}
+
+pub use RustEmbed as Embed; //~ WARN ambiguous import visibility
+                            //~| WARN this was previously accepted
+fn main() {}

--- a/tests/ui/imports/ambiguous-import-visibility-macro.stderr
+++ b/tests/ui/imports/ambiguous-import-visibility-macro.stderr
@@ -1,0 +1,29 @@
+warning: ambiguous import visibility: pub(crate) or pub
+  --> $DIR/ambiguous-import-visibility-macro.rs:17:9
+   |
+LL | pub use RustEmbed as Embed;
+   |         ^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #149145 <https://github.com/rust-lang/rust/issues/149145>
+   = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
+note: `RustEmbed` could refer to the derive macro imported here
+  --> $DIR/ambiguous-import-visibility-macro.rs:7:17
+   |
+LL |         pub use same_res_ambigious_extern_macro::*;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | globbing! {} // this imports the same `RustEmbed` macro with `pub` visibility
+   | ------------ in this macro invocation
+   = help: consider adding an explicit import of `RustEmbed` to disambiguate
+   = help: or use `crate::RustEmbed` to refer to this derive macro unambiguously
+note: `RustEmbed` could also refer to the derive macro imported here
+  --> $DIR/ambiguous-import-visibility-macro.rs:11:1
+   |
+LL | #[macro_use] // this imports the `RustEmbed` macro with `pub(crate)` visibility
+   | ^^^^^^^^^^^^
+   = note: `#[warn(ambiguous_import_visibilities)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: this warning originates in the macro `globbing` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: 1 warning emitted
+

--- a/tests/ui/imports/ambiguous-import-visibility-module.rs
+++ b/tests/ui/imports/ambiguous-import-visibility-module.rs
@@ -1,0 +1,24 @@
+//@ check-pass
+//@ edition:2018..
+
+mod reexport {
+    mod m {
+        pub struct S {}
+    }
+
+    macro_rules! mac {
+        () => {
+            use m::S;
+        };
+    }
+
+    pub use m::*;
+    mac!();
+
+    pub use S as Z; //~ WARN ambiguous import visibility
+                    //~| WARN this was previously accepted
+}
+
+fn main() {
+    reexport::Z {};
+}

--- a/tests/ui/imports/ambiguous-import-visibility-module.stderr
+++ b/tests/ui/imports/ambiguous-import-visibility-module.stderr
@@ -1,0 +1,29 @@
+warning: ambiguous import visibility: pub or pub(in crate::reexport)
+  --> $DIR/ambiguous-import-visibility-module.rs:18:13
+   |
+LL |     pub use S as Z;
+   |             ^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #149145 <https://github.com/rust-lang/rust/issues/149145>
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
+note: `S` could refer to the struct imported here
+  --> $DIR/ambiguous-import-visibility-module.rs:11:17
+   |
+LL |             use m::S;
+   |                 ^^^^
+...
+LL |     mac!();
+   |     ------ in this macro invocation
+   = help: use `self::S` to refer to this struct unambiguously
+note: `S` could also refer to the struct imported here
+  --> $DIR/ambiguous-import-visibility-module.rs:15:13
+   |
+LL |     pub use m::*;
+   |             ^^^^
+   = help: use `self::S` to refer to this struct unambiguously
+   = note: `#[warn(ambiguous_import_visibilities)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: this warning originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: 1 warning emitted
+

--- a/tests/ui/imports/ambiguous-import-visibility.rs
+++ b/tests/ui/imports/ambiguous-import-visibility.rs
@@ -1,0 +1,14 @@
+//@ check-pass
+//@ edition:2018
+//@ proc-macro: same-res-ambigious-extern-macro.rs
+
+#[macro_use] // this imports the `RustEmbed` macro with `pub(crate)` visibility
+extern crate same_res_ambigious_extern_macro;
+// this imports the same `RustEmbed` macro with `pub` visibility
+pub use same_res_ambigious_extern_macro::*;
+
+pub trait RustEmbed {}
+
+pub use RustEmbed as Embed; //~ WARN ambiguous import visibility
+                            //~| WARN this was previously accepted
+fn main() {}

--- a/tests/ui/imports/ambiguous-import-visibility.stderr
+++ b/tests/ui/imports/ambiguous-import-visibility.stderr
@@ -1,0 +1,25 @@
+warning: ambiguous import visibility: pub(crate) or pub
+  --> $DIR/ambiguous-import-visibility.rs:12:9
+   |
+LL | pub use RustEmbed as Embed;
+   |         ^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #149145 <https://github.com/rust-lang/rust/issues/149145>
+   = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
+note: `RustEmbed` could refer to the derive macro imported here
+  --> $DIR/ambiguous-import-visibility.rs:8:9
+   |
+LL | pub use same_res_ambigious_extern_macro::*;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `RustEmbed` to disambiguate
+   = help: or use `crate::RustEmbed` to refer to this derive macro unambiguously
+note: `RustEmbed` could also refer to the derive macro imported here
+  --> $DIR/ambiguous-import-visibility.rs:5:1
+   |
+LL | #[macro_use] // this imports the `RustEmbed` macro with `pub(crate)` visibility
+   | ^^^^^^^^^^^^
+   = note: `#[warn(ambiguous_import_visibilities)]` (part of `#[warn(future_incompatible)]`) on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/lint/unused/unused-allocation-box-ref-issue-151846.rs
+++ b/tests/ui/lint/unused/unused-allocation-box-ref-issue-151846.rs
@@ -1,0 +1,54 @@
+//@ check-pass
+// Test for issue #151846: unused_allocation warning should ignore
+// allocations to pass Box to things taking self: &Box
+
+#![deny(unused_allocation)]
+
+struct MyStruct;
+
+trait TraitTakesBoxRef {
+    fn trait_takes_box_ref(&self);
+}
+
+impl TraitTakesBoxRef for Box<MyStruct> {
+    fn trait_takes_box_ref(&self) {}
+}
+
+impl MyStruct {
+    fn inherent_takes_box_ref(self: &Box<Self>) {}
+}
+
+fn takes_box_ref(_: &Box<MyStruct>) {}
+
+trait TraitTakesBoxVal {
+    fn trait_takes_box_val(self);
+}
+
+impl TraitTakesBoxVal for Box<MyStruct> {
+    fn trait_takes_box_val(self) {}
+}
+
+impl MyStruct {
+    fn inherent_takes_box_val(self: Box<Self>) {}
+}
+
+fn takes_box_val(_: Box<MyStruct>) {}
+
+pub fn foo() {
+    // These should NOT warn - the allocation is necessary because
+    // the method takes &Box<Self>
+    Box::new(MyStruct).trait_takes_box_ref();
+    Box::new(MyStruct).inherent_takes_box_ref();
+    takes_box_ref(&Box::new(MyStruct));
+
+    // These already don't warn - the allocation is necessary
+    Box::new(MyStruct).trait_takes_box_val();
+    Box::new(MyStruct).inherent_takes_box_val();
+    takes_box_val(Box::new(MyStruct));
+
+    // Fully-qualified syntax also does not warn:
+    <Box<MyStruct> as TraitTakesBoxRef>::trait_takes_box_ref(&Box::new(MyStruct));
+    MyStruct::inherent_takes_box_ref(&Box::new(MyStruct));
+}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#149596 (resolve: Report more visibility-related early resolution ambiguities for imports)
 - rust-lang/rust#151886 (Skip unused_allocation lint when method takes &Box<Self>)
 - rust-lang/rust#151102 (Feature-gate `mut ref` patterns in struct pattern field shorthand)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=149596,151886,151102)
<!-- homu-ignore:end -->

