### PR TITLE
Rework explanation of CLI lint level flags

### DIFF
--- a/src/doc/rustc/src/lints/levels.md
+++ b/src/doc/rustc/src/lints/levels.md
@@ -393,7 +393,7 @@ Here’s how these different lint controls interact:
     warning: 1 warning emitted
    ```
 
-3. [CLI level flags](#via-compiler-flag) take precedence over attributes.
+3. [CLI level flags](#via-compiler-flag) override the default level of a lint. They essentially behave like crate-level attributes. Attributes within the source code take precedence over CLI flags, except for `-F`/`--forbid`, which cannot be overridden.
 
    The order of the flags matter; flags on the right take precedence over earlier flags.
 


### PR DESCRIPTION
I think the previous wording as either wrong or confusing. I would consider the CLI flags at a *lower* ranking, since source attributes are able to override the CLI flag.
