### PR TITLE
Fix fn_sig() called on non-function in EII comparison

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/compare_eii.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_eii.rs
@@ -9,6 +9,7 @@ use std::iter;
 use rustc_data_structures::fx::FxIndexSet;
 use rustc_errors::{Applicability, E0806, struct_span_code_err};
 use rustc_hir::attrs::{AttributeKind, EiiImplResolution};
+use rustc_hir::def::{CtorKind, DefKind};
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::{self as hir, FnSig, HirId, ItemKind, find_attr};
 use rustc_infer::infer::{self, InferCtxt, TyCtxtInferExt};
@@ -25,7 +26,7 @@ use super::potentially_plural_count;
 use crate::check::compare_impl_item::{
     CheckNumberOfEarlyBoundRegionsError, check_number_of_early_bound_regions,
 };
-use crate::errors::{EiiWithGenerics, LifetimesOrBoundsMismatchOnEii};
+use crate::errors::{EiiDeclarationNotFn, EiiWithGenerics, LifetimesOrBoundsMismatchOnEii};
 
 /// Checks whether the signature of some `external_impl`, matches
 /// the signature of `declaration`, which it is supposed to be compatible
@@ -37,6 +38,20 @@ pub(crate) fn compare_eii_function_types<'tcx>(
     eii_name: Symbol,
     eii_attr_span: Span,
 ) -> Result<(), ErrorGuaranteed> {
+    // EII only applies to function declarations; name resolution may have given us a const/static/etc.
+    let decl_kind = tcx.def_kind(foreign_item);
+    let is_fn =
+        matches!(decl_kind, DefKind::Fn | DefKind::AssocFn | DefKind::Ctor(_, CtorKind::Fn));
+    if !is_fn {
+        return Err(tcx.dcx().emit_err(EiiDeclarationNotFn {
+            span: tcx.def_span(external_impl),
+            attr: eii_attr_span,
+            decl_span: tcx.def_span(foreign_item),
+            decl_name: tcx.item_name(foreign_item),
+            kind_descr: tcx.def_descr(foreign_item),
+        }));
+    }
+
     check_is_structurally_compatible(tcx, external_impl, foreign_item, eii_name, eii_attr_span)?;
 
     let external_impl_span = tcx.def_span(external_impl);

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1857,6 +1857,20 @@ pub(crate) struct LifetimesOrBoundsMismatchOnEii {
 }
 
 #[derive(Diagnostic)]
+#[diag("externally implementable item declaration must be a function")]
+#[help("externally implementable items only apply to function declarations")]
+pub(crate) struct EiiDeclarationNotFn {
+    #[primary_span]
+    pub span: Span,
+    #[label("required by this attribute")]
+    pub attr: Span,
+    #[label("`{$decl_name}` is a {$kind_descr}, not a function")]
+    pub decl_span: Span,
+    pub decl_name: Symbol,
+    pub kind_descr: &'static str,
+}
+
+#[derive(Diagnostic)]
 #[diag("`{$impl_name}` cannot have generic parameters other than lifetimes")]
 #[help("`#[{$eii_name}]` marks the implementation of an \"externally implementable item\"")]
 pub(crate) struct EiiWithGenerics {

--- a/tests/ui/eii/eii-declaration-not-fn-issue-152337.rs
+++ b/tests/ui/eii/eii-declaration-not-fn-issue-152337.rs
@@ -1,0 +1,11 @@
+// Regression test for ICE "unexpected sort of node in fn_sig()" (issue #152337).
+// When the same name is used for a const and an #[eii] function, the declaration
+// was incorrectly resolved to the const, causing fn_sig() to be called on a non-function.
+#![feature(extern_item_impls)]
+
+const A: () = ();
+#[eii]
+fn A() {} //~ ERROR the name `A` is defined multiple times
+//~^ ERROR externally implementable item declaration must be a function
+
+fn main() {}

--- a/tests/ui/eii/eii-declaration-not-fn-issue-152337.stderr
+++ b/tests/ui/eii/eii-declaration-not-fn-issue-152337.stderr
@@ -1,0 +1,26 @@
+error[E0428]: the name `A` is defined multiple times
+  --> $DIR/eii-declaration-not-fn-issue-152337.rs:8:1
+   |
+LL | const A: () = ();
+   | ----------------- previous definition of the value `A` here
+LL | #[eii]
+LL | fn A() {}
+   | ^^^^^^ `A` redefined here
+   |
+   = note: `A` must be defined only once in the value namespace of this module
+
+error: externally implementable item declaration must be a function
+  --> $DIR/eii-declaration-not-fn-issue-152337.rs:8:1
+   |
+LL | const A: () = ();
+   | ----------- `A` is a constant, not a function
+LL | #[eii]
+   | ------ required by this attribute
+LL | fn A() {}
+   | ^^^^^^
+   |
+   = help: externally implementable items only apply to function declarations
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0428`.


### PR DESCRIPTION
when the same name is used for a const and an `#[eii]` function, name resolution can give the const's `DefId` as the EII declaration. we then call `fn_sig()` on it and hit the ICE.

now, at the start of `compare_eii_function_types`, require the declaration to be `Fn`, `AssocFn`, or `Ctor(_, Fn)` before calling `fn_sig()`. If not, emit the new `EiiDeclarationNotFn` diagnostic and return.

also, added test with stderr

Fixes rust-lang/rust#152337
