### PR TITLE
Improve write! and writeln! error when called without destination

### DIFF
--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -611,6 +611,9 @@ macro_rules! write {
     ($dst:expr, $($arg:tt)*) => {
         $dst.write_fmt($crate::format_args!($($arg)*))
     };
+    ($($arg:tt)*) => {
+        compile_error!("requires a destination and format arguments, like `write!(dest, \"format string\", args...)`")
+    };
 }
 
 /// Writes formatted data into a buffer, with a newline appended.
@@ -648,6 +651,9 @@ macro_rules! writeln {
     };
     ($dst:expr, $($arg:tt)*) => {
         $dst.write_fmt($crate::format_args_nl!($($arg)*))
+    };
+    ($($arg:tt)*) => {
+        compile_error!("requires a destination and format arguments, like `writeln!(dest, \"format string\", args...)`")
     };
 }
 

--- a/tests/ui/macros/write-missing-destination.rs
+++ b/tests/ui/macros/write-missing-destination.rs
@@ -1,0 +1,7 @@
+// Check that `write!` without a destination gives a helpful error message.
+// See https://github.com/rust-lang/rust/issues/152493
+
+fn main() {
+    write!("S");
+    //~^ ERROR requires a destination and format arguments
+}

--- a/tests/ui/macros/write-missing-destination.stderr
+++ b/tests/ui/macros/write-missing-destination.stderr
@@ -1,0 +1,8 @@
+error: requires a destination and format arguments, like `write!(dest, "format string", args...)`
+  --> $DIR/write-missing-destination.rs:5:5
+   |
+LL |     write!("S");
+   |     ^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes rust-lang/rust#152493

Adds catch-all arms to `write!` and `writeln!` macros so that calling them without a destination (e.g., `write!("S")` instead of `write!(f, "S")`) gives a clear error instead of the cryptic "unexpected end of macro invocation" pointing at macro internals.

r? @estebank 