### PR TITLE
Build: Add `stdenv.cc.cc.lib` to Nix dependencies

### DIFF
--- a/src/bootstrap/src/core/download.rs
+++ b/src/bootstrap/src/core/download.rs
@@ -675,6 +675,7 @@ fn fix_bin_or_dylib(out: &Path, fname: &Path, exec_ctx: &ExecutionContext) {
         // the `.nix-deps` location.
         //
         // bintools: Needed for the path of `ld-linux.so` (via `nix-support/dynamic-linker`).
+        // cc.lib: Needed similarly for `libstdc++.so.6`.
         // zlib: Needed as a system dependency of `libLLVM-*.so`.
         // patchelf: Needed for patching ELF binaries (see doc comment above).
         let nix_deps_dir = out.join(".nix-deps");
@@ -686,6 +687,7 @@ fn fix_bin_or_dylib(out: &Path, fname: &Path, exec_ctx: &ExecutionContext) {
                 zlib
                 patchelf
                 stdenv.cc.bintools
+                stdenv.cc.cc.lib
             ];
         }
         ";


### PR DESCRIPTION
Otherwise, it systematically fails on:

```
error: process didn't exit successfully: `[...]/rust/build/bootstrap/debug/rustc [...]/rust/build/bootstrap/debug/rustc -vV` (exit status: 127)
--- stderr
[...]/rust/build/x86_64-unknown-linux-gnu/stage1/bin/rustc: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory
```

for us at least. Closes rust-lang/rust#127620.

@rustbot label T-bootstrap A-reproducibility