### PR TITLE
add simd intrinsic simd_shuffle_dyn

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/intrinsics/simd.rs
+++ b/compiler/rustc_codegen_cranelift/src/intrinsics/simd.rs
@@ -254,6 +254,44 @@ pub(super) fn codegen_simd_intrinsic_call<'tcx>(
             }
         }
 
+        // simd_shuffle_dyn<T>(x: T, y: T, idx: T) -> T
+        sym::simd_shuffle_dyn => {
+            let (src, idx) = match args {
+                [src, idx] => (src, idx),
+                _ => {
+                    bug!("wrong number of args for intrinsic {intrinsic}");
+                }
+            };
+            let src = codegen_operand(fx, &src.node);
+            let idx = codegen_operand(fx, &idx.node);
+
+            if !src.layout().ty.is_simd() {
+                report_simd_type_validation_error(fx, intrinsic, span, src.layout().ty);
+                return;
+            }
+
+            let ty = src.layout().ty;
+            let n: u64 = if ty.is_simd()
+                && matches!(ty.simd_size_and_type(fx.tcx).1.kind(), ty::Uint(ty::UintTy::U8))
+            {
+                ty.simd_size_and_type(fx.tcx).0
+            } else {
+                fx.tcx.dcx().span_err(
+                    span,
+                    format!("simd_shuffle_dyn index must be a SIMD vector of `u8`, got `{}`", ty),
+                );
+                // Prevent verifier error
+                fx.bcx.ins().trap(TrapCode::user(1 /* unreachable */).unwrap());
+                return;
+            };
+
+            for i in 0..n {
+                let idx = idx.value_lane(fx, i.into()).load_scalar(fx);
+                let val = src.value_lane_dyn(fx, idx);
+                ret.place_lane(fx, i.into()).write_cvalue(fx, val);
+            }
+        }
+
         sym::simd_insert => {
             let (base, idx, val) = match args {
                 [base, idx, val] => (base, idx, val),

--- a/compiler/rustc_codegen_gcc/src/builder.rs
+++ b/compiler/rustc_codegen_gcc/src/builder.rs
@@ -2031,7 +2031,9 @@ impl<'a, 'gcc, 'tcx> Builder<'a, 'gcc, 'tcx> {
 
         // NOTE: this condition is needed because we call shuffle_vector in the implementation of
         // simd_gather.
-        let mut mask_elements = if let Some(vector_type) = mask.get_type().dyncast_vector() {
+        let mut mask_elements = if let Some(vector_type) =
+            mask.get_type().unqualified().dyncast_vector()
+        {
             let mask_num_units = vector_type.get_num_units();
             let mut mask_elements = vec![];
             for i in 0..mask_num_units {

--- a/compiler/rustc_codegen_gcc/src/intrinsic/simd.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/simd.rs
@@ -24,6 +24,7 @@ use crate::builder::Builder;
 use crate::common::SignType;
 #[cfg(feature = "master")]
 use crate::context::CodegenCx;
+use crate::rustc_codegen_ssa::traits::ConstCodegenMethods;
 
 pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
     bx: &mut Builder<'a, 'gcc, 'tcx>,
@@ -458,6 +459,20 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
         let vector = args[2].immediate();
 
         return Ok(bx.shuffle_vector(args[0].immediate(), args[1].immediate(), vector));
+    }
+
+    if name == sym::simd_shuffle_dyn {
+        let ty = args[0].layout.ty;
+        let n: u64 = if ty.is_simd()
+            && matches!(ty.simd_size_and_type(bx.cx.tcx).1.kind(), ty::Uint(ty::UintTy::U8))
+        {
+            ty.simd_size_and_type(bx.cx.tcx).0
+        } else {
+            return_error!(InvalidMonomorphization::SimdShuffleDyn { span, name, ty })
+        };
+
+        let undef = bx.const_poison(bx.type_vector(bx.type_u8(), n));
+        return Ok(bx.shuffle_vector(args[0].immediate(), undef, args[1].immediate()));
     }
 
     #[cfg(feature = "master")]

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -24,7 +24,7 @@ use rustc_session::config::CrateType;
 use rustc_span::{Span, Symbol, sym};
 use rustc_symbol_mangling::{mangle_internal_symbol, symbol_name_for_instance_in_crate};
 use rustc_target::callconv::PassMode;
-use rustc_target::spec::Os;
+use rustc_target::spec::{Arch, Os};
 use tracing::debug;
 
 use crate::abi::FnAbiLlvmExt;
@@ -1759,6 +1759,36 @@ fn generic_simd_intrinsic<'ll, 'tcx>(
         }
 
         return Ok(bx.shuffle_vector(args[0].immediate(), args[1].immediate(), indices));
+    }
+
+    if name == sym::simd_shuffle_dyn {
+        let ty = args[0].layout.ty;
+        let n: u64 = if ty.is_simd()
+            && matches!(ty.simd_size_and_type(bx.cx.tcx).1.kind(), ty::Uint(ty::UintTy::U8))
+        {
+            ty.simd_size_and_type(bx.cx.tcx).0
+        } else {
+            return_error!(InvalidMonomorphization::SimdShuffleDyn { span, name, ty })
+        };
+
+        if matches!(bx.tcx.sess.target.arch, Arch::Wasm32 | Arch::Wasm64) {
+            let mut result = bx.const_poison(bx.type_vector(bx.type_i8(), n));
+            for i in 0..n {
+                let idx = bx.extract_element(args[1].immediate(), bx.const_i32(i as i32));
+                let idx = bx.sext(idx, bx.type_i32());
+                let val = bx.extract_element(args[0].immediate(), idx);
+                result = bx.insert_element(result, val, bx.const_i32(i as i32));
+            }
+            return Ok(result);
+        }
+
+        let mut result = bx.const_poison(bx.type_vector(bx.type_i8(), n));
+        for i in 0..n {
+            let idx = bx.extract_element(args[1].immediate(), bx.const_i32(i as i32));
+            let val = bx.extract_element(args[0].immediate(), idx);
+            result = bx.insert_element(result, val, bx.const_i32(i as i32));
+        }
+        return Ok(result);
     }
 
     if name == sym::simd_insert || name == sym::simd_insert_dyn {

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -867,6 +867,14 @@ pub enum InvalidMonomorphization<'tcx> {
         ty: Ty<'tcx>,
     },
 
+    #[diag("invalid monomorphization of `{$name}` intrinsic: simd_shuffle_dyn arguments must SIMD vectors of `u8`, got `{$ty}`", code = E0511)]
+    SimdShuffleDyn {
+        #[primary_span]
+        span: Span,
+        name: Symbol,
+        ty: Ty<'tcx>,
+    },
+
     #[diag("invalid monomorphization of `{$name}` intrinsic: expected return type of length {$in_len}, found `{$ret_ty}` with length {$out_len}", code = E0511)]
     ReturnLength {
         #[primary_span]

--- a/compiler/rustc_const_eval/src/interpret/intrinsics/simd.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics/simd.rs
@@ -609,6 +609,34 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                     self.write_immediate(*val, &dest)?;
                 }
             }
+            sym::simd_shuffle_dyn => {
+                let (src, src_len) = self.project_to_simd(&args[0])?;
+                let (index, index_len) = self.project_to_simd(&args[1])?;
+                let (dest, dest_len) = self.project_to_simd(&dest)?;
+
+                assert_eq!(src_len, index_len);
+                assert_eq!(index_len, dest_len);
+
+                for i in 0..dest_len {
+                    let src_index: u64 = self
+                        .read_immediate(&self.project_index(&index, i)?)?
+                        .to_scalar()
+                        .to_u8()?
+                        .into();
+
+                    let val = if src_index < src_len {
+                        self.read_immediate(&self.project_index(&src, src_index)?)?
+                    } else {
+                        throw_ub_format!(
+                            "`simd_shuffle_dyn` index {src_index} is out-of-bounds for a vector with length {dest_len}"
+                        );
+                    };
+
+                    let dest = self.project_index(&dest, i)?;
+
+                    self.write_immediate(*val, &dest)?;
+                }
+            }
             sym::simd_gather => {
                 let (passthru, passthru_len) = self.project_to_simd(&args[0])?;
                 let (ptrs, ptrs_len) = self.project_to_simd(&args[1])?;

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -769,6 +769,7 @@ pub(crate) fn check_intrinsic_type(
         | sym::simd_reduce_max => (2, 0, vec![param(0)], param(1)),
         sym::simd_shuffle => (3, 0, vec![param(0), param(0), param(1)], param(2)),
         sym::simd_shuffle_const_generic => (2, 1, vec![param(0), param(0)], param(1)),
+        sym::simd_shuffle_dyn => (1, 0, vec![param(0), param(0)], param(0)),
 
         sym::atomic_cxchg | sym::atomic_cxchgweak => (
             1,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2157,6 +2157,7 @@ symbols! {
         simd_shr,
         simd_shuffle,
         simd_shuffle_const_generic,
+        simd_shuffle_dyn,
         simd_splat,
         simd_sub,
         simd_trunc,

--- a/library/core/src/intrinsics/simd.rs
+++ b/library/core/src/intrinsics/simd.rs
@@ -334,6 +334,19 @@ pub const unsafe fn simd_ge<T, U>(x: T, y: T) -> U;
 #[rustc_nounwind]
 pub const unsafe fn simd_shuffle<T, U, V>(x: T, y: T, idx: U) -> V;
 
+/// Shuffles a vector by indices.
+///
+/// `T` must be a vector of `u8`s.
+///
+/// Returns a new vector such that element `i` is selected from `x[idx[i]]`.
+///
+/// /// # Safety
+///
+/// `idx` must be in-bounds of the vector.
+#[rustc_intrinsic]
+#[rustc_nounwind]
+pub const unsafe fn simd_shuffle_dyn<T>(x: T, idx: T) -> T;
+
 /// Reads a vector of pointers.
 ///
 /// `T` must be a vector.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

LLVM can recognize all of the currently hard-coded pattern matching in `std::simd` and generate the correct instructions except for `armv7_neon_swizzle_u8x16`, so we need to add this pattern matching to LLVM.

https://github.com/rust-lang/portable-simd/issues/242