### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_mir_build/src/thir/cx/block.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/block.rs
@@ -75,8 +75,13 @@ impl<'tcx> ThirBuildCx<'tcx> {
                         debug!(?pattern);
 
                         let span = match local.init {
-                            Some(init) => local.span.with_hi(init.span.hi()),
-                            None => local.span,
+                            Some(init)
+                                if let Some(init_span) =
+                                    init.span.find_ancestor_inside_same_ctxt(local.span) =>
+                            {
+                                local.span.with_hi(init_span.hi())
+                            }
+                            Some(_) | None => local.span,
                         };
                         let stmt = Stmt {
                             kind: StmtKind::Let {

--- a/tests/ui/span/let-offset-of.rs
+++ b/tests/ui/span/let-offset-of.rs
@@ -1,0 +1,19 @@
+#![crate_type = "rlib"]
+//@ edition: 2024
+//@ check-pass
+
+// Using `offset_of` in the RHS of a let-else statement should not produce
+// malformed spans or a blank diagnostic snippet.
+//
+// Regression test for <https://github.com/rust-lang/rust/pull/152284>.
+
+fn init_to_offset_of() {
+    use std::mem::offset_of;
+    struct Foo { field: u32 }
+
+    if let x = offset_of!(Foo, field) {}
+    //~^ WARN irrefutable `if let` pattern
+
+    let x = offset_of!(Foo, field) else { return; };
+    //~^ WARN irrefutable `let...else` pattern
+}

--- a/tests/ui/span/let-offset-of.stderr
+++ b/tests/ui/span/let-offset-of.stderr
@@ -1,0 +1,17 @@
+warning: irrefutable `if let` pattern
+  --> $DIR/let-offset-of.rs:14:8
+   |
+LL |     if let x = offset_of!(Foo, field) {}
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this pattern will always match, so the `if let` is useless
+   = help: consider replacing the `if let` with a `let`
+   = note: `#[warn(irrefutable_let_patterns)]` on by default
+
+warning: irrefutable `let...else` pattern
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: 2 warnings emitted
+

--- a/tests/ui/span/let-offset-of.stderr
+++ b/tests/ui/span/let-offset-of.stderr
@@ -9,6 +9,10 @@ LL |     if let x = offset_of!(Foo, field) {}
    = note: `#[warn(irrefutable_let_patterns)]` on by default
 
 warning: irrefutable `let...else` pattern
+  --> $DIR/let-offset-of.rs:17:5
+   |
+LL |     let x = offset_of!(Foo, field) else { return; };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this pattern will always match, so the `else` clause is useless
    = help: consider removing the `else` clause

--- a/tests/ui/thir-print/offset_of.stdout
+++ b/tests/ui/thir-print/offset_of.stdout
@@ -68,7 +68,7 @@ body:
                                             )
                                             else_block: None
                                             hir_id: HirId(DefId(offset_of::concrete).10)
-                                            span: $DIR/offset_of.rs:37:5: 1445:57 (#0)
+                                            span: $DIR/offset_of.rs:37:5: 37:33 (#0)
                                         }
                                     }
                                     Stmt {
@@ -117,7 +117,7 @@ body:
                                             )
                                             else_block: None
                                             hir_id: HirId(DefId(offset_of::concrete).20)
-                                            span: $DIR/offset_of.rs:38:5: 1445:57 (#0)
+                                            span: $DIR/offset_of.rs:38:5: 38:33 (#0)
                                         }
                                     }
                                     Stmt {
@@ -166,7 +166,7 @@ body:
                                             )
                                             else_block: None
                                             hir_id: HirId(DefId(offset_of::concrete).30)
-                                            span: $DIR/offset_of.rs:39:5: 1445:57 (#0)
+                                            span: $DIR/offset_of.rs:39:5: 39:34 (#0)
                                         }
                                     }
                                     Stmt {
@@ -215,7 +215,7 @@ body:
                                             )
                                             else_block: None
                                             hir_id: HirId(DefId(offset_of::concrete).40)
-                                            span: $DIR/offset_of.rs:40:5: 1445:57 (#0)
+                                            span: $DIR/offset_of.rs:40:5: 40:36 (#0)
                                         }
                                     }
                                     Stmt {
@@ -264,7 +264,7 @@ body:
                                             )
                                             else_block: None
                                             hir_id: HirId(DefId(offset_of::concrete).50)
-                                            span: $DIR/offset_of.rs:41:5: 1445:57 (#0)
+                                            span: $DIR/offset_of.rs:41:5: 41:36 (#0)
                                         }
                                     }
                                 ]
@@ -864,7 +864,7 @@ body:
                                             )
                                             else_block: None
                                             hir_id: HirId(DefId(offset_of::generic).12)
-                                            span: $DIR/offset_of.rs:45:5: 1445:57 (#0)
+                                            span: $DIR/offset_of.rs:45:5: 45:37 (#0)
                                         }
                                     }
                                     Stmt {
@@ -913,7 +913,7 @@ body:
                                             )
                                             else_block: None
                                             hir_id: HirId(DefId(offset_of::generic).24)
-                                            span: $DIR/offset_of.rs:46:5: 1445:57 (#0)
+                                            span: $DIR/offset_of.rs:46:5: 46:37 (#0)
                                         }
                                     }
                                     Stmt {
@@ -962,7 +962,7 @@ body:
                                             )
                                             else_block: None
                                             hir_id: HirId(DefId(offset_of::generic).36)
-                                            span: $DIR/offset_of.rs:47:5: 1445:57 (#0)
+                                            span: $DIR/offset_of.rs:47:5: 47:37 (#0)
                                         }
                                     }
                                     Stmt {
@@ -1011,7 +1011,7 @@ body:
                                             )
                                             else_block: None
                                             hir_id: HirId(DefId(offset_of::generic).48)
-                                            span: $DIR/offset_of.rs:48:5: 1445:57 (#0)
+                                            span: $DIR/offset_of.rs:48:5: 48:37 (#0)
                                         }
                                     }
                                 ]

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1488,11 +1488,6 @@ infra-ci = [
     "@jdno",
     "@jieyouxu",
 ]
-rustdoc = [
-    "@GuillaumeGomez",
-    "@notriddle",
-    "@fmease",
-]
 docs = [
     "@ehuss",
     "@GuillaumeGomez",


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#152310 (Remove `rustdoc` adhoc group)
 - rust-lang/rust#152284 (Avoid a bogus THIR span for `let x = offset_of!(..)`)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=152310,152284)
<!-- homu-ignore:end -->

