### PR TITLE
[1.93.1] Revert "Update wasm-related dependencies in CI"

### DIFF
--- a/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
@@ -85,9 +85,9 @@ RUN /tmp/build-fuchsia-toolchain.sh
 COPY host-x86_64/dist-various-2/build-x86_64-fortanix-unknown-sgx-toolchain.sh /tmp/
 RUN /tmp/build-x86_64-fortanix-unknown-sgx-toolchain.sh
 
-RUN curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-29/wasi-sdk-29.0-x86_64-linux.tar.gz | \
+RUN curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-27/wasi-sdk-27.0-x86_64-linux.tar.gz | \
   tar -xz
-ENV WASI_SDK_PATH=/tmp/wasi-sdk-29.0-x86_64-linux
+ENV WASI_SDK_PATH=/tmp/wasi-sdk-27.0-x86_64-linux
 
 COPY scripts/freebsd-toolchain.sh /tmp/
 RUN /tmp/freebsd-toolchain.sh i686

--- a/src/ci/docker/host-x86_64/pr-check-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/pr-check-2/Dockerfile
@@ -21,9 +21,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   mingw-w64 \
   && rm -rf /var/lib/apt/lists/*
 
-RUN curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-29/wasi-sdk-29.0-x86_64-linux.tar.gz | \
+RUN curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-27/wasi-sdk-27.0-x86_64-linux.tar.gz | \
   tar -xz
-ENV WASI_SDK_PATH=/wasi-sdk-29.0-x86_64-linux
+ENV WASI_SDK_PATH=/wasi-sdk-27.0-x86_64-linux
 
 ENV RUST_CONFIGURE_ARGS="--set rust.validate-mir-opts=3"
 

--- a/src/ci/docker/host-x86_64/test-various/Dockerfile
+++ b/src/ci/docker/host-x86_64/test-various/Dockerfile
@@ -41,9 +41,9 @@ WORKDIR /
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-RUN curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-29/wasi-sdk-29.0-x86_64-linux.tar.gz | \
+RUN curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-27/wasi-sdk-27.0-x86_64-linux.tar.gz | \
   tar -xz
-ENV WASI_SDK_PATH=/wasi-sdk-29.0-x86_64-linux
+ENV WASI_SDK_PATH=/wasi-sdk-27.0-x86_64-linux
 
 ENV RUST_CONFIGURE_ARGS \
   --musl-root-x86_64=/usr/local/x86_64-linux-musl \
@@ -56,9 +56,9 @@ ENV RUST_CONFIGURE_ARGS \
 ENV NO_DEBUG_ASSERTIONS=1
 ENV NO_OVERFLOW_CHECKS=1
 
-RUN curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v38.0.4/wasmtime-v38.0.4-x86_64-linux.tar.xz | \
+RUN curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v19.0.0/wasmtime-v19.0.0-x86_64-linux.tar.xz | \
   tar -xJ
-ENV PATH "$PATH:/wasmtime-v38.0.4-x86_64-linux"
+ENV PATH "$PATH:/wasmtime-v19.0.0-x86_64-linux"
 
 ENV WASM_WASIP_TARGET=wasm32-wasip1
 ENV WASM_WASIP_SCRIPT python3 /checkout/x.py --stage 2 test --host='' --target $WASM_WASIP_TARGET \


### PR DESCRIPTION
This reverts commit 4c6e41cb5305567ddc81fde28b2f6e601c4936a4 which was https://github.com/rust-lang/rust/pull/149037. The purpose of this revert is to fix https://github.com/rust-lang/rust/issues/152255. This bug is present for Rust 1.93.0 and no other releases of Rust. For example beta/1.94.0 is not affected (for a sort of weird confluence of events reasons).

The specific change here is that the wasi-libc bundled with the `wasm32-wasip{1,2}` targets, as shipped by rustup, is downgraded from wasi-sdk-29 to wasi-sdk-27. The [changelog for these two tags](https://github.com/WebAssembly/wasi-sdk/compare/wasi-sdk-27...wasi-sdk-29) is relatively modest, but there were major differences in the submodules. The LLVM submodule of wasi-sdk was updated from LLVM 20 to LLVM 21, but this only affects the compiled output. There were no known bugs with LLVM 20 and so this is not known to have affected the compiled artifact of wasi-libc much.

The main update of wasi-sdk-27 to wasi-sdk-29, however, is [a very large amount of changes in wasi-libc](https://github.com/WebAssembly/wasi-libc/compare/3f7eb4c7d6ede4dde3c4bffa6ed14e8d656fe93f...ac020b86fd44bafe60aa4fa12f407d16e3731329), which directly affects what rustc is shipping. Most of these changes are in the bucket of "port the `wasm32-wasip2` target to using WASIp2 APIs directly". This is the source of the bug in rust-lang/rust#152255 since rustc was half-using wasi-libc and half-using WASIp1 directly. Functionality-wise wasi-libc did not change all that much, however. The migration to WASIp2 APIs directly is intended to be behavior neutral, for example. Inevitably there were small behavioral changes in wasi-libc, some intentional and some unintentional. For example randomness in wasi-libc [calls the host less in 27 and more in 29](https://github.com/WebAssembly/wasi-libc/pull/620) and a bug related to the [`poll` function was fixed in 29](https://github.com/WebAssembly/wasi-libc/pull/630).

Overall my personal opinion is that while it's theoretically possible to break users of Rust 1.93 who are relying on the update to wasi-sdk-29 we'll instead fix more users by reverting this update. Not reverting this update means that dropping a `std::fs::File` doesn't actually do anything and thus wasm components can easily exhaust the file descriptor limit.

---

In summary:

* Rust 1.93 is broken for the `wasm32-wasip2` target alone due to https://github.com/rust-lang/rust/pull/149037
* Rust 1.92-and-prior, as well as Rust 1.94-and-later, are all unaffected by this bug. The reason 1.94+ is unaffected is unrelated to this revert and is related to orthogonal development in libstd w.r.t. wasm targets (aka https://github.com/rust-lang/rust/pull/147572)
* The consequence of this change is wasi-libc is being downgraded from 29.0 to 27.0 in the rustup-shipped artifacts. This runs a small risk of breaking users, but my personal feeling is we'll fix more users instead.


Fixes rust-lang/rust#152255