### PR TITLE
rustc_expand: improve diagnostics for non-repeatable metavars in repetition

### DIFF
--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -17,6 +17,59 @@ pub(crate) struct CfgAttrNoAttributes;
 pub(crate) struct NoSyntaxVarsExprRepeat {
     #[primary_span]
     pub span: Span,
+    #[subdiagnostic]
+    pub typo_repeatable: Option<VarTypoSuggestionRepeatable>,
+    #[subdiagnostic]
+    pub typo_unrepeatable: Option<VarTypoSuggestionUnrepeatable>,
+    #[subdiagnostic]
+    pub typo_unrepeatable_label: Option<VarTypoSuggestionUnrepeatableLabel>,
+    #[subdiagnostic]
+    pub var_no_typo: Option<VarNoTypo>,
+    #[subdiagnostic]
+    pub no_repeatable_var: Option<NoRepeatableVar>,
+}
+
+#[derive(Subdiagnostic)]
+#[multipart_suggestion(
+    "there's a macro metavariable with a similar name",
+    applicability = "maybe-incorrect",
+    style = "verbose"
+)]
+pub(crate) struct VarTypoSuggestionRepeatable {
+    #[suggestion_part(code = "{name}")]
+    pub span: Span,
+    pub name: Symbol,
+}
+
+#[derive(Subdiagnostic)]
+#[label("argument not found")]
+pub(crate) struct VarTypoSuggestionUnrepeatable {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Subdiagnostic)]
+#[label("this similarly named macro metavariable is unrepeatable")]
+pub(crate) struct VarTypoSuggestionUnrepeatableLabel {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Subdiagnostic)]
+#[label("expected a repeatable metavariable: {$msg}")]
+pub(crate) struct VarNoTypo {
+    #[primary_span]
+    pub span: Span,
+    pub msg: String,
+}
+
+#[derive(Subdiagnostic)]
+#[label(
+    "this macro metavariable is not repeatable and there are no other repeatable metavariables"
+)]
+pub(crate) struct NoRepeatableVar {
+    #[primary_span]
+    pub span: Span,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_expand/src/mbe/macro_parser.rs
+++ b/compiler/rustc_expand/src/mbe/macro_parser.rs
@@ -388,6 +388,15 @@ pub(crate) enum NamedMatch {
     MatchedSingle(ParseNtResult),
 }
 
+impl NamedMatch {
+    pub(super) fn is_repeatable(&self) -> bool {
+        match self {
+            NamedMatch::MatchedSeq(_) => true,
+            NamedMatch::MatchedSingle(_) => false,
+        }
+    }
+}
+
 /// Performs a token equality check, ignoring syntax context (that is, an unhygienic comparison)
 fn token_name_eq(t1: &Token, t2: &Token) -> bool {
     if let (Some((ident1, is_raw1)), Some((ident2, is_raw2))) = (t1.ident(), t2.ident()) {

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2778,6 +2778,14 @@ impl MacroRulesNormalizedIdent {
     pub fn new(ident: Ident) -> Self {
         MacroRulesNormalizedIdent(ident.normalize_to_macro_rules())
     }
+
+    pub fn symbol(&self) -> Symbol {
+        self.0.name
+    }
+
+    pub fn ident(&self) -> Ident {
+        self.0
+    }
 }
 
 impl fmt::Debug for MacroRulesNormalizedIdent {

--- a/tests/ui/macros/typo-in-repeat-expr-2.rs
+++ b/tests/ui/macros/typo-in-repeat-expr-2.rs
@@ -1,0 +1,27 @@
+macro_rules! mn {
+    (begin $($arg:ident),* end) => {
+        [$($typo),*] //~ ERROR attempted to repeat an expression containing no syntax variables matched as repeating at this depth
+        //~^ NOTE expected a repeatable metavariable: `$arg`
+    };
+}
+
+macro_rules! mnr {
+    (begin $arg:ident end) => { //~ NOTE this similarly named macro metavariable is unrepeatable
+        [$($ard),*] //~ ERROR attempted to repeat an expression containing no syntax variables matched as repeating at this depth
+        //~^ NOTE: argument not found
+    };
+}
+
+macro_rules! err {
+    (begin $arg:ident end) => {
+        [$($typo),*] //~ ERROR attempted to repeat an expression containing no syntax variables matched as repeating at this depth
+        //~^ NOTE this macro metavariable is not repeatable and there are no other repeatable metavariables
+    };
+}
+
+fn main() {
+    let x = 1;
+    let _ = mn![begin x end];
+    let _ = mnr![begin x end];
+    let _ = err![begin x  end];
+}

--- a/tests/ui/macros/typo-in-repeat-expr-2.stderr
+++ b/tests/ui/macros/typo-in-repeat-expr-2.stderr
@@ -1,0 +1,28 @@
+error: attempted to repeat an expression containing no syntax variables matched as repeating at this depth
+  --> $DIR/typo-in-repeat-expr-2.rs:3:11
+   |
+LL |         [$($typo),*]
+   |           ^^----^
+   |             |
+   |             expected a repeatable metavariable: `$arg`
+
+error: attempted to repeat an expression containing no syntax variables matched as repeating at this depth
+  --> $DIR/typo-in-repeat-expr-2.rs:10:11
+   |
+LL |     (begin $arg:ident end) => {
+   |             --- this similarly named macro metavariable is unrepeatable
+LL |         [$($ard),*]
+   |           ^^---^
+   |             |
+   |             argument not found
+
+error: attempted to repeat an expression containing no syntax variables matched as repeating at this depth
+  --> $DIR/typo-in-repeat-expr-2.rs:17:11
+   |
+LL |         [$($typo),*]
+   |           ^^----^
+   |             |
+   |             this macro metavariable is not repeatable and there are no other repeatable metavariables
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/macros/typo-in-repeat-expr.fixed
+++ b/tests/ui/macros/typo-in-repeat-expr.fixed
@@ -1,0 +1,12 @@
+//@ run-rustfix
+macro_rules! m {
+    (begin $($ard:ident),* end) => {
+        [$($ard),*] //~ ERROR attempted to repeat an expression containing no syntax variables matched as repeating at this depth
+        //~^ HELP there's a macro metavariable with a similar name
+    };
+}
+
+fn main() {
+    let x = 1;
+    let _ = m![begin x end];
+}

--- a/tests/ui/macros/typo-in-repeat-expr.rs
+++ b/tests/ui/macros/typo-in-repeat-expr.rs
@@ -1,0 +1,12 @@
+//@ run-rustfix
+macro_rules! m {
+    (begin $($ard:ident),* end) => {
+        [$($arg),*] //~ ERROR attempted to repeat an expression containing no syntax variables matched as repeating at this depth
+        //~^ HELP there's a macro metavariable with a similar name
+    };
+}
+
+fn main() {
+    let x = 1;
+    let _ = m![begin x end];
+}

--- a/tests/ui/macros/typo-in-repeat-expr.stderr
+++ b/tests/ui/macros/typo-in-repeat-expr.stderr
@@ -1,0 +1,14 @@
+error: attempted to repeat an expression containing no syntax variables matched as repeating at this depth
+  --> $DIR/typo-in-repeat-expr.rs:4:11
+   |
+LL |         [$($arg),*]
+   |           ^^^^^^
+   |
+help: there's a macro metavariable with a similar name
+   |
+LL -         [$($arg),*]
+LL +         [$($ard),*]
+   |
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Enhance `NoSyntaxVarsExprRepeat` by suggesting similarly named metavariables, distinguishing repeatable vs non-repeatable bindings, and listing available repeatable variables when no match exists.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
