### PR TITLE
Remove `impl IntoQueryParam<P> for &'a P`.

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
@@ -626,7 +626,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         let predicates = match parent.kind {
             hir::ExprKind::Call(callee, _) => {
                 let ty = typeck_result.node_type_opt(callee.hir_id)?;
-                let ty::FnDef(fn_def_id, args) = ty.kind() else { return None };
+                let ty::FnDef(fn_def_id, args) = *ty.kind() else { return None };
                 tcx.predicates_of(fn_def_id).instantiate(tcx, args)
             }
             hir::ExprKind::MethodCall(..) => {

--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -614,7 +614,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                     }
                     _ => {
                         let local = &self.body.local_decls[local];
-                        match local.local_info() {
+                        match *local.local_info() {
                             LocalInfo::StaticRef { def_id, .. } => {
                                 let span = self.infcx.tcx.def_span(def_id);
                                 err.span_label(span, format!("this `static` cannot be {acted_on}"));

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -926,7 +926,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         let tcx = self.infcx.tcx;
 
         let ConstraintCategory::CallArgument(Some(func_ty)) = category else { return };
-        let ty::FnDef(fn_did, args) = func_ty.kind() else { return };
+        let ty::FnDef(fn_did, args) = *func_ty.kind() else { return };
         debug!(?fn_did, ?args);
 
         // Only suggest this on function calls, not closures
@@ -938,7 +938,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         let Ok(Some(instance)) = ty::Instance::try_resolve(
             tcx,
             self.infcx.typing_env(self.infcx.param_env),
-            *fn_did,
+            fn_did,
             self.infcx.resolve_vars_if_possible(args),
         ) else {
             return;

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -1013,12 +1013,12 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                         let is_implicit_coercion = coercion_source == CoercionSource::Implicit;
                         let src_ty = op.ty(self.body, tcx);
                         let mut src_sig = src_ty.fn_sig(tcx);
-                        if let ty::FnDef(def_id, _) = src_ty.kind()
+                        if let ty::FnDef(def_id, _) = *src_ty.kind()
                             && let ty::FnPtr(_, target_hdr) = *ty.kind()
                             && tcx.codegen_fn_attrs(def_id).safe_target_features
                             && target_hdr.safety.is_safe()
                             && let Some(safe_sig) = tcx.adjust_target_feature_sig(
-                                *def_id,
+                                def_id,
                                 src_sig,
                                 self.body.source.def_id(),
                             )

--- a/compiler/rustc_const_eval/src/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/check_consts/check.rs
@@ -577,7 +577,7 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
 
             Rvalue::Aggregate(kind, ..) => {
                 if let AggregateKind::Coroutine(def_id, ..) = kind.as_ref()
-                    && let Some(coroutine_kind) = self.tcx.coroutine_kind(def_id)
+                    && let Some(coroutine_kind) = self.tcx.coroutine_kind(*def_id)
                 {
                     self.check_op(ops::Coroutine(coroutine_kind));
                 }

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -1221,7 +1221,7 @@ fn check_impl_items_against_trait<'tcx>(
     match impl_trait_header.polarity {
         ty::ImplPolarity::Reservation | ty::ImplPolarity::Positive => {}
         ty::ImplPolarity::Negative => {
-            if let [first_item_ref, ..] = impl_item_refs {
+            if let [first_item_ref, ..] = *impl_item_refs {
                 let first_item_span = tcx.def_span(first_item_ref);
                 struct_span_code_err!(
                     tcx.dcx(),

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -1333,7 +1333,7 @@ fn check_region_late_boundedness<'tcx>(
         .iter()
         .map(|param| {
             let (LateEarlyMismatch::EarlyInImpl(impl_param_def_id, ..)
-            | LateEarlyMismatch::LateInImpl(impl_param_def_id, ..)) = param;
+            | LateEarlyMismatch::LateInImpl(impl_param_def_id, ..)) = *param;
             tcx.def_span(impl_param_def_id)
         })
         .collect();

--- a/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
+++ b/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
@@ -2445,12 +2445,12 @@ fn is_late_bound_map(
                 )) => {
                     // See comments on `ConstrainedCollectorPostHirTyLowering` for why this arm does not
                     // just consider args to be unconstrained.
-                    let generics = self.tcx.generics_of(alias_def);
+                    let generics = self.tcx.generics_of(*alias_def);
                     let mut walker = ConstrainedCollectorPostHirTyLowering {
                         arg_is_constrained: vec![false; generics.own_params.len()]
                             .into_boxed_slice(),
                     };
-                    walker.visit_ty(self.tcx.type_of(alias_def).instantiate_identity());
+                    walker.visit_ty(self.tcx.type_of(*alias_def).instantiate_identity());
 
                     match segments.last() {
                         Some(hir::PathSegment { args: Some(args), .. }) => {

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -214,7 +214,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             if let [best_trait] = visible_traits
                 .iter()
                 .copied()
-                .filter(|trait_def_id| {
+                .filter(|&trait_def_id| {
                     tcx.associated_items(trait_def_id)
                         .filter_by_name_unhygienic(suggested_name)
                         .any(|item| item.tag() == assoc_tag)
@@ -1234,7 +1234,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             && let name = Symbol::intern(&format!("{ident2}_{ident3}"))
             && let Some(item) = inherent_impls
                 .iter()
-                .flat_map(|inherent_impl| {
+                .flat_map(|&inherent_impl| {
                     tcx.associated_items(inherent_impl).filter_by_name_unhygienic(name)
                 })
                 .next()

--- a/compiler/rustc_hir_analysis/src/impl_wf_check.rs
+++ b/compiler/rustc_hir_analysis/src/impl_wf_check.rs
@@ -101,7 +101,7 @@ pub(crate) fn enforce_impl_lifetime_params_are_constrained(
     let lifetimes_in_associated_types: FxHashSet<_> = tcx
         .associated_item_def_ids(impl_def_id)
         .iter()
-        .flat_map(|def_id| {
+        .flat_map(|&def_id| {
             let item = tcx.associated_item(def_id);
             match item.kind {
                 ty::AssocKind::Type { .. } => {

--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -87,7 +87,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             result = self.try_overloaded_call_step(call_expr, callee_expr, arg_exprs, &autoderef);
         }
 
-        match autoderef.final_ty().kind() {
+        match *autoderef.final_ty().kind() {
             ty::FnDef(def_id, _) => {
                 let abi = self.tcx.fn_sig(def_id).skip_binder().skip_binder().abi;
                 self.check_call_abi(abi, call_expr.span);
@@ -430,11 +430,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     fn is_scalable_vector_ctor(&self, callee_ty: Ty<'_>) -> bool {
-        if let ty::FnDef(def_id, _) = callee_ty.kind()
+        if let ty::FnDef(def_id, _) = *callee_ty.kind()
             && let def::DefKind::Ctor(def::CtorOf::Struct, _) = self.tcx.def_kind(def_id)
         {
             self.tcx
-                .opt_parent(*def_id)
+                .opt_parent(def_id)
                 .and_then(|id| self.tcx.adt_def(id).repr().scalable)
                 .is_some()
         } else {

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -2448,7 +2448,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 .tcx
                 .inherent_impls(def_id)
                 .into_iter()
-                .flat_map(|i| self.tcx.associated_items(i).in_definition_order())
+                .flat_map(|&i| self.tcx.associated_items(i).in_definition_order())
                 // Only assoc fn with no receivers.
                 .filter(|item| item.is_fn() && !item.is_method())
                 .filter_map(|item| {
@@ -3183,7 +3183,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Check if there is an associated function with the same name.
         if let Some(def_id) = base_ty.peel_refs().ty_adt_def().map(|d| d.did()) {
-            for impl_def_id in self.tcx.inherent_impls(def_id) {
+            for &impl_def_id in self.tcx.inherent_impls(def_id) {
                 for item in self.tcx.associated_items(impl_def_id).in_definition_order() {
                     if let ExprKind::Field(base_expr, _) = expr.kind
                         && item.name() == field.name

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -1118,7 +1118,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // error in `validate_res_from_ribs` -- it's just difficult to tell whether the
             // self type has any generic types during rustc_resolve, which is what we use
             // to determine if this is a hard error or warning.
-            if std::iter::successors(Some(self.body_id.to_def_id()), |def_id| {
+            if std::iter::successors(Some(self.body_id.to_def_id()), |&def_id| {
                 self.tcx.generics_of(def_id).parent
             })
             .all(|def_id| def_id != impl_def_id)

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -567,7 +567,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return false;
         }
         if self.may_coerce(Ty::new_box(self.tcx, found), expected) {
-            let suggest_boxing = match found.kind() {
+            let suggest_boxing = match *found.kind() {
                 ty::Tuple(tuple) if tuple.is_empty() => {
                     errors::SuggestBoxing::Unit { start: span.shrink_to_lo(), end: span }
                 }

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -1414,7 +1414,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     })
                     .collect::<Vec<_>>();
                 if !inherent_impls_candidate.is_empty() {
-                    inherent_impls_candidate.sort_by_key(|id| self.tcx.def_path_str(id));
+                    inherent_impls_candidate.sort_by_key(|&id| self.tcx.def_path_str(id));
                     inherent_impls_candidate.dedup();
 
                     // number of types to show at most
@@ -2256,7 +2256,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         call_args: Option<Vec<Ty<'tcx>>>,
     ) -> Option<Symbol> {
         if let ty::Adt(adt, adt_args) = rcvr_ty.kind() {
-            for inherent_impl_did in self.tcx.inherent_impls(adt.did()).into_iter() {
+            for &inherent_impl_did in self.tcx.inherent_impls(adt.did()).into_iter() {
                 for inherent_method in
                     self.tcx.associated_items(inherent_impl_did).in_definition_order()
                 {
@@ -2315,7 +2315,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         sources: &mut Vec<CandidateSource>,
         sugg_span: Option<Span>,
     ) {
-        sources.sort_by_key(|source| match source {
+        sources.sort_by_key(|source| match *source {
             CandidateSource::Trait(id) => (0, self.tcx.def_path_str(id)),
             CandidateSource::Impl(id) => (1, self.tcx.def_path_str(id)),
         });
@@ -2468,7 +2468,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             .tcx
             .inherent_impls(adt_def.did())
             .iter()
-            .flat_map(|i| self.tcx.associated_items(i).in_definition_order())
+            .flat_map(|&i| self.tcx.associated_items(i).in_definition_order())
             // Only assoc fn with no receivers and only if
             // they are resolvable
             .filter(|item| {
@@ -2521,7 +2521,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         } else {
             String::new()
         };
-        match &items[..] {
+        match items[..] {
             [] => {}
             [(def_id, ret_ty)] => {
                 err.span_note(
@@ -2536,7 +2536,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             _ => {
                 let span: MultiSpan = items
                     .iter()
-                    .map(|(def_id, _)| self.tcx.def_span(def_id))
+                    .map(|&(def_id, _)| self.tcx.def_span(def_id))
                     .collect::<Vec<Span>>()
                     .into();
                 err.span_note(
@@ -2546,7 +2546,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                          following associated functions:\n{}{post}",
                         items
                             .iter()
-                            .map(|(def_id, _ret_ty)| self.tcx.def_path_str(def_id))
+                            .map(|&(def_id, _ret_ty)| self.tcx.def_path_str(def_id))
                             .collect::<Vec<String>>()
                             .join("\n")
                     ),
@@ -3518,7 +3518,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 traits.push(trait_pred.def_id());
             }
         }
-        traits.sort_by_key(|id| self.tcx.def_path_str(id));
+        traits.sort_by_key(|&id| self.tcx.def_path_str(id));
         traits.dedup();
 
         let len = traits.len();
@@ -3920,7 +3920,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         valid_out_of_scope_traits.retain(|id| self.tcx.is_user_visible_dep(id.krate));
         if !valid_out_of_scope_traits.is_empty() {
             let mut candidates = valid_out_of_scope_traits;
-            candidates.sort_by_key(|id| self.tcx.def_path_str(id));
+            candidates.sort_by_key(|&id| self.tcx.def_path_str(id));
             candidates.dedup();
 
             // `TryFrom` and `FromIterator` have no methods

--- a/compiler/rustc_hir_typeck/src/op.rs
+++ b/compiler/rustc_hir_typeck/src/op.rs
@@ -380,8 +380,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             self.tcx
                                 .associated_item_def_ids(def_id)
                                 .iter()
-                                .find(|item_def_id| {
-                                    self.tcx.associated_item(*item_def_id).name() == sym::Output
+                                .find(|&&item_def_id| {
+                                    self.tcx.associated_item(item_def_id).name() == sym::Output
                                 })
                                 .cloned()
                         });

--- a/compiler/rustc_lint/src/impl_trait_overcaptures.rs
+++ b/compiler/rustc_lint/src/impl_trait_overcaptures.rs
@@ -308,7 +308,7 @@ where
                         return true;
                     };
                     // We only computed variance of lifetimes...
-                    debug_assert_matches!(self.tcx.def_kind(def_id), DefKind::LifetimeParam);
+                    debug_assert_matches!(self.tcx.def_kind(*def_id), DefKind::LifetimeParam);
                     let uncaptured = match *kind {
                         ParamKind::Early(name, index) => ty::Region::new_early_param(
                             self.tcx,
@@ -342,7 +342,7 @@ where
 
                     let uncaptured_spans: Vec<_> = uncaptured_args
                         .into_iter()
-                        .map(|(def_id, _)| self.tcx.def_span(def_id))
+                        .map(|(&def_id, _)| self.tcx.def_span(def_id))
                         .collect();
 
                     self.tcx.emit_node_span_lint(

--- a/compiler/rustc_lint/src/internal.rs
+++ b/compiler/rustc_lint/src/internal.rs
@@ -282,9 +282,9 @@ fn lint_ty_kind_usage(cx: &LateContext<'_>, res: &Res) -> bool {
 }
 
 fn is_ty_or_ty_ctxt(cx: &LateContext<'_>, path: &hir::Path<'_>) -> Option<String> {
-    match &path.res {
+    match path.res {
         Res::Def(_, def_id) => {
-            if let Some(name @ (sym::Ty | sym::TyCtxt)) = cx.tcx.get_diagnostic_name(*def_id) {
+            if let Some(name @ (sym::Ty | sym::TyCtxt)) = cx.tcx.get_diagnostic_name(def_id) {
                 return Some(format!("{}{}", name, gen_args(path.segments.last().unwrap())));
             }
         }

--- a/compiler/rustc_middle/src/mir/graphviz.rs
+++ b/compiler/rustc_middle/src/mir/graphviz.rs
@@ -16,12 +16,12 @@ where
 
     let mirs = def_ids
         .iter()
-        .filter(|def_id| !tcx.is_trivial_const(*def_id))
-        .flat_map(|def_id| {
-            if tcx.is_const_fn(*def_id) {
-                vec![tcx.optimized_mir(*def_id), tcx.mir_for_ctfe(*def_id)]
+        .filter(|&&def_id| !tcx.is_trivial_const(def_id))
+        .flat_map(|&def_id| {
+            if tcx.is_const_fn(def_id) {
+                vec![tcx.optimized_mir(def_id), tcx.mir_for_ctfe(def_id)]
             } else {
-                vec![tcx.instance_mir(ty::InstanceKind::Item(*def_id))]
+                vec![tcx.instance_mir(ty::InstanceKind::Item(def_id))]
             }
         })
         .collect::<Vec<_>>();

--- a/compiler/rustc_middle/src/mir/interpret/mod.rs
+++ b/compiler/rustc_middle/src/mir/interpret/mod.rs
@@ -309,7 +309,7 @@ impl<'tcx> GlobalAlloc<'tcx> {
 
     pub fn mutability(&self, tcx: TyCtxt<'tcx>, typing_env: ty::TypingEnv<'tcx>) -> Mutability {
         // Let's see what kind of memory we are.
-        match self {
+        match *self {
             GlobalAlloc::Static(did) => {
                 let DefKind::Static { safety: _, mutability, nested } = tcx.def_kind(did) else {
                     bug!()
@@ -351,7 +351,7 @@ impl<'tcx> GlobalAlloc<'tcx> {
         tcx: TyCtxt<'tcx>,
         typing_env: ty::TypingEnv<'tcx>,
     ) -> (Size, Align) {
-        match self {
+        match *self {
             GlobalAlloc::Static(def_id) => {
                 let DefKind::Static { nested, .. } = tcx.def_kind(def_id) else {
                     bug!("GlobalAlloc::Static is not a static")

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -633,13 +633,6 @@ mod sealed {
         }
     }
 
-    impl<'a, P: Copy> IntoQueryParam<P> for &'a P {
-        #[inline(always)]
-        fn into_query_param(self) -> P {
-            *self
-        }
-    }
-
     impl IntoQueryParam<LocalDefId> for OwnerId {
         #[inline(always)]
         fn into_query_param(self) -> LocalDefId {

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2086,7 +2086,7 @@ impl<'tcx> TyCtxt<'tcx> {
 
     /// Given a `ty`, return whether it's an `impl Future<...>`.
     pub fn ty_is_opaque_future(self, ty: Ty<'_>) -> bool {
-        let ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. }) = ty.kind() else { return false };
+        let ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. }) = *ty.kind() else { return false };
         let future_trait = self.require_lang_item(LangItem::Future, DUMMY_SP);
 
         self.explicit_item_self_bounds(def_id).skip_binder().iter().any(|&(predicate, _)| {

--- a/compiler/rustc_middle/src/ty/significant_drop_order.rs
+++ b/compiler/rustc_middle/src/ty/significant_drop_order.rs
@@ -119,7 +119,7 @@ pub fn extract_component_with_significant_dtor<'tcx>(
 /// when we are working with current local crate.
 #[instrument(level = "trace", skip(tcx))]
 pub fn ty_dtor_span<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Span> {
-    match ty.kind() {
+    match *ty.kind() {
         ty::Bool
         | ty::Char
         | ty::Int(_)

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -417,7 +417,7 @@ impl<'tcx> TyCtxt<'tcx> {
                 continue;
             }
 
-            let Some(item_id) = self.associated_item_def_ids(impl_did).first() else {
+            let Some(&item_id) = self.associated_item_def_ids(impl_did).first() else {
                 self.dcx()
                     .span_delayed_bug(self.def_span(impl_did), "Drop impl without drop function");
                 continue;
@@ -435,7 +435,7 @@ impl<'tcx> TyCtxt<'tcx> {
                     .delay_as_bug();
             }
 
-            dtor_candidate = Some(*item_id);
+            dtor_candidate = Some(item_id);
         }
 
         let did = dtor_candidate?;

--- a/compiler/rustc_mir_build/src/builder/expr/into.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/into.rs
@@ -370,7 +370,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             // Some intrinsics are handled here because they desperately want to avoid introducing
             // unnecessary copies.
             ExprKind::Call { ty, fun, ref args, .. }
-                if let ty::FnDef(def_id, generic_args) = ty.kind()
+                if let ty::FnDef(def_id, generic_args) = *ty.kind()
                     && let Some(intrinsic) = this.tcx.intrinsic(def_id)
                     && matches!(intrinsic.name, sym::write_via_move | sym::write_box_via_move) =>
             {

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -471,7 +471,7 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
             ExprKind::Call { fun, ty: _, args: _, from_hir_call: _, fn_span: _ } => {
                 let fn_ty = self.thir[fun].ty;
                 let sig = fn_ty.fn_sig(self.tcx);
-                let (callee_features, safe_target_features): (&[_], _) = match fn_ty.kind() {
+                let (callee_features, safe_target_features): (&[_], _) = match *fn_ty.kind() {
                     ty::FnDef(func_id, ..) => {
                         let cg_attrs = self.tcx.codegen_fn_attrs(func_id);
                         (&cg_attrs.target_features, cg_attrs.safe_target_features)

--- a/compiler/rustc_mir_transform/src/elaborate_drop.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drop.rs
@@ -251,19 +251,16 @@ where
             // impl_item_refs may be empty if drop fn is not implemented in 'impl AsyncDrop for ...'
             // (#140974).
             // Such code will report error, so just generate sync drop here and return
-            let Some(drop_fn_def_id) = tcx
-                .associated_item_def_ids(drop_trait)
-                .first()
-                .and_then(|def_id| {
+            let Some(drop_fn_def_id) =
+                tcx.associated_item_def_ids(drop_trait).first().and_then(|&def_id| {
                     if tcx.def_kind(def_id) == DefKind::AssocFn
-                        && tcx.check_args_compatible(*def_id, trait_args)
+                        && tcx.check_args_compatible(def_id, trait_args)
                     {
                         Some(def_id)
                     } else {
                         None
                     }
                 })
-                .copied()
             else {
                 tcx.dcx().span_delayed_bug(
                     self.elaborator.body().span,

--- a/compiler/rustc_mir_transform/src/validate.rs
+++ b/compiler/rustc_mir_transform/src/validate.rs
@@ -440,7 +440,7 @@ impl<'a, 'tcx> Visitor<'tcx> for CfgChecker<'a, 'tcx> {
                     }
                 }
 
-                if let ty::FnDef(did, ..) = func.ty(&self.body.local_decls, self.tcx).kind()
+                if let ty::FnDef(did, ..) = *func.ty(&self.body.local_decls, self.tcx).kind()
                     && self.body.phase >= MirPhase::Runtime(RuntimePhase::Optimized)
                     && matches!(self.tcx.codegen_fn_attrs(did).inline, InlineAttr::Force { .. })
                 {

--- a/compiler/rustc_monomorphize/src/collector/autodiff.rs
+++ b/compiler/rustc_monomorphize/src/collector/autodiff.rs
@@ -28,13 +28,13 @@ fn collect_autodiff_fn_from_arg<'tcx>(
     output: &mut MonoItems<'tcx>,
 ) {
     let (instance, span) = match arg.kind() {
-        ty::GenericArgKind::Type(ty) => match ty.kind() {
+        ty::GenericArgKind::Type(ty) => match *ty.kind() {
             ty::FnDef(def_id, substs) => {
                 let span = tcx.def_span(def_id);
                 let instance = ty::Instance::expect_resolve(
                     tcx,
                     ty::TypingEnv::non_body_analysis(tcx, def_id),
-                    *def_id,
+                    def_id,
                     substs,
                     span,
                 );

--- a/compiler/rustc_monomorphize/src/lib.rs
+++ b/compiler/rustc_monomorphize/src/lib.rs
@@ -37,7 +37,7 @@ fn custom_coerce_unsize_info<'tcx>(
         Ok(traits::ImplSource::UserDefined(traits::ImplSourceUserDefinedData {
             impl_def_id,
             ..
-        })) => Ok(tcx.coerce_unsized_info(impl_def_id)?.custom_kind.unwrap()),
+        })) => Ok(tcx.coerce_unsized_info(*impl_def_id)?.custom_kind.unwrap()),
         impl_source => {
             bug!(
                 "invalid `CoerceUnsized` from {source_ty} to {target_ty}: impl_source: {:?}",

--- a/compiler/rustc_monomorphize/src/mono_checks/move_check.rs
+++ b/compiler/rustc_monomorphize/src/mono_checks/move_check.rs
@@ -190,7 +190,7 @@ impl<'tcx> MoveCheckVisitor<'tcx> {
 }
 
 fn assoc_fn_of_type<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, fn_ident: Ident) -> Option<DefId> {
-    for impl_def_id in tcx.inherent_impls(def_id) {
+    for &impl_def_id in tcx.inherent_impls(def_id) {
         if let Some(new) = tcx.associated_items(impl_def_id).find_by_ident_and_kind(
             tcx,
             fn_ident,

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -2207,7 +2207,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     })
                 })
                 .collect();
-            if let Some(def_id) = path.get(0)
+            if let Some(&def_id) = path.get(0)
                 && let Some(path) = path_names
             {
                 if let Some(def_id) = def_id.as_local() {

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1295,7 +1295,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                             .tcx
                             .associated_item_def_ids(def_id)
                             .iter()
-                            .map(|field_id| self.tcx.visibility(field_id))
+                            .map(|&field_id| self.tcx.visibility(field_id))
                             .collect();
                         (ctor_res, ctor_vis, field_visibilities)
                     })

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -2359,7 +2359,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                                 .tcx
                                 .associated_item_def_ids(def_id)
                                 .iter()
-                                .map(|field_id| self.r.tcx.visibility(field_id))
+                                .map(|&field_id| self.r.tcx.visibility(field_id))
                                 .collect();
                             (ctor_res, ctor_vis, field_visibilities)
                         })
@@ -2594,7 +2594,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
             .tcx
             .inherent_impls(def_id)
             .iter()
-            .flat_map(|i| self.r.tcx.associated_items(i).in_definition_order())
+            .flat_map(|&i| self.r.tcx.associated_items(i).in_definition_order())
             // Only assoc fn with no receivers.
             .filter(|item| item.is_fn() && !item.is_method())
             .filter_map(|item| {
@@ -2702,7 +2702,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                     .tcx
                     .associated_item_def_ids(def_id)
                     .iter()
-                    .map(|field_id| self.r.tcx.visibility(field_id))
+                    .map(|&field_id| self.r.tcx.visibility(field_id))
                     .collect(),
             ),
         };

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/ambiguity.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/ambiguity.rs
@@ -362,7 +362,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         && self.tcx.trait_of_assoc(*item_id) == Some(*trait_id)
                         && let None = self.tainted_by_errors()
                     {
-                        let assoc_item = self.tcx.associated_item(item_id);
+                        let assoc_item = self.tcx.associated_item(*item_id);
                         let (verb, noun) = match assoc_item.kind {
                             ty::AssocKind::Const { .. } => ("refer to the", "constant"),
                             ty::AssocKind::Fn { .. } => ("call", "function"),
@@ -394,7 +394,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 
                         let trait_impls = self.tcx.trait_impls_of(data.trait_ref.def_id);
 
-                        if let Some(impl_def_id) =
+                        if let Some(&impl_def_id) =
                             trait_impls.non_blanket_impls().values().flatten().next()
                         {
                             let non_blanket_impl_count =
@@ -418,7 +418,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                                         .non_blanket_impls()
                                         .values()
                                         .flatten()
-                                        .map(|id| {
+                                        .map(|&id| {
                                             format!(
                                                 "{}",
                                                 self.tcx.type_of(id).instantiate_identity()

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
@@ -373,12 +373,12 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             self.tcx.extern_crate(trait_def_id.krate),
         ) {
             (
-                Some(ExternCrate {
+                Some(&ExternCrate {
                     src: ExternCrateSource::Extern(expected_def_id),
                     dependency_of: LOCAL_CRATE,
                     ..
                 }),
-                Some(ExternCrate {
+                Some(&ExternCrate {
                     src: ExternCrateSource::Extern(trait_def_id),
                     dependency_of: LOCAL_CRATE,
                     ..
@@ -402,9 +402,9 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let krate = self.tcx.crate_name(expected_did.krate);
         let name = self.tcx.item_name(expected_did);
         let definitions_with_same_path: UnordSet<_> = found_dids
-            .filter(|def_id| {
+            .filter(|&def_id| {
                 def_id.krate != expected_did.krate
-                    && (self.extern_crates_with_the_same_name(expected_did, *def_id)
+                    && (self.extern_crates_with_the_same_name(expected_did, def_id)
                         || self.tcx.crate_name(def_id.krate) == krate)
                     && self.tcx.item_name(def_id) == name
             })

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/on_unimplemented.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/on_unimplemented.rs
@@ -207,7 +207,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
 
             if self_ty.is_fn() {
                 let fn_sig = self_ty.fn_sig(self.tcx);
-                let shortname = if let ty::FnDef(def_id, _) = self_ty.kind()
+                let shortname = if let ty::FnDef(def_id, _) = *self_ty.kind()
                     && self.tcx.codegen_fn_attrs(def_id).safe_target_features
                 {
                     "#[target_feature] fn"

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/on_unimplemented_format.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/on_unimplemented_format.rs
@@ -231,7 +231,7 @@ fn parse_arg<'tcx>(
     is_source_literal: bool,
 ) -> FormatArg {
     let (Ctx::RustcOnUnimplemented { tcx, trait_def_id }
-    | Ctx::DiagnosticOnUnimplemented { tcx, trait_def_id }) = ctx;
+    | Ctx::DiagnosticOnUnimplemented { tcx, trait_def_id }) = *ctx;
 
     let span = slice_span(input_span, arg.position_span.clone(), is_source_literal);
 

--- a/compiler/rustc_trait_selection/src/traits/query/dropck_outlives.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/dropck_outlives.rs
@@ -267,7 +267,7 @@ pub fn dtorck_constraint_for_ty_inner<'tcx>(
         return;
     }
 
-    match ty.kind() {
+    match *ty.kind() {
         ty::Bool
         | ty::Char
         | ty::Int(_)
@@ -287,7 +287,7 @@ pub fn dtorck_constraint_for_ty_inner<'tcx>(
         ty::Pat(ety, _) | ty::Array(ety, _) | ty::Slice(ety) => {
             // single-element containers, behave like their element
             rustc_data_structures::stack::ensure_sufficient_stack(|| {
-                dtorck_constraint_for_ty_inner(tcx, typing_env, span, depth + 1, *ety, constraints)
+                dtorck_constraint_for_ty_inner(tcx, typing_env, span, depth + 1, ety, constraints)
             });
         }
 

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -191,7 +191,7 @@ pub(crate) fn try_inline_glob(
                 .iter()
                 .filter(|child| !child.reexport_chain.is_empty())
                 .filter_map(|child| child.res.opt_def_id())
-                .filter(|def_id| !cx.tcx.is_doc_hidden(def_id))
+                .filter(|&def_id| !cx.tcx.is_doc_hidden(def_id))
                 .collect();
             let attrs = cx.tcx.hir_attrs(import.hir_id());
             let mut items = build_module_items(

--- a/src/librustdoc/passes/collect_trait_impls.rs
+++ b/src/librustdoc/passes/collect_trait_impls.rs
@@ -94,7 +94,7 @@ pub(crate) fn collect_trait_impls(mut krate: Crate, cx: &mut DocContext<'_>) -> 
             // While the `impl` blocks themselves are only in `libcore`, the module with `doc`
             // attached is directly included in `libstd` as well.
             if did.is_local() {
-                for def_id in prim.impls(tcx).filter(|def_id| {
+                for def_id in prim.impls(tcx).filter(|&def_id| {
                     // Avoid including impl blocks with filled-in generics.
                     // https://github.com/rust-lang/rust/issues/94937
                     //

--- a/src/tools/clippy/clippy_lints/src/eta_reduction.rs
+++ b/src/tools/clippy/clippy_lints/src/eta_reduction.rs
@@ -150,16 +150,16 @@ fn check_closure<'tcx>(cx: &LateContext<'tcx>, outer_receiver: Option<&Expr<'tcx
             let callee_ty_adjustments = typeck.expr_adjustments(callee);
             let callee_ty_adjusted = callee_ty_adjustments.last().map_or(callee_ty, |a| a.target);
 
-            let sig = match callee_ty_adjusted.kind() {
+            let sig = match *callee_ty_adjusted.kind() {
                 ty::FnDef(def, _) => {
                     // Rewriting `x(|| f())` to `x(f)` where f is marked `#[track_caller]` moves the `Location`
-                    if find_attr!(cx.tcx, *def, TrackCaller(..)) {
+                    if find_attr!(cx.tcx, def, TrackCaller(..)) {
                         return;
                     }
 
                     cx.tcx.fn_sig(def).skip_binder().skip_binder()
                 },
-                ty::FnPtr(sig_tys, hdr) => sig_tys.with(*hdr).skip_binder(),
+                ty::FnPtr(sig_tys, hdr) => sig_tys.with(hdr).skip_binder(),
                 ty::Closure(_, subs) => cx
                     .tcx
                     .signature_unclosure(subs.as_closure().sig(), Safety::Safe)

--- a/src/tools/clippy/clippy_lints/src/methods/or_fun_call.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/or_fun_call.rs
@@ -133,7 +133,7 @@ fn check_unwrap_or_default(
 
     let output_type_implements_default = |fun| {
         let fun_ty = cx.typeck_results().expr_ty(fun);
-        if let ty::FnDef(def_id, args) = fun_ty.kind() {
+        if let ty::FnDef(def_id, args) = *fun_ty.kind() {
             let output_ty = cx.tcx.fn_sig(def_id).instantiate(cx.tcx, args).skip_binder().output();
             cx.tcx
                 .get_diagnostic_item(sym::Default)
@@ -153,7 +153,7 @@ fn check_unwrap_or_default(
         cx.tcx
             .inherent_impls(adt_def.did())
             .iter()
-            .flat_map(|impl_id| cx.tcx.associated_items(impl_id).filter_by_name_unhygienic(sugg))
+            .flat_map(|&impl_id| cx.tcx.associated_items(impl_id).filter_by_name_unhygienic(sugg))
             .find_map(|assoc| {
                 if assoc.is_method() && cx.tcx.fn_sig(assoc.def_id).skip_binder().inputs().skip_binder().len() == 1 {
                     Some(assoc.def_id)

--- a/src/tools/clippy/clippy_lints/src/operators/identity_op.rs
+++ b/src/tools/clippy/clippy_lints/src/operators/identity_op.rs
@@ -287,7 +287,7 @@ fn is_assoc_fn_without_type_instance<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'
                 ..
             },
         )) = func.kind
-        && let output_ty = cx.tcx.fn_sig(def_id).instantiate_identity().skip_binder().output()
+        && let output_ty = cx.tcx.fn_sig(*def_id).instantiate_identity().skip_binder().output()
         && let ty::Param(ty::ParamTy {
             name: kw::SelfUpper, ..
         }) = output_ty.kind()

--- a/src/tools/clippy/clippy_lints/src/unconditional_recursion.rs
+++ b/src/tools/clippy/clippy_lints/src/unconditional_recursion.rs
@@ -335,8 +335,8 @@ impl UnconditionalRecursion {
             let impls = cx.tcx.trait_impls_of(default_trait_id);
             for (ty, impl_def_ids) in impls.non_blanket_impls() {
                 let Some(self_def_id) = ty.def() else { continue };
-                for impl_def_id in impl_def_ids {
-                    if !cx.tcx.is_automatically_derived(*impl_def_id) &&
+                for &impl_def_id in impl_def_ids {
+                    if !cx.tcx.is_automatically_derived(impl_def_id) &&
                         let Some(assoc_item) = cx
                             .tcx
                             .associated_items(impl_def_id)

--- a/src/tools/clippy/clippy_utils/src/lib.rs
+++ b/src/tools/clippy/clippy_utils/src/lib.rs
@@ -601,9 +601,9 @@ pub fn is_default_equivalent_call(
             && let StatementKind::Assign(assign) = &block_data.statements[0].kind
             && assign.0.local == RETURN_PLACE
             && let Rvalue::Aggregate(kind, _places) = &assign.1
-            && let AggregateKind::Adt(did, variant_index, _, _, _) = &**kind
+            && let AggregateKind::Adt(did, variant_index, _, _, _) = **kind
             && let def = cx.tcx.adt_def(did)
-            && let variant = &def.variant(*variant_index)
+            && let variant = &def.variant(variant_index)
             && variant.fields.is_empty()
             && let Some((_, did)) = variant.ctor
             && did == repl_def_id

--- a/src/tools/clippy/clippy_utils/src/paths.rs
+++ b/src/tools/clippy/clippy_utils/src/paths.rs
@@ -335,7 +335,7 @@ fn non_local_item_child_by_name(tcx: TyCtxt<'_>, def_id: DefId, ns: PathNS, name
             .associated_item_def_ids(def_id)
             .iter()
             .copied()
-            .find(|assoc_def_id| tcx.item_name(*assoc_def_id) == name && ns.matches(tcx.def_kind(assoc_def_id).ns())),
+            .find(|&assoc_def_id| tcx.item_name(assoc_def_id) == name && ns.matches(tcx.def_kind(assoc_def_id).ns())),
         _ => None,
     }
 }

--- a/src/tools/clippy/clippy_utils/src/ty/mod.rs
+++ b/src/tools/clippy/clippy_utils/src/ty/mod.rs
@@ -310,13 +310,13 @@ pub fn has_drop<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
 
 // Returns whether the type has #[must_use] attribute
 pub fn is_must_use_ty<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
-    match ty.kind() {
+    match *ty.kind() {
         ty::Adt(adt, _) => find_attr!(cx.tcx, adt.did(), MustUse { .. }),
-        ty::Foreign(did) => find_attr!(cx.tcx, *did, MustUse { .. }),
+        ty::Foreign(did) => find_attr!(cx.tcx, did, MustUse { .. }),
         ty::Slice(ty) | ty::Array(ty, _) | ty::RawPtr(ty, _) | ty::Ref(_, ty, _) => {
             // for the Array case we don't need to care for the len == 0 case
             // because we don't want to lint functions returning empty arrays
-            is_must_use_ty(cx, *ty)
+            is_must_use_ty(cx, ty)
         },
         ty::Tuple(args) => args.iter().any(|ty| is_must_use_ty(cx, ty)),
         ty::Alias(ty::Opaque, AliasTy { def_id, .. }) => {
@@ -330,7 +330,7 @@ pub fn is_must_use_ty<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
             false
         },
         ty::Dynamic(binder, _) => {
-            for predicate in *binder {
+            for predicate in binder {
                 if let ty::ExistentialPredicate::Trait(ref trait_ref) = predicate.skip_binder()
                     && find_attr!(cx.tcx, trait_ref.def_id, MustUse { .. })
                 {

--- a/src/tools/miri/src/helpers.rs
+++ b/src/tools/miri/src/helpers.rs
@@ -62,7 +62,7 @@ fn try_resolve_did(tcx: TyCtxt<'_>, path: &[&str], namespace: Option<Namespace>)
         // Go over the modules.
         for &segment in modules {
             let Some(next_item) = find_children(tcx, cur_item, segment)
-                .find(|item| tcx.def_kind(item) == DefKind::Mod)
+                .find(|&item| tcx.def_kind(item) == DefKind::Mod)
             else {
                 continue 'crates;
             };
@@ -72,7 +72,7 @@ fn try_resolve_did(tcx: TyCtxt<'_>, path: &[&str], namespace: Option<Namespace>)
         match item {
             Some((item_name, namespace)) => {
                 let Some(item) = find_children(tcx, cur_item, item_name)
-                    .find(|item| tcx.def_kind(item).ns() == Some(namespace))
+                    .find(|&item| tcx.def_kind(item).ns() == Some(namespace))
                 else {
                     continue 'crates;
                 };


### PR DESCRIPTION
`IntoQueryParam` is a trait that lets query callers be a bit sloppy with the passed-in key.
- Types similar to `DefId` will be auto-converted to `DefId`. Likewise for `LocalDefId`.
- Reference types will be auto-derefed.

The auto-conversion is genuinely useful; the auto-derefing much less so. In practice it's only used for passing `&DefId` to queries that accept `DefId`, which is an anti-pattern because `DefId` is marked with `#[rustc_pass_by_value]`.

This commit removes the auto-deref impl and makes the necessary sigil adjustments. (I generally avoid using `*` to deref manually at call sites, preferring to deref via `&` in patterns or via `*` in match expressions. Mostly because that way a single deref often covers multiple call sites.)

r? @cjgillot 