### PR TITLE
explicitly show behavior of <_>::assoc_fn

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -890,7 +890,20 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
             | ty::Tuple(..) => {
                 self.assemble_inherent_candidates_for_incoherent_ty(raw_self_ty, receiver_steps)
             }
-            _ => {}
+            ty::Alias(..)
+            | ty::Bound(..)
+            | ty::Closure(..)
+            | ty::Coroutine(..)
+            | ty::CoroutineClosure(..)
+            | ty::CoroutineWitness(..)
+            | ty::Dynamic(..)
+            | ty::Error(..)
+            | ty::FnDef(..)
+            | ty::FnPtr(..)
+            | ty::Infer(..)
+            | ty::Pat(..)
+            | ty::Placeholder(..)
+            | ty::UnsafeBinder(..) => {}
         }
     }
 


### PR DESCRIPTION
Inspired by a conversation with @lcnr about type relative name resolution.

From lcnr:

> and i hate the fact that this match isn't exhaustive (hiding the behavior for `<_>::assoc_fn` https://github.com/rust-lang/rust/blob/13c38730d981289cc7ae4cc109fd7756bf83ee67/compiler/rustc_hir_typeck/src/method/probe.rs#L893

This PR changes that match to be exhaustive.