### PR TITLE
feat: Implement `int_from_ascii` for `NonZero<T>`

### DIFF
--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -66,6 +66,7 @@
 #![feature(generic_assert_internals)]
 #![feature(hasher_prefixfree_extras)]
 #![feature(hashmap_internals)]
+#![feature(int_from_ascii)]
 #![feature(int_lowest_highest_one)]
 #![feature(int_roundings)]
 #![feature(ip)]

--- a/library/coretests/tests/nonzero.rs
+++ b/library/coretests/tests/nonzero.rs
@@ -125,6 +125,62 @@ fn test_from_signed_nonzero() {
 }
 
 #[test]
+fn test_from_ascii_radix() {
+    assert_eq!(NonZero::<u8>::from_ascii_radix(b"123", 10), Ok(NonZero::new(123).unwrap()));
+    assert_eq!(NonZero::<u8>::from_ascii_radix(b"1001", 2), Ok(NonZero::new(9).unwrap()));
+    assert_eq!(NonZero::<u8>::from_ascii_radix(b"123", 8), Ok(NonZero::new(83).unwrap()));
+    assert_eq!(NonZero::<u16>::from_ascii_radix(b"123", 16), Ok(NonZero::new(291).unwrap()));
+    assert_eq!(NonZero::<u16>::from_ascii_radix(b"ffff", 16), Ok(NonZero::new(65535).unwrap()));
+    assert_eq!(NonZero::<u8>::from_ascii_radix(b"z", 36), Ok(NonZero::new(35).unwrap()));
+    assert_eq!(
+        NonZero::<u8>::from_ascii_radix(b"0", 10).err().map(|e| e.kind().clone()),
+        Some(IntErrorKind::Zero)
+    );
+    assert_eq!(
+        NonZero::<u8>::from_ascii_radix(b"-1", 10).err().map(|e| e.kind().clone()),
+        Some(IntErrorKind::InvalidDigit)
+    );
+    assert_eq!(
+        NonZero::<i8>::from_ascii_radix(b"-129", 10).err().map(|e| e.kind().clone()),
+        Some(IntErrorKind::NegOverflow)
+    );
+    assert_eq!(
+        NonZero::<u8>::from_ascii_radix(b"257", 10).err().map(|e| e.kind().clone()),
+        Some(IntErrorKind::PosOverflow)
+    );
+
+    assert_eq!(
+        NonZero::<u8>::from_ascii_radix(b"Z", 10).err().map(|e| e.kind().clone()),
+        Some(IntErrorKind::InvalidDigit)
+    );
+    assert_eq!(
+        NonZero::<u8>::from_ascii_radix(b"_", 2).err().map(|e| e.kind().clone()),
+        Some(IntErrorKind::InvalidDigit)
+    );
+}
+
+#[test]
+fn test_from_ascii() {
+    assert_eq!(NonZero::<u8>::from_ascii(b"123"), Ok(NonZero::new(123).unwrap()));
+    assert_eq!(
+        NonZero::<u8>::from_ascii(b"0").err().map(|e| e.kind().clone()),
+        Some(IntErrorKind::Zero)
+    );
+    assert_eq!(
+        NonZero::<u8>::from_ascii(b"-1").err().map(|e| e.kind().clone()),
+        Some(IntErrorKind::InvalidDigit)
+    );
+    assert_eq!(
+        NonZero::<i8>::from_ascii(b"-129").err().map(|e| e.kind().clone()),
+        Some(IntErrorKind::NegOverflow)
+    );
+    assert_eq!(
+        NonZero::<u8>::from_ascii(b"257").err().map(|e| e.kind().clone()),
+        Some(IntErrorKind::PosOverflow)
+    );
+}
+
+#[test]
 fn test_from_str_radix() {
     assert_eq!(NonZero::<u8>::from_str_radix("123", 10), Ok(NonZero::new(123).unwrap()));
     assert_eq!(NonZero::<u8>::from_str_radix("1001", 2), Ok(NonZero::new(9).unwrap()));


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

- Tracking issue: rust-lang/rust#134821

This pull request adds `from_ascii` and `from_ascii_radix` methods to `NonZero<T>` that parses a non-zero integer from an ASCII-byte slice (`&[u8]`) with decimal digits or digits in a given base.

When using the combination of `int::from_ascii` or `int::from_ascii_radix` and `NonZero::<T>::new`, [`IntErrorKind::Zero`](https://doc.rust-lang.org/core/num/enum.IntErrorKind.html#variant.Zero) cannot be returned as an error.

`NonZero::<T>::from_str_radix` and `NonZero::<T>::from_str` require a string (`&str`) as a parameter.

```rust
// Cannot return `IntErrorKind::Zero` as an error.
assert_eq!(NonZero::new(u8::from_ascii(b"0").unwrap()), None);

// Can return `IntErrorKind::Zero` as an error.
let err = NonZero::<u8>::from_ascii(b"0").unwrap_err();
assert_eq!(err.kind(), &IntErrorKind::Zero);
```

See also rust-lang/rust#152193