### PR TITLE
Add Boxes to Annotatable

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -557,6 +557,12 @@ pub struct Crate {
     pub is_placeholder: bool,
 }
 
+impl From<Box<Crate>> for Crate {
+    fn from(krate: Box<Crate>) -> Self {
+        *krate
+    }
+}
+
 /// A semantic representation of a meta item. A meta item is a slightly
 /// restricted form of an attribute -- it can only contain expressions in
 /// certain leaf positions, rather than arbitrary token streams -- that is used

--- a/compiler/rustc_builtin_macros/src/derive.rs
+++ b/compiler/rustc_builtin_macros/src/derive.rs
@@ -103,7 +103,7 @@ impl MultiItemModifier for Expander {
 
 // The cheapest `Annotatable` to construct.
 fn dummy_annotatable() -> Annotatable {
-    Annotatable::GenericParam(ast::GenericParam {
+    Annotatable::GenericParam(Box::new(ast::GenericParam {
         id: ast::DUMMY_NODE_ID,
         ident: Ident::dummy(),
         attrs: Default::default(),
@@ -111,7 +111,7 @@ fn dummy_annotatable() -> Annotatable {
         is_placeholder: false,
         kind: GenericParamKind::Lifetime,
         colon_span: None,
-    })
+    }))
 }
 
 fn report_bad_target(

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -48,15 +48,15 @@ pub enum Annotatable {
     ForeignItem(Box<ast::ForeignItem>),
     Stmt(Box<ast::Stmt>),
     Expr(Box<ast::Expr>),
-    Arm(ast::Arm),
-    ExprField(ast::ExprField),
-    PatField(ast::PatField),
-    GenericParam(ast::GenericParam),
-    Param(ast::Param),
-    FieldDef(ast::FieldDef),
-    Variant(ast::Variant),
-    WherePredicate(ast::WherePredicate),
-    Crate(ast::Crate),
+    Arm(Box<ast::Arm>),
+    ExprField(Box<ast::ExprField>),
+    PatField(Box<ast::PatField>),
+    GenericParam(Box<ast::GenericParam>),
+    Param(Box<ast::Param>),
+    FieldDef(Box<ast::FieldDef>),
+    Variant(Box<ast::Variant>),
+    WherePredicate(Box<ast::WherePredicate>),
+    Crate(Box<ast::Crate>),
 }
 
 impl Annotatable {
@@ -167,9 +167,9 @@ impl Annotatable {
         }
     }
 
-    pub fn expect_stmt(self) -> ast::Stmt {
+    pub fn expect_stmt(self) -> Box<ast::Stmt> {
         match self {
-            Annotatable::Stmt(stmt) => *stmt,
+            Annotatable::Stmt(stmt) => stmt,
             _ => panic!("expected statement"),
         }
     }
@@ -181,63 +181,63 @@ impl Annotatable {
         }
     }
 
-    pub fn expect_arm(self) -> ast::Arm {
+    pub fn expect_arm(self) -> Box<ast::Arm> {
         match self {
             Annotatable::Arm(arm) => arm,
             _ => panic!("expected match arm"),
         }
     }
 
-    pub fn expect_expr_field(self) -> ast::ExprField {
+    pub fn expect_expr_field(self) -> Box<ast::ExprField> {
         match self {
             Annotatable::ExprField(field) => field,
             _ => panic!("expected field"),
         }
     }
 
-    pub fn expect_pat_field(self) -> ast::PatField {
+    pub fn expect_pat_field(self) -> Box<ast::PatField> {
         match self {
             Annotatable::PatField(fp) => fp,
             _ => panic!("expected field pattern"),
         }
     }
 
-    pub fn expect_generic_param(self) -> ast::GenericParam {
+    pub fn expect_generic_param(self) -> Box<ast::GenericParam> {
         match self {
             Annotatable::GenericParam(gp) => gp,
             _ => panic!("expected generic parameter"),
         }
     }
 
-    pub fn expect_param(self) -> ast::Param {
+    pub fn expect_param(self) -> Box<ast::Param> {
         match self {
             Annotatable::Param(param) => param,
             _ => panic!("expected parameter"),
         }
     }
 
-    pub fn expect_field_def(self) -> ast::FieldDef {
+    pub fn expect_field_def(self) -> Box<ast::FieldDef> {
         match self {
             Annotatable::FieldDef(sf) => sf,
             _ => panic!("expected struct field"),
         }
     }
 
-    pub fn expect_variant(self) -> ast::Variant {
+    pub fn expect_variant(self) -> Box<ast::Variant> {
         match self {
             Annotatable::Variant(v) => v,
             _ => panic!("expected variant"),
         }
     }
 
-    pub fn expect_where_predicate(self) -> ast::WherePredicate {
+    pub fn expect_where_predicate(self) -> Box<ast::WherePredicate> {
         match self {
             Annotatable::WherePredicate(wp) => wp,
             _ => panic!("expected where predicate"),
         }
     }
 
-    pub fn expect_crate(self) -> ast::Crate {
+    pub fn expect_crate(self) -> Box<ast::Crate> {
         match self {
             Annotatable::Crate(krate) => krate,
             _ => panic!("expected krate"),
@@ -503,7 +503,7 @@ pub trait MacResult {
         None
     }
 
-    fn make_crate(self: Box<Self>) -> Option<ast::Crate> {
+    fn make_crate(self: Box<Self>) -> Option<Box<ast::Crate>> {
         // Fn-like macros cannot produce a crate.
         unreachable!()
     }
@@ -718,14 +718,14 @@ impl MacResult for DummyResult {
         Some(SmallVec::new())
     }
 
-    fn make_crate(self: Box<DummyResult>) -> Option<ast::Crate> {
-        Some(ast::Crate {
+    fn make_crate(self: Box<DummyResult>) -> Option<Box<ast::Crate>> {
+        Some(Box::new(ast::Crate {
             attrs: Default::default(),
             items: Default::default(),
             spans: Default::default(),
             id: ast::DUMMY_NODE_ID,
             is_placeholder: Default::default(),
-        })
+        }))
     }
 }
 

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -279,7 +279,7 @@ ast_fragments! {
         many fn flat_map_where_predicate; fn visit_where_predicate(); fn unreachable_to_string;
         fn make_where_predicates;
     }
-    Crate(ast::Crate) {
+    Crate(Box<ast::Crate>) {
         "crate";
         one fn visit_crate; fn visit_crate; fn unreachable_to_string;
         fn make_crate;
@@ -328,28 +328,28 @@ impl AstFragmentKind {
         let mut items = items.into_iter();
         match self {
             AstFragmentKind::Arms => {
-                AstFragment::Arms(items.map(Annotatable::expect_arm).collect())
+                AstFragment::Arms(items.map(|ann| *ann.expect_arm()).collect())
             }
             AstFragmentKind::ExprFields => {
-                AstFragment::ExprFields(items.map(Annotatable::expect_expr_field).collect())
+                AstFragment::ExprFields(items.map(|ann| *ann.expect_expr_field()).collect())
             }
             AstFragmentKind::PatFields => {
-                AstFragment::PatFields(items.map(Annotatable::expect_pat_field).collect())
+                AstFragment::PatFields(items.map(|ann| *ann.expect_pat_field()).collect())
             }
             AstFragmentKind::GenericParams => {
-                AstFragment::GenericParams(items.map(Annotatable::expect_generic_param).collect())
+                AstFragment::GenericParams(items.map(|ann| *ann.expect_generic_param()).collect())
             }
             AstFragmentKind::Params => {
-                AstFragment::Params(items.map(Annotatable::expect_param).collect())
+                AstFragment::Params(items.map(|ann| *ann.expect_param()).collect())
             }
             AstFragmentKind::FieldDefs => {
-                AstFragment::FieldDefs(items.map(Annotatable::expect_field_def).collect())
+                AstFragment::FieldDefs(items.map(|ann| *ann.expect_field_def()).collect())
             }
             AstFragmentKind::Variants => {
-                AstFragment::Variants(items.map(Annotatable::expect_variant).collect())
+                AstFragment::Variants(items.map(|ann| *ann.expect_variant()).collect())
             }
             AstFragmentKind::WherePredicates => AstFragment::WherePredicates(
-                items.map(Annotatable::expect_where_predicate).collect(),
+                items.map(|ann| *ann.expect_where_predicate()).collect(),
             ),
             AstFragmentKind::Items => {
                 AstFragment::Items(items.map(Annotatable::expect_item).collect())
@@ -367,7 +367,7 @@ impl AstFragmentKind {
                 AstFragment::ForeignItems(items.map(Annotatable::expect_foreign_item).collect())
             }
             AstFragmentKind::Stmts => {
-                AstFragment::Stmts(items.map(Annotatable::expect_stmt).collect())
+                AstFragment::Stmts(items.map(|ann| *ann.expect_stmt()).collect())
             }
             AstFragmentKind::Expr => AstFragment::Expr(
                 items.next().expect("expected exactly one expression").expect_expr(),
@@ -468,7 +468,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
         MacroExpander { cx, monotonic }
     }
 
-    pub fn expand_crate(&mut self, krate: ast::Crate) -> ast::Crate {
+    pub fn expand_crate(&mut self, krate: Box<ast::Crate>) -> Box<ast::Crate> {
         let file_path = match self.cx.source_map().span_to_filename(krate.spans.inner_span) {
             FileName::Real(name) => name
                 .into_local_path()
@@ -1159,7 +1159,7 @@ pub fn parse_ast_fragment<'a>(
             RecoverColon::Yes,
             CommaRecoveryMode::LikelyTuple,
         )?)),
-        AstFragmentKind::Crate => AstFragment::Crate(this.parse_crate_mod()?),
+        AstFragmentKind::Crate => AstFragment::Crate(Box::new(this.parse_crate_mod()?)),
         AstFragmentKind::Arms
         | AstFragmentKind::ExprFields
         | AstFragmentKind::PatFields
@@ -1606,7 +1606,7 @@ impl InvocationCollectorNode for Box<ast::ForeignItem> {
 impl InvocationCollectorNode for ast::Variant {
     const KIND: AstFragmentKind = AstFragmentKind::Variants;
     fn to_annotatable(self) -> Annotatable {
-        Annotatable::Variant(self)
+        Annotatable::Variant(Box::new(self))
     }
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_variants()
@@ -1619,7 +1619,7 @@ impl InvocationCollectorNode for ast::Variant {
 impl InvocationCollectorNode for ast::WherePredicate {
     const KIND: AstFragmentKind = AstFragmentKind::WherePredicates;
     fn to_annotatable(self) -> Annotatable {
-        Annotatable::WherePredicate(self)
+        Annotatable::WherePredicate(Box::new(self))
     }
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_where_predicates()
@@ -1632,7 +1632,7 @@ impl InvocationCollectorNode for ast::WherePredicate {
 impl InvocationCollectorNode for ast::FieldDef {
     const KIND: AstFragmentKind = AstFragmentKind::FieldDefs;
     fn to_annotatable(self) -> Annotatable {
-        Annotatable::FieldDef(self)
+        Annotatable::FieldDef(Box::new(self))
     }
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_field_defs()
@@ -1645,7 +1645,7 @@ impl InvocationCollectorNode for ast::FieldDef {
 impl InvocationCollectorNode for ast::PatField {
     const KIND: AstFragmentKind = AstFragmentKind::PatFields;
     fn to_annotatable(self) -> Annotatable {
-        Annotatable::PatField(self)
+        Annotatable::PatField(Box::new(self))
     }
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_pat_fields()
@@ -1658,7 +1658,7 @@ impl InvocationCollectorNode for ast::PatField {
 impl InvocationCollectorNode for ast::ExprField {
     const KIND: AstFragmentKind = AstFragmentKind::ExprFields;
     fn to_annotatable(self) -> Annotatable {
-        Annotatable::ExprField(self)
+        Annotatable::ExprField(Box::new(self))
     }
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_expr_fields()
@@ -1671,7 +1671,7 @@ impl InvocationCollectorNode for ast::ExprField {
 impl InvocationCollectorNode for ast::Param {
     const KIND: AstFragmentKind = AstFragmentKind::Params;
     fn to_annotatable(self) -> Annotatable {
-        Annotatable::Param(self)
+        Annotatable::Param(Box::new(self))
     }
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_params()
@@ -1684,7 +1684,7 @@ impl InvocationCollectorNode for ast::Param {
 impl InvocationCollectorNode for ast::GenericParam {
     const KIND: AstFragmentKind = AstFragmentKind::GenericParams;
     fn to_annotatable(self) -> Annotatable {
-        Annotatable::GenericParam(self)
+        Annotatable::GenericParam(Box::new(self))
     }
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_generic_params()
@@ -1697,7 +1697,7 @@ impl InvocationCollectorNode for ast::GenericParam {
 impl InvocationCollectorNode for ast::Arm {
     const KIND: AstFragmentKind = AstFragmentKind::Arms;
     fn to_annotatable(self) -> Annotatable {
-        Annotatable::Arm(self)
+        Annotatable::Arm(Box::new(self))
     }
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_arms()
@@ -1781,10 +1781,10 @@ impl InvocationCollectorNode for ast::Stmt {
 }
 
 impl InvocationCollectorNode for ast::Crate {
-    type OutputTy = ast::Crate;
+    type OutputTy = Box<ast::Crate>;
     const KIND: AstFragmentKind = AstFragmentKind::Crate;
     fn to_annotatable(self) -> Annotatable {
-        Annotatable::Crate(self)
+        Annotatable::Crate(Box::new(self))
     }
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_crate()

--- a/compiler/rustc_expand/src/placeholders.rs
+++ b/compiler/rustc_expand/src/placeholders.rs
@@ -55,13 +55,13 @@ pub(crate) fn placeholder(
     };
 
     match kind {
-        AstFragmentKind::Crate => AstFragment::Crate(ast::Crate {
+        AstFragmentKind::Crate => AstFragment::Crate(Box::new(ast::Crate {
             attrs: Default::default(),
             items: Default::default(),
             spans: ast::ModSpans { inner_span: span, ..Default::default() },
             id,
             is_placeholder: true,
-        }),
+        })),
         AstFragmentKind::Expr => AstFragment::Expr(expr_placeholder()),
         AstFragmentKind::OptExpr => AstFragment::OptExpr(Some(expr_placeholder())),
         AstFragmentKind::MethodReceiverExpr => AstFragment::MethodReceiverExpr(expr_placeholder()),
@@ -428,7 +428,7 @@ impl MutVisitor for PlaceholderExpander {
 
     fn visit_crate(&mut self, krate: &mut ast::Crate) {
         if krate.is_placeholder {
-            *krate = self.remove(krate.id).make_crate();
+            *krate = *self.remove(krate.id).make_crate();
         } else {
             walk_crate(self, krate)
         }

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -130,16 +130,16 @@ impl LintStoreExpand for LintStoreExpandImpl<'_> {
 /// standard library and prelude, and name resolution.
 #[instrument(level = "trace", skip(krate, resolver))]
 fn configure_and_expand(
-    mut krate: ast::Crate,
+    mut krate: Box<ast::Crate>,
     pre_configured_attrs: &[ast::Attribute],
     resolver: &mut Resolver<'_, '_>,
-) -> ast::Crate {
+) -> Box<ast::Crate> {
     let tcx = resolver.tcx();
     let sess = tcx.sess;
     let features = tcx.features();
     let lint_store = unerased_lint_store(tcx.sess);
     let crate_name = tcx.crate_name(LOCAL_CRATE);
-    let lint_check_node = (&krate, pre_configured_attrs);
+    let lint_check_node = (&*krate, pre_configured_attrs);
     pre_expansion_lint(
         sess,
         features,
@@ -785,6 +785,7 @@ fn resolver_for_lowering_raw<'tcx>(
     let arenas = Resolver::arenas();
     let _ = tcx.registered_tools(()); // Uses `crate_for_resolver`.
     let (krate, pre_configured_attrs) = tcx.crate_for_resolver(()).steal();
+    let krate = Box::new(krate);
     let mut resolver = Resolver::new(
         tcx,
         &pre_configured_attrs,
@@ -792,7 +793,7 @@ fn resolver_for_lowering_raw<'tcx>(
         krate.spans.inject_use_span,
         &arenas,
     );
-    let krate = configure_and_expand(krate, &pre_configured_attrs, &mut resolver);
+    let krate = Arc::new(*configure_and_expand(krate, &pre_configured_attrs, &mut resolver));
 
     // Make sure we don't mutate the cstore from here on.
     tcx.untracked().cstore.freeze();
@@ -803,7 +804,7 @@ fn resolver_for_lowering_raw<'tcx>(
     } = resolver.into_outputs();
 
     let resolutions = tcx.arena.alloc(untracked_resolutions);
-    (tcx.arena.alloc(Steal::new((untracked_resolver_for_lowering, Arc::new(krate)))), resolutions)
+    (tcx.arena.alloc(Steal::new((untracked_resolver_for_lowering, krate))), resolutions)
 }
 
 pub fn write_dep_info(tcx: TyCtxt<'_>) {


### PR DESCRIPTION
This shrinks `Invocation` from 224 to 128 bytes, reducing memcopies in a local test.