### PR TITLE
Remove timing assertion from `oneshot::send_before_recv_timeout`

### DIFF
--- a/library/std/tests/sync/oneshot.rs
+++ b/library/std/tests/sync/oneshot.rs
@@ -89,15 +89,15 @@ fn send_before_recv_timeout() {
 
     assert!(sender.send(22i128).is_ok());
 
-    let start = Instant::now();
-
     let timeout = Duration::from_secs(1);
     match receiver.recv_timeout(timeout) {
         Ok(22) => {}
         _ => panic!("expected Ok(22)"),
     }
 
-    assert!(start.elapsed() < timeout);
+    // FIXME(#152648): There previously was a timing assertion here.
+    // This was removed, because under load there's no guarantee that the main thread is
+    // scheduled and run before `timeout` expires
 }
 
 #[test]


### PR DESCRIPTION
This test regularly spuriously fails in CI, such as https://github.com/rust-lang/rust/pull/152632#issuecomment-3902778366
We can just remove the assertion but I'd like to understand why, so I'm adding more information to the assert