### PR TITLE
Allow `UnsafeCell` in shared statics

### DIFF
--- a/compiler/rustc_codegen_cranelift/example/mini_core.rs
+++ b/compiler/rustc_codegen_cranelift/example/mini_core.rs
@@ -86,7 +86,6 @@ impl<T: PointeeSized> Copy for *const T {}
 impl<T: PointeeSized> Copy for *mut T {}
 impl<T: Copy> Copy for Option<T> {}
 
-#[lang = "sync"]
 pub unsafe trait Sync {}
 
 unsafe impl Sync for bool {}

--- a/compiler/rustc_codegen_cranelift/example/mini_core.rs
+++ b/compiler/rustc_codegen_cranelift/example/mini_core.rs
@@ -104,6 +104,10 @@ unsafe impl Sync for f32 {}
 unsafe impl<'a, T: PointeeSized> Sync for &'a T {}
 unsafe impl<T: Sync, const N: usize> Sync for [T; N] {}
 
+#[lang = "allow_shared_static"]
+unsafe trait AllowSharedStatic {}
+unsafe impl<T: PointeeSized + Sync> AllowSharedStatic for T {}
+
 #[lang = "freeze"]
 unsafe auto trait Freeze {}
 

--- a/compiler/rustc_codegen_gcc/example/mini_core.rs
+++ b/compiler/rustc_codegen_gcc/example/mini_core.rs
@@ -94,7 +94,6 @@ impl<'a, T: PointeeSized> Copy for &'a T {}
 impl<T: PointeeSized> Copy for *const T {}
 impl<T: PointeeSized> Copy for *mut T {}
 
-#[lang = "sync"]
 pub unsafe trait Sync {}
 
 unsafe impl Sync for bool {}

--- a/compiler/rustc_codegen_gcc/example/mini_core.rs
+++ b/compiler/rustc_codegen_gcc/example/mini_core.rs
@@ -111,6 +111,10 @@ unsafe impl Sync for char {}
 unsafe impl<'a, T: PointeeSized> Sync for &'a T {}
 unsafe impl Sync for [u8; 16] {}
 
+#[lang = "allow_shared_static"]
+unsafe trait AllowSharedStatic {}
+unsafe impl<T: PointeeSized + Sync> AllowSharedStatic for T {}
+
 #[lang = "freeze"]
 unsafe auto trait Freeze {}
 

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -231,6 +231,7 @@ language_item_table! {
     IndexMut,                sym::index_mut,           index_mut_trait,            Target::Trait,          GenericRequirement::Exact(1);
 
     UnsafeCell,              sym::unsafe_cell,         unsafe_cell_type,           Target::Struct,         GenericRequirement::None;
+    AllowSharedStatic,       sym::allow_shared_static, allow_shared_static_trait,  Target::Trait,          GenericRequirement::Exact(0);
     UnsafePinned,            sym::unsafe_pinned,       unsafe_pinned_type,         Target::Struct,         GenericRequirement::None;
 
     VaList,                  sym::va_list,             va_list,                    Target::Struct,         GenericRequirement::None;

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -178,7 +178,6 @@ language_item_table! {
     CloneFn,                 sym::clone_fn,            clone_fn,                   Target::Method(MethodKind::Trait { body: false }), GenericRequirement::None;
     UseCloned,               sym::use_cloned,          use_cloned_trait,           Target::Trait,          GenericRequirement::None;
     TrivialClone,            sym::trivial_clone,       trivial_clone_trait,        Target::Trait,          GenericRequirement::None;
-    Sync,                    sym::sync,                sync_trait,                 Target::Trait,          GenericRequirement::Exact(0);
     DiscriminantKind,        sym::discriminant_kind,   discriminant_kind_trait,    Target::Trait,          GenericRequirement::None;
     /// The associated item of the `DiscriminantKind` trait.
     Discriminant,            sym::discriminant_type,   discriminant_type,          Target::AssocTy,        GenericRequirement::None;

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -770,7 +770,7 @@ pub(crate) fn check_item_type(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Result<(),
             check_static_linkage(tcx, def_id);
             let ty = tcx.type_of(def_id).instantiate_identity();
             res = res.and(wfcheck::check_static_item(
-                tcx, def_id, ty, /* should_check_for_sync */ true,
+                tcx, def_id, ty, /* should_check_allow_in_shared_static */ true,
             ));
 
             // Only `Node::Item` and `Node::ForeignItem` still have HIR based

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1228,7 +1228,7 @@ pub(crate) fn check_static_item<'tcx>(
     tcx: TyCtxt<'tcx>,
     item_id: LocalDefId,
     ty: Ty<'tcx>,
-    should_check_for_sync: bool,
+    should_check_allow_in_shared_static: bool,
 ) -> Result<(), ErrorGuaranteed> {
     enter_wf_checking_ctxt(tcx, item_id, |wfcx| {
         let span = tcx.ty_span(item_id);
@@ -1263,13 +1263,13 @@ pub(crate) fn check_static_item<'tcx>(
             );
         }
 
-        // Ensure that the end result is `Sync` in a non-thread local `static`.
-        let should_check_for_sync = should_check_for_sync
+        // Ensure that the end result is `Sync` or `UnsafeCell<T: Sync>` in a non-thread local `static`.
+        let should_check_allow_in_shared_static = should_check_allow_in_shared_static
             && !is_foreign_item
             && tcx.static_mutability(item_id.to_def_id()) == Some(hir::Mutability::Not)
             && !tcx.is_thread_local_static(item_id.to_def_id());
 
-        if should_check_for_sync {
+        if should_check_allow_in_shared_static {
             wfcx.register_bound(
                 traits::ObligationCause::new(
                     span,
@@ -1278,7 +1278,7 @@ pub(crate) fn check_static_item<'tcx>(
                 ),
                 wfcx.param_env,
                 item_ty,
-                tcx.require_lang_item(LangItem::Sync, span),
+                tcx.require_lang_item(LangItem::AllowSharedStatic, span),
             );
         }
         Ok(())

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -131,7 +131,9 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::EarlyBinder<'_
                     // Verify that here to avoid ill-formed MIR.
                     // We skip the `Sync` check to avoid cycles for type-alias-impl-trait,
                     // relying on the fact that non-Sync statics don't ICE the rest of the compiler.
-                    match check_static_item(tcx, def_id, ty, /* should_check_for_sync */ false) {
+                    match check_static_item(
+                        tcx, def_id, ty, /* should_check_allow_in_shared_static */ false,
+                    ) {
                         Ok(()) => ty,
                         Err(guar) => Ty::new_error(tcx, guar),
                     }
@@ -199,7 +201,9 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::EarlyBinder<'_
                 // Verify that here to avoid ill-formed MIR.
                 // We skip the `Sync` check to avoid cycles for type-alias-impl-trait,
                 // relying on the fact that non-Sync statics don't ICE the rest of the compiler.
-                match check_static_item(tcx, def_id, ty, /* should_check_for_sync */ false) {
+                match check_static_item(
+                    tcx, def_id, ty, /* should_check_allow_in_shared_static */ false,
+                ) {
                     Ok(()) => ty,
                     Err(guar) => Ty::new_error(tcx, guar),
                 }

--- a/compiler/rustc_hir_typeck/src/upvar.rs
+++ b/compiler/rustc_hir_typeck/src/upvar.rs
@@ -1153,7 +1153,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) -> Option<FxIndexMap<UpvarMigrationInfo, UnordSet<&'static str>>> {
         let auto_traits_def_id = [
             self.tcx.lang_items().clone_trait(),
-            self.tcx.lang_items().sync_trait(),
+            self.tcx.get_diagnostic_item(sym::Sync),
             self.tcx.get_diagnostic_item(sym::Send),
             self.tcx.lang_items().unpin_trait(),
             self.tcx.get_diagnostic_item(sym::unwind_safe_trait),

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -269,7 +269,7 @@ pub enum ObligationCauseCode<'tcx> {
     /// Constant expressions must be sized.
     SizedConstOrStatic,
 
-    /// `static` items must have `Sync` type.
+    /// `static` items must have `Sync` or `UnsafeCell<T: Sync>` type (`AllowSharedStatic`).
     SharedStatic,
 
     /// Derived obligation (i.e. theoretical `where` clause) on a built-in

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -461,6 +461,7 @@ symbols! {
         allow_fail,
         allow_internal_unsafe,
         allow_internal_unstable,
+        allow_shared_static,
         altivec,
         alu32,
         always,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -3400,6 +3400,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 ));
             }
             ObligationCauseCode::SharedStatic => {
+                // TODO: Add note about `UnsafeCell` here too?
                 err.note("shared static variables must have a type that implements `Sync`");
             }
             ObligationCauseCode::BuiltinDerived(ref data) => {

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -583,7 +583,6 @@ pub trait BikeshedGuaranteedNoDrop {}
 /// [nomicon-send-and-sync]: ../../nomicon/send-and-sync.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_diagnostic_item = "Sync"]
-#[lang = "sync"]
 #[rustc_on_unimplemented(
     on(
         Self = "core::cell::once::OnceCell<T>",

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -676,6 +676,35 @@ impl<T: PointeeSized> !Sync for *const T {}
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: PointeeSized> !Sync for *mut T {}
 
+/// Whether a type is usable in shared statics.
+///
+/// TODO.
+#[lang = "allow_shared_static"]
+#[unstable(feature = "allow_shared_static_trait", issue = "none")]
+#[rustc_on_unimplemented(
+    message = "`{Self}` cannot be shared between threads safely",
+    label = "`{Self}` cannot be shared between threads safely"
+)]
+pub unsafe trait AllowSharedStatic {}
+
+// SAFETY: All `T: Sync` types are usable in shared statics.
+//
+// NOTE: The `MetaSized` bound is mostly a lie, as only sized types can be
+// used directly in statics. But this is already enforced by the compiler.
+#[unstable(feature = "allow_shared_static_trait", issue = "none")]
+unsafe impl<T: MetaSized + Sync> AllowSharedStatic for T {}
+
+// SAFETY: `UnsafeCell<T: Sync>` could (and should) have been `Sync`, there
+// is nothing inherent to `UnsafeCell` that forbids `Sync`.
+//
+// NOTE: Ideally, we'd have marked `UnsafeCell<T: Sync>: Sync`, but that is a
+// breaking change, since users rely upon `UnsafeCell<u32>` making their type
+// `!Sync`.
+//
+// See also TODO link.
+#[unstable(feature = "allow_shared_static_trait", issue = "none")]
+unsafe impl<T: MetaSized + Sync> AllowSharedStatic for UnsafeCell<T> {}
+
 /// Zero-sized type used to mark things that "act like" they own a `T`.
 ///
 /// Adding a `PhantomData<T>` field to your type tells the compiler that your

--- a/library/rtstartup/rsbegin.rs
+++ b/library/rtstartup/rsbegin.rs
@@ -30,8 +30,9 @@ pub trait MetaSized: PointeeSized {}
 #[lang = "sized"]
 pub trait Sized: MetaSized {}
 
-#[lang = "sync"]
-auto trait Sync {}
+#[lang = "allow_shared_static"]
+trait AllowSharedStatic {}
+impl<T: PointeeSized> AllowSharedStatic for T {}
 #[lang = "copy"]
 trait Copy {}
 #[lang = "freeze"]

--- a/library/rtstartup/rsend.rs
+++ b/library/rtstartup/rsend.rs
@@ -17,9 +17,9 @@ pub trait MetaSized: PointeeSized {}
 #[lang = "sized"]
 pub trait Sized: MetaSized {}
 
-#[lang = "sync"]
-trait Sync {}
-impl<T> Sync for T {}
+#[lang = "allow_shared_static"]
+trait AllowSharedStatic {}
+impl<T: PointeeSized> AllowSharedStatic for T {}
 #[lang = "copy"]
 trait Copy {}
 #[lang = "freeze"]

--- a/src/tools/clippy/clippy_lints/src/arc_with_non_send_sync.rs
+++ b/src/tools/clippy/clippy_lints/src/arc_with_non_send_sync.rs
@@ -54,7 +54,7 @@ impl<'tcx> LateLintPass<'tcx> for ArcWithNonSendSync {
                 !matches!(arg.kind(), GenericArgKind::Type(ty) if matches!(ty.kind(), ty::Param(_)))
             })
             && let Some(send) = cx.tcx.get_diagnostic_item(sym::Send)
-            && let Some(sync) = cx.tcx.lang_items().sync_trait()
+            && let Some(sync) = cx.tcx.get_diagnostic_item(sym::Sync)
             && let [is_send, is_sync] = [send, sync].map(|id| implements_trait(cx, arg_ty, id, &[]))
             && let reason = match (is_send, is_sync) {
                 (false, false) => "neither `Send` nor `Sync`",

--- a/src/tools/clippy/clippy_lints/src/non_copy_const.rs
+++ b/src/tools/clippy/clippy_lints/src/non_copy_const.rs
@@ -725,10 +725,10 @@ impl<'tcx> LateLintPass<'tcx> for NonCopyConst<'tcx> {
                 ident.span,
                 "named constant with interior mutability",
                 |diag| {
-                    let Some(sync_trait) = cx.tcx.lang_items().sync_trait() else {
+                    let Some(sync) = cx.tcx.get_diagnostic_item(sym::Sync) else {
                         return;
                     };
-                    if implements_trait(cx, ty, sync_trait, &[]) {
+                    if implements_trait(cx, ty, sync, &[]) {
                         diag.help("did you mean to make this a `static` item");
                     } else {
                         diag.help("did you mean to make this a `thread_local!` item");

--- a/src/tools/rust-analyzer/crates/hir-def/src/lang_item.rs
+++ b/src/tools/rust-analyzer/crates/hir-def/src/lang_item.rs
@@ -308,7 +308,6 @@ language_item_table! { LangItems =>
     Copy,                    sym::copy,                TraitId;
     Clone,                   sym::clone,               TraitId;
     TrivialClone,            sym::trivial_clone,       TraitId;
-    Sync,                    sym::sync,                TraitId;
     DiscriminantKind,        sym::discriminant_kind,   TraitId;
     /// The associated item of the `DiscriminantKind` trait.
     Discriminant,            sym::discriminant_type,   TypeAliasId;

--- a/tests/auxiliary/minicore.rs
+++ b/tests/auxiliary/minicore.rs
@@ -229,6 +229,10 @@ impl_marker_trait!(
     ]
 );
 
+#[lang = "allow_shared_static"]
+trait AllowSharedStatic {}
+impl<T: PointeeSized + Sync> AllowSharedStatic for T {}
+
 #[lang = "drop_in_place"]
 fn drop_in_place<T>(_: *mut T) {}
 

--- a/tests/auxiliary/minicore.rs
+++ b/tests/auxiliary/minicore.rs
@@ -218,7 +218,6 @@ impl Neg for i8 {
     }
 }
 
-#[lang = "sync"]
 pub trait Sync {}
 impl_marker_trait!(
     Sync => [

--- a/tests/run-make/arm64ec-import-export-static/export.rs
+++ b/tests/run-make/arm64ec-import-export-static/export.rs
@@ -11,9 +11,9 @@ pub trait PointeeSized {}
 pub trait MetaSized: PointeeSized {}
 #[lang = "sized"]
 pub trait Sized: MetaSized {}
-#[lang = "sync"]
-trait Sync {}
-impl Sync for i32 {}
+#[lang = "allow_shared_static"]
+trait AllowSharedStatic {}
+impl AllowSharedStatic for i32 {}
 #[lang = "copy"]
 pub trait Copy {}
 impl Copy for i32 {}

--- a/tests/run-make/min-global-align/min_global_align.rs
+++ b/tests/run-make/min-global-align/min_global_align.rs
@@ -29,10 +29,10 @@ trait Freeze {}
 // No `UnsafeCell`, so everything is `Freeze`.
 impl<T: ?Sized> Freeze for T {}
 
-#[lang = "sync"]
-trait Sync {}
-impl Sync for bool {}
-impl Sync for &'static bool {}
+#[lang = "allow_shared_static"]
+trait AllowSharedStatic {}
+impl AllowSharedStatic for bool {}
+impl AllowSharedStatic for &'static bool {}
 
 #[lang = "drop_in_place"]
 pub unsafe fn drop_in_place<T: ?Sized>(_: *mut T) {}

--- a/tests/ui/lang-items/issue-87573.rs
+++ b/tests/ui/lang-items/issue-87573.rs
@@ -19,9 +19,9 @@ trait Sized: MetaSized {}
 #[lang = "copy"]
 trait Copy {}
 
-#[lang = "sync"]
-trait Sync {}
-impl Sync for bool {}
+#[lang = "allow_shared_static"]
+trait AllowSharedStatic {}
+impl AllowSharedStatic for bool {}
 
 #[lang = "drop_in_place"]
 //~^ ERROR: `drop_in_place` lang item must be applied to a function with at least 1 generic argument
@@ -31,4 +31,4 @@ fn drop_fn() {
 
 #[lang = "start"]
 //~^ ERROR: `start` lang item must be applied to a function with 1 generic argument
-fn start(){}
+fn start() {}

--- a/tests/ui/static/global-variable-promotion-error-7364.stderr
+++ b/tests/ui/static/global-variable-promotion-error-7364.stderr
@@ -9,6 +9,7 @@ LL | static boxed: Box<RefCell<isize>> = Box::new(RefCell::new(0));
    = note: required for `std::ptr::Unique<RefCell<isize>>` to implement `Sync`
 note: required because it appears within the type `Box<RefCell<isize>>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
+   = note: required for `Box<RefCell<isize>>` to implement `AllowSharedStatic`
    = note: shared static variables must have a type that implements `Sync`
 
 error[E0015]: cannot call non-const associated function `Box::<RefCell<isize>>::new` in statics

--- a/tests/ui/static/static-requires-lang-item.rs
+++ b/tests/ui/static/static-requires-lang-item.rs
@@ -1,0 +1,16 @@
+//! Test that creating statics requires the `AllowSharedStatic` language item.
+#![feature(lang_items, no_core)]
+#![no_core]
+#![no_main]
+
+#[lang = "pointee_sized"]
+trait PointeeSized {}
+#[lang = "meta_sized"]
+trait MetaSized: PointeeSized {}
+#[lang = "sized"]
+pub trait Sized: MetaSized {}
+#[lang = "copy"]
+trait Copy {}
+
+static FOO: () = ();
+//~^ ERROR: requires `allow_shared_static` lang_item

--- a/tests/ui/static/static-requires-lang-item.stderr
+++ b/tests/ui/static/static-requires-lang-item.stderr
@@ -1,0 +1,8 @@
+error: requires `allow_shared_static` lang_item
+  --> $DIR/static-requires-lang-item.rs:15:13
+   |
+LL | static FOO: () = ();
+   |             ^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/static/unsafe-cell.rs
+++ b/tests/ui/static/unsafe-cell.rs
@@ -1,0 +1,14 @@
+//! Test `UnsafeCell` in `static`s.
+use std::cell::UnsafeCell;
+
+// Works even though it isn't `Sync`.
+#[allow(dead_code)]
+static FOO: UnsafeCell<i32> = UnsafeCell::new(42);
+
+// Does not work, requires `unsafe impl Sync for Bar {}`.
+struct Bar(UnsafeCell<i32>);
+#[allow(dead_code)]
+static BAR: Bar = Bar(UnsafeCell::new(42));
+//~^ ERROR: `UnsafeCell<i32>` cannot be shared between threads safely
+
+fn main() {}

--- a/tests/ui/static/unsafe-cell.stderr
+++ b/tests/ui/static/unsafe-cell.stderr
@@ -1,0 +1,18 @@
+error[E0277]: `UnsafeCell<i32>` cannot be shared between threads safely
+  --> $DIR/unsafe-cell.rs:11:13
+   |
+LL | static BAR: Bar = Bar(UnsafeCell::new(42));
+   |             ^^^ `UnsafeCell<i32>` cannot be shared between threads safely
+   |
+   = help: within `Bar`, the trait `Sync` is not implemented for `UnsafeCell<i32>`
+note: required because it appears within the type `Bar`
+  --> $DIR/unsafe-cell.rs:9:8
+   |
+LL | struct Bar(UnsafeCell<i32>);
+   |        ^^^
+   = note: required for `Bar` to implement `AllowSharedStatic`
+   = note: shared static variables must have a type that implements `Sync`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/statics/issue-17718-static-sync.stderr
+++ b/tests/ui/statics/issue-17718-static-sync.stderr
@@ -9,6 +9,7 @@ help: the trait `Sync` is not implemented for `Foo`
    |
 LL | struct Foo;
    | ^^^^^^^^^^
+   = note: required for `Foo` to implement `AllowSharedStatic`
    = note: shared static variables must have a type that implements `Sync`
 
 error: aborting due to 1 previous error

--- a/tests/ui/statics/unsizing-wfcheck-issue-127299.stderr
+++ b/tests/ui/statics/unsizing-wfcheck-issue-127299.stderr
@@ -35,6 +35,7 @@ note: required because it appears within the type `Lint`
 LL | pub struct Lint {
    |            ^^^^
    = note: required because it appears within the type `&'static Lint`
+   = note: required for `&'static Lint` to implement `AllowSharedStatic`
    = note: shared static variables must have a type that implements `Sync`
 
 error[E0038]: the trait `Qux` is not dyn compatible


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/152540)*
<!-- homu-ignore:end -->

## Background

Using a type in a (shared) static introduces a `Sync` bound on that type, to ensure that it is safe to share across threads.

This is sufficient, but overly restrictive: there exist other types which are safe to use directly in a static, including `UnsafeCell` and raw pointers (these types are `!Sync` primarily as a "hint" to avoid items containing them being `Sync` via auto traits, but they are by themselves not unsafe to share across multiple threads).

For example `static NULL_INT: *const i32 = std::ptr::null();` would be perfectly valid. Another (very contrived) example can be found in [this playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=b563fc7c9a8a0a97155d13ee86e90ffe).

## Proposal

I propose special-casing `UnsafeCell<T: Sync>` to allow it as the type in shared statics.

This would enable the following to compile:
```rust
static FOO: UnsafeCell<i32> = UnsafeCell::new(42);

fn main() {
    // SAFETY: No other threads are accessing FOO.
    unsafe { FOO.get().write(43) };
}
```

As an alternative to:
```rust
static mut FOO: i32 = 42;

fn main() {
    // SAFETY: No other threads are accessing FOO.
    unsafe { addr_of_mut!(FOO).write(43) };
}
```

While the following would still be an error (because `MyCell` is `!Sync`):
```rust
struct MyCell(UnsafeCell<i32>);
static CELL: MyCell = MyCell(UnsafeCell::new(42));
```

Unlike adding an `unsafe impl<T: Sync> Sync for UnsafeCell<T>`, this would not be a breaking change as far as I can tell, as library authors shouldn't rely on an arbitrary `UnsafeCell` not being shared elsewhere (APIs taking `&UnsafeCell<T>` can't be safe).

This is intended as a partial alternative to `SyncUnsafeCell` ([tracking issue](https://github.com/rust-lang/rust/issues/95439)), which was [introduced](https://github.com/rust-lang/rust/pull/95438) primarily to avoid having to use `static mut`, and secondarily to avoid the need for a manual `Sync` impl. (This PR would make the first item redundant but wouldn't change the second).

I have opened https://github.com/rust-lang/reference/pull/2169 to update the reference, to allow you to see how things would look if this was stabilized.

## Implementation

This PR introduces a new unstable trait `AllowSharedStatic` which is now used for the bound on shared statics instead of `Sync`. It is defined as:
```rust
#[lang = "allow_shared_static"]
pub unsafe trait AllowSharedStatic {}
unsafe impl<T: Sync> AllowSharedStatic for T {}
unsafe impl<T: Sync> AllowSharedStatic for UnsafeCell<T> {}
// Maybe in the future:
// unsafe impl<T> AllowSharedStatic for UnsafeCell<T> {}
// unsafe impl<T> AllowSharedStatic for *const T {}
// unsafe impl<T> AllowSharedStatic for *mut T {}
```

This trait is intended to be perma-unstable and not be exposed to users (at least not unless we find a compelling reason to do so).

One interesting thing to notice is that this bound is the only place where the compiler requires the `sync` lang item - with this change, we'd move that to `allow_shared_static` being the required lang item, and `Sync` being just another library type.

## TODO

- Make this opt-in with an unstable feature, and create a tracking issue.
- Measure performance impact, special-case in compiler if necessary.
- Better diagnostics, we (probably?) want to keep using `Sync`'s "on_unimplemented" messages, and `AllowSharedStatic` shouldn't appear in error messages.
- Proper documentation.
- Bikeshed naming.

I will do these if t-lang decides to go forwards with this idea.
r? compiler