### PR TITLE
Do not emit separator before elements for `Intersperse` on non-fused iterators

### DIFF
--- a/library/core/src/iter/adapters/intersperse.rs
+++ b/library/core/src/iter/adapters/intersperse.rs
@@ -57,8 +57,9 @@ where
                 }
             }
         } else {
-            self.started = true;
-            self.iter.next()
+            let item = self.iter.next();
+            self.started = item.is_some();
+            item
         }
     }
 
@@ -173,8 +174,9 @@ where
                 }
             }
         } else {
-            self.started = true;
-            self.iter.next()
+            let item = self.iter.next();
+            self.started = item.is_some();
+            item
         }
     }
 


### PR DESCRIPTION
This change is related to unstable feature `#![feature(iter_intersperse)]`
https://github.com/rust-lang/rust/issues/79524

What this does is changes behavior of `Intersperse` on non `Fused` iterators.
Particularly in case of iterator that returns `None` once from `next` method and then proceeds to yield elements normally.
Without this change the `Intersperse` will also return `None`, but then it will yield separator before first actual element from inner iterator.
This change fixes that, so even if underlying iterator starts with `None`s, `Intersperse` waits for one item to be returned before inserting separators.