### PR TITLE
Avoid ICE in From/TryFrom diagnostic under -Znext-solver

### DIFF
--- a/tests/ui/traits/next-solver-ice.rs
+++ b/tests/ui/traits/next-solver-ice.rs
@@ -1,0 +1,9 @@
+//@compile-flags: -Znext-solver=globally
+//@check-fail
+
+fn check<T: Iterator>() {
+    <f32 as From<<T as Iterator>::Item>>::from;
+    //~^ ERROR the trait bound `f32: From<<T as Iterator>::Item>` is not satisfied
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver-ice.stderr
+++ b/tests/ui/traits/next-solver-ice.stderr
@@ -1,0 +1,21 @@
+error[E0277]: the trait bound `f32: From<<T as Iterator>::Item>` is not satisfied
+  --> $DIR/next-solver-ice.rs:5:6
+   |
+LL |     <f32 as From<<T as Iterator>::Item>>::from;
+   |      ^^^ the nightly-only, unstable trait `ZeroablePrimitive` is not implemented for `f32`
+   |
+   = help: the following other types implement trait `ZeroablePrimitive`:
+             i128
+             i16
+             i32
+             i64
+             i8
+             isize
+             u128
+             u16
+           and 4 others
+   = note: required for `f32` to implement `From<<T as Iterator>::Item>`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes rust-lang/rust#152518.

Under `-Znext-solver=globally`, `trait_ref.args` may contain fewer
elements than expected. The diagnostic logic in
`fulfillment_errors.rs` assumed at least two elements and
unconditionally called `type_at(1)`, which could lead to an
index out-of-bounds panic during error reporting.

This change adds a defensive check before accessing the second
argument to avoid the ICE. A UI regression test has been added.
