### PR TITLE
Set crt_static_allow_dylibs to true for Emscripten target

### DIFF
--- a/compiler/rustc_target/src/spec/targets/wasm32_unknown_emscripten.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_unknown_emscripten.rs
@@ -19,8 +19,15 @@ pub(crate) fn target() -> Target {
         pre_link_args,
         post_link_args,
         relocation_model: RelocModel::Pic,
+        // crt_static should always be true for an executable and always false
+        // for a shared library. There is no easy way to indicate this and it
+        // doesn't seem to matter much so we set crt_static_allows_dylibs to
+        // true and leave crt_static as true when linking dynamic libraries.
+        // wasi also sets crt_static_allows_dylibs: true so this is at least
+        // aligned between wasm targets.
         crt_static_respected: true,
         crt_static_default: true,
+        crt_static_allows_dylibs: true,
         panic_strategy: PanicStrategy::Unwind,
         no_default_libraries: false,
         families: cvs!["unix", "wasm"],

--- a/src/tools/compiletest/src/directives/directive_names.rs
+++ b/src/tools/compiletest/src/directives/directive_names.rs
@@ -249,6 +249,7 @@ pub(crate) const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "only-unix",
     "only-visionos",
     "only-wasm32",
+    "only-wasm32-unknown-emscripten",
     "only-wasm32-unknown-unknown",
     "only-wasm32-wasip1",
     "only-watchos",

--- a/tests/run-make/wasm-emscripten-cdylib/foo.rs
+++ b/tests/run-make/wasm-emscripten-cdylib/foo.rs
@@ -1,0 +1,4 @@
+#[no_mangle]
+pub extern "C" fn foo() -> i32 {
+    42
+}

--- a/tests/run-make/wasm-emscripten-cdylib/rmake.rs
+++ b/tests/run-make/wasm-emscripten-cdylib/rmake.rs
@@ -1,0 +1,25 @@
+//! Check that cdylib crate type is supported for the wasm32-unknown-emscripten
+//! target and produces a valid Emscripten dynamic library.
+
+//@ only-wasm32-unknown-emscripten
+
+use run_make_support::{bare_rustc, rfs, wasmparser};
+
+fn main() {
+    bare_rustc().input("foo.rs").target("wasm32-unknown-emscripten").crate_type("cdylib").run();
+
+    // Verify the output is a valid wasm file with a dylink.0 section
+    let file = rfs::read("foo.wasm");
+    let mut has_dylink = false;
+
+    for payload in wasmparser::Parser::new(0).parse_all(&file) {
+        let payload = payload.unwrap();
+        if let wasmparser::Payload::CustomSection(s) = payload {
+            if s.name() == "dylink.0" {
+                has_dylink = true;
+            }
+        }
+    }
+
+    assert!(has_dylink, "expected dylink.0 section in emscripten cdylib output");
+}


### PR DESCRIPTION
And add a test. This is followup work to rust-lang/rust#151704. It introduced a regression where cargo is now unwilling to build cdylibs for Emscripten because `crt_static_default` is `true` but `crt_static_allows_dylibs` is `false`. Unfortunately the added test does not fail without the change because the validation logic is in Cargo, not in rustc. But it's good to have some coverage of this anyways.
