### PR TITLE
bootstrap: exclude hexagon-unknown-qurt from llvm-libunwind default

### DIFF
--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1859,11 +1859,17 @@ impl Config {
             .get(&target)
             .and_then(|t| t.llvm_libunwind)
             .or(self.llvm_libunwind_default)
-            .unwrap_or(if target.contains("fuchsia") || target.contains("hexagon") {
-                LlvmLibunwind::InTree
-            } else {
-                LlvmLibunwind::No
-            })
+            .unwrap_or(
+                if target.contains("fuchsia")
+                    || (target.contains("hexagon") && !target.contains("qurt"))
+                {
+                    // Fuchsia and Hexagon Linux use in-tree llvm-libunwind.
+                    // Hexagon QuRT uses libc_eh from the Hexagon SDK instead.
+                    LlvmLibunwind::InTree
+                } else {
+                    LlvmLibunwind::No
+                },
+            )
     }
 
     pub fn split_debuginfo(&self, target: TargetSelection) -> SplitDebuginfo {


### PR DESCRIPTION
Hexagon Linux targets (hexagon-unknown-linux-musl) use in-tree llvm-libunwind for stack unwinding. However, hexagon-unknown-qurt uses libc_eh from the Hexagon SDK instead.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
