### PR TITLE
style-guide: Add try blocks

### DIFF
--- a/src/doc/style-guide/src/expressions.md
+++ b/src/doc/style-guide/src/expressions.md
@@ -154,6 +154,37 @@ move |arg1: i32, arg2: i32| -> i32 {
 }
 ```
 
+## Try blocks
+
+### Homogeneous
+
+Put a space between `try` and the block. Format on a single line if it fits. Otherwise format the
+block as if it started with `try {` instead of `{`.
+
+```rust
+try { foo()?; bar()? }
+
+try {
+    foo()?;
+    bar()?
+}
+```
+
+### Heterogeneous
+
+Put a space between `try` and `bikeshed`, between `bikeshed` and the type, and between the type and
+the block. Format on a single line if it fits. Otherwise format the block as if it started with `try
+bikeshed Type {` instead of `{`, where `Type` is the type formatted on a single line.
+
+```rust
+try bikeshed Option<()> { foo()?; bar()? }
+
+try bikeshed Result<(), _> {
+    foo()?;
+    bar()?;
+}
+```
+
 ## Struct literals
 
 If a struct literal is *small*, format it on a single line, and do not use a

--- a/src/doc/style-guide/src/expressions.md
+++ b/src/doc/style-guide/src/expressions.md
@@ -6,8 +6,8 @@ A block expression must have a newline after the initial `{` and before the
 terminal `}`, unless it qualifies to be written as a single line based on
 another style rule.
 
-A keyword before the block (such as `unsafe` or `async`) must be on the same
-line as the opening brace, with a single space between the keyword and the
+A keyword before the block (such as `unsafe`, `async`, or `try`) must be on the
+same line as the opening brace, with a single space between the keyword and the
 opening brace. Indent the contents of the block.
 
 ```rust
@@ -154,35 +154,33 @@ move |arg1: i32, arg2: i32| -> i32 {
 }
 ```
 
-## Try blocks
+## `try` blocks with types
 
-### Homogeneous
+Use a single space between `try` and `bikeshed`, between `bikeshed` and the
+type, and between the type and `{`. Do not break between any of these.
 
-Put a space between `try` and the block. Format on a single line if it fits. Otherwise format the
-block as if it started with `try {` instead of `{`.
+If `try`, `bikeshed`, the type, and `{` fit on a single line, always format them
+that way. If, having done that, the block's formatting allows placing it on a
+single line, do so, otherwise break after the `{` and format the block as usual.
 
-```rust
-try { foo()?; bar()? }
-
-try {
-    foo()?;
-    bar()?
-}
-```
-
-### Heterogeneous
-
-Put a space between `try` and `bikeshed`, between `bikeshed` and the type, and between the type and
-the block. Format on a single line if it fits. Otherwise format the block as if it started with `try
-bikeshed Type {` instead of `{`, where `Type` is the type formatted on a single line.
+If `try`, `bikeshed`, the type, and `{` do not fit on a single line, then break
+within the type per the rules for formatting large types, and keep the `{` on
+the line with the end of the type (e.g. a closing `>` or `)`).
 
 ```rust
-try bikeshed Option<()> { foo()?; bar()? }
+try bikeshed Option<()> { foo()? }
 
 try bikeshed Result<(), _> {
     foo()?;
     bar()?;
 }
+
+try bikeshed Result<
+    VeryVeryVeryVeryLongTypeForSuccess,
+    VeryVeryVeryVeryLongTypeForFailure,
+> {
+    foo()?
+};
 ```
 
 ## Struct literals


### PR DESCRIPTION
The tracking issue for `try_blocks` is https://github.com/rust-lang/rust/issues/31436.
The tracking issue for `try_blocks_heterogeneous` is https://github.com/rust-lang/rust/issues/149488.

I'm not sure if this should be in `nightly.md` instead.

See [#t-lang > try blocks @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang/topic/try.20blocks/near/572556680) for context.

Also there doesn't seem to be any style guide about "overflowed expressions". If there were, then any decision on https://github.com/rust-lang/rustfmt/issues/6799 would be relevant to document.