### PR TITLE
Remove unhelpful hint from trivial bound errors

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -3845,7 +3845,6 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 err.span_note(assoc_span, msg);
             }
             ObligationCauseCode::TrivialBound => {
-                err.help("see issue #48214");
                 tcx.disabled_nightly_features(err, [(String::new(), sym::trivial_bounds)]);
             }
             ObligationCauseCode::OpaqueReturnType(expr_info) => {

--- a/tests/ui/const-generics/issues/issue-67185-2.stderr
+++ b/tests/ui/const-generics/issues/issue-67185-2.stderr
@@ -11,7 +11,6 @@ LL | impl Bar for [u16; 4] {}
    | ^^^^^^^^^^^^^^^^^^^^^ `[u16; 4]`
 LL | impl Bar for [[u16; 3]; 3] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ `[[u16; 3]; 3]`
-   = help: see issue #48214
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 LL + #![feature(trivial_bounds)]
@@ -30,7 +29,6 @@ LL | impl Bar for [u16; 4] {}
    | ^^^^^^^^^^^^^^^^^^^^^ `[u16; 4]`
 LL | impl Bar for [[u16; 3]; 3] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ `[[u16; 3]; 3]`
-   = help: see issue #48214
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 LL + #![feature(trivial_bounds)]

--- a/tests/ui/cross/cross-fn-cache-hole.stderr
+++ b/tests/ui/cross/cross-fn-cache-hole.stderr
@@ -9,7 +9,6 @@ help: this trait has no implementations, consider adding one
    |
 LL | trait Bar<X> { }
    | ^^^^^^^^^^^^
-   = help: see issue #48214
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 LL + #![feature(trivial_bounds)]

--- a/tests/ui/delegation/generics/impl-to-trait-method.stderr
+++ b/tests/ui/delegation/generics/impl-to-trait-method.stderr
@@ -14,7 +14,6 @@ help: this trait has no implementations, consider adding one
    |
 LL |     trait Trait0 {}
    |     ^^^^^^^^^^^^
-   = help: see issue #48214
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 LL + #![feature(trivial_bounds)]

--- a/tests/ui/feature-gates/feature-gate-trivial_bounds.stderr
+++ b/tests/ui/feature-gates/feature-gate-trivial_bounds.stderr
@@ -9,7 +9,6 @@ help: the trait `Foo` is implemented for `()`
    |
 LL | impl Foo for () where i32: Foo {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: see issue #48214
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 LL + #![feature(trivial_bounds)]
@@ -26,7 +25,6 @@ help: the trait `Foo` is implemented for `()`
    |
 LL | impl Foo for () where i32: Foo {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: see issue #48214
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 LL + #![feature(trivial_bounds)]
@@ -43,7 +41,6 @@ help: the trait `Foo` is implemented for `()`
    |
 LL | impl Foo for () where i32: Foo {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: see issue #48214
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 LL + #![feature(trivial_bounds)]
@@ -60,7 +57,6 @@ help: the trait `Foo` is implemented for `()`
    |
 LL | impl Foo for () where i32: Foo {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: see issue #48214
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 LL + #![feature(trivial_bounds)]
@@ -77,7 +73,6 @@ help: the trait `Foo` is implemented for `()`
    |
 LL | impl Foo for () where i32: Foo {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: see issue #48214
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 LL + #![feature(trivial_bounds)]
@@ -94,7 +89,6 @@ help: the trait `Foo` is implemented for `()`
    |
 LL | impl Foo for () where i32: Foo {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: see issue #48214
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 LL + #![feature(trivial_bounds)]
@@ -106,7 +100,6 @@ error[E0277]: the trait bound `String: Neg` is not satisfied
 LL | fn use_op(s: String) -> String where String: ::std::ops::Neg<Output=String> {
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Neg` is not implemented for `String`
    |
-   = help: see issue #48214
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 LL + #![feature(trivial_bounds)]
@@ -119,7 +112,6 @@ LL | fn use_for() where i32: Iterator {
    |                    ^^^^^^^^^^^^^ `i32` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `i32`
-   = help: see issue #48214
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 LL + #![feature(trivial_bounds)]
@@ -132,7 +124,6 @@ LL | struct TwoStrs(str, str) where str: Sized;
    |                                ^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
-   = help: see issue #48214
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 LL + #![feature(trivial_bounds)]
@@ -150,7 +141,6 @@ note: required because it appears within the type `Dst<(dyn A + 'static)>`
    |
 LL | struct Dst<X: ?Sized> {
    |        ^^^
-   = help: see issue #48214
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 LL + #![feature(trivial_bounds)]
@@ -163,7 +153,6 @@ LL | fn return_str() -> str where str: Sized {
    |                              ^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
-   = help: see issue #48214
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 LL + #![feature(trivial_bounds)]

--- a/tests/ui/impl-trait/in-trait/synthetic-hir-has-parent.stderr
+++ b/tests/ui/impl-trait/in-trait/synthetic-hir-has-parent.stderr
@@ -4,7 +4,6 @@ error[E0277]: the trait bound `String: Copy` is not satisfied
 LL |         String: Copy;
    |         ^^^^^^^^^^^^ the trait `Copy` is not implemented for `String`
    |
-   = help: see issue #48214
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 LL + #![feature(trivial_bounds)]
@@ -16,7 +15,6 @@ error[E0277]: the trait bound `String: Copy` is not satisfied
 LL |     fn demo() -> impl Foo
    |                  ^^^^^^^^ the trait `Copy` is not implemented for `String`
    |
-   = help: see issue #48214
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 LL + #![feature(trivial_bounds)]

--- a/tests/ui/parser/impl-item-type-no-body-semantic-fail.stderr
+++ b/tests/ui/parser/impl-item-type-no-body-semantic-fail.stderr
@@ -88,7 +88,6 @@ error[E0277]: the trait bound `X: Eq` is not satisfied
 LL |     type W: Ord where Self: Eq;
    |                       ^^^^^^^^ the trait `Eq` is not implemented for `X`
    |
-   = help: see issue #48214
 help: consider annotating `X` with `#[derive(Eq)]`
    |
 LL + #[derive(Eq)]
@@ -105,7 +104,6 @@ error[E0277]: the trait bound `X: Eq` is not satisfied
 LL |     type W where Self: Eq;
    |                  ^^^^^^^^ the trait `Eq` is not implemented for `X`
    |
-   = help: see issue #48214
 help: consider annotating `X` with `#[derive(Eq)]`
    |
 LL + #[derive(Eq)]

--- a/tests/ui/trait-bounds/super-assoc-mismatch.stderr
+++ b/tests/ui/trait-bounds/super-assoc-mismatch.stderr
@@ -77,7 +77,6 @@ help: this trait has no implementations, consider adding one
    |
 LL | trait Sub: Super<Assoc = u16> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: see issue #48214
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 LL + #![feature(trivial_bounds)]


### PR DESCRIPTION
The `= help: see issue #48214` hint on trivial bound errors isn't useful, most users hitting these errors aren't trying to use the `trivial_bounds` feature. The `disabled_nightly_features` call already handles suggesting the feature gate on nightly.
 
Closes rust-lang/rust#152872