### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -209,6 +209,7 @@ attribute_parsers!(
         Single<RustcLintOptDenyFieldAccessParser>,
         Single<RustcMustImplementOneOfParser>,
         Single<RustcObjectLifetimeDefaultParser>,
+        Single<RustcReservationImplParser>,
         Single<RustcScalableVectorParser>,
         Single<RustcSimdMonomorphizeLaneLimitParser>,
         Single<RustcSymbolName>,

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -106,9 +106,9 @@ pub(crate) struct UnstableInStableExposed {
     pub is_function_call2: bool,
     #[suggestion(
         "if the {$is_function_call2 ->
-    [true] caller
-    *[false] function
-} is not (yet) meant to be exposed to stable const contexts, add `#[rustc_const_unstable]`",
+            [true] caller
+            *[false] function
+        } is not (yet) meant to be exposed to stable const contexts, add `#[rustc_const_unstable]`",
         code = "#[rustc_const_unstable(feature = \"...\", issue = \"...\")]\n",
         applicability = "has-placeholders"
     )]
@@ -300,11 +300,11 @@ pub(crate) struct UnallowedHeapAllocations {
     #[primary_span]
     #[label(
         r#"allocation not allowed in {$kind ->
-    [const] constant
-    [static] static
-    [const_fn] constant function
-    *[other] {""}
-}s"#
+            [const] constant
+            [static] static
+            [const_fn] constant function
+            *[other] {""}
+        }s"#
     )]
     pub span: Span,
     pub kind: ConstContext,
@@ -539,20 +539,20 @@ pub enum NonConstClosureNote {
     },
     #[note(
         r#"function pointers need an RFC before allowed to be called in {$kind ->
-    [const] constant
-    [static] static
-    [const_fn] constant function
-    *[other] {""}
-}s"#
+            [const] constant
+            [static] static
+            [const_fn] constant function
+            *[other] {""}
+        }s"#
     )]
     FnPtr,
     #[note(
         r#"closures need an RFC before allowed to be called in {$kind ->
-    [const] constant
-    [static] static
-    [const_fn] constant function
-    *[other] {""}
-}s"#
+            [const] constant
+            [static] static
+            [const_fn] constant function
+            *[other] {""}
+        }s"#
     )]
     Closure,
 }
@@ -608,11 +608,11 @@ pub struct LiveDrop<'tcx> {
     #[primary_span]
     #[label(
         r#"the destructor for this type cannot be evaluated in {$kind ->
-    [const] constant
-    [static] static
-    [const_fn] constant function
-    *[other] {""}
-}s"#
+            [const] constant
+            [static] static
+            [const_fn] constant function
+            *[other] {""}
+        }s"#
     )]
     pub span: Span,
     pub kind: ConstContext,

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -1219,6 +1219,9 @@ pub enum AttributeKind {
     /// Represents `#[rustc_regions]`
     RustcRegions,
 
+    /// Represents `#[rustc_reservation_impl]`
+    RustcReservationImpl(Span, Symbol),
+
     /// Represents `#[rustc_scalable_vector(N)]`
     RustcScalableVector {
         /// The base multiple of lanes that are in a scalable vector, if provided. `element_count`

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -151,6 +151,7 @@ impl AttributeKind {
             RustcPubTransparent(..) => Yes,
             RustcReallocator => No,
             RustcRegions => No,
+            RustcReservationImpl(..) => Yes,
             RustcScalableVector { .. } => Yes,
             RustcShouldNotBeCalledOnConstItems(..) => Yes,
             RustcSimdMonomorphizeLaneLimit(..) => Yes, // Affects layout computation, which needs to work cross-crate

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -1275,7 +1275,8 @@ fn impl_trait_header(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::ImplTraitHeader
         .of_trait
         .unwrap_or_else(|| panic!("expected impl trait, found inherent impl on {def_id:?}"));
     let selfty = tcx.type_of(def_id).instantiate_identity();
-    let is_rustc_reservation = tcx.has_attr(def_id, sym::rustc_reservation_impl);
+    let is_rustc_reservation =
+        find_attr!(tcx.get_all_attrs(def_id), AttributeKind::RustcReservationImpl(..));
 
     check_impl_constness(tcx, impl_.constness, &of_trait.trait_ref);
 

--- a/compiler/rustc_macros/src/diagnostics/diagnostic_builder.rs
+++ b/compiler/rustc_macros/src/diagnostics/diagnostic_builder.rs
@@ -203,8 +203,11 @@ impl DiagnosticDeriveVariantBuilder {
                         )
                         .emit();
                     }
-                    self.message =
-                        Some(Message { message_span: message.span(), value: message.value() });
+                    self.message = Some(Message {
+                        attr_span: attr.span(),
+                        message_span: message.span(),
+                        value: message.value(),
+                    });
                 }
 
                 // Parse arguments

--- a/compiler/rustc_macros/src/diagnostics/utils.rs
+++ b/compiler/rustc_macros/src/diagnostics/utils.rs
@@ -708,7 +708,7 @@ impl SubdiagnosticVariant {
                     }
                     if !input.is_empty() { input.parse::<Token![,]>()?; }
                     if is_first {
-                        message = Some(Message { message_span: inline_message.span(), value: inline_message.value() });
+                        message = Some(Message { attr_span: attr.span(), message_span: inline_message.span(), value: inline_message.value() });
                         is_first = false;
                     } else {
                         span_err(inline_message.span().unwrap(), "a diagnostic message must be the first argument to the attribute").emit();

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -198,12 +198,12 @@ pub(crate) struct UnsafeOpInUnsafeFnCallToFunctionWithRequiresUnsafe {
     pub(crate) missing_target_features: DiagArgValue,
     pub(crate) missing_target_features_count: usize,
     #[note("the {$build_target_features} target {$build_target_features_count ->
-    [1] feature
-    *[count] features
+        [1] feature
+        *[count] features
     } being enabled in the build configuration does not remove the requirement to list {$build_target_features_count ->
-    [1] it
-*[count] them
-} in `#[target_feature]`")]
+        [1] it
+        *[count] them
+    } in `#[target_feature]`")]
     pub(crate) note: bool,
     pub(crate) build_target_features: DiagArgValue,
     pub(crate) build_target_features_count: usize,
@@ -532,12 +532,12 @@ pub(crate) struct CallToFunctionWithRequiresUnsafe {
     pub(crate) missing_target_features: DiagArgValue,
     pub(crate) missing_target_features_count: usize,
     #[note("the {$build_target_features} target {$build_target_features_count ->
-    [1] feature
-    *[count] features
-} being enabled in the build configuration does not remove the requirement to list {$build_target_features_count ->
-    [1] it
-    *[count] them
-} in `#[target_feature]`")]
+        [1] feature
+        *[count] features
+    } being enabled in the build configuration does not remove the requirement to list {$build_target_features_count ->
+        [1] it
+        *[count] them
+    } in `#[target_feature]`")]
     pub(crate) note: bool,
     pub(crate) build_target_features: DiagArgValue,
     pub(crate) build_target_features_count: usize,
@@ -1264,9 +1264,9 @@ pub(crate) struct InterpretedAsConstSugg {
 pub(crate) enum SuggestLet {
     #[multipart_suggestion(
         "you might want to use `if let` to ignore the {$count ->
-[one] variant that isn't
-*[other] variants that aren't
-} matched",
+            [one] variant that isn't
+            *[other] variants that aren't
+        } matched",
         applicability = "has-placeholders"
     )]
     If {
@@ -1278,9 +1278,9 @@ pub(crate) enum SuggestLet {
     },
     #[suggestion(
         "you might want to use `let...else` to handle the {$count ->
-[one] variant that isn't
-*[other] variants that aren't
-} matched",
+            [one] variant that isn't
+            *[other] variants that aren't
+        } matched",
         code = " else {{ todo!() }}",
         applicability = "has-placeholders"
     )]

--- a/compiler/rustc_monomorphize/src/errors.rs
+++ b/compiler/rustc_monomorphize/src/errors.rs
@@ -162,9 +162,9 @@ pub(crate) struct AbiRequiredTargetFeature<'a> {
     #[primary_span]
     #[label(
         "function {$is_call ->
-[true] called
-*[false] defined
-} here"
+            [true] called
+            *[false] defined
+        } here"
     )]
     pub span: Span,
     pub required_feature: &'a str,

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -1151,7 +1151,7 @@ pub(crate) enum MatchArmBodyWithoutBracesSugg {
     #[multipart_suggestion(
         "surround the {$num_statements ->
             [one] statement
-           *[other] statements
+            *[other] statements
         } with a body",
         applicability = "machine-applicable"
     )]

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -342,6 +342,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     | AttributeKind::RustcPreserveUbChecks
                     | AttributeKind::RustcReallocator
                     | AttributeKind::RustcRegions
+                    | AttributeKind::RustcReservationImpl(..)
                     | AttributeKind::RustcScalableVector { .. }
                     | AttributeKind::RustcShouldNotBeCalledOnConstItems(..)
                     | AttributeKind::RustcSimdMonomorphizeLaneLimit(..)
@@ -396,7 +397,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                             | sym::rustc_trivial_field_reads
                             | sym::rustc_on_unimplemented
                             | sym::rustc_do_not_const_check
-                            | sym::rustc_reservation_impl
                             | sym::rustc_doc_primitive
                             | sym::rustc_conversion_suggestion
                             | sym::rustc_deprecated_safe_2024

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -1417,8 +1417,8 @@ pub(crate) struct DuplicateEiiImpls {
     pub second_crate: Symbol,
 
     #[note("in addition to these two, { $num_additional_crates ->
-         [one] another implementation was found in crate {$additional_crate_names}
-         *[other] more implementations were also found in the following crates: {$additional_crate_names}
+        [one] another implementation was found in crate {$additional_crate_names}
+        *[other] more implementations were also found in the following crates: {$additional_crate_names}
     }")]
     pub additional_crates: Option<()>,
 

--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -327,18 +327,18 @@ pub struct InferenceBadError<'a> {
 pub enum SourceKindSubdiag<'a> {
     #[suggestion(
         "{$kind ->
-[with_pattern] consider giving `{$name}` an explicit type
-[closure] consider giving this closure parameter an explicit type
-*[other] consider giving this pattern a type
-}{$x_kind ->
-[has_name] , where the {$prefix_kind ->
-*[type] type for {$prefix}
-[const_with_param] value of const parameter
-[const] value of the constant
-} `{$arg_name}` is specified
-[underscore] , where the placeholders `_` are specified
-*[empty] {\"\"}
-}",
+            [with_pattern] consider giving `{$name}` an explicit type
+            [closure] consider giving this closure parameter an explicit type
+            *[other] consider giving this pattern a type
+        }{$x_kind ->
+            [has_name] , where the {$prefix_kind ->
+                *[type] type for {$prefix}
+                [const_with_param] value of const parameter
+                [const] value of the constant
+            } `{$arg_name}` is specified
+            [underscore] , where the placeholders `_` are specified
+            *[empty] {\"\"}
+        }",
         style = "verbose",
         code = ": {type_name}",
         applicability = "has-placeholders"
@@ -356,15 +356,15 @@ pub enum SourceKindSubdiag<'a> {
     },
     #[label(
         "cannot infer {$is_type ->
-[true] type
-*[false] the value
-} of the {$is_type ->
-[true] type
-*[false] const
-} {$parent_exists ->
-[true] parameter `{$param_name}` declared on the {$parent_prefix} `{$parent_name}`
-*[false] parameter {$param_name}
-}"
+            [true] type
+            *[false] the value
+        } of the {$is_type ->
+            [true] type
+            *[false] const
+        } {$parent_exists ->
+            [true] parameter `{$param_name}` declared on the {$parent_prefix} `{$parent_name}`
+            *[false] parameter {$param_name}
+        }"
     )]
     GenericLabel {
         #[primary_span]
@@ -377,9 +377,9 @@ pub enum SourceKindSubdiag<'a> {
     },
     #[suggestion(
         "consider specifying the generic {$arg_count ->
-[one] argument
-*[other] arguments
-}",
+            [one] argument
+            *[other] arguments
+        }",
         style = "verbose",
         code = "::<{args}>",
         applicability = "has-placeholders"
@@ -945,9 +945,9 @@ impl IntoDiagArg for TyOrSig<'_> {
 #[derive(Subdiagnostic)]
 pub enum ActualImplExplNotes<'tcx> {
     #[note("{$leading_ellipsis ->
-[true] ...
-*[false] {\"\"}
-}closure with signature `{$ty_or_sig}` must implement `{$trait_path}`, for any two lifetimes `'{$lifetime_1}` and `'{$lifetime_2}`...")]
+        [true] ...
+        *[false] {\"\"}
+    }closure with signature `{$ty_or_sig}` must implement `{$trait_path}`, for any two lifetimes `'{$lifetime_1}` and `'{$lifetime_2}`...")]
     ExpectedSignatureTwo {
         leading_ellipsis: bool,
         ty_or_sig: TyOrSig<'tcx>,
@@ -956,9 +956,9 @@ pub enum ActualImplExplNotes<'tcx> {
         lifetime_2: usize,
     },
     #[note("{$leading_ellipsis ->
-[true] ...
-*[false] {\"\"}
-}closure with signature `{$ty_or_sig}` must implement `{$trait_path}`, for any lifetime `'{$lifetime_1}`...")]
+        [true] ...
+        *[false] {\"\"}
+    }closure with signature `{$ty_or_sig}` must implement `{$trait_path}`, for any lifetime `'{$lifetime_1}`...")]
     ExpectedSignatureAny {
         leading_ellipsis: bool,
         ty_or_sig: TyOrSig<'tcx>,
@@ -966,9 +966,9 @@ pub enum ActualImplExplNotes<'tcx> {
         lifetime_1: usize,
     },
     #[note("{$leading_ellipsis ->
-[true] ...
-*[false] {\"\"}
-}closure with signature `{$ty_or_sig}` must implement `{$trait_path}`, for some specific lifetime `'{$lifetime_1}`...")]
+        [true] ...
+        *[false] {\"\"}
+    }closure with signature `{$ty_or_sig}` must implement `{$trait_path}`, for some specific lifetime `'{$lifetime_1}`...")]
     ExpectedSignatureSome {
         leading_ellipsis: bool,
         ty_or_sig: TyOrSig<'tcx>,
@@ -977,9 +977,9 @@ pub enum ActualImplExplNotes<'tcx> {
     },
     #[note(
         "{$leading_ellipsis ->
-[true] ...
-*[false] {\"\"}
-}closure with signature `{$ty_or_sig}` must implement `{$trait_path}`"
+            [true] ...
+            *[false] {\"\"}
+        }closure with signature `{$ty_or_sig}` must implement `{$trait_path}`"
     )]
     ExpectedSignatureNothing {
         leading_ellipsis: bool,
@@ -987,9 +987,9 @@ pub enum ActualImplExplNotes<'tcx> {
         trait_path: Highlighted<'tcx, TraitRefPrintOnlyTraitPath<'tcx>>,
     },
     #[note("{$leading_ellipsis ->
-[true] ...
-*[false] {\"\"}
-}`{$trait_path}` would have to be implemented for the type `{$ty_or_sig}`, for any two lifetimes `'{$lifetime_1}` and `'{$lifetime_2}`...")]
+        [true] ...
+        *[false] {\"\"}
+    }`{$trait_path}` would have to be implemented for the type `{$ty_or_sig}`, for any two lifetimes `'{$lifetime_1}` and `'{$lifetime_2}`...")]
     ExpectedPassiveTwo {
         leading_ellipsis: bool,
         ty_or_sig: TyOrSig<'tcx>,
@@ -998,9 +998,9 @@ pub enum ActualImplExplNotes<'tcx> {
         lifetime_2: usize,
     },
     #[note("{$leading_ellipsis ->
-[true] ...
-*[false] {\"\"}
-}`{$trait_path}` would have to be implemented for the type `{$ty_or_sig}`, for any lifetime `'{$lifetime_1}`...")]
+        [true] ...
+        *[false] {\"\"}
+    }`{$trait_path}` would have to be implemented for the type `{$ty_or_sig}`, for any lifetime `'{$lifetime_1}`...")]
     ExpectedPassiveAny {
         leading_ellipsis: bool,
         ty_or_sig: TyOrSig<'tcx>,
@@ -1008,9 +1008,9 @@ pub enum ActualImplExplNotes<'tcx> {
         lifetime_1: usize,
     },
     #[note("{$leading_ellipsis ->
-[true] ...
-*[false] {\"\"}
-}`{$trait_path}` would have to be implemented for the type `{$ty_or_sig}`, for some specific lifetime `'{$lifetime_1}`...")]
+        [true] ...
+        *[false] {\"\"}
+    }`{$trait_path}` would have to be implemented for the type `{$ty_or_sig}`, for some specific lifetime `'{$lifetime_1}`...")]
     ExpectedPassiveSome {
         leading_ellipsis: bool,
         ty_or_sig: TyOrSig<'tcx>,
@@ -1019,9 +1019,9 @@ pub enum ActualImplExplNotes<'tcx> {
     },
     #[note(
         "{$leading_ellipsis ->
-[true] ...
-*[false] {\"\"}
-}`{$trait_path}` would have to be implemented for the type `{$ty_or_sig}`"
+            [true] ...
+            *[false] {\"\"}
+        }`{$trait_path}` would have to be implemented for the type `{$ty_or_sig}`"
     )]
     ExpectedPassiveNothing {
         leading_ellipsis: bool,
@@ -1029,9 +1029,9 @@ pub enum ActualImplExplNotes<'tcx> {
         trait_path: Highlighted<'tcx, TraitRefPrintOnlyTraitPath<'tcx>>,
     },
     #[note("{$leading_ellipsis ->
-[true] ...
-*[false] {\"\"}
-}`{$ty_or_sig}` must implement `{$trait_path}`, for any two lifetimes `'{$lifetime_1}` and `'{$lifetime_2}`...")]
+        [true] ...
+        *[false] {\"\"}
+    }`{$ty_or_sig}` must implement `{$trait_path}`, for any two lifetimes `'{$lifetime_1}` and `'{$lifetime_2}`...")]
     ExpectedOtherTwo {
         leading_ellipsis: bool,
         ty_or_sig: TyOrSig<'tcx>,
@@ -1041,9 +1041,9 @@ pub enum ActualImplExplNotes<'tcx> {
     },
     #[note(
         "{$leading_ellipsis ->
-[true] ...
-*[false] {\"\"}
-}`{$ty_or_sig}` must implement `{$trait_path}`, for any lifetime `'{$lifetime_1}`..."
+            [true] ...
+            *[false] {\"\"}
+        }`{$ty_or_sig}` must implement `{$trait_path}`, for any lifetime `'{$lifetime_1}`..."
     )]
     ExpectedOtherAny {
         leading_ellipsis: bool,
@@ -1053,9 +1053,9 @@ pub enum ActualImplExplNotes<'tcx> {
     },
     #[note(
         "{$leading_ellipsis ->
-[true] ...
-*[false] {\"\"}
-}`{$ty_or_sig}` must implement `{$trait_path}`, for some specific lifetime `'{$lifetime_1}`..."
+            [true] ...
+            *[false] {\"\"}
+        }`{$ty_or_sig}` must implement `{$trait_path}`, for some specific lifetime `'{$lifetime_1}`..."
     )]
     ExpectedOtherSome {
         leading_ellipsis: bool,
@@ -1065,9 +1065,9 @@ pub enum ActualImplExplNotes<'tcx> {
     },
     #[note(
         "{$leading_ellipsis ->
-[true] ...
-*[false] {\"\"}
-}`{$ty_or_sig}` must implement `{$trait_path}`"
+            [true] ...
+            *[false] {\"\"}
+        }`{$ty_or_sig}` must implement `{$trait_path}`"
     )]
     ExpectedOtherNothing {
         leading_ellipsis: bool,
@@ -1076,9 +1076,9 @@ pub enum ActualImplExplNotes<'tcx> {
     },
     #[note(
         "...but it actually implements `{$trait_path}`{$has_lifetime ->
-[true] , for some specific lifetime `'{$lifetime}`
-*[false] {\"\"}
-}"
+            [true] , for some specific lifetime `'{$lifetime}`
+            *[false] {\"\"}
+        }"
     )]
     ButActuallyImplementsTrait {
         trait_path: Highlighted<'tcx, TraitRefPrintOnlyTraitPath<'tcx>>,
@@ -1087,9 +1087,9 @@ pub enum ActualImplExplNotes<'tcx> {
     },
     #[note(
         "...but `{$trait_path}` is actually implemented for the type `{$ty}`{$has_lifetime ->
-[true] , for some specific lifetime `'{$lifetime}`
-*[false] {\"\"}
-}"
+            [true] , for some specific lifetime `'{$lifetime}`
+            *[false] {\"\"}
+        }"
     )]
     ButActuallyImplementedForTy {
         trait_path: Highlighted<'tcx, TraitRefPrintOnlyTraitPath<'tcx>>,
@@ -1099,9 +1099,9 @@ pub enum ActualImplExplNotes<'tcx> {
     },
     #[note(
         "...but `{$ty}` actually implements `{$trait_path}`{$has_lifetime ->
-[true] , for some specific lifetime `'{$lifetime}`
-*[false] {\"\"}
-}"
+            [true] , for some specific lifetime `'{$lifetime}`
+            *[false] {\"\"}
+        }"
     )]
     ButActuallyTyImplements {
         trait_path: Highlighted<'tcx, TraitRefPrintOnlyTraitPath<'tcx>>,
@@ -1246,7 +1246,7 @@ pub struct TraitImplDiff {
     pub trait_sp: Span,
     #[note(
         "expected signature `{$expected}`
-               {\"   \"}found signature `{$found}`"
+        {\"   \"}found signature `{$found}`"
     )]
     pub note: (),
     #[subdiagnostic]
@@ -1940,10 +1940,12 @@ pub enum ObligationCauseFailureCode {
         #[primary_span]
         span: Span,
     },
-    #[diag("{$lang_item_name ->
-[panic_impl] `#[panic_handler]`
-*[lang_item_name] lang item `{$lang_item_name}`
-} function has wrong type", code = E0308)]
+    #[diag(
+        "{$lang_item_name ->
+            [panic_impl] `#[panic_handler]`
+            *[lang_item_name] lang item `{$lang_item_name}`
+        } function has wrong type"
+    , code = E0308)]
     FnLangCorrectType {
         #[primary_span]
         span: Span,


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#152357 (std: Don't panic when removing a nonexistent UEFI var)
 - rust-lang/rust#152180 (Port `rustc_reservation_impl` to the new attribute parser)
 - rust-lang/rust#152276 (Add message format checking)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=152357,152180,152276)
<!-- homu-ignore:end -->

