### PR TITLE
interpret: fix comment typo

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -647,8 +647,9 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
                 }
             } else {
                 // This is not CTFE, so it's Miri with recursive checking.
-                // FIXME: should we also `UnsafeCell` behind shared references? Currently that is not
-                // needed since validation reads bypass Stacked Borrows and data race checks.
+                // FIXME: should we skip `UnsafeCell` behind shared references? Currently that is
+                // not needed since validation reads bypass Stacked Borrows and data race checks,
+                // but is that really coherent?
             }
             let path = &self.path;
             ref_tracking.track(place, || {


### PR DESCRIPTION
Pointed out in https://github.com/rust-lang/rust/pull/152756#pullrequestreview-3819458236 after that PR already had been rolled up.