### PR TITLE
Add CURRENT_RUSTC_VERSION support for Clippy

### DIFF
--- a/src/tools/replace-version-placeholder/src/main.rs
+++ b/src/tools/replace-version-placeholder/src/main.rs
@@ -15,6 +15,7 @@ fn main() {
             &root_path.join("library"),
             &root_path.join("src/doc/rustc"),
             &root_path.join("src/doc/rustdoc"),
+            &root_path.join("src/tools/clippy"),
         ],
         |path, _is_dir| filter_dirs(path),
         &mut |entry, contents| {


### PR DESCRIPTION
We've been talking about this since Sept. 2022, finally decided to add the dreaded 1-line diff.

cc https://rust-lang.zulipchat.com/#narrow/channel/257328-clippy/topic/Using.20CURRENT_RUSTC_VERSION.20in.20clippy.3A.3Aversion.3F/with/516468805

cc https://rust-lang.zulipchat.com/#narrow/channel/257328-clippy/topic/Use.20CURRENT_RUSTC_VERSION.20for.20version.20attribute/with/299900715

Overrides the currently unmerged rust-lang/rust-clippy#14299

cc @rust-lang/clippy

---

This PR does not modify in any way the needed behaviour of T-Release when releasing (I hope)

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
