### PR TITLE
Fix const normalization for generic const items with trait assoc consts

### DIFF
--- a/tests/ui/generic-const-items/type-const-nested-assoc-const.rs
+++ b/tests/ui/generic-const-items/type-const-nested-assoc-const.rs
@@ -1,0 +1,18 @@
+//@ check-pass
+
+#![feature(generic_const_items, min_generic_const_args)]
+#![allow(incomplete_features)]
+
+type const CT<T: ?Sized>: usize = { <T as Trait>::N };
+
+trait Trait {
+    type const N: usize;
+}
+
+impl<T: ?Sized> Trait for T {
+    type const N:usize = 0;
+}
+
+fn f(_x: [(); CT::<()>]) {}
+
+fn main() {}


### PR DESCRIPTION
In `try_fold_free_or_assoc`, the check for whether the normalization result needs further normalization only considered types, not constants. This caused generic const items marked with `#[type_const]` that reference trait associated consts to only partially normalize—the outer const would be expanded, but the inner associated const would remain unevaluated, resulting in an ICE in borrowck.

close rust-lang/rust#151647

r? BoxyUwU
(Based on git blame)