### PR TITLE
switch to v0 mangling by default on stable

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1483,11 +1483,7 @@ impl Options {
     }
 
     pub fn get_symbol_mangling_version(&self) -> SymbolManglingVersion {
-        self.cg.symbol_mangling_version.unwrap_or(if self.unstable_features.is_nightly_build() {
-            SymbolManglingVersion::V0
-        } else {
-            SymbolManglingVersion::Legacy
-        })
+        self.cg.symbol_mangling_version.unwrap_or(SymbolManglingVersion::V0)
     }
 
     #[inline]

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2194,7 +2194,7 @@ options! {
         "tell the linker which information to strip (`none` (default), `debuginfo` or `symbols`)"),
     symbol_mangling_version: Option<SymbolManglingVersion> = (None,
         parse_symbol_mangling_version, [TRACKED],
-        "which mangling version to use for symbol names ('legacy' (default), 'v0', or 'hashed')"),
+        "which mangling version to use for symbol names ('legacy', 'v0' (default), or 'hashed')"),
     target_cpu: Option<String> = (None, parse_opt_string, [TRACKED],
         "select target processor (`rustc --print target-cpus` for details)"),
     target_feature: String = (String::new(), parse_target_feature, [TRACKED],

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -664,16 +664,6 @@ impl Builder<'_> {
             rustflags.arg(sysroot_str);
         }
 
-        let use_new_symbol_mangling = self.config.rust_new_symbol_mangling.or_else(|| {
-            if mode != Mode::Std {
-                // The compiler and tools default to the new scheme
-                Some(true)
-            } else {
-                // std follows the flag's default, which per compiler-team#938 is v0 on nightly
-                None
-            }
-        });
-
         // By default, windows-rs depends on a native library that doesn't get copied into the
         // sysroot. Passing this cfg enables raw-dylib support instead, which makes the native
         // library unnecessary. This can be removed when windows-rs enables raw-dylib
@@ -683,7 +673,8 @@ impl Builder<'_> {
             rustflags.arg("--cfg=windows_raw_dylib");
         }
 
-        if let Some(usm) = use_new_symbol_mangling {
+        // When unset, follow the default of the compiler flag - the compiler, tools and std use v0
+        if let Some(usm) = self.config.rust_new_symbol_mangling {
             rustflags.arg(if usm {
                 "-Csymbol-mangling-version=v0"
             } else {

--- a/src/doc/rustc/src/symbol-mangling/index.md
+++ b/src/doc/rustc/src/symbol-mangling/index.md
@@ -46,7 +46,6 @@ foo::example_function
 
 ## Mangling versions
 
-`rustc` supports different mangling versions which encode the names in different ways.
-The legacy version (which is currently the default on beta/stable) is not described here.
-The "v0" mangling scheme addresses several limitations of the legacy format,
-and is described in the [v0 Symbol Format](v0.md) chapter.
+There is currently one stable mangling scheme version - `v0`. On nightly builds, rustc supports
+switching back to the `legacy` mangling scheme using [`-C symbol-mangling-version`]. The `v0`
+mangling scheme is described in the [v0 Symbol Format](v0.md) chapter.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/151994)*
<!-- homu-ignore:end -->

Following rust-lang/rust#89117, rustc has defaulted to the v0 mangling scheme by default (since Nov 20th 2025). This surfaced two bugs:

- rust-lang/rust#138261 was a small ICE (found via fuzzing) where an implementation-internal namespace was missing for global assembly - this occurs with names instantiated within global assembly (that can happen inside constants)

- rust-lang/rust#134479 only occurs with unstable `generic_const_exprs`

Since there have been three-to-four months for users to find bugs with this mangling scheme on nightly, that the scheme has been waiting many years to be stabilised, and has been used successfully internally at Microsoft, Meta and Google for many years, this patch proposes stabilising the v0 mangling scheme on stable.

This patch does not propose removing the legacy mangling, it will remain usable on nightly as an escape-hatch if there are remaining bugs (though admittedly it would require switching to nightly for those on stable) - it is anticipated that this would be unlikely given current testing undergone by v0. Legacy mangling can be removed in another follow-up.

r? @wesleywiser
