### PR TITLE
Fix potential panics in Drop implementations in rustc_errors::lock

### DIFF
--- a/compiler/rustc_errors/src/lock.rs
+++ b/compiler/rustc_errors/src/lock.rs
@@ -27,8 +27,10 @@ pub(crate) fn acquire_global_lock(name: &str) -> Box<dyn Any> {
     impl Drop for Handle {
         fn drop(&mut self) {
             unsafe {
-                // FIXME can panic here
-                CloseHandle(self.0).unwrap();
+                // Ignore errors during drop to avoid panicking in a destructor.
+                // If CloseHandle fails, the handle will be leaked, but this is
+                // preferable to aborting the process.
+                let _ = CloseHandle(self.0);
             }
         }
     }
@@ -38,8 +40,10 @@ pub(crate) fn acquire_global_lock(name: &str) -> Box<dyn Any> {
     impl Drop for Guard {
         fn drop(&mut self) {
             unsafe {
-                // FIXME can panic here
-                ReleaseMutex((self.0).0).unwrap();
+                // Ignore errors during drop to avoid panicking in a destructor.
+                // If ReleaseMutex fails, the mutex will remain locked, but this is
+                // preferable to aborting the process.
+                let _ = ReleaseMutex((self.0).0);
             }
         }
     }


### PR DESCRIPTION
Replace .unwrap() calls with error ignoring in Drop implementations for Handle and Guard structs to prevent panicking in destructors.

Panicking in Drop can lead to process abortion if it occurs during stack unwinding. This change makes the code more robust by ignoring errors from CloseHandle and ReleaseMutex during cleanup.

Fixes the FIXME comments about potential panics in drop handlers.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
