### PR TITLE
Re-add TaKO8Ki to triagebot review queue

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1466,6 +1466,7 @@ compiler = [
     "@oli-obk",
     "@petrochenkov",
     "@SparrowLii",
+    "@TaKO8Ki",
     "@tiif",
     "@WaffleLapkin",
     "@wesleywiser",
@@ -1512,6 +1513,7 @@ diagnostics = [
     "@davidtwco",
     "@oli-obk",
     "@chenyukang",
+    "@TaKO8Ki"
 ]
 parser = [
     "@davidtwco",


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->


I’m rejoining the compiler review rotation to help with ongoing review load.