### PR TITLE
`rustc_queries` simplifications

### DIFF
--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -239,13 +239,13 @@ rustc_queries! {
     /// Avoid calling this query directly.
     query hir_module_items(key: LocalModDefId) -> &'tcx rustc_middle::hir::ModuleItems {
         arena_cache
-        desc { |tcx| "getting HIR module items in `{}`", tcx.def_path_str(key) }
+        desc { "getting HIR module items in `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { true }
     }
 
     /// Returns HIR ID for the given `LocalDefId`.
     query local_def_id_to_hir_id(key: LocalDefId) -> hir::HirId {
-        desc { |tcx| "getting HIR ID of `{}`", tcx.def_path_str(key) }
+        desc { "getting HIR ID of `{}`", tcx.def_path_str(key) }
         feedable
     }
 
@@ -254,7 +254,7 @@ rustc_queries! {
     /// This can be conveniently accessed by `tcx.hir_*` methods.
     /// Avoid calling this query directly.
     query hir_owner_parent_q(key: hir::OwnerId) -> hir::HirId {
-        desc { |tcx| "getting HIR parent of `{}`", tcx.def_path_str(key) }
+        desc { "getting HIR parent of `{}`", tcx.def_path_str(key) }
     }
 
     /// Gives access to the HIR nodes and bodies inside `key` if it's a HIR owner.
@@ -262,7 +262,7 @@ rustc_queries! {
     /// This can be conveniently accessed by `tcx.hir_*` methods.
     /// Avoid calling this query directly.
     query opt_hir_owner_nodes(key: LocalDefId) -> Option<&'tcx hir::OwnerNodes<'tcx>> {
-        desc { |tcx| "getting HIR owner items in `{}`", tcx.def_path_str(key) }
+        desc { "getting HIR owner items in `{}`", tcx.def_path_str(key) }
         feedable
     }
 
@@ -271,7 +271,7 @@ rustc_queries! {
     /// This can be conveniently accessed by `tcx.hir_*` methods.
     /// Avoid calling this query directly.
     query hir_attr_map(key: hir::OwnerId) -> &'tcx hir::AttributeMap<'tcx> {
-        desc { |tcx| "getting HIR owner attributes in `{}`", tcx.def_path_str(key) }
+        desc { "getting HIR owner attributes in `{}`", tcx.def_path_str(key) }
         feedable
     }
 
@@ -280,14 +280,14 @@ rustc_queries! {
     /// This can be conveniently accessed by `tcx.hir_*` methods.
     /// Avoid calling this query directly.
     query opt_ast_lowering_delayed_lints(key: hir::OwnerId) -> Option<&'tcx hir::lints::DelayedLints> {
-        desc { |tcx| "getting AST lowering delayed lints in `{}`", tcx.def_path_str(key) }
+        desc { "getting AST lowering delayed lints in `{}`", tcx.def_path_str(key) }
     }
 
     /// Returns the *default* of the const pararameter given by `DefId`.
     ///
     /// E.g., given `struct Ty<const N: usize = 3>;` this returns `3` for `N`.
     query const_param_default(param: DefId) -> ty::EarlyBinder<'tcx, ty::Const<'tcx>> {
-        desc { |tcx| "computing the default for const parameter `{}`", tcx.def_path_str(param)  }
+        desc { "computing the default for const parameter `{}`", tcx.def_path_str(param)  }
         cache_on_disk_if { param.is_local() }
         separate_provide_extern
     }
@@ -300,7 +300,7 @@ rustc_queries! {
     ///
     /// This query will ICE if given a const that is not marked with `type const`.
     query const_of_item(def_id: DefId) -> ty::EarlyBinder<'tcx, ty::Const<'tcx>> {
-        desc { |tcx| "computing the type-level value for `{}`", tcx.def_path_str(def_id)  }
+        desc { "computing the type-level value for `{}`", tcx.def_path_str(def_id)  }
         cache_on_disk_if { def_id.is_local() }
         separate_provide_extern
     }
@@ -324,7 +324,7 @@ rustc_queries! {
     ///
     /// [alias type]: rustc_middle::ty::AliasTy
     query type_of(key: DefId) -> ty::EarlyBinder<'tcx, Ty<'tcx>> {
-        desc { |tcx|
+        desc {
             "{action} `{path}`",
             action = match tcx.def_kind(key) {
                 DefKind::TyAlias => "expanding type alias",
@@ -349,14 +349,14 @@ rustc_queries! {
     ///
     /// This query will panic if the given definition is not an opaque type.
     query type_of_opaque(key: DefId) -> Result<ty::EarlyBinder<'tcx, Ty<'tcx>>, CyclePlaceholder> {
-        desc { |tcx|
+        desc {
             "computing type of opaque `{path}`",
             path = tcx.def_path_str(key),
         }
         cycle_stash
     }
     query type_of_opaque_hir_typeck(key: LocalDefId) -> ty::EarlyBinder<'tcx, Ty<'tcx>> {
-        desc { |tcx|
+        desc {
             "computing type of opaque `{path}` via HIR typeck",
             path = tcx.def_path_str(key),
         }
@@ -376,7 +376,7 @@ rustc_queries! {
     /// [free]: rustc_middle::ty::Free
     /// [alias type]: rustc_middle::ty::AliasTy
     query type_alias_is_lazy(key: DefId) -> bool {
-        desc { |tcx|
+        desc {
             "computing whether the type alias `{path}` is lazy",
             path = tcx.def_path_str(key),
         }
@@ -400,7 +400,7 @@ rustc_queries! {
     query unsizing_params_for_adt(key: DefId) -> &'tcx rustc_index::bit_set::DenseBitSet<u32>
     {
         arena_cache
-        desc { |tcx|
+        desc {
             "determining what parameters of `{}` can participate in unsizing",
             tcx.def_path_str(key),
         }
@@ -409,7 +409,7 @@ rustc_queries! {
     /// The root query triggering all analysis passes like typeck or borrowck.
     query analysis(key: ()) {
         eval_always
-        desc { |tcx|
+        desc {
             "running analysis passes on crate `{}`",
             tcx.crate_name(LOCAL_CRATE),
         }
@@ -436,7 +436,7 @@ rustc_queries! {
 
     /// Returns the *generics* of the definition given by `DefId`.
     query generics_of(key: DefId) -> &'tcx ty::Generics {
-        desc { |tcx| "computing generics of `{}`", tcx.def_path_str(key) }
+        desc { "computing generics of `{}`", tcx.def_path_str(key) }
         arena_cache
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
@@ -451,7 +451,7 @@ rustc_queries! {
     /// **Tip**: You can use `#[rustc_dump_predicates]` on an item to basically print
     /// the result of this query for use in UI tests or for debugging purposes.
     query predicates_of(key: DefId) -> ty::GenericPredicates<'tcx> {
-        desc { |tcx| "computing predicates of `{}`", tcx.def_path_str(key) }
+        desc { "computing predicates of `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
     }
 
@@ -459,7 +459,7 @@ rustc_queries! {
         key: LocalDefId
     ) -> &'tcx ty::List<LocalDefId> {
         desc {
-            |tcx| "computing the opaque types defined by `{}`",
+            "computing the opaque types defined by `{}`",
             tcx.def_path_str(key.to_def_id())
         }
     }
@@ -470,7 +470,7 @@ rustc_queries! {
         key: LocalDefId
     ) -> &'tcx ty::List<LocalDefId> {
         desc {
-            |tcx| "computing the coroutines defined within `{}`",
+            "computing the coroutines defined within `{}`",
             tcx.def_path_str(key.to_def_id())
         }
     }
@@ -494,7 +494,7 @@ rustc_queries! {
     /// //                    ^^^^^^^^^^^^^^^
     /// ```
     query explicit_item_bounds(key: DefId) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, Span)]> {
-        desc { |tcx| "finding item bounds for `{}`", tcx.def_path_str(key) }
+        desc { "finding item bounds for `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
         feedable
@@ -507,7 +507,7 @@ rustc_queries! {
     ///
     /// [explicit item bounds]: Self::explicit_item_bounds
     query explicit_item_self_bounds(key: DefId) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, Span)]> {
-        desc { |tcx| "finding item bounds for `{}`", tcx.def_path_str(key) }
+        desc { "finding item bounds for `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
         feedable
@@ -537,19 +537,19 @@ rustc_queries! {
     /// ]
     /// ```
     query item_bounds(key: DefId) -> ty::EarlyBinder<'tcx, ty::Clauses<'tcx>> {
-        desc { |tcx| "elaborating item bounds for `{}`", tcx.def_path_str(key) }
+        desc { "elaborating item bounds for `{}`", tcx.def_path_str(key) }
     }
 
     query item_self_bounds(key: DefId) -> ty::EarlyBinder<'tcx, ty::Clauses<'tcx>> {
-        desc { |tcx| "elaborating item assumptions for `{}`", tcx.def_path_str(key) }
+        desc { "elaborating item assumptions for `{}`", tcx.def_path_str(key) }
     }
 
     query item_non_self_bounds(key: DefId) -> ty::EarlyBinder<'tcx, ty::Clauses<'tcx>> {
-        desc { |tcx| "elaborating item assumptions for `{}`", tcx.def_path_str(key) }
+        desc { "elaborating item assumptions for `{}`", tcx.def_path_str(key) }
     }
 
     query impl_super_outlives(key: DefId) -> ty::EarlyBinder<'tcx, ty::Clauses<'tcx>> {
-        desc { |tcx| "elaborating supertrait outlives for trait of `{}`", tcx.def_path_str(key) }
+        desc { "elaborating supertrait outlives for trait of `{}`", tcx.def_path_str(key) }
     }
 
     /// Look up all native libraries this crate depends on.
@@ -564,7 +564,7 @@ rustc_queries! {
 
     query shallow_lint_levels_on(key: hir::OwnerId) -> &'tcx rustc_middle::lint::ShallowLintLevelMap {
         arena_cache
-        desc { |tcx| "looking up lint levels for `{}`", tcx.def_path_str(key) }
+        desc { "looking up lint levels for `{}`", tcx.def_path_str(key) }
     }
 
     query lint_expectations(_: ()) -> &'tcx Vec<(LintExpectationId, LintExpectation)> {
@@ -578,7 +578,7 @@ rustc_queries! {
     }
 
     query expn_that_defined(key: DefId) -> rustc_span::ExpnId {
-        desc { |tcx| "getting the expansion that defined `{}`", tcx.def_path_str(key) }
+        desc { "getting the expansion that defined `{}`", tcx.def_path_str(key) }
         separate_provide_extern
     }
 
@@ -619,7 +619,7 @@ rustc_queries! {
     query thir_body(key: LocalDefId) -> Result<(&'tcx Steal<thir::Thir<'tcx>>, thir::ExprId), ErrorGuaranteed> {
         // Perf tests revealed that hashing THIR is inefficient (see #85729).
         no_hash
-        desc { |tcx| "building THIR for `{}`", tcx.def_path_str(key) }
+        desc { "building THIR for `{}`", tcx.def_path_str(key) }
     }
 
     /// Set of all the `DefId`s in this crate that have MIR associated with
@@ -634,7 +634,7 @@ rustc_queries! {
     /// of the MIR const-checking pass. This is the set of qualifs in
     /// the final value of a `const`.
     query mir_const_qualif(key: DefId) -> mir::ConstQualifs {
-        desc { |tcx| "const checking `{}`", tcx.def_path_str(key) }
+        desc { "const checking `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
     }
@@ -645,7 +645,7 @@ rustc_queries! {
     ///
     /// [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/mir/construction.html
     query mir_built(key: LocalDefId) -> &'tcx Steal<mir::Body<'tcx>> {
-        desc { |tcx| "building MIR for `{}`", tcx.def_path_str(key) }
+        desc { "building MIR for `{}`", tcx.def_path_str(key) }
         feedable
     }
 
@@ -654,20 +654,20 @@ rustc_queries! {
         key: DefId
     ) -> Result<Option<ty::EarlyBinder<'tcx, ty::Const<'tcx>>>, ErrorGuaranteed> {
         desc {
-            |tcx| "building an abstract representation for `{}`", tcx.def_path_str(key),
+            "building an abstract representation for `{}`", tcx.def_path_str(key),
         }
         separate_provide_extern
     }
 
     query mir_drops_elaborated_and_const_checked(key: LocalDefId) -> &'tcx Steal<mir::Body<'tcx>> {
         no_hash
-        desc { |tcx| "elaborating drops for `{}`", tcx.def_path_str(key) }
+        desc { "elaborating drops for `{}`", tcx.def_path_str(key) }
     }
 
     query mir_for_ctfe(
         key: DefId
     ) -> &'tcx mir::Body<'tcx> {
-        desc { |tcx| "caching mir of `{}` for CTFE", tcx.def_path_str(key) }
+        desc { "caching mir of `{}` for CTFE", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
     }
@@ -677,12 +677,12 @@ rustc_queries! {
         &'tcx Steal<IndexVec<mir::Promoted, mir::Body<'tcx>>>
     ) {
         no_hash
-        desc { |tcx| "promoting constants in MIR for `{}`", tcx.def_path_str(key) }
+        desc { "promoting constants in MIR for `{}`", tcx.def_path_str(key) }
     }
 
     query closure_typeinfo(key: LocalDefId) -> ty::ClosureTypeInfo<'tcx> {
         desc {
-            |tcx| "finding symbols for captures of closure `{}`",
+            "finding symbols for captures of closure `{}`",
             tcx.def_path_str(key)
         }
     }
@@ -696,19 +696,19 @@ rustc_queries! {
     /// For coroutines this only contains upvars that are shared by all states.
     query closure_saved_names_of_captured_variables(def_id: DefId) -> &'tcx IndexVec<abi::FieldIdx, Symbol> {
         arena_cache
-        desc { |tcx| "computing debuginfo for closure `{}`", tcx.def_path_str(def_id) }
+        desc { "computing debuginfo for closure `{}`", tcx.def_path_str(def_id) }
         separate_provide_extern
     }
 
     query mir_coroutine_witnesses(key: DefId) -> Option<&'tcx mir::CoroutineLayout<'tcx>> {
         arena_cache
-        desc { |tcx| "coroutine witness types for `{}`", tcx.def_path_str(key) }
+        desc { "coroutine witness types for `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
     }
 
     query check_coroutine_obligations(key: LocalDefId) -> Result<(), ErrorGuaranteed> {
-        desc { |tcx| "verify auto trait bounds for coroutine interior type `{}`", tcx.def_path_str(key) }
+        desc { "verify auto trait bounds for coroutine interior type `{}`", tcx.def_path_str(key) }
         return_result_from_ensure_ok
     }
 
@@ -723,7 +723,7 @@ rustc_queries! {
     /// delay a bug if it does not.
     query check_potentially_region_dependent_goals(key: LocalDefId) -> Result<(), ErrorGuaranteed> {
         desc {
-            |tcx| "reproving potentially region dependent HIR typeck goals for `{}",
+            "reproving potentially region dependent HIR typeck goals for `{}",
             tcx.def_path_str(key)
         }
     }
@@ -731,7 +731,7 @@ rustc_queries! {
     /// MIR after our optimization passes have run. This is MIR that is ready
     /// for codegen. This is also the only query that can fetch non-local MIR, at present.
     query optimized_mir(key: DefId) -> &'tcx mir::Body<'tcx> {
-        desc { |tcx| "optimizing MIR for `{}`", tcx.def_path_str(key) }
+        desc { "optimizing MIR for `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
     }
@@ -742,7 +742,7 @@ rustc_queries! {
     /// Returns `false` if `#[coverage(off)]` was found, or `true` if
     /// either `#[coverage(on)]` or no coverage attribute was found.
     query coverage_attr_on(key: LocalDefId) -> bool {
-        desc { |tcx| "checking for `#[coverage(..)]` on `{}`", tcx.def_path_str(key) }
+        desc { "checking for `#[coverage(..)]` on `{}`", tcx.def_path_str(key) }
         feedable
     }
 
@@ -759,7 +759,7 @@ rustc_queries! {
     ///
     /// Returns `None` for functions that were not instrumented.
     query coverage_ids_info(key: ty::InstanceKind<'tcx>) -> Option<&'tcx mir::coverage::CoverageIdsInfo> {
-        desc { |tcx| "retrieving coverage IDs info from MIR for `{}`", tcx.def_path_str(key.def_id()) }
+        desc { "retrieving coverage IDs info from MIR for `{}`", tcx.def_path_str(key.def_id()) }
         arena_cache
     }
 
@@ -769,7 +769,7 @@ rustc_queries! {
     /// after inlining a body may refer to promoteds from other bodies. In that case you still
     /// need to use the `DefId` of the original body.
     query promoted_mir(key: DefId) -> &'tcx IndexVec<mir::Promoted, mir::Body<'tcx>> {
-        desc { |tcx| "optimizing promoted MIR for `{}`", tcx.def_path_str(key) }
+        desc { "optimizing promoted MIR for `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
     }
@@ -815,7 +815,7 @@ rustc_queries! {
     ///
     /// This query will panic if the given definition is not a trait.
     query trait_explicit_predicates_and_bounds(key: LocalDefId) -> ty::GenericPredicates<'tcx> {
-        desc { |tcx| "computing explicit predicates of trait `{}`", tcx.def_path_str(key) }
+        desc { "computing explicit predicates of trait `{}`", tcx.def_path_str(key) }
     }
 
     /// Returns the explicitly user-written *predicates* of the definition given by `DefId`
@@ -824,7 +824,7 @@ rustc_queries! {
     /// You should probably use [`Self::predicates_of`] unless you're looking for
     /// predicates with explicit spans for diagnostics purposes.
     query explicit_predicates_of(key: DefId) -> ty::GenericPredicates<'tcx> {
-        desc { |tcx| "computing explicit predicates of `{}`", tcx.def_path_str(key) }
+        desc { "computing explicit predicates of `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
         feedable
@@ -837,7 +837,7 @@ rustc_queries! {
     /// **Tip**: You can use `#[rustc_outlives]` on an item to basically print the
     /// result of this query for use in UI tests or for debugging purposes.
     query inferred_outlives_of(key: DefId) -> &'tcx [(ty::Clause<'tcx>, Span)] {
-        desc { |tcx| "computing inferred outlives-predicates of `{}`", tcx.def_path_str(key) }
+        desc { "computing inferred outlives-predicates of `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
         feedable
@@ -851,7 +851,7 @@ rustc_queries! {
     /// because we must evaluate them even during type conversion, often before the full
     /// predicates are available (note that super-predicates must not be cyclic).
     query explicit_super_predicates_of(key: DefId) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, Span)]> {
-        desc { |tcx| "computing the super predicates of `{}`", tcx.def_path_str(key) }
+        desc { "computing the super predicates of `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
     }
@@ -863,7 +863,7 @@ rustc_queries! {
     /// associated type bounds. For trait aliases, currently, this includes all of the
     /// predicates of the trait alias.
     query explicit_implied_predicates_of(key: DefId) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, Span)]> {
-        desc { |tcx| "computing the implied predicates of `{}`", tcx.def_path_str(key) }
+        desc { "computing the implied predicates of `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
     }
@@ -874,7 +874,7 @@ rustc_queries! {
     query explicit_supertraits_containing_assoc_item(
         key: (DefId, rustc_span::Ident)
     ) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, Span)]> {
-        desc { |tcx| "computing the super traits of `{}` with associated type name `{}`",
+        desc { "computing the super traits of `{}` with associated type name `{}`",
             tcx.def_path_str(key.0),
             key.1
         }
@@ -892,7 +892,7 @@ rustc_queries! {
     query const_conditions(
         key: DefId
     ) -> ty::ConstConditions<'tcx> {
-        desc { |tcx| "computing the conditions for `{}` to be considered const",
+        desc { "computing the conditions for `{}` to be considered const",
             tcx.def_path_str(key)
         }
         separate_provide_extern
@@ -906,7 +906,7 @@ rustc_queries! {
     query explicit_implied_const_bounds(
         key: DefId
     ) -> ty::EarlyBinder<'tcx, &'tcx [(ty::PolyTraitRef<'tcx>, Span)]> {
-        desc { |tcx| "computing the implied `[const]` bounds for `{}`",
+        desc { "computing the implied `[const]` bounds for `{}`",
             tcx.def_path_str(key)
         }
         separate_provide_extern
@@ -917,40 +917,40 @@ rustc_queries! {
     query type_param_predicates(
         key: (LocalDefId, LocalDefId, rustc_span::Ident)
     ) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, Span)]> {
-        desc { |tcx| "computing the bounds for type parameter `{}`", tcx.hir_ty_param_name(key.1) }
+        desc { "computing the bounds for type parameter `{}`", tcx.hir_ty_param_name(key.1) }
     }
 
     query trait_def(key: DefId) -> &'tcx ty::TraitDef {
-        desc { |tcx| "computing trait definition for `{}`", tcx.def_path_str(key) }
+        desc { "computing trait definition for `{}`", tcx.def_path_str(key) }
         arena_cache
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
     }
     query adt_def(key: DefId) -> ty::AdtDef<'tcx> {
-        desc { |tcx| "computing ADT definition for `{}`", tcx.def_path_str(key) }
+        desc { "computing ADT definition for `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
     }
     query adt_destructor(key: DefId) -> Option<ty::Destructor> {
-        desc { |tcx| "computing `Drop` impl for `{}`", tcx.def_path_str(key) }
+        desc { "computing `Drop` impl for `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
     }
     query adt_async_destructor(key: DefId) -> Option<ty::AsyncDestructor> {
-        desc { |tcx| "computing `AsyncDrop` impl for `{}`", tcx.def_path_str(key) }
+        desc { "computing `AsyncDrop` impl for `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
     }
     query adt_sizedness_constraint(
         key: (DefId, SizedTraitKind)
     ) -> Option<ty::EarlyBinder<'tcx, Ty<'tcx>>> {
-        desc { |tcx| "computing the sizedness constraint for `{}`", tcx.def_path_str(key.0) }
+        desc { "computing the sizedness constraint for `{}`", tcx.def_path_str(key.0) }
     }
 
     query adt_dtorck_constraint(
         key: DefId
     ) -> &'tcx DropckConstraint<'tcx> {
-        desc { |tcx| "computing drop-check constraints for `{}`", tcx.def_path_str(key) }
+        desc { "computing drop-check constraints for `{}`", tcx.def_path_str(key) }
     }
 
     /// Returns the constness of the function-like[^1] definition given by `DefId`.
@@ -975,13 +975,13 @@ rustc_queries! {
     ///
     /// [^1]: Tuple struct/variant constructors, closures and free, associated and foreign functions.
     query constness(key: DefId) -> hir::Constness {
-        desc { |tcx| "checking if item is const: `{}`", tcx.def_path_str(key) }
+        desc { "checking if item is const: `{}`", tcx.def_path_str(key) }
         separate_provide_extern
         feedable
     }
 
     query asyncness(key: DefId) -> ty::Asyncness {
-        desc { |tcx| "checking if the function is async: `{}`", tcx.def_path_str(key) }
+        desc { "checking if the function is async: `{}`", tcx.def_path_str(key) }
         separate_provide_extern
     }
 
@@ -993,7 +993,7 @@ rustc_queries! {
     /// function does not inspect the bits of any of its arguments (so is essentially just a
     /// constructor function).
     query is_promotable_const_fn(key: DefId) -> bool {
-        desc { |tcx| "checking if item is promotable: `{}`", tcx.def_path_str(key) }
+        desc { "checking if item is promotable: `{}`", tcx.def_path_str(key) }
     }
 
     /// The body of the coroutine, modified to take its upvars by move rather than by ref.
@@ -1003,19 +1003,19 @@ rustc_queries! {
     /// is run right after building the initial MIR, and will only be populated for coroutines
     /// which come out of the async closure desugaring.
     query coroutine_by_move_body_def_id(def_id: DefId) -> DefId {
-        desc { |tcx| "looking up the coroutine by-move body for `{}`", tcx.def_path_str(def_id) }
+        desc { "looking up the coroutine by-move body for `{}`", tcx.def_path_str(def_id) }
         separate_provide_extern
     }
 
     /// Returns `Some(coroutine_kind)` if the node pointed to by `def_id` is a coroutine.
     query coroutine_kind(def_id: DefId) -> Option<hir::CoroutineKind> {
-        desc { |tcx| "looking up coroutine kind of `{}`", tcx.def_path_str(def_id) }
+        desc { "looking up coroutine kind of `{}`", tcx.def_path_str(def_id) }
         separate_provide_extern
         feedable
     }
 
     query coroutine_for_closure(def_id: DefId) -> DefId {
-        desc { |_tcx| "Given a coroutine-closure def id, return the def id of the coroutine returned by it" }
+        desc { "Given a coroutine-closure def id, return the def id of the coroutine returned by it" }
         separate_provide_extern
     }
 
@@ -1045,7 +1045,7 @@ rustc_queries! {
     /// **Tip**: You can use `#[rustc_variance]` on an item to basically print the
     /// result of this query for use in UI tests or for debugging purposes.
     query variances_of(def_id: DefId) -> &'tcx [ty::Variance] {
-        desc { |tcx| "computing the variances of `{}`", tcx.def_path_str(def_id) }
+        desc { "computing the variances of `{}`", tcx.def_path_str(def_id) }
         cache_on_disk_if { def_id.is_local() }
         separate_provide_extern
         cycle_delay_bug
@@ -1066,14 +1066,14 @@ rustc_queries! {
     /// Maps from an impl/trait or struct/variant `DefId`
     /// to a list of the `DefId`s of its associated items or fields.
     query associated_item_def_ids(key: DefId) -> &'tcx [DefId] {
-        desc { |tcx| "collecting associated items or fields of `{}`", tcx.def_path_str(key) }
+        desc { "collecting associated items or fields of `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
     }
 
     /// Maps from a trait/impl item to the trait/impl item "descriptor".
     query associated_item(key: DefId) -> ty::AssocItem {
-        desc { |tcx| "computing associated item data for `{}`", tcx.def_path_str(key) }
+        desc { "computing associated item data for `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
         feedable
@@ -1082,7 +1082,7 @@ rustc_queries! {
     /// Collects the associated items defined on a trait or impl.
     query associated_items(key: DefId) -> &'tcx ty::AssocItems {
         arena_cache
-        desc { |tcx| "collecting associated items of `{}`", tcx.def_path_str(key) }
+        desc { "collecting associated items of `{}`", tcx.def_path_str(key) }
     }
 
     /// Maps from associated items on a trait to the corresponding associated
@@ -1108,20 +1108,20 @@ rustc_queries! {
     ///`{ trait_f: impl_f, trait_g: impl_g }`
     query impl_item_implementor_ids(impl_id: DefId) -> &'tcx DefIdMap<DefId> {
         arena_cache
-        desc { |tcx| "comparing impl items against trait for `{}`", tcx.def_path_str(impl_id) }
+        desc { "comparing impl items against trait for `{}`", tcx.def_path_str(impl_id) }
     }
 
     /// Given the `item_def_id` of a trait or impl, return a mapping from associated fn def id
     /// to its associated type items that correspond to the RPITITs in its signature.
     query associated_types_for_impl_traits_in_trait_or_impl(item_def_id: DefId) -> &'tcx DefIdMap<Vec<DefId>> {
         arena_cache
-        desc { |tcx| "synthesizing RPITIT items for the opaque types for methods in `{}`", tcx.def_path_str(item_def_id) }
+        desc { "synthesizing RPITIT items for the opaque types for methods in `{}`", tcx.def_path_str(item_def_id) }
         separate_provide_extern
     }
 
     /// Given an `impl_id`, return the trait it implements along with some header information.
     query impl_trait_header(impl_id: DefId) -> ty::ImplTraitHeader<'tcx> {
-        desc { |tcx| "computing trait implemented by `{}`", tcx.def_path_str(impl_id) }
+        desc { "computing trait implemented by `{}`", tcx.def_path_str(impl_id) }
         cache_on_disk_if { impl_id.is_local() }
         separate_provide_extern
     }
@@ -1130,35 +1130,35 @@ rustc_queries! {
     /// to either being one of the built-in unsized types (str/slice/dyn) or to be a struct
     /// whose tail is one of those types.
     query impl_self_is_guaranteed_unsized(impl_def_id: DefId) -> bool {
-        desc { |tcx| "computing whether `{}` has a guaranteed unsized self type", tcx.def_path_str(impl_def_id) }
+        desc { "computing whether `{}` has a guaranteed unsized self type", tcx.def_path_str(impl_def_id) }
     }
 
     /// Maps a `DefId` of a type to a list of its inherent impls.
     /// Contains implementations of methods that are inherent to a type.
     /// Methods in these implementations don't need to be exported.
     query inherent_impls(key: DefId) -> &'tcx [DefId] {
-        desc { |tcx| "collecting inherent impls for `{}`", tcx.def_path_str(key) }
+        desc { "collecting inherent impls for `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
     }
 
     query incoherent_impls(key: SimplifiedType) -> &'tcx [DefId] {
-        desc { |tcx| "collecting all inherent impls for `{:?}`", key }
+        desc { "collecting all inherent impls for `{:?}`", key }
     }
 
     /// Unsafety-check this `LocalDefId`.
     query check_transmutes(key: LocalDefId) {
-        desc { |tcx| "check transmute calls inside `{}`", tcx.def_path_str(key) }
+        desc { "check transmute calls inside `{}`", tcx.def_path_str(key) }
     }
 
     /// Unsafety-check this `LocalDefId`.
     query check_unsafety(key: LocalDefId) {
-        desc { |tcx| "unsafety-checking `{}`", tcx.def_path_str(key) }
+        desc { "unsafety-checking `{}`", tcx.def_path_str(key) }
     }
 
     /// Checks well-formedness of tail calls (`become f()`).
     query check_tail_calls(key: LocalDefId) -> Result<(), rustc_errors::ErrorGuaranteed> {
-        desc { |tcx| "tail-call-checking `{}`", tcx.def_path_str(key) }
+        desc { "tail-call-checking `{}`", tcx.def_path_str(key) }
         return_result_from_ensure_ok
     }
 
@@ -1167,19 +1167,19 @@ rustc_queries! {
     /// Note that we've liberated the late bound regions of function signatures, so
     /// this can not be used to check whether these types are well formed.
     query assumed_wf_types(key: LocalDefId) -> &'tcx [(Ty<'tcx>, Span)] {
-        desc { |tcx| "computing the implied bounds of `{}`", tcx.def_path_str(key) }
+        desc { "computing the implied bounds of `{}`", tcx.def_path_str(key) }
     }
 
     /// We need to store the assumed_wf_types for an RPITIT so that impls of foreign
     /// traits with return-position impl trait in traits can inherit the right wf types.
     query assumed_wf_types_for_rpitit(key: DefId) -> &'tcx [(Ty<'tcx>, Span)] {
-        desc { |tcx| "computing the implied bounds of `{}`", tcx.def_path_str(key) }
+        desc { "computing the implied bounds of `{}`", tcx.def_path_str(key) }
         separate_provide_extern
     }
 
     /// Computes the signature of the function.
     query fn_sig(key: DefId) -> ty::EarlyBinder<'tcx, ty::PolyFnSig<'tcx>> {
-        desc { |tcx| "computing function signature of `{}`", tcx.def_path_str(key) }
+        desc { "computing function signature of `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
         cycle_delay_bug
@@ -1187,7 +1187,7 @@ rustc_queries! {
 
     /// Performs lint checking for the module.
     query lint_mod(key: LocalModDefId) {
-        desc { |tcx| "linting {}", describe_as_module(key, tcx) }
+        desc { "linting {}", describe_as_module(key, tcx) }
     }
 
     query check_unused_traits(_: ()) {
@@ -1196,21 +1196,21 @@ rustc_queries! {
 
     /// Checks the attributes in the module.
     query check_mod_attrs(key: LocalModDefId) {
-        desc { |tcx| "checking attributes in {}", describe_as_module(key, tcx) }
+        desc { "checking attributes in {}", describe_as_module(key, tcx) }
     }
 
     /// Checks for uses of unstable APIs in the module.
     query check_mod_unstable_api_usage(key: LocalModDefId) {
-        desc { |tcx| "checking for unstable API usage in {}", describe_as_module(key, tcx) }
+        desc { "checking for unstable API usage in {}", describe_as_module(key, tcx) }
     }
 
     query check_mod_privacy(key: LocalModDefId) {
-        desc { |tcx| "checking privacy in {}", describe_as_module(key.to_local_def_id(), tcx) }
+        desc { "checking privacy in {}", describe_as_module(key.to_local_def_id(), tcx) }
     }
 
     query check_liveness(key: LocalDefId) -> &'tcx rustc_index::bit_set::DenseBitSet<abi::FieldIdx> {
         arena_cache
-        desc { |tcx| "checking liveness of variables in `{}`", tcx.def_path_str(key.to_def_id()) }
+        desc { "checking liveness of variables in `{}`", tcx.def_path_str(key.to_def_id()) }
         cache_on_disk_if(tcx) { tcx.is_typeck_child(key.to_def_id()) }
     }
 
@@ -1226,7 +1226,7 @@ rustc_queries! {
     }
 
     query check_mod_deathness(key: LocalModDefId) {
-        desc { |tcx| "checking deathness of variables in {}", describe_as_module(key, tcx) }
+        desc { "checking deathness of variables in {}", describe_as_module(key, tcx) }
     }
 
     query check_type_wf(key: ()) -> Result<(), ErrorGuaranteed> {
@@ -1236,24 +1236,24 @@ rustc_queries! {
 
     /// Caches `CoerceUnsized` kinds for impls on custom types.
     query coerce_unsized_info(key: DefId) -> Result<ty::adjustment::CoerceUnsizedInfo, ErrorGuaranteed> {
-        desc { |tcx| "computing CoerceUnsized info for `{}`", tcx.def_path_str(key) }
+        desc { "computing CoerceUnsized info for `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
         return_result_from_ensure_ok
     }
 
     query typeck(key: LocalDefId) -> &'tcx ty::TypeckResults<'tcx> {
-        desc { |tcx| "type-checking `{}`", tcx.def_path_str(key) }
+        desc { "type-checking `{}`", tcx.def_path_str(key) }
         cache_on_disk_if(tcx) { !tcx.is_typeck_child(key.to_def_id()) }
     }
 
     query used_trait_imports(key: LocalDefId) -> &'tcx UnordSet<LocalDefId> {
-        desc { |tcx| "finding used_trait_imports `{}`", tcx.def_path_str(key) }
+        desc { "finding used_trait_imports `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { true }
     }
 
     query coherent_trait(def_id: DefId) -> Result<(), ErrorGuaranteed> {
-        desc { |tcx| "coherence checking all impls of trait `{}`", tcx.def_path_str(def_id) }
+        desc { "coherence checking all impls of trait `{}`", tcx.def_path_str(def_id) }
         return_result_from_ensure_ok
     }
 
@@ -1263,7 +1263,7 @@ rustc_queries! {
         &'tcx FxIndexMap<LocalDefId, ty::DefinitionSiteHiddenType<'tcx>>,
         ErrorGuaranteed
     > {
-        desc { |tcx| "borrow-checking `{}`", tcx.def_path_str(key) }
+        desc { "borrow-checking `{}`", tcx.def_path_str(key) }
     }
 
     /// Gets a complete map from all types to their inherent impls.
@@ -1304,7 +1304,7 @@ rustc_queries! {
     /// Checks whether all impls in the crate pass the overlap check, returning
     /// which impls fail it. If all impls are correct, the returned slice is empty.
     query orphan_check_impl(key: LocalDefId) -> Result<(), ErrorGuaranteed> {
-        desc { |tcx|
+        desc {
             "checking whether impl `{}` follows the orphan rules",
             tcx.def_path_str(key),
         }
@@ -1316,7 +1316,7 @@ rustc_queries! {
     query mir_callgraph_cyclic(key: LocalDefId) -> &'tcx Option<UnordSet<LocalDefId>> {
         cycle_fatal
         arena_cache
-        desc { |tcx|
+        desc {
             "computing (transitive) callees of `{}` that may recurse",
             tcx.def_path_str(key),
         }
@@ -1326,7 +1326,7 @@ rustc_queries! {
     /// Obtain all the calls into other local functions
     query mir_inliner_callees(key: ty::InstanceKind<'tcx>) -> &'tcx [(DefId, GenericArgsRef<'tcx>)] {
         cycle_fatal
-        desc { |tcx|
+        desc {
             "computing all local function calls in `{}`",
             tcx.def_path_str(key.def_id()),
         }
@@ -1355,7 +1355,7 @@ rustc_queries! {
     /// </div>
     query eval_to_allocation_raw(key: ty::PseudoCanonicalInput<'tcx, GlobalId<'tcx>>)
         -> EvalToAllocationRawResult<'tcx> {
-        desc { |tcx|
+        desc {
             "const-evaluating + checking `{}`",
             key.value.display(tcx)
         }
@@ -1364,7 +1364,7 @@ rustc_queries! {
 
     /// Evaluate a static's initializer, returning the allocation of the initializer's memory.
     query eval_static_initializer(key: DefId) -> EvalStaticInitializerRawResult<'tcx> {
-        desc { |tcx|
+        desc {
             "evaluating initializer of static `{}`",
             tcx.def_path_str(key)
         }
@@ -1387,7 +1387,7 @@ rustc_queries! {
     /// [^1]: Such as enum variant explicit discriminants or array lengths.
     query eval_to_const_value_raw(key: ty::PseudoCanonicalInput<'tcx, GlobalId<'tcx>>)
         -> EvalToConstValueResult<'tcx> {
-        desc { |tcx|
+        desc {
             "simplifying constant for the type system `{}`",
             key.value.display(tcx)
         }
@@ -1416,7 +1416,7 @@ rustc_queries! {
     }
 
     query check_match(key: LocalDefId) -> Result<(), rustc_errors::ErrorGuaranteed> {
-        desc { |tcx| "match-checking `{}`", tcx.def_path_str(key) }
+        desc { "match-checking `{}`", tcx.def_path_str(key) }
         return_result_from_ensure_ok
     }
 
@@ -1426,7 +1426,7 @@ rustc_queries! {
         desc { "checking effective visibilities" }
     }
     query check_private_in_public(module_def_id: LocalModDefId) {
-        desc { |tcx|
+        desc {
             "checking for private elements in public interfaces for {}",
             describe_as_module(module_def_id, tcx)
         }
@@ -1441,14 +1441,14 @@ rustc_queries! {
     /// Per-body `region::ScopeTree`. The `DefId` should be the owner `DefId` for the body;
     /// in the case of closures, this will be redirected to the enclosing function.
     query region_scope_tree(def_id: DefId) -> &'tcx crate::middle::region::ScopeTree {
-        desc { |tcx| "computing drop scopes for `{}`", tcx.def_path_str(def_id) }
+        desc { "computing drop scopes for `{}`", tcx.def_path_str(def_id) }
     }
 
     /// Generates a MIR body for the shim.
     query mir_shims(key: ty::InstanceKind<'tcx>) -> &'tcx mir::Body<'tcx> {
         arena_cache
         desc {
-            |tcx| "generating MIR shim for `{}`, instance={:?}",
+            "generating MIR shim for `{}`, instance={:?}",
             tcx.def_path_str(key.def_id()),
             key
         }
@@ -1463,7 +1463,7 @@ rustc_queries! {
     }
 
     query def_kind(def_id: DefId) -> DefKind {
-        desc { |tcx| "looking up definition kind of `{}`", tcx.def_path_str(def_id) }
+        desc { "looking up definition kind of `{}`", tcx.def_path_str(def_id) }
         cache_on_disk_if { def_id.is_local() }
         separate_provide_extern
         feedable
@@ -1471,7 +1471,7 @@ rustc_queries! {
 
     /// Gets the span for the definition.
     query def_span(def_id: DefId) -> Span {
-        desc { |tcx| "looking up span for `{}`", tcx.def_path_str(def_id) }
+        desc { "looking up span for `{}`", tcx.def_path_str(def_id) }
         cache_on_disk_if { def_id.is_local() }
         separate_provide_extern
         feedable
@@ -1479,7 +1479,7 @@ rustc_queries! {
 
     /// Gets the span for the identifier of the definition.
     query def_ident_span(def_id: DefId) -> Option<Span> {
-        desc { |tcx| "looking up span for `{}`'s identifier", tcx.def_path_str(def_id) }
+        desc { "looking up span for `{}`'s identifier", tcx.def_path_str(def_id) }
         cache_on_disk_if { def_id.is_local() }
         separate_provide_extern
         feedable
@@ -1488,57 +1488,57 @@ rustc_queries! {
     /// Gets the span for the type of the definition.
     /// Panics if it is not a definition that has a single type.
     query ty_span(def_id: LocalDefId) -> Span {
-        desc { |tcx| "looking up span for `{}`'s type", tcx.def_path_str(def_id) }
+        desc { "looking up span for `{}`'s type", tcx.def_path_str(def_id) }
         cache_on_disk_if { true }
     }
 
     query lookup_stability(def_id: DefId) -> Option<hir::Stability> {
-        desc { |tcx| "looking up stability of `{}`", tcx.def_path_str(def_id) }
+        desc { "looking up stability of `{}`", tcx.def_path_str(def_id) }
         cache_on_disk_if { def_id.is_local() }
         separate_provide_extern
     }
 
     query lookup_const_stability(def_id: DefId) -> Option<hir::ConstStability> {
-        desc { |tcx| "looking up const stability of `{}`", tcx.def_path_str(def_id) }
+        desc { "looking up const stability of `{}`", tcx.def_path_str(def_id) }
         cache_on_disk_if { def_id.is_local() }
         separate_provide_extern
     }
 
     query lookup_default_body_stability(def_id: DefId) -> Option<hir::DefaultBodyStability> {
-        desc { |tcx| "looking up default body stability of `{}`", tcx.def_path_str(def_id) }
+        desc { "looking up default body stability of `{}`", tcx.def_path_str(def_id) }
         separate_provide_extern
     }
 
     query should_inherit_track_caller(def_id: DefId) -> bool {
-        desc { |tcx| "computing should_inherit_track_caller of `{}`", tcx.def_path_str(def_id) }
+        desc { "computing should_inherit_track_caller of `{}`", tcx.def_path_str(def_id) }
     }
 
     query inherited_align(def_id: DefId) -> Option<Align> {
-        desc { |tcx| "computing inherited_align of `{}`", tcx.def_path_str(def_id) }
+        desc { "computing inherited_align of `{}`", tcx.def_path_str(def_id) }
     }
 
     query lookup_deprecation_entry(def_id: DefId) -> Option<DeprecationEntry> {
-        desc { |tcx| "checking whether `{}` is deprecated", tcx.def_path_str(def_id) }
+        desc { "checking whether `{}` is deprecated", tcx.def_path_str(def_id) }
         cache_on_disk_if { def_id.is_local() }
         separate_provide_extern
     }
 
     /// Determines whether an item is annotated with `#[doc(hidden)]`.
     query is_doc_hidden(def_id: DefId) -> bool {
-        desc { |tcx| "checking whether `{}` is `doc(hidden)`", tcx.def_path_str(def_id) }
+        desc { "checking whether `{}` is `doc(hidden)`", tcx.def_path_str(def_id) }
         separate_provide_extern
     }
 
     /// Determines whether an item is annotated with `#[doc(notable_trait)]`.
     query is_doc_notable_trait(def_id: DefId) -> bool {
-        desc { |tcx| "checking whether `{}` is `doc(notable_trait)`", tcx.def_path_str(def_id) }
+        desc { "checking whether `{}` is `doc(notable_trait)`", tcx.def_path_str(def_id) }
     }
 
     /// Returns the attributes on the item at `def_id`.
     ///
     /// Do not use this directly, use `tcx.get_attrs` instead.
     query attrs_for_def(def_id: DefId) -> &'tcx [hir::Attribute] {
-        desc { |tcx| "collecting attributes of `{}`", tcx.def_path_str(def_id) }
+        desc { "collecting attributes of `{}`", tcx.def_path_str(def_id) }
         separate_provide_extern
     }
 
@@ -1552,7 +1552,7 @@ rustc_queries! {
     /// Using this query would include the attribute regardless of the actual instance
     /// kind at the call site.
     query codegen_fn_attrs(def_id: DefId) -> &'tcx CodegenFnAttrs {
-        desc { |tcx| "computing codegen attributes of `{}`", tcx.def_path_str(def_id) }
+        desc { "computing codegen attributes of `{}`", tcx.def_path_str(def_id) }
         arena_cache
         cache_on_disk_if { def_id.is_local() }
         separate_provide_extern
@@ -1560,11 +1560,11 @@ rustc_queries! {
     }
 
     query asm_target_features(def_id: DefId) -> &'tcx FxIndexSet<Symbol> {
-        desc { |tcx| "computing target features for inline asm of `{}`", tcx.def_path_str(def_id) }
+        desc { "computing target features for inline asm of `{}`", tcx.def_path_str(def_id) }
     }
 
     query fn_arg_idents(def_id: DefId) -> &'tcx [Option<rustc_span::Ident>] {
-        desc { |tcx| "looking up function parameter identifiers for `{}`", tcx.def_path_str(def_id) }
+        desc { "looking up function parameter identifiers for `{}`", tcx.def_path_str(def_id) }
         separate_provide_extern
     }
 
@@ -1572,23 +1572,23 @@ rustc_queries! {
     /// Used by rustdoc.
     query rendered_const(def_id: DefId) -> &'tcx String {
         arena_cache
-        desc { |tcx| "rendering constant initializer of `{}`", tcx.def_path_str(def_id) }
+        desc { "rendering constant initializer of `{}`", tcx.def_path_str(def_id) }
         separate_provide_extern
     }
 
     /// Gets the rendered precise capturing args for an opaque for use in rustdoc.
     query rendered_precise_capturing_args(def_id: DefId) -> Option<&'tcx [PreciseCapturingArgKind<Symbol, Symbol>]> {
-        desc { |tcx| "rendering precise capturing args for `{}`", tcx.def_path_str(def_id) }
+        desc { "rendering precise capturing args for `{}`", tcx.def_path_str(def_id) }
         separate_provide_extern
     }
 
     query impl_parent(def_id: DefId) -> Option<DefId> {
-        desc { |tcx| "computing specialization parent impl of `{}`", tcx.def_path_str(def_id) }
+        desc { "computing specialization parent impl of `{}`", tcx.def_path_str(def_id) }
         separate_provide_extern
     }
 
     query is_mir_available(key: DefId) -> bool {
-        desc { |tcx| "checking if item has MIR available: `{}`", tcx.def_path_str(key) }
+        desc { "checking if item has MIR available: `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
     }
@@ -1596,25 +1596,25 @@ rustc_queries! {
     query own_existential_vtable_entries(
         key: DefId
     ) -> &'tcx [DefId] {
-        desc { |tcx| "finding all existential vtable entries for trait `{}`", tcx.def_path_str(key) }
+        desc { "finding all existential vtable entries for trait `{}`", tcx.def_path_str(key) }
     }
 
     query vtable_entries(key: ty::TraitRef<'tcx>)
                         -> &'tcx [ty::VtblEntry<'tcx>] {
-        desc { |tcx| "finding all vtable entries for trait `{}`", tcx.def_path_str(key.def_id) }
+        desc { "finding all vtable entries for trait `{}`", tcx.def_path_str(key.def_id) }
     }
 
     query first_method_vtable_slot(key: ty::TraitRef<'tcx>) -> usize {
-        desc { |tcx| "finding the slot within the vtable of `{}` for the implementation of `{}`", key.self_ty(), key.print_only_trait_name() }
+        desc { "finding the slot within the vtable of `{}` for the implementation of `{}`", key.self_ty(), key.print_only_trait_name() }
     }
 
     query supertrait_vtable_slot(key: (Ty<'tcx>, Ty<'tcx>)) -> Option<usize> {
-        desc { |tcx| "finding the slot within vtable for trait object `{}` vtable ptr during trait upcasting coercion from `{}` vtable",
+        desc { "finding the slot within vtable for trait object `{}` vtable ptr during trait upcasting coercion from `{}` vtable",
             key.1, key.0 }
     }
 
     query vtable_allocation(key: (Ty<'tcx>, Option<ty::ExistentialTraitRef<'tcx>>)) -> mir::interpret::AllocId {
-        desc { |tcx| "vtable const allocation for <{} as {}>",
+        desc { "vtable const allocation for <{} as {}>",
             key.0,
             key.1.map(|trait_ref| format!("{trait_ref}")).unwrap_or_else(|| "_".to_owned())
         }
@@ -1624,7 +1624,7 @@ rustc_queries! {
         key: PseudoCanonicalInput<'tcx, ty::TraitRef<'tcx>>
     ) -> Result<&'tcx ImplSource<'tcx, ()>, CodegenObligationError> {
         cache_on_disk_if { true }
-        desc { |tcx| "computing candidate for `{}`", key.value }
+        desc { "computing candidate for `{}`", key.value }
     }
 
     /// Return all `impl` blocks in the current crate.
@@ -1640,19 +1640,19 @@ rustc_queries! {
     /// Given a trait `trait_id`, return all known `impl` blocks.
     query trait_impls_of(trait_id: DefId) -> &'tcx ty::trait_def::TraitImpls {
         arena_cache
-        desc { |tcx| "finding trait impls of `{}`", tcx.def_path_str(trait_id) }
+        desc { "finding trait impls of `{}`", tcx.def_path_str(trait_id) }
     }
 
     query specialization_graph_of(trait_id: DefId) -> Result<&'tcx specialization_graph::Graph, ErrorGuaranteed> {
-        desc { |tcx| "building specialization graph of trait `{}`", tcx.def_path_str(trait_id) }
+        desc { "building specialization graph of trait `{}`", tcx.def_path_str(trait_id) }
         cache_on_disk_if { true }
         return_result_from_ensure_ok
     }
     query dyn_compatibility_violations(trait_id: DefId) -> &'tcx [DynCompatibilityViolation] {
-        desc { |tcx| "determining dyn-compatibility of trait `{}`", tcx.def_path_str(trait_id) }
+        desc { "determining dyn-compatibility of trait `{}`", tcx.def_path_str(trait_id) }
     }
     query is_dyn_compatible(trait_id: DefId) -> bool {
-        desc { |tcx| "checking if trait `{}` is dyn-compatible", tcx.def_path_str(trait_id) }
+        desc { "checking if trait `{}` is dyn-compatible", tcx.def_path_str(trait_id) }
     }
 
     /// Gets the ParameterEnvironment for a given item; this environment
@@ -1664,7 +1664,7 @@ rustc_queries! {
     /// you should also probably have a `ParamEnv` from when it was built. If you don't,
     /// then you should take a `TypingEnv` to ensure that you handle opaque types correctly.
     query param_env(def_id: DefId) -> ty::ParamEnv<'tcx> {
-        desc { |tcx| "computing normalized predicates of `{}`", tcx.def_path_str(def_id) }
+        desc { "computing normalized predicates of `{}`", tcx.def_path_str(def_id) }
         feedable
     }
 
@@ -1672,7 +1672,7 @@ rustc_queries! {
     /// replaced with their hidden type. This is used in the old trait solver
     /// when in `PostAnalysis` mode and should not be called directly.
     query typing_env_normalized_for_post_analysis(def_id: DefId) -> ty::TypingEnv<'tcx> {
-        desc { |tcx| "computing revealed normalized predicates of `{}`", tcx.def_path_str(def_id) }
+        desc { "computing revealed normalized predicates of `{}`", tcx.def_path_str(def_id) }
     }
 
     /// Trait selection queries. These are best used by invoking `ty.is_copy_modulo_regions()`,
@@ -1733,7 +1733,7 @@ rustc_queries! {
     /// those types require drop. If the ADT is known to always need drop
     /// then `Err(AlwaysRequiresDrop)` is returned.
     query adt_drop_tys(def_id: DefId) -> Result<&'tcx ty::List<Ty<'tcx>>, AlwaysRequiresDrop> {
-        desc { |tcx| "computing when `{}` needs drop", tcx.def_path_str(def_id) }
+        desc { "computing when `{}` needs drop", tcx.def_path_str(def_id) }
         cache_on_disk_if { true }
     }
 
@@ -1741,7 +1741,7 @@ rustc_queries! {
     /// those types require async drop. If the ADT is known to always need async drop
     /// then `Err(AlwaysRequiresDrop)` is returned.
     query adt_async_drop_tys(def_id: DefId) -> Result<&'tcx ty::List<Ty<'tcx>>, AlwaysRequiresDrop> {
-        desc { |tcx| "computing when `{}` needs async drop", tcx.def_path_str(def_id) }
+        desc { "computing when `{}` needs async drop", tcx.def_path_str(def_id) }
         cache_on_disk_if { true }
     }
 
@@ -1752,7 +1752,7 @@ rustc_queries! {
     /// freeing up memory). If the ADT is known to have a significant destructor then
     /// `Err(AlwaysRequiresDrop)` is returned.
     query adt_significant_drop_tys(def_id: DefId) -> Result<&'tcx ty::List<Ty<'tcx>>, AlwaysRequiresDrop> {
-        desc { |tcx| "computing when `{}` has a significant destructor", tcx.def_path_str(def_id) }
+        desc { "computing when `{}` has a significant destructor", tcx.def_path_str(def_id) }
     }
 
     /// Returns a list of types which (a) have a potentially significant destructor
@@ -1773,7 +1773,7 @@ rustc_queries! {
     /// because this query partially depends on that query.
     /// Otherwise, there is a risk of query cycles.
     query list_significant_drop_tys(ty: ty::PseudoCanonicalInput<'tcx, Ty<'tcx>>) -> &'tcx ty::List<Ty<'tcx>> {
-        desc { |tcx| "computing when `{}` has a significant destructor", ty.value }
+        desc { "computing when `{}` has a significant destructor", ty.value }
     }
 
     /// Computes the layout of a type. Note that this implicitly
@@ -1849,7 +1849,7 @@ rustc_queries! {
         separate_provide_extern
     }
     query has_ffi_unwind_calls(key: LocalDefId) -> bool {
-        desc { |tcx| "checking if `{}` contains FFI-unwind calls", tcx.def_path_str(key) }
+        desc { "checking if `{}` contains FFI-unwind calls", tcx.def_path_str(key) }
         cache_on_disk_if { true }
     }
     query required_panic_strategy(_: CrateNum) -> Option<PanicStrategy> {
@@ -1895,24 +1895,24 @@ rustc_queries! {
     /// Returns whether the impl or associated function has the `default` keyword.
     /// Note: This will ICE on inherent impl items. Consider using `AssocItem::defaultness`.
     query defaultness(def_id: DefId) -> hir::Defaultness {
-        desc { |tcx| "looking up whether `{}` has `default`", tcx.def_path_str(def_id) }
+        desc { "looking up whether `{}` has `default`", tcx.def_path_str(def_id) }
         separate_provide_extern
         feedable
     }
 
     /// Returns whether the field corresponding to the `DefId` has a default field value.
     query default_field(def_id: DefId) -> Option<DefId> {
-        desc { |tcx| "looking up the `const` corresponding to the default for `{}`", tcx.def_path_str(def_id) }
+        desc { "looking up the `const` corresponding to the default for `{}`", tcx.def_path_str(def_id) }
         separate_provide_extern
     }
 
     query check_well_formed(key: LocalDefId) -> Result<(), ErrorGuaranteed> {
-        desc { |tcx| "checking that `{}` is well-formed", tcx.def_path_str(key) }
+        desc { "checking that `{}` is well-formed", tcx.def_path_str(key) }
         return_result_from_ensure_ok
     }
 
     query enforce_impl_non_lifetime_params_are_constrained(key: LocalDefId) -> Result<(), ErrorGuaranteed> {
-        desc { |tcx| "checking that `{}`'s generics are constrained by the impl header", tcx.def_path_str(key) }
+        desc { "checking that `{}`'s generics are constrained by the impl header", tcx.def_path_str(key) }
         return_result_from_ensure_ok
     }
 
@@ -1935,12 +1935,12 @@ rustc_queries! {
         separate_provide_extern
     }
     query is_reachable_non_generic(def_id: DefId) -> bool {
-        desc { |tcx| "checking whether `{}` is an exported symbol", tcx.def_path_str(def_id) }
+        desc { "checking whether `{}` is an exported symbol", tcx.def_path_str(def_id) }
         cache_on_disk_if { def_id.is_local() }
         separate_provide_extern
     }
     query is_unreachable_local_definition(def_id: LocalDefId) -> bool {
-        desc { |tcx|
+        desc {
             "checking whether `{}` is reachable from outside the crate",
             tcx.def_path_str(def_id),
         }
@@ -1968,7 +1968,7 @@ rustc_queries! {
     query upstream_monomorphizations_for(def_id: DefId)
         -> Option<&'tcx UnordMap<GenericArgsRef<'tcx>, CrateNum>>
     {
-        desc { |tcx|
+        desc {
             "collecting available upstream monomorphizations for `{}`",
             tcx.def_path_str(def_id),
         }
@@ -2086,13 +2086,13 @@ rustc_queries! {
     /// Do not call this directly, but instead use the `incoherent_impls` query.
     /// This query is only used to get the data necessary for that query.
     query crate_incoherent_impls(key: (CrateNum, SimplifiedType)) -> &'tcx [DefId] {
-        desc { |tcx| "collecting all impls for a type in a crate" }
+        desc { "collecting all impls for a type in a crate" }
         separate_provide_extern
     }
 
     /// Get the corresponding native library from the `native_libraries` query
     query native_library(def_id: DefId) -> Option<&'tcx NativeLib> {
-        desc { |tcx| "getting the native library for `{}`", tcx.def_path_str(def_id) }
+        desc { "getting the native library for `{}`", tcx.def_path_str(def_id) }
     }
 
     query inherit_sig_for_delegation_item(def_id: LocalDefId) -> &'tcx [Ty<'tcx>] {
@@ -2104,13 +2104,13 @@ rustc_queries! {
     /// See `rustc_resolve::late::lifetimes` for details.
     query resolve_bound_vars(owner_id: hir::OwnerId) -> &'tcx ResolveBoundVars<'tcx> {
         arena_cache
-        desc { |tcx| "resolving lifetimes for `{}`", tcx.def_path_str(owner_id) }
+        desc { "resolving lifetimes for `{}`", tcx.def_path_str(owner_id) }
     }
     query named_variable_map(owner_id: hir::OwnerId) -> &'tcx SortedMap<ItemLocalId, ResolvedArg> {
-        desc { |tcx| "looking up a named region inside `{}`", tcx.def_path_str(owner_id) }
+        desc { "looking up a named region inside `{}`", tcx.def_path_str(owner_id) }
     }
     query is_late_bound_map(owner_id: hir::OwnerId) -> Option<&'tcx FxIndexSet<ItemLocalId>> {
-        desc { |tcx| "testing if a region is late bound inside `{}`", tcx.def_path_str(owner_id) }
+        desc { "testing if a region is late bound inside `{}`", tcx.def_path_str(owner_id) }
     }
     /// Returns the *default lifetime* to be used if a trait object type were to be passed for
     /// the type parameter given by `DefId`.
@@ -2132,7 +2132,7 @@ rustc_queries! {
     }
     query late_bound_vars_map(owner_id: hir::OwnerId)
         -> &'tcx SortedMap<ItemLocalId, Vec<ty::BoundVariableKind<'tcx>>> {
-        desc { |tcx| "looking up late bound vars inside `{}`", tcx.def_path_str(owner_id) }
+        desc { "looking up late bound vars inside `{}`", tcx.def_path_str(owner_id) }
     }
     /// For an opaque type, return the list of (captured lifetime, inner generic param).
     /// ```ignore (illustrative)
@@ -2149,7 +2149,7 @@ rustc_queries! {
     ///                                                       ^^^^^^ captured lifetimes
     /// ```
     query opaque_captured_lifetimes(def_id: LocalDefId) -> &'tcx [(ResolvedArg, LocalDefId)] {
-        desc { |tcx| "listing captured lifetimes for opaque `{}`", tcx.def_path_str(def_id) }
+        desc { "listing captured lifetimes for opaque `{}`", tcx.def_path_str(def_id) }
     }
 
     /// Computes the visibility of the provided `def_id`.
@@ -2165,7 +2165,7 @@ rustc_queries! {
     ///
     /// In here, if you call `visibility` on `T`, it'll panic.
     query visibility(def_id: DefId) -> ty::Visibility<DefId> {
-        desc { |tcx| "computing visibility of `{}`", tcx.def_path_str(def_id) }
+        desc { "computing visibility of `{}`", tcx.def_path_str(def_id) }
         separate_provide_extern
         feedable
     }
@@ -2192,7 +2192,7 @@ rustc_queries! {
         separate_provide_extern
     }
     query module_children(def_id: DefId) -> &'tcx [ModChild] {
-        desc { |tcx| "collecting child items of module `{}`", tcx.def_path_str(def_id) }
+        desc { "collecting child items of module `{}`", tcx.def_path_str(def_id) }
         separate_provide_extern
     }
 
@@ -2230,7 +2230,7 @@ rustc_queries! {
     }
     /// Whether the function is an intrinsic
     query intrinsic_raw(def_id: DefId) -> Option<rustc_middle::ty::IntrinsicDef> {
-        desc { |tcx| "fetch intrinsic name if `{}` is an intrinsic", tcx.def_path_str(def_id) }
+        desc { "fetch intrinsic name if `{}` is an intrinsic", tcx.def_path_str(def_id) }
         separate_provide_extern
     }
     /// Returns the lang items defined in another crate by loading it from metadata.
@@ -2323,7 +2323,7 @@ rustc_queries! {
     }
 
     query upvars_mentioned(def_id: DefId) -> Option<&'tcx FxIndexMap<hir::HirId, hir::Upvar>> {
-        desc { |tcx| "collecting upvars mentioned in `{}`", tcx.def_path_str(def_id) }
+        desc { "collecting upvars mentioned in `{}`", tcx.def_path_str(def_id) }
     }
 
     /// All available crates in the graph, including those that should not be user-facing
@@ -2406,7 +2406,7 @@ rustc_queries! {
     }
 
     query is_codegened_item(def_id: DefId) -> bool {
-        desc { |tcx| "determining whether `{}` needs codegen", tcx.def_path_str(def_id) }
+        desc { "determining whether `{}` needs codegen", tcx.def_path_str(def_id) }
     }
 
     query codegen_unit(sym: Symbol) -> &'tcx CodegenUnit<'tcx> {
@@ -2565,14 +2565,14 @@ rustc_queries! {
     }
 
     query instantiate_and_check_impossible_predicates(key: (DefId, GenericArgsRef<'tcx>)) -> bool {
-        desc { |tcx|
+        desc {
             "checking impossible instantiated predicates: `{}`",
             tcx.def_path_str(key.0)
         }
     }
 
     query is_impossible_associated_item(key: (DefId, DefId)) -> bool {
-        desc { |tcx|
+        desc {
             "checking if `{}` is impossible to reference within `{}`",
             tcx.def_path_str(key.1),
             tcx.def_path_str(key.0),
@@ -2674,12 +2674,12 @@ rustc_queries! {
     ///
     /// Any other def id will ICE.
     query compare_impl_item(key: LocalDefId) -> Result<(), ErrorGuaranteed> {
-        desc { |tcx| "checking assoc item `{}` is compatible with trait definition", tcx.def_path_str(key) }
+        desc { "checking assoc item `{}` is compatible with trait definition", tcx.def_path_str(key) }
         return_result_from_ensure_ok
     }
 
     query deduced_param_attrs(def_id: DefId) -> &'tcx [DeducedParamAttrs] {
-        desc { |tcx| "deducing parameter attributes for {}", tcx.def_path_str(def_id) }
+        desc { "deducing parameter attributes for {}", tcx.def_path_str(def_id) }
         separate_provide_extern
     }
 
@@ -2736,12 +2736,12 @@ rustc_queries! {
     }
 
     query anon_const_kind(def_id: DefId) -> ty::AnonConstKind {
-        desc { |tcx| "looking up anon const kind of `{}`", tcx.def_path_str(def_id) }
+        desc { "looking up anon const kind of `{}`", tcx.def_path_str(def_id) }
         separate_provide_extern
     }
 
     query trivial_const(def_id: DefId) -> Option<(mir::ConstValue, Ty<'tcx>)> {
-        desc { |tcx| "checking if `{}` is a trivial const", tcx.def_path_str(def_id) }
+        desc { "checking if `{}` is a trivial const", tcx.def_path_str(def_id) }
         cache_on_disk_if { def_id.is_local() }
         separate_provide_extern
     }
@@ -2752,7 +2752,7 @@ rustc_queries! {
     ///
     /// Returns the sanitizer settings for this def.
     query sanitizer_settings_for(key: LocalDefId) -> SanitizerFnAttrs {
-        desc { |tcx| "checking what set of sanitizers are enabled on `{}`", tcx.def_path_str(key) }
+        desc { "checking what set of sanitizers are enabled on `{}`", tcx.def_path_str(key) }
         feedable
     }
 
@@ -2769,7 +2769,7 @@ rustc_queries! {
     }
 
     query is_rhs_type_const(def_id: DefId) -> bool {
-        desc { |tcx| "checking whether `{}` is a rhs type const", tcx.def_path_str(def_id) }
+        desc { "checking whether `{}` is a rhs type const", tcx.def_path_str(def_id) }
         cache_on_disk_if { def_id.is_local() }
         separate_provide_extern
     }

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -589,7 +589,7 @@ rustc_queries! {
     }
 
     /// Checks whether a type is representable or infinitely sized
-    query representability(_: LocalDefId) -> rustc_middle::ty::Representability {
+    query representability(key: LocalDefId) -> rustc_middle::ty::Representability {
         desc { "checking if `{}` is representable", tcx.def_path_str(key) }
         // infinitely sized types will cause a cycle
         cycle_delay_bug
@@ -600,7 +600,7 @@ rustc_queries! {
     }
 
     /// An implementation detail for the `representability` query
-    query representability_adt_ty(_: Ty<'tcx>) -> rustc_middle::ty::Representability {
+    query representability_adt_ty(key: Ty<'tcx>) -> rustc_middle::ty::Representability {
         desc { "checking if `{}` is representable", key }
         cycle_delay_bug
         anon

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -25,9 +25,13 @@
 //! Query modifiers are special flags that alter the behavior of a query. They are parsed and processed by the `rustc_macros`
 //! The main modifiers are:
 //!
-//! - `desc { ... }`: Sets the human-readable description for diagnostics and profiling. Required for every query.
+//! - `desc { ... }`: Sets the human-readable description for diagnostics and profiling. Required
+//!   for every query. The block should contain a `format!`-style string literal followed by
+//!   optional arguments. The query key identifier is available for use within the block, as is
+//!   `tcx`.
 //! - `arena_cache`: Use an arena for in-memory caching of the query result.
-//! - `cache_on_disk_if { ... }`: Cache the query result to disk if the provided block evaluates to true.
+//! - `cache_on_disk_if { ... }`: Cache the query result to disk if the provided block evaluates to
+//!   true. The query key identifier is available for use within the block, as is `tcx`.
 //! - `cycle_fatal`: If a dependency cycle is detected, abort compilation with a fatal error.
 //! - `cycle_delay_bug`: If a dependency cycle is detected, emit a delayed bug instead of aborting immediately.
 //! - `cycle_stash`: If a dependency cycle is detected, stash the error for later handling.
@@ -1211,7 +1215,7 @@ rustc_queries! {
     query check_liveness(key: LocalDefId) -> &'tcx rustc_index::bit_set::DenseBitSet<abi::FieldIdx> {
         arena_cache
         desc { "checking liveness of variables in `{}`", tcx.def_path_str(key.to_def_id()) }
-        cache_on_disk_if(tcx) { tcx.is_typeck_child(key.to_def_id()) }
+        cache_on_disk_if { tcx.is_typeck_child(key.to_def_id()) }
     }
 
     /// Return the live symbols in the crate for dead code check.
@@ -1244,7 +1248,7 @@ rustc_queries! {
 
     query typeck(key: LocalDefId) -> &'tcx ty::TypeckResults<'tcx> {
         desc { "type-checking `{}`", tcx.def_path_str(key) }
-        cache_on_disk_if(tcx) { !tcx.is_typeck_child(key.to_def_id()) }
+        cache_on_disk_if { !tcx.is_typeck_child(key.to_def_id()) }
     }
 
     query used_trait_imports(key: LocalDefId) -> &'tcx UnordSet<LocalDefId> {


### PR DESCRIPTION
Queries have two ways of specifying code snippets, in `desc` and `cache_on_disk_if` blocks. An example:
```rust
query check_liveness(key: LocalDefId) -> &'tcx rustc_index::bit_set::DenseBitSet<abi::FieldIdx> {
    arena_cache
    desc { |tcx| "checking liveness of variables in `{}`", tcx.def_path_str(key.to_def_id()) }
    cache_on_disk_if(tcx) { tcx.is_typeck_child(key.to_def_id()) }
}
```
If you need to use `tcx` in the snippet, you can use an explicit binding. But there are multiple problems with this.

- The syntax used is different in the two snippets: `|tcx|` within the block vs. `(tcx)` outside the block. (!!)
- Bug 1: In `desc` snippets you can leave out the `|tcx|` and still use `tcx`. Several existing queries do this.
- Bug 2: In `desc` snippets you can always use `key` in the snippet to refer to the key, even if that's not the identifier used in the query head.
- Finally, you can bind `tcx` and not use it, without a warning. Several existing queries do this.

I think explicit `tcx` binding is silly. Many queries need `tcx` and this macro is already super-magical, so just making `tcx` implicitly available seems fine, rather than making the query writer jump through a little syntactic hoop. This makes both the query definitions and the proc macro simpler.

r? @petrochenkov 