### PR TITLE
Don't ICE on layout error in vtable computation

### DIFF
--- a/compiler/rustc_middle/src/ty/vtable.rs
+++ b/compiler/rustc_middle/src/ty/vtable.rs
@@ -99,9 +99,10 @@ pub(super) fn vtable_allocation_provider<'tcx>(
     // This confirms that the layout computation for &dyn Trait has an accurate sizing.
     assert!(vtable_entries.len() >= vtable_min_entries(tcx, poly_trait_ref));
 
-    let layout = tcx
-        .layout_of(ty::TypingEnv::fully_monomorphized().as_query_input(ty))
-        .expect("failed to build vtable representation");
+    let layout = match tcx.layout_of(ty::TypingEnv::fully_monomorphized().as_query_input(ty)) {
+        Ok(layout) => layout,
+        Err(e) => tcx.dcx().emit_fatal(e.into_diagnostic()),
+    };
     assert!(layout.is_sized(), "can't create a vtable for an unsized type");
     let size = layout.size.bytes();
     let align = layout.align.bytes();

--- a/tests/ui/limits/vtable-try-as-dyn.full-debuginfo.stderr
+++ b/tests/ui/limits/vtable-try-as-dyn.full-debuginfo.stderr
@@ -1,0 +1,4 @@
+error: values of the type `[u8; usize::MAX]` are too big for the target architecture
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/limits/vtable-try-as-dyn.no-debuginfo.stderr
+++ b/tests/ui/limits/vtable-try-as-dyn.no-debuginfo.stderr
@@ -1,0 +1,4 @@
+error: values of the type `[u8; usize::MAX]` are too big for the target architecture
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/limits/vtable-try-as-dyn.rs
+++ b/tests/ui/limits/vtable-try-as-dyn.rs
@@ -1,0 +1,15 @@
+// At the time of writing, vtable.rs would ICE only with debuginfo disabled, while this testcase,
+// originally reported as #152030, would ICE even with debuginfo enabled.
+//@ revisions: no-debuginfo full-debuginfo
+//@ compile-flags: --crate-type=lib --emit=mir
+//@[no-debuginfo] compile-flags: -C debuginfo=0
+//@[full-debuginfo] compile-flags: -C debuginfo=2
+#![feature(try_as_dyn)]
+
+trait Trait {}
+impl<T> Trait for T {}
+
+//~? ERROR: values of the type `[u8; usize::MAX]` are too big for the target architecture
+pub fn foo(x: &[u8; usize::MAX]) {
+    let _ = std::any::try_as_dyn::<[u8; usize::MAX], dyn Trait>(x);
+}

--- a/tests/ui/limits/vtable.rs
+++ b/tests/ui/limits/vtable.rs
@@ -1,0 +1,8 @@
+//@ compile-flags: --crate-type=lib --emit=mir -C debuginfo=0
+pub trait Trait {}
+impl<T> Trait for T {}
+
+//~? ERROR: values of the type `[u8; usize::MAX]` are too big for the target architecture
+pub fn foo(x: &[u8; usize::MAX]) -> &dyn Trait {
+    x as &dyn Trait
+}

--- a/tests/ui/limits/vtable.stderr
+++ b/tests/ui/limits/vtable.stderr
@@ -1,0 +1,4 @@
+error: values of the type `[u8; usize::MAX]` are too big for the target architecture
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes rust-lang/rust#152030.

Note: I'm including a more general testcase that doesn't use the feature in the original report, but only reproduces with debuginfo disabled. Does it make sense to also include the original testcase?

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
