### PR TITLE
sess: `-Zbranch-protection` is a target modifier

### DIFF
--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2240,7 +2240,7 @@ options! {
         (default: no)"),
     box_noalias: bool = (true, parse_bool, [TRACKED],
         "emit noalias metadata for box (default: yes)"),
-    branch_protection: Option<BranchProtection> = (None, parse_branch_protection, [TRACKED],
+    branch_protection: Option<BranchProtection> = (None, parse_branch_protection, [TRACKED TARGET_MODIFIER],
         "set options for branch target identification and pointer authentication on AArch64"),
     build_sdylib_interface: bool = (false, parse_bool, [UNTRACKED],
         "whether the stable interface is being built"),

--- a/tests/assembly-llvm/naked-functions/aarch64-naked-fn-no-bti-prolog.rs
+++ b/tests/assembly-llvm/naked-functions/aarch64-naked-fn-no-bti-prolog.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -C no-prepopulate-passes -Zbranch-protection=bti
+//@ compile-flags: -C no-prepopulate-passes -Zbranch-protection=bti -Cunsafe-allow-abi-mismatch=branch-protection
 //@ assembly-output: emit-asm
 //@ needs-asm-support
 //@ only-aarch64

--- a/tests/run-make/pointer-auth-link-with-c-lto-clang/rmake.rs
+++ b/tests/run-make/pointer-auth-link-with-c-lto-clang/rmake.rs
@@ -32,6 +32,7 @@ fn main() {
         .opt_level("2")
         .linker(&env_var("CLANG"))
         .link_arg("-fuse-ld=lld")
+        .arg("-Cunsafe-allow-abi-mismatch=branch-protection")
         .arg("-Zbranch-protection=bti,gcs,pac-ret,leaf")
         .input("test.rs")
         .output("test.bin")

--- a/tests/run-make/pointer-auth-link-with-c/rmake.rs
+++ b/tests/run-make/pointer-auth-link-with-c/rmake.rs
@@ -15,7 +15,11 @@ use run_make_support::{build_native_static_lib, cc, is_windows_msvc, llvm_ar, ru
 
 fn main() {
     build_native_static_lib("test");
-    rustc().arg("-Zbranch-protection=bti,gcs,pac-ret,leaf").input("test.rs").run();
+    rustc()
+        .arg("-Cunsafe-allow-abi-mismatch=branch-protection")
+        .arg("-Zbranch-protection=bti,gcs,pac-ret,leaf")
+        .input("test.rs")
+        .run();
     run("test");
     cc().arg("-v")
         .arg("-c")
@@ -25,7 +29,11 @@ fn main() {
         .run();
     let obj_file = if is_windows_msvc() { "test.obj" } else { "test" };
     llvm_ar().obj_to_ar().output_input("libtest.a", &obj_file).run();
-    rustc().arg("-Zbranch-protection=bti,gcs,pac-ret,leaf").input("test.rs").run();
+    rustc()
+        .arg("-Cunsafe-allow-abi-mismatch=branch-protection")
+        .arg("-Zbranch-protection=bti,gcs,pac-ret,leaf")
+        .input("test.rs")
+        .run();
     run("test");
 
     // FIXME: +pc was only recently added to LLVM
@@ -37,6 +45,10 @@ fn main() {
     //     .run();
     // let obj_file = if is_windows_msvc() { "test.obj" } else { "test" };
     // llvm_ar().obj_to_ar().output_input("libtest.a", &obj_file).run();
-    // rustc().arg("-Zbranch-protection=bti,pac-ret,pc,leaf").input("test.rs").run();
+    // rustc()
+    //     .arg("-Cunsafe-allow-abi-mismatch=branch-protection")
+    //     .arg("-Zbranch-protection=bti,pac-ret,pc,leaf")
+    //     .input("test.rs")
+    //     .run();
     // run("test");
 }


### PR DESCRIPTION
`-Zbranch-protection` only makes sense if the entire crate graph has the option set, otherwise the security properties that branch protection provides won't be effective - hence a target modifier. This flag is unstable so I don't think this warrants an MCP.