### PR TITLE
Fix a few diagnostics

### DIFF
--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -503,7 +503,7 @@ pub(crate) struct AutoTraitItems {
     #[primary_span]
     pub spans: Vec<Span>,
     #[suggestion(
-        "remove the super traits or lifetime bounds",
+        "remove the associated items",
         code = "",
         applicability = "machine-applicable",
         style = "tool-only"

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -22,7 +22,7 @@ pub(crate) struct CallToDeprecatedSafeFnRequiresUnsafe {
 
 #[derive(Subdiagnostic)]
 #[multipart_suggestion(
-    "you can wrap the call in an `unsafe` block if you can guarantee that the environment access only happens in single-threaded code",
+    "you can wrap the call in an `unsafe` block if you can guarantee {$guarantee}",
     applicability = "machine-applicable"
 )]
 pub(crate) struct CallToDeprecatedSafeFnRequiresUnsafeSub {

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -2266,7 +2266,9 @@ pub(crate) enum AmbiguousMissingKwForItemSub {
         span: Span,
         snippet: String,
     },
-    #[help("you likely meant to define an item, e.g., `{$vis} fn foo() {\"{}\"}`")]
+    #[help(
+        "if you meant to call a macro, remove the `pub` and add a trailing `!` after the identifier"
+    )]
     HelpMacro,
 }
 

--- a/tests/ui/auto-traits/assoc-ty.current.stderr
+++ b/tests/ui/auto-traits/assoc-ty.current.stderr
@@ -1,9 +1,9 @@
 error[E0380]: auto traits cannot have associated items
-  --> $DIR/assoc-ty.rs:10:10
+  --> $DIR/assoc-ty.rs:11:10
    |
 LL | auto trait Trait {
    |            ----- auto traits cannot have associated items
-LL |
+...
 LL |     type Output;
    |          ^^^^^^
 
@@ -12,8 +12,9 @@ error[E0658]: auto traits are experimental and possibly buggy
    |
 LL | / auto trait Trait {
 LL | |
-LL | |     type Output;
 LL | |
+LL | |     type Output;
+...  |
 LL | | }
    | |_^
    |
@@ -22,7 +23,7 @@ LL | | }
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0308]: mismatched types
-  --> $DIR/assoc-ty.rs:15:36
+  --> $DIR/assoc-ty.rs:17:36
    |
 LL |     let _: <() as Trait>::Output = ();
    |            ---------------------   ^^ expected associated type, found `()`

--- a/tests/ui/auto-traits/assoc-ty.next.stderr
+++ b/tests/ui/auto-traits/assoc-ty.next.stderr
@@ -1,9 +1,9 @@
 error[E0380]: auto traits cannot have associated items
-  --> $DIR/assoc-ty.rs:10:10
+  --> $DIR/assoc-ty.rs:11:10
    |
 LL | auto trait Trait {
    |            ----- auto traits cannot have associated items
-LL |
+...
 LL |     type Output;
    |          ^^^^^^
 
@@ -12,8 +12,9 @@ error[E0658]: auto traits are experimental and possibly buggy
    |
 LL | / auto trait Trait {
 LL | |
-LL | |     type Output;
 LL | |
+LL | |     type Output;
+...  |
 LL | | }
    | |_^
    |
@@ -22,13 +23,13 @@ LL | | }
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0271]: type mismatch resolving `<() as Trait>::Output normalizes-to _`
-  --> $DIR/assoc-ty.rs:15:12
+  --> $DIR/assoc-ty.rs:17:12
    |
 LL |     let _: <() as Trait>::Output = ();
    |            ^^^^^^^^^^^^^^^^^^^^^ types differ
 
 error[E0271]: type mismatch resolving `<() as Trait>::Output normalizes-to _`
-  --> $DIR/assoc-ty.rs:15:12
+  --> $DIR/assoc-ty.rs:17:12
    |
 LL |     let _: <() as Trait>::Output = ();
    |            ^^^^^^^^^^^^^^^^^^^^^ types differ

--- a/tests/ui/auto-traits/assoc-ty.rs
+++ b/tests/ui/auto-traits/assoc-ty.rs
@@ -7,13 +7,16 @@
 
 auto trait Trait {
     //~^ ERROR auto traits are experimental and possibly buggy
+    //~| HELP add `#![feature(auto_traits)]` to the crate attributes to enable
     type Output;
     //~^ ERROR auto traits cannot have associated items
+    //~| HELP remove the associated items
 }
 
 fn main() {
     let _: <() as Trait>::Output = ();
     //[current]~^ ERROR mismatched types
-    //[next]~^^ ERROR type mismatch resolving `<() as Trait>::Output normalizes-to _`
+    //[current]~| HELP consider constraining the associated type `<() as Trait>::Output` to `()` or calling a method that returns `<() as Trait>::Output`
+    //[next]~^^^ ERROR type mismatch resolving `<() as Trait>::Output normalizes-to _`
     //[next]~| ERROR type mismatch resolving `<() as Trait>::Output normalizes-to _`
 }

--- a/tests/ui/macros/metavar-expressions/usage-errors.rs
+++ b/tests/ui/macros/metavar-expressions/usage-errors.rs
@@ -27,6 +27,7 @@ curly__rhs_dollar__no_round !(a);
 macro_rules! no_curly__no_rhs_dollar__round {
     ( $( $i:ident ),* ) => { count(i) };
     //~^ ERROR missing `fn` or `struct` for function or struct definition
+    //~| HELP if you meant to call a macro, try
 }
 no_curly__no_rhs_dollar__round !(a, b, c);
 
@@ -34,6 +35,7 @@ no_curly__no_rhs_dollar__round !(a, b, c);
 macro_rules! no_curly__no_rhs_dollar__no_round {
     ( $i:ident ) => { count(i) };
     //~^ ERROR missing `fn` or `struct` for function or struct definition
+    //~| HELP if you meant to call a macro, try
 }
 no_curly__no_rhs_dollar__no_round !(a);
 

--- a/tests/ui/macros/metavar-expressions/usage-errors.stderr
+++ b/tests/ui/macros/metavar-expressions/usage-errors.stderr
@@ -26,7 +26,7 @@ LL |     ( $( $i:ident ),* ) => { count!(i) };
    |                                   +
 
 error: missing `fn` or `struct` for function or struct definition
-  --> $DIR/usage-errors.rs:35:23
+  --> $DIR/usage-errors.rs:36:23
    |
 LL |     ( $i:ident ) => { count(i) };
    |                       ^^^^^
@@ -41,13 +41,13 @@ LL |     ( $i:ident ) => { count!(i) };
    |                            +
 
 error: variable `i` is still repeating at this depth
-  --> $DIR/usage-errors.rs:42:36
+  --> $DIR/usage-errors.rs:44:36
    |
 LL |     ( $( $i:ident ),* ) => { count($i) };
    |                                    ^^
 
 error[E0425]: cannot find value `a` in this scope
-  --> $DIR/usage-errors.rs:52:49
+  --> $DIR/usage-errors.rs:54:49
    |
 LL |     ( $i:ident ) => { count($i) };
    |                             -- due to this macro variable
@@ -56,7 +56,7 @@ LL | const _: u32 = no_curly__rhs_dollar__no_round! (a);
    |                                                 ^ not found in this scope
 
 error[E0425]: cannot find function `count` in this scope
-  --> $DIR/usage-errors.rs:49:23
+  --> $DIR/usage-errors.rs:51:23
    |
 LL |     ( $i:ident ) => { count($i) };
    |                       ^^^^^ not found in this scope

--- a/tests/ui/rust-2024/unsafe-before_exec-suggestion.fixed
+++ b/tests/ui/rust-2024/unsafe-before_exec-suggestion.fixed
@@ -1,0 +1,18 @@
+//@ edition:2015
+//@ only-unix
+//@ run-rustfix
+
+#![deny(deprecated_safe_2024)]
+
+use std::process::Command;
+use std::os::unix::process::CommandExt;
+
+#[allow(deprecated)]
+fn main() {
+    let mut cmd = Command::new("sleep");
+    // TODO: Audit that the closure is async-signal-safe.
+    unsafe { cmd.before_exec(|| Ok(())) };
+    //~^ ERROR call to deprecated safe function
+    //~| WARN this is accepted in the current edition
+    drop(cmd);
+}

--- a/tests/ui/rust-2024/unsafe-before_exec-suggestion.rs
+++ b/tests/ui/rust-2024/unsafe-before_exec-suggestion.rs
@@ -1,0 +1,17 @@
+//@ edition:2015
+//@ only-unix
+//@ run-rustfix
+
+#![deny(deprecated_safe_2024)]
+
+use std::process::Command;
+use std::os::unix::process::CommandExt;
+
+#[allow(deprecated)]
+fn main() {
+    let mut cmd = Command::new("sleep");
+    cmd.before_exec(|| Ok(()));
+    //~^ ERROR call to deprecated safe function
+    //~| WARN this is accepted in the current edition
+    drop(cmd);
+}

--- a/tests/ui/rust-2024/unsafe-before_exec-suggestion.stderr
+++ b/tests/ui/rust-2024/unsafe-before_exec-suggestion.stderr
@@ -1,0 +1,21 @@
+error: call to deprecated safe function `std::os::unix::process::CommandExt::before_exec` is unsafe and requires unsafe block
+  --> $DIR/unsafe-before_exec-suggestion.rs:13:5
+   |
+LL |     cmd.before_exec(|| Ok(()));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/newly-unsafe-functions.html>
+note: the lint level is defined here
+  --> $DIR/unsafe-before_exec-suggestion.rs:5:9
+   |
+LL | #![deny(deprecated_safe_2024)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+help: you can wrap the call in an `unsafe` block if you can guarantee that the closure is async-signal-safe
+   |
+LL +     // TODO: Audit that the closure is async-signal-safe.
+LL ~     unsafe { cmd.before_exec(|| Ok(())) };
+   |
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
When working on the inline diagnostics conversion (https://github.com/rust-lang/rust/issues/151366), I noticed that my script sometimes took the wrong message. 
Because it didn't happen very often, I just fixed it manually when a uitest fails.

However I got paranoid that the script changed messages that were not covered by uitests, so I checked for all messages in the previous `messages.ftl` files, whether they occured at least once in the codebase. I found 3 messages that indeed were wrongly replaced by my script, fixed them, and added uitests to make sure this doesn't happen again :)

r? @jdonszelmann (Anyone else, also feel free to review, just assigning to Jana because she's been reviewing the other PRs)