### PR TITLE
Validate source snippet when format input is raw string

### DIFF
--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -314,12 +314,15 @@ impl<'input> Parser<'input> {
                 let prefix_len = nr_hashes + 2; // r + hashes + opening "
                 let suffix_len = nr_hashes + 1; // closing " + hashes
                 let snippet_bytes = snippet.as_bytes();
+                let content_end = snippet.len() - suffix_len;
                 if snippet.len() >= prefix_len + suffix_len // is sufficiently long
                     && snippet_bytes[0] == b'r'
                     && snippet_bytes[1..1 + nr_hashes].iter().all(|&c| c == b'#')
                     && snippet_bytes[1 + nr_hashes] == b'"'
+                    && snippet_bytes[content_end] == b'"'
+                    && snippet_bytes[content_end + 1..].iter().all(|&c| c == b'#')
                 {
-                    let snippet_without_quotes = &snippet[prefix_len..snippet.len() - suffix_len];
+                    let snippet_without_quotes = &snippet[prefix_len..content_end];
                     let input_without_newline =
                         if appended_newline { &input[..input.len() - 1] } else { input };
                     if snippet_without_quotes == input_without_newline {

--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -307,24 +307,46 @@ impl<'input> Parser<'input> {
 
         let (is_source_literal, end_of_snippet, pre_input_vec) = if let Some(snippet) = snippet {
             if let Some(nr_hashes) = style {
-                // snippet is a raw string, which starts with 'r', a number of hashes, and a quote
-                // and ends with a quote and the same number of hashes
-                (true, snippet.len() - nr_hashes - 1, vec![])
+                // snippet is a raw string
+
+                // validate snippet because a proc macro may have
+                // respanned it to something completely different (fixes #114865)
+                let prefix_len = nr_hashes + 2; // r + hashes + opening "
+                let suffix_len = nr_hashes + 1; // closing " + hashes
+                let snippet_bytes = snippet.as_bytes();
+                if snippet.len() >= prefix_len + suffix_len // is sufficiently long
+                    && snippet_bytes[0] == b'r'
+                    && snippet_bytes[1..1 + nr_hashes].iter().all(|&c| c == b'#')
+                    && snippet_bytes[1 + nr_hashes] == b'"'
+                {
+                    let snippet_without_quotes = &snippet[prefix_len..snippet.len() - suffix_len];
+                    let input_without_newline =
+                        if appended_newline { &input[..input.len() - 1] } else { input };
+                    if snippet_without_quotes == input_without_newline {
+                        (true, snippet.len() - suffix_len, vec![])
+                    } else {
+                        (false, snippet.len(), vec![])
+                    }
+                } else {
+                    (false, snippet.len(), vec![])
+                }
             } else {
                 // snippet is not a raw string
                 if snippet.starts_with('"') {
                     // snippet looks like an ordinary string literal
                     // check whether it is the escaped version of input
-                    let without_quotes = &snippet[1..snippet.len() - 1];
+                    let snippet_without_quotes = &snippet[1..snippet.len() - 1];
                     let (mut ok, mut vec) = (true, vec![]);
                     let mut chars = input.chars();
-                    rustc_literal_escaper::unescape_str(without_quotes, |range, res| match res {
-                        Ok(ch) if ok && chars.next().is_some_and(|c| ch == c) => {
-                            vec.push((range, ch));
-                        }
-                        _ => {
-                            ok = false;
-                            vec = vec![];
+                    rustc_literal_escaper::unescape_str(snippet_without_quotes, |range, res| {
+                        match res {
+                            Ok(ch) if ok && chars.next().is_some_and(|c| ch == c) => {
+                                vec.push((range, ch));
+                            }
+                            _ => {
+                                ok = false;
+                                vec = vec![];
+                            }
                         }
                     });
                     let end = vec.last().map(|(r, _)| r.end).unwrap_or(0);

--- a/tests/ui/proc-macro/auxiliary/ice-wrong-span-114865.rs
+++ b/tests/ui/proc-macro/auxiliary/ice-wrong-span-114865.rs
@@ -35,7 +35,8 @@ pub fn foo2(input: TokenStream) -> TokenStream {
 
 
 /// Same as `foo` but respans to a combination of two consecutive tokens.
-/// This makes possible scenarios where
+/// This makes possible scenarios where you can land on the second token
+/// which is a multi-byte char
 #[proc_macro]
 pub fn foo3(input: TokenStream) -> TokenStream {
     let mut iter = input.into_iter();

--- a/tests/ui/proc-macro/auxiliary/ice-wrong-span-114865.rs
+++ b/tests/ui/proc-macro/auxiliary/ice-wrong-span-114865.rs
@@ -1,0 +1,32 @@
+extern crate proc_macro;
+
+use proc_macro::{Delimiter, Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
+use std::iter::FromIterator;
+
+/// Expands to a call to `println!` having a format string as its argument
+/// but with the format string's span set to that of the proc macro's input token
+#[proc_macro]
+pub fn foo(input: TokenStream) -> TokenStream {
+    let token = input.into_iter().next().unwrap();
+    let mut lit: Literal = r#"r"{}""#.parse().unwrap();
+    lit.set_span(token.span());
+    FromIterator::<TokenTree>::from_iter([
+        Ident::new("println", Span::mixed_site()).into(),
+        Punct::new('!', Spacing::Alone).into(),
+        Group::new(Delimiter::Parenthesis, TokenTree::from(lit).into()).into(),
+    ])
+}
+
+
+/// Same as `foo` but with the format string containing multiple `#`s
+#[proc_macro]
+pub fn foo2(input: TokenStream) -> TokenStream {
+    let token = input.into_iter().next().unwrap();
+    let mut lit: Literal = r###"r##"{}"##"###.parse().unwrap();
+    lit.set_span(token.span());
+    FromIterator::<TokenTree>::from_iter([
+        Ident::new("println", Span::mixed_site()).into(),
+        Punct::new('!', Spacing::Alone).into(),
+        Group::new(Delimiter::Parenthesis, TokenTree::from(lit).into()).into(),
+    ])
+}

--- a/tests/ui/proc-macro/auxiliary/ice-wrong-span-114865.rs
+++ b/tests/ui/proc-macro/auxiliary/ice-wrong-span-114865.rs
@@ -1,3 +1,5 @@
+#![feature(proc_macro_span)]
+
 extern crate proc_macro;
 
 use proc_macro::{Delimiter, Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
@@ -24,6 +26,24 @@ pub fn foo2(input: TokenStream) -> TokenStream {
     let token = input.into_iter().next().unwrap();
     let mut lit: Literal = r###"r##"{}"##"###.parse().unwrap();
     lit.set_span(token.span());
+    FromIterator::<TokenTree>::from_iter([
+        Ident::new("println", Span::mixed_site()).into(),
+        Punct::new('!', Spacing::Alone).into(),
+        Group::new(Delimiter::Parenthesis, TokenTree::from(lit).into()).into(),
+    ])
+}
+
+
+/// Same as `foo` but respans to a combination of two consecutive tokens.
+/// This makes possible scenarios where
+#[proc_macro]
+pub fn foo3(input: TokenStream) -> TokenStream {
+    let mut iter = input.into_iter();
+    let first = iter.next().unwrap();
+    let second = iter.next().unwrap();
+    let joined_span = first.span().join(second.span()).unwrap();
+    let mut lit: Literal = r#"r"{}""#.parse().unwrap();
+    lit.set_span(joined_span);
     FromIterator::<TokenTree>::from_iter([
         Ident::new("println", Span::mixed_site()).into(),
         Punct::new('!', Spacing::Alone).into(),

--- a/tests/ui/proc-macro/auxiliary/ice-wrong-span-114865.rs
+++ b/tests/ui/proc-macro/auxiliary/ice-wrong-span-114865.rs
@@ -51,3 +51,20 @@ pub fn foo3(input: TokenStream) -> TokenStream {
         Group::new(Delimiter::Parenthesis, TokenTree::from(lit).into()).into(),
     ])
 }
+
+
+/// Same as `foo3` but with hashes in the raw string literal
+#[proc_macro]
+pub fn foo4(input: TokenStream) -> TokenStream {
+    let mut iter = input.into_iter();
+    let first = iter.next().unwrap();
+    let second = iter.next().unwrap();
+    let joined_span = first.span().join(second.span()).unwrap();
+    let mut lit: Literal = r###"r##"{}"##"###.parse().unwrap();
+    lit.set_span(joined_span);
+    FromIterator::<TokenTree>::from_iter([
+        Ident::new("println", Span::mixed_site()).into(),
+        Punct::new('!', Spacing::Alone).into(),
+        Group::new(Delimiter::Parenthesis, TokenTree::from(lit).into()).into(),
+    ])
+}

--- a/tests/ui/proc-macro/auxiliary/ice-wrong-span-114865.rs
+++ b/tests/ui/proc-macro/auxiliary/ice-wrong-span-114865.rs
@@ -5,66 +5,44 @@ extern crate proc_macro;
 use proc_macro::{Delimiter, Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
 use std::iter::FromIterator;
 
-/// Expands to a call to `println!` having a format string as its argument
-/// but with the format string's span set to that of the proc macro's input token
+/// Builds a `println!(<fmt_str>)` token stream with the given span on the format string literal.
+fn make_println(fmt_str: &str, span: Span) -> TokenStream {
+    let mut lit: Literal = fmt_str.parse().unwrap();
+    lit.set_span(span);
+    FromIterator::<TokenTree>::from_iter([
+        Ident::new("println", Span::mixed_site()).into(),
+        Punct::new('!', Spacing::Alone).into(),
+        Group::new(Delimiter::Parenthesis, TokenTree::from(lit).into()).into(),
+    ])
+}
+
+/// Expands to `println!(r"{}")` with the span of the first input token.
 #[proc_macro]
 pub fn foo(input: TokenStream) -> TokenStream {
-    let token = input.into_iter().next().unwrap();
-    let mut lit: Literal = r#"r"{}""#.parse().unwrap();
-    lit.set_span(token.span());
-    FromIterator::<TokenTree>::from_iter([
-        Ident::new("println", Span::mixed_site()).into(),
-        Punct::new('!', Spacing::Alone).into(),
-        Group::new(Delimiter::Parenthesis, TokenTree::from(lit).into()).into(),
-    ])
+    let span = input.into_iter().next().unwrap().span();
+    make_println(r#"r"{}""#, span)
 }
 
-
-/// Same as `foo` but with the format string containing multiple `#`s
+/// Same as `foo` but with hashes: expands to `println!(r##"{}"##)`.
 #[proc_macro]
 pub fn foo2(input: TokenStream) -> TokenStream {
-    let token = input.into_iter().next().unwrap();
-    let mut lit: Literal = r###"r##"{}"##"###.parse().unwrap();
-    lit.set_span(token.span());
-    FromIterator::<TokenTree>::from_iter([
-        Ident::new("println", Span::mixed_site()).into(),
-        Punct::new('!', Spacing::Alone).into(),
-        Group::new(Delimiter::Parenthesis, TokenTree::from(lit).into()).into(),
-    ])
+    let span = input.into_iter().next().unwrap().span();
+    make_println(r###"r##"{}"##"###, span)
 }
 
-
-/// Same as `foo` but respans to a combination of two consecutive tokens.
-/// This makes possible scenarios where you can land on the second token
-/// which is a multi-byte char
+/// Expands to `println!(r"{}")` with a span joining two input tokens,
+/// creating a span whose source text may not be a valid raw string.
 #[proc_macro]
 pub fn foo3(input: TokenStream) -> TokenStream {
     let mut iter = input.into_iter();
-    let first = iter.next().unwrap();
-    let second = iter.next().unwrap();
-    let joined_span = first.span().join(second.span()).unwrap();
-    let mut lit: Literal = r#"r"{}""#.parse().unwrap();
-    lit.set_span(joined_span);
-    FromIterator::<TokenTree>::from_iter([
-        Ident::new("println", Span::mixed_site()).into(),
-        Punct::new('!', Spacing::Alone).into(),
-        Group::new(Delimiter::Parenthesis, TokenTree::from(lit).into()).into(),
-    ])
+    let span = iter.next().unwrap().span().join(iter.next().unwrap().span()).unwrap();
+    make_println(r#"r"{}""#, span)
 }
 
-
-/// Same as `foo3` but with hashes in the raw string literal
+/// Same as `foo3` but with hashes: expands to `println!(r##"{}"##)`.
 #[proc_macro]
 pub fn foo4(input: TokenStream) -> TokenStream {
     let mut iter = input.into_iter();
-    let first = iter.next().unwrap();
-    let second = iter.next().unwrap();
-    let joined_span = first.span().join(second.span()).unwrap();
-    let mut lit: Literal = r###"r##"{}"##"###.parse().unwrap();
-    lit.set_span(joined_span);
-    FromIterator::<TokenTree>::from_iter([
-        Ident::new("println", Span::mixed_site()).into(),
-        Punct::new('!', Spacing::Alone).into(),
-        Group::new(Delimiter::Parenthesis, TokenTree::from(lit).into()).into(),
-    ])
+    let span = iter.next().unwrap().span().join(iter.next().unwrap().span()).unwrap();
+    make_println(r###"r##"{}"##"###, span)
 }

--- a/tests/ui/proc-macro/ice-wrong-span-114865.rs
+++ b/tests/ui/proc-macro/ice-wrong-span-114865.rs
@@ -1,0 +1,21 @@
+// Regression test for ICE https://github.com/rust-lang/rust/issues/114865
+
+// Tests that we do not ICE when a proc macro expands
+// to a string formatting macro (like println!) and respans
+// this formatting macro's arg to that of its own input which
+// happens to be a multi-byte string (see the auxiliary file
+// ice-wrong-span-114865.rs).
+
+//@ proc-macro: ice-wrong-span-114865.rs
+
+extern crate ice_wrong_span_114865;
+
+use ice_wrong_span_114865::{foo, foo2};
+
+fn main() {
+    foo!("字"); //~ ERROR 1 positional argument in format string, but no arguments were given
+    foo!("r字字"); //~ ERROR 1 positional argument in format string, but no arguments were given
+
+    foo2!("字"); //~ ERROR 1 positional argument in format string, but no arguments were given
+    foo2!("r字字"); //~ ERROR 1 positional argument in format string, but no arguments were given
+}

--- a/tests/ui/proc-macro/ice-wrong-span-114865.rs
+++ b/tests/ui/proc-macro/ice-wrong-span-114865.rs
@@ -10,7 +10,7 @@
 
 extern crate ice_wrong_span_114865;
 
-use ice_wrong_span_114865::{foo, foo2, foo3};
+use ice_wrong_span_114865::{foo, foo2, foo3, foo4};
 
 fn main() {
     foo!("字"); //~ ERROR 1 positional argument in format string, but no arguments were given
@@ -20,4 +20,5 @@ fn main() {
     foo2!("r字字"); //~ ERROR 1 positional argument in format string, but no arguments were given
 
     foo3!(r"abc" 字); //~ ERROR 1 positional argument in format string, but no arguments were given
+    foo4!(r##"abcd"## 字); //~ ERROR 1 positional argument in format string, but no arguments were given
 }

--- a/tests/ui/proc-macro/ice-wrong-span-114865.rs
+++ b/tests/ui/proc-macro/ice-wrong-span-114865.rs
@@ -10,7 +10,7 @@
 
 extern crate ice_wrong_span_114865;
 
-use ice_wrong_span_114865::{foo, foo2};
+use ice_wrong_span_114865::{foo, foo2, foo3};
 
 fn main() {
     foo!("字"); //~ ERROR 1 positional argument in format string, but no arguments were given
@@ -18,4 +18,6 @@ fn main() {
 
     foo2!("字"); //~ ERROR 1 positional argument in format string, but no arguments were given
     foo2!("r字字"); //~ ERROR 1 positional argument in format string, but no arguments were given
+
+    foo3!(r"abc" 字); //~ ERROR 1 positional argument in format string, but no arguments were given
 }

--- a/tests/ui/proc-macro/ice-wrong-span-114865.rs
+++ b/tests/ui/proc-macro/ice-wrong-span-114865.rs
@@ -20,5 +20,6 @@ fn main() {
     foo2!("r字字"); //~ ERROR 1 positional argument in format string, but no arguments were given
 
     foo3!(r"abc" 字); //~ ERROR 1 positional argument in format string, but no arguments were given
+
     foo4!(r##"abcd"## 字); //~ ERROR 1 positional argument in format string, but no arguments were given
 }

--- a/tests/ui/proc-macro/ice-wrong-span-114865.stderr
+++ b/tests/ui/proc-macro/ice-wrong-span-114865.stderr
@@ -1,0 +1,26 @@
+error: 1 positional argument in format string, but no arguments were given
+  --> $DIR/ice-wrong-span-114865.rs:16:10
+   |
+LL |     foo!("字");
+   |          ^^^^
+
+error: 1 positional argument in format string, but no arguments were given
+  --> $DIR/ice-wrong-span-114865.rs:17:10
+   |
+LL |     foo!("r字字");
+   |          ^^^^^^^
+
+error: 1 positional argument in format string, but no arguments were given
+  --> $DIR/ice-wrong-span-114865.rs:19:11
+   |
+LL |     foo2!("字");
+   |           ^^^^
+
+error: 1 positional argument in format string, but no arguments were given
+  --> $DIR/ice-wrong-span-114865.rs:20:11
+   |
+LL |     foo2!("r字字");
+   |           ^^^^^^^
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/proc-macro/ice-wrong-span-114865.stderr
+++ b/tests/ui/proc-macro/ice-wrong-span-114865.stderr
@@ -29,7 +29,7 @@ LL |     foo3!(r"abc" 字);
    |           ^^^^^^^^^
 
 error: 1 positional argument in format string, but no arguments were given
-  --> $DIR/ice-wrong-span-114865.rs:23:11
+  --> $DIR/ice-wrong-span-114865.rs:24:11
    |
 LL |     foo4!(r##"abcd"## 字);
    |           ^^^^^^^^^^^^^^

--- a/tests/ui/proc-macro/ice-wrong-span-114865.stderr
+++ b/tests/ui/proc-macro/ice-wrong-span-114865.stderr
@@ -22,5 +22,11 @@ error: 1 positional argument in format string, but no arguments were given
 LL |     foo2!("r字字");
    |           ^^^^^^^
 
-error: aborting due to 4 previous errors
+error: 1 positional argument in format string, but no arguments were given
+  --> $DIR/ice-wrong-span-114865.rs:22:11
+   |
+LL |     foo3!(r"abc" 字);
+   |           ^^^^^^^^^
+
+error: aborting due to 5 previous errors
 

--- a/tests/ui/proc-macro/ice-wrong-span-114865.stderr
+++ b/tests/ui/proc-macro/ice-wrong-span-114865.stderr
@@ -28,5 +28,11 @@ error: 1 positional argument in format string, but no arguments were given
 LL |     foo3!(r"abc" 字);
    |           ^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error: 1 positional argument in format string, but no arguments were given
+  --> $DIR/ice-wrong-span-114865.rs:23:11
+   |
+LL |     foo4!(r##"abcd"## 字);
+   |           ^^^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/152277)*
<!-- homu-ignore:end -->

Fixes rust-lang/rust#114865

The issue occurred because the user's proc macro respanned the format arg to an unrelated multi-byte string and we ICE'd by landing in the middle of a multi-byte char.

This PR adds validation that prevents the parser from trying to walk such obviously wrong snippets. Such validation already existed for non-raw strings. This PR adds it for raw strings as well.

