### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
+++ b/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
@@ -1695,7 +1695,8 @@ impl<'a, 'tcx> BoundVarContext<'a, 'tcx> {
                 | DefKind::Union
                 | DefKind::Enum
                 | DefKind::TyAlias
-                | DefKind::Trait,
+                | DefKind::Trait
+                | DefKind::TraitAlias,
                 def_id,
             ) if depth == 0 => Some(def_id),
             _ => None,
@@ -1865,7 +1866,7 @@ impl<'a, 'tcx> BoundVarContext<'a, 'tcx> {
             if constraint.gen_args.parenthesized == hir::GenericArgsParentheses::ReturnTypeNotation
             {
                 let bound_vars = if let Some(type_def_id) = type_def_id
-                    && self.tcx.def_kind(type_def_id) == DefKind::Trait
+                    && let DefKind::Trait | DefKind::TraitAlias = self.tcx.def_kind(type_def_id)
                     && let Some((mut bound_vars, assoc_fn)) = BoundVarContext::supertrait_hrtb_vars(
                         self.tcx,
                         type_def_id,

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -2426,14 +2426,12 @@ impl SourceFile {
     /// normalized one. Hence we need to convert those offsets to the normalized
     /// form when constructing spans.
     pub fn normalized_byte_pos(&self, offset: u32) -> BytePos {
-        let diff = match self
-            .normalized_pos
-            .binary_search_by(|np| (np.pos.0 + np.diff).cmp(&(self.start_pos.0 + offset)))
-        {
-            Ok(i) => self.normalized_pos[i].diff,
-            Err(0) => 0,
-            Err(i) => self.normalized_pos[i - 1].diff,
-        };
+        let diff =
+            match self.normalized_pos.binary_search_by(|np| (np.pos.0 + np.diff).cmp(&offset)) {
+                Ok(i) => self.normalized_pos[i].diff,
+                Err(0) => 0,
+                Err(i) => self.normalized_pos[i - 1].diff,
+            };
 
         BytePos::from_u32(self.start_pos.0 + offset - diff)
     }

--- a/src/tools/compiletest/src/directives/needs.rs
+++ b/src/tools/compiletest/src/directives/needs.rs
@@ -290,7 +290,7 @@ pub(super) fn handle_needs(
     }
 
     // Handled elsewhere.
-    if name == "needs-llvm-components" {
+    if name == "needs-llvm-components" || name == "needs-backends" {
         return IgnoreDecision::Continue;
     }
 

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -150,6 +150,7 @@ fn check_unexpected_extension(check: &mut RunningCheck, file_path: &Path, ext: &
 
     const EXTENSION_EXCEPTION_PATHS: &[&str] = &[
         "tests/ui/asm/named-asm-labels.s", // loading an external asm file to test named labels lint
+        "tests/ui/asm/normalize-offsets-for-crlf.s", // loading an external asm file to test CRLF normalization
         "tests/ui/codegen/mismatched-data-layout.json", // testing mismatched data layout w/ custom targets
         "tests/ui/check-cfg/my-awesome-platform.json",  // testing custom targets with cfgs
         "tests/ui/argfile/commandline-argfile-badutf8.args", // passing args via a file

--- a/tests/codegen-llvm/gpu_offload/control_flow.rs
+++ b/tests/codegen-llvm/gpu_offload/control_flow.rs
@@ -19,9 +19,9 @@
 // CHECK: br label %bb3
 // CHECK-NOT define
 // CHECK: bb3
-// CHECK: call void @__tgt_target_data_begin_mapper(ptr nonnull @anon.{{.*}}.1, i64 -1, i32 1, ptr nonnull %.offload_baseptrs, ptr nonnull %.offload_ptrs, ptr nonnull %.offload_sizes, ptr nonnull @.offload_maptypes.foo, ptr null, ptr null)
+// CHECK: call void @__tgt_target_data_begin_mapper(ptr nonnull @anon.{{.*}}.1, i64 -1, i32 1, ptr nonnull %.offload_baseptrs, ptr nonnull %.offload_ptrs, ptr nonnull %.offload_sizes, ptr nonnull @.offload_maptypes.foo.begin, ptr null, ptr null)
 // CHECK: %10 = call i32 @__tgt_target_kernel(ptr nonnull @anon.{{.*}}.1, i64 -1, i32 256, i32 32, ptr nonnull @.foo.region_id, ptr nonnull %kernel_args)
-// CHECK-NEXT: call void @__tgt_target_data_end_mapper(ptr nonnull @anon.{{.*}}.1, i64 -1, i32 1, ptr nonnull %.offload_baseptrs, ptr nonnull %.offload_ptrs, ptr nonnull %.offload_sizes, ptr nonnull @.offload_maptypes.foo, ptr null, ptr null)
+// CHECK-NEXT: call void @__tgt_target_data_end_mapper(ptr nonnull @anon.{{.*}}.1, i64 -1, i32 1, ptr nonnull %.offload_baseptrs, ptr nonnull %.offload_ptrs, ptr nonnull %.offload_sizes, ptr nonnull @.offload_maptypes.foo.end, ptr null, ptr null)
 #[unsafe(no_mangle)]
 unsafe fn main() {
     let A = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0];

--- a/tests/codegen-llvm/gpu_offload/gpu_host.rs
+++ b/tests/codegen-llvm/gpu_offload/gpu_host.rs
@@ -14,19 +14,20 @@
 #[unsafe(no_mangle)]
 fn main() {
     let mut x = [3.0; 256];
-    kernel_1(&mut x);
+    let y = [1.0; 256];
+    kernel_1(&mut x, &y);
     core::hint::black_box(&x);
+    core::hint::black_box(&y);
 }
 
-pub fn kernel_1(x: &mut [f32; 256]) {
-    core::intrinsics::offload(kernel_1, [256, 1, 1], [32, 1, 1], (x,))
+pub fn kernel_1(x: &mut [f32; 256], y: &[f32; 256]) {
+    core::intrinsics::offload(_kernel_1, [256, 1, 1], [32, 1, 1], (x, y))
 }
 
-#[unsafe(no_mangle)]
 #[inline(never)]
-pub fn _kernel_1(x: &mut [f32; 256]) {
+pub fn _kernel_1(x: &mut [f32; 256], y: &[f32; 256]) {
     for i in 0..256 {
-        x[i] = 21.0;
+        x[i] = 21.0 + y[i];
     }
 }
 
@@ -39,8 +40,10 @@ pub fn _kernel_1(x: &mut [f32; 256]) {
 
 // CHECK-DAG: @.omp_offloading.descriptor = internal constant { i32, ptr, ptr, ptr } zeroinitializer
 // CHECK-DAG: @llvm.global_ctors = appending constant [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 101, ptr @.omp_offloading.descriptor_reg, ptr null }]
-// CHECK-DAG: @.offload_sizes.[[K:[^ ]*kernel_1]] = private unnamed_addr constant [1 x i64] [i64 1024]
-// CHECK-DAG: @.offload_maptypes.[[K]] = private unnamed_addr constant [1 x i64] [i64 35]
+// CHECK-DAG: @.offload_sizes.[[K:[^ ]*kernel_1]] = private unnamed_addr constant [2 x i64] [i64 1024, i64 1024]
+// CHECK-DAG: @.offload_maptypes.[[K]].begin = private unnamed_addr constant [2 x i64] [i64 1, i64 1]
+// CHECK-DAG: @.offload_maptypes.[[K]].kernel = private unnamed_addr constant [2 x i64] [i64 32, i64 32]
+// CHECK-DAG: @.offload_maptypes.[[K]].end = private unnamed_addr constant [2 x i64] [i64 2, i64 0]
 // CHECK-DAG: @.[[K]].region_id = internal constant i8 0
 // CHECK-DAG: @.offloading.entry_name.[[K]] = internal unnamed_addr constant [{{[0-9]+}} x i8] c"[[K]]{{\\00}}", section ".llvm.rodata.offloading", align 1
 // CHECK-DAG: @.offloading.entry.[[K]] = internal constant %struct.__tgt_offload_entry { i64 0, i16 1, i16 1, i32 0, ptr @.[[K]].region_id, ptr @.offloading.entry_name.[[K]], i64 0, i64 0, ptr null }, section "llvm_offload_entries", align 8
@@ -49,20 +52,27 @@ pub fn _kernel_1(x: &mut [f32; 256]) {
 
 // CHECK-LABEL: define{{( dso_local)?}} void @main()
 // CHECK-NEXT: start:
-// CHECK-NEXT:  %0 = alloca [8 x i8], align 8
-// CHECK-NEXT:  %x = alloca [1024 x i8], align 16
-// CHECK-NEXT:   %.offload_baseptrs = alloca [1 x ptr], align 8
-// CHECK-NEXT:   %.offload_ptrs = alloca [1 x ptr], align 8
-// CHECK-NEXT:   %.offload_sizes = alloca [1 x i64], align 8
+// CHECK-NEXT:   %0 = alloca [8 x i8], align 8
+// CHECK-NEXT:   %1 = alloca [8 x i8], align 8
+// CHECK-NEXT:   %y = alloca [1024 x i8], align 16
+// CHECK-NEXT:   %x = alloca [1024 x i8], align 16
+// CHECK-NEXT:   %.offload_baseptrs = alloca [2 x ptr], align 8
+// CHECK-NEXT:   %.offload_ptrs = alloca [2 x ptr], align 8
+// CHECK-NEXT:   %.offload_sizes = alloca [2 x i64], align 8
 // CHECK-NEXT:   %kernel_args = alloca %struct.__tgt_kernel_arguments, align 8
-// CHECK:        call void @__tgt_init_all_rtls()
-// CHECK-NEXT:   store ptr %x, ptr %.offload_baseptrs, align 8
+// CHECK:   store ptr %x, ptr %.offload_baseptrs, align 8
 // CHECK-NEXT:   store ptr %x, ptr %.offload_ptrs, align 8
 // CHECK-NEXT:   store i64 1024, ptr %.offload_sizes, align 8
-// CHECK-NEXT:   call void @__tgt_target_data_begin_mapper(ptr nonnull @anon.{{.*}}.1, i64 -1, i32 1, ptr nonnull %.offload_baseptrs, ptr nonnull %.offload_ptrs, ptr nonnull %.offload_sizes, ptr nonnull @.offload_maptypes.[[K]], ptr null, ptr null)
+// CHECK-NEXT:   [[BPTRS_1:%.*]] = getelementptr inbounds nuw i8, ptr %.offload_baseptrs, i64 8
+// CHECK-NEXT:   store ptr %y, ptr [[BPTRS_1]], align 8
+// CHECK-NEXT:   [[PTRS_1:%.*]] = getelementptr inbounds nuw i8, ptr %.offload_ptrs, i64 8
+// CHECK-NEXT:   store ptr %y, ptr [[PTRS_1]], align 8
+// CHECK-NEXT:   [[SIZES_1:%.*]] = getelementptr inbounds nuw i8, ptr %.offload_sizes, i64 8
+// CHECK-NEXT:   store i64 1024, ptr [[SIZES_1]], align 8
+// CHECK-NEXT:   call void @__tgt_target_data_begin_mapper(ptr nonnull @anon.{{.*}}.1, i64 -1, i32 2, ptr nonnull %.offload_baseptrs, ptr nonnull %.offload_ptrs, ptr nonnull %.offload_sizes, ptr nonnull @.offload_maptypes.[[K]].begin, ptr null, ptr null)
 // CHECK-NEXT:   store i32 3, ptr %kernel_args, align 8
 // CHECK-NEXT:   [[P4:%[^ ]+]] = getelementptr inbounds nuw i8, ptr %kernel_args, i64 4
-// CHECK-NEXT:   store i32 1, ptr [[P4]], align 4
+// CHECK-NEXT:   store i32 2, ptr [[P4]], align 4
 // CHECK-NEXT:   [[P8:%[^ ]+]] = getelementptr inbounds nuw i8, ptr %kernel_args, i64 8
 // CHECK-NEXT:   store ptr %.offload_baseptrs, ptr [[P8]], align 8
 // CHECK-NEXT:   [[P16:%[^ ]+]] = getelementptr inbounds nuw i8, ptr %kernel_args, i64 16
@@ -70,7 +80,7 @@ pub fn _kernel_1(x: &mut [f32; 256]) {
 // CHECK-NEXT:   [[P24:%[^ ]+]] = getelementptr inbounds nuw i8, ptr %kernel_args, i64 24
 // CHECK-NEXT:   store ptr %.offload_sizes, ptr [[P24]], align 8
 // CHECK-NEXT:   [[P32:%[^ ]+]] = getelementptr inbounds nuw i8, ptr %kernel_args, i64 32
-// CHECK-NEXT:   store ptr @.offload_maptypes.[[K]], ptr [[P32]], align 8
+// CHECK-NEXT:   store ptr @.offload_maptypes.[[K]].kernel, ptr [[P32]], align 8
 // CHECK-NEXT:   [[P40:%[^ ]+]] = getelementptr inbounds nuw i8, ptr %kernel_args, i64 40
 // CHECK-NEXT:   [[P72:%[^ ]+]] = getelementptr inbounds nuw i8, ptr %kernel_args, i64 72
 // CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr noundef nonnull align 8 dereferenceable(32) [[P40]], i8 0, i64 32, i1 false)
@@ -81,9 +91,9 @@ pub fn _kernel_1(x: &mut [f32; 256]) {
 // CHECK-NEXT:   store i32 1, ptr [[P92]], align 4
 // CHECK-NEXT:   [[P96:%[^ ]+]] = getelementptr inbounds nuw i8, ptr %kernel_args, i64 96
 // CHECK-NEXT:   store i32 0, ptr [[P96]], align 8
-// CHECK-NEXT:   {{%[^ ]+}} = call i32 @__tgt_target_kernel(ptr nonnull @anon.{{.*}}.1, i64 -1, i32 256, i32 32, ptr nonnull @.[[K]].region_id, ptr nonnull %kernel_args)
-// CHECK-NEXT:   call void @__tgt_target_data_end_mapper(ptr nonnull @anon.{{.*}}.1, i64 -1, i32 1, ptr nonnull %.offload_baseptrs, ptr nonnull %.offload_ptrs, ptr nonnull %.offload_sizes, ptr nonnull @.offload_maptypes.[[K]], ptr null, ptr null)
-// CHECK:   ret void
+// CHECK-NEXT:   [[TGT_RET:%.*]] = call i32 @__tgt_target_kernel(ptr nonnull @anon.{{.*}}.1, i64 -1, i32 256, i32 32, ptr nonnull @.[[K]].region_id, ptr nonnull %kernel_args)
+// CHECK-NEXT:   call void @__tgt_target_data_end_mapper(ptr nonnull @anon.{{.*}}.1, i64 -1, i32 2, ptr nonnull %.offload_baseptrs, ptr nonnull %.offload_ptrs, ptr nonnull %.offload_sizes, ptr nonnull @.offload_maptypes.[[K]].end, ptr null, ptr null)
+// CHECK:  ret void
 // CHECK-NEXT: }
 
 // CHECK: declare void @__tgt_register_lib(ptr) local_unnamed_addr
@@ -92,6 +102,7 @@ pub fn _kernel_1(x: &mut [f32; 256]) {
 // CHECK-LABEL: define internal void @.omp_offloading.descriptor_reg() section ".text.startup" {
 // CHECK-NEXT: entry:
 // CHECK-NEXT:   call void @__tgt_register_lib(ptr nonnull @.omp_offloading.descriptor)
+// CHECK-NEXT:   call void @__tgt_init_all_rtls()
 // CHECK-NEXT:   %0 = {{tail }}call i32 @atexit(ptr nonnull @.omp_offloading.descriptor_unreg)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }

--- a/tests/ui/asm/.gitattributes
+++ b/tests/ui/asm/.gitattributes
@@ -1,0 +1,2 @@
+# Disable EOL normalization, as it is deliberately denormalized
+normalize-offsets-for-crlf.s -text

--- a/tests/ui/asm/normalize-offsets-for-crlf.rs
+++ b/tests/ui/asm/normalize-offsets-for-crlf.rs
@@ -1,0 +1,14 @@
+// Byte positions into inline assembly reported by codegen errors require normalization or else
+// they may not identify the appropriate span.  Worse still, an ICE can occur if the erroneous
+// span begins or ends part-way through a multibyte character.
+//
+// Regression test for https://github.com/rust-lang/rust/issues/110885
+
+// This test is tied to assembler syntax and errors, which can vary by backend and architecture.
+//@only-x86_64
+//@needs-backends: llvm
+//@build-fail
+
+//~? ERROR instruction mnemonic
+std::arch::global_asm!(include_str!("normalize-offsets-for-crlf.s"));
+fn main() {}

--- a/tests/ui/asm/normalize-offsets-for-crlf.s
+++ b/tests/ui/asm/normalize-offsets-for-crlf.s
@@ -1,0 +1,13 @@
+// This file contains (some) CRLF line endings.  When codegen reports an error, the byte
+// offsets into this file that it identifies require normalization or else they will not
+// identify the appropriate span.  Worse still, an ICE can result if the erroneous span
+// begins or ends part-way through a multibyte character such as £.
+non_existent_mnemonic
+
+// Without normalization, the three CRLF line endings below cause the diagnostic on the
+// `non_existent_mnemonic` above to be spanned three bytes backward, and thus begin
+// part-way inside the multibyte character in the preceding comment.
+//
+// NOTE: The lines of this note DELIBERATELY end with CRLF - DO NOT strip/convert them!
+//       It may not be obvious if you accidentally do, eg `git diff` may appear to show
+//       that the lines have been updated to the exact same content.

--- a/tests/ui/asm/normalize-offsets-for-crlf.stderr
+++ b/tests/ui/asm/normalize-offsets-for-crlf.stderr
@@ -1,0 +1,10 @@
+error: invalid instruction mnemonic 'non_existent_mnemonic'
+   |
+note: instantiated into assembly here
+  --> <inline asm>:6:1
+   |
+LL | non_existent_mnemonic
+   | ^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/associated-type-bounds/return-type-notation/trait-alias.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/trait-alias.rs
@@ -1,0 +1,13 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/152158>.
+//@ check-pass
+#![feature(return_type_notation, trait_alias)]
+
+trait Tr {
+    fn f() -> impl Sized;
+}
+
+trait Al = Tr;
+
+fn f<T: Al<f(..): Copy>>() {}
+
+fn main() {}

--- a/tests/ui/associated-type-bounds/trait-alias-bound-vars.rs
+++ b/tests/ui/associated-type-bounds/trait-alias-bound-vars.rs
@@ -1,0 +1,14 @@
+// Check that we're successfully collecting bound vars behind trait aliases.
+// Regression test for <https://github.com/rust-lang/rust/issues/152244>.
+//@ check-pass
+//@ needs-rustc-debug-assertions
+#![feature(trait_alias)]
+
+trait A<'a> { type X; }
+trait B: for<'a> A<'a> {}
+trait C = B;
+
+fn f<T>() where T: C<X: Copy> {}
+fn g<T>() where T: C<X: for<'r> A<'r>> {}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#151455 (Fix `SourceFile::normalized_byte_pos`)
 - rust-lang/rust#151640 (Cleanup offload datatransfer)
 - rust-lang/rust#152309 (Fix bound var resolution for trait aliases)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=151455,151640,152309)
<!-- homu-ignore:end -->

