### PR TITLE
Introduce helper `ty::Generics::has_own_self`

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/generics.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/generics.rs
@@ -393,8 +393,7 @@ pub fn check_generic_arg_count_for_call(
         IsMethodCall::Yes => GenericArgPosition::MethodCall,
         IsMethodCall::No => GenericArgPosition::Value,
     };
-    let has_self = generics.parent.is_none() && generics.has_self;
-    check_generic_arg_count(cx, def_id, seg, generics, gen_pos, has_self)
+    check_generic_arg_count(cx, def_id, seg, generics, gen_pos, generics.has_own_self())
 }
 
 /// Checks that the correct number of generic arguments have been provided.

--- a/compiler/rustc_middle/src/ty/generics.rs
+++ b/compiler/rustc_middle/src/ty/generics.rs
@@ -284,7 +284,7 @@ impl<'tcx> Generics {
         args: &'a [ty::GenericArg<'tcx>],
     ) -> &'a [ty::GenericArg<'tcx>] {
         let mut own_params = self.parent_count..self.count();
-        if self.has_self && self.parent.is_none() {
+        if self.has_own_self() {
             own_params.start = 1;
         }
 
@@ -316,7 +316,7 @@ impl<'tcx> Generics {
         args: &'tcx [ty::GenericArg<'tcx>],
     ) -> &'tcx [ty::GenericArg<'tcx>] {
         let own = &args[self.parent_count..][..self.own_params.len()];
-        if self.has_self && self.parent.is_none() { &own[1..] } else { own }
+        if self.has_own_self() { &own[1..] } else { own }
     }
 
     /// Returns true if a concrete type is specified after a default type.
@@ -349,6 +349,10 @@ impl<'tcx> Generics {
 
     pub fn is_own_empty(&'tcx self) -> bool {
         self.own_params.is_empty()
+    }
+
+    pub fn has_own_self(&'tcx self) -> bool {
+        self.has_self && self.parent.is_none()
     }
 }
 

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
@@ -1263,7 +1263,7 @@ impl<'a, 'tcx> Visitor<'tcx> for FindInferSourceVisitor<'a, 'tcx> {
                 .iter()
                 .position(|&arg| self.generic_arg_contains_target(arg))
             {
-                if generics.parent.is_none() && generics.has_self {
+                if generics.has_own_self() {
                     argument_index += 1;
                 }
                 let args = self.tecx.resolve_vars_if_possible(args);

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -105,7 +105,7 @@ pub(crate) fn clean_middle_generic_args<'tcx>(
     // to align the arguments and parameters for the iteration below and to enable us to correctly
     // instantiate the generic parameter default later.
     let generics = cx.tcx.generics_of(owner);
-    let args = if !has_self && generics.parent.is_none() && generics.has_self {
+    let args = if !has_self && generics.has_own_self() {
         has_self = true;
         [cx.tcx.types.trait_object_dummy_self.into()]
             .into_iter()


### PR DESCRIPTION
The pattern `generics.has_self && generics.parent.is_none()` only occurs 5 times in rustc+rustdoc at the time of writing but I keep getting reminded/annoyed that there doesn't exist a nice wrapper fn that abstracts it & immediately clarifies the intent. Most recently that happened when working on my open PR RUST-129543 in which I add yet another occurrence of it ([via](https://github.com/fmease/rust/blob/ae8c0a5a46364b0d0bca349cba544adb762e7c0a/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs#L1771-L1773)).

For context, `generics.has_self` indicates that there is a `Self` type parameter (at position 0) in the "oldest" / "root" generic parameter list in the chain of generic parameter lists (rephrased: it's true if the chain *as a whole* has a `Self` type parameter). `has_own_self` on the other hand indicates that the `own_params` contain a `Self` type parameter which is sometimes needed for offsetting the own parameters or arguments.