### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/compiler/rustc_attr_parsing/messages.ftl
+++ b/compiler/rustc_attr_parsing/messages.ftl
@@ -53,6 +53,9 @@ attr_parsing_expects_feature_list =
 attr_parsing_expects_features =
     `{$name}` expects feature names
 
+attr_parsing_export_symbols_needs_static =
+    linking modifier `export-symbols` is only compatible with `static` linking kind
+
 attr_parsing_import_name_type_raw =
     import name type can only be used with link kind `raw-dylib`
 
@@ -95,7 +98,7 @@ attr_parsing_invalid_issue_string =
     .neg_overflow = number too small to fit in target type
 
 attr_parsing_invalid_link_modifier =
-    invalid linking modifier syntax, expected '+' or '-' prefix before one of: bundle, verbatim, whole-archive, as-needed
+    invalid linking modifier syntax, expected '+' or '-' prefix before one of: bundle, verbatim, whole-archive, as-needed, export-symbols
 
 attr_parsing_invalid_meta_item = expected a literal (`1u8`, `1.0f32`, `"string"`, etc.) here, found {$descr}
     .remove_neg_sugg = negative numbers are not literals, try removing the `-` sign

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -307,6 +307,14 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcHasIncoherentInherentImplsParse
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcHasIncoherentInherentImpls;
 }
 
+pub(crate) struct RustcHiddenTypeOfOpaquesParser;
+
+impl<S: Stage> NoArgsAttributeParser<S> for RustcHiddenTypeOfOpaquesParser {
+    const PATH: &[Symbol] = &[sym::rustc_hidden_type_of_opaques];
+    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
+    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcHiddenTypeOfOpaques;
+}
 pub(crate) struct RustcNounwindParser;
 
 impl<S: Stage> NoArgsAttributeParser<S> for RustcNounwindParser {

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -75,13 +75,14 @@ use crate::attributes::rustc_dump::{
     RustcDumpVtable,
 };
 use crate::attributes::rustc_internal::{
-    RustcHasIncoherentInherentImplsParser, RustcLayoutParser, RustcLayoutScalarValidRangeEndParser,
-    RustcLayoutScalarValidRangeStartParser, RustcLegacyConstGenericsParser,
-    RustcLintOptDenyFieldAccessParser, RustcLintOptTyParser, RustcLintQueryInstabilityParser,
-    RustcLintUntrackedQueryInformationParser, RustcMainParser, RustcMustImplementOneOfParser,
-    RustcNeverReturnsNullPointerParser, RustcNoImplicitAutorefsParser,
-    RustcNonConstTraitMethodParser, RustcNounwindParser, RustcObjectLifetimeDefaultParser,
-    RustcOffloadKernelParser, RustcScalableVectorParser, RustcSimdMonomorphizeLaneLimitParser,
+    RustcHasIncoherentInherentImplsParser, RustcHiddenTypeOfOpaquesParser, RustcLayoutParser,
+    RustcLayoutScalarValidRangeEndParser, RustcLayoutScalarValidRangeStartParser,
+    RustcLegacyConstGenericsParser, RustcLintOptDenyFieldAccessParser, RustcLintOptTyParser,
+    RustcLintQueryInstabilityParser, RustcLintUntrackedQueryInformationParser, RustcMainParser,
+    RustcMustImplementOneOfParser, RustcNeverReturnsNullPointerParser,
+    RustcNoImplicitAutorefsParser, RustcNonConstTraitMethodParser, RustcNounwindParser,
+    RustcObjectLifetimeDefaultParser, RustcOffloadKernelParser, RustcScalableVectorParser,
+    RustcSimdMonomorphizeLaneLimitParser,
 };
 use crate::attributes::semantics::MayDangleParser;
 use crate::attributes::stability::{
@@ -299,6 +300,7 @@ attribute_parsers!(
         Single<WithoutArgs<RustcDumpUserArgs>>,
         Single<WithoutArgs<RustcDumpVtable>>,
         Single<WithoutArgs<RustcHasIncoherentInherentImplsParser>>,
+        Single<WithoutArgs<RustcHiddenTypeOfOpaquesParser>>,
         Single<WithoutArgs<RustcLintOptTyParser>>,
         Single<WithoutArgs<RustcLintQueryInstabilityParser>>,
         Single<WithoutArgs<RustcLintUntrackedQueryInformationParser>>,

--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -915,6 +915,13 @@ pub(crate) struct BundleNeedsStatic {
 }
 
 #[derive(Diagnostic)]
+#[diag(attr_parsing_export_symbols_needs_static)]
+pub(crate) struct ExportSymbolsNeedsStatic {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(attr_parsing_whole_archive_needs_static)]
 pub(crate) struct WholeArchiveNeedsStatic {
     #[primary_span]

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -2312,12 +2312,12 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
             tcx: TyCtxt<'hir>,
             issue_span: Span,
             expr_span: Span,
-            body_expr: Option<&'hir hir::Expr<'hir>>,
-            loop_bind: Option<&'hir Ident>,
-            loop_span: Option<Span>,
-            head_span: Option<Span>,
-            pat_span: Option<Span>,
-            head: Option<&'hir hir::Expr<'hir>>,
+            body_expr: Option<&'hir hir::Expr<'hir>> = None,
+            loop_bind: Option<&'hir Ident> = None,
+            loop_span: Option<Span> = None,
+            head_span: Option<Span> = None,
+            pat_span: Option<Span> = None,
+            head: Option<&'hir hir::Expr<'hir>> = None,
         }
         impl<'hir> Visitor<'hir> for ExprFinder<'hir> {
             fn visit_expr(&mut self, ex: &'hir hir::Expr<'hir>) {
@@ -2383,17 +2383,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 hir::intravisit::walk_expr(self, ex);
             }
         }
-        let mut finder = ExprFinder {
-            tcx,
-            expr_span: span,
-            issue_span,
-            loop_bind: None,
-            body_expr: None,
-            head_span: None,
-            loop_span: None,
-            pat_span: None,
-            head: None,
-        };
+        let mut finder = ExprFinder { tcx, expr_span: span, issue_span, .. };
         finder.visit_expr(tcx.hir_body(body_id).value);
 
         if let Some(body_expr) = finder.body_expr
@@ -2628,13 +2618,13 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
 
         struct ExpressionFinder<'tcx> {
             capture_span: Span,
-            closure_change_spans: Vec<Span>,
-            closure_arg_span: Option<Span>,
-            in_closure: bool,
-            suggest_arg: String,
+            closure_change_spans: Vec<Span> = vec![],
+            closure_arg_span: Option<Span> = None,
+            in_closure: bool = false,
+            suggest_arg: String = String::new(),
             tcx: TyCtxt<'tcx>,
-            closure_local_id: Option<hir::HirId>,
-            closure_call_changes: Vec<(Span, String)>,
+            closure_local_id: Option<hir::HirId> = None,
+            closure_call_changes: Vec<(Span, String)> = vec![],
         }
         impl<'hir> Visitor<'hir> for ExpressionFinder<'hir> {
             fn visit_expr(&mut self, e: &'hir hir::Expr<'hir>) {
@@ -2715,16 +2705,8 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         }) = self.infcx.tcx.hir_node(self.mir_hir_id())
             && let hir::Node::Expr(expr) = self.infcx.tcx.hir_node(body_id.hir_id)
         {
-            let mut finder = ExpressionFinder {
-                capture_span: *capture_kind_span,
-                closure_change_spans: vec![],
-                closure_arg_span: None,
-                in_closure: false,
-                suggest_arg: String::new(),
-                closure_local_id: None,
-                closure_call_changes: vec![],
-                tcx: self.infcx.tcx,
-            };
+            let mut finder =
+                ExpressionFinder { capture_span: *capture_kind_span, tcx: self.infcx.tcx, .. };
             finder.visit_expr(expr);
 
             if finder.closure_change_spans.is_empty() || finder.closure_call_changes.is_empty() {

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -4,6 +4,7 @@
 #![allow(internal_features)]
 #![feature(assert_matches)]
 #![feature(box_patterns)]
+#![feature(default_field_values)]
 #![feature(file_buffered)]
 #![feature(if_let_guard)]
 #![feature(negative_impls)]

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -331,6 +331,8 @@ pub enum NativeLibKind {
         bundle: Option<bool>,
         /// Whether to link static library without throwing any object files away
         whole_archive: Option<bool>,
+        /// Whether to export c static library symbols
+        export_symbols: Option<bool>,
     },
     /// Dynamic library (e.g. `libfoo.so` on Linux)
     /// or an import library corresponding to a dynamic library (e.g. `foo.lib` on Windows/MSVC).
@@ -363,8 +365,8 @@ pub enum NativeLibKind {
 impl NativeLibKind {
     pub fn has_modifiers(&self) -> bool {
         match self {
-            NativeLibKind::Static { bundle, whole_archive } => {
-                bundle.is_some() || whole_archive.is_some()
+            NativeLibKind::Static { bundle, whole_archive, export_symbols } => {
+                bundle.is_some() || whole_archive.is_some() || export_symbols.is_some()
             }
             NativeLibKind::Dylib { as_needed }
             | NativeLibKind::Framework { as_needed }

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -1057,6 +1057,9 @@ pub enum AttributeKind {
     /// Represents `#[rustc_has_incoherent_inherent_impls]`
     RustcHasIncoherentInherentImpls,
 
+    /// Represents `#[rustc_hidden_type_of_opaques]`
+    RustcHiddenTypeOfOpaques,
+
     /// Represents `#[rustc_layout]`
     RustcLayout(ThinVec<RustcLayoutType>),
 

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -111,6 +111,7 @@ impl AttributeKind {
             RustcDumpVtable(..) => No,
             RustcDynIncompatibleTrait(..) => No,
             RustcHasIncoherentInherentImpls => Yes,
+            RustcHiddenTypeOfOpaques => No,
             RustcLayout(..) => No,
             RustcLayoutScalarValidRangeEnd(..) => Yes,
             RustcLayoutScalarValidRangeStart(..) => Yes,

--- a/compiler/rustc_hir_analysis/src/collect/dump.rs
+++ b/compiler/rustc_hir_analysis/src/collect/dump.rs
@@ -7,10 +7,9 @@ use rustc_middle::ty::{self, TyCtxt, TypeVisitableExt};
 use rustc_span::sym;
 
 pub(crate) fn opaque_hidden_types(tcx: TyCtxt<'_>) {
-    if !tcx.has_attr(CRATE_DEF_ID, sym::rustc_hidden_type_of_opaques) {
+    if !find_attr!(tcx.get_all_attrs(CRATE_DEF_ID), AttributeKind::RustcHiddenTypeOfOpaques) {
         return;
     }
-
     for id in tcx.hir_crate_items(()).opaques() {
         if let hir::OpaqueTyOrigin::FnReturn { parent: fn_def_id, .. }
         | hir::OpaqueTyOrigin::AsyncFn { parent: fn_def_id, .. } =

--- a/compiler/rustc_hir_analysis/src/hir_wf_check.rs
+++ b/compiler/rustc_hir_analysis/src/hir_wf_check.rs
@@ -51,12 +51,12 @@ pub(super) fn diagnostic_hir_wf_check<'tcx>(
     struct HirWfCheck<'tcx> {
         tcx: TyCtxt<'tcx>,
         predicate: ty::Predicate<'tcx>,
-        cause: Option<ObligationCause<'tcx>>,
-        cause_depth: usize,
+        cause: Option<ObligationCause<'tcx>> = None,
+        cause_depth: usize = 0,
         icx: ItemCtxt<'tcx>,
         def_id: LocalDefId,
         param_env: ty::ParamEnv<'tcx>,
-        depth: usize,
+        depth: usize = 0,
     }
 
     impl<'tcx> Visitor<'tcx> for HirWfCheck<'tcx> {
@@ -124,16 +124,8 @@ pub(super) fn diagnostic_hir_wf_check<'tcx>(
         }
     }
 
-    let mut visitor = HirWfCheck {
-        tcx,
-        predicate,
-        cause: None,
-        cause_depth: 0,
-        icx,
-        def_id,
-        param_env: tcx.param_env(def_id.to_def_id()),
-        depth: 0,
-    };
+    let param_env = tcx.param_env(def_id.to_def_id());
+    let mut visitor = HirWfCheck { tcx, predicate, icx, def_id, param_env, .. };
 
     // Get the starting `hir::Ty` using our `WellFormedLoc`.
     // We will walk 'into' this type to try to find

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -59,6 +59,7 @@ This API is completely unstable and subject to change.
 #![allow(rustc::diagnostic_outside_of_impl)]
 #![allow(rustc::untranslatable_diagnostic)]
 #![feature(assert_matches)]
+#![feature(default_field_values)]
 #![feature(gen_blocks)]
 #![feature(if_let_guard)]
 #![feature(iter_intersperse)]

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -379,7 +379,7 @@ fn test_native_libs_tracking_hash_different_values() {
         NativeLib {
             name: String::from("a"),
             new_name: None,
-            kind: NativeLibKind::Static { bundle: None, whole_archive: None },
+            kind: NativeLibKind::Static { bundle: None, whole_archive: None, export_symbols: None },
             verbatim: None,
         },
         NativeLib {
@@ -401,7 +401,7 @@ fn test_native_libs_tracking_hash_different_values() {
         NativeLib {
             name: String::from("a"),
             new_name: None,
-            kind: NativeLibKind::Static { bundle: None, whole_archive: None },
+            kind: NativeLibKind::Static { bundle: None, whole_archive: None, export_symbols: None },
             verbatim: None,
         },
         NativeLib {
@@ -423,13 +423,13 @@ fn test_native_libs_tracking_hash_different_values() {
         NativeLib {
             name: String::from("a"),
             new_name: None,
-            kind: NativeLibKind::Static { bundle: None, whole_archive: None },
+            kind: NativeLibKind::Static { bundle: None, whole_archive: None, export_symbols: None },
             verbatim: None,
         },
         NativeLib {
             name: String::from("b"),
             new_name: None,
-            kind: NativeLibKind::Static { bundle: None, whole_archive: None },
+            kind: NativeLibKind::Static { bundle: None, whole_archive: None, export_symbols: None },
             verbatim: None,
         },
         NativeLib {
@@ -445,7 +445,7 @@ fn test_native_libs_tracking_hash_different_values() {
         NativeLib {
             name: String::from("a"),
             new_name: None,
-            kind: NativeLibKind::Static { bundle: None, whole_archive: None },
+            kind: NativeLibKind::Static { bundle: None, whole_archive: None, export_symbols: None },
             verbatim: None,
         },
         NativeLib {
@@ -467,7 +467,7 @@ fn test_native_libs_tracking_hash_different_values() {
         NativeLib {
             name: String::from("a"),
             new_name: None,
-            kind: NativeLibKind::Static { bundle: None, whole_archive: None },
+            kind: NativeLibKind::Static { bundle: None, whole_archive: None, export_symbols: None },
             verbatim: None,
         },
         NativeLib {
@@ -501,7 +501,7 @@ fn test_native_libs_tracking_hash_different_order() {
         NativeLib {
             name: String::from("a"),
             new_name: None,
-            kind: NativeLibKind::Static { bundle: None, whole_archive: None },
+            kind: NativeLibKind::Static { bundle: None, whole_archive: None, export_symbols: None },
             verbatim: None,
         },
         NativeLib {
@@ -528,7 +528,7 @@ fn test_native_libs_tracking_hash_different_order() {
         NativeLib {
             name: String::from("a"),
             new_name: None,
-            kind: NativeLibKind::Static { bundle: None, whole_archive: None },
+            kind: NativeLibKind::Static { bundle: None, whole_archive: None, export_symbols: None },
             verbatim: None,
         },
         NativeLib {
@@ -549,7 +549,7 @@ fn test_native_libs_tracking_hash_different_order() {
         NativeLib {
             name: String::from("a"),
             new_name: None,
-            kind: NativeLibKind::Static { bundle: None, whole_archive: None },
+            kind: NativeLibKind::Static { bundle: None, whole_archive: None, export_symbols: None },
             verbatim: None,
         },
         NativeLib {

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -161,7 +161,7 @@ fn find_bundled_library(
     tcx: TyCtxt<'_>,
 ) -> Option<Symbol> {
     let sess = tcx.sess;
-    if let NativeLibKind::Static { bundle: Some(true) | None, whole_archive } = kind
+    if let NativeLibKind::Static { bundle: Some(true) | None, whole_archive, .. } = kind
         && tcx.crate_types().iter().any(|t| matches!(t, &CrateType::Rlib | CrateType::StaticLib))
         && (sess.opts.unstable_opts.packed_bundled_libs || has_cfg || whole_archive == Some(true))
     {

--- a/compiler/rustc_middle/src/mir/statement.rs
+++ b/compiler/rustc_middle/src/mir/statement.rs
@@ -441,6 +441,8 @@ impl<'tcx> Place<'tcx> {
     where
         D: ?Sized + HasLocalDecls<'tcx>,
     {
+        // If there's a field projection element in `projection`, we *could* skip everything
+        // before that, but on 2026-01-31 a perf experiment showed no benefit from doing so.
         PlaceTy::from_ty(local_decls.local_decls()[local].ty).multi_projection_ty(tcx, projection)
     }
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -299,6 +299,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     | AttributeKind::RustcDumpVtable(..)
                     | AttributeKind::RustcDynIncompatibleTrait(..)
                     | AttributeKind::RustcHasIncoherentInherentImpls
+                    | AttributeKind::RustcHiddenTypeOfOpaques
                     | AttributeKind::RustcLayout(..)
                     | AttributeKind::RustcLayoutScalarValidRangeEnd(..)
                     | AttributeKind::RustcLayoutScalarValidRangeStart(..)
@@ -390,7 +391,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                             | sym::rustc_capture_analysis
                             | sym::rustc_regions
                             | sym::rustc_strict_coherence
-                            | sym::rustc_hidden_type_of_opaques
                             | sym::rustc_mir
                             | sym::rustc_effective_visibility
                             | sym::rustc_outlives

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -86,10 +86,7 @@ where
     }
 
     #[inline(always)]
-    fn query_state<'a>(self, qcx: QueryCtxt<'tcx>) -> &'a QueryState<'tcx, Self::Key>
-    where
-        QueryCtxt<'tcx>: 'a,
-    {
+    fn query_state(self, qcx: QueryCtxt<'tcx>) -> &'tcx QueryState<'tcx, Self::Key> {
         // Safety:
         // This is just manually doing the subfield referencing through pointer math.
         unsafe {
@@ -100,7 +97,7 @@ where
     }
 
     #[inline(always)]
-    fn query_cache<'a>(self, qcx: QueryCtxt<'tcx>) -> &'a Self::Cache {
+    fn query_cache(self, qcx: QueryCtxt<'tcx>) -> &'tcx Self::Cache {
         // Safety:
         // This is just manually doing the subfield referencing through pointer math.
         unsafe {
@@ -216,12 +213,12 @@ trait QueryDispatcherUnerased<'tcx> {
     ) -> Self::UnerasedValue;
 }
 
-pub fn query_system<'a>(
+pub fn query_system<'tcx>(
     local_providers: Providers,
     extern_providers: ExternProviders,
     on_disk_cache: Option<OnDiskCache>,
     incremental: bool,
-) -> QuerySystem<'a> {
+) -> QuerySystem<'tcx> {
     QuerySystem {
         states: Default::default(),
         arenas: Default::default(),

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -708,14 +708,18 @@ macro_rules! define_queries {
                 data: PhantomData<&'tcx ()>
             }
 
+            const FLAGS: QueryFlags = QueryFlags {
+                is_anon: is_anon!([$($modifiers)*]),
+                is_depth_limit: depth_limit!([$($modifiers)*]),
+                is_feedable: feedable!([$($modifiers)*]),
+            };
+
             impl<'tcx> QueryDispatcherUnerased<'tcx> for QueryType<'tcx> {
                 type UnerasedValue = queries::$name::Value<'tcx>;
                 type Dispatcher = SemiDynamicQueryDispatcher<
                     'tcx,
                     queries::$name::Storage<'tcx>,
-                    { is_anon!([$($modifiers)*]) },
-                    { depth_limit!([$($modifiers)*]) },
-                    { feedable!([$($modifiers)*]) },
+                    FLAGS,
                 >;
 
                 const NAME: &'static &'static str = &stringify!($name);

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -104,13 +104,6 @@ impl<'tcx> QueryContext<'tcx> for QueryCtxt<'tcx> {
         if complete { Ok(jobs) } else { Err(jobs) }
     }
 
-    fn lift_query_info(
-        self,
-        info: &QueryStackDeferred<'tcx>,
-    ) -> rustc_query_system::query::QueryStackFrameExtra {
-        info.extract()
-    }
-
     // Interactions with on_disk_cache
     fn load_side_effect(
         self,
@@ -174,10 +167,7 @@ impl<'tcx> QueryContext<'tcx> for QueryCtxt<'tcx> {
 
         self.tcx.sess.dcx().emit_fatal(QueryOverflow {
             span: info.job.span,
-            note: QueryOverflowNote {
-                desc: self.lift_query_info(&info.query.info).description,
-                depth,
-            },
+            note: QueryOverflowNote { desc: info.query.info.extract().description, depth },
             suggested_limit,
             crate_name: self.tcx.crate_name(LOCAL_CRATE),
         });

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -167,7 +167,7 @@ impl<'tcx> QueryContext<'tcx> for QueryCtxt<'tcx> {
 
         self.tcx.sess.dcx().emit_fatal(QueryOverflow {
             span: info.job.span,
-            note: QueryOverflowNote { desc: info.query.info.extract().description, depth },
+            note: QueryOverflowNote { desc: info.frame.info.extract().description, depth },
             suggested_limit,
             crate_name: self.tcx.crate_name(LOCAL_CRATE),
         });
@@ -728,14 +728,14 @@ macro_rules! define_queries {
                 qmap: &mut QueryMap<'tcx>,
                 require_complete: bool,
             ) -> Option<()> {
-                let make_query = |tcx, key| {
+                let make_frame = |tcx, key| {
                     let kind = rustc_middle::dep_graph::dep_kinds::$name;
                     let name = stringify!($name);
                     $crate::plumbing::create_query_frame(tcx, rustc_middle::query::descs::$name, key, kind, name)
                 };
                 let res = tcx.query_system.states.$name.collect_active_jobs(
                     tcx,
-                    make_query,
+                    make_frame,
                     qmap,
                     require_complete,
                 );

--- a/compiler/rustc_query_system/src/query/dispatcher.rs
+++ b/compiler/rustc_query_system/src/query/dispatcher.rs
@@ -25,7 +25,7 @@ type DepContextOf<'tcx, This: QueryDispatcher<'tcx>> =
 /// Those types are not visible from this `rustc_query_system` crate.
 ///
 /// "Dispatcher" should be understood as a near-synonym of "vtable".
-pub trait QueryDispatcher<'tcx>: Copy {
+pub trait QueryDispatcher<'tcx>: Copy + 'tcx {
     fn name(self) -> &'static str;
 
     /// Query context used by this dispatcher, i.e. `rustc_query_impl::QueryCtxt`.
@@ -41,10 +41,10 @@ pub trait QueryDispatcher<'tcx>: Copy {
     fn format_value(self) -> fn(&Self::Value) -> String;
 
     // Don't use this method to access query results, instead use the methods on TyCtxt
-    fn query_state<'a>(self, tcx: Self::Qcx) -> &'a QueryState<'tcx, Self::Key>;
+    fn query_state(self, tcx: Self::Qcx) -> &'tcx QueryState<'tcx, Self::Key>;
 
     // Don't use this method to access query results, instead use the methods on TyCtxt
-    fn query_cache<'a>(self, tcx: Self::Qcx) -> &'a Self::Cache;
+    fn query_cache(self, tcx: Self::Qcx) -> &'tcx Self::Cache;
 
     fn will_cache_on_disk_for_key(self, tcx: DepContextOf<'tcx, Self>, key: &Self::Key) -> bool;
 

--- a/compiler/rustc_query_system/src/query/job.rs
+++ b/compiler/rustc_query_system/src/query/job.rs
@@ -27,11 +27,8 @@ pub struct QueryInfo<I> {
 }
 
 impl<'tcx> QueryInfo<QueryStackDeferred<'tcx>> {
-    pub(crate) fn lift<Qcx: QueryContext<'tcx>>(
-        &self,
-        qcx: Qcx,
-    ) -> QueryInfo<QueryStackFrameExtra> {
-        QueryInfo { span: self.span, query: self.query.lift(qcx) }
+    pub(crate) fn lift(&self) -> QueryInfo<QueryStackFrameExtra> {
+        QueryInfo { span: self.span, query: self.query.lift() }
     }
 }
 
@@ -628,7 +625,7 @@ pub fn print_query_stack<'tcx, Qcx: QueryContext<'tcx>>(
         let Some(query_info) = query_map.get(&query) else {
             break;
         };
-        let query_extra = qcx.lift_query_info(&query_info.query.info);
+        let query_extra = query_info.query.info.extract();
         if Some(count_printed) < limit_frames || limit_frames.is_none() {
             // Only print to stderr as many stack frames as `num_frames` when present.
             dcx.struct_failure_note(format!(

--- a/compiler/rustc_query_system/src/query/job.rs
+++ b/compiler/rustc_query_system/src/query/job.rs
@@ -23,12 +23,12 @@ use crate::query::{QueryContext, QueryStackFrame};
 pub struct QueryInfo<I> {
     /// The span corresponding to the reason for which this query was required.
     pub span: Span,
-    pub query: QueryStackFrame<I>,
+    pub frame: QueryStackFrame<I>,
 }
 
 impl<'tcx> QueryInfo<QueryStackDeferred<'tcx>> {
     pub(crate) fn lift(&self) -> QueryInfo<QueryStackFrameExtra> {
-        QueryInfo { span: self.span, query: self.query.lift() }
+        QueryInfo { span: self.span, frame: self.frame.lift() }
     }
 }
 
@@ -39,8 +39,8 @@ pub type QueryMap<'tcx> = FxHashMap<QueryJobId, QueryJobInfo<'tcx>>;
 pub struct QueryJobId(pub NonZero<u64>);
 
 impl QueryJobId {
-    fn query<'a, 'tcx>(self, map: &'a QueryMap<'tcx>) -> QueryStackFrame<QueryStackDeferred<'tcx>> {
-        map.get(&self).unwrap().query.clone()
+    fn frame<'a, 'tcx>(self, map: &'a QueryMap<'tcx>) -> QueryStackFrame<QueryStackDeferred<'tcx>> {
+        map.get(&self).unwrap().frame.clone()
     }
 
     fn span<'a, 'tcx>(self, map: &'a QueryMap<'tcx>) -> Span {
@@ -58,7 +58,7 @@ impl QueryJobId {
 
 #[derive(Clone, Debug)]
 pub struct QueryJobInfo<'tcx> {
-    pub query: QueryStackFrame<QueryStackDeferred<'tcx>>,
+    pub frame: QueryStackFrame<QueryStackDeferred<'tcx>>,
     pub job: QueryJob<'tcx>,
 }
 
@@ -122,7 +122,7 @@ impl QueryJobId {
 
         while let Some(job) = current_job {
             let info = query_map.get(&job).unwrap();
-            cycle.push(QueryInfo { span: info.job.span, query: info.query.clone() });
+            cycle.push(QueryInfo { span: info.job.span, frame: info.frame.clone() });
 
             if job == *self {
                 cycle.reverse();
@@ -137,7 +137,7 @@ impl QueryJobId {
                     .job
                     .parent
                     .as_ref()
-                    .map(|parent| (info.job.span, parent.query(&query_map)));
+                    .map(|parent| (info.job.span, parent.frame(&query_map)));
                 return CycleError { usage, cycle };
             }
 
@@ -155,13 +155,13 @@ impl QueryJobId {
     ) -> (QueryJobInfo<'tcx>, usize) {
         let mut depth = 1;
         let info = query_map.get(&self).unwrap();
-        let dep_kind = info.query.dep_kind;
+        let dep_kind = info.frame.dep_kind;
         let mut current_id = info.job.parent;
         let mut last_layout = (info.clone(), depth);
 
         while let Some(id) = current_id {
             let info = query_map.get(&id).unwrap();
-            if info.query.dep_kind == dep_kind {
+            if info.frame.dep_kind == dep_kind {
                 depth += 1;
                 last_layout = (info.clone(), depth);
             }
@@ -386,7 +386,7 @@ where
         .iter()
         .min_by_key(|v| {
             let (span, query) = f(v);
-            let hash = query.query(query_map).hash;
+            let hash = query.frame(query_map).hash;
             // Prefer entry points which have valid spans for nicer error messages
             // We add an integer to the tuple ensuring that entry points
             // with valid spans are picked first
@@ -470,14 +470,14 @@ fn remove_cycle<'tcx>(
             stack.rotate_left(pos);
         }
 
-        let usage = usage.as_ref().map(|(span, query)| (*span, query.query(query_map)));
+        let usage = usage.as_ref().map(|(span, query)| (*span, query.frame(query_map)));
 
         // Create the cycle error
         let error = CycleError {
             usage,
             cycle: stack
                 .iter()
-                .map(|&(s, ref q)| QueryInfo { span: s, query: q.query(query_map) })
+                .map(|&(s, ref q)| QueryInfo { span: s, frame: q.frame(query_map) })
                 .collect(),
         };
 
@@ -556,7 +556,7 @@ pub fn report_cycle<'a>(
 ) -> Diag<'a> {
     assert!(!stack.is_empty());
 
-    let span = stack[0].query.info.default_span(stack[1 % stack.len()].span);
+    let span = stack[0].frame.info.default_span(stack[1 % stack.len()].span);
 
     let mut cycle_stack = Vec::new();
 
@@ -564,9 +564,9 @@ pub fn report_cycle<'a>(
     let stack_count = if stack.len() == 1 { StackCount::Single } else { StackCount::Multiple };
 
     for i in 1..stack.len() {
-        let query = &stack[i].query;
-        let span = query.info.default_span(stack[(i + 1) % stack.len()].span);
-        cycle_stack.push(CycleStack { span, desc: query.info.description.to_owned() });
+        let frame = &stack[i].frame;
+        let span = frame.info.default_span(stack[(i + 1) % stack.len()].span);
+        cycle_stack.push(CycleStack { span, desc: frame.info.description.to_owned() });
     }
 
     let mut cycle_usage = None;
@@ -578,9 +578,9 @@ pub fn report_cycle<'a>(
     }
 
     let alias =
-        if stack.iter().all(|entry| matches!(entry.query.info.def_kind, Some(DefKind::TyAlias))) {
+        if stack.iter().all(|entry| matches!(entry.frame.info.def_kind, Some(DefKind::TyAlias))) {
             Some(crate::error::Alias::Ty)
-        } else if stack.iter().all(|entry| entry.query.info.def_kind == Some(DefKind::TraitAlias)) {
+        } else if stack.iter().all(|entry| entry.frame.info.def_kind == Some(DefKind::TraitAlias)) {
             Some(crate::error::Alias::Trait)
         } else {
             None
@@ -589,7 +589,7 @@ pub fn report_cycle<'a>(
     let cycle_diag = crate::error::Cycle {
         span,
         cycle_stack,
-        stack_bottom: stack[0].query.info.description.to_owned(),
+        stack_bottom: stack[0].frame.info.description.to_owned(),
         alias,
         cycle_usage,
         stack_count,
@@ -625,12 +625,12 @@ pub fn print_query_stack<'tcx, Qcx: QueryContext<'tcx>>(
         let Some(query_info) = query_map.get(&query) else {
             break;
         };
-        let query_extra = query_info.query.info.extract();
+        let query_extra = query_info.frame.info.extract();
         if Some(count_printed) < limit_frames || limit_frames.is_none() {
             // Only print to stderr as many stack frames as `num_frames` when present.
             dcx.struct_failure_note(format!(
                 "#{} [{:?}] {}",
-                count_printed, query_info.query.dep_kind, query_extra.description
+                count_printed, query_info.frame.dep_kind, query_extra.description
             ))
             .with_span(query_info.job.span)
             .emit();
@@ -642,7 +642,7 @@ pub fn print_query_stack<'tcx, Qcx: QueryContext<'tcx>>(
                 file,
                 "#{} [{}] {}",
                 count_total,
-                qcx.dep_context().dep_kind_vtable(query_info.query.dep_kind).name,
+                qcx.dep_context().dep_kind_vtable(query_info.frame.dep_kind).name,
                 query_extra.description
             );
         }

--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -70,9 +70,9 @@ impl<'tcx> QueryStackFrame<QueryStackDeferred<'tcx>> {
         Self { info, def_id, dep_kind, hash, def_id_for_ty_in_cycle }
     }
 
-    fn lift<Qcx: QueryContext<'tcx>>(&self, qcx: Qcx) -> QueryStackFrame<QueryStackFrameExtra> {
+    fn lift(&self) -> QueryStackFrame<QueryStackFrameExtra> {
         QueryStackFrame {
-            info: qcx.lift_query_info(&self.info),
+            info: self.info.extract(),
             dep_kind: self.dep_kind,
             hash: self.hash,
             def_id: self.def_id,
@@ -167,8 +167,6 @@ pub trait QueryContext<'tcx>: HasDepContext {
     fn current_query_job(self) -> Option<QueryJobId>;
 
     fn collect_active_jobs(self, require_complete: bool) -> Result<QueryMap<'tcx>, QueryMap<'tcx>>;
-
-    fn lift_query_info(self, info: &QueryStackDeferred<'tcx>) -> QueryStackFrameExtra;
 
     /// Load a side effect associated to the node in the previous session.
     fn load_side_effect(

--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -181,6 +181,4 @@ pub trait QueryContext<'tcx>: HasDepContext {
     /// new query job while it executes.
     fn start_query<R>(self, token: QueryJobId, depth_limit: bool, compute: impl FnOnce() -> R)
     -> R;
-
-    fn depth_limit_error(self, job: QueryJobId);
 }

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -127,11 +127,11 @@ impl<'tcx, K> Default for QueryState<'tcx, K> {
 
 /// A type representing the responsibility to execute the job in the `job` field.
 /// This will poison the relevant query if dropped.
-struct JobOwner<'a, 'tcx, K>
+struct JobOwner<'tcx, K>
 where
     K: Eq + Hash + Copy,
 {
-    state: &'a QueryState<'tcx, K>,
+    state: &'tcx QueryState<'tcx, K>,
     key: K,
 }
 
@@ -181,7 +181,7 @@ where
     }
 }
 
-impl<'a, 'tcx, K> JobOwner<'a, 'tcx, K>
+impl<'tcx, K> JobOwner<'tcx, K>
 where
     K: Eq + Hash + Copy,
 {
@@ -218,7 +218,7 @@ where
     }
 }
 
-impl<'a, 'tcx, K> Drop for JobOwner<'a, 'tcx, K>
+impl<'tcx, K> Drop for JobOwner<'tcx, K>
 where
     K: Eq + Hash + Copy,
 {
@@ -422,7 +422,7 @@ where
 fn execute_job<'tcx, Q, const INCR: bool>(
     query: Q,
     qcx: Q::Qcx,
-    state: &QueryState<'tcx, Q::Key>,
+    state: &'tcx QueryState<'tcx, Q::Key>,
     key: Q::Key,
     key_hash: u64,
     id: QueryJobId,

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -253,10 +253,10 @@ pub struct CycleError<I = QueryStackFrameExtra> {
 }
 
 impl<'tcx> CycleError<QueryStackDeferred<'tcx>> {
-    fn lift<Qcx: QueryContext<'tcx>>(&self, qcx: Qcx) -> CycleError<QueryStackFrameExtra> {
+    fn lift(&self) -> CycleError<QueryStackFrameExtra> {
         CycleError {
-            usage: self.usage.as_ref().map(|(span, frame)| (*span, frame.lift(qcx))),
-            cycle: self.cycle.iter().map(|info| info.lift(qcx)).collect(),
+            usage: self.usage.as_ref().map(|(span, frame)| (*span, frame.lift())),
+            cycle: self.cycle.iter().map(|info| info.lift()).collect(),
         }
     }
 }
@@ -297,7 +297,7 @@ where
     let query_map = qcx.collect_active_jobs(false).ok().expect("failed to collect active queries");
 
     let error = try_execute.find_cycle_in_stack(query_map, &qcx.current_query_job(), span);
-    (mk_cycle(query, qcx, error.lift(qcx)), None)
+    (mk_cycle(query, qcx, error.lift()), None)
 }
 
 #[inline(always)]
@@ -345,7 +345,7 @@ where
 
             (v, Some(index))
         }
-        Err(cycle) => (mk_cycle(query, qcx, cycle.lift(qcx)), None),
+        Err(cycle) => (mk_cycle(query, qcx, cycle.lift()), None),
     }
 }
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1001,6 +1001,7 @@ symbols! {
         explicit_tail_calls,
         export_name,
         export_stable,
+        export_symbols: "export-symbols",
         expr,
         expr_2021,
         expr_fragment_specifier_2024,

--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -108,6 +108,17 @@ pub mod consts {
     pub const FRAC_1_SQRT_3: f128 =
         0.577350269189625764509148780501957455647601751270126876018602_f128;
 
+    /// sqrt(5)
+    #[unstable(feature = "more_float_constants", issue = "146939")]
+    // Also, #[unstable(feature = "f128", issue = "116909")]
+    pub const SQRT_5: f128 = 2.23606797749978969640917366873127623544061835961152572427089_f128;
+
+    /// 1/sqrt(5)
+    #[unstable(feature = "more_float_constants", issue = "146939")]
+    // Also, #[unstable(feature = "f128", issue = "116909")]
+    pub const FRAC_1_SQRT_5: f128 =
+        0.447213595499957939281834733746255247088123671922305144854179_f128;
+
     /// Euler's number (e)
     #[unstable(feature = "f128", issue = "116909")]
     pub const E: f128 = 2.71828182845904523536028747135266249775724709369995957496697_f128;

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -103,6 +103,16 @@ pub mod consts {
     // Also, #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const FRAC_1_SQRT_3: f16 = 0.577350269189625764509148780501957456_f16;
 
+    /// sqrt(5)
+    #[unstable(feature = "more_float_constants", issue = "146939")]
+    // Also, #[unstable(feature = "f16", issue = "116909")]
+    pub const SQRT_5: f16 = 2.23606797749978969640917366873127623_f16;
+
+    /// 1/sqrt(5)
+    #[unstable(feature = "more_float_constants", issue = "146939")]
+    // Also, #[unstable(feature = "f16", issue = "116909")]
+    pub const FRAC_1_SQRT_5: f16 = 0.44721359549995793928183473374625524_f16;
+
     /// Euler's number (e)
     #[unstable(feature = "f16", issue = "116909")]
     pub const E: f16 = 2.71828182845904523536028747135266250_f16;

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -356,6 +356,14 @@ pub mod consts {
     #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const FRAC_1_SQRT_3: f32 = 0.577350269189625764509148780501957456_f32;
 
+    /// sqrt(5)
+    #[unstable(feature = "more_float_constants", issue = "146939")]
+    pub const SQRT_5: f32 = 2.23606797749978969640917366873127623_f32;
+
+    /// 1/sqrt(5)
+    #[unstable(feature = "more_float_constants", issue = "146939")]
+    pub const FRAC_1_SQRT_5: f32 = 0.44721359549995793928183473374625524_f32;
+
     /// Euler's number (e)
     #[stable(feature = "rust1", since = "1.0.0")]
     pub const E: f32 = 2.71828182845904523536028747135266250_f32;

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -356,6 +356,14 @@ pub mod consts {
     #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const FRAC_1_SQRT_3: f64 = 0.577350269189625764509148780501957456_f64;
 
+    /// sqrt(5)
+    #[unstable(feature = "more_float_constants", issue = "146939")]
+    pub const SQRT_5: f64 = 2.23606797749978969640917366873127623_f64;
+
+    /// 1/sqrt(5)
+    #[unstable(feature = "more_float_constants", issue = "146939")]
+    pub const FRAC_1_SQRT_5: f64 = 0.44721359549995793928183473374625524_f64;
+
     /// Euler's number (e)
     #[stable(feature = "rust1", since = "1.0.0")]
     pub const E: f64 = 2.71828182845904523536028747135266250_f64;

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -690,7 +690,7 @@ impl<T, E> Result<T, E> {
     /// Converts from `Result<T, E>` to [`Option<T>`].
     ///
     /// Converts `self` into an [`Option<T>`], consuming `self`,
-    /// and discarding the error, if any.
+    /// and converting the error to `None`, if any.
     ///
     /// # Examples
     ///

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -260,6 +260,7 @@
     all(target_vendor = "fortanix", target_env = "sgx"),
     feature(slice_index_methods, coerce_unsized, sgx_platform)
 )]
+#![cfg_attr(all(test, target_os = "uefi"), feature(uefi_std))]
 #![cfg_attr(target_family = "wasm", feature(stdarch_wasm_atomic_wait))]
 #![cfg_attr(target_arch = "wasm64", feature(simd_wasm64))]
 //

--- a/library/std/src/os/uefi/env.rs
+++ b/library/std/src/os/uefi/env.rs
@@ -4,13 +4,25 @@
 
 use crate::ffi::c_void;
 use crate::ptr::NonNull;
-use crate::sync::atomic::{Atomic, AtomicBool, AtomicPtr, Ordering};
+use crate::sync::atomic::Ordering;
 
-static SYSTEM_TABLE: Atomic<*mut c_void> = AtomicPtr::new(crate::ptr::null_mut());
-static IMAGE_HANDLE: Atomic<*mut c_void> = AtomicPtr::new(crate::ptr::null_mut());
-// Flag to check if BootServices are still valid.
-// Start with assuming that they are not available
-static BOOT_SERVICES_FLAG: Atomic<bool> = AtomicBool::new(false);
+#[doc(hidden)]
+#[cfg(not(test))]
+pub mod globals {
+    use crate::ffi::c_void;
+    use crate::sync::atomic::{Atomic, AtomicBool, AtomicPtr};
+
+    pub static SYSTEM_TABLE: Atomic<*mut c_void> = AtomicPtr::new(crate::ptr::null_mut());
+    pub static IMAGE_HANDLE: Atomic<*mut c_void> = AtomicPtr::new(crate::ptr::null_mut());
+    // Flag to check if BootServices are still valid.
+    // Start with assuming that they are not available
+    pub static BOOT_SERVICES_FLAG: Atomic<bool> = AtomicBool::new(false);
+}
+
+#[cfg(not(test))]
+use globals::*;
+#[cfg(test)]
+use realstd::os::uefi::env::globals::*;
 
 /// Initializes the global System Table and Image Handle pointers.
 ///

--- a/src/tools/compiletest/src/directives/auxiliary/tests.rs
+++ b/src/tools/compiletest/src/directives/auxiliary/tests.rs
@@ -25,3 +25,19 @@ fn test_aux_crate_value_with_modifiers() {
 fn test_aux_crate_value_invalid() {
     parse_aux_crate("foo.rs".to_string());
 }
+
+#[test]
+fn test_proc_macro_value_no_modifiers() {
+    assert_eq!(
+        ProcMacro { extern_modifiers: None, path: "foo.rs".to_string() },
+        parse_proc_macro("foo.rs".to_string())
+    );
+}
+
+#[test]
+fn test_proc_macro_value_with_modifiers() {
+    assert_eq!(
+        ProcMacro { extern_modifiers: Some("noprelude".to_string()), path: "foo.rs".to_string() },
+        parse_proc_macro("noprelude:foo.rs".to_string())
+    );
+}

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1302,7 +1302,7 @@ impl<'test> TestCx<'test> {
             let crate_name = path_to_crate_name(&proc_macro.path);
             add_extern(
                 rustc,
-                None, // `extern_modifiers`
+                proc_macro.extern_modifiers.as_deref(),
                 &crate_name,
                 &proc_macro.path,
                 AuxType::ProcMacro,

--- a/tests/run-make/cdylib-export-c-library-symbols/foo.c
+++ b/tests/run-make/cdylib-export-c-library-symbols/foo.c
@@ -1,0 +1,1 @@
+void my_function() {}

--- a/tests/run-make/cdylib-export-c-library-symbols/foo.rs
+++ b/tests/run-make/cdylib-export-c-library-symbols/foo.rs
@@ -1,0 +1,10 @@
+extern "C" {
+    pub fn my_function();
+}
+
+#[no_mangle]
+pub extern "C" fn rust_entry() {
+    unsafe {
+        my_function();
+    }
+}

--- a/tests/run-make/cdylib-export-c-library-symbols/foo_export.rs
+++ b/tests/run-make/cdylib-export-c-library-symbols/foo_export.rs
@@ -1,0 +1,10 @@
+extern "C" {
+    fn my_function();
+}
+
+#[no_mangle]
+pub extern "C" fn rust_entry() {
+    unsafe {
+        my_function();
+    }
+}

--- a/tests/run-make/cdylib-export-c-library-symbols/rmake.rs
+++ b/tests/run-make/cdylib-export-c-library-symbols/rmake.rs
@@ -1,0 +1,34 @@
+//@ ignore-nvptx64
+//@ ignore-wasm
+//@ ignore-i686-pc-windows-msvc
+// FIXME:The symbol mangle rules are slightly different in 32-bit Windows. Need to be resolved.
+//@ ignore-cross-compile
+// Reason: the compiled binary is executed
+
+use run_make_support::{build_native_static_lib, cc, dynamic_lib_name, is_darwin, llvm_nm, rustc};
+
+fn main() {
+    cc().input("foo.c").arg("-c").out_exe("foo.o").run();
+    build_native_static_lib("foo");
+
+    rustc().input("foo.rs").arg("-lstatic=foo").crate_type("cdylib").run();
+
+    let out = llvm_nm()
+        .input(dynamic_lib_name("foo"))
+        .run()
+        .assert_stdout_not_contains_regex("T *my_function");
+
+    rustc().input("foo_export.rs").arg("-lstatic:+export-symbols=foo").crate_type("cdylib").run();
+
+    if is_darwin() {
+        let out = llvm_nm()
+            .input(dynamic_lib_name("foo_export"))
+            .run()
+            .assert_stdout_contains("T _my_function");
+    } else {
+        let out = llvm_nm()
+            .input(dynamic_lib_name("foo_export"))
+            .run()
+            .assert_stdout_contains("T my_function");
+    }
+}

--- a/tests/ui/feature-gates/feature-gate-link-arg-attribute.in_flag.stderr
+++ b/tests/ui/feature-gates/feature-gate-link-arg-attribute.in_flag.stderr
@@ -1,2 +1,2 @@
-error: unknown linking modifier `link-arg`, expected one of: bundle, verbatim, whole-archive, as-needed
+error: unknown linking modifier `link-arg`, expected one of: bundle, verbatim, whole-archive, as-needed, export-symbols
 

--- a/tests/ui/link-native-libs/link-arg-error2.rs
+++ b/tests/ui/link-native-libs/link-arg-error2.rs
@@ -1,0 +1,5 @@
+//@ compile-flags: -l link-arg:+export-symbols=arg -Z unstable-options
+
+fn main() {}
+
+//~? ERROR linking modifier `export-symbols` is only compatible with `static` linking kind

--- a/tests/ui/link-native-libs/link-arg-error2.stderr
+++ b/tests/ui/link-native-libs/link-arg-error2.stderr
@@ -1,0 +1,2 @@
+error: linking modifier `export-symbols` is only compatible with `static` linking kind
+

--- a/tests/ui/link-native-libs/link-arg-from-rs2.rs
+++ b/tests/ui/link-native-libs/link-arg-from-rs2.rs
@@ -1,0 +1,7 @@
+#![feature(link_arg_attribute)]
+
+#[link(kind = "link-arg", name = "arg", modifiers = "+export-symbols")]
+//~^ ERROR linking modifier `export-symbols` is only compatible with `static` linking kind
+extern "C" {}
+
+pub fn main() {}

--- a/tests/ui/link-native-libs/link-arg-from-rs2.stderr
+++ b/tests/ui/link-native-libs/link-arg-from-rs2.stderr
@@ -1,0 +1,8 @@
+error: linking modifier `export-symbols` is only compatible with `static` linking kind
+  --> $DIR/link-arg-from-rs2.rs:3:53
+   |
+LL | #[link(kind = "link-arg", name = "arg", modifiers = "+export-symbols")]
+   |                                                     ^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/link-native-libs/link-attr-validation-late.stderr
+++ b/tests/ui/link-native-libs/link-attr-validation-late.stderr
@@ -178,13 +178,13 @@ LL | #[link(name = "...", wasm_import_module())]
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
-error: invalid linking modifier syntax, expected '+' or '-' prefix before one of: bundle, verbatim, whole-archive, as-needed
+error: invalid linking modifier syntax, expected '+' or '-' prefix before one of: bundle, verbatim, whole-archive, as-needed, export-symbols
   --> $DIR/link-attr-validation-late.rs:31:34
    |
 LL | #[link(name = "...", modifiers = "")]
    |                                  ^^
 
-error: invalid linking modifier syntax, expected '+' or '-' prefix before one of: bundle, verbatim, whole-archive, as-needed
+error: invalid linking modifier syntax, expected '+' or '-' prefix before one of: bundle, verbatim, whole-archive, as-needed, export-symbols
   --> $DIR/link-attr-validation-late.rs:32:34
    |
 LL | #[link(name = "...", modifiers = "no-plus-minus")]
@@ -196,7 +196,7 @@ error[E0539]: malformed `link` attribute input
 LL | #[link(name = "...", modifiers = "+unknown")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------^^
    |                                  |
-   |                                  valid arguments are "bundle", "verbatim", "whole-archive" or "as-needed"
+   |                                  valid arguments are "bundle", "export-symbols", "verbatim", "whole-archive" or "as-needed"
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 

--- a/tests/ui/link-native-libs/modifiers-bad.blank.stderr
+++ b/tests/ui/link-native-libs/modifiers-bad.blank.stderr
@@ -1,2 +1,2 @@
-error: invalid linking modifier syntax, expected '+' or '-' prefix before one of: bundle, verbatim, whole-archive, as-needed
+error: invalid linking modifier syntax, expected '+' or '-' prefix before one of: bundle, verbatim, whole-archive, as-needed, export-symbols
 

--- a/tests/ui/link-native-libs/modifiers-bad.no-prefix.stderr
+++ b/tests/ui/link-native-libs/modifiers-bad.no-prefix.stderr
@@ -1,2 +1,2 @@
-error: invalid linking modifier syntax, expected '+' or '-' prefix before one of: bundle, verbatim, whole-archive, as-needed
+error: invalid linking modifier syntax, expected '+' or '-' prefix before one of: bundle, verbatim, whole-archive, as-needed, export-symbols
 

--- a/tests/ui/link-native-libs/modifiers-bad.prefix-only.stderr
+++ b/tests/ui/link-native-libs/modifiers-bad.prefix-only.stderr
@@ -1,2 +1,2 @@
-error: unknown linking modifier ``, expected one of: bundle, verbatim, whole-archive, as-needed
+error: unknown linking modifier ``, expected one of: bundle, verbatim, whole-archive, as-needed, export-symbols
 

--- a/tests/ui/link-native-libs/modifiers-bad.unknown.stderr
+++ b/tests/ui/link-native-libs/modifiers-bad.unknown.stderr
@@ -1,2 +1,2 @@
-error: unknown linking modifier `ferris`, expected one of: bundle, verbatim, whole-archive, as-needed
+error: unknown linking modifier `ferris`, expected one of: bundle, verbatim, whole-archive, as-needed, export-symbols
 

--- a/tests/ui/privacy/pub-priv-dep/auxiliary/pm.rs
+++ b/tests/ui/privacy/pub-priv-dep/auxiliary/pm.rs
@@ -1,8 +1,3 @@
-//@ force-host
-//@ no-prefer-dynamic
-
-#![crate_type = "proc-macro"]
-
 extern crate proc_macro;
 use proc_macro::TokenStream;
 

--- a/tests/ui/privacy/pub-priv-dep/pub-priv1.rs
+++ b/tests/ui/privacy/pub-priv-dep/pub-priv1.rs
@@ -1,6 +1,6 @@
 //@ aux-crate:priv:priv_dep=priv_dep.rs
 //@ aux-build:pub_dep.rs
-//@ aux-crate:priv:pm=pm.rs
+//@ proc-macro:priv:pm.rs
 //@ compile-flags: -Zunstable-options
 
 // Basic behavior check of exported_private_dependencies from either a public

--- a/tests/ui/traits/next-solver/generalize/relate-alias-in-lub.rs
+++ b/tests/ui/traits/next-solver/generalize/relate-alias-in-lub.rs
@@ -1,0 +1,30 @@
+//@ revisions: old next
+//@[next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@ check-pass
+// Reproduces https://github.com/rust-lang/rust/pull/151746#issuecomment-3822930803.
+//
+// The change we tried to make there caused relating a type variable with an alias inside lub,
+// In 5bd20bbd0ba6c0285664e55a1ffc677d7487c98b, we moved around code
+// that adds an alias-relate predicate to be earlier, from one shared codepath into several
+// distinct code paths. However, we forgot one codepath, through lub, causing an ICE in serde.
+// In the end we dropped said commit, but the reproducer is still a useful as test.
+
+use std::marker::PhantomData;
+
+pub trait Trait {
+    type Error;
+}
+
+pub struct Struct<E>(PhantomData<E>);
+
+impl Trait for () {
+    type Error = ();
+}
+
+fn main() {
+    let _: Struct<<() as Trait>::Error> = match loop {} {
+        b => loop {},
+        a => Struct(PhantomData),
+    };
+}

--- a/tests/ui/traits/next-solver/generalize/relate-alias-in-lub.rs
+++ b/tests/ui/traits/next-solver/generalize/relate-alias-in-lub.rs
@@ -7,7 +7,7 @@
 // The change we tried to make there caused relating a type variable with an alias inside lub,
 // In 5bd20bbd0ba6c0285664e55a1ffc677d7487c98b, we moved around code
 // that adds an alias-relate predicate to be earlier, from one shared codepath into several
-// distinct code paths. However, we forgot one codepath, through lub, causing an ICE in serde.
+// distinct code paths. However, we forgot the codepath in `LatticeOp`, causing an ICE in serde.
 // In the end we dropped said commit, but the reproducer is still a useful as test.
 
 use std::marker::PhantomData;


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#150992 (link modifier `export-symbols`: export all global symbols from selected uptream c static libraries)
 - rust-lang/rust#151695 (compiletest: Support `--extern` modifiers with `proc-macro` directive)
 - rust-lang/rust#151938 (Use `#![feature(adt_const_params)]` for static query flags)
 - rust-lang/rust#151172 (Use default field values in a few more cases)
 - rust-lang/rust#151825 (more float constants)
 - rust-lang/rust#151870 (regression test for alias-relate changes in lub)
 - rust-lang/rust#151902 (explain why we dont skip some of this work when there are field projections)
 - rust-lang/rust#151974 (Update documentation for `Result::ok()`)
 - rust-lang/rust#151978 (Query cleanups)
 - rust-lang/rust#151979 (Fix uninitialized UEFI globals in tests)
 - rust-lang/rust#151992 (Port `#[rustc_hidden_type_of_opaque]` to attribute parser)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=150992,151695,151938,151172,151825,151870,151902,151974,151978,151979,151992)
<!-- homu-ignore:end -->

