### PR TITLE
Fix GitHub CI summary in CodeBuild

### DIFF
--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -359,11 +359,11 @@ docker \
   rust-ci \
   "${command[@]}"
 
-if isCI; then
-    cat $objdir/${SUMMARY_FILE} >> "${GITHUB_STEP_SUMMARY}"
-fi
-
 if [ -f /.dockerenv ]; then
   rm -rf $objdir
   docker cp checkout:/checkout/obj $objdir
+fi
+
+if isCI; then
+    cat $objdir/${SUMMARY_FILE} >> "${GITHUB_STEP_SUMMARY}"
 fi


### PR DESCRIPTION
We need to copy the summary only after the data is copied out from the Docker image in Docker-in-Docker/CodeBuild scenarios. This was broken for many months now.

Compare the summary https://github.com/rust-lang/rust/actions/runs/21663321354 (before) and https://github.com/rust-lang/rust/actions/runs/21671277310 (after) - the dist-x86_64-linux job now correctly contains the summary generated by `opt-dist`.

r? @marcoieni
