### PR TITLE
remove redundant backchain attribute in codegen

### DIFF
--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -301,17 +301,6 @@ fn stackprotector_attr<'ll>(cx: &SimpleCx<'ll>, sess: &Session) -> Option<&'ll A
     Some(sspattr.create_attr(cx.llcx))
 }
 
-fn backchain_attr<'ll>(cx: &SimpleCx<'ll>, sess: &Session) -> Option<&'ll Attribute> {
-    if sess.target.arch != Arch::S390x {
-        return None;
-    }
-
-    let requested_features = sess.opts.cg.target_feature.split(',');
-    let found_positive = requested_features.clone().any(|r| r == "+backchain");
-
-    if found_positive { Some(llvm::CreateAttrString(cx.llcx, "backchain")) } else { None }
-}
-
 pub(crate) fn target_cpu_attr<'ll>(cx: &SimpleCx<'ll>, sess: &Session) -> &'ll Attribute {
     let target_cpu = llvm_util::target_cpu(sess);
     llvm::CreateAttrStringValue(cx.llcx, "target-cpu", target_cpu)
@@ -529,9 +518,6 @@ pub(crate) fn llfn_attrs_from_instance<'ll, 'tcx>(
     }
     if let Some(align) = codegen_fn_attrs.alignment {
         llvm::set_alignment(llfn, align);
-    }
-    if let Some(backchain) = backchain_attr(cx, sess) {
-        to_add.push(backchain);
     }
     to_add.extend(patchable_function_entry_attrs(
         cx,

--- a/tests/codegen-llvm/backchain.rs
+++ b/tests/codegen-llvm/backchain.rs
@@ -1,0 +1,15 @@
+//@ add-minicore
+//@ compile-flags: -Copt-level=3 --crate-type=lib --target=s390x-unknown-linux-gnu -Ctarget-feature=+backchain
+//@ needs-llvm-components: systemz
+#![crate_type = "lib"]
+#![feature(no_core, lang_items)]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
+
+#[no_mangle]
+pub fn test_backchain() {
+    // CHECK: @test_backchain() unnamed_addr #0
+}
+// CHECK: attributes #0 = { {{.*}}"target-features"="{{[^"]*}}+backchain{{.*}} }


### PR DESCRIPTION
llvm will look at both
1. the values of `"target-features"` and
2. the function string attributes.

this patch removes the redundant function string attribute because it is not needed at all. rustc sets the `+backchain` attribute through `target_features_attr(...)` 
https://github.com/rust-lang/rust/blob/d34f1f931489618efffc4007e6b6bdb9e10f6467/compiler/rustc_codegen_llvm/src/attributes.rs#L590
https://github.com/rust-lang/rust/blob/d34f1f931489618efffc4007e6b6bdb9e10f6467/compiler/rustc_codegen_llvm/src/attributes.rs#L326-L337

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
