### PR TITLE
Replacing `self` overwriting with proper resolution

### DIFF
--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -626,41 +626,41 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
 
         match use_tree.kind {
             ast::UseTreeKind::Simple(rename) => {
-                let mut ident = use_tree.ident();
                 let mut module_path = prefix;
-                let mut source = module_path.pop().unwrap();
+                let source = module_path.pop().unwrap();
 
                 // `true` for `...::{self [as target]}` imports, `false` otherwise.
                 let type_ns_only = nested && source.ident.name == kw::SelfLower;
 
+                // Suggest `use prefix::{self};` for `use prefix::self;`
                 if source.ident.name == kw::SelfLower
-                    && let Some(parent) = module_path.pop()
+                    && let Some(parent) = module_path.last()
+                    && !type_ns_only
+                    && (parent.ident.name != kw::PathRoot
+                        || self.r.path_root_is_crate_root(parent.ident))
                 {
-                    // Suggest `use prefix::{self};` for `use prefix::self;`
-                    if !type_ns_only
-                        && (parent.ident.name != kw::PathRoot
-                            || self.r.path_root_is_crate_root(parent.ident))
-                    {
-                        let span_with_rename = match rename {
-                            Some(rename) => source.ident.span.to(rename.span),
-                            None => source.ident.span,
-                        };
+                    let span_with_rename = match rename {
+                        Some(rename) => source.ident.span.to(rename.span),
+                        None => source.ident.span,
+                    };
 
-                        self.r.report_error(
-                            parent.ident.span.shrink_to_hi().to(source.ident.span),
-                            ResolutionError::SelfImportsOnlyAllowedWithin {
-                                root: parent.ident.name == kw::PathRoot,
-                                span_with_rename,
-                            },
-                        );
-                    }
-
-                    let self_span = source.ident.span;
-                    source = parent;
-                    if rename.is_none() {
-                        ident = Ident::new(source.ident.name, self_span);
-                    }
+                    self.r.report_error(
+                        parent.ident.span.shrink_to_hi().to(source.ident.span),
+                        ResolutionError::SelfImportsOnlyAllowedWithin {
+                            root: parent.ident.name == kw::PathRoot,
+                            span_with_rename,
+                        },
+                    );
                 }
+
+                let ident = if source.ident.name == kw::SelfLower
+                    && rename.is_none()
+                    && let Some(parent) = module_path.last()
+                {
+                    Ident::new(parent.ident.name, source.ident.span)
+                } else {
+                    use_tree.ident()
+                };
 
                 match source.ident.name {
                     kw::DollarCrate => {
@@ -698,7 +698,11 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
                         }
                     }
                     // Deny `use ::{self};` after edition 2015
-                    kw::PathRoot if !self.r.path_root_is_crate_root(source.ident) => {
+                    kw::SelfLower
+                        if let Some(parent) = module_path.last()
+                            && parent.ident.name == kw::PathRoot
+                            && !self.r.path_root_is_crate_root(parent.ident) =>
+                    {
                         self.r.dcx().span_err(use_tree.span(), "extern prelude cannot be imported");
                         return;
                     }

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -959,12 +959,16 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     ) -> Result<Decl<'ra>, Determinacy> {
         match module {
             ModuleOrUniformRoot::Module(module) => {
-                if ns == TypeNS
-                    && ident.name == kw::Super
-                    && let Some(module) =
-                        self.resolve_super_in_module(ident, Some(module), parent_scope)
-                {
-                    return Ok(module.self_decl.unwrap());
+                if ns == TypeNS {
+                    if ident.name == kw::SelfLower {
+                        return Ok(module.self_decl.unwrap());
+                    }
+                    if ident.name == kw::Super
+                        && let Some(module) =
+                            self.resolve_super_in_module(ident, Some(module), parent_scope)
+                    {
+                        return Ok(module.self_decl.unwrap());
+                    }
                 }
 
                 let (ident_key, def) = IdentKey::new_adjusted(ident, module.expansion);
@@ -1032,7 +1036,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     {
                         let module = self.resolve_crate_root(ident);
                         return Ok(module.self_decl.unwrap());
-                    } else if ident.name == kw::Super || ident.name == kw::SelfLower {
+                    } else if ident.name == kw::Super {
                         // FIXME: Implement these with renaming requirements so that e.g.
                         // `use super;` doesn't work, but `use super as name;` does.
                         // Fall through here to get an error from `early_resolve_...`.

--- a/tests/ui/imports/cycle-import-in-std-1.stderr
+++ b/tests/ui/imports/cycle-import-in-std-1.stderr
@@ -1,11 +1,13 @@
 error[E0432]: unresolved import `ops`
-  --> $DIR/cycle-import-in-std-1.rs:5:11
+  --> $DIR/cycle-import-in-std-1.rs:5:5
    |
 LL | use ops::{self as std};
-   |           ^^^^^^^^^^^ no external crate `ops`
+   |     ^^^
    |
-   = help: consider importing this module instead:
-           std::ops
+help: a similar path exists
+   |
+LL | use core::ops::{self as std};
+   |     ++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/cycle-import-in-std-2.stderr
+++ b/tests/ui/imports/cycle-import-in-std-2.stderr
@@ -1,11 +1,13 @@
 error[E0432]: unresolved import `ops`
-  --> $DIR/cycle-import-in-std-2.rs:5:11
+  --> $DIR/cycle-import-in-std-2.rs:5:5
    |
 LL | use ops::{self as std};
-   |           ^^^^^^^^^^^ no external crate `ops`
+   |     ^^^
    |
-   = help: consider importing this module instead:
-           std::ops
+help: a similar path exists
+   |
+LL | use core::ops::{self as std};
+   |     ++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-28388-1.stderr
+++ b/tests/ui/imports/issue-28388-1.stderr
@@ -2,7 +2,12 @@ error[E0432]: unresolved import `foo`
   --> $DIR/issue-28388-1.rs:4:5
    |
 LL | use foo::{};
-   |     ^^^ no `foo` in the root
+   |     ^^^ use of unresolved module or unlinked crate `foo`
+   |
+help: you might be missing a crate named `foo`, add it to your project and import it in your code
+   |
+LL + extern crate foo;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-38293.stderr
+++ b/tests/ui/imports/issue-38293.stderr
@@ -1,8 +1,8 @@
 error[E0432]: unresolved import `foo::f`
-  --> $DIR/issue-38293.rs:7:14
+  --> $DIR/issue-38293.rs:7:10
    |
 LL | use foo::f::{self};
-   |              ^^^^ no `f` in `foo`
+   |          ^ expected type, found function `f` in `foo`
 
 error[E0423]: expected function, found module `baz`
   --> $DIR/issue-38293.rs:16:5

--- a/tests/ui/imports/issue-45829/import-self.stderr
+++ b/tests/ui/imports/issue-45829/import-self.stderr
@@ -47,9 +47,8 @@ LL | use foo::self;
    = note: `foo` must be defined only once in the type namespace of this module
 help: you can use `as` to change the binding name of the import
    |
-LL - use foo::self;
-LL + use foo as other_foo;
-   |
+LL | use foo::self as other_foo;
+   |               ++++++++++++
 
 error[E0252]: the name `A` is defined multiple times
   --> $DIR/import-self.rs:16:11

--- a/tests/ui/privacy/private-variant-reexport.rs
+++ b/tests/ui/privacy/private-variant-reexport.rs
@@ -8,7 +8,7 @@ mod m2 {
 }
 
 mod m3 {
-    pub use ::E::V::{self}; //~ ERROR `V` is only public within the crate, and cannot be re-exported outside
+    pub use ::E::V::{self}; //~ ERROR unresolved import `E::V`
 }
 
 #[deny(unused_imports)]

--- a/tests/ui/privacy/private-variant-reexport.stderr
+++ b/tests/ui/privacy/private-variant-reexport.stderr
@@ -22,13 +22,11 @@ note: consider marking `V` as `pub` in the imported module
 LL |     pub use ::E::{V};
    |                   ^
 
-error[E0365]: `V` is only public within the crate, and cannot be re-exported outside
-  --> $DIR/private-variant-reexport.rs:11:22
+error[E0432]: unresolved import `E::V`
+  --> $DIR/private-variant-reexport.rs:11:18
    |
 LL |     pub use ::E::V::{self};
-   |                      ^^^^ re-export of crate public `V`
-   |
-   = note: consider declaring type or module `V` with `pub`
+   |                  ^ `V` is a variant, not a module
 
 error: glob import doesn't reexport anything with visibility `pub` because no imported item is public enough
   --> $DIR/private-variant-reexport.rs:16:13
@@ -56,5 +54,5 @@ LL |     pub use ::E::*;
 
 error: aborting due to 5 previous errors
 
-Some errors have detailed explanations: E0364, E0365.
+Some errors have detailed explanations: E0364, E0432.
 For more information about an error, try `rustc --explain E0364`.

--- a/tests/ui/resolve/resolve-bad-import-prefix.rs
+++ b/tests/ui/resolve/resolve-bad-import-prefix.rs
@@ -8,7 +8,7 @@ use {}; // OK
 use ::{}; // OK
 use m::{}; // OK
 use E::{}; // OK
-use S::{}; // FIXME, this and `use S::{self};` should be an error
+use S::{}; //~ ERROR unresolved import `S`
 use Tr::{}; // FIXME, this and `use Tr::{self};` should be an error
 use Nonexistent::{}; //~ ERROR unresolved import `Nonexistent`
 

--- a/tests/ui/resolve/resolve-bad-import-prefix.stderr
+++ b/tests/ui/resolve/resolve-bad-import-prefix.stderr
@@ -1,9 +1,20 @@
+error[E0432]: unresolved import `S`
+  --> $DIR/resolve-bad-import-prefix.rs:11:5
+   |
+LL | use S::{};
+   |     ^ `S` is a struct, not a module
+
 error[E0432]: unresolved import `Nonexistent`
   --> $DIR/resolve-bad-import-prefix.rs:13:5
    |
 LL | use Nonexistent::{};
-   |     ^^^^^^^^^^^ no `Nonexistent` in the root
+   |     ^^^^^^^^^^^ use of unresolved module or unlinked crate `Nonexistent`
+   |
+help: you might be missing a crate named `Nonexistent`, add it to your project and import it in your code
+   |
+LL + extern crate Nonexistent;
+   |
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0432`.

--- a/tests/ui/use/pub-use-self-super-crate.rs
+++ b/tests/ui/use/pub-use-self-super-crate.rs
@@ -8,7 +8,7 @@ mod foo {
         pub use self::super as parent2;
         //~^ ERROR `super` is only public within the crate, and cannot be re-exported outside
         pub use super::{self as parent3};
-        //~^ ERROR `super` is only public within the crate, and cannot be re-exported outside
+        //~^ ERROR `self` is only public within the crate, and cannot be re-exported outside
         pub use self::{super as parent4};
         //~^ ERROR `super` is only public within the crate, and cannot be re-exported outside
 

--- a/tests/ui/use/pub-use-self-super-crate.stderr
+++ b/tests/ui/use/pub-use-self-super-crate.stderr
@@ -22,13 +22,13 @@ LL |         pub use self::super as parent2;
    |
    = note: consider declaring type or module `super` with `pub`
 
-error[E0365]: `super` is only public within the crate, and cannot be re-exported outside
+error[E0365]: `self` is only public within the crate, and cannot be re-exported outside
   --> $DIR/pub-use-self-super-crate.rs:10:25
    |
 LL |         pub use super::{self as parent3};
-   |                         ^^^^^^^^^^^^^^^ re-export of crate public `super`
+   |                         ^^^^^^^^^^^^^^^ re-export of crate public `self`
    |
-   = note: consider declaring type or module `super` with `pub`
+   = note: consider declaring type or module `self` with `pub`
 
 error[E0365]: `super` is only public within the crate, and cannot be re-exported outside
   --> $DIR/pub-use-self-super-crate.rs:12:24

--- a/tests/ui/use/use-mod/use-mod-4.stderr
+++ b/tests/ui/use/use-mod/use-mod-4.stderr
@@ -31,10 +31,15 @@ LL | use std::mem::{self};
    |               +    +
 
 error[E0432]: unresolved import `crate::foo`
-  --> $DIR/use-mod-4.rs:1:5
+  --> $DIR/use-mod-4.rs:1:12
    |
 LL | use crate::foo::self;
-   |     ^^^^^^^^^^^^^^^^ no `foo` in the root
+   |            ^^^ use of unresolved module or unlinked crate `foo`
+   |
+help: you might be missing a crate named `foo`, add it to your project and import it in your code
+   |
+LL + extern crate foo;
+   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/use/use-path-segment-kw.e2015.stderr
+++ b/tests/ui/use/use-path-segment-kw.e2015.stderr
@@ -935,39 +935,49 @@ help: try renaming it with a name
 LL |         use $crate::{self as name};
    |                           +++++++
 
-error[E0432]: unresolved import `foobar`
+error[E0433]: cannot find module or crate `foobar` in the crate root
   --> $DIR/use-path-segment-kw.rs:187:17
    |
 LL |         pub use foobar::qux::self;
-   |                 ^^^^^^
+   |                 ^^^^^^ use of unresolved module or unlinked crate `foobar`
    |
-help: a similar path exists
+help: you might be missing a crate named `foobar`, add it to your project and import it in your code
    |
-LL |         pub use self::foobar::qux::self;
-   |                 ++++++
+LL + extern crate foobar;
+   |
+
+error[E0433]: cannot find module or crate `foobar` in the crate root
+  --> $DIR/use-path-segment-kw.rs:191:17
+   |
+LL |         pub use foobar::baz::{self};
+   |                 ^^^^^^ use of unresolved module or unlinked crate `foobar`
+   |
+help: you might be missing a crate named `foobar`, add it to your project and import it in your code
+   |
+LL + extern crate foobar;
+   |
 
 error[E0432]: unresolved import `foobar`
   --> $DIR/use-path-segment-kw.rs:189:17
    |
 LL |         pub use foobar::self as _self3;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^ no `foobar` in the root
-
-error[E0432]: unresolved import `foobar`
-  --> $DIR/use-path-segment-kw.rs:191:17
-   |
-LL |         pub use foobar::baz::{self};
    |                 ^^^^^^
    |
 help: a similar path exists
    |
-LL |         pub use self::foobar::baz::{self};
+LL |         pub use self::foobar::self as _self3;
    |                 ++++++
 
 error[E0432]: unresolved import `foobar`
-  --> $DIR/use-path-segment-kw.rs:192:26
+  --> $DIR/use-path-segment-kw.rs:192:17
    |
 LL |         pub use foobar::{self as _nested_self3};
-   |                          ^^^^^^^^^^^^^^^^^^^^^ no `foobar` in the root
+   |                 ^^^^^^
+   |
+help: a similar path exists
+   |
+LL |         pub use self::foobar::{self as _nested_self3};
+   |                 ++++++
 
 error[E0433]: `self` in paths can only be used in start position
   --> $DIR/use-path-segment-kw.rs:215:36

--- a/tests/ui/use/use-path-segment-kw.rs
+++ b/tests/ui/use/use-path-segment-kw.rs
@@ -185,10 +185,10 @@ pub mod foo {
 
         type D3 = foobar::self; //~ ERROR `self` in paths can only be used in start position
         pub use foobar::qux::self; //~ ERROR `self` imports are only allowed within a { } list
-        //[e2015]~^ ERROR unresolved import `foobar`
+        //[e2015]~^ ERROR cannot find module or crate `foobar` in the crate root
         pub use foobar::self as _self3; //~ ERROR `self` imports are only allowed within a { } list
         //[e2015]~^ ERROR unresolved import `foobar`
-        pub use foobar::baz::{self}; //[e2015]~ ERROR unresolved import `foobar`
+        pub use foobar::baz::{self}; //[e2015]~ ERROR cannot find module or crate `foobar` in the crate root
         pub use foobar::{self as _nested_self3}; //[e2015]~ ERROR unresolved import `foobar`
 
         type D4 = crate::self; //~ ERROR `self` in paths can only be used in start position

--- a/tests/ui/use/use-self-at-end.e2015.stderr
+++ b/tests/ui/use/use-self-at-end.e2015.stderr
@@ -1,0 +1,528 @@
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:14:22
+   |
+LL |         pub use crate::self;
+   |                      ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use crate::self;
+LL +         pub use crate;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use crate::{self};
+   |                        +    +
+
+error: imports need to be explicitly named
+  --> $DIR/use-self-at-end.rs:14:24
+   |
+LL |         pub use crate::self;
+   |                        ^^^^
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:16:22
+   |
+LL |         pub use crate::self as crate1;
+   |                      ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use crate::self as crate1;
+LL +         pub use crate as crate1;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use crate::{self as crate1};
+   |                        +              +
+
+error: imports need to be explicitly named
+  --> $DIR/use-self-at-end.rs:17:25
+   |
+LL |         pub use crate::{self};
+   |                         ^^^^
+   |
+help: try renaming it with a name
+   |
+LL |         pub use crate::{self as name};
+   |                              +++++++
+
+error: imports need to be explicitly named
+  --> $DIR/use-self-at-end.rs:21:17
+   |
+LL |         pub use self;
+   |                 ^^^^
+
+error: imports need to be explicitly named
+  --> $DIR/use-self-at-end.rs:23:18
+   |
+LL |         pub use {self};
+   |                  ^^^^
+   |
+help: try renaming it with a name
+   |
+LL |         pub use {self as name};
+   |                       +++++++
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:27:21
+   |
+LL |         pub use self::self;
+   |                     ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use self::self;
+LL +         pub use self;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use self::{self};
+   |                       +    +
+
+error: imports need to be explicitly named
+  --> $DIR/use-self-at-end.rs:27:23
+   |
+LL |         pub use self::self;
+   |                       ^^^^
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:29:21
+   |
+LL |         pub use self::self as self3;
+   |                     ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use self::self as self3;
+LL +         pub use self as self3;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use self::{self as self3};
+   |                       +             +
+
+error: imports need to be explicitly named
+  --> $DIR/use-self-at-end.rs:30:24
+   |
+LL |         pub use self::{self};
+   |                        ^^^^
+   |
+help: try renaming it with a name
+   |
+LL |         pub use self::{self as name};
+   |                             +++++++
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:34:22
+   |
+LL |         pub use super::self;
+   |                      ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use super::self;
+LL +         pub use super;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use super::{self};
+   |                        +    +
+
+error: imports need to be explicitly named
+  --> $DIR/use-self-at-end.rs:34:24
+   |
+LL |         pub use super::self;
+   |                        ^^^^
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:36:22
+   |
+LL |         pub use super::self as super1;
+   |                      ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use super::self as super1;
+LL +         pub use super as super1;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use super::{self as super1};
+   |                        +              +
+
+error: imports need to be explicitly named
+  --> $DIR/use-self-at-end.rs:37:25
+   |
+LL |         pub use super::{self};
+   |                         ^^^^
+   |
+help: try renaming it with a name
+   |
+LL |         pub use super::{self as name};
+   |                              +++++++
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:41:25
+   |
+LL |         pub use crate::x::self;
+   |                         ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use crate::x::self;
+LL +         pub use crate::x;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use crate::x::{self};
+   |                           +    +
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:42:25
+   |
+LL |         pub use crate::x::self as x3;
+   |                         ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use crate::x::self as x3;
+LL +         pub use crate::x as x3;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use crate::x::{self as x3};
+   |                           +          +
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:47:17
+   |
+LL |         pub use ::self;
+   |                 ^^^^^^
+
+error: imports need to be explicitly named
+  --> $DIR/use-self-at-end.rs:47:19
+   |
+LL |         pub use ::self;
+   |                   ^^^^
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:50:17
+   |
+LL |         pub use ::self as crate4;
+   |                 ^^^^^^
+
+error: imports need to be explicitly named
+  --> $DIR/use-self-at-end.rs:52:20
+   |
+LL |         pub use ::{self};
+   |                    ^^^^
+   |
+help: try renaming it with a name
+   |
+LL |         pub use ::{self as name};
+   |                         +++++++
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:57:24
+   |
+LL |         pub use z::self::self;
+   |                        ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use z::self::self;
+LL +         pub use z::self;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use z::self::{self};
+   |                          +    +
+
+error: imports need to be explicitly named
+  --> $DIR/use-self-at-end.rs:57:26
+   |
+LL |         pub use z::self::self;
+   |                          ^^^^
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:59:24
+   |
+LL |         pub use z::self::self as z1;
+   |                        ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use z::self::self as z1;
+LL +         pub use z::self as z1;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use z::self::{self as z1};
+   |                          +          +
+
+error: imports need to be explicitly named
+  --> $DIR/use-self-at-end.rs:61:28
+   |
+LL |         pub use z::{self::{self}};
+   |                            ^^^^
+   |
+help: try renaming it with a name
+   |
+LL |         pub use z::{self::{self as name}};
+   |                                 +++++++
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:65:30
+   |
+LL |         pub use super::Struct::self;
+   |                              ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use super::Struct::self;
+LL +         pub use super::Struct;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use super::Struct::{self};
+   |                                +    +
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:67:30
+   |
+LL |         pub use super::Struct::self as Struct1;
+   |                              ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use super::Struct::self as Struct1;
+LL +         pub use super::Struct as Struct1;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use super::Struct::{self as Struct1};
+   |                                +               +
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:73:28
+   |
+LL |         pub use super::Enum::self;
+   |                            ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use super::Enum::self;
+LL +         pub use super::Enum;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use super::Enum::{self};
+   |                              +    +
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:74:28
+   |
+LL |         pub use super::Enum::self as Enum1;
+   |                            ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use super::Enum::self as Enum1;
+LL +         pub use super::Enum as Enum1;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use super::Enum::{self as Enum1};
+   |                              +             +
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:79:29
+   |
+LL |         pub use super::Trait::self;
+   |                             ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use super::Trait::self;
+LL +         pub use super::Trait;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use super::Trait::{self};
+   |                               +    +
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:80:29
+   |
+LL |         pub use super::Trait::self as Trait1;
+   |                             ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use super::Trait::self as Trait1;
+LL +         pub use super::Trait as Trait1;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use super::Trait::{self as Trait1};
+   |                               +              +
+
+error[E0252]: the name `x` is defined multiple times
+  --> $DIR/use-self-at-end.rs:43:28
+   |
+LL |         pub use crate::x::self;
+   |                 -------------- previous import of the module `x` here
+LL |         pub use crate::x::self as x3;
+LL |         pub use crate::x::{self};
+   |         -------------------^^^^--
+   |         |                  |
+   |         |                  `x` reimported here
+   |         help: remove unnecessary import
+   |
+   = note: `x` must be defined only once in the type namespace of this module
+
+error[E0252]: the name `Enum` is defined multiple times
+  --> $DIR/use-self-at-end.rs:75:31
+   |
+LL |         pub use super::Enum::self;
+   |                 ----------------- previous import of the type `Enum` here
+LL |         pub use super::Enum::self as Enum1;
+LL |         pub use super::Enum::{self};
+   |         ----------------------^^^^--
+   |         |                     |
+   |         |                     `Enum` reimported here
+   |         help: remove unnecessary import
+   |
+   = note: `Enum` must be defined only once in the type namespace of this module
+
+error[E0252]: the name `Trait` is defined multiple times
+  --> $DIR/use-self-at-end.rs:81:32
+   |
+LL |         pub use super::Trait::self;
+   |                 ------------------ previous import of the trait `Trait` here
+LL |         pub use super::Trait::self as Trait1;
+LL |         pub use super::Trait::{self};
+   |         -----------------------^^^^--
+   |         |                      |
+   |         |                      `Trait` reimported here
+   |         help: remove unnecessary import
+   |
+   = note: `Trait` must be defined only once in the type namespace of this module
+
+error[E0433]: `self` in paths can only be used in start position
+  --> $DIR/use-self-at-end.rs:59:20
+   |
+LL |         pub use z::self::self as z1;
+   |                    ^^^^ can only be used in path start position
+
+error[E0433]: `self` in paths can only be used in start position
+  --> $DIR/use-self-at-end.rs:62:21
+   |
+LL |         pub use z::{self::{self as z2}};
+   |                     ^^^^ can only be used in path start position
+
+error[E0432]: unresolved import `super::Struct`
+  --> $DIR/use-self-at-end.rs:65:24
+   |
+LL |         pub use super::Struct::self;
+   |                        ^^^^^^ `Struct` is a struct, not a module
+
+error[E0432]: unresolved import `super::Struct`
+  --> $DIR/use-self-at-end.rs:67:24
+   |
+LL |         pub use super::Struct::self as Struct1;
+   |                        ^^^^^^ `Struct` is a struct, not a module
+
+error[E0432]: unresolved import `super::Struct`
+  --> $DIR/use-self-at-end.rs:69:24
+   |
+LL |         pub use super::Struct::{self};
+   |                        ^^^^^^ `Struct` is a struct, not a module
+
+error[E0432]: unresolved import `super::Struct`
+  --> $DIR/use-self-at-end.rs:70:24
+   |
+LL |         pub use super::Struct::{self as Struct2};
+   |                        ^^^^^^ `Struct` is a struct, not a module
+
+error[E0433]: `self` in paths can only be used in start position
+  --> $DIR/use-self-at-end.rs:56:21
+   |
+LL |         type G = z::self::self;
+   |                     ^^^^ can only be used in path start position
+
+error[E0433]: `self` in paths can only be used in start position
+  --> $DIR/use-self-at-end.rs:72:31
+   |
+LL |         type I = super::Enum::self;
+   |                               ^^^^ can only be used in path start position
+
+error[E0433]: `self` in paths can only be used in start position
+  --> $DIR/use-self-at-end.rs:78:32
+   |
+LL |         type J = super::Trait::self;
+   |                                ^^^^ can only be used in path start position
+
+error[E0573]: expected type, found module `self`
+  --> $DIR/use-self-at-end.rs:20:18
+   |
+LL |         type B = self;
+   |                  ^^^^ not a type
+
+error[E0433]: `self` in paths can only be used in start position
+  --> $DIR/use-self-at-end.rs:40:28
+   |
+LL |         type E = crate::x::self;
+   |                            ^^^^ can only be used in path start position
+   |
+help: consider importing this module
+   |
+LL +         use x;
+   |
+help: if you import `x`, refer to it directly
+   |
+LL -         type E = crate::x::self;
+LL +         type E = x::self;
+   |
+
+error[E0223]: ambiguous associated type
+  --> $DIR/use-self-at-end.rs:64:18
+   |
+LL |         type H = super::Struct::self;
+   |                  ^^^^^^^^^^^^^^^^^^^
+   |
+help: if there were a trait named `Example` with associated type `self` implemented for `x::Struct`, you could use the fully-qualified path
+   |
+LL -         type H = super::Struct::self;
+LL +         type H = <x::Struct as Example>::self;
+   |
+
+error[E0433]: `self` in paths can only be used in start position
+  --> $DIR/use-self-at-end.rs:13:25
+   |
+LL |         type A = crate::self;
+   |                         ^^^^ can only be used in path start position
+
+error[E0433]: `self` in paths can only be used in start position
+  --> $DIR/use-self-at-end.rs:26:24
+   |
+LL |         type C = self::self;
+   |                        ^^^^ can only be used in path start position
+
+error[E0433]: `self` in paths can only be used in start position
+  --> $DIR/use-self-at-end.rs:33:25
+   |
+LL |         type D = super::self;
+   |                         ^^^^ can only be used in path start position
+
+error[E0433]: global paths cannot start with `self`
+  --> $DIR/use-self-at-end.rs:46:20
+   |
+LL |         type F = ::self;
+   |                    ^^^^ cannot start with this
+
+error: aborting due to 49 previous errors
+
+Some errors have detailed explanations: E0223, E0252, E0429, E0432, E0433, E0573.
+For more information about an error, try `rustc --explain E0223`.

--- a/tests/ui/use/use-self-at-end.e2018.stderr
+++ b/tests/ui/use/use-self-at-end.e2018.stderr
@@ -1,0 +1,523 @@
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:14:22
+   |
+LL |         pub use crate::self;
+   |                      ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use crate::self;
+LL +         pub use crate;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use crate::{self};
+   |                        +    +
+
+error: imports need to be explicitly named
+  --> $DIR/use-self-at-end.rs:14:24
+   |
+LL |         pub use crate::self;
+   |                        ^^^^
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:16:22
+   |
+LL |         pub use crate::self as crate1;
+   |                      ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use crate::self as crate1;
+LL +         pub use crate as crate1;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use crate::{self as crate1};
+   |                        +              +
+
+error: imports need to be explicitly named
+  --> $DIR/use-self-at-end.rs:17:25
+   |
+LL |         pub use crate::{self};
+   |                         ^^^^
+   |
+help: try renaming it with a name
+   |
+LL |         pub use crate::{self as name};
+   |                              +++++++
+
+error: imports need to be explicitly named
+  --> $DIR/use-self-at-end.rs:21:17
+   |
+LL |         pub use self;
+   |                 ^^^^
+
+error: imports need to be explicitly named
+  --> $DIR/use-self-at-end.rs:23:18
+   |
+LL |         pub use {self};
+   |                  ^^^^
+   |
+help: try renaming it with a name
+   |
+LL |         pub use {self as name};
+   |                       +++++++
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:27:21
+   |
+LL |         pub use self::self;
+   |                     ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use self::self;
+LL +         pub use self;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use self::{self};
+   |                       +    +
+
+error: imports need to be explicitly named
+  --> $DIR/use-self-at-end.rs:27:23
+   |
+LL |         pub use self::self;
+   |                       ^^^^
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:29:21
+   |
+LL |         pub use self::self as self3;
+   |                     ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use self::self as self3;
+LL +         pub use self as self3;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use self::{self as self3};
+   |                       +             +
+
+error: imports need to be explicitly named
+  --> $DIR/use-self-at-end.rs:30:24
+   |
+LL |         pub use self::{self};
+   |                        ^^^^
+   |
+help: try renaming it with a name
+   |
+LL |         pub use self::{self as name};
+   |                             +++++++
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:34:22
+   |
+LL |         pub use super::self;
+   |                      ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use super::self;
+LL +         pub use super;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use super::{self};
+   |                        +    +
+
+error: imports need to be explicitly named
+  --> $DIR/use-self-at-end.rs:34:24
+   |
+LL |         pub use super::self;
+   |                        ^^^^
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:36:22
+   |
+LL |         pub use super::self as super1;
+   |                      ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use super::self as super1;
+LL +         pub use super as super1;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use super::{self as super1};
+   |                        +              +
+
+error: imports need to be explicitly named
+  --> $DIR/use-self-at-end.rs:37:25
+   |
+LL |         pub use super::{self};
+   |                         ^^^^
+   |
+help: try renaming it with a name
+   |
+LL |         pub use super::{self as name};
+   |                              +++++++
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:41:25
+   |
+LL |         pub use crate::x::self;
+   |                         ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use crate::x::self;
+LL +         pub use crate::x;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use crate::x::{self};
+   |                           +    +
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:42:25
+   |
+LL |         pub use crate::x::self as x3;
+   |                         ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use crate::x::self as x3;
+LL +         pub use crate::x as x3;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use crate::x::{self as x3};
+   |                           +          +
+
+error: extern prelude cannot be imported
+  --> $DIR/use-self-at-end.rs:47:17
+   |
+LL |         pub use ::self;
+   |                 ^^^^^^
+
+error: extern prelude cannot be imported
+  --> $DIR/use-self-at-end.rs:50:17
+   |
+LL |         pub use ::self as crate4;
+   |                 ^^^^^^^^^^^^^^^^
+
+error: extern prelude cannot be imported
+  --> $DIR/use-self-at-end.rs:52:20
+   |
+LL |         pub use ::{self};
+   |                    ^^^^
+
+error: extern prelude cannot be imported
+  --> $DIR/use-self-at-end.rs:54:20
+   |
+LL |         pub use ::{self as crate5};
+   |                    ^^^^^^^^^^^^^^
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:57:24
+   |
+LL |         pub use z::self::self;
+   |                        ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use z::self::self;
+LL +         pub use z::self;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use z::self::{self};
+   |                          +    +
+
+error: imports need to be explicitly named
+  --> $DIR/use-self-at-end.rs:57:26
+   |
+LL |         pub use z::self::self;
+   |                          ^^^^
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:59:24
+   |
+LL |         pub use z::self::self as z1;
+   |                        ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use z::self::self as z1;
+LL +         pub use z::self as z1;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use z::self::{self as z1};
+   |                          +          +
+
+error: imports need to be explicitly named
+  --> $DIR/use-self-at-end.rs:61:28
+   |
+LL |         pub use z::{self::{self}};
+   |                            ^^^^
+   |
+help: try renaming it with a name
+   |
+LL |         pub use z::{self::{self as name}};
+   |                                 +++++++
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:65:30
+   |
+LL |         pub use super::Struct::self;
+   |                              ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use super::Struct::self;
+LL +         pub use super::Struct;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use super::Struct::{self};
+   |                                +    +
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:67:30
+   |
+LL |         pub use super::Struct::self as Struct1;
+   |                              ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use super::Struct::self as Struct1;
+LL +         pub use super::Struct as Struct1;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use super::Struct::{self as Struct1};
+   |                                +               +
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:73:28
+   |
+LL |         pub use super::Enum::self;
+   |                            ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use super::Enum::self;
+LL +         pub use super::Enum;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use super::Enum::{self};
+   |                              +    +
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:74:28
+   |
+LL |         pub use super::Enum::self as Enum1;
+   |                            ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use super::Enum::self as Enum1;
+LL +         pub use super::Enum as Enum1;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use super::Enum::{self as Enum1};
+   |                              +             +
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:79:29
+   |
+LL |         pub use super::Trait::self;
+   |                             ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use super::Trait::self;
+LL +         pub use super::Trait;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use super::Trait::{self};
+   |                               +    +
+
+error[E0429]: `self` imports are only allowed within a { } list
+  --> $DIR/use-self-at-end.rs:80:29
+   |
+LL |         pub use super::Trait::self as Trait1;
+   |                             ^^^^^^
+   |
+help: consider importing the module directly
+   |
+LL -         pub use super::Trait::self as Trait1;
+LL +         pub use super::Trait as Trait1;
+   |
+help: alternatively, use the multi-path `use` syntax to import `self`
+   |
+LL |         pub use super::Trait::{self as Trait1};
+   |                               +              +
+
+error[E0252]: the name `x` is defined multiple times
+  --> $DIR/use-self-at-end.rs:43:28
+   |
+LL |         pub use crate::x::self;
+   |                 -------------- previous import of the module `x` here
+LL |         pub use crate::x::self as x3;
+LL |         pub use crate::x::{self};
+   |         -------------------^^^^--
+   |         |                  |
+   |         |                  `x` reimported here
+   |         help: remove unnecessary import
+   |
+   = note: `x` must be defined only once in the type namespace of this module
+
+error[E0252]: the name `Enum` is defined multiple times
+  --> $DIR/use-self-at-end.rs:75:31
+   |
+LL |         pub use super::Enum::self;
+   |                 ----------------- previous import of the type `Enum` here
+LL |         pub use super::Enum::self as Enum1;
+LL |         pub use super::Enum::{self};
+   |         ----------------------^^^^--
+   |         |                     |
+   |         |                     `Enum` reimported here
+   |         help: remove unnecessary import
+   |
+   = note: `Enum` must be defined only once in the type namespace of this module
+
+error[E0252]: the name `Trait` is defined multiple times
+  --> $DIR/use-self-at-end.rs:81:32
+   |
+LL |         pub use super::Trait::self;
+   |                 ------------------ previous import of the trait `Trait` here
+LL |         pub use super::Trait::self as Trait1;
+LL |         pub use super::Trait::{self};
+   |         -----------------------^^^^--
+   |         |                      |
+   |         |                      `Trait` reimported here
+   |         help: remove unnecessary import
+   |
+   = note: `Trait` must be defined only once in the type namespace of this module
+
+error[E0433]: `self` in paths can only be used in start position
+  --> $DIR/use-self-at-end.rs:59:20
+   |
+LL |         pub use z::self::self as z1;
+   |                    ^^^^ can only be used in path start position
+
+error[E0433]: `self` in paths can only be used in start position
+  --> $DIR/use-self-at-end.rs:62:21
+   |
+LL |         pub use z::{self::{self as z2}};
+   |                     ^^^^ can only be used in path start position
+
+error[E0432]: unresolved import `super::Struct`
+  --> $DIR/use-self-at-end.rs:65:24
+   |
+LL |         pub use super::Struct::self;
+   |                        ^^^^^^ `Struct` is a struct, not a module
+
+error[E0432]: unresolved import `super::Struct`
+  --> $DIR/use-self-at-end.rs:67:24
+   |
+LL |         pub use super::Struct::self as Struct1;
+   |                        ^^^^^^ `Struct` is a struct, not a module
+
+error[E0432]: unresolved import `super::Struct`
+  --> $DIR/use-self-at-end.rs:69:24
+   |
+LL |         pub use super::Struct::{self};
+   |                        ^^^^^^ `Struct` is a struct, not a module
+
+error[E0432]: unresolved import `super::Struct`
+  --> $DIR/use-self-at-end.rs:70:24
+   |
+LL |         pub use super::Struct::{self as Struct2};
+   |                        ^^^^^^ `Struct` is a struct, not a module
+
+error[E0433]: `self` in paths can only be used in start position
+  --> $DIR/use-self-at-end.rs:56:21
+   |
+LL |         type G = z::self::self;
+   |                     ^^^^ can only be used in path start position
+
+error[E0433]: `self` in paths can only be used in start position
+  --> $DIR/use-self-at-end.rs:72:31
+   |
+LL |         type I = super::Enum::self;
+   |                               ^^^^ can only be used in path start position
+
+error[E0433]: `self` in paths can only be used in start position
+  --> $DIR/use-self-at-end.rs:78:32
+   |
+LL |         type J = super::Trait::self;
+   |                                ^^^^ can only be used in path start position
+
+error[E0573]: expected type, found module `self`
+  --> $DIR/use-self-at-end.rs:20:18
+   |
+LL |         type B = self;
+   |                  ^^^^ not a type
+
+error[E0433]: `self` in paths can only be used in start position
+  --> $DIR/use-self-at-end.rs:40:28
+   |
+LL |         type E = crate::x::self;
+   |                            ^^^^ can only be used in path start position
+   |
+help: consider importing this module
+   |
+LL +         use crate::x;
+   |
+help: if you import `x`, refer to it directly
+   |
+LL -         type E = crate::x::self;
+LL +         type E = x::self;
+   |
+
+error[E0223]: ambiguous associated type
+  --> $DIR/use-self-at-end.rs:64:18
+   |
+LL |         type H = super::Struct::self;
+   |                  ^^^^^^^^^^^^^^^^^^^
+   |
+help: if there were a trait named `Example` with associated type `self` implemented for `x::Struct`, you could use the fully-qualified path
+   |
+LL -         type H = super::Struct::self;
+LL +         type H = <x::Struct as Example>::self;
+   |
+
+error[E0433]: `self` in paths can only be used in start position
+  --> $DIR/use-self-at-end.rs:13:25
+   |
+LL |         type A = crate::self;
+   |                         ^^^^ can only be used in path start position
+
+error[E0433]: `self` in paths can only be used in start position
+  --> $DIR/use-self-at-end.rs:26:24
+   |
+LL |         type C = self::self;
+   |                        ^^^^ can only be used in path start position
+
+error[E0433]: `self` in paths can only be used in start position
+  --> $DIR/use-self-at-end.rs:33:25
+   |
+LL |         type D = super::self;
+   |                         ^^^^ can only be used in path start position
+
+error[E0433]: global paths cannot start with `self`
+  --> $DIR/use-self-at-end.rs:46:20
+   |
+LL |         type F = ::self;
+   |                    ^^^^ cannot start with this
+
+error: aborting due to 49 previous errors
+
+Some errors have detailed explanations: E0223, E0252, E0429, E0432, E0433, E0573.
+For more information about an error, try `rustc --explain E0223`.

--- a/tests/ui/use/use-self-at-end.rs
+++ b/tests/ui/use/use-self-at-end.rs
@@ -1,0 +1,88 @@
+//@ revisions: e2015 e2018
+//@ [e2015] edition: 2015
+//@ [e2018] edition: 2018..
+
+pub mod x {
+    pub struct Struct;
+    pub enum Enum {}
+    pub trait Trait {}
+
+    pub mod y {
+        pub mod z {}
+
+        type A = crate::self; //~ ERROR `self` in paths can only be used in start position
+        pub use crate::self; //~ ERROR `self` imports are only allowed within a { } list
+        //~^ ERROR imports need to be explicitly named
+        pub use crate::self as crate1; //~ ERROR `self` imports are only allowed within a { } list
+        pub use crate::{self}; //~ ERROR imports need to be explicitly named
+        pub use crate::{self as crate2};
+
+        type B = self; //~ ERROR expected type, found module `self`
+        pub use self; //~ ERROR imports need to be explicitly named
+        pub use self as self1;
+        pub use {self}; //~ ERROR imports need to be explicitly named
+        pub use {self as self2};
+
+        type C = self::self; //~ ERROR `self` in paths can only be used in start position
+        pub use self::self; //~ ERROR `self` imports are only allowed within a { } list
+        //~^ ERROR imports need to be explicitly named
+        pub use self::self as self3; //~ ERROR `self` imports are only allowed within a { } list
+        pub use self::{self}; //~ ERROR imports need to be explicitly named
+        pub use self::{self as self4};
+
+        type D = super::self; //~ ERROR `self` in paths can only be used in start position
+        pub use super::self; //~ ERROR `self` imports are only allowed within a { } list
+        //~^ ERROR imports need to be explicitly named
+        pub use super::self as super1; //~ ERROR `self` imports are only allowed within a { } list
+        pub use super::{self}; //~ ERROR imports need to be explicitly named
+        pub use super::{self as super2};
+
+        type E = crate::x::self; //~ ERROR `self` in paths can only be used in start position
+        pub use crate::x::self; //~ ERROR `self` imports are only allowed within a { } list
+        pub use crate::x::self as x3; //~ ERROR `self` imports are only allowed within a { } list
+        pub use crate::x::{self}; //~ ERROR the name `x` is defined multiple times
+        pub use crate::x::{self as x4};
+
+        type F = ::self; //~ ERROR global paths cannot start with `self`
+        pub use ::self; //[e2018]~ ERROR extern prelude cannot be imported
+        //[e2015]~^ ERROR imports need to be explicitly named
+        //[e2015]~^^ ERROR `self` imports are only allowed within a { } list
+        pub use ::self as crate4; //[e2018]~ ERROR extern prelude cannot be imported
+        //[e2015]~^ ERROR `self` imports are only allowed within a { } list
+        pub use ::{self}; //[e2018]~ ERROR extern prelude cannot be imported
+        //[e2015]~^ ERROR imports need to be explicitly named
+        pub use ::{self as crate5}; //[e2018]~ ERROR extern prelude cannot be imported
+
+        type G = z::self::self; //~ ERROR `self` in paths can only be used in start position
+        pub use z::self::self; //~ ERROR imports need to be explicitly named
+        //~^ ERROR `self` imports are only allowed within a { } list
+        pub use z::self::self as z1; //~ ERROR `self` in paths can only be used in start position
+        //~^ ERROR `self` imports are only allowed within a { } list
+        pub use z::{self::{self}}; //~ ERROR imports need to be explicitly named
+        pub use z::{self::{self as z2}}; //~ ERROR `self` in paths can only be used in start position
+
+        type H = super::Struct::self; //~ ERROR ambiguous associated type
+        pub use super::Struct::self; //~ ERROR unresolved import `super::Struct`
+        //~^ ERROR `self` imports are only allowed within a { } list
+        pub use super::Struct::self as Struct1; //~ ERROR unresolved import `super::Struct`
+        //~^ ERROR `self` imports are only allowed within a { } list
+        pub use super::Struct::{self}; //~ ERROR unresolved import `super::Struct`
+        pub use super::Struct::{self as Struct2}; //~ ERROR unresolved import `super::Struct`
+
+        type I = super::Enum::self; //~ ERROR `self` in paths can only be used in start position
+        pub use super::Enum::self; //~ ERROR `self` imports are only allowed within a { } list
+        pub use super::Enum::self as Enum1; //~ ERROR `self` imports are only allowed within a { } list
+        pub use super::Enum::{self}; //~ ERROR the name `Enum` is defined multiple times
+        pub use super::Enum::{self as Enum2};
+
+        type J = super::Trait::self; //~ ERROR `self` in paths can only be used in start position
+        pub use super::Trait::self; //~ ERROR `self` imports are only allowed within a { } list
+        pub use super::Trait::self as Trait1; //~ ERROR `self` imports are only allowed within a { } list
+        pub use super::Trait::{self}; //~ ERROR the name `Trait` is defined multiple times
+        pub use super::Trait::{self as Trait2};
+    }
+}
+
+pub mod z {}
+
+fn main() {}

--- a/tests/ui/use/use-super-in-middle.rs
+++ b/tests/ui/use/use-super-in-middle.rs
@@ -1,13 +1,13 @@
 pub mod x {
     pub use crate::x::super::{self as crate1}; //~ ERROR `super` in paths can only be used in start position
-    pub use crate::x::self::super::{self as crate2}; //~ ERROR `super` in paths can only be used in start position
+    pub use crate::x::self::super::{self as crate2}; //~ ERROR `self` in paths can only be used in start position
 
     pub fn foo() {}
 }
 
 fn main() {
-    x::crate1::x::foo(); //~ ERROR cannot find `crate1` in `x`
-    x::crate2::x::foo(); //~ ERROR cannot find `crate2` in `x`
+    x::crate1::x::foo();
+    x::crate2::x::foo();
 
     crate::x::super::x::foo(); //~ ERROR `super` in paths can only be used in start position
     crate::x::self::super::x::foo(); //~ ERROR `self` in paths can only be used in start position

--- a/tests/ui/use/use-super-in-middle.stderr
+++ b/tests/ui/use/use-super-in-middle.stderr
@@ -1,26 +1,14 @@
-error: `super` in paths can only be used in start position, after `self`, or after another `super`
+error[E0433]: `super` in paths can only be used in start position
   --> $DIR/use-super-in-middle.rs:2:23
    |
 LL |     pub use crate::x::super::{self as crate1};
-   |                       ^^^^^
+   |                       ^^^^^ can only be used in path start position
 
-error: `super` in paths can only be used in start position, after `self`, or after another `super`
-  --> $DIR/use-super-in-middle.rs:3:29
+error[E0433]: `self` in paths can only be used in start position
+  --> $DIR/use-super-in-middle.rs:3:23
    |
 LL |     pub use crate::x::self::super::{self as crate2};
-   |                             ^^^^^
-
-error[E0433]: cannot find `crate1` in `x`
-  --> $DIR/use-super-in-middle.rs:9:8
-   |
-LL |     x::crate1::x::foo();
-   |        ^^^^^^ could not find `crate1` in `x`
-
-error[E0433]: cannot find `crate2` in `x`
-  --> $DIR/use-super-in-middle.rs:10:8
-   |
-LL |     x::crate2::x::foo();
-   |        ^^^^^^ could not find `crate2` in `x`
+   |                       ^^^^ can only be used in path start position
 
 error[E0433]: `super` in paths can only be used in start position
   --> $DIR/use-super-in-middle.rs:12:15
@@ -34,6 +22,6 @@ error[E0433]: `self` in paths can only be used in start position
 LL |     crate::x::self::super::x::foo();
    |               ^^^^ can only be used in path start position
 
-error: aborting due to 6 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0433`.


### PR DESCRIPTION
Reference PR:

- https://github.com/rust-lang/reference/pull/2221

<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/152996)*
<!-- homu-ignore:end -->

As a follow-up PR to https://github.com/rust-lang/rust/pull/146972 ([step 1](https://github.com/rust-lang/rust/pull/152996#issuecomment-4011548479)), after this PR:
~~1. Trailing `self` can appear in paths (as the consensus in https://github.com/rust-lang/rust/pull/146972#issuecomment-3719825627)~~ (in future)
~~2. [E0429](https://doc.rust-lang.org/stable/error_codes/E0429.html#error-code-e0429) will be no longer emitted, `use ...::self [as target];` will be equivalent to `use ...::{self [as target]};`~~ (in future)
3. Things like `struct S {}; use S::{self as Other};` will be rejected

---

This PR used to add a new lint `redundant_self`, which would lint `use ...::self [as target];` and `use ...::{self [as target]};`, and fixes all warnings emitted by this lint.

But this lint and clippy lint [unnecessary_self_imports](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_self_imports) have some overlap. And `use std::io::self;` is not equivalent to `use std::io` in fact for now, the new lint will also cause the following known issue:
> Removing `::{self}` will cause any non-module items at the same path to also be imported. This might cause a naming conflict (https://github.com/rust-lang/rustfmt/issues/3568).

So I removed this lint, and I think what it does should be done by extending the clippy lint `unnecessary_self_imports`.

r? petrochenkov