### PR TITLE
std random.rs: update link to RTEMS docs

### DIFF
--- a/library/std/src/random.rs
+++ b/library/std/src/random.rs
@@ -37,7 +37,7 @@ use crate::sys::random as sys;
 /// Horizon, Cygwin        | `getrandom`
 /// AIX, Hurd, L4Re, QNX   | `/dev/urandom`
 /// Redox                  | `/scheme/rand`
-/// RTEMS                  | [`arc4random_buf`](https://docs.rtems.org/branches/master/bsp-howto/getentropy.html)
+/// RTEMS                  | [`arc4random_buf`](https://docs.rtems.org/branches/main/bsp-howto/getentropy.html)
 /// SGX                    | [`rdrand`](https://en.wikipedia.org/wiki/RDRAND)
 /// SOLID                  | `SOLID_RNG_SampleRandomBytes`
 /// TEEOS                  | `TEE_GenerateRandom`


### PR DESCRIPTION
The old URL with `master` resulted in a 404 error - use `main` instead.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
