### PR TITLE
Fixed ByteStr not padding within its Display trait when no specific alignment is mentioned

### DIFF
--- a/library/core/src/bstr/mod.rs
+++ b/library/core/src/bstr/mod.rs
@@ -174,39 +174,38 @@ impl fmt::Debug for ByteStr {
 #[unstable(feature = "bstr", issue = "134915")]
 impl fmt::Display for ByteStr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fn fmt_nopad(this: &ByteStr, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            for chunk in this.utf8_chunks() {
-                f.write_str(chunk.valid())?;
-                if !chunk.invalid().is_empty() {
-                    f.write_str("\u{FFFD}")?;
-                }
-            }
-            Ok(())
-        }
-
-        let Some(align) = f.align() else {
-            return fmt_nopad(self, f);
-        };
         let nchars: usize = self
             .utf8_chunks()
             .map(|chunk| {
                 chunk.valid().chars().count() + if chunk.invalid().is_empty() { 0 } else { 1 }
             })
             .sum();
+
         let padding = f.width().unwrap_or(0).saturating_sub(nchars);
         let fill = f.fill();
-        let (lpad, rpad) = match align {
-            fmt::Alignment::Left => (0, padding),
-            fmt::Alignment::Right => (padding, 0),
-            fmt::Alignment::Center => {
+
+        let (lpad, rpad) = match f.align() {
+            Some(fmt::Alignment::Right) => (padding, 0),
+            Some(fmt::Alignment::Center) => {
                 let half = padding / 2;
                 (half, half + padding % 2)
             }
+            // Either alignment is not specified or it's left aligned
+            // which behaves the same with padding
+            _ => (0, padding),
         };
+
         for _ in 0..lpad {
             write!(f, "{fill}")?;
         }
-        fmt_nopad(self, f)?;
+
+        for chunk in self.utf8_chunks() {
+            f.write_str(chunk.valid())?;
+            if !chunk.invalid().is_empty() {
+                f.write_str("\u{FFFD}")?;
+            }
+        }
+
         for _ in 0..rpad {
             write!(f, "{fill}")?;
         }

--- a/library/std/tests/path.rs
+++ b/library/std/tests/path.rs
@@ -2292,6 +2292,26 @@ fn display_format_flags() {
 }
 
 #[test]
+fn display_path_with_padding_no_align() {
+    assert_eq!(format!("{:10}", Path::new("/foo/bar").display()), "/foo/bar  ");
+}
+
+#[test]
+fn display_path_with_padding_align_left() {
+    assert_eq!(format!("{:<10}", Path::new("/foo/bar").display()), "/foo/bar  ");
+}
+
+#[test]
+fn display_path_with_padding_align_right() {
+    assert_eq!(format!("{:>10}", Path::new("/foo/bar").display()), "  /foo/bar");
+}
+
+#[test]
+fn display_path_with_padding_align_center() {
+    assert_eq!(format!("{:^10}", Path::new("/foo/bar").display()), " /foo/bar ");
+}
+
+#[test]
 fn into_rc() {
     let orig = "hello/world";
     let path = Path::new(orig);


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#152804. `Path`'s `Display` uses `ByteStr`'s `Display`, which is where the problem was occurring.

The issue was coming from `ByteStr` implementation of `fmt()` in this particular area:
```rust
        let Some(align) = f.align() else {
            return fmt_nopad(self, f);
        };
        let nchars: usize = self
            .utf8_chunks()
            .map(|chunk| {
                chunk.valid().chars().count() + if chunk.invalid().is_empty() { 0 } else { 1 }
            })
            .sum();
        let padding = f.width().unwrap_or(0).saturating_sub(nchars);
        let fill = f.fill();
        let (lpad, rpad) = match align {
            fmt::Alignment::Left => (0, padding),
            fmt::Alignment::Right => (padding, 0),
            fmt::Alignment::Center => {
                let half = padding / 2;
                (half, half + padding % 2)
            }
        };
```

The docs for the align implies that `Alignment::Left`, `Alignment::Right`, `Alignment::Center` comes from `:<`, `:>`, and `:^` respectively with `align()` returning `None` if neither of those symbols are used in the formatted string. However, while padding is taken care of in the aligned cases, we could still have padding for things that don't use alignment like:
```rust
assert_eq!(format!("{:10}", Path::new("/foo/bar").display()), "/foo/bar  ");
```
We shouldn't write to `f` and return from there when there's no alignment; we should also include any potential padding/filling bytes here.

r? @joboet 
