### PR TITLE
Pull implied bound computation out of borrowck

### DIFF
--- a/compiler/rustc_borrowck/src/compute_rename_later.rs
+++ b/compiler/rustc_borrowck/src/compute_rename_later.rs
@@ -1,0 +1,229 @@
+// TODO: add description later
+
+use rustc_infer::infer::canonical::Canonical;
+use rustc_infer::infer::{TyCtxtInferExt, TypeOutlivesConstraint, canonical};
+use rustc_infer::traits::ObligationCause;
+use rustc_infer::traits::query::OutlivesBound;
+use rustc_middle::query::Providers;
+use rustc_middle::ty::{RegionExt, TyCtxt};
+use rustc_span::sym;
+use rustc_trait_selection::traits::ObligationCtxt;
+use rustc_trait_selection::traits::query::type_op::implied_outlives_bounds::{
+    compute_implied_outlives_bounds_inner_new, implied_bounds_from_components,
+};
+use smallvec::smallvec;
+
+use crate::hir::def::DefKind;
+use crate::ty::outlives::push_outlives_components;
+use crate::ty::solve::NoSolution;
+use crate::ty::{CanonicalVarValues, GenericArg, GenericArgKind, GenericArgs, Region};
+use crate::universal_regions::{
+    compute_inputs_and_output_non_nll, defining_ty_non_nll,
+    for_each_late_bound_region_in_recursive_scope,
+};
+use crate::{
+    LocalDefId, ParamEnv, RegionVariableOrigin, SmallVec, Ty, TypingMode, debug, fold_regions, ty,
+};
+
+pub(crate) fn provide(p: &mut Providers) {
+    *p = Providers { compute_outlives_bounds_rename, ..*p };
+}
+
+fn compute_outlives_bounds_rename<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    mir_def: LocalDefId,
+) -> Result<
+    &'tcx Canonical<'tcx, canonical::QueryResponse<'tcx, Vec<OutlivesBound<'tcx>>>>,
+    NoSolution,
+> {
+    debug!("enter compute_outlives_bounds_rename");
+    let infcx = tcx.infer_ctxt().build(TypingMode::non_body_analysis());
+    let ocx = ObligationCtxt::new(&infcx);
+    let param_env = ParamEnv::empty();
+    let defining_ty = defining_ty_non_nll(&infcx, mir_def);
+    let defining_ty_def_id = defining_ty.def_id().expect_local();
+    let mut late_bound_region: Vec<Region<'_>> = vec![];
+
+    let unnormalized_input_output_tys =
+        compute_inputs_and_output_non_nll(&infcx, mir_def, defining_ty);
+    debug!("first unnormalized input and output ty is {:?}", unnormalized_input_output_tys);
+
+    // Collect late bound region before instantiating the binder. There is difference between collecting region like this
+    // and just collect it after `liberate_late_bound_region`. With this, we can make sure unused late bound region is
+    // collected too.
+    for (idx, bound_var) in unnormalized_input_output_tys.bound_vars().iter().enumerate() {
+        if let ty::BoundVariableKind::Region(kind) = bound_var {
+            let kind = ty::LateParamRegionKind::from_bound(ty::BoundVar::from_usize(idx), kind);
+            let region = ty::Region::new_late_param(infcx.tcx, mir_def.to_def_id(), kind);
+            debug!(?region);
+            late_bound_region.push(region);
+        }
+    }
+
+    debug!("late bound region is {:?}", late_bound_region);
+
+    let unnormalized_input_output_tys = tcx
+        .liberate_late_bound_regions(defining_ty_def_id.to_def_id(), unnormalized_input_output_tys);
+
+    debug!("second unnormalized input and output ty is {:?}", unnormalized_input_output_tys);
+
+    let span = tcx.def_span(defining_ty_def_id);
+    let mut outlives_bounds: Vec<OutlivesBound<'tcx>> = vec![];
+    let mut norm_sig_tys: Vec<Ty<'_>> = vec![];
+
+    for ty in unnormalized_input_output_tys {
+        debug!("the ty for input and output are {:?}", ty);
+
+        // Replace erased regions with fresh region variables.
+        let ty = fold_regions(tcx, ty, |re, _dbi| match re.kind() {
+            ty::ReErased => infcx.next_region_var(RegionVariableOrigin::Misc(span)),
+            _ => re,
+        });
+
+        // We add implied bounds from both the unnormalized and normalized ty.
+        // See issue #87748
+        if let Ok(bounds) = compute_implied_outlives_bounds_inner_new(&ocx, param_env, ty, span) {
+            outlives_bounds.extend(bounds);
+        }
+
+        let Ok(norm_ty) = ocx.deeply_normalize(
+            &ObligationCause::dummy_with_span(span),
+            param_env,
+            ty::Unnormalized::new_wip(ty),
+        ) else {
+            // Even if deeply normalize returns no solution, we still need to store the ty for canonicalization later.
+            norm_sig_tys.push(ty);
+            continue;
+        };
+
+        // Currently `implied_outlives_bounds` will normalize the provided
+        // `Ty`, despite this it's still important to normalize the ty ourselves
+        // as normalization may introduce new region variables (#136547).
+        //
+        // If we do not add implied bounds for the type involving these new
+        // region variables then we'll wind up with the normalized form of
+        // the signature having not-wf types due to unsatisfied region
+        // constraints.
+        //
+        // Note: we need this in examples like
+        // ```
+        // trait Foo {
+        //   type Bar;
+        //   fn foo(&self) -> &Self::Bar;
+        // }
+        // impl Foo for () {
+        //   type Bar = ();
+        //   fn foo(&self) -> &() {}
+        // }
+        // ```
+        // Both &Self::Bar and &() are WF
+        if ty != norm_ty {
+            if let Ok(bounds) =
+                compute_implied_outlives_bounds_inner_new(&ocx, param_env, norm_ty, span)
+            {
+                outlives_bounds.extend(bounds);
+            }
+        }
+        debug!("normalized ty is {:?}", norm_ty);
+
+        norm_sig_tys.push(norm_ty);
+    }
+
+    // Add implied bounds from impl header.
+    // We don't use `assumed_wf_types` to source the entire set of implied bounds for
+    // a few reasons:
+    // - `DefiningTy` for closure has the `&'env Self` type while `assumed_wf_types` doesn't
+    // - We compute implied bounds from the unnormalized types in the `DefiningTy` but do not
+    //   do so for types in impl headers
+    // - We must compute the normalized signature and then compute implied bounds from that
+    //   in order to connect any unconstrained region vars created during normalization to
+    //   the types of the locals corresponding to the inputs and outputs of the item. (#136547)
+    if matches!(tcx.def_kind(defining_ty_def_id), DefKind::AssocFn | DefKind::AssocConst { .. }) {
+        for &(ty, _) in tcx.assumed_wf_types(tcx.local_parent(defining_ty_def_id)) {
+            // Replace erased regions with fresh region variables.
+            let ty = fold_regions(tcx, ty, |re, _dbi| match re.kind() {
+                ty::ReErased => infcx.next_region_var(RegionVariableOrigin::Misc(span)),
+                _ => re,
+            });
+
+            let Ok(norm_ty) = ocx.deeply_normalize(
+                &ObligationCause::dummy_with_span(span),
+                param_env,
+                ty::Unnormalized::new_wip(ty),
+            ) else {
+                continue;
+            };
+
+            // We currently add implied bounds from the normalized ty only.
+            // This is more conservative and matches wfcheck behavior.
+            if let Ok(bounds) =
+                compute_implied_outlives_bounds_inner_new(&ocx, param_env, norm_ty, span)
+            {
+                outlives_bounds.extend(bounds);
+            }
+        }
+    }
+    // Take outlives constraints from fn sig for bevy.
+    // Previously, we only collect outlives obligations for `ParamSet<T>` or
+    // `&ParamSet<T>`, now we collect outlives obligations for the entire function
+    // signature.
+    if !tcx.sess.opts.unstable_opts.no_implied_bounds_compat
+        && tcx.crate_name(mir_def.to_def_id().krate) == sym::bevy_ecs
+    {
+        for TypeOutlivesConstraint { sup_type, sub_region, .. } in
+            infcx.clone_registered_region_obligations()
+        {
+            let mut components = smallvec![];
+            push_outlives_components(tcx, sup_type, &mut components);
+            outlives_bounds.extend(implied_bounds_from_components(tcx, sub_region, components));
+        }
+    }
+
+    // Get early bound params.
+    let typeck_root_def_id = tcx.typeck_root_def_id(mir_def.to_def_id());
+
+    let early_bound_params = GenericArgs::identity_for_item(tcx, typeck_root_def_id);
+    let mut early_bound_region: SmallVec<[GenericArg<'_>; 8]> = Default::default();
+    let mut early_bound_non_region: SmallVec<[GenericArg<'_>; 8]> = Default::default();
+
+    debug!("early bound params are {:?}", early_bound_params);
+    // Separate early bound region and non-region.
+    for param in early_bound_params {
+        match param.kind() {
+            GenericArgKind::Lifetime(_) => early_bound_region.push(param),
+            _ => early_bound_non_region.push(param),
+        }
+    }
+
+    let mut var_value: SmallVec<[GenericArg<'_>; 8]> = early_bound_non_region;
+
+    for param in early_bound_region {
+        var_value.push(param);
+    }
+
+    // Collect late bound region for closure, coroutine, or inline-const.
+    if mir_def.to_def_id() != typeck_root_def_id {
+        for_each_late_bound_region_in_recursive_scope(tcx, tcx.local_parent(mir_def), |r| {
+            debug!("the late bound region for closure is {:?}", r);
+            var_value.push(GenericArg::from(r));
+        });
+    }
+
+    // var value = [generic param, early bound region, late bound region, sig tys]
+    // Make generic param goes before region to match with the call site in free_region_relations.
+
+    for region in &late_bound_region {
+        var_value.push(GenericArg::from(*region))
+    }
+
+    for ty in &norm_sig_tys {
+        var_value.push(GenericArg::from(*ty))
+    }
+
+    let var_values: CanonicalVarValues<TyCtxt<'_>> =
+        CanonicalVarValues { var_values: tcx.mk_args(var_value.as_slice()) };
+
+    debug!("var value in query is {:?}", var_values);
+
+    ocx.make_canonicalized_query_response(var_values, outlives_bounds)
+}

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -76,6 +76,7 @@ use crate::type_check::{Locations, MirTypeckRegionConstraints, MirTypeckResults}
 
 mod borrow_set;
 mod borrowck_errors;
+mod compute_rename_later;
 mod constraints;
 mod dataflow;
 mod def_use;
@@ -107,6 +108,7 @@ impl<'tcx> TyCtxtConsts<'tcx> {
 
 pub fn provide(providers: &mut Providers) {
     *providers = Providers { mir_borrowck, ..*providers };
+    compute_rename_later::provide(providers);
 }
 
 /// Provider for `query mir_borrowck`. Unlike `typeck`, this must
@@ -351,6 +353,7 @@ fn borrowck_collect_region_constraints<'tcx>(
     let mut polonius_facts =
         (polonius_input || PoloniusFacts::enabled(infcx.tcx)).then_some(PoloniusFacts::default());
 
+    // TODO: figure out if I can reuse the same defId from somewhere instead of passing it.
     // Run the MIR type-checker.
     let MirTypeckResults {
         constraints,
@@ -361,6 +364,7 @@ fn borrowck_collect_region_constraints<'tcx>(
         polonius_context,
     } = type_check::type_check(
         root_cx,
+        def,
         &infcx,
         body,
         &promoted,

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -719,6 +719,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             // avoid potential non-determinism we approximate this by requiring
             // T: '1 and T: '2.
             for upper_bound in non_local_ub {
+                debug!("the current upper bound is {:?}", upper_bound);
                 debug_assert!(self.universal_regions().is_universal_region(upper_bound));
                 debug_assert!(!self.universal_regions().is_local_free_region(upper_bound));
 

--- a/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
+++ b/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
@@ -103,7 +103,9 @@ impl<'a, 'tcx> ConstraintConversion<'a, 'tcx> {
         // Create the predicates.
         let backup = (self.category, self.span, self.from_closure);
         self.from_closure = true;
+        debug!("closure mapping is {:?}", closure_mapping);
         for outlives_requirement in &closure_requirements.outlives_requirements {
+            debug!("outlive requirement for closure is {:?}", outlives_requirement);
             let outlived_region = closure_mapping[outlives_requirement.outlived_free_region];
             let subject = match outlives_requirement.subject {
                 ClosureOutlivesSubject::Region(re) => closure_mapping[re].into(),

--- a/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
+++ b/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
@@ -1,10 +1,10 @@
 use rustc_data_structures::frozen::Frozen;
 use rustc_data_structures::transitive_relation::{TransitiveRelation, TransitiveRelationBuilder};
-use rustc_hir::def::DefKind;
-use rustc_infer::infer::canonical::QueryRegionConstraints;
-use rustc_infer::infer::outlives;
+use rustc_infer::infer::canonical::{OriginalQueryValues, QueryRegionConstraints};
 use rustc_infer::infer::outlives::env::RegionBoundPairs;
 use rustc_infer::infer::region_constraints::GenericKind;
+use rustc_infer::infer::{InferOk, outlives};
+use rustc_infer::traits::ObligationCause;
 use rustc_infer::traits::query::type_op::Normalize;
 use rustc_middle::mir::ConstraintCategory;
 use rustc_middle::traits::query::OutlivesBound;
@@ -14,9 +14,10 @@ use rustc_trait_selection::traits::query::type_op;
 use tracing::{debug, instrument};
 use type_op::TypeOpOutput;
 
-use crate::BorrowckInferCtxt;
+use crate::ty::{GenericArg, GenericArgs};
 use crate::type_check::{Locations, MirTypeckRegionConstraints, constraint_conversion};
 use crate::universal_regions::UniversalRegions;
+use crate::{BorrowckInferCtxt, LocalDefId, SmallVec};
 
 #[derive(Debug)]
 #[derive(Clone)] // FIXME(#146079)
@@ -50,11 +51,13 @@ pub(crate) struct CreateResult<'tcx> {
 
 pub(crate) fn create<'tcx>(
     infcx: &BorrowckInferCtxt<'tcx>,
+    def: LocalDefId,
     universal_regions: UniversalRegions<'tcx>,
     constraints: &mut MirTypeckRegionConstraints<'tcx>,
 ) -> CreateResult<'tcx> {
     UniversalRegionRelationsBuilder {
         infcx,
+        def,
         constraints,
         universal_regions,
         region_bound_pairs: Default::default(),
@@ -160,6 +163,7 @@ impl UniversalRegionRelations<'_> {
 
 struct UniversalRegionRelationsBuilder<'a, 'tcx> {
     infcx: &'a BorrowckInferCtxt<'tcx>,
+    def: LocalDefId,
     universal_regions: UniversalRegions<'tcx>,
     constraints: &'a mut MirTypeckRegionConstraints<'tcx>,
 
@@ -234,14 +238,10 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
         //   handled later by actual borrow checking.
         let mut normalized_inputs_and_output =
             Vec::with_capacity(self.universal_regions.unnormalized_input_tys.len() + 1);
+
         for ty in unnormalized_input_output_tys {
             debug!("build: input_or_output={:?}", ty);
-            // We add implied bounds from both the unnormalized and normalized ty.
-            // See issue #87748
-            let constraints_unnorm = self.add_implied_bounds(ty, span);
-            if let Some(c) = constraints_unnorm {
-                constraints.push(c)
-            }
+
             let TypeOpOutput { output: norm_ty, constraints: constraints_normalize, .. } = self
                 .infcx
                 .fully_perform(Normalize { value: ty::Unnormalized::new_wip(ty) }, span)
@@ -254,65 +254,71 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
                 constraints.push(c)
             }
 
-            // Currently `implied_outlives_bounds` will normalize the provided
-            // `Ty`, despite this it's still important to normalize the ty ourselves
-            // as normalization may introduce new region variables (#136547).
-            //
-            // If we do not add implied bounds for the type involving these new
-            // region variables then we'll wind up with the normalized form of
-            // the signature having not-wf types due to unsatisfied region
-            // constraints.
-            //
-            // Note: we need this in examples like
-            // ```
-            // trait Foo {
-            //   type Bar;
-            //   fn foo(&self) -> &Self::Bar;
-            // }
-            // impl Foo for () {
-            //   type Bar = ();
-            //   fn foo(&self) -> &() {}
-            // }
-            // ```
-            // Both &Self::Bar and &() are WF
-            if ty != norm_ty {
-                let constraints_norm = self.add_implied_bounds(norm_ty, span);
-                if let Some(c) = constraints_norm {
-                    constraints.push(c)
-                }
-            }
-
             normalized_inputs_and_output.push(norm_ty);
         }
 
-        // Add implied bounds from impl header.
-        //
-        // We don't use `assumed_wf_types` to source the entire set of implied bounds for
-        // a few reasons:
-        // - `DefiningTy` for closure has the `&'env Self` type while `assumed_wf_types` doesn't
-        // - We compute implied bounds from the unnormalized types in the `DefiningTy` but do not
-        //   do so for types in impl headers
-        // - We must compute the normalized signature and then compute implied bounds from that
-        //   in order to connect any unconstrained region vars created during normalization to
-        //   the types of the locals corresponding to the inputs and outputs of the item. (#136547)
-        if matches!(tcx.def_kind(defining_ty_def_id), DefKind::AssocFn | DefKind::AssocConst { .. })
-        {
-            for &(ty, _) in tcx.assumed_wf_types(tcx.local_parent(defining_ty_def_id)) {
-                let result: Result<_, ErrorGuaranteed> = self
-                    .infcx
-                    .fully_perform(Normalize { value: ty::Unnormalized::new_wip(ty) }, span);
-                let Ok(TypeOpOutput { output: norm_ty, constraints: c, .. }) = result else {
-                    continue;
-                };
+        let early_bound_params = GenericArgs::identity_for_item(tcx, self.infcx.root_def_id);
 
-                constraints.extend(c);
+        // Add non-region params to var_values.
+        let mut var_values: SmallVec<[GenericArg<'_>; 8]> =
+            early_bound_params.into_iter().filter(|k| k.as_region().is_none()).collect();
 
-                // We currently add implied bounds from the normalized ty only.
-                // This is more conservative and matches wfcheck behavior.
-                let c = self.add_implied_bounds(norm_ty, span);
-                constraints.extend(c);
+        debug!("call site: non region param is {:?}", var_values);
+
+        // Add both early and late bound region to var_values.
+        for (region, region_vid) in self.universal_regions.named_universal_regions_iter() {
+            if region_vid != fr_static {
+                // filter out 'static, it is always in indices
+                debug!("call site: all the region params are {:?}", region);
+                var_values.push(GenericArg::from(region));
             }
         }
+
+        // Add normalized fn_sig to var_values.
+        for ty in &normalized_inputs_and_output {
+            debug!("call site: normalized ty are {:?}", ty);
+            var_values.push(GenericArg::from(*ty));
+        }
+
+        debug!("var value at call site is {:?}", var_values);
+
+        let Ok(canonical_result) = tcx.compute_outlives_bounds_rename(self.def) else {
+            // see what will hit this case and think about this later
+            todo!();
+        };
+
+        // Instantiate query result
+        let mut output_query_region_constraints = QueryRegionConstraints::default();
+        let mut universe_map = SmallVec::default();
+        universe_map.push(ty::UniverseIndex::ROOT);
+        let original_query_value = OriginalQueryValues { var_values, universe_map };
+
+        let instantiate_res = self.infcx.instantiate_nll_query_response_and_region_obligations(
+            &ObligationCause::dummy_with_span(span),
+            param_env,
+            &original_query_value,
+            canonical_result,
+            &mut output_query_region_constraints,
+        );
+
+        let bounds = match instantiate_res {
+            Ok(InferOk { value: bounds, obligations: _ }) => bounds,
+            Err(_) => vec![],
+        };
+
+        // Add the outlives bound and constraints.
+        // Because of #109628, we may have unexpected placeholders. Ignore them!
+        // FIXME(#109628): panic in this case once the issue is fixed.
+        let bounds = bounds.into_iter().filter(|bound| !bound.has_placeholders());
+
+        // FIXME: let it fail early to see which test fails under this.
+        //self.see_if_bounds_contain_non_universals(bounds.clone());
+
+        self.add_outlives_bounds(bounds);
+
+        if !output_query_region_constraints.is_empty() {
+            constraints.push(&output_query_region_constraints);
+        };
 
         for c in constraints {
             constraint_conversion::ConstraintConversion::new(
@@ -373,26 +379,6 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
         known_type_outlives_obligations.push(outlives);
     }
 
-    /// Compute and add any implied bounds that come from a given type.
-    #[instrument(level = "debug", skip(self))]
-    fn add_implied_bounds(
-        &mut self,
-        ty: Ty<'tcx>,
-        span: Span,
-    ) -> Option<&'tcx QueryRegionConstraints<'tcx>> {
-        let TypeOpOutput { output: bounds, constraints, .. } = self
-            .infcx
-            .fully_perform(type_op::ImpliedOutlivesBounds { ty }, span)
-            .map_err(|_: ErrorGuaranteed| debug!("failed to compute implied bounds {:?}", ty))
-            .ok()?;
-        debug!(?bounds, ?constraints);
-        // Because of #109628, we may have unexpected placeholders. Ignore them!
-        // FIXME(#109628): panic in this case once the issue is fixed.
-        let bounds = bounds.into_iter().filter(|bound| !bound.has_placeholders());
-        self.add_outlives_bounds(bounds);
-        constraints
-    }
-
     /// Registers the `OutlivesBound` items from `outlives_bounds` in
     /// the outlives relation as well as the region-bound pairs
     /// listing.
@@ -423,4 +409,33 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
             }
         }
     }
+
+    // FIXME: remove this later, for debug purpose
+    //fn see_if_bounds_contain_non_universals<I>(&mut self, outlives_bounds: I)
+    //where
+    //    I: IntoIterator<Item = OutlivesBound<'tcx>>,
+    //{
+    //    for outlives_bound in outlives_bounds {
+    //        match outlives_bound {
+    //            OutlivesBound::RegionSubRegion(r1, r2) => {
+    //                let r1 = self.universal_regions.to_region_vid(r1);
+    //                let r2 = self.universal_regions.to_region_vid(r2);
+
+    //                assert!(self.universal_regions.is_universal_region(r1));
+    //                assert!(self.universal_regions.is_universal_region(r2));
+    //            }
+
+    //            OutlivesBound::RegionSubParam(r_a, _param_b) => {
+    //                let r1 = self.universal_regions.to_region_vid(r_a);
+    //                assert!(self.universal_regions.is_universal_region(r1));
+    //            }
+
+    //            OutlivesBound::RegionSubAlias(r_a, _alias_b) => {
+    //                // FIXME remove later? should always return universal vid?
+    //                let r1 = self.universal_regions.to_region_vid(r_a);
+    //                assert!(self.universal_regions.is_universal_region(r1));
+    //            }
+    //        }
+    //    }
+    //}
 }

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -95,7 +95,8 @@ mod relate_tys;
 /// - `move_data` -- move-data constructed when performing the maybe-init dataflow analysis
 /// - `location_map` -- map between MIR `Location` and `PointIndex`
 pub(crate) fn type_check<'tcx>(
-    root_cx: &BorrowCheckRootCtxt<'_, 'tcx>,
+    root_cx: &mut BorrowCheckRootCtxt<'_, 'tcx>,
+    def: LocalDefId,
     infcx: &BorrowckInferCtxt<'tcx>,
     body: &Body<'tcx>,
     promoted: &IndexSlice<Promoted, Body<'tcx>>,
@@ -120,7 +121,7 @@ pub(crate) fn type_check<'tcx>(
         region_bound_pairs,
         normalized_inputs_and_output,
         known_type_outlives_obligations,
-    } = free_region_relations::create(infcx, universal_regions, &mut constraints);
+    } = free_region_relations::create(infcx, def, universal_regions, &mut constraints);
 
     {
         // Scope these variables so it's clear they're not used later

--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -33,8 +33,8 @@ use rustc_middle::{bug, span_bug};
 use rustc_span::{ErrorGuaranteed, kw, sym};
 use tracing::{debug, instrument};
 
-use crate::BorrowckInferCtxt;
 use crate::renumber::RegionCtxt;
+use crate::{BorrowckInferCtxt, InferCtxt};
 
 #[derive(Debug)]
 #[derive(Clone)] // FIXME(#146079)
@@ -557,6 +557,7 @@ impl<'tcx> UniversalRegionsBuilder<'_, 'tcx> {
         debug!("build: global regions = {}..{}", FIRST_GLOBAL_INDEX, first_extern_index);
         debug!("build: extern regions = {}..{}", first_extern_index, first_local_index);
         debug!("build: local regions  = {}..{}", first_local_index, num_universals);
+        debug!("build: final indices={:?}", indices);
 
         let (resume_ty, yield_ty) = match defining_ty {
             DefiningTy::Coroutine(_, args) => {
@@ -954,7 +955,7 @@ impl<'tcx> UniversalRegionIndices<'tcx> {
 /// Iterates over the late-bound regions defined on `mir_def_id` and all of its
 /// parents, up to the typeck root, and invokes `f` with the liberated form
 /// of each one.
-fn for_each_late_bound_region_in_recursive_scope<'tcx>(
+pub(crate) fn for_each_late_bound_region_in_recursive_scope<'tcx>(
     tcx: TyCtxt<'tcx>,
     mut mir_def_id: LocalDefId,
     mut f: impl FnMut(ty::Region<'tcx>),
@@ -1006,5 +1007,219 @@ fn for_each_late_bound_region_in_item<'tcx>(
             let liberated_region = ty::Region::new_late_param(tcx, mir_def_id.to_def_id(), kind);
             f(liberated_region);
         }
+    }
+}
+
+// FIXME: Move this somewhere to be used by the new query
+pub(crate) fn compute_inputs_and_output_non_nll<'tcx>(
+    infcx: &InferCtxt<'tcx>,
+    mir_def: LocalDefId,
+    defining_ty: DefiningTy<'tcx>,
+) -> ty::Binder<'tcx, &'tcx ty::List<Ty<'tcx>>> {
+    let tcx = infcx.tcx;
+
+    let inputs_and_output = match defining_ty {
+        DefiningTy::Closure(def_id, args) => {
+            assert_eq!(mir_def.to_def_id(), def_id);
+            let closure_sig = args.as_closure().sig();
+            let inputs_and_output = closure_sig.inputs_and_output();
+            let bound_vars =
+                tcx.mk_bound_variable_kinds_from_iter(inputs_and_output.bound_vars().iter().chain(
+                    iter::once(ty::BoundVariableKind::Region(ty::BoundRegionKind::ClosureEnv)),
+                ));
+            let br = ty::BoundRegion {
+                var: ty::BoundVar::from_usize(bound_vars.len() - 1),
+                kind: ty::BoundRegionKind::ClosureEnv,
+            };
+            let env_region = ty::Region::new_bound(tcx, ty::INNERMOST, br);
+            let closure_ty = tcx.closure_env_ty(
+                Ty::new_closure(tcx, def_id, args),
+                args.as_closure().kind(),
+                env_region,
+            );
+
+            // The "inputs" of the closure in the
+            // signature appear as a tuple. The MIR side
+            // flattens this tuple.
+            let (&output, tuplized_inputs) = inputs_and_output.skip_binder().split_last().unwrap();
+            assert_eq!(tuplized_inputs.len(), 1, "multiple closure inputs");
+            let &ty::Tuple(inputs) = tuplized_inputs[0].kind() else {
+                bug!("closure inputs not a tuple: {:?}", tuplized_inputs[0]);
+            };
+
+            ty::Binder::bind_with_vars(
+                tcx.mk_type_list_from_iter(
+                    iter::once(closure_ty).chain(inputs).chain(iter::once(output)),
+                ),
+                bound_vars,
+            )
+        }
+
+        DefiningTy::Coroutine(def_id, args) => {
+            assert_eq!(mir_def.to_def_id(), def_id);
+            let resume_ty = args.as_coroutine().resume_ty();
+            let output = args.as_coroutine().return_ty();
+            let coroutine_ty = Ty::new_coroutine(tcx, def_id, args);
+            let inputs_and_output = infcx.tcx.mk_type_list(&[coroutine_ty, resume_ty, output]);
+            ty::Binder::dummy(inputs_and_output)
+        }
+
+        // Construct the signature of the CoroutineClosure for the purposes of borrowck.
+        // This is pretty straightforward -- we:
+        // 1. first grab the `coroutine_closure_sig`,
+        // 2. compute the self type (`&`/`&mut`/no borrow),
+        // 3. flatten the tupled_input_tys,
+        // 4. construct the correct generator type to return with
+        //    `CoroutineClosureSignature::to_coroutine_given_kind_and_upvars`.
+        // Then we wrap it all up into a list of inputs and output.
+        DefiningTy::CoroutineClosure(def_id, args) => {
+            assert_eq!(mir_def.to_def_id(), def_id);
+            let closure_sig = args.as_coroutine_closure().coroutine_closure_sig();
+            let bound_vars =
+                tcx.mk_bound_variable_kinds_from_iter(closure_sig.bound_vars().iter().chain(
+                    iter::once(ty::BoundVariableKind::Region(ty::BoundRegionKind::ClosureEnv)),
+                ));
+            let br = ty::BoundRegion {
+                var: ty::BoundVar::from_usize(bound_vars.len() - 1),
+                kind: ty::BoundRegionKind::ClosureEnv,
+            };
+            let env_region = ty::Region::new_bound(tcx, ty::INNERMOST, br);
+            let closure_kind = args.as_coroutine_closure().kind();
+
+            let closure_ty = tcx.closure_env_ty(
+                Ty::new_coroutine_closure(tcx, def_id, args),
+                closure_kind,
+                env_region,
+            );
+
+            let inputs = closure_sig.skip_binder().tupled_inputs_ty.tuple_fields();
+            let output = closure_sig.skip_binder().to_coroutine_given_kind_and_upvars(
+                tcx,
+                args.as_coroutine_closure().parent_args(),
+                tcx.coroutine_for_closure(def_id),
+                closure_kind,
+                env_region,
+                args.as_coroutine_closure().tupled_upvars_ty(),
+                args.as_coroutine_closure().coroutine_captures_by_ref_ty(),
+            );
+
+            ty::Binder::bind_with_vars(
+                tcx.mk_type_list_from_iter(
+                    iter::once(closure_ty).chain(inputs).chain(iter::once(output)),
+                ),
+                bound_vars,
+            )
+        }
+
+        DefiningTy::FnDef(def_id, _) => {
+            let sig = tcx.fn_sig(def_id).instantiate_identity().skip_norm_wip();
+            let inputs_and_output = sig.inputs_and_output();
+
+            // C-variadic fns also have a `VaList` input that's not listed in the signature
+            // (as it's created inside the body itself, not passed in from outside).
+            if infcx.tcx.fn_sig(def_id).skip_binder().c_variadic() {
+                let va_list_did =
+                    infcx.tcx.require_lang_item(LangItem::VaList, infcx.tcx.def_span(mir_def));
+
+                let reg_vid =
+                    infcx.next_nll_region_var(NllRegionVariableOrigin::FreeRegion).as_var();
+
+                let region = ty::Region::new_var(infcx.tcx, reg_vid);
+                let va_list_ty = infcx
+                    .tcx
+                    .type_of(va_list_did)
+                    .instantiate(infcx.tcx, &[region.into()])
+                    .skip_norm_wip();
+
+                // The signature needs to follow the order [input_tys, va_list_ty, output_ty]
+                return inputs_and_output.map_bound(|tys| {
+                    let (output_ty, input_tys) = tys.split_last().unwrap();
+                    tcx.mk_type_list_from_iter(
+                        input_tys.iter().copied().chain([va_list_ty, *output_ty]),
+                    )
+                });
+            }
+
+            inputs_and_output
+        }
+
+        DefiningTy::Const(def_id, _) => {
+            // For a constant body, there are no inputs, and one
+            // "output" (the type of the constant).
+            assert_eq!(mir_def.to_def_id(), def_id);
+            let ty = tcx.type_of(mir_def).instantiate_identity().skip_norm_wip();
+
+            ty::Binder::dummy(tcx.mk_type_list(&[ty]))
+        }
+
+        DefiningTy::InlineConst(def_id, args) => {
+            assert_eq!(mir_def.to_def_id(), def_id);
+            let ty = args.as_inline_const().ty();
+            ty::Binder::dummy(tcx.mk_type_list(&[ty]))
+        }
+
+        DefiningTy::GlobalAsm(def_id) => ty::Binder::dummy(
+            tcx.mk_type_list(&[tcx.type_of(def_id).instantiate_identity().skip_norm_wip()]),
+        ),
+    };
+
+    // FIXME(#129952): We probably want a more principled approach here.
+    if let Err(e) = inputs_and_output.error_reported() {
+        infcx.set_tainted_by_errors(e);
+    }
+
+    inputs_and_output
+}
+
+// FIXME: Move this somewhere to be used by the new query
+pub(crate) fn defining_ty_non_nll<'tcx>(
+    infcx: &InferCtxt<'tcx>,
+    mir_def: LocalDefId,
+) -> DefiningTy<'tcx> {
+    let tcx = infcx.tcx;
+    let typeck_root_def_id = tcx.typeck_root_def_id(mir_def.to_def_id());
+
+    match tcx.hir_body_owner_kind(mir_def) {
+        BodyOwnerKind::Closure | BodyOwnerKind::Fn => {
+            let defining_ty = tcx.type_of(mir_def).instantiate_identity().skip_norm_wip();
+
+            match defining_ty.kind() {
+                ty::Closure(def_id, args) => DefiningTy::Closure(*def_id, args),
+                ty::Coroutine(def_id, args) => DefiningTy::Coroutine(*def_id, args),
+                ty::CoroutineClosure(def_id, args) => DefiningTy::CoroutineClosure(*def_id, args),
+                ty::FnDef(def_id, args) => {
+                    DefiningTy::FnDef(*def_id, args.no_bound_vars().unwrap())
+                }
+                _ => span_bug!(
+                    tcx.def_span(mir_def),
+                    "expected defining type for `{:?}`: `{:?}`",
+                    mir_def,
+                    defining_ty
+                ),
+            }
+        }
+
+        BodyOwnerKind::Const { .. } | BodyOwnerKind::Static(..) => {
+            let args = GenericArgs::identity_for_item(tcx, typeck_root_def_id);
+            if mir_def.to_def_id() == typeck_root_def_id {
+                DefiningTy::Const(mir_def.to_def_id(), args)
+            } else {
+                // FIXME: this line creates a query dependency between borrowck and typeck.
+                //
+                // This is required for `AscribeUserType` canonical query, which will call
+                // `type_of(inline_const_def_id)`. That `type_of` would inject erased lifetimes
+                // into borrowck, which is ICE #78174.
+                //
+                // As a workaround, inline consts have an additional generic param (`ty`
+                // below), so that `type_of(inline_const_def_id).args(args)` uses the
+                // proper type with NLL infer vars.
+                let ty = tcx.typeck(mir_def).node_type(tcx.local_def_id_to_hir_id(mir_def));
+                let args =
+                    InlineConstArgs::new(tcx, InlineConstArgsParts { parent_args: args, ty }).args;
+                DefiningTy::InlineConst(mir_def.to_def_id(), args)
+            }
+        }
+
+        BodyOwnerKind::GlobalAsm => DefiningTy::GlobalAsm(mir_def.to_def_id()),
     }
 }

--- a/compiler/rustc_infer/src/traits/mod.rs
+++ b/compiler/rustc_infer/src/traits/mod.rs
@@ -10,8 +10,6 @@ pub mod util;
 use std::cmp;
 use std::hash::{Hash, Hasher};
 
-use hir::def_id::LocalDefId;
-use rustc_hir as hir;
 use rustc_macros::{TypeFoldable, TypeVisitable};
 use rustc_middle::traits::query::NoSolution;
 use rustc_middle::traits::solve::Certainty;

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -2532,6 +2532,15 @@ rustc_queries! {
         desc { "computing implied outlives bounds for `{}` (hack disabled = {:?})", key.0.canonical.value.value.ty, key.1 }
     }
 
+    query compute_outlives_bounds_rename(
+        mir_def: LocalDefId
+    ) -> Result<
+        &'tcx Canonical<'tcx, canonical::QueryResponse<'tcx, Vec<OutlivesBound<'tcx>>>>,
+        NoSolution,
+    > {
+        desc { "rename later" }
+    }
+
     /// Do not call this query directly:
     /// invoke `DropckOutlives::new(dropped_ty)).fully_perform(typeck.infcx)` instead.
     query dropck_outlives(

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -20,7 +20,8 @@ use rustc_hir::def_id::DefId;
 use rustc_macros::{
     Decodable, Encodable, StableHash, TyDecodable, TyEncodable, TypeFoldable, TypeVisitable,
 };
-use rustc_span::def_id::{CRATE_DEF_ID, LocalDefId};
+use rustc_span::def_id::CRATE_DEF_ID;
+pub use rustc_span::def_id::LocalDefId;
 use rustc_span::{DUMMY_SP, Span, Symbol};
 use smallvec::{SmallVec, smallvec};
 use thin_vec::ThinVec;

--- a/compiler/rustc_trait_selection/src/traits/query/type_op/implied_outlives_bounds.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/type_op/implied_outlives_bounds.rs
@@ -58,7 +58,8 @@ pub fn compute_implied_outlives_bounds_inner<'tcx>(
     // Inside mir borrowck, each computation starts with an empty list.
     assert!(
         ocx.infcx.inner.borrow().region_obligations().is_empty(),
-        "compute_implied_outlives_bounds assumes region obligations are empty before starting"
+        "compute_implied_outlives_bounds assumes region obligations are empty before starting {:?}",
+        ocx.infcx.inner.borrow().region_obligations()
     );
 
     let tcx = ocx.infcx.tcx;
@@ -170,6 +171,108 @@ pub fn compute_implied_outlives_bounds_inner<'tcx>(
     Ok(outlives_bounds)
 }
 
+// TODO: Find a way to deduplicate this later.
+// We need this because the new query "compute_rename_later" will wind up generating new
+// region constraint due to normalization, and hits the assert of region obligation needs
+// to be empty when this function is called.
+pub fn compute_implied_outlives_bounds_inner_new<'tcx>(
+    ocx: &ObligationCtxt<'_, 'tcx>,
+    param_env: ty::ParamEnv<'tcx>,
+    ty: Ty<'tcx>,
+    span: Span,
+) -> Result<Vec<OutlivesBound<'tcx>>, NoSolution> {
+    let tcx = ocx.infcx.tcx;
+    // FIXME: This doesn't seem right. All call sites already normalize `ty`:
+    // - `Ty`s from the `DefiningTy` in Borrowck: we have to normalize in the caller
+    //      in order to get implied bounds involving any unconstrained region vars
+    //      created as part of normalizing the sig. See #136547
+    // - `Ty`s from impl headers in Borrowck and in Non-Borrowck contexts: we have
+    //      to normalize in the caller as computing implied bounds from unnormalized
+    //      types would be unsound. See #100989
+    //
+    // We must normalize the type so we can compute the right outlives components.
+    // for example, if we have some constrained param type like `T: Trait<Out = U>`,
+    // and we know that `&'a T::Out` is WF, then we want to imply `U: 'a`.
+    let normalized_ty = ocx
+        .deeply_normalize(
+            &ObligationCause::dummy_with_span(span),
+            param_env,
+            ty::Unnormalized::new_wip(ty),
+        )
+        .map_err(|_| NoSolution)?;
+
+    // Sometimes when we ask what it takes for T: WF, we get back that
+    // U: WF is required; in that case, we push U onto this stack and
+    // process it next. Because the resulting predicates aren't always
+    // guaranteed to be a subset of the original type, so we need to store the
+    // WF args we've computed in a set.
+    let mut checked_wf_args = rustc_data_structures::fx::FxHashSet::default();
+    let mut wf_args = vec![ty.into(), normalized_ty.into()];
+
+    let mut outlives_bounds: Vec<OutlivesBound<'tcx>> = vec![];
+
+    while let Some(arg) = wf_args.pop() {
+        if !checked_wf_args.insert(arg) {
+            continue;
+        }
+
+        // From the full set of obligations, just filter down to the region relationships.
+        for obligation in
+            wf::unnormalized_obligations(ocx.infcx, param_env, arg, DUMMY_SP, CRATE_DEF_ID)
+                .into_iter()
+                .flatten()
+        {
+            let pred = ocx
+                .deeply_normalize(
+                    &ObligationCause::dummy_with_span(span),
+                    param_env,
+                    ty::Unnormalized::new_wip(obligation.predicate),
+                )
+                .map_err(|_| NoSolution)?;
+            let Some(pred) = pred.kind().no_bound_vars() else {
+                continue;
+            };
+            match pred {
+                // FIXME(generic_const_parameter_types): Make sure that `<'a, 'b, const N: &'a &'b u32>`
+                // is sound if we ever support that
+                ty::PredicateKind::Clause(ty::ClauseKind::Trait(..))
+                | ty::PredicateKind::Clause(ty::ClauseKind::HostEffect(..))
+                | ty::PredicateKind::Clause(ty::ClauseKind::ConstArgHasType(..))
+                | ty::PredicateKind::Subtype(..)
+                | ty::PredicateKind::Coerce(..)
+                | ty::PredicateKind::Clause(ty::ClauseKind::Projection(..))
+                | ty::PredicateKind::DynCompatible(..)
+                | ty::PredicateKind::Clause(ty::ClauseKind::ConstEvaluatable(..))
+                | ty::PredicateKind::ConstEquate(..)
+                | ty::PredicateKind::Ambiguous
+                | ty::PredicateKind::NormalizesTo(..)
+                | ty::PredicateKind::Clause(ty::ClauseKind::UnstableFeature(_)) => {}
+
+                // We need to search through *all* WellFormed predicates
+                ty::PredicateKind::Clause(ty::ClauseKind::WellFormed(term)) => {
+                    wf_args.push(term);
+                }
+
+                // We need to register region relationships
+                ty::PredicateKind::Clause(ty::ClauseKind::RegionOutlives(
+                    ty::OutlivesPredicate(r_a, r_b),
+                )) => outlives_bounds.push(OutlivesBound::RegionSubRegion(r_b, r_a)),
+
+                ty::PredicateKind::Clause(ty::ClauseKind::TypeOutlives(ty::OutlivesPredicate(
+                    ty_a,
+                    r_b,
+                ))) => {
+                    let mut components = smallvec![];
+                    push_outlives_components(tcx, ty_a, &mut components);
+                    outlives_bounds.extend(implied_bounds_from_components(tcx, r_b, components))
+                }
+            }
+        }
+    }
+
+    Ok(outlives_bounds)
+}
+
 struct ContainsBevyParamSet<'tcx> {
     tcx: TyCtxt<'tcx>,
 }
@@ -199,7 +302,7 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for ContainsBevyParamSet<'tcx> {
 /// this down to determine what relationships would have to hold for
 /// `T: 'a` to hold. We get to assume that the caller has validated
 /// those relationships.
-fn implied_bounds_from_components<'tcx>(
+pub fn implied_bounds_from_components<'tcx>(
     tcx: TyCtxt<'tcx>,
     sub_region: ty::Region<'tcx>,
     sup_components: SmallVec<[Component<TyCtxt<'tcx>>; 4]>,

--- a/tests/ui/borrowck/manual_test.rs
+++ b/tests/ui/borrowck/manual_test.rs
@@ -1,0 +1,13 @@
+//fn foo<T, 'a, 'b, 'c, 'd>(val: T, _: &'b u64, _: &'a u32, _: &'c u32, _: &'d u32) where 'b : 'b, 'd : 'd {}
+//pub trait Moo {}
+//impl Moo for &u8 {}
+//pub struct Foo<Q: Moo>(Q);
+//
+//fn test_handler<'a>(x: Foo<Moo<&'a u8>>) {}
+
+fn test2<'a>(x: &'a u32) {}
+
+
+
+
+fn main() {}

--- a/tests/ui/borrowck/manual_test0.rs
+++ b/tests/ui/borrowck/manual_test0.rs
@@ -1,0 +1,10 @@
+//fn foo<T, 'a, 'b, 'c, 'd>(val: T, _: &'b u64, _: &'a u32, _: &'c u32, _: &'d u32) where 'b : 'b, 'd : 'd {}
+
+pub trait Moo {}
+impl Moo for &u8 {}
+pub struct Foo<Q: Moo>(Q);
+
+fn test_handler<'a>(x: Foo<Moo<&'a u8>>) {}
+
+
+fn main() {}

--- a/tests/ui/borrowck/test-rename-later.rs
+++ b/tests/ui/borrowck/test-rename-later.rs
@@ -1,0 +1,29 @@
+//@ compile-flags: -Znext-solver
+
+use std::any::Any;
+
+struct Outlives<'a, T>(Option<&'a T>);
+trait Trait {
+    type Assoc;
+}
+
+impl<T> Trait for T {
+    type Assoc = T;
+}
+
+// Computing the implied bounds for `foo` normalizes `impl Sized` to
+// `Outlives::<'static, <T as Trait>::Assoc>`, adding the implied bound
+// `<T as Trait>::Assoc: 'static`.
+//
+// The caller does not have to prove that bound.
+fn foo<T: Trait>(x: <T as Trait>::Assoc) -> (Box<dyn Any>, impl Sized) {
+    (Box::new(x), Outlives::<'static, <T as Trait>::Assoc>(None))
+}
+
+fn main() {
+    let string = String::from("temporary");
+    let (any, _proof) = foo::<&str>(string.as_str());
+    drop(_proof);
+    drop(string);
+    println!("{}", any.downcast_ref::<&str>().unwrap());
+}

--- a/tests/ui/borrowck/test-rename-later.stderr
+++ b/tests/ui/borrowck/test-rename-later.stderr
@@ -1,0 +1,75 @@
+error[E0310]: the associated type `<T as Trait>::Assoc` may not live long enough
+  --> $DIR/test-rename-later.rs:19:1
+   |
+LL | fn foo<T: Trait>(x: <T as Trait>::Assoc) -> (Box<dyn Any>, impl Sized) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | the associated type `<T as Trait>::Assoc` must be valid for the static lifetime...
+   | ...so that the type `<T as Trait>::Assoc` will meet its required lifetime bounds
+   |
+help: consider adding an explicit lifetime bound
+   |
+LL | fn foo<T: Trait>(x: <T as Trait>::Assoc) -> (Box<dyn Any>, impl Sized) where <T as Trait>::Assoc: 'static {
+   |                                                                        ++++++++++++++++++++++++++++++++++
+
+error[E0310]: the associated type `<T as Trait>::Assoc` may not live long enough
+  --> $DIR/test-rename-later.rs:20:6
+   |
+LL |     (Box::new(x), Outlives::<'static, <T as Trait>::Assoc>(None))
+   |      ^^^^^^^^^^^
+   |      |
+   |      the associated type `<T as Trait>::Assoc` must be valid for the static lifetime...
+   |      ...so that the type `<T as Trait>::Assoc` will meet its required lifetime bounds
+   |
+help: consider adding an explicit lifetime bound
+   |
+LL | fn foo<T: Trait>(x: <T as Trait>::Assoc) -> (Box<dyn Any>, impl Sized) where <T as Trait>::Assoc: 'static {
+   |                                                                        ++++++++++++++++++++++++++++++++++
+
+error[E0310]: the associated type `<T as Trait>::Assoc` may not live long enough
+  --> $DIR/test-rename-later.rs:20:6
+   |
+LL |     (Box::new(x), Outlives::<'static, <T as Trait>::Assoc>(None))
+   |      ^^^^^^^^^^^
+   |      |
+   |      the associated type `<T as Trait>::Assoc` must be valid for the static lifetime...
+   |      ...so that the type `<T as Trait>::Assoc` will meet its required lifetime bounds
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider adding an explicit lifetime bound
+   |
+LL | fn foo<T: Trait>(x: <T as Trait>::Assoc) -> (Box<dyn Any>, impl Sized) where <T as Trait>::Assoc: 'static {
+   |                                                                        ++++++++++++++++++++++++++++++++++
+
+error[E0310]: the associated type `<T as Trait>::Assoc` may not live long enough
+  --> $DIR/test-rename-later.rs:20:19
+   |
+LL |     (Box::new(x), Outlives::<'static, <T as Trait>::Assoc>(None))
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                   |
+   |                   the associated type `<T as Trait>::Assoc` must be valid for the static lifetime...
+   |                   ...so that the type `<T as Trait>::Assoc` will meet its required lifetime bounds
+   |
+help: consider adding an explicit lifetime bound
+   |
+LL | fn foo<T: Trait>(x: <T as Trait>::Assoc) -> (Box<dyn Any>, impl Sized) where <T as Trait>::Assoc: 'static {
+   |                                                                        ++++++++++++++++++++++++++++++++++
+
+error[E0310]: the associated type `<T as Trait>::Assoc` may not live long enough
+  --> $DIR/test-rename-later.rs:20:19
+   |
+LL |     (Box::new(x), Outlives::<'static, <T as Trait>::Assoc>(None))
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                   |
+   |                   the associated type `<T as Trait>::Assoc` must be valid for the static lifetime...
+   |                   ...so that the type `<T as Trait>::Assoc` will meet its required lifetime bounds
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider adding an explicit lifetime bound
+   |
+LL | fn foo<T: Trait>(x: <T as Trait>::Assoc) -> (Box<dyn Any>, impl Sized) where <T as Trait>::Assoc: 'static {
+   |                                                                        ++++++++++++++++++++++++++++++++++
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0310`.


### PR DESCRIPTION
Open this draft PR so it's easier to discuss, feel free to point out any logic / soundness / error handling issues :>

Current status: 
- The implementation is mostly done, currently trying to get core to build and resolve ICEs found in test suite
- The test for https://github.com/rust-lang/trait-system-refactor-initiative/issues/159 successfully error in the new solver
- need more clean ups
- need to add test for https://github.com/rust-lang/rust/issues/136547

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
