### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -153,10 +153,10 @@ impl Subdiagnostic for AdjustSignatureBorrow {
     fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
         match self {
             AdjustSignatureBorrow::Borrow { to_borrow } => {
-                diag.arg("len", to_borrow.len());
+                diag.arg("borrow_len", to_borrow.len());
                 diag.multipart_suggestion_verbose(
                     inline_fluent!(
-                        "consider adjusting the signature so it borrows its {$len ->
+                        "consider adjusting the signature so it borrows its {$borrow_len ->
 [one] argument
 *[other] arguments
 }"
@@ -166,10 +166,10 @@ impl Subdiagnostic for AdjustSignatureBorrow {
                 );
             }
             AdjustSignatureBorrow::RemoveBorrow { remove_borrow } => {
-                diag.arg("len", remove_borrow.len());
+                diag.arg("remove_borrow_len", remove_borrow.len());
                 diag.multipart_suggestion_verbose(
                     inline_fluent!(
-                        "consider adjusting the signature so it does not borrow its {$len ->
+                        "consider adjusting the signature so it does not borrow its {$remove_borrow_len ->
 [one] argument
 *[other] arguments
 }"

--- a/tests/ui/closures/closure-arg-borrow-ice-issue-152331.rs
+++ b/tests/ui/closures/closure-arg-borrow-ice-issue-152331.rs
@@ -1,0 +1,10 @@
+fn main() {
+    h2(|_: (), _: (), _: (), x: &_| {});
+    //~^ ERROR type mismatch in closure arguments
+}
+
+fn h2<F>(_: F)
+where
+    F: for<'t0> Fn(&(), Box<dyn Fn(&())>, &'t0 (), fn(&(), &())),
+{
+}

--- a/tests/ui/closures/closure-arg-borrow-ice-issue-152331.stderr
+++ b/tests/ui/closures/closure-arg-borrow-ice-issue-152331.stderr
@@ -1,0 +1,32 @@
+error[E0631]: type mismatch in closure arguments
+  --> $DIR/closure-arg-borrow-ice-issue-152331.rs:2:5
+   |
+LL |     h2(|_: (), _: (), _: (), x: &_| {});
+   |     ^^^----------------------------^^^^
+   |     |  |
+   |     |  found signature defined here
+   |     expected due to this
+   |
+   = note: expected closure signature `for<'a, 't0> fn(&'a (), Box<(dyn for<'a> Fn(&'a ()) + 'static)>, &'t0 (), for<'a, 'b> fn(&'a (), &'b ())) -> _`
+              found closure signature `fn((), (), (), &_) -> _`
+note: required by a bound in `h2`
+  --> $DIR/closure-arg-borrow-ice-issue-152331.rs:8:8
+   |
+LL | fn h2<F>(_: F)
+   |    -- required by a bound in this function
+LL | where
+LL |     F: for<'t0> Fn(&(), Box<dyn Fn(&())>, &'t0 (), fn(&(), &())),
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `h2`
+help: consider adjusting the signature so it borrows its arguments
+   |
+LL |     h2(|_: &(), _: (), _: &(), x: &_| {});
+   |            +              +
+help: consider adjusting the signature so it does not borrow its argument
+   |
+LL -     h2(|_: (), _: (), _: (), x: &_| {});
+LL +     h2(|_: (), _: (), _: (), x: _| {});
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0631`.

--- a/tests/ui/macros/cfg_select.rs
+++ b/tests/ui/macros/cfg_select.rs
@@ -34,6 +34,7 @@ fn arm_rhs_expr_3() -> i32 {
         any(true) => 1,
         any(false) => 2,
         any(true) => { 42 }
+        any(true) => { 42 },
         any(false) => -1 as i32,
         any(true) => 2 + 2,
         any(false) => "",
@@ -62,7 +63,7 @@ fn expand_to_statements() -> i32 {
 }
 
 type ExpandToType = cfg_select! {
-    unix => u32,
+    unix => { u32 },
     _ => i32,
 };
 
@@ -113,7 +114,7 @@ impl T for S {
     cfg_select! {
         false => {
             fn a() {}
-        }
+        },
         _ => {
             fn b() {}
         }
@@ -145,7 +146,7 @@ cfg_select! {
 
 cfg_select! {
     unix => {}
-    not(unix) => {}
+    not(unix) => {},
     _ => {}
     //~^ WARN unreachable configuration predicate
 }

--- a/tests/ui/macros/cfg_select.stderr
+++ b/tests/ui/macros/cfg_select.stderr
@@ -1,5 +1,5 @@
 error: none of the predicates in this `cfg_select` evaluated to true
-  --> $DIR/cfg_select.rs:161:1
+  --> $DIR/cfg_select.rs:162:1
    |
 LL | / cfg_select! {
 LL | |
@@ -8,55 +8,55 @@ LL | | }
    | |_^
 
 error: none of the predicates in this `cfg_select` evaluated to true
-  --> $DIR/cfg_select.rs:166:1
+  --> $DIR/cfg_select.rs:167:1
    |
 LL | cfg_select! {}
    | ^^^^^^^^^^^^^^
 
 error: expected a literal (`1u8`, `1.0f32`, `"string"`, etc.) here, found `=>`
-  --> $DIR/cfg_select.rs:170:5
+  --> $DIR/cfg_select.rs:171:5
    |
 LL |     => {}
    |     ^^
 
 error: expected a literal (`1u8`, `1.0f32`, `"string"`, etc.) here, found expression
-  --> $DIR/cfg_select.rs:175:5
+  --> $DIR/cfg_select.rs:176:5
    |
 LL |     () => {}
    |     ^^ expressions are not allowed here
 
 error[E0539]: malformed `cfg_select` macro input
-  --> $DIR/cfg_select.rs:180:5
+  --> $DIR/cfg_select.rs:181:5
    |
 LL |     "str" => {}
    |     ^^^^^ expected a valid identifier here
 
 error[E0539]: malformed `cfg_select` macro input
-  --> $DIR/cfg_select.rs:185:5
+  --> $DIR/cfg_select.rs:186:5
    |
 LL |     a::b => {}
    |     ^^^^ expected a valid identifier here
 
 error[E0537]: invalid predicate `a`
-  --> $DIR/cfg_select.rs:190:5
+  --> $DIR/cfg_select.rs:191:5
    |
 LL |     a() => {}
    |     ^^^
 
 error: expected one of `(`, `::`, `=>`, or `=`, found `+`
-  --> $DIR/cfg_select.rs:195:7
+  --> $DIR/cfg_select.rs:196:7
    |
 LL |     a + 1 => {}
    |       ^ expected one of `(`, `::`, `=>`, or `=`
 
 error: expected one of `(`, `::`, `=>`, or `=`, found `!`
-  --> $DIR/cfg_select.rs:201:8
+  --> $DIR/cfg_select.rs:202:8
    |
 LL |     cfg!() => {}
    |        ^ expected one of `(`, `::`, `=>`, or `=`
 
 warning: unreachable configuration predicate
-  --> $DIR/cfg_select.rs:136:5
+  --> $DIR/cfg_select.rs:137:5
    |
 LL |     _ => {}
    |     - always matches
@@ -70,7 +70,7 @@ LL | #![warn(unreachable_cfg_select_predicates)] // Unused warnings are disabled
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unreachable configuration predicate
-  --> $DIR/cfg_select.rs:142:5
+  --> $DIR/cfg_select.rs:143:5
    |
 LL |     true => {}
    |     ---- always matches
@@ -78,25 +78,25 @@ LL |     _ => {}
    |     ^ this configuration predicate is never reached
 
 warning: unreachable configuration predicate
-  --> $DIR/cfg_select.rs:149:5
+  --> $DIR/cfg_select.rs:150:5
    |
 LL |     _ => {}
    |     ^ this configuration predicate is never reached
 
 warning: unreachable configuration predicate
-  --> $DIR/cfg_select.rs:155:5
+  --> $DIR/cfg_select.rs:156:5
    |
 LL |     test => {}
    |     ^^^^ this configuration predicate is never reached
 
 warning: unreachable configuration predicate
-  --> $DIR/cfg_select.rs:157:5
+  --> $DIR/cfg_select.rs:158:5
    |
 LL |     _ => {}
    |     ^ this configuration predicate is never reached
 
 warning: unexpected `cfg` condition name: `a`
-  --> $DIR/cfg_select.rs:195:5
+  --> $DIR/cfg_select.rs:196:5
    |
 LL |     a + 1 => {}
    |     ^ help: found config with similar value: `target_feature = "a"`
@@ -107,7 +107,7 @@ LL |     a + 1 => {}
    = note: `#[warn(unexpected_cfgs)]` on by default
 
 warning: unexpected `cfg` condition name: `cfg`
-  --> $DIR/cfg_select.rs:201:5
+  --> $DIR/cfg_select.rs:202:5
    |
 LL |     cfg!() => {}
    |     ^^^


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#152339 (diagnostics: fix ICE in closure signature mismatch)
 - rust-lang/rust#152341 (`cfg_select!`: allow optional comma after `{ /* ... */ }`)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=152339,152341)
<!-- homu-ignore:end -->

