### PR TITLE
Port test_exp and test_exp2 to unified float test infrastructure

### DIFF
--- a/library/coretests/tests/floats/mod.rs
+++ b/library/coretests/tests/floats/mod.rs
@@ -1650,3 +1650,40 @@ float_test! {
 //         assert_biteq!(Float::from(i64::MAX), 9223372036854775807.0);
 //     }
 // }
+
+// Port of `test_exp` from `library/std/tests/floats/f*.rs`.
+float_test! {
+    name: exp,
+    attrs: {
+        const: #[cfg(false)],
+        f16: #[cfg(any(miri, target_has_reliable_f16_math))],
+        f128: #[cfg(any(miri, target_has_reliable_f128_math))],
+    },
+    test<Float> {
+        assert_biteq!((0.0 as Float).exp(), 1.0 as Float);
+        assert_approx_eq!((1.0 as Float).exp(), 2.718281828459045 as Float);
+        assert_approx_eq!((5.0 as Float).exp(), 148.4131591025766 as Float);
+
+        assert_eq!(Float::INFINITY.exp(), Float::INFINITY);
+        assert_biteq!(Float::NEG_INFINITY.exp(), 0.0 as Float);
+        assert!(Float::NAN.exp().is_nan());
+    }
+}
+
+// Port of `test_exp2` from `library/std/tests/floats/f*.rs`.
+float_test! {
+    name: exp2,
+    attrs: {
+        const: #[cfg(false)],
+        f16: #[cfg(any(miri, target_has_reliable_f16_math))],
+        f128: #[cfg(any(miri, target_has_reliable_f128_math))],
+    },
+    test<Float> {
+        assert_biteq!((0.0 as Float).exp2(), 1.0 as Float);
+        assert_biteq!((5.0 as Float).exp2(), 32.0 as Float);
+
+        assert_eq!(Float::INFINITY.exp2(), Float::INFINITY);
+        assert_biteq!(Float::NEG_INFINITY.exp2(), 0.0 as Float);
+        assert!(Float::NAN.exp2().is_nan());
+    }
+}


### PR DESCRIPTION
Part of rust-lang/rust#141726.

Ports `test_exp` and `test_exp2` from `library/std/tests/floats/f*.rs` to the unified `float_test!` macro infrastructure in `library/coretests/tests/floats/mod.rs`.

### Changes

- Added unified `exp` test covering `exp(0) = 1`, `exp(1) ≈ e`, `exp(5) ≈ 148.41...`, and special values (infinity, neg_infinity, NaN)
- Added unified `exp2` test covering `exp2(0) = 1`, `exp2(5) = 32`, and special values
- Both tests use `const: #[cfg(false)]` since `exp`/`exp2` are not const functions
- Both tests include the standard `f16`/`f128` reliability cfg guards

### Notes

- This is a small incremental PR as suggested in the mentoring instructions
- The duplicate tests in `library/std/tests/floats/f*.rs` can be removed in a follow-up once this lands
- Uses `assert_approx_eq!` with auto-tolerance for `exp(1)` and `exp(5)`, and `assert_biteq!` for exact results like `exp(0)` and `exp2(5)`

r? @tgross35