### PR TITLE
Fix incorrect target in aarch64-unknown-linux-gnu docs

### DIFF
--- a/src/doc/rustc/src/platform-support/aarch64-unknown-linux-gnu.md
+++ b/src/doc/rustc/src/platform-support/aarch64-unknown-linux-gnu.md
@@ -29,7 +29,7 @@ If cross-compiling, make sure your C compiler is included in `$PATH`, then add i
 `bootstrap.toml`:
 
 ```toml
-[target.aarch64-unknown-linux-musl]
+[target.aarch64-unknown-linux-gnu]
 cc = "aarch64-linux-gnu-gcc"
 cxx = "aarch64-linux-gnu-g++"
 ar = "aarch64-linux-gnu-ar"


### PR DESCRIPTION
Very minor thing, but the target should be `-gnu` instead of `-musl`. 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
