### PR TITLE
Derives `Copy` for `ffi::FromBytesUntilNulError`

### DIFF
--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -155,7 +155,7 @@ impl Error for FromBytesWithNulError {}
 /// within the slice.
 ///
 /// This error is created by the [`CStr::from_bytes_until_nul`] method.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[stable(feature = "cstr_from_bytes_until_nul", since = "1.69.0")]
 pub struct FromBytesUntilNulError(());
 


### PR DESCRIPTION
[`ffi::FromBytesWithNulError` derives `Copy` since Rust 1.93](https://github.com/rust-lang/rust/commit/2f5a3d4b06a0a9e8749c2e361758ec517df0c96a) while `ffi::FromBytesUntilNulError` doesn't.
This Pr fixes that by deriving `Copy` for `ffi::FromBytesUntilNulError`.

I encountered this issue while I was working in a const context.

Note: I couldn't find any documentation about what kind of PR is allowed. As this one is very small, I guess it is ok to submit it directly without opening an issue first?