### PR TITLE
docs: document platform-specific program behavior in Command

### DIFF
--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -590,6 +590,26 @@ impl fmt::Debug for ChildStderr {
 /// // And then execute `ls` again but in the root directory.
 /// list_dir.status().expect("process failed to execute");
 /// ```
+///
+/// # Platform-Specific Program Behavior
+///
+/// While `Command` is designed to be OS-agnostic, the spawned program's
+/// behavior may differ by platform. For example, when detecting whether
+/// a program is available, invoking it with no arguments may hang on
+/// Windows (if the program waits for stdin) but exit immediately on Unix:
+///
+/// ```no_run
+/// use std::process::Command;
+///
+/// // Programs that read stdin (python3, node, cat, etc.) may behave differently:
+/// // - Unix: often detect non-TTY stdin and exit immediately
+/// // - Windows: may wait indefinitely for input
+/// // Using `--version` ensures consistent behavior when probing for availability.
+/// let output = Command::new("python3")
+///     .arg("--version")
+///     .output()
+///     .expect("failed to execute python3");
+/// ```
 #[stable(feature = "process", since = "1.0.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "Command")]
 pub struct Command {


### PR DESCRIPTION
While `Command` itself is designed to be OS-agnostic, spawned programs behavior may differ by platform. Example, invoking program with no arguments may hang on Windows (if waits for stdin) but exit immediately on Unix.

This adds new section to `Command` documentation noting behavior and suggesting use of flags like `--version` to ensure consistent behavior when probing for program availability.

Context:
Discovered while debugging cross-platform build system (Servo) that hung on Windows ARM64 when detecting Python availability. Fix was use `python --version` instead of `python` with no args.

This addresses workingjubilee's suggestion in https://github.com/rust-lang/rust/pull/152143#issuecomment-2863408604:

> While Command is intended to be OS-agnostic, spawning a process itself can still have enough OS-specific consequences, unavoidably, that it makes the same thing less useful. That may be something to document."