### PR TITLE
DRAFT: consistent Windows PATH parsing

### DIFF
--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -456,6 +456,9 @@ pub struct SplitPaths<'a> {
 /// On most Unix platforms, the separator is `:` and on Windows it is `;`. This
 /// also performs unquoting on Windows.
 ///
+/// On Unix systems an empty path corresponds to the current working directory
+/// and on Windows systems an empty path is disregarded.
+///
 /// [`join_paths`] can be used to recombine elements.
 ///
 /// # Panics

--- a/library/std/src/sys/pal/windows/os.rs
+++ b/library/std/src/sys/pal/windows/os.rs
@@ -45,7 +45,7 @@ impl<'a> Iterator for SplitPaths<'a> {
 
         let mut in_progress = Vec::new();
         let mut in_quote = false;
-        for b in self.data.by_ref() {
+        for b in self.data.by_ref().skip_while(|&b| b == ';' as u16) {
             if b == '"' as u16 {
                 in_quote = !in_quote;
             } else if b == ';' as u16 && !in_quote {

--- a/library/std/tests/path.rs
+++ b/library/std/tests/path.rs
@@ -9,9 +9,9 @@ use std::ffi::OsStr;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::mem::MaybeUninit;
 use std::path::*;
+use std::ptr;
 use std::rc::Rc;
 use std::sync::Arc;
-use std::{env, ptr};
 
 #[allow(unknown_lints, unused_macro_rules)]
 macro_rules! t (

--- a/library/std/tests/path.rs
+++ b/library/std/tests/path.rs
@@ -9,9 +9,9 @@ use std::ffi::OsStr;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::mem::MaybeUninit;
 use std::path::*;
-use std::ptr;
 use std::rc::Rc;
 use std::sync::Arc;
+use std::{env, ptr};
 
 #[allow(unknown_lints, unused_macro_rules)]
 macro_rules! t (
@@ -2575,5 +2575,50 @@ fn test_trim_trailing_sep() {
         assert_eq!(Path::new("c:.\\\\").trim_trailing_sep().as_os_str(), OsStr::new("c:."));
         assert_eq!(Path::new("c:..\\").trim_trailing_sep().as_os_str(), OsStr::new("c:.."));
         assert_eq!(Path::new("c:..\\\\").trim_trailing_sep().as_os_str(), OsStr::new("c:.."));
+    }
+}
+
+// Test: Empty PATH paths
+// This test checks how `split_paths` handles empty segments.
+// On Unix it should be an empty `Path` and on Windows it should disregard the segment.
+#[test]
+fn test_only_separators() {
+    use std::env::split_paths;
+    #[cfg(unix)]
+    {
+        assert_eq!(split_paths("").collect::<Vec<_>>(), vec![PathBuf::new(); 1]);
+        assert_eq!(split_paths(":").collect::<Vec<_>>(), vec![PathBuf::new(); 2]);
+        assert_eq!(split_paths("::").collect::<Vec<_>>(), vec![PathBuf::new(); 3]);
+
+        assert_eq!(
+            split_paths("a::").collect::<Vec<_>>(),
+            vec![PathBuf::from("a"), PathBuf::from(""), PathBuf::from("")]
+        );
+        assert_eq!(
+            split_paths("a::b").collect::<Vec<_>>(),
+            vec![PathBuf::from("a"), PathBuf::from(""), PathBuf::from("b")]
+        );
+        assert_eq!(
+            split_paths("::b").collect::<Vec<_>>(),
+            vec![PathBuf::from(""), PathBuf::from(""), PathBuf::from("b")]
+        );
+        assert_eq!(
+            split_paths(":a:").collect::<Vec<_>>(),
+            vec![PathBuf::from(""), PathBuf::from("a"), PathBuf::from("")]
+        );
+    }
+    #[cfg(windows)]
+    {
+        assert_eq!(split_paths("").collect::<Vec<PathBuf>>(), vec![]);
+        assert_eq!(split_paths(";").collect::<Vec<PathBuf>>(), vec![]);
+        assert_eq!(split_paths(";;").collect::<Vec<PathBuf>>(), vec![]);
+
+        assert_eq!(split_paths("a;;").collect::<Vec<_>>(), vec![PathBuf::from("a")]);
+        assert_eq!(
+            split_paths("a;;b").collect::<Vec<_>>(),
+            vec![PathBuf::from("a"), PathBuf::from("b")]
+        );
+        assert_eq!(split_paths(";;b").collect::<Vec<_>>(), vec![PathBuf::from("b")]);
+        assert_eq!(split_paths(";a;").collect::<Vec<_>>(), vec![PathBuf::from("a")]);
     }
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This is my first pull request, and Dylan is helping me get used to the process. This PR should fix the inconsistency at rust-lang/rust#111832 . Neither I nor Dylan have a local Windows development environment, so we're hoping the CI has us covered.

cc @Dylan-DPC 