### PR TITLE
Big query system cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4500,7 +4500,6 @@ dependencies = [
  "rustc_index",
  "rustc_macros",
  "rustc_middle",
- "rustc_query_system",
  "rustc_serialize",
  "rustc_session",
  "rustc_span",

--- a/compiler/rustc_incremental/src/assert_dep_graph.rs
+++ b/compiler/rustc_incremental/src/assert_dep_graph.rs
@@ -45,7 +45,7 @@ use rustc_hir::def_id::{CRATE_DEF_ID, DefId, LocalDefId};
 use rustc_hir::intravisit::{self, Visitor};
 use rustc_middle::bug;
 use rustc_middle::dep_graph::{
-    DepGraphQuery, DepKind, DepNode, DepNodeExt, DepNodeFilter, EdgeFilter, dep_kinds,
+    DepGraphQuery, DepKind, DepNode, DepNodeFilter, EdgeFilter, dep_kinds,
 };
 use rustc_middle::hir::nested_filter;
 use rustc_middle::ty::TyCtxt;

--- a/compiler/rustc_incremental/src/persist/clean.rs
+++ b/compiler/rustc_incremental/src/persist/clean.rs
@@ -27,7 +27,7 @@ use rustc_hir::{
     Attribute, ImplItemKind, ItemKind as HirItem, Node as HirNode, TraitItemKind, find_attr,
     intravisit,
 };
-use rustc_middle::dep_graph::{DepNode, DepNodeExt, dep_kind_from_label, label_strs};
+use rustc_middle::dep_graph::{DepNode, dep_kind_from_label, label_strs};
 use rustc_middle::hir::nested_filter;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::{Span, Symbol};

--- a/compiler/rustc_incremental/src/persist/load.rs
+++ b/compiler/rustc_incremental/src/persist/load.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use rustc_data_structures::memmap::Mmap;
 use rustc_data_structures::unord::UnordMap;
 use rustc_hashes::Hash64;
-use rustc_middle::dep_graph::{DepGraph, DepsType, SerializedDepGraph, WorkProductMap};
+use rustc_middle::dep_graph::{DepGraph, SerializedDepGraph, WorkProductMap};
 use rustc_middle::query::on_disk_cache::OnDiskCache;
 use rustc_serialize::Decodable;
 use rustc_serialize::opaque::MemDecoder;
@@ -171,7 +171,7 @@ fn load_dep_graph(sess: &Session) -> LoadResult<(Arc<SerializedDepGraph>, WorkPr
                 return LoadResult::DataOutOfDate;
             }
 
-            let dep_graph = SerializedDepGraph::decode::<DepsType>(&mut decoder);
+            let dep_graph = SerializedDepGraph::decode(&mut decoder);
 
             LoadResult::Ok { data: (dep_graph, prev_work_products) }
         }

--- a/compiler/rustc_interface/src/callbacks.rs
+++ b/compiler/rustc_interface/src/callbacks.rs
@@ -13,7 +13,7 @@ use std::fmt;
 
 use rustc_errors::{DiagInner, TRACK_DIAGNOSTIC};
 use rustc_middle::dep_graph::dep_node::default_dep_kind_debug;
-use rustc_middle::dep_graph::{DepContext, DepKind, DepNode, TaskDepsRef};
+use rustc_middle::dep_graph::{DepKind, DepNode, TaskDepsRef};
 use rustc_middle::ty::tls;
 
 fn track_span_parent(def_id: rustc_span::def_id::LocalDefId) {

--- a/compiler/rustc_interface/src/callbacks.rs
+++ b/compiler/rustc_interface/src/callbacks.rs
@@ -13,9 +13,8 @@ use std::fmt;
 
 use rustc_errors::{DiagInner, TRACK_DIAGNOSTIC};
 use rustc_middle::dep_graph::dep_node::default_dep_kind_debug;
-use rustc_middle::dep_graph::{DepContext, DepKind, DepNode, DepNodeExt, TaskDepsRef};
+use rustc_middle::dep_graph::{DepContext, DepKind, DepNode, TaskDepsRef};
 use rustc_middle::ty::tls;
-use rustc_query_impl::QueryCtxt;
 
 fn track_span_parent(def_id: rustc_span::def_id::LocalDefId) {
     tls::with_context_opt(|icx| {
@@ -41,7 +40,7 @@ fn track_span_parent(def_id: rustc_span::def_id::LocalDefId) {
 fn track_diagnostic<R>(diagnostic: DiagInner, f: &mut dyn FnMut(DiagInner) -> R) -> R {
     tls::with_context_opt(|icx| {
         if let Some(icx) = icx {
-            icx.tcx.dep_graph.record_diagnostic(QueryCtxt::new(icx.tcx), &diagnostic);
+            icx.tcx.dep_graph.record_diagnostic(icx.tcx, &diagnostic);
 
             // Diagnostics are tracked, we can ignore the dependency.
             let icx = tls::ImplicitCtxt { task_deps: TaskDepsRef::Ignore, ..icx.clone() };

--- a/compiler/rustc_middle/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node.rs
@@ -434,19 +434,7 @@ pub(crate) fn make_metadata(tcx: TyCtxt<'_>) -> DepNode {
     DepNode::construct(tcx, dep_kinds::Metadata, &())
 }
 
-pub trait DepNodeExt: Sized {
-    fn extract_def_id(&self, tcx: TyCtxt<'_>) -> Option<DefId>;
-
-    fn from_label_string(
-        tcx: TyCtxt<'_>,
-        label: &str,
-        def_path_hash: DefPathHash,
-    ) -> Result<Self, ()>;
-
-    fn has_label_string(label: &str) -> bool;
-}
-
-impl DepNodeExt for DepNode {
+impl DepNode {
     /// Extracts the DefId corresponding to this DepNode. This will work
     /// if two conditions are met:
     ///
@@ -457,7 +445,7 @@ impl DepNodeExt for DepNode {
     /// DepNode. Condition (2) might not be fulfilled if a DepNode
     /// refers to something from the previous compilation session that
     /// has been removed.
-    fn extract_def_id(&self, tcx: TyCtxt<'_>) -> Option<DefId> {
+    pub fn extract_def_id(&self, tcx: TyCtxt<'_>) -> Option<DefId> {
         if tcx.fingerprint_style(self.kind) == FingerprintStyle::DefPathHash {
             tcx.def_path_hash_to_def_id(DefPathHash(self.hash.into()))
         } else {
@@ -465,8 +453,7 @@ impl DepNodeExt for DepNode {
         }
     }
 
-    /// Used in testing
-    fn from_label_string(
+    pub fn from_label_string(
         tcx: TyCtxt<'_>,
         label: &str,
         def_path_hash: DefPathHash,
@@ -482,8 +469,7 @@ impl DepNodeExt for DepNode {
         }
     }
 
-    /// Used in testing
-    fn has_label_string(label: &str) -> bool {
+    pub fn has_label_string(label: &str) -> bool {
         dep_kind_from_label_string(label).is_ok()
     }
 }

--- a/compiler/rustc_middle/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node.rs
@@ -92,6 +92,26 @@ impl DepKind {
     pub const fn as_usize(&self) -> usize {
         self.variant as usize
     }
+
+    pub(crate) fn name(self) -> &'static str {
+        DEP_KIND_NAMES[self.as_usize()]
+    }
+
+    /// We use this for most things when incr. comp. is turned off.
+    pub(crate) const NULL: DepKind = dep_kinds::Null;
+
+    /// We use this to create a forever-red node.
+    pub(crate) const RED: DepKind = dep_kinds::Red;
+
+    /// We use this to create a side effect node.
+    pub(crate) const SIDE_EFFECT: DepKind = dep_kinds::SideEffect;
+
+    /// We use this to create the anon node with zero dependencies.
+    pub(crate) const ANON_ZERO_DEPS: DepKind = dep_kinds::AnonZeroDeps;
+
+    /// This is the highest value a `DepKind` can have. It's used during encoding to
+    /// pack information into the unused bits.
+    pub(crate) const MAX: u16 = DEP_KIND_VARIANTS - 1;
 }
 
 pub fn default_dep_kind_debug(kind: DepKind, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/compiler/rustc_middle/src/dep_graph/dep_node_key.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node_key.rs
@@ -3,7 +3,7 @@ use rustc_hir::def_id::{CrateNum, DefId, LOCAL_CRATE, LocalDefId, LocalModDefId,
 use rustc_hir::definitions::DefPathHash;
 use rustc_hir::{HirId, ItemLocalId, OwnerId};
 
-use crate::dep_graph::{DepContext, DepNode, DepNodeExt, DepNodeKey, FingerprintStyle};
+use crate::dep_graph::{DepContext, DepNode, DepNodeKey, FingerprintStyle};
 use crate::ty::TyCtxt;
 
 impl<'tcx> DepNodeKey<TyCtxt<'tcx>> for () {

--- a/compiler/rustc_middle/src/dep_graph/dep_node_key.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node_key.rs
@@ -3,10 +3,10 @@ use rustc_hir::def_id::{CrateNum, DefId, LOCAL_CRATE, LocalDefId, LocalModDefId,
 use rustc_hir::definitions::DefPathHash;
 use rustc_hir::{HirId, ItemLocalId, OwnerId};
 
-use crate::dep_graph::{DepContext, DepNode, DepNodeKey, FingerprintStyle};
+use crate::dep_graph::{DepNode, DepNodeKey, FingerprintStyle};
 use crate::ty::TyCtxt;
 
-impl<'tcx> DepNodeKey<TyCtxt<'tcx>> for () {
+impl<'tcx> DepNodeKey<'tcx> for () {
     #[inline(always)]
     fn fingerprint_style() -> FingerprintStyle {
         FingerprintStyle::Unit
@@ -23,7 +23,7 @@ impl<'tcx> DepNodeKey<TyCtxt<'tcx>> for () {
     }
 }
 
-impl<'tcx> DepNodeKey<TyCtxt<'tcx>> for DefId {
+impl<'tcx> DepNodeKey<'tcx> for DefId {
     #[inline(always)]
     fn fingerprint_style() -> FingerprintStyle {
         FingerprintStyle::DefPathHash
@@ -45,7 +45,7 @@ impl<'tcx> DepNodeKey<TyCtxt<'tcx>> for DefId {
     }
 }
 
-impl<'tcx> DepNodeKey<TyCtxt<'tcx>> for LocalDefId {
+impl<'tcx> DepNodeKey<'tcx> for LocalDefId {
     #[inline(always)]
     fn fingerprint_style() -> FingerprintStyle {
         FingerprintStyle::DefPathHash
@@ -67,7 +67,7 @@ impl<'tcx> DepNodeKey<TyCtxt<'tcx>> for LocalDefId {
     }
 }
 
-impl<'tcx> DepNodeKey<TyCtxt<'tcx>> for OwnerId {
+impl<'tcx> DepNodeKey<'tcx> for OwnerId {
     #[inline(always)]
     fn fingerprint_style() -> FingerprintStyle {
         FingerprintStyle::DefPathHash
@@ -89,7 +89,7 @@ impl<'tcx> DepNodeKey<TyCtxt<'tcx>> for OwnerId {
     }
 }
 
-impl<'tcx> DepNodeKey<TyCtxt<'tcx>> for CrateNum {
+impl<'tcx> DepNodeKey<'tcx> for CrateNum {
     #[inline(always)]
     fn fingerprint_style() -> FingerprintStyle {
         FingerprintStyle::DefPathHash
@@ -112,7 +112,7 @@ impl<'tcx> DepNodeKey<TyCtxt<'tcx>> for CrateNum {
     }
 }
 
-impl<'tcx> DepNodeKey<TyCtxt<'tcx>> for (DefId, DefId) {
+impl<'tcx> DepNodeKey<'tcx> for (DefId, DefId) {
     #[inline(always)]
     fn fingerprint_style() -> FingerprintStyle {
         FingerprintStyle::Opaque
@@ -139,7 +139,7 @@ impl<'tcx> DepNodeKey<TyCtxt<'tcx>> for (DefId, DefId) {
     }
 }
 
-impl<'tcx> DepNodeKey<TyCtxt<'tcx>> for HirId {
+impl<'tcx> DepNodeKey<'tcx> for HirId {
     #[inline(always)]
     fn fingerprint_style() -> FingerprintStyle {
         FingerprintStyle::HirId
@@ -182,7 +182,7 @@ impl<'tcx> DepNodeKey<TyCtxt<'tcx>> for HirId {
     }
 }
 
-impl<'tcx> DepNodeKey<TyCtxt<'tcx>> for ModDefId {
+impl<'tcx> DepNodeKey<'tcx> for ModDefId {
     #[inline(always)]
     fn fingerprint_style() -> FingerprintStyle {
         FingerprintStyle::DefPathHash
@@ -204,7 +204,7 @@ impl<'tcx> DepNodeKey<TyCtxt<'tcx>> for ModDefId {
     }
 }
 
-impl<'tcx> DepNodeKey<TyCtxt<'tcx>> for LocalModDefId {
+impl<'tcx> DepNodeKey<'tcx> for LocalModDefId {
     #[inline(always)]
     fn fingerprint_style() -> FingerprintStyle {
         FingerprintStyle::DefPathHash

--- a/compiler/rustc_middle/src/dep_graph/graph.rs
+++ b/compiler/rustc_middle/src/dep_graph/graph.rs
@@ -25,7 +25,7 @@ use {super::debug::EdgeFilter, std::env};
 
 use super::query::DepGraphQuery;
 use super::serialized::{GraphEncoder, SerializedDepGraph, SerializedDepNodeIndex};
-use super::{DepContext, DepKind, DepNode, Deps, DepsType, HasDepContext, WorkProductId};
+use super::{DepContext, DepKind, DepNode, DepsType, HasDepContext, WorkProductId};
 use crate::dep_graph::edges::EdgesVec;
 use crate::ty::TyCtxt;
 use crate::verify_ich::incremental_verify_ich;
@@ -252,7 +252,7 @@ impl DepGraph {
     }
 
     #[inline(always)]
-    pub fn with_task<Ctxt: HasDepContext<Deps = DepsType>, A: Debug, R>(
+    pub fn with_task<Ctxt: HasDepContext, A: Debug, R>(
         &self,
         key: DepNode,
         cx: Ctxt,
@@ -266,7 +266,7 @@ impl DepGraph {
         }
     }
 
-    pub fn with_anon_task<Tcx: DepContext<Deps = DepsType>, OP, R>(
+    pub fn with_anon_task<Tcx: DepContext, OP, R>(
         &self,
         cx: Tcx,
         dep_kind: DepKind,
@@ -315,7 +315,7 @@ impl DepGraphData {
     ///
     /// [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/queries/incremental-compilation.html
     #[inline(always)]
-    pub fn with_task<Ctxt: HasDepContext<Deps = DepsType>, A: Debug, R>(
+    pub fn with_task<Ctxt: HasDepContext, A: Debug, R>(
         &self,
         key: DepNode,
         cx: Ctxt,
@@ -369,7 +369,7 @@ impl DepGraphData {
     /// FIXME: This could perhaps return a `WithDepNode` to ensure that the
     /// user of this function actually performs the read; we'll have to see
     /// how to make that work with `anon` in `execute_job_incr`, though.
-    pub fn with_anon_task_inner<Tcx: DepContext<Deps = DepsType>, OP, R>(
+    pub fn with_anon_task_inner<Tcx: DepContext, OP, R>(
         &self,
         cx: Tcx,
         dep_kind: DepKind,
@@ -438,7 +438,7 @@ impl DepGraphData {
     }
 
     /// Intern the new `DepNode` with the dependencies up-to-now.
-    fn hash_result_and_alloc_node<Ctxt: DepContext<Deps = DepsType>, R>(
+    fn hash_result_and_alloc_node<Ctxt: DepContext, R>(
         &self,
         cx: &Ctxt,
         node: DepNode,
@@ -553,7 +553,7 @@ impl DepGraph {
     /// FIXME: If the code is changed enough for this node to be marked before requiring the
     /// caller's node, we suppose that those changes will be enough to mark this node red and
     /// force a recomputation using the "normal" way.
-    pub fn with_feed_task<Ctxt: DepContext<Deps = DepsType>, R>(
+    pub fn with_feed_task<Ctxt: DepContext, R>(
         &self,
         node: DepNode,
         cx: Ctxt,

--- a/compiler/rustc_middle/src/dep_graph/mod.rs
+++ b/compiler/rustc_middle/src/dep_graph/mod.rs
@@ -7,8 +7,7 @@ use rustc_session::Session;
 use tracing::instrument;
 
 pub use self::dep_node::{
-    DepKind, DepNode, DepNodeExt, DepNodeKey, WorkProductId, dep_kind_from_label, dep_kinds,
-    label_strs,
+    DepKind, DepNode, DepNodeKey, WorkProductId, dep_kind_from_label, dep_kinds, label_strs,
 };
 pub use self::graph::{
     DepGraphData, DepNodeIndex, TaskDepsRef, WorkProduct, WorkProductMap, hash_result,
@@ -52,6 +51,7 @@ pub trait DepContext: Copy {
 
     #[inline(always)]
     /// Return whether this kind always require evaluation.
+    // FIXME: remove this in favour of the version on `TyCtxt`.
     fn is_eval_always(self, kind: DepKind) -> bool {
         self.dep_kind_vtable(kind).is_eval_always
     }

--- a/compiler/rustc_middle/src/dep_graph/mod.rs
+++ b/compiler/rustc_middle/src/dep_graph/mod.rs
@@ -10,7 +10,7 @@ pub use self::dep_node::{
     DepKind, DepNode, DepNodeKey, WorkProductId, dep_kind_from_label, dep_kinds, label_strs,
 };
 pub use self::graph::{
-    DepGraphData, DepNodeIndex, TaskDepsRef, WorkProduct, WorkProductMap, hash_result,
+    DepGraph, DepGraphData, DepNodeIndex, TaskDepsRef, WorkProduct, WorkProductMap, hash_result,
 };
 use self::graph::{MarkFrame, print_markframe_trace};
 pub use self::query::DepGraphQuery;
@@ -34,7 +34,7 @@ pub trait DepContext: Copy {
     fn with_stable_hashing_context<R>(self, f: impl FnOnce(StableHashingContext<'_>) -> R) -> R;
 
     /// Access the DepGraph.
-    fn dep_graph(&self) -> &graph::DepGraph<Self::Deps>;
+    fn dep_graph(&self) -> &DepGraph;
 
     /// Access the profiler.
     fn profiler(&self) -> &SelfProfilerRef;
@@ -178,8 +178,6 @@ impl FingerprintStyle {
         }
     }
 }
-
-pub type DepGraph = graph::DepGraph<DepsType>;
 
 pub type DepKindVTable<'tcx> = dep_node::DepKindVTable<TyCtxt<'tcx>>;
 

--- a/compiler/rustc_middle/src/dep_graph/serialized.rs
+++ b/compiler/rustc_middle/src/dep_graph/serialized.rs
@@ -41,7 +41,6 @@
 
 use std::cell::RefCell;
 use std::cmp::max;
-use std::marker::PhantomData;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::{iter, mem, u64};
@@ -62,6 +61,7 @@ use tracing::{debug, instrument};
 use super::graph::{CurrentDepGraph, DepNodeColorMap};
 use super::query::DepGraphQuery;
 use super::{DepKind, DepNode, DepNodeIndex, Deps};
+use crate::dep_graph::DepsType;
 use crate::dep_graph::edges::EdgesVec;
 
 // The maximum value of `SerializedDepNodeIndex` leaves the upper two bits
@@ -192,7 +192,7 @@ fn mask(bits: usize) -> usize {
 
 impl SerializedDepGraph {
     #[instrument(level = "debug", skip(d))]
-    pub fn decode<D: Deps>(d: &mut MemDecoder<'_>) -> Arc<SerializedDepGraph> {
+    pub fn decode(d: &mut MemDecoder<'_>) -> Arc<SerializedDepGraph> {
         // The last 16 bytes are the node count and edge count.
         debug!("position: {:?}", d.position());
 
@@ -213,7 +213,10 @@ impl SerializedDepGraph {
         let graph_bytes = d.len() - (3 * IntEncodedWithFixedSize::ENCODED_SIZE) - d.position();
 
         let mut nodes = IndexVec::from_elem_n(
-            DepNode { kind: D::DEP_KIND_NULL, hash: PackedFingerprint::from(Fingerprint::ZERO) },
+            DepNode {
+                kind: DepsType::DEP_KIND_NULL,
+                hash: PackedFingerprint::from(Fingerprint::ZERO),
+            },
             node_max,
         );
         let mut fingerprints = IndexVec::from_elem_n(Fingerprint::ZERO, node_max);
@@ -230,19 +233,21 @@ impl SerializedDepGraph {
         // least (34 byte header + 1 byte len + 64 bytes edge data), which is ~1%. A 2-byte leb128
         // length is about the same fractional overhead and it amortizes for yet greater lengths.
         let mut edge_list_data =
-            Vec::with_capacity(graph_bytes - node_count * size_of::<SerializedNodeHeader<D>>());
+            Vec::with_capacity(graph_bytes - node_count * size_of::<SerializedNodeHeader>());
 
         for _ in 0..node_count {
             // Decode the header for this edge; the header packs together as many of the fixed-size
             // fields as possible to limit the number of times we update decoder state.
-            let node_header =
-                SerializedNodeHeader::<D> { bytes: d.read_array(), _marker: PhantomData };
+            let node_header = SerializedNodeHeader { bytes: d.read_array() };
 
             let index = node_header.index();
 
             let node = &mut nodes[index];
             // Make sure there's no duplicate indices in the dep graph.
-            assert!(node_header.node().kind != D::DEP_KIND_NULL && node.kind == D::DEP_KIND_NULL);
+            assert!(
+                node_header.node().kind != DepsType::DEP_KIND_NULL
+                    && node.kind == DepsType::DEP_KIND_NULL
+            );
             *node = node_header.node();
 
             fingerprints[index] = node_header.fingerprint();
@@ -270,7 +275,7 @@ impl SerializedDepGraph {
         edge_list_data.extend(&[0u8; DEP_NODE_PAD]);
 
         // Read the number of each dep kind and use it to create an hash map with a suitable size.
-        let mut index: Vec<_> = (0..(D::DEP_KIND_MAX + 1))
+        let mut index: Vec<_> = (0..(DepsType::DEP_KIND_MAX + 1))
             .map(|_| UnhashMap::with_capacity_and_hasher(d.read_u32() as usize, Default::default()))
             .collect();
 
@@ -279,8 +284,10 @@ impl SerializedDepGraph {
         for (idx, node) in nodes.iter_enumerated() {
             if index[node.kind.as_usize()].insert(node.hash, idx).is_some() {
                 // Empty nodes and side effect nodes can have duplicates
-                if node.kind != D::DEP_KIND_NULL && node.kind != D::DEP_KIND_SIDE_EFFECT {
-                    let name = D::name(node.kind);
+                if node.kind != DepsType::DEP_KIND_NULL
+                    && node.kind != DepsType::DEP_KIND_SIDE_EFFECT
+                {
+                    let name = DepsType::name(node.kind);
                     panic!(
                     "Error: A dep graph node ({name}) does not have an unique index. \
                      Running a clean build on a nightly compiler with `-Z incremental-verify-ich` \
@@ -310,13 +317,12 @@ impl SerializedDepGraph {
 /// * The `DepKind`'s discriminant (a u16, but not all bits are used...)
 /// * The byte width of the encoded edges for this node
 /// * In whatever bits remain, the length of the edge list for this node, if it fits
-struct SerializedNodeHeader<D> {
+struct SerializedNodeHeader {
     // 2 bytes for the DepNode
     // 4 bytes for the index
     // 16 for Fingerprint in DepNode
     // 16 for Fingerprint in NodeInfo
     bytes: [u8; 38],
-    _marker: PhantomData<D>,
 }
 
 // The fields of a `SerializedNodeHeader`, this struct is an implementation detail and exists only
@@ -337,11 +343,11 @@ struct Unpacked {
 // 0..M    length of the edge
 // M..M+N  bytes per index
 // M+N..16 kind
-impl<D: Deps> SerializedNodeHeader<D> {
+impl SerializedNodeHeader {
     const TOTAL_BITS: usize = size_of::<DepKind>() * 8;
     const LEN_BITS: usize = Self::TOTAL_BITS - Self::KIND_BITS - Self::WIDTH_BITS;
     const WIDTH_BITS: usize = DEP_NODE_WIDTH_BITS;
-    const KIND_BITS: usize = Self::TOTAL_BITS - D::DEP_KIND_MAX.leading_zeros() as usize;
+    const KIND_BITS: usize = Self::TOTAL_BITS - DepsType::DEP_KIND_MAX.leading_zeros() as usize;
     const MAX_INLINE_LEN: usize = (u16::MAX as usize >> (Self::TOTAL_BITS - Self::LEN_BITS)) - 1;
 
     #[inline]
@@ -377,14 +383,14 @@ impl<D: Deps> SerializedNodeHeader<D> {
 
         #[cfg(debug_assertions)]
         {
-            let res = Self { bytes, _marker: PhantomData };
+            let res = Self { bytes };
             assert_eq!(fingerprint, res.fingerprint());
             assert_eq!(*node, res.node());
             if let Some(len) = res.len() {
                 assert_eq!(edge_count, len as usize);
             }
         }
-        Self { bytes, _marker: PhantomData }
+        Self { bytes }
     }
 
     #[inline]
@@ -451,15 +457,10 @@ struct NodeInfo {
 }
 
 impl NodeInfo {
-    fn encode<D: Deps>(&self, e: &mut MemEncoder, index: DepNodeIndex) {
+    fn encode(&self, e: &mut MemEncoder, index: DepNodeIndex) {
         let NodeInfo { ref node, fingerprint, ref edges } = *self;
-        let header = SerializedNodeHeader::<D>::new(
-            node,
-            index,
-            fingerprint,
-            edges.max_index(),
-            edges.len(),
-        );
+        let header =
+            SerializedNodeHeader::new(node, index, fingerprint, edges.max_index(), edges.len());
         e.write_array(header.bytes);
 
         if header.len().is_none() {
@@ -480,7 +481,7 @@ impl NodeInfo {
     /// the previous dep graph and expects all edges to already have a new dep node index assigned.
     /// This avoids the overhead of constructing `EdgesVec`, which would be needed to call `encode`.
     #[inline]
-    fn encode_promoted<D: Deps>(
+    fn encode_promoted(
         e: &mut MemEncoder,
         node: &DepNode,
         index: DepNodeIndex,
@@ -496,7 +497,7 @@ impl NodeInfo {
         let edge_max =
             edges.clone().map(|i| colors.current(i).unwrap().as_u32()).max().unwrap_or(0);
 
-        let header = SerializedNodeHeader::<D>::new(node, index, fingerprint, edge_max, edge_count);
+        let header = SerializedNodeHeader::new(node, index, fingerprint, edge_max, edge_count);
         e.write_array(header.bytes);
 
         if header.len().is_none() {
@@ -543,16 +544,15 @@ struct LocalEncoderResult {
     kind_stats: Vec<u32>,
 }
 
-struct EncoderState<D: Deps> {
+struct EncoderState {
     next_node_index: AtomicU64,
     previous: Arc<SerializedDepGraph>,
     file: Lock<Option<FileEncoder>>,
     local: WorkerLocal<RefCell<LocalEncoderState>>,
     stats: Option<Lock<FxHashMap<DepKind, Stat>>>,
-    marker: PhantomData<D>,
 }
 
-impl<D: Deps> EncoderState<D> {
+impl EncoderState {
     fn new(encoder: FileEncoder, record_stats: bool, previous: Arc<SerializedDepGraph>) -> Self {
         Self {
             previous,
@@ -566,10 +566,9 @@ impl<D: Deps> EncoderState<D> {
                     edge_count: 0,
                     node_count: 0,
                     encoder: MemEncoder::new(),
-                    kind_stats: iter::repeat_n(0, D::DEP_KIND_MAX as usize + 1).collect(),
+                    kind_stats: iter::repeat_n(0, DepsType::DEP_KIND_MAX as usize + 1).collect(),
                 })
             }),
-            marker: PhantomData,
         }
     }
 
@@ -658,7 +657,7 @@ impl<D: Deps> EncoderState<D> {
         record_graph: &Option<Lock<DepGraphQuery>>,
         local: &mut LocalEncoderState,
     ) {
-        node.encode::<D>(&mut local.encoder, index);
+        node.encode(&mut local.encoder, index);
         self.flush_mem_encoder(&mut *local);
         self.record(
             &node.node,
@@ -687,7 +686,7 @@ impl<D: Deps> EncoderState<D> {
     ) {
         let node = self.previous.index_to_node(prev_index);
         let fingerprint = self.previous.fingerprint_by_index(prev_index);
-        let edge_count = NodeInfo::encode_promoted::<D>(
+        let edge_count = NodeInfo::encode_promoted(
             &mut local.encoder,
             node,
             index,
@@ -712,7 +711,7 @@ impl<D: Deps> EncoderState<D> {
         );
     }
 
-    fn finish(&self, profiler: &SelfProfilerRef, current: &CurrentDepGraph<D>) -> FileEncodeResult {
+    fn finish(&self, profiler: &SelfProfilerRef, current: &CurrentDepGraph) -> FileEncodeResult {
         // Prevent more indices from being allocated.
         self.next_node_index.store(u32::MAX as u64 + 1, Ordering::SeqCst);
 
@@ -735,7 +734,8 @@ impl<D: Deps> EncoderState<D> {
 
         let mut encoder = self.file.lock().take().unwrap();
 
-        let mut kind_stats: Vec<u32> = iter::repeat_n(0, D::DEP_KIND_MAX as usize + 1).collect();
+        let mut kind_stats: Vec<u32> =
+            iter::repeat_n(0, DepsType::DEP_KIND_MAX as usize + 1).collect();
 
         let mut node_max = 0;
         let mut node_count = 0;
@@ -778,7 +778,7 @@ impl<D: Deps> EncoderState<D> {
 
     fn print_incremental_info(
         &self,
-        current: &CurrentDepGraph<D>,
+        current: &CurrentDepGraph,
         total_node_count: usize,
         total_edge_count: usize,
     ) {
@@ -835,13 +835,13 @@ impl<D: Deps> EncoderState<D> {
     }
 }
 
-pub(crate) struct GraphEncoder<D: Deps> {
+pub(crate) struct GraphEncoder {
     profiler: SelfProfilerRef,
-    status: EncoderState<D>,
+    status: EncoderState,
     record_graph: Option<Lock<DepGraphQuery>>,
 }
 
-impl<D: Deps> GraphEncoder<D> {
+impl GraphEncoder {
     pub(crate) fn new(
         sess: &Session,
         encoder: FileEncoder,
@@ -945,7 +945,7 @@ impl<D: Deps> GraphEncoder<D> {
         }
     }
 
-    pub(crate) fn finish(&self, current: &CurrentDepGraph<D>) -> FileEncodeResult {
+    pub(crate) fn finish(&self, current: &CurrentDepGraph) -> FileEncodeResult {
         let _prof_timer = self.profiler.generic_activity("incr_comp_encode_dep_graph_finish");
 
         self.status.finish(&self.profiler, current)

--- a/compiler/rustc_middle/src/dep_graph/serialized.rs
+++ b/compiler/rustc_middle/src/dep_graph/serialized.rs
@@ -60,7 +60,7 @@ use tracing::{debug, instrument};
 
 use super::graph::{CurrentDepGraph, DepNodeColorMap};
 use super::query::DepGraphQuery;
-use super::{DepKind, DepNode, DepNodeIndex, Deps};
+use super::{DepKind, DepNode, DepNodeIndex};
 use crate::dep_graph::DepsType;
 use crate::dep_graph::edges::EdgesVec;
 

--- a/compiler/rustc_middle/src/query/inner.rs
+++ b/compiler/rustc_middle/src/query/inner.rs
@@ -105,7 +105,7 @@ pub(crate) fn query_feed<'tcx, Cache>(
     value: Cache::Value,
 ) where
     Cache: QueryCache,
-    Cache::Key: DepNodeKey<TyCtxt<'tcx>>,
+    Cache::Key: DepNodeKey<'tcx>,
 {
     let format_value = query_vtable.format_value;
 

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1,6 +1,4 @@
-use rustc_data_structures::jobserver::Proxy;
 use rustc_hir::def_id::LocalDefId;
-use rustc_query_system::query::QuerySideEffect;
 
 pub use self::caches::{
     DefIdCache, DefaultCache, QueryCache, QueryCacheKey, SingleCache, VecCache,
@@ -12,7 +10,6 @@ pub use self::plumbing::{
     TyCtxtAt, TyCtxtEnsureDone, TyCtxtEnsureOk,
 };
 pub use self::stack::{QueryStackDeferred, QueryStackFrame, QueryStackFrameExtra};
-use crate::dep_graph::{DepNodeIndex, HasDepContext, SerializedDepNodeIndex};
 pub use crate::queries::Providers;
 use crate::ty::TyCtxt;
 
@@ -35,19 +32,4 @@ pub fn describe_as_module(def_id: impl Into<LocalDefId>, tcx: TyCtxt<'_>) -> Str
     } else {
         format!("module `{}`", tcx.def_path_str(def_id))
     }
-}
-
-pub trait QueryContext<'tcx>: HasDepContext {
-    /// Gets a jobserver reference which is used to release then acquire
-    /// a token while waiting on a query.
-    fn jobserver_proxy(&self) -> &Proxy;
-
-    /// Load a side effect associated to the node in the previous session.
-    fn load_side_effect(
-        self,
-        prev_dep_node_index: SerializedDepNodeIndex,
-    ) -> Option<QuerySideEffect>;
-
-    /// Register a side effect for the given node, for use in next session.
-    fn store_side_effect(self, dep_node_index: DepNodeIndex, side_effect: QuerySideEffect);
 }

--- a/compiler/rustc_middle/src/verify_ich.rs
+++ b/compiler/rustc_middle/src/verify_ich.rs
@@ -10,7 +10,7 @@ use crate::dep_graph::{DepContext, DepGraphData, SerializedDepNodeIndex};
 #[instrument(skip(tcx, dep_graph_data, result, hash_result, format_value), level = "debug")]
 pub fn incremental_verify_ich<Tcx, V>(
     tcx: Tcx,
-    dep_graph_data: &DepGraphData<Tcx::Deps>,
+    dep_graph_data: &DepGraphData,
     result: &V,
     prev_index: SerializedDepNodeIndex,
     hash_result: Option<fn(&mut StableHashingContext<'_>, &V) -> Fingerprint>,

--- a/compiler/rustc_middle/src/verify_ich.rs
+++ b/compiler/rustc_middle/src/verify_ich.rs
@@ -4,20 +4,19 @@ use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_query_system::ich::StableHashingContext;
 use tracing::instrument;
 
-use crate::dep_graph::{DepContext, DepGraphData, SerializedDepNodeIndex};
+use crate::dep_graph::{DepGraphData, SerializedDepNodeIndex};
+use crate::ty::TyCtxt;
 
 #[inline]
 #[instrument(skip(tcx, dep_graph_data, result, hash_result, format_value), level = "debug")]
-pub fn incremental_verify_ich<Tcx, V>(
-    tcx: Tcx,
+pub fn incremental_verify_ich<'tcx, V>(
+    tcx: TyCtxt<'tcx>,
     dep_graph_data: &DepGraphData,
     result: &V,
     prev_index: SerializedDepNodeIndex,
     hash_result: Option<fn(&mut StableHashingContext<'_>, &V) -> Fingerprint>,
     format_value: fn(&V) -> String,
-) where
-    Tcx: DepContext,
-{
+) {
     if !dep_graph_data.is_index_green(prev_index) {
         incremental_verify_ich_not_green(tcx, prev_index)
     }
@@ -35,13 +34,10 @@ pub fn incremental_verify_ich<Tcx, V>(
 
 #[cold]
 #[inline(never)]
-fn incremental_verify_ich_not_green<Tcx>(tcx: Tcx, prev_index: SerializedDepNodeIndex)
-where
-    Tcx: DepContext,
-{
+fn incremental_verify_ich_not_green<'tcx>(tcx: TyCtxt<'tcx>, prev_index: SerializedDepNodeIndex) {
     panic!(
         "fingerprint for green query instance not loaded from cache: {:?}",
-        tcx.dep_graph().data().unwrap().prev_node_of(prev_index)
+        tcx.dep_graph.data().unwrap().prev_node_of(prev_index)
     )
 }
 
@@ -50,13 +46,11 @@ where
 // chew on (and filling up the final binary, too).
 #[cold]
 #[inline(never)]
-fn incremental_verify_ich_failed<Tcx>(
-    tcx: Tcx,
+fn incremental_verify_ich_failed<'tcx>(
+    tcx: TyCtxt<'tcx>,
     prev_index: SerializedDepNodeIndex,
     result: &dyn Fn() -> String,
-) where
-    Tcx: DepContext,
-{
+) {
     // When we emit an error message and panic, we try to debug-print the `DepNode`
     // and query result. Unfortunately, this can cause us to run additional queries,
     // which may result in another fingerprint mismatch while we're in the middle
@@ -70,16 +64,16 @@ fn incremental_verify_ich_failed<Tcx>(
     let old_in_panic = INSIDE_VERIFY_PANIC.replace(true);
 
     if old_in_panic {
-        tcx.sess().dcx().emit_err(crate::error::Reentrant);
+        tcx.dcx().emit_err(crate::error::Reentrant);
     } else {
-        let run_cmd = if let Some(crate_name) = &tcx.sess().opts.crate_name {
+        let run_cmd = if let Some(crate_name) = &tcx.sess.opts.crate_name {
             format!("`cargo clean -p {crate_name}` or `cargo clean`")
         } else {
             "`cargo clean`".to_string()
         };
 
-        let dep_node = tcx.dep_graph().data().unwrap().prev_node_of(prev_index);
-        tcx.sess().dcx().emit_err(crate::error::IncrementCompilation {
+        let dep_node = tcx.dep_graph.data().unwrap().prev_node_of(prev_index);
+        tcx.dcx().emit_err(crate::error::IncrementCompilation {
             run_cmd,
             dep_node: format!("{dep_node:?}"),
         });

--- a/compiler/rustc_query_impl/Cargo.toml
+++ b/compiler/rustc_query_impl/Cargo.toml
@@ -14,7 +14,6 @@ rustc_hir = { path = "../rustc_hir" }
 rustc_index = { path = "../rustc_index" }
 rustc_macros = { path = "../rustc_macros" }
 rustc_middle = { path = "../rustc_middle" }
-rustc_query_system = { path = "../rustc_query_system" }
 rustc_serialize = { path = "../rustc_serialize" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }

--- a/compiler/rustc_query_impl/src/dep_kind_vtables.rs
+++ b/compiler/rustc_query_impl/src/dep_kind_vtables.rs
@@ -4,7 +4,7 @@ use rustc_middle::query::QueryCache;
 use rustc_middle::ty::TyCtxt;
 
 use crate::plumbing::{force_from_dep_node_inner, try_load_from_on_disk_cache_inner};
-use crate::{QueryCtxt, QueryDispatcherUnerased, QueryFlags};
+use crate::{QueryDispatcherUnerased, QueryFlags};
 
 /// [`DepKindVTable`] constructors for special dep kinds that aren't queries.
 #[expect(non_snake_case, reason = "use non-snake case to avoid collision with query names")]
@@ -45,7 +45,7 @@ mod non_query {
             is_eval_always: false,
             fingerprint_style: FingerprintStyle::Unit,
             force_from_dep_node: Some(|tcx, _, prev_index| {
-                tcx.dep_graph.force_diagnostic_node(QueryCtxt::new(tcx), prev_index);
+                tcx.dep_graph.force_diagnostic_node(tcx, prev_index);
                 true
             }),
             try_load_from_on_disk_cache: None,

--- a/compiler/rustc_query_impl/src/dep_kind_vtables.rs
+++ b/compiler/rustc_query_impl/src/dep_kind_vtables.rs
@@ -1,7 +1,6 @@
 use rustc_middle::bug;
 use rustc_middle::dep_graph::{DepKindVTable, DepNodeKey, FingerprintStyle};
 use rustc_middle::query::QueryCache;
-use rustc_middle::ty::TyCtxt;
 
 use crate::plumbing::{force_from_dep_node_inner, try_load_from_on_disk_cache_inner};
 use crate::{QueryDispatcherUnerased, QueryFlags};
@@ -122,7 +121,7 @@ where
     let fingerprint_style = if is_anon {
         FingerprintStyle::Opaque
     } else {
-        <Cache::Key as DepNodeKey<TyCtxt<'tcx>>>::fingerprint_style()
+        <Cache::Key as DepNodeKey<'tcx>>::fingerprint_style()
     };
 
     if is_anon || !fingerprint_style.reconstructible() {

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -495,7 +495,7 @@ fn try_load_from_disk_and_cache_in_memory<'tcx, C: QueryCache, const FLAGS: Quer
     // Note this function can be called concurrently from the same query
     // We must ensure that this is handled correctly.
 
-    let (prev_dep_node_index, dep_node_index) = dep_graph_data.try_mark_green(qcx, dep_node)?;
+    let (prev_dep_node_index, dep_node_index) = dep_graph_data.try_mark_green(qcx.tcx, dep_node)?;
 
     debug_assert!(dep_graph_data.is_index_green(prev_dep_node_index));
 
@@ -602,7 +602,7 @@ fn ensure_must_run<'tcx, C: QueryCache, const FLAGS: QueryFlags>(
     let dep_node = query.construct_dep_node(qcx.tcx, key);
 
     let dep_graph = &qcx.tcx.dep_graph;
-    let serialized_dep_node_index = match dep_graph.try_mark_green(qcx, &dep_node) {
+    let serialized_dep_node_index = match dep_graph.try_mark_green(qcx.tcx, &dep_node) {
         None => {
             // A None return from `try_mark_green` means that this is either
             // a new dep node or that the dep node has already been marked red.

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -5,7 +5,7 @@ use rustc_data_structures::hash_table::{Entry, HashTable};
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_data_structures::{outline, sharded, sync};
 use rustc_errors::{Diag, FatalError, StashKey};
-use rustc_middle::dep_graph::{DepGraphData, DepNodeKey, DepsType, HasDepContext};
+use rustc_middle::dep_graph::{DepGraphData, DepNodeKey, HasDepContext};
 use rustc_middle::query::{
     ActiveKeyStatus, CycleError, CycleErrorHandling, QueryCache, QueryJob, QueryJobId, QueryLatch,
     QueryMode, QueryStackDeferred, QueryStackFrame, QueryState,
@@ -438,7 +438,7 @@ fn execute_job_non_incr<'tcx, C: QueryCache, const FLAGS: QueryFlags>(
 fn execute_job_incr<'tcx, C: QueryCache, const FLAGS: QueryFlags>(
     query: SemiDynamicQueryDispatcher<'tcx, C, FLAGS>,
     qcx: QueryCtxt<'tcx>,
-    dep_graph_data: &DepGraphData<DepsType>,
+    dep_graph_data: &DepGraphData,
     key: C::Key,
     mut dep_node_opt: Option<DepNode>,
     job_id: QueryJobId,
@@ -487,7 +487,7 @@ fn execute_job_incr<'tcx, C: QueryCache, const FLAGS: QueryFlags>(
 #[inline(always)]
 fn try_load_from_disk_and_cache_in_memory<'tcx, C: QueryCache, const FLAGS: QueryFlags>(
     query: SemiDynamicQueryDispatcher<'tcx, C, FLAGS>,
-    dep_graph_data: &DepGraphData<DepsType>,
+    dep_graph_data: &DepGraphData,
     qcx: QueryCtxt<'tcx>,
     key: &C::Key,
     dep_node: &DepNode,

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -14,7 +14,7 @@ use rustc_middle::ty::TyCtxt;
 use rustc_middle::verify_ich::incremental_verify_ich;
 use rustc_span::{DUMMY_SP, Span};
 
-use crate::dep_graph::{DepContext, DepNode, DepNodeIndex};
+use crate::dep_graph::{DepNode, DepNodeIndex};
 use crate::job::{QueryJobInfo, QueryJobMap, find_cycle_in_stack, report_cycle};
 use crate::{QueryCtxt, QueryFlags, SemiDynamicQueryDispatcher};
 
@@ -535,7 +535,7 @@ fn try_load_from_disk_and_cache_in_memory<'tcx, C: QueryCache, const FLAGS: Quer
     // can be forced from `DepNode`.
     debug_assert!(
         !query.will_cache_on_disk_for_key(qcx.tcx, key)
-            || !qcx.dep_context().fingerprint_style(dep_node.kind).reconstructible(),
+            || !qcx.tcx.fingerprint_style(dep_node.kind).reconstructible(),
         "missing on-disk cache entry for {dep_node:?}"
     );
 

--- a/compiler/rustc_query_impl/src/job.rs
+++ b/compiler/rustc_query_impl/src/job.rs
@@ -13,7 +13,6 @@ use rustc_session::Session;
 use rustc_span::{DUMMY_SP, Span};
 
 use crate::QueryCtxt;
-use crate::dep_graph::DepContext;
 
 /// Map from query job IDs to job information collected by
 /// `collect_active_jobs_from_all_queries`.

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -4,7 +4,6 @@
 
 use std::num::NonZero;
 
-use rustc_data_structures::jobserver::Proxy;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::sync::{DynSend, DynSync};
 use rustc_data_structures::unord::UnordMap;
@@ -24,14 +23,12 @@ use rustc_middle::query::on_disk_cache::{
 };
 use rustc_middle::query::plumbing::QueryVTable;
 use rustc_middle::query::{
-    Key, QueryCache, QueryContext, QueryJobId, QueryStackDeferred, QueryStackFrame,
-    QueryStackFrameExtra,
+    Key, QueryCache, QueryJobId, QueryStackDeferred, QueryStackFrame, QueryStackFrameExtra,
 };
 use rustc_middle::ty::codec::TyEncoder;
 use rustc_middle::ty::print::with_reduced_queries;
 use rustc_middle::ty::tls::{self, ImplicitCtxt};
 use rustc_middle::ty::{self, TyCtxt};
-use rustc_query_system::query::QuerySideEffect;
 use rustc_serialize::{Decodable, Encodable};
 use rustc_span::def_id::LOCAL_CRATE;
 
@@ -40,8 +37,6 @@ use crate::execution::{all_inactive, force_query};
 use crate::job::{QueryJobMap, find_dep_kind_root};
 use crate::{QueryDispatcherUnerased, QueryFlags, SemiDynamicQueryDispatcher};
 
-/// Implements [`QueryContext`] for use by [`rustc_query_system`], since that
-/// crate does not have direct access to [`TyCtxt`].
 #[derive(Copy, Clone)]
 pub struct QueryCtxt<'tcx> {
     pub tcx: TyCtxt<'tcx>,
@@ -156,35 +151,8 @@ impl<'tcx> HasDepContext for QueryCtxt<'tcx> {
     }
 }
 
-impl<'tcx> QueryContext<'tcx> for QueryCtxt<'tcx> {
-    #[inline]
-    fn jobserver_proxy(&self) -> &Proxy {
-        &self.tcx.jobserver_proxy
-    }
-
-    // Interactions with on_disk_cache
-    fn load_side_effect(
-        self,
-        prev_dep_node_index: SerializedDepNodeIndex,
-    ) -> Option<QuerySideEffect> {
-        self.tcx
-            .query_system
-            .on_disk_cache
-            .as_ref()
-            .and_then(|c| c.load_side_effect(self.tcx, prev_dep_node_index))
-    }
-
-    #[inline(never)]
-    #[cold]
-    fn store_side_effect(self, dep_node_index: DepNodeIndex, side_effect: QuerySideEffect) {
-        if let Some(c) = self.tcx.query_system.on_disk_cache.as_ref() {
-            c.store_side_effect(dep_node_index, side_effect)
-        }
-    }
-}
-
 pub(super) fn try_mark_green<'tcx>(tcx: TyCtxt<'tcx>, dep_node: &dep_graph::DepNode) -> bool {
-    tcx.dep_graph.try_mark_green(QueryCtxt::new(tcx), dep_node).is_some()
+    tcx.dep_graph.try_mark_green(tcx, dep_node).is_some()
 }
 
 pub(super) fn encode_all_query_results<'tcx>(

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -15,8 +15,7 @@ use rustc_middle::bug;
 #[expect(unused_imports, reason = "used by doc comments")]
 use rustc_middle::dep_graph::DepKindVTable;
 use rustc_middle::dep_graph::{
-    self, DepContext, DepNode, DepNodeIndex, DepNodeKey, HasDepContext, SerializedDepNodeIndex,
-    dep_kinds,
+    self, DepNode, DepNodeIndex, DepNodeKey, HasDepContext, SerializedDepNodeIndex, dep_kinds,
 };
 use rustc_middle::query::on_disk_cache::{
     AbsoluteBytePos, CacheDecoder, CacheEncoder, EncodedDepNodeIndex,
@@ -141,12 +140,10 @@ impl<'tcx> QueryCtxt<'tcx> {
     }
 }
 
-impl<'tcx> HasDepContext for QueryCtxt<'tcx> {
-    type DepContext = TyCtxt<'tcx>;
-
+impl<'tcx> HasDepContext<'tcx> for QueryCtxt<'tcx> {
     #[inline]
-    fn dep_context(&self) -> &Self::DepContext {
-        &self.tcx
+    fn dep_context(&self) -> TyCtxt<'tcx> {
+        self.tcx
     }
 }
 
@@ -165,7 +162,7 @@ pub(super) fn encode_all_query_results<'tcx>(
 }
 
 pub fn query_key_hash_verify_all<'tcx>(tcx: TyCtxt<'tcx>) {
-    if tcx.sess().opts.unstable_opts.incremental_verify_ich || cfg!(debug_assertions) {
+    if tcx.sess.opts.unstable_opts.incremental_verify_ich || cfg!(debug_assertions) {
         tcx.sess.time("query_key_hash_verify_all", || {
             for verify in super::QUERY_KEY_HASH_VERIFY.iter() {
                 verify(tcx);

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -15,8 +15,8 @@ use rustc_middle::bug;
 #[expect(unused_imports, reason = "used by doc comments")]
 use rustc_middle::dep_graph::DepKindVTable;
 use rustc_middle::dep_graph::{
-    self, DepContext, DepNode, DepNodeIndex, DepNodeKey, DepsType, HasDepContext,
-    SerializedDepNodeIndex, dep_kinds,
+    self, DepContext, DepNode, DepNodeIndex, DepNodeKey, HasDepContext, SerializedDepNodeIndex,
+    dep_kinds,
 };
 use rustc_middle::query::on_disk_cache::{
     AbsoluteBytePos, CacheDecoder, CacheEncoder, EncodedDepNodeIndex,
@@ -142,7 +142,6 @@ impl<'tcx> QueryCtxt<'tcx> {
 }
 
 impl<'tcx> HasDepContext for QueryCtxt<'tcx> {
-    type Deps = DepsType;
     type DepContext = TyCtxt<'tcx>;
 
     #[inline]

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -60,7 +60,6 @@ use rustc_hir::lang_items::LangItem;
 use rustc_hir::{self as hir};
 use rustc_macros::extension;
 use rustc_middle::bug;
-use rustc_middle::dep_graph::DepContext;
 use rustc_middle::traits::PatternOriginExpr;
 use rustc_middle::ty::error::{ExpectedFound, TypeError, TypeErrorToStringExt};
 use rustc_middle::ty::print::{PrintTraitRefExt as _, WrapBinderMode, with_forced_trimmed_paths};
@@ -1757,7 +1756,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 // containing a single ASCII character, perhaps the user meant to write `b'c'` to
                 // specify a byte literal
                 (ty::Uint(ty::UintTy::U8), ty::Char) => {
-                    if let Ok(code) = self.tcx.sess().source_map().span_to_snippet(span)
+                    if let Ok(code) = self.tcx.sess.source_map().span_to_snippet(span)
                         && let Some(code) = code.strip_circumfix('\'', '\'')
                         // forbid all Unicode escapes
                         && !code.starts_with("\\u")
@@ -1774,7 +1773,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 // containing a single character, perhaps the user meant to write `'c'` to
                 // specify a character literal (issue #92479)
                 (ty::Char, ty::Ref(_, r, _)) if r.is_str() => {
-                    if let Ok(code) = self.tcx.sess().source_map().span_to_snippet(span)
+                    if let Ok(code) = self.tcx.sess.source_map().span_to_snippet(span)
                         && let Some(code) = code.strip_circumfix('"', '"')
                         && code.chars().count() == 1
                     {
@@ -1787,7 +1786,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 // If a string was expected and the found expression is a character literal,
                 // perhaps the user meant to write `"s"` to specify a string literal.
                 (ty::Ref(_, r, _), ty::Char) if r.is_str() => {
-                    if let Ok(code) = self.tcx.sess().source_map().span_to_snippet(span)
+                    if let Ok(code) = self.tcx.sess.source_map().span_to_snippet(span)
                         && code.starts_with("'")
                         && code.ends_with("'")
                     {
@@ -1928,7 +1927,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             return None;
         }
 
-        let Ok(code) = self.tcx.sess().source_map().span_to_snippet(span) else { return None };
+        let Ok(code) = self.tcx.sess.source_map().span_to_snippet(span) else { return None };
 
         let sugg = if code.starts_with('(') && code.ends_with(')') {
             let before_close = span.hi() - BytePos::from_u32(1);
@@ -2005,7 +2004,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 // Use the terminal width as the basis to determine when to compress the printed
                 // out type, but give ourselves some leeway to avoid ending up creating a file for
                 // a type that is somewhat shorter than the path we'd write to.
-                let len = self.tcx.sess().diagnostic_width() + 40;
+                let len = self.tcx.sess.diagnostic_width() + 40;
                 let exp_s = exp.content();
                 let fnd_s = fnd.content();
                 if exp_s.len() > len {


### PR DESCRIPTION
Recent PRs have moved a lot of code from `rustc_query_system` to `rustc_middle` and `rustc_query_impl`, where this code now has access to `TyCtxt`, e.g. rust-lang/rust#152419, rust-lang/rust#152516. As a result, a lot of abstraction and indirection that existed to work around this limitation is no longer necessary. This PR removes a lot of it.

r? @Zalathar