### PR TITLE
Stabilize -Zinstrument-mcount

### DIFF
--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -152,7 +152,7 @@ pub(crate) fn frame_pointer_type_attr<'ll>(
     let opts = &sess.opts;
     // "mcount" function relies on stack pointer.
     // See <https://sourceware.org/binutils/docs/gprof/Implementation.html>.
-    if opts.unstable_opts.instrument_mcount {
+    if opts.cg.instrument_mcount {
         fp.ratchet(FramePointer::Always);
     }
     fp.ratchet(opts.cg.force_frame_pointers);
@@ -180,7 +180,7 @@ fn instrument_function_attr<'ll>(
     sess: &Session,
 ) -> SmallVec<[&'ll Attribute; 4]> {
     let mut attrs = SmallVec::new();
-    if sess.opts.unstable_opts.instrument_mcount {
+    if sess.opts.cg.instrument_mcount {
         // Similar to `clang -pg` behavior. Handled by the
         // `post-inline-ee-instrument` LLVM pass.
 

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -620,6 +620,7 @@ fn test_codegen_options_tracking_hash() {
     tracked!(force_frame_pointers, FramePointer::Always);
     tracked!(force_unwind_tables, Some(true));
     tracked!(instrument_coverage, InstrumentCoverage::Yes);
+    tracked!(instrument_mcount, true);
     tracked!(jump_tables, false);
     tracked!(link_dead_code, Some(true));
     tracked!(linker_plugin_lto, LinkerPluginLto::LinkerPluginAuto);
@@ -813,7 +814,6 @@ fn test_unstable_options_tracking_hash() {
     tracked!(inline_mir, Some(true));
     tracked!(inline_mir_hint_threshold, Some(123));
     tracked!(inline_mir_threshold, Some(123));
-    tracked!(instrument_mcount, true);
     tracked!(instrument_xray, Some(InstrumentXRay::default()));
     tracked!(link_directives, false);
     tracked!(link_only, true);

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2093,6 +2093,8 @@ options! {
         "instrument the generated code to support LLVM source-based code coverage reports \
         (note, the compiler build config must include `profiler = true`); \
         implies `-C symbol-mangling-version=v0`"),
+    instrument_mcount: bool = (false, parse_bool, [TRACKED],
+        "insert function instrument code for mcount-based tracing (default: no)"),
     jump_tables: bool = (true, parse_bool, [TRACKED],
         "allow jump table and lookup table generation from switch case lowering (default: yes)"),
     link_arg: (/* redirected to link_args */) = ((), parse_string_push, [UNTRACKED],
@@ -2385,8 +2387,6 @@ options! {
         "a default MIR inlining threshold (default: 50)"),
     input_stats: bool = (false, parse_bool, [UNTRACKED],
         "print some statistics about AST and HIR (default: no)"),
-    instrument_mcount: bool = (false, parse_bool, [TRACKED],
-        "insert function instrument code for mcount-based tracing (default: no)"),
     instrument_xray: Option<InstrumentXRay> = (None, parse_instrument_xray, [TRACKED],
         "insert function instrument code for XRay-based tracing (default: no)
          Optional extra settings:

--- a/src/doc/rustc/src/codegen-options/index.md
+++ b/src/doc/rustc/src/codegen-options/index.md
@@ -209,6 +209,12 @@ Note that while the `-C instrument-coverage` option is stable, the profile data
 format produced by the resulting instrumentation may change, and may not work
 with coverage tools other than those built and shipped with the compiler.
 
+## instrument-mcount
+
+This option inserts an mcount profiling call into each function prologue within
+the crate being compiled. The instrumentation is compatible with gprof and
+similiar tools.
+
 ## jump-tables
 
 This option is used to allow or prevent the LLVM codegen backend from creating

--- a/tests/assembly-llvm/x86_64-mcount.rs
+++ b/tests/assembly-llvm/x86_64-mcount.rs
@@ -1,5 +1,5 @@
 //@ assembly-output: emit-asm
-//@ compile-flags: -Zinstrument-mcount=y -Cllvm-args=-x86-asm-syntax=intel
+//@ compile-flags: -Cinstrument-mcount=y -Cllvm-args=-x86-asm-syntax=intel
 
 //@ revisions: x86_64-linux
 //@[x86_64-linux] compile-flags: --target=x86_64-unknown-linux-gnu

--- a/tests/codegen-llvm/instrument-mcount.rs
+++ b/tests/codegen-llvm/instrument-mcount.rs
@@ -1,5 +1,5 @@
 //
-//@ compile-flags: -Z instrument-mcount -Copt-level=0
+//@ compile-flags: -C instrument-mcount=yes -Copt-level=0
 
 #![crate_type = "lib"]
 


### PR DESCRIPTION
# Stabilization report

## Summary

Stabilize the boolean `-Zinstrument-mcount` command line option into `-Cinstrument-mcount`.
This option is similar to the gcc or clang `-pg` option to support instrumented profiling. This option
inserts a special function call into each function's prologue in the crate being compiler. The name of
the function is target specific. A user would then link a library which implements this function to
collect profiling data.

A common use is to compile a binary for instrumented profiling using [gprof](https://sourceware.org/binutils/docs/gprof/Compiling.html).
`ld` supports a special option (also called `-pg`) to link the necessary runtime support for
instrumented profiling.

This option was introduced several years ago, and quietly broke for a period of time due to
refactoring within LLVM, but has since been fixed with an end-to-end test to verify (at least on
x86-64) functions are instrumented.

And all other contributors who have tested, reported, or fixed bugs since 2018.

cc @rust-lang/compiler

### What is stabilized

The command line option `-Cinstrument-mcount`. More generally, the ability to instrument function entry points in way compatible with other widely adopted toolchains (gcc, clang) for instrumenting function calls.

### What isn't stabilized

None.

## Design

### Reference

This feature annotates LLVM IR functions with `instrument-function-entry-inlined=target_mcount_name` where `target_mcount_name` is target specific. 

### RFC history

This option was likely considered too trivial for an RFC.

### Answers to unresolved questions

None yet.

### Post-RFC changes

None.

### Key points

### Nightly extensions

There is not part of this feature which will remain unstable.

### Doors closed

This option has minimal impact on other options.

## Feedback

### Call for testing

No. This is a very narrowly scoped option. In the years since this was added there is now sufficient testing to verify the compiler feature
works end-to-end on major targets.

### Nightly use

> Do any known nightly users use this feature? Counting instances of `#![feature(FEATURE_NAME)]` on GitHub with grep might be informative.

No. It was suggested this might be useful for Rust For Linux, but it is not yet used.

## Implementation

### Major parts

- @quark-zju's [PR#57220 add -Z instrument-mcount](https://github.com/rust-lang/rust/pull/57220)

### Coverage

Various PR's over the years have added support for target specific mcount function names which verify the correct function attributes are applied, and several tier 1 targets verify the mcount function is called after LLVM code generation.

- @clubby789's [PR#145884 test to verify LLVM actually instruments functions](https://github.com/rust-lang/rust/pull/145884/)
- @JohnTitor's [PR#59506 support for target specific mcount function name](https://github.com/rust-lang/rust/pull/59506/)
- @ChoKyuWon's [PR#113814 fix ARM32 mcount instrinsic](https://github.com/rust-lang/rust/pull/113814)

### Outstanding bugs

There are no outstanding bugs.

### Outstanding FIXMEs

None.

### Tool changes

This requires no tooling changes. Though, the utility of this option could be increased by addition cargo support to build instrumented binaries. That would required a stabilized means to build and instrumented `std` and apply appropriate linker flags. That discussion is out of this scope.

### Breaking changes

None.

## History and Acknoledgments

The following contributors have implemented, tested, and stabilized this feature:
- @clubby789's [PR#145884 test to verify LLVM actually instruments functions](https://github.com/rust-lang/rust/pull/145884/)
- @JohnTitor's [PR#59506 support for target specific mcount function name](https://github.com/rust-lang/rust/pull/59506/)
- @ChoKyuWon's [PR#113814 fix ARM32 mcount instrinsic](https://github.com/rust-lang/rust/pull/113814)
- @quark-zju's [PR#57220 add -Z instrument-mcount](https://github.com/rust-lang/rust/pull/57220)

And any others I have failed to uncover in the long history of this option.

## Open items

- [ ] The linux kernel also makes use of attributes to inhibit tracing on selected functions. Should a Rust attribute be added to support inhibiting instrumentation? e.g
```rust
#[instrument_mcount(no)]
fn foo() {
    // ...
}
```

- [ ] Is there any objection to the name of this option? mcount seems to be a historical artifact from BSD, nor is the instrumentation function named this.
- [ ] End-to-end testing should be expanded to all tier1 targets
- [ ] There is a lack of documentation about the target specific profiling ABI. How much documentation should Rust provide?
- [ ] Are the target specific calls inserted by LLVM sufficiently stable to make this a stable option? 


