### PR TITLE
LinkedGraph: support adding nodes and edges in arbitrary order

### DIFF
--- a/compiler/rustc_data_structures/src/graph/linked_graph/tests.rs
+++ b/compiler/rustc_data_structures/src/graph/linked_graph/tests.rs
@@ -40,7 +40,7 @@ fn each_node() {
     let expected = ["A", "B", "C", "D", "E", "F"];
     graph.each_node(|idx, node| {
         assert_eq!(&expected[idx.0], graph.node_data(idx));
-        assert_eq!(expected[idx.0], node.data);
+        assert_eq!(expected[idx.0], node.data.unwrap());
         true
     });
 }

--- a/compiler/rustc_middle/src/dep_graph/retained.rs
+++ b/compiler/rustc_middle/src/dep_graph/retained.rs
@@ -1,6 +1,5 @@
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::graph::linked_graph::{Direction, INCOMING, LinkedGraph, NodeIndex};
-use rustc_index::IndexVec;
 
 use super::{DepNode, DepNodeIndex};
 
@@ -13,7 +12,6 @@ use super::{DepNode, DepNodeIndex};
 pub struct RetainedDepGraph {
     pub inner: LinkedGraph<DepNode, ()>,
     pub indices: FxHashMap<DepNode, NodeIndex>,
-    pub dep_index_to_index: IndexVec<DepNodeIndex, Option<NodeIndex>>,
 }
 
 impl RetainedDepGraph {
@@ -23,27 +21,22 @@ impl RetainedDepGraph {
 
         let inner = LinkedGraph::with_capacity(node_count, edge_count);
         let indices = FxHashMap::default();
-        let dep_index_to_index = IndexVec::new();
 
-        Self { inner, indices, dep_index_to_index }
+        Self { inner, indices }
     }
 
     pub fn push(&mut self, index: DepNodeIndex, node: DepNode, edges: &[DepNodeIndex]) {
-        let source = self.inner.add_node(node);
-        self.dep_index_to_index.insert(index, source);
+        let source = NodeIndex(index.as_usize());
+        self.inner.add_node_with_idx(source, node);
         self.indices.insert(node, source);
 
         for &target in edges.iter() {
-            // We may miss the edges that are pushed while the `DepGraphQuery` is being accessed.
-            // Skip them to issues.
-            if let Some(&Some(target)) = self.dep_index_to_index.get(target) {
-                self.inner.add_edge(source, target, ());
-            }
+            self.inner.add_edge(source, NodeIndex(target.as_usize()), ());
         }
     }
 
     pub fn nodes(&self) -> Vec<&DepNode> {
-        self.inner.all_nodes().iter().map(|n| &n.data).collect()
+        self.inner.all_nodes().iter().map(|n| n.data.as_ref().unwrap()).collect()
     }
 
     pub fn edges(&self) -> Vec<(&DepNode, &DepNode)> {


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/152621)*
<!-- homu-ignore:end -->

If an edge uses some not-yet-known node, we just leave the node's data empty, that data can be added later.

Use this support to avoid skipping edges in RetainedDepGraph.

This is continuation of https://github.com/rust-lang/rust/pull/152590, that PR just fixes the ICE, this PR also preserves all the edges in debug dumps.
This is also a minimized version of https://github.com/rust-lang/rust/pull/151821 with a smaller amount of data structure hacks.