### PR TITLE
`-Znext-solver` use the trait object's own bounds instead of goal when considering builtin object bounds

### DIFF
--- a/compiler/rustc_next_trait_solver/src/coherence.rs
+++ b/compiler/rustc_next_trait_solver/src/coherence.rs
@@ -425,7 +425,7 @@ where
                 }
             }
             ty::Dynamic(tt, ..) => {
-                let principal = tt.principal().map(|p| p.def_id());
+                let principal = tt.principal_def_id();
                 if principal.is_some_and(|p| self.def_id_is_local(p)) {
                     ControlFlow::Break(OrphanCheckEarlyExit::LocalTy(ty))
                 } else {

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -88,10 +88,26 @@ where
             let ty::Dynamic(bounds, _) = goal.predicate.self_ty().kind() else {
                 panic!("expected object type in `probe_and_consider_object_bound_candidate`");
             };
+
+            let trait_ref = assumption.kind().map_bound(|clause| match clause {
+                ty::ClauseKind::Trait(pred) => pred.trait_ref,
+                ty::ClauseKind::Projection(proj) => proj.projection_term.trait_ref(cx),
+
+                ty::ClauseKind::RegionOutlives(..)
+                | ty::ClauseKind::TypeOutlives(..)
+                | ty::ClauseKind::ConstArgHasType(..)
+                | ty::ClauseKind::WellFormed(..)
+                | ty::ClauseKind::ConstEvaluatable(..)
+                | ty::ClauseKind::HostEffect(..)
+                | ty::ClauseKind::UnstableFeature(..) => {
+                    unreachable!("expected trait or projection predicate as an assumption")
+                }
+            });
+
             match structural_traits::predicates_for_object_candidate(
                 ecx,
                 goal.param_env,
-                goal.predicate.trait_ref(cx),
+                trait_ref,
                 bounds,
             ) {
                 Ok(requirements) => {

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
@@ -8,7 +8,7 @@ use rustc_type_ir::lang_items::{SolverLangItem, SolverTraitLangItem};
 use rustc_type_ir::solve::SizedTraitKind;
 use rustc_type_ir::solve::inspect::ProbeKind;
 use rustc_type_ir::{
-    self as ty, FallibleTypeFolder, Interner, Movability, Mutability, TypeFoldable,
+    self as ty, Binder, FallibleTypeFolder, Interner, Movability, Mutability, TypeFoldable,
     TypeSuperFoldable, Upcast as _, elaborate,
 };
 use rustc_type_ir_macros::{TypeFoldable_Generic, TypeVisitable_Generic};
@@ -856,7 +856,7 @@ pub(in crate::solve) fn const_conditions_for_destruct<I: Interner>(
 pub(in crate::solve) fn predicates_for_object_candidate<D, I>(
     ecx: &mut EvalCtxt<'_, D>,
     param_env: I::ParamEnv,
-    trait_ref: ty::TraitRef<I>,
+    trait_ref: Binder<I, ty::TraitRef<I>>,
     object_bounds: I::BoundExistentialPredicates,
 ) -> Result<Vec<Goal<I, I::Predicate>>, Ambiguous>
 where
@@ -864,6 +864,7 @@ where
     I: Interner,
 {
     let cx = ecx.cx();
+    let trait_ref = ecx.instantiate_binder_with_infer(trait_ref);
     let mut requirements = vec![];
     // Elaborating all supertrait outlives obligations here is not soundness critical,
     // since if we just used the unelaborated set, then the transitive supertraits would
@@ -942,7 +943,7 @@ where
             && self
                 .ecx
                 .probe(|_| ProbeKind::ProjectionCompatibility)
-                .enter(|ecx| -> Result<_, NoSolution> {
+                .enter_without_propagated_nested_goals(|ecx| -> Result<_, NoSolution> {
                     let source_projection = ecx.instantiate_binder_with_infer(source_projection);
                     ecx.eq(self.param_env, source_projection.projection_term, target_projection)?;
                     ecx.try_evaluate_added_goals()

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/probe.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/probe.rs
@@ -7,7 +7,8 @@ use tracing::instrument;
 use crate::delegate::SolverDelegate;
 use crate::solve::assembly::Candidate;
 use crate::solve::{
-    BuiltinImplSource, CandidateSource, EvalCtxt, NoSolution, QueryResult, inspect,
+    BuiltinImplSource, CandidateSource, EvalCtxt, Goal, GoalSource, GoalStalledOn, NoSolution,
+    QueryResult, inspect,
 };
 
 pub(in crate::solve) struct ProbeCtxt<'me, 'a, D, I, F, T>
@@ -41,6 +42,22 @@ where
     }
 
     pub(in crate::solve) fn enter(self, f: impl FnOnce(&mut EvalCtxt<'_, D>) -> T) -> T {
+        let nested_goals = self.ecx.nested_goals.clone();
+        self.enter_inner(f, nested_goals)
+    }
+
+    pub(in crate::solve) fn enter_without_propagated_nested_goals(
+        self,
+        f: impl FnOnce(&mut EvalCtxt<'_, D>) -> T,
+    ) -> T {
+        self.enter_inner(f, Default::default())
+    }
+
+    fn enter_inner(
+        self,
+        f: impl FnOnce(&mut EvalCtxt<'_, D>) -> T,
+        propagated_nested_goals: Vec<(GoalSource, Goal<I, I::Predicate>, Option<GoalStalledOn<I>>)>,
+    ) -> T {
         let ProbeCtxt { ecx: outer, probe_kind, _result } = self;
 
         let delegate = outer.delegate;
@@ -54,7 +71,7 @@ where
             initial_opaque_types_storage_num_entries: outer
                 .initial_opaque_types_storage_num_entries,
             search_graph: outer.search_graph,
-            nested_goals: outer.nested_goals.clone(),
+            nested_goals: propagated_nested_goals,
             origin_span: outer.origin_span,
             tainted: outer.tainted,
             inspect: outer.inspect.take_and_enter_probe(),

--- a/tests/ui/traits/next-solver/object-projection-with-param-env-bound-1.rs
+++ b/tests/ui/traits/next-solver/object-projection-with-param-env-bound-1.rs
@@ -1,0 +1,24 @@
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@ check-pass
+
+// A regression test for https://github.com/rust-lang/rust/issues/152789.
+// Ensures we do not trigger an ICE or compilation error when normalizing
+// a projection on a trait object, where the matching trait predicate
+// (with the same trait id as the object bound) originates from another
+// source such as the param env, rather than from the object's own bounds.
+
+pub trait Trait<T> {
+    type Assoc;
+}
+
+pub trait Foo {
+    type FooAssoc;
+}
+
+pub struct Wrap<U: Foo>(<dyn Trait<i32, Assoc = i64> as Trait<U::FooAssoc>>::Assoc)
+where
+    dyn Trait<i32, Assoc = i64>: Trait<U::FooAssoc>;
+
+fn main() {}

--- a/tests/ui/traits/next-solver/object-projection-with-param-env-bound-2.rs
+++ b/tests/ui/traits/next-solver/object-projection-with-param-env-bound-2.rs
@@ -1,0 +1,35 @@
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@ check-pass
+
+// A regression test for https://github.com/rust-lang/rust/issues/152789.
+// Ensures we do not trigger an ICE or compilation error when normalizing
+// a projection on a trait object, where the matching trait predicate
+// (with the same trait id as the object bound) originates from another
+// source such as the param env, rather than from the object's own bounds.
+
+pub trait Trait<T> {
+    type Assoc;
+}
+
+pub trait Trait2<T> {
+    type Assoc2;
+}
+
+impl<T, U: ?Sized> Trait<T> for U
+where
+    U: Trait2<T>,
+{
+    type Assoc = <U as Trait2<T>>::Assoc2;
+}
+
+pub trait Foo {
+    type FooAssoc;
+}
+
+pub struct Wrap<U: Foo>(<dyn Trait<i32, Assoc = i64> as Trait<U::FooAssoc>>::Assoc)
+where
+    dyn Trait<i32, Assoc = i64>: Trait2<U::FooAssoc>;
+
+fn main() {}

--- a/tests/ui/traits/next-solver/object-projection-with-unsatisfied-bound-1.current.stderr
+++ b/tests/ui/traits/next-solver/object-projection-with-unsatisfied-bound-1.current.stderr
@@ -1,0 +1,14 @@
+error[E0277]: the trait bound `(dyn Trait<i32, Assoc = i64> + 'static): Trait<<U as Foo>::FooAssoc>` is not satisfied
+  --> $DIR/object-projection-with-unsatisfied-bound-1.rs:18:25
+   |
+LL | pub struct Wrap<U: Foo>(<dyn Trait<i32, Assoc = i64> as Trait<U::FooAssoc>>::Assoc);
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait<<U as Foo>::FooAssoc>` is not implemented for `(dyn Trait<i32, Assoc = i64> + 'static)`
+   |
+help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
+   |
+LL | pub struct Wrap<U: Foo>(<dyn Trait<i32, Assoc = i64> as Trait<U::FooAssoc>>::Assoc) where (dyn Trait<i32, Assoc = i64> + 'static): Trait<<U as Foo>::FooAssoc>;
+   |                                                                                     ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/next-solver/object-projection-with-unsatisfied-bound-1.next.stderr
+++ b/tests/ui/traits/next-solver/object-projection-with-unsatisfied-bound-1.next.stderr
@@ -1,0 +1,14 @@
+error[E0277]: the trait bound `(dyn Trait<i32, Assoc = i64> + 'static): Trait<<U as Foo>::FooAssoc>` is not satisfied
+  --> $DIR/object-projection-with-unsatisfied-bound-1.rs:18:25
+   |
+LL | pub struct Wrap<U: Foo>(<dyn Trait<i32, Assoc = i64> as Trait<U::FooAssoc>>::Assoc);
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait<<U as Foo>::FooAssoc>` is not implemented for `(dyn Trait<i32, Assoc = i64> + 'static)`
+   |
+help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
+   |
+LL | pub struct Wrap<U: Foo>(<dyn Trait<i32, Assoc = i64> as Trait<U::FooAssoc>>::Assoc) where (dyn Trait<i32, Assoc = i64> + 'static): Trait<<U as Foo>::FooAssoc>;
+   |                                                                                     ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/next-solver/object-projection-with-unsatisfied-bound-1.rs
+++ b/tests/ui/traits/next-solver/object-projection-with-unsatisfied-bound-1.rs
@@ -1,0 +1,21 @@
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+
+// A regression test for https://github.com/rust-lang/rust/issues/152789.
+// Ensures we do not trigger an ICE when normalization fails for a
+// projection on a trait object, even if the projection has the same
+// trait id as the object's bound.
+
+pub trait Trait<T> {
+    type Assoc;
+}
+
+pub trait Foo {
+    type FooAssoc;
+}
+
+pub struct Wrap<U: Foo>(<dyn Trait<i32, Assoc = i64> as Trait<U::FooAssoc>>::Assoc);
+//~^ ERROR: the trait bound `(dyn Trait<i32, Assoc = i64> + 'static): Trait<<U as Foo>::FooAssoc>` is not satisfied
+
+fn main() {}

--- a/tests/ui/traits/next-solver/object-projection-with-unsatisfied-bound-2.current.stderr
+++ b/tests/ui/traits/next-solver/object-projection-with-unsatisfied-bound-2.current.stderr
@@ -1,0 +1,58 @@
+error[E0277]: the trait bound `(dyn Callback<T> + 'static): Foo` is not satisfied
+  --> $DIR/object-projection-with-unsatisfied-bound-2.rs:20:14
+   |
+LL | impl<T: Foo> Bar<dyn Callback<T>> {
+   |              ^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `(dyn Callback<T> + 'static)`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/object-projection-with-unsatisfied-bound-2.rs:10:1
+   |
+LL | trait Foo {
+   | ^^^^^^^^^
+note: required by a bound in `Bar`
+  --> $DIR/object-projection-with-unsatisfied-bound-2.rs:16:15
+   |
+LL | struct Bar<T: Foo + ?Sized> {
+   |               ^^^ required by this bound in `Bar`
+
+error[E0277]: the trait bound `(dyn Callback<T> + 'static): Foo` is not satisfied
+  --> $DIR/object-projection-with-unsatisfied-bound-2.rs:22:14
+   |
+LL |     fn event(&self) {
+   |              ^^^^^ the trait `Foo` is not implemented for `(dyn Callback<T> + 'static)`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/object-projection-with-unsatisfied-bound-2.rs:10:1
+   |
+LL | trait Foo {
+   | ^^^^^^^^^
+note: required by a bound in `Bar`
+  --> $DIR/object-projection-with-unsatisfied-bound-2.rs:16:15
+   |
+LL | struct Bar<T: Foo + ?Sized> {
+   |               ^^^ required by this bound in `Bar`
+
+error[E0277]: the trait bound `(dyn Callback<T> + 'static): Foo` is not satisfied
+  --> $DIR/object-projection-with-unsatisfied-bound-2.rs:24:9
+   |
+LL |         (self.callback)(any(), any());
+   |         ^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `(dyn Callback<T> + 'static)`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/object-projection-with-unsatisfied-bound-2.rs:10:1
+   |
+LL | trait Foo {
+   | ^^^^^^^^^
+
+error[E0618]: expected function, found `Box<(dyn Callback<(dyn Callback<T> + 'static), Output = ()> + 'static)>`
+  --> $DIR/object-projection-with-unsatisfied-bound-2.rs:24:9
+   |
+LL |         (self.callback)(any(), any());
+   |         ^^^^^^^^^^^^^^^--------------
+   |         |
+   |         call expression requires function
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0277, E0618.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/traits/next-solver/object-projection-with-unsatisfied-bound-2.next.stderr
+++ b/tests/ui/traits/next-solver/object-projection-with-unsatisfied-bound-2.next.stderr
@@ -1,0 +1,58 @@
+error[E0277]: the trait bound `(dyn Callback<T> + 'static): Foo` is not satisfied
+  --> $DIR/object-projection-with-unsatisfied-bound-2.rs:20:14
+   |
+LL | impl<T: Foo> Bar<dyn Callback<T>> {
+   |              ^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `(dyn Callback<T> + 'static)`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/object-projection-with-unsatisfied-bound-2.rs:10:1
+   |
+LL | trait Foo {
+   | ^^^^^^^^^
+note: required by a bound in `Bar`
+  --> $DIR/object-projection-with-unsatisfied-bound-2.rs:16:15
+   |
+LL | struct Bar<T: Foo + ?Sized> {
+   |               ^^^ required by this bound in `Bar`
+
+error[E0277]: the trait bound `(dyn Callback<T> + 'static): Foo` is not satisfied
+  --> $DIR/object-projection-with-unsatisfied-bound-2.rs:22:14
+   |
+LL |     fn event(&self) {
+   |              ^^^^^ the trait `Foo` is not implemented for `(dyn Callback<T> + 'static)`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/object-projection-with-unsatisfied-bound-2.rs:10:1
+   |
+LL | trait Foo {
+   | ^^^^^^^^^
+note: required by a bound in `Bar`
+  --> $DIR/object-projection-with-unsatisfied-bound-2.rs:16:15
+   |
+LL | struct Bar<T: Foo + ?Sized> {
+   |               ^^^ required by this bound in `Bar`
+
+error[E0618]: expected function, found `Box<(dyn Callback<(dyn Callback<T> + 'static)> + 'static)>`
+  --> $DIR/object-projection-with-unsatisfied-bound-2.rs:24:9
+   |
+LL |         (self.callback)(any(), any());
+   |         ^^^^^^^^^^^^^^^--------------
+   |         |
+   |         call expression requires function
+
+error[E0277]: the trait bound `(dyn Callback<T> + 'static): Foo` is not satisfied
+  --> $DIR/object-projection-with-unsatisfied-bound-2.rs:24:9
+   |
+LL |         (self.callback)(any(), any());
+   |         ^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `(dyn Callback<T> + 'static)`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/object-projection-with-unsatisfied-bound-2.rs:10:1
+   |
+LL | trait Foo {
+   | ^^^^^^^^^
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0277, E0618.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/traits/next-solver/object-projection-with-unsatisfied-bound-2.rs
+++ b/tests/ui/traits/next-solver/object-projection-with-unsatisfied-bound-2.rs
@@ -1,0 +1,32 @@
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+
+// A regression test for https://github.com/rust-lang/rust/issues/151329.
+// Ensures we do not trigger an ICE when normalization fails for a
+// projection on a trait object, even if the projection has the same
+// trait id as the object's bound.
+
+trait Foo {
+    type V;
+}
+
+trait Callback<T: Foo>: Fn(&T, &T::V) {}
+
+struct Bar<T: Foo + ?Sized> {
+    callback: Box<dyn Callback<T>>,
+}
+
+impl<T: Foo> Bar<dyn Callback<T>> {
+    //~^ ERROR: the trait bound `(dyn Callback<T> + 'static): Foo` is not satisfied
+    fn event(&self) {
+        //~^ ERROR: the trait bound `(dyn Callback<T> + 'static): Foo` is not satisfied
+        (self.callback)(any(), any());
+        //~^ ERROR: the trait bound `(dyn Callback<T> + 'static): Foo` is not satisfied
+        //~| ERROR: expected function
+    }
+}
+
+fn any() {}
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/152859)*
<!-- homu-ignore:end -->

Fixes https://github.com/rust-lang/rust/issues/152789 and fixes https://github.com/rust-lang/rust/issues/151329

r? lcnr