### PR TITLE
Fix ICE when using Iterator in const contexts

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/effect_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/effect_goals.rs
@@ -352,17 +352,29 @@ where
     }
 
     fn consider_builtin_iterator_candidate(
-        _ecx: &mut EvalCtxt<'_, D>,
+        ecx: &mut EvalCtxt<'_, D>,
         _goal: Goal<I, Self>,
     ) -> Result<Candidate<I>, NoSolution> {
-        todo!("Iterator is not yet const")
+        let certainty = ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)?;
+
+        Ok(Candidate {
+            source: CandidateSource::BuiltinImpl(BuiltinImplSource::Misc),
+            result: certainty,
+            head_usages: Default::default(),
+        })
     }
 
     fn consider_builtin_fused_iterator_candidate(
-        _ecx: &mut EvalCtxt<'_, D>,
+        ecx: &mut EvalCtxt<'_, D>,
         _goal: Goal<I, Self>,
     ) -> Result<Candidate<I>, NoSolution> {
-        unreachable!("FusedIterator is not const")
+        let certainty = ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)?;
+
+        Ok(Candidate {
+            source: CandidateSource::BuiltinImpl(BuiltinImplSource::Misc),
+            result: certainty,
+            head_usages: Default::default(),
+        })
     }
 
     fn consider_builtin_async_iterator_candidate(

--- a/tests/ui/traits/next-solver/iterator-ice.rs
+++ b/tests/ui/traits/next-solver/iterator-ice.rs
@@ -1,8 +1,8 @@
 //@ compile-flags: -Znext-solver=globally
 
 fn main() {
-    const { 
-        for _ in 1..5 {} 
+    const {
+        for _ in 1..5 {}
         //~^ ERROR cannot use `for` loop on `std::ops::Range<i32>` in constants
         //~| ERROR `IntoIterator` is not yet stable as a const trait
         //~| ERROR cannot use `for` loop on `std::ops::Range<i32>` in constants

--- a/tests/ui/traits/next-solver/iterator-ice.rs
+++ b/tests/ui/traits/next-solver/iterator-ice.rs
@@ -1,0 +1,11 @@
+//@ compile-flags: -Znext-solver=globally
+
+fn main() {
+    const { 
+        for _ in 1..5 {} 
+        //~^ ERROR cannot use `for` loop on `std::ops::Range<i32>` in constants
+        //~| ERROR `IntoIterator` is not yet stable as a const trait
+        //~| ERROR cannot use `for` loop on `std::ops::Range<i32>` in constants
+        //~| ERROR `Iterator` is not yet stable as a const trait
+    }
+}

--- a/tests/ui/traits/next-solver/iterator-ice.rs
+++ b/tests/ui/traits/next-solver/iterator-ice.rs
@@ -1,11 +1,12 @@
 //@ compile-flags: -Znext-solver=globally
+//@ edition: 2021
 
 fn main() {
     const {
         for _ in 1..5 {}
-        //~^ ERROR cannot use `for` loop on `std::ops::Range<i32>` in constants
-        //~| ERROR `IntoIterator` is not yet stable as a const trait
-        //~| ERROR cannot use `for` loop on `std::ops::Range<i32>` in constants
-        //~| ERROR `Iterator` is not yet stable as a const trait
+        //~^ ERROR cannot use `for` loop
+        //~| ERROR `IntoIterator` is not yet stable
+        //~| ERROR cannot use `for` loop
+        //~| ERROR `Iterator` is not yet stable
     }
 }

--- a/tests/ui/traits/next-solver/iterator-ice.stderr
+++ b/tests/ui/traits/next-solver/iterator-ice.stderr
@@ -1,0 +1,48 @@
+error[E0658]: cannot use `for` loop on `std::ops::Range<i32>` in constants
+  --> $DIR/iterator-ice.rs:5:18
+   |
+LL |         for _ in 1..5 {} 
+   |                  ^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = note: see issue #143874 <https://github.com/rust-lang/rust/issues/143874> for more information
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: `IntoIterator` is not yet stable as a const trait
+  --> $DIR/iterator-ice.rs:5:18
+   |
+LL |         for _ in 1..5 {} 
+   |                  ^^^^
+   |
+help: add `#![feature(const_iter)]` to the crate attributes to enable
+   |
+LL + #![feature(const_iter)]
+   |
+
+error[E0658]: cannot use `for` loop on `std::ops::Range<i32>` in constants
+  --> $DIR/iterator-ice.rs:5:18
+   |
+LL |         for _ in 1..5 {} 
+   |                  ^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = note: see issue #143874 <https://github.com/rust-lang/rust/issues/143874> for more information
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: `Iterator` is not yet stable as a const trait
+  --> $DIR/iterator-ice.rs:5:18
+   |
+LL |         for _ in 1..5 {} 
+   |                  ^^^^
+   |
+help: add `#![feature(const_iter)]` to the crate attributes to enable
+   |
+LL + #![feature(const_iter)]
+   |
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/traits/next-solver/iterator-ice.stderr
+++ b/tests/ui/traits/next-solver/iterator-ice.stderr
@@ -1,7 +1,7 @@
 error[E0658]: cannot use `for` loop on `std::ops::Range<i32>` in constants
-  --> $DIR/iterator-ice.rs:5:18
+  --> $DIR/iterator-ice.rs:6:18
    |
-LL |         for _ in 1..5 {} 
+LL |         for _ in 1..5 {}
    |                  ^^^^
    |
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
@@ -10,9 +10,9 @@ LL |         for _ in 1..5 {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: `IntoIterator` is not yet stable as a const trait
-  --> $DIR/iterator-ice.rs:5:18
+  --> $DIR/iterator-ice.rs:6:18
    |
-LL |         for _ in 1..5 {} 
+LL |         for _ in 1..5 {}
    |                  ^^^^
    |
 help: add `#![feature(const_iter)]` to the crate attributes to enable
@@ -21,9 +21,9 @@ LL + #![feature(const_iter)]
    |
 
 error[E0658]: cannot use `for` loop on `std::ops::Range<i32>` in constants
-  --> $DIR/iterator-ice.rs:5:18
+  --> $DIR/iterator-ice.rs:6:18
    |
-LL |         for _ in 1..5 {} 
+LL |         for _ in 1..5 {}
    |                  ^^^^
    |
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
@@ -33,9 +33,9 @@ LL |         for _ in 1..5 {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `Iterator` is not yet stable as a const trait
-  --> $DIR/iterator-ice.rs:5:18
+  --> $DIR/iterator-ice.rs:6:18
    |
-LL |         for _ in 1..5 {} 
+LL |         for _ in 1..5 {}
    |                  ^^^^
    |
 help: add `#![feature(const_iter)]` to the crate attributes to enable


### PR DESCRIPTION
In this PR built-in candidates are implemented for Iterator and FusedIterator to resolve the issue in https://github.com/rust-lang/rust/issues/151901

-> implement built-in candidates for Iterator and FusedIterator.
-> Added and blessed test for the  built-in candidates implementation.