### PR TITLE
library/std: Rename `ON_BROKEN_PIPE_FLAG_USED` to `ON_BROKEN_PIPE_USED`

### DIFF
--- a/library/std/src/sys/pal/unix/mod.rs
+++ b/library/std/src/sys/pal/unix/mod.rs
@@ -169,15 +169,15 @@ pub unsafe fn init(argc: isize, argv: *const *const u8, sigpipe: u8) {
                 pub const SIG_DFL: u8 = 3;
             }
 
-            let (sigpipe_attr_specified, handler) = match sigpipe {
+            let (on_broken_pipe_used, handler) = match sigpipe {
                 sigpipe::DEFAULT => (false, Some(libc::SIG_IGN)),
                 sigpipe::INHERIT => (true, None),
                 sigpipe::SIG_IGN => (true, Some(libc::SIG_IGN)),
                 sigpipe::SIG_DFL => (true, Some(libc::SIG_DFL)),
                 _ => unreachable!(),
             };
-            if sigpipe_attr_specified {
-                ON_BROKEN_PIPE_FLAG_USED.store(true, crate::sync::atomic::Ordering::Relaxed);
+            if on_broken_pipe_used {
+                ON_BROKEN_PIPE_USED.store(true, crate::sync::atomic::Ordering::Relaxed);
             }
             if let Some(handler) = handler {
                 rtassert!(signal(libc::SIGPIPE, handler) != libc::SIG_ERR);
@@ -199,7 +199,7 @@ pub unsafe fn init(argc: isize, argv: *const *const u8, sigpipe: u8) {
     target_os = "vxworks",
     target_os = "vita",
 )))]
-static ON_BROKEN_PIPE_FLAG_USED: crate::sync::atomic::Atomic<bool> =
+static ON_BROKEN_PIPE_USED: crate::sync::atomic::Atomic<bool> =
     crate::sync::atomic::AtomicBool::new(false);
 
 #[cfg(not(any(
@@ -211,8 +211,8 @@ static ON_BROKEN_PIPE_FLAG_USED: crate::sync::atomic::Atomic<bool> =
     target_os = "vita",
     target_os = "nuttx",
 )))]
-pub(crate) fn on_broken_pipe_flag_used() -> bool {
-    ON_BROKEN_PIPE_FLAG_USED.load(crate::sync::atomic::Ordering::Relaxed)
+pub(crate) fn on_broken_pipe_used() -> bool {
+    ON_BROKEN_PIPE_USED.load(crate::sync::atomic::Ordering::Relaxed)
 }
 
 // SAFETY: must be called only once during runtime cleanup.

--- a/library/std/src/sys/process/unix/unix.rs
+++ b/library/std/src/sys/process/unix/unix.rs
@@ -356,7 +356,7 @@ impl Command {
             // If -Zon-broken-pipe is not used, reset SIGPIPE to SIG_DFL for backward compatibility.
             //
             // -Zon-broken-pipe is an opportunity to change the default here.
-            if !crate::sys::pal::on_broken_pipe_flag_used() {
+            if !crate::sys::pal::on_broken_pipe_used() {
                 #[cfg(target_os = "android")] // see issue #88585
                 {
                     let mut action: libc::sigaction = mem::zeroed();
@@ -455,7 +455,7 @@ impl Command {
         use core::sync::atomic::{Atomic, AtomicU8, Ordering};
 
         use crate::mem::MaybeUninit;
-        use crate::sys::{self, cvt_nz, on_broken_pipe_flag_used};
+        use crate::sys::{self, cvt_nz, on_broken_pipe_used};
 
         if self.get_gid().is_some()
             || self.get_uid().is_some()
@@ -731,7 +731,7 @@ impl Command {
             // If -Zon-broken-pipe is not used, reset SIGPIPE to SIG_DFL for backward compatibility.
             //
             // -Zon-broken-pipe is an opportunity to change the default here.
-            if !on_broken_pipe_flag_used() {
+            if !on_broken_pipe_used() {
                 let mut default_set = MaybeUninit::<libc::sigset_t>::uninit();
                 cvt(sigemptyset(default_set.as_mut_ptr()))?;
                 cvt(sigaddset(default_set.as_mut_ptr(), libc::SIGPIPE))?;


### PR DESCRIPTION
This commit is a pure internal rename and does not change any functionality.

The `FLAG_` part of `ON_BROKEN_PIPE_FLAG_USED` comes from that the compiler flag `-Zon-broken-pipe=...` is used to enable the feature.

Remove the `FLAG_` part so the name works both for the current compiler flag `-Zon-broken-pipe=...` and for the upcoming [Externally Implementable Item `#[std::io::on_broken_pipe]`](https://github.com/rust-lang/rust/pull/150591) PR. This makes the diff of that PR smaller.

The local variable name `sigpipe_attr_specified` comes from way back when the feature was controlled with an `fn main()` attribute called `#[unix_sigpipe = "..."]`. Rename that too.

