### PR TITLE
[DO NOT MERGE] Revert "Revert "Stabilize `str_as_str`""

### DIFF
--- a/library/alloctests/tests/lib.rs
+++ b/library/alloctests/tests/lib.rs
@@ -33,7 +33,6 @@
 #![feature(thin_box)]
 #![feature(drain_keep_rest)]
 #![feature(local_waker)]
-#![feature(str_as_str)]
 #![feature(strict_provenance_lints)]
 #![feature(string_replace_in_place)]
 #![feature(vec_deque_truncate_front)]

--- a/library/core/src/bstr/mod.rs
+++ b/library/core/src/bstr/mod.rs
@@ -74,7 +74,6 @@ impl ByteStr {
     /// it helps dereferencing other "container" types,
     /// for example `Box<ByteStr>` or `Arc<ByteStr>`.
     #[inline]
-    // #[unstable(feature = "str_as_str", issue = "130366")]
     #[unstable(feature = "bstr", issue = "134915")]
     pub const fn as_byte_str(&self) -> &ByteStr {
         self
@@ -86,7 +85,6 @@ impl ByteStr {
     /// it helps dereferencing other "container" types,
     /// for example `Box<ByteStr>` or `MutexGuard<ByteStr>`.
     #[inline]
-    // #[unstable(feature = "str_as_str", issue = "130366")]
     #[unstable(feature = "bstr", issue = "134915")]
     pub const fn as_mut_byte_str(&mut self) -> &mut ByteStr {
         self

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -655,7 +655,8 @@ impl CStr {
     /// it helps dereferencing other string-like types to string slices,
     /// for example references to `Box<CStr>` or `Arc<CStr>`.
     #[inline]
-    #[unstable(feature = "str_as_str", issue = "130366")]
+    #[stable(feature = "str_as_str", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "str_as_str", since = "CURRENT_RUSTC_VERSION")]
     pub const fn as_c_str(&self) -> &CStr {
         self
     }

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -5337,7 +5337,8 @@ impl<T> [T] {
     /// it helps dereferencing other "container" types to slices,
     /// for example `Box<[T]>` or `Arc<[T]>`.
     #[inline]
-    #[unstable(feature = "str_as_str", issue = "130366")]
+    #[stable(feature = "str_as_str", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "str_as_str", since = "CURRENT_RUSTC_VERSION")]
     pub const fn as_slice(&self) -> &[T] {
         self
     }
@@ -5348,7 +5349,8 @@ impl<T> [T] {
     /// it helps dereferencing other "container" types to slices,
     /// for example `Box<[T]>` or `MutexGuard<[T]>`.
     #[inline]
-    #[unstable(feature = "str_as_str", issue = "130366")]
+    #[stable(feature = "str_as_str", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "str_as_str", since = "CURRENT_RUSTC_VERSION")]
     pub const fn as_mut_slice(&mut self) -> &mut [T] {
         self
     }

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -3137,7 +3137,8 @@ impl str {
     /// it helps dereferencing other string-like types to string slices,
     /// for example references to `Box<str>` or `Arc<str>`.
     #[inline]
-    #[unstable(feature = "str_as_str", issue = "130366")]
+    #[stable(feature = "str_as_str", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "str_as_str", since = "CURRENT_RUSTC_VERSION")]
     pub const fn as_str(&self) -> &str {
         self
     }

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -1285,7 +1285,8 @@ impl OsStr {
     /// it helps dereferencing other string-like types to string slices,
     /// for example references to `Box<OsStr>` or `Arc<OsStr>`.
     #[inline]
-    #[unstable(feature = "str_as_str", issue = "130366")]
+    #[stable(feature = "str_as_str", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "str_as_str", since = "CURRENT_RUSTC_VERSION")]
     pub const fn as_os_str(&self) -> &OsStr {
         self
     }

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -3235,7 +3235,8 @@ impl Path {
     /// it helps dereferencing other `PathBuf`-like types to `Path`s,
     /// for example references to `Box<Path>` or `Arc<Path>`.
     #[inline]
-    #[unstable(feature = "str_as_str", issue = "130366")]
+    #[stable(feature = "str_as_str", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "str_as_str", since = "CURRENT_RUSTC_VERSION")]
     pub const fn as_path(&self) -> &Path {
         self
     }


### PR DESCRIPTION
- Tracking issue: rust-lang/rust#130366.
- Was stabilized in rust-lang/rust#151603.
- Caused a regression: rust-lang/rust#152961.
- Stabilization is being reverted in rust-lang/rust#152963.

The PR is based on top of rust-lang/rust#152963 and re-stabilizes the feature, because I want to try a crater run and see if there are things other than `rgb` being broken by this feature.

CI is going to fail on the regression test added in rust-lang/rust#152963.

I don't have enough rights to start a crater run myself, so I ask someone who _can_ do it to start a crater run with the baseline of rust-lang/rust#152963 after it gets merged.

Or right now with the baseline of 99246f40931ce1d1d29517b61bd70dd9ed4fbe5d (AKA rust-lang/rust#152896, AKA the latest master before the stabilization PR (rust-lang/rust#151603) was merged in a rollup (rust-lang/rust#152934)).

@rustbot label -T-compiler +T-libs-api