### PR TITLE
Install LLVM DLL in the right place on Windows

### DIFF
--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -61,6 +61,8 @@ pub fn walk_native_lib_search_dirs<R>(
     // library directory instead of the self-contained directories.
     // Sanitizer libraries have the same issue and are also linked by name on Apple targets.
     // The targets here should be in sync with `copy_third_party_objects` in bootstrap.
+    // Finally there is shared LLVM library, which unlike compiler libraries, is linked by the name,
+    // therefore requiring the search path for the linker.
     // FIXME: implement `-Clink-self-contained=+/-unwind,+/-sanitizers`, move the shipped libunwind
     // and sanitizers to self-contained directory, and stop adding this search path.
     // FIXME: On AIX this also has the side-effect of making the list of library search paths
@@ -71,6 +73,9 @@ pub fn walk_native_lib_search_dirs<R>(
         || sess.target.os == Os::Fuchsia
         || sess.target.is_like_aix
         || sess.target.is_like_darwin && !sess.sanitizers().is_empty()
+        || sess.target.os == Os::Windows
+            && sess.target.env == Env::Gnu
+            && sess.target.abi == Abi::Llvm
     {
         f(&sess.target_tlib_path.dir, false)?;
     }

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -2557,7 +2557,7 @@ pub fn maybe_install_llvm_target(builder: &Builder<'_>, target: TargetSelection,
     ),
 )]
 pub fn maybe_install_llvm_runtime(builder: &Builder<'_>, target: TargetSelection, sysroot: &Path) {
-    let dst_libdir = sysroot.join(builder.sysroot_libdir_relative(Compiler::new(1, target)));
+    let dst_libdir = sysroot.join(builder.libdir_relative(Compiler::new(1, target)));
     // We do not need to copy LLVM files into the sysroot if it is not
     // dynamically linked; it is already included into librustc_llvm
     // statically.

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -691,6 +691,7 @@ auto:
         --target=aarch64-pc-windows-gnullvm,i686-pc-windows-gnullvm
         --enable-full-tools
         --enable-profiler
+        --enable-llvm-link-shared
       DIST_REQUIRE_ALL_TOOLS: 1
       CODEGEN_BACKENDS: llvm,cranelift
       CC_i686_pc_windows_gnullvm: i686-w64-mingw32-clang
@@ -703,6 +704,7 @@ auto:
         --build=x86_64-pc-windows-gnullvm
         --enable-full-tools
         --enable-profiler
+        --enable-llvm-link-shared
       DIST_REQUIRE_ALL_TOOLS: 1
       CODEGEN_BACKENDS: llvm,cranelift
     <<: *job-windows


### PR DESCRIPTION
Continuation of https://github.com/rust-lang/rust/pull/151795 towards https://github.com/rust-lang/rust/issues/151774.

Unlike other systems, Windows requires runtime libraries to be present in `PATH` or right next to the binary.
So, we copy the library next to the binary as the easier solution.

Tested building `rust-openssl` in debug and release modes, but the difference is within noise margin.