### PR TITLE
Don't use `DepContext` in `rustc_middle::traits::cache`

### DIFF
--- a/compiler/rustc_middle/src/traits/cache.rs
+++ b/compiler/rustc_middle/src/traits/cache.rs
@@ -5,7 +5,8 @@ use std::hash::Hash;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sync::Lock;
 
-use crate::dep_graph::{DepContext, DepNodeIndex};
+use crate::dep_graph::DepNodeIndex;
+use crate::ty::TyCtxt;
 
 pub struct WithDepNodeCache<Key, Value> {
     hashmap: Lock<FxHashMap<Key, WithDepNode<Value>>>,
@@ -24,7 +25,7 @@ impl<Key, Value> Default for WithDepNodeCache<Key, Value> {
 }
 
 impl<Key: Eq + Hash, Value: Clone> WithDepNodeCache<Key, Value> {
-    pub fn get<Tcx: DepContext>(&self, key: &Key, tcx: Tcx) -> Option<Value> {
+    pub fn get<'tcx>(&self, key: &Key, tcx: TyCtxt<'tcx>) -> Option<Value> {
         Some(self.hashmap.borrow().get(key)?.get(tcx))
     }
 
@@ -40,12 +41,12 @@ pub struct WithDepNode<T> {
 }
 
 impl<T: Clone> WithDepNode<T> {
-    pub fn new(dep_node: DepNodeIndex, cached_value: T) -> Self {
+    pub(crate) fn new(dep_node: DepNodeIndex, cached_value: T) -> Self {
         WithDepNode { dep_node, cached_value }
     }
 
-    pub fn get<Tcx: DepContext>(&self, tcx: Tcx) -> T {
-        tcx.dep_graph().read_index(self.dep_node);
+    pub(crate) fn get<'tcx>(&self, tcx: TyCtxt<'tcx>) -> T {
+        tcx.dep_graph.read_index(self.dep_node);
         self.cached_value.clone()
     }
 }


### PR DESCRIPTION
- A nice little simplification unlocked by https://github.com/rust-lang/rust/pull/152199.

---

This code is now in `rustc_middle`, and doesn't need any non-trivial methods, so it can just use `TyCtxt` directly instead.
