### PR TITLE
borrowck: suggest `&mut *x` for pattern reborrows

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -354,14 +354,71 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                         self.infcx.tcx.sess.source_map().span_to_snippet(source_info.span)
                     {
                         if snippet.starts_with("&mut ") {
-                            // We don't have access to the HIR to get accurate spans, but we can
-                            // give a best effort structured suggestion.
-                            err.span_suggestion_verbose(
-                                source_info.span.with_hi(source_info.span.lo() + BytePos(5)),
-                                "if there is only one mutable reborrow, remove the `&mut`",
-                                "",
-                                Applicability::MaybeIncorrect,
-                            );
+                            // In calls, `&mut &mut T` may be deref-coerced to `&mut T`, and
+                            // removing the extra `&mut` is the most direct suggestion. But for
+                            // pattern-matching expressions (`match`, `if let`, `while let`), that
+                            // can easily turn into a move, so prefer suggesting an explicit
+                            // reborrow via `&mut *x` instead.
+                            let mut in_pat_scrutinee = false;
+                            let mut is_deref_coerced = false;
+                            if let Some(expr) = self.find_expr(source_info.span) {
+                                let tcx = self.infcx.tcx;
+                                let span = expr.span.source_callsite();
+                                for (_, node) in tcx.hir_parent_iter(expr.hir_id) {
+                                    if let Node::Expr(parent_expr) = node {
+                                        match parent_expr.kind {
+                                            ExprKind::Match(scrutinee, ..)
+                                                if scrutinee
+                                                    .span
+                                                    .source_callsite()
+                                                    .contains(span) =>
+                                            {
+                                                in_pat_scrutinee = true;
+                                                break;
+                                            }
+                                            ExprKind::Let(let_expr)
+                                                if let_expr
+                                                    .init
+                                                    .span
+                                                    .source_callsite()
+                                                    .contains(span) =>
+                                            {
+                                                in_pat_scrutinee = true;
+                                                break;
+                                            }
+                                            _ => {}
+                                        }
+                                    }
+                                }
+
+                                let typeck = tcx.typeck(expr.hir_id.owner.def_id);
+                                is_deref_coerced =
+                                    typeck.expr_adjustments(expr).iter().any(|adj| {
+                                        matches!(adj.kind, ty::adjustment::Adjust::Deref(_))
+                                    });
+                            }
+
+                            if in_pat_scrutinee {
+                                // Best-effort structured suggestion: insert `*` after `&mut `.
+                                err.span_suggestion_verbose(
+                                    source_info
+                                        .span
+                                        .with_lo(source_info.span.lo() + BytePos(5))
+                                        .shrink_to_lo(),
+                                    "to reborrow the mutable reference, add `*`",
+                                    "*",
+                                    Applicability::MaybeIncorrect,
+                                );
+                            } else if is_deref_coerced {
+                                // We don't have access to the HIR to get accurate spans, but we
+                                // can give a best effort structured suggestion.
+                                err.span_suggestion_verbose(
+                                    source_info.span.with_hi(source_info.span.lo() + BytePos(5)),
+                                    "if there is only one mutable reborrow, remove the `&mut`",
+                                    "",
+                                    Applicability::MaybeIncorrect,
+                                );
+                            }
                         } else {
                             // This can occur with things like `(&mut self).foo()`.
                             err.span_help(source_info.span, "try removing `&mut` here");

--- a/tests/ui/borrowck/mut-borrow-of-mut-ref.fixed
+++ b/tests/ui/borrowck/mut-borrow-of-mut-ref.fixed
@@ -2,19 +2,19 @@
 //@ run-rustfix
 #![crate_type = "rlib"]
 
-pub fn f(b: &mut i32) {
+pub fn f(mut b: &mut i32) {
     //~^ ERROR: cannot borrow
     //~| NOTE: not mutable
     //~| NOTE: the binding is already a mutable borrow
     //~| HELP: consider making the binding mutable if you need to reborrow multiple times
-    h(&mut b);
+    h(b);
     //~^ NOTE: cannot borrow as mutable
     //~| HELP: if there is only one mutable reborrow, remove the `&mut`
     g(&mut &mut b);
     //~^ NOTE: cannot borrow as mutable
 }
 
-pub fn g(b: &mut i32) { //~ NOTE: the binding is already a mutable borrow
+pub fn g(mut b: &mut i32) { //~ NOTE: the binding is already a mutable borrow
     //~^ HELP: consider making the binding mutable if you need to reborrow multiple times
     h(&mut &mut b);
     //~^ ERROR: cannot borrow
@@ -31,7 +31,7 @@ impl Foo for &mut String {
     fn bar(&mut self) {}
 }
 
-pub fn baz(f: &mut String) { //~ HELP consider making the binding mutable
+pub fn baz(mut f: &mut String) { //~ HELP consider making the binding mutable
     f.bar(); //~ ERROR cannot borrow `f` as mutable, as it is not declared as mutable
     //~^ NOTE cannot borrow as mutable
 }

--- a/tests/ui/borrowck/mut-borrow-of-mut-ref.stderr
+++ b/tests/ui/borrowck/mut-borrow-of-mut-ref.stderr
@@ -1,5 +1,5 @@
 error[E0596]: cannot borrow `b` as mutable, as it is not declared as mutable
-  --> $DIR/mut-borrow-of-mut-ref.rs:4:10
+  --> $DIR/mut-borrow-of-mut-ref.rs:5:10
    |
 LL | pub fn f(b: &mut i32) {
    |          ^ not mutable
@@ -11,7 +11,7 @@ LL |     g(&mut &mut b);
    |            ------ cannot borrow as mutable
    |
 note: the binding is already a mutable borrow
-  --> $DIR/mut-borrow-of-mut-ref.rs:4:13
+  --> $DIR/mut-borrow-of-mut-ref.rs:5:13
    |
 LL | pub fn f(b: &mut i32) {
    |             ^^^^^^^^
@@ -23,11 +23,6 @@ help: if there is only one mutable reborrow, remove the `&mut`
    |
 LL -     h(&mut b);
 LL +     h(b);
-   |
-help: if there is only one mutable reborrow, remove the `&mut`
-   |
-LL -     g(&mut &mut b);
-LL +     g(&mut b);
    |
 
 error[E0596]: cannot borrow `b` as mutable, as it is not declared as mutable
@@ -45,14 +40,9 @@ help: consider making the binding mutable if you need to reborrow multiple times
    |
 LL | pub fn g(mut b: &mut i32) {
    |          +++
-help: if there is only one mutable reborrow, remove the `&mut`
-   |
-LL -     h(&mut &mut b);
-LL +     h(&mut b);
-   |
 
 error[E0596]: cannot borrow `f` as mutable, as it is not declared as mutable
-  --> $DIR/mut-borrow-of-mut-ref.rs:36:5
+  --> $DIR/mut-borrow-of-mut-ref.rs:35:5
    |
 LL |     f.bar();
    |     ^ cannot borrow as mutable

--- a/tests/ui/borrowck/reborrow-in-match-suggest-deref.fixed
+++ b/tests/ui/borrowck/reborrow-in-match-suggest-deref.fixed
@@ -1,0 +1,23 @@
+// Regression test for #81059.
+// edition:2024
+//@ run-rustfix
+
+#![allow(unused)]
+
+fn test(mut outer: &mut Option<i32>) {
+    //~^ NOTE: the binding is already a mutable borrow
+    //~| HELP: consider making the binding mutable if you need to reborrow multiple times
+    match (&mut *outer, 23) {
+        //~^ ERROR: cannot borrow `outer` as mutable, as it is not declared as mutable
+        //~| NOTE: cannot borrow as mutable
+        //~| HELP: to reborrow the mutable reference, add `*`
+        (Some(inner), _) => {
+            *inner = 17;
+        }
+        _ => {
+            *outer = Some(2);
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/borrowck/reborrow-in-match-suggest-deref.rs
+++ b/tests/ui/borrowck/reborrow-in-match-suggest-deref.rs
@@ -1,0 +1,23 @@
+// Regression test for #81059.
+// edition:2024
+//@ run-rustfix
+
+#![allow(unused)]
+
+fn test(outer: &mut Option<i32>) {
+    //~^ NOTE: the binding is already a mutable borrow
+    //~| HELP: consider making the binding mutable if you need to reborrow multiple times
+    match (&mut outer, 23) {
+        //~^ ERROR: cannot borrow `outer` as mutable, as it is not declared as mutable
+        //~| NOTE: cannot borrow as mutable
+        //~| HELP: to reborrow the mutable reference, add `*`
+        (Some(inner), _) => {
+            *inner = 17;
+        }
+        _ => {
+            *outer = Some(2);
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/borrowck/reborrow-in-match-suggest-deref.stderr
+++ b/tests/ui/borrowck/reborrow-in-match-suggest-deref.stderr
@@ -1,0 +1,23 @@
+error[E0596]: cannot borrow `outer` as mutable, as it is not declared as mutable
+  --> $DIR/reborrow-in-match-suggest-deref.rs:10:12
+   |
+LL |     match (&mut outer, 23) {
+   |            ^^^^^^^^^^ cannot borrow as mutable
+   |
+note: the binding is already a mutable borrow
+  --> $DIR/reborrow-in-match-suggest-deref.rs:7:16
+   |
+LL | fn test(outer: &mut Option<i32>) {
+   |                ^^^^^^^^^^^^^^^^
+help: consider making the binding mutable if you need to reborrow multiple times
+   |
+LL | fn test(mut outer: &mut Option<i32>) {
+   |         +++
+help: to reborrow the mutable reference, add `*`
+   |
+LL |     match (&mut *outer, 23) {
+   |                 +
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0596`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Fixes rust-lang/rust#81059
r? @estebank as you should have some context here, but feel free to re-assign if you don't have time to review right now.