### PR TITLE
update compiler stable backport zulip msg

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -795,7 +795,8 @@ zulip_stream = 474880 # #t-compiler/backports
 topic = "#{number}: stable-nominated"
 message_on_add = [
     """\
-@**channel** PR #{number} "{title}" has been nominated for stable backport.
+PR #{number} "{title}" fixes a regression and has been nominated for backport.
+{recipients}, what do you think about it?
 """,
     """\
 /poll Approve stable backport of #{number}?


### PR DESCRIPTION
I'd like to update the message when stable backports (for t-compiler) Zulip topics are opened.

Stable backports mention the channel i.e. also people who might not have context, example:
[#t-compiler/backports > #150590: stable-nominated @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/474880-t-compiler.2Fbackports/topic/.23150590.3A.20stable-nominated/near/569989784)

Beta backports mention author+reviewer (which fits better), example:
[#t-compiler/backports > #151896: beta-nominated @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/474880-t-compiler.2Fbackports/topic/.23151896.3A.20beta-nominated/near/571171604)

This patch makes the `stable` backport opening message just like the `beta` backport one.

Thanks 