### PR TITLE
coverage: Add a test case for a previously-unknown span mismatch

### DIFF
--- a/compiler/rustc_mir_transform/src/coverage/spans.rs
+++ b/compiler/rustc_mir_transform/src/coverage/spans.rs
@@ -55,12 +55,10 @@ pub(super) fn extract_refined_covspans<'tcx>(
             }
 
             // Each pushed covspan should have the same context as the body span.
-            // If it somehow doesn't, discard the covspan, or panic in debug builds.
+            // If it somehow doesn't, discard the covspan.
             if !body_span.eq_ctxt(covspan_span) {
-                debug_assert!(
-                    false,
-                    "span context mismatch: body_span={body_span:?}, covspan.span={covspan_span:?}"
-                );
+                // FIXME(Zalathar): Investigate how and why this is triggered
+                // by `tests/coverage/macros/context-mismatch-issue-147339.rs`.
                 return false;
             }
 

--- a/tests/coverage/macros/context-mismatch-issue-147339.cov-map
+++ b/tests/coverage/macros/context-mismatch-issue-147339.cov-map
@@ -1,0 +1,40 @@
+Function name: context_mismatch_issue_147339::a (unused)
+Raw bytes (14): 0x[01, 01, 00, 02, 00, 0c, 27, 00, 35, 00, 00, 3b, 00, 3c]
+Number of files: 1
+- file 0 => $DIR/context-mismatch-issue-147339.rs
+Number of expressions: 0
+Number of file 0 mappings: 2
+- Code(Zero) at (prev + 12, 39) to (start + 0, 53)
+- Code(Zero) at (prev + 0, 59) to (start + 0, 60)
+Highest counter ID seen: (none)
+
+Function name: context_mismatch_issue_147339::b (unused)
+Raw bytes (14): 0x[01, 01, 00, 02, 00, 0c, 27, 00, 35, 00, 00, 3b, 00, 3c]
+Number of files: 1
+- file 0 => $DIR/context-mismatch-issue-147339.rs
+Number of expressions: 0
+Number of file 0 mappings: 2
+- Code(Zero) at (prev + 12, 39) to (start + 0, 53)
+- Code(Zero) at (prev + 0, 59) to (start + 0, 60)
+Highest counter ID seen: (none)
+
+Function name: context_mismatch_issue_147339::c (unused)
+Raw bytes (14): 0x[01, 01, 00, 02, 00, 0c, 27, 00, 35, 00, 00, 3b, 00, 3c]
+Number of files: 1
+- file 0 => $DIR/context-mismatch-issue-147339.rs
+Number of expressions: 0
+Number of file 0 mappings: 2
+- Code(Zero) at (prev + 12, 39) to (start + 0, 53)
+- Code(Zero) at (prev + 0, 59) to (start + 0, 60)
+Highest counter ID seen: (none)
+
+Function name: context_mismatch_issue_147339::main
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 14, 01, 00, 0a, 01, 00, 0c, 00, 0d]
+Number of files: 1
+- file 0 => $DIR/context-mismatch-issue-147339.rs
+Number of expressions: 0
+Number of file 0 mappings: 2
+- Code(Counter(0)) at (prev + 20, 1) to (start + 0, 10)
+- Code(Counter(0)) at (prev + 0, 12) to (start + 0, 13)
+Highest counter ID seen: c0
+

--- a/tests/coverage/macros/context-mismatch-issue-147339.coverage
+++ b/tests/coverage/macros/context-mismatch-issue-147339.coverage
@@ -1,0 +1,28 @@
+   LL|       |//@ edition: 2024
+   LL|       |
+   LL|       |// These nested macro expansions were found to cause span refinement to produce
+   LL|       |// spans with a context that doesn't match the function body span, triggering
+   LL|       |// a defensive check that discards the span.
+   LL|       |//
+   LL|       |// Reported in <https://github.com/rust-lang/rust/issues/147339>.
+   LL|       |
+   LL|       |macro_rules! foo {
+   LL|       |    ($($m:ident $($f:ident $v:tt)+),*) => {
+   LL|       |        $($(macro_rules! $f { () => { $v } })+)*
+   LL|      0|        $(macro_rules! $m { () => { $(fn $f() -> i32 { $v })+ } })*
+  ------------------
+  | Unexecuted instantiation: context_mismatch_issue_147339::a
+  ------------------
+  | Unexecuted instantiation: context_mismatch_issue_147339::b
+  ------------------
+  | Unexecuted instantiation: context_mismatch_issue_147339::c
+  ------------------
+   LL|       |    }
+   LL|       |}
+   LL|       |
+   LL|       |foo!(m a 1 b 2, n c 3);
+   LL|       |m!();
+   LL|       |n!();
+   LL|       |
+   LL|      1|fn main() {}
+

--- a/tests/coverage/macros/context-mismatch-issue-147339.rs
+++ b/tests/coverage/macros/context-mismatch-issue-147339.rs
@@ -1,0 +1,20 @@
+//@ edition: 2024
+
+// These nested macro expansions were found to cause span refinement to produce
+// spans with a context that doesn't match the function body span, triggering
+// a defensive check that discards the span.
+//
+// Reported in <https://github.com/rust-lang/rust/issues/147339>.
+
+macro_rules! foo {
+    ($($m:ident $($f:ident $v:tt)+),*) => {
+        $($(macro_rules! $f { () => { $v } })+)*
+        $(macro_rules! $m { () => { $(fn $f() -> i32 { $v })+ } })*
+    }
+}
+
+foo!(m a 1 b 2, n c 3);
+m!();
+n!();
+
+fn main() {}


### PR DESCRIPTION
- This is a revised version of https://github.com/rust-lang/rust/pull/152036.
---

In https://github.com/rust-lang/rust/pull/145643, a defensive check was added to detect spans that unexpectedly don't match the context of the function body span. There was no known way to trigger that condition, so a `debug_assert!` was added to make violations easier to notice.

A way to trigger the condition using nested macro expansions was subsequently found and reported as an ICE (in debug-assertion builds) in https://github.com/rust-lang/rust/issues/147339.

Now that we have a concrete example to investigate, we can remove the `debug_assert!` so that there is no ICE in debug-assertion builds.

- Fixes https://github.com/rust-lang/rust/issues/147339.

r? chenyukang