### PR TITLE
Skip `tidy` in PR CI jobs not dedicated to running `tidy`

### DIFF
--- a/src/ci/docker/scripts/stage_2_test_set1.sh
+++ b/src/ci/docker/scripts/stage_2_test_set1.sh
@@ -4,6 +4,15 @@ set -ex
 
 # Run a subset of tests. Used to run tests in parallel in multiple jobs.
 
+# When this job partition is run as part of PR CI, skip tidy to allow revealing more failures. The
+# dedicated `tidy` job failing won't block other PR CI jobs from completing, and so tidy failures
+# shouldn't inhibit revealing other failures in PR CI jobs.
+if [ "$PR_CI_JOB" == "1" ]; then
+  echo "PR_CI_JOB set; skipping tidy"
+  SKIP_TIDY="--skip tidy"
+fi
+
 ../x.py --stage 2 test \
+  ${SKIP_TIDY:+$SKIP_TIDY} \
   --skip compiler \
   --skip src

--- a/src/ci/docker/scripts/stage_2_test_set2.sh
+++ b/src/ci/docker/scripts/stage_2_test_set2.sh
@@ -4,7 +4,16 @@ set -ex
 
 # Run a subset of tests. Used to run tests in parallel in multiple jobs.
 
+# When this job partition is run as part of PR CI, skip tidy to allow revealing more failures. The
+# dedicated `tidy` job failing won't block other PR CI jobs from completing, and so tidy failures
+# shouldn't inhibit revealing other failures in PR CI jobs.
+if [ "$PR_CI_JOB" == "1" ]; then
+  echo "PR_CI_JOB set; skipping tidy"
+  SKIP_TIDY="--skip tidy"
+fi
+
 ../x.py --stage 2 test \
+  ${SKIP_TIDY:+$SKIP_TIDY} \
   --skip tests \
   --skip coverage-map \
   --skip coverage-run \


### PR DESCRIPTION
This is both:

1. Redundant, since PR CI has a dedicated `tidy` job which runs in parallel and doesn't early-cancel other PR CI jobs
2. A contributor roadblock, because tidy failures in one test jobs block further failures from other test jobs being revealed.

(2) defeats the parallel-but-not-early-cancelling reason of the separate `tidy` job in the first place.

This PR skips tidy from being run in PR CI jobs that are not dedicated to running `tidy` (i.e. the non-`tidy` CI jobs).

Fixes rust-lang/rust#148932.