### PR TITLE
fix interpreter tracing output

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -86,7 +86,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             span = ?stmt.source_info.span,
             tracing_separate_thread = Empty,
         )
-        .or_if_tracing_disabled(|| info!(stmt = ?stmt.kind));
+        .or_if_tracing_disabled(|| info!("{:?}", stmt.kind));
 
         use rustc_middle::mir::StatementKind::*;
 
@@ -490,7 +490,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             span = ?terminator.source_info.span,
             tracing_separate_thread = Empty,
         )
-        .or_if_tracing_disabled(|| info!(terminator = ?terminator.kind));
+        .or_if_tracing_disabled(|| info!("{:?}", terminator.kind));
 
         use rustc_middle::mir::TerminatorKind::*;
         match terminator.kind {

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -802,10 +802,10 @@ impl<'de, 'tcx> MirWriter<'de, 'tcx> {
     }
 }
 
-impl Debug for Statement<'_> {
+impl Debug for StatementKind<'_> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         use self::StatementKind::*;
-        match self.kind {
+        match *self {
             Assign(box (ref place, ref rv)) => write!(fmt, "{place:?} = {rv:?}"),
             FakeRead(box (ref cause, ref place)) => {
                 write!(fmt, "FakeRead({cause:?}, {place:?})")
@@ -842,6 +842,11 @@ impl Debug for Statement<'_> {
                 write!(fmt, "BackwardIncompatibleDropHint({place:?})")
             }
         }
+    }
+}
+impl Debug for Statement<'_> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
+        self.kind.fmt(fmt)
     }
 }
 
@@ -913,6 +918,11 @@ impl<'tcx> Debug for TerminatorKind<'tcx> {
                 write!(fmt, "]")
             }
         }
+    }
+}
+impl Debug for Terminator<'_> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
+        self.kind.fmt(fmt)
     }
 }
 

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -306,7 +306,7 @@ pub enum FakeBorrowKind {
 /// Not all of these are allowed at every [`MirPhase`]. Check the documentation there to see which
 /// ones you do not have to worry about. The MIR validator will generally enforce such restrictions,
 /// causing an ICE if they are violated.
-#[derive(Clone, Debug, PartialEq, TyEncodable, TyDecodable, Hash, HashStable)]
+#[derive(Clone, PartialEq, TyEncodable, TyDecodable, Hash, HashStable)]
 #[derive(TypeFoldable, TypeVisitable)]
 pub enum StatementKind<'tcx> {
     /// Assign statements roughly correspond to an assignment in Rust proper (`x = ...`) except

--- a/compiler/rustc_middle/src/mir/terminator.rs
+++ b/compiler/rustc_middle/src/mir/terminator.rs
@@ -444,7 +444,7 @@ impl<O> AssertKind<O> {
     }
 }
 
-#[derive(Clone, Debug, TyEncodable, TyDecodable, HashStable, TypeFoldable, TypeVisitable)]
+#[derive(Clone, TyEncodable, TyDecodable, HashStable, TypeFoldable, TypeVisitable)]
 pub struct Terminator<'tcx> {
     pub source_info: SourceInfo,
     pub kind: TerminatorKind<'tcx>,


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/144708 accidentally changed the output of `MIRI_LOG=info <miri run>` in two ways:
- by adding `stmt=`/`terminator=` prefixes
- by changing the statement printing to be a verbose debug version instead of MIR pretty-printing

This fixes both of these:
- use explicit format strings to avoid the prefixes
- fix inconsistency in Debug impls for MIR types: now both TerminatorKind and StatementKind are pretty-printed, and Terminator and Statement just forward to the *Kind output