### PR TITLE
Trait aliases: Also imply default trait bounds on type params other than `Self`

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
@@ -979,6 +979,32 @@ impl<'tcx> ItemCtxt<'tcx> {
     ) -> Vec<(ty::Clause<'tcx>, Span)> {
         let mut bounds = Vec::new();
 
+        if let PredicateFilter::All = filter {
+            for param in hir_generics.params {
+                match param.kind {
+                    hir::GenericParamKind::Type { .. } => {
+                        let param_ty = self.lowerer().lower_ty_param(param.hir_id);
+                        self.lowerer().add_implicit_sizedness_bounds(
+                            &mut bounds,
+                            param_ty,
+                            &[],
+                            ImpliedBoundsContext::TyParam(param.def_id, hir_generics.predicates),
+                            param.span,
+                        );
+                        self.lowerer().add_default_traits(
+                            &mut bounds,
+                            param_ty,
+                            &[],
+                            ImpliedBoundsContext::TyParam(param.def_id, hir_generics.predicates),
+                            param.span,
+                        );
+                    }
+                    hir::GenericParamKind::Lifetime { .. }
+                    | hir::GenericParamKind::Const { .. } => {}
+                }
+            }
+        }
+
         for predicate in hir_generics.predicates {
             let hir_id = predicate.hir_id;
             let hir::WherePredicateKind::BoundPredicate(predicate) = predicate.kind else {

--- a/tests/ui/traits/alias/default-trait-bounds.fail.stderr
+++ b/tests/ui/traits/alias/default-trait-bounds.fail.stderr
@@ -1,0 +1,44 @@
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/default-trait-bounds.rs:26:34
+   |
+LL | #[cfg(fail)] fn a1_fail() { a1::<str>; }
+   |                                  ^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = note: required for `()` to implement `A1<str>`
+note: required by a bound in `a1`
+  --> $DIR/default-trait-bounds.rs:25:30
+   |
+LL | fn a1<T: ?Sized>() where (): A1<T> { ensure_is_sized::<T>; }
+   |                              ^^^^^ required by this bound in `a1`
+
+error[E0277]: the size for values of type `ExternTy` cannot be known
+  --> $DIR/default-trait-bounds.rs:49:34
+   |
+LL | #[cfg(fail)] fn b1_fail() { b1::<ExternTy>; }
+   |                                  ^^^^^^^^ doesn't have a known size
+   |
+   = help: the nightly-only, unstable trait `MetaSized` is not implemented for `ExternTy`
+   = note: required for `()` to implement `B1<ExternTy>`
+note: required by a bound in `b1`
+  --> $DIR/default-trait-bounds.rs:47:36
+   |
+LL | fn b1<T: PointeeSized>() where (): B1<T> { ensure_is_meta_sized::<T>(); }
+   |                                    ^^^^^ required by this bound in `b1`
+
+error[E0277]: the trait bound `ExternTy: C1` is not satisfied
+  --> $DIR/default-trait-bounds.rs:65:34
+   |
+LL | #[cfg(fail)] fn c1_fail() { c1::<ExternTy>; }
+   |                                  ^^^^^^^^ the nightly-only, unstable trait `MetaSized` is not implemented for `ExternTy`
+   |
+   = note: required for `ExternTy` to implement `C1`
+note: required by a bound in `c1`
+  --> $DIR/default-trait-bounds.rs:63:35
+   |
+LL | fn c1<T: PointeeSized>() where T: C1 { ensure_is_meta_sized::<T>; }
+   |                                   ^^ required by this bound in `c1`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/alias/default-trait-bounds.rs
+++ b/tests/ui/traits/alias/default-trait-bounds.rs
@@ -1,0 +1,71 @@
+// Check that trait alias bounds also imply default trait bounds to ensure that
+// default and user-written bounds behave the same wrt. trait solving.
+//
+// Previously, we would only imply default trait bounds on
+// *`Self`* type params, not on regular type params however.
+// issue: <https://github.com/rust-lang/rust/issues/152687>
+//
+//@ revisions: pass fail
+//@[pass] check-pass
+
+#![feature(trait_alias)]
+#![feature(sized_hierarchy, extern_types)] // only used for the `MetaSized` test cases
+
+//------------------------- `Sized`
+
+trait A0<T: Sized> =; // has a user-written `T: Sized` boun
+
+// `(): A0<T>` requires+implies `T: Sized`
+fn a0<T: ?Sized>() where (): A0<T> { ensure_is_sized::<T>; }
+
+
+trait A1<T> =; // has a default `T: Sized` bound
+
+// `(): A1<T>` requires+implies `T: Sized`
+fn a1<T: ?Sized>() where (): A1<T> { ensure_is_sized::<T>; }
+#[cfg(fail)] fn a1_fail() { a1::<str>; }
+//[fail]~^ ERROR the size for values of type `str` cannot be known at compilation time
+
+
+fn ensure_is_sized<T: Sized>() {}
+
+//------------------------- `MetaSized`
+
+use std::marker::{MetaSized, PointeeSized};
+unsafe extern "C" { type ExternTy; }
+
+
+trait B0<T: MetaSized> =; // has a user-written `T: MetaSized` bounds
+
+// `(): B0<T>` requires+implies `T: MetaSized`
+fn b0<T: PointeeSized>() where (): B0<T> { ensure_is_meta_sized::<T>(); }
+
+
+trait B1<T: ?Sized> =; // has a default `T: MetaSized` bound
+
+// `(): B1<T>` requires+implies `T: MetaSized`
+fn b1<T: PointeeSized>() where (): B1<T> { ensure_is_meta_sized::<T>(); }
+
+#[cfg(fail)] fn b1_fail() { b1::<ExternTy>; }
+//[fail]~^ ERROR the size for values of type `ExternTy` cannot be known
+
+// For completeness, let's also check default trait bounds on `Self`.
+
+trait C0 = MetaSized; // has a user-written `Self: MetaSized` bound
+
+// `T: C0` requires+implies `T: MetaSized`
+fn c0<T: PointeeSized>() where T: C0 { ensure_is_meta_sized::<T>; }
+
+
+trait C1 =; // has a default `Self: MetaSized` bound
+
+// `T: C1` requires+implies `T: MetaSized`
+fn c1<T: PointeeSized>() where T: C1 { ensure_is_meta_sized::<T>; }
+
+#[cfg(fail)] fn c1_fail() { c1::<ExternTy>; }
+//[fail]~^ ERROR the trait bound `ExternTy: C1` is not satisfied
+
+
+fn ensure_is_meta_sized<T: MetaSized>() {}
+
+fn main() {}

--- a/tests/ui/traits/alias/more-default-trait-bounds.fail.stderr
+++ b/tests/ui/traits/alias/more-default-trait-bounds.fail.stderr
@@ -1,0 +1,39 @@
+error[E0277]: the trait bound `Unmarked: Mark` is not satisfied
+  --> $DIR/more-default-trait-bounds.rs:27:34
+   |
+LL | #[cfg(fail)] fn a1_fail() { a1::<Unmarked>; }
+   |                                  ^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `Mark` is not implemented for `Unmarked`
+  --> $DIR/more-default-trait-bounds.rs:47:1
+   |
+LL | enum Unmarked {}
+   | ^^^^^^^^^^^^^
+   = note: required for `()` to implement `A1<Unmarked>`
+note: required by a bound in `a1`
+  --> $DIR/more-default-trait-bounds.rs:25:29
+   |
+LL | fn a1<T: ?Mark>() where (): A1<T> { ensure_has_mark::<T>; }
+   |                             ^^^^^ required by this bound in `a1`
+
+error[E0277]: the trait bound `Unmarked: B1` is not satisfied
+  --> $DIR/more-default-trait-bounds.rs:41:34
+   |
+LL | #[cfg(fail)] fn b1_fail() { b1::<Unmarked>; }
+   |                                  ^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `Mark` is not implemented for `Unmarked`
+  --> $DIR/more-default-trait-bounds.rs:47:1
+   |
+LL | enum Unmarked {}
+   | ^^^^^^^^^^^^^
+   = note: required for `Unmarked` to implement `B1`
+note: required by a bound in `b1`
+  --> $DIR/more-default-trait-bounds.rs:39:28
+   |
+LL | fn b1<T: ?Mark>() where T: B1 { ensure_has_mark::<T>; }
+   |                            ^^ required by this bound in `b1`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/alias/more-default-trait-bounds.rs
+++ b/tests/ui/traits/alias/more-default-trait-bounds.rs
@@ -1,0 +1,50 @@
+// Check that trait alias bounds also imply default trait bounds to ensure_has_mark that
+// default and user-written bounds behave the same wrt. trait solving.
+//
+// Previously, we would only imply default trait bounds on
+// *`Self`* type params, not on regular type params however.
+// issue: <https://github.com/rust-lang/rust/issues/152687>
+//
+//@ revisions: pass fail
+//@ compile-flags: -Zexperimental-default-bounds
+//@[pass] check-pass
+
+#![feature(trait_alias, more_maybe_bounds, lang_items, auto_traits, negative_impls)]
+
+#[lang = "default_trait1"]
+auto trait Mark {}
+
+
+trait A0<T: Mark> = ?Mark; // has a user-written `T: Mark` bound
+
+fn a0<T: ?Mark>() where (): A0<T> { ensure_has_mark::<T>; }
+
+
+trait A1<T> = ?Mark; // has a default `T: Mark` bound
+
+fn a1<T: ?Mark>() where (): A1<T> { ensure_has_mark::<T>; }
+
+#[cfg(fail)] fn a1_fail() { a1::<Unmarked>; }
+//[fail]~^ ERROR the trait bound `Unmarked: Mark` is not satisfied
+
+// For completeness, let's also check default trait bounds on `Self`.
+
+trait B0 = Mark; // has a user-written `Self: Mark` bound
+
+fn b0<T: ?Mark>() where T: B0 { ensure_has_mark::<T>; }
+
+
+trait B1 =; // has a default `Self: Mark` bound
+
+fn b1<T: ?Mark>() where T: B1 { ensure_has_mark::<T>; }
+
+#[cfg(fail)] fn b1_fail() { b1::<Unmarked>; }
+//[fail]~^ ERROR the trait bound `Unmarked: B1` is not satisfied
+
+
+fn ensure_has_mark<T: Mark>() {}
+
+enum Unmarked {}
+impl !Mark for Unmarked {}
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/152688)*
<!-- homu-ignore:end -->

Trait aliases already correctly imply default trait bounds on `Self` type params. However, due to an oversight, they didn't do that for normal type params.

Fixes rust-lang/rust#152687.