### PR TITLE
Neon fast path for str::contains

### DIFF
--- a/library/core/src/str/pattern.rs
+++ b/library/core/src/str/pattern.rs
@@ -997,7 +997,8 @@ impl<'b> Pattern for &'b str {
 
                 #[cfg(any(
                     all(target_arch = "x86_64", target_feature = "sse2"),
-                    all(target_arch = "loongarch64", target_feature = "lsx")
+                    all(target_arch = "loongarch64", target_feature = "lsx"),
+                    all(target_arch = "aarch64", target_feature = "neon")
                 ))]
                 if self.len() <= 32 {
                     if let Some(result) = simd_contains(self, haystack) {
@@ -1782,7 +1783,8 @@ impl TwoWayStrategy for RejectAndMatch {
 /// [0]: http://0x80.pl/articles/simd-strfind.html#sse-avx2
 #[cfg(any(
     all(target_arch = "x86_64", target_feature = "sse2"),
-    all(target_arch = "loongarch64", target_feature = "lsx")
+    all(target_arch = "loongarch64", target_feature = "lsx"),
+    all(target_arch = "aarch64", target_feature = "neon")
 ))]
 #[inline]
 fn simd_contains(needle: &str, haystack: &str) -> Option<bool> {
@@ -1917,7 +1919,8 @@ fn simd_contains(needle: &str, haystack: &str) -> Option<bool> {
 /// Both slices must have the same length.
 #[cfg(any(
     all(target_arch = "x86_64", target_feature = "sse2"),
-    all(target_arch = "loongarch64", target_feature = "lsx")
+    all(target_arch = "loongarch64", target_feature = "lsx"),
+    all(target_arch = "aarch64", target_feature = "neon")
 ))]
 #[inline]
 unsafe fn small_slice_eq(x: &[u8], y: &[u8]) -> bool {


### PR DESCRIPTION
Using the SIMD friendly version of the function also gives a decent speed up with Neon.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
