### PR TITLE
perf(codegen): Eliminate `size_of_val == 0` for DSTs with Non-zero-sized Prefix via NUW and Assume

### DIFF
--- a/compiler/rustc_codegen_ssa/src/size_of_val.rs
+++ b/compiler/rustc_codegen_ssa/src/size_of_val.rs
@@ -159,7 +159,7 @@ pub fn size_and_align_of_dst<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
             // Furthermore, `align >= unsized_align`, and therefore we only need to do:
             // let full_size = (unsized_offset_unadjusted + unsized_size).align_to(full_align);
 
-            let full_size = bx.add(unsized_offset_unadjusted, unsized_size);
+            let unrounded_size = bx.unchecked_suadd(unsized_offset_unadjusted, unsized_size);
 
             // Issue #27023: must add any necessary padding to `size`
             // (to make it a multiple of `align`) before returning it.
@@ -173,9 +173,13 @@ pub fn size_and_align_of_dst<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
             //   `(size + (align-1)) & -align`
             let one = bx.const_usize(1);
             let addend = bx.sub(full_align, one);
-            let add = bx.add(full_size, addend);
+            let add = bx.add(unrounded_size, addend);
             let neg = bx.neg(full_align);
             let full_size = bx.and(add, neg);
+
+            // `round_up(x, a) >= x` for pow2 `a` (#152788).
+            let size_ge = bx.icmp(IntPredicate::IntUGE, full_size, unrounded_size);
+            bx.assume(size_ge);
 
             (full_size, full_align)
         }

--- a/tests/codegen-llvm/dst-size-of-val-not-zst.rs
+++ b/tests/codegen-llvm/dst-size-of-val-not-zst.rs
@@ -1,0 +1,30 @@
+//@ compile-flags: -Copt-level=3 -Z merge-functions=disabled
+//@ min-llvm-version: 21
+//@ needs-deterministic-layouts
+
+// Regression test for #152788.
+
+#![crate_type = "lib"]
+
+pub struct Foo<T: ?Sized>(pub [u32; 3], pub T);
+
+// CHECK-LABEL: @size_of_val_dyn_not_zero
+#[no_mangle]
+pub fn size_of_val_dyn_not_zero(p: &Foo<dyn std::fmt::Debug>) -> bool {
+    // CHECK: ret i1 false
+    std::mem::size_of_val(p) == 0
+}
+
+// CHECK-LABEL: @size_of_val_slice_u8_not_zero
+#[no_mangle]
+pub fn size_of_val_slice_u8_not_zero(p: &Foo<[u8]>) -> bool {
+    // CHECK: ret i1 false
+    std::mem::size_of_val(p) == 0
+}
+
+// CHECK-LABEL: @size_of_val_slice_i32_not_zero
+#[no_mangle]
+pub fn size_of_val_slice_i32_not_zero(p: &Foo<[i32]>) -> bool {
+    // CHECK: ret i1 false
+    std::mem::size_of_val(p) == 0
+}

--- a/tests/codegen-llvm/dst-vtable-align-1-elide-check.rs
+++ b/tests/codegen-llvm/dst-vtable-align-1-elide-check.rs
@@ -1,0 +1,30 @@
+//@ compile-flags: -Copt-level=3 -Z merge-functions=disabled
+//@ min-llvm-version: 21
+
+#![crate_type = "lib"]
+
+pub trait Trait {
+    fn f(&self);
+}
+
+pub struct WrapperWithAlign1<T: ?Sized> {
+    x: u8,
+    y: T,
+}
+
+pub struct Struct<W: ?Sized> {
+    _field: i8,
+    dst: W,
+}
+
+// CHECK-LABEL: @eliminates_runtime_check_when_align_1
+#[no_mangle]
+pub fn eliminates_runtime_check_when_align_1(
+    x: &Struct<WrapperWithAlign1<dyn Trait>>,
+) -> &WrapperWithAlign1<dyn Trait> {
+    // CHECK: load i{{[0-9]+}}, {{.+}} !range
+    // CHECK-NOT: llvm.umax
+    // CHECK-NOT: select
+    // CHECK: ret
+    &x.dst
+}

--- a/tests/codegen-llvm/dst-vtable-align-nonzero.rs
+++ b/tests/codegen-llvm/dst-vtable-align-nonzero.rs
@@ -3,16 +3,11 @@
 #![crate_type = "lib"]
 #![feature(core_intrinsics)]
 
-// This test checks that we annotate alignment loads from vtables with nonzero range metadata,
-// and that this allows LLVM to eliminate redundant `align >= 1` checks.
+// This test checks that we annotate alignment loads from vtables with nonzero range metadata.
+// The companion LLVM-21-only fold check lives in `dst-vtable-align-1-elide-check.rs`.
 
 pub trait Trait {
     fn f(&self);
-}
-
-pub struct WrapperWithAlign1<T: ?Sized> {
-    x: u8,
-    y: T,
 }
 
 pub struct WrapperWithAlign2<T: ?Sized> {
@@ -25,25 +20,11 @@ pub struct Struct<W: ?Sized> {
     dst: W,
 }
 
-// CHECK-LABEL: @eliminates_runtime_check_when_align_1
-#[no_mangle]
-pub fn eliminates_runtime_check_when_align_1(
-    x: &Struct<WrapperWithAlign1<dyn Trait>>,
-) -> &WrapperWithAlign1<dyn Trait> {
-    // CHECK: load [[USIZE:i[0-9]+]], {{.+}} !range [[RANGE_META:![0-9]+]]
-    // CHECK-NOT: llvm.umax
-    // CHECK-NOT: icmp
-    // CHECK-NOT: select
-    // CHECK: ret
-    &x.dst
-}
-
 // CHECK-LABEL: @does_not_eliminate_runtime_check_when_align_2
 #[no_mangle]
 pub fn does_not_eliminate_runtime_check_when_align_2(
     x: &Struct<WrapperWithAlign2<dyn Trait>>,
 ) -> &WrapperWithAlign2<dyn Trait> {
-    // CHECK: [[X0:%[0-9]+]] = load [[USIZE]], {{.+}} !range [[RANGE_META]]
     // CHECK: {{icmp|llvm.umax}}
     // CHECK: ret
     &x.dst
@@ -52,7 +33,7 @@ pub fn does_not_eliminate_runtime_check_when_align_2(
 // CHECK-LABEL: @align_load_from_align_of_val
 #[no_mangle]
 pub fn align_load_from_align_of_val(x: &dyn Trait) -> usize {
-    // CHECK: {{%[0-9]+}} = load [[USIZE]], {{.+}} !range [[RANGE_META]]
+    // CHECK: {{%[0-9]+}} = load [[USIZE:i[0-9]+]], {{.+}} !range [[RANGE_META:![0-9]+]]
     core::mem::align_of_val(x)
 }
 


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/152843)*

### Summary:

#### Problem:

`size_of_val(p) == 0` fails to optimize away for DST types that have a statically-known non-zero-sized prefix:

```rust
pub struct Foo<T: ?Sized>(pub [u32; 3], pub T);

pub fn demo(p: &Foo<dyn std::fmt::Debug>) -> bool {
    std::mem::size_of_val(p) == 0  // always false, but LLVM can't prove it
}
```

`Foo` has a 12-byte prefix, so its total size is always ≥ 12. Yet the comparison persists as a runtime computation in LLVM IR. This matters because `Box<dyn T>` drop emits this exact check to guard the deallocation call — for types with a guaranteed non-zero prefix, the branch should vanish but doesn't.

The slice tail variant `Foo<[i32]>` already optimized correctly; `Foo<dyn Trait>` and `Foo<[u8]>` did not.

#### Root Cause:

In `size_and_align_of_dst` (the ADT/Tuple branch), the size computation is:

```
full_size = (offset + unsized_size + (align-1)) & -align
```

LLVM cannot prove `full_size > 0` because:

1. `offset + unsized_size` used plain `add` — no overflow flags, so LLVM cannot conclude the result is ≥ `offset`.
2. `(x + addend) & -align` — LLVM has no fold to prove that alignment rounding never reduces the value below `x`.

#### Solution:

Two changes:

1. **`add nuw nsw` on `offset + unsized_size`** — the sum is bounded by the rounded size ≤ `isize::MAX`, so neither signed nor unsigned overflow is possible. Tells LLVM: `unrounded_size ≥ offset`.

2. **`assume(full_size ≥ unrounded_size)`** — `round_up(x, a) ≥ x` is a mathematical identity for power-of-two `a`. Tells LLVM: `full_size ≥ unrounded_size ≥ offset`. If `offset > 0`, the chain proves `full_size > 0`.

#### LLVM IR Comparison:

`Foo<dyn Debug>` — before ([godbolt](https://rust.godbolt.org/z/r1d5n6Phe)):

```llvm
define noundef zeroext i1 @demo(ptr %p.0, ptr %p.1) {
start:
  %0 = getelementptr inbounds nuw i8, ptr %p.1, i64 8
  %1 = load i64, ptr %0, align 8, !range !3, !invariant.load !4
  %2 = getelementptr inbounds nuw i8, ptr %p.1, i64 16
  %3 = load i64, ptr %2, align 8, !range !5, !invariant.load !4
  %4 = tail call i64 @llvm.umax.i64(i64 %3, i64 4)
  %5 = add nuw i64 %1, 11
  %6 = add i64 %5, %4
  %7 = sub i64 0, %4
  %8 = and i64 %6, %7
  %_0 = icmp eq i64 %8, 0
  ret i1 %_0
}
```

`Foo<dyn Debug>` — after:

```llvm
define noundef zeroext i1 @demo(ptr %p.0, ptr %p.1) {
start:
  ret i1 false
}
```

`Foo<[u8]>` — before:

```llvm
define noundef zeroext i1 @demo_lessalignedslice(ptr %p.0, i64 %p.1) {
start:
  %0 = add i64 %p.1, 15
  %_0 = icmp ult i64 %0, 4
  ret i1 %_0
}
```

`Foo<[u8]>` — after:

```llvm
define noundef zeroext i1 @demo_lessalignedslice(ptr %p.0, i64 %p.1) {
start:
  ret i1 false
}
```

### Changes:

- `compiler/rustc_codegen_ssa/src/size_of_val.rs`: `add` → `unchecked_suadd` (NUW+NSW) on `offset + unsized_size`; add `assume(full_size ≥ unrounded_size)`.
- `tests/codegen-llvm/dst-size-of-val-not-zst.rs`: new codegen test verifying `size_of_val == 0` folds to `ret i1 false` for `Foo<dyn Debug>`, `Foo<[u8]>`, and `Foo<[i32]>`.

Fixes rust-lang/rust#152788.