### PR TITLE
chore: clearify tidy's error message

### DIFF
--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -302,7 +302,7 @@ fn deny_new_nondescriptive_test_names(
             && !stripped_path.starts_with("ui/issues/")
         {
             check.error(format!(
-                "file `tests/{stripped_path}` must begin with a descriptive name, consider `{{reason}}-issue-{issue_n}.rs`",
+                "the name of the file `tests/{stripped_path}` must begin with a descriptive prefix, consider `{{reason}}-issue-{issue_n}.rs`",
                 issue_n = &test_name[1],
             ));
         }

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -302,7 +302,7 @@ fn deny_new_nondescriptive_test_names(
             && !stripped_path.starts_with("ui/issues/")
         {
             check.error(format!(
-                "the name of the file `tests/{stripped_path}` must begin with a descriptive prefix, consider `{{reason}}-issue-{issue_n}.rs`",
+                "the name of the file `tests/{stripped_path}` is not descriptive, consider renaming to `{{reason}}-issue-{issue_n}.rs`",
                 issue_n = &test_name[1],
             ));
         }

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -302,7 +302,7 @@ fn deny_new_nondescriptive_test_names(
             && !stripped_path.starts_with("ui/issues/")
         {
             check.error(format!(
-                "the name of the file `tests/{stripped_path}` is not descriptive, consider renaming to `{{reason}}-issue-{issue_n}.rs`",
+                "issue-number-only test names are not descriptive, consider renaming file `tests/{stripped_path}` to `{{reason}}-issue-{issue_n}.rs`",
                 issue_n = &test_name[1],
             ));
         }


### PR DESCRIPTION
it took me a while to realize this error was due to the name of the file, not the file's content