### PR TITLE
Rename `inline_fluent!` to `msg!`

### DIFF
--- a/compiler/rustc_ast_lowering/src/asm.rs
+++ b/compiler/rustc_ast_lowering/src/asm.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 
 use rustc_ast::*;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap};
-use rustc_errors::inline_fluent;
+use rustc_errors::msg;
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
 use rustc_session::parse::feature_err;
@@ -67,7 +67,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     &self.tcx.sess,
                     sym::asm_experimental_arch,
                     sp,
-                    inline_fluent!("inline assembly is not stable yet on this architecture"),
+                    msg!("inline assembly is not stable yet on this architecture"),
                 )
                 .emit();
             }
@@ -84,7 +84,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 &self.tcx.sess,
                 sym::asm_unwind,
                 sp,
-                inline_fluent!("the `may_unwind` option is unstable"),
+                msg!("the `may_unwind` option is unstable"),
             )
             .emit();
         }
@@ -499,9 +499,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     sess,
                     sym::asm_goto_with_outputs,
                     *op_sp,
-                    inline_fluent!(
-                        "using both label and output operands for inline assembly is unstable"
-                    ),
+                    msg!("using both label and output operands for inline assembly is unstable"),
                 )
                 .emit();
             }

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use rustc_ast::*;
 use rustc_ast_pretty::pprust::expr_to_string;
 use rustc_data_structures::stack::ensure_sufficient_stack;
-use rustc_errors::inline_fluent;
+use rustc_errors::msg;
 use rustc_hir as hir;
 use rustc_hir::attrs::AttributeKind;
 use rustc_hir::def::{DefKind, Res};
@@ -1702,7 +1702,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 &self.tcx.sess,
                 sym::yield_expr,
                 span,
-                inline_fluent!("yield syntax is experimental"),
+                msg!("yield syntax is experimental"),
             )
             .emit();
         }

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -1,6 +1,6 @@
 use rustc_ast::visit::{self, AssocCtxt, FnCtxt, FnKind, Visitor};
 use rustc_ast::{self as ast, AttrVec, NodeId, PatKind, attr, token};
-use rustc_errors::inline_fluent;
+use rustc_errors::msg;
 use rustc_feature::{AttributeGate, BUILTIN_ATTRIBUTE_MAP, BuiltinAttribute, Features};
 use rustc_session::Session;
 use rustc_session::parse::{feature_err, feature_warn};
@@ -125,7 +125,7 @@ impl<'a> PostExpansionVisitor<'a> {
             &self,
             non_lifetime_binders,
             non_lt_param_spans,
-            inline_fluent!("only lifetime parameters can be used in this context")
+            msg!("only lifetime parameters can be used in this context")
         );
 
         // FIXME(non_lifetime_binders): Const bound params are pretty broken.

--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -3,7 +3,7 @@ use std::convert::identity;
 use rustc_ast::token::Delimiter;
 use rustc_ast::tokenstream::DelimSpan;
 use rustc_ast::{AttrItem, Attribute, CRATE_NODE_ID, LitKind, ast, token};
-use rustc_errors::{Applicability, PResult, inline_fluent};
+use rustc_errors::{Applicability, PResult, msg};
 use rustc_feature::{
     AttrSuggestionStyle, AttributeTemplate, Features, GatedCfg, find_gated_cfg, template,
 };
@@ -141,7 +141,7 @@ fn parse_cfg_entry_target<S: Stage>(
             cx.sess(),
             sym::cfg_target_compact,
             meta_span,
-            inline_fluent!("compact `cfg(target(..))` is experimental and subject to change"),
+            msg!("compact `cfg(target(..))` is experimental and subject to change"),
         )
         .emit();
     }

--- a/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
@@ -1,4 +1,4 @@
-use rustc_errors::inline_fluent;
+use rustc_errors::msg;
 use rustc_feature::Features;
 use rustc_hir::attrs::AttributeKind::{LinkName, LinkOrdinal, LinkSection};
 use rustc_hir::attrs::*;
@@ -316,7 +316,7 @@ impl LinkParser {
                         sess,
                         sym::raw_dylib_elf,
                         nv.value_span,
-                        inline_fluent!("link kind `raw-dylib` is unstable on ELF platforms"),
+                        msg!("link kind `raw-dylib` is unstable on ELF platforms"),
                     )
                     .emit();
                 } else {
@@ -331,7 +331,7 @@ impl LinkParser {
                         sess,
                         sym::link_arg_attribute,
                         nv.value_span,
-                        inline_fluent!("link kind `link-arg` is unstable"),
+                        msg!("link kind `link-arg` is unstable"),
                     )
                     .emit();
                 }
@@ -396,8 +396,7 @@ impl LinkParser {
             return true;
         };
         if !features.link_cfg() {
-            feature_err(sess, sym::link_cfg, item.span(), inline_fluent!("link cfg is unstable"))
-                .emit();
+            feature_err(sess, sym::link_cfg, item.span(), msg!("link cfg is unstable")).emit();
         }
         *cfg = parse_cfg_entry(cx, link_cfg).ok();
         true

--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -4,9 +4,7 @@ use std::collections::BTreeMap;
 
 use rustc_abi::{FieldIdx, VariantIdx};
 use rustc_data_structures::fx::FxIndexMap;
-use rustc_errors::{
-    Applicability, Diag, DiagMessage, EmissionGuarantee, MultiSpan, inline_fluent, listify,
-};
+use rustc_errors::{Applicability, Diag, DiagMessage, EmissionGuarantee, MultiSpan, listify, msg};
 use rustc_hir::def::{CtorKind, Namespace};
 use rustc_hir::{
     self as hir, CoroutineKind, GenericBound, LangItem, WhereBoundPredicate, WherePredicateKind,
@@ -1313,7 +1311,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                         let mut span: MultiSpan = spans.clone().into();
                         err.arg("ty", param_ty.to_string());
                         let msg = err.dcx.eagerly_translate_to_string(
-                            inline_fluent!("`{$ty}` is made to be an `FnOnce` closure here"),
+                            msg!("`{$ty}` is made to be an `FnOnce` closure here"),
                             err.args.iter(),
                         );
                         err.remove_arg("ty");
@@ -1322,12 +1320,9 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                         }
                         span.push_span_label(
                             fn_call_span,
-                            inline_fluent!("this value implements `FnOnce`, which causes it to be moved when called"),
+                            msg!("this value implements `FnOnce`, which causes it to be moved when called"),
                         );
-                        err.span_note(
-                            span,
-                            inline_fluent!("`FnOnce` closures can only be called once"),
-                        );
+                        err.span_note(span, msg!("`FnOnce` closures can only be called once"));
                     } else {
                         err.subdiagnostic(CaptureReasonNote::FnOnceMoveInCall { var_span });
                     }
@@ -1573,6 +1568,5 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
     }
 }
 
-const LIMITATION_NOTE: DiagMessage = inline_fluent!(
-    "due to a current limitation of the type system, this implies a `'static` lifetime"
-);
+const LIMITATION_NOTE: DiagMessage =
+    msg!("due to a current limitation of the type system, this implies a `'static` lifetime");

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -1,7 +1,7 @@
 //! Error reporting machinery for lifetime errors.
 
 use rustc_data_structures::fx::FxIndexSet;
-use rustc_errors::{Applicability, Diag, ErrorGuaranteed, MultiSpan, inline_fluent};
+use rustc_errors::{Applicability, Diag, ErrorGuaranteed, MultiSpan, msg};
 use rustc_hir as hir;
 use rustc_hir::GenericBound::Trait;
 use rustc_hir::QPath::Resolved;
@@ -291,7 +291,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         if suggestions.len() > 0 {
             suggestions.dedup();
             diag.multipart_suggestion_verbose(
-                inline_fluent!("consider restricting the type parameter to the `'static` lifetime"),
+                msg!("consider restricting the type parameter to the `'static` lifetime"),
                 suggestions,
                 Applicability::MaybeIncorrect,
             );
@@ -982,18 +982,16 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 let mut multi_span: MultiSpan = vec![*span].into();
                 multi_span.push_span_label(
                     *span,
-                    inline_fluent!("this has an implicit `'static` lifetime requirement"),
+                    msg!("this has an implicit `'static` lifetime requirement"),
                 );
                 multi_span.push_span_label(
                     ident.span,
-                    inline_fluent!(
-                        "calling this method introduces the `impl`'s `'static` requirement"
-                    ),
+                    msg!("calling this method introduces the `impl`'s `'static` requirement"),
                 );
                 err.subdiagnostic(RequireStaticErr::UsedImpl { multi_span });
                 err.span_suggestion_verbose(
                     span.shrink_to_hi(),
-                    inline_fluent!("consider relaxing the implicit `'static` requirement"),
+                    msg!("consider relaxing the implicit `'static` requirement"),
                     " + '_",
                     Applicability::MaybeIncorrect,
                 );
@@ -1156,7 +1154,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         if ocx.evaluate_obligations_error_on_ambiguity().is_empty() && count > 0 {
             diag.span_suggestion_verbose(
                 tcx.hir_body(*body).value.peel_blocks().span.shrink_to_lo(),
-                inline_fluent!("dereference the return value"),
+                msg!("dereference the return value"),
                 "*".repeat(count),
                 Applicability::MachineApplicable,
             );
@@ -1200,7 +1198,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         if let Some(closure_span) = closure_span {
             diag.span_suggestion_verbose(
                 closure_span,
-                inline_fluent!("consider adding 'move' keyword before the nested closure"),
+                msg!("consider adding 'move' keyword before the nested closure"),
                 "move ",
                 Applicability::MaybeIncorrect,
             );

--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -1,7 +1,7 @@
 use rustc_errors::codes::*;
 use rustc_errors::{
     Diag, DiagCtxtHandle, Diagnostic, EmissionGuarantee, Level, MultiSpan, SingleLabelManySpans,
-    Subdiagnostic, inline_fluent,
+    Subdiagnostic, msg,
 };
 use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
 use rustc_span::{Ident, Span, Symbol};
@@ -764,7 +764,7 @@ pub(crate) struct FormatUnusedArg {
 impl Subdiagnostic for FormatUnusedArg {
     fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
         diag.arg("named", self.named);
-        let msg = diag.eagerly_translate(inline_fluent!(
+        let msg = diag.eagerly_translate(msg!(
             "{$named ->
                 [true] named argument
                 *[false] argument
@@ -947,13 +947,12 @@ pub(crate) struct AsmClobberNoReg {
 impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for AsmClobberNoReg {
     fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, G> {
         // eager translation as `span_labels` takes `AsRef<str>`
-        let lbl1 = dcx.eagerly_translate_to_string(inline_fluent!("clobber_abi"), [].into_iter());
-        let lbl2 =
-            dcx.eagerly_translate_to_string(inline_fluent!("generic outputs"), [].into_iter());
+        let lbl1 = dcx.eagerly_translate_to_string(msg!("clobber_abi"), [].into_iter());
+        let lbl2 = dcx.eagerly_translate_to_string(msg!("generic outputs"), [].into_iter());
         Diag::new(
             dcx,
             level,
-            inline_fluent!("asm with `clobber_abi` must specify explicit registers for outputs"),
+            msg!("asm with `clobber_abi` must specify explicit registers for outputs"),
         )
         .with_span(self.spans.clone())
         .with_span_labels(self.clobbers, &lbl1)

--- a/compiler/rustc_codegen_llvm/src/errors.rs
+++ b/compiler/rustc_codegen_llvm/src/errors.rs
@@ -2,7 +2,7 @@ use std::ffi::CString;
 use std::path::Path;
 
 use rustc_data_structures::small_c_str::SmallCStr;
-use rustc_errors::{Diag, DiagCtxtHandle, Diagnostic, EmissionGuarantee, Level, inline_fluent};
+use rustc_errors::{Diag, DiagCtxtHandle, Diagnostic, EmissionGuarantee, Level, msg};
 use rustc_macros::Diagnostic;
 use rustc_span::Span;
 
@@ -28,7 +28,7 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for ParseTargetMachineConfig<'_> {
         Diag::new(
             dcx,
             level,
-            inline_fluent!("failed to parse target machine config to target machine: {$error}"),
+            msg!("failed to parse target machine config to target machine: {$error}"),
         )
         .with_arg("error", message)
     }
@@ -121,25 +121,25 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for WithLlvmError<'_> {
     fn into_diag(self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
         use LlvmError::*;
         let msg_with_llvm_err = match &self.0 {
-            WriteOutput { .. } => inline_fluent!("could not write output to {$path}: {$llvm_err}"),
-            CreateTargetMachine { .. } => inline_fluent!(
-                "could not create LLVM TargetMachine for triple: {$triple}: {$llvm_err}"
-            ),
-            RunLlvmPasses => inline_fluent!("failed to run LLVM passes: {$llvm_err}"),
-            WriteIr { .. } => inline_fluent!("failed to write LLVM IR to {$path}: {$llvm_err}"),
+            WriteOutput { .. } => msg!("could not write output to {$path}: {$llvm_err}"),
+            CreateTargetMachine { .. } => {
+                msg!("could not create LLVM TargetMachine for triple: {$triple}: {$llvm_err}")
+            }
+            RunLlvmPasses => msg!("failed to run LLVM passes: {$llvm_err}"),
+            WriteIr { .. } => msg!("failed to write LLVM IR to {$path}: {$llvm_err}"),
             PrepareThinLtoContext => {
-                inline_fluent!("failed to prepare thin LTO context: {$llvm_err}")
+                msg!("failed to prepare thin LTO context: {$llvm_err}")
             }
             LoadBitcode { .. } => {
-                inline_fluent!("failed to load bitcode of module \"{$name}\": {$llvm_err}")
+                msg!("failed to load bitcode of module \"{$name}\": {$llvm_err}")
             }
             WriteThinLtoKey { .. } => {
-                inline_fluent!("error while writing ThinLTO key data: {$err}: {$llvm_err}")
+                msg!("error while writing ThinLTO key data: {$err}: {$llvm_err}")
             }
             PrepareThinLtoModule => {
-                inline_fluent!("failed to prepare thin LTO module: {$llvm_err}")
+                msg!("failed to prepare thin LTO module: {$llvm_err}")
             }
-            ParseBitcode => inline_fluent!("failed to parse bitcode for LTO module: {$llvm_err}"),
+            ParseBitcode => msg!("failed to parse bitcode for LTO module: {$llvm_err}"),
         };
         self.0
             .into_diag(dcx, level)

--- a/compiler/rustc_codegen_ssa/src/back/apple.rs
+++ b/compiler/rustc_codegen_ssa/src/back/apple.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use itertools::Itertools;
-use rustc_errors::inline_fluent;
+use rustc_errors::msg;
 use rustc_middle::middle::exported_symbols::SymbolExportKind;
 use rustc_session::Session;
 pub(super) use rustc_target::spec::apple::OSVersion;
@@ -185,21 +185,19 @@ pub(super) fn get_sdk_root(sess: &Session) -> Option<PathBuf> {
             // FIXME(madsmtm): Make this a lint, to allow deny warnings to work.
             // (Or fix <https://github.com/rust-lang/rust/issues/21204>).
             let mut diag = sess.dcx().create_warn(err);
-            diag.note(inline_fluent!("the SDK is needed by the linker to know where to find symbols in system libraries and for embedding the SDK version in the final object file"));
+            diag.note(msg!("the SDK is needed by the linker to know where to find symbols in system libraries and for embedding the SDK version in the final object file"));
 
             // Recognize common error cases, and give more Rust-specific error messages for those.
             if let Some(developer_dir) = xcode_select_developer_dir() {
                 diag.arg("developer_dir", &developer_dir);
-                diag.note(inline_fluent!(
-                    "found active developer directory at \"{$developer_dir}\""
-                ));
+                diag.note(msg!("found active developer directory at \"{$developer_dir}\""));
                 if developer_dir.as_os_str().to_string_lossy().contains("CommandLineTools") {
                     if sdk_name != "MacOSX" {
-                        diag.help(inline_fluent!("when compiling for iOS, tvOS, visionOS or watchOS, you need a full installation of Xcode"));
+                        diag.help(msg!("when compiling for iOS, tvOS, visionOS or watchOS, you need a full installation of Xcode"));
                     }
                 }
             } else {
-                diag.help(inline_fluent!("pass the path of an Xcode installation via the DEVELOPER_DIR environment variable, or an SDK with the SDKROOT environment variable"));
+                diag.help(msg!("pass the path of an Xcode installation via the DEVELOPER_DIR environment variable, or an SDK with the SDKROOT environment variable"));
             }
 
             diag.emit();

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -8,8 +8,7 @@ use std::process::ExitStatus;
 
 use rustc_errors::codes::*;
 use rustc_errors::{
-    Diag, DiagArgValue, DiagCtxtHandle, Diagnostic, EmissionGuarantee, IntoDiagArg, Level,
-    inline_fluent,
+    Diag, DiagArgValue, DiagCtxtHandle, Diagnostic, EmissionGuarantee, IntoDiagArg, Level, msg,
 };
 use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
 use rustc_middle::ty::layout::LayoutError;
@@ -217,122 +216,122 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for ThorinErrorWrapper {
     fn into_diag(self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
         let build = |msg| Diag::new(dcx, level, msg);
         match self.0 {
-            thorin::Error::ReadInput(_) => build(inline_fluent!("failed to read input file")),
+            thorin::Error::ReadInput(_) => build(msg!("failed to read input file")),
             thorin::Error::ParseFileKind(_) => {
-                build(inline_fluent!("failed to parse input file kind"))
+                build(msg!("failed to parse input file kind"))
             }
             thorin::Error::ParseObjectFile(_) => {
-                build(inline_fluent!("failed to parse input object file"))
+                build(msg!("failed to parse input object file"))
             }
             thorin::Error::ParseArchiveFile(_) => {
-                build(inline_fluent!("failed to parse input archive file"))
+                build(msg!("failed to parse input archive file"))
             }
             thorin::Error::ParseArchiveMember(_) => {
-                build(inline_fluent!("failed to parse archive member"))
+                build(msg!("failed to parse archive member"))
             }
-            thorin::Error::InvalidInputKind => build(inline_fluent!("input is not an archive or elf object")),
-            thorin::Error::DecompressData(_) => build(inline_fluent!("failed to decompress compressed section")),
+            thorin::Error::InvalidInputKind => build(msg!("input is not an archive or elf object")),
+            thorin::Error::DecompressData(_) => build(msg!("failed to decompress compressed section")),
             thorin::Error::NamelessSection(_, offset) => {
-                build(inline_fluent!("section without name at offset {$offset}"))
+                build(msg!("section without name at offset {$offset}"))
                     .with_arg("offset", format!("0x{offset:08x}"))
             }
             thorin::Error::RelocationWithInvalidSymbol(section, offset) => {
-                build(inline_fluent!("relocation with invalid symbol for section `{$section}` at offset {$offset}"))
+                build(msg!("relocation with invalid symbol for section `{$section}` at offset {$offset}"))
                     .with_arg("section", section)
                     .with_arg("offset", format!("0x{offset:08x}"))
             }
             thorin::Error::MultipleRelocations(section, offset) => {
-                build(inline_fluent!("multiple relocations for section `{$section}` at offset {$offset}"))
+                build(msg!("multiple relocations for section `{$section}` at offset {$offset}"))
                     .with_arg("section", section)
                     .with_arg("offset", format!("0x{offset:08x}"))
             }
             thorin::Error::UnsupportedRelocation(section, offset) => {
-                build(inline_fluent!("unsupported relocation for section {$section} at offset {$offset}"))
+                build(msg!("unsupported relocation for section {$section} at offset {$offset}"))
                     .with_arg("section", section)
                     .with_arg("offset", format!("0x{offset:08x}"))
             }
-            thorin::Error::MissingDwoName(id) => build(inline_fluent!("missing path attribute to DWARF object ({$id})"))
+            thorin::Error::MissingDwoName(id) => build(msg!("missing path attribute to DWARF object ({$id})"))
                 .with_arg("id", format!("0x{id:08x}")),
             thorin::Error::NoCompilationUnits => {
-                build(inline_fluent!("input object has no compilation units"))
+                build(msg!("input object has no compilation units"))
             }
-            thorin::Error::NoDie => build(inline_fluent!("no top-level debugging information entry in compilation/type unit")),
+            thorin::Error::NoDie => build(msg!("no top-level debugging information entry in compilation/type unit")),
             thorin::Error::TopLevelDieNotUnit => {
-                build(inline_fluent!("top-level debugging information entry is not a compilation/type unit"))
+                build(msg!("top-level debugging information entry is not a compilation/type unit"))
             }
             thorin::Error::MissingRequiredSection(section) => {
-                build(inline_fluent!("input object missing required section `{$section}`"))
+                build(msg!("input object missing required section `{$section}`"))
                     .with_arg("section", section)
             }
             thorin::Error::ParseUnitAbbreviations(_) => {
-                build(inline_fluent!("failed to parse unit abbreviations"))
+                build(msg!("failed to parse unit abbreviations"))
             }
             thorin::Error::ParseUnitAttribute(_) => {
-                build(inline_fluent!("failed to parse unit attribute"))
+                build(msg!("failed to parse unit attribute"))
             }
             thorin::Error::ParseUnitHeader(_) => {
-                build(inline_fluent!("failed to parse unit header"))
+                build(msg!("failed to parse unit header"))
             }
-            thorin::Error::ParseUnit(_) => build(inline_fluent!("failed to parse unit")),
+            thorin::Error::ParseUnit(_) => build(msg!("failed to parse unit")),
             thorin::Error::IncompatibleIndexVersion(section, format, actual) => {
-                build(inline_fluent!("incompatible `{$section}` index version: found version {$actual}, expected version {$format}"))
+                build(msg!("incompatible `{$section}` index version: found version {$actual}, expected version {$format}"))
                     .with_arg("section", section)
                     .with_arg("actual", actual)
                     .with_arg("format", format)
             }
             thorin::Error::OffsetAtIndex(_, index) => {
-                build(inline_fluent!("read offset at index {$index} of `.debug_str_offsets.dwo` section")).with_arg("index", index)
+                build(msg!("read offset at index {$index} of `.debug_str_offsets.dwo` section")).with_arg("index", index)
             }
             thorin::Error::StrAtOffset(_, offset) => {
-                build(inline_fluent!("read string at offset {$offset} of `.debug_str.dwo` section"))
+                build(msg!("read string at offset {$offset} of `.debug_str.dwo` section"))
                     .with_arg("offset", format!("0x{offset:08x}"))
             }
             thorin::Error::ParseIndex(_, section) => {
-                build(inline_fluent!("failed to parse `{$section}` index section")).with_arg("section", section)
+                build(msg!("failed to parse `{$section}` index section")).with_arg("section", section)
             }
             thorin::Error::UnitNotInIndex(unit) => {
-                build(inline_fluent!("unit {$unit} from input package is not in its index"))
+                build(msg!("unit {$unit} from input package is not in its index"))
                     .with_arg("unit", format!("0x{unit:08x}"))
             }
             thorin::Error::RowNotInIndex(_, row) => {
-                build(inline_fluent!("row {$row} found in index's hash table not present in index")).with_arg("row", row)
+                build(msg!("row {$row} found in index's hash table not present in index")).with_arg("row", row)
             }
-            thorin::Error::SectionNotInRow => build(inline_fluent!("section not found in unit's row in index")),
-            thorin::Error::EmptyUnit(unit) => build(inline_fluent!("unit {$unit} in input DWARF object with no data"))
+            thorin::Error::SectionNotInRow => build(msg!("section not found in unit's row in index")),
+            thorin::Error::EmptyUnit(unit) => build(msg!("unit {$unit} in input DWARF object with no data"))
                 .with_arg("unit", format!("0x{unit:08x}")),
             thorin::Error::MultipleDebugInfoSection => {
-                build(inline_fluent!("multiple `.debug_info.dwo` sections"))
+                build(msg!("multiple `.debug_info.dwo` sections"))
             }
             thorin::Error::MultipleDebugTypesSection => {
-                build(inline_fluent!("multiple `.debug_types.dwo` sections in a package"))
+                build(msg!("multiple `.debug_types.dwo` sections in a package"))
             }
-            thorin::Error::NotSplitUnit => build(inline_fluent!("regular compilation unit in object (missing dwo identifier)")),
-            thorin::Error::DuplicateUnit(unit) => build(inline_fluent!("duplicate split compilation unit ({$unit})"))
+            thorin::Error::NotSplitUnit => build(msg!("regular compilation unit in object (missing dwo identifier)")),
+            thorin::Error::DuplicateUnit(unit) => build(msg!("duplicate split compilation unit ({$unit})"))
                 .with_arg("unit", format!("0x{unit:08x}")),
             thorin::Error::MissingReferencedUnit(unit) => {
-                build(inline_fluent!("unit {$unit} referenced by executable was not found"))
+                build(msg!("unit {$unit} referenced by executable was not found"))
                     .with_arg("unit", format!("0x{unit:08x}"))
             }
             thorin::Error::NoOutputObjectCreated => {
-                build(inline_fluent!("no output object was created from inputs"))
+                build(msg!("no output object was created from inputs"))
             }
             thorin::Error::MixedInputEncodings => {
-                build(inline_fluent!("input objects have mixed encodings"))
+                build(msg!("input objects have mixed encodings"))
             }
             thorin::Error::Io(e) => {
-                build(inline_fluent!("{$error}")).with_arg("error", format!("{e}"))
+                build(msg!("{$error}")).with_arg("error", format!("{e}"))
             }
             thorin::Error::ObjectRead(e) => {
-                build(inline_fluent!("{$error}")).with_arg("error", format!("{e}"))
+                build(msg!("{$error}")).with_arg("error", format!("{e}"))
             }
             thorin::Error::ObjectWrite(e) => {
-                build(inline_fluent!("{$error}")).with_arg("error", format!("{e}"))
+                build(msg!("{$error}")).with_arg("error", format!("{e}"))
             }
             thorin::Error::GimliRead(e) => {
-                build(inline_fluent!("{$error}")).with_arg("error", format!("{e}"))
+                build(msg!("{$error}")).with_arg("error", format!("{e}"))
             }
             thorin::Error::GimliWrite(e) => {
-                build(inline_fluent!("{$error}")).with_arg("error", format!("{e}"))
+                build(msg!("{$error}")).with_arg("error", format!("{e}"))
             }
             _ => unimplemented!("Untranslated thorin error"),
         }
@@ -350,11 +349,8 @@ pub(crate) struct LinkingFailed<'a> {
 
 impl<G: EmissionGuarantee> Diagnostic<'_, G> for LinkingFailed<'_> {
     fn into_diag(mut self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
-        let mut diag = Diag::new(
-            dcx,
-            level,
-            inline_fluent!("linking with `{$linker_path}` failed: {$exit_status}"),
-        );
+        let mut diag =
+            Diag::new(dcx, level, msg!("linking with `{$linker_path}` failed: {$exit_status}"));
         diag.arg("linker_path", format!("{}", self.linker_path.display()));
         diag.arg("exit_status", format!("{}", self.exit_status));
 
@@ -463,11 +459,11 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for LinkingFailed<'_> {
         // Trying to match an error from OS linkers
         // which by now we have no way to translate.
         if contains_undefined_ref {
-            diag.note(inline_fluent!("some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified"))
-                .note(inline_fluent!("use the `-l` flag to specify native libraries to link"));
+            diag.note(msg!("some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified"))
+                .note(msg!("use the `-l` flag to specify native libraries to link"));
 
             if rustc_session::utils::was_invoked_from_cargo() {
-                diag.note(inline_fluent!("use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-link-lib)"));
+                diag.note(msg!("use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-link-lib)"));
             }
         }
         diag
@@ -482,12 +478,11 @@ pub(crate) struct LinkExeStatusStackBufferOverrun;
 
 impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for LinkExeStatusStackBufferOverrun {
     fn into_diag(self, dcx: rustc_errors::DiagCtxtHandle<'a>, level: Level) -> Diag<'a, G> {
-        let mut diag =
-            Diag::new(dcx, level, inline_fluent!("0xc0000409 is `STATUS_STACK_BUFFER_OVERRUN`"));
-        diag.note(inline_fluent!(
+        let mut diag = Diag::new(dcx, level, msg!("0xc0000409 is `STATUS_STACK_BUFFER_OVERRUN`"));
+        diag.note(msg!(
             "this may have been caused by a program abort and not a stack buffer overrun"
         ));
-        diag.note(inline_fluent!("consider checking the Application Event Log for Windows Error Reporting events to see the fail fast error code"));
+        diag.note(msg!("consider checking the Application Event Log for Windows Error Reporting events to see the fail fast error code"));
         diag
     }
 }
@@ -1233,9 +1228,7 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for TargetFeatureDisableOrEnable<'_
         let mut diag = Diag::new(
             dcx,
             level,
-            inline_fluent!(
-                "the target features {$features} must all be either enabled or disabled together"
-            ),
+            msg!("the target features {$features} must all be either enabled or disabled together"),
         );
         if let Some(span) = self.span {
             diag.span(span);

--- a/compiler/rustc_const_eval/src/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/check_consts/ops.rs
@@ -2,7 +2,7 @@
 
 use hir::{ConstContext, LangItem};
 use rustc_errors::codes::*;
-use rustc_errors::{Applicability, Diag, MultiSpan, inline_fluent};
+use rustc_errors::{Applicability, Diag, MultiSpan, msg};
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_infer::infer::TyCtxtInferExt;
@@ -181,7 +181,7 @@ impl<'tcx> NonConstOp<'tcx> for FnCallNonConst<'tcx> {
         );
 
         if let ConstContext::Static(_) = ccx.const_kind() {
-            err.note(inline_fluent!(
+            err.note(msg!(
                 "consider wrapping this expression in `std::sync::LazyLock::new(|| ...)`"
             ));
         }

--- a/compiler/rustc_const_eval/src/const_eval/error.rs
+++ b/compiler/rustc_const_eval/src/const_eval/error.rs
@@ -43,40 +43,36 @@ pub enum ConstEvalErrKind {
 impl MachineStopType for ConstEvalErrKind {
     fn diagnostic_message(&self) -> DiagMessage {
         use ConstEvalErrKind::*;
-        use rustc_errors::inline_fluent;
+        use rustc_errors::msg;
 
         match self {
             ConstAccessesMutGlobal => "constant accesses mutable global memory".into(),
             ModifiedGlobal => {
                 "modifying a static's initial value from another static's initializer".into()
             }
-            Panic { .. } => inline_fluent!("evaluation panicked: {$msg}"),
+            Panic { .. } => msg!("evaluation panicked: {$msg}"),
             RecursiveStatic => {
                 "encountered static that tried to access itself during initialization".into()
             }
             AssertFailure(x) => x.diagnostic_message(),
             WriteThroughImmutablePointer => {
-                inline_fluent!(
+                msg!(
                     "writing through a pointer that was derived from a shared (immutable) reference"
                 )
             }
             ConstMakeGlobalPtrAlreadyMadeGlobal { .. } => {
-                inline_fluent!(
-                    "attempting to call `const_make_global` twice on the same allocation {$alloc}"
-                )
+                msg!("attempting to call `const_make_global` twice on the same allocation {$alloc}")
             }
             ConstMakeGlobalPtrIsNonHeap(_) => {
-                inline_fluent!(
+                msg!(
                     "pointer passed to `const_make_global` does not point to a heap allocation: {$ptr}"
                 )
             }
             ConstMakeGlobalWithDanglingPtr(_) => {
-                inline_fluent!("pointer passed to `const_make_global` is dangling: {$ptr}")
+                msg!("pointer passed to `const_make_global` is dangling: {$ptr}")
             }
             ConstMakeGlobalWithOffset(_) => {
-                inline_fluent!(
-                    "making {$ptr} global which does not point to the beginning of an object"
-                )
+                msg!("making {$ptr} global which does not point to the beginning of an object")
             }
         }
     }

--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::Ordering::Relaxed;
 
 use either::{Left, Right};
 use rustc_abi::{self as abi, BackendRepr};
-use rustc_errors::{E0080, inline_fluent};
+use rustc_errors::{E0080, msg};
 use rustc_hir::def::DefKind;
 use rustc_middle::mir::interpret::{AllocId, ErrorHandled, InterpErrorInfo, ReportedErrorInfo};
 use rustc_middle::mir::{self, ConstAlloc, ConstValue};
@@ -469,7 +469,7 @@ fn report_eval_error<'tcx>(
             diag.code(E0080);
             diag.span_label(
                 span,
-                inline_fluent!(
+                msg!(
                     "evaluation of `{$instance}` failed {$num_frames ->
                         [0] here
                         *[other] inside this call

--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -5,7 +5,7 @@ use std::hash::Hash;
 use rustc_abi::{Align, Size};
 use rustc_ast::Mutability;
 use rustc_data_structures::fx::{FxHashMap, FxIndexMap, IndexEntry};
-use rustc_errors::inline_fluent;
+use rustc_errors::msg;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::{self as hir, CRATE_HIR_ID, LangItem};
 use rustc_middle::mir::AssertMessage;
@@ -489,7 +489,7 @@ impl<'tcx> interpret::Machine<'tcx> for CompileTimeMachine<'tcx> {
                 let align = match Align::from_bytes(align) {
                     Ok(a) => a,
                     Err(err) => throw_ub_custom!(
-                        inline_fluent!(
+                        msg!(
                             "invalid align passed to `{$name}`: {$align} is {$err_kind ->
                                 [not_power_of_two] not a power of 2
                                 [too_large] too large
@@ -519,7 +519,7 @@ impl<'tcx> interpret::Machine<'tcx> for CompileTimeMachine<'tcx> {
                 let align = match Align::from_bytes(align) {
                     Ok(a) => a,
                     Err(err) => throw_ub_custom!(
-                        inline_fluent!(
+                        msg!(
                             "invalid align passed to `{$name}`: {$align} is {$err_kind ->
                                 [not_power_of_two] not a power of 2
                                 [too_large] too large

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -6,7 +6,7 @@ use rustc_abi::WrappingRange;
 use rustc_errors::codes::*;
 use rustc_errors::{
     Diag, DiagArgValue, DiagMessage, Diagnostic, EmissionGuarantee, Level, MultiSpan,
-    Subdiagnostic, inline_fluent,
+    Subdiagnostic, msg,
 };
 use rustc_hir::ConstContext;
 use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
@@ -389,9 +389,9 @@ impl Subdiagnostic for FrameNote {
         diag.arg("instance", self.instance);
         let mut span: MultiSpan = self.span.into();
         if self.has_label && !self.span.is_dummy() {
-            span.push_span_label(self.span, inline_fluent!("the failure occurred here"));
+            span.push_span_label(self.span, msg!("the failure occurred here"));
         }
-        let msg = diag.eagerly_translate(inline_fluent!(
+        let msg = diag.eagerly_translate(msg!(
             r#"{$times ->
                 [0] inside {$where_ ->
                     [closure] closure
@@ -653,25 +653,25 @@ impl<'a> ReportErrorExt for UndefinedBehaviorInfo<'a> {
             ValidationError(e) => e.diagnostic_message(),
 
             Unreachable => "entering unreachable code".into(),
-            BoundsCheckFailed { .. } => inline_fluent!("indexing out of bounds: the len is {$len} but the index is {$index}"),
+            BoundsCheckFailed { .. } => msg!("indexing out of bounds: the len is {$len} but the index is {$index}"),
             DivisionByZero => "dividing by zero".into(),
             RemainderByZero => "calculating the remainder with a divisor of zero".into(),
             DivisionOverflow => "overflow in signed division (dividing MIN by -1)".into(),
             RemainderOverflow => "overflow in signed remainder (dividing MIN by -1)".into(),
             PointerArithOverflow => "overflowing pointer arithmetic: the total offset in bytes does not fit in an `isize`".into(),
-            ArithOverflow { .. } => inline_fluent!("arithmetic overflow in `{$intrinsic}`"),
-            ShiftOverflow { .. } => inline_fluent!("overflowing shift by {$shift_amount} in `{$intrinsic}`"),
+            ArithOverflow { .. } => msg!("arithmetic overflow in `{$intrinsic}`"),
+            ShiftOverflow { .. } => msg!("overflowing shift by {$shift_amount} in `{$intrinsic}`"),
             InvalidMeta(InvalidMetaKind::SliceTooBig) => "invalid metadata in wide pointer: slice is bigger than largest supported object".into(),
             InvalidMeta(InvalidMetaKind::TooBig) => "invalid metadata in wide pointer: total size is bigger than largest supported object".into(),
             UnterminatedCString(_) => "reading a null-terminated string starting at {$pointer} with no null found before end of allocation".into(),
-            PointerUseAfterFree(_, _) => inline_fluent!(
+            PointerUseAfterFree(_, _) => msg!(
                 "{$operation ->
                     [MemoryAccess] memory access failed
                     [InboundsPointerArithmetic] in-bounds pointer arithmetic failed
                     *[Dereferenceable] pointer not dereferenceable
                 }: {$alloc_id} has been freed, so this pointer is dangling"
             ),
-            PointerOutOfBounds { .. } => inline_fluent!(
+            PointerOutOfBounds { .. } => msg!(
                 "{$operation ->
                     [MemoryAccess] memory access failed
                     [InboundsPointerArithmetic] in-bounds pointer arithmetic failed
@@ -708,7 +708,7 @@ impl<'a> ReportErrorExt for UndefinedBehaviorInfo<'a> {
                     }
                 }"
             ),
-            DanglingIntPointer { addr: 0, .. } => inline_fluent!(
+            DanglingIntPointer { addr: 0, .. } => msg!(
                 "{$operation ->
                     [MemoryAccess] memory access failed
                     [InboundsPointerArithmetic] in-bounds pointer arithmetic failed
@@ -728,7 +728,7 @@ impl<'a> ReportErrorExt for UndefinedBehaviorInfo<'a> {
                         *[x] be dereferenceable for {$inbounds_size} bytes
                     }
                 }, but got null pointer"),
-            DanglingIntPointer { .. } => inline_fluent!(
+            DanglingIntPointer { .. } => msg!(
                 "{$operation ->
                     [MemoryAccess] memory access failed
                     [InboundsPointerArithmetic] in-bounds pointer arithmetic failed
@@ -748,34 +748,34 @@ impl<'a> ReportErrorExt for UndefinedBehaviorInfo<'a> {
                         *[x] be dereferenceable for {$inbounds_size} bytes
                     }
                 }, but got {$pointer} which is a dangling pointer (it has no provenance)"),
-            AlignmentCheckFailed { .. } => inline_fluent!(
+            AlignmentCheckFailed { .. } => msg!(
                 "{$msg ->
                     [AccessedPtr] accessing memory
                     *[other] accessing memory based on pointer
                 } with alignment {$has}, but alignment {$required} is required"
             ),
-            WriteToReadOnly(_) => inline_fluent!("writing to {$allocation} which is read-only"),
-            DerefFunctionPointer(_) => inline_fluent!("accessing {$allocation} which contains a function"),
-            DerefVTablePointer(_) => inline_fluent!("accessing {$allocation} which contains a vtable"),
-            DerefTypeIdPointer(_) => inline_fluent!("accessing {$allocation} which contains a `TypeId`"),
-            InvalidBool(_) => inline_fluent!("interpreting an invalid 8-bit value as a bool: 0x{$value}"),
-            InvalidChar(_) => inline_fluent!("interpreting an invalid 32-bit value as a char: 0x{$value}"),
-            InvalidTag(_) => inline_fluent!("enum value has invalid tag: {$tag}"),
-            InvalidFunctionPointer(_) => inline_fluent!("using {$pointer} as function pointer but it does not point to a function"),
-            InvalidVTablePointer(_) => inline_fluent!("using {$pointer} as vtable pointer but it does not point to a vtable"),
-            InvalidVTableTrait { .. } => inline_fluent!("using vtable for `{$vtable_dyn_type}` but `{$expected_dyn_type}` was expected"),
-            InvalidStr(_) => inline_fluent!("this string is not valid UTF-8: {$err}"),
+            WriteToReadOnly(_) => msg!("writing to {$allocation} which is read-only"),
+            DerefFunctionPointer(_) => msg!("accessing {$allocation} which contains a function"),
+            DerefVTablePointer(_) => msg!("accessing {$allocation} which contains a vtable"),
+            DerefTypeIdPointer(_) => msg!("accessing {$allocation} which contains a `TypeId`"),
+            InvalidBool(_) => msg!("interpreting an invalid 8-bit value as a bool: 0x{$value}"),
+            InvalidChar(_) => msg!("interpreting an invalid 32-bit value as a char: 0x{$value}"),
+            InvalidTag(_) => msg!("enum value has invalid tag: {$tag}"),
+            InvalidFunctionPointer(_) => msg!("using {$pointer} as function pointer but it does not point to a function"),
+            InvalidVTablePointer(_) => msg!("using {$pointer} as vtable pointer but it does not point to a vtable"),
+            InvalidVTableTrait { .. } => msg!("using vtable for `{$vtable_dyn_type}` but `{$expected_dyn_type}` was expected"),
+            InvalidStr(_) => msg!("this string is not valid UTF-8: {$err}"),
             InvalidUninitBytes(None) => "using uninitialized data, but this operation requires initialized memory".into(),
-            InvalidUninitBytes(Some(_)) => inline_fluent!("reading memory at {$alloc}{$access}, but memory is uninitialized at {$uninit}, and this operation requires initialized memory"),
+            InvalidUninitBytes(Some(_)) => msg!("reading memory at {$alloc}{$access}, but memory is uninitialized at {$uninit}, and this operation requires initialized memory"),
             DeadLocal => "accessing a dead local variable".into(),
-            ScalarSizeMismatch(_) => inline_fluent!("scalar size mismatch: expected {$target_size} bytes but got {$data_size} bytes instead"),
+            ScalarSizeMismatch(_) => msg!("scalar size mismatch: expected {$target_size} bytes but got {$data_size} bytes instead"),
             UninhabitedEnumVariantWritten(_) => "writing discriminant of an uninhabited enum variant".into(),
             UninhabitedEnumVariantRead(_) => "read discriminant of an uninhabited enum variant".into(),
             InvalidNichedEnumVariantWritten { .. } => {
-                inline_fluent!("trying to set discriminant of a {$ty} to the niched variant, but the value does not match")
+                msg!("trying to set discriminant of a {$ty} to the niched variant, but the value does not match")
             }
-            AbiMismatchArgument { .. } => inline_fluent!("calling a function whose parameter #{$arg_idx} has type {$callee_ty} passing argument of type {$caller_ty}"),
-            AbiMismatchReturn { .. } => inline_fluent!("calling a function with return type {$callee_ty} passing return place of type {$caller_ty}"),
+            AbiMismatchArgument { .. } => msg!("calling a function whose parameter #{$arg_idx} has type {$callee_ty} passing argument of type {$caller_ty}"),
+            AbiMismatchReturn { .. } => msg!("calling a function with return type {$callee_ty} passing return place of type {$caller_ty}"),
         }
     }
 
@@ -920,29 +920,25 @@ impl<'tcx> ReportErrorExt for ValidationErrorInfo<'tcx> {
 
         match self.kind {
             PtrToUninhabited { ptr_kind: PointerKind::Box, .. } => {
-                inline_fluent!(
-                    "{$front_matter}: encountered a box pointing to uninhabited type {$ty}"
-                )
+                msg!("{$front_matter}: encountered a box pointing to uninhabited type {$ty}")
             }
             PtrToUninhabited { ptr_kind: PointerKind::Ref(_), .. } => {
-                inline_fluent!(
-                    "{$front_matter}: encountered a reference pointing to uninhabited type {$ty}"
-                )
+                msg!("{$front_matter}: encountered a reference pointing to uninhabited type {$ty}")
             }
 
             PointerAsInt { .. } => {
-                inline_fluent!("{$front_matter}: encountered a pointer, but {$expected}")
+                msg!("{$front_matter}: encountered a pointer, but {$expected}")
             }
-            PartialPointer => inline_fluent!(
-                "{$front_matter}: encountered a partial pointer or a mix of pointers"
-            ),
+            PartialPointer => {
+                msg!("{$front_matter}: encountered a partial pointer or a mix of pointers")
+            }
             MutableRefToImmutable => {
-                inline_fluent!(
+                msg!(
                     "{$front_matter}: encountered mutable reference or box pointing to read-only memory"
                 )
             }
             NullFnPtr { .. } => {
-                inline_fluent!(
+                msg!(
                     "{$front_matter}: encountered a {$maybe ->
                         [true] maybe-null
                         *[false] null
@@ -950,84 +946,78 @@ impl<'tcx> ReportErrorExt for ValidationErrorInfo<'tcx> {
                 )
             }
             NeverVal => {
-                inline_fluent!("{$front_matter}: encountered a value of the never type `!`")
+                msg!("{$front_matter}: encountered a value of the never type `!`")
             }
             NonnullPtrMaybeNull { .. } => {
-                inline_fluent!(
+                msg!(
                     "{$front_matter}: encountered a maybe-null pointer, but expected something that is definitely non-zero"
                 )
             }
             PtrOutOfRange { .. } => {
-                inline_fluent!(
+                msg!(
                     "{$front_matter}: encountered a pointer with unknown absolute address, but expected something that is definitely {$in_range}"
                 )
             }
             OutOfRange { .. } => {
-                inline_fluent!(
-                    "{$front_matter}: encountered {$value}, but expected something {$in_range}"
-                )
+                msg!("{$front_matter}: encountered {$value}, but expected something {$in_range}")
             }
             UnsafeCellInImmutable => {
-                inline_fluent!("{$front_matter}: encountered `UnsafeCell` in read-only memory")
+                msg!("{$front_matter}: encountered `UnsafeCell` in read-only memory")
             }
             UninhabitedVal { .. } => {
-                inline_fluent!("{$front_matter}: encountered a value of uninhabited type `{$ty}`")
+                msg!("{$front_matter}: encountered a value of uninhabited type `{$ty}`")
             }
             InvalidEnumTag { .. } => {
-                inline_fluent!(
-                    "{$front_matter}: encountered {$value}, but expected a valid enum tag"
-                )
+                msg!("{$front_matter}: encountered {$value}, but expected a valid enum tag")
             }
             UninhabitedEnumVariant => {
-                inline_fluent!("{$front_matter}: encountered an uninhabited enum variant")
+                msg!("{$front_matter}: encountered an uninhabited enum variant")
             }
             Uninit { .. } => {
-                inline_fluent!("{$front_matter}: encountered uninitialized memory, but {$expected}")
+                msg!("{$front_matter}: encountered uninitialized memory, but {$expected}")
             }
             InvalidVTablePtr { .. } => {
-                inline_fluent!(
-                    "{$front_matter}: encountered {$value}, but expected a vtable pointer"
-                )
+                msg!("{$front_matter}: encountered {$value}, but expected a vtable pointer")
             }
             InvalidMetaWrongTrait { .. } => {
-                inline_fluent!(
+                msg!(
                     "{$front_matter}: wrong trait in wide pointer vtable: expected `{$expected_dyn_type}`, but encountered `{$vtable_dyn_type}`"
                 )
             }
             InvalidMetaSliceTooLarge { ptr_kind: PointerKind::Box } => {
-                inline_fluent!(
+                msg!(
                     "{$front_matter}: encountered invalid box metadata: slice is bigger than largest supported object"
                 )
             }
             InvalidMetaSliceTooLarge { ptr_kind: PointerKind::Ref(_) } => {
-                inline_fluent!(
+                msg!(
                     "{$front_matter}: encountered invalid reference metadata: slice is bigger than largest supported object"
                 )
             }
 
             InvalidMetaTooLarge { ptr_kind: PointerKind::Box } => {
-                inline_fluent!(
+                msg!(
                     "{$front_matter}: encountered invalid box metadata: total size is bigger than largest supported object"
                 )
             }
             InvalidMetaTooLarge { ptr_kind: PointerKind::Ref(_) } => {
-                inline_fluent!(
+                msg!(
                     "{$front_matter}: encountered invalid reference metadata: total size is bigger than largest supported object"
                 )
             }
             UnalignedPtr { ptr_kind: PointerKind::Ref(_), .. } => {
-                inline_fluent!(
+                msg!(
                     "{$front_matter}: encountered an unaligned reference (required {$required_bytes} byte alignment but found {$found_bytes})"
                 )
             }
             UnalignedPtr { ptr_kind: PointerKind::Box, .. } => {
-                inline_fluent!(
+                msg!(
                     "{$front_matter}: encountered an unaligned box (required {$required_bytes} byte alignment but found {$found_bytes})"
                 )
             }
 
             NullPtr { ptr_kind: PointerKind::Box, .. } => {
-                inline_fluent!(
+                msg!(
                     "{$front_matter}: encountered a {$maybe ->
                         [true] maybe-null
                         *[false] null
@@ -1035,7 +1025,7 @@ impl<'tcx> ReportErrorExt for ValidationErrorInfo<'tcx> {
                 )
             }
             NullPtr { ptr_kind: PointerKind::Ref(_), .. } => {
-                inline_fluent!(
+                msg!(
                     "{$front_matter}: encountered a {$maybe ->
                         [true] maybe-null
                         *[false] null
@@ -1043,66 +1033,59 @@ impl<'tcx> ReportErrorExt for ValidationErrorInfo<'tcx> {
                 )
             }
             DanglingPtrNoProvenance { ptr_kind: PointerKind::Box, .. } => {
-                inline_fluent!(
-                    "{$front_matter}: encountered a dangling box ({$pointer} has no provenance)"
-                )
+                msg!("{$front_matter}: encountered a dangling box ({$pointer} has no provenance)")
             }
             DanglingPtrNoProvenance { ptr_kind: PointerKind::Ref(_), .. } => {
-                inline_fluent!(
+                msg!(
                     "{$front_matter}: encountered a dangling reference ({$pointer} has no provenance)"
                 )
             }
             DanglingPtrOutOfBounds { ptr_kind: PointerKind::Box } => {
-                inline_fluent!(
+                msg!(
                     "{$front_matter}: encountered a dangling box (going beyond the bounds of its allocation)"
                 )
             }
             DanglingPtrOutOfBounds { ptr_kind: PointerKind::Ref(_) } => {
-                inline_fluent!(
+                msg!(
                     "{$front_matter}: encountered a dangling reference (going beyond the bounds of its allocation)"
                 )
             }
             DanglingPtrUseAfterFree { ptr_kind: PointerKind::Box } => {
-                inline_fluent!("{$front_matter}: encountered a dangling box (use-after-free)")
+                msg!("{$front_matter}: encountered a dangling box (use-after-free)")
             }
             DanglingPtrUseAfterFree { ptr_kind: PointerKind::Ref(_) } => {
-                inline_fluent!("{$front_matter}: encountered a dangling reference (use-after-free)")
+                msg!("{$front_matter}: encountered a dangling reference (use-after-free)")
             }
             InvalidBool { .. } => {
-                inline_fluent!("{$front_matter}: encountered {$value}, but expected a boolean")
+                msg!("{$front_matter}: encountered {$value}, but expected a boolean")
             }
             InvalidChar { .. } => {
-                inline_fluent!(
+                msg!(
                     "{$front_matter}: encountered {$value}, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)"
                 )
             }
             InvalidFnPtr { .. } => {
-                inline_fluent!(
-                    "{$front_matter}: encountered {$value}, but expected a function pointer"
-                )
+                msg!("{$front_matter}: encountered {$value}, but expected a function pointer")
             }
         }
     }
 
     fn add_args<G: EmissionGuarantee>(self, err: &mut Diag<'_, G>) {
-        use rustc_errors::inline_fluent;
+        use rustc_errors::msg;
         use rustc_middle::mir::interpret::ValidationErrorKind::*;
 
         if let PointerAsInt { .. } | PartialPointer = self.kind {
-            err.help(inline_fluent!("this code performed an operation that depends on the underlying bytes representing a pointer"));
-            err.help(inline_fluent!("the absolute address of a pointer is not known at compile-time, so such operations are not supported"));
+            err.help(msg!("this code performed an operation that depends on the underlying bytes representing a pointer"));
+            err.help(msg!("the absolute address of a pointer is not known at compile-time, so such operations are not supported"));
         }
 
         let message = if let Some(path) = self.path {
             err.dcx.eagerly_translate_to_string(
-                inline_fluent!("constructing invalid value at {$path}"),
+                msg!("constructing invalid value at {$path}"),
                 [("path".into(), DiagArgValue::Str(path.into()))].iter().map(|(a, b)| (a, b)),
             )
         } else {
-            err.dcx.eagerly_translate_to_string(
-                inline_fluent!("constructing invalid value"),
-                [].into_iter(),
-            )
+            err.dcx.eagerly_translate_to_string(msg!("constructing invalid value"), [].into_iter())
         };
 
         err.arg("front_matter", message);
@@ -1115,17 +1098,17 @@ impl<'tcx> ReportErrorExt for ValidationErrorInfo<'tcx> {
             let WrappingRange { start: lo, end: hi } = r;
             assert!(hi <= max_hi);
             let msg = if lo > hi {
-                inline_fluent!("less or equal to {$hi}, or greater or equal to {$lo}")
+                msg!("less or equal to {$hi}, or greater or equal to {$lo}")
             } else if lo == hi {
-                inline_fluent!("equal to {$lo}")
+                msg!("equal to {$lo}")
             } else if lo == 0 {
                 assert!(hi < max_hi, "should not be printing if the range covers everything");
-                inline_fluent!("less or equal to {$hi}")
+                msg!("less or equal to {$hi}")
             } else if hi == max_hi {
                 assert!(lo > 0, "should not be printing if the range covers everything");
-                inline_fluent!("greater or equal to {$lo}")
+                msg!("greater or equal to {$lo}")
             } else {
-                inline_fluent!("in the range {$lo}..={$hi}")
+                msg!("in the range {$lo}..={$hi}")
             };
 
             let args = [
@@ -1143,17 +1126,17 @@ impl<'tcx> ReportErrorExt for ValidationErrorInfo<'tcx> {
             }
             PointerAsInt { expected } | Uninit { expected } => {
                 let msg = match expected {
-                    ExpectedKind::Reference => inline_fluent!("expected a reference"),
-                    ExpectedKind::Box => inline_fluent!("expected a box"),
-                    ExpectedKind::RawPtr => inline_fluent!("expected a raw pointer"),
-                    ExpectedKind::InitScalar => inline_fluent!("expected initialized scalar value"),
-                    ExpectedKind::Bool => inline_fluent!("expected a boolean"),
-                    ExpectedKind::Char => inline_fluent!("expected a unicode scalar value"),
-                    ExpectedKind::Float => inline_fluent!("expected a floating point number"),
-                    ExpectedKind::Int => inline_fluent!("expected an integer"),
-                    ExpectedKind::FnPtr => inline_fluent!("expected a function pointer"),
-                    ExpectedKind::EnumTag => inline_fluent!("expected a valid enum tag"),
-                    ExpectedKind::Str => inline_fluent!("expected a string"),
+                    ExpectedKind::Reference => msg!("expected a reference"),
+                    ExpectedKind::Box => msg!("expected a box"),
+                    ExpectedKind::RawPtr => msg!("expected a raw pointer"),
+                    ExpectedKind::InitScalar => msg!("expected initialized scalar value"),
+                    ExpectedKind::Bool => msg!("expected a boolean"),
+                    ExpectedKind::Char => msg!("expected a unicode scalar value"),
+                    ExpectedKind::Float => msg!("expected a floating point number"),
+                    ExpectedKind::Int => msg!("expected an integer"),
+                    ExpectedKind::FnPtr => msg!("expected a function pointer"),
+                    ExpectedKind::EnumTag => msg!("expected a valid enum tag"),
+                    ExpectedKind::Str => msg!("expected a string"),
                 };
                 let msg = err.dcx.eagerly_translate_to_string(msg, [].into_iter());
                 err.arg("expected", msg);
@@ -1207,14 +1190,14 @@ impl ReportErrorExt for UnsupportedOpInfo {
             }
             UnsupportedOpInfo::UnsizedLocal => "unsized locals are not supported".into(),
             UnsupportedOpInfo::ReadPartialPointer(_) => {
-                inline_fluent!("unable to read parts of a pointer from memory at {$ptr}")
+                msg!("unable to read parts of a pointer from memory at {$ptr}")
             }
             UnsupportedOpInfo::ReadPointerAsInt(_) => "unable to turn pointer into integer".into(),
             UnsupportedOpInfo::ThreadLocalStatic(_) => {
-                inline_fluent!("cannot access thread local static `{$did}`")
+                msg!("cannot access thread local static `{$did}`")
             }
             UnsupportedOpInfo::ExternStatic(_) => {
-                inline_fluent!("cannot access extern static `{$did}`")
+                msg!("cannot access extern static `{$did}`")
             }
         }
         .into()

--- a/compiler/rustc_const_eval/src/interpret/call.rs
+++ b/compiler/rustc_const_eval/src/interpret/call.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 use either::{Left, Right};
 use rustc_abi::{self as abi, ExternAbi, FieldIdx, Integer, VariantIdx};
 use rustc_data_structures::assert_matches;
-use rustc_errors::inline_fluent;
+use rustc_errors::msg;
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty::layout::{IntegerExt, TyAndLayout};
 use rustc_middle::ty::{self, AdtDef, Instance, Ty, VariantDef};
@@ -297,9 +297,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         }
         // Find next caller arg.
         let Some((caller_arg, caller_abi)) = caller_args.next() else {
-            throw_ub_custom!(inline_fluent!(
-                "calling a function with fewer arguments than it requires"
-            ));
+            throw_ub_custom!(msg!("calling a function with fewer arguments than it requires"));
         };
         assert_eq!(caller_arg.layout().layout, caller_abi.layout.layout);
         // Sadly we cannot assert that `caller_arg.layout().ty` and `caller_abi.layout.ty` are
@@ -366,7 +364,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
 
         if caller_fn_abi.conv != callee_fn_abi.conv {
             throw_ub_custom!(
-                rustc_errors::inline_fluent!(
+                rustc_errors::msg!(
                     "calling a function with calling convention \"{$callee_conv}\" using calling convention \"{$caller_conv}\""
                 ),
                 callee_conv = format!("{}", callee_fn_abi.conv),
@@ -499,9 +497,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 "mismatch between callee ABI and callee body arguments"
             );
             if caller_args.next().is_some() {
-                throw_ub_custom!(inline_fluent!(
-                    "calling a function with more arguments than it expected"
-                ));
+                throw_ub_custom!(msg!("calling a function with more arguments than it expected"));
             }
             // Don't forget to check the return type!
             if !self.check_argument_compat(&caller_fn_abi.ret, &callee_fn_abi.ret)? {
@@ -701,7 +697,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 let vtable_entries = self.vtable_entries(receiver_trait.principal(), dyn_ty);
                 let Some(ty::VtblEntry::Method(fn_inst)) = vtable_entries.get(idx).copied() else {
                     // FIXME(fee1-dead) these could be variants of the UB info enum instead of this
-                    throw_ub_custom!(inline_fluent!(
+                    throw_ub_custom!(msg!(
                         "`dyn` call trying to call something that is not a method"
                     ));
                 };
@@ -900,7 +896,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             }
         );
         if unwinding && self.frame_idx() == 0 {
-            throw_ub_custom!(inline_fluent!("unwinding past the topmost frame of the stack"));
+            throw_ub_custom!(msg!("unwinding past the topmost frame of the stack"));
         }
 
         // Get out the return value. Must happen *before* the frame is popped as we have to get the

--- a/compiler/rustc_const_eval/src/interpret/cast.rs
+++ b/compiler/rustc_const_eval/src/interpret/cast.rs
@@ -2,7 +2,7 @@ use rustc_abi::{FieldIdx, Integer};
 use rustc_apfloat::ieee::{Double, Half, Quad, Single};
 use rustc_apfloat::{Float, FloatConvert};
 use rustc_data_structures::assert_matches;
-use rustc_errors::inline_fluent;
+use rustc_errors::msg;
 use rustc_middle::mir::CastKind;
 use rustc_middle::mir::interpret::{InterpResult, PointerArithmetic, Scalar};
 use rustc_middle::ty::adjustment::PointerCoercion;
@@ -139,7 +139,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 assert_eq!(cast_ty, dest.layout.ty); // we otherwise ignore `cast_ty` enirely...
                 if src.layout.size != dest.layout.size {
                     throw_ub_custom!(
-                        inline_fluent!(
+                        msg!(
                             "transmuting from {$src_bytes}-byte type to {$dest_bytes}-byte type: `{$src}` -> `{$dest}`"
                         ),
                         src_bytes = src.layout.size.bytes(),

--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -1,7 +1,7 @@
 use either::{Left, Right};
 use rustc_abi::{Align, HasDataLayout, Size, TargetDataLayout};
 use rustc_data_structures::debug_assert_matches;
-use rustc_errors::{DiagCtxtHandle, inline_fluent};
+use rustc_errors::{DiagCtxtHandle, msg};
 use rustc_hir::def_id::DefId;
 use rustc_hir::limit::Limit;
 use rustc_middle::mir::interpret::{ErrorHandled, InvalidMetaKind, ReportedErrorInfo};
@@ -555,7 +555,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             mir::UnwindAction::Cleanup(block) => Left(mir::Location { block, statement_index: 0 }),
             mir::UnwindAction::Continue => Right(self.frame_mut().body.span),
             mir::UnwindAction::Unreachable => {
-                throw_ub_custom!(inline_fluent!(
+                throw_ub_custom!(msg!(
                     "unwinding past a stack frame that does not allow unwinding"
                 ));
             }

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -7,7 +7,7 @@ mod simd;
 use rustc_abi::{FIRST_VARIANT, FieldIdx, HasDataLayout, Size, VariantIdx};
 use rustc_apfloat::ieee::{Double, Half, Quad, Single};
 use rustc_data_structures::assert_matches;
-use rustc_errors::inline_fluent;
+use rustc_errors::msg;
 use rustc_hir::def_id::CRATE_DEF_ID;
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::mir::interpret::{CTFE_ALLOC_SALT, read_target_uint, write_target_uint};
@@ -443,7 +443,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                         _ => {
                             // Not into the same allocation -- this is UB.
                             throw_ub_custom!(
-                                inline_fluent!(
+                                msg!(
                                     "`{$name}` called on two different pointers that are not both derived from the same allocation"
                                 ),
                                 name = intrinsic_name,
@@ -466,7 +466,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                         // a < b
                         if intrinsic_name == sym::ptr_offset_from_unsigned {
                             throw_ub_custom!(
-                                inline_fluent!(
+                                msg!(
                                     "`ptr_offset_from_unsigned` called when first pointer has smaller {$is_addr ->
                                         [true] address
                                         *[false] offset
@@ -483,7 +483,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                         let dist = val.to_target_isize(self)?;
                         if dist >= 0 || i128::from(dist) == self.pointer_size().signed_int_min() {
                             throw_ub_custom!(
-                                inline_fluent!(
+                                msg!(
                                     "`{$name}` called when first pointer is too far before second"
                                 ),
                                 name = intrinsic_name,
@@ -497,7 +497,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                         // because they were more than isize::MAX apart.
                         if dist < 0 {
                             throw_ub_custom!(
-                                inline_fluent!(
+                                msg!(
                                     "`{$name}` called when first pointer is too far ahead of second"
                                 ),
                                 name = intrinsic_name,
@@ -518,12 +518,12 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                             && a_alloc_id == b_alloc_id
                         {
                             err_ub_custom!(
-                                inline_fluent!("`{$name}` called on two different pointers where the memory range between them is not in-bounds of an allocation"),
+                                msg!("`{$name}` called on two different pointers where the memory range between them is not in-bounds of an allocation"),
                                 name = intrinsic_name,
                             )
                         } else {
                             err_ub_custom!(
-                                inline_fluent!("`{$name}` called on two different pointers that are not both derived from the same allocation"),
+                                msg!("`{$name}` called on two different pointers that are not both derived from the same allocation"),
                                 name = intrinsic_name,
                             )
                         }
@@ -538,7 +538,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 .map_err_kind(|_| {
                     // Make the error more specific.
                     err_ub_custom!(
-                        inline_fluent!("`{$name}` called on two different pointers that are not both derived from the same allocation"),
+                        msg!("`{$name}` called on two different pointers that are not both derived from the same allocation"),
                         name = intrinsic_name,
                     )
                 })?;
@@ -768,7 +768,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 let op = self.eval_operand(op, None)?;
                 let cond = self.read_scalar(&op)?.to_bool()?;
                 if !cond {
-                    throw_ub_custom!(inline_fluent!("`assume` called with `false`"));
+                    throw_ub_custom!(msg!("`assume` called with `false`"));
                 }
                 interp_ok(())
             }
@@ -798,7 +798,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         let bits_out = match name {
             sym::ctpop => u128::from(bits.count_ones()),
             sym::ctlz_nonzero | sym::cttz_nonzero if bits == 0 => {
-                throw_ub_custom!(inline_fluent!("`{$name}` called on 0"), name = name,);
+                throw_ub_custom!(msg!("`{$name}` called on 0"), name = name,);
             }
             sym::ctlz | sym::ctlz_nonzero => u128::from(bits.leading_zeros()) - extra,
             sym::cttz | sym::cttz_nonzero => u128::from((bits << extra).trailing_zeros()) - extra,
@@ -831,7 +831,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         // sign does not matter for 0 test, so `to_bits` is fine
         if rem.to_scalar().to_bits(a.layout.size)? != 0 {
             throw_ub_custom!(
-                inline_fluent!("exact_div: {$a} cannot be divided by {$b} without remainder"),
+                msg!("exact_div: {$a} cannot be divided by {$b} without remainder"),
                 a = format!("{a}"),
                 b = format!("{b}")
             )
@@ -916,7 +916,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
 
         let size = self.compute_size_in_bytes(size, count).ok_or_else(|| {
             err_ub_custom!(
-                inline_fluent!("overflow computing total size of `{$name}`"),
+                msg!("overflow computing total size of `{$name}`"),
                 name = if nonoverlapping { "copy_nonoverlapping" } else { "copy" }
             )
         })?;
@@ -980,10 +980,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         // `checked_mul` enforces a too small bound (the correct one would probably be target_isize_max),
         // but no actual allocation can be big enough for the difference to be noticeable.
         let len = self.compute_size_in_bytes(layout.size, count).ok_or_else(|| {
-            err_ub_custom!(
-                inline_fluent!("overflow computing total size of `{$name}`"),
-                name = name
-            )
+            err_ub_custom!(msg!("overflow computing total size of `{$name}`"), name = name)
         })?;
 
         let bytes = std::iter::repeat_n(byte, len.bytes_usize());

--- a/compiler/rustc_errors/src/diagnostic_impls.rs
+++ b/compiler/rustc_errors/src/diagnostic_impls.rs
@@ -6,9 +6,7 @@ use rustc_macros::Subdiagnostic;
 use rustc_span::{Span, Symbol};
 
 use crate::diagnostic::DiagLocation;
-use crate::{
-    Diag, DiagCtxtHandle, Diagnostic, EmissionGuarantee, Level, Subdiagnostic, inline_fluent,
-};
+use crate::{Diag, DiagCtxtHandle, Diagnostic, EmissionGuarantee, Level, Subdiagnostic, msg};
 
 impl IntoDiagArg for DiagLocation {
     fn into_diag_arg(self, _: &mut Option<std::path::PathBuf>) -> DiagArgValue {
@@ -43,24 +41,24 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for TargetDataLayoutErrors<'_> {
     fn into_diag(self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
         match self {
             TargetDataLayoutErrors::InvalidAddressSpace { addr_space, err, cause } => {
-                Diag::new(dcx, level, inline_fluent!("invalid address space `{$addr_space}` for `{$cause}` in \"data-layout\": {$err}"))
+                Diag::new(dcx, level, msg!("invalid address space `{$addr_space}` for `{$cause}` in \"data-layout\": {$err}"))
                     .with_arg("addr_space", addr_space)
                     .with_arg("cause", cause)
                     .with_arg("err", err)
             }
             TargetDataLayoutErrors::InvalidBits { kind, bit, cause, err } => {
-                Diag::new(dcx, level, inline_fluent!("invalid {$kind} `{$bit}` for `{$cause}` in \"data-layout\": {$err}"))
+                Diag::new(dcx, level, msg!("invalid {$kind} `{$bit}` for `{$cause}` in \"data-layout\": {$err}"))
                     .with_arg("kind", kind)
                     .with_arg("bit", bit)
                     .with_arg("cause", cause)
                     .with_arg("err", err)
             }
             TargetDataLayoutErrors::MissingAlignment { cause } => {
-                Diag::new(dcx, level, inline_fluent!("missing alignment for `{$cause}` in \"data-layout\""))
+                Diag::new(dcx, level, msg!("missing alignment for `{$cause}` in \"data-layout\""))
                     .with_arg("cause", cause)
             }
             TargetDataLayoutErrors::InvalidAlignment { cause, err } => {
-                Diag::new(dcx, level, inline_fluent!(
+                Diag::new(dcx, level, msg!(
                     "invalid alignment for `{$cause}` in \"data-layout\": `{$align}` is {$err_kind ->
                         [not_power_of_two] not a power of 2
                         [too_large] too large
@@ -72,21 +70,21 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for TargetDataLayoutErrors<'_> {
                 .with_arg("align", err.align())
             }
             TargetDataLayoutErrors::InconsistentTargetArchitecture { dl, target } => {
-                Diag::new(dcx, level, inline_fluent!(
+                Diag::new(dcx, level, msg!(
                     "inconsistent target specification: \"data-layout\" claims architecture is {$dl}-endian, while \"target-endian\" is `{$target}`"
                 ))
                 .with_arg("dl", dl).with_arg("target", target)
             }
             TargetDataLayoutErrors::InconsistentTargetPointerWidth { pointer_size, target } => {
-                Diag::new(dcx, level, inline_fluent!(
+                Diag::new(dcx, level, msg!(
                     "inconsistent target specification: \"data-layout\" claims pointers are {$pointer_size}-bit, while \"target-pointer-width\" is `{$target}`"
                 )).with_arg("pointer_size", pointer_size).with_arg("target", target)
             }
             TargetDataLayoutErrors::InvalidBitsSize { err } => {
-                Diag::new(dcx, level, inline_fluent!("{$err}")).with_arg("err", err)
+                Diag::new(dcx, level, msg!("{$err}")).with_arg("err", err)
             }
             TargetDataLayoutErrors::UnknownPointerSpecification { err } => {
-                Diag::new(dcx, level, inline_fluent!("unknown pointer specification `{$err}` in datalayout string"))
+                Diag::new(dcx, level, msg!("unknown pointer specification `{$err}` in datalayout string"))
                     .with_arg("err", err)
             }
         }

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -61,7 +61,7 @@ pub use rustc_error_messages::{
 use rustc_hashes::Hash128;
 use rustc_lint_defs::LintExpectationId;
 pub use rustc_lint_defs::{Applicability, listify, pluralize};
-pub use rustc_macros::inline_fluent;
+pub use rustc_macros::msg;
 use rustc_macros::{Decodable, Encodable};
 pub use rustc_span::ErrorGuaranteed;
 pub use rustc_span::fatal_error::{FatalError, FatalErrorMarker, catch_fatal_errors};
@@ -1514,7 +1514,7 @@ impl DiagCtxtInner {
                 // the usual `Diag`/`DiagCtxt` level, so we must augment `bug`
                 // in a lower-level fashion.
                 bug.arg("level", bug.level);
-                let msg = inline_fluent!(
+                let msg = msg!(
                     "`flushed_delayed` got diagnostic with level {$level}, instead of the expected `DelayedBug`"
                 );
                 let msg = self.eagerly_translate_for_subdiag(&bug, msg); // after the `arg` call
@@ -1558,13 +1558,13 @@ impl DelayedDiagInner {
         // lower-level fashion.
         let mut diag = self.inner;
         let msg = match self.note.status() {
-            BacktraceStatus::Captured => inline_fluent!(
+            BacktraceStatus::Captured => msg!(
                 "delayed at {$emitted_at}
                 {$note}"
             ),
             // Avoid the needless newline when no backtrace has been captured,
             // the display impl should just be a single line.
-            _ => inline_fluent!("delayed at {$emitted_at} - {$note}"),
+            _ => msg!("delayed at {$emitted_at} - {$note}"),
         };
         diag.arg("emitted_at", diag.emitted_at.clone());
         diag.arg("note", self.note);

--- a/compiler/rustc_expand/src/config.rs
+++ b/compiler/rustc_expand/src/config.rs
@@ -15,7 +15,7 @@ use rustc_attr_parsing::{
     AttributeParser, CFG_TEMPLATE, EvalConfigResult, ShouldEmit, eval_config_entry, parse_cfg,
 };
 use rustc_data_structures::flat_map_in_place::FlatMapInPlace;
-use rustc_errors::inline_fluent;
+use rustc_errors::msg;
 use rustc_feature::{
     ACCEPTED_LANG_FEATURES, EnabledLangFeature, EnabledLibFeature, Features, REMOVED_LANG_FEATURES,
     UNSTABLE_LANG_FEATURES,
@@ -433,14 +433,14 @@ impl<'a> StripUnconfigured<'a> {
                 &self.sess,
                 sym::stmt_expr_attributes,
                 attr.span,
-                inline_fluent!("attributes on expressions are experimental"),
+                msg!("attributes on expressions are experimental"),
             );
 
             if attr.is_doc_comment() {
                 err.help(if attr.style == AttrStyle::Outer {
-                    inline_fluent!("`///` is used for outer documentation comments; for a plain comment, use `//`")
+                    msg!("`///` is used for outer documentation comments; for a plain comment, use `//`")
                 } else {
-                    inline_fluent!("`//!` is used for inner documentation comments; for a plain comment, use `//` by removing the `!` or inserting a space in between them: `// !`")
+                    msg!("`//!` is used for inner documentation comments; for a plain comment, use `//` by removing the `!` or inserting a space in between them: `// !`")
                 });
             }
 

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -19,7 +19,7 @@ use rustc_attr_parsing::{
 };
 use rustc_data_structures::flat_map_in_place::FlatMapInPlace;
 use rustc_data_structures::stack::ensure_sufficient_stack;
-use rustc_errors::{PResult, inline_fluent};
+use rustc_errors::{PResult, msg};
 use rustc_feature::Features;
 use rustc_hir::Target;
 use rustc_hir::def::MacroKinds;
@@ -1051,7 +1051,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                             self.sess,
                             sym::proc_macro_hygiene,
                             item.span,
-                            inline_fluent!("file modules in proc macro input are unstable"),
+                            msg!("file modules in proc macro input are unstable"),
                         )
                         .emit();
                     }

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -5,9 +5,7 @@ use hir::intravisit::{self, Visitor};
 use rustc_abi::{ExternAbi, ScalableElt};
 use rustc_data_structures::fx::{FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_errors::codes::*;
-use rustc_errors::{
-    Applicability, ErrorGuaranteed, inline_fluent, pluralize, struct_span_code_err,
-};
+use rustc_errors::{Applicability, ErrorGuaranteed, msg, pluralize, struct_span_code_err};
 use rustc_hir::attrs::{AttributeKind, EiiDecl, EiiImpl, EiiImplResolution};
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::{DefId, LocalDefId};
@@ -1771,7 +1769,7 @@ fn check_method_receiver<'tcx>(
                             the `arbitrary_self_types` feature",
                     ),
                 )
-                .with_help(inline_fluent!("consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`"))
+                .with_help(msg!("consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`"))
                 .emit()
             }
             None | Some(ArbitrarySelfTypesLevel::Basic)
@@ -1795,7 +1793,7 @@ fn check_method_receiver<'tcx>(
                             the `arbitrary_self_types_pointers` feature",
                     ),
                 )
-                .with_help(inline_fluent!("consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`"))
+                .with_help(msg!("consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`"))
                 .emit()
             }
             _ =>

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -4,7 +4,7 @@ use rustc_abi::ExternAbi;
 use rustc_errors::codes::*;
 use rustc_errors::{
     Applicability, Diag, DiagCtxtHandle, DiagSymbolList, Diagnostic, EmissionGuarantee, Level,
-    MultiSpan, inline_fluent, listify,
+    MultiSpan, listify, msg,
 };
 use rustc_hir::limit::Limit;
 use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
@@ -444,7 +444,7 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for MissingGenericParams {
         let mut err = Diag::new(
             dcx,
             level,
-            inline_fluent!(
+            msg!(
                 "the {$descr} {$parameterCount ->
                     [one] parameter
                     *[other] parameters
@@ -455,7 +455,7 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for MissingGenericParams {
         err.code(E0393);
         err.span_label(
             self.def_span,
-            inline_fluent!(
+            msg!(
                 "{$descr} {$parameterCount ->
                     [one] parameter
                     *[other] parameters
@@ -511,7 +511,7 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for MissingGenericParams {
                 // least we can clue them to the correct syntax `Trait</* Term */>`.
                 err.span_suggestion_verbose(
                     self.span.shrink_to_hi(),
-                    inline_fluent!(
+                    msg!(
                         "explicitly specify the {$descr} {$parameterCount ->
                             [one] parameter
                             *[other] parameters
@@ -533,7 +533,7 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for MissingGenericParams {
         if !suggested {
             err.span_label(
                 self.span,
-                inline_fluent!(
+                msg!(
                     "missing {$parameterCount ->
                         [one] reference
                         *[other] references
@@ -542,7 +542,7 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for MissingGenericParams {
             );
         }
 
-        err.note(inline_fluent!(
+        err.note(msg!(
             "because the parameter {$parameterCount ->
                 [one] default references
                 *[other] defaults reference

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -3,8 +3,8 @@ use rustc_data_structures::sorted_map::SortedMap;
 use rustc_data_structures::unord::UnordMap;
 use rustc_errors::codes::*;
 use rustc_errors::{
-    Applicability, Diag, ErrorGuaranteed, MultiSpan, SuggestionStyle, inline_fluent, listify,
-    pluralize, struct_span_code_err,
+    Applicability, Diag, ErrorGuaranteed, MultiSpan, SuggestionStyle, listify, msg, pluralize,
+    struct_span_code_err,
 };
 use rustc_hir::def::{CtorOf, DefKind, Res};
 use rustc_hir::def_id::DefId;
@@ -304,7 +304,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                             // was also not an exact match, so we also suggest changing it.
                             err.span_suggestion_verbose(
                                 assoc_ident.span,
-                                inline_fluent!("...and changing the associated {$assoc_kind} name"),
+                                msg!("...and changing the associated {$assoc_kind} name"),
                                 suggested_name,
                                 Applicability::MaybeIncorrect,
                             );

--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -2,7 +2,7 @@ use std::iter;
 
 use rustc_abi::{CanonAbi, ExternAbi};
 use rustc_ast::util::parser::ExprPrecedence;
-use rustc_errors::{Applicability, Diag, ErrorGuaranteed, StashKey, inline_fluent};
+use rustc_errors::{Applicability, Diag, ErrorGuaranteed, StashKey, msg};
 use rustc_hir::attrs::AttributeKind;
 use rustc_hir::def::{self, CtorKind, Namespace, Res};
 use rustc_hir::def_id::DefId;
@@ -836,12 +836,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 (Some((_, kind, path)), _) => {
                     err.arg("kind", kind);
                     err.arg("path", path);
-                    Some(inline_fluent!("{$kind} `{$path}` defined here"))
+                    Some(msg!("{$kind} `{$path}` defined here"))
                 }
                 (_, Some(hir::QPath::Resolved(_, path))) => {
                     self.tcx.sess.source_map().span_to_snippet(path.span).ok().map(|p| {
                         err.arg("func", p);
-                        inline_fluent!("`{$func}` defined here returns `{$ty}`")
+                        msg!("`{$func}` defined here returns `{$ty}`")
                     })
                 }
                 _ => {
@@ -850,15 +850,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         // type definitions themselves, but rather variables *of* that type.
                         Res::Local(hir_id) => {
                             err.arg("local_name", self.tcx.hir_name(hir_id));
-                            Some(inline_fluent!("`{$local_name}` has type `{$ty}`"))
+                            Some(msg!("`{$local_name}` has type `{$ty}`"))
                         }
                         Res::Def(kind, def_id) if kind.ns() == Some(Namespace::ValueNS) => {
                             err.arg("path", self.tcx.def_path_str(def_id));
-                            Some(inline_fluent!("`{$path}` defined here"))
+                            Some(msg!("`{$path}` defined here"))
                         }
                         _ => {
                             err.arg("path", callee_ty);
-                            Some(inline_fluent!("`{$path}` defined here"))
+                            Some(msg!("`{$path}` defined here"))
                         }
                     }
                 }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -5,7 +5,7 @@ use core::iter;
 use hir::def_id::LocalDefId;
 use rustc_ast::util::parser::ExprPrecedence;
 use rustc_data_structures::packed::Pu128;
-use rustc_errors::{Applicability, Diag, MultiSpan, inline_fluent, listify};
+use rustc_errors::{Applicability, Diag, MultiSpan, listify, msg};
 use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res};
 use rustc_hir::lang_items::LangItem;
 use rustc_hir::{
@@ -482,7 +482,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let sugg = prefix_wrap(".map(|x| x.as_str())");
                 err.span_suggestion_verbose(
                     expr.span.shrink_to_hi(),
-                    inline_fluent!("try converting the passed type into a `&str`"),
+                    msg!("try converting the passed type into a `&str`"),
                     sugg,
                     Applicability::MachineApplicable,
                 );

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -22,7 +22,7 @@ use rustc_ast::visit::{FnCtxt, FnKind};
 use rustc_ast::{self as ast, *};
 use rustc_ast_pretty::pprust::expr_to_string;
 use rustc_attr_parsing::AttributeParser;
-use rustc_errors::{Applicability, LintDiagnostic, inline_fluent};
+use rustc_errors::{Applicability, LintDiagnostic, msg};
 use rustc_feature::GateIssue;
 use rustc_hir as hir;
 use rustc_hir::attrs::{AttributeKind, DocAttribute};
@@ -2653,10 +2653,10 @@ impl<'tcx> LateLintPass<'tcx> for InvalidValue {
             if let Some(err) = with_no_trimmed_paths!(ty_find_init_error(cx, conjured_ty, init)) {
                 let msg = match init {
                     InitKind::Zeroed => {
-                        inline_fluent!("the type `{$ty}` does not permit zero-initialization")
+                        msg!("the type `{$ty}` does not permit zero-initialization")
                     }
                     InitKind::Uninit => {
-                        inline_fluent!("the type `{$ty}` does not permit being left uninitialized")
+                        msg!("the type `{$ty}` does not permit being left uninitialized")
                     }
                 };
                 let sub = BuiltinUnpermittedTypeInitSub { err };

--- a/compiler/rustc_lint/src/errors.rs
+++ b/compiler/rustc_lint/src/errors.rs
@@ -1,5 +1,5 @@
 use rustc_errors::codes::*;
-use rustc_errors::{Diag, EmissionGuarantee, Subdiagnostic, inline_fluent};
+use rustc_errors::{Diag, EmissionGuarantee, Subdiagnostic, msg};
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_session::lint::Level;
 use rustc_span::{Span, Symbol};
@@ -27,17 +27,17 @@ impl Subdiagnostic for OverruledAttributeSub {
     fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
         match self {
             OverruledAttributeSub::DefaultSource { id } => {
-                diag.note(inline_fluent!("`forbid` lint level is the default for {$id}"));
+                diag.note(msg!("`forbid` lint level is the default for {$id}"));
                 diag.arg("id", id);
             }
             OverruledAttributeSub::NodeSource { span, reason } => {
-                diag.span_label(span, inline_fluent!("`forbid` level set here"));
+                diag.span_label(span, msg!("`forbid` level set here"));
                 if let Some(rationale) = reason {
                     diag.note(rationale.to_string());
                 }
             }
             OverruledAttributeSub::CommandLineSource => {
-                diag.note(inline_fluent!("`forbid` lint level was set on command line"));
+                diag.note(msg!("`forbid` lint level was set on command line"));
             }
         }
     }

--- a/compiler/rustc_lint/src/if_let_rescope.rs
+++ b/compiler/rustc_lint/src/if_let_rescope.rs
@@ -3,9 +3,7 @@ use std::ops::ControlFlow;
 
 use hir::intravisit::{self, Visitor};
 use rustc_ast::Recovered;
-use rustc_errors::{
-    Applicability, Diag, EmissionGuarantee, Subdiagnostic, SuggestionStyle, inline_fluent,
-};
+use rustc_errors::{Applicability, Diag, EmissionGuarantee, Subdiagnostic, SuggestionStyle, msg};
 use rustc_hir::{self as hir, HirIdSet};
 use rustc_macros::{LintDiagnostic, Subdiagnostic};
 use rustc_middle::ty::adjustment::Adjust;
@@ -356,7 +354,7 @@ impl Subdiagnostic for IfLetRescopeRewrite {
                 .chain(repeat_n('}', closing_brackets.count))
                 .collect(),
         ));
-        let msg = diag.eagerly_translate(inline_fluent!(
+        let msg = diag.eagerly_translate(msg!(
             "a `match` with a single arm can preserve the drop order up to Edition 2021"
         ));
         diag.multipart_suggestion_with_style(

--- a/compiler/rustc_lint/src/impl_trait_overcaptures.rs
+++ b/compiler/rustc_lint/src/impl_trait_overcaptures.rs
@@ -3,7 +3,7 @@ use std::cell::LazyCell;
 use rustc_data_structures::debug_assert_matches;
 use rustc_data_structures::fx::{FxHashMap, FxIndexMap, FxIndexSet};
 use rustc_data_structures::unord::UnordSet;
-use rustc_errors::{LintDiagnostic, Subdiagnostic, inline_fluent};
+use rustc_errors::{LintDiagnostic, Subdiagnostic, msg};
 use rustc_hir as hir;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
@@ -435,23 +435,21 @@ struct ImplTraitOvercapturesLint<'tcx> {
 
 impl<'a> LintDiagnostic<'a, ()> for ImplTraitOvercapturesLint<'_> {
     fn decorate_lint<'b>(self, diag: &'b mut rustc_errors::Diag<'a, ()>) {
-        diag.primary_message(inline_fluent!(
+        diag.primary_message(msg!(
             "`{$self_ty}` will capture more lifetimes than possibly intended in edition 2024"
         ));
         diag.arg("self_ty", self.self_ty.to_string())
             .arg("num_captured", self.num_captured)
             .span_note(
                 self.uncaptured_spans,
-                inline_fluent!(
+                msg!(
                     "specifically, {$num_captured ->
                         [one] this lifetime is
                         *[other] these lifetimes are
                     } in scope but not mentioned in the type's bounds"
                 ),
             )
-            .note(inline_fluent!(
-                "all lifetimes in scope will be captured by `impl Trait`s in edition 2024"
-            ));
+            .note(msg!("all lifetimes in scope will be captured by `impl Trait`s in edition 2024"));
         if let Some(suggestion) = self.suggestion {
             suggestion.add_to_diag(diag);
         }

--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -2,7 +2,7 @@ use rustc_ast::attr::AttributeExt;
 use rustc_ast_pretty::pprust;
 use rustc_data_structures::fx::{FxHashSet, FxIndexMap};
 use rustc_data_structures::unord::UnordSet;
-use rustc_errors::{Diag, LintDiagnostic, MultiSpan, inline_fluent};
+use rustc_errors::{Diag, LintDiagnostic, MultiSpan, msg};
 use rustc_feature::{Features, GateIssue};
 use rustc_hir::HirId;
 use rustc_hir::intravisit::{self, Visitor};
@@ -941,9 +941,9 @@ impl<'s, P: LintLevelsProvider> LintLevelsBuilder<'s, P> {
             let lint = builtin::UNKNOWN_LINTS;
             let level = self.lint_level(builtin::UNKNOWN_LINTS);
             lint_level(self.sess, lint, level, Some(span.into()), |lint| {
-                lint.primary_message(inline_fluent!("unknown lint: `{$name}`"));
+                lint.primary_message(msg!("unknown lint: `{$name}`"));
                 lint.arg("name", lint_id.lint.name_lower());
-                lint.note(inline_fluent!("the `{$name}` lint is unstable"));
+                lint.note(msg!("the `{$name}` lint is unstable"));
                 rustc_session::parse::add_feature_diagnostics_for_issue(
                     lint,
                     &self.sess,

--- a/compiler/rustc_lint/src/non_fmt_panic.rs
+++ b/compiler/rustc_lint/src/non_fmt_panic.rs
@@ -1,5 +1,5 @@
 use rustc_ast as ast;
-use rustc_errors::{Applicability, inline_fluent};
+use rustc_errors::{Applicability, msg};
 use rustc_hir::{self as hir, LangItem};
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::{bug, ty};
@@ -121,20 +121,20 @@ fn check_panic<'tcx>(cx: &LateContext<'tcx>, f: &'tcx hir::Expr<'tcx>, arg: &'tc
     }
 
     cx.span_lint(NON_FMT_PANICS, arg_span, |lint| {
-        lint.primary_message(inline_fluent!("panic message is not a string literal"));
+        lint.primary_message(msg!("panic message is not a string literal"));
         lint.arg("name", symbol);
-        lint.note(inline_fluent!("this usage of `{$name}!()` is deprecated; it will be a hard error in Rust 2021"));
-        lint.note(inline_fluent!("for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>"));
+        lint.note(msg!("this usage of `{$name}!()` is deprecated; it will be a hard error in Rust 2021"));
+        lint.note(msg!("for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>"));
         if !is_arg_inside_call(arg_span, span) {
             // No clue where this argument is coming from.
             return;
         }
         if arg_macro.is_some_and(|id| cx.tcx.is_diagnostic_item(sym::format_macro, id)) {
             // A case of `panic!(format!(..))`.
-            lint.note(inline_fluent!("the `{$name}!()` macro supports formatting, so there's no need for the `format!()` macro here"));
+            lint.note(msg!("the `{$name}!()` macro supports formatting, so there's no need for the `format!()` macro here"));
             if let Some((open, close, _)) = find_delimiters(cx, arg_span) {
                 lint.multipart_suggestion(
-                    inline_fluent!("remove the `format!(..)` macro call"),
+                    msg!("remove the `format!(..)` macro call"),
                     vec![
                         (arg_span.until(open.shrink_to_hi()), "".into()),
                         (close.until(arg_span.shrink_to_hi()), "".into()),
@@ -178,7 +178,7 @@ fn check_panic<'tcx>(cx: &LateContext<'tcx>, f: &'tcx hir::Expr<'tcx>, arg: &'tc
             if suggest_display {
                 lint.span_suggestion_verbose(
                     arg_span.shrink_to_lo(),
-                    inline_fluent!(r#"add a "{"{"}{"}"}" format string to `Display` the message"#),
+                    msg!(r#"add a "{"{"}{"}"}" format string to `Display` the message"#),
                     "\"{}\", ",
                     fmt_applicability,
                 );
@@ -186,7 +186,7 @@ fn check_panic<'tcx>(cx: &LateContext<'tcx>, f: &'tcx hir::Expr<'tcx>, arg: &'tc
                 lint.arg("ty", ty);
                 lint.span_suggestion_verbose(
                     arg_span.shrink_to_lo(),
-                    inline_fluent!(r#"add a "{"{"}:?{"}"}" format string to use the `Debug` implementation of `{$ty}`"#),
+                    msg!(r#"add a "{"{"}:?{"}"}" format string to use the `Debug` implementation of `{$ty}`"#),
                     "\"{:?}\", ",
                     fmt_applicability,
                 );
@@ -196,7 +196,7 @@ fn check_panic<'tcx>(cx: &LateContext<'tcx>, f: &'tcx hir::Expr<'tcx>, arg: &'tc
                 if let Some((open, close, del)) = find_delimiters(cx, span) {
                     lint.arg("already_suggested", suggest_display || suggest_debug);
                     lint.multipart_suggestion(
-                        inline_fluent!(
+                        msg!(
                             "{$already_suggested ->
                                 [true] or use
                                 *[false] use

--- a/compiler/rustc_lint/src/non_local_def.rs
+++ b/compiler/rustc_lint/src/non_local_def.rs
@@ -1,4 +1,4 @@
-use rustc_errors::{MultiSpan, inline_fluent};
+use rustc_errors::{MultiSpan, msg};
 use rustc_hir::attrs::AttributeKind;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::intravisit::{self, Visitor, VisitorExt};
@@ -210,7 +210,7 @@ impl<'tcx> LateLintPass<'tcx> for NonLocalDefinitions {
                 if !doctest {
                     ms.push_span_label(
                         cx.tcx.def_span(parent),
-                        inline_fluent!(
+                        msg!(
                             "move the `impl` block outside of this {$body_kind_descr} {$depth ->
                                 [one] `{$body_name}`
                                 *[other] `{$body_name}` and up {$depth} bodies

--- a/compiler/rustc_macros/src/diagnostics/mod.rs
+++ b/compiler/rustc_macros/src/diagnostics/mod.rs
@@ -1,13 +1,13 @@
 mod diagnostic;
 mod diagnostic_builder;
 mod error;
-mod inline_fluent;
 mod message;
+mod msg_macro;
 mod subdiagnostic;
 mod utils;
 
 use diagnostic::{DiagnosticDerive, LintDiagnosticDerive};
-pub(super) use inline_fluent::inline_fluent;
+pub(super) use msg_macro::msg_macro;
 use proc_macro2::TokenStream;
 use subdiagnostic::SubdiagnosticDerive;
 use synstructure::Structure;

--- a/compiler/rustc_macros/src/diagnostics/msg_macro.rs
+++ b/compiler/rustc_macros/src/diagnostics/msg_macro.rs
@@ -2,7 +2,7 @@ use syn::{LitStr, parse_macro_input};
 
 use crate::diagnostics::message::Message;
 
-pub(crate) fn inline_fluent(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+pub(crate) fn msg_macro(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let inline = parse_macro_input!(input as LitStr);
     let message =
         Message { attr_span: inline.span(), message_span: inline.span(), value: inline.value() };

--- a/compiler/rustc_macros/src/lib.rs
+++ b/compiler/rustc_macros/src/lib.rs
@@ -245,8 +245,8 @@ decl_derive!(
 ///
 /// This macro statically checks that the message is valid Fluent, but not that variables in the Fluent message actually exist.
 #[proc_macro]
-pub fn inline_fluent(input: TokenStream) -> TokenStream {
-    diagnostics::inline_fluent(input)
+pub fn msg(input: TokenStream) -> TokenStream {
+    diagnostics::msg_macro(input)
 }
 
 decl_derive! {

--- a/compiler/rustc_middle/src/middle/stability.rs
+++ b/compiler/rustc_middle/src/middle/stability.rs
@@ -4,7 +4,7 @@
 use std::num::NonZero;
 
 use rustc_ast::NodeId;
-use rustc_errors::{Applicability, Diag, EmissionGuarantee, LintBuffer, inline_fluent};
+use rustc_errors::{Applicability, Diag, EmissionGuarantee, LintBuffer, msg};
 use rustc_feature::GateIssue;
 use rustc_hir::attrs::{DeprecatedSince, Deprecation};
 use rustc_hir::def_id::{DefId, LocalDefId};
@@ -128,20 +128,20 @@ pub struct Deprecated {
 impl<'a, G: EmissionGuarantee> rustc_errors::LintDiagnostic<'a, G> for Deprecated {
     fn decorate_lint<'b>(self, diag: &'b mut Diag<'a, G>) {
         diag.primary_message(match &self.since_kind {
-            DeprecatedSinceKind::InEffect => inline_fluent!(
+            DeprecatedSinceKind::InEffect => msg!(
                 "use of deprecated {$kind} `{$path}`{$has_note ->
                     [true] : {$note}
                     *[other] {\"\"}
                 }"
             ),
-            DeprecatedSinceKind::InFuture => inline_fluent!(
+            DeprecatedSinceKind::InFuture => msg!(
                 "use of {$kind} `{$path}` that will be deprecated in a future Rust version{$has_note ->
                     [true] : {$note}
                     *[other] {\"\"}
                 }"
             ),
             DeprecatedSinceKind::InVersion(_) => {
-                inline_fluent!(
+                msg!(
                     "use of {$kind} `{$path}` that will be deprecated in future version {$version}{$has_note ->
                         [true] : {$note}
                         *[other] {\"\"}

--- a/compiler/rustc_middle/src/mir/terminator.rs
+++ b/compiler/rustc_middle/src/mir/terminator.rs
@@ -337,25 +337,25 @@ impl<O> AssertKind<O> {
         use AssertKind::*;
 
         match self {
-            BoundsCheck { .. } => inline_fluent!(
-                "index out of bounds: the length is {$len} but the index is {$index}"
-            ),
+            BoundsCheck { .. } => {
+                msg!("index out of bounds: the length is {$len} but the index is {$index}")
+            }
             Overflow(BinOp::Shl, _, _) => {
-                inline_fluent!("attempt to shift left by `{$val}`, which would overflow")
+                msg!("attempt to shift left by `{$val}`, which would overflow")
             }
             Overflow(BinOp::Shr, _, _) => {
-                inline_fluent!("attempt to shift right by `{$val}`, which would overflow")
+                msg!("attempt to shift right by `{$val}`, which would overflow")
             }
             Overflow(_, _, _) => {
-                inline_fluent!("attempt to compute `{$left} {$op} {$right}`, which would overflow")
+                msg!("attempt to compute `{$left} {$op} {$right}`, which would overflow")
             }
-            OverflowNeg(_) => inline_fluent!("attempt to negate `{$val}`, which would overflow"),
-            DivisionByZero(_) => inline_fluent!("attempt to divide `{$val}` by zero"),
-            RemainderByZero(_) => inline_fluent!(
-                "attempt to calculate the remainder of `{$val}` with a divisor of zero"
-            ),
+            OverflowNeg(_) => msg!("attempt to negate `{$val}`, which would overflow"),
+            DivisionByZero(_) => msg!("attempt to divide `{$val}` by zero"),
+            RemainderByZero(_) => {
+                msg!("attempt to calculate the remainder of `{$val}` with a divisor of zero")
+            }
             ResumedAfterReturn(CoroutineKind::Desugared(CoroutineDesugaring::Async, _)) => {
-                inline_fluent!("`async fn` resumed after completion")
+                msg!("`async fn` resumed after completion")
             }
             ResumedAfterReturn(CoroutineKind::Desugared(CoroutineDesugaring::AsyncGen, _)) => {
                 todo!()
@@ -364,40 +364,38 @@ impl<O> AssertKind<O> {
                 bug!("gen blocks can be resumed after they return and will keep returning `None`")
             }
             ResumedAfterReturn(CoroutineKind::Coroutine(_)) => {
-                inline_fluent!("coroutine resumed after completion")
+                msg!("coroutine resumed after completion")
             }
             ResumedAfterPanic(CoroutineKind::Desugared(CoroutineDesugaring::Async, _)) => {
-                inline_fluent!("`async fn` resumed after panicking")
+                msg!("`async fn` resumed after panicking")
             }
             ResumedAfterPanic(CoroutineKind::Desugared(CoroutineDesugaring::AsyncGen, _)) => {
                 todo!()
             }
             ResumedAfterPanic(CoroutineKind::Desugared(CoroutineDesugaring::Gen, _)) => {
-                inline_fluent!("`gen` fn or block cannot be further iterated on after it panicked")
+                msg!("`gen` fn or block cannot be further iterated on after it panicked")
             }
             ResumedAfterPanic(CoroutineKind::Coroutine(_)) => {
-                inline_fluent!("coroutine resumed after panicking")
+                msg!("coroutine resumed after panicking")
             }
-            NullPointerDereference => inline_fluent!("null pointer dereference occurred"),
+            NullPointerDereference => msg!("null pointer dereference occurred"),
             InvalidEnumConstruction(_) => {
-                inline_fluent!("trying to construct an enum from an invalid value `{$source}`")
+                msg!("trying to construct an enum from an invalid value `{$source}`")
             }
             ResumedAfterDrop(CoroutineKind::Desugared(CoroutineDesugaring::Async, _)) => {
-                inline_fluent!("`async fn` resumed after async drop")
+                msg!("`async fn` resumed after async drop")
             }
             ResumedAfterDrop(CoroutineKind::Desugared(CoroutineDesugaring::AsyncGen, _)) => {
                 todo!()
             }
             ResumedAfterDrop(CoroutineKind::Desugared(CoroutineDesugaring::Gen, _)) => {
-                inline_fluent!(
-                    "`gen` fn or block cannot be further iterated on after it async dropped"
-                )
+                msg!("`gen` fn or block cannot be further iterated on after it async dropped")
             }
             ResumedAfterDrop(CoroutineKind::Coroutine(_)) => {
-                inline_fluent!("coroutine resumed after async drop")
+                msg!("coroutine resumed after async drop")
             }
 
-            MisalignedPointerDereference { .. } => inline_fluent!(
+            MisalignedPointerDereference { .. } => msg!(
                 "misaligned pointer dereference: address must be a multiple of {$required} but is {$found}"
             ),
         }
@@ -512,7 +510,7 @@ impl<'tcx> TerminatorKind<'tcx> {
 }
 
 pub use helper::*;
-use rustc_errors::inline_fluent;
+use rustc_errors::msg;
 
 mod helper {
     use super::*;

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -8,8 +8,7 @@ use rustc_abi::{
 };
 use rustc_error_messages::DiagMessage;
 use rustc_errors::{
-    Diag, DiagArgValue, DiagCtxtHandle, Diagnostic, EmissionGuarantee, IntoDiagArg, Level,
-    inline_fluent,
+    Diag, DiagArgValue, DiagCtxtHandle, Diagnostic, EmissionGuarantee, IntoDiagArg, Level, msg,
 };
 use rustc_hir::LangItem;
 use rustc_hir::def_id::DefId;
@@ -270,24 +269,22 @@ impl<'tcx> LayoutError<'tcx> {
         use LayoutError::*;
 
         match self {
-            Unknown(_) => inline_fluent!("the type `{$ty}` has an unknown layout"),
+            Unknown(_) => msg!("the type `{$ty}` has an unknown layout"),
             SizeOverflow(_) => {
-                inline_fluent!("values of the type `{$ty}` are too big for the target architecture")
+                msg!("values of the type `{$ty}` are too big for the target architecture")
             }
             InvalidSimd { kind: SimdLayoutError::TooManyLanes(_), .. } => {
-                inline_fluent!(
-                    "the SIMD type `{$ty}` has more elements than the limit {$max_lanes}"
-                )
+                msg!("the SIMD type `{$ty}` has more elements than the limit {$max_lanes}")
             }
             InvalidSimd { kind: SimdLayoutError::ZeroLength, .. } => {
-                inline_fluent!("the SIMD type `{$ty}` has zero elements")
+                msg!("the SIMD type `{$ty}` has zero elements")
             }
-            TooGeneric(_) => inline_fluent!("the type `{$ty}` does not have a fixed layout"),
-            NormalizationFailure(_, _) => inline_fluent!(
+            TooGeneric(_) => msg!("the type `{$ty}` does not have a fixed layout"),
+            NormalizationFailure(_, _) => msg!(
                 "unable to determine layout for `{$ty}` because `{$failure_ty}` cannot be normalized"
             ),
-            Cycle(_) => inline_fluent!("a cycle occurred during layout computation"),
-            ReferencesError(_) => inline_fluent!("the type has an unknown layout"),
+            Cycle(_) => msg!("a cycle occurred during layout computation"),
+            ReferencesError(_) => msg!("the type has an unknown layout"),
         }
     }
 

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -3,9 +3,7 @@ use rustc_ast::Mutability;
 use rustc_data_structures::fx::FxIndexSet;
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_errors::codes::*;
-use rustc_errors::{
-    Applicability, ErrorGuaranteed, MultiSpan, inline_fluent, struct_span_code_err,
-};
+use rustc_errors::{Applicability, ErrorGuaranteed, MultiSpan, msg, struct_span_code_err};
 use rustc_hir::def::*;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::{self as hir, BindingMode, ByRef, HirId, MatchSource};
@@ -987,22 +985,16 @@ fn report_unreachable_pattern<'p, 'tcx>(
             let mut iter = covering_pats.iter();
             let mut multispan = MultiSpan::from_span(pat_span);
             for p in iter.by_ref().take(CAP_COVERED_BY_MANY) {
-                multispan.push_span_label(
-                    p.data().span,
-                    inline_fluent!("matches some of the same values"),
-                );
+                multispan.push_span_label(p.data().span, msg!("matches some of the same values"));
             }
             let remain = iter.count();
             if remain == 0 {
-                multispan.push_span_label(
-                    pat_span,
-                    inline_fluent!("collectively making this unreachable"),
-                );
+                multispan.push_span_label(pat_span, msg!("collectively making this unreachable"));
             } else {
                 lint.covered_by_many_n_more_count = remain;
                 multispan.push_span_label(
                     pat_span,
-                    inline_fluent!("...and {$covered_by_many_n_more_count} other patterns collectively make this unreachable"),
+                    msg!("...and {$covered_by_many_n_more_count} other patterns collectively make this unreachable"),
                 );
             }
             lint.covered_by_many = Some(multispan);

--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -3,7 +3,7 @@ use core::ops::ControlFlow;
 use rustc_abi::{FieldIdx, VariantIdx};
 use rustc_apfloat::Float;
 use rustc_data_structures::fx::FxHashSet;
-use rustc_errors::{Diag, inline_fluent};
+use rustc_errors::{Diag, msg};
 use rustc_hir as hir;
 use rustc_hir::attrs::AttributeKind;
 use rustc_hir::find_attr;
@@ -82,7 +82,7 @@ impl<'tcx> ConstToPat<'tcx> {
                 err.span_label(self.tcx.def_span(self.tcx.local_parent(def_id)), "");
             }
             if let hir::def::DefKind::Const | hir::def::DefKind::AssocConst = def_kind {
-                err.span_label(self.tcx.def_span(uv.def), inline_fluent!("constant defined here"));
+                err.span_label(self.tcx.def_span(uv.def), msg!("constant defined here"));
             }
         }
         Box::new(Pat { span: self.span, ty, kind: PatKind::Error(err.emit()), extra: None })

--- a/compiler/rustc_mir_transform/src/errors.rs
+++ b/compiler/rustc_mir_transform/src/errors.rs
@@ -1,7 +1,5 @@
 use rustc_errors::codes::*;
-use rustc_errors::{
-    Applicability, Diag, EmissionGuarantee, LintDiagnostic, Subdiagnostic, inline_fluent,
-};
+use rustc_errors::{Applicability, Diag, EmissionGuarantee, LintDiagnostic, Subdiagnostic, msg};
 use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
 use rustc_middle::mir::AssertKind;
 use rustc_middle::query::Key;
@@ -135,10 +133,10 @@ impl<'a, P: std::fmt::Debug> LintDiagnostic<'a, ()> for AssertLint<P> {
     fn decorate_lint<'b>(self, diag: &'b mut Diag<'a, ()>) {
         diag.primary_message(match self.lint_kind {
             AssertLintKind::ArithmeticOverflow => {
-                inline_fluent!("this arithmetic operation will overflow")
+                msg!("this arithmetic operation will overflow")
             }
             AssertLintKind::UnconditionalPanic => {
-                inline_fluent!("this operation will panic at runtime")
+                msg!("this operation will panic at runtime")
             }
         });
         let label = self.assert_kind.diagnostic_message();
@@ -295,12 +293,10 @@ impl Subdiagnostic for UnusedVariableStringInterp {
     fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
         diag.span_label(
             self.lit,
-            inline_fluent!(
-                "you might have meant to use string interpolation in this string literal"
-            ),
+            msg!("you might have meant to use string interpolation in this string literal"),
         );
         diag.multipart_suggestion(
-            inline_fluent!("string interpolation only works in `format!` invocations"),
+            msg!("string interpolation only works in `format!` invocations"),
             vec![
                 (self.lit.shrink_to_lo(), String::from("format!(")),
                 (self.lit.shrink_to_hi(), String::from(")")),
@@ -337,17 +333,14 @@ pub(crate) struct MustNotSupend<'a, 'tcx> {
 // Needed for def_path_str
 impl<'a> LintDiagnostic<'a, ()> for MustNotSupend<'_, '_> {
     fn decorate_lint<'b>(self, diag: &'b mut rustc_errors::Diag<'a, ()>) {
-        diag.primary_message(inline_fluent!(
+        diag.primary_message(msg!(
             "{$pre}`{$def_path}`{$post} held across a suspend point, but should not be"
         ));
-        diag.span_label(
-            self.yield_sp,
-            inline_fluent!("the value is held across this suspend point"),
-        );
+        diag.span_label(self.yield_sp, msg!("the value is held across this suspend point"));
         if let Some(reason) = self.reason {
             diag.subdiagnostic(reason);
         }
-        diag.span_help(self.src_sp, inline_fluent!("consider using a block (`{\"{ ... }\"}`) to shrink the value's scope, ending before the suspend point"));
+        diag.span_help(self.src_sp, msg!("consider using a block (`{\"{ ... }\"}`) to shrink the value's scope, ending before the suspend point"));
         diag.arg("pre", self.pre);
         diag.arg("def_path", self.tcx.def_path_str(self.def_id));
         diag.arg("post", self.post);

--- a/compiler/rustc_mir_transform/src/lint_tail_expr_drop_order.rs
+++ b/compiler/rustc_mir_transform/src/lint_tail_expr_drop_order.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 use itertools::Itertools as _;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap};
 use rustc_data_structures::unord::{UnordMap, UnordSet};
-use rustc_errors::{Subdiagnostic, inline_fluent};
+use rustc_errors::{Subdiagnostic, msg};
 use rustc_hir::CRATE_HIR_ID;
 use rustc_hir::def_id::LocalDefId;
 use rustc_index::bit_set::MixedBitSet;
@@ -531,7 +531,7 @@ impl Subdiagnostic for LocalLabel<'_> {
         diag.arg("is_generated_name", self.is_generated_name);
         diag.remove_arg("is_dropped_first_edition_2024");
         diag.arg("is_dropped_first_edition_2024", self.is_dropped_first_edition_2024);
-        let msg = diag.eagerly_translate(inline_fluent!(
+        let msg = diag.eagerly_translate(msg!(
             "{$is_generated_name ->
                 [true] this value will be stored in a temporary; let us call it `{$name}`
                 *[false] `{$name}` calls a custom destructor
@@ -542,7 +542,7 @@ impl Subdiagnostic for LocalLabel<'_> {
             dtor.add_to_diag(diag);
         }
         let msg =
-            diag.eagerly_translate(inline_fluent!(
+            diag.eagerly_translate(msg!(
                 "{$is_dropped_first_edition_2024 ->
                     [true] up until Edition 2021 `{$name}` is dropped last but will be dropped earlier in Edition 2024
                     *[false] `{$name}` will be dropped later as of Edition 2024

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -9,7 +9,7 @@ use rustc_ast::{Path, Visibility};
 use rustc_errors::codes::*;
 use rustc_errors::{
     Applicability, Diag, DiagArgValue, DiagCtxtHandle, Diagnostic, EmissionGuarantee, IntoDiagArg,
-    Level, Subdiagnostic, SuggestionStyle, inline_fluent,
+    Level, Subdiagnostic, SuggestionStyle, msg,
 };
 use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
 use rustc_session::errors::ExprParenthesesNeeded;
@@ -1463,22 +1463,22 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for ExpectedIdentifier {
             level,
             match token_descr {
                 Some(TokenDescription::ReservedIdentifier) => {
-                    inline_fluent!("expected identifier, found reserved identifier `{$token}`")
+                    msg!("expected identifier, found reserved identifier `{$token}`")
                 }
                 Some(TokenDescription::Keyword) => {
-                    inline_fluent!("expected identifier, found keyword `{$token}`")
+                    msg!("expected identifier, found keyword `{$token}`")
                 }
                 Some(TokenDescription::ReservedKeyword) => {
-                    inline_fluent!("expected identifier, found reserved keyword `{$token}`")
+                    msg!("expected identifier, found reserved keyword `{$token}`")
                 }
                 Some(TokenDescription::DocComment) => {
-                    inline_fluent!("expected identifier, found doc comment `{$token}`")
+                    msg!("expected identifier, found doc comment `{$token}`")
                 }
                 Some(TokenDescription::MetaVar(_)) => {
                     add_token = false;
-                    inline_fluent!("expected identifier, found metavariable")
+                    msg!("expected identifier, found metavariable")
                 }
-                None => inline_fluent!("expected identifier, found `{$token}`"),
+                None => msg!("expected identifier, found `{$token}`"),
             },
         );
         diag.span(self.span);
@@ -1530,22 +1530,22 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for ExpectedSemi {
             level,
             match token_descr {
                 Some(TokenDescription::ReservedIdentifier) => {
-                    inline_fluent!("expected `;`, found reserved identifier `{$token}`")
+                    msg!("expected `;`, found reserved identifier `{$token}`")
                 }
                 Some(TokenDescription::Keyword) => {
-                    inline_fluent!("expected `;`, found keyword `{$token}`")
+                    msg!("expected `;`, found keyword `{$token}`")
                 }
                 Some(TokenDescription::ReservedKeyword) => {
-                    inline_fluent!("expected `;`, found reserved keyword `{$token}`")
+                    msg!("expected `;`, found reserved keyword `{$token}`")
                 }
                 Some(TokenDescription::DocComment) => {
-                    inline_fluent!("expected `;`, found doc comment `{$token}`")
+                    msg!("expected `;`, found doc comment `{$token}`")
                 }
                 Some(TokenDescription::MetaVar(_)) => {
                     add_token = false;
-                    inline_fluent!("expected `;`, found metavariable")
+                    msg!("expected `;`, found metavariable")
                 }
-                None => inline_fluent!("expected `;`, found `{$token}`"),
+                None => msg!("expected `;`, found `{$token}`"),
             },
         );
         diag.span(self.span);
@@ -1554,7 +1554,7 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for ExpectedSemi {
         }
 
         if let Some(unexpected_token_label) = self.unexpected_token_label {
-            diag.span_label(unexpected_token_label, inline_fluent!("unexpected token"));
+            diag.span_label(unexpected_token_label, msg!("unexpected token"));
         }
 
         self.sugg.add_to_diag(&mut diag);
@@ -1980,10 +1980,10 @@ pub(crate) struct FnTraitMissingParen {
 
 impl Subdiagnostic for FnTraitMissingParen {
     fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
-        diag.span_label(self.span, inline_fluent!("`Fn` bounds require arguments in parentheses"));
+        diag.span_label(self.span, msg!("`Fn` bounds require arguments in parentheses"));
         diag.span_suggestion_short(
             self.span.shrink_to_hi(),
-            inline_fluent!("try adding parentheses"),
+            msg!("try adding parentheses"),
             "()",
             Applicability::MachineApplicable,
         );
@@ -4303,13 +4303,13 @@ impl Subdiagnostic for HiddenUnicodeCodepointsDiagSub {
         match self {
             HiddenUnicodeCodepointsDiagSub::Escape { spans } => {
                 diag.multipart_suggestion_with_style(
-                    inline_fluent!("if their presence wasn't intentional, you can remove them"),
+                    msg!("if their presence wasn't intentional, you can remove them"),
                     spans.iter().map(|(_, span)| (*span, "".to_string())).collect(),
                     Applicability::MachineApplicable,
                     SuggestionStyle::HideCodeAlways,
                 );
                 diag.multipart_suggestion(
-                    inline_fluent!("if you want to keep them but make them visible in your source code, you can escape them"),
+                    msg!("if you want to keep them but make them visible in your source code, you can escape them"),
                     spans
                         .into_iter()
                         .map(|(c, span)| {
@@ -4332,10 +4332,8 @@ impl Subdiagnostic for HiddenUnicodeCodepointsDiagSub {
                         .collect::<Vec<String>>()
                         .join(", "),
                 );
-                diag.note(inline_fluent!(
-                    "if their presence wasn't intentional, you can remove them"
-                ));
-                diag.note(inline_fluent!("if you want to keep them but make them visible in your source code, you can escape them: {$escaped}"));
+                diag.note(msg!("if their presence wasn't intentional, you can remove them"));
+                diag.note(msg!("if you want to keep them but make them visible in your source code, you can escape them: {$escaped}"));
             }
         }
     }

--- a/compiler/rustc_parse/src/parser/attr.rs
+++ b/compiler/rustc_parse/src/parser/attr.rs
@@ -3,7 +3,7 @@ use rustc_ast::token::{self, MetaVarKind};
 use rustc_ast::tokenstream::ParserRange;
 use rustc_ast::{AttrItemKind, Attribute, attr};
 use rustc_errors::codes::*;
-use rustc_errors::{Diag, PResult, inline_fluent};
+use rustc_errors::{Diag, PResult, msg};
 use rustc_span::{BytePos, Span};
 use thin_vec::ThinVec;
 use tracing::debug;
@@ -66,9 +66,8 @@ impl<'a> Parser<'a> {
             } else if let token::DocComment(comment_kind, attr_style, data) = self.token.kind {
                 if attr_style != ast::AttrStyle::Outer {
                     let span = self.token.span;
-                    let mut err = self
-                        .dcx()
-                        .struct_span_err(span, inline_fluent!("expected outer doc comment"));
+                    let mut err =
+                        self.dcx().struct_span_err(span, msg!("expected outer doc comment"));
                     err.code(E0753);
                     if let Some(replacement_span) = self.annotate_following_item_if_applicable(
                         &mut err,
@@ -79,12 +78,12 @@ impl<'a> Parser<'a> {
                         },
                         true,
                     ) {
-                        err.note(inline_fluent!(
+                        err.note(msg!(
                             "inner doc comments like this (starting with `//!` or `/*!`) can only appear before items"
                         ));
                         err.span_suggestion_verbose(
                             replacement_span,
-                            inline_fluent!("you might have meant to write a regular comment"),
+                            msg!("you might have meant to write a regular comment"),
                             "",
                             rustc_errors::Applicability::MachineApplicable,
                         );
@@ -214,10 +213,10 @@ impl<'a> Parser<'a> {
                     item.span,
                     match attr_type {
                         OuterAttributeType::Attribute => {
-                            inline_fluent!("the inner attribute doesn't annotate this {$item}")
+                            msg!("the inner attribute doesn't annotate this {$item}")
                         }
                         OuterAttributeType::DocComment | OuterAttributeType::DocBlockComment => {
-                            inline_fluent!("the inner doc comment doesn't annotate this {$item}")
+                            msg!("the inner doc comment doesn't annotate this {$item}")
                         }
                     },
                 );
@@ -225,8 +224,8 @@ impl<'a> Parser<'a> {
                     err.span_suggestion_verbose(
                         replacement_span,
                         match attr_type {
-                            OuterAttributeType::Attribute =>  inline_fluent!("to annotate the {$item}, change the attribute from inner to outer style"),
-                            OuterAttributeType::DocComment | OuterAttributeType::DocBlockComment =>  inline_fluent!("to annotate the {$item}, change the doc comment from inner to outer style"),
+                            OuterAttributeType::Attribute =>  msg!("to annotate the {$item}, change the attribute from inner to outer style"),
+                            OuterAttributeType::DocComment | OuterAttributeType::DocBlockComment =>  msg!("to annotate the {$item}, change the doc comment from inner to outer style"),
                         },
                         match attr_type {
                             OuterAttributeType::Attribute => "",
@@ -258,42 +257,31 @@ impl<'a> Parser<'a> {
                     self.dcx()
                         .struct_span_err(
                             attr_sp,
-                            inline_fluent!(
+                            msg!(
                                 "an inner attribute is not permitted following an outer doc comment"
                             ),
                         )
                         .with_span_label(
                             attr_sp,
-                            inline_fluent!("not permitted following an outer doc comment"),
+                            msg!("not permitted following an outer doc comment"),
                         )
-                        .with_span_label(
-                            prev_doc_comment_span,
-                            inline_fluent!("previous doc comment"),
-                        )
+                        .with_span_label(prev_doc_comment_span, msg!("previous doc comment"))
                 }
                 Some(InnerAttrForbiddenReason::AfterOuterAttribute { prev_outer_attr_sp }) => self
                     .dcx()
                     .struct_span_err(
                         attr_sp,
-                        inline_fluent!(
-                            "an inner attribute is not permitted following an outer attribute"
-                        ),
+                        msg!("an inner attribute is not permitted following an outer attribute"),
                     )
-                    .with_span_label(
-                        attr_sp,
-                        inline_fluent!("not permitted following an outer attribute"),
-                    )
-                    .with_span_label(
-                        prev_outer_attr_sp,
-                        inline_fluent!("previous outer attribute"),
-                    ),
+                    .with_span_label(attr_sp, msg!("not permitted following an outer attribute"))
+                    .with_span_label(prev_outer_attr_sp, msg!("previous outer attribute")),
                 Some(InnerAttrForbiddenReason::InCodeBlock) | None => self.dcx().struct_span_err(
                     attr_sp,
-                    inline_fluent!("an inner attribute is not permitted in this context"),
+                    msg!("an inner attribute is not permitted in this context"),
                 ),
             };
 
-            diag.note(inline_fluent!("inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files"));
+            diag.note(msg!("inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files"));
             if self
                 .annotate_following_item_if_applicable(
                     &mut diag,
@@ -303,7 +291,7 @@ impl<'a> Parser<'a> {
                 )
                 .is_some()
             {
-                diag.note(inline_fluent!(
+                diag.note(msg!(
                     "outer attributes, like `#[test]`, annotate the item following them"
                 ));
             };

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -12,8 +12,8 @@ use rustc_ast::{
 use rustc_ast_pretty::pprust;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::{
-    Applicability, Diag, DiagCtxtHandle, ErrorGuaranteed, PResult, Subdiagnostic, Suggestions,
-    inline_fluent, pluralize,
+    Applicability, Diag, DiagCtxtHandle, ErrorGuaranteed, PResult, Subdiagnostic, Suggestions, msg,
+    pluralize,
 };
 use rustc_session::errors::ExprParenthesesNeeded;
 use rustc_span::source_map::Spanned;
@@ -1272,7 +1272,7 @@ impl<'a> Parser<'a> {
                         // We made sense of it. Improve the error message.
                         e.span_suggestion_verbose(
                             binop.span.shrink_to_lo(),
-                            inline_fluent!("use `::<...>` instead of `<...>` to specify lifetime, type, or const arguments"),
+                            msg!("use `::<...>` instead of `<...>` to specify lifetime, type, or const arguments"),
                             "::",
                             Applicability::MaybeIncorrect,
                         );

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -9,7 +9,7 @@ use rustc_ast::util::case::Case;
 use rustc_ast::{self as ast};
 use rustc_ast_pretty::pprust;
 use rustc_errors::codes::*;
-use rustc_errors::{Applicability, PResult, StashKey, inline_fluent, struct_span_code_err};
+use rustc_errors::{Applicability, PResult, StashKey, msg, struct_span_code_err};
 use rustc_session::lint::builtin::VARARGS_WITHOUT_PATTERN;
 use rustc_span::edit_distance::edit_distance;
 use rustc_span::edition::Edition;
@@ -1743,7 +1743,7 @@ impl<'a> Parser<'a> {
 
             if this.token == token::Bang {
                 if let Err(err) = this.unexpected() {
-                    err.with_note(inline_fluent!("macros cannot expand to enum variants")).emit();
+                    err.with_note(msg!("macros cannot expand to enum variants")).emit();
                 }
 
                 this.bump();

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -15,7 +15,7 @@ use rustc_attr_parsing::{AttributeParser, Late};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::thin_vec::ThinVec;
 use rustc_data_structures::unord::UnordMap;
-use rustc_errors::{DiagCtxtHandle, IntoDiagArg, MultiSpan, StashKey, inline_fluent};
+use rustc_errors::{DiagCtxtHandle, IntoDiagArg, MultiSpan, StashKey, msg};
 use rustc_feature::{
     ACCEPTED_LANG_FEATURES, AttributeDuplicates, AttributeType, BUILTIN_ATTRIBUTE_MAP,
     BuiltinAttribute,
@@ -1003,10 +1003,10 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 for (inline2, span2) in rest {
                     if inline2 != inline {
                         let mut spans = MultiSpan::from_spans(vec![*span, *span2]);
-                        spans.push_span_label(*span, inline_fluent!("this attribute..."));
+                        spans.push_span_label(*span, msg!("this attribute..."));
                         spans.push_span_label(
                             *span2,
-                            inline_fluent!("{\".\"}..conflicts with this attribute"),
+                            msg!("{\".\"}..conflicts with this attribute"),
                         );
                         self.dcx().emit_err(errors::DocInlineConflict { spans });
                         return;
@@ -1151,7 +1151,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 &self.tcx.sess,
                 sym::rustdoc_internals,
                 *span,
-                inline_fluent!("the `#[doc(rust_logo)]` attribute is used for Rust branding"),
+                msg!("the `#[doc(rust_logo)]` attribute is used for Rust branding"),
             )
             .emit();
         }

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -1,7 +1,7 @@
 use rustc_errors::codes::*;
 use rustc_errors::{
     Applicability, Diag, DiagCtxtHandle, DiagMessage, Diagnostic, ElidedLifetimeInPathSubdiag,
-    EmissionGuarantee, IntoDiagArg, Level, LintDiagnostic, MultiSpan, Subdiagnostic, inline_fluent,
+    EmissionGuarantee, IntoDiagArg, Level, LintDiagnostic, MultiSpan, Subdiagnostic, msg,
 };
 use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
 use rustc_span::source_map::Spanned;
@@ -1371,16 +1371,16 @@ impl Subdiagnostic for FoundItemConfigureOut {
                 let key = "feature".into();
                 let value = feature.into_diag_arg(&mut None);
                 let msg = diag.dcx.eagerly_translate_to_string(
-                    inline_fluent!("the item is gated behind the `{$feature}` feature"),
+                    msg!("the item is gated behind the `{$feature}` feature"),
                     [(&key, &value)].into_iter(),
                 );
                 multispan.push_span_label(span, msg);
             }
             ItemWas::CfgOut { span } => {
-                multispan.push_span_label(span, inline_fluent!("the item is gated here"));
+                multispan.push_span_label(span, msg!("the item is gated here"));
             }
         }
-        diag.span_note(multispan, inline_fluent!("found an item that was configured out"));
+        diag.span_note(multispan, msg!("found an item that was configured out"));
     }
 }
 

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
@@ -2,8 +2,7 @@ use std::iter;
 
 use rustc_data_structures::fx::FxIndexSet;
 use rustc_errors::{
-    Applicability, Diag, E0309, E0310, E0311, E0803, Subdiagnostic, inline_fluent,
-    struct_span_code_err,
+    Applicability, Diag, E0309, E0310, E0311, E0803, Subdiagnostic, msg, struct_span_code_err,
 };
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
@@ -230,20 +229,20 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             .add_to_diag(err),
             SubregionOrigin::Reborrow(span) => RegionOriginNote::Plain {
                 span,
-                msg: inline_fluent!("...so that reference does not outlive borrowed content"),
+                msg: msg!("...so that reference does not outlive borrowed content"),
             }
             .add_to_diag(err),
             SubregionOrigin::RelateObjectBound(span) => {
                 RegionOriginNote::Plain {
                     span,
-                    msg: inline_fluent!("...so that it can be closed over into an object"),
+                    msg: msg!("...so that it can be closed over into an object"),
                 }
                 .add_to_diag(err);
             }
             SubregionOrigin::ReferenceOutlivesReferent(ty, span) => {
                 RegionOriginNote::WithName {
                     span,
-                    msg: inline_fluent!("...so that the reference type `{$name}` does not outlive the data it points at"),
+                    msg: msg!("...so that the reference type `{$name}` does not outlive the data it points at"),
                     name: &self.ty_to_string(ty),
                     continues: false,
                 }
@@ -252,7 +251,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             SubregionOrigin::RelateParamBound(span, ty, opt_span) => {
                 RegionOriginNote::WithName {
                     span,
-                    msg: inline_fluent!(
+                    msg: msg!(
                         "...so that the type `{$name}` will meet its required lifetime bounds{$continues ->
                             [true] ...
                             *[false] {\"\"}
@@ -265,7 +264,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 if let Some(span) = opt_span {
                     RegionOriginNote::Plain {
                         span,
-                        msg: inline_fluent!("...that is required by this bound"),
+                        msg: msg!("...that is required by this bound"),
                     }
                     .add_to_diag(err);
                 }
@@ -273,16 +272,14 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             SubregionOrigin::RelateRegionParamBound(span, _) => {
                 RegionOriginNote::Plain {
                     span,
-                    msg: inline_fluent!(
-                        "...so that the declared lifetime parameter bounds are satisfied"
-                    ),
+                    msg: msg!("...so that the declared lifetime parameter bounds are satisfied"),
                 }
                 .add_to_diag(err);
             }
             SubregionOrigin::CompareImplItemObligation { span, .. } => {
                 RegionOriginNote::Plain {
                     span,
-                    msg: inline_fluent!(
+                    msg: msg!(
                         "...so that the definition in impl matches the definition from the trait"
                     ),
                 }
@@ -292,11 +289,8 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 self.note_region_origin(err, parent);
             }
             SubregionOrigin::AscribeUserTypeProvePredicate(span) => {
-                RegionOriginNote::Plain {
-                    span,
-                    msg: inline_fluent!("...so that the where clause holds"),
-                }
-                .add_to_diag(err);
+                RegionOriginNote::Plain { span, msg: msg!("...so that the where clause holds") }
+                    .add_to_diag(err);
             }
         }
     }

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -11,8 +11,8 @@ use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::unord::UnordSet;
 use rustc_errors::codes::*;
 use rustc_errors::{
-    Applicability, Diag, ErrorGuaranteed, Level, MultiSpan, StashKey, StringPart, Suggestions,
-    inline_fluent, pluralize, struct_span_code_err,
+    Applicability, Diag, ErrorGuaranteed, Level, MultiSpan, StashKey, StringPart, Suggestions, msg,
+    pluralize, struct_span_code_err,
 };
 use rustc_hir::def_id::{DefId, LOCAL_CRATE, LocalDefId};
 use rustc_hir::intravisit::Visitor;
@@ -3088,7 +3088,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         {
             err.span_help(
                 self.tcx.def_span(trait_def_id),
-                inline_fluent!("this trait has no implementations, consider adding one"),
+                msg!("this trait has no implementations, consider adding one"),
             );
         } else if !suggested && trait_predicate.polarity() == ty::PredicatePolarity::Positive {
             // Can't show anything else useful, try to find similar impls.

--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -3,7 +3,7 @@ use rustc_data_structures::fx::{FxHashSet, FxIndexSet};
 use rustc_errors::codes::*;
 use rustc_errors::{
     Applicability, Diag, DiagCtxtHandle, DiagMessage, DiagStyledString, Diagnostic,
-    EmissionGuarantee, IntoDiagArg, Level, MultiSpan, Subdiagnostic, inline_fluent,
+    EmissionGuarantee, IntoDiagArg, Level, MultiSpan, Subdiagnostic, msg,
 };
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
@@ -105,7 +105,7 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for NegativePositiveConflict<'_> {
         let mut diag = Diag::new(
             dcx,
             level,
-            inline_fluent!(
+            msg!(
             "found both positive and negative implementation of trait `{$trait_desc}`{$self_desc ->
                 [none] {\"\"}
                 *[default] {\" \"}for type `{$self_desc}`
@@ -118,23 +118,19 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for NegativePositiveConflict<'_> {
         diag.code(E0751);
         match self.negative_impl_span {
             Ok(span) => {
-                diag.span_label(span, inline_fluent!("negative implementation here"));
+                diag.span_label(span, msg!("negative implementation here"));
             }
             Err(cname) => {
-                diag.note(inline_fluent!(
-                    "negative implementation in crate `{$negative_impl_cname}`"
-                ));
+                diag.note(msg!("negative implementation in crate `{$negative_impl_cname}`"));
                 diag.arg("negative_impl_cname", cname.to_string());
             }
         }
         match self.positive_impl_span {
             Ok(span) => {
-                diag.span_label(span, inline_fluent!("positive implementation here"));
+                diag.span_label(span, msg!("positive implementation here"));
             }
             Err(cname) => {
-                diag.note(inline_fluent!(
-                    "positive implementation in crate `{$positive_impl_cname}`"
-                ));
+                diag.note(msg!("positive implementation in crate `{$positive_impl_cname}`"));
                 diag.arg("positive_impl_cname", cname.to_string());
             }
         }
@@ -161,7 +157,7 @@ impl Subdiagnostic for AdjustSignatureBorrow {
             AdjustSignatureBorrow::Borrow { to_borrow } => {
                 diag.arg("borrow_len", to_borrow.len());
                 diag.multipart_suggestion_verbose(
-                    inline_fluent!(
+                    msg!(
                         "consider adjusting the signature so it borrows its {$borrow_len ->
                             [one] argument
                             *[other] arguments
@@ -174,7 +170,7 @@ impl Subdiagnostic for AdjustSignatureBorrow {
             AdjustSignatureBorrow::RemoveBorrow { remove_borrow } => {
                 diag.arg("remove_borrow_len", remove_borrow.len());
                 diag.multipart_suggestion_verbose(
-                    inline_fluent!(
+                    msg!(
                         "consider adjusting the signature so it does not borrow its {$remove_borrow_len ->
                             [one] argument
                             *[other] arguments
@@ -509,7 +505,7 @@ impl Subdiagnostic for RegionOriginNote<'_> {
             } => {
                 label_or_note(
                     span,
-                    inline_fluent!(
+                    msg!(
                         "...so that the {$requirement ->
                             [method_compat] method type is compatible with trait
                             [type_compat] associated type is compatible with trait
@@ -535,7 +531,7 @@ impl Subdiagnostic for RegionOriginNote<'_> {
                 // *terrible*.
                 label_or_note(
                     span,
-                    inline_fluent!(
+                    msg!(
                         "...so that {$requirement ->
                             [method_compat] method type is compatible with trait
                             [type_compat] associated type is compatible with trait
@@ -578,11 +574,11 @@ impl Subdiagnostic for LifetimeMismatchLabels {
     fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
         match self {
             LifetimeMismatchLabels::InRet { param_span, ret_span, span, label_var1 } => {
-                diag.span_label(param_span, inline_fluent!("this parameter and the return type are declared with different lifetimes..."));
-                diag.span_label(ret_span, inline_fluent!("{\"\"}"));
+                diag.span_label(param_span, msg!("this parameter and the return type are declared with different lifetimes..."));
+                diag.span_label(ret_span, msg!("{\"\"}"));
                 diag.span_label(
                     span,
-                    inline_fluent!(
+                    msg!(
                         "...but data{$label_var1_exists ->
                             [true] {\" \"}from `{$label_var1}`
                             *[false] {\"\"}
@@ -603,22 +599,22 @@ impl Subdiagnostic for LifetimeMismatchLabels {
                 if hir_equal {
                     diag.span_label(
                         ty_sup,
-                        inline_fluent!("this type is declared with multiple lifetimes..."),
+                        msg!("this type is declared with multiple lifetimes..."),
                     );
-                    diag.span_label(ty_sub, inline_fluent!("{\"\"}"));
+                    diag.span_label(ty_sub, msg!("{\"\"}"));
                     diag.span_label(
                         span,
-                        inline_fluent!("...but data with one lifetime flows into the other here"),
+                        msg!("...but data with one lifetime flows into the other here"),
                     );
                 } else {
                     diag.span_label(
                         ty_sup,
-                        inline_fluent!("these two types are declared with different lifetimes..."),
+                        msg!("these two types are declared with different lifetimes..."),
                     );
-                    diag.span_label(ty_sub, inline_fluent!("{\"\"}"));
+                    diag.span_label(ty_sub, msg!("{\"\"}"));
                     diag.span_label(
                         span,
-                        inline_fluent!(
+                        msg!(
                             "...but data{$label_var1_exists ->
                                 [true] {\" \"}from `{$label_var1}`
                                 *[false] {\"\"}
@@ -793,7 +789,7 @@ impl Subdiagnostic for AddLifetimeParamsSuggestion<'_> {
                 visitor.suggestions.push(new_param_suggestion);
             }
             diag.multipart_suggestion_verbose(
-                inline_fluent!(
+                msg!(
                     "consider {$is_reuse ->
                         [true] reusing
                         *[false] introducing
@@ -811,9 +807,7 @@ impl Subdiagnostic for AddLifetimeParamsSuggestion<'_> {
             true
         };
         if mk_suggestion() && self.add_note {
-            diag.note(inline_fluent!(
-                "each elided lifetime in input position becomes a distinct lifetime"
-            ));
+            diag.note(msg!("each elided lifetime in input position becomes a distinct lifetime"));
         }
     }
 }
@@ -838,11 +832,11 @@ impl Subdiagnostic for IntroducesStaticBecauseUnmetLifetimeReq {
     fn add_to_diag<G: EmissionGuarantee>(mut self, diag: &mut Diag<'_, G>) {
         self.unmet_requirements.push_span_label(
             self.binding_span,
-            inline_fluent!("introduces a `'static` lifetime requirement"),
+            msg!("introduces a `'static` lifetime requirement"),
         );
         diag.span_note(
             self.unmet_requirements,
-            inline_fluent!("because this has an unmet lifetime requirement"),
+            msg!("because this has an unmet lifetime requirement"),
         );
     }
 }
@@ -1226,12 +1220,10 @@ impl Subdiagnostic for ConsiderBorrowingParamHelp {
         let mut type_param_span: MultiSpan = self.spans.clone().into();
         for &span in &self.spans {
             // Seems like we can't call f() here as Into<DiagMessage> is required
-            type_param_span.push_span_label(
-                span,
-                inline_fluent!("consider borrowing this type parameter in the trait"),
-            );
+            type_param_span
+                .push_span_label(span, msg!("consider borrowing this type parameter in the trait"));
         }
-        let msg = diag.eagerly_translate(inline_fluent!("the lifetime requirements from the `impl` do not correspond to the requirements in the `trait`"));
+        let msg = diag.eagerly_translate(msg!("the lifetime requirements from the `impl` do not correspond to the requirements in the `trait`"));
         diag.span_help(type_param_span, msg);
     }
 }
@@ -1269,18 +1261,16 @@ impl Subdiagnostic for DynTraitConstraintSuggestion {
         let mut multi_span: MultiSpan = vec![self.span].into();
         multi_span.push_span_label(
             self.span,
-            inline_fluent!("this has an implicit `'static` lifetime requirement"),
+            msg!("this has an implicit `'static` lifetime requirement"),
         );
         multi_span.push_span_label(
             self.ident.span,
-            inline_fluent!("calling this method introduces the `impl`'s `'static` requirement"),
+            msg!("calling this method introduces the `impl`'s `'static` requirement"),
         );
-        let msg =
-            diag.eagerly_translate(inline_fluent!("the used `impl` has a `'static` requirement"));
+        let msg = diag.eagerly_translate(msg!("the used `impl` has a `'static` requirement"));
         diag.span_note(multi_span, msg);
-        let msg = diag.eagerly_translate(inline_fluent!(
-            "consider relaxing the implicit `'static` requirement"
-        ));
+        let msg =
+            diag.eagerly_translate(msg!("consider relaxing the implicit `'static` requirement"));
         diag.span_suggestion_verbose(
             self.span.shrink_to_hi(),
             msg,
@@ -1333,20 +1323,17 @@ pub struct ReqIntroducedLocations {
 impl Subdiagnostic for ReqIntroducedLocations {
     fn add_to_diag<G: EmissionGuarantee>(mut self, diag: &mut Diag<'_, G>) {
         for sp in self.spans {
-            self.span.push_span_label(sp, inline_fluent!("`'static` requirement introduced here"));
+            self.span.push_span_label(sp, msg!("`'static` requirement introduced here"));
         }
 
         if self.add_label {
             self.span.push_span_label(
                 self.fn_decl_span,
-                inline_fluent!("requirement introduced by this return type"),
+                msg!("requirement introduced by this return type"),
             );
         }
-        self.span.push_span_label(
-            self.cause_span,
-            inline_fluent!("because of this returned expression"),
-        );
-        let msg = diag.eagerly_translate(inline_fluent!(
+        self.span.push_span_label(self.cause_span, msg!("because of this returned expression"));
+        let msg = diag.eagerly_translate(msg!(
             "\"`'static` lifetime requirement introduced by the return type"
         ));
         diag.span_note(self.span, msg);
@@ -1788,9 +1775,8 @@ pub struct SuggestTuplePatternMany {
 impl Subdiagnostic for SuggestTuplePatternMany {
     fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
         diag.arg("path", self.path);
-        let message = diag.eagerly_translate(inline_fluent!(
-            "try wrapping the pattern in a variant of `{$path}`"
-        ));
+        let message =
+            diag.eagerly_translate(msg!("try wrapping the pattern in a variant of `{$path}`"));
         diag.multipart_suggestions(
             message,
             self.compatible_variants.into_iter().map(|variant| {
@@ -2034,13 +2020,13 @@ impl Subdiagnostic for AddPreciseCapturingAndParams {
     fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
         diag.arg("new_lifetime", self.new_lifetime);
         diag.multipart_suggestion_verbose(
-            inline_fluent!("add a `use<...>` bound to explicitly capture `{$new_lifetime}` after turning all argument-position `impl Trait` into type parameters, noting that this possibly affects the API of this crate"),
+            msg!("add a `use<...>` bound to explicitly capture `{$new_lifetime}` after turning all argument-position `impl Trait` into type parameters, noting that this possibly affects the API of this crate"),
             self.suggs,
             Applicability::MaybeIncorrect,
         );
         diag.span_note(
             self.apit_spans,
-            inline_fluent!("you could use a `use<...>` bound to explicitly capture `{$new_lifetime}`, but argument-position `impl Trait`s are not nameable"),
+            msg!("you could use a `use<...>` bound to explicitly capture `{$new_lifetime}`, but argument-position `impl Trait`s are not nameable"),
         );
     }
 }
@@ -2181,16 +2167,14 @@ impl Subdiagnostic for AddPreciseCapturingForOvercapture {
             Applicability::MaybeIncorrect
         };
         diag.multipart_suggestion_verbose(
-            inline_fluent!(
-                "use the precise capturing `use<...>` syntax to make the captures explicit"
-            ),
+            msg!("use the precise capturing `use<...>` syntax to make the captures explicit"),
             self.suggs,
             applicability,
         );
         if !self.apit_spans.is_empty() {
             diag.span_note(
                 self.apit_spans,
-                inline_fluent!("you could use a `use<...>` bound to explicitly specify captures, but argument-position `impl Trait`s are not nameable"),
+                msg!("you could use a `use<...>` bound to explicitly specify captures, but argument-position `impl Trait`s are not nameable"),
             );
         }
     }

--- a/compiler/rustc_trait_selection/src/errors/note_and_explain.rs
+++ b/compiler/rustc_trait_selection/src/errors/note_and_explain.rs
@@ -1,4 +1,4 @@
-use rustc_errors::{Diag, EmissionGuarantee, IntoDiagArg, Subdiagnostic, inline_fluent};
+use rustc_errors::{Diag, EmissionGuarantee, IntoDiagArg, Subdiagnostic, msg};
 use rustc_hir::def_id::LocalDefId;
 use rustc_middle::bug;
 use rustc_middle::ty::{self, TyCtxt};
@@ -169,7 +169,7 @@ impl Subdiagnostic for RegionExplanation<'_> {
         diag.arg("desc_kind", self.desc.kind);
         diag.arg("desc_arg", self.desc.arg);
 
-        let msg = diag.eagerly_translate(inline_fluent!(
+        let msg = diag.eagerly_translate(msg!(
             "{$pref_kind ->
                 *[should_not_happen] [{$pref_kind}]
                 [ref_valid_for] ...the reference is valid for

--- a/compiler/rustc_trait_selection/src/traits/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/normalize.rs
@@ -1,7 +1,7 @@
 //! Deeply normalize types using the old trait solver.
 
 use rustc_data_structures::stack::ensure_sufficient_stack;
-use rustc_errors::inline_fluent;
+use rustc_errors::msg;
 use rustc_hir::def::DefKind;
 use rustc_infer::infer::at::At;
 use rustc_infer::infer::{InferCtxt, InferOk};
@@ -295,7 +295,7 @@ impl<'a, 'b, 'tcx> AssocTypeNormalizer<'a, 'b, 'tcx> {
                 self.cause.span,
                 false,
                 |diag| {
-                    diag.note(inline_fluent!("in case this is a recursive type alias, consider using a struct, enum, or union instead"));
+                    diag.note(msg!("in case this is a recursive type alias, consider using a struct, enum, or union instead"));
                 },
             );
         }


### PR DESCRIPTION
This was the most popular name for the macro as voted in [#t-compiler > Bikeshed the new &#96;inline_fluent!&#96; macro @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Bikeshed.20the.20new.20.60inline_fluent!.60.20macro/near/572751863)