### PR TITLE
Checking for metadata before `check_wide_ptr_meta`

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -728,7 +728,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
             }
             ty::RawPtr(..) => {
                 let place = self.deref_pointer(value, ExpectedKind::RawPtr)?;
-                if place.layout.is_unsized() {
+                if place.layout.is_unsized() && place.meta().has_meta() {
                     self.check_wide_ptr_meta(place.meta(), place.layout)?;
                 }
                 interp_ok(true)

--- a/tests/ui/unsized/ice-thin-ptr-to-unsized-projection.rs
+++ b/tests/ui/unsized/ice-thin-ptr-to-unsized-projection.rs
@@ -1,0 +1,5 @@
+// regression test for <https://github.com/rust-lang/rust/issues/152682>
+struct Foo<'a>(<& /*'a*/ [fn()] as core::ops::Deref>::Target); // adding the lifetime solves the ice
+             //~^ ERROR: missing lifetime specifier [E0106]
+const _: *const Foo = 0 as _;
+fn main() {}

--- a/tests/ui/unsized/ice-thin-ptr-to-unsized-projection.stderr
+++ b/tests/ui/unsized/ice-thin-ptr-to-unsized-projection.stderr
@@ -1,0 +1,14 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/ice-thin-ptr-to-unsized-projection.rs:2:17
+   |
+LL | struct Foo<'a>(<& /*'a*/ [fn()] as core::ops::Deref>::Target); // adding the lifetime solves the ice
+   |                 ^ expected named lifetime parameter
+   |
+help: consider using the `'a` lifetime
+   |
+LL | struct Foo<'a>(<&'a  /*'a*/ [fn()] as core::ops::Deref>::Target); // adding the lifetime solves the ice
+   |                  ++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0106`.


### PR DESCRIPTION
Fixes: rust-lang/rust#152682 .

In this edge case where `unsized` != `has_meta`, I'm split at the moment whether it's due to typeck... will investigate a little bit.

Also, note that `check_wide_ptr_meta` is used in similar ways elsewhere, e.g., [here](https://github.com/rust-lang/rust/blob/c043085801b7a884054add21a94882216df5971c/compiler/rustc_const_eval/src/interpret/validity.rs#L489-L491).