### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -689,6 +689,30 @@ impl<T: CoerceUnsized<U>, U> CoerceUnsized<Cell<U>> for Cell<T> {}
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
 impl<T: DispatchFromDyn<U>, U> DispatchFromDyn<Cell<U>> for Cell<T> {}
 
+#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+impl<T, const N: usize> AsRef<[Cell<T>; N]> for Cell<[T; N]> {
+    #[inline]
+    fn as_ref(&self) -> &[Cell<T>; N] {
+        self.as_array_of_cells()
+    }
+}
+
+#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+impl<T, const N: usize> AsRef<[Cell<T>]> for Cell<[T; N]> {
+    #[inline]
+    fn as_ref(&self) -> &[Cell<T>] {
+        &*self.as_array_of_cells()
+    }
+}
+
+#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+impl<T> AsRef<[Cell<T>]> for Cell<[T]> {
+    #[inline]
+    fn as_ref(&self) -> &[Cell<T>] {
+        self.as_slice_of_cells()
+    }
+}
+
 impl<T> Cell<[T]> {
     /// Returns a `&[Cell<T>]` from a `&Cell<[T]>`
     ///

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -1532,6 +1532,56 @@ impl<T, const N: usize> MaybeUninit<[T; N]> {
     }
 }
 
+#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+impl<T, const N: usize> From<[MaybeUninit<T>; N]> for MaybeUninit<[T; N]> {
+    #[inline]
+    fn from(arr: [MaybeUninit<T>; N]) -> Self {
+        arr.transpose()
+    }
+}
+
+#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+impl<T, const N: usize> AsRef<[MaybeUninit<T>; N]> for MaybeUninit<[T; N]> {
+    #[inline]
+    fn as_ref(&self) -> &[MaybeUninit<T>; N] {
+        // SAFETY: T and MaybeUninit<T> have the same layout
+        unsafe { &*ptr::from_ref(self).cast() }
+    }
+}
+
+#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+impl<T, const N: usize> AsRef<[MaybeUninit<T>]> for MaybeUninit<[T; N]> {
+    #[inline]
+    fn as_ref(&self) -> &[MaybeUninit<T>] {
+        &*AsRef::<[MaybeUninit<T>; N]>::as_ref(self)
+    }
+}
+
+#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+impl<T, const N: usize> AsMut<[MaybeUninit<T>; N]> for MaybeUninit<[T; N]> {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [MaybeUninit<T>; N] {
+        // SAFETY: T and MaybeUninit<T> have the same layout
+        unsafe { &mut *ptr::from_mut(self).cast() }
+    }
+}
+
+#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+impl<T, const N: usize> AsMut<[MaybeUninit<T>]> for MaybeUninit<[T; N]> {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [MaybeUninit<T>] {
+        &mut *AsMut::<[MaybeUninit<T>; N]>::as_mut(self)
+    }
+}
+
+#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+impl<T, const N: usize> From<MaybeUninit<[T; N]>> for [MaybeUninit<T>; N] {
+    #[inline]
+    fn from(arr: MaybeUninit<[T; N]>) -> Self {
+        arr.transpose()
+    }
+}
+
 impl<T, const N: usize> [MaybeUninit<T>; N] {
     /// Transposes a `[MaybeUninit<T>; N]` into a `MaybeUninit<[T; N]>`.
     ///

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -2175,7 +2175,7 @@ unsafe impl<T> Sync for ChunksExactMut<'_, T> where T: Sync {}
 ///
 /// [`array_windows`]: slice::array_windows
 /// [slices]: slice
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 #[stable(feature = "array_windows", since = "1.94.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 pub struct ArrayWindows<'a, T: 'a, const N: usize> {

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -2175,7 +2175,7 @@ unsafe impl<T> Sync for ChunksExactMut<'_, T> where T: Sync {}
 ///
 /// [`array_windows`]: slice::array_windows
 /// [slices]: slice
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[stable(feature = "array_windows", since = "1.94.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 pub struct ArrayWindows<'a, T: 'a, const N: usize> {
@@ -2186,6 +2186,14 @@ impl<'a, T: 'a, const N: usize> ArrayWindows<'a, T, N> {
     #[inline]
     pub(super) const fn new(slice: &'a [T]) -> Self {
         Self { v: slice }
+    }
+}
+
+// FIXME(#26925) Remove in favor of `#[derive(Clone)]`
+#[stable(feature = "array_windows", since = "1.94.0")]
+impl<T, const N: usize> Clone for ArrayWindows<'_, T, N> {
+    fn clone(&self) -> Self {
+        Self { v: self.v }
     }
 }
 

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -2232,6 +2232,14 @@ impl<'a, T, const N: usize> Iterator for ArrayWindows<'a, T, N> {
     fn last(self) -> Option<Self::Item> {
         self.v.last_chunk()
     }
+
+    unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
+        // SAFETY: since the caller guarantees that `idx` is in bounds,
+        // which means that `idx` cannot overflow an `isize`, and the
+        // "slice" created by `cast_array` is a subslice of `self.v`
+        // thus is guaranteed to be valid for the lifetime `'a` of `self.v`.
+        unsafe { &*self.v.as_ptr().add(idx).cast_array() }
+    }
 }
 
 #[stable(feature = "array_windows", since = "1.94.0")]
@@ -2265,6 +2273,16 @@ unsafe impl<T, const N: usize> TrustedLen for ArrayWindows<'_, T, N> {}
 
 #[stable(feature = "array_windows", since = "1.94.0")]
 impl<T, const N: usize> FusedIterator for ArrayWindows<'_, T, N> {}
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+unsafe impl<T, const N: usize> TrustedRandomAccess for ArrayWindows<'_, T, N> {}
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+unsafe impl<T, const N: usize> TrustedRandomAccessNoCoerce for ArrayWindows<'_, T, N> {
+    const MAY_HAVE_SIDE_EFFECT: bool = false;
+}
 
 /// An iterator over a slice in (non-overlapping) chunks (`chunk_size` elements at a
 /// time), starting at the end of the slice.

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -2260,6 +2260,9 @@ impl<T, const N: usize> ExactSizeIterator for ArrayWindows<'_, T, N> {
     }
 }
 
+#[unstable(feature = "trusted_len", issue = "37572")]
+unsafe impl<T, const N: usize> TrustedLen for ArrayWindows<'_, T, N> {}
+
 #[stable(feature = "array_windows", since = "1.94.0")]
 impl<T, const N: usize> FusedIterator for ArrayWindows<'_, T, N> {}
 

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -2260,6 +2260,9 @@ impl<T, const N: usize> ExactSizeIterator for ArrayWindows<'_, T, N> {
     }
 }
 
+#[stable(feature = "array_windows", since = "1.94.0")]
+impl<T, const N: usize> FusedIterator for ArrayWindows<'_, T, N> {}
+
 /// An iterator over a slice in (non-overlapping) chunks (`chunk_size` elements at a
 /// time), starting at the end of the slice.
 ///

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -19,6 +19,20 @@
 //! matter the platform or filesystem. An exception to this is made for Windows
 //! drive letters.
 //!
+//! ## Path normalization
+//!
+//! Several methods in this module perform basic path normalization by disregarding
+//! repeated separators, non-leading `.` components, and trailing separators. These include:
+//! - Methods for iteration, such as [`Path::components`] and [`Path::iter`]
+//! - Methods for inspection, such as [`Path::has_root`]
+//! - Comparisons using [`PartialEq`], [`PartialOrd`], and [`Ord`]
+//!
+//! [`Path::join`] and [`PathBuf::push`] also disregard trailing slashes.
+//!
+// FIXME(normalize_lexically): mention normalize_lexically once stable
+//! These methods **do not** resolve `..` components or symlinks. For full normalization
+//! including `..` resolution, use [`Path::canonicalize`] (which does access the filesystem).
+//!
 //! ## Simple usage
 //!
 //! Path manipulation includes both parsing components from slices and building

--- a/tests/ui/suggestions/issue-71394-no-from-impl.stderr
+++ b/tests/ui/suggestions/issue-71394-no-from-impl.stderr
@@ -13,7 +13,7 @@ LL |     let _: &[i8] = data.into();
              `[T; 6]` implements `From<(T, T, T, T, T, T)>`
              `[T; 7]` implements `From<(T, T, T, T, T, T, T)>`
              `[T; 8]` implements `From<(T, T, T, T, T, T, T, T)>`
-           and 6 others
+           and 7 others
    = note: required for `&[u8]` to implement `Into<&[i8]>`
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#151613 (Align `ArrayWindows` trait impls with `Windows`)
 - rust-lang/rust#142957 (std: introduce path normalize methods at top of `std::path`)
 - rust-lang/rust#145504 (Add some conversion trait impls)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=151613,142957,145504)
<!-- homu-ignore:end -->

