### PR TITLE
Fix typos and grammar in top-level and src/doc documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ the Zulip stream is the best place to *ask* for help.
 
 Documentation for contributing to the compiler or tooling is located in the [Guide to Rustc
 Development][rustc-dev-guide], commonly known as the [rustc-dev-guide]. Documentation for the
-standard library in the [Standard library developers Guide][std-dev-guide], commonly known as the [std-dev-guide].
+standard library is in the [Standard library developers Guide][std-dev-guide], commonly known as the [std-dev-guide].
 
 ## Making changes to subtrees and submodules
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -233,7 +233,7 @@ itself back on after some time).
 
 ### MSVC
 
-MSVC builds of Rust additionally requires an installation of:
+MSVC builds of Rust additionally require an installation of:
 
 - Visual Studio 2022 (or later) build tools so `rustc` can use its linker. Older
   Visual Studio versions such as 2019 *may* work but aren't actively tested.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1546,7 +1546,7 @@ Compatibility Notes
 - [Check well-formedness of the source type's signature in fn pointer casts.](https://github.com/rust-lang/rust/pull/129021) This partly closes a soundness hole that comes when casting a function item to function pointer
 - [Use equality instead of subtyping when resolving type dependent paths.](https://github.com/rust-lang/rust/pull/129073)
 - Linking on macOS now correctly includes Rust's default deployment target. Due to a linker bug, you might have to pass `MACOSX_DEPLOYMENT_TARGET` or fix your `#[link]` attributes to point to the correct frameworks. See <https://github.com/rust-lang/rust/pull/129369>.
-- [Rust will now correctly raise an error for `repr(Rust)` written on non-`struct`/`enum`/`union` items, since it previous did not have any effect.](https://github.com/rust-lang/rust/pull/129422)
+- [Rust will now correctly raise an error for `repr(Rust)` written on non-`struct`/`enum`/`union` items, since it previously did not have any effect.](https://github.com/rust-lang/rust/pull/129422)
 - The future incompatibility lint `deprecated_cfg_attr_crate_type_name` [has been made into a hard error](https://github.com/rust-lang/rust/pull/129670). It was used to deny usage of `#![crate_type]` and `#![crate_name]` attributes in `#![cfg_attr]`, which required a hack in the compiler to be able to change the used crate type and crate name after cfg expansion.
   Users can use `--crate-type` instead of `#![cfg_attr(..., crate_type = "...")]` and `--crate-name` instead of `#![cfg_attr(..., crate_name = "...")]` when running `rustc`/`cargo rustc` on the command line.
   Use of those two attributes outside of `#![cfg_attr]` continue to be fully supported.
@@ -1722,7 +1722,7 @@ Cargo
 Compatibility Notes
 -------------------
  - We now [disallow setting some built-in cfgs via the command-line](https://github.com/rust-lang/rust/pull/126158) with the newly added [`explicit_builtin_cfgs_in_flags`](https://doc.rust-lang.org/rustc/lints/listing/deny-by-default.html#explicit-builtin-cfgs-in-flags) lint in order to prevent incoherent state, eg. `windows` cfg active but target is Linux based. The appropriate [`rustc` flag](https://doc.rust-lang.org/rustc/command-line-arguments.html) should be used instead.
-- The standard library has a new implementation of `binary_search` which is significantly improves performance ([#128254](https://github.com/rust-lang/rust/pull/128254)). However when a sorted slice has multiple values which compare equal, the new implementation may select a different value among the equal ones than the old implementation.
+- The standard library has a new implementation of `binary_search` which significantly improves performance ([#128254](https://github.com/rust-lang/rust/pull/128254)). However when a sorted slice has multiple values which compare equal, the new implementation may select a different value among the equal ones than the old implementation.
 - [illumos/Solaris now sets `MSG_NOSIGNAL` when writing to sockets](https://github.com/rust-lang/rust/pull/128259). This avoids killing the process with SIGPIPE when writing to a closed socket, which matches the existing behavior on other UNIX targets.
 - [Removes a problematic hack that always passed the --whole-archive linker flag for tests, which may cause linker errors for code accidentally relying on it.](https://github.com/rust-lang/rust/pull/128400)
 - The WebAssembly target features `multivalue` and `reference-types` are now
@@ -1872,7 +1872,7 @@ These changes do not affect any public interfaces of Rust, but they represent
 significant improvements to the performance or internals of rustc and related
 tools.
 
-- [Add a Rust-for Linux `auto` CI job to check kernel builds.](https://github.com/rust-lang/rust/pull/125209/)
+- [Add a Rust-for-Linux `auto` CI job to check kernel builds.](https://github.com/rust-lang/rust/pull/125209/)
 
 Version 1.80.1 (2024-08-08)
 ===========================
@@ -4510,7 +4510,7 @@ Compatibility Notes
   saturating to `0` instead][89926]. In the real world the panic happened mostly
   on platforms with buggy monotonic clock implementations rather than catching
   programming errors like reversing the start and end times. Such programming
-  errors will now results in `0` rather than a panic.
+  errors will now result in `0` rather than a panic.
 - In a future release we're planning to increase the baseline requirements for
   the Linux kernel to version 3.2, and for glibc to version 2.17. We'd love
   your feedback in [PR #95026][95026].

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -194,9 +194,8 @@ resources maintained by the [Embedded Working Group] useful.
 
 #### The Embedded Rust Book
 
-[The Embedded Rust Book] is targeted at developers familiar with embedded
-development and familiar with Rust, but have not used Rust for embedded
-development.
+[The Embedded Rust Book] is targeted at developers who are familiar with embedded
+development and Rust, but who have not used Rust for embedded development.
 
 [The Embedded Rust Book]: embedded-book/index.html
 [Rust project]: https://www.rust-lang.org

--- a/src/doc/not_found.md
+++ b/src/doc/not_found.md
@@ -41,7 +41,7 @@ Some things that might be helpful to you though:
     <input type="submit" value="Search" id="search-but">
     <!--
       Don't show the options by default,
-      since "From the Standary Library" doesn't work without JavaScript
+      since "From the Standard Library" doesn't work without JavaScript
     -->
     <fieldset id="search-from" style="display:none">
       <label><input name="from" value="library" type="radio"> From the Standard Library</label>


### PR DESCRIPTION
Fix contextual typos and grammar issues in top-level and src/doc documentation that automated spellcheckers miss:

- `CONTRIBUTING.md`: add missing verb "is"
- `INSTALL.md`: fix subject-verb agreement ("requires" → "require")
- `RELEASES.md`: fix 4 issues (previous → previously, remove extra "is", add hyphen in Rust-for-Linux, results → result)
- `src/doc/not_found.md`: fix misspelling ("Standary" → "Standard")
- `src/doc/index.md`: fix awkward grammar in Embedded Rust Book description

No functional changes.