### PR TITLE
Include assoc const projections in CFI trait object

### DIFF
--- a/tests/ui/sanitizer/cfi/assoc-const-projection-issue-151878.rs
+++ b/tests/ui/sanitizer/cfi/assoc-const-projection-issue-151878.rs
@@ -1,0 +1,20 @@
+//@ compile-flags: -Zsanitizer=cfi -Cunsafe-allow-abi-mismatch=sanitizer -Ccodegen-units=1 -Clto
+//@ needs-rustc-debug-assertions
+//@ needs-sanitizer-cfi
+//@ build-pass
+//@ no-prefer-dynamic
+
+#![feature(min_generic_const_args)]
+#![expect(incomplete_features)]
+
+trait Trait {
+    #[type_const]
+    const N: usize = 0;
+    fn process(&self, _: [u8; Self::N]) {}
+}
+
+impl Trait for () {}
+
+fn main() {
+    let _x: &dyn Trait<N = 0> = &();
+}


### PR DESCRIPTION
Fixes rust-lang/rust#151878

After https://github.com/rust-lang/rust/pull/150843, projections of trait objects should include assoc consts, but the cfi `trait_object_ty` still include only assoc types. So that we got the ICE `expected 1 projection but got 0`.