### PR TITLE
Correctly check if a macro call is actually a macro call in rustdoc highlighter

### DIFF
--- a/tests/rustdoc-html/source-code-pages/macro-call-2.rs
+++ b/tests/rustdoc-html/source-code-pages/macro-call-2.rs
@@ -1,0 +1,18 @@
+// This is yet another test to ensure that only macro calls are considered as such
+// by the rustdoc highlighter, in particular when named `macro_rules`.
+// This is a regression test for <https://github.com/rust-lang/rust/issues/151904>.
+
+#![crate_name = "foo"]
+
+//@ has src/foo/macro-call-2.rs.html
+//@ count - '//code/span[@class="macro"]' 2
+//@ has - '//code/span[@class="macro"]' 'macro_rules!'
+//@ has - '//code/span[@class="macro"]' 'r#macro_rules!'
+
+macro_rules! r#macro_rules {
+    () => {
+        fn main() {}
+    }
+}
+
+r#macro_rules!();

--- a/tests/rustdoc-html/source-code-pages/macro-call.rs
+++ b/tests/rustdoc-html/source-code-pages/macro-call.rs
@@ -1,0 +1,29 @@
+// This is yet another test to ensure that only macro calls are considered as such
+// by the rustdoc highlighter.
+// This is a regression test for <https://github.com/rust-lang/rust/issues/151904>.
+
+#![crate_name = "foo"]
+
+//@ has src/foo/macro-call.rs.html
+//@ count - '//code/span[@class="macro"]' 2
+//@ has - '//code/span[@class="macro"]' 'panic!'
+//@ has - '//code/span[@class="macro"]' 'macro_rules!'
+
+pub struct Layout;
+
+impl Layout {
+    pub fn new<X: std::fmt::Debug>() {}
+}
+
+pub fn bar() {
+    let layout = Layout::new::<u32>();
+    if layout != Layout::new::<u32>() {
+        panic!();
+    }
+    let macro_rules = 3;
+    if macro_rules != 3 {}
+}
+
+macro_rules! blob {
+    () => {}
+}


### PR DESCRIPTION
Fixes rust-lang/rust#151904.

Issues was that if there was a `!` following an ident, we would always assume it's a macro call... except it's very lacking. I'm actually surprised it went for so long unnoticed. To fix it, I added a check for the next (non-blank) token after the `!`, if it's a `{` or a `[` or a `(`, then only do we consider it to be a macro call.

r? @lolbinarycat 