### PR TITLE
Error on attempt to construct scalable vector type

### DIFF
--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -99,6 +99,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             _ => { /* cannot have a non-rust abi */ }
         }
 
+        if self.is_scalable_vector_ctor(autoderef.final_ty()) {
+            let mut err = self.dcx().create_err(errors::ScalableVectorCtor {
+                span: callee_expr.span,
+                ty: autoderef.final_ty(),
+            });
+            err.span_label(callee_expr.span, "you can create scalable vectors using intrinsics");
+            Ty::new_error(self.tcx, err.emit());
+        }
+
         self.register_predicates(autoderef.into_obligations());
 
         let output = match result {
@@ -419,6 +428,19 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
 
         None
+    }
+
+    fn is_scalable_vector_ctor(&self, callee_ty: Ty<'_>) -> bool {
+        if let ty::FnDef(def_id, _) = callee_ty.kind()
+            && let def::DefKind::Ctor(def::CtorOf::Struct, _) = self.tcx.def_kind(def_id)
+        {
+            self.tcx
+                .opt_parent(*def_id)
+                .and_then(|id| self.tcx.adt_def(id).repr().scalable)
+                .is_some()
+        } else {
+            false
+        }
     }
 
     /// Give appropriate suggestion when encountering `||{/* not callable */}()`, where the

--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -570,6 +570,14 @@ pub(crate) struct InvalidCallee<'tcx> {
 }
 
 #[derive(Diagnostic)]
+#[diag("scalable vector types cannot be initialised using their constructor")]
+pub(crate) struct ScalableVectorCtor<'tcx> {
+    #[primary_span]
+    pub span: Span,
+    pub ty: Ty<'tcx>,
+}
+
+#[derive(Diagnostic)]
 #[diag("cannot cast `{$expr_ty}` to a pointer that {$known_wide ->
     [true] is
     *[false] may be

--- a/tests/ui/scalable-vectors/illegal_init.rs
+++ b/tests/ui/scalable-vectors/illegal_init.rs
@@ -1,0 +1,10 @@
+#![allow(incomplete_features, internal_features)]
+#![feature(rustc_attrs)]
+
+#[rustc_scalable_vector(4)]
+#[allow(non_camel_case_types)]
+struct svint32_t(i32);
+fn main() {
+    let foo = svint32_t(1);
+    //~^ ERROR: scalable vector types cannot be initialised using their constructor
+}

--- a/tests/ui/scalable-vectors/illegal_init.stderr
+++ b/tests/ui/scalable-vectors/illegal_init.stderr
@@ -1,0 +1,8 @@
+error: scalable vector types cannot be initialised using their constructor
+  --> $DIR/illegal_init.rs:8:15
+   |
+LL |     let foo = svint32_t(1);
+   |               ^^^^^^^^^ you can create scalable vectors using intrinsics
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
If you attempt to construct a scalable vector type rust will ICE. 

E.g.:
```rust
#[rustc_scalable_vector(4)]
#[allow(non_camel_case_types)]
struct svint32_t(i32);
fn main() {
    let foo = svint32_t(1);
    // This will ICE
}
```

This PR adds a check that will emit an error if you attempt to use a SV constructor and a test to ensure it works.