### PR TITLE
Have the alignment intrinsics return `ptr::Alignment` directly

### DIFF
--- a/compiler/rustc_codegen_cranelift/example/mini_core.rs
+++ b/compiler/rustc_codegen_cranelift/example/mini_core.rs
@@ -686,6 +686,12 @@ pub union MaybeUninit<T> {
     pub value: ManuallyDrop<T>,
 }
 
+pub mod mem {
+    #[lang = "Alignment"]
+    #[repr(transparent)]
+    pub struct Alignment(pub usize);
+}
+
 pub mod intrinsics {
     #[rustc_intrinsic]
     pub fn abort() -> !;
@@ -694,9 +700,9 @@ pub mod intrinsics {
     #[rustc_intrinsic]
     pub unsafe fn size_of_val<T: ?crate::Sized>(val: *const T) -> usize;
     #[rustc_intrinsic]
-    pub const fn align_of<T>() -> usize;
+    pub const fn align_of<T>() -> crate::mem::Alignment;
     #[rustc_intrinsic]
-    pub unsafe fn align_of_val<T: ?crate::Sized>(val: *const T) -> usize;
+    pub unsafe fn align_of_val<T: ?crate::Sized>(val: *const T) -> crate::mem::Alignment;
     #[rustc_intrinsic]
     pub unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize);
     #[rustc_intrinsic]
@@ -764,7 +770,7 @@ pub const fn size_of<T>() -> usize {
 }
 
 pub const fn align_of<T>() -> usize {
-    <T as SizedTypeProperties>::ALIGN
+    <T as SizedTypeProperties>::ALIGN.0
 }
 
 trait SizedTypeProperties: Sized {
@@ -772,7 +778,7 @@ trait SizedTypeProperties: Sized {
     const SIZE: usize = intrinsics::size_of::<Self>();
 
     #[lang = "mem_align_const"]
-    const ALIGN: usize = intrinsics::align_of::<Self>();
+    const ALIGN: crate::mem::Alignment = intrinsics::align_of::<Self>();
 }
 impl<T> SizedTypeProperties for T {}
 

--- a/compiler/rustc_codegen_cranelift/example/mini_core_hello_world.rs
+++ b/compiler/rustc_codegen_cranelift/example/mini_core_hello_world.rs
@@ -220,7 +220,7 @@ fn main() {
         assert_eq!(intrinsics::size_of_val(&0u32) as u8, 4);
 
         assert_eq!(align_of::<u16>() as u8, 2);
-        assert_eq!(intrinsics::align_of_val(&a) as u8, align_of::<&str>() as u8);
+        assert_eq!(intrinsics::align_of_val(&a).0 as u8, align_of::<&str>() as u8);
 
         let u8_needs_drop = const { intrinsics::needs_drop::<u8>() };
         assert!(!u8_needs_drop);

--- a/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
@@ -592,7 +592,8 @@ fn codegen_regular_intrinsic_call<'tcx>(
                 None
             };
             let (_size, align) = crate::unsize::size_and_align_of(fx, layout, meta);
-            ret.write_cvalue(fx, CValue::by_val(align, usize_layout));
+            let alignment_layout = fx.layout_of(fx.tcx.ty_alignment(source_info.span));
+            ret.write_cvalue(fx, CValue::by_val(align, alignment_layout));
         }
 
         sym::vtable_size => {

--- a/compiler/rustc_codegen_gcc/example/mini_core.rs
+++ b/compiler/rustc_codegen_gcc/example/mini_core.rs
@@ -694,6 +694,12 @@ pub union MaybeUninit<T> {
     pub value: ManuallyDrop<T>,
 }
 
+pub mod mem {
+    #[lang = "Alignment"]
+    #[repr(transparent)]
+    pub struct Alignment(pub usize);
+}
+
 pub mod intrinsics {
     #[rustc_intrinsic]
     pub const fn black_box<T>(_dummy: T) -> T;
@@ -704,9 +710,9 @@ pub mod intrinsics {
     #[rustc_intrinsic]
     pub unsafe fn size_of_val<T: ?::Sized>(val: *const T) -> usize;
     #[rustc_intrinsic]
-    pub const fn align_of<T>() -> usize;
+    pub const fn align_of<T>() -> crate::mem::Alignment;
     #[rustc_intrinsic]
-    pub unsafe fn align_of_val<T: ?::Sized>(val: *const T) -> usize;
+    pub unsafe fn align_of_val<T: ?::Sized>(val: *const T) -> crate::mem::Alignment;
     #[rustc_intrinsic]
     pub unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize);
     #[rustc_intrinsic]
@@ -747,7 +753,7 @@ pub const fn size_of<T>() -> usize {
 }
 
 pub const fn align_of<T>() -> usize {
-    <T as SizedTypeProperties>::ALIGN
+    <T as SizedTypeProperties>::ALIGN.0
 }
 
 trait SizedTypeProperties: Sized {
@@ -755,7 +761,7 @@ trait SizedTypeProperties: Sized {
     const SIZE: usize = intrinsics::size_of::<Self>();
 
     #[lang = "mem_align_const"]
-    const ALIGN: usize = intrinsics::align_of::<Self>();
+    const ALIGN: crate::mem::Alignment = intrinsics::align_of::<Self>();
 }
 
 impl<T> SizedTypeProperties for T {}

--- a/compiler/rustc_codegen_gcc/example/mini_core_hello_world.rs
+++ b/compiler/rustc_codegen_gcc/example/mini_core_hello_world.rs
@@ -196,7 +196,7 @@ fn main() {
         assert_eq!(intrinsics::size_of_val(&0u32) as u8, 4);
 
         assert_eq!(align_of::<u16>() as u8, 2);
-        assert_eq!(intrinsics::align_of_val(&a) as u8, align_of::<&str>() as u8);
+        assert_eq!(intrinsics::align_of_val(&a).0 as u8, align_of::<&str>() as u8);
 
         let u8_needs_drop = const { intrinsics::needs_drop::<u8>() };
         assert!(!u8_needs_drop);

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -156,6 +156,7 @@ language_item_table! {
     MetaSized,               sym::meta_sized,          meta_sized_trait,           Target::Trait,          GenericRequirement::Exact(0);
     PointeeSized,            sym::pointee_sized,       pointee_sized_trait,        Target::Trait,          GenericRequirement::Exact(0);
     Unsize,                  sym::unsize,              unsize_trait,               Target::Trait,          GenericRequirement::Minimum(1);
+    Alignment,               sym::Alignment,           alignment_type,             Target::Struct,         GenericRequirement::Exact(0);
     AlignOf,                 sym::mem_align_const,     align_const,                Target::AssocConst,     GenericRequirement::Exact(0);
     SizeOf,                  sym::mem_size_const,      size_const,                 Target::AssocConst,     GenericRequirement::Exact(0);
     OffsetOf,                sym::offset_of,           offset_of,                  Target::Fn,             GenericRequirement::Exact(1);

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -292,10 +292,10 @@ pub(crate) fn check_intrinsic_type(
         sym::amdgpu_dispatch_ptr => (0, 0, vec![], Ty::new_imm_ptr(tcx, tcx.types.unit)),
         sym::unreachable => (0, 0, vec![], tcx.types.never),
         sym::breakpoint => (0, 0, vec![], tcx.types.unit),
-        sym::size_of | sym::align_of | sym::variant_count => (1, 0, vec![], tcx.types.usize),
-        sym::size_of_val | sym::align_of_val => {
-            (1, 0, vec![Ty::new_imm_ptr(tcx, param(0))], tcx.types.usize)
-        }
+        sym::size_of | sym::variant_count => (1, 0, vec![], tcx.types.usize),
+        sym::align_of => (1, 0, vec![], tcx.ty_alignment(span)),
+        sym::size_of_val => (1, 0, vec![Ty::new_imm_ptr(tcx, param(0))], tcx.types.usize),
+        sym::align_of_val => (1, 0, vec![Ty::new_imm_ptr(tcx, param(0))], tcx.ty_alignment(span)),
         sym::size_of_type_id => (0, 0, vec![type_id_ty()], Ty::new_option(tcx, tcx.types.usize)),
         sym::offset_of => (1, 0, vec![tcx.types.u32, tcx.types.u32], tcx.types.usize),
         sym::field_offset => (1, 0, vec![], tcx.types.usize),

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -979,6 +979,13 @@ impl<'tcx> TyCtxt<'tcx> {
         self.type_of(ordering_enum).no_bound_vars().unwrap()
     }
 
+    /// Gets a `Ty` representing the [`LangItem::Alignment`]
+    #[track_caller]
+    pub fn ty_alignment(self, span: Span) -> Ty<'tcx> {
+        let alignment = self.require_lang_item(hir::LangItem::Alignment, span);
+        self.type_of(alignment).no_bound_vars().unwrap()
+    }
+
     /// Obtain the given diagnostic item's `DefId`. Use `is_diagnostic_item` if you just want to
     /// compare against another `DefId`, since `is_diagnostic_item` is cheaper.
     pub fn get_diagnostic_item(self, name: Symbol) -> Option<DefId> {

--- a/compiler/rustc_mir_transform/src/check_alignment.rs
+++ b/compiler/rustc_mir_transform/src/check_alignment.rs
@@ -55,14 +55,23 @@ fn insert_alignment_check<'tcx>(
     stmts.push(Statement::new(source_info, StatementKind::Assign(Box::new((thin_ptr, rvalue)))));
 
     // Transmute the pointer to a usize (equivalent to `ptr.addr()`).
-    let rvalue = Rvalue::Cast(CastKind::Transmute, Operand::Copy(thin_ptr), tcx.types.usize);
+    let rvalue = Rvalue::Cast(CastKind::Transmute, Operand::Move(thin_ptr), tcx.types.usize);
     let addr = local_decls.push(LocalDecl::with_source_info(tcx.types.usize, source_info)).into();
     stmts.push(Statement::new(source_info, StatementKind::Assign(Box::new((addr, rvalue)))));
 
     // Get the alignment of the pointee
     let align_def_id = tcx.require_lang_item(LangItem::AlignOf, source_info.span);
+    let alignment_usize =
+        local_decls.push(LocalDecl::with_source_info(tcx.types.usize, source_info)).into();
     let alignment =
         Operand::unevaluated_constant(tcx, align_def_id, &[pointee_ty.into()], source_info.span);
+    stmts.push(Statement::new(
+        source_info,
+        StatementKind::Assign(Box::new((
+            alignment_usize,
+            Rvalue::Cast(CastKind::Transmute, alignment.clone(), tcx.types.usize),
+        ))),
+    ));
 
     // Subtract 1 from the alignment to get the alignment mask
     let alignment_mask =
@@ -76,7 +85,7 @@ fn insert_alignment_check<'tcx>(
         source_info,
         StatementKind::Assign(Box::new((
             alignment_mask,
-            Rvalue::BinaryOp(BinOp::Sub, Box::new((alignment.clone(), one))),
+            Rvalue::BinaryOp(BinOp::SubUnchecked, Box::new((Operand::Move(alignment_usize), one))),
         ))),
     ));
 
@@ -138,10 +147,10 @@ fn insert_alignment_check<'tcx>(
     // Emit a check that asserts on the alignment and otherwise triggers a
     // AssertKind::MisalignedPointerDereference.
     PointerCheck {
-        cond: Operand::Copy(is_ok),
+        cond: Operand::Move(is_ok),
         assert_kind: Box::new(AssertKind::MisalignedPointerDereference {
             required: alignment,
-            found: Operand::Copy(addr),
+            found: Operand::Move(addr),
         }),
     }
 }

--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -216,18 +216,16 @@ impl Global {
 
     #[inline]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
-    fn deallocate_impl_runtime(ptr: NonNull<u8>, layout: Layout) {
-        if layout.size() != 0 {
-            // SAFETY:
-            // * We have checked that `layout` is non-zero in size.
-            // * The caller is obligated to provide a layout that "fits", and in this case,
-            //   "fit" always means a layout that is equal to the original, because our
-            //   `allocate()`, `grow()`, and `shrink()` implementations never returns a larger
-            //   allocation than requested.
-            // * Other conditions must be upheld by the caller, as per `Allocator::deallocate()`'s
-            //   safety documentation.
-            unsafe { dealloc_nonnull(ptr, layout) }
-        }
+    fn deallocate_nonzero_impl_runtime(ptr: NonNull<u8>, layout: Layout) {
+        // SAFETY:
+        // * The caller provided a `layout` that is non-zero in size.
+        // * The caller is obligated to provide a layout that "fits", and in this case,
+        //   "fit" always means a layout that is equal to the original, because our
+        //   `allocate()`, `grow()`, and `shrink()` implementations never returns a larger
+        //   allocation than requested.
+        // * Other conditions must be upheld by the caller, as per `Allocator::deallocate()`'s
+        //   safety documentation.
+        unsafe { dealloc_nonnull(ptr, layout) }
     }
 
     // SAFETY: Same as `Allocator::grow`
@@ -340,11 +338,11 @@ impl Global {
     #[inline]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[rustc_const_unstable(feature = "const_heap", issue = "79597")]
-    const unsafe fn deallocate_impl(&self, ptr: NonNull<u8>, layout: Layout) {
+    const unsafe fn deallocate_nonzero_impl(&self, ptr: NonNull<u8>, layout: Layout) {
         core::intrinsics::const_eval_select(
             (ptr, layout),
-            Global::deallocate_impl_const,
-            Global::deallocate_impl_runtime,
+            Global::deallocate_nonzero_impl_const,
+            Global::deallocate_nonzero_impl_runtime,
         )
     }
 
@@ -405,12 +403,10 @@ impl Global {
     #[inline]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[rustc_const_unstable(feature = "const_heap", issue = "79597")]
-    const fn deallocate_impl_const(ptr: NonNull<u8>, layout: Layout) {
-        if layout.size() != 0 {
-            // SAFETY: We checked for nonzero size; other preconditions must be upheld by caller.
-            unsafe {
-                core::intrinsics::const_deallocate(ptr.as_ptr(), layout.size(), layout.align());
-            }
+    const fn deallocate_nonzero_impl_const(ptr: NonNull<u8>, layout: Layout) {
+        // SAFETY: all conditions must be upheld by the caller
+        unsafe {
+            core::intrinsics::const_deallocate(ptr.as_ptr(), layout.size(), layout.align());
         }
     }
 
@@ -434,7 +430,7 @@ impl Global {
             );
         }
         unsafe {
-            self.deallocate_impl(ptr, old_layout);
+            self.deallocate(ptr, old_layout);
         }
         Ok(new_ptr)
     }
@@ -458,8 +454,17 @@ unsafe impl const Allocator for Global {
     #[inline]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        if layout.size() != 0 {
+            // SAFETY: We checked for nonzero size; other preconditions must be upheld by caller.
+            unsafe { self.deallocate_nonzero_size(ptr, layout) }
+        }
+    }
+
+    #[inline]
+    #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    unsafe fn deallocate_nonzero_size(&self, ptr: NonNull<u8>, layout: Layout) {
         // SAFETY: all conditions must be upheld by the caller
-        unsafe { self.deallocate_impl(ptr, layout) }
+        unsafe { self.deallocate_nonzero_impl(ptr, layout) }
     }
 
     #[inline]

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1953,7 +1953,7 @@ unsafe impl<#[may_dangle] T: ?Sized, A: Allocator> Drop for Box<T, A> {
         unsafe {
             let layout = Layout::for_value_raw(ptr.as_ptr());
             if layout.size() != 0 {
-                self.1.deallocate(From::from(ptr.cast()), layout);
+                self.1.deallocate_nonzero_size(From::from(ptr.cast()), layout);
             }
         }
     }

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -215,9 +215,8 @@ impl Layout {
     #[must_use]
     #[inline]
     pub const fn for_value<T: ?Sized>(t: &T) -> Self {
-        let (size, alignment) = (size_of_val(t), Alignment::of_val(t));
-        // SAFETY: see rationale in `new` for why this is using the unsafe variant
-        unsafe { Layout::from_size_alignment_unchecked(size, alignment) }
+        // SAFETY: Because `t` is a reference, its metadata is valid for this.
+        unsafe { Layout::for_value_raw(t) }
     }
 
     /// Produces layout describing a record that could be used to
@@ -250,11 +249,14 @@ impl Layout {
     #[unstable(feature = "layout_for_ptr", issue = "69835")]
     #[must_use]
     #[inline]
-    pub const unsafe fn for_value_raw<T: ?Sized>(t: *const T) -> Self {
+    pub const unsafe fn for_value_raw<T: ?Sized>(ptr: *const T) -> Self {
         // SAFETY: we pass along the prerequisites of these functions to the caller
-        let (size, alignment) = unsafe { (mem::size_of_val_raw(t), Alignment::of_val_raw(t)) };
-        // SAFETY: see rationale in `new` for why this is using the unsafe variant
-        unsafe { Layout::from_size_alignment_unchecked(size, alignment) }
+        let (size, align) = unsafe { (mem::size_of_val_raw(ptr), Alignment::of_val_raw(ptr)) };
+        // SAFETY: the dynamic size is that of a valid rust type, and those always
+        // meet the rules of `Layout` (just like in `Layout::new`).
+        // NB: We use a struct literal, instead of the unsafe constructor,
+        // to avoid the unnecessary UB check that has compile-time impact.
+        Layout { size, align }
     }
 
     /// Creates a `NonNull` that is dangling, but well-aligned for this Layout.

--- a/library/core/src/alloc/mod.rs
+++ b/library/core/src/alloc/mod.rs
@@ -172,6 +172,22 @@ pub const unsafe trait Allocator {
     /// [*fit*]: #memory-fitting
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout);
 
+    /// Deallocates the memory referenced by `ptr`.
+    ///
+    /// # Safety
+    ///
+    /// * `ptr` must denote a block of memory [*currently allocated*] via this allocator, and
+    /// * `layout` must [*fit*] that block of memory, and
+    /// * `layout.size()` must be greater than zero.
+    ///
+    /// [*currently allocated*]: #currently-allocated-memory
+    /// [*fit*]: #memory-fitting
+    #[inline]
+    unsafe fn deallocate_nonzero_size(&self, ptr: NonNull<u8>, layout: Layout) {
+        // SAFETY: all conditions must be upheld by the caller
+        unsafe { self.deallocate(ptr, layout) }
+    }
+
     /// Attempts to extend the memory block.
     ///
     /// Returns a new [`NonNull<[u8]>`][NonNull] containing a pointer and the actual size of the allocated

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2797,7 +2797,7 @@ pub const fn size_of<T>() -> usize;
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
-pub const fn align_of<T>() -> usize;
+pub const fn align_of<T>() -> mem::Alignment;
 
 /// The offset of a field inside a type.
 ///
@@ -2871,7 +2871,7 @@ pub const unsafe fn size_of_val<T: ?Sized>(ptr: *const T) -> usize;
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_intrinsic]
 #[rustc_intrinsic_const_stable_indirect]
-pub const unsafe fn align_of_val<T: ?Sized>(ptr: *const T) -> usize;
+pub const unsafe fn align_of_val<T: ?Sized>(ptr: *const T) -> mem::Alignment;
 
 #[rustc_intrinsic]
 #[unstable(feature = "core_intrinsics", issue = "none")]

--- a/library/core/src/mem/alignment.rs
+++ b/library/core/src/mem/alignment.rs
@@ -3,7 +3,7 @@
 use crate::marker::MetaSized;
 use crate::num::NonZero;
 use crate::ub_checks::assert_unsafe_precondition;
-use crate::{cmp, fmt, hash, mem, num};
+use crate::{cmp, fmt, hash, intrinsics, mem, num};
 
 /// A type storing a `usize` which is a power of two, and thus
 /// represents a possible alignment in the Rust abstract machine.
@@ -11,8 +11,11 @@ use crate::{cmp, fmt, hash, mem, num};
 /// Note that particularly large alignments, while representable in this type,
 /// are likely not to be supported by actual allocators and linkers.
 #[unstable(feature = "ptr_alignment_type", issue = "102070")]
+// No special behaviour, but used as the return type from an intrinsic
+#[lang = "Alignment"]
 #[derive(Copy)]
 #[derive_const(Clone, PartialEq, Eq)]
+// This being transparent is critical for its use in `__rust_alloc` and friends
 #[repr(transparent)]
 pub struct Alignment {
     // This field is never used directly (nor is the enum),
@@ -74,9 +77,8 @@ impl Alignment {
     #[must_use]
     #[unstable(feature = "ptr_alignment_type", issue = "102070")]
     pub const fn of_val<T: MetaSized>(val: &T) -> Self {
-        let align = mem::align_of_val(val);
-        // SAFETY: `align_of_val` returns valid alignment
-        unsafe { Alignment::new_unchecked(align) }
+        // SAFETY: val is a reference, so it's a valid raw pointer
+        unsafe { Alignment::of_val_raw(val) }
     }
 
     /// Returns the [ABI]-required minimum alignment of the type of the value that `val` points to.
@@ -122,9 +124,7 @@ impl Alignment {
     #[unstable(feature = "ptr_alignment_type", issue = "102070")]
     pub const unsafe fn of_val_raw<T: MetaSized>(val: *const T) -> Self {
         // SAFETY: precondition propagated to the caller
-        let align = unsafe { mem::align_of_val_raw(val) };
-        // SAFETY: `align_of_val_raw` returns valid alignment
-        unsafe { Alignment::new_unchecked(align) }
+        unsafe { intrinsics::align_of_val(val) }
     }
 
     /// Creates an `Alignment` from a `usize`, or returns `None` if it's

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -479,7 +479,7 @@ pub const unsafe fn size_of_val_raw<T: ?Sized>(val: *const T) -> usize {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(note = "use `align_of` instead", since = "1.2.0", suggestion = "align_of")]
 pub fn min_align_of<T>() -> usize {
-    <T as SizedTypeProperties>::ALIGN
+    align_of::<T>()
 }
 
 /// Returns the [ABI]-required minimum alignment of the type of the value that `val` points to in
@@ -502,8 +502,7 @@ pub fn min_align_of<T>() -> usize {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(note = "use `align_of_val` instead", since = "1.2.0", suggestion = "align_of_val")]
 pub fn min_align_of_val<T: ?Sized>(val: &T) -> usize {
-    // SAFETY: val is a reference, so it's a valid raw pointer
-    unsafe { intrinsics::align_of_val(val) }
+    align_of_val(val)
 }
 
 /// Returns the [ABI]-required minimum alignment of a type in bytes.
@@ -526,7 +525,7 @@ pub fn min_align_of_val<T: ?Sized>(val: &T) -> usize {
 #[rustc_const_stable(feature = "const_align_of", since = "1.24.0")]
 #[rustc_diagnostic_item = "mem_align_of"]
 pub const fn align_of<T>() -> usize {
-    <T as SizedTypeProperties>::ALIGN
+    Alignment::of::<T>().as_usize()
 }
 
 /// Returns the [ABI]-required minimum alignment of the type of the value that `val` points to in
@@ -546,8 +545,7 @@ pub const fn align_of<T>() -> usize {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_stable(feature = "const_align_of_val", since = "1.85.0")]
 pub const fn align_of_val<T: ?Sized>(val: &T) -> usize {
-    // SAFETY: val is a reference, so it's a valid raw pointer
-    unsafe { intrinsics::align_of_val(val) }
+    Alignment::of_val(val).as_usize()
 }
 
 /// Returns the [ABI]-required minimum alignment of the type of the value that `val` points to in
@@ -594,7 +592,7 @@ pub const fn align_of_val<T: ?Sized>(val: &T) -> usize {
 #[unstable(feature = "layout_for_ptr", issue = "69835")]
 pub const unsafe fn align_of_val_raw<T: ?Sized>(val: *const T) -> usize {
     // SAFETY: the caller must provide a valid raw pointer
-    unsafe { intrinsics::align_of_val(val) }
+    unsafe { Alignment::of_val_raw(val) }.as_usize()
 }
 
 /// Returns `true` if dropping values of type `T` matters.
@@ -1381,14 +1379,8 @@ pub trait SizedTypeProperties: Sized {
     #[doc(hidden)]
     #[unstable(feature = "sized_type_properties", issue = "none")]
     #[lang = "mem_align_const"]
-    const ALIGN: usize = intrinsics::align_of::<Self>();
-
-    #[doc(hidden)]
-    #[unstable(feature = "ptr_alignment_type", issue = "102070")]
-    const ALIGNMENT: Alignment = {
-        // This can't panic since type alignment is always a power of two.
-        Alignment::new(Self::ALIGN).unwrap()
-    };
+    // #[unstable(feature = "ptr_alignment_type", issue = "102070")]
+    const ALIGNMENT: Alignment = intrinsics::align_of::<Self>();
 
     /// `true` if this type requires no storage.
     /// `false` if its [size](size_of) is greater than zero.
@@ -1425,7 +1417,7 @@ pub trait SizedTypeProperties: Sized {
         // SAFETY: if the type is instantiated, rustc already ensures that its
         // layout is valid. Use the unchecked constructor to avoid inserting a
         // panicking codepath that needs to be optimized out.
-        unsafe { Layout::from_size_align_unchecked(Self::SIZE, Self::ALIGN) }
+        unsafe { Layout::from_size_alignment_unchecked(Self::SIZE, Self::ALIGNMENT) }
     };
 
     /// The largest safe length for a `[Self]`.

--- a/src/tools/miri/tests/fail/alloc/stack_free.stderr
+++ b/src/tools/miri/tests/fail/alloc/stack_free.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: deallocating ALLOC, which is stack variable memory, using Rust heap deallocation operation
   --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
-LL |                 self.1.deallocate(From::from(ptr.cast()), layout);
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+LL |                 self.1.deallocate_nonzero_size(From::from(ptr.cast()), layout);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/miri/tests/fail/stacked_borrows/deallocate_against_protector1.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/deallocate_against_protector1.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: deallocating while item [Unique for <TAG>] is strongly protected
   --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
-LL |                 self.1.deallocate(From::from(ptr.cast()), layout);
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+LL |                 self.1.deallocate_nonzero_size(From::from(ptr.cast()), layout);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/src/tools/miri/tests/pass/alloc-access-tracking.stderr
+++ b/src/tools/miri/tests/pass/alloc-access-tracking.stderr
@@ -19,8 +19,8 @@ LL |         assert_eq!(*ptr, 42);
 note: freed allocation ALLOC
   --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
-LL |                 self.1.deallocate(From::from(ptr.cast()), layout);
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ tracking was triggered here
+LL |                 self.1.deallocate_nonzero_size(From::from(ptr.cast()), layout);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ tracking was triggered here
    |
    = note: stack backtrace:
            0: <std::boxed::Box<std::mem::MaybeUninit<[u8; 123]>> as std::ops::Drop>::drop

--- a/tests/auxiliary/minicore.rs
+++ b/tests/auxiliary/minicore.rs
@@ -351,9 +351,14 @@ pub mod mem {
     #[rustc_nounwind]
     #[rustc_intrinsic]
     pub const fn size_of<T>() -> usize;
+
     #[rustc_nounwind]
     #[rustc_intrinsic]
-    pub const fn align_of<T>() -> usize;
+    pub const fn align_of<T>() -> Alignment;
+
+    #[lang = "Alignment"]
+    #[repr(transparent)]
+    pub struct Alignment(usize);
 }
 
 pub mod ptr {

--- a/tests/mir-opt/alignment_checks.rs
+++ b/tests/mir-opt/alignment_checks.rs
@@ -14,6 +14,6 @@ pub unsafe fn sized_ptr(ptr: *const u32) -> u32 {
     // CHECK: _2 = copy _1 as usize (Transmute);
     // CHECK: _3 = BitAnd(copy _2, const 3_usize);
     // CHECK: _4 = Eq(copy _3, const 0_usize);
-    // CHECK: assert(copy _4,
+    // CHECK: assert(move _4,
     *ptr
 }

--- a/tests/mir-opt/alignment_checks.sized_ptr.CheckAlignment.panic-abort.diff
+++ b/tests/mir-opt/alignment_checks.sized_ptr.CheckAlignment.panic-abort.diff
@@ -8,15 +8,17 @@
 +     let mut _3: usize;
 +     let mut _4: usize;
 +     let mut _5: usize;
-+     let mut _6: bool;
++     let mut _6: usize;
++     let mut _7: bool;
   
       bb0: {
 +         _2 = copy _1 as *const () (PtrToPtr);
-+         _3 = copy _2 as usize (Transmute);
-+         _4 = Sub(const <u32 as std::mem::SizedTypeProperties>::ALIGN, const 1_usize);
-+         _5 = BitAnd(copy _3, copy _4);
-+         _6 = Eq(copy _5, const 0_usize);
-+         assert(copy _6, "misaligned pointer dereference: address must be a multiple of {} but is {}", const <u32 as std::mem::SizedTypeProperties>::ALIGN, copy _3) -> [success: bb1, unwind unreachable];
++         _3 = move _2 as usize (Transmute);
++         _4 = const <u32 as std::mem::SizedTypeProperties>::ALIGNMENT as usize (Transmute);
++         _5 = SubUnchecked(move _4, const 1_usize);
++         _6 = BitAnd(copy _3, copy _5);
++         _7 = Eq(copy _6, const 0_usize);
++         assert(move _7, "misaligned pointer dereference: address must be a multiple of {} but is {}", const <u32 as std::mem::SizedTypeProperties>::ALIGNMENT, move _3) -> [success: bb1, unwind unreachable];
 +     }
 + 
 +     bb1: {

--- a/tests/mir-opt/alignment_checks.sized_ptr.CheckAlignment.panic-unwind.diff
+++ b/tests/mir-opt/alignment_checks.sized_ptr.CheckAlignment.panic-unwind.diff
@@ -8,15 +8,17 @@
 +     let mut _3: usize;
 +     let mut _4: usize;
 +     let mut _5: usize;
-+     let mut _6: bool;
++     let mut _6: usize;
++     let mut _7: bool;
   
       bb0: {
 +         _2 = copy _1 as *const () (PtrToPtr);
-+         _3 = copy _2 as usize (Transmute);
-+         _4 = Sub(const <u32 as std::mem::SizedTypeProperties>::ALIGN, const 1_usize);
-+         _5 = BitAnd(copy _3, copy _4);
-+         _6 = Eq(copy _5, const 0_usize);
-+         assert(copy _6, "misaligned pointer dereference: address must be a multiple of {} but is {}", const <u32 as std::mem::SizedTypeProperties>::ALIGN, copy _3) -> [success: bb1, unwind unreachable];
++         _3 = move _2 as usize (Transmute);
++         _4 = const <u32 as std::mem::SizedTypeProperties>::ALIGNMENT as usize (Transmute);
++         _5 = SubUnchecked(move _4, const 1_usize);
++         _6 = BitAnd(copy _3, copy _5);
++         _7 = Eq(copy _6, const 0_usize);
++         assert(move _7, "misaligned pointer dereference: address must be a multiple of {} but is {}", const <u32 as std::mem::SizedTypeProperties>::ALIGNMENT, move _3) -> [success: bb1, unwind unreachable];
 +     }
 + 
 +     bb1: {

--- a/tests/mir-opt/instsimplify/align_of_slice.of_val_slice.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/align_of_slice.of_val_slice.InstSimplify-after-simplifycfg.diff
@@ -1,16 +1,16 @@
 - // MIR for `of_val_slice` before InstSimplify-after-simplifycfg
 + // MIR for `of_val_slice` after InstSimplify-after-simplifycfg
   
-  fn of_val_slice(_1: &[T]) -> usize {
+  fn of_val_slice(_1: &[T]) -> std::mem::Alignment {
       debug slice => _1;
-      let mut _0: usize;
+      let mut _0: std::mem::Alignment;
       let mut _2: *const [T];
   
       bb0: {
           StorageLive(_2);
           _2 = &raw const (*_1);
 -         _0 = std::intrinsics::align_of_val::<[T]>(move _2) -> [return: bb1, unwind unreachable];
-+         _0 = const <T as std::mem::SizedTypeProperties>::ALIGN;
++         _0 = const <T as std::mem::SizedTypeProperties>::ALIGNMENT;
 +         goto -> bb1;
       }
   

--- a/tests/mir-opt/instsimplify/align_of_slice.rs
+++ b/tests/mir-opt/instsimplify/align_of_slice.rs
@@ -3,10 +3,11 @@
 
 #![crate_type = "lib"]
 #![feature(core_intrinsics)]
+#![feature(ptr_alignment_type)]
 
 // EMIT_MIR align_of_slice.of_val_slice.InstSimplify-after-simplifycfg.diff
-pub fn of_val_slice<T>(slice: &[T]) -> usize {
+pub fn of_val_slice<T>(slice: &[T]) -> std::mem::Alignment {
     // CHECK-LABEL: fn of_val_slice(_1: &[T])
-    // CHECK: _0 = const <T as std::mem::SizedTypeProperties>::ALIGN;
+    // CHECK: _0 = const <T as std::mem::SizedTypeProperties>::ALIGNMENT;
     unsafe { core::intrinsics::align_of_val(slice) }
 }

--- a/tests/mir-opt/instsimplify/align_or_size_of_sized_val.align_of_val_sized.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/align_or_size_of_sized_val.align_of_val_sized.InstSimplify-after-simplifycfg.diff
@@ -1,16 +1,16 @@
 - // MIR for `align_of_val_sized` before InstSimplify-after-simplifycfg
 + // MIR for `align_of_val_sized` after InstSimplify-after-simplifycfg
   
-  fn align_of_val_sized(_1: &T) -> usize {
+  fn align_of_val_sized(_1: &T) -> std::mem::Alignment {
       debug val => _1;
-      let mut _0: usize;
+      let mut _0: std::mem::Alignment;
       let mut _2: *const T;
   
       bb0: {
           StorageLive(_2);
           _2 = &raw const (*_1);
 -         _0 = std::intrinsics::align_of_val::<T>(move _2) -> [return: bb1, unwind unreachable];
-+         _0 = const <T as std::mem::SizedTypeProperties>::ALIGN;
++         _0 = const <T as std::mem::SizedTypeProperties>::ALIGNMENT;
 +         goto -> bb1;
       }
   

--- a/tests/mir-opt/instsimplify/align_or_size_of_sized_val.rs
+++ b/tests/mir-opt/instsimplify/align_or_size_of_sized_val.rs
@@ -3,11 +3,12 @@
 
 #![crate_type = "lib"]
 #![feature(core_intrinsics)]
+#![feature(ptr_alignment_type)]
 
 // EMIT_MIR align_or_size_of_sized_val.align_of_val_sized.InstSimplify-after-simplifycfg.diff
-pub fn align_of_val_sized<T>(val: &T) -> usize {
+pub fn align_of_val_sized<T>(val: &T) -> std::mem::Alignment {
     // CHECK-LABEL: fn align_of_val_sized
-    // CHECK: _0 = const <T as std::mem::SizedTypeProperties>::ALIGN;
+    // CHECK: _0 = const <T as std::mem::SizedTypeProperties>::ALIGNMENT;
     unsafe { core::intrinsics::align_of_val(val) }
 }
 

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.PreCodegen.after.panic-abort.mir
@@ -10,28 +10,26 @@ fn drop_bytes(_1: *mut Box<[u8; 1024]>) -> () {
                 let _4: ();
                 scope 4 {
                     scope 5 {
-                        scope 17 (inlined Layout::size) {
+                        scope 12 (inlined Layout::size) {
                         }
-                        scope 18 (inlined std::ptr::Unique::<[u8; 1024]>::cast::<u8>) {
+                        scope 13 (inlined std::ptr::Unique::<[u8; 1024]>::cast::<u8>) {
                             let mut _3: std::ptr::NonNull<u8>;
-                            scope 19 (inlined NonNull::<[u8; 1024]>::cast::<u8>) {
-                                scope 20 (inlined NonNull::<[u8; 1024]>::as_ptr) {
+                            scope 14 (inlined NonNull::<[u8; 1024]>::cast::<u8>) {
+                                scope 15 (inlined NonNull::<[u8; 1024]>::as_ptr) {
                                 }
                             }
                         }
-                        scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                            scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                        scope 16 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                            scope 17 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                             }
                         }
-                        scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                            scope 24 (inlined std::alloc::Global::deallocate_impl) {
-                                scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                    scope 26 (inlined Layout::size) {
-                                    }
-                                    scope 27 (inlined alloc::alloc::dealloc_nonnull) {
-                                        scope 28 (inlined Layout::size) {
+                        scope 18 (inlined <std::alloc::Global as Allocator>::deallocate_nonzero_size) {
+                            scope 19 (inlined std::alloc::Global::deallocate_nonzero_impl) {
+                                scope 20 (inlined std::alloc::Global::deallocate_nonzero_impl_runtime) {
+                                    scope 21 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 22 (inlined Layout::size) {
                                         }
-                                        scope 29 (inlined Layout::alignment) {
+                                        scope 23 (inlined Layout::alignment) {
                                         }
                                     }
                                 }
@@ -48,16 +46,6 @@ fn drop_bytes(_1: *mut Box<[u8; 1024]>) -> () {
                         scope 10 (inlined size_of_val_raw::<[u8; 1024]>) {
                         }
                         scope 11 (inlined std::mem::Alignment::of_val_raw::<[u8; 1024]>) {
-                            scope 12 {
-                                scope 14 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
-                                    scope 15 (inlined core::ub_checks::check_language_ub) {
-                                        scope 16 (inlined core::ub_checks::check_language_ub::runtime) {
-                                        }
-                                    }
-                                }
-                            }
-                            scope 13 (inlined align_of_val_raw::<[u8; 1024]>) {
-                            }
                         }
                     }
                 }

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.PreCodegen.after.panic-abort.mir
@@ -10,28 +10,28 @@ fn drop_bytes(_1: *mut Box<[u8; 1024]>) -> () {
                 let _4: ();
                 scope 4 {
                     scope 5 {
-                        scope 18 (inlined Layout::size) {
+                        scope 17 (inlined Layout::size) {
                         }
-                        scope 19 (inlined std::ptr::Unique::<[u8; 1024]>::cast::<u8>) {
+                        scope 18 (inlined std::ptr::Unique::<[u8; 1024]>::cast::<u8>) {
                             let mut _3: std::ptr::NonNull<u8>;
-                            scope 20 (inlined NonNull::<[u8; 1024]>::cast::<u8>) {
-                                scope 21 (inlined NonNull::<[u8; 1024]>::as_ptr) {
+                            scope 19 (inlined NonNull::<[u8; 1024]>::cast::<u8>) {
+                                scope 20 (inlined NonNull::<[u8; 1024]>::as_ptr) {
                                 }
                             }
                         }
-                        scope 22 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                            scope 23 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                        scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                            scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                             }
                         }
-                        scope 24 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                            scope 25 (inlined std::alloc::Global::deallocate_impl) {
-                                scope 26 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                    scope 27 (inlined Layout::size) {
+                        scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                            scope 24 (inlined std::alloc::Global::deallocate_impl) {
+                                scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                                    scope 26 (inlined Layout::size) {
                                     }
-                                    scope 28 (inlined alloc::alloc::dealloc_nonnull) {
-                                        scope 29 (inlined Layout::size) {
+                                    scope 27 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 28 (inlined Layout::size) {
                                         }
-                                        scope 30 (inlined Layout::alignment) {
+                                        scope 29 (inlined Layout::alignment) {
                                         }
                                     }
                                 }
@@ -44,8 +44,6 @@ fn drop_bytes(_1: *mut Box<[u8; 1024]>) -> () {
                     }
                     scope 8 (inlined Layout::for_value_raw::<[u8; 1024]>) {
                         scope 9 {
-                            scope 17 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
-                            }
                         }
                         scope 10 (inlined size_of_val_raw::<[u8; 1024]>) {
                         }

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.PreCodegen.after.panic-unwind.mir
@@ -10,28 +10,26 @@ fn drop_bytes(_1: *mut Box<[u8; 1024]>) -> () {
                 let _4: ();
                 scope 4 {
                     scope 5 {
-                        scope 17 (inlined Layout::size) {
+                        scope 12 (inlined Layout::size) {
                         }
-                        scope 18 (inlined std::ptr::Unique::<[u8; 1024]>::cast::<u8>) {
+                        scope 13 (inlined std::ptr::Unique::<[u8; 1024]>::cast::<u8>) {
                             let mut _3: std::ptr::NonNull<u8>;
-                            scope 19 (inlined NonNull::<[u8; 1024]>::cast::<u8>) {
-                                scope 20 (inlined NonNull::<[u8; 1024]>::as_ptr) {
+                            scope 14 (inlined NonNull::<[u8; 1024]>::cast::<u8>) {
+                                scope 15 (inlined NonNull::<[u8; 1024]>::as_ptr) {
                                 }
                             }
                         }
-                        scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                            scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                        scope 16 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                            scope 17 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                             }
                         }
-                        scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                            scope 24 (inlined std::alloc::Global::deallocate_impl) {
-                                scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                    scope 26 (inlined Layout::size) {
-                                    }
-                                    scope 27 (inlined alloc::alloc::dealloc_nonnull) {
-                                        scope 28 (inlined Layout::size) {
+                        scope 18 (inlined <std::alloc::Global as Allocator>::deallocate_nonzero_size) {
+                            scope 19 (inlined std::alloc::Global::deallocate_nonzero_impl) {
+                                scope 20 (inlined std::alloc::Global::deallocate_nonzero_impl_runtime) {
+                                    scope 21 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 22 (inlined Layout::size) {
                                         }
-                                        scope 29 (inlined Layout::alignment) {
+                                        scope 23 (inlined Layout::alignment) {
                                         }
                                     }
                                 }
@@ -48,16 +46,6 @@ fn drop_bytes(_1: *mut Box<[u8; 1024]>) -> () {
                         scope 10 (inlined size_of_val_raw::<[u8; 1024]>) {
                         }
                         scope 11 (inlined std::mem::Alignment::of_val_raw::<[u8; 1024]>) {
-                            scope 12 {
-                                scope 14 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
-                                    scope 15 (inlined core::ub_checks::check_language_ub) {
-                                        scope 16 (inlined core::ub_checks::check_language_ub::runtime) {
-                                        }
-                                    }
-                                }
-                            }
-                            scope 13 (inlined align_of_val_raw::<[u8; 1024]>) {
-                            }
                         }
                     }
                 }

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.PreCodegen.after.panic-unwind.mir
@@ -10,28 +10,28 @@ fn drop_bytes(_1: *mut Box<[u8; 1024]>) -> () {
                 let _4: ();
                 scope 4 {
                     scope 5 {
-                        scope 18 (inlined Layout::size) {
+                        scope 17 (inlined Layout::size) {
                         }
-                        scope 19 (inlined std::ptr::Unique::<[u8; 1024]>::cast::<u8>) {
+                        scope 18 (inlined std::ptr::Unique::<[u8; 1024]>::cast::<u8>) {
                             let mut _3: std::ptr::NonNull<u8>;
-                            scope 20 (inlined NonNull::<[u8; 1024]>::cast::<u8>) {
-                                scope 21 (inlined NonNull::<[u8; 1024]>::as_ptr) {
+                            scope 19 (inlined NonNull::<[u8; 1024]>::cast::<u8>) {
+                                scope 20 (inlined NonNull::<[u8; 1024]>::as_ptr) {
                                 }
                             }
                         }
-                        scope 22 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                            scope 23 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                        scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                            scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                             }
                         }
-                        scope 24 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                            scope 25 (inlined std::alloc::Global::deallocate_impl) {
-                                scope 26 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                    scope 27 (inlined Layout::size) {
+                        scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                            scope 24 (inlined std::alloc::Global::deallocate_impl) {
+                                scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                                    scope 26 (inlined Layout::size) {
                                     }
-                                    scope 28 (inlined alloc::alloc::dealloc_nonnull) {
-                                        scope 29 (inlined Layout::size) {
+                                    scope 27 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 28 (inlined Layout::size) {
                                         }
-                                        scope 30 (inlined Layout::alignment) {
+                                        scope 29 (inlined Layout::alignment) {
                                         }
                                     }
                                 }
@@ -44,8 +44,6 @@ fn drop_bytes(_1: *mut Box<[u8; 1024]>) -> () {
                     }
                     scope 8 (inlined Layout::for_value_raw::<[u8; 1024]>) {
                         scope 9 {
-                            scope 17 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
-                            }
                         }
                         scope 10 (inlined size_of_val_raw::<[u8; 1024]>) {
                         }

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-abort.mir
@@ -7,31 +7,29 @@ fn drop_generic(_1: *mut Box<T>) -> () {
         scope 2 (inlined std::ptr::drop_glue::<Box<T>> - shim(Some(Box<T>))) {
             scope 3 (inlined <Box<T> as Drop>::drop) {
                 let _2: std::ptr::NonNull<T>;
-                let _5: ();
+                let _4: ();
                 scope 4 {
                     scope 5 {
-                        scope 17 (inlined Layout::size) {
+                        scope 12 (inlined Layout::size) {
                         }
-                        scope 18 (inlined std::ptr::Unique::<T>::cast::<u8>) {
-                            let mut _4: std::ptr::NonNull<u8>;
-                            scope 19 (inlined NonNull::<T>::cast::<u8>) {
-                                scope 20 (inlined NonNull::<T>::as_ptr) {
+                        scope 13 (inlined std::ptr::Unique::<T>::cast::<u8>) {
+                            let mut _3: std::ptr::NonNull<u8>;
+                            scope 14 (inlined NonNull::<T>::cast::<u8>) {
+                                scope 15 (inlined NonNull::<T>::as_ptr) {
                                 }
                             }
                         }
-                        scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                            scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                        scope 16 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                            scope 17 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                             }
                         }
-                        scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                            scope 24 (inlined std::alloc::Global::deallocate_impl) {
-                                scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                    scope 26 (inlined Layout::size) {
-                                    }
-                                    scope 27 (inlined alloc::alloc::dealloc_nonnull) {
-                                        scope 28 (inlined Layout::size) {
+                        scope 18 (inlined <std::alloc::Global as Allocator>::deallocate_nonzero_size) {
+                            scope 19 (inlined std::alloc::Global::deallocate_nonzero_impl) {
+                                scope 20 (inlined std::alloc::Global::deallocate_nonzero_impl_runtime) {
+                                    scope 21 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 22 (inlined Layout::size) {
                                         }
-                                        scope 29 (inlined Layout::alignment) {
+                                        scope 23 (inlined Layout::alignment) {
                                         }
                                     }
                                 }
@@ -43,22 +41,11 @@ fn drop_generic(_1: *mut Box<T>) -> () {
                         }
                     }
                     scope 8 (inlined Layout::for_value_raw::<T>) {
-                        let mut _3: std::mem::Alignment;
                         scope 9 {
                         }
                         scope 10 (inlined size_of_val_raw::<T>) {
                         }
                         scope 11 (inlined std::mem::Alignment::of_val_raw::<T>) {
-                            scope 12 {
-                                scope 14 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
-                                    scope 15 (inlined core::ub_checks::check_language_ub) {
-                                        scope 16 (inlined core::ub_checks::check_language_ub::runtime) {
-                                        }
-                                    }
-                                }
-                            }
-                            scope 13 (inlined align_of_val_raw::<T>) {
-                            }
                         }
                     }
                 }
@@ -67,25 +54,20 @@ fn drop_generic(_1: *mut Box<T>) -> () {
     }
 
     bb0: {
-        StorageLive(_4);
+        StorageLive(_3);
         StorageLive(_2);
         _2 = copy (((*_1).0: std::ptr::Unique<T>).0: std::ptr::NonNull<T>);
-        _3 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::mem::Alignment (Transmute);
-        switchInt(const <T as std::mem::SizedTypeProperties>::SIZE) -> [0: bb3, otherwise: bb1];
+        switchInt(const <T as std::mem::SizedTypeProperties>::SIZE) -> [0: bb2, otherwise: bb1];
     }
 
     bb1: {
-        _4 = copy _2 as std::ptr::NonNull<u8> (Transmute);
-        switchInt(const <T as std::mem::SizedTypeProperties>::SIZE) -> [0: bb3, otherwise: bb2];
+        _3 = copy _2 as std::ptr::NonNull<u8> (Transmute);
+        _4 = alloc::alloc::__rust_dealloc(move _3, const <T as std::mem::SizedTypeProperties>::SIZE, const <T as std::mem::SizedTypeProperties>::ALIGNMENT) -> [return: bb2, unwind unreachable];
     }
 
     bb2: {
-        _5 = alloc::alloc::__rust_dealloc(move _4, const <T as std::mem::SizedTypeProperties>::SIZE, move _3) -> [return: bb3, unwind unreachable];
-    }
-
-    bb3: {
         StorageDead(_2);
-        StorageDead(_4);
+        StorageDead(_3);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-abort.mir
@@ -10,28 +10,28 @@ fn drop_generic(_1: *mut Box<T>) -> () {
                 let _5: ();
                 scope 4 {
                     scope 5 {
-                        scope 18 (inlined Layout::size) {
+                        scope 17 (inlined Layout::size) {
                         }
-                        scope 19 (inlined std::ptr::Unique::<T>::cast::<u8>) {
+                        scope 18 (inlined std::ptr::Unique::<T>::cast::<u8>) {
                             let mut _4: std::ptr::NonNull<u8>;
-                            scope 20 (inlined NonNull::<T>::cast::<u8>) {
-                                scope 21 (inlined NonNull::<T>::as_ptr) {
+                            scope 19 (inlined NonNull::<T>::cast::<u8>) {
+                                scope 20 (inlined NonNull::<T>::as_ptr) {
                                 }
                             }
                         }
-                        scope 22 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                            scope 23 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                        scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                            scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                             }
                         }
-                        scope 24 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                            scope 25 (inlined std::alloc::Global::deallocate_impl) {
-                                scope 26 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                    scope 27 (inlined Layout::size) {
+                        scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                            scope 24 (inlined std::alloc::Global::deallocate_impl) {
+                                scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                                    scope 26 (inlined Layout::size) {
                                     }
-                                    scope 28 (inlined alloc::alloc::dealloc_nonnull) {
-                                        scope 29 (inlined Layout::size) {
+                                    scope 27 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 28 (inlined Layout::size) {
                                         }
-                                        scope 30 (inlined Layout::alignment) {
+                                        scope 29 (inlined Layout::alignment) {
                                         }
                                     }
                                 }
@@ -45,8 +45,6 @@ fn drop_generic(_1: *mut Box<T>) -> () {
                     scope 8 (inlined Layout::for_value_raw::<T>) {
                         let mut _3: std::mem::Alignment;
                         scope 9 {
-                            scope 17 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
-                            }
                         }
                         scope 10 (inlined size_of_val_raw::<T>) {
                         }

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-unwind.mir
@@ -7,31 +7,29 @@ fn drop_generic(_1: *mut Box<T>) -> () {
         scope 2 (inlined std::ptr::drop_glue::<Box<T>> - shim(Some(Box<T>))) {
             scope 3 (inlined <Box<T> as Drop>::drop) {
                 let _2: std::ptr::NonNull<T>;
-                let _5: ();
+                let _4: ();
                 scope 4 {
                     scope 5 {
-                        scope 17 (inlined Layout::size) {
+                        scope 12 (inlined Layout::size) {
                         }
-                        scope 18 (inlined std::ptr::Unique::<T>::cast::<u8>) {
-                            let mut _4: std::ptr::NonNull<u8>;
-                            scope 19 (inlined NonNull::<T>::cast::<u8>) {
-                                scope 20 (inlined NonNull::<T>::as_ptr) {
+                        scope 13 (inlined std::ptr::Unique::<T>::cast::<u8>) {
+                            let mut _3: std::ptr::NonNull<u8>;
+                            scope 14 (inlined NonNull::<T>::cast::<u8>) {
+                                scope 15 (inlined NonNull::<T>::as_ptr) {
                                 }
                             }
                         }
-                        scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                            scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                        scope 16 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                            scope 17 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                             }
                         }
-                        scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                            scope 24 (inlined std::alloc::Global::deallocate_impl) {
-                                scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                    scope 26 (inlined Layout::size) {
-                                    }
-                                    scope 27 (inlined alloc::alloc::dealloc_nonnull) {
-                                        scope 28 (inlined Layout::size) {
+                        scope 18 (inlined <std::alloc::Global as Allocator>::deallocate_nonzero_size) {
+                            scope 19 (inlined std::alloc::Global::deallocate_nonzero_impl) {
+                                scope 20 (inlined std::alloc::Global::deallocate_nonzero_impl_runtime) {
+                                    scope 21 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 22 (inlined Layout::size) {
                                         }
-                                        scope 29 (inlined Layout::alignment) {
+                                        scope 23 (inlined Layout::alignment) {
                                         }
                                     }
                                 }
@@ -43,22 +41,11 @@ fn drop_generic(_1: *mut Box<T>) -> () {
                         }
                     }
                     scope 8 (inlined Layout::for_value_raw::<T>) {
-                        let mut _3: std::mem::Alignment;
                         scope 9 {
                         }
                         scope 10 (inlined size_of_val_raw::<T>) {
                         }
                         scope 11 (inlined std::mem::Alignment::of_val_raw::<T>) {
-                            scope 12 {
-                                scope 14 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
-                                    scope 15 (inlined core::ub_checks::check_language_ub) {
-                                        scope 16 (inlined core::ub_checks::check_language_ub::runtime) {
-                                        }
-                                    }
-                                }
-                            }
-                            scope 13 (inlined align_of_val_raw::<T>) {
-                            }
                         }
                     }
                 }
@@ -67,25 +54,20 @@ fn drop_generic(_1: *mut Box<T>) -> () {
     }
 
     bb0: {
-        StorageLive(_4);
+        StorageLive(_3);
         StorageLive(_2);
         _2 = copy (((*_1).0: std::ptr::Unique<T>).0: std::ptr::NonNull<T>);
-        _3 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::mem::Alignment (Transmute);
-        switchInt(const <T as std::mem::SizedTypeProperties>::SIZE) -> [0: bb3, otherwise: bb1];
+        switchInt(const <T as std::mem::SizedTypeProperties>::SIZE) -> [0: bb2, otherwise: bb1];
     }
 
     bb1: {
-        _4 = copy _2 as std::ptr::NonNull<u8> (Transmute);
-        switchInt(const <T as std::mem::SizedTypeProperties>::SIZE) -> [0: bb3, otherwise: bb2];
+        _3 = copy _2 as std::ptr::NonNull<u8> (Transmute);
+        _4 = alloc::alloc::__rust_dealloc(move _3, const <T as std::mem::SizedTypeProperties>::SIZE, const <T as std::mem::SizedTypeProperties>::ALIGNMENT) -> [return: bb2, unwind unreachable];
     }
 
     bb2: {
-        _5 = alloc::alloc::__rust_dealloc(move _4, const <T as std::mem::SizedTypeProperties>::SIZE, move _3) -> [return: bb3, unwind unreachable];
-    }
-
-    bb3: {
         StorageDead(_2);
-        StorageDead(_4);
+        StorageDead(_3);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-unwind.mir
@@ -10,28 +10,28 @@ fn drop_generic(_1: *mut Box<T>) -> () {
                 let _5: ();
                 scope 4 {
                     scope 5 {
-                        scope 18 (inlined Layout::size) {
+                        scope 17 (inlined Layout::size) {
                         }
-                        scope 19 (inlined std::ptr::Unique::<T>::cast::<u8>) {
+                        scope 18 (inlined std::ptr::Unique::<T>::cast::<u8>) {
                             let mut _4: std::ptr::NonNull<u8>;
-                            scope 20 (inlined NonNull::<T>::cast::<u8>) {
-                                scope 21 (inlined NonNull::<T>::as_ptr) {
+                            scope 19 (inlined NonNull::<T>::cast::<u8>) {
+                                scope 20 (inlined NonNull::<T>::as_ptr) {
                                 }
                             }
                         }
-                        scope 22 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                            scope 23 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                        scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                            scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                             }
                         }
-                        scope 24 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                            scope 25 (inlined std::alloc::Global::deallocate_impl) {
-                                scope 26 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                    scope 27 (inlined Layout::size) {
+                        scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                            scope 24 (inlined std::alloc::Global::deallocate_impl) {
+                                scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                                    scope 26 (inlined Layout::size) {
                                     }
-                                    scope 28 (inlined alloc::alloc::dealloc_nonnull) {
-                                        scope 29 (inlined Layout::size) {
+                                    scope 27 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 28 (inlined Layout::size) {
                                         }
-                                        scope 30 (inlined Layout::alignment) {
+                                        scope 29 (inlined Layout::alignment) {
                                         }
                                     }
                                 }
@@ -45,8 +45,6 @@ fn drop_generic(_1: *mut Box<T>) -> () {
                     scope 8 (inlined Layout::for_value_raw::<T>) {
                         let mut _3: std::mem::Alignment;
                         scope 9 {
-                            scope 17 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
-                            }
                         }
                         scope 10 (inlined size_of_val_raw::<T>) {
                         }

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.rs
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.rs
@@ -6,8 +6,7 @@
 // EMIT_MIR drop_box_of_sized.drop_generic.PreCodegen.after.mir
 pub unsafe fn drop_generic<T: Copy>(x: *mut Box<T>) {
     // CHECK-LABEL: fn drop_generic
-    // CHECK: [[ALIGNMENT:_.+]] = const <T as std::mem::SizedTypeProperties>::ALIGN as std::mem::Alignment (Transmute)
-    // CHECK: alloc::alloc::__rust_dealloc({{.+}}, const <T as std::mem::SizedTypeProperties>::SIZE, move [[ALIGNMENT]])
+    // CHECK: alloc::alloc::__rust_dealloc({{.+}}, const <T as std::mem::SizedTypeProperties>::SIZE, const <T as std::mem::SizedTypeProperties>::ALIGNMENT)
     std::ptr::drop_in_place(x)
 }
 

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-abort.mir
@@ -9,32 +9,30 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 let _2: std::ptr::NonNull<[T]>;
                 let mut _3: *mut [T];
                 let mut _4: *const [T];
-                let _9: ();
+                let _8: ();
                 scope 4 {
                     scope 5 {
-                        scope 17 (inlined Layout::size) {
+                        scope 12 (inlined Layout::size) {
                         }
-                        scope 18 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
-                            let mut _8: std::ptr::NonNull<u8>;
-                            scope 19 (inlined NonNull::<[T]>::cast::<u8>) {
-                                let mut _7: *mut u8;
-                                scope 20 (inlined NonNull::<[T]>::as_ptr) {
+                        scope 13 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
+                            let mut _7: std::ptr::NonNull<u8>;
+                            scope 14 (inlined NonNull::<[T]>::cast::<u8>) {
+                                let mut _6: *mut u8;
+                                scope 15 (inlined NonNull::<[T]>::as_ptr) {
                                 }
                             }
                         }
-                        scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                            scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                        scope 16 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                            scope 17 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                             }
                         }
-                        scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                            scope 24 (inlined std::alloc::Global::deallocate_impl) {
-                                scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                    scope 26 (inlined Layout::size) {
-                                    }
-                                    scope 27 (inlined alloc::alloc::dealloc_nonnull) {
-                                        scope 28 (inlined Layout::size) {
+                        scope 18 (inlined <std::alloc::Global as Allocator>::deallocate_nonzero_size) {
+                            scope 19 (inlined std::alloc::Global::deallocate_nonzero_impl) {
+                                scope 20 (inlined std::alloc::Global::deallocate_nonzero_impl_runtime) {
+                                    scope 21 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 22 (inlined Layout::size) {
                                         }
-                                        scope 29 (inlined Layout::alignment) {
+                                        scope 23 (inlined Layout::alignment) {
                                         }
                                     }
                                 }
@@ -47,22 +45,11 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                     }
                     scope 8 (inlined Layout::for_value_raw::<[T]>) {
                         let mut _5: usize;
-                        let mut _6: std::mem::Alignment;
                         scope 9 {
                         }
                         scope 10 (inlined size_of_val_raw::<[T]>) {
                         }
                         scope 11 (inlined std::mem::Alignment::of_val_raw::<[T]>) {
-                            scope 12 {
-                                scope 14 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
-                                    scope 15 (inlined core::ub_checks::check_language_ub) {
-                                        scope 16 (inlined core::ub_checks::check_language_ub::runtime) {
-                                        }
-                                    }
-                                }
-                            }
-                            scope 13 (inlined align_of_val_raw::<[T]>) {
-                            }
                         }
                     }
                 }
@@ -73,7 +60,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
     bb0: {
         StorageLive(_3);
         StorageLive(_5);
-        StorageLive(_8);
+        StorageLive(_7);
         StorageLive(_2);
         _2 = copy (((*_1).0: std::ptr::Unique<[T]>).0: std::ptr::NonNull<[T]>);
         StorageLive(_4);
@@ -83,22 +70,21 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
     }
 
     bb1: {
-        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::mem::Alignment (Transmute);
         StorageDead(_4);
         switchInt(copy _5) -> [0: bb3, otherwise: bb2];
     }
 
     bb2: {
-        StorageLive(_7);
-        _7 = copy _3 as *mut u8 (PtrToPtr);
-        _8 = copy _7 as std::ptr::NonNull<u8> (Transmute);
-        StorageDead(_7);
-        _9 = alloc::alloc::__rust_dealloc(move _8, move _5, move _6) -> [return: bb3, unwind unreachable];
+        StorageLive(_6);
+        _6 = copy _3 as *mut u8 (PtrToPtr);
+        _7 = copy _6 as std::ptr::NonNull<u8> (Transmute);
+        StorageDead(_6);
+        _8 = alloc::alloc::__rust_dealloc(move _7, move _5, const <T as std::mem::SizedTypeProperties>::ALIGNMENT) -> [return: bb3, unwind unreachable];
     }
 
     bb3: {
         StorageDead(_2);
-        StorageDead(_8);
+        StorageDead(_7);
         StorageDead(_5);
         StorageDead(_3);
         return;

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-abort.mir
@@ -12,29 +12,29 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 let _9: ();
                 scope 4 {
                     scope 5 {
-                        scope 18 (inlined Layout::size) {
+                        scope 17 (inlined Layout::size) {
                         }
-                        scope 19 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
+                        scope 18 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
                             let mut _8: std::ptr::NonNull<u8>;
-                            scope 20 (inlined NonNull::<[T]>::cast::<u8>) {
+                            scope 19 (inlined NonNull::<[T]>::cast::<u8>) {
                                 let mut _7: *mut u8;
-                                scope 21 (inlined NonNull::<[T]>::as_ptr) {
+                                scope 20 (inlined NonNull::<[T]>::as_ptr) {
                                 }
                             }
                         }
-                        scope 22 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                            scope 23 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                        scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                            scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                             }
                         }
-                        scope 24 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                            scope 25 (inlined std::alloc::Global::deallocate_impl) {
-                                scope 26 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                    scope 27 (inlined Layout::size) {
+                        scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                            scope 24 (inlined std::alloc::Global::deallocate_impl) {
+                                scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                                    scope 26 (inlined Layout::size) {
                                     }
-                                    scope 28 (inlined alloc::alloc::dealloc_nonnull) {
-                                        scope 29 (inlined Layout::size) {
+                                    scope 27 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 28 (inlined Layout::size) {
                                         }
-                                        scope 30 (inlined Layout::alignment) {
+                                        scope 29 (inlined Layout::alignment) {
                                         }
                                     }
                                 }
@@ -49,8 +49,6 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                         let mut _5: usize;
                         let mut _6: std::mem::Alignment;
                         scope 9 {
-                            scope 17 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
-                            }
                         }
                         scope 10 (inlined size_of_val_raw::<[T]>) {
                         }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-unwind.mir
@@ -9,32 +9,30 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 let _2: std::ptr::NonNull<[T]>;
                 let mut _3: *mut [T];
                 let mut _4: *const [T];
-                let _9: ();
+                let _8: ();
                 scope 4 {
                     scope 5 {
-                        scope 17 (inlined Layout::size) {
+                        scope 12 (inlined Layout::size) {
                         }
-                        scope 18 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
-                            let mut _8: std::ptr::NonNull<u8>;
-                            scope 19 (inlined NonNull::<[T]>::cast::<u8>) {
-                                let mut _7: *mut u8;
-                                scope 20 (inlined NonNull::<[T]>::as_ptr) {
+                        scope 13 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
+                            let mut _7: std::ptr::NonNull<u8>;
+                            scope 14 (inlined NonNull::<[T]>::cast::<u8>) {
+                                let mut _6: *mut u8;
+                                scope 15 (inlined NonNull::<[T]>::as_ptr) {
                                 }
                             }
                         }
-                        scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                            scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                        scope 16 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                            scope 17 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                             }
                         }
-                        scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                            scope 24 (inlined std::alloc::Global::deallocate_impl) {
-                                scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                    scope 26 (inlined Layout::size) {
-                                    }
-                                    scope 27 (inlined alloc::alloc::dealloc_nonnull) {
-                                        scope 28 (inlined Layout::size) {
+                        scope 18 (inlined <std::alloc::Global as Allocator>::deallocate_nonzero_size) {
+                            scope 19 (inlined std::alloc::Global::deallocate_nonzero_impl) {
+                                scope 20 (inlined std::alloc::Global::deallocate_nonzero_impl_runtime) {
+                                    scope 21 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 22 (inlined Layout::size) {
                                         }
-                                        scope 29 (inlined Layout::alignment) {
+                                        scope 23 (inlined Layout::alignment) {
                                         }
                                     }
                                 }
@@ -47,22 +45,11 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                     }
                     scope 8 (inlined Layout::for_value_raw::<[T]>) {
                         let mut _5: usize;
-                        let mut _6: std::mem::Alignment;
                         scope 9 {
                         }
                         scope 10 (inlined size_of_val_raw::<[T]>) {
                         }
                         scope 11 (inlined std::mem::Alignment::of_val_raw::<[T]>) {
-                            scope 12 {
-                                scope 14 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
-                                    scope 15 (inlined core::ub_checks::check_language_ub) {
-                                        scope 16 (inlined core::ub_checks::check_language_ub::runtime) {
-                                        }
-                                    }
-                                }
-                            }
-                            scope 13 (inlined align_of_val_raw::<[T]>) {
-                            }
                         }
                     }
                 }
@@ -73,7 +60,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
     bb0: {
         StorageLive(_3);
         StorageLive(_5);
-        StorageLive(_8);
+        StorageLive(_7);
         StorageLive(_2);
         _2 = copy (((*_1).0: std::ptr::Unique<[T]>).0: std::ptr::NonNull<[T]>);
         StorageLive(_4);
@@ -83,22 +70,21 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
     }
 
     bb1: {
-        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::mem::Alignment (Transmute);
         StorageDead(_4);
         switchInt(copy _5) -> [0: bb3, otherwise: bb2];
     }
 
     bb2: {
-        StorageLive(_7);
-        _7 = copy _3 as *mut u8 (PtrToPtr);
-        _8 = copy _7 as std::ptr::NonNull<u8> (Transmute);
-        StorageDead(_7);
-        _9 = alloc::alloc::__rust_dealloc(move _8, move _5, move _6) -> [return: bb3, unwind unreachable];
+        StorageLive(_6);
+        _6 = copy _3 as *mut u8 (PtrToPtr);
+        _7 = copy _6 as std::ptr::NonNull<u8> (Transmute);
+        StorageDead(_6);
+        _8 = alloc::alloc::__rust_dealloc(move _7, move _5, const <T as std::mem::SizedTypeProperties>::ALIGNMENT) -> [return: bb3, unwind unreachable];
     }
 
     bb3: {
         StorageDead(_2);
-        StorageDead(_8);
+        StorageDead(_7);
         StorageDead(_5);
         StorageDead(_3);
         return;

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-unwind.mir
@@ -12,29 +12,29 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 let _9: ();
                 scope 4 {
                     scope 5 {
-                        scope 18 (inlined Layout::size) {
+                        scope 17 (inlined Layout::size) {
                         }
-                        scope 19 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
+                        scope 18 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
                             let mut _8: std::ptr::NonNull<u8>;
-                            scope 20 (inlined NonNull::<[T]>::cast::<u8>) {
+                            scope 19 (inlined NonNull::<[T]>::cast::<u8>) {
                                 let mut _7: *mut u8;
-                                scope 21 (inlined NonNull::<[T]>::as_ptr) {
+                                scope 20 (inlined NonNull::<[T]>::as_ptr) {
                                 }
                             }
                         }
-                        scope 22 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                            scope 23 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                        scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                            scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                             }
                         }
-                        scope 24 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                            scope 25 (inlined std::alloc::Global::deallocate_impl) {
-                                scope 26 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                    scope 27 (inlined Layout::size) {
+                        scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                            scope 24 (inlined std::alloc::Global::deallocate_impl) {
+                                scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                                    scope 26 (inlined Layout::size) {
                                     }
-                                    scope 28 (inlined alloc::alloc::dealloc_nonnull) {
-                                        scope 29 (inlined Layout::size) {
+                                    scope 27 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 28 (inlined Layout::size) {
                                         }
-                                        scope 30 (inlined Layout::alignment) {
+                                        scope 29 (inlined Layout::alignment) {
                                         }
                                     }
                                 }
@@ -49,8 +49,6 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                         let mut _5: usize;
                         let mut _6: std::mem::Alignment;
                         scope 9 {
-                            scope 17 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
-                            }
                         }
                         scope 10 (inlined size_of_val_raw::<[T]>) {
                         }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
@@ -9,32 +9,30 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 let _2: std::ptr::NonNull<[T]>;
                 let mut _3: *mut [T];
                 let mut _4: *const [T];
-                let _9: ();
+                let _8: ();
                 scope 4 {
                     scope 5 {
-                        scope 17 (inlined Layout::size) {
+                        scope 12 (inlined Layout::size) {
                         }
-                        scope 18 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
-                            let mut _8: std::ptr::NonNull<u8>;
-                            scope 19 (inlined NonNull::<[T]>::cast::<u8>) {
-                                let mut _7: *mut u8;
-                                scope 20 (inlined NonNull::<[T]>::as_ptr) {
+                        scope 13 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
+                            let mut _7: std::ptr::NonNull<u8>;
+                            scope 14 (inlined NonNull::<[T]>::cast::<u8>) {
+                                let mut _6: *mut u8;
+                                scope 15 (inlined NonNull::<[T]>::as_ptr) {
                                 }
                             }
                         }
-                        scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                            scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                        scope 16 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                            scope 17 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                             }
                         }
-                        scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                            scope 24 (inlined std::alloc::Global::deallocate_impl) {
-                                scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                    scope 26 (inlined Layout::size) {
-                                    }
-                                    scope 27 (inlined alloc::alloc::dealloc_nonnull) {
-                                        scope 28 (inlined Layout::size) {
+                        scope 18 (inlined <std::alloc::Global as Allocator>::deallocate_nonzero_size) {
+                            scope 19 (inlined std::alloc::Global::deallocate_nonzero_impl) {
+                                scope 20 (inlined std::alloc::Global::deallocate_nonzero_impl_runtime) {
+                                    scope 21 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 22 (inlined Layout::size) {
                                         }
-                                        scope 29 (inlined Layout::alignment) {
+                                        scope 23 (inlined Layout::alignment) {
                                         }
                                     }
                                 }
@@ -47,22 +45,11 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                     }
                     scope 8 (inlined Layout::for_value_raw::<[T]>) {
                         let mut _5: usize;
-                        let mut _6: std::mem::Alignment;
                         scope 9 {
                         }
                         scope 10 (inlined size_of_val_raw::<[T]>) {
                         }
                         scope 11 (inlined std::mem::Alignment::of_val_raw::<[T]>) {
-                            scope 12 {
-                                scope 14 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
-                                    scope 15 (inlined core::ub_checks::check_language_ub) {
-                                        scope 16 (inlined core::ub_checks::check_language_ub::runtime) {
-                                        }
-                                    }
-                                }
-                            }
-                            scope 13 (inlined align_of_val_raw::<[T]>) {
-                            }
                         }
                     }
                 }
@@ -73,7 +60,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
     bb0: {
         StorageLive(_3);
         StorageLive(_5);
-        StorageLive(_8);
+        StorageLive(_7);
         StorageLive(_2);
         _2 = copy (((*_1).0: std::ptr::Unique<[T]>).0: std::ptr::NonNull<[T]>);
         StorageLive(_4);
@@ -83,22 +70,21 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
     }
 
     bb1: {
-        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::mem::Alignment (Transmute);
         StorageDead(_4);
         switchInt(copy _5) -> [0: bb3, otherwise: bb2];
     }
 
     bb2: {
-        StorageLive(_7);
-        _7 = copy _3 as *mut u8 (PtrToPtr);
-        _8 = copy _7 as std::ptr::NonNull<u8> (Transmute);
-        StorageDead(_7);
-        _9 = alloc::alloc::__rust_dealloc(move _8, move _5, move _6) -> [return: bb3, unwind unreachable];
+        StorageLive(_6);
+        _6 = copy _3 as *mut u8 (PtrToPtr);
+        _7 = copy _6 as std::ptr::NonNull<u8> (Transmute);
+        StorageDead(_6);
+        _8 = alloc::alloc::__rust_dealloc(move _7, move _5, const <T as std::mem::SizedTypeProperties>::ALIGNMENT) -> [return: bb3, unwind unreachable];
     }
 
     bb3: {
         StorageDead(_2);
-        StorageDead(_8);
+        StorageDead(_7);
         StorageDead(_5);
         StorageDead(_3);
         return;

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
@@ -12,29 +12,29 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 let _9: ();
                 scope 4 {
                     scope 5 {
-                        scope 18 (inlined Layout::size) {
+                        scope 17 (inlined Layout::size) {
                         }
-                        scope 19 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
+                        scope 18 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
                             let mut _8: std::ptr::NonNull<u8>;
-                            scope 20 (inlined NonNull::<[T]>::cast::<u8>) {
+                            scope 19 (inlined NonNull::<[T]>::cast::<u8>) {
                                 let mut _7: *mut u8;
-                                scope 21 (inlined NonNull::<[T]>::as_ptr) {
+                                scope 20 (inlined NonNull::<[T]>::as_ptr) {
                                 }
                             }
                         }
-                        scope 22 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                            scope 23 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                        scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                            scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                             }
                         }
-                        scope 24 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                            scope 25 (inlined std::alloc::Global::deallocate_impl) {
-                                scope 26 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                    scope 27 (inlined Layout::size) {
+                        scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                            scope 24 (inlined std::alloc::Global::deallocate_impl) {
+                                scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                                    scope 26 (inlined Layout::size) {
                                     }
-                                    scope 28 (inlined alloc::alloc::dealloc_nonnull) {
-                                        scope 29 (inlined Layout::size) {
+                                    scope 27 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 28 (inlined Layout::size) {
                                         }
-                                        scope 30 (inlined Layout::alignment) {
+                                        scope 29 (inlined Layout::alignment) {
                                         }
                                     }
                                 }
@@ -49,8 +49,6 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                         let mut _5: usize;
                         let mut _6: std::mem::Alignment;
                         scope 9 {
-                            scope 17 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
-                            }
                         }
                         scope 10 (inlined size_of_val_raw::<[T]>) {
                         }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-unwind.mir
@@ -9,32 +9,30 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 let _2: std::ptr::NonNull<[T]>;
                 let mut _3: *mut [T];
                 let mut _4: *const [T];
-                let _9: ();
+                let _8: ();
                 scope 4 {
                     scope 5 {
-                        scope 17 (inlined Layout::size) {
+                        scope 12 (inlined Layout::size) {
                         }
-                        scope 18 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
-                            let mut _8: std::ptr::NonNull<u8>;
-                            scope 19 (inlined NonNull::<[T]>::cast::<u8>) {
-                                let mut _7: *mut u8;
-                                scope 20 (inlined NonNull::<[T]>::as_ptr) {
+                        scope 13 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
+                            let mut _7: std::ptr::NonNull<u8>;
+                            scope 14 (inlined NonNull::<[T]>::cast::<u8>) {
+                                let mut _6: *mut u8;
+                                scope 15 (inlined NonNull::<[T]>::as_ptr) {
                                 }
                             }
                         }
-                        scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                            scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                        scope 16 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                            scope 17 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                             }
                         }
-                        scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                            scope 24 (inlined std::alloc::Global::deallocate_impl) {
-                                scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                    scope 26 (inlined Layout::size) {
-                                    }
-                                    scope 27 (inlined alloc::alloc::dealloc_nonnull) {
-                                        scope 28 (inlined Layout::size) {
+                        scope 18 (inlined <std::alloc::Global as Allocator>::deallocate_nonzero_size) {
+                            scope 19 (inlined std::alloc::Global::deallocate_nonzero_impl) {
+                                scope 20 (inlined std::alloc::Global::deallocate_nonzero_impl_runtime) {
+                                    scope 21 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 22 (inlined Layout::size) {
                                         }
-                                        scope 29 (inlined Layout::alignment) {
+                                        scope 23 (inlined Layout::alignment) {
                                         }
                                     }
                                 }
@@ -47,22 +45,11 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                     }
                     scope 8 (inlined Layout::for_value_raw::<[T]>) {
                         let mut _5: usize;
-                        let mut _6: std::mem::Alignment;
                         scope 9 {
                         }
                         scope 10 (inlined size_of_val_raw::<[T]>) {
                         }
                         scope 11 (inlined std::mem::Alignment::of_val_raw::<[T]>) {
-                            scope 12 {
-                                scope 14 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
-                                    scope 15 (inlined core::ub_checks::check_language_ub) {
-                                        scope 16 (inlined core::ub_checks::check_language_ub::runtime) {
-                                        }
-                                    }
-                                }
-                            }
-                            scope 13 (inlined align_of_val_raw::<[T]>) {
-                            }
                         }
                     }
                 }
@@ -73,7 +60,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
     bb0: {
         StorageLive(_3);
         StorageLive(_5);
-        StorageLive(_8);
+        StorageLive(_7);
         StorageLive(_2);
         _2 = copy (((*_1).0: std::ptr::Unique<[T]>).0: std::ptr::NonNull<[T]>);
         StorageLive(_4);
@@ -83,22 +70,21 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
     }
 
     bb1: {
-        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::mem::Alignment (Transmute);
         StorageDead(_4);
         switchInt(copy _5) -> [0: bb3, otherwise: bb2];
     }
 
     bb2: {
-        StorageLive(_7);
-        _7 = copy _3 as *mut u8 (PtrToPtr);
-        _8 = copy _7 as std::ptr::NonNull<u8> (Transmute);
-        StorageDead(_7);
-        _9 = alloc::alloc::__rust_dealloc(move _8, move _5, move _6) -> [return: bb3, unwind unreachable];
+        StorageLive(_6);
+        _6 = copy _3 as *mut u8 (PtrToPtr);
+        _7 = copy _6 as std::ptr::NonNull<u8> (Transmute);
+        StorageDead(_6);
+        _8 = alloc::alloc::__rust_dealloc(move _7, move _5, const <T as std::mem::SizedTypeProperties>::ALIGNMENT) -> [return: bb3, unwind unreachable];
     }
 
     bb3: {
         StorageDead(_2);
-        StorageDead(_8);
+        StorageDead(_7);
         StorageDead(_5);
         StorageDead(_3);
         return;

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-unwind.mir
@@ -12,29 +12,29 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 let _9: ();
                 scope 4 {
                     scope 5 {
-                        scope 18 (inlined Layout::size) {
+                        scope 17 (inlined Layout::size) {
                         }
-                        scope 19 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
+                        scope 18 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
                             let mut _8: std::ptr::NonNull<u8>;
-                            scope 20 (inlined NonNull::<[T]>::cast::<u8>) {
+                            scope 19 (inlined NonNull::<[T]>::cast::<u8>) {
                                 let mut _7: *mut u8;
-                                scope 21 (inlined NonNull::<[T]>::as_ptr) {
+                                scope 20 (inlined NonNull::<[T]>::as_ptr) {
                                 }
                             }
                         }
-                        scope 22 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                            scope 23 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                        scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                            scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                             }
                         }
-                        scope 24 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                            scope 25 (inlined std::alloc::Global::deallocate_impl) {
-                                scope 26 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                    scope 27 (inlined Layout::size) {
+                        scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                            scope 24 (inlined std::alloc::Global::deallocate_impl) {
+                                scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                                    scope 26 (inlined Layout::size) {
                                     }
-                                    scope 28 (inlined alloc::alloc::dealloc_nonnull) {
-                                        scope 29 (inlined Layout::size) {
+                                    scope 27 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 28 (inlined Layout::size) {
                                         }
-                                        scope 30 (inlined Layout::alignment) {
+                                        scope 29 (inlined Layout::alignment) {
                                         }
                                     }
                                 }
@@ -49,8 +49,6 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                         let mut _5: usize;
                         let mut _6: std::mem::Alignment;
                         scope 9 {
-                            scope 17 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
-                            }
                         }
                         scope 10 (inlined size_of_val_raw::<[T]>) {
                         }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.rs
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.rs
@@ -9,7 +9,6 @@ pub unsafe fn generic_in_place<T: Copy>(ptr: *mut Box<[T]>) {
     // CHECK-LABEL: fn generic_in_place(_1: *mut Box<[T]>)
     // CHECK: (inlined <Box<[T]> as Drop>::drop)
     // CHECK: [[SIZE:_.+]] = std::intrinsics::size_of_val::<[T]>
-    // CHECK: [[ALIGN:_.+]] = const <T as std::mem::SizedTypeProperties>::ALIGN as std::mem::Alignment (Transmute);
-    // CHECK: = alloc::alloc::__rust_dealloc({{.+}}, move [[SIZE]], move [[ALIGN]]) ->
+    // CHECK: = alloc::alloc::__rust_dealloc({{.+}}, move [[SIZE]], const <T as std::mem::SizedTypeProperties>::ALIGNMENT) ->
     std::ptr::drop_in_place(ptr)
 }

--- a/tests/ui/consts/auxiliary/unstable_intrinsic.rs
+++ b/tests/ui/consts/auxiliary/unstable_intrinsic.rs
@@ -1,5 +1,5 @@
-#![feature(staged_api, rustc_attrs, intrinsics)]
-#![stable(since="1.0.0", feature = "stable")]
+#![feature(staged_api, rustc_attrs, intrinsics, ptr_alignment_type)]
+#![stable(since = "1.0.0", feature = "stable")]
 
 #[unstable(feature = "unstable", issue = "42")]
 #[rustc_intrinsic]
@@ -8,4 +8,4 @@ pub const unsafe fn size_of_val<T>(x: *const T) -> usize;
 #[unstable(feature = "unstable", issue = "42")]
 #[rustc_const_unstable(feature = "unstable", issue = "42")]
 #[rustc_intrinsic]
-pub const unsafe fn align_of_val<T>(x: *const T) -> usize;
+pub const unsafe fn align_of_val<T>(x: *const T) -> std::mem::Alignment;

--- a/tests/ui/consts/const-size_of_val-align_of_val-extern-type.rs
+++ b/tests/ui/consts/const-size_of_val-align_of_val-extern-type.rs
@@ -1,7 +1,9 @@
 #![feature(extern_types)]
 #![feature(core_intrinsics)]
+#![feature(ptr_alignment_type)]
 
 use std::intrinsics::{align_of_val, size_of_val};
+use std::mem::Alignment;
 
 extern "C" {
     type Opaque;
@@ -9,7 +11,7 @@ extern "C" {
 
 const _SIZE: usize = unsafe { size_of_val(&4 as *const i32 as *const Opaque) };
 //~^ ERROR: the size for values of type `Opaque` cannot be known
-const _ALIGN: usize = unsafe { align_of_val(&4 as *const i32 as *const Opaque) };
+const _ALIGN: Alignment = unsafe { align_of_val(&4 as *const i32 as *const Opaque) };
 //~^ ERROR: the size for values of type `Opaque` cannot be known
 
 fn main() {}

--- a/tests/ui/consts/const-size_of_val-align_of_val-extern-type.stderr
+++ b/tests/ui/consts/const-size_of_val-align_of_val-extern-type.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the size for values of type `Opaque` cannot be known
-  --> $DIR/const-size_of_val-align_of_val-extern-type.rs:10:43
+  --> $DIR/const-size_of_val-align_of_val-extern-type.rs:12:43
    |
 LL | const _SIZE: usize = unsafe { size_of_val(&4 as *const i32 as *const Opaque) };
    |                               ----------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `MetaSized` is not implemented for `Opaque`
@@ -17,22 +17,22 @@ LL | const _SIZE: usize = unsafe { size_of_val(&mut (&4 as *const i32 as *const 
    |                                           ++++++                                 +
 
 error[E0277]: the size for values of type `Opaque` cannot be known
-  --> $DIR/const-size_of_val-align_of_val-extern-type.rs:12:45
+  --> $DIR/const-size_of_val-align_of_val-extern-type.rs:14:49
    |
-LL | const _ALIGN: usize = unsafe { align_of_val(&4 as *const i32 as *const Opaque) };
-   |                                ------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `MetaSized` is not implemented for `Opaque`
-   |                                |
-   |                                required by a bound introduced by this call
+LL | const _ALIGN: Alignment = unsafe { align_of_val(&4 as *const i32 as *const Opaque) };
+   |                                    ------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `MetaSized` is not implemented for `Opaque`
+   |                                    |
+   |                                    required by a bound introduced by this call
    |
    = note: the trait bound `Opaque: MetaSized` is not satisfied
 note: required by a bound in `std::intrinsics::align_of_val`
   --> $SRC_DIR/core/src/intrinsics/mod.rs:LL:COL
 help: consider borrowing here
    |
-LL | const _ALIGN: usize = unsafe { align_of_val(&(&4 as *const i32 as *const Opaque)) };
-   |                                             ++                                 +
-LL | const _ALIGN: usize = unsafe { align_of_val(&mut (&4 as *const i32 as *const Opaque)) };
-   |                                             ++++++                                 +
+LL | const _ALIGN: Alignment = unsafe { align_of_val(&(&4 as *const i32 as *const Opaque)) };
+   |                                                 ++                                 +
+LL | const _ALIGN: Alignment = unsafe { align_of_val(&mut (&4 as *const i32 as *const Opaque)) };
+   |                                                 ++++++                                 +
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-unstable-intrinsic.rs
+++ b/tests/ui/consts/const-unstable-intrinsic.rs
@@ -1,7 +1,7 @@
 //! Ensure that unstable intrinsics can actually not be called,
 //! neither within a crate nor cross-crate.
 //@ aux-build:unstable_intrinsic.rs
-#![feature(staged_api, rustc_attrs, intrinsics)]
+#![feature(staged_api, rustc_attrs, intrinsics, ptr_alignment_type)]
 #![stable(since = "1.0.0", feature = "stable")]
 #![feature(local)]
 
@@ -35,7 +35,7 @@ pub const unsafe fn size_of_val<T>(x: *const T) -> usize;
 #[unstable(feature = "local", issue = "42")]
 #[rustc_const_unstable(feature = "local", issue = "42")]
 #[rustc_intrinsic]
-pub const unsafe fn align_of_val<T>(x: *const T) -> usize;
+pub const unsafe fn align_of_val<T>(x: *const T) -> std::mem::Alignment;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.63.0")]

--- a/tests/ui/layout/invalid-unsized-in-always-sized-tail.stderr
+++ b/tests/ui/layout/invalid-unsized-in-always-sized-tail.stderr
@@ -21,7 +21,7 @@ LL | struct MySlice<T>(T);
 error[E0080]: the type `MySlice<[bool]>` has an unknown layout
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
    |
-   = note: evaluation of `<P2 as std::mem::SizedTypeProperties>::ALIGN` failed here
+   = note: evaluation of `<P2 as std::mem::SizedTypeProperties>::ALIGNMENT` failed here
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/152641)*
<!-- homu-ignore:end -->

Follow-up to https://github.com/rust-lang/rust/pull/152605

Notably, a common case of `align_of_val` is to put it in `Layout` for allocator calls, so might as well have it just be an `Alignment` already to avoid the extra transmute.

No changes to `rustc_const_eval` because that's already writing a `Scalar` into a place, which does what we need since `ptr::Alignment` is [`repr(transparent)` to a `repr(usize)`](https://github.com/rust-lang/rust/blob/7bee525095c0872e87c038c412c781b9bbb3f5dc/library/core/src/ptr/alignment.rs#L23-L25).