### PR TITLE
[Clippy stable backport] Fix `panicking_unwrap` FP on field access with implicit deref

### DIFF
--- a/src/tools/clippy/tests/ui/checked_unwrap/simple_conditionals.rs
+++ b/src/tools/clippy/tests/ui/checked_unwrap/simple_conditionals.rs
@@ -472,3 +472,22 @@ fn issue15321() {
         //~^ unnecessary_unwrap
     }
 }
+
+mod issue16188 {
+    struct Foo {
+        value: Option<i32>,
+    }
+
+    impl Foo {
+        pub fn bar(&mut self) {
+            let print_value = |v: i32| {
+                println!("{}", v);
+            };
+
+            if self.value.is_none() {
+                self.value = Some(10);
+                print_value(self.value.unwrap());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Cherry-pick of commit c59e7a9a823391aea5e913d011e4662e827b07aa from the `beta` branch to backport https://github.com/rust-lang/rust-clippy/pull/16196 which fixes an ICE in Clippy.

r? @Mark-Simulacrum 