### PR TITLE
ci: Optimize loongarch64-linux dist builders

### DIFF
--- a/src/ci/docker/host-x86_64/dist-loongarch64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-loongarch64-linux/Dockerfile
@@ -50,6 +50,9 @@ ENV RUST_CONFIGURE_ARGS \
       --enable-full-tools \
       --enable-profiler \
       --enable-sanitizers \
-      --disable-docs
+      --disable-docs \
+      --set rust.jemalloc \
+      --set rust.lto=thin \
+      --set rust.codegen-units=1
 
 ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $TARGETS

--- a/src/ci/docker/host-x86_64/dist-loongarch64-musl/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-loongarch64-musl/Dockerfile
@@ -33,6 +33,9 @@ ENV RUST_CONFIGURE_ARGS \
       --enable-profiler \
       --enable-sanitizers \
       --disable-docs \
+      --set rust.jemalloc \
+      --set rust.lto=thin \
+      --set rust.codegen-units=1 \
       --set target.loongarch64-unknown-linux-musl.crt-static=false \
       --musl-root-loongarch64=/x-tools/loongarch64-unknown-linux-musl/loongarch64-unknown-linux-musl/sysroot/usr
 


### PR DESCRIPTION
Tune the build configuration for loongarch64-linux targets to speed up rustc.

Changes include:
- Enable jemalloc and rust thin-lto.
- Set codegen-units=1.

These changes reduce rustc-perf compile time by ~17%.
