### PR TITLE
Fix ICE in `deny_equality_constraints` with bare qualified self types

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -1838,6 +1838,7 @@ fn deny_equality_constraints(
 
     // Given `<A as Foo>::Bar = RhsTy`, suggest `A: Foo<Bar = RhsTy>`.
     if let TyKind::Path(Some(qself), full_path) = &predicate.lhs_ty.kind
+        && qself.position > 0 // `<T>::AssocTy` is handled further down
         && let TyKind::Path(None, path) = &qself.ty.kind
         && let [PathSegment { ident, args: None, .. }] = &path.segments[..]
     {
@@ -1982,6 +1983,35 @@ fn deny_equality_constraints(
                         {
                             suggest(poly, potential_assoc, predicate);
                         }
+                    }
+                }
+            }
+        }
+    }
+    // Given `A: Foo, <A>::Bar = RhsTy`, suggest `A: Foo<Bar = RhsTy>`.
+    if let TyKind::Path(Some(qself), full_path) = &predicate.lhs_ty.kind
+        && qself.position == 0
+        && let TyKind::Path(None, path) = &qself.ty.kind
+        && let [potential_param] = &path.segments[..]
+        && let [potential_assoc] = &full_path.segments[..]
+    {
+        for (ident, bounds) in generics.params.iter().map(|p| (p.ident, &p.bounds)).chain(
+            generics.where_clause.predicates.iter().filter_map(|pred| match &pred.kind {
+                WherePredicateKind::BoundPredicate(p)
+                    if let ast::TyKind::Path(None, path) = &p.bounded_ty.kind
+                        && let [segment] = &path.segments[..] =>
+                {
+                    Some((segment.ident, &p.bounds))
+                }
+                _ => None,
+            }),
+        ) {
+            if ident == potential_param.ident {
+                for bound in bounds {
+                    if let ast::GenericBound::Trait(poly) = bound
+                        && poly.modifiers == TraitBoundModifiers::NONE
+                    {
+                        suggest(poly, potential_assoc, predicate);
                     }
                 }
             }

--- a/tests/ui/where-clauses/equality-constraint-with-bare-qself.rs
+++ b/tests/ui/where-clauses/equality-constraint-with-bare-qself.rs
@@ -1,0 +1,12 @@
+// issue: <https://github.com/rust-lang/rust/issues/152338>
+
+use std::iter::Iterator;
+
+struct Ty<T>
+//~^ ERROR type parameter `T` is never used
+where
+    T: Iterator,
+    <T>::Item = i32, {}
+//~^ ERROR equality constraints are not yet supported in `where` clauses
+
+fn main() {}

--- a/tests/ui/where-clauses/equality-constraint-with-bare-qself.stderr
+++ b/tests/ui/where-clauses/equality-constraint-with-bare-qself.stderr
@@ -1,0 +1,25 @@
+error: equality constraints are not yet supported in `where` clauses
+  --> $DIR/equality-constraint-with-bare-qself.rs:9:5
+   |
+LL |     <T>::Item = i32, {}
+   |     ^^^^^^^^^^^^^^^ not supported
+   |
+   = note: see issue #20041 <https://github.com/rust-lang/rust/issues/20041> for more information
+help: if `Iterator::Item` is an associated type you're trying to set, use the associated type binding syntax
+   |
+LL -     T: Iterator,
+LL -     <T>::Item = i32, {}
+LL +     T: Iterator<Item = i32>, {}
+   |
+
+error[E0392]: type parameter `T` is never used
+  --> $DIR/equality-constraint-with-bare-qself.rs:5:11
+   |
+LL | struct Ty<T>
+   |           ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0392`.


### PR DESCRIPTION
close rust-lang/rust#152338 

When processing equality constraints in where clauses like `<T>::Item = T`, the compiler would panic with an index underflow. This occurred because `deny_equality_constraints` assumed that qualified paths always include a trait (e.g., `<T as Foo>::Bar`), but `<T>::Item` has no trait part (`qself.position == 0`). After removing the associated type segment, the path becomes empty, causing underflow in `segments.len()-1` in [here](https://github.com/rust-lang/rust/blob/13c38730d981289cc7ae4cc109fd7756bf83ee67/compiler/rustc_ast_passes/src/ast_validation.rs#L1852).

I think this can be prevented by checking the value of `qself.position`, similar to how it's handled in `rustc_resolve/src/late.rs`:

https://github.com/rust-lang/rust/blob/be4794c78beca8a88f0a1ee583f3d4b5c321e5d8/compiler/rustc_resolve/src/late.rs#L4748-L4750