### PR TITLE
Rename the query system's `JobOwner` to `ActiveJobGuard`, and include `key_hash`

### DIFF
--- a/compiler/rustc_middle/src/ty/context/tls.rs
+++ b/compiler/rustc_middle/src/ty/context/tls.rs
@@ -16,8 +16,7 @@ pub struct ImplicitCtxt<'a, 'tcx> {
     /// The current `TyCtxt`.
     pub tcx: TyCtxt<'tcx>,
 
-    /// The current query job, if any. This is updated by `JobOwner::start` in
-    /// `ty::query::plumbing` when executing a query.
+    /// The current query job, if any.
     pub query: Option<QueryJobId>,
 
     /// Used to prevent queries from calling too deeply.

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -94,6 +94,7 @@ where
 {
     state: &'tcx QueryState<'tcx, K>,
     key: K,
+    key_hash: u64,
 }
 
 #[cold]
@@ -146,14 +147,13 @@ where
 {
     /// Completes the query by updating the query cache with the `result`,
     /// signals the waiter, and forgets the guard so it won't poison the query.
-    fn complete<C>(self, cache: &C, key_hash: u64, result: C::Value, dep_node_index: DepNodeIndex)
+    fn complete<C>(self, cache: &C, result: C::Value, dep_node_index: DepNodeIndex)
     where
         C: QueryCache<Key = K>,
     {
-        let key = self.key;
-        let state = self.state;
-
-        // Forget ourself so our destructor won't poison the query
+        // Forget ourself so our destructor won't poison the query.
+        // (Extract fields by value first to make sure we don't leak anything.)
+        let Self { state, key, key_hash }: Self = self;
         mem::forget(self);
 
         // Mark as complete before we remove the job from the active state
@@ -185,11 +185,10 @@ where
     #[cold]
     fn drop(&mut self) {
         // Poison the query so jobs waiting on it panic.
-        let state = self.state;
+        let Self { state, key, key_hash } = *self;
         let job = {
-            let key_hash = sharded::make_hash(&self.key);
             let mut shard = state.active.lock_shard_by_hash(key_hash);
-            match shard.find_entry(key_hash, equivalent_key(&self.key)) {
+            match shard.find_entry(key_hash, equivalent_key(&key)) {
                 Err(_) => panic!(),
                 Ok(occupied) => {
                     let ((key, value), vacant) = occupied.remove();
@@ -347,7 +346,7 @@ fn execute_job<'tcx, C: QueryCache, const FLAGS: QueryFlags, const INCR: bool>(
 ) -> (C::Value, Option<DepNodeIndex>) {
     // Set up a guard object that will automatically poison the query if a
     // panic occurs while executing the query (or any intermediate plumbing).
-    let job_guard = ActiveJobGuard { state, key };
+    let job_guard = ActiveJobGuard { state, key, key_hash };
 
     debug_assert_eq!(qcx.tcx.dep_graph.is_fully_enabled(), INCR);
 
@@ -395,7 +394,7 @@ fn execute_job<'tcx, C: QueryCache, const FLAGS: QueryFlags, const INCR: bool>(
     }
 
     // Tell the guard to perform completion bookkeeping, and also to not poison the query.
-    job_guard.complete(cache, key_hash, result, dep_node_index);
+    job_guard.complete(cache, result, dep_node_index);
 
     (result, Some(dep_node_index))
 }


### PR DESCRIPTION
`JobOwner` appears to have had more responsibilities in the past, but nowadays it's just a stack-guard object used by `execute_job` to poison the query state for the current key if some inner part of query execution panics.

The new name and comments should hopefully be clearer about its (limited) role.

I have also included a follow-up change that stores both the key and its previously-computed hash in the guard, instead of just the key. This avoids having to pass the key to `complete`, and avoids having to recompute the hash in `drop`.

r? nnethercote (or compiler)