### PR TITLE
layout_of unexpected rigid alias delayed bug

### DIFF
--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -777,7 +777,9 @@ fn layout_of_uncached<'tcx>(
             let err = if ty.has_param() || !cx.typing_env.param_env.caller_bounds().is_empty() {
                 LayoutError::TooGeneric(ty)
             } else {
-                unreachable!("invalid rigid alias in layout_of after normalization: {ty:?}");
+                LayoutError::ReferencesError(cx.tcx().dcx().delayed_bug(format!(
+                    "unexpected rigid alias in layout_of after normalization: {ty:?}"
+                )))
             };
             return Err(error(cx, err));
         }

--- a/tests/ui/layout/rigid-alias-due-to-broken-impl.rs
+++ b/tests/ui/layout/rigid-alias-due-to-broken-impl.rs
@@ -1,0 +1,17 @@
+// Make sure we don't ICE if `layout_of` encounters an alias
+// which is rigid due to a malformed program. A regression test
+// for #152545.
+//
+// This specific ICE happens in the `KnownPanicsLint` visitor.
+
+//@ compile-flags: --crate-type=rlib
+trait Foo {
+    type Assoc;
+}
+
+// The trait solver only treats missng associated items
+// as rigid if the self-type is known to be unsized.
+impl Foo for str {}
+//~^ ERROR not all trait items implemented
+
+fn foo(_: [u32; std::mem::size_of::<<str as Foo>::Assoc>()]) {}

--- a/tests/ui/layout/rigid-alias-due-to-broken-impl.stderr
+++ b/tests/ui/layout/rigid-alias-due-to-broken-impl.stderr
@@ -1,0 +1,12 @@
+error[E0046]: not all trait items implemented, missing: `Assoc`
+  --> $DIR/rigid-alias-due-to-broken-impl.rs:14:1
+   |
+LL |     type Assoc;
+   |     ---------- `Assoc` from trait
+...
+LL | impl Foo for str {}
+   | ^^^^^^^^^^^^^^^^ missing `Assoc` in implementation
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0046`.


### PR DESCRIPTION
fixes rust-lang/rust#152545. The trait solver can keep aliases as rigid even if they are not well-formed https://github.com/rust-lang/rust/blob/d7daac06d87e1252d10eaa44960164faac46beff/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs#L315-L345

r? types