### PR TITLE
Rework `rustc_query_impl::define_queries`.

### DIFF
--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -991,7 +991,7 @@ pub fn create_and_enter_global_ctxt<T, F: for<'tcx> FnOnce(TyCtxt<'tcx>) -> T>(
             hir_arena,
             untracked,
             dep_graph,
-            rustc_query_impl::make_dep_kind_vtables(arena),
+            rustc_query_impl::queries::make_dep_kind_vtables(arena),
             rustc_query_impl::query_system(
                 providers.queries,
                 providers.extern_queries,

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -270,6 +270,7 @@ macro_rules! separate_provide_extern_default {
     };
 }
 
+// See also `define_queries!`.
 macro_rules! define_callbacks {
     (
         $(
@@ -277,7 +278,7 @@ macro_rules! define_callbacks {
             [$($modifiers:tt)*] fn $name:ident($($K:tt)*) -> $V:ty,
         )*
     ) => {
-        $(#[allow(unused_lifetimes)] pub mod $name {
+        $(pub mod $name {
             use super::*;
             use $crate::query::erase::{self, Erased};
 

--- a/compiler/rustc_query_impl/src/profiling_support.rs
+++ b/compiler/rustc_query_impl/src/profiling_support.rs
@@ -256,7 +256,7 @@ pub fn alloc_self_profile_query_strings(tcx: TyCtxt<'_>) {
 
     let mut string_cache = QueryKeyStringCache::new();
 
-    for alloc in super::ALLOC_SELF_PROFILE_QUERY_STRINGS.iter() {
+    for alloc in crate::queries::ALLOC_SELF_PROFILE_QUERY_STRINGS.iter() {
         alloc(tcx, &mut string_cache)
     }
     tcx.sess.prof.store_query_cache_hits();


### PR DESCRIPTION
To make it more similar to `rustc_middle::define_callbacks`, because I think it's very helpful for the two macros to work similarly.

`define_queries` currently generates one module called `query_impl::$name` for every query, and also generates a few types/consts/funcs into crate root.

After this change, it instead generates one module called `queries::$name` for every query, and also generates those few types/consts/funcs into `queries`. This makes it much more like `define_callbacks`.

The commit also adjusts imports so the body of `define_queries` needs fewer qualifiers, and to minimize potential confusion between `rustc_middle::queries` and `rustc_query_impl::queries`. And removes some unnecessary `$crate`/`crate` qualifiers.

r? @Zalathar 