### PR TITLE
Fix typos and grammar in library documentation

### DIFF
--- a/library/core/src/error.md
+++ b/library/core/src/error.md
@@ -34,7 +34,7 @@ responsibilities they cover:
 
 ## Converting Errors into Panics
 
-The panic and error systems are not entirely distinct. Often times errors
+The panic and error systems are not entirely distinct. Oftentimes errors
 that are anticipated runtime failures in an API might instead represent bugs
 to a caller. For these situations the standard library provides APIs for
 constructing panics with an `Error` as its source.

--- a/library/core/src/ffi/c_ulong.md
+++ b/library/core/src/ffi/c_ulong.md
@@ -1,5 +1,5 @@
 Equivalent to C's `unsigned long` type.
 
-This type will always be [`u32`] or [`u64`]. Most notably, many Linux-based systems assume an `u64`, but Windows assumes `u32`. The C standard technically only requires that this type be an unsigned integer with the size of a [`long`], although in practice, no system would have a `ulong` that is neither a `u32` nor `u64`.
+This type will always be [`u32`] or [`u64`]. Most notably, many Linux-based systems assume a `u64`, but Windows assumes `u32`. The C standard technically only requires that this type be an unsigned integer with the size of a [`long`], although in practice, no system would have a `ulong` that is neither a `u32` nor `u64`.
 
 [`long`]: c_long

--- a/library/core/src/ffi/c_void.md
+++ b/library/core/src/ffi/c_void.md
@@ -9,7 +9,7 @@ stabilized, it is recommended to use a newtype wrapper around an empty
 byte array. See the [Nomicon] for details.
 
 One could use `std::os::raw::c_void` if they want to support old Rust
-compiler down to 1.1.0. After Rust 1.30.0, it was re-exported by
+compilers down to 1.1.0. After Rust 1.30.0, it was re-exported by
 this definition. For more information, please read [RFC 2521].
 
 [Nomicon]: https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs

--- a/library/core/src/macros/panic.md
+++ b/library/core/src/macros/panic.md
@@ -19,7 +19,7 @@ call. You can override the panic hook using [`std::panic::set_hook()`].
 Inside the hook a panic can be accessed as a `&dyn Any + Send`,
 which contains either a `&str` or `String` for regular `panic!()` invocations.
 (Whether a particular invocation contains the payload at type `&str` or `String` is unspecified and can change.)
-To panic with a value of another other type, [`panic_any`] can be used.
+To panic with a value of another type, [`panic_any`] can be used.
 
 See also the macro [`compile_error!`], for raising errors during compilation.
 

--- a/library/core/src/ptr/docs/as_ref.md
+++ b/library/core/src/ptr/docs/as_ref.md
@@ -16,4 +16,4 @@ determined to be null or not. See [`is_null`] for more information.
 # Null-unchecked version
 
 If you are sure the pointer can never be null, you can use `as_ref_unchecked` which returns
-`&mut T` instead of `Option<&mut T>`.
+`&T` instead of `Option<&T>`.

--- a/library/core/src/ptr/docs/as_uninit_slice.md
+++ b/library/core/src/ptr/docs/as_uninit_slice.md
@@ -7,7 +7,7 @@ that the value has to be initialized.
 # Safety
 
 When calling this method, you have to ensure that *either* the pointer is null *or*
-all of the following is true:
+all of the following are true:
 
 * The pointer must be [valid] for reads for `ptr.len() * size_of::<T>()` many bytes,
   and it must be properly aligned. This means in particular:

--- a/library/std_detect/README.md
+++ b/library/std_detect/README.md
@@ -25,7 +25,7 @@ regard to better serve the needs of `#[no_std]` targets.
 
 * All `x86`/`x86_64` targets are supported on all platforms by querying the
   `cpuid` instruction directly for the features supported by the hardware and
-  the operating system. `std_detect` assumes that the binary is an user-space
+  the operating system. `std_detect` assumes that the binary is a user-space
   application.
 
 * Linux/Android:


### PR DESCRIPTION
Fix contextual typos and grammar issues in library docs that automated spellcheckers miss:

- `library/core/src/macros/panic.md`: remove duplicate word ("another other" → "another")
- `library/core/src/error.md`: fix spacing ("Often times" → "Oftentimes")
- `library/core/src/ptr/docs/as_ref.md`: fix wrong types in Null-unchecked section (`&mut T` → `&T`)
- `library/core/src/ffi/c_ulong.md`: fix article ("an `u64`" → "a `u64`")
- `library/core/src/ffi/c_void.md`: fix plural ("compiler" → "compilers")
- `library/core/src/ptr/docs/as_uninit_slice.md`: fix subject-verb agreement ("is true" → "are true")
- `library/std_detect/README.md`: fix article ("an user-space" → "a user-space")

No functional changes.