### PR TITLE
Feature gate for defaulted associated type_consts with associated_type_defaults 

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -431,7 +431,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 false
             }
             ast::AssocItemKind::Const(box ast::ConstItem {
-                rhs_kind: ast::ConstItemRhsKind::TypeConst { .. },
+                rhs_kind: ast::ConstItemRhsKind::TypeConst { rhs },
                 ..
             }) => {
                 // Make sure this is only allowed if the feature gate is enabled.
@@ -442,6 +442,17 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                     i.span,
                     "associated `type const` are unstable"
                 );
+                // Make sure associated `type const` defaults in traits are only allowed
+                // if the feature gate is enabled.
+                // #![feature(associated_type_defaults)]
+                if ctxt == AssocCtxt::Trait && rhs.is_some() {
+                    gate!(
+                        &self,
+                        associated_type_defaults,
+                        i.span,
+                        "associated type defaults are unstable"
+                    );
+                }
                 false
             }
             _ => false,

--- a/tests/ui/const-generics/associated-const-bindings/const_evaluatable_unchecked.rs
+++ b/tests/ui/const-generics/associated-const-bindings/const_evaluatable_unchecked.rs
@@ -4,7 +4,7 @@
 //
 // issue: <https://github.com/rust-lang/rust/issues/108220>
 //@ check-pass
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, associated_type_defaults)]
 #![allow(incomplete_features)]
 
 pub trait TraitA<T> {

--- a/tests/ui/const-generics/mgca/type-const-associated-default.rs
+++ b/tests/ui/const-generics/mgca/type-const-associated-default.rs
@@ -1,0 +1,9 @@
+#![feature(min_generic_const_args)]
+#![expect(incomplete_features)]
+trait Trait {
+    type const N: usize = 10;
+    //~^ ERROR associated type defaults are unstable
+}
+
+fn main(){
+}

--- a/tests/ui/const-generics/mgca/type-const-associated-default.stderr
+++ b/tests/ui/const-generics/mgca/type-const-associated-default.stderr
@@ -1,0 +1,13 @@
+error[E0658]: associated type defaults are unstable
+  --> $DIR/type-const-associated-default.rs:4:5
+   |
+LL |     type const N: usize = 10;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #29661 <https://github.com/rust-lang/rust/issues/29661> for more information
+   = help: add `#![feature(associated_type_defaults)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/generic-const-items/assoc-const-no-infer-ice-115806.rs
+++ b/tests/ui/generic-const-items/assoc-const-no-infer-ice-115806.rs
@@ -1,6 +1,7 @@
 // ICE: assertion failed: !value.has_infer()
 // issue: rust-lang/rust#115806
 #![feature(adt_const_params, min_generic_const_args, unsized_const_params)]
+#![feature(associated_type_defaults)]
 #![allow(incomplete_features)]
 
 pub struct NoPin;

--- a/tests/ui/generic-const-items/assoc-const-no-infer-ice-115806.stderr
+++ b/tests/ui/generic-const-items/assoc-const-no-infer-ice-115806.stderr
@@ -1,5 +1,5 @@
 error[E0119]: conflicting implementations of trait `Pins<_>` for type `NoPin`
-  --> $DIR/assoc-const-no-infer-ice-115806.rs:16:1
+  --> $DIR/assoc-const-no-infer-ice-115806.rs:17:1
    |
 LL | impl<TA> Pins<TA> for NoPin {}
    | --------------------------- first implementation here

--- a/tests/ui/sanitizer/cfi/assoc-const-projection-issue-151878.rs
+++ b/tests/ui/sanitizer/cfi/assoc-const-projection-issue-151878.rs
@@ -4,7 +4,7 @@
 //@ build-pass
 //@ no-prefer-dynamic
 
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, associated_type_defaults)]
 #![expect(incomplete_features)]
 
 trait Trait {


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/152385)*

This PR for issue rust-lang/rust#130288 extends a feature gate that was already present for defaulted associated types to defaulted type consts under associated_type_defaults. 

Code added:
```
if ctxt == AssocCtxt::Trait && rhs.is_some() {
                    gate!(
                        &self,
                        associated_type_defaults,
                        i.span,
                        "associated type defaults are unstable"
                    );
                }
```

Error produced: 
```
error[E0658]: associated type defaults are unstable
  --> $DIR/type-const-associated-default.rs:4:5
   |
LL |     type const N: usize = 10;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #29661 <https://github.com/rust-lang/rust/issues/29661> for more information
   = help: add `#![feature(associated_type_defaults)]` to the crate attributes to enable
   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date

warning: the feature `min_generic_const_args` is incomplete and may not be safe to use and/or cause compiler crashes
  --> $DIR/type-const-associated-default.rs:1:12
   |
LL | #![feature(min_generic_const_args)]
   |            ^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
   = note: `#[warn(incomplete_features)]` on by default

error: aborting due to 1 previous error; 1 warning emitted

For more information about this error, try `rustc --explain E0658`.

```
Thanks to @BoxyUwU for the guidance on this issue.