### PR TITLE
DepGraphQuery: correctly skip adding edges with not-yet-added nodes

### DIFF
--- a/compiler/rustc_middle/src/dep_graph/query.rs
+++ b/compiler/rustc_middle/src/dep_graph/query.rs
@@ -28,10 +28,9 @@ impl DepGraphQuery {
         self.indices.insert(node, source);
 
         for &target in edges.iter() {
-            let target = self.dep_index_to_index[target];
             // We may miss the edges that are pushed while the `DepGraphQuery` is being accessed.
             // Skip them to issues.
-            if let Some(target) = target {
+            if let Some(&Some(target)) = self.dep_index_to_index.get(target) {
                 self.graph.add_edge(source, target, ());
             }
         }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/142152.

The current logic already skips some edges, so I'm not sure how critical it is to have *all* the edges recorded, the logic seems to only be used for debug dumping.
Recording all edges requires supporting holes in the `LinkedGraph` data structure, to add nodes and edges out of order, https://github.com/rust-lang/rust/pull/151821 implements that at cost of complicating the data structure.