### PR TITLE
Store query modifier `eval_always` in compile-time `QueryFlags`

### DIFF
--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -40,7 +40,6 @@ pub type HashResult<V> = Option<fn(&mut StableHashingContext<'_>, &V) -> Fingerp
 /// and also used directly by query plumbing in `rustc_query_impl`.
 pub struct QueryVTable<'tcx, C: QueryCache> {
     pub name: &'static str,
-    pub eval_always: bool,
     pub dep_kind: DepKind,
     /// How this query deals with query cycle errors.
     pub cycle_error_handling: CycleErrorHandling,

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -45,6 +45,8 @@ struct QueryFlags {
     is_anon: bool,
     /// True if this query has the `depth_limit` modifier.
     is_depth_limit: bool,
+    /// True if this query has the `is_eval_always` modifier.
+    is_eval_always: bool,
     /// True if this query has the `feedable` modifier.
     is_feedable: bool,
 }
@@ -162,7 +164,7 @@ impl<'tcx, C: QueryCache, const FLAGS: QueryFlags> SemiDynamicQueryDispatcher<'t
 
     #[inline(always)]
     fn eval_always(self) -> bool {
-        self.vtable.eval_always
+        FLAGS.is_eval_always
     }
 
     #[inline(always)]

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -513,13 +513,13 @@ pub(crate) fn make_dep_kind_vtable_for_query<
     Q,
     C: QueryCache + 'tcx,
     const FLAGS: QueryFlags,
->(
-    is_eval_always: bool,
-) -> DepKindVTable<'tcx>
+>() -> DepKindVTable<'tcx>
 where
     Q: QueryDispatcherUnerased<'tcx, C, FLAGS>,
 {
     let is_anon = FLAGS.is_anon;
+    let is_eval_always = FLAGS.is_eval_always;
+
     let fingerprint_style = if is_anon {
         FingerprintStyle::Opaque
     } else {
@@ -662,7 +662,6 @@ macro_rules! define_queries {
             {
                 QueryVTable {
                     name: stringify!($name),
-                    eval_always: is_eval_always!([$($modifiers)*]),
                     dep_kind: dep_graph::dep_kinds::$name,
                     cycle_error_handling: cycle_error_handling!([$($modifiers)*]),
                     query_state: std::mem::offset_of!(QueryStates<'tcx>, $name),
@@ -716,6 +715,7 @@ macro_rules! define_queries {
             const FLAGS: QueryFlags = QueryFlags {
                 is_anon: is_anon!([$($modifiers)*]),
                 is_depth_limit: depth_limit!([$($modifiers)*]),
+                is_eval_always: is_eval_always!([$($modifiers)*]),
                 is_feedable: feedable!([$($modifiers)*]),
             };
 
@@ -970,9 +970,7 @@ macro_rules! define_queries {
 
             $(pub(crate) fn $name<'tcx>() -> DepKindVTable<'tcx> {
                 use $crate::query_impl::$name::QueryType;
-                $crate::plumbing::make_dep_kind_vtable_for_query::<QueryType<'tcx>, _, _>(
-                    is_eval_always!([$($modifiers)*]),
-                )
+                $crate::plumbing::make_dep_kind_vtable_for_query::<QueryType<'tcx>, _, _>()
             })*
         }
 


### PR DESCRIPTION
This should be a perf win, but I don't know what effect it will have on bootstrap times.