### PR TITLE
Fix LegacyKeyValueFormat report from docker build

### DIFF
--- a/src/ci/docker/host-aarch64/aarch64-gnu-debug/Dockerfile
+++ b/src/ci/docker/host-aarch64/aarch64-gnu-debug/Dockerfile
@@ -29,19 +29,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-ENV RUSTBUILD_FORCE_CLANG_BASED_TESTS 1
+ENV RUSTBUILD_FORCE_CLANG_BASED_TESTS="1"
 
 # llvm.use-linker conflicts with downloading CI LLVM
-ENV NO_DOWNLOAD_CI_LLVM 1
+ENV NO_DOWNLOAD_CI_LLVM="1"
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
       --build=aarch64-unknown-linux-gnu \
       --enable-debug \
       --enable-lld \
       --set llvm.use-linker=lld \
       --set target.aarch64-unknown-linux-gnu.linker=clang \
       --set target.aarch64-unknown-linux-gnu.cc=clang \
-      --set target.aarch64-unknown-linux-gnu.cxx=clang++
+      --set target.aarch64-unknown-linux-gnu.cxx=clang++"
 
 # This job appears to be checking two separate things:
 # - That we can build the compiler with `--enable-debug`
@@ -52,6 +52,6 @@ ENV RUST_CONFIGURE_ARGS \
 #     Currently we only run the subset of tests with "clang" in their name.
 #   - See also FIXME(#132034)
 
-ENV SCRIPT \
+ENV SCRIPT=" \
   python3 ../x.py --stage 2 build && \
-  python3 ../x.py --stage 2 test tests/run-make tests/run-make-cargo
+  python3 ../x.py --stage 2 test tests/run-make tests/run-make-cargo"

--- a/src/ci/docker/host-aarch64/aarch64-gnu-llvm-20/Dockerfile
+++ b/src/ci/docker/host-aarch64/aarch64-gnu-llvm-20/Dockerfile
@@ -37,20 +37,20 @@ RUN sh /scripts/sccache.sh
 
 # We are disabling CI LLVM since this builder is intentionally using a host
 # LLVM, rather than the typical src/llvm-project LLVM.
-ENV NO_DOWNLOAD_CI_LLVM 1
-ENV EXTERNAL_LLVM 1
+ENV NO_DOWNLOAD_CI_LLVM="1"
+ENV EXTERNAL_LLVM="1"
 
 # Using llvm-link-shared due to libffi issues -- see #34486
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
       --build=aarch64-unknown-linux-gnu \
       --llvm-root=/usr/lib/llvm-20 \
       --enable-llvm-link-shared \
       --set rust.randomize-layout=true \
-      --set rust.thin-lto-import-instr-limit=10
+      --set rust.thin-lto-import-instr-limit=10"
 
 COPY scripts/shared.sh /scripts/
 
 COPY scripts/stage_2_test_set1.sh /scripts/
 COPY scripts/stage_2_test_set2.sh /scripts/
 
-ENV SCRIPT "Must specify DOCKER_SCRIPT for this image"
+ENV SCRIPT="Must specify DOCKER_SCRIPT for this image"

--- a/src/ci/docker/host-aarch64/aarch64-gnu/Dockerfile
+++ b/src/ci/docker/host-aarch64/aarch64-gnu/Dockerfile
@@ -21,10 +21,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
  --build=aarch64-unknown-linux-gnu \
  --enable-sanitizers \
  --enable-profiler \
- --enable-compiler-docs
-ENV SCRIPT python3 ../x.py --stage 2 test && \
-  python3 ../x.py --stage 2 test src/tools/cargo
+ --enable-compiler-docs"
+ENV SCRIP="python3 ../x.py --stage 2 test && \
+  python3 ../x.py --stage 2 test src/tools/cargo"

--- a/src/ci/docker/host-aarch64/dist-aarch64-linux/Dockerfile
+++ b/src/ci/docker/host-aarch64/dist-aarch64-linux/Dockerfile
@@ -76,7 +76,7 @@ ENV HOSTS=aarch64-unknown-linux-gnu
 
 ENV CPATH=/usr/include/aarch64-linux-gnu/:$CPATH
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
       --build=aarch64-unknown-linux-gnu \
       --enable-full-tools \
       --enable-profiler \
@@ -93,12 +93,12 @@ ENV RUST_CONFIGURE_ARGS \
       --set rust.jemalloc \
       --set rust.bootstrap-override-lld=true \
       --set rust.lto=thin \
-      --set rust.codegen-units=1
+      --set rust.codegen-units=1"
 
-ENV SCRIPT python3 ../x.py build --set rust.debug=true opt-dist && \
+ENV SCRIPT="python3 ../x.py build --set rust.debug=true opt-dist && \
       ./build/$HOSTS/stage1-tools-bin/opt-dist linux-ci --  python3 ../x.py dist \
-      --host $HOSTS --target $HOSTS --include-default-paths build-manifest bootstrap
+      --host $HOSTS --target $HOSTS --include-default-paths build-manifest bootstrap"
 
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=clang
-ENV LIBCURL_NO_PKG_CONFIG 1
-ENV DIST_REQUIRE_ALL_TOOLS 1
+ENV LIBCURL_NO_PKG_CONFIG="1"
+ENV DIST_REQUIRE_ALL_TOOLS="1"

--- a/src/ci/docker/host-x86_64/arm-android/Dockerfile
+++ b/src/ci/docker/host-x86_64/arm-android/Dockerfile
@@ -32,9 +32,9 @@ ENV PATH=$PATH:/android/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin
 
 ENV TARGETS=arm-linux-androideabi
 
-ENV RUST_CONFIGURE_ARGS --android-ndk=/android/ndk/
+ENV RUST_CONFIGURE_ARGS="--android-ndk=/android/ndk/"
 
-ENV SCRIPT python3 ../x.py --stage 2 test --host='' --target $TARGETS
+ENV SCRIPT="python3 ../x.py --stage 2 test --host= --target $TARGETS"
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh

--- a/src/ci/docker/host-x86_64/armhf-gnu/Dockerfile
+++ b/src/ci/docker/host-x86_64/armhf-gnu/Dockerfile
@@ -82,7 +82,7 @@ RUN sh /scripts/sccache.sh
 
 COPY static/gitconfig /etc/gitconfig
 
-ENV RUST_CONFIGURE_ARGS --qemu-armhf-rootfs=/tmp/rootfs
-ENV SCRIPT python3 ../x.py --stage 2 test --host='' --target arm-unknown-linux-gnueabihf
+ENV RUST_CONFIGURE_ARGS="--qemu-armhf-rootfs=/tmp/rootfs"
+ENV SCRIPT="python3 ../x.py --stage 2 test --host= --target arm-unknown-linux-gnueabihf"
 
 ENV NO_CHANGE_USER=1

--- a/src/ci/docker/host-x86_64/disabled/dist-aarch64-android/Dockerfile
+++ b/src/ci/docker/host-x86_64/disabled/dist-aarch64-android/Dockerfile
@@ -13,13 +13,13 @@ ENV DEP_Z_ROOT=/android/ndk/arm64-21/sysroot/usr/
 
 ENV HOSTS=aarch64-linux-android
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
       --aarch64-linux-android-ndk=/android/ndk/arm64-21 \
       --disable-rpath \
       --enable-extended \
-      --enable-cargo-openssl-static
+      --enable-cargo-openssl-static"
 
-ENV SCRIPT python3 ../x.py dist --target $HOSTS --host $HOSTS
+ENV SCRIPT="python3 ../x.py dist --target $HOSTS --host $HOSTS"
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh

--- a/src/ci/docker/host-x86_64/disabled/dist-armv7-android/Dockerfile
+++ b/src/ci/docker/host-x86_64/disabled/dist-armv7-android/Dockerfile
@@ -19,11 +19,11 @@ ENV DEP_Z_ROOT=/android/ndk/arm-14/sysroot/usr/
 
 ENV HOSTS=armv7-linux-androideabi
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
       --armv7-linux-androideabi-ndk=/android/ndk/arm \
       --disable-rpath \
       --enable-extended \
-      --enable-cargo-openssl-static
+      --enable-cargo-openssl-static"
 
 # We support api level 14, but api level 21 is required to build llvm. To
 # overcome this problem we use a ndk with api level 21 to build llvm and then
@@ -32,12 +32,12 @@ ENV RUST_CONFIGURE_ARGS \
 # level 14), the default linker behavior is to generate an error, to allow the
 # build to finish we use --warn-unresolved-symbols. Note that the missing
 # symbols does not affect std, only the compiler (llvm) and cargo (openssl).
-ENV SCRIPT \
+ENV SCRIPT=" \
   python3 ../x.py --stage 2 build src/llvm --host $HOSTS --target $HOSTS && \
-  (export RUSTFLAGS="\"-C link-arg=-Wl,--warn-unresolved-symbols\""; \
+  (export RUSTFLAGS=\"-C link-arg=-Wl,--warn-unresolved-symbols\"; \
     rm /android/ndk/arm && \
     ln -s /android/ndk/arm-14 /android/ndk/arm && \
-    python3 ../x.py dist --host $HOSTS --target $HOSTS)
+    python3 ../x.py dist --host $HOSTS --target $HOSTS)"
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh

--- a/src/ci/docker/host-x86_64/disabled/dist-i686-android/Dockerfile
+++ b/src/ci/docker/host-x86_64/disabled/dist-i686-android/Dockerfile
@@ -19,11 +19,11 @@ ENV DEP_Z_ROOT=/android/ndk/x86-14/sysroot/usr/
 
 ENV HOSTS=i686-linux-android
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
       --i686-linux-android-ndk=/android/ndk/x86 \
       --disable-rpath \
       --enable-extended \
-      --enable-cargo-openssl-static
+      --enable-cargo-openssl-static"
 
 # We support api level 14, but api level 21 is required to build llvm. To
 # overcome this problem we use a ndk with api level 21 to build llvm and then
@@ -32,12 +32,12 @@ ENV RUST_CONFIGURE_ARGS \
 # level 14), the default linker behavior is to generate an error, to allow the
 # build to finish we use --warn-unresolved-symbols. Note that the missing
 # symbols does not affect std, only the compiler (llvm) and cargo (openssl).
-ENV SCRIPT \
+ENV SCRIPT=" \
   python3 ../x.py --stage 2 build src/llvm --host $HOSTS --target $HOSTS && \
-  (export RUSTFLAGS="\"-C link-arg=-Wl,--warn-unresolved-symbols\""; \
+  (export RUSTFLAGS=\"-C link-arg=-Wl,--warn-unresolved-symbols\"; \
     rm /android/ndk/x86 && \
     ln -s /android/ndk/x86-14 /android/ndk/x86 && \
-    python3 ../x.py dist --host $HOSTS --target $HOSTS)
+    python3 ../x.py dist --host $HOSTS --target $HOSTS)"
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh

--- a/src/ci/docker/host-x86_64/disabled/dist-m68k-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/disabled/dist-m68k-linux/Dockerfile
@@ -24,5 +24,5 @@ RUN sh /scripts/sccache.sh
 
 ENV HOSTS=m68k-unknown-linux-gnu
 
-ENV RUST_CONFIGURE_ARGS --host=$HOSTS --enable-extended
-ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS
+ENV RUST_CONFIGURE_ARGS="--host=$HOSTS --enable-extended"
+ENV SCRIPT="python3 ../x.py dist --host $HOSTS --target $HOSTS"

--- a/src/ci/docker/host-x86_64/disabled/dist-powerpcspe-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/disabled/dist-powerpcspe-linux/Dockerfile
@@ -23,5 +23,5 @@ RUN sh /scripts/sccache.sh
 
 ENV HOSTS=powerpc-unknown-linux-gnuspe
 
-ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS
+ENV RUST_CONFIGURE_ARGS="--enable-extended --disable-docs"
+ENV SCRIPT="python3 ../x.py dist --host $HOSTS --target $HOSTS"

--- a/src/ci/docker/host-x86_64/disabled/dist-sparc64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/disabled/dist-sparc64-linux/Dockerfile
@@ -23,5 +23,5 @@ RUN sh /scripts/sccache.sh
 
 ENV HOSTS=sparc64-unknown-linux-gnu
 
-ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS
+ENV RUST_CONFIGURE_ARGS="--enable-extended --disable-docs"
+ENV SCRIPT="python3 ../x.py dist --host $HOSTS --target $HOSTS"

--- a/src/ci/docker/host-x86_64/disabled/dist-x86_64-android/Dockerfile
+++ b/src/ci/docker/host-x86_64/disabled/dist-x86_64-android/Dockerfile
@@ -13,13 +13,13 @@ ENV DEP_Z_ROOT=/android/ndk/x86_64-21/sysroot/usr/
 
 ENV HOSTS=x86_64-linux-android
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
       --x86_64-linux-android-ndk=/android/ndk/x86_64-21 \
       --disable-rpath \
       --enable-extended \
-      --enable-cargo-openssl-static
+      --enable-cargo-openssl-static"
 
-ENV SCRIPT python3 ../x.py dist --target $HOSTS --host $HOSTS
+ENV SCRIPT="python3 ../x.py dist --target $HOSTS --host $HOSTS"
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh

--- a/src/ci/docker/host-x86_64/disabled/dist-x86_64-dragonfly/Dockerfile
+++ b/src/ci/docker/host-x86_64/disabled/dist-x86_64-dragonfly/Dockerfile
@@ -33,5 +33,5 @@ ENV \
 
 ENV HOSTS=x86_64-unknown-dragonfly
 
-ENV RUST_CONFIGURE_ARGS --enable-extended
-ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS
+ENV RUST_CONFIGURE_ARGS="--enable-extended"
+ENV SCRIPT="python3 ../x.py dist --host $HOSTS --target $HOSTS"

--- a/src/ci/docker/host-x86_64/disabled/dist-x86_64-haiku/Dockerfile
+++ b/src/ci/docker/host-x86_64/disabled/dist-x86_64-haiku/Dockerfile
@@ -43,10 +43,10 @@ RUN sh /scripts/sccache.sh
 ENV HOST=x86_64-unknown-haiku
 ENV TARGET=target.$HOST
 
-ENV RUST_CONFIGURE_ARGS --disable-jemalloc \
+ENV RUST_CONFIGURE_ARGS="--disable-jemalloc \
   --set=$TARGET.cc=x86_64-unknown-haiku-gcc \
   --set=$TARGET.cxx=x86_64-unknown-haiku-g++ \
-  --set=$TARGET.llvm-config=/bin/llvm-config-haiku
-ENV EXTERNAL_LLVM 1
+  --set=$TARGET.llvm-config=/bin/llvm-config-haiku"
+ENV EXTERNAL_LLVM="1"
 
-ENV SCRIPT python3 ../x.py dist --host=$HOST --target=$HOST
+ENV SCRIPT="python3 ../x.py dist --host=$HOST --target=$HOST"

--- a/src/ci/docker/host-x86_64/disabled/dist-x86_64-redox/Dockerfile
+++ b/src/ci/docker/host-x86_64/disabled/dist-x86_64-redox/Dockerfile
@@ -18,5 +18,5 @@ ENV \
     CC_x86_64_unknown_redox=x86_64-unknown-redox-gcc \
     CXX_x86_64_unknown_redox=x86_64-unknown-redox-g++
 
-ENV RUST_CONFIGURE_ARGS --enable-extended
-ENV SCRIPT python3 ../x.py dist --host='' --target x86_64-unknown-redox
+ENV RUST_CONFIGURE_ARGS="--enable-extended"
+ENV SCRIPT="python3 ../x.py dist --host= --target x86_64-unknown-redox"

--- a/src/ci/docker/host-x86_64/disabled/riscv64gc-gnu/Dockerfile
+++ b/src/ci/docker/host-x86_64/disabled/riscv64gc-gnu/Dockerfile
@@ -91,9 +91,9 @@ RUN sh /scripts/sccache.sh
 # Avoid "fatal: detected dubious ownership in repository at '/checkout'" error
 RUN git config --global --add safe.directory /checkout
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
     --qemu-riscv64-rootfs=/tmp/rootfs \
-    --set target.riscv64gc-unknown-linux-gnu.linker=riscv64-linux-gnu-gcc
-ENV SCRIPT python3 ../x.py --stage 2 test --host='' --target riscv64gc-unknown-linux-gnu
+    --set target.riscv64gc-unknown-linux-gnu.linker=riscv64-linux-gnu-gcc"
+ENV SCRIPT="python3 ../x.py --stage 2 test --host= --target riscv64gc-unknown-linux-gnu"
 
 ENV NO_CHANGE_USER=1

--- a/src/ci/docker/host-x86_64/dist-android/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-android/Dockerfile
@@ -16,15 +16,15 @@ ENV TARGETS=$TARGETS,i686-linux-android
 ENV TARGETS=$TARGETS,aarch64-linux-android
 ENV TARGETS=$TARGETS,x86_64-linux-android
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
       --enable-extended \
       --enable-profiler \
       --android-ndk=/android/ndk/ \
-      --disable-docs
+      --disable-docs"
 
 ENV PATH=$PATH:/android/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin
 
-ENV SCRIPT python3 ../x.py dist --host='' --target $TARGETS
+ENV SCRIPT="python3 ../x.py dist --host= --target $TARGETS"
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh

--- a/src/ci/docker/host-x86_64/dist-arm-linux-gnueabi/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-arm-linux-gnueabi/Dockerfile
@@ -27,9 +27,9 @@ ENV CC_arm_unknown_linux_gnueabi=arm-unknown-linux-gnueabi-gcc \
 
 ENV HOSTS=arm-unknown-linux-gnueabi
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
       --enable-full-tools \
       --disable-docs \
       --enable-sanitizers \
-      --enable-profiler
-ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS
+      --enable-profiler"
+ENV SCRIPT="python3 ../x.py dist --host $HOSTS --target $HOSTS"

--- a/src/ci/docker/host-x86_64/dist-arm-linux-musl/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-arm-linux-musl/Dockerfile
@@ -27,11 +27,11 @@ RUN sh /scripts/sccache.sh
 
 ENV HOSTS=aarch64-unknown-linux-musl
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
       --enable-full-tools \
       --disable-docs \
       --musl-root-aarch64=/usr/local/aarch64-linux-musl \
       --enable-sanitizers \
       --enable-profiler \
-      --set target.aarch64-unknown-linux-musl.crt-static=false
-ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS
+      --set target.aarch64-unknown-linux-musl.crt-static=false"
+ENV SCRIPT="python3 ../x.py dist --host $HOSTS --target $HOSTS"

--- a/src/ci/docker/host-x86_64/dist-armhf-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-armhf-linux/Dockerfile
@@ -25,5 +25,5 @@ ENV CC_arm_unknown_linux_gnueabihf=arm-unknown-linux-gnueabihf-gcc \
 
 ENV HOSTS=arm-unknown-linux-gnueabihf
 
-ENV RUST_CONFIGURE_ARGS --enable-full-tools --enable-profiler --disable-docs
-ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS
+ENV RUST_CONFIGURE_ARGS="--enable-full-tools --enable-profiler --disable-docs"
+ENV SCRIPT="python3 ../x.py dist --host $HOSTS --target $HOSTS"

--- a/src/ci/docker/host-x86_64/dist-armv7-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-armv7-linux/Dockerfile
@@ -25,5 +25,5 @@ ENV CC_armv7_unknown_linux_gnueabihf=armv7-unknown-linux-gnueabihf-gcc \
 
 ENV HOSTS=armv7-unknown-linux-gnueabihf
 
-ENV RUST_CONFIGURE_ARGS --enable-full-tools --enable-profiler --disable-docs
-ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS
+ENV RUST_CONFIGURE_ARGS="--enable-full-tools --enable-profiler --disable-docs"
+ENV SCRIPT="python3 ../x.py dist --host $HOSTS --target $HOSTS"

--- a/src/ci/docker/host-x86_64/dist-i586-gnu-i586-i686-musl/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-i586-gnu-i586-i686-musl/Dockerfile
@@ -57,10 +57,10 @@ RUN ln -s /usr/lib32/libgcc_s.so.1 /musl-i686/lib/
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
       --musl-root-i586=/musl-i586 \
       --musl-root-i686=/musl-i686 \
-      --disable-docs
+      --disable-docs"
 
 # Newer binutils broke things on some vms/distros (i.e., linking against
 # unknown relocs disabled by the following flag), so we need to go out of our
@@ -73,6 +73,6 @@ ENV CFLAGS_i586_unknown_linux_musl=-Wa,-mrelax-relocations=no
 
 ENV TARGETS=i586-unknown-linux-gnu,i686-unknown-linux-musl
 
-ENV SCRIPT \
-      python3 ../x.py --stage 2 test --host='' --target $TARGETS && \
-      python3 ../x.py dist --host='' --target $TARGETS,i586-unknown-linux-musl
+ENV SCRIPT=" \
+      python3 ../x.py --stage 2 test --host= --target $TARGETS && \
+      python3 ../x.py dist --host= --target $TARGETS,i586-unknown-linux-musl"

--- a/src/ci/docker/host-x86_64/dist-i686-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-i686-linux/Dockerfile
@@ -70,15 +70,15 @@ RUN sh /scripts/sccache.sh
 
 ENV HOSTS=i686-unknown-linux-gnu
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
       --enable-full-tools \
       --enable-sanitizers \
       --enable-profiler \
       --set target.i686-unknown-linux-gnu.linker=clang \
       --build=i686-unknown-linux-gnu \
       --set llvm.ninja=false \
-      --set rust.jemalloc
-ENV SCRIPT python3 ../x.py dist --build $HOSTS --host $HOSTS --target $HOSTS
+      --set rust.jemalloc"
+ENV SCRIPT="python3 ../x.py dist --build $HOSTS --host $HOSTS --target $HOSTS"
 ENV CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_LINKER=clang
 
 # This was added when we switched from gcc to clang. It's not clear why this is
@@ -89,17 +89,17 @@ ENV CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_LINKER=clang
 # misaligned stack access.
 #
 # Added in #50200 there's some more logs there
-ENV CFLAGS -mstackrealign
+ENV CFLAGS="-mstackrealign"
 
 # When we build cargo in this container, we don't want it to use the system
 # libcurl, instead it should compile its own.
-ENV LIBCURL_NO_PKG_CONFIG 1
+ENV LIBCURL_NO_PKG_CONFIG="1"
 
 # There was a bad interaction between "old" 32-bit binaries on current 64-bit
 # kernels with selinux enabled, where ASLR mmap would sometimes choose a low
 # address and then block it for being below `vm.mmap_min_addr` -> `EACCES`.
 # This is probably a kernel bug, but setting `ulimit -Hs` works around it.
 # See also `src/ci/run.sh` where this takes effect.
-ENV SET_HARD_RLIMIT_STACK 1
+ENV SET_HARD_RLIMIT_STACK="1"
 
-ENV DIST_REQUIRE_ALL_TOOLS 1
+ENV DIST_REQUIRE_ALL_TOOLS="1"

--- a/src/ci/docker/host-x86_64/dist-loongarch64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-loongarch64-linux/Dockerfile
@@ -45,7 +45,7 @@ ENV TARGETS=$HOSTS
 ENV TARGETS=$TARGETS,loongarch64-unknown-none
 ENV TARGETS=$TARGETS,loongarch64-unknown-none-softfloat
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
       --enable-extended \
       --enable-full-tools \
       --enable-profiler \
@@ -53,6 +53,6 @@ ENV RUST_CONFIGURE_ARGS \
       --disable-docs \
       --set rust.jemalloc \
       --set rust.lto=thin \
-      --set rust.codegen-units=1
+      --set rust.codegen-units=1"
 
-ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $TARGETS
+ENV SCRIPT="python3 ../x.py dist --host $HOSTS --target $TARGETS"

--- a/src/ci/docker/host-x86_64/dist-loongarch64-musl/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-loongarch64-musl/Dockerfile
@@ -27,7 +27,7 @@ ENV CC_loongarch64_unknown_linux_musl=loongarch64-unknown-linux-musl-gcc \
 
 ENV HOSTS=loongarch64-unknown-linux-musl
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
       --enable-extended \
       --enable-full-tools \
       --enable-profiler \
@@ -37,6 +37,6 @@ ENV RUST_CONFIGURE_ARGS \
       --set rust.lto=thin \
       --set rust.codegen-units=1 \
       --set target.loongarch64-unknown-linux-musl.crt-static=false \
-      --musl-root-loongarch64=/x-tools/loongarch64-unknown-linux-musl/loongarch64-unknown-linux-musl/sysroot/usr
+      --musl-root-loongarch64=/x-tools/loongarch64-unknown-linux-musl/loongarch64-unknown-linux-musl/sysroot/usr"
 
-ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS
+ENV SCRIPT="python3 ../x.py dist --host $HOSTS --target $HOSTS"

--- a/src/ci/docker/host-x86_64/dist-mips-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-mips-linux/Dockerfile
@@ -26,5 +26,5 @@ ENV \
 
 ENV HOSTS=mips-unknown-linux-gnu
 
-ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS
+ENV RUST_CONFIGURE_ARGS="--enable-extended --disable-docs"
+ENV SCRIPT="python3 ../x.py dist --host $HOSTS --target $HOSTS"

--- a/src/ci/docker/host-x86_64/dist-mips64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-mips64-linux/Dockerfile
@@ -26,5 +26,5 @@ ENV \
 
 ENV HOSTS=mips64-unknown-linux-gnuabi64
 
-ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS
+ENV RUST_CONFIGURE_ARGS="--enable-extended --disable-docs"
+ENV SCRIPT="python3 ../x.py dist --host $HOSTS --target $HOSTS"

--- a/src/ci/docker/host-x86_64/dist-mips64el-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-mips64el-linux/Dockerfile
@@ -26,5 +26,5 @@ ENV \
 
 ENV HOSTS=mips64el-unknown-linux-gnuabi64
 
-ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS
+ENV RUST_CONFIGURE_ARGS="--enable-extended --disable-docs"
+ENV SCRIPT="python3 ../x.py dist --host $HOSTS --target $HOSTS"

--- a/src/ci/docker/host-x86_64/dist-mipsel-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-mipsel-linux/Dockerfile
@@ -26,5 +26,5 @@ ENV \
 
 ENV HOSTS=mipsel-unknown-linux-gnu
 
-ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS
+ENV RUST_CONFIGURE_ARGS="--enable-extended --disable-docs"
+ENV SCRIPT="python3 ../x.py dist --host $HOSTS --target $HOSTS"

--- a/src/ci/docker/host-x86_64/dist-ohos-aarch64/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-ohos-aarch64/Dockerfile
@@ -40,14 +40,14 @@ ENV \
     AR_aarch64_unknown_linux_ohos=/opt/ohos-sdk/native/llvm/bin/llvm-ar \
     CXX_aarch64_unknown_linux_ohos=/usr/local/bin/aarch64-unknown-linux-ohos-clang++.sh
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
     --enable-profiler \
     --disable-docs \
     --tools=cargo,clippy,rustdocs,rustfmt,rust-analyzer,rust-analyzer-proc-macro-srv,analysis,src,wasm-component-ld \
     --enable-extended \
-    --enable-sanitizers
+    --enable-sanitizers"
 
-ENV SCRIPT python3 ../x.py dist --host=$TARGETS --target $TARGETS
+ENV SCRIPT="python3 ../x.py dist --host=$TARGETS --target $TARGETS"
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh

--- a/src/ci/docker/host-x86_64/dist-ohos-armv7/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-ohos-armv7/Dockerfile
@@ -40,14 +40,14 @@ ENV \
     AR_armv7_unknown_linux_ohos=/opt/ohos-sdk/native/llvm/bin/llvm-ar \
     CXX_armv7_unknown_linux_ohos=/usr/local/bin/armv7-unknown-linux-ohos-clang++.sh
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
     --enable-profiler \
     --disable-docs \
     --tools=cargo,clippy,rustdocs,rustfmt,rust-analyzer,rust-analyzer-proc-macro-srv,analysis,src,wasm-component-ld \
     --enable-extended \
-    --enable-sanitizers
+    --enable-sanitizers"
 
-ENV SCRIPT python3 ../x.py dist --host=$TARGETS --target $TARGETS
+ENV SCRIPT="python3 ../x.py dist --host=$TARGETS --target $TARGETS"
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh

--- a/src/ci/docker/host-x86_64/dist-ohos-x86_64/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-ohos-x86_64/Dockerfile
@@ -40,14 +40,14 @@ ENV \
     AR_x86_64_unknown_linux_ohos=/opt/ohos-sdk/native/llvm/bin/llvm-ar \
     CXX_x86_64_unknown_linux_ohos=/usr/local/bin/x86_64-unknown-linux-ohos-clang++.sh
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
     --enable-profiler \
     --disable-docs \
     --tools=cargo,clippy,rustdocs,rustfmt,rust-analyzer,rust-analyzer-proc-macro-srv,analysis,src,wasm-component-ld \
     --enable-extended \
-    --enable-sanitizers
+    --enable-sanitizers"
 
-ENV SCRIPT python3 ../x.py dist --host=$TARGETS --target $TARGETS
+ENV SCRIPT="python3 ../x.py dist --host=$TARGETS --target $TARGETS"
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh

--- a/src/ci/docker/host-x86_64/dist-powerpc-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-powerpc-linux/Dockerfile
@@ -26,5 +26,5 @@ ENV \
 
 ENV HOSTS=powerpc-unknown-linux-gnu
 
-ENV RUST_CONFIGURE_ARGS --enable-extended --enable-profiler --disable-docs
-ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS
+ENV RUST_CONFIGURE_ARGS="--enable-extended --enable-profiler --disable-docs"
+ENV SCRIPT="python3 ../x.py dist --host $HOSTS --target $HOSTS"

--- a/src/ci/docker/host-x86_64/dist-powerpc64-linux-gnu/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-powerpc64-linux-gnu/Dockerfile
@@ -26,5 +26,5 @@ ENV \
 
 ENV HOSTS=powerpc64-unknown-linux-gnu
 
-ENV RUST_CONFIGURE_ARGS --enable-extended --enable-profiler --disable-docs
-ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS
+ENV RUST_CONFIGURE_ARGS="--enable-extended --enable-profiler --disable-docs"
+ENV SCRIPT="python3 ../x.py dist --host $HOSTS --target $HOSTS"

--- a/src/ci/docker/host-x86_64/dist-powerpc64-linux-musl/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-powerpc64-linux-musl/Dockerfile
@@ -27,13 +27,13 @@ ENV \
 
 ENV HOSTS=powerpc64-unknown-linux-musl
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
     --enable-extended \
     --enable-full-tools \
     --enable-profiler \
     --enable-sanitizers \
     --disable-docs \
     --set target.powerpc64-unknown-linux-musl.crt-static=false \
-    --musl-root-powerpc64=/x-tools/powerpc64-unknown-linux-musl/powerpc64-unknown-linux-musl/sysroot/usr
+    --musl-root-powerpc64=/x-tools/powerpc64-unknown-linux-musl/powerpc64-unknown-linux-musl/sysroot/usr"
 
-ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS
+ENV SCRIPT="python3 ../x.py dist --host $HOSTS --target $HOSTS"

--- a/src/ci/docker/host-x86_64/dist-powerpc64le-linux-gnu/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-powerpc64le-linux-gnu/Dockerfile
@@ -27,11 +27,11 @@ ENV \
 
 ENV HOSTS=powerpc64le-unknown-linux-gnu
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
     --enable-extended \
     --enable-full-tools \
     --enable-profiler \
     --enable-sanitizers \
-    --disable-docs
+    --disable-docs"
 
-ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS
+ENV SCRIPT="python3 ../x.py dist --host $HOSTS --target $HOSTS"

--- a/src/ci/docker/host-x86_64/dist-powerpc64le-linux-musl/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-powerpc64le-linux-musl/Dockerfile
@@ -27,13 +27,13 @@ ENV \
 
 ENV HOSTS=powerpc64le-unknown-linux-musl
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
     --enable-extended \
     --enable-full-tools \
     --enable-profiler \
     --enable-sanitizers \
     --disable-docs \
     --set target.powerpc64le-unknown-linux-musl.crt-static=false \
-    --musl-root-powerpc64le=/x-tools/powerpc64le-unknown-linux-musl/powerpc64le-unknown-linux-musl/sysroot/usr
+    --musl-root-powerpc64le=/x-tools/powerpc64le-unknown-linux-musl/powerpc64le-unknown-linux-musl/sysroot/usr"
 
-ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS
+ENV SCRIPT="python3 ../x.py dist --host $HOSTS --target $HOSTS"

--- a/src/ci/docker/host-x86_64/dist-riscv64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-riscv64-linux/Dockerfile
@@ -30,5 +30,5 @@ ENV CC_riscv64gc_unknown_linux_gnu=riscv64-unknown-linux-gnu-gcc \
 ENV HOSTS=riscv64gc-unknown-linux-gnu
 ENV TARGETS=riscv64gc-unknown-linux-gnu,riscv64a23-unknown-linux-gnu
 
-ENV RUST_CONFIGURE_ARGS --enable-extended --enable-profiler --disable-docs
-ENV SCRIPT python3 ../x.py dist --target $TARGETS --host $HOSTS
+ENV RUST_CONFIGURE_ARGS="--enable-extended --enable-profiler --disable-docs"
+ENV SCRIPT="python3 ../x.py dist --target $TARGETS --host $HOSTS"

--- a/src/ci/docker/host-x86_64/dist-s390x-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-s390x-linux/Dockerfile
@@ -26,5 +26,5 @@ ENV \
 
 ENV HOSTS=s390x-unknown-linux-gnu
 
-ENV RUST_CONFIGURE_ARGS --enable-extended --enable-lld --enable-sanitizers --enable-profiler --disable-docs
-ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS
+ENV RUST_CONFIGURE_ARGS="--enable-extended --enable-lld --enable-sanitizers --enable-profiler --disable-docs"
+ENV SCRIPT="python3 ../x.py dist --host $HOSTS --target $HOSTS"

--- a/src/ci/docker/host-x86_64/dist-sparcv9-solaris/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-sparcv9-solaris/Dockerfile
@@ -32,5 +32,5 @@ ENV \
 
 ENV HOSTS=sparcv9-sun-solaris
 
-ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS
+ENV RUST_CONFIGURE_ARGS="--enable-extended --disable-docs"
+ENV SCRIPT="python3 ../x.py dist --host $HOSTS --target $HOSTS"

--- a/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
@@ -152,16 +152,16 @@ ENV CFLAGS_armv5te_unknown_linux_musleabi="-march=armv5te -marm -mfloat-abi=soft
     CC_riscv64gc_unknown_none_elf=riscv64-unknown-elf-gcc \
     CFLAGS_riscv64gc_unknown_none_elf=-march=rv64gc -mabi=lp64
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
       --musl-root-armv5te=/musl-armv5te \
       --musl-root-arm=/musl-arm \
       --musl-root-armhf=/musl-armhf \
       --musl-root-armv7hf=/musl-armv7hf \
-      --disable-docs
+      --disable-docs"
 
-ENV SCRIPT \
-      python3 ../x.py --stage 2 test --host='' --target $RUN_MAKE_TARGETS tests/run-make tests/run-make-cargo && \
-      python3 ../x.py dist --host='' --target $TARGETS
+ENV SCRIPT=" \
+      python3 ../x.py --stage 2 test --host= --target $RUN_MAKE_TARGETS tests/run-make tests/run-make-cargo && \
+      python3 ../x.py dist --host= --target $TARGETS"
 
 # sccache
 COPY scripts/sccache.sh /scripts/

--- a/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
@@ -95,16 +95,16 @@ RUN /tmp/freebsd-toolchain.sh i686
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-ENV CARGO_TARGET_X86_64_UNKNOWN_FUCHSIA_AR /usr/local/bin/llvm-ar
-ENV CARGO_TARGET_X86_64_UNKNOWN_FUCHSIA_RUSTFLAGS \
+ENV CARGO_TARGET_X86_64_UNKNOWN_FUCHSIA_AR="/usr/local/bin/llvm-ar"
+ENV CARGO_TARGET_X86_64_UNKNOWN_FUCHSIA_RUSTFLAGS=" \
 -C link-arg=--sysroot=/usr/local/core-linux-amd64-fuchsia-sdk/arch/x64/sysroot \
 -Lnative=/usr/local/core-linux-amd64-fuchsia-sdk/arch/x64/sysroot/lib \
--Lnative=/usr/local/core-linux-amd64-fuchsia-sdk/arch/x64/lib
-ENV CARGO_TARGET_AARCH64_UNKNOWN_FUCHSIA_AR /usr/local/bin/llvm-ar
-ENV CARGO_TARGET_AARCH64_UNKNOWN_FUCHSIA_RUSTFLAGS \
+-Lnative=/usr/local/core-linux-amd64-fuchsia-sdk/arch/x64/lib"
+ENV CARGO_TARGET_AARCH64_UNKNOWN_FUCHSIA_AR="/usr/local/bin/llvm-ar"
+ENV CARGO_TARGET_AARCH64_UNKNOWN_FUCHSIA_RUSTFLAGS=" \
 -C link-arg=--sysroot=/usr/local/core-linux-amd64-fuchsia-sdk/arch/arm64/sysroot \
 -Lnative=/usr/local/core-linux-amd64-fuchsia-sdk/arch/arm64/sysroot/lib \
--Lnative=/usr/local/core-linux-amd64-fuchsia-sdk/arch/arm64/lib
+-Lnative=/usr/local/core-linux-amd64-fuchsia-sdk/arch/arm64/lib"
 
 ENV TARGETS=x86_64-unknown-fuchsia
 ENV TARGETS=$TARGETS,aarch64-unknown-fuchsia
@@ -136,8 +136,8 @@ RUN ln -s /usr/include/x86_64-linux-gnu/asm /usr/local/include/asm
 # musl-gcc can't find libgcc_s.so.1 since it doesn't use the standard search paths.
 RUN ln -s /usr/riscv64-linux-gnu/lib/libgcc_s.so.1 /usr/lib/gcc-cross/riscv64-linux-gnu/11/
 
-ENV RUST_CONFIGURE_ARGS --enable-extended --enable-lld --enable-llvm-bitcode-linker --disable-docs \
+ENV RUST_CONFIGURE_ARGS="--enable-extended --enable-lld --enable-llvm-bitcode-linker --disable-docs \
   --musl-root-armv7=/musl-armv7 \
-  --musl-root-riscv64gc=/musl-riscv64gc
+  --musl-root-riscv64gc=/musl-riscv64gc"
 
-ENV SCRIPT python3 ../x.py dist --host='' --target $TARGETS && python3 ../x.py dist --host='' --set build.sanitizers=true --target $TARGETS_SANITIZERS
+ENV SCRIPT="python3 ../x.py dist --host= --target $TARGETS && python3 ../x.py dist --host= --set build.sanitizers=true --target $TARGETS_SANITIZERS"

--- a/src/ci/docker/host-x86_64/dist-x86_64-freebsd/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-freebsd/Dockerfile
@@ -35,10 +35,10 @@ ENV \
 
 ENV HOSTS=x86_64-unknown-freebsd
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
     --enable-full-tools \
     --enable-extended \
     --enable-profiler \
     --enable-sanitizers \
-    --disable-docs
-ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS
+    --disable-docs"
+ENV SCRIPT="python3 ../x.py dist --host $HOSTS --target $HOSTS"

--- a/src/ci/docker/host-x86_64/dist-x86_64-illumos/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-illumos/Dockerfile
@@ -36,5 +36,5 @@ ENV \
 
 ENV HOSTS=x86_64-unknown-illumos
 
-ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS
+ENV RUST_CONFIGURE_ARGS="--enable-extended --disable-docs"
+ENV SCRIPT="python2.7 ../x.py dist --host $HOSTS --target $HOSTS"

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -80,7 +80,7 @@ ENV PGO_HOST=x86_64-unknown-linux-gnu
 
 ENV HOSTS=x86_64-unknown-linux-gnu
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
       --enable-full-tools \
       --enable-sanitizers \
       --enable-profiler \
@@ -94,23 +94,23 @@ ENV RUST_CONFIGURE_ARGS \
       --set rust.jemalloc \
       --set rust.bootstrap-override-lld=true \
       --set rust.lto=thin \
-      --set rust.codegen-units=1
+      --set rust.codegen-units=1"
 
 COPY host-x86_64/dist-x86_64-linux/dist.sh /scripts/
 COPY host-x86_64/dist-x86_64-linux/dist-alt.sh /scripts/
 
-ENV SCRIPT "Must specify DOCKER_SCRIPT for this image"
+ENV SCRIPT="Must specify DOCKER_SCRIPT for this image"
 
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=clang
 
 # This is the only builder which will create source tarballs
-ENV DIST_SRC 1
+ENV DIST_SRC="1"
 
 # When we build cargo in this container, we don't want it to use the system
 # libcurl, instead it should compile its own.
-ENV LIBCURL_NO_PKG_CONFIG 1
+ENV LIBCURL_NO_PKG_CONFIG="1"
 
-ENV DIST_REQUIRE_ALL_TOOLS 1
+ENV DIST_REQUIRE_ALL_TOOLS="1"
 
 # FIXME: Without this, LLVMgold.so incorrectly resolves to the system
 # libstdc++, instead of the one we build.

--- a/src/ci/docker/host-x86_64/dist-x86_64-musl/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-musl/Dockerfile
@@ -35,14 +35,14 @@ RUN sh /scripts/sccache.sh
 
 ENV HOSTS=x86_64-unknown-linux-musl
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
       --musl-root-x86_64=/usr/local/x86_64-linux-musl \
       --enable-extended \
       --enable-sanitizers \
       --enable-profiler \
       --enable-lld \
       --set target.x86_64-unknown-linux-musl.crt-static=false \
-      --build $HOSTS
+      --build $HOSTS"
 
 # Newer binutils broke things on some vms/distros (i.e., linking against
 # unknown relocs disabled by the following flag), so we need to go out of our
@@ -54,4 +54,4 @@ ENV CFLAGS_x86_64_unknown_linux_musl="-Wa,-mrelax-relocations=no -Wa,--compress-
     -Wl,--compress-debug-sections=none"
 
 # To run native tests replace `dist` below with `test`
-ENV SCRIPT python3 ../x.py dist --build $HOSTS
+ENV SCRIPT="python3 ../x.py dist --build $HOSTS"

--- a/src/ci/docker/host-x86_64/dist-x86_64-netbsd/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-netbsd/Dockerfile
@@ -22,5 +22,5 @@ ENV \
 
 ENV HOSTS=x86_64-unknown-netbsd
 
-ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS
+ENV RUST_CONFIGURE_ARGS="--enable-extended --disable-docs"
+ENV SCRIPT="python3 ../x.py dist --host $HOSTS --target $HOSTS"

--- a/src/ci/docker/host-x86_64/dist-x86_64-solaris/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-solaris/Dockerfile
@@ -32,5 +32,5 @@ ENV \
 
 ENV HOSTS=x86_64-pc-solaris
 
-ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
-ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS
+ENV RUST_CONFIGURE_ARGS="--enable-extended --disable-docs"
+ENV SCRIPT="python3 ../x.py dist --host $HOSTS --target $HOSTS"

--- a/src/ci/docker/host-x86_64/i686-gnu-nopt/Dockerfile
+++ b/src/ci/docker/host-x86_64/i686-gnu-nopt/Dockerfile
@@ -22,8 +22,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-ENV RUST_CONFIGURE_ARGS --build=i686-unknown-linux-gnu --disable-optimize-tests
+ENV RUST_CONFIGURE_ARGS="--build=i686-unknown-linux-gnu --disable-optimize-tests"
 COPY scripts/stage_2_test_set1.sh /scripts/
 COPY scripts/stage_2_test_set2.sh /scripts/
 COPY scripts/i686-gnu-nopt-2.sh /scripts/
-ENV SCRIPT "Must specify DOCKER_SCRIPT for this image"
+ENV SCRIPT="Must specify DOCKER_SCRIPT for this image"

--- a/src/ci/docker/host-x86_64/i686-gnu/Dockerfile
+++ b/src/ci/docker/host-x86_64/i686-gnu/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-ENV RUST_CONFIGURE_ARGS --build=i686-unknown-linux-gnu
+ENV RUST_CONFIGURE_ARGS="--build=i686-unknown-linux-gnu"
 COPY scripts/stage_2_test_set1.sh /scripts/
 COPY scripts/stage_2_test_set2.sh /scripts/
-ENV SCRIPT "Must specify DOCKER_SCRIPT for this image"
+ENV SCRIPT="Must specify DOCKER_SCRIPT for this image"

--- a/src/ci/docker/host-x86_64/pr-check-1/Dockerfile
+++ b/src/ci/docker/host-x86_64/pr-check-1/Dockerfile
@@ -39,7 +39,7 @@ COPY host-x86_64/pr-check-1/validate-toolstate.sh /scripts/
 # Check library crates on all tier 1 targets.
 # We disable optimized compiler built-ins because that requires a C toolchain for the target.
 # We also skip the x86_64-unknown-linux-gnu target as it is well-tested by other jobs.
-ENV SCRIPT \
+ENV SCRIPT=" \
   # Check some tools that aren't included in `x check` by default, to
   # ensure that maintainers can still do check builds locally.
   python3 ../x.py check \
@@ -58,4 +58,4 @@ ENV SCRIPT \
   python3 ../x.py check --set build.optimized-compiler-builtins=false core alloc std --target=aarch64-unknown-linux-gnu,i686-pc-windows-msvc,i686-unknown-linux-gnu,x86_64-apple-darwin,x86_64-pc-windows-gnu,x86_64-pc-windows-msvc && \
   /scripts/validate-toolstate.sh && \
   reuse --include-submodules lint && \
-  python3 ../x.py test collect-license-metadata
+  python3 ../x.py test collect-license-metadata"

--- a/src/ci/docker/host-x86_64/pr-check-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/pr-check-2/Dockerfile
@@ -30,7 +30,7 @@ ENV RUST_CONFIGURE_ARGS="--set rust.validate-mir-opts=3"
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-ENV SCRIPT \
+ENV SCRIPT=" \
         python3 ../x.py check && \
         python3 ../x.py clippy ci --stage 2 && \
         python3 ../x.py test --stage 1 core alloc std test proc_macro && \
@@ -48,4 +48,4 @@ ENV SCRIPT \
         RUSTDOCFLAGS=\"--document-private-items --document-hidden-items\" python3 ../x.py doc library/test --stage 1 && \
         # The BOOTSTRAP_TRACING flag is added to verify whether the
         # bootstrap process compiles successfully with this flag enabled.
-        BOOTSTRAP_TRACING=1 python3 ../x.py --help
+        BOOTSTRAP_TRACING=1 python3 ../x.py --help"

--- a/src/ci/docker/host-x86_64/test-various/Dockerfile
+++ b/src/ci/docker/host-x86_64/test-various/Dockerfile
@@ -45,9 +45,9 @@ RUN curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-3
   tar -xz
 ENV WASI_SDK_PATH=/wasi-sdk-30.0-x86_64-linux
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
   --musl-root-x86_64=/usr/local/x86_64-linux-musl \
-  --set rust.lld
+  --set rust.lld"
 
 # Some run-make tests have assertions about code size, and enabling debug
 # assertions in libstd causes the binary to be much bigger than it would
@@ -58,10 +58,10 @@ ENV NO_OVERFLOW_CHECKS=1
 
 RUN curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v38.0.4/wasmtime-v38.0.4-x86_64-linux.tar.xz | \
   tar -xJ
-ENV PATH "$PATH:/wasmtime-v38.0.4-x86_64-linux"
+ENV PATH="$PATH:/wasmtime-v38.0.4-x86_64-linux"
 
 ENV WASM_WASIP_TARGET=wasm32-wasip1
-ENV WASM_WASIP_SCRIPT python3 /checkout/x.py --stage 2 test --host='' --target $WASM_WASIP_TARGET \
+ENV WASM_WASIP_SCRIPT="python3 /checkout/x.py --stage 2 test --host= --target $WASM_WASIP_TARGET \
   tests/run-make \
   tests/run-make-cargo \
   tests/ui \
@@ -69,18 +69,18 @@ ENV WASM_WASIP_SCRIPT python3 /checkout/x.py --stage 2 test --host='' --target $
   tests/codegen-units \
   tests/codegen-llvm \
   tests/assembly-llvm \
-  library/core
+  library/core"
 
 ENV NVPTX_TARGETS=nvptx64-nvidia-cuda
-ENV NVPTX_SCRIPT python3 /checkout/x.py --stage 2 test --host='' --target $NVPTX_TARGETS \
+ENV NVPTX_SCRIPT="python3 /checkout/x.py --stage 2 test --host= --target $NVPTX_TARGETS \
   tests/run-make \
   tests/run-make-cargo \
-  tests/assembly-llvm
+  tests/assembly-llvm"
 
 ENV MUSL_TARGETS=x86_64-unknown-linux-musl \
     CC_x86_64_unknown_linux_musl=x86_64-linux-musl-gcc \
     CXX_x86_64_unknown_linux_musl=x86_64-linux-musl-g++
-ENV MUSL_SCRIPT python3 /checkout/x.py --stage 2 test --host='' --target $MUSL_TARGETS
+ENV MUSL_SCRIPT="python3 /checkout/x.py --stage 2 test --host= --target $MUSL_TARGETS"
 
 ENV UEFI_TARGETS=aarch64-unknown-uefi,i686-unknown-uefi,x86_64-unknown-uefi \
     CC_aarch64_unknown_uefi=clang-11 \
@@ -89,9 +89,9 @@ ENV UEFI_TARGETS=aarch64-unknown-uefi,i686-unknown-uefi,x86_64-unknown-uefi \
     CXX_i686_unknown_uefi=clang++-11 \
     CC_x86_64_unknown_uefi=clang-11 \
     CXX_x86_64_unknown_uefi=clang++-11
-ENV UEFI_SCRIPT python3 /checkout/x.py --stage 2 build --host='' --target $UEFI_TARGETS && \
+ENV UEFI_SCRIPT="python3 /checkout/x.py --stage 2 build --host= --target $UEFI_TARGETS && \
   python3 /checkout/x.py --stage 2 test tests/run-make-cargo/uefi-qemu/rmake.rs --target aarch64-unknown-uefi && \
   python3 /checkout/x.py --stage 2 test tests/run-make-cargo/uefi-qemu/rmake.rs --target i686-unknown-uefi && \
-  python3 /checkout/x.py --stage 2 test tests/run-make-cargo/uefi-qemu/rmake.rs --target x86_64-unknown-uefi
+  python3 /checkout/x.py --stage 2 test tests/run-make-cargo/uefi-qemu/rmake.rs --target x86_64-unknown-uefi"
 
-ENV SCRIPT $WASM_WASIP_SCRIPT && $NVPTX_SCRIPT && $MUSL_SCRIPT && $UEFI_SCRIPT
+ENV SCRIPT="$WASM_WASIP_SCRIPT && $NVPTX_SCRIPT && $MUSL_SCRIPT && $UEFI_SCRIPT"

--- a/src/ci/docker/host-x86_64/tidy/Dockerfile
+++ b/src/ci/docker/host-x86_64/tidy/Dockerfile
@@ -39,5 +39,5 @@ COPY host-x86_64/pr-check-1/validate-toolstate.sh /scripts/
 
 # NOTE: intentionally uses python2 for x.py so we can test it still works.
 # validate-toolstate only runs in our CI, so it's ok for it to only support python3.
-ENV SCRIPT TIDY_PRINT_DIFF=1 python2.7 ../x.py test \
-  src/tools/tidy tidyselftest --extra-checks=py,cpp,js,spellcheck
+ENV SCRIPT="TIDY_PRINT_DIFF=1 python2.7 ../x.py test \
+  src/tools/tidy tidyselftest --extra-checks=py,cpp,js,spellcheck"

--- a/src/ci/docker/host-x86_64/x86_64-fuchsia/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-fuchsia/Dockerfile
@@ -38,13 +38,13 @@ COPY scripts/shared.sh /tmp/
 COPY scripts/build-fuchsia-toolchain.sh /tmp/
 RUN /tmp/build-fuchsia-toolchain.sh
 
-ENV CARGO_TARGET_X86_64_UNKNOWN_FUCHSIA_AR /usr/local/bin/llvm-ar
-ENV CARGO_TARGET_X86_64_UNKNOWN_FUCHSIA_RUSTFLAGS \
+ENV CARGO_TARGET_X86_64_UNKNOWN_FUCHSIA_AR="/usr/local/bin/llvm-ar"
+ENV CARGO_TARGET_X86_64_UNKNOWN_FUCHSIA_RUSTFLAGS=" \
   -C panic=abort \
   -C force-unwind-tables=yes \
   -C link-arg=--sysroot=/usr/local/core-linux-amd64-fuchsia-sdk/arch/x64/sysroot \
   -Lnative=/usr/local/core-linux-amd64-fuchsia-sdk/arch/x64/sysroot/lib \
-  -Lnative=/usr/local/core-linux-amd64-fuchsia-sdk/arch/x64/lib
+  -Lnative=/usr/local/core-linux-amd64-fuchsia-sdk/arch/x64/lib"
 
 ENV TARGETS=x86_64-unknown-fuchsia
 ENV TARGETS=$TARGETS,x86_64-unknown-linux-gnu
@@ -52,16 +52,16 @@ ENV TARGETS=$TARGETS,x86_64-unknown-linux-gnu
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-ENV RUST_INSTALL_DIR /checkout/obj/install
+ENV RUST_INSTALL_DIR="/checkout/obj/install"
 RUN mkdir -p $RUST_INSTALL_DIR/etc
 
 # Fuchsia only supports LLVM.
-ENV CODEGEN_BACKENDS llvm
+ENV CODEGEN_BACKENDS="llvm"
 
 # download-rustc is not allowed for `x install`
-ENV NO_DOWNLOAD_CI_RUSTC 1
+ENV NO_DOWNLOAD_CI_RUSTC="1"
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
   --prefix=$RUST_INSTALL_DIR \
   --sysconfdir=etc \
   --enable-lld \
@@ -72,8 +72,8 @@ ENV RUST_CONFIGURE_ARGS \
   --set target.x86_64-unknown-fuchsia.cxx=/usr/local/bin/clang++ \
   --set target.x86_64-unknown-fuchsia.ar=/usr/local/bin/llvm-ar \
   --set target.x86_64-unknown-fuchsia.ranlib=/usr/local/bin/llvm-ranlib \
-  --set target.x86_64-unknown-fuchsia.linker=/usr/local/bin/ld.lld
+  --set target.x86_64-unknown-fuchsia.linker=/usr/local/bin/ld.lld"
 
-ENV SCRIPT \
+ENV SCRIPT=" \
     python3 ../x.py install --target $TARGETS compiler/rustc library/std clippy && \
-    bash ../src/ci/docker/host-x86_64/x86_64-fuchsia/build-fuchsia.sh
+    bash ../src/ci/docker/host-x86_64/x86_64-fuchsia/build-fuchsia.sh"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-aux/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-aux/Dockerfile
@@ -29,5 +29,5 @@ RUN sh /scripts/sccache.sh
 ENV NO_DEBUG_ASSERTIONS=1
 ENV NO_OVERFLOW_CHECKS=1
 
-ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu
-ENV RUST_CHECK_TARGET check-aux
+ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu"
+ENV RUST_CHECK_TARGET="check-aux"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-debug/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-debug/Dockerfile
@@ -29,12 +29,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-ENV RUSTBUILD_FORCE_CLANG_BASED_TESTS 1
+ENV RUSTBUILD_FORCE_CLANG_BASED_TESTS="1"
 
 # llvm.use-linker conflicts with downloading CI LLVM
-ENV NO_DOWNLOAD_CI_LLVM 1
+ENV NO_DOWNLOAD_CI_LLVM="1"
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
       --build=x86_64-unknown-linux-gnu \
       --enable-debug \
       --enable-lld \
@@ -42,7 +42,7 @@ ENV RUST_CONFIGURE_ARGS \
       --set llvm.use-linker=lld \
       --set target.x86_64-unknown-linux-gnu.linker=clang \
       --set target.x86_64-unknown-linux-gnu.cc=clang \
-      --set target.x86_64-unknown-linux-gnu.cxx=clang++
+      --set target.x86_64-unknown-linux-gnu.cxx=clang++"
 
 # This job checks:
 # - That ui tests can be built with `-Cdebuginfo=1`
@@ -53,7 +53,7 @@ ENV RUST_CONFIGURE_ARGS \
 # - That the tests with `//@ needs-force-clang-based-tests` pass, since they
 #   don't run by default unless RUSTBUILD_FORCE_CLANG_BASED_TESTS is set.
 
-ENV SCRIPT \
+ENV SCRIPT=" \
   python3 ../x.py --stage 2 build && \
   python3 ../x.py --stage 2 test tests/ui && \
-  python3 ../x.py --stage 2 test tests/run-make tests/run-make-cargo
+  python3 ../x.py --stage 2 test tests/run-make tests/run-make-cargo"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-distcheck/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-distcheck/Dockerfile
@@ -1,5 +1,5 @@
 # Runs `distcheck`, which is a collection of smoke tests:
-# 
+#
 # - Run `make check` from an unpacked dist tarball to make sure we can at the
 #   minimum run check steps from those sources.
 # - Check that selected dist components at least have expected directory shape
@@ -34,6 +34,6 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 # Make distcheck builds faster
-ENV DISTCHECK_CONFIGURE_ARGS "--enable-sccache"
+ENV DISTCHECK_CONFIGURE_ARGS="--enable-sccache"
 
-ENV SCRIPT python3 ../x.py test distcheck
+ENV SCRIPT="python3 ../x.py test distcheck"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-gcc/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-gcc/Dockerfile
@@ -31,15 +31,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-ENV NO_DEBUG_ASSERTIONS 1
-ENV RUST_CONFIGURE_ARGS \
+ENV NO_DEBUG_ASSERTIONS="1"
+ENV RUST_CONFIGURE_ARGS=" \
  --build=x86_64-unknown-linux-gnu \
  --enable-sanitizers \
  --enable-profiler \
  --enable-compiler-docs \
  --set llvm.libzstd=true \
- --set 'rust.codegen-backends=[\"llvm\",\"gcc\"]'
-ENV SCRIPT python3 ../x.py \
+ --set rust.codegen-backends=[\\\"llvm\\\",\\\"gcc\\\"]"
+ENV SCRIPT="python3 ../x.py \
   --stage 2 \
   test tests \
   --test-codegen-backend gcc \
@@ -51,4 +51,4 @@ ENV SCRIPT python3 ../x.py \
   --skip tests/rustdoc-js-std \
   --skip tests/rustdoc-json \
   --skip tests/rustdoc-ui \
-  --set 'rust.codegen-backends=[\"llvm\",\"gcc\"]'
+  --set rust.codegen-backends=[\\\"llvm\\\",\\\"gcc\\\"]"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-20/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-20/Dockerfile
@@ -44,16 +44,16 @@ RUN sh /scripts/sccache.sh
 
 # We are disabling CI LLVM since this builder is intentionally using a host
 # LLVM, rather than the typical src/llvm-project LLVM.
-ENV NO_DOWNLOAD_CI_LLVM 1
-ENV EXTERNAL_LLVM 1
+ENV NO_DOWNLOAD_CI_LLVM="1"
+ENV EXTERNAL_LLVM="1"
 
 # Using llvm-link-shared due to libffi issues -- see #34486
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
       --build=x86_64-unknown-linux-gnu \
       --llvm-root=/usr/lib/llvm-20 \
       --enable-llvm-link-shared \
       --set rust.randomize-layout=true \
-      --set rust.thin-lto-import-instr-limit=10
+      --set rust.thin-lto-import-instr-limit=10"
 
 COPY scripts/shared.sh /scripts/
 
@@ -63,4 +63,4 @@ COPY scripts/x86_64-gnu-llvm3.sh /scripts/
 COPY scripts/stage_2_test_set1.sh /scripts/
 COPY scripts/stage_2_test_set2.sh /scripts/
 
-ENV SCRIPT "Must specify DOCKER_SCRIPT for this image"
+ENV SCRIPT="Must specify DOCKER_SCRIPT for this image"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-21/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-21/Dockerfile
@@ -44,16 +44,16 @@ RUN sh /scripts/sccache.sh
 
 # We are disabling CI LLVM since this builder is intentionally using a host
 # LLVM, rather than the typical src/llvm-project LLVM.
-ENV NO_DOWNLOAD_CI_LLVM 1
-ENV EXTERNAL_LLVM 1
+ENV NO_DOWNLOAD_CI_LLVM="1"
+ENV EXTERNAL_LLVM="1"
 
 # Using llvm-link-shared due to libffi issues -- see #34486
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
       --build=x86_64-unknown-linux-gnu \
       --llvm-root=/usr/lib/llvm-21 \
       --enable-llvm-link-shared \
       --set rust.randomize-layout=true \
-      --set rust.thin-lto-import-instr-limit=10
+      --set rust.thin-lto-import-instr-limit=10"
 
 COPY scripts/shared.sh /scripts/
 
@@ -63,4 +63,4 @@ COPY scripts/x86_64-gnu-llvm3.sh /scripts/
 COPY scripts/stage_2_test_set1.sh /scripts/
 COPY scripts/stage_2_test_set2.sh /scripts/
 
-ENV SCRIPT "Must specify DOCKER_SCRIPT for this image"
+ENV SCRIPT="Must specify DOCKER_SCRIPT for this image"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-miri/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-miri/Dockerfile
@@ -34,11 +34,11 @@ ENV GCC_EXEC_PREFIX="/usr/lib/gcc/"
 
 COPY host-x86_64/x86_64-gnu-miri/check-miri.sh /tmp/
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
   --build=x86_64-unknown-linux-gnu \
-  --enable-new-symbol-mangling
+  --enable-new-symbol-mangling"
 
-ENV HOST_TARGET x86_64-unknown-linux-gnu
+ENV HOST_TARGET="x86_64-unknown-linux-gnu"
 
 # FIXME(#133381): currently rustc alt builds do *not* have rustc debug
 # assertions enabled! Therefore, we cannot force download CI rustc.
@@ -46,4 +46,4 @@ ENV HOST_TARGET x86_64-unknown-linux-gnu
 
 COPY scripts/shared.sh /scripts/
 
-ENV SCRIPT /tmp/check-miri.sh ../x.py
+ENV SCRIPT="/tmp/check-miri.sh ../x.py"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-nopt/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-nopt/Dockerfile
@@ -22,8 +22,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu \
+ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu \
   --disable-optimize-tests \
-  --set rust.test-compare-mode
-ENV SCRIPT python3 ../x.py test --stage 1 --set rust.optimize=false library/std \
-  && python3 ../x.py --stage 2 test
+  --set rust.test-compare-mode"
+ENV SCRIPT="python3 ../x.py test --stage 1 --set rust.optimize=false library/std \
+  && python3 ../x.py --stage 2 test"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
@@ -76,12 +76,12 @@ COPY scripts/nodejs.sh /scripts/
 RUN sh /scripts/nodejs.sh /node
 ENV PATH="/node/bin:${PATH}"
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
   --build=x86_64-unknown-linux-gnu \
   --save-toolstates=/tmp/toolstate/toolstates.json \
-  --enable-new-symbol-mangling
+  --enable-new-symbol-mangling"
 
-ENV HOST_TARGET x86_64-unknown-linux-gnu
+ENV HOST_TARGET="x86_64-unknown-linux-gnu"
 
 # FIXME(#133381): currently rustc alt builds do *not* have rustc debug
 # assertions enabled! Therefore, we cannot force download CI rustc.
@@ -89,5 +89,5 @@ ENV HOST_TARGET x86_64-unknown-linux-gnu
 
 COPY scripts/shared.sh /scripts/
 
-ENV SCRIPT /tmp/checktools.sh ../x.py && \
-  python3 ../x.py test tests/rustdoc-gui --stage 2 --test-args "'--jobs 1'"
+ENV SCRIPT="/tmp/checktools.sh ../x.py && \
+  python3 ../x.py test tests/rustdoc-gui --stage 2 --test-args '--jobs 1'"

--- a/src/ci/docker/host-x86_64/x86_64-gnu/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu/Dockerfile
@@ -24,10 +24,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-ENV RUST_CONFIGURE_ARGS \
+ENV RUST_CONFIGURE_ARGS=" \
  --build=x86_64-unknown-linux-gnu \
  --enable-sanitizers \
  --enable-profiler \
  --enable-compiler-docs \
- --set llvm.libzstd=true
-ENV SCRIPT python3 ../x.py --stage 2 test
+ --set llvm.libzstd=true"
+ENV SCRIPT="python3 ../x.py --stage 2 test"

--- a/src/ci/docker/host-x86_64/x86_64-rust-for-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-rust-for-linux/Dockerfile
@@ -34,7 +34,7 @@ RUN sh /scripts/sccache.sh
 # RfL needs access to cland, lld and llvm tools
 ENV PATH="${PATH}:/usr/lib/llvm-15/bin"
 
-ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu
+ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu"
 
 COPY /scripts/rfl-build.sh /tmp/rfl-build.sh
-ENV SCRIPT bash /tmp/rfl-build.sh
+ENV SCRIPT="bash /tmp/rfl-build.sh"


### PR DESCRIPTION
Merge split (requested in https://github.com/rust-lang/rust/pull/152305#issuecomment-3950237116):
1. `aarch64-gnu-debug` (1): rust-lang/rust#153109
2. `aarch64` (3): rust-lang/rust#153223
3. `disabled/` (11): rust-lang/rust#153224
4. `arm` (7): rust-lang/rust#153371
5. `x86_64-gnu` (10): rust-lang/rust#153372
6. `dist-x86_64` (6): rust-lang/rust#153374
7. `powerpc` (5): rust-lang/rust#153373
8. `i686` (4): rust-lang/rust#153526
9. `ohos` (2): rust-lang/rust#153527
10. `mips` (4): rust-lang/rust#153528
11. `pr-check-1`, `pr-check-2`, `tidy` (3): rust-lang/rust#153529
12. `dist-various-1`, `dist-various-2`,  `test-various` (3): rust-lang/rust#153531
13. `dist-android`, `dist-loongarch64-linux`, `dist-loongarch64-musl`, `dist-riscv64-linux`, `dist-s390x-linux`, `dist-sparcv9-solaris`, `x86_64-fuchsia`, `x86_64-rust-for-linux` (8): rust-lang/rust#153533

While checking job logs (https://github.com/rust-lang/rust/actions/runs/21779827147/job/62842068357#step:28:217) I noticed:
```log
   2 warnings found (use docker --debug to expand):
   - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 24)
   - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 29)
```

I identified warnings with:
```sh
git ls-files --directory **/Dockerfile | sed -E -e "s/(\/Dockerfile)//" |xargs --verbose --replace={} docker build --check {}
```

I went with `ENV ENVVAR="quoted"` because it is the most working solution I found. Note that I did not touch lines that did not report a warning but that were written as `ENV ENVVAR=unquoted` or `ENV ENVVAR=multi \\n line`.

```Dockerfile
FROM alpine

ENV INLINE_UNQUOTE=this is a test
ENV INLINE_QUOTE="this is a test"
ENV MULTILINE_UNQUOTE= \
  this \
  is \
  a \
  test
ENV MULTILINE_QUOTE="\
  this \
  is \
  a \
  test"
```
