### PR TITLE
Revert doc attribute parsing errors to future warnings

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/doc.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/doc.rs
@@ -591,7 +591,7 @@ impl DocParser {
                 let suggestions = cx.suggestions();
                 let span = cx.attr_span;
                 cx.emit_lint(
-                    rustc_session::lint::builtin::ILL_FORMED_ATTRIBUTE_INPUT,
+                    rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
                     AttributeLintKind::IllFormedAttributeInput { suggestions, docs: None },
                     span,
                 );
@@ -604,14 +604,27 @@ impl DocParser {
                             self.parse_single_doc_attr_item(cx, mip);
                         }
                         MetaItemOrLitParser::Lit(lit) => {
-                            cx.expected_name_value(lit.span, None);
+                            // FIXME: Remove the lint and uncomment line after beta backport is
+                            // done.
+                            // cx.expected_name_value(lit.span, None);
+                            cx.emit_lint(
+                                rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
+                                AttributeLintKind::MalformedDoc,
+                                lit.span,
+                            );
                         }
                     }
                 }
             }
             ArgParser::NameValue(nv) => {
                 if nv.value_as_str().is_none() {
-                    cx.expected_string_literal(nv.value_span, Some(nv.value_as_lit()));
+                    // FIXME: Remove the lint and uncomment line after beta backport is done.
+                    // cx.expected_string_literal(nv.value_span, Some(nv.value_as_lit()));
+                    cx.emit_lint(
+                        rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
+                        AttributeLintKind::MalformedDoc,
+                        nv.value_span,
+                    );
                 } else {
                     unreachable!(
                         "Should have been handled at the same time as sugar-syntaxed doc comments"

--- a/compiler/rustc_attr_parsing/src/attributes/doc.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/doc.rs
@@ -70,6 +70,42 @@ fn check_attr_crate_level<S: Stage>(cx: &mut AcceptContext<'_, '_, S>, span: Spa
     true
 }
 
+// FIXME: To be removed once merged and replace with `cx.expected_name_value(span, _name)`.
+fn expected_name_value<S: Stage>(
+    cx: &mut AcceptContext<'_, '_, S>,
+    span: Span,
+    _name: Option<Symbol>,
+) {
+    cx.emit_lint(
+        rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
+        AttributeLintKind::ExpectedNameValue,
+        span,
+    );
+}
+
+// FIXME: remove this method once merged and use `cx.expected_no_args(span)` instead.
+fn expected_no_args<S: Stage>(cx: &mut AcceptContext<'_, '_, S>, span: Span) {
+    cx.emit_lint(
+        rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
+        AttributeLintKind::ExpectedNoArgs,
+        span,
+    );
+}
+
+// FIXME: remove this method once merged and use `cx.expected_no_args(span)` instead.
+// cx.expected_string_literal(span, _actual_literal);
+fn expected_string_literal<S: Stage>(
+    cx: &mut AcceptContext<'_, '_, S>,
+    span: Span,
+    _actual_literal: Option<&MetaItemLit>,
+) {
+    cx.emit_lint(
+        rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
+        AttributeLintKind::MalformedDoc,
+        span,
+    );
+}
+
 fn parse_keyword_and_attribute<S: Stage>(
     cx: &mut AcceptContext<'_, '_, S>,
     path: &OwnedPathParser,
@@ -78,12 +114,12 @@ fn parse_keyword_and_attribute<S: Stage>(
     attr_name: Symbol,
 ) {
     let Some(nv) = args.name_value() else {
-        cx.expected_name_value(args.span().unwrap_or(path.span()), path.word_sym());
+        expected_name_value(cx, args.span().unwrap_or(path.span()), path.word_sym());
         return;
     };
 
     let Some(value) = nv.value_as_str() else {
-        cx.expected_string_literal(nv.value_span, Some(nv.value_as_lit()));
+        expected_string_literal(cx, nv.value_span, Some(nv.value_as_lit()));
         return;
     };
 
@@ -127,7 +163,7 @@ impl DocParser {
         match path.word_sym() {
             Some(sym::no_crate_inject) => {
                 if let Err(span) = args.no_args() {
-                    cx.expected_no_args(span);
+                    expected_no_args(cx, span);
                     return;
                 }
 
@@ -153,7 +189,14 @@ impl DocParser {
             }
             Some(sym::attr) => {
                 let Some(list) = args.list() else {
-                    cx.expected_list(cx.attr_span, args);
+                    // FIXME: remove this method once merged and uncomment the line below instead.
+                    // cx.expected_list(cx.attr_span, args);
+                    let span = cx.attr_span;
+                    cx.emit_lint(
+                        rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
+                        AttributeLintKind::MalformedDoc,
+                        span,
+                    );
                     return;
                 };
 
@@ -255,7 +298,7 @@ impl DocParser {
         inline: DocInline,
     ) {
         if let Err(span) = args.no_args() {
-            cx.expected_no_args(span);
+            expected_no_args(cx, span);
             return;
         }
 
@@ -337,7 +380,14 @@ impl DocParser {
                         match sub_item.args() {
                             a @ (ArgParser::NoArgs | ArgParser::NameValue(_)) => {
                                 let Some(name) = sub_item.path().word_sym() else {
-                                    cx.expected_identifier(sub_item.path().span());
+                                    // FIXME: remove this method once merged and uncomment the line
+                                    // below instead.
+                                    // cx.expected_identifier(sub_item.path().span());
+                                    cx.emit_lint(
+                                        rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
+                                        AttributeLintKind::MalformedDoc,
+                                        sub_item.path().span(),
+                                    );
                                     continue;
                                 };
                                 if let Ok(CfgEntry::NameValue { name, value, .. }) =
@@ -400,7 +450,7 @@ impl DocParser {
         macro_rules! no_args {
             ($ident: ident) => {{
                 if let Err(span) = args.no_args() {
-                    cx.expected_no_args(span);
+                    expected_no_args(cx, span);
                     return;
                 }
 
@@ -419,7 +469,7 @@ impl DocParser {
         macro_rules! no_args_and_not_crate_level {
             ($ident: ident) => {{
                 if let Err(span) = args.no_args() {
-                    cx.expected_no_args(span);
+                    expected_no_args(cx, span);
                     return;
                 }
                 let span = path.span();
@@ -432,7 +482,7 @@ impl DocParser {
         macro_rules! no_args_and_crate_level {
             ($ident: ident) => {{
                 if let Err(span) = args.no_args() {
-                    cx.expected_no_args(span);
+                    expected_no_args(cx, span);
                     return;
                 }
                 let span = path.span();
@@ -445,12 +495,12 @@ impl DocParser {
         macro_rules! string_arg_and_crate_level {
             ($ident: ident) => {{
                 let Some(nv) = args.name_value() else {
-                    cx.expected_name_value(args.span().unwrap_or(path.span()), path.word_sym());
+                    expected_name_value(cx, args.span().unwrap_or(path.span()), path.word_sym());
                     return;
                 };
 
                 let Some(s) = nv.value_as_str() else {
-                    cx.expected_string_literal(nv.value_span, Some(nv.value_as_lit()));
+                    expected_string_literal(cx, nv.value_span, Some(nv.value_as_lit()));
                     return;
                 };
 
@@ -521,7 +571,14 @@ impl DocParser {
                             self.parse_single_test_doc_attr_item(cx, mip);
                         }
                         MetaItemOrLitParser::Lit(lit) => {
-                            cx.unexpected_literal(lit.span);
+                            // FIXME: remove this method once merged and uncomment the line
+                            // below instead.
+                            // cx.unexpected_literal(lit.span);
+                            cx.emit_lint(
+                                rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
+                                AttributeLintKind::MalformedDoc,
+                                lit.span,
+                            );
                         }
                     }
                 }
@@ -604,27 +661,14 @@ impl DocParser {
                             self.parse_single_doc_attr_item(cx, mip);
                         }
                         MetaItemOrLitParser::Lit(lit) => {
-                            // FIXME: Remove the lint and uncomment line after beta backport is
-                            // done.
-                            // cx.expected_name_value(lit.span, None);
-                            cx.emit_lint(
-                                rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-                                AttributeLintKind::MalformedDoc,
-                                lit.span,
-                            );
+                            expected_name_value(cx, lit.span, None);
                         }
                     }
                 }
             }
             ArgParser::NameValue(nv) => {
                 if nv.value_as_str().is_none() {
-                    // FIXME: Remove the lint and uncomment line after beta backport is done.
-                    // cx.expected_string_literal(nv.value_span, Some(nv.value_as_lit()));
-                    cx.emit_lint(
-                        rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-                        AttributeLintKind::MalformedDoc,
-                        nv.value_span,
-                    );
+                    expected_string_literal(cx, nv.value_span, Some(nv.value_as_lit()));
                 } else {
                     unreachable!(
                         "Should have been handled at the same time as sugar-syntaxed doc comments"

--- a/compiler/rustc_attr_parsing/src/attributes/doc.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/doc.rs
@@ -131,8 +131,17 @@ impl DocParser {
                     return;
                 }
 
-                if self.attribute.no_crate_inject.is_some() {
-                    cx.duplicate_key(path.span(), sym::no_crate_inject);
+                if let Some(used_span) = self.attribute.no_crate_inject {
+                    let unused_span = path.span();
+                    cx.emit_lint(
+                        rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
+                        AttributeLintKind::UnusedDuplicate {
+                            this: unused_span,
+                            other: used_span,
+                            warning: true,
+                        },
+                        unused_span,
+                    );
                     return;
                 }
 

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -326,6 +326,14 @@ lint_expectation = this lint expectation is unfulfilled
     .note = the `unfulfilled_lint_expectations` lint can't be expected and will always produce this message
     .rationale = {$rationale}
 
+lint_expected_name_value =
+    expected this to be of the form `... = "..."`
+    .warn = {-lint_previously_accepted}
+
+lint_expected_no_args =
+    didn't expect any arguments here
+    .warn = {-lint_previously_accepted}
+
 lint_for_loops_over_fallibles =
     for loop over {$article} `{$ref_prefix}{$ty}`. This is more readably written as an `if let` statement
     .suggestion = consider using `if let` to clear intent

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -558,6 +558,10 @@ lint_macro_expr_fragment_specifier_2024_migration =
 
 lint_malformed_attribute = malformed lint attribute input
 
+lint_malformed_doc =
+    malformed `doc` attribute input
+    .warn = {-lint_previously_accepted}
+
 lint_map_unit_fn = `Iterator::map` call that discard the iterator's values
     .note = `Iterator::map`, like many of the methods on `Iterator`, gets executed lazily, meaning that its effects won't be visible until it is iterated
     .function_label = this function returns `()`, which is likely not what you wanted

--- a/compiler/rustc_lint/src/early/diagnostics.rs
+++ b/compiler/rustc_lint/src/early/diagnostics.rs
@@ -430,5 +430,9 @@ pub fn decorate_attribute_lint(
         .decorate_lint(diag),
 
         &AttributeLintKind::MalformedDoc => lints::MalformedDoc.decorate_lint(diag),
+
+        &AttributeLintKind::ExpectedNoArgs => lints::ExpectedNoArgs.decorate_lint(diag),
+
+        &AttributeLintKind::ExpectedNameValue => lints::ExpectedNameValue.decorate_lint(diag),
     }
 }

--- a/compiler/rustc_lint/src/early/diagnostics.rs
+++ b/compiler/rustc_lint/src/early/diagnostics.rs
@@ -428,5 +428,7 @@ pub fn decorate_attribute_lint(
             sugg: suggested.map(|s| lints::UnknownCrateTypesSuggestion { span, snippet: s }),
         }
         .decorate_lint(diag),
+
+        &AttributeLintKind::MalformedDoc => lints::MalformedDoc.decorate_lint(diag),
     }
 }

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -3191,6 +3191,16 @@ pub(crate) struct UnusedDuplicate {
 pub(crate) struct MalformedDoc;
 
 #[derive(LintDiagnostic)]
+#[diag(lint_expected_no_args)]
+#[warning]
+pub(crate) struct ExpectedNoArgs;
+
+#[derive(LintDiagnostic)]
+#[diag(lint_expected_name_value)]
+#[warning]
+pub(crate) struct ExpectedNameValue;
+
+#[derive(LintDiagnostic)]
 #[diag(lint_unsafe_attr_outside_unsafe)]
 pub(crate) struct UnsafeAttrOutsideUnsafeLint {
     #[label]

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -3186,6 +3186,11 @@ pub(crate) struct UnusedDuplicate {
 }
 
 #[derive(LintDiagnostic)]
+#[diag(lint_malformed_doc)]
+#[warning]
+pub(crate) struct MalformedDoc;
+
+#[derive(LintDiagnostic)]
 #[diag(lint_unsafe_attr_outside_unsafe)]
 pub(crate) struct UnsafeAttrOutsideUnsafeLint {
     #[label]

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -3458,7 +3458,7 @@ declare_lint! {
     /// but this lint was introduced to avoid breaking any existing
     /// crates which included them.
     pub INVALID_DOC_ATTRIBUTES,
-    Deny,
+    Warn,
     "detects invalid `#[doc(...)]` attributes",
 }
 

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -827,6 +827,8 @@ pub enum AttributeLintKind {
         suggested: Option<Symbol>,
     },
     MalformedDoc,
+    ExpectedNoArgs,
+    ExpectedNameValue,
 }
 
 pub type RegisteredTools = FxIndexSet<Ident>;

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -826,6 +826,7 @@ pub enum AttributeLintKind {
         span: Span,
         suggested: Option<Symbol>,
     },
+    MalformedDoc,
 }
 
 pub type RegisteredTools = FxIndexSet<Ident>;

--- a/tests/rustdoc-ui/bad-render-options.rs
+++ b/tests/rustdoc-ui/bad-render-options.rs
@@ -1,29 +1,30 @@
 // regression test for https://github.com/rust-lang/rust/issues/149187
+#![deny(invalid_doc_attributes)]
 
 #![doc(html_favicon_url)]
-//~^ ERROR: malformed `doc` attribute
-//~| NOTE expected this to be of the form `html_favicon_url = "..."`
+//~^ ERROR
+//~| WARN
 #![doc(html_logo_url)]
-//~^ ERROR: malformed `doc` attribute
-//~| NOTE expected this to be of the form `html_logo_url = "..."`
+//~^ ERROR
+//~| WARN
 #![doc(html_playground_url)]
-//~^ ERROR: malformed `doc` attribute
-//~| NOTE expected this to be of the form `html_playground_url = "..."`
+//~^ ERROR
+//~| WARN
 #![doc(issue_tracker_base_url)]
-//~^ ERROR: malformed `doc` attribute
-//~| NOTE expected this to be of the form `issue_tracker_base_url = "..."`
+//~^ ERROR
+//~| WARN
 #![doc(html_favicon_url = 1)]
-//~^ ERROR malformed `doc` attribute
-//~| NOTE expected a string literal
+//~^ ERROR
+//~| WARN
 #![doc(html_logo_url = 2)]
-//~^ ERROR malformed `doc` attribute
-//~| NOTE expected a string literal
+//~^ ERROR
+//~| WARN
 #![doc(html_playground_url = 3)]
-//~^ ERROR malformed `doc` attribute
-//~| NOTE expected a string literal
+//~^ ERROR
+//~| WARN
 #![doc(issue_tracker_base_url = 4)]
-//~^ ERROR malformed `doc` attribute
-//~| NOTE expected a string literal
+//~^ ERROR
+//~| WARN
 #![doc(html_no_source = "asdf")]
-//~^ ERROR malformed `doc` attribute
-//~| NOTE didn't expect any arguments here
+//~^ ERROR
+//~| WARN

--- a/tests/rustdoc-ui/bad-render-options.stderr
+++ b/tests/rustdoc-ui/bad-render-options.stderr
@@ -1,76 +1,79 @@
-error[E0539]: malformed `doc` attribute input
-  --> $DIR/bad-render-options.rs:3:1
+error: expected this to be of the form `... = "..."`
+  --> $DIR/bad-render-options.rs:4:8
    |
 LL | #![doc(html_favicon_url)]
-   | ^^^^^^^----------------^^
-   |        |
-   |        expected this to be of the form `html_favicon_url = "..."`
+   |        ^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+note: the lint level is defined here
+  --> $DIR/bad-render-options.rs:2:9
+   |
+LL | #![deny(invalid_doc_attributes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0539]: malformed `doc` attribute input
-  --> $DIR/bad-render-options.rs:6:1
+error: expected this to be of the form `... = "..."`
+  --> $DIR/bad-render-options.rs:7:8
    |
 LL | #![doc(html_logo_url)]
-   | ^^^^^^^-------------^^
-   |        |
-   |        expected this to be of the form `html_logo_url = "..."`
+   |        ^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error[E0539]: malformed `doc` attribute input
-  --> $DIR/bad-render-options.rs:9:1
+error: expected this to be of the form `... = "..."`
+  --> $DIR/bad-render-options.rs:10:8
    |
 LL | #![doc(html_playground_url)]
-   | ^^^^^^^-------------------^^
-   |        |
-   |        expected this to be of the form `html_playground_url = "..."`
+   |        ^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error[E0539]: malformed `doc` attribute input
-  --> $DIR/bad-render-options.rs:12:1
+error: expected this to be of the form `... = "..."`
+  --> $DIR/bad-render-options.rs:13:8
    |
 LL | #![doc(issue_tracker_base_url)]
-   | ^^^^^^^----------------------^^
-   |        |
-   |        expected this to be of the form `issue_tracker_base_url = "..."`
+   |        ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error[E0539]: malformed `doc` attribute input
-  --> $DIR/bad-render-options.rs:15:1
+error: malformed `doc` attribute input
+  --> $DIR/bad-render-options.rs:16:27
    |
 LL | #![doc(html_favicon_url = 1)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^-^^
-   |                           |
-   |                           expected a string literal here
+   |                           ^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error[E0539]: malformed `doc` attribute input
-  --> $DIR/bad-render-options.rs:18:1
+error: malformed `doc` attribute input
+  --> $DIR/bad-render-options.rs:19:24
    |
 LL | #![doc(html_logo_url = 2)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^-^^
-   |                        |
-   |                        expected a string literal here
+   |                        ^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error[E0539]: malformed `doc` attribute input
-  --> $DIR/bad-render-options.rs:21:1
+error: malformed `doc` attribute input
+  --> $DIR/bad-render-options.rs:22:30
    |
 LL | #![doc(html_playground_url = 3)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-^^
-   |                              |
-   |                              expected a string literal here
+   |                              ^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error[E0539]: malformed `doc` attribute input
-  --> $DIR/bad-render-options.rs:24:1
+error: malformed `doc` attribute input
+  --> $DIR/bad-render-options.rs:25:33
    |
 LL | #![doc(issue_tracker_base_url = 4)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-^^
-   |                                 |
-   |                                 expected a string literal here
+   |                                 ^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error[E0565]: malformed `doc` attribute input
-  --> $DIR/bad-render-options.rs:27:1
+error: didn't expect any arguments here
+  --> $DIR/bad-render-options.rs:28:23
    |
 LL | #![doc(html_no_source = "asdf")]
-   | ^^^^^^^^^^^^^^^^^^^^^^--------^^
-   |                       |
-   |                       didn't expect any arguments here
+   |                       ^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: aborting due to 9 previous errors
 
-Some errors have detailed explanations: E0539, E0565.
-For more information about an error, try `rustc --explain E0539`.

--- a/tests/rustdoc-ui/deprecated-attrs.rs
+++ b/tests/rustdoc-ui/deprecated-attrs.rs
@@ -1,11 +1,13 @@
 //@ compile-flags: --passes unknown-pass
 
+#![deny(invalid_doc_attributes)]
+//~^ NOTE
+
 #![doc(no_default_passes)]
 //~^ ERROR unknown `doc` attribute `no_default_passes`
 //~| NOTE no longer functions
 //~| NOTE see issue #44136
 //~| NOTE `doc(no_default_passes)` is now a no-op
-//~| NOTE `#[deny(invalid_doc_attributes)]` on by default
 #![doc(passes = "collapse-docs unindent-comments")]
 //~^ ERROR unknown `doc` attribute `passes`
 //~| NOTE no longer functions

--- a/tests/rustdoc-ui/deprecated-attrs.stderr
+++ b/tests/rustdoc-ui/deprecated-attrs.stderr
@@ -4,17 +4,21 @@ warning: the `passes` flag no longer functions
    = help: you may want to use --document-private-items
 
 error: unknown `doc` attribute `no_default_passes`
-  --> $DIR/deprecated-attrs.rs:3:8
+  --> $DIR/deprecated-attrs.rs:6:8
    |
 LL | #![doc(no_default_passes)]
    |        ^^^^^^^^^^^^^^^^^ no longer functions
    |
    = note: `doc` attribute `no_default_passes` no longer functions; see issue #44136 <https://github.com/rust-lang/rust/issues/44136>
    = note: `doc(no_default_passes)` is now a no-op
-   = note: `#[deny(invalid_doc_attributes)]` on by default
+note: the lint level is defined here
+  --> $DIR/deprecated-attrs.rs:3:9
+   |
+LL | #![deny(invalid_doc_attributes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: unknown `doc` attribute `passes`
-  --> $DIR/deprecated-attrs.rs:9:8
+  --> $DIR/deprecated-attrs.rs:11:8
    |
 LL | #![doc(passes = "collapse-docs unindent-comments")]
    |        ^^^^^^ no longer functions
@@ -23,7 +27,7 @@ LL | #![doc(passes = "collapse-docs unindent-comments")]
    = note: `doc(passes)` is now a no-op
 
 error: unknown `doc` attribute `plugins`
-  --> $DIR/deprecated-attrs.rs:14:8
+  --> $DIR/deprecated-attrs.rs:16:8
    |
 LL | #![doc(plugins = "xxx")]
    |        ^^^^^^^ no longer functions

--- a/tests/rustdoc-ui/doc-cfg-2.rs
+++ b/tests/rustdoc-ui/doc-cfg-2.rs
@@ -1,3 +1,4 @@
+#![deny(invalid_doc_attributes)]
 #![feature(doc_cfg)]
 
 #[doc(cfg(foo), cfg(bar))]

--- a/tests/rustdoc-ui/doc-cfg-2.stderr
+++ b/tests/rustdoc-ui/doc-cfg-2.stderr
@@ -1,5 +1,5 @@
 warning: unexpected `cfg` condition name: `foo`
-  --> $DIR/doc-cfg-2.rs:3:11
+  --> $DIR/doc-cfg-2.rs:4:11
    |
 LL | #[doc(cfg(foo), cfg(bar))]
    |           ^^^
@@ -10,7 +10,7 @@ LL | #[doc(cfg(foo), cfg(bar))]
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition name: `bar`
-  --> $DIR/doc-cfg-2.rs:3:21
+  --> $DIR/doc-cfg-2.rs:4:21
    |
 LL | #[doc(cfg(foo), cfg(bar))]
    |                     ^^^
@@ -19,45 +19,49 @@ LL | #[doc(cfg(foo), cfg(bar))]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 error: only `hide` or `show` are allowed in `#[doc(auto_cfg(...))]`
-  --> $DIR/doc-cfg-2.rs:6:16
+  --> $DIR/doc-cfg-2.rs:7:16
    |
 LL | #[doc(auto_cfg(42))]
    |                ^^
    |
-   = note: `#[deny(invalid_doc_attributes)]` on by default
+note: the lint level is defined here
+  --> $DIR/doc-cfg-2.rs:1:9
+   |
+LL | #![deny(invalid_doc_attributes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: `#![doc(auto_cfg(hide(...)))]` only accepts identifiers or key/value items
-  --> $DIR/doc-cfg-2.rs:7:21
+  --> $DIR/doc-cfg-2.rs:8:21
    |
 LL | #[doc(auto_cfg(hide(true)))]
    |                     ^^^^
 
 error: `#![doc(auto_cfg(hide(...)))]` only accepts identifiers or key/value items
-  --> $DIR/doc-cfg-2.rs:8:21
+  --> $DIR/doc-cfg-2.rs:9:21
    |
 LL | #[doc(auto_cfg(hide(42)))]
    |                     ^^
 
 error: `#![doc(auto_cfg(hide(...)))]` only accepts identifiers or key/value items
-  --> $DIR/doc-cfg-2.rs:9:21
+  --> $DIR/doc-cfg-2.rs:10:21
    |
 LL | #[doc(auto_cfg(hide("a")))]
    |                     ^^^
 
 error: expected boolean for `#[doc(auto_cfg = ...)]`
-  --> $DIR/doc-cfg-2.rs:10:18
+  --> $DIR/doc-cfg-2.rs:11:18
    |
 LL | #[doc(auto_cfg = 42)]
    |                  ^^
 
 error: expected boolean for `#[doc(auto_cfg = ...)]`
-  --> $DIR/doc-cfg-2.rs:11:18
+  --> $DIR/doc-cfg-2.rs:12:18
    |
 LL | #[doc(auto_cfg = "a")]
    |                  ^^^
 
 warning: unexpected `cfg` condition name: `feature`
-  --> $DIR/doc-cfg-2.rs:14:21
+  --> $DIR/doc-cfg-2.rs:15:21
    |
 LL | #[doc(auto_cfg(hide(feature = "windows")))]
    |                     ^^^^^^^^^^^^^^^^^^^
@@ -66,7 +70,7 @@ LL | #[doc(auto_cfg(hide(feature = "windows")))]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `foo`
-  --> $DIR/doc-cfg-2.rs:16:21
+  --> $DIR/doc-cfg-2.rs:17:21
    |
 LL | #[doc(auto_cfg(hide(foo)))]
    |                     ^^^

--- a/tests/rustdoc-ui/doc-cfg.rs
+++ b/tests/rustdoc-ui/doc-cfg.rs
@@ -1,9 +1,10 @@
+#![deny(invalid_doc_attributes)]
 #![feature(doc_cfg)]
 
 #[doc(cfg(), cfg(foo, bar))]
-//~^ ERROR malformed `doc` attribute input
-//~| ERROR malformed `doc` attribute input
+//~^ ERROR
+//~| ERROR
 #[doc(cfg())] //~ ERROR
 #[doc(cfg(foo, bar))] //~ ERROR
-#[doc(auto_cfg(hide(foo::bar)))] //~ ERROR
+#[doc(auto_cfg(hide(foo::bar)))]
 pub fn foo() {}

--- a/tests/rustdoc-ui/doc-cfg.stderr
+++ b/tests/rustdoc-ui/doc-cfg.stderr
@@ -1,5 +1,5 @@
 error[E0805]: malformed `doc` attribute input
-  --> $DIR/doc-cfg.rs:3:1
+  --> $DIR/doc-cfg.rs:4:1
    |
 LL | #[doc(cfg(), cfg(foo, bar))]
    | ^^^^^^^^^--^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL | #[doc(cfg(), cfg(foo, bar))]
    |          expected a single argument here
 
 error[E0805]: malformed `doc` attribute input
-  --> $DIR/doc-cfg.rs:3:1
+  --> $DIR/doc-cfg.rs:4:1
    |
 LL | #[doc(cfg(), cfg(foo, bar))]
    | ^^^^^^^^^^^^^^^^----------^^
@@ -15,7 +15,7 @@ LL | #[doc(cfg(), cfg(foo, bar))]
    |                 expected a single argument here
 
 error[E0805]: malformed `doc` attribute input
-  --> $DIR/doc-cfg.rs:6:1
+  --> $DIR/doc-cfg.rs:7:1
    |
 LL | #[doc(cfg())]
    | ^^^^^^^^^--^^
@@ -23,22 +23,13 @@ LL | #[doc(cfg())]
    |          expected a single argument here
 
 error[E0805]: malformed `doc` attribute input
-  --> $DIR/doc-cfg.rs:7:1
+  --> $DIR/doc-cfg.rs:8:1
    |
 LL | #[doc(cfg(foo, bar))]
    | ^^^^^^^^^----------^^
    |          |
    |          expected a single argument here
 
-error[E0539]: malformed `doc` attribute input
-  --> $DIR/doc-cfg.rs:8:1
-   |
-LL | #[doc(auto_cfg(hide(foo::bar)))]
-   | ^^^^^^^^^^^^^^^^^^^^--------^^^^
-   |                     |
-   |                     expected a valid identifier here
+error: aborting due to 4 previous errors
 
-error: aborting due to 5 previous errors
-
-Some errors have detailed explanations: E0539, E0805.
-For more information about an error, try `rustc --explain E0539`.
+For more information about this error, try `rustc --explain E0805`.

--- a/tests/rustdoc-ui/doc-include-suggestion.rs
+++ b/tests/rustdoc-ui/doc-include-suggestion.rs
@@ -1,6 +1,8 @@
+#![deny(invalid_doc_attributes)]
+//~^ NOTE
+
 #[doc(include = "external-cross-doc.md")]
 //~^ ERROR unknown `doc` attribute `include`
 //~| HELP use `doc = include_str!` instead
 // FIXME(#85497): make this a deny instead so it's more clear what's happening
-//~| NOTE on by default
 pub struct NeedMoreDocs;

--- a/tests/rustdoc-ui/doc-include-suggestion.stderr
+++ b/tests/rustdoc-ui/doc-include-suggestion.stderr
@@ -1,10 +1,14 @@
 error: unknown `doc` attribute `include`
-  --> $DIR/doc-include-suggestion.rs:1:7
+  --> $DIR/doc-include-suggestion.rs:4:7
    |
 LL | #[doc(include = "external-cross-doc.md")]
    |       ^^^^^^^ help: use `doc = include_str!` instead: `#[doc = include_str!("external-cross-doc.md")]`
    |
-   = note: `#[deny(invalid_doc_attributes)]` on by default
+note: the lint level is defined here
+  --> $DIR/doc-include-suggestion.rs:1:9
+   |
+LL | #![deny(invalid_doc_attributes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/rustdoc-ui/doctest/doc-test-attr.rs
+++ b/tests/rustdoc-ui/doctest/doc-test-attr.rs
@@ -1,3 +1,4 @@
+#![deny(invalid_doc_attributes)]
 #![crate_type = "lib"]
 
 #![doc(test)]

--- a/tests/rustdoc-ui/doctest/doc-test-attr.stderr
+++ b/tests/rustdoc-ui/doctest/doc-test-attr.stderr
@@ -1,19 +1,23 @@
 error: `#[doc(test(...)]` takes a list of attributes
-  --> $DIR/doc-test-attr.rs:3:8
+  --> $DIR/doc-test-attr.rs:4:8
    |
 LL | #![doc(test)]
    |        ^^^^
    |
-   = note: `#[deny(invalid_doc_attributes)]` on by default
+note: the lint level is defined here
+  --> $DIR/doc-test-attr.rs:1:9
+   |
+LL | #![deny(invalid_doc_attributes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: `#[doc(test(...)]` takes a list of attributes
-  --> $DIR/doc-test-attr.rs:5:13
+  --> $DIR/doc-test-attr.rs:6:13
    |
 LL | #![doc(test = "hello")]
    |             ^^^^^^^^^
 
 error: unknown `doc(test)` attribute `a`
-  --> $DIR/doc-test-attr.rs:7:13
+  --> $DIR/doc-test-attr.rs:8:13
    |
 LL | #![doc(test(a))]
    |             ^

--- a/tests/rustdoc-ui/lints/doc-attr-2.rs
+++ b/tests/rustdoc-ui/lints/doc-attr-2.rs
@@ -1,3 +1,4 @@
+#![deny(invalid_doc_attributes)]
 #![doc(as_ptr)]
 //~^ ERROR unknown `doc` attribute `as_ptr`
 

--- a/tests/rustdoc-ui/lints/doc-attr-2.stderr
+++ b/tests/rustdoc-ui/lints/doc-attr-2.stderr
@@ -1,25 +1,29 @@
 error: unknown `doc` attribute `as_ptr`
-  --> $DIR/doc-attr-2.rs:4:7
+  --> $DIR/doc-attr-2.rs:5:7
    |
 LL | #[doc(as_ptr)]
    |       ^^^^^^
    |
-   = note: `#[deny(invalid_doc_attributes)]` on by default
+note: the lint level is defined here
+  --> $DIR/doc-attr-2.rs:1:9
+   |
+LL | #![deny(invalid_doc_attributes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: unknown `doc` attribute `foo::bar`
-  --> $DIR/doc-attr-2.rs:8:7
+  --> $DIR/doc-attr-2.rs:9:7
    |
 LL | #[doc(foo::bar, crate::bar::baz = "bye")]
    |       ^^^^^^^^
 
 error: unknown `doc` attribute `crate::bar::baz`
-  --> $DIR/doc-attr-2.rs:8:17
+  --> $DIR/doc-attr-2.rs:9:17
    |
 LL | #[doc(foo::bar, crate::bar::baz = "bye")]
    |                 ^^^^^^^^^^^^^^^
 
 error: unknown `doc` attribute `as_ptr`
-  --> $DIR/doc-attr-2.rs:1:8
+  --> $DIR/doc-attr-2.rs:2:8
    |
 LL | #![doc(as_ptr)]
    |        ^^^^^^

--- a/tests/rustdoc-ui/lints/doc-attr.rs
+++ b/tests/rustdoc-ui/lints/doc-attr.rs
@@ -1,8 +1,12 @@
 #![crate_type = "lib"]
+#![deny(invalid_doc_attributes)]
 
 #[doc(123)]
 //~^ ERROR malformed `doc` attribute
+//~| WARN
 #[doc("hello", "bar")]
 //~^ ERROR malformed `doc` attribute
 //~| ERROR malformed `doc` attribute
+//~| WARN
+//~| WARN
 fn bar() {}

--- a/tests/rustdoc-ui/lints/doc-attr.rs
+++ b/tests/rustdoc-ui/lints/doc-attr.rs
@@ -2,11 +2,11 @@
 #![deny(invalid_doc_attributes)]
 
 #[doc(123)]
-//~^ ERROR malformed `doc` attribute
+//~^ ERROR
 //~| WARN
 #[doc("hello", "bar")]
-//~^ ERROR malformed `doc` attribute
-//~| ERROR malformed `doc` attribute
+//~^ ERROR
+//~| ERROR
 //~| WARN
 //~| WARN
 fn bar() {}

--- a/tests/rustdoc-ui/lints/doc-attr.stderr
+++ b/tests/rustdoc-ui/lints/doc-attr.stderr
@@ -1,27 +1,31 @@
-error[E0539]: malformed `doc` attribute input
-  --> $DIR/doc-attr.rs:3:1
+error: malformed `doc` attribute input
+  --> $DIR/doc-attr.rs:4:7
    |
 LL | #[doc(123)]
-   | ^^^^^^---^^
-   |       |
-   |       expected this to be of the form `... = "..."`
+   |       ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+note: the lint level is defined here
+  --> $DIR/doc-attr.rs:2:9
+   |
+LL | #![deny(invalid_doc_attributes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0539]: malformed `doc` attribute input
-  --> $DIR/doc-attr.rs:5:1
+error: malformed `doc` attribute input
+  --> $DIR/doc-attr.rs:7:7
    |
 LL | #[doc("hello", "bar")]
-   | ^^^^^^-------^^^^^^^^^
-   |       |
-   |       expected this to be of the form `... = "..."`
+   |       ^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error[E0539]: malformed `doc` attribute input
-  --> $DIR/doc-attr.rs:5:1
+error: malformed `doc` attribute input
+  --> $DIR/doc-attr.rs:7:16
    |
 LL | #[doc("hello", "bar")]
-   | ^^^^^^^^^^^^^^^-----^^
-   |                |
-   |                expected this to be of the form `... = "..."`
+   |                ^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0539`.

--- a/tests/rustdoc-ui/lints/doc-attr.stderr
+++ b/tests/rustdoc-ui/lints/doc-attr.stderr
@@ -1,4 +1,4 @@
-error: malformed `doc` attribute input
+error: expected this to be of the form `... = "..."`
   --> $DIR/doc-attr.rs:4:7
    |
 LL | #[doc(123)]
@@ -11,7 +11,7 @@ note: the lint level is defined here
 LL | #![deny(invalid_doc_attributes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
-error: malformed `doc` attribute input
+error: expected this to be of the form `... = "..."`
   --> $DIR/doc-attr.rs:7:7
    |
 LL | #[doc("hello", "bar")]
@@ -19,7 +19,7 @@ LL | #[doc("hello", "bar")]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: malformed `doc` attribute input
+error: expected this to be of the form `... = "..."`
   --> $DIR/doc-attr.rs:7:16
    |
 LL | #[doc("hello", "bar")]

--- a/tests/rustdoc-ui/lints/doc-spotlight.fixed
+++ b/tests/rustdoc-ui/lints/doc-spotlight.fixed
@@ -1,5 +1,6 @@
 //@ run-rustfix
 #![feature(doc_notable_trait)]
+#![deny(invalid_doc_attributes)]
 
 #[doc(notable_trait)]
 //~^ ERROR unknown `doc` attribute `spotlight`

--- a/tests/rustdoc-ui/lints/doc-spotlight.rs
+++ b/tests/rustdoc-ui/lints/doc-spotlight.rs
@@ -1,5 +1,6 @@
 //@ run-rustfix
 #![feature(doc_notable_trait)]
+#![deny(invalid_doc_attributes)]
 
 #[doc(spotlight)]
 //~^ ERROR unknown `doc` attribute `spotlight`

--- a/tests/rustdoc-ui/lints/doc-spotlight.stderr
+++ b/tests/rustdoc-ui/lints/doc-spotlight.stderr
@@ -1,12 +1,16 @@
 error: unknown `doc` attribute `spotlight`
-  --> $DIR/doc-spotlight.rs:4:7
+  --> $DIR/doc-spotlight.rs:5:7
    |
 LL | #[doc(spotlight)]
    |       ^^^^^^^^^ help: use `notable_trait` instead
    |
    = note: `doc(spotlight)` was renamed to `doc(notable_trait)`
    = note: `doc(spotlight)` is now a no-op
-   = note: `#[deny(invalid_doc_attributes)]` on by default
+note: the lint level is defined here
+  --> $DIR/doc-spotlight.rs:3:9
+   |
+LL | #![deny(invalid_doc_attributes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/rustdoc-ui/lints/doc_cfg_hide.rs
+++ b/tests/rustdoc-ui/lints/doc_cfg_hide.rs
@@ -1,3 +1,4 @@
+#![deny(invalid_doc_attributes)]
 #![feature(doc_cfg)]
 #![doc(auto_cfg(hide = "test"))] //~ ERROR
 #![doc(auto_cfg(hide))] //~ ERROR

--- a/tests/rustdoc-ui/lints/doc_cfg_hide.stderr
+++ b/tests/rustdoc-ui/lints/doc_cfg_hide.stderr
@@ -1,19 +1,23 @@
 error: `#![doc(auto_cfg(hide(...)))]` expects a list of items
-  --> $DIR/doc_cfg_hide.rs:2:17
+  --> $DIR/doc_cfg_hide.rs:3:17
    |
 LL | #![doc(auto_cfg(hide = "test"))]
    |                 ^^^^^^^^^^^^^
    |
-   = note: `#[deny(invalid_doc_attributes)]` on by default
+note: the lint level is defined here
+  --> $DIR/doc_cfg_hide.rs:1:9
+   |
+LL | #![deny(invalid_doc_attributes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: `#![doc(auto_cfg(hide(...)))]` expects a list of items
-  --> $DIR/doc_cfg_hide.rs:3:17
+  --> $DIR/doc_cfg_hide.rs:4:17
    |
 LL | #![doc(auto_cfg(hide))]
    |                 ^^^^
 
 error: `#![doc(auto_cfg(hide(...)))]` only accepts identifiers or key/value items
-  --> $DIR/doc_cfg_hide.rs:4:22
+  --> $DIR/doc_cfg_hide.rs:5:22
    |
 LL | #![doc(auto_cfg(hide(not(windows))))]
    |                      ^^^^^^^^^^^^

--- a/tests/rustdoc-ui/lints/duplicated-attr.rs
+++ b/tests/rustdoc-ui/lints/duplicated-attr.rs
@@ -1,0 +1,6 @@
+#![deny(invalid_doc_attributes)]
+#![expect(unused_attributes)]
+#![doc(test(no_crate_inject))]
+#![doc(test(no_crate_inject))]
+//~^ ERROR
+//~| WARN

--- a/tests/rustdoc-ui/lints/duplicated-attr.stderr
+++ b/tests/rustdoc-ui/lints/duplicated-attr.stderr
@@ -1,0 +1,20 @@
+error: unused attribute
+  --> $DIR/duplicated-attr.rs:4:13
+   |
+LL | #![doc(test(no_crate_inject))]
+   |             ^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/duplicated-attr.rs:3:13
+   |
+LL | #![doc(test(no_crate_inject))]
+   |             ^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+note: the lint level is defined here
+  --> $DIR/duplicated-attr.rs:1:9
+   |
+LL | #![deny(invalid_doc_attributes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/rustdoc-ui/lints/invalid-crate-level-lint.rs
+++ b/tests/rustdoc-ui/lints/invalid-crate-level-lint.rs
@@ -1,3 +1,4 @@
+#![deny(invalid_doc_attributes)]
 #![crate_type = "lib"]
 
 #[doc(test(no_crate_inject))]

--- a/tests/rustdoc-ui/lints/invalid-crate-level-lint.stderr
+++ b/tests/rustdoc-ui/lints/invalid-crate-level-lint.stderr
@@ -1,14 +1,18 @@
 error: this attribute can only be applied at the crate level
-  --> $DIR/invalid-crate-level-lint.rs:3:12
+  --> $DIR/invalid-crate-level-lint.rs:4:12
    |
 LL | #[doc(test(no_crate_inject))]
    |            ^^^^^^^^^^^^^^^
    |
    = note: read <https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html#at-the-crate-level> for more information
-   = note: `#[deny(invalid_doc_attributes)]` on by default
+note: the lint level is defined here
+  --> $DIR/invalid-crate-level-lint.rs:1:9
+   |
+LL | #![deny(invalid_doc_attributes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: this attribute can only be applied at the crate level
-  --> $DIR/invalid-crate-level-lint.rs:7:17
+  --> $DIR/invalid-crate-level-lint.rs:8:17
    |
 LL |     #![doc(test(no_crate_inject))]
    |                 ^^^^^^^^^^^^^^^
@@ -16,7 +20,7 @@ LL |     #![doc(test(no_crate_inject))]
    = note: read <https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html#at-the-crate-level> for more information
 
 error: this attribute can only be applied at the crate level
-  --> $DIR/invalid-crate-level-lint.rs:10:16
+  --> $DIR/invalid-crate-level-lint.rs:11:16
    |
 LL |     #[doc(test(no_crate_inject))]
    |                ^^^^^^^^^^^^^^^

--- a/tests/rustdoc-ui/lints/invalid-doc-attr-2.rs
+++ b/tests/rustdoc-ui/lints/invalid-doc-attr-2.rs
@@ -1,0 +1,7 @@
+#![deny(invalid_doc_attributes)]
+
+#![doc("other attribute")]
+//~^ ERROR
+//~| WARN
+#![doc]
+//~^ ERROR

--- a/tests/rustdoc-ui/lints/invalid-doc-attr-2.stderr
+++ b/tests/rustdoc-ui/lints/invalid-doc-attr-2.stderr
@@ -1,4 +1,4 @@
-error: malformed `doc` attribute input
+error: expected this to be of the form `... = "..."`
   --> $DIR/invalid-doc-attr-2.rs:3:8
    |
 LL | #![doc("other attribute")]

--- a/tests/rustdoc-ui/lints/invalid-doc-attr-2.stderr
+++ b/tests/rustdoc-ui/lints/invalid-doc-attr-2.stderr
@@ -1,0 +1,21 @@
+error: malformed `doc` attribute input
+  --> $DIR/invalid-doc-attr-2.rs:3:8
+   |
+LL | #![doc("other attribute")]
+   |        ^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+note: the lint level is defined here
+  --> $DIR/invalid-doc-attr-2.rs:1:9
+   |
+LL | #![deny(invalid_doc_attributes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+
+error: valid forms for the attribute are `#![doc = "string"]`, `#![doc(alias)]`, `#![doc(attribute)]`, `#![doc(auto_cfg)]`, `#![doc(cfg)]`, `#![doc(fake_variadic)]`, `#![doc(hidden)]`, `#![doc(html_favicon_url)]`, `#![doc(html_logo_url)]`, `#![doc(html_no_source)]`, `#![doc(html_playground_url)]`, `#![doc(html_root_url)]`, `#![doc(include)]`, `#![doc(inline)]`, `#![doc(issue_tracker_base_url)]`, `#![doc(keyword)]`, `#![doc(masked)]`, `#![doc(no_default_passes)]`, `#![doc(no_inline)]`, `#![doc(notable_trait)]`, `#![doc(passes)]`, `#![doc(plugins)]`, `#![doc(rust_logo)]`, `#![doc(search_unbox)]`, `#![doc(spotlight)]`, and `#![doc(test)]`
+  --> $DIR/invalid-doc-attr-2.rs:6:1
+   |
+LL | #![doc]
+   | ^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/tests/rustdoc-ui/lints/invalid-doc-attr-3.rs
+++ b/tests/rustdoc-ui/lints/invalid-doc-attr-3.rs
@@ -1,0 +1,22 @@
+#![deny(invalid_doc_attributes)]
+
+#![doc(test(no_crate_inject = 1))]
+//~^ ERROR
+//~| WARN
+#![doc(test(attr = 1))]
+//~^ ERROR
+//~| WARN
+
+#[doc(hidden = true)]
+//~^ ERROR
+//~| WARN
+#[doc(hidden("or you will be fired"))]
+//~^ ERROR
+//~| WARN
+#[doc(hidden = "handled transparently by codegen")]
+//~^ ERROR
+//~| WARN
+#[doc = 1]
+//~^ ERROR
+//~| WARN
+pub struct X;

--- a/tests/rustdoc-ui/lints/invalid-doc-attr-3.stderr
+++ b/tests/rustdoc-ui/lints/invalid-doc-attr-3.stderr
@@ -1,0 +1,55 @@
+error: didn't expect any arguments here
+  --> $DIR/invalid-doc-attr-3.rs:10:14
+   |
+LL | #[doc(hidden = true)]
+   |              ^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+note: the lint level is defined here
+  --> $DIR/invalid-doc-attr-3.rs:1:9
+   |
+LL | #![deny(invalid_doc_attributes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+
+error: didn't expect any arguments here
+  --> $DIR/invalid-doc-attr-3.rs:13:13
+   |
+LL | #[doc(hidden("or you will be fired"))]
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+error: didn't expect any arguments here
+  --> $DIR/invalid-doc-attr-3.rs:16:14
+   |
+LL | #[doc(hidden = "handled transparently by codegen")]
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+error: malformed `doc` attribute input
+  --> $DIR/invalid-doc-attr-3.rs:19:9
+   |
+LL | #[doc = 1]
+   |         ^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+error: didn't expect any arguments here
+  --> $DIR/invalid-doc-attr-3.rs:3:29
+   |
+LL | #![doc(test(no_crate_inject = 1))]
+   |                             ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+error: malformed `doc` attribute input
+  --> $DIR/invalid-doc-attr-3.rs:6:1
+   |
+LL | #![doc(test(attr = 1))]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+error: aborting due to 6 previous errors
+

--- a/tests/rustdoc-ui/lints/invalid-doc-attr.rs
+++ b/tests/rustdoc-ui/lints/invalid-doc-attr.rs
@@ -1,3 +1,4 @@
+#![deny(invalid_doc_attributes)]
 #![crate_type = "lib"]
 #![feature(doc_masked)]
 

--- a/tests/rustdoc-ui/lints/invalid-doc-attr.stderr
+++ b/tests/rustdoc-ui/lints/invalid-doc-attr.stderr
@@ -1,5 +1,5 @@
 error: this attribute can only be applied to a `use` item
-  --> $DIR/invalid-doc-attr.rs:7:7
+  --> $DIR/invalid-doc-attr.rs:8:7
    |
 LL | #[doc(inline)]
    |       ^^^^^^ only applicable on `use` items
@@ -8,10 +8,14 @@ LL | pub fn foo() {}
    | ------------ not a `use` item
    |
    = note: read <https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html#inline-and-no_inline> for more information
-   = note: `#[deny(invalid_doc_attributes)]` on by default
+note: the lint level is defined here
+  --> $DIR/invalid-doc-attr.rs:1:9
+   |
+LL | #![deny(invalid_doc_attributes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: conflicting doc inlining attributes
-  --> $DIR/invalid-doc-attr.rs:17:7
+  --> $DIR/invalid-doc-attr.rs:18:7
    |
 LL | #[doc(inline)]
    |       ^^^^^^ this attribute...
@@ -21,7 +25,7 @@ LL | #[doc(no_inline)]
    = help: remove one of the conflicting attributes
 
 error: this attribute can only be applied to an `extern crate` item
-  --> $DIR/invalid-doc-attr.rs:23:7
+  --> $DIR/invalid-doc-attr.rs:24:7
    |
 LL | #[doc(masked)]
    |       ^^^^^^ only applicable on `extern crate` items
@@ -32,7 +36,7 @@ LL | pub struct Masked;
    = note: read <https://doc.rust-lang.org/unstable-book/language-features/doc-masked.html> for more information
 
 error: this attribute cannot be applied to an `extern crate self` item
-  --> $DIR/invalid-doc-attr.rs:27:7
+  --> $DIR/invalid-doc-attr.rs:28:7
    |
 LL | #[doc(masked)]
    |       ^^^^^^ not applicable on `extern crate self` items
@@ -41,9 +45,10 @@ LL | pub extern crate self as reexport;
    | --------------------------------- `extern crate self` defined here
 
 error: this attribute can only be applied to an `extern crate` item
-  --> $DIR/invalid-doc-attr.rs:4:8
+  --> $DIR/invalid-doc-attr.rs:5:8
    |
-LL | / #![crate_type = "lib"]
+LL | / #![deny(invalid_doc_attributes)]
+LL | | #![crate_type = "lib"]
 LL | | #![feature(doc_masked)]
 LL | |
 LL | | #![doc(masked)]
@@ -55,7 +60,7 @@ LL | | pub extern crate self as reexport;
    = note: read <https://doc.rust-lang.org/unstable-book/language-features/doc-masked.html> for more information
 
 error: this attribute can only be applied to a `use` item
-  --> $DIR/invalid-doc-attr.rs:12:11
+  --> $DIR/invalid-doc-attr.rs:13:11
    |
 LL |     #[doc(inline)]
    |           ^^^^^^ only applicable on `use` items

--- a/tests/ui/attributes/doc-attr.rs
+++ b/tests/ui/attributes/doc-attr.rs
@@ -8,10 +8,13 @@
 pub fn foo() {}
 
 #[doc(123)]
-//~^ ERROR malformed `doc` attribute
+//~^ ERROR
+//~| WARN
 #[doc("hello", "bar")]
-//~^ ERROR malformed `doc` attribute
-//~| ERROR malformed `doc` attribute
+//~^ ERROR
+//~| ERROR
+//~| WARN
+//~| WARN
 #[doc(foo::bar, crate::bar::baz = "bye")]
 //~^ ERROR unknown `doc` attribute
 //~| ERROR unknown `doc` attribute

--- a/tests/ui/attributes/doc-attr.rs
+++ b/tests/ui/attributes/doc-attr.rs
@@ -1,3 +1,4 @@
+#![deny(invalid_doc_attributes)]
 #![crate_type = "lib"]
 #![doc(as_ptr)]
 //~^ ERROR unknown `doc` attribute

--- a/tests/ui/attributes/doc-attr.stderr
+++ b/tests/ui/attributes/doc-attr.stderr
@@ -1,5 +1,5 @@
 error[E0539]: malformed `doc` attribute input
-  --> $DIR/doc-attr.rs:9:1
+  --> $DIR/doc-attr.rs:10:1
    |
 LL | #[doc(123)]
    | ^^^^^^---^^
@@ -7,7 +7,7 @@ LL | #[doc(123)]
    |       expected this to be of the form `... = "..."`
 
 error[E0539]: malformed `doc` attribute input
-  --> $DIR/doc-attr.rs:11:1
+  --> $DIR/doc-attr.rs:12:1
    |
 LL | #[doc("hello", "bar")]
    | ^^^^^^-------^^^^^^^^^
@@ -15,7 +15,7 @@ LL | #[doc("hello", "bar")]
    |       expected this to be of the form `... = "..."`
 
 error[E0539]: malformed `doc` attribute input
-  --> $DIR/doc-attr.rs:11:1
+  --> $DIR/doc-attr.rs:12:1
    |
 LL | #[doc("hello", "bar")]
    | ^^^^^^^^^^^^^^^-----^^
@@ -23,27 +23,31 @@ LL | #[doc("hello", "bar")]
    |                expected this to be of the form `... = "..."`
 
 error: unknown `doc` attribute `as_ptr`
-  --> $DIR/doc-attr.rs:5:7
+  --> $DIR/doc-attr.rs:6:7
    |
 LL | #[doc(as_ptr)]
    |       ^^^^^^
    |
-   = note: `#[deny(invalid_doc_attributes)]` on by default
+note: the lint level is defined here
+  --> $DIR/doc-attr.rs:1:9
+   |
+LL | #![deny(invalid_doc_attributes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: unknown `doc` attribute `foo::bar`
-  --> $DIR/doc-attr.rs:14:7
+  --> $DIR/doc-attr.rs:15:7
    |
 LL | #[doc(foo::bar, crate::bar::baz = "bye")]
    |       ^^^^^^^^
 
 error: unknown `doc` attribute `crate::bar::baz`
-  --> $DIR/doc-attr.rs:14:17
+  --> $DIR/doc-attr.rs:15:17
    |
 LL | #[doc(foo::bar, crate::bar::baz = "bye")]
    |                 ^^^^^^^^^^^^^^^
 
 error: unknown `doc` attribute `as_ptr`
-  --> $DIR/doc-attr.rs:2:8
+  --> $DIR/doc-attr.rs:3:8
    |
 LL | #![doc(as_ptr)]
    |        ^^^^^^

--- a/tests/ui/attributes/doc-attr.stderr
+++ b/tests/ui/attributes/doc-attr.stderr
@@ -1,27 +1,3 @@
-error[E0539]: malformed `doc` attribute input
-  --> $DIR/doc-attr.rs:10:1
-   |
-LL | #[doc(123)]
-   | ^^^^^^---^^
-   |       |
-   |       expected this to be of the form `... = "..."`
-
-error[E0539]: malformed `doc` attribute input
-  --> $DIR/doc-attr.rs:12:1
-   |
-LL | #[doc("hello", "bar")]
-   | ^^^^^^-------^^^^^^^^^
-   |       |
-   |       expected this to be of the form `... = "..."`
-
-error[E0539]: malformed `doc` attribute input
-  --> $DIR/doc-attr.rs:12:1
-   |
-LL | #[doc("hello", "bar")]
-   | ^^^^^^^^^^^^^^^-----^^
-   |                |
-   |                expected this to be of the form `... = "..."`
-
 error: unknown `doc` attribute `as_ptr`
   --> $DIR/doc-attr.rs:6:7
    |
@@ -34,14 +10,38 @@ note: the lint level is defined here
 LL | #![deny(invalid_doc_attributes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
+error: expected this to be of the form `... = "..."`
+  --> $DIR/doc-attr.rs:10:7
+   |
+LL | #[doc(123)]
+   |       ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+error: expected this to be of the form `... = "..."`
+  --> $DIR/doc-attr.rs:13:7
+   |
+LL | #[doc("hello", "bar")]
+   |       ^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+error: expected this to be of the form `... = "..."`
+  --> $DIR/doc-attr.rs:13:16
+   |
+LL | #[doc("hello", "bar")]
+   |                ^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
 error: unknown `doc` attribute `foo::bar`
-  --> $DIR/doc-attr.rs:15:7
+  --> $DIR/doc-attr.rs:18:7
    |
 LL | #[doc(foo::bar, crate::bar::baz = "bye")]
    |       ^^^^^^^^
 
 error: unknown `doc` attribute `crate::bar::baz`
-  --> $DIR/doc-attr.rs:15:17
+  --> $DIR/doc-attr.rs:18:17
    |
 LL | #[doc(foo::bar, crate::bar::baz = "bye")]
    |                 ^^^^^^^^^^^^^^^
@@ -54,4 +54,3 @@ LL | #![doc(as_ptr)]
 
 error: aborting due to 7 previous errors
 
-For more information about this error, try `rustc --explain E0539`.

--- a/tests/ui/attributes/doc-test-literal.rs
+++ b/tests/ui/attributes/doc-test-literal.rs
@@ -1,4 +1,7 @@
+#![deny(invalid_doc_attributes)]
+
 #![doc(test(""))]
-//~^ ERROR malformed `doc` attribute input
+//~^ ERROR
+//~| WARN
 
 fn main() {}

--- a/tests/ui/attributes/doc-test-literal.stderr
+++ b/tests/ui/attributes/doc-test-literal.stderr
@@ -1,11 +1,15 @@
-error[E0565]: malformed `doc` attribute input
-  --> $DIR/doc-test-literal.rs:1:1
+error: malformed `doc` attribute input
+  --> $DIR/doc-test-literal.rs:3:13
    |
 LL | #![doc(test(""))]
-   | ^^^^^^^^^^^^--^^^
-   |             |
-   |             didn't expect a literal here
+   |             ^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+note: the lint level is defined here
+  --> $DIR/doc-test-literal.rs:1:9
+   |
+LL | #![deny(invalid_doc_attributes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0565`.

--- a/tests/ui/attributes/malformed-attrs.rs
+++ b/tests/ui/attributes/malformed-attrs.rs
@@ -1,5 +1,6 @@
 // This file contains a bunch of malformed attributes.
 // We enable a bunch of features to not get feature-gate errs in this test.
+#![deny(invalid_doc_attributes)]
 #![feature(rustc_attrs)]
 #![feature(rustc_allow_const_fn_unstable)]
 #![feature(allow_internal_unstable)]
@@ -39,8 +40,7 @@
 #[deprecated = 5]
 //~^ ERROR malformed
 #[doc]
-//~^ ERROR valid forms for the attribute are
-//~| WARN this was previously accepted by the compiler
+//~^ ERROR
 #[rustc_macro_transparency]
 //~^ ERROR malformed
 //~| ERROR attribute cannot be used on
@@ -75,8 +75,7 @@
 //~^ ERROR malformed
 //~| WARN crate-level attribute should be an inner attribute
 #[doc]
-//~^ ERROR valid forms for the attribute are
-//~| WARN this was previously accepted by the compiler
+//~^ ERROR
 #[target_feature]
 //~^ ERROR malformed
 #[export_stable = 1]

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -1,5 +1,5 @@
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/malformed-attrs.rs:108:1
+  --> $DIR/malformed-attrs.rs:107:1
    |
 LL | #[cfg]
    | ^^^^^^
@@ -10,7 +10,7 @@ LL | #[cfg]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/malformed-attrs.rs:110:1
+  --> $DIR/malformed-attrs.rs:109:1
    |
 LL | #[cfg_attr]
    | ^^^^^^^^^^^
@@ -21,13 +21,13 @@ LL | #[cfg_attr]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 
 error[E0463]: can't find crate for `wloop`
-  --> $DIR/malformed-attrs.rs:218:1
+  --> $DIR/malformed-attrs.rs:217:1
    |
 LL | extern crate wloop;
    | ^^^^^^^^^^^^^^^^^^^ can't find crate
 
 error: malformed `allow` attribute input
-  --> $DIR/malformed-attrs.rs:184:1
+  --> $DIR/malformed-attrs.rs:183:1
    |
 LL | #[allow]
    | ^^^^^^^^
@@ -43,7 +43,7 @@ LL | #[allow(lint1, lint2, lint3, reason = "...")]
    |        +++++++++++++++++++++++++++++++++++++
 
 error: malformed `expect` attribute input
-  --> $DIR/malformed-attrs.rs:186:1
+  --> $DIR/malformed-attrs.rs:185:1
    |
 LL | #[expect]
    | ^^^^^^^^^
@@ -59,7 +59,7 @@ LL | #[expect(lint1, lint2, lint3, reason = "...")]
    |         +++++++++++++++++++++++++++++++++++++
 
 error: malformed `warn` attribute input
-  --> $DIR/malformed-attrs.rs:188:1
+  --> $DIR/malformed-attrs.rs:187:1
    |
 LL | #[warn]
    | ^^^^^^^
@@ -75,7 +75,7 @@ LL | #[warn(lint1, lint2, lint3, reason = "...")]
    |       +++++++++++++++++++++++++++++++++++++
 
 error: malformed `deny` attribute input
-  --> $DIR/malformed-attrs.rs:190:1
+  --> $DIR/malformed-attrs.rs:189:1
    |
 LL | #[deny]
    | ^^^^^^^
@@ -91,7 +91,7 @@ LL | #[deny(lint1, lint2, lint3, reason = "...")]
    |       +++++++++++++++++++++++++++++++++++++
 
 error: malformed `forbid` attribute input
-  --> $DIR/malformed-attrs.rs:192:1
+  --> $DIR/malformed-attrs.rs:191:1
    |
 LL | #[forbid]
    | ^^^^^^^^^
@@ -107,25 +107,25 @@ LL | #[forbid(lint1, lint2, lint3, reason = "...")]
    |         +++++++++++++++++++++++++++++++++++++
 
 error: the `#[proc_macro]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/malformed-attrs.rs:105:1
+  --> $DIR/malformed-attrs.rs:104:1
    |
 LL | #[proc_macro = 18]
    | ^^^^^^^^^^^^^^^^^^
 
 error: the `#[proc_macro_attribute]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/malformed-attrs.rs:122:1
+  --> $DIR/malformed-attrs.rs:121:1
    |
 LL | #[proc_macro_attribute = 19]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: the `#[proc_macro_derive]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/malformed-attrs.rs:129:1
+  --> $DIR/malformed-attrs.rs:128:1
    |
 LL | #[proc_macro_derive]
    | ^^^^^^^^^^^^^^^^^^^^
 
 error[E0658]: allow_internal_unsafe side-steps the unsafe_code lint
-  --> $DIR/malformed-attrs.rs:223:1
+  --> $DIR/malformed-attrs.rs:222:1
    |
 LL | #[allow_internal_unsafe = 1]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -134,7 +134,7 @@ LL | #[allow_internal_unsafe = 1]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0539]: malformed `windows_subsystem` attribute input
-  --> $DIR/malformed-attrs.rs:26:1
+  --> $DIR/malformed-attrs.rs:27:1
    |
 LL | #![windows_subsystem]
    | ^^^-----------------^
@@ -150,25 +150,25 @@ LL | #![windows_subsystem = "windows"]
    |                      +++++++++++
 
 error[E0539]: malformed `export_name` attribute input
-  --> $DIR/malformed-attrs.rs:29:1
+  --> $DIR/malformed-attrs.rs:30:1
    |
 LL | #[unsafe(export_name)]
    | ^^^^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[export_name = "name"]`
 
 error: `rustc_allow_const_fn_unstable` expects a list of feature names
-  --> $DIR/malformed-attrs.rs:31:1
+  --> $DIR/malformed-attrs.rs:32:1
    |
 LL | #[rustc_allow_const_fn_unstable]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `allow_internal_unstable` expects a list of feature names
-  --> $DIR/malformed-attrs.rs:34:1
+  --> $DIR/malformed-attrs.rs:35:1
    |
 LL | #[allow_internal_unstable]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0539]: malformed `rustc_confusables` attribute input
-  --> $DIR/malformed-attrs.rs:36:1
+  --> $DIR/malformed-attrs.rs:37:1
    |
 LL | #[rustc_confusables]
    | ^^^^^^^^^^^^^^^^^^^^
@@ -177,7 +177,7 @@ LL | #[rustc_confusables]
    | help: must be of the form: `#[rustc_confusables("name1", "name2", ...)]`
 
 error: `#[rustc_confusables]` attribute cannot be used on functions
-  --> $DIR/malformed-attrs.rs:36:1
+  --> $DIR/malformed-attrs.rs:37:1
    |
 LL | #[rustc_confusables]
    | ^^^^^^^^^^^^^^^^^^^^
@@ -185,7 +185,7 @@ LL | #[rustc_confusables]
    = help: `#[rustc_confusables]` can only be applied to inherent methods
 
 error[E0539]: malformed `deprecated` attribute input
-  --> $DIR/malformed-attrs.rs:39:1
+  --> $DIR/malformed-attrs.rs:40:1
    |
 LL | #[deprecated = 5]
    | ^^^^^^^^^^^^^^^-^
@@ -349,7 +349,7 @@ LL | #[crate_name]
    | ^^^^^^^^^^^^^ help: must be of the form: `#[crate_name = "name"]`
 
 error[E0539]: malformed `target_feature` attribute input
-  --> $DIR/malformed-attrs.rs:80:1
+  --> $DIR/malformed-attrs.rs:79:1
    |
 LL | #[target_feature]
    | ^^^^^^^^^^^^^^^^^
@@ -358,7 +358,7 @@ LL | #[target_feature]
    | help: must be of the form: `#[target_feature(enable = "feat1, feat2")]`
 
 error[E0565]: malformed `export_stable` attribute input
-  --> $DIR/malformed-attrs.rs:82:1
+  --> $DIR/malformed-attrs.rs:81:1
    |
 LL | #[export_stable = 1]
    | ^^^^^^^^^^^^^^^^---^
@@ -367,7 +367,7 @@ LL | #[export_stable = 1]
    | help: must be of the form: `#[export_stable]`
 
 error[E0539]: malformed `link` attribute input
-  --> $DIR/malformed-attrs.rs:84:1
+  --> $DIR/malformed-attrs.rs:83:1
    |
 LL | #[link]
    | ^^^^^^^ expected this to be a list
@@ -375,7 +375,7 @@ LL | #[link]
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 error[E0539]: malformed `link_name` attribute input
-  --> $DIR/malformed-attrs.rs:88:1
+  --> $DIR/malformed-attrs.rs:87:1
    |
 LL | #[link_name]
    | ^^^^^^^^^^^^ help: must be of the form: `#[link_name = "name"]`
@@ -383,7 +383,7 @@ LL | #[link_name]
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_name-attribute>
 
 error[E0539]: malformed `link_section` attribute input
-  --> $DIR/malformed-attrs.rs:92:1
+  --> $DIR/malformed-attrs.rs:91:1
    |
 LL | #[link_section]
    | ^^^^^^^^^^^^^^^ help: must be of the form: `#[link_section = "name"]`
@@ -391,7 +391,7 @@ LL | #[link_section]
    = note: for more information, visit <https://doc.rust-lang.org/reference/abi.html#the-link_section-attribute>
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/malformed-attrs.rs:94:1
+  --> $DIR/malformed-attrs.rs:93:1
    |
 LL | #[coverage]
    | ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
@@ -404,13 +404,13 @@ LL | #[coverage(on)]
    |           ++++
 
 error[E0539]: malformed `sanitize` attribute input
-  --> $DIR/malformed-attrs.rs:96:1
+  --> $DIR/malformed-attrs.rs:95:1
    |
 LL | #[sanitize]
    | ^^^^^^^^^^^ expected this to be a list
 
 error[E0565]: malformed `no_implicit_prelude` attribute input
-  --> $DIR/malformed-attrs.rs:101:1
+  --> $DIR/malformed-attrs.rs:100:1
    |
 LL | #[no_implicit_prelude = 23]
    | ^^^^^^^^^^^^^^^^^^^^^^----^
@@ -419,7 +419,7 @@ LL | #[no_implicit_prelude = 23]
    | help: must be of the form: `#[no_implicit_prelude]`
 
 error[E0565]: malformed `proc_macro` attribute input
-  --> $DIR/malformed-attrs.rs:105:1
+  --> $DIR/malformed-attrs.rs:104:1
    |
 LL | #[proc_macro = 18]
    | ^^^^^^^^^^^^^----^
@@ -428,7 +428,7 @@ LL | #[proc_macro = 18]
    | help: must be of the form: `#[proc_macro]`
 
 error[E0539]: malformed `instruction_set` attribute input
-  --> $DIR/malformed-attrs.rs:112:1
+  --> $DIR/malformed-attrs.rs:111:1
    |
 LL | #[instruction_set]
    | ^^^^^^^^^^^^^^^^^^
@@ -439,7 +439,7 @@ LL | #[instruction_set]
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute>
 
 error[E0539]: malformed `patchable_function_entry` attribute input
-  --> $DIR/malformed-attrs.rs:114:1
+  --> $DIR/malformed-attrs.rs:113:1
    |
 LL | #[patchable_function_entry]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -448,7 +448,7 @@ LL | #[patchable_function_entry]
    | help: must be of the form: `#[patchable_function_entry(prefix_nops = m, entry_nops = n)]`
 
 error[E0565]: malformed `coroutine` attribute input
-  --> $DIR/malformed-attrs.rs:117:5
+  --> $DIR/malformed-attrs.rs:116:5
    |
 LL |     #[coroutine = 63] || {}
    |     ^^^^^^^^^^^^----^
@@ -457,7 +457,7 @@ LL |     #[coroutine = 63] || {}
    |     help: must be of the form: `#[coroutine]`
 
 error[E0565]: malformed `proc_macro_attribute` attribute input
-  --> $DIR/malformed-attrs.rs:122:1
+  --> $DIR/malformed-attrs.rs:121:1
    |
 LL | #[proc_macro_attribute = 19]
    | ^^^^^^^^^^^^^^^^^^^^^^^----^
@@ -466,7 +466,7 @@ LL | #[proc_macro_attribute = 19]
    | help: must be of the form: `#[proc_macro_attribute]`
 
 error[E0539]: malformed `must_use` attribute input
-  --> $DIR/malformed-attrs.rs:125:1
+  --> $DIR/malformed-attrs.rs:124:1
    |
 LL | #[must_use = 1]
    | ^^^^^^^^^^^^^-^
@@ -484,7 +484,7 @@ LL + #[must_use]
    |
 
 error[E0539]: malformed `proc_macro_derive` attribute input
-  --> $DIR/malformed-attrs.rs:129:1
+  --> $DIR/malformed-attrs.rs:128:1
    |
 LL | #[proc_macro_derive]
    | ^^^^^^^^^^^^^^^^^^^^ expected this to be a list
@@ -498,7 +498,7 @@ LL | #[proc_macro_derive(TraitName, attributes(name1, name2, ...))]
    |                    ++++++++++++++++++++++++++++++++++++++++++
 
 error[E0539]: malformed `rustc_layout_scalar_valid_range_start` attribute input
-  --> $DIR/malformed-attrs.rs:134:1
+  --> $DIR/malformed-attrs.rs:133:1
    |
 LL | #[rustc_layout_scalar_valid_range_start]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -507,7 +507,7 @@ LL | #[rustc_layout_scalar_valid_range_start]
    | help: must be of the form: `#[rustc_layout_scalar_valid_range_start(start)]`
 
 error[E0539]: malformed `rustc_layout_scalar_valid_range_end` attribute input
-  --> $DIR/malformed-attrs.rs:136:1
+  --> $DIR/malformed-attrs.rs:135:1
    |
 LL | #[rustc_layout_scalar_valid_range_end]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -516,7 +516,7 @@ LL | #[rustc_layout_scalar_valid_range_end]
    | help: must be of the form: `#[rustc_layout_scalar_valid_range_end(end)]`
 
 error[E0539]: malformed `must_not_suspend` attribute input
-  --> $DIR/malformed-attrs.rs:138:1
+  --> $DIR/malformed-attrs.rs:137:1
    |
 LL | #[must_not_suspend()]
    | ^^^^^^^^^^^^^^^^^^--^
@@ -532,7 +532,7 @@ LL + #[must_not_suspend]
    |
 
 error[E0539]: malformed `cfi_encoding` attribute input
-  --> $DIR/malformed-attrs.rs:140:1
+  --> $DIR/malformed-attrs.rs:139:1
    |
 LL | #[cfi_encoding = ""]
    | ^^^^^^^^^^^^^^^^^--^
@@ -541,7 +541,7 @@ LL | #[cfi_encoding = ""]
    | help: must be of the form: `#[cfi_encoding = "encoding"]`
 
 error[E0565]: malformed `marker` attribute input
-  --> $DIR/malformed-attrs.rs:161:1
+  --> $DIR/malformed-attrs.rs:160:1
    |
 LL | #[marker = 3]
    | ^^^^^^^^^---^
@@ -550,7 +550,7 @@ LL | #[marker = 3]
    | help: must be of the form: `#[marker]`
 
 error[E0565]: malformed `fundamental` attribute input
-  --> $DIR/malformed-attrs.rs:163:1
+  --> $DIR/malformed-attrs.rs:162:1
    |
 LL | #[fundamental()]
    | ^^^^^^^^^^^^^--^
@@ -559,7 +559,7 @@ LL | #[fundamental()]
    | help: must be of the form: `#[fundamental]`
 
 error[E0565]: malformed `ffi_pure` attribute input
-  --> $DIR/malformed-attrs.rs:171:5
+  --> $DIR/malformed-attrs.rs:170:5
    |
 LL |     #[unsafe(ffi_pure = 1)]
    |     ^^^^^^^^^^^^^^^^^^---^^
@@ -568,7 +568,7 @@ LL |     #[unsafe(ffi_pure = 1)]
    |     help: must be of the form: `#[ffi_pure]`
 
 error[E0539]: malformed `link_ordinal` attribute input
-  --> $DIR/malformed-attrs.rs:173:5
+  --> $DIR/malformed-attrs.rs:172:5
    |
 LL |     #[link_ordinal]
    |     ^^^^^^^^^^^^^^^
@@ -579,7 +579,7 @@ LL |     #[link_ordinal]
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_ordinal-attribute>
 
 error[E0565]: malformed `ffi_const` attribute input
-  --> $DIR/malformed-attrs.rs:177:5
+  --> $DIR/malformed-attrs.rs:176:5
    |
 LL |     #[unsafe(ffi_const = 1)]
    |     ^^^^^^^^^^^^^^^^^^^---^^
@@ -588,13 +588,13 @@ LL |     #[unsafe(ffi_const = 1)]
    |     help: must be of the form: `#[ffi_const]`
 
 error[E0539]: malformed `linkage` attribute input
-  --> $DIR/malformed-attrs.rs:179:5
+  --> $DIR/malformed-attrs.rs:178:5
    |
 LL |     #[linkage]
    |     ^^^^^^^^^^ expected this to be of the form `linkage = "..."`
 
 error[E0539]: malformed `debugger_visualizer` attribute input
-  --> $DIR/malformed-attrs.rs:194:1
+  --> $DIR/malformed-attrs.rs:193:1
    |
 LL | #[debugger_visualizer]
    | ^^^^^^^^^^^^^^^^^^^^^^
@@ -605,7 +605,7 @@ LL | #[debugger_visualizer]
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/debugger.html#the-debugger_visualizer-attribute>
 
 error[E0565]: malformed `automatically_derived` attribute input
-  --> $DIR/malformed-attrs.rs:196:1
+  --> $DIR/malformed-attrs.rs:195:1
    |
 LL | #[automatically_derived = 18]
    | ^^^^^^^^^^^^^^^^^^^^^^^^----^
@@ -614,7 +614,7 @@ LL | #[automatically_derived = 18]
    | help: must be of the form: `#[automatically_derived]`
 
 error[E0565]: malformed `non_exhaustive` attribute input
-  --> $DIR/malformed-attrs.rs:204:1
+  --> $DIR/malformed-attrs.rs:203:1
    |
 LL | #[non_exhaustive = 1]
    | ^^^^^^^^^^^^^^^^^---^
@@ -623,7 +623,7 @@ LL | #[non_exhaustive = 1]
    | help: must be of the form: `#[non_exhaustive]`
 
 error[E0565]: malformed `thread_local` attribute input
-  --> $DIR/malformed-attrs.rs:210:1
+  --> $DIR/malformed-attrs.rs:209:1
    |
 LL | #[thread_local()]
    | ^^^^^^^^^^^^^^--^
@@ -632,7 +632,7 @@ LL | #[thread_local()]
    | help: must be of the form: `#[thread_local]`
 
 error[E0565]: malformed `no_link` attribute input
-  --> $DIR/malformed-attrs.rs:214:1
+  --> $DIR/malformed-attrs.rs:213:1
    |
 LL | #[no_link()]
    | ^^^^^^^^^--^
@@ -641,7 +641,7 @@ LL | #[no_link()]
    | help: must be of the form: `#[no_link]`
 
 error[E0539]: malformed `macro_use` attribute input
-  --> $DIR/malformed-attrs.rs:216:1
+  --> $DIR/malformed-attrs.rs:215:1
    |
 LL | #[macro_use = 1]
    | ^^^^^^^^^^^^---^
@@ -659,7 +659,7 @@ LL + #[macro_use]
    |
 
 error[E0539]: malformed `macro_export` attribute input
-  --> $DIR/malformed-attrs.rs:221:1
+  --> $DIR/malformed-attrs.rs:220:1
    |
 LL | #[macro_export = 18]
    | ^^^^^^^^^^^^^^^----^
@@ -676,7 +676,7 @@ LL + #[macro_export]
    |
 
 error[E0565]: malformed `allow_internal_unsafe` attribute input
-  --> $DIR/malformed-attrs.rs:223:1
+  --> $DIR/malformed-attrs.rs:222:1
    |
 LL | #[allow_internal_unsafe = 1]
    | ^^^^^^^^^^^^^^^^^^^^^^^^---^
@@ -685,7 +685,7 @@ LL | #[allow_internal_unsafe = 1]
    | help: must be of the form: `#[allow_internal_unsafe]`
 
 error[E0565]: malformed `type_const` attribute input
-  --> $DIR/malformed-attrs.rs:149:5
+  --> $DIR/malformed-attrs.rs:148:5
    |
 LL |     #[type_const = 1]
    |     ^^^^^^^^^^^^^---^
@@ -694,7 +694,7 @@ LL |     #[type_const = 1]
    |     help: must be of the form: `#[type_const]`
 
 error: attribute should be applied to `const fn`
-  --> $DIR/malformed-attrs.rs:31:1
+  --> $DIR/malformed-attrs.rs:32:1
    |
 LL |   #[rustc_allow_const_fn_unstable]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -706,7 +706,7 @@ LL | | }
    | |_- not a `const fn`
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/malformed-attrs.rs:84:1
+  --> $DIR/malformed-attrs.rs:83:1
    |
 LL |   #[link]
    |   ^^^^^^^
@@ -733,7 +733,7 @@ LL | #[repr]
    | ^^^^^^^
 
 warning: missing options for `on_unimplemented` attribute
-  --> $DIR/malformed-attrs.rs:144:1
+  --> $DIR/malformed-attrs.rs:143:1
    |
 LL | #[diagnostic::on_unimplemented]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -742,7 +742,7 @@ LL | #[diagnostic::on_unimplemented]
    = note: `#[warn(malformed_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: malformed `on_unimplemented` attribute
-  --> $DIR/malformed-attrs.rs:146:1
+  --> $DIR/malformed-attrs.rs:145:1
    |
 LL | #[diagnostic::on_unimplemented = 1]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid option found here
@@ -750,14 +750,16 @@ LL | #[diagnostic::on_unimplemented = 1]
    = help: only `message`, `note` and `label` are allowed as options
 
 error: valid forms for the attribute are `#[doc = "string"]`, `#[doc(alias)]`, `#[doc(attribute)]`, `#[doc(auto_cfg)]`, `#[doc(cfg)]`, `#[doc(fake_variadic)]`, `#[doc(hidden)]`, `#[doc(html_favicon_url)]`, `#[doc(html_logo_url)]`, `#[doc(html_no_source)]`, `#[doc(html_playground_url)]`, `#[doc(html_root_url)]`, `#[doc(include)]`, `#[doc(inline)]`, `#[doc(issue_tracker_base_url)]`, `#[doc(keyword)]`, `#[doc(masked)]`, `#[doc(no_default_passes)]`, `#[doc(no_inline)]`, `#[doc(notable_trait)]`, `#[doc(passes)]`, `#[doc(plugins)]`, `#[doc(rust_logo)]`, `#[doc(search_unbox)]`, `#[doc(spotlight)]`, and `#[doc(test)]`
-  --> $DIR/malformed-attrs.rs:41:1
+  --> $DIR/malformed-attrs.rs:42:1
    |
 LL | #[doc]
    | ^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
-   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
+note: the lint level is defined here
+  --> $DIR/malformed-attrs.rs:3:9
+   |
+LL | #![deny(invalid_doc_attributes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: valid forms for the attribute are `#[inline(always)]`, `#[inline(never)]`, and `#[inline]`
   --> $DIR/malformed-attrs.rs:52:1
@@ -767,6 +769,7 @@ LL | #[inline = 5]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_name]`
   --> $DIR/malformed-attrs.rs:74:1
@@ -775,7 +778,7 @@ LL | #[crate_name]
    | ^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/malformed-attrs.rs:116:1
+  --> $DIR/malformed-attrs.rs:115:1
    |
 LL | / fn test() {
 LL | |     #[coroutine = 63] || {}
@@ -788,12 +791,9 @@ error: valid forms for the attribute are `#[doc = "string"]`, `#[doc(alias)]`, `
    |
 LL | #[doc]
    | ^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 warning: `#[link_name]` attribute cannot be used on functions
-  --> $DIR/malformed-attrs.rs:88:1
+  --> $DIR/malformed-attrs.rs:87:1
    |
 LL | #[link_name]
    | ^^^^^^^^^^^^
@@ -802,7 +802,7 @@ LL | #[link_name]
    = help: `#[link_name]` can be applied to foreign functions and foreign statics
 
 error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
-  --> $DIR/malformed-attrs.rs:98:1
+  --> $DIR/malformed-attrs.rs:97:1
    |
 LL | #[ignore()]
    | ^^^^^^^^^^^
@@ -811,7 +811,7 @@ LL | #[ignore()]
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on functions
-  --> $DIR/malformed-attrs.rs:101:1
+  --> $DIR/malformed-attrs.rs:100:1
    |
 LL | #[no_implicit_prelude = 23]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -820,13 +820,13 @@ LL | #[no_implicit_prelude = 23]
    = help: `#[no_implicit_prelude]` can be applied to crates and modules
 
 warning: `#[diagnostic::do_not_recommend]` does not expect any arguments
-  --> $DIR/malformed-attrs.rs:155:1
+  --> $DIR/malformed-attrs.rs:154:1
    |
 LL | #[diagnostic::do_not_recommend()]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: `#[automatically_derived]` attribute cannot be used on modules
-  --> $DIR/malformed-attrs.rs:196:1
+  --> $DIR/malformed-attrs.rs:195:1
    |
 LL | #[automatically_derived = 18]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -835,7 +835,7 @@ LL | #[automatically_derived = 18]
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
 
 error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
-  --> $DIR/malformed-attrs.rs:230:1
+  --> $DIR/malformed-attrs.rs:229:1
    |
 LL | #[ignore = 1]
    | ^^^^^^^^^^^^^
@@ -844,7 +844,7 @@ LL | #[ignore = 1]
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 error[E0308]: mismatched types
-  --> $DIR/malformed-attrs.rs:117:23
+  --> $DIR/malformed-attrs.rs:116:23
    |
 LL | fn test() {
    |          - help: a return type might be missing here: `-> _`
@@ -852,24 +852,13 @@ LL |     #[coroutine = 63] || {}
    |                       ^^^^^ expected `()`, found coroutine
    |
    = note: expected unit type `()`
-              found coroutine `{coroutine@$DIR/malformed-attrs.rs:117:23: 117:25}`
+              found coroutine `{coroutine@$DIR/malformed-attrs.rs:116:23: 116:25}`
 
 error: aborting due to 76 previous errors; 8 warnings emitted
 
 Some errors have detailed explanations: E0308, E0463, E0539, E0565, E0658, E0805.
 For more information about an error, try `rustc --explain E0308`.
 Future incompatibility report: Future breakage diagnostic:
-error: valid forms for the attribute are `#[doc = "string"]`, `#[doc(alias)]`, `#[doc(attribute)]`, `#[doc(auto_cfg)]`, `#[doc(cfg)]`, `#[doc(fake_variadic)]`, `#[doc(hidden)]`, `#[doc(html_favicon_url)]`, `#[doc(html_logo_url)]`, `#[doc(html_no_source)]`, `#[doc(html_playground_url)]`, `#[doc(html_root_url)]`, `#[doc(include)]`, `#[doc(inline)]`, `#[doc(issue_tracker_base_url)]`, `#[doc(keyword)]`, `#[doc(masked)]`, `#[doc(no_default_passes)]`, `#[doc(no_inline)]`, `#[doc(notable_trait)]`, `#[doc(passes)]`, `#[doc(plugins)]`, `#[doc(rust_logo)]`, `#[doc(search_unbox)]`, `#[doc(spotlight)]`, and `#[doc(test)]`
-  --> $DIR/malformed-attrs.rs:41:1
-   |
-LL | #[doc]
-   | ^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
-   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
-
-Future breakage diagnostic:
 error: valid forms for the attribute are `#[inline(always)]`, `#[inline(never)]`, and `#[inline]`
   --> $DIR/malformed-attrs.rs:52:1
    |
@@ -881,19 +870,8 @@ LL | #[inline = 5]
    = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
-error: valid forms for the attribute are `#[doc = "string"]`, `#[doc(alias)]`, `#[doc(attribute)]`, `#[doc(auto_cfg)]`, `#[doc(cfg)]`, `#[doc(fake_variadic)]`, `#[doc(hidden)]`, `#[doc(html_favicon_url)]`, `#[doc(html_logo_url)]`, `#[doc(html_no_source)]`, `#[doc(html_playground_url)]`, `#[doc(html_root_url)]`, `#[doc(include)]`, `#[doc(inline)]`, `#[doc(issue_tracker_base_url)]`, `#[doc(keyword)]`, `#[doc(masked)]`, `#[doc(no_default_passes)]`, `#[doc(no_inline)]`, `#[doc(notable_trait)]`, `#[doc(passes)]`, `#[doc(plugins)]`, `#[doc(rust_logo)]`, `#[doc(search_unbox)]`, `#[doc(spotlight)]`, and `#[doc(test)]`
-  --> $DIR/malformed-attrs.rs:77:1
-   |
-LL | #[doc]
-   | ^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
-   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
-
-Future breakage diagnostic:
 error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
-  --> $DIR/malformed-attrs.rs:98:1
+  --> $DIR/malformed-attrs.rs:97:1
    |
 LL | #[ignore()]
    | ^^^^^^^^^^^
@@ -904,7 +882,7 @@ LL | #[ignore()]
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
-  --> $DIR/malformed-attrs.rs:230:1
+  --> $DIR/malformed-attrs.rs:229:1
    |
 LL | #[ignore = 1]
    | ^^^^^^^^^^^^^

--- a/tests/ui/feature-gates/removed-features-note-version-and-pr-issue-141619.rs
+++ b/tests/ui/feature-gates/removed-features-note-version-and-pr-issue-141619.rs
@@ -1,3 +1,4 @@
+#![deny(invalid_doc_attributes)]
 #![feature(external_doc)] //~ ERROR feature has been removed
 #![doc(include("README.md"))] //~ ERROR unknown `doc` attribute `include`
 

--- a/tests/ui/feature-gates/removed-features-note-version-and-pr-issue-141619.stderr
+++ b/tests/ui/feature-gates/removed-features-note-version-and-pr-issue-141619.stderr
@@ -1,5 +1,5 @@
 error[E0557]: feature has been removed
-  --> $DIR/removed-features-note-version-and-pr-issue-141619.rs:1:12
+  --> $DIR/removed-features-note-version-and-pr-issue-141619.rs:2:12
    |
 LL | #![feature(external_doc)]
    |            ^^^^^^^^^^^^ feature has been removed
@@ -8,12 +8,16 @@ LL | #![feature(external_doc)]
    = note: use #[doc = include_str!("filename")] instead, which handles macro invocations
 
 error: unknown `doc` attribute `include`
-  --> $DIR/removed-features-note-version-and-pr-issue-141619.rs:2:8
+  --> $DIR/removed-features-note-version-and-pr-issue-141619.rs:3:8
    |
 LL | #![doc(include("README.md"))]
    |        ^^^^^^^
    |
-   = note: `#[deny(invalid_doc_attributes)]` on by default
+note: the lint level is defined here
+  --> $DIR/removed-features-note-version-and-pr-issue-141619.rs:1:9
+   |
+LL | #![deny(invalid_doc_attributes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/malformed/malformed-regressions.rs
+++ b/tests/ui/malformed/malformed-regressions.rs
@@ -1,5 +1,6 @@
+#![deny(invalid_doc_attributes)]
+
 #[doc] //~ ERROR valid forms for the attribute are
-//~^ WARN this was previously accepted
 #[ignore()] //~ ERROR valid forms for the attribute are
 //~^ WARN this was previously accepted
 #[inline = ""] //~ ERROR valid forms for the attribute are

--- a/tests/ui/malformed/malformed-regressions.stderr
+++ b/tests/ui/malformed/malformed-regressions.stderr
@@ -1,5 +1,5 @@
 error[E0539]: malformed `link` attribute input
-  --> $DIR/malformed-regressions.rs:7:1
+  --> $DIR/malformed-regressions.rs:8:1
    |
 LL | #[link]
    | ^^^^^^^ expected this to be a list
@@ -7,7 +7,7 @@ LL | #[link]
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 error[E0539]: malformed `link` attribute input
-  --> $DIR/malformed-regressions.rs:10:1
+  --> $DIR/malformed-regressions.rs:11:1
    |
 LL | #[link = ""]
    | ^^^^^^^----^
@@ -17,7 +17,7 @@ LL | #[link = ""]
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/malformed-regressions.rs:7:1
+  --> $DIR/malformed-regressions.rs:8:1
    |
 LL | #[link]
    | ^^^^^^^
@@ -29,26 +29,29 @@ LL | fn main() {}
    = note: requested on the command line with `-W unused-attributes`
 
 error: valid forms for the attribute are `#[doc = "string"]`, `#[doc(alias)]`, `#[doc(attribute)]`, `#[doc(auto_cfg)]`, `#[doc(cfg)]`, `#[doc(fake_variadic)]`, `#[doc(hidden)]`, `#[doc(html_favicon_url)]`, `#[doc(html_logo_url)]`, `#[doc(html_no_source)]`, `#[doc(html_playground_url)]`, `#[doc(html_root_url)]`, `#[doc(include)]`, `#[doc(inline)]`, `#[doc(issue_tracker_base_url)]`, `#[doc(keyword)]`, `#[doc(masked)]`, `#[doc(no_default_passes)]`, `#[doc(no_inline)]`, `#[doc(notable_trait)]`, `#[doc(passes)]`, `#[doc(plugins)]`, `#[doc(rust_logo)]`, `#[doc(search_unbox)]`, `#[doc(spotlight)]`, and `#[doc(test)]`
-  --> $DIR/malformed-regressions.rs:1:1
+  --> $DIR/malformed-regressions.rs:3:1
    |
 LL | #[doc]
    | ^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
-   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
+note: the lint level is defined here
+  --> $DIR/malformed-regressions.rs:1:9
+   |
+LL | #![deny(invalid_doc_attributes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
-  --> $DIR/malformed-regressions.rs:3:1
+  --> $DIR/malformed-regressions.rs:4:1
    |
 LL | #[ignore()]
    | ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: valid forms for the attribute are `#[inline(always)]`, `#[inline(never)]`, and `#[inline]`
-  --> $DIR/malformed-regressions.rs:5:1
+  --> $DIR/malformed-regressions.rs:6:1
    |
 LL | #[inline = ""]
    | ^^^^^^^^^^^^^^
@@ -60,19 +63,8 @@ error: aborting due to 5 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0539`.
 Future incompatibility report: Future breakage diagnostic:
-error: valid forms for the attribute are `#[doc = "string"]`, `#[doc(alias)]`, `#[doc(attribute)]`, `#[doc(auto_cfg)]`, `#[doc(cfg)]`, `#[doc(fake_variadic)]`, `#[doc(hidden)]`, `#[doc(html_favicon_url)]`, `#[doc(html_logo_url)]`, `#[doc(html_no_source)]`, `#[doc(html_playground_url)]`, `#[doc(html_root_url)]`, `#[doc(include)]`, `#[doc(inline)]`, `#[doc(issue_tracker_base_url)]`, `#[doc(keyword)]`, `#[doc(masked)]`, `#[doc(no_default_passes)]`, `#[doc(no_inline)]`, `#[doc(notable_trait)]`, `#[doc(passes)]`, `#[doc(plugins)]`, `#[doc(rust_logo)]`, `#[doc(search_unbox)]`, `#[doc(spotlight)]`, and `#[doc(test)]`
-  --> $DIR/malformed-regressions.rs:1:1
-   |
-LL | #[doc]
-   | ^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
-   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
-
-Future breakage diagnostic:
 error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
-  --> $DIR/malformed-regressions.rs:3:1
+  --> $DIR/malformed-regressions.rs:4:1
    |
 LL | #[ignore()]
    | ^^^^^^^^^^^
@@ -83,7 +75,7 @@ LL | #[ignore()]
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[inline(always)]`, `#[inline(never)]`, and `#[inline]`
-  --> $DIR/malformed-regressions.rs:5:1
+  --> $DIR/malformed-regressions.rs:6:1
    |
 LL | #[inline = ""]
    | ^^^^^^^^^^^^^^

--- a/tests/ui/malformed/malformed-special-attrs.rs
+++ b/tests/ui/malformed/malformed-special-attrs.rs
@@ -1,3 +1,5 @@
+#![deny(invalid_doc_attributes)]
+
 #[cfg_attr] //~ ERROR malformed `cfg_attr` attribute
 struct S1;
 

--- a/tests/ui/malformed/malformed-special-attrs.stderr
+++ b/tests/ui/malformed/malformed-special-attrs.stderr
@@ -1,5 +1,5 @@
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/malformed-special-attrs.rs:1:1
+  --> $DIR/malformed-special-attrs.rs:3:1
    |
 LL | #[cfg_attr]
    | ^^^^^^^^^^^
@@ -10,7 +10,7 @@ LL | #[cfg_attr]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/malformed-special-attrs.rs:4:1
+  --> $DIR/malformed-special-attrs.rs:6:1
    |
 LL | #[cfg_attr = ""]
    | ^^^^^^^^^^^^^^^^
@@ -21,13 +21,13 @@ LL | #[cfg_attr = ""]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 
 error: malformed `derive` attribute input
-  --> $DIR/malformed-special-attrs.rs:7:1
+  --> $DIR/malformed-special-attrs.rs:9:1
    |
 LL | #[derive]
    | ^^^^^^^^^ help: must be of the form: `#[derive(Trait1, Trait2, ...)]`
 
 error: malformed `derive` attribute input
-  --> $DIR/malformed-special-attrs.rs:10:1
+  --> $DIR/malformed-special-attrs.rs:12:1
    |
 LL | #[derive = ""]
    | ^^^^^^^^^^^^^^ help: must be of the form: `#[derive(Trait1, Trait2, ...)]`

--- a/tests/ui/repr/invalid_repr_list_help.rs
+++ b/tests/ui/repr/invalid_repr_list_help.rs
@@ -1,3 +1,4 @@
+#![deny(invalid_doc_attributes)]
 #![crate_type = "lib"]
 
 #[repr(uwu)] //~ERROR: unrecognized representation hint

--- a/tests/ui/repr/invalid_repr_list_help.stderr
+++ b/tests/ui/repr/invalid_repr_list_help.stderr
@@ -1,5 +1,5 @@
 error[E0552]: unrecognized representation hint
-  --> $DIR/invalid_repr_list_help.rs:3:8
+  --> $DIR/invalid_repr_list_help.rs:4:8
    |
 LL | #[repr(uwu)]
    |        ^^^
@@ -8,7 +8,7 @@ LL | #[repr(uwu)]
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html?highlight=repr#representations>
 
 error[E0552]: unrecognized representation hint
-  --> $DIR/invalid_repr_list_help.rs:6:8
+  --> $DIR/invalid_repr_list_help.rs:7:8
    |
 LL | #[repr(uwu = "a")]
    |        ^^^^^^^^^
@@ -17,7 +17,7 @@ LL | #[repr(uwu = "a")]
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html?highlight=repr#representations>
 
 error[E0552]: unrecognized representation hint
-  --> $DIR/invalid_repr_list_help.rs:9:8
+  --> $DIR/invalid_repr_list_help.rs:10:8
    |
 LL | #[repr(uwu(4))]
    |        ^^^^^^
@@ -26,7 +26,7 @@ LL | #[repr(uwu(4))]
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html?highlight=repr#representations>
 
 error[E0552]: unrecognized representation hint
-  --> $DIR/invalid_repr_list_help.rs:14:8
+  --> $DIR/invalid_repr_list_help.rs:15:8
    |
 LL | #[repr(uwu, u8)]
    |        ^^^
@@ -35,7 +35,7 @@ LL | #[repr(uwu, u8)]
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html?highlight=repr#representations>
 
 error[E0552]: unrecognized representation hint
-  --> $DIR/invalid_repr_list_help.rs:19:8
+  --> $DIR/invalid_repr_list_help.rs:20:8
    |
 LL | #[repr(uwu)]
    |        ^^^
@@ -44,12 +44,16 @@ LL | #[repr(uwu)]
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html?highlight=repr#representations>
 
 error: unknown `doc` attribute `owo`
-  --> $DIR/invalid_repr_list_help.rs:20:7
+  --> $DIR/invalid_repr_list_help.rs:21:7
    |
 LL | #[doc(owo)]
    |       ^^^
    |
-   = note: `#[deny(invalid_doc_attributes)]` on by default
+note: the lint level is defined here
+  --> $DIR/invalid_repr_list_help.rs:1:9
+   |
+LL | #![deny(invalid_doc_attributes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 6 previous errors
 


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/151865 (hopefully fixes it).

r? @JonathanBrouwer 