### PR TITLE
Gate #![reexport_test_harness_main] properly

### DIFF
--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -473,11 +473,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         ),
         FutureWarnFollowing, EncodeCrossCrate::No,
     ),
-    // FIXME(Centril): This can be used on stable but shouldn't.
-    ungated!(
-        reexport_test_harness_main, CrateLevel, template!(NameValueStr: "name"), ErrorFollowing,
-        EncodeCrossCrate::No,
-    ),
 
     // Macros:
     ungated!(
@@ -831,6 +826,13 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         EncodeCrossCrate::Yes, custom_test_frameworks,
         "custom test frameworks are an unstable feature",
     ),
+
+    gated!(
+        reexport_test_harness_main, CrateLevel, template!(NameValueStr: "name"), ErrorFollowing,
+        EncodeCrossCrate::No, custom_test_frameworks,
+        "custom test frameworks are an unstable feature",
+    ),
+
     // RFC #1268
     gated!(
         marker, Normal, template!(Word), WarnFollowing, EncodeCrossCrate::No,

--- a/src/tools/rust-analyzer/crates/hir-expand/src/inert_attr_macro.rs
+++ b/src/tools/rust-analyzer/crates/hir-expand/src/inert_attr_macro.rs
@@ -124,8 +124,6 @@ pub const INERT_ATTRIBUTES: &[BuiltinAttribute] = &[
         should_panic, Normal,
         template!(Word, List: r#"expected = "reason""#, NameValueStr: "reason"), FutureWarnFollowing,
     ),
-    // FIXME(Centril): This can be used on stable but shouldn't.
-    ungated!(reexport_test_harness_main, CrateLevel, template!(NameValueStr: "name"), ErrorFollowing),
 
     // Macros:
     ungated!(automatically_derived, Normal, template!(Word), WarnFollowing),
@@ -264,6 +262,13 @@ pub const INERT_ATTRIBUTES: &[BuiltinAttribute] = &[
         test_runner, CrateLevel, template!(List: "path"), ErrorFollowing, custom_test_frameworks,
         "custom test frameworks are an unstable feature",
     ),
+
+    gated!(
+        reexport_test_harness_main, CrateLevel, template!(NameValueStr: "name"),
+        ErrorFollowing, custom_test_frameworks,
+        "custom test frameworks are an unstable feature",
+    ),
+
     // RFC #1268
     gated!(
         marker, Normal, template!(Word), WarnFollowing, @only_local: true,

--- a/tests/ui/attributes/reexport-test-harness-entry-point.rs
+++ b/tests/ui/attributes/reexport-test-harness-entry-point.rs
@@ -4,6 +4,7 @@
 //@ run-pass
 //@ compile-flags:--test
 
+#![feature(custom_test_frameworks)]
 #![reexport_test_harness_main = "test_main"]
 
 #[cfg(test)]

--- a/tests/ui/feature-gates/feature-gate-custom_test_frameworks.rs
+++ b/tests/ui/feature-gates/feature-gate-custom_test_frameworks.rs
@@ -1,5 +1,5 @@
 #![test_runner(main)] //~ ERROR custom test frameworks are an unstable feature
-
+#![reexport_test_harness_main = "foo"] //~ ERROR custom test frameworks are an unstable feature
 #[test_case] //~ ERROR custom test frameworks are an unstable feature
 fn f() {}
 

--- a/tests/ui/feature-gates/feature-gate-custom_test_frameworks.stderr
+++ b/tests/ui/feature-gates/feature-gate-custom_test_frameworks.stderr
@@ -18,6 +18,16 @@ LL | #![test_runner(main)]
    = help: add `#![feature(custom_test_frameworks)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 2 previous errors
+error[E0658]: custom test frameworks are an unstable feature
+  --> $DIR/feature-gate-custom_test_frameworks.rs:2:1
+   |
+LL | #![reexport_test_harness_main = "foo"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #50297 <https://github.com/rust-lang/rust/issues/50297> for more information
+   = help: add `#![feature(custom_test_frameworks)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.rs
@@ -55,7 +55,6 @@
 //~| HELP can only be applied to
 //~| HELP remove the attribute
 #![no_implicit_prelude]
-#![reexport_test_harness_main = "2900"]
 // see gated-link-args.rs
 // see issue-43106-gating-of-macro_escape.rs for crate-level; but non crate-level is below at "2700"
 // (cannot easily test gating of crate-level #[no_std]; but non crate-level is below at "2600")
@@ -463,30 +462,6 @@ mod no_implicit_prelude {
 //~| WARN previously accepted
     //~| HELP can be applied to
     //~| HELP remove the attribute
-}
-
-#[reexport_test_harness_main = "2900"]
-//~^ WARN crate-level attribute should be
-mod reexport_test_harness_main {
-//~^ NOTE this attribute does not have an `!`, which means it is applied to this module
-    mod inner { #![reexport_test_harness_main="2900"] }
-    //~^ WARN the `#![reexport_test_harness_main]` attribute can only be used at the crate root
-
-    #[reexport_test_harness_main = "2900"] fn f() { }
-    //~^ WARN crate-level attribute should be
-    //~| NOTE this attribute does not have an `!`, which means it is applied to this function
-
-    #[reexport_test_harness_main = "2900"] struct S;
-    //~^ WARN crate-level attribute should be
-    //~| NOTE this attribute does not have an `!`, which means it is applied to this struct
-
-    #[reexport_test_harness_main = "2900"] type T = S;
-    //~^ WARN crate-level attribute should be
-    //~| NOTE this attribute does not have an `!`, which means it is applied to this type alias
-
-    #[reexport_test_harness_main = "2900"] impl S { }
-    //~^ WARN crate-level attribute should be
-    //~| NOTE this attribute does not have an `!`, which means it is applied to this implementation block
 }
 
 // Cannot feed "2700" to `#[macro_escape]` without signaling an error.

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
@@ -1,5 +1,5 @@
 warning: `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:496:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:471:17
    |
 LL |     mod inner { #![macro_escape] }
    |                 ^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |     mod inner { #![macro_escape] }
    = help: try an outer attribute: `#[macro_use]`
 
 warning: `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:493:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:468:1
    |
 LL | #[macro_escape]
    | ^^^^^^^^^^^^^^^
@@ -43,151 +43,151 @@ LL | #![deny(x5100)]
    |         ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:110:8
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:109:8
    |
 LL | #[warn(x5400)]
    |        ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:113:25
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:112:25
    |
 LL |     mod inner { #![warn(x5400)] }
    |                         ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:116:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:115:12
    |
 LL |     #[warn(x5400)] fn f() { }
    |            ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:119:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:118:12
    |
 LL |     #[warn(x5400)] struct S;
    |            ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:122:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:121:12
    |
 LL |     #[warn(x5400)] type T = S;
    |            ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:125:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:124:12
    |
 LL |     #[warn(x5400)] impl S { }
    |            ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:129:9
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:128:9
    |
 LL | #[allow(x5300)]
    |         ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:132:26
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:131:26
    |
 LL |     mod inner { #![allow(x5300)] }
    |                          ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:135:13
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:134:13
    |
 LL |     #[allow(x5300)] fn f() { }
    |             ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:138:13
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:137:13
    |
 LL |     #[allow(x5300)] struct S;
    |             ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:141:13
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:140:13
    |
 LL |     #[allow(x5300)] type T = S;
    |             ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:144:13
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:143:13
    |
 LL |     #[allow(x5300)] impl S { }
    |             ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:148:10
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:147:10
    |
 LL | #[forbid(x5200)]
    |          ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:151:27
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:150:27
    |
 LL |     mod inner { #![forbid(x5200)] }
    |                           ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:154:14
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:153:14
    |
 LL |     #[forbid(x5200)] fn f() { }
    |              ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:157:14
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:156:14
    |
 LL |     #[forbid(x5200)] struct S;
    |              ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:160:14
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:159:14
    |
 LL |     #[forbid(x5200)] type T = S;
    |              ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:163:14
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:162:14
    |
 LL |     #[forbid(x5200)] impl S { }
    |              ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:167:8
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:166:8
    |
 LL | #[deny(x5100)]
    |        ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:170:25
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:169:25
    |
 LL |     mod inner { #![deny(x5100)] }
    |                         ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:173:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:172:12
    |
 LL |     #[deny(x5100)] fn f() { }
    |            ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:176:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:175:12
    |
 LL |     #[deny(x5100)] struct S;
    |            ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:179:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:178:12
    |
 LL |     #[deny(x5100)] type T = S;
    |            ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:182:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:181:12
    |
 LL |     #[deny(x5100)] impl S { }
    |            ^^^^^
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:710:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:685:1
    |
 LL |   #[link(name = "x")]
    |   ^^^^^^^^^^^^^^^^^^^
@@ -208,7 +208,7 @@ LL | #![warn(unused_attributes, unknown_lints)]
    |         ^^^^^^^^^^^^^^^^^
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:71:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:70:1
    |
 LL | #![link(name = "x")]
    | ^^^^^^^^^^^^^^^^^^^^ not an `extern` block
@@ -216,7 +216,7 @@ LL | #![link(name = "x")]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: the feature `rust1` has been stable since 1.0.0 and no longer requires an attribute to enable
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:99:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:98:12
    |
 LL | #![feature(rust1)]
    |            ^^^^^
@@ -224,7 +224,7 @@ LL | #![feature(rust1)]
    = note: `#[warn(stable_features)]` on by default
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:716:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:691:17
    |
 LL |     mod inner { #![link(name = "x")] }
    |     ------------^^^^^^^^^^^^^^^^^^^^-- not an `extern` block
@@ -232,7 +232,7 @@ LL |     mod inner { #![link(name = "x")] }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:721:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:696:5
    |
 LL |     #[link(name = "x")] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^ ---------- not an `extern` block
@@ -240,7 +240,7 @@ LL |     #[link(name = "x")] fn f() { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:726:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:701:5
    |
 LL |     #[link(name = "x")] struct S;
    |     ^^^^^^^^^^^^^^^^^^^ --------- not an `extern` block
@@ -248,7 +248,7 @@ LL |     #[link(name = "x")] struct S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:731:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:706:5
    |
 LL |     #[link(name = "x")] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^ ----------- not an `extern` block
@@ -256,7 +256,7 @@ LL |     #[link(name = "x")] type T = S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:736:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:711:5
    |
 LL |     #[link(name = "x")] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^ ---------- not an `extern` block
@@ -264,7 +264,7 @@ LL |     #[link(name = "x")] impl S { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:741:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:716:5
    |
 LL |     #[link(name = "x")] extern "Rust" {}
    |     ^^^^^^^^^^^^^^^^^^^
@@ -272,7 +272,7 @@ LL |     #[link(name = "x")] extern "Rust" {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[macro_use]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:190:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:189:5
    |
 LL |     #[macro_use] fn f() { }
    |     ^^^^^^^^^^^^
@@ -281,7 +281,7 @@ LL |     #[macro_use] fn f() { }
    = help: `#[macro_use]` can be applied to crates, extern crates, and modules
 
 warning: `#[macro_use]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:196:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:195:5
    |
 LL |     #[macro_use] struct S;
    |     ^^^^^^^^^^^^
@@ -290,7 +290,7 @@ LL |     #[macro_use] struct S;
    = help: `#[macro_use]` can be applied to crates, extern crates, and modules
 
 warning: `#[macro_use]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:202:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:201:5
    |
 LL |     #[macro_use] type T = S;
    |     ^^^^^^^^^^^^
@@ -299,7 +299,7 @@ LL |     #[macro_use] type T = S;
    = help: `#[macro_use]` can be applied to crates, extern crates, and modules
 
 warning: `#[macro_use]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:208:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:207:5
    |
 LL |     #[macro_use] impl S { }
    |     ^^^^^^^^^^^^
@@ -308,7 +308,7 @@ LL |     #[macro_use] impl S { }
    = help: `#[macro_use]` can be applied to crates, extern crates, and modules
 
 warning: `#[macro_export]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:215:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:214:1
    |
 LL | #[macro_export]
    | ^^^^^^^^^^^^^^^
@@ -317,7 +317,7 @@ LL | #[macro_export]
    = help: `#[macro_export]` can only be applied to macro defs
 
 warning: `#[macro_export]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:221:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:220:17
    |
 LL |     mod inner { #![macro_export] }
    |                 ^^^^^^^^^^^^^^^^
@@ -326,7 +326,7 @@ LL |     mod inner { #![macro_export] }
    = help: `#[macro_export]` can only be applied to macro defs
 
 warning: `#[macro_export]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:227:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:226:5
    |
 LL |     #[macro_export] fn f() { }
    |     ^^^^^^^^^^^^^^^
@@ -335,7 +335,7 @@ LL |     #[macro_export] fn f() { }
    = help: `#[macro_export]` can only be applied to macro defs
 
 warning: `#[macro_export]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:233:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:232:5
    |
 LL |     #[macro_export] struct S;
    |     ^^^^^^^^^^^^^^^
@@ -344,7 +344,7 @@ LL |     #[macro_export] struct S;
    = help: `#[macro_export]` can only be applied to macro defs
 
 warning: `#[macro_export]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:239:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:238:5
    |
 LL |     #[macro_export] type T = S;
    |     ^^^^^^^^^^^^^^^
@@ -353,7 +353,7 @@ LL |     #[macro_export] type T = S;
    = help: `#[macro_export]` can only be applied to macro defs
 
 warning: `#[macro_export]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:245:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:244:5
    |
 LL |     #[macro_export] impl S { }
    |     ^^^^^^^^^^^^^^^
@@ -362,7 +362,7 @@ LL |     #[macro_export] impl S { }
    = help: `#[macro_export]` can only be applied to macro defs
 
 warning: `#[path]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:256:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:255:5
    |
 LL |     #[path = "3800"] fn f() { }
    |     ^^^^^^^^^^^^^^^^
@@ -371,7 +371,7 @@ LL |     #[path = "3800"] fn f() { }
    = help: `#[path]` can only be applied to modules
 
 warning: `#[path]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:262:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:261:5
    |
 LL |     #[path = "3800"]  struct S;
    |     ^^^^^^^^^^^^^^^^
@@ -380,7 +380,7 @@ LL |     #[path = "3800"]  struct S;
    = help: `#[path]` can only be applied to modules
 
 warning: `#[path]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:268:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:267:5
    |
 LL |     #[path = "3800"] type T = S;
    |     ^^^^^^^^^^^^^^^^
@@ -389,7 +389,7 @@ LL |     #[path = "3800"] type T = S;
    = help: `#[path]` can only be applied to modules
 
 warning: `#[path]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:274:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:273:5
    |
 LL |     #[path = "3800"] impl S { }
    |     ^^^^^^^^^^^^^^^^
@@ -398,7 +398,7 @@ LL |     #[path = "3800"] impl S { }
    = help: `#[path]` can only be applied to modules
 
 warning: `#[automatically_derived]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:281:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:280:1
    |
 LL | #[automatically_derived]
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -407,7 +407,7 @@ LL | #[automatically_derived]
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
 
 warning: `#[automatically_derived]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:287:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:286:17
    |
 LL |     mod inner { #![automatically_derived] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -416,7 +416,7 @@ LL |     mod inner { #![automatically_derived] }
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
 
 warning: `#[automatically_derived]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:293:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:292:5
    |
 LL |     #[automatically_derived] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -425,7 +425,7 @@ LL |     #[automatically_derived] fn f() { }
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
 
 warning: `#[automatically_derived]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:299:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:298:5
    |
 LL |     #[automatically_derived] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -434,7 +434,7 @@ LL |     #[automatically_derived] struct S;
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
 
 warning: `#[automatically_derived]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:305:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:304:5
    |
 LL |     #[automatically_derived] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -443,7 +443,7 @@ LL |     #[automatically_derived] type T = S;
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
 
 warning: `#[automatically_derived]` attribute cannot be used on traits
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:311:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:310:5
    |
 LL |     #[automatically_derived] trait W { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -452,7 +452,7 @@ LL |     #[automatically_derived] trait W { }
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
 
 warning: `#[automatically_derived]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:317:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:316:5
    |
 LL |     #[automatically_derived] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -461,7 +461,7 @@ LL |     #[automatically_derived] impl S { }
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
 
 warning: `#[no_mangle]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:326:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:325:1
    |
 LL | #[no_mangle]
    | ^^^^^^^^^^^^
@@ -470,7 +470,7 @@ LL | #[no_mangle]
    = help: `#[no_mangle]` can be applied to functions and statics
 
 warning: `#[no_mangle]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:332:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:331:17
    |
 LL |     mod inner { #![no_mangle] }
    |                 ^^^^^^^^^^^^^
@@ -479,7 +479,7 @@ LL |     mod inner { #![no_mangle] }
    = help: `#[no_mangle]` can be applied to functions and statics
 
 warning: `#[no_mangle]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:340:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:339:5
    |
 LL |     #[no_mangle] struct S;
    |     ^^^^^^^^^^^^
@@ -488,7 +488,7 @@ LL |     #[no_mangle] struct S;
    = help: `#[no_mangle]` can be applied to functions and statics
 
 warning: `#[no_mangle]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:346:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:345:5
    |
 LL |     #[no_mangle] type T = S;
    |     ^^^^^^^^^^^^
@@ -497,7 +497,7 @@ LL |     #[no_mangle] type T = S;
    = help: `#[no_mangle]` can be applied to functions and statics
 
 warning: `#[no_mangle]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:352:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:351:5
    |
 LL |     #[no_mangle] impl S { }
    |     ^^^^^^^^^^^^
@@ -506,7 +506,7 @@ LL |     #[no_mangle] impl S { }
    = help: `#[no_mangle]` can be applied to functions and statics
 
 warning: `#[no_mangle]` attribute cannot be used on required trait methods
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:359:9
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:358:9
    |
 LL |         #[no_mangle] fn foo();
    |         ^^^^^^^^^^^^
@@ -515,7 +515,7 @@ LL |         #[no_mangle] fn foo();
    = help: `#[no_mangle]` can be applied to functions, inherent methods, statics, and trait methods in impl blocks
 
 warning: `#[no_mangle]` attribute cannot be used on provided trait methods
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:365:9
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:364:9
    |
 LL |         #[no_mangle] fn bar() {}
    |         ^^^^^^^^^^^^
@@ -524,7 +524,7 @@ LL |         #[no_mangle] fn bar() {}
    = help: `#[no_mangle]` can be applied to functions, inherent methods, statics, and trait methods in impl blocks
 
 warning: `#[should_panic]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:373:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:372:1
    |
 LL | #[should_panic]
    | ^^^^^^^^^^^^^^^
@@ -533,7 +533,7 @@ LL | #[should_panic]
    = help: `#[should_panic]` can only be applied to functions
 
 warning: `#[should_panic]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:379:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:378:17
    |
 LL |     mod inner { #![should_panic] }
    |                 ^^^^^^^^^^^^^^^^
@@ -542,7 +542,7 @@ LL |     mod inner { #![should_panic] }
    = help: `#[should_panic]` can only be applied to functions
 
 warning: `#[should_panic]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:387:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:386:5
    |
 LL |     #[should_panic] struct S;
    |     ^^^^^^^^^^^^^^^
@@ -551,7 +551,7 @@ LL |     #[should_panic] struct S;
    = help: `#[should_panic]` can only be applied to functions
 
 warning: `#[should_panic]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:393:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:392:5
    |
 LL |     #[should_panic] type T = S;
    |     ^^^^^^^^^^^^^^^
@@ -560,7 +560,7 @@ LL |     #[should_panic] type T = S;
    = help: `#[should_panic]` can only be applied to functions
 
 warning: `#[should_panic]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:399:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:398:5
    |
 LL |     #[should_panic] impl S { }
    |     ^^^^^^^^^^^^^^^
@@ -569,7 +569,7 @@ LL |     #[should_panic] impl S { }
    = help: `#[should_panic]` can only be applied to functions
 
 warning: `#[ignore]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:406:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:405:1
    |
 LL | #[ignore]
    | ^^^^^^^^^
@@ -578,7 +578,7 @@ LL | #[ignore]
    = help: `#[ignore]` can only be applied to functions
 
 warning: `#[ignore]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:412:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:411:17
    |
 LL |     mod inner { #![ignore] }
    |                 ^^^^^^^^^^
@@ -587,7 +587,7 @@ LL |     mod inner { #![ignore] }
    = help: `#[ignore]` can only be applied to functions
 
 warning: `#[ignore]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:420:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:419:5
    |
 LL |     #[ignore] struct S;
    |     ^^^^^^^^^
@@ -596,7 +596,7 @@ LL |     #[ignore] struct S;
    = help: `#[ignore]` can only be applied to functions
 
 warning: `#[ignore]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:426:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:425:5
    |
 LL |     #[ignore] type T = S;
    |     ^^^^^^^^^
@@ -605,7 +605,7 @@ LL |     #[ignore] type T = S;
    = help: `#[ignore]` can only be applied to functions
 
 warning: `#[ignore]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:432:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:431:5
    |
 LL |     #[ignore] impl S { }
    |     ^^^^^^^^^
@@ -614,7 +614,7 @@ LL |     #[ignore] impl S { }
    = help: `#[ignore]` can only be applied to functions
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:443:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:442:5
    |
 LL |     #[no_implicit_prelude] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -623,7 +623,7 @@ LL |     #[no_implicit_prelude] fn f() { }
    = help: `#[no_implicit_prelude]` can be applied to crates and modules
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:449:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:448:5
    |
 LL |     #[no_implicit_prelude] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -632,7 +632,7 @@ LL |     #[no_implicit_prelude] struct S;
    = help: `#[no_implicit_prelude]` can be applied to crates and modules
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:455:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:454:5
    |
 LL |     #[no_implicit_prelude] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -641,7 +641,7 @@ LL |     #[no_implicit_prelude] type T = S;
    = help: `#[no_implicit_prelude]` can be applied to crates and modules
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:461:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:460:5
    |
 LL |     #[no_implicit_prelude] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -649,78 +649,8 @@ LL |     #[no_implicit_prelude] impl S { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = help: `#[no_implicit_prelude]` can be applied to crates and modules
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![reexport_test_harness_main]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:468:1
-   |
-LL | #[reexport_test_harness_main = "2900"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: this attribute does not have an `!`, which means it is applied to this module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:470:1
-   |
-LL | / mod reexport_test_harness_main {
-LL | |
-LL | |     mod inner { #![reexport_test_harness_main="2900"] }
-...  |
-LL | | }
-   | |_^
-
-warning: the `#![reexport_test_harness_main]` attribute can only be used at the crate root
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:472:17
-   |
-LL |     mod inner { #![reexport_test_harness_main="2900"] }
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![reexport_test_harness_main]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:475:5
-   |
-LL |     #[reexport_test_harness_main = "2900"] fn f() { }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:475:44
-   |
-LL |     #[reexport_test_harness_main = "2900"] fn f() { }
-   |                                            ^^^^^^^^^^
-
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![reexport_test_harness_main]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:479:5
-   |
-LL |     #[reexport_test_harness_main = "2900"] struct S;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: this attribute does not have an `!`, which means it is applied to this struct
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:479:44
-   |
-LL |     #[reexport_test_harness_main = "2900"] struct S;
-   |                                            ^^^^^^^^^
-
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![reexport_test_harness_main]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:483:5
-   |
-LL |     #[reexport_test_harness_main = "2900"] type T = S;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: this attribute does not have an `!`, which means it is applied to this type alias
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:483:44
-   |
-LL |     #[reexport_test_harness_main = "2900"] type T = S;
-   |                                            ^^^^^^^^^^^
-
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![reexport_test_harness_main]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:487:5
-   |
-LL |     #[reexport_test_harness_main = "2900"] impl S { }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: this attribute does not have an `!`, which means it is applied to this implementation block
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:487:44
-   |
-LL |     #[reexport_test_harness_main = "2900"] impl S { }
-   |                                            ^^^^^^^^^^
-
 warning: `#[macro_escape]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:500:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:475:5
    |
 LL |     #[macro_escape] fn f() { }
    |     ^^^^^^^^^^^^^^^
@@ -729,7 +659,7 @@ LL |     #[macro_escape] fn f() { }
    = help: `#[macro_escape]` can be applied to crates, extern crates, and modules
 
 warning: `#[macro_escape]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:506:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:481:5
    |
 LL |     #[macro_escape] struct S;
    |     ^^^^^^^^^^^^^^^
@@ -738,7 +668,7 @@ LL |     #[macro_escape] struct S;
    = help: `#[macro_escape]` can be applied to crates, extern crates, and modules
 
 warning: `#[macro_escape]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:512:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:487:5
    |
 LL |     #[macro_escape] type T = S;
    |     ^^^^^^^^^^^^^^^
@@ -747,7 +677,7 @@ LL |     #[macro_escape] type T = S;
    = help: `#[macro_escape]` can be applied to crates, extern crates, and modules
 
 warning: `#[macro_escape]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:518:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:493:5
    |
 LL |     #[macro_escape] impl S { }
    |     ^^^^^^^^^^^^^^^
@@ -756,13 +686,13 @@ LL |     #[macro_escape] impl S { }
    = help: `#[macro_escape]` can be applied to crates, extern crates, and modules
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:525:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:500:1
    |
 LL | #[no_std]
    | ^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:527:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:502:1
    |
 LL | / mod no_std {
 LL | |
@@ -772,61 +702,61 @@ LL | | }
    | |_^
 
 warning: the `#![no_std]` attribute can only be used at the crate root
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:529:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:504:17
    |
 LL |     mod inner { #![no_std] }
    |                 ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:532:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:507:5
    |
 LL |     #[no_std] fn f() { }
    |     ^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:532:15
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:507:15
    |
 LL |     #[no_std] fn f() { }
    |               ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:536:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:511:5
    |
 LL |     #[no_std] struct S;
    |     ^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this struct
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:536:15
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:511:15
    |
 LL |     #[no_std] struct S;
    |               ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:540:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:515:5
    |
 LL |     #[no_std] type T = S;
    |     ^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this type alias
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:540:15
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:515:15
    |
 LL |     #[no_std] type T = S;
    |               ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:544:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:519:5
    |
 LL |     #[no_std] impl S { }
    |     ^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this implementation block
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:544:15
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:519:15
    |
 LL |     #[no_std] impl S { }
    |               ^^^^^^^^^^
 
 warning: `#[cold]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:566:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:541:1
    |
 LL | #[cold]
    | ^^^^^^^
@@ -835,7 +765,7 @@ LL | #[cold]
    = help: `#[cold]` can only be applied to functions
 
 warning: `#[cold]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:573:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:548:17
    |
 LL |     mod inner { #![cold] }
    |                 ^^^^^^^^
@@ -844,7 +774,7 @@ LL |     mod inner { #![cold] }
    = help: `#[cold]` can only be applied to functions
 
 warning: `#[cold]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:581:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:556:5
    |
 LL |     #[cold] struct S;
    |     ^^^^^^^
@@ -853,7 +783,7 @@ LL |     #[cold] struct S;
    = help: `#[cold]` can only be applied to functions
 
 warning: `#[cold]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:587:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:562:5
    |
 LL |     #[cold] type T = S;
    |     ^^^^^^^
@@ -862,7 +792,7 @@ LL |     #[cold] type T = S;
    = help: `#[cold]` can only be applied to functions
 
 warning: `#[cold]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:593:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:568:5
    |
 LL |     #[cold] impl S { }
    |     ^^^^^^^
@@ -871,7 +801,7 @@ LL |     #[cold] impl S { }
    = help: `#[cold]` can only be applied to functions
 
 warning: `#[link_name]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:600:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:575:1
    |
 LL | #[link_name = "1900"]
    | ^^^^^^^^^^^^^^^^^^^^^
@@ -880,7 +810,7 @@ LL | #[link_name = "1900"]
    = help: `#[link_name]` can be applied to foreign functions and foreign statics
 
 warning: `#[link_name]` attribute cannot be used on foreign modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:606:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:581:5
    |
 LL |     #[link_name = "1900"]
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -889,7 +819,7 @@ LL |     #[link_name = "1900"]
    = help: `#[link_name]` can be applied to foreign functions and foreign statics
 
 warning: `#[link_name]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:613:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:588:17
    |
 LL |     mod inner { #![link_name="1900"] }
    |                 ^^^^^^^^^^^^^^^^^^^^
@@ -898,7 +828,7 @@ LL |     mod inner { #![link_name="1900"] }
    = help: `#[link_name]` can be applied to foreign functions and foreign statics
 
 warning: `#[link_name]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:619:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:594:5
    |
 LL |     #[link_name = "1900"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -907,7 +837,7 @@ LL |     #[link_name = "1900"] fn f() { }
    = help: `#[link_name]` can be applied to foreign functions and foreign statics
 
 warning: `#[link_name]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:625:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:600:5
    |
 LL |     #[link_name = "1900"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -916,7 +846,7 @@ LL |     #[link_name = "1900"] struct S;
    = help: `#[link_name]` can be applied to foreign functions and foreign statics
 
 warning: `#[link_name]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:631:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:606:5
    |
 LL |     #[link_name = "1900"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -925,7 +855,7 @@ LL |     #[link_name = "1900"] type T = S;
    = help: `#[link_name]` can be applied to foreign functions and foreign statics
 
 warning: `#[link_name]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:637:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:612:5
    |
 LL |     #[link_name = "1900"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -934,7 +864,7 @@ LL |     #[link_name = "1900"] impl S { }
    = help: `#[link_name]` can be applied to foreign functions and foreign statics
 
 warning: `#[link_section]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:644:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:619:1
    |
 LL | #[link_section = "1800"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -943,7 +873,7 @@ LL | #[link_section = "1800"]
    = help: `#[link_section]` can be applied to functions and statics
 
 warning: `#[link_section]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:650:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:625:17
    |
 LL |     mod inner { #![link_section="1800"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -952,7 +882,7 @@ LL |     mod inner { #![link_section="1800"] }
    = help: `#[link_section]` can be applied to functions and statics
 
 warning: `#[link_section]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:658:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:633:5
    |
 LL |     #[link_section = "1800"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -961,7 +891,7 @@ LL |     #[link_section = "1800"] struct S;
    = help: `#[link_section]` can be applied to functions and statics
 
 warning: `#[link_section]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:664:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:639:5
    |
 LL |     #[link_section = "1800"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -970,7 +900,7 @@ LL |     #[link_section = "1800"] type T = S;
    = help: `#[link_section]` can be applied to functions and statics
 
 warning: `#[link_section]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:670:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:645:5
    |
 LL |     #[link_section = "1800"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -979,7 +909,7 @@ LL |     #[link_section = "1800"] impl S { }
    = help: `#[link_section]` can be applied to functions and statics
 
 warning: `#[link_section]` attribute cannot be used on traits
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:676:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:651:5
    |
 LL |     #[link_section = "1800"]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -988,7 +918,7 @@ LL |     #[link_section = "1800"]
    = help: `#[link_section]` can be applied to functions and statics
 
 warning: `#[link_section]` attribute cannot be used on required trait methods
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:682:9
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:657:9
    |
 LL |         #[link_section = "1800"]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -997,7 +927,7 @@ LL |         #[link_section = "1800"]
    = help: `#[link_section]` can be applied to functions, inherent methods, provided trait methods, statics, and trait methods in impl blocks
 
 warning: `#[must_use]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:761:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:736:1
    |
 LL | #[must_use]
    | ^^^^^^^^^^^
@@ -1006,7 +936,7 @@ LL | #[must_use]
    = help: `#[must_use]` can be applied to data types, functions, and traits
 
 warning: `#[must_use]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:766:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:741:17
    |
 LL |     mod inner { #![must_use] }
    |                 ^^^^^^^^^^^^
@@ -1015,7 +945,7 @@ LL |     mod inner { #![must_use] }
    = help: `#[must_use]` can be applied to data types, functions, and traits
 
 warning: `#[must_use]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:775:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:750:5
    |
 LL |     #[must_use] type T = S;
    |     ^^^^^^^^^^^
@@ -1024,7 +954,7 @@ LL |     #[must_use] type T = S;
    = help: `#[must_use]` can be applied to data types, functions, and traits
 
 warning: `#[must_use]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:780:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:755:5
    |
 LL |     #[must_use] impl S { }
    |     ^^^^^^^^^^^
@@ -1033,13 +963,13 @@ LL |     #[must_use] impl S { }
    = help: `#[must_use]` can be applied to data types, functions, and traits
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![windows_subsystem]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:786:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:761:1
    |
 LL | #[windows_subsystem = "windows"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:788:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:763:1
    |
 LL | / mod windows_subsystem {
 LL | |
@@ -1049,67 +979,67 @@ LL | | }
    | |_^
 
 warning: the `#![windows_subsystem]` attribute can only be used at the crate root
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:790:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:765:17
    |
 LL |     mod inner { #![windows_subsystem="windows"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![windows_subsystem]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:793:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:768:5
    |
 LL |     #[windows_subsystem = "windows"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:793:38
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:768:38
    |
 LL |     #[windows_subsystem = "windows"] fn f() { }
    |                                      ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![windows_subsystem]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:797:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:772:5
    |
 LL |     #[windows_subsystem = "windows"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this struct
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:797:38
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:772:38
    |
 LL |     #[windows_subsystem = "windows"] struct S;
    |                                      ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![windows_subsystem]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:801:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:776:5
    |
 LL |     #[windows_subsystem = "windows"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this type alias
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:801:38
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:776:38
    |
 LL |     #[windows_subsystem = "windows"] type T = S;
    |                                      ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![windows_subsystem]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:805:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:780:5
    |
 LL |     #[windows_subsystem = "windows"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this implementation block
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:805:38
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:780:38
    |
 LL |     #[windows_subsystem = "windows"] impl S { }
    |                                      ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_name]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:812:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:787:1
    |
 LL | #[crate_name = "0900"]
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:814:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:789:1
    |
 LL | / mod crate_name {
 LL | |
@@ -1119,67 +1049,67 @@ LL | | }
    | |_^
 
 warning: the `#![crate_name]` attribute can only be used at the crate root
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:816:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:791:17
    |
 LL |     mod inner { #![crate_name="0900"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_name]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:819:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:794:5
    |
 LL |     #[crate_name = "0900"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:819:28
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:794:28
    |
 LL |     #[crate_name = "0900"] fn f() { }
    |                            ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_name]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:823:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:798:5
    |
 LL |     #[crate_name = "0900"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this struct
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:823:28
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:798:28
    |
 LL |     #[crate_name = "0900"] struct S;
    |                            ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_name]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:827:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:802:5
    |
 LL |     #[crate_name = "0900"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this type alias
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:827:28
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:802:28
    |
 LL |     #[crate_name = "0900"] type T = S;
    |                            ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_name]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:831:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:806:5
    |
 LL |     #[crate_name = "0900"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this implementation block
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:831:28
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:806:28
    |
 LL |     #[crate_name = "0900"] impl S { }
    |                            ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_type]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:836:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:811:1
    |
 LL | #[crate_type = "0800"]
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:838:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:813:1
    |
 LL | / mod crate_type {
 LL | |
@@ -1189,67 +1119,67 @@ LL | | }
    | |_^
 
 warning: the `#![crate_type]` attribute can only be used at the crate root
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:840:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:815:17
    |
 LL |     mod inner { #![crate_type="0800"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_type]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:843:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:818:5
    |
 LL |     #[crate_type = "0800"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:843:28
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:818:28
    |
 LL |     #[crate_type = "0800"] fn f() { }
    |                            ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_type]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:847:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:822:5
    |
 LL |     #[crate_type = "0800"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this struct
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:847:28
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:822:28
    |
 LL |     #[crate_type = "0800"] struct S;
    |                            ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_type]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:851:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:826:5
    |
 LL |     #[crate_type = "0800"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this type alias
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:851:28
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:826:28
    |
 LL |     #[crate_type = "0800"] type T = S;
    |                            ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_type]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:855:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:830:5
    |
 LL |     #[crate_type = "0800"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this implementation block
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:855:28
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:830:28
    |
 LL |     #[crate_type = "0800"] impl S { }
    |                            ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![feature]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:860:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:835:1
    |
 LL | #[feature(x0600)]
    | ^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:862:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:837:1
    |
 LL | / mod feature {
 LL | |
@@ -1259,67 +1189,67 @@ LL | | }
    | |_^
 
 warning: the `#![feature]` attribute can only be used at the crate root
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:864:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:839:17
    |
 LL |     mod inner { #![feature(x0600)] }
    |                 ^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![feature]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:867:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:842:5
    |
 LL |     #[feature(x0600)] fn f() { }
    |     ^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:867:23
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:842:23
    |
 LL |     #[feature(x0600)] fn f() { }
    |                       ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![feature]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:871:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:846:5
    |
 LL |     #[feature(x0600)] struct S;
    |     ^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this struct
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:871:23
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:846:23
    |
 LL |     #[feature(x0600)] struct S;
    |                       ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![feature]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:875:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:850:5
    |
 LL |     #[feature(x0600)] type T = S;
    |     ^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this type alias
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:875:23
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:850:23
    |
 LL |     #[feature(x0600)] type T = S;
    |                       ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![feature]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:879:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:854:5
    |
 LL |     #[feature(x0600)] impl S { }
    |     ^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this implementation block
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:879:23
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:854:23
    |
 LL |     #[feature(x0600)] impl S { }
    |                       ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_main]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:885:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:860:1
    |
 LL | #[no_main]
    | ^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:887:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:862:1
    |
 LL | / mod no_main_1 {
 LL | |
@@ -1329,67 +1259,67 @@ LL | | }
    | |_^
 
 warning: the `#![no_main]` attribute can only be used at the crate root
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:889:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:864:17
    |
 LL |     mod inner { #![no_main] }
    |                 ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_main]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:892:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:867:5
    |
 LL |     #[no_main] fn f() { }
    |     ^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:892:16
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:867:16
    |
 LL |     #[no_main] fn f() { }
    |                ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_main]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:896:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:871:5
    |
 LL |     #[no_main] struct S;
    |     ^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this struct
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:896:16
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:871:16
    |
 LL |     #[no_main] struct S;
    |                ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_main]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:900:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:875:5
    |
 LL |     #[no_main] type T = S;
    |     ^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this type alias
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:900:16
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:875:16
    |
 LL |     #[no_main] type T = S;
    |                ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_main]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:904:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:879:5
    |
 LL |     #[no_main] impl S { }
    |     ^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this implementation block
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:904:16
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:879:16
    |
 LL |     #[no_main] impl S { }
    |                ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_builtins]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:909:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:884:1
    |
 LL | #[no_builtins]
    | ^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:911:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:886:1
    |
 LL | / mod no_builtins {
 LL | |
@@ -1399,67 +1329,67 @@ LL | | }
    | |_^
 
 warning: the `#![no_builtins]` attribute can only be used at the crate root
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:913:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:888:17
    |
 LL |     mod inner { #![no_builtins] }
    |                 ^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_builtins]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:916:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:891:5
    |
 LL |     #[no_builtins] fn f() { }
    |     ^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:916:20
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:891:20
    |
 LL |     #[no_builtins] fn f() { }
    |                    ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_builtins]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:920:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:895:5
    |
 LL |     #[no_builtins] struct S;
    |     ^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this struct
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:920:20
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:895:20
    |
 LL |     #[no_builtins] struct S;
    |                    ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_builtins]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:924:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:899:5
    |
 LL |     #[no_builtins] type T = S;
    |     ^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this type alias
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:924:20
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:899:20
    |
 LL |     #[no_builtins] type T = S;
    |                    ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_builtins]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:928:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:903:5
    |
 LL |     #[no_builtins] impl S { }
    |     ^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this implementation block
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:928:20
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:903:20
    |
 LL |     #[no_builtins] impl S { }
    |                    ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![recursion_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:933:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:908:1
    |
 LL | #[recursion_limit="0200"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:935:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:910:1
    |
 LL | / mod recursion_limit {
 LL | |
@@ -1469,67 +1399,67 @@ LL | | }
    | |_^
 
 warning: the `#![recursion_limit]` attribute can only be used at the crate root
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:937:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:912:17
    |
 LL |     mod inner { #![recursion_limit="0200"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![recursion_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:940:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:915:5
    |
 LL |     #[recursion_limit="0200"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:940:31
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:915:31
    |
 LL |     #[recursion_limit="0200"] fn f() { }
    |                               ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![recursion_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:944:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:919:5
    |
 LL |     #[recursion_limit="0200"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this struct
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:944:31
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:919:31
    |
 LL |     #[recursion_limit="0200"] struct S;
    |                               ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![recursion_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:948:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:923:5
    |
 LL |     #[recursion_limit="0200"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this type alias
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:948:31
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:923:31
    |
 LL |     #[recursion_limit="0200"] type T = S;
    |                               ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![recursion_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:952:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:927:5
    |
 LL |     #[recursion_limit="0200"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this implementation block
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:952:31
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:927:31
    |
 LL |     #[recursion_limit="0200"] impl S { }
    |                               ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![type_length_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:957:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:932:1
    |
 LL | #[type_length_limit="0100"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:959:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:934:1
    |
 LL | / mod type_length_limit {
 LL | |
@@ -1539,55 +1469,55 @@ LL | | }
    | |_^
 
 warning: the `#![type_length_limit]` attribute can only be used at the crate root
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:961:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:936:17
    |
 LL |     mod inner { #![type_length_limit="0100"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![type_length_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:964:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:939:5
    |
 LL |     #[type_length_limit="0100"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:964:33
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:939:33
    |
 LL |     #[type_length_limit="0100"] fn f() { }
    |                                 ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![type_length_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:968:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:943:5
    |
 LL |     #[type_length_limit="0100"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this struct
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:968:33
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:943:33
    |
 LL |     #[type_length_limit="0100"] struct S;
    |                                 ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![type_length_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:972:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:947:5
    |
 LL |     #[type_length_limit="0100"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this type alias
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:972:33
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:947:33
    |
 LL |     #[type_length_limit="0100"] type T = S;
    |                                 ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![type_length_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:976:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:951:5
    |
 LL |     #[type_length_limit="0100"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this implementation block
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:976:33
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:951:33
    |
 LL |     #[type_length_limit="0100"] impl S { }
    |                                 ^^^^^^^^^^
@@ -1611,7 +1541,7 @@ LL | #![ignore]
    = help: `#[ignore]` can only be applied to functions
 
 warning: `#[proc_macro_derive]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:62:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:61:1
    |
 LL | #![proc_macro_derive(Test)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1620,7 +1550,7 @@ LL | #![proc_macro_derive(Test)]
    = help: `#[proc_macro_derive]` can only be applied to functions
 
 warning: `#[cold]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:67:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:66:1
    |
 LL | #![cold]
    | ^^^^^^^^
@@ -1629,7 +1559,7 @@ LL | #![cold]
    = help: `#[cold]` can only be applied to functions
 
 warning: `#[link_name]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:73:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:72:1
    |
 LL | #![link_name = "1900"]
    | ^^^^^^^^^^^^^^^^^^^^^^
@@ -1638,7 +1568,7 @@ LL | #![link_name = "1900"]
    = help: `#[link_name]` can be applied to foreign functions and foreign statics
 
 warning: `#[link_section]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:78:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:77:1
    |
 LL | #![link_section = "1800"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1647,7 +1577,7 @@ LL | #![link_section = "1800"]
    = help: `#[link_section]` can be applied to functions and statics
 
 warning: `#[must_use]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:83:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:82:1
    |
 LL | #![must_use]
    | ^^^^^^^^^^^^
@@ -1655,5 +1585,5 @@ LL | #![must_use]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = help: `#[must_use]` can be applied to data types, functions, and traits
 
-warning: 175 warnings emitted
+warning: 169 warnings emitted
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/152210)*
<!-- homu-ignore:end -->

Address the FIXME

Removed from `issue-43106-gating-of-builtin-attrs.rs` since that is for stable attributes only.

This would be a breaking change, search of github shows it is mostly but not always used with `#![test_runner]` which is already gated correctly.

Details:
https://github.com/rust-lang/rust/issues/50297

Feel free to close this issue if you think it is not worth addressing the FIXME...
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
