### PR TITLE
Move the needs-drop check for `arena_cache` queries out of macro code

### DIFF
--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -63,7 +63,6 @@
 #![allow(unused_parens)]
 
 use std::ffi::OsStr;
-use std::mem;
 use std::path::PathBuf;
 use std::sync::Arc;
 


### PR DESCRIPTION
This is slightly simpler than before, because now the macro only needs to call a single function, and can just unconditionally supply `tcx` and a typed arena.

There should be no actual change to compiler behaviour.