### PR TITLE
Suppress unstable-trait notes under `-Zforce-unstable-if-unmarked`

### DIFF
--- a/tests/ui/traits/auxiliary/force_unstable.rs
+++ b/tests/ui/traits/auxiliary/force_unstable.rs
@@ -1,0 +1,7 @@
+//@ edition: 2024
+//@ compile-flags: -Zforce-unstable-if-unmarked
+
+// Auxiliary crate that uses `-Zforce-unstable-if-unmarked` to export an
+// "unstable" trait.
+
+pub trait ForeignTrait {}

--- a/tests/ui/traits/nightly-only-unstable.force.stderr
+++ b/tests/ui/traits/nightly-only-unstable.force.stderr
@@ -1,0 +1,36 @@
+error[E0277]: the trait bound `(): LocalTrait` is not satisfied
+  --> $DIR/nightly-only-unstable.rs:25:21
+   |
+LL |     use_local_trait(());
+   |     --------------- ^^ the nightly-only, unstable trait `LocalTrait` is not implemented for `()`
+   |     |
+   |     required by a bound introduced by this call
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/nightly-only-unstable.rs:14:1
+   |
+LL | trait LocalTrait {}
+   | ^^^^^^^^^^^^^^^^
+note: required by a bound in `use_local_trait`
+  --> $DIR/nightly-only-unstable.rs:16:28
+   |
+LL | fn use_local_trait(_: impl LocalTrait) {}
+   |                            ^^^^^^^^^^ required by this bound in `use_local_trait`
+
+error[E0277]: the trait bound `(): ForeignTrait` is not satisfied
+  --> $DIR/nightly-only-unstable.rs:31:23
+   |
+LL |     use_foreign_trait(());
+   |     ----------------- ^^ the nightly-only, unstable trait `ForeignTrait` is not implemented for `()`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required by a bound in `use_foreign_trait`
+  --> $DIR/nightly-only-unstable.rs:20:30
+   |
+LL | fn use_foreign_trait(_: impl force_unstable::ForeignTrait) {}
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `use_foreign_trait`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/nightly-only-unstable.force.stderr
+++ b/tests/ui/traits/nightly-only-unstable.force.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `(): LocalTrait` is not satisfied
   --> $DIR/nightly-only-unstable.rs:25:21
    |
 LL |     use_local_trait(());
-   |     --------------- ^^ the nightly-only, unstable trait `LocalTrait` is not implemented for `()`
+   |     --------------- ^^ the trait `LocalTrait` is not implemented for `()`
    |     |
    |     required by a bound introduced by this call
    |
@@ -21,7 +21,7 @@ error[E0277]: the trait bound `(): ForeignTrait` is not satisfied
   --> $DIR/nightly-only-unstable.rs:31:23
    |
 LL |     use_foreign_trait(());
-   |     ----------------- ^^ the nightly-only, unstable trait `ForeignTrait` is not implemented for `()`
+   |     ----------------- ^^ the trait `ForeignTrait` is not implemented for `()`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/traits/nightly-only-unstable.normal.stderr
+++ b/tests/ui/traits/nightly-only-unstable.normal.stderr
@@ -1,0 +1,36 @@
+error[E0277]: the trait bound `(): LocalTrait` is not satisfied
+  --> $DIR/nightly-only-unstable.rs:25:21
+   |
+LL |     use_local_trait(());
+   |     --------------- ^^ the trait `LocalTrait` is not implemented for `()`
+   |     |
+   |     required by a bound introduced by this call
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/nightly-only-unstable.rs:14:1
+   |
+LL | trait LocalTrait {}
+   | ^^^^^^^^^^^^^^^^
+note: required by a bound in `use_local_trait`
+  --> $DIR/nightly-only-unstable.rs:16:28
+   |
+LL | fn use_local_trait(_: impl LocalTrait) {}
+   |                            ^^^^^^^^^^ required by this bound in `use_local_trait`
+
+error[E0277]: the trait bound `(): ForeignTrait` is not satisfied
+  --> $DIR/nightly-only-unstable.rs:31:23
+   |
+LL |     use_foreign_trait(());
+   |     ----------------- ^^ the nightly-only, unstable trait `ForeignTrait` is not implemented for `()`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required by a bound in `use_foreign_trait`
+  --> $DIR/nightly-only-unstable.rs:20:30
+   |
+LL | fn use_foreign_trait(_: impl force_unstable::ForeignTrait) {}
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `use_foreign_trait`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/nightly-only-unstable.rs
+++ b/tests/ui/traits/nightly-only-unstable.rs
@@ -25,12 +25,12 @@ fn main() {
     use_local_trait(());
     //~^ ERROR the trait bound `(): LocalTrait` is not satisfied
     //[normal]~| NOTE the trait `LocalTrait` is not implemented for `()`
-    //[force]~| NOTE the nightly-only, unstable trait `LocalTrait` is not implemented for `()`
+    //[force]~| NOTE the trait `LocalTrait` is not implemented for `()`
     //~| NOTE required by a bound introduced by this call
 
     use_foreign_trait(());
     //~^ ERROR the trait bound `(): ForeignTrait` is not satisfied
     //[normal]~| NOTE the nightly-only, unstable trait `ForeignTrait` is not implemented for `()`
-    //[force]~| NOTE the nightly-only, unstable trait `ForeignTrait` is not implemented for `()`
+    //[force]~| NOTE the trait `ForeignTrait` is not implemented for `()`
     //~| NOTE required by a bound introduced by this call
 }

--- a/tests/ui/traits/nightly-only-unstable.rs
+++ b/tests/ui/traits/nightly-only-unstable.rs
@@ -1,0 +1,36 @@
+//@ revisions: normal force
+//@ edition: 2024
+//@ aux-crate: force_unstable=force_unstable.rs
+//@[force] compile-flags: -Zforce-unstable-if-unmarked
+
+#![feature(rustc_private)]
+
+// Regression test for <https://github.com/rust-lang/rust/issues/152692>.
+//
+// When building a crate with `-Zforce-unstable-if-unmarked` (e.g. the compiler or stdlib),
+// it's unhelpful to mention that a not-implemented trait is unstable, because that will
+// be true of every local and foreign trait that isn't explicitly marked stable.
+
+trait LocalTrait {}
+
+fn use_local_trait(_: impl LocalTrait) {}
+//~^ NOTE required by a bound in `use_local_trait`
+//~| NOTE required by this bound in `use_local_trait`
+
+fn use_foreign_trait(_: impl force_unstable::ForeignTrait) {}
+//~^ NOTE required by a bound in `use_foreign_trait`
+//~| NOTE required by this bound in `use_foreign_trait`
+
+fn main() {
+    use_local_trait(());
+    //~^ ERROR the trait bound `(): LocalTrait` is not satisfied
+    //[normal]~| NOTE the trait `LocalTrait` is not implemented for `()`
+    //[force]~| NOTE the nightly-only, unstable trait `LocalTrait` is not implemented for `()`
+    //~| NOTE required by a bound introduced by this call
+
+    use_foreign_trait(());
+    //~^ ERROR the trait bound `(): ForeignTrait` is not satisfied
+    //[normal]~| NOTE the nightly-only, unstable trait `ForeignTrait` is not implemented for `()`
+    //[force]~| NOTE the nightly-only, unstable trait `ForeignTrait` is not implemented for `()`
+    //~| NOTE required by a bound introduced by this call
+}


### PR DESCRIPTION
- Fixes https://github.com/rust-lang/rust/issues/152692.
---

https://github.com/rust-lang/rust/pull/151036 adds extra diagnostic text (“the nightly-only, unstable trait”) to note when a not-implemented trait is unstable.

However, that extra text is usually unhelpful when building a crate graph with `-Zforce-unstable-if-unmarked` (such as the compiler or stdlib), because *any* trait not explicitly marked stable will be treated as unstable.

(For typical compiler contributors using the stage0 compiler, this fix won't take effect until the next bootstrap beta bump.)
