### PR TITLE
Distinguish error message for `#[diagnostic::on_const]` on const trait impls

### DIFF
--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -87,6 +87,10 @@ passes_deprecated_annotation_has_no_effect =
 passes_deprecated_attribute =
     deprecated attribute must be paired with either stable or unstable attribute
 
+passes_diagnostic_diagnostic_on_const_only_for_non_const_trait_impls =
+    `#[diagnostic::on_const]` can only be applied to non-const trait impls
+    .label = this is a const trait impl
+
 passes_diagnostic_diagnostic_on_const_only_for_trait_impls =
     `#[diagnostic::on_const]` can only be applied to trait impls
     .label = not a trait impl

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -67,6 +67,13 @@ struct DiagnosticOnConstOnlyForTraitImpls {
     item_span: Span,
 }
 
+#[derive(LintDiagnostic)]
+#[diag(passes_diagnostic_diagnostic_on_const_only_for_non_const_trait_impls)]
+struct DiagnosticOnConstOnlyForNonConstTraitImpls {
+    #[label]
+    item_span: Span,
+}
+
 fn target_from_impl_item<'tcx>(tcx: TyCtxt<'tcx>, impl_item: &hir::ImplItem<'_>) -> Target {
     match impl_item.kind {
         hir::ImplItemKind::Const(..) => Target::AssocConst,
@@ -629,7 +636,16 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
         if target == (Target::Impl { of_trait: true }) {
             match item.unwrap() {
                 ItemLike::Item(it) => match it.expect_impl().constness {
-                    Constness::Const => {}
+                    Constness::Const => {
+                        let item_span = self.tcx.hir_span(hir_id);
+                        self.tcx.emit_node_span_lint(
+                            MISPLACED_DIAGNOSTIC_ATTRIBUTES,
+                            hir_id,
+                            attr_span,
+                            DiagnosticOnConstOnlyForNonConstTraitImpls { item_span },
+                        );
+                        return;
+                    }
                     Constness::NotConst => return,
                 },
                 ItemLike::ForeignItem => {}

--- a/tests/ui/diagnostic_namespace/on_const/misplaced_attr.rs
+++ b/tests/ui/diagnostic_namespace/on_const/misplaced_attr.rs
@@ -6,7 +6,7 @@
 pub struct Foo;
 
 #[diagnostic::on_const(message = "tadaa", note = "boing")]
-//~^ ERROR: `#[diagnostic::on_const]` can only be applied to trait impls
+//~^ ERROR: `#[diagnostic::on_const]` can only be applied to non-const trait impls
 impl const PartialEq for Foo {
     fn eq(&self, _other: &Foo) -> bool {
         true

--- a/tests/ui/diagnostic_namespace/on_const/misplaced_attr.stderr
+++ b/tests/ui/diagnostic_namespace/on_const/misplaced_attr.stderr
@@ -13,14 +13,14 @@ note: the lint level is defined here
 LL | #![deny(misplaced_diagnostic_attributes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: `#[diagnostic::on_const]` can only be applied to trait impls
+error: `#[diagnostic::on_const]` can only be applied to non-const trait impls
   --> $DIR/misplaced_attr.rs:8:1
    |
 LL | #[diagnostic::on_const(message = "tadaa", note = "boing")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL | impl const PartialEq for Foo {
-   | ---------------------------- not a trait impl
+   | ---------------------------- this is a const trait impl
 
 error: `#[diagnostic::on_const]` can only be applied to trait impls
   --> $DIR/misplaced_attr.rs:16:1


### PR DESCRIPTION
context: https://github.com/rust-lang/rust/pull/149627#discussion_r2589712535

Sorry for the delay between receiving the review and submitting this patch. I'll ask the original proposer to review it.

r? estebank