### PR TITLE
Use relative paths for std links in rustc-docs

### DIFF
--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -953,6 +953,13 @@ impl Step for Rustc {
         cargo.rustdocflag("--extern-html-root-url");
         cargo.rustdocflag("ena=https://docs.rs/ena/latest/");
 
+        // Point std library crate links to local docs for offline usage.
+        for krate in STD_PUBLIC_CRATES {
+            cargo.rustdocflag("--extern-html-root-url");
+            cargo.rustdocflag(&format!("{krate}=../"));
+        }
+        cargo.rustdocflag("--extern-html-root-takes-precedence");
+
         let mut to_open = None;
 
         let out_dir = builder.stage_out(build_compiler, Mode::Rustc).join(target).join("doc");


### PR DESCRIPTION
Fixes rust-lang/rust#151496

This adds `--extern-html-root-url` for each `STD_PUBLIC_CRATES` entry pointing to `../`, so that `rustc-docs` links to the locally installed `rust-docs` via relative paths.

r? @GuillaumeGomez @rami3l