### PR TITLE
Fix `unused_crate_dependencies` firing erroneously with `-Z build-std`

### DIFF
--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -1192,7 +1192,7 @@ impl CStore {
                 // Don't worry about pathless `--extern foo` sysroot references
                 continue;
             }
-            if entry.nounused_dep || entry.force {
+            if entry.nounused_dep || entry.force || !entry.add_prelude {
                 // We're not worried about this one
                 continue;
             }

--- a/tests/ui/unused-crate-deps/auxiliary/baz.rs
+++ b/tests/ui/unused-crate-deps/auxiliary/baz.rs
@@ -1,0 +1,1 @@
+pub const BAZ: &str = "baz";

--- a/tests/ui/unused-crate-deps/noprelude.rs
+++ b/tests/ui/unused-crate-deps/noprelude.rs
@@ -1,7 +1,10 @@
 // noprelude --extern references don't count
 //@ edition:2018
 //@ check-pass
+//@ aux-crate:baz=baz.rs
 //@ aux-crate:noprelude:bar=bar.rs
 //@ compile-flags: -Zunstable-options
 #![warn(unused_crate_dependencies)]
+//~^ WARNING extern crate `baz` is unused in crate `noprelude`
+// No warning from bar is expected since it's noprelude
 fn main() {}

--- a/tests/ui/unused-crate-deps/noprelude.rs
+++ b/tests/ui/unused-crate-deps/noprelude.rs
@@ -1,0 +1,7 @@
+// noprelude --extern references don't count
+//@ edition:2018
+//@ check-pass
+//@ aux-crate:noprelude:bar=bar.rs
+//@ compile-flags: -Zunstable-options
+#![warn(unused_crate_dependencies)]
+fn main() {}

--- a/tests/ui/unused-crate-deps/noprelude.stderr
+++ b/tests/ui/unused-crate-deps/noprelude.stderr
@@ -1,0 +1,15 @@
+warning: extern crate `baz` is unused in crate `noprelude`
+  --> $DIR/noprelude.rs:7:1
+   |
+LL | #![warn(unused_crate_dependencies)]
+   | ^
+   |
+   = help: remove the dependency or add `use baz as _;` to the crate root
+note: the lint level is defined here
+  --> $DIR/noprelude.rs:7:9
+   |
+LL | #![warn(unused_crate_dependencies)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Fixes rust-lang/rust#152561

When using `-Z build-std`, cargo passes implicitly injected crates like
`alloc`, `core`, `compiler_builtins`, and `proc_macro` to rustc as
`--extern noprelude:foo`. These crates are not user-declared
dependencies and dont appear in `Cargo.toml`.

Fix is a change in `report_unused_deps_in_crate` which now skips any extern entry where `add_prelude` is false

Added UI test `tests/ui/unused-crate-deps/noprelude.rs` which verifies that
an unused `noprelude:` extern does not trigger the lint.
