### PR TITLE
ci: cache cargo artifacts; recommend sccache for faster CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,19 @@
+# Repository-level Cargo configuration to improve local and CI iteration speed.
+# Conservative, non-invasive defaults. Remove or override these in local
+# environments if you prefer a different layout.
+
+[build]
+# Keep a single `target` directory under the repo root so CI caching is
+# effective and users share a predictable location.
+target-dir = "target"
+
+# Example: to use `sccache` locally or in CI, set `RUSTC_WRAPPER` in your
+# environment or uncomment the line below. We do NOT enable it by default to
+# avoid surprising environments that don't have `sccache` installed.
+#
+# [env]
+# RUSTC_WRAPPER = "sccache"
+
+[term]
+# Prefer some verbosity during builds in CI to help debugging failed jobs.
+verbose = true

--- a/.github/workflows/cargo-cache.yml
+++ b/.github/workflows/cargo-cache.yml
@@ -1,0 +1,47 @@
+name: CI — Cargo cache
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  prepare-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cache cargo artifacts
+        uses: actions/cache@v4
+        with:
+          # Cache the workspace `target` dir and cargo registries so CI runs
+          # and subsequent builds are faster. Keep keys conservative to avoid
+          # cache poisoning.
+          path: |
+            target
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Install sccache (optional)
+        # Install `sccache` if possible to speed up CI; fail-safe so job still works
+        # even when install is unavailable.
+        run: |
+          set -e
+          if command -v cargo >/dev/null 2>&1; then
+            cargo install sccache || true
+          fi
+
+      - name: Show tool versions
+        run: |
+          rustc --version
+          cargo --version


### PR DESCRIPTION
  Add a lightweight GitHub Actions workflow (\.github/workflows/cargo-cache.yml) to cache the workspace 'target' directory and cargo registries to speed CI runs.
  
  Add a conservative repository-level Cargo configuration (\.cargo/config.toml) that centralizes the  directory and documents how to enable  without forcing it. These small, low-risk changes improve iteration speed for contributors and CI.
  
  <!-- homu-ignore:start -->
  <!--
  If this PR is related to an unstable feature or an otherwise tracked effort,
  please link to the relevant tracking issue here. If you don't know of a related
  tracking issue or there are none, feel free to ignore this.
  
  This PR will get automatically assigned to a reviewer. In case you would like
  a specific user to review your work, you can assign it to them by using
  
      r? <reviewer name>
  -->
  <!-- homu-ignore:end -->
