### PR TITLE
Support if-let-guard in `matches!` and `assert_matches!`

### DIFF
--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -192,6 +192,30 @@ pub macro assert_matches {
             }
         }
     },
+    ($left:expr, $(|)? $( $pattern:pat_param )|+ $( if let $($let_guards: tt)+ )? $(,)?) => {
+        match $left {
+            $( $pattern )|+ $( if let $($let_guards)+ )? => {}
+            ref left_val => {
+                $crate::panicking::assert_matches_failed(
+                    left_val,
+                    $crate::stringify!($($pattern)|+ $(if let $($let_guards)+)?),
+                    $crate::option::Option::None
+                );
+            }
+        }
+    },
+    ($left:expr, $(|)? $( $pattern:pat_param )|+ $( if let $($let_guards: tt)+ )?, $($arg:tt)+) => {
+        match $left {
+            $( $pattern )|+ $( if let $($let_guards)+ )? => {}
+            ref left_val => {
+                $crate::panicking::assert_matches_failed(
+                    left_val,
+                    $crate::stringify!($($pattern)|+ $(if let $($let_guards)+)?),
+                    $crate::option::Option::Some($crate::format_args!($($arg)+))
+                );
+            }
+        }
+    },
 }
 
 /// Selects code at compile-time based on `cfg` predicates.
@@ -432,6 +456,13 @@ macro_rules! matches {
         #[allow(non_exhaustive_omitted_patterns)]
         match $expression {
             $pattern $(if $guard)? => true,
+            _ => false
+        }
+    };
+    ($expression:expr, $pattern:pat $(if let $($let_guards:tt)+)? $(,)?) => {
+        #[allow(non_exhaustive_omitted_patterns)]
+        match $expression {
+            $pattern $(if let $($let_guards)+)? => true,
             _ => false
         }
     };

--- a/library/coretests/tests/macros.rs
+++ b/library/coretests/tests/macros.rs
@@ -45,6 +45,16 @@ fn matches_leading_pipe() {
 }
 
 #[test]
+fn matches_if_let_guard() {
+    use std::assert_matches;
+
+    assert!(
+        matches!(Some(Some(2_i32)), Some(inner) if let Some(value) = inner && value.pow(2) == 4)
+    );
+    assert_matches!(Some(Some(2_i32)), Some(inner) if let Some(value) = inner && value.pow(2) == 4);
+}
+
+#[test]
 fn cfg_select_basic() {
     cfg_select! {
         target_pointer_width = "64" => { fn f0_() -> bool { true }}


### PR DESCRIPTION
Closes rust-lang/rust#152313, and if-let-guard is stabilized in rust-lang/rust#141295 just now.

## Motivations

Simplify code where `match` and `let-else` are used for assertions. For examples, see files:

- https://github.com/rust-lang/rust/blob/e0cb264b814526acb82def4b5810e394a2ed294f/library/coretests/tests/mem/type_info.rs
- https://github.com/9SonSteroids/rust/blob/7287be900699468bb8a2d9b4705f3545aa28c451/library/coretests/tests/mem/fn_ptr.rs (PR rust-lang/rust#152173)

```diff
-    const {
-        match Type::of::<(i8, u8)>().kind {
-            TypeKind::Tuple(tup) => {
-                let [a, b] = tup.fields else { unreachable!() };
-
-                assert!(a.offset == 0);
-                assert!(b.offset == 1);
-
-                match (a.ty.info().kind, b.ty.info().kind) {
-                    (TypeKind::Int(a), TypeKind::Int(b)) => {
-                        assert!(a.bits == 8 && a.signed);
-                        assert!(b.bits == 8 && !b.signed);
-                    }
-                    _ => unreachable!(),
-                }
-            }
-            _ => unreachable!(),
-        }
-    }
+    assert_matches!(
+        const { Type::of::<(i8, u8)>().kind }, TypeKind::Tuple(tup)
+            if let [a, b] = tup.fields
+            && a.offset == 0
+            && b.offset == 1
+            && let (TypeKind::Int(a), TypeKind::Int(b)) = (a.ty.info().kind, b.ty.info().kind)
+            && a.bits == 8 && a.signed
+            && b.bits == 8 && !b.signed
+    );
```

```diff
     struct TestStruct {
         first: u8,
         second: u16,
         reference: &'static u16,
     }
-    const {
-        let Type { kind: Struct(ty), size, .. } = Type::of::<TestStruct>() else { panic!() };
-        assert!(size == Some(size_of::<TestStruct>()));
-        assert!(!ty.non_exhaustive);
-        assert!(ty.fields.len() == 3);
-        assert!(ty.fields[0].name == "first");
-        assert!(ty.fields[0].ty == TypeId::of::<u8>());
-        assert!(ty.fields[0].offset == offset_of!(TestStruct, first));
-        assert!(ty.fields[1].name == "second");
-        assert!(ty.fields[1].ty == TypeId::of::<u16>());
-        assert!(ty.fields[1].offset == offset_of!(TestStruct, second));
-        assert!(ty.fields[2].name == "reference");
-        assert!(ty.fields[2].ty == TypeId::of::<&'static u16>());
-        assert!(ty.fields[2].offset == offset_of!(TestStruct, reference));
-    }
+    assert_matches!(
+        const {Type::of::<TestStruct>() }, Type { kind: Struct(ty), size, .. }
+           if size == Some(size_of::<TestStruct>())
+           && !ty.non_exhaustive
+           && ty.fields.len() == 3
+           && ty.fields[0].name == "first"
+           && ty.fields[0].ty == TypeId::of::<u8>()
+           && ty.fields[0].offset == offset_of!(TestStruct, first)
+           && ty.fields[1].name == "second"
+           && ty.fields[1].ty == TypeId::of::<u16>()
+           && ty.fields[1].offset == offset_of!(TestStruct, second)
+           && ty.fields[2].name == "reference"
+           && ty.fields[2].ty == TypeId::of::<&'static u16>()
+           && ty.fields[2].offset == offset_of!(TestStruct, reference)
+    );
```

### Notes

At the moment, it seems we cannot fully port const-eval only operations (e.g. file https://github.com/rust-lang/rust/blob/e0cb264b814526acb82def4b5810e394a2ed294f/library/coretests/tests/mem/type_info.rs) to use `assert_matches!` with if-let-guards, because of:
- ```rust
  assert_matches!(
      const { Type::of::<(i8, u8)>().kind }, TypeKind::Tuple(tup)
          if let [a, b] = tup.fields
          && let (TypeKind::Int(a), TypeKind::Int(b)) = (a.ty.info().kind, b.ty.info().kind)
  );
  ```
  triggers a runtime panic https://github.com/rust-lang/rust/blob/e0cb264b814526acb82def4b5810e394a2ed294f/library/core/src/intrinsics/mod.rs#L2872-L2874

- ```rust
  const {
      assert_matches!(
          Type::of::<(i8, u8)>().kind, TypeKind::Tuple(tup)
              if let [a, b] = tup.fields
              && let (TypeKind::Int(a), TypeKind::Int(b)) = (a.ty.info().kind, b.ty.info().kind)
      );
  }
  ```
  triggers `error[E0015]: cannot call non-const function 'core::panicking::assert_matches_failed::<_>' in constants`. (blocked by rust-lang/rust#119826)

## Todo

- [ ] Documentation updates.

r? theemathas
cc @rustbot ping libs-api