### PR TITLE
rustc_target: callconv: powerpc64: Use llvm_abiname rather than target_abi for ABI determination

### DIFF
--- a/compiler/rustc_target/src/callconv/powerpc64.rs
+++ b/compiler/rustc_target/src/callconv/powerpc64.rs
@@ -5,7 +5,7 @@
 use rustc_abi::{Endian, HasDataLayout, TyAbiInterface};
 
 use crate::callconv::{Align, ArgAbi, FnAbi, Reg, RegKind, Uniform};
-use crate::spec::{Abi, HasTargetSpec, Os};
+use crate::spec::{HasTargetSpec, Os};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum ABI {
@@ -106,9 +106,9 @@ where
     Ty: TyAbiInterface<'a, C> + Copy,
     C: HasDataLayout + HasTargetSpec,
 {
-    let abi = if cx.target_spec().options.abi == Abi::ElfV2 {
+    let abi = if cx.target_spec().options.llvm_abiname == "elfv2" {
         ELFv2
-    } else if cx.target_spec().options.abi == Abi::ElfV1 {
+    } else if cx.target_spec().options.llvm_abiname == "elfv1" {
         ELFv1
     } else if cx.target_spec().os == Os::Aix {
         AIX


### PR DESCRIPTION
Currently on PowerPC64 targets, `llvm_abiname` and `target_abi` will be the same unless we're on AIX. Since `llvm_abiname` is what we pass on to LLVM, it is preferable to use the value of that to determine the calling convention rather than `target_abi`.

All PowerPC64 targets set both `llvm_abiname` and `target_abi` to the respective ELF ABIs, with the exception of AIX. This is a non-functional change.

Noticed this in the follow-up discussion from rust-lang/rust#150468 and also requested by @RalfJung [here](https://github.com/rust-lang/rust/pull/150468#discussion_r2842291237).

r? @RalfJung