### PR TITLE
Stop needing `alloca`s for consuming `noundef` enums

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/analyze.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/analyze.rs
@@ -72,6 +72,8 @@ struct LocalAnalyzer<'a, 'b, 'tcx, Bx: BuilderMethods<'b, 'tcx>> {
     locals: IndexVec<mir::Local, LocalKind>,
 }
 
+const COPY_CONTEXT: PlaceContext = PlaceContext::NonMutatingUse(NonMutatingUseContext::Copy);
+
 impl<'a, 'b, 'tcx, Bx: BuilderMethods<'b, 'tcx>> LocalAnalyzer<'a, 'b, 'tcx, Bx> {
     fn define(&mut self, local: mir::Local, location: DefLocation) {
         let fx = self.fx;
@@ -94,6 +96,33 @@ impl<'a, 'b, 'tcx, Bx: BuilderMethods<'b, 'tcx>> LocalAnalyzer<'a, 'b, 'tcx, Bx>
         }
     }
 
+    /// Usually the interesting part of places it the underlying local, but it's
+    /// also possible for the [`mir::PlaceElem`]s to mention them. So this visits
+    /// those locals to ensure any non-dominating definitions are handled.
+    fn process_locals_in_projections(
+        &mut self,
+        projections: &[mir::PlaceElem<'tcx>],
+        location: Location,
+    ) {
+        use mir::ProjectionElem::*;
+        for projection in projections {
+            match *projection {
+                // This is currently the only one with a `Local`.
+                Index(local) => self.visit_local(local, COPY_CONTEXT, location),
+
+                // Even the ones here that do indexing or slicing only take
+                // constants, not locals.
+                Deref
+                | Field(..)
+                | ConstantIndex { .. }
+                | Subslice { .. }
+                | Downcast(..)
+                | OpaqueCast(..)
+                | UnwrapUnsafeBinder(..) => {}
+            }
+        }
+    }
+
     fn process_place(
         &mut self,
         place_ref: &mir::PlaceRef<'tcx>,
@@ -101,16 +130,7 @@ impl<'a, 'b, 'tcx, Bx: BuilderMethods<'b, 'tcx>> LocalAnalyzer<'a, 'b, 'tcx, Bx>
         location: Location,
     ) {
         if !place_ref.projection.is_empty() {
-            const COPY_CONTEXT: PlaceContext =
-                PlaceContext::NonMutatingUse(NonMutatingUseContext::Copy);
-
-            // `PlaceElem::Index` is the only variant that can mention other `Local`s,
-            // so check for those up-front before any potential short-circuits.
-            for elem in place_ref.projection {
-                if let mir::PlaceElem::Index(index_local) = *elem {
-                    self.visit_local(index_local, COPY_CONTEXT, location);
-                }
-            }
+            self.process_locals_in_projections(place_ref.projection, location);
 
             // If our local is already memory, nothing can make it *more* memory
             // so we don't need to bother checking the projections further.
@@ -184,6 +204,64 @@ impl<'a, 'b, 'tcx, Bx: BuilderMethods<'b, 'tcx>> Visitor<'tcx> for LocalAnalyzer
         }
 
         self.visit_rvalue(rvalue, location);
+    }
+
+    fn visit_rvalue(&mut self, rvalue: &mir::Rvalue<'tcx>, location: Location) {
+        fn repr_has_fully_init_scalar_fields(repr: &abi::BackendRepr) -> bool {
+            match repr {
+                abi::BackendRepr::Scalar(scalar) => !matches!(scalar, abi::Scalar::Union { .. }),
+                abi::BackendRepr::ScalarPair(scalar1, scalar2) => {
+                    !matches!(scalar1, abi::Scalar::Union { .. })
+                        && !matches!(scalar2, abi::Scalar::Union { .. })
+                }
+                abi::BackendRepr::Memory { .. }
+                | abi::BackendRepr::SimdVector { .. }
+                | abi::BackendRepr::ScalableVector { .. } => false,
+            }
+        }
+
+        // The general place code needs to worry about more-complex contexts
+        // like inside dereferences. For the common case of copy/move, though,
+        // we often don't even need to look at the projections.
+        if let mir::Rvalue::Use(operand) = rvalue
+            && let Some(place) = operand.place()
+        {
+            if let LocalKind::ZST | LocalKind::Memory = self.locals[place.local] {
+                // If the local already knows it's not SSA, there's no point in looking
+                // at it further, other than to make sure indexing is tracked.
+                return self.process_locals_in_projections(place.projection, location);
+            }
+
+            if place.projection.is_empty() {
+                // No projections? Trivially fine.
+                return self.visit_local(place.local, COPY_CONTEXT, location);
+            }
+
+            if place.is_indirect_first_projection() {
+                // We're reading through a pointer, so any projections end up just being
+                // pointer math, none of which needs to force the pointer to memory.
+                self.process_locals_in_projections(place.projection, location);
+                return self.visit_local(place.local, COPY_CONTEXT, location);
+            }
+
+            let local_ty = self.fx.monomorphized_place_ty(mir::PlaceRef::from(place.local));
+            let local_layout = self.fx.cx.layout_of(local_ty);
+
+            if repr_has_fully_init_scalar_fields(&local_layout.backend_repr) {
+                // For Scalar/ScalarPair, we can handle *every* possible projection.
+                // We could potentially handle union too, but today we don't since as currently
+                // implemented that would lose `noundef` information on things like the payload
+                // of an `Option<u32>`, which can be important for LLVM to optimize it.
+                debug_assert!(
+                    // `Index` would be the only reason we'd need to look at the projections,
+                    // but layout never makes anything indexable Scalar or ScalarPair.
+                    place.projection.iter().all(|p| !matches!(p, mir::PlaceElem::Index(..)))
+                );
+                return self.visit_local(place.local, COPY_CONTEXT, location);
+            }
+        }
+
+        self.super_rvalue(rvalue, location)
     }
 
     fn visit_place(&mut self, place: &mir::Place<'tcx>, context: PlaceContext, location: Location) {

--- a/compiler/rustc_codegen_ssa/src/mir/analyze.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/analyze.rs
@@ -7,7 +7,7 @@ use rustc_index::bit_set::DenseBitSet;
 use rustc_index::{IndexSlice, IndexVec};
 use rustc_middle::mir::visit::{MutatingUseContext, NonMutatingUseContext, PlaceContext, Visitor};
 use rustc_middle::mir::{self, DefLocation, Location, TerminatorKind, traversal};
-use rustc_middle::ty::layout::LayoutOf;
+use rustc_middle::ty::layout::{LayoutOf, TyAndLayout};
 use rustc_middle::{bug, span_bug};
 use tracing::debug;
 
@@ -26,7 +26,10 @@ pub(crate) fn non_ssa_locals<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
         .map(|decl| {
             let ty = fx.monomorphize(decl.ty);
             let layout = fx.cx.spanned_layout_of(ty, decl.source_info.span);
-            if layout.is_zst() { LocalKind::ZST } else { LocalKind::Unused }
+            KindAndLayout {
+                kind: if layout.is_zst() { LocalKind::ZST } else { LocalKind::Unused },
+                layout,
+            }
         })
         .collect();
 
@@ -46,8 +49,8 @@ pub(crate) fn non_ssa_locals<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
     }
 
     let mut non_ssa_locals = DenseBitSet::new_empty(analyzer.locals.len());
-    for (local, kind) in analyzer.locals.iter_enumerated() {
-        if matches!(kind, LocalKind::Memory) {
+    for (local, info) in analyzer.locals.iter_enumerated() {
+        if matches!(info.kind, LocalKind::Memory) {
             non_ssa_locals.insert(local);
         }
     }
@@ -66,10 +69,16 @@ enum LocalKind {
     SSA(DefLocation),
 }
 
+#[derive(Copy, Clone, PartialEq, Eq)]
+struct KindAndLayout<'tcx> {
+    kind: LocalKind,
+    layout: TyAndLayout<'tcx>,
+}
+
 struct LocalAnalyzer<'a, 'b, 'tcx, Bx: BuilderMethods<'b, 'tcx>> {
     fx: &'a FunctionCx<'b, 'tcx, Bx>,
     dominators: &'a Dominators<mir::BasicBlock>,
-    locals: IndexVec<mir::Local, LocalKind>,
+    locals: IndexVec<mir::Local, KindAndLayout<'tcx>>,
 }
 
 const COPY_CONTEXT: PlaceContext = PlaceContext::NonMutatingUse(NonMutatingUseContext::Copy);
@@ -77,22 +86,20 @@ const COPY_CONTEXT: PlaceContext = PlaceContext::NonMutatingUse(NonMutatingUseCo
 impl<'a, 'b, 'tcx, Bx: BuilderMethods<'b, 'tcx>> LocalAnalyzer<'a, 'b, 'tcx, Bx> {
     fn define(&mut self, local: mir::Local, location: DefLocation) {
         let fx = self.fx;
-        let kind = &mut self.locals[local];
-        let decl = &fx.mir.local_decls[local];
-        match *kind {
+        let info = &mut self.locals[local];
+        match info.kind {
             LocalKind::ZST => {}
             LocalKind::Memory => {}
             LocalKind::Unused => {
-                let ty = fx.monomorphize(decl.ty);
-                let layout = fx.cx.spanned_layout_of(ty, decl.source_info.span);
-                *kind =
+                let layout = info.layout;
+                info.kind =
                     if fx.cx.is_backend_immediate(layout) || fx.cx.is_backend_scalar_pair(layout) {
                         LocalKind::SSA(location)
                     } else {
                         LocalKind::Memory
                     };
             }
-            LocalKind::SSA(_) => *kind = LocalKind::Memory,
+            LocalKind::SSA(_) => info.kind = LocalKind::Memory,
         }
     }
 
@@ -134,7 +141,7 @@ impl<'a, 'b, 'tcx, Bx: BuilderMethods<'b, 'tcx>> LocalAnalyzer<'a, 'b, 'tcx, Bx>
 
             // If our local is already memory, nothing can make it *more* memory
             // so we don't need to bother checking the projections further.
-            if self.locals[place_ref.local] == LocalKind::Memory {
+            if self.locals[place_ref.local].kind == LocalKind::Memory {
                 return;
             }
 
@@ -158,8 +165,7 @@ impl<'a, 'b, 'tcx, Bx: BuilderMethods<'b, 'tcx>> LocalAnalyzer<'a, 'b, 'tcx, Bx>
 
             // Scan through to ensure the only projections are those which
             // `FunctionCx::maybe_codegen_consume_direct` can handle.
-            let base_ty = self.fx.monomorphized_place_ty(mir::PlaceRef::from(place_ref.local));
-            let mut layout = self.fx.cx.layout_of(base_ty);
+            let mut layout = self.locals[place_ref.local].layout;
             for elem in place_ref.projection {
                 layout = match *elem {
                     mir::PlaceElem::Field(fidx, ..) => layout.field(self.fx.cx, fidx.as_usize()),
@@ -171,7 +177,7 @@ impl<'a, 'b, 'tcx, Bx: BuilderMethods<'b, 'tcx>> LocalAnalyzer<'a, 'b, 'tcx, Bx>
                         layout.for_variant(self.fx.cx, vidx)
                     }
                     _ => {
-                        self.locals[place_ref.local] = LocalKind::Memory;
+                        self.locals[place_ref.local].kind = LocalKind::Memory;
                         return;
                     }
                 }
@@ -226,7 +232,7 @@ impl<'a, 'b, 'tcx, Bx: BuilderMethods<'b, 'tcx>> Visitor<'tcx> for LocalAnalyzer
         if let mir::Rvalue::Use(operand) = rvalue
             && let Some(place) = operand.place()
         {
-            if let LocalKind::ZST | LocalKind::Memory = self.locals[place.local] {
+            if let LocalKind::ZST | LocalKind::Memory = self.locals[place.local].kind {
                 // If the local already knows it's not SSA, there's no point in looking
                 // at it further, other than to make sure indexing is tracked.
                 return self.process_locals_in_projections(place.projection, location);
@@ -244,9 +250,7 @@ impl<'a, 'b, 'tcx, Bx: BuilderMethods<'b, 'tcx>> Visitor<'tcx> for LocalAnalyzer
                 return self.visit_local(place.local, COPY_CONTEXT, location);
             }
 
-            let local_ty = self.fx.monomorphized_place_ty(mir::PlaceRef::from(place.local));
-            let local_layout = self.fx.cx.layout_of(local_ty);
-
+            let local_layout = self.locals[place.local].layout;
             if repr_has_fully_init_scalar_fields(&local_layout.backend_repr) {
                 // For Scalar/ScalarPair, we can handle *every* possible projection.
                 // We could potentially handle union too, but today we don't since as currently
@@ -292,7 +296,7 @@ impl<'a, 'b, 'tcx, Bx: BuilderMethods<'b, 'tcx>> Visitor<'tcx> for LocalAnalyzer
                 // which we can treat similar to `Copy` use for the purpose of
                 // whether we can use SSA variables for things.
                 | NonMutatingUseContext::Inspect,
-            ) => match &mut self.locals[local] {
+            ) => match &mut self.locals[local].kind {
                 LocalKind::ZST => {}
                 LocalKind::Memory => {}
                 LocalKind::SSA(def) if def.dominates(location, self.dominators) => {}
@@ -319,17 +323,16 @@ impl<'a, 'b, 'tcx, Bx: BuilderMethods<'b, 'tcx>> Visitor<'tcx> for LocalAnalyzer
                 | NonMutatingUseContext::RawBorrow
                 | NonMutatingUseContext::Projection,
             ) => {
-                self.locals[local] = LocalKind::Memory;
+                self.locals[local].kind = LocalKind::Memory;
             }
 
             PlaceContext::MutatingUse(MutatingUseContext::Drop) => {
-                let kind = &mut self.locals[local];
-                if *kind != LocalKind::Memory {
-                    let ty = self.fx.mir.local_decls[local].ty;
-                    let ty = self.fx.monomorphize(ty);
+                let info = &mut self.locals[local];
+                if info.kind != LocalKind::Memory {
+                    let ty = info.layout.ty;
                     if self.fx.cx.type_needs_drop(ty) {
                         // Only need the place if we're actually dropping it.
-                        *kind = LocalKind::Memory;
+                        info.kind = LocalKind::Memory;
                     }
                 }
             }

--- a/compiler/rustc_codegen_ssa/src/mir/operand.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/operand.rs
@@ -350,8 +350,34 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
         bx: &mut Bx,
         i: usize,
     ) -> Self {
-        let field = self.layout.field(bx.cx(), i);
-        let offset = self.layout.fields.offset(i);
+        self.extract_field_inner(fx, bx, None, i)
+    }
+
+    fn extract_variant_field<Bx: BuilderMethods<'a, 'tcx, Value = V>>(
+        &self,
+        fx: &mut FunctionCx<'a, 'tcx, Bx>,
+        bx: &mut Bx,
+        variant_idx: Option<VariantIdx>,
+        field_idx: FieldIdx,
+    ) -> Self {
+        self.extract_field_inner(fx, bx, variant_idx, field_idx.as_usize())
+    }
+
+    fn extract_field_inner<Bx: BuilderMethods<'a, 'tcx, Value = V>>(
+        &self,
+        fx: &mut FunctionCx<'a, 'tcx, Bx>,
+        bx: &mut Bx,
+        variant_idx: Option<VariantIdx>,
+        i: usize,
+    ) -> Self {
+        let layout = if let Some(variant_idx) = variant_idx {
+            self.layout.for_variant(bx.cx(), variant_idx)
+        } else {
+            self.layout
+        };
+
+        let field = layout.field(bx.cx(), i);
+        let offset = layout.fields.offset(i);
 
         if !bx.is_backend_ref(self.layout) && bx.is_backend_ref(field) {
             // Part of https://github.com/rust-lang/compiler-team/issues/838
@@ -394,7 +420,12 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
                             self
                         )
                     };
-                    if in_scalar != out_scalar {
+                    if variant_idx.is_some() {
+                        // If there was a downcast involved, we need to worry about
+                        // more than just `i1` since `Result<usize, *const()>` needs
+                        // to correct for the `usize` being stored in a pointer.
+                        transmute_scalar(bx, imm, in_scalar, out_scalar)
+                    } else if in_scalar != out_scalar {
                         // If the backend and backend_immediate types might differ,
                         // flip back to the backend type then to the new immediate.
                         // This avoids nop truncations, but still handles things like
@@ -975,23 +1006,46 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             LocalRef::Operand(mut o) => {
                 // We only need to handle the projections that
                 // `LocalAnalyzer::process_place` let make it here.
+
+                // Track whether the previous projection was a non-trivial downcast,
+                let mut downcast_variant = None;
                 for elem in place_ref.projection {
                     match *elem {
-                        mir::ProjectionElem::Field(f, _) => {
+                        mir::ProjectionElem::Field(fidx, field_ty) => {
                             assert!(
                                 !o.layout.ty.is_any_ptr(),
                                 "Bad PlaceRef: destructing pointers should use cast/PtrMetadata, \
-                                 but tried to access field {f:?} of pointer {o:?}",
+                                 but tried to access field {fidx:?} of pointer {o:?}",
                             );
-                            o = o.extract_field(self, bx, f.index());
+                            let vidx = downcast_variant.take();
+                            o = o.extract_variant_field(self, bx, vidx, fidx);
+                            debug_assert!(
+                                {
+                                    let field_ty = self.monomorphize(field_ty);
+                                    let field_layout = bx.cx().layout_of(field_ty);
+                                    field_ty == o.layout.ty && field_layout == o.layout
+                                },
+                                "Mismatch with field type {field_ty:?}",
+                            );
                         }
                         mir::PlaceElem::Downcast(_, vidx) => {
-                            debug_assert_eq!(
-                                o.layout.variants,
-                                abi::Variants::Single { index: vidx },
-                            );
-                            let layout = o.layout.for_variant(bx.cx(), vidx);
-                            o = OperandRef { layout, ..o }
+                            if let abi::Variants::Single { index } = o.layout.variants {
+                                // When the downcast is just to the only only possible variant,
+                                // we can treat it the same as a struct (which doesn't get a
+                                // downcast projection) to avoid extra work in the field later.
+                                debug_assert_eq!(index, vidx);
+                                let layout = o.layout.for_variant(bx.cx(), vidx);
+                                o = OperandRef { layout, ..o }
+                            } else {
+                                // For a non-trivial downcast, we just record it to handle later.
+                                //
+                                // It's tempting to try to just transmute to the variant layout,
+                                // but that turns out not to work because while it does handle the
+                                // `i8`-vs-`i1` cases in `Option<bool>`, it doesn't handle the
+                                // `ptr`-vs-`i64` cases in `Result<usize, *const _>`. Delaying it
+                                // means `extract_variant_field` deals with both complications.
+                                downcast_variant = Some(vidx);
+                            };
                         }
                         _ => return None,
                     }

--- a/tests/codegen-llvm/array-cmp.rs
+++ b/tests/codegen-llvm/array-cmp.rs
@@ -67,7 +67,7 @@ pub fn array_of_tuple_le(a: &[(i16, u16); 2], b: &[(i16, u16); 2]) -> bool {
     // CHECK-NEXT: br i1 %[[EQ11]], label %[[DONE:.+]], label %[[EXIT_U]]
 
     // CHECK: [[DONE]]:
-    // CHECK: %[[RET:.+]] = phi i1 [ %{{.+}}, %[[EXIT_S]] ], [ %{{.+}}, %[[EXIT_U]] ], [ true, %[[L11]] ]
+    // CHECK: %[[RET:.+]] = phi i1 [ true, %[[L11]] ], [ %{{.+}}, %[[EXIT_S]] ], [ %{{.+}}, %[[EXIT_U]] ]
     // CHECK: ret i1 %[[RET]]
 
     a <= b

--- a/tests/codegen-llvm/common_prim_int_ptr.rs
+++ b/tests/codegen-llvm/common_prim_int_ptr.rs
@@ -40,7 +40,7 @@ pub unsafe fn extract_int(x: Result<usize, Box<()>>) -> usize {
 }
 
 // CHECK-LABEL: @extract_box
-// CHECK-SAME: (i{{[0-9]+}} {{[^%]+}} [[DISCRIMINANT:%[0-9]+]], ptr {{[^%]+}} [[PAYLOAD:%[0-9]+]])
+// CHECK-SAME: (i{{[0-9]+}} {{[^%]+}} [[DISCRIMINANT:%x\.0]], ptr {{[^%]+}} [[PAYLOAD:%x\.1]])
 #[no_mangle]
 pub unsafe fn extract_box(x: Result<usize, Box<i32>>) -> Box<i32> {
     // CHECK: ret ptr [[PAYLOAD]]

--- a/tests/codegen-llvm/enum-extract.rs
+++ b/tests/codegen-llvm/enum-extract.rs
@@ -1,0 +1,163 @@
+//@ revisions: OPT DBG
+//@ compile-flags: -Cno-prepopulate-passes -Cdebuginfo=0
+//@[OPT] compile-flags: -Copt-level=1
+//@[DBG] compile-flags: -Copt-level=0
+//@ only-64bit
+
+#![crate_type = "lib"]
+
+// This tests various cases around consuming enums as SSA values in what we emit.
+// Importantly, it checks things like correct `i1` handling for `bool`
+// and for mixed integer/pointer payloads.
+
+use std::cmp::Ordering;
+use std::num::NonZero;
+use std::ptr::NonNull;
+
+#[no_mangle]
+fn use_option_bool(x: Option<bool>) -> bool {
+    // CHECK-LABEL: @use_option_bool
+    // OPT-SAME: (i8 noundef range(i8 0, 3) %x)
+
+    // CHECK-NOT: alloca
+    // CHECK: %[[IS_NONE:.+]] = icmp eq i8 %x, 2
+    // CHECK: %[[DISCR:.+]] = select i1 %[[IS_NONE]], i64 0, i64 1
+    // CHECK: %[[IS_SOME:.+]] = trunc nuw i64 %[[DISCR]] to i1
+    // OPT: %[[LIKELY:.+]] = call i1 @llvm.expect.i1(i1 %[[IS_SOME]], i1 true)
+    // OPT: br i1 %[[LIKELY]], label %[[BLOCK:.+]],
+    // DBG: br i1 %[[IS_SOME]], label %[[BLOCK:.+]],
+
+    // CHECK: [[BLOCK]]:
+    // CHECK: %val = trunc nuw i8 %x to i1
+    // CHECK: ret i1 %val
+
+    if let Some(val) = x { val } else { unreachable!() }
+}
+
+#[no_mangle]
+fn use_option_ordering(x: Option<Ordering>) -> Ordering {
+    // CHECK-LABEL: @use_option_ordering
+    // OPT-SAME: (i8 noundef range(i8 -1, 3) %x)
+
+    // CHECK: %[[IS_NONE:.+]] = icmp eq i8 %x, 2
+    // CHECK: %[[DISCR:.+]] = select i1 %[[IS_NONE]], i64 0, i64 1
+    // CHECK: %[[IS_SOME:.+]] = trunc nuw i64 %[[DISCR]] to i1
+    // OPT: %[[LIKELY:.+]] = call i1 @llvm.expect.i1(i1 %[[IS_SOME]], i1 true)
+    // OPT: br i1 %[[LIKELY]], label %[[BLOCK:.+]],
+    // DBG: br i1 %[[IS_SOME]], label %[[BLOCK:.+]],
+
+    // CHECK: [[BLOCK]]:
+    // OPT: %[[SHIFTED:.+]] = sub i8 %x, -1
+    // OPT: %[[IN_WIDTH:.+]] = icmp ule i8 %[[SHIFTED]], 2
+    // OPT: call void @llvm.assume(i1 %[[IN_WIDTH]])
+    // DBG-NOT: assume
+    // CHECK: ret i8 %x
+
+    if let Some(val) = x { val } else { unreachable!() }
+}
+
+#[no_mangle]
+fn use_option_nonnull(x: Option<NonNull<u16>>) -> NonNull<u16> {
+    // CHECK-LABEL: @use_option_nonnull
+    // OPT-SAME: (ptr noundef %x)
+
+    // CHECK: %[[ADDR:.+]] = ptrtoint ptr %x to i64
+    // CHECK: %[[IS_NONE:.+]] = icmp eq i64 %[[ADDR]], 0
+    // CHECK: %[[DISCR:.+]] = select i1 %[[IS_NONE]], i64 0, i64 1
+    // CHECK: %[[IS_SOME:.+]] = trunc nuw i64 %[[DISCR]] to i1
+    // OPT: %[[LIKELY:.+]] = call i1 @llvm.expect.i1(i1 %[[IS_SOME]], i1 true)
+    // OPT: br i1 %[[LIKELY]], label %[[BLOCK:.+]],
+    // DBG: br i1 %[[IS_SOME]], label %[[BLOCK:.+]],
+
+    // CHECK: [[BLOCK]]:
+    // OPT: %[[IS_NOT_NULL:.+]] = icmp ne ptr %x, null
+    // OPT: call void @llvm.assume(i1 %[[IS_NOT_NULL]])
+    // DBG-NOT: assume
+    // CHECK: ret ptr %x
+
+    if let Some(val) = x { val } else { unreachable!() }
+}
+
+#[no_mangle]
+fn use_result_nzusize(x: Result<NonZero<usize>, NonNull<u32>>) -> NonZero<usize> {
+    // CHECK-LABEL: @use_result_nzusize
+    // OPT-SAME: (i64 noundef range(i64 0, 2) %x.0, ptr noundef %x.1)
+
+    // CHECK-NOT: alloca
+    // CHECK: %[[IS_ERR:.+]] = trunc nuw i64 %x.0 to i1
+    // OPT: %[[UNLIKELY:.+]] = call i1 @llvm.expect.i1(i1 %[[IS_ERR]], i1 false)
+    // OPT: br i1 %[[UNLIKELY]], label %[[PANIC:.+]], label %[[BLOCK:.+]]
+    // DBG: br i1 %[[IS_ERR]], label %[[PANIC:.+]], label %[[BLOCK:.+]]
+
+    // CHECK: [[BLOCK]]:
+    // CHECK: %val = ptrtoint ptr %x.1 to i64
+    // CHECK: ret i64 %val
+
+    if let Ok(val) = x { val } else { unreachable!() }
+}
+
+#[no_mangle]
+fn use_result_i32_char(x: Result<i32, char>) -> char {
+    // CHECK-LABEL: @use_result_i32_char
+    // OPT-SAME: (i32 noundef range(i32 0, 2) %x.0, i32 noundef %x.1)
+
+    // CHECK-NOT: alloca
+    // CHECK: %[[IS_ERR_WIDE:.+]] = zext i32 %x.0 to i64
+    // CHECK: %[[IS_ERR:.+]] = trunc nuw i64 %[[IS_ERR_WIDE]] to i1
+    // OPT: %[[LIKELY:.+]] = call i1 @llvm.expect.i1(i1 %[[IS_ERR]], i1 true)
+    // OPT: br i1 %[[LIKELY]], label %[[BLOCK:.+]], label %[[PANIC:.+]]
+    // DBG: br i1 %[[IS_ERR]], label %[[BLOCK:.+]], label %[[PANIC:.+]]
+
+    // CHECK: [[BLOCK]]:
+    // OPT: %[[RANGE:.+]] = icmp ule i32 %x.1, 1114111
+    // OPT: call void @llvm.assume(i1 %[[RANGE]])
+    // DBG-NOT: call
+    // CHECK: ret i32 %x.1
+
+    if let Err(val) = x { val } else { unreachable!() }
+}
+
+#[repr(u64)]
+enum BigEnum {
+    Foo = 100,
+    Bar = 200,
+}
+
+#[no_mangle]
+fn use_result_bigenum(x: Result<BigEnum, u64>) -> BigEnum {
+    // CHECK-LABEL: @use_result_bigenum
+    // OPT-SAME: (i64 noundef range(i64 0, 2) %x.0, i64 noundef %x.1)
+
+    // CHECK-NOT: alloca
+    // CHECK: %[[IS_ERR:.+]] = trunc nuw i64 %x.0 to i1
+    // OPT: %[[UNLIKELY:.+]] = call i1 @llvm.expect.i1(i1 %[[IS_ERR]], i1 false)
+    // OPT: br i1 %[[UNLIKELY]], label %[[PANIC:.+]], label %[[BLOCK:.+]]
+    // DBG: br i1 %[[IS_ERR]], label %[[PANIC:.+]], label %[[BLOCK:.+]]
+
+    // CHECK: [[BLOCK]]:
+    // CHECK: ret i64 %x.1
+
+    if let Ok(val) = x { val } else { unreachable!() }
+}
+
+struct WhateverError;
+
+#[no_mangle]
+fn use_result_nonnull(x: Result<NonNull<u16>, WhateverError>) -> NonNull<u16> {
+    // CHECK-LABEL: @use_result_nonnull
+    // OPT-SAME: (ptr noundef %x)
+
+    // CHECK-NOT: alloca
+    // CHECK: %[[ADDR:.+]] = ptrtoint ptr %x to i64
+    // CHECK: %[[IS_NULL:.+]] = icmp eq i64 %[[ADDR]], 0
+    // CHECK: %[[DISCR:.+]] = select i1 %[[IS_NULL]], i64 1, i64 0
+    // CHECK: %[[IS_ERR:.+]] = trunc nuw i64 %[[DISCR]] to i1
+    // OPT: %[[UNLIKELY:.+]] = call i1 @llvm.expect.i1(i1 %[[IS_ERR]], i1 false)
+    // OPT: br i1 %[[UNLIKELY]], label %[[PANIC:.+]], label %[[BLOCK:.+]]
+    // DBG: br i1 %[[IS_ERR]], label %[[PANIC:.+]], label %[[BLOCK:.+]]
+
+    // CHECK: [[BLOCK]]:
+    // CHECK: ret ptr %x
+
+    if let Ok(val) = x { val } else { unreachable!() }
+}

--- a/tests/codegen-llvm/enum/enum-match.rs
+++ b/tests/codegen-llvm/enum/enum-match.rs
@@ -15,11 +15,10 @@ pub enum Enum0 {
     B,
 }
 
-// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i8 [0-9]+, [0-9]+\))?}} i8 @match0(i8{{.+}}%0)
+// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i8 [0-9]+, [0-9]+\))?}} i8 @match0(i8{{.+}}%e)
 // CHECK-NEXT: start:
-// CHECK-NEXT: %[[IS_B:.+]] = icmp eq i8 %0, 2
-// CHECK-NEXT: %[[TRUNC:.+]] = and i8 %0, 1
-// CHECK-NEXT: %[[R:.+]] = select i1 %[[IS_B]], i8 13, i8 %[[TRUNC]]
+// CHECK-NEXT: %[[IS_B:.+]] = icmp eq i8 %e, 2
+// CHECK-NEXT: %[[R:.+]] = select i1 %[[IS_B]], i8 13, i8 %e
 // CHECK-NEXT: ret i8 %[[R]]
 #[no_mangle]
 pub fn match0(e: Enum0) -> u8 {
@@ -37,11 +36,11 @@ pub enum Enum1 {
     C,
 }
 
-// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i8 [0-9]+, [0-9]+\))?}} i8 @match1(i8{{.+}}%0)
+// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i8 [0-9]+, [0-9]+\))?}} i8 @match1(i8{{.+}}%e)
 // CHECK-NEXT: start:
-// CHECK-NEXT: %[[REL_VAR:.+]] = add{{( nsw)?}} i8 %0, -2
+// CHECK-NEXT: %[[REL_VAR:.+]] = add{{( nsw)?}} i8 %e, -2
 // CHECK-NEXT: %[[REL_VAR_WIDE:.+]] = zext i8 %[[REL_VAR]] to i64
-// CHECK-NEXT: %[[IS_NICHE:.+]] = icmp{{( samesign)?}} ugt i8 %0, 1
+// CHECK-NEXT: %[[IS_NICHE:.+]] = icmp{{( samesign)?}} ugt i8 %e, 1
 // CHECK-NEXT: %[[NICHE_DISCR:.+]] = add nuw nsw i64 %[[REL_VAR_WIDE]], 1
 // CHECK-NEXT: %[[DISCR:.+]] = select i1 %[[IS_NICHE]], i64 %[[NICHE_DISCR]], i64 0
 // CHECK-NEXT: switch i64 %[[DISCR]]
@@ -98,9 +97,9 @@ pub enum Enum2 {
     E,
 }
 
-// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i8 [0-9]+, -?[0-9]+\))?}} i8 @match2(i8{{.+}}%0)
+// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i8 [0-9]+, -?[0-9]+\))?}} i8 @match2(i8{{.+}}%e)
 // CHECK-NEXT: start:
-// CHECK-NEXT: %[[REL_VAR:.+]] = add i8 %0, 2
+// CHECK-NEXT: %[[REL_VAR:.+]] = add i8 %e, 2
 // CHECK-NEXT: %[[REL_VAR_WIDE:.+]] = zext i8 %[[REL_VAR]] to i64
 // CHECK-NEXT: %[[IS_NICHE:.+]] = icmp ult i8 %[[REL_VAR]], 4
 // CHECK-NEXT: %[[NICHE_DISCR:.+]] = add nuw nsw i64 %[[REL_VAR_WIDE]], 1
@@ -121,9 +120,9 @@ pub fn match2(e: Enum2) -> u8 {
 // And make sure it works even if the niched scalar is a pointer.
 // (For example, that we don't try to `sub` on pointers.)
 
-// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i16 -?[0-9]+, -?[0-9]+\))?}} i16 @match3(ptr{{.+}}%0)
+// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i16 -?[0-9]+, -?[0-9]+\))?}} i16 @match3(ptr{{.+}}%e)
 // CHECK-NEXT: start:
-// CHECK-NEXT: %[[IS_NULL:.+]] = icmp eq ptr %0, null
+// CHECK-NEXT: %[[IS_NULL:.+]] = icmp eq ptr %e, null
 // CHECK-NEXT: br i1 %[[IS_NULL]]
 #[no_mangle]
 pub fn match3(e: Option<&u8>) -> i16 {
@@ -145,12 +144,12 @@ pub enum MiddleNiche {
     E,       // tag 6
 }
 
-// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i8 -?[0-9]+, -?[0-9]+\))?}} i8 @match4(i8{{.+}}%0)
+// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i8 -?[0-9]+, -?[0-9]+\))?}} i8 @match4(i8{{.+}}%e)
 // CHECK-NEXT: start:
-// CHECK-NEXT: %[[NOT_IMPOSSIBLE:.+]] = icmp ne i8 %0, 4
+// CHECK-NEXT: %[[NOT_IMPOSSIBLE:.+]] = icmp ne i8 %e, 4
 // CHECK-NEXT: call void @llvm.assume(i1 %[[NOT_IMPOSSIBLE]])
-// CHECK-NEXT: %[[REL_VAR:.+]] = add{{( nsw)?}} i8 %0, -2
-// CHECK-NEXT: %[[NOT_NICHE:.+]] = icmp{{( samesign)?}} ult i8 %0, 2
+// CHECK-NEXT: %[[REL_VAR:.+]] = add{{( nsw)?}} i8 %e, -2
+// CHECK-NEXT: %[[NOT_NICHE:.+]] = icmp{{( samesign)?}} ult i8 %e, 2
 // CHECK-NEXT: %[[DISCR:.+]] = select i1 %[[NOT_NICHE]], i8 2, i8 %[[REL_VAR]]
 // CHECK-NEXT: switch i8 %[[DISCR]]
 #[no_mangle]
@@ -448,13 +447,13 @@ pub enum HugeVariantIndex {
     Possible259,   // tag 4
 }
 
-// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i8 [0-9]+, [0-9]+\))?}} i8 @match5(i8{{.+}}%0)
+// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i8 [0-9]+, [0-9]+\))?}} i8 @match5(i8{{.+}}%e)
 // CHECK-NEXT: start:
-// CHECK-NEXT: %[[NOT_IMPOSSIBLE:.+]] = icmp ne i8 %0, 3
+// CHECK-NEXT: %[[NOT_IMPOSSIBLE:.+]] = icmp ne i8 %e, 3
 // CHECK-NEXT: call void @llvm.assume(i1 %[[NOT_IMPOSSIBLE]])
-// CHECK-NEXT: %[[REL_VAR:.+]] = add{{( nsw)?}} i8 %0, -2
+// CHECK-NEXT: %[[REL_VAR:.+]] = add{{( nsw)?}} i8 %e, -2
 // CHECK-NEXT: %[[REL_VAR_WIDE:.+]] = zext i8 %[[REL_VAR]] to i64
-// CHECK-NEXT: %[[IS_NICHE:.+]] = icmp{{( samesign)?}} ugt i8 %0, 1
+// CHECK-NEXT: %[[IS_NICHE:.+]] = icmp{{( samesign)?}} ugt i8 %e, 1
 // CHECK-NEXT: %[[NICHE_DISCR:.+]] = add nuw nsw i64 %[[REL_VAR_WIDE]], 257
 // CHECK-NEXT: %[[DISCR:.+]] = select i1 %[[IS_NICHE]], i64 %[[NICHE_DISCR]], i64 258
 // CHECK-NEXT: switch i64 %[[DISCR]],

--- a/tests/codegen-llvm/issues/multiple-option-or-permutations.rs
+++ b/tests/codegen-llvm/issues/multiple-option-or-permutations.rs
@@ -118,12 +118,12 @@ pub fn if_some_slice_u8(opta: Option<[u8; 1]>, optb: Option<[u8; 1]>) -> Option<
 // Test a niche optimization case of `NonZero<u8>`
 
 // CHECK-LABEL: @or_match_nz_u8
-// CHECK-SAME: (i8{{.+}}%0, i8{{.+}}%optb)
+// CHECK-SAME: (i8{{.+}}%opta, i8{{.+}}%optb)
 #[no_mangle]
 pub fn or_match_nz_u8(opta: Option<NonZero<u8>>, optb: Option<NonZero<u8>>) -> Option<NonZero<u8>> {
     // CHECK: start:
-    // CHECK-NEXT: [[NOT_A:%.+]] = icmp eq i8 %0, 0
-    // CHECK-NEXT: [[R:%.+]] = select i1 [[NOT_A]], i8 %optb, i8 %0
+    // CHECK-NEXT: [[NOT_A:%.+]] = icmp eq i8 %opta, 0
+    // CHECK-NEXT: [[R:%.+]] = select i1 [[NOT_A]], i8 %optb, i8 %opta
     // CHECK: ret i8 [[R]]
     match opta {
         Some(x) => Some(x),

--- a/tests/codegen-llvm/try_question_mark_nop.rs
+++ b/tests/codegen-llvm/try_question_mark_nop.rs
@@ -211,10 +211,22 @@ pub fn control_flow_nop_traits_128(x: ControlFlow<i128, u128>) -> ControlFlow<i1
 // CHECK-LABEL: @result_nop_match_ptr
 #[no_mangle]
 pub fn result_nop_match_ptr(x: Result<usize, Box<()>>) -> Result<usize, Box<()>> {
+    // The check here is a bit more involved as it does get a check, but the check
+    // is only there for the assume -- the actual pair is still a pass-through.
+
     // CHECK: start:
-    // CHECK-NEXT: insertvalue { i{{[0-9]+}}, ptr }
-    // CHECK-NEXT: insertvalue { i{{[0-9]+}}, ptr }
-    // CHECK-NEXT: ret
+    // CHECK-NEXT: [[IS_ERR:%.+]] = trunc nuw [[USIZE:i32|i64]] %x.0 to i1
+    // CHECK-NEXT: br i1 [[IS_ERR]], label %[[ERR_BLOCK:.+]], label %[[RET_BLOCK:.+]]
+    //
+    // CHECK: [[ERR_BLOCK]]:
+    // CHECK-NEXT: [[NOT_NULL:%.+]] = icmp ne ptr %x.1, null
+    // CHECK-NEXT: tail call void @llvm.assume(i1 [[NOT_NULL]])
+    // CHECK-NEXT: br label %[[RET_BLOCK]]
+    //
+    // CHECK: [[RET_BLOCK]]:
+    // CHECK-NEXT: [[PAIR0:%.+]] = insertvalue { i64, ptr } poison, i64 %x.0, 0
+    // CHECK-NEXT: [[PAIR1:%.+]] = insertvalue { i64, ptr } [[PAIR0]], ptr %x.1, 1
+    // CHECK-NEXT: ret { [[USIZE]], ptr } [[PAIR1]]
     match x {
         Ok(x) => Ok(x),
         Err(x) => Err(x),


### PR DESCRIPTION
Notably this includes common cases like `Option<NonNull<_>>`.
