### PR TITLE
Improve runtest revision redundant cfg check

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -504,6 +504,7 @@ impl<'test> TestCx<'test> {
             let normalized_revision = normalize_revision(revision);
             let cfg_arg = ["--cfg", &normalized_revision];
             let arg = format!("--cfg={normalized_revision}");
+            // Handle if compile_flags is length 1
             let contains_arg =
                 self.props.compile_flags.iter().any(|considered_arg| *considered_arg == arg);
             let contains_cfg_arg = self.props.compile_flags.windows(2).any(|args| args == cfg_arg);

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -504,12 +504,10 @@ impl<'test> TestCx<'test> {
             let normalized_revision = normalize_revision(revision);
             let cfg_arg = ["--cfg", &normalized_revision];
             let arg = format!("--cfg={normalized_revision}");
-            if self
-                .props
-                .compile_flags
-                .windows(2)
-                .any(|args| args == cfg_arg || args[0] == arg || args[1] == arg)
-            {
+            let contains_arg =
+                self.props.compile_flags.iter().any(|considered_arg| *considered_arg == arg);
+            let contains_cfg_arg = self.props.compile_flags.windows(2).any(|args| args == cfg_arg);
+            if contains_arg || contains_cfg_arg {
                 error!(
                     "redundant cfg argument `{normalized_revision}` is already created by the \
                     revision"

--- a/tests/mir-opt/pre-codegen/copy_and_clone.rs
+++ b/tests/mir-opt/pre-codegen/copy_and_clone.rs
@@ -1,4 +1,3 @@
-//@ [COPY] compile-flags: --cfg=copy
 //@ revisions: COPY CLONE
 
 // Test case from https://github.com/rust-lang/rust/issues/128081.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
While attempting to ingest https://github.com/rust-lang/rust/pull/148034 via https://github.com/ferrocene/ferrocene/pull/2172 we noticed a test failure, as we add some `compile_flags` to tests. 

We saw a failure looking like this:

```
Testing stage1 with compiletest suite=mir-opt mode=mir-opt (x86_64-unknown-linux-gnu)

running 2 tests
2026-02-20T20:21:28.846102Z ERROR compiletest::runtest: redundant cfg argument `copy` is already created by the revision

[mir-opt] tests/mir-opt/pre-codegen/copy_and_clone.rs#COPY ... F
.
```

While my Rust checkout passed:


```
Testing stage1 with compiletest suite=mir-opt mode=mir-opt (x86_64-unknown-linux-gnu)

running 2 tests
..

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 381 filtered out; finished in 107.10ms
```

This caused me to add some debugging statements.

Ferrocene:

```
2026-02-20T21:05:39.808427Z ERROR compiletest::runtest: "copy": does ["--edition=2015", "--cfg=copy"] contain `"--cfg=copy"` or `["--cfg", "copy"]`? true
2026-02-20T21:05:39.808427Z ERROR compiletest::runtest: "clone": does ["--edition=2015"] contain `"--cfg=clone"` or `["--cfg", "clone"]`? false
2026-02-20T21:05:39.808435Z ERROR compiletest::runtest: redundant cfg argument `copy` is already created by the revision
```

Rust:

```
2026-02-20T21:04:18.493158Z ERROR compiletest::runtest: "copy": does ["--cfg=copy"] contain `"--cfg=copy"` or `["--cfg", "copy"]`? false
2026-02-20T21:04:18.493158Z ERROR compiletest::runtest: "clone": does [] contain `"--cfg=clone"` or `["--cfg", "clone"]`? false
```

I noticed while reviewing the related functionality that there is a call to `.windows(2)` in the relevant check for redundant cfgs:

https://github.com/rust-lang/rust/blob/0376d43d443cba463a0b6a6ec9140ea17d7b7130/src/tools/compiletest/src/runtest.rs#L507-L511

Noting:

https://github.com/rust-lang/rust/blob/0376d43d443cba463a0b6a6ec9140ea17d7b7130/library/core/src/slice/mod.rs#L1064-L1066

Because of this, the revision check was getting an empty iterator when `self.props.compile_flags` was length 0 or 1.

This fix adjusts the check to handle such cases.

I went ahead and fixed the relevant test (4b3cd9b289ce0a36bda2756321f5fe455ea301e1) that was impacted by this. I do not suspect there are others, at least within the scope that Ferrocene tests, as we have not previously seen this failure.