### PR TITLE
Add #[must_use] to FileTimes::set_accessed and set_modified

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -2218,6 +2218,7 @@ impl FileTimes {
     }
 
     /// Set the last access time of a file.
+    #[must_use]
     #[stable(feature = "file_set_times", since = "1.75.0")]
     pub fn set_accessed(mut self, t: SystemTime) -> Self {
         self.0.set_accessed(t.into_inner());
@@ -2225,6 +2226,7 @@ impl FileTimes {
     }
 
     /// Set the last modified time of a file.
+    #[must_use]
     #[stable(feature = "file_set_times", since = "1.75.0")]
     pub fn set_modified(mut self, t: SystemTime) -> Self {
         self.0.set_modified(t.into_inner());


### PR DESCRIPTION
## Summary

`FileTimes::set_accessed` and `FileTimes::set_modified` take `self` by value and return `Self` (builder pattern). Without `#[must_use]`, calling `ft.set_modified(time)` without using the return value silently does nothing, which is a common source of bugs.

This PR adds `#[must_use]` to both methods so that the compiler warns when the return value is discarded.

### Example of the bug this prevents:

```rust
let ft = FileTimes::new();
ft.set_modified(modified); // silently does nothing - no warning!
```

With this change, the compiler will emit a warning for the above code, guiding users to use the builder pattern correctly:

```rust
let ft = FileTimes::new().set_modified(modified); // correct usage
```

Fixes rust-lang/rust#152231