### PR TITLE
rustdoc: properly support macros with multiple kinds

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -802,7 +802,7 @@ fn build_macro(
                         source: utils::display_macro_source(tcx, name, &def),
                         macro_rules: def.macro_rules,
                     },
-                    None,
+                    MacroKinds::BANG,
                 ),
                 None,
             ),
@@ -826,7 +826,7 @@ fn build_macro(
                         source: utils::display_macro_source(cx, name, &def),
                         macro_rules: def.macro_rules,
                     },
-                    Some(macro_kinds),
+                    macro_kinds,
                 );
                 let mut ret = vec![];
                 for kind in macro_kinds.iter().filter(|kind| *kind != MacroKinds::BANG) {

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -139,13 +139,12 @@ pub(crate) fn try_inline(
         Res::Def(DefKind::Macro(kinds), did) => {
             let mac = build_macro(cx.tcx, did, name, kinds);
 
-            // FIXME: handle attributes and derives that aren't proc macros, and macros with
-            // multiple kinds
             let type_kind = match kinds {
                 MacroKinds::BANG => ItemType::Macro,
                 MacroKinds::ATTR => ItemType::ProcAttribute,
                 MacroKinds::DERIVE => ItemType::ProcDerive,
-                _ => todo!("Handle macros with multiple kinds"),
+                _ if kinds.contains(MacroKinds::BANG) => ItemType::Macro,
+                _ => panic!("unsupported macro kind {kinds:?}"),
             };
             record_extern_fqn(cx, did, type_kind);
             mac
@@ -777,13 +776,14 @@ fn build_macro(
     macro_kinds: MacroKinds,
 ) -> clean::ItemKind {
     match CStore::from_tcx(tcx).load_macro_untracked(tcx, def_id) {
-        // FIXME: handle attributes and derives that aren't proc macros, and macros with multiple
-        // kinds
         LoadedMacro::MacroDef { def, .. } => match macro_kinds {
-            MacroKinds::BANG => clean::MacroItem(clean::Macro {
-                source: utils::display_macro_source(tcx, name, &def),
-                macro_rules: def.macro_rules,
-            }),
+            MacroKinds::BANG => clean::MacroItem(
+                clean::Macro {
+                    source: utils::display_macro_source(tcx, name, &def),
+                    macro_rules: def.macro_rules,
+                },
+                None,
+            ),
             MacroKinds::DERIVE => clean::ProcMacroItem(clean::ProcMacro {
                 kind: MacroKind::Derive,
                 helpers: Vec::new(),
@@ -792,7 +792,14 @@ fn build_macro(
                 kind: MacroKind::Attr,
                 helpers: Vec::new(),
             }),
-            _ => todo!("Handle macros with multiple kinds"),
+            _ if macro_kinds == (MacroKinds::BANG | MacroKinds::ATTR) => clean::MacroItem(
+                clean::Macro {
+                    source: utils::display_macro_source(tcx, name, &def),
+                    macro_rules: def.macro_rules,
+                },
+                Some(macro_kinds),
+            ),
+            _ => panic!("unsupported macro kind {macro_kinds:?}"),
         },
         LoadedMacro::ProcMacro(ext) => {
             // Proc macros can only have a single kind

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -158,7 +158,7 @@ pub(crate) fn try_inline(
             })
         }
         Res::Def(DefKind::Macro(kinds), did) => {
-            let (mac, others) = build_macro(cx.tcx, did, name, kinds);
+            let mac = build_macro(cx.tcx, did, name, kinds);
 
             let type_kind = match kinds {
                 MacroKinds::BANG => ItemType::Macro,
@@ -168,15 +168,7 @@ pub(crate) fn try_inline(
                 _ => ItemType::Macro,
             };
             record_extern_fqn(cx, did, type_kind);
-            let first = try_inline_inner(cx, mac, did, name, import_def_id);
-            if let Some(others) = others {
-                for mac_kind in others {
-                    let mut mac = first.clone();
-                    mac.inner.kind = mac_kind;
-                    ret.push(mac);
-                }
-            }
-            ret.push(first);
+            ret.push(try_inline_inner(cx, mac, did, name, import_def_id));
             return Some(ret);
         }
         _ => return None,
@@ -793,52 +785,24 @@ fn build_macro(
     def_id: DefId,
     name: Symbol,
     macro_kinds: MacroKinds,
-) -> (clean::ItemKind, Option<Vec<clean::ItemKind>>) {
+) -> clean::ItemKind {
     match CStore::from_tcx(tcx).load_macro_untracked(tcx, def_id) {
         LoadedMacro::MacroDef { def, .. } => match macro_kinds {
-            MacroKinds::BANG => (
-                clean::MacroItem(
-                    clean::Macro {
-                        source: utils::display_macro_source(tcx, name, &def),
-                        macro_rules: def.macro_rules,
-                    },
-                    MacroKinds::BANG,
-                ),
-                None,
+            MacroKinds::DERIVE => clean::ProcMacroItem(clean::ProcMacro {
+                kind: MacroKind::Derive,
+                helpers: Vec::new(),
+            }),
+            MacroKinds::ATTR => clean::ProcMacroItem(clean::ProcMacro {
+                kind: MacroKind::Attr,
+                helpers: Vec::new(),
+            }),
+            _ => clean::MacroItem(
+                clean::Macro {
+                    source: utils::display_macro_source(tcx, name, &def),
+                    macro_rules: def.macro_rules,
+                },
+                macro_kinds,
             ),
-            MacroKinds::DERIVE => (
-                clean::ProcMacroItem(clean::ProcMacro {
-                    kind: MacroKind::Derive,
-                    helpers: Vec::new(),
-                }),
-                None,
-            ),
-            MacroKinds::ATTR => (
-                clean::ProcMacroItem(clean::ProcMacro {
-                    kind: MacroKind::Attr,
-                    helpers: Vec::new(),
-                }),
-                None,
-            ),
-            _ => {
-                let mut kinds = Vec::new();
-                kinds.push(clean::MacroItem(
-                    clean::Macro {
-                        source: utils::display_macro_source(tcx, name, &def),
-                        macro_rules: def.macro_rules,
-                    },
-                    macro_kinds,
-                ));
-                for kind in macro_kinds.iter().filter(|kind| *kind != MacroKinds::BANG) {
-                    match kind {
-                        MacroKinds::ATTR => kinds.push(clean::AttrMacroItem),
-                        MacroKinds::DERIVE => kinds.push(clean::DeriveMacroItem),
-                        _ => panic!("unsupported macro kind {kind:?}"),
-                    }
-                }
-                let kind = kinds.pop().expect("no supported macro kind found");
-                (kind, Some(kinds))
-            }
         },
         LoadedMacro::ProcMacro(ext) => {
             // Proc macros can only have a single kind
@@ -848,7 +812,7 @@ fn build_macro(
                 MacroKinds::DERIVE => MacroKind::Derive,
                 _ => unreachable!(),
             };
-            (clean::ProcMacroItem(clean::ProcMacro { kind, helpers: ext.helper_attrs }), None)
+            clean::ProcMacroItem(clean::ProcMacro { kind, helpers: ext.helper_attrs })
         }
     }
 }

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -164,8 +164,8 @@ pub(crate) fn try_inline(
                 MacroKinds::BANG => ItemType::Macro,
                 MacroKinds::ATTR => ItemType::ProcAttribute,
                 MacroKinds::DERIVE => ItemType::ProcDerive,
-                _ if kinds.contains(MacroKinds::BANG) => ItemType::Macro,
-                _ => panic!("unsupported macro kind {kinds:?}"),
+                // Then it means it's more than one type so we default to "macro".
+                _ => ItemType::Macro,
             };
             record_extern_fqn(cx, did, type_kind);
             let first = try_inline_inner(cx, mac, did, name, import_def_id);
@@ -820,25 +820,25 @@ fn build_macro(
                 }),
                 None,
             ),
-            _ if macro_kinds.contains(MacroKinds::BANG) => {
-                let kind = clean::MacroItem(
+            _ => {
+                let mut kinds = Vec::new();
+                kinds.push(clean::MacroItem(
                     clean::Macro {
-                        source: utils::display_macro_source(cx, name, &def),
+                        source: utils::display_macro_source(tcx, name, &def),
                         macro_rules: def.macro_rules,
                     },
                     macro_kinds,
-                );
-                let mut ret = vec![];
+                ));
                 for kind in macro_kinds.iter().filter(|kind| *kind != MacroKinds::BANG) {
                     match kind {
-                        MacroKinds::ATTR => ret.push(clean::AttrMacroItem),
-                        MacroKinds::DERIVE => ret.push(clean::DeriveMacroItem),
+                        MacroKinds::ATTR => kinds.push(clean::AttrMacroItem),
+                        MacroKinds::DERIVE => kinds.push(clean::DeriveMacroItem),
                         _ => panic!("unsupported macro kind {kind:?}"),
                     }
                 }
-                (kind, Some(ret))
+                let kind = kinds.pop().expect("no supported macro kind found");
+                (kind, Some(kinds))
             }
-            _ => panic!("unsupported macro kind {macro_kinds:?}"),
         },
         LoadedMacro::ProcMacro(ext) => {
             // Proc macros can only have a single kind

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -45,6 +45,27 @@ pub(crate) fn try_inline(
     attrs: Option<(&[hir::Attribute], Option<LocalDefId>)>,
     visited: &mut DefIdSet,
 ) -> Option<Vec<clean::Item>> {
+    fn try_inline_inner(
+        cx: &mut DocContext<'_>,
+        kind: clean::ItemKind,
+        did: DefId,
+        name: Symbol,
+        import_def_id: Option<LocalDefId>,
+    ) -> clean::Item {
+        cx.inlined.insert(did.into());
+        let mut item = crate::clean::generate_item_with_correct_attrs(
+            cx,
+            kind,
+            did,
+            name,
+            import_def_id.as_slice(),
+            None,
+        );
+        // The visibility needs to reflect the one from the reexport and not from the "source" DefId.
+        item.inner.inline_stmt_id = import_def_id;
+        item
+    }
+
     let did = res.opt_def_id()?;
     if did.is_local() {
         return None;
@@ -137,7 +158,7 @@ pub(crate) fn try_inline(
             })
         }
         Res::Def(DefKind::Macro(kinds), did) => {
-            let mac = build_macro(cx.tcx, did, name, kinds);
+            let (mac, others) = build_macro(cx.tcx, did, name, kinds);
 
             let type_kind = match kinds {
                 MacroKinds::BANG => ItemType::Macro,
@@ -147,23 +168,21 @@ pub(crate) fn try_inline(
                 _ => panic!("unsupported macro kind {kinds:?}"),
             };
             record_extern_fqn(cx, did, type_kind);
-            mac
+            let first = try_inline_inner(cx, mac, did, name, import_def_id);
+            if let Some(others) = others {
+                for mac_kind in others {
+                    let mut mac = first.clone();
+                    mac.inner.kind = mac_kind;
+                    ret.push(mac);
+                }
+            }
+            ret.push(first);
+            return Some(ret);
         }
         _ => return None,
     };
 
-    cx.inlined.insert(did.into());
-    let mut item = crate::clean::generate_item_with_correct_attrs(
-        cx,
-        kind,
-        did,
-        name,
-        import_def_id.as_slice(),
-        None,
-    );
-    // The visibility needs to reflect the one from the reexport and not from the "source" DefId.
-    item.inner.inline_stmt_id = import_def_id;
-    ret.push(item);
+    ret.push(try_inline_inner(cx, kind, did, name, import_def_id));
     Some(ret)
 }
 
@@ -774,31 +793,51 @@ fn build_macro(
     def_id: DefId,
     name: Symbol,
     macro_kinds: MacroKinds,
-) -> clean::ItemKind {
+) -> (clean::ItemKind, Option<Vec<clean::ItemKind>>) {
     match CStore::from_tcx(tcx).load_macro_untracked(tcx, def_id) {
         LoadedMacro::MacroDef { def, .. } => match macro_kinds {
-            MacroKinds::BANG => clean::MacroItem(
-                clean::Macro {
-                    source: utils::display_macro_source(tcx, name, &def),
-                    macro_rules: def.macro_rules,
-                },
+            MacroKinds::BANG => (
+                clean::MacroItem(
+                    clean::Macro {
+                        source: utils::display_macro_source(tcx, name, &def),
+                        macro_rules: def.macro_rules,
+                    },
+                    None,
+                ),
                 None,
             ),
-            MacroKinds::DERIVE => clean::ProcMacroItem(clean::ProcMacro {
-                kind: MacroKind::Derive,
-                helpers: Vec::new(),
-            }),
-            MacroKinds::ATTR => clean::ProcMacroItem(clean::ProcMacro {
-                kind: MacroKind::Attr,
-                helpers: Vec::new(),
-            }),
-            _ if macro_kinds == (MacroKinds::BANG | MacroKinds::ATTR) => clean::MacroItem(
-                clean::Macro {
-                    source: utils::display_macro_source(tcx, name, &def),
-                    macro_rules: def.macro_rules,
-                },
-                Some(macro_kinds),
+            MacroKinds::DERIVE => (
+                clean::ProcMacroItem(clean::ProcMacro {
+                    kind: MacroKind::Derive,
+                    helpers: Vec::new(),
+                }),
+                None,
             ),
+            MacroKinds::ATTR => (
+                clean::ProcMacroItem(clean::ProcMacro {
+                    kind: MacroKind::Attr,
+                    helpers: Vec::new(),
+                }),
+                None,
+            ),
+            _ if macro_kinds.contains(MacroKinds::BANG) => {
+                let kind = clean::MacroItem(
+                    clean::Macro {
+                        source: utils::display_macro_source(cx, name, &def),
+                        macro_rules: def.macro_rules,
+                    },
+                    Some(macro_kinds),
+                );
+                let mut ret = vec![];
+                for kind in macro_kinds.iter().filter(|kind| *kind != MacroKinds::BANG) {
+                    match kind {
+                        MacroKinds::ATTR => ret.push(clean::AttrMacroItem),
+                        MacroKinds::DERIVE => ret.push(clean::DeriveMacroItem),
+                        _ => panic!("unsupported macro kind {kind:?}"),
+                    }
+                }
+                (kind, Some(ret))
+            }
             _ => panic!("unsupported macro kind {macro_kinds:?}"),
         },
         LoadedMacro::ProcMacro(ext) => {
@@ -809,7 +848,7 @@ fn build_macro(
                 MacroKinds::DERIVE => MacroKind::Derive,
                 _ => unreachable!(),
             };
-            clean::ProcMacroItem(clean::ProcMacro { kind, helpers: ext.helper_attrs })
+            (clean::ProcMacroItem(clean::ProcMacro { kind, helpers: ext.helper_attrs }), None)
         }
     }
 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2940,7 +2940,7 @@ fn clean_maybe_renamed_item<'tcx>(
                         source: display_macro_source(cx.tcx, name, macro_def),
                         macro_rules: macro_def.macro_rules,
                     },
-                    None,
+                    MacroKinds::BANG,
                 ),
                 MacroKinds::ATTR => clean_proc_macro(item, &mut name, MacroKind::Attr, cx.tcx),
                 MacroKinds::DERIVE => clean_proc_macro(item, &mut name, MacroKind::Derive, cx.tcx),
@@ -2950,7 +2950,7 @@ fn clean_maybe_renamed_item<'tcx>(
                             source: display_macro_source(cx.tcx, name, macro_def),
                             macro_rules: macro_def.macro_rules,
                         },
-                        Some(kinds),
+                        kinds,
                     );
                     let mac = generate_item_with_correct_attrs(
                         cx,

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2944,42 +2944,13 @@ fn clean_maybe_renamed_item<'tcx>(
                 ),
                 MacroKinds::ATTR => clean_proc_macro(item, &mut name, MacroKind::Attr, cx.tcx),
                 MacroKinds::DERIVE => clean_proc_macro(item, &mut name, MacroKind::Derive, cx.tcx),
-                _ => {
-                    let kind = MacroItem(
-                        Macro {
-                            source: display_macro_source(cx.tcx, name, macro_def),
-                            macro_rules: macro_def.macro_rules,
-                        },
-                        kinds,
-                    );
-                    let mac = generate_item_with_correct_attrs(
-                        cx,
-                        kind,
-                        item.owner_id.def_id.to_def_id(),
-                        name,
-                        import_ids,
-                        renamed,
-                    );
-
-                    let mut ret = Vec::with_capacity(3);
-                    for kind in kinds.iter().filter(|kind| *kind != MacroKinds::BANG) {
-                        match kind {
-                            MacroKinds::ATTR => {
-                                let mut attr = mac.clone();
-                                attr.inner.kind = AttrMacroItem;
-                                ret.push(attr);
-                            }
-                            MacroKinds::DERIVE => {
-                                let mut derive = mac.clone();
-                                derive.inner.kind = DeriveMacroItem;
-                                ret.push(derive);
-                            }
-                            _ => panic!("unsupported macro kind {kind:?}"),
-                        }
-                    }
-                    ret.push(mac);
-                    return ret;
-                }
+                _ => MacroItem(
+                    Macro {
+                        source: display_macro_source(cx.tcx, name, macro_def),
+                        macro_rules: macro_def.macro_rules,
+                    },
+                    kinds,
+                ),
             },
             // proc macros can have a name set by attributes
             ItemKind::Fn { ref sig, generics, body: body_id, .. } => {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2944,13 +2944,43 @@ fn clean_maybe_renamed_item<'tcx>(
                 ),
                 MacroKinds::ATTR => clean_proc_macro(item, &mut name, MacroKind::Attr, cx.tcx),
                 MacroKinds::DERIVE => clean_proc_macro(item, &mut name, MacroKind::Derive, cx.tcx),
-                _ => MacroItem(
-                    Macro {
-                        source: display_macro_source(cx.tcx, name, macro_def),
-                        macro_rules: macro_def.macro_rules,
-                    },
-                    Some(kinds),
-                ),
+                _ if kinds.contains(MacroKinds::BANG) => {
+                    let kind = MacroItem(
+                        Macro {
+                            source: display_macro_source(cx.tcx, name, macro_def),
+                            macro_rules: macro_def.macro_rules,
+                        },
+                        Some(kinds),
+                    );
+                    let mac = generate_item_with_correct_attrs(
+                        cx,
+                        kind,
+                        item.owner_id.def_id.to_def_id(),
+                        name,
+                        import_ids,
+                        renamed,
+                    );
+
+                    let mut ret = Vec::with_capacity(3);
+                    for kind in kinds.iter().filter(|kind| *kind != MacroKinds::BANG) {
+                        match kind {
+                            MacroKinds::ATTR => {
+                                let mut attr = mac.clone();
+                                attr.inner.kind = AttrMacroItem;
+                                ret.push(attr);
+                            }
+                            MacroKinds::DERIVE => {
+                                let mut derive = mac.clone();
+                                derive.inner.kind = DeriveMacroItem;
+                                ret.push(derive);
+                            }
+                            _ => panic!("unsupported macro kind {kind:?}"),
+                        }
+                    }
+                    ret.push(mac);
+                    return ret;
+                }
+                _ => panic!("unsupported macro kind {kinds:?}"),
             },
             // proc macros can have a name set by attributes
             ItemKind::Fn { ref sig, generics, body: body_id, .. } => {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2944,7 +2944,7 @@ fn clean_maybe_renamed_item<'tcx>(
                 ),
                 MacroKinds::ATTR => clean_proc_macro(item, &mut name, MacroKind::Attr, cx.tcx),
                 MacroKinds::DERIVE => clean_proc_macro(item, &mut name, MacroKind::Derive, cx.tcx),
-                _ if kinds.contains(MacroKinds::BANG) => {
+                _ => {
                     let kind = MacroItem(
                         Macro {
                             source: display_macro_source(cx.tcx, name, macro_def),
@@ -2980,7 +2980,6 @@ fn clean_maybe_renamed_item<'tcx>(
                     ret.push(mac);
                     return ret;
                 }
-                _ => panic!("unsupported macro kind {kinds:?}"),
             },
             // proc macros can have a name set by attributes
             ItemKind::Fn { ref sig, generics, body: body_id, .. } => {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2935,13 +2935,6 @@ fn clean_maybe_renamed_item<'tcx>(
                 fields: variant_data.fields().iter().map(|x| clean_field(x, cx)).collect(),
             }),
             ItemKind::Macro(_, macro_def, kinds) => match kinds {
-                MacroKinds::BANG => MacroItem(
-                    Macro {
-                        source: display_macro_source(cx.tcx, name, macro_def),
-                        macro_rules: macro_def.macro_rules,
-                    },
-                    MacroKinds::BANG,
-                ),
                 MacroKinds::ATTR => clean_proc_macro(item, &mut name, MacroKind::Attr, cx.tcx),
                 MacroKinds::DERIVE => clean_proc_macro(item, &mut name, MacroKind::Derive, cx.tcx),
                 _ => MacroItem(

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2934,19 +2934,24 @@ fn clean_maybe_renamed_item<'tcx>(
                 generics: clean_generics(generics, cx),
                 fields: variant_data.fields().iter().map(|x| clean_field(x, cx)).collect(),
             }),
-            // FIXME: handle attributes and derives that aren't proc macros, and macros with
-            // multiple kinds
-            ItemKind::Macro(_, macro_def, MacroKinds::BANG) => MacroItem(Macro {
-                source: display_macro_source(cx.tcx, name, macro_def),
-                macro_rules: macro_def.macro_rules,
-            }),
-            ItemKind::Macro(_, _, MacroKinds::ATTR) => {
-                clean_proc_macro(item, &mut name, MacroKind::Attr, cx.tcx)
-            }
-            ItemKind::Macro(_, _, MacroKinds::DERIVE) => {
-                clean_proc_macro(item, &mut name, MacroKind::Derive, cx.tcx)
-            }
-            ItemKind::Macro(_, _, _) => todo!("Handle macros with multiple kinds"),
+            ItemKind::Macro(_, macro_def, kinds) => match kinds {
+                MacroKinds::BANG => MacroItem(
+                    Macro {
+                        source: display_macro_source(cx.tcx, name, macro_def),
+                        macro_rules: macro_def.macro_rules,
+                    },
+                    None,
+                ),
+                MacroKinds::ATTR => clean_proc_macro(item, &mut name, MacroKind::Attr, cx.tcx),
+                MacroKinds::DERIVE => clean_proc_macro(item, &mut name, MacroKind::Derive, cx.tcx),
+                _ => MacroItem(
+                    Macro {
+                        source: display_macro_source(cx.tcx, name, macro_def),
+                        macro_rules: macro_def.macro_rules,
+                    },
+                    Some(kinds),
+                ),
+            },
             // proc macros can have a name set by attributes
             ItemKind::Fn { ref sig, generics, body: body_id, .. } => {
                 clean_fn_or_proc_macro(item, sig, generics, body_id, &mut name, cx)

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -781,7 +781,7 @@ impl Item {
     }
 
     /// Returns true if this a macro declared with the `macro` keyword or with `macro_rules!.
-    pub(crate) fn is_bang_macro_or_macro_rules(&self) -> bool {
+    pub(crate) fn is_decl_macro(&self) -> bool {
         matches!(self.kind, ItemKind::MacroItem(..))
     }
 

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -12,7 +12,7 @@ use rustc_data_structures::fx::{FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_data_structures::thin_vec::ThinVec;
 use rustc_hir as hir;
 use rustc_hir::attrs::{AttributeKind, DeprecatedSince, Deprecation, DocAttribute};
-use rustc_hir::def::{CtorKind, DefKind, Res};
+use rustc_hir::def::{CtorKind, DefKind, MacroKinds, Res};
 use rustc_hir::def_id::{CrateNum, DefId, LOCAL_CRATE, LocalDefId};
 use rustc_hir::lang_items::LangItem;
 use rustc_hir::{Attribute, BodyId, ConstStability, Mutability, Stability, StableSince, find_attr};
@@ -758,6 +758,24 @@ impl Item {
         find_attr!(&self.attrs.other_attrs, NonExhaustive(..))
     }
 
+    pub(crate) fn bang_macro_types(&self) -> Option<Vec<ItemType>> {
+        match self.kind {
+            ItemKind::MacroItem(_, None) => Some(vec![ItemType::Macro]),
+            ItemKind::MacroItem(_, Some(kinds)) => Some(
+                kinds
+                    .iter()
+                    .map(|kind| match kind {
+                        MacroKinds::BANG => ItemType::Macro,
+                        MacroKinds::ATTR => ItemType::ProcAttribute,
+                        MacroKinds::DERIVE => ItemType::ProcDerive,
+                        _ => panic!("unexpected macro kind {kind:?}"),
+                    })
+                    .collect::<Vec<_>>(),
+            ),
+            _ => None,
+        }
+    }
+
     /// Returns a documentation-level item type from the item.
     pub(crate) fn type_(&self) -> ItemType {
         ItemType::from(self)
@@ -931,7 +949,7 @@ pub(crate) enum ItemKind {
     ForeignStaticItem(Static, hir::Safety),
     /// `type`s from an extern block
     ForeignTypeItem,
-    MacroItem(Macro),
+    MacroItem(Macro, Option<MacroKinds>),
     ProcMacroItem(ProcMacro),
     PrimitiveItem(PrimitiveType),
     /// A required associated constant in a trait declaration.
@@ -986,7 +1004,7 @@ impl ItemKind {
             | ForeignFunctionItem(_, _)
             | ForeignStaticItem(_, _)
             | ForeignTypeItem
-            | MacroItem(_)
+            | MacroItem(..)
             | ProcMacroItem(_)
             | PrimitiveItem(_)
             | RequiredAssocConstItem(..)

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -758,31 +758,30 @@ impl Item {
         find_attr!(&self.attrs.other_attrs, NonExhaustive(..))
     }
 
-    /// Returns a documentation-level item type from the item.
+    /// Returns a documentation-level item type from the item. In case of a `macro_rules!` which
+    /// contains an attr/derive kind, it will always return `ItemType::Macro`. If you want all
+    /// kinds, you need to use [`Item::types`].
     pub(crate) fn type_(&self) -> ItemType {
         ItemType::from(self)
     }
 
-    // FIXME: Return an iterator instead of a `ThinVec`.
-    pub(crate) fn types(&self) -> ThinVec<ItemType> {
+    /// Returns an item types. There is only one case where it can return more than one kind:
+    /// for `macro_rules!` items which contain an attr/derive kind.
+    pub(crate) fn types(&self) -> impl Iterator<Item = ItemType> {
         if let ItemKind::MacroItem(_, macro_kinds) = self.kind {
-            let mut types = ThinVec::with_capacity(3);
-            for kind in macro_kinds.iter() {
-                match kind {
-                    MacroKinds::ATTR => types.push(ItemType::BangMacroAttribute),
-                    MacroKinds::DERIVE => types.push(ItemType::BangMacroDerive),
-                    MacroKinds::BANG => types.push(ItemType::Macro),
-                    _ => panic!("unsupported macro kind {kind:?}"),
-                }
-            }
-            return types;
+            Either::Right(macro_kinds.iter().map(|kind| match kind {
+                MacroKinds::ATTR => ItemType::BangMacroAttribute,
+                MacroKinds::DERIVE => ItemType::BangMacroDerive,
+                MacroKinds::BANG => ItemType::Macro,
+                _ => panic!("unsupported macro kind {kind:?}"),
+            }))
+        } else {
+            Either::Left(std::iter::once(self.type_()))
         }
-        let mut types = ThinVec::with_capacity(1);
-        types.push(self.type_());
-        types
     }
 
-    pub(crate) fn is_macro_rules(&self) -> bool {
+    /// Returns true if this a macro declared with the `macro` keyword or with `macro_rules!.
+    pub(crate) fn is_bang_macro_or_macro_rules(&self) -> bool {
         matches!(self.kind, ItemKind::MacroItem(..))
     }
 
@@ -959,8 +958,12 @@ pub(crate) enum ItemKind {
     ForeignStaticItem(Static, hir::Safety),
     /// `type`s from an extern block
     ForeignTypeItem,
-    /// A bang macro. it can be multiple things (macro, derive and attribute, potentially multiple
-    /// at once). Don't forget to look into the `MacroKinds` values.
+    /// A macro defined with `macro_rules` or the `macro` keyword. It can be multiple things (macro,
+    /// derive and attribute, potentially multiple at once). Don't forget to look into the
+    ///`MacroKinds` values.
+    ///
+    /// If a `macro_rules!` only contains a `attr`/`derive` branch, then it's not stored in this
+    /// variant but in the `ProcMacroItem` variant.
     MacroItem(Macro, MacroKinds),
     ProcMacroItem(ProcMacro),
     PrimitiveItem(PrimitiveType),

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -763,6 +763,29 @@ impl Item {
         ItemType::from(self)
     }
 
+    // FIXME: Return an iterator instead of a `ThinVec`.
+    pub(crate) fn types(&self) -> ThinVec<ItemType> {
+        if let ItemKind::MacroItem(_, macro_kinds) = self.kind {
+            let mut types = ThinVec::with_capacity(3);
+            for kind in macro_kinds.iter() {
+                match kind {
+                    MacroKinds::ATTR => types.push(ItemType::BangMacroAttribute),
+                    MacroKinds::DERIVE => types.push(ItemType::BangMacroDerive),
+                    MacroKinds::BANG => types.push(ItemType::Macro),
+                    _ => panic!("unsupported macro kind {kind:?}"),
+                }
+            }
+            return types;
+        }
+        let mut types = ThinVec::with_capacity(1);
+        types.push(self.type_());
+        types
+    }
+
+    pub(crate) fn is_macro_rules(&self) -> bool {
+        matches!(self.kind, ItemKind::MacroItem(..))
+    }
+
     pub(crate) fn defaultness(&self) -> Option<Defaultness> {
         match self.kind {
             ItemKind::MethodItem(_, defaultness) | ItemKind::RequiredMethodItem(_, defaultness) => {
@@ -774,14 +797,7 @@ impl Item {
 
     /// Generates the HTML file name based on the item kind.
     pub(crate) fn html_filename(&self) -> String {
-        let type_ = if self.is_macro_placeholder() { ItemType::Macro } else { self.type_() };
-        format!("{type_}.{}.html", self.name.unwrap())
-    }
-
-    /// If the current item is a "fake" macro (ie, `AttrMacroItem | ItemKind::DeriveMacroItem` which
-    /// don't hold any data), it returns `true`.
-    pub(crate) fn is_macro_placeholder(&self) -> bool {
-        matches!(self.kind, ItemKind::AttrMacroItem | ItemKind::DeriveMacroItem)
+        format!("{type_}.{name}.html", type_ = self.type_(), name = self.name.unwrap())
     }
 
     /// Returns a `FnHeader` if `self` is a function item, otherwise returns `None`.
@@ -943,13 +959,9 @@ pub(crate) enum ItemKind {
     ForeignStaticItem(Static, hir::Safety),
     /// `type`s from an extern block
     ForeignTypeItem,
+    /// A bang macro. it can be multiple things (macro, derive and attribute, potentially multiple
+    /// at once). Don't forget to look into the `MacroKinds` values.
     MacroItem(Macro, MacroKinds),
-    /// This is NOT an attribute proc-macro but a bang macro with support for being used as an
-    /// attribute macro.
-    AttrMacroItem,
-    /// This is NOT an attribute proc-macro but a bang macro with support for being used as a
-    /// derive macro.
-    DeriveMacroItem,
     ProcMacroItem(ProcMacro),
     PrimitiveItem(PrimitiveType),
     /// A required associated constant in a trait declaration.
@@ -1005,8 +1017,6 @@ impl ItemKind {
             | ForeignStaticItem(_, _)
             | ForeignTypeItem
             | MacroItem(..)
-            | AttrMacroItem
-            | DeriveMacroItem
             | ProcMacroItem(_)
             | PrimitiveItem(_)
             | RequiredAssocConstItem(..)

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -943,8 +943,12 @@ pub(crate) enum ItemKind {
     ForeignStaticItem(Static, hir::Safety),
     /// `type`s from an extern block
     ForeignTypeItem,
-    MacroItem(Macro, Option<MacroKinds>),
+    MacroItem(Macro, MacroKinds),
+    /// This is NOT an attribute proc-macro but a bang macro with support for being used as an
+    /// attribute macro.
     AttrMacroItem,
+    /// This is NOT an attribute proc-macro but a bang macro with support for being used as a
+    /// derive macro.
     DeriveMacroItem,
     ProcMacroItem(ProcMacro),
     PrimitiveItem(PrimitiveType),

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -770,8 +770,8 @@ impl Item {
     pub(crate) fn types(&self) -> impl Iterator<Item = ItemType> {
         if let ItemKind::MacroItem(_, macro_kinds) = self.kind {
             Either::Right(macro_kinds.iter().map(|kind| match kind {
-                MacroKinds::ATTR => ItemType::BangMacroAttribute,
-                MacroKinds::DERIVE => ItemType::BangMacroDerive,
+                MacroKinds::ATTR => ItemType::DeclMacroAttribute,
+                MacroKinds::DERIVE => ItemType::DeclMacroDerive,
                 MacroKinds::BANG => ItemType::Macro,
                 _ => panic!("unsupported macro kind {kind:?}"),
             }))

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -758,24 +758,6 @@ impl Item {
         find_attr!(&self.attrs.other_attrs, NonExhaustive(..))
     }
 
-    pub(crate) fn bang_macro_types(&self) -> Option<Vec<ItemType>> {
-        match self.kind {
-            ItemKind::MacroItem(_, None) => Some(vec![ItemType::Macro]),
-            ItemKind::MacroItem(_, Some(kinds)) => Some(
-                kinds
-                    .iter()
-                    .map(|kind| match kind {
-                        MacroKinds::BANG => ItemType::Macro,
-                        MacroKinds::ATTR => ItemType::ProcAttribute,
-                        MacroKinds::DERIVE => ItemType::ProcDerive,
-                        _ => panic!("unexpected macro kind {kind:?}"),
-                    })
-                    .collect::<Vec<_>>(),
-            ),
-            _ => None,
-        }
-    }
-
     /// Returns a documentation-level item type from the item.
     pub(crate) fn type_(&self) -> ItemType {
         ItemType::from(self)
@@ -788,6 +770,18 @@ impl Item {
             }
             _ => None,
         }
+    }
+
+    /// Generates the HTML file name based on the item kind.
+    pub(crate) fn html_filename(&self) -> String {
+        let type_ = if self.is_macro_placeholder() { ItemType::Macro } else { self.type_() };
+        format!("{type_}.{}.html", self.name.unwrap())
+    }
+
+    /// If the current item is a "fake" macro (ie, `AttrMacroItem | ItemKind::DeriveMacroItem` which
+    /// don't hold any data), it returns `true`.
+    pub(crate) fn is_macro_placeholder(&self) -> bool {
+        matches!(self.kind, ItemKind::AttrMacroItem | ItemKind::DeriveMacroItem)
     }
 
     /// Returns a `FnHeader` if `self` is a function item, otherwise returns `None`.
@@ -950,6 +944,8 @@ pub(crate) enum ItemKind {
     /// `type`s from an extern block
     ForeignTypeItem,
     MacroItem(Macro, Option<MacroKinds>),
+    AttrMacroItem,
+    DeriveMacroItem,
     ProcMacroItem(ProcMacro),
     PrimitiveItem(PrimitiveType),
     /// A required associated constant in a trait declaration.
@@ -1005,6 +1001,8 @@ impl ItemKind {
             | ForeignStaticItem(_, _)
             | ForeignTypeItem
             | MacroItem(..)
+            | AttrMacroItem
+            | DeriveMacroItem
             | ProcMacroItem(_)
             | PrimitiveItem(_)
             | RequiredAssocConstItem(..)

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -585,38 +585,68 @@ pub(crate) static RUSTDOC_VERSION: Lazy<&'static str> =
 
 /// Render a sequence of macro arms in a format suitable for displaying to the user
 /// as part of an item declaration.
-fn render_macro_arms<'a>(
+fn render_macro_arms(
     tcx: TyCtxt<'_>,
-    matchers: impl Iterator<Item = &'a TokenTree>,
+    tokens: &rustc_ast::tokenstream::TokenStream,
     arm_delim: &str,
 ) -> String {
+    let mut tokens = tokens.iter();
     let mut out = String::new();
-    for matcher in matchers {
+    while let Some(mut token) = tokens.next() {
+        // If this an attr/derive rule, it looks like `attr() () => {}`, so the token needs to be
+        // handled at the same time as the actual matcher.
+        //
+        // Without that, we would end up with `attr()` on one line and the matcher `()` on another.
+        let pre = if matches!(token, TokenTree::Token(..)) {
+            let pre = format!("{}() ", render_macro_matcher(tcx, token));
+            // Skipping the always empty `()` following the attr/derive ident.
+            tokens.next();
+            let Some(next) = tokens.next() else {
+                return out;
+            };
+            token = next;
+            pre
+        } else {
+            String::new()
+        };
         writeln!(
             out,
-            "    {matcher} => {{ ... }}{arm_delim}",
-            matcher = render_macro_matcher(tcx, matcher),
+            "    {pre}{matcher} => {{ ... }}{arm_delim}",
+            matcher = render_macro_matcher(tcx, token),
         )
         .unwrap();
+        // We skip the `=>`, macro "body" and the delimiter closing that "body" since we don't
+        // render them.
+        tokens.next();
+        tokens.next();
+        tokens.next();
     }
     out
 }
 
 pub(super) fn display_macro_source(tcx: TyCtxt<'_>, name: Symbol, def: &ast::MacroDef) -> String {
     // Extract the spans of all matchers. They represent the "interface" of the macro.
-    let matchers = def.body.tokens.chunks(4).map(|arm| &arm[0]);
-
     if def.macro_rules {
-        format!("macro_rules! {name} {{\n{arms}}}", arms = render_macro_arms(tcx, matchers, ";"))
+        format!(
+            "macro_rules! {name} {{\n{arms}}}",
+            arms = render_macro_arms(tcx, &def.body.tokens, ";")
+        )
     } else {
-        if matchers.len() <= 1 {
+        if def.body.tokens.len() <= 4 {
             format!(
                 "macro {name}{matchers} {{\n    ...\n}}",
-                matchers =
-                    matchers.map(|matcher| render_macro_matcher(tcx, matcher)).collect::<String>(),
+                matchers = def
+                    .body
+                    .tokens
+                    .get(0)
+                    .map(|matcher| render_macro_matcher(tcx, matcher))
+                    .unwrap_or_default(),
             )
         } else {
-            format!("macro {name} {{\n{arms}}}", arms = render_macro_arms(tcx, matchers, ","))
+            format!(
+                "macro {name} {{\n{arms}}}",
+                arms = render_macro_arms(tcx, &def.body.tokens, ",")
+            )
         }
     }
 }

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -5,6 +5,7 @@ use std::{ascii, mem};
 
 use rustc_ast as ast;
 use rustc_ast::join_path_idents;
+use rustc_ast::token::{Token, TokenKind};
 use rustc_ast::tokenstream::TokenTree;
 use rustc_data_structures::thin_vec::{ThinVec, thin_vec};
 use rustc_hir as hir;
@@ -617,9 +618,18 @@ fn render_macro_arms(
         .unwrap();
         // We skip the `=>`, macro "body" and the delimiter closing that "body" since we don't
         // render them.
-        tokens.next();
-        tokens.next();
-        tokens.next();
+        let _token = tokens.next();
+        // The `=>`.
+        debug_assert_matches!(
+            _token,
+            Some(TokenTree::Token(Token { kind: TokenKind::FatArrow, .. }, _))
+        );
+        let _token = tokens.next();
+        // The arm body.
+        debug_assert_matches!(_token, Some(TokenTree::Delimited(..)));
+        // The delimiter (which may be omitted on the last arm's body).
+        let _token = tokens.next();
+        debug_assert_matches!(_token, None | Some(TokenTree::Token(Token { .. }, _)));
     }
     out
 }

--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -89,6 +89,8 @@ pub(crate) trait DocFolder: Sized {
             | ForeignStaticItem(..)
             | ForeignTypeItem
             | MacroItem(..)
+            | AttrMacroItem
+            | DeriveMacroItem
             | ProcMacroItem(_)
             | PrimitiveItem(_)
             | RequiredAssocConstItem(..)

--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -88,7 +88,7 @@ pub(crate) trait DocFolder: Sized {
             | ForeignFunctionItem(..)
             | ForeignStaticItem(..)
             | ForeignTypeItem
-            | MacroItem(_)
+            | MacroItem(..)
             | ProcMacroItem(_)
             | PrimitiveItem(_)
             | RequiredAssocConstItem(..)

--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -89,8 +89,6 @@ pub(crate) trait DocFolder: Sized {
             | ForeignStaticItem(..)
             | ForeignTypeItem
             | MacroItem(..)
-            | AttrMacroItem
-            | DeriveMacroItem
             | ProcMacroItem(_)
             | PrimitiveItem(_)
             | RequiredAssocConstItem(..)

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -380,8 +380,10 @@ impl DocFolder for CacheBuilder<'_, '_> {
             | clean::RequiredAssocTypeItem(..)
             | clean::AssocTypeItem(..)
             | clean::StrippedItem(..)
-            | clean::KeywordItem
-            | clean::AttributeItem => {
+            | clean::AttributeItem
+            | clean::AttrMacroItem
+            | clean::DeriveMacroItem
+            | clean::KeywordItem => {
                 // FIXME: Do these need handling?
                 // The person writing this comment doesn't know.
                 // So would rather leave them to an expert,

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -2,6 +2,7 @@ use std::mem;
 
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_hir::StabilityLevel;
+use rustc_hir::def::MacroKinds;
 use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, DefIdSet};
 use rustc_metadata::creader::CStore;
 use rustc_middle::ty::{self, TyCtxt};
@@ -490,6 +491,7 @@ fn add_item_to_search_index(tcx: TyCtxt<'_>, cache: &mut Cache, item: &clean::It
     // Item has a name, so it must also have a DefId (can't be an impl, let alone a blanket or auto impl).
     let item_def_id = item.item_id.as_def_id().unwrap();
     let (parent_did, parent_path) = match item.kind {
+        clean::MacroItem(_, kinds) if !kinds.contains(MacroKinds::BANG) => return,
         clean::StrippedItem(..) => return,
         clean::ProvidedAssocConstItem(..)
         | clean::ImplAssocConstItem(..)

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -380,8 +380,8 @@ impl DocFolder for CacheBuilder<'_, '_> {
             | clean::RequiredAssocTypeItem(..)
             | clean::AssocTypeItem(..)
             | clean::StrippedItem(..)
-            | clean::AttributeItem
-            | clean::KeywordItem => {
+            | clean::KeywordItem
+            | clean::AttributeItem => {
                 // FIXME: Do these need handling?
                 // The person writing this comment doesn't know.
                 // So would rather leave them to an expert,

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -2,7 +2,6 @@ use std::mem;
 
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_hir::StabilityLevel;
-use rustc_hir::def::MacroKinds;
 use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, DefIdSet};
 use rustc_metadata::creader::CStore;
 use rustc_middle::ty::{self, TyCtxt};
@@ -382,8 +381,6 @@ impl DocFolder for CacheBuilder<'_, '_> {
             | clean::AssocTypeItem(..)
             | clean::StrippedItem(..)
             | clean::AttributeItem
-            | clean::AttrMacroItem
-            | clean::DeriveMacroItem
             | clean::KeywordItem => {
                 // FIXME: Do these need handling?
                 // The person writing this comment doesn't know.
@@ -491,7 +488,6 @@ fn add_item_to_search_index(tcx: TyCtxt<'_>, cache: &mut Cache, item: &clean::It
     // Item has a name, so it must also have a DefId (can't be an impl, let alone a blanket or auto impl).
     let item_def_id = item.item_id.as_def_id().unwrap();
     let (parent_did, parent_path) = match item.kind {
-        clean::MacroItem(_, kinds) if !kinds.contains(MacroKinds::BANG) => return,
         clean::StrippedItem(..) => return,
         clean::ProvidedAssocConstItem(..)
         | clean::ImplAssocConstItem(..)
@@ -592,12 +588,14 @@ fn add_item_to_search_index(tcx: TyCtxt<'_>, cache: &mut Cache, item: &clean::It
         _ => item_def_id,
     };
     let (impl_id, trait_parent) = cache.parent_stack_last_impl_and_trait_id();
+    let mut types = item.types();
     let info = IndexItemInfo::new(
         tcx,
         cache,
         item,
         parent_did,
         clean_impl_generics(cache.parent_stack.last()).as_ref(),
+        types.next().unwrap(),
     );
     let index_item = IndexItem {
         defid: Some(defid),
@@ -611,7 +609,11 @@ fn add_item_to_search_index(tcx: TyCtxt<'_>, cache: &mut Cache, item: &clean::It
         impl_id,
         info,
     };
-
+    for type_ in types {
+        let mut index_item_copy = index_item.clone();
+        index_item_copy.info.ty = type_;
+        cache.search_index.push(index_item_copy);
+    }
     cache.search_index.push(index_item);
 }
 

--- a/src/librustdoc/formats/item_type.rs
+++ b/src/librustdoc/formats/item_type.rs
@@ -130,6 +130,10 @@ impl<'a> From<&'a clean::Item> for ItemType {
             clean::ForeignFunctionItem(..) => ItemType::Function, // no ForeignFunction
             clean::ForeignStaticItem(..) => ItemType::Static,     // no ForeignStatic
             clean::MacroItem(..) => ItemType::Macro,
+            // Is this a good idea?
+            clean::AttrMacroItem => ItemType::ProcAttribute,
+            // Is this a good idea?
+            clean::DeriveMacroItem => ItemType::ProcDerive,
             clean::PrimitiveItem(..) => ItemType::Primitive,
             clean::RequiredAssocConstItem(..)
             | clean::ProvidedAssocConstItem(..)

--- a/src/librustdoc/formats/item_type.rs
+++ b/src/librustdoc/formats/item_type.rs
@@ -132,8 +132,6 @@ impl<'a> From<&'a clean::Item> for ItemType {
             clean::ForeignFunctionItem(..) => ItemType::Function, // no ForeignFunction
             clean::ForeignStaticItem(..) => ItemType::Static,     // no ForeignStatic
             clean::MacroItem(..) => ItemType::Macro,
-            clean::AttrMacroItem => ItemType::BangMacroAttribute,
-            clean::DeriveMacroItem => ItemType::BangMacroDerive,
             clean::PrimitiveItem(..) => ItemType::Primitive,
             clean::RequiredAssocConstItem(..)
             | clean::ProvidedAssocConstItem(..)
@@ -167,10 +165,9 @@ impl ItemType {
             DefKind::Trait => Self::Trait,
             DefKind::TyAlias => Self::TypeAlias,
             DefKind::TraitAlias => Self::TraitAlias,
-            DefKind::Macro(MacroKinds::BANG) => ItemType::Macro,
             DefKind::Macro(MacroKinds::ATTR) => ItemType::ProcAttribute,
             DefKind::Macro(MacroKinds::DERIVE) => ItemType::ProcDerive,
-            DefKind::Macro(_) => todo!("Handle macros with multiple kinds"),
+            DefKind::Macro(_) => ItemType::Macro,
             DefKind::ForeignTy => Self::ForeignType,
             DefKind::Variant => Self::Variant,
             DefKind::Field => Self::StructField,

--- a/src/librustdoc/formats/item_type.rs
+++ b/src/librustdoc/formats/item_type.rs
@@ -101,6 +101,10 @@ item_type! {
     // This number is reserved for use in JavaScript
     // Generic = 26,
     Attribute = 27,
+    // The two next ones represent an attr/derive macro declared as a `macro_rules!`. We need this
+    // distinction because they will point to a `macro.[name].html` file and not
+    // `[attr|derive].[name].html` file, so the link generation needs to take it into account while
+    // still having the filtering working as expected.
     BangMacroAttribute = 28,
     BangMacroDerive = 29,
 }

--- a/src/librustdoc/formats/item_type.rs
+++ b/src/librustdoc/formats/item_type.rs
@@ -101,6 +101,8 @@ item_type! {
     // This number is reserved for use in JavaScript
     // Generic = 26,
     Attribute = 27,
+    BangMacroAttribute = 28,
+    BangMacroDerive = 29,
 }
 
 impl<'a> From<&'a clean::Item> for ItemType {
@@ -130,10 +132,8 @@ impl<'a> From<&'a clean::Item> for ItemType {
             clean::ForeignFunctionItem(..) => ItemType::Function, // no ForeignFunction
             clean::ForeignStaticItem(..) => ItemType::Static,     // no ForeignStatic
             clean::MacroItem(..) => ItemType::Macro,
-            // Is this a good idea?
-            clean::AttrMacroItem => ItemType::ProcAttribute,
-            // Is this a good idea?
-            clean::DeriveMacroItem => ItemType::ProcDerive,
+            clean::AttrMacroItem => ItemType::BangMacroAttribute,
+            clean::DeriveMacroItem => ItemType::BangMacroDerive,
             clean::PrimitiveItem(..) => ItemType::Primitive,
             clean::RequiredAssocConstItem(..)
             | clean::ProvidedAssocConstItem(..)
@@ -225,8 +225,8 @@ impl ItemType {
             ItemType::AssocConst => "associatedconstant",
             ItemType::ForeignType => "foreigntype",
             ItemType::Keyword => "keyword",
-            ItemType::ProcAttribute => "attr",
-            ItemType::ProcDerive => "derive",
+            ItemType::ProcAttribute | ItemType::BangMacroAttribute => "attr",
+            ItemType::ProcDerive | ItemType::BangMacroDerive => "derive",
             ItemType::TraitAlias => "traitalias",
             ItemType::Attribute => "attribute",
         }

--- a/src/librustdoc/formats/item_type.rs
+++ b/src/librustdoc/formats/item_type.rs
@@ -105,8 +105,8 @@ item_type! {
     // distinction because they will point to a `macro.[name].html` file and not
     // `[attr|derive].[name].html` file, so the link generation needs to take it into account while
     // still having the filtering working as expected.
-    BangMacroAttribute = 28,
-    BangMacroDerive = 29,
+    DeclMacroAttribute = 28,
+    DeclMacroDerive = 29,
 }
 
 impl<'a> From<&'a clean::Item> for ItemType {
@@ -226,8 +226,8 @@ impl ItemType {
             ItemType::AssocConst => "associatedconstant",
             ItemType::ForeignType => "foreigntype",
             ItemType::Keyword => "keyword",
-            ItemType::ProcAttribute | ItemType::BangMacroAttribute => "attr",
-            ItemType::ProcDerive | ItemType::BangMacroDerive => "derive",
+            ItemType::ProcAttribute | ItemType::DeclMacroAttribute => "attr",
+            ItemType::ProcDerive | ItemType::DeclMacroDerive => "derive",
             ItemType::TraitAlias => "traitalias",
             ItemType::Attribute => "attribute",
         }

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -2051,7 +2051,7 @@ fn is_default_id(id: &str) -> bool {
         | "crate-search"
         | "crate-search-div"
         // This is the list of IDs used in HTML generated in Rust (including the ones
-        // used in tera template files).
+        // used in askama template files).
         | "themeStyle"
         | "settings-menu"
         | "help-button"
@@ -2090,7 +2090,7 @@ fn is_default_id(id: &str) -> bool {
         | "blanket-implementations-list"
         | "deref-methods"
         | "layout"
-        | "aliased-type"
+        | "aliased-type",
     )
 }
 

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -171,7 +171,10 @@ impl SharedContext<'_> {
 
 struct SidebarItem {
     name: String,
-    is_actually_macro: bool,
+    /// Bang macros can now be used as attribute/derive macros, making it tricky to correctly
+    /// handle all their cases at once, which means that even if they are categorized as
+    /// derive/attribute macros, they should still link to a "macro_rules" URL.
+    is_macro_rules: bool,
 }
 
 impl serde::Serialize for SidebarItem {
@@ -179,7 +182,7 @@ impl serde::Serialize for SidebarItem {
     where
         S: serde::Serializer,
     {
-        if self.is_actually_macro {
+        if self.is_macro_rules {
             let mut seq = serializer.serialize_seq(Some(2))?;
             seq.serialize_element(&self.name)?;
             seq.serialize_element(&1)?;
@@ -355,7 +358,7 @@ impl<'tcx> Context<'tcx> {
                 let name = name.to_string();
                 map.entry(type_)
                     .or_default()
-                    .push(SidebarItem { name, is_actually_macro: item.is_macro_placeholder() });
+                    .push(SidebarItem { name, is_macro_rules: item.is_macro_placeholder() });
             }
         }
 

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -10,7 +10,6 @@ use rustc_ast::join_path_syms;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_hir::Attribute;
 use rustc_hir::attrs::AttributeKind;
-use rustc_hir::def::MacroKinds;
 use rustc_hir::def_id::{DefIdMap, LOCAL_CRATE};
 use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
@@ -352,14 +351,13 @@ impl<'tcx> Context<'tcx> {
                 Some(s) => s,
             };
 
-            let type_ = item.type_();
-
-            if inserted.entry(type_).or_default().insert(name) {
-                let type_ = type_.to_string();
-                let name = name.to_string();
-                map.entry(type_)
-                    .or_default()
-                    .push(SidebarItem { name, is_macro_rules: item.is_macro_placeholder() });
+            let is_macro_rules = item.is_macro_rules();
+            for type_ in item.types() {
+                if inserted.entry(type_).or_default().insert(name) {
+                    let type_ = type_.to_string();
+                    let name = name.to_string();
+                    map.entry(type_).or_default().push(SidebarItem { name, is_macro_rules });
+                }
             }
         }
 
@@ -840,7 +838,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
 
         info!("Recursing into {}", self.dst.display());
 
-        if !item.is_stripped() && !item.is_macro_placeholder() {
+        if !item.is_stripped() {
             let buf = self.render_item(item, true);
             // buf will be empty if the module is stripped and there is no redirect for it
             if !buf.is_empty() {
@@ -896,19 +894,10 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             self.info.render_redirect_pages = item.is_stripped();
         }
 
-        if item.is_macro_placeholder() {
-            if !self.info.render_redirect_pages {
-                self.shared.all.borrow_mut().append(full_path(self, item), &item);
-            }
-            return Ok(());
-        }
-
         let buf = self.render_item(item, false);
         // buf will be empty if the item is stripped and there is no redirect for it
         if !buf.is_empty() {
-            if !self.info.render_redirect_pages
-                && !matches!(item.kind, clean::ItemKind::MacroItem(_, kinds) if !kinds.contains(MacroKinds::BANG))
-            {
+            if !self.info.render_redirect_pages {
                 self.shared.all.borrow_mut().append(full_path(self, item), &item);
             }
 

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -168,6 +168,27 @@ impl SharedContext<'_> {
     }
 }
 
+struct SidebarItem {
+    name: String,
+    is_actually_macro: bool,
+}
+
+impl serde::Serialize for SidebarItem {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if self.is_actually_macro {
+            let mut seq = serializer.serialize_seq(Some(2))?;
+            seq.serialize_element(&self.name)?;
+            seq.serialize_element(&1)?;
+            seq.end()
+        } else {
+            serializer.serialize_some(&Some(&self.name))
+        }
+    }
+}
+
 impl<'tcx> Context<'tcx> {
     pub(crate) fn tcx(&self) -> TyCtxt<'tcx> {
         self.shared.tcx
@@ -312,7 +333,20 @@ impl<'tcx> Context<'tcx> {
     }
 
     /// Construct a map of items shown in the sidebar to a plain-text summary of their docs.
-    fn build_sidebar_items(&self, m: &clean::Module) -> BTreeMap<String, Vec<String>> {
+    fn build_sidebar_items(&self, m: &clean::Module) -> BTreeMap<String, Vec<SidebarItem>> {
+        fn build_sidebar_items_inner(
+            name: Symbol,
+            type_: ItemType,
+            map: &mut BTreeMap<String, Vec<SidebarItem>>,
+            inserted: &mut FxHashMap<ItemType, FxHashSet<Symbol>>,
+            is_actually_macro: bool,
+        ) {
+            if inserted.entry(type_).or_default().insert(name) {
+                let type_ = type_.to_string();
+                let name = name.to_string();
+                map.entry(type_).or_default().push(SidebarItem { name, is_actually_macro });
+            }
+        }
         // BTreeMap instead of HashMap to get a sorted output
         let mut map: BTreeMap<_, Vec<_>> = BTreeMap::new();
         let mut inserted: FxHashMap<ItemType, FxHashSet<Symbol>> = FxHashMap::default();
@@ -321,23 +355,24 @@ impl<'tcx> Context<'tcx> {
             if item.is_stripped() {
                 continue;
             }
-
-            let short = item.type_();
-            let myname = match item.name {
+            let name = match item.name {
                 None => continue,
                 Some(s) => s,
             };
-            if inserted.entry(short).or_default().insert(myname) {
-                let short = short.to_string();
-                let myname = myname.to_string();
-                map.entry(short).or_default().push(myname);
+
+            if let Some(types) = item.bang_macro_types() {
+                for type_ in types {
+                    build_sidebar_items_inner(name, type_, &mut map, &mut inserted, true);
+                }
+            } else {
+                build_sidebar_items_inner(name, item.type_(), &mut map, &mut inserted, false);
             }
         }
 
         match self.shared.module_sorting {
             ModuleSorting::Alphabetical => {
                 for items in map.values_mut() {
-                    items.sort();
+                    items.sort_by(|a, b| a.name.cmp(&b.name));
                 }
             }
             ModuleSorting::DeclarationOrder => {}
@@ -878,7 +913,11 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             self.shared.fs.write(joint_dst, buf)?;
 
             if !self.info.render_redirect_pages {
-                self.shared.all.borrow_mut().append(full_path(self, item), &item_type);
+                self.shared.all.borrow_mut().append(
+                    full_path(self, item),
+                    &item_type,
+                    item.bang_macro_types(),
+                );
             }
             // If the item is a macro, redirect from the old macro URL (with !)
             // to the new one (without).

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -10,6 +10,7 @@ use rustc_ast::join_path_syms;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_hir::Attribute;
 use rustc_hir::attrs::AttributeKind;
+use rustc_hir::def::MacroKinds;
 use rustc_hir::def_id::{DefIdMap, LOCAL_CRATE};
 use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
@@ -905,7 +906,9 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
         let buf = self.render_item(item, false);
         // buf will be empty if the item is stripped and there is no redirect for it
         if !buf.is_empty() {
-            if !self.info.render_redirect_pages {
+            if !self.info.render_redirect_pages
+                && !matches!(item.kind, clean::ItemKind::MacroItem(_, kinds) if !kinds.contains(MacroKinds::BANG))
+            {
                 self.shared.all.borrow_mut().append(full_path(self, item), &item);
             }
 

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -15,9 +15,10 @@ use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
 use rustc_span::edition::Edition;
 use rustc_span::{BytePos, FileName, RemapPathScopeComponents, Symbol};
+use serde::ser::SerializeSeq;
 use tracing::info;
 
-use super::print_item::{full_path, print_item, print_item_path};
+use super::print_item::{full_path, print_item, print_item_path, print_ty_path};
 use super::sidebar::{ModuleLike, Sidebar, print_sidebar, sidebar_module_like};
 use super::{AllTypes, LinkFromSrc, StylePath, collect_spans_and_sources, scrape_examples_help};
 use crate::clean::types::ExternalLocation;
@@ -307,7 +308,7 @@ impl<'tcx> Context<'tcx> {
                     for name in &names[..names.len() - 1] {
                         write!(f, "{name}/")?;
                     }
-                    write!(f, "{}", print_item_path(ty, names.last().unwrap().as_str()))
+                    write!(f, "{}", print_ty_path(ty, names.last().unwrap().as_str()))
                 });
                 match self.shared.redirections {
                     Some(ref redirections) => {
@@ -319,7 +320,7 @@ impl<'tcx> Context<'tcx> {
                         let _ = write!(
                             current_path,
                             "{}",
-                            print_item_path(ty, names.last().unwrap().as_str())
+                            print_ty_path(ty, names.last().unwrap().as_str())
                         );
                         redirections.borrow_mut().insert(current_path, path.to_string());
                     }
@@ -334,19 +335,6 @@ impl<'tcx> Context<'tcx> {
 
     /// Construct a map of items shown in the sidebar to a plain-text summary of their docs.
     fn build_sidebar_items(&self, m: &clean::Module) -> BTreeMap<String, Vec<SidebarItem>> {
-        fn build_sidebar_items_inner(
-            name: Symbol,
-            type_: ItemType,
-            map: &mut BTreeMap<String, Vec<SidebarItem>>,
-            inserted: &mut FxHashMap<ItemType, FxHashSet<Symbol>>,
-            is_actually_macro: bool,
-        ) {
-            if inserted.entry(type_).or_default().insert(name) {
-                let type_ = type_.to_string();
-                let name = name.to_string();
-                map.entry(type_).or_default().push(SidebarItem { name, is_actually_macro });
-            }
-        }
         // BTreeMap instead of HashMap to get a sorted output
         let mut map: BTreeMap<_, Vec<_>> = BTreeMap::new();
         let mut inserted: FxHashMap<ItemType, FxHashSet<Symbol>> = FxHashMap::default();
@@ -360,12 +348,14 @@ impl<'tcx> Context<'tcx> {
                 Some(s) => s,
             };
 
-            if let Some(types) = item.bang_macro_types() {
-                for type_ in types {
-                    build_sidebar_items_inner(name, type_, &mut map, &mut inserted, true);
-                }
-            } else {
-                build_sidebar_items_inner(name, item.type_(), &mut map, &mut inserted, false);
+            let type_ = item.type_();
+
+            if inserted.entry(type_).or_default().insert(name) {
+                let type_ = type_.to_string();
+                let name = name.to_string();
+                map.entry(type_)
+                    .or_default()
+                    .push(SidebarItem { name, is_actually_macro: item.is_macro_placeholder() });
             }
         }
 
@@ -846,7 +836,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
 
         info!("Recursing into {}", self.dst.display());
 
-        if !item.is_stripped() {
+        if !item.is_stripped() && !item.is_macro_placeholder() {
             let buf = self.render_item(item, true);
             // buf will be empty if the module is stripped and there is no redirect for it
             if !buf.is_empty() {
@@ -902,26 +892,29 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             self.info.render_redirect_pages = item.is_stripped();
         }
 
+        if item.is_macro_placeholder() {
+            if !self.info.render_redirect_pages {
+                self.shared.all.borrow_mut().append(full_path(self, item), &item);
+            }
+            return Ok(());
+        }
+
         let buf = self.render_item(item, false);
         // buf will be empty if the item is stripped and there is no redirect for it
         if !buf.is_empty() {
-            let name = item.name.as_ref().unwrap();
-            let item_type = item.type_();
-            let file_name = print_item_path(item_type, name.as_str()).to_string();
+            if !self.info.render_redirect_pages {
+                self.shared.all.borrow_mut().append(full_path(self, item), &item);
+            }
+
+            let file_name = print_item_path(item).to_string();
             self.shared.ensure_dir(&self.dst)?;
             let joint_dst = self.dst.join(&file_name);
             self.shared.fs.write(joint_dst, buf)?;
-
-            if !self.info.render_redirect_pages {
-                self.shared.all.borrow_mut().append(
-                    full_path(self, item),
-                    &item_type,
-                    item.bang_macro_types(),
-                );
-            }
             // If the item is a macro, redirect from the old macro URL (with !)
             // to the new one (without).
+            let item_type = item.type_();
             if item_type == ItemType::Macro {
+                let name = item.name.as_ref().unwrap();
                 let redir_name = format!("{item_type}.{name}!.html");
                 if let Some(ref redirections) = self.shared.redirections {
                     let crate_name = &self.shared.layout.krate;

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -351,7 +351,7 @@ impl<'tcx> Context<'tcx> {
                 Some(s) => s,
             };
 
-            let is_macro_rules = item.is_macro_rules();
+            let is_macro_rules = item.is_bang_macro_or_macro_rules();
             for type_ in item.types() {
                 if inserted.entry(type_).or_default().insert(name) {
                     let type_ = type_.to_string();

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -351,7 +351,7 @@ impl<'tcx> Context<'tcx> {
                 Some(s) => s,
             };
 
-            let is_macro_rules = item.is_bang_macro_or_macro_rules();
+            let is_macro_rules = item.is_decl_macro();
             for type_ in item.types() {
                 if inserted.entry(type_).or_default().insert(name) {
                     let type_ = type_.to_string();

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -549,10 +549,12 @@ impl AllTypes {
                 ItemType::TypeAlias => self.type_aliases.insert(ItemEntry::new(new_url, name)),
                 ItemType::Static => self.statics.insert(ItemEntry::new(new_url, name)),
                 ItemType::Constant => self.constants.insert(ItemEntry::new(new_url, name)),
-                ItemType::ProcAttribute => {
+                ItemType::ProcAttribute | ItemType::BangMacroAttribute => {
                     self.attribute_macros.insert(ItemEntry::new(new_url, name))
                 }
-                ItemType::ProcDerive => self.derive_macros.insert(ItemEntry::new(new_url, name)),
+                ItemType::ProcDerive | ItemType::BangMacroDerive => {
+                    self.derive_macros.insert(ItemEntry::new(new_url, name))
+                }
                 ItemType::TraitAlias => self.trait_aliases.insert(ItemEntry::new(new_url, name)),
                 _ => true,
             };
@@ -2660,8 +2662,8 @@ fn item_ty_to_section(ty: ItemType) -> ItemSection {
         ItemType::ForeignType => ItemSection::ForeignTypes,
         ItemType::Keyword => ItemSection::Keywords,
         ItemType::Attribute => ItemSection::Attributes,
-        ItemType::ProcAttribute => ItemSection::AttributeMacros,
-        ItemType::ProcDerive => ItemSection::DeriveMacros,
+        ItemType::ProcAttribute | ItemType::BangMacroAttribute => ItemSection::AttributeMacros,
+        ItemType::ProcDerive | ItemType::BangMacroDerive => ItemSection::DeriveMacros,
         ItemType::TraitAlias => ItemSection::TraitAliases,
     }
 }

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -531,44 +531,32 @@ impl AllTypes {
         }
     }
 
-    fn append(
-        &mut self,
-        item_name: String,
-        item_type: &ItemType,
-        extra_types: Option<Vec<ItemType>>,
-    ) {
+    fn append(&mut self, item_name: String, item: &clean::Item) {
         let mut url: Vec<_> = item_name.split("::").skip(1).collect();
         if let Some(name) = url.pop() {
-            let new_url = format!("{}/{item_type}.{name}.html", url.join("/"));
+            let new_url = format!("{}/{}", url.join("/"), item.html_filename());
             url.push(name);
+            let item_type = item.type_();
             let name = url.join("::");
-            if let Some(extra_types) = extra_types {
-                for extra_type in extra_types {
-                    self.append_with_url(name.clone(), &extra_type, new_url.clone());
+            match item_type {
+                ItemType::Struct => self.structs.insert(ItemEntry::new(new_url, name)),
+                ItemType::Enum => self.enums.insert(ItemEntry::new(new_url, name)),
+                ItemType::Union => self.unions.insert(ItemEntry::new(new_url, name)),
+                ItemType::Primitive => self.primitives.insert(ItemEntry::new(new_url, name)),
+                ItemType::Trait => self.traits.insert(ItemEntry::new(new_url, name)),
+                ItemType::Macro => self.macros.insert(ItemEntry::new(new_url, name)),
+                ItemType::Function => self.functions.insert(ItemEntry::new(new_url, name)),
+                ItemType::TypeAlias => self.type_aliases.insert(ItemEntry::new(new_url, name)),
+                ItemType::Static => self.statics.insert(ItemEntry::new(new_url, name)),
+                ItemType::Constant => self.constants.insert(ItemEntry::new(new_url, name)),
+                ItemType::ProcAttribute => {
+                    self.attribute_macros.insert(ItemEntry::new(new_url, name))
                 }
-            } else {
-                self.append_with_url(name, item_type, new_url);
-            }
+                ItemType::ProcDerive => self.derive_macros.insert(ItemEntry::new(new_url, name)),
+                ItemType::TraitAlias => self.trait_aliases.insert(ItemEntry::new(new_url, name)),
+                _ => true,
+            };
         }
-    }
-
-    fn append_with_url(&mut self, name: String, item_type: &ItemType, url: String) {
-        match *item_type {
-            ItemType::Struct => self.structs.insert(ItemEntry::new(url, name)),
-            ItemType::Enum => self.enums.insert(ItemEntry::new(url, name)),
-            ItemType::Union => self.unions.insert(ItemEntry::new(url, name)),
-            ItemType::Primitive => self.primitives.insert(ItemEntry::new(url, name)),
-            ItemType::Trait => self.traits.insert(ItemEntry::new(url, name)),
-            ItemType::Macro => self.macros.insert(ItemEntry::new(url, name)),
-            ItemType::Function => self.functions.insert(ItemEntry::new(url, name)),
-            ItemType::TypeAlias => self.type_aliases.insert(ItemEntry::new(url, name)),
-            ItemType::Static => self.statics.insert(ItemEntry::new(url, name)),
-            ItemType::Constant => self.constants.insert(ItemEntry::new(url, name)),
-            ItemType::ProcAttribute => self.attribute_macros.insert(ItemEntry::new(url, name)),
-            ItemType::ProcDerive => self.derive_macros.insert(ItemEntry::new(url, name)),
-            ItemType::TraitAlias => self.trait_aliases.insert(ItemEntry::new(url, name)),
-            _ => true,
-        };
     }
 
     fn item_sections(&self) -> FxHashSet<ItemSection> {

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -543,10 +543,10 @@ impl AllTypes {
             ItemType::TypeAlias => self.type_aliases.insert(ItemEntry::new(new_url, name)),
             ItemType::Static => self.statics.insert(ItemEntry::new(new_url, name)),
             ItemType::Constant => self.constants.insert(ItemEntry::new(new_url, name)),
-            ItemType::ProcAttribute | ItemType::BangMacroAttribute => {
+            ItemType::ProcAttribute | ItemType::DeclMacroAttribute => {
                 self.attribute_macros.insert(ItemEntry::new(new_url, name))
             }
-            ItemType::ProcDerive | ItemType::BangMacroDerive => {
+            ItemType::ProcDerive | ItemType::DeclMacroDerive => {
                 self.derive_macros.insert(ItemEntry::new(new_url, name))
             }
             ItemType::TraitAlias => self.trait_aliases.insert(ItemEntry::new(new_url, name)),
@@ -2605,8 +2605,8 @@ impl ItemSection {
             Self::AssociatedConstants => "associated-consts",
             Self::ForeignTypes => "foreign-types",
             Self::Keywords => "keywords",
-            Self::Attributes => "attributes",
-            Self::AttributeMacros => "attribute-macros",
+            Self::Attributes => "attribute-docs",
+            Self::AttributeMacros => "attributes",
             Self::DeriveMacros => "derives",
             Self::TraitAliases => "trait-aliases",
         }
@@ -2667,8 +2667,8 @@ fn item_ty_to_section(ty: ItemType) -> ItemSection {
         ItemType::ForeignType => ItemSection::ForeignTypes,
         ItemType::Keyword => ItemSection::Keywords,
         ItemType::Attribute => ItemSection::Attributes,
-        ItemType::ProcAttribute | ItemType::BangMacroAttribute => ItemSection::AttributeMacros,
-        ItemType::ProcDerive | ItemType::BangMacroDerive => ItemSection::DeriveMacros,
+        ItemType::ProcAttribute | ItemType::DeclMacroAttribute => ItemSection::AttributeMacros,
+        ItemType::ProcDerive | ItemType::DeclMacroDerive => ItemSection::DeriveMacros,
         ItemType::TraitAlias => ItemSection::TraitAliases,
     }
 }

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -531,31 +531,44 @@ impl AllTypes {
         }
     }
 
-    fn append(&mut self, item_name: String, item_type: &ItemType) {
+    fn append(
+        &mut self,
+        item_name: String,
+        item_type: &ItemType,
+        extra_types: Option<Vec<ItemType>>,
+    ) {
         let mut url: Vec<_> = item_name.split("::").skip(1).collect();
         if let Some(name) = url.pop() {
             let new_url = format!("{}/{item_type}.{name}.html", url.join("/"));
             url.push(name);
             let name = url.join("::");
-            match *item_type {
-                ItemType::Struct => self.structs.insert(ItemEntry::new(new_url, name)),
-                ItemType::Enum => self.enums.insert(ItemEntry::new(new_url, name)),
-                ItemType::Union => self.unions.insert(ItemEntry::new(new_url, name)),
-                ItemType::Primitive => self.primitives.insert(ItemEntry::new(new_url, name)),
-                ItemType::Trait => self.traits.insert(ItemEntry::new(new_url, name)),
-                ItemType::Macro => self.macros.insert(ItemEntry::new(new_url, name)),
-                ItemType::Function => self.functions.insert(ItemEntry::new(new_url, name)),
-                ItemType::TypeAlias => self.type_aliases.insert(ItemEntry::new(new_url, name)),
-                ItemType::Static => self.statics.insert(ItemEntry::new(new_url, name)),
-                ItemType::Constant => self.constants.insert(ItemEntry::new(new_url, name)),
-                ItemType::ProcAttribute => {
-                    self.attribute_macros.insert(ItemEntry::new(new_url, name))
+            if let Some(extra_types) = extra_types {
+                for extra_type in extra_types {
+                    self.append_with_url(name.clone(), &extra_type, new_url.clone());
                 }
-                ItemType::ProcDerive => self.derive_macros.insert(ItemEntry::new(new_url, name)),
-                ItemType::TraitAlias => self.trait_aliases.insert(ItemEntry::new(new_url, name)),
-                _ => true,
-            };
+            } else {
+                self.append_with_url(name, item_type, new_url);
+            }
         }
+    }
+
+    fn append_with_url(&mut self, name: String, item_type: &ItemType, url: String) {
+        match *item_type {
+            ItemType::Struct => self.structs.insert(ItemEntry::new(url, name)),
+            ItemType::Enum => self.enums.insert(ItemEntry::new(url, name)),
+            ItemType::Union => self.unions.insert(ItemEntry::new(url, name)),
+            ItemType::Primitive => self.primitives.insert(ItemEntry::new(url, name)),
+            ItemType::Trait => self.traits.insert(ItemEntry::new(url, name)),
+            ItemType::Macro => self.macros.insert(ItemEntry::new(url, name)),
+            ItemType::Function => self.functions.insert(ItemEntry::new(url, name)),
+            ItemType::TypeAlias => self.type_aliases.insert(ItemEntry::new(url, name)),
+            ItemType::Static => self.statics.insert(ItemEntry::new(url, name)),
+            ItemType::Constant => self.constants.insert(ItemEntry::new(url, name)),
+            ItemType::ProcAttribute => self.attribute_macros.insert(ItemEntry::new(url, name)),
+            ItemType::ProcDerive => self.derive_macros.insert(ItemEntry::new(url, name)),
+            ItemType::TraitAlias => self.trait_aliases.insert(ItemEntry::new(url, name)),
+            _ => true,
+        };
     }
 
     fn item_sections(&self) -> FxHashSet<ItemSection> {

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -560,13 +560,8 @@ impl AllTypes {
             let new_url = format!("{}/{}", url.join("/"), item.html_filename());
             url.push(name);
             let name = url.join("::");
-            let mut types = item.types();
-            if types.len() == 1 {
-                self.add_item_entry(types.pop().unwrap(), new_url, name);
-            } else {
-                for type_ in types {
-                    self.add_item_entry(type_, new_url.clone(), name.clone());
-                }
+            for type_ in item.types() {
+                self.add_item_entry(type_, new_url.clone(), name.clone());
             }
         }
     }

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -125,7 +125,7 @@ enum RenderMode {
 // Helper structs for rendering items/sidebars and carrying along contextual
 // information
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct IndexItemInfo {
     pub(crate) ty: ItemType,
     pub(crate) desc: String,
@@ -142,8 +142,8 @@ impl IndexItemInfo {
         item: &Item,
         parent_did: Option<DefId>,
         impl_generics: Option<&(clean::Type, clean::Generics)>,
+        ty: ItemType,
     ) -> Self {
-        let ty = item.type_();
         let desc = short_markdown_summary(&item.doc_value(), &item.link_names(cache));
         let search_type = get_function_type_for_search(item, tcx, impl_generics, parent_did, cache);
         let aliases = item.attrs.get_doc_aliases();
@@ -155,7 +155,7 @@ impl IndexItemInfo {
 
 /// Struct representing one entry in the JS search index. These are all emitted
 /// by hand to a large JS file at the end of cache-creation.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct IndexItem {
     pub(crate) defid: Option<DefId>,
     pub(crate) name: Symbol,
@@ -531,33 +531,43 @@ impl AllTypes {
         }
     }
 
+    fn add_item_entry(&mut self, item_type: ItemType, new_url: String, name: String) {
+        match item_type {
+            ItemType::Struct => self.structs.insert(ItemEntry::new(new_url, name)),
+            ItemType::Enum => self.enums.insert(ItemEntry::new(new_url, name)),
+            ItemType::Union => self.unions.insert(ItemEntry::new(new_url, name)),
+            ItemType::Primitive => self.primitives.insert(ItemEntry::new(new_url, name)),
+            ItemType::Trait => self.traits.insert(ItemEntry::new(new_url, name)),
+            ItemType::Macro => self.macros.insert(ItemEntry::new(new_url, name)),
+            ItemType::Function => self.functions.insert(ItemEntry::new(new_url, name)),
+            ItemType::TypeAlias => self.type_aliases.insert(ItemEntry::new(new_url, name)),
+            ItemType::Static => self.statics.insert(ItemEntry::new(new_url, name)),
+            ItemType::Constant => self.constants.insert(ItemEntry::new(new_url, name)),
+            ItemType::ProcAttribute | ItemType::BangMacroAttribute => {
+                self.attribute_macros.insert(ItemEntry::new(new_url, name))
+            }
+            ItemType::ProcDerive | ItemType::BangMacroDerive => {
+                self.derive_macros.insert(ItemEntry::new(new_url, name))
+            }
+            ItemType::TraitAlias => self.trait_aliases.insert(ItemEntry::new(new_url, name)),
+            _ => true,
+        };
+    }
+
     fn append(&mut self, item_name: String, item: &clean::Item) {
         let mut url: Vec<_> = item_name.split("::").skip(1).collect();
         if let Some(name) = url.pop() {
             let new_url = format!("{}/{}", url.join("/"), item.html_filename());
             url.push(name);
-            let item_type = item.type_();
             let name = url.join("::");
-            match item_type {
-                ItemType::Struct => self.structs.insert(ItemEntry::new(new_url, name)),
-                ItemType::Enum => self.enums.insert(ItemEntry::new(new_url, name)),
-                ItemType::Union => self.unions.insert(ItemEntry::new(new_url, name)),
-                ItemType::Primitive => self.primitives.insert(ItemEntry::new(new_url, name)),
-                ItemType::Trait => self.traits.insert(ItemEntry::new(new_url, name)),
-                ItemType::Macro => self.macros.insert(ItemEntry::new(new_url, name)),
-                ItemType::Function => self.functions.insert(ItemEntry::new(new_url, name)),
-                ItemType::TypeAlias => self.type_aliases.insert(ItemEntry::new(new_url, name)),
-                ItemType::Static => self.statics.insert(ItemEntry::new(new_url, name)),
-                ItemType::Constant => self.constants.insert(ItemEntry::new(new_url, name)),
-                ItemType::ProcAttribute | ItemType::BangMacroAttribute => {
-                    self.attribute_macros.insert(ItemEntry::new(new_url, name))
+            let mut types = item.types();
+            if types.len() == 1 {
+                self.add_item_entry(types.pop().unwrap(), new_url, name);
+            } else {
+                for type_ in types {
+                    self.add_item_entry(type_, new_url.clone(), name.clone());
                 }
-                ItemType::ProcDerive | ItemType::BangMacroDerive => {
-                    self.derive_macros.insert(ItemEntry::new(new_url, name))
-                }
-                ItemType::TraitAlias => self.trait_aliases.insert(ItemEntry::new(new_url, name)),
-                _ => true,
-            };
+            }
         }
     }
 

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2599,7 +2599,7 @@ impl ItemSection {
             Self::ForeignTypes => "foreign-types",
             Self::Keywords => "keywords",
             Self::Attributes => "attributes",
-            Self::AttributeMacros => "attributes",
+            Self::AttributeMacros => "attribute-macros",
             Self::DeriveMacros => "derives",
             Self::TraitAliases => "trait-aliases",
         }

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -233,18 +233,14 @@ fn item_module(cx: &Context<'_>, item: &clean::Item, items: &[clean::Item]) -> i
         for (index, item) in items.iter().filter(|i| !i.is_stripped()).enumerate() {
             // To prevent having new "bang macro attribute/derive" sections in the module,
             // we cheat by turning them into their "proc-macro equivalent".
-            if let clean::ItemKind::MacroItem(_, kinds) = &item.kind
-                && !kinds.contains(MacroKinds::BANG)
-            {
-                // This is a placeholder, no need to list it in the module items.
-                continue;
+            for type_ in item.types() {
+                let type_ = match type_ {
+                    ItemType::BangMacroAttribute => ItemType::ProcAttribute,
+                    ItemType::BangMacroDerive => ItemType::ProcDerive,
+                    type_ => type_,
+                };
+                not_stripped_items.entry(type_).or_default().push((index, item));
             }
-            let type_ = match item.type_() {
-                ItemType::BangMacroAttribute => ItemType::ProcAttribute,
-                ItemType::BangMacroDerive => ItemType::ProcDerive,
-                type_ => type_,
-            };
-            not_stripped_items.entry(type_).or_default().push((index, item));
         }
 
         // the order of item types in the listing

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -233,6 +233,12 @@ fn item_module(cx: &Context<'_>, item: &clean::Item, items: &[clean::Item]) -> i
         for (index, item) in items.iter().filter(|i| !i.is_stripped()).enumerate() {
             // To prevent having new "bang macro attribute/derive" sections in the module,
             // we cheat by turning them into their "proc-macro equivalent".
+            if let clean::ItemKind::MacroItem(_, kinds) = &item.kind
+                && !kinds.contains(MacroKinds::BANG)
+            {
+                // This is a placeholder, no need to list it in the module items.
+                continue;
+            }
             let type_ = match item.type_() {
                 ItemType::BangMacroAttribute => ItemType::ProcAttribute,
                 ItemType::BangMacroDerive => ItemType::ProcDerive,

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -231,7 +231,14 @@ fn item_module(cx: &Context<'_>, item: &clean::Item, items: &[clean::Item]) -> i
             FxIndexMap::default();
 
         for (index, item) in items.iter().filter(|i| !i.is_stripped()).enumerate() {
-            not_stripped_items.entry(item.type_()).or_default().push((index, item));
+            // To prevent having new "bang macro attribute/derive" sections in the module,
+            // we cheat by turning them into their "proc-macro equivalent".
+            let type_ = match item.type_() {
+                ItemType::BangMacroAttribute => ItemType::ProcAttribute,
+                ItemType::BangMacroDerive => ItemType::ProcDerive,
+                type_ => type_,
+            };
+            not_stripped_items.entry(type_).or_default().push((index, item));
         }
 
         // the order of item types in the listing

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -230,17 +230,8 @@ fn item_module(cx: &Context<'_>, item: &clean::Item, items: &[clean::Item]) -> i
         let mut not_stripped_items: FxIndexMap<ItemType, Vec<(usize, &clean::Item)>> =
             FxIndexMap::default();
 
-        let mut index = 0;
-        for item in items.iter().filter(|i| !i.is_stripped()) {
-            if let Some(types) = item.bang_macro_types() {
-                for type_ in types {
-                    not_stripped_items.entry(type_).or_default().push((index, item));
-                    index += 1;
-                }
-            } else {
-                not_stripped_items.entry(item.type_()).or_default().push((index, item));
-                index += 1;
-            }
+        for (index, item) in items.iter().filter(|i| !i.is_stripped()).enumerate() {
+            not_stripped_items.entry(item.type_()).or_default().push((index, item));
         }
 
         // the order of item types in the listing
@@ -480,7 +471,7 @@ fn item_module(cx: &Context<'_>, item: &clean::Item, items: &[clean::Item]) -> i
                             stab_tags = print_extra_info_tags(tcx, myitem, item, None),
                             class = type_,
                             unsafety_flag = unsafety_flag,
-                            href = print_item_path(type_, item_name.as_str()),
+                            href = print_item_path(myitem),
                             title1 = myitem.type_(),
                             title2 = full_path(cx, myitem),
                         )?;
@@ -2297,7 +2288,16 @@ pub(super) fn full_path(cx: &Context<'_>, item: &clean::Item) -> String {
     s
 }
 
-pub(super) fn print_item_path(ty: ItemType, name: &str) -> impl Display {
+pub(super) fn print_item_path(item: &clean::Item) -> impl Display {
+    fmt::from_fn(move |f| match item.kind {
+        clean::ItemKind::ModuleItem(..) => {
+            write!(f, "{}index.html", ensure_trailing_slash(item.name.unwrap().as_str()))
+        }
+        _ => f.write_str(&item.html_filename()),
+    })
+}
+
+pub(super) fn print_ty_path(ty: ItemType, name: &str) -> impl Display {
     fmt::from_fn(move |f| match ty {
         ItemType::Module => write!(f, "{}index.html", ensure_trailing_slash(name)),
         _ => write!(f, "{ty}.{name}.html"),

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -7,7 +7,7 @@ use rustc_abi::VariantIdx;
 use rustc_ast::join_path_syms;
 use rustc_data_structures::fx::{FxHashMap, FxIndexMap, FxIndexSet};
 use rustc_hir as hir;
-use rustc_hir::def::CtorKind;
+use rustc_hir::def::{CtorKind, MacroKinds};
 use rustc_hir::def_id::DefId;
 use rustc_index::IndexVec;
 use rustc_middle::ty::{self, TyCtxt};
@@ -129,6 +129,9 @@ pub(super) fn print_item(cx: &Context<'_>, item: &clean::Item) -> impl fmt::Disp
         let item_vars = ItemVars {
             typ,
             name: item.name.as_ref().unwrap().as_str(),
+            // If `type_` returns `None`, it means it's a bang macro with multiple kinds, but
+            // since we're generating its documentation page, we can default to the "parent" type,
+            // ie "bang macro".
             item_type: &item.type_().to_string(),
             path_components,
             stability_since_raw: &stability_since_raw,
@@ -153,7 +156,7 @@ pub(super) fn print_item(cx: &Context<'_>, item: &clean::Item) -> impl fmt::Disp
             clean::TypeAliasItem(t) => {
                 write!(buf, "{}", item_type_alias(cx, item, t))
             }
-            clean::MacroItem(m) => write!(buf, "{}", item_macro(cx, item, m)),
+            clean::MacroItem(m, kinds) => write!(buf, "{}", item_macro(cx, item, m, *kinds)),
             clean::ProcMacroItem(m) => {
                 write!(buf, "{}", item_proc_macro(cx, item, m))
             }
@@ -227,8 +230,17 @@ fn item_module(cx: &Context<'_>, item: &clean::Item, items: &[clean::Item]) -> i
         let mut not_stripped_items: FxIndexMap<ItemType, Vec<(usize, &clean::Item)>> =
             FxIndexMap::default();
 
-        for (index, item) in items.iter().filter(|i| !i.is_stripped()).enumerate() {
-            not_stripped_items.entry(item.type_()).or_default().push((index, item));
+        let mut index = 0;
+        for item in items.iter().filter(|i| !i.is_stripped()) {
+            if let Some(types) = item.bang_macro_types() {
+                for type_ in types {
+                    not_stripped_items.entry(type_).or_default().push((index, item));
+                    index += 1;
+                }
+            } else {
+                not_stripped_items.entry(item.type_()).or_default().push((index, item));
+                index += 1;
+            }
         }
 
         // the order of item types in the listing
@@ -1888,8 +1900,13 @@ fn item_variants(
     })
 }
 
-fn item_macro(cx: &Context<'_>, it: &clean::Item, t: &clean::Macro) -> impl fmt::Display {
-    fmt::from_fn(|w| {
+fn item_macro(
+    cx: &Context<'_>,
+    it: &clean::Item,
+    t: &clean::Macro,
+    kinds: Option<MacroKinds>,
+) -> impl fmt::Display {
+    fmt::from_fn(move |w| {
         wrap_item(w, |w| {
             render_attributes_in_code(w, it, "", cx)?;
             if !t.macro_rules {
@@ -1897,6 +1914,14 @@ fn item_macro(cx: &Context<'_>, it: &clean::Item, t: &clean::Macro) -> impl fmt:
             }
             write!(w, "{}", Escape(&t.source))
         })?;
+        if let Some(kinds) = kinds {
+            write!(
+                w,
+                "<h3 class='macro-info'>ⓘ This is {} {}</h3>",
+                kinds.article(),
+                kinds.descr(),
+            )?;
+        }
         write!(w, "{}", document(cx, it, None, HeadingOffset::H2))
     })
 }

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -129,9 +129,9 @@ pub(super) fn print_item(cx: &Context<'_>, item: &clean::Item) -> impl fmt::Disp
         let item_vars = ItemVars {
             typ,
             name: item.name.as_ref().unwrap().as_str(),
-            // If `type_` returns `None`, it means it's a bang macro with multiple kinds, but
+            // It's fine to use `type_` here because, even if it's a bang macro with multiple kinds,
             // since we're generating its documentation page, we can default to the "parent" type,
-            // ie "bang macro".
+            // ie "macro".
             item_type: &item.type_().to_string(),
             path_components,
             stability_since_raw: &stability_since_raw,

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -317,34 +317,18 @@ fn item_module(cx: &Context<'_>, item: &clean::Item, items: &[clean::Item]) -> i
         let mut types = not_stripped_items.keys().copied().collect::<Vec<_>>();
         types.sort_unstable_by(|a, b| reorder(*a).cmp(&reorder(*b)));
 
-        let mut last_section: Option<super::ItemSection> = None;
-
         for type_ in types {
             let my_section = item_ty_to_section(type_);
-
-            // Only render section heading if the section changed
-            if last_section != Some(my_section) {
-                // Close the previous section if there was one
-                if last_section.is_some() {
-                    w.write_str(ITEM_TABLE_CLOSE)?;
-                }
-                let tag = if my_section == super::ItemSection::Reexports {
-                    REEXPORTS_TABLE_OPEN
-                } else {
-                    ITEM_TABLE_OPEN
-                };
-                write!(
-                    w,
-                    "{}",
-                    write_section_heading(
-                        my_section.name(),
-                        &cx.derive_id(my_section.id()),
-                        None,
-                        tag
-                    )
-                )?;
-                last_section = Some(my_section);
-            }
+            let tag = if my_section == super::ItemSection::Reexports {
+                REEXPORTS_TABLE_OPEN
+            } else {
+                ITEM_TABLE_OPEN
+            };
+            write!(
+                w,
+                "{}",
+                write_section_heading(my_section.name(), &cx.derive_id(my_section.id()), None, tag)
+            )?;
 
             for (_, myitem) in &not_stripped_items[&type_] {
                 let visibility_and_hidden = |item: &clean::Item| match item.visibility(tcx) {
@@ -478,9 +462,6 @@ fn item_module(cx: &Context<'_>, item: &clean::Item, items: &[clean::Item]) -> i
                     }
                 }
             }
-        }
-        // Close the final section
-        if last_section.is_some() {
             w.write_str(ITEM_TABLE_CLOSE)?;
         }
 
@@ -1895,7 +1876,7 @@ fn item_macro(
     cx: &Context<'_>,
     it: &clean::Item,
     t: &clean::Macro,
-    kinds: Option<MacroKinds>,
+    kinds: MacroKinds,
 ) -> impl fmt::Display {
     fmt::from_fn(move |w| {
         wrap_item(w, |w| {
@@ -1905,7 +1886,7 @@ fn item_macro(
             }
             write!(w, "{}", Escape(&t.source))
         })?;
-        if let Some(kinds) = kinds {
+        if kinds != MacroKinds::BANG {
             write!(
                 w,
                 "<h3 class='macro-info'>ⓘ This is {} {}</h3>",

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -129,9 +129,8 @@ pub(super) fn print_item(cx: &Context<'_>, item: &clean::Item) -> impl fmt::Disp
         let item_vars = ItemVars {
             typ,
             name: item.name.as_ref().unwrap().as_str(),
-            // It's fine to use `type_` here because, even if it's a bang macro with multiple kinds,
-            // since we're generating its documentation page, we can default to the "parent" type,
-            // ie "macro".
+            // It's fine to use `type_` here because, even if it's a decl macro with multiple kinds,
+            // since we're generating its documentation page, we can default to the macro type.
             item_type: &item.type_().to_string(),
             path_components,
             stability_since_raw: &stability_since_raw,
@@ -231,7 +230,7 @@ fn item_module(cx: &Context<'_>, item: &clean::Item, items: &[clean::Item]) -> i
             FxIndexMap::default();
 
         for (index, item) in items.iter().filter(|i| !i.is_stripped()).enumerate() {
-            // To prevent having new "bang macro attribute/derive" sections in the module,
+            // To prevent having new "decl macro attribute/derive" sections in the module,
             // we cheat by turning them into their "proc-macro equivalent".
             for type_ in item.types() {
                 let type_ = match type_ {

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -235,8 +235,8 @@ fn item_module(cx: &Context<'_>, item: &clean::Item, items: &[clean::Item]) -> i
             // we cheat by turning them into their "proc-macro equivalent".
             for type_ in item.types() {
                 let type_ = match type_ {
-                    ItemType::BangMacroAttribute => ItemType::ProcAttribute,
-                    ItemType::BangMacroDerive => ItemType::ProcDerive,
+                    ItemType::DeclMacroAttribute => ItemType::ProcAttribute,
+                    ItemType::DeclMacroDerive => ItemType::ProcDerive,
                     type_ => type_,
                 };
                 not_stripped_items.entry(type_).or_default().push((index, item));

--- a/src/librustdoc/html/render/search_index.rs
+++ b/src/librustdoc/html/render/search_index.rs
@@ -1272,7 +1272,14 @@ pub(crate) fn build_index(
         &cache.orphan_impl_items
     {
         if let Some((fqp, _)) = cache.paths.get(&parent) {
-            let info = IndexItemInfo::new(tcx, cache, item, Some(parent), impl_generics.as_ref());
+            let info = IndexItemInfo::new(
+                tcx,
+                cache,
+                item,
+                Some(parent),
+                impl_generics.as_ref(),
+                item.type_(),
+            );
             search_index.push(IndexItem {
                 defid: item.item_id.as_def_id(),
                 name: item.name.unwrap(),

--- a/src/librustdoc/html/render/sidebar.rs
+++ b/src/librustdoc/html/render/sidebar.rs
@@ -676,7 +676,13 @@ fn sidebar_module(
                     })
                     .is_some()
         })
-        .map(|it| item_ty_to_section(it.type_()))
+        .flat_map(|it| {
+            if let Some(types) = it.bang_macro_types() {
+                types.into_iter().map(|type_| item_ty_to_section(type_)).collect::<Vec<_>>()
+            } else {
+                vec![item_ty_to_section(it.type_())]
+            }
+        })
         .collect();
 
     sidebar_module_like(item_sections_in_use, ids, module_like)

--- a/src/librustdoc/html/render/sidebar.rs
+++ b/src/librustdoc/html/render/sidebar.rs
@@ -659,25 +659,27 @@ fn sidebar_module(
     ids: &mut IdMap,
     module_like: ModuleLike,
 ) -> LinkBlock<'static> {
-    let item_sections_in_use: FxHashSet<_> = items
-        .iter()
-        .filter(|it| {
-            !it.is_stripped()
-                && it
-                    .name
-                    .or_else(|| {
-                        if let clean::ImportItem(ref i) = it.kind
-                            && let clean::ImportKind::Simple(s) = i.kind
-                        {
-                            Some(s)
-                        } else {
-                            None
-                        }
-                    })
-                    .is_some()
-        })
-        .map(|it| item_ty_to_section(it.type_()))
-        .collect();
+    let mut item_sections_in_use: FxHashSet<_> = Default::default();
+
+    for item in items.iter().filter(|it| {
+        !it.is_stripped()
+            && it
+                .name
+                .or_else(|| {
+                    if let clean::ImportItem(ref i) = it.kind
+                        && let clean::ImportKind::Simple(s) = i.kind
+                    {
+                        Some(s)
+                    } else {
+                        None
+                    }
+                })
+                .is_some()
+    }) {
+        for type_ in item.types() {
+            item_sections_in_use.insert(item_ty_to_section(type_));
+        }
+    }
 
     sidebar_module_like(item_sections_in_use, ids, module_like)
 }

--- a/src/librustdoc/html/render/sidebar.rs
+++ b/src/librustdoc/html/render/sidebar.rs
@@ -676,13 +676,7 @@ fn sidebar_module(
                     })
                     .is_some()
         })
-        .flat_map(|it| {
-            if let Some(types) = it.bang_macro_types() {
-                types.into_iter().map(|type_| item_ty_to_section(type_)).collect::<Vec<_>>()
-            } else {
-                vec![item_ty_to_section(it.type_())]
-            }
-        })
+        .map(|it| item_ty_to_section(it.type_()))
         .collect();
 
     sidebar_module_like(item_sections_in_use, ids, module_like)

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -794,7 +794,7 @@ function preLoadCss(cssUrl) {
             block("foreigntype", "foreign-types", "Foreign Types");
             block("keyword", "keywords", "Keywords");
             block("attribute", "attributes", "Attributes");
-            block("attr", "attributes", "Attribute Macros");
+            block("attr", "attribute-macros", "Attribute Macros");
             block("derive", "derives", "Derive Macros");
             block("traitalias", "trait-aliases", "Trait Aliases");
         }

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -731,12 +731,20 @@ function preLoadCss(cssUrl) {
             const ul = document.createElement("ul");
             ul.className = "block " + shortty;
 
-            for (const name of filtered) {
+            for (const item of filtered) {
+                let name = item;
+                let isMacro = false;
+                if (Array.isArray(item)) {
+                    name = item[0];
+                    isMacro = true;
+                }
                 let path;
                 if (shortty === "mod") {
                     path = `${modpath}${name}/index.html`;
-                } else {
+                } else if (!isMacro) {
                     path = `${modpath}${shortty}.${name}.html`;
+                } else {
+                    path = `${modpath}macro.${name}.html`;
                 }
                 let current_page = document.location.href.toString();
                 if (current_page.endsWith("/")) {

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -793,8 +793,8 @@ function preLoadCss(cssUrl) {
             //block("associatedconstant", "associated-consts", "Associated Constants");
             block("foreigntype", "foreign-types", "Foreign Types");
             block("keyword", "keywords", "Keywords");
-            block("attribute", "attributes", "Attributes");
-            block("attr", "attribute-macros", "Attribute Macros");
+            block("attribute", "attribute-docs", "Attributes");
+            block("attr", "attributes", "Attribute Macros");
             block("derive", "derives", "Derive Macros");
             block("traitalias", "trait-aliases", "Trait Aliases");
         }

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -732,12 +732,7 @@ function preLoadCss(cssUrl) {
             ul.className = "block " + shortty;
 
             for (const item of filtered) {
-                let name = item;
-                let isMacro = false;
-                if (Array.isArray(item)) {
-                    name = item[0];
-                    isMacro = true;
-                }
+                const [name, isMacro] = Array.isArray(item) ? [item[0], true] : [item, false];
                 let path;
                 if (shortty === "mod") {
                     path = `${modpath}${name}/index.html`;

--- a/src/librustdoc/html/static/js/rustdoc.d.ts
+++ b/src/librustdoc/html/static/js/rustdoc.d.ts
@@ -245,6 +245,27 @@ declare namespace rustdoc {
         deprecated: boolean,
         unstable: boolean,
         associatedItemDisambiguatorOrExternCrateUrl: string?,
+        /**
+         * If `true`, this item is a `macro_rules!` macro that supports
+         * multiple usage syntaxes, as described in RFC 3697 and 3698.
+         * The syntax for such a macro looks like this:
+         *
+         * ```rust
+         * /// Doc Comment.
+         * macro_rules! NAME {
+         *     attr(key = $value:literal) ($attached:item) => { ... };
+         *     derive() ($attached:item) => { ... };
+         *     ($bang:tt) => { ... };
+         *  }
+         * ```
+         *
+         * Each usage syntax gets a separate EntryData---one for the attr,
+         * one for the derive, and one for the bang syntax---with a corresponding
+         * `ty` field that can be used for filtering and presenting results.
+         * But the documentation lives in a single `macro.NAME.html` page, and
+         * this boolean flag is used for generating that HREF.
+         */
+        isBangMacro: boolean,
     }
 
     /**
@@ -302,7 +323,7 @@ declare namespace rustdoc {
 
     type ItemType = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 |
         11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 |
-        21 | 22 | 23 | 24 | 25 | 26;
+        21 | 22 | 23 | 24 | 25 | 26 | 28 | 29;
 
     /**
      * The viewmodel for the search engine results page.

--- a/src/librustdoc/html/static/js/rustdoc.d.ts
+++ b/src/librustdoc/html/static/js/rustdoc.d.ts
@@ -265,7 +265,7 @@ declare namespace rustdoc {
          * But the documentation lives in a single `macro.NAME.html` page, and
          * this boolean flag is used for generating that HREF.
          */
-        isBangMacro: boolean,
+        forceMacroHref: boolean,
     }
 
     /**

--- a/src/librustdoc/html/static/js/rustdoc.d.ts
+++ b/src/librustdoc/html/static/js/rustdoc.d.ts
@@ -27,7 +27,7 @@ declare global {
         /** Make the current theme easy to find */
         currentTheme: HTMLLinkElement|null;
         /** Generated in `render/context.rs` */
-        SIDEBAR_ITEMS?: { [key: string]: string[] };
+        SIDEBAR_ITEMS?: { [key: string]: Array<string | string[]> };
         /** Notable trait data */
         NOTABLE_TRAITS?: { [key: string]: string };
         CURRENT_TOOLTIP_ELEMENT?: HTMLElement & { TOOLTIP_BASE: HTMLElement };

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -1648,7 +1648,7 @@ class DocSearch {
          * ], [string]>}
          */
         const raw = JSON.parse(encoded);
-        return {
+        const item = {
             krate: raw[0],
             ty: raw[1],
             modulePath: raw[2] === 0 ? null : raw[2] - 1,
@@ -1658,7 +1658,15 @@ class DocSearch {
             deprecated: raw[6] === 1 ? true : false,
             unstable: raw[7] === 1 ? true : false,
             associatedItemDisambiguatorOrExternCrateUrl: raw.length === 8 ? null : raw[8],
+            isBangMacro: false,
         };
+        if (item.ty === 28 || item.ty === 29) {
+            // "proc attribute" is 23, "proc derive" is 24 whereas "bang macro attribute" is 28 and
+            // "bang macro derive" is 29, so 5 of difference to go from the latter to the former.
+            item.ty -= 5;
+            item.isBangMacro = true;
+        }
+        return item;
     }
 
     /**
@@ -2156,7 +2164,7 @@ class DocSearch {
             let displayPath;
             let href;
             let traitPath = null;
-            const type = itemTypesName[item.ty];
+            const type = item.entry && item.entry.isBangMacro ? "macro" : itemTypesName[item.ty];
             const name = item.name;
             let path = item.modulePath;
             let exactPath = item.exactModulePath;
@@ -3972,7 +3980,7 @@ class DocSearch {
                  * @param {Promise<rustdoc.PlainResultObject|null>[]} data
                  * @returns {AsyncGenerator<rustdoc.ResultObject, boolean>}
                  */
-                const flush = async function* (data) {
+                const flush = async function*(data) {
                     const satr = sortAndTransformResults(
                         await Promise.all(data),
                         null,

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -1661,8 +1661,8 @@ class DocSearch {
             forceMacroHref: false,
         };
         if (item.ty === 28 || item.ty === 29) {
-            // "proc attribute" is 23, "proc derive" is 24 whereas "bang macro attribute" is 28 and
-            // "bang macro derive" is 29, so 5 of difference to go from the latter to the former.
+            // "proc attribute" is 23, "proc derive" is 24 whereas "decl macro attribute" is 28 and
+            // "decl macro derive" is 29, so 5 of difference to go from the latter to the former.
             item.ty -= 5;
             item.forceMacroHref = true;
         }

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -1658,13 +1658,13 @@ class DocSearch {
             deprecated: raw[6] === 1 ? true : false,
             unstable: raw[7] === 1 ? true : false,
             associatedItemDisambiguatorOrExternCrateUrl: raw.length === 8 ? null : raw[8],
-            isBangMacro: false,
+            forceMacroHref: false,
         };
         if (item.ty === 28 || item.ty === 29) {
             // "proc attribute" is 23, "proc derive" is 24 whereas "bang macro attribute" is 28 and
             // "bang macro derive" is 29, so 5 of difference to go from the latter to the former.
             item.ty -= 5;
-            item.isBangMacro = true;
+            item.forceMacroHref = true;
         }
         return item;
     }
@@ -2164,7 +2164,7 @@ class DocSearch {
             let displayPath;
             let href;
             let traitPath = null;
-            const type = item.entry && item.entry.isBangMacro ? "macro" : itemTypesName[item.ty];
+            const type = item.entry && item.entry.forceMacroHref ? "macro" : itemTypesName[item.ty];
             const name = item.name;
             let path = item.modulePath;
             let exactPath = item.exactModulePath;

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -120,6 +120,8 @@ const itemTypes = Object.freeze({
     traitalias: 25,
     generic: 26,
     attribute: 27,
+    decl_macro_attribute: 28,
+    decl_macro_derive: 29,
 });
 const itemTypesName = Array.from(Object.keys(itemTypes));
 
@@ -1660,7 +1662,7 @@ class DocSearch {
             associatedItemDisambiguatorOrExternCrateUrl: raw.length === 8 ? null : raw[8],
             forceMacroHref: false,
         };
-        if (item.ty === 28 || item.ty === 29) {
+        if (item.ty === itemTypes.decl_macro_attribute || item.ty === itemTypes.decl_macro_derive) {
             // "proc attribute" is 23, "proc derive" is 24 whereas "decl macro attribute" is 28 and
             // "decl macro derive" is 29, so 5 of difference to go from the latter to the former.
             item.ty -= 5;
@@ -4823,6 +4825,8 @@ const longItemTypes = [
     "trait alias",
     "",
     "attribute",
+    "", // decl macro attribute, never used as is
+    "", // decl macro derive, never used as is
 ];
 // @ts-expect-error
 let currentResults;

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -309,7 +309,7 @@ fn from_clean_item(item: &clean::Item, renderer: &JsonRenderer<'_>) -> ItemEnum 
             type_: ci.type_.into_json(renderer),
             const_: ci.kind.into_json(renderer),
         },
-        MacroItem(m) => ItemEnum::Macro(m.source.clone()),
+        MacroItem(m, _) => ItemEnum::Macro(m.source.clone()),
         ProcMacroItem(m) => ItemEnum::ProcMacro(m.into_json(renderer)),
         PrimitiveItem(p) => {
             ItemEnum::Primitive(Primitive {

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -53,7 +53,12 @@ impl JsonRenderer<'_> {
         let clean::ItemInner { name, item_id, .. } = *item.inner;
         let id = self.id_from_item(item);
         let inner = match item.kind {
-            clean::KeywordItem | clean::AttributeItem => return None,
+            clean::KeywordItem
+            | clean::AttributeItem
+            // Placeholder so no need to handle it.
+            | clean::AttrMacroItem
+            // Placeholder so no need to handle it.
+            | clean::DeriveMacroItem => return None,
             clean::StrippedItem(ref inner) => {
                 match &**inner {
                     // We document stripped modules as with `Module::is_stripped` set to
@@ -62,12 +67,12 @@ impl JsonRenderer<'_> {
                     clean::ModuleItem(_)
                         if self.imported_items.contains(&item_id.expect_def_id()) =>
                     {
-                        from_clean_item(item, self)?
+                        from_clean_item(item, self)
                     }
                     _ => return None,
                 }
             }
-            _ => from_clean_item(item, self)?,
+            _ => from_clean_item(item, self),
         };
         Some(Item {
             id,
@@ -269,13 +274,13 @@ impl FromClean<clean::AssocItemConstraintKind> for AssocItemConstraintKind {
     }
 }
 
-fn from_clean_item(item: &clean::Item, renderer: &JsonRenderer<'_>) -> Option<ItemEnum> {
+fn from_clean_item(item: &clean::Item, renderer: &JsonRenderer<'_>) -> ItemEnum {
     use clean::ItemKind::*;
     let name = item.name;
     let is_crate = item.is_crate();
     let header = item.fn_header(renderer.tcx);
 
-    Some(match &item.inner.kind {
+    match &item.inner.kind {
         ModuleItem(m) => {
             ItemEnum::Module(Module { is_crate, items: renderer.ids(&m.items), is_stripped: false })
         }
@@ -310,8 +315,6 @@ fn from_clean_item(item: &clean::Item, renderer: &JsonRenderer<'_>) -> Option<It
             const_: ci.kind.into_json(renderer),
         },
         MacroItem(m, _) => ItemEnum::Macro(m.source.clone()),
-        // They are just placeholders so no need to handle them.
-        AttrMacroItem | DeriveMacroItem => return None,
         ProcMacroItem(m) => ItemEnum::ProcMacro(m.into_json(renderer)),
         PrimitiveItem(p) => {
             ItemEnum::Primitive(Primitive {
@@ -338,8 +341,9 @@ fn from_clean_item(item: &clean::Item, renderer: &JsonRenderer<'_>) -> Option<It
             bounds: b.into_json(renderer),
             type_: Some(t.item_type.as_ref().unwrap_or(&t.type_).into_json(renderer)),
         },
-        // `convert_item` early returns `None` for stripped items, keywords and attributes.
-        KeywordItem | AttributeItem => unreachable!(),
+        // `convert_item` early returns `None` for stripped items, keywords, attributes and
+        // "special" macro rules.
+        KeywordItem | AttributeItem | AttrMacroItem | DeriveMacroItem => unreachable!(),
         StrippedItem(inner) => {
             match inner.as_ref() {
                 ModuleItem(m) => ItemEnum::Module(Module {
@@ -357,7 +361,7 @@ fn from_clean_item(item: &clean::Item, renderer: &JsonRenderer<'_>) -> Option<It
         },
         // All placeholder impl items should have been removed in the stripper passes.
         PlaceholderImplItem => unreachable!(),
-    })
+    }
 }
 
 impl FromClean<clean::Struct> for Struct {

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -904,8 +904,8 @@ impl FromClean<ItemType> for ItemKind {
             Keyword => ItemKind::Keyword,
             Attribute => ItemKind::Attribute,
             TraitAlias => ItemKind::TraitAlias,
-            ProcAttribute => ItemKind::ProcAttribute,
-            ProcDerive => ItemKind::ProcDerive,
+            ProcAttribute | BangMacroAttribute => ItemKind::ProcAttribute,
+            ProcDerive | BangMacroDerive => ItemKind::ProcDerive,
         }
     }
 }

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -53,12 +53,7 @@ impl JsonRenderer<'_> {
         let clean::ItemInner { name, item_id, .. } = *item.inner;
         let id = self.id_from_item(item);
         let inner = match item.kind {
-            clean::KeywordItem
-            | clean::AttributeItem
-            // Placeholder so no need to handle it.
-            | clean::AttrMacroItem
-            // Placeholder so no need to handle it.
-            | clean::DeriveMacroItem => return None,
+            clean::KeywordItem | clean::AttributeItem => return None,
             clean::StrippedItem(ref inner) => {
                 match &**inner {
                     // We document stripped modules as with `Module::is_stripped` set to
@@ -343,7 +338,7 @@ fn from_clean_item(item: &clean::Item, renderer: &JsonRenderer<'_>) -> ItemEnum 
         },
         // `convert_item` early returns `None` for stripped items, keywords, attributes and
         // "special" macro rules.
-        KeywordItem | AttributeItem | AttrMacroItem | DeriveMacroItem => unreachable!(),
+        KeywordItem | AttributeItem => unreachable!(),
         StrippedItem(inner) => {
             match inner.as_ref() {
                 ModuleItem(m) => ItemEnum::Module(Module {

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -62,12 +62,12 @@ impl JsonRenderer<'_> {
                     clean::ModuleItem(_)
                         if self.imported_items.contains(&item_id.expect_def_id()) =>
                     {
-                        from_clean_item(item, self)
+                        from_clean_item(item, self)?
                     }
                     _ => return None,
                 }
             }
-            _ => from_clean_item(item, self),
+            _ => from_clean_item(item, self)?,
         };
         Some(Item {
             id,
@@ -269,13 +269,13 @@ impl FromClean<clean::AssocItemConstraintKind> for AssocItemConstraintKind {
     }
 }
 
-fn from_clean_item(item: &clean::Item, renderer: &JsonRenderer<'_>) -> ItemEnum {
+fn from_clean_item(item: &clean::Item, renderer: &JsonRenderer<'_>) -> Option<ItemEnum> {
     use clean::ItemKind::*;
     let name = item.name;
     let is_crate = item.is_crate();
     let header = item.fn_header(renderer.tcx);
 
-    match &item.inner.kind {
+    Some(match &item.inner.kind {
         ModuleItem(m) => {
             ItemEnum::Module(Module { is_crate, items: renderer.ids(&m.items), is_stripped: false })
         }
@@ -310,6 +310,8 @@ fn from_clean_item(item: &clean::Item, renderer: &JsonRenderer<'_>) -> ItemEnum 
             const_: ci.kind.into_json(renderer),
         },
         MacroItem(m, _) => ItemEnum::Macro(m.source.clone()),
+        // They are just placeholders so no need to handle them.
+        AttrMacroItem | DeriveMacroItem => return None,
         ProcMacroItem(m) => ItemEnum::ProcMacro(m.into_json(renderer)),
         PrimitiveItem(p) => {
             ItemEnum::Primitive(Primitive {
@@ -355,7 +357,7 @@ fn from_clean_item(item: &clean::Item, renderer: &JsonRenderer<'_>) -> ItemEnum 
         },
         // All placeholder impl items should have been removed in the stripper passes.
         PlaceholderImplItem => unreachable!(),
-    }
+    })
 }
 
 impl FromClean<clean::Struct> for Struct {

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -899,8 +899,8 @@ impl FromClean<ItemType> for ItemKind {
             Keyword => ItemKind::Keyword,
             Attribute => ItemKind::Attribute,
             TraitAlias => ItemKind::TraitAlias,
-            ProcAttribute | BangMacroAttribute => ItemKind::ProcAttribute,
-            ProcDerive | BangMacroDerive => ItemKind::ProcDerive,
+            ProcAttribute | DeclMacroAttribute => ItemKind::ProcAttribute,
+            ProcDerive | DeclMacroDerive => ItemKind::ProcDerive,
         }
     }
 }

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -117,9 +117,9 @@ impl Res {
             DefKind::Fn | DefKind::AssocFn => return Suggestion::Function,
             // FIXME: handle macros with multiple kinds, and attribute/derive macros that aren't
             // proc macros
-            DefKind::Macro(MacroKinds::BANG) => return Suggestion::Macro,
-
+            DefKind::Macro(MacroKinds::ATTR) => "attribute",
             DefKind::Macro(MacroKinds::DERIVE) => "derive",
+            DefKind::Macro(_) => return Suggestion::Macro,
             DefKind::Struct => "struct",
             DefKind::Enum => "enum",
             DefKind::Trait => "trait",

--- a/src/librustdoc/passes/propagate_doc_cfg.rs
+++ b/src/librustdoc/passes/propagate_doc_cfg.rs
@@ -92,7 +92,7 @@ impl CfgPropagator<'_, '_> {
         }
         // We also need to merge an item attributes with its parent's in case it's a macro with
         // the `#[macro_export]` attribute, because it might not be defined at crate root.
-        else if matches!(item.kind, ItemKind::MacroItem(_))
+        else if matches!(item.kind, ItemKind::MacroItem(_, _))
             && item.inner.attrs.other_attrs.iter().any(|attr| {
                 matches!(
                     attr,

--- a/src/librustdoc/passes/propagate_stability.rs
+++ b/src/librustdoc/passes/propagate_stability.rs
@@ -88,6 +88,8 @@ impl DocFolder for StabilityPropagator<'_, '_> {
                     | ItemKind::ForeignStaticItem(..)
                     | ItemKind::ForeignTypeItem
                     | ItemKind::MacroItem(..)
+                    | ItemKind::AttrMacroItem
+                    | ItemKind::DeriveMacroItem
                     | ItemKind::ProcMacroItem(..)
                     | ItemKind::ConstantItem(..) => {
                         // If any of the item's parents was stabilized later or is still unstable,

--- a/src/librustdoc/passes/propagate_stability.rs
+++ b/src/librustdoc/passes/propagate_stability.rs
@@ -88,8 +88,6 @@ impl DocFolder for StabilityPropagator<'_, '_> {
                     | ItemKind::ForeignStaticItem(..)
                     | ItemKind::ForeignTypeItem
                     | ItemKind::MacroItem(..)
-                    | ItemKind::AttrMacroItem
-                    | ItemKind::DeriveMacroItem
                     | ItemKind::ProcMacroItem(..)
                     | ItemKind::ConstantItem(..) => {
                         // If any of the item's parents was stabilized later or is still unstable,

--- a/src/librustdoc/passes/stripper.rs
+++ b/src/librustdoc/passes/stripper.rs
@@ -64,6 +64,8 @@ impl DocFolder for Stripper<'_, '_> {
             | clean::UnionItem(..)
             | clean::TraitAliasItem(..)
             | clean::MacroItem(..)
+            | clean::AttrMacroItem
+            | clean::DeriveMacroItem
             | clean::ForeignTypeItem => {
                 let item_id = i.item_id;
                 if item_id.is_local()

--- a/src/librustdoc/passes/stripper.rs
+++ b/src/librustdoc/passes/stripper.rs
@@ -64,8 +64,6 @@ impl DocFolder for Stripper<'_, '_> {
             | clean::UnionItem(..)
             | clean::TraitAliasItem(..)
             | clean::MacroItem(..)
-            | clean::AttrMacroItem
-            | clean::DeriveMacroItem
             | clean::ForeignTypeItem => {
                 let item_id = i.item_id;
                 if item_id.is_local()

--- a/src/librustdoc/visit.rs
+++ b/src/librustdoc/visit.rs
@@ -41,7 +41,7 @@ pub(crate) trait DocVisitor<'a>: Sized {
             | ForeignFunctionItem(..)
             | ForeignStaticItem(..)
             | ForeignTypeItem
-            | MacroItem(_)
+            | MacroItem(..)
             | ProcMacroItem(_)
             | PrimitiveItem(_)
             | RequiredAssocConstItem(..)

--- a/src/librustdoc/visit.rs
+++ b/src/librustdoc/visit.rs
@@ -42,6 +42,8 @@ pub(crate) trait DocVisitor<'a>: Sized {
             | ForeignStaticItem(..)
             | ForeignTypeItem
             | MacroItem(..)
+            | AttrMacroItem
+            | DeriveMacroItem
             | ProcMacroItem(_)
             | PrimitiveItem(_)
             | RequiredAssocConstItem(..)

--- a/src/librustdoc/visit.rs
+++ b/src/librustdoc/visit.rs
@@ -42,8 +42,6 @@ pub(crate) trait DocVisitor<'a>: Sized {
             | ForeignStaticItem(..)
             | ForeignTypeItem
             | MacroItem(..)
-            | AttrMacroItem
-            | DeriveMacroItem
             | ProcMacroItem(_)
             | PrimitiveItem(_)
             | RequiredAssocConstItem(..)

--- a/tests/rustdoc-gui/attr-macros.goml
+++ b/tests/rustdoc-gui/attr-macros.goml
@@ -1,0 +1,39 @@
+// This test ensures that a bang macro which is also an attribute macro is listed correctly in
+// the sidebar and in the module.
+
+go-to: "file://" + |DOC_PATH| + "/test_docs/macro.b.html"
+// It should be present twice in the sidebar.
+assert-count: ("#rustdoc-modnav a[href='macro.attr_macro.html']", 2)
+assert-count: ("//*[@id='rustdoc-modnav']//a[text()='attr_macro']", 2)
+// We check that the current item in the sidebar is the correct one.
+assert-text: ("#rustdoc-modnav .block.macro .current", "b")
+
+// We now go to the attribute macro page.
+click: "#rustdoc-modnav a[href='macro.attr_macro.html']"
+// It should be present twice in the sidebar.
+assert-count: ("#rustdoc-modnav a[href='macro.attr_macro.html']", 2)
+assert-count: ("//*[@id='rustdoc-modnav']//a[text()='attr_macro']", 2)
+// We check that the current item is the "attr_macro".
+assert-text: ("#rustdoc-modnav .block.macro .current", "attr_macro")
+// Since the item is present twice in the sidebar, we should have two "current" items.
+assert-count: ("#rustdoc-modnav .current", 2)
+// We check it has the expected information.
+assert-text: ("h3.macro-info", "ⓘ This is an attribute/function macro")
+
+// Now we check it's correctly listed in the crate page.
+go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
+// It should be only present twice.
+assert-count: ("#main-content a[href='macro.attr_macro.html']", 2)
+// First in the "Macros" section.
+assert-text: ("#macros + .item-table a[href='macro.attr_macro.html']", "attr_macro")
+// Then in the "Attribute Macros" section.
+assert-text: ("#attributes + .item-table a[href='macro.attr_macro.html']", "attr_macro")
+
+// And finally we check it's correctly listed in the "all items" page.
+go-to: "file://" + |DOC_PATH| + "/test_docs/all.html"
+// It should be only present twice.
+assert-count: ("#main-content a[href='macro.attr_macro.html']", 2)
+// First in the "Macros" section.
+assert-text: ("#macros + .all-items a[href='macro.attr_macro.html']", "attr_macro")
+// Then in the "Attribute Macros" section.
+assert-text: ("#attributes + .all-items a[href='macro.attr_macro.html']", "attr_macro")

--- a/tests/rustdoc-gui/attr-macros.goml
+++ b/tests/rustdoc-gui/attr-macros.goml
@@ -27,7 +27,7 @@ assert-count: ("#main-content a[href='macro.attr_macro.html']", 2)
 // First in the "Macros" section.
 assert-text: ("#macros + .item-table a[href='macro.attr_macro.html']", "attr_macro")
 // Then in the "Attribute Macros" section.
-assert-text: ("#attributes + .item-table a[href='macro.attr_macro.html']", "attr_macro")
+assert-text: ("#attribute-macros + .item-table a[href='macro.attr_macro.html']", "attr_macro")
 
 // And finally we check it's correctly listed in the "all items" page.
 go-to: "file://" + |DOC_PATH| + "/test_docs/all.html"
@@ -36,4 +36,4 @@ assert-count: ("#main-content a[href='macro.attr_macro.html']", 2)
 // First in the "Macros" section.
 assert-text: ("#macros + .all-items a[href='macro.attr_macro.html']", "attr_macro")
 // Then in the "Attribute Macros" section.
-assert-text: ("#attributes + .all-items a[href='macro.attr_macro.html']", "attr_macro")
+assert-text: ("#attribute-macros + .all-items a[href='macro.attr_macro.html']", "attr_macro")

--- a/tests/rustdoc-gui/attr-macros.goml
+++ b/tests/rustdoc-gui/attr-macros.goml
@@ -2,38 +2,75 @@
 // the sidebar and in the module.
 
 go-to: "file://" + |DOC_PATH| + "/test_docs/macro.b.html"
-// It should be present twice in the sidebar.
-assert-count: ("#rustdoc-modnav a[href='macro.attr_macro.html']", 2)
-assert-count: ("//*[@id='rustdoc-modnav']//a[text()='attr_macro']", 2)
 // We check that the current item in the sidebar is the correct one.
 assert-text: ("#rustdoc-modnav .block.macro .current", "b")
 
-// We now go to the attribute macro page.
-click: "#rustdoc-modnav a[href='macro.attr_macro.html']"
-// It should be present twice in the sidebar.
-assert-count: ("#rustdoc-modnav a[href='macro.attr_macro.html']", 2)
-assert-count: ("//*[@id='rustdoc-modnav']//a[text()='attr_macro']", 2)
-// We check that the current item is the "attr_macro".
-assert-text: ("#rustdoc-modnav .block.macro .current", "attr_macro")
-// Since the item is present twice in the sidebar, we should have two "current" items.
-assert-count: ("#rustdoc-modnav .current", 2)
-// We check it has the expected information.
-assert-text: ("h3.macro-info", "ⓘ This is an attribute/function macro")
+define-function: (
+    "check_macro",
+    [name, info],
+    block {
+        // It should be present twice in the sidebar.
+        assert-count: ("#rustdoc-modnav a[href='macro." + |name| + ".html']", 2)
+        assert-count: ("//*[@id='rustdoc-modnav']//a[text()='" + |name| + "']", 2)
+
+        // We now go to the macro page.
+        click: "#rustdoc-modnav a[href='macro." + |name| + ".html']"
+        // It should be present twice in the sidebar.
+        assert-count: ("#rustdoc-modnav a[href='macro." + |name| + ".html']", 2)
+        assert-count: ("//*[@id='rustdoc-modnav']//a[text()='" + |name| + "']", 2)
+        // We check that the current item is the macro.
+        assert-text: ("#rustdoc-modnav .block.macro .current", |name|)
+        // Since the item is present twice in the sidebar, we should have two "current" items.
+        assert-count: ("#rustdoc-modnav .current", 2)
+        // We check it has the expected information.
+        assert-text: ("h3.macro-info", "ⓘ This is " + |info| + "/function macro")
+    }
+)
+
+call-function: ("check_macro", {"name": "attr_macro", "info": "an attribute"})
+call-function: ("check_macro", {"name": "derive_macro", "info": "a derive"})
+
+define-function: (
+    "crate_page",
+    [name, section_id],
+    block {
+        // It should be only present twice.
+        assert-count: ("#main-content a[href='macro." + |name| + ".html']", 2)
+        // First in the "Macros" section.
+        assert-text: ("#macros + .item-table a[href='macro." + |name| + ".html']", |name|)
+        // Then in the other macro section.
+        assert-text: (
+            "#" + |section_id| + " + .item-table a[href='macro." + |name| + ".html']",
+            |name|,
+        )
+    }
+)
 
 // Now we check it's correctly listed in the crate page.
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
-// It should be only present twice.
-assert-count: ("#main-content a[href='macro.attr_macro.html']", 2)
-// First in the "Macros" section.
-assert-text: ("#macros + .item-table a[href='macro.attr_macro.html']", "attr_macro")
-// Then in the "Attribute Macros" section.
-assert-text: ("#attribute-macros + .item-table a[href='macro.attr_macro.html']", "attr_macro")
+call-function: ("crate_page", {"name": "attr_macro", "section_id": "attribute-macros"})
+call-function: ("crate_page", {"name": "derive_macro", "section_id": "derives"})
+// We also check we don't have duplicated sections.
+assert-count: ("//*[@id='main-content']/h2[text()='Attribute Macros']", 1)
+assert-count: ("//*[@id='main-content']/h2[text()='Derive Macros']", 1)
+
+define-function: (
+    "all_items_page",
+    [name, section_id],
+    block {
+        // It should be only present twice.
+        assert-count: ("#main-content a[href='macro." + |name| + ".html']", 2)
+        // First in the "Macros" section.
+        assert-text: ("#macros + .all-items a[href='macro." + |name| + ".html']", |name|)
+        // Then in the "Attribute Macros" section.
+        assert-text: (
+            "#" + |section_id| + " + .all-items a[href='macro." + |name| + ".html']",
+            |name|,
+        )
+    }
+)
 
 // And finally we check it's correctly listed in the "all items" page.
 go-to: "file://" + |DOC_PATH| + "/test_docs/all.html"
-// It should be only present twice.
-assert-count: ("#main-content a[href='macro.attr_macro.html']", 2)
-// First in the "Macros" section.
-assert-text: ("#macros + .all-items a[href='macro.attr_macro.html']", "attr_macro")
-// Then in the "Attribute Macros" section.
-assert-text: ("#attribute-macros + .all-items a[href='macro.attr_macro.html']", "attr_macro")
+call-function: ("all_items_page", {"name": "attr_macro", "section_id": "attribute-macros"})
+call-function: ("all_items_page", {"name": "derive_macro", "section_id": "derives"})

--- a/tests/rustdoc-gui/attr-macros.goml
+++ b/tests/rustdoc-gui/attr-macros.goml
@@ -7,7 +7,7 @@ assert-text: ("#rustdoc-modnav .block.macro .current", "b")
 
 define-function: (
     "check_macro",
-    [name, info],
+    [name, info, kind],
     block {
         // It should be present twice in the sidebar.
         assert-count: ("#rustdoc-modnav a[href='macro." + |name| + ".html']", 2)
@@ -24,11 +24,16 @@ define-function: (
         assert-count: ("#rustdoc-modnav .current", 2)
         // We check it has the expected information.
         assert-text: ("h3.macro-info", "ⓘ This is " + |info| + "/function macro")
+        // We check how the item declaration looks like.
+        assert-text: (".item-decl", "macro_rules! " + |name| + " {
+    " + |kind| + "() () => { ... };
+    () => { ... };
+}")
     }
 )
 
-call-function: ("check_macro", {"name": "attr_macro", "info": "an attribute"})
-call-function: ("check_macro", {"name": "derive_macro", "info": "a derive"})
+call-function: ("check_macro", {"name": "attr_macro", "info": "an attribute", "kind": "attr"})
+call-function: ("check_macro", {"name": "derive_macro", "info": "a derive", "kind": "derive"})
 
 define-function: (
     "crate_page",
@@ -74,3 +79,13 @@ define-function: (
 go-to: "file://" + |DOC_PATH| + "/test_docs/all.html"
 call-function: ("all_items_page", {"name": "attr_macro", "section_id": "attribute-macros"})
 call-function: ("all_items_page", {"name": "derive_macro", "section_id": "derives"})
+
+// We now check a macro with all 3 different kinds.
+go-to: "file://" + |DOC_PATH| + "/test_docs/macro.one_for_all_macro.html"
+assert-text: (".item-decl", "macro_rules! one_for_all_macro {
+    attr() () => { ... };
+    derive() () => { ... };
+    () => { ... };
+}")
+// We check it has the expected information.
+assert-text: ("h3.macro-info", "ⓘ This is an attribute/derive/function macro")

--- a/tests/rustdoc-gui/attr-macros.goml
+++ b/tests/rustdoc-gui/attr-macros.goml
@@ -53,7 +53,7 @@ define-function: (
 
 // Now we check it's correctly listed in the crate page.
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
-call-function: ("crate_page", {"name": "attr_macro", "section_id": "attribute-macros"})
+call-function: ("crate_page", {"name": "attr_macro", "section_id": "attributes"})
 call-function: ("crate_page", {"name": "derive_macro", "section_id": "derives"})
 // We also check we don't have duplicated sections.
 assert-count: ("//*[@id='main-content']/h2[text()='Attribute Macros']", 1)
@@ -77,7 +77,7 @@ define-function: (
 
 // And finally we check it's correctly listed in the "all items" page.
 go-to: "file://" + |DOC_PATH| + "/test_docs/all.html"
-call-function: ("all_items_page", {"name": "attr_macro", "section_id": "attribute-macros"})
+call-function: ("all_items_page", {"name": "attr_macro", "section_id": "attributes"})
 call-function: ("all_items_page", {"name": "derive_macro", "section_id": "derives"})
 
 // We now check a macro with all 3 different kinds.

--- a/tests/rustdoc-gui/module-items-font.goml
+++ b/tests/rustdoc-gui/module-items-font.goml
@@ -74,3 +74,12 @@ assert-css: (
     "#attributes + .item-table dd",
     {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
 )
+// attribute macros
+assert-css: (
+    "#attribute-macros + .item-table dt a",
+    {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'},
+)
+assert-css: (
+    "#attribute-macros + .item-table dd",
+    {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
+)

--- a/tests/rustdoc-gui/module-items-font.goml
+++ b/tests/rustdoc-gui/module-items-font.goml
@@ -67,19 +67,19 @@ assert-css: (
 )
 // attributes
 assert-css: (
+    "#attribute-docs + .item-table dt a",
+    {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'},
+)
+assert-css: (
+    "#attribute-docs + .item-table dd",
+    {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
+)
+// attribute macros
+assert-css: (
     "#attributes + .item-table dt a",
     {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'},
 )
 assert-css: (
     "#attributes + .item-table dd",
-    {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
-)
-// attribute macros
-assert-css: (
-    "#attribute-macros + .item-table dt a",
-    {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'},
-)
-assert-css: (
-    "#attribute-macros + .item-table dd",
     {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
 )

--- a/tests/rustdoc-gui/src/test_docs/lib.rs
+++ b/tests/rustdoc-gui/src/test_docs/lib.rs
@@ -8,6 +8,7 @@
 #![feature(rustdoc_internals)]
 #![feature(doc_cfg)]
 #![feature(associated_type_defaults)]
+#![feature(macro_attr)]
 
 /*!
 Enable the feature <span class="stab portability"><code>some-feature</code></span> to enjoy

--- a/tests/rustdoc-gui/src/test_docs/lib.rs
+++ b/tests/rustdoc-gui/src/test_docs/lib.rs
@@ -9,6 +9,7 @@
 #![feature(doc_cfg)]
 #![feature(associated_type_defaults)]
 #![feature(macro_attr)]
+#![feature(macro_derive)]
 
 /*!
 Enable the feature <span class="stab portability"><code>some-feature</code></span> to enjoy

--- a/tests/rustdoc-gui/src/test_docs/macros.rs
+++ b/tests/rustdoc-gui/src/test_docs/macros.rs
@@ -2,3 +2,10 @@
 macro_rules! a{ () => {}}
 #[macro_export]
 macro_rules! b{ () => {}}
+
+// An attribute bang macro.
+#[macro_export]
+macro_rules! attr_macro {
+    attr() () => {};
+    () => {};
+}

--- a/tests/rustdoc-gui/src/test_docs/macros.rs
+++ b/tests/rustdoc-gui/src/test_docs/macros.rs
@@ -3,7 +3,7 @@ macro_rules! a{ () => {}}
 #[macro_export]
 macro_rules! b{ () => {}}
 
-// An attribute bang macro.
+/// An attribute bang macro.
 #[macro_export]
 macro_rules! attr_macro {
     attr() () => {};

--- a/tests/rustdoc-gui/src/test_docs/macros.rs
+++ b/tests/rustdoc-gui/src/test_docs/macros.rs
@@ -9,3 +9,17 @@ macro_rules! attr_macro {
     attr() () => {};
     () => {};
 }
+
+/// A derive bang macro.
+#[macro_export]
+macro_rules! derive_macro {
+    derive() () => {};
+    () => {};
+}
+
+#[macro_export]
+macro_rules! one_for_all_macro {
+    attr() () => {};
+    derive() () => {};
+    () => {};
+}

--- a/tests/rustdoc-html/doc-attribute.rs
+++ b/tests/rustdoc-html/doc-attribute.rs
@@ -4,10 +4,10 @@
 
 #![feature(rustdoc_internals)]
 
-//@ has foo/index.html '//h2[@id="attributes"]' 'Attributes'
+//@ has foo/index.html '//h2[@id="attribute-docs"]' 'Attributes'
 //@ has foo/index.html '//a[@href="attribute.no_mangle.html"]' 'no_mangle'
 //@ has foo/index.html '//div[@class="sidebar-elems"]//li/a' 'Attributes'
-//@ has foo/index.html '//div[@class="sidebar-elems"]//li/a/@href' '#attributes'
+//@ has foo/index.html '//div[@class="sidebar-elems"]//li/a/@href' '#attribute-docs'
 //@ has foo/attribute.no_mangle.html '//h1' 'Attribute no_mangle'
 //@ has foo/attribute.no_mangle.html '//section[@id="main-content"]//div[@class="docblock"]//p' 'this is a test!'
 //@ has foo/index.html '//a/@href' '../foo/index.html'

--- a/tests/rustdoc-html/macro/decl_macro-sidebar.rs
+++ b/tests/rustdoc-html/macro/decl_macro-sidebar.rs
@@ -1,0 +1,15 @@
+// This test ensures that the `foo` decl macro is present in the module sidebar.
+
+#![feature(decl_macro)]
+#![crate_name = "foo"]
+
+//@has 'foo/bar/index.html'
+//@has - '//*[@id="rustdoc-modnav"]/ul[@class="block macro"]//a[@href="../macro.foo.html"]' 'foo'
+
+pub macro foo {
+    () => { "bar" }
+}
+
+/// docs
+pub mod bar {
+}

--- a/tests/rustdoc-html/macro/macro-attr-derive.rs
+++ b/tests/rustdoc-html/macro/macro-attr-derive.rs
@@ -1,0 +1,29 @@
+// Test for the `macro_attr` and `macro_derive` features.
+
+#![feature(macro_attr)]
+#![feature(macro_derive)]
+
+#![crate_name = "foo"]
+
+//@ has 'foo/index.html'
+//@ count - '//*[@id="main-content"]/h2[@class="section-header"]' 3
+//@ has - '//*[@id="main-content"]/h2[@class="section-header"]' 'Attribute Macros'
+//@ has - '//*[@id="main-content"]/h2[@class="section-header"]' 'Derive Macros'
+//@ has - '//*[@id="main-content"]/h2[@class="section-header"]' 'Macros'
+//@ has - '//a[@href="macro.all.html"]' 'all'
+
+//@ has 'foo/macro.all.html'
+//@ has - '//*[@class="macro-info"]' 'ⓘ This is an attribute/derive/function macro'
+
+//@ has 'foo/all.html'
+//@ count - '//*[@id="main-content"]/h3' 3
+//@ has - '//*[@id="main-content"]/h3' 'Attribute Macros'
+//@ has - '//*[@id="main-content"]/h3' 'Derive Macros'
+//@ has - '//*[@id="main-content"]/h3' 'Macros'
+
+#[macro_export]
+macro_rules! all {
+    () => {};
+    attr() () => {};
+    derive() () => {};
+}

--- a/tests/rustdoc-html/macro/macro-attr.rs
+++ b/tests/rustdoc-html/macro/macro-attr.rs
@@ -1,0 +1,22 @@
+// Test for the `macro_attr` and `macro_derive` features.
+
+#![feature(macro_attr)]
+
+#![crate_name = "foo"]
+
+//@ has 'foo/index.html'
+//@ count - '//*[@id="main-content"]/h2[@class="section-header"]' 1
+//@ has - '//*[@id="main-content"]/h2[@class="section-header"]' 'Attribute Macros'
+//@ has - '//a[@href="attr.attr.html"]' 'attr'
+
+//@ has 'foo/attr.attr.html'
+//@ has - '//*[@class="rust item-decl"]/code' '#[attr]'
+
+//@ has 'foo/all.html'
+//@ count - '//*[@id="main-content"]/h3' 1
+//@ has - '//*[@id="main-content"]/h3' 'Attribute Macros'
+
+#[macro_export]
+macro_rules! attr {
+    attr() () => {};
+}

--- a/tests/rustdoc-html/macro/macro-derive.rs
+++ b/tests/rustdoc-html/macro/macro-derive.rs
@@ -1,0 +1,22 @@
+// Test for the `macro_attr` and `macro_derive` features.
+
+#![feature(macro_derive)]
+
+#![crate_name = "foo"]
+
+//@ has 'foo/index.html'
+//@ count - '//*[@id="main-content"]/h2[@class="section-header"]' 1
+//@ has - '//*[@id="main-content"]/h2[@class="section-header"]' 'Derive Macros'
+//@ has - '//a[@href="derive.derive.html"]' 'derive'
+
+//@ has 'foo/derive.derive.html'
+//@ has - '//*[@class="rust item-decl"]/code' '#[derive(derive)]'
+
+//@ has 'foo/all.html'
+//@ count - '//*[@id="main-content"]/h3' 1
+//@ has - '//*[@id="main-content"]/h3' 'Derive Macros'
+
+#[macro_export]
+macro_rules! derive {
+    derive() () => {};
+}

--- a/tests/rustdoc-html/macro/macro-no-bang.rs
+++ b/tests/rustdoc-html/macro/macro-no-bang.rs
@@ -1,0 +1,26 @@
+// Test for the `macro_attr` and `macro_derive` features.
+
+#![feature(macro_attr)]
+#![feature(macro_derive)]
+
+#![crate_name = "foo"]
+
+//@ has 'foo/index.html'
+//@ count - '//*[@id="main-content"]/h2[@class="section-header"]' 2
+//@ has - '//*[@id="main-content"]/h2[@class="section-header"]' 'Attribute Macros'
+//@ has - '//*[@id="main-content"]/h2[@class="section-header"]' 'Derive Macros'
+//@ has - '//a[@href="macro.no_bang.html"]' 'no_bang'
+
+//@ has 'foo/macro.no_bang.html'
+//@ has - '//*[@class="macro-info"]' 'ⓘ This is an attribute/derive macro'
+
+//@ has 'foo/all.html'
+//@ count - '//*[@id="main-content"]/h3' 2
+//@ has - '//*[@id="main-content"]/h3' 'Attribute Macros'
+//@ has - '//*[@id="main-content"]/h3' 'Derive Macros'
+
+#[macro_export]
+macro_rules! no_bang {
+    attr() () => {};
+    derive() () => {};
+}

--- a/tests/rustdoc-js/macro-kinds.js
+++ b/tests/rustdoc-js/macro-kinds.js
@@ -1,0 +1,18 @@
+// exact-check
+
+const EXPECTED = [
+    {
+        'query': 'macro:macro',
+        'others': [
+            { 'path': 'macro_kinds', 'name': 'macro1' },
+            { 'path': 'macro_kinds', 'name': 'macro3' },
+        ],
+    },
+    {
+        'query': 'attr:macro',
+        'others': [
+            { 'path': 'macro_kinds', 'name': 'macro1' },
+            { 'path': 'macro_kinds', 'name': 'macro2' },
+        ],
+    },
+];

--- a/tests/rustdoc-js/macro-kinds.js
+++ b/tests/rustdoc-js/macro-kinds.js
@@ -4,15 +4,24 @@ const EXPECTED = [
     {
         'query': 'macro:macro',
         'others': [
-            { 'path': 'macro_kinds', 'name': 'macro1' },
-            { 'path': 'macro_kinds', 'name': 'macro3' },
+            { 'path': 'macro_kinds', 'name': 'macro1', 'href': '../macro_kinds/macro.macro1.html' },
+            { 'path': 'macro_kinds', 'name': 'macro3', 'href': '../macro_kinds/macro.macro3.html' },
         ],
     },
     {
         'query': 'attr:macro',
         'others': [
-            { 'path': 'macro_kinds', 'name': 'macro1' },
-            { 'path': 'macro_kinds', 'name': 'macro2' },
+            { 'path': 'macro_kinds', 'name': 'macro1', 'href': '../macro_kinds/macro.macro1.html' },
+            { 'path': 'macro_kinds', 'name': 'macro2', 'href': '../macro_kinds/attr.macro2.html' },
+        ],
+    },
+    {
+        'query': 'derive:macro',
+        'others': [
+            { 'path': 'macro_kinds', 'name': 'macro1', 'href': '../macro_kinds/macro.macro1.html' },
+            {
+                'path': 'macro_kinds', 'name': 'macro4', 'href': '../macro_kinds/derive.macro4.html'
+            },
         ],
     },
 ];

--- a/tests/rustdoc-js/macro-kinds.js
+++ b/tests/rustdoc-js/macro-kinds.js
@@ -4,8 +4,42 @@ const EXPECTED = [
     {
         'query': 'macro:macro',
         'others': [
-            { 'path': 'macro_kinds', 'name': 'macro1', 'href': '../macro_kinds/macro.macro1.html' },
-            { 'path': 'macro_kinds', 'name': 'macro3', 'href': '../macro_kinds/macro.macro3.html' },
+            {
+                'path': 'macro_kinds',
+                'name': 'macro1',
+                'href': '../macro_kinds/macro.macro1.html',
+                'ty': 16,
+            },
+            {
+                'path': 'macro_kinds',
+                'name': 'macro1',
+                'href': '../macro_kinds/macro.macro1.html',
+                'ty': 23,
+            },
+            {
+                'path': 'macro_kinds',
+                'name': 'macro1',
+                'href': '../macro_kinds/macro.macro1.html',
+                'ty': 24,
+            },
+            {
+                'path': 'macro_kinds',
+                'name': 'macro2',
+                'href': '../macro_kinds/attr.macro2.html',
+                'ty': 23,
+            },
+            {
+                'path': 'macro_kinds',
+                'name': 'macro4',
+                'href': '../macro_kinds/derive.macro4.html',
+                'ty': 24,
+            },
+            {
+                'path': 'macro_kinds',
+                'name': 'macro3',
+                'href': '../macro_kinds/macro.macro3.html',
+                'ty': 16,
+            },
         ],
     },
     {

--- a/tests/rustdoc-js/macro-kinds.js
+++ b/tests/rustdoc-js/macro-kinds.js
@@ -30,6 +30,18 @@ const EXPECTED = [
             },
             {
                 'path': 'macro_kinds',
+                'name': 'macro5',
+                'href': '../macro_kinds/macro.macro5.html',
+                'ty': 23,
+            },
+            {
+                'path': 'macro_kinds',
+                'name': 'macro5',
+                'href': '../macro_kinds/macro.macro5.html',
+                'ty': 24,
+            },
+            {
+                'path': 'macro_kinds',
                 'name': 'macro4',
                 'href': '../macro_kinds/derive.macro4.html',
                 'ty': 24,
@@ -47,12 +59,14 @@ const EXPECTED = [
         'others': [
             { 'path': 'macro_kinds', 'name': 'macro1', 'href': '../macro_kinds/macro.macro1.html' },
             { 'path': 'macro_kinds', 'name': 'macro2', 'href': '../macro_kinds/attr.macro2.html' },
+            { 'path': 'macro_kinds', 'name': 'macro5', 'href': '../macro_kinds/macro.macro5.html' },
         ],
     },
     {
         'query': 'derive:macro',
         'others': [
             { 'path': 'macro_kinds', 'name': 'macro1', 'href': '../macro_kinds/macro.macro1.html' },
+            { 'path': 'macro_kinds', 'name': 'macro5', 'href': '../macro_kinds/macro.macro5.html' },
             {
                 'path': 'macro_kinds', 'name': 'macro4', 'href': '../macro_kinds/derive.macro4.html'
             },

--- a/tests/rustdoc-js/macro-kinds.rs
+++ b/tests/rustdoc-js/macro-kinds.rs
@@ -3,10 +3,12 @@
 // `macro2` and `macro3` should only appear in `attr` or `macro` filters respectively.
 
 #![feature(macro_attr)]
+#![feature(macro_derive)]
 
 #[macro_export]
 macro_rules! macro1 {
     attr() () => {};
+    derive() () => {};
     () => {};
 }
 
@@ -18,4 +20,9 @@ macro_rules! macro2 {
 #[macro_export]
 macro_rules! macro3 {
     () => {};
+}
+
+#[macro_export]
+macro_rules! macro4 {
+    derive() () => {};
 }

--- a/tests/rustdoc-js/macro-kinds.rs
+++ b/tests/rustdoc-js/macro-kinds.rs
@@ -1,0 +1,21 @@
+// Test which ensures that attribute macros are correctly handled by the search.
+// For example: `macro1` should appear in both `attr` and `macro` filters whereas
+// `macro2` and `macro3` should only appear in `attr` or `macro` filters respectively.
+
+#![feature(macro_attr)]
+
+#[macro_export]
+macro_rules! macro1 {
+    attr() () => {};
+    () => {};
+}
+
+#[macro_export]
+macro_rules! macro2 {
+    attr() () => {};
+}
+
+#[macro_export]
+macro_rules! macro3 {
+    () => {};
+}

--- a/tests/rustdoc-js/macro-kinds.rs
+++ b/tests/rustdoc-js/macro-kinds.rs
@@ -26,3 +26,9 @@ macro_rules! macro3 {
 macro_rules! macro4 {
     derive() () => {};
 }
+
+#[macro_export]
+macro_rules! macro5 {
+    attr() () => {};
+    derive() () => {};
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/152449)*
<!-- homu-ignore:end -->

Since it seems like I can't reopen https://github.com/rust-lang/rust/pull/145458, opening this one. Although, it's the same PR minus the last new commit to handle a comment that was left unresolved in the original PR. All relevant details are still in the original PR though.

It's an alternative (and likely a take-over) of https://github.com/rust-lang/rust/pull/148005 since lang-team rejected the idea to add documentation on macro branches, making the multiple files approach less suitable.

This implements rust-lang/rust#145153 in rustdoc. This PR voluntarily doesn't touch anything related to intra-doc links, I'll send a follow-up if needed.

So now about the implementation itself: this is a weird case where a macro can be different things at once but still only gets one file generated. I saw two ways to implement this:
1. Handle `ItemKind::Macro` differently and iter through its `MacroKinds` values.
2. Add new placeholder variants in the `ItemKind` enum, which means that when we encounter them in rendering, we need to ignore them. It also makes the `ItemKind` enum bigger (and also needs more code to be handled). Another downside is that it needs to be handled in the JSON output.

Now there was an interesting improvement that came with this PR in the `html::render::print_item::item_module` function: I simplified its implementation and split the different parts in a `HashMap` where the key is the item type. So then, we can just iterate through the keys and open/close the section at each iteration instead of keeping an `Option<section>` around.

From RFCs:
* https://github.com/rust-lang/rust/pull/144579
* https://github.com/rust-lang/rust/pull/145208

derive:

<img width="442" height="327" alt="Screenshot From 2026-04-18 03-11-40" src="https://github.com/user-attachments/assets/f69587a0-8a2b-4080-bc8a-b63dd18f21c1" />

attr:

<img width="442" height="327" alt="Screenshot From 2026-04-18 03-11-31" src="https://github.com/user-attachments/assets/bf9b235a-9d2f-435c-a91e-167562df6b68" />

both:

<img width="442" height="327" alt="Screenshot From 2026-04-18 03-11-50" src="https://github.com/user-attachments/assets/b7e8b3c6-eb99-495b-bdf9-17ba8fb4da0d" />

r? @notriddle 