### PR TITLE
Clean up some subdiagnostics

### DIFF
--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -3,7 +3,7 @@
 use rustc_abi::ExternAbi;
 use rustc_ast::ParamKindOrd;
 use rustc_errors::codes::*;
-use rustc_errors::{Applicability, Diag, EmissionGuarantee, Subdiagnostic, inline_fluent};
+use rustc_errors::{Applicability, Diag, EmissionGuarantee, Subdiagnostic};
 use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
 use rustc_span::{Ident, Span, Symbol};
 
@@ -927,17 +927,13 @@ pub(crate) struct FeatureOnNonNightly {
     pub sugg: Option<Span>,
 }
 
+#[derive(Subdiagnostic)]
+#[help(
+    "the feature `{$name}` has been stable since `{$since}` and no longer requires an attribute to enable"
+)]
 pub(crate) struct StableFeature {
     pub name: Symbol,
     pub since: Symbol,
-}
-
-impl Subdiagnostic for StableFeature {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
-        diag.arg("name", self.name);
-        diag.arg("since", self.since);
-        diag.help(inline_fluent!("the feature `{$name}` has been stable since `{$since}` and no longer requires an attribute to enable"));
-    }
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1975,25 +1975,15 @@ pub(crate) struct OverflowingBinHex<'a> {
     pub sign_bit_sub: Option<OverflowingBinHexSignBitSub<'a>>,
 }
 
+#[derive(Subdiagnostic)]
 pub(crate) enum OverflowingBinHexSign {
+    #[note(
+        "the literal `{$lit}` (decimal `{$dec}`) does not fit into the type `{$ty}` and will become `{$actually}{$ty}`"
+    )]
     Positive,
+    #[note("the literal `{$lit}` (decimal `{$dec}`) does not fit into the type `{$ty}`")]
+    #[note("and the value `-{$lit}` will become `{$actually}{$ty}`")]
     Negative,
-}
-
-impl Subdiagnostic for OverflowingBinHexSign {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
-        match self {
-            OverflowingBinHexSign::Positive => {
-                diag.note(inline_fluent!("the literal `{$lit}` (decimal `{$dec}`) does not fit into the type `{$ty}` and will become `{$actually}{$ty}`"));
-            }
-            OverflowingBinHexSign::Negative => {
-                diag.note(inline_fluent!(
-                    "the literal `{$lit}` (decimal `{$dec}`) does not fit into the type `{$ty}`"
-                ));
-                diag.note(inline_fluent!("and the value `-{$lit}` will become `{$actually}{$ty}`"));
-            }
-        }
-    }
 }
 
 #[derive(Subdiagnostic)]

--- a/compiler/rustc_metadata/src/dependency_format.rs
+++ b/compiler/rustc_metadata/src/dependency_format.rs
@@ -68,8 +68,7 @@ use crate::creader::CStore;
 use crate::errors::{
     BadPanicStrategy, CrateDepMultiple, IncompatiblePanicInDropStrategy,
     IncompatibleWithImmediateAbort, IncompatibleWithImmediateAbortCore, LibRequired,
-    NonStaticCrateDep, RequiredPanicStrategy, RlibRequired, RustcDriverHelp, RustcLibRequired,
-    TwoPanicRuntimes,
+    NonStaticCrateDep, RequiredPanicStrategy, RlibRequired, RustcLibRequired, TwoPanicRuntimes,
 };
 
 pub(crate) fn calculate(tcx: TyCtxt<'_>) -> Dependencies {
@@ -318,7 +317,7 @@ fn add_library(
                         .drain(..)
                         .map(|cnum| NonStaticCrateDep { crate_name_: tcx.crate_name(cnum) })
                         .collect(),
-                    rustc_driver_help: linking_to_rustc_driver.then_some(RustcDriverHelp),
+                    rustc_driver_help: linking_to_rustc_driver,
                 });
             }
         }

--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -43,8 +43,8 @@ pub struct CrateDepMultiple {
     pub crate_name: Symbol,
     #[subdiagnostic]
     pub non_static_deps: Vec<NonStaticCrateDep>,
-    #[subdiagnostic]
-    pub rustc_driver_help: Option<RustcDriverHelp>,
+    #[help("`feature(rustc_private)` is needed to link to the compiler's `rustc_driver` library")]
+    pub rustc_driver_help: bool,
 }
 
 #[derive(Subdiagnostic)]
@@ -53,10 +53,6 @@ pub struct NonStaticCrateDep {
     /// It's different from `crate_name` in main Diagnostic.
     pub crate_name_: Symbol,
 }
-
-#[derive(Subdiagnostic)]
-#[help("`feature(rustc_private)` is needed to link to the compiler's `rustc_driver` library")]
-pub struct RustcDriverHelp;
 
 #[derive(Diagnostic)]
 #[diag("cannot link together two panic runtimes: {$prev_name} and {$cur_name}")]

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -2786,12 +2786,14 @@ pub(crate) struct UnknownTokenStart {
     pub escaped: String,
     #[subdiagnostic]
     pub sugg: Option<TokenSubstitution>,
-    #[subdiagnostic]
-    pub null: Option<UnknownTokenNull>,
+    #[help(
+        "source files must contain UTF-8 encoded text, unexpected null bytes might occur when a different encoding is used"
+    )]
+    pub null: bool,
     #[subdiagnostic]
     pub repeat: Option<UnknownTokenRepeat>,
-    #[subdiagnostic]
-    pub invisible: Option<InvisibleCharacter>,
+    #[help("invisible characters like '{$escaped}' are not usually visible in text editors")]
+    pub invisible: bool,
 }
 
 #[derive(Subdiagnostic)]
@@ -2836,16 +2838,6 @@ pub(crate) enum TokenSubstitution {
 pub(crate) struct UnknownTokenRepeat {
     pub repeats: usize,
 }
-
-#[derive(Subdiagnostic)]
-#[help("invisible characters like '{$escaped}' are not usually visible in text editors")]
-pub(crate) struct InvisibleCharacter;
-
-#[derive(Subdiagnostic)]
-#[help(
-    "source files must contain UTF-8 encoded text, unexpected null bytes might occur when a different encoding is used"
-)]
-pub(crate) struct UnknownTokenNull;
 
 #[derive(Diagnostic)]
 pub(crate) enum UnescapeError {

--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -459,8 +459,8 @@ impl<'psess, 'src> Lexer<'psess, 'src> {
                         span: self.mk_sp(start, self.pos + Pos::from_usize(repeats * c.len_utf8())),
                         escaped: escaped_char(c),
                         sugg,
-                        null: if c == '\x00' { Some(errors::UnknownTokenNull) } else { None },
-                        invisible: if INVISIBLE_CHARACTERS.contains(&c) { Some(errors::InvisibleCharacter) } else { None },
+                        null: c == '\x00',
+                        invisible: INVISIBLE_CHARACTERS.contains(&c),
                         repeat: if repeats > 0 {
                             swallow_next_invalid = repeats;
                             Some(errors::UnknownTokenRepeat { repeats })

--- a/compiler/rustc_pattern_analysis/src/errors.rs
+++ b/compiler/rustc_pattern_analysis/src/errors.rs
@@ -56,20 +56,12 @@ pub struct OverlappingRangeEndpoints {
     pub overlap: Vec<Overlap>,
 }
 
+#[derive(Subdiagnostic)]
+#[label("this range overlaps on `{$range}`...")]
 pub struct Overlap {
+    #[primary_span]
     pub span: Span,
     pub range: String, // a printed pattern
-}
-
-impl Subdiagnostic for Overlap {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
-        let Overlap { span, range } = self;
-
-        // FIXME(mejrs) unfortunately `#[derive(LintDiagnostic)]`
-        // does not support `#[subdiagnostic(eager)]`...
-        let message = format!("this range overlaps on `{range}`...");
-        diag.span_label(span, message);
-    }
 }
 
 #[derive(LintDiagnostic)]

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1015,11 +1015,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     span,
                     name,
                     param_kind: is_type,
-                    help: self
-                        .tcx
-                        .sess
-                        .is_nightly_build()
-                        .then_some(errs::ParamInNonTrivialAnonConstHelp),
+                    help: self.tcx.sess.is_nightly_build(),
                 })
             }
             ResolutionError::ParamInEnumDiscriminant { name, param_kind: is_type } => self

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -429,13 +429,9 @@ pub(crate) struct ParamInNonTrivialAnonConst {
     pub(crate) name: Symbol,
     #[subdiagnostic]
     pub(crate) param_kind: ParamKindInNonTrivialAnonConst,
-    #[subdiagnostic]
-    pub(crate) help: Option<ParamInNonTrivialAnonConstHelp>,
+    #[help("add `#![feature(generic_const_exprs)]` to allow generic const expressions")]
+    pub(crate) help: bool,
 }
-
-#[derive(Subdiagnostic)]
-#[help("add `#![feature(generic_const_exprs)]` to allow generic const expressions")]
-pub(crate) struct ParamInNonTrivialAnonConstHelp;
 
 #[derive(Debug)]
 #[derive(Subdiagnostic)]

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -3510,12 +3510,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                         span: lifetime_ref.ident.span,
                         name: lifetime_ref.ident.name,
                         param_kind: errors::ParamKindInNonTrivialAnonConst::Lifetime,
-                        help: self
-                            .r
-                            .tcx
-                            .sess
-                            .is_nightly_build()
-                            .then_some(errors::ParamInNonTrivialAnonConstHelp),
+                        help: self.r.tcx.sess.is_nightly_build(),
                     })
                     .emit();
             }

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/trait_impl_difference.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/trait_impl_difference.rs
@@ -16,7 +16,7 @@ use tracing::debug;
 
 use crate::error_reporting::infer::nice_region_error::NiceRegionError;
 use crate::error_reporting::infer::nice_region_error::placeholder_error::Highlighted;
-use crate::errors::{ConsiderBorrowingParamHelp, RelationshipHelp, TraitImplDiff};
+use crate::errors::{ConsiderBorrowingParamHelp, TraitImplDiff};
 use crate::infer::{RegionResolutionError, ValuePairs};
 
 impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
@@ -117,7 +117,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
             trait_sp,
             note: (),
             param_help: ConsiderBorrowingParamHelp { spans: visitor.types.to_vec() },
-            rel_help: visitor.types.is_empty().then_some(RelationshipHelp),
+            rel_help: visitor.types.is_empty(),
             expected,
             found,
         };

--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -1230,12 +1230,6 @@ impl Subdiagnostic for ConsiderBorrowingParamHelp {
     }
 }
 
-#[derive(Subdiagnostic)]
-#[help(
-    "verify the lifetime relationships in the `trait` and `impl` between the `self` argument, the other inputs and its output"
-)]
-pub struct RelationshipHelp;
-
 #[derive(Diagnostic)]
 #[diag("`impl` item signature doesn't match `trait` item signature")]
 pub struct TraitImplDiff {
@@ -1251,10 +1245,10 @@ pub struct TraitImplDiff {
     pub note: (),
     #[subdiagnostic]
     pub param_help: ConsiderBorrowingParamHelp,
-    #[subdiagnostic]
-    // Seems like subdiagnostics are always pushed to the end, so this one
-    // also has to be a subdiagnostic to maintain order.
-    pub rel_help: Option<RelationshipHelp>,
+    #[help(
+        "verify the lifetime relationships in the `trait` and `impl` between the `self` argument, the other inputs and its output"
+    )]
+    pub rel_help: bool,
     pub expected: String,
     pub found: String,
 }


### PR DESCRIPTION
Just a nice minor cleanup :)
* Removes some empty subdiagnostics which could just be subdiagnostic attributes
* Convert some manual implementation of `Subdiagnostic` to derives