### PR TITLE
rustdoc: make `--emit` and `--out-dir` mimic rustc

### DIFF
--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -285,7 +285,11 @@ pub(crate) fn create_config(
         crate_check_cfg: check_cfgs,
         input,
         output_file: None,
-        output_dir: None,
+        output_dir: if render_options.output_to_stdout {
+            None
+        } else {
+            Some(render_options.output.clone())
+        },
         file_loader: None,
         lint_caps,
         psess_created: None,

--- a/tests/run-make/rustdoc-dep-info/rmake.rs
+++ b/tests/run-make/rustdoc-dep-info/rmake.rs
@@ -7,6 +7,8 @@ use run_make_support::assertion_helpers::assert_contains;
 use run_make_support::{path, rfs, rustdoc};
 
 fn main() {
+    rfs::create_dir("doc");
+
     // We're only emitting dep info, so we shouldn't be running static analysis to
     // figure out that this program is erroneous.
     // Ensure that all kinds of input reading flags end up in dep-info.
@@ -20,7 +22,7 @@ fn main() {
         .emit("dep-info")
         .run();
 
-    let content = rfs::read_to_string("foo.d");
+    let content = rfs::read_to_string("doc/foo.d");
     assert_contains(&content, "lib.rs:");
     assert_contains(&content, "foo.rs:");
     assert_contains(&content, "bar.rs:");

--- a/tests/run-make/rustdoc-scrape-examples-dep-info/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-dep-info/rmake.rs
@@ -5,15 +5,17 @@ use run_make_support::{assert_contains, rfs};
 mod scrape;
 
 fn main() {
+    rfs::create_dir("rustdoc");
+
     scrape::scrape(
         &["--scrape-tests", "--emit=dep-info"],
         &["--emit=dep-info,invocation-specific"],
     );
 
-    let content = rfs::read_to_string("foobar.d").replace(r"\", "/");
+    let content = rfs::read_to_string("rustdoc/foobar.d").replace(r"\", "/");
     assert_contains(&content, "lib.rs:");
     assert_contains(&content, "rustdoc/ex.calls:");
 
-    let content = rfs::read_to_string("ex.d").replace(r"\", "/");
+    let content = rfs::read_to_string("rustdoc/ex.d").replace(r"\", "/");
     assert_contains(&content, "examples/ex.rs:");
 }


### PR DESCRIPTION
The behavior in the test case matches rustc's:

    test-dingus % ls
    main.rs
    test-dingus % mkdir foobar
    test-dingus % rustc --emit=dep-info main.rs --out-dir=foobar
    test-dingus % ls
    foobar  main.rs
    test-dingus % ls foobar
    main.d
    test-dingus % rustc --emit=dep-info=testfile.d main.rs --out-dir=foobar
    test-dingus % ls
    foobar          main.rs         testfile.d
    test-dingus % ls foobar
    main.d

CC https://github.com/rust-lang/rust/pull/146220#issuecomment-3936957755