### PR TITLE
Fix ICE in borrowck when recovering `fn_sig` for `-> _`

### DIFF
--- a/tests/crashes/135845.rs
+++ b/tests/crashes/135845.rs
@@ -1,6 +1,0 @@
-//@ known-bug: #135845
-struct S<'a, T: ?Sized>(&'a T);
-
-fn b<'a>() -> S<'static, _> {
-    S::<'a>(&0)
-}

--- a/tests/ui/lifetimes/recover-infer-ret-ty-issue-135845.rs
+++ b/tests/ui/lifetimes/recover-infer-ret-ty-issue-135845.rs
@@ -1,0 +1,11 @@
+// Regression test for #135845.
+
+use std::marker::PhantomData;
+
+fn b<'a>() -> _ {
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types [E0121]
+    let _: PhantomData<&'a ()> = PhantomData;
+    0
+}
+
+fn main() {}

--- a/tests/ui/lifetimes/recover-infer-ret-ty-issue-135845.stderr
+++ b/tests/ui/lifetimes/recover-infer-ret-ty-issue-135845.stderr
@@ -1,0 +1,15 @@
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/recover-infer-ret-ty-issue-135845.rs:5:15
+   |
+LL | fn b<'a>() -> _ {
+   |               ^ not allowed in type signatures
+   |
+help: replace with the correct return type
+   |
+LL - fn b<'a>() -> _ {
+LL + fn b<'a>() -> i32 {
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0121`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
(Should be) a proper fix for rust-lang/rust#135845, replaces a dummy binder with a concrete one not to ICE, as mentioned in https://github.com/rust-lang/rust/pull/147631#issuecomment-3460724226.
Fixes rust-lang/rust#135845
r? @lcnr @jackh726 