### PR TITLE
Use `builder.create_dir` more in bootstrap

### DIFF
--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -17,7 +17,7 @@ use crate::core::builder::{
 };
 use crate::core::config::TargetSelection;
 use crate::utils::build_stamp::{self, BuildStamp};
-use crate::{CodegenBackendKind, Compiler, Mode, Subcommand, t};
+use crate::{CodegenBackendKind, Compiler, Mode, Subcommand};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Std {
@@ -184,7 +184,7 @@ impl RmetaSysroot {
         let host_dir = directory.join("host");
         let target_dir = directory.join(target);
         let _ = fs::remove_dir_all(directory);
-        t!(fs::create_dir_all(directory));
+        builder.create_dir(directory);
         add_to_sysroot(builder, &target_dir, &host_dir, &stamp);
 
         Self { host_dir, target_dir }

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -379,7 +379,7 @@ fn copy_self_contained_objects(
 ) -> Vec<(PathBuf, DependencyType)> {
     let libdir_self_contained =
         builder.sysroot_target_libdir(*compiler, target).join("self-contained");
-    t!(fs::create_dir_all(&libdir_self_contained));
+    builder.create_dir(&libdir_self_contained);
     let mut target_deps = vec![];
 
     // Copies the libc and CRT objects.
@@ -783,16 +783,16 @@ impl Step for StdLink {
             let host = compiler.host;
             let stage0_bin_dir = builder.out.join(host).join("stage0/bin");
             let sysroot_bin_dir = sysroot.join("bin");
-            t!(fs::create_dir_all(&sysroot_bin_dir));
+            builder.create_dir(&sysroot_bin_dir);
             builder.cp_link_r(&stage0_bin_dir, &sysroot_bin_dir);
 
             let stage0_lib_dir = builder.out.join(host).join("stage0/lib");
-            t!(fs::create_dir_all(sysroot.join("lib")));
+            builder.create_dir(&sysroot.join("lib"));
             builder.cp_link_r(&stage0_lib_dir, &sysroot.join("lib"));
 
             // Copy codegen-backends from stage0
             let sysroot_codegen_backends = builder.sysroot_codegen_backends(compiler);
-            t!(fs::create_dir_all(&sysroot_codegen_backends));
+            builder.create_dir(&sysroot_codegen_backends);
             let stage0_codegen_backends = builder
                 .out
                 .join(host)
@@ -924,7 +924,7 @@ impl Step for StartupObjects {
         let src_dir = &builder.src.join("library").join("rtstartup");
         let dst_dir = &builder.native_dir(target).join("rtstartup");
         let sysroot_dir = &builder.sysroot_target_libdir(for_compiler, target);
-        t!(fs::create_dir_all(dst_dir));
+        builder.create_dir(&dst_dir);
 
         for file in &["rsbegin", "rsend"] {
             let src_file = &src_dir.join(file.to_string() + ".rs");
@@ -961,7 +961,7 @@ fn cp_rustc_component_to_ci_sysroot(builder: &Builder<'_>, sysroot: &Path, conte
         let src = ci_rustc_dir.join(&file);
         let dst = sysroot.join(file);
         if src.is_dir() {
-            t!(fs::create_dir_all(dst));
+            builder.create_dir(&dst);
         } else {
             builder.copy_link(&src, &dst, FileType::Regular);
         }
@@ -1629,7 +1629,7 @@ impl GccDylibSet {
             );
 
             let dst = cg_sysroot.join(libgccjit_path_relative_to_cg_dir(target_pair, libgccjit));
-            t!(std::fs::create_dir_all(dst.parent().unwrap()));
+            builder.create_dir(&dst.parent().unwrap());
             builder.copy_link(&libgccjit_path, &dst, FileType::NativeLibrary);
         }
     }
@@ -1865,7 +1865,7 @@ fn copy_codegen_backends_to_sysroot(
     // Here we're looking for the output dylib of the `CodegenBackend` step and
     // we're copying that into the `codegen-backends` folder.
     let dst = builder.sysroot_codegen_backends(target_compiler);
-    t!(fs::create_dir_all(&dst), dst);
+    builder.create_dir(&dst);
 
     if builder.config.dry_run() {
         return;
@@ -1959,7 +1959,7 @@ impl Step for Sysroot {
             println!("Removing sysroot {} to avoid caching bugs", sysroot.display())
         });
         let _ = fs::remove_dir_all(&sysroot);
-        t!(fs::create_dir_all(&sysroot));
+        builder.create_dir(&sysroot);
 
         // In some cases(see https://github.com/rust-lang/rust/issues/109314), when the stage0
         // compiler relies on more recent version of LLVM than the stage0 compiler, it may not
@@ -2037,7 +2037,7 @@ impl Step for Sysroot {
         // directory (for running tests with `rust.remap-debuginfo = true`).
         if compiler.stage != 0 {
             let sysroot_lib_rustlib_src = sysroot.join("lib/rustlib/src");
-            t!(fs::create_dir_all(&sysroot_lib_rustlib_src));
+            builder.create_dir(&sysroot_lib_rustlib_src);
             let sysroot_lib_rustlib_src_rust = sysroot_lib_rustlib_src.join("rust");
             if let Err(e) =
                 symlink_dir(&builder.config, &builder.src, &sysroot_lib_rustlib_src_rust)
@@ -2061,7 +2061,7 @@ impl Step for Sysroot {
         // rustc-src component is already part of CI rustc's sysroot
         if !builder.download_rustc() {
             let sysroot_lib_rustlib_rustcsrc = sysroot.join("lib/rustlib/rustc-src");
-            t!(fs::create_dir_all(&sysroot_lib_rustlib_rustcsrc));
+            builder.create_dir(&sysroot_lib_rustlib_rustcsrc);
             let sysroot_lib_rustlib_rustcsrc_rust = sysroot_lib_rustlib_rustcsrc.join("rust");
             if let Err(e) =
                 symlink_dir(&builder.config, &builder.src, &sysroot_lib_rustlib_rustcsrc_rust)
@@ -2126,7 +2126,7 @@ impl Step for Assemble {
         // avoid shadowing the system LLD we rename the LLD we provide to `rust-lld`.
         let libdir = builder.sysroot_target_libdir(target_compiler, target_compiler.host);
         let libdir_bin = libdir.parent().unwrap().join("bin");
-        t!(fs::create_dir_all(&libdir_bin));
+        builder.create_dir(&libdir_bin);
 
         if builder.config.llvm_enabled(target_compiler.host) {
             trace!("target_compiler.host" = ?target_compiler.host, "LLVM enabled");
@@ -2227,7 +2227,7 @@ impl Step for Assemble {
                     .join(format!("lib/rustlib/{}/bin/self-contained", target_compiler.host));
                 let tool_exe = exe("llvm-bitcode-linker", target_compiler.host);
 
-                t!(fs::create_dir_all(&bindir_self_contained));
+                builder.create_dir(&bindir_self_contained);
                 builder.copy_link(
                     &llvm_bitcode_linker.tool_path,
                     &bindir_self_contained.join(tool_exe),
@@ -2351,7 +2351,7 @@ impl Step for Assemble {
 
         let sysroot = builder.sysroot(target_compiler);
         let rustc_libdir = builder.rustc_libdir(target_compiler);
-        t!(fs::create_dir_all(&rustc_libdir));
+        builder.create_dir(&rustc_libdir);
         let src_libdir = builder.sysroot_target_libdir(build_compiler, host);
         for f in builder.read_dir(&src_libdir) {
             let filename = f.file_name().into_string().unwrap();
@@ -2552,7 +2552,7 @@ impl Step for Assemble {
         let out_dir = builder.cargo_out(build_compiler, Mode::Rustc, host);
         let rustc = out_dir.join(exe("rustc-main", host));
         let bindir = sysroot.join("bin");
-        t!(fs::create_dir_all(bindir));
+        builder.create_dir(&bindir);
         let compiler = builder.rustc(target_compiler);
         debug!(src = ?rustc, dst = ?compiler, "linking compiler binary itself");
         builder.copy_link(&rustc, &compiler, FileType::Executable);
@@ -2573,9 +2573,9 @@ pub fn add_to_sysroot(
     stamp: &BuildStamp,
 ) {
     let self_contained_dst = &sysroot_dst.join("self-contained");
-    t!(fs::create_dir_all(sysroot_dst));
-    t!(fs::create_dir_all(sysroot_host_dst));
-    t!(fs::create_dir_all(self_contained_dst));
+    builder.create_dir(&sysroot_dst);
+    builder.create_dir(&sysroot_host_dst);
+    builder.create_dir(&self_contained_dst);
 
     let mut crates = HashMap::new();
     for (path, dependency_type) in builder.read_stamp_file(stamp) {

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -279,8 +279,8 @@ fn make_win_dist(plat_root: &Path, target: TargetSelection, builder: &Builder<'_
     //Copy platform tools to platform-specific bin directory
     let plat_target_bin_self_contained_dir =
         plat_root.join("lib/rustlib").join(target).join("bin/self-contained");
-    fs::create_dir_all(&plat_target_bin_self_contained_dir)
-        .expect("creating plat_target_bin_self_contained_dir failed");
+    builder.create_dir(&plat_target_bin_self_contained_dir);
+
     for src in target_tools {
         builder.copy_link_to_folder(&src, &plat_target_bin_self_contained_dir);
     }
@@ -296,8 +296,7 @@ fn make_win_dist(plat_root: &Path, target: TargetSelection, builder: &Builder<'_
     //Copy platform libs to platform-specific lib directory
     let plat_target_lib_self_contained_dir =
         plat_root.join("lib/rustlib").join(target).join("lib/self-contained");
-    fs::create_dir_all(&plat_target_lib_self_contained_dir)
-        .expect("creating plat_target_lib_self_contained_dir failed");
+    builder.create_dir(&plat_target_lib_self_contained_dir);
     for src in target_libs {
         builder.copy_link_to_folder(&src, &plat_target_lib_self_contained_dir);
     }
@@ -334,8 +333,7 @@ fn make_win_llvm_dist(plat_root: &Path, target: TargetSelection, builder: &Build
     //Copy platform libs to platform-specific lib directory
     let plat_target_lib_self_contained_dir =
         plat_root.join("lib/rustlib").join(target).join("lib/self-contained");
-    fs::create_dir_all(&plat_target_lib_self_contained_dir)
-        .expect("creating plat_target_lib_self_contained_dir failed");
+    builder.create_dir(&plat_target_lib_self_contained_dir);
     for src in target_libs {
         builder.copy_link_to_folder(&src, &plat_target_lib_self_contained_dir);
     }
@@ -366,7 +364,7 @@ fn runtime_dll_dist(rust_root: &Path, target: TargetSelection, builder: &Builder
 
     // Copy runtime dlls next to rustc.exe
     let rust_bin_dir = rust_root.join("bin/");
-    fs::create_dir_all(&rust_bin_dir).expect("creating rust_bin_dir failed");
+    builder.create_dir(&rust_bin_dir);
     for src in &rustc_dlls {
         builder.copy_link_to_folder(src, &rust_bin_dir);
     }
@@ -374,7 +372,7 @@ fn runtime_dll_dist(rust_root: &Path, target: TargetSelection, builder: &Builder
     if builder.config.lld_enabled {
         // rust-lld.exe also needs runtime dlls
         let rust_target_bin_dir = rust_root.join("lib/rustlib").join(target).join("bin");
-        fs::create_dir_all(&rust_target_bin_dir).expect("creating rust_target_bin_dir failed");
+        builder.create_dir(&rust_target_bin_dir);
         for src in &rustc_dlls {
             builder.copy_link_to_folder(src, &rust_target_bin_dir);
         }
@@ -518,7 +516,7 @@ impl Step for Rustc {
             let src = builder.sysroot(target_compiler);
 
             // Copy rustc binary
-            t!(fs::create_dir_all(image.join("bin")));
+            builder.create_dir(&image.join("bin"));
             builder.cp_link_r(&src.join("bin"), &image.join("bin"));
 
             // If enabled, copy rustdoc binary
@@ -576,7 +574,7 @@ impl Step for Rustc {
             maybe_install_llvm_runtime(builder, target, image);
 
             let dst_dir = image.join("lib/rustlib").join(target).join("bin");
-            t!(fs::create_dir_all(&dst_dir));
+            builder.create_dir(&dst_dir);
 
             // Copy over lld if it's there
             if builder.config.lld_enabled {
@@ -589,7 +587,7 @@ impl Step for Rustc {
                 );
                 let self_contained_lld_src_dir = src_dir.join("gcc-ld");
                 let self_contained_lld_dst_dir = dst_dir.join("gcc-ld");
-                t!(fs::create_dir(&self_contained_lld_dst_dir));
+                builder.create_dir(&self_contained_lld_dst_dir);
                 for name in crate::LLD_FILE_NAMES {
                     let exe_name = exe(name, target_compiler.host);
                     builder.copy_link(
@@ -620,7 +618,7 @@ impl Step for Rustc {
             }
 
             // Man pages
-            t!(fs::create_dir_all(image.join("share/man/man1")));
+            builder.create_dir(&image.join("share/man/man1"));
             let man_src = builder.src.join("src/doc/man");
             let man_dst = image.join("share/man/man1");
 
@@ -680,12 +678,12 @@ fn generate_target_spec_json_schema(builder: &Builder<'_>, sysroot: &Path) {
     let schema = rustc.run_capture(builder).stdout();
 
     let schema_dir = tmpdir(builder);
-    t!(fs::create_dir_all(&schema_dir));
+    builder.create_dir(&schema_dir);
     let schema_file = schema_dir.join("target-spec-json-schema.json");
     t!(std::fs::write(&schema_file, schema));
 
     let dst = sysroot.join("etc");
-    t!(fs::create_dir_all(&dst));
+    builder.create_dir(&dst);
 
     builder.install(&schema_file, &dst, FileType::Regular);
 }
@@ -709,7 +707,7 @@ impl Step for DebuggerScripts {
         let target = self.target;
         let sysroot = self.sysroot;
         let dst = sysroot.join("lib/rustlib/etc");
-        t!(fs::create_dir_all(&dst));
+        builder.create_dir(&dst);
         let cp_debugger_script = |file: &str| {
             builder.install(&builder.src.join("src/etc/").join(file), &dst, FileType::Regular);
         };
@@ -811,8 +809,8 @@ fn copy_target_libs(
 ) {
     let dst = image.join("lib/rustlib").join(target).join("lib");
     let self_contained_dst = dst.join("self-contained");
-    t!(fs::create_dir_all(&dst));
-    t!(fs::create_dir_all(&self_contained_dst));
+    builder.create_dir(&dst);
+    builder.create_dir(&self_contained_dst);
     for (path, dependency_type) in builder.read_stamp_file(stamp) {
         if dependency_type == DependencyType::TargetSelfContained {
             builder.copy_link(
@@ -1013,7 +1011,7 @@ impl Step for Analysis {
             .join("save-analysis");
 
         // Write a file indicating that this component has been removed.
-        t!(std::fs::create_dir_all(&src));
+        builder.create_dir(&src);
         let mut removed = src.clone();
         removed.push("removed.json");
         let mut f = t!(std::fs::File::create(removed));
@@ -1143,7 +1141,7 @@ fn copy_src_dirs(
     // Copy the directories using our filter
     for item in src_dirs {
         let dst = &dst_dir.join(item);
-        t!(fs::create_dir_all(dst));
+        builder.create_dir(&dst);
         builder
             .cp_link_filtered(&base.join(item), dst, &|path| filter_fn(exclude_dirs, item, path));
     }
@@ -1344,7 +1342,7 @@ fn prepare_source_tarball<'a>(
     // Create the files containing git info, to ensure --version outputs the same.
     let write_git_info = |info: Option<&Info>, path: &Path| {
         if let Some(info) = info {
-            t!(std::fs::create_dir_all(path));
+            builder.create_dir(&path);
             channel::write_commit_hash_file(path, &info.sha);
             channel::write_commit_info_file(path, info);
         }

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -140,7 +140,7 @@ impl<P: Step> Step for RustbookSrc<P> {
         let name = self.name;
         let src = self.src;
         let out = builder.doc_out(target);
-        t!(fs::create_dir_all(&out));
+        builder.create_dir(&out);
 
         let out = out.join(&name);
         let index = out.join("index.html");
@@ -376,7 +376,7 @@ impl Step for Standalone {
         let build_compiler = self.build_compiler;
         let _guard = builder.msg(Kind::Doc, "standalone", None, build_compiler, target);
         let out = builder.doc_out(target);
-        t!(fs::create_dir_all(&out));
+        builder.create_dir(&out);
 
         let version_info = builder.ensure(SharedAssets { target: self.target }).version_info;
 
@@ -485,7 +485,7 @@ impl Step for Releases {
         let build_compiler = self.build_compiler;
         let _guard = builder.msg(Kind::Doc, "releases", None, build_compiler, target);
         let out = builder.doc_out(target);
-        t!(fs::create_dir_all(&out));
+        builder.create_dir(&out);
 
         builder.ensure(Standalone { build_compiler, target });
 
@@ -691,7 +691,7 @@ impl Step for Std {
             DocumentationFormat::Json => builder.json_doc_out(target),
         };
 
-        t!(fs::create_dir_all(&out));
+        builder.create_dir(&out);
 
         if self.format == DocumentationFormat::Html {
             builder.ensure(SharedAssets { target: self.target });
@@ -897,7 +897,7 @@ impl Step for Rustc {
 
         // This is the intended out directory for compiler documentation.
         let out = builder.compiler_doc_out(target);
-        t!(fs::create_dir_all(&out));
+        builder.create_dir(&out);
 
         // Build the standard library, so that proc-macros can use it.
         // (Normally, only the metadata would be necessary, but proc-macros are special since they run at compile-time.)
@@ -968,7 +968,8 @@ impl Step for Rustc {
             // relative links.
             // FIXME: Cargo should probably do this itself.
             let dir_name = krate.replace('-', "_");
-            t!(fs::create_dir_all(out_dir.join(&*dir_name)));
+            builder.create_dir(&out_dir.join(&*dir_name));
+
             cargo.arg("-p").arg(krate);
             if to_open.is_none() {
                 to_open = Some(dir_name);
@@ -1082,7 +1083,7 @@ macro_rules! tool_doc {
 
                 // This is the intended out directory for compiler documentation.
                 let out = builder.compiler_doc_out(target);
-                t!(fs::create_dir_all(&out));
+                builder.create_dir(&out);
 
                 // Build cargo command.
                 let mut cargo = prepare_tool_cargo(
@@ -1127,7 +1128,7 @@ macro_rules! tool_doc {
                 let out_dir = builder.stage_out(build_compiler, mode).join(target).join("doc");
                 $(for krate in $crates {
                     let dir_name = krate.replace("-", "_");
-                    t!(fs::create_dir_all(out_dir.join(&*dir_name)));
+                    builder.create_dir(&out_dir.join(&*dir_name));
                 })?
 
                 // Symlink compiler docs to the output directory of rustdoc documentation.
@@ -1257,7 +1258,7 @@ impl Step for ErrorIndex {
     fn run(self, builder: &Builder<'_>) {
         builder.info(&format!("Documenting error index ({})", self.compilers.target()));
         let out = builder.doc_out(self.compilers.target());
-        t!(fs::create_dir_all(&out));
+        builder.create_dir(&out);
         tool::ErrorIndex::command(builder, self.compilers)
             .arg("html")
             .arg(&out)
@@ -1386,7 +1387,7 @@ impl Step for RustcBook {
     /// "rustbook" is used to convert it to HTML.
     fn run(self, builder: &Builder<'_>) {
         let out_base = builder.md_doc_out(self.target).join("rustc");
-        t!(fs::create_dir_all(&out_base));
+        builder.create_dir(&out_base);
         let out_listing = out_base.join("src/lints");
         builder.cp_link_r(&builder.src.join("src/doc/rustc"), &out_base);
         builder.info(&format!("Generating lint docs ({})", self.target));

--- a/src/bootstrap/src/core/build_steps/gcc.rs
+++ b/src/bootstrap/src/core/build_steps/gcc.rs
@@ -9,7 +9,6 @@
 //! ensure that they're always in place if needed.
 
 use std::fmt::{Display, Formatter};
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
@@ -299,8 +298,8 @@ fn build_gcc(metadata: &Meta, builder: &Builder<'_>, target_pair: GccTargetPair)
 
     let Meta { stamp: _, out_dir, install_dir, root } = metadata;
 
-    t!(fs::create_dir_all(out_dir));
-    t!(fs::create_dir_all(install_dir));
+    builder.create_dir(&out_dir);
+    builder.create_dir(&install_dir);
 
     // GCC creates files (e.g. symlinks to the downloaded dependencies)
     // in the source directory, which does not work with our CI/Docker setup, where we mount

--- a/src/bootstrap/src/core/build_steps/install.rs
+++ b/src/bootstrap/src/core/build_steps/install.rs
@@ -106,7 +106,7 @@ fn install_sh(
     let bindir = prefix.join(&builder.config.bindir); // Default in config.rs
 
     let empty_dir = builder.out.join("tmp/empty_dir");
-    t!(fs::create_dir_all(&empty_dir));
+    builder.create_dir(&empty_dir);
 
     let mut cmd = command(SHELL);
     cmd.current_dir(&empty_dir)

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -313,7 +313,7 @@ impl Step for Llvm {
         let _guard = builder.msg_unstaged(Kind::Build, "LLVM", target);
         t!(stamp.remove());
         let _time = helpers::timeit(builder);
-        t!(fs::create_dir_all(&out_dir));
+        builder.create_dir(&out_dir);
 
         // https://llvm.org/docs/CMake.html
         let mut cfg = cmake::Config::new(builder.src.join(root));
@@ -1005,7 +1005,7 @@ impl Step for OmpOffload {
         builder.info(&format!("Building OpenMP/Offload for {target}"));
         t!(stamp.remove());
         let _time = helpers::timeit(builder);
-        t!(fs::create_dir_all(&out_dir));
+        builder.create_dir(&out_dir);
 
         builder.config.update_submodule("src/llvm-project");
 
@@ -1189,7 +1189,7 @@ impl Step for Enzyme {
         builder.info(&format!("Building Enzyme for {target}"));
         t!(stamp.remove());
         let _time = helpers::timeit(builder);
-        t!(fs::create_dir_all(&out_dir));
+        builder.create_dir(&out_dir);
 
         let mut cfg = cmake::Config::new(builder.src.join("src/tools/enzyme/enzyme/"));
         // Enzyme devs maintain upstream compatibility, but only fix deprecations when they are about
@@ -1283,7 +1283,7 @@ impl Step for Lld {
 
         let _guard = builder.msg_unstaged(Kind::Build, "LLD", target);
         let _time = helpers::timeit(builder);
-        t!(fs::create_dir_all(&out_dir));
+        builder.create_dir(&out_dir);
 
         let mut cfg = cmake::Config::new(builder.src.join("src/llvm-project/lld"));
         let mut ldflags = LdFlags::default();
@@ -1454,7 +1454,7 @@ impl Step for Sanitizers {
             suppressed_compiler_flag_prefixes,
         );
 
-        t!(fs::create_dir_all(&out_dir));
+        builder.create_dir(&out_dir);
         cfg.out_dir(out_dir);
 
         for runtime in &runtimes {
@@ -1592,7 +1592,7 @@ impl Step for CrtBeginEnd {
         }
 
         let _guard = builder.msg_unstaged(Kind::Build, "crtbegin.o and crtend.o", self.target);
-        t!(fs::create_dir_all(&out_dir));
+        builder.create_dir(&out_dir);
 
         let mut cfg = cc::Build::new();
 
@@ -1665,7 +1665,7 @@ impl Step for Libunwind {
         }
 
         let _guard = builder.msg_unstaged(Kind::Build, "libunwind.a", self.target);
-        t!(fs::create_dir_all(&out_dir));
+        builder.create_dir(&out_dir);
 
         let mut cc_cfg = cc::Build::new();
         let mut cpp_cfg = cc::Build::new();

--- a/src/bootstrap/src/core/build_steps/synthetic_targets.rs
+++ b/src/bootstrap/src/core/build_steps/synthetic_targets.rs
@@ -50,7 +50,7 @@ fn create_synthetic_target(
 
     let name = format!("{base}-synthetic-{suffix}");
     let path = builder.out.join("synthetic-target-specs").join(format!("{name}.json"));
-    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    builder.create_dir(&path.parent().unwrap());
 
     if builder.config.dry_run() {
         std::fs::write(&path, b"dry run\n").unwrap();

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -310,7 +310,7 @@ impl Step for Cargotest {
         // is currently to minimize the length of path on Windows where we otherwise
         // quickly run into path name limit constraints.
         let out_dir = builder.out.join("ct");
-        t!(fs::create_dir_all(&out_dir));
+        builder.create_dir(&out_dir);
 
         let _time = helpers::timeit(builder);
         let mut cmd = builder.tool_cmd(Tool::CargoTest);
@@ -590,7 +590,7 @@ impl Step for Rustfmt {
         );
 
         let dir = testdir(builder, target);
-        t!(fs::create_dir_all(&dir));
+        builder.create_dir(&dir);
         cargo.env("RUSTFMT_TEST_DIR", dir);
 
         cargo.add_rustc_lib_path(builder);
@@ -2798,7 +2798,7 @@ impl Step for ErrorIndex {
         let target_compiler = self.compilers.target_compiler();
 
         let dir = testdir(builder, target_compiler.host);
-        t!(fs::create_dir_all(&dir));
+        builder.create_dir(&dir);
         let output = dir.join("error-index.md");
 
         let mut tool = tool::ErrorIndex::command(builder, self.compilers);
@@ -3738,7 +3738,7 @@ impl Step for RustInstaller {
         let mut cmd = command(builder.src.join("src/tools/rust-installer/test.sh"));
         let tmpdir = testdir(builder, build_compiler.host).join("rust-installer");
         let _ = std::fs::remove_dir_all(&tmpdir);
-        let _ = std::fs::create_dir_all(&tmpdir);
+        builder.create_dir(&tmpdir);
         cmd.current_dir(&tmpdir);
         cmd.env("CARGO_TARGET_DIR", tmpdir.join("cargo-target"));
         cmd.env("CARGO", &builder.initial_cargo);
@@ -3785,7 +3785,7 @@ impl Step for TestHelpers {
         }
 
         let _guard = builder.msg_unstaged(Kind::Build, "test helpers", target);
-        t!(fs::create_dir_all(&dst));
+        builder.create_dir(&dst);
         let mut cfg = cc::Build::new();
 
         // We may have found various cross-compilers a little differently due to our

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -22,7 +22,7 @@ use crate::core::builder::{
 };
 use crate::core::config::{DebuginfoLevel, RustcLto, TargetSelection};
 use crate::utils::exec::{BootstrapCommand, command};
-use crate::utils::helpers::{add_dylib_path, exe, t};
+use crate::utils::helpers::{add_dylib_path, exe};
 use crate::{Compiler, FileType, Kind, Mode};
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -713,7 +713,7 @@ impl Step for Rustdoc {
         let bin_rustdoc = || {
             let sysroot = builder.sysroot(target_compiler);
             let bindir = sysroot.join("bin");
-            t!(fs::create_dir_all(&bindir));
+            builder.create_dir(&bindir);
             let bin_rustdoc = bindir.join(exe("rustdoc", target_compiler.host));
             let _ = fs::remove_file(&bin_rustdoc);
             bin_rustdoc
@@ -930,7 +930,7 @@ pub(crate) fn copy_lld_artifacts(
     let target = target_compiler.host;
 
     let libdir_bin = builder.sysroot_target_bindir(target_compiler, target);
-    t!(fs::create_dir_all(&libdir_bin));
+    builder.create_dir(&libdir_bin);
 
     let src_exe = exe("lld", target);
     let dst_exe = exe("rust-lld", target);
@@ -941,7 +941,7 @@ pub(crate) fn copy_lld_artifacts(
         FileType::Executable,
     );
     let self_contained_lld_dir = libdir_bin.join("gcc-ld");
-    t!(fs::create_dir_all(&self_contained_lld_dir));
+    builder.create_dir(&self_contained_lld_dir);
 
     for name in crate::LLD_FILE_NAMES {
         builder.copy_link(
@@ -1119,7 +1119,7 @@ impl Step for RustAnalyzerProcMacroSrv {
         // Copy `rust-analyzer-proc-macro-srv` to `<sysroot>/libexec/`
         // so that r-a can use it.
         let libexec_path = builder.sysroot(self.compilers.target_compiler).join("libexec");
-        t!(fs::create_dir_all(&libexec_path));
+        builder.create_dir(&libexec_path);
         builder.copy_link(
             &tool_result.tool_path,
             &libexec_path.join("rust-analyzer-proc-macro-srv"),
@@ -1243,7 +1243,7 @@ impl Step for LibcxxVersionTool {
         // Therefore, we want to avoid recompiling this file unnecessarily.
         if !executable.exists() {
             if !out_dir.exists() {
-                t!(fs::create_dir_all(&out_dir));
+                builder.create_dir(&out_dir);
             }
 
             let compiler = builder.cxx(self.target).unwrap();
@@ -1537,7 +1537,7 @@ fn build_extended_rustc_tool(
         && !add_bins_to_sysroot.is_empty()
     {
         let bindir = builder.sysroot(target_compiler).join("bin");
-        t!(fs::create_dir_all(&bindir));
+        builder.create_dir(&bindir);
 
         for add_bin in add_bins_to_sysroot {
             let bin_destination = bindir.join(exe(add_bin, target_compiler.host));

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -715,7 +715,7 @@ impl Step for Libdir {
                     )
                 });
                 let _ = fs::remove_dir_all(&sysroot_target_libdir);
-                t!(fs::create_dir_all(&sysroot_target_libdir));
+                builder.create_dir(&sysroot_target_libdir);
             }
 
             if self.compiler.stage == 0 {

--- a/src/bootstrap/src/utils/build_stamp.rs
+++ b/src/bootstrap/src/utils/build_stamp.rs
@@ -118,7 +118,7 @@ pub fn clear_if_dirty(builder: &Builder<'_>, dir: &Path, input: &Path) -> bool {
     } else if stamp.path().exists() {
         return cleared;
     }
-    t!(fs::create_dir_all(dir));
+    builder.create_dir(&dir);
     t!(fs::File::create(stamp.path()));
     cleared
 }

--- a/src/bootstrap/src/utils/tarball.rs
+++ b/src/bootstrap/src/utils/tarball.rs
@@ -199,7 +199,7 @@ impl<'a> Tarball<'a> {
     }
 
     pub(crate) fn image_dir(&self) -> &Path {
-        t!(std::fs::create_dir_all(&self.image_dir));
+        self.builder.create_dir(&self.image_dir);
         &self.image_dir
     }
 
@@ -217,7 +217,7 @@ impl<'a> Tarball<'a> {
             self.image_dir.join(destdir.as_ref())
         };
 
-        t!(std::fs::create_dir_all(&destdir));
+        self.builder.create_dir(&destdir);
         self.builder.install(src.as_ref(), &destdir, file_type);
     }
 
@@ -229,7 +229,7 @@ impl<'a> Tarball<'a> {
         file_type: FileType,
     ) {
         let destdir = self.image_dir.join(destdir.as_ref());
-        t!(std::fs::create_dir_all(&destdir));
+        self.builder.create_dir(&destdir);
         self.builder.copy_link(src.as_ref(), &destdir.join(new_name), file_type);
     }
 
@@ -242,7 +242,7 @@ impl<'a> Tarball<'a> {
     pub(crate) fn add_dir(&self, src: impl AsRef<Path>, dest: impl AsRef<Path>) {
         let dest = self.image_dir.join(dest.as_ref());
 
-        t!(std::fs::create_dir_all(&dest));
+        self.builder.create_dir(&dest);
         self.builder.cp_link_r(src.as_ref(), &dest);
     }
 
@@ -306,7 +306,7 @@ impl<'a> Tarball<'a> {
 
         self.run(|this, cmd| {
             let distdir = distdir(this.builder);
-            t!(std::fs::create_dir_all(&distdir));
+            this.builder.create_dir(&distdir);
             cmd.arg("tarball")
                 .arg("--input")
                 .arg(&dest)
@@ -336,7 +336,7 @@ impl<'a> Tarball<'a> {
     }
 
     fn run(self, build_cli: impl FnOnce(&Tarball<'a>, &mut BootstrapCommand)) -> GeneratedTarball {
-        t!(std::fs::create_dir_all(&self.overlay_dir));
+        self.builder.create_dir(&self.overlay_dir);
         self.builder.create(&self.overlay_dir.join("version"), &self.overlay.version(self.builder));
         if let Some(info) = self.builder.rust_info().info() {
             channel::write_commit_hash_file(&self.overlay_dir, &info.sha);


### PR DESCRIPTION
Since this helper:

- Handles `dry_run` skipping
- Allows tracing of dir creation

r? ghost