### PR TITLE
tests: adapt align-offset.rs for InstCombine improvements in LLVM 23

### DIFF
--- a/tests/assembly-llvm/align_offset.rs
+++ b/tests/assembly-llvm/align_offset.rs
@@ -4,7 +4,7 @@
 #![crate_type = "rlib"]
 
 // CHECK-LABEL: align_offset_byte_ptr
-// CHECK: leaq 31
+// CHECK: leaq {{31|28}}
 // CHECK: andq $-32
 // CHECK: subq
 #[no_mangle]
@@ -13,7 +13,7 @@ pub fn align_offset_byte_ptr(ptr: *const u8) -> usize {
 }
 
 // CHECK-LABEL: align_offset_byte_slice
-// CHECK: leaq 31
+// CHECK: leaq {{31|28}}
 // CHECK: andq $-32
 // CHECK: subq
 #[no_mangle]
@@ -22,7 +22,7 @@ pub fn align_offset_byte_slice(slice: &[u8]) -> usize {
 }
 
 // CHECK-LABEL: align_offset_word_ptr
-// CHECK: leaq 31
+// CHECK: leaq {{31|28}}
 // CHECK: andq $-32
 // CHECK: subq
 // CHECK: shrq
@@ -35,7 +35,7 @@ pub fn align_offset_word_ptr(ptr: *const u32) -> usize {
 }
 
 // CHECK-LABEL: align_offset_word_slice
-// CHECK: leaq 31
+// CHECK: leaq {{31|28}}
 // CHECK: andq $-32
 // CHECK: subq
 // CHECK: shrq

--- a/tests/codegen-llvm/align-offset.rs
+++ b/tests/codegen-llvm/align-offset.rs
@@ -24,7 +24,7 @@ pub fn align_to4(x: &[u8]) -> bool {
 #[no_mangle]
 pub fn align_offset_byte_ptr(ptr: *const u8) -> usize {
     // CHECK: %[[ADDR:.+]] = ptrtoint ptr %ptr to [[USIZE:i[0-9]+]]
-    // CHECK: %[[UP:.+]] = add [[USIZE]] %[[ADDR]], 31
+    // CHECK: %[[UP:.+]] = add [[USIZE]] %[[ADDR]], {{31|28}}
     // CHECK: %[[ALIGNED:.+]] = and [[USIZE]] %[[UP]], -32
     // CHECK: %[[OFFSET:.+]] = sub [[USIZE]] %[[ALIGNED]], %[[ADDR]]
 
@@ -41,7 +41,7 @@ pub fn align_offset_byte_ptr(ptr: *const u8) -> usize {
 #[no_mangle]
 pub fn align_offset_word_slice(slice: &[Align4]) -> usize {
     // CHECK: %[[ADDR:.+]] = ptrtoint ptr %slice.0 to [[USIZE]]
-    // CHECK: %[[UP:.+]] = add [[USIZE]] %[[ADDR]], 31
+    // CHECK: %[[UP:.+]] = add [[USIZE]] %[[ADDR]], {{31|28}}
     // CHECK: %[[ALIGNED:.+]] = and [[USIZE]] %[[UP]], -32
     // CHECK: %[[BOFFSET:.+]] = sub [[USIZE]] %[[ALIGNED]], %[[ADDR]]
     // CHECK: %[[OFFSET:.+]] = lshr exact [[USIZE]] %[[BOFFSET]], 2
@@ -57,7 +57,7 @@ pub fn align_offset_word_slice(slice: &[Align4]) -> usize {
 #[no_mangle]
 pub fn align_offset_word_ptr(ptr: *const Align4) -> usize {
     // CHECK: %[[ADDR:.+]] = ptrtoint ptr %ptr to [[USIZE]]
-    // CHECK: %[[UP:.+]] = add [[USIZE]] %[[ADDR]], 31
+    // CHECK: %[[UP:.+]] = add [[USIZE]] %[[ADDR]], {{31|28}}
     // CHECK: %[[ALIGNED:.+]] = and [[USIZE]] %[[UP]], -32
     // CHECK: %[[BOFFSET:.+]] = sub [[USIZE]] %[[ALIGNED]], %[[ADDR]]
 


### PR DESCRIPTION
Upstream [has improved InstCombine](https://github.com/llvm/llvm-project/commit/8d2078332c23b10dcf3571adc1a186e5c65f82df) so that it can shrink added constants using known zeroes, which caused a little bit of change in this test. As far as I can tell either output is fine, so we just accept both.

@rustbot label: +llvm-main
