### PR TITLE
Update `UnsafeUnpin` impls involving extern types.

### DIFF
--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -46,8 +46,8 @@ use crate::pin::UnsafePinned;
 /// marker_impls! {
 ///     MarkerTrait for
 ///         u8, i8,
-///         {T: ?Sized} *const T,
-///         {T: ?Sized} *mut T,
+///         {T: PointeeSized} *const T,
+///         {T: PointeeSized} *mut T,
 ///         {T: MarkerTrait} PhantomData<T>,
 ///         u32,
 /// }
@@ -931,15 +931,15 @@ marker_impls! {
 pub unsafe auto trait UnsafeUnpin {}
 
 #[unstable(feature = "unsafe_unpin", issue = "125735")]
-impl<T: ?Sized> !UnsafeUnpin for UnsafePinned<T> {}
+impl<T: PointeeSized> !UnsafeUnpin for UnsafePinned<T> {}
 marker_impls! {
 #[unstable(feature = "unsafe_unpin", issue = "125735")]
     unsafe UnsafeUnpin for
-        {T: ?Sized} PhantomData<T>,
-        {T: ?Sized} *const T,
-        {T: ?Sized} *mut T,
-        {T: ?Sized} &T,
-        {T: ?Sized} &mut T,
+        {T: PointeeSized} PhantomData<T>,
+        {T: PointeeSized} *const T,
+        {T: PointeeSized} *mut T,
+        {T: PointeeSized} &T,
+        {T: PointeeSized} &mut T,
 }
 
 /// Types that do not require any pinning guarantees.


### PR DESCRIPTION
`UnsafeUnpin` tracking issue: https://github.com/rust-lang/rust/issues/125735

Relaxes from `T: ?Sized` (i.e. `T: MetaSized`) to `T: PointeeSized` for the `UnsafeUnpin` impls for pointers, references, and `PhantomData<T>`, and for the negative `UnsafeUnpin` impl for `UnsafePinned<T>`. (Compare to the impls for `Freeze` on lines 911-921.)

Both `UnsafeUnpin` and `extern type`s (the only way to have a `!MetaSized` type) are unstable, so this should have no effect on stable code.

Also updates the marker_impls macro docs to use PointeeSized bound, as most uses of the macro now do.

Concretely, this change means that the following types will newly implement `UnsafeUnpin`:

* pointers and references to `T` where `T` is an `extern type`
* `PhantomData<T>` where `T` is an extern type
* either of the above where `T` is a `struct` or tuple with `extern type` tail

Additionally, the negative `UnsafeUnpin` impl for `UnsafePinned<T>` is also relaxed to `T: PointeeSized` to align with the analogous negative `Freeze` impl for `UnsafeCell<T>`, even though both structs have `T: ?Sized` in their declaration (which probably should be relaxed, but that is a separate issue), so this part of the change doesn't actually *do* anything currently, but if `UnsafeCell` and `UnsafePinned` are later relaxed to `T: PointeeSized`, then the negative impl will apply to the newly possible instantiations. Also cc https://github.com/rust-lang/rust/issues/152645 that these impls compile at all.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
