### PR TITLE
Respect the `--ci` flag in more places in bootstrap

### DIFF
--- a/src/bootstrap/src/bin/main.rs
+++ b/src/bootstrap/src/bin/main.rs
@@ -71,7 +71,7 @@ fn main() {
 
     // check_version warnings are not printed during setup, or during CI
     let changelog_suggestion = if matches!(config.cmd, Subcommand::Setup { .. })
-        || config.is_running_on_ci
+        || config.is_running_on_ci()
         || config.dry_run()
     {
         None

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -3084,7 +3084,7 @@ impl Step for Gcc {
             return None;
         }
 
-        if builder.config.is_running_on_ci {
+        if builder.config.is_running_on_ci() {
             assert_eq!(
                 builder.config.gcc_ci_mode,
                 GccCiMode::BuildLocally,

--- a/src/bootstrap/src/core/build_steps/format.rs
+++ b/src/bootstrap/src/core/build_steps/format.rs
@@ -92,7 +92,7 @@ fn update_rustfmt_version(build: &Builder<'_>) {
 fn get_modified_rs_files(build: &Builder<'_>) -> Result<Option<Vec<String>>, String> {
     // In CI `get_git_modified_files` returns something different to normal environment.
     // This shouldn't be called in CI anyway.
-    assert!(!build.config.is_running_on_ci);
+    assert!(!build.config.is_running_on_ci());
 
     if !verify_rustfmt_version(build) {
         return Ok(None);
@@ -142,7 +142,7 @@ pub fn format(build: &Builder<'_>, check: bool, all: bool, paths: &[PathBuf]) {
     // `--all` is specified or we are in CI. We check all files in CI to avoid bugs in
     // `get_modified_rs_files` letting regressions slip through; we also care about CI time less
     // since this is still very fast compared to building the compiler.
-    let all = all || build.config.is_running_on_ci;
+    let all = all || build.config.is_running_on_ci();
 
     let mut builder = ignore::types::TypesBuilder::new();
     builder.add_defaults();

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -3500,7 +3500,7 @@ impl Step for BootstrapPy {
         // Bootstrap tests might not be perfectly self-contained and can depend
         // on the environment, so only run them by default in CI, not locally.
         // See `test::Bootstrap::should_run`.
-        builder.config.is_running_on_ci
+        builder.config.is_running_on_ci()
     }
 
     fn make_run(run: RunConfig<'_>) {
@@ -3539,7 +3539,7 @@ impl Step for Bootstrap {
         // Bootstrap tests might not be perfectly self-contained and can depend on the external
         // environment, submodules that are checked out, etc.
         // Therefore we only run them by default on CI.
-        builder.config.is_running_on_ci
+        builder.config.is_running_on_ci()
     }
 
     /// Tests the build system itself.

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -2,8 +2,6 @@ use std::env;
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 
-use build_helper::ci::CiEnv;
-
 use super::{Builder, Kind};
 use crate::core::build_steps::test;
 use crate::core::build_steps::tool::SourceType;
@@ -1326,7 +1324,7 @@ impl Builder<'_> {
         // Try to use a sysroot-relative bindir, in case it was configured absolutely.
         cargo.env("RUSTC_INSTALL_BINDIR", self.config.bindir_relative());
 
-        if CiEnv::is_ci() {
+        if self.config.is_running_on_ci() {
             // Tell cargo to use colored output for nicer logs in CI, even
             // though CI isn't printing to a terminal.
             // Also set an explicit `TERM=xterm` so that cargo doesn't warn

--- a/src/bootstrap/src/core/config/tests.rs
+++ b/src/bootstrap/src/core/config/tests.rs
@@ -42,7 +42,7 @@ fn download_ci_llvm() {
         .config("check")
         .with_default_toml_config("llvm.download-ci-llvm = \"if-unchanged\"")
         .create_config();
-    if if_unchanged_config.llvm_from_ci && if_unchanged_config.is_running_on_ci {
+    if if_unchanged_config.llvm_from_ci && if_unchanged_config.is_running_on_ci() {
         let has_changes = if_unchanged_config.has_changes_from_upstream(LLVM_INVALIDATION_PATHS);
 
         assert!(
@@ -491,13 +491,14 @@ fn test_exclude() {
 #[test]
 fn test_ci_flag() {
     let config = TestCtx::new().config("check").arg("--ci").arg("false").create_config();
-    assert!(!config.is_running_on_ci);
+    assert!(!config.is_running_on_ci());
 
     let config = TestCtx::new().config("check").arg("--ci").arg("true").create_config();
-    assert!(config.is_running_on_ci);
+    assert!(config.is_running_on_ci());
 
+    // If --ci flag is not added, is_running_on_ci() relies on if it is run on actual CI or not.
     let config = TestCtx::new().config("check").create_config();
-    assert_eq!(config.is_running_on_ci, CiEnv::is_ci());
+    assert_eq!(config.is_running_on_ci(), CiEnv::is_ci());
 }
 
 #[test]

--- a/src/bootstrap/src/utils/cc_detect.rs
+++ b/src/bootstrap/src/utils/cc_detect.rs
@@ -223,7 +223,7 @@ fn default_compiler(
             let root = if let Some(path) = build.wasi_sdk_path.as_ref() {
                 path
             } else {
-                if build.config.is_running_on_ci {
+                if build.config.is_running_on_ci() {
                     panic!("ERROR: WASI_SDK_PATH must be configured for a -wasi target on CI");
                 }
                 println!("WARNING: WASI_SDK_PATH not set, using default cc/cxx compiler");

--- a/src/bootstrap/src/utils/metrics.rs
+++ b/src/bootstrap/src/utils/metrics.rs
@@ -222,7 +222,7 @@ impl BuildMetrics {
             format_version: CURRENT_FORMAT_VERSION,
             system_stats,
             invocations,
-            ci_metadata: get_ci_metadata(CiEnv::current()),
+            ci_metadata: get_ci_metadata(build.config.ci_env),
         };
 
         t!(std::fs::create_dir_all(dest.parent().unwrap()));

--- a/src/bootstrap/src/utils/render_tests.rs
+++ b/src/bootstrap/src/utils/render_tests.rs
@@ -179,7 +179,7 @@ impl<'a> Renderer<'a> {
 
         if self.builder.config.verbose_tests {
             self.render_test_outcome_verbose(outcome, test);
-        } else if self.builder.config.is_running_on_ci {
+        } else if self.builder.config.is_running_on_ci() {
             self.render_test_outcome_ci(outcome, test);
         } else {
             self.render_test_outcome_terse(outcome, test);


### PR DESCRIPTION
### Motivation
Currently, the way of checking CI environment in bootstrap is not unified. Sometimes `--ci` flag is respected, but in other cases only GITHUB_ACTIONS env var is checked.

### Change
This PR modifies the way of treating the flag in bootstrap. If `--ci` (or `--ci=true`) is added, bootstrap's config set ci_env as `CiEnv::GithubActions`. This PR also modifies some lines in bootstrap to respect the config's CiEnv instance.

### Note
I haven't touched anything in tidy, because I want to raise another PR for introducing --ci flag in tidy. In the PR, I will need to change how tidy treats CI information. So currently I leave it as it is.