### PR TITLE
Format heterogeneous try blocks

### DIFF
--- a/src/tools/rustfmt/tests/source/try_block.rs
+++ b/src/tools/rustfmt/tests/source/try_block.rs
@@ -1,4 +1,5 @@
 // rustfmt-edition: 2018
+#![feature(try_blocks)]
 
 fn main() -> Result<(), !> {
     let _x: Option<_> = try {

--- a/src/tools/rustfmt/tests/source/try_blocks_heterogeneous.rs
+++ b/src/tools/rustfmt/tests/source/try_blocks_heterogeneous.rs
@@ -1,4 +1,5 @@
 // rustfmt-edition: 2018
+#![feature(try_blocks_heterogeneous)]
 
 fn main() -> Result<(), !> {
     let _x = try bikeshed Option<_> {
@@ -23,6 +24,10 @@ fn baz() -> Option<i32> {
     let y = try bikeshed Option<i32> {
         6
     }; // comment
+
+    let x = try /* Invisible comment */ bikeshed Option<()> {};
+    let x = try bikeshed /* Invisible comment */ Option<()> {};
+    let x = try bikeshed Option<()> /* Invisible comment */ {};
 
     let x = try bikeshed Option<i32> { baz()?; baz()?; baz()?; 7 };
 

--- a/src/tools/rustfmt/tests/source/try_blocks_heterogeneous.rs
+++ b/src/tools/rustfmt/tests/source/try_blocks_heterogeneous.rs
@@ -1,0 +1,34 @@
+// rustfmt-edition: 2018
+
+fn main() -> Result<(), !> {
+    let _x = try bikeshed Option<_> {
+        4
+    };
+
+    try bikeshed Result<_, _> {}
+}
+
+fn baz() -> Option<i32> {
+    if (1 == 1) {
+        return try bikeshed Option<i32> {
+            5
+        };
+    }
+
+    // test
+    let x = try bikeshed Option<()> {
+        // try blocks are great
+    };
+
+    let y = try bikeshed Option<i32> {
+        6
+    }; // comment
+
+    let x = try bikeshed Option<i32> { baz()?; baz()?; baz()?; 7 };
+
+    let x = try bikeshed Foo<Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar> { 1 + 1 + 1 };
+
+    let x = try bikeshed Foo<Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar> {};
+
+    return None;
+}

--- a/src/tools/rustfmt/tests/target/try_block.rs
+++ b/src/tools/rustfmt/tests/target/try_block.rs
@@ -1,4 +1,5 @@
 // rustfmt-edition: 2018
+#![feature(try_blocks)]
 
 fn main() -> Result<(), !> {
     let _x: Option<_> = try { 4 };

--- a/src/tools/rustfmt/tests/target/try_blocks_heterogeneous.rs
+++ b/src/tools/rustfmt/tests/target/try_blocks_heterogeneous.rs
@@ -1,4 +1,5 @@
 // rustfmt-edition: 2018
+#![feature(try_blocks_heterogeneous)]
 
 fn main() -> Result<(), !> {
     let _x = try bikeshed Option<_> { 4 };
@@ -17,6 +18,10 @@ fn baz() -> Option<i32> {
     };
 
     let y = try bikeshed Option<i32> { 6 }; // comment
+
+    let x = try /* Invisible comment */ bikeshed Option<()> {};
+    let x = try bikeshed /* Invisible comment */ Option<()> {};
+    let x = try bikeshed Option<()> /* Invisible comment */ {};
 
     let x = try bikeshed Option<i32> {
         baz()?;

--- a/src/tools/rustfmt/tests/target/try_blocks_heterogeneous.rs
+++ b/src/tools/rustfmt/tests/target/try_blocks_heterogeneous.rs
@@ -1,0 +1,36 @@
+// rustfmt-edition: 2018
+
+fn main() -> Result<(), !> {
+    let _x = try bikeshed Option<_> { 4 };
+
+    try bikeshed Result<_, _> {}
+}
+
+fn baz() -> Option<i32> {
+    if (1 == 1) {
+        return try bikeshed Option<i32> { 5 };
+    }
+
+    // test
+    let x = try bikeshed Option<()> {
+        // try blocks are great
+    };
+
+    let y = try bikeshed Option<i32> { 6 }; // comment
+
+    let x = try bikeshed Option<i32> {
+        baz()?;
+        baz()?;
+        baz()?;
+        7
+    };
+
+    let x = try bikeshed Foo<Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar> {
+        1 + 1 + 1
+    };
+
+    let x =
+        try bikeshed Foo<Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar> {};
+
+    return None;
+}


### PR DESCRIPTION
The tracking issue for `try_blocks_heterogeneous` is https://github.com/rust-lang/rust/issues/149488.

This follows the formatting of homogeneous try blocks (feature `try_blocks`) by considering `try bikeshed <type>` to be the equivalent of `try` (in particular a single "token").

An alternative would be to permit breaking between `bikeshed` and `<type>`, but given that those 2 elements are an explicitly temporary part of the syntax, it doesn't seem worth it. There also doesn't seem to be any existing precedent breaking between a keyword and a type. It also doesn't seem to be useful in practice, given that the type itself doesn't break (which is how it works for the return type of closures) and has more chances to dominate the length in case a break is necessary.

Happy to adapt anything in case this formatting is not optimal.

The test is also copied from homogeneous try blocks with 2 additional test cases to demonstrate the behavior with long types.

See [#t-lang > try blocks @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang/topic/try.20blocks/near/572387493) for context.