### PR TITLE
perf(codegen): Restore `noundef` On `PassMode::Cast` Args In Rust ABI

### DIFF
--- a/compiler/rustc_ty_utils/src/abi.rs
+++ b/compiler/rustc_ty_utils/src/abi.rs
@@ -627,6 +627,7 @@ fn fn_abi_adjust_for_abi<'tcx>(
 
     if abi.is_rustic_abi() {
         fn_abi.adjust_for_rust_abi(cx);
+
         // Look up the deduced parameter attributes for this function, if we have its def ID and
         // we're optimizing in non-incremental mode. We'll tag its parameters with those attributes
         // as appropriate.

--- a/tests/codegen-llvm/abi-noundef-cast.rs
+++ b/tests/codegen-llvm/abi-noundef-cast.rs
@@ -1,0 +1,206 @@
+// Verify that `PassMode::Cast` arguments/returns in the Rust ABI carry `noundef`
+// when the original layout provably contains no uninit bytes, and correctly omit
+// it when uninit bytes or padding may be present.
+//
+// See <https://github.com/rust-lang/rust/issues/123183>.
+
+//@ compile-flags: -Copt-level=3 -C no-prepopulate-passes
+//@ only-64bit
+
+#![crate_type = "lib"]
+
+use std::mem::MaybeUninit;
+
+// CHECK-LABEL: @arg_array_u32x2(
+// CHECK-SAME: i64 noundef
+#[no_mangle]
+pub fn arg_array_u32x2(v: [u32; 2]) -> u32 {
+    v[0]
+}
+
+// CHECK-LABEL: @arg_array_u8x4(
+// CHECK-SAME: i32 noundef
+#[no_mangle]
+pub fn arg_array_u8x4(v: [u8; 4]) -> u8 {
+    v[0]
+}
+
+// CHECK-LABEL: @arg_nested_array(
+// CHECK-SAME: i64 noundef
+#[no_mangle]
+pub fn arg_nested_array(v: [[u8; 2]; 4]) -> u8 {
+    v[0][0]
+}
+
+// CHECK-LABEL: @arg_array_bool(
+// CHECK-SAME: i64 noundef
+#[no_mangle]
+pub fn arg_array_bool(v: [bool; 8]) -> bool {
+    v[0]
+}
+
+struct FourU8 {
+    a: u8,
+    b: u8,
+    c: u8,
+    d: u8,
+}
+
+// CHECK-LABEL: @arg_four_u8(
+// CHECK-SAME: i32 noundef
+#[no_mangle]
+pub fn arg_four_u8(v: FourU8) -> u8 {
+    v.a
+}
+
+struct Wrapper([u32; 2]);
+
+// CHECK-LABEL: @arg_newtype_wrapper(
+// CHECK-SAME: i64 noundef
+#[no_mangle]
+pub fn arg_newtype_wrapper(v: Wrapper) -> u32 {
+    (v.0)[0]
+}
+
+enum SingleVariant {
+    Only([u32; 2]),
+}
+
+// CHECK-LABEL: @arg_single_variant_enum(
+// CHECK-SAME: i64 noundef
+#[no_mangle]
+pub fn arg_single_variant_enum(v: SingleVariant) -> u32 {
+    match v {
+        SingleVariant::Only(a) => a[0],
+    }
+}
+
+struct ContainsScalarPair {
+    a: (u16, u16),
+    b: u32,
+}
+
+// CHECK-LABEL: @arg_contains_scalar_pair(
+// CHECK-SAME: i64 noundef
+#[no_mangle]
+pub fn arg_contains_scalar_pair(v: ContainsScalarPair) -> u32 {
+    v.b
+}
+
+// CHECK: define noundef i64 @ret_array_u32x2(
+#[no_mangle]
+pub fn ret_array_u32x2(x: u32, y: u32) -> [u32; 2] {
+    [x, y]
+}
+
+// CHECK-LABEL: @arg_maybeuninit_u8x8(
+// CHECK-SAME: i64 %
+#[no_mangle]
+pub fn arg_maybeuninit_u8x8(v: [MaybeUninit<u8>; 8]) -> MaybeUninit<u8> {
+    v[0]
+}
+
+enum MultiVariant {
+    A(u8),
+    B(u16),
+    C,
+}
+
+// CHECK-LABEL: @arg_multi_variant_enum(
+// CHECK-SAME: i32 %
+#[no_mangle]
+pub fn arg_multi_variant_enum(v: MultiVariant) -> u8 {
+    match v {
+        MultiVariant::A(x) => x,
+        MultiVariant::B(_) | MultiVariant::C => 0,
+    }
+}
+
+#[repr(C)]
+struct HasFieldGap {
+    a: u8,
+    b: u16,
+    c: u8,
+}
+
+// CHECK-LABEL: @arg_struct_field_gap(
+// CHECK-SAME: i48 %
+#[no_mangle]
+pub fn arg_struct_field_gap(v: HasFieldGap) -> u8 {
+    v.a
+}
+
+#[repr(C)]
+struct HasPaddedPairField {
+    a: (u8, u16),
+    b: u8,
+}
+
+// CHECK-LABEL: @arg_struct_padded_pair_field(
+// CHECK-SAME: i48 %
+#[no_mangle]
+pub fn arg_struct_padded_pair_field(v: HasPaddedPairField) -> u8 {
+    v.b
+}
+
+#[repr(C)]
+struct HasUndefPairField {
+    a: (MaybeUninit<u16>, u16),
+    b: u32,
+}
+
+// CHECK-LABEL: @arg_struct_undef_pair_field(
+// CHECK-SAME: i64 %
+#[no_mangle]
+pub fn arg_struct_undef_pair_field(v: HasUndefPairField) -> u32 {
+    v.b
+}
+
+// CHECK-LABEL: @arg_triple_maybeuninit_u8(
+// CHECK-SAME: i24 %
+#[no_mangle]
+pub fn arg_triple_maybeuninit_u8(
+    v: (MaybeUninit<u8>, MaybeUninit<u8>, MaybeUninit<u8>),
+) -> MaybeUninit<u8> {
+    v.0
+}
+
+#[repr(C)]
+struct HasTrailingPadding {
+    x: u32,
+    y: u16,
+    z: u8,
+}
+
+// CHECK-LABEL: @arg_struct_trailing_pad(
+// CHECK-SAME: i64 %
+#[no_mangle]
+pub fn arg_struct_trailing_pad(v: HasTrailingPadding) -> u32 {
+    v.x
+}
+
+// CHECK-LABEL: @arg_tuple_i8_i16(
+// CHECK-SAME: i8 noundef
+// CHECK-SAME: i16 noundef
+#[no_mangle]
+pub fn arg_tuple_i8_i16(v: (i8, i16)) -> i8 {
+    v.0
+}
+
+// CHECK-LABEL: @arg_tuple_i16_maybeuninit(
+// CHECK-SAME: i16 noundef
+// CHECK-SAME: i16 %
+#[no_mangle]
+pub fn arg_tuple_i16_maybeuninit(v: (i16, MaybeUninit<i16>)) -> i16 {
+    v.0
+}
+
+// CHECK-LABEL: @arg_result_i32(
+// CHECK-SAME: i32 noundef
+// CHECK-SAME: i32 noundef
+#[no_mangle]
+pub fn arg_result_i32(v: Result<i32, i32>) -> i32 {
+    match v {
+        Ok(x) | Err(x) => x,
+    }
+}

--- a/tests/codegen-llvm/debuginfo-dse.rs
+++ b/tests/codegen-llvm/debuginfo-dse.rs
@@ -148,7 +148,7 @@ fn direct(
 // Arguments are passed through registers, the final values are poison.
 #[unsafe(no_mangle)]
 fn cast(aggregate_4xi8: Aggregate_4xi8) {
-    // CHECK-LABEL: define{{( dso_local)?}} void @cast(i32 %0)
+    // CHECK-LABEL: define{{( dso_local)?}} void @cast(i32 noundef %0)
     // CHECK: call void @opaque_fn()
     opaque_fn();
     // The temporary allocated variable is eliminated.

--- a/tests/ui/abi/pass-indirectly-attr.stderr
+++ b/tests/ui/abi/pass-indirectly-attr.stderr
@@ -143,7 +143,7 @@ error: fn_abi_of(extern_rust) = FnAbi {
                                is_consecutive: false,
                            },
                            attrs: ArgAttributes {
-                               regular: ,
+                               regular: NoUndef,
                                arg_ext: None,
                                pointee_size: Size(0 bytes),
                                pointee_align: None,


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/152864)*
<!-- homu-ignore:end -->

### Summary:

#### Problem:

Small aggregate arguments passed via `PassMode::Cast` in the Rust ABI (e.g. `[u32; 2]` cast to `i64`) are missing `noundef` in the emitted LLVM IR, even when the type contains no uninit bytes:

```rust
#[no_mangle]
pub fn f(v: [u32; 2]) -> u32 { v[0] }
```

```llvm
; expected: define i32 @f(i64 noundef %0)
; actual:   define i32 @f(i64 %0)           ← noundef missing
```

This blocks LLVM from applying optimizations that require value-defined semantics on function arguments.

#### Root Cause:

`adjust_for_rust_abi` calls `arg.cast_to(Reg::Integer)`, which internally creates a `CastTarget` with `ArgAttributes::new()` — always empty. Any validity attribute that was present before the cast is silently dropped.

This affects all `PassMode::Cast` arguments and return values in the Rust ABI: plain arrays, newtype wrappers, and any `BackendRepr::Memory` type small enough to fit in a register.

A prior attempt (rust-lang/rust#127210) used `Ty`/`repr` attributes to detect padding.

#### Solution:

After `adjust_for_rust_abi`, iterate all `PassMode::Cast` args and the return value. For each, call `layout_is_noundef` on the original layout; if it returns `true`, set `NoUndef` on the `CastTarget`'s `attrs`.

`layout_is_noundef` uses only the computed layout — `BackendRepr`, `FieldsShape`, `Variants`, `Scalar::is_uninit_valid()` — and never touches `Ty` or repr attributes. **Anything it cannot prove returns `false`.**

Covered cases:
- `Scalar` / `ScalarPair` (both halves initialized, fields contiguous)
- `FieldsShape::Array` (element type recursively uninit-free)
- `FieldsShape::Arbitrary` with `Variants::Single` (fields cover `0..size` with no gaps, each recursively uninit-free) — handles newtype wrappers, multi-field structs, single-variant enums, `repr(transparent)`, `repr(C)` wrappers

Conservatively excluded with FIXMEs:
- Multi-variant enums (per-variant padding analysis needed)
- Foreign-ABI casts (cast target may exceed layout size, needs a size guard)

### Changes:

- `compiler/rustc_ty_utils/src/abi.rs`: add restoration loop after `adjust_for_rust_abi`; add `layout_is_noundef` and `fields_cover_layout`.
- `tests/codegen-llvm/abi-noundef-cast.rs`: new FileCheck test covering arrays, newtype wrappers (`repr(Rust)`, `repr(transparent)`, `repr(C)`), multi-field structs, single-variant enums, return values, and negative cases (`MaybeUninit`, struct with trailing padding).
- `tests/codegen-llvm/debuginfo-dse.rs`: update one CHECK pattern — `Aggregate_4xi8` (`struct { i8, i8, i8, i8 }`) now correctly gets `noundef`.

Fixes rust-lang/rust#123183.

r? @RalfJung