### PR TITLE
Fix typo in armv7a-vex-v5.md

### DIFF
--- a/src/doc/rustc/src/platform-support/armv7a-vex-v5.md
+++ b/src/doc/rustc/src/platform-support/armv7a-vex-v5.md
@@ -24,7 +24,7 @@ This target is cross-compiled. Dynamic linking is unsupported.
 `std` has only partial support due to platform limitations. Notably:
 - `std::process` and `std::net` are unimplemented. `std::thread` only supports sleeping and yielding, as this is a single-threaded environment.
 - `std::time` has full support for `Instant`, but no support for `SystemTime`.
-- `std::io` has full support for `stdin`/`stdout`/`stderr`. `stdout` and `stderr` both write to to USB channel 1 on this platform and are not differentiated.
+- `std::io` has full support for `stdin`/`stdout`/`stderr`. `stdout` and `stderr` both write to USB channel 1 on this platform and are not differentiated.
 - `std::fs` has limited support for reading or writing to files. Directory operations, file deletion, and some file opening features are unsupported and will return errors.
 - A global allocator implemented on top of `dlmalloc` is provided.
 - Modules that do not need to interact with the OS beyond allocation such as `std::collections`, `std::hash`, `std::future`, `std::sync`, etc are fully supported.


### PR DESCRIPTION
Remove duplicate "to" in armv7-vex-v5.md