### PR TITLE
Add regression test for #141738

### DIFF
--- a/tests/ui/const-generics/mgca/struct-ctor-in-array-len.rs
+++ b/tests/ui/const-generics/mgca/struct-ctor-in-array-len.rs
@@ -1,0 +1,16 @@
+// Regression test for https://github.com/rust-lang/rust/issues/141738
+//
+// Using a struct constructor as an array repeat count with
+// `min_generic_const_args` used to ICE with "unexpected `DefKind`
+// for const alias to resolve to: Ctor(Struct, Const)".
+// It should now produce a proper type error.
+
+#![feature(min_generic_const_args)]
+//~^ WARN the feature `min_generic_const_args` is incomplete
+
+struct S;
+
+fn main() {
+    let _b = [0; S];
+    //~^ ERROR the constant `S` is not of type `usize`
+}

--- a/tests/ui/const-generics/mgca/struct-ctor-in-array-len.stderr
+++ b/tests/ui/const-generics/mgca/struct-ctor-in-array-len.stderr
@@ -1,0 +1,19 @@
+warning: the feature `min_generic_const_args` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/struct-ctor-in-array-len.rs:8:12
+   |
+LL | #![feature(min_generic_const_args)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: the constant `S` is not of type `usize`
+  --> $DIR/struct-ctor-in-array-len.rs:14:14
+   |
+LL |     let _b = [0; S];
+   |              ^^^^^^ expected `usize`, found `S`
+   |
+   = note: the length of array `[{integer}; S]` must be type `usize`
+
+error: aborting due to 1 previous error; 1 warning emitted
+


### PR DESCRIPTION
Closes rust-lang/rust#141738

- Add a regression test for rust-lang/rust#141738
- Using a struct constructor (`DefKind::Ctor(Struct, Const)`) as an array repeat count with `#![feature(min_generic_const_args)]` used to ICE in const alias normalization
- Fixed by rust-lang/rust#150704, which added const constructor support for mGCA. This test covers the **error path** (struct ctor where `usize` is expected), which was not covered by the tests in rust-lang/rust#150704


