### PR TITLE
Streamline `define_dep_nodes`.

### DIFF
--- a/compiler/rustc_middle/src/dep_graph/mod.rs
+++ b/compiler/rustc_middle/src/dep_graph/mod.rs
@@ -54,7 +54,7 @@ impl Deps for DepsType {
     const DEP_KIND_RED: DepKind = dep_kinds::Red;
     const DEP_KIND_SIDE_EFFECT: DepKind = dep_kinds::SideEffect;
     const DEP_KIND_ANON_ZERO_DEPS: DepKind = dep_kinds::AnonZeroDeps;
-    const DEP_KIND_MAX: u16 = dep_node::DEP_KIND_VARIANTS - 1;
+    const DEP_KIND_MAX: u16 = dep_node::NUM_DEP_KIND_VARIANTS - 1;
 }
 
 impl<'tcx> DepContext for TyCtxt<'tcx> {

--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -44,6 +44,7 @@
 #![feature(gen_blocks)]
 #![feature(if_let_guard)]
 #![feature(intra_doc_pointers)]
+#![feature(macro_metavar_expr)]
 #![feature(min_specialization)]
 #![feature(negative_impls)]
 #![feature(never_type)]


### PR DESCRIPTION
Changes that make this macro easier to read.

- `DepKindDefs` is an enum that is used purely to generate a list of ascending numbers at compile time, to implement the functions within `dep_kinds`. This commit replaces it with a `${index()}` macro metavar. (The comment about u16 data representation doesn't seem relevant any more.)

- `DEP_KIND_VARIANTS` just counts the number of dep kind variants. It's implemented via `len()` and a const loop to ensure `DepKindDefs` truly implements a list of ascending numbers. This commit replaces it with a `${count(..)}` macro metavar. This commit also renames it to make clearer it's a count of varants, not an actual list/array/vec of variants.

- This commit uses `stringify!` more for variant-names-as-strings, instead of going indirectly via `label_strs`.

r? @saethlin