### PR TITLE
Fix set_times_nofollow for directory on windows

### DIFF
--- a/library/std/src/sys/fs/windows.rs
+++ b/library/std/src/sys/fs/windows.rs
@@ -1556,7 +1556,7 @@ pub fn set_perm(p: &WCStr, perm: FilePermissions) -> io::Result<()> {
 
 pub fn set_times(p: &WCStr, times: FileTimes) -> io::Result<()> {
     let mut opts = OpenOptions::new();
-    opts.write(true);
+    opts.access_mode(c::FILE_WRITE_ATTRIBUTES);
     opts.custom_flags(c::FILE_FLAG_BACKUP_SEMANTICS);
     let file = File::open_native(p, &opts)?;
     file.set_times(times)
@@ -1564,7 +1564,7 @@ pub fn set_times(p: &WCStr, times: FileTimes) -> io::Result<()> {
 
 pub fn set_times_nofollow(p: &WCStr, times: FileTimes) -> io::Result<()> {
     let mut opts = OpenOptions::new();
-    opts.write(true);
+    opts.access_mode(c::FILE_WRITE_ATTRIBUTES);
     // `FILE_FLAG_OPEN_REPARSE_POINT` for no_follow behavior
     opts.custom_flags(c::FILE_FLAG_BACKUP_SEMANTICS | c::FILE_FLAG_OPEN_REPARSE_POINT);
     let file = File::open_native(p, &opts)?;


### PR DESCRIPTION
Fix issue from:
https://github.com/rust-lang/rust/issues/147455#issuecomment-3841311858

old code `opts.write(true)` on Windows requests `GENERIC_WRITE` access, replace with `opts.access_mode(c::FILE_WRITE_ATTRIBUTES)` to get minimal permission.

r? @joshtriplett