### PR TITLE
Fix ICE when ABI computation fails for unreachable/no-codegen instances

### DIFF
--- a/compiler/rustc_monomorphize/src/mono_checks/abi_check.rs
+++ b/compiler/rustc_monomorphize/src/mono_checks/abi_check.rs
@@ -5,6 +5,7 @@ use rustc_hir::{CRATE_HIR_ID, HirId};
 use rustc_middle::mir::{self, Location, traversal};
 use rustc_middle::ty::{self, Instance, InstanceKind, Ty, TyCtxt};
 use rustc_span::def_id::DefId;
+use rustc_span::source_map::Spanned;
 use rustc_span::{DUMMY_SP, Span, Symbol, sym};
 use rustc_target::callconv::{FnAbi, PassMode};
 
@@ -157,12 +158,16 @@ fn do_check_unsized_params<'tcx>(
 /// - the signature requires target features that are not enabled
 fn check_instance_abi<'tcx>(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) {
     let typing_env = ty::TypingEnv::fully_monomorphized();
-    let Ok(abi) = tcx.fn_abi_of_instance(typing_env.as_query_input((instance, ty::List::empty())))
-    else {
-        // An error will be reported during codegen if we cannot determine the ABI of this
-        // function.
-        tcx.dcx().delayed_bug("ABI computation failure should lead to compilation failure");
-        return;
+    let abi = match tcx.fn_abi_of_instance(typing_env.as_query_input((instance, ty::List::empty())))
+    {
+        Ok(abi) => abi,
+        Err(err) => {
+            // Emit directly: codegen may never see this instance (dead code, `-Zno-codegen`).
+            let ty::layout::FnAbiError::Layout(layout_err) = *err;
+            let span = tcx.def_span(instance.def_id());
+            tcx.dcx().emit_err(Spanned { node: layout_err.into_diagnostic(), span });
+            return;
+        }
     };
     // Unlike the call-site check, we do also check "Rust" ABI functions here.
     // This should never trigger, *except* if we start making use of vector registers

--- a/tests/crashes/138008.rs
+++ b/tests/crashes/138008.rs
@@ -1,8 +1,0 @@
-//@ known-bug: #138008
-//@compile-flags: --crate-type=lib -Copt-level=0
-#![feature(repr_simd)]
-const C: usize = 16;
-
-#[repr(simd)]
-pub struct Foo([u8; C]);
-pub unsafe fn foo(a: Foo) {}

--- a/tests/ui/layout/post-mono-layout-cycle.rs
+++ b/tests/ui/layout/post-mono-layout-cycle.rs
@@ -13,7 +13,7 @@ struct Wrapper<T: Trait> {
     _x: <T as Trait>::Assoc,
 }
 
-fn abi<T: Trait>(_: Option<Wrapper<T>>) {}
+fn abi<T: Trait>(_: Option<Wrapper<T>>) {} //~ ERROR a cycle occurred during layout computation
 
 fn indirect<T: Trait>() {
     abi::<T>(None);

--- a/tests/ui/layout/post-mono-layout-cycle.stderr
+++ b/tests/ui/layout/post-mono-layout-cycle.stderr
@@ -5,12 +5,18 @@ error[E0391]: cycle detected when computing layout of `Wrapper<()>`
    = note: cycle used when computing layout of `core::option::Option<Wrapper<()>>`
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
+error: a cycle occurred during layout computation
+  --> $DIR/post-mono-layout-cycle.rs:16:1
+   |
+LL | fn abi<T: Trait>(_: Option<Wrapper<T>>) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 note: the above error was encountered while instantiating `fn abi::<()>`
   --> $DIR/post-mono-layout-cycle.rs:19:5
    |
 LL |     abi::<T>(None);
    |     ^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/limits/issue-17913.32bit.stderr
+++ b/tests/ui/limits/issue-17913.32bit.stderr
@@ -1,3 +1,6 @@
+error: values of the type `[&usize; usize::MAX]` are too big for the target architecture
+  --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
+
 error[E0080]: values of the type `[&usize; usize::MAX]` are too big for the target architecture
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
    |
@@ -14,6 +17,6 @@ note: the above error was encountered while instantiating `fn Box::<[&usize; usi
 LL |     let a: Box<_> = Box::new([&n; SIZE]);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/limits/issue-17913.64bit.stderr
+++ b/tests/ui/limits/issue-17913.64bit.stderr
@@ -1,3 +1,6 @@
+error: values of the type `[&usize; usize::MAX]` are too big for the target architecture
+  --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
+
 error[E0080]: values of the type `[&usize; usize::MAX]` are too big for the target architecture
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
    |
@@ -14,6 +17,6 @@ note: the above error was encountered while instantiating `fn Box::<[&usize; usi
 LL |     let a: Box<_> = Box::new([&n; SIZE]);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/limits/issue-17913.rs
+++ b/tests/ui/limits/issue-17913.rs
@@ -19,3 +19,4 @@ fn main() {
 
 //~? ERROR are too big for the target architecture
 //~? ERROR are too big for the target architecture
+//~? ERROR are too big for the target architecture

--- a/tests/ui/simd/monomorphize-oversized-no-codegen.rs
+++ b/tests/ui/simd/monomorphize-oversized-no-codegen.rs
@@ -1,0 +1,13 @@
+// Regression test for #149156.
+//@ build-fail
+//@ compile-flags: -Zno-codegen
+//@ only-x86_64
+
+#![crate_type = "lib"]
+#![allow(private_interfaces)]
+
+struct Struct([u8; 0xffff_ffff_ffff_ffff]);
+
+pub fn function(value: Struct) -> u8 { //~ ERROR are too big for the target architecture
+    value.0[0]
+}

--- a/tests/ui/simd/monomorphize-oversized-no-codegen.stderr
+++ b/tests/ui/simd/monomorphize-oversized-no-codegen.stderr
@@ -1,0 +1,8 @@
+error: values of the type `[u8; usize::MAX]` are too big for the target architecture
+  --> $DIR/monomorphize-oversized-no-codegen.rs:11:1
+   |
+LL | pub fn function(value: Struct) -> u8 {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/simd/monomorphize-oversized-unreachable.rs
+++ b/tests/ui/simd/monomorphize-oversized-unreachable.rs
@@ -1,0 +1,13 @@
+// Regression test for #152204.
+//@ build-fail
+//@ only-x86_64
+
+#![feature(portable_simd)]
+
+fn main() {
+    if false {
+        let _ = core::simd::Simd::<u8, 256>::splat(0);
+    }
+}
+
+//~? ERROR the SIMD type `Simd<u8, 256>` has more elements than the limit 64

--- a/tests/ui/simd/monomorphize-oversized-unreachable.stderr
+++ b/tests/ui/simd/monomorphize-oversized-unreachable.stderr
@@ -1,0 +1,11 @@
+error: the SIMD type `Simd<u8, 256>` has more elements than the limit 64
+  --> $SRC_DIR/core/src/../../portable-simd/crates/core_simd/src/vector.rs:LL:COL
+
+note: the above error was encountered while instantiating `fn Simd::<u8, 256>::splat`
+  --> $DIR/monomorphize-oversized-unreachable.rs:9:17
+   |
+LL |         let _ = core::simd::Simd::<u8, 256>::splat(0);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/simd/monomorphize-repr-simd-const-generic.rs
+++ b/tests/ui/simd/monomorphize-repr-simd-const-generic.rs
@@ -1,0 +1,12 @@
+// Regression test for #138008.
+//@ build-fail
+//@ compile-flags: --crate-type=lib -Copt-level=0
+
+#![feature(repr_simd)]
+
+const C: usize = 16;
+
+#[repr(simd)]
+pub struct Foo([u8; C]);
+
+pub unsafe fn foo(a: Foo) {} //~ ERROR the type `Foo` has an unknown layout

--- a/tests/ui/simd/monomorphize-repr-simd-const-generic.stderr
+++ b/tests/ui/simd/monomorphize-repr-simd-const-generic.stderr
@@ -1,0 +1,8 @@
+error: the type `Foo` has an unknown layout
+  --> $DIR/monomorphize-repr-simd-const-generic.rs:12:1
+   |
+LL | pub unsafe fn foo(a: Foo) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
## Summary

Fix ICE when ABI computation fails for monomorphized instances that never reach codegen.

## Problem

`check_instance_abi` in `abi_check.rs` uses `delayed_bug` for ABI computation failures, assuming codegen will report the actual error. However, if the instance is in unreachable code or compiled with `-Zno-codegen`, codegen never processes it and the error goes unreported, causing the `delayed_bug` to fire as an ICE.

### Reproducer (rust-lang/rust#152204)

```rust
#![feature(portable_simd)]
fn main() {
    if false {
        let _ = core::simd::Simd::<u8, 256>::splat(0);
    }
}
```
### Reproducer (rust-lang/rust#149156)

```
#![crate_type = "lib"]
struct Struct([u8; 0xffff_ffff_ffff_ffff]);
pub fn function(value: Struct) -> u8 { value.0[0] }
// compile with: rustc -Zno-codegen
```

## Fix

Replace delayed_bug with emit_err in check_instance_abi to report the layout error directly rather than deferring to codegen. FnAbiError already implements Diagnostic, so the existing error infrastructure handles all variants (SizeOverflow, InvalidSimd, etc.).

After this change:

• rust-lang/rust#152204 emits: error: the SIMD type 'Simd<u8, 256>' has more elements than the limit 64
• rust-lang/rust#149156 emits: error: values of the type '[u8; 18446744073709551615]' are too big for the target architecture
Includes regression test.

Fixes rust-lang/rust#152204
Fixes rust-lang/rust#149156