### PR TITLE
Port `#[lang]` and `#[panic_handler]` to the new attribute parsers

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -668,6 +668,15 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcHasIncoherentInherentImplsParse
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcHasIncoherentInherentImpls;
 }
 
+pub(crate) struct PanicHandlerParser;
+
+impl<S: Stage> NoArgsAttributeParser<S> for PanicHandlerParser {
+    const PATH: &[Symbol] = &[sym::panic_handler];
+    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
+    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS); // Targets are checked per lang item in `rustc_passes`
+    const CREATE: fn(Span) -> AttributeKind = |span| AttributeKind::Lang(LangItem::PanicImpl, span);
+}
+
 pub(crate) struct RustcHiddenTypeOfOpaquesParser;
 
 impl<S: Stage> NoArgsAttributeParser<S> for RustcHiddenTypeOfOpaquesParser {

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -254,6 +254,7 @@ attribute_parsers!(
         Single<WithoutArgs<NoMangleParser>>,
         Single<WithoutArgs<NoStdParser>>,
         Single<WithoutArgs<NonExhaustiveParser>>,
+        Single<WithoutArgs<PanicHandlerParser>>,
         Single<WithoutArgs<PanicRuntimeParser>>,
         Single<WithoutArgs<ParenSugarParser>>,
         Single<WithoutArgs<PassByValueParser>>,

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -181,6 +181,7 @@ attribute_parsers!(
         Single<IgnoreParser>,
         Single<InlineParser>,
         Single<InstructionSetParser>,
+        Single<LangParser>,
         Single<LinkNameParser>,
         Single<LinkOrdinalParser>,
         Single<LinkSectionParser>,

--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -1014,6 +1014,15 @@ pub(crate) struct DocAliasMalformed {
 }
 
 #[derive(Diagnostic)]
+#[diag("definition of an unknown lang item: `{$name}`", code = E0522)]
+pub(crate) struct UnknownLangItem {
+    #[primary_span]
+    #[label("definition of unknown lang item `{$name}`")]
+    pub span: Span,
+    pub name: Symbol,
+}
+
+#[derive(Diagnostic)]
 #[diag("target `{$current_target}` does not support `#[instruction_set({$instruction_set}::*)]`")]
 pub(crate) struct UnsupportedInstructionSet<'a> {
     #[primary_span]

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -8,7 +8,7 @@ use rustc_hir::attrs::{
 };
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LOCAL_CRATE, LocalDefId};
-use rustc_hir::{self as hir, Attribute, LangItem, find_attr, lang_items};
+use rustc_hir::{self as hir, Attribute, find_attr};
 use rustc_middle::middle::codegen_fn_attrs::{
     CodegenFnAttrFlags, CodegenFnAttrs, PatchableFunctionEntry, SanitizerFnAttrs,
 };
@@ -504,7 +504,7 @@ fn handle_lang_items(
     attrs: &[Attribute],
     codegen_fn_attrs: &mut CodegenFnAttrs,
 ) {
-    let lang_item = lang_items::extract(attrs).and_then(|(name, _)| LangItem::from_name(name));
+    let lang_item = find_attr!(attrs, AttributeKind::Lang(lang, _) => lang);
 
     // Weak lang items have the same semantics as "std internal" symbols in the
     // sense that they're preserved through all our LTO passes and only

--- a/compiler/rustc_error_codes/src/error_codes/E0264.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0264.md
@@ -7,8 +7,8 @@ Erroneous code example:
 #![allow(internal_features)]
 
 extern "C" {
-    #[lang = "cake"] // error: unknown external lang item: `cake`
-    fn cake();
+    #[lang = "copy"] // error: unknown external lang item: `copy`
+    fn copy();
 }
 ```
 

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -8,6 +8,7 @@ use rustc_ast::token::DocFragmentKind;
 use rustc_ast::{AttrStyle, Path, ast};
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_error_messages::{DiagArgValue, IntoDiagArg};
+use rustc_hir::LangItem;
 use rustc_macros::{Decodable, Encodable, HashStable_Generic, PrintAttribute};
 use rustc_span::def_id::DefId;
 use rustc_span::hygiene::Transparency;
@@ -952,6 +953,9 @@ pub enum AttributeKind {
 
     /// Represents `#[instruction_set]`
     InstructionSet(InstructionSetAttr),
+
+    /// Represents `#[lang]`
+    Lang(LangItem, Span),
 
     /// Represents `#[link]`.
     Link(ThinVec<LinkEntry>, Span),

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -50,6 +50,7 @@ impl AttributeKind {
             Ignore { .. } => No,
             Inline(..) => No,
             InstructionSet(..) => No,
+            Lang(..) => Yes,
             Link(..) => No,
             LinkName { .. } => Yes, // Needed for rustdoc
             LinkOrdinal { .. } => No,

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -465,15 +465,6 @@ pub(crate) struct LangItemOnIncorrectTarget {
     pub actual_target: Target,
 }
 
-#[derive(Diagnostic)]
-#[diag("definition of an unknown lang item: `{$name}`", code = E0522)]
-pub(crate) struct UnknownLangItem {
-    #[primary_span]
-    #[label("definition of unknown lang item `{$name}`")]
-    pub span: Span,
-    pub name: Symbol,
-}
-
 pub(crate) struct InvalidAttrAtCrateLevel {
     pub span: Span,
     pub sugg_span: Option<Span>,

--- a/compiler/rustc_passes/src/lang_items.rs
+++ b/compiler/rustc_passes/src/lang_items.rs
@@ -8,19 +8,18 @@
 //! * Functions called by the compiler itself.
 
 use rustc_ast as ast;
-use rustc_ast::visit;
+use rustc_ast::fmvisit;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def_id::{DefId, LocalDefId};
-use rustc_hir::lang_items::{GenericRequirement, extract};
+use rustc_hir::lang_items::GenericRequirement;
 use rustc_hir::{LangItem, LanguageItems, MethodKind, Target};
 use rustc_middle::query::Providers;
 use rustc_middle::ty::{ResolverAstLowering, TyCtxt};
 use rustc_session::cstore::ExternCrate;
-use rustc_span::Span;
+use rustc_span::{Span, Symbol, sym};
 
 use crate::errors::{
     DuplicateLangItem, IncorrectCrateType, IncorrectTarget, LangItemOnIncorrectTarget,
-    UnknownLangItem,
 };
 use crate::weak_lang_items;
 
@@ -62,7 +61,7 @@ impl<'ast, 'tcx> LanguageItemCollector<'ast, 'tcx> {
         item_span: Span,
         generics: Option<&'ast ast::Generics>,
     ) {
-        if let Some((name, attr_span)) = extract(attrs) {
+        if let Some((name, attr_span)) = extract_ast(attrs) {
             match LangItem::from_name(name) {
                 // Known lang item with attribute on correct target.
                 Some(lang_item) if actual_target == lang_item.target() => {
@@ -86,7 +85,7 @@ impl<'ast, 'tcx> LanguageItemCollector<'ast, 'tcx> {
                 }
                 // Unknown lang item.
                 _ => {
-                    self.tcx.dcx().emit_err(UnknownLangItem { span: attr_span, name });
+                    self.tcx.dcx().delayed_bug("unknown lang item");
                 }
             }
         }
@@ -357,6 +356,20 @@ impl<'ast, 'tcx> visit::Visitor<'ast> for LanguageItemCollector<'ast, 'tcx> {
 
         visit::walk_assoc_item(self, i, ctxt);
     }
+}
+
+/// Extracts the first `lang = "$name"` out of a list of attributes.
+/// The `#[panic_handler]` attribute is also extracted out when found.
+///
+/// This function is used for `ast::Attribute`, for `hir::Attribute` use the `find_attr!` macro with `AttributeKind::Lang`
+pub(crate) fn extract_ast(attrs: &[rustc_ast::ast::Attribute]) -> Option<(Symbol, Span)> {
+    attrs.iter().find_map(|attr| {
+        Some(match attr {
+            _ if attr.has_name(sym::lang) => (attr.value_str()?, attr.span()),
+            _ if attr.has_name(sym::panic_handler) => (sym::panic_impl, attr.span()),
+            _ => return None,
+        })
+    })
 }
 
 pub(crate) fn provide(providers: &mut Providers) {

--- a/compiler/rustc_passes/src/lang_items.rs
+++ b/compiler/rustc_passes/src/lang_items.rs
@@ -8,7 +8,7 @@
 //! * Functions called by the compiler itself.
 
 use rustc_ast as ast;
-use rustc_ast::fmvisit;
+use rustc_ast::visit;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::lang_items::GenericRequirement;

--- a/compiler/rustc_passes/src/weak_lang_items.rs
+++ b/compiler/rustc_passes/src/weak_lang_items.rs
@@ -13,6 +13,7 @@ use rustc_target::spec::Os;
 use crate::errors::{
     MissingLangItem, MissingPanicHandler, PanicUnwindWithoutStd, UnknownExternLangItem,
 };
+use crate::lang_items::extract_ast;
 
 /// Checks the crate for usage of weak lang items, returning a vector of all the
 /// lang items required by this crate, but not defined yet.
@@ -46,7 +47,7 @@ struct WeakLangItemVisitor<'a, 'tcx> {
 
 impl<'ast> visit::Visitor<'ast> for WeakLangItemVisitor<'_, '_> {
     fn visit_foreign_item(&mut self, i: &'ast ast::ForeignItem) {
-        if let Some((lang_item, _)) = lang_items::extract(&i.attrs) {
+        if let Some((lang_item, _)) = extract_ast(&i.attrs) {
             if let Some(item) = LangItem::from_name(lang_item)
                 && item.is_weak()
             {

--- a/tests/ui/error-codes/E0264.rs
+++ b/tests/ui/error-codes/E0264.rs
@@ -1,8 +1,8 @@
 #![feature(lang_items)]
 
 extern "C" {
-    #[lang = "cake"]
-    fn cake(); //~ ERROR E0264
+    #[lang = "copy"]
+    fn copy(); //~ ERROR E0264
 }
 
 fn main() {}

--- a/tests/ui/error-codes/E0264.stderr
+++ b/tests/ui/error-codes/E0264.stderr
@@ -1,7 +1,7 @@
-error[E0264]: unknown external lang item: `cake`
+error[E0264]: unknown external lang item: `copy`
   --> $DIR/E0264.rs:5:5
    |
-LL |     fn cake();
+LL |     fn copy();
    |     ^^^^^^^^^^
 
 error: aborting due to 1 previous error

--- a/tests/ui/lowering/issue-96847.rs
+++ b/tests/ui/lowering/issue-96847.rs
@@ -1,4 +1,4 @@
-//@ run-pass
+//@ check-fail
 
 // Test that this doesn't abort during AST lowering. In #96847 it did abort
 // because the attribute was being lowered twice.
@@ -9,6 +9,7 @@
 fn main() {
     for _ in [1,2,3] {
         #![lang="foo"]
+        //~^ ERROR definition of an unknown lang item: `foo` [E0522]
         println!("foo");
     }
 }

--- a/tests/ui/lowering/issue-96847.stderr
+++ b/tests/ui/lowering/issue-96847.stderr
@@ -1,0 +1,9 @@
+error[E0522]: definition of an unknown lang item: `foo`
+  --> $DIR/issue-96847.rs:11:9
+   |
+LL |         #![lang="foo"]
+   |         ^^^^^^^^^^^^^^ definition of unknown lang item `foo`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0522`.


### PR DESCRIPTION
For https://github.com/rust-lang/rust/issues/131229#issuecomment-2971351163

r? @jdonszelmann 