### PR TITLE
Remove rustc-dev un-remapping

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1772,17 +1772,6 @@ impl<'a> CrateMetadataRef<'a> {
                     &mut name,
                 );
 
-                // If this file is under $sysroot/lib/rustlib/rustc-src/
-                // and the user wish to simulate remapping with -Z simulate-remapped-rust-src-base,
-                // then we change `name` to a similar state as if the rust was bootstrapped
-                // with `remap-debuginfo = true`.
-                try_to_translate_real_to_virtual(
-                    option_env!("CFG_VIRTUAL_RUSTC_DEV_SOURCE_BASE_DIR"),
-                    &tcx.sess.opts.real_rustc_dev_source_base_dir,
-                    "compiler",
-                    &mut name,
-                );
-
                 // If this file's path has been remapped to `/rustc/$hash`,
                 // we might be able to reverse that.
                 //
@@ -1791,17 +1780,6 @@ impl<'a> CrateMetadataRef<'a> {
                 try_to_translate_virtual_to_real(
                     option_env!("CFG_VIRTUAL_RUST_SOURCE_BASE_DIR"),
                     &tcx.sess.opts.real_rust_source_base_dir,
-                    &mut name,
-                );
-
-                // If this file's path has been remapped to `/rustc-dev/$hash`,
-                // we might be able to reverse that.
-                //
-                // NOTE: if you update this, you might need to also update bootstrap's code for generating
-                // the `rustc-dev` component in `Src::run` in `src/bootstrap/dist.rs`.
-                try_to_translate_virtual_to_real(
-                    option_env!("CFG_VIRTUAL_RUSTC_DEV_SOURCE_BASE_DIR"),
-                    &tcx.sess.opts.real_rustc_dev_source_base_dir,
                     &mut name,
                 );
 

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -1029,10 +1029,9 @@ impl Builder<'_> {
         }
 
         // `rustc` needs to know the remapping scheme, in order to know how to reverse it (unremap)
-        // later. Two env vars are set and made available to the compiler
+        // later. The following env var is set and made available to the compiler:
         //
         // - `CFG_VIRTUAL_RUST_SOURCE_BASE_DIR`: `rust-src` remap scheme (`NonCompiler`)
-        // - `CFG_VIRTUAL_RUSTC_DEV_SOURCE_BASE_DIR`: `rustc-dev` remap scheme (`Compiler`)
         //
         // Keep this scheme in sync with `rustc_metadata::rmeta::decoder`'s
         // `try_to_translate_virtual_to_real`.
@@ -1051,9 +1050,6 @@ impl Builder<'_> {
                 if let Some(ref map_to) =
                     self.build.debuginfo_map_to(GitRepo::Rustc, RemapScheme::Compiler)
                 {
-                    // Tell the compiler which prefix was used for remapping the compiler it-self
-                    cargo.env("CFG_VIRTUAL_RUSTC_DEV_SOURCE_BASE_DIR", map_to);
-
                     // When building compiler sources, we want to apply the compiler remap scheme.
                     let map = [
                         // Cargo use relative paths for workspace members, so let's remap those.


### PR DESCRIPTION
During local development it doesn't matter, for end users it doesn't help as it doesn't affect the precompiled rustc executable and during development of custom drivers, most paths are kept remapped anyway due to rustc not getting recompiled. As such for the use cases where you want the original source paths, you either already have the original source paths or un-remapping doesn't have any effect.