### PR TITLE
Remove dummy loads on offload codegen

### DIFF
--- a/tests/codegen-llvm/gpu_offload/gpu_host.rs
+++ b/tests/codegen-llvm/gpu_offload/gpu_host.rs
@@ -55,9 +55,7 @@ pub fn _kernel_1(x: &mut [f32; 256]) {
 // CHECK-NEXT:   %.offload_ptrs = alloca [1 x ptr], align 8
 // CHECK-NEXT:   %.offload_sizes = alloca [1 x i64], align 8
 // CHECK-NEXT:   %kernel_args = alloca %struct.__tgt_kernel_arguments, align 8
-// CHECK:   %dummy = load volatile ptr, ptr @.offload_sizes.[[K]], align 8
-// CHECK-NEXT:   %dummy1 = load volatile ptr, ptr @.offloading.entry.[[K]], align 8
-// CHECK-NEXT:   call void @__tgt_init_all_rtls()
+// CHECK:        call void @__tgt_init_all_rtls()
 // CHECK-NEXT:   store ptr %x, ptr %.offload_baseptrs, align 8
 // CHECK-NEXT:   store ptr %x, ptr %.offload_ptrs, align 8
 // CHECK-NEXT:   store i64 1024, ptr %.offload_sizes, align 8


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

The current logic generates two dummy loads to prevent some globals from being optimized away. This blocks memtransfer loop hoisting optimizations, so it's time to remove them.

r? @ZuseZ4 
