### PR TITLE
Fix uninitialized UEFI globals in tests

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -260,6 +260,7 @@
     all(target_vendor = "fortanix", target_env = "sgx"),
     feature(slice_index_methods, coerce_unsized, sgx_platform)
 )]
+#![cfg_attr(all(test, target_os = "uefi"), feature(uefi_std))]
 #![cfg_attr(target_family = "wasm", feature(stdarch_wasm_atomic_wait))]
 #![cfg_attr(target_arch = "wasm64", feature(simd_wasm64))]
 //

--- a/library/std/src/os/uefi/env.rs
+++ b/library/std/src/os/uefi/env.rs
@@ -4,13 +4,25 @@
 
 use crate::ffi::c_void;
 use crate::ptr::NonNull;
-use crate::sync::atomic::{Atomic, AtomicBool, AtomicPtr, Ordering};
+use crate::sync::atomic::Ordering;
 
-static SYSTEM_TABLE: Atomic<*mut c_void> = AtomicPtr::new(crate::ptr::null_mut());
-static IMAGE_HANDLE: Atomic<*mut c_void> = AtomicPtr::new(crate::ptr::null_mut());
-// Flag to check if BootServices are still valid.
-// Start with assuming that they are not available
-static BOOT_SERVICES_FLAG: Atomic<bool> = AtomicBool::new(false);
+#[doc(hidden)]
+#[cfg(not(test))]
+pub mod globals {
+    use crate::ffi::c_void;
+    use crate::sync::atomic::{Atomic, AtomicBool, AtomicPtr};
+
+    pub static SYSTEM_TABLE: Atomic<*mut c_void> = AtomicPtr::new(crate::ptr::null_mut());
+    pub static IMAGE_HANDLE: Atomic<*mut c_void> = AtomicPtr::new(crate::ptr::null_mut());
+    // Flag to check if BootServices are still valid.
+    // Start with assuming that they are not available
+    pub static BOOT_SERVICES_FLAG: Atomic<bool> = AtomicBool::new(false);
+}
+
+#[cfg(not(test))]
+use globals::*;
+#[cfg(test)]
+use realstd::os::uefi::env::globals::*;
 
 /// Initializes the global System Table and Image Handle pointers.
 ///


### PR DESCRIPTION
Export globals via a `doc(hidden)` module. In test code, use the globals from `realstd` so that they are properly initialized.

CC @Ayush1325 