### PR TITLE
Revert relative paths for std links in rustc-docs

### DIFF
--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -953,13 +953,6 @@ impl Step for Rustc {
         cargo.rustdocflag("--extern-html-root-url");
         cargo.rustdocflag("ena=https://docs.rs/ena/latest/");
 
-        // Point std library crate links to local docs for offline usage.
-        for krate in STD_PUBLIC_CRATES {
-            cargo.rustdocflag("--extern-html-root-url");
-            cargo.rustdocflag(&format!("{krate}=../"));
-        }
-        cargo.rustdocflag("--extern-html-root-takes-precedence");
-
         let mut to_open = None;
 
         let out_dir = builder.stage_out(build_compiler, Mode::Rustc).join(target).join("doc");


### PR DESCRIPTION
Reverts rust-lang/rust#152243.

The relative path `../` passed via `--extern-html-root-url` produces broken links in compiler documentation. The path is wrong in both the published layout (`doc.rust-lang.org/nightly/nightly-rustc/` vs `doc.rust-lang.org/nightly/core/`) and local builds (`compiler-doc/` vs `doc/`).

This restores absolute URLs via `#[doc(html_root_url)]`.

Fixes rust-lang/rust#152917
Re-opens rust-lang/rust#151496

cc @eggyal