### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -307,6 +307,14 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcHasIncoherentInherentImplsParse
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcHasIncoherentInherentImpls;
 }
 
+pub(crate) struct RustcHiddenTypeOfOpaquesParser;
+
+impl<S: Stage> NoArgsAttributeParser<S> for RustcHiddenTypeOfOpaquesParser {
+    const PATH: &[Symbol] = &[sym::rustc_hidden_type_of_opaques];
+    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
+    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcHiddenTypeOfOpaques;
+}
 pub(crate) struct RustcNounwindParser;
 
 impl<S: Stage> NoArgsAttributeParser<S> for RustcNounwindParser {

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -75,13 +75,14 @@ use crate::attributes::rustc_dump::{
     RustcDumpVtable,
 };
 use crate::attributes::rustc_internal::{
-    RustcHasIncoherentInherentImplsParser, RustcLayoutParser, RustcLayoutScalarValidRangeEndParser,
-    RustcLayoutScalarValidRangeStartParser, RustcLegacyConstGenericsParser,
-    RustcLintOptDenyFieldAccessParser, RustcLintOptTyParser, RustcLintQueryInstabilityParser,
-    RustcLintUntrackedQueryInformationParser, RustcMainParser, RustcMustImplementOneOfParser,
-    RustcNeverReturnsNullPointerParser, RustcNoImplicitAutorefsParser,
-    RustcNonConstTraitMethodParser, RustcNounwindParser, RustcObjectLifetimeDefaultParser,
-    RustcOffloadKernelParser, RustcScalableVectorParser, RustcSimdMonomorphizeLaneLimitParser,
+    RustcHasIncoherentInherentImplsParser, RustcHiddenTypeOfOpaquesParser, RustcLayoutParser,
+    RustcLayoutScalarValidRangeEndParser, RustcLayoutScalarValidRangeStartParser,
+    RustcLegacyConstGenericsParser, RustcLintOptDenyFieldAccessParser, RustcLintOptTyParser,
+    RustcLintQueryInstabilityParser, RustcLintUntrackedQueryInformationParser, RustcMainParser,
+    RustcMustImplementOneOfParser, RustcNeverReturnsNullPointerParser,
+    RustcNoImplicitAutorefsParser, RustcNonConstTraitMethodParser, RustcNounwindParser,
+    RustcObjectLifetimeDefaultParser, RustcOffloadKernelParser, RustcScalableVectorParser,
+    RustcSimdMonomorphizeLaneLimitParser,
 };
 use crate::attributes::semantics::MayDangleParser;
 use crate::attributes::stability::{
@@ -299,6 +300,7 @@ attribute_parsers!(
         Single<WithoutArgs<RustcDumpUserArgs>>,
         Single<WithoutArgs<RustcDumpVtable>>,
         Single<WithoutArgs<RustcHasIncoherentInherentImplsParser>>,
+        Single<WithoutArgs<RustcHiddenTypeOfOpaquesParser>>,
         Single<WithoutArgs<RustcLintOptTyParser>>,
         Single<WithoutArgs<RustcLintQueryInstabilityParser>>,
         Single<WithoutArgs<RustcLintUntrackedQueryInformationParser>>,

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -2312,12 +2312,12 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
             tcx: TyCtxt<'hir>,
             issue_span: Span,
             expr_span: Span,
-            body_expr: Option<&'hir hir::Expr<'hir>>,
-            loop_bind: Option<&'hir Ident>,
-            loop_span: Option<Span>,
-            head_span: Option<Span>,
-            pat_span: Option<Span>,
-            head: Option<&'hir hir::Expr<'hir>>,
+            body_expr: Option<&'hir hir::Expr<'hir>> = None,
+            loop_bind: Option<&'hir Ident> = None,
+            loop_span: Option<Span> = None,
+            head_span: Option<Span> = None,
+            pat_span: Option<Span> = None,
+            head: Option<&'hir hir::Expr<'hir>> = None,
         }
         impl<'hir> Visitor<'hir> for ExprFinder<'hir> {
             fn visit_expr(&mut self, ex: &'hir hir::Expr<'hir>) {
@@ -2383,17 +2383,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 hir::intravisit::walk_expr(self, ex);
             }
         }
-        let mut finder = ExprFinder {
-            tcx,
-            expr_span: span,
-            issue_span,
-            loop_bind: None,
-            body_expr: None,
-            head_span: None,
-            loop_span: None,
-            pat_span: None,
-            head: None,
-        };
+        let mut finder = ExprFinder { tcx, expr_span: span, issue_span, .. };
         finder.visit_expr(tcx.hir_body(body_id).value);
 
         if let Some(body_expr) = finder.body_expr
@@ -2628,13 +2618,13 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
 
         struct ExpressionFinder<'tcx> {
             capture_span: Span,
-            closure_change_spans: Vec<Span>,
-            closure_arg_span: Option<Span>,
-            in_closure: bool,
-            suggest_arg: String,
+            closure_change_spans: Vec<Span> = vec![],
+            closure_arg_span: Option<Span> = None,
+            in_closure: bool = false,
+            suggest_arg: String = String::new(),
             tcx: TyCtxt<'tcx>,
-            closure_local_id: Option<hir::HirId>,
-            closure_call_changes: Vec<(Span, String)>,
+            closure_local_id: Option<hir::HirId> = None,
+            closure_call_changes: Vec<(Span, String)> = vec![],
         }
         impl<'hir> Visitor<'hir> for ExpressionFinder<'hir> {
             fn visit_expr(&mut self, e: &'hir hir::Expr<'hir>) {
@@ -2715,16 +2705,8 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         }) = self.infcx.tcx.hir_node(self.mir_hir_id())
             && let hir::Node::Expr(expr) = self.infcx.tcx.hir_node(body_id.hir_id)
         {
-            let mut finder = ExpressionFinder {
-                capture_span: *capture_kind_span,
-                closure_change_spans: vec![],
-                closure_arg_span: None,
-                in_closure: false,
-                suggest_arg: String::new(),
-                closure_local_id: None,
-                closure_call_changes: vec![],
-                tcx: self.infcx.tcx,
-            };
+            let mut finder =
+                ExpressionFinder { capture_span: *capture_kind_span, tcx: self.infcx.tcx, .. };
             finder.visit_expr(expr);
 
             if finder.closure_change_spans.is_empty() || finder.closure_call_changes.is_empty() {

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -4,6 +4,7 @@
 #![allow(internal_features)]
 #![feature(assert_matches)]
 #![feature(box_patterns)]
+#![feature(default_field_values)]
 #![feature(file_buffered)]
 #![feature(if_let_guard)]
 #![feature(negative_impls)]

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -1057,6 +1057,9 @@ pub enum AttributeKind {
     /// Represents `#[rustc_has_incoherent_inherent_impls]`
     RustcHasIncoherentInherentImpls,
 
+    /// Represents `#[rustc_hidden_type_of_opaques]`
+    RustcHiddenTypeOfOpaques,
+
     /// Represents `#[rustc_layout]`
     RustcLayout(ThinVec<RustcLayoutType>),
 

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -111,6 +111,7 @@ impl AttributeKind {
             RustcDumpVtable(..) => No,
             RustcDynIncompatibleTrait(..) => No,
             RustcHasIncoherentInherentImpls => Yes,
+            RustcHiddenTypeOfOpaques => No,
             RustcLayout(..) => No,
             RustcLayoutScalarValidRangeEnd(..) => Yes,
             RustcLayoutScalarValidRangeStart(..) => Yes,

--- a/compiler/rustc_hir_analysis/src/collect/dump.rs
+++ b/compiler/rustc_hir_analysis/src/collect/dump.rs
@@ -7,10 +7,9 @@ use rustc_middle::ty::{self, TyCtxt, TypeVisitableExt};
 use rustc_span::sym;
 
 pub(crate) fn opaque_hidden_types(tcx: TyCtxt<'_>) {
-    if !tcx.has_attr(CRATE_DEF_ID, sym::rustc_hidden_type_of_opaques) {
+    if !find_attr!(tcx.get_all_attrs(CRATE_DEF_ID), AttributeKind::RustcHiddenTypeOfOpaques) {
         return;
     }
-
     for id in tcx.hir_crate_items(()).opaques() {
         if let hir::OpaqueTyOrigin::FnReturn { parent: fn_def_id, .. }
         | hir::OpaqueTyOrigin::AsyncFn { parent: fn_def_id, .. } =

--- a/compiler/rustc_hir_analysis/src/hir_wf_check.rs
+++ b/compiler/rustc_hir_analysis/src/hir_wf_check.rs
@@ -51,12 +51,12 @@ pub(super) fn diagnostic_hir_wf_check<'tcx>(
     struct HirWfCheck<'tcx> {
         tcx: TyCtxt<'tcx>,
         predicate: ty::Predicate<'tcx>,
-        cause: Option<ObligationCause<'tcx>>,
-        cause_depth: usize,
+        cause: Option<ObligationCause<'tcx>> = None,
+        cause_depth: usize = 0,
         icx: ItemCtxt<'tcx>,
         def_id: LocalDefId,
         param_env: ty::ParamEnv<'tcx>,
-        depth: usize,
+        depth: usize = 0,
     }
 
     impl<'tcx> Visitor<'tcx> for HirWfCheck<'tcx> {
@@ -124,16 +124,8 @@ pub(super) fn diagnostic_hir_wf_check<'tcx>(
         }
     }
 
-    let mut visitor = HirWfCheck {
-        tcx,
-        predicate,
-        cause: None,
-        cause_depth: 0,
-        icx,
-        def_id,
-        param_env: tcx.param_env(def_id.to_def_id()),
-        depth: 0,
-    };
+    let param_env = tcx.param_env(def_id.to_def_id());
+    let mut visitor = HirWfCheck { tcx, predicate, icx, def_id, param_env, .. };
 
     // Get the starting `hir::Ty` using our `WellFormedLoc`.
     // We will walk 'into' this type to try to find

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -59,6 +59,7 @@ This API is completely unstable and subject to change.
 #![allow(rustc::diagnostic_outside_of_impl)]
 #![allow(rustc::untranslatable_diagnostic)]
 #![feature(assert_matches)]
+#![feature(default_field_values)]
 #![feature(gen_blocks)]
 #![feature(if_let_guard)]
 #![feature(iter_intersperse)]

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -20,6 +20,7 @@ declare_lint_pass! {
         AMBIGUOUS_GLOB_IMPORTED_TRAITS,
         AMBIGUOUS_GLOB_IMPORTS,
         AMBIGUOUS_GLOB_REEXPORTS,
+        AMBIGUOUS_IMPORT_VISIBILITIES,
         AMBIGUOUS_PANIC_IMPORTS,
         ARITHMETIC_OVERFLOW,
         ASM_SUB_REGISTER,
@@ -4561,6 +4562,55 @@ declare_lint! {
     @future_incompatible = FutureIncompatibleInfo {
         reason: fcw!(FutureReleaseError #147319),
         report_in_deps: false,
+    };
+}
+
+declare_lint! {
+    /// The `ambiguous_import_visibilities` lint detects imports that should report ambiguity
+    /// errors, but previously didn't do that due to rustc bugs.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,compile_fail
+    /// #![deny(unknown_lints)]
+    /// #![deny(ambiguous_import_visibilities)]
+    /// mod reexport {
+    ///     mod m {
+    ///         pub struct S {}
+    ///     }
+    ///
+    ///     macro_rules! mac {
+    ///         () => { use m::S; }
+    ///     }
+    ///
+    ///     pub use m::*;
+    ///     mac!();
+    ///
+    ///     pub use S as Z; // ambiguous visibility
+    /// }
+    ///
+    /// fn main() {
+    ///     reexport::Z {};
+    /// }
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// Previous versions of Rust compile it successfully because it
+    /// fetched the glob import's visibility for `pub use S as Z` import, and ignored the private
+    /// `use m::S` import that appeared later.
+    ///
+    /// This is a [future-incompatible] lint to transition this to a
+    /// hard error in the future.
+    ///
+    /// [future-incompatible]: ../index.md#future-incompatible-lints
+    pub AMBIGUOUS_IMPORT_VISIBILITIES,
+    Warn,
+    "detects certain glob imports that require reporting an ambiguity error",
+    @future_incompatible = FutureIncompatibleInfo {
+        reason: fcw!(FutureReleaseError #149145),
     };
 }
 

--- a/compiler/rustc_middle/src/mir/statement.rs
+++ b/compiler/rustc_middle/src/mir/statement.rs
@@ -441,6 +441,8 @@ impl<'tcx> Place<'tcx> {
     where
         D: ?Sized + HasLocalDecls<'tcx>,
     {
+        // If there's a field projection element in `projection`, we *could* skip everything
+        // before that, but on 2026-01-31 a perf experiment showed no benefit from doing so.
         PlaceTy::from_ty(local_decls.local_decls()[local].ty).multi_projection_ty(tcx, projection)
     }
 

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -408,6 +408,12 @@ impl<Id: Into<DefId>> Visibility<Id> {
     }
 }
 
+impl<Id: Into<DefId> + Copy> Visibility<Id> {
+    pub fn min(self, vis: Visibility<Id>, tcx: TyCtxt<'_>) -> Visibility<Id> {
+        if self.is_at_least(vis, tcx) { vis } else { self }
+    }
+}
+
 impl Visibility<DefId> {
     pub fn expect_local(self) -> Visibility {
         self.map_id(|id| id.expect_local())

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -299,6 +299,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     | AttributeKind::RustcDumpVtable(..)
                     | AttributeKind::RustcDynIncompatibleTrait(..)
                     | AttributeKind::RustcHasIncoherentInherentImpls
+                    | AttributeKind::RustcHiddenTypeOfOpaques
                     | AttributeKind::RustcLayout(..)
                     | AttributeKind::RustcLayoutScalarValidRangeEnd(..)
                     | AttributeKind::RustcLayoutScalarValidRangeStart(..)
@@ -390,7 +391,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                             | sym::rustc_capture_analysis
                             | sym::rustc_regions
                             | sym::rustc_strict_coherence
-                            | sym::rustc_hidden_type_of_opaques
                             | sym::rustc_mir
                             | sym::rustc_effective_visibility
                             | sym::rustc_outlives

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -86,10 +86,7 @@ where
     }
 
     #[inline(always)]
-    fn query_state<'a>(self, qcx: QueryCtxt<'tcx>) -> &'a QueryState<'tcx, Self::Key>
-    where
-        QueryCtxt<'tcx>: 'a,
-    {
+    fn query_state(self, qcx: QueryCtxt<'tcx>) -> &'tcx QueryState<'tcx, Self::Key> {
         // Safety:
         // This is just manually doing the subfield referencing through pointer math.
         unsafe {
@@ -100,7 +97,7 @@ where
     }
 
     #[inline(always)]
-    fn query_cache<'a>(self, qcx: QueryCtxt<'tcx>) -> &'a Self::Cache {
+    fn query_cache(self, qcx: QueryCtxt<'tcx>) -> &'tcx Self::Cache {
         // Safety:
         // This is just manually doing the subfield referencing through pointer math.
         unsafe {
@@ -216,12 +213,12 @@ trait QueryDispatcherUnerased<'tcx> {
     ) -> Self::UnerasedValue;
 }
 
-pub fn query_system<'a>(
+pub fn query_system<'tcx>(
     local_providers: Providers,
     extern_providers: ExternProviders,
     on_disk_cache: Option<OnDiskCache>,
     incremental: bool,
-) -> QuerySystem<'a> {
+) -> QuerySystem<'tcx> {
     QuerySystem {
         states: Default::default(),
         arenas: Default::default(),

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -708,14 +708,18 @@ macro_rules! define_queries {
                 data: PhantomData<&'tcx ()>
             }
 
+            const FLAGS: QueryFlags = QueryFlags {
+                is_anon: is_anon!([$($modifiers)*]),
+                is_depth_limit: depth_limit!([$($modifiers)*]),
+                is_feedable: feedable!([$($modifiers)*]),
+            };
+
             impl<'tcx> QueryDispatcherUnerased<'tcx> for QueryType<'tcx> {
                 type UnerasedValue = queries::$name::Value<'tcx>;
                 type Dispatcher = SemiDynamicQueryDispatcher<
                     'tcx,
                     queries::$name::Storage<'tcx>,
-                    { is_anon!([$($modifiers)*]) },
-                    { depth_limit!([$($modifiers)*]) },
-                    { feedable!([$($modifiers)*]) },
+                    FLAGS,
                 >;
 
                 const NAME: &'static &'static str = &stringify!($name);

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -104,13 +104,6 @@ impl<'tcx> QueryContext<'tcx> for QueryCtxt<'tcx> {
         if complete { Ok(jobs) } else { Err(jobs) }
     }
 
-    fn lift_query_info(
-        self,
-        info: &QueryStackDeferred<'tcx>,
-    ) -> rustc_query_system::query::QueryStackFrameExtra {
-        info.extract()
-    }
-
     // Interactions with on_disk_cache
     fn load_side_effect(
         self,
@@ -174,10 +167,7 @@ impl<'tcx> QueryContext<'tcx> for QueryCtxt<'tcx> {
 
         self.tcx.sess.dcx().emit_fatal(QueryOverflow {
             span: info.job.span,
-            note: QueryOverflowNote {
-                desc: self.lift_query_info(&info.query.info).description,
-                depth,
-            },
+            note: QueryOverflowNote { desc: info.query.info.extract().description, depth },
             suggested_limit,
             crate_name: self.tcx.crate_name(LOCAL_CRATE),
         });

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -167,7 +167,7 @@ impl<'tcx> QueryContext<'tcx> for QueryCtxt<'tcx> {
 
         self.tcx.sess.dcx().emit_fatal(QueryOverflow {
             span: info.job.span,
-            note: QueryOverflowNote { desc: info.query.info.extract().description, depth },
+            note: QueryOverflowNote { desc: info.frame.info.extract().description, depth },
             suggested_limit,
             crate_name: self.tcx.crate_name(LOCAL_CRATE),
         });
@@ -728,14 +728,14 @@ macro_rules! define_queries {
                 qmap: &mut QueryMap<'tcx>,
                 require_complete: bool,
             ) -> Option<()> {
-                let make_query = |tcx, key| {
+                let make_frame = |tcx, key| {
                     let kind = rustc_middle::dep_graph::dep_kinds::$name;
                     let name = stringify!($name);
                     $crate::plumbing::create_query_frame(tcx, rustc_middle::query::descs::$name, key, kind, name)
                 };
                 let res = tcx.query_system.states.$name.collect_active_jobs(
                     tcx,
-                    make_query,
+                    make_frame,
                     qmap,
                     require_complete,
                 );

--- a/compiler/rustc_query_system/src/query/dispatcher.rs
+++ b/compiler/rustc_query_system/src/query/dispatcher.rs
@@ -25,7 +25,7 @@ type DepContextOf<'tcx, This: QueryDispatcher<'tcx>> =
 /// Those types are not visible from this `rustc_query_system` crate.
 ///
 /// "Dispatcher" should be understood as a near-synonym of "vtable".
-pub trait QueryDispatcher<'tcx>: Copy {
+pub trait QueryDispatcher<'tcx>: Copy + 'tcx {
     fn name(self) -> &'static str;
 
     /// Query context used by this dispatcher, i.e. `rustc_query_impl::QueryCtxt`.
@@ -41,10 +41,10 @@ pub trait QueryDispatcher<'tcx>: Copy {
     fn format_value(self) -> fn(&Self::Value) -> String;
 
     // Don't use this method to access query results, instead use the methods on TyCtxt
-    fn query_state<'a>(self, tcx: Self::Qcx) -> &'a QueryState<'tcx, Self::Key>;
+    fn query_state(self, tcx: Self::Qcx) -> &'tcx QueryState<'tcx, Self::Key>;
 
     // Don't use this method to access query results, instead use the methods on TyCtxt
-    fn query_cache<'a>(self, tcx: Self::Qcx) -> &'a Self::Cache;
+    fn query_cache(self, tcx: Self::Qcx) -> &'tcx Self::Cache;
 
     fn will_cache_on_disk_for_key(self, tcx: DepContextOf<'tcx, Self>, key: &Self::Key) -> bool;
 

--- a/compiler/rustc_query_system/src/query/job.rs
+++ b/compiler/rustc_query_system/src/query/job.rs
@@ -27,11 +27,8 @@ pub struct QueryInfo<I> {
 }
 
 impl<'tcx> QueryInfo<QueryStackDeferred<'tcx>> {
-    pub(crate) fn lift<Qcx: QueryContext<'tcx>>(
-        &self,
-        qcx: Qcx,
-    ) -> QueryInfo<QueryStackFrameExtra> {
-        QueryInfo { span: self.span, query: self.query.lift(qcx) }
+    pub(crate) fn lift(&self) -> QueryInfo<QueryStackFrameExtra> {
+        QueryInfo { span: self.span, query: self.query.lift() }
     }
 }
 
@@ -628,7 +625,7 @@ pub fn print_query_stack<'tcx, Qcx: QueryContext<'tcx>>(
         let Some(query_info) = query_map.get(&query) else {
             break;
         };
-        let query_extra = qcx.lift_query_info(&query_info.query.info);
+        let query_extra = query_info.query.info.extract();
         if Some(count_printed) < limit_frames || limit_frames.is_none() {
             // Only print to stderr as many stack frames as `num_frames` when present.
             dcx.struct_failure_note(format!(

--- a/compiler/rustc_query_system/src/query/job.rs
+++ b/compiler/rustc_query_system/src/query/job.rs
@@ -23,12 +23,12 @@ use crate::query::{QueryContext, QueryStackFrame};
 pub struct QueryInfo<I> {
     /// The span corresponding to the reason for which this query was required.
     pub span: Span,
-    pub query: QueryStackFrame<I>,
+    pub frame: QueryStackFrame<I>,
 }
 
 impl<'tcx> QueryInfo<QueryStackDeferred<'tcx>> {
     pub(crate) fn lift(&self) -> QueryInfo<QueryStackFrameExtra> {
-        QueryInfo { span: self.span, query: self.query.lift() }
+        QueryInfo { span: self.span, frame: self.frame.lift() }
     }
 }
 
@@ -39,8 +39,8 @@ pub type QueryMap<'tcx> = FxHashMap<QueryJobId, QueryJobInfo<'tcx>>;
 pub struct QueryJobId(pub NonZero<u64>);
 
 impl QueryJobId {
-    fn query<'a, 'tcx>(self, map: &'a QueryMap<'tcx>) -> QueryStackFrame<QueryStackDeferred<'tcx>> {
-        map.get(&self).unwrap().query.clone()
+    fn frame<'a, 'tcx>(self, map: &'a QueryMap<'tcx>) -> QueryStackFrame<QueryStackDeferred<'tcx>> {
+        map.get(&self).unwrap().frame.clone()
     }
 
     fn span<'a, 'tcx>(self, map: &'a QueryMap<'tcx>) -> Span {
@@ -58,7 +58,7 @@ impl QueryJobId {
 
 #[derive(Clone, Debug)]
 pub struct QueryJobInfo<'tcx> {
-    pub query: QueryStackFrame<QueryStackDeferred<'tcx>>,
+    pub frame: QueryStackFrame<QueryStackDeferred<'tcx>>,
     pub job: QueryJob<'tcx>,
 }
 
@@ -122,7 +122,7 @@ impl QueryJobId {
 
         while let Some(job) = current_job {
             let info = query_map.get(&job).unwrap();
-            cycle.push(QueryInfo { span: info.job.span, query: info.query.clone() });
+            cycle.push(QueryInfo { span: info.job.span, frame: info.frame.clone() });
 
             if job == *self {
                 cycle.reverse();
@@ -137,7 +137,7 @@ impl QueryJobId {
                     .job
                     .parent
                     .as_ref()
-                    .map(|parent| (info.job.span, parent.query(&query_map)));
+                    .map(|parent| (info.job.span, parent.frame(&query_map)));
                 return CycleError { usage, cycle };
             }
 
@@ -155,13 +155,13 @@ impl QueryJobId {
     ) -> (QueryJobInfo<'tcx>, usize) {
         let mut depth = 1;
         let info = query_map.get(&self).unwrap();
-        let dep_kind = info.query.dep_kind;
+        let dep_kind = info.frame.dep_kind;
         let mut current_id = info.job.parent;
         let mut last_layout = (info.clone(), depth);
 
         while let Some(id) = current_id {
             let info = query_map.get(&id).unwrap();
-            if info.query.dep_kind == dep_kind {
+            if info.frame.dep_kind == dep_kind {
                 depth += 1;
                 last_layout = (info.clone(), depth);
             }
@@ -386,7 +386,7 @@ where
         .iter()
         .min_by_key(|v| {
             let (span, query) = f(v);
-            let hash = query.query(query_map).hash;
+            let hash = query.frame(query_map).hash;
             // Prefer entry points which have valid spans for nicer error messages
             // We add an integer to the tuple ensuring that entry points
             // with valid spans are picked first
@@ -470,14 +470,14 @@ fn remove_cycle<'tcx>(
             stack.rotate_left(pos);
         }
 
-        let usage = usage.as_ref().map(|(span, query)| (*span, query.query(query_map)));
+        let usage = usage.as_ref().map(|(span, query)| (*span, query.frame(query_map)));
 
         // Create the cycle error
         let error = CycleError {
             usage,
             cycle: stack
                 .iter()
-                .map(|&(s, ref q)| QueryInfo { span: s, query: q.query(query_map) })
+                .map(|&(s, ref q)| QueryInfo { span: s, frame: q.frame(query_map) })
                 .collect(),
         };
 
@@ -556,7 +556,7 @@ pub fn report_cycle<'a>(
 ) -> Diag<'a> {
     assert!(!stack.is_empty());
 
-    let span = stack[0].query.info.default_span(stack[1 % stack.len()].span);
+    let span = stack[0].frame.info.default_span(stack[1 % stack.len()].span);
 
     let mut cycle_stack = Vec::new();
 
@@ -564,9 +564,9 @@ pub fn report_cycle<'a>(
     let stack_count = if stack.len() == 1 { StackCount::Single } else { StackCount::Multiple };
 
     for i in 1..stack.len() {
-        let query = &stack[i].query;
-        let span = query.info.default_span(stack[(i + 1) % stack.len()].span);
-        cycle_stack.push(CycleStack { span, desc: query.info.description.to_owned() });
+        let frame = &stack[i].frame;
+        let span = frame.info.default_span(stack[(i + 1) % stack.len()].span);
+        cycle_stack.push(CycleStack { span, desc: frame.info.description.to_owned() });
     }
 
     let mut cycle_usage = None;
@@ -578,9 +578,9 @@ pub fn report_cycle<'a>(
     }
 
     let alias =
-        if stack.iter().all(|entry| matches!(entry.query.info.def_kind, Some(DefKind::TyAlias))) {
+        if stack.iter().all(|entry| matches!(entry.frame.info.def_kind, Some(DefKind::TyAlias))) {
             Some(crate::error::Alias::Ty)
-        } else if stack.iter().all(|entry| entry.query.info.def_kind == Some(DefKind::TraitAlias)) {
+        } else if stack.iter().all(|entry| entry.frame.info.def_kind == Some(DefKind::TraitAlias)) {
             Some(crate::error::Alias::Trait)
         } else {
             None
@@ -589,7 +589,7 @@ pub fn report_cycle<'a>(
     let cycle_diag = crate::error::Cycle {
         span,
         cycle_stack,
-        stack_bottom: stack[0].query.info.description.to_owned(),
+        stack_bottom: stack[0].frame.info.description.to_owned(),
         alias,
         cycle_usage,
         stack_count,
@@ -625,12 +625,12 @@ pub fn print_query_stack<'tcx, Qcx: QueryContext<'tcx>>(
         let Some(query_info) = query_map.get(&query) else {
             break;
         };
-        let query_extra = query_info.query.info.extract();
+        let query_extra = query_info.frame.info.extract();
         if Some(count_printed) < limit_frames || limit_frames.is_none() {
             // Only print to stderr as many stack frames as `num_frames` when present.
             dcx.struct_failure_note(format!(
                 "#{} [{:?}] {}",
-                count_printed, query_info.query.dep_kind, query_extra.description
+                count_printed, query_info.frame.dep_kind, query_extra.description
             ))
             .with_span(query_info.job.span)
             .emit();
@@ -642,7 +642,7 @@ pub fn print_query_stack<'tcx, Qcx: QueryContext<'tcx>>(
                 file,
                 "#{} [{}] {}",
                 count_total,
-                qcx.dep_context().dep_kind_vtable(query_info.query.dep_kind).name,
+                qcx.dep_context().dep_kind_vtable(query_info.frame.dep_kind).name,
                 query_extra.description
             );
         }

--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -70,9 +70,9 @@ impl<'tcx> QueryStackFrame<QueryStackDeferred<'tcx>> {
         Self { info, def_id, dep_kind, hash, def_id_for_ty_in_cycle }
     }
 
-    fn lift<Qcx: QueryContext<'tcx>>(&self, qcx: Qcx) -> QueryStackFrame<QueryStackFrameExtra> {
+    fn lift(&self) -> QueryStackFrame<QueryStackFrameExtra> {
         QueryStackFrame {
-            info: qcx.lift_query_info(&self.info),
+            info: self.info.extract(),
             dep_kind: self.dep_kind,
             hash: self.hash,
             def_id: self.def_id,
@@ -167,8 +167,6 @@ pub trait QueryContext<'tcx>: HasDepContext {
     fn current_query_job(self) -> Option<QueryJobId>;
 
     fn collect_active_jobs(self, require_complete: bool) -> Result<QueryMap<'tcx>, QueryMap<'tcx>>;
-
-    fn lift_query_info(self, info: &QueryStackDeferred<'tcx>) -> QueryStackFrameExtra;
 
     /// Load a side effect associated to the node in the previous session.
     fn load_side_effect(

--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -181,6 +181,4 @@ pub trait QueryContext<'tcx>: HasDepContext {
     /// new query job while it executes.
     fn start_query<R>(self, token: QueryJobId, depth_limit: bool, compute: impl FnOnce() -> R)
     -> R;
-
-    fn depth_limit_error(self, job: QueryJobId);
 }

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -127,11 +127,11 @@ impl<'tcx, K> Default for QueryState<'tcx, K> {
 
 /// A type representing the responsibility to execute the job in the `job` field.
 /// This will poison the relevant query if dropped.
-struct JobOwner<'a, 'tcx, K>
+struct JobOwner<'tcx, K>
 where
     K: Eq + Hash + Copy,
 {
-    state: &'a QueryState<'tcx, K>,
+    state: &'tcx QueryState<'tcx, K>,
     key: K,
 }
 
@@ -181,7 +181,7 @@ where
     }
 }
 
-impl<'a, 'tcx, K> JobOwner<'a, 'tcx, K>
+impl<'tcx, K> JobOwner<'tcx, K>
 where
     K: Eq + Hash + Copy,
 {
@@ -218,7 +218,7 @@ where
     }
 }
 
-impl<'a, 'tcx, K> Drop for JobOwner<'a, 'tcx, K>
+impl<'tcx, K> Drop for JobOwner<'tcx, K>
 where
     K: Eq + Hash + Copy,
 {
@@ -422,7 +422,7 @@ where
 fn execute_job<'tcx, Q, const INCR: bool>(
     query: Q,
     qcx: Q::Qcx,
-    state: &QueryState<'tcx, Q::Key>,
+    state: &'tcx QueryState<'tcx, Q::Key>,
     key: Q::Key,
     key_hash: u64,
     id: QueryJobId,

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -253,10 +253,10 @@ pub struct CycleError<I = QueryStackFrameExtra> {
 }
 
 impl<'tcx> CycleError<QueryStackDeferred<'tcx>> {
-    fn lift<Qcx: QueryContext<'tcx>>(&self, qcx: Qcx) -> CycleError<QueryStackFrameExtra> {
+    fn lift(&self) -> CycleError<QueryStackFrameExtra> {
         CycleError {
-            usage: self.usage.as_ref().map(|(span, frame)| (*span, frame.lift(qcx))),
-            cycle: self.cycle.iter().map(|info| info.lift(qcx)).collect(),
+            usage: self.usage.as_ref().map(|(span, frame)| (*span, frame.lift())),
+            cycle: self.cycle.iter().map(|info| info.lift()).collect(),
         }
     }
 }
@@ -297,7 +297,7 @@ where
     let query_map = qcx.collect_active_jobs(false).ok().expect("failed to collect active queries");
 
     let error = try_execute.find_cycle_in_stack(query_map, &qcx.current_query_job(), span);
-    (mk_cycle(query, qcx, error.lift(qcx)), None)
+    (mk_cycle(query, qcx, error.lift()), None)
 }
 
 #[inline(always)]
@@ -345,7 +345,7 @@ where
 
             (v, Some(index))
         }
-        Err(cycle) => (mk_cycle(query, qcx, cycle.lift(qcx)), None),
+        Err(cycle) => (mk_cycle(query, qcx, cycle.lift()), None),
     }
 }
 

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -24,8 +24,8 @@ use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
 use rustc_session::lint::BuiltinLintDiag;
 use rustc_session::lint::builtin::{
-    ABSOLUTE_PATHS_NOT_STARTING_WITH_CRATE, AMBIGUOUS_GLOB_IMPORTS, AMBIGUOUS_PANIC_IMPORTS,
-    MACRO_EXPANDED_MACRO_EXPORTS_ACCESSED_BY_ABSOLUTE_PATHS,
+    ABSOLUTE_PATHS_NOT_STARTING_WITH_CRATE, AMBIGUOUS_GLOB_IMPORTS, AMBIGUOUS_IMPORT_VISIBILITIES,
+    AMBIGUOUS_PANIC_IMPORTS, MACRO_EXPANDED_MACRO_EXPORTS_ACCESSED_BY_ABSOLUTE_PATHS,
 };
 use rustc_session::utils::was_invoked_from_cargo;
 use rustc_span::edit_distance::find_best_match_for_name;
@@ -145,6 +145,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 };
 
                 let lint = match ambiguity_warning {
+                    _ if ambiguity_error.ambig_vis.is_some() => AMBIGUOUS_IMPORT_VISIBILITIES,
                     AmbiguityWarning::GlobImport => AMBIGUOUS_GLOB_IMPORTS,
                     AmbiguityWarning::PanicImport => AMBIGUOUS_PANIC_IMPORTS,
                 };
@@ -1995,7 +1996,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     }
 
     fn ambiguity_diagnostic(&self, ambiguity_error: &AmbiguityError<'ra>) -> errors::Ambiguity {
-        let AmbiguityError { kind, ident, b1, b2, scope1, scope2, .. } = *ambiguity_error;
+        let AmbiguityError { kind, ambig_vis, ident, b1, b2, scope1, scope2, .. } =
+            *ambiguity_error;
         let extern_prelude_ambiguity = || {
             // Note: b1 may come from a module scope, as an extern crate item in module.
             matches!(scope2, Scope::ExternPreludeFlags)
@@ -2074,9 +2076,18 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             None
         };
 
+        let ambig_vis = ambig_vis.map(|(vis1, vis2)| {
+            format!(
+                "{} or {}",
+                vis1.to_string(CRATE_DEF_ID, self.tcx),
+                vis2.to_string(CRATE_DEF_ID, self.tcx)
+            )
+        });
+
         errors::Ambiguity {
             ident,
             help,
+            ambig_vis,
             kind: kind.descr(),
             b1_note,
             b1_help_msgs,

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -1463,6 +1463,7 @@ pub(crate) struct UnknownDiagnosticAttributeTypoSugg {
 // FIXME: Make this properly translatable.
 pub(crate) struct Ambiguity {
     pub ident: Ident,
+    pub ambig_vis: Option<String>,
     pub kind: &'static str,
     pub help: Option<&'static [&'static str]>,
     pub b1_note: Spanned<String>,
@@ -1473,8 +1474,12 @@ pub(crate) struct Ambiguity {
 
 impl Ambiguity {
     fn decorate<'a>(self, diag: &mut Diag<'a, impl EmissionGuarantee>) {
-        diag.primary_message(format!("`{}` is ambiguous", self.ident));
-        diag.span_label(self.ident.span, "ambiguous name");
+        if let Some(ambig_vis) = self.ambig_vis {
+            diag.primary_message(format!("ambiguous import visibility: {ambig_vis}"));
+        } else {
+            diag.primary_message(format!("`{}` is ambiguous", self.ident));
+            diag.span_label(self.ident.span, "ambiguous name");
+        }
         diag.note(format!("ambiguous because of {}", self.kind));
         diag.span_note(self.b1_note.span, self.b1_note.node);
         if let Some(help) = self.help {

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -5,6 +5,7 @@ use Namespace::*;
 use rustc_ast::{self as ast, NodeId};
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir::def::{DefKind, MacroKinds, Namespace, NonMacroAttrKind, PartialRes, PerNS};
+use rustc_middle::ty::Visibility;
 use rustc_middle::{bug, span_bug};
 use rustc_session::lint::builtin::PROC_MACRO_DERIVE_RESOLUTION_FALLBACK;
 use rustc_session::parse::feature_err;
@@ -485,9 +486,12 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         // We do not need to report them if we are either in speculative resolution,
                         // or in late resolution when everything is already imported and expanded
                         // and no ambiguities exist.
-                        if matches!(finalize, None | Some(Finalize { stage: Stage::Late, .. })) {
-                            return ControlFlow::Break(Ok(decl));
-                        }
+                        let import_vis = match finalize {
+                            None | Some(Finalize { stage: Stage::Late, .. }) => {
+                                return ControlFlow::Break(Ok(decl));
+                            }
+                            Some(Finalize { import_vis, .. }) => import_vis,
+                        };
 
                         if let Some(&(innermost_decl, _)) = innermost_results.first() {
                             // Found another solution, if the first one was "weak", report an error.
@@ -500,6 +504,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                 decl,
                                 scope,
                                 &innermost_results,
+                                import_vis,
                             ) {
                                 // No need to search for more potential ambiguities, one is enough.
                                 return ControlFlow::Break(Ok(innermost_decl));
@@ -779,12 +784,22 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         decl: Decl<'ra>,
         scope: Scope<'ra>,
         innermost_results: &[(Decl<'ra>, Scope<'ra>)],
+        import_vis: Option<Visibility>,
     ) -> bool {
         let (innermost_decl, innermost_scope) = innermost_results[0];
         let (res, innermost_res) = (decl.res(), innermost_decl.res());
-        if res == innermost_res {
+        let ambig_vis = if res != innermost_res {
+            None
+        } else if let Some(import_vis) = import_vis
+            && let min =
+                (|d: Decl<'_>| d.vis().min(import_vis.to_def_id(), self.tcx).expect_local())
+            && let (min1, min2) = (min(decl), min(innermost_decl))
+            && min1 != min2
+        {
+            Some((min1, min2))
+        } else {
             return false;
-        }
+        };
 
         // FIXME: Use `scope` instead of `res` to detect built-in attrs and derive helpers,
         // it will exclude imports, make slightly more code legal, and will require lang approval.
@@ -871,10 +886,17 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         || (self.is_specific_builtin_macro(res, sym::core_panic)
                             && self.is_specific_builtin_macro(innermost_res, sym::std_panic)));
 
-                let warning = is_issue_147319_hack.then_some(AmbiguityWarning::PanicImport);
+                let warning = if ambig_vis.is_some() {
+                    Some(AmbiguityWarning::GlobImport)
+                } else if is_issue_147319_hack {
+                    Some(AmbiguityWarning::PanicImport)
+                } else {
+                    None
+                };
 
                 self.ambiguity_errors.push(AmbiguityError {
                     kind,
+                    ambig_vis,
                     ident: ident.orig(orig_ident_span),
                     b1: innermost_decl,
                     b2: decl,

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -1189,7 +1189,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     ident,
                     ns,
                     &import.parent_scope,
-                    Some(Finalize { report_private: false, ..finalize }),
+                    Some(Finalize {
+                        report_private: false,
+                        import_vis: Some(import.vis),
+                        ..finalize
+                    }),
                     bindings[ns].get().decl(),
                     Some(import),
                 );

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -969,6 +969,7 @@ enum AmbiguityWarning {
 
 struct AmbiguityError<'ra> {
     kind: AmbiguityKind,
+    ambig_vis: Option<(Visibility, Visibility)>,
     ident: Ident,
     b1: Decl<'ra>,
     b2: Decl<'ra>,
@@ -2087,6 +2088,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         if let Some(b2) = used_decl.ambiguity.get() {
             let ambiguity_error = AmbiguityError {
                 kind: AmbiguityKind::GlobVsGlob,
+                ambig_vis: None,
                 ident,
                 b1: used_decl,
                 b2,
@@ -2556,6 +2558,8 @@ struct Finalize {
     used: Used = Used::Other,
     /// Finalizing early or late resolution.
     stage: Stage = Stage::Early,
+    /// Nominal visibility of the import item, in case we are resolving an import's final segment.
+    import_vis: Option<Visibility> = None,
 }
 
 impl Finalize {

--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -108,6 +108,17 @@ pub mod consts {
     pub const FRAC_1_SQRT_3: f128 =
         0.577350269189625764509148780501957455647601751270126876018602_f128;
 
+    /// sqrt(5)
+    #[unstable(feature = "more_float_constants", issue = "146939")]
+    // Also, #[unstable(feature = "f128", issue = "116909")]
+    pub const SQRT_5: f128 = 2.23606797749978969640917366873127623544061835961152572427089_f128;
+
+    /// 1/sqrt(5)
+    #[unstable(feature = "more_float_constants", issue = "146939")]
+    // Also, #[unstable(feature = "f128", issue = "116909")]
+    pub const FRAC_1_SQRT_5: f128 =
+        0.447213595499957939281834733746255247088123671922305144854179_f128;
+
     /// Euler's number (e)
     #[unstable(feature = "f128", issue = "116909")]
     pub const E: f128 = 2.71828182845904523536028747135266249775724709369995957496697_f128;

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -103,6 +103,16 @@ pub mod consts {
     // Also, #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const FRAC_1_SQRT_3: f16 = 0.577350269189625764509148780501957456_f16;
 
+    /// sqrt(5)
+    #[unstable(feature = "more_float_constants", issue = "146939")]
+    // Also, #[unstable(feature = "f16", issue = "116909")]
+    pub const SQRT_5: f16 = 2.23606797749978969640917366873127623_f16;
+
+    /// 1/sqrt(5)
+    #[unstable(feature = "more_float_constants", issue = "146939")]
+    // Also, #[unstable(feature = "f16", issue = "116909")]
+    pub const FRAC_1_SQRT_5: f16 = 0.44721359549995793928183473374625524_f16;
+
     /// Euler's number (e)
     #[unstable(feature = "f16", issue = "116909")]
     pub const E: f16 = 2.71828182845904523536028747135266250_f16;

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -356,6 +356,14 @@ pub mod consts {
     #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const FRAC_1_SQRT_3: f32 = 0.577350269189625764509148780501957456_f32;
 
+    /// sqrt(5)
+    #[unstable(feature = "more_float_constants", issue = "146939")]
+    pub const SQRT_5: f32 = 2.23606797749978969640917366873127623_f32;
+
+    /// 1/sqrt(5)
+    #[unstable(feature = "more_float_constants", issue = "146939")]
+    pub const FRAC_1_SQRT_5: f32 = 0.44721359549995793928183473374625524_f32;
+
     /// Euler's number (e)
     #[stable(feature = "rust1", since = "1.0.0")]
     pub const E: f32 = 2.71828182845904523536028747135266250_f32;

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -356,6 +356,14 @@ pub mod consts {
     #[unstable(feature = "more_float_constants", issue = "146939")]
     pub const FRAC_1_SQRT_3: f64 = 0.577350269189625764509148780501957456_f64;
 
+    /// sqrt(5)
+    #[unstable(feature = "more_float_constants", issue = "146939")]
+    pub const SQRT_5: f64 = 2.23606797749978969640917366873127623_f64;
+
+    /// 1/sqrt(5)
+    #[unstable(feature = "more_float_constants", issue = "146939")]
+    pub const FRAC_1_SQRT_5: f64 = 0.44721359549995793928183473374625524_f64;
+
     /// Euler's number (e)
     #[stable(feature = "rust1", since = "1.0.0")]
     pub const E: f64 = 2.71828182845904523536028747135266250_f64;

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -260,6 +260,7 @@
     all(target_vendor = "fortanix", target_env = "sgx"),
     feature(slice_index_methods, coerce_unsized, sgx_platform)
 )]
+#![cfg_attr(all(test, target_os = "uefi"), feature(uefi_std))]
 #![cfg_attr(target_family = "wasm", feature(stdarch_wasm_atomic_wait))]
 #![cfg_attr(target_arch = "wasm64", feature(simd_wasm64))]
 //

--- a/library/std/src/os/uefi/env.rs
+++ b/library/std/src/os/uefi/env.rs
@@ -4,13 +4,25 @@
 
 use crate::ffi::c_void;
 use crate::ptr::NonNull;
-use crate::sync::atomic::{Atomic, AtomicBool, AtomicPtr, Ordering};
+use crate::sync::atomic::Ordering;
 
-static SYSTEM_TABLE: Atomic<*mut c_void> = AtomicPtr::new(crate::ptr::null_mut());
-static IMAGE_HANDLE: Atomic<*mut c_void> = AtomicPtr::new(crate::ptr::null_mut());
-// Flag to check if BootServices are still valid.
-// Start with assuming that they are not available
-static BOOT_SERVICES_FLAG: Atomic<bool> = AtomicBool::new(false);
+#[doc(hidden)]
+#[cfg(not(test))]
+pub mod globals {
+    use crate::ffi::c_void;
+    use crate::sync::atomic::{Atomic, AtomicBool, AtomicPtr};
+
+    pub static SYSTEM_TABLE: Atomic<*mut c_void> = AtomicPtr::new(crate::ptr::null_mut());
+    pub static IMAGE_HANDLE: Atomic<*mut c_void> = AtomicPtr::new(crate::ptr::null_mut());
+    // Flag to check if BootServices are still valid.
+    // Start with assuming that they are not available
+    pub static BOOT_SERVICES_FLAG: Atomic<bool> = AtomicBool::new(false);
+}
+
+#[cfg(not(test))]
+use globals::*;
+#[cfg(test)]
+use realstd::os::uefi::env::globals::*;
 
 /// Initializes the global System Table and Image Handle pointers.
 ///

--- a/src/tools/compiletest/src/directives/auxiliary/tests.rs
+++ b/src/tools/compiletest/src/directives/auxiliary/tests.rs
@@ -25,3 +25,19 @@ fn test_aux_crate_value_with_modifiers() {
 fn test_aux_crate_value_invalid() {
     parse_aux_crate("foo.rs".to_string());
 }
+
+#[test]
+fn test_proc_macro_value_no_modifiers() {
+    assert_eq!(
+        ProcMacro { extern_modifiers: None, path: "foo.rs".to_string() },
+        parse_proc_macro("foo.rs".to_string())
+    );
+}
+
+#[test]
+fn test_proc_macro_value_with_modifiers() {
+    assert_eq!(
+        ProcMacro { extern_modifiers: Some("noprelude".to_string()), path: "foo.rs".to_string() },
+        parse_proc_macro("noprelude:foo.rs".to_string())
+    );
+}

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1302,7 +1302,7 @@ impl<'test> TestCx<'test> {
             let crate_name = path_to_crate_name(&proc_macro.path);
             add_extern(
                 rustc,
-                None, // `extern_modifiers`
+                proc_macro.extern_modifiers.as_deref(),
                 &crate_name,
                 &proc_macro.path,
                 AuxType::ProcMacro,

--- a/tests/ui/argument-suggestions/disjoint-spans-issue-151607.rs
+++ b/tests/ui/argument-suggestions/disjoint-spans-issue-151607.rs
@@ -1,0 +1,16 @@
+// Regression test for #151607
+// The ICE was "all spans must be disjoint" when emitting diagnostics
+// with overlapping suggestion spans.
+
+struct B;
+struct D;
+struct F;
+fn foo(g: F, y: F, e: &E) {
+    //~^ ERROR cannot find type `E` in this scope
+    foo(B, g, D, E, F, G)
+    //~^ ERROR this function takes 3 arguments but 6 arguments were supplied
+    //~| ERROR cannot find value `E` in this scope
+    //~| ERROR cannot find value `G` in this scope
+}
+
+fn main() {}

--- a/tests/ui/argument-suggestions/disjoint-spans-issue-151607.stderr
+++ b/tests/ui/argument-suggestions/disjoint-spans-issue-151607.stderr
@@ -1,0 +1,85 @@
+error[E0425]: cannot find type `E` in this scope
+  --> $DIR/disjoint-spans-issue-151607.rs:8:24
+   |
+LL | struct B;
+   | --------- similarly named struct `B` defined here
+...
+LL | fn foo(g: F, y: F, e: &E) {
+   |                        ^
+   |
+help: a struct with a similar name exists
+   |
+LL - fn foo(g: F, y: F, e: &E) {
+LL + fn foo(g: F, y: F, e: &B) {
+   |
+help: you might be missing a type parameter
+   |
+LL | fn foo<E>(g: F, y: F, e: &E) {
+   |       +++
+
+error[E0425]: cannot find value `E` in this scope
+  --> $DIR/disjoint-spans-issue-151607.rs:10:18
+   |
+LL |     foo(B, g, D, E, F, G)
+   |                  ^
+   |
+help: a local variable with a similar name exists
+   |
+LL -     foo(B, g, D, E, F, G)
+LL +     foo(B, g, D, e, F, G)
+   |
+help: consider importing one of these constants
+   |
+LL + use std::f128::consts::E;
+   |
+LL + use std::f16::consts::E;
+   |
+LL + use std::f32::consts::E;
+   |
+LL + use std::f64::consts::E;
+   |
+
+error[E0425]: cannot find value `G` in this scope
+  --> $DIR/disjoint-spans-issue-151607.rs:10:24
+   |
+LL |     foo(B, g, D, E, F, G)
+   |                        ^
+   |
+help: a local variable with a similar name exists
+   |
+LL -     foo(B, g, D, E, F, G)
+LL +     foo(B, g, D, E, F, g)
+   |
+help: you might be missing a const parameter
+   |
+LL | fn foo<const G: /* Type */>(g: F, y: F, e: &E) {
+   |       +++++++++++++++++++++
+
+error[E0061]: this function takes 3 arguments but 6 arguments were supplied
+  --> $DIR/disjoint-spans-issue-151607.rs:10:5
+   |
+LL |     foo(B, g, D, E, F, G)
+   |     ^^^ -     -  - unexpected argument #4
+   |         |     |
+   |         |     unexpected argument #3 of type `D`
+   |         unexpected argument #1 of type `B`
+   |
+note: function defined here
+  --> $DIR/disjoint-spans-issue-151607.rs:8:4
+   |
+LL | fn foo(g: F, y: F, e: &E) {
+   |    ^^^             -----
+help: consider borrowing here
+   |
+LL |     foo(B, g, D, E, F, &G)
+   |                        +
+help: remove the extra arguments
+   |
+LL -     foo(B, g, D, E, F, G)
+LL +     foo(, g, F, G)
+   |
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0061, E0425.
+For more information about an error, try `rustc --explain E0061`.

--- a/tests/ui/imports/ambiguous-import-visibility-macro.rs
+++ b/tests/ui/imports/ambiguous-import-visibility-macro.rs
@@ -1,0 +1,19 @@
+//@ check-pass
+//@ edition:2018
+//@ proc-macro: same-res-ambigious-extern-macro.rs
+
+macro_rules! globbing{
+    () => {
+        pub use same_res_ambigious_extern_macro::*;
+    }
+}
+
+#[macro_use] // this imports the `RustEmbed` macro with `pub(crate)` visibility
+extern crate same_res_ambigious_extern_macro;
+globbing! {} // this imports the same `RustEmbed` macro with `pub` visibility
+
+pub trait RustEmbed {}
+
+pub use RustEmbed as Embed; //~ WARN ambiguous import visibility
+                            //~| WARN this was previously accepted
+fn main() {}

--- a/tests/ui/imports/ambiguous-import-visibility-macro.stderr
+++ b/tests/ui/imports/ambiguous-import-visibility-macro.stderr
@@ -1,0 +1,29 @@
+warning: ambiguous import visibility: pub(crate) or pub
+  --> $DIR/ambiguous-import-visibility-macro.rs:17:9
+   |
+LL | pub use RustEmbed as Embed;
+   |         ^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #149145 <https://github.com/rust-lang/rust/issues/149145>
+   = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
+note: `RustEmbed` could refer to the derive macro imported here
+  --> $DIR/ambiguous-import-visibility-macro.rs:7:17
+   |
+LL |         pub use same_res_ambigious_extern_macro::*;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | globbing! {} // this imports the same `RustEmbed` macro with `pub` visibility
+   | ------------ in this macro invocation
+   = help: consider adding an explicit import of `RustEmbed` to disambiguate
+   = help: or use `crate::RustEmbed` to refer to this derive macro unambiguously
+note: `RustEmbed` could also refer to the derive macro imported here
+  --> $DIR/ambiguous-import-visibility-macro.rs:11:1
+   |
+LL | #[macro_use] // this imports the `RustEmbed` macro with `pub(crate)` visibility
+   | ^^^^^^^^^^^^
+   = note: `#[warn(ambiguous_import_visibilities)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: this warning originates in the macro `globbing` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: 1 warning emitted
+

--- a/tests/ui/imports/ambiguous-import-visibility-module.rs
+++ b/tests/ui/imports/ambiguous-import-visibility-module.rs
@@ -1,0 +1,24 @@
+//@ check-pass
+//@ edition:2018..
+
+mod reexport {
+    mod m {
+        pub struct S {}
+    }
+
+    macro_rules! mac {
+        () => {
+            use m::S;
+        };
+    }
+
+    pub use m::*;
+    mac!();
+
+    pub use S as Z; //~ WARN ambiguous import visibility
+                    //~| WARN this was previously accepted
+}
+
+fn main() {
+    reexport::Z {};
+}

--- a/tests/ui/imports/ambiguous-import-visibility-module.stderr
+++ b/tests/ui/imports/ambiguous-import-visibility-module.stderr
@@ -1,0 +1,29 @@
+warning: ambiguous import visibility: pub or pub(in crate::reexport)
+  --> $DIR/ambiguous-import-visibility-module.rs:18:13
+   |
+LL |     pub use S as Z;
+   |             ^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #149145 <https://github.com/rust-lang/rust/issues/149145>
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
+note: `S` could refer to the struct imported here
+  --> $DIR/ambiguous-import-visibility-module.rs:11:17
+   |
+LL |             use m::S;
+   |                 ^^^^
+...
+LL |     mac!();
+   |     ------ in this macro invocation
+   = help: use `self::S` to refer to this struct unambiguously
+note: `S` could also refer to the struct imported here
+  --> $DIR/ambiguous-import-visibility-module.rs:15:13
+   |
+LL |     pub use m::*;
+   |             ^^^^
+   = help: use `self::S` to refer to this struct unambiguously
+   = note: `#[warn(ambiguous_import_visibilities)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: this warning originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: 1 warning emitted
+

--- a/tests/ui/imports/ambiguous-import-visibility.rs
+++ b/tests/ui/imports/ambiguous-import-visibility.rs
@@ -1,0 +1,14 @@
+//@ check-pass
+//@ edition:2018
+//@ proc-macro: same-res-ambigious-extern-macro.rs
+
+#[macro_use] // this imports the `RustEmbed` macro with `pub(crate)` visibility
+extern crate same_res_ambigious_extern_macro;
+// this imports the same `RustEmbed` macro with `pub` visibility
+pub use same_res_ambigious_extern_macro::*;
+
+pub trait RustEmbed {}
+
+pub use RustEmbed as Embed; //~ WARN ambiguous import visibility
+                            //~| WARN this was previously accepted
+fn main() {}

--- a/tests/ui/imports/ambiguous-import-visibility.stderr
+++ b/tests/ui/imports/ambiguous-import-visibility.stderr
@@ -1,0 +1,25 @@
+warning: ambiguous import visibility: pub(crate) or pub
+  --> $DIR/ambiguous-import-visibility.rs:12:9
+   |
+LL | pub use RustEmbed as Embed;
+   |         ^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #149145 <https://github.com/rust-lang/rust/issues/149145>
+   = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
+note: `RustEmbed` could refer to the derive macro imported here
+  --> $DIR/ambiguous-import-visibility.rs:8:9
+   |
+LL | pub use same_res_ambigious_extern_macro::*;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `RustEmbed` to disambiguate
+   = help: or use `crate::RustEmbed` to refer to this derive macro unambiguously
+note: `RustEmbed` could also refer to the derive macro imported here
+  --> $DIR/ambiguous-import-visibility.rs:5:1
+   |
+LL | #[macro_use] // this imports the `RustEmbed` macro with `pub(crate)` visibility
+   | ^^^^^^^^^^^^
+   = note: `#[warn(ambiguous_import_visibilities)]` (part of `#[warn(future_incompatible)]`) on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/privacy/pub-priv-dep/auxiliary/pm.rs
+++ b/tests/ui/privacy/pub-priv-dep/auxiliary/pm.rs
@@ -1,8 +1,3 @@
-//@ force-host
-//@ no-prefer-dynamic
-
-#![crate_type = "proc-macro"]
-
 extern crate proc_macro;
 use proc_macro::TokenStream;
 

--- a/tests/ui/privacy/pub-priv-dep/pub-priv1.rs
+++ b/tests/ui/privacy/pub-priv-dep/pub-priv1.rs
@@ -1,6 +1,6 @@
 //@ aux-crate:priv:priv_dep=priv_dep.rs
 //@ aux-build:pub_dep.rs
-//@ aux-crate:priv:pm=pm.rs
+//@ proc-macro:priv:pm.rs
 //@ compile-flags: -Zunstable-options
 
 // Basic behavior check of exported_private_dependencies from either a public

--- a/tests/ui/traits/next-solver/generalize/relate-alias-in-lub.rs
+++ b/tests/ui/traits/next-solver/generalize/relate-alias-in-lub.rs
@@ -1,0 +1,30 @@
+//@ revisions: old next
+//@[next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@ check-pass
+// Reproduces https://github.com/rust-lang/rust/pull/151746#issuecomment-3822930803.
+//
+// The change we tried to make there caused relating a type variable with an alias inside lub,
+// In 5bd20bbd0ba6c0285664e55a1ffc677d7487c98b, we moved around code
+// that adds an alias-relate predicate to be earlier, from one shared codepath into several
+// distinct code paths. However, we forgot one codepath, through lub, causing an ICE in serde.
+// In the end we dropped said commit, but the reproducer is still a useful as test.
+
+use std::marker::PhantomData;
+
+pub trait Trait {
+    type Error;
+}
+
+pub struct Struct<E>(PhantomData<E>);
+
+impl Trait for () {
+    type Error = ();
+}
+
+fn main() {
+    let _: Struct<<() as Trait>::Error> = match loop {} {
+        b => loop {},
+        a => Struct(PhantomData),
+    };
+}

--- a/tests/ui/traits/next-solver/generalize/relate-alias-in-lub.rs
+++ b/tests/ui/traits/next-solver/generalize/relate-alias-in-lub.rs
@@ -7,7 +7,7 @@
 // The change we tried to make there caused relating a type variable with an alias inside lub,
 // In 5bd20bbd0ba6c0285664e55a1ffc677d7487c98b, we moved around code
 // that adds an alias-relate predicate to be earlier, from one shared codepath into several
-// distinct code paths. However, we forgot one codepath, through lub, causing an ICE in serde.
+// distinct code paths. However, we forgot the codepath in `LatticeOp`, causing an ICE in serde.
 // In the end we dropped said commit, but the reproducer is still a useful as test.
 
 use std::marker::PhantomData;


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#149596 (resolve: Report more visibility-related early resolution ambiguities for imports)
 - rust-lang/rust#151695 (compiletest: Support `--extern` modifiers with `proc-macro` directive)
 - rust-lang/rust#151938 (Use `#![feature(adt_const_params)]` for static query flags)
 - rust-lang/rust#151172 (Use default field values in a few more cases)
 - rust-lang/rust#151825 (more float constants)
 - rust-lang/rust#151870 (regression test for alias-relate changes in lub)
 - rust-lang/rust#151902 (explain why we dont skip some of this work when there are field projections)
 - rust-lang/rust#151909 (Skip overlapping spans in argument error suggestions)
 - rust-lang/rust#151978 (Query cleanups)
 - rust-lang/rust#151979 (Fix uninitialized UEFI globals in tests)
 - rust-lang/rust#151992 (Port `#[rustc_hidden_type_of_opaque]` to attribute parser)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=149596,151695,151938,151172,151825,151870,151902,151909,151978,151979,151992)
<!-- homu-ignore:end -->

