### PR TITLE
Add uv to the list of possible python runners

### DIFF
--- a/x
+++ b/x
@@ -29,16 +29,19 @@ xpy=$(dirname "$(realpath "$0")")/x.py
 # On MacOS, `py` tries to install "Developer command line tools". Try `python3` first.
 # NOTE: running `bash -c ./x` from Windows doesn't set OSTYPE.
 case ${OSTYPE:-} in
-    cygwin*|msys*) SEARCH="py python3 python python2";;
-    *) SEARCH="python3 python py python2";;
+    cygwin*|msys*) SEARCH="py python3 python python2 uv";;
+    *) SEARCH="python3 python py python2 uv";;
 esac
 for SEARCH_PYTHON in $SEARCH; do
     if python=$(command -v $SEARCH_PYTHON) && [ -x "$python" ]; then
-        if [ $SEARCH_PYTHON = py ]; then
-            extra_arg="-3"
-        else
-            extra_arg=""
-        fi
+        case $SEARCH_PYTHON in
+            py)
+                extra_arg="-3";;
+            uv)
+                extra_arg="run";;
+            *)
+                extra_arg="";;
+        esac
         exec "$python" $extra_arg "$xpy" "$@"
     fi
 done


### PR DESCRIPTION
Fixes the unlikely case that one has uv, but not python, globally installed

(It's me, I'm the unlikely case)

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
