### PR TITLE
Avoid semicolon suggestion when tail expr is error

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -954,7 +954,9 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 
         let new_obligation =
             self.mk_trait_obligation_with_new_self_ty(obligation.param_env, trait_pred_and_self);
-        if self.predicate_must_hold_modulo_regions(&new_obligation) {
+        if !matches!(tail_expr.kind, hir::ExprKind::Err(_))
+            && self.predicate_must_hold_modulo_regions(&new_obligation)
+        {
             err.span_suggestion_short(
                 stmt.span.with_lo(tail_expr.span.hi()),
                 "remove this semicolon",

--- a/tests/ui/type/recover-from-semicolon-trailing-undefined.rs
+++ b/tests/ui/type/recover-from-semicolon-trailing-undefined.rs
@@ -1,0 +1,12 @@
+//@ compile-flags: -Znext-solver=globally
+
+// Regression test for https://github.com/rust-lang/rust/issues/151610
+
+fn main() {
+    let x_str = {
+        x!("{}", x);
+        //~^ ERROR cannot find macro `x` in this scope
+    };
+    println!("{}", x_str);
+    //~^ ERROR `()` doesn't implement `std::fmt::Display`
+}

--- a/tests/ui/type/recover-from-semicolon-trailing-undefined.stderr
+++ b/tests/ui/type/recover-from-semicolon-trailing-undefined.stderr
@@ -1,0 +1,26 @@
+error: cannot find macro `x` in this scope
+  --> $DIR/recover-from-semicolon-trailing-undefined.rs:7:9
+   |
+LL |         x!("{}", x);
+   |         ^
+
+error[E0277]: `()` doesn't implement `std::fmt::Display`
+  --> $DIR/recover-from-semicolon-trailing-undefined.rs:10:20
+   |
+LL |       let x_str = {
+   |  _________________-
+LL | |         x!("{}", x);
+LL | |
+LL | |     };
+   | |_____- this block is missing a tail expression
+LL |       println!("{}", x_str);
+   |                 --   ^^^^^ `()` cannot be formatted with the default formatter
+   |                 |
+   |                 required by this formatting parameter
+   |
+   = help: the trait `std::fmt::Display` is not implemented for `()`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#151610

When the tail expression is Err due to recovery, HIR constructs `StmtKind::Semi(Err(..))`. The suggestion path then uses `stmt.span.with_lo(tail_expr.span.hi())` to target the semicolon, but `stmt.span == tail_expr.span` so the derived span is empty/invalid.