### PR TITLE
std::ops::ControlFlow - use "a" before `Result`

### DIFF
--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -197,7 +197,7 @@ impl<B, C> ControlFlow<B, C> {
         }
     }
 
-    /// Converts the `ControlFlow` into an `Result` which is `Ok` if the
+    /// Converts the `ControlFlow` into a `Result` which is `Ok` if the
     /// `ControlFlow` was `Break` and `Err` if otherwise.
     ///
     /// # Examples
@@ -311,7 +311,7 @@ impl<B, C> ControlFlow<B, C> {
         }
     }
 
-    /// Converts the `ControlFlow` into an `Result` which is `Ok` if the
+    /// Converts the `ControlFlow` into a `Result` which is `Ok` if the
     /// `ControlFlow` was `Continue` and `Err` if otherwise.
     ///
     /// # Examples


### PR DESCRIPTION
Rather than "an"

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
