### PR TITLE
Enable "View all comments" link feature in `triagebot.toml`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1678,3 +1678,7 @@ labels = ["S-waiting-on-concerns"]
 # since the review
 # Documentation at: https://forge.rust-lang.org/triagebot/review-changes-since.html
 [review-changes-since]
+
+# Adds a "View all comments" link on the issue/PR body that shows all the comments of it
+# Documentation at: https://forge.rust-lang.org/triagebot/view-all-comments-link.html
+[view-all-comments-link]


### PR DESCRIPTION
This PR enables triagebot "View all comments" link feature.

Documentation: https://forge.rust-lang.org/triagebot/view-all-comments-link.html

Example for this PR: [View all comments](https://triage.rust-lang.org/gh-comments/rust-lang/rust/issues/152824)

<!-- homu-ignore:start -->
r? @Kobzol 
<!-- homu-ignore:end -->
