### PR TITLE
Make std::thread::panicking() simplify to false with panic=abort

### DIFF
--- a/library/std/src/thread/functions.rs
+++ b/library/std/src/thread/functions.rs
@@ -214,7 +214,11 @@ pub fn yield_now() {
 #[must_use]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn panicking() -> bool {
-    panicking::panicking()
+    if cfg!(panic = "abort") {
+        false
+    } else {
+        panicking::panicking()
+    }
 }
 
 /// Uses [`sleep`].


### PR DESCRIPTION
When compiled with panic=abort, the panicking() function should constant-fold to false since there's no unwinding in that mode.

This optimization allows code using std::thread::panicking() to compile down to nothing when panic=abort is enabled.

Fixes rust-lang/rust#151458