### PR TITLE
Fix mis-constructed `file_span` when generating scraped examples

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -60,7 +60,7 @@ use rustc_hir::{ConstStability, Mutability, RustcVersion, StabilityLevel, Stable
 use rustc_middle::ty::print::PrintTraitRefExt;
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_span::symbol::{Symbol, sym};
-use rustc_span::{BytePos, DUMMY_SP, FileName};
+use rustc_span::DUMMY_SP;
 use tracing::{debug, info};
 
 pub(crate) use self::context::*;

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -59,8 +59,8 @@ use rustc_hir::def_id::{DefId, DefIdSet};
 use rustc_hir::{ConstStability, Mutability, RustcVersion, StabilityLevel, StableSince};
 use rustc_middle::ty::print::PrintTraitRefExt;
 use rustc_middle::ty::{self, TyCtxt};
-use rustc_span::symbol::{Symbol, sym};
 use rustc_span::DUMMY_SP;
+use rustc_span::symbol::{Symbol, sym};
 use tracing::{debug, info};
 
 pub(crate) use self::context::*;

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2779,46 +2779,12 @@ fn render_call_locations<W: fmt::Write>(
         let needs_expansion = line_max - line_min > NUM_VISIBLE_LINES;
         let locations_encoded = serde_json::to_string(&line_ranges).unwrap();
 
-        let source_map = tcx.sess.source_map();
-        let files = source_map.files();
-        let local = tcx.sess.local_crate_source_file().unwrap();
-
-        let get_file_start_pos = || {
-            let crate_src = local.clone().into_local_path()?;
-            let abs_crate_src = crate_src.canonicalize().ok()?;
-            let crate_root = abs_crate_src.parent()?.parent()?;
-            let rel_path = path.strip_prefix(crate_root).ok()?;
-            files
-                .iter()
-                .find(|file| match &file.name {
-                    FileName::Real(real) => real.local_path().map_or(false, |p| p == rel_path),
-                    _ => false,
-                })
-                .map(|file| file.start_pos)
-        };
-
-        // Look for the example file in the source map if it exists, otherwise
-        // return a span to the local crate's source file
-        let Some(file_span) = get_file_start_pos()
-            .or_else(|| {
-                files
-                    .iter()
-                    .find(|file| match &file.name {
-                        FileName::Real(file_name) => file_name == &local,
-                        _ => false,
-                    })
-                    .map(|file| file.start_pos)
-            })
-            .map(|start_pos| {
-                rustc_span::Span::with_root_ctxt(
-                    start_pos + BytePos(byte_min),
-                    start_pos + BytePos(byte_max),
-                )
-            })
-        else {
-            // if the fallback span can't be built, don't render the code for this example
-            return false;
-        };
+        // For scraped examples, we don't need a real span from the SourceMap.
+        // The URL is already provided in ScrapedInfo, and sources::print_src
+        // will use that directly. We use DUMMY_SP as a placeholder.
+        // Note: DUMMY_SP is safe here because href_from_span won't be called
+        // for scraped examples.
+        let file_span = rustc_span::DUMMY_SP;
 
         let mut decoration_info = FxIndexMap::default();
         decoration_info.insert("highlight focus", vec![byte_ranges.remove(0)]);

--- a/src/librustdoc/html/sources.rs
+++ b/src/librustdoc/html/sources.rs
@@ -344,9 +344,15 @@ pub(crate) fn print_src(
         lines += line_info.start_line as usize;
     }
     let code = fmt::from_fn(move |fmt| {
-        let current_href = context
-            .href_from_span(clean::Span::new(file_span), false)
-            .expect("only local crates should have sources emitted");
+        // For scraped examples, use the URL from ScrapedInfo directly.
+        // For regular sources, derive it from the span.
+        let current_href = if let SourceContext::Embedded(info) = source_context {
+            info.url.to_string()
+        } else {
+            context
+                .href_from_span(clean::Span::new(file_span), false)
+                .expect("only local crates should have sources emitted")
+        };
         highlight::write_code(
             fmt,
             s,


### PR DESCRIPTION
Fixes rust-lang/rust#152601. Seemingly relative with rust-lang/rust#147399 but I could not reproduce the original ICE.

This PR removes the `file_span` logic from scraped example generation. The original implementation did not read or write items using `file_span`; it only used it to locate a source file, `context.href_from_span`. However, the span was validated against the wrong file, which could trigger ICEs on inputs such as multibyte characters due to an incorrectly constructed span. Since scraped examples do not use the span and the `url` is already given, the safest and simplest fix is to remove it.

Tested against the crate and MCVE documented in the original issue.

P.S. there seems to be some bug when rendering call sites, but since fixing mis-behavior is a change rather than a bug-fix that would be implemented in another PR.