### PR TITLE
`format_args!`: only de-duplicate captured identifiers that refer to places

### DIFF
--- a/compiler/rustc_ast/src/format.rs
+++ b/compiler/rustc_ast/src/format.rs
@@ -77,14 +77,14 @@ pub struct FormatArguments {
     arguments: Vec<FormatArgument>,
     num_unnamed_args: usize,
     num_explicit_args: usize,
-    names: FxHashMap<Symbol, usize>,
+    explicit_names: FxHashMap<Symbol, usize>,
 }
 
 impl FormatArguments {
     pub fn new() -> Self {
         Self {
             arguments: Vec::new(),
-            names: FxHashMap::default(),
+            explicit_names: FxHashMap::default(),
             num_unnamed_args: 0,
             num_explicit_args: 0,
         }
@@ -92,12 +92,20 @@ impl FormatArguments {
 
     pub fn add(&mut self, arg: FormatArgument) -> usize {
         let index = self.arguments.len();
-        if let Some(name) = arg.kind.ident() {
-            self.names.insert(name.name, index);
-        } else if self.names.is_empty() {
-            // Only count the unnamed args before the first named arg.
-            // (Any later ones are errors.)
-            self.num_unnamed_args += 1;
+        match arg.kind {
+            FormatArgumentKind::Normal => {
+                // Only count the unnamed args before the first named arg.
+                // (Any later ones are errors.)
+                if self.explicit_names.is_empty() {
+                    self.num_unnamed_args += 1;
+                }
+            }
+            FormatArgumentKind::Named(ident) => {
+                self.explicit_names.insert(ident.name, index);
+            }
+            FormatArgumentKind::Captured(_) => {
+                // Don't record the name yet, to keep duplicate captures until AST->HIR lowering.
+            }
         }
         if !matches!(arg.kind, FormatArgumentKind::Captured(..)) {
             // This is an explicit argument.
@@ -113,8 +121,8 @@ impl FormatArguments {
         index
     }
 
-    pub fn by_name(&self, name: Symbol) -> Option<(usize, &FormatArgument)> {
-        let i = *self.names.get(&name)?;
+    pub fn by_explicit_name(&self, name: Symbol) -> Option<(usize, &FormatArgument)> {
+        let i = *self.explicit_names.get(&name)?;
         Some((i, &self.arguments[i]))
     }
 

--- a/compiler/rustc_ast_lowering/src/format.rs
+++ b/compiler/rustc_ast_lowering/src/format.rs
@@ -1,8 +1,9 @@
 use std::borrow::Cow;
 
 use rustc_ast::*;
-use rustc_data_structures::fx::FxIndexMap;
-use rustc_hir as hir;
+use rustc_data_structures::fx::{FxHashMap, FxIndexMap};
+use rustc_hir::def::{DefKind, Res};
+use rustc_hir::{self as hir};
 use rustc_session::config::FmtDebug;
 use rustc_span::{ByteSymbol, DesugaringKind, Ident, Span, Symbol, sym};
 
@@ -25,6 +26,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             fmt = flatten_format_args(fmt);
             fmt = self.inline_literals(fmt);
         }
+        fmt = self.dedup_captured_places(fmt);
         expand_format_args(self, sp, &fmt, allow_const)
     }
 
@@ -116,6 +118,80 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
             // Don't remove anything that's still used.
             for_all_argument_indexes(&mut fmt.template, |index| remove[*index] = false);
+
+            // Drop all the arguments that are marked for removal.
+            let mut remove_it = remove.iter();
+            fmt.arguments.all_args_mut().retain(|_| remove_it.next() != Some(&true));
+
+            // Calculate the mapping of old to new indexes for the remaining arguments.
+            let index_map: Vec<usize> = remove
+                .into_iter()
+                .scan(0, |i, remove| {
+                    let mapped = *i;
+                    *i += !remove as usize;
+                    Some(mapped)
+                })
+                .collect();
+
+            // Correct the indexes that refer to arguments that have shifted position.
+            for_all_argument_indexes(&mut fmt.template, |index| *index = index_map[*index]);
+        }
+
+        fmt
+    }
+
+    /// De-duplicate implicit captures of identifiers that refer to places.
+    ///
+    /// Turns
+    ///
+    /// `format_args!("Hello, {hello}, {hello}!")`
+    ///
+    /// into
+    ///
+    /// `format_args!("Hello, {hello}, {hello}!", hello=hello)`.
+    fn dedup_captured_places<'fmt>(&self, mut fmt: Cow<'fmt, FormatArgs>) -> Cow<'fmt, FormatArgs> {
+        use std::collections::hash_map::Entry;
+
+        let mut deduped_arg_indices: FxHashMap<Symbol, usize> = FxHashMap::default();
+        let mut remove = vec![false; fmt.arguments.all_args().len()];
+        let mut deduped_anything = false;
+
+        // Re-use arguments for placeholders capturing the same local/static identifier.
+        for i in 0..fmt.template.len() {
+            if let FormatArgsPiece::Placeholder(placeholder) = &fmt.template[i]
+                && let Ok(arg_index) = placeholder.argument.index
+                && let arg = &fmt.arguments.all_args()[arg_index]
+                && let FormatArgumentKind::Captured(ident) = arg.kind
+            {
+                match deduped_arg_indices.entry(ident.name) {
+                    Entry::Occupied(occupied_entry) => {
+                        // We've seen this identifier before, and it's dedupable. Point the
+                        // placeholder at the recorded arg index, cloning `fmt` if necessary.
+                        let piece = &mut fmt.to_mut().template[i];
+                        let FormatArgsPiece::Placeholder(placeholder) = piece else {
+                            unreachable!();
+                        };
+                        placeholder.argument.index = Ok(*occupied_entry.get());
+                        remove[arg_index] = true;
+                        deduped_anything = true;
+                    }
+                    Entry::Vacant(vacant_entry) => {
+                        // This is the first time we've seen a captured identifier. If it's a local
+                        // or static, note the argument index so other occurrences can be deduped.
+                        if let Some(partial_res) = self.resolver.partial_res_map.get(&arg.expr.id)
+                            && let Some(res) = partial_res.full_res()
+                            && matches!(res, Res::Local(_) | Res::Def(DefKind::Static { .. }, _))
+                        {
+                            vacant_entry.insert(arg_index);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Remove the arguments that were de-duplicated.
+        if deduped_anything {
+            let fmt = fmt.to_mut();
 
             // Drop all the arguments that are marked for removal.
             let mut remove_it = remove.iter();

--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -121,7 +121,7 @@ fn parse_args<'a>(ecx: &ExtCtxt<'a>, sp: Span, tts: TokenStream) -> PResult<'a, 
                 p.bump();
                 p.expect(exp!(Eq))?;
                 let expr = p.parse_expr()?;
-                if let Some((_, prev)) = args.by_name(ident.name) {
+                if let Some((_, prev)) = args.by_explicit_name(ident.name) {
                     ecx.dcx().emit_err(errors::FormatDuplicateArg {
                         span: ident.span,
                         prev: prev.kind.ident().unwrap().span,
@@ -396,12 +396,11 @@ fn make_format_args(
             }
             Name(name, span) => {
                 let name = Symbol::intern(name);
-                if let Some((index, _)) = args.by_name(name) {
+                if let Some((index, _)) = args.by_explicit_name(name) {
                     // Name found in `args`, so we resolve it to its index.
-                    if index < args.explicit_args().len() {
-                        // Mark it as used, if it was an explicit argument.
-                        used[index] = true;
-                    }
+                    assert!(index < args.explicit_args().len());
+                    // Mark it as used, as this is an explicit argument.
+                    used[index] = true;
                     Ok(index)
                 } else {
                     // Name not found in `args`, so we add it as an implicitly captured argument.

--- a/tests/pretty/hir-format-args-duplicated-captures.pp
+++ b/tests/pretty/hir-format-args-duplicated-captures.pp
@@ -1,0 +1,79 @@
+//! Test for <https://github.com/rust-lang/rust/issues/145739>: identifiers referring to places
+//! should have their captures de-duplicated by `format_args!`, but identifiers referring to values
+//! should not be de-duplicated.
+extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+//@ pretty-compare-only
+//@ pretty-mode:hir
+//@ pp-exact:hir-format-args-duplicated-captures.pp
+
+const X: i32 = 42;
+
+struct Struct;
+
+static STATIC: i32 = 0;
+
+fn main() {
+    // Consts and constructors refer to values. Whether we construct them multiple times or just
+    // once can be observed in some cases, so we don't de-duplicate them.
+    let _ =
+        {
+            super let args = (&X,);
+            super let args = [format_argument::new_display(args.0)];
+            unsafe {
+                format_arguments::new(b"\xc0\x01 \xc8\x00\x00\x00", &args)
+            }
+        };
+    let _ =
+        {
+            super let args = (&Struct,);
+            super let args = [format_argument::new_display(args.0)];
+            unsafe {
+                format_arguments::new(b"\xc0\x01 \xc8\x00\x00\x00", &args)
+            }
+        };
+
+    // Variables and statics refer to places. We can de-duplicate without an observable difference.
+    let x = 3;
+    let _ =
+        {
+            super let args = (&STATIC,);
+            super let args = [format_argument::new_display(args.0)];
+            unsafe {
+                format_arguments::new(b"\xc0\x01 \xc8\x00\x00\x00", &args)
+            }
+        };
+    let _ =
+        {
+            super let args = (&x,);
+            super let args = [format_argument::new_display(args.0)];
+            unsafe {
+                format_arguments::new(b"\xc0\x01 \xc8\x00\x00\x00", &args)
+            }
+        };
+
+    // We don't de-duplicate widths or precisions since de-duplication can be observed.
+    let _ =
+        {
+            super let args = (&x,);
+            super let args =
+                [format_argument::new_display(args.0),
+                        format_argument::from_usize(args.0)];
+            unsafe {
+                format_arguments::new(b"\xd3 \x00\x00h\x01\x00\x01 \xdb \x00\x00h\x01\x00\x00\x00\x00",
+                    &args)
+            }
+        };
+    let _ =
+        {
+            super let args = (&0.0, &x);
+            super let args =
+                [format_argument::new_display(args.0),
+                        format_argument::from_usize(args.1)];
+            unsafe {
+                format_arguments::new(b"\xe5 \x00\x00p\x01\x00\x01 \xed \x00\x00p\x01\x00\x00\x00\x00",
+                    &args)
+            }
+        };
+}

--- a/tests/pretty/hir-format-args-duplicated-captures.pp
+++ b/tests/pretty/hir-format-args-duplicated-captures.pp
@@ -19,19 +19,19 @@ fn main() {
     // once can be observed in some cases, so we don't de-duplicate them.
     let _ =
         {
-            super let args = (&X,);
-            super let args = [format_argument::new_display(args.0)];
-            unsafe {
-                format_arguments::new(b"\xc0\x01 \xc8\x00\x00\x00", &args)
-            }
+            super let args = (&X, &X);
+            super let args =
+                [format_argument::new_display(args.0),
+                        format_argument::new_display(args.1)];
+            unsafe { format_arguments::new(b"\xc0\x01 \xc0\x00", &args) }
         };
     let _ =
         {
-            super let args = (&Struct,);
-            super let args = [format_argument::new_display(args.0)];
-            unsafe {
-                format_arguments::new(b"\xc0\x01 \xc8\x00\x00\x00", &args)
-            }
+            super let args = (&Struct, &Struct);
+            super let args =
+                [format_argument::new_display(args.0),
+                        format_argument::new_display(args.1)];
+            unsafe { format_arguments::new(b"\xc0\x01 \xc0\x00", &args) }
         };
 
     // Variables and statics refer to places. We can de-duplicate without an observable difference.
@@ -56,23 +56,25 @@ fn main() {
     // We don't de-duplicate widths or precisions since de-duplication can be observed.
     let _ =
         {
-            super let args = (&x,);
+            super let args = (&x, &x, &x);
             super let args =
                 [format_argument::new_display(args.0),
-                        format_argument::from_usize(args.0)];
+                        format_argument::from_usize(args.1),
+                        format_argument::from_usize(args.2)];
             unsafe {
-                format_arguments::new(b"\xd3 \x00\x00h\x01\x00\x01 \xdb \x00\x00h\x01\x00\x00\x00\x00",
+                format_arguments::new(b"\xd3 \x00\x00h\x01\x00\x01 \xdb \x00\x00h\x02\x00\x00\x00\x00",
                     &args)
             }
         };
     let _ =
         {
-            super let args = (&0.0, &x);
+            super let args = (&0.0, &x, &x);
             super let args =
                 [format_argument::new_display(args.0),
-                        format_argument::from_usize(args.1)];
+                        format_argument::from_usize(args.1),
+                        format_argument::from_usize(args.2)];
             unsafe {
-                format_arguments::new(b"\xe5 \x00\x00p\x01\x00\x01 \xed \x00\x00p\x01\x00\x00\x00\x00",
+                format_arguments::new(b"\xe5 \x00\x00p\x01\x00\x01 \xed \x00\x00p\x02\x00\x00\x00\x00",
                     &args)
             }
         };

--- a/tests/pretty/hir-format-args-duplicated-captures.rs
+++ b/tests/pretty/hir-format-args-duplicated-captures.rs
@@ -1,0 +1,28 @@
+//! Test for <https://github.com/rust-lang/rust/issues/145739>: identifiers referring to places
+//! should have their captures de-duplicated by `format_args!`, but identifiers referring to values
+//! should not be de-duplicated.
+//@ pretty-compare-only
+//@ pretty-mode:hir
+//@ pp-exact:hir-format-args-duplicated-captures.pp
+
+const X: i32 = 42;
+
+struct Struct;
+
+static STATIC: i32 = 0;
+
+fn main() {
+    // Consts and constructors refer to values. Whether we construct them multiple times or just
+    // once can be observed in some cases, so we don't de-duplicate them.
+    let _ = format_args!("{X} {X}");
+    let _ = format_args!("{Struct} {Struct}");
+
+    // Variables and statics refer to places. We can de-duplicate without an observable difference.
+    let x = 3;
+    let _ = format_args!("{STATIC} {STATIC}");
+    let _ = format_args!("{x} {x}");
+
+    // We don't de-duplicate widths or precisions since de-duplication can be observed.
+    let _ = format_args!("{x:x$} {x:x$}");
+    let _ = format_args!("{0:.x$} {0:.x$}", 0.0);
+}

--- a/tests/ui/deref/format-args-capture-deref-coercion.rs
+++ b/tests/ui/deref/format-args-capture-deref-coercion.rs
@@ -1,0 +1,37 @@
+//! Test for <https://github.com/rust-lang/rust/issues/145739>: width and precision arguments
+//! implicitly captured by `format_args!` should behave as if they were written individually.
+//@ run-pass
+use std::ops::Deref;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DEREF_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+struct LogDeref;
+impl Deref for LogDeref {
+    type Target = usize;
+    fn deref(&self) -> &usize {
+        if DEREF_COUNTER.fetch_add(1, Ordering::Relaxed).is_multiple_of(2) {
+            &2
+        } else {
+            &3
+        }
+    }
+}
+
+fn main() {
+    assert_eq!(DEREF_COUNTER.load(Ordering::Relaxed), 0);
+
+    let x = 0.0;
+
+    let _ = format_args!("{x:LogDeref$} {x:LogDeref$}");
+    // TODO: Increased by 2, as `&LogDeref` is coerced to a `&usize` twice.
+    assert_eq!(DEREF_COUNTER.load(Ordering::Relaxed), 1);
+
+    let _ = format_args!("{x:.LogDeref$} {x:.LogDeref$}");
+    // TODO: Increased by 2, as `&LogDeref` is coerced to a `&usize` twice.
+    assert_eq!(DEREF_COUNTER.load(Ordering::Relaxed), 2);
+
+    let _ = format_args!("{x:LogDeref$} {x:.LogDeref$}");
+    // TODO: Increased by 2, as `&LogDeref` is coerced to a `&usize` twice.
+    assert_eq!(DEREF_COUNTER.load(Ordering::Relaxed), 3);
+}

--- a/tests/ui/deref/format-args-capture-deref-coercion.rs
+++ b/tests/ui/deref/format-args-capture-deref-coercion.rs
@@ -24,14 +24,14 @@ fn main() {
     let x = 0.0;
 
     let _ = format_args!("{x:LogDeref$} {x:LogDeref$}");
-    // TODO: Increased by 2, as `&LogDeref` is coerced to a `&usize` twice.
-    assert_eq!(DEREF_COUNTER.load(Ordering::Relaxed), 1);
-
-    let _ = format_args!("{x:.LogDeref$} {x:.LogDeref$}");
-    // TODO: Increased by 2, as `&LogDeref` is coerced to a `&usize` twice.
+    // Increased by 2, as `&LogDeref` is coerced to a `&usize` twice.
     assert_eq!(DEREF_COUNTER.load(Ordering::Relaxed), 2);
 
+    let _ = format_args!("{x:.LogDeref$} {x:.LogDeref$}");
+    // Increased by 2, as `&LogDeref` is coerced to a `&usize` twice.
+    assert_eq!(DEREF_COUNTER.load(Ordering::Relaxed), 4);
+
     let _ = format_args!("{x:LogDeref$} {x:.LogDeref$}");
-    // TODO: Increased by 2, as `&LogDeref` is coerced to a `&usize` twice.
-    assert_eq!(DEREF_COUNTER.load(Ordering::Relaxed), 3);
+    // Increased by 2, as `&LogDeref` is coerced to a `&usize` twice.
+    assert_eq!(DEREF_COUNTER.load(Ordering::Relaxed), 6);
 }

--- a/tests/ui/drop/format-args-duplicated-captured-const-drops.rs
+++ b/tests/ui/drop/format-args-duplicated-captured-const-drops.rs
@@ -1,0 +1,79 @@
+//! A regression test for <https://github.com/rust-lang/rust/issues/145739>.
+//! `format_args!` should not deduplicate captured identifiers referring to values (e.g. consts and
+//! constructors). They must be evaluated once per occurrence, whereas explicitly provided arguments
+//! are evaluated only once, regardless of how many times they appear in the format string.
+//@ run-pass
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DROP_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Debug)]
+struct Foo;
+
+impl Drop for Foo {
+    fn drop(&mut self) {
+        DROP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+const FOO: Foo = Foo;
+
+fn main() {
+    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 0);
+
+    {
+        let _x = format_args!("{Foo:?}");
+    }
+    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 1);
+    {
+        let _x = format_args!("{FOO:?}");
+    }
+    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 2);
+
+    {
+        let _x = format_args!("{Foo:?}{Foo:?}");
+    }
+    // TODO: Increased by 2, as `Foo` is constructed for each captured `Foo`.
+    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 3);
+    {
+        let _x = format_args!("{FOO:?}{FOO:?}");
+    }
+    // TODO: Increased by 2, as `Foo` is constructed for each captured `FOO`.
+    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 4);
+
+    {
+        let _x = format_args!("{:?}{0:?}", Foo);
+    }
+    // Increased by 1, as `Foo` is constructed just once as an explicit argument.
+    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 5);
+    {
+        let _x = format_args!("{:?}{0:?}", FOO);
+    }
+    // Increased by 1, as `Foo` is constructed just once as an explicit argument.
+    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 6);
+
+    {
+        let _x = format_args!("{foo:?}{foo:?}{bar:?}{Foo:?}{Foo:?}", foo = Foo, bar = Foo);
+    }
+    // TODO: Increased by 4, as `Foo` is constructed twice for captured `Foo`, and once for each
+    // `foo` and `bar`.
+    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 9);
+    {
+        let _x = format_args!("{foo:?}{foo:?}{bar:?}{FOO:?}{FOO:?}", foo = FOO, bar = FOO);
+    }
+    // TODO: Increased by 4, as `Foo` is constructed twice for captured `FOO`, and once for each
+    // `foo` and `bar`.
+    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 12);
+
+    {
+        let _x = format_args!("{Foo:?}{Foo:?}", Foo = Foo);
+    }
+    // Increased by 1, as `Foo` is shadowed by an explicit argument.
+    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 13);
+    {
+        let _x = format_args!("{FOO:?}{FOO:?}", FOO = FOO);
+    }
+    // Increased by 1, as `FOO` is shadowed by an explicit argument.
+    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 14);
+}

--- a/tests/ui/drop/format-args-duplicated-captured-const-drops.rs
+++ b/tests/ui/drop/format-args-duplicated-captured-const-drops.rs
@@ -34,46 +34,46 @@ fn main() {
     {
         let _x = format_args!("{Foo:?}{Foo:?}");
     }
-    // TODO: Increased by 2, as `Foo` is constructed for each captured `Foo`.
-    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 3);
+    // Increased by 2, as `Foo` is constructed for each captured `Foo`.
+    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 4);
     {
         let _x = format_args!("{FOO:?}{FOO:?}");
     }
-    // TODO: Increased by 2, as `Foo` is constructed for each captured `FOO`.
-    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 4);
+    // Increased by 2, as `Foo` is constructed for each captured `FOO`.
+    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 6);
 
     {
         let _x = format_args!("{:?}{0:?}", Foo);
     }
     // Increased by 1, as `Foo` is constructed just once as an explicit argument.
-    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 5);
+    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 7);
     {
         let _x = format_args!("{:?}{0:?}", FOO);
     }
     // Increased by 1, as `Foo` is constructed just once as an explicit argument.
-    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 6);
+    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 8);
 
     {
         let _x = format_args!("{foo:?}{foo:?}{bar:?}{Foo:?}{Foo:?}", foo = Foo, bar = Foo);
     }
-    // TODO: Increased by 4, as `Foo` is constructed twice for captured `Foo`, and once for each
+    // Increased by 4, as `Foo` is constructed twice for captured `Foo`, and once for each
     // `foo` and `bar`.
-    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 9);
+    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 12);
     {
         let _x = format_args!("{foo:?}{foo:?}{bar:?}{FOO:?}{FOO:?}", foo = FOO, bar = FOO);
     }
-    // TODO: Increased by 4, as `Foo` is constructed twice for captured `FOO`, and once for each
+    // Increased by 4, as `Foo` is constructed twice for captured `FOO`, and once for each
     // `foo` and `bar`.
-    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 12);
+    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 16);
 
     {
         let _x = format_args!("{Foo:?}{Foo:?}", Foo = Foo);
     }
     // Increased by 1, as `Foo` is shadowed by an explicit argument.
-    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 13);
+    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 17);
     {
         let _x = format_args!("{FOO:?}{FOO:?}", FOO = FOO);
     }
     // Increased by 1, as `FOO` is shadowed by an explicit argument.
-    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 14);
+    assert_eq!(DROP_COUNTER.load(Ordering::Relaxed), 18);
 }


### PR DESCRIPTION
Proof-of-concept PR to help resolve the lets-see-the-optimization concern on rust-lang/rust#149926. I tried to aim for something as decoupled as possible from the rest of the `format_args!` logic, rather than a clever or efficient implementation. This doesn't do anything to optimize captured width/precision arguments. I've left more details inline.