### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/library/core/src/alloc/global.rs
+++ b/library/core/src/alloc/global.rs
@@ -284,9 +284,10 @@ pub unsafe trait GlobalAlloc {
     /// [`handle_alloc_error`]: ../../alloc/alloc/fn.handle_alloc_error.html
     #[stable(feature = "global_alloc", since = "1.28.0")]
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-        // SAFETY: the caller must ensure that the `new_size` does not overflow.
-        // `layout.align()` comes from a `Layout` and is thus guaranteed to be valid.
-        let new_layout = unsafe { Layout::from_size_align_unchecked(new_size, layout.align()) };
+        let alignment = layout.alignment();
+        // SAFETY: the caller must ensure that the `new_size` does not overflow
+        // when rounded up to the next multiple of `alignment`.
+        let new_layout = unsafe { Layout::from_size_alignment_unchecked(new_size, alignment) };
         // SAFETY: the caller must ensure that `new_layout` is greater than zero.
         let new_ptr = unsafe { self.alloc(new_layout) };
         if !new_ptr.is_null() {

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1260,7 +1260,10 @@ pub trait SizedTypeProperties: Sized {
 
     #[doc(hidden)]
     #[unstable(feature = "ptr_alignment_type", issue = "102070")]
-    const ALIGNMENT: Alignment = Alignment::of::<Self>();
+    const ALIGNMENT: Alignment = {
+        // This can't panic since type alignment is always a power of two.
+        Alignment::new(Self::ALIGN).unwrap()
+    };
 
     /// `true` if this type requires no storage.
     /// `false` if its [size](size_of) is greater than zero.

--- a/library/core/src/ptr/alignment.rs
+++ b/library/core/src/ptr/alignment.rs
@@ -52,8 +52,7 @@ impl Alignment {
     #[inline]
     #[must_use]
     pub const fn of<T>() -> Self {
-        // This can't actually panic since type alignment is always a power of two.
-        const { Alignment::new(align_of::<T>()).unwrap() }
+        <T as mem::SizedTypeProperties>::ALIGNMENT
     }
 
     /// Returns the [ABI]-required minimum alignment of the type of the value that `val` points to.

--- a/tests/codegen-llvm/simd/array-repeat.rs
+++ b/tests/codegen-llvm/simd/array-repeat.rs
@@ -1,0 +1,40 @@
+//@ add-minicore
+//@ revisions: X86 AARCH64 RISCV S390X
+//@ [X86] compile-flags: -Copt-level=3 --target=x86_64-unknown-linux-gnu
+//@ [X86] needs-llvm-components: x86
+//@ [AARCH64] compile-flags: -Copt-level=3 --target=aarch64-unknown-linux-gnu
+//@ [AARCH64] needs-llvm-components: aarch64
+//@ [RISCV] compile-flags: -Copt-level=3 --target riscv64gc-unknown-linux-gnu -Ctarget-feature=+v
+//@ [RISCV] needs-llvm-components: riscv
+//@ [S390X] compile-flags: -Copt-level=3 --target s390x-unknown-linux-gnu -Ctarget-feature=+vector
+//@ [S390X] needs-llvm-components: systemz
+#![crate_type = "lib"]
+#![feature(repr_simd)]
+#![feature(no_core)]
+#![no_std]
+#![no_core]
+extern crate minicore;
+use minicore::*;
+
+#[repr(simd)]
+pub struct Simd<T, const N: usize>(pub [T; N]);
+
+pub type u8x16 = Simd<u8, 16>;
+
+// Regression test for https://github.com/rust-lang/rust/issues/97804.
+
+#[unsafe(no_mangle)]
+fn foo(v: u16, p: &mut [u8; 16]) {
+    // An array repeat transmuted into a SIMD type should emit a canonical LLVM splat sequence:
+    //
+    // CHECK-LABEL: foo
+    // CHECK: start
+    // CHECK-NEXT: %0 = insertelement <8 x i16> poison, i16 %v, i64 0
+    // CHECK-NEXT: %1 = shufflevector <8 x i16> %0, <8 x i16> poison, <8 x i32> zeroinitializer
+    // CHECK-NEXT: store <8 x i16> %1, ptr %p, align 1
+    // CHECK-NEXT: ret void
+    unsafe {
+        let v: u8x16 = mem::transmute([v; 8]);
+        *p = mem::transmute(v);
+    }
+}

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-abort.diff
@@ -44,7 +44,7 @@
           StorageLive(_4);
           StorageLive(_5);
           StorageLive(_6);
--         _6 = const std::ptr::Alignment::of::<[bool; 0]>::{constant#0} as *const [bool; 0] (Transmute);
+-         _6 = const <[bool; 0] as std::mem::SizedTypeProperties>::ALIGNMENT as *const [bool; 0] (Transmute);
 -         _5 = NonNull::<[bool; 0]> { pointer: copy _6 };
 +         _6 = const {0x1 as *const [bool; 0]};
 +         _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-unwind.diff
@@ -44,7 +44,7 @@
           StorageLive(_4);
           StorageLive(_5);
           StorageLive(_6);
--         _6 = const std::ptr::Alignment::of::<[bool; 0]>::{constant#0} as *const [bool; 0] (Transmute);
+-         _6 = const <[bool; 0] as std::mem::SizedTypeProperties>::ALIGNMENT as *const [bool; 0] (Transmute);
 -         _5 = NonNull::<[bool; 0]> { pointer: copy _6 };
 +         _6 = const {0x1 as *const [bool; 0]};
 +         _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-abort.diff
@@ -44,7 +44,7 @@
           StorageLive(_4);
           StorageLive(_5);
           StorageLive(_6);
--         _6 = const std::ptr::Alignment::of::<[bool; 0]>::{constant#0} as *const [bool; 0] (Transmute);
+-         _6 = const <[bool; 0] as std::mem::SizedTypeProperties>::ALIGNMENT as *const [bool; 0] (Transmute);
 -         _5 = NonNull::<[bool; 0]> { pointer: copy _6 };
 +         _6 = const {0x1 as *const [bool; 0]};
 +         _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-unwind.diff
@@ -44,7 +44,7 @@
           StorageLive(_4);
           StorageLive(_5);
           StorageLive(_6);
--         _6 = const std::ptr::Alignment::of::<[bool; 0]>::{constant#0} as *const [bool; 0] (Transmute);
+-         _6 = const <[bool; 0] as std::mem::SizedTypeProperties>::ALIGNMENT as *const [bool; 0] (Transmute);
 -         _5 = NonNull::<[bool; 0]> { pointer: copy _6 };
 +         _6 = const {0x1 as *const [bool; 0]};
 +         _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};

--- a/tests/mir-opt/gvn_ptr_eq_with_constant.main.GVN.diff
+++ b/tests/mir-opt/gvn_ptr_eq_with_constant.main.GVN.diff
@@ -40,7 +40,7 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
--         _3 = const std::ptr::Alignment::of::<u8>::{constant#0};
+-         _3 = const <u8 as std::mem::SizedTypeProperties>::ALIGNMENT;
 -         _2 = copy _3 as *mut u8 (Transmute);
 +         _3 = const std::ptr::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }};
 +         _2 = const {0x1 as *mut u8};

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1536,13 +1536,6 @@ mir-opt = [
     "@wesleywiser",
     "@saethlin",
 ]
-types = [
-    "@jackh726",
-    "@lcnr",
-    "@oli-obk",
-    "@spastorino",
-    "@BoxyUwU",
-]
 borrowck = [
     "@davidtwco",
     "@matthewjasper"

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1555,10 +1555,6 @@ style-team = [
     "@joshtriplett",
     "@traviscross",
 ]
-project-exploit-mitigations = [
-    "@cuviper",
-    "@rcvalle",
-]
 compiletest = [
     "@jieyouxu",
 ]

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1555,11 +1555,6 @@ style-team = [
     "@joshtriplett",
     "@traviscross",
 ]
-project-const-traits = [
-    "@fee1-dead",
-    "@fmease",
-    "@oli-obk",
-]
 project-stable-mir = [
     "@celinval",
     "@oli-obk",

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1555,12 +1555,6 @@ style-team = [
     "@joshtriplett",
     "@traviscross",
 ]
-project-stable-mir = [
-    "@celinval",
-    "@oli-obk",
-    "@scottmcm",
-    "@makai410",
-]
 project-exploit-mitigations = [
     "@cuviper",
     "@rcvalle",


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#151869 (add test for codegen of SIMD vector from array repeat)
 - rust-lang/rust#152077 (bootstrap: always propagate `CARGO_TARGET_{host}_LINKER`)
 - rust-lang/rust#126100 (Reword the caveats on `array::map`)
 - rust-lang/rust#152275 (Stop having two different alignment constants)
 - rust-lang/rust#152325 (Remove more adhoc groups that correspond to teams)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=151869,152077,126100,152275,152325)
<!-- homu-ignore:end -->

