### PR TITLE
Revert "resolve: Downgrade `ambiguous_glob_imports` to warn-by-default"

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -4565,7 +4565,7 @@ declare_lint! {
     ///
     /// [future-incompatible]: ../index.md#future-incompatible-lints
     pub AMBIGUOUS_GLOB_IMPORTS,
-    Warn,
+    Deny,
     "detects certain glob imports that require reporting an ambiguity error",
     @future_incompatible = FutureIncompatibleInfo {
         reason: fcw!(FutureReleaseError #114095),

--- a/tests/ui/imports/ambiguous-10.rs
+++ b/tests/ui/imports/ambiguous-10.rs
@@ -1,5 +1,5 @@
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1637022296
-//@ check-pass
+
 mod a {
     pub enum Token {}
 }
@@ -13,6 +13,6 @@ mod b {
 use crate::a::*;
 use crate::b::*;
 fn c(_: Token) {}
-//~^ WARN `Token` is ambiguous
+//~^ ERROR `Token` is ambiguous
 //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 fn main() { }

--- a/tests/ui/imports/ambiguous-10.stderr
+++ b/tests/ui/imports/ambiguous-10.stderr
@@ -1,4 +1,4 @@
-warning: `Token` is ambiguous
+error: `Token` is ambiguous
   --> $DIR/ambiguous-10.rs:15:9
    |
 LL | fn c(_: Token) {}
@@ -19,12 +19,12 @@ note: `Token` could also refer to the enum imported here
 LL | use crate::b::*;
    |     ^^^^^^^^^^^
    = help: consider adding an explicit import of `Token` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `Token` is ambiguous
+error: `Token` is ambiguous
   --> $DIR/ambiguous-10.rs:15:9
    |
 LL | fn c(_: Token) {}
@@ -45,5 +45,5 @@ note: `Token` could also refer to the enum imported here
 LL | use crate::b::*;
    |     ^^^^^^^^^^^
    = help: consider adding an explicit import of `Token` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-12.rs
+++ b/tests/ui/imports/ambiguous-12.rs
@@ -1,5 +1,5 @@
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1637022296
-//@ check-pass
+
 macro_rules! m {
     () => {
         pub fn b() {}
@@ -19,6 +19,6 @@ use crate::public::*;
 
 fn main() {
     b();
-    //~^ WARN `b` is ambiguous
+    //~^ ERROR `b` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }

--- a/tests/ui/imports/ambiguous-12.stderr
+++ b/tests/ui/imports/ambiguous-12.stderr
@@ -1,4 +1,4 @@
-warning: `b` is ambiguous
+error: `b` is ambiguous
   --> $DIR/ambiguous-12.rs:21:5
    |
 LL |     b();
@@ -19,12 +19,12 @@ note: `b` could also refer to the function imported here
 LL | use crate::public::*;
    |     ^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `b` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `b` is ambiguous
+error: `b` is ambiguous
   --> $DIR/ambiguous-12.rs:21:5
    |
 LL |     b();
@@ -45,5 +45,5 @@ note: `b` could also refer to the function imported here
 LL | use crate::public::*;
    |     ^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `b` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-13.rs
+++ b/tests/ui/imports/ambiguous-13.rs
@@ -1,5 +1,5 @@
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1637022296
-//@ check-pass
+
 pub mod object {
     #[derive(Debug)]
     pub struct Rect;
@@ -16,6 +16,6 @@ use crate::object::*;
 use crate::content::*;
 
 fn a(_: Rect) {}
-//~^ WARN `Rect` is ambiguous
+//~^ ERROR `Rect` is ambiguous
 //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 fn main() { }

--- a/tests/ui/imports/ambiguous-13.stderr
+++ b/tests/ui/imports/ambiguous-13.stderr
@@ -1,4 +1,4 @@
-warning: `Rect` is ambiguous
+error: `Rect` is ambiguous
   --> $DIR/ambiguous-13.rs:18:9
    |
 LL | fn a(_: Rect) {}
@@ -19,12 +19,12 @@ note: `Rect` could also refer to the struct imported here
 LL | use crate::content::*;
    |     ^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `Rect` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `Rect` is ambiguous
+error: `Rect` is ambiguous
   --> $DIR/ambiguous-13.rs:18:9
    |
 LL | fn a(_: Rect) {}
@@ -45,5 +45,5 @@ note: `Rect` could also refer to the struct imported here
 LL | use crate::content::*;
    |     ^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `Rect` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-14.rs
+++ b/tests/ui/imports/ambiguous-14.rs
@@ -1,6 +1,6 @@
 //@ edition:2015
 // https://github.com/rust-lang/rust/issues/98467
-//@ check-pass
+
 mod a {
     pub fn foo() {}
 }
@@ -21,6 +21,6 @@ mod g {
 
 fn main() {
     g::foo();
-    //~^ WARN `foo` is ambiguous
+    //~^ ERROR `foo` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }

--- a/tests/ui/imports/ambiguous-14.stderr
+++ b/tests/ui/imports/ambiguous-14.stderr
@@ -1,4 +1,4 @@
-warning: `foo` is ambiguous
+error: `foo` is ambiguous
   --> $DIR/ambiguous-14.rs:23:8
    |
 LL |     g::foo();
@@ -19,12 +19,12 @@ note: `foo` could also refer to the function imported here
 LL |     pub use f::*;
    |             ^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `foo` is ambiguous
+error: `foo` is ambiguous
   --> $DIR/ambiguous-14.rs:23:8
    |
 LL |     g::foo();
@@ -45,5 +45,5 @@ note: `foo` could also refer to the function imported here
 LL |     pub use f::*;
    |             ^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-15.rs
+++ b/tests/ui/imports/ambiguous-15.rs
@@ -1,5 +1,5 @@
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1638206152
-//@ check-pass
+
 mod t2 {
     #[derive(Debug)]
     pub enum Error {}
@@ -20,7 +20,7 @@ mod t3 {
 
 use self::t3::*;
 fn a<E: Error>(_: E) {}
-//~^ WARN `Error` is ambiguous
+//~^ ERROR `Error` is ambiguous
 //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 fn main() {}

--- a/tests/ui/imports/ambiguous-15.stderr
+++ b/tests/ui/imports/ambiguous-15.stderr
@@ -1,4 +1,4 @@
-warning: `Error` is ambiguous
+error: `Error` is ambiguous
   --> $DIR/ambiguous-15.rs:22:9
    |
 LL | fn a<E: Error>(_: E) {}
@@ -19,12 +19,12 @@ note: `Error` could also refer to the enum imported here
 LL | pub use t2::*;
    |         ^^^^^
    = help: consider adding an explicit import of `Error` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `Error` is ambiguous
+error: `Error` is ambiguous
   --> $DIR/ambiguous-15.rs:22:9
    |
 LL | fn a<E: Error>(_: E) {}
@@ -45,5 +45,5 @@ note: `Error` could also refer to the enum imported here
 LL | pub use t2::*;
    |         ^^^^^
    = help: consider adding an explicit import of `Error` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-16.rs
+++ b/tests/ui/imports/ambiguous-16.rs
@@ -1,5 +1,5 @@
 // https://github.com/rust-lang/rust/pull/113099
-//@ check-pass
+
 mod framing {
     mod public_message {
         use super::*;
@@ -20,7 +20,7 @@ mod framing {
 }
 
 use crate::framing::ConfirmedTranscriptHashInput;
-//~^ WARN `ConfirmedTranscriptHashInput` is ambiguous
+//~^ ERROR `ConfirmedTranscriptHashInput` is ambiguous
 //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 fn main() { }

--- a/tests/ui/imports/ambiguous-16.stderr
+++ b/tests/ui/imports/ambiguous-16.stderr
@@ -1,4 +1,4 @@
-warning: `ConfirmedTranscriptHashInput` is ambiguous
+error: `ConfirmedTranscriptHashInput` is ambiguous
   --> $DIR/ambiguous-16.rs:22:21
    |
 LL | use crate::framing::ConfirmedTranscriptHashInput;
@@ -19,12 +19,12 @@ note: `ConfirmedTranscriptHashInput` could also refer to the struct imported her
 LL |     pub use self::public_message_in::*;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `ConfirmedTranscriptHashInput` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `ConfirmedTranscriptHashInput` is ambiguous
+error: `ConfirmedTranscriptHashInput` is ambiguous
   --> $DIR/ambiguous-16.rs:22:21
    |
 LL | use crate::framing::ConfirmedTranscriptHashInput;
@@ -45,5 +45,5 @@ note: `ConfirmedTranscriptHashInput` could also refer to the struct imported her
 LL |     pub use self::public_message_in::*;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `ConfirmedTranscriptHashInput` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-17.rs
+++ b/tests/ui/imports/ambiguous-17.rs
@@ -1,6 +1,6 @@
 //@ edition:2015
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1638206152
-//@ check-pass
+
 pub use evp::*; //~ WARNING ambiguous glob re-exports
 pub use handwritten::*;
 
@@ -24,6 +24,6 @@ mod handwritten {
 
 fn main() {
     id();
-    //~^ WARN `id` is ambiguous
+    //~^ ERROR `id` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }

--- a/tests/ui/imports/ambiguous-17.stderr
+++ b/tests/ui/imports/ambiguous-17.stderr
@@ -8,7 +8,7 @@ LL | pub use handwritten::*;
    |
    = note: `#[warn(ambiguous_glob_reexports)]` on by default
 
-warning: `id` is ambiguous
+error: `id` is ambiguous
   --> $DIR/ambiguous-17.rs:26:5
    |
 LL |     id();
@@ -29,12 +29,12 @@ note: `id` could also refer to the function imported here
 LL | pub use handwritten::*;
    |         ^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `id` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 2 warnings emitted
+error: aborting due to 1 previous error; 1 warning emitted
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `id` is ambiguous
+error: `id` is ambiguous
   --> $DIR/ambiguous-17.rs:26:5
    |
 LL |     id();
@@ -55,5 +55,5 @@ note: `id` could also refer to the function imported here
 LL | pub use handwritten::*;
    |         ^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `id` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-2.rs
+++ b/tests/ui/imports/ambiguous-2.rs
@@ -1,9 +1,9 @@
 //@ aux-build: ../ambiguous-1.rs
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1633574396
-//@ check-pass
+
 extern crate ambiguous_1;
 
 fn main() {
-    ambiguous_1::id(); //~ WARN `id` is ambiguous
+    ambiguous_1::id(); //~ ERROR `id` is ambiguous
                        //~| WARN this was previously accepted
 }

--- a/tests/ui/imports/ambiguous-2.stderr
+++ b/tests/ui/imports/ambiguous-2.stderr
@@ -1,4 +1,4 @@
-warning: `id` is ambiguous
+error: `id` is ambiguous
   --> $DIR/ambiguous-2.rs:7:18
    |
 LL |     ambiguous_1::id();
@@ -19,12 +19,12 @@ note: `id` could also refer to the function defined here
    |
 LL |     pub use self::handwritten::*;
    |             ^^^^^^^^^^^^^^^^^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `id` is ambiguous
+error: `id` is ambiguous
   --> $DIR/ambiguous-2.rs:7:18
    |
 LL |     ambiguous_1::id();
@@ -45,5 +45,5 @@ note: `id` could also refer to the function defined here
    |
 LL |     pub use self::handwritten::*;
    |             ^^^^^^^^^^^^^^^^^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-3.rs
+++ b/tests/ui/imports/ambiguous-3.rs
@@ -1,9 +1,9 @@
 // https://github.com/rust-lang/rust/issues/47525
-//@ check-pass
+
 fn main() {
     use a::*;
     x();
-    //~^ WARN `x` is ambiguous
+    //~^ ERROR `x` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }
 

--- a/tests/ui/imports/ambiguous-3.stderr
+++ b/tests/ui/imports/ambiguous-3.stderr
@@ -1,4 +1,4 @@
-warning: `x` is ambiguous
+error: `x` is ambiguous
   --> $DIR/ambiguous-3.rs:5:5
    |
 LL |     x();
@@ -19,12 +19,12 @@ note: `x` could also refer to the function imported here
 LL |     pub use self::c::*;
    |             ^^^^^^^^^^
    = help: consider adding an explicit import of `x` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `x` is ambiguous
+error: `x` is ambiguous
   --> $DIR/ambiguous-3.rs:5:5
    |
 LL |     x();
@@ -45,5 +45,5 @@ note: `x` could also refer to the function imported here
 LL |     pub use self::c::*;
    |             ^^^^^^^^^^
    = help: consider adding an explicit import of `x` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-4.rs
+++ b/tests/ui/imports/ambiguous-4.rs
@@ -1,9 +1,9 @@
 //@ edition:2015
 //@ aux-build: ../ambiguous-4-extern.rs
-//@ check-pass
+
 extern crate ambiguous_4_extern;
 
 fn main() {
-    ambiguous_4_extern::id(); //~ WARN `id` is ambiguous
+    ambiguous_4_extern::id(); //~ ERROR `id` is ambiguous
                               //~| WARN this was previously accepted
 }

--- a/tests/ui/imports/ambiguous-4.stderr
+++ b/tests/ui/imports/ambiguous-4.stderr
@@ -1,4 +1,4 @@
-warning: `id` is ambiguous
+error: `id` is ambiguous
   --> $DIR/ambiguous-4.rs:7:25
    |
 LL |     ambiguous_4_extern::id();
@@ -19,12 +19,12 @@ note: `id` could also refer to the function defined here
    |
 LL | pub use handwritten::*;
    |         ^^^^^^^^^^^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `id` is ambiguous
+error: `id` is ambiguous
   --> $DIR/ambiguous-4.rs:7:25
    |
 LL |     ambiguous_4_extern::id();
@@ -45,5 +45,5 @@ note: `id` could also refer to the function defined here
    |
 LL | pub use handwritten::*;
    |         ^^^^^^^^^^^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-5.rs
+++ b/tests/ui/imports/ambiguous-5.rs
@@ -1,5 +1,5 @@
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1637022296
-//@ check-pass
+
 mod a {
     pub struct Class(u16);
 }
@@ -10,7 +10,7 @@ mod gpos {
     use super::gsubgpos::*;
     use super::*;
     struct MarkRecord(Class);
-    //~^ WARN`Class` is ambiguous
+    //~^ ERROR`Class` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }
 

--- a/tests/ui/imports/ambiguous-5.stderr
+++ b/tests/ui/imports/ambiguous-5.stderr
@@ -1,4 +1,4 @@
-warning: `Class` is ambiguous
+error: `Class` is ambiguous
   --> $DIR/ambiguous-5.rs:12:23
    |
 LL |     struct MarkRecord(Class);
@@ -19,12 +19,12 @@ note: `Class` could also refer to the struct imported here
 LL |     use super::gsubgpos::*;
    |         ^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `Class` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `Class` is ambiguous
+error: `Class` is ambiguous
   --> $DIR/ambiguous-5.rs:12:23
    |
 LL |     struct MarkRecord(Class);
@@ -45,5 +45,5 @@ note: `Class` could also refer to the struct imported here
 LL |     use super::gsubgpos::*;
    |         ^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `Class` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-6.rs
+++ b/tests/ui/imports/ambiguous-6.rs
@@ -1,10 +1,10 @@
 //@ edition: 2021
 // https://github.com/rust-lang/rust/issues/112713
-//@ check-pass
+
 pub fn foo() -> u32 {
     use sub::*;
     C
-    //~^ WARN `C` is ambiguous
+    //~^ ERROR `C` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }
 

--- a/tests/ui/imports/ambiguous-6.stderr
+++ b/tests/ui/imports/ambiguous-6.stderr
@@ -1,4 +1,4 @@
-warning: `C` is ambiguous
+error: `C` is ambiguous
   --> $DIR/ambiguous-6.rs:6:5
    |
 LL |     C
@@ -19,12 +19,12 @@ note: `C` could also refer to the constant imported here
 LL |     pub use mod2::*;
    |             ^^^^^^^
    = help: consider adding an explicit import of `C` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `C` is ambiguous
+error: `C` is ambiguous
   --> $DIR/ambiguous-6.rs:6:5
    |
 LL |     C
@@ -45,5 +45,5 @@ note: `C` could also refer to the constant imported here
 LL |     pub use mod2::*;
    |             ^^^^^^^
    = help: consider adding an explicit import of `C` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-9.rs
+++ b/tests/ui/imports/ambiguous-9.rs
@@ -1,5 +1,5 @@
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1638206152
-//@ check-pass
+
 pub mod dsl {
     mod range {
         pub fn date_range() {}
@@ -21,8 +21,8 @@ use prelude::*;
 
 fn main() {
     date_range();
-    //~^ WARN `date_range` is ambiguous
+    //~^ ERROR `date_range` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-    //~| WARN `date_range` is ambiguous
+    //~| ERROR `date_range` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }

--- a/tests/ui/imports/ambiguous-9.stderr
+++ b/tests/ui/imports/ambiguous-9.stderr
@@ -8,7 +8,7 @@ LL |     use super::prelude::*;
    |
    = note: `#[warn(ambiguous_glob_reexports)]` on by default
 
-warning: `date_range` is ambiguous
+error: `date_range` is ambiguous
   --> $DIR/ambiguous-9.rs:23:5
    |
 LL |     date_range();
@@ -29,7 +29,7 @@ note: `date_range` could also refer to the function imported here
 LL |     use super::prelude::*;
    |         ^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `date_range` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 warning: ambiguous glob re-exports
   --> $DIR/ambiguous-9.rs:15:13
@@ -39,7 +39,7 @@ LL |     pub use self::t::*;
 LL |     pub use super::dsl::*;
    |             ------------- but the name `date_range` in the value namespace is also re-exported here
 
-warning: `date_range` is ambiguous
+error: `date_range` is ambiguous
   --> $DIR/ambiguous-9.rs:23:5
    |
 LL |     date_range();
@@ -61,10 +61,10 @@ LL | use prelude::*;
    |     ^^^^^^^^^^
    = help: consider adding an explicit import of `date_range` to disambiguate
 
-warning: 4 warnings emitted
+error: aborting due to 2 previous errors; 2 warnings emitted
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `date_range` is ambiguous
+error: `date_range` is ambiguous
   --> $DIR/ambiguous-9.rs:23:5
    |
 LL |     date_range();
@@ -85,10 +85,10 @@ note: `date_range` could also refer to the function imported here
 LL |     use super::prelude::*;
    |         ^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `date_range` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
-warning: `date_range` is ambiguous
+error: `date_range` is ambiguous
   --> $DIR/ambiguous-9.rs:23:5
    |
 LL |     date_range();
@@ -109,5 +109,5 @@ note: `date_range` could also refer to the function imported here
 LL | use prelude::*;
    |     ^^^^^^^^^^
    = help: consider adding an explicit import of `date_range` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-panic-globvsglob.rs
+++ b/tests/ui/imports/ambiguous-panic-globvsglob.rs
@@ -3,7 +3,7 @@
 mod m1 {
     pub use core::prelude::v1::*;
 }
-//@ check-pass
+
 mod m2 {
     pub use std::prelude::v1::*;
 }
@@ -18,6 +18,6 @@ fn foo() {
     panic!();
     //~^ WARN: `panic` is ambiguous [ambiguous_panic_imports]
     //~| WARN: this was previously accepted by the compiler
-    //~| WARN: `panic` is ambiguous [ambiguous_glob_imports]
+    //~| ERROR: `panic` is ambiguous [ambiguous_glob_imports]
     //~| WARN: this was previously accepted by the compiler
 }

--- a/tests/ui/imports/ambiguous-panic-globvsglob.stderr
+++ b/tests/ui/imports/ambiguous-panic-globvsglob.stderr
@@ -1,4 +1,4 @@
-warning: `panic` is ambiguous
+error: `panic` is ambiguous
   --> $DIR/ambiguous-panic-globvsglob.rs:18:5
    |
 LL |     panic!();
@@ -19,7 +19,7 @@ note: `panic` could also refer to the macro imported here
 LL |     use m2::*;
    |         ^^^^^
    = help: consider adding an explicit import of `panic` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 warning: `panic` is ambiguous
   --> $DIR/ambiguous-panic-globvsglob.rs:18:5
@@ -40,10 +40,10 @@ note: `panic` could also refer to a macro from prelude
   --> $SRC_DIR/std/src/prelude/mod.rs:LL:COL
    = note: `#[warn(ambiguous_panic_imports)]` (part of `#[warn(future_incompatible)]`) on by default
 
-warning: 2 warnings emitted
+error: aborting due to 1 previous error; 1 warning emitted
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `panic` is ambiguous
+error: `panic` is ambiguous
   --> $DIR/ambiguous-panic-globvsglob.rs:18:5
    |
 LL |     panic!();
@@ -64,5 +64,5 @@ note: `panic` could also refer to the macro imported here
 LL |     use m2::*;
    |         ^^^^^
    = help: consider adding an explicit import of `panic` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/duplicate.rs
+++ b/tests/ui/imports/duplicate.rs
@@ -34,7 +34,7 @@ fn main() {
     e::foo();
     f::foo(); //~ ERROR `foo` is ambiguous
     g::foo();
-    //~^ WARN `foo` is ambiguous
+    //~^ ERROR `foo` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }
 

--- a/tests/ui/imports/duplicate.stderr
+++ b/tests/ui/imports/duplicate.stderr
@@ -68,7 +68,7 @@ LL |     use self::m2::*;
    |         ^^^^^^^^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
 
-warning: `foo` is ambiguous
+error: `foo` is ambiguous
   --> $DIR/duplicate.rs:36:8
    |
 LL |     g::foo();
@@ -89,14 +89,14 @@ note: `foo` could also refer to the function imported here
 LL |     pub use crate::f::*;
    |             ^^^^^^^^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-error: aborting due to 4 previous errors; 1 warning emitted
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0252, E0659.
 For more information about an error, try `rustc --explain E0252`.
 Future incompatibility report: Future breakage diagnostic:
-warning: `foo` is ambiguous
+error: `foo` is ambiguous
   --> $DIR/duplicate.rs:36:8
    |
 LL |     g::foo();
@@ -117,5 +117,5 @@ note: `foo` could also refer to the function imported here
 LL |     pub use crate::f::*;
    |             ^^^^^^^^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/glob-conflict-cross-crate-1.rs
+++ b/tests/ui/imports/glob-conflict-cross-crate-1.rs
@@ -1,11 +1,11 @@
 //@ edition:2015
 //@ aux-build:glob-conflict.rs
-//@ check-pass
+
 extern crate glob_conflict;
 
 fn main() {
-    glob_conflict::f(); //~ WARN `f` is ambiguous
+    glob_conflict::f(); //~ ERROR `f` is ambiguous
                         //~| WARN this was previously accepted
-    glob_conflict::glob::f(); //~ WARN `f` is ambiguous
+    glob_conflict::glob::f(); //~ ERROR `f` is ambiguous
                               //~| WARN this was previously accepted
 }

--- a/tests/ui/imports/glob-conflict-cross-crate-1.stderr
+++ b/tests/ui/imports/glob-conflict-cross-crate-1.stderr
@@ -1,4 +1,4 @@
-warning: `f` is ambiguous
+error: `f` is ambiguous
   --> $DIR/glob-conflict-cross-crate-1.rs:7:20
    |
 LL |     glob_conflict::f();
@@ -19,9 +19,9 @@ note: `f` could also refer to the function defined here
    |
 LL | pub use m2::*;
    |         ^^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: `f` is ambiguous
+error: `f` is ambiguous
   --> $DIR/glob-conflict-cross-crate-1.rs:9:26
    |
 LL |     glob_conflict::glob::f();
@@ -43,10 +43,10 @@ note: `f` could also refer to the function defined here
 LL | pub use m2::*;
    |         ^^
 
-warning: 2 warnings emitted
+error: aborting due to 2 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `f` is ambiguous
+error: `f` is ambiguous
   --> $DIR/glob-conflict-cross-crate-1.rs:7:20
    |
 LL |     glob_conflict::f();
@@ -67,10 +67,10 @@ note: `f` could also refer to the function defined here
    |
 LL | pub use m2::*;
    |         ^^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
-warning: `f` is ambiguous
+error: `f` is ambiguous
   --> $DIR/glob-conflict-cross-crate-1.rs:9:26
    |
 LL |     glob_conflict::glob::f();
@@ -91,5 +91,5 @@ note: `f` could also refer to the function defined here
    |
 LL | pub use m2::*;
    |         ^^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/glob-conflict-cross-crate-2.rs
+++ b/tests/ui/imports/glob-conflict-cross-crate-2.rs
@@ -1,10 +1,10 @@
 //@ aux-build:glob-conflict-cross-crate-2-extern.rs
-//@ check-pass
+
 extern crate glob_conflict_cross_crate_2_extern;
 
 use glob_conflict_cross_crate_2_extern::*;
 
 fn main() {
-    let _a: C = 1; //~ WARN `C` is ambiguous
+    let _a: C = 1; //~ ERROR `C` is ambiguous
                    //~| WARN this was previously accepted
 }

--- a/tests/ui/imports/glob-conflict-cross-crate-2.stderr
+++ b/tests/ui/imports/glob-conflict-cross-crate-2.stderr
@@ -1,4 +1,4 @@
-warning: `C` is ambiguous
+error: `C` is ambiguous
   --> $DIR/glob-conflict-cross-crate-2.rs:8:13
    |
 LL |     let _a: C = 1;
@@ -19,12 +19,12 @@ note: `C` could also refer to the type alias defined here
    |
 LL | pub use b::*;
    |         ^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `C` is ambiguous
+error: `C` is ambiguous
   --> $DIR/glob-conflict-cross-crate-2.rs:8:13
    |
 LL |     let _a: C = 1;
@@ -45,5 +45,5 @@ note: `C` could also refer to the type alias defined here
    |
 LL | pub use b::*;
    |         ^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/glob-conflict-cross-crate-3.rs
+++ b/tests/ui/imports/glob-conflict-cross-crate-3.rs
@@ -1,5 +1,5 @@
 //@ aux-build:glob-conflict-cross-crate-2-extern.rs
-//@ check-pass
+
 extern crate glob_conflict_cross_crate_2_extern;
 
 mod a {
@@ -11,8 +11,8 @@ use a::*;
 
 fn main() {
     let _a: C = 1;
-    //~^ WARN `C` is ambiguous
-    //~| WARN `C` is ambiguous
+    //~^ ERROR `C` is ambiguous
+    //~| ERROR `C` is ambiguous
     //~| WARN this was previously accepted
     //~| WARN this was previously accepted
 }

--- a/tests/ui/imports/glob-conflict-cross-crate-3.stderr
+++ b/tests/ui/imports/glob-conflict-cross-crate-3.stderr
@@ -1,4 +1,4 @@
-warning: `C` is ambiguous
+error: `C` is ambiguous
   --> $DIR/glob-conflict-cross-crate-3.rs:13:13
    |
 LL |     let _a: C = 1;
@@ -19,9 +19,9 @@ note: `C` could also refer to the type alias defined here
    |
 LL | pub use b::*;
    |         ^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: `C` is ambiguous
+error: `C` is ambiguous
   --> $DIR/glob-conflict-cross-crate-3.rs:13:13
    |
 LL |     let _a: C = 1;
@@ -43,10 +43,10 @@ LL | use a::*;
    |     ^^^^
    = help: consider adding an explicit import of `C` to disambiguate
 
-warning: 2 warnings emitted
+error: aborting due to 2 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `C` is ambiguous
+error: `C` is ambiguous
   --> $DIR/glob-conflict-cross-crate-3.rs:13:13
    |
 LL |     let _a: C = 1;
@@ -67,10 +67,10 @@ note: `C` could also refer to the type alias defined here
    |
 LL | pub use b::*;
    |         ^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
-warning: `C` is ambiguous
+error: `C` is ambiguous
   --> $DIR/glob-conflict-cross-crate-3.rs:13:13
    |
 LL |     let _a: C = 1;
@@ -91,5 +91,5 @@ note: `C` could also refer to the type alias imported here
 LL | use a::*;
    |     ^^^^
    = help: consider adding an explicit import of `C` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/issue-114682-2.rs
+++ b/tests/ui/imports/issue-114682-2.rs
@@ -1,12 +1,12 @@
 //@ aux-build: issue-114682-2-extern.rs
 // https://github.com/rust-lang/rust/pull/114682#issuecomment-1879998900
-//@ check-pass
+
 extern crate issue_114682_2_extern;
 
-use issue_114682_2_extern::max; //~ WARN `max` is ambiguous
+use issue_114682_2_extern::max; //~ ERROR `max` is ambiguous
                                 //~| WARN this was previously accepted
 
-type A = issue_114682_2_extern::max; //~ WARN `max` is ambiguous
+type A = issue_114682_2_extern::max; //~ ERROR `max` is ambiguous
                                      //~| WARN this was previously accepted
 
 fn main() {}

--- a/tests/ui/imports/issue-114682-2.stderr
+++ b/tests/ui/imports/issue-114682-2.stderr
@@ -1,4 +1,4 @@
-warning: `max` is ambiguous
+error: `max` is ambiguous
   --> $DIR/issue-114682-2.rs:6:28
    |
 LL | use issue_114682_2_extern::max;
@@ -19,9 +19,9 @@ note: `max` could also refer to the module defined here
    |
 LL | pub use self::d::*;
    |         ^^^^^^^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: `max` is ambiguous
+error: `max` is ambiguous
   --> $DIR/issue-114682-2.rs:9:33
    |
 LL | type A = issue_114682_2_extern::max;
@@ -43,10 +43,10 @@ note: `max` could also refer to the module defined here
 LL | pub use self::d::*;
    |         ^^^^^^^
 
-warning: 2 warnings emitted
+error: aborting due to 2 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `max` is ambiguous
+error: `max` is ambiguous
   --> $DIR/issue-114682-2.rs:6:28
    |
 LL | use issue_114682_2_extern::max;
@@ -67,10 +67,10 @@ note: `max` could also refer to the module defined here
    |
 LL | pub use self::d::*;
    |         ^^^^^^^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
-warning: `max` is ambiguous
+error: `max` is ambiguous
   --> $DIR/issue-114682-2.rs:9:33
    |
 LL | type A = issue_114682_2_extern::max;
@@ -91,5 +91,5 @@ note: `max` could also refer to the module defined here
    |
 LL | pub use self::d::*;
    |         ^^^^^^^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/issue-114682-4.rs
+++ b/tests/ui/imports/issue-114682-4.rs
@@ -6,7 +6,7 @@ extern crate issue_114682_4_extern;
 use issue_114682_4_extern::*;
 
 //~v ERROR type alias takes 1 generic argument but 2 generic arguments were supplied
-fn a() -> Result<i32, ()> { //~ WARN `Result` is ambiguous
+fn a() -> Result<i32, ()> { //~ ERROR `Result` is ambiguous
                             //~| WARN this was previously accepted
     Ok(1)
 }

--- a/tests/ui/imports/issue-114682-4.stderr
+++ b/tests/ui/imports/issue-114682-4.stderr
@@ -1,4 +1,4 @@
-warning: `Result` is ambiguous
+error: `Result` is ambiguous
   --> $DIR/issue-114682-4.rs:9:11
    |
 LL | fn a() -> Result<i32, ()> {
@@ -19,7 +19,7 @@ note: `Result` could also refer to the type alias defined here
    |
 LL | pub use b::*;
    |         ^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error[E0107]: type alias takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/issue-114682-4.rs:9:11
@@ -35,11 +35,11 @@ note: type alias defined here, with 1 generic parameter: `T`
 LL |     pub type Result<T> = std::result::Result<T, ()>;
    |              ^^^^^^ -
 
-error: aborting due to 1 previous error; 1 warning emitted
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0107`.
 Future incompatibility report: Future breakage diagnostic:
-warning: `Result` is ambiguous
+error: `Result` is ambiguous
   --> $DIR/issue-114682-4.rs:9:11
    |
 LL | fn a() -> Result<i32, ()> {
@@ -60,5 +60,5 @@ note: `Result` could also refer to the type alias defined here
    |
 LL | pub use b::*;
    |         ^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/issue-114682-5.rs
+++ b/tests/ui/imports/issue-114682-5.rs
@@ -9,7 +9,7 @@ extern crate issue_114682_5_extern_2;
 use issue_114682_5_extern_2::p::*;
 use issue_114682_5_extern_1::Url;
 //~^ ERROR `issue_114682_5_extern_1` is ambiguous
-//~| WARN `issue_114682_5_extern_1` is ambiguous
+//~| ERROR `issue_114682_5_extern_1` is ambiguous
 //~| ERROR unresolved import `issue_114682_5_extern_1::Url`
 //~| WARN this was previously accepted
 

--- a/tests/ui/imports/issue-114682-5.stderr
+++ b/tests/ui/imports/issue-114682-5.stderr
@@ -26,7 +26,7 @@ LL | use issue_114682_5_extern_2::p::*;
    = help: consider adding an explicit import of `issue_114682_5_extern_1` to disambiguate
    = help: or use `crate::issue_114682_5_extern_1` to refer to this module unambiguously
 
-warning: `issue_114682_5_extern_1` is ambiguous
+error: `issue_114682_5_extern_1` is ambiguous
   --> $DIR/issue-114682-5.rs:10:5
    |
 LL | use issue_114682_5_extern_1::Url;
@@ -48,14 +48,14 @@ note: `issue_114682_5_extern_1` could also refer to the crate defined here
 LL |     pub use crate::*;
    |             ^^^^^
    = help: use `::issue_114682_5_extern_1` to refer to this crate unambiguously
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0432, E0659.
 For more information about an error, try `rustc --explain E0432`.
 Future incompatibility report: Future breakage diagnostic:
-warning: `issue_114682_5_extern_1` is ambiguous
+error: `issue_114682_5_extern_1` is ambiguous
   --> $DIR/issue-114682-5.rs:10:5
    |
 LL | use issue_114682_5_extern_1::Url;
@@ -77,5 +77,5 @@ note: `issue_114682_5_extern_1` could also refer to the crate defined here
 LL |     pub use crate::*;
    |             ^^^^^
    = help: use `::issue_114682_5_extern_1` to refer to this crate unambiguously
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/issue-114682-6.rs
+++ b/tests/ui/imports/issue-114682-6.rs
@@ -1,12 +1,12 @@
 //@ aux-build: issue-114682-6-extern.rs
 // https://github.com/rust-lang/rust/pull/114682#issuecomment-1880755441
-//@ check-pass
+
 extern crate issue_114682_6_extern;
 
 use issue_114682_6_extern::*;
 
 fn main() {
-    let log = 2; //~ WARN `log` is ambiguous
+    let log = 2; //~ ERROR `log` is ambiguous
                  //~| WARN this was previously accepted
     let _ = log;
 }

--- a/tests/ui/imports/issue-114682-6.stderr
+++ b/tests/ui/imports/issue-114682-6.stderr
@@ -1,4 +1,4 @@
-warning: `log` is ambiguous
+error: `log` is ambiguous
   --> $DIR/issue-114682-6.rs:9:9
    |
 LL |     let log = 2;
@@ -19,12 +19,12 @@ note: `log` could also refer to the function defined here
    |
 LL | pub use self::b::*;
    |         ^^^^^^^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `log` is ambiguous
+error: `log` is ambiguous
   --> $DIR/issue-114682-6.rs:9:9
    |
 LL |     let log = 2;
@@ -45,5 +45,5 @@ note: `log` could also refer to the function defined here
    |
 LL | pub use self::b::*;
    |         ^^^^^^^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/overwrite-different-ambig-2.rs
+++ b/tests/ui/imports/overwrite-different-ambig-2.rs
@@ -1,5 +1,3 @@
-//@ check-pass
-
 mod m1 {
     mod inner {
         pub struct S {}
@@ -21,6 +19,6 @@ use m1::*;
 use m2::*;
 
 fn main() {
-    let _: m1::S = S {}; //~ WARN `S` is ambiguous
+    let _: m1::S = S {}; //~ ERROR `S` is ambiguous
                          //~| WARN this was previously accepted
 }

--- a/tests/ui/imports/overwrite-different-ambig-2.stderr
+++ b/tests/ui/imports/overwrite-different-ambig-2.stderr
@@ -1,5 +1,5 @@
-warning: `S` is ambiguous
-  --> $DIR/overwrite-different-ambig-2.rs:24:20
+error: `S` is ambiguous
+  --> $DIR/overwrite-different-ambig-2.rs:22:20
    |
 LL |     let _: m1::S = S {};
    |                    ^ ambiguous name
@@ -8,24 +8,24 @@ LL |     let _: m1::S = S {};
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `S` could refer to the struct imported here
-  --> $DIR/overwrite-different-ambig-2.rs:20:5
+  --> $DIR/overwrite-different-ambig-2.rs:18:5
    |
 LL | use m1::*;
    |     ^^^^^
    = help: consider adding an explicit import of `S` to disambiguate
 note: `S` could also refer to the struct imported here
-  --> $DIR/overwrite-different-ambig-2.rs:21:5
+  --> $DIR/overwrite-different-ambig-2.rs:19:5
    |
 LL | use m2::*;
    |     ^^^^^
    = help: consider adding an explicit import of `S` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `S` is ambiguous
-  --> $DIR/overwrite-different-ambig-2.rs:24:20
+error: `S` is ambiguous
+  --> $DIR/overwrite-different-ambig-2.rs:22:20
    |
 LL |     let _: m1::S = S {};
    |                    ^ ambiguous name
@@ -34,16 +34,16 @@ LL |     let _: m1::S = S {};
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `S` could refer to the struct imported here
-  --> $DIR/overwrite-different-ambig-2.rs:20:5
+  --> $DIR/overwrite-different-ambig-2.rs:18:5
    |
 LL | use m1::*;
    |     ^^^^^
    = help: consider adding an explicit import of `S` to disambiguate
 note: `S` could also refer to the struct imported here
-  --> $DIR/overwrite-different-ambig-2.rs:21:5
+  --> $DIR/overwrite-different-ambig-2.rs:19:5
    |
 LL | use m2::*;
    |     ^^^^^
    = help: consider adding an explicit import of `S` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/unresolved-seg-after-ambiguous.rs
+++ b/tests/ui/imports/unresolved-seg-after-ambiguous.rs
@@ -18,7 +18,7 @@ mod a {
 
 use self::a::E::in_exist;
 //~^ ERROR: unresolved import `self::a::E`
-//~| WARN: `E` is ambiguous
+//~| ERROR: `E` is ambiguous
 //~| WARNING: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 fn main() {}

--- a/tests/ui/imports/unresolved-seg-after-ambiguous.stderr
+++ b/tests/ui/imports/unresolved-seg-after-ambiguous.stderr
@@ -4,7 +4,7 @@ error[E0432]: unresolved import `self::a::E`
 LL | use self::a::E::in_exist;
    |              ^ `E` is a struct, not a module
 
-warning: `E` is ambiguous
+error: `E` is ambiguous
   --> $DIR/unresolved-seg-after-ambiguous.rs:19:14
    |
 LL | use self::a::E::in_exist;
@@ -25,13 +25,13 @@ note: `E` could also refer to the struct imported here
 LL |         pub use self::d::*;
    |                 ^^^^^^^^^^
    = help: consider adding an explicit import of `E` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-error: aborting due to 1 previous error; 1 warning emitted
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0432`.
 Future incompatibility report: Future breakage diagnostic:
-warning: `E` is ambiguous
+error: `E` is ambiguous
   --> $DIR/unresolved-seg-after-ambiguous.rs:19:14
    |
 LL | use self::a::E::in_exist;
@@ -52,5 +52,5 @@ note: `E` could also refer to the struct imported here
 LL |         pub use self::d::*;
    |                 ^^^^^^^^^^
    = help: consider adding an explicit import of `E` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 


### PR DESCRIPTION
This reverts commit cd05071ec4a4b62d469603fb7b89d0a35857cbe1.

Revert of https://github.com/rust-lang/rust/pull/151130.
This will need to be merged after ~February 27 2026, when Rust 1.95 branches out from the main branch.