### PR TITLE
Add optional json logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5752,6 +5752,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5762,12 +5772,15 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/compiler/rustc_log/Cargo.toml
+++ b/compiler/rustc_log/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 # tidy-alphabetical-start
 tracing = "0.1.41"
 tracing-core = "0.1.34"
-tracing-subscriber = { version = "0.3.3", default-features = false, features = ["fmt", "env-filter", "smallvec", "parking_lot", "ansi"] }
+tracing-subscriber = { version = "0.3.3", default-features = false, features = ["fmt", "env-filter", "smallvec", "parking_lot", "ansi", "json"] }
 tracing-tree = "0.3.1"
 # tidy-alphabetical-end
 

--- a/compiler/rustc_log/src/lib.rs
+++ b/compiler/rustc_log/src/lib.rs
@@ -66,6 +66,7 @@ pub struct LoggerConfig {
 
 impl LoggerConfig {
     pub fn from_env(env: &str) -> Self {
+        // NOTE: documented in the dev guide. If you change this, also update it!
         LoggerConfig {
             filter: env::var(env),
             color_logs: env::var(format!("{env}_COLOR")),

--- a/src/doc/rustc-dev-guide/src/tracing.md
+++ b/src/doc/rustc-dev-guide/src/tracing.md
@@ -12,6 +12,25 @@ To see the logs, you need to set the `RUSTC_LOG` environment variable to your lo
 The full syntax of the log filters can be found in the [rustdoc
 of `tracing-subscriber`](https://docs.rs/tracing-subscriber/0.2.24/tracing_subscriber/filter/struct.EnvFilter.html#directives).
 
+## Environment variables
+
+This is an overview of the environment variables rustc accepts to customize
+its tracing output. The definition of these can mostly be found in `compiler/rustc_log/src/lib.rs`.
+
+|  Name                     | Usage                                                                                                                   |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `RUSTC_LOG`               | Tracing filters (see the rest of this page)                                                                             |
+| `RUSTC_LOG_COLOR`         | `always`, `never` or `auto`.                                                                                            |
+| `RUSTC_LOG_ENTRY_EXIT`    | if set and not '0', log span entry/exit.                                                                                |
+| `RUSTC_LOG_THREAD_IDS`    | if set and equal to '1', also log thread ids.                                                                           |
+| `RUSTC_LOG_BACKTRACE`     | Capture and print a backtrace if a trace is emitted with a target that matches the provided string value.               |
+| `RUSTC_LOG_LINES`         | If `1`, indents log lines based on depth.                                                                               |
+| `RUSTC_LOG_FORMAT_JSON`   | If `1`, outputs logs as JSON. The exact parameters can be found in `rustc_log/src/lib.rs` but the format is *UNSTABLE*. |
+| `RUSTC_LOG_OUTPUT_TARGET` | If provided, logs go to the provided file name instead of stderr.                                                       |
+
+
+
+
 ## Function level filters
 
 Lots of functions in rustc are annotated with

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -450,6 +450,7 @@ const PERMITTED_RUSTC_DEPENDENCIES: &[&str] = &[
     "tracing-attributes",
     "tracing-core",
     "tracing-log",
+    "tracing-serde",
     "tracing-subscriber",
     "tracing-tree",
     "twox-hash",


### PR DESCRIPTION
I became slightly frustrated with rust's logging output, and wanted to experiment a little with slightly postprocessing it with custom scripts. I think this is a pretty uninteresting change otherwise, shouldn't affect anyone else nor bother anyone. It's small enough that we can remove it again, nor is any of this stable or expected to be.

r? @jieyouxu 