### PR TITLE
Remove `rustdoc` adhoc group

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1488,11 +1488,6 @@ infra-ci = [
     "@jdno",
     "@jieyouxu",
 ]
-rustdoc = [
-    "@GuillaumeGomez",
-    "@notriddle",
-    "@fmease",
-]
 docs = [
     "@ehuss",
     "@GuillaumeGomez",


### PR DESCRIPTION
With https://github.com/rust-lang/triagebot/pull/2273, reviewers can now tell triagebot to opt them out of being assigned through a given team, so that `r? <team>` does not consider them if they don't want to.

That means that we can now finally get rid of adhoc groups that correspond to actual Rust teams. I wanted to start with a smaller team than `t-compiler` to test this, so I started with `rustdoc`, which was the smallest team that I found an adhoc group for.

Currently, the `rustdoc` team contains the following members:
- aDotInTheVoid
- GuillaumeGomez
- notriddle
- fmease
- camelid
- Manishearth
- Urgau
- lolbinarycat
- yotamofek

Only three of those were previously assignable through `r? rustdoc`. So to reproduce the previous state, I will run `as <username> work set-team-rotation-mode rustdoc off` for the remaining members of the `rustdoc` team before this is merged.

If more people from `t-rustdoc` want to join the review rotation, they can send [triagebot](https://rust-lang.zulipchat.com/#narrow/dm/261224-triagebot) a DM with `work set-team-rotation-mode rustdoc on`.

CC @rust-lang/rustdoc
