### PR TITLE
Change query proc macro to be more rust-analyzer friendly

### DIFF
--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -13,6 +13,7 @@ mod keys;
 pub mod on_disk_cache;
 #[macro_use]
 pub mod plumbing;
+pub(crate) mod modifiers;
 
 pub fn describe_as_module(def_id: impl Into<LocalDefId>, tcx: TyCtxt<'_>) -> String {
     let def_id = def_id.into();

--- a/compiler/rustc_middle/src/query/modifiers.rs
+++ b/compiler/rustc_middle/src/query/modifiers.rs
@@ -1,0 +1,77 @@
+//! This contains documentation which is linked from query modifiers used in the `rustc_queries!` proc macro.
+#![allow(unused, non_camel_case_types)]
+// FIXME: Update and clarify documentation for these modifiers.
+
+/// # `desc` query modifier
+///
+/// The description of the query. This modifier is required on every query.
+pub struct desc;
+
+/// # `arena_cache` query modifier
+///
+/// Use this type for the in-memory cache.
+pub struct arena_cache;
+
+/// # `cache_on_disk_if` query modifier
+///
+/// Cache the query to disk if the `Block` returns true.
+pub struct cache_on_disk_if;
+
+/// # `cycle_fatal` query modifier
+///
+/// A cycle error for this query aborting the compilation with a fatal error.
+pub struct cycle_fatal;
+
+/// # `cycle_delay_bug` query modifier
+///
+/// A cycle error results in a delay_bug call
+pub struct cycle_delay_bug;
+
+/// # `cycle_stash` query modifier
+///
+/// A cycle error results in a stashed cycle error that can be unstashed and canceled later
+pub struct cycle_stash;
+
+/// # `no_hash` query modifier
+///
+/// Don't hash the result, instead just mark a query red if it runs
+pub struct no_hash;
+
+/// # `anon` query modifier
+///
+/// Generate a dep node based on the dependencies of the query
+pub struct anon;
+
+/// # `eval_always` query modifier
+///
+/// Always evaluate the query, ignoring its dependencies
+pub struct eval_always;
+
+/// # `depth_limit` query modifier
+///
+/// Whether the query has a call depth limit
+pub struct depth_limit;
+
+/// # `separate_provide_extern` query modifier
+///
+/// Use a separate query provider for local and extern crates
+pub struct separate_provide_extern;
+
+/// # `feedable` query modifier
+///
+/// Generate a `feed` method to set the query's value from another query.
+pub struct feedable;
+
+/// # `return_result_from_ensure_ok` query modifier
+///
+/// When this query is called via `tcx.ensure_ok()`, it returns
+/// `Result<(), ErrorGuaranteed>` instead of `()`. If the query needs to
+/// be executed, and that execution returns an error, the error result is
+/// returned to the caller.
+///
+/// If execution is skipped, a synthetic `Ok(())` is returned, on the
+/// assumption that a query with all-green inputs must have succeeded.
+///
+/// Can only be applied to queries with a return value of
+/// `Result<_, ErrorGuaranteed>`.
+pub struct return_result_from_ensure_ok;

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -462,10 +462,14 @@ macro_rules! define_callbacks {
         }
 
         pub struct Providers {
-            $(pub $name: for<'tcx> fn(
-                TyCtxt<'tcx>,
-                $name::LocalKey<'tcx>,
-            ) -> $name::ProvidedValue<'tcx>,)*
+            $(
+                /// This is the provider for the query. Use `Find references` on this to
+                /// navigate between the provider assignment and the query definition.
+                pub $name: for<'tcx> fn(
+                    TyCtxt<'tcx>,
+                    $name::LocalKey<'tcx>,
+                ) -> $name::ProvidedValue<'tcx>,
+            )*
         }
 
         pub struct ExternProviders {


### PR DESCRIPTION
This changes the query proc macro to be more rust-analyzer friendly.

- Types in the macro now have a proper span
- Some functions have their span hidden so they don't show up when hovering over the query name
- Added a hint on the provider field on how to find providers. That is shown when hovering over the query name
- Linked query name to the provider field on all queries, not just ones with caching
- Added tooltip for the query modifiers by linking to the new types in `rustc_middle:::query::modifiers`