### PR TITLE
Remove `fallback = "niko"` from the attribute documentation

### DIFF
--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -1001,7 +1001,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         template!(List: &[
             "",
             r#"fallback = "unit""#,
-            r#"fallback = "niko""#,
             r#"fallback = "never""#,
             r#"fallback = "no""#,
         ]),

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -536,7 +536,7 @@ fn parse_never_type_options_attr(
                 sym::never => fallback = Some(DivergingFallbackBehavior::ToNever),
                 sym::no => fallback = Some(DivergingFallbackBehavior::NoFallback),
                 _ => {
-                    tcx.dcx().span_err(item.span(), format!("unknown never type fallback mode: `{mode}` (supported: `unit`, `niko`, `never` and `no`)"));
+                    tcx.dcx().span_err(item.span(), format!("unknown never type fallback mode: `{mode}` (supported: `unit`, `never` and `no`)"));
                 }
             };
             continue;

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1574,7 +1574,6 @@ symbols! {
         new_v1,
         new_v1_formatted,
         next,
-        niko,
         nll,
         no,
         no_builtins,


### PR DESCRIPTION
r? @WaffleLapkin 
cc @jdonszelmann 

Not exactly sure what happened to this option, but it no longer seems to be implemented