### PR TITLE
rustc_parse: improve the error diagnostic for "missing let"

### DIFF
--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -574,6 +574,24 @@ pub(crate) struct ExpectedExpressionFoundLet {
 }
 
 #[derive(Diagnostic)]
+#[diag("let-chain with missing `let`")]
+pub(crate) struct LetChainMissingLet {
+    #[primary_span]
+    pub span: Span,
+    #[label("expected `let` expression, found assignment")]
+    pub label_span: Span,
+    #[label("let expression later in the condition")]
+    pub rhs_span: Span,
+    #[suggestion(
+        "add `let` before the expression",
+        applicability = "maybe-incorrect",
+        code = "let ",
+        style = "verbose"
+    )]
+    pub sug_span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag("`||` operators are not supported in let chain conditions")]
 pub(crate) struct OrInLetChain {
     #[primary_span]

--- a/tests/ui/missing/missing-let.rs
+++ b/tests/ui/missing/missing-let.rs
@@ -1,6 +1,18 @@
 fn main() {
     let x = Some(42);
+    let y = Some(42);
+    let z = Some(42);
     if let Some(_) = x
         && Some(x) = x //~^ ERROR expected expression, found `let` statement
+        //~| NOTE: only supported directly in conditions of `if` and `while` expressions
+    {}
+
+    if Some(_) = y &&
+    //~^ NOTE expected `let` expression, found assignment
+    //~| ERROR let-chain with missing `let`
+        let Some(_) = z
+        //~^ ERROR: expected expression, found `let` statement
+        //~| NOTE: let expression later in the condition
+        //~| NOTE: only supported directly in conditions of `if` and `while` expressions
     {}
 }

--- a/tests/ui/missing/missing-let.stderr
+++ b/tests/ui/missing/missing-let.stderr
@@ -1,5 +1,5 @@
 error: expected expression, found `let` statement
-  --> $DIR/missing-let.rs:3:8
+  --> $DIR/missing-let.rs:5:8
    |
 LL |     if let Some(_) = x
    |        ^^^^^^^^^^^^^^^
@@ -14,5 +14,29 @@ help: you might have meant to compare for equality
 LL |         && Some(x) == x
    |                     +
 
-error: aborting due to 1 previous error
+error: expected expression, found `let` statement
+  --> $DIR/missing-let.rs:13:9
+   |
+LL |         let Some(_) = z
+   |         ^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
+
+error: let-chain with missing `let`
+  --> $DIR/missing-let.rs:10:8
+   |
+LL |     if Some(_) = y &&
+   |        ^^^^^^^----
+   |        |
+   |        expected `let` expression, found assignment
+...
+LL |         let Some(_) = z
+   |         --------------- let expression later in the condition
+   |
+help: add `let` before the expression
+   |
+LL |     if let Some(_) = y &&
+   |        +++
+
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? estebank 
-->
<!-- homu-ignore:end -->
