### PR TITLE
Add x86_64-unknown-linux-gnu{m,t}san target which enables {M,T}San by default

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1815,6 +1815,8 @@ supported_targets! {
     ("x86_64-pc-cygwin", x86_64_pc_cygwin),
 
     ("x86_64-unknown-linux-gnuasan", x86_64_unknown_linux_gnuasan),
+    ("x86_64-unknown-linux-gnumsan", x86_64_unknown_linux_gnumsan),
+    ("x86_64-unknown-linux-gnutsan", x86_64_unknown_linux_gnutsan),
 }
 
 /// Cow-Vec-Str: Cow<'static, [Cow<'static, str>]>

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnumsan.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnumsan.rs
@@ -1,0 +1,16 @@
+use crate::spec::{SanitizerSet, Target, TargetMetadata};
+
+pub(crate) fn target() -> Target {
+    let mut base = super::x86_64_unknown_linux_gnu::target();
+    base.metadata = TargetMetadata {
+        description: Some(
+            "64-bit Linux (kernel 3.2+, glibc 2.17+) with MSAN enabled by default".into(),
+        ),
+        tier: Some(2),
+        host_tools: Some(false),
+        std: Some(true),
+    };
+    base.supported_sanitizers = SanitizerSet::MEMORY;
+    base.default_sanitizers = SanitizerSet::MEMORY;
+    base
+}

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnutsan.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnutsan.rs
@@ -1,0 +1,16 @@
+use crate::spec::{SanitizerSet, Target, TargetMetadata};
+
+pub(crate) fn target() -> Target {
+    let mut base = super::x86_64_unknown_linux_gnu::target();
+    base.metadata = TargetMetadata {
+        description: Some(
+            "64-bit Linux (kernel 3.2+, glibc 2.17+) with TSAN enabled by default".into(),
+        ),
+        tier: Some(2),
+        host_tools: Some(false),
+        std: Some(true),
+    };
+    base.supported_sanitizers = SanitizerSet::THREAD;
+    base.default_sanitizers = SanitizerSet::THREAD;
+    base
+}

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -1552,6 +1552,8 @@ fn supported_sanitizers(
             &["asan", "dfsan", "lsan", "msan", "safestack", "tsan", "rtsan"],
         ),
         "x86_64-unknown-linux-gnuasan" => common_libs("linux", "x86_64", &["asan"]),
+        "x86_64-unknown-linux-gnumsan" => common_libs("linux", "x86_64", &["msan"]),
+        "x86_64-unknown-linux-gnutsan" => common_libs("linux", "x86_64", &["tsan"]),
         "x86_64-unknown-linux-musl" => {
             common_libs("linux", "x86_64", &["asan", "lsan", "msan", "tsan"])
         }

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -37,6 +37,8 @@ pub struct Finder {
 /// when the newly-bumped stage 0 compiler now knows about the formerly-missing targets.
 const STAGE0_MISSING_TARGETS: &[&str] = &[
     // just a dummy comment so the list doesn't get onelined
+    "x86_64-unknown-linux-gnumsan",
+    "x86_64-unknown-linux-gnutsan",
 ];
 
 /// Minimum version threshold for libstdc++ required when using prebuilt LLVM

--- a/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
@@ -126,6 +126,8 @@ ENV TARGETS=$TARGETS,x86_64-unknown-uefi
 ENV TARGETS=$TARGETS,riscv64gc-unknown-linux-musl
 
 ENV TARGETS_SANITIZERS=x86_64-unknown-linux-gnuasan
+ENV TARGETS_SANITIZERS=$TARGETS_SANITIZERS,x86_64-unknown-linux-gnumsan
+ENV TARGETS_SANITIZERS=$TARGETS_SANITIZERS,x86_64-unknown-linux-gnutsan
 
 # As per https://bugs.launchpad.net/ubuntu/+source/gcc-defaults/+bug/1300211
 # we need asm in the search path for gcc-9 (for gnux32) but not in the search path of the

--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -155,5 +155,7 @@
     - [x86_64-unknown-linux-none](platform-support/x86_64-unknown-linux-none.md)
     - [x86_64-unknown-none](platform-support/x86_64-unknown-none.md)
     - [x86_64-unknown-linux-gnuasan](platform-support/x86_64-unknown-linux-gnuasan.md)
+    - [x86_64-unknown-linux-gnumsan](platform-support/x86_64-unknown-linux-gnumsan.md)
+    - [x86_64-unknown-linux-gnutsan](platform-support/x86_64-unknown-linux-gnutsan.md)
     - [xtensa-\*-none-elf](platform-support/xtensa.md)
     - [\*-nuttx-\*](platform-support/nuttx.md)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -216,6 +216,8 @@ target | std | notes
 [`x86_64-fortanix-unknown-sgx`](platform-support/x86_64-fortanix-unknown-sgx.md) | ✓ | [Fortanix ABI] for 64-bit Intel SGX
 [`x86_64-linux-android`](platform-support/android.md) | ✓ | 64-bit x86 Android
 [`x86_64-unknown-linux-gnuasan`](platform-support/x86_64-unknown-linux-gnuasan.md) | ✓ | 64-bit Linux (kernel 3.2+, glibc 2.17+) with ASAN enabled by default
+[`x86_64-unknown-linux-gnumsan`](platform-support/x86_64-unknown-linux-gnumsan.md) | ✓ | 64-bit Linux (kernel 3.2+, glibc 2.17+) with MSAN enabled by default
+[`x86_64-unknown-linux-gnutsan`](platform-support/x86_64-unknown-linux-gnutsan.md) | ✓ | 64-bit Linux (kernel 3.2+, glibc 2.17+) with TSAN enabled by default
 [`x86_64-unknown-fuchsia`](platform-support/fuchsia.md) | ✓ | 64-bit x86 Fuchsia
 `x86_64-unknown-linux-gnux32` | ✓ | 64-bit Linux (x32 ABI) (kernel 4.15+, glibc 2.27)
 [`x86_64-unknown-none`](platform-support/x86_64-unknown-none.md) | * | Freestanding/bare-metal x86_64, softfloat

--- a/src/doc/rustc/src/platform-support/x86_64-unknown-linux-gnumsan.md
+++ b/src/doc/rustc/src/platform-support/x86_64-unknown-linux-gnumsan.md
@@ -1,0 +1,56 @@
+# `x86_64-unknown-linux-gnumsan`
+
+**Tier: 2**
+
+Target mirroring `x86_64-unknown-linux-gnu` with MemorySanitizer enabled by
+default.
+The goal of this target is to allow shipping MSAN-instrumented standard
+libraries through rustup, enabling a fully instrumented binary without requiring
+nightly features (build-std).
+Once build-std stabilizes, this target is no longer needed and will be removed.
+
+## Target maintainers
+
+- [@jakos-sec](https://github.com/jakos-sec)
+- [@1c3t3a](https://github.com/1c3t3a)
+- [@rust-lang/project-exploit-mitigations][project-exploit-mitigations]
+
+## Requirements
+
+The target is for cross-compilation only. Host tools are not supported, since
+there is no need to have the host tools instrumented with MSAN. std is fully
+supported.
+
+In all other aspects the target is equivalent to `x86_64-unknown-linux-gnu`.
+
+## Building the target
+
+The target can be built by enabling it for a rustc build:
+
+```toml
+[build]
+target = ["x86_64-unknown-linux-gnumsan"]
+```
+
+## Building Rust programs
+
+Rust programs can be compiled by adding this target via rustup:
+
+```sh
+$ rustup target add x86_64-unknown-linux-gnumsan
+```
+
+and then compiling with the target:
+
+```sh
+$ rustc foo.rs --target x86_64-unknown-linux-gnumsan
+```
+
+## Testing
+
+Created binaries will run on Linux without any external requirements.
+
+## Cross-compilation toolchains and C code
+
+The target supports C code and should use the same toolchain target as
+`x86_64-unknown-linux-gnu`.

--- a/src/doc/rustc/src/platform-support/x86_64-unknown-linux-gnutsan.md
+++ b/src/doc/rustc/src/platform-support/x86_64-unknown-linux-gnutsan.md
@@ -1,0 +1,56 @@
+# `x86_64-unknown-linux-gnutsan`
+
+**Tier: 2**
+
+Target mirroring `x86_64-unknown-linux-gnu` with ThreadSanitizer enabled by
+default.
+The goal of this target is to allow shipping TSAN-instrumented standard
+libraries through rustup, enabling a fully instrumented binary without requiring
+nightly features (build-std).
+Once build-std stabilizes, this target is no longer needed and will be removed.
+
+## Target maintainers
+
+- [@jakos-sec](https://github.com/jakos-sec)
+- [@1c3t3a](https://github.com/1c3t3a)
+- [@rust-lang/project-exploit-mitigations][project-exploit-mitigations]
+
+## Requirements
+
+The target is for cross-compilation only. Host tools are not supported, since
+there is no need to have the host tools instrumented with TSAN. std is fully
+supported.
+
+In all other aspects the target is equivalent to `x86_64-unknown-linux-gnu`.
+
+## Building the target
+
+The target can be built by enabling it for a rustc build:
+
+```toml
+[build]
+target = ["x86_64-unknown-linux-gnutsan"]
+```
+
+## Building Rust programs
+
+Rust programs can be compiled by adding this target via rustup:
+
+```sh
+$ rustup target add x86_64-unknown-linux-gnutsan
+```
+
+and then compiling with the target:
+
+```sh
+$ rustc foo.rs --target x86_64-unknown-linux-gnutsan
+```
+
+## Testing
+
+Created binaries will run on Linux without any external requirements.
+
+## Cross-compilation toolchains and C code
+
+The target supports C code and should use the same toolchain target as
+`x86_64-unknown-linux-gnu`.

--- a/tests/assembly-llvm/targets/targets-elf.rs
+++ b/tests/assembly-llvm/targets/targets-elf.rs
@@ -709,6 +709,12 @@
 //@ revisions: x86_64_unknown_linux_gnuasan
 //@ [x86_64_unknown_linux_gnuasan] compile-flags: --target x86_64-unknown-linux-gnuasan
 //@ [x86_64_unknown_linux_gnuasan] needs-llvm-components: x86
+//@ revisions: x86_64_unknown_linux_gnumsan
+//@ [x86_64_unknown_linux_gnumsan] compile-flags: --target x86_64-unknown-linux-gnumsan
+//@ [x86_64_unknown_linux_gnumsan] needs-llvm-components: x86
+//@ revisions: x86_64_unknown_linux_gnutsan
+//@ [x86_64_unknown_linux_gnutsan] compile-flags: --target x86_64-unknown-linux-gnutsan
+//@ [x86_64_unknown_linux_gnutsan] needs-llvm-components: x86
 //@ revisions: x86_64_unknown_linux_musl
 //@ [x86_64_unknown_linux_musl] compile-flags: --target x86_64-unknown-linux-musl
 //@ [x86_64_unknown_linux_musl] needs-llvm-components: x86


### PR DESCRIPTION
Analogous to the ASan target (https://github.com/rust-lang/rust/pull/149644), this adds targets for MSan and TSan.

As suggested, in order to distribute sanitizer instrumented standard libraries without introducing new rustc flags, this adds a new dedicated target. With the target, we can distribute the instrumented standard libraries through a separate rustup component.

> A tier 2 target must have value to people other than its maintainers. (It may still be a niche target, but it must not be exclusively useful for an inherently closed group.)

The target is useful to anyone who wants to use MSan/TSan with a stable compiler or the ease to not have to recompiled all standard libraries for full coverage.

> A tier 2 target must have a designated team of developers (the “target maintainers”) available to consult on target-specific build-breaking issues, or if necessary to develop target-specific language or library implementation details. This team must have at least 2 developers.
> * The target maintainers should not only fix target-specific issues, but should use any such issue as an opportunity to educate the Rust community about portability to their target, and enhance documentation of the target.

I pledge myself and the folks from the Exploit Mitigations Project Group (rcvalle@ & 1c3t3a@) as target maintainers to fix target-specific issues and educate the Rust community about their use.

> The target must not place undue burden on Rust developers not specifically concerned with that target. Rust developers are expected to not gratuitously break a tier 2 target, but are not expected to become experts in every tier 2 target, and are not expected to provide target-specific implementations for every tier 2 target.

Understood. The target should not have negative impact for anyone not using it.

> The target must provide documentation for the Rust community explaining how to build for the target using cross-compilation, and explaining how to run tests for the target. If at all possible, this documentation should show how to run Rust programs and tests for the target using emulation, to allow anyone to do so. If the target cannot be feasibly emulated, the documentation should explain how to obtain and work with physical hardware, cloud systems, or equivalent.

`src/doc/rustc/src/platform-support/x86_64-unknown-linux-gnu{m,t}san.md` should provide the necessary documentation on how to build the target or compile programs with it. In the way the target can be emulated it should not differ from the tier 1 target `x86_64-unknown-linux-gnu`.

> The target must document its baseline expectations for the features or versions of CPUs, operating systems, libraries, runtime environments, and similar.

The baseline expectation mirror `x86_64-unknown-linux-gnu`.

> If introducing a new tier 2 or higher target that is identical to an existing Rust target except for the baseline expectations for the features or versions of CPUs, operating systems, libraries, runtime environments, and similar, then the proposed target must document to the satisfaction of the approving teams why the specific difference in baseline expectations provides sufficient value to justify a separate target.
> * Note that in some cases, based on the usage of existing targets within the Rust community, Rust developers or a target’s maintainers may wish to modify the baseline expectations of a target, or split an existing target into multiple targets with different baseline expectations. A proposal to do so will be treated similarly to the analogous promotion, demotion, or removal of a target, according to this policy, with the same team approvals required.
>     * For instance, if an OS version has become obsolete and unsupported, a target for that OS may raise its baseline expectations for OS version (treated as though removing a target corresponding to the older versions), or a target for that OS may split out support for older OS versions into a lower-tier target (treated as though demoting a target corresponding to the older versions, and requiring justification for a new target at a lower tier for the older OS versions).

This has been outlined sufficiently. We should not enable MSan/TSan in the default target and are therefore creating a new tier 2 target to bridge the gap until `build-std` stabilized.

> Tier 2 targets must not leave any significant portions of core or the standard library unimplemented or stubbed out, unless they cannot possibly be supported on the target.
> * The right approach to handling a missing feature from a target may depend on whether the target seems likely to develop the feature in the future. In some cases, a target may be co-developed along with Rust support, and Rust may gain new features on the target as that target gains the capabilities to support those features.
> * As an exception, a target identical to an existing tier 1 target except for lower baseline expectations for the OS, CPU, or similar, may propose to qualify as tier 2 (but not higher) without support for std if the target will primarily be used in no_std applications, to reduce the support burden for the standard library. In this case, evaluation of the proposed target’s value will take this limitation into account.

All of std that is supported by `x86_64-unknown-linux-gnu` is also supported.

> The code generation backend for the target should not have deficiencies that invalidate Rust safety properties, as evaluated by the Rust compiler team. (This requirement does not apply to arbitrary security enhancements or mitigations provided by code generation backends, only to those properties needed to ensure safe Rust code cannot cause undefined behavior or other unsoundness.) If this requirement does not hold, the target must clearly and prominently document any such limitations as part of the target’s entry in the target tier list, and ideally also via a failing test in the testsuite. The Rust compiler team must be satisfied with the balance between these limitations and the difficulty of implementing the necessary features.
> * For example, if Rust relies on a specific code generation feature to ensure that safe code cannot overflow the stack, the code generation for the target should support that feature.
> * If the Rust compiler introduces new safety properties (such as via new capabilities of a compiler backend), the Rust compiler team will determine if they consider those new safety properties a best-effort improvement for specific targets, or a required property for all Rust targets. In the latter case, the compiler team may require the maintainers of existing targets to either implement and confirm support for the property or update the target tier list with documentation of the missing property.

The entire point is to have more security instead of less ;) The safety properties provided are already present in the compiler, just not enabled by default.

> If the target supports C code, and the target has an interoperable calling convention for C code, the Rust target must support that C calling convention for the platform via extern "C". The C calling convention does not need to be the default Rust calling convention for the target, however.

Understood.

> The target must build reliably in CI, for all components that Rust’s CI considers mandatory.

Understood and the reason for introducing the tier 2 target.

> The approving teams may additionally require that a subset of tests pass in CI, such as enough to build a functional “hello world” program, ./x.py test --no-run, or equivalent “smoke tests”. In particular, this requirement may apply if the target builds host tools, or if the tests in question provide substantial value via early detection of critical problems.

Understood.

> Building the target in CI must not take substantially longer than the current slowest target in CI, and should not substantially raise the maintenance burden of the CI infrastructure. This requirement is subjective, to be evaluated by the infrastructure team, and will take the community importance of the target into account.

Understood.

> Tier 2 targets should, if at all possible, support cross-compiling. Tier 2 targets should not require using the target as the host for builds, even if the target supports host tools.

Understood. No need to use this target as the host (no benefit of having MSan/TSan enabled for compiling).

> In addition to the legal requirements for all targets (specified in the tier 3 requirements), because a tier 2 target typically involves the Rust project building and supplying various compiled binaries, incorporating the target and redistributing any resulting compiled binaries (e.g. built libraries, host tools if any) must not impose any onerous license requirements on any members of the Rust project, including infrastructure team members and those operating CI systems. This is a subjective requirement, to be evaluated by the approving teams.
> * As an exception to this, if the target’s primary purpose is to build components for a Free and Open Source Software (FOSS) project licensed under “copyleft” terms (terms which require licensing other code under compatible FOSS terms), such as kernel modules or plugins, then the standard libraries for the target may potentially be subject to copyleft terms, as long as such terms are satisfied by Rust’s existing practices of providing full corresponding source code. Note that anything added to the Rust repository itself must still use Rust’s standard license terms.

Understood, no legal differences between this target and `x86_64-unknown-linux-gnu`.

> Tier 2 targets must not impose burden on the authors of pull requests, or other developers in the community, to ensure that tests pass for the target. In particular, do not post comments (automated or manual) on a PR that derail or suggest a block on the PR based on tests failing for the target. Do not send automated messages or notifications (via any medium, including via @) to a PR author or others involved with a PR regarding the PR breaking tests on a tier 2 target, unless they have opted into such messages.
> * Backlinks such as those generated by the issue/PR tracker when linking to an issue or PR are not considered a violation of this policy, within reason. However, such messages (even on a separate repository) must not generate notifications to anyone involved with a PR who has not requested such notifications.

Understood.

> The target maintainers should regularly run the testsuite for the target, and should fix any test failures in a reasonably timely fashion.

Understood.

> All requirements for tier 3 apply.

Requirements for tier 3 are listed below.

> A tier 3 target must have a designated developer or developers (the "target maintainers") on record to be CCed when issues arise regarding the target. (The mechanism to track and CC such developers may evolve over time.)

I pledge to do my best maintaining it and we can also include the folks from the Exploit Mitigations Project Group (rcvalle@ & 1c3t3a@).

> Targets must use naming consistent with any existing targets; for instance, a target for the same CPU or OS as an existing Rust target should use the same name for that CPU or OS. Targets should normally use the same names and naming conventions as used elsewhere in the broader ecosystem beyond Rust (such as in other toolchains), unless they have a very good reason to diverge. Changing the name of a target can be highly disruptive, especially once the target reaches a higher tier, so getting the name right is important even for a tier 3 target.

We've chosen `x86_64-unknown-linux-gnu{m,t}san` as the name which was suggested on [#t-compiler/major changes > Create new Tier 2 targets with sanitizers… compiler-team#951 @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/233931-t-compiler.2Fmajor-changes/topic/Create.20new.20Tier.202.20targets.20with.20sanitizers.E2.80.A6.20compiler-team.23951/near/564482315). We've merged `x86_64-unknown-linux-gnuasan` and are now following up with the MSan and TSan targets

> Target names should not introduce undue confusion or ambiguity unless absolutely necessary to maintain ecosystem compatibility. For example, if the name of the target makes people extremely likely to form incorrect beliefs about what it targets, the name should be changed or augmented to disambiguate it.

There should be no confusion, it's clear that it's the original target with MSan/TSan enabled.

> If possible, use only letters, numbers, dashes and underscores for the name. Periods (.) are known to cause issues in Cargo.

Only letters, numbers and dashes used.

> Tier 3 targets may have unusual requirements to build or use, but must not create legal issues or impose onerous legal terms for the Rust project or for Rust developers or users.

There are no unusual requirements to build or use it. It's the original `x86_64-unknown-linux-gnu` target with MSan/TSan enabled as a default sanitizer.

> The target must not introduce license incompatibilities.

There are no license implications.

> Anything added to the Rust repository must be under the standard Rust license (MIT OR Apache-2.0).

Given, by reusing the existing MSan/TSan code.

> The target must not cause the Rust tools or libraries built for any other host (even when supporting cross-compilation to the target) to depend on any new dependency less permissive than the Rust licensing policy. This applies whether the dependency is a Rust crate that would require adding new license exceptions (as specified by the tidy tool in the rust-lang/rust repository), or whether the dependency is a native library or binary. In other words, the introduction of the target must not cause a user installing or running a version of Rust or the Rust tools to be subject to any new license requirements.

There are no new dependencies/features required.

> Compiling, linking, and emitting functional binaries, libraries, or other code for the target (whether hosted on the target itself or cross-compiling from another target) must not depend on proprietary (non-FOSS) libraries. Host tools built for the target itself may depend on the ordinary runtime libraries supplied by the platform and commonly used by other applications built for the target, but those libraries must not be required for code generation for the target; cross-compilation to the target must not require such libraries at all. For instance, rustc built for the target may depend on a common proprietary C runtime library or console output library, but must not depend on a proprietary code generation library or code optimization library. Rust's license permits such combinations, but the Rust project has no interest in maintaining such combinations within the scope of Rust itself, even at tier 3.

It's using open source tools only.

> "onerous" here is an intentionally subjective term. At a minimum, "onerous" legal/licensing terms include but are not limited to: non-disclosure requirements, non-compete requirements, contributor license agreements (CLAs) or equivalent, "non-commercial"/"research-only"/etc terms, requirements conditional on the employer or employment of any particular Rust developers, revocable terms, any requirements that create liability for the Rust project or its developers or users, or any requirements that adversely affect the livelihood or prospects of the Rust project or its developers or users.

There are no such terms present.

> Neither this policy nor any decisions made regarding targets shall create any binding agreement or estoppel by any party. If any member of an approving Rust team serves as one of the maintainers of a target, or has any legal or employment requirement (explicit or implicit) that might affect their decisions regarding a target, they must recuse themselves from any approval decisions regarding the target's tier status, though they may otherwise participate in discussions.

Understood.

> This requirement does not prevent part or all of this policy from being cited in an explicit contract or work agreement (e.g. to implement or maintain support for a target). This requirement exists to ensure that a developer or team responsible for reviewing and approving a target does not face any legal threats or obligations that would prevent them from freely exercising their judgment in such approval, even if such judgment involves subjective matters or goes beyond the letter of these requirements.

Understood.

> Tier 3 targets should attempt to implement as much of the standard libraries as possible and appropriate (core for most targets, alloc for targets that can support dynamic memory allocation, std for targets with an operating system or equivalent layer of system-provided functionality), but may leave some code unimplemented (either unavailable or stubbed out as appropriate), whether because the target makes it impossible to implement or challenging to implement. The authors of pull requests are not obligated to avoid calling any portions of the standard library on the basis of a tier 3 target not implementing those portions.

The goal is to have MSan/TSan instrumented standard library variants of the existing `x86_64-unknown-linux-gnu` target, so all should be present.

> The target must provide documentation for the Rust community explaining how to build for the target, using cross-compilation if possible. If the target supports running binaries, or running tests (even if they do not pass), the documentation must explain how to run such binaries or tests for the target, using emulation if possible or dedicated hardware if necessary.

I think the explanation in platform support doc is enough to make this aspect clear.

> Tier 3 targets must not impose burden on the authors of pull requests, or other developers in the community, to maintain the target. In particular, do not post comments (automated or manual) on a PR that derail or suggest a block on the PR based on a tier 3 target. Do not send automated messages or notifications (via any medium, including via @) to a PR author or others involved with a PR regarding a tier 3 target, unless they have opted into such messages.
Backlinks such as those generated by the issue/PR tracker when linking to an issue or PR are not considered a violation of this policy, within reason. However, such messages (even on a separate repository) must not generate notifications to anyone involved with a PR who has not requested such notifications.

Understood.

> Patches adding or updating tier 3 targets must not break any existing tier 2 or tier 1 target, and must not knowingly break another tier 3 target without approval of either the compiler team or the maintainers of the other tier 3 target.

Understood.

> In particular, this may come up when working on closely related targets, such as variations of the same architecture with different features. Avoid introducing unconditional uses of features that another variation of the target may not have; use conditional compilation or runtime detection, as appropriate, to let each target run code supported by that target.

I don't believe this PR is affected by this.

> Tier 3 targets must be able to produce assembly using at least one of rustc's supported backends from any host target. (Having support in a fork of the backend is not sufficient, it must be upstream.)

The target should work on all rustc versions that correctly compile for `x86_64-unknown-linux-gnu`.


<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
