### PR TITLE
Fix incorrect RSS on systems with non-4K page size

### DIFF
--- a/compiler/rustc_data_structures/src/profiling.rs
+++ b/compiler/rustc_data_structures/src/profiling.rs
@@ -995,12 +995,14 @@ cfg_select! {
     }
     unix => {
         pub fn get_resident_set_size() -> Option<usize> {
+            use libc::{sysconf, _SC_PAGESIZE};
             let field = 1;
             let contents = fs::read("/proc/self/statm").ok()?;
             let contents = String::from_utf8(contents).ok()?;
             let s = contents.split_whitespace().nth(field)?;
             let npages = s.parse::<usize>().ok()?;
-            Some(npages * 4096)
+            // SAFETY: `sysconf(_SC_PAGESIZE)` has no side effects and is safe to call.
+            Some(npages * unsafe { sysconf(_SC_PAGESIZE) } as usize)
         }
     }
     _ => {


### PR DESCRIPTION
`get_resident_set_size` computed RSS by multiplying the number of pages from `/proc/self/statm` with a hard-coded 4096-byte page size. This produces incorrect results on systems where the runtime page size is not 4 KiB.

Use `sysconf(_SC_PAGESIZE)` to determine the actual page size at runtime so the RSS reported in `-Z time-passes` output is accurate across platforms.