### PR TITLE
Tighten the `!range` bounds on alignments in vtables

### DIFF
--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -1036,6 +1036,19 @@ impl Align {
     // LLVM has a maximal supported alignment of 2^29, we inherit that.
     pub const MAX: Align = Align { pow2: 29 };
 
+    /// Either `1 << (pointer_bits - 1)` or [`Align::MAX`], whichever is smaller.
+    #[inline]
+    pub fn max_for_target(tdl: &TargetDataLayout) -> Align {
+        let pointer_bits = tdl.pointer_size().bits();
+        if let Ok(pointer_bits) = u8::try_from(pointer_bits)
+            && pointer_bits <= Align::MAX.pow2
+        {
+            Align { pow2: pointer_bits - 1 }
+        } else {
+            Align::MAX
+        }
+    }
+
     #[inline]
     pub fn from_bits(bits: u64) -> Result<Align, AlignFromBytesError> {
         Align::from_bytes(Size::from_bits(bits).bytes())

--- a/tests/codegen-llvm/dst-vtable-align-nonzero.rs
+++ b/tests/codegen-llvm/dst-vtable-align-nonzero.rs
@@ -64,4 +64,4 @@ pub unsafe fn align_load_from_vtable_align_intrinsic(x: &dyn Trait) -> usize {
     core::intrinsics::vtable_align(vtable)
 }
 
-// CHECK: [[RANGE_META]] = !{[[USIZE]] 1, [[USIZE]] 0}
+// CHECK: [[RANGE_META]] = !{[[USIZE]] 1, [[USIZE]] [[#0x20000001]]


### PR DESCRIPTION
Right now we're only telling LLVM that they're non-zero, but alignments must be powers of two so can't be more than `isize::MAX+1`.  And we actually never emit anything beyond LLVM's limit of 2²⁹, so outside of 16-bit targets the limit is that.

(Pulled out from rust-lang/rust#152867 which is starting to have too much in it.)