### PR TITLE
Expose Span for all DefIds in rustc_public

### DIFF
--- a/compiler/rustc_public/src/compiler_interface.rs
+++ b/compiler/rustc_public/src/compiler_interface.rs
@@ -562,12 +562,12 @@ impl<'tcx> CompilerInterface<'tcx> {
         cnst.internal(&mut *tables, cx.tcx).to_string()
     }
 
-    /// `Span` of an item.
-    pub(crate) fn span_of_an_item(&self, def_id: DefId) -> Span {
+    /// `Span` of a `DefId`.
+    pub(crate) fn span_of_a_def(&self, def_id: DefId) -> Span {
         let mut tables = self.tables.borrow_mut();
         let cx = &*self.cx.borrow();
         let did = tables[def_id];
-        cx.span_of_an_item(did).stable(&mut *tables, cx)
+        cx.span_of_a_def(did).stable(&mut *tables, cx)
     }
 
     pub(crate) fn ty_const_pretty(&self, ct: TyConstId) -> String {

--- a/compiler/rustc_public/src/crate_def.rs
+++ b/compiler/rustc_public/src/crate_def.rs
@@ -34,6 +34,10 @@ impl DefId {
     pub fn parent(&self) -> Option<DefId> {
         with(|cx| cx.def_parent(*self))
     }
+
+    pub fn span(&self) -> Span {
+        with(|cx| cx.span_of_a_def(*self))
+    }
 }
 
 /// A trait for retrieving information about a particular definition.
@@ -68,8 +72,7 @@ pub trait CrateDef {
 
     /// Return the span of this definition.
     fn span(&self) -> Span {
-        let def_id = self.def_id();
-        with(|cx| cx.span_of_an_item(def_id))
+        self.def_id().span()
     }
 
     /// Return registered tool attributes with the given attribute name.

--- a/compiler/rustc_public/src/lib.rs
+++ b/compiler/rustc_public/src/lib.rs
@@ -155,7 +155,7 @@ impl CrateItem {
     }
 
     pub fn span(&self) -> Span {
-        with(|cx| cx.span_of_an_item(self.0))
+        self.0.span()
     }
 
     pub fn kind(&self) -> ItemKind {

--- a/compiler/rustc_public/src/unstable/convert/stable/mod.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/mod.rs
@@ -82,6 +82,18 @@ impl<'tcx> Stable<'tcx> for rustc_span::Symbol {
     }
 }
 
+impl<'tcx> Stable<'tcx> for rustc_span::def_id::DefId {
+    type T = crate::DefId;
+
+    fn stable<'cx>(
+        &self,
+        tables: &mut Tables<'cx, BridgeTys>,
+        _: &CompilerCtxt<'cx, BridgeTys>,
+    ) -> Self::T {
+        tables.create_def_id(*self)
+    }
+}
+
 impl<'tcx> Stable<'tcx> for rustc_span::Span {
     type T = crate::ty::Span;
 

--- a/compiler/rustc_public_bridge/src/context/impls.rs
+++ b/compiler/rustc_public_bridge/src/context/impls.rs
@@ -554,8 +554,8 @@ impl<'tcx, B: Bridge> CompilerCtxt<'tcx, B> {
         )
     }
 
-    /// `Span` of an item.
-    pub fn span_of_an_item(&self, def_id: DefId) -> Span {
+    /// `Span` of a `DefId`.
+    pub fn span_of_a_def(&self, def_id: DefId) -> Span {
         self.tcx.def_span(def_id)
     }
 


### PR DESCRIPTION
Part of https://github.com/rust-lang/project-stable-mir/issues/118

To be maximally useful, `VariantDef` and `FieldDef` should be changed to be a wrapper around `DefId` instead of holding their parent and index. I can do this change in this PR or a follow-up if it is desired. For now, I added the missing `impl Stable for DefId` in internals so you can convert from rustc internals.