### PR TITLE
bootstrap: Inline the `is_tool` check for setting `-Zforce-unstable-if-unmarked`

### DIFF
--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -340,13 +340,6 @@ pub enum Mode {
 }
 
 impl Mode {
-    pub fn is_tool(&self) -> bool {
-        match self {
-            Mode::ToolBootstrap | Mode::ToolRustcPrivate | Mode::ToolStd | Mode::ToolTarget => true,
-            Mode::Std | Mode::Codegen | Mode::Rustc => false,
-        }
-    }
-
     pub fn must_support_dlopen(&self) -> bool {
         match self {
             Mode::Std | Mode::Codegen => true,


### PR DESCRIPTION
`Mode::is_tool` is the sort of method that looks general-purpose, but is only actually used for a very specific purpose, to control the setting of `-Zforce-unstable-if-unmarked`.

It is therefore clearer to inline the mode check, which makes it easier to see how the condition affects the result.

I have tried to add some comments explaining why we set that flag, but they are based on my own recent investigations, so I'm not 100% confident that they're accurate.