### PR TITLE
fix(macros): allow custom attributes on exported macros

### DIFF
--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1230,10 +1230,14 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             }
         }
 
+        // Only report when the `macro_export` was produced by another macro (e.g. macro_rules!
+        // expanding to a macro_rules!), not when it merely has attributes (AstPass/Desugaring)
+        // or inert attribute processing (MacroKind::Attr).
         if shadowing == Shadowing::Unrestricted
             && binding.expansion != LocalExpnId::ROOT
             && let DeclKind::Import { import, .. } = binding.kind
             && matches!(import.kind, ImportKind::MacroExport)
+            && matches!(binding.expansion.expn_data().kind, ExpnKind::Macro(MacroKind::Bang, _))
         {
             self.macro_expanded_macro_export_errors.insert((path_span, binding.span));
         }

--- a/tests/ui/macros/attributes-issue-98291.rs
+++ b/tests/ui/macros/attributes-issue-98291.rs
@@ -1,0 +1,27 @@
+//! Regression test for #98291: attribute on macro_export + re-export should compile.
+//! See also issue #150518 for a similar case.
+
+//@ check-pass
+
+#[rustfmt::skip]
+#[macro_export]
+macro_rules! _a {
+    () => { "Hello world" };
+}
+
+pub use _a as a;
+
+#[macro_export]
+#[rust_analyzer::macro_style(braces)]
+macro_rules! match_ast {
+    (match $node:ident {}) => { $crate::match_ast!(match ($node) {}) };
+    (match ($node:expr) {}) => {};
+}
+
+fn main() {
+    println!(a!());
+
+    match_ast! {
+        match foo {}
+    }
+}


### PR DESCRIPTION
fixes rust-lang/rust#98291
