### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
+++ b/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
@@ -1695,7 +1695,8 @@ impl<'a, 'tcx> BoundVarContext<'a, 'tcx> {
                 | DefKind::Union
                 | DefKind::Enum
                 | DefKind::TyAlias
-                | DefKind::Trait,
+                | DefKind::Trait
+                | DefKind::TraitAlias,
                 def_id,
             ) if depth == 0 => Some(def_id),
             _ => None,
@@ -1865,7 +1866,7 @@ impl<'a, 'tcx> BoundVarContext<'a, 'tcx> {
             if constraint.gen_args.parenthesized == hir::GenericArgsParentheses::ReturnTypeNotation
             {
                 let bound_vars = if let Some(type_def_id) = type_def_id
-                    && self.tcx.def_kind(type_def_id) == DefKind::Trait
+                    && let DefKind::Trait | DefKind::TraitAlias = self.tcx.def_kind(type_def_id)
                     && let Some((mut bound_vars, assoc_fn)) = BoundVarContext::supertrait_hrtb_vars(
                         self.tcx,
                         type_def_id,

--- a/tests/ui/associated-type-bounds/return-type-notation/trait-alias.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/trait-alias.rs
@@ -1,0 +1,13 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/152158>.
+//@ check-pass
+#![feature(return_type_notation, trait_alias)]
+
+trait Tr {
+    fn f() -> impl Sized;
+}
+
+trait Al = Tr;
+
+fn f<T: Al<f(..): Copy>>() {}
+
+fn main() {}

--- a/tests/ui/associated-type-bounds/trait-alias-bound-vars.rs
+++ b/tests/ui/associated-type-bounds/trait-alias-bound-vars.rs
@@ -1,0 +1,12 @@
+// Check that we're successfully collecting bound vars behind trait aliases.
+// Regression test for <https://github.com/rust-lang/rust/issues/152244>.
+//@ check-pass
+//@ needs-rustc-debug-assertions
+#![feature(trait_alias)]
+
+trait A<'a> { type X; }
+trait B: for<'a> A<'a> {}
+trait C = B;
+
+fn f<T>() where T: C<X: Copy> {}
+fn g<T>() where T: C<X: for<'r> A<'r>> {}

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1488,11 +1488,6 @@ infra-ci = [
     "@jdno",
     "@jieyouxu",
 ]
-rustdoc = [
-    "@GuillaumeGomez",
-    "@notriddle",
-    "@fmease",
-]
 docs = [
     "@ehuss",
     "@GuillaumeGomez",


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#152309 (Fix bound var resolution for trait aliases)
 - rust-lang/rust#152310 (Remove `rustdoc` adhoc group)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=152309,152310)
<!-- homu-ignore:end -->

