### PR TITLE
make `rustc_allow_const_fn_unstable` an actual `rustc_attrs` attribute

### DIFF
--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -1208,7 +1208,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         rustc_intrinsic_const_stable_indirect, Normal,
         template!(Word), WarnFollowing, EncodeCrossCrate::No,  "this is an internal implementation detail",
     ),
-    gated!(
+    rustc_attr!(
         rustc_allow_const_fn_unstable, Normal,
         template!(Word, List: &["feat1, feat2, ..."]), DuplicatesOk, EncodeCrossCrate::No,
         "rustc_allow_const_fn_unstable side-steps feature gating and stability checks"

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -287,10 +287,6 @@ declare_features! (
     (internal, panic_runtime, "1.10.0", Some(32837)),
     /// Allows using pattern types.
     (internal, pattern_types, "1.79.0", Some(123646)),
-    /// Allows using `#[rustc_allow_const_fn_unstable]`.
-    /// This is an attribute on `const fn` for the same
-    /// purpose as `#[allow_internal_unstable]`.
-    (internal, rustc_allow_const_fn_unstable, "1.49.0", Some(69399)),
     /// Allows using compiler's own crates.
     (unstable, rustc_private, "1.0.0", Some(27812)),
     /// Allows using internal rustdoc features like `doc(keyword)`.

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -182,7 +182,6 @@
 #![feature(negative_impls)]
 #![feature(never_type)]
 #![feature(optimize_attribute)]
-#![feature(rustc_allow_const_fn_unstable)]
 #![feature(rustc_attrs)]
 #![feature(slice_internals)]
 #![feature(staged_api)]

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -159,7 +159,6 @@
 #![feature(pattern_types)]
 #![feature(prelude_import)]
 #![feature(repr_simd)]
-#![feature(rustc_allow_const_fn_unstable)]
 #![feature(rustc_attrs)]
 #![feature(rustdoc_internals)]
 #![feature(simd_ffi)]

--- a/tests/codegen-llvm/intrinsics/likely_assert.rs
+++ b/tests/codegen-llvm/intrinsics/likely_assert.rs
@@ -1,5 +1,5 @@
 //@ compile-flags: -Copt-level=3
-#![feature(panic_internals, const_eval_select, rustc_allow_const_fn_unstable, core_intrinsics)]
+#![feature(panic_internals, const_eval_select, rustc_attrs, core_intrinsics)]
 #![crate_type = "lib"]
 
 // check that assert! and const_assert! emit branch weights

--- a/tests/ui/attributes/malformed-attrs.rs
+++ b/tests/ui/attributes/malformed-attrs.rs
@@ -2,7 +2,6 @@
 // We enable a bunch of features to not get feature-gate errs in this test.
 #![deny(invalid_doc_attributes)]
 #![feature(rustc_attrs)]
-#![feature(rustc_allow_const_fn_unstable)]
 #![feature(allow_internal_unstable)]
 // FIXME(#82232, #143834): temporarily renamed to mitigate `#[align]` nameres ambiguity
 #![feature(fn_align)]

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -1,5 +1,5 @@
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/malformed-attrs.rs:107:1
+  --> $DIR/malformed-attrs.rs:106:1
    |
 LL | #[cfg]
    | ^^^^^^
@@ -10,7 +10,7 @@ LL | #[cfg]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/malformed-attrs.rs:109:1
+  --> $DIR/malformed-attrs.rs:108:1
    |
 LL | #[cfg_attr]
    | ^^^^^^^^^^^
@@ -21,13 +21,13 @@ LL | #[cfg_attr]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 
 error[E0463]: can't find crate for `wloop`
-  --> $DIR/malformed-attrs.rs:215:1
+  --> $DIR/malformed-attrs.rs:214:1
    |
 LL | extern crate wloop;
    | ^^^^^^^^^^^^^^^^^^^ can't find crate
 
 error: malformed `allow` attribute input
-  --> $DIR/malformed-attrs.rs:181:1
+  --> $DIR/malformed-attrs.rs:180:1
    |
 LL | #[allow]
    | ^^^^^^^^
@@ -43,7 +43,7 @@ LL | #[allow(lint1, lint2, lint3, reason = "...")]
    |        +++++++++++++++++++++++++++++++++++++
 
 error: malformed `expect` attribute input
-  --> $DIR/malformed-attrs.rs:183:1
+  --> $DIR/malformed-attrs.rs:182:1
    |
 LL | #[expect]
    | ^^^^^^^^^
@@ -59,7 +59,7 @@ LL | #[expect(lint1, lint2, lint3, reason = "...")]
    |         +++++++++++++++++++++++++++++++++++++
 
 error: malformed `warn` attribute input
-  --> $DIR/malformed-attrs.rs:185:1
+  --> $DIR/malformed-attrs.rs:184:1
    |
 LL | #[warn]
    | ^^^^^^^
@@ -75,7 +75,7 @@ LL | #[warn(lint1, lint2, lint3, reason = "...")]
    |       +++++++++++++++++++++++++++++++++++++
 
 error: malformed `deny` attribute input
-  --> $DIR/malformed-attrs.rs:187:1
+  --> $DIR/malformed-attrs.rs:186:1
    |
 LL | #[deny]
    | ^^^^^^^
@@ -91,7 +91,7 @@ LL | #[deny(lint1, lint2, lint3, reason = "...")]
    |       +++++++++++++++++++++++++++++++++++++
 
 error: malformed `forbid` attribute input
-  --> $DIR/malformed-attrs.rs:189:1
+  --> $DIR/malformed-attrs.rs:188:1
    |
 LL | #[forbid]
    | ^^^^^^^^^
@@ -107,25 +107,25 @@ LL | #[forbid(lint1, lint2, lint3, reason = "...")]
    |         +++++++++++++++++++++++++++++++++++++
 
 error: the `#[proc_macro]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/malformed-attrs.rs:104:1
+  --> $DIR/malformed-attrs.rs:103:1
    |
 LL | #[proc_macro = 18]
    | ^^^^^^^^^^^^^^^^^^
 
 error: the `#[proc_macro_attribute]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/malformed-attrs.rs:121:1
+  --> $DIR/malformed-attrs.rs:120:1
    |
 LL | #[proc_macro_attribute = 19]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: the `#[proc_macro_derive]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/malformed-attrs.rs:128:1
+  --> $DIR/malformed-attrs.rs:127:1
    |
 LL | #[proc_macro_derive]
    | ^^^^^^^^^^^^^^^^^^^^
 
 error[E0658]: allow_internal_unsafe side-steps the unsafe_code lint
-  --> $DIR/malformed-attrs.rs:220:1
+  --> $DIR/malformed-attrs.rs:219:1
    |
 LL | #[allow_internal_unsafe = 1]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -134,7 +134,7 @@ LL | #[allow_internal_unsafe = 1]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0539]: malformed `windows_subsystem` attribute input
-  --> $DIR/malformed-attrs.rs:27:1
+  --> $DIR/malformed-attrs.rs:26:1
    |
 LL | #![windows_subsystem]
    | ^^^-----------------^
@@ -150,25 +150,25 @@ LL | #![windows_subsystem = "windows"]
    |                      +++++++++++
 
 error[E0539]: malformed `export_name` attribute input
-  --> $DIR/malformed-attrs.rs:30:1
+  --> $DIR/malformed-attrs.rs:29:1
    |
 LL | #[unsafe(export_name)]
    | ^^^^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[export_name = "name"]`
 
 error: `rustc_allow_const_fn_unstable` expects a list of feature names
-  --> $DIR/malformed-attrs.rs:32:1
+  --> $DIR/malformed-attrs.rs:31:1
    |
 LL | #[rustc_allow_const_fn_unstable]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `allow_internal_unstable` expects a list of feature names
-  --> $DIR/malformed-attrs.rs:35:1
+  --> $DIR/malformed-attrs.rs:34:1
    |
 LL | #[allow_internal_unstable]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0539]: malformed `rustc_confusables` attribute input
-  --> $DIR/malformed-attrs.rs:37:1
+  --> $DIR/malformed-attrs.rs:36:1
    |
 LL | #[rustc_confusables]
    | ^^^^^^^^^^^^^^^^^^^^
@@ -177,7 +177,7 @@ LL | #[rustc_confusables]
    | help: must be of the form: `#[rustc_confusables("name1", "name2", ...)]`
 
 error: `#[rustc_confusables]` attribute cannot be used on functions
-  --> $DIR/malformed-attrs.rs:37:1
+  --> $DIR/malformed-attrs.rs:36:1
    |
 LL | #[rustc_confusables]
    | ^^^^^^^^^^^^^^^^^^^^
@@ -185,7 +185,7 @@ LL | #[rustc_confusables]
    = help: `#[rustc_confusables]` can only be applied to inherent methods
 
 error[E0539]: malformed `deprecated` attribute input
-  --> $DIR/malformed-attrs.rs:40:1
+  --> $DIR/malformed-attrs.rs:39:1
    |
 LL | #[deprecated = 5]
    | ^^^^^^^^^^^^^^^-^
@@ -193,7 +193,7 @@ LL | #[deprecated = 5]
    |                expected a string literal here
 
 error[E0539]: malformed `rustc_macro_transparency` attribute input
-  --> $DIR/malformed-attrs.rs:44:1
+  --> $DIR/malformed-attrs.rs:43:1
    |
 LL | #[rustc_macro_transparency]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -208,7 +208,7 @@ LL | #[rustc_macro_transparency = "transparent"]
    |                            +++++++++++++++
 
 error: `#[rustc_macro_transparency]` attribute cannot be used on functions
-  --> $DIR/malformed-attrs.rs:44:1
+  --> $DIR/malformed-attrs.rs:43:1
    |
 LL | #[rustc_macro_transparency]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -216,7 +216,7 @@ LL | #[rustc_macro_transparency]
    = help: `#[rustc_macro_transparency]` can only be applied to macro defs
 
 error[E0539]: malformed `repr` attribute input
-  --> $DIR/malformed-attrs.rs:47:1
+  --> $DIR/malformed-attrs.rs:46:1
    |
 LL | #[repr]
    | ^^^^^^^ expected this to be a list
@@ -224,7 +224,7 @@ LL | #[repr]
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 
 error[E0565]: malformed `rustc_as_ptr` attribute input
-  --> $DIR/malformed-attrs.rs:50:1
+  --> $DIR/malformed-attrs.rs:49:1
    |
 LL | #[rustc_as_ptr = 5]
    | ^^^^^^^^^^^^^^^---^
@@ -233,7 +233,7 @@ LL | #[rustc_as_ptr = 5]
    | help: must be of the form: `#[rustc_as_ptr]`
 
 error[E0539]: malformed `rustc_align` attribute input
-  --> $DIR/malformed-attrs.rs:55:1
+  --> $DIR/malformed-attrs.rs:54:1
    |
 LL | #[rustc_align]
    | ^^^^^^^^^^^^^^
@@ -242,7 +242,7 @@ LL | #[rustc_align]
    | help: must be of the form: `#[rustc_align(<alignment in bytes>)]`
 
 error[E0539]: malformed `optimize` attribute input
-  --> $DIR/malformed-attrs.rs:57:1
+  --> $DIR/malformed-attrs.rs:56:1
    |
 LL | #[optimize]
    | ^^^^^^^^^^^ expected this to be a list
@@ -257,7 +257,7 @@ LL | #[optimize(speed)]
    |           +++++++
 
 error[E0565]: malformed `cold` attribute input
-  --> $DIR/malformed-attrs.rs:59:1
+  --> $DIR/malformed-attrs.rs:58:1
    |
 LL | #[cold = 1]
    | ^^^^^^^---^
@@ -266,7 +266,7 @@ LL | #[cold = 1]
    | help: must be of the form: `#[cold]`
 
 error[E0539]: malformed `must_use` attribute input
-  --> $DIR/malformed-attrs.rs:61:1
+  --> $DIR/malformed-attrs.rs:60:1
    |
 LL | #[must_use()]
    | ^^^^^^^^^^--^
@@ -284,7 +284,7 @@ LL + #[must_use]
    |
 
 error[E0565]: malformed `no_mangle` attribute input
-  --> $DIR/malformed-attrs.rs:63:1
+  --> $DIR/malformed-attrs.rs:62:1
    |
 LL | #[no_mangle = 1]
    | ^^^^^^^^^^^^---^
@@ -293,7 +293,7 @@ LL | #[no_mangle = 1]
    | help: must be of the form: `#[no_mangle]`
 
 error[E0565]: malformed `naked` attribute input
-  --> $DIR/malformed-attrs.rs:65:1
+  --> $DIR/malformed-attrs.rs:64:1
    |
 LL | #[unsafe(naked())]
    | ^^^^^^^^^^^^^^--^^
@@ -302,7 +302,7 @@ LL | #[unsafe(naked())]
    | help: must be of the form: `#[naked]`
 
 error[E0565]: malformed `track_caller` attribute input
-  --> $DIR/malformed-attrs.rs:67:1
+  --> $DIR/malformed-attrs.rs:66:1
    |
 LL | #[track_caller()]
    | ^^^^^^^^^^^^^^--^
@@ -311,13 +311,13 @@ LL | #[track_caller()]
    | help: must be of the form: `#[track_caller]`
 
 error[E0539]: malformed `export_name` attribute input
-  --> $DIR/malformed-attrs.rs:69:1
+  --> $DIR/malformed-attrs.rs:68:1
    |
 LL | #[export_name()]
    | ^^^^^^^^^^^^^^^^ help: must be of the form: `#[export_name = "name"]`
 
 error[E0805]: malformed `used` attribute input
-  --> $DIR/malformed-attrs.rs:71:1
+  --> $DIR/malformed-attrs.rs:70:1
    |
 LL | #[used()]
    | ^^^^^^--^
@@ -335,7 +335,7 @@ LL + #[used]
    |
 
 error: `#[used]` attribute cannot be used on functions
-  --> $DIR/malformed-attrs.rs:71:1
+  --> $DIR/malformed-attrs.rs:70:1
    |
 LL | #[used()]
    | ^^^^^^^^^
@@ -343,13 +343,13 @@ LL | #[used()]
    = help: `#[used]` can only be applied to statics
 
 error[E0539]: malformed `crate_name` attribute input
-  --> $DIR/malformed-attrs.rs:74:1
+  --> $DIR/malformed-attrs.rs:73:1
    |
 LL | #[crate_name]
    | ^^^^^^^^^^^^^ help: must be of the form: `#[crate_name = "name"]`
 
 error[E0539]: malformed `target_feature` attribute input
-  --> $DIR/malformed-attrs.rs:79:1
+  --> $DIR/malformed-attrs.rs:78:1
    |
 LL | #[target_feature]
    | ^^^^^^^^^^^^^^^^^
@@ -358,7 +358,7 @@ LL | #[target_feature]
    | help: must be of the form: `#[target_feature(enable = "feat1, feat2")]`
 
 error[E0565]: malformed `export_stable` attribute input
-  --> $DIR/malformed-attrs.rs:81:1
+  --> $DIR/malformed-attrs.rs:80:1
    |
 LL | #[export_stable = 1]
    | ^^^^^^^^^^^^^^^^---^
@@ -367,7 +367,7 @@ LL | #[export_stable = 1]
    | help: must be of the form: `#[export_stable]`
 
 error[E0539]: malformed `link` attribute input
-  --> $DIR/malformed-attrs.rs:83:1
+  --> $DIR/malformed-attrs.rs:82:1
    |
 LL | #[link]
    | ^^^^^^^ expected this to be a list
@@ -375,7 +375,7 @@ LL | #[link]
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 error[E0539]: malformed `link_name` attribute input
-  --> $DIR/malformed-attrs.rs:87:1
+  --> $DIR/malformed-attrs.rs:86:1
    |
 LL | #[link_name]
    | ^^^^^^^^^^^^ help: must be of the form: `#[link_name = "name"]`
@@ -383,7 +383,7 @@ LL | #[link_name]
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_name-attribute>
 
 error[E0539]: malformed `link_section` attribute input
-  --> $DIR/malformed-attrs.rs:91:1
+  --> $DIR/malformed-attrs.rs:90:1
    |
 LL | #[link_section]
    | ^^^^^^^^^^^^^^^ help: must be of the form: `#[link_section = "name"]`
@@ -391,7 +391,7 @@ LL | #[link_section]
    = note: for more information, visit <https://doc.rust-lang.org/reference/abi.html#the-link_section-attribute>
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/malformed-attrs.rs:93:1
+  --> $DIR/malformed-attrs.rs:92:1
    |
 LL | #[coverage]
    | ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
@@ -404,13 +404,13 @@ LL | #[coverage(on)]
    |           ++++
 
 error[E0539]: malformed `sanitize` attribute input
-  --> $DIR/malformed-attrs.rs:95:1
+  --> $DIR/malformed-attrs.rs:94:1
    |
 LL | #[sanitize]
    | ^^^^^^^^^^^ expected this to be a list
 
 error[E0565]: malformed `no_implicit_prelude` attribute input
-  --> $DIR/malformed-attrs.rs:100:1
+  --> $DIR/malformed-attrs.rs:99:1
    |
 LL | #[no_implicit_prelude = 23]
    | ^^^^^^^^^^^^^^^^^^^^^^----^
@@ -419,7 +419,7 @@ LL | #[no_implicit_prelude = 23]
    | help: must be of the form: `#[no_implicit_prelude]`
 
 error[E0565]: malformed `proc_macro` attribute input
-  --> $DIR/malformed-attrs.rs:104:1
+  --> $DIR/malformed-attrs.rs:103:1
    |
 LL | #[proc_macro = 18]
    | ^^^^^^^^^^^^^----^
@@ -428,7 +428,7 @@ LL | #[proc_macro = 18]
    | help: must be of the form: `#[proc_macro]`
 
 error[E0539]: malformed `instruction_set` attribute input
-  --> $DIR/malformed-attrs.rs:111:1
+  --> $DIR/malformed-attrs.rs:110:1
    |
 LL | #[instruction_set]
    | ^^^^^^^^^^^^^^^^^^
@@ -439,7 +439,7 @@ LL | #[instruction_set]
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute>
 
 error[E0539]: malformed `patchable_function_entry` attribute input
-  --> $DIR/malformed-attrs.rs:113:1
+  --> $DIR/malformed-attrs.rs:112:1
    |
 LL | #[patchable_function_entry]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -448,7 +448,7 @@ LL | #[patchable_function_entry]
    | help: must be of the form: `#[patchable_function_entry(prefix_nops = m, entry_nops = n)]`
 
 error[E0565]: malformed `coroutine` attribute input
-  --> $DIR/malformed-attrs.rs:116:5
+  --> $DIR/malformed-attrs.rs:115:5
    |
 LL |     #[coroutine = 63] || {}
    |     ^^^^^^^^^^^^----^
@@ -457,7 +457,7 @@ LL |     #[coroutine = 63] || {}
    |     help: must be of the form: `#[coroutine]`
 
 error[E0565]: malformed `proc_macro_attribute` attribute input
-  --> $DIR/malformed-attrs.rs:121:1
+  --> $DIR/malformed-attrs.rs:120:1
    |
 LL | #[proc_macro_attribute = 19]
    | ^^^^^^^^^^^^^^^^^^^^^^^----^
@@ -466,7 +466,7 @@ LL | #[proc_macro_attribute = 19]
    | help: must be of the form: `#[proc_macro_attribute]`
 
 error[E0539]: malformed `must_use` attribute input
-  --> $DIR/malformed-attrs.rs:124:1
+  --> $DIR/malformed-attrs.rs:123:1
    |
 LL | #[must_use = 1]
    | ^^^^^^^^^^^^^-^
@@ -484,7 +484,7 @@ LL + #[must_use]
    |
 
 error[E0539]: malformed `proc_macro_derive` attribute input
-  --> $DIR/malformed-attrs.rs:128:1
+  --> $DIR/malformed-attrs.rs:127:1
    |
 LL | #[proc_macro_derive]
    | ^^^^^^^^^^^^^^^^^^^^ expected this to be a list
@@ -498,7 +498,7 @@ LL | #[proc_macro_derive(TraitName, attributes(name1, name2, ...))]
    |                    ++++++++++++++++++++++++++++++++++++++++++
 
 error[E0539]: malformed `rustc_layout_scalar_valid_range_start` attribute input
-  --> $DIR/malformed-attrs.rs:133:1
+  --> $DIR/malformed-attrs.rs:132:1
    |
 LL | #[rustc_layout_scalar_valid_range_start]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -507,7 +507,7 @@ LL | #[rustc_layout_scalar_valid_range_start]
    | help: must be of the form: `#[rustc_layout_scalar_valid_range_start(start)]`
 
 error[E0539]: malformed `rustc_layout_scalar_valid_range_end` attribute input
-  --> $DIR/malformed-attrs.rs:135:1
+  --> $DIR/malformed-attrs.rs:134:1
    |
 LL | #[rustc_layout_scalar_valid_range_end]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -516,7 +516,7 @@ LL | #[rustc_layout_scalar_valid_range_end]
    | help: must be of the form: `#[rustc_layout_scalar_valid_range_end(end)]`
 
 error[E0539]: malformed `must_not_suspend` attribute input
-  --> $DIR/malformed-attrs.rs:137:1
+  --> $DIR/malformed-attrs.rs:136:1
    |
 LL | #[must_not_suspend()]
    | ^^^^^^^^^^^^^^^^^^--^
@@ -532,7 +532,7 @@ LL + #[must_not_suspend]
    |
 
 error[E0539]: malformed `cfi_encoding` attribute input
-  --> $DIR/malformed-attrs.rs:139:1
+  --> $DIR/malformed-attrs.rs:138:1
    |
 LL | #[cfi_encoding = ""]
    | ^^^^^^^^^^^^^^^^^--^
@@ -541,7 +541,7 @@ LL | #[cfi_encoding = ""]
    | help: must be of the form: `#[cfi_encoding = "encoding"]`
 
 error[E0565]: malformed `marker` attribute input
-  --> $DIR/malformed-attrs.rs:158:1
+  --> $DIR/malformed-attrs.rs:157:1
    |
 LL | #[marker = 3]
    | ^^^^^^^^^---^
@@ -550,7 +550,7 @@ LL | #[marker = 3]
    | help: must be of the form: `#[marker]`
 
 error[E0565]: malformed `fundamental` attribute input
-  --> $DIR/malformed-attrs.rs:160:1
+  --> $DIR/malformed-attrs.rs:159:1
    |
 LL | #[fundamental()]
    | ^^^^^^^^^^^^^--^
@@ -559,7 +559,7 @@ LL | #[fundamental()]
    | help: must be of the form: `#[fundamental]`
 
 error[E0565]: malformed `ffi_pure` attribute input
-  --> $DIR/malformed-attrs.rs:168:5
+  --> $DIR/malformed-attrs.rs:167:5
    |
 LL |     #[unsafe(ffi_pure = 1)]
    |     ^^^^^^^^^^^^^^^^^^---^^
@@ -568,7 +568,7 @@ LL |     #[unsafe(ffi_pure = 1)]
    |     help: must be of the form: `#[ffi_pure]`
 
 error[E0539]: malformed `link_ordinal` attribute input
-  --> $DIR/malformed-attrs.rs:170:5
+  --> $DIR/malformed-attrs.rs:169:5
    |
 LL |     #[link_ordinal]
    |     ^^^^^^^^^^^^^^^
@@ -579,7 +579,7 @@ LL |     #[link_ordinal]
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_ordinal-attribute>
 
 error[E0565]: malformed `ffi_const` attribute input
-  --> $DIR/malformed-attrs.rs:174:5
+  --> $DIR/malformed-attrs.rs:173:5
    |
 LL |     #[unsafe(ffi_const = 1)]
    |     ^^^^^^^^^^^^^^^^^^^---^^
@@ -588,13 +588,13 @@ LL |     #[unsafe(ffi_const = 1)]
    |     help: must be of the form: `#[ffi_const]`
 
 error[E0539]: malformed `linkage` attribute input
-  --> $DIR/malformed-attrs.rs:176:5
+  --> $DIR/malformed-attrs.rs:175:5
    |
 LL |     #[linkage]
    |     ^^^^^^^^^^ expected this to be of the form `linkage = "..."`
 
 error[E0539]: malformed `debugger_visualizer` attribute input
-  --> $DIR/malformed-attrs.rs:191:1
+  --> $DIR/malformed-attrs.rs:190:1
    |
 LL | #[debugger_visualizer]
    | ^^^^^^^^^^^^^^^^^^^^^^
@@ -605,7 +605,7 @@ LL | #[debugger_visualizer]
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/debugger.html#the-debugger_visualizer-attribute>
 
 error[E0565]: malformed `automatically_derived` attribute input
-  --> $DIR/malformed-attrs.rs:193:1
+  --> $DIR/malformed-attrs.rs:192:1
    |
 LL | #[automatically_derived = 18]
    | ^^^^^^^^^^^^^^^^^^^^^^^^----^
@@ -614,7 +614,7 @@ LL | #[automatically_derived = 18]
    | help: must be of the form: `#[automatically_derived]`
 
 error[E0565]: malformed `non_exhaustive` attribute input
-  --> $DIR/malformed-attrs.rs:201:1
+  --> $DIR/malformed-attrs.rs:200:1
    |
 LL | #[non_exhaustive = 1]
    | ^^^^^^^^^^^^^^^^^---^
@@ -623,7 +623,7 @@ LL | #[non_exhaustive = 1]
    | help: must be of the form: `#[non_exhaustive]`
 
 error[E0565]: malformed `thread_local` attribute input
-  --> $DIR/malformed-attrs.rs:207:1
+  --> $DIR/malformed-attrs.rs:206:1
    |
 LL | #[thread_local()]
    | ^^^^^^^^^^^^^^--^
@@ -632,7 +632,7 @@ LL | #[thread_local()]
    | help: must be of the form: `#[thread_local]`
 
 error[E0565]: malformed `no_link` attribute input
-  --> $DIR/malformed-attrs.rs:211:1
+  --> $DIR/malformed-attrs.rs:210:1
    |
 LL | #[no_link()]
    | ^^^^^^^^^--^
@@ -641,7 +641,7 @@ LL | #[no_link()]
    | help: must be of the form: `#[no_link]`
 
 error[E0539]: malformed `macro_use` attribute input
-  --> $DIR/malformed-attrs.rs:213:1
+  --> $DIR/malformed-attrs.rs:212:1
    |
 LL | #[macro_use = 1]
    | ^^^^^^^^^^^^---^
@@ -659,7 +659,7 @@ LL + #[macro_use]
    |
 
 error[E0539]: malformed `macro_export` attribute input
-  --> $DIR/malformed-attrs.rs:218:1
+  --> $DIR/malformed-attrs.rs:217:1
    |
 LL | #[macro_export = 18]
    | ^^^^^^^^^^^^^^^----^
@@ -676,7 +676,7 @@ LL + #[macro_export]
    |
 
 error[E0565]: malformed `allow_internal_unsafe` attribute input
-  --> $DIR/malformed-attrs.rs:220:1
+  --> $DIR/malformed-attrs.rs:219:1
    |
 LL | #[allow_internal_unsafe = 1]
    | ^^^^^^^^^^^^^^^^^^^^^^^^---^
@@ -685,7 +685,7 @@ LL | #[allow_internal_unsafe = 1]
    | help: must be of the form: `#[allow_internal_unsafe]`
 
 error: attribute should be applied to `const fn`
-  --> $DIR/malformed-attrs.rs:32:1
+  --> $DIR/malformed-attrs.rs:31:1
    |
 LL |   #[rustc_allow_const_fn_unstable]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -697,7 +697,7 @@ LL | | }
    | |_- not a `const fn`
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/malformed-attrs.rs:83:1
+  --> $DIR/malformed-attrs.rs:82:1
    |
 LL |   #[link]
    |   ^^^^^^^
@@ -712,19 +712,19 @@ LL | | }
    = note: requested on the command line with `-W unused-attributes`
 
 error: `#[repr(align(...))]` is not supported on functions
-  --> $DIR/malformed-attrs.rs:47:1
+  --> $DIR/malformed-attrs.rs:46:1
    |
 LL | #[repr]
    | ^^^^^^^
    |
 help: use `#[rustc_align(...)]` instead
-  --> $DIR/malformed-attrs.rs:47:1
+  --> $DIR/malformed-attrs.rs:46:1
    |
 LL | #[repr]
    | ^^^^^^^
 
 warning: missing options for `on_unimplemented` attribute
-  --> $DIR/malformed-attrs.rs:143:1
+  --> $DIR/malformed-attrs.rs:142:1
    |
 LL | #[diagnostic::on_unimplemented]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -733,7 +733,7 @@ LL | #[diagnostic::on_unimplemented]
    = note: `#[warn(malformed_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: malformed `on_unimplemented` attribute
-  --> $DIR/malformed-attrs.rs:145:1
+  --> $DIR/malformed-attrs.rs:144:1
    |
 LL | #[diagnostic::on_unimplemented = 1]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid option found here
@@ -741,7 +741,7 @@ LL | #[diagnostic::on_unimplemented = 1]
    = help: only `message`, `note` and `label` are allowed as options
 
 error: valid forms for the attribute are `#[doc = "string"]`, `#[doc(alias)]`, `#[doc(attribute)]`, `#[doc(auto_cfg)]`, `#[doc(cfg)]`, `#[doc(fake_variadic)]`, `#[doc(hidden)]`, `#[doc(html_favicon_url)]`, `#[doc(html_logo_url)]`, `#[doc(html_no_source)]`, `#[doc(html_playground_url)]`, `#[doc(html_root_url)]`, `#[doc(include)]`, `#[doc(inline)]`, `#[doc(issue_tracker_base_url)]`, `#[doc(keyword)]`, `#[doc(masked)]`, `#[doc(no_default_passes)]`, `#[doc(no_inline)]`, `#[doc(notable_trait)]`, `#[doc(passes)]`, `#[doc(plugins)]`, `#[doc(rust_logo)]`, `#[doc(search_unbox)]`, `#[doc(spotlight)]`, and `#[doc(test)]`
-  --> $DIR/malformed-attrs.rs:42:1
+  --> $DIR/malformed-attrs.rs:41:1
    |
 LL | #[doc]
    | ^^^^^^
@@ -753,7 +753,7 @@ LL | #![deny(invalid_doc_attributes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: valid forms for the attribute are `#[inline(always)]`, `#[inline(never)]`, and `#[inline]`
-  --> $DIR/malformed-attrs.rs:52:1
+  --> $DIR/malformed-attrs.rs:51:1
    |
 LL | #[inline = 5]
    | ^^^^^^^^^^^^^
@@ -763,13 +763,13 @@ LL | #[inline = 5]
    = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_name]`
-  --> $DIR/malformed-attrs.rs:74:1
+  --> $DIR/malformed-attrs.rs:73:1
    |
 LL | #[crate_name]
    | ^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/malformed-attrs.rs:115:1
+  --> $DIR/malformed-attrs.rs:114:1
    |
 LL | / fn test() {
 LL | |     #[coroutine = 63] || {}
@@ -778,13 +778,13 @@ LL | | }
    | |_^
 
 error: valid forms for the attribute are `#[doc = "string"]`, `#[doc(alias)]`, `#[doc(attribute)]`, `#[doc(auto_cfg)]`, `#[doc(cfg)]`, `#[doc(fake_variadic)]`, `#[doc(hidden)]`, `#[doc(html_favicon_url)]`, `#[doc(html_logo_url)]`, `#[doc(html_no_source)]`, `#[doc(html_playground_url)]`, `#[doc(html_root_url)]`, `#[doc(include)]`, `#[doc(inline)]`, `#[doc(issue_tracker_base_url)]`, `#[doc(keyword)]`, `#[doc(masked)]`, `#[doc(no_default_passes)]`, `#[doc(no_inline)]`, `#[doc(notable_trait)]`, `#[doc(passes)]`, `#[doc(plugins)]`, `#[doc(rust_logo)]`, `#[doc(search_unbox)]`, `#[doc(spotlight)]`, and `#[doc(test)]`
-  --> $DIR/malformed-attrs.rs:77:1
+  --> $DIR/malformed-attrs.rs:76:1
    |
 LL | #[doc]
    | ^^^^^^
 
 warning: `#[link_name]` attribute cannot be used on functions
-  --> $DIR/malformed-attrs.rs:87:1
+  --> $DIR/malformed-attrs.rs:86:1
    |
 LL | #[link_name]
    | ^^^^^^^^^^^^
@@ -793,7 +793,7 @@ LL | #[link_name]
    = help: `#[link_name]` can be applied to foreign functions and foreign statics
 
 error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
-  --> $DIR/malformed-attrs.rs:97:1
+  --> $DIR/malformed-attrs.rs:96:1
    |
 LL | #[ignore()]
    | ^^^^^^^^^^^
@@ -802,7 +802,7 @@ LL | #[ignore()]
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on functions
-  --> $DIR/malformed-attrs.rs:100:1
+  --> $DIR/malformed-attrs.rs:99:1
    |
 LL | #[no_implicit_prelude = 23]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -811,13 +811,13 @@ LL | #[no_implicit_prelude = 23]
    = help: `#[no_implicit_prelude]` can be applied to crates and modules
 
 warning: `#[diagnostic::do_not_recommend]` does not expect any arguments
-  --> $DIR/malformed-attrs.rs:152:1
+  --> $DIR/malformed-attrs.rs:151:1
    |
 LL | #[diagnostic::do_not_recommend()]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: `#[automatically_derived]` attribute cannot be used on modules
-  --> $DIR/malformed-attrs.rs:193:1
+  --> $DIR/malformed-attrs.rs:192:1
    |
 LL | #[automatically_derived = 18]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -826,7 +826,7 @@ LL | #[automatically_derived = 18]
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
 
 error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
-  --> $DIR/malformed-attrs.rs:227:1
+  --> $DIR/malformed-attrs.rs:226:1
    |
 LL | #[ignore = 1]
    | ^^^^^^^^^^^^^
@@ -835,7 +835,7 @@ LL | #[ignore = 1]
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 error[E0308]: mismatched types
-  --> $DIR/malformed-attrs.rs:116:23
+  --> $DIR/malformed-attrs.rs:115:23
    |
 LL | fn test() {
    |          - help: a return type might be missing here: `-> _`
@@ -843,7 +843,7 @@ LL |     #[coroutine = 63] || {}
    |                       ^^^^^ expected `()`, found coroutine
    |
    = note: expected unit type `()`
-              found coroutine `{coroutine@$DIR/malformed-attrs.rs:116:23: 116:25}`
+              found coroutine `{coroutine@$DIR/malformed-attrs.rs:115:23: 115:25}`
 
 error: aborting due to 75 previous errors; 8 warnings emitted
 
@@ -851,7 +851,7 @@ Some errors have detailed explanations: E0308, E0463, E0539, E0565, E0658, E0805
 For more information about an error, try `rustc --explain E0308`.
 Future incompatibility report: Future breakage diagnostic:
 error: valid forms for the attribute are `#[inline(always)]`, `#[inline(never)]`, and `#[inline]`
-  --> $DIR/malformed-attrs.rs:52:1
+  --> $DIR/malformed-attrs.rs:51:1
    |
 LL | #[inline = 5]
    | ^^^^^^^^^^^^^
@@ -862,7 +862,7 @@ LL | #[inline = 5]
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
-  --> $DIR/malformed-attrs.rs:97:1
+  --> $DIR/malformed-attrs.rs:96:1
    |
 LL | #[ignore()]
    | ^^^^^^^^^^^
@@ -873,7 +873,7 @@ LL | #[ignore()]
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
-  --> $DIR/malformed-attrs.rs:227:1
+  --> $DIR/malformed-attrs.rs:226:1
    |
 LL | #[ignore = 1]
    | ^^^^^^^^^^^^^

--- a/tests/ui/consts/precise-drop-allow-const-fn-unstable.rs
+++ b/tests/ui/consts/precise-drop-allow-const-fn-unstable.rs
@@ -2,7 +2,7 @@
 //@ compile-flags: --crate-type=lib -Cinstrument-coverage  -Zno-profiler-runtime
 //@[allow] check-pass
 
-#![feature(staged_api, rustc_allow_const_fn_unstable)]
+#![feature(staged_api, rustc_attrs)]
 #![stable(feature = "rust_test", since = "1.0.0")]
 
 #[stable(feature = "rust_test", since = "1.0.0")]

--- a/tests/ui/feature-gates/feature-gate-rustc-allow-const-fn-unstable.rs
+++ b/tests/ui/feature-gates/feature-gate-rustc-allow-const-fn-unstable.rs
@@ -1,6 +1,6 @@
 #![allow(unused_macros)]
 
-#[rustc_allow_const_fn_unstable()] //~ ERROR rustc_allow_const_fn_unstable side-steps
+#[rustc_allow_const_fn_unstable()] //~ ERROR use of an internal attribute
 const fn foo() { }
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-rustc-allow-const-fn-unstable.stderr
+++ b/tests/ui/feature-gates/feature-gate-rustc-allow-const-fn-unstable.stderr
@@ -1,12 +1,12 @@
-error[E0658]: rustc_allow_const_fn_unstable side-steps feature gating and stability checks
+error[E0658]: use of an internal attribute
   --> $DIR/feature-gate-rustc-allow-const-fn-unstable.rs:3:1
    |
 LL | #[rustc_allow_const_fn_unstable()]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #69399 <https://github.com/rust-lang/rust/issues/69399> for more information
-   = help: add `#![feature(rustc_allow_const_fn_unstable)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
+   = note: the `#[rustc_allow_const_fn_unstable]` attribute is an internal implementation detail that will never be stable
+   = note: rustc_allow_const_fn_unstable side-steps feature gating and stability checks
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/staged-api.rs
+++ b/tests/ui/traits/const-traits/staged-api.rs
@@ -5,7 +5,7 @@
 #![feature(local_feature)]
 #![feature(const_trait_impl)]
 #![feature(staged_api)]
-#![feature(rustc_allow_const_fn_unstable)]
+#![feature(rustc_attrs)]
 #![stable(feature = "rust1", since = "1.0.0")]
 
 //@ aux-build: staged-api.rs


### PR DESCRIPTION
It is already named like one, but used to have its own feature gate, which this PR now removes in favor of just using `#![feature(rustc_attrs)]`.

Most of the diff is just the line number changes in `malformed-attrs.stderr`.