### PR TITLE
`probe_op` silence ambiguity errors if tainted

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -490,6 +490,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     .unwrap_or_else(|_| span_bug!(span, "instantiating {:?} failed?", ty));
                 let ty = self.resolve_vars_if_possible(ty.value);
                 let guar = match *ty.kind() {
+                    _ if let Some(guar) = self.tainted_by_errors() => guar,
                     ty::Infer(ty::TyVar(_)) => {
                         // We want to get the variable name that the method
                         // is being called on. If it is a method call.

--- a/tests/ui/methods/call_method_unknown_pointee.rs
+++ b/tests/ui/methods/call_method_unknown_pointee.rs
@@ -3,26 +3,39 @@
 // tests that the pointee type of a raw pointer must be known to call methods on it
 // see also: `tests/ui/editions/edition-raw-pointer-method-2018.rs`
 
-fn main() {
-    let val = 1_u32;
-    let ptr = &val as *const u32;
+fn a() {
+    let ptr = &1u32 as *const u32;
     unsafe {
         let _a: i32 = (ptr as *const _).read();
         //~^ ERROR type annotations needed
+    }
+}
+
+fn b() {
+    let ptr = &1u32 as *const u32;
+    unsafe {
         let b = ptr as *const _;
         //~^ ERROR type annotations needed
         let _b: u8 = b.read();
-        let _c = (ptr as *const u8).read(); // we know the type here
-    }
-
-    let mut val = 2_u32;
-    let ptr = &mut val as *mut u32;
-    unsafe {
-        let _a: i32 = (ptr as *mut _).read();
-        //~^ ERROR type annotations needed
-        let b = ptr as *mut _;
-        //~^ ERROR type annotations needed
-        b.write(10);
-        (ptr as *mut i32).write(1000); // we know the type here
     }
 }
+
+
+fn c() {
+    let ptr = &mut 2u32 as *mut u32;
+    unsafe {
+        let _c: i32 = (ptr as *mut _).read();
+        //~^ ERROR type annotations needed
+    }
+}
+
+fn d() {
+    let ptr = &mut 2u32 as *mut u32;
+    unsafe {
+        let d = ptr as *mut _;
+        //~^ ERROR type annotations needed
+        let _d: u8 = d.read();
+    }
+}
+
+fn main() {}

--- a/tests/ui/methods/call_method_unknown_pointee.stderr
+++ b/tests/ui/methods/call_method_unknown_pointee.stderr
@@ -1,5 +1,5 @@
 error[E0282]: type annotations needed
-  --> $DIR/call_method_unknown_pointee.rs:10:23
+  --> $DIR/call_method_unknown_pointee.rs:9:23
    |
 LL |         let _a: i32 = (ptr as *const _).read();
    |                       ^^^^^^^^^^^^^^^^^ ---- cannot call a method on a raw pointer with an unknown pointee type
@@ -7,7 +7,7 @@ LL |         let _a: i32 = (ptr as *const _).read();
    |                       cannot infer type
 
 error[E0282]: type annotations needed for `*const _`
-  --> $DIR/call_method_unknown_pointee.rs:12:13
+  --> $DIR/call_method_unknown_pointee.rs:17:13
    |
 LL |         let b = ptr as *const _;
    |             ^
@@ -21,25 +21,25 @@ LL |         let b: *const _ = ptr as *const _;
    |              ++++++++++
 
 error[E0282]: type annotations needed
-  --> $DIR/call_method_unknown_pointee.rs:21:23
+  --> $DIR/call_method_unknown_pointee.rs:27:23
    |
-LL |         let _a: i32 = (ptr as *mut _).read();
+LL |         let _c: i32 = (ptr as *mut _).read();
    |                       ^^^^^^^^^^^^^^^ ---- cannot call a method on a raw pointer with an unknown pointee type
    |                       |
    |                       cannot infer type
 
 error[E0282]: type annotations needed for `*mut _`
-  --> $DIR/call_method_unknown_pointee.rs:23:13
+  --> $DIR/call_method_unknown_pointee.rs:35:13
    |
-LL |         let b = ptr as *mut _;
+LL |         let d = ptr as *mut _;
    |             ^
 LL |
-LL |         b.write(10);
-   |           ----- cannot call a method on a raw pointer with an unknown pointee type
+LL |         let _d: u8 = d.read();
+   |                        ---- cannot call a method on a raw pointer with an unknown pointee type
    |
-help: consider giving `b` an explicit type, where the placeholders `_` are specified
+help: consider giving `d` an explicit type, where the placeholders `_` are specified
    |
-LL |         let b: *mut _ = ptr as *mut _;
+LL |         let d: *mut _ = ptr as *mut _;
    |              ++++++++
 
 error: aborting due to 4 previous errors

--- a/tests/ui/methods/call_method_unknown_referent.rs
+++ b/tests/ui/methods/call_method_unknown_referent.rs
@@ -14,20 +14,22 @@ impl<T> SmartPtr<T> {
     fn foo(&self) {}
 }
 
-fn main() {
-    let val = 1_u32;
-    let ptr = &val;
+fn a() {
+    let ptr = &1u32;
     let _a: i32 = (ptr as &_).read();
     //~^ ERROR type annotations needed
+}
 
+fn b() {
     // Same again, but with a smart pointer type
-    let val2 = 1_u32;
-    let rc = std::rc::Rc::new(val2);
+    let rc = std::rc::Rc::new(1u32);
     let _b = (rc as std::rc::Rc<_>).read();
     //~^ ERROR type annotations needed
+}
 
+fn c() {
     // Same again, but with a smart pointer type
-    let ptr = SmartPtr(val);
+    let ptr = SmartPtr(1u32);
 
     // We can call unambiguous outer-type methods on this
     (ptr as SmartPtr<_>).foo();
@@ -46,3 +48,5 @@ fn main() {
     let _c = (ptr as SmartPtr<_>).read();
     //~^ ERROR no method named `read` found for struct `SmartPtr<T>`
 }
+
+fn main() {}

--- a/tests/ui/methods/call_method_unknown_referent.stderr
+++ b/tests/ui/methods/call_method_unknown_referent.stderr
@@ -1,5 +1,5 @@
 error[E0282]: type annotations needed
-  --> $DIR/call_method_unknown_referent.rs:20:19
+  --> $DIR/call_method_unknown_referent.rs:19:19
    |
 LL |     let _a: i32 = (ptr as &_).read();
    |                   ^^^^^^^^^^^ cannot infer type
@@ -11,7 +11,7 @@ LL |     let _b = (rc as std::rc::Rc<_>).read();
    |              ^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
 
 error[E0599]: no method named `read` found for struct `SmartPtr<T>` in the current scope
-  --> $DIR/call_method_unknown_referent.rs:46:35
+  --> $DIR/call_method_unknown_referent.rs:48:35
    |
 LL | struct SmartPtr<T>(T);
    | ------------------ method `read` not found for this struct

--- a/tests/ui/proc-macro/quote/not-repeatable.rs
+++ b/tests/ui/proc-macro/quote/not-repeatable.rs
@@ -10,5 +10,4 @@ fn main() {
     let ip = Ipv4Addr;
     let _ = quote! { $($ip)* };
     //~^ ERROR the method `quote_into_iter` exists for struct `Ipv4Addr`, but its trait bounds were not satisfied
-    //~| ERROR type annotations needed
 }

--- a/tests/ui/proc-macro/quote/not-repeatable.stderr
+++ b/tests/ui/proc-macro/quote/not-repeatable.stderr
@@ -20,13 +20,6 @@ note: the traits `Iterator` and `ToTokens` must be implemented
   --> $SRC_DIR/proc_macro/src/to_tokens.rs:LL:COL
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 
-error[E0282]: type annotations needed
-  --> $DIR/not-repeatable.rs:11:25
-   |
-LL |     let _ = quote! { $($ip)* };
-   |                         ^^ cannot infer type
+error: aborting due to 1 previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0282, E0599.
-For more information about an error, try `rustc --explain E0282`.
+For more information about this error, try `rustc --explain E0599`.

--- a/tests/ui/typeck/issue-13853.rs
+++ b/tests/ui/typeck/issue-13853.rs
@@ -25,7 +25,7 @@ impl Node for Stuff {
 
 fn iterate<N: Node, G: Graph<N>>(graph: &G) {
     for node in graph.iter() { //~ ERROR no method named `iter` found
-        node.zomg(); //~ ERROR type annotations needed
+        node.zomg();
     }
 }
 

--- a/tests/ui/typeck/issue-13853.stderr
+++ b/tests/ui/typeck/issue-13853.stderr
@@ -17,12 +17,6 @@ error[E0599]: no method named `iter` found for reference `&G` in the current sco
 LL |     for node in graph.iter() {
    |                       ^^^^ method not found in `&G`
 
-error[E0282]: type annotations needed
-  --> $DIR/issue-13853.rs:28:9
-   |
-LL |         node.zomg();
-   |         ^^^^ cannot infer type
-
 error[E0308]: mismatched types
   --> $DIR/issue-13853.rs:37:13
    |
@@ -43,7 +37,7 @@ help: consider borrowing here
 LL |     iterate(&graph);
    |             +
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0282, E0308, E0599.
-For more information about an error, try `rustc --explain E0282`.
+Some errors have detailed explanations: E0308, E0599.
+For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
see the `proc-macro/quote/not-repeatable.rs` test for a case where this is useful

r? types