### PR TITLE
Add build.rustdoc option to bootstrap config

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -302,6 +302,11 @@
 # If you set this, you likely want to set `cargo` as well.
 #build.rustc = "/path/to/rustc"
 
+# Use this rustdoc binary as the stage0 snapshot rustdoc.
+# If unspecified, then the binary "rustdoc" (with platform-specific extension, e.g. ".exe")
+# in the same directory as "rustc" will be used.
+#build.rustdoc = "/path/to/rustdoc"
+
 # Instead of downloading the src/stage0 version of rustfmt specified,
 # use this rustfmt binary instead as the stage0 snapshot rustfmt.
 #build.rustfmt = "/path/to/rustfmt"

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -298,6 +298,7 @@ pub struct Config {
     // These are either the stage0 downloaded binaries or the locally installed ones.
     pub initial_cargo: PathBuf,
     pub initial_rustc: PathBuf,
+    pub initial_rustdoc: PathBuf,
     pub initial_cargo_clippy: Option<PathBuf>,
     pub initial_sysroot: PathBuf,
     pub initial_rustfmt: Option<PathBuf>,
@@ -456,6 +457,7 @@ impl Config {
             build_dir: build_build_dir,
             cargo: mut build_cargo,
             rustc: mut build_rustc,
+            rustdoc: build_rustdoc,
             rustfmt: build_rustfmt,
             cargo_clippy: build_cargo_clippy,
             docs: build_docs,
@@ -750,6 +752,9 @@ impl Config {
             download_beta_toolchain(&dwn_ctx, &out);
             default_stage0_rustc_path(&out)
         });
+
+        let initial_rustdoc = build_rustdoc
+            .unwrap_or_else(|| initial_rustc.with_file_name(exe("rustdoc", host_target)));
 
         let initial_sysroot = t!(PathBuf::from_str(
             command(&initial_rustc)
@@ -1348,6 +1353,7 @@ impl Config {
             initial_cargo,
             initial_cargo_clippy: build_cargo_clippy,
             initial_rustc,
+            initial_rustdoc,
             initial_rustfmt,
             initial_sysroot,
             jemalloc: rust_jemalloc.unwrap_or(false),

--- a/src/bootstrap/src/core/config/toml/build.rs
+++ b/src/bootstrap/src/core/config/toml/build.rs
@@ -25,6 +25,7 @@ define_config! {
         build_dir: Option<String> = "build-dir",
         cargo: Option<PathBuf> = "cargo",
         rustc: Option<PathBuf> = "rustc",
+        rustdoc: Option<PathBuf> = "rustdoc",
         rustfmt: Option<PathBuf> = "rustfmt",
         cargo_clippy: Option<PathBuf> = "cargo-clippy",
         docs: Option<bool> = "docs",

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -535,9 +535,7 @@ impl Build {
             initial_lld,
             initial_relative_libdir,
             initial_rustc: config.initial_rustc.clone(),
-            initial_rustdoc: config
-                .initial_rustc
-                .with_file_name(exe("rustdoc", config.host_target)),
+            initial_rustdoc: config.initial_rustdoc.clone(),
             initial_cargo: config.initial_cargo.clone(),
             initial_sysroot: config.initial_sysroot.clone(),
             local_rebuild: config.local_rebuild,


### PR DESCRIPTION
This adds a bootstrap config option `build.rustdoc` to be able to override the stage0 `rustdoc` binary. When unspecified, this defaults to the existing behavior of using the `rustdoc` binary in the same directory as `rustc`, making this a backward-compatible change.

### Motivation

The existing behavior does not seem to be documented and can be surprising. By adding the new option, the behavior gets documented in `bootstrap.example.toml`.

I ran into this because I was experimenting with a build with a configuration like this:
```
build.rustc = "/usr/bin/rustc-1.92"
build.cargo = "/usr/bin/cargo-1.92"
```
This was on Ubuntu where the packages `rustc-1.92` and `cargo-1.92` place symlinks at these locations. This resulted in failure as the bootstrap process tried to run doc tests on `tidy` using a binary `/usr/bin/rustdoc` which did not exist. It took some digging to understand where that path `/usr/bin/rustdoc` was coming from.

@rustbot label +A-bootstrap-config