### PR TITLE
Add UI test for spurious double borrow (issue #151903)

### DIFF
--- a/tests/ui/borrowck/spurious-double-borrow-151903.rs
+++ b/tests/ui/borrowck/spurious-double-borrow-151903.rs
@@ -1,0 +1,34 @@
+//@ edition:2021
+//! UI test for spurious double borrow error with temporaries in match expressions.
+//!
+//! This test demonstrates that temporaries created in a match scrutinee
+//! extend to the end of the match, causing an E0502 borrow error.
+//!
+//! See: https://github.com/rust-lang/rust/issues/151903
+
+use std::task::{Context, Poll};
+use std::pin::Pin;
+use std::future::Future;
+
+struct Foo<'buf> {
+    data: &'buf String,
+}
+
+async fn read_foo<'buf>(buffer: &'buf mut String) -> Result<Foo<'buf>, ()> {
+    Ok(Foo { data: buffer })
+}
+
+fn poll_next(mut buffer: Pin<&mut String>, cx: &mut Context<'_>) -> Poll<()> {
+    let _ = match Box::pin(read_foo(&mut *buffer)).as_mut().poll(cx) {
+        Poll::Ready(Ok(foo)) => {
+            println!("buffer: {}", buffer);
+//~^ ERROR[E0502]
+        }
+        Poll::Ready(Err(())) => {}
+        Poll::Pending => {}
+    };
+
+    Poll::Pending
+}
+
+fn main() {}

--- a/tests/ui/borrowck/spurious-double-borrow-151903.stderr
+++ b/tests/ui/borrowck/spurious-double-borrow-151903.stderr
@@ -1,0 +1,18 @@
+error[E0502]: cannot borrow `buffer` as immutable because it is also borrowed as mutable
+  --> $DIR/spurious-double-borrow-151903.rs:24:36
+   |
+LL |     let _ = match Box::pin(read_foo(&mut *buffer)).as_mut().poll(cx) {
+   |                   --------------------------------
+   |                   |                       |
+   |                   |                       mutable borrow occurs here
+   |                   a temporary with access to the mutable borrow is created here ...
+LL |         Poll::Ready(Ok(foo)) => {
+LL |             println!("buffer: {}", buffer);
+   |                                    ^^^^^^ immutable borrow occurs here
+...
+LL |     };
+   |      - ... and the mutable borrow might be used here, when that temporary is dropped and runs the destructor for type `Pin<Box<impl Future<Output = Result<Foo<'_>, ()>>>>`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0502`.

--- a/tests/ui/issues/issue-151903.rs
+++ b/tests/ui/issues/issue-151903.rs
@@ -1,0 +1,34 @@
+//@ edition:2021
+//! UI test for spurious double borrow error with temporaries in match expressions.
+//!
+//! This test demonstrates that temporaries created in a match scrutinee
+//! extend to the end of the match, causing an E0502 borrow error.
+//!
+//! See: https://github.com/rust-lang/rust/issues/151903
+
+use std::task::{Context, Poll};
+use std::pin::Pin;
+use std::future::Future;
+
+struct Foo<'buf> {
+    data: &'buf String,
+}
+
+async fn read_foo<'buf>(buffer: &'buf mut String) -> Result<Foo<'buf>, ()> {
+    Ok(Foo { data: buffer })
+}
+
+fn poll_next(mut buffer: Pin<&mut String>, cx: &mut Context<'_>) -> Poll<()> {
+    let _ = match Box::pin(read_foo(&mut *buffer)).as_mut().poll(cx) {
+        Poll::Ready(Ok(foo)) => {
+            println!("buffer: {}", buffer);
+//~^ ERROR[E0502]
+        }
+        Poll::Ready(Err(())) => {}
+        Poll::Pending => {}
+    };
+
+    Poll::Pending
+}
+
+fn main() {}

--- a/tests/ui/issues/issue-151903.stderr
+++ b/tests/ui/issues/issue-151903.stderr
@@ -1,0 +1,18 @@
+error[E0502]: cannot borrow `buffer` as immutable because it is also borrowed as mutable
+  --> $DIR/issue-151903.rs:24:36
+   |
+LL |     let _ = match Box::pin(read_foo(&mut *buffer)).as_mut().poll(cx) {
+   |                   --------------------------------
+   |                   |                       |
+   |                   |                       mutable borrow occurs here
+   |                   a temporary with access to the mutable borrow is created here ...
+LL |         Poll::Ready(Ok(foo)) => {
+LL |             println!("buffer: {}", buffer);
+   |                                    ^^^^^^ immutable borrow occurs here
+...
+LL |     };
+   |      - ... and the mutable borrow might be used here, when that temporary is dropped and runs the destructor for type `Pin<Box<impl Future<Output = Result<Foo<'_>, ()>>>>`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0502`.


### PR DESCRIPTION
### Summary
This PR adds a UI test that reproduces the spurious double borrow error (E0502) caused by temporaries in a match scrutinee.

Closes rust-lang/rust#151903
