### PR TITLE
Also duplicate `#[expect]` attribute in `#[derive]`-ed code

### DIFF
--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -540,6 +540,7 @@ impl<'a> TraitDef<'a> {
                         .filter(|a| {
                             a.has_any_name(&[
                                 sym::allow,
+                                sym::expect,
                                 sym::warn,
                                 sym::deny,
                                 sym::forbid,

--- a/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553-2.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553-2.rs
@@ -1,0 +1,14 @@
+// Make sure that the copied `#[expect]` attr in the derived code does not trigger an unfulfilled
+// expectation as it's linked to the original one which is fulfilled.
+//
+// See <https://github.com/rust-lang/rust/issues/150553#issuecomment-3780810363> for rational.
+
+//@ check-pass
+
+#[expect(non_camel_case_types)]
+#[derive(Debug)]
+pub struct SCREAMING_CASE {
+    pub t_ref: i64,
+}
+
+fn main() {}

--- a/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553-3.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553-3.rs
@@ -1,0 +1,14 @@
+// Make sure we produce the unfulfilled expectation lint if neither the struct or the
+// derived code fulfilled it.
+
+//@ check-pass
+
+#[expect(unexpected_cfgs)]
+//~^ WARN this lint expectation is unfulfilled
+//~^^ WARN this lint expectation is unfulfilled
+#[derive(Debug)]
+pub struct MyStruct {
+    pub t_ref: i64,
+}
+
+fn main() {}

--- a/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553-3.stderr
+++ b/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553-3.stderr
@@ -1,0 +1,18 @@
+warning: this lint expectation is unfulfilled
+  --> $DIR/derive-expect-issue-150553-3.rs:6:10
+   |
+LL | #[expect(unexpected_cfgs)]
+   |          ^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(unfulfilled_lint_expectations)]` on by default
+
+warning: this lint expectation is unfulfilled
+  --> $DIR/derive-expect-issue-150553-3.rs:6:10
+   |
+LL | #[expect(unexpected_cfgs)]
+   |          ^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: 2 warnings emitted
+

--- a/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553.rs
@@ -1,0 +1,22 @@
+// Make sure we properly copy the `#[expect]` attr to the derived code and that no
+// unfulfilled expectations are trigerred.
+//
+// See <https://github.com/rust-lang/rust/issues/150553> for rational.
+
+//@ check-pass
+
+#![deny(redundant_lifetimes)]
+
+use std::fmt::Debug;
+
+#[derive(Debug)]
+#[expect(redundant_lifetimes)]
+pub struct RefWrapper<'a, T>
+where
+    'a: 'static,
+    T: Debug,
+{
+    pub t_ref: &'a T,
+}
+
+fn main() {}


### PR DESCRIPTION
This PR updates our derive logic to also duplicate any `#[expect]` attribute in the `#[derive]`-ed code, as we already do for all the other lint attribute (`#[allow]`, `#[warn]`, `#[deny]`, ...).

The original and duplicated attribute share the same attribute id, which due to the way [`check_expectations`](https://github.com/rust-lang/rust/blob/56aaf58ec02b6ac974e8364269fbb33a8a806e28/compiler/rustc_lint/src/expect.rs#L28-L46) is implemented makes the expectation fulfilled if the lint is either trigger in the original code or the derived code.

This was discussed by T-lang in https://github.com/rust-lang/rust/issues/150553#issuecomment-3780810363.

cc @rust-lang/lang-ops (in case you want to do an FCP)
Fixes rust-lang/rust#150553
