### PR TITLE
Add a test for issue #34127

### DIFF
--- a/tests/debuginfo/huge-zst-array-debuginfo.rs
+++ b/tests/debuginfo/huge-zst-array-debuginfo.rs
@@ -1,0 +1,9 @@
+// Verify that the compiler doesn't crash when generating debug info
+// for a huge array of zero-sized types.
+// See: https://github.com/rust-lang/rust/issues/34127
+
+//@ compile-flags:-g
+
+fn main() {
+    let _a = [(); 1 << 63];
+}


### PR DESCRIPTION
The example from https://github.com/rust-lang/rust/issues/34127:
```
fn main() {
    let _a = [(); 1 << 63];
}
```

no longer crashes in codegen when compiling with debuginfo (`-g`). The issue was fixed in 1.85. Adding a test. 