### PR TITLE
carryless_mul: mention the base

### DIFF
--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -487,8 +487,8 @@ macro_rules! uint_impl {
 
         /// Performs a carry-less multiplication, returning the lower bits.
         ///
-        /// This operation is similar to long multiplication, except that exclusive or is used
-        /// instead of addition. The implementation is equivalent to:
+        /// This operation is similar to long multiplication in base 2, except that exclusive or is
+        /// used instead of addition. The implementation is equivalent to:
         ///
         /// ```no_run
         #[doc = concat!("pub fn carryless_mul(lhs: ", stringify!($SelfT), ", rhs: ", stringify!($SelfT), ") -> ", stringify!($SelfT), "{")]


### PR DESCRIPTION
Arithmetic operations do not typically care about the base that is used to represent numbers, but this one does. Mentioning that makes it easier to understand the operation, I think.

Cc @folkertdev 