### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -1282,6 +1282,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                 if i.name == ident.name {
                                     return None;
                                 } // Never suggest the same name
+                                if i.name == kw::Underscore {
+                                    return None;
+                                } // `use _` is never valid
 
                                 let resolution = resolution.borrow();
                                 if let Some(name_binding) = resolution.best_decl() {

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1908,7 +1908,7 @@ pub const trait Iterator {
     /// without giving up ownership of the original iterator,
     /// so you can use the original iterator afterwards.
     ///
-    /// Uses [`impl<I: Iterator + ?Sized> Iterator for &mut I { type Item = I::Item; ...}`](https://doc.rust-lang.org/nightly/std/iter/trait.Iterator.html#impl-Iterator-for-%26mut+I).
+    /// Uses [`impl<I: Iterator + ?Sized> Iterator for &mut I { type Item = I::Item; ...}`](Iterator#impl-Iterator-for-%26mut+I).
     ///
     /// # Examples
     ///

--- a/library/core/src/mem/type_info.rs
+++ b/library/core/src/mem/type_info.rs
@@ -153,7 +153,7 @@ pub struct Trait {
     pub is_auto: bool,
 }
 
-/// Compile-time type information about arrays.
+/// Compile-time type information about structs.
 #[derive(Debug)]
 #[non_exhaustive]
 #[unstable(feature = "type_info", issue = "146922")]

--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -197,7 +197,7 @@ impl<B, C> ControlFlow<B, C> {
         }
     }
 
-    /// Converts the `ControlFlow` into an `Result` which is `Ok` if the
+    /// Converts the `ControlFlow` into a `Result` which is `Ok` if the
     /// `ControlFlow` was `Break` and `Err` if otherwise.
     ///
     /// # Examples
@@ -311,7 +311,7 @@ impl<B, C> ControlFlow<B, C> {
         }
     }
 
-    /// Converts the `ControlFlow` into an `Result` which is `Ok` if the
+    /// Converts the `ControlFlow` into a `Result` which is `Ok` if the
     /// `ControlFlow` was `Continue` and `Err` if otherwise.
     ///
     /// # Examples

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -547,9 +547,17 @@ impl Builder<'_> {
             assert_eq!(target, compiler.host);
         }
 
-        // Remove make-related flags to ensure Cargo can correctly set things up
-        cargo.env_remove("MAKEFLAGS");
-        cargo.env_remove("MFLAGS");
+        // Bootstrap only supports modern FIFO jobservers. Older pipe-based jobservers can run into
+        // "invalid file descriptor" errors, as the jobserver file descriptors are not inherited by
+        // scripts like bootstrap.py, while the environment variable is propagated. So, we pass
+        // MAKEFLAGS only if we detect a FIFO jobserver, otherwise we clear it.
+        let has_modern_jobserver = env::var("MAKEFLAGS")
+            .map(|flags| flags.contains("--jobserver-auth=fifo:"))
+            .unwrap_or(false);
+
+        if !has_modern_jobserver {
+            cargo.env_remove("MAKEFLAGS");
+        }
 
         cargo
     }

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -2855,18 +2855,167 @@ mod snapshot {
     }
 
     #[test]
+    fn install_plain() {
+        let ctx = TestCtx::new();
+        insta::assert_snapshot!(
+            ctx.config("install")
+                .args(&[
+                    // Using backslashes fails with `--set`
+                    "--set", &format!("install.prefix={}", ctx.normalized_dir()),
+                    "--set", &format!("install.bindir={}", ctx.normalized_dir()),
+                    "--set", &format!("install.libdir={}", ctx.normalized_dir()),
+                    "--set", &format!("install.datadir={}", ctx.normalized_dir()),
+                    "--set", &format!("install.mandir={}", ctx.normalized_dir()),
+                    "--set", &format!("install.sysconfdir={}", ctx.normalized_dir()),
+                    "--build", "x86_64-unknown-linux-gnu",
+                    "--host", "x86_64-unknown-linux-gnu",
+                    "--target", "x86_64-unknown-linux-gnu",
+                ])
+                .get_steps()
+                .render_with(RenderConfig {
+                    normalize_host: false
+                }), @r"
+        [build] llvm <x86_64-unknown-linux-gnu>
+        [build] rustc 0 <x86_64-unknown-linux-gnu> -> rustc 1 <x86_64-unknown-linux-gnu>
+        [build] rustc 0 <x86_64-unknown-linux-gnu> -> UnstableBookGen 1 <x86_64-unknown-linux-gnu>
+        [build] rustc 0 <x86_64-unknown-linux-gnu> -> Rustbook 1 <x86_64-unknown-linux-gnu>
+        [doc] unstable-book (book) <x86_64-unknown-linux-gnu>
+        [build] rustc 1 <x86_64-unknown-linux-gnu> -> std 1 <x86_64-unknown-linux-gnu>
+        [doc] book (book) <x86_64-unknown-linux-gnu>
+        [doc] book/first-edition (book) <x86_64-unknown-linux-gnu>
+        [doc] book/second-edition (book) <x86_64-unknown-linux-gnu>
+        [doc] book/2018-edition (book) <x86_64-unknown-linux-gnu>
+        [build] rustdoc 1 <x86_64-unknown-linux-gnu>
+        [doc] rustc 1 <x86_64-unknown-linux-gnu> -> standalone 2 <x86_64-unknown-linux-gnu>
+        [doc] rustc 1 <x86_64-unknown-linux-gnu> -> std 1 <x86_64-unknown-linux-gnu> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,rustc-std-workspace-core,std,std_detect,sysroot,test,unwind]
+        [build] rustc 1 <x86_64-unknown-linux-gnu> -> rustc 2 <x86_64-unknown-linux-gnu>
+        [build] rustc 1 <x86_64-unknown-linux-gnu> -> error-index 2 <x86_64-unknown-linux-gnu>
+        [doc] rustc 1 <x86_64-unknown-linux-gnu> -> error-index 2 <x86_64-unknown-linux-gnu>
+        [doc] nomicon (book) <x86_64-unknown-linux-gnu>
+        [doc] rustc 1 <x86_64-unknown-linux-gnu> -> reference (book) 2 <x86_64-unknown-linux-gnu>
+        [doc] rustdoc (book) <x86_64-unknown-linux-gnu>
+        [doc] rust-by-example (book) <x86_64-unknown-linux-gnu>
+        [build] rustc 0 <x86_64-unknown-linux-gnu> -> LintDocs 1 <x86_64-unknown-linux-gnu>
+        [doc] rustc (book) <x86_64-unknown-linux-gnu>
+        [doc] cargo (book) <x86_64-unknown-linux-gnu>
+        [doc] clippy (book) <x86_64-unknown-linux-gnu>
+        [doc] embedded-book (book) <x86_64-unknown-linux-gnu>
+        [doc] edition-guide (book) <x86_64-unknown-linux-gnu>
+        [doc] style-guide (book) <x86_64-unknown-linux-gnu>
+        [doc] rustc 1 <x86_64-unknown-linux-gnu> -> releases 2 <x86_64-unknown-linux-gnu>
+        [build] rustc 0 <x86_64-unknown-linux-gnu> -> RustInstaller 1 <x86_64-unknown-linux-gnu>
+        [dist] docs <x86_64-unknown-linux-gnu>
+        [dist] rustc 1 <x86_64-unknown-linux-gnu> -> std 1 <x86_64-unknown-linux-gnu>
+        [build] rustdoc 2 <x86_64-unknown-linux-gnu>
+        [build] rustc 0 <x86_64-unknown-linux-gnu> -> GenerateCopyright 1 <x86_64-unknown-linux-gnu>
+        [dist] rustc <x86_64-unknown-linux-gnu>
+        ");
+    }
+
+    #[test]
+    fn install_src() {
+        let ctx = TestCtx::new();
+        insta::assert_snapshot!(
+            ctx.config("install")
+                .path("src")
+                .args(&[
+                    // Using backslashes fails with `--set`
+                    "--set", &format!("install.prefix={}", ctx.normalized_dir()),
+                    "--set", &format!("install.bindir={}", ctx.normalized_dir()),
+                    "--set", &format!("install.libdir={}", ctx.normalized_dir()),
+                    "--set", &format!("install.datadir={}", ctx.normalized_dir()),
+                    "--set", &format!("install.mandir={}", ctx.normalized_dir()),
+                    "--set", &format!("install.sysconfdir={}", ctx.normalized_dir()),
+                    "--build", "x86_64-unknown-linux-gnu",
+                    "--host", "x86_64-unknown-linux-gnu",
+                    "--target", "x86_64-unknown-linux-gnu",
+                ])
+                .get_steps()
+                .render_with(RenderConfig {
+                    normalize_host: false
+                }), @r"
+        [build] llvm <x86_64-unknown-linux-gnu>
+        [build] rustc 0 <x86_64-unknown-linux-gnu> -> rustc 1 <x86_64-unknown-linux-gnu>
+        [build] rustc 0 <x86_64-unknown-linux-gnu> -> UnstableBookGen 1 <x86_64-unknown-linux-gnu>
+        [build] rustc 0 <x86_64-unknown-linux-gnu> -> Rustbook 1 <x86_64-unknown-linux-gnu>
+        [doc] unstable-book (book) <x86_64-unknown-linux-gnu>
+        [build] rustc 1 <x86_64-unknown-linux-gnu> -> std 1 <x86_64-unknown-linux-gnu>
+        [doc] book (book) <x86_64-unknown-linux-gnu>
+        [doc] book/first-edition (book) <x86_64-unknown-linux-gnu>
+        [doc] book/second-edition (book) <x86_64-unknown-linux-gnu>
+        [doc] book/2018-edition (book) <x86_64-unknown-linux-gnu>
+        [build] rustdoc 1 <x86_64-unknown-linux-gnu>
+        [doc] rustc 1 <x86_64-unknown-linux-gnu> -> standalone 2 <x86_64-unknown-linux-gnu>
+        [doc] rustc 1 <x86_64-unknown-linux-gnu> -> std 1 <x86_64-unknown-linux-gnu> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,rustc-std-workspace-core,std,std_detect,sysroot,test,unwind]
+        [build] rustc 1 <x86_64-unknown-linux-gnu> -> rustc 2 <x86_64-unknown-linux-gnu>
+        [build] rustc 1 <x86_64-unknown-linux-gnu> -> error-index 2 <x86_64-unknown-linux-gnu>
+        [doc] rustc 1 <x86_64-unknown-linux-gnu> -> error-index 2 <x86_64-unknown-linux-gnu>
+        [doc] nomicon (book) <x86_64-unknown-linux-gnu>
+        [doc] rustc 1 <x86_64-unknown-linux-gnu> -> reference (book) 2 <x86_64-unknown-linux-gnu>
+        [doc] rustdoc (book) <x86_64-unknown-linux-gnu>
+        [doc] rust-by-example (book) <x86_64-unknown-linux-gnu>
+        [build] rustc 0 <x86_64-unknown-linux-gnu> -> LintDocs 1 <x86_64-unknown-linux-gnu>
+        [doc] rustc (book) <x86_64-unknown-linux-gnu>
+        [doc] cargo (book) <x86_64-unknown-linux-gnu>
+        [doc] clippy (book) <x86_64-unknown-linux-gnu>
+        [doc] embedded-book (book) <x86_64-unknown-linux-gnu>
+        [doc] edition-guide (book) <x86_64-unknown-linux-gnu>
+        [doc] style-guide (book) <x86_64-unknown-linux-gnu>
+        [doc] rustc 1 <x86_64-unknown-linux-gnu> -> releases 2 <x86_64-unknown-linux-gnu>
+        [build] rustc 0 <x86_64-unknown-linux-gnu> -> RustInstaller 1 <x86_64-unknown-linux-gnu>
+        [dist] docs <x86_64-unknown-linux-gnu>
+        [dist] src <>
+        ");
+    }
+
+    #[test]
+    fn install_src_no_docs() {
+        let ctx = TestCtx::new();
+        insta::assert_snapshot!(
+            ctx.config("install")
+                .path("src")
+                .args(&[
+                    // Using backslashes fails with `--set`
+                    "--set", &format!("install.prefix={}", ctx.normalized_dir()),
+                    "--set", &format!("install.bindir={}", ctx.normalized_dir()),
+                    "--set", &format!("install.libdir={}", ctx.normalized_dir()),
+                    "--set", &format!("install.datadir={}", ctx.normalized_dir()),
+                    "--set", &format!("install.mandir={}", ctx.normalized_dir()),
+                    "--set", &format!("install.sysconfdir={}", ctx.normalized_dir()),
+                    "--set", "build.docs=false",
+                    "--build", "x86_64-unknown-linux-gnu",
+                    "--host", "x86_64-unknown-linux-gnu",
+                    "--target", "x86_64-unknown-linux-gnu",
+                ])
+                .get_steps()
+                .render_with(RenderConfig {
+                    normalize_host: false
+                }), @r"
+        [build] llvm <x86_64-unknown-linux-gnu>
+        [build] rustc 0 <x86_64-unknown-linux-gnu> -> rustc 1 <x86_64-unknown-linux-gnu>
+        [build] rustc 0 <x86_64-unknown-linux-gnu> -> RustInstaller 1 <x86_64-unknown-linux-gnu>
+        [dist] docs <x86_64-unknown-linux-gnu>
+        [dist] src <>
+        ");
+    }
+
+    #[test]
     fn install_extended() {
         let ctx = TestCtx::new();
         insta::assert_snapshot!(
             ctx.config("install")
                 .args(&[
                     // Using backslashes fails with `--set`
-                    "--set", &format!("install.prefix={}", ctx.dir().display()).replace("\\", "/"),
-                    "--set", &format!("install.sysconfdir={}", ctx.dir().display()).replace("\\", "/"),
+                    "--set", &format!("install.prefix={}", ctx.normalized_dir()),
+                    "--set", &format!("install.bindir={}", ctx.normalized_dir()),
+                    "--set", &format!("install.libdir={}", ctx.normalized_dir()),
+                    "--set", &format!("install.datadir={}", ctx.normalized_dir()),
+                    "--set", &format!("install.mandir={}", ctx.normalized_dir()),
+                    "--set", &format!("install.sysconfdir={}", ctx.normalized_dir()),
                     "--set", "build.extended=true",
                     // For Cranelift to be disted
                     "--build", "x86_64-unknown-linux-gnu",
-                    "--host", "x86_64-unknown-linux-gnu"
+                    "--host", "x86_64-unknown-linux-gnu",
                 ])
                 .get_steps()
                 .render_with(RenderConfig {

--- a/src/bootstrap/src/utils/tests/mod.rs
+++ b/src/bootstrap/src/utils/tests/mod.rs
@@ -35,6 +35,11 @@ impl TestCtx {
         self.directory.path()
     }
 
+    /// Using backslashes fails with `--set`
+    pub fn normalized_dir(&self) -> String {
+        self.dir().to_string_lossy().replace("\\", "/")
+    }
+
     /// Starts a new invocation of bootstrap that executes `kind` as its top level command
     /// (i.e. `x <kind>`). Returns a builder that configures the created config through CLI flags.
     pub fn config(&self, kind: &str) -> ConfigBuilder {

--- a/tests/ui/resolve/underscore-bindings-disambiguators.stderr
+++ b/tests/ui/resolve/underscore-bindings-disambiguators.stderr
@@ -3,24 +3,12 @@ error[E0432]: unresolved import `X`
    |
 LL | use X as Y;
    |     ^^^^^^ no `X` in the root
-   |
-help: a similar name exists in the module
-   |
-LL - use X as Y;
-LL + use _ as Y;
-   |
 
 error[E0432]: unresolved import `Z`
   --> $DIR/underscore-bindings-disambiguators.rs:26:5
    |
 LL | use Z as W;
    |     ^^^^^^ no `Z` in the root
-   |
-help: a similar name exists in the module
-   |
-LL - use Z as W;
-LL + use _ as W;
-   |
 
 error[E0080]: evaluation panicked: not yet implemented
   --> $DIR/underscore-bindings-disambiguators.rs:19:19


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#152057 (bootstrap: respect POSIX jobserver)
 - rust-lang/rust#152818 (DOC: do not link to "nightly" in Iterator::by_ref() docstring)
 - rust-lang/rust#152840 (Add bootstrap snapshot tests for {`install`, `install src`})
 - rust-lang/rust#152846 (Clarify some variable names in the query proc-macro)
 - rust-lang/rust#152858 (Fix typo in doc for core::mem::type_info::Struct)
 - rust-lang/rust#152861 (resolve: do not suggest `_` for unresolved imports)
 - rust-lang/rust#152873 (std::ops::ControlFlow - use "a" before `Result`)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=152057,152818,152840,152846,152858,152861,152873)
<!-- homu-ignore:end -->

