### PR TITLE
`proc_macro::bridge`: simplify `ExecutionStrategy` and `DispatcherTrait`

### DIFF
--- a/compiler/rustc_expand/src/proc_macro.rs
+++ b/compiler/rustc_expand/src/proc_macro.rs
@@ -12,10 +12,10 @@ use crate::base::{self, *};
 use crate::{errors, proc_macro_server};
 
 fn exec_strategy(sess: &Session) -> impl pm::bridge::server::ExecutionStrategy + 'static {
-    pm::bridge::server::MaybeCrossThread::new(
-        sess.opts.unstable_opts.proc_macro_execution_strategy
+    pm::bridge::server::MaybeCrossThread {
+        cross_thread: sess.opts.unstable_opts.proc_macro_execution_strategy
             == ProcMacroExecutionStrategy::CrossThread,
-    )
+    }
 }
 
 pub struct BangProcMacro {

--- a/compiler/rustc_expand/src/proc_macro.rs
+++ b/compiler/rustc_expand/src/proc_macro.rs
@@ -11,29 +11,8 @@ use {rustc_ast as ast, rustc_proc_macro as pm};
 use crate::base::{self, *};
 use crate::{errors, proc_macro_server};
 
-struct MessagePipe<T> {
-    tx: std::sync::mpsc::SyncSender<T>,
-    rx: std::sync::mpsc::Receiver<T>,
-}
-
-impl<T> pm::bridge::server::MessagePipe<T> for MessagePipe<T> {
-    fn new() -> (Self, Self) {
-        let (tx1, rx1) = std::sync::mpsc::sync_channel(1);
-        let (tx2, rx2) = std::sync::mpsc::sync_channel(1);
-        (MessagePipe { tx: tx1, rx: rx2 }, MessagePipe { tx: tx2, rx: rx1 })
-    }
-
-    fn send(&mut self, value: T) {
-        self.tx.send(value).unwrap();
-    }
-
-    fn recv(&mut self) -> Option<T> {
-        self.rx.recv().ok()
-    }
-}
-
 fn exec_strategy(sess: &Session) -> impl pm::bridge::server::ExecutionStrategy + 'static {
-    pm::bridge::server::MaybeCrossThread::<MessagePipe<_>>::new(
+    pm::bridge::server::MaybeCrossThread::new(
         sess.opts.unstable_opts.proc_macro_execution_strategy
             == ProcMacroExecutionStrategy::CrossThread,
     )

--- a/library/proc_macro/src/bridge/client.rs
+++ b/library/proc_macro/src/bridge/client.rs
@@ -98,7 +98,7 @@ pub(crate) use super::symbol::Symbol;
 
 macro_rules! define_client_side {
     (
-        $(fn $method:ident($($arg:ident: $arg_ty:ty),* $(,)?) $(-> $ret_ty:ty)*;)*
+        $(fn $method:ident($($arg:ident: $arg_ty:ty),* $(,)?) $(-> $ret_ty:ty)?;)*
     ) => {
         impl Methods {
             $(pub(crate) fn $method($($arg: $arg_ty),*) $(-> $ret_ty)? {

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -133,7 +133,7 @@ impl !Sync for BridgeConfig<'_> {}
 
 macro_rules! declare_tags {
     (
-        $(fn $method:ident($($arg:ident: $arg_ty:ty),* $(,)?) $(-> $ret_ty:ty)*;)*
+        $(fn $method:ident($($arg:ident: $arg_ty:ty),* $(,)?) $(-> $ret_ty:ty)?;)*
     ) => {
         #[allow(non_camel_case_types)]
         pub(super) enum ApiTags {

--- a/library/proc_macro/src/bridge/server.rs
+++ b/library/proc_macro/src/bridge/server.rs
@@ -60,7 +60,7 @@ struct Dispatcher<S: Server> {
 
 macro_rules! define_server {
     (
-        $(fn $method:ident($($arg:ident: $arg_ty:ty),* $(,)?) $(-> $ret_ty:ty)*;)*
+        $(fn $method:ident($($arg:ident: $arg_ty:ty),* $(,)?) $(-> $ret_ty:ty)?;)*
     ) => {
         pub trait Server {
             type TokenStream: 'static + Clone + Default;
@@ -83,7 +83,7 @@ with_api!(define_server, Self::TokenStream, Self::Span, Self::Symbol);
 
 macro_rules! define_dispatcher {
     (
-        $(fn $method:ident($($arg:ident: $arg_ty:ty),* $(,)?) $(-> $ret_ty:ty)*;)*
+        $(fn $method:ident($($arg:ident: $arg_ty:ty),* $(,)?) $(-> $ret_ty:ty)?;)*
     ) => {
         // FIXME(eddyb) `pub` only for `ExecutionStrategy` below.
         pub trait DispatcherTrait {
@@ -100,9 +100,7 @@ macro_rules! define_dispatcher {
                         let mut call_method = || {
                             $(let $arg = <$arg_ty>::decode(&mut reader, handle_store).unmark();)*
                             let r = server.$method($($arg),*);
-                            $(
-                                let r: $ret_ty = Mark::mark(r);
-                            )*
+                            $(let r: $ret_ty = Mark::mark(r);)?
                             r
                         };
                         // HACK(eddyb) don't use `panic::catch_unwind` in a panic.

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/dylib/proc_macros.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/dylib/proc_macros.rs
@@ -30,7 +30,7 @@ impl ProcMacros {
                     if *trait_name == macro_name =>
                 {
                     let res = client.run(
-                        &bridge::server::SameThread,
+                        &bridge::server::SAME_THREAD,
                         S::make_server(call_site, def_site, mixed_site, callback),
                         macro_body,
                         cfg!(debug_assertions),
@@ -39,7 +39,7 @@ impl ProcMacros {
                 }
                 bridge::client::ProcMacro::Bang { name, client } if *name == macro_name => {
                     let res = client.run(
-                        &bridge::server::SameThread,
+                        &bridge::server::SAME_THREAD,
                         S::make_server(call_site, def_site, mixed_site, callback),
                         macro_body,
                         cfg!(debug_assertions),
@@ -48,7 +48,7 @@ impl ProcMacros {
                 }
                 bridge::client::ProcMacro::Attr { name, client } if *name == macro_name => {
                     let res = client.run(
-                        &bridge::server::SameThread,
+                        &bridge::server::SAME_THREAD,
                         S::make_server(call_site, def_site, mixed_site, callback),
                         parsed_attributes,
                         macro_body,


### PR DESCRIPTION
Also includes another tiny cleanup (functions can only have one return type).
