### PR TITLE
Port `#[rustc_diagnostic_item]` to the new attribute parsers

### DIFF
--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -203,6 +203,7 @@ attribute_parsers!(
         Single<RustcBuiltinMacroParser>,
         Single<RustcDefPath>,
         Single<RustcDeprecatedSafe2024Parser>,
+        Single<RustcDiagnosticItemParser>,
         Single<RustcForceInlineParser>,
         Single<RustcIfThisChangedParser>,
         Single<RustcLayoutScalarValidRangeEndParser>,

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -919,7 +919,7 @@ impl SyntaxExtension {
     fn get_hide_backtrace(attrs: &[hir::Attribute]) -> bool {
         // FIXME(estebank): instead of reusing `#[rustc_diagnostic_item]` as a proxy, introduce a
         // new attribute purely for this under the `#[diagnostic]` namespace.
-        ast::attr::find_by_name(attrs, sym::rustc_diagnostic_item).is_some()
+        find_attr!(attrs, AttributeKind::RustcDiagnosticItem(..))
     }
 
     /// Constructs a syntax extension with the given properties

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -1153,6 +1153,9 @@ pub enum AttributeKind {
     /// Represents `#[rustc_deprecated_safe_2024]`
     RustcDeprecatedSafe2024 { suggestion: Symbol },
 
+    /// Represents `#[rustc_diagnostic_item]`
+    RustcDiagnosticItem(Symbol),
+
     /// Represents `#[rustc_dummy]`.
     RustcDummy,
 

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -112,6 +112,7 @@ impl AttributeKind {
             RustcDelayedBugFromInsideQuery => No,
             RustcDenyExplicitImpl(..) => No,
             RustcDeprecatedSafe2024 { .. } => Yes,
+            RustcDiagnosticItem(..) => Yes,
             RustcDummy => No,
             RustcDumpDefParents => No,
             RustcDumpItemBounds => No,

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -307,6 +307,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     | AttributeKind::RustcDelayedBugFromInsideQuery
                     | AttributeKind::RustcDenyExplicitImpl(..)
                     | AttributeKind::RustcDeprecatedSafe2024 {..}
+                    | AttributeKind::RustcDiagnosticItem(..)
                     | AttributeKind::RustcDummy
                     | AttributeKind::RustcDumpDefParents
                     | AttributeKind::RustcDumpItemBounds
@@ -398,7 +399,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                             | sym::panic_handler
                             | sym::lang
                             | sym::default_lib_allocator
-                            | sym::rustc_diagnostic_item
                             | sym::rustc_nonnull_optimization_guaranteed
                             | sym::rustc_inherit_overflow_checks
                             | sym::rustc_on_unimplemented

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1425,14 +1425,12 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         // a note about editions
                         let note = if let Some(did) = did {
                             let requires_note = !did.is_local()
-                                && this.tcx.get_attrs(did, sym::rustc_diagnostic_item).any(
-                                    |attr| {
-                                        [sym::TryInto, sym::TryFrom, sym::FromIterator]
-                                            .map(|x| Some(x))
-                                            .contains(&attr.value_str())
-                                    },
+                                && find_attr!(
+                                    this.tcx.get_all_attrs(did),
+                                    AttributeKind::RustcDiagnosticItem(
+                                        sym::TryInto | sym::TryFrom | sym::FromIterator
+                                    )
                                 );
-
                             requires_note.then(|| {
                                 format!(
                                     "'{}' is included in the prelude starting in Edition 2021",

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -21,7 +21,7 @@ use rustc_hir::attrs::AttributeKind;
 use rustc_hir::def::Namespace::{self, *};
 use rustc_hir::def::{self, CtorKind, CtorOf, DefKind, MacroKinds};
 use rustc_hir::def_id::{CRATE_DEF_ID, DefId};
-use rustc_hir::{MissingLifetimeKind, PrimTy};
+use rustc_hir::{MissingLifetimeKind, PrimTy, find_attr};
 use rustc_middle::ty;
 use rustc_session::{Session, lint};
 use rustc_span::edit_distance::{edit_distance, find_best_match_for_name};
@@ -2446,10 +2446,10 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
             .iter()
             .filter_map(|candidate| candidate.did)
             .find(|did| {
-                self.r
-                    .tcx
-                    .get_attrs(*did, sym::rustc_diagnostic_item)
-                    .any(|attr| attr.value_str() == Some(sym::Default))
+                find_attr!(
+                    self.r.tcx.get_all_attrs(*did),
+                    AttributeKind::RustcDiagnosticItem(sym::Default)
+                )
             });
         let Some(default_trait) = default_trait else {
             return;


### PR DESCRIPTION
r? @jdonszelmann 