### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -86,10 +86,7 @@ where
     }
 
     #[inline(always)]
-    fn query_state<'a>(self, qcx: QueryCtxt<'tcx>) -> &'a QueryState<'tcx, Self::Key>
-    where
-        QueryCtxt<'tcx>: 'a,
-    {
+    fn query_state(self, qcx: QueryCtxt<'tcx>) -> &'tcx QueryState<'tcx, Self::Key> {
         // Safety:
         // This is just manually doing the subfield referencing through pointer math.
         unsafe {
@@ -100,7 +97,7 @@ where
     }
 
     #[inline(always)]
-    fn query_cache<'a>(self, qcx: QueryCtxt<'tcx>) -> &'a Self::Cache {
+    fn query_cache(self, qcx: QueryCtxt<'tcx>) -> &'tcx Self::Cache {
         // Safety:
         // This is just manually doing the subfield referencing through pointer math.
         unsafe {
@@ -216,12 +213,12 @@ trait QueryDispatcherUnerased<'tcx> {
     ) -> Self::UnerasedValue;
 }
 
-pub fn query_system<'a>(
+pub fn query_system<'tcx>(
     local_providers: Providers,
     extern_providers: ExternProviders,
     on_disk_cache: Option<OnDiskCache>,
     incremental: bool,
-) -> QuerySystem<'a> {
+) -> QuerySystem<'tcx> {
     QuerySystem {
         states: Default::default(),
         arenas: Default::default(),

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -708,14 +708,18 @@ macro_rules! define_queries {
                 data: PhantomData<&'tcx ()>
             }
 
+            const FLAGS: QueryFlags = QueryFlags {
+                is_anon: is_anon!([$($modifiers)*]),
+                is_depth_limit: depth_limit!([$($modifiers)*]),
+                is_feedable: feedable!([$($modifiers)*]),
+            };
+
             impl<'tcx> QueryDispatcherUnerased<'tcx> for QueryType<'tcx> {
                 type UnerasedValue = queries::$name::Value<'tcx>;
                 type Dispatcher = SemiDynamicQueryDispatcher<
                     'tcx,
                     queries::$name::Storage<'tcx>,
-                    { is_anon!([$($modifiers)*]) },
-                    { depth_limit!([$($modifiers)*]) },
-                    { feedable!([$($modifiers)*]) },
+                    FLAGS,
                 >;
 
                 const NAME: &'static &'static str = &stringify!($name);

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -104,13 +104,6 @@ impl<'tcx> QueryContext<'tcx> for QueryCtxt<'tcx> {
         if complete { Ok(jobs) } else { Err(jobs) }
     }
 
-    fn lift_query_info(
-        self,
-        info: &QueryStackDeferred<'tcx>,
-    ) -> rustc_query_system::query::QueryStackFrameExtra {
-        info.extract()
-    }
-
     // Interactions with on_disk_cache
     fn load_side_effect(
         self,
@@ -174,10 +167,7 @@ impl<'tcx> QueryContext<'tcx> for QueryCtxt<'tcx> {
 
         self.tcx.sess.dcx().emit_fatal(QueryOverflow {
             span: info.job.span,
-            note: QueryOverflowNote {
-                desc: self.lift_query_info(&info.query.info).description,
-                depth,
-            },
+            note: QueryOverflowNote { desc: info.query.info.extract().description, depth },
             suggested_limit,
             crate_name: self.tcx.crate_name(LOCAL_CRATE),
         });

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -167,7 +167,7 @@ impl<'tcx> QueryContext<'tcx> for QueryCtxt<'tcx> {
 
         self.tcx.sess.dcx().emit_fatal(QueryOverflow {
             span: info.job.span,
-            note: QueryOverflowNote { desc: info.query.info.extract().description, depth },
+            note: QueryOverflowNote { desc: info.frame.info.extract().description, depth },
             suggested_limit,
             crate_name: self.tcx.crate_name(LOCAL_CRATE),
         });
@@ -728,14 +728,14 @@ macro_rules! define_queries {
                 qmap: &mut QueryMap<'tcx>,
                 require_complete: bool,
             ) -> Option<()> {
-                let make_query = |tcx, key| {
+                let make_frame = |tcx, key| {
                     let kind = rustc_middle::dep_graph::dep_kinds::$name;
                     let name = stringify!($name);
                     $crate::plumbing::create_query_frame(tcx, rustc_middle::query::descs::$name, key, kind, name)
                 };
                 let res = tcx.query_system.states.$name.collect_active_jobs(
                     tcx,
-                    make_query,
+                    make_frame,
                     qmap,
                     require_complete,
                 );

--- a/compiler/rustc_query_system/src/query/dispatcher.rs
+++ b/compiler/rustc_query_system/src/query/dispatcher.rs
@@ -25,7 +25,7 @@ type DepContextOf<'tcx, This: QueryDispatcher<'tcx>> =
 /// Those types are not visible from this `rustc_query_system` crate.
 ///
 /// "Dispatcher" should be understood as a near-synonym of "vtable".
-pub trait QueryDispatcher<'tcx>: Copy {
+pub trait QueryDispatcher<'tcx>: Copy + 'tcx {
     fn name(self) -> &'static str;
 
     /// Query context used by this dispatcher, i.e. `rustc_query_impl::QueryCtxt`.
@@ -41,10 +41,10 @@ pub trait QueryDispatcher<'tcx>: Copy {
     fn format_value(self) -> fn(&Self::Value) -> String;
 
     // Don't use this method to access query results, instead use the methods on TyCtxt
-    fn query_state<'a>(self, tcx: Self::Qcx) -> &'a QueryState<'tcx, Self::Key>;
+    fn query_state(self, tcx: Self::Qcx) -> &'tcx QueryState<'tcx, Self::Key>;
 
     // Don't use this method to access query results, instead use the methods on TyCtxt
-    fn query_cache<'a>(self, tcx: Self::Qcx) -> &'a Self::Cache;
+    fn query_cache(self, tcx: Self::Qcx) -> &'tcx Self::Cache;
 
     fn will_cache_on_disk_for_key(self, tcx: DepContextOf<'tcx, Self>, key: &Self::Key) -> bool;
 

--- a/compiler/rustc_query_system/src/query/job.rs
+++ b/compiler/rustc_query_system/src/query/job.rs
@@ -27,11 +27,8 @@ pub struct QueryInfo<I> {
 }
 
 impl<'tcx> QueryInfo<QueryStackDeferred<'tcx>> {
-    pub(crate) fn lift<Qcx: QueryContext<'tcx>>(
-        &self,
-        qcx: Qcx,
-    ) -> QueryInfo<QueryStackFrameExtra> {
-        QueryInfo { span: self.span, query: self.query.lift(qcx) }
+    pub(crate) fn lift(&self) -> QueryInfo<QueryStackFrameExtra> {
+        QueryInfo { span: self.span, query: self.query.lift() }
     }
 }
 
@@ -628,7 +625,7 @@ pub fn print_query_stack<'tcx, Qcx: QueryContext<'tcx>>(
         let Some(query_info) = query_map.get(&query) else {
             break;
         };
-        let query_extra = qcx.lift_query_info(&query_info.query.info);
+        let query_extra = query_info.query.info.extract();
         if Some(count_printed) < limit_frames || limit_frames.is_none() {
             // Only print to stderr as many stack frames as `num_frames` when present.
             dcx.struct_failure_note(format!(

--- a/compiler/rustc_query_system/src/query/job.rs
+++ b/compiler/rustc_query_system/src/query/job.rs
@@ -23,12 +23,12 @@ use crate::query::{QueryContext, QueryStackFrame};
 pub struct QueryInfo<I> {
     /// The span corresponding to the reason for which this query was required.
     pub span: Span,
-    pub query: QueryStackFrame<I>,
+    pub frame: QueryStackFrame<I>,
 }
 
 impl<'tcx> QueryInfo<QueryStackDeferred<'tcx>> {
     pub(crate) fn lift(&self) -> QueryInfo<QueryStackFrameExtra> {
-        QueryInfo { span: self.span, query: self.query.lift() }
+        QueryInfo { span: self.span, frame: self.frame.lift() }
     }
 }
 
@@ -39,8 +39,8 @@ pub type QueryMap<'tcx> = FxHashMap<QueryJobId, QueryJobInfo<'tcx>>;
 pub struct QueryJobId(pub NonZero<u64>);
 
 impl QueryJobId {
-    fn query<'a, 'tcx>(self, map: &'a QueryMap<'tcx>) -> QueryStackFrame<QueryStackDeferred<'tcx>> {
-        map.get(&self).unwrap().query.clone()
+    fn frame<'a, 'tcx>(self, map: &'a QueryMap<'tcx>) -> QueryStackFrame<QueryStackDeferred<'tcx>> {
+        map.get(&self).unwrap().frame.clone()
     }
 
     fn span<'a, 'tcx>(self, map: &'a QueryMap<'tcx>) -> Span {
@@ -58,7 +58,7 @@ impl QueryJobId {
 
 #[derive(Clone, Debug)]
 pub struct QueryJobInfo<'tcx> {
-    pub query: QueryStackFrame<QueryStackDeferred<'tcx>>,
+    pub frame: QueryStackFrame<QueryStackDeferred<'tcx>>,
     pub job: QueryJob<'tcx>,
 }
 
@@ -122,7 +122,7 @@ impl QueryJobId {
 
         while let Some(job) = current_job {
             let info = query_map.get(&job).unwrap();
-            cycle.push(QueryInfo { span: info.job.span, query: info.query.clone() });
+            cycle.push(QueryInfo { span: info.job.span, frame: info.frame.clone() });
 
             if job == *self {
                 cycle.reverse();
@@ -137,7 +137,7 @@ impl QueryJobId {
                     .job
                     .parent
                     .as_ref()
-                    .map(|parent| (info.job.span, parent.query(&query_map)));
+                    .map(|parent| (info.job.span, parent.frame(&query_map)));
                 return CycleError { usage, cycle };
             }
 
@@ -155,13 +155,13 @@ impl QueryJobId {
     ) -> (QueryJobInfo<'tcx>, usize) {
         let mut depth = 1;
         let info = query_map.get(&self).unwrap();
-        let dep_kind = info.query.dep_kind;
+        let dep_kind = info.frame.dep_kind;
         let mut current_id = info.job.parent;
         let mut last_layout = (info.clone(), depth);
 
         while let Some(id) = current_id {
             let info = query_map.get(&id).unwrap();
-            if info.query.dep_kind == dep_kind {
+            if info.frame.dep_kind == dep_kind {
                 depth += 1;
                 last_layout = (info.clone(), depth);
             }
@@ -386,7 +386,7 @@ where
         .iter()
         .min_by_key(|v| {
             let (span, query) = f(v);
-            let hash = query.query(query_map).hash;
+            let hash = query.frame(query_map).hash;
             // Prefer entry points which have valid spans for nicer error messages
             // We add an integer to the tuple ensuring that entry points
             // with valid spans are picked first
@@ -470,14 +470,14 @@ fn remove_cycle<'tcx>(
             stack.rotate_left(pos);
         }
 
-        let usage = usage.as_ref().map(|(span, query)| (*span, query.query(query_map)));
+        let usage = usage.as_ref().map(|(span, query)| (*span, query.frame(query_map)));
 
         // Create the cycle error
         let error = CycleError {
             usage,
             cycle: stack
                 .iter()
-                .map(|&(s, ref q)| QueryInfo { span: s, query: q.query(query_map) })
+                .map(|&(s, ref q)| QueryInfo { span: s, frame: q.frame(query_map) })
                 .collect(),
         };
 
@@ -556,7 +556,7 @@ pub fn report_cycle<'a>(
 ) -> Diag<'a> {
     assert!(!stack.is_empty());
 
-    let span = stack[0].query.info.default_span(stack[1 % stack.len()].span);
+    let span = stack[0].frame.info.default_span(stack[1 % stack.len()].span);
 
     let mut cycle_stack = Vec::new();
 
@@ -564,9 +564,9 @@ pub fn report_cycle<'a>(
     let stack_count = if stack.len() == 1 { StackCount::Single } else { StackCount::Multiple };
 
     for i in 1..stack.len() {
-        let query = &stack[i].query;
-        let span = query.info.default_span(stack[(i + 1) % stack.len()].span);
-        cycle_stack.push(CycleStack { span, desc: query.info.description.to_owned() });
+        let frame = &stack[i].frame;
+        let span = frame.info.default_span(stack[(i + 1) % stack.len()].span);
+        cycle_stack.push(CycleStack { span, desc: frame.info.description.to_owned() });
     }
 
     let mut cycle_usage = None;
@@ -578,9 +578,9 @@ pub fn report_cycle<'a>(
     }
 
     let alias =
-        if stack.iter().all(|entry| matches!(entry.query.info.def_kind, Some(DefKind::TyAlias))) {
+        if stack.iter().all(|entry| matches!(entry.frame.info.def_kind, Some(DefKind::TyAlias))) {
             Some(crate::error::Alias::Ty)
-        } else if stack.iter().all(|entry| entry.query.info.def_kind == Some(DefKind::TraitAlias)) {
+        } else if stack.iter().all(|entry| entry.frame.info.def_kind == Some(DefKind::TraitAlias)) {
             Some(crate::error::Alias::Trait)
         } else {
             None
@@ -589,7 +589,7 @@ pub fn report_cycle<'a>(
     let cycle_diag = crate::error::Cycle {
         span,
         cycle_stack,
-        stack_bottom: stack[0].query.info.description.to_owned(),
+        stack_bottom: stack[0].frame.info.description.to_owned(),
         alias,
         cycle_usage,
         stack_count,
@@ -625,12 +625,12 @@ pub fn print_query_stack<'tcx, Qcx: QueryContext<'tcx>>(
         let Some(query_info) = query_map.get(&query) else {
             break;
         };
-        let query_extra = query_info.query.info.extract();
+        let query_extra = query_info.frame.info.extract();
         if Some(count_printed) < limit_frames || limit_frames.is_none() {
             // Only print to stderr as many stack frames as `num_frames` when present.
             dcx.struct_failure_note(format!(
                 "#{} [{:?}] {}",
-                count_printed, query_info.query.dep_kind, query_extra.description
+                count_printed, query_info.frame.dep_kind, query_extra.description
             ))
             .with_span(query_info.job.span)
             .emit();
@@ -642,7 +642,7 @@ pub fn print_query_stack<'tcx, Qcx: QueryContext<'tcx>>(
                 file,
                 "#{} [{}] {}",
                 count_total,
-                qcx.dep_context().dep_kind_vtable(query_info.query.dep_kind).name,
+                qcx.dep_context().dep_kind_vtable(query_info.frame.dep_kind).name,
                 query_extra.description
             );
         }

--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -70,9 +70,9 @@ impl<'tcx> QueryStackFrame<QueryStackDeferred<'tcx>> {
         Self { info, def_id, dep_kind, hash, def_id_for_ty_in_cycle }
     }
 
-    fn lift<Qcx: QueryContext<'tcx>>(&self, qcx: Qcx) -> QueryStackFrame<QueryStackFrameExtra> {
+    fn lift(&self) -> QueryStackFrame<QueryStackFrameExtra> {
         QueryStackFrame {
-            info: qcx.lift_query_info(&self.info),
+            info: self.info.extract(),
             dep_kind: self.dep_kind,
             hash: self.hash,
             def_id: self.def_id,
@@ -167,8 +167,6 @@ pub trait QueryContext<'tcx>: HasDepContext {
     fn current_query_job(self) -> Option<QueryJobId>;
 
     fn collect_active_jobs(self, require_complete: bool) -> Result<QueryMap<'tcx>, QueryMap<'tcx>>;
-
-    fn lift_query_info(self, info: &QueryStackDeferred<'tcx>) -> QueryStackFrameExtra;
 
     /// Load a side effect associated to the node in the previous session.
     fn load_side_effect(

--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -181,6 +181,4 @@ pub trait QueryContext<'tcx>: HasDepContext {
     /// new query job while it executes.
     fn start_query<R>(self, token: QueryJobId, depth_limit: bool, compute: impl FnOnce() -> R)
     -> R;
-
-    fn depth_limit_error(self, job: QueryJobId);
 }

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -127,11 +127,11 @@ impl<'tcx, K> Default for QueryState<'tcx, K> {
 
 /// A type representing the responsibility to execute the job in the `job` field.
 /// This will poison the relevant query if dropped.
-struct JobOwner<'a, 'tcx, K>
+struct JobOwner<'tcx, K>
 where
     K: Eq + Hash + Copy,
 {
-    state: &'a QueryState<'tcx, K>,
+    state: &'tcx QueryState<'tcx, K>,
     key: K,
 }
 
@@ -181,7 +181,7 @@ where
     }
 }
 
-impl<'a, 'tcx, K> JobOwner<'a, 'tcx, K>
+impl<'tcx, K> JobOwner<'tcx, K>
 where
     K: Eq + Hash + Copy,
 {
@@ -218,7 +218,7 @@ where
     }
 }
 
-impl<'a, 'tcx, K> Drop for JobOwner<'a, 'tcx, K>
+impl<'tcx, K> Drop for JobOwner<'tcx, K>
 where
     K: Eq + Hash + Copy,
 {
@@ -422,7 +422,7 @@ where
 fn execute_job<'tcx, Q, const INCR: bool>(
     query: Q,
     qcx: Q::Qcx,
-    state: &QueryState<'tcx, Q::Key>,
+    state: &'tcx QueryState<'tcx, Q::Key>,
     key: Q::Key,
     key_hash: u64,
     id: QueryJobId,

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -253,10 +253,10 @@ pub struct CycleError<I = QueryStackFrameExtra> {
 }
 
 impl<'tcx> CycleError<QueryStackDeferred<'tcx>> {
-    fn lift<Qcx: QueryContext<'tcx>>(&self, qcx: Qcx) -> CycleError<QueryStackFrameExtra> {
+    fn lift(&self) -> CycleError<QueryStackFrameExtra> {
         CycleError {
-            usage: self.usage.as_ref().map(|(span, frame)| (*span, frame.lift(qcx))),
-            cycle: self.cycle.iter().map(|info| info.lift(qcx)).collect(),
+            usage: self.usage.as_ref().map(|(span, frame)| (*span, frame.lift())),
+            cycle: self.cycle.iter().map(|info| info.lift()).collect(),
         }
     }
 }
@@ -297,7 +297,7 @@ where
     let query_map = qcx.collect_active_jobs(false).ok().expect("failed to collect active queries");
 
     let error = try_execute.find_cycle_in_stack(query_map, &qcx.current_query_job(), span);
-    (mk_cycle(query, qcx, error.lift(qcx)), None)
+    (mk_cycle(query, qcx, error.lift()), None)
 }
 
 #[inline(always)]
@@ -345,7 +345,7 @@ where
 
             (v, Some(index))
         }
-        Err(cycle) => (mk_cycle(query, qcx, cycle.lift(qcx)), None),
+        Err(cycle) => (mk_cycle(query, qcx, cycle.lift()), None),
     }
 }
 

--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -108,6 +108,17 @@ pub mod consts {
     pub const FRAC_1_SQRT_3: f128 =
         0.577350269189625764509148780501957455647601751270126876018602_f128;
 
+    /// sqrt(5)
+    #[unstable(feature = "more_float_constants", issue = "146939")]
+    // Also, #[unstable(feature = "f128", issue = "116909")]
+    pub const SQRT_5: f128 = 2.23606797749978969640917366873127623544061835961152572427089_f128;
+
+    /// 1/sqrt(5)
+    #[unstable(feature = "more_float_constants", issue = "146939")]
+    // Also, #[unstable(feature = "f128", issue = "116909")]
+    pub const FRAC_1_SQRT_5: f128 =
+        0.447213595499957939281834733746255247088123671922305144854179_f128;
+
     /// Euler's number (e)
     #[unstable(feature = "f128", issue = "116909")]
     pub const E: f128 = 2.71828182845904523536028747135266249775724709369995957496697_f128;

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -103,6 +103,16 @@ pub mod consts {
     // Also, #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const FRAC_1_SQRT_3: f16 = 0.577350269189625764509148780501957456_f16;
 
+    /// sqrt(5)
+    #[unstable(feature = "more_float_constants", issue = "146939")]
+    // Also, #[unstable(feature = "f16", issue = "116909")]
+    pub const SQRT_5: f16 = 2.23606797749978969640917366873127623_f16;
+
+    /// 1/sqrt(5)
+    #[unstable(feature = "more_float_constants", issue = "146939")]
+    // Also, #[unstable(feature = "f16", issue = "116909")]
+    pub const FRAC_1_SQRT_5: f16 = 0.44721359549995793928183473374625524_f16;
+
     /// Euler's number (e)
     #[unstable(feature = "f16", issue = "116909")]
     pub const E: f16 = 2.71828182845904523536028747135266250_f16;

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -356,6 +356,14 @@ pub mod consts {
     #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const FRAC_1_SQRT_3: f32 = 0.577350269189625764509148780501957456_f32;
 
+    /// sqrt(5)
+    #[unstable(feature = "more_float_constants", issue = "146939")]
+    pub const SQRT_5: f32 = 2.23606797749978969640917366873127623_f32;
+
+    /// 1/sqrt(5)
+    #[unstable(feature = "more_float_constants", issue = "146939")]
+    pub const FRAC_1_SQRT_5: f32 = 0.44721359549995793928183473374625524_f32;
+
     /// Euler's number (e)
     #[stable(feature = "rust1", since = "1.0.0")]
     pub const E: f32 = 2.71828182845904523536028747135266250_f32;

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -356,6 +356,14 @@ pub mod consts {
     #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const FRAC_1_SQRT_3: f64 = 0.577350269189625764509148780501957456_f64;
 
+    /// sqrt(5)
+    #[unstable(feature = "more_float_constants", issue = "146939")]
+    pub const SQRT_5: f64 = 2.23606797749978969640917366873127623_f64;
+
+    /// 1/sqrt(5)
+    #[unstable(feature = "more_float_constants", issue = "146939")]
+    pub const FRAC_1_SQRT_5: f64 = 0.44721359549995793928183473374625524_f64;
+
     /// Euler's number (e)
     #[stable(feature = "rust1", since = "1.0.0")]
     pub const E: f64 = 2.71828182845904523536028747135266250_f64;

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -690,7 +690,7 @@ impl<T, E> Result<T, E> {
     /// Converts from `Result<T, E>` to [`Option<T>`].
     ///
     /// Converts `self` into an [`Option<T>`], consuming `self`,
-    /// and discarding the error, if any.
+    /// and converting the error to `None`, if any.
     ///
     /// # Examples
     ///

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -260,6 +260,7 @@
     all(target_vendor = "fortanix", target_env = "sgx"),
     feature(slice_index_methods, coerce_unsized, sgx_platform)
 )]
+#![cfg_attr(all(test, target_os = "uefi"), feature(uefi_std))]
 #![cfg_attr(target_family = "wasm", feature(stdarch_wasm_atomic_wait))]
 #![cfg_attr(target_arch = "wasm64", feature(simd_wasm64))]
 //

--- a/library/std/src/os/uefi/env.rs
+++ b/library/std/src/os/uefi/env.rs
@@ -4,13 +4,25 @@
 
 use crate::ffi::c_void;
 use crate::ptr::NonNull;
-use crate::sync::atomic::{Atomic, AtomicBool, AtomicPtr, Ordering};
+use crate::sync::atomic::Ordering;
 
-static SYSTEM_TABLE: Atomic<*mut c_void> = AtomicPtr::new(crate::ptr::null_mut());
-static IMAGE_HANDLE: Atomic<*mut c_void> = AtomicPtr::new(crate::ptr::null_mut());
-// Flag to check if BootServices are still valid.
-// Start with assuming that they are not available
-static BOOT_SERVICES_FLAG: Atomic<bool> = AtomicBool::new(false);
+#[doc(hidden)]
+#[cfg(not(test))]
+pub mod globals {
+    use crate::ffi::c_void;
+    use crate::sync::atomic::{Atomic, AtomicBool, AtomicPtr};
+
+    pub static SYSTEM_TABLE: Atomic<*mut c_void> = AtomicPtr::new(crate::ptr::null_mut());
+    pub static IMAGE_HANDLE: Atomic<*mut c_void> = AtomicPtr::new(crate::ptr::null_mut());
+    // Flag to check if BootServices are still valid.
+    // Start with assuming that they are not available
+    pub static BOOT_SERVICES_FLAG: Atomic<bool> = AtomicBool::new(false);
+}
+
+#[cfg(not(test))]
+use globals::*;
+#[cfg(test)]
+use realstd::os::uefi::env::globals::*;
 
 /// Initializes the global System Table and Image Handle pointers.
 ///


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#151938 (Use `#![feature(adt_const_params)]` for static query flags)
 - rust-lang/rust#151825 (more float constants)
 - rust-lang/rust#151974 (Update documentation for `Result::ok()`)
 - rust-lang/rust#151978 (Query cleanups)
 - rust-lang/rust#151979 (Fix uninitialized UEFI globals in tests)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=151938,151825,151974,151978,151979)
<!-- homu-ignore:end -->

