### PR TITLE
std::ops::ControlFlow - use normal comment for internal methods

### DIFF
--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -422,9 +422,9 @@ impl<T> ControlFlow<T, T> {
     }
 }
 
-/// These are used only as part of implementing the iterator adapters.
-/// They have mediocre names and non-obvious semantics, so aren't
-/// currently on a path to potential stabilization.
+// These are used only as part of implementing the iterator adapters.
+// They have mediocre names and non-obvious semantics, so aren't
+// currently on a path to potential stabilization.
 impl<R: ops::Try> ControlFlow<R, R::Output> {
     /// Creates a `ControlFlow` from any type implementing `Try`.
     #[inline]


### PR DESCRIPTION
Rather than a doc comment, which causes rustdoc to output the impl documentation even though the impl block only has non-public methods.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->