### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -302,6 +302,11 @@
 # If you set this, you likely want to set `cargo` as well.
 #build.rustc = "/path/to/rustc"
 
+# Use this rustdoc binary as the stage0 snapshot rustdoc.
+# If unspecified, then the binary "rustdoc" (with platform-specific extension, e.g. ".exe")
+# in the same directory as "rustc" will be used.
+#build.rustdoc = "/path/to/rustdoc"
+
 # Instead of downloading the src/stage0 version of rustfmt specified,
 # use this rustfmt binary instead as the stage0 snapshot rustfmt.
 #build.rustfmt = "/path/to/rustfmt"

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1088,9 +1088,18 @@ impl<'hir> LoweringContext<'_, 'hir> {
             }
         };
 
-        let (defaultness, _) = self.lower_defaultness(i.kind.defaultness(), has_value, || {
-            hir::Defaultness::Default { has_value }
-        });
+        let defaultness = match i.kind.defaultness() {
+            // We do not yet support `final` on trait associated items other than functions.
+            // Even though we reject `final` on non-functions during AST validation, we still
+            // need to stop propagating it here because later compiler passes do not expect
+            // and cannot handle such items.
+            Defaultness::Final(..) if !matches!(i.kind, AssocItemKind::Fn(..)) => {
+                Defaultness::Implicit
+            }
+            defaultness => defaultness,
+        };
+        let (defaultness, _) = self
+            .lower_defaultness(defaultness, has_value, || hir::Defaultness::Default { has_value });
 
         let item = hir::TraitItem {
             owner_id: trait_item_def_id,

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -431,7 +431,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 false
             }
             ast::AssocItemKind::Const(box ast::ConstItem {
-                rhs_kind: ast::ConstItemRhsKind::TypeConst { .. },
+                rhs_kind: ast::ConstItemRhsKind::TypeConst { rhs },
                 ..
             }) => {
                 // Make sure this is only allowed if the feature gate is enabled.
@@ -442,6 +442,17 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                     i.span,
                     "associated `type const` are unstable"
                 );
+                // Make sure associated `type const` defaults in traits are only allowed
+                // if the feature gate is enabled.
+                // #![feature(associated_type_defaults)]
+                if ctxt == AssocCtxt::Trait && rhs.is_some() {
+                    gate!(
+                        &self,
+                        associated_type_defaults,
+                        i.span,
+                        "associated type defaults are unstable"
+                    );
+                }
                 false
             }
             _ => false,

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -298,6 +298,7 @@ pub struct Config {
     // These are either the stage0 downloaded binaries or the locally installed ones.
     pub initial_cargo: PathBuf,
     pub initial_rustc: PathBuf,
+    pub initial_rustdoc: PathBuf,
     pub initial_cargo_clippy: Option<PathBuf>,
     pub initial_sysroot: PathBuf,
     pub initial_rustfmt: Option<PathBuf>,
@@ -456,6 +457,7 @@ impl Config {
             build_dir: build_build_dir,
             cargo: mut build_cargo,
             rustc: mut build_rustc,
+            rustdoc: build_rustdoc,
             rustfmt: build_rustfmt,
             cargo_clippy: build_cargo_clippy,
             docs: build_docs,
@@ -750,6 +752,9 @@ impl Config {
             download_beta_toolchain(&dwn_ctx, &out);
             default_stage0_rustc_path(&out)
         });
+
+        let initial_rustdoc = build_rustdoc
+            .unwrap_or_else(|| initial_rustc.with_file_name(exe("rustdoc", host_target)));
 
         let initial_sysroot = t!(PathBuf::from_str(
             command(&initial_rustc)
@@ -1348,6 +1353,7 @@ impl Config {
             initial_cargo,
             initial_cargo_clippy: build_cargo_clippy,
             initial_rustc,
+            initial_rustdoc,
             initial_rustfmt,
             initial_sysroot,
             jemalloc: rust_jemalloc.unwrap_or(false),

--- a/src/bootstrap/src/core/config/toml/build.rs
+++ b/src/bootstrap/src/core/config/toml/build.rs
@@ -25,6 +25,7 @@ define_config! {
         build_dir: Option<String> = "build-dir",
         cargo: Option<PathBuf> = "cargo",
         rustc: Option<PathBuf> = "rustc",
+        rustdoc: Option<PathBuf> = "rustdoc",
         rustfmt: Option<PathBuf> = "rustfmt",
         cargo_clippy: Option<PathBuf> = "cargo-clippy",
         docs: Option<bool> = "docs",

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -535,9 +535,7 @@ impl Build {
             initial_lld,
             initial_relative_libdir,
             initial_rustc: config.initial_rustc.clone(),
-            initial_rustdoc: config
-                .initial_rustc
-                .with_file_name(exe("rustdoc", config.host_target)),
+            initial_rustdoc: config.initial_rustdoc.clone(),
             initial_cargo: config.initial_cargo.clone(),
             initial_sysroot: config.initial_sysroot.clone(),
             local_rebuild: config.local_rebuild,

--- a/tests/ui/const-generics/associated-const-bindings/const_evaluatable_unchecked.rs
+++ b/tests/ui/const-generics/associated-const-bindings/const_evaluatable_unchecked.rs
@@ -4,7 +4,7 @@
 //
 // issue: <https://github.com/rust-lang/rust/issues/108220>
 //@ check-pass
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, associated_type_defaults)]
 #![allow(incomplete_features)]
 
 pub trait TraitA<T> {

--- a/tests/ui/const-generics/mgca/type-const-associated-default.rs
+++ b/tests/ui/const-generics/mgca/type-const-associated-default.rs
@@ -1,0 +1,9 @@
+#![feature(min_generic_const_args)]
+#![expect(incomplete_features)]
+trait Trait {
+    type const N: usize = 10;
+    //~^ ERROR associated type defaults are unstable
+}
+
+fn main(){
+}

--- a/tests/ui/const-generics/mgca/type-const-associated-default.stderr
+++ b/tests/ui/const-generics/mgca/type-const-associated-default.stderr
@@ -1,0 +1,13 @@
+error[E0658]: associated type defaults are unstable
+  --> $DIR/type-const-associated-default.rs:4:5
+   |
+LL |     type const N: usize = 10;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #29661 <https://github.com/rust-lang/rust/issues/29661> for more information
+   = help: add `#![feature(associated_type_defaults)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/generic-const-items/assoc-const-no-infer-ice-115806.rs
+++ b/tests/ui/generic-const-items/assoc-const-no-infer-ice-115806.rs
@@ -1,6 +1,7 @@
 // ICE: assertion failed: !value.has_infer()
 // issue: rust-lang/rust#115806
 #![feature(adt_const_params, min_generic_const_args, unsized_const_params)]
+#![feature(associated_type_defaults)]
 #![allow(incomplete_features)]
 
 pub struct NoPin;

--- a/tests/ui/generic-const-items/assoc-const-no-infer-ice-115806.stderr
+++ b/tests/ui/generic-const-items/assoc-const-no-infer-ice-115806.stderr
@@ -1,5 +1,5 @@
 error[E0119]: conflicting implementations of trait `Pins<_>` for type `NoPin`
-  --> $DIR/assoc-const-no-infer-ice-115806.rs:16:1
+  --> $DIR/assoc-const-no-infer-ice-115806.rs:17:1
    |
 LL | impl<TA> Pins<TA> for NoPin {}
    | --------------------------- first implementation here

--- a/tests/ui/sanitizer/cfi/assoc-const-projection-issue-151878.rs
+++ b/tests/ui/sanitizer/cfi/assoc-const-projection-issue-151878.rs
@@ -4,7 +4,7 @@
 //@ build-pass
 //@ no-prefer-dynamic
 
-#![feature(min_generic_const_args)]
+#![feature(min_generic_const_args, associated_type_defaults)]
 #![expect(incomplete_features)]
 
 trait Trait {

--- a/tests/ui/traits/final/final-on-assoc-type-const.rs
+++ b/tests/ui/traits/final/final-on-assoc-type-const.rs
@@ -1,0 +1,12 @@
+// This is a regression test for <https://github.com/rust-lang/rust/issues/152797>.
+#![feature(final_associated_functions)]
+#![feature(min_generic_const_args)]
+#![expect(incomplete_features)]
+trait Uwu {
+    final type Ovo;
+    //~^ error: `final` is only allowed on associated functions in traits
+    final type const QwQ: ();
+    //~^ error: `final` is only allowed on associated functions in traits
+}
+
+fn main() {}

--- a/tests/ui/traits/final/final-on-assoc-type-const.stderr
+++ b/tests/ui/traits/final/final-on-assoc-type-const.stderr
@@ -1,0 +1,18 @@
+error: `final` is only allowed on associated functions in traits
+  --> $DIR/final-on-assoc-type-const.rs:6:5
+   |
+LL |     final type Ovo;
+   |     -----^^^^^^^^^^
+   |     |
+   |     `final` because of this
+
+error: `final` is only allowed on associated functions in traits
+  --> $DIR/final-on-assoc-type-const.rs:8:5
+   |
+LL |     final type const QwQ: ();
+   |     -----^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     `final` because of this
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/traits/final/positions.rs
+++ b/tests/ui/traits/final/positions.rs
@@ -38,11 +38,9 @@ final impl Trait for Foo {
 
     final type Foo = ();
     //~^ ERROR `final` is only allowed on associated functions in traits
-    //~^^ ERROR cannot override `Foo` because it already has a `final` definition in the trait
 
     final const FOO: usize = 1;
     //~^ ERROR `final` is only allowed on associated functions in traits
-    //~^^ ERROR cannot override `FOO` because it already has a `final` definition in the trait
 }
 
 

--- a/tests/ui/traits/final/positions.stderr
+++ b/tests/ui/traits/final/positions.stderr
@@ -15,7 +15,7 @@ LL | final trait Trait {
    = note: only associated functions in traits can be `final`
 
 error: a static item cannot be `final`
-  --> $DIR/positions.rs:67:5
+  --> $DIR/positions.rs:65:5
    |
 LL |     final static FOO_EXTERN: usize = 0;
    |     ^^^^^ `final` because of this
@@ -23,7 +23,7 @@ LL |     final static FOO_EXTERN: usize = 0;
    = note: only associated functions in traits can be `final`
 
 error: an extern block cannot be `final`
-  --> $DIR/positions.rs:58:1
+  --> $DIR/positions.rs:56:1
    |
 LL | final unsafe extern "C" {
    | ^^^^^ `final` because of this
@@ -87,7 +87,7 @@ LL |     final type Foo = ();
    |     `final` because of this
 
 error: `final` is only allowed on associated functions in traits
-  --> $DIR/positions.rs:43:5
+  --> $DIR/positions.rs:42:5
    |
 LL |     final const FOO: usize = 1;
    |     -----^^^^^^^^^^^^^^^^^^^^^^
@@ -95,7 +95,7 @@ LL |     final const FOO: usize = 1;
    |     `final` because of this
 
 error: `final` is only allowed on associated functions in traits
-  --> $DIR/positions.rs:49:1
+  --> $DIR/positions.rs:47:1
    |
 LL | final fn foo() {}
    | -----^^^^^^^^^
@@ -103,7 +103,7 @@ LL | final fn foo() {}
    | `final` because of this
 
 error: `final` is only allowed on associated functions in traits
-  --> $DIR/positions.rs:52:1
+  --> $DIR/positions.rs:50:1
    |
 LL | final type FooTy = ();
    | -----^^^^^^^^^^^^^^^^^
@@ -111,7 +111,7 @@ LL | final type FooTy = ();
    | `final` because of this
 
 error: `final` is only allowed on associated functions in traits
-  --> $DIR/positions.rs:55:1
+  --> $DIR/positions.rs:53:1
    |
 LL | final const FOO: usize = 0;
    | -----^^^^^^^^^^^^^^^^^^^^^^
@@ -119,7 +119,7 @@ LL | final const FOO: usize = 0;
    | `final` because of this
 
 error: `final` is only allowed on associated functions in traits
-  --> $DIR/positions.rs:61:5
+  --> $DIR/positions.rs:59:5
    |
 LL |     final fn foo_extern();
    |     -----^^^^^^^^^^^^^^^^^
@@ -127,7 +127,7 @@ LL |     final fn foo_extern();
    |     `final` because of this
 
 error: `final` is only allowed on associated functions in traits
-  --> $DIR/positions.rs:64:5
+  --> $DIR/positions.rs:62:5
    |
 LL |     final type FooExtern;
    |     -----^^^^^^^^^^^^^^^^
@@ -135,7 +135,7 @@ LL |     final type FooExtern;
    |     `final` because of this
 
 error: incorrect `static` inside `extern` block
-  --> $DIR/positions.rs:67:18
+  --> $DIR/positions.rs:65:18
    |
 LL | final unsafe extern "C" {
    | ----------------------- `extern` blocks define existing foreign statics and statics inside of them cannot have a body
@@ -159,29 +159,5 @@ note: `method` is marked final here
 LL |     final fn method() {}
    |     ^^^^^^^^^^^^^^^^^
 
-error: cannot override `Foo` because it already has a `final` definition in the trait
-  --> $DIR/positions.rs:39:5
-   |
-LL |     final type Foo = ();
-   |     ^^^^^^^^^^^^^^
-   |
-note: `Foo` is marked final here
-  --> $DIR/positions.rs:16:5
-   |
-LL |     final type Foo = ();
-   |     ^^^^^^^^^^^^^^
-
-error: cannot override `FOO` because it already has a `final` definition in the trait
-  --> $DIR/positions.rs:43:5
-   |
-LL |     final const FOO: usize = 1;
-   |     ^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: `FOO` is marked final here
-  --> $DIR/positions.rs:19:5
-   |
-LL |     final const FOO: usize = 1;
-   |     ^^^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to 21 previous errors
+error: aborting due to 19 previous errors
 


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#152385 (Feature gate for defaulted associated type_consts with associated_type_defaults )
 - rust-lang/rust#152921 (Add build.rustdoc option to bootstrap config)
 - rust-lang/rust#152926 (Fix ICE when an associated type is wrongly marked as `final`)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=152385,152921,152926)
<!-- homu-ignore:end -->

