### PR TITLE
Remove `with_no_trimmed_paths` use in query macro

### DIFF
--- a/compiler/rustc_macros/src/query.rs
+++ b/compiler/rustc_macros/src/query.rs
@@ -303,9 +303,7 @@ fn add_query_desc_cached_impl(
         #[allow(unused_variables)]
         pub fn #name<'tcx>(tcx: TyCtxt<'tcx>, key: crate::query::queries::#name::Key<'tcx>) -> String {
             let (#tcx, #key) = (tcx, key);
-            ::rustc_middle::ty::print::with_no_trimmed_paths!(
-                format!(#desc)
-            )
+            format!(#desc)
         }
     };
 


### PR DESCRIPTION
We already use `with_no_trimmed_paths!` when calling query descriptors so the extra call generated by the macro is not needed.