### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_lint/src/errors.rs
+++ b/compiler/rustc_lint/src/errors.rs
@@ -20,7 +20,7 @@ pub(crate) struct OverruledAttribute<'a> {
 pub(crate) enum OverruledAttributeSub {
     DefaultSource { id: String },
     NodeSource { span: Span, reason: Option<Symbol> },
-    CommandLineSource,
+    CommandLineSource { id: Symbol },
 }
 
 impl Subdiagnostic for OverruledAttributeSub {
@@ -36,8 +36,9 @@ impl Subdiagnostic for OverruledAttributeSub {
                     diag.note(rationale.to_string());
                 }
             }
-            OverruledAttributeSub::CommandLineSource => {
-                diag.note(msg!("`forbid` lint level was set on command line"));
+            OverruledAttributeSub::CommandLineSource { id } => {
+                diag.note(msg!("`forbid` lint level was set on command line (`-F {$id}`)"));
+                diag.arg("id", id);
             }
         }
     }

--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -580,7 +580,9 @@ impl<'s, P: LintLevelsProvider> LintLevelsBuilder<'s, P> {
                 LintLevelSource::Node { span, reason, .. } => {
                     OverruledAttributeSub::NodeSource { span, reason }
                 }
-                LintLevelSource::CommandLine(_, _) => OverruledAttributeSub::CommandLineSource,
+                LintLevelSource::CommandLine(name, _) => {
+                    OverruledAttributeSub::CommandLineSource { id: name }
+                }
             };
             if !fcw_warning {
                 self.sess.dcx().emit_err(OverruledAttribute {

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -71,6 +71,8 @@ pub fn walk_native_lib_search_dirs<R>(
         || sess.target.os == Os::Fuchsia
         || sess.target.is_like_aix
         || sess.target.is_like_darwin && !sess.sanitizers().is_empty()
+        // FIXME: For the shared LLVM library.
+        || sess.target.os == Os::Windows && sess.target.env == Env::Gnu && sess.target.abi == Abi::Llvm
     {
         f(&sess.target_tlib_path.dir, false)?;
     }

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -2557,7 +2557,7 @@ pub fn maybe_install_llvm_target(builder: &Builder<'_>, target: TargetSelection,
     ),
 )]
 pub fn maybe_install_llvm_runtime(builder: &Builder<'_>, target: TargetSelection, sysroot: &Path) {
-    let dst_libdir = sysroot.join(builder.sysroot_libdir_relative(Compiler::new(1, target)));
+    let dst_libdir = sysroot.join(builder.libdir_relative(Compiler::new(1, target)));
     // We do not need to copy LLVM files into the sysroot if it is not
     // dynamically linked; it is already included into librustc_llvm
     // statically.

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -691,6 +691,7 @@ auto:
         --target=aarch64-pc-windows-gnullvm,i686-pc-windows-gnullvm
         --enable-full-tools
         --enable-profiler
+        --enable-llvm-link-shared
       DIST_REQUIRE_ALL_TOOLS: 1
       CODEGEN_BACKENDS: llvm,cranelift
       CC_i686_pc_windows_gnullvm: i686-w64-mingw32-clang
@@ -703,6 +704,7 @@ auto:
         --build=x86_64-pc-windows-gnullvm
         --enable-full-tools
         --enable-profiler
+        --enable-llvm-link-shared
       DIST_REQUIRE_ALL_TOOLS: 1
       CODEGEN_BACKENDS: llvm,cranelift
     <<: *job-windows

--- a/tests/ui/lint/lint-forbid-attr.rs
+++ b/tests/ui/lint/lint-forbid-attr.rs
@@ -1,6 +1,7 @@
-#![forbid(deprecated)]
+#![forbid(deprecated)] //~ NOTE `forbid` level set here
 
 #[allow(deprecated)]
-//~^ ERROR allow(deprecated) incompatible
+//~^ ERROR allow(deprecated) incompatible with previous forbid [E0453]
+//~^^ NOTE overruled by previous forbid
 fn main() {
 }

--- a/tests/ui/lint/lint-forbid-cmdline-1.rs
+++ b/tests/ui/lint/lint-forbid-cmdline-1.rs
@@ -1,0 +1,5 @@
+//@ compile-flags: -F deprecated
+
+#[allow(deprecated)] //~ ERROR allow(deprecated) incompatible with previous forbid [E0453]
+fn main() {
+}

--- a/tests/ui/lint/lint-forbid-cmdline-1.stderr
+++ b/tests/ui/lint/lint-forbid-cmdline-1.stderr
@@ -1,10 +1,10 @@
 error[E0453]: allow(deprecated) incompatible with previous forbid
-  --> $DIR/lint-forbid-cmdline.rs:3:9
+  --> $DIR/lint-forbid-cmdline-1.rs:3:9
    |
 LL | #[allow(deprecated)]
    |         ^^^^^^^^^^ overruled by previous forbid
    |
-   = note: `forbid` lint level was set on command line
+   = note: `forbid` lint level was set on command line (`-F deprecated`)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lint/lint-forbid-cmdline-2.rs
+++ b/tests/ui/lint/lint-forbid-cmdline-2.rs
@@ -1,0 +1,8 @@
+//@ compile-flags: -F dead_code
+
+#[allow(unused)]
+//~^ ERROR allow(unused) incompatible with previous forbid [E0453]
+//~| NOTE overruled by previous forbid
+//~| NOTE `forbid` lint level was set on command line (`-F dead_code`)
+fn main() {
+}

--- a/tests/ui/lint/lint-forbid-cmdline-2.stderr
+++ b/tests/ui/lint/lint-forbid-cmdline-2.stderr
@@ -1,0 +1,11 @@
+error[E0453]: allow(unused) incompatible with previous forbid
+  --> $DIR/lint-forbid-cmdline-2.rs:3:9
+   |
+LL | #[allow(unused)]
+   |         ^^^^^^ overruled by previous forbid
+   |
+   = note: `forbid` lint level was set on command line (`-F dead_code`)
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0453`.

--- a/tests/ui/lint/lint-forbid-cmdline.rs
+++ b/tests/ui/lint/lint-forbid-cmdline.rs
@@ -1,5 +1,0 @@
-//@ compile-flags: -F deprecated
-
-#[allow(deprecated)] //~ ERROR allow(deprecated) incompatible
-fn main() {
-}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#152609 (Install LLVM DLL in the right place on Windows)
 - rust-lang/rust#152452 (feat: show what lint was overruled)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=152609,152452)
<!-- homu-ignore:end -->

