### PR TITLE
Revert "Stabilize `str_as_str`"

### DIFF
--- a/library/alloctests/tests/lib.rs
+++ b/library/alloctests/tests/lib.rs
@@ -33,6 +33,7 @@
 #![feature(thin_box)]
 #![feature(drain_keep_rest)]
 #![feature(local_waker)]
+#![feature(str_as_str)]
 #![feature(strict_provenance_lints)]
 #![feature(string_replace_in_place)]
 #![feature(vec_deque_truncate_front)]

--- a/library/core/src/bstr/mod.rs
+++ b/library/core/src/bstr/mod.rs
@@ -74,6 +74,7 @@ impl ByteStr {
     /// it helps dereferencing other "container" types,
     /// for example `Box<ByteStr>` or `Arc<ByteStr>`.
     #[inline]
+    // #[unstable(feature = "str_as_str", issue = "130366")]
     #[unstable(feature = "bstr", issue = "134915")]
     pub const fn as_byte_str(&self) -> &ByteStr {
         self
@@ -85,6 +86,7 @@ impl ByteStr {
     /// it helps dereferencing other "container" types,
     /// for example `Box<ByteStr>` or `MutexGuard<ByteStr>`.
     #[inline]
+    // #[unstable(feature = "str_as_str", issue = "130366")]
     #[unstable(feature = "bstr", issue = "134915")]
     pub const fn as_mut_byte_str(&mut self) -> &mut ByteStr {
         self

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -655,8 +655,7 @@ impl CStr {
     /// it helps dereferencing other string-like types to string slices,
     /// for example references to `Box<CStr>` or `Arc<CStr>`.
     #[inline]
-    #[stable(feature = "str_as_str", since = "CURRENT_RUSTC_VERSION")]
-    #[rustc_const_stable(feature = "str_as_str", since = "CURRENT_RUSTC_VERSION")]
+    #[unstable(feature = "str_as_str", issue = "130366")]
     pub const fn as_c_str(&self) -> &CStr {
         self
     }

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -5337,8 +5337,7 @@ impl<T> [T] {
     /// it helps dereferencing other "container" types to slices,
     /// for example `Box<[T]>` or `Arc<[T]>`.
     #[inline]
-    #[stable(feature = "str_as_str", since = "CURRENT_RUSTC_VERSION")]
-    #[rustc_const_stable(feature = "str_as_str", since = "CURRENT_RUSTC_VERSION")]
+    #[unstable(feature = "str_as_str", issue = "130366")]
     pub const fn as_slice(&self) -> &[T] {
         self
     }
@@ -5349,8 +5348,7 @@ impl<T> [T] {
     /// it helps dereferencing other "container" types to slices,
     /// for example `Box<[T]>` or `MutexGuard<[T]>`.
     #[inline]
-    #[stable(feature = "str_as_str", since = "CURRENT_RUSTC_VERSION")]
-    #[rustc_const_stable(feature = "str_as_str", since = "CURRENT_RUSTC_VERSION")]
+    #[unstable(feature = "str_as_str", issue = "130366")]
     pub const fn as_mut_slice(&mut self) -> &mut [T] {
         self
     }

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -3137,8 +3137,7 @@ impl str {
     /// it helps dereferencing other string-like types to string slices,
     /// for example references to `Box<str>` or `Arc<str>`.
     #[inline]
-    #[stable(feature = "str_as_str", since = "CURRENT_RUSTC_VERSION")]
-    #[rustc_const_stable(feature = "str_as_str", since = "CURRENT_RUSTC_VERSION")]
+    #[unstable(feature = "str_as_str", issue = "130366")]
     pub const fn as_str(&self) -> &str {
         self
     }

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -1285,8 +1285,7 @@ impl OsStr {
     /// it helps dereferencing other string-like types to string slices,
     /// for example references to `Box<OsStr>` or `Arc<OsStr>`.
     #[inline]
-    #[stable(feature = "str_as_str", since = "CURRENT_RUSTC_VERSION")]
-    #[rustc_const_stable(feature = "str_as_str", since = "CURRENT_RUSTC_VERSION")]
+    #[unstable(feature = "str_as_str", issue = "130366")]
     pub const fn as_os_str(&self) -> &OsStr {
         self
     }

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -3235,8 +3235,7 @@ impl Path {
     /// it helps dereferencing other `PathBuf`-like types to `Path`s,
     /// for example references to `Box<Path>` or `Arc<Path>`.
     #[inline]
-    #[stable(feature = "str_as_str", since = "CURRENT_RUSTC_VERSION")]
-    #[rustc_const_stable(feature = "str_as_str", since = "CURRENT_RUSTC_VERSION")]
+    #[unstable(feature = "str_as_str", issue = "130366")]
     pub const fn as_path(&self) -> &Path {
         self
     }

--- a/tests/ui/resolve/slice-as-slice.rs
+++ b/tests/ui/resolve/slice-as-slice.rs
@@ -1,0 +1,26 @@
+//@ check-pass
+// This is a regression test for github.com/rust-lang/rust/issues/152961
+// This broke when a method `as_slice` was added on slices
+// This pattern is used in the `rgb` crate
+
+struct Meow;
+
+trait ComponentSlice<T> {
+    fn as_slice(&self) -> &[T];
+}
+
+impl ComponentSlice<u8> for [Meow] {
+    fn as_slice(&self) -> &[u8] {
+        todo!()
+    }
+}
+
+fn a(data: &[Meow]) {
+    b(data.as_slice());
+    //~^ WARN a method with this name may be added to the standard library in the future
+    //~| WARN once this associated item is added to the standard library, the ambiguity may cause an error or change in behavior!
+}
+
+fn b(_b: &[u8]) { }
+
+fn main() {}

--- a/tests/ui/resolve/slice-as-slice.stderr
+++ b/tests/ui/resolve/slice-as-slice.stderr
@@ -1,0 +1,17 @@
+warning: a method with this name may be added to the standard library in the future
+  --> $DIR/slice-as-slice.rs:19:12
+   |
+LL |     b(data.as_slice());
+   |            ^^^^^^^^
+   |
+   = warning: once this associated item is added to the standard library, the ambiguity may cause an error or change in behavior!
+   = note: for more information, see issue #48919 <https://github.com/rust-lang/rust/issues/48919>
+   = help: call with fully qualified syntax `ComponentSlice::as_slice(...)` to keep using the current method
+   = note: `#[warn(unstable_name_collisions)]` (part of `#[warn(future_incompatible)]`) on by default
+help: add `#![feature(str_as_str)]` to the crate attributes to enable `core::slice::<impl [T]>::as_slice`
+   |
+LL + #![feature(str_as_str)]
+   |
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Reverts https://github.com/rust-lang/rust/pull/151603, clean revert.
Fixes https://github.com/rust-lang/rust/issues/152961

