### PR TITLE
std: implement `sleep_until` for Fuchsia

### DIFF
--- a/library/std/src/sys/pal/unix/fuchsia.rs
+++ b/library/std/src/sys/pal/unix/fuchsia.rs
@@ -15,6 +15,7 @@ pub const ZX_TIME_INFINITE: zx_instant_mono_t = i64::MAX;
 
 unsafe extern "C" {
     pub safe fn zx_clock_get_monotonic() -> zx_instant_mono_t;
+    pub safe fn zx_nanosleep(deadline: zx_instant_mono_t) -> zx_status_t;
 }
 
 /////////////

--- a/library/std/src/sys/pal/unix/fuchsia.rs
+++ b/library/std/src/sys/pal/unix/fuchsia.rs
@@ -9,12 +9,12 @@ use crate::io;
 // Time //
 //////////
 
-pub type zx_time_t = i64;
+pub type zx_instant_mono_t = i64;
 
-pub const ZX_TIME_INFINITE: zx_time_t = i64::MAX;
+pub const ZX_TIME_INFINITE: zx_instant_mono_t = i64::MAX;
 
 unsafe extern "C" {
-    pub safe fn zx_clock_get_monotonic() -> zx_time_t;
+    pub safe fn zx_clock_get_monotonic() -> zx_instant_mono_t;
 }
 
 /////////////
@@ -62,7 +62,7 @@ unsafe extern "C" {
     pub fn zx_object_wait_one(
         handle: zx_handle_t,
         signals: zx_signals_t,
-        timeout: zx_time_t,
+        deadline: zx_instant_mono_t,
         pending: *mut zx_signals_t,
     ) -> zx_status_t;
 
@@ -70,7 +70,7 @@ unsafe extern "C" {
         value_ptr: *const zx_futex_t,
         current_value: zx_futex_t,
         new_futex_owner: zx_handle_t,
-        deadline: zx_time_t,
+        deadline: zx_instant_mono_t,
     ) -> zx_status_t;
     pub fn zx_futex_wake(value_ptr: *const zx_futex_t, wake_count: u32) -> zx_status_t;
     pub fn zx_futex_wake_single_owner(value_ptr: *const zx_futex_t) -> zx_status_t;
@@ -117,7 +117,7 @@ pub type zx_info_process_flags_t = u32;
 #[repr(C)]
 pub struct zx_info_process_t {
     pub return_code: i64,
-    pub start_time: zx_time_t,
+    pub start_time: zx_instant_mono_t,
     pub flags: zx_info_process_flags_t,
     pub reserved1: u32,
 }

--- a/library/std/src/sys/thread/mod.rs
+++ b/library/std/src/sys/thread/mod.rs
@@ -73,6 +73,7 @@ cfg_select! {
             target_os = "vxworks",
             target_os = "wasi",
             target_vendor = "apple",
+            target_os = "fuchsia",
         ))]
         pub use unix::sleep_until;
         #[expect(dead_code)]
@@ -134,7 +135,8 @@ cfg_select! {
     target_os = "wasi",
     target_vendor = "apple",
     target_os = "motor",
-    target_os = "vexos"
+    target_os = "vexos",
+    target_os = "fuchsia",
 )))]
 pub fn sleep_until(deadline: crate::time::Instant) {
     use crate::time::Instant;

--- a/library/std/src/sys/thread/unix.rs
+++ b/library/std/src/sys/thread/unix.rs
@@ -765,6 +765,16 @@ pub fn sleep_until(deadline: crate::time::Instant) {
     }
 }
 
+#[cfg(target_os = "fuchsia")]
+pub fn sleep_until(deadline: crate::time::Instant) {
+    use crate::sys::pal::fuchsia::{zx_cvt, zx_nanosleep};
+
+    let deadline = deadline.into_inner().into_deadline();
+    if let Err(error) = zx_cvt(zx_nanosleep(deadline)) {
+        panic!("zx_nanosleep failed: {error}");
+    }
+}
+
 pub fn yield_now() {
     let ret = unsafe { libc::sched_yield() };
     debug_assert_eq!(ret, 0);

--- a/library/std/src/sys/thread/unix.rs
+++ b/library/std/src/sys/thread/unix.rs
@@ -778,6 +778,16 @@ pub fn sleep_until(deadline: crate::time::Instant) {
     }
 }
 
+#[cfg(target_os = "fuchsia")]
+pub fn sleep_until(deadline: crate::time::Instant) {
+    use crate::sys::pal::fuchsia::{zx_cvt, zx_nanosleep};
+
+    let deadline = deadline.into_inner().into_deadline();
+    if let Err(error) = zx_cvt(zx_nanosleep(deadline)) {
+        panic!("zx_nanosleep failed: {error}");
+    }
+}
+
 pub fn yield_now() {
     let ret = unsafe { libc::sched_yield() };
     debug_assert_eq!(ret, 0);

--- a/library/std/src/sys/time/unix.rs
+++ b/library/std/src/sys/time/unix.rs
@@ -123,6 +123,11 @@ impl Instant {
         // 126 bits.
         Some((nanos * u128::from(timebase.denom)).div_ceil(u128::from(timebase.numer)))
     }
+
+    #[cfg(target_os = "fuchsia")]
+    pub fn into_deadline(self) -> crate::sys::pal::fuchsia::zx_instant_mono_t {
+        self.t.tv_sec.saturating_mul(1_000_000_000).saturating_add(self.t.tv_nsec.as_inner().into())
+    }
 }
 
 impl AsInner<Timespec> for Instant {

--- a/library/std/src/thread/functions.rs
+++ b/library/std/src/thread/functions.rs
@@ -313,19 +313,21 @@ pub fn sleep(dur: Duration) {
 ///
 /// |  Platform |               System call                                            |
 /// |-----------|----------------------------------------------------------------------|
-/// | Linux     | [clock_nanosleep] (Monotonic Clock)                                  |
-/// | BSD except OpenBSD | [clock_nanosleep] (Monotonic Clock)                         |
-/// | Android   | [clock_nanosleep] (Monotonic Clock)                                  |
-/// | Solaris   | [clock_nanosleep] (Monotonic Clock)                                  |
-/// | Illumos   | [clock_nanosleep] (Monotonic Clock)                                  |
-/// | Dragonfly | [clock_nanosleep] (Monotonic Clock)                                  |
-/// | Hurd      | [clock_nanosleep] (Monotonic Clock)                                  |
-/// | Vxworks   | [clock_nanosleep] (Monotonic Clock)                                  |
+/// | Linux     | [`clock_nanosleep`] (Monotonic Clock)                                |
+/// | BSD except OpenBSD | [`clock_nanosleep`] (Monotonic Clock)                       |
+/// | Android   | [`clock_nanosleep`] (Monotonic Clock)                                |
+/// | Solaris   | [`clock_nanosleep`] (Monotonic Clock)                                |
+/// | Illumos   | [`clock_nanosleep`] (Monotonic Clock)                                |
+/// | Dragonfly | [`clock_nanosleep`] (Monotonic Clock)                                |
+/// | Hurd      | [`clock_nanosleep`] (Monotonic Clock)                                |
+/// | Vxworks   | [`clock_nanosleep`] (Monotonic Clock)                                |
 /// | Apple     | `mach_wait_until`                                                    |
+/// | Fuchsia   | [`zx_nanosleep`]                                                     |
 /// | Other     | `sleep_until` uses [`sleep`] and does not issue a syscall itself     |
 ///
 /// [currently]: crate::io#platform-specific-behavior
-/// [clock_nanosleep]: https://linux.die.net/man/3/clock_nanosleep
+/// [`clock_nanosleep`]: https://linux.die.net/man/3/clock_nanosleep
+/// [`zx_nanosleep`]: https://fuchsia.dev/reference/syscalls/nanosleep
 ///
 /// **Disclaimer:** These system calls might change over time.
 ///


### PR DESCRIPTION
Tracking issue: rust-lang/rust#113752

Unfortunately Fuchsia's `clock_nanosleep` is [only a stub](https://cs.opensource.google/fuchsia/fuchsia/+/main:zircon/third_party/ulib/musl/src/time/clock_nanosleep.c;l=4;drc=26e68e7948a6cc4a1c4a0c8eb19b7e4a2dc27153). The kernel's `zx_nanosleep` syscall however does exactly what's needed.

I've done a few drive-by changes in the two outer commits, our uses of `zx_time_t` use the `zx_instant_mono_t` alias nowadays and the syscall table in the `sleep_until` documentation didn't mark the function names as code.

@rustbot ping fuchsia