### PR TITLE
cfgs for target modifiers

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -13,7 +13,7 @@ use rustc_hir::{AttrPath, RustcVersion, Target};
 use rustc_parse::parser::{ForceCollect, Parser};
 use rustc_parse::{exp, parse_in};
 use rustc_session::Session;
-use rustc_session::config::ExpectedValues;
+use rustc_session::config::{ExpectedValues, Z_OPTIONS};
 use rustc_session::lint::builtin::UNEXPECTED_CFGS;
 use rustc_session::parse::{ParseSess, feature_err};
 use rustc_span::{ErrorGuaranteed, Span, Symbol, sym};
@@ -410,6 +410,20 @@ fn try_gate_cfg(name: Symbol, span: Span, sess: &Session, features: Option<&Feat
     let gate = find_gated_cfg(|sym| sym == name);
     if let (Some(feats), Some(gated_cfg)) = (features, gate) {
         gate_cfg(gated_cfg, span, sess, feats);
+    }
+
+    let gate =
+        Z_OPTIONS.iter().filter_map(|opt| opt.target_modifier_cfg()).find(|cfg| *cfg == name).map(
+            |cfg| {
+                (
+                    cfg,
+                    sym::cfg_unstable_target_modifier,
+                    Features::cfg_unstable_target_modifier as for<'a> fn(&'a Features) -> _,
+                )
+            },
+        );
+    if let (Some(feats), Some(gated_cfg)) = (features, gate) {
+        gate_cfg(&gated_cfg, span, sess, feats);
     }
 }
 

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -217,6 +217,8 @@ declare_features! (
     (internal, cfg_emscripten_wasm_eh, "1.86.0", None),
     /// Allows checking whether or not the backend correctly supports unstable float types.
     (internal, cfg_target_has_reliable_f16_f128, "1.88.0", None),
+    /// Allows use of `cfg` for unstable target modifier flags
+    (unstable, cfg_unstable_target_modifier, "CURRENT_RUSTC_VERSION", None),
     /// Allows identifying the `compiler_builtins` crate.
     (internal, compiler_builtins, "1.13.0", None),
     /// Allows writing custom MIR

--- a/compiler/rustc_session/src/config/cfg.rs
+++ b/compiler/rustc_session/src/config/cfg.rs
@@ -452,6 +452,15 @@ impl CheckCfg {
                 .map(Symbol::intern),
         );
 
+        // FIXME(target_modifiers): Find a way to work out what the appropriate values for these
+        // options are here
+        for cfg in CG_OPTIONS.iter().filter_map(|desc| desc.target_modifier_cfg()) {
+            ins!(cfg, || ExpectedValues::Any);
+        }
+        for cfg in Z_OPTIONS.iter().filter_map(|desc| desc.target_modifier_cfg()) {
+            ins!(cfg, || ExpectedValues::Any);
+        }
+
         // sym::target_*
         {
             const VALUES: [&Symbol; 8] = [

--- a/compiler/rustc_session/src/config/cfg.rs
+++ b/compiler/rustc_session/src/config/cfg.rs
@@ -20,6 +20,7 @@
 //!  - Add the cfg in [`disallow_cfgs`] to disallow users from setting it via `--cfg`
 //!  - Add the feature gating in `compiler/rustc_feature/src/builtin_attrs.rs`
 
+use std::borrow::Cow;
 use std::hash::Hash;
 use std::iter;
 
@@ -30,7 +31,7 @@ use rustc_lint_defs::builtin::EXPLICIT_BUILTIN_CFGS_IN_FLAGS;
 use rustc_span::{Symbol, sym};
 use rustc_target::spec::{PanicStrategy, RelocModel, SanitizerSet, Target};
 
-use crate::config::{CrateType, FmtDebug};
+use crate::config::{CG_OPTIONS, CrateType, FmtDebug, OptionDesc, OptionPrefix, Z_OPTIONS};
 use crate::{Session, errors};
 
 /// The parsed `--cfg` options that define the compilation environment of the
@@ -115,20 +116,20 @@ pub(crate) fn disallow_cfgs(sess: &Session, user_cfgs: &Cfg) {
 
     for cfg in user_cfgs {
         match cfg {
-            (sym::overflow_checks, None) => disallow(cfg, "-C overflow-checks"),
-            (sym::debug_assertions, None) => disallow(cfg, "-C debug-assertions"),
-            (sym::ub_checks, None) => disallow(cfg, "-Z ub-checks"),
-            (sym::contract_checks, None) => disallow(cfg, "-Z contract-checks"),
-            (sym::sanitize, None | Some(_)) => disallow(cfg, "-Z sanitizer"),
+            (sym::overflow_checks, None) => disallow(cfg, Cow::Borrowed("-C overflow-checks")),
+            (sym::debug_assertions, None) => disallow(cfg, Cow::Borrowed("-C debug-assertions")),
+            (sym::ub_checks, None) => disallow(cfg, Cow::Borrowed("-Z ub-checks")),
+            (sym::contract_checks, None) => disallow(cfg, Cow::Borrowed("-Z contract-checks")),
+            (sym::sanitize, None | Some(_)) => disallow(cfg, Cow::Borrowed("-Z sanitizer")),
             (
                 sym::sanitizer_cfi_generalize_pointers | sym::sanitizer_cfi_normalize_integers,
                 None | Some(_),
-            ) => disallow(cfg, "-Z sanitizer=cfi"),
-            (sym::proc_macro, None) => disallow(cfg, "--crate-type proc-macro"),
+            ) => disallow(cfg, Cow::Borrowed("-Z sanitizer=cfi")),
+            (sym::proc_macro, None) => disallow(cfg, Cow::Borrowed("--crate-type proc-macro")),
             (sym::panic, Some(sym::abort | sym::unwind | sym::immediate_abort)) => {
-                disallow(cfg, "-C panic")
+                disallow(cfg, Cow::Borrowed("-C panic"))
             }
-            (sym::target_feature, Some(_)) => disallow(cfg, "-C target-feature"),
+            (sym::target_feature, Some(_)) => disallow(cfg, Cow::Borrowed("-C target-feature")),
             (sym::unix, None)
             | (sym::windows, None)
             | (sym::relocation_model, Some(_))
@@ -147,11 +148,31 @@ pub(crate) fn disallow_cfgs(sess: &Session, user_cfgs: &Cfg) {
             | (sym::target_has_reliable_f16_math, None | Some(_))
             | (sym::target_has_reliable_f128, None | Some(_))
             | (sym::target_has_reliable_f128_math, None | Some(_))
-            | (sym::target_thread_local, None) => disallow(cfg, "--target"),
-            (sym::fmt_debug, None | Some(_)) => disallow(cfg, "-Z fmt-debug"),
-            (sym::emscripten_wasm_eh, None | Some(_)) => disallow(cfg, "-Z emscripten_wasm_eh"),
+            | (sym::target_thread_local, None) => disallow(cfg, Cow::Borrowed("--target")),
+            (sym::fmt_debug, None | Some(_)) => disallow(cfg, Cow::Borrowed("-Z fmt-debug")),
+            (sym::emscripten_wasm_eh, None | Some(_)) => {
+                disallow(cfg, Cow::Borrowed("-Z emscripten_wasm_eh"))
+            }
             _ => {}
         }
+    }
+
+    // Also prohibit setting any target modifier cfgs, these all have corresponding flags.
+    fn target_modifiers_with_cfgs(
+        desc: &OptionDesc<impl OptionPrefix>,
+    ) -> Option<(String, Symbol)> {
+        desc.target_modifier_cfg().map(|sym| (desc.flag(), sym))
+    }
+    let check_target_modifier_with_cfg = |flag, flag_cfg| {
+        if let Some(matching_cfg) = user_cfgs.iter().find(|(cfg, _)| *cfg == flag_cfg) {
+            disallow(matching_cfg, Cow::Owned(flag));
+        }
+    };
+    for (flag, cfg) in CG_OPTIONS.iter().filter_map(target_modifiers_with_cfgs) {
+        check_target_modifier_with_cfg(flag, cfg);
+    }
+    for (flag, cfg) in Z_OPTIONS.iter().filter_map(target_modifiers_with_cfgs) {
+        check_target_modifier_with_cfg(flag, cfg);
     }
 }
 

--- a/compiler/rustc_session/src/config/cfg.rs
+++ b/compiler/rustc_session/src/config/cfg.rs
@@ -300,6 +300,30 @@ pub(crate) fn default_configuration(sess: &Session) -> Cfg {
 
     ins_sym!(sym::target_vendor, sess.target.vendor_symbol());
 
+    // Target modifiers affect the ABI of targets and need to be accounted for in assembly, which
+    // necessitates a way to detect whether a target modifier has been set.
+    let target_modifiers = sess.opts.gather_target_modifiers();
+    for target_modifier in target_modifiers {
+        if let Some(key) = target_modifier.opt.cfg() {
+            if target_modifier.value_name.is_empty() {
+                ins_none!(key);
+                break;
+            }
+
+            // Flags like `branch-protection` accept a list of options, but without hardcoding a
+            // check for each parsed target modifier flag here, it's not especially practical to
+            // do something more robust than just split on ','.
+            let values = if target_modifier.value_name.contains(',') {
+                target_modifier.value_name.split(',').collect()
+            } else {
+                vec![target_modifier.value_name.as_str()]
+            };
+            for value in values {
+                ins_sym!(key, Symbol::intern(value));
+            }
+        }
+    }
+
     // If the user wants a test runner, then add the test cfg.
     if sess.is_test_crate() {
         ins_none!(sym::test);

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::num::{NonZero, ParseIntError};
 
 use rustc_ast::token;
@@ -514,5 +515,5 @@ pub(crate) struct SoftFloatDeprecated;
 pub(crate) struct UnexpectedBuiltinCfg {
     pub(crate) cfg: String,
     pub(crate) cfg_name: Symbol,
-    pub(crate) controlled_by: &'static str,
+    pub(crate) controlled_by: Cow<'static, str>,
 }

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -13,7 +13,7 @@ use rustc_hashes::Hash64;
 use rustc_hir::attrs::CollapseMacroDebuginfo;
 use rustc_macros::{BlobDecodable, Encodable};
 use rustc_span::edition::Edition;
-use rustc_span::{RealFileName, RemapPathScopeComponents, SourceFileHashAlgorithm};
+use rustc_span::{RealFileName, RemapPathScopeComponents, SourceFileHashAlgorithm, Symbol};
 use rustc_target::spec::{
     CodeModel, FramePointer, LinkerFlavorCli, MergeFunctions, OnBrokenPipe, PanicStrategy,
     RelocModel, RelroLevel, SanitizerSet, SplitDebuginfo, StackProtector, SymbolVisibility,
@@ -185,7 +185,15 @@ macro_rules! gather_tmods {
         compile_error!("SUBSTRUCT can't be target modifier");
     };
     ($struct_name:ident, $tmod_enum_name:ident, $opt_name:ident, $opt_expr:expr, $init:expr, $mods:expr, $tmod_vals:expr,
+        [SUBSTRUCT], [TARGET_MODIFIER_CFG]) => {
+        compile_error!("SUBSTRUCT can't be target modifier");
+    };
+    ($struct_name:ident, $tmod_enum_name:ident, $opt_name:ident, $opt_expr:expr, $init:expr, $mods:expr, $tmod_vals:expr,
         [UNTRACKED], [TARGET_MODIFIER]) => {
+        tmod_push!($struct_name, $tmod_enum_name, $opt_name, $opt_expr, $init, $mods, $tmod_vals)
+    };
+    ($struct_name:ident, $tmod_enum_name:ident, $opt_name:ident, $opt_expr:expr, $init:expr, $mods:expr, $tmod_vals:expr,
+        [UNTRACKED], [TARGET_MODIFIER_CFG]) => {
         tmod_push!($struct_name, $tmod_enum_name, $opt_name, $opt_expr, $init, $mods, $tmod_vals)
     };
     ($struct_name:ident, $tmod_enum_name:ident, $opt_name:ident, $opt_expr:expr, $init:expr, $mods:expr, $tmod_vals:expr,
@@ -193,7 +201,15 @@ macro_rules! gather_tmods {
         tmod_push!($struct_name, $tmod_enum_name, $opt_name, $opt_expr, $init, $mods, $tmod_vals)
     };
     ($struct_name:ident, $tmod_enum_name:ident, $opt_name:ident, $opt_expr:expr, $init:expr, $mods:expr, $tmod_vals:expr,
+        [TRACKED], [TARGET_MODIFIER_CFG]) => {
+        tmod_push!($struct_name, $tmod_enum_name, $opt_name, $opt_expr, $init, $mods, $tmod_vals)
+    };
+    ($struct_name:ident, $tmod_enum_name:ident, $opt_name:ident, $opt_expr:expr, $init:expr, $mods:expr, $tmod_vals:expr,
         [TRACKED_NO_CRATE_HASH], [TARGET_MODIFIER]) => {
+        tmod_push!($struct_name, $tmod_enum_name, $opt_name, $opt_expr, $init, $mods, $tmod_vals)
+    };
+    ($struct_name:ident, $tmod_enum_name:ident, $opt_name:ident, $opt_expr:expr, $init:expr, $mods:expr, $tmod_vals:expr,
+        [TRACKED_NO_CRATE_HASH], [TARGET_MODIFIER_CFG]) => {
         tmod_push!($struct_name, $tmod_enum_name, $opt_name, $opt_expr, $init, $mods, $tmod_vals)
     };
     ($struct_name:ident, $tmod_enum_name:ident, $opt_name:ident, $opt_expr:expr, $init:expr, $mods:expr, $tmod_vals:expr,
@@ -240,13 +256,14 @@ macro_rules! gather_tmods_top_level {
 /// ```
 macro_rules! top_level_tmod_enum {
     ($( {$($optinfo:tt)*} ),* $(,)*) => {
-        top_level_tmod_enum! { @parse {}, (user_value){}; $($($optinfo)*|)* }
+        top_level_tmod_enum! { @parse {}, (user_value){}, {}; $($($optinfo)*|)* }
     };
     // Termination
     (
         @parse
         {$($variant:tt($substruct_enum:tt))*},
-        ($user_value:ident){$($pout:tt)*};
+        ($user_value:ident){$($pout:tt)*},
+        {$($cout:tt)*};
     ) => {
         #[allow(non_camel_case_types)]
         #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Copy, Clone, Encodable, BlobDecodable)]
@@ -265,11 +282,19 @@ macro_rules! top_level_tmod_enum {
             pub fn is_target_modifier(flag_name: &str) -> bool {
                 $($substruct_enum::is_target_modifier(flag_name))||*
             }
+            pub fn cfg(&self) -> Option<Symbol> {
+                #[allow(unreachable_patterns)]
+                match self {
+                    $($cout)*
+                    _ => panic!("unknown target modifier option: {:?}", *self)
+
+                }
+            }
         }
     };
     // Adding SUBSTRUCT option group into $eout
     (
-        @parse {$($eout:tt)*}, ($puser_value:ident){$($pout:tt)*};
+        @parse {$($eout:tt)*}, ($puser_value:ident){$($pout:tt)*}, {$($cout:tt)*};
             [SUBSTRUCT $substruct_enum:ident $variant:ident] |
         $($tail:tt)*
     ) => {
@@ -282,13 +307,17 @@ macro_rules! top_level_tmod_enum {
             ($puser_value){
                 $($pout)*
                 Self::$variant(v) => v.reparse($puser_value),
+            },
+            {
+                $($cout)*
+                Self::$variant(v) => v.cfg(),
             };
             $($tail)*
         }
     };
     // Skipping non-target-modifier and non-substruct
     (
-        @parse {$($eout:tt)*}, ($puser_value:ident){$($pout:tt)*};
+        @parse {$($eout:tt)*}, ($puser_value:ident){$($pout:tt)*}, {$($cout:tt)*};
             [$non_substruct:ident] |
         $($tail:tt)*
     ) => {
@@ -299,6 +328,9 @@ macro_rules! top_level_tmod_enum {
             },
             ($puser_value){
                 $($pout)*
+            },
+            {
+                $($cout)*
             };
             $($tail)*
         }
@@ -512,16 +544,20 @@ macro_rules! tmod_enum_opt {
     };
 }
 
+/// Prefix used for cfgs of target modifier flags.
+const TARGET_MODIFIER_CFG_PREFIX: &'static str = "target_modifier";
+
 macro_rules! tmod_enum {
     ($tmod_enum_name:ident, $prefix:expr, $( {$($optinfo:tt)*} ),* $(,)*) => {
-        tmod_enum! { $tmod_enum_name, $prefix, @parse {}, (user_value){}; $($($optinfo)*|)* }
+        tmod_enum! { $tmod_enum_name, $prefix, @parse {}, (user_value){}, {}; $($($optinfo)*|)* }
     };
     // Termination
     (
         $tmod_enum_name:ident, $prefix:expr,
         @parse
         {$($eout:tt)*},
-        ($user_value:ident){$($pout:tt)*};
+        ($user_value:ident){$($pout:tt)*},
+        {$($cout:tt)*};
     ) => {
         #[allow(non_camel_case_types)]
         #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Copy, Clone, Encodable, BlobDecodable)]
@@ -543,12 +579,19 @@ macro_rules! tmod_enum {
                     _ => false,
                 }
             }
+            pub fn cfg(&self) -> Option<Symbol> {
+                #[allow(unreachable_patterns)]
+                match self {
+                    $($cout)*
+                    _ => None,
+                }
+            }
         }
     };
     // Adding target-modifier option into $eout
     (
         $tmod_enum_name:ident, $prefix:expr,
-        @parse {$($eout:tt)*}, ($puser_value:ident){$($pout:tt)*};
+        @parse {$($eout:tt)*}, ($puser_value:ident){$($pout:tt)*}, {$($cout:tt)*};
             $opt:ident, $parse:ident, $t:ty, [TARGET_MODIFIER] |
         $($tail:tt)*
     ) => {
@@ -571,6 +614,47 @@ macro_rules! tmod_enum {
                         tech_value: format!("{:?}", parsed),
                     }
                 },
+            },
+            {
+                $($cout)*
+                Self::$opt => None,
+            };
+            $($tail)*
+        }
+    };
+    (
+        $tmod_enum_name:ident, $prefix:expr,
+        @parse {$($eout:tt)*}, ($puser_value:ident){$($pout:tt)*}, {$($cout:tt)*};
+            $opt:ident, $parse:ident, $t:ty, [TARGET_MODIFIER_CFG] |
+        $($tail:tt)*
+    ) => {
+        tmod_enum! {
+            $tmod_enum_name, $prefix,
+            @parse
+            {
+                $($eout)*
+                $opt
+            },
+            ($puser_value){
+                $($pout)*
+                Self::$opt => {
+                    let mut parsed : $t = Default::default();
+                    let val = if $puser_value.is_empty() { None } else { Some($puser_value) };
+                    parse::$parse(&mut parsed, val);
+                    ExtendedTargetModifierInfo {
+                        prefix: $prefix.to_string(),
+                        name: stringify!($opt).to_string().replace('_', "-"),
+                        tech_value: format!("{:?}", parsed),
+                    }
+                },
+            },
+            {
+                $($cout)*
+                Self::$opt => {
+                    Some(Symbol::intern(
+                        &format!("{TARGET_MODIFIER_CFG_PREFIX}_{}", stringify!($opt))
+                    ))
+                },
             };
             $($tail)*
         }
@@ -578,7 +662,7 @@ macro_rules! tmod_enum {
     // Skipping non-target-modifier
     (
         $tmod_enum_name:ident, $prefix:expr,
-        @parse {$($eout:tt)*}, ($puser_value:ident){$($pout:tt)*};
+        @parse {$($eout:tt)*}, ($puser_value:ident){$($pout:tt)*}, {$($cout:tt)*};
             $opt:ident, $parse:ident, $t:ty, [] |
         $($tail:tt)*
     ) => {
@@ -590,6 +674,9 @@ macro_rules! tmod_enum {
             },
             ($puser_value){
                 $($pout)*
+            },
+            {
+                $($cout)*
             };
             $($tail)*
         }
@@ -665,6 +752,10 @@ macro_rules! options {
         }
     }
 
+    impl OptionPrefix for $struct_name {
+        const PREFIX: &'static str = $prefix;
+    }
+
     pub const $stat: OptionDescrs<$struct_name> =
         &[ $( OptionDesc{ name: stringify!($opt), setter: $optmod::$opt,
             type_desc: desc::$parse, desc: $desc, is_deprecated_and_do_nothing: false $( || $dnn )?,
@@ -702,6 +793,10 @@ macro_rules! redirect_field {
     };
 }
 
+pub trait OptionPrefix {
+    const PREFIX: &'static str;
+}
+
 type OptionSetter<O> = fn(&mut O, v: Option<&str>) -> bool;
 type OptionDescrs<O> = &'static [OptionDesc<O>];
 
@@ -723,6 +818,16 @@ impl<O> OptionDesc<O> {
 
     pub fn desc(&self) -> &'static str {
         self.desc
+    }
+
+    pub fn target_modifier_cfg(&self) -> Option<Symbol> {
+        self.tmod.and_then(|tmod| tmod.cfg())
+    }
+}
+
+impl<O: OptionPrefix> OptionDesc<O> {
+    pub fn flag(&self) -> String {
+        format!("-{} {}", <O as OptionPrefix>::PREFIX, self.name().replace('_', "-"))
     }
 }
 
@@ -2353,7 +2458,7 @@ options! {
     fewer_names: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "reduce memory use by retaining fewer names within compilation artifacts (LLVM-IR) \
         (default: no)"),
-    fixed_x18: bool = (false, parse_bool, [TRACKED TARGET_MODIFIER],
+    fixed_x18: bool = (false, parse_bool, [TRACKED TARGET_MODIFIER_CFG],
         "make the x18 register reserved on AArch64 (default: no)"),
     flatten_format_args: bool = (true, parse_bool, [TRACKED],
         "flatten nested format_args!() and literals into a simplified format_args!() call \
@@ -2397,7 +2502,7 @@ options! {
         - hashes of green query instances
         - hash collisions of query keys
         - hash collisions when creating dep-nodes"),
-    indirect_branch_cs_prefix: bool = (false, parse_bool, [TRACKED TARGET_MODIFIER],
+    indirect_branch_cs_prefix: bool = (false, parse_bool, [TRACKED TARGET_MODIFIER_CFG],
         "add `cs` prefix to `call` and `jmp` to indirect thunks (default: no)"),
     inline_llvm: bool = (true, parse_bool, [TRACKED],
         "enable LLVM inlining (default: yes)"),
@@ -2583,10 +2688,10 @@ options! {
         "enable queries of the dependency graph for regression testing (default: no)"),
     randomize_layout: bool = (false, parse_bool, [TRACKED],
         "randomize the layout of types (default: no)"),
-    reg_struct_return: bool = (false, parse_bool, [TRACKED TARGET_MODIFIER],
+    reg_struct_return: bool = (false, parse_bool, [TRACKED TARGET_MODIFIER_CFG],
         "On x86-32 targets, it overrides the default ABI to return small structs in registers.
         It is UNSOUND to link together crates that use different values for this flag!"),
-    regparm: Option<u32> = (None, parse_opt_number, [TRACKED TARGET_MODIFIER],
+    regparm: Option<u32> = (None, parse_opt_number, [TRACKED TARGET_MODIFIER_CFG],
         "On x86-32 targets, setting this to N causes the compiler to pass N arguments \
         in registers EAX, EDX, and ECX instead of on the stack for\
         \"C\", \"cdecl\", and \"stdcall\" fn.\
@@ -2598,9 +2703,9 @@ options! {
     remark_dir: Option<PathBuf> = (None, parse_opt_pathbuf, [UNTRACKED],
         "directory into which to write optimization remarks (if not specified, they will be \
 written to standard error output)"),
-    retpoline: bool = (false, parse_bool, [TRACKED TARGET_MODIFIER],
+    retpoline: bool = (false, parse_bool, [TRACKED TARGET_MODIFIER_CFG],
         "enables retpoline-indirect-branches and retpoline-indirect-calls target features (default: no)"),
-    retpoline_external_thunk: bool = (false, parse_bool, [TRACKED TARGET_MODIFIER],
+    retpoline_external_thunk: bool = (false, parse_bool, [TRACKED TARGET_MODIFIER_CFG],
         "enables retpoline-external-thunk, retpoline-indirect-branches and retpoline-indirect-calls \
         target features (default: no)"),
     #[rustc_lint_opt_deny_field_access("use `Session::sanitizers()` instead of this field")]

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2357,7 +2357,7 @@ options! {
         (default: no)"),
     box_noalias: bool = (true, parse_bool, [TRACKED],
         "emit noalias metadata for box (default: yes)"),
-    branch_protection: Option<BranchProtection> = (None, parse_branch_protection, [TRACKED],
+    branch_protection: Option<BranchProtection> = (None, parse_branch_protection, [TRACKED TARGET_MODIFIER_CFG],
         "set options for branch target identification and pointer authentication on AArch64"),
     build_sdylib_interface: bool = (false, parse_bool, [UNTRACKED],
         "whether the stable interface is being built"),

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -676,6 +676,7 @@ symbols! {
         cfg_target_vendor,
         cfg_trace: "<cfg_trace>", // must not be a valid identifier
         cfg_ub_checks,
+        cfg_unstable_target_modifier,
         cfg_version,
         cfi,
         cfi_encoding,

--- a/tests/assembly-llvm/naked-functions/aarch64-naked-fn-no-bti-prolog.rs
+++ b/tests/assembly-llvm/naked-functions/aarch64-naked-fn-no-bti-prolog.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -C no-prepopulate-passes -Zbranch-protection=bti
+//@ compile-flags: -C no-prepopulate-passes -Zbranch-protection=bti -Cunsafe-allow-abi-mismatch=branch-protection
 //@ assembly-output: emit-asm
 //@ needs-asm-support
 //@ only-aarch64

--- a/tests/run-make/print-cfg-target-modifiers/rmake.rs
+++ b/tests/run-make/print-cfg-target-modifiers/rmake.rs
@@ -1,0 +1,85 @@
+//! This checks the output of `--print=cfg` to confirm that cfgs are correctly set for
+//! target modifier flags
+
+// ignore-tidy-linelength
+//@ needs-llvm-components: aarch64 x86
+// Note: without the needs-llvm-components it will fail on LLVM built without the required
+// components listed above.
+
+use std::collections::HashSet;
+use std::iter::FromIterator;
+
+use run_make_support::rustc;
+
+struct PrintCfg {
+    target: &'static str,
+    flag: &'static str,
+    cfgs: &'static [&'static str],
+}
+
+fn main() {
+    // `-Zfixed-x18`
+    check(PrintCfg {
+        target: "aarch64-unknown-linux-gnu",
+        flag: "-Zfixed-x18",
+        cfgs: &["target_modifier_fixed_x18"],
+    });
+    // `-Zindirect-branch-cs-prefix`
+    check(PrintCfg {
+        target: "x86_64-unknown-linux-gnu",
+        flag: "-Zindirect-branch-cs-prefix",
+        cfgs: &["target_modifier_indirect_branch_cs_prefix"],
+    });
+    // `-Zreg-struct-return`
+    check(PrintCfg {
+        target: "i686-unknown-linux-gnu",
+        flag: "-Zreg-struct-return",
+        cfgs: &["target_modifier_reg_struct_return"],
+    });
+    // `-Zregparm`
+    check(PrintCfg {
+        target: "i686-unknown-linux-gnu",
+        flag: "-Zregparm=0",
+        cfgs: &["target_modifier_regparm=\"0\""],
+    });
+    // `-Zretpoline`/`-Zretpoline-external-thunk`
+    check(PrintCfg {
+        target: "x86_64-unknown-linux-gnu",
+        flag: "-Zretpoline",
+        cfgs: &["target_modifier_retpoline"],
+    });
+    check(PrintCfg {
+        target: "x86_64-unknown-linux-gnu",
+        flag: "-Zretpoline-external-thunk",
+        cfgs: &["target_modifier_retpoline_external_thunk"],
+    });
+}
+
+fn check(PrintCfg { target, flag, cfgs }: PrintCfg) {
+    let output = rustc().target(target).arg(flag).print("cfg").run();
+    let stdout = output.stdout_utf8();
+
+    let mut found = HashSet::<String>::new();
+    let mut recorded = HashSet::<String>::new();
+
+    for l in stdout.lines() {
+        assert!(l == l.trim());
+        if let Some((left, right)) = l.split_once('=') {
+            assert!(right.starts_with("\""));
+            assert!(right.ends_with("\""));
+            assert!(!left.contains("\""));
+        } else {
+            assert!(!l.contains("\""));
+        }
+
+        assert!(recorded.insert(l.to_string()), "duplicated: {}", &l);
+        if cfgs.contains(&l) {
+            assert!(found.insert(l.to_string()), "duplicated (includes): {}", &l);
+        }
+    }
+
+    let should_found = HashSet::<String>::from_iter(cfgs.iter().map(|s| s.to_string()));
+    let diff: Vec<_> = should_found.difference(&found).collect();
+
+    assert!(diff.is_empty(), "expected: {:?}, found: {:?} (~ {:?})", &should_found, &found, &diff);
+}

--- a/tests/run-make/print-cfg-target-modifiers/rmake.rs
+++ b/tests/run-make/print-cfg-target-modifiers/rmake.rs
@@ -18,6 +18,73 @@ struct PrintCfg {
 }
 
 fn main() {
+    // `-Zbranch-protection`
+    check(PrintCfg {
+        target: "aarch64-unknown-linux-gnu",
+        flag: "-Zbranch-protection=bti",
+        cfgs: &["target_modifier_branch_protection=\"bti\""],
+    });
+    check(PrintCfg {
+        target: "aarch64-unknown-linux-gnu",
+        flag: "-Zbranch-protection=gcs",
+        cfgs: &["target_modifier_branch_protection=\"gcs\""],
+    });
+    check(PrintCfg {
+        target: "aarch64-unknown-linux-gnu",
+        flag: "-Zbranch-protection=pac-ret",
+        cfgs: &["target_modifier_branch_protection=\"pac-ret\""],
+    });
+    check(PrintCfg {
+        target: "aarch64-unknown-linux-gnu",
+        flag: "-Zbranch-protection=pac-ret,leaf",
+        cfgs: &[
+            "target_modifier_branch_protection=\"pac-ret\"",
+            "target_modifier_branch_protection=\"leaf\"",
+        ],
+    });
+    check(PrintCfg {
+        target: "aarch64-unknown-linux-gnu",
+        flag: "-Zbranch-protection=pac-ret,b-key",
+        cfgs: &[
+            "target_modifier_branch_protection=\"pac-ret\"",
+            "target_modifier_branch_protection=\"b-key\"",
+        ],
+    });
+    check(PrintCfg {
+        target: "aarch64-unknown-linux-gnu",
+        flag: "-Zbranch-protection=pac-ret,pc",
+        cfgs: &[
+            "target_modifier_branch_protection=\"pac-ret\"",
+            "target_modifier_branch_protection=\"pc\"",
+        ],
+    });
+    check(PrintCfg {
+        target: "aarch64-unknown-linux-gnu",
+        flag: "-Zbranch-protection=pac-ret,pc,b-key",
+        cfgs: &[
+            "target_modifier_branch_protection=\"pac-ret\"",
+            "target_modifier_branch_protection=\"pc\"",
+            "target_modifier_branch_protection=\"b-key\"",
+        ],
+    });
+    check(PrintCfg {
+        target: "aarch64-unknown-linux-gnu",
+        flag: "-Zbranch-protection=pac-ret,pc,leaf",
+        cfgs: &[
+            "target_modifier_branch_protection=\"pac-ret\"",
+            "target_modifier_branch_protection=\"pc\"",
+            "target_modifier_branch_protection=\"leaf\"",
+        ],
+    });
+    check(PrintCfg {
+        target: "aarch64-unknown-linux-gnu",
+        flag: "-Zbranch-protection=bti,pac-ret,pc",
+        cfgs: &[
+            "target_modifier_branch_protection=\"bti\"",
+            "target_modifier_branch_protection=\"pac-ret\"",
+            "target_modifier_branch_protection=\"pc\"",
+        ],
+    });
     // `-Zfixed-x18`
     check(PrintCfg {
         target: "aarch64-unknown-linux-gnu",

--- a/tests/ui/cfg/target-modifiers/stability.no_feat.stderr
+++ b/tests/ui/cfg/target-modifiers/stability.no_feat.stderr
@@ -1,0 +1,57 @@
+error[E0658]: `cfg(target_modifier_fixed_x18)` is experimental and subject to change
+  --> $DIR/stability.rs:9:7
+   |
+LL | #[cfg(target_modifier_fixed_x18)]
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(cfg_unstable_target_modifier)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `cfg(target_modifier_indirect_branch_cs_prefix)` is experimental and subject to change
+  --> $DIR/stability.rs:13:7
+   |
+LL | #[cfg(target_modifier_indirect_branch_cs_prefix)]
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(cfg_unstable_target_modifier)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `cfg(target_modifier_reg_struct_return)` is experimental and subject to change
+  --> $DIR/stability.rs:17:7
+   |
+LL | #[cfg(target_modifier_reg_struct_return)]
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(cfg_unstable_target_modifier)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `cfg(target_modifier_regparm)` is experimental and subject to change
+  --> $DIR/stability.rs:21:7
+   |
+LL | #[cfg(target_modifier_regparm="0")]
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(cfg_unstable_target_modifier)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `cfg(target_modifier_retpoline)` is experimental and subject to change
+  --> $DIR/stability.rs:25:7
+   |
+LL | #[cfg(target_modifier_retpoline)]
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(cfg_unstable_target_modifier)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `cfg(target_modifier_retpoline_external_thunk)` is experimental and subject to change
+  --> $DIR/stability.rs:29:7
+   |
+LL | #[cfg(target_modifier_retpoline_external_thunk)]
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(cfg_unstable_target_modifier)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/cfg/target-modifiers/stability.no_feat.stderr
+++ b/tests/ui/cfg/target-modifiers/stability.no_feat.stderr
@@ -1,5 +1,5 @@
 error[E0658]: `cfg(target_modifier_fixed_x18)` is experimental and subject to change
-  --> $DIR/stability.rs:9:7
+  --> $DIR/stability.rs:8:7
    |
 LL | #[cfg(target_modifier_fixed_x18)]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL | #[cfg(target_modifier_fixed_x18)]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(target_modifier_indirect_branch_cs_prefix)` is experimental and subject to change
-  --> $DIR/stability.rs:13:7
+  --> $DIR/stability.rs:12:7
    |
 LL | #[cfg(target_modifier_indirect_branch_cs_prefix)]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL | #[cfg(target_modifier_indirect_branch_cs_prefix)]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(target_modifier_reg_struct_return)` is experimental and subject to change
-  --> $DIR/stability.rs:17:7
+  --> $DIR/stability.rs:16:7
    |
 LL | #[cfg(target_modifier_reg_struct_return)]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -26,7 +26,7 @@ LL | #[cfg(target_modifier_reg_struct_return)]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(target_modifier_regparm)` is experimental and subject to change
-  --> $DIR/stability.rs:21:7
+  --> $DIR/stability.rs:20:7
    |
 LL | #[cfg(target_modifier_regparm="0")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -35,7 +35,7 @@ LL | #[cfg(target_modifier_regparm="0")]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(target_modifier_retpoline)` is experimental and subject to change
-  --> $DIR/stability.rs:25:7
+  --> $DIR/stability.rs:24:7
    |
 LL | #[cfg(target_modifier_retpoline)]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -44,7 +44,7 @@ LL | #[cfg(target_modifier_retpoline)]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(target_modifier_retpoline_external_thunk)` is experimental and subject to change
-  --> $DIR/stability.rs:29:7
+  --> $DIR/stability.rs:28:7
    |
 LL | #[cfg(target_modifier_retpoline_external_thunk)]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/cfg/target-modifiers/stability.no_feat.stderr
+++ b/tests/ui/cfg/target-modifiers/stability.no_feat.stderr
@@ -1,5 +1,14 @@
-error[E0658]: `cfg(target_modifier_fixed_x18)` is experimental and subject to change
+error[E0658]: `cfg(target_modifier_branch_protection)` is experimental and subject to change
   --> $DIR/stability.rs:8:7
+   |
+LL | #[cfg(target_modifier_branch_protection="bti")]
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(cfg_unstable_target_modifier)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `cfg(target_modifier_fixed_x18)` is experimental and subject to change
+  --> $DIR/stability.rs:12:7
    |
 LL | #[cfg(target_modifier_fixed_x18)]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +17,7 @@ LL | #[cfg(target_modifier_fixed_x18)]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(target_modifier_indirect_branch_cs_prefix)` is experimental and subject to change
-  --> $DIR/stability.rs:12:7
+  --> $DIR/stability.rs:16:7
    |
 LL | #[cfg(target_modifier_indirect_branch_cs_prefix)]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -17,7 +26,7 @@ LL | #[cfg(target_modifier_indirect_branch_cs_prefix)]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(target_modifier_reg_struct_return)` is experimental and subject to change
-  --> $DIR/stability.rs:16:7
+  --> $DIR/stability.rs:20:7
    |
 LL | #[cfg(target_modifier_reg_struct_return)]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -26,7 +35,7 @@ LL | #[cfg(target_modifier_reg_struct_return)]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(target_modifier_regparm)` is experimental and subject to change
-  --> $DIR/stability.rs:20:7
+  --> $DIR/stability.rs:24:7
    |
 LL | #[cfg(target_modifier_regparm="0")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -35,7 +44,7 @@ LL | #[cfg(target_modifier_regparm="0")]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(target_modifier_retpoline)` is experimental and subject to change
-  --> $DIR/stability.rs:24:7
+  --> $DIR/stability.rs:28:7
    |
 LL | #[cfg(target_modifier_retpoline)]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -44,7 +53,7 @@ LL | #[cfg(target_modifier_retpoline)]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(target_modifier_retpoline_external_thunk)` is experimental and subject to change
-  --> $DIR/stability.rs:28:7
+  --> $DIR/stability.rs:32:7
    |
 LL | #[cfg(target_modifier_retpoline_external_thunk)]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -52,6 +61,6 @@ LL | #[cfg(target_modifier_retpoline_external_thunk)]
    = help: add `#![feature(cfg_unstable_target_modifier)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/cfg/target-modifiers/stability.rs
+++ b/tests/ui/cfg/target-modifiers/stability.rs
@@ -5,6 +5,10 @@
 
 #![cfg_attr(feat, feature(cfg_unstable_target_modifier))]
 
+#[cfg(target_modifier_branch_protection="bti")]
+//[no_feat]~^ ERROR: `cfg(target_modifier_branch_protection)` is experimental and subject to change
+fn branch_protection() {}
+
 #[cfg(target_modifier_fixed_x18)]
 //[no_feat]~^ ERROR: `cfg(target_modifier_fixed_x18)` is experimental and subject to change
 fn fixed_x18() {}

--- a/tests/ui/cfg/target-modifiers/stability.rs
+++ b/tests/ui/cfg/target-modifiers/stability.rs
@@ -3,7 +3,6 @@
 //@[feat] check-pass
 //@[no_feat] check-fail
 
-#![allow(unexpected_cfgs)]
 #![cfg_attr(feat, feature(cfg_unstable_target_modifier))]
 
 #[cfg(target_modifier_fixed_x18)]

--- a/tests/ui/cfg/target-modifiers/stability.rs
+++ b/tests/ui/cfg/target-modifiers/stability.rs
@@ -1,0 +1,31 @@
+//@ compile-flags: --crate-type=lib
+//@ revisions: feat no_feat
+//@[feat] check-pass
+//@[no_feat] check-fail
+
+#![allow(unexpected_cfgs)]
+#![cfg_attr(feat, feature(cfg_unstable_target_modifier))]
+
+#[cfg(target_modifier_fixed_x18)]
+//[no_feat]~^ ERROR: `cfg(target_modifier_fixed_x18)` is experimental and subject to change
+fn fixed_x18() {}
+
+#[cfg(target_modifier_indirect_branch_cs_prefix)]
+//[no_feat]~^ ERROR: `cfg(target_modifier_indirect_branch_cs_prefix)` is experimental and subject to change
+fn indirect_branch_cs_prefix() {}
+
+#[cfg(target_modifier_reg_struct_return)]
+//[no_feat]~^ ERROR: `cfg(target_modifier_reg_struct_return)` is experimental and subject to change
+fn reg_struct_return() {}
+
+#[cfg(target_modifier_regparm="0")]
+//[no_feat]~^ ERROR: `cfg(target_modifier_regparm)` is experimental and subject to change
+fn regparm() {}
+
+#[cfg(target_modifier_retpoline)]
+//[no_feat]~^ ERROR: `cfg(target_modifier_retpoline)` is experimental and subject to change
+fn retpoline() {}
+
+#[cfg(target_modifier_retpoline_external_thunk)]
+//[no_feat]~^ ERROR: `cfg(target_modifier_retpoline_external_thunk)` is experimental and subject to change
+fn retpoline_external_thunk() {}

--- a/tests/ui/cfg/target-modifiers/user-sets.branch_protection.stderr
+++ b/tests/ui/cfg/target-modifiers/user-sets.branch_protection.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg target_modifier_branch_protection="bti"` flag
+   |
+   = note: config `target_modifier_branch_protection` is only supposed to be controlled by `-Z branch-protection`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/target-modifiers/user-sets.fixed_x18.stderr
+++ b/tests/ui/cfg/target-modifiers/user-sets.fixed_x18.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg target_modifier_fixed_x18` flag
+   |
+   = note: config `target_modifier_fixed_x18` is only supposed to be controlled by `-Z fixed-x18`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/target-modifiers/user-sets.indirect_branch_cs_prefix.stderr
+++ b/tests/ui/cfg/target-modifiers/user-sets.indirect_branch_cs_prefix.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg target_modifier_indirect_branch_cs_prefix` flag
+   |
+   = note: config `target_modifier_indirect_branch_cs_prefix` is only supposed to be controlled by `-Z indirect-branch-cs-prefix`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/target-modifiers/user-sets.reg_struct_return.stderr
+++ b/tests/ui/cfg/target-modifiers/user-sets.reg_struct_return.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg target_modifier_reg_struct_return` flag
+   |
+   = note: config `target_modifier_reg_struct_return` is only supposed to be controlled by `-Z reg-struct-return`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/target-modifiers/user-sets.regparm.stderr
+++ b/tests/ui/cfg/target-modifiers/user-sets.regparm.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg target_modifier_regparm="0"` flag
+   |
+   = note: config `target_modifier_regparm` is only supposed to be controlled by `-Z regparm`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/target-modifiers/user-sets.retpoline.stderr
+++ b/tests/ui/cfg/target-modifiers/user-sets.retpoline.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg target_modifier_retpoline` flag
+   |
+   = note: config `target_modifier_retpoline` is only supposed to be controlled by `-Z retpoline`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/target-modifiers/user-sets.retpoline_external_thunk.stderr
+++ b/tests/ui/cfg/target-modifiers/user-sets.retpoline_external_thunk.stderr
@@ -1,0 +1,8 @@
+error: unexpected `--cfg target_modifier_retpoline_external_thunk` flag
+   |
+   = note: config `target_modifier_retpoline_external_thunk` is only supposed to be controlled by `-Z retpoline-external-thunk`
+   = note: manually setting a built-in cfg can and does create incoherent behaviors
+   = note: `#[deny(explicit_builtin_cfgs_in_flags)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/cfg/target-modifiers/user-sets.rs
+++ b/tests/ui/cfg/target-modifiers/user-sets.rs
@@ -1,0 +1,14 @@
+//@ check-fail
+//@ compile-flags: --crate-type=lib
+//@ revisions: fixed_x18 indirect_branch_cs_prefix regparm
+//@ revisions: reg_struct_return retpoline retpoline_external_thunk
+//@[fixed_x18] compile-flags: --cfg target_modifier_fixed_x18
+//@[indirect_branch_cs_prefix] compile-flags: --cfg target_modifier_indirect_branch_cs_prefix
+//@[regparm] compile-flags: --cfg target_modifier_regparm="0"
+//@[reg_struct_return] compile-flags: --cfg target_modifier_reg_struct_return
+//@[retpoline] compile-flags: --cfg target_modifier_retpoline
+//@[retpoline_external_thunk] compile-flags: --cfg target_modifier_retpoline_external_thunk
+
+fn main() {}
+
+//~? ERROR unexpected `--cfg

--- a/tests/ui/cfg/target-modifiers/user-sets.rs
+++ b/tests/ui/cfg/target-modifiers/user-sets.rs
@@ -1,7 +1,8 @@
 //@ check-fail
 //@ compile-flags: --crate-type=lib
-//@ revisions: fixed_x18 indirect_branch_cs_prefix regparm
+//@ revisions: branch_protection fixed_x18 indirect_branch_cs_prefix regparm
 //@ revisions: reg_struct_return retpoline retpoline_external_thunk
+//@[branch_protection] compile-flags: --cfg target_modifier_branch_protection="bti"
 //@[fixed_x18] compile-flags: --cfg target_modifier_fixed_x18
 //@[indirect_branch_cs_prefix] compile-flags: --cfg target_modifier_indirect_branch_cs_prefix
 //@[regparm] compile-flags: --cfg target_modifier_regparm="0"

--- a/tests/ui/check-cfg/cargo-build-script.stderr
+++ b/tests/ui/check-cfg/cargo-build-script.stderr
@@ -4,7 +4,7 @@ warning: unexpected `cfg` condition name: `has_foo`
 LL | #[cfg(has_foo)]
    |       ^^^^^^^
    |
-   = help: expected names are: `has_bar` and 31 more
+   = help: expected names are: `has_bar` and 38 more
    = help: consider using a Cargo feature instead
    = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
             [lints.rust]

--- a/tests/ui/check-cfg/cargo-feature.none.stderr
+++ b/tests/ui/check-cfg/cargo-feature.none.stderr
@@ -25,7 +25,7 @@ warning: unexpected `cfg` condition name: `tokio_unstable`
 LL | #[cfg(tokio_unstable)]
    |       ^^^^^^^^^^^^^^
    |
-   = help: expected names are: `docsrs`, `feature`, and `test` and 31 more
+   = help: expected names are: `docsrs`, `feature`, and `test` and 38 more
    = help: consider using a Cargo feature instead
    = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
             [lints.rust]

--- a/tests/ui/check-cfg/cargo-feature.some.stderr
+++ b/tests/ui/check-cfg/cargo-feature.some.stderr
@@ -25,7 +25,7 @@ warning: unexpected `cfg` condition name: `tokio_unstable`
 LL | #[cfg(tokio_unstable)]
    |       ^^^^^^^^^^^^^^
    |
-   = help: expected names are: `CONFIG_NVME`, `docsrs`, `feature`, and `test` and 31 more
+   = help: expected names are: `CONFIG_NVME`, `docsrs`, `feature`, and `test` and 38 more
    = help: consider using a Cargo feature instead
    = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
             [lints.rust]

--- a/tests/ui/check-cfg/cfg-select.stderr
+++ b/tests/ui/check-cfg/cfg-select.stderr
@@ -4,7 +4,7 @@ warning: unexpected `cfg` condition name: `invalid_cfg1`
 LL |     invalid_cfg1 => {}
    |     ^^^^^^^^^^^^
    |
-   = help: expected names are: `FALSE` and `test` and 31 more
+   = help: expected names are: `FALSE` and `test` and 38 more
    = help: to expect this configuration use `--check-cfg=cfg(invalid_cfg1)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default

--- a/tests/ui/check-cfg/cfg-value-for-cfg-name-duplicate.stderr
+++ b/tests/ui/check-cfg/cfg-value-for-cfg-name-duplicate.stderr
@@ -4,7 +4,7 @@ warning: unexpected `cfg` condition name: `value`
 LL | #[cfg(value)]
    |       ^^^^^
    |
-   = help: expected names are: `bar`, `bee`, `cow`, and `foo` and 31 more
+   = help: expected names are: `bar`, `bee`, `cow`, and `foo` and 38 more
    = help: to expect this configuration use `--check-cfg=cfg(value)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default

--- a/tests/ui/check-cfg/cfg-value-for-cfg-name-multiple.stderr
+++ b/tests/ui/check-cfg/cfg-value-for-cfg-name-multiple.stderr
@@ -4,7 +4,7 @@ warning: unexpected `cfg` condition name: `my_value`
 LL | #[cfg(my_value)]
    |       ^^^^^^^^
    |
-   = help: expected names are: `bar` and `foo` and 31 more
+   = help: expected names are: `bar` and `foo` and 38 more
    = help: to expect this configuration use `--check-cfg=cfg(my_value)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default

--- a/tests/ui/check-cfg/exhaustive-names-values.feature.stderr
+++ b/tests/ui/check-cfg/exhaustive-names-values.feature.stderr
@@ -4,7 +4,7 @@ warning: unexpected `cfg` condition name: `unknown_key`
 LL | #[cfg(unknown_key = "value")]
    |       ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: expected names are: `feature` and 31 more
+   = help: expected names are: `feature` and 38 more
    = help: to expect this configuration use `--check-cfg=cfg(unknown_key, values("value"))`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default

--- a/tests/ui/check-cfg/exhaustive-names-values.full.stderr
+++ b/tests/ui/check-cfg/exhaustive-names-values.full.stderr
@@ -4,7 +4,7 @@ warning: unexpected `cfg` condition name: `unknown_key`
 LL | #[cfg(unknown_key = "value")]
    |       ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: expected names are: `feature` and 31 more
+   = help: expected names are: `feature` and 38 more
    = help: to expect this configuration use `--check-cfg=cfg(unknown_key, values("value"))`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default

--- a/tests/ui/check-cfg/hrtb-crash.stderr
+++ b/tests/ui/check-cfg/hrtb-crash.stderr
@@ -4,7 +4,7 @@ warning: unexpected `cfg` condition name: `b`
 LL |     for<#[cfg(b)] c> u8:;
    |               ^ help: found config with similar value: `target_feature = "b"`
    |
-   = help: expected names are: `FALSE`, `docsrs`, and `test` and 31 more
+   = help: expected names are: `FALSE`, `docsrs`, and `test` and 38 more
    = help: to expect this configuration use `--check-cfg=cfg(b)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default

--- a/tests/ui/check-cfg/mix.stderr
+++ b/tests/ui/check-cfg/mix.stderr
@@ -44,7 +44,7 @@ warning: unexpected `cfg` condition name: `uu`
 LL | #[cfg_attr(uu, unix)]
    |            ^^
    |
-   = help: expected names are: `feature` and 31 more
+   = help: expected names are: `feature` and 38 more
    = help: to expect this configuration use `--check-cfg=cfg(uu)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 

--- a/tests/ui/check-cfg/nested-cfg.stderr
+++ b/tests/ui/check-cfg/nested-cfg.stderr
@@ -4,7 +4,7 @@ warning: unexpected `cfg` condition name: `unknown`
 LL | #[cfg(unknown)]
    |       ^^^^^^^
    |
-   = help: expected names are: `FALSE` and `test` and 31 more
+   = help: expected names are: `FALSE` and `test` and 38 more
    = help: to expect this configuration use `--check-cfg=cfg(unknown)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default

--- a/tests/ui/check-cfg/raw-keywords.edition2015.stderr
+++ b/tests/ui/check-cfg/raw-keywords.edition2015.stderr
@@ -14,7 +14,7 @@ warning: unexpected `cfg` condition name: `r#false`
 LL | #[cfg(r#false)]
    |       ^^^^^^^
    |
-   = help: expected names are: `async`, `edition2015`, `edition2021`, and `r#true` and 31 more
+   = help: expected names are: `async`, `edition2015`, `edition2021`, and `r#true` and 38 more
    = help: to expect this configuration use `--check-cfg=cfg(r#false)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 

--- a/tests/ui/check-cfg/raw-keywords.edition2021.stderr
+++ b/tests/ui/check-cfg/raw-keywords.edition2021.stderr
@@ -14,7 +14,7 @@ warning: unexpected `cfg` condition name: `r#false`
 LL | #[cfg(r#false)]
    |       ^^^^^^^
    |
-   = help: expected names are: `r#async`, `edition2015`, `edition2021`, and `r#true` and 31 more
+   = help: expected names are: `r#async`, `edition2015`, `edition2021`, and `r#true` and 38 more
    = help: to expect this configuration use `--check-cfg=cfg(r#false)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 

--- a/tests/ui/check-cfg/report-in-external-macros.cargo.stderr
+++ b/tests/ui/check-cfg/report-in-external-macros.cargo.stderr
@@ -4,7 +4,7 @@ warning: unexpected `cfg` condition name: `my_lib_cfg`
 LL |     cfg_macro::my_lib_macro!();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: expected names are: `feature` and 31 more
+   = help: expected names are: `feature` and 38 more
    = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
    = help: try referring to `cfg_macro::my_lib_macro` crate for guidance on how handle this unexpected cfg
    = help: the macro `cfg_macro::my_lib_macro` may come from an old version of the `cfg_macro` crate, try updating your dependency with `cargo update -p cfg_macro`

--- a/tests/ui/check-cfg/report-in-external-macros.rustc.stderr
+++ b/tests/ui/check-cfg/report-in-external-macros.rustc.stderr
@@ -4,7 +4,7 @@ warning: unexpected `cfg` condition name: `my_lib_cfg`
 LL |     cfg_macro::my_lib_macro!();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: expected names are: `feature` and 31 more
+   = help: expected names are: `feature` and 38 more
    = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
    = help: try referring to `cfg_macro::my_lib_macro` crate for guidance on how handle this unexpected cfg
    = help: to expect this configuration use `--check-cfg=cfg(my_lib_cfg)`

--- a/tests/ui/check-cfg/well-known-names.stderr
+++ b/tests/ui/check-cfg/well-known-names.stderr
@@ -28,6 +28,13 @@ LL | #[cfg(list_all_well_known_cfgs)]
 `target_has_atomic`
 `target_has_atomic_equal_alignment`
 `target_has_atomic_load_store`
+`target_modifier_branch_protection`
+`target_modifier_fixed_x18`
+`target_modifier_indirect_branch_cs_prefix`
+`target_modifier_reg_struct_return`
+`target_modifier_regparm`
+`target_modifier_retpoline`
+`target_modifier_retpoline_external_thunk`
 `target_os`
 `target_pointer_width`
 `target_thread_local`

--- a/tests/ui/feature-gates/feature-gate-cfg-unstable-target-modifier.rs
+++ b/tests/ui/feature-gates/feature-gate-cfg-unstable-target-modifier.rs
@@ -1,0 +1,5 @@
+//@ compile-flags: --crate-type=lib
+
+#[cfg(target_modifier_fixed_x18)]
+//~^ ERROR: `cfg(target_modifier_fixed_x18)` is experimental and subject to change
+fn branch_protection() {}

--- a/tests/ui/feature-gates/feature-gate-cfg-unstable-target-modifier.stderr
+++ b/tests/ui/feature-gates/feature-gate-cfg-unstable-target-modifier.stderr
@@ -1,0 +1,12 @@
+error[E0658]: `cfg(target_modifier_fixed_x18)` is experimental and subject to change
+  --> $DIR/feature-gate-cfg-unstable-target-modifier.rs:3:7
+   |
+LL | #[cfg(target_modifier_fixed_x18)]
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(cfg_unstable_target_modifier)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/macros/cfg.stderr
+++ b/tests/ui/macros/cfg.stderr
@@ -38,7 +38,7 @@ warning: unexpected `cfg` condition name: `foo`
 LL |     cfg!(foo);
    |          ^^^
    |
-   = help: expected names are: `FALSE` and `test` and 31 more
+   = help: expected names are: `FALSE` and `test` and 38 more
    = help: to expect this configuration use `--check-cfg=cfg(foo)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default

--- a/tests/ui/macros/cfg_select.stderr
+++ b/tests/ui/macros/cfg_select.stderr
@@ -69,7 +69,7 @@ warning: unexpected `cfg` condition name: `a`
 LL |     a + 1 => {}
    |     ^ help: found config with similar value: `target_feature = "a"`
    |
-   = help: expected names are: `FALSE` and `test` and 31 more
+   = help: expected names are: `FALSE` and `test` and 38 more
    = help: to expect this configuration use `--check-cfg=cfg(a)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default


### PR DESCRIPTION
This is a rough draft that can be nominated for t-lang, plenty of the details will change.

#### The issue this aims to solve...
In rust-lang/rust#151486, Chromium uses `-Zbranch-protection=bti`, which is an AArch64 extension for control-flow integrity (e.g. to protect against ROP attacks). The idea is that every indirect branch target has to start with a BTI landing pad instruction that tells the CPU whether it is a valid target for calls or jumps, otherwise the CPU faults.

Since rust-lang/rust#149633 and rust-lang/rust#144938, we enable a `outline-atomics` feature on AArch64 targets. This lowers atomic operations to out-of-line helper functions, which can use the Large System Extension (LSE) if present, and otherwise falls back to an implementation that doesn't use LSE. Rust's fallback implementation is provided by compiler-builtins.

When `-Zbranch-protection=bti` is used, compiler-builtins' `outline-atomics` routines need to have the BTI hint instruction so that the program can jump to it without the CPU faulting. These are normally added automatically by `-Zbranch-protection=bti` but outline-atomics' implementations use naked functions, so correctly don't automatically have the BTI hint instructions.

We'd like to add the BTI hint instruction to these, but there is no way of knowing that BTI is enabled when writing the naked function. LLVM does this conditionally when they generate their implementations ([here](https://github.com/llvm/llvm-project/blob/737db63fafa273a840d84594ca7c96fef113c8f2/compiler-rt/lib/builtins/assembly.h#L104-L108)), because they have a preprocessor define they can check. BTI isn't a target feature, so there's no `cfg(target_feature = "bti")` that could be used to cfg this in compiler-builtins.

(Technically BTI uses hint-space instructions, that older CPUs without support for BTI would ignore, so it could be added to these functions unconditionally. However, this still has a code-size cost and the other overheads of a no-op, like instruction cache pressure.)

`-Zbranch-protection` isn't a target modifier but should be, we just haven't made it one yet because it's waiting on build-std to be stabilised anyway. It would be useful to have a cfg for BTI to be able be able to write naked functions that are aware of it, e.g. `cfg(branch_protection = "bti")`. During the discussion on Zulip, it was suggested that perhaps this same logic applies to all target modifiers.

#### What this proposes..
Target modifier flags are those that must be set across all compilation units as they indicate an ABI incompatibility (or in general that the flag is only effective if the entire crate graph also has it set, e.g. for pointer authentication, the security isn't as useful if there are functions compiled without it). Knowledge of enabled target modifiers is necessary for naked functions or asm in general to appropriately generate the right assembly (for BTI on AArch64, for example).

This patch proposes automatically adding a cfg for target modifier flags (e.g. `-Zbranch-protection=bti` -> `cfg(target_modifier_branch_protection="bti")`. Flags that do not accept values similarly have cfgs without values (e.g. `-Zfixed-x18` -> `cfg(target_modifier_fixed_x18)`), whereas flags that do have values have cfgs with values (e.g. `-Zregparm=0` -> `cfg(target_modifier_regparm="0")`). Flags that take comma-separated values will set multiple cfgs (e.g. `-Zbranch-protection=bti,pac-ret` -> `cfg(target_modifier_branch_protection="bti")`,`cfg(target_modifier_branch_protection="pac-ret")`).

Not all target modifiers need to have cfgs - for example, sanitizers are a target modifier but have their own cfg already so this patch does not have an automatically-generated target modifier cfg.

Each of the target modifier cfgs for unstable target modifier flags are gated on `feature(cfg_unstable_target_modifier)` and will be stabilised automatically alongside their flag counterparts. All target modifiers are currently unstable so this doesn't stabilise anything.

Like all other builtin cfgs, users cannot set target modifier cfgs via `--cfg`.

This patch makes `-Zbranch-protection` a target modifier in the same patch, just to test this works with a target modifier that accepts comma-separated values, but that can be split out into a separate PR.

With this patch, the original issue could be resolved by adding..

```rust
#[cfg(target_modifier_branch_protection="bti")]
"hint #34"
```

..in the `naked_asm!` of the compiler-builtins implementations.

### Unresolved questions for t-lang...

1. Do we want this?
    
    - If not, do we want a cfg only for `-Zbranch-protection` to solve the original issue?

2. What should these be called?
    
    - e.g. `target_modifier_$flag`, `target_modifier($flag)`, `$flag`, something different for each 
    - To date, the "target modifier" terminology hasn't been user-facing

3. Does it make sense to group target modifier flags together to match the cfg?
    - e.g. `-Ztarget-modifier branch-protection="bti"`?

4. Should each target modifier cfg have a separate feature to permit its use?
    - e.g. `feature(target_modifier_branch_protection_cfg)` rather than `feature(cfg_unstable_target_modifier)`

5. Should target modifier cfgs be stabilised alongside their flags?

6. Compiler flags have different stability guarantees than language features, as sometimes the output of a flag can't be guaranteed to never change (e.g. it might depend on LLVM's behaviour), or the values accepted by a flag may change over time (e.g. `--target` as targets can be added and removed), or a flag may be deprecated (`-Csoft-float`). Does the fact that target modifier flags have cfgs that are subject to the language's stability guarantees change anything?

cc [#t-libs > bti in compiler-builtins' aarch64 outline-atomics @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/219381-t-libs/topic/bti.20in.20compiler-builtins'.20aarch64.20outline-atomics/near/570351460), rust-lang/rust#151486 

r? @ghost (the exact implementation isn't super important yet until we've decided if we want this or not)