### PR TITLE
Use `symlink_dir` to create junctions on Windows instead of trying to use symbolic links in `copy_link_internal`

### DIFF
--- a/src/bootstrap/src/core/session.rs
+++ b/src/bootstrap/src/core/session.rs
@@ -25,7 +25,8 @@ use crate::utils::build_stamp::BuildStamp;
 use crate::utils::channel::GitInfo;
 use crate::utils::exec::{BootstrapCommand, ExecutionContext, command};
 use crate::utils::helpers::{
-    self, dir_is_empty, exe, libdir, set_file_times, split_debuginfo, symlink_dir, t,
+    self, dir_is_empty, exe, is_symlink_dir, libdir, set_file_times, split_debuginfo, symlink_dir,
+    t,
 };
 use crate::{debug, trace};
 
@@ -1606,7 +1607,11 @@ impl Build {
                 metadata = t!(fs::metadata(&src), format!("target = {}", src.display()));
             } else {
                 let link = t!(fs::read_link(src));
-                t!(self.symlink_file(link, dst));
+                if is_symlink_dir(&metadata) {
+                    t!(symlink_dir(&self.config, &link, dst));
+                } else {
+                    t!(self.symlink_file(link, dst));
+                }
                 return;
             }
         }

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -1818,7 +1818,11 @@ impl Build {
                 metadata = t!(fs::metadata(&src), format!("target = {}", src.display()));
             } else {
                 let link = t!(fs::read_link(src));
-                t!(self.symlink_file(link, dst));
+                if t!(link.metadata()).is_dir() {
+                    t!(symlink_dir(&self.config, &link, dst));
+                } else {
+                    t!(self.symlink_file(link, dst));
+                }
                 return;
             }
         }

--- a/src/bootstrap/src/utils/helpers.rs
+++ b/src/bootstrap/src/utils/helpers.rs
@@ -185,6 +185,17 @@ pub fn symlink_dir(config: &Config, original: &Path, link: &Path) -> io::Result<
     }
 }
 
+/// Detects a symlink or a junction on Windows
+pub fn is_symlink_dir(_metadata: &fs::Metadata) -> bool {
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::FileTypeExt;
+        _metadata.file_type().is_symlink_dir()
+    }
+    #[cfg(not(windows))]
+    false
+}
+
 /// Return the host target on which we are currently running.
 pub fn get_host_target() -> TargetSelection {
     TargetSelection::from_user(env!("BUILD_TRIPLE"))


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/152433)*
<!-- homu-ignore:end -->

Symbolic links require extra privileges on Windows, so this falls back to creating junctions in `symlink_file` when operating on a directory.