### PR TITLE
Rename `rustc::pass_by_value` lint as `rustc::disallowed_pass_by_ref`.

### DIFF
--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -757,9 +757,11 @@ macro_rules! common_visitor_and_walkers {
             ) -> V::Result;
         }
 
-        // this is only used by the MutVisitor. We include this symmetry here to make writing other functions easier
+        // This is only used by the MutVisitor. We include this symmetry here to make writing other
+        // functions easier.
         $(${ignore($lt)}
-            #[expect(unused, rustc::pass_by_value)]
+            #[cfg_attr(not(bootstrap), expect(unused, rustc::disallowed_pass_by_ref))]
+            #[cfg_attr(bootstrap, expect(unused, rustc::pass_by_value))]
             #[inline]
         )?
         fn visit_span<$($lt,)? V: $Visitor$(<$lt>)?>(vis: &mut V, span: &$($lt)? $($mut)? Span) -> V::Result {

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -37,6 +37,7 @@ mod context;
 mod dangling;
 mod default_could_be_derived;
 mod deref_into_dyn_supertrait;
+mod disallowed_pass_by_ref;
 mod drop_forget_useless;
 mod early;
 mod enum_intrinsics_non_enums;
@@ -65,7 +66,6 @@ mod non_local_def;
 mod nonstandard_style;
 mod noop_method_call;
 mod opaque_hidden_inferred_bound;
-mod pass_by_value;
 mod passes;
 mod precedence;
 mod ptr_nulls;
@@ -88,6 +88,7 @@ use builtin::*;
 use dangling::*;
 use default_could_be_derived::DefaultCouldBeDerived;
 use deref_into_dyn_supertrait::*;
+use disallowed_pass_by_ref::*;
 use drop_forget_useless::*;
 use enum_intrinsics_non_enums::EnumIntrinsicsNonEnums;
 use for_loops_over_fallibles::*;
@@ -109,7 +110,6 @@ use non_local_def::*;
 use nonstandard_style::*;
 use noop_method_call::*;
 use opaque_hidden_inferred_bound::*;
-use pass_by_value::*;
 use precedence::*;
 use ptr_nulls::*;
 use redundant_semicolon::*;
@@ -657,8 +657,8 @@ fn register_internals(store: &mut LintStore) {
     store.register_late_mod_pass(|_| Box::new(TypeIr));
     store.register_lints(&BadOptAccess::lint_vec());
     store.register_late_mod_pass(|_| Box::new(BadOptAccess));
-    store.register_lints(&PassByValue::lint_vec());
-    store.register_late_mod_pass(|_| Box::new(PassByValue));
+    store.register_lints(&DisallowedPassByRef::lint_vec());
+    store.register_late_mod_pass(|_| Box::new(DisallowedPassByRef));
     store.register_lints(&SpanUseEqCtxt::lint_vec());
     store.register_late_mod_pass(|_| Box::new(SpanUseEqCtxt));
     store.register_lints(&SymbolInternStringLiteral::lint_vec());
@@ -676,7 +676,7 @@ fn register_internals(store: &mut LintStore) {
             LintId::of(POTENTIAL_QUERY_INSTABILITY),
             LintId::of(UNTRACKED_QUERY_INFORMATION),
             LintId::of(USAGE_OF_TY_TYKIND),
-            LintId::of(PASS_BY_VALUE),
+            LintId::of(DISALLOWED_PASS_BY_REF),
             LintId::of(LINT_PASS_IMPL_WITHOUT_MACRO),
             LintId::of(USAGE_OF_QUALIFIED_TY),
             LintId::of(NON_GLOB_IMPORT_OF_TYPE_IR_INHERENT),

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1806,10 +1806,10 @@ pub(crate) struct AmbiguousNegativeLiteralsCurrentBehaviorSuggestion {
     pub end_span: Span,
 }
 
-// pass_by_value.rs
+// disallowed_pass_by_ref.rs
 #[derive(LintDiagnostic)]
 #[diag("passing `{$ty}` by reference")]
-pub(crate) struct PassByValueDiag {
+pub(crate) struct DisallowedPassByRefDiag {
     pub ty: String,
     #[suggestion("try passing by value", code = "{ty}", applicability = "maybe-incorrect")]
     pub suggestion: Span,

--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -300,7 +300,8 @@ impl<'a, 'tcx> ValueSet<'a, 'tcx> {
 
     /// Insert a `(Value, Ty)` pair to be deduplicated.
     /// Returns `true` as second tuple field if this value did not exist previously.
-    #[allow(rustc::pass_by_value)] // closures take `&VnIndex`
+    #[cfg_attr(not(bootstrap), allow(rustc::disallowed_pass_by_ref))] // closures take `&VnIndex`
+    #[cfg_attr(bootstrap, allow(rustc::pass_by_value))]
     fn insert(&mut self, ty: Ty<'tcx>, value: Value<'a, 'tcx>) -> (VnIndex, bool) {
         debug_assert!(match value {
             Value::Opaque(_) | Value::Address { .. } => false,

--- a/tests/ui-fulldeps/internal-lints/rustc_pass_by_value.rs
+++ b/tests/ui-fulldeps/internal-lints/rustc_pass_by_value.rs
@@ -1,8 +1,8 @@
 //@ compile-flags: -Z unstable-options
-
+//@ ignore-stage1 (this can be removed when nightly goes to 1.96)
 #![feature(rustc_attrs)]
 #![feature(rustc_private)]
-#![deny(rustc::pass_by_value)]
+#![deny(rustc::disallowed_pass_by_ref)]
 #![allow(unused)]
 
 extern crate rustc_middle;

--- a/tests/ui-fulldeps/internal-lints/rustc_pass_by_value.stderr
+++ b/tests/ui-fulldeps/internal-lints/rustc_pass_by_value.stderr
@@ -7,8 +7,8 @@ LL |     ty_ref: &Ty<'_>,
 note: the lint level is defined here
   --> $DIR/rustc_pass_by_value.rs:5:9
    |
-LL | #![deny(rustc::pass_by_value)]
-   |         ^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(rustc::disallowed_pass_by_ref)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: passing `TyCtxt<'_>` by reference
   --> $DIR/rustc_pass_by_value.rs:16:18

--- a/tests/ui/internal-lints/rustc_pass_by_value_self.rs
+++ b/tests/ui/internal-lints/rustc_pass_by_value_self.rs
@@ -5,7 +5,7 @@
 // Considering that all other `internal-lints` are tested here
 // this seems like the cleaner solution though.
 #![feature(rustc_attrs)]
-#![deny(rustc::pass_by_value)]
+#![deny(rustc::disallowed_pass_by_ref)]
 #![allow(unused)]
 
 #[rustc_pass_by_value]

--- a/tests/ui/internal-lints/rustc_pass_by_value_self.stderr
+++ b/tests/ui/internal-lints/rustc_pass_by_value_self.stderr
@@ -7,8 +7,8 @@ LL |     fn by_ref(&self) {}
 note: the lint level is defined here
   --> $DIR/rustc_pass_by_value_self.rs:8:9
    |
-LL | #![deny(rustc::pass_by_value)]
-   |         ^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(rustc::disallowed_pass_by_ref)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: passing `Ty<'tcx>` by reference
   --> $DIR/rustc_pass_by_value_self.rs:30:21


### PR DESCRIPTION
The name `pass_by_value` is completely wrong. The lint actually checks for the use of pass by reference for types marked with `rustc_pass_by_value`.

The hardest part of this was choosing the new name. The `disallowed_` part of the name closely matches the following clippy lints:
- `disallowed_macros`
- `disallowed_methods`
- `disallowed_names`
- `disallowed_script_idents`
- `disallowed_types`

The `pass_by_value` part of the name aligns with the following clippy lints:
- `needless_pass_by_value`
- `needless_pass_by_ref_mut`
- `trivially_copy_pass_by_ref`
- `large_types_passed_by_value` (less so)

r? @Urgau 