### PR TITLE
resolve: do not suggest `_` for unresolved imports

### DIFF
--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -1282,6 +1282,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                 if i.name == ident.name {
                                     return None;
                                 } // Never suggest the same name
+                                if i.name == kw::Underscore {
+                                    return None;
+                                } // `use _` is never valid
 
                                 let resolution = resolution.borrow();
                                 if let Some(name_binding) = resolution.best_decl() {

--- a/tests/ui/resolve/underscore-bindings-disambiguators.stderr
+++ b/tests/ui/resolve/underscore-bindings-disambiguators.stderr
@@ -3,24 +3,12 @@ error[E0432]: unresolved import `X`
    |
 LL | use X as Y;
    |     ^^^^^^ no `X` in the root
-   |
-help: a similar name exists in the module
-   |
-LL - use X as Y;
-LL + use _ as Y;
-   |
 
 error[E0432]: unresolved import `Z`
   --> $DIR/underscore-bindings-disambiguators.rs:26:5
    |
 LL | use Z as W;
    |     ^^^^^^ no `Z` in the root
-   |
-help: a similar name exists in the module
-   |
-LL - use Z as W;
-LL + use _ as W;
-   |
 
 error[E0080]: evaluation panicked: not yet implemented
   --> $DIR/underscore-bindings-disambiguators.rs:19:19


### PR DESCRIPTION
Fix invalid unresolved-import suggestion when a module contains an item named `_`.

`use _` is never valid syntax, so `_` should not be suggested as a similar name.

Closes rust-lang/rust#152812
