### PR TITLE
Fix ICE in supertrait_vtable_slot when supertrait has missing generics

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/vtable.rs
+++ b/compiler/rustc_trait_selection/src/traits/vtable.rs
@@ -434,7 +434,16 @@ pub(crate) fn supertrait_vtable_slot<'tcx>(
         }
     };
 
-    prepare_vtable_segments(tcx, source_principal, vtable_segment_callback).unwrap()
+    prepare_vtable_segments(tcx, source_principal, vtable_segment_callback).unwrap_or_else(|| {
+        // This can happen if the trait hierarchy is malformed (e.g., due to
+        // missing generics on a supertrait bound). There should already be an error
+        // emitted for this, so we just delay the ICE.
+        tcx.dcx().delayed_bug(format!(
+            "could not find the supertrait vtable slot for `{}` -> `{}`",
+            source, target
+        ));
+        None
+    })
 }
 
 pub(super) fn provide(providers: &mut Providers) {

--- a/tests/ui/traits/vtable/missing-generics-issue-151330.rs
+++ b/tests/ui/traits/vtable/missing-generics-issue-151330.rs
@@ -1,0 +1,23 @@
+//@ compile-flags: -Znext-solver=globally
+// Regression test for issue https://github.com/rust-lang/rust/issues/151330
+
+trait Supertrait<T> {}
+
+trait Trait<P>: Supertrait {}
+//~^ ERROR missing generics for trait `Supertrait`
+//~| ERROR missing generics for trait `Supertrait`
+//~| ERROR missing generics for trait `Supertrait`
+
+impl<P> Trait<P> for () {}
+
+const fn upcast<P>(x: &dyn Trait<P>) -> &dyn Trait<P> {
+    x
+}
+
+const fn foo() -> &'static dyn Supertrait<()> {
+    upcast::<()>(&())
+}
+
+const _: &'static dyn Supertrait<()> = foo();
+
+fn main() {}

--- a/tests/ui/traits/vtable/missing-generics-issue-151330.stderr
+++ b/tests/ui/traits/vtable/missing-generics-issue-151330.stderr
@@ -1,0 +1,53 @@
+error[E0107]: missing generics for trait `Supertrait`
+  --> $DIR/missing-generics-issue-151330.rs:6:17
+   |
+LL | trait Trait<P>: Supertrait {}
+   |                 ^^^^^^^^^^ expected 1 generic argument
+   |
+note: trait defined here, with 1 generic parameter: `T`
+  --> $DIR/missing-generics-issue-151330.rs:4:7
+   |
+LL | trait Supertrait<T> {}
+   |       ^^^^^^^^^^ -
+help: add missing generic argument
+   |
+LL | trait Trait<P>: Supertrait<T> {}
+   |                           +++
+
+error[E0107]: missing generics for trait `Supertrait`
+  --> $DIR/missing-generics-issue-151330.rs:6:17
+   |
+LL | trait Trait<P>: Supertrait {}
+   |                 ^^^^^^^^^^ expected 1 generic argument
+   |
+note: trait defined here, with 1 generic parameter: `T`
+  --> $DIR/missing-generics-issue-151330.rs:4:7
+   |
+LL | trait Supertrait<T> {}
+   |       ^^^^^^^^^^ -
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing generic argument
+   |
+LL | trait Trait<P>: Supertrait<T> {}
+   |                           +++
+
+error[E0107]: missing generics for trait `Supertrait`
+  --> $DIR/missing-generics-issue-151330.rs:6:17
+   |
+LL | trait Trait<P>: Supertrait {}
+   |                 ^^^^^^^^^^ expected 1 generic argument
+   |
+note: trait defined here, with 1 generic parameter: `T`
+  --> $DIR/missing-generics-issue-151330.rs:4:7
+   |
+LL | trait Supertrait<T> {}
+   |       ^^^^^^^^^^ -
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing generic argument
+   |
+LL | trait Trait<P>: Supertrait<T> {}
+   |                           +++
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0107`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#151330