### PR TITLE
Remove more adhoc groups that correspond to teams

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1536,13 +1536,6 @@ mir-opt = [
     "@wesleywiser",
     "@saethlin",
 ]
-types = [
-    "@jackh726",
-    "@lcnr",
-    "@oli-obk",
-    "@spastorino",
-    "@BoxyUwU",
-]
 borrowck = [
     "@davidtwco",
     "@matthewjasper"

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1555,10 +1555,6 @@ style-team = [
     "@joshtriplett",
     "@traviscross",
 ]
-project-exploit-mitigations = [
-    "@cuviper",
-    "@rcvalle",
-]
 compiletest = [
     "@jieyouxu",
 ]

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1555,11 +1555,6 @@ style-team = [
     "@joshtriplett",
     "@traviscross",
 ]
-project-const-traits = [
-    "@fee1-dead",
-    "@fmease",
-    "@oli-obk",
-]
 project-stable-mir = [
     "@celinval",
     "@oli-obk",

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1555,12 +1555,6 @@ style-team = [
     "@joshtriplett",
     "@traviscross",
 ]
-project-stable-mir = [
-    "@celinval",
-    "@oli-obk",
-    "@scottmcm",
-    "@makai410",
-]
 project-exploit-mitigations = [
     "@cuviper",
     "@rcvalle",


### PR DESCRIPTION
Following in the footsteps of https://github.com/rust-lang/rust/pull/152310.

- [types](https://github.com/rust-lang/team/blob/main/teams/types.toml) team - removed Niko and lqd from team rotation in triagebot
- [project-const-traits](https://github.com/rust-lang/team/blob/main/teams/project-const-traits.toml) - no changes needed, whole team was already on rotation
- [project-stable-mir](https://github.com/rust-lang/team/blob/main/teams/project-stable-mir.toml) - no changes needed, whole team was already on rotation
- [project-exploit-mitigations](https://github.com/rust-lang/team/blob/main/teams/project-exploit-mitigations.toml) - removed 1c3t3a from team rotation in triagebot (TODO - it didn't work yet, need to fix triagebot to allow running commands on top of people that are only in project/working groups)