### PR TITLE
Update documentation for `Result::ok()`

### DIFF
--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -690,7 +690,7 @@ impl<T, E> Result<T, E> {
     /// Converts from `Result<T, E>` to [`Option<T>`].
     ///
     /// Converts `self` into an [`Option<T>`], consuming `self`,
-    /// and discarding the error, if any.
+    /// and converting the error to `None`, if any.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
The term of "discard" is misleading. An error is not discarded but converted to an `Option::None`.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
