### PR TITLE
Updated docs for Vec::swap_remove and VecDeque::swap_remove_front/back

### DIFF
--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -2312,6 +2312,12 @@ impl<T, A: Allocator> VecDeque<T, A> {
     ///
     /// Element at index 0 is the front of the queue.
     ///
+    /// When removing the front element, 
+    /// this is equivalent to [`pop_front`] and no swap operation is preformed.
+    /// If always removing the front element, [`pop_front`] should be used instead. 
+    ///
+    /// [`pop_front']: VecDeque::pop_front
+    ///
     /// # Examples
     ///
     /// ```
@@ -2322,10 +2328,14 @@ impl<T, A: Allocator> VecDeque<T, A> {
     /// buf.push_back(1);
     /// buf.push_back(2);
     /// buf.push_back(3);
-    /// assert_eq!(buf, [1, 2, 3]);
+    /// buf.push_back(4);
+    /// assert_eq!(buf, [1, 2, 3, 4]);
     ///
     /// assert_eq!(buf.swap_remove_front(2), Some(3));
-    /// assert_eq!(buf, [2, 1]);
+    /// assert_eq!(buf, [2, 1, 4]);
+    ///
+    /// assert_eq!(buf.swap_remove_front(0), Some(2));
+    /// assert_eq!(buf, [1, 4]);
     /// ```
     #[stable(feature = "deque_extras_15", since = "1.5.0")]
     pub fn swap_remove_front(&mut self, index: usize) -> Option<T> {
@@ -2347,6 +2357,12 @@ impl<T, A: Allocator> VecDeque<T, A> {
     ///
     /// Element at index 0 is the front of the queue.
     ///
+    /// When removing the back element, 
+    /// this is equivalent to [`pop_back`] and no swap operation is preformed.
+    /// If always removing the front element, [`pop_back`] should be used instead. 
+    ///
+    /// [`pop_back']: VecDeque::pop_back
+    //
     /// # Examples
     ///
     /// ```

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -2362,7 +2362,7 @@ impl<T, A: Allocator> VecDeque<T, A> {
     /// If always removing the front element, [`pop_back`] should be used instead. 
     ///
     /// [`pop_back']: VecDeque::pop_back
-    //
+    ///
     /// # Examples
     ///
     /// ```
@@ -2373,10 +2373,14 @@ impl<T, A: Allocator> VecDeque<T, A> {
     /// buf.push_back(1);
     /// buf.push_back(2);
     /// buf.push_back(3);
-    /// assert_eq!(buf, [1, 2, 3]);
+    /// buf.push_back(4);
+    /// assert_eq!(buf, [1, 2, 3, 4]);
     ///
-    /// assert_eq!(buf.swap_remove_back(0), Some(1));
-    /// assert_eq!(buf, [3, 2]);
+    /// assert_eq!(buf.swap_remove_back(1), Some(2));
+    /// assert_eq!(buf, [1, 4, 3]);
+    ///
+    /// assert_eq!(buf.swap_remove_back(2), Some(3));
+    /// assert_eq!(buf, [1, 4]);
     /// ```
     #[stable(feature = "deque_extras_15", since = "1.5.0")]
     pub fn swap_remove_back(&mut self, index: usize) -> Option<T> {

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -2109,8 +2109,12 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// This does not preserve ordering of the remaining elements, but is *O*(1).
     /// If you need to preserve the element order, use [`remove`] instead.
+    /// When removing the last element of a vec,
+    /// this is equivalent to [`pop`] and no swap operation is preformed.
+    /// If always removing the last element, pop should be used instead. 
     ///
     /// [`remove`]: Vec::remove
+    /// [`pop']: Vec::pop
     ///
     /// # Panics
     ///
@@ -2126,6 +2130,9 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// assert_eq!(v.swap_remove(0), "foo");
     /// assert_eq!(v, ["baz", "qux"]);
+    ///
+    /// assert_eq!(v.swap_remove(1), "qux");
+    /// assert_eq!(v, ["baz"]);
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
The docs for the swap remove functions do not obviously specify behavior when removing the last element (or in the case of `swap_remove_front` the first). This makes the specification explicit, adds doc tests for it, ands points users to use `pop(_front/_back)` when applicable.