### PR TITLE
rustdoc: Improve sentence for documented empty impl blocks

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2343,9 +2343,10 @@ fn render_impl_summary(
         if let Some(doc) = doc {
             if impl_is_empty {
                 w.write_str(
-                    "<div class=\"item-info\">\
-                         <div class=\"stab empty-impl\">This impl block contains no items.</div>\
-                     </div>",
+                    "\
+<div class=\"item-info\">\
+    <div class=\"stab empty-impl\">This impl block contains no public items.</div>\
+</div>",
                 )?;
             }
             write!(w, "<div class=\"docblock\">{doc}</div>")?;

--- a/tests/rustdoc-html/impl/empty-impl-block.rs
+++ b/tests/rustdoc-html/impl/empty-impl-block.rs
@@ -4,7 +4,7 @@
 pub struct Foo;
 
 //@ has - '//*[@class="docblock"]' 'Hello empty impl block!'
-//@ has - '//*[@class="item-info"]' 'This impl block contains no items.'
+//@ has - '//*[@class="item-info"]' 'This impl block contains no public items.'
 /// Hello empty impl block!
 impl Foo {}
 // We ensure that this empty impl block without doc isn't rendered.


### PR DESCRIPTION
Part of rust-lang/rust#152874.

An impl block is not necessarily empty, so instead, better to precise that there are no **public** items.

r? @Urgau 