### PR TITLE
Use `HashStable` derive in more places

### DIFF
--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -47,6 +47,9 @@ use std::fmt;
 #[cfg(not(bootstrap))]
 pub use std::{assert_matches, debug_assert_matches};
 
+// This allows derive macros to reference this crate
+extern crate self as rustc_data_structures;
+
 pub use atomic_ref::AtomicRef;
 pub use ena::{snapshot_vec, undo_log, unify};
 // Re-export `hashbrown::hash_table`, because it's part of our API

--- a/compiler/rustc_data_structures/src/sorted_map/index_map.rs
+++ b/compiler/rustc_data_structures/src/sorted_map/index_map.rs
@@ -3,8 +3,7 @@
 use std::hash::{Hash, Hasher};
 
 use rustc_index::{Idx, IndexVec};
-
-use crate::stable_hasher::{HashStable, StableHasher};
+use rustc_macros::HashStable_NoContext;
 
 /// An indexed multi-map that preserves insertion order while permitting both *O*(log *n*) lookup of
 /// an item by key and *O*(1) lookup by index.
@@ -24,11 +23,13 @@ use crate::stable_hasher::{HashStable, StableHasher};
 /// in-place.
 ///
 /// [`SortedMap`]: super::SortedMap
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, HashStable_NoContext)]
 pub struct SortedIndexMultiMap<I: Idx, K, V> {
     /// The elements of the map in insertion order.
     items: IndexVec<I, (K, V)>,
 
+    // We can ignore this field because it is not observable from the outside.
+    #[stable_hasher(ignore)]
     /// Indices of the items in the set, sorted by the item's key.
     idx_sorted_by_item_key: Vec<I>,
 }
@@ -123,22 +124,6 @@ where
 {
     fn hash<H: Hasher>(&self, hasher: &mut H) {
         self.items.hash(hasher)
-    }
-}
-
-impl<I: Idx, K, V, C> HashStable<C> for SortedIndexMultiMap<I, K, V>
-where
-    K: HashStable<C>,
-    V: HashStable<C>,
-{
-    fn hash_stable(&self, ctx: &mut C, hasher: &mut StableHasher) {
-        let SortedIndexMultiMap {
-            items,
-            // We can ignore this field because it is not observable from the outside.
-            idx_sorted_by_item_key: _,
-        } = self;
-
-        items.hash_stable(ctx, hasher)
     }
 }
 

--- a/compiler/rustc_data_structures/src/svh.rs
+++ b/compiler/rustc_data_structures/src/svh.rs
@@ -7,12 +7,21 @@
 
 use std::fmt;
 
-use rustc_macros::{Decodable_NoContext, Encodable_NoContext};
+use rustc_macros::{Decodable_NoContext, Encodable_NoContext, HashStable_NoContext};
 
 use crate::fingerprint::Fingerprint;
-use crate::stable_hasher;
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Encodable_NoContext, Decodable_NoContext, Hash)]
+#[derive(
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Debug,
+    Encodable_NoContext,
+    Decodable_NoContext,
+    Hash,
+    HashStable_NoContext
+)]
 pub struct Svh {
     hash: Fingerprint,
 }
@@ -37,13 +46,5 @@ impl Svh {
 impl fmt::Display for Svh {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad(&self.to_hex())
-    }
-}
-
-impl<T> stable_hasher::HashStable<T> for Svh {
-    #[inline]
-    fn hash_stable(&self, ctx: &mut T, hasher: &mut stable_hasher::StableHasher) {
-        let Svh { hash } = *self;
-        hash.hash_stable(ctx, hasher);
     }
 }

--- a/compiler/rustc_hir/src/diagnostic_items.rs
+++ b/compiler/rustc_hir/src/diagnostic_items.rs
@@ -1,19 +1,13 @@
 use rustc_data_structures::fx::FxIndexMap;
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
+use rustc_macros::HashStable_Generic;
 use rustc_span::Symbol;
 use rustc_span::def_id::DefIdMap;
 
 use crate::def_id::DefId;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, HashStable_Generic)]
 pub struct DiagnosticItems {
+    #[stable_hasher(ignore)]
     pub id_to_name: DefIdMap<Symbol>,
     pub name_to_id: FxIndexMap<Symbol, DefId>,
-}
-
-impl<CTX: crate::HashStableContext> HashStable<CTX> for DiagnosticItems {
-    #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        self.name_to_id.hash_stable(ctx, hasher);
-    }
 }

--- a/compiler/rustc_macros/src/lib.rs
+++ b/compiler/rustc_macros/src/lib.rs
@@ -64,7 +64,7 @@ decl_derive!(
     hash_stable::hash_stable_generic_derive
 );
 decl_derive!(
-    [HashStable_NoContext] =>
+    [HashStable_NoContext, attributes(stable_hasher)] =>
     /// `HashStable` implementation that has no `HashStableContext` bound and
     /// which adds `where` bounds for `HashStable` based off of fields and not
     /// generics. This is suitable for use in crates like `rustc_type_ir`.

--- a/compiler/rustc_middle/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node.rs
@@ -54,7 +54,7 @@ use rustc_data_structures::fingerprint::{Fingerprint, PackedFingerprint};
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher, StableOrd, ToStableHashKey};
 use rustc_hir::def_id::DefId;
 use rustc_hir::definitions::DefPathHash;
-use rustc_macros::{Decodable, Encodable};
+use rustc_macros::{Decodable, Encodable, HashStable};
 use rustc_span::Symbol;
 
 use super::{KeyFingerprintStyle, SerializedDepNodeIndex};
@@ -290,7 +290,9 @@ pub struct DepKindVTable<'tcx> {
 /// some independent path or string that persists between runs without
 /// the need to be mapped or unmapped. (This ensures we can serialize
 /// them even in the absence of a tcx.)
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Encodable, Decodable)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Encodable, Decodable, HashStable
+)]
 pub struct WorkProductId {
     hash: Fingerprint,
 }
@@ -300,13 +302,6 @@ impl WorkProductId {
         let mut hasher = StableHasher::new();
         cgu_name.hash(&mut hasher);
         WorkProductId { hash: hasher.finish() }
-    }
-}
-
-impl<HCX> HashStable<HCX> for WorkProductId {
-    #[inline]
-    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
-        self.hash.hash_stable(hcx, hasher)
     }
 }
 impl<HCX> ToStableHashKey<HCX> for WorkProductId {

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -891,7 +891,7 @@ pub struct VarBindingForm<'tcx> {
     pub introductions: Vec<VarBindingIntroduction>,
 }
 
-#[derive(Clone, Debug, TyEncodable, TyDecodable)]
+#[derive(Clone, Debug, TyEncodable, TyDecodable, HashStable)]
 pub enum BindingForm<'tcx> {
     /// This is a binding for a non-`self` binding, or a `self` that has an explicit type.
     Var(VarBindingForm<'tcx>),
@@ -907,25 +907,6 @@ pub struct VarBindingIntroduction {
     pub span: Span,
     /// Is that introduction a shorthand struct pattern, i.e. `Foo { x }`.
     pub is_shorthand: bool,
-}
-
-mod binding_form_impl {
-    use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
-
-    use crate::ich::StableHashingContext;
-
-    impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for super::BindingForm<'tcx> {
-        fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
-            use super::BindingForm::*;
-            std::mem::discriminant(self).hash_stable(hcx, hasher);
-
-            match self {
-                Var(binding) => binding.hash_stable(hcx, hasher),
-                ImplicitSelf(kind) => kind.hash_stable(hcx, hasher),
-                RefForGuard(local) => local.hash_stable(hcx, hasher),
-            }
-        }
-    }
 }
 
 /// `BlockTailInfo` is attached to the `LocalDecl` for temporaries

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -2653,7 +2653,7 @@ impl_pos! {
     pub struct BytePos(pub u32);
 
     /// A byte offset relative to file beginning.
-    #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Debug, HashStable_Generic)]
     pub struct RelativeBytePos(pub u32);
 
     /// A character offset.
@@ -2674,12 +2674,6 @@ impl<S: Encoder> Encodable<S> for BytePos {
 impl<D: Decoder> Decodable<D> for BytePos {
     fn decode(d: &mut D) -> BytePos {
         BytePos(d.read_u32())
-    }
-}
-
-impl<H: HashStableContext> HashStable<H> for RelativeBytePos {
-    fn hash_stable(&self, hcx: &mut H, hasher: &mut StableHasher) {
-        self.0.hash_stable(hcx, hasher);
     }
 }
 

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -2,7 +2,7 @@
 //! Note that these are similar to but not always identical to LLVM's feature names,
 //! and Rust adds some features that do not correspond to LLVM features at all.
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
+use rustc_macros::HashStable_Generic;
 use rustc_span::{Symbol, sym};
 
 use crate::spec::{Abi, Arch, FloatAbi, RustcAbi, Target};
@@ -12,7 +12,7 @@ use crate::spec::{Abi, Arch, FloatAbi, RustcAbi, Target};
 pub const RUSTC_SPECIFIC_FEATURES: &[&str] = &["crt-static"];
 
 /// Stability information for target features.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, HashStable_Generic)]
 pub enum Stability {
     /// This target feature is stable, it can be used in `#[target_feature]` and
     /// `#[cfg(target_feature)]`.
@@ -31,22 +31,6 @@ pub enum Stability {
     Forbidden { reason: &'static str },
 }
 use Stability::*;
-
-impl<CTX> HashStable<CTX> for Stability {
-    #[inline]
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
-        std::mem::discriminant(self).hash_stable(hcx, hasher);
-        match self {
-            Stability::Stable => {}
-            Stability::Unstable(nightly_feature) => {
-                nightly_feature.hash_stable(hcx, hasher);
-            }
-            Stability::Forbidden { reason } => {
-                reason.hash_stable(hcx, hasher);
-            }
-        }
-    }
-}
 
 impl Stability {
     /// Returns whether the feature can be used in `cfg(target_feature)` ever.


### PR DESCRIPTION
This applies `HashStable` derive in a couple more places. Also `stable_hasher` is declared for `HashStable_NoContext`.