### PR TITLE
feat: Add `NonZero::<T>::from_str_radix`

### DIFF
--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -90,6 +90,7 @@
 #![feature(new_range_api)]
 #![feature(next_index)]
 #![feature(non_exhaustive_omitted_patterns_lint)]
+#![feature(nonzero_from_str_radix)]
 #![feature(numfmt)]
 #![feature(one_sided_range)]
 #![feature(option_reduce)]

--- a/library/coretests/tests/nonzero.rs
+++ b/library/coretests/tests/nonzero.rs
@@ -125,6 +125,41 @@ fn test_from_signed_nonzero() {
 }
 
 #[test]
+fn test_from_str_radix() {
+    assert_eq!(NonZero::<u8>::from_str_radix("123", 10), Ok(NonZero::new(123).unwrap()));
+    assert_eq!(NonZero::<u8>::from_str_radix("1001", 2), Ok(NonZero::new(9).unwrap()));
+    assert_eq!(NonZero::<u8>::from_str_radix("123", 8), Ok(NonZero::new(83).unwrap()));
+    assert_eq!(NonZero::<u16>::from_str_radix("123", 16), Ok(NonZero::new(291).unwrap()));
+    assert_eq!(NonZero::<u16>::from_str_radix("ffff", 16), Ok(NonZero::new(65535).unwrap()));
+    assert_eq!(NonZero::<u8>::from_str_radix("z", 36), Ok(NonZero::new(35).unwrap()));
+    assert_eq!(
+        NonZero::<u8>::from_str_radix("0", 10).err().map(|e| e.kind().clone()),
+        Some(IntErrorKind::Zero)
+    );
+    assert_eq!(
+        NonZero::<u8>::from_str_radix("-1", 10).err().map(|e| e.kind().clone()),
+        Some(IntErrorKind::InvalidDigit)
+    );
+    assert_eq!(
+        NonZero::<i8>::from_str_radix("-129", 10).err().map(|e| e.kind().clone()),
+        Some(IntErrorKind::NegOverflow)
+    );
+    assert_eq!(
+        NonZero::<u8>::from_str_radix("257", 10).err().map(|e| e.kind().clone()),
+        Some(IntErrorKind::PosOverflow)
+    );
+
+    assert_eq!(
+        NonZero::<u8>::from_str_radix("Z", 10).err().map(|e| e.kind().clone()),
+        Some(IntErrorKind::InvalidDigit)
+    );
+    assert_eq!(
+        NonZero::<u8>::from_str_radix("_", 2).err().map(|e| e.kind().clone()),
+        Some(IntErrorKind::InvalidDigit)
+    );
+}
+
+#[test]
 fn test_from_str() {
     assert_eq!("123".parse::<NonZero<u8>>(), Ok(NonZero::new(123).unwrap()));
     assert_eq!(


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

- Accepted ACP: rust-lang/libs-team#548
- Tracking issue: rust-lang/rust#152193

This pull request adds a method to `NonZero<T>` that parses a non-zero integer from a string slice with digits in a given base.

When using the combination of `int::from_str_radix` and `NonZero::<T>::new`, [`IntErrorKind::Zero`](https://doc.rust-lang.org/core/num/enum.IntErrorKind.html#variant.Zero) cannot be returned as an error. When using `NonZero::<T>::from_str`, `IntErrorKind::Zero` can be returned as an error, but this method cannot parse non-decimal integers.

`NonZero::<T>::from_str_radix` can return `IntErrorKind::Zero` as an error, and can parse both decimal integers and non-decimal integers.