### PR TITLE
c-variadic: fix implementation on `avr`

### DIFF
--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -285,37 +285,47 @@ impl<'ll, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'_, 'll, 'tcx> {
             }
             sym::breakpoint => self.call_intrinsic("llvm.debugtrap", &[], &[]),
             sym::va_arg => {
-                match result.layout.backend_repr {
-                    BackendRepr::Scalar(scalar) => {
-                        match scalar.primitive() {
-                            Primitive::Int(..) => {
-                                if self.cx().size_of(result.layout.ty).bytes() < 4 {
-                                    // `va_arg` should not be called on an integer type
-                                    // less than 4 bytes in length. If it is, promote
-                                    // the integer to an `i32` and truncate the result
-                                    // back to the smaller type.
-                                    let promoted_result = emit_va_arg(self, args[0], tcx.types.i32);
-                                    self.trunc(promoted_result, result.layout.llvm_type(self))
-                                } else {
-                                    emit_va_arg(self, args[0], result.layout.ty)
-                                }
-                            }
-                            Primitive::Float(Float::F16) => {
-                                bug!("the va_arg intrinsic does not work with `f16`")
-                            }
-                            Primitive::Float(Float::F64) | Primitive::Pointer(_) => {
-                                emit_va_arg(self, args[0], result.layout.ty)
-                            }
-                            // `va_arg` should never be used with the return type f32.
-                            Primitive::Float(Float::F32) => {
-                                bug!("the va_arg intrinsic does not work with `f32`")
-                            }
-                            Primitive::Float(Float::F128) => {
-                                bug!("the va_arg intrinsic does not work with `f128`")
-                            }
+                let BackendRepr::Scalar(scalar) = result.layout.backend_repr else {
+                    bug!("the va_arg intrinsic does not support non-scalar types")
+                };
+
+                match scalar.primitive() {
+                    Primitive::Pointer(_) => {
+                        // Pointers are always OK.
+                        emit_va_arg(self, args[0], result.layout.ty)
+                    }
+                    Primitive::Int(..) => {
+                        let int_width = self.cx().size_of(result.layout.ty).bits();
+                        let target_c_int_width = self.cx().sess().target.options.c_int_width;
+                        if int_width < u64::from(target_c_int_width) {
+                            // Smaller integer types are automatically promototed and `va_arg`
+                            // should not be called on them.
+                            bug!(
+                                "va_arg got i{} but needs at least c_int (an i{})",
+                                int_width,
+                                target_c_int_width
+                            );
+                        }
+                        emit_va_arg(self, args[0], result.layout.ty)
+                    }
+                    Primitive::Float(Float::F16) => {
+                        bug!("the va_arg intrinsic does not support `f16`")
+                    }
+                    Primitive::Float(Float::F32) => {
+                        if self.cx().sess().target.arch == Arch::Avr {
+                            // c_double is actually f32 on avr.
+                            emit_va_arg(self, args[0], result.layout.ty)
+                        } else {
+                            bug!("the va_arg intrinsic does not support `f32` on this target")
                         }
                     }
-                    _ => bug!("the va_arg intrinsic does not work with non-scalar types"),
+                    Primitive::Float(Float::F64) => {
+                        // 64-bit floats are always OK.
+                        emit_va_arg(self, args[0], result.layout.ty)
+                    }
+                    Primitive::Float(Float::F128) => {
+                        bug!("the va_arg intrinsic does not support `f128`")
+                    }
                 }
             }
 

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -221,6 +221,7 @@ language_item_table! {
     UnsafeCell,              sym::unsafe_cell,         unsafe_cell_type,           Target::Struct,         GenericRequirement::None;
     UnsafePinned,            sym::unsafe_pinned,       unsafe_pinned_type,         Target::Struct,         GenericRequirement::None;
 
+    VaArgSafe,               sym::va_arg_safe,         va_arg_safe,                Target::Trait,          GenericRequirement::None;
     VaList,                  sym::va_list,             va_list,                    Target::Struct,         GenericRequirement::None;
 
     Deref,                   sym::deref,               deref_trait,                Target::Trait,          GenericRequirement::Exact(0);

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -494,21 +494,29 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
                 // There are a few types which get autopromoted when passed via varargs
                 // in C but we just error out instead and require explicit casts.
+                //
+                // We use implementations of VaArgSafe as the source of truth. On some embedded
+                // targets, c_double is f32 and c_int/c_uing are i16/u16, and these types implement
+                // VaArgSafe there. On all other targets, these types do not implement VaArgSafe.
+                //
+                // cfg(bootstrap): change the if let to an unwrap.
                 let arg_ty = self.structurally_resolve_type(arg.span, arg_ty);
+                if let Some(trait_def_id) = tcx.lang_items().va_arg_safe()
+                    && self
+                        .type_implements_trait(trait_def_id, [arg_ty], self.param_env)
+                        .must_apply_modulo_regions()
+                {
+                    continue;
+                }
+
                 match arg_ty.kind() {
                     ty::Float(ty::FloatTy::F32) => {
                         variadic_error(tcx.sess, arg.span, arg_ty, "c_double");
                     }
-                    ty::Int(ty::IntTy::I8) | ty::Bool => {
+                    ty::Int(ty::IntTy::I8 | ty::IntTy::I16) | ty::Bool => {
                         variadic_error(tcx.sess, arg.span, arg_ty, "c_int");
                     }
-                    ty::Uint(ty::UintTy::U8) => {
-                        variadic_error(tcx.sess, arg.span, arg_ty, "c_uint");
-                    }
-                    ty::Int(ty::IntTy::I16) if tcx.sess.target.options.c_int_width > 16 => {
-                        variadic_error(tcx.sess, arg.span, arg_ty, "c_int");
-                    }
-                    ty::Uint(ty::UintTy::U16) if tcx.sess.target.options.c_int_width > 16 => {
+                    ty::Uint(ty::UintTy::U8 | ty::UintTy::U16) => {
                         variadic_error(tcx.sess, arg.span, arg_ty, "c_uint");
                     }
                     ty::FnDef(..) => {

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -499,10 +499,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     ty::Float(ty::FloatTy::F32) => {
                         variadic_error(tcx.sess, arg.span, arg_ty, "c_double");
                     }
-                    ty::Int(ty::IntTy::I8 | ty::IntTy::I16) | ty::Bool => {
+                    ty::Int(ty::IntTy::I8) | ty::Bool => {
                         variadic_error(tcx.sess, arg.span, arg_ty, "c_int");
                     }
-                    ty::Uint(ty::UintTy::U8 | ty::UintTy::U16) => {
+                    ty::Uint(ty::UintTy::U8) => {
+                        variadic_error(tcx.sess, arg.span, arg_ty, "c_uint");
+                    }
+                    ty::Int(ty::IntTy::I16) if tcx.sess.target.options.c_int_width > 16 => {
+                        variadic_error(tcx.sess, arg.span, arg_ty, "c_int");
+                    }
+                    ty::Uint(ty::UintTy::U16) if tcx.sess.target.options.c_int_width > 16 => {
                         variadic_error(tcx.sess, arg.span, arg_ty, "c_uint");
                     }
                     ty::FnDef(..) => {

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2209,6 +2209,7 @@ symbols! {
         v1,
         v8plus,
         va_arg,
+        va_arg_safe,
         va_copy,
         va_end,
         va_list,

--- a/library/core/src/ffi/va_list.rs
+++ b/library/core/src/ffi/va_list.rs
@@ -300,6 +300,7 @@ mod sealed {
 // We may unseal this trait in the future, but currently our `va_arg` implementations don't support
 // types with an alignment larger than 8, or with a non-scalar layout. Inline assembly can be used
 // to accept unsupported types in the meantime.
+#[lang = "va_arg_safe"]
 pub unsafe trait VaArgSafe: sealed::Sealed {}
 
 crate::cfg_select! {

--- a/library/core/src/ffi/va_list.rs
+++ b/library/core/src/ffi/va_list.rs
@@ -266,14 +266,17 @@ impl<'f> const Drop for VaList<'f> {
 mod sealed {
     pub trait Sealed {}
 
+    impl Sealed for i16 {}
     impl Sealed for i32 {}
     impl Sealed for i64 {}
     impl Sealed for isize {}
 
+    impl Sealed for u16 {}
     impl Sealed for u32 {}
     impl Sealed for u64 {}
     impl Sealed for usize {}
 
+    impl Sealed for f32 {}
     impl Sealed for f64 {}
 
     impl<T> Sealed for *mut T {}
@@ -299,21 +302,60 @@ mod sealed {
 // to accept unsupported types in the meantime.
 pub unsafe trait VaArgSafe: sealed::Sealed {}
 
-// i8 and i16 are implicitly promoted to c_int in C, and cannot implement `VaArgSafe`.
+crate::cfg_select! {
+    any(target_arch = "avr", target_arch = "msp430") => {
+        // c_int/c_uint are i16/u16 on these targets.
+        //
+        // - i8 is implicitly promoted to c_int in C, and cannot implement `VaArgSafe`.
+        // - u8 is implicitly promoted to c_uint in C, and cannot implement `VaArgSafe`.
+        unsafe impl VaArgSafe for i16 {}
+        unsafe impl VaArgSafe for u16 {}
+    }
+    _ => {
+        // c_int/c_uint are i32/u32 on this target.
+        //
+        // - i8 and i16 are implicitly promoted to c_int in C, and cannot implement `VaArgSafe`.
+        // - u8 and u16 are implicitly promoted to c_uint in C, and cannot implement `VaArgSafe`.
+    }
+}
+
+crate::cfg_select! {
+    target_arch = "avr" => {
+        // c_double is f32 on this target.
+        unsafe impl VaArgSafe for f32 {}
+    }
+    _ => {
+        // c_double is f64 on this target.
+        //
+        // - f32 is implicitly promoted to c_double in C, and cannot implement `VaArgSafe`.
+    }
+}
+
 unsafe impl VaArgSafe for i32 {}
 unsafe impl VaArgSafe for i64 {}
 unsafe impl VaArgSafe for isize {}
 
-// u8 and u16 are implicitly promoted to c_int in C, and cannot implement `VaArgSafe`.
 unsafe impl VaArgSafe for u32 {}
 unsafe impl VaArgSafe for u64 {}
 unsafe impl VaArgSafe for usize {}
 
-// f32 is implicitly promoted to c_double in C, and cannot implement `VaArgSafe`.
 unsafe impl VaArgSafe for f64 {}
 
 unsafe impl<T> VaArgSafe for *mut T {}
 unsafe impl<T> VaArgSafe for *const T {}
+
+// Check that relevant `core::ffi` types implement `VaArgSafe`.
+const _: () = {
+    const fn va_arg_safe_check<T: VaArgSafe>() {}
+
+    va_arg_safe_check::<crate::ffi::c_int>();
+    va_arg_safe_check::<crate::ffi::c_uint>();
+    va_arg_safe_check::<crate::ffi::c_long>();
+    va_arg_safe_check::<crate::ffi::c_ulong>();
+    va_arg_safe_check::<crate::ffi::c_longlong>();
+    va_arg_safe_check::<crate::ffi::c_ulonglong>();
+    va_arg_safe_check::<crate::ffi::c_double>();
+};
 
 impl<'f> VaList<'f> {
     /// Read an argument from the variable argument list, and advance to the next argument.

--- a/tests/run-make/c-link-to-rust-va-list-fn/checkrust.rs
+++ b/tests/run-make/c-link-to-rust-va-list-fn/checkrust.rs
@@ -30,17 +30,17 @@ pub unsafe extern "C" fn check_list_1(mut ap: VaList) -> usize {
     continue_if!(ap.arg::<c_int>() == '4' as c_int);
     continue_if!(ap.arg::<c_int>() == ';' as c_int);
     continue_if!(ap.arg::<c_int>() == 0x32);
-    continue_if!(ap.arg::<c_int>() == 0x10000001);
+    continue_if!(ap.arg::<i32>() == 0x10000001);
     continue_if!(compare_c_str(ap.arg::<*const c_char>(), c"Valid!"));
     0
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn check_list_2(mut ap: VaList) -> usize {
-    continue_if!(ap.arg::<c_double>() == 3.14f64);
+    continue_if!(ap.arg::<c_double>() == 3.14);
     continue_if!(ap.arg::<c_long>() == 12);
     continue_if!(ap.arg::<c_int>() == 'a' as c_int);
-    continue_if!(ap.arg::<c_double>() == 6.28f64);
+    continue_if!(ap.arg::<c_double>() == 6.28);
     continue_if!(compare_c_str(ap.arg::<*const c_char>(), c"Hello"));
     continue_if!(ap.arg::<c_int>() == 42);
     continue_if!(compare_c_str(ap.arg::<*const c_char>(), c"World"));
@@ -49,7 +49,7 @@ pub unsafe extern "C" fn check_list_2(mut ap: VaList) -> usize {
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn check_list_copy_0(mut ap: VaList) -> usize {
-    continue_if!(ap.arg::<c_double>() == 6.28f64);
+    continue_if!(ap.arg::<c_double>() == 6.28);
     continue_if!(ap.arg::<c_int>() == 16);
     continue_if!(ap.arg::<c_int>() == 'A' as c_int);
     continue_if!(compare_c_str(ap.arg::<*const c_char>(), c"Skip Me!"));
@@ -66,7 +66,7 @@ pub unsafe extern "C" fn check_varargs_0(_: c_int, mut ap: ...) -> usize {
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn check_varargs_1(_: c_int, mut ap: ...) -> usize {
-    continue_if!(ap.arg::<c_double>() == 3.14f64);
+    continue_if!(ap.arg::<c_double>() == 3.14);
     continue_if!(ap.arg::<c_long>() == 12);
     continue_if!(ap.arg::<c_int>() == 'A' as c_int);
     continue_if!(ap.arg::<c_longlong>() == 1);
@@ -156,7 +156,7 @@ extern "C" fn run_test_variadic() -> usize {
 
 #[unsafe(no_mangle)]
 extern "C" fn run_test_va_list_by_value() -> usize {
-    unsafe extern "C" fn helper(mut ap: ...) -> usize {
+    unsafe extern "C" fn helper(ap: ...) -> usize {
         unsafe { test_va_list_by_value(ap) }
     }
 

--- a/tests/run-make/c-link-to-rust-va-list-fn/test.c
+++ b/tests/run-make/c-link-to-rust-va-list-fn/test.c
@@ -32,7 +32,7 @@ int test_rust(size_t (*fn)(va_list), ...) {
 int main(int argc, char* argv[]) {
     assert(test_rust(check_list_0, 0x01LL, 0x02, 0x03LL) == 0);
 
-    assert(test_rust(check_list_1, -1, 'A', '4', ';', 0x32, 0x10000001, "Valid!") == 0);
+    assert(test_rust(check_list_1, -1, 'A', '4', ';', 0x32, (int32_t)0x10000001, "Valid!") == 0);
 
     assert(test_rust(check_list_2, 3.14, 12l, 'a', 6.28, "Hello", 42, "World") == 0);
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/152980)*
<!-- homu-ignore:end -->

tracking issue: https://github.com/rust-lang/rust/issues/44930
cc target maintainer @Patryk27

I ran into multiple issues, and although with this PR and a little harness I can run the test with qemu on avr, the implementation is perhaps not ideal.

The problem we found is that on `avr` the `c_int/c_uint` types are `i16/u16`, and this was not handled in the c-variadic checks. Luckily there is a field in the target configuration that contains the targets `c_int_width`. However, this field is not actually used in `core` at all, there the 16-bit targets are just hardcoded.

https://github.com/rust-lang/rust/blob/1500f0f47f5fe8ddcd6528f6c6c031b210b4eac5/library/core/src/ffi/primitives.rs#L174-L185

Perhaps we should expose this like endianness and pointer width?

---

Finally there are some changes to the test to make it compile with `no_std`. 