### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/compiler/rustc_ast/src/attr/mod.rs
+++ b/compiler/rustc_ast/src/attr/mod.rs
@@ -296,6 +296,10 @@ impl AttributeExt for Attribute {
         }
         false
     }
+
+    fn is_rustc_doc_primitive(&self) -> bool {
+        self.has_name(sym::rustc_doc_primitive)
+    }
 }
 
 impl Attribute {
@@ -935,6 +939,9 @@ pub trait AttributeExt: Debug {
 
     /// Returns `true` is this attribute contains `doc(keyword)` or `doc(attribute)`.
     fn is_doc_keyword_or_attribute(&self) -> bool;
+
+    /// Returns `true` if this is a `#[rustc_doc_primitive]` attribute.
+    fn is_rustc_doc_primitive(&self) -> bool;
 }
 
 // FIXME(fn_delegation): use function delegation instead of manually forwarding

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -205,6 +205,7 @@ attribute_parsers!(
         Single<RustcDefPath>,
         Single<RustcDeprecatedSafe2024Parser>,
         Single<RustcDiagnosticItemParser>,
+        Single<RustcDocPrimitiveParser>,
         Single<RustcForceInlineParser>,
         Single<RustcIfThisChangedParser>,
         Single<RustcLayoutScalarValidRangeEndParser>,

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -535,7 +535,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 if let Some(pat) = finder.parent_pat {
                     sugg.insert(0, (pat.span.shrink_to_lo(), "ref ".to_string()));
                 }
-                err.multipart_suggestion_verbose(
+                err.multipart_suggestion(
                     "borrow this binding in the pattern to avoid moving the value",
                     sugg,
                     Applicability::MachineApplicable,
@@ -1509,7 +1509,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         } else {
             "consider cloning the value if the performance cost is acceptable"
         };
-        err.multipart_suggestion_verbose(msg, sugg, Applicability::MachineApplicable);
+        err.multipart_suggestion(msg, sugg, Applicability::MachineApplicable);
         true
     }
 
@@ -2759,7 +2759,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 .chain(finder.closure_call_changes)
                 .collect();
 
-            err.multipart_suggestion_verbose(
+            err.multipart_suggestion(
                 "try explicitly passing `&Self` into the closure as an argument",
                 sugg,
                 Applicability::MachineApplicable,
@@ -3347,7 +3347,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
 
                             let addition =
                                 format!("let {}binding = {};\n{}", mutability, s, " ".repeat(p));
-                            err.multipart_suggestion_verbose(
+                            err.multipart_suggestion(
                                 msg,
                                 vec![
                                     (stmt.span.shrink_to_lo(), addition),

--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -1511,11 +1511,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                                         )
                                     }
                                 };
-                                err.multipart_suggestion_verbose(
-                                    msg,
-                                    sugg,
-                                    Applicability::MaybeIncorrect,
-                                );
+                                err.multipart_suggestion(msg, sugg, Applicability::MaybeIncorrect);
                                 for error in errors {
                                     if let FulfillmentErrorCode::Select(
                                         SelectionError::Unimplemented,

--- a/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
@@ -375,7 +375,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                     .source_map()
                     .indentation_before(stmt.span)
                     .unwrap_or_else(|| "    ".to_string());
-                err.multipart_suggestion_verbose(
+                err.multipart_suggestion(
                     "consider cloning the value before moving it into the closure",
                     vec![
                         (
@@ -405,7 +405,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 .source_map()
                 .indentation_before(closure_expr.span)
                 .unwrap_or_else(|| "    ".to_string());
-            err.multipart_suggestion_verbose(
+            err.multipart_suggestion(
                 "consider cloning the value before moving it into the closure",
                 vec![
                     (

--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -1340,7 +1340,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 return;
             }
 
-            err.multipart_suggestion_verbose(
+            err.multipart_suggestion(
                 format!(
                     "consider changing this to be a mutable {pointer_desc}{}{extra}",
                     if is_trait_sig {
@@ -1365,7 +1365,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 if self.infcx.tcx.sess.source_map().is_imported(span) {
                     return;
                 }
-                err.multipart_suggestion_verbose(
+                err.multipart_suggestion(
                     "consider using `get_mut`",
                     vec![(span, suggestion)],
                     Applicability::MaybeIncorrect,

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -290,7 +290,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         });
         if suggestions.len() > 0 {
             suggestions.dedup();
-            diag.multipart_suggestion_verbose(
+            diag.multipart_suggestion(
                 msg!("consider restricting the type parameter to the `'static` lifetime"),
                 suggestions,
                 Applicability::MaybeIncorrect,
@@ -902,7 +902,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 spans_suggs.push((alias_span.shrink_to_hi(), "<'a>".to_string()));
             }
 
-            diag.multipart_suggestion_verbose(
+            diag.multipart_suggestion(
                 format!(
                     "to declare that the trait object {captures}, you can add a lifetime parameter `'a` in the type alias"
                 ),

--- a/compiler/rustc_codegen_llvm/src/llvm/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/mod.rs
@@ -284,6 +284,10 @@ pub(crate) fn set_comdat(llmod: &Module, llglobal: &Value, name: &CStr) {
     }
 }
 
+pub(crate) fn count_params(llfn: &Value) -> c_uint {
+    LLVMCountParams(llfn)
+}
+
 /// Safe wrapper around `LLVMGetParam`, because segfaults are no fun.
 pub(crate) fn get_param(llfn: &Value, index: c_uint) -> &Value {
     unsafe {

--- a/compiler/rustc_codegen_llvm/src/mono_item.rs
+++ b/compiler/rustc_codegen_llvm/src/mono_item.rs
@@ -117,7 +117,7 @@ impl<'ll, 'tcx> CodegenCx<'ll, 'tcx> {
     /// This is not a problem: instead of using LLVM aliases, we can just generate
     /// a new function symbol (with target architecture!) which effectively comes down to:
     ///
-    /// ```rust,ignore
+    /// ```ignore (illustrative example)
     /// fn alias_name(...args) {
     ///     original_name(...args)
     /// }

--- a/compiler/rustc_codegen_llvm/src/mono_item.rs
+++ b/compiler/rustc_codegen_llvm/src/mono_item.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::ffi::CString;
 
 use rustc_abi::AddressSpace;
@@ -6,13 +7,17 @@ use rustc_hir::attrs::Linkage;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_middle::bug;
+use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrs;
 use rustc_middle::mir::mono::Visibility;
 use rustc_middle::ty::layout::{FnAbiOf, HasTypingEnv, LayoutOf};
-use rustc_middle::ty::{self, Instance, TypeVisitableExt};
+use rustc_middle::ty::{self, Instance, Ty, TypeVisitableExt};
 use rustc_session::config::CrateType;
+use rustc_target::callconv::FnAbi;
 use rustc_target::spec::{Arch, RelocModel};
 use tracing::debug;
 
+use crate::abi::FnAbiLlvmExt;
+use crate::builder::Builder;
 use crate::context::CodegenCx;
 use crate::errors::SymbolAlreadyDefined;
 use crate::type_of::LayoutLlvmExt;
@@ -46,7 +51,7 @@ impl<'tcx> PreDefineCodegenMethods<'tcx> for CodegenCx<'_, 'tcx> {
         self.assume_dso_local(g, false);
 
         let attrs = self.tcx.codegen_instance_attrs(instance.def);
-        self.add_aliases(g, &attrs.foreign_item_symbol_aliases);
+        self.add_static_aliases(g, &attrs.foreign_item_symbol_aliases);
 
         self.instances.borrow_mut().insert(instance, g);
     }
@@ -60,11 +65,29 @@ impl<'tcx> PreDefineCodegenMethods<'tcx> for CodegenCx<'_, 'tcx> {
     ) {
         assert!(!instance.args.has_infer());
 
-        let fn_abi = self.fn_abi_of_instance(instance, ty::List::empty());
+        let attrs = self.tcx.codegen_instance_attrs(instance.def);
+
+        let lldecl =
+            self.predefine_without_aliases(instance, &attrs, linkage, visibility, symbol_name);
+        self.add_function_aliases(instance, lldecl, &attrs, &attrs.foreign_item_symbol_aliases);
+
+        self.instances.borrow_mut().insert(instance, lldecl);
+    }
+}
+
+impl<'ll, 'tcx> CodegenCx<'ll, 'tcx> {
+    fn predefine_without_aliases(
+        &self,
+        instance: Instance<'tcx>,
+        attrs: &Cow<'_, CodegenFnAttrs>,
+        linkage: Linkage,
+        visibility: Visibility,
+        symbol_name: &str,
+    ) -> &'ll llvm::Value {
+        let fn_abi: &FnAbi<'tcx, Ty<'tcx>> = self.fn_abi_of_instance(instance, ty::List::empty());
         let lldecl = self.declare_fn(symbol_name, fn_abi, Some(instance));
         llvm::set_linkage(lldecl, base::linkage_to_llvm(linkage));
-        let attrs = self.tcx.codegen_instance_attrs(instance.def);
-        base::set_link_section(lldecl, &attrs);
+        base::set_link_section(lldecl, attrs);
         if (linkage == Linkage::LinkOnceODR || linkage == Linkage::WeakODR)
             && self.tcx.sess.target.supports_comdat()
         {
@@ -76,20 +99,45 @@ impl<'tcx> PreDefineCodegenMethods<'tcx> for CodegenCx<'_, 'tcx> {
 
         self.assume_dso_local(lldecl, false);
 
-        self.add_aliases(lldecl, &attrs.foreign_item_symbol_aliases);
-
-        self.instances.borrow_mut().insert(instance, lldecl);
+        lldecl
     }
-}
 
-impl CodegenCx<'_, '_> {
-    fn add_aliases(&self, aliasee: &llvm::Value, aliases: &[(DefId, Linkage, Visibility)]) {
+    /// LLVM has the concept of an `alias`.
+    /// We need this for the "externally implementable items" feature,
+    /// though it's generally useful.
+    ///
+    /// On macos, though this might be a more general problem, function symbols
+    /// have a fixed target architecture. This is necessary, since macos binaries
+    /// may contain code for both ARM and x86 macs.
+    ///
+    /// LLVM *can* add attributes for target architecture to function symbols,
+    /// cannot do so for statics, but importantly, also cannot for aliases
+    /// *even* when aliases may refer to a function symbol.
+    ///
+    /// This is not a problem: instead of using LLVM aliases, we can just generate
+    /// a new function symbol (with target architecture!) which effectively comes down to:
+    ///
+    /// ```rust,ignore
+    /// fn alias_name(...args) {
+    ///     original_name(...args)
+    /// }
+    /// ```
+    ///
+    /// That's also an alias.
+    ///
+    /// This does mean that the alias symbol has a different address than the original symbol
+    /// (assuming no optimizations by LLVM occur). This is unacceptable for statics.
+    /// So for statics we do want to use LLVM aliases, which is fine,
+    /// since for those we don't care about target architecture anyway.
+    ///
+    /// So, this function is for static aliases. See [`add_function_aliases`](Self::add_function_aliases) for the alternative.
+    fn add_static_aliases(&self, aliasee: &llvm::Value, aliases: &[(DefId, Linkage, Visibility)]) {
         let ty = self.get_type_of_global(aliasee);
 
         for (alias, linkage, visibility) in aliases {
             let symbol_name = self.tcx.symbol_name(Instance::mono(self.tcx, *alias));
+            tracing::debug!("STATIC ALIAS: {alias:?} {linkage:?} {visibility:?}");
 
-            tracing::debug!("ALIAS: {alias:?} {linkage:?} {visibility:?}");
             let lldecl = llvm::add_alias(
                 self.llmod,
                 ty,
@@ -100,6 +148,54 @@ impl CodegenCx<'_, '_> {
 
             llvm::set_visibility(lldecl, base::visibility_to_llvm(*visibility));
             llvm::set_linkage(lldecl, base::linkage_to_llvm(*linkage));
+        }
+    }
+
+    /// See [`add_static_aliases`](Self::add_static_aliases) for docs.
+    fn add_function_aliases(
+        &self,
+        aliasee_instance: Instance<'tcx>,
+        aliasee: &'ll llvm::Value,
+        attrs: &Cow<'_, CodegenFnAttrs>,
+        aliases: &[(DefId, Linkage, Visibility)],
+    ) {
+        for (alias, linkage, visibility) in aliases {
+            let symbol_name = self.tcx.symbol_name(Instance::mono(self.tcx, *alias));
+            tracing::debug!("FUNCTION ALIAS: {alias:?} {linkage:?} {visibility:?}");
+
+            // predefine another copy of the original instance
+            // with a new symbol name
+            let alias_lldecl = self.predefine_without_aliases(
+                aliasee_instance,
+                attrs,
+                *linkage,
+                *visibility,
+                symbol_name.name,
+            );
+
+            let fn_abi: &FnAbi<'tcx, Ty<'tcx>> =
+                self.fn_abi_of_instance(aliasee_instance, ty::List::empty());
+
+            // both the alias and the aliasee have the same ty
+            let fn_ty = fn_abi.llvm_type(self);
+            let start_llbb = Builder::append_block(self, alias_lldecl, "start");
+            let mut start_bx = Builder::build(self, start_llbb);
+
+            let num_params = llvm::count_params(alias_lldecl);
+            let mut args = Vec::with_capacity(num_params as usize);
+            for index in 0..num_params {
+                args.push(llvm::get_param(alias_lldecl, index));
+            }
+
+            start_bx.tail_call(
+                fn_ty,
+                Some(attrs),
+                fn_abi,
+                aliasee,
+                &args,
+                None,
+                Some(aliasee_instance),
+            );
         }
     }
 

--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -838,7 +838,7 @@ impl<'a, G: EmissionGuarantee> Diag<'a, G> {
     }
 
     with_fn! { with_multipart_suggestion,
-    /// Show a suggestion that has multiple parts to it.
+    /// Show a suggestion that has multiple parts to it, always as its own subdiagnostic.
     /// In other words, multiple changes need to be applied as part of this suggestion.
     pub fn multipart_suggestion(
         &mut self,
@@ -850,25 +850,9 @@ impl<'a, G: EmissionGuarantee> Diag<'a, G> {
             msg,
             suggestion,
             applicability,
-            SuggestionStyle::ShowCode,
-        )
-    } }
-
-    /// Show a suggestion that has multiple parts to it, always as its own subdiagnostic.
-    /// In other words, multiple changes need to be applied as part of this suggestion.
-    pub fn multipart_suggestion_verbose(
-        &mut self,
-        msg: impl Into<DiagMessage>,
-        suggestion: Vec<(Span, String)>,
-        applicability: Applicability,
-    ) -> &mut Self {
-        self.multipart_suggestion_with_style(
-            msg,
-            suggestion,
-            applicability,
             SuggestionStyle::ShowAlways,
         )
-    }
+    } }
 
     /// [`Diag::multipart_suggestion()`] but you can set the [`SuggestionStyle`].
     pub fn multipart_suggestion_with_style(

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -17,6 +17,59 @@ pub(crate) struct CfgAttrNoAttributes;
 pub(crate) struct NoSyntaxVarsExprRepeat {
     #[primary_span]
     pub span: Span,
+    #[subdiagnostic]
+    pub typo_repeatable: Option<VarTypoSuggestionRepeatable>,
+    #[subdiagnostic]
+    pub typo_unrepeatable: Option<VarTypoSuggestionUnrepeatable>,
+    #[subdiagnostic]
+    pub typo_unrepeatable_label: Option<VarTypoSuggestionUnrepeatableLabel>,
+    #[subdiagnostic]
+    pub var_no_typo: Option<VarNoTypo>,
+    #[subdiagnostic]
+    pub no_repeatable_var: Option<NoRepeatableVar>,
+}
+
+#[derive(Subdiagnostic)]
+#[multipart_suggestion(
+    "there's a macro metavariable with a similar name",
+    applicability = "maybe-incorrect",
+    style = "verbose"
+)]
+pub(crate) struct VarTypoSuggestionRepeatable {
+    #[suggestion_part(code = "{name}")]
+    pub span: Span,
+    pub name: Symbol,
+}
+
+#[derive(Subdiagnostic)]
+#[label("argument not found")]
+pub(crate) struct VarTypoSuggestionUnrepeatable {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Subdiagnostic)]
+#[label("this similarly named macro metavariable is unrepeatable")]
+pub(crate) struct VarTypoSuggestionUnrepeatableLabel {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Subdiagnostic)]
+#[label("expected a repeatable metavariable: {$msg}")]
+pub(crate) struct VarNoTypo {
+    #[primary_span]
+    pub span: Span,
+    pub msg: String,
+}
+
+#[derive(Subdiagnostic)]
+#[label(
+    "this macro metavariable is not repeatable and there are no other repeatable metavariables"
+)]
+pub(crate) struct NoRepeatableVar {
+    #[primary_span]
+    pub span: Span,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_expand/src/mbe/macro_parser.rs
+++ b/compiler/rustc_expand/src/mbe/macro_parser.rs
@@ -388,6 +388,15 @@ pub(crate) enum NamedMatch {
     MatchedSingle(ParseNtResult),
 }
 
+impl NamedMatch {
+    pub(super) fn is_repeatable(&self) -> bool {
+        match self {
+            NamedMatch::MatchedSeq(_) => true,
+            NamedMatch::MatchedSingle(_) => false,
+        }
+    }
+}
+
 /// Performs a token equality check, ignoring syntax context (that is, an unhygienic comparison)
 fn token_name_eq(t1: &Token, t2: &Token) -> bool {
     if let (Some((ident1, is_raw1)), Some((ident2, is_raw2))) = (t1.ident(), t2.ident()) {

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -1169,6 +1169,9 @@ pub enum AttributeKind {
     /// Represents `#[rustc_do_not_const_check]`
     RustcDoNotConstCheck,
 
+    /// Represents `#[rustc_doc_primitive = ...]`
+    RustcDocPrimitive(Span, Symbol),
+
     /// Represents `#[rustc_dummy]`.
     RustcDummy,
 

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -117,6 +117,7 @@ impl AttributeKind {
             RustcDeprecatedSafe2024 { .. } => Yes,
             RustcDiagnosticItem(..) => Yes,
             RustcDoNotConstCheck => Yes,
+            RustcDocPrimitive(..) => Yes,
             RustcDummy => No,
             RustcDumpDefParents => No,
             RustcDumpItemBounds => No,

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1467,6 +1467,10 @@ impl AttributeExt for Attribute {
     fn is_doc_keyword_or_attribute(&self) -> bool {
         matches!(self, Attribute::Parsed(AttributeKind::Doc(d)) if d.attribute.is_some() || d.keyword.is_some())
     }
+
+    fn is_rustc_doc_primitive(&self) -> bool {
+        matches!(self, Attribute::Parsed(AttributeKind::RustcDocPrimitive(..)))
+    }
 }
 
 // FIXME(fn_delegation): use function delegation instead of manually forwarding

--- a/compiler/rustc_hir_analysis/src/errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_hir_analysis/src/errors/wrong_number_of_generic_args.rs
@@ -1026,7 +1026,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
                     .collect::<Vec<_>>();
 
                 if !suggestions.is_empty() {
-                    err.multipart_suggestion_verbose(
+                    err.multipart_suggestion(
                         format!(
                             "replace the generic bound{s} with the associated type{s}",
                             s = pluralize!(unbound_types.len())

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs
@@ -609,7 +609,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             tcx.node_span_lint(BARE_TRAIT_OBJECTS, hir_id, span, |lint| {
                 lint.primary_message("trait objects without an explicit `dyn` are deprecated");
                 if span.can_be_used_for_suggestions() {
-                    lint.multipart_suggestion_verbose(
+                    lint.multipart_suggestion(
                         "if this is a dyn-compatible trait, use `dyn`",
                         sugg,
                         Applicability::MachineApplicable,
@@ -674,7 +674,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         } else {
             sugg.push((generics.where_clause_span, format!("<{param}: {}>", rendered_ty)));
         }
-        diag.multipart_suggestion_verbose(
+        diag.multipart_suggestion(
             "you might be missing a type parameter",
             sugg,
             Applicability::MachineApplicable,
@@ -785,7 +785,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         }
 
         // FIXME: Only emit this suggestion if the trait is dyn-compatible.
-        diag.multipart_suggestion_verbose(
+        diag.multipart_suggestion(
             "you can add the `dyn` keyword if you want a trait object",
             sugg,
             Applicability::MachineApplicable,
@@ -871,7 +871,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                  single underlying type",
             );
 
-            diag.multipart_suggestion_verbose(msg, impl_sugg, Applicability::MachineApplicable);
+            diag.multipart_suggestion(msg, impl_sugg, Applicability::MachineApplicable);
 
             // Suggest `Box<dyn Trait>` for return type
             if is_dyn_compatible {
@@ -887,7 +887,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                     ]
                 };
 
-                diag.multipart_suggestion_verbose(
+                diag.multipart_suggestion(
                     "alternatively, you can return an owned trait object",
                     suggestion,
                     Applicability::MachineApplicable,
@@ -902,12 +902,12 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 continue;
             }
             let sugg = self.add_generic_param_suggestion(generics, span, &trait_name);
-            diag.multipart_suggestion_verbose(
+            diag.multipart_suggestion(
                 format!("use a new generic type parameter, constrained by `{trait_name}`"),
                 sugg,
                 Applicability::MachineApplicable,
             );
-            diag.multipart_suggestion_verbose(
+            diag.multipart_suggestion(
                 "you can also use an opaque type, but users won't be able to specify the type \
                  parameter when calling the `fn`, having to rely exclusively on type inference",
                 impl_sugg,
@@ -931,7 +931,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 } else {
                     vec![(span.shrink_to_lo(), dyn_str.to_string())]
                 };
-                diag.multipart_suggestion_verbose(
+                diag.multipart_suggestion(
                     format!(
                         "alternatively, use a trait object to accept any type that implements \
                          `{trait_name}`, accessing its methods at runtime using dynamic dispatch",

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -528,7 +528,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                         }
                     }
                 }
-                err.multipart_suggestion_verbose(
+                err.multipart_suggestion(
                     "there is a variant with a similar name",
                     suggestion,
                     Applicability::HasPlaceholders,
@@ -1546,7 +1546,7 @@ pub fn prohibit_assoc_item_constraint(
                             (constraint.span.with_lo(constraint.ident.span.hi()), String::new()),
                         ];
 
-                        err.multipart_suggestion_verbose(
+                        err.multipart_suggestion(
                             "declare the type parameter right after the `impl` keyword",
                             suggestions,
                             Applicability::MaybeIncorrect,
@@ -1721,7 +1721,7 @@ fn generics_args_err_extend<'a>(
                 },
                 (args_span, String::new()),
             ];
-            err.multipart_suggestion_verbose(msg, suggestion, Applicability::MaybeIncorrect);
+            err.multipart_suggestion(msg, suggestion, Applicability::MaybeIncorrect);
         }
         GenericsArgsErrExtend::DefVariant(segments) => {
             let args: Vec<Span> = segments

--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -485,7 +485,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                         ));
                     }
 
-                    err.multipart_suggestion_verbose(
+                    err.multipart_suggestion(
                         "consider borrowing the value",
                         suggestion,
                         Applicability::MachineApplicable,

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -888,7 +888,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             ]);
             // We suggest changing the argument from `mut ident: &Ty` to `ident: &'_ mut Ty` and the
             // assignment from `ident = val;` to `*ident = val;`.
-            err.multipart_suggestion_verbose(
+            err.multipart_suggestion(
                 "you might have meant to mutate the pointed at value being passed in, instead of \
                 changing the reference in the local binding",
                 sugg,

--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -304,7 +304,7 @@ impl Subdiagnostic for SuggestAnnotations {
             }
         }
 
-        diag.multipart_suggestion_verbose(
+        diag.multipart_suggestion(
             "use `()` annotations to avoid fallback changes",
             suggestions,
             Applicability::MachineApplicable,

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1994,7 +1994,7 @@ impl<'a, 'b, 'tcx> FnCallDiagCtxt<'a, 'b, 'tcx> {
                             ),
                         );
                         err.code(self.err_code.to_owned());
-                        err.multipart_suggestion_verbose(
+                        err.multipart_suggestion(
                             "wrap these arguments in parentheses to construct a tuple",
                             vec![
                                 (lo.shrink_to_lo(), "(".to_string()),
@@ -2649,7 +2649,7 @@ impl<'a, 'b, 'tcx> FnCallDiagCtxt<'a, 'b, 'tcx> {
                 Some(format!("provide the argument{}", if plural { "s" } else { "" }))
             }
             SuggestionText::Remove(plural) => {
-                err.multipart_suggestion_verbose(
+                err.multipart_suggestion(
                     format!("remove the extra argument{}", if plural { "s" } else { "" }),
                     suggestions,
                     Applicability::HasPlaceholders,

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -156,11 +156,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
             };
 
-            err.multipart_suggestion_verbose(
-                format!("use parentheses to {msg}"),
-                sugg,
-                applicability,
-            );
+            err.multipart_suggestion(format!("use parentheses to {msg}"), sugg, applicability);
             return true;
         }
         false
@@ -245,7 +241,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
             }
 
-            err.multipart_suggestion_verbose("use parentheses to call these", sugg, applicability);
+            err.multipart_suggestion("use parentheses to call these", sugg, applicability);
 
             true
         } else {
@@ -298,7 +294,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             self.suggest_deref_or_ref(expr, found, expected)
         {
             if verbose {
-                err.multipart_suggestion_verbose(msg, suggestion, applicability);
+                err.multipart_suggestion(msg, suggestion, applicability);
             } else {
                 err.multipart_suggestion(msg, suggestion, applicability);
             }
@@ -1299,7 +1295,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             if !is_in_arm(expr, self.tcx) {
                 suggs.push((span.shrink_to_hi(), ";".to_string()));
             }
-            err.multipart_suggestion_verbose(
+            err.multipart_suggestion(
                 "you might have meant to return this value",
                 suggs,
                 Applicability::MaybeIncorrect,
@@ -1611,7 +1607,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return;
         }
         let msg = format!("use `{adt_name}::map_or` to deref inner value of `{adt_name}`");
-        err.multipart_suggestion_verbose(
+        err.multipart_suggestion(
             msg,
             vec![
                 (call_ident.span, "map_or".to_owned()),
@@ -1639,7 +1635,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 && snippet.starts_with('{')
                 && snippet.ends_with('}')
             {
-                diag.multipart_suggestion_verbose(
+                diag.multipart_suggestion(
                     "to create an array, use square brackets instead of curly braces",
                     vec![
                         (
@@ -2604,7 +2600,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 [] => { /* No variants to format */ }
                 [(variant, ctor_kind, field_name, note)] => {
                     // Just a single matching variant.
-                    err.multipart_suggestion_verbose(
+                    err.multipart_suggestion(
                         format!(
                             "try wrapping the expression in `{variant}`{note}",
                             note = note.as_deref().unwrap_or("")
@@ -3376,7 +3372,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     ));
                     (msg, suggestion)
                 };
-                err.multipart_suggestion_verbose(msg, suggestion, Applicability::MachineApplicable);
+                err.multipart_suggestion(msg, suggestion, Applicability::MachineApplicable);
             };
 
         let suggest_to_change_suffix_or_into =
@@ -3411,7 +3407,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 } else {
                     into_suggestion.clone()
                 };
-                err.multipart_suggestion_verbose(msg, suggestion, Applicability::MachineApplicable);
+                err.multipart_suggestion(msg, suggestion, Applicability::MachineApplicable);
             };
 
         match (expected_ty.kind(), checked_ty.kind()) {
@@ -3465,14 +3461,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 if found.bit_width() < exp.bit_width() {
                     suggest_to_change_suffix_or_into(err, false, true);
                 } else if literal_is_ty_suffixed(expr) {
-                    err.multipart_suggestion_verbose(
+                    err.multipart_suggestion(
                         lit_msg,
                         suffix_suggestion,
                         Applicability::MachineApplicable,
                     );
                 } else if can_cast {
                     // Missing try_into implementation for `f64` to `f32`
-                    err.multipart_suggestion_verbose(
+                    err.multipart_suggestion(
                         format!("{cast_msg}, producing the closest possible value"),
                         cast_suggestion,
                         Applicability::MaybeIncorrect, // lossy conversion
@@ -3482,14 +3478,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
             (&ty::Uint(_) | &ty::Int(_), &ty::Float(_)) => {
                 if literal_is_ty_suffixed(expr) {
-                    err.multipart_suggestion_verbose(
+                    err.multipart_suggestion(
                         lit_msg,
                         suffix_suggestion,
                         Applicability::MachineApplicable,
                     );
                 } else if can_cast {
                     // Missing try_into implementation for `{float}` to `{integer}`
-                    err.multipart_suggestion_verbose(
+                    err.multipart_suggestion(
                         format!("{msg}, rounding the float towards zero"),
                         cast_suggestion,
                         Applicability::MaybeIncorrect, // lossy conversion
@@ -3500,7 +3496,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             (ty::Float(exp), ty::Uint(found)) => {
                 // if `found` is `None` (meaning found is `usize`), don't suggest `.into()`
                 if exp.bit_width() > found.bit_width().unwrap_or(256) {
-                    err.multipart_suggestion_verbose(
+                    err.multipart_suggestion(
                         format!(
                             "{msg}, producing the floating point representation of the integer",
                         ),
@@ -3508,14 +3504,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         Applicability::MachineApplicable,
                     );
                 } else if literal_is_ty_suffixed(expr) {
-                    err.multipart_suggestion_verbose(
+                    err.multipart_suggestion(
                         lit_msg,
                         suffix_suggestion,
                         Applicability::MachineApplicable,
                     );
                 } else {
                     // Missing try_into implementation for `{integer}` to `{float}`
-                    err.multipart_suggestion_verbose(
+                    err.multipart_suggestion(
                         format!(
                             "{cast_msg}, producing the floating point representation of the integer, \
                                  rounded if necessary",
@@ -3529,7 +3525,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             (ty::Float(exp), ty::Int(found)) => {
                 // if `found` is `None` (meaning found is `isize`), don't suggest `.into()`
                 if exp.bit_width() > found.bit_width().unwrap_or(256) {
-                    err.multipart_suggestion_verbose(
+                    err.multipart_suggestion(
                         format!(
                             "{}, producing the floating point representation of the integer",
                             msg.clone(),
@@ -3538,14 +3534,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         Applicability::MachineApplicable,
                     );
                 } else if literal_is_ty_suffixed(expr) {
-                    err.multipart_suggestion_verbose(
+                    err.multipart_suggestion(
                         lit_msg,
                         suffix_suggestion,
                         Applicability::MachineApplicable,
                     );
                 } else {
                     // Missing try_into implementation for `{integer}` to `{float}`
-                    err.multipart_suggestion_verbose(
+                    err.multipart_suggestion(
                         format!(
                             "{}, producing the floating point representation of the integer, \
                                 rounded if necessary",
@@ -3562,7 +3558,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 | &ty::Int(ty::IntTy::I32 | ty::IntTy::I64 | ty::IntTy::I128),
                 &ty::Char,
             ) => {
-                err.multipart_suggestion_verbose(
+                err.multipart_suggestion(
                     format!("{cast_msg}, since a `char` always occupies 4 bytes"),
                     cast_suggestion,
                     Applicability::MachineApplicable,

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -452,7 +452,7 @@ fn report_unexpected_variant_res(
                 }
             }
 
-            err.multipart_suggestion_verbose(descr, suggestion, Applicability::HasPlaceholders);
+            err.multipart_suggestion(descr, suggestion, Applicability::HasPlaceholders);
             err
         }
         Res::Def(DefKind::Variant, _) if expr.is_none() => {

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -890,7 +890,20 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
             | ty::Tuple(..) => {
                 self.assemble_inherent_candidates_for_incoherent_ty(raw_self_ty, receiver_steps)
             }
-            _ => {}
+            ty::Alias(..)
+            | ty::Bound(..)
+            | ty::Closure(..)
+            | ty::Coroutine(..)
+            | ty::CoroutineClosure(..)
+            | ty::CoroutineWitness(..)
+            | ty::Dynamic(..)
+            | ty::Error(..)
+            | ty::FnDef(..)
+            | ty::FnPtr(..)
+            | ty::Infer(..)
+            | ty::Pat(..)
+            | ty::Placeholder(..)
+            | ty::UnsafeBinder(..) => {}
         }
     }
 

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -854,7 +854,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         {
             err.span_label(span, format!("`{rcvr_ty}` is not an iterator"));
             if !span.in_external_macro(self.tcx.sess.source_map()) {
-                err.multipart_suggestion_verbose(
+                err.multipart_suggestion(
                     "call `.into_iter()` first",
                     vec![(span.shrink_to_lo(), format!("into_iter()."))],
                     Applicability::MaybeIncorrect,
@@ -1581,7 +1581,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     }
                 }
             }
-            err.multipart_suggestion_verbose(
+            err.multipart_suggestion(
                 "there is a variant with a similar name",
                 suggestion,
                 Applicability::HasPlaceholders,

--- a/compiler/rustc_hir_typeck/src/op.rs
+++ b/compiler/rustc_hir_typeck/src/op.rs
@@ -465,7 +465,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 && lhs_new_mutbl.is_not()
                                 && rhs_new_mutbl.is_not()
                             {
-                                err.multipart_suggestion_verbose(
+                                err.multipart_suggestion(
                                     "consider reborrowing both sides",
                                     vec![
                                         (lhs_expr.span.shrink_to_lo(), "&*".to_string()),
@@ -826,7 +826,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             lhs_sugg,
                             (rhs_expr.span.shrink_to_lo(), "&".to_owned()),
                         ];
-                        err.multipart_suggestion_verbose(
+                        err.multipart_suggestion(
                             sugg_msg,
                             suggestions,
                             Applicability::MachineApplicable,

--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -1410,7 +1410,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // Check that there is explicit type (ie this is not a closure param with inferred type)
                 // so we don't suggest moving something to the type that does not exist
                 hir::Node::Param(hir::Param { ty_span, pat, .. }) if pat.span != *ty_span => {
-                    err.multipart_suggestion_verbose(
+                    err.multipart_suggestion(
                         format!("to take parameter `{binding}` by reference, move `&{pin_and_mut}` to the type"),
                         vec![
                             (pat.span.until(inner.span), "".to_owned()),

--- a/compiler/rustc_lint/src/default_could_be_derived.rs
+++ b/compiler/rustc_lint/src/default_could_be_derived.rs
@@ -180,7 +180,7 @@ fn mk_lint(
     if removed_all_fields {
         let msg = "to avoid divergence in behavior between `Struct { .. }` and \
                    `<Struct as Default>::default()`, derive the `Default`";
-        diag.multipart_suggestion_verbose(
+        diag.multipart_suggestion(
             msg,
             vec![
                 (tcx.def_span(type_def_id).shrink_to_lo(), "#[derive(Default)] ".to_string()),

--- a/compiler/rustc_macros/src/lib.rs
+++ b/compiler/rustc_macros/src/lib.rs
@@ -232,7 +232,6 @@ decl_derive!(
         multipart_suggestion,
         multipart_suggestion_short,
         multipart_suggestion_hidden,
-        multipart_suggestion_verbose,
         // field attributes
         skip_arg,
         primary_span,

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -572,7 +572,7 @@ pub fn suggest_constraining_type_params<'a>(
         err.span_suggestion_verbose(span, msg, suggestion, applicability);
     } else if suggestions.len() > 1 {
         let post = if unstable_suggestion { " (some of them are unstable traits)" } else { "" };
-        err.multipart_suggestion_verbose(
+        err.multipart_suggestion(
             format!("consider restricting type parameters{post}"),
             suggestions.into_iter().map(|(span, _, suggestion, _)| (span, suggestion)).collect(),
             applicability,

--- a/compiler/rustc_mir_build/src/thir/pattern/migration.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/migration.rs
@@ -129,7 +129,7 @@ impl<'a> PatMigration<'a> {
         // FIXME(dianne): for peace of mind, don't risk emitting a 0-part suggestion (that panics!)
         debug_assert!(!self.suggestion.is_empty());
         if !self.suggestion.is_empty() {
-            diag.multipart_suggestion_verbose(msg, self.suggestion, applicability);
+            diag.multipart_suggestion(msg, self.suggestion, applicability);
         }
     }
 

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -236,7 +236,7 @@ impl MultiSugg {
     }
 
     fn emit_verbose(self, err: &mut Diag<'_>) {
-        err.multipart_suggestion_verbose(self.msg, self.patches, self.applicability);
+        err.multipart_suggestion(self.msg, self.patches, self.applicability);
     }
 }
 
@@ -389,7 +389,7 @@ impl<'a> Parser<'a> {
                                 && let Ok(snippet) =
                                     self.psess.source_map().span_to_snippet(generic.span)
                             {
-                                err.multipart_suggestion_verbose(
+                                err.multipart_suggestion(
                                         format!("place the generic parameter name after the {ident_name} name"),
                                         vec![
                                             (self.token.span.shrink_to_hi(), snippet),
@@ -1056,7 +1056,7 @@ impl<'a> Parser<'a> {
                 // and recover.
                 self.eat_to_tokens(&[exp!(CloseParen), exp!(Comma)]);
 
-                err.multipart_suggestion_verbose(
+                err.multipart_suggestion(
                     "you might have meant to open the body of the closure",
                     vec![
                         (prev.span.shrink_to_hi(), " {".to_string()),
@@ -1069,7 +1069,7 @@ impl<'a> Parser<'a> {
             _ if token.kind != token::OpenBrace => {
                 // We don't have a heuristic to correctly identify where the block
                 // should be closed.
-                err.multipart_suggestion_verbose(
+                err.multipart_suggestion(
                     "you might have meant to open the body of the closure",
                     vec![(prev.span.shrink_to_hi(), " {".to_string())],
                     Applicability::HasPlaceholders,

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2521,7 +2521,7 @@ impl<'a> Parser<'a> {
                         ret_span,
                         "explicit return type requires closure body to be enclosed in braces",
                     );
-                    diag.multipart_suggestion_verbose(
+                    diag.multipart_suggestion(
                         "wrap the expression in curly braces",
                         vec![
                             (expr.span.shrink_to_lo(), "{ ".to_string()),

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -312,6 +312,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     | AttributeKind::RustcDeprecatedSafe2024 {..}
                     | AttributeKind::RustcDiagnosticItem(..)
                     | AttributeKind::RustcDoNotConstCheck
+                    | AttributeKind::RustcDocPrimitive(..)
                     | AttributeKind::RustcDummy
                     | AttributeKind::RustcDumpDefParents
                     | AttributeKind::RustcDumpItemBounds
@@ -402,7 +403,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                             // internal
                             | sym::rustc_inherit_overflow_checks
                             | sym::rustc_on_unimplemented
-                            | sym::rustc_doc_primitive
                             | sym::rustc_layout
                             | sym::rustc_autodiff
                             | sym::rustc_capture_analysis

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -908,7 +908,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         err.help(msg);
                         return err;
                     }
-                    err.multipart_suggestion_verbose(msg, suggestions, applicability);
+                    err.multipart_suggestion(msg, suggestions, applicability);
                 }
 
                 let module = match module {
@@ -2379,7 +2379,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                             (last_span.shrink_to_hi(), ", ..".to_string()),
                         ]
                     };
-                    err.multipart_suggestion_verbose(
+                    err.multipart_suggestion(
                         format!(
                             "the type `{ident}` of field `{}` is private, but you can construct \
                              the default value defined for it in `{}` using `..` in the struct \

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -2045,7 +2045,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
             if let Some(ty) = &self.diag_metadata.current_self_type
                 && let ControlFlow::Break(sp) = AnonRefFinder.visit_ty(ty)
             {
-                err.multipart_suggestion_verbose(
+                err.multipart_suggestion(
                     "add a lifetime to the impl block and use it in the self type and associated \
                      type",
                     vec![
@@ -2060,7 +2060,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 && let Some(of_trait) = &impl_.of_trait
                 && let ControlFlow::Break(sp) = AnonRefFinder.visit_trait_ref(&of_trait.trait_ref)
             {
-                err.multipart_suggestion_verbose(
+                err.multipart_suggestion(
                     "add a lifetime to the impl block and use it in the trait and associated type",
                     vec![
                         (span, "<'a>".to_string()),

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -2218,7 +2218,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                                 "}".to_owned(),
                             ));
 
-                            err.multipart_suggestion_verbose(
+                            err.multipart_suggestion(
                                 format!("use struct {descr} syntax instead of calling"),
                                 parts,
                                 applicability,
@@ -2430,7 +2430,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
 
                     if non_visible_spans.len() > 0 {
                         if let Some(fields) = self.r.field_visibility_spans.get(&def_id) {
-                            err.multipart_suggestion_verbose(
+                            err.multipart_suggestion(
                                 format!(
                                     "consider making the field{} publicly accessible",
                                     pluralize!(fields.len())
@@ -3529,7 +3529,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                 &mut err,
                 Some(lifetime_ref.ident),
                 |err, _, span, message, suggestion, span_suggs| {
-                    err.multipart_suggestion_verbose(
+                    err.multipart_suggestion(
                         message,
                         std::iter::once((span, suggestion)).chain(span_suggs).collect(),
                         Applicability::MaybeIncorrect,
@@ -3912,7 +3912,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                     err,
                     None,
                     |err, higher_ranked, span, message, intro_sugg, _| {
-                        err.multipart_suggestion_verbose(
+                        err.multipart_suggestion(
                             message,
                             std::iter::once((span, intro_sugg))
                                 .chain(spans_suggs.clone())
@@ -3941,7 +3941,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                 } else {
                     String::new()
                 };
-                err.multipart_suggestion_verbose(
+                err.multipart_suggestion(
                     format!("consider using the `{existing_name}` lifetime{post}"),
                     spans_suggs,
                     Applicability::MaybeIncorrect,
@@ -3990,7 +3990,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                             };
                             let dotdotdot =
                                 if lt.kind == MissingLifetimeKind::Ampersand { "..." } else { "" };
-                            err.multipart_suggestion_verbose(
+                            err.multipart_suggestion(
                                 format!(
                                     "instead, you are more likely to want to change {the} \
                                      argument{s} to be borrowed{dotdotdot}",
@@ -4045,7 +4045,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                                 err,
                                 None,
                                 |err, higher_ranked, span, message, intro_sugg, _| {
-                                    err.multipart_suggestion_verbose(
+                                    err.multipart_suggestion(
                                         message,
                                         std::iter::once((span, intro_sugg))
                                             .chain(spans_suggs.clone())
@@ -4173,7 +4173,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                             {
                                 sugg = vec![(span, String::new())];
                             }
-                            err.multipart_suggestion_verbose(
+                            err.multipart_suggestion(
                                 format!("{pre} to return an owned value"),
                                 sugg,
                                 Applicability::MaybeIncorrect,
@@ -4190,7 +4190,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                 if spans_suggs.len() > 0 {
                     // This happens when we have `Foo<T>` where we point at the space before `T`,
                     // but this can be confusing so we give a suggestion with placeholders.
-                    err.multipart_suggestion_verbose(
+                    err.multipart_suggestion(
                         "consider using one of the available lifetimes here",
                         spans_suggs,
                         Applicability::HasPlaceholders,

--- a/compiler/rustc_resolve/src/rustdoc.rs
+++ b/compiler/rustc_resolve/src/rustdoc.rs
@@ -367,7 +367,7 @@ pub fn inner_docs(attrs: &[impl AttributeExt]) -> bool {
 /// Has `#[rustc_doc_primitive]` or `#[doc(keyword)]` or `#[doc(attribute)]`.
 pub fn has_primitive_or_keyword_or_attribute_docs(attrs: &[impl AttributeExt]) -> bool {
     for attr in attrs {
-        if attr.has_name(sym::rustc_doc_primitive) || attr.is_doc_keyword_or_attribute() {
+        if attr.is_rustc_doc_primitive() || attr.is_doc_keyword_or_attribute() {
             return true;
         }
     }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2778,6 +2778,14 @@ impl MacroRulesNormalizedIdent {
     pub fn new(ident: Ident) -> Self {
         MacroRulesNormalizedIdent(ident.normalize_to_macro_rules())
     }
+
+    pub fn symbol(&self) -> Symbol {
+        self.0.name
+    }
+
+    pub fn ident(&self) -> Ident {
+        self.0
+    }
 }
 
 impl fmt::Debug for MacroRulesNormalizedIdent {

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/static_impl_trait.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/static_impl_trait.rs
@@ -238,7 +238,7 @@ pub fn suggest_new_region_bound(
                             format!("you can use the named lifetime parameter `{name}`")
                         };
                         spans_suggs.push((fn_return.span.shrink_to_hi(), format!(" + {name} ")));
-                        err.multipart_suggestion_verbose(
+                        err.multipart_suggestion(
                             format!("{declare} `{ty}` {captures}, {use_lt}"),
                             spans_suggs,
                             Applicability::MaybeIncorrect,

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
@@ -863,7 +863,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             }
 
             if !suggs.is_empty() {
-                err.multipart_suggestion_verbose(
+                err.multipart_suggestion(
                     msg,
                     suggs,
                     Applicability::MaybeIncorrect, // Issue #41966

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -558,7 +558,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     if receiver_expr.hir_id == *arg_hir_id
                 );
                 if is_receiver {
-                    err.multipart_suggestion_verbose(
+                    err.multipart_suggestion(
                         msg,
                         vec![
                             (span.shrink_to_lo(), format!("({derefs}")),
@@ -697,7 +697,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 {
                     let mut suggestion = make_sugg(lhs, lsteps).1;
                     suggestion.append(&mut make_sugg(rhs, rsteps).1);
-                    err.multipart_suggestion_verbose(
+                    err.multipart_suggestion(
                         "consider dereferencing both sides of the expression",
                         suggestion,
                         Applicability::MachineApplicable,
@@ -707,21 +707,13 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     && lsteps > 0
                 {
                     let (msg, suggestion) = make_sugg(lhs, lsteps);
-                    err.multipart_suggestion_verbose(
-                        msg,
-                        suggestion,
-                        Applicability::MachineApplicable,
-                    );
+                    err.multipart_suggestion(msg, suggestion, Applicability::MachineApplicable);
                     return true;
                 } else if let Some(rsteps) = rsteps
                     && rsteps > 0
                 {
                     let (msg, suggestion) = make_sugg(rhs, rsteps);
-                    err.multipart_suggestion_verbose(
-                        msg,
-                        suggestion,
-                        Applicability::MachineApplicable,
-                    );
+                    err.multipart_suggestion(msg, suggestion, Applicability::MachineApplicable);
                     return true;
                 }
             }
@@ -1268,7 +1260,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     };
                     match (imm_ref_self_ty_satisfies_pred, mut_ref_self_ty_satisfies_pred, mtbl) {
                         (true, _, hir::Mutability::Not) | (_, true, hir::Mutability::Mut) => {
-                            err.multipart_suggestion_verbose(
+                            err.multipart_suggestion(
                                 sugg_msg(mtbl.prefix_str()),
                                 vec![
                                     (outer.span.shrink_to_lo(), "<".to_string()),
@@ -1279,7 +1271,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         }
                         (true, _, hir::Mutability::Mut) => {
                             // There's an associated function found on the immutable borrow of the
-                            err.multipart_suggestion_verbose(
+                            err.multipart_suggestion(
                                 sugg_msg("mut "),
                                 vec![
                                     (outer.span.shrink_to_lo().until(span), "<&".to_string()),
@@ -1289,7 +1281,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                             );
                         }
                         (_, true, hir::Mutability::Not) => {
-                            err.multipart_suggestion_verbose(
+                            err.multipart_suggestion(
                                 sugg_msg(""),
                                 vec![
                                     (outer.span.shrink_to_lo().until(span), "<&mut ".to_string()),
@@ -1608,11 +1600,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     format!("consider removing {count} leading `&`-references")
                 };
 
-                err.multipart_suggestion_verbose(
-                    msg,
-                    suggestions,
-                    Applicability::MachineApplicable,
-                );
+                err.multipart_suggestion(msg, suggestions, Applicability::MachineApplicable);
                 true
             } else {
                 false
@@ -3273,7 +3261,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                                     (ty.span.shrink_to_hi(), ")".to_string()),
                                 ]
                             };
-                            err.multipart_suggestion_verbose(
+                            err.multipart_suggestion(
                                 borrowed_msg,
                                 sugg,
                                 Applicability::MachineApplicable,
@@ -3350,7 +3338,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     "&",
                     Applicability::MachineApplicable,
                 );
-                err.multipart_suggestion_verbose(
+                err.multipart_suggestion(
                     "the `Box` type always has a statically known size and allocates its contents \
                      in the heap",
                     vec![
@@ -4849,7 +4837,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     suggestions.push((span.shrink_to_lo(), "&".into()));
                 }
                 suggestions.push((span.shrink_to_hi(), "[..]".into()));
-                err.multipart_suggestion_verbose(msg, suggestions, Applicability::MaybeIncorrect);
+                err.multipart_suggestion(msg, suggestions, Applicability::MaybeIncorrect);
             } else {
                 err.span_help(span, msg);
             }
@@ -4884,7 +4872,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 
         if self.predicate_must_hold_modulo_regions(&obligation) {
             let arg_span = self.tcx.hir_span(*arg_hir_id);
-            err.multipart_suggestion_verbose(
+            err.multipart_suggestion(
                 format!("use a unary tuple instead"),
                 vec![(arg_span.shrink_to_lo(), "(".into()), (arg_span.shrink_to_hi(), ",)".into())],
                 Applicability::MaybeIncorrect,
@@ -5178,7 +5166,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     ),
                 ));
             }
-            err.multipart_suggestion_verbose(
+            err.multipart_suggestion(
                 format!("consider adding return type"),
                 sugg_spans,
                 Applicability::MaybeIncorrect,
@@ -5268,7 +5256,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             suggs.push((span, suggestion));
         }
 
-        err.multipart_suggestion_verbose(
+        err.multipart_suggestion(
             "consider relaxing the implicit `Sized` restriction",
             suggs,
             Applicability::MachineApplicable,

--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -156,7 +156,7 @@ impl Subdiagnostic for AdjustSignatureBorrow {
         match self {
             AdjustSignatureBorrow::Borrow { to_borrow } => {
                 diag.arg("borrow_len", to_borrow.len());
-                diag.multipart_suggestion_verbose(
+                diag.multipart_suggestion(
                     msg!(
                         "consider adjusting the signature so it borrows its {$borrow_len ->
                             [one] argument
@@ -169,7 +169,7 @@ impl Subdiagnostic for AdjustSignatureBorrow {
             }
             AdjustSignatureBorrow::RemoveBorrow { remove_borrow } => {
                 diag.arg("remove_borrow_len", remove_borrow.len());
-                diag.multipart_suggestion_verbose(
+                diag.multipart_suggestion(
                     msg!(
                         "consider adjusting the signature so it does not borrow its {$remove_borrow_len ->
                             [one] argument
@@ -788,7 +788,7 @@ impl Subdiagnostic for AddLifetimeParamsSuggestion<'_> {
 
                 visitor.suggestions.push(new_param_suggestion);
             }
-            diag.multipart_suggestion_verbose(
+            diag.multipart_suggestion(
                 msg!(
                     "consider {$is_reuse ->
                         [true] reusing
@@ -2019,7 +2019,7 @@ pub struct AddPreciseCapturingAndParams {
 impl Subdiagnostic for AddPreciseCapturingAndParams {
     fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
         diag.arg("new_lifetime", self.new_lifetime);
-        diag.multipart_suggestion_verbose(
+        diag.multipart_suggestion(
             msg!("add a `use<...>` bound to explicitly capture `{$new_lifetime}` after turning all argument-position `impl Trait` into type parameters, noting that this possibly affects the API of this crate"),
             self.suggs,
             Applicability::MaybeIncorrect,
@@ -2166,7 +2166,7 @@ impl Subdiagnostic for AddPreciseCapturingForOvercapture {
             // not intended.
             Applicability::MaybeIncorrect
         };
-        diag.multipart_suggestion_verbose(
+        diag.multipart_suggestion(
             msg!("use the precise capturing `use<...>` syntax to make the captures explicit"),
             self.suggs,
             applicability,

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -99,9 +99,6 @@ impl<'a> Iterator for Chars<'a> {
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let len = self.iter.len();
-        // `(len + 3)` can't overflow, because we know that the `slice::Iter`
-        // belongs to a slice in memory which has a maximum length of
-        // `isize::MAX` (that's well below `usize::MAX`).
         (len.div_ceil(4), Some(len))
     }
 
@@ -1528,9 +1525,6 @@ impl<'a> Iterator for EncodeUtf16<'a> {
         // is therefore determined by assuming the remaining bytes contain as
         // many 3-byte sequences as possible. The highest bytes:code units
         // ratio is for 1-byte sequences, so use this for the upper bound.
-        // `(len + 2)` can't overflow, because we know that the `slice::Iter`
-        // belongs to a slice in memory which has a maximum length of
-        // `isize::MAX` (that's well below `usize::MAX`)
         if self.extra == 0 {
             (len.div_ceil(3), Some(len))
         } else {

--- a/src/librustdoc/json/ids.rs
+++ b/src/librustdoc/json/ids.rs
@@ -6,9 +6,10 @@
 //! other phases think of as an "item".
 
 use rustc_data_structures::fx::FxHashMap;
-use rustc_hir::def::DefKind;
+use rustc_hir::attrs::AttributeKind;
 use rustc_hir::def_id::DefId;
-use rustc_span::{Symbol, sym};
+use rustc_hir::find_attr;
+use rustc_span::Symbol;
 use rustdoc_json_types as types;
 
 use super::JsonRenderer;
@@ -88,12 +89,10 @@ impl JsonRenderer<'_> {
                 // We need this workaround because primitive types' DefId actually refers to
                 // their parent module, which isn't present in the output JSON items. So
                 // instead, we directly get the primitive symbol
-                if matches!(self.tcx.def_kind(def_id), DefKind::Mod)
-                    && let Some(prim) = self
-                        .tcx
-                        .get_attrs(def_id, sym::rustc_doc_primitive)
-                        .find_map(|attr| attr.value_str())
-                {
+                if let Some(prim) = find_attr!(
+                    self.tcx.get_all_attrs(def_id),
+                    AttributeKind::RustcDocPrimitive(_, prim) => *prim
+                ) {
                     Some(prim)
                 } else {
                     self.tcx.opt_item_name(def_id)

--- a/src/tools/clippy/clippy_lints/src/create_dir.rs
+++ b/src/tools/clippy/clippy_lints/src/create_dir.rs
@@ -51,7 +51,7 @@ impl LateLintPass<'_> for CreateDir {
                         suggestions.push((path.span.shrink_to_lo(), "std::fs::".to_owned()));
                     }
 
-                    diag.multipart_suggestion_verbose(
+                    diag.multipart_suggestion(
                         "consider calling `std::fs::create_dir_all` instead",
                         suggestions,
                         Applicability::MaybeIncorrect,

--- a/src/tools/clippy/clippy_lints/src/duration_suboptimal_units.rs
+++ b/src/tools/clippy/clippy_lints/src/duration_suboptimal_units.rs
@@ -98,7 +98,7 @@ impl LateLintPass<'_> for DurationSuboptimalUnits {
                         (func_name.ident.span, promoted_constructor.to_string()),
                         (arg.span, promoted_value.to_string()),
                     ];
-                    diag.multipart_suggestion_verbose(
+                    diag.multipart_suggestion(
                         format!("try using {promoted_constructor}"),
                         suggestions,
                         Applicability::MachineApplicable,

--- a/src/tools/clippy/clippy_lints/src/empty_line_after.rs
+++ b/src/tools/clippy/clippy_lints/src/empty_line_after.rs
@@ -367,7 +367,7 @@ impl EmptyLineAfter {
                         Some(name) => format!("{} `{name}`", info.kind).into(),
                         None => Cow::from("the following item"),
                     };
-                    diag.multipart_suggestion_verbose(
+                    diag.multipart_suggestion(
                         format!("if the doc comment should not document {name} then comment it out"),
                         suggestions,
                         Applicability::MaybeIncorrect,
@@ -384,7 +384,7 @@ impl EmptyLineAfter {
                     // Commentless empty gaps between line doc comments, possibly intended to be part of the markdown
 
                     let indent = snippet_indent(cx, first_gap.prev_stop.span).unwrap_or_default();
-                    diag.multipart_suggestion_verbose(
+                    diag.multipart_suggestion(
                         format!("if the documentation should include the empty {lines} include {them} in the comment"),
                         empty_lines()
                             .map(|empty_line| (empty_line, format!("{indent}///")))
@@ -414,7 +414,7 @@ impl EmptyLineAfter {
             } else {
                 parent.kind
             };
-            diag.multipart_suggestion_verbose(
+            diag.multipart_suggestion(
                 match kind {
                     StopKind::Attr => format!("if the attribute should apply to the {desc} use an inner attribute"),
                     StopKind::Doc(_) => format!("if the comment should document the {desc} use an inner doc comment"),

--- a/src/tools/clippy/clippy_lints/src/loops/never_loop.rs
+++ b/src/tools/clippy/clippy_lints/src/loops/never_loop.rs
@@ -56,7 +56,7 @@ pub(super) fn check<'tcx>(
                     )];
                     // Make sure to clear up the diverging sites when we remove a loopp.
                     suggestions.extend(break_spans.iter().map(|span| (*span, String::new())));
-                    diag.multipart_suggestion_verbose(
+                    diag.multipart_suggestion(
                         "if you need the first element of the iterator, try writing",
                         suggestions,
                         app,

--- a/src/tools/clippy/clippy_lints/src/matches/match_same_arms.rs
+++ b/src/tools/clippy/clippy_lints/src/matches/match_same_arms.rs
@@ -129,7 +129,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, arms: &'tcx [Arm<'_>]) {
                     diag.span_label(last.span, "the wildcard arm");
 
                     let s = if prev.len() > 1 { "s" } else { "" };
-                    diag.multipart_suggestion_verbose(
+                    diag.multipart_suggestion(
                         format!("otherwise remove the non-wildcard arm{s}"),
                         prev.iter()
                             .map(|(_, arm)| (adjusted_arm_span(cx, arm.span), String::new()))
@@ -158,7 +158,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, arms: &'tcx [Arm<'_>]) {
                             .chain([(dest.pat.span, pat_snippets.iter().join(" | "))])
                             .collect_vec();
 
-                        diag.multipart_suggestion_verbose(
+                        diag.multipart_suggestion(
                             "otherwise merge the patterns into a single arm",
                             suggs,
                             Applicability::MaybeIncorrect,

--- a/src/tools/clippy/clippy_lints/src/matches/redundant_guards.rs
+++ b/src/tools/clippy/clippy_lints/src/matches/redundant_guards.rs
@@ -226,7 +226,7 @@ fn emit_redundant_guards<'tcx>(
                 } => (span.shrink_to_hi(), format!(": {binding_replacement}")),
                 PatBindingInfo { span, .. } => (span, binding_replacement.into_owned()),
             };
-            diag.multipart_suggestion_verbose(
+            diag.multipart_suggestion(
                 "try",
                 vec![
                     suggestion_span,

--- a/src/tools/clippy/clippy_lints/src/methods/io_other_error.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/io_other_error.rs
@@ -24,7 +24,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, path: &Expr<'_>, args
             expr.span,
             "this can be `std::io::Error::other(_)`",
             |diag| {
-                diag.multipart_suggestion_verbose(
+                diag.multipart_suggestion(
                     "use `std::io::Error::other`",
                     vec![
                         (new_segment.ident.span, "other".to_owned()),

--- a/src/tools/clippy/clippy_lints/src/methods/ip_constant.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/ip_constant.rs
@@ -45,7 +45,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, func: &Expr<'_>, args
         }
 
         span_lint_and_then(cx, IP_CONSTANT, expr.span, "hand-coded well-known IP address", |diag| {
-            diag.multipart_suggestion_verbose("use", sugg, Applicability::MachineApplicable);
+            diag.multipart_suggestion("use", sugg, Applicability::MachineApplicable);
         });
     }
 }

--- a/src/tools/clippy/clippy_lints/src/methods/suspicious_command_arg_space.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/suspicious_command_arg_space.rs
@@ -23,7 +23,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, recv: &'tcx hir::Expr<'_>, arg
             arg.span,
             "single argument that looks like it should be multiple arguments",
             |diag: &mut Diag<'_, ()>| {
-                diag.multipart_suggestion_verbose(
+                diag.multipart_suggestion(
                     "consider splitting the argument",
                     vec![(span, "args".to_string()), (arg.span, format!("[{arg1:?}, {arg2:?}]"))],
                     Applicability::MaybeIncorrect,

--- a/src/tools/clippy/clippy_lints/src/methods/unnecessary_map_or.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/unnecessary_map_or.rs
@@ -154,7 +154,7 @@ pub(super) fn check<'a>(
         expr.span,
         "this `map_or` can be simplified",
         |diag| {
-            diag.multipart_suggestion_verbose(format!("use {method} instead"), sugg, applicability);
+            diag.multipart_suggestion(format!("use {method} instead"), sugg, applicability);
         },
     );
 }

--- a/src/tools/clippy/clippy_lints/src/needless_arbitrary_self_type.rs
+++ b/src/tools/clippy/clippy_lints/src/needless_arbitrary_self_type.rs
@@ -117,7 +117,7 @@ impl EarlyLintPass for NeedlessArbitrarySelfType {
                     if !add.is_empty() {
                         sugg.push((p.span.shrink_to_lo(), add));
                     }
-                    diag.multipart_suggestion_verbose("remove the type", sugg, applicability);
+                    diag.multipart_suggestion("remove the type", sugg, applicability);
                 },
             );
         }

--- a/src/tools/clippy/clippy_lints/src/raw_strings.rs
+++ b/src/tools/clippy/clippy_lints/src/raw_strings.rs
@@ -123,7 +123,7 @@ impl RawStrings {
                         remove.push((end, String::new()));
                     }
 
-                    diag.multipart_suggestion_verbose(
+                    diag.multipart_suggestion(
                         format!("use a plain {descr} literal instead"),
                         remove,
                         Applicability::MachineApplicable,

--- a/src/tools/clippy/clippy_lints/src/returns/needless_return.rs
+++ b/src/tools/clippy/clippy_lints/src/returns/needless_return.rs
@@ -251,7 +251,7 @@ fn emit_return_lint(
                 .chain(semi_spans.into_iter().map(|span| (span, String::new())))
                 .collect();
 
-            diag.multipart_suggestion_verbose(replacement.sugg_help(), suggestions, replacement.applicability());
+            diag.multipart_suggestion(replacement.sugg_help(), suggestions, replacement.applicability());
         },
     );
 }

--- a/src/tools/clippy/clippy_lints/src/significant_drop_tightening.rs
+++ b/src/tools/clippy/clippy_lints/src/significant_drop_tightening.rs
@@ -104,7 +104,7 @@ impl<'tcx> LateLintPass<'tcx> for SignificantDropTightening<'tcx> {
                                 format!("\n{indent}{init_method}.{usage_method};")
                             };
 
-                            diag.multipart_suggestion_verbose(
+                            diag.multipart_suggestion(
                                 "merge the temporary construction with its single usage",
                                 vec![(apa.first_stmt_span, stmt), (apa.last_stmt_span, String::new())],
                                 Applicability::MaybeIncorrect,

--- a/src/tools/clippy/clippy_lints/src/unit_types/let_unit_value.rs
+++ b/src/tools/clippy/clippy_lints/src/unit_types/let_unit_value.rs
@@ -118,7 +118,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, format_args: &FormatArgsStorag
                                 init_new_span.shrink_to_lo(),
                                 format!("();\n{}", snippet_indent(cx, local.span).as_deref().unwrap_or("")),
                             ));
-                            diag.multipart_suggestion_verbose("replace variable usages with `()`", suggestions, app);
+                            diag.multipart_suggestion("replace variable usages with `()`", suggestions, app);
                             return;
                         }
                     }
@@ -131,7 +131,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, format_args: &FormatArgsStorag
                     } else {
                         "omit the `let` binding and replace variable usages with `()`"
                     };
-                    diag.multipart_suggestion_verbose(message, suggestions, app);
+                    diag.multipart_suggestion(message, suggestions, app);
                 },
             );
         }

--- a/src/tools/clippy/clippy_lints_internal/src/repeated_is_diagnostic_item.rs
+++ b/src/tools/clippy/clippy_lints_internal/src/repeated_is_diagnostic_item.rs
@@ -190,7 +190,7 @@ impl<'tcx> LateLintPass<'tcx> for RepeatedIsDiagnosticItem {
                         }))
                         .collect();
 
-                        diag.multipart_suggestion_verbose(
+                        diag.multipart_suggestion(
                             format!("call `{recv_ty}::opt_diag_name`, and reuse the results"),
                             sugg,
                             app,
@@ -234,7 +234,7 @@ impl<'tcx> LateLintPass<'tcx> for RepeatedIsDiagnosticItem {
                         }))
                         .collect();
 
-                        diag.multipart_suggestion_verbose(
+                        diag.multipart_suggestion(
                             "call `TyCtxt::get_diagnostic_name`, and reuse the results",
                             sugg,
                             app,
@@ -437,7 +437,7 @@ fn check_if_chains<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'_>, conds: Vec<&'t
                 }))
                 .collect();
 
-                diag.multipart_suggestion_verbose(
+                diag.multipart_suggestion(
                     format!("call `{recv_ty}::opt_diag_name`, and reuse the results"),
                     sugg,
                     app,
@@ -489,7 +489,7 @@ fn check_if_chains<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'_>, conds: Vec<&'t
                 }))
                 .collect();
 
-                diag.multipart_suggestion_verbose(
+                diag.multipart_suggestion(
                     "call `TyCtxt::get_diagnostic_name`, and reuse the results",
                     sugg,
                     app,

--- a/src/tools/clippy/tests/ui-toml/ref_option/ref_option.all.stderr
+++ b/src/tools/clippy/tests/ui-toml/ref_option/ref_option.all.stderr
@@ -2,52 +2,69 @@ error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option.rs:9:1
    |
 LL | fn opt_u8(a: &Option<u8>) {}
-   | ^^^^^^^^^^^^^-----------^^^^
-   |              |
-   |              help: change this to: `Option<&u8>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::ref-option` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::ref_option)]`
+help: change this to
+   |
+LL - fn opt_u8(a: &Option<u8>) {}
+LL + fn opt_u8(a: Option<&u8>) {}
+   |
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option.rs:11:1
    |
 LL | fn opt_gen<T>(a: &Option<T>) {}
-   | ^^^^^^^^^^^^^^^^^----------^^^^
-   |                  |
-   |                  help: change this to: `Option<&T>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL - fn opt_gen<T>(a: &Option<T>) {}
+LL + fn opt_gen<T>(a: Option<&T>) {}
+   |
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option.rs:13:1
    |
 LL | fn opt_string(a: &std::option::Option<String>) {}
-   | ^^^^^^^^^^^^^^^^^----------------------------^^^^
-   |                  |
-   |                  help: change this to: `std::option::Option<&String>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL - fn opt_string(a: &std::option::Option<String>) {}
+LL + fn opt_string(a: std::option::Option<&String>) {}
+   |
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option.rs:15:1
    |
-LL |   fn ret_u8<'a>(p: &'a str) -> &'a Option<u8> {
-   |   ^                            -------------- help: change this to: `Option<&'a u8>`
-   |  _|
-   | |
+LL | / fn ret_u8<'a>(p: &'a str) -> &'a Option<u8> {
 LL | |
 LL | |     panic!()
 LL | | }
    | |_^
+   |
+help: change this to
+   |
+LL - fn ret_u8<'a>(p: &'a str) -> &'a Option<u8> {
+LL + fn ret_u8<'a>(p: &'a str) -> Option<&'a u8> {
+   |
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option.rs:19:1
    |
-LL |   fn ret_u8_static() -> &'static Option<u8> {
-   |   ^                     ------------------- help: change this to: `Option<&'static u8>`
-   |  _|
-   | |
+LL | / fn ret_u8_static() -> &'static Option<u8> {
 LL | |
 LL | |     panic!()
 LL | | }
    | |_^
+   |
+help: change this to
+   |
+LL - fn ret_u8_static() -> &'static Option<u8> {
+LL + fn ret_u8_static() -> Option<&'static u8> {
+   |
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option.rs:23:1
@@ -64,22 +81,29 @@ LL + fn mult_string(a: Option<&String>, b: Option<&Vec<u8>>) {}
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option.rs:25:1
    |
-LL |   fn ret_box<'a>() -> &'a Option<Box<u8>> {
-   |   ^                   ------------------- help: change this to: `Option<&'a Box<u8>>`
-   |  _|
-   | |
+LL | / fn ret_box<'a>() -> &'a Option<Box<u8>> {
 LL | |
 LL | |     panic!()
 LL | | }
    | |_^
+   |
+help: change this to
+   |
+LL - fn ret_box<'a>() -> &'a Option<Box<u8>> {
+LL + fn ret_box<'a>() -> Option<&'a Box<u8>> {
+   |
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option.rs:30:1
    |
 LL | pub fn pub_opt_string(a: &Option<String>) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^---------------^^^^
-   |                          |
-   |                          help: change this to: `Option<&String>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL - pub fn pub_opt_string(a: &Option<String>) {}
+LL + pub fn pub_opt_string(a: Option<&String>) {}
+   |
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option.rs:32:1
@@ -97,41 +121,55 @@ error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option.rs:38:5
    |
 LL |     pub fn pub_opt_params(&self, a: &Option<()>) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------^^^^
-   |                                     |
-   |                                     help: change this to: `Option<&()>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL -     pub fn pub_opt_params(&self, a: &Option<()>) {}
+LL +     pub fn pub_opt_params(&self, a: Option<&()>) {}
+   |
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option.rs:40:5
    |
-LL |       pub fn pub_opt_ret(&self) -> &Option<String> {
-   |       ^                            --------------- help: change this to: `Option<&String>`
-   |  _____|
-   | |
+LL | /     pub fn pub_opt_ret(&self) -> &Option<String> {
 LL | |
 LL | |         panic!()
 LL | |     }
    | |_____^
+   |
+help: change this to
+   |
+LL -     pub fn pub_opt_ret(&self) -> &Option<String> {
+LL +     pub fn pub_opt_ret(&self) -> Option<&String> {
+   |
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option.rs:45:5
    |
 LL |     fn private_opt_params(&self, a: &Option<()>) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------^^^^
-   |                                     |
-   |                                     help: change this to: `Option<&()>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL -     fn private_opt_params(&self, a: &Option<()>) {}
+LL +     fn private_opt_params(&self, a: Option<&()>) {}
+   |
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option.rs:47:5
    |
-LL |       fn private_opt_ret(&self) -> &Option<String> {
-   |       ^                            --------------- help: change this to: `Option<&String>`
-   |  _____|
-   | |
+LL | /     fn private_opt_ret(&self) -> &Option<String> {
 LL | |
 LL | |         panic!()
 LL | |     }
    | |_____^
+   |
+help: change this to
+   |
+LL -     fn private_opt_ret(&self) -> &Option<String> {
+LL +     fn private_opt_ret(&self) -> Option<&String> {
+   |
 
 error: aborting due to 13 previous errors
 

--- a/src/tools/clippy/tests/ui-toml/ref_option/ref_option.private.stderr
+++ b/src/tools/clippy/tests/ui-toml/ref_option/ref_option.private.stderr
@@ -2,52 +2,69 @@ error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option.rs:9:1
    |
 LL | fn opt_u8(a: &Option<u8>) {}
-   | ^^^^^^^^^^^^^-----------^^^^
-   |              |
-   |              help: change this to: `Option<&u8>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::ref-option` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::ref_option)]`
+help: change this to
+   |
+LL - fn opt_u8(a: &Option<u8>) {}
+LL + fn opt_u8(a: Option<&u8>) {}
+   |
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option.rs:11:1
    |
 LL | fn opt_gen<T>(a: &Option<T>) {}
-   | ^^^^^^^^^^^^^^^^^----------^^^^
-   |                  |
-   |                  help: change this to: `Option<&T>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL - fn opt_gen<T>(a: &Option<T>) {}
+LL + fn opt_gen<T>(a: Option<&T>) {}
+   |
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option.rs:13:1
    |
 LL | fn opt_string(a: &std::option::Option<String>) {}
-   | ^^^^^^^^^^^^^^^^^----------------------------^^^^
-   |                  |
-   |                  help: change this to: `std::option::Option<&String>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL - fn opt_string(a: &std::option::Option<String>) {}
+LL + fn opt_string(a: std::option::Option<&String>) {}
+   |
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option.rs:15:1
    |
-LL |   fn ret_u8<'a>(p: &'a str) -> &'a Option<u8> {
-   |   ^                            -------------- help: change this to: `Option<&'a u8>`
-   |  _|
-   | |
+LL | / fn ret_u8<'a>(p: &'a str) -> &'a Option<u8> {
 LL | |
 LL | |     panic!()
 LL | | }
    | |_^
+   |
+help: change this to
+   |
+LL - fn ret_u8<'a>(p: &'a str) -> &'a Option<u8> {
+LL + fn ret_u8<'a>(p: &'a str) -> Option<&'a u8> {
+   |
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option.rs:19:1
    |
-LL |   fn ret_u8_static() -> &'static Option<u8> {
-   |   ^                     ------------------- help: change this to: `Option<&'static u8>`
-   |  _|
-   | |
+LL | / fn ret_u8_static() -> &'static Option<u8> {
 LL | |
 LL | |     panic!()
 LL | | }
    | |_^
+   |
+help: change this to
+   |
+LL - fn ret_u8_static() -> &'static Option<u8> {
+LL + fn ret_u8_static() -> Option<&'static u8> {
+   |
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option.rs:23:1
@@ -64,34 +81,44 @@ LL + fn mult_string(a: Option<&String>, b: Option<&Vec<u8>>) {}
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option.rs:25:1
    |
-LL |   fn ret_box<'a>() -> &'a Option<Box<u8>> {
-   |   ^                   ------------------- help: change this to: `Option<&'a Box<u8>>`
-   |  _|
-   | |
+LL | / fn ret_box<'a>() -> &'a Option<Box<u8>> {
 LL | |
 LL | |     panic!()
 LL | | }
    | |_^
+   |
+help: change this to
+   |
+LL - fn ret_box<'a>() -> &'a Option<Box<u8>> {
+LL + fn ret_box<'a>() -> Option<&'a Box<u8>> {
+   |
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option.rs:45:5
    |
 LL |     fn private_opt_params(&self, a: &Option<()>) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------^^^^
-   |                                     |
-   |                                     help: change this to: `Option<&()>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL -     fn private_opt_params(&self, a: &Option<()>) {}
+LL +     fn private_opt_params(&self, a: Option<&()>) {}
+   |
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option.rs:47:5
    |
-LL |       fn private_opt_ret(&self) -> &Option<String> {
-   |       ^                            --------------- help: change this to: `Option<&String>`
-   |  _____|
-   | |
+LL | /     fn private_opt_ret(&self) -> &Option<String> {
 LL | |
 LL | |         panic!()
 LL | |     }
    | |_____^
+   |
+help: change this to
+   |
+LL -     fn private_opt_ret(&self) -> &Option<String> {
+LL +     fn private_opt_ret(&self) -> Option<&String> {
+   |
 
 error: aborting due to 9 previous errors
 

--- a/src/tools/clippy/tests/ui-toml/ref_option/ref_option_traits.all.stderr
+++ b/src/tools/clippy/tests/ui-toml/ref_option/ref_option_traits.all.stderr
@@ -2,36 +2,51 @@ error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option_traits.rs:10:5
    |
 LL |     fn pub_trait_opt(&self, a: &Option<Vec<u8>>);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------^^
-   |                                |
-   |                                help: change this to: `Option<&Vec<u8>>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::ref-option` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::ref_option)]`
+help: change this to
+   |
+LL -     fn pub_trait_opt(&self, a: &Option<Vec<u8>>);
+LL +     fn pub_trait_opt(&self, a: Option<&Vec<u8>>);
+   |
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option_traits.rs:12:5
    |
 LL |     fn pub_trait_ret(&self) -> &Option<Vec<u8>>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------^
-   |                                |
-   |                                help: change this to: `Option<&Vec<u8>>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL -     fn pub_trait_ret(&self) -> &Option<Vec<u8>>;
+LL +     fn pub_trait_ret(&self) -> Option<&Vec<u8>>;
+   |
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option_traits.rs:17:5
    |
 LL |     fn trait_opt(&self, a: &Option<String>);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^---------------^^
-   |                            |
-   |                            help: change this to: `Option<&String>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL -     fn trait_opt(&self, a: &Option<String>);
+LL +     fn trait_opt(&self, a: Option<&String>);
+   |
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option_traits.rs:19:5
    |
 LL |     fn trait_ret(&self) -> &Option<String>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^---------------^
-   |                            |
-   |                            help: change this to: `Option<&String>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL -     fn trait_ret(&self) -> &Option<String>;
+LL +     fn trait_ret(&self) -> Option<&String>;
+   |
 
 error: aborting due to 4 previous errors
 

--- a/src/tools/clippy/tests/ui-toml/ref_option/ref_option_traits.private.stderr
+++ b/src/tools/clippy/tests/ui-toml/ref_option/ref_option_traits.private.stderr
@@ -2,20 +2,27 @@ error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option_traits.rs:17:5
    |
 LL |     fn trait_opt(&self, a: &Option<String>);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^---------------^^
-   |                            |
-   |                            help: change this to: `Option<&String>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::ref-option` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::ref_option)]`
+help: change this to
+   |
+LL -     fn trait_opt(&self, a: &Option<String>);
+LL +     fn trait_opt(&self, a: Option<&String>);
+   |
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
   --> tests/ui-toml/ref_option/ref_option_traits.rs:19:5
    |
 LL |     fn trait_ret(&self) -> &Option<String>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^---------------^
-   |                            |
-   |                            help: change this to: `Option<&String>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL -     fn trait_ret(&self) -> &Option<String>;
+LL +     fn trait_ret(&self) -> Option<&String>;
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/tools/clippy/tests/ui-toml/renamed_function_params/renamed_function_params.default.stderr
+++ b/src/tools/clippy/tests/ui-toml/renamed_function_params/renamed_function_params.default.stderr
@@ -2,28 +2,51 @@ error: renamed function parameter of trait impl
   --> tests/ui-toml/renamed_function_params/renamed_function_params.rs:30:18
    |
 LL |     fn eq(&self, rhs: &Self) -> bool {
-   |                  ^^^ help: consider using the default name: `other`
+   |                  ^^^
    |
    = note: `-D clippy::renamed-function-params` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::renamed_function_params)]`
+help: consider using the default name
+   |
+LL -     fn eq(&self, rhs: &Self) -> bool {
+LL +     fn eq(&self, other: &Self) -> bool {
+   |
 
 error: renamed function parameter of trait impl
   --> tests/ui-toml/renamed_function_params/renamed_function_params.rs:34:18
    |
 LL |     fn ne(&self, rhs: &Self) -> bool {
-   |                  ^^^ help: consider using the default name: `other`
+   |                  ^^^
+   |
+help: consider using the default name
+   |
+LL -     fn ne(&self, rhs: &Self) -> bool {
+LL +     fn ne(&self, other: &Self) -> bool {
+   |
 
 error: renamed function parameter of trait impl
   --> tests/ui-toml/renamed_function_params/renamed_function_params.rs:48:19
    |
 LL |     fn foo(&self, i_dont_wanna_use_your_name: u8) {} // only lint in `extend`
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using the default name: `val`
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using the default name
+   |
+LL -     fn foo(&self, i_dont_wanna_use_your_name: u8) {} // only lint in `extend`
+LL +     fn foo(&self, val: u8) {} // only lint in `extend`
+   |
 
 error: renamed function parameter of trait impl
   --> tests/ui-toml/renamed_function_params/renamed_function_params.rs:57:31
    |
 LL |     fn hash<H: Hasher>(&self, states: &mut H) {
-   |                               ^^^^^^ help: consider using the default name: `state`
+   |                               ^^^^^^
+   |
+help: consider using the default name
+   |
+LL -     fn hash<H: Hasher>(&self, states: &mut H) {
+LL +     fn hash<H: Hasher>(&self, state: &mut H) {
+   |
 
 error: renamed function parameters of trait impl
   --> tests/ui-toml/renamed_function_params/renamed_function_params.rs:61:30
@@ -41,7 +64,13 @@ error: renamed function parameter of trait impl
   --> tests/ui-toml/renamed_function_params/renamed_function_params.rs:82:18
    |
 LL |     fn add(self, b: B) -> C {
-   |                  ^ help: consider using the default name: `rhs`
+   |                  ^
+   |
+help: consider using the default name
+   |
+LL -     fn add(self, b: B) -> C {
+LL +     fn add(self, rhs: B) -> C {
+   |
 
 error: aborting due to 6 previous errors
 

--- a/src/tools/clippy/tests/ui-toml/renamed_function_params/renamed_function_params.extend.stderr
+++ b/src/tools/clippy/tests/ui-toml/renamed_function_params/renamed_function_params.extend.stderr
@@ -2,22 +2,39 @@ error: renamed function parameter of trait impl
   --> tests/ui-toml/renamed_function_params/renamed_function_params.rs:30:18
    |
 LL |     fn eq(&self, rhs: &Self) -> bool {
-   |                  ^^^ help: consider using the default name: `other`
+   |                  ^^^
    |
    = note: `-D clippy::renamed-function-params` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::renamed_function_params)]`
+help: consider using the default name
+   |
+LL -     fn eq(&self, rhs: &Self) -> bool {
+LL +     fn eq(&self, other: &Self) -> bool {
+   |
 
 error: renamed function parameter of trait impl
   --> tests/ui-toml/renamed_function_params/renamed_function_params.rs:34:18
    |
 LL |     fn ne(&self, rhs: &Self) -> bool {
-   |                  ^^^ help: consider using the default name: `other`
+   |                  ^^^
+   |
+help: consider using the default name
+   |
+LL -     fn ne(&self, rhs: &Self) -> bool {
+LL +     fn ne(&self, other: &Self) -> bool {
+   |
 
 error: renamed function parameter of trait impl
   --> tests/ui-toml/renamed_function_params/renamed_function_params.rs:57:31
    |
 LL |     fn hash<H: Hasher>(&self, states: &mut H) {
-   |                               ^^^^^^ help: consider using the default name: `state`
+   |                               ^^^^^^
+   |
+help: consider using the default name
+   |
+LL -     fn hash<H: Hasher>(&self, states: &mut H) {
+LL +     fn hash<H: Hasher>(&self, state: &mut H) {
+   |
 
 error: renamed function parameters of trait impl
   --> tests/ui-toml/renamed_function_params/renamed_function_params.rs:61:30

--- a/src/tools/clippy/tests/ui/default_constructed_unit_structs.stderr
+++ b/src/tools/clippy/tests/ui/default_constructed_unit_structs.stderr
@@ -2,52 +2,75 @@ error: use of `default` to create a unit struct
   --> tests/ui/default_constructed_unit_structs.rs:11:9
    |
 LL |         Self::default()
-   |         ^^^^-----------
-   |             |
-   |             help: remove this call to `default`
+   |         ^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::default-constructed-unit-structs` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::default_constructed_unit_structs)]`
+help: remove this call to `default`
+   |
+LL -         Self::default()
+LL +         Self
+   |
 
 error: use of `default` to create a unit struct
   --> tests/ui/default_constructed_unit_structs.rs:54:20
    |
 LL |             inner: PhantomData::default(),
-   |                    ^^^^^^^^^^^-----------
-   |                               |
-   |                               help: remove this call to `default`
+   |                    ^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove this call to `default`
+   |
+LL -             inner: PhantomData::default(),
+LL +             inner: PhantomData,
+   |
 
 error: use of `default` to create a unit struct
   --> tests/ui/default_constructed_unit_structs.rs:128:13
    |
 LL |     let _ = PhantomData::<usize>::default();
-   |             ^^^^^^^^^^^^^^^^^^^^-----------
-   |                                 |
-   |                                 help: remove this call to `default`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove this call to `default`
+   |
+LL -     let _ = PhantomData::<usize>::default();
+LL +     let _ = PhantomData::<usize>;
+   |
 
 error: use of `default` to create a unit struct
   --> tests/ui/default_constructed_unit_structs.rs:130:31
    |
 LL |     let _: PhantomData<i32> = PhantomData::default();
-   |                               ^^^^^^^^^^^-----------
-   |                                          |
-   |                                          help: remove this call to `default`
+   |                               ^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove this call to `default`
+   |
+LL -     let _: PhantomData<i32> = PhantomData::default();
+LL +     let _: PhantomData<i32> = PhantomData;
+   |
 
 error: use of `default` to create a unit struct
   --> tests/ui/default_constructed_unit_structs.rs:132:31
    |
 LL |     let _: PhantomData<i32> = std::marker::PhantomData::default();
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^-----------
-   |                                                       |
-   |                                                       help: remove this call to `default`
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove this call to `default`
+   |
+LL -     let _: PhantomData<i32> = std::marker::PhantomData::default();
+LL +     let _: PhantomData<i32> = std::marker::PhantomData;
+   |
 
 error: use of `default` to create a unit struct
   --> tests/ui/default_constructed_unit_structs.rs:134:13
    |
 LL |     let _ = UnitStruct::default();
-   |             ^^^^^^^^^^-----------
-   |                       |
-   |                       help: remove this call to `default`
+   |             ^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove this call to `default`
+   |
+LL -     let _ = UnitStruct::default();
+LL +     let _ = UnitStruct;
+   |
 
 error: use of `default` to create a unit struct
   --> tests/ui/default_constructed_unit_structs.rs:172:7

--- a/src/tools/clippy/tests/ui/double_ended_iterator_last.stderr
+++ b/src/tools/clippy/tests/ui/double_ended_iterator_last.stderr
@@ -2,20 +2,27 @@ error: called `Iterator::last` on a `DoubleEndedIterator`; this will needlessly 
   --> tests/ui/double_ended_iterator_last.rs:5:5
    |
 LL |     s.split(' ').last()
-   |     ^^^^^^^^^^^^^------
-   |                  |
-   |                  help: try: `next_back()`
+   |     ^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::double-ended-iterator-last` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::double_ended_iterator_last)]`
+help: try
+   |
+LL -     s.split(' ').last()
+LL +     s.split(' ').next_back()
+   |
 
 error: called `Iterator::last` on a `DoubleEndedIterator`; this will needlessly iterate the entire iterator
   --> tests/ui/double_ended_iterator_last.rs:22:13
    |
 LL |     let _ = DeIterator.last();
-   |             ^^^^^^^^^^^------
-   |                        |
-   |                        help: try: `next_back()`
+   |             ^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     let _ = DeIterator.last();
+LL +     let _ = DeIterator.next_back();
+   |
 
 error: called `Iterator::last` on a `DoubleEndedIterator`; this will needlessly iterate the entire iterator
   --> tests/ui/double_ended_iterator_last.rs:114:36

--- a/src/tools/clippy/tests/ui/extra_unused_type_parameters.stderr
+++ b/src/tools/clippy/tests/ui/extra_unused_type_parameters.stderr
@@ -2,22 +2,39 @@ error: type parameter `T` goes unused in function definition
   --> tests/ui/extra_unused_type_parameters.rs:9:13
    |
 LL | fn unused_ty<T>(x: u8) {
-   |             ^^^ help: consider removing the parameter
+   |             ^^^
    |
    = note: `-D clippy::extra-unused-type-parameters` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::extra_unused_type_parameters)]`
+help: consider removing the parameter
+   |
+LL - fn unused_ty<T>(x: u8) {
+LL + fn unused_ty(x: u8) {
+   |
 
 error: type parameters go unused in function definition: T, U
   --> tests/ui/extra_unused_type_parameters.rs:14:16
    |
 LL | fn unused_multi<T, U>(x: u8) {
-   |                ^^^^^^ help: consider removing the parameters
+   |                ^^^^^^
+   |
+help: consider removing the parameters
+   |
+LL - fn unused_multi<T, U>(x: u8) {
+LL + fn unused_multi(x: u8) {
+   |
 
 error: type parameter `T` goes unused in function definition
   --> tests/ui/extra_unused_type_parameters.rs:19:21
    |
 LL | fn unused_with_lt<'a, T>(x: &'a u8) {
-   |                     ^^^ help: consider removing the parameter
+   |                     ^^^
+   |
+help: consider removing the parameter
+   |
+LL - fn unused_with_lt<'a, T>(x: &'a u8) {
+LL + fn unused_with_lt<'a>(x: &'a u8) {
+   |
 
 error: type parameters go unused in function definition: T, V
   --> tests/ui/extra_unused_type_parameters.rs:32:19
@@ -47,19 +64,37 @@ error: type parameter `T` goes unused in function definition
   --> tests/ui/extra_unused_type_parameters.rs:63:22
    |
 LL |     fn unused_ty_impl<T>(&self) {
-   |                      ^^^ help: consider removing the parameter
+   |                      ^^^
+   |
+help: consider removing the parameter
+   |
+LL -     fn unused_ty_impl<T>(&self) {
+LL +     fn unused_ty_impl(&self) {
+   |
 
 error: type parameters go unused in function definition: A, B
   --> tests/ui/extra_unused_type_parameters.rs:86:17
    |
 LL | fn unused_opaque<A, B>(dummy: impl Default) {
-   |                 ^^^^^^ help: consider removing the parameters
+   |                 ^^^^^^
+   |
+help: consider removing the parameters
+   |
+LL - fn unused_opaque<A, B>(dummy: impl Default) {
+LL + fn unused_opaque(dummy: impl Default) {
+   |
 
 error: type parameter `U` goes unused in function definition
   --> tests/ui/extra_unused_type_parameters.rs:100:56
    |
 LL |     fn unused_with_priv_trait_bound<T: private::Private, U>() {
-   |                                                        ^^^ help: consider removing the parameter
+   |                                                        ^^^
+   |
+help: consider removing the parameter
+   |
+LL -     fn unused_with_priv_trait_bound<T: private::Private, U>() {
+LL +     fn unused_with_priv_trait_bound<T: private::Private>() {
+   |
 
 error: aborting due to 8 previous errors
 

--- a/src/tools/clippy/tests/ui/manual_is_ascii_check.stderr
+++ b/src/tools/clippy/tests/ui/manual_is_ascii_check.stderr
@@ -2,148 +2,291 @@ error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:5:13
    |
 LL |     assert!(matches!('x', 'a'..='z'));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'x'.is_ascii_lowercase()`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::manual-is-ascii-check` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::manual_is_ascii_check)]`
+help: try
+   |
+LL -     assert!(matches!('x', 'a'..='z'));
+LL +     assert!('x'.is_ascii_lowercase());
+   |
 
 error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:7:13
    |
 LL |     assert!(matches!('X', 'A'..='Z'));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'X'.is_ascii_uppercase()`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     assert!(matches!('X', 'A'..='Z'));
+LL +     assert!('X'.is_ascii_uppercase());
+   |
 
 error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:9:13
    |
 LL |     assert!(matches!(b'x', b'a'..=b'z'));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b'x'.is_ascii_lowercase()`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     assert!(matches!(b'x', b'a'..=b'z'));
+LL +     assert!(b'x'.is_ascii_lowercase());
+   |
 
 error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:11:13
    |
 LL |     assert!(matches!(b'X', b'A'..=b'Z'));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b'X'.is_ascii_uppercase()`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     assert!(matches!(b'X', b'A'..=b'Z'));
+LL +     assert!(b'X'.is_ascii_uppercase());
+   |
 
 error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:15:13
    |
 LL |     assert!(matches!(num, '0'..='9'));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `num.is_ascii_digit()`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     assert!(matches!(num, '0'..='9'));
+LL +     assert!(num.is_ascii_digit());
+   |
 
 error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:17:13
    |
 LL |     assert!(matches!(b'1', b'0'..=b'9'));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b'1'.is_ascii_digit()`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     assert!(matches!(b'1', b'0'..=b'9'));
+LL +     assert!(b'1'.is_ascii_digit());
+   |
 
 error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:19:13
    |
 LL |     assert!(matches!('x', 'A'..='Z' | 'a'..='z'));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'x'.is_ascii_alphabetic()`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     assert!(matches!('x', 'A'..='Z' | 'a'..='z'));
+LL +     assert!('x'.is_ascii_alphabetic());
+   |
 
 error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:24:5
    |
 LL |     (b'0'..=b'9').contains(&b'0');
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b'0'.is_ascii_digit()`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     (b'0'..=b'9').contains(&b'0');
+LL +     b'0'.is_ascii_digit();
+   |
 
 error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:26:5
    |
 LL |     (b'a'..=b'z').contains(&b'a');
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b'a'.is_ascii_lowercase()`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     (b'a'..=b'z').contains(&b'a');
+LL +     b'a'.is_ascii_lowercase();
+   |
 
 error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:28:5
    |
 LL |     (b'A'..=b'Z').contains(&b'A');
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b'A'.is_ascii_uppercase()`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     (b'A'..=b'Z').contains(&b'A');
+LL +     b'A'.is_ascii_uppercase();
+   |
 
 error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:31:5
    |
 LL |     ('0'..='9').contains(&'0');
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'0'.is_ascii_digit()`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     ('0'..='9').contains(&'0');
+LL +     '0'.is_ascii_digit();
+   |
 
 error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:33:5
    |
 LL |     ('a'..='z').contains(&'a');
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'a'.is_ascii_lowercase()`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     ('a'..='z').contains(&'a');
+LL +     'a'.is_ascii_lowercase();
+   |
 
 error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:35:5
    |
 LL |     ('A'..='Z').contains(&'A');
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'A'.is_ascii_uppercase()`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     ('A'..='Z').contains(&'A');
+LL +     'A'.is_ascii_uppercase();
+   |
 
 error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:39:5
    |
 LL |     ('0'..='9').contains(cool_letter);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `cool_letter.is_ascii_digit()`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     ('0'..='9').contains(cool_letter);
+LL +     cool_letter.is_ascii_digit();
+   |
 
 error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:41:5
    |
 LL |     ('a'..='z').contains(cool_letter);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `cool_letter.is_ascii_lowercase()`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     ('a'..='z').contains(cool_letter);
+LL +     cool_letter.is_ascii_lowercase();
+   |
 
 error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:43:5
    |
 LL |     ('A'..='Z').contains(cool_letter);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `cool_letter.is_ascii_uppercase()`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     ('A'..='Z').contains(cool_letter);
+LL +     cool_letter.is_ascii_uppercase();
+   |
 
 error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:57:13
    |
 LL |     assert!(matches!(b'1', b'0'..=b'9'));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b'1'.is_ascii_digit()`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     assert!(matches!(b'1', b'0'..=b'9'));
+LL +     assert!(b'1'.is_ascii_digit());
+   |
 
 error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:59:13
    |
 LL |     assert!(matches!('X', 'A'..='Z'));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'X'.is_ascii_uppercase()`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     assert!(matches!('X', 'A'..='Z'));
+LL +     assert!('X'.is_ascii_uppercase());
+   |
 
 error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:61:13
    |
 LL |     assert!(matches!('x', 'A'..='Z' | 'a'..='z'));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'x'.is_ascii_alphabetic()`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     assert!(matches!('x', 'A'..='Z' | 'a'..='z'));
+LL +     assert!('x'.is_ascii_alphabetic());
+   |
 
 error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:63:13
    |
 LL |     assert!(matches!('x', '0'..='9' | 'a'..='f' | 'A'..='F'));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'x'.is_ascii_hexdigit()`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     assert!(matches!('x', '0'..='9' | 'a'..='f' | 'A'..='F'));
+LL +     assert!('x'.is_ascii_hexdigit());
+   |
 
 error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:75:23
    |
 LL |     const FOO: bool = matches!('x', '0'..='9');
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'x'.is_ascii_digit()`
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     const FOO: bool = matches!('x', '0'..='9');
+LL +     const FOO: bool = 'x'.is_ascii_digit();
+   |
 
 error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:77:23
    |
 LL |     const BAR: bool = matches!('x', '0'..='9' | 'a'..='f' | 'A'..='F');
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'x'.is_ascii_hexdigit()`
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     const BAR: bool = matches!('x', '0'..='9' | 'a'..='f' | 'A'..='F');
+LL +     const BAR: bool = 'x'.is_ascii_hexdigit();
+   |
 
 error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:84:5
    |
 LL |     ('0'..='9').contains(&&cool_letter);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `cool_letter.is_ascii_digit()`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     ('0'..='9').contains(&&cool_letter);
+LL +     cool_letter.is_ascii_digit();
+   |
 
 error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:86:5
    |
 LL |     ('a'..='z').contains(*cool_letter);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `cool_letter.is_ascii_lowercase()`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     ('a'..='z').contains(*cool_letter);
+LL +     cool_letter.is_ascii_lowercase();
+   |
 
 error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:105:20
@@ -173,7 +316,13 @@ error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:109:26
    |
 LL |     take_while(|c: char| ('A'..='Z').contains(&c));
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `c.is_ascii_uppercase()`
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     take_while(|c: char| ('A'..='Z').contains(&c));
+LL +     take_while(|c: char| c.is_ascii_uppercase());
+   |
 
 error: manual check for common ascii range
   --> tests/ui/manual_is_ascii_check.rs:111:20

--- a/src/tools/clippy/tests/ui/mutex_atomic.stderr
+++ b/src/tools/clippy/tests/ui/mutex_atomic.stderr
@@ -2,69 +2,109 @@ error: using a `Mutex` where an atomic would do
   --> tests/ui/mutex_atomic.rs:8:13
    |
 LL |     let _ = Mutex::new(true);
-   |             ^^^^^^^^^^^^^^^^ help: try: `std::sync::atomic::AtomicBool::new(true)`
+   |             ^^^^^^^^^^^^^^^^
    |
    = help: if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
    = note: `-D clippy::mutex-atomic` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::mutex_atomic)]`
+help: try
+   |
+LL -     let _ = Mutex::new(true);
+LL +     let _ = std::sync::atomic::AtomicBool::new(true);
+   |
 
 error: using a `Mutex` where an atomic would do
   --> tests/ui/mutex_atomic.rs:11:13
    |
 LL |     let _ = Mutex::new(5usize);
-   |             ^^^^^^^^^^^^^^^^^^ help: try: `std::sync::atomic::AtomicUsize::new(5usize)`
+   |             ^^^^^^^^^^^^^^^^^^
    |
    = help: if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
+help: try
+   |
+LL -     let _ = Mutex::new(5usize);
+LL +     let _ = std::sync::atomic::AtomicUsize::new(5usize);
+   |
 
 error: using a `Mutex` where an atomic would do
   --> tests/ui/mutex_atomic.rs:14:13
    |
 LL |     let _ = Mutex::new(9isize);
-   |             ^^^^^^^^^^^^^^^^^^ help: try: `std::sync::atomic::AtomicIsize::new(9isize)`
+   |             ^^^^^^^^^^^^^^^^^^
    |
    = help: if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
+help: try
+   |
+LL -     let _ = Mutex::new(9isize);
+LL +     let _ = std::sync::atomic::AtomicIsize::new(9isize);
+   |
 
 error: using a `Mutex` where an atomic would do
   --> tests/ui/mutex_atomic.rs:21:13
    |
 LL |     let _ = Mutex::new(&mut x as *mut u32);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::sync::atomic::AtomicPtr::new(&mut x as *mut u32)`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
+help: try
+   |
+LL -     let _ = Mutex::new(&mut x as *mut u32);
+LL +     let _ = std::sync::atomic::AtomicPtr::new(&mut x as *mut u32);
+   |
 
 error: using a `Mutex` where an atomic would do
   --> tests/ui/mutex_atomic.rs:24:13
    |
 LL |     let _ = Mutex::new(0u32);
-   |             ^^^^^^^^^^^^^^^^ help: try: `std::sync::atomic::AtomicU32::new(0u32)`
+   |             ^^^^^^^^^^^^^^^^
    |
    = help: if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
    = note: `-D clippy::mutex-integer` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::mutex_integer)]`
+help: try
+   |
+LL -     let _ = Mutex::new(0u32);
+LL +     let _ = std::sync::atomic::AtomicU32::new(0u32);
+   |
 
 error: using a `Mutex` where an atomic would do
   --> tests/ui/mutex_atomic.rs:27:13
    |
 LL |     let _ = Mutex::new(0i32);
-   |             ^^^^^^^^^^^^^^^^ help: try: `std::sync::atomic::AtomicI32::new(0i32)`
+   |             ^^^^^^^^^^^^^^^^
    |
    = help: if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
+help: try
+   |
+LL -     let _ = Mutex::new(0i32);
+LL +     let _ = std::sync::atomic::AtomicI32::new(0i32);
+   |
 
 error: using a `Mutex` where an atomic would do
   --> tests/ui/mutex_atomic.rs:31:13
    |
 LL |     let _ = Mutex::new(0u8);
-   |             ^^^^^^^^^^^^^^^ help: try: `std::sync::atomic::AtomicU8::new(0u8)`
+   |             ^^^^^^^^^^^^^^^
    |
    = help: if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
+help: try
+   |
+LL -     let _ = Mutex::new(0u8);
+LL +     let _ = std::sync::atomic::AtomicU8::new(0u8);
+   |
 
 error: using a `Mutex` where an atomic would do
   --> tests/ui/mutex_atomic.rs:34:13
    |
 LL |     let _ = Mutex::new(0i16);
-   |             ^^^^^^^^^^^^^^^^ help: try: `std::sync::atomic::AtomicI16::new(0i16)`
+   |             ^^^^^^^^^^^^^^^^
    |
    = help: if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
+help: try
+   |
+LL -     let _ = Mutex::new(0i16);
+LL +     let _ = std::sync::atomic::AtomicI16::new(0i16);
+   |
 
 error: using a `Mutex` where an atomic would do
   --> tests/ui/mutex_atomic.rs:37:25
@@ -83,9 +123,14 @@ error: using a `Mutex` where an atomic would do
   --> tests/ui/mutex_atomic.rs:41:13
    |
 LL |     let _ = Mutex::new(X);
-   |             ^^^^^^^^^^^^^ help: try: `std::sync::atomic::AtomicI64::new(X)`
+   |             ^^^^^^^^^^^^^
    |
    = help: if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
+help: try
+   |
+LL -     let _ = Mutex::new(X);
+LL +     let _ = std::sync::atomic::AtomicI64::new(X);
+   |
 
 error: using a `Mutex` where an atomic would do
   --> tests/ui/mutex_atomic.rs:53:30
@@ -104,9 +149,14 @@ error: using a `Mutex` where an atomic would do
   --> tests/ui/mutex_atomic.rs:56:15
    |
 LL |     let mtx = Mutex::new(0);
-   |               ^^^^^^^^^^^^^ help: try: `std::sync::atomic::AtomicI32::new(0)`
+   |               ^^^^^^^^^^^^^
    |
    = help: if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
+help: try
+   |
+LL -     let mtx = Mutex::new(0);
+LL +     let mtx = std::sync::atomic::AtomicI32::new(0);
+   |
 
 error: using a `Mutex` where an atomic would do
   --> tests/ui/mutex_atomic.rs:60:22
@@ -134,9 +184,14 @@ error: using a `Mutex` where an atomic would do
   --> tests/ui/mutex_atomic.rs:76:13
    |
 LL |     let _ = Mutex::new(test_expr!(1));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::sync::atomic::AtomicBool::new(test_expr!(1))`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
+help: try
+   |
+LL -     let _ = Mutex::new(test_expr!(1));
+LL +     let _ = std::sync::atomic::AtomicBool::new(test_expr!(1));
+   |
 
 error: aborting due to 15 previous errors
 

--- a/src/tools/clippy/tests/ui/needless_borrow_pat.stderr
+++ b/src/tools/clippy/tests/ui/needless_borrow_pat.stderr
@@ -2,10 +2,15 @@ error: this pattern creates a reference to a reference
   --> tests/ui/needless_borrow_pat.rs:57:14
    |
 LL |         Some(ref x) => x,
-   |              ^^^^^ help: try: `x`
+   |              ^^^^^
    |
    = note: `-D clippy::needless-borrow` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::needless_borrow)]`
+help: try
+   |
+LL -         Some(ref x) => x,
+LL +         Some(x) => x,
+   |
 
 error: this pattern creates a reference to a reference
   --> tests/ui/needless_borrow_pat.rs:64:14
@@ -38,13 +43,25 @@ error: this pattern creates a reference to a reference
   --> tests/ui/needless_borrow_pat.rs:83:14
    |
 LL |         Some(ref x) => m1!(x),
-   |              ^^^^^ help: try: `x`
+   |              ^^^^^
+   |
+help: try
+   |
+LL -         Some(ref x) => m1!(x),
+LL +         Some(x) => m1!(x),
+   |
 
 error: this pattern creates a reference to a reference
   --> tests/ui/needless_borrow_pat.rs:89:15
    |
 LL |     let _ = |&ref x: &&String| {
-   |               ^^^^^ help: try: `x`
+   |               ^^^^^
+   |
+help: try
+   |
+LL -     let _ = |&ref x: &&String| {
+LL +     let _ = |&x: &&String| {
+   |
 
 error: this pattern creates a reference to a reference
   --> tests/ui/needless_borrow_pat.rs:96:10
@@ -64,7 +81,13 @@ error: this pattern creates a reference to a reference
   --> tests/ui/needless_borrow_pat.rs:108:14
    |
 LL |         Some(ref x) => x.0,
-   |              ^^^^^ help: try: `x`
+   |              ^^^^^
+   |
+help: try
+   |
+LL -         Some(ref x) => x.0,
+LL +         Some(x) => x.0,
+   |
 
 error: this pattern creates a reference to a reference
   --> tests/ui/needless_borrow_pat.rs:119:14
@@ -82,7 +105,13 @@ error: this pattern creates a reference to a reference
   --> tests/ui/needless_borrow_pat.rs:126:21
    |
 LL |         if let Some(ref x) = Some(&String::new());
-   |                     ^^^^^ help: try: `x`
+   |                     ^^^^^
+   |
+help: try
+   |
+LL -         if let Some(ref x) = Some(&String::new());
+LL +         if let Some(x) = Some(&String::new());
+   |
 
 error: this pattern creates a reference to a reference
   --> tests/ui/needless_borrow_pat.rs:136:12
@@ -103,7 +132,13 @@ error: this pattern creates a reference to a reference
   --> tests/ui/needless_borrow_pat.rs:145:11
    |
 LL |     fn f(&ref x: &&String) {
-   |           ^^^^^ help: try: `x`
+   |           ^^^^^
+   |
+help: try
+   |
+LL -     fn f(&ref x: &&String) {
+LL +     fn f(&x: &&String) {
+   |
 
 error: this pattern creates a reference to a reference
   --> tests/ui/needless_borrow_pat.rs:155:11

--- a/src/tools/clippy/tests/ui/non_canonical_partial_ord_impl.stderr
+++ b/src/tools/clippy/tests/ui/non_canonical_partial_ord_impl.stderr
@@ -1,18 +1,23 @@
 error: non-canonical implementation of `partial_cmp` on an `Ord` type
   --> tests/ui/non_canonical_partial_ord_impl.rs:20:1
    |
-LL | /  impl PartialOrd for A {
+LL | / impl PartialOrd for A {
 LL | |
-LL | |      fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-   | | _____________________________________________________________-
-LL | ||         todo!();
-LL | ||     }
-   | ||_____- help: change this to: `{ Some(self.cmp(other)) }`
-LL | |  }
-   | |__^
+LL | |     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+LL | |         todo!();
+LL | |     }
+LL | | }
+   | |_^
    |
    = note: `-D clippy::non-canonical-partial-ord-impl` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::non_canonical_partial_ord_impl)]`
+help: change this to
+   |
+LL -     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+LL -         todo!();
+LL -     }
+LL +     fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(self.cmp(other)) }
+   |
 
 error: non-canonical implementation of `partial_cmp` on an `Ord` type
   --> tests/ui/non_canonical_partial_ord_impl.rs:55:1
@@ -36,43 +41,60 @@ LL +     fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(self.cmp
 error: non-canonical implementation of `partial_cmp` on an `Ord` type
   --> tests/ui/non_canonical_partial_ord_impl.rs:191:9
    |
-LL | /          impl PartialOrd for A {
+LL | /         impl PartialOrd for A {
 LL | |
-LL | |              fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-   | | _____________________________________________________________________-
-LL | ||                 todo!();
-LL | ||             }
-   | ||_____________- help: change this to: `{ Some(self.cmp(other)) }`
-LL | |          }
-   | |__________^
+LL | |             fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+LL | |                 todo!();
+LL | |             }
+LL | |         }
+   | |_________^
    |
    = note: this error originates in the macro `__inline_mac_mod_issue12788` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: change this to
+   |
+LL -             fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+LL -                 todo!();
+LL -             }
+LL +             fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(self.cmp(other)) }
+   |
 
 error: non-canonical implementation of `partial_cmp` on an `Ord` type
   --> tests/ui/non_canonical_partial_ord_impl.rs:271:1
    |
-LL | /  impl PartialOrd for K {
+LL | / impl PartialOrd for K {
 LL | |
-LL | |      fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-   | | _____________________________________________________________-
-LL | ||         Ordering::Greater.into()
-LL | ||     }
-   | ||_____- help: change this to: `{ Some(self.cmp(other)) }`
-LL | |  }
-   | |__^
+LL | |     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+LL | |         Ordering::Greater.into()
+LL | |     }
+LL | | }
+   | |_^
+   |
+help: change this to
+   |
+LL -     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+LL -         Ordering::Greater.into()
+LL -     }
+LL +     fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(self.cmp(other)) }
+   |
 
 error: non-canonical implementation of `partial_cmp` on an `Ord` type
   --> tests/ui/non_canonical_partial_ord_impl.rs:289:1
    |
-LL | /  impl PartialOrd for L {
+LL | / impl PartialOrd for L {
 LL | |
-LL | |      fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-   | | _____________________________________________________________-
-LL | ||         Some(other.cmp(self))
-LL | ||     }
-   | ||_____- help: change this to: `{ Some(self.cmp(other)) }`
-LL | |  }
-   | |__^
+LL | |     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+LL | |         Some(other.cmp(self))
+LL | |     }
+LL | | }
+   | |_^
+   |
+help: change this to
+   |
+LL -     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+LL -         Some(other.cmp(self))
+LL -     }
+LL +     fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(self.cmp(other)) }
+   |
 
 error: aborting due to 5 previous errors
 

--- a/src/tools/clippy/tests/ui/non_canonical_partial_ord_impl_fully_qual.stderr
+++ b/src/tools/clippy/tests/ui/non_canonical_partial_ord_impl_fully_qual.stderr
@@ -1,34 +1,43 @@
 error: non-canonical implementation of `partial_cmp` on an `Ord` type
   --> tests/ui/non_canonical_partial_ord_impl_fully_qual.rs:23:1
    |
-LL | /  impl PartialOrd for A {
+LL | / impl PartialOrd for A {
 LL | |
-LL | |      fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-   | | _____________________________________________________________-
-LL | ||         // NOTE: This suggestion is wrong, as `Ord` is not in scope. But this should be fine as it isn't
-LL | ||         // automatically applied
-LL | ||         todo!();
-LL | ||     }
-   | ||_____- help: change this to: `{ Some(self.cmp(other)) }`
-LL | |  }
-   | |__^
+LL | |     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+...  |
+LL | | }
+   | |_^
    |
    = note: `-D clippy::non-canonical-partial-ord-impl` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::non_canonical_partial_ord_impl)]`
+help: change this to
+   |
+LL -     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+LL -         // NOTE: This suggestion is wrong, as `Ord` is not in scope. But this should be fine as it isn't
+LL -         // automatically applied
+LL -         todo!();
+LL -     }
+LL +     fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(self.cmp(other)) }
+   |
 
 error: non-canonical implementation of `partial_cmp` on an `Ord` type
   --> tests/ui/non_canonical_partial_ord_impl_fully_qual.rs:47:1
    |
-LL | /  impl PartialOrd for B {
+LL | / impl PartialOrd for B {
 LL | |
-LL | |      fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-   | | _____________________________________________________________-
-LL | ||         // This calls `B.cmp`, not `Ord::cmp`!
-LL | ||         Some(self.cmp(other))
-LL | ||     }
-   | ||_____- help: change this to: `{ Some(std::cmp::Ord::cmp(self, other)) }`
-LL | |  }
-   | |__^
+LL | |     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+...  |
+LL | | }
+   | |_^
+   |
+help: change this to
+   |
+LL -     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+LL -         // This calls `B.cmp`, not `Ord::cmp`!
+LL -         Some(self.cmp(other))
+LL -     }
+LL +     fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(std::cmp::Ord::cmp(self, other)) }
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/tools/clippy/tests/ui/ptr_arg.stderr
+++ b/src/tools/clippy/tests/ui/ptr_arg.stderr
@@ -2,46 +2,87 @@ error: writing `&Vec` instead of `&[_]` involves a new object where a slice will
   --> tests/ui/ptr_arg.rs:13:14
    |
 LL | fn do_vec(x: &Vec<i64>) {
-   |              ^^^^^^^^^ help: change this to: `&[i64]`
+   |              ^^^^^^^^^
    |
    = note: `-D clippy::ptr-arg` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::ptr_arg)]`
+help: change this to
+   |
+LL - fn do_vec(x: &Vec<i64>) {
+LL + fn do_vec(x: &[i64]) {
+   |
 
 error: writing `&mut Vec` instead of `&mut [_]` involves a new object where a slice will do
   --> tests/ui/ptr_arg.rs:19:18
    |
 LL | fn do_vec_mut(x: &mut Vec<i64>) {
-   |                  ^^^^^^^^^^^^^ help: change this to: `&mut [i64]`
+   |                  ^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL - fn do_vec_mut(x: &mut Vec<i64>) {
+LL + fn do_vec_mut(x: &mut [i64]) {
+   |
 
 error: writing `&mut Vec` instead of `&mut [_]` involves a new object where a slice will do
   --> tests/ui/ptr_arg.rs:25:19
    |
 LL | fn do_vec_mut2(x: &mut Vec<i64>) {
-   |                   ^^^^^^^^^^^^^ help: change this to: `&mut [i64]`
+   |                   ^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL - fn do_vec_mut2(x: &mut Vec<i64>) {
+LL + fn do_vec_mut2(x: &mut [i64]) {
+   |
 
 error: writing `&String` instead of `&str` involves a new object where a slice will do
   --> tests/ui/ptr_arg.rs:32:14
    |
 LL | fn do_str(x: &String) {
-   |              ^^^^^^^ help: change this to: `&str`
+   |              ^^^^^^^
+   |
+help: change this to
+   |
+LL - fn do_str(x: &String) {
+LL + fn do_str(x: &str) {
+   |
 
 error: writing `&mut String` instead of `&mut str` involves a new object where a slice will do
   --> tests/ui/ptr_arg.rs:38:18
    |
 LL | fn do_str_mut(x: &mut String) {
-   |                  ^^^^^^^^^^^ help: change this to: `&mut str`
+   |                  ^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL - fn do_str_mut(x: &mut String) {
+LL + fn do_str_mut(x: &mut str) {
+   |
 
 error: writing `&PathBuf` instead of `&Path` involves a new object where a slice will do
   --> tests/ui/ptr_arg.rs:44:15
    |
 LL | fn do_path(x: &PathBuf) {
-   |               ^^^^^^^^ help: change this to: `&Path`
+   |               ^^^^^^^^
+   |
+help: change this to
+   |
+LL - fn do_path(x: &PathBuf) {
+LL + fn do_path(x: &Path) {
+   |
 
 error: writing `&mut PathBuf` instead of `&mut Path` involves a new object where a slice will do
   --> tests/ui/ptr_arg.rs:50:19
    |
 LL | fn do_path_mut(x: &mut PathBuf) {
-   |                   ^^^^^^^^^^^^ help: change this to: `&mut Path`
+   |                   ^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL - fn do_path_mut(x: &mut PathBuf) {
+LL + fn do_path_mut(x: &mut Path) {
+   |
 
 error: writing `&Vec` instead of `&[_]` involves a new object where a slice will do
   --> tests/ui/ptr_arg.rs:60:18
@@ -130,7 +171,13 @@ error: writing `&String` instead of `&str` involves a new object where a slice w
   --> tests/ui/ptr_arg.rs:152:64
    |
 LL |     fn some_allowed(#[allow(clippy::ptr_arg)] v: &Vec<u32>, s: &String) {}
-   |                                                                ^^^^^^^ help: change this to: `&str`
+   |                                                                ^^^^^^^
+   |
+help: change this to
+   |
+LL -     fn some_allowed(#[allow(clippy::ptr_arg)] v: &Vec<u32>, s: &String) {}
+LL +     fn some_allowed(#[allow(clippy::ptr_arg)] v: &Vec<u32>, s: &str) {}
+   |
 
 error: writing `&Vec` instead of `&[_]` involves a new object where a slice will do
   --> tests/ui/ptr_arg.rs:182:21
@@ -181,25 +228,49 @@ error: writing `&mut Vec` instead of `&mut [_]` involves a new object where a sl
   --> tests/ui/ptr_arg.rs:204:29
    |
 LL | fn mut_vec_slice_methods(v: &mut Vec<u32>) {
-   |                             ^^^^^^^^^^^^^ help: change this to: `&mut [u32]`
+   |                             ^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL - fn mut_vec_slice_methods(v: &mut Vec<u32>) {
+LL + fn mut_vec_slice_methods(v: &mut [u32]) {
+   |
 
 error: writing `&mut Vec` instead of `&mut [_]` involves a new object where a slice will do
   --> tests/ui/ptr_arg.rs:268:17
    |
 LL | fn dyn_trait(a: &mut Vec<u32>, b: &mut String, c: &mut PathBuf) {
-   |                 ^^^^^^^^^^^^^ help: change this to: `&mut [u32]`
+   |                 ^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL - fn dyn_trait(a: &mut Vec<u32>, b: &mut String, c: &mut PathBuf) {
+LL + fn dyn_trait(a: &mut [u32], b: &mut String, c: &mut PathBuf) {
+   |
 
 error: writing `&mut String` instead of `&mut str` involves a new object where a slice will do
   --> tests/ui/ptr_arg.rs:268:35
    |
 LL | fn dyn_trait(a: &mut Vec<u32>, b: &mut String, c: &mut PathBuf) {
-   |                                   ^^^^^^^^^^^ help: change this to: `&mut str`
+   |                                   ^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL - fn dyn_trait(a: &mut Vec<u32>, b: &mut String, c: &mut PathBuf) {
+LL + fn dyn_trait(a: &mut Vec<u32>, b: &mut str, c: &mut PathBuf) {
+   |
 
 error: writing `&mut PathBuf` instead of `&mut Path` involves a new object where a slice will do
   --> tests/ui/ptr_arg.rs:268:51
    |
 LL | fn dyn_trait(a: &mut Vec<u32>, b: &mut String, c: &mut PathBuf) {
-   |                                                   ^^^^^^^^^^^^ help: change this to: `&mut Path`
+   |                                                   ^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL - fn dyn_trait(a: &mut Vec<u32>, b: &mut String, c: &mut PathBuf) {
+LL + fn dyn_trait(a: &mut Vec<u32>, b: &mut String, c: &mut Path) {
+   |
 
 error: using a reference to `Cow` is not recommended
   --> tests/ui/ptr_arg.rs:295:39
@@ -223,49 +294,97 @@ error: writing `&String` instead of `&str` involves a new object where a slice w
   --> tests/ui/ptr_arg.rs:347:17
    |
 LL |     fn good(v1: &String, v2: &String) {
-   |                 ^^^^^^^ help: change this to: `&str`
+   |                 ^^^^^^^
+   |
+help: change this to
+   |
+LL -     fn good(v1: &String, v2: &String) {
+LL +     fn good(v1: &str, v2: &String) {
+   |
 
 error: writing `&String` instead of `&str` involves a new object where a slice will do
   --> tests/ui/ptr_arg.rs:347:30
    |
 LL |     fn good(v1: &String, v2: &String) {
-   |                              ^^^^^^^ help: change this to: `&str`
+   |                              ^^^^^^^
+   |
+help: change this to
+   |
+LL -     fn good(v1: &String, v2: &String) {
+LL +     fn good(v1: &String, v2: &str) {
+   |
 
 error: writing `&Vec` instead of `&[_]` involves a new object where a slice will do
   --> tests/ui/ptr_arg.rs:363:20
    |
 LL |     fn foo_used(x: &Vec<i32>) {
-   |                    ^^^^^^^^^ help: change this to: `&[i32]`
+   |                    ^^^^^^^^^
+   |
+help: change this to
+   |
+LL -     fn foo_used(x: &Vec<i32>) {
+LL +     fn foo_used(x: &[i32]) {
+   |
 
 error: writing `&Vec` instead of `&[_]` involves a new object where a slice will do
   --> tests/ui/ptr_arg.rs:377:26
    |
 LL |     fn foo_local_used(x: &Vec<i32>) {
-   |                          ^^^^^^^^^ help: change this to: `&[i32]`
+   |                          ^^^^^^^^^
+   |
+help: change this to
+   |
+LL -     fn foo_local_used(x: &Vec<i32>) {
+LL +     fn foo_local_used(x: &[i32]) {
+   |
 
 error: writing `&String` instead of `&str` involves a new object where a slice will do
   --> tests/ui/ptr_arg.rs:386:33
    |
 LL |     fn foofoo(_x: &Vec<i32>, y: &String) {
-   |                                 ^^^^^^^ help: change this to: `&str`
+   |                                 ^^^^^^^
+   |
+help: change this to
+   |
+LL -     fn foofoo(_x: &Vec<i32>, y: &String) {
+LL +     fn foofoo(_x: &Vec<i32>, y: &str) {
+   |
 
 error: writing `&mut Vec` instead of `&mut [_]` involves a new object where a slice will do
   --> tests/ui/ptr_arg.rs:407:20
    |
 LL |     fn bar_used(x: &mut Vec<u32>) {
-   |                    ^^^^^^^^^^^^^ help: change this to: `&mut [u32]`
+   |                    ^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL -     fn bar_used(x: &mut Vec<u32>) {
+LL +     fn bar_used(x: &mut [u32]) {
+   |
 
 error: writing `&mut Vec` instead of `&mut [_]` involves a new object where a slice will do
   --> tests/ui/ptr_arg.rs:421:26
    |
 LL |     fn bar_local_used(x: &mut Vec<u32>) {
-   |                          ^^^^^^^^^^^^^ help: change this to: `&mut [u32]`
+   |                          ^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL -     fn bar_local_used(x: &mut Vec<u32>) {
+LL +     fn bar_local_used(x: &mut [u32]) {
+   |
 
 error: writing `&mut String` instead of `&mut str` involves a new object where a slice will do
   --> tests/ui/ptr_arg.rs:430:37
    |
 LL |     fn barbar(_x: &mut Vec<u32>, y: &mut String) {
-   |                                     ^^^^^^^^^^^ help: change this to: `&mut str`
+   |                                     ^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL -     fn barbar(_x: &mut Vec<u32>, y: &mut String) {
+LL +     fn barbar(_x: &mut Vec<u32>, y: &mut str) {
+   |
 
 error: eliding a lifetime that's named elsewhere is confusing
   --> tests/ui/ptr_arg.rs:314:56

--- a/src/tools/clippy/tests/ui/range.stderr
+++ b/src/tools/clippy/tests/ui/range.stderr
@@ -2,11 +2,16 @@ error: using `.zip()` with a range and `.len()`
   --> tests/ui/range.rs:6:14
    |
 LL |     let _x = v1.iter().zip(0..v1.len());
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `v1.iter().enumerate()`
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the order of the element and the index will be swapped
    = note: `-D clippy::range-zip-with-len` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::range_zip_with_len)]`
+help: use
+   |
+LL -     let _x = v1.iter().zip(0..v1.len());
+LL +     let _x = v1.iter().enumerate();
+   |
 
 error: using `.zip()` with a range and `.len()`
   --> tests/ui/range.rs:10:19

--- a/src/tools/clippy/tests/ui/range_unfixable.stderr
+++ b/src/tools/clippy/tests/ui/range_unfixable.stderr
@@ -2,11 +2,16 @@ error: using `.zip()` with a range and `.len()`
   --> tests/ui/range_unfixable.rs:10:5
    |
 LL |     v1.iter().zip(0..v1.len()).filter(|(_, i)| *i < 2).for_each(|(e, i)| {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `v1.iter().enumerate()`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the order of the element and the index will be swapped
    = note: `-D clippy::range-zip-with-len` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::range_zip_with_len)]`
+help: use
+   |
+LL -     v1.iter().zip(0..v1.len()).filter(|(_, i)| *i < 2).for_each(|(e, i)| {
+LL +     v1.iter().enumerate().filter(|(_, i)| *i < 2).for_each(|(e, i)| {
+   |
 
 error: aborting due to 1 previous error
 

--- a/src/tools/clippy/tests/ui/unit_arg_fixable.stderr
+++ b/src/tools/clippy/tests/ui/unit_arg_fixable.stderr
@@ -2,20 +2,27 @@ error: passing a unit value to a function
   --> tests/ui/unit_arg_fixable.rs:16:5
    |
 LL |     foo({});
-   |     ^^^^--^
-   |         |
-   |         help: use a unit literal instead: `()`
+   |     ^^^^^^^
    |
    = note: `-D clippy::unit-arg` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unit_arg)]`
+help: use a unit literal instead
+   |
+LL -     foo({});
+LL +     foo(());
+   |
 
 error: passing a unit value to a function
   --> tests/ui/unit_arg_fixable.rs:18:5
    |
 LL |     foo3({}, 2, 2);
-   |     ^^^^^--^^^^^^^
-   |          |
-   |          help: use a unit literal instead: `()`
+   |     ^^^^^^^^^^^^^^
+   |
+help: use a unit literal instead
+   |
+LL -     foo3({}, 2, 2);
+LL +     foo3((), 2, 2);
+   |
 
 error: passing unit values to a function
   --> tests/ui/unit_arg_fixable.rs:20:5
@@ -46,9 +53,13 @@ error: passing a unit value to a function
   --> tests/ui/unit_arg_fixable.rs:35:5
    |
 LL |     fn_take_unit(Default::default());
-   |     ^^^^^^^^^^^^^------------------^
-   |                  |
-   |                  help: use a unit literal instead: `()`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use a unit literal instead
+   |
+LL -     fn_take_unit(Default::default());
+LL +     fn_take_unit(());
+   |
 
 error: passing a unit value to a function
   --> tests/ui/unit_arg_fixable.rs:49:5
@@ -78,9 +89,13 @@ error: passing a unit value to a function
   --> tests/ui/unit_arg_fixable.rs:60:5
    |
 LL |     fn_take_unit(mac!(nondef Default::default()));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^------------------^^
-   |                              |
-   |                              help: use a unit literal instead: `()`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use a unit literal instead
+   |
+LL -     fn_take_unit(mac!(nondef Default::default()));
+LL +     fn_take_unit(mac!(nondef ()));
+   |
 
 error: passing a unit value to a function
   --> tests/ui/unit_arg_fixable.rs:62:5

--- a/src/tools/clippy/tests/ui/unnecessary_fallible_conversions_unfixable.stderr
+++ b/src/tools/clippy/tests/ui/unnecessary_fallible_conversions_unfixable.stderr
@@ -2,51 +2,81 @@ error: use of a fallible conversion when an infallible one could be used
   --> tests/ui/unnecessary_fallible_conversions_unfixable.rs:27:34
    |
 LL |     let _: Result<Foo, _> = 0i64.try_into();
-   |                                  ^^^^^^^^ help: use: `into`
+   |                                  ^^^^^^^^
    |
    = note: converting `i64` to `Foo` cannot fail
    = note: `-D clippy::unnecessary-fallible-conversions` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_fallible_conversions)]`
+help: use
+   |
+LL -     let _: Result<Foo, _> = 0i64.try_into();
+LL +     let _: Result<Foo, _> = 0i64.into();
+   |
 
 error: use of a fallible conversion when an infallible one could be used
   --> tests/ui/unnecessary_fallible_conversions_unfixable.rs:29:29
    |
 LL |     let _: Result<Foo, _> = i64::try_into(0i64);
-   |                             ^^^^^^^^^^^^^ help: use: `Into::into`
+   |                             ^^^^^^^^^^^^^
    |
    = note: converting `i64` to `Foo` cannot fail
+help: use
+   |
+LL -     let _: Result<Foo, _> = i64::try_into(0i64);
+LL +     let _: Result<Foo, _> = Into::into(0i64);
+   |
 
 error: use of a fallible conversion when an infallible one could be used
   --> tests/ui/unnecessary_fallible_conversions_unfixable.rs:31:29
    |
 LL |     let _: Result<Foo, _> = Foo::try_from(0i64);
-   |                             ^^^^^^^^^^^^^ help: use: `From::from`
+   |                             ^^^^^^^^^^^^^
    |
    = note: converting `i64` to `Foo` cannot fail
+help: use
+   |
+LL -     let _: Result<Foo, _> = Foo::try_from(0i64);
+LL +     let _: Result<Foo, _> = From::from(0i64);
+   |
 
 error: use of a fallible conversion when an infallible one could be used
   --> tests/ui/unnecessary_fallible_conversions_unfixable.rs:34:34
    |
 LL |     let _: Result<i64, _> = 0i32.try_into();
-   |                                  ^^^^^^^^ help: use: `into`
+   |                                  ^^^^^^^^
    |
    = note: converting `i32` to `i64` cannot fail
+help: use
+   |
+LL -     let _: Result<i64, _> = 0i32.try_into();
+LL +     let _: Result<i64, _> = 0i32.into();
+   |
 
 error: use of a fallible conversion when an infallible one could be used
   --> tests/ui/unnecessary_fallible_conversions_unfixable.rs:36:29
    |
 LL |     let _: Result<i64, _> = i32::try_into(0i32);
-   |                             ^^^^^^^^^^^^^ help: use: `Into::into`
+   |                             ^^^^^^^^^^^^^
    |
    = note: converting `i32` to `i64` cannot fail
+help: use
+   |
+LL -     let _: Result<i64, _> = i32::try_into(0i32);
+LL +     let _: Result<i64, _> = Into::into(0i32);
+   |
 
 error: use of a fallible conversion when an infallible one could be used
   --> tests/ui/unnecessary_fallible_conversions_unfixable.rs:38:29
    |
 LL |     let _: Result<i64, _> = <_>::try_from(0i32);
-   |                             ^^^^^^^^^^^^^ help: use: `From::from`
+   |                             ^^^^^^^^^^^^^
    |
    = note: converting `i32` to `i64` cannot fail
+help: use
+   |
+LL -     let _: Result<i64, _> = <_>::try_from(0i32);
+LL +     let _: Result<i64, _> = From::from(0i32);
+   |
 
 error: aborting due to 6 previous errors
 

--- a/src/tools/clippy/tests/ui/unnecessary_iter_cloned.stderr
+++ b/src/tools/clippy/tests/ui/unnecessary_iter_cloned.stderr
@@ -30,7 +30,13 @@ error: unnecessary use of `cloned`
   --> tests/ui/unnecessary_iter_cloned.rs:179:18
    |
 LL |         for c in v.iter().cloned() {
-   |                  ^^^^^^^^^^^^^^^^^ help: remove any references to the binding: `v.iter()`
+   |                  ^^^^^^^^^^^^^^^^^
+   |
+help: remove any references to the binding
+   |
+LL -         for c in v.iter().cloned() {
+LL +         for c in v.iter() {
+   |
 
 error: unnecessary use of `cloned`
   --> tests/ui/unnecessary_iter_cloned.rs:188:18

--- a/src/tools/clippy/tests/ui/unnecessary_literal_unwrap.stderr
+++ b/src/tools/clippy/tests/ui/unnecessary_literal_unwrap.stderr
@@ -52,7 +52,13 @@ error: used `unwrap()` on `None` value
   --> tests/ui/unnecessary_literal_unwrap.rs:24:16
    |
 LL |     let _val = None::<()>.unwrap();
-   |                ^^^^^^^^^^^^^^^^^^^ help: remove the `None` and `unwrap()`: `panic!()`
+   |                ^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the `None` and `unwrap()`
+   |
+LL -     let _val = None::<()>.unwrap();
+LL +     let _val = panic!();
+   |
 
 error: used `expect()` on `None` value
   --> tests/ui/unnecessary_literal_unwrap.rs:26:16
@@ -70,7 +76,13 @@ error: used `unwrap_or_default()` on `None` value
   --> tests/ui/unnecessary_literal_unwrap.rs:28:24
    |
 LL |     let _val: String = None.unwrap_or_default();
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the `None` and `unwrap_or_default()`: `String::default()`
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the `None` and `unwrap_or_default()`
+   |
+LL -     let _val: String = None.unwrap_or_default();
+LL +     let _val: String = String::default();
+   |
 
 error: used `unwrap_or()` on `None` value
   --> tests/ui/unnecessary_literal_unwrap.rs:30:21
@@ -124,7 +136,13 @@ error: used `unwrap()` on `None` value
   --> tests/ui/unnecessary_literal_unwrap.rs:39:5
    |
 LL |     None::<()>.unwrap();
-   |     ^^^^^^^^^^^^^^^^^^^ help: remove the `None` and `unwrap()`: `panic!()`
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the `None` and `unwrap()`
+   |
+LL -     None::<()>.unwrap();
+LL +     panic!();
+   |
 
 error: used `expect()` on `None` value
   --> tests/ui/unnecessary_literal_unwrap.rs:41:5
@@ -142,7 +160,13 @@ error: used `unwrap_or_default()` on `None` value
   --> tests/ui/unnecessary_literal_unwrap.rs:43:5
    |
 LL |     None::<String>.unwrap_or_default();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the `None` and `unwrap_or_default()`: `String::default()`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the `None` and `unwrap_or_default()`
+   |
+LL -     None::<String>.unwrap_or_default();
+LL +     String::default();
+   |
 
 error: used `unwrap_or()` on `None` value
   --> tests/ui/unnecessary_literal_unwrap.rs:45:5

--- a/src/tools/clippy/tests/ui/unnecessary_literal_unwrap_unfixable.stderr
+++ b/src/tools/clippy/tests/ui/unnecessary_literal_unwrap_unfixable.stderr
@@ -100,13 +100,25 @@ error: used `unwrap_or_default()` on `None` value
   --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:37:21
    |
 LL |     let _val3: u8 = None.unwrap_or_default();
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the `None` and `unwrap_or_default()`: `Default::default()`
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the `None` and `unwrap_or_default()`
+   |
+LL -     let _val3: u8 = None.unwrap_or_default();
+LL +     let _val3: u8 = Default::default();
+   |
 
 error: used `unwrap_or_default()` on `None` value
   --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:40:5
    |
 LL |     None::<()>.unwrap_or_default();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the `None` and `unwrap_or_default()`: `Default::default()`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the `None` and `unwrap_or_default()`
+   |
+LL -     None::<()>.unwrap_or_default();
+LL +     Default::default();
+   |
 
 error: used `unwrap()` on `Ok` value
   --> tests/ui/unnecessary_literal_unwrap_unfixable.rs:46:17

--- a/src/tools/clippy/tests/ui/useless_conversion.stderr
+++ b/src/tools/clippy/tests/ui/useless_conversion.stderr
@@ -139,127 +139,154 @@ error: explicit call to `.into_iter()` in function argument accepting `IntoItera
   --> tests/ui/useless_conversion.rs:218:7
    |
 LL |     b(vec![1, 2].into_iter());
-   |       ^^^^^^^^^^------------
-   |                 |
-   |                 help: consider removing the `.into_iter()`
+   |       ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
   --> tests/ui/useless_conversion.rs:208:13
    |
 LL |     fn b<T: IntoIterator<Item = i32>>(_: T) {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
+help: consider removing the `.into_iter()`
+   |
+LL -     b(vec![1, 2].into_iter());
+LL +     b(vec![1, 2]);
+   |
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
   --> tests/ui/useless_conversion.rs:220:7
    |
 LL |     c(vec![1, 2].into_iter());
-   |       ^^^^^^^^^^------------
-   |                 |
-   |                 help: consider removing the `.into_iter()`
+   |       ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
   --> tests/ui/useless_conversion.rs:209:18
    |
 LL |     fn c(_: impl IntoIterator<Item = i32>) {}
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^
+help: consider removing the `.into_iter()`
+   |
+LL -     c(vec![1, 2].into_iter());
+LL +     c(vec![1, 2]);
+   |
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
   --> tests/ui/useless_conversion.rs:222:7
    |
 LL |     d(vec![1, 2].into_iter());
-   |       ^^^^^^^^^^------------
-   |                 |
-   |                 help: consider removing the `.into_iter()`
+   |       ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
   --> tests/ui/useless_conversion.rs:212:12
    |
 LL |         T: IntoIterator<Item = i32>,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
+help: consider removing the `.into_iter()`
+   |
+LL -     d(vec![1, 2].into_iter());
+LL +     d(vec![1, 2]);
+   |
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
   --> tests/ui/useless_conversion.rs:226:7
    |
 LL |     b(vec![1, 2].into_iter().into_iter());
-   |       ^^^^^^^^^^------------------------
-   |                 |
-   |                 help: consider removing the `.into_iter()`s
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
   --> tests/ui/useless_conversion.rs:208:13
    |
 LL |     fn b<T: IntoIterator<Item = i32>>(_: T) {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
+help: consider removing the `.into_iter()`s
+   |
+LL -     b(vec![1, 2].into_iter().into_iter());
+LL +     b(vec![1, 2]);
+   |
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
   --> tests/ui/useless_conversion.rs:228:7
    |
 LL |     b(vec![1, 2].into_iter().into_iter().into_iter());
-   |       ^^^^^^^^^^------------------------------------
-   |                 |
-   |                 help: consider removing the `.into_iter()`s
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
   --> tests/ui/useless_conversion.rs:208:13
    |
 LL |     fn b<T: IntoIterator<Item = i32>>(_: T) {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
+help: consider removing the `.into_iter()`s
+   |
+LL -     b(vec![1, 2].into_iter().into_iter().into_iter());
+LL +     b(vec![1, 2]);
+   |
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
   --> tests/ui/useless_conversion.rs:275:24
    |
 LL |         foo2::<i32, _>([1, 2, 3].into_iter());
-   |                        ^^^^^^^^^------------
-   |                                 |
-   |                                 help: consider removing the `.into_iter()`
+   |                        ^^^^^^^^^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
   --> tests/ui/useless_conversion.rs:254:12
    |
 LL |         I: IntoIterator<Item = i32> + Helper<X>,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
+help: consider removing the `.into_iter()`
+   |
+LL -         foo2::<i32, _>([1, 2, 3].into_iter());
+LL +         foo2::<i32, _>([1, 2, 3]);
+   |
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
   --> tests/ui/useless_conversion.rs:284:14
    |
 LL |         foo3([1, 2, 3].into_iter());
-   |              ^^^^^^^^^------------
-   |                       |
-   |                       help: consider removing the `.into_iter()`
+   |              ^^^^^^^^^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
   --> tests/ui/useless_conversion.rs:263:12
    |
 LL |         I: IntoIterator<Item = i32>,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
+help: consider removing the `.into_iter()`
+   |
+LL -         foo3([1, 2, 3].into_iter());
+LL +         foo3([1, 2, 3]);
+   |
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
   --> tests/ui/useless_conversion.rs:294:16
    |
 LL |         S1.foo([1, 2].into_iter());
-   |                ^^^^^^------------
-   |                      |
-   |                      help: consider removing the `.into_iter()`
+   |                ^^^^^^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
   --> tests/ui/useless_conversion.rs:291:27
    |
 LL |             pub fn foo<I: IntoIterator>(&self, _: I) {}
    |                           ^^^^^^^^^^^^
+help: consider removing the `.into_iter()`
+   |
+LL -         S1.foo([1, 2].into_iter());
+LL +         S1.foo([1, 2]);
+   |
 
 error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
   --> tests/ui/useless_conversion.rs:314:44
    |
 LL |         v0.into_iter().interleave_shortest(v1.into_iter());
-   |                                            ^^------------
-   |                                              |
-   |                                              help: consider removing the `.into_iter()`
+   |                                            ^^^^^^^^^^^^^^
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
   --> tests/ui/useless_conversion.rs:301:20
    |
 LL |                 J: IntoIterator,
    |                    ^^^^^^^^^^^^
+help: consider removing the `.into_iter()`
+   |
+LL -         v0.into_iter().interleave_shortest(v1.into_iter());
+LL +         v0.into_iter().interleave_shortest(v1);
+   |
 
 error: useless conversion to the same type: `()`
   --> tests/ui/useless_conversion.rs:342:58

--- a/src/tools/replace-version-placeholder/src/main.rs
+++ b/src/tools/replace-version-placeholder/src/main.rs
@@ -15,6 +15,7 @@ fn main() {
             &root_path.join("library"),
             &root_path.join("src/doc/rustc"),
             &root_path.join("src/doc/rustdoc"),
+            &root_path.join("src/tools/clippy"),
         ],
         |path, _is_dir| filter_dirs(path),
         &mut |entry, contents| {

--- a/tests/rustdoc-ui/lints/bare-urls.stderr
+++ b/tests/rustdoc-ui/lints/bare-urls.stderr
@@ -247,9 +247,14 @@ error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:72:5
    |
 LL | /// [https://bloob.blob]
-   |     ^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://bloob.blob>`
+   |     ^^^^^^^^^^^^^^^^^^^^
    |
    = note: bare URLs are not automatically turned into clickable links
+help: use an automatic link instead
+   |
+LL - /// [https://bloob.blob]
+LL + /// <https://bloob.blob>
+   |
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:74:7

--- a/tests/ui/associated-inherent-types/type-alias-bounds.stderr
+++ b/tests/ui/associated-inherent-types/type-alias-bounds.stderr
@@ -2,15 +2,17 @@ warning: bounds on generic parameters in type aliases are not enforced
   --> $DIR/type-alias-bounds.rs:21:19
    |
 LL | pub type Alias<T: Bound> = (Source<T>::Assoc,);
-   |                 --^^^^^
-   |                 | |
-   |                 | will not be checked at usage sites of the type alias
-   |                 help: remove this bound
+   |                   ^^^^^ will not be checked at usage sites of the type alias
    |
    = note: this is a known limitation of the type checker that may be lifted in a future edition.
            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics
    = note: `#[warn(type_alias_bounds)]` on by default
+help: remove this bound
+   |
+LL - pub type Alias<T: Bound> = (Source<T>::Assoc,);
+LL + pub type Alias<T> = (Source<T>::Assoc,);
+   |
 
 warning: 1 warning emitted
 

--- a/tests/ui/associated-type-bounds/overlaping-bound-suggestion.stderr
+++ b/tests/ui/associated-type-bounds/overlaping-bound-suggestion.stderr
@@ -2,7 +2,12 @@ error[E0191]: the value of the associated types `Item` and `IntoIter` in `IntoIt
   --> $DIR/overlaping-bound-suggestion.rs:7:13
    |
 LL |     inner: <IntoIterator<Item: IntoIterator<Item: >>::IntoIterator as Item>::Core,
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: specify the associated types: `IntoIterator<Item: IntoIterator<Item: >, Item = /* Type */, IntoIter = /* Type */>`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: specify the associated types
+   |
+LL |     inner: <IntoIterator<Item: IntoIterator<Item: >, Item = /* Type */, IntoIter = /* Type */>::IntoIterator as Item>::Core,
+   |                                                    ++++++++++++++++++++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-type-bounds/type-alias.stderr
+++ b/tests/ui/associated-type-bounds/type-alias.stderr
@@ -2,158 +2,182 @@ warning: where clauses on type aliases are not enforced
   --> $DIR/type-alias.rs:3:25
    |
 LL | type _TaWhere1<T> where T: Iterator<Item: Copy> = T;
-   |                   ------^^^^^^^^^^^^^^^^^^^^^^^
-   |                   |     |
-   |                   |     will not be checked at usage sites of the type alias
-   |                   help: remove this where clause
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^ will not be checked at usage sites of the type alias
    |
    = note: this is a known limitation of the type checker that may be lifted in a future edition.
            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics
    = note: `#[warn(type_alias_bounds)]` on by default
+help: remove this where clause
+   |
+LL - type _TaWhere1<T> where T: Iterator<Item: Copy> = T;
+LL + type _TaWhere1<T>  = T;
+   |
 
 warning: where clauses on type aliases are not enforced
   --> $DIR/type-alias.rs:4:25
    |
 LL | type _TaWhere2<T> where T: Iterator<Item: 'static> = T;
-   |                   ------^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                   |     |
-   |                   |     will not be checked at usage sites of the type alias
-   |                   help: remove this where clause
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ will not be checked at usage sites of the type alias
    |
    = note: this is a known limitation of the type checker that may be lifted in a future edition.
            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics
+help: remove this where clause
+   |
+LL - type _TaWhere2<T> where T: Iterator<Item: 'static> = T;
+LL + type _TaWhere2<T>  = T;
+   |
 
 warning: where clauses on type aliases are not enforced
   --> $DIR/type-alias.rs:5:25
    |
 LL | type _TaWhere3<T> where T: Iterator<Item: 'static> = T;
-   |                   ------^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                   |     |
-   |                   |     will not be checked at usage sites of the type alias
-   |                   help: remove this where clause
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ will not be checked at usage sites of the type alias
    |
    = note: this is a known limitation of the type checker that may be lifted in a future edition.
            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics
+help: remove this where clause
+   |
+LL - type _TaWhere3<T> where T: Iterator<Item: 'static> = T;
+LL + type _TaWhere3<T>  = T;
+   |
 
 warning: where clauses on type aliases are not enforced
   --> $DIR/type-alias.rs:6:25
    |
 LL | type _TaWhere4<T> where T: Iterator<Item: 'static + Copy + Send> = T;
-   |                   ------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                   |     |
-   |                   |     will not be checked at usage sites of the type alias
-   |                   help: remove this where clause
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ will not be checked at usage sites of the type alias
    |
    = note: this is a known limitation of the type checker that may be lifted in a future edition.
            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics
+help: remove this where clause
+   |
+LL - type _TaWhere4<T> where T: Iterator<Item: 'static + Copy + Send> = T;
+LL + type _TaWhere4<T>  = T;
+   |
 
 warning: where clauses on type aliases are not enforced
   --> $DIR/type-alias.rs:7:25
    |
 LL | type _TaWhere5<T> where T: Iterator<Item: for<'a> Into<&'a u8>> = T;
-   |                   ------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                   |     |
-   |                   |     will not be checked at usage sites of the type alias
-   |                   help: remove this where clause
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ will not be checked at usage sites of the type alias
    |
    = note: this is a known limitation of the type checker that may be lifted in a future edition.
            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics
+help: remove this where clause
+   |
+LL - type _TaWhere5<T> where T: Iterator<Item: for<'a> Into<&'a u8>> = T;
+LL + type _TaWhere5<T>  = T;
+   |
 
 warning: where clauses on type aliases are not enforced
   --> $DIR/type-alias.rs:8:25
    |
 LL | type _TaWhere6<T> where T: Iterator<Item: Iterator<Item: Copy>> = T;
-   |                   ------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                   |     |
-   |                   |     will not be checked at usage sites of the type alias
-   |                   help: remove this where clause
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ will not be checked at usage sites of the type alias
    |
    = note: this is a known limitation of the type checker that may be lifted in a future edition.
            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics
+help: remove this where clause
+   |
+LL - type _TaWhere6<T> where T: Iterator<Item: Iterator<Item: Copy>> = T;
+LL + type _TaWhere6<T>  = T;
+   |
 
 warning: bounds on generic parameters in type aliases are not enforced
   --> $DIR/type-alias.rs:10:20
    |
 LL | type _TaInline1<T: Iterator<Item: Copy>> = T;
-   |                  --^^^^^^^^^^^^^^^^^^^^
-   |                  | |
-   |                  | will not be checked at usage sites of the type alias
-   |                  help: remove this bound
+   |                    ^^^^^^^^^^^^^^^^^^^^ will not be checked at usage sites of the type alias
    |
    = note: this is a known limitation of the type checker that may be lifted in a future edition.
            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics
+help: remove this bound
+   |
+LL - type _TaInline1<T: Iterator<Item: Copy>> = T;
+LL + type _TaInline1<T> = T;
+   |
 
 warning: bounds on generic parameters in type aliases are not enforced
   --> $DIR/type-alias.rs:11:20
    |
 LL | type _TaInline2<T: Iterator<Item: 'static>> = T;
-   |                  --^^^^^^^^^^^^^^^^^^^^^^^
-   |                  | |
-   |                  | will not be checked at usage sites of the type alias
-   |                  help: remove this bound
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^ will not be checked at usage sites of the type alias
    |
    = note: this is a known limitation of the type checker that may be lifted in a future edition.
            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics
+help: remove this bound
+   |
+LL - type _TaInline2<T: Iterator<Item: 'static>> = T;
+LL + type _TaInline2<T> = T;
+   |
 
 warning: bounds on generic parameters in type aliases are not enforced
   --> $DIR/type-alias.rs:12:20
    |
 LL | type _TaInline3<T: Iterator<Item: 'static>> = T;
-   |                  --^^^^^^^^^^^^^^^^^^^^^^^
-   |                  | |
-   |                  | will not be checked at usage sites of the type alias
-   |                  help: remove this bound
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^ will not be checked at usage sites of the type alias
    |
    = note: this is a known limitation of the type checker that may be lifted in a future edition.
            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics
+help: remove this bound
+   |
+LL - type _TaInline3<T: Iterator<Item: 'static>> = T;
+LL + type _TaInline3<T> = T;
+   |
 
 warning: bounds on generic parameters in type aliases are not enforced
   --> $DIR/type-alias.rs:13:20
    |
 LL | type _TaInline4<T: Iterator<Item: 'static + Copy + Send>> = T;
-   |                  --^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                  | |
-   |                  | will not be checked at usage sites of the type alias
-   |                  help: remove this bound
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ will not be checked at usage sites of the type alias
    |
    = note: this is a known limitation of the type checker that may be lifted in a future edition.
            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics
+help: remove this bound
+   |
+LL - type _TaInline4<T: Iterator<Item: 'static + Copy + Send>> = T;
+LL + type _TaInline4<T> = T;
+   |
 
 warning: bounds on generic parameters in type aliases are not enforced
   --> $DIR/type-alias.rs:14:20
    |
 LL | type _TaInline5<T: Iterator<Item: for<'a> Into<&'a u8>>> = T;
-   |                  --^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                  | |
-   |                  | will not be checked at usage sites of the type alias
-   |                  help: remove this bound
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ will not be checked at usage sites of the type alias
    |
    = note: this is a known limitation of the type checker that may be lifted in a future edition.
            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics
+help: remove this bound
+   |
+LL - type _TaInline5<T: Iterator<Item: for<'a> Into<&'a u8>>> = T;
+LL + type _TaInline5<T> = T;
+   |
 
 warning: bounds on generic parameters in type aliases are not enforced
   --> $DIR/type-alias.rs:15:20
    |
 LL | type _TaInline6<T: Iterator<Item: Iterator<Item: Copy>>> = T;
-   |                  --^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                  | |
-   |                  | will not be checked at usage sites of the type alias
-   |                  help: remove this bound
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ will not be checked at usage sites of the type alias
    |
    = note: this is a known limitation of the type checker that may be lifted in a future edition.
            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics
+help: remove this bound
+   |
+LL - type _TaInline6<T: Iterator<Item: Iterator<Item: Copy>>> = T;
+LL + type _TaInline6<T> = T;
+   |
 
 warning: 12 warnings emitted
 

--- a/tests/ui/associated-types/associated-types-incomplete-object.stderr
+++ b/tests/ui/associated-types/associated-types-incomplete-object.stderr
@@ -5,7 +5,12 @@ LL |     type B;
    |     ------ `B` defined here
 ...
 LL |     let b = &42isize as &dyn Foo<A=usize>;
-   |                              ^^^^^^^^^^^^ help: specify the associated type: `Foo<A=usize, B = /* Type */>`
+   |                              ^^^^^^^^^^^^
+   |
+help: specify the associated type
+   |
+LL |     let b = &42isize as &dyn Foo<A=usize, B = /* Type */>;
+   |                                         ++++++++++++++++
 
 error[E0191]: the value of the associated type `A` in `Foo` must be specified
   --> $DIR/associated-types-incomplete-object.rs:26:30
@@ -14,7 +19,12 @@ LL |     type A;
    |     ------ `A` defined here
 ...
 LL |     let c = &42isize as &dyn Foo<B=char>;
-   |                              ^^^^^^^^^^^ help: specify the associated type: `Foo<B=char, A = /* Type */>`
+   |                              ^^^^^^^^^^^
+   |
+help: specify the associated type
+   |
+LL |     let c = &42isize as &dyn Foo<B=char, A = /* Type */>;
+   |                                        ++++++++++++++++
 
 error[E0191]: the value of the associated types `A` and `B` in `Foo` must be specified
   --> $DIR/associated-types-incomplete-object.rs:29:30
@@ -25,7 +35,12 @@ LL |     type B;
    |     ------ `B` defined here
 ...
 LL |     let d = &42isize as &dyn Foo;
-   |                              ^^^ help: specify the associated types: `Foo<A = /* Type */, B = /* Type */>`
+   |                              ^^^
+   |
+help: specify the associated types
+   |
+LL |     let d = &42isize as &dyn Foo<A = /* Type */, B = /* Type */>;
+   |                                 ++++++++++++++++++++++++++++++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/associated-types/issue-23595-1.stderr
+++ b/tests/ui/associated-types/issue-23595-1.stderr
@@ -6,7 +6,12 @@ LL |     type Value;
 LL |     type ChildKey;
    |     ------------- `ChildKey` defined here
 LL |     type Children = dyn Index<Self::ChildKey, Output = dyn Hierarchy>;
-   |     ------------- `Children` defined here                  ^^^^^^^^^ help: specify the associated types: `Hierarchy<Value = /* Type */, ChildKey = /* Type */, Children = /* Type */>`
+   |     ------------- `Children` defined here                  ^^^^^^^^^
+   |
+help: specify the associated types
+   |
+LL |     type Children = dyn Index<Self::ChildKey, Output = dyn Hierarchy<Value = /* Type */, ChildKey = /* Type */, Children = /* Type */>>;
+   |                                                                     ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-types/tuple-struct-expr-pat.stderr
+++ b/tests/ui/associated-types/tuple-struct-expr-pat.stderr
@@ -2,17 +2,27 @@ error[E0575]: expected method or associated constant, found associated type `Tra
   --> $DIR/tuple-struct-expr-pat.rs:10:36
    |
 LL |     let <T<0> as Trait>::Assoc() = <T<0> as Trait>::Assoc();
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^-- help: use struct expression instead: `{}`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: can't use a type alias as a constructor
+help: use struct expression instead
+   |
+LL -     let <T<0> as Trait>::Assoc() = <T<0> as Trait>::Assoc();
+LL +     let <T<0> as Trait>::Assoc() = <T<0> as Trait>::Assoc {};
+   |
 
 error[E0575]: expected tuple struct or tuple variant, found associated type `Trait::Assoc`
   --> $DIR/tuple-struct-expr-pat.rs:10:9
    |
 LL |     let <T<0> as Trait>::Assoc() = <T<0> as Trait>::Assoc();
-   |         ^^^^^^^^^^^^^^^^^^^^^^-- help: use struct pattern instead: `{}`
+   |         ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: can't use a type alias as tuple pattern
+help: use struct pattern instead
+   |
+LL -     let <T<0> as Trait>::Assoc() = <T<0> as Trait>::Assoc();
+LL +     let <T<0> as Trait>::Assoc {} = <T<0> as Trait>::Assoc();
+   |
 
 error[E0575]: expected method or associated constant, found associated type `Trait::Assoc`
   --> $DIR/tuple-struct-expr-pat.rs:13:38

--- a/tests/ui/borrowck/issue-109271-pass-self-into-closure.stderr
+++ b/tests/ui/borrowck/issue-109271-pass-self-into-closure.stderr
@@ -5,10 +5,15 @@ LL |     v.call(|(), this: &mut S| v.get());
    |     ^^----^------------------^-^^^^^^^
    |     | |    |                  |
    |     | |    |                  first borrow occurs due to use of `v` in closure
-   |     | |    |                  help: try using the closure argument: `this`
    |     | |    immutable borrow occurs here
    |     | immutable borrow later used by call
    |     mutable borrow occurs here
+   |
+help: try using the closure argument
+   |
+LL -     v.call(|(), this: &mut S| v.get());
+LL +     v.call(|(), this: &mut S| this.get());
+   |
 
 error[E0499]: cannot borrow `v` as mutable more than once at a time
   --> $DIR/issue-109271-pass-self-into-closure.rs:21:5
@@ -17,10 +22,15 @@ LL |     v.call(|(), this: &mut S| v.set());
    |     ^^----^------------------^-^^^^^^^
    |     | |    |                  |
    |     | |    |                  first borrow occurs due to use of `v` in closure
-   |     | |    |                  help: try using the closure argument: `this`
    |     | |    first mutable borrow occurs here
    |     | first borrow later used by call
    |     second mutable borrow occurs here
+   |
+help: try using the closure argument
+   |
+LL -     v.call(|(), this: &mut S| v.set());
+LL +     v.call(|(), this: &mut S| this.set());
+   |
 
 error[E0499]: cannot borrow `v` as mutable more than once at a time
   --> $DIR/issue-109271-pass-self-into-closure.rs:21:12

--- a/tests/ui/const-generics/associated-const-bindings/dyn-compat-const-projection-from-supertrait-mentions-self.stderr
+++ b/tests/ui/const-generics/associated-const-bindings/dyn-compat-const-projection-from-supertrait-mentions-self.stderr
@@ -5,7 +5,12 @@ LL |     type const K: usize;
    |     ------------------- `K` defined here
 ...
 LL |     let _: dyn X<Q = 10>;
-   |                ^^^^^^^^^ help: specify the associated constant: `X<Q = 10, K = /* CONST */>`
+   |                ^^^^^^^^^
+   |
+help: specify the associated constant
+   |
+LL |     let _: dyn X<Q = 10, K = /* CONST */>;
+   |                        +++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/associated-const-bindings/dyn-compat-unspecified-assoc-consts.stderr
+++ b/tests/ui/const-generics/associated-const-bindings/dyn-compat-unspecified-assoc-consts.stderr
@@ -5,7 +5,12 @@ LL |     type const K: usize;
    |     ------------------- `K` defined here
 ...
 LL | struct Store(dyn Trait);
-   |                  ^^^^^ help: specify the associated constant: `Trait<K = /* CONST */>`
+   |                  ^^^^^
+   |
+help: specify the associated constant
+   |
+LL | struct Store(dyn Trait<K = /* CONST */>);
+   |                       +++++++++++++++++
 
 error[E0191]: the value of the associated constant `K` in `Trait` must be specified
   --> $DIR/dyn-compat-unspecified-assoc-consts.rs:23:21
@@ -14,7 +19,12 @@ LL |     type const K: usize;
    |     ------------------- `K` defined here
 ...
 LL | type DynTrait = dyn Trait;
-   |                     ^^^^^ help: specify the associated constant: `Trait<K = /* CONST */>`
+   |                     ^^^^^
+   |
+help: specify the associated constant
+   |
+LL | type DynTrait = dyn Trait<K = /* CONST */>;
+   |                          +++++++++++++++++
 
 error[E0191]: the value of the associated constant `K` in `Trait` must be specified
   --> $DIR/dyn-compat-unspecified-assoc-consts.rs:14:16
@@ -23,7 +33,12 @@ LL |     type const K: usize;
    |     ------------------- `K` defined here
 ...
 LL |     let _: dyn Trait;
-   |                ^^^^^ help: specify the associated constant: `Trait<K = /* CONST */>`
+   |                ^^^^^
+   |
+help: specify the associated constant
+   |
+LL |     let _: dyn Trait<K = /* CONST */>;
+   |                     +++++++++++++++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/const-generics/generic_const_exprs/unevaluated-const-ice-119731.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/unevaluated-const-ice-119731.stderr
@@ -2,10 +2,13 @@ error[E0432]: unresolved import `v20::v13`
   --> $DIR/unevaluated-const-ice-119731.rs:42:15
    |
 LL | pub use v20::{v13, v17};
-   |               ^^^
-   |               |
-   |               no `v13` in `v20`
-   |               help: a similar name exists in the module: `v11`
+   |               ^^^ no `v13` in `v20`
+   |
+help: a similar name exists in the module
+   |
+LL - pub use v20::{v13, v17};
+LL + pub use v20::{v11, v17};
+   |
 
 error[E0425]: cannot find value `v8` in this scope
   --> $DIR/unevaluated-const-ice-119731.rs:13:38

--- a/tests/ui/dyn-compatibility/assoc_type_bounds.stderr
+++ b/tests/ui/dyn-compatibility/assoc_type_bounds.stderr
@@ -5,7 +5,12 @@ LL |     type Bar
    |     -------- `Bar` defined here
 ...
 LL | fn foo(_: &dyn Foo<()>) {}
-   |                ^^^^^^^ help: specify the associated type: `Foo<(), Bar = /* Type */>`
+   |                ^^^^^^^
+   |
+help: specify the associated type
+   |
+LL | fn foo(_: &dyn Foo<(), Bar = /* Type */>) {}
+   |                      ++++++++++++++++++
 
 error[E0191]: the value of the associated type `Bar` in `Foo<i32>` must be specified
   --> $DIR/assoc_type_bounds.rs:11:16
@@ -14,7 +19,12 @@ LL |     type Bar
    |     -------- `Bar` defined here
 ...
 LL | fn bar(_: &dyn Foo<i32>) {}
-   |                ^^^^^^^^ help: specify the associated type: `Foo<i32, Bar = /* Type */>`
+   |                ^^^^^^^^
+   |
+help: specify the associated type
+   |
+LL | fn bar(_: &dyn Foo<i32, Bar = /* Type */>) {}
+   |                       ++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/dyn-compatibility/assoc_type_bounds2.stderr
+++ b/tests/ui/dyn-compatibility/assoc_type_bounds2.stderr
@@ -5,7 +5,12 @@ LL |     type Bar
    |     -------- `Bar` defined here
 ...
 LL | fn foo(_: &dyn Foo<()>) {}
-   |                ^^^^^^^ help: specify the associated type: `Foo<(), Bar = /* Type */>`
+   |                ^^^^^^^
+   |
+help: specify the associated type
+   |
+LL | fn foo(_: &dyn Foo<(), Bar = /* Type */>) {}
+   |                      ++++++++++++++++++
 
 error[E0191]: the value of the associated type `Bar` in `Foo<i32>` must be specified
   --> $DIR/assoc_type_bounds2.rs:11:16
@@ -14,7 +19,12 @@ LL |     type Bar
    |     -------- `Bar` defined here
 ...
 LL | fn bar(_: &dyn Foo<i32>) {}
-   |                ^^^^^^^^ help: specify the associated type: `Foo<i32, Bar = /* Type */>`
+   |                ^^^^^^^^
+   |
+help: specify the associated type
+   |
+LL | fn bar(_: &dyn Foo<i32, Bar = /* Type */>) {}
+   |                       ++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/dyn-compatibility/assoc_type_bounds_sized_others.stderr
+++ b/tests/ui/dyn-compatibility/assoc_type_bounds_sized_others.stderr
@@ -5,7 +5,12 @@ LL |     type Bop;
    |     -------- `Bop` defined here
 ...
 LL | fn foo(_: &dyn Foo) {}
-   |                ^^^ help: specify the associated type: `Foo<Bop = /* Type */>`
+   |                ^^^
+   |
+help: specify the associated type
+   |
+LL | fn foo(_: &dyn Foo<Bop = /* Type */>) {}
+   |                   ++++++++++++++++++
 
 error[E0191]: the value of the associated type `Bop` in `Bar` must be specified
   --> $DIR/assoc_type_bounds_sized_others.rs:22:16
@@ -14,7 +19,12 @@ LL |     type Bop;
    |     -------- `Bop` defined here
 ...
 LL | fn bar(_: &dyn Bar) {}
-   |                ^^^ help: specify the associated type: `Bar<Bop = /* Type */>`
+   |                ^^^
+   |
+help: specify the associated type
+   |
+LL | fn bar(_: &dyn Bar<Bop = /* Type */>) {}
+   |                   ++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/dyn-compatibility/require-assoc-for-all-super-substs.stderr
+++ b/tests/ui/dyn-compatibility/require-assoc-for-all-super-substs.stderr
@@ -5,7 +5,12 @@ LL |     type Assoc: Default;
    |     ------------------- `Assoc` defined here
 ...
 LL |     let q: <dyn Dyn<i32, u32> as Sup<u32>>::Assoc = Default::default();
-   |                 ^^^^^^^^^^^^^ help: specify the associated type: `Dyn<i32, u32, Assoc = /* Type */>`
+   |                 ^^^^^^^^^^^^^
+   |
+help: specify the associated type
+   |
+LL |     let q: <dyn Dyn<i32, u32, Assoc = /* Type */> as Sup<u32>>::Assoc = Default::default();
+   |                             ++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/eii/default/auxiliary/decl_with_default_panics.rs
+++ b/tests/ui/eii/default/auxiliary/decl_with_default_panics.rs
@@ -1,0 +1,10 @@
+//@ no-prefer-dynamic
+//@ needs-unwind
+//@ exec-env:RUST_BACKTRACE=1
+#![crate_type = "rlib"]
+#![feature(extern_item_impls)]
+
+#[eii(eii1)]
+pub fn decl1(x: u64) {
+    panic!("{}", x);
+}

--- a/tests/ui/eii/default/call_default.rs
+++ b/tests/ui/eii/default/call_default.rs
@@ -5,16 +5,6 @@
 //@ ignore-backends: gcc
 // FIXME: linking on windows (speciifcally mingw) not yet supported, see tracking issue #125418
 //@ ignore-windows
-// Functions can have target-cpu applied. On apple-darwin this is super important,
-// since you can have binaries which mix x86 and aarch64 code that are compatible
-// with both architectures. So we can't just reject target_cpu on EIIs since apple
-// puts them on by default. The problem: we generate aliases. And aliases cannot
-// get target_cpu applied to them. So, instead we should, in the case of functions,
-// generate a shim function. For statics aliases should keep working in theory.
-// In fact, aliases are only necessary for statics. For functions we could just
-//  always generate a shim and a previous version of EII did so but I was sad
-// that that'd never support statics.
-//@ ignore-macos
 // Tests EIIs with default implementations.
 // When there's no explicit declaration, the default should be called from the declaring crate.
 #![feature(extern_item_impls)]

--- a/tests/ui/eii/default/call_default_panics.rs
+++ b/tests/ui/eii/default/call_default_panics.rs
@@ -1,0 +1,35 @@
+//@ no-prefer-dynamic
+//@ aux-build: decl_with_default_panics.rs
+//@ edition: 2021
+//@ run-pass
+//@ needs-unwind
+//@ exec-env:RUST_BACKTRACE=1
+//@ ignore-backends: gcc
+// FIXME: linking on windows (speciifcally mingw) not yet supported, see tracking issue #125418
+//@ ignore-windows
+// A small test to make sure that unwinding works properly.
+//
+// Functions can have target-cpu applied. On apple-darwin this is super important,
+// since you can have binaries which mix x86 and aarch64 code that are compatible
+// with both architectures. So we can't just reject target_cpu on EIIs since apple
+// puts them on by default. The problem: we generate aliases. And aliases cannot
+// get target_cpu applied to them. So, instead we should, in the case of functions,
+// generate a shim function. For statics aliases should keep working.
+// However, to make this work properly,
+// on LLVM we generate shim functions instead of function aliases.
+// Little extra functions that look like
+// ```
+// function alias_symbol(*args) {return (tailcall) aliasee(*args);}
+// ```
+// This is a simple test to make sure that we can unwind through these,
+// and that this wrapper function effectively doesn't show up in the trace.
+#![feature(extern_item_impls)]
+
+extern crate decl_with_default_panics;
+
+fn main() {
+    let result = std::panic::catch_unwind(|| {
+        decl_with_default_panics::decl1(10);
+    });
+    assert!(result.is_err());
+}

--- a/tests/ui/eii/default/call_default_panics.run.stderr
+++ b/tests/ui/eii/default/call_default_panics.run.stderr
@@ -1,0 +1,10 @@
+
+thread 'main' ($TID) panicked at $DIR/auxiliary/decl_with_default_panics.rs:14:5:
+10
+stack backtrace:
+   0: __rustc::rust_begin_unwind
+   1: core::panicking::panic_fmt
+   2: core::panicking::panic_display::<u64>
+   3: decl_with_default_panics::_::decl1
+   4: call_default_panics::main
+note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

--- a/tests/ui/env-macro/error-recovery-issue-55897.stderr
+++ b/tests/ui/env-macro/error-recovery-issue-55897.stderr
@@ -16,10 +16,12 @@ error[E0432]: unresolved import `prelude`
   --> $DIR/error-recovery-issue-55897.rs:2:5
    |
 LL | use prelude::*;
-   |     ^^^^^^^
-   |     |
-   |     unresolved import
-   |     help: a similar path exists: `std::prelude`
+   |     ^^^^^^^ unresolved import
+   |
+help: a similar path exists
+   |
+LL | use std::prelude::*;
+   |     +++++
 
 error[E0432]: unresolved import `env`
   --> $DIR/error-recovery-issue-55897.rs:5:9

--- a/tests/ui/error-codes/E0191.stderr
+++ b/tests/ui/error-codes/E0191.stderr
@@ -5,7 +5,12 @@ LL |     type Bar;
    |     -------- `Bar` defined here
 ...
 LL | type Foo = dyn Trait;
-   |                ^^^^^ help: specify the associated type: `Trait<Bar = /* Type */>`
+   |                ^^^^^
+   |
+help: specify the associated type
+   |
+LL | type Foo = dyn Trait<Bar = /* Type */>;
+   |                     ++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/error-codes/E0220.stderr
+++ b/tests/ui/error-codes/E0220.stderr
@@ -11,7 +11,12 @@ LL |     type Bar;
    |     -------- `Bar` defined here
 ...
 LL | type Foo = dyn Trait<F=i32>;
-   |                ^^^^^^^^^^^^ help: specify the associated type: `Trait<F=i32, Bar = /* Type */>`
+   |                ^^^^^^^^^^^^
+   |
+help: specify the associated type
+   |
+LL | type Foo = dyn Trait<F=i32, Bar = /* Type */>;
+   |                           ++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/errors/dynless-turbofish-e0191-issue-91997.stderr
+++ b/tests/ui/errors/dynless-turbofish-e0191-issue-91997.stderr
@@ -16,7 +16,12 @@ error[E0191]: the value of the associated type `Item` in `Iterator` must be spec
   --> $DIR/dynless-turbofish-e0191-issue-91997.rs:5:13
    |
 LL |     let _ = MyIterator::next;
-   |             ^^^^^^^^^^ help: specify the associated type: `MyIterator::<Item = /* Type */>`
+   |             ^^^^^^^^^^
+   |
+help: specify the associated type
+   |
+LL |     let _ = MyIterator::<Item = /* Type */>::next;
+   |                       +++++++++++++++++++++
 
 error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/feature-gates/feature-gate-extern_absolute_paths.stderr
+++ b/tests/ui/feature-gates/feature-gate-extern_absolute_paths.stderr
@@ -2,10 +2,13 @@ error[E0432]: unresolved import `core`
   --> $DIR/feature-gate-extern_absolute_paths.rs:2:5
    |
 LL | use core::default;
-   |     ^^^^
-   |     |
-   |     you might be missing crate `core`
-   |     help: try using `std` instead of `core`: `std`
+   |     ^^^^ you might be missing crate `core`
+   |
+help: try using `std` instead of `core`
+   |
+LL - use core::default;
+LL + use std::default;
+   |
 
 error[E0433]: cannot find `core` in the crate root
   --> $DIR/feature-gate-extern_absolute_paths.rs:5:19

--- a/tests/ui/fmt/ifmt-bad-arg.stderr
+++ b/tests/ui/fmt/ifmt-bad-arg.stderr
@@ -178,11 +178,14 @@ error: argument never used
   --> $DIR/ifmt-bad-arg.rs:56:27
    |
 LL |     format!("foo %s baz", "bar");
-   |                  --       ^^^^^ argument never used
-   |                  |
-   |                  help: format specifiers use curly braces: `{}`
+   |                           ^^^^^ argument never used
    |
    = note: printf formatting is not supported; see the documentation for `std::fmt`
+help: format specifiers use curly braces
+   |
+LL -     format!("foo %s baz", "bar");
+LL +     format!("foo {} baz", "bar");
+   |
 
 error: invalid format string: expected `}`, found `t`
   --> $DIR/ifmt-bad-arg.rs:75:1

--- a/tests/ui/impl-trait/associated-type-cycle.stderr
+++ b/tests/ui/impl-trait/associated-type-cycle.stderr
@@ -5,7 +5,12 @@ LL |     type Bar;
    |     -------- `Bar` defined here
 ...
 LL | impl Foo for Box<dyn Foo> {
-   |                      ^^^ help: specify the associated type: `Foo<Bar = /* Type */>`
+   |                      ^^^
+   |
+help: specify the associated type
+   |
+LL | impl Foo for Box<dyn Foo<Bar = /* Type */>> {
+   |                         ++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/import.stderr
+++ b/tests/ui/imports/import.stderr
@@ -2,10 +2,13 @@ error[E0432]: unresolved import `zed::baz`
   --> $DIR/import.rs:5:5
    |
 LL | use zed::baz;
-   |     ^^^^^---
-   |     |    |
-   |     |    help: a similar name exists in the module: `bar`
-   |     no `baz` in `zed`
+   |     ^^^^^^^^ no `baz` in `zed`
+   |
+help: a similar name exists in the module
+   |
+LL - use zed::baz;
+LL + use zed::bar;
+   |
 
 error[E0432]: unresolved import `foo`
   --> $DIR/import.rs:13:9

--- a/tests/ui/imports/issue-55457.stderr
+++ b/tests/ui/imports/issue-55457.stderr
@@ -2,10 +2,13 @@ error[E0432]: unresolved import `NonExistent`
   --> $DIR/issue-55457.rs:2:5
    |
 LL | use NonExistent;
-   |     ^^^^^^^^^^^
-   |     |
-   |     no `NonExistent` in the root
-   |     help: a similar name exists in the module: `non_existent`
+   |     ^^^^^^^^^^^ no `NonExistent` in the root
+   |
+help: a similar name exists in the module
+   |
+LL - use NonExistent;
+LL + use non_existent;
+   |
 
 error[E0432]: unresolved import `non_existent`
   --> $DIR/issue-55457.rs:3:5

--- a/tests/ui/imports/resolve_self_super_hint.stderr
+++ b/tests/ui/imports/resolve_self_super_hint.stderr
@@ -2,31 +2,45 @@ error[E0432]: unresolved import `alloc`
   --> $DIR/resolve_self_super_hint.rs:4:9
    |
 LL |     use alloc::HashMap;
-   |         ^^^^^ help: a similar path exists: `self::alloc`
+   |         ^^^^^
+   |
+help: a similar path exists
+   |
+LL |     use self::alloc::HashMap;
+   |         ++++++
 
 error[E0432]: unresolved import `alloc`
   --> $DIR/resolve_self_super_hint.rs:9:13
    |
 LL |         use alloc::HashMap;
-   |             ^^^^^ help: a similar path exists: `super::alloc`
+   |             ^^^^^
+   |
+help: a similar path exists
+   |
+LL |         use super::alloc::HashMap;
+   |             +++++++
 
 error[E0432]: unresolved import `alloc`
   --> $DIR/resolve_self_super_hint.rs:14:17
    |
 LL |             use alloc::HashMap;
-   |                 ^^^^^
-   |                 |
-   |                 unresolved import
-   |                 help: a similar path exists: `a::alloc`
+   |                 ^^^^^ unresolved import
+   |
+help: a similar path exists
+   |
+LL |             use a::alloc::HashMap;
+   |                 +++
 
 error[E0432]: unresolved import `alloc`
   --> $DIR/resolve_self_super_hint.rs:19:21
    |
 LL |                 use alloc::HashMap;
-   |                     ^^^^^
-   |                     |
-   |                     unresolved import
-   |                     help: a similar path exists: `a::alloc`
+   |                     ^^^^^ unresolved import
+   |
+help: a similar path exists
+   |
+LL |                 use a::alloc::HashMap;
+   |                     +++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/imports/shadow-glob-module-resolution-2.stderr
+++ b/tests/ui/imports/shadow-glob-module-resolution-2.stderr
@@ -16,10 +16,13 @@ error[E0432]: unresolved import `e`
   --> $DIR/shadow-glob-module-resolution-2.rs:14:5
    |
 LL | use e as b;
-   |     -^^^^^
-   |     |
-   |     no `e` in the root
-   |     help: a similar name exists in the module: `a`
+   |     ^^^^^^ no `e` in the root
+   |
+help: a similar name exists in the module
+   |
+LL - use e as b;
+LL + use a as b;
+   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/imports/underscore-imports/multiple-uses.ed2015.stderr
+++ b/tests/ui/imports/underscore-imports/multiple-uses.ed2015.stderr
@@ -32,11 +32,14 @@ error[E0432]: unresolved imports `std::b`, `std::c`
   --> $DIR/multiple-uses.rs:9:15
    |
 LL | pub use std::{b, _, c};
-   |               ^     ^
-   |               |     |
-   |               |     no `c` in the root
-   |               |     help: a similar name exists in the module: `rc`
+   |               ^     ^ no `c` in the root
+   |               |
    |               no `b` in the root
+   |
+help: a similar name exists in the module
+   |
+LL | pub use std::{b, _, rc};
+   |                     +
 
 error[E0432]: unresolved import `std::d`
   --> $DIR/multiple-uses.rs:12:18

--- a/tests/ui/imports/underscore-imports/multiple-uses.ed2021.stderr
+++ b/tests/ui/imports/underscore-imports/multiple-uses.ed2021.stderr
@@ -32,11 +32,14 @@ error[E0432]: unresolved imports `std::b`, `std::c`
   --> $DIR/multiple-uses.rs:9:15
    |
 LL | pub use std::{b, _, c};
-   |               ^     ^
-   |               |     |
-   |               |     no `c` in the root
-   |               |     help: a similar name exists in the module: `rc`
+   |               ^     ^ no `c` in the root
+   |               |
    |               no `b` in the root
+   |
+help: a similar name exists in the module
+   |
+LL | pub use std::{b, _, rc};
+   |                     +
 
 error[E0432]: unresolved import `std::d`
   --> $DIR/multiple-uses.rs:12:18

--- a/tests/ui/issues/issue-19482.stderr
+++ b/tests/ui/issues/issue-19482.stderr
@@ -5,7 +5,12 @@ LL |     type A;
    |     ------ `A` defined here
 ...
 LL | fn bar(x: &dyn Foo) {}
-   |                ^^^ help: specify the associated type: `Foo<A = /* Type */>`
+   |                ^^^
+   |
+help: specify the associated type
+   |
+LL | fn bar(x: &dyn Foo<A = /* Type */>) {}
+   |                   ++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-28344.stderr
+++ b/tests/ui/issues/issue-28344.stderr
@@ -16,7 +16,12 @@ error[E0191]: the value of the associated type `Output` in `BitXor<_>` must be s
   --> $DIR/issue-28344.rs:5:17
    |
 LL |     let x: u8 = BitXor::bitor(0 as u8, 0 as u8);
-   |                 ^^^^^^ help: specify the associated type: `BitXor::<Output = /* Type */>`
+   |                 ^^^^^^
+   |
+help: specify the associated type
+   |
+LL |     let x: u8 = BitXor::<Output = /* Type */>::bitor(0 as u8, 0 as u8);
+   |                       +++++++++++++++++++++++
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/issue-28344.rs:10:13
@@ -35,7 +40,12 @@ error[E0191]: the value of the associated type `Output` in `BitXor<_>` must be s
   --> $DIR/issue-28344.rs:10:13
    |
 LL |     let g = BitXor::bitor;
-   |             ^^^^^^ help: specify the associated type: `BitXor::<Output = /* Type */>`
+   |             ^^^^^^
+   |
+help: specify the associated type
+   |
+LL |     let g = BitXor::<Output = /* Type */>::bitor;
+   |                   +++++++++++++++++++++++
 
 error: aborting due to 2 previous errors; 2 warnings emitted
 

--- a/tests/ui/macros/format-foreign.stderr
+++ b/tests/ui/macros/format-foreign.stderr
@@ -19,11 +19,14 @@ error: argument never used
   --> $DIR/format-foreign.rs:3:29
    |
 LL |     println!("%1$*2$.*3$f", 123.456);
-   |               -----------   ^^^^^^^ argument never used
-   |               |
-   |               help: format specifiers use curly braces: `{0:1$.2$}`
+   |                             ^^^^^^^ argument never used
    |
    = note: printf formatting is not supported; see the documentation for `std::fmt`
+help: format specifiers use curly braces
+   |
+LL -     println!("%1$*2$.*3$f", 123.456);
+LL +     println!("{0:1$.2$}", 123.456);
+   |
 
 error: multiple unused formatting arguments
   --> $DIR/format-foreign.rs:6:7
@@ -57,11 +60,14 @@ error: named argument never used
   --> $DIR/format-foreign.rs:14:39
    |
 LL |     println!("Hi there, $NAME.", NAME="Tim");
-   |                         -----         ^^^^^ named argument never used
-   |                         |
-   |                         help: format specifiers use curly braces: `{NAME}`
+   |                                       ^^^^^ named argument never used
    |
    = note: shell formatting is not supported; see the documentation for `std::fmt`
+help: format specifiers use curly braces
+   |
+LL -     println!("Hi there, $NAME.", NAME="Tim");
+LL +     println!("Hi there, {NAME}.", NAME="Tim");
+   |
 
 error: multiple unused formatting arguments
   --> $DIR/format-foreign.rs:15:32

--- a/tests/ui/macros/format-unused-lables.stderr
+++ b/tests/ui/macros/format-unused-lables.stderr
@@ -47,10 +47,7 @@ error: multiple unused formatting arguments
   --> $DIR/format-unused-lables.rs:14:9
    |
 LL |     println!("Some more $STUFF",
-   |              ------------------
-   |              |          |
-   |              |          help: format specifiers use curly braces: `{STUFF}`
-   |              multiple missing formatting specifiers
+   |              ------------------ multiple missing formatting specifiers
 LL |         "woo!",
    |         ^^^^^^ argument never used
 LL |             STUFF=
@@ -60,6 +57,11 @@ LL |              , UNUSED="args");
    |                       ^^^^^^ named argument never used
    |
    = note: shell formatting is not supported; see the documentation for `std::fmt`
+help: format specifiers use curly braces
+   |
+LL -     println!("Some more $STUFF",
+LL +     println!("Some more {STUFF}",
+   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/macros/non-fmt-panic.stderr
+++ b/tests/ui/macros/non-fmt-panic.stderr
@@ -413,13 +413,16 @@ warning: panic message is not a string literal
   --> $DIR/non-fmt-panic.rs:79:12
    |
 LL |     panic!(v);
-   |     ------ ^
-   |     |
-   |     help: use std::panic::panic_any instead: `std::panic::panic_any`
+   |            ^
    |
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
    = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
+help: use std::panic::panic_any instead
+   |
+LL -     panic!(v);
+LL +     std::panic::panic_any(v);
+   |
 
 warning: panic message is not a string literal
   --> $DIR/non-fmt-panic.rs:80:20

--- a/tests/ui/macros/typo-in-repeat-expr-2.rs
+++ b/tests/ui/macros/typo-in-repeat-expr-2.rs
@@ -1,0 +1,27 @@
+macro_rules! mn {
+    (begin $($arg:ident),* end) => {
+        [$($typo),*] //~ ERROR attempted to repeat an expression containing no syntax variables matched as repeating at this depth
+        //~^ NOTE expected a repeatable metavariable: `$arg`
+    };
+}
+
+macro_rules! mnr {
+    (begin $arg:ident end) => { //~ NOTE this similarly named macro metavariable is unrepeatable
+        [$($ard),*] //~ ERROR attempted to repeat an expression containing no syntax variables matched as repeating at this depth
+        //~^ NOTE: argument not found
+    };
+}
+
+macro_rules! err {
+    (begin $arg:ident end) => {
+        [$($typo),*] //~ ERROR attempted to repeat an expression containing no syntax variables matched as repeating at this depth
+        //~^ NOTE this macro metavariable is not repeatable and there are no other repeatable metavariables
+    };
+}
+
+fn main() {
+    let x = 1;
+    let _ = mn![begin x end];
+    let _ = mnr![begin x end];
+    let _ = err![begin x  end];
+}

--- a/tests/ui/macros/typo-in-repeat-expr-2.stderr
+++ b/tests/ui/macros/typo-in-repeat-expr-2.stderr
@@ -1,0 +1,28 @@
+error: attempted to repeat an expression containing no syntax variables matched as repeating at this depth
+  --> $DIR/typo-in-repeat-expr-2.rs:3:11
+   |
+LL |         [$($typo),*]
+   |           ^^----^
+   |             |
+   |             expected a repeatable metavariable: `$arg`
+
+error: attempted to repeat an expression containing no syntax variables matched as repeating at this depth
+  --> $DIR/typo-in-repeat-expr-2.rs:10:11
+   |
+LL |     (begin $arg:ident end) => {
+   |             --- this similarly named macro metavariable is unrepeatable
+LL |         [$($ard),*]
+   |           ^^---^
+   |             |
+   |             argument not found
+
+error: attempted to repeat an expression containing no syntax variables matched as repeating at this depth
+  --> $DIR/typo-in-repeat-expr-2.rs:17:11
+   |
+LL |         [$($typo),*]
+   |           ^^----^
+   |             |
+   |             this macro metavariable is not repeatable and there are no other repeatable metavariables
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/macros/typo-in-repeat-expr.fixed
+++ b/tests/ui/macros/typo-in-repeat-expr.fixed
@@ -1,0 +1,12 @@
+//@ run-rustfix
+macro_rules! m {
+    (begin $($ard:ident),* end) => {
+        [$($ard),*] //~ ERROR attempted to repeat an expression containing no syntax variables matched as repeating at this depth
+        //~^ HELP there's a macro metavariable with a similar name
+    };
+}
+
+fn main() {
+    let x = 1;
+    let _ = m![begin x end];
+}

--- a/tests/ui/macros/typo-in-repeat-expr.rs
+++ b/tests/ui/macros/typo-in-repeat-expr.rs
@@ -1,0 +1,12 @@
+//@ run-rustfix
+macro_rules! m {
+    (begin $($ard:ident),* end) => {
+        [$($arg),*] //~ ERROR attempted to repeat an expression containing no syntax variables matched as repeating at this depth
+        //~^ HELP there's a macro metavariable with a similar name
+    };
+}
+
+fn main() {
+    let x = 1;
+    let _ = m![begin x end];
+}

--- a/tests/ui/macros/typo-in-repeat-expr.stderr
+++ b/tests/ui/macros/typo-in-repeat-expr.stderr
@@ -1,0 +1,14 @@
+error: attempted to repeat an expression containing no syntax variables matched as repeating at this depth
+  --> $DIR/typo-in-repeat-expr.rs:4:11
+   |
+LL |         [$($arg),*]
+   |           ^^^^^^
+   |
+help: there's a macro metavariable with a similar name
+   |
+LL -         [$($arg),*]
+LL +         [$($ard),*]
+   |
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/issues/issue-112188.stderr
+++ b/tests/ui/parser/issues/issue-112188.stderr
@@ -27,11 +27,16 @@ error: expected `}`, found `,`
   --> $DIR/issue-112188.rs:13:17
    |
 LL |     let Foo { .., x, .. } = f;
-   |               --^-
+   |               --^
    |               | |
    |               | expected `}`
    |               `..` must be at the end and cannot have a trailing comma
-   |               help: remove the starting `..`
+   |
+help: remove the starting `..`
+   |
+LL -     let Foo { .., x, .. } = f;
+LL +     let Foo { x, .. } = f;
+   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/privacy/private-in-public-warn.stderr
+++ b/tests/ui/privacy/private-in-public-warn.stderr
@@ -543,28 +543,32 @@ warning: bounds on generic parameters in type aliases are not enforced
   --> $DIR/private-in-public-warn.rs:42:23
    |
 LL |     pub type Alias<T: PrivTr> = T;
-   |                     --^^^^^^
-   |                     | |
-   |                     | will not be checked at usage sites of the type alias
-   |                     help: remove this bound
+   |                       ^^^^^^ will not be checked at usage sites of the type alias
    |
    = note: this is a known limitation of the type checker that may be lifted in a future edition.
            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics
    = note: `#[warn(type_alias_bounds)]` on by default
+help: remove this bound
+   |
+LL -     pub type Alias<T: PrivTr> = T;
+LL +     pub type Alias<T> = T;
+   |
 
 warning: where clauses on type aliases are not enforced
   --> $DIR/private-in-public-warn.rs:67:29
    |
 LL |     pub type Alias<T> where T: PrivTr = T;
-   |                       ------^^^^^^^^^
-   |                       |     |
-   |                       |     will not be checked at usage sites of the type alias
-   |                       help: remove this where clause
+   |                             ^^^^^^^^^ will not be checked at usage sites of the type alias
    |
    = note: this is a known limitation of the type checker that may be lifted in a future edition.
            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics
+help: remove this where clause
+   |
+LL -     pub type Alias<T> where T: PrivTr = T;
+LL +     pub type Alias<T>  = T;
+   |
 
 error: aborting due to 46 previous errors; 2 warnings emitted
 

--- a/tests/ui/proc-macro/mixed-site-span.stderr
+++ b/tests/ui/proc-macro/mixed-site-span.stderr
@@ -42,74 +42,88 @@ error[E0432]: unresolved import `$crate::proc_macro_item`
   --> $DIR/mixed-site-span.rs:56:5
    |
 LL |     invoke_with_ident!{krate input proc_macro_item}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---------------^
-   |     |                              |
-   |     |                              help: a similar name exists in the module: `proc_macro_rules`
-   |     no `proc_macro_item` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
    |
    = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: a similar name exists in the module
+   |
+LL -     invoke_with_ident!{krate input proc_macro_item}
+LL +     invoke_with_ident!{krate input proc_macro_rules}
+   |
 
 error[E0432]: unresolved import `$crate::proc_macro_item`
   --> $DIR/mixed-site-span.rs:57:5
    |
 LL |     with_crate!{krate input proc_macro_item}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^---------------^
-   |     |                       |
-   |     |                       help: a similar name exists in the module: `proc_macro_rules`
-   |     no `proc_macro_item` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
    |
    = note: this error originates in the macro `with_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: a similar name exists in the module
+   |
+LL -     with_crate!{krate input proc_macro_item}
+LL +     with_crate!{krate input proc_macro_rules}
+   |
 
 error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:58:5
    |
 LL |     with_crate!{krate call proc_macro_item}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^---------------^
-   |     |                      |
-   |     |                      help: a similar name exists in the module: `proc_macro_rules`
-   |     no `proc_macro_item` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
    |
    = note: this error originates in the macro `with_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: a similar name exists in the module
+   |
+LL -     with_crate!{krate call proc_macro_item}
+LL +     with_crate!{krate call proc_macro_rules}
+   |
 
 error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:62:28
    |
 LL |         invoke_with_ident!{$crate input proc_macro_item}
-   |                            ^^^^^^       --------------- help: a similar name exists in the module: `proc_macro_rules`
-   |                            |
-   |                            no `proc_macro_item` in the root
+   |                            ^^^^^^ no `proc_macro_item` in the root
 ...
 LL |     test!();
    |     ------- in this macro invocation
    |
    = note: this error originates in the macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: a similar name exists in the module
+   |
+LL -         invoke_with_ident!{$crate input proc_macro_item}
+LL +         invoke_with_ident!{$crate input proc_macro_rules}
+   |
 
 error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:63:21
    |
 LL |         with_crate!{$crate input proc_macro_item}
-   |                     ^^^^^^       --------------- help: a similar name exists in the module: `proc_macro_rules`
-   |                     |
-   |                     no `proc_macro_item` in the root
+   |                     ^^^^^^ no `proc_macro_item` in the root
 ...
 LL |     test!();
    |     ------- in this macro invocation
    |
    = note: this error originates in the macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: a similar name exists in the module
+   |
+LL -         with_crate!{$crate input proc_macro_item}
+LL +         with_crate!{$crate input proc_macro_rules}
+   |
 
 error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:64:9
    |
 LL |         with_crate!{$crate call proc_macro_item}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^---------------^
-   |         |                       |
-   |         |                       help: a similar name exists in the module: `proc_macro_rules`
-   |         no `proc_macro_item` in the root
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
 ...
 LL |     test!();
    |     ------- in this macro invocation
    |
    = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: a similar name exists in the module
+   |
+LL -         with_crate!{$crate call proc_macro_item}
+LL +         with_crate!{$crate call proc_macro_rules}
+   |
 
 error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:67:9

--- a/tests/ui/resolve/underscore-bindings-disambiguators.stderr
+++ b/tests/ui/resolve/underscore-bindings-disambiguators.stderr
@@ -2,19 +2,25 @@ error[E0432]: unresolved import `X`
   --> $DIR/underscore-bindings-disambiguators.rs:25:5
    |
 LL | use X as Y;
-   |     -^^^^^
-   |     |
-   |     no `X` in the root
-   |     help: a similar name exists in the module: `_`
+   |     ^^^^^^ no `X` in the root
+   |
+help: a similar name exists in the module
+   |
+LL - use X as Y;
+LL + use _ as Y;
+   |
 
 error[E0432]: unresolved import `Z`
   --> $DIR/underscore-bindings-disambiguators.rs:26:5
    |
 LL | use Z as W;
-   |     -^^^^^
-   |     |
-   |     no `Z` in the root
-   |     help: a similar name exists in the module: `_`
+   |     ^^^^^^ no `Z` in the root
+   |
+help: a similar name exists in the module
+   |
+LL - use Z as W;
+LL + use _ as W;
+   |
 
 error[E0080]: evaluation panicked: not yet implemented
   --> $DIR/underscore-bindings-disambiguators.rs:19:19

--- a/tests/ui/rust-2018/issue-54006.stderr
+++ b/tests/ui/rust-2018/issue-54006.stderr
@@ -2,7 +2,12 @@ error[E0432]: unresolved import `alloc`
   --> $DIR/issue-54006.rs:6:5
    |
 LL | use alloc::vec;
-   |     ^^^^^ help: a similar path exists: `core::alloc`
+   |     ^^^^^
+   |
+help: a similar path exists
+   |
+LL | use core::alloc::vec;
+   |     ++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rust-2018/local-path-suggestions-2015.stderr
+++ b/tests/ui/rust-2018/local-path-suggestions-2015.stderr
@@ -2,10 +2,12 @@ error[E0432]: unresolved import `foobar`
   --> $DIR/local-path-suggestions-2015.rs:24:5
    |
 LL | use foobar::Baz;
-   |     ^^^^^^
-   |     |
-   |     unresolved import
-   |     help: a similar path exists: `aux_baz::foobar`
+   |     ^^^^^^ unresolved import
+   |
+help: a similar path exists
+   |
+LL | use aux_baz::foobar::Baz;
+   |     +++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rust-2018/local-path-suggestions-2018.stderr
+++ b/tests/ui/rust-2018/local-path-suggestions-2018.stderr
@@ -2,15 +2,24 @@ error[E0432]: unresolved import `foo`
   --> $DIR/local-path-suggestions-2018.rs:10:9
    |
 LL |     use foo::Bar;
-   |         ^^^ help: a similar path exists: `crate::foo`
+   |         ^^^
    |
    = note: `use` statements changed in Rust 2018; read more at <https://doc.rust-lang.org/edition-guide/rust-2018/module-system/path-clarity.html>
+help: a similar path exists
+   |
+LL |     use crate::foo::Bar;
+   |         +++++++
 
 error[E0432]: unresolved import `foobar`
   --> $DIR/local-path-suggestions-2018.rs:19:5
    |
 LL | use foobar::Baz;
-   |     ^^^^^^ help: a similar path exists: `baz::foobar`
+   |     ^^^^^^
+   |
+help: a similar path exists
+   |
+LL | use baz::foobar::Baz;
+   |     +++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/suggestions/trait-hidden-method.stderr
+++ b/tests/ui/suggestions/trait-hidden-method.stderr
@@ -2,7 +2,12 @@ error[E0191]: the value of the associated type `Item` in `Iterator` must be spec
   --> $DIR/trait-hidden-method.rs:4:33
    |
 LL |     Box::new(1..=10) as Box<dyn Iterator>
-   |                                 ^^^^^^^^ help: specify the associated type: `Iterator<Item = /* Type */>`
+   |                                 ^^^^^^^^
+   |
+help: specify the associated type
+   |
+LL |     Box::new(1..=10) as Box<dyn Iterator<Item = /* Type */>>
+   |                                         +++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/alias/object-fail.stderr
+++ b/tests/ui/traits/alias/object-fail.stderr
@@ -19,7 +19,12 @@ error[E0191]: the value of the associated type `Item` in `Iterator` must be spec
   --> $DIR/object-fail.rs:9:17
    |
 LL |     let _: &dyn IteratorAlias = &vec![123].into_iter();
-   |                 ^^^^^^^^^^^^^ help: specify the associated type: `IteratorAlias<Item = /* Type */>`
+   |                 ^^^^^^^^^^^^^
+   |
+help: specify the associated type
+   |
+LL |     let _: &dyn IteratorAlias<Item = /* Type */> = &vec![123].into_iter();
+   |                              +++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/cast-as-dyn-trait-wo-assoc-type-issue-21950.stderr
+++ b/tests/ui/traits/cast-as-dyn-trait-wo-assoc-type-issue-21950.stderr
@@ -5,7 +5,12 @@ LL |     type Output;
    |     ----------- `Output` defined here
 ...
 LL |     let x = &10 as &dyn Add;
-   |                         ^^^ help: specify the associated type: `Add<Output = /* Type */>`
+   |                         ^^^
+   |
+help: specify the associated type
+   |
+LL |     let x = &10 as &dyn Add<Output = /* Type */>;
+   |                            +++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/object/with-self-in-projection-output-bad.stderr
+++ b/tests/ui/traits/object/with-self-in-projection-output-bad.stderr
@@ -5,7 +5,12 @@ LL |     type Output;
    |     ----------- `Output` defined here
 ...
 LL |     let _x: Box<dyn Helper<Target=i32>> = Box::new(2u32);
-   |                     ^^^^^^^^^^^^^^^^^^ help: specify the associated type: `Helper<Target=i32, Output = /* Type */>`
+   |                     ^^^^^^^^^^^^^^^^^^
+   |
+help: specify the associated type
+   |
+LL |     let _x: Box<dyn Helper<Target=i32, Output = /* Type */>> = Box::new(2u32);
+   |                                      +++++++++++++++++++++
 
 error[E0191]: the value of the associated type `Output` in `Base` must be specified
   --> $DIR/with-self-in-projection-output-bad.rs:48:21
@@ -14,7 +19,12 @@ LL |     type Output;
    |     ----------- `Output` defined here
 ...
 LL |     let _y: Box<dyn NormalizableHelper<Target=i32>> = Box::new(2u32);
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: specify the associated type: `NormalizableHelper<Target=i32, Output = /* Type */>`
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: specify the associated type
+   |
+LL |     let _y: Box<dyn NormalizableHelper<Target=i32, Output = /* Type */>> = Box::new(2u32);
+   |                                                  +++++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/transmute/unnecessary-transmutation.stderr
+++ b/tests/ui/transmute/unnecessary-transmutation.stderr
@@ -2,9 +2,7 @@ error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:7:14
    |
 LL |     unsafe { transmute(x) }
-   |              ---------^^^
-   |              |
-   |              help: replace this with: `u32::to_ne_bytes`
+   |              ^^^^^^^^^^^^
    |
    = help: there's also `to_le_bytes` and `to_be_bytes` if you expect a particular byte order
 note: the lint level is defined here
@@ -12,6 +10,11 @@ note: the lint level is defined here
    |
 LL | #![deny(unnecessary_transmutes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
+help: replace this with
+   |
+LL -     unsafe { transmute(x) }
+LL +     unsafe { u32::to_ne_bytes(x) }
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:12:14
@@ -77,179 +80,234 @@ error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:33:22
    |
 LL |         let x: u16 = transmute(*b"01");
-   |                      ---------^^^^^^^^
-   |                      |
-   |                      help: replace this with: `u16::from_ne_bytes`
+   |                      ^^^^^^^^^^^^^^^^^
    |
    = help: there's also `from_le_bytes` and `from_be_bytes` if you expect a particular byte order
+help: replace this with
+   |
+LL -         let x: u16 = transmute(*b"01");
+LL +         let x: u16 = u16::from_ne_bytes(*b"01");
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:35:26
    |
 LL |         let x: [u8; 2] = transmute(x);
-   |                          ---------^^^
-   |                          |
-   |                          help: replace this with: `u16::to_ne_bytes`
+   |                          ^^^^^^^^^^^^
    |
    = help: there's also `to_le_bytes` and `to_be_bytes` if you expect a particular byte order
+help: replace this with
+   |
+LL -         let x: [u8; 2] = transmute(x);
+LL +         let x: [u8; 2] = u16::to_ne_bytes(x);
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:37:22
    |
 LL |         let x: u32 = transmute(*b"0123");
-   |                      ---------^^^^^^^^^^
-   |                      |
-   |                      help: replace this with: `u32::from_ne_bytes`
+   |                      ^^^^^^^^^^^^^^^^^^^
    |
    = help: there's also `from_le_bytes` and `from_be_bytes` if you expect a particular byte order
+help: replace this with
+   |
+LL -         let x: u32 = transmute(*b"0123");
+LL +         let x: u32 = u32::from_ne_bytes(*b"0123");
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:39:26
    |
 LL |         let x: [u8; 4] = transmute(x);
-   |                          ---------^^^
-   |                          |
-   |                          help: replace this with: `u32::to_ne_bytes`
+   |                          ^^^^^^^^^^^^
    |
    = help: there's also `to_le_bytes` and `to_be_bytes` if you expect a particular byte order
+help: replace this with
+   |
+LL -         let x: [u8; 4] = transmute(x);
+LL +         let x: [u8; 4] = u32::to_ne_bytes(x);
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:41:22
    |
 LL |         let x: u64 = transmute(*b"feriscat");
-   |                      ---------^^^^^^^^^^^^^^
-   |                      |
-   |                      help: replace this with: `u64::from_ne_bytes`
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: there's also `from_le_bytes` and `from_be_bytes` if you expect a particular byte order
+help: replace this with
+   |
+LL -         let x: u64 = transmute(*b"feriscat");
+LL +         let x: u64 = u64::from_ne_bytes(*b"feriscat");
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:43:26
    |
 LL |         let x: [u8; 8] = transmute(x);
-   |                          ---------^^^
-   |                          |
-   |                          help: replace this with: `u64::to_ne_bytes`
+   |                          ^^^^^^^^^^^^
    |
    = help: there's also `to_le_bytes` and `to_be_bytes` if you expect a particular byte order
+help: replace this with
+   |
+LL -         let x: [u8; 8] = transmute(x);
+LL +         let x: [u8; 8] = u64::to_ne_bytes(x);
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:46:22
    |
 LL |         let y: i16 = transmute(*b"01");
-   |                      ---------^^^^^^^^
-   |                      |
-   |                      help: replace this with: `i16::from_ne_bytes`
+   |                      ^^^^^^^^^^^^^^^^^
    |
    = help: there's also `from_le_bytes` and `from_be_bytes` if you expect a particular byte order
+help: replace this with
+   |
+LL -         let y: i16 = transmute(*b"01");
+LL +         let y: i16 = i16::from_ne_bytes(*b"01");
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:48:26
    |
 LL |         let y: [u8; 2] = transmute(y);
-   |                          ---------^^^
-   |                          |
-   |                          help: replace this with: `i16::to_ne_bytes`
+   |                          ^^^^^^^^^^^^
    |
    = help: there's also `to_le_bytes` and `to_be_bytes` if you expect a particular byte order
+help: replace this with
+   |
+LL -         let y: [u8; 2] = transmute(y);
+LL +         let y: [u8; 2] = i16::to_ne_bytes(y);
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:50:22
    |
 LL |         let y: i32 = transmute(*b"0123");
-   |                      ---------^^^^^^^^^^
-   |                      |
-   |                      help: replace this with: `i32::from_ne_bytes`
+   |                      ^^^^^^^^^^^^^^^^^^^
    |
    = help: there's also `from_le_bytes` and `from_be_bytes` if you expect a particular byte order
+help: replace this with
+   |
+LL -         let y: i32 = transmute(*b"0123");
+LL +         let y: i32 = i32::from_ne_bytes(*b"0123");
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:52:26
    |
 LL |         let y: [u8; 4] = transmute(y);
-   |                          ---------^^^
-   |                          |
-   |                          help: replace this with: `i32::to_ne_bytes`
+   |                          ^^^^^^^^^^^^
    |
    = help: there's also `to_le_bytes` and `to_be_bytes` if you expect a particular byte order
+help: replace this with
+   |
+LL -         let y: [u8; 4] = transmute(y);
+LL +         let y: [u8; 4] = i32::to_ne_bytes(y);
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:54:22
    |
 LL |         let y: i64 = transmute(*b"feriscat");
-   |                      ---------^^^^^^^^^^^^^^
-   |                      |
-   |                      help: replace this with: `i64::from_ne_bytes`
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: there's also `from_le_bytes` and `from_be_bytes` if you expect a particular byte order
+help: replace this with
+   |
+LL -         let y: i64 = transmute(*b"feriscat");
+LL +         let y: i64 = i64::from_ne_bytes(*b"feriscat");
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:56:26
    |
 LL |         let y: [u8; 8] = transmute(y);
-   |                          ---------^^^
-   |                          |
-   |                          help: replace this with: `i64::to_ne_bytes`
+   |                          ^^^^^^^^^^^^
    |
    = help: there's also `to_le_bytes` and `to_be_bytes` if you expect a particular byte order
+help: replace this with
+   |
+LL -         let y: [u8; 8] = transmute(y);
+LL +         let y: [u8; 8] = i64::to_ne_bytes(y);
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:59:22
    |
 LL |         let z: f32 = transmute(*b"0123");
-   |                      ---------^^^^^^^^^^
-   |                      |
-   |                      help: replace this with: `f32::from_ne_bytes`
+   |                      ^^^^^^^^^^^^^^^^^^^
    |
    = help: there's also `from_le_bytes` and `from_be_bytes` if you expect a particular byte order
+help: replace this with
+   |
+LL -         let z: f32 = transmute(*b"0123");
+LL +         let z: f32 = f32::from_ne_bytes(*b"0123");
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:61:26
    |
 LL |         let z: [u8; 4] = transmute(z);
-   |                          ---------^^^
-   |                          |
-   |                          help: replace this with: `f32::to_ne_bytes`
+   |                          ^^^^^^^^^^^^
    |
    = help: there's also `to_le_bytes` and `to_be_bytes` if you expect a particular byte order
+help: replace this with
+   |
+LL -         let z: [u8; 4] = transmute(z);
+LL +         let z: [u8; 4] = f32::to_ne_bytes(z);
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:63:22
    |
 LL |         let z: f64 = transmute(*b"feriscat");
-   |                      ---------^^^^^^^^^^^^^^
-   |                      |
-   |                      help: replace this with: `f64::from_ne_bytes`
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: there's also `from_le_bytes` and `from_be_bytes` if you expect a particular byte order
+help: replace this with
+   |
+LL -         let z: f64 = transmute(*b"feriscat");
+LL +         let z: f64 = f64::from_ne_bytes(*b"feriscat");
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:65:26
    |
 LL |         let z: [u8; 8] = transmute(z);
-   |                          ---------^^^
-   |                          |
-   |                          help: replace this with: `f64::to_ne_bytes`
+   |                          ^^^^^^^^^^^^
    |
    = help: there's also `to_le_bytes` and `to_be_bytes` if you expect a particular byte order
+help: replace this with
+   |
+LL -         let z: [u8; 8] = transmute(z);
+LL +         let z: [u8; 8] = f64::to_ne_bytes(z);
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:68:22
    |
 LL |         let y: u32 = transmute('🦀');
-   |                      ---------^^^^^^
-   |                      |
-   |                      help: replace this with: `u32::from`
+   |                      ^^^^^^^^^^^^^^^
+   |
+help: replace this with
+   |
+LL -         let y: u32 = transmute('🦀');
+LL +         let y: u32 = u32::from('🦀');
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:70:23
    |
 LL |         let y: char = transmute(y);
-   |                       ---------^^^
-   |                       |
-   |                       help: replace this with: `char::from_u32_unchecked`
+   |                       ^^^^^^^^^^^^
    |
    = help: consider using `char::from_u32(…).unwrap()`
+help: replace this with
+   |
+LL -         let y: char = transmute(y);
+LL +         let y: char = char::from_u32_unchecked(y);
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:72:22
@@ -280,81 +338,121 @@ error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:77:22
    |
 LL |         let x: u16 = transmute(8i16);
-   |                      ---------^^^^^^
-   |                      |
-   |                      help: replace this with: `i16::cast_unsigned`
+   |                      ^^^^^^^^^^^^^^^
+   |
+help: replace this with
+   |
+LL -         let x: u16 = transmute(8i16);
+LL +         let x: u16 = i16::cast_unsigned(8i16);
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:79:22
    |
 LL |         let x: i16 = transmute(x);
-   |                      ---------^^^
-   |                      |
-   |                      help: replace this with: `u16::cast_signed`
+   |                      ^^^^^^^^^^^^
+   |
+help: replace this with
+   |
+LL -         let x: i16 = transmute(x);
+LL +         let x: i16 = u16::cast_signed(x);
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:81:22
    |
 LL |         let x: u32 = transmute(4i32);
-   |                      ---------^^^^^^
-   |                      |
-   |                      help: replace this with: `i32::cast_unsigned`
+   |                      ^^^^^^^^^^^^^^^
+   |
+help: replace this with
+   |
+LL -         let x: u32 = transmute(4i32);
+LL +         let x: u32 = i32::cast_unsigned(4i32);
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:83:22
    |
 LL |         let x: i32 = transmute(x);
-   |                      ---------^^^
-   |                      |
-   |                      help: replace this with: `u32::cast_signed`
+   |                      ^^^^^^^^^^^^
+   |
+help: replace this with
+   |
+LL -         let x: i32 = transmute(x);
+LL +         let x: i32 = u32::cast_signed(x);
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:85:22
    |
 LL |         let x: u64 = transmute(7i64);
-   |                      ---------^^^^^^
-   |                      |
-   |                      help: replace this with: `i64::cast_unsigned`
+   |                      ^^^^^^^^^^^^^^^
+   |
+help: replace this with
+   |
+LL -         let x: u64 = transmute(7i64);
+LL +         let x: u64 = i64::cast_unsigned(7i64);
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:87:22
    |
 LL |         let x: i64 = transmute(x);
-   |                      ---------^^^
-   |                      |
-   |                      help: replace this with: `u64::cast_signed`
+   |                      ^^^^^^^^^^^^
+   |
+help: replace this with
+   |
+LL -         let x: i64 = transmute(x);
+LL +         let x: i64 = u64::cast_signed(x);
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:90:22
    |
 LL |         let y: f32 = transmute(1u32);
-   |                      ---------^^^^^^
-   |                      |
-   |                      help: replace this with: `f32::from_bits`
+   |                      ^^^^^^^^^^^^^^^
+   |
+help: replace this with
+   |
+LL -         let y: f32 = transmute(1u32);
+LL +         let y: f32 = f32::from_bits(1u32);
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:92:22
    |
 LL |         let y: u32 = transmute(y);
-   |                      ---------^^^
-   |                      |
-   |                      help: replace this with: `f32::to_bits`
+   |                      ^^^^^^^^^^^^
+   |
+help: replace this with
+   |
+LL -         let y: u32 = transmute(y);
+LL +         let y: u32 = f32::to_bits(y);
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:94:22
    |
 LL |         let y: f64 = transmute(3u64);
-   |                      ---------^^^^^^
-   |                      |
-   |                      help: replace this with: `f64::from_bits`
+   |                      ^^^^^^^^^^^^^^^
+   |
+help: replace this with
+   |
+LL -         let y: f64 = transmute(3u64);
+LL +         let y: f64 = f64::from_bits(3u64);
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:96:22
    |
 LL |         let y: u64 = transmute(2.0);
-   |                      ---------^^^^^
-   |                      |
-   |                      help: replace this with: `f64::to_bits`
+   |                      ^^^^^^^^^^^^^^
+   |
+help: replace this with
+   |
+LL -         let y: u64 = transmute(2.0);
+LL +         let y: u64 = f64::to_bits(2.0);
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:99:22
@@ -384,17 +482,25 @@ error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:106:21
    |
 LL |         let z: u8 = transmute(z);
-   |                     ---------^^^
-   |                     |
-   |                     help: replace this with: `u8::from`
+   |                     ^^^^^^^^^^^^
+   |
+help: replace this with
+   |
+LL -         let z: u8 = transmute(z);
+LL +         let z: u8 = u8::from(z);
+   |
 
 error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:111:21
    |
 LL |         let z: i8 = transmute(z);
-   |                     ---------^^^
-   |                     |
-   |                     help: replace this with: `i8::from`
+   |                     ^^^^^^^^^^^^
+   |
+help: replace this with
+   |
+LL -         let z: i8 = transmute(z);
+LL +         let z: i8 = i8::from(z);
+   |
 
 error: aborting due to 40 previous errors
 

--- a/tests/ui/trivial-bounds/trivial-bounds-inconsistent.stderr
+++ b/tests/ui/trivial-bounds/trivial-bounds-inconsistent.stderr
@@ -28,15 +28,17 @@ warning: where clauses on type aliases are not enforced
   --> $DIR/trivial-bounds-inconsistent.rs:22:14
    |
 LL | type Y where i32: Foo = ();
-   |        ------^^^^^^^^
-   |        |     |
-   |        |     will not be checked at usage sites of the type alias
-   |        help: remove this where clause
+   |              ^^^^^^^^ will not be checked at usage sites of the type alias
    |
    = note: this is a known limitation of the type checker that may be lifted in a future edition.
            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics
    = note: `#[warn(type_alias_bounds)]` on by default
+help: remove this where clause
+   |
+LL - type Y where i32: Foo = ();
+LL + type Y  = ();
+   |
 
 warning: trait bound i32: Foo does not depend on any type or lifetime parameters
   --> $DIR/trivial-bounds-inconsistent.rs:22:19

--- a/tests/ui/type-alias/missing-associated-type-in-trait-object-22434.stderr
+++ b/tests/ui/type-alias/missing-associated-type-in-trait-object-22434.stderr
@@ -5,7 +5,12 @@ LL |     type A;
    |     ------ `A` defined here
 ...
 LL | type I<'a> = &'a (dyn Foo + 'a);
-   |                       ^^^ help: specify the associated type: `Foo<A = /* Type */>`
+   |                       ^^^
+   |
+help: specify the associated type
+   |
+LL | type I<'a> = &'a (dyn Foo<A = /* Type */> + 'a);
+   |                          ++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type/issue-67690-type-alias-bound-diagnostic-crash.stderr
+++ b/tests/ui/type/issue-67690-type-alias-bound-diagnostic-crash.stderr
@@ -2,15 +2,17 @@ warning: bounds on generic parameters in type aliases are not enforced
   --> $DIR/issue-67690-type-alias-bound-diagnostic-crash.rs:5:15
    |
 LL | pub type T<P: Send + Send + Send> = P;
-   |             --^^^^---^^^^---^^^^
-   |             |               |
-   |             |               will not be checked at usage sites of the type alias
-   |             help: remove this bound
+   |               ^^^^   ^^^^   ^^^^ will not be checked at usage sites of the type alias
    |
    = note: this is a known limitation of the type checker that may be lifted in a future edition.
            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics
    = note: `#[warn(type_alias_bounds)]` on by default
+help: remove this bound
+   |
+LL - pub type T<P: Send + Send + Send> = P;
+LL + pub type T<P> = P;
+   |
 
 warning: 1 warning emitted
 

--- a/tests/ui/type/type-alias-bounds.stderr
+++ b/tests/ui/type/type-alias-bounds.stderr
@@ -2,67 +2,77 @@ warning: bounds on generic parameters in type aliases are not enforced
   --> $DIR/type-alias-bounds.rs:8:14
    |
 LL | type SVec<T: Send + Send> = Vec<T>;
-   |            --^^^^---^^^^
-   |            |        |
-   |            |        will not be checked at usage sites of the type alias
-   |            help: remove this bound
+   |              ^^^^   ^^^^ will not be checked at usage sites of the type alias
    |
    = note: this is a known limitation of the type checker that may be lifted in a future edition.
            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics
    = note: `#[warn(type_alias_bounds)]` on by default
+help: remove this bound
+   |
+LL - type SVec<T: Send + Send> = Vec<T>;
+LL + type SVec<T> = Vec<T>;
+   |
 
 warning: where clauses on type aliases are not enforced
   --> $DIR/type-alias-bounds.rs:10:21
    |
 LL | type S2Vec<T> where T: Send = Vec<T>;
-   |               ------^^^^^^^
-   |               |     |
-   |               |     will not be checked at usage sites of the type alias
-   |               help: remove this where clause
+   |                     ^^^^^^^ will not be checked at usage sites of the type alias
    |
    = note: this is a known limitation of the type checker that may be lifted in a future edition.
            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics
+help: remove this where clause
+   |
+LL - type S2Vec<T> where T: Send = Vec<T>;
+LL + type S2Vec<T>  = Vec<T>;
+   |
 
 warning: bounds on generic parameters in type aliases are not enforced
   --> $DIR/type-alias-bounds.rs:12:19
    |
 LL | type VVec<'b, 'a: 'b + 'b> = (&'b u32, Vec<&'a i32>);
-   |                 --^^---^^
-   |                 |      |
-   |                 |      will not be checked at usage sites of the type alias
-   |                 help: remove this bound
+   |                   ^^   ^^ will not be checked at usage sites of the type alias
    |
    = note: this is a known limitation of the type checker that may be lifted in a future edition.
            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics
+help: remove this bound
+   |
+LL - type VVec<'b, 'a: 'b + 'b> = (&'b u32, Vec<&'a i32>);
+LL + type VVec<'b, 'a> = (&'b u32, Vec<&'a i32>);
+   |
 
 warning: bounds on generic parameters in type aliases are not enforced
   --> $DIR/type-alias-bounds.rs:14:18
    |
 LL | type WVec<'b, T: 'b + 'b> = (&'b u32, Vec<T>);
-   |                --^^---^^
-   |                |      |
-   |                |      will not be checked at usage sites of the type alias
-   |                help: remove this bound
+   |                  ^^   ^^ will not be checked at usage sites of the type alias
    |
    = note: this is a known limitation of the type checker that may be lifted in a future edition.
            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics
+help: remove this bound
+   |
+LL - type WVec<'b, T: 'b + 'b> = (&'b u32, Vec<T>);
+LL + type WVec<'b, T> = (&'b u32, Vec<T>);
+   |
 
 warning: where clauses on type aliases are not enforced
   --> $DIR/type-alias-bounds.rs:16:25
    |
 LL | type W2Vec<'b, T> where T: 'b, T: 'b = (&'b u32, Vec<T>);
-   |                   ------^^^^^--^^^^^
-   |                   |            |
-   |                   |            will not be checked at usage sites of the type alias
-   |                   help: remove this where clause
+   |                         ^^^^^  ^^^^^ will not be checked at usage sites of the type alias
    |
    = note: this is a known limitation of the type checker that may be lifted in a future edition.
            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics
+help: remove this where clause
+   |
+LL - type W2Vec<'b, T> where T: 'b, T: 'b = (&'b u32, Vec<T>);
+LL + type W2Vec<'b, T>  = (&'b u32, Vec<T>);
+   |
 
 warning: bounds on generic parameters in type aliases are not enforced
   --> $DIR/type-alias-bounds.rs:48:12
@@ -106,27 +116,31 @@ warning: bounds on generic parameters in type aliases are not enforced
   --> $DIR/type-alias-bounds.rs:57:12
    |
 LL | type T5<U: Bound> = <U as Bound>::Assoc;
-   |          --^^^^^
-   |          | |
-   |          | will not be checked at usage sites of the type alias
-   |          help: remove this bound
+   |            ^^^^^ will not be checked at usage sites of the type alias
    |
    = note: this is a known limitation of the type checker that may be lifted in a future edition.
            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics
+help: remove this bound
+   |
+LL - type T5<U: Bound> = <U as Bound>::Assoc;
+LL + type T5<U> = <U as Bound>::Assoc;
+   |
 
 warning: bounds on generic parameters in type aliases are not enforced
   --> $DIR/type-alias-bounds.rs:58:12
    |
 LL | type T6<U: Bound> = ::std::vec::Vec<U>;
-   |          --^^^^^
-   |          | |
-   |          | will not be checked at usage sites of the type alias
-   |          help: remove this bound
+   |            ^^^^^ will not be checked at usage sites of the type alias
    |
    = note: this is a known limitation of the type checker that may be lifted in a future edition.
            see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = help: add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics
+help: remove this bound
+   |
+LL - type T6<U: Bound> = ::std::vec::Vec<U>;
+LL + type T6<U> = ::std::vec::Vec<U>;
+   |
 
 warning: 9 warnings emitted
 

--- a/tests/ui/unresolved/unresolved-import.stderr
+++ b/tests/ui/unresolved/unresolved-import.stderr
@@ -13,46 +13,64 @@ error[E0432]: unresolved import `bar::Baz`
   --> $DIR/unresolved-import.rs:8:5
    |
 LL | use bar::Baz as x;
-   |     ^^^^^---^^^^^
-   |     |    |
-   |     |    help: a similar name exists in the module: `Bar`
-   |     no `Baz` in `bar`
+   |     ^^^^^^^^^^^^^ no `Baz` in `bar`
+   |
+help: a similar name exists in the module
+   |
+LL - use bar::Baz as x;
+LL + use bar::Bar as x;
+   |
 
 error[E0432]: unresolved import `food::baz`
   --> $DIR/unresolved-import.rs:14:5
    |
 LL | use food::baz;
-   |     ^^^^^^---
-   |     |     |
-   |     |     help: a similar name exists in the module: `bag`
-   |     no `baz` in `food`
+   |     ^^^^^^^^^ no `baz` in `food`
    |
 note: module `food::zug::baz` exists but is inaccessible
   --> $DIR/unresolved-import.rs:34:9
    |
 LL |         pub mod baz {
    |         ^^^^^^^^^^^ not accessible
+help: a similar name exists in the module
+   |
+LL - use food::baz;
+LL + use food::bag;
+   |
 
 error[E0432]: unresolved import `food::beens`
   --> $DIR/unresolved-import.rs:20:12
    |
 LL | use food::{beens as Foo};
-   |            -----^^^^^^^
-   |            |
-   |            no `beens` in `food`
-   |            help: a similar name exists in the module: `beans`
+   |            ^^^^^^^^^^^^ no `beens` in `food`
+   |
+help: a similar name exists in the module
+   |
+LL - use food::{beens as Foo};
+LL + use food::{beans as Foo};
+   |
 
 error[E0432]: unresolved import `MyEnum`
   --> $DIR/unresolved-import.rs:47:9
    |
 LL |     use MyEnum::*;
-   |         ^^^^^^ help: a similar path exists: `self::MyEnum`
+   |         ^^^^^^
+   |
+help: a similar path exists
+   |
+LL |     use self::MyEnum::*;
+   |         ++++++
 
 error[E0432]: unresolved import `Enum`
   --> $DIR/unresolved-import.rs:58:9
    |
 LL |     use Enum::*;
-   |         ^^^^ help: a similar path exists: `self::Enum`
+   |         ^^^^
+   |
+help: a similar path exists
+   |
+LL |     use self::Enum::*;
+   |         ++++++
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/use/use-nested-groups-error.stderr
+++ b/tests/ui/use/use-nested-groups-error.stderr
@@ -2,10 +2,13 @@ error[E0432]: unresolved import `a::b1::C1`
   --> $DIR/use-nested-groups-error.rs:9:14
    |
 LL | use a::{b1::{C1, C2}, B2};
-   |              ^^
-   |              |
-   |              no `C1` in `a::b1`
-   |              help: a similar name exists in the module: `C2`
+   |              ^^ no `C1` in `a::b1`
+   |
+help: a similar name exists in the module
+   |
+LL - use a::{b1::{C1, C2}, B2};
+LL + use a::{b1::{C2, C2}, B2};
+   |
 
 error: aborting due to 1 previous error
 

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1678,3 +1678,7 @@ labels = ["S-waiting-on-concerns"]
 # since the review
 # Documentation at: https://forge.rust-lang.org/triagebot/review-changes-since.html
 [review-changes-since]
+
+# Adds a "View all comments" link on the issue/PR body that shows all the comments of it
+# Documentation at: https://forge.rust-lang.org/triagebot/view-all-comments-link.html
+[view-all-comments-link]


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#151733 (Use function shims to make sure EII works on apple targets)
 - rust-lang/rust#152558 (rustc_expand: improve diagnostics for non-repeatable metavars in repetition)
 - rust-lang/rust#152596 (Make all multipart suggestions verbose)
 - rust-lang/rust#152815 (Add CURRENT_RUSTC_VERSION support for Clippy)
 - rust-lang/rust#152733 (Port #[rustc_doc_primitive] to the new attribute parser)
 - rust-lang/rust#152817 (Update enzyme submodule to match upstream)
 - rust-lang/rust#152819 (explicitly show behavior of <_>::assoc_fn)
 - rust-lang/rust#152823 (fix stale comments left over from ed3711e)
 - rust-lang/rust#152824 (Enable "View all comments" link feature in `triagebot.toml`)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=151733,152558,152596,152815,152733,152817,152819,152823,152824)
<!-- homu-ignore:end -->

