### PR TITLE
Do not enable split debuginfo for windows-gnu

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -1008,9 +1008,10 @@
 # its historical default, but when compiling the compiler itself, we skip it by
 # default since we know it's safe to do so in that case.
 #
-# On Windows platforms, packed debuginfo is the only supported option,
-# producing a `.pdb` file.
-#split-debuginfo = if linux { off } else if windows { packed } else if apple { unpacked }
+# On Windows MSVC platforms, packed debuginfo is the only supported option,
+# producing a `.pdb` file. On Windows GNU rustc doesn't support splitting debuginfo,
+# and enabling it causes issues.
+#split-debuginfo = if linux || windows-gnu { off } else if windows-msvc { packed } else if apple { unpacked }
 
 # Path to the `llvm-config` binary of the installation of a custom LLVM to link
 # against. Note that if this is specified we don't compile LLVM at all for this

--- a/src/bootstrap/src/core/config/target_selection.rs
+++ b/src/bootstrap/src/core/config/target_selection.rs
@@ -142,7 +142,7 @@ impl SplitDebuginfo {
     pub fn default_for_platform(target: TargetSelection) -> Self {
         if target.contains("apple") {
             SplitDebuginfo::Unpacked
-        } else if target.is_windows() {
+        } else if target.is_msvc() {
             SplitDebuginfo::Packed
         } else {
             SplitDebuginfo::Off


### PR DESCRIPTION
Because rustc doesn't handle split debuginfo for these targets, enabling that option causes them to be missing some of the debuginfo.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
