### PR TITLE
Test(lib/win/proc): Skip `raw_attributes` doctest under Win7

### DIFF
--- a/library/std/src/os/windows/process.rs
+++ b/library/std/src/os/windows/process.rs
@@ -573,7 +573,8 @@ impl<'a> ProcThreadAttributeListBuilder<'a> {
     ///
     /// # Example
     ///
-    /// ```
+    #[cfg_attr(target_vendor = "win7", doc = "```no_run")]
+    #[cfg_attr(not(target_vendor = "win7"), doc = "```")]
     /// #![feature(windows_process_extensions_raw_attribute)]
     /// use std::ffi::c_void;
     /// use std::os::windows::process::{CommandExt, ProcThreadAttributeList};


### PR DESCRIPTION
The current doctest for `ProcThreadAttributeListBuilder::raw_attribute` uses `CreatePseudoConsole`, which is only available on Windows 10 October 2018 Update and above. On older versions of Windows, the test fails due to trying to link against a function that is not present in the kernel32 DLL. This therefore ensures the test is still built, but not run under the Win7 target.

@rustbot label T-libs A-process A-doctests O-windows-7