### PR TITLE
Remove driver_lint_caps

### DIFF
--- a/compiler/rustc_baked_icu_data/src/lib.rs
+++ b/compiler/rustc_baked_icu_data/src/lib.rs
@@ -21,8 +21,9 @@
 
 // tidy-alphabetical-start
 #![allow(elided_lifetimes_in_paths)]
-#![allow(unreachable_pub)] // because this crate is mostly generated code
+#![allow(unreachable_pub, reason = "this crate is mostly generated code")]
 // #![warn(unreachable_pub)] // don't use because this crate is mostly generated code
+#![doc(test(attr(allow(elided_lifetimes_in_paths))))]
 // tidy-alphabetical-end
 
 pub struct BakedDataProvider;

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -213,7 +213,6 @@ pub fn run_compiler(at_args: &[String], callbacks: &mut (dyn Callbacks + Send)) 
         output_dir: odir,
         ice_file,
         file_loader: None,
-        lint_caps: Default::default(),
         psess_created: None,
         track_state: None,
         register_lints: None,

--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use rustc_ast::{LitKind, MetaItemKind, token};
 use rustc_codegen_ssa::traits::CodegenBackend;
-use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::jobserver::{self, Proxy};
 use rustc_errors::{DiagCtxtHandle, ErrorGuaranteed};
 use rustc_lint::LintStore;
@@ -18,7 +18,7 @@ use rustc_parse::parser::attr::AllowLeadingUnsafe;
 use rustc_query_impl::print_query_stack;
 use rustc_session::config::{self, Cfg, CheckCfg, ExpectedValues, Input, OutFileName};
 use rustc_session::parse::ParseSess;
-use rustc_session::{CompilerIO, EarlyDiagCtxt, Session, lint};
+use rustc_session::{CompilerIO, EarlyDiagCtxt, Session};
 use rustc_span::source_map::{FileLoader, RealFileLoader, SourceMapInputs};
 use rustc_span::{FileName, sym};
 use tracing::trace;
@@ -330,8 +330,6 @@ pub struct Config {
     /// running rustc without having to save". (See #102759.)
     pub file_loader: Option<Box<dyn FileLoader + Send + Sync>>,
 
-    pub lint_caps: FxHashMap<lint::LintId, lint::Level>,
-
     /// This is a callback from the driver that is called when [`ParseSess`] is created.
     pub psess_created: Option<Box<dyn FnOnce(&mut ParseSess) + Send>>,
 
@@ -427,7 +425,6 @@ pub fn run_compiler<R: Send>(config: Config, f: impl FnOnce(&Compiler) -> R + Se
                     output_file: config.output_file,
                     temps_dir,
                 },
-                config.lint_caps,
                 target,
                 util::rustc_version_str().unwrap_or("unknown"),
                 config.ice_file,

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -68,15 +68,7 @@ where
 
         static USING_INTERNAL_FEATURES: AtomicBool = AtomicBool::new(false);
 
-        let sess = build_session(
-            sessopts,
-            io,
-            Default::default(),
-            target,
-            "",
-            None,
-            &USING_INTERNAL_FEATURES,
-        );
+        let sess = build_session(sessopts, io, target, "", None, &USING_INTERNAL_FEATURES);
         let cfg = parse_cfg(sess.dcx(), matches.opt_strs("cfg"));
         let cfg = build_configuration(&sess, cfg);
         f(sess, cfg)

--- a/compiler/rustc_middle/src/lint.rs
+++ b/compiler/rustc_middle/src/lint.rs
@@ -186,11 +186,6 @@ pub fn reveal_actual_level_spec<Id: Copy>(
         level_spec.level = min(level_spec.level, sess.opts.lint_cap.unwrap_or(Level::Forbid));
     };
 
-    // Ensure that we never exceed driver level.
-    if let Some(driver_level) = sess.driver_lint_caps.get(&lint) {
-        level_spec.level = min(level_spec.level, *driver_level);
-    }
-
     level_spec
 }
 

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -117,9 +117,6 @@ pub struct Session {
     /// This only ever stores a `LintStore` but we don't want a dependency on that type here.
     pub lint_store: Option<Arc<dyn DynLintStore>>,
 
-    /// Cap lint level specified by a driver specifically.
-    pub driver_lint_caps: FxHashMap<lint::LintId, lint::Level>,
-
     /// Tracks the current behavior of the CTFE engine when an error occurs.
     /// Options range from returning the error without a backtrace to returning an error
     /// and immediately printing the backtrace to stderr.
@@ -1010,7 +1007,6 @@ fn default_emitter(sopts: &config::Options, source_map: Arc<SourceMap>) -> Box<D
 pub fn build_session(
     sopts: config::Options,
     io: CompilerIO,
-    driver_lint_caps: FxHashMap<lint::LintId, lint::Level>,
     target: Target,
     cfg_version: &'static str,
     ice_file: Option<PathBuf>,
@@ -1116,7 +1112,6 @@ pub fn build_session(
         timings,
         code_stats: Default::default(),
         lint_store: None,
-        driver_lint_caps,
         ctfe_backtrace,
         miri_unleashed_features: Lock::new(Default::default()),
         asm_arch,

--- a/src/doc/rustc-dev-guide/examples/rustc-interface-example.rs
+++ b/src/doc/rustc-dev-guide/examples/rustc-interface-example.rs
@@ -28,12 +28,11 @@ fn main() {
     println!("{HELLO}");
 }
 "#
-                .into(),
+            .into(),
         },
-        output_dir: None,                // Option<PathBuf>
-        output_file: None,               // Option<PathBuf>
-        file_loader: None,               // Option<Box<dyn FileLoader + Send + Sync>>
-        lint_caps: FxHashMap::default(), // FxHashMap<lint::LintId, lint::Level>
+        output_dir: None,  // Option<PathBuf>
+        output_file: None, // Option<PathBuf>
+        file_loader: None, // Option<Box<dyn FileLoader + Send + Sync>>
         // This is a callback from the driver that is called when [`ParseSess`] is created.
         psess_created: None, //Option<Box<dyn FnOnce(&mut ParseSess) + Send>>
         // This is a callback from the driver that is called when we're registering lints;

--- a/src/doc/rustc-dev-guide/examples/rustc-interface-getting-diagnostics.rs
+++ b/src/doc/rustc-dev-guide/examples/rustc-interface-getting-diagnostics.rs
@@ -59,14 +59,13 @@ fn main() {
     let x: &str = 1;
 }
 "
-                .into(),
+            .into(),
         },
         crate_cfg: Vec::new(),
         crate_check_cfg: Vec::new(),
         output_dir: None,
         output_file: None,
         file_loader: None,
-        lint_caps: rustc_hash::FxHashMap::default(),
         psess_created: Some(Box::new(|parse_sess| {
             parse_sess.dcx().set_emitter(Box::new(DebugEmitter {
                 source_map: parse_sess.clone_source_map(),

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -247,7 +247,7 @@ pub(crate) fn create_config(
     ];
     lints_to_show.extend(crate::lint::RUSTDOC_LINTS.iter().map(|lint| lint.name.to_string()));
 
-    let (lint_opts, lint_caps) = crate::lint::init_lints(lints_to_show, lint_opts, |lint| {
+    let lint_opts = crate::lint::init_lints(lints_to_show, lint_opts, |lint| {
         Some((lint.name_lower(), lint::Allow))
     });
 
@@ -302,7 +302,6 @@ pub(crate) fn create_config(
             Some(render_options.output.clone())
         },
         file_loader: None,
-        lint_caps,
         psess_created: None,
         track_state: None,
         register_lints: Some(Box::new(crate::lint::register_lints)),

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -144,7 +144,7 @@ pub(crate) fn run(dcx: DiagCtxtHandle<'_>, input: Input, options: RustdocOptions
         lint::builtin::RENAMED_AND_REMOVED_LINTS.name.to_owned(),
     ];
 
-    let (lint_opts, lint_caps) = init_lints(allowed_lints, options.lint_opts.clone(), |lint| {
+    let lint_opts = init_lints(allowed_lints, options.lint_opts.clone(), |lint| {
         if lint.name == invalid_codeblock_attributes_name {
             None
         } else {
@@ -162,7 +162,7 @@ pub(crate) fn run(dcx: DiagCtxtHandle<'_>, input: Input, options: RustdocOptions
         search_paths: options.libs.clone(),
         crate_types,
         lint_opts,
-        lint_cap: Some(options.lint_cap.unwrap_or(lint::Forbid)),
+        lint_cap: None,
         cg: options.codegen_options.clone(),
         externs: options.externs.clone(),
         unstable_features: options.unstable_features,
@@ -189,7 +189,6 @@ pub(crate) fn run(dcx: DiagCtxtHandle<'_>, input: Input, options: RustdocOptions
         output_file: None,
         output_dir: None,
         file_loader: None,
-        lint_caps,
         psess_created: None,
         track_state: None,
         register_lints: Some(Box::new(crate::lint::register_lints)),

--- a/src/librustdoc/lint.rs
+++ b/src/librustdoc/lint.rs
@@ -1,6 +1,5 @@
 use std::sync::LazyLock as Lazy;
 
-use rustc_data_structures::fx::FxHashMap;
 use rustc_lint::LintStore;
 use rustc_lint_defs::{Lint, LintId, declare_tool_lint};
 use rustc_session::{Session, lint};
@@ -14,14 +13,12 @@ use rustc_session::{Session, lint};
 /// through the "WARNINGS" lint. To prevent this to happen, we set it back to its "normal" level
 /// inside this function.
 ///
-/// It returns a tuple containing:
-///  * Vector of tuples of lints' name and their associated "max" level
-///  * HashMap of lint id with their associated "max" level
+/// It returns a vector of tuples of lints' name and their associated "max" level
 pub(crate) fn init_lints<F>(
     mut allowed_lints: Vec<String>,
     lint_opts: Vec<(String, lint::Level)>,
     filter_call: F,
-) -> (Vec<(String, lint::Level)>, FxHashMap<lint::LintId, lint::Level>)
+) -> Vec<(String, lint::Level)>
 where
     F: Fn(&lint::Lint) -> Option<(String, lint::Level)>,
 {
@@ -36,7 +33,7 @@ where
             .chain(rustc_lint::SoftLints::lint_vec())
     };
 
-    let lint_opts = lints()
+    lints()
         .filter_map(|lint| {
             // Permit feature-gated lints to avoid feature errors when trying to
             // allow all lints.
@@ -47,20 +44,7 @@ where
             }
         })
         .chain(lint_opts)
-        .collect::<Vec<_>>();
-
-    let lint_caps = lints()
-        .filter_map(|lint| {
-            // We don't want to allow *all* lints so let's ignore
-            // those ones.
-            if allowed_lints.iter().any(|l| lint.name == l) {
-                None
-            } else {
-                Some((lint::LintId::of(lint), lint::Allow))
-            }
-        })
-        .collect();
-    (lint_opts, lint_caps)
+        .collect::<Vec<_>>()
 }
 
 macro_rules! declare_rustdoc_lint {

--- a/tests/ui-fulldeps/run-compiler-twice.rs
+++ b/tests/ui-fulldeps/run-compiler-twice.rs
@@ -64,7 +64,6 @@ fn compile(code: String, output: PathBuf, sysroot: Sysroot, linker: Option<&Path
         output_dir: None,
         ice_file: None,
         file_loader: None,
-        lint_caps: Default::default(),
         psess_created: None,
         track_state: None,
         register_lints: None,


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/152852)*
<!-- homu-ignore:end -->

It was only used by rustdoc and doesn't seem like it was necessary there. No tests fail at least.

r? rust-lang/rustdoc