### PR TITLE
Port rustc_abi to the attribute parser

### DIFF
--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -191,6 +191,7 @@ attribute_parsers!(
         Single<ProcMacroDeriveParser>,
         Single<RecursionLimitParser>,
         Single<ReexportTestHarnessMainParser>,
+        Single<RustcAbiParser>,
         Single<RustcAllocatorZeroedVariantParser>,
         Single<RustcBuiltinMacroParser>,
         Single<RustcForceInlineParser>,

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -167,6 +167,14 @@ pub enum CoverageAttrKind {
     Off,
 }
 
+/// Successfully-parsed value of a `#[rustc_abi(..)]` attribute.
+#[derive(Copy, Debug, Eq, PartialEq, Encodable, Decodable, Clone)]
+#[derive(HashStable_Generic, PrintAttribute)]
+pub enum RustcAbiAttrKind {
+    Debug,
+    AssertEq,
+}
+
 impl Deprecation {
     /// Whether an item marked with #[deprecated(since = "X")] is currently
     /// deprecated (i.e., whether X is not greater than the current rustc
@@ -1014,6 +1022,9 @@ pub enum AttributeKind {
 
     /// Represents [`#[repr]`](https://doc.rust-lang.org/stable/reference/type-layout.html#representations).
     Repr { reprs: ThinVec<(ReprAttr, Span)>, first_span: Span },
+
+    /// Represents `#[rustc_abi(..)]`
+    RustcAbi { attr_span: Span, kind: RustcAbiAttrKind },
 
     /// Represents `#[rustc_allocator]`
     RustcAllocator,

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -89,6 +89,7 @@ impl AttributeKind {
             RecursionLimit { .. } => No,
             ReexportTestHarnessMain(..) => No,
             Repr { .. } => No,
+            RustcAbi { .. } => No,
             RustcAllocator => No,
             RustcAllocatorZeroed => No,
             RustcAllocatorZeroedVariant { .. } => Yes,

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -287,6 +287,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     | AttributeKind::ReexportTestHarnessMain(..)
                     // handled below this loop and elsewhere
                     | AttributeKind::Repr { .. }
+                    | AttributeKind::RustcAbi { .. }
                     | AttributeKind::RustcAllocator
                     | AttributeKind::RustcAllocatorZeroed
                     | AttributeKind::RustcAllocatorZeroedVariant { .. }
@@ -392,7 +393,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                             | sym::rustc_conversion_suggestion
                             | sym::rustc_deprecated_safe_2024
                             | sym::rustc_test_marker
-                            | sym::rustc_abi
                             | sym::rustc_layout
                             | sym::rustc_proc_macro_decls
                             | sym::rustc_never_type_options

--- a/tests/ui/abi/debug.generic.stderr
+++ b/tests/ui/abi/debug.generic.stderr
@@ -1,3 +1,36 @@
+error: `#[rustc_abi]` attribute cannot be used on constants
+  --> $DIR/debug.rs:42:1
+   |
+LL | #[rustc_abi(debug)]
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_abi]` can be applied to functions and type aliases
+
+error: `#[rustc_abi]` attribute cannot be used on associated consts
+  --> $DIR/debug.rs:46:5
+   |
+LL |     #[rustc_abi(debug)]
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_abi]` can be applied to functions and type aliases
+
+error[E0539]: malformed `rustc_abi` attribute input
+  --> $DIR/debug.rs:74:1
+   |
+LL | #[rustc_abi("assert_eq")]
+   | ^^^^^^^^^^^-------------^
+   |            |
+   |            valid arguments are `assert_eq` or `debug`
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[rustc_abi("assert_eq")]
+LL + #[rustc_abi(assert_eq)]
+   |
+LL - #[rustc_abi("assert_eq")]
+LL + #[rustc_abi(debug)]
+   |
+
 error: fn_abi_of(test) = FnAbi {
            args: [
                ArgAbi {
@@ -884,12 +917,6 @@ LL | type TestAbiEqNonsense = (fn((str, str)), fn((str, str)));
    = help: the trait `Sized` is not implemented for `str`
    = note: only the last element of a tuple may have a dynamically sized type
 
-error: unrecognized argument
-  --> $DIR/debug.rs:74:13
-   |
-LL | #[rustc_abi("assert_eq")]
-   |             ^^^^^^^^^^^
-
 error: `#[rustc_abi]` can only be applied to function items, type aliases, and associated functions
   --> $DIR/debug.rs:47:5
    |
@@ -986,6 +1013,7 @@ error: fn_abi_of(assoc_test) = FnAbi {
 LL |     fn assoc_test(&self) {}
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 12 previous errors
+error: aborting due to 14 previous errors
 
-For more information about this error, try `rustc --explain E0277`.
+Some errors have detailed explanations: E0277, E0539.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/abi/debug.loongarch64.stderr
+++ b/tests/ui/abi/debug.loongarch64.stderr
@@ -1,3 +1,36 @@
+error: `#[rustc_abi]` attribute cannot be used on constants
+  --> $DIR/debug.rs:42:1
+   |
+LL | #[rustc_abi(debug)]
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_abi]` can be applied to functions and type aliases
+
+error: `#[rustc_abi]` attribute cannot be used on associated consts
+  --> $DIR/debug.rs:46:5
+   |
+LL |     #[rustc_abi(debug)]
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_abi]` can be applied to functions and type aliases
+
+error[E0539]: malformed `rustc_abi` attribute input
+  --> $DIR/debug.rs:74:1
+   |
+LL | #[rustc_abi("assert_eq")]
+   | ^^^^^^^^^^^-------------^
+   |            |
+   |            valid arguments are `assert_eq` or `debug`
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[rustc_abi("assert_eq")]
+LL + #[rustc_abi(assert_eq)]
+   |
+LL - #[rustc_abi("assert_eq")]
+LL + #[rustc_abi(debug)]
+   |
+
 error: fn_abi_of(test) = FnAbi {
            args: [
                ArgAbi {
@@ -884,12 +917,6 @@ LL | type TestAbiEqNonsense = (fn((str, str)), fn((str, str)));
    = help: the trait `Sized` is not implemented for `str`
    = note: only the last element of a tuple may have a dynamically sized type
 
-error: unrecognized argument
-  --> $DIR/debug.rs:74:13
-   |
-LL | #[rustc_abi("assert_eq")]
-   |             ^^^^^^^^^^^
-
 error: `#[rustc_abi]` can only be applied to function items, type aliases, and associated functions
   --> $DIR/debug.rs:47:5
    |
@@ -986,6 +1013,7 @@ error: fn_abi_of(assoc_test) = FnAbi {
 LL |     fn assoc_test(&self) {}
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 12 previous errors
+error: aborting due to 14 previous errors
 
-For more information about this error, try `rustc --explain E0277`.
+Some errors have detailed explanations: E0277, E0539.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/abi/debug.riscv64.stderr
+++ b/tests/ui/abi/debug.riscv64.stderr
@@ -1,3 +1,36 @@
+error: `#[rustc_abi]` attribute cannot be used on constants
+  --> $DIR/debug.rs:42:1
+   |
+LL | #[rustc_abi(debug)]
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_abi]` can be applied to functions and type aliases
+
+error: `#[rustc_abi]` attribute cannot be used on associated consts
+  --> $DIR/debug.rs:46:5
+   |
+LL |     #[rustc_abi(debug)]
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_abi]` can be applied to functions and type aliases
+
+error[E0539]: malformed `rustc_abi` attribute input
+  --> $DIR/debug.rs:74:1
+   |
+LL | #[rustc_abi("assert_eq")]
+   | ^^^^^^^^^^^-------------^
+   |            |
+   |            valid arguments are `assert_eq` or `debug`
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[rustc_abi("assert_eq")]
+LL + #[rustc_abi(assert_eq)]
+   |
+LL - #[rustc_abi("assert_eq")]
+LL + #[rustc_abi(debug)]
+   |
+
 error: fn_abi_of(test) = FnAbi {
            args: [
                ArgAbi {
@@ -884,12 +917,6 @@ LL | type TestAbiEqNonsense = (fn((str, str)), fn((str, str)));
    = help: the trait `Sized` is not implemented for `str`
    = note: only the last element of a tuple may have a dynamically sized type
 
-error: unrecognized argument
-  --> $DIR/debug.rs:74:13
-   |
-LL | #[rustc_abi("assert_eq")]
-   |             ^^^^^^^^^^^
-
 error: `#[rustc_abi]` can only be applied to function items, type aliases, and associated functions
   --> $DIR/debug.rs:47:5
    |
@@ -986,6 +1013,7 @@ error: fn_abi_of(assoc_test) = FnAbi {
 LL |     fn assoc_test(&self) {}
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 12 previous errors
+error: aborting due to 14 previous errors
 
-For more information about this error, try `rustc --explain E0277`.
+Some errors have detailed explanations: E0277, E0539.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/abi/debug.rs
+++ b/tests/ui/abi/debug.rs
@@ -39,12 +39,12 @@ type TestFnPtr = fn(bool) -> u8; //~ ERROR: fn_abi
 #[rustc_abi(debug)]
 fn test_generic<T>(_x: *const T) {} //~ ERROR: fn_abi
 
-#[rustc_abi(debug)]
-const C: () = (); //~ ERROR: can only be applied to
+#[rustc_abi(debug)] //~ ERROR: `#[rustc_abi]` attribute cannot be used on constants
+const C: () = (); //~ ERROR: `#[rustc_abi]` can only be applied to
 
 impl S {
-    #[rustc_abi(debug)]
-    const C: () = (); //~ ERROR: can only be applied to
+    #[rustc_abi(debug)] //~ ERROR: `#[rustc_abi]` attribute cannot be used on assoc
+    const C: () = (); //~ ERROR: `#[rustc_abi]` can only be applied to
 }
 
 impl S {
@@ -71,5 +71,5 @@ type TestAbiNeSign = (fn(i32), fn(u32)); //~ ERROR: ABIs are not compatible
 #[rustc_abi(assert_eq)]
 type TestAbiEqNonsense = (fn((str, str)), fn((str, str))); //~ ERROR: cannot be known at compilation time
 
-#[rustc_abi("assert_eq")] //~ ERROR unrecognized argument
+#[rustc_abi("assert_eq")] //~ ERROR malformed `rustc_abi` attribute input
 type Bad = u32;


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/131229

This attribute either dumps the abi info for functions (debug arg)
or if you put it on a pair of fn ptr's it checks they match (assert_eq arg)

r? @JonathanBrouwer 
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
