### PR TITLE
unwind/wasm: fix compile error by wrapping wasm_throw in unsafe block

### DIFF
--- a/library/unwind/src/wasm.rs
+++ b/library/unwind/src/wasm.rs
@@ -73,7 +73,7 @@ pub unsafe fn _Unwind_RaiseException(exception: *mut _Unwind_Exception) -> _Unwi
             // corresponds with llvm::WebAssembly::Tag::CPP_EXCEPTION
             //     in llvm-project/llvm/include/llvm/CodeGen/WasmEHFuncInfo.h
             const CPP_EXCEPTION_TAG: i32 = 0;
-            wasm_throw(CPP_EXCEPTION_TAG, exception.cast())
+            unsafe { wasm_throw(CPP_EXCEPTION_TAG, exception.cast()) }
         }
         _ => {
             let _ = exception;


### PR DESCRIPTION
This fix rust-std compile error on wasm32-unknown-unknown with panic=unwind because of `#![deny(unsafe_op_in_unsafe_fn)]`