### PR TITLE
Disable debug_assert_not_in_new_nodes for multiple threads

### DIFF
--- a/compiler/rustc_middle/src/dep_graph/graph.rs
+++ b/compiler/rustc_middle/src/dep_graph/graph.rs
@@ -9,7 +9,7 @@ use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::profiling::QueryInvocationId;
 use rustc_data_structures::sharded::{self, ShardedHashMap};
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
-use rustc_data_structures::sync::{AtomicU64, Lock};
+use rustc_data_structures::sync::{AtomicU64, Lock, is_dyn_thread_safe};
 use rustc_data_structures::unord::UnordMap;
 use rustc_data_structures::{assert_matches, outline};
 use rustc_errors::DiagInner;
@@ -1311,7 +1311,9 @@ impl<D: Deps> CurrentDepGraph<D> {
         prev_graph: &SerializedDepGraph,
         prev_index: SerializedDepNodeIndex,
     ) {
-        if let Some(ref nodes_in_current_session) = self.nodes_in_current_session {
+        if !is_dyn_thread_safe()
+            && let Some(ref nodes_in_current_session) = self.nodes_in_current_session
+        {
             debug_assert!(
                 !nodes_in_current_session
                     .lock()


### PR DESCRIPTION
Fixes rust-lang/rust#152654

This debug assertion is no longer intended to succeed for the parallel compiler since rust-lang/rust#151509 doesn't panic on a red-green query graph coloring race, generating both red and green nodes  (https://github.com/rust-lang/rust/pull/151509#discussion_r2764707236)