### PR TITLE
Update `exchange_malloc` to take `Alignment` too

### DIFF
--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -157,6 +157,7 @@ language_item_table! {
     PointeeSized,            sym::pointee_sized,       pointee_sized_trait,        Target::Trait,          GenericRequirement::Exact(0);
     Unsize,                  sym::unsize,              unsize_trait,               Target::Trait,          GenericRequirement::Minimum(1);
     AlignOf,                 sym::mem_align_const,     align_const,                Target::AssocConst,     GenericRequirement::Exact(0);
+    AlignmentOf,             sym::mem_alignment_const, alignment_const,            Target::AssocConst,     GenericRequirement::Exact(0);
     SizeOf,                  sym::mem_size_const,      size_const,                 Target::AssocConst,     GenericRequirement::Exact(0);
     OffsetOf,                sym::offset_of,           offset_of,                  Target::Fn,             GenericRequirement::Exact(1);
     /// Trait injected by `#[derive(PartialEq)]`, (i.e. "Partial EQ").

--- a/compiler/rustc_mir_build/src/builder/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_rvalue.rs
@@ -132,7 +132,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let size = tcx.require_lang_item(LangItem::SizeOf, expr_span);
                 let size = Operand::unevaluated_constant(tcx, size, &[value_ty.into()], expr_span);
 
-                let align = tcx.require_lang_item(LangItem::AlignOf, expr_span);
+                let align = tcx.require_lang_item(LangItem::AlignmentOf, expr_span);
                 let align =
                     Operand::unevaluated_constant(tcx, align, &[value_ty.into()], expr_span);
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1445,6 +1445,7 @@ symbols! {
         maybe_uninit_zeroed,
         mem_align_const,
         mem_align_of,
+        mem_alignment_const,
         mem_discriminant,
         mem_drop,
         mem_forget,

--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -484,8 +484,8 @@ unsafe impl const Allocator for Global {
 #[lang = "exchange_malloc"]
 #[inline]
 #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
-unsafe fn exchange_malloc(size: usize, align: usize) -> *mut u8 {
-    let layout = unsafe { Layout::from_size_align_unchecked(size, align) };
+unsafe fn exchange_malloc(size: usize, align: Alignment) -> *mut u8 {
+    let layout = unsafe { Layout::from_size_alignment_unchecked(size, align) };
     match Global.allocate(layout) {
         Ok(ptr) => ptr.as_mut_ptr(),
         Err(_) => handle_alloc_error(layout),

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1260,6 +1260,7 @@ pub trait SizedTypeProperties: Sized {
 
     #[doc(hidden)]
     #[unstable(feature = "ptr_alignment_type", issue = "102070")]
+    #[lang = "mem_alignment_const"]
     const ALIGNMENT: Alignment = {
         // This can't panic since type alignment is always a power of two.
         Alignment::new(Self::ALIGN).unwrap()
@@ -1300,7 +1301,7 @@ pub trait SizedTypeProperties: Sized {
         // SAFETY: if the type is instantiated, rustc already ensures that its
         // layout is valid. Use the unchecked constructor to avoid inserting a
         // panicking codepath that needs to be optimized out.
-        unsafe { Layout::from_size_align_unchecked(Self::SIZE, Self::ALIGN) }
+        unsafe { Layout::from_size_alignment_unchecked(Self::SIZE, Self::ALIGNMENT) }
     };
 
     /// The largest safe length for a `[Self]`.

--- a/tests/codegen-units/item-collection/opaque-return-impls.rs
+++ b/tests/codegen-units/item-collection/opaque-return-impls.rs
@@ -46,8 +46,7 @@ pub fn foo2() -> Box<dyn TestTrait2> {
 //~ MONO_ITEM fn foo2
 //~ MONO_ITEM fn std::alloc::Global::alloc_impl_runtime
 //~ MONO_ITEM fn std::boxed::Box::<TestStruct2>::new
-//~ MONO_ITEM fn std::alloc::Layout::from_size_align_unchecked::precondition_check
-//~ MONO_ITEM fn std::ptr::Alignment::new_unchecked::precondition_check
+//~ MONO_ITEM fn std::alloc::Layout::from_size_alignment_unchecked::precondition_check
 //~ MONO_ITEM fn std::ptr::NonNull::<T>::new_unchecked::precondition_check
 
 struct Counter {

--- a/tests/mir-opt/box_expr.main.ElaborateDrops.diff
+++ b/tests/mir-opt/box_expr.main.ElaborateDrops.diff
@@ -17,7 +17,7 @@
   
       bb0: {
           StorageLive(_1);
-          _2 = alloc::alloc::exchange_malloc(const <S as std::mem::SizedTypeProperties>::SIZE, const <S as std::mem::SizedTypeProperties>::ALIGN) -> [return: bb1, unwind continue];
+          _2 = alloc::alloc::exchange_malloc(const <S as std::mem::SizedTypeProperties>::SIZE, const <S as std::mem::SizedTypeProperties>::ALIGNMENT) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/building/uniform_array_move_out.move_out_by_subslice.built.after.mir
+++ b/tests/mir-opt/building/uniform_array_move_out.move_out_by_subslice.built.after.mir
@@ -20,7 +20,7 @@ fn move_out_by_subslice() -> () {
     bb0: {
         StorageLive(_1);
         StorageLive(_2);
-        _3 = alloc::alloc::exchange_malloc(const <i32 as std::mem::SizedTypeProperties>::SIZE, const <i32 as std::mem::SizedTypeProperties>::ALIGN) -> [return: bb1, unwind: bb13];
+        _3 = alloc::alloc::exchange_malloc(const <i32 as std::mem::SizedTypeProperties>::SIZE, const <i32 as std::mem::SizedTypeProperties>::ALIGNMENT) -> [return: bb1, unwind: bb13];
     }
 
     bb1: {
@@ -34,7 +34,7 @@ fn move_out_by_subslice() -> () {
     bb2: {
         StorageDead(_4);
         StorageLive(_5);
-        _6 = alloc::alloc::exchange_malloc(const <i32 as std::mem::SizedTypeProperties>::SIZE, const <i32 as std::mem::SizedTypeProperties>::ALIGN) -> [return: bb3, unwind: bb12];
+        _6 = alloc::alloc::exchange_malloc(const <i32 as std::mem::SizedTypeProperties>::SIZE, const <i32 as std::mem::SizedTypeProperties>::ALIGNMENT) -> [return: bb3, unwind: bb12];
     }
 
     bb3: {

--- a/tests/mir-opt/building/uniform_array_move_out.move_out_from_end.built.after.mir
+++ b/tests/mir-opt/building/uniform_array_move_out.move_out_from_end.built.after.mir
@@ -20,7 +20,7 @@ fn move_out_from_end() -> () {
     bb0: {
         StorageLive(_1);
         StorageLive(_2);
-        _3 = alloc::alloc::exchange_malloc(const <i32 as std::mem::SizedTypeProperties>::SIZE, const <i32 as std::mem::SizedTypeProperties>::ALIGN) -> [return: bb1, unwind: bb13];
+        _3 = alloc::alloc::exchange_malloc(const <i32 as std::mem::SizedTypeProperties>::SIZE, const <i32 as std::mem::SizedTypeProperties>::ALIGNMENT) -> [return: bb1, unwind: bb13];
     }
 
     bb1: {
@@ -34,7 +34,7 @@ fn move_out_from_end() -> () {
     bb2: {
         StorageDead(_4);
         StorageLive(_5);
-        _6 = alloc::alloc::exchange_malloc(const <i32 as std::mem::SizedTypeProperties>::SIZE, const <i32 as std::mem::SizedTypeProperties>::ALIGN) -> [return: bb3, unwind: bb12];
+        _6 = alloc::alloc::exchange_malloc(const <i32 as std::mem::SizedTypeProperties>::SIZE, const <i32 as std::mem::SizedTypeProperties>::ALIGNMENT) -> [return: bb3, unwind: bb12];
     }
 
     bb3: {

--- a/tests/mir-opt/const_prop/boxes.main.GVN.panic-abort.diff
+++ b/tests/mir-opt/const_prop/boxes.main.GVN.panic-abort.diff
@@ -22,7 +22,7 @@
 -         StorageLive(_2);
 +         nop;
           StorageLive(_3);
-          _4 = alloc::alloc::exchange_malloc(const <i32 as std::mem::SizedTypeProperties>::SIZE, const <i32 as std::mem::SizedTypeProperties>::ALIGN) -> [return: bb1, unwind unreachable];
+          _4 = alloc::alloc::exchange_malloc(const <i32 as std::mem::SizedTypeProperties>::SIZE, const <i32 as std::mem::SizedTypeProperties>::ALIGNMENT) -> [return: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/const_prop/boxes.main.GVN.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/boxes.main.GVN.panic-unwind.diff
@@ -22,7 +22,7 @@
 -         StorageLive(_2);
 +         nop;
           StorageLive(_3);
-          _4 = alloc::alloc::exchange_malloc(const <i32 as std::mem::SizedTypeProperties>::SIZE, const <i32 as std::mem::SizedTypeProperties>::ALIGN) -> [return: bb1, unwind continue];
+          _4 = alloc::alloc::exchange_malloc(const <i32 as std::mem::SizedTypeProperties>::SIZE, const <i32 as std::mem::SizedTypeProperties>::ALIGNMENT) -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.32bit.panic-abort.diff
@@ -12,8 +12,8 @@
       let mut _10: std::boxed::Box<()>;
       let mut _11: *const ();
       let mut _16: usize;
-      let mut _17: usize;
-      let mut _26: usize;
+      let mut _17: std::ptr::Alignment;
+      let mut _25: usize;
       scope 1 {
           debug vp_ctx => _1;
           let _5: *const ();
@@ -27,7 +27,7 @@
                       debug _x => _8;
                   }
                   scope 19 (inlined foo) {
-                      let mut _27: *const [()];
+                      let mut _26: *const [()];
                   }
               }
               scope 17 (inlined slice_from_raw_parts::<()>) {
@@ -52,7 +52,7 @@
                       scope 12 (inlined NonNull::<[u8]>::as_mut_ptr) {
                           scope 13 (inlined NonNull::<[u8]>::as_non_null_ptr) {
                               scope 14 (inlined NonNull::<[u8]>::cast::<u8>) {
-                                  let mut _25: *mut [u8];
+                                  let mut _24: *mut [u8];
                                   scope 15 (inlined NonNull::<[u8]>::as_ptr) {
                                   }
                               }
@@ -66,9 +66,8 @@
                       }
                   }
               }
-              scope 9 (inlined #[track_caller] Layout::from_size_align_unchecked) {
+              scope 9 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
                   let _23: ();
-                  let mut _24: std::ptr::Alignment;
               }
           }
       }
@@ -88,8 +87,8 @@
 -         _16 = const <() as std::mem::SizedTypeProperties>::SIZE;
 +         _16 = const 0_usize;
           StorageLive(_17);
--         _17 = const <() as std::mem::SizedTypeProperties>::ALIGN;
-+         _17 = const 1_usize;
+-         _17 = const <() as std::mem::SizedTypeProperties>::ALIGNMENT;
++         _17 = const std::ptr::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }};
           StorageLive(_18);
           StorageLive(_20);
           StorageLive(_21);
@@ -115,11 +114,11 @@
   
       bb4: {
           _21 = copy ((_19 as Ok).0: std::ptr::NonNull<[u8]>);
--         StorageLive(_25);
+-         StorageLive(_24);
 +         nop;
-          _25 = copy _21 as *mut [u8] (Transmute);
-          _12 = copy _25 as *mut u8 (PtrToPtr);
--         StorageDead(_25);
+          _24 = copy _21 as *mut [u8] (Transmute);
+          _12 = copy _24 as *mut u8 (PtrToPtr);
+-         StorageDead(_24);
 +         nop;
           StorageDead(_19);
           StorageDead(_23);
@@ -130,7 +129,7 @@
           StorageDead(_17);
           StorageDead(_16);
 -         _13 = copy _12 as *const () (PtrToPtr);
-+         _13 = copy _25 as *const () (PtrToPtr);
++         _13 = copy _24 as *const () (PtrToPtr);
           _14 = NonNull::<()> { pointer: copy _13 };
           _15 = std::ptr::Unique::<()> { pointer: copy _14, _marker: const PhantomData::<()> };
           _3 = Box::<()>(move _15, const std::alloc::Global);
@@ -153,21 +152,21 @@
 +         nop;
           StorageLive(_7);
           _7 = copy _5;
-          StorageLive(_26);
-          _26 = const 1_usize;
--         _6 = *const [()] from (copy _7, copy _26);
+          StorageLive(_25);
+          _25 = const 1_usize;
+-         _6 = *const [()] from (copy _7, copy _25);
 +         _6 = *const [()] from (copy _5, const 1_usize);
-          StorageDead(_26);
+          StorageDead(_25);
           StorageDead(_7);
           StorageLive(_8);
           StorageLive(_9);
           _9 = copy _6;
-          StorageLive(_27);
--         _27 = copy _9;
+          StorageLive(_26);
+-         _26 = copy _9;
 -         _8 = copy _9 as *mut () (PtrToPtr);
-+         _27 = copy _6;
++         _26 = copy _6;
 +         _8 = copy _5 as *mut () (PtrToPtr);
-          StorageDead(_27);
+          StorageDead(_26);
           StorageDead(_9);
           _0 = const ();
           StorageDead(_8);
@@ -179,17 +178,13 @@
       }
   
       bb5: {
--         _23 = Layout::from_size_align_unchecked::precondition_check(copy _16, copy _17) -> [return: bb6, unwind unreachable];
-+         _23 = Layout::from_size_align_unchecked::precondition_check(const 0_usize, const 1_usize) -> [return: bb6, unwind unreachable];
+-         _23 = Layout::from_size_alignment_unchecked::precondition_check(copy _16, copy _17) -> [return: bb6, unwind unreachable];
++         _23 = Layout::from_size_alignment_unchecked::precondition_check(const 0_usize, const std::ptr::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }}) -> [return: bb6, unwind unreachable];
       }
   
       bb6: {
-          StorageLive(_24);
--         _24 = copy _17 as std::ptr::Alignment (Transmute);
--         _18 = Layout { size: copy _16, align: move _24 };
-+         _24 = const std::ptr::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }};
+-         _18 = Layout { size: copy _16, align: copy _17 };
 +         _18 = const Layout {{ size: 0_usize, align: std::ptr::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }} }};
-          StorageDead(_24);
           StorageLive(_19);
 -         _19 = std::alloc::Global::alloc_impl_runtime(copy _18, const false) -> [return: bb7, unwind unreachable];
 +         _19 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: 0_usize, align: std::ptr::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }} }}, const false) -> [return: bb7, unwind unreachable];

--- a/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.64bit.panic-abort.diff
@@ -12,8 +12,8 @@
       let mut _10: std::boxed::Box<()>;
       let mut _11: *const ();
       let mut _16: usize;
-      let mut _17: usize;
-      let mut _26: usize;
+      let mut _17: std::ptr::Alignment;
+      let mut _25: usize;
       scope 1 {
           debug vp_ctx => _1;
           let _5: *const ();
@@ -27,7 +27,7 @@
                       debug _x => _8;
                   }
                   scope 19 (inlined foo) {
-                      let mut _27: *const [()];
+                      let mut _26: *const [()];
                   }
               }
               scope 17 (inlined slice_from_raw_parts::<()>) {
@@ -52,7 +52,7 @@
                       scope 12 (inlined NonNull::<[u8]>::as_mut_ptr) {
                           scope 13 (inlined NonNull::<[u8]>::as_non_null_ptr) {
                               scope 14 (inlined NonNull::<[u8]>::cast::<u8>) {
-                                  let mut _25: *mut [u8];
+                                  let mut _24: *mut [u8];
                                   scope 15 (inlined NonNull::<[u8]>::as_ptr) {
                                   }
                               }
@@ -66,9 +66,8 @@
                       }
                   }
               }
-              scope 9 (inlined #[track_caller] Layout::from_size_align_unchecked) {
+              scope 9 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
                   let _23: ();
-                  let mut _24: std::ptr::Alignment;
               }
           }
       }
@@ -88,8 +87,8 @@
 -         _16 = const <() as std::mem::SizedTypeProperties>::SIZE;
 +         _16 = const 0_usize;
           StorageLive(_17);
--         _17 = const <() as std::mem::SizedTypeProperties>::ALIGN;
-+         _17 = const 1_usize;
+-         _17 = const <() as std::mem::SizedTypeProperties>::ALIGNMENT;
++         _17 = const std::ptr::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }};
           StorageLive(_18);
           StorageLive(_20);
           StorageLive(_21);
@@ -115,11 +114,11 @@
   
       bb4: {
           _21 = copy ((_19 as Ok).0: std::ptr::NonNull<[u8]>);
--         StorageLive(_25);
+-         StorageLive(_24);
 +         nop;
-          _25 = copy _21 as *mut [u8] (Transmute);
-          _12 = copy _25 as *mut u8 (PtrToPtr);
--         StorageDead(_25);
+          _24 = copy _21 as *mut [u8] (Transmute);
+          _12 = copy _24 as *mut u8 (PtrToPtr);
+-         StorageDead(_24);
 +         nop;
           StorageDead(_19);
           StorageDead(_23);
@@ -130,7 +129,7 @@
           StorageDead(_17);
           StorageDead(_16);
 -         _13 = copy _12 as *const () (PtrToPtr);
-+         _13 = copy _25 as *const () (PtrToPtr);
++         _13 = copy _24 as *const () (PtrToPtr);
           _14 = NonNull::<()> { pointer: copy _13 };
           _15 = std::ptr::Unique::<()> { pointer: copy _14, _marker: const PhantomData::<()> };
           _3 = Box::<()>(move _15, const std::alloc::Global);
@@ -153,21 +152,21 @@
 +         nop;
           StorageLive(_7);
           _7 = copy _5;
-          StorageLive(_26);
-          _26 = const 1_usize;
--         _6 = *const [()] from (copy _7, copy _26);
+          StorageLive(_25);
+          _25 = const 1_usize;
+-         _6 = *const [()] from (copy _7, copy _25);
 +         _6 = *const [()] from (copy _5, const 1_usize);
-          StorageDead(_26);
+          StorageDead(_25);
           StorageDead(_7);
           StorageLive(_8);
           StorageLive(_9);
           _9 = copy _6;
-          StorageLive(_27);
--         _27 = copy _9;
+          StorageLive(_26);
+-         _26 = copy _9;
 -         _8 = copy _9 as *mut () (PtrToPtr);
-+         _27 = copy _6;
++         _26 = copy _6;
 +         _8 = copy _5 as *mut () (PtrToPtr);
-          StorageDead(_27);
+          StorageDead(_26);
           StorageDead(_9);
           _0 = const ();
           StorageDead(_8);
@@ -179,17 +178,13 @@
       }
   
       bb5: {
--         _23 = Layout::from_size_align_unchecked::precondition_check(copy _16, copy _17) -> [return: bb6, unwind unreachable];
-+         _23 = Layout::from_size_align_unchecked::precondition_check(const 0_usize, const 1_usize) -> [return: bb6, unwind unreachable];
+-         _23 = Layout::from_size_alignment_unchecked::precondition_check(copy _16, copy _17) -> [return: bb6, unwind unreachable];
++         _23 = Layout::from_size_alignment_unchecked::precondition_check(const 0_usize, const std::ptr::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }}) -> [return: bb6, unwind unreachable];
       }
   
       bb6: {
-          StorageLive(_24);
--         _24 = copy _17 as std::ptr::Alignment (Transmute);
--         _18 = Layout { size: copy _16, align: move _24 };
-+         _24 = const std::ptr::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }};
+-         _18 = Layout { size: copy _16, align: copy _17 };
 +         _18 = const Layout {{ size: 0_usize, align: std::ptr::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }} }};
-          StorageDead(_24);
           StorageLive(_19);
 -         _19 = std::alloc::Global::alloc_impl_runtime(copy _18, const false) -> [return: bb7, unwind unreachable];
 +         _19 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: 0_usize, align: std::ptr::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }} }}, const false) -> [return: bb7, unwind unreachable];

--- a/tests/mir-opt/issue_62289.test.ElaborateDrops.before.panic-abort.mir
+++ b/tests/mir-opt/issue_62289.test.ElaborateDrops.before.panic-abort.mir
@@ -25,7 +25,7 @@ fn test() -> Option<Box<u32>> {
 
     bb0: {
         StorageLive(_1);
-        _2 = alloc::alloc::exchange_malloc(const <u32 as std::mem::SizedTypeProperties>::SIZE, const <u32 as std::mem::SizedTypeProperties>::ALIGN) -> [return: bb1, unwind: bb13];
+        _2 = alloc::alloc::exchange_malloc(const <u32 as std::mem::SizedTypeProperties>::SIZE, const <u32 as std::mem::SizedTypeProperties>::ALIGNMENT) -> [return: bb1, unwind: bb13];
     }
 
     bb1: {

--- a/tests/mir-opt/issue_62289.test.ElaborateDrops.before.panic-unwind.mir
+++ b/tests/mir-opt/issue_62289.test.ElaborateDrops.before.panic-unwind.mir
@@ -25,7 +25,7 @@ fn test() -> Option<Box<u32>> {
 
     bb0: {
         StorageLive(_1);
-        _2 = alloc::alloc::exchange_malloc(const <u32 as std::mem::SizedTypeProperties>::SIZE, const <u32 as std::mem::SizedTypeProperties>::ALIGN) -> [return: bb1, unwind continue];
+        _2 = alloc::alloc::exchange_malloc(const <u32 as std::mem::SizedTypeProperties>::SIZE, const <u32 as std::mem::SizedTypeProperties>::ALIGNMENT) -> [return: bb1, unwind continue];
     }
 
     bb1: {


### PR DESCRIPTION
rust-lang/rust#152605 updated the shim (`__rust_alloc` and friends), but not the special one that box uses.  So do that one too.

This is split out from rust-lang/rust#152641 in hopes of simplifying things.

r? @cjgillot 