### PR TITLE
compiler: Don't mark `SingleUseConsts` MIR pass as "required for soundness"

### DIFF
--- a/compiler/rustc_mir_transform/src/single_use_consts.rs
+++ b/compiler/rustc_mir_transform/src/single_use_consts.rs
@@ -85,7 +85,7 @@ impl<'tcx> crate::MirPass<'tcx> for SingleUseConsts {
     }
 
     fn is_required(&self) -> bool {
-        true
+        false
     }
 }
 

--- a/tests/mir-opt/optimize_none.rs
+++ b/tests/mir-opt/optimize_none.rs
@@ -15,13 +15,14 @@ pub fn add_noopt() -> i32 {
 #[optimize(none)]
 pub fn const_branch() -> i32 {
     // CHECK-LABEL: fn const_branch(
-    // CHECK: switchInt(const true) -> [0: [[FALSE:bb[0-9]+]], otherwise: [[TRUE:bb[0-9]+]]];
+    // CHECK: [[BOOL:_[0-9]+]] = const true;
+    // CHECK: switchInt(move [[BOOL]]) -> [0: [[BB_FALSE:bb[0-9]+]], otherwise: [[BB_TRUE:bb[0-9]+]]];
     // CHECK-NEXT: }
-    // CHECK: [[FALSE]]: {
+    // CHECK: [[BB_FALSE]]: {
     // CHECK-NEXT: _0 = const 0
     // CHECK-NEXT: goto
     // CHECK-NEXT: }
-    // CHECK: [[TRUE]]: {
+    // CHECK: [[BB_TRUE]]: {
     // CHECK-NEXT: _0 = const 1
     // CHECK-NEXT: goto
     // CHECK-NEXT: }


### PR DESCRIPTION
I don't think this MIR pass is required for soundness. The reasons are:
* Something like it was not enabled by default before PR rust-lang/rust#107404 which was the precursor to `SingleUseConsts` (see rust-lang/rust#125910 for the switch).
* By following the advice from https://github.com/rust-lang/rust/pull/128657#discussion_r1705114015 we can conclude it is not required for soundness since it has only ever run on MIR opt level > 0.
* Its [`MirPass::can_be_overridden()`](https://github.com/rust-lang/rust/blob/0ee7d96253f92b15115c94a530db8b79cb341b15/compiler/rustc_mir_transform/src/pass_manager.rs#L98-L102) is unchanged and thus returns `true`, indicating that it is not a required MIR pass.
* PR CI pass in rust-lang/rust#151426 which stops enabling it by default in non-optimized builds.

As shown in the updated test `tests/mir-opt/optimize_none.rs`, `#[optimize(none)]` functions become even less optimized, as expected and desired.

Unblocks https://github.com/rust-lang/rust/pull/151426.
