### PR TITLE
`-Znext-solver` Prevent committing unfulfilled unsized coercion

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
+++ b/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
@@ -443,9 +443,10 @@ impl<'a, 'tcx> InspectGoal<'a, 'tcx> {
     pub(crate) fn visit_with<V: ProofTreeVisitor<'tcx>>(&self, visitor: &mut V) -> V::Result {
         if self.depth < visitor.config().max_depth {
             try_visit!(visitor.visit_goal(self));
+            V::Result::output()
+        } else {
+            visitor.on_recursion_limit()
         }
-
-        V::Result::output()
     }
 }
 
@@ -460,6 +461,10 @@ pub trait ProofTreeVisitor<'tcx> {
     }
 
     fn visit_goal(&mut self, goal: &InspectGoal<'_, 'tcx>) -> Self::Result;
+
+    fn on_recursion_limit(&mut self) -> Self::Result {
+        Self::Result::output()
+    }
 }
 
 #[extension(pub trait InferCtxtProofTreeExt<'tcx>)]

--- a/tests/ui/traits/next-solver/coercion/unfulfilled-unsize-coercion-recursion-limit.rs
+++ b/tests/ui/traits/next-solver/coercion/unfulfilled-unsize-coercion-recursion-limit.rs
@@ -1,0 +1,35 @@
+//@ check-pass
+//@ compile-flags: -Znext-solver
+
+// A regression test for https://github.com/rust-lang/trait-system-refactor-initiative/issues/266.
+// Ensure that we do not accidentaly trying unfulfilled unsized coercions due to hitting recursion
+// limits while trying to find the right fulfillment error source.
+
+fn argument_coercion<U>(_: &U) {}
+
+pub fn test() {
+    argument_coercion(&{
+        Nested(0.0, 0.0)
+            .add(0.0)
+            .add(0.0)
+            .add(0.0)
+            .add(0.0)
+            .add(0.0)
+            .add(0.0)
+            .add(0.0)
+            .add(0.0)
+            .add(0.0)
+            .add(0.0)
+            .add(0.0)
+    });
+}
+
+struct Nested<T, R>(T, R);
+
+impl<T, R> Nested<T, R> {
+    fn add<U>(self, value: U) -> Nested<U, Nested<T, R>> {
+        Nested(value, self)
+    }
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/coercion/unsize-coercion-recursion-limit.rs
+++ b/tests/ui/traits/next-solver/coercion/unsize-coercion-recursion-limit.rs
@@ -1,0 +1,25 @@
+//@ check-pass
+//@ compile-flags: -Znext-solver
+
+// A test to ensure that unsized coercion is not aborted when visiting a nested goal that
+// exceeds the recursion limit and evaluates to `Certainty::Maybe`.
+// See https://github.com/rust-lang/rust/pull/152444.
+
+#![allow(warnings)]
+
+struct W<T: ?Sized>(T);
+type Four<T: ?Sized> = W<W<W<W<T>>>>;
+type Sixteen<T: ?Sized> = Four<Four<Four<Four<T>>>>;
+
+fn ret<T>(x: T) -> Sixteen<T> {
+    todo!();
+}
+
+fn please_coerce() {
+    let mut y = Default::default();
+    let x = ret(y);
+    let _: &Sixteen<dyn Send> = &x;
+    y = 1u32;
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/trait-system-refactor-initiative/issues/266

r? lcnr