### PR TITLE
Reenable a GCI+mGCA+GCPT test case

### DIFF
--- a/tests/ui/generic-const-items/assoc-const-bindings.rs
+++ b/tests/ui/generic-const-items/assoc-const-bindings.rs
@@ -1,35 +1,33 @@
 //@ check-pass
 
 #![feature(generic_const_items, min_generic_const_args)]
-#![feature(adt_const_params)]
-#![allow(incomplete_features)]
+#![feature(adt_const_params, unsized_const_params, generic_const_parameter_types)]
+#![expect(incomplete_features)]
+
+use std::marker::{ConstParamTy, ConstParamTy_};
 
 trait Owner {
     type const C<const N: u32>: u32;
     type const K<const N: u32>: u32;
-    // #[type_const]
-    // const Q<T>: Maybe<T>;
+    type const Q<T: ConstParamTy_>: Maybe<T>;
 }
 
 impl Owner for () {
     type const C<const N: u32>: u32 = N;
     type const K<const N: u32>: u32 = const { 99 + 1 };
-    // FIXME(mgca): re-enable once we properly support ctors and generics on paths
-    // #[type_const]
-    // const Q<T>: Maybe<T> = Maybe::Nothing;
+    type const Q<T: ConstParamTy_>: Maybe<T> = Maybe::Nothing::<T>;
 }
 
 fn take0<const N: u32>(_: impl Owner<C<N> = { N }>) {}
 fn take1(_: impl Owner<K<99> = 100>) {}
-// FIXME(mgca): re-enable once we properly support ctors and generics on paths
-// fn take2(_: impl Owner<Q<()> = { Maybe::Just(()) }>) {}
+fn take2(_: impl Owner<Q<()> = { Maybe::Just::<()>(()) }>) {}
 
 fn main() {
     take0::<128>(());
     take1(());
 }
 
-#[derive(PartialEq, Eq, std::marker::ConstParamTy)]
+#[derive(PartialEq, Eq, ConstParamTy)]
 enum Maybe<T> {
     Nothing,
     Just(T),


### PR DESCRIPTION
The GCI+mGCA+GCPT test case can now be made to work with the necessary features and tweaks.