### PR TITLE
Add docs: warn that reading uninitialized POD is undefined behavior

### DIFF
--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -695,6 +695,16 @@ impl<T> MaybeUninit<T> {
     /// let x_init = unsafe { x.assume_init() };
     /// // `x` had not been initialized yet, so this last line caused undefined behavior. ⚠️
     /// ```
+    ///
+    /// *Incorrect* usage of this method:
+    ///
+    /// ```rust,no_run
+    /// use std::mem::MaybeUninit;
+    ///
+    /// let x = MaybeUninit::<u8>::uninit();
+    /// let x_init = unsafe { x.assume_init() };
+    /// // `x` was not initialized, reading uninitialized integer is undefined behavior! ⚠️
+    /// ```
     #[stable(feature = "maybe_uninit", since = "1.36.0")]
     #[rustc_const_stable(feature = "const_maybe_uninit_assume_init_by_value", since = "1.59.0")]
     #[inline(always)]
@@ -703,6 +713,7 @@ impl<T> MaybeUninit<T> {
     pub const unsafe fn assume_init(self) -> T {
         // SAFETY: the caller must guarantee that `self` is initialized.
         // This also means that `self` must be a `value` variant.
+        // Note that reading uninitialized POD (such as `u8`) is undefined behavior.
         unsafe {
             intrinsics::assert_inhabited::<T>();
             // We do this via a raw ptr read instead of `ManuallyDrop::into_inner` so that there's

--- a/library/std/src/thread/functions.rs
+++ b/library/std/src/thread/functions.rs
@@ -214,7 +214,11 @@ pub fn yield_now() {
 #[must_use]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn panicking() -> bool {
-    panicking::panicking()
+    if cfg!(panic = "abort") {
+        false
+    } else {
+        panicking::panicking()
+    }
 }
 
 /// Uses [`sleep`].


### PR DESCRIPTION
Add an example showing that even reading uninitialized integers (u8) with MaybeUninit::assume_init() is undefined behavior, not just types like Vec.

This addresses the issue raised in rust-lang/rust#150689 about documenting that reading uninitialized POD isn't sound, not just for Vec but for any Plain Old Data type.

Fixes rust-lang/rust#150689