### PR TITLE
Fix ICE on coverage span context mismatch for nested macros

### DIFF
--- a/compiler/rustc_mir_transform/src/coverage/spans.rs
+++ b/compiler/rustc_mir_transform/src/coverage/spans.rs
@@ -54,13 +54,13 @@ pub(super) fn extract_refined_covspans<'tcx>(
                 return false;
             }
 
-            // Each pushed covspan should have the same context as the body span.
-            // If it somehow doesn't, discard the covspan, or panic in debug builds.
-            if !body_span.eq_ctxt(covspan_span) {
-                debug_assert!(
-                    false,
-                    "span context mismatch: body_span={body_span:?}, covspan.span={covspan_span:?}"
-                );
+            // Each covspan should have the same context as the body span.
+            // For nested macro expansions, contexts might differ. In that case,
+            // we check if the covspan resulted from a macro expansion that happened
+            // inside the function body.
+            if !body_span.eq_ctxt(covspan_span)
+                && covspan_span.find_ancestor_inside(body_span).is_none()
+            {
                 return false;
             }
 

--- a/tests/ui/instrument-coverage/nested-macro-coverage-issue-147339.rs
+++ b/tests/ui/instrument-coverage/nested-macro-coverage-issue-147339.rs
@@ -1,0 +1,19 @@
+//@ check-pass
+//@ compile-flags: -Cinstrument-coverage -Zno-profiler-runtime
+//@ edition: 2024
+
+// Regression test for issue #147339
+// Nested macro expansions should not cause ICE during coverage instrumentation
+
+macro_rules! foo {
+    ($($m:ident $($f:ident $v:tt)+),*) => {
+        $($(macro_rules! $f { () => { $v } })+)*
+        $(macro_rules! $m { () => { $(fn $f() -> i32 { $v })+ } })*
+    }
+}
+
+foo!(m a 1 b 2, n c 3);
+m!();
+n!();
+
+fn main() {}


### PR DESCRIPTION
Fixes rust-lang/rust#147339

r? @Zalathar 