### PR TITLE
Handle unbalanced delimiters gracefully in make_attr_token_stream

### DIFF
--- a/tests/ui/macros/tokenstream-ice-issue-149954.rs
+++ b/tests/ui/macros/tokenstream-ice-issue-149954.rs
@@ -1,0 +1,22 @@
+// Regression test for ICE https://github.com/rust-lang/rust/issues/149954
+//@ edition: 2024
+
+enum A {
+    A
+    const A: A = { //~ ERROR expected one of `(`, `,`, `=`, `{`, or `}`, found keyword `const`
+        #[derive(Debug)]
+        struct A
+        where
+            A: A<{ struct A<A: A<{ #[cfg] () }>> ; enum A  }
+            //~^ ERROR malformed `cfg` attribute input
+            //~| ERROR malformed `cfg` attribute input
+            //~| ERROR expected trait, found struct `A`
+            //~| ERROR expected trait, found type parameter `A`
+            //~| ERROR expected trait, found struct `A`
+            //~| ERROR expected trait, found type parameter `A`
+            //~| ERROR expected one of `<`, `where`, or `{`, found `}`
+            //~| ERROR expected one of `<`, `where`, or `{`, found `}`
+            //~| ERROR expected one of `,`, `>`, or `}`, found `<eof>`
+        }
+        >;
+}; //~ ERROR `main` function not found in crate

--- a/tests/ui/macros/tokenstream-ice-issue-149954.stderr
+++ b/tests/ui/macros/tokenstream-ice-issue-149954.stderr
@@ -1,0 +1,110 @@
+error: expected one of `(`, `,`, `=`, `{`, or `}`, found keyword `const`
+  --> $DIR/tokenstream-ice-issue-149954.rs:6:5
+   |
+LL |     A
+   |      - expected one of `(`, `,`, `=`, `{`, or `}`
+LL |     const A: A = {
+   |     ^^^^^ unexpected token
+   |
+   = help: enum variants can be `Variant`, `Variant = <integer>`, `Variant(Type, ..., TypeN)` or `Variant { fields: Types }`
+
+error: expected one of `<`, `where`, or `{`, found `}`
+  --> $DIR/tokenstream-ice-issue-149954.rs:10:60
+   |
+LL |             A: A<{ struct A<A: A<{ #[cfg] () }>> ; enum A  }
+   |                                                         -  ^ expected one of `<`, `where`, or `{`
+   |                                                         |
+   |                                                         while parsing this enum
+
+error: expected one of `<`, `where`, or `{`, found `}`
+  --> $DIR/tokenstream-ice-issue-149954.rs:10:60
+   |
+LL |             A: A<{ struct A<A: A<{ #[cfg] () }>> ; enum A  }
+   |                                                         -  ^ expected one of `<`, `where`, or `{`
+   |                                                         |
+   |                                                         while parsing this enum
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `,`, `>`, or `}`, found `<eof>`
+  --> $DIR/tokenstream-ice-issue-149954.rs:10:60
+   |
+LL |             A: A<{ struct A<A: A<{ #[cfg] () }>> ; enum A  }
+   |                                                            ^ expected one of `,`, `>`, or `}`
+   |
+help: you might have meant to end the type parameters here
+   |
+LL |             A: A<{ struct A<A: A<{ #[cfg] () }>> ; enum A  }>
+   |                                                             +
+
+error[E0539]: malformed `cfg` attribute input
+  --> $DIR/tokenstream-ice-issue-149954.rs:10:36
+   |
+LL |             A: A<{ struct A<A: A<{ #[cfg] () }>> ; enum A  }
+   |                                    ^^^^^^
+   |                                    |
+   |                                    expected this to be a list
+   |                                    help: must be of the form: `#[cfg(predicate)]`
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+
+error[E0539]: malformed `cfg` attribute input
+  --> $DIR/tokenstream-ice-issue-149954.rs:10:36
+   |
+LL |             A: A<{ struct A<A: A<{ #[cfg] () }>> ; enum A  }
+   |                                    ^^^^^^
+   |                                    |
+   |                                    expected this to be a list
+   |                                    help: must be of the form: `#[cfg(predicate)]`
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0404]: expected trait, found struct `A`
+  --> $DIR/tokenstream-ice-issue-149954.rs:10:16
+   |
+LL |               A: A<{ struct A<A: A<{ #[cfg] () }>> ; enum A  }
+   |  ________________^
+...  |
+LL | |         >;
+   | |_________^ not a trait
+
+error[E0404]: expected trait, found type parameter `A`
+  --> $DIR/tokenstream-ice-issue-149954.rs:10:32
+   |
+LL |             A: A<{ struct A<A: A<{ #[cfg] () }>> ; enum A  }
+   |                             -  ^^^^^^^^^^^^^^^^ not a trait
+   |                             |
+   |                             found this type parameter
+
+error[E0404]: expected trait, found struct `A`
+  --> $DIR/tokenstream-ice-issue-149954.rs:10:16
+   |
+LL |               A: A<{ struct A<A: A<{ #[cfg] () }>> ; enum A  }
+   |  ________________^
+...  |
+LL | |         >;
+   | |_________^ not a trait
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0404]: expected trait, found type parameter `A`
+  --> $DIR/tokenstream-ice-issue-149954.rs:10:32
+   |
+LL |             A: A<{ struct A<A: A<{ #[cfg] () }>> ; enum A  }
+   |                             -  ^^^^^^^^^^^^^^^^ not a trait
+   |                             |
+   |                             found this type parameter
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0601]: `main` function not found in crate `tokenstream_ice_issue_149954`
+  --> $DIR/tokenstream-ice-issue-149954.rs:22:3
+   |
+LL | };
+   |   ^ consider adding a `main` function to `$DIR/tokenstream-ice-issue-149954.rs`
+
+error: aborting due to 11 previous errors
+
+Some errors have detailed explanations: E0404, E0539, E0601.
+For more information about an error, try `rustc --explain E0404`.


### PR DESCRIPTION
Fixes rust-lang/rust#149954