### PR TITLE
Port #[prelude_import] to the attribute parser

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -1211,3 +1211,12 @@ impl<S: Stage> SingleAttributeParser<S> for RustcReservationImplParser {
         Some(AttributeKind::RustcReservationImpl(cx.attr_span, value_str))
     }
 }
+
+pub(crate) struct PreludeImportParser;
+
+impl<S: Stage> NoArgsAttributeParser<S> for PreludeImportParser {
+    const PATH: &[Symbol] = &[sym::prelude_import];
+    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
+    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Use)]);
+    const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::PreludeImport;
+}

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -258,6 +258,7 @@ attribute_parsers!(
         Single<WithoutArgs<PassByValueParser>>,
         Single<WithoutArgs<PinV2Parser>>,
         Single<WithoutArgs<PointeeParser>>,
+        Single<WithoutArgs<PreludeImportParser>>,
         Single<WithoutArgs<ProcMacroAttributeParser>>,
         Single<WithoutArgs<ProcMacroParser>>,
         Single<WithoutArgs<ProfilerRuntimeParser>>,

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -1053,6 +1053,9 @@ pub enum AttributeKind {
     /// Represents `#[pointee]`
     Pointee(Span),
 
+    /// Represents `#[prelude_import]`
+    PreludeImport,
+
     /// Represents `#[proc_macro]`
     ProcMacro(Span),
 

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -82,6 +82,7 @@ impl AttributeKind {
             PatternComplexityLimit { .. } => No,
             PinV2(..) => Yes,
             Pointee(..) => No,
+            PreludeImport => No,
             ProcMacro(..) => No,
             ProcMacroAttribute(..) => No,
             ProcMacroDerive { .. } => No,

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -282,6 +282,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     | AttributeKind::PatternComplexityLimit { .. }
                     | AttributeKind::PinV2(..)
                     | AttributeKind::Pointee(..)
+                    | AttributeKind::PreludeImport
                     | AttributeKind::ProfilerRuntime
                     | AttributeKind::RecursionLimit { .. }
                     | AttributeKind::ReexportTestHarnessMain(..)
@@ -394,7 +395,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                             // need to be fixed
                             | sym::deprecated_safe // FIXME(deprecated_safe)
                             // internal
-                            | sym::prelude_import
                             | sym::panic_handler
                             | sym::lang
                             | sym::default_lib_allocator

--- a/tests/pretty/delegation-inherit-attributes.pp
+++ b/tests/pretty/delegation-inherit-attributes.pp
@@ -7,7 +7,7 @@
 #![allow(incomplete_features)]
 #![feature(fn_delegation)]
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use std::prelude::rust_2021::*;
 
 extern crate to_reuse_functions;

--- a/tests/pretty/delegation-inline-attribute.pp
+++ b/tests/pretty/delegation-inline-attribute.pp
@@ -5,7 +5,7 @@
 #![allow(incomplete_features)]
 #![feature(fn_delegation)]
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;
 
 mod to_reuse {

--- a/tests/pretty/hir-delegation.pp
+++ b/tests/pretty/hir-delegation.pp
@@ -5,7 +5,7 @@
 #![allow(incomplete_features)]
 #![feature(fn_delegation)]
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;
 
 fn b<C>(e: C) { }

--- a/tests/pretty/hir-fn-params.pp
+++ b/tests/pretty/hir-fn-params.pp
@@ -1,5 +1,5 @@
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:hir

--- a/tests/pretty/hir-fn-variadic.pp
+++ b/tests/pretty/hir-fn-variadic.pp
@@ -4,7 +4,7 @@
 
 #![feature(c_variadic)]
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;
 
 extern "C" {

--- a/tests/pretty/hir-if-else.pp
+++ b/tests/pretty/hir-if-else.pp
@@ -1,5 +1,5 @@
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:hir

--- a/tests/pretty/hir-lifetimes.pp
+++ b/tests/pretty/hir-lifetimes.pp
@@ -6,7 +6,7 @@
 
 #![allow(unused)]
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;
 
 struct Foo<'a> {

--- a/tests/pretty/hir-pretty-attr.pp
+++ b/tests/pretty/hir-pretty-attr.pp
@@ -1,5 +1,5 @@
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:hir

--- a/tests/pretty/hir-pretty-loop.pp
+++ b/tests/pretty/hir-pretty-loop.pp
@@ -1,5 +1,5 @@
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:hir

--- a/tests/pretty/hir-struct-expr.pp
+++ b/tests/pretty/hir-struct-expr.pp
@@ -1,5 +1,5 @@
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:hir

--- a/tests/pretty/issue-4264.pp
+++ b/tests/pretty/issue-4264.pp
@@ -1,5 +1,5 @@
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:hir,typed

--- a/tests/pretty/issue-85089.pp
+++ b/tests/pretty/issue-85089.pp
@@ -1,5 +1,5 @@
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;
 // Test to print lifetimes on HIR pretty-printing.
 

--- a/tests/pretty/pin-ergonomics-hir.pp
+++ b/tests/pretty/pin-ergonomics-hir.pp
@@ -5,7 +5,7 @@
 #![feature(pin_ergonomics)]
 #![allow(dead_code, incomplete_features)]
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;
 
 use std::pin::Pin;

--- a/tests/ui/consts/const-block-items/hir.stdout
+++ b/tests/ui/consts/const-block-items/hir.stdout
@@ -3,7 +3,7 @@
 
 #![feature(const_block_items)]
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;
 
 const _: () =

--- a/tests/ui/macros/genercs-in-path-with-prettry-hir.stdout
+++ b/tests/ui/macros/genercs-in-path-with-prettry-hir.stdout
@@ -1,5 +1,5 @@
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;
 //@ compile-flags: -Zunpretty=hir
 //@ edition: 2015

--- a/tests/ui/match/issue-82392.stdout
+++ b/tests/ui/match/issue-82392.stdout
@@ -1,5 +1,5 @@
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;
 // https://github.com/rust-lang/rust/issues/82329
 //@ compile-flags: -Zunpretty=hir,typed

--- a/tests/ui/type-alias-impl-trait/issue-60662.stdout
+++ b/tests/ui/type-alias-impl-trait/issue-60662.stdout
@@ -4,7 +4,7 @@
 
 #![feature(type_alias_impl_trait)]
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;
 
 trait Animal { }

--- a/tests/ui/unpretty/bad-literal.stdout
+++ b/tests/ui/unpretty/bad-literal.stdout
@@ -1,5 +1,5 @@
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;
 //@ compile-flags: -Zunpretty=hir
 //@ check-fail

--- a/tests/ui/unpretty/debug-fmt-hir.stdout
+++ b/tests/ui/unpretty/debug-fmt-hir.stdout
@@ -1,5 +1,5 @@
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass

--- a/tests/ui/unpretty/deprecated-attr.stdout
+++ b/tests/ui/unpretty/deprecated-attr.stdout
@@ -1,5 +1,5 @@
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass

--- a/tests/ui/unpretty/diagnostic-attr.stdout
+++ b/tests/ui/unpretty/diagnostic-attr.stdout
@@ -1,5 +1,5 @@
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass

--- a/tests/ui/unpretty/exhaustive-asm.hir.stdout
+++ b/tests/ui/unpretty/exhaustive-asm.hir.stdout
@@ -1,5 +1,5 @@
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use std::prelude::rust_2024::*;
 //@ revisions: expanded hir
 //@[expanded]compile-flags: -Zunpretty=expanded

--- a/tests/ui/unpretty/exhaustive.hir.stdout
+++ b/tests/ui/unpretty/exhaustive.hir.stdout
@@ -31,7 +31,7 @@
 #![feature(yeet_expr)]
 #![allow(incomplete_features)]
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use std::prelude::rust_2024::*;
 
 mod prelude {
@@ -46,7 +46,7 @@ mod prelude {
     }
 }
 
-#[prelude_import]
+#[attr = PreludeImport]
 use self::prelude::*;
 
 /// inner single-line doc comment

--- a/tests/ui/unpretty/flattened-format-args.stdout
+++ b/tests/ui/unpretty/flattened-format-args.stdout
@@ -1,5 +1,5 @@
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;
 //@ compile-flags: -Zunpretty=hir -Zflatten-format-args=yes
 //@ check-pass

--- a/tests/ui/unpretty/let-else-hir.stdout
+++ b/tests/ui/unpretty/let-else-hir.stdout
@@ -1,5 +1,5 @@
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass

--- a/tests/ui/unpretty/self-hir.stdout
+++ b/tests/ui/unpretty/self-hir.stdout
@@ -1,5 +1,5 @@
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass

--- a/tests/ui/unpretty/struct-exprs-tuple-call-pretty-printing.stdout
+++ b/tests/ui/unpretty/struct-exprs-tuple-call-pretty-printing.stdout
@@ -5,7 +5,7 @@
 #![expect(incomplete_features)]
 #![allow(dead_code)]
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;
 
 use std::marker::ConstParamTy;

--- a/tests/ui/unpretty/unpretty-expr-fn-arg.stdout
+++ b/tests/ui/unpretty/unpretty-expr-fn-arg.stdout
@@ -9,7 +9,7 @@
 //@ edition: 2015
 #![allow(dead_code)]
 extern crate std;
-#[prelude_import]
+#[attr = PreludeImport]
 use ::std::prelude::rust_2015::*;
 
 fn main() ({ } as ())


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/131229

r? @JonathanBrouwer 

Didn't change any use-sites of it in the compiler
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
