### PR TITLE
[beta] Revert destabilise target-spec-json

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -1129,10 +1129,9 @@ fn get_backend_from_raw_matches(
     let backend_name = debug_flags
         .iter()
         .find_map(|x| x.strip_prefix("codegen-backend=").or(x.strip_prefix("codegen_backend=")));
-    let unstable_options = debug_flags.iter().find(|x| *x == "unstable-options").is_some();
     let target = parse_target_triple(early_dcx, matches);
     let sysroot = Sysroot::new(matches.opt_str("sysroot").map(PathBuf::from));
-    let target = config::build_target_config(early_dcx, &target, sysroot.path(), unstable_options);
+    let target = config::build_target_config(early_dcx, &target, sysroot.path());
 
     get_codegen_backend(early_dcx, &sysroot, backend_name, &target)
 }

--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -435,7 +435,6 @@ pub fn run_compiler<R: Send>(config: Config, f: impl FnOnce(&Compiler) -> R + Se
         &early_dcx,
         &config.opts.target_triple,
         config.opts.sysroot.path(),
-        config.opts.unstable_opts.unstable_options,
     );
     let file_loader = config.file_loader.unwrap_or_else(|| Box::new(RealFileLoader));
     let path_mapping = config.opts.file_path_mapping();

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -46,7 +46,6 @@ where
         &early_dcx,
         &sessopts.target_triple,
         sessopts.sysroot.path(),
-        sessopts.unstable_opts.unstable_options,
     );
     let hash_kind = sessopts.unstable_opts.src_hash_algorithm(&target);
     let checksum_hash_kind = sessopts.unstable_opts.checksum_hash_algorithm();

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1589,9 +1589,8 @@ pub fn build_target_config(
     early_dcx: &EarlyDiagCtxt,
     target: &TargetTuple,
     sysroot: &Path,
-    unstable_options: bool,
 ) -> Target {
-    match Target::search(target, sysroot, unstable_options) {
+    match Target::search(target, sysroot) {
         Ok((target, warnings)) => {
             for warning in warnings.warning_messages() {
                 early_dcx.early_warn(warning)

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1002,11 +1002,8 @@ pub fn build_session(
     }
 
     let host_triple = TargetTuple::from_tuple(config::host_tuple());
-    let (host, target_warnings) =
-        Target::search(&host_triple, sopts.sysroot.path(), sopts.unstable_opts.unstable_options)
-            .unwrap_or_else(|e| {
-                dcx.handle().fatal(format!("Error loading host specification: {e}"))
-            });
+    let (host, target_warnings) = Target::search(&host_triple, sopts.sysroot.path())
+        .unwrap_or_else(|e| dcx.handle().fatal(format!("Error loading host specification: {e}")));
     for warning in target_warnings.warning_messages() {
         dcx.handle().warn(warning)
     }

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -3296,19 +3296,10 @@ impl Target {
     pub fn search(
         target_tuple: &TargetTuple,
         sysroot: &Path,
-        unstable_options: bool,
     ) -> Result<(Target, TargetWarnings), String> {
         use std::{env, fs};
 
-        fn load_file(
-            path: &Path,
-            unstable_options: bool,
-        ) -> Result<(Target, TargetWarnings), String> {
-            if !unstable_options {
-                return Err(
-                    "custom targets are unstable and require `-Zunstable-options`".to_string()
-                );
-            }
+        fn load_file(path: &Path) -> Result<(Target, TargetWarnings), String> {
             let contents = fs::read_to_string(path).map_err(|e| e.to_string())?;
             Target::from_json(&contents)
         }
@@ -3332,7 +3323,7 @@ impl Target {
                 for dir in env::split_paths(&target_path) {
                     let p = dir.join(&path);
                     if p.is_file() {
-                        return load_file(&p, unstable_options);
+                        return load_file(&p);
                     }
                 }
 
@@ -3345,7 +3336,7 @@ impl Target {
                     Path::new("target.json"),
                 ]);
                 if p.is_file() {
-                    return load_file(&p, unstable_options);
+                    return load_file(&p);
                 }
 
                 Err(format!("could not find specification for target {target_tuple:?}"))

--- a/tests/run-make/target-specs/rmake.rs
+++ b/tests/run-make/target-specs/rmake.rs
@@ -15,20 +15,11 @@ fn main() {
         .run_fail()
         .assert_stderr_contains("error loading target specification");
     rustc()
-        .arg("-Zunstable-options")
         .input("foo.rs")
         .target("my-incomplete-platform.json")
         .run_fail()
         .assert_stderr_contains("missing field `llvm-target`");
-    let test_platform = rustc()
-        .input("foo.rs")
-        .target("my-x86_64-unknown-linux-gnu-platform")
-        .crate_type("lib")
-        .emit("asm")
-        .run_fail()
-        .assert_stderr_contains("custom targets are unstable and require `-Zunstable-options`");
     rustc()
-        .arg("-Zunstable-options")
         .env("RUST_TARGET_PATH", ".")
         .input("foo.rs")
         .target("my-awesome-platform")
@@ -36,7 +27,6 @@ fn main() {
         .emit("asm")
         .run();
     rustc()
-        .arg("-Zunstable-options")
         .env("RUST_TARGET_PATH", ".")
         .input("foo.rs")
         .target("my-x86_64-unknown-linux-gnu-platform")
@@ -62,31 +52,27 @@ fn main() {
         .actual_text("test-platform-2", test_platform_2)
         .run();
     rustc()
-        .arg("-Zunstable-options")
         .input("foo.rs")
         .target("endianness-mismatch")
         .run_fail()
         .assert_stderr_contains(r#""data-layout" claims architecture is little-endian"#);
     rustc()
-        .arg("-Zunstable-options")
         .input("foo.rs")
         .target("mismatching-data-layout")
         .crate_type("lib")
         .run_fail()
         .assert_stderr_contains("data-layout for target");
     rustc()
-        .arg("-Zunstable-options")
         .input("foo.rs")
         .target("require-explicit-cpu")
         .crate_type("lib")
         .run_fail()
         .assert_stderr_contains("target requires explicitly specifying a cpu");
     rustc()
-        .arg("-Zunstable-options")
         .input("foo.rs")
         .target("require-explicit-cpu")
         .crate_type("lib")
         .arg("-Ctarget-cpu=generic")
         .run();
-    rustc().arg("-Zunstable-options").target("require-explicit-cpu").print("target-cpus").run();
+    rustc().target("require-explicit-cpu").arg("--print=target-cpus").run();
 }


### PR DESCRIPTION
This reverts https://github.com/rust-lang/rust/pull/150151 in order to deal with https://github.com/rust-lang/rust/issues/151729 where the destabilization caused a problem with building rustc itself with JSON target specs. There's a fix at https://github.com/rust-lang/rust/pull/152677, but we would prefer to not backport that, and instead give ourselves more time to work out the kinks. Also, the destabilization was incomplete, and the rest of the changes are in 1.95 (https://github.com/rust-lang/rust/pull/151534 and https://github.com/rust-lang/cargo/pull/16557), so it would be nice to keep all the changes together in one release.

This reverts commit a89683dd954be39f433b4e0ff6380d845e80ec6b, reversing changes made to 2f1bd3f3781c90a8447e37d65a898442b8618895.
