### PR TITLE
Use `#![feature(adt_const_params)]` for static query flags

### DIFF
--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -708,14 +708,18 @@ macro_rules! define_queries {
                 data: PhantomData<&'tcx ()>
             }
 
+            const FLAGS: QueryFlags = QueryFlags {
+                is_anon: is_anon!([$($modifiers)*]),
+                is_depth_limit: depth_limit!([$($modifiers)*]),
+                is_feedable: feedable!([$($modifiers)*]),
+            };
+
             impl<'tcx> QueryDispatcherUnerased<'tcx> for QueryType<'tcx> {
                 type UnerasedValue = queries::$name::Value<'tcx>;
                 type Dispatcher = SemiDynamicQueryDispatcher<
                     'tcx,
                     queries::$name::Storage<'tcx>,
-                    { is_anon!([$($modifiers)*]) },
-                    { depth_limit!([$($modifiers)*]) },
-                    { feedable!([$($modifiers)*]) },
+                    FLAGS,
                 >;
 
                 const NAME: &'static &'static str = &stringify!($name);


### PR DESCRIPTION
As suggested by https://github.com/rust-lang/rust/pull/151633#issuecomment-3799180811, this replaces multiple clunky const booleans with a single const struct, which is a bit nicer.

This should also make it easier to experiment with statically resolving other flags, like `eval_always`.

There are currently no other compiler crates using `feature(adt_const_params)`, so hopefully it's mature enough for a simple use-case like this one.