### PR TITLE
Remove deterministic picking from query cycle handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4492,7 +4492,6 @@ dependencies = [
  "rustc_abi",
  "rustc_data_structures",
  "rustc_errors",
- "rustc_hashes",
  "rustc_hir",
  "rustc_index",
  "rustc_macros",

--- a/compiler/rustc_middle/src/query/stack.rs
+++ b/compiler/rustc_middle/src/query/stack.rs
@@ -4,7 +4,6 @@ use std::mem::transmute;
 use std::sync::Arc;
 
 use rustc_data_structures::sync::{DynSend, DynSync};
-use rustc_hashes::Hash64;
 use rustc_hir::def::DefKind;
 use rustc_span::Span;
 use rustc_span::def_id::DefId;
@@ -23,9 +22,6 @@ pub struct QueryStackFrame<I> {
     pub info: I,
 
     pub dep_kind: DepKind,
-    /// This hash is used to deterministically pick
-    /// a query to remove cycles in the parallel compiler.
-    pub hash: Hash64,
     pub def_id: Option<DefId>,
     /// A def-id that is extracted from a `Ty` in a query key
     pub def_id_for_ty_in_cycle: Option<DefId>,
@@ -36,18 +32,16 @@ impl<'tcx> QueryStackFrame<QueryStackDeferred<'tcx>> {
     pub fn new(
         info: QueryStackDeferred<'tcx>,
         dep_kind: DepKind,
-        hash: Hash64,
         def_id: Option<DefId>,
         def_id_for_ty_in_cycle: Option<DefId>,
     ) -> Self {
-        Self { info, def_id, dep_kind, hash, def_id_for_ty_in_cycle }
+        Self { info, def_id, dep_kind, def_id_for_ty_in_cycle }
     }
 
     pub fn lift(&self) -> QueryStackFrame<QueryStackFrameExtra> {
         QueryStackFrame {
             info: self.info.extract(),
             dep_kind: self.dep_kind,
-            hash: self.hash,
             def_id: self.def_id,
             def_id_for_ty_in_cycle: self.def_id_for_ty_in_cycle,
         }

--- a/compiler/rustc_query_impl/Cargo.toml
+++ b/compiler/rustc_query_impl/Cargo.toml
@@ -9,7 +9,6 @@ measureme = "12.0.1"
 rustc_abi = { path = "../rustc_abi" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_errors = { path = "../rustc_errors" }
-rustc_hashes = { path = "../rustc_hashes" }
 rustc_hir = { path = "../rustc_hir" }
 rustc_index = { path = "../rustc_index" }
 rustc_macros = { path = "../rustc_macros" }

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -4,10 +4,8 @@
 
 use std::num::NonZero;
 
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::sync::{DynSend, DynSync};
 use rustc_data_structures::unord::UnordMap;
-use rustc_hashes::Hash64;
 use rustc_hir::def_id::DefId;
 use rustc_hir::limit::Limit;
 use rustc_index::Idx;
@@ -319,18 +317,11 @@ where
 {
     let kind = vtable.dep_kind;
 
-    let hash = tcx.with_stable_hashing_context(|mut hcx| {
-        let mut hasher = StableHasher::new();
-        kind.as_usize().hash_stable(&mut hcx, &mut hasher);
-        key.hash_stable(&mut hcx, &mut hasher);
-        hasher.finish::<Hash64>()
-    });
-
     let def_id: Option<DefId> = key.key_as_def_id();
     let def_id_for_ty_in_cycle: Option<DefId> = key.def_id_for_ty_in_cycle();
 
     let info = QueryStackDeferred::new((tcx, vtable, key), mk_query_stack_frame_extra);
-    QueryStackFrame::new(info, kind, hash, def_id, def_id_for_ty_in_cycle)
+    QueryStackFrame::new(info, kind, def_id, def_id_for_ty_in_cycle)
 }
 
 pub(crate) fn encode_query_results<'a, 'tcx, Q, C: QueryCache, const FLAGS: QueryFlags>(


### PR DESCRIPTION
This removes the deterministic picking of queries from the query cycle handling. The sets we pick from are themselves non-deterministic, making this ineffective. There may be additional entry points to the cycle which we won't discover until after we resume from the cycle handler and run more code.