### PR TITLE
Add 2048-bit HvxVectorPair support to Hexagon SIMD ABI checks

### DIFF
--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -984,8 +984,11 @@ const RISCV_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'stat
 const SPARC_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
     &[/*(64, "vis")*/];
 
-const HEXAGON_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
-    &[(512, "hvx-length64b"), (1024, "hvx-length128b")];
+const HEXAGON_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] = &[
+    (512, "hvx-length64b"),   // HvxVector in 64-byte mode
+    (1024, "hvx-length128b"), // HvxVector in 128-byte mode, or HvxVectorPair in 64-byte mode
+    (2048, "hvx-length128b"), // HvxVectorPair in 128-byte mode
+];
 const MIPS_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
     &[(128, "msa")];
 const CSKY_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =


### PR DESCRIPTION
Previously, rustc rejected HvxVectorPair types in function signatures because the HEXAGON_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI array only had entries for vectors up to 1024 bits. This caused the ABI checker to emit "unsupported vector type" errors for 2048-bit HvxVectorPair (used in 128-byte HVX mode).

Add 2048 byte entry to allow HvxVectorPair to be passed in extern "C" funcs when the hvx-length128b is enabled.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
