### PR TITLE
Collect active query jobs into struct `QueryJobMap`

### DIFF
--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -248,7 +248,7 @@ internal compiler error: query cycle handler thread panicked, aborting process";
                             tls::with(|tcx| {
                                 // Accessing session globals is sound as they outlive `GlobalCtxt`.
                                 // They are needed to hash query keys containing spans or symbols.
-                                let query_map = rustc_span::set_session_globals_then(
+                                let job_map = rustc_span::set_session_globals_then(
                                     unsafe { &*(session_globals as *const SessionGlobals) },
                                     || {
                                         // Ensure there were no errors collecting all active jobs.
@@ -258,7 +258,7 @@ internal compiler error: query cycle handler thread panicked, aborting process";
                                         )
                                     },
                                 );
-                                break_query_cycles(query_map, &registry);
+                                break_query_cycles(job_map, &registry);
                             })
                         })
                     });

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -15,7 +15,7 @@ use rustc_query_system::query::{
 use rustc_span::{DUMMY_SP, Span};
 
 use crate::dep_graph::{DepContext, DepNode, DepNodeIndex};
-use crate::job::{QueryJobInfo, QueryMap, find_cycle_in_stack, report_cycle};
+use crate::job::{QueryJobInfo, QueryJobMap, find_cycle_in_stack, report_cycle};
 use crate::{QueryCtxt, QueryFlags, SemiDynamicQueryDispatcher};
 
 #[inline]
@@ -45,8 +45,8 @@ pub(crate) fn gather_active_jobs_inner<'tcx, K: Copy>(
     state: &QueryState<'tcx, K>,
     tcx: TyCtxt<'tcx>,
     make_frame: fn(TyCtxt<'tcx>, K) -> QueryStackFrame<QueryStackDeferred<'tcx>>,
-    jobs: &mut QueryMap<'tcx>,
     require_complete: bool,
+    job_map_out: &mut QueryJobMap<'tcx>, // Out-param; job info is gathered into this map
 ) -> Option<()> {
     let mut active = Vec::new();
 
@@ -77,7 +77,7 @@ pub(crate) fn gather_active_jobs_inner<'tcx, K: Copy>(
     // queries leading to a deadlock.
     for (key, job) in active {
         let frame = make_frame(tcx, key);
-        jobs.insert(job.id, QueryJobInfo { frame, job });
+        job_map_out.insert(job.id, QueryJobInfo { frame, job });
     }
 
     Some(())
@@ -213,12 +213,12 @@ fn cycle_error<'tcx, C: QueryCache, const FLAGS: QueryFlags>(
 ) -> (C::Value, Option<DepNodeIndex>) {
     // Ensure there was no errors collecting all active jobs.
     // We need the complete map to ensure we find a cycle to break.
-    let query_map = qcx
+    let job_map = qcx
         .collect_active_jobs_from_all_queries(false)
         .ok()
         .expect("failed to collect active queries");
 
-    let error = find_cycle_in_stack(try_execute, query_map, &qcx.current_query_job(), span);
+    let error = find_cycle_in_stack(try_execute, job_map, &qcx.current_query_job(), span);
     (mk_cycle(query, qcx, error.lift()), None)
 }
 

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(core_intrinsics)]
 #![feature(min_specialization)]
 #![feature(rustc_attrs)]
+#![feature(try_blocks)]
 // tidy-alphabetical-end
 
 use std::marker::ConstParamTy;
@@ -26,7 +27,7 @@ use rustc_query_system::query::{
 };
 use rustc_span::{ErrorGuaranteed, Span};
 
-pub use crate::job::{QueryMap, break_query_cycles, print_query_stack};
+pub use crate::job::{QueryJobMap, break_query_cycles, print_query_stack};
 pub use crate::plumbing::{QueryCtxt, query_key_hash_verify_all};
 use crate::plumbing::{encode_all_query_results, try_mark_green};
 use crate::profiling_support::QueryKeyStringCache;


### PR DESCRIPTION
This PR encapsulates the existing `QueryMap` type alias into a proper struct named `QueryJobMap`, which is used by code that wants to inspect the full set of currently-active query jobs.

Wrapping the query job map in a struct makes it easier to see how other code interacts with the map, and also lets us change some free functions for map lookup into methods.

We also do a renaming pass to consistently refer to the query job map as `job_map`, or as `job_map_out` in the places where it's a mutable out-parameter.

There should be no change to compiler behaviour.

r? nnethercote (or compiler)