### PR TITLE
bootstrap: Remove `ShouldRun::paths`

### DIFF
--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -706,7 +706,7 @@ macro_rules! tool_check_step {
             const IS_HOST: bool = true;
 
             fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-                run.paths(&[ $path, $( $alt_path ),* ])
+                run.path($path) $( .path( $alt_path ) )*
             }
 
             fn is_default_step(_builder: &Builder<'_>) -> bool {

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -3155,7 +3155,7 @@ impl Step for CrateRustdoc {
     const IS_HOST: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        run.paths(&["src/librustdoc", "src/tools/rustdoc"])
+        run.path("src/librustdoc").path("src/tools/rustdoc")
     }
 
     fn is_default_step(_builder: &Builder<'_>) -> bool {

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -3816,7 +3816,7 @@ impl Step for CodegenCranelift {
     const IS_HOST: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        run.paths(&["compiler/rustc_codegen_cranelift"])
+        run.path("compiler/rustc_codegen_cranelift")
     }
 
     fn is_default_step(_builder: &Builder<'_>) -> bool {
@@ -3937,7 +3937,7 @@ impl Step for CodegenGCC {
     const IS_HOST: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        run.paths(&["compiler/rustc_codegen_gcc"])
+        run.path("compiler/rustc_codegen_gcc")
     }
 
     fn is_default_step(_builder: &Builder<'_>) -> bool {

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_bench.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_bench.snap
@@ -98,4 +98,5 @@ expression: bench
     - Set({bench::compiler/rustc_windows_rc})
 [Bench] test::CrateRustdoc
     targets: [x86_64-unknown-linux-gnu]
-    - Set({bench::src/librustdoc, bench::src/tools/rustdoc})
+    - Set({bench::src/librustdoc})
+    - Set({bench::src/tools/rustdoc})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_check.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_check.snap
@@ -82,7 +82,8 @@ expression: check
     - Set({check::compiler/rustc_windows_rc})
 [Check] check::Rustdoc
     targets: [x86_64-unknown-linux-gnu]
-    - Set({check::src/librustdoc, check::src/tools/rustdoc})
+    - Set({check::src/librustdoc})
+    - Set({check::src/tools/rustdoc})
 [Check] check::CraneliftCodegenBackend
     targets: [x86_64-unknown-linux-gnu]
     - Set({check::cg_clif})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_check_compiletest_include_default_paths.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_check_compiletest_include_default_paths.snap
@@ -82,7 +82,8 @@ expression: check compiletest --include-default-paths
     - Set({check::compiler/rustc_windows_rc})
 [Check] check::Rustdoc
     targets: [x86_64-unknown-linux-gnu]
-    - Set({check::src/librustdoc, check::src/tools/rustdoc})
+    - Set({check::src/librustdoc})
+    - Set({check::src/tools/rustdoc})
 [Check] check::CraneliftCodegenBackend
     targets: [x86_64-unknown-linux-gnu]
     - Set({check::cg_clif})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_fix.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_fix.snap
@@ -82,7 +82,8 @@ expression: fix
     - Set({fix::compiler/rustc_windows_rc})
 [Fix] check::Rustdoc
     targets: [x86_64-unknown-linux-gnu]
-    - Set({fix::src/librustdoc, fix::src/tools/rustdoc})
+    - Set({fix::src/librustdoc})
+    - Set({fix::src/tools/rustdoc})
 [Fix] check::CraneliftCodegenBackend
     targets: [x86_64-unknown-linux-gnu]
     - Set({fix::cg_clif})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test.snap
@@ -148,7 +148,8 @@ expression: test
     - Set({test::compiler/rustc_windows_rc})
 [Test] test::CrateRustdoc
     targets: [x86_64-unknown-linux-gnu]
-    - Set({test::src/librustdoc, test::src/tools/rustdoc})
+    - Set({test::src/librustdoc})
+    - Set({test::src/tools/rustdoc})
 [Test] test::CrateRustdocJsonTypes
     targets: [x86_64-unknown-linux-gnu]
     - Set({test::src/rustdoc-json-types})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_librustdoc_rustdoc.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_librustdoc_rustdoc.snap
@@ -4,7 +4,8 @@ expression: test librustdoc rustdoc
 ---
 [Test] test::CrateRustdoc
     targets: [x86_64-unknown-linux-gnu]
-    - Set({test::src/librustdoc, test::src/tools/rustdoc})
+    - Set({test::src/librustdoc})
+    - Set({test::src/tools/rustdoc})
 [Test] test::RustdocBook
     targets: [x86_64-unknown-linux-gnu]
     - Set({test::src/doc/rustdoc})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage.snap
@@ -147,7 +147,8 @@ expression: test --skip=coverage
     - Set({test::compiler/rustc_windows_rc})
 [Test] test::CrateRustdoc
     targets: [x86_64-unknown-linux-gnu]
-    - Set({test::src/librustdoc, test::src/tools/rustdoc})
+    - Set({test::src/librustdoc})
+    - Set({test::src/tools/rustdoc})
 [Test] test::CrateRustdocJsonTypes
     targets: [x86_64-unknown-linux-gnu]
     - Set({test::src/rustdoc-json-types})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests.snap
@@ -112,7 +112,8 @@ expression: test --skip=tests
     - Set({test::compiler/rustc_windows_rc})
 [Test] test::CrateRustdoc
     targets: [x86_64-unknown-linux-gnu]
-    - Set({test::src/librustdoc, test::src/tools/rustdoc})
+    - Set({test::src/librustdoc})
+    - Set({test::src/tools/rustdoc})
 [Test] test::CrateRustdocJsonTypes
     targets: [x86_64-unknown-linux-gnu]
     - Set({test::src/rustdoc-json-types})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests_etc.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests_etc.snap
@@ -92,7 +92,8 @@ expression: test --skip=tests --skip=coverage-map --skip=coverage-run --skip=lib
     - Set({test::compiler/rustc_windows_rc})
 [Test] test::CrateRustdoc
     targets: [x86_64-unknown-linux-gnu]
-    - Set({test::src/librustdoc, test::src/tools/rustdoc})
+    - Set({test::src/librustdoc})
+    - Set({test::src/tools/rustdoc})
 [Test] test::CrateRustdocJsonTypes
     targets: [x86_64-unknown-linux-gnu]
     - Set({test::src/rustdoc-json-types})

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -558,38 +558,19 @@ impl<'a> ShouldRun<'a> {
     /// single, non-aliased path
     ///
     /// Must be an on-disk path; use `alias` for names that do not correspond to on-disk paths.
-    pub fn path(self, path: &str) -> Self {
-        self.paths(&[path])
-    }
-
-    /// Multiple aliases for the same job.
-    ///
-    /// This differs from [`path`] in that multiple calls to path will end up calling `make_run`
-    /// multiple times, whereas a single call to `paths` will only ever generate a single call to
-    /// `make_run`.
-    ///
-    /// This is analogous to `all_krates`, although `all_krates` is gone now. Prefer [`path`] where possible.
-    ///
-    /// [`path`]: ShouldRun::path
-    pub fn paths(mut self, paths: &[&str]) -> Self {
+    pub fn path(mut self, path: &str) -> Self {
         let submodules_paths = self.builder.submodule_paths();
 
-        self.paths.insert(PathSet::Set(
-            paths
-                .iter()
-                .map(|p| {
-                    // assert only if `p` isn't submodule
-                    if !submodules_paths.iter().any(|sm_p| p.contains(sm_p)) {
-                        assert!(
-                            self.builder.src.join(p).exists(),
-                            "`should_run.paths` should correspond to real on-disk paths - use `alias` if there is no relevant path: {p}"
-                        );
-                    }
+        // assert only if `p` isn't submodule
+        if !submodules_paths.iter().any(|sm_p| path.contains(sm_p)) {
+            assert!(
+                self.builder.src.join(path).exists(),
+                "`should_run.path` should correspond to a real on-disk path - use `alias` if there is no relevant path: {path}"
+            );
+        }
 
-                    TaskPath { path: p.into(), kind: Some(self.kind) }
-                })
-                .collect(),
-        ));
+        let task = TaskPath { path: path.into(), kind: Some(self.kind) };
+        self.paths.insert(PathSet::Set(BTreeSet::from_iter([task])));
         self
     }
 


### PR DESCRIPTION
Split out from https://github.com/rust-lang/rust/pull/151930. I've copied my comment in https://github.com/rust-lang/rust/pull/151930#discussion_r2750409129 into the commit description.

r? @Zalathar cc @Mark-Simulacrum @Kobzol 

---

Some history about `paths()`. The original intent @Mark-Simulacrum had
when he introduced PathSet in https://github.com/rust-lang/rust/commit/f104b120595d21e8aef311bc0057b3f854cddfc0, to my knowledge, was that multiple paths
could be aliases for the same step. That's what rustdoc is doing; both
paths for rustdoc run exactly the same Step, regardless of whether one
or both are present.

That never really caught on. To my knowledge, rustdoc is the only usage
of paths() there's ever been.

Later, in rust-lang/rust#95503, I repurposed PathSet to mean "each crate in this set
should be passed to Step::make_run in RunConfig". That was not the
previous meaning.

Rustdoc never looks at run.paths in make_run, so it's safe to just treat
it as an alias, like elsewhere in bootstrap. Same for all the other tool
steps.



<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
