### PR TITLE
[EXPERIMENT] Change query `erase_and_anonymize_regions_ty` from `anon` to `no_hash`

### DIFF
--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -783,9 +783,9 @@ rustc_queries! {
         // is not a good candidates for "replay" because it is essentially a
         // pure function of its input (and hence the expectation is that
         // no caller would be green **apart** from just these
-        // queries). Making it anonymous avoids hashing the result, which
+        // queries). Making it no_hash avoids hashing the result, which
         // may save a bit of time.
-        anon
+        no_hash
         desc { "erasing regions from `{}`", ty }
     }
 


### PR DESCRIPTION
Based on its comment, this query's use of `anon` might be better off as `no_hash`.

- [Zulip thread](https://rust-lang.zulipchat.com/#narrow/channel/182449-t-compiler.2Fhelp/topic/What.20exactly.20is.20an.20.60anon.60.20query.3F/near/572501238)
- PR that made this query `anon`: https://github.com/rust-lang/rust/pull/45364

r? ghost