### PR TITLE
Fix missing unused_variables lint when using a match guard

### DIFF
--- a/src/tools/clippy/clippy_lints/src/time_subtraction.rs
+++ b/src/tools/clippy/clippy_lints/src/time_subtraction.rs
@@ -85,7 +85,7 @@ impl LateLintPass<'_> for UncheckedTimeSubtraction {
     fn check_expr(&mut self, cx: &LateContext<'_>, expr: &'_ Expr<'_>) {
         let (lhs, rhs) = match expr.kind {
             ExprKind::Binary(op, lhs, rhs) if matches!(op.node, BinOpKind::Sub,) => (lhs, rhs),
-            ExprKind::MethodCall(fn_name, lhs, [rhs], _) if cx.ty_based_def(expr).is_diag_item(cx, sym::sub) => {
+            ExprKind::MethodCall(_, lhs, [rhs], _) if cx.ty_based_def(expr).is_diag_item(cx, sym::sub) => {
                 (lhs, rhs)
             },
             _ => return,

--- a/tests/ui/lint/unused/match_with_guard.rs
+++ b/tests/ui/lint/unused/match_with_guard.rs
@@ -1,0 +1,10 @@
+//! The mere presence of a match guard should not deem bound variables "used".
+//! Regression test for https://github.com/rust-lang/rust/issues/151983
+//@ check-pass
+#![warn(unused)]
+fn main() {
+    match Some(42) {
+        Some(unused) if true => (), //~WARN unused variable: `unused`
+        _ => (),
+    }
+}

--- a/tests/ui/lint/unused/match_with_guard.stderr
+++ b/tests/ui/lint/unused/match_with_guard.stderr
@@ -1,0 +1,15 @@
+warning: unused variable: `unused`
+  --> $DIR/match_with_guard.rs:7:14
+   |
+LL |         Some(unused) if true => (),
+   |              ^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused`
+   |
+note: the lint level is defined here
+  --> $DIR/match_with_guard.rs:4:9
+   |
+LL | #![warn(unused)]
+   |         ^^^^^^
+   = note: `#[warn(unused_variables)]` implied by `#[warn(unused)]`
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Within a binding pattern match guard, only real reads of a bound local impact its liveness analysis - not the fake read that is injected.

Fixes rust-lang/rust#151983
r? compiler