### PR TITLE
Clarify names of `QueryVTable` functions for "executing" a query

### DIFF
--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -49,8 +49,21 @@ pub struct QueryVTable<'tcx, C: QueryCache> {
     // Offset of this query's cache field in the QueryCaches struct
     pub query_cache: usize,
     pub will_cache_on_disk_for_key_fn: Option<WillCacheOnDiskForKeyFn<'tcx, C::Key>>,
-    pub execute_query: fn(tcx: TyCtxt<'tcx>, k: C::Key) -> C::Value,
-    pub compute_fn: fn(tcx: TyCtxt<'tcx>, key: C::Key) -> C::Value,
+
+    /// Function pointer that calls `tcx.$query(key)` for this query and
+    /// discards the returned value.
+    ///
+    /// This is a weird thing to be doing, and probably not what you want.
+    /// It is used for loading query results from disk-cache in some cases.
+    pub call_query_method_fn: fn(tcx: TyCtxt<'tcx>, key: C::Key),
+
+    /// Function pointer that actually calls this query's provider.
+    /// Also performs some associated secondary tasks; see the macro-defined
+    /// implementation in `mod invoke_provider_fn` for more details.
+    ///
+    /// This should be the only code that calls the provider function.
+    pub invoke_provider_fn: fn(tcx: TyCtxt<'tcx>, key: C::Key) -> C::Value,
+
     pub try_load_from_disk_fn: Option<TryLoadFromDiskFn<'tcx, C::Key, C::Value>>,
     pub is_loadable_from_disk_fn: Option<IsLoadableFromDiskFn<'tcx, C::Key>>,
     pub hash_result: HashResult<C::Value>,

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -107,15 +107,18 @@ impl<'tcx, C: QueryCache, const FLAGS: QueryFlags> SemiDynamicQueryDispatcher<'t
         }
     }
 
-    // Don't use this method to compute query results, instead use the methods on TyCtxt.
+    /// Calls `tcx.$query(key)` for this query, and discards the returned value.
+    /// See [`QueryVTable::call_query_method_fn`] for details of this strange operation.
     #[inline(always)]
-    fn execute_query(self, tcx: TyCtxt<'tcx>, key: C::Key) -> C::Value {
-        (self.vtable.execute_query)(tcx, key)
+    fn call_query_method(self, tcx: TyCtxt<'tcx>, key: C::Key) {
+        (self.vtable.call_query_method_fn)(tcx, key)
     }
 
+    /// Calls the actual provider function for this query.
+    /// See [`QueryVTable::invoke_provider_fn`] for more details.
     #[inline(always)]
-    fn compute(self, qcx: QueryCtxt<'tcx>, key: C::Key) -> C::Value {
-        (self.vtable.compute_fn)(qcx.tcx, key)
+    fn invoke_provider(self, qcx: QueryCtxt<'tcx>, key: C::Key) -> C::Value {
+        (self.vtable.invoke_provider_fn)(qcx.tcx, key)
     }
 
     #[inline(always)]


### PR DESCRIPTION
In the query system, there are several layers of functions involved in “executing” a query, with very different responsibilities at each layer, making it important to be able to tell them apart.

This PR renames two of the function pointers in `QueryVTable`, along with their associated helper functions, to hopefully do a better job of indicating what their actual responsibilities are.

r? nnethercote