### PR TITLE
Avoid delayed-bug ICE for malformed diagnostic attrs

### DIFF
--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -522,6 +522,13 @@ impl<'a, 'sess> MetaItemListParserContext<'a, 'sess> {
             return self.parser.dcx().create_err(err);
         }
 
+        if let ShouldEmit::ErrorsAndLints { recovery: Recovery::Forbidden } = self.should_emit {
+            // Do not attempt to suggest anything in `Recovery::Forbidden` mode.
+            // Malformed diagnostic-attr arguments that start with an `if` expression can lead to
+            // an ICE (https://github.com/rust-lang/rust/issues/152744), because callers may cancel the `InvalidMetaItem` error.
+            return self.parser.dcx().create_err(err);
+        }
+
         // Suggest quoting idents, e.g. in `#[cfg(key = value)]`. We don't use `Token::ident` and
         // don't `uninterpolate` the token to avoid suggesting anything butchered or questionable
         // when macro metavariables are involved.

--- a/tests/ui/diagnostic_namespace/do_not_recommend/malformed-diagnostic-attributes-if-expression.rs
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/malformed-diagnostic-attributes-if-expression.rs
@@ -1,0 +1,10 @@
+//@ check-pass
+//@ reference: attributes.diagnostic.do_not_recommend.syntax
+
+trait Foo {}
+
+#[diagnostic::do_not_recommend(if not_accepted)]
+//~^ WARNING `#[diagnostic::do_not_recommend]` does not expect any arguments
+impl Foo for () {}
+
+fn main() {}

--- a/tests/ui/diagnostic_namespace/do_not_recommend/malformed-diagnostic-attributes-if-expression.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/malformed-diagnostic-attributes-if-expression.stderr
@@ -1,0 +1,10 @@
+warning: `#[diagnostic::do_not_recommend]` does not expect any arguments
+  --> $DIR/malformed-diagnostic-attributes-if-expression.rs:6:1
+   |
+LL | #[diagnostic::do_not_recommend(if not_accepted)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(malformed_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#152744

Skip suggestions in `expected_lit` when parsing with `Recovery::Forbidden`, since this may later cancel `InvalidMetaItem`. This avoids creating delayed bugs that can be promoted to ICE.