### PR TITLE
Fix ICE in `try_to_raw_bytes` when array elements have mismatched

### DIFF
--- a/tests/ui/const-generics/mgca/array_elem_type_mismatch.rs
+++ b/tests/ui/const-generics/mgca/array_elem_type_mismatch.rs
@@ -1,0 +1,10 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/152683>
+#![expect(incomplete_features)]
+#![feature(adt_const_params, generic_const_parameter_types, min_generic_const_args)]
+fn foo<const N: usize, const A: [u8; N]>() {}
+
+fn main() {
+    foo::<_, { [0, 1u8, 2u32, 8u64] }>();
+    //~^ ERROR the constant `2` is not of type `u8`
+    //~| ERROR the constant `8` is not of type `u8`
+}

--- a/tests/ui/const-generics/mgca/array_elem_type_mismatch.stderr
+++ b/tests/ui/const-generics/mgca/array_elem_type_mismatch.stderr
@@ -1,0 +1,14 @@
+error: the constant `2` is not of type `u8`
+  --> $DIR/array_elem_type_mismatch.rs:7:16
+   |
+LL |     foo::<_, { [0, 1u8, 2u32, 8u64] }>();
+   |                ^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `u32`
+
+error: the constant `8` is not of type `u8`
+  --> $DIR/array_elem_type_mismatch.rs:7:16
+   |
+LL |     foo::<_, { [0, 1u8, 2u32, 8u64] }>();
+   |                ^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `u64`
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/const-generics/mgca/wrapped_array_elem_type_mismatch.rs
+++ b/tests/ui/const-generics/mgca/wrapped_array_elem_type_mismatch.rs
@@ -1,0 +1,10 @@
+#![expect(incomplete_features)]
+#![feature(adt_const_params, min_generic_const_args)]
+
+struct ArrWrap<const N: [u8; 1]>;
+
+fn main() {
+    let _: ArrWrap<{ [1_u8] }> = ArrWrap::<{ [1_u16] }>;
+    //~^ ERROR: mismatched types
+    //~| ERROR the constant `1` is not of type `u8`
+}

--- a/tests/ui/const-generics/mgca/wrapped_array_elem_type_mismatch.stderr
+++ b/tests/ui/const-generics/mgca/wrapped_array_elem_type_mismatch.stderr
@@ -1,0 +1,20 @@
+error[E0308]: mismatched types
+  --> $DIR/wrapped_array_elem_type_mismatch.rs:7:34
+   |
+LL |     let _: ArrWrap<{ [1_u8] }> = ArrWrap::<{ [1_u16] }>;
+   |            -------------------   ^^^^^^^^^^^^^^^^^^^^^^ expected `*b"\x01"`, found `[1]`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `ArrWrap<*b"\x01">`
+              found struct `ArrWrap<[1]>`
+
+error: the constant `1` is not of type `u8`
+  --> $DIR/wrapped_array_elem_type_mismatch.rs:7:46
+   |
+LL |     let _: ArrWrap<{ [1_u8] }> = ArrWrap::<{ [1_u16] }>;
+   |                                              ^^^^^^^ expected `u8`, found `u16`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
close: rust-lang/rust#152683

After rust-lang/rust#152001, suffixed integer literals preserve their own type during const lowering, so `try_to_raw_bytes` could call `.to_u8()` on a scalar with size > 1, causing an ICE. Fix by using `try_to_bits(Size::from_bytes(1)).ok()` instead.

r? BoxyUwU
