### PR TITLE
[EXPERIMENT] Measure the perf impact of `PackedFingerprint`

### DIFF
--- a/compiler/rustc_data_structures/src/fingerprint.rs
+++ b/compiler/rustc_data_structures/src/fingerprint.rs
@@ -196,7 +196,6 @@ impl<D: Decoder> Decodable<D> for Fingerprint {
 //
 // The wrapped `Fingerprint` is private to reduce the chance of a client
 // invoking undefined behavior by taking a reference to the packed field.
-#[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), repr(packed))]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Copy, Hash)]
 pub struct PackedFingerprint(Fingerprint);
 

--- a/compiler/rustc_middle/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node.rs
@@ -502,9 +502,6 @@ mod size_asserts {
     use super::*;
     // tidy-alphabetical-start
     static_assert_size!(DepKind, 2);
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    static_assert_size!(DepNode, 18);
-    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
     static_assert_size!(DepNode, 24);
     // tidy-alphabetical-end
 }


### PR DESCRIPTION
I noticed that the `PackedFingerprint` optimization in https://github.com/rust-lang/rust/pull/78646 is only applied on x86-family hosts, and not on other host architectures, even if they can be expected to support unaligned memory access efficiently (e.g. modern `aarch64`).

Before I propose expanding that optimization to some or all other architectures, let's measure the perf and memory impact that it currently has on x86-64.