### PR TITLE
Improve the `inline_fluent!` macro

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -471,9 +471,9 @@ fn report_eval_error<'tcx>(
                 span,
                 inline_fluent!(
                     "evaluation of `{$instance}` failed {$num_frames ->
-    [0] here
-    *[other] inside this call
-}"
+                        [0] here
+                        *[other] inside this call
+                    }"
                 ),
             );
             for frame in frames {

--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -491,10 +491,10 @@ impl<'tcx> interpret::Machine<'tcx> for CompileTimeMachine<'tcx> {
                     Err(err) => throw_ub_custom!(
                         inline_fluent!(
                             "invalid align passed to `{$name}`: {$align} is {$err_kind ->
-    [not_power_of_two] not a power of 2
-    [too_large] too large
-    *[other] {\"\"}
-}"
+                                [not_power_of_two] not a power of 2
+                                [too_large] too large
+                                *[other] {\"\"}
+                            }"
                         ),
                         name = "const_allocate",
                         err_kind = err.diag_ident(),
@@ -521,10 +521,10 @@ impl<'tcx> interpret::Machine<'tcx> for CompileTimeMachine<'tcx> {
                     Err(err) => throw_ub_custom!(
                         inline_fluent!(
                             "invalid align passed to `{$name}`: {$align} is {$err_kind ->
-    [not_power_of_two] not a power of 2
-    [too_large] too large
-    *[other] {\"\"}
-}"
+                                [not_power_of_two] not a power of 2
+                                [too_large] too large
+                                *[other] {\"\"}
+                            }"
                         ),
                         name = "const_deallocate",
                         err_kind = err.diag_ident(),

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -461,10 +461,12 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                         // a < b
                         if intrinsic_name == sym::ptr_offset_from_unsigned {
                             throw_ub_custom!(
-                                inline_fluent!("`ptr_offset_from_unsigned` called when first pointer has smaller {$is_addr ->
-    [true] address
-    *[false] offset
-} than second: {$a_offset} < {$b_offset}"),
+                                inline_fluent!(
+                                    "`ptr_offset_from_unsigned` called when first pointer has smaller {$is_addr ->
+                                        [true] address
+                                        *[false] offset
+                                    } than second: {$a_offset} < {$b_offset}"
+                                ),
                                 a_offset = a_offset,
                                 b_offset = b_offset,
                                 is_addr = is_addr,

--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -293,10 +293,10 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             throw_ub_custom!(
                 inline_fluent!(
                     "{$kind ->
-    [dealloc] deallocating
-    [realloc] reallocating
-    *[other] {\"\"}
-} {$ptr} which does not point to the beginning of an object"
+                        [dealloc] deallocating
+                        [realloc] reallocating
+                        *[other] {\"\"}
+                    } {$ptr} which does not point to the beginning of an object"
                 ),
                 ptr = format!("{ptr:?}"),
                 kind = "realloc"
@@ -379,10 +379,10 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             throw_ub_custom!(
                 inline_fluent!(
                     "{$kind ->
-    [dealloc] deallocating
-    [realloc] reallocating
-    *[other] {\"\"}
-} {$ptr} which does not point to the beginning of an object"
+                        [dealloc] deallocating
+                        [realloc] reallocating
+                        *[other] {\"\"}
+                    } {$ptr} which does not point to the beginning of an object"
                 ),
                 ptr = format!("{ptr:?}"),
                 kind = "dealloc",
@@ -396,11 +396,11 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                     err_ub_custom!(
                         inline_fluent!(
                             "deallocating {$alloc_id}, which is {$kind ->
-    [fn] a function
-    [vtable] a vtable
-    [static_mem] static memory
-    *[other] {\"\"}
-}"
+                                [fn] a function
+                                [vtable] a vtable
+                                [static_mem] static memory
+                                *[other] {\"\"}
+                            }"
                         ),
                         alloc_id = alloc_id,
                         kind = "fn",
@@ -410,11 +410,11 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                     err_ub_custom!(
                         inline_fluent!(
                             "deallocating {$alloc_id}, which is {$kind ->
-    [fn] a function
-    [vtable] a vtable
-    [static_mem] static memory
-    *[other] {\"\"}
-}"
+                                [fn] a function
+                                [vtable] a vtable
+                                [static_mem] static memory
+                                *[other] {\"\"}
+                            }"
                         ),
                         alloc_id = alloc_id,
                         kind = "vtable",
@@ -424,11 +424,11 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                     err_ub_custom!(
                         inline_fluent!(
                             "deallocating {$alloc_id}, which is {$kind ->
-    [fn] a function
-    [vtable] a vtable
-    [static_mem] static memory
-    *[other] {\"\"}
-}"
+                                [fn] a function
+                                [vtable] a vtable
+                                [static_mem] static memory
+                                *[other] {\"\"}
+                            }"
                         ),
                         alloc_id = alloc_id,
                         kind = "typeid",
@@ -438,11 +438,11 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                     err_ub_custom!(
                         inline_fluent!(
                             "deallocating {$alloc_id}, which is {$kind ->
-    [fn] a function
-    [vtable] a vtable
-    [static_mem] static memory
-    *[other] {\"\"}
-}"
+                                [fn] a function
+                                [vtable] a vtable
+                                [static_mem] static memory
+                                *[other] {\"\"}
+                            }"
                         ),
                         alloc_id = alloc_id,
                         kind = "static_mem"

--- a/compiler/rustc_errors/src/diagnostic_impls.rs
+++ b/compiler/rustc_errors/src/diagnostic_impls.rs
@@ -60,11 +60,13 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for TargetDataLayoutErrors<'_> {
                     .with_arg("cause", cause)
             }
             TargetDataLayoutErrors::InvalidAlignment { cause, err } => {
-                Diag::new(dcx, level, inline_fluent!("invalid alignment for `{$cause}` in \"data-layout\": `{$align}` is {$err_kind ->
-                    [not_power_of_two] not a power of 2
-                    [too_large] too large
-                    *[other] {\"\"}
-                }"))
+                Diag::new(dcx, level, inline_fluent!(
+                    "invalid alignment for `{$cause}` in \"data-layout\": `{$align}` is {$err_kind ->
+                        [not_power_of_two] not a power of 2
+                        [too_large] too large
+                        *[other] {\"\"}
+                    }"
+                ))
                 .with_arg("cause", cause)
                 .with_arg("err_kind", err.diag_ident())
                 .with_arg("align", err.align())

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -63,6 +63,7 @@ pub use rustc_error_messages::{
 use rustc_hashes::Hash128;
 use rustc_lint_defs::LintExpectationId;
 pub use rustc_lint_defs::{Applicability, listify, pluralize};
+pub use rustc_macros::inline_fluent;
 use rustc_macros::{Decodable, Encodable};
 pub use rustc_span::ErrorGuaranteed;
 pub use rustc_span::fatal_error::{FatalError, FatalErrorMarker, catch_fatal_errors};
@@ -1562,7 +1563,7 @@ impl DelayedDiagInner {
         let msg = match self.note.status() {
             BacktraceStatus::Captured => inline_fluent!(
                 "delayed at {$emitted_at}
-{$note}"
+                {$note}"
             ),
             // Avoid the needless newline when no backtrace has been captured,
             // the display impl should just be a single line.

--- a/compiler/rustc_errors/src/translation.rs
+++ b/compiler/rustc_errors/src/translation.rs
@@ -90,14 +90,3 @@ impl Translator {
         }
     }
 }
-
-/// This macro creates a translatable `DiagMessage` from a literal string.
-/// It should be used in places where a translatable message is needed, but struct diagnostics are undesired.
-///
-/// This is a macro because in the future we may want to globally register these messages.
-#[macro_export]
-macro_rules! inline_fluent {
-    ($inline: literal) => {
-        rustc_errors::DiagMessage::Inline(std::borrow::Cow::Borrowed($inline))
-    };
-}

--- a/compiler/rustc_lint/src/impl_trait_overcaptures.rs
+++ b/compiler/rustc_lint/src/impl_trait_overcaptures.rs
@@ -446,7 +446,7 @@ impl<'a> LintDiagnostic<'a, ()> for ImplTraitOvercapturesLint<'_> {
                     "specifically, {$num_captured ->
                         [one] this lifetime is
                         *[other] these lifetimes are
-                     } in scope but not mentioned in the type's bounds"
+                    } in scope but not mentioned in the type's bounds"
                 ),
             )
             .note(inline_fluent!(

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -353,8 +353,10 @@ impl<'a> LintDiagnostic<'a, ()> for BuiltinTypeAliasBounds<'_> {
             self.label,
             inline_fluent!("will not be checked at usage sites of the type alias"),
         );
-        diag.note(inline_fluent!("this is a known limitation of the type checker that may be lifted in a future edition.
-            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information"));
+        diag.note(inline_fluent!(
+            "this is a known limitation of the type checker that may be lifted in a future edition.
+            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information"
+        ));
         if self.enable_feat_help {
             diag.help(inline_fluent!("add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics"));
         }
@@ -1748,10 +1750,12 @@ impl<'a> LintDiagnostic<'a, ()> for NonLocalDefinitionsDiag {
                 if doctest {
                     diag.help(inline_fluent!(r#"remove the `#[macro_export]` or make this doc-test a standalone test with its own `fn main() {"{"} ... {"}"}`"#));
                 } else {
-                    diag.help(inline_fluent!("remove the `#[macro_export]` or move this `macro_rules!` outside the of the current {$body_kind_descr} {$depth ->
-                        [one] `{$body_name}`
-                       *[other] `{$body_name}` and up {$depth} bodies
-                    }"));
+                    diag.help(inline_fluent!(
+                        "remove the `#[macro_export]` or move this `macro_rules!` outside the of the current {$body_kind_descr} {$depth ->
+                            [one] `{$body_name}`
+                            *[other] `{$body_name}` and up {$depth} bodies
+                        }"
+                    ));
                 }
 
                 diag.note(inline_fluent!("a `macro_rules!` definition is non-local if it is nested inside an item and has a `#[macro_export]` attribute"));

--- a/compiler/rustc_lint/src/non_fmt_panic.rs
+++ b/compiler/rustc_lint/src/non_fmt_panic.rs
@@ -196,10 +196,12 @@ fn check_panic<'tcx>(cx: &LateContext<'tcx>, f: &'tcx hir::Expr<'tcx>, arg: &'tc
                 if let Some((open, close, del)) = find_delimiters(cx, span) {
                     lint.arg("already_suggested", suggest_display || suggest_debug);
                     lint.multipart_suggestion(
-                        inline_fluent!("{$already_suggested ->
-                            [true] or use
-                            *[false] use
-                        } std::panic::panic_any instead"),
+                        inline_fluent!(
+                            "{$already_suggested ->
+                                [true] or use
+                                *[false] use
+                            } std::panic::panic_any instead"
+                        ),
                         if del == '(' {
                             vec![(span.until(open), "std::panic::panic_any".into())]
                         } else {

--- a/compiler/rustc_macros/src/diagnostics/inline_fluent.rs
+++ b/compiler/rustc_macros/src/diagnostics/inline_fluent.rs
@@ -1,0 +1,10 @@
+use syn::{LitStr, parse_macro_input};
+
+use crate::diagnostics::message::Message;
+
+pub(crate) fn inline_fluent(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let inline = parse_macro_input!(input as LitStr);
+    let message =
+        Message { attr_span: inline.span(), message_span: inline.span(), value: inline.value() };
+    message.diag_message(None).into()
+}

--- a/compiler/rustc_macros/src/diagnostics/mod.rs
+++ b/compiler/rustc_macros/src/diagnostics/mod.rs
@@ -1,11 +1,13 @@
 mod diagnostic;
 mod diagnostic_builder;
 mod error;
+mod inline_fluent;
 mod message;
 mod subdiagnostic;
 mod utils;
 
 use diagnostic::{DiagnosticDerive, LintDiagnosticDerive};
+pub(super) use inline_fluent::inline_fluent;
 use proc_macro2::TokenStream;
 use subdiagnostic::SubdiagnosticDerive;
 use synstructure::Structure;

--- a/compiler/rustc_macros/src/lib.rs
+++ b/compiler/rustc_macros/src/lib.rs
@@ -241,6 +241,15 @@ decl_derive!(
         applicability)] => diagnostics::subdiagnostic_derive
 );
 
+/// This macro creates a translatable `DiagMessage` from a fluent format string.
+/// It should be used in places where a translatable message is needed, but struct diagnostics are undesired.
+///
+/// This macro statically checks that the message is valid Fluent, but not that variables in the Fluent message actually exist.
+#[proc_macro]
+pub fn inline_fluent(input: TokenStream) -> TokenStream {
+    diagnostics::inline_fluent(input)
+}
+
 decl_derive! {
     [PrintAttribute] =>
     /// Derives `PrintAttribute` for `AttributeKind`.

--- a/compiler/rustc_middle/src/middle/stability.rs
+++ b/compiler/rustc_middle/src/middle/stability.rs
@@ -128,19 +128,25 @@ pub struct Deprecated {
 impl<'a, G: EmissionGuarantee> rustc_errors::LintDiagnostic<'a, G> for Deprecated {
     fn decorate_lint<'b>(self, diag: &'b mut Diag<'a, G>) {
         diag.primary_message(match &self.since_kind {
-            DeprecatedSinceKind::InEffect => inline_fluent!("use of deprecated {$kind} `{$path}`{$has_note ->
-                [true] : {$note}
-                *[other] {\"\"}
-            }"),
-            DeprecatedSinceKind::InFuture => inline_fluent!("use of {$kind} `{$path}` that will be deprecated in a future Rust version{$has_note ->
-                [true] : {$note}
-                *[other] {\"\"}
-            }"),
-            DeprecatedSinceKind::InVersion(_) => {
-                inline_fluent!("use of {$kind} `{$path}` that will be deprecated in future version {$version}{$has_note ->
+            DeprecatedSinceKind::InEffect => inline_fluent!(
+                "use of deprecated {$kind} `{$path}`{$has_note ->
                     [true] : {$note}
                     *[other] {\"\"}
-                }")
+                }"
+            ),
+            DeprecatedSinceKind::InFuture => inline_fluent!(
+                "use of {$kind} `{$path}` that will be deprecated in a future Rust version{$has_note ->
+                    [true] : {$note}
+                    *[other] {\"\"}
+                }"
+            ),
+            DeprecatedSinceKind::InVersion(_) => {
+                inline_fluent!(
+                    "use of {$kind} `{$path}` that will be deprecated in future version {$version}{$has_note ->
+                        [true] : {$note}
+                        *[other] {\"\"}
+                    }"
+                )
             }
         });
         diag.arg("kind", self.kind);

--- a/compiler/rustc_mir_transform/src/lint_tail_expr_drop_order.rs
+++ b/compiler/rustc_mir_transform/src/lint_tail_expr_drop_order.rs
@@ -542,10 +542,12 @@ impl Subdiagnostic for LocalLabel<'_> {
             dtor.add_to_diag(diag);
         }
         let msg =
-            diag.eagerly_translate(inline_fluent!("{$is_dropped_first_edition_2024 ->
-                [true] up until Edition 2021 `{$name}` is dropped last but will be dropped earlier in Edition 2024
-                *[false] `{$name}` will be dropped later as of Edition 2024
-            }"));
+            diag.eagerly_translate(inline_fluent!(
+                "{$is_dropped_first_edition_2024 ->
+                    [true] up until Edition 2021 `{$name}` is dropped last but will be dropped earlier in Edition 2024
+                    *[false] `{$name}` will be dropped later as of Edition 2024
+                }"
+            ));
         diag.span_label(self.span, msg);
     }
 }

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -684,9 +684,9 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for NoMainErr {
             // There were some functions named `main` though. Try to give the user a hint.
             inline_fluent!(
                 "the main function must be defined at the crate level{$has_filename ->
-                [true] {\" \"}(in `{$filename}`)
-                *[false] {\"\"}
-            }"
+                    [true] {\" \"}(in `{$filename}`)
+                    *[false] {\"\"}
+                }"
             )
         } else if self.has_filename {
             inline_fluent!("consider adding a `main` function to `{$filename}`")

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
@@ -252,10 +252,12 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             SubregionOrigin::RelateParamBound(span, ty, opt_span) => {
                 RegionOriginNote::WithName {
                     span,
-                    msg: inline_fluent!("...so that the type `{$name}` will meet its required lifetime bounds{$continues ->
-[true] ...
-*[false] {\"\"}
-}"),
+                    msg: inline_fluent!(
+                        "...so that the type `{$name}` will meet its required lifetime bounds{$continues ->
+                            [true] ...
+                            *[false] {\"\"}
+                        }"
+                    ),
                     name: &self.ty_to_string(ty),
                     continues: opt_span.is_some(),
                 }

--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -102,10 +102,16 @@ pub struct NegativePositiveConflict<'tcx> {
 impl<G: EmissionGuarantee> Diagnostic<'_, G> for NegativePositiveConflict<'_> {
     #[track_caller]
     fn into_diag(self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
-        let mut diag = Diag::new(dcx, level, inline_fluent!("found both positive and negative implementation of trait `{$trait_desc}`{$self_desc ->
-[none] {\"\"}
-*[default] {\" \"}for type `{$self_desc}`
-}:"));
+        let mut diag = Diag::new(
+            dcx,
+            level,
+            inline_fluent!(
+            "found both positive and negative implementation of trait `{$trait_desc}`{$self_desc ->
+                [none] {\"\"}
+                *[default] {\" \"}for type `{$self_desc}`
+            }:"
+        ),
+        );
         diag.arg("trait_desc", self.trait_desc.print_only_trait_path().to_string());
         diag.arg("self_desc", self.self_ty.map_or_else(|| "none".to_string(), |ty| ty.to_string()));
         diag.span(self.impl_span);
@@ -157,9 +163,9 @@ impl Subdiagnostic for AdjustSignatureBorrow {
                 diag.multipart_suggestion_verbose(
                     inline_fluent!(
                         "consider adjusting the signature so it borrows its {$borrow_len ->
-[one] argument
-*[other] arguments
-}"
+                            [one] argument
+                            *[other] arguments
+                        }"
                     ),
                     to_borrow,
                     Applicability::MaybeIncorrect,
@@ -170,9 +176,9 @@ impl Subdiagnostic for AdjustSignatureBorrow {
                 diag.multipart_suggestion_verbose(
                     inline_fluent!(
                         "consider adjusting the signature so it does not borrow its {$remove_borrow_len ->
-[one] argument
-*[other] arguments
-}"
+                            [one] argument
+                            *[other] arguments
+                        }"
                     ),
                     remove_borrow,
                     Applicability::MaybeIncorrect,
@@ -505,18 +511,18 @@ impl Subdiagnostic for RegionOriginNote<'_> {
                     span,
                     inline_fluent!(
                         "...so that the {$requirement ->
-[method_compat] method type is compatible with trait
-[type_compat] associated type is compatible with trait
-[const_compat] const is compatible with trait
-[expr_assignable] expression is assignable
-[if_else_different] `if` and `else` have incompatible types
-[no_else] `if` missing an `else` returns `()`
-[fn_main_correct_type] `main` function has the correct type
-[fn_lang_correct_type] lang item function has the correct type
-[intrinsic_correct_type] intrinsic has the correct type
-[method_correct_type] method receiver has the correct type
-*[other] types are compatible
-}"
+                            [method_compat] method type is compatible with trait
+                            [type_compat] associated type is compatible with trait
+                            [const_compat] const is compatible with trait
+                            [expr_assignable] expression is assignable
+                            [if_else_different] `if` and `else` have incompatible types
+                            [no_else] `if` missing an `else` returns `()`
+                            [fn_main_correct_type] `main` function has the correct type
+                            [fn_lang_correct_type] lang item function has the correct type
+                            [intrinsic_correct_type] intrinsic has the correct type
+                            [method_correct_type] method receiver has the correct type
+                            *[other] types are compatible
+                        }"
                     ),
                 );
                 diag.arg("requirement", requirement);
@@ -531,18 +537,18 @@ impl Subdiagnostic for RegionOriginNote<'_> {
                     span,
                     inline_fluent!(
                         "...so that {$requirement ->
-[method_compat] method type is compatible with trait
-[type_compat] associated type is compatible with trait
-[const_compat] const is compatible with trait
-[expr_assignable] expression is assignable
-[if_else_different] `if` and `else` have incompatible types
-[no_else] `if` missing an `else` returns `()`
-[fn_main_correct_type] `main` function has the correct type
-[fn_lang_correct_type] lang item function has the correct type
-[intrinsic_correct_type] intrinsic has the correct type
-[method_correct_type] method receiver has the correct type
-*[other] types are compatible
-}"
+                            [method_compat] method type is compatible with trait
+                            [type_compat] associated type is compatible with trait
+                            [const_compat] const is compatible with trait
+                            [expr_assignable] expression is assignable
+                            [if_else_different] `if` and `else` have incompatible types
+                            [no_else] `if` missing an `else` returns `()`
+                            [fn_main_correct_type] `main` function has the correct type
+                            [fn_lang_correct_type] lang item function has the correct type
+                            [intrinsic_correct_type] intrinsic has the correct type
+                            [method_correct_type] method receiver has the correct type
+                            *[other] types are compatible
+                        }"
                     ),
                 );
                 diag.arg("requirement", requirement);
@@ -578,9 +584,9 @@ impl Subdiagnostic for LifetimeMismatchLabels {
                     span,
                     inline_fluent!(
                         "...but data{$label_var1_exists ->
-[true] {\" \"}from `{$label_var1}`
-*[false] {\"\"}
-} is returned here"
+                            [true] {\" \"}from `{$label_var1}`
+                            *[false] {\"\"}
+                        } is returned here"
                     ),
                 );
                 diag.arg("label_var1_exists", label_var1.is_some());
@@ -614,12 +620,12 @@ impl Subdiagnostic for LifetimeMismatchLabels {
                         span,
                         inline_fluent!(
                             "...but data{$label_var1_exists ->
-[true] {\" \"}from `{$label_var1}`
-*[false] {\"\"}
-} flows{$label_var2_exists ->
-[true] {\" \"}into `{$label_var2}`
-*[false] {\"\"}
-} here"
+                                [true] {\" \"}from `{$label_var1}`
+                                *[false] {\"\"}
+                            } flows{$label_var2_exists ->
+                                [true] {\" \"}into `{$label_var2}`
+                                *[false] {\"\"}
+                            } here"
                         ),
                     );
                     diag.arg("label_var1_exists", label_var1.is_some());
@@ -789,12 +795,12 @@ impl Subdiagnostic for AddLifetimeParamsSuggestion<'_> {
             diag.multipart_suggestion_verbose(
                 inline_fluent!(
                     "consider {$is_reuse ->
-[true] reusing
-*[false] introducing
-} a named lifetime parameter{$is_impl ->
-[true] {\" \"}and update trait if needed
-*[false] {\"\"}
-}"
+                        [true] reusing
+                        *[false] introducing
+                    } a named lifetime parameter{$is_impl ->
+                        [true] {\" \"}and update trait if needed
+                        *[false] {\"\"}
+                    }"
                 ),
                 visitor.suggestions,
                 Applicability::MaybeIncorrect,

--- a/compiler/rustc_trait_selection/src/errors/note_and_explain.rs
+++ b/compiler/rustc_trait_selection/src/errors/note_and_explain.rs
@@ -171,37 +171,37 @@ impl Subdiagnostic for RegionExplanation<'_> {
 
         let msg = diag.eagerly_translate(inline_fluent!(
             "{$pref_kind ->
-*[should_not_happen] [{$pref_kind}]
-[ref_valid_for] ...the reference is valid for
-[content_valid_for] ...but the borrowed content is only valid for
-[type_obj_valid_for] object type is valid for
-[source_pointer_valid_for] source pointer is only valid for
-[type_satisfy] type must satisfy
-[type_outlive] type must outlive
-[lf_param_instantiated_with] lifetime parameter instantiated with
-[lf_param_must_outlive] but lifetime parameter must outlive
-[lf_instantiated_with] lifetime instantiated with
-[lf_must_outlive] but lifetime must outlive
-[pointer_valid_for] the pointer is valid for
-[data_valid_for] but the referenced data is only valid for
-[empty] {\"\"}
-}{$pref_kind ->
-[empty] {\"\"}
-*[other] {\" \"}
-}{$desc_kind ->
-*[should_not_happen] [{$desc_kind}]
-[restatic] the static lifetime
-[revar] lifetime {$desc_arg}
-[as_defined] the lifetime `{$desc_arg}` as defined here
-[as_defined_anon] the anonymous lifetime as defined here
-[defined_here] the anonymous lifetime defined here
-[defined_here_reg] the lifetime `{$desc_arg}` as defined here
-}{$suff_kind ->
-*[should_not_happen] [{$suff_kind}]
-[empty]{\"\"}
-[continues] ...
-[req_by_binding] {\" \"}as required by this binding
-}"
+                *[should_not_happen] [{$pref_kind}]
+                [ref_valid_for] ...the reference is valid for
+                [content_valid_for] ...but the borrowed content is only valid for
+                [type_obj_valid_for] object type is valid for
+                [source_pointer_valid_for] source pointer is only valid for
+                [type_satisfy] type must satisfy
+                [type_outlive] type must outlive
+                [lf_param_instantiated_with] lifetime parameter instantiated with
+                [lf_param_must_outlive] but lifetime parameter must outlive
+                [lf_instantiated_with] lifetime instantiated with
+                [lf_must_outlive] but lifetime must outlive
+                [pointer_valid_for] the pointer is valid for
+                [data_valid_for] but the referenced data is only valid for
+                [empty] {\"\"}
+            }{$pref_kind ->
+                [empty] {\"\"}
+                *[other] {\" \"}
+            }{$desc_kind ->
+                *[should_not_happen] [{$desc_kind}]
+                [restatic] the static lifetime
+                [revar] lifetime {$desc_arg}
+                [as_defined] the lifetime `{$desc_arg}` as defined here
+                [as_defined_anon] the anonymous lifetime as defined here
+                [defined_here] the anonymous lifetime defined here
+                [defined_here_reg] the lifetime `{$desc_arg}` as defined here
+                }{$suff_kind ->
+                *[should_not_happen] [{$suff_kind}]
+                [empty]{\"\"}
+                [continues] ...
+                [req_by_binding] {\" \"}as required by this binding
+            }"
         ));
         diag.restore_args();
         if let Some(span) = self.desc.span {


### PR DESCRIPTION
For https://github.com/rust-lang/rust/issues/151366

This PR turns `inline_fluent!` into a proc macro, so we can run validation on the messages in this macro :)
I started a thread here because I don't like the name of the macro, but that's for a future PR: [#t-compiler > Bikeshed the new &#96;inline_fluent!&#96; macro](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Bikeshed.20the.20new.20.60inline_fluent!.60.20macro/with/572646242)