### PR TITLE
disable socket tests in Miri

### DIFF
--- a/library/std/tests/windows_unix_socket.rs
+++ b/library/std/tests/windows_unix_socket.rs
@@ -1,4 +1,5 @@
 #![cfg(windows)]
+#![cfg(not(miri))] // no socket support in Miri
 #![feature(windows_unix_domain_sockets)]
 // Now only test windows_unix_domain_sockets feature
 // in the future, will test both unix and windows uds


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/150428 added some tests that do not work in Miri since we do not support sockets.

r? @Mark-Simulacrum 