### PR TITLE
Box in `ValTreeKind::Branch(Box<[I::Const]>)` changed to `List`

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/valtrees.rs
+++ b/compiler/rustc_const_eval/src/const_eval/valtrees.rs
@@ -413,7 +413,7 @@ fn valtree_into_mplace<'tcx>(
                         Some(variant_idx),
                     )
                 }
-                _ => (place.clone(), branches, None),
+                _ => (place.clone(), branches.as_slice(), None),
             };
             debug!(?place_adjusted, ?branches);
 

--- a/compiler/rustc_middle/src/arena.rs
+++ b/compiler/rustc_middle/src/arena.rs
@@ -92,7 +92,6 @@ macro_rules! arena_types {
             [] name_set: rustc_data_structures::unord::UnordSet<rustc_span::Symbol>,
             [] autodiff_item: rustc_ast::expand::autodiff_attrs::AutoDiffItem,
             [] ordered_name_set: rustc_data_structures::fx::FxIndexSet<rustc_span::Symbol>,
-            [] valtree: rustc_middle::ty::ValTreeKind<rustc_middle::ty::TyCtxt<'tcx>>,
             [] stable_order_of_exportable_impls:
                 rustc_data_structures::fx::FxIndexMap<rustc_hir::def_id::DefId, usize>,
 

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -13,6 +13,7 @@ use std::marker::{DiscriminantKind, PointeeSized};
 use rustc_abi::FieldIdx;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def_id::LocalDefId;
+use rustc_middle::ty::Const;
 use rustc_serialize::{Decodable, Encodable};
 use rustc_span::source_map::Spanned;
 use rustc_span::{Span, SpanDecoder, SpanEncoder};
@@ -498,6 +499,7 @@ impl_decodable_via_ref! {
     &'tcx ty::List<ty::BoundVariableKind<'tcx>>,
     &'tcx ty::List<ty::Pattern<'tcx>>,
     &'tcx ty::ListWithCachedTypeInfo<ty::Clause<'tcx>>,
+    &'tcx ty::List<Const<'tcx>>,
 }
 
 #[macro_export]

--- a/compiler/rustc_middle/src/ty/consts/valtree.rs
+++ b/compiler/rustc_middle/src/ty/consts/valtree.rs
@@ -44,7 +44,7 @@ impl<'tcx> ValTree<'tcx> {
     }
 
     pub fn is_zst(self) -> bool {
-        matches!(*self, ty::ValTreeKind::Branch(box []))
+        matches!(*self, ty::ValTreeKind::Branch(consts) if consts.is_empty())
     }
 
     pub fn from_raw_bytes(tcx: TyCtxt<'tcx>, bytes: &[u8]) -> Self {
@@ -58,7 +58,9 @@ impl<'tcx> ValTree<'tcx> {
         tcx: TyCtxt<'tcx>,
         branches: impl IntoIterator<Item = ty::Const<'tcx>>,
     ) -> Self {
-        tcx.intern_valtree(ty::ValTreeKind::Branch(branches.into_iter().collect()))
+        tcx.intern_valtree(ty::ValTreeKind::Branch(
+            tcx.mk_const_list_from_iter(branches.into_iter()),
+        ))
     }
 
     pub fn from_scalar_int(tcx: TyCtxt<'tcx>, i: ScalarInt) -> Self {

--- a/compiler/rustc_middle/src/ty/consts/valtree.rs
+++ b/compiler/rustc_middle/src/ty/consts/valtree.rs
@@ -31,12 +31,6 @@ impl<'tcx> ty::ValTreeKind<TyCtxt<'tcx>> {
 // recurses through
 pub struct ValTree<'tcx>(pub(crate) Interned<'tcx, ty::ValTreeKind<TyCtxt<'tcx>>>);
 
-impl<'tcx> rustc_type_ir::inherent::ValTree<TyCtxt<'tcx>> for ValTree<'tcx> {
-    fn kind(&self) -> &ty::ValTreeKind<TyCtxt<'tcx>> {
-        &self
-    }
-}
-
 impl<'tcx> ValTree<'tcx> {
     /// Returns the zero-sized valtree: `Branch([])`.
     pub fn zst(tcx: TyCtxt<'tcx>) -> Self {
@@ -80,6 +74,14 @@ impl<'tcx> Deref for ValTree<'tcx> {
 impl fmt::Debug for ValTree<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (**self).fmt(f)
+    }
+}
+
+impl<'tcx> rustc_type_ir::inherent::IntoKind for ty::ValTree<'tcx> {
+    type Kind = ty::ValTreeKind<TyCtxt<'tcx>>;
+
+    fn kind(self) -> Self::Kind {
+        *self.0
     }
 }
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -565,7 +565,7 @@ impl<'tcx> CommonConsts<'tcx> {
             ))
         };
 
-        let valtree_zst = mk_valtree(ty::ValTreeKind::Branch(Box::default()));
+        let valtree_zst = mk_valtree(ty::ValTreeKind::Branch(List::empty()));
         let valtree_true = mk_valtree(ty::ValTreeKind::Leaf(ty::ScalarInt::TRUE));
         let valtree_false = mk_valtree(ty::ValTreeKind::Leaf(ty::ScalarInt::FALSE));
 

--- a/compiler/rustc_middle/src/ty/context/impl_interner.rs
+++ b/compiler/rustc_middle/src/ty/context/impl_interner.rs
@@ -95,6 +95,7 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
     type Safety = hir::Safety;
     type Abi = ExternAbi;
     type Const = ty::Const<'tcx>;
+    type Consts = &'tcx List<Self::Const>;
 
     type ParamConst = ty::ParamConst;
     type ValueConst = ty::Value<'tcx>;

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1920,7 +1920,7 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
             }
             // Otherwise, print the array separated by commas (or if it's a tuple)
             (ty::ValTreeKind::Branch(fields), ty::Array(..) | ty::Tuple(..)) => {
-                let fields_iter = fields.as_slice().iter().copied();
+                let fields_iter = fields.iter();
 
                 match *cv.ty.kind() {
                     ty::Array(..) => {

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1920,7 +1920,7 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
             }
             // Otherwise, print the array separated by commas (or if it's a tuple)
             (ty::ValTreeKind::Branch(fields), ty::Array(..) | ty::Tuple(..)) => {
-                let fields_iter = fields.iter().copied();
+                let fields_iter = fields.as_slice().iter().copied();
 
                 match *cv.ty.kind() {
                     ty::Array(..) => {

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -805,4 +805,5 @@ list_fold! {
     &'tcx ty::List<PlaceElem<'tcx>> : mk_place_elems,
     &'tcx ty::List<ty::Pattern<'tcx>> : mk_patterns,
     &'tcx ty::List<ty::ArgOutlivesPredicate<'tcx>> : mk_outlives,
+    &'tcx ty::List<ty::Const<'tcx>> : mk_const_list,
 }

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -2944,11 +2944,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let ValTreeKind::Branch(branch) = *valtree else {
                     bug!("malformed valtree for an enum")
                 };
-                let Some(actual_variant_idx) = branch.get(0) else {
+                if branch.len() != 1 {
                     bug!("malformed valtree for an enum")
                 };
-                let ValTreeKind::Leaf(actual_variant_idx) = *actual_variant_idx.to_value().valtree
-                else {
+                let ValTreeKind::Leaf(actual_variant_idx) = **branch[0].to_value().valtree else {
                     bug!("malformed valtree for an enum")
                 };
 

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -2941,10 +2941,12 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
         match pat.ctor() {
             Constructor::Variant(variant_index) => {
-                let ValTreeKind::Branch(box [actual_variant_idx]) = *valtree else {
+                let ValTreeKind::Branch(branch) = *valtree else {
                     bug!("malformed valtree for an enum")
                 };
-
+                let Some(actual_variant_idx) = branch.get(0) else {
+                    bug!("malformed valtree for an enum")
+                };
                 let ValTreeKind::Leaf(actual_variant_idx) = *actual_variant_idx.to_value().valtree
                 else {
                     bug!("malformed valtree for an enum")

--- a/compiler/rustc_type_ir/src/const_kind.rs
+++ b/compiler/rustc_type_ir/src/const_kind.rs
@@ -9,7 +9,6 @@ use rustc_type_ir_macros::{
     GenericTypeVisitable, Lift_Generic, TypeFoldable_Generic, TypeVisitable_Generic,
 };
 
-use crate::inherent::*;
 use crate::{self as ty, BoundVarIndexKind, Interner};
 
 /// Represents a constant in Rust.
@@ -141,7 +140,7 @@ impl<CTX> HashStable<CTX> for InferConst {
 ///
 /// `ValTree` does not have this problem with representation, as it only contains integers or
 /// lists of (nested) `ty::Const`s (which may indirectly contain more `ValTree`s).
-#[derive_where(Clone, Debug, Hash, Eq, PartialEq; I: Interner)]
+#[derive_where(Clone, Copy, Debug, Hash, Eq, PartialEq; I: Interner)]
 #[derive(TypeVisitable_Generic, TypeFoldable_Generic)]
 #[cfg_attr(
     feature = "nightly",
@@ -177,9 +176,9 @@ impl<I: Interner> ValTreeKind<I> {
     /// Converts to a `ValTreeKind::Branch` value, `panic`'ing
     /// if this valtree is some other kind.
     #[inline]
-    pub fn to_branch(&self) -> &[I::Const] {
+    pub fn to_branch(&self) -> I::Consts {
         match self {
-            ValTreeKind::Branch(branch) => branch.as_slice(),
+            ValTreeKind::Branch(branch) => *branch,
             ValTreeKind::Leaf(..) => panic!("expected branch, got {:?}", self),
         }
     }
@@ -193,9 +192,9 @@ impl<I: Interner> ValTreeKind<I> {
     }
 
     /// Attempts to convert to a `ValTreeKind::Branch` value.
-    pub fn try_to_branch(&self) -> Option<&[I::Const]> {
+    pub fn try_to_branch(&self) -> Option<I::Consts> {
         match self {
-            ValTreeKind::Branch(branch) => Some(branch.as_slice()),
+            ValTreeKind::Branch(branch) => Some(*branch),
             ValTreeKind::Leaf(_) => None,
         }
     }

--- a/compiler/rustc_type_ir/src/const_kind.rs
+++ b/compiler/rustc_type_ir/src/const_kind.rs
@@ -9,6 +9,7 @@ use rustc_type_ir_macros::{
     GenericTypeVisitable, Lift_Generic, TypeFoldable_Generic, TypeVisitable_Generic,
 };
 
+use crate::inherent::*;
 use crate::{self as ty, BoundVarIndexKind, Interner};
 
 /// Represents a constant in Rust.
@@ -159,8 +160,7 @@ pub enum ValTreeKind<I: Interner> {
     /// the fields of the variant.
     ///
     /// ZST types are represented as an empty slice.
-    // FIXME(mgca): Use a `List` here instead of a boxed slice
-    Branch(Box<[I::Const]>),
+    Branch(I::Consts),
 }
 
 impl<I: Interner> ValTreeKind<I> {
@@ -179,7 +179,7 @@ impl<I: Interner> ValTreeKind<I> {
     #[inline]
     pub fn to_branch(&self) -> &[I::Const] {
         match self {
-            ValTreeKind::Branch(branch) => &**branch,
+            ValTreeKind::Branch(branch) => branch.as_slice(),
             ValTreeKind::Leaf(..) => panic!("expected branch, got {:?}", self),
         }
     }
@@ -195,7 +195,7 @@ impl<I: Interner> ValTreeKind<I> {
     /// Attempts to convert to a `ValTreeKind::Branch` value.
     pub fn try_to_branch(&self) -> Option<&[I::Const]> {
         match self {
-            ValTreeKind::Branch(branch) => Some(&**branch),
+            ValTreeKind::Branch(branch) => Some(branch.as_slice()),
             ValTreeKind::Leaf(_) => None,
         }
     }

--- a/compiler/rustc_type_ir/src/flags.rs
+++ b/compiler/rustc_type_ir/src/flags.rs
@@ -482,8 +482,8 @@ impl<I: Interner> FlagComputation<I> {
                 match cv.valtree().kind() {
                     ty::ValTreeKind::Leaf(_) => (),
                     ty::ValTreeKind::Branch(cts) => {
-                        for ct in cts {
-                            self.add_const(*ct);
+                        for ct in cts.iter() {
+                            self.add_const(ct);
                         }
                     }
                 }

--- a/compiler/rustc_type_ir/src/inherent.rs
+++ b/compiler/rustc_type_ir/src/inherent.rs
@@ -292,12 +292,6 @@ pub trait ValueConst<I: Interner<ValueConst = Self>>: Copy + Debug + Hash + Eq {
     fn valtree(self) -> I::ValTree;
 }
 
-// FIXME(mgca): This trait can be removed once we're not using a `Box` in `Branch`
-pub trait ValTree<I: Interner<ValTree = Self>>: Copy + Debug + Hash + Eq {
-    // This isnt' `IntoKind` because then we can't return a reference
-    fn kind(&self) -> &ty::ValTreeKind<I>;
-}
-
 pub trait ExprConst<I: Interner<ExprConst = Self>>: Copy + Debug + Hash + Eq + Relate<I> {
     fn args(self) -> I::GenericArgs;
 }

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -154,7 +154,7 @@ pub trait Interner:
     type ParamConst: Copy + Debug + Hash + Eq + ParamLike;
     type ValueConst: ValueConst<Self>;
     type ExprConst: ExprConst<Self>;
-    type ValTree: ValTree<Self>;
+    type ValTree: Copy + Debug + Hash + Eq + IntoKind<Kind = ty::ValTreeKind<Self>>;
     type ScalarInt: Copy + Debug + Hash + Eq;
 
     // Kinds of regions

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -150,6 +150,7 @@ pub trait Interner:
 
     // Kinds of consts
     type Const: Const<Self>;
+    type Consts: Copy + Debug + Hash + Eq + SliceLike<Item = Self::Const> + Default;
     type ParamConst: Copy + Debug + Hash + Eq + ParamLike;
     type ValueConst: ValueConst<Self>;
     type ExprConst: ExprConst<Self>;

--- a/compiler/rustc_type_ir/src/relate.rs
+++ b/compiler/rustc_type_ir/src/relate.rs
@@ -577,8 +577,9 @@ pub fn structurally_relate_consts<I: Interner, R: TypeRelation<I>>(
                     if branches_a.len() == branches_b.len() =>
                 {
                     branches_a
-                        .into_iter()
-                        .zip(branches_b)
+                        .as_slice()
+                        .iter()
+                        .zip(branches_b.as_slice().iter())
                         .all(|(a, b)| relation.relate(*a, *b).is_ok())
                 }
                 _ => false,

--- a/compiler/rustc_type_ir/src/relate.rs
+++ b/compiler/rustc_type_ir/src/relate.rs
@@ -577,10 +577,9 @@ pub fn structurally_relate_consts<I: Interner, R: TypeRelation<I>>(
                     if branches_a.len() == branches_b.len() =>
                 {
                     branches_a
-                        .as_slice()
                         .iter()
-                        .zip(branches_b.as_slice().iter())
-                        .all(|(a, b)| relation.relate(*a, *b).is_ok())
+                        .zip(branches_b.iter())
+                        .all(|(a, b)| relation.relate(a, b).is_ok())
                 }
                 _ => false,
             }

--- a/tests/debuginfo/function-names.rs
+++ b/tests/debuginfo/function-names.rs
@@ -39,7 +39,7 @@
 // Const generic parameter
 //@ gdb-command:info functions -q function_names::const_generic_fn.*
 //@ gdb-check:[...]static fn function_names::const_generic_fn_bool<false>();
-//@ gdb-check:[...]static fn function_names::const_generic_fn_non_int<{CONST#ffa3db4ca1d52dce}>();
+//@ gdb-check:[...]static fn function_names::const_generic_fn_non_int<{CONST#6dd80cc0c950c171}>();
 //@ gdb-check:[...]static fn function_names::const_generic_fn_signed_int<-7>();
 //@ gdb-check:[...]static fn function_names::const_generic_fn_unsigned_int<14>();
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This is related to trait system refactoring. It fixes the FIXME in `ValTreeKind`

```
   // FIXME(mgca): Use a `List` here instead of a boxed slice
    Branch(Box<[I::Const]>),
```

It introduces `Interner::Consts`, changes `Branch(Box<[I::Const]>)` to `Branch(I::Consts)`, and updates all relevant places.

r? lcnr