### PR TITLE
Remove `rustc_feedable_queries` and `define_feedable` macros.

### DIFF
--- a/compiler/rustc_macros/src/query.rs
+++ b/compiler/rustc_macros/src/query.rs
@@ -399,7 +399,6 @@ pub(super) fn rustc_queries(input: TokenStream) -> TokenStream {
 
     let mut query_stream = quote! {};
     let mut helpers = HelperTokenStreams::default();
-    let mut feedable_queries = quote! {};
     let mut analyzer_stream = quote! {};
     let mut errors = quote! {};
 
@@ -480,10 +479,6 @@ pub(super) fn rustc_queries(input: TokenStream) -> TokenStream {
                 feedable.span(),
                 "Query {name} cannot be both `feedable` and `eval_always`."
             );
-            feedable_queries.extend(quote! {
-                [#modifiers_stream]
-                fn #name(#key_ty) #return_ty,
-            });
         }
 
         add_to_analyzer_stream(&query, &mut analyzer_stream);
@@ -512,11 +507,6 @@ pub(super) fn rustc_queries(input: TokenStream) -> TokenStream {
                     $( $($extra_fake_queries)* )?
                     #query_stream
                 }
-            }
-        }
-        macro_rules! rustc_feedable_queries {
-            ( $macro:ident! ) => {
-                $macro!(#feedable_queries);
             }
         }
 

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -825,7 +825,7 @@ rustc_queries! {
     /// Returns the explicitly user-written *predicates* of the definition given by `DefId`
     /// that must be proven true at usage sites (and which can be assumed at definition site).
     ///
-    /// You should probably use [`Self::predicates_of`] unless you're looking for
+    /// You should probably use [`TyCtxt::predicates_of`] unless you're looking for
     /// predicates with explicit spans for diagnostics purposes.
     query explicit_predicates_of(key: DefId) -> ty::GenericPredicates<'tcx> {
         desc { "computing explicit predicates of `{}`", tcx.def_path_str(key) }
@@ -2780,4 +2780,3 @@ rustc_queries! {
 }
 
 rustc_with_all_queries! { define_callbacks! }
-rustc_feedable_queries! { define_feedable! }

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -295,6 +295,17 @@ macro_rules! if_return_result_from_ensure_ok {
     };
 }
 
+// Expands to `$item` if the `feedable` modifier is present.
+macro_rules! item_if_feedable {
+    ([] $($item:tt)*) => {};
+    ([(feedable) $($rest:tt)*] $($item:tt)*) => {
+        $($item)*
+    };
+    ([$other:tt $($modifiers:tt)*] $($item:tt)*) => {
+        item_if_feedable! { [$($modifiers)*] $($item)* }
+    };
+}
+
 macro_rules! define_callbacks {
     (
         // You might expect the key to be `$K:ty`, but it needs to be `$($K:tt)*` so that
@@ -489,6 +500,30 @@ macro_rules! define_callbacks {
             )*
         }
 
+        $(
+            item_if_feedable! {
+                [$($modifiers)*]
+                impl<'tcx, K: $crate::query::IntoQueryParam<$name::Key<'tcx>> + Copy>
+                    TyCtxtFeed<'tcx, K>
+                {
+                    $(#[$attr])*
+                    #[inline(always)]
+                    pub fn $name(self, value: $name::ProvidedValue<'tcx>) {
+                        let key = self.key().into_query_param();
+                        let erased_value = $name::provided_to_erased(self.tcx, value);
+                        $crate::query::inner::query_feed(
+                            self.tcx,
+                            dep_graph::DepKind::$name,
+                            &self.tcx.query_system.query_vtables.$name,
+                            &self.tcx.query_system.caches.$name,
+                            key,
+                            erased_value,
+                        );
+                    }
+                }
+            }
+        )*
+
         /// Holds a `QueryVTable` for each query.
         ///
         /// ("Per" just makes this pluralized name more visually distinct.)
@@ -576,39 +611,6 @@ macro_rules! define_callbacks {
             )*
         }
     };
-}
-
-// Note: `$V` is unused but present so this can be called by `rustc_with_all_queries`.
-macro_rules! define_feedable {
-    (
-        $(
-            $(#[$attr:meta])*
-            [$($modifiers:tt)*]
-            fn $name:ident($K:ty) -> $V:ty,
-        )*
-    ) => {
-        $(
-            impl<'tcx, K: $crate::query::IntoQueryParam<$K> + Copy> TyCtxtFeed<'tcx, K> {
-                $(#[$attr])*
-                #[inline(always)]
-                pub fn $name(self, value: $name::ProvidedValue<'tcx>) {
-                    let key = self.key().into_query_param();
-
-                    let tcx = self.tcx;
-                    let erased_value = $name::provided_to_erased(tcx, value);
-
-                    $crate::query::inner::query_feed(
-                        tcx,
-                        dep_graph::DepKind::$name,
-                        &tcx.query_system.query_vtables.$name,
-                        &tcx.query_system.caches.$name,
-                        key,
-                        erased_value,
-                    );
-                }
-            }
-        )*
-    }
 }
 
 // Each of these queries corresponds to a function pointer field in the


### PR DESCRIPTION
The can be folded into `rustc_with_all_queries` and `define_callbacks`. Details in individual commits.

r? @oli-obk