### PR TITLE
Make `const_lit_matches_ty` check literal suffixes for exact type match

### DIFF
--- a/compiler/rustc_middle/src/ty/consts/lit.rs
+++ b/compiler/rustc_middle/src/ty/consts/lit.rs
@@ -1,4 +1,4 @@
-use rustc_ast::LitKind;
+use rustc_ast::{LitFloatType, LitIntType, LitKind};
 use rustc_hir;
 use rustc_macros::HashStable;
 
@@ -44,10 +44,17 @@ pub fn const_lit_matches_ty<'tcx>(
         {
             true
         }
-        (LitKind::Int(..), ty::Uint(_)) if !neg => true,
-        (LitKind::Int(..), ty::Int(_)) => true,
+        (LitKind::Int(_, LitIntType::Unsigned(lit_ty)), ty::Uint(expect_ty)) if !neg => {
+            lit_ty == *expect_ty
+        }
+        (LitKind::Int(_, LitIntType::Signed(lit_ty)), ty::Int(expect_ty)) => lit_ty == *expect_ty,
+        (LitKind::Int(_, LitIntType::Unsuffixed), ty::Uint(_)) if !neg => true,
+        (LitKind::Int(_, LitIntType::Unsuffixed), ty::Int(_)) => true,
         (LitKind::Bool(..), ty::Bool) => true,
-        (LitKind::Float(..), ty::Float(_)) => true,
+        (LitKind::Float(_, LitFloatType::Suffixed(lit_ty)), ty::Float(expect_ty)) => {
+            lit_ty == *expect_ty
+        }
+        (LitKind::Float(_, LitFloatType::Unsuffixed), ty::Float(_)) => true,
         (LitKind::Char(..), ty::Char) => true,
         (LitKind::Err(..), _) => true,
         _ => false,

--- a/tests/ui/const-generics/mgca/const-arg-mismatched-literal-suffix.rs
+++ b/tests/ui/const-generics/mgca/const-arg-mismatched-literal-suffix.rs
@@ -1,0 +1,10 @@
+#![feature(min_generic_const_args)]
+#![expect(incomplete_features)]
+
+type const CONST: usize = 1_i32;
+//~^ ERROR the constant `1` is not of type `usize`
+//~| NOTE expected `usize`, found `i32`
+
+fn main() {
+    const { CONST };
+}

--- a/tests/ui/const-generics/mgca/const-arg-mismatched-literal-suffix.stderr
+++ b/tests/ui/const-generics/mgca/const-arg-mismatched-literal-suffix.stderr
@@ -1,0 +1,8 @@
+error: the constant `1` is not of type `usize`
+  --> $DIR/const-arg-mismatched-literal-suffix.rs:4:1
+   |
+LL | type const CONST: usize = 1_i32;
+   | ^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `i32`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/const-generics/type-dependent/type-mismatch.full.stderr
+++ b/tests/ui/const-generics/type-dependent/type-mismatch.full.stderr
@@ -1,15 +1,3 @@
-error: the constant `1` is not of type `u8`
-  --> $DIR/type-mismatch.rs:8:27
-   |
-LL |     assert_eq!(R.method::<1u16>(), 1);
-   |                           ^^^^ expected `u8`, found `u16`
-   |
-note: required by a const generic parameter in `R::method`
-  --> $DIR/type-mismatch.rs:5:15
-   |
-LL |     fn method<const N: u8>(&self) -> u8 { N }
-   |               ^^^^^^^^^^^ required by this const generic parameter in `R::method`
-
 error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:8:27
    |
@@ -22,6 +10,6 @@ LL -     assert_eq!(R.method::<1u16>(), 1);
 LL +     assert_eq!(R.method::<1u8>(), 1);
    |
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/type-dependent/type-mismatch.min.stderr
+++ b/tests/ui/const-generics/type-dependent/type-mismatch.min.stderr
@@ -1,15 +1,3 @@
-error: the constant `1` is not of type `u8`
-  --> $DIR/type-mismatch.rs:8:27
-   |
-LL |     assert_eq!(R.method::<1u16>(), 1);
-   |                           ^^^^ expected `u8`, found `u16`
-   |
-note: required by a const generic parameter in `R::method`
-  --> $DIR/type-mismatch.rs:5:15
-   |
-LL |     fn method<const N: u8>(&self) -> u8 { N }
-   |               ^^^^^^^^^^^ required by this const generic parameter in `R::method`
-
 error[E0308]: mismatched types
   --> $DIR/type-mismatch.rs:8:27
    |
@@ -22,6 +10,6 @@ LL -     assert_eq!(R.method::<1u16>(), 1);
 LL +     assert_eq!(R.method::<1u8>(), 1);
    |
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/type-dependent/type-mismatch.rs
+++ b/tests/ui/const-generics/type-dependent/type-mismatch.rs
@@ -6,6 +6,5 @@ impl R {
 }
 fn main() {
     assert_eq!(R.method::<1u16>(), 1);
-    //~^ ERROR the constant `1` is not of type `u8`
-    //~| ERROR mismatched types
+    //~^ ERROR mismatched types
 }

--- a/tests/ui/consts/const-eval/array-len-mismatch-type.rs
+++ b/tests/ui/consts/const-eval/array-len-mismatch-type.rs
@@ -1,8 +1,5 @@
 //! Regression test for <https://github.com/rust-lang/rust/issues/133966>
 pub struct Data([[&'static str]; 5_i32]);
-//~^ ERROR the constant `5` is not of type `usize`
-//~| ERROR the size for values of type `[&'static str]` cannot be known at compilation time
-//~| ERROR mismatched types
+//~^ ERROR mismatched types
 const _: &'static Data = unsafe { &*(&[] as *const Data) };
-//~^ ERROR the type `[[&str]; 5]` has an unknown layout
 fn main() {}

--- a/tests/ui/consts/const-eval/array-len-mismatch-type.stderr
+++ b/tests/ui/consts/const-eval/array-len-mismatch-type.stderr
@@ -1,26 +1,3 @@
-error: the constant `5` is not of type `usize`
-  --> $DIR/array-len-mismatch-type.rs:2:17
-   |
-LL | pub struct Data([[&'static str]; 5_i32]);
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `i32`
-   |
-   = note: the length of array `[[&'static str]; 5]` must be type `usize`
-
-error[E0277]: the size for values of type `[&'static str]` cannot be known at compilation time
-  --> $DIR/array-len-mismatch-type.rs:2:17
-   |
-LL | pub struct Data([[&'static str]; 5_i32]);
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[&'static str]`
-   = note: slice and array elements must have `Sized` type
-
-error[E0080]: the type `[[&str]; 5]` has an unknown layout
-  --> $DIR/array-len-mismatch-type.rs:6:39
-   |
-LL | const _: &'static Data = unsafe { &*(&[] as *const Data) };
-   |                                       ^^ evaluation of `_` failed here
-
 error[E0308]: mismatched types
   --> $DIR/array-len-mismatch-type.rs:2:34
    |
@@ -33,7 +10,6 @@ LL - pub struct Data([[&'static str]; 5_i32]);
 LL + pub struct Data([[&'static str]; 5_usize]);
    |
 
-error: aborting due to 4 previous errors
+error: aborting due to 1 previous error
 
-Some errors have detailed explanations: E0080, E0277, E0308.
-For more information about an error, try `rustc --explain E0080`.
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/repeat-expr/repeat_count.rs
+++ b/tests/ui/repeat-expr/repeat_count.rs
@@ -27,10 +27,7 @@ fn main() {
     //~| NOTE expected `usize`, found `isize`
     //~| NOTE `-1_isize` cannot fit into type `usize`
     let h = [0; 4u8];
-    //~^ ERROR the constant `4` is not of type `usize`
-    //~| NOTE expected `usize`, found `u8`
-    //~| NOTE the length of array `[{integer}; 4]` must be type `usize`
-    //~| ERROR mismatched types
+    //~^ ERROR mismatched types
     //~| NOTE expected `usize`, found `u8`
     struct I {
         i: (),

--- a/tests/ui/repeat-expr/repeat_count.stderr
+++ b/tests/ui/repeat-expr/repeat_count.stderr
@@ -50,20 +50,6 @@ LL |     let g = [0_usize; -1_isize];
    |
    = note: `-1_isize` cannot fit into type `usize`
 
-error: the constant `4` is not of type `usize`
-  --> $DIR/repeat_count.rs:29:13
-   |
-LL |     let h = [0; 4u8];
-   |             ^^^^^^^^ expected `usize`, found `u8`
-   |
-   = note: the length of array `[{integer}; 4]` must be type `usize`
-
-error[E0308]: mismatched types
-  --> $DIR/repeat_count.rs:38:17
-   |
-LL |     let i = [0; I { i: () }];
-   |                 ^^^^^^^^^^^ expected `usize`, found `I`
-
 error[E0308]: mismatched types
   --> $DIR/repeat_count.rs:29:17
    |
@@ -76,7 +62,13 @@ LL -     let h = [0; 4u8];
 LL +     let h = [0; 4usize];
    |
 
-error: aborting due to 10 previous errors
+error[E0308]: mismatched types
+  --> $DIR/repeat_count.rs:35:17
+   |
+LL |     let i = [0; I { i: () }];
+   |                 ^^^^^^^^^^^ expected `usize`, found `I`
+
+error: aborting due to 9 previous errors
 
 Some errors have detailed explanations: E0308, E0435.
 For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/152906)*
<!-- homu-ignore:end -->

`const_lit_matches_ty` ignored literal suffixes. This let the `try_lower_anon_const_lit` fast path produce a mistyped `ty::Const::Value`, bypassing the type mismatch error that typeck would otherwise report.