### PR TITLE
Disable flaky test `oneshot::recv_timeout_before_send`

### DIFF
--- a/library/std/tests/sync/oneshot.rs
+++ b/library/std/tests/sync/oneshot.rs
@@ -127,6 +127,7 @@ fn recv_before_send() {
 }
 
 #[test]
+#[ignore = "Inherently flaky and has caused several CI failures"]
 fn recv_timeout_before_send() {
     let (sender, receiver) = oneshot::channel();
 
@@ -135,6 +136,8 @@ fn recv_timeout_before_send() {
         sender.send(99u128).unwrap();
     });
 
+    // FIXME(#152145): Under load, there's no guarantee that thread `t` has
+    // ever been scheduled and run before this timeout expires.
     match receiver.recv_timeout(Duration::from_secs(1)) {
         Ok(99) => {}
         _ => panic!("expected Ok(99)"),


### PR DESCRIPTION
This test is inherently flaky due to a thread-scheduling race condition, and has failed several times in CI, e.g.:
- https://github.com/rust-lang/rust/pull/151739#issuecomment-3850533911
- https://github.com/rust-lang/rust/pull/151971#issuecomment-3832862029
- https://github.com/rust-lang/rust/pull/151376#issuecomment-3774862894

---
- cc @connortsui20, author of https://github.com/rust-lang/rust/pull/143741