### PR TITLE
Add const_generics_assoc_consts gate for assoc const projections in const args

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -60,7 +60,7 @@ use rustc_index::{Idx, IndexSlice, IndexVec};
 use rustc_macros::extension;
 use rustc_middle::span_bug;
 use rustc_middle::ty::{ResolverAstLowering, TyCtxt};
-use rustc_session::parse::add_feature_diagnostics;
+use rustc_session::parse::{add_feature_diagnostics, feature_err};
 use rustc_span::symbol::{Ident, Symbol, kw, sym};
 use rustc_span::{DUMMY_SP, DesugaringKind, Span};
 use smallvec::SmallVec;
@@ -2449,6 +2449,26 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 ConstArg { hir_id: self.next_id(), kind: hir::ConstArgKind::Tup(exprs), span }
             }
             ExprKind::Path(qself, path) => {
+                if let Some(qself) = qself
+                    && path.segments.len() >= 2
+                    && matches!(qself.ty.kind, TyKind::Path(None, _))
+                    && self
+                        .resolver
+                        .get_partial_res(qself.ty.id)
+                        .and_then(|partial_res| partial_res.full_res())
+                        .is_some_and(|res| matches!(res, Res::Def(DefKind::TyParam, _)))
+                    && !self.tcx.features().const_generics_assoc_consts()
+                {
+                    let err = feature_err(
+                        self.tcx.sess,
+                        sym::const_generics_assoc_consts,
+                        expr.span,
+                        "associated const projections in const arguments are experimental",
+                    )
+                    .emit();
+                    return ConstArg { hir_id: self.next_id(), kind: hir::ConstArgKind::Error(err), span };
+                }
+
                 let qpath = self.lower_qpath(
                     expr.id,
                     qself,

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -422,6 +422,8 @@ declare_features! (
     (unstable, const_destruct, "1.85.0", Some(133214)),
     /// Allows `for _ in _` loops in const contexts.
     (unstable, const_for, "1.56.0", Some(87575)),
+    /// Allows associated const projections from type parameters in const-generic arguments.
+    (incomplete, const_generics_assoc_consts, "CURRENT_RUSTC_VERSION", None),
     /// Be more precise when looking for live drops in a const context.
     (unstable, const_precise_live_drops, "1.46.0", Some(73255)),
     /// Allows `impl const Trait for T` syntax.

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -766,6 +766,7 @@ symbols! {
         const_for,
         const_format_args,
         const_generics,
+        const_generics_assoc_consts,
         const_generics_defaults,
         const_if_match,
         const_impl_trait,

--- a/tests/ui/const-generics/assoc-const-projection/feature-gate-c1-inherent.rs
+++ b/tests/ui/const-generics/assoc-const-projection/feature-gate-c1-inherent.rs
@@ -1,0 +1,12 @@
+//@ check-pass
+
+struct Foo;
+impl Foo {
+    const N: usize = 4;
+}
+
+struct S([u8; Foo::N]);
+
+fn main() {
+    let _ = S([0; Foo::N]);
+}

--- a/tests/ui/const-generics/assoc-const-projection/feature-gate-c1-with-gate.rs
+++ b/tests/ui/const-generics/assoc-const-projection/feature-gate-c1-with-gate.rs
@@ -1,0 +1,18 @@
+//@ check-pass
+#![feature(min_generic_const_args)]
+#![feature(const_generics_assoc_consts)]
+#![allow(incomplete_features)]
+
+trait HasLen {
+    type const N: usize;
+}
+
+impl<T> HasLen for T {
+    type const N: usize = 4;
+}
+
+struct Buf<T: HasLen>([u8; { <T as HasLen>::N }]);
+
+fn main() {
+    let _ = Buf::<u8>([0; 4]);
+}

--- a/tests/ui/const-generics/assoc-const-projection/feature-gate-c1-without-gate.rs
+++ b/tests/ui/const-generics/assoc-const-projection/feature-gate-c1-without-gate.rs
@@ -1,0 +1,17 @@
+#![feature(min_generic_const_args)]
+#![allow(incomplete_features)]
+
+trait HasLen {
+    type const N: usize;
+}
+
+impl<T> HasLen for T {
+    type const N: usize = 4;
+}
+
+struct Buf<T: HasLen>([u8; { <T as HasLen>::N }]);
+//~^ ERROR associated const projections in const arguments are experimental
+
+fn main() {
+    let _ = Buf::<u8>([0; 4]);
+}

--- a/tests/ui/const-generics/assoc-const-projection/feature-gate-c1-without-gate.stderr
+++ b/tests/ui/const-generics/assoc-const-projection/feature-gate-c1-without-gate.stderr
@@ -1,0 +1,12 @@
+error[E0658]: associated const projections in const arguments are experimental
+  --> $DIR/feature-gate-c1-without-gate.rs:12:30
+   |
+LL | struct Buf<T: HasLen>([u8; { <T as HasLen>::N }]);
+   |                              ^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(const_generics_assoc_consts)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
## Summary
- add new language feature gate symbol `const_generics_assoc_consts`
- declare the feature in `rustc_feature`
- gate type-parameter associated const projections used in const-generic arguments during AST lowering
- add UI tests for with-gate / without-gate / inherent-const regression

## Testing
- `./x test tests/ui/const-generics/assoc-const-projection/feature-gate-c1-with-gate.rs`
- `./x test tests/ui/const-generics/assoc-const-projection/feature-gate-c1-inherent.rs`
- `./x test tests/ui/const-generics/assoc-const-projection/feature-gate-c1-without-gate.rs`
- `./x test tests/ui/const-generics/assoc-const-projection`
