### PR TITLE
Fix error spans for `asm!()` args that are macros

### DIFF
--- a/tests/crashes/131292.rs
+++ b/tests/crashes/131292.rs
@@ -1,7 +1,0 @@
-//@ known-bug: #131292
-//@ needs-asm-support
-use std::arch::asm;
-
-unsafe fn f6() {
-    asm!(concat!(r#"lJ𐏿Æ�.𐏿�"#, "{}/day{:02}.txt"));
-}

--- a/tests/ui/asm/ice-bad-err-span-in-template-129503.rs
+++ b/tests/ui/asm/ice-bad-err-span-in-template-129503.rs
@@ -1,16 +1,21 @@
-// Regression test for ICE #129503
-
-
+// Regression test for ICEs #129503 and #131292
+//
 // Tests that we come up with decent error spans
 // when the template fed to `asm!()` is itself a
 // macro call like `concat!()` and should not ICE
 
+//@ needs-asm-support
+
 use std::arch::asm;
 
 fn main() {
-    // Should not ICE
+    // Should not ICE (test case for #129503)
     asm!(concat!(r#"lJ𐏿Æ�.𐏿�"#, "r} {}"));
     //~^ ERROR invalid asm template string: unmatched `}` found
+
+    // Should not ICE (test case for #131292)
+    asm!(concat!(r#"lJ𐏿Æ�.𐏿�"#, "{}/day{:02}.txt"));
+    //~^ ERROR invalid asm template string: expected `}`, found `0`
 
 
     // Macro call template: should point to

--- a/tests/ui/asm/ice-bad-err-span-in-template-129503.stderr
+++ b/tests/ui/asm/ice-bad-err-span-in-template-129503.stderr
@@ -1,13 +1,24 @@
 error: invalid asm template string: unmatched `}` found
-  --> $DIR/ice-bad-err-span-in-template-129503.rs:12:10
+  --> $DIR/ice-bad-err-span-in-template-129503.rs:13:10
    |
 LL |     asm!(concat!(r#"lJ𐏿Æ�.𐏿�"#, "r} {}"));
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unmatched `}` in asm template string
    |
    = note: if you intended to print `}`, you can escape it using `}}`
 
+error: invalid asm template string: expected `}`, found `0`
+  --> $DIR/ice-bad-err-span-in-template-129503.rs:17:10
+   |
+LL |     asm!(concat!(r#"lJ𐏿Æ�.𐏿�"#, "{}/day{:02}.txt"));
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |          |
+   |          expected `}` in asm template string
+   |          because of this opening brace
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
 error: invalid asm template string: unmatched `}` found
-  --> $DIR/ice-bad-err-span-in-template-129503.rs:18:10
+  --> $DIR/ice-bad-err-span-in-template-129503.rs:23:10
    |
 LL |     asm!(concat!("abc", "r} {}"));
    |          ^^^^^^^^^^^^^^^^^^^^^^^ unmatched `}` in asm template string
@@ -15,12 +26,12 @@ LL |     asm!(concat!("abc", "r} {}"));
    = note: if you intended to print `}`, you can escape it using `}}`
 
 error: invalid asm template string: unmatched `}` found
-  --> $DIR/ice-bad-err-span-in-template-129503.rs:24:19
+  --> $DIR/ice-bad-err-span-in-template-129503.rs:29:19
    |
 LL |     asm!("abc", "r} {}");
    |                   ^ unmatched `}` in asm template string
    |
    = note: if you intended to print `}`, you can escape it using `}}`
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust#131292 which is exactly the same issue as rust-lang/rust#129503 but for [`err.secondary_label`](https://github.com/rust-lang/rust/blob/9f4b56a5aed81e8c36cc26b3c1b4666ead6b71fc/compiler/rustc_builtin_macros/src/asm.rs#L399-L401) instead of [`err.span`](https://github.com/rust-lang/rust/blob/9f4b56a5aed81e8c36cc26b3c1b4666ead6b71fc/compiler/rustc_builtin_macros/src/asm.rs#L385-L391). The latter issue was fixed in https://github.com/rust-lang/rust/pull/130917 so see that PR for context.

In addition to the above, the current PR also proactively fixes potential future issues of the same kind which would have occurred over [here ](https://github.com/rust-lang/rust/blob/9f4b56a5aed81e8c36cc26b3c1b4666ead6b71fc/compiler/rustc_builtin_macros/src/asm.rs#L478-L482)and [here](https://github.com/rust-lang/rust/blob/9f4b56a5aed81e8c36cc26b3c1b4666ead6b71fc/compiler/rustc_builtin_macros/src/asm.rs#L493-L497).

