### PR TITLE
feat: show what lint was overruled

### DIFF
--- a/compiler/rustc_lint/src/errors.rs
+++ b/compiler/rustc_lint/src/errors.rs
@@ -20,7 +20,7 @@ pub(crate) struct OverruledAttribute<'a> {
 pub(crate) enum OverruledAttributeSub {
     DefaultSource { id: String },
     NodeSource { span: Span, reason: Option<Symbol> },
-    CommandLineSource,
+    CommandLineSource { id: Symbol },
 }
 
 impl Subdiagnostic for OverruledAttributeSub {
@@ -36,8 +36,9 @@ impl Subdiagnostic for OverruledAttributeSub {
                     diag.note(rationale.to_string());
                 }
             }
-            OverruledAttributeSub::CommandLineSource => {
-                diag.note(msg!("`forbid` lint level was set on command line"));
+            OverruledAttributeSub::CommandLineSource { id } => {
+                diag.note(msg!("`forbid` lint level was set on command line (`-F {$id}`)"));
+                diag.arg("id", id);
             }
         }
     }

--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -580,7 +580,9 @@ impl<'s, P: LintLevelsProvider> LintLevelsBuilder<'s, P> {
                 LintLevelSource::Node { span, reason, .. } => {
                     OverruledAttributeSub::NodeSource { span, reason }
                 }
-                LintLevelSource::CommandLine(_, _) => OverruledAttributeSub::CommandLineSource,
+                LintLevelSource::CommandLine(name, _) => {
+                    OverruledAttributeSub::CommandLineSource { id: name }
+                }
             };
             if !fcw_warning {
                 self.sess.dcx().emit_err(OverruledAttribute {

--- a/tests/ui/lint/lint-forbid-attr.rs
+++ b/tests/ui/lint/lint-forbid-attr.rs
@@ -1,6 +1,7 @@
-#![forbid(deprecated)]
+#![forbid(deprecated)] //~ NOTE `forbid` level set here
 
 #[allow(deprecated)]
-//~^ ERROR allow(deprecated) incompatible
+//~^ ERROR allow(deprecated) incompatible with previous forbid [E0453]
+//~^^ NOTE overruled by previous forbid
 fn main() {
 }

--- a/tests/ui/lint/lint-forbid-cmdline-1.rs
+++ b/tests/ui/lint/lint-forbid-cmdline-1.rs
@@ -1,0 +1,5 @@
+//@ compile-flags: -F deprecated
+
+#[allow(deprecated)] //~ ERROR allow(deprecated) incompatible with previous forbid [E0453]
+fn main() {
+}

--- a/tests/ui/lint/lint-forbid-cmdline-1.stderr
+++ b/tests/ui/lint/lint-forbid-cmdline-1.stderr
@@ -1,10 +1,10 @@
 error[E0453]: allow(deprecated) incompatible with previous forbid
-  --> $DIR/lint-forbid-cmdline.rs:3:9
+  --> $DIR/lint-forbid-cmdline-1.rs:3:9
    |
 LL | #[allow(deprecated)]
    |         ^^^^^^^^^^ overruled by previous forbid
    |
-   = note: `forbid` lint level was set on command line
+   = note: `forbid` lint level was set on command line (`-F deprecated`)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lint/lint-forbid-cmdline-2.rs
+++ b/tests/ui/lint/lint-forbid-cmdline-2.rs
@@ -1,0 +1,8 @@
+//@ compile-flags: -F dead_code
+
+#[allow(unused)]
+//~^ ERROR allow(unused) incompatible with previous forbid [E0453]
+//~| NOTE overruled by previous forbid
+//~| NOTE `forbid` lint level was set on command line (`-F dead_code`)
+fn main() {
+}

--- a/tests/ui/lint/lint-forbid-cmdline-2.stderr
+++ b/tests/ui/lint/lint-forbid-cmdline-2.stderr
@@ -1,0 +1,11 @@
+error[E0453]: allow(unused) incompatible with previous forbid
+  --> $DIR/lint-forbid-cmdline-2.rs:3:9
+   |
+LL | #[allow(unused)]
+   |         ^^^^^^ overruled by previous forbid
+   |
+   = note: `forbid` lint level was set on command line (`-F dead_code`)
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0453`.

--- a/tests/ui/lint/lint-forbid-cmdline.rs
+++ b/tests/ui/lint/lint-forbid-cmdline.rs
@@ -1,5 +1,0 @@
-//@ compile-flags: -F deprecated
-
-#[allow(deprecated)] //~ ERROR allow(deprecated) incompatible
-fn main() {
-}


### PR DESCRIPTION
We can't `#[allow]` a whole lint group if any of its members is forbidden, but the offending member is not currently shown if it was forbidden from the command line.

Before/after:
```diff
 $ rustc -F dead_code - <<< '#![allow(unused)]'
 error[E0453]: allow(unused) incompatible with previous forbid
  --> <anon>:1:10
   |
 1 | #![allow(unused)]
   |          ^^^^^^ overruled by previous forbid
   |
-  = note: `forbid` lint level was set on command line
+  = note: `forbid` lint level was set on command line (`-F dead_code`)
 
 error: aborting due to 1 previous error
```

@rustbot label +A-diagnostics +A-lints +D-terse