### PR TITLE
Allow forbidden target features to be hard errors

### DIFF
--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -1220,14 +1220,17 @@ pub(crate) struct UnstableCTargetFeature<'a> {
 
 #[derive(Diagnostic)]
 #[diag("target feature `{$feature}` cannot be {$enabled} with `-Ctarget-feature`: {$reason}")]
-#[note(
-    "this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!"
-)]
-#[note("for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>")]
 pub(crate) struct ForbiddenCTargetFeature<'a> {
     pub feature: &'a str,
     pub enabled: &'a str,
     pub reason: &'a str,
+    #[note(
+        "this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!"
+    )]
+    #[note(
+        "for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>"
+    )]
+    pub future_compat_note: bool,
 }
 
 pub(crate) struct TargetFeatureDisableOrEnable<'a> {

--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -308,12 +308,19 @@ pub fn cfg_target_feature<'a, const N: usize>(
                     sess.dcx().emit_warn(unknown_feature);
                 }
                 Some((_, stability, _)) => {
-                    if let Err(reason) = stability.toggle_allowed() {
-                        sess.dcx().emit_warn(errors::ForbiddenCTargetFeature {
+                    if let Stability::Forbidden { reason, hard_error } = stability {
+                        let diag = errors::ForbiddenCTargetFeature {
                             feature: base_feature,
                             enabled: if enable { "enabled" } else { "disabled" },
                             reason,
-                        });
+                            future_compat_note: !hard_error,
+                        };
+
+                        if *hard_error {
+                            sess.dcx().emit_err(diag);
+                        } else {
+                            sess.dcx().emit_warn(diag);
+                        }
                     } else if stability.requires_nightly(/* in_cfg */ false).is_some() {
                         // An unstable feature. Warn about using it. It makes little sense
                         // to hard-error here since we just warn about fully unknown

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -35,7 +35,12 @@ pub enum Stability {
     /// set in the target spec. It is never set in `cfg(target_feature)`. Used in
     /// particular for features are actually ABI configuration flags (not all targets are as nice as
     /// RISC-V and have an explicit way to set the ABI separate from target features).
-    Forbidden { reason: &'static str },
+    Forbidden {
+        reason: &'static str,
+        /// True if this is always an error, false if this can be reported as a warning when set via
+        /// `-Ctarget-feature`.
+        hard_error: bool,
+    },
 }
 use Stability::*;
 
@@ -85,14 +90,14 @@ impl Stability {
     }
 
     /// Returns whether the feature may be toggled via `#[target_feature]` or `-Ctarget-feature`.
-    /// (It might still be nightly-only even if this returns `true`, so make sure to also check
+    /// (It might still be nightly-only even if this returns `Ok(())`, so make sure to also check
     /// `requires_nightly`.)
     pub fn toggle_allowed(&self) -> Result<(), &'static str> {
         match self {
             Stability::Unstable(_)
             | Stability::CfgStableToggleUnstable(_)
             | Stability::Stable { .. } => Ok(()),
-            Stability::Forbidden { reason } => Err(reason),
+            Stability::Forbidden { reason, hard_error: _ } => Err(reason),
         }
     }
 }
@@ -149,7 +154,10 @@ static ARM_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     ("aes", Unstable(sym::arm_target_feature), &["neon"]),
     (
         "atomics-32",
-        Stability::Forbidden { reason: "unsound because it changes the ABI of atomic operations" },
+        Stability::Forbidden {
+            reason: "unsound because it changes the ABI of atomic operations",
+            hard_error: false,
+        },
         &[],
     ),
     ("crc", Unstable(sym::arm_target_feature), &[]),
@@ -225,7 +233,11 @@ static AARCH64_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     // FEAT_FLAGM2
     ("flagm2", Unstable(sym::aarch64_unstable_target_feature), &[]),
     // We forbid directly toggling just `fp-armv8`; it must be toggled with `neon`.
-    ("fp-armv8", Stability::Forbidden { reason: "Rust ties `fp-armv8` to `neon`" }, &[]),
+    (
+        "fp-armv8",
+        Stability::Forbidden { reason: "Rust ties `fp-armv8` to `neon`", hard_error: false },
+        &[],
+    ),
     // FEAT_FP8
     ("fp8", Unstable(sym::aarch64_unstable_target_feature), &["faminmax", "lut", "bf16"]),
     // FEAT_FP8DOT2
@@ -288,7 +300,11 @@ static AARCH64_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     ("rcpc3", Unstable(sym::aarch64_unstable_target_feature), &["rcpc2"]),
     // FEAT_RDM
     ("rdm", Stable, &["neon"]),
-    ("reserve-x18", Forbidden { reason: "use `-Zfixed-x18` compiler flag instead" }, &[]),
+    (
+        "reserve-x18",
+        Forbidden { reason: "use `-Zfixed-x18` compiler flag instead", hard_error: false },
+        &[],
+    ),
     // FEAT_SB
     ("sb", Stable, &[]),
     // FEAT_SHA1 & FEAT_SHA256
@@ -467,17 +483,26 @@ static X86_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     ("rdseed", Stable, &[]),
     (
         "retpoline-external-thunk",
-        Stability::Forbidden { reason: "use `-Zretpoline-external-thunk` compiler flag instead" },
+        Stability::Forbidden {
+            reason: "use `-Zretpoline-external-thunk` compiler flag instead",
+            hard_error: false,
+        },
         &[],
     ),
     (
         "retpoline-indirect-branches",
-        Stability::Forbidden { reason: "use `-Zretpoline` compiler flag instead" },
+        Stability::Forbidden {
+            reason: "use `-Zretpoline` compiler flag instead",
+            hard_error: false,
+        },
         &[],
     ),
     (
         "retpoline-indirect-calls",
-        Stability::Forbidden { reason: "use `-Zretpoline` compiler flag instead" },
+        Stability::Forbidden {
+            reason: "use `-Zretpoline` compiler flag instead",
+            hard_error: false,
+        },
         &[],
     ),
     ("rtm", Unstable(sym::rtm_target_feature), &[]),
@@ -485,7 +510,11 @@ static X86_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     ("sha512", Stable, &["avx2"]),
     ("sm3", Stable, &["avx"]),
     ("sm4", Stable, &["avx2"]),
-    ("soft-float", Stability::Forbidden { reason: "use a soft-float target instead" }, &[]),
+    (
+        "soft-float",
+        Stability::Forbidden { reason: "use a soft-float target instead", hard_error: false },
+        &[],
+    ),
     ("sse", Stable, &[]),
     ("sse2", Stable, &["sse"]),
     ("sse3", Stable, &["sse2"]),
@@ -615,7 +644,10 @@ static RISCV_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     ("f", Unstable(sym::riscv_target_feature), &["zicsr"]),
     (
         "forced-atomics",
-        Stability::Forbidden { reason: "unsound because it changes the ABI of atomic operations" },
+        Stability::Forbidden {
+            reason: "unsound because it changes the ABI of atomic operations",
+            hard_error: false,
+        },
         &[],
     ),
     ("m", Stable, &[]),
@@ -872,7 +904,7 @@ const IBMZ_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     ("miscellaneous-extensions-3", Stable, &[]),
     ("miscellaneous-extensions-4", Stable, &[]),
     ("nnp-assist", Stable, &["vector"]),
-    ("soft-float", Forbidden { reason: "unsupported ABI-configuration feature" }, &[]),
+    ("soft-float", Forbidden { reason: "unsupported ABI-configuration feature", hard_error: false }, &[]),
     ("transactional-execution", Unstable(sym::s390x_target_feature), &[]),
     ("vector", Stable, &[]),
     ("vector-enhancements-1", Stable, &["vector"]),
@@ -924,7 +956,11 @@ static AVR_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     ("rmw", Unstable(sym::avr_target_feature), &[]),
     ("spm", Unstable(sym::avr_target_feature), &[]),
     ("spmx", Unstable(sym::avr_target_feature), &[]),
-    ("sram", Forbidden { reason: "devices that have no SRAM are unsupported" }, &[]),
+    (
+        "sram",
+        Forbidden { reason: "devices that have no SRAM are unsupported", hard_error: false },
+        &[],
+    ),
     ("tinyencoding", Unstable(sym::avr_target_feature), &[]),
     // tidy-alphabetical-end
 ];


### PR DESCRIPTION
Sometimes when adding a new target features to the list of known target features, we want to completely forbid them from being used because they are ABI affecting and should be target modifiers instead. As such, we want to issue an error rather than a warning since there are no future compatibility concerns .

r? @workingjubilee since you're familiar with the motivating case in rust-lang/rust#136597 

If I rebase that PR on top of this locally, then we get the following error messages when trying to activate the SLS target feature (note that they are *errors* not *warnings* and we've omitted the usual note about future compatibility):

```
error: target feature `harden-sls-ijmp` cannot be enabled with `-Ctarget-feature`: use `harden-sls` compiler flag instead

error: target feature `harden-sls-ret` cannot be enabled with `-Ctarget-feature`: use `harden-sls` compiler flag instead

error: aborting due to 2 previous errors
```