### PR TITLE
Fix ICE when projection error reporting sees opaque alias terms

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1607,6 +1607,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         };
 
                     if let Some(lhs) = lhs.to_alias_term()
+                        && let ty::AliasTermKind::ProjectionTy | ty::AliasTermKind::ProjectionConst = lhs.kind(self.tcx)
                         && let Some((better_type_err, expected_term)) =
                             derive_better_type_error(lhs, rhs)
                     {
@@ -1615,6 +1616,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                             better_type_err,
                         )
                     } else if let Some(rhs) = rhs.to_alias_term()
+                        && let ty::AliasTermKind::ProjectionTy | ty::AliasTermKind::ProjectionConst = rhs.kind(self.tcx)
                         && let Some((better_type_err, expected_term)) =
                             derive_better_type_error(rhs, lhs)
                     {

--- a/tests/ui/type-alias-impl-trait/opaque-alias-relate-issue-151331.rs
+++ b/tests/ui/type-alias-impl-trait/opaque-alias-relate-issue-151331.rs
@@ -1,0 +1,10 @@
+//@ compile-flags: -Znext-solver=globally
+#![feature(type_alias_impl_trait)]
+
+type Foo = Vec<impl Send>;
+
+#[define_opaque(Foo)]
+fn make_foo() -> Foo {}
+//~^ ERROR type mismatch resolving
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/opaque-alias-relate-issue-151331.stderr
+++ b/tests/ui/type-alias-impl-trait/opaque-alias-relate-issue-151331.stderr
@@ -1,0 +1,9 @@
+error[E0271]: type mismatch resolving `Foo == ()`
+  --> $DIR/opaque-alias-relate-issue-151331.rs:7:18
+   |
+LL | fn make_foo() -> Foo {}
+   |                  ^^^ types differ
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0271`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#151331