### PR TITLE
escape symbol names in global asm

### DIFF
--- a/tests/ui/asm/x86_64/global_asm_escape.rs
+++ b/tests/ui/asm/x86_64/global_asm_escape.rs
@@ -1,0 +1,17 @@
+//@ run-pass
+//@ only-x86_64-unknown-linux-gnu
+//@ ignore-backends: gcc
+
+// https://github.com/rust-lang/rust/issues/151950
+
+unsafe extern "C" {
+    #[link_name = "exit@GLIBC_2.2.5"]
+    safe fn exit(status: i32) -> !;
+    safe fn my_exit(status: i32) -> !;
+}
+
+core::arch::global_asm!(".global my_exit", "my_exit:", "jmp {}", sym exit);
+
+fn main() {
+    my_exit(0);
+}

--- a/tests/ui/asm/x86_64/naked_asm_escape.rs
+++ b/tests/ui/asm/x86_64/naked_asm_escape.rs
@@ -1,0 +1,32 @@
+//@ build-fail
+//@ only-x86_64-unknown-linux-gnu
+//@ dont-check-compiler-stderr
+//@ dont-check-compiler-stdout
+//@ ignore-backends: gcc
+
+// https://github.com/rust-lang/rust/issues/151950
+
+unsafe extern "C" {
+    #[link_name = "memset]; mov eax, 1; #"]
+    unsafe fn inject();
+}
+
+#[unsafe(export_name = "memset]; mov eax, 1; #")]
+extern "C" fn inject_() {}
+
+#[unsafe(naked)]
+extern "C" fn print_0() -> usize {
+    core::arch::naked_asm!("lea rax, [{}]", "ret", sym inject)
+}
+
+#[unsafe(naked)]
+extern "C" fn print_1() -> usize {
+    core::arch::naked_asm!("lea rax, [{}]", "ret", sym inject_)
+}
+
+fn main() {
+    dbg!(print_0());
+    dbg!(print_1());
+}
+
+//~? ERROR linking


### PR DESCRIPTION
copied from https://github.com/llvm/llvm-project/blob/main/llvm/lib/MC/MCSymbol.cpp

closes https://github.com/rust-lang/rust/issues/151950