### PR TITLE
Do no add -no-pie on Windows

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -527,7 +527,8 @@ impl<'a> Linker for GccLinker<'a> {
     ) {
         match output_kind {
             LinkOutputKind::DynamicNoPicExe => {
-                if !self.is_ld && self.is_gnu {
+                // noop on windows w/ gcc, warning w/ clang
+                if !self.is_ld && self.is_gnu && !self.sess.target.is_like_windows {
                     self.cc_arg("-no-pie");
                 }
             }


### PR DESCRIPTION
Windows binaries are always position independent and Clang warns when trying to enable or disable that:
```
❯ clang hello.c -pie
clang: warning: argument unused during compilation: '-pie' [-Wunused-command-line-argument]

❯ clang hello.c -no-pie
clang: warning: argument unused during compilation: '-no-pie' [-Wunused-command-line-argument]
```

https://github.com/rust-lang/rust/pull/149937 will turn these warnings into build errors:
```
❯ cargo rustc -- -D linker-messages
   Compiling hello v0.1.0 (E:\tmp\hello)
error: linker stderr: x86_64-w64-mingw32-clang: argument unused during compilation: '-nolibc' [-Wunused-command-line-argument]␍
       x86_64-w64-mingw32-clang: argument unused during compilation: '-no-pie' [-Wunused-command-line-argument]␍

  |
  = note: requested on the command line with `-D linker-messages`

error: could not compile `hello` (bin "hello") due to 1 previous error
```