### PR TITLE
fix error on missing value for -C flags

### DIFF
--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -611,7 +611,7 @@ macro_rules! options {
         $parse:ident,
         [$dep_tracking_marker:ident $( $tmod:ident )?],
         $desc:expr
-        $(, deprecated_do_nothing: $dnn:literal )?)
+        $(, is_deprecated_and_do_nothing: $dnn:literal )?)
      ),* ,) =>
 (
     #[derive(Clone)]
@@ -2059,7 +2059,7 @@ options! {
     #[rustc_lint_opt_deny_field_access("documented to do nothing")]
     ar: String = (String::new(), parse_string, [UNTRACKED],
         "this option is deprecated and does nothing",
-        deprecated_do_nothing: true),
+        is_deprecated_and_do_nothing: true),
     #[rustc_lint_opt_deny_field_access("use `Session::code_model` instead of this field")]
     code_model: Option<CodeModel> = (None, parse_code_model, [TRACKED],
         "choose the code model to use (`rustc --print code-models` for details)"),
@@ -2098,7 +2098,7 @@ options! {
     inline_threshold: Option<u32> = (None, parse_opt_number, [UNTRACKED],
         "this option is deprecated and does nothing \
         (consider using `-Cllvm-args=--inline-threshold=...`)",
-        deprecated_do_nothing: true),
+        is_deprecated_and_do_nothing: true),
     #[rustc_lint_opt_deny_field_access("use `Session::instrument_coverage` instead of this field")]
     instrument_coverage: InstrumentCoverage = (InstrumentCoverage::No, parse_instrument_coverage, [TRACKED],
         "instrument the generated code to support LLVM source-based code coverage reports \
@@ -2139,7 +2139,7 @@ options! {
     #[rustc_lint_opt_deny_field_access("documented to do nothing")]
     no_stack_check: bool = (false, parse_no_value, [UNTRACKED],
         "this option is deprecated and does nothing",
-        deprecated_do_nothing: true),
+        is_deprecated_and_do_nothing: true),
     no_vectorize_loops: bool = (false, parse_no_value, [TRACKED],
         "disable loop vectorization optimization passes"),
     no_vectorize_slp: bool = (false, parse_no_value, [TRACKED],

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -760,7 +760,7 @@ fn build_options<O: Default>(
                     match value {
                         None => early_dcx.early_fatal(
                             format!(
-                                "{outputname} option `{key}` requires {type_desc} ({prefix} {key}=<value>)"
+                                "{outputname} option `{key}` requires {type_desc} (`-{prefix} {key}=<value>`)"
                             ),
                         ),
                         Some(value) => early_dcx.early_fatal(

--- a/tests/ui/deprecation/deprecated_inline_threshold.no_val.stderr
+++ b/tests/ui/deprecation/deprecated_inline_threshold.no_val.stderr
@@ -1,4 +1,4 @@
 warning: `-C inline-threshold`: this option is deprecated and does nothing (consider using `-Cllvm-args=--inline-threshold=...`)
 
-error: codegen option `inline-threshold` requires a number (C inline-threshold=<value>)
+error: codegen option `inline-threshold` requires a number (`-C inline-threshold=<value>`)
 

--- a/tests/ui/panic-runtime/bad-panic-flag2.stderr
+++ b/tests/ui/panic-runtime/bad-panic-flag2.stderr
@@ -1,2 +1,2 @@
-error: codegen option `panic` requires either `unwind`, `abort`, or `immediate-abort` (C panic=<value>)
+error: codegen option `panic` requires either `unwind`, `abort`, or `immediate-abort` (`-C panic=<value>`)
 

--- a/tests/ui/runtime/on-broken-pipe/no-flag-arg.stderr
+++ b/tests/ui/runtime/on-broken-pipe/no-flag-arg.stderr
@@ -1,2 +1,2 @@
-error: unstable option `on-broken-pipe` requires either `kill`, `error`, or `inherit` (Z on-broken-pipe=<value>)
+error: unstable option `on-broken-pipe` requires either `kill`, `error`, or `inherit` (`-Z on-broken-pipe=<value>`)
 

--- a/tests/ui/symbol-mangling-version/bad-value.no-value.stderr
+++ b/tests/ui/symbol-mangling-version/bad-value.no-value.stderr
@@ -1,2 +1,2 @@
-error: codegen option `symbol-mangling-version` requires one of: `legacy`, `v0` (RFC 2603), or `hashed` (C symbol-mangling-version=<value>)
+error: codegen option `symbol-mangling-version` requires one of: `legacy`, `v0` (RFC 2603), or `hashed` (`-C symbol-mangling-version=<value>`)
 

--- a/tests/ui/target_modifiers/incompatible_regparm.allow_no_value.stderr
+++ b/tests/ui/target_modifiers/incompatible_regparm.allow_no_value.stderr
@@ -1,2 +1,2 @@
-error: codegen option `unsafe-allow-abi-mismatch` requires a comma-separated list of strings (C unsafe-allow-abi-mismatch=<value>)
+error: codegen option `unsafe-allow-abi-mismatch` requires a comma-separated list of strings (`-C unsafe-allow-abi-mismatch=<value>`)
 


### PR DESCRIPTION
Before:
```
error: codegen option `panic` requires either `unwind`, `abort`, or `immediate-abort` (C panic=<value>)
```
After:
```
error: codegen option `panic` requires either `unwind`, `abort`, or `immediate-abort` (`-C panic=<value>`)
```

The second commit renames a field in the options macro for better consistency; that did not seem worth its own PR.