### PR TITLE
compiletest: standardize bool-like env var handling

### DIFF
--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -1175,7 +1175,7 @@ fn ignore_llvm(config: &Config, line: &DirectiveLine<'_>) -> IgnoreDecision {
             .split_whitespace()
             .find(|needed_component| !components.contains(needed_component))
         {
-            if env::var_os("COMPILETEST_REQUIRE_ALL_LLVM_COMPONENTS").is_some() {
+            if crate::util::env_var_is_set("COMPILETEST_REQUIRE_ALL_LLVM_COMPONENTS") {
                 panic!(
                     "missing LLVM component {missing_component}, \
                     and COMPILETEST_REQUIRE_ALL_LLVM_COMPONENTS is set: {path}",

--- a/src/tools/compiletest/src/directives/cfg.rs
+++ b/src/tools/compiletest/src/directives/cfg.rs
@@ -248,7 +248,7 @@ pub(crate) fn prepare_conditions(config: &Config) -> PreparedConditions {
     // flag, not an environment variable.
     builder.cond(
         "dist",
-        std::env::var("COMPILETEST_ENABLE_DIST_TESTS").as_deref() == Ok("1"),
+        crate::util::env_var_is_set("COMPILETEST_ENABLE_DIST_TESTS"),
         "when performing tests on dist toolchain",
     );
 

--- a/src/tools/compiletest/src/directives/needs.rs
+++ b/src/tools/compiletest/src/directives/needs.rs
@@ -353,7 +353,7 @@ impl CachedNeedsConditions {
         let target = &&*config.target;
         let sanitizers = &config.target_cfg().sanitizers;
         Self {
-            sanitizer_support: std::env::var_os("RUSTC_SANITIZER_SUPPORT").is_some(),
+            sanitizer_support: crate::util::env_var_is_set("RUSTC_SANITIZER_SUPPORT"),
             sanitizer_address: sanitizers.contains(&Sanitizer::Address),
             sanitizer_cfi: sanitizers.contains(&Sanitizer::Cfi),
             sanitizer_dataflow: sanitizers.contains(&Sanitizer::Dataflow),
@@ -424,7 +424,7 @@ fn find_dlltool(config: &Config) -> bool {
 // not available.
 #[cfg(windows)]
 fn has_symlinks() -> bool {
-    if std::env::var_os("CI").is_some() {
+    if crate::util::env_var_is_set("CI") {
         return true;
     }
     let link = std::env::temp_dir().join("RUST_COMPILETEST_SYMLINK_CHECK");

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -372,7 +372,7 @@ fn parse_config(args: Vec<String>) -> Config {
     Config {
         bless: matches.opt_present("bless"),
         fail_fast: matches.opt_present("fail-fast")
-            || env::var_os("RUSTC_TEST_FAIL_FAST").is_some(),
+            || crate::util::env_var_is_set("RUSTC_TEST_FAIL_FAST"),
 
         host_compile_lib_path: make_absolute(opt_path(matches, "compile-lib-path")),
         target_run_lib_path: make_absolute(opt_path(matches, "run-lib-path")),
@@ -1145,7 +1145,7 @@ fn early_config_check(config: &Config) {
     }
 
     // `RUST_TEST_NOCAPTURE` is a libtest env var, but we don't callout to libtest.
-    if env::var("RUST_TEST_NOCAPTURE").is_ok() {
+    if crate::util::env_var_is_set("RUST_TEST_NOCAPTURE") {
         warning!("`RUST_TEST_NOCAPTURE` is not supported; use the `--no-capture` flag instead");
     }
 }

--- a/src/tools/compiletest/src/runtest/crashes.rs
+++ b/src/tools/compiletest/src/runtest/crashes.rs
@@ -5,7 +5,7 @@ impl TestCx<'_> {
         let pm = self.pass_mode();
         let proc_res = self.compile_test(WillExecute::No, self.should_emit_metadata(pm));
 
-        if std::env::var("COMPILETEST_VERBOSE_CRASHES").is_ok() {
+        if crate::util::env_var_is_set("COMPILETEST_VERBOSE_CRASHES") {
             writeln!(self.stderr, "{}", proc_res.status);
             writeln!(self.stderr, "{}", proc_res.stdout);
             writeln!(self.stderr, "{}", proc_res.stderr);

--- a/src/tools/compiletest/src/util.rs
+++ b/src/tools/compiletest/src/util.rs
@@ -6,6 +6,24 @@ use camino::{Utf8Path, Utf8PathBuf};
 #[cfg(test)]
 mod tests;
 
+/// Returns `true` if the named environment variable is set to a non-empty value.
+///
+/// This provides consistent handling of "bool-like" environment variables:
+/// any non-empty value is truthy, and an unset or empty value is falsey.
+///
+/// # Panics
+///
+/// Panics if the environment variable's value contains invalid UTF-8.
+pub fn env_var_is_set(name: &str) -> bool {
+    match env::var(name) {
+        Ok(val) => !val.is_empty(),
+        Err(env::VarError::NotPresent) => false,
+        Err(env::VarError::NotUnicode(val)) => {
+            panic!("environment variable `{name}` contains invalid UTF-8: {val:?}");
+        }
+    }
+}
+
 pub fn make_new_path(path: &str) -> String {
     assert!(cfg!(windows));
     // Windows just uses PATH as the library search path, so we have to

--- a/src/tools/compiletest/src/util/tests.rs
+++ b/src/tools/compiletest/src/util/tests.rs
@@ -12,3 +12,29 @@ fn path_buf_with_extra_extension_test() {
     );
     assert_eq!(Utf8PathBuf::from("foo.rs"), Utf8PathBuf::from("foo.rs").with_extra_extension(""));
 }
+
+#[test]
+fn env_var_is_set_returns_true_for_non_empty_value() {
+    let name = "COMPILETEST_TEST_ENV_VAR_IS_SET_TRUE";
+    // SAFETY: test-only, not running concurrent tests that depend on this var.
+    unsafe { std::env::set_var(name, "1") };
+    assert!(env_var_is_set(name));
+    unsafe { std::env::remove_var(name) };
+}
+
+#[test]
+fn env_var_is_set_returns_false_when_unset() {
+    let name = "COMPILETEST_TEST_ENV_VAR_IS_SET_UNSET";
+    // SAFETY: test-only, not running concurrent tests that depend on this var.
+    unsafe { std::env::remove_var(name) };
+    assert!(!env_var_is_set(name));
+}
+
+#[test]
+fn env_var_is_set_returns_false_for_empty_value() {
+    let name = "COMPILETEST_TEST_ENV_VAR_IS_SET_EMPTY";
+    // SAFETY: test-only, not running concurrent tests that depend on this var.
+    unsafe { std::env::set_var(name, "") };
+    assert!(!env_var_is_set(name));
+    unsafe { std::env::remove_var(name) };
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
Fixes rust-lang/rust#125895

r? @jieyouxu
<!-- homu-ignore:end -->

## Summary

Adds a `env_var_is_set()` utility function to replace the inconsistent mix of patterns used to check bool-like environment variables across compiletest:

| Before | After |
|--------|-------|
| `env::var_os("X").is_some()` | `env_var_is_set("X")` |
| `env::var("X").is_ok()` | `env_var_is_set("X")` |
| `env::var("X").as_deref() == Ok("1")` | `env_var_is_set("X")` |

The new helper:
- **Panics on invalid UTF-8** instead of silently treating it as truthy/falsey
- **Uniform semantics**: any non-empty value → `true`, unset or empty → `false`

## Env vars migrated

| Variable | Previous pattern | File |
|----------|-----------------|------|
| `RUSTC_TEST_FAIL_FAST` | `.is_some()` | `lib.rs` |
| `RUST_TEST_NOCAPTURE` | `.is_ok()` | `lib.rs` |
| `COMPILETEST_VERBOSE_CRASHES` | `.is_ok()` | `runtest/crashes.rs` |
| `RUSTC_SANITIZER_SUPPORT` | `.is_some()` | `directives/needs.rs` |
| `CI` | `.is_some()` | `directives/needs.rs` |
| `COMPILETEST_REQUIRE_ALL_LLVM_COMPONENTS` | `.is_some()` | `directives.rs` |
| `COMPILETEST_ENABLE_DIST_TESTS` | `== Ok("1")` | `directives/cfg.rs` |

`NO_COLOR` and `RUST_VXWORKS_TEST_DYLINK` are left unchanged as they have value-specific semantics (not simple booleans).

## Test plan

- [x] `x.py check compiletest` passes
- [x] `x.py test src/tools/compiletest` — all 85 tests pass (3 new)
- [x] `x.py fmt --check` passes

---
🤖 Generated with Claude Code (issue-hunter-pro)