### PR TITLE
Bump tvOS, visionOS and watchOS Aarch64 targets to tier 2

### DIFF
--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_tvos.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_tvos.rs
@@ -7,7 +7,7 @@ pub(crate) fn target() -> Target {
         llvm_target,
         metadata: TargetMetadata {
             description: Some("ARM64 Apple tvOS".into()),
-            tier: Some(3),
+            tier: Some(2),
             host_tools: Some(false),
             std: Some(true),
         },

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_tvos_sim.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_tvos_sim.rs
@@ -7,7 +7,7 @@ pub(crate) fn target() -> Target {
         llvm_target,
         metadata: TargetMetadata {
             description: Some("ARM64 Apple tvOS Simulator".into()),
-            tier: Some(3),
+            tier: Some(2),
             host_tools: Some(false),
             std: Some(true),
         },

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_visionos.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_visionos.rs
@@ -7,7 +7,7 @@ pub(crate) fn target() -> Target {
         llvm_target,
         metadata: TargetMetadata {
             description: Some("ARM64 Apple visionOS".into()),
-            tier: Some(3),
+            tier: Some(2),
             host_tools: Some(false),
             std: Some(true),
         },

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_visionos_sim.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_visionos_sim.rs
@@ -7,7 +7,7 @@ pub(crate) fn target() -> Target {
         llvm_target,
         metadata: TargetMetadata {
             description: Some("ARM64 Apple visionOS simulator".into()),
-            tier: Some(3),
+            tier: Some(2),
             host_tools: Some(false),
             std: Some(true),
         },

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_watchos.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_watchos.rs
@@ -7,7 +7,7 @@ pub(crate) fn target() -> Target {
         llvm_target,
         metadata: TargetMetadata {
             description: Some("ARM64 Apple watchOS".into()),
-            tier: Some(3),
+            tier: Some(2),
             host_tools: Some(false),
             std: Some(true),
         },

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_watchos_sim.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_watchos_sim.rs
@@ -7,7 +7,7 @@ pub(crate) fn target() -> Target {
         llvm_target,
         metadata: TargetMetadata {
             description: Some("ARM64 Apple watchOS Simulator".into()),
-            tier: Some(3),
+            tier: Some(2),
             host_tools: Some(false),
             std: Some(true),
         },

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -466,7 +466,19 @@ auto:
 
   - name: dist-apple-various
     env:
-      SCRIPT: ./x.py dist bootstrap --include-default-paths --host='' --target=aarch64-apple-ios,x86_64-apple-ios,aarch64-apple-ios-sim,aarch64-apple-ios-macabi,x86_64-apple-ios-macabi
+      # Build and distribute the standard library for these targets.
+      TARGETS: "aarch64-apple-ios,\
+        aarch64-apple-ios-sim,\
+        x86_64-apple-ios,\
+        aarch64-apple-ios-macabi,\
+        x86_64-apple-ios-macabi,\
+        aarch64-apple-tvos,\
+        aarch64-apple-tvos-sim,\
+        aarch64-apple-visionos,\
+        aarch64-apple-visionos-sim,\
+        aarch64-apple-watchos,\
+        aarch64-apple-watchos-sim"
+      SCRIPT: ./x.py dist bootstrap --include-default-paths --host='' --target=$TARGETS
       # Mac Catalyst cannot currently compile the sanitizer:
       # https://github.com/rust-lang/rust/issues/129069
       RUST_CONFIGURE_ARGS: --enable-sanitizers --enable-profiler --set rust.jemalloc --set target.aarch64-apple-ios-macabi.sanitizers=false --set target.x86_64-apple-ios-macabi.sanitizers=false

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -481,7 +481,19 @@ auto:
       SCRIPT: ./x.py dist bootstrap --include-default-paths --host='' --target=$TARGETS
       # Mac Catalyst cannot currently compile the sanitizer:
       # https://github.com/rust-lang/rust/issues/129069
-      RUST_CONFIGURE_ARGS: --enable-sanitizers --enable-profiler --set rust.jemalloc --set target.aarch64-apple-ios-macabi.sanitizers=false --set target.x86_64-apple-ios-macabi.sanitizers=false
+      #
+      # And tvOS and watchOS don't currently support the profiler runtime:
+      # https://github.com/rust-lang/rust/issues/152426
+      RUST_CONFIGURE_ARGS: >-
+        --enable-sanitizers
+        --enable-profiler
+        --set rust.jemalloc
+        --set target.aarch64-apple-ios-macabi.sanitizers=false
+        --set target.x86_64-apple-ios-macabi.sanitizers=false
+        --set target.aarch64-apple-tvos.profiler=false
+        --set target.aarch64-apple-tvos-sim.profiler=false
+        --set target.aarch64-apple-watchos.profiler=false
+        --set target.aarch64-apple-watchos-sim.profiler=false
       # Ensure that host tooling is built to support our minimum support macOS version.
       # FIXME(madsmtm): This might be redundant, as we're not building host tooling here (?)
       MACOSX_DEPLOYMENT_TARGET: 10.12

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -148,6 +148,12 @@ target | std | notes
 [`aarch64-apple-ios`](platform-support/apple-ios.md) | ✓ | ARM64 iOS
 [`aarch64-apple-ios-macabi`](platform-support/apple-ios-macabi.md) | ✓ | Mac Catalyst on ARM64
 [`aarch64-apple-ios-sim`](platform-support/apple-ios.md) | ✓ | Apple iOS Simulator on ARM64
+[`aarch64-apple-tvos`](platform-support/apple-tvos.md) | ✓ | ARM64 tvOS
+[`aarch64-apple-tvos-sim`](platform-support/apple-tvos.md) | ✓ | ARM64 tvOS Simulator
+[`aarch64-apple-visionos`](platform-support/apple-visionos.md) | ✓ | ARM64 Apple visionOS
+[`aarch64-apple-visionos-sim`](platform-support/apple-visionos.md) | ✓ | ARM64 Apple visionOS Simulator
+[`aarch64-apple-watchos`](platform-support/apple-watchos.md) | ✓ | ARM64 Apple WatchOS
+[`aarch64-apple-watchos-sim`](platform-support/apple-watchos.md) | ✓ | ARM64 Apple WatchOS Simulator
 [`aarch64-linux-android`](platform-support/android.md) | ✓ | ARM64 Android
 [`aarch64-unknown-fuchsia`](platform-support/fuchsia.md) | ✓ | ARM64 Fuchsia
 [`aarch64-unknown-none`](platform-support/aarch64-unknown-none.md) | * | Bare ARM64, hardfloat
@@ -250,12 +256,6 @@ host tools.
 
 target | std | host | notes
 -------|:---:|:----:|-------
-[`aarch64-apple-tvos`](platform-support/apple-tvos.md) | ✓ |  | ARM64 tvOS
-[`aarch64-apple-tvos-sim`](platform-support/apple-tvos.md) | ✓ |  | ARM64 tvOS Simulator
-[`aarch64-apple-visionos`](platform-support/apple-visionos.md) | ✓ |  | ARM64 Apple visionOS
-[`aarch64-apple-visionos-sim`](platform-support/apple-visionos.md) | ✓ |  | ARM64 Apple visionOS Simulator
-[`aarch64-apple-watchos`](platform-support/apple-watchos.md) | ✓ |  | ARM64 Apple WatchOS
-[`aarch64-apple-watchos-sim`](platform-support/apple-watchos.md) | ✓ |  | ARM64 Apple WatchOS Simulator
 [`aarch64-kmc-solid_asp3`](platform-support/kmc-solid.md) | ✓ |  | ARM64 SOLID with TOPPERS/ASP3
 [`aarch64-nintendo-switch-freestanding`](platform-support/aarch64-nintendo-switch-freestanding.md) | * |  | ARM64 Nintendo Switch, Horizon
 [`aarch64-unknown-freebsd`](platform-support/freebsd.md) | ✓ | ✓ | ARM64 FreeBSD

--- a/src/doc/rustc/src/platform-support/apple-tvos.md
+++ b/src/doc/rustc/src/platform-support/apple-tvos.md
@@ -2,10 +2,13 @@
 
 Apple tvOS targets.
 
-**Tier: 3**
+**Tier: 2 (without Host Tools)**
 
 - `aarch64-apple-tvos`: Apple tvOS on ARM64.
 - `aarch64-apple-tvos-sim`: Apple tvOS Simulator on ARM64.
+
+**Tier: 3**
+
 - `x86_64-apple-tvos`: Apple tvOS Simulator on x86_64.
 
 ## Target maintainers
@@ -52,16 +55,13 @@ The following APIs are currently known to have missing or incomplete support:
 
 ## Building the target
 
-The targets can be built by enabling them for a `rustc` build in
-`bootstrap.toml`, by adding, for example:
-
-```toml
-[build]
-build-stage = 1
-target = ["aarch64-apple-tvos", "aarch64-apple-tvos-sim"]
+The tier 2 targets are distributed through `rustup`, and can be installed using one of:
+```console
+$ rustup target add aarch64-apple-tvos
+$ rustup target add aarch64-apple-tvos-sim
 ```
 
-Using the unstable `-Zbuild-std` with a nightly Cargo may also work.
+See [the instructions for iOS](./apple-ios.md#building-the-target) for how to build the tier 3 target.
 
 ## Building Rust programs
 

--- a/src/doc/rustc/src/platform-support/apple-visionos.md
+++ b/src/doc/rustc/src/platform-support/apple-visionos.md
@@ -2,7 +2,7 @@
 
 Apple visionOS / xrOS targets.
 
-**Tier: 3**
+**Tier: 2 (without Host Tools)**
 
 - `aarch64-apple-visionos`: Apple visionOS on arm64.
 - `aarch64-apple-visionos-sim`: Apple visionOS Simulator on arm64.
@@ -31,18 +31,11 @@ case `XROS_DEPLOYMENT_TARGET`.
 
 ## Building the target
 
-The targets can be built by enabling them for a `rustc` build in
-`bootstrap.toml`, by adding, for example:
-
-```toml
-[build]
-target = ["aarch64-apple-visionos", "aarch64-apple-visionos-sim"]
+The targets are distributed through `rustup`, and can be installed using one of:
+```console
+$ rustup target add aarch64-apple-visionos
+$ rustup target add aarch64-apple-visionos-sim
 ```
-
-Using the unstable `-Zbuild-std` with a nightly Cargo may also work.
-
-Note: Currently, a newer version of `libc` and `cc` may be required, this will
-be fixed in [#124560](https://github.com/rust-lang/rust/pull/124560).
 
 ## Building Rust programs
 

--- a/src/doc/rustc/src/platform-support/apple-watchos.md
+++ b/src/doc/rustc/src/platform-support/apple-watchos.md
@@ -2,10 +2,13 @@
 
 Apple watchOS targets.
 
-**Tier: 3**
+**Tier: 2 (without Host Tools)**
 
 - `aarch64-apple-watchos`: Apple WatchOS on ARM64.
 - `aarch64-apple-watchos-sim`: Apple WatchOS Simulator on ARM64.
+
+**Tier: 3**
+
 - `x86_64-apple-watchos-sim`: Apple WatchOS Simulator on 64-bit x86.
 - `arm64_32-apple-watchos`: Apple WatchOS on Arm 64_32.
 - `armv7k-apple-watchos`: Apple WatchOS on Armv7k.
@@ -37,16 +40,13 @@ case `WATCHOS_DEPLOYMENT_TARGET`.
 
 ## Building the target
 
-The targets can be built by enabling them for a `rustc` build in
-`bootstrap.toml`, by adding, for example:
-
-```toml
-[build]
-build-stage = 1
-target = ["aarch64-apple-watchos", "aarch64-apple-watchos-sim"]
+The tier 2 targets are distributed through `rustup`, and can be installed using one of:
+```console
+$ rustup target add aarch64-apple-watchos
+$ rustup target add aarch64-apple-watchos-sim
 ```
 
-Using the unstable `-Zbuild-std` with a nightly Cargo may also work.
+See [the instructions for iOS](./apple-ios.md#building-the-target) for how to build the tier 3 targets.
 
 ## Building Rust programs
 


### PR DESCRIPTION
Promote the following targets to Tier 2 without host tools:
- `aarch64-apple-tvos`.
- `aarch64-apple-tvos-sim`.
- `aarch64-apple-watchos`.
- `aarch64-apple-watchos-sim`.
- `aarch64-apple-visionos`.
- `aarch64-apple-visionos-sim`.

This implements MCP https://github.com/rust-lang/compiler-team/issues/918. Fixes https://github.com/rust-lang/rust/issues/151705.

r? shepmaster