### PR TITLE
core::sync: rename `Exclusive` to `SyncView` and make improvements

### DIFF
--- a/library/core/src/sync/mod.rs
+++ b/library/core/src/sync/mod.rs
@@ -3,6 +3,6 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 pub mod atomic;
-mod exclusive;
+mod sync_view;
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-pub use exclusive::Exclusive;
+pub use sync_view::SyncView;

--- a/library/core/src/sync/sync_view.rs
+++ b/library/core/src/sync/sync_view.rs
@@ -1,4 +1,4 @@
-//! Defines [`Exclusive`].
+//! Defines [`SyncView`].
 
 use core::clone::TrivialClone;
 use core::cmp::Ordering;
@@ -10,18 +10,18 @@ use core::ops::{Coroutine, CoroutineState};
 use core::pin::Pin;
 use core::task::{Context, Poll};
 
-/// `Exclusive` provides _mutable_ access, also referred to as _exclusive_
+/// `SyncView` provides _mutable_ access, also referred to as _exclusive_
 /// access to the underlying value. However, it only permits _immutable_, or _shared_
 /// access to the underlying value when that value is [`Sync`].
 ///
-/// While this may seem not very useful, it allows `Exclusive` to _unconditionally_
-/// implement `Sync`. Indeed, the safety requirements of `Sync` state that for `Exclusive`
+/// While this may seem not very useful, it allows `SyncView` to _unconditionally_
+/// implement `Sync`. Indeed, the safety requirements of `Sync` state that for `SyncView`
 /// to be `Sync`, it must be sound to _share_ across threads, that is, it must be sound
-/// for `&Exclusive` to cross thread boundaries. By design, a `&Exclusive<T>` for non-`Sync` T
+/// for `&SyncView` to cross thread boundaries. By design, a `&SyncView<T>` for non-`Sync` T
 /// has no API whatsoever, making it useless, thus harmless, thus memory safe.
 ///
 /// Certain constructs like [`Future`]s can only be used with _exclusive_ access,
-/// and are often `Send` but not `Sync`, so `Exclusive` can be used as hint to the
+/// and are often `Send` but not `Sync`, so `SyncView` can be used as hint to the
 /// Rust compiler that something is `Sync` in practice.
 ///
 /// ## Examples
@@ -47,22 +47,22 @@ use core::task::{Context, Poll};
 /// });
 /// ```
 ///
-/// `Exclusive` ensures the struct is `Sync` without stripping the future of its
+/// `SyncView` ensures the struct is `Sync` without stripping the future of its
 /// functionality:
 ///
 /// ```
 /// #![feature(exclusive_wrapper)]
 /// use core::cell::Cell;
-/// use core::sync::Exclusive;
+/// use core::sync::SyncView;
 ///
 /// async fn other() {}
 /// fn assert_sync<T: Sync>(t: T) {}
 /// struct State<F> {
-///     future: Exclusive<F>
+///     future: SyncView<F>
 /// }
 ///
 /// assert_sync(State {
-///     future: Exclusive::new(async {
+///     future: SyncView::new(async {
 ///         let cell = Cell::new(1);
 ///         let cell_ref = &cell;
 ///         other().await;
@@ -73,7 +73,7 @@ use core::task::{Context, Poll};
 ///
 /// ## Parallels with a mutex
 ///
-/// In some sense, `Exclusive` can be thought of as a _compile-time_ version of
+/// In some sense, `SyncView` can be thought of as a _compile-time_ version of
 /// a mutex, as the borrow-checker guarantees that only one `&mut` can exist
 /// for any value. This is a parallel with the fact that
 /// `&` and `&mut` references together can be thought of as a _compile-time_
@@ -82,28 +82,29 @@ use core::task::{Context, Poll};
 #[doc(alias = "SyncWrapper")]
 #[doc(alias = "SyncCell")]
 #[doc(alias = "Unique")]
-// `Exclusive` can't have derived `PartialOrd`, `Clone`, etc. impls as they would
+#[doc(alias = "Exclusive")]
+// `SyncView` can't have derived `PartialOrd`, `Clone`, etc. impls as they would
 // use `&` access to the inner value, violating the `Sync` impl's safety
 // requirements.
 #[derive(Default)]
 #[repr(transparent)]
-pub struct Exclusive<T: ?Sized> {
+pub struct SyncView<T: ?Sized> {
     inner: T,
 }
 
-// See `Exclusive`'s docs for justification.
+// See `SyncView`'s docs for justification.
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-unsafe impl<T: ?Sized> Sync for Exclusive<T> {}
+unsafe impl<T: ?Sized> Sync for SyncView<T> {}
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-impl<T: ?Sized> fmt::Debug for Exclusive<T> {
+impl<T: ?Sized> fmt::Debug for SyncView<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        f.debug_struct("Exclusive").finish_non_exhaustive()
+        f.debug_struct("SyncView").finish_non_exhaustive()
     }
 }
 
-impl<T: Sized> Exclusive<T> {
-    /// Wrap a value in an `Exclusive`
+impl<T: Sized> SyncView<T> {
+    /// Wrap a value in an `SyncView`
     #[unstable(feature = "exclusive_wrapper", issue = "98407")]
     #[must_use]
     #[inline]
@@ -111,7 +112,7 @@ impl<T: Sized> Exclusive<T> {
         Self { inner: t }
     }
 
-    /// Unwrap the value contained in the `Exclusive`
+    /// Unwrap the value contained in the `SyncView`
     #[unstable(feature = "exclusive_wrapper", issue = "98407")]
     #[rustc_const_unstable(feature = "exclusive_wrapper", issue = "98407")]
     #[must_use]
@@ -121,7 +122,7 @@ impl<T: Sized> Exclusive<T> {
     }
 }
 
-impl<T: ?Sized> Exclusive<T> {
+impl<T: ?Sized> SyncView<T> {
     /// Gets exclusive access to the underlying value.
     #[unstable(feature = "exclusive_wrapper", issue = "98407")]
     #[must_use]
@@ -132,38 +133,38 @@ impl<T: ?Sized> Exclusive<T> {
 
     /// Gets pinned exclusive access to the underlying value.
     ///
-    /// `Exclusive` is considered to _structurally pin_ the underlying
-    /// value, which means _unpinned_ `Exclusive`s can produce _unpinned_
-    /// access to the underlying value, but _pinned_ `Exclusive`s only
+    /// `SyncView` is considered to _structurally pin_ the underlying
+    /// value, which means _unpinned_ `SyncView`s can produce _unpinned_
+    /// access to the underlying value, but _pinned_ `SyncView`s only
     /// produce _pinned_ access to the underlying value.
     #[unstable(feature = "exclusive_wrapper", issue = "98407")]
     #[must_use]
     #[inline]
     pub const fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut T> {
-        // SAFETY: `Exclusive` can only produce `&mut T` if itself is unpinned
+        // SAFETY: `SyncView` can only produce `&mut T` if itself is unpinned
         // `Pin::map_unchecked_mut` is not const, so we do this conversion manually
         unsafe { Pin::new_unchecked(&mut self.get_unchecked_mut().inner) }
     }
 
-    /// Build a _mutable_ reference to an `Exclusive<T>` from
+    /// Build a _mutable_ reference to an `SyncView<T>` from
     /// a _mutable_ reference to a `T`. This allows you to skip
-    /// building an `Exclusive` with [`Exclusive::new`].
+    /// building an `SyncView` with [`SyncView::new`].
     #[unstable(feature = "exclusive_wrapper", issue = "98407")]
     #[must_use]
     #[inline]
-    pub const fn from_mut(r: &'_ mut T) -> &'_ mut Exclusive<T> {
-        // SAFETY: repr is ≥ C, so refs have the same layout; and `Exclusive` properties are `&mut`-agnostic
-        unsafe { &mut *(r as *mut T as *mut Exclusive<T>) }
+    pub const fn from_mut(r: &'_ mut T) -> &'_ mut SyncView<T> {
+        // SAFETY: repr is ≥ C, so refs have the same layout; and `SyncView` properties are `&mut`-agnostic
+        unsafe { &mut *(r as *mut T as *mut SyncView<T>) }
     }
 
-    /// Build a _pinned mutable_ reference to an `Exclusive<T>` from
+    /// Build a _pinned mutable_ reference to an `SyncView<T>` from
     /// a _pinned mutable_ reference to a `T`. This allows you to skip
-    /// building an `Exclusive` with [`Exclusive::new`].
+    /// building an `SyncView` with [`SyncView::new`].
     #[unstable(feature = "exclusive_wrapper", issue = "98407")]
     #[must_use]
     #[inline]
-    pub const fn from_pin_mut(r: Pin<&'_ mut T>) -> Pin<&'_ mut Exclusive<T>> {
-        // SAFETY: `Exclusive` can only produce `&mut T` if itself is unpinned
+    pub const fn from_pin_mut(r: Pin<&'_ mut T>) -> Pin<&'_ mut SyncView<T>> {
+        // SAFETY: `SyncView` can only produce `&mut T` if itself is unpinned
         // `Pin::map_unchecked_mut` is not const, so we do this conversion manually
         unsafe { Pin::new_unchecked(Self::from_mut(r.get_unchecked_mut())) }
     }
@@ -171,7 +172,7 @@ impl<T: ?Sized> Exclusive<T> {
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
-impl<T> const From<T> for Exclusive<T> {
+impl<T> const From<T> for SyncView<T> {
     #[inline]
     fn from(t: T) -> Self {
         Self::new(t)
@@ -179,7 +180,7 @@ impl<T> const From<T> for Exclusive<T> {
 }
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-impl<F, Args> FnOnce<Args> for Exclusive<F>
+impl<F, Args> FnOnce<Args> for SyncView<F>
 where
     F: FnOnce<Args>,
     Args: Tuple,
@@ -192,7 +193,7 @@ where
 }
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-impl<F, Args> FnMut<Args> for Exclusive<F>
+impl<F, Args> FnMut<Args> for SyncView<F>
 where
     F: FnMut<Args>,
     Args: Tuple,
@@ -203,7 +204,7 @@ where
 }
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-impl<F, Args> Fn<Args> for Exclusive<F>
+impl<F, Args> Fn<Args> for SyncView<F>
 where
     F: Sync + Fn<Args>,
     Args: Tuple,
@@ -214,7 +215,7 @@ where
 }
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-impl<T> Future for Exclusive<T>
+impl<T> Future for SyncView<T>
 where
     T: Future + ?Sized,
 {
@@ -227,7 +228,7 @@ where
 }
 
 #[unstable(feature = "coroutine_trait", issue = "43122")] // also #98407
-impl<R, G> Coroutine<R> for Exclusive<G>
+impl<R, G> Coroutine<R> for SyncView<G>
 where
     G: Coroutine<R> + ?Sized,
 {
@@ -241,7 +242,7 @@ where
 }
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-impl<T> AsRef<T> for Exclusive<T>
+impl<T> AsRef<T> for SyncView<T>
 where
     T: Sync + ?Sized,
 {
@@ -252,7 +253,7 @@ where
 }
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-impl<T> Clone for Exclusive<T>
+impl<T> Clone for SyncView<T>
 where
     T: Sync + Clone,
 {
@@ -264,31 +265,31 @@ where
 
 #[doc(hidden)]
 #[unstable(feature = "trivial_clone", issue = "none")]
-unsafe impl<T> TrivialClone for Exclusive<T> where T: Sync + TrivialClone {}
+unsafe impl<T> TrivialClone for SyncView<T> where T: Sync + TrivialClone {}
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-impl<T> Copy for Exclusive<T> where T: Sync + Copy {}
+impl<T> Copy for SyncView<T> where T: Sync + Copy {}
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-impl<T, U> PartialEq<Exclusive<U>> for Exclusive<T>
+impl<T, U> PartialEq<SyncView<U>> for SyncView<T>
 where
     T: Sync + PartialEq<U> + ?Sized,
     U: Sync + ?Sized,
 {
     #[inline]
-    fn eq(&self, other: &Exclusive<U>) -> bool {
+    fn eq(&self, other: &SyncView<U>) -> bool {
         self.inner == other.inner
     }
 }
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-impl<T> StructuralPartialEq for Exclusive<T> where T: Sync + StructuralPartialEq + ?Sized {}
+impl<T> StructuralPartialEq for SyncView<T> where T: Sync + StructuralPartialEq + ?Sized {}
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-impl<T> Eq for Exclusive<T> where T: Sync + Eq + ?Sized {}
+impl<T> Eq for SyncView<T> where T: Sync + Eq + ?Sized {}
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-impl<T> Hash for Exclusive<T>
+impl<T> Hash for SyncView<T>
 where
     T: Sync + Hash + ?Sized,
 {
@@ -299,19 +300,19 @@ where
 }
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-impl<T, U> PartialOrd<Exclusive<U>> for Exclusive<T>
+impl<T, U> PartialOrd<SyncView<U>> for SyncView<T>
 where
     T: Sync + PartialOrd<U> + ?Sized,
     U: Sync + ?Sized,
 {
     #[inline]
-    fn partial_cmp(&self, other: &Exclusive<U>) -> Option<Ordering> {
+    fn partial_cmp(&self, other: &SyncView<U>) -> Option<Ordering> {
         self.inner.partial_cmp(&other.inner)
     }
 }
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-impl<T> Ord for Exclusive<T>
+impl<T> Ord for SyncView<T>
 where
     T: Sync + Ord + ?Sized,
 {

--- a/library/core/src/sync/sync_view.rs
+++ b/library/core/src/sync/sync_view.rs
@@ -243,6 +243,48 @@ where
 }
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
+impl<F, Args> AsyncFnOnce<Args> for SyncView<F>
+where
+    F: AsyncFnOnce<Args>,
+    Args: Tuple,
+{
+    type CallOnceFuture = F::CallOnceFuture;
+
+    type Output = F::Output;
+
+    extern "rust-call" fn async_call_once(self, args: Args) -> Self::CallOnceFuture {
+        self.into_inner().async_call_once(args)
+    }
+}
+
+#[unstable(feature = "exclusive_wrapper", issue = "98407")]
+impl<F, Args> AsyncFnMut<Args> for SyncView<F>
+where
+    F: AsyncFnMut<Args>,
+    Args: Tuple,
+{
+    type CallRefFuture<'a>
+        = F::CallRefFuture<'a>
+    where
+        F: 'a;
+
+    extern "rust-call" fn async_call_mut(&mut self, args: Args) -> Self::CallRefFuture<'_> {
+        self.as_mut().async_call_mut(args)
+    }
+}
+
+#[unstable(feature = "exclusive_wrapper", issue = "98407")]
+impl<F, Args> AsyncFn<Args> for SyncView<F>
+where
+    F: Sync + AsyncFn<Args>,
+    Args: Tuple,
+{
+    extern "rust-call" fn async_call(&self, args: Args) -> Self::CallRefFuture<'_> {
+        self.as_ref().async_call(args)
+    }
+}
+
+#[unstable(feature = "exclusive_wrapper", issue = "98407")]
 impl<T> Future for SyncView<T>
 where
     T: Future + ?Sized,

--- a/library/core/src/sync/sync_view.rs
+++ b/library/core/src/sync/sync_view.rs
@@ -123,14 +123,6 @@ impl<T: Sized> SyncView<T> {
 }
 
 impl<T: ?Sized> SyncView<T> {
-    /// Gets exclusive access to the underlying value.
-    #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-    #[must_use]
-    #[inline]
-    pub const fn get_mut(&mut self) -> &mut T {
-        &mut self.inner
-    }
-
     /// Gets pinned exclusive access to the underlying value.
     ///
     /// `SyncView` is considered to _structurally pin_ the underlying
@@ -140,7 +132,7 @@ impl<T: ?Sized> SyncView<T> {
     #[unstable(feature = "exclusive_wrapper", issue = "98407")]
     #[must_use]
     #[inline]
-    pub const fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut T> {
+    pub const fn as_pin_mut(self: Pin<&mut Self>) -> Pin<&mut T> {
         // SAFETY: `SyncView` can only produce `&mut T` if itself is unpinned
         // `Pin::map_unchecked_mut` is not const, so we do this conversion manually
         unsafe { Pin::new_unchecked(&mut self.get_unchecked_mut().inner) }
@@ -199,7 +191,7 @@ where
     Args: Tuple,
 {
     extern "rust-call" fn call_mut(&mut self, args: Args) -> Self::Output {
-        self.get_mut().call_mut(args)
+        self.as_mut().call_mut(args)
     }
 }
 
@@ -223,7 +215,7 @@ where
 
     #[inline]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.get_pin_mut().poll(cx)
+        self.as_pin_mut().poll(cx)
     }
 }
 
@@ -237,18 +229,33 @@ where
 
     #[inline]
     fn resume(self: Pin<&mut Self>, arg: R) -> CoroutineState<Self::Yield, Self::Return> {
-        G::resume(self.get_pin_mut(), arg)
+        G::resume(self.as_pin_mut(), arg)
     }
 }
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-impl<T> AsRef<T> for SyncView<T>
+#[rustc_const_unstable(feature = "const_convert", issue = "143773")]
+impl<T> const AsRef<T> for SyncView<T>
 where
     T: Sync + ?Sized,
 {
+    /// Gets shared access to the underlying value.
     #[inline]
     fn as_ref(&self) -> &T {
         &self.inner
+    }
+}
+
+#[unstable(feature = "exclusive_wrapper", issue = "98407")]
+#[rustc_const_unstable(feature = "const_convert", issue = "143773")]
+impl<T> const AsMut<T> for SyncView<T>
+where
+    T: ?Sized,
+{
+    /// Gets exclusive access to the underlying value.
+    #[inline]
+    fn as_mut(&mut self) -> &mut T {
+        &mut self.inner
     }
 }
 

--- a/library/core/src/sync/sync_view.rs
+++ b/library/core/src/sync/sync_view.rs
@@ -177,6 +177,24 @@ impl<T: ?Sized> SyncView<T> {
     }
 }
 
+impl<T: ?Sized + Sync> SyncView<T> {
+    /// Gets pinned shared access to the underlying value.
+    ///
+    /// `SyncView` is considered to _structurally pin_ the underlying
+    /// value, which means _unpinned_ `SyncView`s can produce _unpinned_
+    /// access to the underlying value, but _pinned_ `SyncView`s only
+    /// produce _pinned_ access to the underlying value.
+    #[unstable(feature = "exclusive_wrapper", issue = "98407")]
+    #[rustc_const_unstable(feature = "exclusive_wrapper", issue = "98407")]
+    #[must_use]
+    #[inline]
+    pub const fn as_pin(self: Pin<&Self>) -> Pin<&T> {
+        // SAFETY: `SyncView` can only produce `&T` if itself is unpinned
+        // `Pin::map_unchecked` is not const, so we do this conversion manually
+        unsafe { Pin::new_unchecked(&self.get_ref().inner) }
+    }
+}
+
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 impl<T> const From<T> for SyncView<T> {

--- a/library/core/src/sync/sync_view.rs
+++ b/library/core/src/sync/sync_view.rs
@@ -17,11 +17,11 @@ use core::task::{Context, Poll};
 /// While this may seem not very useful, it allows `SyncView` to _unconditionally_
 /// implement `Sync`. Indeed, the safety requirements of `Sync` state that for `SyncView`
 /// to be `Sync`, it must be sound to _share_ across threads, that is, it must be sound
-/// for `&SyncView` to cross thread boundaries. By design, a `&SyncView<T>` for non-`Sync` T
-/// has no API whatsoever, making it useless, thus harmless, thus memory safe.
+/// for `&SyncView` to cross thread boundaries. By design, a `&SyncView<T>` for non-`Sync`
+/// `T` has no API whatsoever, making it useless, thus harmless, thus memory safe.
 ///
 /// Certain constructs like [`Future`]s can only be used with _exclusive_ access,
-/// and are often `Send` but not `Sync`, so `SyncView` can be used as hint to the
+/// and are often [`Send`] but not `Sync`, so `SyncView` can be used as hint to the
 /// Rust compiler that something is `Sync` in practice.
 ///
 /// ## Examples

--- a/library/core/src/sync/sync_view.rs
+++ b/library/core/src/sync/sync_view.rs
@@ -86,7 +86,6 @@ use core::task::{Context, Poll};
 // `SyncView` can't have derived `PartialOrd`, `Clone`, etc. impls as they would
 // use `&` access to the inner value, violating the `Sync` impl's safety
 // requirements.
-#[derive(Default)]
 #[repr(transparent)]
 pub struct SyncView<T: ?Sized> {
     inner: T,
@@ -95,6 +94,18 @@ pub struct SyncView<T: ?Sized> {
 // See `SyncView`'s docs for justification.
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
 unsafe impl<T: ?Sized> Sync for SyncView<T> {}
+
+#[unstable(feature = "exclusive_wrapper", issue = "98407")]
+#[rustc_const_unstable(feature = "const_default", issue = "143894")]
+impl<T> const Default for SyncView<T>
+where
+    T: [const] Default,
+{
+    #[inline]
+    fn default() -> Self {
+        Self { inner: Default::default() }
+    }
+}
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
 impl<T: ?Sized> fmt::Debug for SyncView<T> {
@@ -106,6 +117,7 @@ impl<T: ?Sized> fmt::Debug for SyncView<T> {
 impl<T: Sized> SyncView<T> {
     /// Wrap a value in an `SyncView`
     #[unstable(feature = "exclusive_wrapper", issue = "98407")]
+    #[rustc_const_unstable(feature = "exclusive_wrapper", issue = "98407")]
     #[must_use]
     #[inline]
     pub const fn new(t: T) -> Self {
@@ -130,6 +142,7 @@ impl<T: ?Sized> SyncView<T> {
     /// access to the underlying value, but _pinned_ `SyncView`s only
     /// produce _pinned_ access to the underlying value.
     #[unstable(feature = "exclusive_wrapper", issue = "98407")]
+    #[rustc_const_unstable(feature = "exclusive_wrapper", issue = "98407")]
     #[must_use]
     #[inline]
     pub const fn as_pin_mut(self: Pin<&mut Self>) -> Pin<&mut T> {
@@ -142,6 +155,7 @@ impl<T: ?Sized> SyncView<T> {
     /// a _mutable_ reference to a `T`. This allows you to skip
     /// building an `SyncView` with [`SyncView::new`].
     #[unstable(feature = "exclusive_wrapper", issue = "98407")]
+    #[rustc_const_unstable(feature = "exclusive_wrapper", issue = "98407")]
     #[must_use]
     #[inline]
     pub const fn from_mut(r: &'_ mut T) -> &'_ mut SyncView<T> {
@@ -153,6 +167,7 @@ impl<T: ?Sized> SyncView<T> {
     /// a _pinned mutable_ reference to a `T`. This allows you to skip
     /// building an `SyncView` with [`SyncView::new`].
     #[unstable(feature = "exclusive_wrapper", issue = "98407")]
+    #[rustc_const_unstable(feature = "exclusive_wrapper", issue = "98407")]
     #[must_use]
     #[inline]
     pub const fn from_pin_mut(r: Pin<&'_ mut T>) -> Pin<&'_ mut SyncView<T>> {
@@ -172,9 +187,10 @@ impl<T> const From<T> for SyncView<T> {
 }
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-impl<F, Args> FnOnce<Args> for SyncView<F>
+#[rustc_const_unstable(feature = "const_trait_impl", issue = "143874")]
+impl<F, Args> const FnOnce<Args> for SyncView<F>
 where
-    F: FnOnce<Args>,
+    F: [const] FnOnce<Args>,
     Args: Tuple,
 {
     type Output = F::Output;
@@ -185,9 +201,10 @@ where
 }
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-impl<F, Args> FnMut<Args> for SyncView<F>
+#[rustc_const_unstable(feature = "const_trait_impl", issue = "143874")]
+impl<F, Args> const FnMut<Args> for SyncView<F>
 where
-    F: FnMut<Args>,
+    F: [const] FnMut<Args>,
     Args: Tuple,
 {
     extern "rust-call" fn call_mut(&mut self, args: Args) -> Self::Output {
@@ -196,9 +213,10 @@ where
 }
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-impl<F, Args> Fn<Args> for SyncView<F>
+#[rustc_const_unstable(feature = "const_trait_impl", issue = "143874")]
+impl<F, Args> const Fn<Args> for SyncView<F>
 where
-    F: Sync + Fn<Args>,
+    F: Sync + [const] Fn<Args>,
     Args: Tuple,
 {
     extern "rust-call" fn call(&self, args: Args) -> Self::Output {
@@ -260,9 +278,10 @@ where
 }
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-impl<T> Clone for SyncView<T>
+#[rustc_const_unstable(feature = "const_clone", issue = "142757")]
+impl<T> const Clone for SyncView<T>
 where
-    T: Sync + Clone,
+    T: Sync + [const] Clone,
 {
     #[inline]
     fn clone(&self) -> Self {
@@ -272,15 +291,17 @@ where
 
 #[doc(hidden)]
 #[unstable(feature = "trivial_clone", issue = "none")]
-unsafe impl<T> TrivialClone for SyncView<T> where T: Sync + TrivialClone {}
+#[rustc_const_unstable(feature = "const_clone", issue = "142757")]
+unsafe impl<T> const TrivialClone for SyncView<T> where T: Sync + [const] TrivialClone {}
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
 impl<T> Copy for SyncView<T> where T: Sync + Copy {}
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-impl<T, U> PartialEq<SyncView<U>> for SyncView<T>
+#[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
+impl<T, U> const PartialEq<SyncView<U>> for SyncView<T>
 where
-    T: Sync + PartialEq<U> + ?Sized,
+    T: Sync + [const] PartialEq<U> + ?Sized,
     U: Sync + ?Sized,
 {
     #[inline]
@@ -293,7 +314,8 @@ where
 impl<T> StructuralPartialEq for SyncView<T> where T: Sync + StructuralPartialEq + ?Sized {}
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-impl<T> Eq for SyncView<T> where T: Sync + Eq + ?Sized {}
+#[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
+impl<T> const Eq for SyncView<T> where T: Sync + [const] Eq + ?Sized {}
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
 impl<T> Hash for SyncView<T>
@@ -307,9 +329,10 @@ where
 }
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-impl<T, U> PartialOrd<SyncView<U>> for SyncView<T>
+#[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
+impl<T, U> const PartialOrd<SyncView<U>> for SyncView<T>
 where
-    T: Sync + PartialOrd<U> + ?Sized,
+    T: Sync + [const] PartialOrd<U> + ?Sized,
     U: Sync + ?Sized,
 {
     #[inline]
@@ -319,9 +342,10 @@ where
 }
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-impl<T> Ord for SyncView<T>
+#[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
+impl<T> const Ord for SyncView<T>
 where
-    T: Sync + Ord + ?Sized,
+    T: Sync + [const] Ord + ?Sized,
 {
     #[inline]
     fn cmp(&self, other: &Self) -> Ordering {

--- a/library/std/src/sync/mod.rs
+++ b/library/std/src/sync/mod.rs
@@ -172,7 +172,7 @@
 
 // These come from `core` & `alloc` and only in one flavor: no poisoning.
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
-pub use core::sync::Exclusive;
+pub use core::sync::SyncView;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::sync::atomic;
 

--- a/tests/ui/explicit-tail-calls/callee_is_weird.rs
+++ b/tests/ui/explicit-tail-calls/callee_is_weird.rs
@@ -4,11 +4,11 @@
 fn f() {}
 
 fn g() {
-    become std::sync::Exclusive::new(f)() //~ error: tail calls can only be performed with function definitions or pointers
+    become std::sync::SyncView::new(f)() //~ error: tail calls can only be performed with function definitions or pointers
 }
 
 fn h() {
-    become (&mut &std::sync::Exclusive::new(f))() //~ error: tail calls can only be performed with function definitions or pointers
+    become (&mut &std::sync::SyncView::new(f))() //~ error: tail calls can only be performed with function definitions or pointers
 }
 
 fn i() {

--- a/tests/ui/explicit-tail-calls/callee_is_weird.stderr
+++ b/tests/ui/explicit-tail-calls/callee_is_weird.stderr
@@ -1,18 +1,18 @@
 error: tail calls can only be performed with function definitions or pointers
   --> $DIR/callee_is_weird.rs:7:12
    |
-LL |     become std::sync::Exclusive::new(f)()
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     become std::sync::SyncView::new(f)()
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: callee has type `Exclusive<fn() {f}>`
+   = note: callee has type `SyncView<fn() {f}>`
 
 error: tail calls can only be performed with function definitions or pointers
   --> $DIR/callee_is_weird.rs:11:12
    |
-LL |     become (&mut &std::sync::Exclusive::new(f))()
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     become (&mut &std::sync::SyncView::new(f))()
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: callee has type `&Exclusive<fn() {f}>`
+   = note: callee has type `&SyncView<fn() {f}>`
 
 error: tail calls can only be performed with function definitions or pointers
   --> $DIR/callee_is_weird.rs:22:12

--- a/tests/ui/impl-trait/where-allowed.stderr
+++ b/tests/ui/impl-trait/where-allowed.stderr
@@ -387,7 +387,7 @@ LL | fn in_impl_Fn_return_in_return() -> &'static impl Fn() -> impl Debug { pani
              where A: std::marker::Tuple, F: Fn<A>, F: ?Sized;
            - impl<Args, F, A> Fn<Args> for Box<F, A>
              where Args: std::marker::Tuple, F: Fn<Args>, A: Allocator, F: ?Sized;
-           - impl<F, Args> Fn<Args> for Exclusive<F>
+           - impl<F, Args> Fn<Args> for SyncView<F>
              where F: Sync, F: Fn<Args>, Args: std::marker::Tuple;
 
 error: unconstrained opaque type

--- a/tests/ui/traits/next-solver/well-formed-in-relate.stderr
+++ b/tests/ui/traits/next-solver/well-formed-in-relate.stderr
@@ -12,7 +12,7 @@ LL |     x = unconstrained_map();
              where A: std::marker::Tuple, F: Fn<A>, F: ?Sized;
            - impl<Args, F, A> Fn<Args> for Box<F, A>
              where Args: std::marker::Tuple, F: Fn<Args>, A: Allocator, F: ?Sized;
-           - impl<F, Args> Fn<Args> for Exclusive<F>
+           - impl<F, Args> Fn<Args> for SyncView<F>
              where F: Sync, F: Fn<Args>, Args: std::marker::Tuple;
 note: required by a bound in `unconstrained_map`
   --> $DIR/well-formed-in-relate.rs:21:25


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/153038)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR implements the renaming of `core::sync::Exclusive` to `SyncView` as decided in rust-lang/rust#98407.  To preserve the ability to search for the old name, it adds `Exclusive` as a `doc_alias`.

It also makes the following additional changes:

- Converting the `get_mut` method to being an instance of `AsMut::as_mut`.  In the process, it makes both the new `impl AsMut` and the existing `impl AsRef` `const`, and it also renames `get_pin_mut` to `as_pin_mut` for consistency.  This direction follows a suggestion from rust-lang/rust#98407.
- Adding an `as_pin` method that can only be used when the wrapped type implements `Sync`, to complete the square of access methods.
- Making as many of the existing `impl`s `const` as possible; this involved making the existing `impl Default` no longer derived.
- Adding `impl`s for `AsyncFnOnce`, `AsyncFnMut`, and `AsyncFn`, akin to the existing `impls` for `FnOnce`, `FnMut`, and `Fn`.

It does not yet do the following, which may be desirable:

- Fixing/improving the documentation to address the concern pointed out in rust-lang/rust#146245.

It previously did the following, but this was removed after discussion:
- Adding an `impl` for (`const`) `Iterator`, which felt in line with the existing `impl`s for `Future` and `Coroutine`.