### PR TITLE
Fix relative path handling for --extern-html-root-url

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -204,7 +204,7 @@ impl ExternalCrate {
                 url.push('/');
             }
             let is_absolute = url.starts_with('/')
-                || url.split_once("://").is_some_and(|(scheme, _)| {
+                || url.split_once(':').is_some_and(|(scheme, _)| {
                     scheme.bytes().next().is_some_and(|b| b.is_ascii_alphabetic())
                         && scheme
                             .bytes()

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -203,7 +203,14 @@ impl ExternalCrate {
             if !url.ends_with('/') {
                 url.push('/');
             }
-            Remote(url)
+            let is_absolute = url.starts_with('/')
+                || url.split_once("://").is_some_and(|(scheme, _)| {
+                    scheme.bytes().next().is_some_and(|b| b.is_ascii_alphabetic())
+                        && scheme
+                            .bytes()
+                            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'+' | b'-' | b'.'))
+                });
+            Remote { url, is_absolute }
         }
 
         // See if there's documentation generated into the local directory
@@ -316,7 +323,7 @@ impl ExternalCrate {
 #[derive(Debug)]
 pub(crate) enum ExternalLocation {
     /// Remote URL root of the external crate
-    Remote(String),
+    Remote { url: String, is_absolute: bool },
     /// This external crate can be found in the local doc/ folder
     Local,
     /// The external crate could not be found.

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -402,9 +402,10 @@ fn generate_macro_def_id_path(
     }
 
     let url = match cache.extern_locations[&def_id.krate] {
-        ExternalLocation::Remote(ref s) => {
-            // `ExternalLocation::Remote` always end with a `/`.
-            format!("{s}{path}", path = fmt::from_fn(|f| path.iter().joined("/", f)))
+        ExternalLocation::Remote { ref url, is_absolute } => {
+            let mut prefix = remote_url_prefix(url, is_absolute, cx.current.len());
+            prefix.extend(path.iter().copied());
+            prefix.finish()
         }
         ExternalLocation::Local => {
             // `root_path` always end with a `/`.
@@ -458,10 +459,10 @@ fn generate_item_def_id_path(
 
     let shortty = ItemType::from_def_id(def_id, tcx);
     let module_fqp = to_module_fqp(shortty, &fqp);
-    let mut is_remote = false;
+    let mut is_absolute = false;
 
-    let url_parts = url_parts(cx.cache(), def_id, module_fqp, &cx.current, &mut is_remote)?;
-    let mut url_parts = make_href(root_path, shortty, url_parts, &fqp, is_remote);
+    let url_parts = url_parts(cx.cache(), def_id, module_fqp, &cx.current, &mut is_absolute)?;
+    let mut url_parts = make_href(root_path, shortty, url_parts, &fqp, is_absolute);
     if def_id != original_def_id {
         let kind = ItemType::from_def_id(original_def_id, tcx);
         url_parts = format!("{url_parts}#{kind}.{}", tcx.item_name(original_def_id))
@@ -493,18 +494,29 @@ fn to_module_fqp(shortty: ItemType, fqp: &[Symbol]) -> &[Symbol] {
     if shortty == ItemType::Module { fqp } else { &fqp[..fqp.len() - 1] }
 }
 
+fn remote_url_prefix(url: &str, is_absolute: bool, depth: usize) -> UrlPartsBuilder {
+    let url = url.trim_end_matches('/');
+    if is_absolute {
+        UrlPartsBuilder::singleton(url)
+    } else {
+        let extra = depth.saturating_sub(1);
+        let mut b: UrlPartsBuilder = iter::repeat_n("..", extra).collect();
+        b.push(url);
+        b
+    }
+}
+
 fn url_parts(
     cache: &Cache,
     def_id: DefId,
     module_fqp: &[Symbol],
     relative_to: &[Symbol],
-    is_remote: &mut bool,
+    is_absolute: &mut bool,
 ) -> Result<UrlPartsBuilder, HrefError> {
     match cache.extern_locations[&def_id.krate] {
-        ExternalLocation::Remote(ref s) => {
-            *is_remote = true;
-            let s = s.trim_end_matches('/');
-            let mut builder = UrlPartsBuilder::singleton(s);
+        ExternalLocation::Remote { ref url, is_absolute: abs } => {
+            *is_absolute = abs;
+            let mut builder = remote_url_prefix(url, abs, relative_to.len());
             builder.extend(module_fqp.iter().copied());
             Ok(builder)
         }
@@ -518,9 +530,9 @@ fn make_href(
     shortty: ItemType,
     mut url_parts: UrlPartsBuilder,
     fqp: &[Symbol],
-    is_remote: bool,
+    is_absolute: bool,
 ) -> String {
-    if !is_remote && let Some(root_path) = root_path {
+    if !is_absolute && let Some(root_path) = root_path {
         let root = root_path.trim_end_matches('/');
         url_parts.push_front(root);
     }
@@ -583,7 +595,7 @@ pub(crate) fn href_with_root_path(
         }
     }
 
-    let mut is_remote = false;
+    let mut is_absolute = false;
     let (fqp, shortty, url_parts) = match cache.paths.get(&did) {
         Some(&(ref fqp, shortty)) => (fqp, shortty, {
             let module_fqp = to_module_fqp(shortty, fqp.as_slice());
@@ -597,7 +609,7 @@ pub(crate) fn href_with_root_path(
             let def_id_to_get = if root_path.is_some() { original_did } else { did };
             if let Some(&(ref fqp, shortty)) = cache.external_paths.get(&def_id_to_get) {
                 let module_fqp = to_module_fqp(shortty, fqp);
-                (fqp, shortty, url_parts(cache, did, module_fqp, relative_to, &mut is_remote)?)
+                (fqp, shortty, url_parts(cache, did, module_fqp, relative_to, &mut is_absolute)?)
             } else if matches!(def_kind, DefKind::Macro(_)) {
                 return generate_macro_def_id_path(did, cx, root_path);
             } else if did.is_local() {
@@ -608,7 +620,7 @@ pub(crate) fn href_with_root_path(
         }
     };
     Ok(HrefInfo {
-        url: make_href(root_path, shortty, url_parts, fqp, is_remote),
+        url: make_href(root_path, shortty, url_parts, fqp, is_absolute),
         kind: shortty,
         rust_path: fqp.clone(),
     })
@@ -762,12 +774,10 @@ fn primitive_link_fragment(
             }
             Some(&def_id) => {
                 let loc = match m.extern_locations[&def_id.krate] {
-                    ExternalLocation::Remote(ref s) => {
+                    ExternalLocation::Remote { ref url, is_absolute } => {
                         let cname_sym = ExternalCrate { crate_num: def_id.krate }.name(cx.tcx());
-                        let builder: UrlPartsBuilder =
-                            [s.as_str().trim_end_matches('/'), cname_sym.as_str()]
-                                .into_iter()
-                                .collect();
+                        let mut builder = remote_url_prefix(url, is_absolute, cx.current.len());
+                        builder.push(cname_sym.as_str());
                         Some(builder)
                     }
                     ExternalLocation::Local => {

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -532,6 +532,7 @@ fn make_href(
     fqp: &[Symbol],
     is_absolute: bool,
 ) -> String {
+    // FIXME: relative extern URLs may break when prefixed with root_path
     if !is_absolute && let Some(root_path) = root_path {
         let root = root_path.trim_end_matches('/');
         url_parts.push_front(root);

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -386,8 +386,9 @@ impl<'tcx> Context<'tcx> {
                     let e = ExternalCrate { crate_num: cnum };
                     (e.name(self.tcx()), e.src_root(self.tcx()))
                 }
-                ExternalLocation::Remote(ref s) => {
-                    root = s.to_string();
+                ExternalLocation::Remote { ref url, .. } => {
+                    // FIXME: relative extern URLs are not depth-adjusted for source pages
+                    root = url.to_string();
                     let e = ExternalCrate { crate_num: cnum };
                     (e.name(self.tcx()), e.src_root(self.tcx()))
                 }

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -280,7 +280,8 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
                         types::ExternalCrate {
                             name: e.name(self.tcx).to_string(),
                             html_root_url: match external_location {
-                                ExternalLocation::Remote(s) => Some(s.clone()),
+                                // FIXME: relative extern URLs are not resolved here
+                                ExternalLocation::Remote { url, .. } => Some(url.clone()),
                                 _ => None,
                             },
                             path: self

--- a/tests/rustdoc-html/extern/extern-html-root-url-relative.rs
+++ b/tests/rustdoc-html/extern/extern-html-root-url-relative.rs
@@ -1,4 +1,4 @@
-//@ compile-flags:-Z unstable-options --extern-html-root-url core=../ --extern-html-root-takes-precedence
+//@ compile-flags:-Z unstable-options --extern-html-root-url core=../ --extern-html-root-takes-precedence --generate-link-to-definition
 
 // At depth 1 (top-level), the href should be ../core/...
 //@ has extern_html_root_url_relative/index.html
@@ -9,7 +9,19 @@ pub use std::iter;
 // At depth 2 (inside a module), the href should be ../../core/...
 pub mod nested {
     //@ has extern_html_root_url_relative/nested/index.html
-    //@ has - '//a/@href' '../../core/iter/index.html'
+    //@ has - '//a/@href' '../../core/future/index.html'
     #[doc(no_inline)]
-    pub use std::iter;
+    pub use std::future;
 }
+
+// Also depth 2, but for an intra-doc link.
+//@ has extern_html_root_url_relative/intra_doc_link/index.html
+//@ has - '//a/@href' '../../core/ptr/fn.write.html'
+/// [write](<core::ptr::write()>)
+pub mod intra_doc_link {
+}
+
+// link-to-definition
+//@ has src/extern_html_root_url_relative/extern-html-root-url-relative.rs.html
+//@ has - '//a/@href' '../../core/iter/index.html'
+//@ has - '//a/@href' '../../core/future/index.html'

--- a/tests/rustdoc-html/extern/extern-html-root-url-relative.rs
+++ b/tests/rustdoc-html/extern/extern-html-root-url-relative.rs
@@ -1,0 +1,15 @@
+//@ compile-flags:-Z unstable-options --extern-html-root-url core=../ --extern-html-root-takes-precedence
+
+// At depth 1 (top-level), the href should be ../core/...
+//@ has extern_html_root_url_relative/index.html
+//@ has - '//a/@href' '../core/iter/index.html'
+#[doc(no_inline)]
+pub use std::iter;
+
+// At depth 2 (inside a module), the href should be ../../core/...
+pub mod nested {
+    //@ has extern_html_root_url_relative/nested/index.html
+    //@ has - '//a/@href' '../../core/iter/index.html'
+    #[doc(no_inline)]
+    pub use std::iter;
+}


### PR DESCRIPTION
When `--extern-html-root-url` receives a relative path (like `../`), rustdoc uses it as a literal prefix regardless of page depth. This works at depth 1 (`crate/index.html`) but breaks at depth 2+ (`crate/module/struct.Foo.html`) because the relative path doesn't account for the extra nesting.

This patch detects relative vs absolute URLs in the `Remote` branch of `url_parts` and prepends the necessary `../` segments based on the current page depth. Absolute URLs (`https://...`) and server-absolute paths (`/docs/...`) are unchanged.

This makes relative paths a viable option for `--extern-html-root-url`, which they weren't before.


Related to rust-lang/rust#152917, which exposed that relative paths weren't handled correctly.

cc @eggyal