### PR TITLE
deny-by-default & report in deps `uninhabited_static`

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2718,12 +2718,13 @@ declare_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust
+    #[cfg_attr(bootstrap, doc = "```rust")]
+    #[cfg_attr(not(bootstrap), doc = "```rust,compile_fail")]
     /// enum Void {}
     /// unsafe extern {
     ///     static EXTERN: Void;
     /// }
-    /// ```
+    #[doc = "```"]
     ///
     /// {{produces}}
     ///
@@ -2734,10 +2735,11 @@ declare_lint! {
     /// compiler which assumes that there are no initialized uninhabited places (such as locals or
     /// statics). This was accidentally allowed, but is being phased out.
     pub UNINHABITED_STATIC,
-    Warn,
+    Deny,
     "uninhabited static",
     @future_incompatible = FutureIncompatibleInfo {
         reason: fcw!(FutureReleaseError #74840),
+        report_in_deps: true,
     };
 }
 

--- a/tests/ui/statics/uninhabited-static.rs
+++ b/tests/ui/statics/uninhabited-static.rs
@@ -1,5 +1,4 @@
 #![feature(never_type)]
-#![deny(uninhabited_static)]
 
 enum Void {}
 extern "C" {

--- a/tests/ui/statics/uninhabited-static.stderr
+++ b/tests/ui/statics/uninhabited-static.stderr
@@ -1,5 +1,5 @@
 error: static of uninhabited type
-  --> $DIR/uninhabited-static.rs:12:1
+  --> $DIR/uninhabited-static.rs:11:1
    |
 LL | static VOID2: Void = unsafe { std::mem::transmute(()) };
    | ^^^^^^^^^^^^^^^^^^
@@ -7,14 +7,10 @@ LL | static VOID2: Void = unsafe { std::mem::transmute(()) };
    = note: uninhabited statics cannot be initialized, and any access would be an immediate error
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
-note: the lint level is defined here
-  --> $DIR/uninhabited-static.rs:2:9
-   |
-LL | #![deny(uninhabited_static)]
-   |         ^^^^^^^^^^^^^^^^^^
+   = note: `#[deny(uninhabited_static)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: static of uninhabited type
-  --> $DIR/uninhabited-static.rs:15:1
+  --> $DIR/uninhabited-static.rs:14:1
    |
 LL | static NEVER2: Void = unsafe { std::mem::transmute(()) };
    | ^^^^^^^^^^^^^^^^^^^
@@ -24,7 +20,7 @@ LL | static NEVER2: Void = unsafe { std::mem::transmute(()) };
    = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
 
 error: static of uninhabited type
-  --> $DIR/uninhabited-static.rs:6:5
+  --> $DIR/uninhabited-static.rs:5:5
    |
 LL |     static VOID: Void;
    |     ^^^^^^^^^^^^^^^^^
@@ -34,7 +30,7 @@ LL |     static VOID: Void;
    = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
 
 error: static of uninhabited type
-  --> $DIR/uninhabited-static.rs:8:5
+  --> $DIR/uninhabited-static.rs:7:5
    |
 LL |     static NEVER: !;
    |     ^^^^^^^^^^^^^^^
@@ -44,13 +40,13 @@ LL |     static NEVER: !;
    = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
 
 error[E0080]: constructing invalid value of type Void: encountered a value of uninhabited type `Void`
-  --> $DIR/uninhabited-static.rs:12:31
+  --> $DIR/uninhabited-static.rs:11:31
    |
 LL | static VOID2: Void = unsafe { std::mem::transmute(()) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `VOID2` failed here
 
 error[E0080]: constructing invalid value of type Void: encountered a value of uninhabited type `Void`
-  --> $DIR/uninhabited-static.rs:15:32
+  --> $DIR/uninhabited-static.rs:14:32
    |
 LL | static NEVER2: Void = unsafe { std::mem::transmute(()) };
    |                                ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NEVER2` failed here
@@ -58,3 +54,51 @@ LL | static NEVER2: Void = unsafe { std::mem::transmute(()) };
 error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0080`.
+Future incompatibility report: Future breakage diagnostic:
+error: static of uninhabited type
+  --> $DIR/uninhabited-static.rs:11:1
+   |
+LL | static VOID2: Void = unsafe { std::mem::transmute(()) };
+   | ^^^^^^^^^^^^^^^^^^
+   |
+   = note: uninhabited statics cannot be initialized, and any access would be an immediate error
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
+   = note: `#[deny(uninhabited_static)]` (part of `#[deny(future_incompatible)]`) on by default
+
+Future breakage diagnostic:
+error: static of uninhabited type
+  --> $DIR/uninhabited-static.rs:14:1
+   |
+LL | static NEVER2: Void = unsafe { std::mem::transmute(()) };
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: uninhabited statics cannot be initialized, and any access would be an immediate error
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
+   = note: `#[deny(uninhabited_static)]` (part of `#[deny(future_incompatible)]`) on by default
+
+Future breakage diagnostic:
+error: static of uninhabited type
+  --> $DIR/uninhabited-static.rs:5:5
+   |
+LL |     static VOID: Void;
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: uninhabited statics cannot be initialized, and any access would be an immediate error
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
+   = note: `#[deny(uninhabited_static)]` (part of `#[deny(future_incompatible)]`) on by default
+
+Future breakage diagnostic:
+error: static of uninhabited type
+  --> $DIR/uninhabited-static.rs:7:5
+   |
+LL |     static NEVER: !;
+   |     ^^^^^^^^^^^^^^^
+   |
+   = note: uninhabited statics cannot be initialized, and any access would be an immediate error
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
+   = note: `#[deny(uninhabited_static)]` (part of `#[deny(future_incompatible)]`) on by default
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/152853)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
The lint was introduced as a FCW in https://github.com/rust-lang/rust/pull/78324 and landed in rust 1.49.0 (5 years ago); see also https://github.com/rust-lang/rust/issues/74840.

Per the discussion in https://github.com/rust-lang/rust/pull/149518#issuecomment-3720302105.

cc @fmease @scottmcm @traviscross