### PR TITLE
compiletest: `-Zunstable-options` for json targets

### DIFF
--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -949,7 +949,9 @@ impl TargetCfgs {
         // actually be changed with `-C` flags.
         for config in query_rustc_output(
             config,
-            &["--print=cfg", "--target", &config.target],
+            // `-Zunstable-options` is necessary when compiletest is running with custom targets
+            // (such as synthetic targets used to bless mir-opt tests).
+            &["-Zunstable-options", "--print=cfg", "--target", &config.target],
             Default::default(),
         )
         .trim()

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1670,6 +1670,11 @@ impl<'test> TestCx<'test> {
                 if self.props.force_host { &*self.config.host } else { &*self.config.target };
 
             compiler.arg(&format!("--target={}", target));
+            if target.ends_with(".json") {
+                // `-Zunstable-options` is necessary when compiletest is running with custom targets
+                // (such as synthetic targets used to bless mir-opt tests).
+                compiler.arg("-Zunstable-options");
+            }
         }
         self.set_revision_flags(&mut compiler);
 


### PR DESCRIPTION
bootstrap runs compiletest with synthetic custom targets when blessing `mir-opt` tests, but that no longer works after rust-lang/rust#150151/rust-lang/rust#151534 because `-Zunstable-options` is required

Contexts on [Zulips](https://rust-lang.zulipchat.com/#narrow/channel/122651-general/topic/custom.20targets.20are.20unstable.20and.20require.20.60-Zunstable-options.60).