### PR TITLE
Remove tm_factory field from CodegenContext

### DIFF
--- a/compiler/rustc_codegen_gcc/src/back/lto.rs
+++ b/compiler/rustc_codegen_gcc/src/back/lto.rs
@@ -50,7 +50,7 @@ struct LtoData {
 }
 
 fn prepare_lto(
-    cgcx: &CodegenContext<GccCodegenBackend>,
+    cgcx: &CodegenContext,
     each_linked_rlib_for_lto: &[PathBuf],
     dcx: DiagCtxtHandle<'_>,
 ) -> LtoData {
@@ -111,7 +111,7 @@ fn save_as_file(obj: &[u8], path: &Path) -> Result<(), LtoBitcodeFromRlib> {
 /// Performs fat LTO by merging all modules into a single one and returning it
 /// for further optimization.
 pub(crate) fn run_fat(
-    cgcx: &CodegenContext<GccCodegenBackend>,
+    cgcx: &CodegenContext,
     shared_emitter: &SharedEmitter,
     each_linked_rlib_for_lto: &[PathBuf],
     modules: Vec<FatLtoInput<GccCodegenBackend>>,
@@ -132,7 +132,7 @@ pub(crate) fn run_fat(
 }
 
 fn fat_lto(
-    cgcx: &CodegenContext<GccCodegenBackend>,
+    cgcx: &CodegenContext,
     _dcx: DiagCtxtHandle<'_>,
     modules: Vec<FatLtoInput<GccCodegenBackend>>,
     mut serialized_modules: Vec<(SerializedModule<ModuleBuffer>, CString)>,
@@ -283,7 +283,7 @@ impl ModuleBufferMethods for ModuleBuffer {
 /// lists, one of the modules that need optimization and another for modules that
 /// can simply be copied over from the incr. comp. cache.
 pub(crate) fn run_thin(
-    cgcx: &CodegenContext<GccCodegenBackend>,
+    cgcx: &CodegenContext,
     dcx: DiagCtxtHandle<'_>,
     each_linked_rlib_for_lto: &[PathBuf],
     modules: Vec<(String, ThinBuffer)>,
@@ -345,7 +345,7 @@ pub(crate) fn prepare_thin(module: ModuleCodegen<GccContext>) -> (String, ThinBu
 /// all of the `LtoModuleCodegen` units returned below and destroyed once
 /// they all go out of scope.
 fn thin_lto(
-    cgcx: &CodegenContext<GccCodegenBackend>,
+    cgcx: &CodegenContext,
     _dcx: DiagCtxtHandle<'_>,
     modules: Vec<(String, ThinBuffer)>,
     serialized_modules: Vec<(SerializedModule<ModuleBuffer>, CString)>,
@@ -520,11 +520,9 @@ fn thin_lto(
 
 pub fn optimize_thin_module(
     thin_module: ThinModule<GccCodegenBackend>,
-    _cgcx: &CodegenContext<GccCodegenBackend>,
+    _cgcx: &CodegenContext,
 ) -> ModuleCodegen<GccContext> {
     //let module_name = &thin_module.shared.module_names[thin_module.idx];
-    /*let tm_factory_config = TargetMachineFactoryConfig::new(cgcx, module_name.to_str().unwrap());
-    let tm = (cgcx.tm_factory)(tm_factory_config).map_err(|e| write::llvm_err(&dcx, e))?;*/
 
     // Right now the implementation we've got only works over serialized
     // modules, so we create a fresh new LLVM context and parse the module

--- a/compiler/rustc_codegen_gcc/src/back/write.rs
+++ b/compiler/rustc_codegen_gcc/src/back/write.rs
@@ -14,10 +14,10 @@ use rustc_target::spec::SplitDebuginfo;
 
 use crate::base::add_pic_option;
 use crate::errors::CopyBitcode;
-use crate::{GccCodegenBackend, GccContext, LtoMode};
+use crate::{GccContext, LtoMode};
 
 pub(crate) fn codegen(
-    cgcx: &CodegenContext<GccCodegenBackend>,
+    cgcx: &CodegenContext,
     shared_emitter: &SharedEmitter,
     module: ModuleCodegen<GccContext>,
     config: &ModuleConfig,
@@ -227,7 +227,7 @@ pub(crate) fn codegen(
 }
 
 pub(crate) fn save_temp_bitcode(
-    cgcx: &CodegenContext<GccCodegenBackend>,
+    cgcx: &CodegenContext,
     _module: &ModuleCodegen<GccContext>,
     _name: &str,
 ) {

--- a/compiler/rustc_codegen_gcc/src/lib.rs
+++ b/compiler/rustc_codegen_gcc/src/lib.rs
@@ -426,8 +426,9 @@ impl WriteBackendMethods for GccCodegenBackend {
     type ThinBuffer = ThinBuffer;
 
     fn run_and_optimize_fat_lto(
-        cgcx: &CodegenContext<Self>,
+        cgcx: &CodegenContext,
         shared_emitter: &SharedEmitter,
+        _tm_factory: TargetMachineFactoryFn<Self>,
         // FIXME(bjorn3): Limit LTO exports to these symbols
         _exported_symbols_for_lto: &[String],
         each_linked_rlib_for_lto: &[PathBuf],
@@ -437,7 +438,7 @@ impl WriteBackendMethods for GccCodegenBackend {
     }
 
     fn run_thin_lto(
-        cgcx: &CodegenContext<Self>,
+        cgcx: &CodegenContext,
         dcx: DiagCtxtHandle<'_>,
         // FIXME(bjorn3): Limit LTO exports to these symbols
         _exported_symbols_for_lto: &[String],
@@ -457,7 +458,7 @@ impl WriteBackendMethods for GccCodegenBackend {
     }
 
     fn optimize(
-        _cgcx: &CodegenContext<Self>,
+        _cgcx: &CodegenContext,
         _shared_emitter: &SharedEmitter,
         module: &mut ModuleCodegen<Self::Module>,
         config: &ModuleConfig,
@@ -466,15 +467,16 @@ impl WriteBackendMethods for GccCodegenBackend {
     }
 
     fn optimize_thin(
-        cgcx: &CodegenContext<Self>,
+        cgcx: &CodegenContext,
         _shared_emitter: &SharedEmitter,
+        _tm_factory: TargetMachineFactoryFn<Self>,
         thin: ThinModule<Self>,
     ) -> ModuleCodegen<Self::Module> {
         back::lto::optimize_thin_module(thin, cgcx)
     }
 
     fn codegen(
-        cgcx: &CodegenContext<Self>,
+        cgcx: &CodegenContext,
         shared_emitter: &SharedEmitter,
         module: ModuleCodegen<Self::Module>,
         config: &ModuleConfig,

--- a/compiler/rustc_codegen_gcc/src/lib.rs
+++ b/compiler/rustc_codegen_gcc/src/lib.rs
@@ -374,7 +374,7 @@ impl ExtraBackendMethods for GccCodegenBackend {
         _features: &[String],
     ) -> TargetMachineFactoryFn<Self> {
         // TODO(antoyo): set opt level.
-        Arc::new(|_| Ok(()))
+        Arc::new(|_, _| ())
     }
 }
 
@@ -421,7 +421,6 @@ unsafe impl Sync for SyncContext {}
 impl WriteBackendMethods for GccCodegenBackend {
     type Module = GccContext;
     type TargetMachine = ();
-    type TargetMachineError = ();
     type ModuleBuffer = ModuleBuffer;
     type ThinData = ThinData;
     type ThinBuffer = ThinBuffer;

--- a/compiler/rustc_codegen_llvm/src/errors.rs
+++ b/compiler/rustc_codegen_llvm/src/errors.rs
@@ -94,7 +94,7 @@ pub(crate) struct LtoBitcodeFromRlib {
 }
 
 #[derive(Diagnostic)]
-pub enum LlvmError<'a> {
+pub(crate) enum LlvmError<'a> {
     #[diag("could not write output to {$path}")]
     WriteOutput { path: &'a Path },
     #[diag("could not create LLVM TargetMachine for triple: {$triple}")]

--- a/compiler/rustc_codegen_llvm/src/errors.rs
+++ b/compiler/rustc_codegen_llvm/src/errors.rs
@@ -101,8 +101,6 @@ pub enum LlvmError<'a> {
     CreateTargetMachine { triple: SmallCStr },
     #[diag("failed to run LLVM passes")]
     RunLlvmPasses,
-    #[diag("failed to serialize module {$name}")]
-    SerializeModule { name: &'a str },
     #[diag("failed to write LLVM IR to {$path}")]
     WriteIr { path: &'a Path },
     #[diag("failed to prepare thin LTO context")]
@@ -115,8 +113,6 @@ pub enum LlvmError<'a> {
     PrepareThinLtoModule,
     #[diag("failed to parse bitcode for LTO module")]
     ParseBitcode,
-    #[diag("failed to prepare autodiff: src: {$src}, target: {$target}, {$error}")]
-    PrepareAutoDiff { src: String, target: String, error: String },
 }
 
 pub(crate) struct WithLlvmError<'a>(pub LlvmError<'a>, pub String);
@@ -130,9 +126,6 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for WithLlvmError<'_> {
                 "could not create LLVM TargetMachine for triple: {$triple}: {$llvm_err}"
             ),
             RunLlvmPasses => inline_fluent!("failed to run LLVM passes: {$llvm_err}"),
-            SerializeModule { .. } => {
-                inline_fluent!("failed to serialize module {$name}: {$llvm_err}")
-            }
             WriteIr { .. } => inline_fluent!("failed to write LLVM IR to {$path}: {$llvm_err}"),
             PrepareThinLtoContext => {
                 inline_fluent!("failed to prepare thin LTO context: {$llvm_err}")
@@ -147,9 +140,6 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for WithLlvmError<'_> {
                 inline_fluent!("failed to prepare thin LTO module: {$llvm_err}")
             }
             ParseBitcode => inline_fluent!("failed to parse bitcode for LTO module: {$llvm_err}"),
-            PrepareAutoDiff { .. } => inline_fluent!(
-                "failed to prepare autodiff: {$llvm_err}, src: {$src}, target: {$target}, {$error}"
-            ),
         };
         self.0
             .into_diag(dcx, level)

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -25,7 +25,6 @@ use std::path::PathBuf;
 use back::owned_target_machine::OwnedTargetMachine;
 use back::write::{create_informational_target_machine, create_target_machine};
 use context::SimpleCx;
-use errors::ParseTargetMachineConfig;
 use llvm_util::target_config;
 use rustc_ast::expand::allocator::AllocatorMethod;
 use rustc_codegen_ssa::back::lto::{SerializedModule, ThinModule};
@@ -152,7 +151,6 @@ impl WriteBackendMethods for LlvmCodegenBackend {
     type Module = ModuleLlvm;
     type ModuleBuffer = back::lto::ModuleBuffer;
     type TargetMachine = OwnedTargetMachine;
-    type TargetMachineError = crate::errors::LlvmError<'static>;
     type ThinData = back::lto::ThinData;
     type ThinBuffer = back::lto::ThinBuffer;
     fn print_pass_timings(&self) {
@@ -445,13 +443,7 @@ impl ModuleLlvm {
         name: &str,
         dcx: DiagCtxtHandle<'_>,
     ) -> OwnedTargetMachine {
-        let tm_factory_config = TargetMachineFactoryConfig::new(cgcx, name);
-        match (cgcx.tm_factory)(tm_factory_config) {
-            Ok(m) => m,
-            Err(e) => {
-                dcx.emit_fatal(ParseTargetMachineConfig(e));
-            }
-        }
+        (cgcx.tm_factory)(dcx, TargetMachineFactoryConfig::new(cgcx, name))
     }
 
     fn parse(

--- a/compiler/rustc_codegen_ssa/src/back/lto.rs
+++ b/compiler/rustc_codegen_ssa/src/back/lto.rs
@@ -127,10 +127,7 @@ pub(super) fn exported_symbols_for_lto(
     symbols_below_threshold
 }
 
-pub(super) fn check_lto_allowed<B: WriteBackendMethods>(
-    cgcx: &CodegenContext<B>,
-    dcx: DiagCtxtHandle<'_>,
-) {
+pub(super) fn check_lto_allowed(cgcx: &CodegenContext, dcx: DiagCtxtHandle<'_>) {
     if cgcx.lto == Lto::ThinLocal {
         // Crate local LTO is always allowed
         return;

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -313,11 +313,10 @@ impl TargetMachineFactoryConfig {
 
 pub type TargetMachineFactoryFn<B> = Arc<
     dyn Fn(
+            DiagCtxtHandle<'_>,
             TargetMachineFactoryConfig,
-        ) -> Result<
-            <B as WriteBackendMethods>::TargetMachine,
-            <B as WriteBackendMethods>::TargetMachineError,
-        > + Send
+        ) -> <B as WriteBackendMethods>::TargetMachine
+        + Send
         + Sync,
 >;
 

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -29,7 +29,8 @@ use rustc_middle::dep_graph::{WorkProduct, WorkProductId};
 use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
 use rustc_session::config::{
-    self, CrateType, Lto, OutFileName, OutputFilenames, OutputType, Passes, SwitchWithOptPath,
+    self, CrateType, Lto, OptLevel, OutFileName, OutputFilenames, OutputType, Passes,
+    SwitchWithOptPath,
 };
 use rustc_span::source_map::SourceMap;
 use rustc_span::{FileName, InnerSpan, Span, SpanData};
@@ -287,10 +288,7 @@ pub struct TargetMachineFactoryConfig {
 }
 
 impl TargetMachineFactoryConfig {
-    pub fn new(
-        cgcx: &CodegenContext<impl WriteBackendMethods>,
-        module_name: &str,
-    ) -> TargetMachineFactoryConfig {
+    pub fn new(cgcx: &CodegenContext, module_name: &str) -> TargetMachineFactoryConfig {
         let split_dwarf_file = if cgcx.target_can_use_split_dwarf {
             cgcx.output_filenames.split_dwarf_path(
                 cgcx.split_debuginfo,
@@ -322,7 +320,7 @@ pub type TargetMachineFactoryFn<B> = Arc<
 
 /// Additional resources used by optimize_and_codegen (not module specific)
 #[derive(Clone)]
-pub struct CodegenContext<B: WriteBackendMethods> {
+pub struct CodegenContext {
     // Resources needed when running LTO
     pub prof: SelfProfilerRef,
     pub lto: Lto,
@@ -336,7 +334,8 @@ pub struct CodegenContext<B: WriteBackendMethods> {
     pub output_filenames: Arc<OutputFilenames>,
     pub invocation_temp: Option<String>,
     pub module_config: Arc<ModuleConfig>,
-    pub tm_factory: TargetMachineFactoryFn<B>,
+    pub opt_level: OptLevel,
+    pub backend_features: Vec<String>,
     pub msvc_imps_needed: bool,
     pub is_pe_coff: bool,
     pub target_can_use_split_dwarf: bool,
@@ -363,7 +362,7 @@ pub struct CodegenContext<B: WriteBackendMethods> {
 }
 
 fn generate_thin_lto_work<B: ExtraBackendMethods>(
-    cgcx: &CodegenContext<B>,
+    cgcx: &CodegenContext,
     dcx: DiagCtxtHandle<'_>,
     exported_symbols_for_lto: &[String],
     each_linked_rlib_for_lto: &[PathBuf],
@@ -409,7 +408,7 @@ enum MaybeLtoModules<B: WriteBackendMethods> {
         allocator_module: Option<CompiledModule>,
     },
     FatLto {
-        cgcx: CodegenContext<B>,
+        cgcx: CodegenContext,
         exported_symbols_for_lto: Arc<Vec<String>>,
         each_linked_rlib_file_for_lto: Vec<PathBuf>,
         needs_fat_lto: Vec<FatLtoInput<B>>,
@@ -417,7 +416,7 @@ enum MaybeLtoModules<B: WriteBackendMethods> {
             Vec<(SerializedModule<<B as WriteBackendMethods>::ModuleBuffer>, WorkProduct)>,
     },
     ThinLto {
-        cgcx: CodegenContext<B>,
+        cgcx: CodegenContext,
         exported_symbols_for_lto: Arc<Vec<String>>,
         each_linked_rlib_file_for_lto: Vec<PathBuf>,
         needs_thin_lto: Vec<(String, <B as WriteBackendMethods>::ThinBuffer)>,
@@ -841,7 +840,7 @@ pub(crate) fn compute_per_cgu_lto_type(
 }
 
 fn execute_optimize_work_item<B: ExtraBackendMethods>(
-    cgcx: &CodegenContext<B>,
+    cgcx: &CodegenContext,
     shared_emitter: SharedEmitter,
     mut module: ModuleCodegen<B::Module>,
 ) -> WorkItemResult<B> {
@@ -896,8 +895,8 @@ fn execute_optimize_work_item<B: ExtraBackendMethods>(
     }
 }
 
-fn execute_copy_from_cache_work_item<B: ExtraBackendMethods>(
-    cgcx: &CodegenContext<B>,
+fn execute_copy_from_cache_work_item(
+    cgcx: &CodegenContext,
     shared_emitter: SharedEmitter,
     module: CachedModuleCodegen,
 ) -> CompiledModule {
@@ -985,8 +984,9 @@ fn execute_copy_from_cache_work_item<B: ExtraBackendMethods>(
 }
 
 fn do_fat_lto<B: ExtraBackendMethods>(
-    cgcx: &CodegenContext<B>,
+    cgcx: &CodegenContext,
     shared_emitter: SharedEmitter,
+    tm_factory: TargetMachineFactoryFn<B>,
     exported_symbols_for_lto: &[String],
     each_linked_rlib_for_lto: &[PathBuf],
     mut needs_fat_lto: Vec<FatLtoInput<B>>,
@@ -1006,6 +1006,7 @@ fn do_fat_lto<B: ExtraBackendMethods>(
     let module = B::run_and_optimize_fat_lto(
         cgcx,
         &shared_emitter,
+        tm_factory,
         exported_symbols_for_lto,
         each_linked_rlib_for_lto,
         needs_fat_lto,
@@ -1014,8 +1015,9 @@ fn do_fat_lto<B: ExtraBackendMethods>(
 }
 
 fn do_thin_lto<'a, B: ExtraBackendMethods>(
-    cgcx: &'a CodegenContext<B>,
+    cgcx: &'a CodegenContext,
     shared_emitter: SharedEmitter,
+    tm_factory: TargetMachineFactoryFn<B>,
     exported_symbols_for_lto: Arc<Vec<String>>,
     each_linked_rlib_for_lto: Vec<PathBuf>,
     needs_thin_lto: Vec<(String, <B as WriteBackendMethods>::ThinBuffer)>,
@@ -1052,7 +1054,7 @@ fn do_thin_lto<'a, B: ExtraBackendMethods>(
     // bunch of work items onto our queue to do LTO. This all
     // happens on the coordinator thread but it's very quick so
     // we don't worry about tokens.
-    for (work, cost) in generate_thin_lto_work(
+    for (work, cost) in generate_thin_lto_work::<B>(
         cgcx,
         dcx,
         &exported_symbols_for_lto,
@@ -1096,7 +1098,13 @@ fn do_thin_lto<'a, B: ExtraBackendMethods>(
             while used_token_count < tokens.len() + 1
                 && let Some((item, _)) = work_items.pop()
             {
-                spawn_thin_lto_work(&cgcx, shared_emitter.clone(), coordinator_send.clone(), item);
+                spawn_thin_lto_work(
+                    &cgcx,
+                    shared_emitter.clone(),
+                    Arc::clone(&tm_factory),
+                    coordinator_send.clone(),
+                    item,
+                );
                 used_token_count += 1;
             }
         } else {
@@ -1157,13 +1165,14 @@ fn do_thin_lto<'a, B: ExtraBackendMethods>(
 }
 
 fn execute_thin_lto_work_item<B: ExtraBackendMethods>(
-    cgcx: &CodegenContext<B>,
+    cgcx: &CodegenContext,
     shared_emitter: SharedEmitter,
+    tm_factory: TargetMachineFactoryFn<B>,
     module: lto::ThinModule<B>,
 ) -> CompiledModule {
     let _timer = cgcx.prof.generic_activity_with_arg("codegen_module_perform_lto", module.name());
 
-    let module = B::optimize_thin(cgcx, &shared_emitter, module);
+    let module = B::optimize_thin(cgcx, &shared_emitter, tm_factory, module);
     B::codegen(cgcx, &shared_emitter, module, &cgcx.module_config)
 }
 
@@ -1291,8 +1300,9 @@ fn start_executing_work<B: ExtraBackendMethods>(
         })
         .expect("failed to spawn helper thread");
 
-    let ol = tcx.backend_optimization_level(());
-    let backend_features = tcx.global_backend_features(());
+    let opt_level = tcx.backend_optimization_level(());
+    let backend_features = tcx.global_backend_features(()).clone();
+    let tm_factory = backend.target_machine_factory(tcx.sess, opt_level, &backend_features);
 
     let remark_dir = if let Some(ref dir) = sess.opts.unstable_opts.remark_dir {
         let result = fs::create_dir_all(dir).and_then(|_| dir.canonicalize());
@@ -1304,7 +1314,7 @@ fn start_executing_work<B: ExtraBackendMethods>(
         None
     };
 
-    let cgcx = CodegenContext::<B> {
+    let cgcx = CodegenContext {
         crate_types: tcx.crate_types().to_vec(),
         lto: sess.lto(),
         use_linker_plugin_lto: sess.opts.cg.linker_plugin_lto.enabled(),
@@ -1319,7 +1329,8 @@ fn start_executing_work<B: ExtraBackendMethods>(
         incr_comp_session_dir: sess.incr_comp_session_dir_opt().map(|r| r.clone()),
         output_filenames: Arc::clone(tcx.output_filenames(())),
         module_config: regular_config,
-        tm_factory: backend.target_machine_factory(tcx.sess, ol, backend_features),
+        opt_level,
+        backend_features,
         msvc_imps_needed: msvc_imps_needed(tcx),
         is_pe_coff: tcx.sess.target.is_like_windows,
         target_can_use_split_dwarf: tcx.sess.target_can_use_split_dwarf(),
@@ -1775,9 +1786,10 @@ fn start_executing_work<B: ExtraBackendMethods>(
             assert!(needs_fat_lto.is_empty());
 
             if cgcx.lto == Lto::ThinLocal {
-                compiled_modules.extend(do_thin_lto(
+                compiled_modules.extend(do_thin_lto::<B>(
                     &cgcx,
                     shared_emitter.clone(),
+                    tm_factory,
                     exported_symbols_for_lto,
                     each_linked_rlib_file_for_lto,
                     needs_thin_lto,
@@ -1871,7 +1883,7 @@ fn start_executing_work<B: ExtraBackendMethods>(
 pub(crate) struct WorkerFatalError;
 
 fn spawn_work<'a, B: ExtraBackendMethods>(
-    cgcx: &'a CodegenContext<B>,
+    cgcx: &'a CodegenContext,
     shared_emitter: SharedEmitter,
     coordinator_send: Sender<Message<B>>,
     llvm_start_time: &mut Option<VerboseTimingGuard<'a>>,
@@ -1909,8 +1921,9 @@ fn spawn_work<'a, B: ExtraBackendMethods>(
 }
 
 fn spawn_thin_lto_work<'a, B: ExtraBackendMethods>(
-    cgcx: &'a CodegenContext<B>,
+    cgcx: &'a CodegenContext,
     shared_emitter: SharedEmitter,
+    tm_factory: TargetMachineFactoryFn<B>,
     coordinator_send: Sender<ThinLtoMessage>,
     work: ThinLtoWorkItem<B>,
 ) {
@@ -1921,7 +1934,9 @@ fn spawn_thin_lto_work<'a, B: ExtraBackendMethods>(
             ThinLtoWorkItem::CopyPostLtoArtifacts(m) => {
                 execute_copy_from_cache_work_item(&cgcx, shared_emitter, m)
             }
-            ThinLtoWorkItem::ThinLto(m) => execute_thin_lto_work_item(&cgcx, shared_emitter, m),
+            ThinLtoWorkItem::ThinLto(m) => {
+                execute_thin_lto_work_item(&cgcx, shared_emitter, tm_factory, m)
+            }
         }));
 
         let msg = match result {
@@ -2158,34 +2173,52 @@ impl<B: ExtraBackendMethods> OngoingCodegen<B> {
                 each_linked_rlib_file_for_lto,
                 needs_fat_lto,
                 lto_import_only_modules,
-            } => CompiledModules {
-                modules: vec![do_fat_lto(
-                    &cgcx,
-                    shared_emitter,
-                    &exported_symbols_for_lto,
-                    &each_linked_rlib_file_for_lto,
-                    needs_fat_lto,
-                    lto_import_only_modules,
-                )],
-                allocator_module: None,
-            },
+            } => {
+                let tm_factory = self.backend.target_machine_factory(
+                    sess,
+                    cgcx.opt_level,
+                    &cgcx.backend_features,
+                );
+
+                CompiledModules {
+                    modules: vec![do_fat_lto(
+                        &cgcx,
+                        shared_emitter,
+                        tm_factory,
+                        &exported_symbols_for_lto,
+                        &each_linked_rlib_file_for_lto,
+                        needs_fat_lto,
+                        lto_import_only_modules,
+                    )],
+                    allocator_module: None,
+                }
+            }
             MaybeLtoModules::ThinLto {
                 cgcx,
                 exported_symbols_for_lto,
                 each_linked_rlib_file_for_lto,
                 needs_thin_lto,
                 lto_import_only_modules,
-            } => CompiledModules {
-                modules: do_thin_lto(
-                    &cgcx,
-                    shared_emitter,
-                    exported_symbols_for_lto,
-                    each_linked_rlib_file_for_lto,
-                    needs_thin_lto,
-                    lto_import_only_modules,
-                ),
-                allocator_module: None,
-            },
+            } => {
+                let tm_factory = self.backend.target_machine_factory(
+                    sess,
+                    cgcx.opt_level,
+                    &cgcx.backend_features,
+                );
+
+                CompiledModules {
+                    modules: do_thin_lto::<B>(
+                        &cgcx,
+                        shared_emitter,
+                        tm_factory,
+                        exported_symbols_for_lto,
+                        each_linked_rlib_file_for_lto,
+                        needs_thin_lto,
+                        lto_import_only_modules,
+                    ),
+                    allocator_module: None,
+                }
+            }
         });
 
         shared_emitter_main.check(sess, true);

--- a/compiler/rustc_codegen_ssa/src/traits/write.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/write.rs
@@ -10,7 +10,6 @@ use crate::{CompiledModule, ModuleCodegen};
 pub trait WriteBackendMethods: Clone + 'static {
     type Module: Send + Sync;
     type TargetMachine;
-    type TargetMachineError;
     type ModuleBuffer: ModuleBufferMethods;
     type ThinData: Send + Sync;
     type ThinBuffer: ThinBufferMethods;

--- a/compiler/rustc_codegen_ssa/src/traits/write.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/write.rs
@@ -4,7 +4,9 @@ use rustc_errors::DiagCtxtHandle;
 use rustc_middle::dep_graph::WorkProduct;
 
 use crate::back::lto::{SerializedModule, ThinModule};
-use crate::back::write::{CodegenContext, FatLtoInput, ModuleConfig, SharedEmitter};
+use crate::back::write::{
+    CodegenContext, FatLtoInput, ModuleConfig, SharedEmitter, TargetMachineFactoryFn,
+};
 use crate::{CompiledModule, ModuleCodegen};
 
 pub trait WriteBackendMethods: Clone + 'static {
@@ -17,8 +19,9 @@ pub trait WriteBackendMethods: Clone + 'static {
     /// Performs fat LTO by merging all modules into a single one, running autodiff
     /// if necessary and running any further optimizations
     fn run_and_optimize_fat_lto(
-        cgcx: &CodegenContext<Self>,
+        cgcx: &CodegenContext,
         shared_emitter: &SharedEmitter,
+        tm_factory: TargetMachineFactoryFn<Self>,
         exported_symbols_for_lto: &[String],
         each_linked_rlib_for_lto: &[PathBuf],
         modules: Vec<FatLtoInput<Self>>,
@@ -27,7 +30,7 @@ pub trait WriteBackendMethods: Clone + 'static {
     /// lists, one of the modules that need optimization and another for modules that
     /// can simply be copied over from the incr. comp. cache.
     fn run_thin_lto(
-        cgcx: &CodegenContext<Self>,
+        cgcx: &CodegenContext,
         dcx: DiagCtxtHandle<'_>,
         exported_symbols_for_lto: &[String],
         each_linked_rlib_for_lto: &[PathBuf],
@@ -37,18 +40,19 @@ pub trait WriteBackendMethods: Clone + 'static {
     fn print_pass_timings(&self);
     fn print_statistics(&self);
     fn optimize(
-        cgcx: &CodegenContext<Self>,
+        cgcx: &CodegenContext,
         shared_emitter: &SharedEmitter,
         module: &mut ModuleCodegen<Self::Module>,
         config: &ModuleConfig,
     );
     fn optimize_thin(
-        cgcx: &CodegenContext<Self>,
+        cgcx: &CodegenContext,
         shared_emitter: &SharedEmitter,
+        tm_factory: TargetMachineFactoryFn<Self>,
         thin: ThinModule<Self>,
     ) -> ModuleCodegen<Self::Module>;
     fn codegen(
-        cgcx: &CodegenContext<Self>,
+        cgcx: &CodegenContext,
         shared_emitter: &SharedEmitter,
         module: ModuleCodegen<Self::Module>,
         config: &ModuleConfig,


### PR DESCRIPTION
This is necessary to support serializing the `CodegenContext` to a `.rlink` file in the future for moving LTO to the `-Zlink-only` step.

Follow up to https://github.com/rust-lang/rust/pull/149209
Part of https://github.com/rust-lang/compiler-team/issues/908