### PR TITLE
Stop using rustc_layout_scalar_valid_range_* in rustc

### DIFF
--- a/compiler/rustc_abi/src/layout.rs
+++ b/compiler/rustc_abi/src/layout.rs
@@ -45,7 +45,7 @@ rustc_index::newtype_index! {
     /// `b` is `FieldIdx(1)` in `VariantIdx(0)`,
     /// `d` is `FieldIdx(1)` in `VariantIdx(1)`, and
     /// `f` is `FieldIdx(1)` in `VariantIdx(0)`.
-    #[cfg_attr(feature = "nightly", derive(rustc_macros::HashStable_Generic))]
+    #[stable_hash_generic]
     #[encodable]
     #[orderable]
     #[gate_rustc_only]
@@ -70,7 +70,7 @@ rustc_index::newtype_index! {
     ///
     /// `struct`s, `tuples`, and `unions`s are considered to have a single variant
     /// with variant index zero, aka [`FIRST_VARIANT`].
-    #[cfg_attr(feature = "nightly", derive(rustc_macros::HashStable_Generic))]
+    #[stable_hash_generic]
     #[encodable]
     #[orderable]
     #[gate_rustc_only]

--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -28,6 +28,8 @@
 #![feature(min_specialization)]
 #![feature(negative_impls)]
 #![feature(never_type)]
+#![feature(pattern_type_macro)]
+#![feature(pattern_types)]
 #![feature(ptr_alignment_type)]
 #![feature(rustc_attrs)]
 #![feature(sized_hierarchy)]

--- a/compiler/rustc_hir_id/src/lib.rs
+++ b/compiler/rustc_hir_id/src/lib.rs
@@ -151,7 +151,7 @@ rustc_index::newtype_index! {
     /// integers starting at zero, so a mapping that maps all or most nodes within
     /// an "item-like" to something else can be implemented by a `Vec` instead of a
     /// tree or hash map.
-    #[derive(HashStable_Generic)]
+    #[stable_hash_generic]
     #[encodable]
     #[orderable]
     pub struct ItemLocalId {}

--- a/compiler/rustc_index_macros/src/lib.rs
+++ b/compiler/rustc_index_macros/src/lib.rs
@@ -34,7 +34,17 @@ mod newtype;
 ///   optimizations. The default max value is 0xFFFF_FF00.
 /// - `#[gate_rustc_only]`: makes parts of the generated code nightly-only.
 #[proc_macro]
-#[cfg_attr(feature = "nightly", allow_internal_unstable(step_trait, rustc_attrs, trusted_step))]
+#[cfg_attr(
+    feature = "nightly",
+    allow_internal_unstable(
+        step_trait,
+        rustc_attrs,
+        trusted_step,
+        pattern_types,
+        pattern_type_macro,
+        structural_match,
+    )
+)]
 pub fn newtype_index(input: TokenStream) -> TokenStream {
     newtype::newtype(input)
 }

--- a/compiler/rustc_middle/src/middle/region.rs
+++ b/compiler/rustc_middle/src/middle/region.rs
@@ -159,7 +159,7 @@ rustc_index::newtype_index! {
     ///
     /// * The subscope with `first_statement_index == 1` is scope of `c`,
     ///   and thus does not include EXPR_2, but covers the `...`.
-    #[derive(HashStable)]
+    #[stable_hash]
     #[encodable]
     #[orderable]
     pub struct FirstStatementIndex {}

--- a/compiler/rustc_middle/src/mir/coverage.rs
+++ b/compiler/rustc_middle/src/mir/coverage.rs
@@ -10,7 +10,7 @@ use rustc_span::Span;
 rustc_index::newtype_index! {
     /// Used by [`CoverageKind::BlockMarker`] to mark blocks during THIR-to-MIR
     /// lowering, so that those blocks can be identified later.
-    #[derive(HashStable)]
+    #[stable_hash]
     #[encodable]
     #[debug_format = "BlockMarkerId({})"]
     pub struct BlockMarkerId {}
@@ -26,7 +26,7 @@ rustc_index::newtype_index! {
     ///
     /// Note that LLVM handles counter IDs as `uint32_t`, so there is no need
     /// to use a larger representation on the Rust side.
-    #[derive(HashStable)]
+    #[stable_hash]
     #[encodable]
     #[orderable]
     #[debug_format = "CounterId({})"]
@@ -43,7 +43,7 @@ rustc_index::newtype_index! {
     ///
     /// Note that LLVM handles expression IDs as `uint32_t`, so there is no need
     /// to use a larger representation on the Rust side.
-    #[derive(HashStable)]
+    #[stable_hash]
     #[encodable]
     #[orderable]
     #[debug_format = "ExpressionId({})"]
@@ -203,7 +203,7 @@ rustc_index::newtype_index! {
     ///
     /// After that pass is complete, the coverage graph no longer exists, so a
     /// BCB is effectively an opaque ID.
-    #[derive(HashStable)]
+    #[stable_hash]
     #[encodable]
     #[orderable]
     #[debug_format = "bcb{}"]

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -840,7 +840,7 @@ impl SourceInfo {
 // Variables and temps
 
 rustc_index::newtype_index! {
-    #[derive(HashStable)]
+    #[stable_hash]
     #[encodable]
     #[orderable]
     #[debug_format = "_{}"]
@@ -1264,7 +1264,7 @@ rustc_index::newtype_index! {
     ///     https://rustc-dev-guide.rust-lang.org/appendix/background.html#what-is-a-dataflow-analysis
     /// [`CriticalCallEdges`]: ../../rustc_mir_transform/add_call_guards/enum.AddCallGuards.html#variant.CriticalCallEdges
     /// [guide-mir]: https://rustc-dev-guide.rust-lang.org/mir/
-    #[derive(HashStable)]
+    #[stable_hash]
     #[encodable]
     #[orderable]
     #[debug_format = "bb{}"]
@@ -1398,7 +1398,7 @@ impl<'tcx> BasicBlockData<'tcx> {
 // Scopes
 
 rustc_index::newtype_index! {
-    #[derive(HashStable)]
+    #[stable_hash]
     #[encodable]
     #[debug_format = "scope[{}]"]
     pub struct SourceScope {
@@ -1537,7 +1537,7 @@ pub struct UserTypeProjection {
 }
 
 rustc_index::newtype_index! {
-    #[derive(HashStable)]
+    #[stable_hash]
     #[encodable]
     #[orderable]
     #[debug_format = "promoted[{}]"]

--- a/compiler/rustc_middle/src/mir/query.rs
+++ b/compiler/rustc_middle/src/mir/query.rs
@@ -13,7 +13,7 @@ use super::{ConstValue, SourceInfo};
 use crate::ty::{self, CoroutineArgsExt, Ty};
 
 rustc_index::newtype_index! {
-    #[derive(HashStable)]
+    #[stable_hash]
     #[encodable]
     #[debug_format = "_s{}"]
     pub struct CoroutineSavedLocal {}

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -44,7 +44,7 @@ macro_rules! thir_with_elements {
     ) => {
         $(
             newtype_index! {
-                #[derive(HashStable)]
+                #[stable_hash]
                 #[debug_format = $format]
                 pub struct $id {}
             }

--- a/compiler/rustc_middle/src/ty/typeck_results.rs
+++ b/compiler/rustc_middle/src/ty/typeck_results.rs
@@ -716,7 +716,7 @@ impl<'a> LocalSetInContextMut<'a> {
 }
 
 rustc_index::newtype_index! {
-    #[derive(HashStable)]
+    #[stable_hash]
     #[encodable]
     #[debug_format = "UserType({})"]
     pub struct UserTypeAnnotationIndex {

--- a/compiler/rustc_mir_transform/src/jump_threading.rs
+++ b/compiler/rustc_mir_transform/src/jump_threading.rs
@@ -161,7 +161,7 @@ struct TOFinder<'a, 'tcx> {
 }
 
 rustc_index::newtype_index! {
-    #[derive(Ord, PartialOrd)]
+    #[orderable]
     #[debug_format = "_c{}"]
     struct ConditionIndex {}
 }

--- a/compiler/rustc_monomorphize/src/graph_checks/statics.rs
+++ b/compiler/rustc_monomorphize/src/graph_checks/statics.rs
@@ -30,7 +30,7 @@ impl From<usize> for StaticNodeIdx {
 }
 
 newtype_index! {
-    #[derive(Ord, PartialOrd)]
+    #[orderable]
     struct StaticSccIdx {}
 }
 

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -123,7 +123,7 @@ rustc_index::newtype_index! {
     /// is the outer fn.
     ///
     /// [dbi]: https://en.wikipedia.org/wiki/De_Bruijn_index
-    #[cfg_attr(feature = "nightly", derive(HashStable_NoContext))]
+    #[stable_hash_no_context]
     #[encodable]
     #[orderable]
     #[debug_format = "DebruijnIndex({})"]
@@ -333,7 +333,7 @@ rustc_index::newtype_index! {
     /// declared, but a type name in a non-zero universe is a placeholder
     /// type -- an idealized representative of "types in general" that we
     /// use for checking generic functions.
-    #[cfg_attr(feature = "nightly", derive(HashStable_NoContext))]
+    #[stable_hash_no_context]
     #[encodable]
     #[orderable]
     #[debug_format = "U{}"]
@@ -388,7 +388,7 @@ impl Default for UniverseIndex {
 }
 
 rustc_index::newtype_index! {
-    #[cfg_attr(feature = "nightly", derive(HashStable_NoContext))]
+    #[stable_hash_generic]
     #[encodable]
     #[orderable]
     #[debug_format = "{}"]

--- a/compiler/rustc_type_ir/src/region_kind.rs
+++ b/compiler/rustc_type_ir/src/region_kind.rs
@@ -4,7 +4,7 @@ use derive_where::derive_where;
 #[cfg(feature = "nightly")]
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 #[cfg(feature = "nightly")]
-use rustc_macros::{Decodable_NoContext, Encodable_NoContext, HashStable_NoContext};
+use rustc_macros::{Decodable_NoContext, Encodable_NoContext};
 use rustc_type_ir_macros::GenericTypeVisitable;
 
 use self::RegionKind::*;
@@ -16,7 +16,7 @@ rustc_index::newtype_index! {
     #[orderable]
     #[debug_format = "'?{}"]
     #[gate_rustc_only]
-    #[cfg_attr(feature = "nightly", derive(HashStable_NoContext))]
+    #[stable_hash_no_context]
     pub struct RegionVid {}
 }
 


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/152569)*

Another step towards rust-lang/rust#135996

Required some manual impls, but we already do many manual impls for the newtype_index types, so it's not really a new maintenance burden.