### PR TITLE
remove `#![allow(stable_features)]` from most tests

### DIFF
--- a/compiler/rustc_feature/src/accepted.rs
+++ b/compiler/rustc_feature/src/accepted.rs
@@ -25,9 +25,6 @@ declare_features! (
     // feature-group-start: for testing purposes
     // -------------------------------------------------------------------------
 
-    /// A temporary feature gate used to enable parser extensions needed
-    /// to bootstrap fix for #5723.
-    (accepted, issue_5723_bootstrap, "1.0.0", None),
     /// These are used to test this portion of the compiler,
     /// they don't actually mean anything.
     (accepted, test_accepted_feature, "1.0.0", None),

--- a/compiler/rustc_feature/src/removed.rs
+++ b/compiler/rustc_feature/src/removed.rs
@@ -172,6 +172,9 @@ declare_features! (
     /// Allow anonymous constants from an inline `const` block in pattern position
     (removed, inline_const_pat, "1.88.0", Some(76001),
      Some("removed due to implementation concerns as it requires significant refactorings"), 138492),
+    /// A temporary feature gate used to enable parser extensions needed
+    /// to bootstrap fix for #5723.
+    (removed, issue_5723_bootstrap, "CURRENT_RUSTC_VERSION", None, None),
     /// Lazily evaluate constants. This allows constants to depend on type parameters.
     (removed, lazy_normalization_consts, "1.56.0", Some(72219), Some("superseded by `generic_const_exprs`"), 88369),
     /// Changes `impl Trait` to capture all lifetimes in scope.

--- a/library/std/tests/volatile-fat-ptr.rs
+++ b/library/std/tests/volatile-fat-ptr.rs
@@ -1,5 +1,3 @@
-#![allow(stable_features)]
-
 use std::ptr::{read_volatile, write_volatile};
 
 #[test]

--- a/tests/ui/array-slice-vec/array_const_index-2.rs
+++ b/tests/ui/array-slice-vec/array_const_index-2.rs
@@ -1,8 +1,5 @@
 //@ run-pass
 #![allow(dead_code)]
-#![allow(stable_features)]
-
-#![feature(const_indexing)]
 
 fn main() {
     const ARR: [i32; 6] = [42, 43, 44, 45, 46, 47];

--- a/tests/ui/array-slice-vec/slice-of-zero-size-elements.rs
+++ b/tests/ui/array-slice-vec/slice-of-zero-size-elements.rs
@@ -1,9 +1,5 @@
 //@ run-pass
-#![allow(stable_features)]
-
 //@ compile-flags: -C debug-assertions
-
-#![feature(iter_to_slice)]
 
 use std::slice;
 

--- a/tests/ui/borrowck/fsu-moves-and-copies.rs
+++ b/tests/ui/borrowck/fsu-moves-and-copies.rs
@@ -1,11 +1,9 @@
 //@ run-pass
 
 #![allow(non_camel_case_types)]
-#![allow(stable_features)]
 // Issue 4691: Ensure that functional-struct-updates operates
 // correctly and moves rather than copy when appropriate.
 
-#![feature(core)]
 
 struct ncint { v: isize }
 fn ncint(v: isize) -> ncint { ncint { v: v } }

--- a/tests/ui/cfg/crt-static-off-works.rs
+++ b/tests/ui/cfg/crt-static-off-works.rs
@@ -1,10 +1,6 @@
 //@ run-pass
-
-#![allow(stable_features)]
 //@ compile-flags:-C target-feature=-crt-static -Z unstable-options
 //@ ignore-musl - requires changing the linker which is hard
-
-#![feature(cfg_target_feature)]
 
 #[cfg(not(target_feature = "crt-static"))]
 fn main() {}

--- a/tests/ui/consts/const-fn.rs
+++ b/tests/ui/consts/const-fn.rs
@@ -1,9 +1,5 @@
 //@ run-pass
-#![allow(stable_features)]
-
 // A very basic test of const fn functionality.
-
-#![feature(const_indexing)]
 
 const fn add(x: u32, y: u32) -> u32 {
     x + y

--- a/tests/ui/consts/issue-29914.rs
+++ b/tests/ui/consts/issue-29914.rs
@@ -1,8 +1,4 @@
 //@ run-pass
-#![allow(stable_features)]
-
-#![feature(const_indexing)]
-
 const ARR: [usize; 5] = [5, 4, 3, 2, 1];
 
 fn main() {

--- a/tests/ui/dropck/cleanup-arm-conditional.rs
+++ b/tests/ui/dropck/cleanup-arm-conditional.rs
@@ -1,12 +1,8 @@
 //@ run-pass
 
-#![allow(stable_features)]
 #![allow(unused_imports)]
 // Test that cleanup scope for temporaries created in a match
 // arm is confined to the match arm itself.
-
-
-#![feature(os)]
 
 use std::os;
 

--- a/tests/ui/dst/dst-coerce-rc.rs
+++ b/tests/ui/dst/dst-coerce-rc.rs
@@ -1,9 +1,6 @@
 //@ run-pass
 #![allow(unused_variables)]
-#![allow(stable_features)]
 // Test a very simple custom DST coercion.
-
-#![feature(core, rc_weak)]
 
 use std::cell::RefCell;
 use std::rc::{Rc, Weak};

--- a/tests/ui/enum-discriminant/discriminant_value.rs
+++ b/tests/ui/enum-discriminant/discriminant_value.rs
@@ -1,6 +1,5 @@
 //@ run-pass
-#![allow(stable_features)]
-#![feature(core, core_intrinsics)]
+#![feature(core_intrinsics)]
 
 extern crate core;
 use core::intrinsics::discriminant_value;

--- a/tests/ui/functions-closures/parallel-codegen-closures.rs
+++ b/tests/ui/functions-closures/parallel-codegen-closures.rs
@@ -1,14 +1,11 @@
 //@ run-pass
 #![allow(dead_code)]
 #![allow(unused_variables)]
-#![allow(stable_features)]
 
 // Tests parallel codegen - this can fail if the symbol for the anonymous
 // closure in `sum` pollutes the second codegen unit from the first.
 
 //@ compile-flags: -C codegen_units=2
-
-#![feature(iter_arith)]
 
 mod a {
     fn foo() {

--- a/tests/ui/inference/iterator-sum-array-15673.rs
+++ b/tests/ui/inference/iterator-sum-array-15673.rs
@@ -1,9 +1,6 @@
 //! Regression test for https://github.com/rust-lang/rust/issues/15673
 
 //@ run-pass
-#![allow(stable_features)]
-
-#![feature(iter_arith)]
 
 fn main() {
     let x: [u64; 3] = [1, 2, 3];

--- a/tests/ui/issues/issue-20644.rs
+++ b/tests/ui/issues/issue-20644.rs
@@ -1,13 +1,9 @@
 //@ build-pass
 #![allow(dead_code)]
 #![allow(unused_imports)]
-#![allow(stable_features)]
 
 // A reduced version of the rustbook ice. The problem this encountered
 // had to do with codegen ignoring binders.
-
-
-#![feature(os)]
 
 use std::iter;
 use std::os;

--- a/tests/ui/issues/issue-21634.rs
+++ b/tests/ui/issues/issue-21634.rs
@@ -1,7 +1,4 @@
 //@ run-pass
-#![allow(stable_features)]
-
-#![feature(cfg_target_feature)]
 
 #[cfg(any(not(target_arch = "x86"), target_feature = "sse2"))]
 fn main() {

--- a/tests/ui/issues/issue-29663.rs
+++ b/tests/ui/issues/issue-29663.rs
@@ -1,8 +1,6 @@
 //@ run-pass
-#![allow(stable_features)]
 // write_volatile causes an LLVM assert with composite types
 
-#![feature(volatile)]
 use std::ptr::{read_volatile, write_volatile};
 
 #[derive(Debug, Eq, PartialEq)]

--- a/tests/ui/issues/issue-34780.rs
+++ b/tests/ui/issues/issue-34780.rs
@@ -1,6 +1,4 @@
 //@ check-pass
-#![allow(stable_features)]
-#![feature(associated_consts)]
 
 use std::marker::PhantomData;
 

--- a/tests/ui/issues/issue-42956.rs
+++ b/tests/ui/issues/issue-42956.rs
@@ -1,7 +1,5 @@
 //@ check-pass
 #![allow(dead_code)]
-#![allow(stable_features)]
-#![feature(associated_consts)]
 
 impl A for i32 {
     type Foo = u32;

--- a/tests/ui/iterators/iter-cloned-type-inference.rs
+++ b/tests/ui/iterators/iter-cloned-type-inference.rs
@@ -1,10 +1,6 @@
 //@ run-pass
-#![allow(stable_features)]
-
 // Test to see that the element type of .cloned() can be inferred
 // properly. Previously this would fail to deduce the type of `sum`.
-
-#![feature(iter_arith)]
 
 fn square_sum(v: &[i64]) -> i64 {
     let sum: i64 = v.iter().cloned().sum();

--- a/tests/ui/iterators/iterator-type-inference-sum-15673.rs
+++ b/tests/ui/iterators/iterator-type-inference-sum-15673.rs
@@ -1,8 +1,5 @@
 // https://github.com/rust-lang/rust/issues/15673
 //@ run-pass
-#![allow(stable_features)]
-
-#![feature(iter_arith)]
 
 fn main() {
     let x: [u64; 3] = [1, 2, 3];

--- a/tests/ui/macros/macro-lifetime-used-with-labels.rs
+++ b/tests/ui/macros/macro-lifetime-used-with-labels.rs
@@ -1,5 +1,4 @@
 //@ run-pass
-#![allow(stable_features)]
 #![allow(unused_labels)]
 #![allow(unreachable_code)]
 

--- a/tests/ui/macros/parse-complex-macro-invoc-op.rs
+++ b/tests/ui/macros/parse-complex-macro-invoc-op.rs
@@ -3,13 +3,9 @@
 #![allow(dead_code)]
 #![allow(unused_assignments)]
 #![allow(unused_variables)]
-#![allow(stable_features)]
 #![allow(dropping_copy_types)]
 
 // Test parsing binary operators after macro invocations.
-
-
-#![feature(macro_rules)]
 
 macro_rules! id {
     ($e: expr) => { $e }

--- a/tests/ui/methods/method-normalize-bounds-issue-20604.rs
+++ b/tests/ui/methods/method-normalize-bounds-issue-20604.rs
@@ -1,7 +1,6 @@
 //@ run-pass
 #![allow(dead_code)]
 #![allow(unused_variables)]
-#![allow(stable_features)]
 
 // Test that we handle projection types which wind up important for
 // resolving methods. This test was reduced from a larger example; the
@@ -9,8 +8,6 @@
 // winnowing stage of method resolution failed to handle an associated
 // type projection.
 
-
-#![feature(associated_types)]
 
 trait Hasher {
     type Output;

--- a/tests/ui/mir/mir_fat_ptr_drop.rs
+++ b/tests/ui/mir/mir_fat_ptr_drop.rs
@@ -1,10 +1,7 @@
 //@ run-pass
 #![allow(unused_variables)]
-#![allow(stable_features)]
 
 // test that ordinary fat pointer operations work.
-
-#![feature(braced_empty_structs)]
 #![feature(rustc_attrs)]
 
 use std::sync::atomic;

--- a/tests/ui/no_std/no-core-with-explicit-std-core.rs
+++ b/tests/ui/no_std/no-core-with-explicit-std-core.rs
@@ -6,8 +6,7 @@
 
 //@ run-pass
 
-#![allow(stable_features)]
-#![feature(no_core, core)]
+#![feature(no_core)]
 #![no_core]
 
 extern crate core;

--- a/tests/ui/overloaded/overloaded-autoderef.rs
+++ b/tests/ui/overloaded/overloaded-autoderef.rs
@@ -1,6 +1,5 @@
 //@ run-pass
 #![allow(unused_variables)]
-#![allow(stable_features)]
 
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/tests/ui/overloaded/overloaded-index-autoderef.rs
+++ b/tests/ui/overloaded/overloaded-index-autoderef.rs
@@ -1,6 +1,4 @@
 //@ run-pass
-#![allow(stable_features)]
-
 // Test overloaded indexing combined with autoderef.
 
 use std::ops::{Index, IndexMut};

--- a/tests/ui/panics/panic-handler-chain-update-hook.rs
+++ b/tests/ui/panics/panic-handler-chain-update-hook.rs
@@ -1,11 +1,8 @@
 //@ run-pass
 //@ needs-unwind
-#![allow(stable_features)]
-
 //@ needs-threads
 //@ ignore-backends: gcc
 
-#![feature(std_panic)]
 #![feature(panic_update_hook)]
 
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/tests/ui/panics/panic-handler-chain.rs
+++ b/tests/ui/panics/panic-handler-chain.rs
@@ -2,9 +2,6 @@
 //@ needs-unwind
 //@ needs-threads
 //@ ignore-backends: gcc
-#![allow(stable_features)]
-
-#![feature(std_panic)]
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::panic;

--- a/tests/ui/panics/panic-handler-flail-wildly.rs
+++ b/tests/ui/panics/panic-handler-flail-wildly.rs
@@ -1,13 +1,10 @@
 //@ run-pass
 //@ needs-unwind
 
-#![allow(stable_features)]
 #![allow(unused_must_use)]
 
 //@ needs-threads
 //@ ignore-backends: gcc
-
-#![feature(std_panic)]
 
 use std::panic;
 use std::thread;

--- a/tests/ui/panics/panic-handler-set-twice.rs
+++ b/tests/ui/panics/panic-handler-set-twice.rs
@@ -1,9 +1,6 @@
 //@ run-pass
 //@ needs-unwind
 #![allow(unused_variables)]
-#![allow(stable_features)]
-
-#![feature(std_panic)]
 
 //@ needs-threads
 //@ ignore-backends: gcc

--- a/tests/ui/regions/regions-bound-lists-feature-gate-2.rs
+++ b/tests/ui/regions/regions-bound-lists-feature-gate-2.rs
@@ -1,8 +1,5 @@
 //@ run-pass
 #![allow(dead_code)]
-#![allow(stable_features)]
-
-#![feature(issue_5723_bootstrap)]
 
 trait Foo {
     fn dummy(&self) { }

--- a/tests/ui/regions/regions-bound-lists-feature-gate.rs
+++ b/tests/ui/regions/regions-bound-lists-feature-gate.rs
@@ -1,9 +1,6 @@
 //@ run-pass
 #![allow(dead_code)]
 #![allow(unused_variables)]
-#![allow(stable_features)]
-
-#![feature(issue_5723_bootstrap)]
 
 trait Foo {
     fn dummy(&self) { }

--- a/tests/ui/repr/align-with-extern-c-fn.rs
+++ b/tests/ui/repr/align-with-extern-c-fn.rs
@@ -1,11 +1,8 @@
 //@ run-pass
 
-#![allow(stable_features)]
 #![allow(unused_variables)]
 
 // #45662
-
-#![feature(repr_align)]
 
 #[repr(align(16))]
 pub struct A(#[allow(dead_code)] i64);

--- a/tests/ui/simd/target-feature-mixup.rs
+++ b/tests/ui/simd/target-feature-mixup.rs
@@ -1,13 +1,12 @@
 //@ run-pass
 #![allow(unused_variables)]
-#![allow(stable_features)]
 #![allow(overflowing_literals)]
 
 //@ needs-subprocess
 //@ ignore-fuchsia must translate zircon signal to SIGILL, FIXME (#58590)
 //@ ignore-backends: gcc
 
-#![feature(repr_simd, target_feature, cfg_target_feature)]
+#![feature(repr_simd)]
 
 #[path = "../../auxiliary/minisimd.rs"]
 mod minisimd;

--- a/tests/ui/target-feature/target-feature-detection.rs
+++ b/tests/ui/target-feature/target-feature-detection.rs
@@ -4,9 +4,6 @@
 //@ run-pass
 //@ ignore-i586 (no SSE2)
 
-#![allow(stable_features)]
-#![feature(cfg_target_feature)]
-
 fn main() {
     if cfg!(any(target_arch = "x86", target_arch = "x86_64")) {
         assert!(

--- a/tests/ui/threads-sendsync/tls-init-on-init.rs
+++ b/tests/ui/threads-sendsync/tls-init-on-init.rs
@@ -1,7 +1,5 @@
 //@ run-pass
-#![allow(stable_features)]
 //@ needs-threads
-#![feature(thread_local_try_with)]
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;

--- a/tests/ui/threads-sendsync/tls-try-with.rs
+++ b/tests/ui/threads-sendsync/tls-try-with.rs
@@ -1,7 +1,5 @@
 //@ run-pass
-#![allow(stable_features)]
 //@ needs-threads
-#![feature(thread_local_try_with)]
 
 use std::thread;
 

--- a/tests/ui/use/use.rs
+++ b/tests/ui/use/use.rs
@@ -1,9 +1,7 @@
 //@ run-pass
 
-#![allow(stable_features)]
-
 #![allow(unused_imports)]
-#![feature(no_core, core)]
+#![feature(no_core)]
 #![no_core]
 
 extern crate std;


### PR DESCRIPTION
The only remaining usages are tests that specifically deal with feature gates.
This also deletes the very weird `#![feature(issue_5723_bootstrap)]`, a 13 year old "temporary fix" (rust-lang/rust#5723).