### PR TITLE
Stabilize const ControlFlow predicates

### DIFF
--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -151,7 +151,7 @@ impl<B, C> ControlFlow<B, C> {
     /// ```
     #[inline]
     #[stable(feature = "control_flow_enum_is", since = "1.59.0")]
-    #[rustc_const_unstable(feature = "min_const_control_flow", issue = "148738")]
+    #[rustc_const_stable(feature = "min_const_control_flow", since = "CURRENT_RUSTC_VERSION")]
     pub const fn is_break(&self) -> bool {
         matches!(*self, ControlFlow::Break(_))
     }
@@ -168,7 +168,7 @@ impl<B, C> ControlFlow<B, C> {
     /// ```
     #[inline]
     #[stable(feature = "control_flow_enum_is", since = "1.59.0")]
-    #[rustc_const_unstable(feature = "min_const_control_flow", issue = "148738")]
+    #[rustc_const_stable(feature = "min_const_control_flow", since = "CURRENT_RUSTC_VERSION")]
     pub const fn is_continue(&self) -> bool {
         matches!(*self, ControlFlow::Continue(_))
     }
@@ -264,7 +264,7 @@ impl<B, C> ControlFlow<B, C> {
     /// ```
     #[inline]
     #[unstable(feature = "control_flow_ok", issue = "140266")]
-    #[rustc_const_unstable(feature = "min_const_control_flow", issue = "148738")]
+    #[rustc_const_unstable(feature = "control_flow_ok", issue = "140266")]
     pub const fn break_ok(self) -> Result<B, C> {
         match self {
             ControlFlow::Continue(c) => Err(c),
@@ -377,7 +377,7 @@ impl<B, C> ControlFlow<B, C> {
     /// ```
     #[inline]
     #[unstable(feature = "control_flow_ok", issue = "140266")]
-    #[rustc_const_unstable(feature = "min_const_control_flow", issue = "148738")]
+    #[rustc_const_unstable(feature = "control_flow_ok", issue = "140266")]
     pub const fn continue_ok(self) -> Result<C, B> {
         match self {
             ControlFlow::Continue(c) => Ok(c),


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Closes: rust-lang/rust#148738 (tracking issue)
Related: rust-lang/rust#140266 (moved the relevant const-unstables to that feature)
r? @dtolnay