### PR TITLE
Stabilize `proc_macro_value` feature

### DIFF
--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -66,7 +66,7 @@ use crate::bridge::client::Methods as BridgeMethods;
 use crate::escape::{EscapeOptions, escape_bytes};
 
 /// Mostly relating to malformed escape sequences, but also a few other problems.
-#[unstable(feature = "proc_macro_value", issue = "136652")]
+#[stable(feature = "proc_macro_value", since = "CURRENT_RUSTC_VERSION")]
 #[derive(Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum EscapeError {
@@ -126,7 +126,7 @@ pub enum EscapeError {
     MultipleSkippedLinesWarning,
 }
 
-#[unstable(feature = "proc_macro_value", issue = "136652")]
+#[stable(feature = "proc_macro_value", since = "CURRENT_RUSTC_VERSION")]
 #[doc(hidden)]
 impl From<rustc_literal_escaper::EscapeError> for EscapeError {
     fn from(value: rustc_literal_escaper::EscapeError) -> Self {
@@ -160,10 +160,10 @@ impl From<rustc_literal_escaper::EscapeError> for EscapeError {
     }
 }
 
-#[unstable(feature = "proc_macro_value", issue = "136652")]
+#[stable(feature = "proc_macro_value", since = "CURRENT_RUSTC_VERSION")]
 impl error::Error for EscapeError {}
 
-#[unstable(feature = "proc_macro_value", issue = "136652")]
+#[stable(feature = "proc_macro_value", since = "CURRENT_RUSTC_VERSION")]
 impl fmt::Display for EscapeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
@@ -195,7 +195,7 @@ impl fmt::Display for EscapeError {
 }
 
 /// Errors returned when trying to retrieve a literal unescaped value.
-#[unstable(feature = "proc_macro_value", issue = "136652")]
+#[stable(feature = "proc_macro_value", since = "CURRENT_RUSTC_VERSION")]
 #[derive(Debug, PartialEq, Eq)]
 pub enum ConversionErrorKind {
     /// The literal failed to be escaped, take a look at [`EscapeError`] for more information.
@@ -1322,7 +1322,7 @@ macro_rules! integer_values {
                 "` value if the literal is a `",
                 stringify!($nb),
                 "` or if it's an \"unmarked\" integer which doesn't overflow.")]
-            #[unstable(feature = "proc_macro_value", issue = "136652")]
+            #[stable(feature = "proc_macro_value", since = "CURRENT_RUSTC_VERSION")]
             pub fn $fn_name(&self) -> Result<$nb, ConversionErrorKind> {
                 if self.0.kind != bridge::LitKind::Integer {
                     return Err(ConversionErrorKind::InvalidLiteralKind);
@@ -1351,7 +1351,7 @@ macro_rules! float_values {
                 "` value if the literal is a `",
                 stringify!($nb),
                 "` or if it's an \"unmarked\" float which doesn't overflow.")]
-            #[unstable(feature = "proc_macro_value", issue = "136652")]
+            #[stable(feature = "proc_macro_value", since = "CURRENT_RUSTC_VERSION")]
             pub fn $fn_name(&self) -> Result<$nb, ConversionErrorKind> {
                 if self.0.kind != bridge::LitKind::Float {
                     return Err(ConversionErrorKind::InvalidLiteralKind);
@@ -1645,7 +1645,7 @@ impl Literal {
     }
 
     /// Returns the unescaped character value if the current literal is a byte character literal.
-    #[unstable(feature = "proc_macro_value", issue = "136652")]
+    #[stable(feature = "proc_macro_value", since = "CURRENT_RUSTC_VERSION")]
     pub fn byte_character_value(&self) -> Result<u8, ConversionErrorKind> {
         self.0.symbol.with(|symbol| match self.0.kind {
             bridge::LitKind::Byte => unescape_byte(symbol)
@@ -1655,7 +1655,7 @@ impl Literal {
     }
 
     /// Returns the unescaped character value if the current literal is a character literal.
-    #[unstable(feature = "proc_macro_value", issue = "136652")]
+    #[stable(feature = "proc_macro_value", since = "CURRENT_RUSTC_VERSION")]
     pub fn character_value(&self) -> Result<char, ConversionErrorKind> {
         self.0.symbol.with(|symbol| match self.0.kind {
             bridge::LitKind::Char => unescape_char(symbol)
@@ -1665,7 +1665,7 @@ impl Literal {
     }
 
     /// Returns the unescaped string value if the current literal is a string or a string literal.
-    #[unstable(feature = "proc_macro_value", issue = "136652")]
+    #[stable(feature = "proc_macro_value", since = "CURRENT_RUSTC_VERSION")]
     pub fn str_value(&self) -> Result<String, ConversionErrorKind> {
         self.0.symbol.with(|symbol| match self.0.kind {
             bridge::LitKind::Str => {
@@ -1699,7 +1699,7 @@ impl Literal {
 
     /// Returns the unescaped string value if the current literal is a c-string or a c-string
     /// literal.
-    #[unstable(feature = "proc_macro_value", issue = "136652")]
+    #[stable(feature = "proc_macro_value", since = "CURRENT_RUSTC_VERSION")]
     pub fn cstr_value(&self) -> Result<Vec<u8>, ConversionErrorKind> {
         self.0.symbol.with(|symbol| match self.0.kind {
             bridge::LitKind::CStr => {
@@ -1738,7 +1738,7 @@ impl Literal {
 
     /// Returns the unescaped string value if the current literal is a byte string or a byte string
     /// literal.
-    #[unstable(feature = "proc_macro_value", issue = "136652")]
+    #[stable(feature = "proc_macro_value", since = "CURRENT_RUSTC_VERSION")]
     pub fn byte_str_value(&self) -> Result<Vec<u8>, ConversionErrorKind> {
         self.0.symbol.with(|symbol| match self.0.kind {
             bridge::LitKind::ByteStr => {


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/151973)*
<!-- homu-ignore:end -->

Fixes https://github.com/rust-lang/rust/issues/136652.

The feature implementation is complete: all string related values now have their `_value` method and `proc_macro2` integration seems to be working as expected.

Integers are voluntarily left untouched as an equivalent API for them is much trickier to provide. I'll open an ACP once I come up with a design I'm happy with.

r? @Amanieu 