### PR TITLE
Report unconstrained region in hidden types lazily

### DIFF
--- a/tests/ui/traits/next-solver/opaques/eventually-constrained-region.rs
+++ b/tests/ui/traits/next-solver/opaques/eventually-constrained-region.rs
@@ -1,0 +1,21 @@
+//@ check-pass
+//@ compile-flags: -Znext-solver
+
+// Regression test for trait-system-refactor-initiative#264.
+//
+// Some defining uses of opaque types can't constrain captured regions to universals.
+// Previouly, we eagerly report error in this case.
+// Now we report error only if there's no fully defining use from all bodies of the typeck root.
+
+struct Inv<'a>(*mut &'a ());
+
+fn mk_static() -> Inv<'static> { todo!() }
+
+fn guide_closure_sig<'a>(f: impl FnOnce() -> Inv<'a>) {}
+
+fn unconstrained_in_closure() -> impl Sized {
+    guide_closure_sig(|| unconstrained_in_closure());
+    mk_static()
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/opaques/report-all-unexpected-hidden-errors.rs
+++ b/tests/ui/traits/next-solver/opaques/report-all-unexpected-hidden-errors.rs
@@ -1,0 +1,34 @@
+//@ compile-flags: -Znext-solver
+
+// Just for diagnostics completeness.
+// This is probably unimportant as we only report one error for such case in HIR typeck.
+
+#![feature(type_alias_impl_trait)]
+
+struct Invar<'a>(*mut &'a ());
+
+fn mk_invar<'a>(a: &'a i32) -> Invar<'a> {
+    todo!()
+}
+
+type MultiUse = impl Sized;
+
+#[define_opaque(MultiUse)]
+fn capture_different_universals_not_on_bounds<'a, 'b, 'c>(a: &'a i32, b: &'b i32, c: &'c i32)  {
+    let _ = || -> MultiUse {
+        //~^ ERROR: hidden type for `MultiUse` captures lifetime that does not appear in bounds [E0700]
+        mk_invar(a)
+    };
+    let _ = || -> MultiUse {
+        //~^ ERROR: hidden type for `MultiUse` captures lifetime that does not appear in bounds [E0700]
+        mk_invar(b)
+    };
+    let _ = || {
+        let _ = || -> MultiUse {
+            //~^ ERROR: hidden type for `MultiUse` captures lifetime that does not appear in bounds [E0700]
+            mk_invar(c)
+        };
+    };
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/opaques/report-all-unexpected-hidden-errors.stderr
+++ b/tests/ui/traits/next-solver/opaques/report-all-unexpected-hidden-errors.stderr
@@ -1,0 +1,36 @@
+error[E0700]: hidden type for `MultiUse` captures lifetime that does not appear in bounds
+  --> $DIR/report-all-unexpected-hidden-errors.rs:18:19
+   |
+LL | type MultiUse = impl Sized;
+   |                 ---------- opaque type defined here
+...
+LL |     let _ = || -> MultiUse {
+   |                   ^^^^^^^^
+   |
+   = note: hidden type `Invar<'_>` captures lifetime `'_`
+
+error[E0700]: hidden type for `MultiUse` captures lifetime that does not appear in bounds
+  --> $DIR/report-all-unexpected-hidden-errors.rs:22:19
+   |
+LL | type MultiUse = impl Sized;
+   |                 ---------- opaque type defined here
+...
+LL |     let _ = || -> MultiUse {
+   |                   ^^^^^^^^
+   |
+   = note: hidden type `Invar<'_>` captures lifetime `'_`
+
+error[E0700]: hidden type for `MultiUse` captures lifetime that does not appear in bounds
+  --> $DIR/report-all-unexpected-hidden-errors.rs:27:23
+   |
+LL | type MultiUse = impl Sized;
+   |                 ---------- opaque type defined here
+...
+LL |         let _ = || -> MultiUse {
+   |                       ^^^^^^^^
+   |
+   = note: hidden type `Invar<'_>` captures lifetime `'_`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0700`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Fixes https://github.com/rust-lang/trait-system-refactor-initiative/issues/264

I didn't copy the mechanism of HIR typeck as I found that we just need to be lax in the unconstrained region case.
It already ignores non-defining uses and invalid params.

About tests, I'm having trouble coming up with more complex ones. 🙁


This fixes `ukanren` and `codecrafters-redis-rust` but not rust-lang/rust#151322 and rust-lang/rust#151323.
I believe they are a [different problem](https://github.com/rust-lang/rust/issues/151322#issuecomment-3864656974).


r? @lcnr 
