### PR TITLE
Remove redundant call to `check_codegen_attributes_extra` in Inliner

### DIFF
--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -607,7 +607,6 @@ fn try_inlining<'tcx, I: Inliner<'tcx>>(
     let callee_attrs = callee_attrs.as_ref();
     check_inline::is_inline_valid_on_fn(tcx, callsite.callee.def_id())?;
     check_codegen_attributes(inliner, callsite, callee_attrs)?;
-    inliner.check_codegen_attributes_extra(callee_attrs)?;
 
     let terminator = caller_body[callsite.block].terminator.as_ref().unwrap();
     let TerminatorKind::Call { args, destination, .. } = &terminator.kind else { bug!() };


### PR DESCRIPTION
Inside `try_inlining`, `check_codegen_attributes` is called first. This function internally invokes `check_codegen_attributes_extra`.
However, immediately after that returns, `try_inlining` calls `check_codegen_attributes_extra` again.

First call:
https://github.com/rust-lang/rust/blob/7ec34defe9e62a1a6946d3e700b5903d8dc89ece/compiler/rustc_mir_transform/src/inline.rs#L800-L814

Second call:
https://github.com/rust-lang/rust/blob/7ec34defe9e62a1a6946d3e700b5903d8dc89ece/compiler/rustc_mir_transform/src/inline.rs#L598-L612

```rust
    // Inside try_inlining:
    check_codegen_attributes(inliner, callsite, callee_attrs)?; // Internally calls `check_codegen_attributes_extra`
    inliner.check_codegen_attributes_extra(callee_attrs)?;      // Called again here
```

In `try_inlining`, inliner is held as a shared reference (`&I`). Since `check_codegen_attributes_extra` takes `&self` and does not rely on interior mutability or external state, there does not seem to be any state change between the two calls.

Therefore, the second call appears to be redundant. 

Currently, `check_codegen_attributes` is only called from `try_inlining`, and `check_codegen_attributes_extra` appears to be called only from these two locations. It seems reasonable for the `check_codegen_attributes` wrapper to handle the hook automatically.
