### PR TITLE
implement PartialEq<VecDeque<U>> for Vec<T>, &[T], &mut [T], [T; N], &[T; N] and &mut [T; N]

### DIFF
--- a/library/alloc/src/collections/vec_deque/macros.rs
+++ b/library/alloc/src/collections/vec_deque/macros.rs
@@ -17,3 +17,23 @@ macro_rules! __impl_slice_eq1 {
         }
     }
 }
+
+macro_rules! __impl_slice_eq2 {
+    ([$($vars:tt)*] $lhs:ty, $rhs:ty, $($constraints:tt)*) => {
+        #[stable(feature = "vec_deque_partial_eq_slice", since = "1.17.0")]
+        impl<T, U, A: Allocator, $($vars)*> PartialEq<$rhs> for $lhs
+        where
+            T: PartialEq<U>,
+            $($constraints)*
+        {
+            fn eq(&self, other: &$rhs) -> bool {
+                if self.len() != other.len() {
+                    return false;
+                }
+                let (oa, ob) = other.as_slices();
+                let (sa, sb) = self[..].split_at(oa.len());
+                sa == oa && sb == ob
+            }
+        }
+    }
+}

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -3589,6 +3589,13 @@ __impl_slice_eq1! { [const N: usize] VecDeque<T, A>, [U; N], }
 __impl_slice_eq1! { [const N: usize] VecDeque<T, A>, &[U; N], }
 __impl_slice_eq1! { [const N: usize] VecDeque<T, A>, &mut [U; N], }
 
+__impl_slice_eq2! { [] Vec<T, A>, VecDeque<U, A>, }
+__impl_slice_eq2! { [] &[T], VecDeque<U, A>, }
+__impl_slice_eq2! { [] &mut [T], VecDeque<U, A>, }
+__impl_slice_eq2! { [const N: usize] [T; N], VecDeque<U, A>, }
+__impl_slice_eq2! { [const N: usize] &[T; N], VecDeque<U, A>, }
+__impl_slice_eq2! { [const N: usize] &mut [T; N], VecDeque<U, A>, }
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: PartialOrd, A: Allocator> PartialOrd for VecDeque<T, A> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -3836,6 +3836,13 @@ __impl_slice_eq1! { [const N: usize] VecDeque<T, A>, [U; N], }
 __impl_slice_eq1! { [const N: usize] VecDeque<T, A>, &[U; N], }
 __impl_slice_eq1! { [const N: usize] VecDeque<T, A>, &mut [U; N], }
 
+__impl_slice_eq2! { [] Vec<T, A>, VecDeque<U, A>, }
+__impl_slice_eq2! { [] &[T], VecDeque<U, A>, }
+__impl_slice_eq2! { [] &mut [T], VecDeque<U, A>, }
+__impl_slice_eq2! { [const N: usize] [T; N], VecDeque<U, A>, }
+__impl_slice_eq2! { [const N: usize] &[T; N], VecDeque<U, A>, }
+__impl_slice_eq2! { [const N: usize] &mut [T; N], VecDeque<U, A>, }
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: PartialOrd, A: Allocator> PartialOrd for VecDeque<T, A> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {

--- a/library/alloctests/tests/vec_deque.rs
+++ b/library/alloctests/tests/vec_deque.rs
@@ -631,6 +631,27 @@ fn test_partial_eq_array() {
 }
 
 #[test]
+fn test_partial_eq_vecdeque_reverse() {
+    let mut d = VecDeque::with_capacity(4);
+    d.push_back(1);
+    d.push_back(2);
+    d.push_back(3);
+    d.pop_front();
+    d.push_back(4);
+
+    let v = vec![2, 3, 4];
+    let a = [2, 3, 4];
+    let mut b = [2, 3, 4];
+
+    assert!(v == d);
+    assert!(&v[..] == d);
+    assert!(&mut b[..] == d);
+    assert!(a == d);
+    assert!(&a == d);
+    assert!(&mut b == d);
+}
+
+#[test]
 fn test_hash() {
     let mut x = VecDeque::new();
     let mut y = VecDeque::new();

--- a/library/alloctests/tests/vec_deque.rs
+++ b/library/alloctests/tests/vec_deque.rs
@@ -632,6 +632,27 @@ fn test_partial_eq_array() {
 }
 
 #[test]
+fn test_partial_eq_vecdeque_reverse() {
+    let mut d = VecDeque::with_capacity(4);
+    d.push_back(1);
+    d.push_back(2);
+    d.push_back(3);
+    d.pop_front();
+    d.push_back(4);
+
+    let v = vec![2, 3, 4];
+    let a = [2, 3, 4];
+    let mut b = [2, 3, 4];
+
+    assert!(v == d);
+    assert!(&v[..] == d);
+    assert!(&mut b[..] == d);
+    assert!(a == d);
+    assert!(&a == d);
+    assert!(&mut b == d);
+}
+
+#[test]
 fn test_hash() {
     let mut x = VecDeque::new();
     let mut y = VecDeque::new();

--- a/tests/ui/consts/too_generic_eval_ice.current.stderr
+++ b/tests/ui/consts/too_generic_eval_ice.current.stderr
@@ -30,15 +30,15 @@ LL |         [5; Self::HOST_SIZE] == [6; 0]
    |
    = help: the trait `PartialEq<[{integer}; 0]>` is not implemented for `[{integer}; Self::HOST_SIZE]`
    = help: the following other types implement trait `PartialEq<Rhs>`:
+             `&[T; N]` implements `PartialEq<VecDeque<U, A>>`
              `&[T]` implements `PartialEq<Vec<U, A>>`
+             `&[T]` implements `PartialEq<VecDeque<U, A>>`
              `&[T]` implements `PartialEq<[U; N]>`
              `&[u8; N]` implements `PartialEq<ByteStr>`
              `&[u8; N]` implements `PartialEq<ByteString>`
              `&[u8]` implements `PartialEq<ByteStr>`
              `&[u8]` implements `PartialEq<ByteString>`
-             `&mut [T]` implements `PartialEq<Vec<U, A>>`
-             `&mut [T]` implements `PartialEq<[U; N]>`
-           and 11 others
+           and 16 others
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/consts/too_generic_eval_ice.current.stderr
+++ b/tests/ui/consts/too_generic_eval_ice.current.stderr
@@ -30,15 +30,15 @@ LL |         [5; Self::HOST_SIZE] == [6; 0]
    |
    = help: the trait `PartialEq<[{integer}; 0]>` is not implemented for `[{integer}; Self::HOST_SIZE]`
    = help: the following other types implement trait `PartialEq<Rhs>`:
+             `&[T; N]` implements `PartialEq<VecDeque<U, A>>`
              `&[T]` implements `PartialEq<Cow<'_, [U]>>`
              `&[T]` implements `PartialEq<Vec<U, A>>`
+             `&[T]` implements `PartialEq<VecDeque<U, A>>`
              `&[T]` implements `PartialEq<[U; N]>`
              `&[u8; N]` implements `PartialEq<ByteStr>`
              `&[u8; N]` implements `PartialEq<ByteString>`
              `&[u8]` implements `PartialEq<ByteStr>`
-             `&[u8]` implements `PartialEq<ByteString>`
-             `&mut [T]` implements `PartialEq<Cow<'_, [U]>>`
-           and 13 others
+           and 18 others
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/macros/assert-ne-no-invalid-help-issue-146204.stderr
+++ b/tests/ui/macros/assert-ne-no-invalid-help-issue-146204.stderr
@@ -6,15 +6,15 @@ LL |     assert_ne!(buf, b"----");
    |
    = help: the trait `PartialEq<&[u8; 4]>` is not implemented for `[u8; 4]`
    = help: the following other types implement trait `PartialEq<Rhs>`:
+             `&[T; N]` implements `PartialEq<VecDeque<U, A>>`
              `&[T]` implements `PartialEq<Cow<'_, [U]>>`
              `&[T]` implements `PartialEq<Vec<U, A>>`
+             `&[T]` implements `PartialEq<VecDeque<U, A>>`
              `&[T]` implements `PartialEq<[U; N]>`
              `&[u8; N]` implements `PartialEq<ByteStr>`
              `&[u8; N]` implements `PartialEq<ByteString>`
              `&[u8]` implements `PartialEq<ByteStr>`
-             `&[u8]` implements `PartialEq<ByteString>`
-             `&mut [T]` implements `PartialEq<Cow<'_, [U]>>`
-           and 13 others
+           and 18 others
 
 error[E0277]: can't compare `[u8; 4]` with `&[u8; 4]`
   --> $DIR/assert-ne-no-invalid-help-issue-146204.rs:19:5
@@ -24,15 +24,15 @@ LL |     assert_eq!(buf, b"----");
    |
    = help: the trait `PartialEq<&[u8; 4]>` is not implemented for `[u8; 4]`
    = help: the following other types implement trait `PartialEq<Rhs>`:
+             `&[T; N]` implements `PartialEq<VecDeque<U, A>>`
              `&[T]` implements `PartialEq<Cow<'_, [U]>>`
              `&[T]` implements `PartialEq<Vec<U, A>>`
+             `&[T]` implements `PartialEq<VecDeque<U, A>>`
              `&[T]` implements `PartialEq<[U; N]>`
              `&[u8; N]` implements `PartialEq<ByteStr>`
              `&[u8; N]` implements `PartialEq<ByteString>`
              `&[u8]` implements `PartialEq<ByteStr>`
-             `&[u8]` implements `PartialEq<ByteString>`
-             `&mut [T]` implements `PartialEq<Cow<'_, [U]>>`
-           and 13 others
+           and 18 others
 
 error[E0277]: can't compare `[u8; 4]` with `&[u8; 4]`
   --> $DIR/assert-ne-no-invalid-help-issue-146204.rs:5:30


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/152972)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR is a response to rust-lang/rust#152830. It implement PartialEq<VecDeque<U>> for Vec<T>, &[T], &mut [T], [T; N] and &mut [T; N]. To be symmetrical with the standard library's __impl_slice_eq1, I added the __impl_slice_eq2 macro to generate the implementation. Additionally, I added the reverse equality unit test (test_partial_eq_vecdeque_reverse), modified too_generic_eval_ice.current.stderr, and passed the local tests.
This PR does not involve the comparison between Cow vs Vec and Cow vs &mut [T]. 
PS:
This is my first time participating in this project. If there are any mistakes, please feel free to correct me.