### PR TITLE
std: make `OsString::truncate` a no-op when `len > current_len`

### DIFF
--- a/library/alloc/src/wtf8/mod.rs
+++ b/library/alloc/src/wtf8/mod.rs
@@ -342,14 +342,18 @@ impl Wtf8Buf {
 
     /// Shortens a string to the specified length.
     ///
+    /// If `new_len` is greater than the string's current length, this has no
+    /// effect.
+    ///
     /// # Panics
     ///
-    /// Panics if `new_len` > current length,
-    /// or if `new_len` is not a code point boundary.
+    /// Panics if `new_len` does not lie on a code point boundary.
     #[inline]
     pub fn truncate(&mut self, new_len: usize) {
-        assert!(self.is_code_point_boundary(new_len));
-        self.bytes.truncate(new_len)
+        if new_len <= self.len() {
+            assert!(self.is_code_point_boundary(new_len));
+            self.bytes.truncate(new_len)
+        }
     }
 
     /// Consumes the WTF-8 string and tries to convert it to a vec of bytes.

--- a/library/alloc/src/wtf8/tests.rs
+++ b/library/alloc/src/wtf8/tests.rs
@@ -308,10 +308,10 @@ fn wtf8buf_truncate_fail_code_point_boundary() {
 }
 
 #[test]
-#[should_panic]
-fn wtf8buf_truncate_fail_longer() {
+fn wtf8buf_truncate_invalid_len() {
     let mut string = Wtf8Buf::from_str("aé");
     string.truncate(4);
+    assert_eq!(string, Wtf8Buf::from_str("aé"));
 }
 
 #[test]

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -576,15 +576,21 @@ impl OsString {
 
     /// Truncate the `OsString` to the specified length.
     ///
+    /// If `new_len` is greater than the string's current length, this has no
+    /// effect.
+    ///
     /// # Panics
+    ///
     /// Panics if `len` does not lie on a valid `OsStr` boundary
     /// (as described in [`OsStr::slice_encoded_bytes`]).
     #[inline]
     #[unstable(feature = "os_string_truncate", issue = "133262")]
     pub fn truncate(&mut self, len: usize) {
-        self.as_os_str().inner.check_public_boundary(len);
-        // SAFETY: The length was just checked to be at a valid boundary.
-        unsafe { self.inner.truncate_unchecked(len) };
+        if len <= self.len() {
+            self.as_os_str().inner.check_public_boundary(len);
+            // SAFETY: The length was just checked to be at a valid boundary.
+            unsafe { self.inner.truncate_unchecked(len) };
+        }
     }
 
     /// Provides plumbing to `Vec::extend_from_slice` without giving full


### PR DESCRIPTION
Align `OsString::truncate` (and the underlying WTF-8 implementation) with `String::truncate` by making it a no-op when `len > self.len()`.

Previously, `OsString::truncate` would panic if `len > self.len()`, while `String::truncate` treats such cases as a no-op.

Tracking (`os_string_truncate`): https://github.com/rust-lang/rust/issues/133262
See also: https://github.com/rust-lang/rust/pull/32977

cc: @alexcrichton, @lolbinarycat