### PR TITLE
Add example showing UB for uninit Copy types in MaybeUninit::assume_init docs

### DIFF
--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -695,6 +695,17 @@ impl<T> MaybeUninit<T> {
     /// let x_init = unsafe { x.assume_init() };
     /// // `x` had not been initialized yet, so this last line caused undefined behavior. ⚠️
     /// ```
+    ///
+    /// This also applies to simple types that can hold any bit pattern, like integers, boolean and so on.
+    /// See the [type-level documentation][inv] for more details.
+    ///
+    /// ```rust,no_run
+    /// use std::mem::MaybeUninit;
+    ///
+    /// let x = MaybeUninit::<u8>::uninit();
+    /// let x_init = unsafe { x.assume_init() }; // undefined behavior! ⚠️
+    /// // Even though `u8` can represent any bit pattern, reading uninitialized memory is still undefined behaviour.
+    /// ```
     #[stable(feature = "maybe_uninit", since = "1.36.0")]
     #[rustc_const_stable(feature = "const_maybe_uninit_assume_init_by_value", since = "1.59.0")]
     #[inline(always)]


### PR DESCRIPTION
This PR adds an explicit example and explanation showing that calling `assume_init()` on uninitialized memory is undefined behavior even for simple types like integers that can hold any bit pattern.

Following up on the discussion in rust-lang/rust#150689 - waited for @Sekar-C-Mca to respond as suggested by @RalfJung.

Closes rust-lang/rust#150689

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
