### PR TITLE
Use the term struct-like variant instead of anonymous structs for data of struct-like enum variants

### DIFF
--- a/library/std/src/keyword_docs.rs
+++ b/library/std/src/keyword_docs.rs
@@ -418,7 +418,7 @@ mod else_keyword {}
 /// The first enum shown is the usual kind of enum you'd find in a C-style language. The second
 /// shows off a hypothetical example of something storing location data, with `Coord` being any
 /// other type that's needed, for example a struct. The third example demonstrates the kind of
-/// data a variant can store, ranging from nothing, to a tuple, to an anonymous struct.
+/// data a variant can store, ranging from nothing, to a tuple, to a struct-like variant.
 ///
 /// Instantiating enum variants involves explicitly using the enum's name as its namespace,
 /// followed by one of its variants. `SimpleEnum::SecondVariant` would be an example from above.


### PR DESCRIPTION
The current term in the docs `anonymous structs` seems to be outdated.
I'd suggest `struct-like data` or rephrasing the whole sentence to use `struct-like variant`.

The terminology used in the [Rust Book on enums](https://doc.rust-lang.org/stable/book/ch06-01-defining-an-enum.html#listing-6-2) is
> named fields, like a struct

The [Reference on enums](https://doc.rust-lang.org/stable/reference/items/enumerations.html#r-items.enum.constructor) uses
> struct-like enum variant

The term `anonymous struct` on the other hand is neither mentioned in the Rust book on [structs](https://doc.rust-lang.org/stable/book/ch05-01-defining-structs.html) or [enums](https://doc.rust-lang.org/stable/book/ch06-01-defining-an-enum.html#listing-6-2), nor the references on [structs](https://doc.rust-lang.org/stable/reference/items/structs.html) or [enums](https://doc.rust-lang.org/stable/reference/items/enumerations.html#r-items.enum.constructor).

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
