### PR TITLE
fix(codegen): Use `body_codegen_attrs` For Caller In `adjust_target_feature_sig`

### DIFF
--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1330,8 +1330,8 @@ impl<'tcx> TyCtxt<'tcx> {
         caller: DefId,
     ) -> Option<ty::Binder<'tcx, ty::FnSig<'tcx>>> {
         let fun_features = &self.codegen_fn_attrs(fun_def).target_features;
-        let callee_features = &self.codegen_fn_attrs(caller).target_features;
-        if self.is_target_feature_call_safe(&fun_features, &callee_features) {
+        let caller_features = &self.body_codegen_attrs(caller).target_features;
+        if self.is_target_feature_call_safe(&fun_features, &caller_features) {
             return Some(fun_sig.map_bound(|sig| ty::FnSig { safety: hir::Safety::Safe, ..sig }));
         }
         None

--- a/tests/ui/target-feature/const-target-feature-fn-ptr-coercion.rs
+++ b/tests/ui/target-feature/const-target-feature-fn-ptr-coercion.rs
@@ -1,0 +1,33 @@
+//@ only-x86_64
+//@ check-pass
+//
+// Regression test for <https://github.com/rust-lang/rust/issues/152340>.
+
+#![allow(dead_code)]
+
+#[target_feature(enable = "sse2")]
+const fn foo() {}
+
+// DefKind::Const
+const _: () = unsafe {
+    let _: unsafe fn() = foo;
+};
+
+// DefKind::AssocConst
+struct S;
+impl S {
+    const C: () = unsafe {
+        let _: unsafe fn() = foo;
+    };
+}
+
+// DefKind::InlineConst
+fn bar() {
+    let _ = const {
+        unsafe {
+            let _: unsafe fn() = foo;
+        }
+    };
+}
+
+fn main() {}


### PR DESCRIPTION
### Summary:

#### Problem:

Coercing a `#[target_feature]` `const fn` to a function pointer inside a `const` body triggers an ICE (debug builds only):

```rust
#[target_feature(enable = "sse2")]
const fn with_target_feature() {}

const X: () = unsafe {
    let _: unsafe fn() = with_target_feature; // ICE
};
```

```text
assertion failed: def_kind.has_codegen_attrs()
unexpected `def_kind` in `codegen_fn_attrs`: Const
```

#### Root Cause:

Introduced in rust-lang/rust#135504 (2025-01-14, commit `8fee6a77394`). `adjust_target_feature_sig` unconditionally calls `codegen_fn_attrs(caller)` to get the caller's target features. `codegen_fn_attrs` requires that the `DefId` satisfies `has_codegen_attrs()`. `DefKind::Const`, `AssocConst`, and `InlineConst` do not — they have no codegen attributes by design. The debug assertion fires.

In release builds the call "worked" accidentally: `codegen_fn_attrs` on a const would reach the query machinery and happen to return empty attributes, producing a correct (but unguaranteed) result. The bug was latent until debug builds exposed it.

#### Solution:

Replace `codegen_fn_attrs(caller)` with `body_codegen_attrs(caller)`. `body_codegen_attrs` exists precisely for this case: it delegates to `codegen_fn_attrs` for function-like `DefKind`s and returns `CodegenFnAttrs::EMPTY` for const items. A const body has no target features, so returning empty is semantically correct.

Also fix the pre-existing variable name `callee_features` → `caller_features` (the variable holds the *caller*'s features, not the callee's).

### Changes:

- `compiler/rustc_middle/src/ty/context.rs`: `adjust_target_feature_sig` — use `body_codegen_attrs` for `caller`; rename `callee_features` → `caller_features`.
- `tests/ui/target-feature/const-target-feature-fn-ptr-coercion.rs`: regression test covering `Const`, `AssocConst`, and `InlineConst` caller contexts.

Fixes rust-lang/rust#152340.