### PR TITLE
diagnostics: fix ICE in closure signature mismatch

### DIFF
--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -153,10 +153,10 @@ impl Subdiagnostic for AdjustSignatureBorrow {
     fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
         match self {
             AdjustSignatureBorrow::Borrow { to_borrow } => {
-                diag.arg("len", to_borrow.len());
+                diag.arg("borrow_len", to_borrow.len());
                 diag.multipart_suggestion_verbose(
                     inline_fluent!(
-                        "consider adjusting the signature so it borrows its {$len ->
+                        "consider adjusting the signature so it borrows its {$borrow_len ->
 [one] argument
 *[other] arguments
 }"
@@ -166,10 +166,10 @@ impl Subdiagnostic for AdjustSignatureBorrow {
                 );
             }
             AdjustSignatureBorrow::RemoveBorrow { remove_borrow } => {
-                diag.arg("len", remove_borrow.len());
+                diag.arg("remove_borrow_len", remove_borrow.len());
                 diag.multipart_suggestion_verbose(
                     inline_fluent!(
-                        "consider adjusting the signature so it does not borrow its {$len ->
+                        "consider adjusting the signature so it does not borrow its {$remove_borrow_len ->
 [one] argument
 *[other] arguments
 }"

--- a/tests/ui/closures/closure-arg-borrow-ice-issue-152331.rs
+++ b/tests/ui/closures/closure-arg-borrow-ice-issue-152331.rs
@@ -1,0 +1,10 @@
+fn main() {
+    h2(|_: (), _: (), _: (), x: &_| {});
+    //~^ ERROR type mismatch in closure arguments
+}
+
+fn h2<F>(_: F)
+where
+    F: for<'t0> Fn(&(), Box<dyn Fn(&())>, &'t0 (), fn(&(), &())),
+{
+}

--- a/tests/ui/closures/closure-arg-borrow-ice-issue-152331.stderr
+++ b/tests/ui/closures/closure-arg-borrow-ice-issue-152331.stderr
@@ -1,0 +1,32 @@
+error[E0631]: type mismatch in closure arguments
+  --> $DIR/closure-arg-borrow-ice-issue-152331.rs:2:5
+   |
+LL |     h2(|_: (), _: (), _: (), x: &_| {});
+   |     ^^^----------------------------^^^^
+   |     |  |
+   |     |  found signature defined here
+   |     expected due to this
+   |
+   = note: expected closure signature `for<'a, 't0> fn(&'a (), Box<(dyn for<'a> Fn(&'a ()) + 'static)>, &'t0 (), for<'a, 'b> fn(&'a (), &'b ())) -> _`
+              found closure signature `fn((), (), (), &_) -> _`
+note: required by a bound in `h2`
+  --> $DIR/closure-arg-borrow-ice-issue-152331.rs:8:8
+   |
+LL | fn h2<F>(_: F)
+   |    -- required by a bound in this function
+LL | where
+LL |     F: for<'t0> Fn(&(), Box<dyn Fn(&())>, &'t0 (), fn(&(), &())),
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `h2`
+help: consider adjusting the signature so it borrows its arguments
+   |
+LL |     h2(|_: &(), _: (), _: &(), x: &_| {});
+   |            +              +
+help: consider adjusting the signature so it does not borrow its argument
+   |
+LL -     h2(|_: (), _: (), _: (), x: &_| {});
+LL +     h2(|_: (), _: (), _: (), x: _| {});
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0631`.


### PR DESCRIPTION
Fixes rust-lang/rust#152331

Fixes an ICE where `AdjustSignatureBorrow` caused a panic because it attempted to set the `len` argument which was already defined by the parent diagnostic.

Both variants used `len` as  argument name, but can both be present in a diagnostic. They now use different names for the argument.
