### PR TITLE
Rename `collect_active_jobs` to several distinct names

### DIFF
--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -254,7 +254,7 @@ internal compiler error: query cycle handler thread panicked, aborting process";
                                     || {
                                         // Ensure there were no errors collecting all active jobs.
                                         // We need the complete map to ensure we find a cycle to break.
-                                        QueryCtxt::new(tcx).collect_active_jobs(false).expect(
+                                        QueryCtxt::new(tcx).collect_active_jobs_from_all_queries(false).expect(
                                             "failed to collect active queries in deadlock handler",
                                         )
                                     },

--- a/compiler/rustc_query_system/src/query/job.rs
+++ b/compiler/rustc_query_system/src/query/job.rs
@@ -32,6 +32,8 @@ impl<'tcx> QueryInfo<QueryStackDeferred<'tcx>> {
     }
 }
 
+/// Map from query job IDs to job information collected by
+/// [`QueryContext::collect_active_jobs_from_all_queries`].
 pub type QueryMap<'tcx> = FxHashMap<QueryJobId, QueryJobInfo<'tcx>>;
 
 /// A value uniquely identifying an active query job.
@@ -613,7 +615,7 @@ pub fn print_query_stack<'tcx, Qcx: QueryContext<'tcx>>(
     let mut count_total = 0;
 
     // Make use of a partial query map if we fail to take locks collecting active queries.
-    let query_map = match qcx.collect_active_jobs(false) {
+    let query_map = match qcx.collect_active_jobs_from_all_queries(false) {
         Ok(query_map) => query_map,
         Err(query_map) => query_map,
     };

--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -166,7 +166,10 @@ pub trait QueryContext<'tcx>: HasDepContext {
     /// Get the query information from the TLS context.
     fn current_query_job(self) -> Option<QueryJobId>;
 
-    fn collect_active_jobs(self, require_complete: bool) -> Result<QueryMap<'tcx>, QueryMap<'tcx>>;
+    fn collect_active_jobs_from_all_queries(
+        self,
+        require_complete: bool,
+    ) -> Result<QueryMap<'tcx>, QueryMap<'tcx>>;
 
     /// Load a side effect associated to the node in the previous session.
     fn load_side_effect(

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -11,7 +11,6 @@ use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::hash_table::{self, Entry, HashTable};
 use rustc_data_structures::sharded::{self, Sharded};
 use rustc_data_structures::stack::ensure_sufficient_stack;
-use rustc_data_structures::sync::LockGuard;
 use rustc_data_structures::{outline, sync};
 use rustc_errors::{Diag, FatalError, StashKey};
 use rustc_span::{DUMMY_SP, Span};
@@ -79,7 +78,10 @@ where
         self.active.lock_shards().all(|shard| shard.is_empty())
     }
 
-    pub fn collect_active_jobs<Qcx: Copy>(
+    /// Internal plumbing for collecting the set of active jobs for this query.
+    ///
+    /// Should only be called from `gather_active_jobs`.
+    pub fn gather_active_jobs_inner<Qcx: Copy>(
         &self,
         qcx: Qcx,
         make_frame: fn(Qcx, K) -> QueryStackFrame<QueryStackDeferred<'tcx>>,
@@ -88,23 +90,26 @@ where
     ) -> Option<()> {
         let mut active = Vec::new();
 
-        let mut collect = |iter: LockGuard<'_, HashTable<(K, ActiveKeyStatus<'tcx>)>>| {
-            for (k, v) in iter.iter() {
+        // Helper to gather active jobs from a single shard.
+        let mut gather_shard_jobs = |shard: &HashTable<(K, ActiveKeyStatus<'tcx>)>| {
+            for (k, v) in shard.iter() {
                 if let ActiveKeyStatus::Started(ref job) = *v {
                     active.push((*k, job.clone()));
                 }
             }
         };
 
+        // Lock shards and gather jobs from each shard.
         if require_complete {
             for shard in self.active.lock_shards() {
-                collect(shard);
+                gather_shard_jobs(&shard);
             }
         } else {
             // We use try_lock_shards here since we are called from the
             // deadlock handler, and this shouldn't be locked.
             for shard in self.active.try_lock_shards() {
-                collect(shard?);
+                let shard = shard?;
+                gather_shard_jobs(&shard);
             }
         }
 
@@ -294,7 +299,10 @@ where
 {
     // Ensure there was no errors collecting all active jobs.
     // We need the complete map to ensure we find a cycle to break.
-    let query_map = qcx.collect_active_jobs(false).ok().expect("failed to collect active queries");
+    let query_map = qcx
+        .collect_active_jobs_from_all_queries(false)
+        .ok()
+        .expect("failed to collect active queries");
 
     let error = try_execute.find_cycle_in_stack(query_map, &qcx.current_query_job(), span);
     (mk_cycle(query, qcx, error.lift()), None)


### PR DESCRIPTION
Key renames:
- Function `collect_active_jobs` → `collect_active_jobs_from_all_queries` (method in trait `QueryContext`)
- Constant `COLLECT_ACTIVE_JOBS` → `PER_QUERY_GATHER_ACTIVE_JOBS_FNS` (list of per-query function pointers)
- Function `collect_active_jobs` → `gather_active_jobs` (per-query function in `query_impl::$name`)
- Function `collect_active_jobs` → `gather_active_jobs_inner` (method in `QueryState`)
  - Giving these four things distinct names makes it a lot easier to tell them apart!
  - The switch from “collect” (all queries) to “gather” (single query) is intended to make the different parts a bit more memorable and searchable; I couldn't think of a more natural way to express this distinction so I settled for two different synonyms.

There should be no change to compiler behaviour.

r? nnethercote (or compiler)