### PR TITLE
c-variadic: implement `va_arg` for `wasm64`

### DIFF
--- a/compiler/rustc_codegen_llvm/src/va_arg.rs
+++ b/compiler/rustc_codegen_llvm/src/va_arg.rs
@@ -1122,7 +1122,7 @@ pub(super) fn emit_va_arg<'ll, 'tcx>(
             AllowHigherAlign::Yes,
             ForceRightAdjust::No,
         ),
-        Arch::Wasm32 => emit_ptr_va_arg(
+        Arch::Wasm32 | Arch::Wasm64 => emit_ptr_va_arg(
             bx,
             addr,
             target_ty,
@@ -1135,7 +1135,6 @@ pub(super) fn emit_va_arg<'ll, 'tcx>(
             AllowHigherAlign::Yes,
             ForceRightAdjust::No,
         ),
-        Arch::Wasm64 => bug!("c-variadic functions are not fully implemented for wasm64"),
         Arch::CSky => emit_ptr_va_arg(
             bx,
             addr,


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/44930

A LLVM maintainer of the wasm backend confirmed that the behavior on wasm64 is intented: the slot size is 4 on both wasm32 and wasm64. https://github.com/llvm/llvm-project/pull/173580#issuecomment-3900118960


r? workingjubilee 
cc @alexcrichton as target maintainer