### PR TITLE
Adopt matches-logical-or-141497.rs to LLVM HEAD

### DIFF
--- a/tests/codegen-llvm/issues/matches-logical-or-141497.rs
+++ b/tests/codegen-llvm/issues/matches-logical-or-141497.rs
@@ -2,7 +2,7 @@
 // `f == FrameType::Inter || f == FrameType::Switch`.
 
 //@ compile-flags: -Copt-level=3
-//@ min-llvm-version: 21
+//@ min-llvm-version: 23
 
 #![crate_type = "lib"]
 
@@ -18,8 +18,7 @@ pub enum FrameType {
 #[no_mangle]
 pub fn is_inter_or_switch(f: FrameType) -> bool {
     // CHECK-NEXT: start:
-    // CHECK-NEXT: and i8
-    // CHECK-NEXT: icmp
+    // CHECK-NEXT: trunc i8 %{{.*}} to i1
     // CHECK-NEXT: ret
     matches!(f, FrameType::Inter | FrameType::Switch)
 }


### PR DESCRIPTION
After http://github.com/llvm/llvm-project/pull/178977, the and + icmp are folded to trunc.