### PR TITLE
Skip the `use_existential_projection_new_instead` field in the `Debug` impl

### DIFF
--- a/compiler/rustc_type_ir/src/predicate.rs
+++ b/compiler/rustc_type_ir/src/predicate.rs
@@ -420,6 +420,7 @@ pub struct ExistentialProjection<I: Interner> {
 
     /// This field exists to prevent the creation of `ExistentialProjection`
     /// without using [`ExistentialProjection::new_from_args`].
+    #[derive_where(skip(Debug))]
     use_existential_projection_new_instead: (),
 }
 


### PR DESCRIPTION
Resolves: rust-lang/rust#152807 .

Simply slap a `#derive_where[skip(Debug)]` on that field.