### PR TITLE
Show largest job duration changes in hours and minutes in the post-merge report

### DIFF
--- a/src/ci/citool/Cargo.lock
+++ b/src/ci/citool/Cargo.lock
@@ -66,9 +66,9 @@ checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "askama"
-version = "0.15.1"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7125972258312e79827b60c9eb93938334100245081cf701a2dee981b17427"
+checksum = "08e1676b346cadfec169374f949d7490fd80a24193d37d2afce0c047cf695e57"
 dependencies = [
  "askama_macros",
  "itoa",
@@ -79,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "askama_derive"
-version = "0.15.1"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba5e7259a1580c61571e3116ebaaa01e3c001b2132b17c4cc5c70780ca3e994"
+checksum = "7661ff56517787343f376f75db037426facd7c8d3049cef8911f1e75016f3a37"
 dependencies = [
  "askama_parser",
  "basic-toml",
@@ -96,18 +96,18 @@ dependencies = [
 
 [[package]]
 name = "askama_macros"
-version = "0.15.1"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "236ce20b77cb13506eaf5024899f4af6e12e8825f390bd943c4c37fd8f322e46"
+checksum = "713ee4dbfd1eb719c2dab859465b01fa1d21cb566684614a713a6b7a99a4e47b"
 dependencies = [
  "askama_derive",
 ]
 
 [[package]]
 name = "askama_parser"
-version = "0.15.1"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c63392767bb2df6aa65a6e1e3b80fd89bb7af6d58359b924c0695620f1512e"
+checksum = "1d62d674238a526418b30c0def480d5beadb9d8964e7f38d635b03bf639c704c"
 dependencies = [
  "rustc-hash",
  "serde",

--- a/src/ci/citool/src/analysis.rs
+++ b/src/ci/citool/src/analysis.rs
@@ -194,8 +194,8 @@ pub fn output_test_diffs(
     report_test_diffs(aggregated_test_diffs, job_metrics, job_info_resolver);
 }
 
-/// Prints the ten largest differences in bootstrap durations.
-pub fn output_largest_duration_changes(
+/// Prints the ten largest differences in job durations.
+pub fn output_largest_job_duration_changes(
     job_metrics: &HashMap<JobName, JobMetrics>,
     job_info_resolver: &mut JobInfoResolver,
 ) {
@@ -237,11 +237,11 @@ pub fn output_largest_duration_changes(
     println!("# Job duration changes");
     for (index, entry) in changes.into_iter().take(10).enumerate() {
         println!(
-            "{}. {}: {:.1}s -> {:.1}s ({:+.1}%)",
+            "{}. {}: {} -> {} ({:+.1}%)",
             index + 1,
             format_job_link(job_info_resolver, job_metrics, entry.job),
-            entry.before.as_secs_f64(),
-            entry.after.as_secs_f64(),
+            format_duration(entry.before),
+            format_duration(entry.after),
             entry.change
         );
     }
@@ -254,6 +254,27 @@ that executed the job, system noise, invalidated caches, etc. The table above is
 mostly for t-infra members, for simpler debugging of potential CI slow-downs."#
         );
     });
+}
+
+fn format_duration(duration: Duration) -> String {
+    let total_secs = duration.as_secs();
+    let hours = total_secs / 3600;
+    let minutes = (total_secs % 3600) / 60;
+    let seconds = total_secs % 60;
+
+    let mut res = String::new();
+
+    if hours > 0 {
+        res.push_str(&format!("{hours}h "));
+    }
+    if minutes > 0 {
+        res.push_str(&format!("{minutes}m "));
+    }
+    if hours == 0 && seconds > 0 {
+        res.push_str(&format!("{seconds}s"));
+    }
+
+    res.trim().to_string()
 }
 
 #[derive(Default)]

--- a/src/ci/citool/src/main.rs
+++ b/src/ci/citool/src/main.rs
@@ -17,7 +17,7 @@ use clap::Parser;
 use jobs::JobDatabase;
 use serde_yaml::Value;
 
-use crate::analysis::{output_largest_duration_changes, output_test_diffs};
+use crate::analysis::{output_largest_job_duration_changes, output_test_diffs};
 use crate::cpu_usage::load_cpu_usage;
 use crate::datadog::upload_datadog_metric;
 use crate::github::JobInfoResolver;
@@ -205,7 +205,7 @@ And then open `test-dashboard/index.html` in your browser to see an overview of 
         );
     });
 
-    output_largest_duration_changes(&metrics, &mut job_info_resolver);
+    output_largest_job_duration_changes(&metrics, &mut job_info_resolver);
 
     Ok(())
 }


### PR DESCRIPTION
This was suggested by... someone, somewhere. But it's a good idea.

See https://github.com/rust-lang/rust/pull/152025#issuecomment-3839702972 - now instead of seconds it would show this:

# Job duration changes
1. [dist-apple-various](https://github.com/rust-lang/rust/actions/runs/21617345733#summary-62299011925): 1h 3m -> 1h 29m (+41.5%)
2. [dist-x86_64-apple](https://github.com/rust-lang/rust/actions/runs/21617345733#summary-62299011972): 2h 1m -> 2h 21m (+16.4%)
3. [dist-ohos-x86_64](https://github.com/rust-lang/rust/actions/runs/21617345733#summary-62299011829): 1h 11m -> 1h 19m (+12.4%)
4. [x86_64-gnu-llvm-20](https://github.com/rust-lang/rust/actions/runs/21617345733#summary-62299011909): 1h 9m -> 1h 17m (+11.9%)
5. [pr-check-1](https://github.com/rust-lang/rust/actions/runs/21617345733#summary-62299011862): 32m 27s -> 28m 44s (-11.4%)
6. [tidy](https://github.com/rust-lang/rust/actions/runs/21617345733#summary-62299011845): 2m 37s -> 2m 52s (+9.9%)
7. [armhf-gnu](https://github.com/rust-lang/rust/actions/runs/21617345733#summary-62299011763): 1h 22m -> 1h 30m (+9.5%)
8. [dist-aarch64-apple](https://github.com/rust-lang/rust/actions/runs/21617345733#summary-62299011941): 1h 54m -> 1h 44m (-9.1%)
9. [x86_64-gnu-llvm-21-3](https://github.com/rust-lang/rust/actions/runs/21617345733#summary-62299011924): 1h 45m -> 1h 54m (+9.1%)
10. [x86_64-gnu-llvm-21-1](https://github.com/rust-lang/rust/actions/runs/21617345733#summary-62299011923): 1h 9m -> 1h 15m (+9.0%)