### PR TITLE
Miri: recursive validity: also recurse into Boxes

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -647,13 +647,8 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
                 }
             } else {
                 // This is not CTFE, so it's Miri with recursive checking.
-                // FIXME: we do *not* check behind boxes, since creating a new box first creates it uninitialized
-                // and then puts the value in there, so briefly we have a box with uninit contents.
-                // FIXME: should we also skip `UnsafeCell` behind shared references? Currently that is not
+                // FIXME: should we also `UnsafeCell` behind shared references? Currently that is not
                 // needed since validation reads bypass Stacked Borrows and data race checks.
-                if matches!(ptr_kind, PointerKind::Box) {
-                    return interp_ok(());
-                }
             }
             let path = &self.path;
             ref_tracking.track(place, || {

--- a/src/tools/miri/tests/fail/validity/recursive-validity-box-bool.rs
+++ b/src/tools/miri/tests/fail/validity/recursive-validity-box-bool.rs
@@ -1,0 +1,8 @@
+//@compile-flags: -Zmiri-recursive-validation
+
+fn main() {
+    let x = 3u8;
+    let xref = &x;
+    let xref_wrong_type: Box<bool> = unsafe { std::mem::transmute(xref) }; //~ERROR: encountered 0x03, but expected a boolean
+    let _val = *xref_wrong_type;
+}

--- a/src/tools/miri/tests/fail/validity/recursive-validity-box-bool.stderr
+++ b/src/tools/miri/tests/fail/validity/recursive-validity-box-bool.stderr
@@ -1,0 +1,13 @@
+error: Undefined Behavior: constructing invalid value at .<deref>: encountered 0x03, but expected a boolean
+  --> tests/fail/validity/recursive-validity-box-bool.rs:LL:CC
+   |
+LL |     let xref_wrong_type: Box<bool> = unsafe { std::mem::transmute(xref) };
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Now that https://github.com/rust-lang/rust/issues/97270 is fixed, the recursive validity mode for Miri can recuse into Boxes without exploding everywhere.