### PR TITLE
autodiff: Simplify autodiff handling of rlib  dependencies

### DIFF
--- a/compiler/rustc_codegen_llvm/src/builder/autodiff.rs
+++ b/compiler/rustc_codegen_llvm/src/builder/autodiff.rs
@@ -20,7 +20,7 @@ pub(crate) fn adjust_activity_to_abi<'tcx>(
     da: &mut Vec<DiffActivity>,
 ) {
     if !matches!(fn_ty.kind(), ty::FnPtr(..)) {
-        // TODO: We may need to support FnDef here for non-`rlib` scenarios.
+        // FIXME: We may need to support FnDef here for non-`rlib` scenarios.
         bug!("expected fn ptr for autodiff, got {:?}", fn_ty);
     }
 
@@ -29,9 +29,10 @@ pub(crate) fn adjust_activity_to_abi<'tcx>(
     let sig = fn_ty.fn_sig(tcx).skip_binder();
 
     // FIXME(Sa4dUs): pass proper varargs once we have support for differentiating variadic functions
-    let Ok(fn_abi) =
-        tcx.fn_abi_of_fn_ptr(PseudoCanonicalInput { typing_env: TypingEnv::fully_monomorphized(), value: (ty::Binder::dummy(sig), ty::List::empty()) })
-    else {
+    let Ok(fn_abi) = tcx.fn_abi_of_fn_ptr(PseudoCanonicalInput {
+        typing_env: TypingEnv::fully_monomorphized(),
+        value: (ty::Binder::dummy(sig), ty::List::empty()),
+    }) else {
         bug!("failed to get fn_abi of fn_ptr with empty varargs");
     };
 

--- a/compiler/rustc_codegen_llvm/src/builder/autodiff.rs
+++ b/compiler/rustc_codegen_llvm/src/builder/autodiff.rs
@@ -4,7 +4,7 @@ use rustc_ast::expand::autodiff_attrs::{AutoDiffAttrs, DiffActivity, DiffMode};
 use rustc_ast::expand::typetree::FncTree;
 use rustc_codegen_ssa::common::TypeKind;
 use rustc_codegen_ssa::traits::{BaseTypeCodegenMethods, BuilderMethods};
-use rustc_middle::ty::{Instance, PseudoCanonicalInput, TyCtxt, TypingEnv};
+use rustc_middle::ty::{PseudoCanonicalInput, Ty, TyCtxt, TypingEnv};
 use rustc_middle::{bug, ty};
 use rustc_target::callconv::PassMode;
 use tracing::debug;
@@ -16,14 +16,12 @@ use crate::llvm::{self, TRUE, Type, Value};
 
 pub(crate) fn adjust_activity_to_abi<'tcx>(
     tcx: TyCtxt<'tcx>,
-    instance: Instance<'tcx>,
-    typing_env: TypingEnv<'tcx>,
+    fn_ty: Ty<'tcx>,
     da: &mut Vec<DiffActivity>,
 ) {
-    let fn_ty = instance.ty(tcx, typing_env);
-
-    if !matches!(fn_ty.kind(), ty::FnDef(..)) {
-        bug!("expected fn def for autodiff, got {:?}", fn_ty);
+    if !matches!(fn_ty.kind(), ty::FnPtr(..)) {
+        // TODO: We may need to support FnDef here for non-`rlib` scenarios.
+        bug!("expected fn ptr for autodiff, got {:?}", fn_ty);
     }
 
     // We don't actually pass the types back into the type system.
@@ -32,16 +30,16 @@ pub(crate) fn adjust_activity_to_abi<'tcx>(
 
     // FIXME(Sa4dUs): pass proper varargs once we have support for differentiating variadic functions
     let Ok(fn_abi) =
-        tcx.fn_abi_of_instance(typing_env.as_query_input((instance, ty::List::empty())))
+        tcx.fn_abi_of_fn_ptr(PseudoCanonicalInput { typing_env: TypingEnv::fully_monomorphized(), value: (ty::Binder::dummy(sig), ty::List::empty()) })
     else {
-        bug!("failed to get fn_abi of instance with empty varargs");
+        bug!("failed to get fn_abi of fn_ptr with empty varargs");
     };
 
     let mut new_activities = vec![];
     let mut new_positions = vec![];
     let mut del_activities = 0;
     for (i, ty) in sig.inputs().iter().enumerate() {
-        if let Some(inner_ty) = ty.builtin_deref(true) {
+        if let Some(inner_ty) = (*ty).builtin_deref(true) {
             if inner_ty.is_slice() {
                 // Now we need to figure out the size of each slice element in memory to allow
                 // safety checks and usability improvements in the backend.

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -1329,12 +1329,7 @@ fn codegen_autodiff<'ll, 'tcx>(
         bug!("could not find autodiff attrs")
     };
 
-    adjust_activity_to_abi(
-        tcx,
-        fn_source,
-        TypingEnv::fully_monomorphized(),
-        &mut diff_attrs.input_activity,
-    );
+    adjust_activity_to_abi(tcx, fn_source.ty(tcx, bx.typing_env()), &mut diff_attrs.input_activity);
 
     let fnc_tree =
         rustc_middle::ty::fnc_typetrees(tcx, fn_source.ty(tcx, TypingEnv::fully_monomorphized()));


### PR DESCRIPTION
Fixes rust-lang/rust#149164

Trying to remove unnecessary complexity in the current automatic differentiation (autodiff) implementation for `rlib`s. The previous approach involved handling `Instance` types when determining the function ABI for autodiff.
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
