### PR TITLE
Add tests for delegation generics

### DIFF
--- a/tests/ui/delegation/generics/generic-params-defaults.rs
+++ b/tests/ui/delegation/generics/generic-params-defaults.rs
@@ -1,0 +1,14 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+trait Trait<'a, 'b, 'c, A = usize, B = u32, C = String, const N: usize = 123> {
+    fn foo<T = usize>(&self) {
+        //~^ ERROR: defaults for generic parameters are not allowed here
+        //~| WARN: this was previously accepted by the compiler but is being phased out
+    }
+}
+
+reuse Trait::foo;
+//~^ ERROR: type annotations needed
+
+fn main() {}

--- a/tests/ui/delegation/generics/generic-params-defaults.stderr
+++ b/tests/ui/delegation/generics/generic-params-defaults.stderr
@@ -1,0 +1,35 @@
+error: defaults for generic parameters are not allowed here
+  --> $DIR/generic-params-defaults.rs:5:12
+   |
+LL |     fn foo<T = usize>(&self) {
+   |            ^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>
+   = note: `#[deny(invalid_type_param_default)]` (part of `#[deny(future_incompatible)]`) on by default
+
+error[E0282]: type annotations needed
+  --> $DIR/generic-params-defaults.rs:11:14
+   |
+LL | reuse Trait::foo;
+   |              ^^^ cannot infer type of the type parameter `T` declared on the method `foo`
+   |
+help: consider specifying the generic argument
+   |
+LL | reuse Trait::foo::<T>;
+   |                 +++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0282`.
+Future incompatibility report: Future breakage diagnostic:
+error: defaults for generic parameters are not allowed here
+  --> $DIR/generic-params-defaults.rs:5:12
+   |
+LL |     fn foo<T = usize>(&self) {
+   |            ^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>
+   = note: `#[deny(invalid_type_param_default)]` (part of `#[deny(future_incompatible)]`) on by default
+

--- a/tests/ui/delegation/generics/generic-params-same-names.rs
+++ b/tests/ui/delegation/generics/generic-params-same-names.rs
@@ -1,0 +1,19 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+trait Trait<'a, 'b, 'c, A, B, C, const N: usize> {
+    fn foo<'a, 'b, 'c, A, B, C, const N: usize>(&self) {
+        //~^ ERROR: lifetime name `'a` shadows a lifetime name that is already in scope
+        //~| ERROR: lifetime name `'b` shadows a lifetime name that is already in scope
+        //~| ERROR: lifetime name `'c` shadows a lifetime name that is already in scope
+        //~| ERROR: the name `A` is already used for a generic parameter in this item's generic parameters
+        //~| ERROR: the name `B` is already used for a generic parameter in this item's generic parameters
+        //~| ERROR: the name `C` is already used for a generic parameter in this item's generic parameters
+        //~| ERROR: the name `N` is already used for a generic parameter in this item's generic parameters
+    }
+}
+
+reuse Trait::foo;
+//~^ ERROR: type annotations needed
+
+fn main() {}

--- a/tests/ui/delegation/generics/generic-params-same-names.stderr
+++ b/tests/ui/delegation/generics/generic-params-same-names.stderr
@@ -1,0 +1,76 @@
+error[E0496]: lifetime name `'a` shadows a lifetime name that is already in scope
+  --> $DIR/generic-params-same-names.rs:5:12
+   |
+LL | trait Trait<'a, 'b, 'c, A, B, C, const N: usize> {
+   |             -- first declared here
+LL |     fn foo<'a, 'b, 'c, A, B, C, const N: usize>(&self) {
+   |            ^^ lifetime `'a` already in scope
+
+error[E0496]: lifetime name `'b` shadows a lifetime name that is already in scope
+  --> $DIR/generic-params-same-names.rs:5:16
+   |
+LL | trait Trait<'a, 'b, 'c, A, B, C, const N: usize> {
+   |                 -- first declared here
+LL |     fn foo<'a, 'b, 'c, A, B, C, const N: usize>(&self) {
+   |                ^^ lifetime `'b` already in scope
+
+error[E0496]: lifetime name `'c` shadows a lifetime name that is already in scope
+  --> $DIR/generic-params-same-names.rs:5:20
+   |
+LL | trait Trait<'a, 'b, 'c, A, B, C, const N: usize> {
+   |                     -- first declared here
+LL |     fn foo<'a, 'b, 'c, A, B, C, const N: usize>(&self) {
+   |                    ^^ lifetime `'c` already in scope
+
+error[E0403]: the name `A` is already used for a generic parameter in this item's generic parameters
+  --> $DIR/generic-params-same-names.rs:5:24
+   |
+LL | trait Trait<'a, 'b, 'c, A, B, C, const N: usize> {
+   |                         - first use of `A`
+LL |     fn foo<'a, 'b, 'c, A, B, C, const N: usize>(&self) {
+   |                        ^ already used
+
+error[E0403]: the name `B` is already used for a generic parameter in this item's generic parameters
+  --> $DIR/generic-params-same-names.rs:5:27
+   |
+LL | trait Trait<'a, 'b, 'c, A, B, C, const N: usize> {
+   |                            - first use of `B`
+LL |     fn foo<'a, 'b, 'c, A, B, C, const N: usize>(&self) {
+   |                           ^ already used
+
+error[E0403]: the name `C` is already used for a generic parameter in this item's generic parameters
+  --> $DIR/generic-params-same-names.rs:5:30
+   |
+LL | trait Trait<'a, 'b, 'c, A, B, C, const N: usize> {
+   |                               - first use of `C`
+LL |     fn foo<'a, 'b, 'c, A, B, C, const N: usize>(&self) {
+   |                              ^ already used
+
+error[E0403]: the name `N` is already used for a generic parameter in this item's generic parameters
+  --> $DIR/generic-params-same-names.rs:5:39
+   |
+LL | trait Trait<'a, 'b, 'c, A, B, C, const N: usize> {
+   |                                        - first use of `N`
+LL |     fn foo<'a, 'b, 'c, A, B, C, const N: usize>(&self) {
+   |                                       ^ already used
+
+error[E0284]: type annotations needed
+  --> $DIR/generic-params-same-names.rs:16:14
+   |
+LL | reuse Trait::foo;
+   |              ^^^ cannot infer the value of the const parameter `N` declared on the method `foo`
+   |
+note: required by a const generic parameter in `Trait::foo`
+  --> $DIR/generic-params-same-names.rs:5:33
+   |
+LL |     fn foo<'a, 'b, 'c, A, B, C, const N: usize>(&self) {
+   |                                 ^^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+help: consider specifying the generic arguments
+   |
+LL | reuse Trait::foo::<A, B, C, N>;
+   |                 ++++++++++++++
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0284, E0403, E0496.
+For more information about an error, try `rustc --explain E0284`.

--- a/tests/ui/delegation/generics/generics-gen-args-errors.rs
+++ b/tests/ui/delegation/generics/generics-gen-args-errors.rs
@@ -1,0 +1,114 @@
+//@ compile-flags: -Z deduplicate-diagnostics=yes
+
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+mod test_1 {
+    fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+    reuse foo as bar;
+    //~^ ERROR: type annotations needed
+
+    fn check<A, B, C>() {
+        bar::<1, 2, 3, 4, 5, 6>();
+        //~^ ERROR: function takes 3 generic arguments but 6 generic arguments were supplied
+
+        bar::<String, String, { String }>();
+        //~^ ERROR: expected value, found struct `String` [E0423]
+
+        bar::<'static, 'static, 'static, 'static, 'static>();
+        //~^ ERROR: function takes 2 lifetime arguments but 5 lifetime arguments were supplied
+
+        bar::<String, 1, 'static, i32, 'static>();
+        //~^ ERROR: constant provided when a type was expected
+
+        bar();
+
+        bar::<_, _, _, _, _>();
+        //~^ ERROR: function takes 3 generic arguments but 5 generic arguments were supplied
+
+        bar::<asd, asd, asd>();
+        //~^ ERROR: cannot find type `asd` in this scope
+        //~| ERROR: cannot find type `asd` in this scope
+        //~| ERROR: cannot find type `asd` in this scope
+        //~| ERROR: unresolved item provided when a constant was expected
+
+        reuse foo::<A, B, C> as xd;
+        //~^ ERROR can't use generic parameters from outer item
+        //~| ERROR can't use generic parameters from outer item
+        //~| ERROR can't use generic parameters from outer item
+        //~| ERROR: unresolved item provided when a constant was expected
+    }
+}
+
+mod test_2 {
+    fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+
+    reuse foo::<> as bar1;
+    //~^ ERROR: type annotations needed
+
+    reuse foo::<String, String> as bar2;
+    //~^ ERROR: function takes 3 generic arguments but 2 generic arguments were supplied
+
+    reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _> as bar3;
+    //~^ ERROR: use of undeclared lifetime name `'asdasd`
+    //~| ERROR: function takes 2 lifetime arguments but 5 lifetime arguments were supplied
+    //~| ERROR: function takes 3 generic arguments but 2 generic arguments were supplied
+    reuse foo::<String, 'static, 123, asdasd> as bar4;
+    //~^ ERROR: cannot find type `asdasd` in this scope
+    //~| ERROR: function takes 2 lifetime arguments but 1 lifetime argument was supplied
+
+    reuse foo::<1, 2, _, 4, 5, _> as bar5;
+    //~^ ERROR: function takes 3 generic arguments but 6 generic arguments were supplied
+
+    reuse foo::<1, 2,asd,String, { let x = 0; }> as bar6;
+    //~^ ERROR: cannot find type `asd` in this scope
+    //~| ERROR: function takes 3 generic arguments but 5 generic arguments were supplied
+
+    reuse foo::<"asdasd", asd, "askdn", 'static, 'a> as bar7;
+    //~^ ERROR: use of undeclared lifetime name `'a`
+    //~| ERROR: cannot find type `asd` in this scope
+    //~| ERROR: constant provided when a type was expected
+
+    reuse foo::<{}, {}, {}> as bar8;
+    //~^ ERROR: constant provided when a type was expected
+}
+
+mod test_3 {
+    trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
+        fn foo<'d: 'd, U, const M: bool>(self) {}
+    }
+
+    reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
+    //~^ ERROR: cannot find type `asd` in this scope
+    //~| ERROR: cannot find type `asd` in this scope
+    //~| ERROR: cannot find type `asd` in this scope
+    //~| ERROR: cannot find type `asd` in this scope
+    //~| ERROR: cannot find type `asd` in this scope
+    //~| ERROR: cannot find type `asdasa` in this scope
+    //~| ERROR: trait takes 2 generic arguments but 6 generic arguments were supplied
+
+    reuse Trait::<'static, 'static>::foo as bar2;
+    //~^ ERROR: trait takes 3 lifetime arguments but 2 lifetime arguments were supplied
+    reuse Trait::<1, 2, 3, 4, 5>::foo as bar3;
+    //~^ ERROR: trait takes 2 generic arguments but 5 generic arguments were supplied
+
+    reuse Trait::<1, 2, true>::foo as bar4;
+    //~^ ERROR: trait takes 2 generic arguments but 3 generic arguments were supplied
+
+    reuse Trait::<'static>::foo as bar5;
+    //~^ ERROR: trait takes 3 lifetime arguments but 1 lifetime argument was supplied
+
+    reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
+    //~^ ERROR: cannot find type `DDDD` in this scope [E0425]
+    //~| ERROR: trait takes 3 lifetime arguments but 1 lifetime argument was supplied
+    //~| ERROR: trait takes 2 generic arguments but 3 generic arguments were supplied
+    //~| ERROR: method takes 2 generic arguments but 6 generic arguments were supplied
+
+    reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
+    //~^ ERROR: missing lifetime specifiers [E0106]
+    //~| ERROR: trait takes 3 lifetime arguments but 1 lifetime argument was supplied
+    //~| ERROR: trait takes 2 generic arguments but 5 generic arguments were supplied
+    //~| ERROR: method takes 2 generic arguments but 5 generic arguments were supplied
+}
+
+fn main() {}

--- a/tests/ui/delegation/generics/generics-gen-args-errors.stderr
+++ b/tests/ui/delegation/generics/generics-gen-args-errors.stderr
@@ -1,0 +1,563 @@
+error[E0401]: can't use generic parameters from outer item
+  --> $DIR/generics-gen-args-errors.rs:35:21
+   |
+LL |     fn check<A, B, C>() {
+   |              - type parameter from outer item
+...
+LL |         reuse foo::<A, B, C> as xd;
+   |                     ^           -- generic parameter used in this inner delegated function
+   |                     |
+   |                     use of generic parameter from outer item
+   |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
+
+error[E0401]: can't use generic parameters from outer item
+  --> $DIR/generics-gen-args-errors.rs:35:24
+   |
+LL |     fn check<A, B, C>() {
+   |                 - type parameter from outer item
+...
+LL |         reuse foo::<A, B, C> as xd;
+   |                        ^        -- generic parameter used in this inner delegated function
+   |                        |
+   |                        use of generic parameter from outer item
+   |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
+
+error[E0401]: can't use generic parameters from outer item
+  --> $DIR/generics-gen-args-errors.rs:35:27
+   |
+LL |     fn check<A, B, C>() {
+   |                    - type parameter from outer item
+...
+LL |         reuse foo::<A, B, C> as xd;
+   |                           ^     -- generic parameter used in this inner delegated function
+   |                           |
+   |                           use of generic parameter from outer item
+   |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
+
+error[E0261]: use of undeclared lifetime name `'asdasd`
+  --> $DIR/generics-gen-args-errors.rs:52:29
+   |
+LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _> as bar3;
+   |                             ^^^^^^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'asdasd` here
+   |
+LL |     reuse foo'asdasd, ::<'static, _, 'asdasd, 'static, 'static, 'static, _> as bar3;
+   |              ++++++++
+
+error[E0261]: use of undeclared lifetime name `'a`
+  --> $DIR/generics-gen-args-errors.rs:67:50
+   |
+LL |     reuse foo::<"asdasd", asd, "askdn", 'static, 'a> as bar7;
+   |                                                  ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL |     reuse foo'a, ::<"asdasd", asd, "askdn", 'static, 'a> as bar7;
+   |              +++
+
+error[E0106]: missing lifetime specifiers
+  --> $DIR/generics-gen-args-errors.rs:107:19
+   |
+LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
+   |                   ^^^^^ expected 3 lifetime parameters
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL |     reuse Trait::<Trait<'a, 'a, 'a>, Clone, _, 'static, dyn Send, _>::foo'a, ::<1, 2, 3, _, 6> as bar7;
+   |                        ++++++++++++                                      +++
+
+error[E0423]: expected value, found struct `String`
+  --> $DIR/generics-gen-args-errors.rs:15:33
+   |
+LL |         bar::<String, String, { String }>();
+   |                                 ^^^^^^
+   |
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
+   |
+   = note: `String` defined here
+
+error[E0425]: cannot find type `asd` in this scope
+  --> $DIR/generics-gen-args-errors.rs:29:15
+   |
+LL |         bar::<asd, asd, asd>();
+   |               ^^^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL |     fn check<A, B, C, asd>() {
+   |                     +++++
+
+error[E0425]: cannot find type `asd` in this scope
+  --> $DIR/generics-gen-args-errors.rs:29:20
+   |
+LL |         bar::<asd, asd, asd>();
+   |                    ^^^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL |     fn check<A, B, C, asd>() {
+   |                     +++++
+
+error[E0425]: cannot find type `asd` in this scope
+  --> $DIR/generics-gen-args-errors.rs:29:25
+   |
+LL |         bar::<asd, asd, asd>();
+   |                         ^^^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL |     fn check<A, B, C, asd>() {
+   |                     +++++
+
+error[E0425]: cannot find type `asdasd` in this scope
+  --> $DIR/generics-gen-args-errors.rs:56:39
+   |
+LL |     reuse foo::<String, 'static, 123, asdasd> as bar4;
+   |                                       ^^^^^^ not found in this scope
+
+error[E0425]: cannot find type `asd` in this scope
+  --> $DIR/generics-gen-args-errors.rs:63:22
+   |
+LL |     reuse foo::<1, 2,asd,String, { let x = 0; }> as bar6;
+   |                      ^^^ not found in this scope
+
+error[E0425]: cannot find type `asd` in this scope
+  --> $DIR/generics-gen-args-errors.rs:67:27
+   |
+LL |     reuse foo::<"asdasd", asd, "askdn", 'static, 'a> as bar7;
+   |                           ^^^ not found in this scope
+
+error[E0425]: cannot find type `asd` in this scope
+  --> $DIR/generics-gen-args-errors.rs:81:19
+   |
+LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
+   |                   ^^^ not found in this scope
+
+error[E0425]: cannot find type `asd` in this scope
+  --> $DIR/generics-gen-args-errors.rs:81:24
+   |
+LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
+   |                        ^^^ not found in this scope
+
+error[E0425]: cannot find type `asd` in this scope
+  --> $DIR/generics-gen-args-errors.rs:81:29
+   |
+LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
+   |                             ^^^ not found in this scope
+
+error[E0425]: cannot find type `asd` in this scope
+  --> $DIR/generics-gen-args-errors.rs:81:34
+   |
+LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
+   |                                  ^^^ not found in this scope
+
+error[E0425]: cannot find type `asd` in this scope
+  --> $DIR/generics-gen-args-errors.rs:81:39
+   |
+LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
+   |                                       ^^^ not found in this scope
+
+error[E0425]: cannot find type `asdasa` in this scope
+  --> $DIR/generics-gen-args-errors.rs:81:44
+   |
+LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
+   |                                            ^^^^^^ not found in this scope
+
+error[E0425]: cannot find type `DDDD` in this scope
+  --> $DIR/generics-gen-args-errors.rs:101:34
+   |
+LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
+   |                                  ^^^^ not found in this scope
+
+error[E0284]: type annotations needed
+  --> $DIR/generics-gen-args-errors.rs:8:11
+   |
+LL |     reuse foo as bar;
+   |           ^^^ cannot infer the value of the const parameter `N` declared on the function `foo`
+   |
+note: required by a const generic parameter in `test_1::foo`
+  --> $DIR/generics-gen-args-errors.rs:7:48
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |                                                ^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
+help: consider specifying the generic arguments
+   |
+LL |     reuse foo::<T, U, N> as bar;
+   |              +++++++++++
+
+error[E0107]: function takes 3 generic arguments but 6 generic arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:12:9
+   |
+LL |         bar::<1, 2, 3, 4, 5, 6>();
+   |         ^^^          --------- help: remove the unnecessary generic arguments
+   |         |
+   |         expected 3 generic arguments
+   |
+note: function defined here, with 3 generic parameters: `T`, `U`, `N`
+  --> $DIR/generics-gen-args-errors.rs:8:18
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |                            -         -         --------------
+LL |     reuse foo as bar;
+   |                  ^^^
+
+error[E0107]: function takes 2 lifetime arguments but 5 lifetime arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:18:9
+   |
+LL |         bar::<'static, 'static, 'static, 'static, 'static>();
+   |         ^^^                   --------------------------- help: remove the lifetime arguments
+   |         |
+   |         expected 2 lifetime arguments
+   |
+note: function defined here, with 2 lifetime parameters: `'a`, `'b`
+  --> $DIR/generics-gen-args-errors.rs:8:18
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |            --      --
+LL |     reuse foo as bar;
+   |                  ^^^
+
+error[E0747]: constant provided when a type was expected
+  --> $DIR/generics-gen-args-errors.rs:21:23
+   |
+LL |         bar::<String, 1, 'static, i32, 'static>();
+   |                       ^
+
+error[E0107]: function takes 3 generic arguments but 5 generic arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:26:9
+   |
+LL |         bar::<_, _, _, _, _>();
+   |         ^^^          ------ help: remove the unnecessary generic arguments
+   |         |
+   |         expected 3 generic arguments
+   |
+note: function defined here, with 3 generic parameters: `T`, `U`, `N`
+  --> $DIR/generics-gen-args-errors.rs:8:18
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |                            -         -         --------------
+LL |     reuse foo as bar;
+   |                  ^^^
+
+error[E0747]: unresolved item provided when a constant was expected
+  --> $DIR/generics-gen-args-errors.rs:29:25
+   |
+LL |         bar::<asd, asd, asd>();
+   |                         ^^^
+   |
+help: if this generic argument was intended as a const parameter, surround it with braces
+   |
+LL |         bar::<asd, asd, { asd }>();
+   |                         +     +
+
+error[E0747]: unresolved item provided when a constant was expected
+  --> $DIR/generics-gen-args-errors.rs:35:27
+   |
+LL |         reuse foo::<A, B, C> as xd;
+   |                           ^
+   |
+help: if this generic argument was intended as a const parameter, surround it with braces
+   |
+LL |         reuse foo::<A, B, { C }> as xd;
+   |                           +   +
+
+error[E0284]: type annotations needed
+  --> $DIR/generics-gen-args-errors.rs:46:11
+   |
+LL |     reuse foo::<> as bar1;
+   |           ^^^ cannot infer the value of the const parameter `N` declared on the function `foo`
+   |
+note: required by a const generic parameter in `test_2::foo`
+  --> $DIR/generics-gen-args-errors.rs:44:48
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |                                                ^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
+help: consider specifying the generic arguments
+   |
+LL |     reuse foo::<T, U, N> as bar1;
+   |                 +++++++
+
+error[E0107]: function takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:49:11
+   |
+LL |     reuse foo::<String, String> as bar2;
+   |           ^^^   ------  ------ supplied 2 generic arguments
+   |           |
+   |           expected 3 generic arguments
+   |
+note: function defined here, with 3 generic parameters: `T`, `U`, `N`
+  --> $DIR/generics-gen-args-errors.rs:44:8
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |        ^^^                 -         -         --------------
+help: add missing generic argument
+   |
+LL |     reuse foo::<String, String, N> as bar2;
+   |                               +++
+
+error[E0107]: function takes 2 lifetime arguments but 5 lifetime arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:52:11
+   |
+LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _> as bar3;
+   |           ^^^                      --------------------------- help: remove the lifetime arguments
+   |           |
+   |           expected 2 lifetime arguments
+   |
+note: function defined here, with 2 lifetime parameters: `'a`, `'b`
+  --> $DIR/generics-gen-args-errors.rs:44:8
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |        ^^^ --      --
+
+error[E0107]: function takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:52:11
+   |
+LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _> as bar3;
+   |           ^^^ expected 3 generic arguments             -------  - supplied 2 generic arguments
+   |
+note: function defined here, with 3 generic parameters: `T`, `U`, `N`
+  --> $DIR/generics-gen-args-errors.rs:44:8
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |        ^^^                 -         -         --------------
+help: add missing generic argument
+   |
+LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _, N> as bar3;
+   |                                                                  +++
+
+error[E0107]: function takes 2 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/generics-gen-args-errors.rs:56:11
+   |
+LL |     reuse foo::<String, 'static, 123, asdasd> as bar4;
+   |           ^^^   ------ supplied 1 lifetime argument
+   |           |
+   |           expected 2 lifetime arguments
+   |
+note: function defined here, with 2 lifetime parameters: `'a`, `'b`
+  --> $DIR/generics-gen-args-errors.rs:44:8
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |        ^^^ --      --
+help: add missing lifetime argument
+   |
+LL |     reuse foo::<String, 'static, 'static, 123, asdasd> as bar4;
+   |                       +++++++++
+
+error[E0107]: function takes 3 generic arguments but 6 generic arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:60:11
+   |
+LL |     reuse foo::<1, 2, _, 4, 5, _> as bar5;
+   |           ^^^          --------- help: remove the unnecessary generic arguments
+   |           |
+   |           expected 3 generic arguments
+   |
+note: function defined here, with 3 generic parameters: `T`, `U`, `N`
+  --> $DIR/generics-gen-args-errors.rs:44:8
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |        ^^^                 -         -         --------------
+
+error[E0107]: function takes 3 generic arguments but 5 generic arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:63:11
+   |
+LL |     reuse foo::<1, 2,asd,String, { let x = 0; }> as bar6;
+   |           ^^^           ----------------------- help: remove the unnecessary generic arguments
+   |           |
+   |           expected 3 generic arguments
+   |
+note: function defined here, with 3 generic parameters: `T`, `U`, `N`
+  --> $DIR/generics-gen-args-errors.rs:44:8
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |        ^^^                 -         -         --------------
+
+error[E0747]: constant provided when a type was expected
+  --> $DIR/generics-gen-args-errors.rs:67:17
+   |
+LL |     reuse foo::<"asdasd", asd, "askdn", 'static, 'a> as bar7;
+   |                 ^^^^^^^^
+
+error[E0747]: constant provided when a type was expected
+  --> $DIR/generics-gen-args-errors.rs:72:17
+   |
+LL |     reuse foo::<{}, {}, {}> as bar8;
+   |                 ^^
+
+error[E0107]: trait takes 2 generic arguments but 6 generic arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:81:11
+   |
+LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
+   |           ^^^^^           ----------------------- help: remove the unnecessary generic arguments
+   |           |
+   |           expected 2 generic arguments
+   |
+note: trait defined here, with 2 generic parameters: `T`, `N`
+  --> $DIR/generics-gen-args-errors.rs:77:11
+   |
+LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
+   |           ^^^^^             -  --------------
+
+error[E0107]: trait takes 3 lifetime arguments but 2 lifetime arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:90:11
+   |
+LL |     reuse Trait::<'static, 'static>::foo as bar2;
+   |           ^^^^^   -------  ------- supplied 2 lifetime arguments
+   |           |
+   |           expected 3 lifetime arguments
+   |
+note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
+  --> $DIR/generics-gen-args-errors.rs:77:11
+   |
+LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
+   |           ^^^^^ --  --  --
+help: add missing lifetime argument
+   |
+LL |     reuse Trait::<'static, 'static, 'static>::foo as bar2;
+   |                                   +++++++++
+
+error[E0107]: trait takes 2 generic arguments but 5 generic arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:92:11
+   |
+LL |     reuse Trait::<1, 2, 3, 4, 5>::foo as bar3;
+   |           ^^^^^       --------- help: remove the unnecessary generic arguments
+   |           |
+   |           expected 2 generic arguments
+   |
+note: trait defined here, with 2 generic parameters: `T`, `N`
+  --> $DIR/generics-gen-args-errors.rs:77:11
+   |
+LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
+   |           ^^^^^             -  --------------
+
+error[E0107]: trait takes 2 generic arguments but 3 generic arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:95:11
+   |
+LL |     reuse Trait::<1, 2, true>::foo as bar4;
+   |           ^^^^^       ------ help: remove the unnecessary generic argument
+   |           |
+   |           expected 2 generic arguments
+   |
+note: trait defined here, with 2 generic parameters: `T`, `N`
+  --> $DIR/generics-gen-args-errors.rs:77:11
+   |
+LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
+   |           ^^^^^             -  --------------
+
+error[E0107]: trait takes 3 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/generics-gen-args-errors.rs:98:11
+   |
+LL |     reuse Trait::<'static>::foo as bar5;
+   |           ^^^^^   ------- supplied 1 lifetime argument
+   |           |
+   |           expected 3 lifetime arguments
+   |
+note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
+  --> $DIR/generics-gen-args-errors.rs:77:11
+   |
+LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
+   |           ^^^^^ --  --  --
+help: add missing lifetime arguments
+   |
+LL |     reuse Trait::<'static, 'static, 'static>::foo as bar5;
+   |                          ++++++++++++++++++
+
+error[E0107]: trait takes 3 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/generics-gen-args-errors.rs:101:11
+   |
+LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
+   |           ^^^^^   - supplied 1 lifetime argument
+   |           |
+   |           expected 3 lifetime arguments
+   |
+note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
+  --> $DIR/generics-gen-args-errors.rs:77:11
+   |
+LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
+   |           ^^^^^ --  --  --
+help: add missing lifetime arguments
+   |
+LL |     reuse Trait::<1, 'static, 'static, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
+   |                    ++++++++++++++++++
+
+error[E0107]: trait takes 2 generic arguments but 3 generic arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:101:11
+   |
+LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
+   |           ^^^^^       --------------- help: remove the unnecessary generic argument
+   |           |
+   |           expected 2 generic arguments
+   |
+note: trait defined here, with 2 generic parameters: `T`, `N`
+  --> $DIR/generics-gen-args-errors.rs:77:11
+   |
+LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
+   |           ^^^^^             -  --------------
+
+error[E0107]: method takes 2 generic arguments but 6 generic arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:101:41
+   |
+LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
+   |                                         ^^^       ------------ help: remove the unnecessary generic arguments
+   |                                         |
+   |                                         expected 2 generic arguments
+   |
+note: method defined here, with 2 generic parameters: `U`, `M`
+  --> $DIR/generics-gen-args-errors.rs:78:12
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(self) {}
+   |            ^^^         -  -------------
+
+error[E0107]: trait takes 3 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/generics-gen-args-errors.rs:107:11
+   |
+LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
+   |           ^^^^^   ----- supplied 1 lifetime argument
+   |           |
+   |           expected 3 lifetime arguments
+   |
+note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
+  --> $DIR/generics-gen-args-errors.rs:77:11
+   |
+LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
+   |           ^^^^^ --  --  --
+help: add missing lifetime arguments
+   |
+LL |     reuse Trait::<Trait, 'static, 'static, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
+   |                        ++++++++++++++++++
+
+error[E0107]: trait takes 2 generic arguments but 5 generic arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:107:11
+   |
+LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
+   |           ^^^^^               --- help: remove the unnecessary generic argument
+   |           |
+   |           expected 2 generic arguments
+   |
+note: trait defined here, with 2 generic parameters: `T`, `N`
+  --> $DIR/generics-gen-args-errors.rs:77:11
+   |
+LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
+   |           ^^^^^             -  --------------
+
+error[E0107]: method takes 2 generic arguments but 5 generic arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:107:59
+   |
+LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
+   |                                                           ^^^       --------- help: remove the unnecessary generic arguments
+   |                                                           |
+   |                                                           expected 2 generic arguments
+   |
+note: method defined here, with 2 generic parameters: `U`, `M`
+  --> $DIR/generics-gen-args-errors.rs:78:12
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(self) {}
+   |            ^^^         -  -------------
+
+error: aborting due to 47 previous errors
+
+Some errors have detailed explanations: E0106, E0107, E0261, E0284, E0401, E0423, E0425, E0747.
+For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/delegation/generics/impl-trait-wrong-args-count.rs
+++ b/tests/ui/delegation/generics/impl-trait-wrong-args-count.rs
@@ -1,0 +1,38 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+mod to_reuse {
+    pub fn bar<'a: 'a, 'b: 'b, A, B>(x: &super::XX) {}
+    pub fn bar1(x: &super::XX) {}
+    pub fn bar2<A, B, C, D, E, F, const X: usize, const Y: bool>(x: &super::XX) {}
+}
+
+trait Trait<'a, 'b, 'c, A, B, const N: usize>: Sized {
+    fn bar<'x: 'x, 'y: 'y, AA, BB, const NN: usize>(&self) {}
+    fn bar1<'x: 'x, 'y: 'y, AA, BB, const NN: usize>(&self) {}
+    fn bar2(&self) {}
+    fn bar3(&self) {}
+    fn bar4<X, Y, Z>(&self) {}
+}
+
+struct X<'x1, 'x2, 'x3, 'x4, X1, X2, const X3: usize>(
+    &'x1 X1, &'x2 X2, &'x3 X1, &'x4 [usize; X3]);
+type XX = X::<'static, 'static, 'static, 'static, i32, i32, 3>;
+
+impl<'a, 'b, 'c, A, B, const N: usize> Trait<'a, 'b, 'c, A, B, N> for XX {
+    reuse to_reuse::bar;
+    //~^ ERROR: type annotations needed
+
+    reuse to_reuse::bar1;
+
+    reuse to_reuse::bar2;
+    //~^ ERROR: type annotations needed
+    //~| ERROR: type annotations needed
+
+    reuse to_reuse::bar2::<i32, i32, i32, i32, i32, i32, 123, true> as bar3;
+
+    reuse to_reuse::bar2::<i32, i32, i32, i32, i32, i32, 123, true> as bar4;
+}
+
+fn main() {
+}

--- a/tests/ui/delegation/generics/impl-trait-wrong-args-count.stderr
+++ b/tests/ui/delegation/generics/impl-trait-wrong-args-count.stderr
@@ -1,0 +1,47 @@
+error[E0282]: type annotations needed
+  --> $DIR/impl-trait-wrong-args-count.rs:23:21
+   |
+LL |     reuse to_reuse::bar;
+   |                     ^^^ cannot infer type of the type parameter `A` declared on the function `bar`
+   |
+help: consider specifying the generic arguments
+   |
+LL |     reuse to_reuse::bar::<A, B>;
+   |                        ++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/impl-trait-wrong-args-count.rs:28:21
+   |
+LL |     reuse to_reuse::bar2;
+   |                     ^^^^ cannot infer the value of the const parameter `X` declared on the function `bar2`
+   |
+note: required by a const generic parameter in `bar2`
+  --> $DIR/impl-trait-wrong-args-count.rs:7:35
+   |
+LL |     pub fn bar2<A, B, C, D, E, F, const X: usize, const Y: bool>(x: &super::XX) {}
+   |                                   ^^^^^^^^^^^^^^ required by this const generic parameter in `bar2`
+help: consider specifying the generic arguments
+   |
+LL |     reuse to_reuse::bar2::<A, B, C, D, E, F, X, Y>;
+   |                         ++++++++++++++++++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/impl-trait-wrong-args-count.rs:28:21
+   |
+LL |     reuse to_reuse::bar2;
+   |                     ^^^^ cannot infer the value of the const parameter `Y` declared on the function `bar2`
+   |
+note: required by a const generic parameter in `bar2`
+  --> $DIR/impl-trait-wrong-args-count.rs:7:51
+   |
+LL |     pub fn bar2<A, B, C, D, E, F, const X: usize, const Y: bool>(x: &super::XX) {}
+   |                                                   ^^^^^^^^^^^^^ required by this const generic parameter in `bar2`
+help: consider specifying the generic arguments
+   |
+LL |     reuse to_reuse::bar2::<A, B, C, D, E, F, X, Y>;
+   |                         ++++++++++++++++++++++++++
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0282, E0284.
+For more information about an error, try `rustc --explain E0282`.

--- a/tests/ui/delegation/generics/mapping/free-to-free.rs
+++ b/tests/ui/delegation/generics/mapping/free-to-free.rs
@@ -1,0 +1,141 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+#![allow(late_bound_lifetime_arguments)]
+
+//! This is one of the mapping tests, which tests mapping of delegee parent and child
+//! generic params, whose main goal is to create cases with
+//! different number of lifetimes/types/consts in delegee child and parent; and in
+//! delegation parent if applicable. At some tests predicates are
+//! added. At some tests user-specified args are specified in reuse statement.
+
+// Testing lifetimes + types + consts, reusing without
+// user args, checking predicates inheritance
+mod test_1 {
+    fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+
+    pub fn check() {
+        reuse foo as bar;
+        //~^ ERROR: type annotations needed [E0284]
+        bar::<i32, i32, 1>();
+    }
+}
+
+// Testing lifetimes + types + consts, reusing without user args,
+// providing delegation parent args in invocation
+mod test_2 {
+    fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+
+    pub fn check<T: Clone, U: Clone>() {
+        reuse foo as bar;
+        //~^ ERROR: type annotations needed [E0284]
+        bar::<T, U, 1>();
+    }
+}
+
+// Testing lifetimes + types + consts, reusing without user args,
+// providing random types with delegation parent generics specified
+mod test_3 {
+    fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+
+    pub fn check<T: Clone, U: Clone>() {
+        reuse foo as bar;
+        //~^ ERROR: type annotations needed [E0284]
+        bar::<u64, i32, 1>();
+    }
+}
+
+// Testing late-bound lifetimes + types + consts, reusing without user args,
+// providing random types with delegation parent generics specified,
+// checking signature inheritance
+mod test_4 {
+    fn foo<'a, 'b, T: Clone, U: Clone, const N: usize>(_t: &'a T, _u: &'b U) {}
+
+    pub fn check<T: Clone, U: Clone>() {
+        reuse foo as bar;
+        //~^ ERROR: type annotations needed [E0284]
+        bar::<u64, i32, 1>(&1, &2);
+    }
+}
+
+// Testing late-bound lifetimes + types + consts, reusing without user args,
+// providing random types with delegation parent generics specified,
+// checking signature inheritance, testing mixed order of types and consts
+mod test_5 {
+    fn foo<'a, 'b, T: Clone, const N: usize, U: Clone>(_t: &'a T, _u: &'b U) {}
+
+    pub fn check<T: Clone, U: Clone>() {
+        reuse foo as bar;
+        //~^ ERROR: type annotations needed [E0284]
+        bar::<u64, 1, u32>(&1, &2);
+    }
+}
+
+// Testing late-bound lifetimes + types + consts, reusing with user args,
+// checking signature inheritance, testing mixed order of types and consts
+mod test_6 {
+    fn foo<'a, 'b, T: Clone, const N: usize, U: Clone>(_t: &'a T, _u: &'b U) {}
+
+    pub fn check<T: Clone, U: Clone>() {
+        reuse foo::<String, 1, String> as bar;
+        //~^ ERROR: arguments to this function are incorrect [E0308]
+        bar(&"".to_string(), &"".to_string());
+        //~^ ERROR: type annotations needed [E0284]
+    }
+}
+
+// FIXME(fn_delegation): Uncomment this test when impl Traits in function params are supported
+
+// mod test_7 {
+//     fn foo<T, U>(t: T, u: U, f: impl FnOnce(T, U) -> U) -> U {
+//         f(t, u)
+//     }
+
+//     pub fn check() {
+//         reuse foo as bar;
+//         assert_eq!(bar::<i32, i32>(1, 2, |x, y| y), 2);
+//     }
+// }
+
+// Testing reuse of local fn with delegation parent generic params specified,
+// late-bound lifetimes + types + consts, reusing with user args,
+// checking signature inheritance, mixed consts and types ordering
+mod test_8 {
+    pub fn check<T: Clone, U: Clone>() {
+        fn foo<'a, 'b, const N: usize, T: Clone, U: Clone>(_t: &'a T, _u: &'b U) {}
+
+        reuse foo::<1, String, String> as bar;
+        //~^ ERROR: arguments to this function are incorrect [E0308]
+        bar(&"".to_string(), &"".to_string());
+        //~^ ERROR: type annotations needed [E0284]
+    }
+}
+
+// Testing reuse of local fn inside closure,
+// late-bound lifetimes + types + consts, reusing with user args,
+// checking signature inheritance, mixed consts and types ordering
+mod test_9 {
+    pub fn check<T: Clone, U: Clone>() {
+        let closure = || {
+            fn foo<'a, 'b, T: Clone, const N: usize, U: Clone>(_t: &'a T, _u: &'b U) {}
+
+            reuse foo::<String, 1, String> as bar;
+            //~^ ERROR: arguments to this function are incorrect [E0308]
+            bar(&"".to_string(), &"".to_string());
+            //~^ ERROR: type annotations needed [E0284]
+        };
+
+        closure();
+    }
+}
+
+pub fn main() {
+    test_1::check();
+    test_2::check::<i32, String>();
+    test_3::check::<i32, String>();
+    test_4::check::<i32, String>();
+    test_5::check::<i32, String>();
+    test_6::check::<i32, String>();
+    // test_7::check();
+    test_8::check::<i32, String>();
+    test_9::check::<String, i32>();
+}

--- a/tests/ui/delegation/generics/mapping/free-to-free.stderr
+++ b/tests/ui/delegation/generics/mapping/free-to-free.stderr
@@ -1,0 +1,213 @@
+error[E0284]: type annotations needed
+  --> $DIR/free-to-free.rs:17:15
+   |
+LL |         reuse foo as bar;
+   |               ^^^ cannot infer the value of the const parameter `N` declared on the function `foo`
+   |
+note: required by a const generic parameter in `test_1::foo`
+  --> $DIR/free-to-free.rs:14:48
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |                                                ^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse foo::<T, U, N> as bar;
+   |                  +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/free-to-free.rs:29:15
+   |
+LL |         reuse foo as bar;
+   |               ^^^ cannot infer the value of the const parameter `N` declared on the function `foo`
+   |
+note: required by a const generic parameter in `test_2::foo`
+  --> $DIR/free-to-free.rs:26:48
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |                                                ^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse foo::<T, U, N> as bar;
+   |                  +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/free-to-free.rs:41:15
+   |
+LL |         reuse foo as bar;
+   |               ^^^ cannot infer the value of the const parameter `N` declared on the function `foo`
+   |
+note: required by a const generic parameter in `test_3::foo`
+  --> $DIR/free-to-free.rs:38:48
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |                                                ^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse foo::<T, U, N> as bar;
+   |                  +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/free-to-free.rs:54:15
+   |
+LL |         reuse foo as bar;
+   |               ^^^ cannot infer the value of the const parameter `N` declared on the function `foo`
+   |
+note: required by a const generic parameter in `test_4::foo`
+  --> $DIR/free-to-free.rs:51:40
+   |
+LL |     fn foo<'a, 'b, T: Clone, U: Clone, const N: usize>(_t: &'a T, _u: &'b U) {}
+   |                                        ^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse foo::<T, U, N> as bar;
+   |                  +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/free-to-free.rs:67:15
+   |
+LL |         reuse foo as bar;
+   |               ^^^ cannot infer the value of the const parameter `N` declared on the function `foo`
+   |
+note: required by a const generic parameter in `test_5::foo`
+  --> $DIR/free-to-free.rs:64:30
+   |
+LL |     fn foo<'a, 'b, T: Clone, const N: usize, U: Clone>(_t: &'a T, _u: &'b U) {}
+   |                              ^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse foo::<T, N, U> as bar;
+   |                  +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/free-to-free.rs:81:9
+   |
+LL |         bar(&"".to_string(), &"".to_string());
+   |         ^^^ cannot infer the value of the const parameter `N` declared on the function `bar`
+   |
+note: required by a const generic parameter in `test_6::check::bar`
+  --> $DIR/free-to-free.rs:76:30
+   |
+LL |     fn foo<'a, 'b, T: Clone, const N: usize, U: Clone>(_t: &'a T, _u: &'b U) {}
+   |                              ^^^^^^^^^^^^^^ required by this const generic parameter in `bar`
+...
+LL |         reuse foo::<String, 1, String> as bar;
+   |                                           --- required by a bound in this function
+help: consider specifying the generic arguments
+   |
+LL |         bar::<String, N, String>(&"".to_string(), &"".to_string());
+   |            +++++++++++++++++++++
+
+error[E0308]: arguments to this function are incorrect
+  --> $DIR/free-to-free.rs:79:15
+   |
+LL |     fn foo<'a, 'b, T: Clone, const N: usize, U: Clone>(_t: &'a T, _u: &'b U) {}
+   |                    -                         - found this type parameter
+   |                    |
+   |                    found this type parameter
+...
+LL |         reuse foo::<String, 1, String> as bar;
+   |               ^^^
+   |               |
+   |               expected `&String`, found `&T`
+   |               expected `&String`, found `&U`
+   |
+   = note: expected reference `&String`
+              found reference `&'a T`
+   = note: expected reference `&String`
+              found reference `&'b U`
+note: function defined here
+  --> $DIR/free-to-free.rs:76:8
+   |
+LL |     fn foo<'a, 'b, T: Clone, const N: usize, U: Clone>(_t: &'a T, _u: &'b U) {}
+   |        ^^^                                             ---------  ---------
+
+error[E0284]: type annotations needed
+  --> $DIR/free-to-free.rs:108:9
+   |
+LL |         bar(&"".to_string(), &"".to_string());
+   |         ^^^ cannot infer the value of the const parameter `N` declared on the function `bar`
+   |
+note: required by a const generic parameter in `test_8::check::bar`
+  --> $DIR/free-to-free.rs:104:24
+   |
+LL |         fn foo<'a, 'b, const N: usize, T: Clone, U: Clone>(_t: &'a T, _u: &'b U) {}
+   |                        ^^^^^^^^^^^^^^ required by this const generic parameter in `bar`
+LL |
+LL |         reuse foo::<1, String, String> as bar;
+   |                                           --- required by a bound in this function
+help: consider specifying the generic arguments
+   |
+LL |         bar::<N, String, String>(&"".to_string(), &"".to_string());
+   |            +++++++++++++++++++++
+
+error[E0308]: arguments to this function are incorrect
+  --> $DIR/free-to-free.rs:106:15
+   |
+LL |         fn foo<'a, 'b, const N: usize, T: Clone, U: Clone>(_t: &'a T, _u: &'b U) {}
+   |                                        -         - found this type parameter
+   |                                        |
+   |                                        found this type parameter
+LL |
+LL |         reuse foo::<1, String, String> as bar;
+   |               ^^^
+   |               |
+   |               expected `&String`, found `&T`
+   |               expected `&String`, found `&U`
+   |
+   = note: expected reference `&String`
+              found reference `&'a T`
+   = note: expected reference `&String`
+              found reference `&'b U`
+note: function defined here
+  --> $DIR/free-to-free.rs:104:12
+   |
+LL |         fn foo<'a, 'b, const N: usize, T: Clone, U: Clone>(_t: &'a T, _u: &'b U) {}
+   |            ^^^                                             ---------  ---------
+
+error[E0284]: type annotations needed
+  --> $DIR/free-to-free.rs:123:13
+   |
+LL |             bar(&"".to_string(), &"".to_string());
+   |             ^^^ cannot infer the value of the const parameter `N` declared on the function `bar`
+   |
+note: required by a const generic parameter in `test_9::check::{closure#0}::bar`
+  --> $DIR/free-to-free.rs:119:38
+   |
+LL |             fn foo<'a, 'b, T: Clone, const N: usize, U: Clone>(_t: &'a T, _u: &'b U) {}
+   |                                      ^^^^^^^^^^^^^^ required by this const generic parameter in `bar`
+LL |
+LL |             reuse foo::<String, 1, String> as bar;
+   |                                               --- required by a bound in this function
+help: consider specifying the generic arguments
+   |
+LL |             bar::<String, N, String>(&"".to_string(), &"".to_string());
+   |                +++++++++++++++++++++
+
+error[E0308]: arguments to this function are incorrect
+  --> $DIR/free-to-free.rs:121:19
+   |
+LL |             fn foo<'a, 'b, T: Clone, const N: usize, U: Clone>(_t: &'a T, _u: &'b U) {}
+   |                            -                         - found this type parameter
+   |                            |
+   |                            found this type parameter
+LL |
+LL |             reuse foo::<String, 1, String> as bar;
+   |                   ^^^
+   |                   |
+   |                   expected `&String`, found `&T`
+   |                   expected `&String`, found `&U`
+   |
+   = note: expected reference `&String`
+              found reference `&'a T`
+   = note: expected reference `&String`
+              found reference `&'b U`
+note: function defined here
+  --> $DIR/free-to-free.rs:119:16
+   |
+LL |             fn foo<'a, 'b, T: Clone, const N: usize, U: Clone>(_t: &'a T, _u: &'b U) {}
+   |                ^^^                                             ---------  ---------
+
+error: aborting due to 11 previous errors
+
+Some errors have detailed explanations: E0284, E0308.
+For more information about an error, try `rustc --explain E0284`.

--- a/tests/ui/delegation/generics/mapping/free-to-trait.rs
+++ b/tests/ui/delegation/generics/mapping/free-to-trait.rs
@@ -1,0 +1,268 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+#![allow(late_bound_lifetime_arguments)]
+
+//! This is one of the mapping tests, which tests mapping of delegee parent and child
+//! generic params, whose main goal is to create cases with
+//! different number of lifetimes/types/consts in delegee child and parent; and in
+//! delegation parent if applicable. At some tests predicates are
+//! added. At some tests user-specified args are specified in reuse statement.
+
+// Testing lifetimes + types + consts in both parent and child, reusing in
+// a function without generic params
+mod test_1 {
+    trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
+        fn foo<'d: 'd, U, const M: bool>(self) {}
+    }
+
+    impl Trait<'static, 'static, 'static, i32, 1> for u8 {}
+
+    pub fn check() {
+        fn no_ctx() {
+            reuse Trait::foo as bar;
+            //~^ ERROR: type annotations needed [E0284]
+            bar::<'static, 'static, 'static, 'static, u8, i32, 1, String, true>(123);
+        }
+
+        fn with_ctx<'a, 'b, 'c, A, B, C, const N: usize, const M: bool>() {
+            reuse Trait::foo as bar;
+            //~^ ERROR: type annotations needed [E0284]
+            bar::<'static, 'static, 'static, 'a, u8, i32, 1, A, M>(123);
+        }
+
+        no_ctx();
+        with_ctx::<i32, i32, i32, 1, true>();
+    }
+}
+
+// Testing lifetimes + types + consts in both parent and child, add user-specified args to parent
+mod test_2 {
+    trait Trait<'a, T, const N: usize>: Sized {
+        fn foo<'b: 'b, U, const M: bool>(self) {}
+    }
+
+    impl Trait<'static, i32, 1> for u8 {}
+
+    pub fn check() {
+        reuse Trait::<'static, i32, 1>::foo as bar;
+        //~^ ERROR: the trait bound `Self: test_2::Trait<'static, i32, 1>` is not satisfied [E0277]
+
+        bar::<'static, u8, String, true>(123);
+        //~^ ERROR: function takes 5 generic arguments but 3 generic arguments were supplied [E0107]
+        //~| ERROR: function takes 2 lifetime arguments but 1 lifetime argument was supplied [E0107]
+    }
+}
+
+// Testing lifetimes + types + consts in both parent and child,
+// add user-specified args to child
+mod test_3 {
+    trait Trait<'a, T, const N: usize>: Sized {
+        fn foo<'b: 'b, U, const M: bool>(self) {}
+    }
+
+    impl Trait<'static, String, 1> for u8 {}
+
+    pub fn check() {
+        reuse Trait::foo::<'static, i32, true> as bar;
+
+        bar::<'static, u8, String, 1>(123);
+        //~^ ERROR: function takes 5 generic arguments but 3 generic arguments were supplied [E0107]
+        //~| ERROR: function takes 2 lifetime arguments but 1 lifetime argument was supplied [E0107]
+    }
+}
+
+// Testing types/consts in parent, lifetimes + types/consts in child,
+// add user-specified args to child
+mod test_4 {
+    trait Trait<T, const N: usize>: Sized {
+        fn foo<'b: 'b, U, const M: bool>(self) {}
+    }
+
+    impl Trait<String, 1> for u8 {}
+
+    pub fn check() {
+        reuse Trait::foo::<'static, i32, true> as bar;
+
+        bar::<u8, String, 1>(123);
+        //~^ ERROR: function takes 5 generic arguments but 3 generic arguments were supplied [E0107]
+    }
+}
+
+// Testing consts in parent, lifetimes + types/consts in child, add user-specified args to child
+mod test_5 {
+    trait Trait<const N: usize>: Sized {
+        fn foo<'b: 'b, U, const M: bool>(self) {}
+    }
+
+    impl Trait<1> for u8 {}
+
+    pub fn check() {
+        reuse Trait::foo::<'static, i32, true> as bar;
+
+        bar::<u8, 1>(123);
+        //~^ ERROR: function takes 4 generic arguments but 2 generic arguments were supplied [E0107]
+    }
+}
+
+// Testing no generics in parent, lifetimes + types/consts in child,
+// add user-specified args to child
+mod test_6 {
+    trait Trait: Sized {
+        fn foo<'b: 'b, U, const M: bool>(self) {}
+    }
+
+    impl Trait for u8 {}
+
+    pub fn check() {
+        reuse Trait::foo::<'static, i32, true> as bar;
+
+        bar::<u8>(123);
+        //~^ ERROR: function takes 3 generic arguments but 1 generic argument was supplied [E0107]
+    }
+}
+
+// Testing lifetimes + types/consts in parent, types/consts in child,
+// add user-specified args to parent
+mod test_7 {
+    trait Trait<'a, T, const N: usize>: Sized {
+        fn foo<U, const M: bool>(self) {}
+    }
+
+    impl Trait<'static, i32, 1> for u8 {}
+
+    pub fn check() {
+        reuse Trait::<'static, i32, 1>::foo as bar;
+        //~^ ERROR: the trait bound `Self: test_7::Trait<'static, i32, 1>` is not satisfied [E0277]
+
+        bar::<u8, String, true>(123);
+        //~^ ERROR: function takes 5 generic arguments but 3 generic arguments were supplied [E0107]
+    }
+}
+
+// Testing lifetimes + types/consts in parent, consts in child, add user-specified args to parent
+mod test_8 {
+    trait Trait<'a, T, const N: usize>: Sized {
+        fn foo<const M: bool>(self) {}
+    }
+
+    impl Trait<'static, i32, 1> for u8 {}
+
+    pub fn check() {
+        reuse Trait::<'static, i32, 1>::foo as bar;
+        //~^ ERROR: the trait bound `Self: test_8::Trait<'static, i32, 1>` is not satisfied [E0277]
+
+        bar::<u8, true>(123);
+        //~^ ERROR: function takes 4 generic arguments but 2 generic arguments were supplied [E0107]
+    }
+}
+
+// Testing lifetimes + types/consts in parent, none in child, add user-specified args to parent
+mod test_9 {
+    trait Trait<'a, T, const N: usize>: Sized {
+        fn foo(self) {}
+    }
+
+    impl Trait<'static, i32, 1> for u8 {}
+
+    pub fn check() {
+        reuse Trait::<'static, i32, 1>::foo as bar;
+        //~^ ERROR: the trait bound `Self: test_9::Trait<'static, i32, 1>` is not satisfied [E0277]
+
+        bar::<u8>(123);
+        //~^ ERROR: function takes 3 generic arguments but 1 generic argument was supplied [E0107]
+    }
+}
+
+// Testing lifetimes + types in parent, lifetimes + types/consts in child,
+// adding self ty to reuse, testing using generic params from delegation parent
+// context, adding user-specified args to none, parent, parent and child
+mod test_10 {
+    trait Trait<'b, 'c, T> {
+        fn foo<'d: 'd, U, const M: bool>() {}
+    }
+
+    impl<'b, 'c, T> Trait<'b, 'c, T> for u8 {}
+
+    pub fn check() {
+        fn with_ctx<'a, 'b, 'c, A, B, C, const N: usize, const M: bool>() {
+            reuse <u8 as Trait>::foo as bar;
+            //~^ ERROR: missing generics for trait `test_10::Trait` [E0107]
+            bar::<'a, 'b, 'c, u8, C, A, M>();
+            bar::<'static, 'static, 'static, u8, i32, i32, false>();
+
+            reuse <u8 as Trait::<'static, 'static, i32>>::foo as bar1;
+            //~^ ERROR: type annotations needed [E0284]
+            bar1::<'static, u8, i32, true>();
+            //~^ ERROR: function takes 4 generic arguments but 3 generic arguments were supplied [E0107]
+            //~| ERROR: function takes 3 lifetime arguments but 1 lifetime argument was supplied [E0107]
+
+            reuse <u8 as Trait::<'static, 'static, i32>>::foo::<'static, u32, true> as bar2;
+            bar2::<u8>();
+            //~^ ERROR: function takes 4 generic arguments but 1 generic argument was supplied [E0107]
+        }
+
+        with_ctx::<i32, i32, i32, 1, true>();
+    }
+}
+
+// Testing lifetimes + types in parent, lifetimes + types/consts in child,
+// adding self ty to reuse, testing using generic params from delegation parent
+// context, testing predicates inheritance
+mod test_11 {
+    trait Bound0 {}
+    trait Bound1 {}
+    trait Bound2<T, U> {}
+
+    trait Trait<'a: 'static, T, P>
+    where
+        Self: Sized,
+        T: Bound0,
+        P: Bound2<P, Vec<Vec<Vec<T>>>>,
+    {
+        fn foo<'d: 'd, U: Bound1, const M: bool>() {}
+    }
+
+    impl Bound0 for u32 {}
+    impl Bound1 for String {}
+    impl<'a: 'static, T: Bound0, P: Bound2<P, Vec<Vec<Vec<T>>>>> Trait<'a, T, P> for usize {}
+
+    struct Struct;
+    impl Bound2<Struct, Vec<Vec<Vec<u32>>>> for Struct {}
+
+    pub fn check<'b>() {
+        reuse <usize as Trait>::foo;
+        //~^ ERROR: missing generics for trait `test_11::Trait` [E0107]
+        foo::<'static, 'b, usize, u32, Struct, String, false>();
+    }
+}
+
+// Testing lifetimes + types/consts in parent with defaults, none in child,
+// reuse without user-specified args
+mod test_12 {
+    trait Trait<'a, T = usize, const N: usize = 123>: Sized {
+        fn foo(self) {}
+    }
+
+    impl Trait<'static, i32, 1> for u8 {}
+
+    pub fn check() {
+        reuse Trait::foo as bar;
+
+        bar::<u8, i32, 1>(123);
+    }
+}
+
+pub fn main() {
+    test_1::check();
+    test_2::check();
+    test_3::check();
+    test_4::check();
+    test_5::check();
+    test_6::check();
+    test_7::check();
+    test_8::check();
+    test_9::check();
+    test_10::check();
+    test_11::check();
+    test_12::check();
+}

--- a/tests/ui/delegation/generics/mapping/free-to-trait.stderr
+++ b/tests/ui/delegation/generics/mapping/free-to-trait.stderr
@@ -1,0 +1,401 @@
+error[E0284]: type annotations needed
+  --> $DIR/free-to-trait.rs:22:26
+   |
+LL |             reuse Trait::foo as bar;
+   |                          ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_1::Trait::foo`
+  --> $DIR/free-to-trait.rs:15:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+help: consider specifying the generic arguments
+   |
+LL |             reuse Trait::foo::<U, M> as bar;
+   |                             ++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/free-to-trait.rs:28:26
+   |
+LL |             reuse Trait::foo as bar;
+   |                          ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_1::Trait::foo`
+  --> $DIR/free-to-trait.rs:15:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+help: consider specifying the generic arguments
+   |
+LL |             reuse Trait::foo::<U, M> as bar;
+   |                             ++++++++
+
+error[E0107]: function takes 2 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/free-to-trait.rs:50:9
+   |
+LL |         bar::<'static, u8, String, true>(123);
+   |         ^^^   ------- supplied 1 lifetime argument
+   |         |
+   |         expected 2 lifetime arguments
+   |
+note: function defined here, with 2 lifetime parameters: `'a`, `'b`
+  --> $DIR/free-to-trait.rs:47:48
+   |
+LL |     trait Trait<'a, T, const N: usize>: Sized {
+   |                 --
+LL |         fn foo<'b: 'b, U, const M: bool>(self) {}
+   |                --
+...
+LL |         reuse Trait::<'static, i32, 1>::foo as bar;
+   |                                                ^^^
+help: add missing lifetime argument
+   |
+LL |         bar::<'static, 'static, u8, String, true>(123);
+   |                      +++++++++
+
+error[E0107]: function takes 5 generic arguments but 3 generic arguments were supplied
+  --> $DIR/free-to-trait.rs:50:9
+   |
+LL |         bar::<'static, u8, String, true>(123);
+   |         ^^^            --  ------  ---- supplied 3 generic arguments
+   |         |
+   |         expected 5 generic arguments
+   |
+note: function defined here, with 5 generic parameters: `Self`, `T`, `N`, `U`, `M`
+  --> $DIR/free-to-trait.rs:47:48
+   |
+LL |     trait Trait<'a, T, const N: usize>: Sized {
+   |     -----------------------------------------
+LL |         fn foo<'b: 'b, U, const M: bool>(self) {}
+   |                        -  -------------
+...
+LL |         reuse Trait::<'static, i32, 1>::foo as bar;
+   |                                                ^^^
+help: add missing generic arguments
+   |
+LL |         bar::<'static, u8, String, true, U, M>(123);
+   |                                        ++++++
+
+error[E0277]: the trait bound `Self: test_2::Trait<'static, i32, 1>` is not satisfied
+  --> $DIR/free-to-trait.rs:47:41
+   |
+LL |         reuse Trait::<'static, i32, 1>::foo as bar;
+   |                                         ^^^ the trait `test_2::Trait<'static, i32, 1>` is not implemented for `Self`
+
+error[E0107]: function takes 2 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/free-to-trait.rs:68:9
+   |
+LL |         bar::<'static, u8, String, 1>(123);
+   |         ^^^   ------- supplied 1 lifetime argument
+   |         |
+   |         expected 2 lifetime arguments
+   |
+note: function defined here, with 2 lifetime parameters: `'a`, `'b`
+  --> $DIR/free-to-trait.rs:66:51
+   |
+LL |     trait Trait<'a, T, const N: usize>: Sized {
+   |                 --
+LL |         fn foo<'b: 'b, U, const M: bool>(self) {}
+   |                --
+...
+LL |         reuse Trait::foo::<'static, i32, true> as bar;
+   |                                                   ^^^
+help: add missing lifetime argument
+   |
+LL |         bar::<'static, 'static, u8, String, 1>(123);
+   |                      +++++++++
+
+error[E0107]: function takes 5 generic arguments but 3 generic arguments were supplied
+  --> $DIR/free-to-trait.rs:68:9
+   |
+LL |         bar::<'static, u8, String, 1>(123);
+   |         ^^^            --  ------  - supplied 3 generic arguments
+   |         |
+   |         expected 5 generic arguments
+   |
+note: function defined here, with 5 generic parameters: `Self`, `T`, `N`, `U`, `M`
+  --> $DIR/free-to-trait.rs:66:51
+   |
+LL |     trait Trait<'a, T, const N: usize>: Sized {
+   |     -----------------------------------------
+LL |         fn foo<'b: 'b, U, const M: bool>(self) {}
+   |                        -  -------------
+...
+LL |         reuse Trait::foo::<'static, i32, true> as bar;
+   |                                                   ^^^
+help: add missing generic arguments
+   |
+LL |         bar::<'static, u8, String, 1, U, M>(123);
+   |                                     ++++++
+
+error[E0107]: function takes 5 generic arguments but 3 generic arguments were supplied
+  --> $DIR/free-to-trait.rs:86:9
+   |
+LL |         bar::<u8, String, 1>(123);
+   |         ^^^   --  ------  - supplied 3 generic arguments
+   |         |
+   |         expected 5 generic arguments
+   |
+note: function defined here, with 5 generic parameters: `Self`, `T`, `N`, `U`, `M`
+  --> $DIR/free-to-trait.rs:84:51
+   |
+LL |     trait Trait<T, const N: usize>: Sized {
+   |     -------------------------------------
+LL |         fn foo<'b: 'b, U, const M: bool>(self) {}
+   |                        -  -------------
+...
+LL |         reuse Trait::foo::<'static, i32, true> as bar;
+   |                                                   ^^^
+help: add missing generic arguments
+   |
+LL |         bar::<u8, String, 1, U, M>(123);
+   |                            ++++++
+
+error[E0107]: function takes 4 generic arguments but 2 generic arguments were supplied
+  --> $DIR/free-to-trait.rs:102:9
+   |
+LL |         bar::<u8, 1>(123);
+   |         ^^^   --  - supplied 2 generic arguments
+   |         |
+   |         expected 4 generic arguments
+   |
+note: function defined here, with 4 generic parameters: `Self`, `N`, `U`, `M`
+  --> $DIR/free-to-trait.rs:100:51
+   |
+LL |     trait Trait<const N: usize>: Sized {
+   |     ----------------------------------
+LL |         fn foo<'b: 'b, U, const M: bool>(self) {}
+   |                        -  -------------
+...
+LL |         reuse Trait::foo::<'static, i32, true> as bar;
+   |                                                   ^^^
+help: add missing generic arguments
+   |
+LL |         bar::<u8, 1, U, M>(123);
+   |                    ++++++
+
+error[E0107]: function takes 3 generic arguments but 1 generic argument was supplied
+  --> $DIR/free-to-trait.rs:119:9
+   |
+LL |         bar::<u8>(123);
+   |         ^^^   -- supplied 1 generic argument
+   |         |
+   |         expected 3 generic arguments
+   |
+note: function defined here, with 3 generic parameters: `Self`, `U`, `M`
+  --> $DIR/free-to-trait.rs:117:51
+   |
+LL |     trait Trait: Sized {
+   |     ------------------
+LL |         fn foo<'b: 'b, U, const M: bool>(self) {}
+   |                        -  -------------
+...
+LL |         reuse Trait::foo::<'static, i32, true> as bar;
+   |                                                   ^^^
+help: add missing generic arguments
+   |
+LL |         bar::<u8, U, M>(123);
+   |                 ++++++
+
+error[E0107]: function takes 5 generic arguments but 3 generic arguments were supplied
+  --> $DIR/free-to-trait.rs:137:9
+   |
+LL |         bar::<u8, String, true>(123);
+   |         ^^^   --  ------  ---- supplied 3 generic arguments
+   |         |
+   |         expected 5 generic arguments
+   |
+note: function defined here, with 5 generic parameters: `Self`, `T`, `N`, `U`, `M`
+  --> $DIR/free-to-trait.rs:134:48
+   |
+LL |     trait Trait<'a, T, const N: usize>: Sized {
+   |     -----------------------------------------
+LL |         fn foo<U, const M: bool>(self) {}
+   |                -  -------------
+...
+LL |         reuse Trait::<'static, i32, 1>::foo as bar;
+   |                                                ^^^
+help: add missing generic arguments
+   |
+LL |         bar::<u8, String, true, U, M>(123);
+   |                               ++++++
+
+error[E0277]: the trait bound `Self: test_7::Trait<'static, i32, 1>` is not satisfied
+  --> $DIR/free-to-trait.rs:134:41
+   |
+LL |         reuse Trait::<'static, i32, 1>::foo as bar;
+   |                                         ^^^ the trait `test_7::Trait<'static, i32, 1>` is not implemented for `Self`
+
+error[E0107]: function takes 4 generic arguments but 2 generic arguments were supplied
+  --> $DIR/free-to-trait.rs:154:9
+   |
+LL |         bar::<u8, true>(123);
+   |         ^^^   --  ---- supplied 2 generic arguments
+   |         |
+   |         expected 4 generic arguments
+   |
+note: function defined here, with 4 generic parameters: `Self`, `T`, `N`, `M`
+  --> $DIR/free-to-trait.rs:151:48
+   |
+LL |     trait Trait<'a, T, const N: usize>: Sized {
+   |     -----------------------------------------
+LL |         fn foo<const M: bool>(self) {}
+   |                -------------
+...
+LL |         reuse Trait::<'static, i32, 1>::foo as bar;
+   |                                                ^^^
+help: add missing generic arguments
+   |
+LL |         bar::<u8, true, N, M>(123);
+   |                       ++++++
+
+error[E0277]: the trait bound `Self: test_8::Trait<'static, i32, 1>` is not satisfied
+  --> $DIR/free-to-trait.rs:151:41
+   |
+LL |         reuse Trait::<'static, i32, 1>::foo as bar;
+   |                                         ^^^ the trait `test_8::Trait<'static, i32, 1>` is not implemented for `Self`
+
+error[E0107]: function takes 3 generic arguments but 1 generic argument was supplied
+  --> $DIR/free-to-trait.rs:171:9
+   |
+LL |         bar::<u8>(123);
+   |         ^^^   -- supplied 1 generic argument
+   |         |
+   |         expected 3 generic arguments
+   |
+note: function defined here, with 3 generic parameters: `Self`, `T`, `N`
+  --> $DIR/free-to-trait.rs:168:48
+   |
+LL |     trait Trait<'a, T, const N: usize>: Sized {
+   |     -----------------------------------------
+...
+LL |         reuse Trait::<'static, i32, 1>::foo as bar;
+   |                                                ^^^
+help: add missing generic arguments
+   |
+LL |         bar::<u8, T, N>(123);
+   |                 ++++++
+
+error[E0277]: the trait bound `Self: test_9::Trait<'static, i32, 1>` is not satisfied
+  --> $DIR/free-to-trait.rs:168:41
+   |
+LL |         reuse Trait::<'static, i32, 1>::foo as bar;
+   |                                         ^^^ the trait `test_9::Trait<'static, i32, 1>` is not implemented for `Self`
+
+error[E0107]: function takes 3 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/free-to-trait.rs:195:13
+   |
+LL |             bar1::<'static, u8, i32, true>();
+   |             ^^^^   ------- supplied 1 lifetime argument
+   |             |
+   |             expected 3 lifetime arguments
+   |
+note: function defined here, with 3 lifetime parameters: `'b`, `'c`, `'d`
+  --> $DIR/free-to-trait.rs:193:66
+   |
+LL |     trait Trait<'b, 'c, T> {
+   |                 --  --
+LL |         fn foo<'d: 'd, U, const M: bool>() {}
+   |                --
+...
+LL |             reuse <u8 as Trait::<'static, 'static, i32>>::foo as bar1;
+   |                                                                  ^^^^
+help: add missing lifetime arguments
+   |
+LL |             bar1::<'static, 'static, 'static, u8, i32, true>();
+   |                           ++++++++++++++++++
+
+error[E0107]: function takes 4 generic arguments but 3 generic arguments were supplied
+  --> $DIR/free-to-trait.rs:195:13
+   |
+LL |             bar1::<'static, u8, i32, true>();
+   |             ^^^^            --  ---  ---- supplied 3 generic arguments
+   |             |
+   |             expected 4 generic arguments
+   |
+note: function defined here, with 4 generic parameters: `Self`, `T`, `U`, `M`
+  --> $DIR/free-to-trait.rs:193:66
+   |
+LL |     trait Trait<'b, 'c, T> {
+   |     ----------------------
+LL |         fn foo<'d: 'd, U, const M: bool>() {}
+   |                        -  -------------
+...
+LL |             reuse <u8 as Trait::<'static, 'static, i32>>::foo as bar1;
+   |                                                                  ^^^^
+help: add missing generic argument
+   |
+LL |             bar1::<'static, u8, i32, true, M>();
+   |                                          +++
+
+error[E0107]: function takes 4 generic arguments but 1 generic argument was supplied
+  --> $DIR/free-to-trait.rs:200:13
+   |
+LL |             bar2::<u8>();
+   |             ^^^^   -- supplied 1 generic argument
+   |             |
+   |             expected 4 generic arguments
+   |
+note: function defined here, with 4 generic parameters: `Self`, `T`, `U`, `M`
+  --> $DIR/free-to-trait.rs:199:88
+   |
+LL |     trait Trait<'b, 'c, T> {
+   |     ----------------------
+LL |         fn foo<'d: 'd, U, const M: bool>() {}
+   |                        -  -------------
+...
+LL |             reuse <u8 as Trait::<'static, 'static, i32>>::foo::<'static, u32, true> as bar2;
+   |                                                                                        ^^^^
+help: add missing generic arguments
+   |
+LL |             bar2::<u8, T, U, M>();
+   |                      +++++++++
+
+error[E0107]: missing generics for trait `test_10::Trait`
+  --> $DIR/free-to-trait.rs:188:26
+   |
+LL |             reuse <u8 as Trait>::foo as bar;
+   |                          ^^^^^ expected 1 generic argument
+   |
+note: trait defined here, with 1 generic parameter: `T`
+  --> $DIR/free-to-trait.rs:180:11
+   |
+LL |     trait Trait<'b, 'c, T> {
+   |           ^^^^^         -
+help: add missing generic argument
+   |
+LL |             reuse <u8 as Trait<T>>::foo as bar;
+   |                               +++
+
+error[E0284]: type annotations needed
+  --> $DIR/free-to-trait.rs:193:59
+   |
+LL |             reuse <u8 as Trait::<'static, 'static, i32>>::foo as bar1;
+   |                                                           ^^^ cannot infer the value of the const parameter `M` declared on the associated function `foo`
+   |
+note: required by a const generic parameter in `test_10::Trait::foo`
+  --> $DIR/free-to-trait.rs:181:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>() {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+
+error[E0107]: missing generics for trait `test_11::Trait`
+  --> $DIR/free-to-trait.rs:233:25
+   |
+LL |         reuse <usize as Trait>::foo;
+   |                         ^^^^^ expected 2 generic arguments
+   |
+note: trait defined here, with 2 generic parameters: `T`, `P`
+  --> $DIR/free-to-trait.rs:216:11
+   |
+LL |     trait Trait<'a: 'static, T, P>
+   |           ^^^^^              -  -
+help: add missing generic arguments
+   |
+LL |         reuse <usize as Trait<T, P>>::foo;
+   |                              ++++++
+
+error: aborting due to 22 previous errors
+
+Some errors have detailed explanations: E0107, E0277, E0284.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/delegation/generics/mapping/impl-trait-to-free.rs
+++ b/tests/ui/delegation/generics/mapping/impl-trait-to-free.rs
@@ -1,0 +1,266 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+#![allow(late_bound_lifetime_arguments)]
+
+//! This is one of the mapping tests, which tests mapping of delegee parent and child
+//! generic params, whose main goal is to create cases with
+//! different number of lifetimes/types/consts in delegee child and parent; and in
+//! delegation parent if applicable. At some tests predicates are
+//! added. At some tests user-specified args are specified in reuse statement.
+
+// Testing lifetimes + types/consts in child reuses,
+// with (un)specified user args with additional generic params in delegation parent
+mod test_1 {
+    mod to_reuse {
+        pub fn foo<'a: 'a, 'b: 'b, A, B, const N: usize>() {}
+        pub fn bar<'a: 'a, 'b: 'b, A, B, const N: usize>(x: &super::XX) {}
+    }
+
+    trait Trait<'a, 'b, 'c, A, B, const N: usize>: Sized {
+        fn foo<'x: 'x, 'y: 'y, AA, BB, const NN: usize>() {}
+        fn bar<'x: 'x, 'y: 'y, AA, BB, const NN: usize>(&self) {}
+        fn oof() {}
+        fn rab(&self) {}
+    }
+
+    struct X<'x1, 'x2, 'x3, 'x4, X1, X2, const X3: usize>(
+        &'x1 X1, &'x2 X2, &'x3 X1, &'x4 [usize; X3]);
+    type XX = X::<'static, 'static, 'static, 'static, i32, i32, 3>;
+
+    impl<'a, 'b, 'c, A, B, const N: usize> Trait<'a, 'b, 'c, A, B, N> for XX {
+        reuse to_reuse::foo;
+        //~^ ERROR: type annotations needed [E0284]
+        reuse to_reuse::bar;
+        //~^ ERROR: type annotations needed [E0284]
+
+        reuse to_reuse::foo::<'a, 'c, A, String, 322> as oof;
+        reuse to_reuse::bar::<'a, 'c, A, B, 223> as rab;
+    }
+
+    pub fn check() {
+        let x = X(&1, &2, &3, &[1, 2, 3]);
+
+        <XX as Trait<'static, 'static, 'static, i32, i32, 1>>
+            ::foo::<'static, 'static, i8, i16, 123>();
+        <XX as Trait<'static, 'static, 'static, i32, i32, 1>>
+            ::bar::<'static, 'static, String, i16, 123>(&x);
+        <XX as Trait<'static, 'static, 'static, i32, i32, 1>>::oof();
+        <XX as Trait<'static, 'static, 'static, i32, String, 1>>::rab(&x);
+    }
+}
+
+// Testing types/consts in child reuses,
+// with (un)specified user args, with additional generic params in delegation parent
+mod test_2 {
+    mod to_reuse {
+        pub fn foo<A, B, const N: usize>() {}
+        pub fn bar<A, B, const N: usize>(x: &super::X) {}
+    }
+
+    trait Trait<'a, 'b, 'c, A, B, const N: usize>: Sized {
+        fn foo<AA, BB, const NN: usize>() {}
+        fn bar<AA, BB, const NN: usize>(&self) {}
+        fn oof() {}
+        fn rab(&self) {}
+    }
+
+    struct X;
+    impl<'a, A, B, const N: usize> Trait<'a, 'static, 'static, A, B, N> for X {
+        reuse to_reuse::foo;
+        //~^ ERROR: type annotations needed [E0284]
+        reuse to_reuse::bar;
+        //~^ ERROR: type annotations needed [E0284]
+
+        reuse to_reuse::foo::<A, String, 322> as oof;
+        reuse to_reuse::bar::<i32, B, 223> as rab;
+    }
+
+    pub fn check() {
+        <X as Trait<'static, 'static, 'static, i32, i32, 1>>::foo::<i8, i16, 123>();
+        <X as Trait<'static, 'static, 'static, i32, i32, 1>>::bar::<X, i16, 123>(&X);
+        <X as Trait<'static, 'static, 'static, i32, i32, 1>>::oof();
+        <X as Trait<'static, 'static, 'static, i32, i32, 1>>::rab(&X);
+    }
+}
+
+// Testing none in child reuses, with unspecified user args,
+// with additional generic params in delegation parent
+mod test_3 {
+    mod to_reuse {
+        pub fn foo() {}
+        pub fn bar(x: &super::X) {}
+    }
+
+    trait Trait<'a, 'b, 'c, A, B, const N: usize>: Sized {
+        fn foo() {}
+        fn bar(&self) {}
+    }
+
+    struct X;
+    impl<'a, A, B, const N: usize> Trait<'a, 'static, 'static, A, B, N> for X {
+        reuse to_reuse::foo;
+        reuse to_reuse::bar;
+    }
+
+    pub fn check() {
+        <X as Trait<'static, 'static, 'static, i32, i32, 1>>::foo();
+        <X as Trait<'static, 'static, 'static, i32, i32, 1>>::bar(&X);
+    }
+}
+
+// Testing lifetimes + types/consts in child reuses,
+// with (un)specified user args, with additional generic params in delegation parent
+mod test_4 {
+    mod to_reuse {
+        pub fn foo<'a: 'a, 'b: 'b, A, B, const N: usize>() {}
+        pub fn bar<'a: 'a, 'b: 'b, A, B, const N: usize>(x: &super::X) {}
+    }
+
+    trait Trait<A, B, const N: usize>: Sized {
+        fn foo<'x: 'x, 'y: 'y, AA, BB, const NN: usize>() {}
+        fn bar<'x: 'x, 'y: 'y, AA, BB, const NN: usize>(&self) {}
+        fn oof() {}
+        fn rab(&self) {}
+    }
+
+    struct X;
+    impl<'a, 'c, A, B, const N: usize> Trait<A, B, N> for X {
+        reuse to_reuse::foo;
+        //~^ ERROR: type annotations needed [E0284]
+        reuse to_reuse::bar;
+        //~^ ERROR: type annotations needed [E0284]
+
+        reuse to_reuse::foo::<'a, 'c, A, String, 322> as oof;
+        reuse to_reuse::bar::<'a, 'c, i32, B, 223> as rab;
+    }
+
+    pub fn check() {
+        <X as Trait<i32, i32, 1>>::foo::<'static, 'static, i8, i16, 123>();
+        <X as Trait<i32, i32, 1>>::bar::<'static, 'static, X, i16, 123>(&X);
+        <X as Trait<i32, i32, 1>>::oof();
+        <X as Trait<i32, i32, 1>>::rab(&X);
+    }
+}
+
+// Testing lifetimes + types/consts in child reuses,
+// with (un)specified user args, with additional generic params in delegation parent
+mod test_5 {
+    mod to_reuse {
+        pub fn foo<'a: 'a, 'b: 'b, A, B, const N: usize>() {}
+        pub fn bar<'a: 'a, 'b: 'b, A, B, const N: usize>(x: &super::X::<A, B>) {}
+    }
+
+    trait Trait: Sized {
+        fn foo<'x: 'x, 'y: 'y, AA, BB, const NN: usize>() {}
+        fn bar<'x: 'x, 'y: 'y, AA, BB, const NN: usize>(&self) {}
+        fn oof() {}
+        fn rab(&self) {}
+    }
+
+    struct X<A, B>(A, B);
+    impl<'a, 'c, A, B> Trait for X<A, B> {
+        reuse to_reuse::foo::<'a, 'c, A, B, 322> as oof;
+        reuse to_reuse::bar::<'a, 'c, A, B, 223> as rab;
+    }
+
+    pub fn check() {
+        <X::<i32, i32> as Trait>::oof();
+        <X::<i32, i32> as Trait>::rab(&X(1, 2));
+    }
+}
+
+// Testing types/consts in child reuses,
+// with (un)specified user args, with additional generic params in delegation parent
+mod test_6 {
+    mod to_reuse {
+        pub fn foo<A, B, const N: usize>() {}
+        pub fn bar<A, B, const N: usize>(x: &super::X) {}
+    }
+
+    trait Trait<A, B, const N: usize>: Sized {
+        fn foo<AA, BB, const NN: usize>() {}
+        fn bar<AA, BB, const NN: usize>(&self) {}
+        fn oof() {}
+        fn rab(&self) {}
+    }
+
+    struct X;
+    impl<'a, 'c, A, B, const N: usize> Trait<A, B, N> for X {
+        reuse to_reuse::foo;
+        //~^ ERROR: type annotations needed [E0284]
+        reuse to_reuse::bar;
+        //~^ ERROR: type annotations needed [E0284]
+
+        reuse to_reuse::foo::<A, String, 322> as oof;
+        reuse to_reuse::bar::<i32, B, 223> as rab;
+    }
+
+    pub fn check() {
+        <X as Trait<i32, i32, 1>>::foo::<i8, i16, 123>();
+        <X as Trait<i32, i32, 1>>::bar::<X, i16, 123>(&X);
+        <X as Trait<i32, i32, 1>>::oof();
+        <X as Trait<i32, i32, 1>>::rab(&X);
+    }
+}
+
+// Testing none in child reuses, with unspecified user args,
+// with additional generic params in delegation parent
+mod test_7 {
+    mod to_reuse {
+        pub fn foo() {}
+        pub fn bar(x: &super::X) {}
+    }
+
+    trait Trait<A, B, const N: usize>: Sized {
+        fn foo() {}
+        fn bar(&self) {}
+    }
+
+    struct X;
+    impl<'a, 'c, A, B, const N: usize> Trait<A, B, N> for X {
+        reuse to_reuse::foo;
+        reuse to_reuse::bar;
+    }
+
+    pub fn check() {
+        <X as Trait<i32, i32, 1>>::foo();
+        <X as Trait<i32, i32, 1>>::bar(&X);
+    }
+}
+
+// Testing none in child reuses, with unspecified user args
+mod test_8 {
+    mod to_reuse {
+        pub fn foo() {}
+        pub fn bar(x: &super::X) {}
+    }
+
+    trait Trait: Sized {
+        fn foo() {}
+        fn bar(&self) {}
+    }
+
+    struct X;
+    impl Trait for X {
+        reuse to_reuse::foo;
+        reuse to_reuse::bar;
+    }
+
+    pub fn check() {
+        <X as Trait>::foo();
+        <X as Trait>::bar(&X);
+        X::foo();
+        X::bar(&X);
+    }
+}
+
+fn main() {
+    test_1::check();
+    test_2::check();
+    test_3::check();
+    test_4::check();
+    test_5::check();
+    test_6::check();
+    test_7::check();
+    test_8::check();
+}

--- a/tests/ui/delegation/generics/mapping/impl-trait-to-free.stderr
+++ b/tests/ui/delegation/generics/mapping/impl-trait-to-free.stderr
@@ -1,0 +1,131 @@
+error[E0284]: type annotations needed
+  --> $DIR/impl-trait-to-free.rs:31:25
+   |
+LL |         reuse to_reuse::foo;
+   |                         ^^^ cannot infer the value of the const parameter `N` declared on the function `foo`
+   |
+note: required by a const generic parameter in `test_1::to_reuse::foo`
+  --> $DIR/impl-trait-to-free.rs:15:42
+   |
+LL |         pub fn foo<'a: 'a, 'b: 'b, A, B, const N: usize>() {}
+   |                                          ^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse to_reuse::foo::<A, B, N>;
+   |                            +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/impl-trait-to-free.rs:33:25
+   |
+LL |         reuse to_reuse::bar;
+   |                         ^^^ cannot infer the value of the const parameter `N` declared on the function `bar`
+   |
+note: required by a const generic parameter in `test_1::to_reuse::bar`
+  --> $DIR/impl-trait-to-free.rs:16:42
+   |
+LL |         pub fn bar<'a: 'a, 'b: 'b, A, B, const N: usize>(x: &super::XX) {}
+   |                                          ^^^^^^^^^^^^^^ required by this const generic parameter in `bar`
+help: consider specifying the generic arguments
+   |
+LL |         reuse to_reuse::bar::<A, B, N>;
+   |                            +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/impl-trait-to-free.rs:69:25
+   |
+LL |         reuse to_reuse::foo;
+   |                         ^^^ cannot infer the value of the const parameter `N` declared on the function `foo`
+   |
+note: required by a const generic parameter in `test_2::to_reuse::foo`
+  --> $DIR/impl-trait-to-free.rs:56:26
+   |
+LL |         pub fn foo<A, B, const N: usize>() {}
+   |                          ^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse to_reuse::foo::<A, B, N>;
+   |                            +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/impl-trait-to-free.rs:71:25
+   |
+LL |         reuse to_reuse::bar;
+   |                         ^^^ cannot infer the value of the const parameter `N` declared on the function `bar`
+   |
+note: required by a const generic parameter in `test_2::to_reuse::bar`
+  --> $DIR/impl-trait-to-free.rs:57:26
+   |
+LL |         pub fn bar<A, B, const N: usize>(x: &super::X) {}
+   |                          ^^^^^^^^^^^^^^ required by this const generic parameter in `bar`
+help: consider specifying the generic arguments
+   |
+LL |         reuse to_reuse::bar::<A, B, N>;
+   |                            +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/impl-trait-to-free.rs:128:25
+   |
+LL |         reuse to_reuse::foo;
+   |                         ^^^ cannot infer the value of the const parameter `N` declared on the function `foo`
+   |
+note: required by a const generic parameter in `test_4::to_reuse::foo`
+  --> $DIR/impl-trait-to-free.rs:115:42
+   |
+LL |         pub fn foo<'a: 'a, 'b: 'b, A, B, const N: usize>() {}
+   |                                          ^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse to_reuse::foo::<A, B, N>;
+   |                            +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/impl-trait-to-free.rs:130:25
+   |
+LL |         reuse to_reuse::bar;
+   |                         ^^^ cannot infer the value of the const parameter `N` declared on the function `bar`
+   |
+note: required by a const generic parameter in `test_4::to_reuse::bar`
+  --> $DIR/impl-trait-to-free.rs:116:42
+   |
+LL |         pub fn bar<'a: 'a, 'b: 'b, A, B, const N: usize>(x: &super::X) {}
+   |                                          ^^^^^^^^^^^^^^ required by this const generic parameter in `bar`
+help: consider specifying the generic arguments
+   |
+LL |         reuse to_reuse::bar::<A, B, N>;
+   |                            +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/impl-trait-to-free.rs:189:25
+   |
+LL |         reuse to_reuse::foo;
+   |                         ^^^ cannot infer the value of the const parameter `N` declared on the function `foo`
+   |
+note: required by a const generic parameter in `test_6::to_reuse::foo`
+  --> $DIR/impl-trait-to-free.rs:176:26
+   |
+LL |         pub fn foo<A, B, const N: usize>() {}
+   |                          ^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse to_reuse::foo::<A, B, N>;
+   |                            +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/impl-trait-to-free.rs:191:25
+   |
+LL |         reuse to_reuse::bar;
+   |                         ^^^ cannot infer the value of the const parameter `N` declared on the function `bar`
+   |
+note: required by a const generic parameter in `test_6::to_reuse::bar`
+  --> $DIR/impl-trait-to-free.rs:177:26
+   |
+LL |         pub fn bar<A, B, const N: usize>(x: &super::X) {}
+   |                          ^^^^^^^^^^^^^^ required by this const generic parameter in `bar`
+help: consider specifying the generic arguments
+   |
+LL |         reuse to_reuse::bar::<A, B, N>;
+   |                            +++++++++++
+
+error: aborting due to 8 previous errors
+
+For more information about this error, try `rustc --explain E0284`.

--- a/tests/ui/delegation/generics/mapping/impl-trait-to-trait.rs
+++ b/tests/ui/delegation/generics/mapping/impl-trait-to-trait.rs
@@ -1,0 +1,241 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+#![allow(late_bound_lifetime_arguments)]
+
+//! This is one of the mapping tests, which tests mapping of delegee parent and child
+//! generic params, whose main goal is to create cases with
+//! different number of lifetimes/types/consts in delegee child and parent; and in
+//! delegation parent if applicable. At some tests predicates are
+//! added. At some tests user-specified args are specified in reuse statement.
+
+// Testing types in parent, types in child reuse,
+// testing predicates inheritance,
+// with additional generic params in delegation parent
+mod test_1 {
+    trait Trait0 {}
+
+    trait Trait1<T> {
+        fn foo<U>(&self)
+        where
+            T: Trait0,
+            U: Trait0,
+        {
+        }
+    }
+
+    struct F;
+    impl<T> Trait1<T> for F {}
+
+    struct S<'a, 'b, 'c, A, B>(F, &'a A, &'b B, &'c B);
+
+    impl<'a, 'b, 'c, T, A, B> Trait1<T> for S<'a, 'b, 'c, A, B> {
+        reuse Trait1::<T>::foo { &self.0 }
+        //~^ ERROR: type annotations needed [E0283]
+    }
+
+    impl Trait0 for u16 {}
+
+    pub fn check() {
+        let s = S(F, &123, &123, &123);
+        <S::<'static, 'static, 'static, i32, i32> as Trait1<u16>>::foo::<u16>(&s);
+    }
+}
+
+// Testing none in parent, none in child reuse,
+// with additional generic params in delegation parent
+mod test_2 {
+    trait Trait {
+        fn foo(&self) {}
+    }
+
+    struct F;
+    impl Trait for F {}
+
+    struct S<'a, 'b, 'c, A, B, const C: bool>(F, &'a A, &'b B, &'c B);
+
+    impl<'a, 'b, 'c, A, B, const C: bool> Trait for S<'a, 'b, 'c, A, B, C> {
+        reuse Trait::foo { &self.0 }
+    }
+
+    pub fn check() {
+        let s = S(F, &123, &123, &123);
+        <S::<'static, 'static, 'static, i32, i32, true> as Trait>::foo(&s);
+    }
+}
+
+// Testing lifetimes + types in parent, none in child reuse,
+// with additional generic params in delegation parent
+mod test_3 {
+    trait Trait<'a, 'b, 'c, X, Y, Z> {
+        fn foo(&self) {}
+    }
+
+    struct F;
+    impl<'a, 'b, 'c, X, Y, Z> Trait<'a, 'b, 'c, X, Y, Z> for F {}
+
+    struct S<'a, 'b, 'c, A, B, const C: bool>(F, &'a A, &'b B, &'c B);
+
+    impl<'a, 'b, 'c, A, B, const C: bool> Trait<'a, 'b, 'static, A, String, bool>
+        for S<'a, 'b, 'c, A, B, C> {
+        reuse Trait::<'a, 'b, 'static, A, String, bool>::foo { &self.0 }
+    }
+
+    pub fn check() {
+        let s = S(F, &123, &123, &123);
+        <S::<'static, 'static, 'static, i32, i32, true>
+            as Trait<'static, 'static, 'static, i32, String, bool>>::foo(&s);
+    }
+}
+
+// Testing lifetimes + types in parent, lifetimes + types/consts in child reuse,
+// with additional generic params in delegation parent
+mod test_4 {
+    trait Trait<'a, 'b, 'c, X, Y, Z> {
+        fn foo<'x: 'x, 'y: 'y, 'z: 'z, A, B, C, const XX: usize>(&self) {}
+    }
+
+    struct F;
+    impl<'a, 'b, 'c, X, Y, Z> Trait<'a, 'b, 'c, X, Y, Z> for F {}
+
+    struct S<'a, 'b, 'c, A, B, const C: bool>(F, &'a A, &'b B, &'c B);
+
+    impl<'a, 'b, 'c, A, B, const C: bool> Trait<'a, 'b, 'static, A, String, bool>
+        for S<'a, 'b, 'c, A, B, C> {
+        reuse Trait::<'a, 'b, 'static, A, String, bool>::foo { &self.0 }
+        //~^ ERROR: type annotations needed [E0284]
+    }
+
+    pub fn check() {
+        let s = S(F, &123, &123, &123);
+        <S::<'static, 'static, 'static, i32, i32, true>
+            as Trait<'static, 'static, 'static, i32, String, bool>>
+                ::foo::<'static, 'static, 'static, i32, i32, i32, 1>(&s);
+    }
+}
+
+// Testing types in parent, lifetimes in child reuse
+// with additional generic params in delegation parent
+mod test_5 {
+    trait Trait<X, Y, Z> {
+        fn foo<'a: 'a, 'b: 'b, 'c: 'c>(&self) {}
+    }
+
+    struct F;
+    impl<X, Y, Z> Trait<X, Y, Z> for F {}
+
+    struct S<'a, 'b, 'c, A, B, const C: bool>(F, &'a A, &'b B, &'c B);
+
+    impl<'a, 'b, 'c, A, B, const C: bool> Trait<A, String, bool> for S<'a, 'b, 'c, A, B, C> {
+        reuse Trait::<A, String, bool>::foo { &self.0 }
+    }
+
+    pub fn check() {
+        let s = S(F, &123, &123, &123);
+        <S::<i32, i32, true> as Trait<i32, String, bool>>
+            ::foo::<'static, 'static, 'static>(&s);
+        <S::<i32, i32, true> as Trait<i32, String, bool>>::foo(&s);
+    }
+}
+
+// Testing types in parent, types in child reuse
+// with additional generic params in delegation parent
+mod test_6 {
+    trait Trait<X, Y, Z> {
+        fn foo<A, B, C>(&self) {}
+    }
+
+    struct F;
+    impl<X, Y, Z> Trait<X, Y, Z> for F {}
+
+    struct S<'a, 'b, 'c, A, B, const C: bool>(F, &'a A, &'b B, &'c B);
+
+    impl<'a, 'b, 'c, A, B, const C: bool> Trait<A, String, bool> for S<'a, 'b, 'c, A, B, C> {
+        reuse Trait::<A, String, bool>::foo { &self.0 }
+        //~^ ERROR: type annotations needed [E0282]
+    }
+
+    pub fn check() {
+        let s = S(F, &123, &123, &123);
+        <S::<i32, i32, true> as Trait<i32, String, bool>>::foo::<i32, i32, i32>(&s);
+    }
+}
+
+// Testing types in parent, none in child reuse
+// with additional generic params in delegation parent
+mod test_7 {
+    trait Trait<X, Y, Z> {
+        fn foo(&self) {}
+    }
+
+    struct F;
+    impl<X, Y, Z> Trait<X, Y, Z> for F {}
+
+    struct S<'a, 'b, 'c, A, B, const C: bool>(F, &'a A, &'b B, &'c B);
+
+    impl<'a, 'b, 'c, A, B, const C: bool> Trait<A, String, bool> for S<'a, 'b, 'c, A, B, C> {
+        reuse Trait::<A, String, bool>::foo { &self.0 }
+    }
+
+    pub fn check() {
+        let s = S(F, &123, &123, &123);
+        <S::<i32, i32, true> as Trait<i32, String, bool>>::foo(&s);
+    }
+}
+
+// Testing lifetimes in parent, none in child reuse
+// with additional generic params in delegation parent
+mod test_8 {
+    trait Trait<'a, 'b, 'c> {
+        fn foo(&self) {}
+    }
+
+    struct F;
+    impl<'a, 'b, 'c> Trait<'a, 'b, 'c> for F {}
+
+    struct S<'a, 'b, 'c, A, B, const C: bool>(F, &'a A, &'b B, &'c B);
+
+    impl<'a, 'b, 'c, A, B, const C: bool> Trait<'a, 'b, 'c> for S<'a, 'b, 'c, A, B, C> {
+        reuse Trait::<'a, 'static, 'b>::foo { &self.0 }
+    }
+
+    pub fn check() {
+        let s = S(F, &123, &123, &123);
+        <S::<i32, i32, true> as Trait<'static, 'static, 'static>>::foo(&s);
+    }
+}
+
+// Testing lifetimes in parent, lifetimes in child reuse
+// with additional generic params in delegation parent
+mod test_9 {
+    trait Trait<'a, 'b, 'c> {
+        fn foo<'x: 'x, 'y: 'y>(&self) {}
+    }
+
+    struct F;
+    impl<'a, 'b, 'c> Trait<'a, 'b, 'c> for F {}
+
+    struct S<'a, 'b, 'c, A, B, const C: bool>(F, &'a A, &'b B, &'c B);
+
+    impl<'a, 'b, 'c, A, B, const C: bool> Trait<'a, 'b, 'c> for S<'a, 'b, 'c, A, B, C> {
+        reuse Trait::<'a, 'static, 'b>::foo { &self.0 }
+    }
+
+    pub fn check() {
+        let s = S(F, &123, &123, &123);
+        <S::<i32, i32, true> as Trait<'static, 'static, 'static>>::foo(&s);
+        <S::<i32, i32, true> as Trait<'static, 'static, 'static>>
+            ::foo::<'static, 'static>(&s);
+    }
+}
+
+fn main() {
+    test_1::check();
+    test_2::check();
+    test_3::check();
+    test_4::check();
+    test_5::check();
+    test_6::check();
+    test_7::check();
+    test_8::check();
+    test_9::check();
+}

--- a/tests/ui/delegation/generics/mapping/impl-trait-to-trait.stderr
+++ b/tests/ui/delegation/generics/mapping/impl-trait-to-trait.stderr
@@ -1,0 +1,43 @@
+error[E0283]: type annotations needed
+  --> $DIR/impl-trait-to-trait.rs:32:28
+   |
+LL |         reuse Trait1::<T>::foo { &self.0 }
+   |                            ^^^ cannot infer type of the type parameter `U` declared on the method `foo`
+   |
+   = note: cannot satisfy `_: Trait0`
+help: the trait `Trait0` is implemented for `u16`
+  --> $DIR/impl-trait-to-trait.rs:36:5
+   |
+LL |     impl Trait0 for u16 {}
+   |     ^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `Trait1::foo`
+  --> $DIR/impl-trait-to-trait.rs:21:16
+   |
+LL |         fn foo<U>(&self)
+   |            --- required by a bound in this associated function
+...
+LL |             U: Trait0,
+   |                ^^^^^^ required by this bound in `Trait1::foo`
+
+error[E0284]: type annotations needed
+  --> $DIR/impl-trait-to-trait.rs:104:58
+   |
+LL |         reuse Trait::<'a, 'b, 'static, A, String, bool>::foo { &self.0 }
+   |                                                          ^^^ cannot infer the value of the const parameter `XX` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_4::Trait::foo`
+  --> $DIR/impl-trait-to-trait.rs:94:49
+   |
+LL |         fn foo<'x: 'x, 'y: 'y, 'z: 'z, A, B, C, const XX: usize>(&self) {}
+   |                                                 ^^^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+
+error[E0282]: type annotations needed
+  --> $DIR/impl-trait-to-trait.rs:153:41
+   |
+LL |         reuse Trait::<A, String, bool>::foo { &self.0 }
+   |                                         ^^^ cannot infer type of the type parameter `A` declared on the method `foo`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0282, E0283, E0284.
+For more information about an error, try `rustc --explain E0282`.

--- a/tests/ui/delegation/generics/mapping/inherent-impl-to-free.rs
+++ b/tests/ui/delegation/generics/mapping/inherent-impl-to-free.rs
@@ -1,0 +1,130 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+#![allow(late_bound_lifetime_arguments)]
+
+//! This is one of the mapping tests, which tests mapping of delegee parent and child
+//! generic params, whose main goal is to create cases with
+//! different number of lifetimes/types/consts in delegee child and parent; and in
+//! delegation parent if applicable. At some tests predicates are
+//! added. At some tests user-specified args are specified in reuse statement.
+
+// Testing lifetimes + types/consts OR types/consts OR none in delegation parent,
+// lifetimes + types/consts in child reuse,
+// with(out) user-specified args
+mod test_1 {
+    mod to_reuse {
+        pub fn foo<'a: 'a, 'b: 'b, A, B, const N: usize>() {}
+    }
+
+    struct X1<'a, 'b, T, X, const N: usize>(&'a T, &'b X, &'a [i32; N]);
+    impl<'a, 'b, T, E, const N: usize> X1<'a, 'b, T, E, N> {
+        reuse to_reuse::foo;
+        //~^ ERROR: type annotations needed [E0284]
+        reuse to_reuse::foo::<'static, 'static, i32, String, 1> as bar;
+    }
+
+    struct X2<T, X, const N: usize>(T, X, &'static [i32; N]);
+    impl<T, E, const N: usize> X2<T, E, N> {
+        reuse to_reuse::foo;
+        //~^ ERROR: type annotations needed [E0284]
+        reuse to_reuse::foo::<'static, 'static, i32, String, 1> as bar;
+    }
+
+    struct X3;
+    impl X3 {
+        reuse to_reuse::foo;
+        //~^ ERROR: type annotations needed [E0284]
+        reuse to_reuse::foo::<'static, 'static, i32, String, 1> as bar;
+    }
+
+    pub fn check() {
+        X1::<'static, 'static, i32, i32, 1>
+            ::foo::<'static, 'static, String, String, 123>();
+        X1::<'static, 'static, i32, i32, 1>::bar();
+        //~^ ERROR: type annotations needed [E0284]
+
+        X2::<i32, i32, 1>::foo::<'static, 'static, String, String, 123>();
+        X2::<i32, i32, 1>::bar();
+        //~^ ERROR: type annotations needed [E0284]
+
+        X3::foo::<'static, 'static, String, String, 123>();
+        X3::bar();
+        //~^ ERROR: type annotations needed [E0284]
+    }
+}
+
+// Testing lifetimes + types/consts OR types/consts OR none in parent,
+// types/consts in child reuse, with(out) user-specified args
+mod test_2 {
+    fn foo<A, B, const N: usize>() {}
+
+    struct X1<'a, 'b, T, X, const N: usize>(&'a T, &'b X, &'a [i32; N]);
+    impl<'a, 'b, T, E, const N: usize> X1<'a, 'b, T, E, N> {
+        reuse foo;
+        //~^ ERROR: type annotations needed [E0284]
+        reuse foo::<i32, String, 1> as bar;
+    }
+
+    struct X2<T, X, const N: usize>(T, X, &'static [i32; N]);
+    impl<T, E, const N: usize> X2<T, E, N> {
+        reuse foo;
+        //~^ ERROR: type annotations needed [E0284]
+        reuse foo::<i32, String, 1> as bar;
+    }
+
+    struct X3;
+    impl X3 {
+        reuse foo;
+        //~^ ERROR: type annotations needed [E0284]
+        reuse foo::<i32, String, 1> as bar;
+    }
+
+    pub fn check() {
+        X1::<'static, 'static, i32, i32, 1>::foo::<String, String, 123>();
+        X1::<'static, 'static, i32, i32, 1>::bar();
+        //~^ ERROR: type annotations needed [E0284]
+
+        X2::<i32, i32, 1>::foo::<String, String, 123>();
+        X2::<i32, i32, 1>::bar();
+        //~^ ERROR: type annotations needed [E0284]
+
+        X3::foo::<String, String, 123>();
+        X3::bar();
+        //~^ ERROR: type annotations needed [E0284]
+    }
+}
+
+// Testing lifetimes + types/consts OR types/consts OR none in parent,
+// none in child reuse
+mod test_3 {
+    fn foo() {}
+
+    struct X1<'a, 'b, T, X, const N: usize>(&'a T, &'b X, &'a [i32; N]);
+    impl<'a, 'b, T, E, const N: usize> X1<'a, 'b, T, E, N> {
+        reuse foo;
+    }
+
+    struct X2<T, X, const N: usize>(T, X, &'static [i32; N]);
+    impl<T, E, const N: usize> X2<T, E, N> {
+        reuse foo;
+    }
+
+    struct X3;
+    impl X3 {
+        reuse foo;
+    }
+
+    pub fn check() {
+        X1::<'static, 'static, i32, i32, 1>::foo();
+
+        X2::<i32, i32, 1>::foo();
+
+        X3::foo();
+    }
+}
+
+fn main() {
+    test_1::check();
+    test_2::check();
+    test_3::check();
+}

--- a/tests/ui/delegation/generics/mapping/inherent-impl-to-free.stderr
+++ b/tests/ui/delegation/generics/mapping/inherent-impl-to-free.stderr
@@ -1,0 +1,213 @@
+error[E0284]: type annotations needed
+  --> $DIR/inherent-impl-to-free.rs:21:25
+   |
+LL |         reuse to_reuse::foo;
+   |                         ^^^ cannot infer the value of the const parameter `N` declared on the function `foo`
+   |
+note: required by a const generic parameter in `to_reuse::foo`
+  --> $DIR/inherent-impl-to-free.rs:16:42
+   |
+LL |         pub fn foo<'a: 'a, 'b: 'b, A, B, const N: usize>() {}
+   |                                          ^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse to_reuse::foo::<A, B, N>;
+   |                            +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/inherent-impl-to-free.rs:28:25
+   |
+LL |         reuse to_reuse::foo;
+   |                         ^^^ cannot infer the value of the const parameter `N` declared on the function `foo`
+   |
+note: required by a const generic parameter in `to_reuse::foo`
+  --> $DIR/inherent-impl-to-free.rs:16:42
+   |
+LL |         pub fn foo<'a: 'a, 'b: 'b, A, B, const N: usize>() {}
+   |                                          ^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse to_reuse::foo::<A, B, N>;
+   |                            +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/inherent-impl-to-free.rs:35:25
+   |
+LL |         reuse to_reuse::foo;
+   |                         ^^^ cannot infer the value of the const parameter `N` declared on the function `foo`
+   |
+note: required by a const generic parameter in `to_reuse::foo`
+  --> $DIR/inherent-impl-to-free.rs:16:42
+   |
+LL |         pub fn foo<'a: 'a, 'b: 'b, A, B, const N: usize>() {}
+   |                                          ^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse to_reuse::foo::<A, B, N>;
+   |                            +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/inherent-impl-to-free.rs:43:9
+   |
+LL |         X1::<'static, 'static, i32, i32, 1>::bar();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `N` declared on the associated function `bar`
+   |
+note: required by a const generic parameter in `test_1::X1::<'a, 'b, T, E, N>::bar`
+  --> $DIR/inherent-impl-to-free.rs:16:42
+   |
+LL |         pub fn foo<'a: 'a, 'b: 'b, A, B, const N: usize>() {}
+   |                                          ^^^^^^^^^^^^^^ required by this const generic parameter in `X1::<'a, 'b, T, E, N>::bar`
+...
+LL |         reuse to_reuse::foo::<'static, 'static, i32, String, 1> as bar;
+   |                                                                    --- required by a bound in this associated function
+help: consider specifying the generic arguments
+   |
+LL |         X1::<'static, 'static, i32, i32, 1>::bar::<A, B, N>();
+   |                                                 +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/inherent-impl-to-free.rs:47:9
+   |
+LL |         X2::<i32, i32, 1>::bar();
+   |         ^^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `N` declared on the associated function `bar`
+   |
+note: required by a const generic parameter in `test_1::X2::<T, E, N>::bar`
+  --> $DIR/inherent-impl-to-free.rs:16:42
+   |
+LL |         pub fn foo<'a: 'a, 'b: 'b, A, B, const N: usize>() {}
+   |                                          ^^^^^^^^^^^^^^ required by this const generic parameter in `X2::<T, E, N>::bar`
+...
+LL |         reuse to_reuse::foo::<'static, 'static, i32, String, 1> as bar;
+   |                                                                    --- required by a bound in this associated function
+help: consider specifying the generic arguments
+   |
+LL |         X2::<i32, i32, 1>::bar::<A, B, N>();
+   |                               +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/inherent-impl-to-free.rs:51:9
+   |
+LL |         X3::bar();
+   |         ^^^^^^^ cannot infer the value of the const parameter `N` declared on the associated function `bar`
+   |
+note: required by a const generic parameter in `test_1::X3::bar`
+  --> $DIR/inherent-impl-to-free.rs:16:42
+   |
+LL |         pub fn foo<'a: 'a, 'b: 'b, A, B, const N: usize>() {}
+   |                                          ^^^^^^^^^^^^^^ required by this const generic parameter in `X3::bar`
+...
+LL |         reuse to_reuse::foo::<'static, 'static, i32, String, 1> as bar;
+   |                                                                    --- required by a bound in this associated function
+help: consider specifying the generic arguments
+   |
+LL |         X3::bar::<A, B, N>();
+   |                +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/inherent-impl-to-free.rs:63:15
+   |
+LL |         reuse foo;
+   |               ^^^ cannot infer the value of the const parameter `N` declared on the function `foo`
+   |
+note: required by a const generic parameter in `test_2::foo`
+  --> $DIR/inherent-impl-to-free.rs:59:18
+   |
+LL |     fn foo<A, B, const N: usize>() {}
+   |                  ^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse foo::<A, B, N>;
+   |                  +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/inherent-impl-to-free.rs:70:15
+   |
+LL |         reuse foo;
+   |               ^^^ cannot infer the value of the const parameter `N` declared on the function `foo`
+   |
+note: required by a const generic parameter in `test_2::foo`
+  --> $DIR/inherent-impl-to-free.rs:59:18
+   |
+LL |     fn foo<A, B, const N: usize>() {}
+   |                  ^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse foo::<A, B, N>;
+   |                  +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/inherent-impl-to-free.rs:77:15
+   |
+LL |         reuse foo;
+   |               ^^^ cannot infer the value of the const parameter `N` declared on the function `foo`
+   |
+note: required by a const generic parameter in `test_2::foo`
+  --> $DIR/inherent-impl-to-free.rs:59:18
+   |
+LL |     fn foo<A, B, const N: usize>() {}
+   |                  ^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse foo::<A, B, N>;
+   |                  +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/inherent-impl-to-free.rs:84:9
+   |
+LL |         X1::<'static, 'static, i32, i32, 1>::bar();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `N` declared on the associated function `bar`
+   |
+note: required by a const generic parameter in `test_2::X1::<'a, 'b, T, E, N>::bar`
+  --> $DIR/inherent-impl-to-free.rs:59:18
+   |
+LL |     fn foo<A, B, const N: usize>() {}
+   |                  ^^^^^^^^^^^^^^ required by this const generic parameter in `X1::<'a, 'b, T, E, N>::bar`
+...
+LL |         reuse foo::<i32, String, 1> as bar;
+   |                                        --- required by a bound in this associated function
+help: consider specifying the generic arguments
+   |
+LL |         X1::<'static, 'static, i32, i32, 1>::bar::<A, B, N>();
+   |                                                 +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/inherent-impl-to-free.rs:88:9
+   |
+LL |         X2::<i32, i32, 1>::bar();
+   |         ^^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `N` declared on the associated function `bar`
+   |
+note: required by a const generic parameter in `test_2::X2::<T, E, N>::bar`
+  --> $DIR/inherent-impl-to-free.rs:59:18
+   |
+LL |     fn foo<A, B, const N: usize>() {}
+   |                  ^^^^^^^^^^^^^^ required by this const generic parameter in `X2::<T, E, N>::bar`
+...
+LL |         reuse foo::<i32, String, 1> as bar;
+   |                                        --- required by a bound in this associated function
+help: consider specifying the generic arguments
+   |
+LL |         X2::<i32, i32, 1>::bar::<A, B, N>();
+   |                               +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/inherent-impl-to-free.rs:92:9
+   |
+LL |         X3::bar();
+   |         ^^^^^^^ cannot infer the value of the const parameter `N` declared on the associated function `bar`
+   |
+note: required by a const generic parameter in `test_2::X3::bar`
+  --> $DIR/inherent-impl-to-free.rs:59:18
+   |
+LL |     fn foo<A, B, const N: usize>() {}
+   |                  ^^^^^^^^^^^^^^ required by this const generic parameter in `X3::bar`
+...
+LL |         reuse foo::<i32, String, 1> as bar;
+   |                                        --- required by a bound in this associated function
+help: consider specifying the generic arguments
+   |
+LL |         X3::bar::<A, B, N>();
+   |                +++++++++++
+
+error: aborting due to 12 previous errors
+
+For more information about this error, try `rustc --explain E0284`.

--- a/tests/ui/delegation/generics/mapping/inherent-impl-to-trait.rs
+++ b/tests/ui/delegation/generics/mapping/inherent-impl-to-trait.rs
@@ -1,0 +1,228 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+#![allow(late_bound_lifetime_arguments)]
+
+//! This is one of the mapping tests, which tests mapping of delegee parent and child
+//! generic params, whose main goal is to create cases with
+//! different number of lifetimes/types/consts in delegee child and parent; and in
+//! delegation parent if applicable. At some tests predicates are
+//! added. At some tests user-specified args are specified in reuse statement.
+
+// Testing types in parent, none in child,
+// user-specified args in parent, checking predicates inheritance,
+// with additional generic params in delegation parent
+mod test_1 {
+    trait Trait<T: ToString> {
+        fn foo(&self) {}
+    }
+
+    struct F;
+    impl<T: ToString> Trait<T> for F {}
+
+    struct S<'a, 'b, 'c, A, B>(F, &'a A, &'b B, &'c B);
+    impl<'a, 'b, 'c, A, B> S<'a, 'b, 'c, A, B> {
+        reuse Trait::<String>::foo { &self.0 }
+    }
+
+    pub fn check() {
+        let s = S(F, &123, &123, &123);
+        S::<'static, 'static, 'static, i32, i32>::foo(&s);
+        //~^ ERROR: type annotations needed [E0283]
+        s.foo();
+    }
+}
+
+// Testing lifetimes + types/consts in parent, none in child,
+// with additional generic params in delegation parent
+mod test_2 {
+    trait Trait<'x, 'y, T, const B: bool> {
+        fn foo(&self) {}
+    }
+
+    struct F;
+    impl<'x, 'y, T, const B: bool> Trait<'x, 'y, T, B> for F {}
+
+    struct S<'a, 'b, 'c, A, B>(F, &'a A, &'b B, &'c B);
+    impl<'a, 'b, 'c, A, B> S<'a, 'b, 'c, A, B> {
+        reuse Trait::<'a, 'b, String, true>::foo { &self.0 }
+    }
+
+    pub fn check() {
+        let s = S(F, &123, &123, &123);
+        S::<'static, 'static, 'static, i32, i32>::foo(&s);
+        //~^ ERROR: type annotations needed [E0284]
+        s.foo();
+        //~^ ERROR: type annotations needed [E0284]
+    }
+}
+
+// Testing lifetimes in parent, none in child,
+// with additional generic params in delegation parent
+mod test_3 {
+    trait Trait<'x, 'y> {
+        fn foo(&self) {}
+    }
+
+    struct F;
+    impl<'x, 'y> Trait<'x, 'y> for F {}
+
+    struct S<'a, 'b, 'c, A, B>(F, &'a A, &'b B, &'c B);
+    impl<'a, 'b, 'c, A, B> S<'a, 'b, 'c, A, B> {
+        reuse Trait::<'a, 'b>::foo { &self.0 }
+    }
+
+    pub fn check() {
+        let s = S(F, &123, &123, &123);
+        S::<'static, 'static, 'static, i32, i32>::foo(&s);
+        s.foo();
+    }
+}
+
+// Testing none in parent, none in child,
+// with additional generic params in delegation parent
+mod test_4 {
+    trait Trait {
+        fn foo(&self) {}
+    }
+
+    struct F;
+    impl Trait for F {}
+
+    struct S<'a, 'b, 'c, A, B>(F, &'a A, &'b B, &'c B);
+    impl<'a, 'b, 'c, A, B> S<'a, 'b, 'c, A, B> {
+        reuse Trait::foo { &self.0 }
+    }
+
+    pub fn check() {
+        let s = S(F, &123, &123, &123);
+        S::<'static, 'static, 'static, i32, i32>::foo(&s);
+        s.foo();
+    }
+}
+
+// Testing none in parent, lifetimes in child,
+// with additional generic params in delegation parent
+mod test_5 {
+    trait Trait {
+        fn foo<'a: 'a, 'b: 'b>(&self) {}
+    }
+
+    struct F;
+    impl Trait for F {}
+
+    struct S<'a, 'b, 'c, A, B>(F, &'a A, &'b B, &'c B);
+    impl<'a, 'b, 'c, A, B> S<'a, 'b, 'c, A, B> {
+        reuse Trait::foo::<'a, 'b> { &self.0 }
+    }
+
+    pub fn check() {
+        let s = S(F, &123, &123, &123);
+        S::<'static, 'static, 'static, i32, i32>::foo(&s);
+        s.foo();
+    }
+}
+
+// Testing none in parent, lifetimes + types in child,
+// with additional generic params in delegation parent
+mod test_6 {
+    trait Trait {
+        fn foo<'a: 'a, 'b: 'b, A, B, C>(&self) {}
+    }
+
+    struct F;
+    impl Trait for F {}
+
+    struct S<'a, 'b, 'c, A, B>(F, &'a A, &'b B, &'c B);
+    impl<'a, 'b, 'c, A, B> S<'a, 'b, 'c, A, B> {
+        reuse Trait::foo::<'a, 'b, A, B, String> { &self.0 }
+    }
+
+    pub fn check() {
+        let s = S(F, &123, &123, &123);
+        S::<'static, 'static, 'static, i32, i32>::foo(&s);
+        //~^ ERROR: type annotations needed [E0282]
+        s.foo();
+    }
+}
+
+// Testing lifetimes in parent, lifetimes + types in child,
+// with additional generic params in delegation parent
+mod test_7 {
+    trait Trait<'x, 'y, 'z> {
+        fn foo<'a: 'a, 'b: 'b, A, B, C>(&self) {}
+    }
+
+    struct F;
+    impl<'a, 'b, 'c> Trait<'a, 'b, 'c> for F {}
+
+    struct S<'a, 'b, 'c, A, B>(F, &'a A, &'b B, &'c B);
+    impl<'a, 'b, 'c, A, B> S<'a, 'b, 'c, A, B> {
+        reuse Trait::<'a, 'b, 'c>::foo::<'a, 'b, A, B, String> { &self.0 }
+    }
+
+    pub fn check() {
+        let s = S(F, &123, &123, &123);
+        S::<'static, 'static, 'static, i32, i32>::foo(&s);
+        //~^ ERROR: type annotations needed [E0282]
+        s.foo();
+    }
+}
+
+// Testing lifetimes + types in parent, lifetimes + types in child,
+// with additional generic params in delegation parent
+mod test_8 {
+    trait Trait<'x, 'y, 'z, X, Y, Z> {
+        fn foo<'a: 'a, 'b: 'b, A, B, C>(&self) {}
+    }
+
+    struct F;
+    impl<'a, 'b, 'c, X, Y, Z> Trait<'a, 'b, 'c, X, Y, Z> for F {}
+
+    struct S<'a, 'b, 'c, A, B>(F, &'a A, &'b B, &'c B);
+    impl<'a, 'b, 'c, A, B> S<'a, 'b, 'c, A, B> {
+        reuse Trait::<'a, 'b, 'c, B, A, i32>::foo::<'a, 'b, A, B, String> { &self.0 }
+    }
+
+    pub fn check() {
+        let s = S(F, &123, &123, &123);
+        S::<'static, 'static, 'static, i32, i32>::foo(&s);
+        //~^ ERROR: type annotations needed [E0282]
+        s.foo();
+    }
+}
+
+// Testing lifetimes + types in parent, lifetimes + types in child,
+// with additional generic params in delegation parent,
+// inside a function with generic params
+mod test_9 {
+    trait Trait<'x, 'y, 'z, X, Y, Z> {
+        fn foo<'a: 'a, 'b: 'b, A, B, C>(&self) {}
+    }
+
+    struct F;
+    impl<'a, 'b, 'c, X, Y, Z> Trait<'a, 'b, 'c, X, Y, Z> for F {}
+
+    pub fn check<T, U>() {
+        struct S<'a, 'b, 'c, A, B>(F, &'a A, &'b B, &'c B);
+        impl<'a, 'b, 'c, A, B> S<'a, 'b, 'c, A, B> {
+            reuse Trait::<'a, 'b, 'c, B, A, i32>::foo::<'a, 'b, A, B, String> { &self.0 }
+        }
+
+        let s = S(F, &123, &123, &123);
+        S::<'static, 'static, 'static, i32, i32>::foo(&s);
+        //~^ ERROR: type annotations needed [E0282]
+        s.foo();
+    }
+}
+
+pub fn main() {
+    test_1::check();
+    test_2::check();
+    test_3::check();
+    test_4::check();
+    test_5::check();
+    test_6::check();
+    test_7::check();
+    test_8::check();
+    test_9::check::<u32, String>();
+}

--- a/tests/ui/delegation/generics/mapping/inherent-impl-to-trait.stderr
+++ b/tests/ui/delegation/generics/mapping/inherent-impl-to-trait.stderr
@@ -1,0 +1,106 @@
+error[E0283]: type annotations needed
+  --> $DIR/inherent-impl-to-trait.rs:29:9
+   |
+LL |         S::<'static, 'static, 'static, i32, i32>::foo(&s);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the method `foo`
+   |
+   = note: cannot satisfy `_: ToString`
+note: required by a bound in `test_1::S::<'a, 'b, 'c, A, B>::foo`
+  --> $DIR/inherent-impl-to-trait.rs:15:20
+   |
+LL |     trait Trait<T: ToString> {
+   |                    ^^^^^^^^ required by this bound in `S::<'a, 'b, 'c, A, B>::foo`
+...
+LL |         reuse Trait::<String>::foo { &self.0 }
+   |                                --- required by a bound in this associated function
+help: consider specifying the generic argument
+   |
+LL |         S::<'static, 'static, 'static, i32, i32>::foo::<T>(&s);
+   |                                                      +++++
+
+error[E0284]: type annotations needed
+  --> $DIR/inherent-impl-to-trait.rs:52:9
+   |
+LL |         S::<'static, 'static, 'static, i32, i32>::foo(&s);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `B` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_2::S::<'a, 'b, 'c, A, B>::foo`
+  --> $DIR/inherent-impl-to-trait.rs:38:28
+   |
+LL |     trait Trait<'x, 'y, T, const B: bool> {
+   |                            ^^^^^^^^^^^^^ required by this const generic parameter in `S::<'a, 'b, 'c, A, B>::foo`
+...
+LL |         reuse Trait::<'a, 'b, String, true>::foo { &self.0 }
+   |                                              --- required by a bound in this associated function
+help: consider specifying the generic arguments
+   |
+LL |         S::<'static, 'static, 'static, i32, i32>::foo::<T, B>(&s);
+   |                                                      ++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/inherent-impl-to-trait.rs:54:11
+   |
+LL |         s.foo();
+   |           ^^^ cannot infer the value of the const parameter `B` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_2::S::<'a, 'b, 'c, A, B>::foo`
+  --> $DIR/inherent-impl-to-trait.rs:38:28
+   |
+LL |     trait Trait<'x, 'y, T, const B: bool> {
+   |                            ^^^^^^^^^^^^^ required by this const generic parameter in `S::<'a, 'b, 'c, A, B>::foo`
+...
+LL |         reuse Trait::<'a, 'b, String, true>::foo { &self.0 }
+   |                                              --- required by a bound in this associated function
+help: consider specifying the generic arguments
+   |
+LL |         s.foo::<T, B>();
+   |              ++++++++
+
+error[E0282]: type annotations needed
+  --> $DIR/inherent-impl-to-trait.rs:142:9
+   |
+LL |         S::<'static, 'static, 'static, i32, i32>::foo(&s);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `A` declared on the method `foo`
+   |
+help: consider specifying the generic arguments
+   |
+LL |         S::<'static, 'static, 'static, i32, i32>::foo::<A, B, C>(&s);
+   |                                                      +++++++++++
+
+error[E0282]: type annotations needed
+  --> $DIR/inherent-impl-to-trait.rs:165:9
+   |
+LL |         S::<'static, 'static, 'static, i32, i32>::foo(&s);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `A` declared on the method `foo`
+   |
+help: consider specifying the generic arguments
+   |
+LL |         S::<'static, 'static, 'static, i32, i32>::foo::<A, B, C>(&s);
+   |                                                      +++++++++++
+
+error[E0282]: type annotations needed
+  --> $DIR/inherent-impl-to-trait.rs:188:9
+   |
+LL |         S::<'static, 'static, 'static, i32, i32>::foo(&s);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `X` declared on the method `foo`
+   |
+help: consider specifying the generic arguments
+   |
+LL |         S::<'static, 'static, 'static, i32, i32>::foo::<X, Y, Z, A, B, C>(&s);
+   |                                                      ++++++++++++++++++++
+
+error[E0282]: type annotations needed
+  --> $DIR/inherent-impl-to-trait.rs:212:9
+   |
+LL |         S::<'static, 'static, 'static, i32, i32>::foo(&s);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `X` declared on the method `foo`
+   |
+help: consider specifying the generic arguments
+   |
+LL |         S::<'static, 'static, 'static, i32, i32>::foo::<X, Y, Z, A, B, C>(&s);
+   |                                                      ++++++++++++++++++++
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0282, E0283, E0284.
+For more information about an error, try `rustc --explain E0282`.

--- a/tests/ui/delegation/generics/mapping/trait-to-free.rs
+++ b/tests/ui/delegation/generics/mapping/trait-to-free.rs
@@ -1,0 +1,142 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+#![allow(late_bound_lifetime_arguments)]
+
+//! This is one of the mapping tests, which tests mapping of delegee parent and child
+//! generic params, whose main goal is to create cases with
+//! different number of lifetimes/types/consts in delegee child and parent; and in
+//! delegation parent if applicable. At some tests predicates are
+//! added. At some tests user-specified args are specified in reuse statement.
+
+// Testing lifetimes + types/consts in child, lifetimes + types/consts in delegation parent,
+// with(out) user-specified args
+mod test_1 {
+    fn foo<'a: 'a, 'b: 'b, T: Clone + ToString, U: Clone, const N: usize>() {}
+
+    trait Trait<'a, A, B, C, const N: usize> {
+        reuse foo;
+        //~^ ERROR: type annotations needed [E0284]
+        reuse foo::<'static, 'static, i32, String, 1> as bar;
+    }
+
+    impl Trait<'static, i32, i32, i32, 1> for u32 {}
+    pub fn check() {
+        <u32 as Trait<'static, i32, i32, i32, 1>>::foo::<'static, 'static, i32, String, 1>();
+        <u32 as Trait<'static, i32, i32, i32, 1>>::bar();
+        //~^ ERROR: type annotations needed [E0284]
+    }
+}
+
+// Testing types/consts in child, lifetimes + types/consts in delegation parent,
+// with(out) user-specified args
+mod test_2 {
+    fn foo<T: Clone, U: Clone, const N: usize>() {}
+
+    trait Trait<'a, A, B, C, const N: usize> {
+        reuse foo;
+        //~^ ERROR: type annotations needed [E0284]
+        reuse foo::<i32, String, 1> as bar;
+    }
+
+    impl Trait<'static, i32, i32, i32, 1> for u32 {}
+    pub fn check() {
+        <u32 as Trait<'static, i32, i32, i32, 1>>::foo::<i32, String, 1>();
+        <u32 as Trait<'static, i32, i32, i32, 1>>::bar();
+        //~^ ERROR: type annotations needed [E0284]
+    }
+}
+
+// Testing none in child, lifetimes + types/consts in delegation parent,
+// with(out) user-specified args
+mod test_3 {
+    fn foo() {}
+
+    trait Trait<'a, A, B, C, const N: usize> {
+        reuse foo;
+    }
+
+    impl Trait<'static, i32, i32, i32, 1> for u32 {}
+    pub fn check() {
+        <u32 as Trait<'static, i32, i32, i32, 1>>::foo();
+    }
+}
+
+// Testing lifetimes + types/consts in child, types/consts in delegation parent,
+// with(out) user-specified args
+mod test_4 {
+    fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+
+    trait Trait<A, B, C, const N: usize> {
+        reuse foo;
+        //~^ ERROR: type annotations needed [E0284]
+        reuse foo::<'static, 'static, i32, String, 1> as bar;
+    }
+
+    impl Trait<i32, i32, i32, 1> for u32 {}
+    pub fn check() {
+        <u32 as Trait<i32, i32, i32, 1>>::foo::<'static, 'static, i32, String, 1>();
+        <u32 as Trait<i32, i32, i32, 1>>::bar();
+        //~^ ERROR: type annotations needed [E0284]
+    }
+}
+
+// Testing lifetimes + types/consts in child, none in delegation parent,
+// with(out) user-specified args
+mod test_5 {
+    fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+
+    trait Trait {
+        reuse foo;
+        //~^ ERROR: type annotations needed [E0284]
+        reuse foo::<'static, 'static, i32, String, 1> as bar;
+    }
+
+    impl Trait for u32 {}
+    pub fn check() {
+        <u32 as Trait>::foo::<'static, 'static, i32, String, 1>();
+        <u32 as Trait>::bar();
+        //~^ ERROR: type annotations needed [E0284]
+    }
+}
+
+// Testing types/consts in child, none in delegation parent, with(out) user-specified args
+mod test_6 {
+    fn foo<T: Clone, U: Clone, const N: usize>() {}
+
+    trait Trait {
+        reuse foo;
+        //~^ ERROR: type annotations needed [E0284]
+        reuse foo::<i32, String, 1> as bar;
+    }
+
+    impl Trait for u32 {}
+    pub fn check() {
+        <u32 as Trait>::foo::<i32, String, 1>();
+        <u32 as Trait>::bar();
+        //~^ ERROR: type annotations needed [E0284]
+    }
+}
+
+// Testing none in child, none in delegation parent, with(out) user-specified args
+mod test_7 {
+    fn foo() {}
+
+    trait Trait {
+        reuse foo;
+    }
+
+    impl Trait for u32 {}
+    pub fn check() {
+        <u32 as Trait>::foo();
+    }
+}
+
+pub fn main() {
+    test_1::check();
+    test_2::check();
+    test_3::check();
+    test_4::check();
+    test_5::check();
+    test_6::check();
+    test_7::check();
+}

--- a/tests/ui/delegation/generics/mapping/trait-to-free.stderr
+++ b/tests/ui/delegation/generics/mapping/trait-to-free.stderr
@@ -1,0 +1,166 @@
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-free.rs:17:15
+   |
+LL |         reuse foo;
+   |               ^^^ cannot infer the value of the const parameter `N` declared on the function `foo`
+   |
+note: required by a const generic parameter in `test_1::foo`
+  --> $DIR/trait-to-free.rs:14:59
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone + ToString, U: Clone, const N: usize>() {}
+   |                                                           ^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse foo::<T, U, N>;
+   |                  +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-free.rs:25:9
+   |
+LL |         <u32 as Trait<'static, i32, i32, i32, 1>>::bar();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `N` declared on the associated function `bar`
+   |
+note: required by a const generic parameter in `test_1::Trait::bar`
+  --> $DIR/trait-to-free.rs:14:59
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone + ToString, U: Clone, const N: usize>() {}
+   |                                                           ^^^^^^^^^^^^^^ required by this const generic parameter in `Trait::bar`
+...
+LL |         reuse foo::<'static, 'static, i32, String, 1> as bar;
+   |                                                          --- required by a bound in this associated function
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-free.rs:36:15
+   |
+LL |         reuse foo;
+   |               ^^^ cannot infer the value of the const parameter `N` declared on the function `foo`
+   |
+note: required by a const generic parameter in `test_2::foo`
+  --> $DIR/trait-to-free.rs:33:32
+   |
+LL |     fn foo<T: Clone, U: Clone, const N: usize>() {}
+   |                                ^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse foo::<T, U, N>;
+   |                  +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-free.rs:44:9
+   |
+LL |         <u32 as Trait<'static, i32, i32, i32, 1>>::bar();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `N` declared on the associated function `bar`
+   |
+note: required by a const generic parameter in `test_2::Trait::bar`
+  --> $DIR/trait-to-free.rs:33:32
+   |
+LL |     fn foo<T: Clone, U: Clone, const N: usize>() {}
+   |                                ^^^^^^^^^^^^^^ required by this const generic parameter in `Trait::bar`
+...
+LL |         reuse foo::<i32, String, 1> as bar;
+   |                                        --- required by a bound in this associated function
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-free.rs:70:15
+   |
+LL |         reuse foo;
+   |               ^^^ cannot infer the value of the const parameter `N` declared on the function `foo`
+   |
+note: required by a const generic parameter in `test_4::foo`
+  --> $DIR/trait-to-free.rs:67:48
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |                                                ^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse foo::<T, U, N>;
+   |                  +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-free.rs:78:9
+   |
+LL |         <u32 as Trait<i32, i32, i32, 1>>::bar();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `N` declared on the associated function `bar`
+   |
+note: required by a const generic parameter in `test_4::Trait::bar`
+  --> $DIR/trait-to-free.rs:67:48
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |                                                ^^^^^^^^^^^^^^ required by this const generic parameter in `Trait::bar`
+...
+LL |         reuse foo::<'static, 'static, i32, String, 1> as bar;
+   |                                                          --- required by a bound in this associated function
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-free.rs:89:15
+   |
+LL |         reuse foo;
+   |               ^^^ cannot infer the value of the const parameter `N` declared on the function `foo`
+   |
+note: required by a const generic parameter in `test_5::foo`
+  --> $DIR/trait-to-free.rs:86:48
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |                                                ^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse foo::<T, U, N>;
+   |                  +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-free.rs:97:9
+   |
+LL |         <u32 as Trait>::bar();
+   |         ^^^^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `N` declared on the associated function `bar`
+   |
+note: required by a const generic parameter in `test_5::Trait::bar`
+  --> $DIR/trait-to-free.rs:86:48
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |                                                ^^^^^^^^^^^^^^ required by this const generic parameter in `Trait::bar`
+...
+LL |         reuse foo::<'static, 'static, i32, String, 1> as bar;
+   |                                                          --- required by a bound in this associated function
+help: consider specifying the generic arguments
+   |
+LL |         <u32 as Trait>::bar::<T, U, N>();
+   |                            +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-free.rs:107:15
+   |
+LL |         reuse foo;
+   |               ^^^ cannot infer the value of the const parameter `N` declared on the function `foo`
+   |
+note: required by a const generic parameter in `test_6::foo`
+  --> $DIR/trait-to-free.rs:104:32
+   |
+LL |     fn foo<T: Clone, U: Clone, const N: usize>() {}
+   |                                ^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse foo::<T, U, N>;
+   |                  +++++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-free.rs:115:9
+   |
+LL |         <u32 as Trait>::bar();
+   |         ^^^^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `N` declared on the associated function `bar`
+   |
+note: required by a const generic parameter in `test_6::Trait::bar`
+  --> $DIR/trait-to-free.rs:104:32
+   |
+LL |     fn foo<T: Clone, U: Clone, const N: usize>() {}
+   |                                ^^^^^^^^^^^^^^ required by this const generic parameter in `Trait::bar`
+...
+LL |         reuse foo::<i32, String, 1> as bar;
+   |                                        --- required by a bound in this associated function
+help: consider specifying the generic arguments
+   |
+LL |         <u32 as Trait>::bar::<T, U, N>();
+   |                            +++++++++++
+
+error: aborting due to 10 previous errors
+
+For more information about this error, try `rustc --explain E0284`.

--- a/tests/ui/delegation/generics/mapping/trait-to-trait.rs
+++ b/tests/ui/delegation/generics/mapping/trait-to-trait.rs
@@ -1,0 +1,895 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+#![allow(late_bound_lifetime_arguments)]
+
+//! This is one of the mapping tests, which tests mapping of delegee parent and child
+//! generic params, whose main goal is to create cases with
+//! different number of lifetimes/types/consts in delegee child and parent; and in
+//! delegation parent if applicable. At some tests predicates are
+//! added. At some tests user-specified args are specified in reuse statement.
+
+// Testing lifetimes + types in parent,
+// lifetimes + types/consts in child,
+// in delegation parent with:
+// lifetimes + types OR none OR lifetimes OR types,
+// with(out) user-specified args, with different target expr
+mod test_1 {
+    trait Trait<'b, 'c, 'a, T>: Sized {
+        fn foo<'d: 'd, U, const M: bool>(&self) {}
+    }
+
+    impl<'b, 'c, 'a, T> Trait<'b, 'c, 'a, T> for u8 {}
+
+    trait Trait2<'a, 'b, 'c, X, Y, Z> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<'static, 'static, 'static, i32>::foo::<'static, String, false> as bar2 {
+                Self::get()
+        }
+
+        reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<'static, 'static, 'static, i32>::foo::<'static, String, false>
+            as bar4 { self.get_self() }
+
+        // FIXME(fn_delegation): Uncomment those tests when proper support for
+        // generics when method call is generated is added
+
+        // reuse Trait::foo::<'static, String, false> as bar5 { Self::get() }
+        // reuse Trait::foo as bar6 { Self::get() }
+        // reuse Trait::foo::<'static, String, false> as bar7 { self.get_self() }
+        // reuse Trait::foo as bar8 { self.get_self() }
+    }
+
+    trait Trait3 {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<'static, 'static, 'static, i32>::foo::<'static, String, false>
+            as bar2 { Self::get() }
+        reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<'static, 'static, 'static, i32>::foo::<'static, String, false>
+            as bar4 { self.get_self() }
+    }
+
+    trait Trait4<'a, 'b, 'c> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<'static, 'static, 'static, i32>::foo::<'static, String, false>
+            as bar2 { Self::get() }
+        reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<'static, 'static, 'static, i32>::foo::<'static, String, false>
+            as bar4 { self.get_self() }
+    }
+
+    trait Trait5<X, Y, Z> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<'static, 'static, 'static, i32>::foo::<'static, String, false>
+            as bar2 { Self::get() }
+        reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<'static, 'static, 'static, i32>::foo::<'static, String, false>
+            as bar4 { self.get_self() }
+    }
+
+    impl<'a, 'b, 'c, X, Y, Z> Trait2<'a, 'b, 'c, X, Y, Z> for u32 {}
+    impl Trait3 for u32 {}
+    impl<'a, 'b, 'c> Trait4<'a, 'b, 'c> for u32 {}
+    impl<X, Y, Z> Trait5<X, Y, Z> for u32 {}
+
+    pub fn check<'a: 'a>() {
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>
+            ::bar1::<'static, String, true>(&123);
+            //~^ ERROR: method takes 3 generic arguments but 2 generic arguments were supplied [E0107]
+            //~| ERROR: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present [E0794]
+        <u32 as Trait3>::bar1::<'static, String, true>(&123);
+        //~^ ERROR: method takes 3 generic arguments but 2 generic arguments were supplied [E0107]
+        //~| ERROR: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present [E0794]
+        <u32 as Trait4<'a, 'a, 'static>>::bar1::<'static, String, true>(&123);
+        //~^ ERROR: method takes 3 generic arguments but 2 generic arguments were supplied [E0107]
+        //~| ERROR: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present [E0794]
+        <u32 as Trait5<i32, u64, String>>::bar1::<'static, String, true>(&123);
+        //~^ ERROR: method takes 3 generic arguments but 2 generic arguments were supplied [E0107]
+        //~| ERROR: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present [E0794]
+
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar2(&123);
+        <u32 as Trait3>::bar2(&123);
+        <u32 as Trait4<'a, 'a, 'static>>::bar2(&123);
+        <u32 as Trait5<i32, u64, String>>::bar2(&123);
+
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>
+            ::bar3::<'static, String, true>(&123);
+            //~^ ERROR: method takes 3 generic arguments but 2 generic arguments were supplied [E0107]
+            //~| ERROR: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present [E0794]
+        <u32 as Trait3>::bar3::<'static, String, true>(&123);
+        //~^ ERROR: method takes 3 generic arguments but 2 generic arguments were supplied [E0107]
+        //~| ERROR: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present [E0794]
+        <u32 as Trait4<'a, 'a, 'static>>::bar3::<'static, String, true>(&123);
+        //~^ ERROR: method takes 3 generic arguments but 2 generic arguments were supplied [E0107]
+        //~| ERROR: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present [E0794]
+        <u32 as Trait5<i32, u64, String>>::bar3::<'static, String, true>(&123);
+        //~^ ERROR: method takes 3 generic arguments but 2 generic arguments were supplied [E0107]
+        //~| ERROR: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present [E0794]
+
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar4(&123);
+        <u32 as Trait3>::bar4(&123);
+        <u32 as Trait4<'a, 'a, 'static>>::bar4(&123);
+        <u32 as Trait5<i32, u64, String>>::bar4(&123);
+    }
+}
+
+// Testing types in parent,
+// lifetimes + types/consts in child,
+// in delegation parent with:
+// lifetimes + types OR none OR lifetimes OR types,
+// with(out) user-specified args, with different target expr
+mod test_2 {
+    trait Trait<T>: Sized {
+        fn foo<'d: 'd, U, const M: bool>(&self) {}
+    }
+
+    impl<T> Trait<T> for u8 {}
+
+    trait Trait2<'a, 'b, 'c, X, Y, Z> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<i32>::foo as bar1 { Self::get() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<i32>::foo::<'static, String, false> as bar2 { Self::get() }
+        reuse Trait::<i32>::foo as bar3 { self.get_self() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<i32>::foo::<'static, String, false> as bar4 { self.get_self() }
+    }
+
+    trait Trait3 {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<i32>::foo as bar1 { Self::get() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<i32>::foo::<'static, String, false> as bar2 { Self::get() }
+        reuse Trait::<i32>::foo as bar3 { self.get_self() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<i32>::foo::<'static, String, false> as bar4 { self.get_self() }
+    }
+
+    trait Trait4<'a, 'b, 'c> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<i32>::foo as bar1 { Self::get() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<i32>::foo::<'static, String, false> as bar2 { Self::get() }
+        reuse Trait::<i32>::foo as bar3 { self.get_self() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<i32>::foo::<'static, String, false> as bar4 { self.get_self() }
+    }
+
+    trait Trait5<X, Y, Z> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<i32>::foo as bar1 { Self::get() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<i32>::foo::<'static, String, false> as bar2 { Self::get() }
+        reuse Trait::<i32>::foo as bar3 { self.get_self() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<i32>::foo::<'static, String, false> as bar4 { self.get_self() }
+    }
+
+    impl<'a, 'b, 'c, X, Y, Z> Trait2<'a, 'b, 'c, X, Y, Z> for u32 {}
+    impl Trait3 for u32 {}
+    impl<'a, 'b, 'c> Trait4<'a, 'b, 'c> for u32 {}
+    impl<X, Y, Z> Trait5<X, Y, Z> for u32 {}
+
+    pub fn check<'a: 'a>() {
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>
+            ::bar1::<'static, String, true>(&123);
+            //~^ ERROR: method takes 3 generic arguments but 2 generic arguments were supplied [E0107]
+        <u32 as Trait3>::bar1::<'static, String, true>(&123);
+        //~^ ERROR: method takes 3 generic arguments but 2 generic arguments were supplied [E0107]
+        <u32 as Trait4<'a, 'a, 'static>>::bar1::<'static, String, true>(&123);
+        //~^ ERROR: method takes 3 generic arguments but 2 generic arguments were supplied [E0107]
+        <u32 as Trait5<i32, u64, String>>::bar1::<'static, String, true>(&123);
+        //~^ ERROR: method takes 3 generic arguments but 2 generic arguments were supplied [E0107]
+
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar2(&123);
+        <u32 as Trait3>::bar2(&123);
+        <u32 as Trait4<'a, 'a, 'static>>::bar2(&123);
+        <u32 as Trait5<i32, u64, String>>::bar2(&123);
+
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>
+            ::bar3::<'static, String, true>(&123);
+            //~^ ERROR: method takes 3 generic arguments but 2 generic arguments were supplied [E0107]
+        <u32 as Trait3>::bar3::<'static, String, true>(&123);
+        //~^ ERROR: method takes 3 generic arguments but 2 generic arguments were supplied [E0107]
+        <u32 as Trait4<'a, 'a, 'static>>::bar3::<'static, String, true>(&123);
+        //~^ ERROR: method takes 3 generic arguments but 2 generic arguments were supplied [E0107]
+        <u32 as Trait5<i32, u64, String>>::bar3::<'static, String, true>(&123);
+        //~^ ERROR: method takes 3 generic arguments but 2 generic arguments were supplied [E0107]
+
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar4(&123);
+        <u32 as Trait3>::bar4(&123);
+        <u32 as Trait4<'a, 'a, 'static>>::bar4(&123);
+        <u32 as Trait5<i32, u64, String>>::bar4(&123);
+    }
+}
+
+// Testing lifetimes in parent,
+// lifetimes + types/consts in child,
+// in delegation parent with:
+// lifetimes + types OR none OR lifetimes OR types,
+// with(out) user-specified args, with different target expr
+mod test_3 {
+    trait Trait<'b, 'c, 'a>: Sized {
+        fn foo<'d: 'd, U, const M: bool>(&self) {}
+    }
+
+    impl<'b, 'c, 'a> Trait<'b, 'c, 'a> for u8 {}
+
+    trait Trait2<'a, 'b, 'c, X, Y, Z> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<'static, 'static, 'static>::foo as bar1 { Self::get() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<'static, 'static, 'static>::foo::<'static, String, false> as bar2 {
+            Self::get()
+        }
+        reuse Trait::<'static, 'static, 'static>::foo as bar3 { self.get_self() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<'static, 'static, 'static>::foo::<'static, String, false> as bar4 {
+            self.get_self()
+        }
+    }
+
+    trait Trait3 {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<'static, 'static, 'static>::foo as bar1 { Self::get() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<'static, 'static, 'static>::foo::<'static, String, false> as bar2 {
+            Self::get()
+        }
+        reuse Trait::<'static, 'static, 'static>::foo as bar3 { self.get_self() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<'static, 'static, 'static>::foo::<'static, String, false> as bar4 {
+            self.get_self()
+        }
+    }
+
+    trait Trait4<'a, 'b, 'c> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<'static, 'static, 'static>::foo as bar1 { Self::get() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<'static, 'static, 'static>::foo::<'static, String, false> as bar2 {
+            Self::get()
+        }
+        reuse Trait::<'static, 'static, 'static>::foo as bar3 { self.get_self() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<'static, 'static, 'static>::foo::<'static, String, false> as bar4 {
+            self.get_self()
+        }
+    }
+
+    trait Trait5<X, Y, Z> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<'static, 'static, 'static>::foo as bar1 { Self::get() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<'static, 'static, 'static>::foo::<'static, String, false>
+            as bar2 { Self::get() }
+        reuse Trait::<'static, 'static, 'static>::foo as bar3 { self.get_self() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<'static, 'static, 'static>::foo::<'static, String, false>
+            as bar4 { self.get_self() }
+    }
+
+    impl<'a, 'b, 'c, X, Y, Z> Trait2<'a, 'b, 'c, X, Y, Z> for u32 {}
+    impl Trait3 for u32 {}
+    impl<'a, 'b, 'c> Trait4<'a, 'b, 'c> for u32 {}
+    impl<X, Y, Z> Trait5<X, Y, Z> for u32 {}
+
+    pub fn check<'a: 'a>() {
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>
+            ::bar1::<'static, String, true>(&123);
+            //~^ ERROR: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present [E0794]
+        <u32 as Trait3>::bar1::<'static, String, true>(&123);
+        //~^ ERROR: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present [E0794]
+        <u32 as Trait4<'a, 'a, 'static>>::bar1::<'static, String, true>(&123);
+        //~^ ERROR: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present [E0794]
+        <u32 as Trait5<i32, u64, String>>::bar1::<'static, String, true>(&123);
+        //~^ ERROR: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present [E0794]
+
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar2(&123);
+        <u32 as Trait3>::bar2(&123);
+        <u32 as Trait4<'a, 'a, 'static>>::bar2(&123);
+        <u32 as Trait5<i32, u64, String>>::bar2(&123);
+
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>
+            ::bar3::<'static, String, true>(&123);
+            //~^ ERROR: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present [E0794]
+        <u32 as Trait3>::bar3::<'static, String, true>(&123);
+        //~^ ERROR: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present [E0794]
+        <u32 as Trait4<'a, 'a, 'static>>::bar3::<'static, String, true>(&123);
+        //~^ ERROR: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present [E0794]
+        <u32 as Trait5<i32, u64, String>>::bar3::<'static, String, true>(&123);
+        //~^ ERROR: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present [E0794]
+
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar4(&123);
+        <u32 as Trait3>::bar4(&123);
+        <u32 as Trait4<'a, 'a, 'static>>::bar4(&123);
+        <u32 as Trait5<i32, u64, String>>::bar4(&123);
+    }
+}
+
+// Testing none in parent,
+// lifetimes + types/consts in child,
+// in delegation parent with:
+// lifetimes + types OR none OR lifetimes OR types,
+// with(out) user-specified args, with different target expr
+mod test_4 {
+    trait Trait: Sized {
+        fn foo<'d: 'd, U, const M: bool>(&self) {}
+    }
+
+    impl Trait for u8 {}
+
+    trait Trait2<'a, 'b, 'c, X, Y, Z> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::foo as bar1 { Self::get() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::foo::<'static, String, false> as bar2 { Self::get() }
+        reuse Trait::foo as bar3 { self.get_self() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::foo::<'static, String, false> as bar4 { self.get_self() }
+    }
+
+    trait Trait3 {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::foo as bar1 { Self::get() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::foo::<'static, String, false> as bar2 { Self::get() }
+        reuse Trait::foo as bar3 { self.get_self() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::foo::<'static, String, false> as bar4 { self.get_self() }
+    }
+
+    trait Trait4<'a, 'b, 'c> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::foo as bar1 { Self::get() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::foo::<'static, String, false> as bar2 { Self::get() }
+        reuse Trait::foo as bar3 { self.get_self() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::foo::<'static, String, false> as bar4 { self.get_self() }
+    }
+
+    trait Trait5<X, Y, Z> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::foo as bar1 { Self::get() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::foo::<'static, String, false> as bar2 { Self::get() }
+        reuse Trait::foo as bar3 { self.get_self() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::foo::<'static, String, false> as bar4 { self.get_self() }
+    }
+
+    impl<'a, 'b, 'c, X, Y, Z> Trait2<'a, 'b, 'c, X, Y, Z> for u32 {}
+    impl Trait3 for u32 {}
+    impl<'a, 'b, 'c> Trait4<'a, 'b, 'c> for u32 {}
+    impl<X, Y, Z> Trait5<X, Y, Z> for u32 {}
+
+    pub fn check<'a: 'a>() {
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>
+            ::bar1::<'static, String, true>(&123);
+        <u32 as Trait3>::bar1::<'static, String, true>(&123);
+        <u32 as Trait4<'a, 'a, 'static>>::bar1::<'static, String, true>(&123);
+        <u32 as Trait5<i32, u64, String>>::bar1::<'static, String, true>(&123);
+
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar2(&123);
+        //~^ ERROR: type annotations needed [E0284]
+        <u32 as Trait3>::bar2(&123);
+        //~^ ERROR: type annotations needed [E0284]
+        <u32 as Trait4<'a, 'a, 'static>>::bar2(&123);
+        //~^ ERROR: type annotations needed [E0284]
+        <u32 as Trait5<i32, u64, String>>::bar2(&123);
+        //~^ ERROR: type annotations needed [E0284]
+
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>
+            ::bar3::<'static, String, true>(&123);
+        <u32 as Trait3>::bar3::<'static, String, true>(&123);
+        <u32 as Trait4<'a, 'a, 'static>>::bar3::<'static, String, true>(&123);
+        <u32 as Trait5<i32, u64, String>>::bar3::<'static, String, true>(&123);
+
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar4(&123);
+        //~^ ERROR: type annotations needed [E0284]
+        <u32 as Trait3>::bar4(&123);
+        //~^ ERROR: type annotations needed [E0284]
+        <u32 as Trait4<'a, 'a, 'static>>::bar4(&123);
+        //~^ ERROR: type annotations needed [E0284]
+        <u32 as Trait5<i32, u64, String>>::bar4(&123);
+        //~^ ERROR: type annotations needed [E0284]
+    }
+}
+
+// Testing lifetimes + types in parent,
+// types/consts in child,
+// in delegation parent with:
+// lifetimes + types OR none OR lifetimes OR types,
+// with(out) user-specified args, with different target expr
+mod test_5 {
+    trait Trait<'b, 'c, 'a, T>: Sized {
+        fn foo<U, const M: bool>(&self) {}
+    }
+
+    impl<'b, 'c, 'a, T> Trait<'b, 'c, 'a, T> for u8 {}
+
+    trait Trait2<'a, 'b, 'c, X, Y, Z> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<'static, 'static, 'static, i32>::foo::<String, false> as bar2 {
+            Self::get()
+        }
+        reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<'static, 'static, 'static, i32>::foo::<String, false> as bar4 {
+            self.get_self()
+        }
+    }
+
+    trait Trait3 {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<'static, 'static, 'static, i32>::foo::<String, false> as bar2 {
+            Self::get()
+        }
+        reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<'static, 'static, 'static, i32>::foo::<String, false> as bar4 {
+            self.get_self()
+        }
+    }
+
+    trait Trait4<'a, 'b, 'c> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<'static, 'static, 'static, i32>::foo::<String, false> as bar2 {
+            Self::get()
+        }
+        reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<'static, 'static, 'static, i32>::foo::<String, false> as bar4 {
+            self.get_self()
+        }
+    }
+
+    trait Trait5<X, Y, Z> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<'static, 'static, 'static, i32>::foo::<String, false> as bar2 {
+            Self::get()
+        }
+        reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+        //~^ ERROR: type annotations needed [E0284]
+        reuse Trait::<'static, 'static, 'static, i32>::foo::<String, false> as bar4 {
+            self.get_self()
+        }
+    }
+
+    impl<'a, 'b, 'c, X, Y, Z> Trait2<'a, 'b, 'c, X, Y, Z> for u32 {}
+    impl Trait3 for u32 {}
+    impl<'a, 'b, 'c> Trait4<'a, 'b, 'c> for u32 {}
+    impl<X, Y, Z> Trait5<X, Y, Z> for u32 {}
+
+    pub fn check<'a: 'a>() {
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar1::<String, true>(&123);
+        //~^ ERROR: method takes 3 generic arguments but 2 generic arguments were supplied [E0107]
+        <u32 as Trait3>::bar1::<String, true>(&123);
+        //~^ ERROR: method takes 3 generic arguments but 2 generic arguments were supplied [E0107]
+        <u32 as Trait4<'a, 'a, 'static>>::bar1::<String, true>(&123);
+        //~^ ERROR: method takes 3 generic arguments but 2 generic arguments were supplied [E0107]
+        <u32 as Trait5<i32, u64, String>>::bar1::<String, true>(&123);
+        //~^ ERROR: method takes 3 generic arguments but 2 generic arguments were supplied [E0107]
+
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar2(&123);
+        <u32 as Trait3>::bar2(&123);
+        <u32 as Trait4<'a, 'a, 'static>>::bar2(&123);
+        <u32 as Trait5<i32, u64, String>>::bar2(&123);
+
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar3::<String, true>(&123);
+        //~^ ERROR: method takes 3 generic arguments but 2 generic arguments were supplied [E0107]
+        <u32 as Trait3>::bar3::<String, true>(&123);
+        //~^ ERROR: method takes 3 generic arguments but 2 generic arguments were supplied [E0107]
+        <u32 as Trait4<'a, 'a, 'static>>::bar3::<String, true>(&123);
+        //~^ ERROR: method takes 3 generic arguments but 2 generic arguments were supplied [E0107]
+        <u32 as Trait5<i32, u64, String>>::bar3::<String, true>(&123);
+        //~^ ERROR: method takes 3 generic arguments but 2 generic arguments were supplied [E0107]
+
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar4(&123);
+        <u32 as Trait3>::bar4(&123);
+        <u32 as Trait4<'a, 'a, 'static>>::bar4(&123);
+        <u32 as Trait5<i32, u64, String>>::bar4(&123);
+    }
+}
+
+// Testing lifetimes + types in parent,
+// none in child,
+// in delegation parent with:
+// lifetimes + types OR none OR lifetimes OR types,
+// with(out) user-specified args, with different target expr
+mod test_6 {
+    trait Trait<'b, 'c, 'a, T>: Sized {
+        fn foo(&self) {}
+    }
+
+    impl<'b, 'c, 'a, T> Trait<'b, 'c, 'a, T> for u8 {}
+
+    trait Trait2<'a, 'b, 'c, X, Y, Z> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+        reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+    }
+
+    trait Trait3 {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+        reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+    }
+
+    trait Trait4<'a, 'b, 'c> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+        reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+    }
+
+    trait Trait5<X, Y, Z> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+        reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+    }
+
+    impl<'a, 'b, 'c, X, Y, Z> Trait2<'a, 'b, 'c, X, Y, Z> for u32 {}
+    impl Trait3 for u32 {}
+    impl<'a, 'b, 'c> Trait4<'a, 'b, 'c> for u32 {}
+    impl<X, Y, Z> Trait5<X, Y, Z> for u32 {}
+
+    pub fn check<'a: 'a>() {
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar1(&123);
+        //~^ ERROR: type annotations needed [E0282]
+        <u32 as Trait3>::bar1(&123);
+        <u32 as Trait4<'a, 'a, 'static>>::bar1(&123);
+        <u32 as Trait5<i32, u64, String>>::bar1(&123);
+
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar3(&123);
+        <u32 as Trait3>::bar3(&123);
+        <u32 as Trait4<'a, 'a, 'static>>::bar3(&123);
+        <u32 as Trait5<i32, u64, String>>::bar3(&123);
+    }
+}
+
+// Testing types in parent,
+// none in child,
+// in delegation parent with:
+// lifetimes + types OR none OR lifetimes OR types,
+// with user-specified args, with different target expr
+mod test_7 {
+    trait Trait<T>: Sized {
+        fn foo(&self) {}
+    }
+
+    impl<T> Trait<T> for u8 {}
+
+    trait Trait2<'a, 'b, 'c, X, Y, Z> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<i32>::foo as bar1 { Self::get() }
+        reuse Trait::<i32>::foo as bar3 { self.get_self() }
+    }
+
+    trait Trait3 {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<i32>::foo as bar1 { Self::get() }
+        reuse Trait::<i32>::foo as bar3 { self.get_self() }
+    }
+
+    trait Trait4<'a, 'b, 'c> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<i32>::foo as bar1 { Self::get() }
+        reuse Trait::<i32>::foo as bar3 { self.get_self() }
+    }
+
+    trait Trait5<X, Y, Z> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<i32>::foo as bar1 { Self::get() }
+        reuse Trait::<i32>::foo as bar3 { self.get_self() }
+    }
+
+    impl<'a, 'b, 'c, X, Y, Z> Trait2<'a, 'b, 'c, X, Y, Z> for u32 {}
+    impl Trait3 for u32 {}
+    impl<'a, 'b, 'c> Trait4<'a, 'b, 'c> for u32 {}
+    impl<X, Y, Z> Trait5<X, Y, Z> for u32 {}
+
+    pub fn check<'a: 'a>() {
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar1(&123);
+        //~^ ERROR: type annotations needed [E0282]
+        <u32 as Trait3>::bar1(&123);
+        <u32 as Trait4<'a, 'a, 'static>>::bar1(&123);
+        <u32 as Trait5<i32, u64, String>>::bar1(&123);
+
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar3(&123);
+        <u32 as Trait3>::bar3(&123);
+        <u32 as Trait4<'a, 'a, 'static>>::bar3(&123);
+        <u32 as Trait5<i32, u64, String>>::bar3(&123);
+    }
+}
+
+// Testing none in parent,
+// none in child,
+// in delegation parent with:
+// lifetimes + types OR none OR lifetimes OR types,
+// without user-specified args, with different target expr
+mod test_8 {
+    trait Trait: Sized {
+        fn foo(&self) {}
+    }
+
+    impl Trait for u8 {}
+
+    trait Trait2<'a, 'b, 'c, X, Y, Z> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::foo as bar1 { Self::get() }
+        reuse Trait::foo as bar3 { self.get_self() }
+    }
+
+    trait Trait3 {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::foo as bar1 { Self::get() }
+        reuse Trait::foo as bar3 { self.get_self() }
+    }
+
+    trait Trait4<'a, 'b, 'c> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::foo as bar1 { Self::get() }
+        reuse Trait::foo as bar3 { self.get_self() }
+    }
+
+    trait Trait5<X, Y, Z> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::foo as bar1 { Self::get() }
+        reuse Trait::foo as bar3 { self.get_self() }
+    }
+
+    impl<'a, 'b, 'c, X, Y, Z> Trait2<'a, 'b, 'c, X, Y, Z> for u32 {}
+    impl Trait3 for u32 {}
+    impl<'a, 'b, 'c> Trait4<'a, 'b, 'c> for u32 {}
+    impl<X, Y, Z> Trait5<X, Y, Z> for u32 {}
+
+    pub fn check<'a: 'a>() {
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar1(&123);
+        <u32 as Trait3>::bar1(&123);
+        <u32 as Trait4<'a, 'a, 'static>>::bar1(&123);
+        <u32 as Trait5<i32, u64, String>>::bar1(&123);
+
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar3(&123);
+        <u32 as Trait3>::bar3(&123);
+        <u32 as Trait4<'a, 'a, 'static>>::bar3(&123);
+        <u32 as Trait5<i32, u64, String>>::bar3(&123);
+    }
+}
+
+// Testing types in parent,
+// lifetimes in child,
+// in delegation parent with:
+// lifetimes + types OR none OR lifetimes OR types,
+// with(out) user-specified args, with different target expr
+mod test_9 {
+    trait Trait<T>: Sized {
+        fn foo<'a: 'a, 'b: 'b>(&self) {}
+    }
+
+    impl<T> Trait<T> for u8 {}
+
+    trait Trait2<'a, 'b, 'c, X, Y, Z> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<i32>::foo as bar1 { Self::get() }
+        reuse Trait::<i32>::foo::<'static, 'static> as bar2 { Self::get() }
+        reuse Trait::<i32>::foo as bar3 { self.get_self() }
+        reuse Trait::<i32>::foo::<'static, 'static> as bar4 { self.get_self() }
+    }
+
+    trait Trait3 {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<i32>::foo as bar1 { Self::get() }
+        reuse Trait::<i32>::foo::<'static, 'static> as bar2 { Self::get() }
+        reuse Trait::<i32>::foo as bar3 { self.get_self() }
+        reuse Trait::<i32>::foo::<'static, 'static> as bar4 { self.get_self() }
+    }
+
+    trait Trait4<'a, 'b, 'c> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<i32>::foo as bar1 { Self::get() }
+        reuse Trait::<i32>::foo::<'static, 'static> as bar2 { Self::get() }
+        reuse Trait::<i32>::foo as bar3 { self.get_self() }
+        reuse Trait::<i32>::foo::<'static, 'static> as bar4 { self.get_self() }
+    }
+
+    trait Trait5<X, Y, Z> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<i32>::foo as bar1 { Self::get() }
+        reuse Trait::<i32>::foo::<'static, 'static> as bar2 { Self::get() }
+        reuse Trait::<i32>::foo as bar3 { self.get_self() }
+        reuse Trait::<i32>::foo::<'static, 'static> as bar4 { self.get_self() }
+    }
+
+    impl<'a, 'b, 'c, X, Y, Z> Trait2<'a, 'b, 'c, X, Y, Z> for u32 {}
+    impl Trait3 for u32 {}
+    impl<'a, 'b, 'c> Trait4<'a, 'b, 'c> for u32 {}
+    impl<X, Y, Z> Trait5<X, Y, Z> for u32 {}
+
+    pub fn check<'a: 'a>() {
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>
+        //~^ ERROR: type annotations needed [E0282]
+            ::bar1::<'static, 'static>(&123);
+        <u32 as Trait3>::bar1::<'static, 'static>(&123);
+        <u32 as Trait4<'a, 'a, 'static>>::bar1::<'a, 'a>(&123);
+        <u32 as Trait5<i32, u64, String>>::bar1::<'a, 'a>(&123);
+
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar2(&123);
+        <u32 as Trait3>::bar2(&123);
+        <u32 as Trait4<'a, 'a, 'static>>::bar2(&123);
+        <u32 as Trait5<i32, u64, String>>::bar2(&123);
+
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>
+            ::bar3::<'static, 'static>(&123);
+        <u32 as Trait3>::bar3::<'static, 'static>(&123);
+        <u32 as Trait4<'a, 'a, 'static>>::bar3::<'static, 'static>(&123);
+        <u32 as Trait5<i32, u64, String>>::bar3::<'static, 'static>(&123);
+
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar4(&123);
+        <u32 as Trait3>::bar4(&123);
+        <u32 as Trait4<'a, 'a, 'static>>::bar4(&123);
+        <u32 as Trait5<i32, u64, String>>::bar4(&123);
+    }
+}
+
+// Testing lifetimes in parent,
+// lifetimes in child,
+// in delegation parent with:
+// lifetimes + types OR none OR lifetimes OR types,
+// with(out) user-specified args, with different target expr
+mod test_10 {
+    trait Trait<'x, 'y, 'z>: Sized {
+        fn foo<'a: 'a, 'b: 'b>(&self) {}
+    }
+
+    impl<'x, 'y, 'z> Trait<'x, 'y, 'z> for u8 {}
+
+    trait Trait2<'a, 'b, 'c, X, Y, Z> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<'a, 'b, 'static>::foo as bar1 { Self::get() }
+        reuse Trait::<'a, 'b, 'static>::foo::<'static, 'static> as bar2 { Self::get() }
+        reuse Trait::<'a, 'b, 'static>::foo as bar3 { self.get_self() }
+        reuse Trait::<'a, 'b, 'static>::foo::<'static, 'static> as bar4 { self.get_self() }
+    }
+
+    trait Trait3 {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<'static, 'static, 'static>::foo as bar1 { Self::get() }
+        reuse Trait::<'static, 'static, 'static>::foo::<'static, 'static> as bar2 {
+            Self::get()
+        }
+        reuse Trait::<'static, 'static, 'static>::foo as bar3 { self.get_self() }
+        reuse Trait::<'static, 'static, 'static>::foo::<'static, 'static> as bar4 {
+                self.get_self()
+        }
+    }
+
+    trait Trait4<'a, 'b, 'c> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<'a, 'b, 'static>::foo as bar1 { Self::get() }
+        reuse Trait::<'a, 'b, 'static>::foo::<'static, 'static> as bar2 { Self::get() }
+        reuse Trait::<'a, 'b, 'static>::foo as bar3 { self.get_self() }
+        reuse Trait::<'a, 'b, 'static>::foo::<'static, 'static> as bar4 { self.get_self() }
+    }
+
+    trait Trait5<X, Y, Z> {
+        fn get() -> &'static u8 { &0 }
+        fn get_self(&self) -> &'static u8 { &0 }
+        reuse Trait::<'static, 'static, 'static>::foo as bar1 { Self::get() }
+        reuse Trait::<'static, 'static, 'static>::foo::<'static, 'static> as bar2 {
+            Self::get()
+        }
+        reuse Trait::<'static, 'static, 'static>::foo as bar3 { self.get_self() }
+        reuse Trait::<'static, 'static, 'static>::foo::<'static, 'static> as bar4 {
+            self.get_self()
+        }
+    }
+
+    impl<'a, 'b, 'c, X, Y, Z> Trait2<'a, 'b, 'c, X, Y, Z> for u32 {}
+    impl Trait3 for u32 {}
+    impl<'a, 'b, 'c> Trait4<'a, 'b, 'c> for u32 {}
+    impl<X, Y, Z> Trait5<X, Y, Z> for u32 {}
+
+    pub fn check<'a: 'a>() {
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>
+            ::bar1::<'static, 'static>(&123);
+            //~^ ERROR: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present [E0794]
+        <u32 as Trait3>::bar1::<'static, 'static>(&123);
+        //~^ ERROR: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present [E0794]
+        <u32 as Trait4<'a, 'a, 'static>>::bar1::<'a, 'a>(&123);
+        //~^ ERROR: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present [E0794]
+        <u32 as Trait5<i32, u64, String>>::bar1::<'a, 'a>(&123);
+        //~^ ERROR: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present [E0794]
+
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar2(&123);
+        <u32 as Trait3>::bar2(&123);
+        <u32 as Trait4<'a, 'a, 'static>>::bar2(&123);
+        <u32 as Trait5<i32, u64, String>>::bar2(&123);
+
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>
+            ::bar3::<'static, 'static>(&123);
+            //~^ ERROR: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present [E0794]
+        <u32 as Trait3>::bar3::<'static, 'static>(&123);
+        //~^ ERROR: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present [E0794]
+        <u32 as Trait4<'a, 'a, 'static>>::bar3::<'static, 'static>(&123);
+        //~^ ERROR: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present [E0794]
+        <u32 as Trait5<i32, u64, String>>::bar3::<'static, 'static>(&123);
+        //~^ ERROR: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present [E0794]
+
+        <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar4(&123);
+        <u32 as Trait3>::bar4(&123);
+        <u32 as Trait4<'a, 'a, 'static>>::bar4(&123);
+        <u32 as Trait5<i32, u64, String>>::bar4(&123);
+    }
+}
+
+pub fn main() {
+    test_1::check();
+    test_2::check();
+    test_3::check();
+    test_4::check();
+    test_5::check();
+    test_6::check();
+    test_7::check();
+    test_8::check();
+    test_9::check();
+    test_10::check();
+}

--- a/tests/ui/delegation/generics/mapping/trait-to-trait.stderr
+++ b/tests/ui/delegation/generics/mapping/trait-to-trait.stderr
@@ -1,0 +1,1544 @@
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:26:56
+   |
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+   |                                                        ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_1::Trait::foo`
+  --> $DIR/trait-to-trait.rs:18:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:32:56
+   |
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+   |                                                        ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_1::Trait::foo`
+  --> $DIR/trait-to-trait.rs:18:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:49:56
+   |
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+   |                                                        ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_1::Trait::foo`
+  --> $DIR/trait-to-trait.rs:18:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:53:56
+   |
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+   |                                                        ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_1::Trait::foo`
+  --> $DIR/trait-to-trait.rs:18:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:62:56
+   |
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+   |                                                        ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_1::Trait::foo`
+  --> $DIR/trait-to-trait.rs:18:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:66:56
+   |
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+   |                                                        ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_1::Trait::foo`
+  --> $DIR/trait-to-trait.rs:18:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:75:56
+   |
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+   |                                                        ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_1::Trait::foo`
+  --> $DIR/trait-to-trait.rs:18:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:79:56
+   |
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+   |                                                        ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_1::Trait::foo`
+  --> $DIR/trait-to-trait.rs:18:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+
+error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/trait-to-trait.rs:92:22
+   |
+LL |             ::bar1::<'static, String, true>(&123);
+   |                      ^^^^^^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/trait-to-trait.rs:18:42
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                                          ^
+
+error[E0107]: method takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/trait-to-trait.rs:92:15
+   |
+LL |             ::bar1::<'static, String, true>(&123);
+   |               ^^^^            ------  ---- supplied 2 generic arguments
+   |               |
+   |               expected 3 generic arguments
+   |
+note: method defined here, with 3 generic parameters: `T`, `U`, `M`
+  --> $DIR/trait-to-trait.rs:26:63
+   |
+LL |     trait Trait<'b, 'c, 'a, T>: Sized {
+   |                             -
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                        -  -------------
+...
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+   |                                                               ^^^^
+help: add missing generic argument
+   |
+LL |             ::bar1::<'static, String, true, M>(&123);
+   |                                           +++
+
+error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/trait-to-trait.rs:95:33
+   |
+LL |         <u32 as Trait3>::bar1::<'static, String, true>(&123);
+   |                                 ^^^^^^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/trait-to-trait.rs:18:42
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                                          ^
+
+error[E0107]: method takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/trait-to-trait.rs:95:26
+   |
+LL |         <u32 as Trait3>::bar1::<'static, String, true>(&123);
+   |                          ^^^^            ------  ---- supplied 2 generic arguments
+   |                          |
+   |                          expected 3 generic arguments
+   |
+note: method defined here, with 3 generic parameters: `T`, `U`, `M`
+  --> $DIR/trait-to-trait.rs:49:63
+   |
+LL |     trait Trait<'b, 'c, 'a, T>: Sized {
+   |                             -
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                        -  -------------
+...
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+   |                                                               ^^^^
+help: add missing generic argument
+   |
+LL |         <u32 as Trait3>::bar1::<'static, String, true, M>(&123);
+   |                                                      +++
+
+error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/trait-to-trait.rs:98:50
+   |
+LL |         <u32 as Trait4<'a, 'a, 'static>>::bar1::<'static, String, true>(&123);
+   |                                                  ^^^^^^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/trait-to-trait.rs:18:42
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                                          ^
+
+error[E0107]: method takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/trait-to-trait.rs:98:43
+   |
+LL |         <u32 as Trait4<'a, 'a, 'static>>::bar1::<'static, String, true>(&123);
+   |                                           ^^^^            ------  ---- supplied 2 generic arguments
+   |                                           |
+   |                                           expected 3 generic arguments
+   |
+note: method defined here, with 3 generic parameters: `T`, `U`, `M`
+  --> $DIR/trait-to-trait.rs:62:63
+   |
+LL |     trait Trait<'b, 'c, 'a, T>: Sized {
+   |                             -
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                        -  -------------
+...
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+   |                                                               ^^^^
+help: add missing generic argument
+   |
+LL |         <u32 as Trait4<'a, 'a, 'static>>::bar1::<'static, String, true, M>(&123);
+   |                                                                       +++
+
+error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/trait-to-trait.rs:101:51
+   |
+LL |         <u32 as Trait5<i32, u64, String>>::bar1::<'static, String, true>(&123);
+   |                                                   ^^^^^^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/trait-to-trait.rs:18:42
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                                          ^
+
+error[E0107]: method takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/trait-to-trait.rs:101:44
+   |
+LL |         <u32 as Trait5<i32, u64, String>>::bar1::<'static, String, true>(&123);
+   |                                            ^^^^            ------  ---- supplied 2 generic arguments
+   |                                            |
+   |                                            expected 3 generic arguments
+   |
+note: method defined here, with 3 generic parameters: `T`, `U`, `M`
+  --> $DIR/trait-to-trait.rs:75:63
+   |
+LL |     trait Trait<'b, 'c, 'a, T>: Sized {
+   |                             -
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                        -  -------------
+...
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+   |                                                               ^^^^
+help: add missing generic argument
+   |
+LL |         <u32 as Trait5<i32, u64, String>>::bar1::<'static, String, true, M>(&123);
+   |                                                                        +++
+
+error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/trait-to-trait.rs:111:22
+   |
+LL |             ::bar3::<'static, String, true>(&123);
+   |                      ^^^^^^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/trait-to-trait.rs:18:42
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                                          ^
+
+error[E0107]: method takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/trait-to-trait.rs:111:15
+   |
+LL |             ::bar3::<'static, String, true>(&123);
+   |               ^^^^            ------  ---- supplied 2 generic arguments
+   |               |
+   |               expected 3 generic arguments
+   |
+note: method defined here, with 3 generic parameters: `T`, `U`, `M`
+  --> $DIR/trait-to-trait.rs:32:63
+   |
+LL |     trait Trait<'b, 'c, 'a, T>: Sized {
+   |                             -
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                        -  -------------
+...
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+   |                                                               ^^^^
+help: add missing generic argument
+   |
+LL |             ::bar3::<'static, String, true, M>(&123);
+   |                                           +++
+
+error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/trait-to-trait.rs:114:33
+   |
+LL |         <u32 as Trait3>::bar3::<'static, String, true>(&123);
+   |                                 ^^^^^^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/trait-to-trait.rs:18:42
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                                          ^
+
+error[E0107]: method takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/trait-to-trait.rs:114:26
+   |
+LL |         <u32 as Trait3>::bar3::<'static, String, true>(&123);
+   |                          ^^^^            ------  ---- supplied 2 generic arguments
+   |                          |
+   |                          expected 3 generic arguments
+   |
+note: method defined here, with 3 generic parameters: `T`, `U`, `M`
+  --> $DIR/trait-to-trait.rs:53:63
+   |
+LL |     trait Trait<'b, 'c, 'a, T>: Sized {
+   |                             -
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                        -  -------------
+...
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+   |                                                               ^^^^
+help: add missing generic argument
+   |
+LL |         <u32 as Trait3>::bar3::<'static, String, true, M>(&123);
+   |                                                      +++
+
+error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/trait-to-trait.rs:117:50
+   |
+LL |         <u32 as Trait4<'a, 'a, 'static>>::bar3::<'static, String, true>(&123);
+   |                                                  ^^^^^^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/trait-to-trait.rs:18:42
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                                          ^
+
+error[E0107]: method takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/trait-to-trait.rs:117:43
+   |
+LL |         <u32 as Trait4<'a, 'a, 'static>>::bar3::<'static, String, true>(&123);
+   |                                           ^^^^            ------  ---- supplied 2 generic arguments
+   |                                           |
+   |                                           expected 3 generic arguments
+   |
+note: method defined here, with 3 generic parameters: `T`, `U`, `M`
+  --> $DIR/trait-to-trait.rs:66:63
+   |
+LL |     trait Trait<'b, 'c, 'a, T>: Sized {
+   |                             -
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                        -  -------------
+...
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+   |                                                               ^^^^
+help: add missing generic argument
+   |
+LL |         <u32 as Trait4<'a, 'a, 'static>>::bar3::<'static, String, true, M>(&123);
+   |                                                                       +++
+
+error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/trait-to-trait.rs:120:51
+   |
+LL |         <u32 as Trait5<i32, u64, String>>::bar3::<'static, String, true>(&123);
+   |                                                   ^^^^^^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/trait-to-trait.rs:18:42
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                                          ^
+
+error[E0107]: method takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/trait-to-trait.rs:120:44
+   |
+LL |         <u32 as Trait5<i32, u64, String>>::bar3::<'static, String, true>(&123);
+   |                                            ^^^^            ------  ---- supplied 2 generic arguments
+   |                                            |
+   |                                            expected 3 generic arguments
+   |
+note: method defined here, with 3 generic parameters: `T`, `U`, `M`
+  --> $DIR/trait-to-trait.rs:79:63
+   |
+LL |     trait Trait<'b, 'c, 'a, T>: Sized {
+   |                             -
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                        -  -------------
+...
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+   |                                                               ^^^^
+help: add missing generic argument
+   |
+LL |         <u32 as Trait5<i32, u64, String>>::bar3::<'static, String, true, M>(&123);
+   |                                                                        +++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:146:29
+   |
+LL |         reuse Trait::<i32>::foo as bar1 { Self::get() }
+   |                             ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_2::Trait::foo`
+  --> $DIR/trait-to-trait.rs:138:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:149:29
+   |
+LL |         reuse Trait::<i32>::foo as bar3 { self.get_self() }
+   |                             ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_2::Trait::foo`
+  --> $DIR/trait-to-trait.rs:138:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:157:29
+   |
+LL |         reuse Trait::<i32>::foo as bar1 { Self::get() }
+   |                             ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_2::Trait::foo`
+  --> $DIR/trait-to-trait.rs:138:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:160:29
+   |
+LL |         reuse Trait::<i32>::foo as bar3 { self.get_self() }
+   |                             ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_2::Trait::foo`
+  --> $DIR/trait-to-trait.rs:138:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:168:29
+   |
+LL |         reuse Trait::<i32>::foo as bar1 { Self::get() }
+   |                             ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_2::Trait::foo`
+  --> $DIR/trait-to-trait.rs:138:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:171:29
+   |
+LL |         reuse Trait::<i32>::foo as bar3 { self.get_self() }
+   |                             ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_2::Trait::foo`
+  --> $DIR/trait-to-trait.rs:138:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:179:29
+   |
+LL |         reuse Trait::<i32>::foo as bar1 { Self::get() }
+   |                             ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_2::Trait::foo`
+  --> $DIR/trait-to-trait.rs:138:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:182:29
+   |
+LL |         reuse Trait::<i32>::foo as bar3 { self.get_self() }
+   |                             ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_2::Trait::foo`
+  --> $DIR/trait-to-trait.rs:138:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+
+error[E0107]: method takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/trait-to-trait.rs:194:15
+   |
+LL |             ::bar1::<'static, String, true>(&123);
+   |               ^^^^            ------  ---- supplied 2 generic arguments
+   |               |
+   |               expected 3 generic arguments
+   |
+note: method defined here, with 3 generic parameters: `T`, `U`, `M`
+  --> $DIR/trait-to-trait.rs:146:36
+   |
+LL |     trait Trait<T>: Sized {
+   |                 -
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                        -  -------------
+...
+LL |         reuse Trait::<i32>::foo as bar1 { Self::get() }
+   |                                    ^^^^
+help: add missing generic argument
+   |
+LL |             ::bar1::<'static, String, true, M>(&123);
+   |                                           +++
+
+error[E0107]: method takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/trait-to-trait.rs:196:26
+   |
+LL |         <u32 as Trait3>::bar1::<'static, String, true>(&123);
+   |                          ^^^^            ------  ---- supplied 2 generic arguments
+   |                          |
+   |                          expected 3 generic arguments
+   |
+note: method defined here, with 3 generic parameters: `T`, `U`, `M`
+  --> $DIR/trait-to-trait.rs:157:36
+   |
+LL |     trait Trait<T>: Sized {
+   |                 -
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                        -  -------------
+...
+LL |         reuse Trait::<i32>::foo as bar1 { Self::get() }
+   |                                    ^^^^
+help: add missing generic argument
+   |
+LL |         <u32 as Trait3>::bar1::<'static, String, true, M>(&123);
+   |                                                      +++
+
+error[E0107]: method takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/trait-to-trait.rs:198:43
+   |
+LL |         <u32 as Trait4<'a, 'a, 'static>>::bar1::<'static, String, true>(&123);
+   |                                           ^^^^            ------  ---- supplied 2 generic arguments
+   |                                           |
+   |                                           expected 3 generic arguments
+   |
+note: method defined here, with 3 generic parameters: `T`, `U`, `M`
+  --> $DIR/trait-to-trait.rs:168:36
+   |
+LL |     trait Trait<T>: Sized {
+   |                 -
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                        -  -------------
+...
+LL |         reuse Trait::<i32>::foo as bar1 { Self::get() }
+   |                                    ^^^^
+help: add missing generic argument
+   |
+LL |         <u32 as Trait4<'a, 'a, 'static>>::bar1::<'static, String, true, M>(&123);
+   |                                                                       +++
+
+error[E0107]: method takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/trait-to-trait.rs:200:44
+   |
+LL |         <u32 as Trait5<i32, u64, String>>::bar1::<'static, String, true>(&123);
+   |                                            ^^^^            ------  ---- supplied 2 generic arguments
+   |                                            |
+   |                                            expected 3 generic arguments
+   |
+note: method defined here, with 3 generic parameters: `T`, `U`, `M`
+  --> $DIR/trait-to-trait.rs:179:36
+   |
+LL |     trait Trait<T>: Sized {
+   |                 -
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                        -  -------------
+...
+LL |         reuse Trait::<i32>::foo as bar1 { Self::get() }
+   |                                    ^^^^
+help: add missing generic argument
+   |
+LL |         <u32 as Trait5<i32, u64, String>>::bar1::<'static, String, true, M>(&123);
+   |                                                                        +++
+
+error[E0107]: method takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/trait-to-trait.rs:209:15
+   |
+LL |             ::bar3::<'static, String, true>(&123);
+   |               ^^^^            ------  ---- supplied 2 generic arguments
+   |               |
+   |               expected 3 generic arguments
+   |
+note: method defined here, with 3 generic parameters: `T`, `U`, `M`
+  --> $DIR/trait-to-trait.rs:149:36
+   |
+LL |     trait Trait<T>: Sized {
+   |                 -
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                        -  -------------
+...
+LL |         reuse Trait::<i32>::foo as bar3 { self.get_self() }
+   |                                    ^^^^
+help: add missing generic argument
+   |
+LL |             ::bar3::<'static, String, true, M>(&123);
+   |                                           +++
+
+error[E0107]: method takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/trait-to-trait.rs:211:26
+   |
+LL |         <u32 as Trait3>::bar3::<'static, String, true>(&123);
+   |                          ^^^^            ------  ---- supplied 2 generic arguments
+   |                          |
+   |                          expected 3 generic arguments
+   |
+note: method defined here, with 3 generic parameters: `T`, `U`, `M`
+  --> $DIR/trait-to-trait.rs:160:36
+   |
+LL |     trait Trait<T>: Sized {
+   |                 -
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                        -  -------------
+...
+LL |         reuse Trait::<i32>::foo as bar3 { self.get_self() }
+   |                                    ^^^^
+help: add missing generic argument
+   |
+LL |         <u32 as Trait3>::bar3::<'static, String, true, M>(&123);
+   |                                                      +++
+
+error[E0107]: method takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/trait-to-trait.rs:213:43
+   |
+LL |         <u32 as Trait4<'a, 'a, 'static>>::bar3::<'static, String, true>(&123);
+   |                                           ^^^^            ------  ---- supplied 2 generic arguments
+   |                                           |
+   |                                           expected 3 generic arguments
+   |
+note: method defined here, with 3 generic parameters: `T`, `U`, `M`
+  --> $DIR/trait-to-trait.rs:171:36
+   |
+LL |     trait Trait<T>: Sized {
+   |                 -
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                        -  -------------
+...
+LL |         reuse Trait::<i32>::foo as bar3 { self.get_self() }
+   |                                    ^^^^
+help: add missing generic argument
+   |
+LL |         <u32 as Trait4<'a, 'a, 'static>>::bar3::<'static, String, true, M>(&123);
+   |                                                                       +++
+
+error[E0107]: method takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/trait-to-trait.rs:215:44
+   |
+LL |         <u32 as Trait5<i32, u64, String>>::bar3::<'static, String, true>(&123);
+   |                                            ^^^^            ------  ---- supplied 2 generic arguments
+   |                                            |
+   |                                            expected 3 generic arguments
+   |
+note: method defined here, with 3 generic parameters: `T`, `U`, `M`
+  --> $DIR/trait-to-trait.rs:182:36
+   |
+LL |     trait Trait<T>: Sized {
+   |                 -
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                        -  -------------
+...
+LL |         reuse Trait::<i32>::foo as bar3 { self.get_self() }
+   |                                    ^^^^
+help: add missing generic argument
+   |
+LL |         <u32 as Trait5<i32, u64, String>>::bar3::<'static, String, true, M>(&123);
+   |                                                                        +++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:240:51
+   |
+LL |         reuse Trait::<'static, 'static, 'static>::foo as bar1 { Self::get() }
+   |                                                   ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_3::Trait::foo`
+  --> $DIR/trait-to-trait.rs:232:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse Trait::<'static, 'static, 'static>::foo::<U, M> as bar1 { Self::get() }
+   |                                                      ++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:245:51
+   |
+LL |         reuse Trait::<'static, 'static, 'static>::foo as bar3 { self.get_self() }
+   |                                                   ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_3::Trait::foo`
+  --> $DIR/trait-to-trait.rs:232:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse Trait::<'static, 'static, 'static>::foo::<U, M> as bar3 { self.get_self() }
+   |                                                      ++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:255:51
+   |
+LL |         reuse Trait::<'static, 'static, 'static>::foo as bar1 { Self::get() }
+   |                                                   ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_3::Trait::foo`
+  --> $DIR/trait-to-trait.rs:232:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse Trait::<'static, 'static, 'static>::foo::<U, M> as bar1 { Self::get() }
+   |                                                      ++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:260:51
+   |
+LL |         reuse Trait::<'static, 'static, 'static>::foo as bar3 { self.get_self() }
+   |                                                   ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_3::Trait::foo`
+  --> $DIR/trait-to-trait.rs:232:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse Trait::<'static, 'static, 'static>::foo::<U, M> as bar3 { self.get_self() }
+   |                                                      ++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:270:51
+   |
+LL |         reuse Trait::<'static, 'static, 'static>::foo as bar1 { Self::get() }
+   |                                                   ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_3::Trait::foo`
+  --> $DIR/trait-to-trait.rs:232:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse Trait::<'static, 'static, 'static>::foo::<U, M> as bar1 { Self::get() }
+   |                                                      ++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:275:51
+   |
+LL |         reuse Trait::<'static, 'static, 'static>::foo as bar3 { self.get_self() }
+   |                                                   ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_3::Trait::foo`
+  --> $DIR/trait-to-trait.rs:232:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse Trait::<'static, 'static, 'static>::foo::<U, M> as bar3 { self.get_self() }
+   |                                                      ++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:285:51
+   |
+LL |         reuse Trait::<'static, 'static, 'static>::foo as bar1 { Self::get() }
+   |                                                   ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_3::Trait::foo`
+  --> $DIR/trait-to-trait.rs:232:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse Trait::<'static, 'static, 'static>::foo::<U, M> as bar1 { Self::get() }
+   |                                                      ++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:289:51
+   |
+LL |         reuse Trait::<'static, 'static, 'static>::foo as bar3 { self.get_self() }
+   |                                                   ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_3::Trait::foo`
+  --> $DIR/trait-to-trait.rs:232:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse Trait::<'static, 'static, 'static>::foo::<U, M> as bar3 { self.get_self() }
+   |                                                      ++++++++
+
+error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/trait-to-trait.rs:302:22
+   |
+LL |             ::bar1::<'static, String, true>(&123);
+   |                      ^^^^^^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/trait-to-trait.rs:232:42
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                                          ^
+
+error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/trait-to-trait.rs:304:33
+   |
+LL |         <u32 as Trait3>::bar1::<'static, String, true>(&123);
+   |                                 ^^^^^^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/trait-to-trait.rs:232:42
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                                          ^
+
+error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/trait-to-trait.rs:306:50
+   |
+LL |         <u32 as Trait4<'a, 'a, 'static>>::bar1::<'static, String, true>(&123);
+   |                                                  ^^^^^^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/trait-to-trait.rs:232:42
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                                          ^
+
+error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/trait-to-trait.rs:308:51
+   |
+LL |         <u32 as Trait5<i32, u64, String>>::bar1::<'static, String, true>(&123);
+   |                                                   ^^^^^^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/trait-to-trait.rs:232:42
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                                          ^
+
+error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/trait-to-trait.rs:317:22
+   |
+LL |             ::bar3::<'static, String, true>(&123);
+   |                      ^^^^^^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/trait-to-trait.rs:232:42
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                                          ^
+
+error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/trait-to-trait.rs:319:33
+   |
+LL |         <u32 as Trait3>::bar3::<'static, String, true>(&123);
+   |                                 ^^^^^^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/trait-to-trait.rs:232:42
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                                          ^
+
+error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/trait-to-trait.rs:321:50
+   |
+LL |         <u32 as Trait4<'a, 'a, 'static>>::bar3::<'static, String, true>(&123);
+   |                                                  ^^^^^^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/trait-to-trait.rs:232:42
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                                          ^
+
+error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/trait-to-trait.rs:323:51
+   |
+LL |         <u32 as Trait5<i32, u64, String>>::bar3::<'static, String, true>(&123);
+   |                                                   ^^^^^^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/trait-to-trait.rs:232:42
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                                          ^
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:348:22
+   |
+LL |         reuse Trait::foo as bar1 { Self::get() }
+   |                      ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_4::Trait::foo`
+  --> $DIR/trait-to-trait.rs:340:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse Trait::foo::<U, M> as bar1 { Self::get() }
+   |                         ++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:351:22
+   |
+LL |         reuse Trait::foo as bar3 { self.get_self() }
+   |                      ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_4::Trait::foo`
+  --> $DIR/trait-to-trait.rs:340:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse Trait::foo::<U, M> as bar3 { self.get_self() }
+   |                         ++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:359:22
+   |
+LL |         reuse Trait::foo as bar1 { Self::get() }
+   |                      ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_4::Trait::foo`
+  --> $DIR/trait-to-trait.rs:340:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse Trait::foo::<U, M> as bar1 { Self::get() }
+   |                         ++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:362:22
+   |
+LL |         reuse Trait::foo as bar3 { self.get_self() }
+   |                      ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_4::Trait::foo`
+  --> $DIR/trait-to-trait.rs:340:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse Trait::foo::<U, M> as bar3 { self.get_self() }
+   |                         ++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:370:22
+   |
+LL |         reuse Trait::foo as bar1 { Self::get() }
+   |                      ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_4::Trait::foo`
+  --> $DIR/trait-to-trait.rs:340:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse Trait::foo::<U, M> as bar1 { Self::get() }
+   |                         ++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:373:22
+   |
+LL |         reuse Trait::foo as bar3 { self.get_self() }
+   |                      ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_4::Trait::foo`
+  --> $DIR/trait-to-trait.rs:340:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse Trait::foo::<U, M> as bar3 { self.get_self() }
+   |                         ++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:381:22
+   |
+LL |         reuse Trait::foo as bar1 { Self::get() }
+   |                      ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_4::Trait::foo`
+  --> $DIR/trait-to-trait.rs:340:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse Trait::foo::<U, M> as bar1 { Self::get() }
+   |                         ++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:384:22
+   |
+LL |         reuse Trait::foo as bar3 { self.get_self() }
+   |                      ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_4::Trait::foo`
+  --> $DIR/trait-to-trait.rs:340:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+help: consider specifying the generic arguments
+   |
+LL |         reuse Trait::foo::<U, M> as bar3 { self.get_self() }
+   |                         ++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:401:9
+   |
+LL |         <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar2(&123);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `M` declared on the method `bar2`
+   |
+note: required by a const generic parameter in `test_4::Trait2::bar2`
+  --> $DIR/trait-to-trait.rs:340:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait2::bar2`
+...
+LL |         reuse Trait::foo::<'static, String, false> as bar2 { Self::get() }
+   |                                                       ---- required by a bound in this associated function
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:403:9
+   |
+LL |         <u32 as Trait3>::bar2(&123);
+   |         ^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `M` declared on the method `bar2`
+   |
+note: required by a const generic parameter in `test_4::Trait3::bar2`
+  --> $DIR/trait-to-trait.rs:340:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait3::bar2`
+...
+LL |         reuse Trait::foo::<'static, String, false> as bar2 { Self::get() }
+   |                                                       ---- required by a bound in this associated function
+help: consider specifying the generic arguments
+   |
+LL |         <u32 as Trait3>::bar2::<U, M>(&123);
+   |                              ++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:405:9
+   |
+LL |         <u32 as Trait4<'a, 'a, 'static>>::bar2(&123);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `M` declared on the method `bar2`
+   |
+note: required by a const generic parameter in `test_4::Trait4::bar2`
+  --> $DIR/trait-to-trait.rs:340:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait4::bar2`
+...
+LL |         reuse Trait::foo::<'static, String, false> as bar2 { Self::get() }
+   |                                                       ---- required by a bound in this associated function
+help: consider specifying the generic arguments
+   |
+LL |         <u32 as Trait4<'a, 'a, 'static>>::bar2::<U, M>(&123);
+   |                                               ++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:407:9
+   |
+LL |         <u32 as Trait5<i32, u64, String>>::bar2(&123);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `M` declared on the method `bar2`
+   |
+note: required by a const generic parameter in `test_4::Trait5::bar2`
+  --> $DIR/trait-to-trait.rs:340:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait5::bar2`
+...
+LL |         reuse Trait::foo::<'static, String, false> as bar2 { Self::get() }
+   |                                                       ---- required by a bound in this associated function
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:416:9
+   |
+LL |         <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar4(&123);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `M` declared on the method `bar4`
+   |
+note: required by a const generic parameter in `test_4::Trait2::bar4`
+  --> $DIR/trait-to-trait.rs:340:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait2::bar4`
+...
+LL |         reuse Trait::foo::<'static, String, false> as bar4 { self.get_self() }
+   |                                                       ---- required by a bound in this associated function
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:418:9
+   |
+LL |         <u32 as Trait3>::bar4(&123);
+   |         ^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `M` declared on the method `bar4`
+   |
+note: required by a const generic parameter in `test_4::Trait3::bar4`
+  --> $DIR/trait-to-trait.rs:340:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait3::bar4`
+...
+LL |         reuse Trait::foo::<'static, String, false> as bar4 { self.get_self() }
+   |                                                       ---- required by a bound in this associated function
+help: consider specifying the generic arguments
+   |
+LL |         <u32 as Trait3>::bar4::<U, M>(&123);
+   |                              ++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:420:9
+   |
+LL |         <u32 as Trait4<'a, 'a, 'static>>::bar4(&123);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `M` declared on the method `bar4`
+   |
+note: required by a const generic parameter in `test_4::Trait4::bar4`
+  --> $DIR/trait-to-trait.rs:340:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait4::bar4`
+...
+LL |         reuse Trait::foo::<'static, String, false> as bar4 { self.get_self() }
+   |                                                       ---- required by a bound in this associated function
+help: consider specifying the generic arguments
+   |
+LL |         <u32 as Trait4<'a, 'a, 'static>>::bar4::<U, M>(&123);
+   |                                               ++++++++
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:422:9
+   |
+LL |         <u32 as Trait5<i32, u64, String>>::bar4(&123);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `M` declared on the method `bar4`
+   |
+note: required by a const generic parameter in `test_4::Trait5::bar4`
+  --> $DIR/trait-to-trait.rs:340:27
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(&self) {}
+   |                           ^^^^^^^^^^^^^ required by this const generic parameter in `Trait5::bar4`
+...
+LL |         reuse Trait::foo::<'static, String, false> as bar4 { self.get_self() }
+   |                                                       ---- required by a bound in this associated function
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:442:56
+   |
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+   |                                                        ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_5::Trait::foo`
+  --> $DIR/trait-to-trait.rs:434:19
+   |
+LL |         fn foo<U, const M: bool>(&self) {}
+   |                   ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:447:56
+   |
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+   |                                                        ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_5::Trait::foo`
+  --> $DIR/trait-to-trait.rs:434:19
+   |
+LL |         fn foo<U, const M: bool>(&self) {}
+   |                   ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:457:56
+   |
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+   |                                                        ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_5::Trait::foo`
+  --> $DIR/trait-to-trait.rs:434:19
+   |
+LL |         fn foo<U, const M: bool>(&self) {}
+   |                   ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:462:56
+   |
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+   |                                                        ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_5::Trait::foo`
+  --> $DIR/trait-to-trait.rs:434:19
+   |
+LL |         fn foo<U, const M: bool>(&self) {}
+   |                   ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:472:56
+   |
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+   |                                                        ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_5::Trait::foo`
+  --> $DIR/trait-to-trait.rs:434:19
+   |
+LL |         fn foo<U, const M: bool>(&self) {}
+   |                   ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:477:56
+   |
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+   |                                                        ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_5::Trait::foo`
+  --> $DIR/trait-to-trait.rs:434:19
+   |
+LL |         fn foo<U, const M: bool>(&self) {}
+   |                   ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:487:56
+   |
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+   |                                                        ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_5::Trait::foo`
+  --> $DIR/trait-to-trait.rs:434:19
+   |
+LL |         fn foo<U, const M: bool>(&self) {}
+   |                   ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+
+error[E0284]: type annotations needed
+  --> $DIR/trait-to-trait.rs:492:56
+   |
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+   |                                                        ^^^ cannot infer the value of the const parameter `M` declared on the method `foo`
+   |
+note: required by a const generic parameter in `test_5::Trait::foo`
+  --> $DIR/trait-to-trait.rs:434:19
+   |
+LL |         fn foo<U, const M: bool>(&self) {}
+   |                   ^^^^^^^^^^^^^ required by this const generic parameter in `Trait::foo`
+
+error[E0107]: method takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/trait-to-trait.rs:505:68
+   |
+LL |         <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar1::<String, true>(&123);
+   |                                                                    ^^^^   ------  ---- supplied 2 generic arguments
+   |                                                                    |
+   |                                                                    expected 3 generic arguments
+   |
+note: method defined here, with 3 generic parameters: `T`, `U`, `M`
+  --> $DIR/trait-to-trait.rs:442:63
+   |
+LL |     trait Trait<'b, 'c, 'a, T>: Sized {
+   |                             -
+LL |         fn foo<U, const M: bool>(&self) {}
+   |                -  -------------
+...
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+   |                                                               ^^^^
+help: add missing generic argument
+   |
+LL |         <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar1::<String, true, M>(&123);
+   |                                                                                       +++
+
+error[E0107]: method takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/trait-to-trait.rs:507:26
+   |
+LL |         <u32 as Trait3>::bar1::<String, true>(&123);
+   |                          ^^^^   ------  ---- supplied 2 generic arguments
+   |                          |
+   |                          expected 3 generic arguments
+   |
+note: method defined here, with 3 generic parameters: `T`, `U`, `M`
+  --> $DIR/trait-to-trait.rs:457:63
+   |
+LL |     trait Trait<'b, 'c, 'a, T>: Sized {
+   |                             -
+LL |         fn foo<U, const M: bool>(&self) {}
+   |                -  -------------
+...
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+   |                                                               ^^^^
+help: add missing generic argument
+   |
+LL |         <u32 as Trait3>::bar1::<String, true, M>(&123);
+   |                                             +++
+
+error[E0107]: method takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/trait-to-trait.rs:509:43
+   |
+LL |         <u32 as Trait4<'a, 'a, 'static>>::bar1::<String, true>(&123);
+   |                                           ^^^^   ------  ---- supplied 2 generic arguments
+   |                                           |
+   |                                           expected 3 generic arguments
+   |
+note: method defined here, with 3 generic parameters: `T`, `U`, `M`
+  --> $DIR/trait-to-trait.rs:472:63
+   |
+LL |     trait Trait<'b, 'c, 'a, T>: Sized {
+   |                             -
+LL |         fn foo<U, const M: bool>(&self) {}
+   |                -  -------------
+...
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+   |                                                               ^^^^
+help: add missing generic argument
+   |
+LL |         <u32 as Trait4<'a, 'a, 'static>>::bar1::<String, true, M>(&123);
+   |                                                              +++
+
+error[E0107]: method takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/trait-to-trait.rs:511:44
+   |
+LL |         <u32 as Trait5<i32, u64, String>>::bar1::<String, true>(&123);
+   |                                            ^^^^   ------  ---- supplied 2 generic arguments
+   |                                            |
+   |                                            expected 3 generic arguments
+   |
+note: method defined here, with 3 generic parameters: `T`, `U`, `M`
+  --> $DIR/trait-to-trait.rs:487:63
+   |
+LL |     trait Trait<'b, 'c, 'a, T>: Sized {
+   |                             -
+LL |         fn foo<U, const M: bool>(&self) {}
+   |                -  -------------
+...
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar1 { Self::get() }
+   |                                                               ^^^^
+help: add missing generic argument
+   |
+LL |         <u32 as Trait5<i32, u64, String>>::bar1::<String, true, M>(&123);
+   |                                                               +++
+
+error[E0107]: method takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/trait-to-trait.rs:519:68
+   |
+LL |         <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar3::<String, true>(&123);
+   |                                                                    ^^^^   ------  ---- supplied 2 generic arguments
+   |                                                                    |
+   |                                                                    expected 3 generic arguments
+   |
+note: method defined here, with 3 generic parameters: `T`, `U`, `M`
+  --> $DIR/trait-to-trait.rs:447:63
+   |
+LL |     trait Trait<'b, 'c, 'a, T>: Sized {
+   |                             -
+LL |         fn foo<U, const M: bool>(&self) {}
+   |                -  -------------
+...
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+   |                                                               ^^^^
+help: add missing generic argument
+   |
+LL |         <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar3::<String, true, M>(&123);
+   |                                                                                       +++
+
+error[E0107]: method takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/trait-to-trait.rs:521:26
+   |
+LL |         <u32 as Trait3>::bar3::<String, true>(&123);
+   |                          ^^^^   ------  ---- supplied 2 generic arguments
+   |                          |
+   |                          expected 3 generic arguments
+   |
+note: method defined here, with 3 generic parameters: `T`, `U`, `M`
+  --> $DIR/trait-to-trait.rs:462:63
+   |
+LL |     trait Trait<'b, 'c, 'a, T>: Sized {
+   |                             -
+LL |         fn foo<U, const M: bool>(&self) {}
+   |                -  -------------
+...
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+   |                                                               ^^^^
+help: add missing generic argument
+   |
+LL |         <u32 as Trait3>::bar3::<String, true, M>(&123);
+   |                                             +++
+
+error[E0107]: method takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/trait-to-trait.rs:523:43
+   |
+LL |         <u32 as Trait4<'a, 'a, 'static>>::bar3::<String, true>(&123);
+   |                                           ^^^^   ------  ---- supplied 2 generic arguments
+   |                                           |
+   |                                           expected 3 generic arguments
+   |
+note: method defined here, with 3 generic parameters: `T`, `U`, `M`
+  --> $DIR/trait-to-trait.rs:477:63
+   |
+LL |     trait Trait<'b, 'c, 'a, T>: Sized {
+   |                             -
+LL |         fn foo<U, const M: bool>(&self) {}
+   |                -  -------------
+...
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+   |                                                               ^^^^
+help: add missing generic argument
+   |
+LL |         <u32 as Trait4<'a, 'a, 'static>>::bar3::<String, true, M>(&123);
+   |                                                              +++
+
+error[E0107]: method takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/trait-to-trait.rs:525:44
+   |
+LL |         <u32 as Trait5<i32, u64, String>>::bar3::<String, true>(&123);
+   |                                            ^^^^   ------  ---- supplied 2 generic arguments
+   |                                            |
+   |                                            expected 3 generic arguments
+   |
+note: method defined here, with 3 generic parameters: `T`, `U`, `M`
+  --> $DIR/trait-to-trait.rs:492:63
+   |
+LL |     trait Trait<'b, 'c, 'a, T>: Sized {
+   |                             -
+LL |         fn foo<U, const M: bool>(&self) {}
+   |                -  -------------
+...
+LL |         reuse Trait::<'static, 'static, 'static, i32>::foo as bar3 { self.get_self() }
+   |                                                               ^^^^
+help: add missing generic argument
+   |
+LL |         <u32 as Trait5<i32, u64, String>>::bar3::<String, true, M>(&123);
+   |                                                               +++
+
+error[E0282]: type annotations needed
+  --> $DIR/trait-to-trait.rs:581:9
+   |
+LL |         <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar1(&123);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the method `bar1`
+
+error[E0282]: type annotations needed
+  --> $DIR/trait-to-trait.rs:640:9
+   |
+LL |         <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>::bar1(&123);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the method `bar1`
+
+error[E0282]: type annotations needed
+  --> $DIR/trait-to-trait.rs:765:9
+   |
+LL | /         <u32 as Trait2<'static, 'static, 'static, i32, i32, i32>>
+LL | |
+LL | |             ::bar1::<'static, 'static>(&123);
+   | |______________________________________^ cannot infer type of the type parameter `T` declared on the method `bar1`
+
+error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/trait-to-trait.rs:853:22
+   |
+LL |             ::bar1::<'static, 'static>(&123);
+   |                      ^^^^^^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/trait-to-trait.rs:797:32
+   |
+LL |         fn foo<'a: 'a, 'b: 'b>(&self) {}
+   |                                ^
+
+error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/trait-to-trait.rs:855:33
+   |
+LL |         <u32 as Trait3>::bar1::<'static, 'static>(&123);
+   |                                 ^^^^^^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/trait-to-trait.rs:797:32
+   |
+LL |         fn foo<'a: 'a, 'b: 'b>(&self) {}
+   |                                ^
+
+error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/trait-to-trait.rs:857:50
+   |
+LL |         <u32 as Trait4<'a, 'a, 'static>>::bar1::<'a, 'a>(&123);
+   |                                                  ^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/trait-to-trait.rs:797:32
+   |
+LL |         fn foo<'a: 'a, 'b: 'b>(&self) {}
+   |                                ^
+
+error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/trait-to-trait.rs:859:51
+   |
+LL |         <u32 as Trait5<i32, u64, String>>::bar1::<'a, 'a>(&123);
+   |                                                   ^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/trait-to-trait.rs:797:32
+   |
+LL |         fn foo<'a: 'a, 'b: 'b>(&self) {}
+   |                                ^
+
+error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/trait-to-trait.rs:868:22
+   |
+LL |             ::bar3::<'static, 'static>(&123);
+   |                      ^^^^^^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/trait-to-trait.rs:797:32
+   |
+LL |         fn foo<'a: 'a, 'b: 'b>(&self) {}
+   |                                ^
+
+error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/trait-to-trait.rs:870:33
+   |
+LL |         <u32 as Trait3>::bar3::<'static, 'static>(&123);
+   |                                 ^^^^^^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/trait-to-trait.rs:797:32
+   |
+LL |         fn foo<'a: 'a, 'b: 'b>(&self) {}
+   |                                ^
+
+error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/trait-to-trait.rs:872:50
+   |
+LL |         <u32 as Trait4<'a, 'a, 'static>>::bar3::<'static, 'static>(&123);
+   |                                                  ^^^^^^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/trait-to-trait.rs:797:32
+   |
+LL |         fn foo<'a: 'a, 'b: 'b>(&self) {}
+   |                                ^
+
+error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/trait-to-trait.rs:874:51
+   |
+LL |         <u32 as Trait5<i32, u64, String>>::bar3::<'static, 'static>(&123);
+   |                                                   ^^^^^^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/trait-to-trait.rs:797:32
+   |
+LL |         fn foo<'a: 'a, 'b: 'b>(&self) {}
+   |                                ^
+
+error: aborting due to 99 previous errors
+
+Some errors have detailed explanations: E0107, E0282, E0284, E0794.
+For more information about an error, try `rustc --explain E0107`.


### PR DESCRIPTION
This PR adds tests from rust-lang/rust#151864 as discussed in this [comment](https://github.com/rust-lang/rust/pull/151864#issuecomment-3928053049). Part of rust-lang/rust#118212.

The majority of new tests are added in `mapping` folder, (`ast-hir-engine` folder in rust-lang/rust#151864), those tests test mapping between generic params of delegee and our generated function for delegation (that is why the name of the folder was changed, I think it better reflects what those tests testing). In each mapping test comments were added to each test case and one comment describing the goal of mapping tests was added at the top of each file.

Next, tests for defaults in generic params (`generic-params-defaults.rs`), params with the same name (`generic-params-same-names`), errors in providing user-specified generic args (`generics-gen-args-errors.rs`) and wrong signature of a generated function in impl trait case (`impl-trait-wrong-args-count.rs`, renamed from `wrong-args-count-ice.rs` in rust-lang/rust#151864). `generic-aux-pass.rs` test was not added, as all reuses in this test produce known ICE `DefId::expect_local DefId(..) isn't local` rust-lang/rust#143498 (which will be fixed in rust-lang/rust#151864, however it will not close mentioned issue, as synthetic generic params are not yet supported in new generics implementation).

r? @petrochenkov