### PR TITLE
Optimisation: avoid emitting verify bounds that always hold

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
+++ b/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
@@ -322,10 +322,11 @@ impl<'a, 'b, 'tcx> TypeOutlivesDelegate<'tcx> for &'a mut ConstraintConversion<'
         a: ty::Region<'tcx>,
         bound: VerifyBound<'tcx>,
     ) {
-        if bound.must_hold() {
-            debug!("Bound {bound:?} always holds; emitting no type test.");
-            return;
-        }
+        debug_assert!(
+            !bound.must_hold(),
+            "Bound {bound:?} on {kind:?} is a no-op, should never have been emitted!"
+        );
+
         let kind = self.replace_placeholders_with_nll(kind);
         let bound = self.replace_placeholders_with_nll(bound);
         let type_test = self.verify_to_type_test(kind, a, bound);

--- a/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
+++ b/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
@@ -322,6 +322,10 @@ impl<'a, 'b, 'tcx> TypeOutlivesDelegate<'tcx> for &'a mut ConstraintConversion<'
         a: ty::Region<'tcx>,
         bound: VerifyBound<'tcx>,
     ) {
+        if bound.must_hold() {
+            debug!("Bound {bound:?} always holds; emitting no type test.");
+            return;
+        }
         let kind = self.replace_placeholders_with_nll(kind);
         let bound = self.replace_placeholders_with_nll(bound);
         let type_test = self.verify_to_type_test(kind, a, bound);

--- a/compiler/rustc_infer/src/infer/outlives/obligations.rs
+++ b/compiler/rustc_infer/src/infer/outlives/obligations.rs
@@ -386,7 +386,9 @@ where
         param_ty: ty::ParamTy,
     ) {
         let verify_bound = self.verify_bound.param_or_placeholder_bound(param_ty.to_ty(self.tcx));
-        self.delegate.push_verify(origin, GenericKind::Param(param_ty), region, verify_bound);
+        if !verify_bound.holds_trivially() {
+            self.delegate.push_verify(origin, GenericKind::Param(param_ty), region, verify_bound);
+        }
     }
 
     #[instrument(level = "debug", skip(self))]
@@ -399,12 +401,14 @@ where
         let verify_bound = self
             .verify_bound
             .param_or_placeholder_bound(Ty::new_placeholder(self.tcx, placeholder_ty));
-        self.delegate.push_verify(
-            origin,
-            GenericKind::Placeholder(placeholder_ty),
-            region,
-            verify_bound,
-        );
+        if !verify_bound.holds_trivially() {
+            self.delegate.push_verify(
+                origin,
+                GenericKind::Placeholder(placeholder_ty),
+                region,
+                verify_bound,
+            );
+        }
     }
 
     #[instrument(level = "debug", skip(self))]
@@ -517,6 +521,18 @@ where
         // edges into the inference graph, leading to inference failures
         // even though a satisfactory solution exists.
         let verify_bound = self.verify_bound.alias_bound(alias_ty);
+        if verify_bound.holds_trivially() {
+            debug!("Skipping trivially satisfied verify bound.");
+            return;
+        }
+
+        // If this bound is always satisfied, a complex bound should never have been
+        // constructed and we should have gotten [[`VerifyBound::always_satisfied`]]
+        debug_assert!(
+            !verify_bound.must_hold(),
+            "Attempted to add always-satisfied verify bound {verify_bound:?}"
+        );
+
         debug!("alias_must_outlive: pushing {:?}", verify_bound);
         self.delegate.push_verify(origin, GenericKind::Alias(alias_ty), region, verify_bound);
     }

--- a/compiler/rustc_infer/src/infer/outlives/verify.rs
+++ b/compiler/rustc_infer/src/infer/outlives/verify.rs
@@ -48,11 +48,16 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
             let bound_region = declared_bound.map_bound(|outlives| outlives.1);
             if let Some(region) = bound_region.no_bound_vars() {
                 // This is `T: 'a` for some free region `'a`.
+                if region.is_static() {
+                    // Since these are going into an Any bound, this bound will always hold
+                    // and there is no point in generating a more complex bound.
+                    return VerifyBound::always_holds();
+                }
                 param_bounds.push(VerifyBound::OutlivedBy(region));
             } else {
                 // This is `for<'a> T: 'a`. This means that `T` outlives everything! All done here.
                 debug!("found that {ty:?} outlives any lifetime, returning empty vector");
-                return VerifyBound::AllBounds(vec![]);
+                return VerifyBound::always_holds();
             }
         }
 
@@ -138,7 +143,7 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
             .iter()
             .map(|component| self.bound_from_single_component(component))
             // Remove bounds that must hold, since they are not interesting.
-            .filter(|bound| !bound.must_hold());
+            .filter(|bound| !bound.holds_trivially());
 
         match (bounds.next(), bounds.next()) {
             (Some(first), None) => first,
@@ -167,8 +172,7 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
                 self.tcx
                     .dcx()
                     .delayed_bug(format!("unresolved inference variable in outlives: {v:?}"));
-                // Add a bound that never holds.
-                VerifyBound::AnyBound(vec![])
+                VerifyBound::never_holds()
             }
         }
     }

--- a/compiler/rustc_infer/src/infer/region_constraints/mod.rs
+++ b/compiler/rustc_infer/src/infer/region_constraints/mod.rs
@@ -404,9 +404,7 @@ impl<'tcx> RegionConstraintCollector<'_, 'tcx> {
         debug!("RegionConstraintCollector: add_verify({:?})", verify);
 
         // skip no-op cases known to be satisfied
-        if let VerifyBound::AllBounds(ref bs) = verify.bound
-            && bs.is_empty()
-        {
+        if verify.bound.holds_trivially() {
             return;
         }
 
@@ -707,13 +705,47 @@ impl<'tcx> VerifyBound<'tcx> {
     }
 
     pub fn or(self, vb: VerifyBound<'tcx>) -> VerifyBound<'tcx> {
-        if self.must_hold() || vb.cannot_hold() {
-            self
-        } else if self.cannot_hold() || vb.must_hold() {
-            vb
-        } else {
-            VerifyBound::AnyBound(vec![self, vb])
+        match (self, vb) {
+            // Normalise the case of a trivially satisfied bound to the smallest possible case.
+            (this, that) if this.must_hold() || that.must_hold() => Self::always_holds(),
+            // Short-circuit:
+            (this, that) if that.cannot_hold() => this,
+            (this, that) if this.cannot_hold() => that,
+            (VerifyBound::AnyBound(mut this), VerifyBound::AnyBound(mut that)) => {
+                // Flatten two `AnyBound`s.
+                this.append(&mut that);
+                VerifyBound::AnyBound(this)
+            }
+            // FIXME: This can still nest arbitrarily.
+            (this, that) => VerifyBound::AnyBound(vec![this, that]),
         }
+    }
+
+    pub fn always_holds() -> Self {
+        VerifyBound::AllBounds(Vec::new())
+    }
+
+    pub fn never_holds() -> Self {
+        VerifyBound::AnyBound(Vec::new())
+    }
+
+    // Perform a cheap check if this bound trivially always holds.
+    #[inline]
+    pub fn holds_trivially(&self) -> bool {
+        let holds_trivially = match self {
+            VerifyBound::IfEq(_) => false,
+            VerifyBound::OutlivedBy(region) => region.is_static(),
+            VerifyBound::IsEmpty => false,
+            VerifyBound::AnyBound(_verify_bounds) => false,
+            VerifyBound::AllBounds(verify_bounds) => verify_bounds.is_empty(),
+        };
+
+        // Booby-trap it so that anyone breaking the intended normalisation trips this.
+        debug_assert!(
+            holds_trivially == self.must_hold(),
+            "Self-evident bound {self:?} wasn't normalised properly!"
+        );
+        holds_trivially
     }
 }
 


### PR DESCRIPTION
This PR normalises verify bounds that always hold and uses that logic to cheaply detect that case and never emit them.

This leaves a ton of tripwire assertions around that will activate if these assumptions are violated.

`VerifyBound::or()` is now also short-circuiting and flattens immediately nested Any bounds. Note that the short-circuiting means information may be lost if both bounds are failing and we want to keep both failing bounds.

r? @lcnr 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
