### PR TITLE
stop marking `deref_patterns` as an incomplete feature

### DIFF
--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -451,7 +451,7 @@ declare_features! (
     /// Allows having using `suggestion` in the `#[deprecated]` attribute.
     (unstable, deprecated_suggestion, "1.61.0", Some(94785)),
     /// Allows deref patterns.
-    (incomplete, deref_patterns, "1.79.0", Some(87121)),
+    (unstable, deref_patterns, "1.79.0", Some(87121)),
     /// Allows deriving the From trait on single-field structs.
     (unstable, derive_from, "1.91.0", Some(144889)),
     /// Allows giving non-const impls custom diagnostic messages if attempted to be used as const

--- a/src/doc/unstable-book/src/language-features/deref-patterns.md
+++ b/src/doc/unstable-book/src/language-features/deref-patterns.md
@@ -6,8 +6,7 @@ The tracking issue for this feature is: [#87121]
 
 ------------------------
 
-> **Note**: This feature is incomplete. In the future, it is meant to supersede
-> [`box_patterns`].
+> **Note**: This feature supersedes [`box_patterns`].
 
 This feature permits pattern matching on [smart pointers in the standard library] through their
 `Deref` target types, either implicitly or with explicit `deref!(_)` patterns (the syntax of which
@@ -15,7 +14,6 @@ is currently a placeholder).
 
 ```rust
 #![feature(deref_patterns)]
-#![allow(incomplete_features)]
 
 let mut v = vec![Box::new(Some(0))];
 
@@ -58,7 +56,6 @@ Like [`box_patterns`], deref patterns may move out of boxes:
 
 ```rust
 # #![feature(deref_patterns)]
-# #![allow(incomplete_features)]
 struct NoCopy;
 let deref!(x) = Box::new(NoCopy);
 drop::<NoCopy>(x);
@@ -69,7 +66,6 @@ allowing then to be used in deref patterns:
 
 ```rust
 # #![feature(deref_patterns)]
-# #![allow(incomplete_features)]
 match ("test".to_string(), Box::from("test"), b"test".to_vec()) {
     ("test", "test", b"test") => {}
     _ => panic!(),

--- a/tests/mir-opt/building/match/deref-patterns/string.rs
+++ b/tests/mir-opt/building/match/deref-patterns/string.rs
@@ -2,7 +2,6 @@
 //@ compile-flags: -Z mir-opt-level=0 -C panic=abort
 
 #![feature(deref_patterns)]
-#![expect(incomplete_features)]
 #![crate_type = "lib"]
 
 // EMIT_MIR string.foo.PreCodegen.after.mir

--- a/tests/ui/pattern/deref-patterns/basic.rs
+++ b/tests/ui/pattern/deref-patterns/basic.rs
@@ -1,7 +1,6 @@
 //@ run-pass
 //@ check-run-results
 #![feature(deref_patterns)]
-#![expect(incomplete_features)]
 
 fn main() {
     test(Some(String::from("42")));

--- a/tests/ui/pattern/deref-patterns/bindings.rs
+++ b/tests/ui/pattern/deref-patterns/bindings.rs
@@ -1,7 +1,6 @@
 //@ revisions: explicit implicit
 //@ run-pass
 #![feature(deref_patterns)]
-#![allow(incomplete_features)]
 
 use std::rc::Rc;
 

--- a/tests/ui/pattern/deref-patterns/branch.rs
+++ b/tests/ui/pattern/deref-patterns/branch.rs
@@ -2,7 +2,6 @@
 //@ run-pass
 // Test the execution of deref patterns.
 #![feature(deref_patterns)]
-#![allow(incomplete_features)]
 
 #[cfg(explicit)]
 fn branch(vec: Vec<u32>) -> u32 {

--- a/tests/ui/pattern/deref-patterns/byte-string-type-errors.rs
+++ b/tests/ui/pattern/deref-patterns/byte-string-type-errors.rs
@@ -5,7 +5,6 @@
 //@ dont-require-annotations: NOTE
 
 #![feature(deref_patterns)]
-#![expect(incomplete_features)]
 
 fn main() {
     // Baseline 1: under normal circumstances, byte string literal patterns have type `&[u8; N]`,

--- a/tests/ui/pattern/deref-patterns/byte-string-type-errors.stderr
+++ b/tests/ui/pattern/deref-patterns/byte-string-type-errors.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/byte-string-type-errors.rs:13:12
+  --> $DIR/byte-string-type-errors.rs:12:12
    |
 LL |     if let b"test" = () {}
    |            ^^^^^^^   -- this expression has type `()`
@@ -7,7 +7,7 @@ LL |     if let b"test" = () {}
    |            expected `()`, found `&[u8; 4]`
 
 error[E0308]: mismatched types
-  --> $DIR/byte-string-type-errors.rs:20:12
+  --> $DIR/byte-string-type-errors.rs:19:12
    |
 LL |     if let b"test" = &[] as &[i8] {}
    |            ^^^^^^^   ------------ this expression has type `&[i8]`
@@ -18,7 +18,7 @@ LL |     if let b"test" = &[] as &[i8] {}
               found reference `&'static [u8]`
 
 error[E0308]: mismatched types
-  --> $DIR/byte-string-type-errors.rs:25:12
+  --> $DIR/byte-string-type-errors.rs:24:12
    |
 LL |     if let b"test" = *(&[] as &[i8]) {}
    |            ^^^^^^^   --------------- this expression has type `[i8]`
@@ -29,7 +29,7 @@ LL |     if let b"test" = *(&[] as &[i8]) {}
               found slice `[u8]`
 
 error[E0308]: mismatched types
-  --> $DIR/byte-string-type-errors.rs:30:12
+  --> $DIR/byte-string-type-errors.rs:29:12
    |
 LL |     if let b"test" = [()] {}
    |            ^^^^^^^   ---- this expression has type `[(); 1]`
@@ -40,7 +40,7 @@ LL |     if let b"test" = [()] {}
               found array `[u8; 4]`
 
 error[E0308]: mismatched types
-  --> $DIR/byte-string-type-errors.rs:33:12
+  --> $DIR/byte-string-type-errors.rs:32:12
    |
 LL |     if let b"test" = *b"this array is too long" {}
    |            ^^^^^^^   -------------------------- this expression has type `[u8; 22]`
@@ -48,7 +48,7 @@ LL |     if let b"test" = *b"this array is too long" {}
    |            expected an array with a size of 22, found one with a size of 4
 
 error[E0308]: mismatched types
-  --> $DIR/byte-string-type-errors.rs:39:12
+  --> $DIR/byte-string-type-errors.rs:38:12
    |
 LL |     if let b"test" = &mut () {}
    |            ^^^^^^^   ------- this expression has type `&mut ()`
@@ -56,7 +56,7 @@ LL |     if let b"test" = &mut () {}
    |            expected `()`, found `&[u8; 4]`
 
 error[E0308]: mismatched types
-  --> $DIR/byte-string-type-errors.rs:44:12
+  --> $DIR/byte-string-type-errors.rs:43:12
    |
 LL |     if let b"test" = &mut [] as &mut [i8] {}
    |            ^^^^^^^   -------------------- this expression has type `&mut [i8]`
@@ -67,7 +67,7 @@ LL |     if let b"test" = &mut [] as &mut [i8] {}
               found slice `[u8]`
 
 error[E0308]: mismatched types
-  --> $DIR/byte-string-type-errors.rs:48:12
+  --> $DIR/byte-string-type-errors.rs:47:12
    |
 LL |     if let b"test" = &mut [()] {}
    |            ^^^^^^^   --------- this expression has type `&mut [(); 1]`
@@ -78,7 +78,7 @@ LL |     if let b"test" = &mut [()] {}
               found array `[u8; 4]`
 
 error[E0308]: mismatched types
-  --> $DIR/byte-string-type-errors.rs:52:12
+  --> $DIR/byte-string-type-errors.rs:51:12
    |
 LL |     if let b"test" = &mut *b"this array is too long" {}
    |            ^^^^^^^   ------------------------------- this expression has type `&mut [u8; 22]`

--- a/tests/ui/pattern/deref-patterns/cant_move_out_of_pattern.rs
+++ b/tests/ui/pattern/deref-patterns/cant_move_out_of_pattern.rs
@@ -1,5 +1,4 @@
 #![feature(deref_patterns)]
-#![allow(incomplete_features)]
 
 use std::rc::Rc;
 

--- a/tests/ui/pattern/deref-patterns/cant_move_out_of_pattern.stderr
+++ b/tests/ui/pattern/deref-patterns/cant_move_out_of_pattern.stderr
@@ -1,5 +1,5 @@
 error[E0508]: cannot move out of type `[Struct]`, a non-copy slice
-  --> $DIR/cant_move_out_of_pattern.rs:9:11
+  --> $DIR/cant_move_out_of_pattern.rs:8:11
    |
 LL |     match b {
    |           ^ cannot move out of here
@@ -16,7 +16,7 @@ LL |         deref!([ref x]) => x,
    |                 +++
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/cant_move_out_of_pattern.rs:17:11
+  --> $DIR/cant_move_out_of_pattern.rs:16:11
    |
 LL |     match rc {
    |           ^^
@@ -33,7 +33,7 @@ LL |         deref!(ref x) => x,
    |                +++
 
 error[E0508]: cannot move out of type `[Struct]`, a non-copy slice
-  --> $DIR/cant_move_out_of_pattern.rs:25:11
+  --> $DIR/cant_move_out_of_pattern.rs:24:11
    |
 LL |     match b {
    |           ^ cannot move out of here
@@ -50,7 +50,7 @@ LL |         [ref x] => x,
    |          +++
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/cant_move_out_of_pattern.rs:35:11
+  --> $DIR/cant_move_out_of_pattern.rs:34:11
    |
 LL |     match rc {
    |           ^^

--- a/tests/ui/pattern/deref-patterns/closure_capture.rs
+++ b/tests/ui/pattern/deref-patterns/closure_capture.rs
@@ -1,6 +1,5 @@
 //@ run-pass
 #![feature(deref_patterns)]
-#![allow(incomplete_features)]
 
 use std::rc::Rc;
 

--- a/tests/ui/pattern/deref-patterns/const-pats-do-not-mislead-inference.rs
+++ b/tests/ui/pattern/deref-patterns/const-pats-do-not-mislead-inference.rs
@@ -8,7 +8,6 @@
 //! we'd get without `deref_patterns` enabled.
 
 #![cfg_attr(deref_patterns, feature(deref_patterns))]
-#![cfg_attr(deref_patterns, expect(incomplete_features))]
 
 fn uninferred<T>() -> T { unimplemented!() }
 

--- a/tests/ui/pattern/deref-patterns/const-pats-do-not-mislead-inference.stable.stderr
+++ b/tests/ui/pattern/deref-patterns/const-pats-do-not-mislead-inference.stable.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/const-pats-do-not-mislead-inference.rs:33:12
+  --> $DIR/const-pats-do-not-mislead-inference.rs:32:12
    |
 LL |     if let b"..." = &&x {}
    |            ^^^^^^   --- this expression has type `&&_`
@@ -10,7 +10,7 @@ LL |     if let b"..." = &&x {}
               found reference `&'static [u8; 3]`
 
 error[E0308]: mismatched types
-  --> $DIR/const-pats-do-not-mislead-inference.rs:39:12
+  --> $DIR/const-pats-do-not-mislead-inference.rs:38:12
    |
 LL |     if let "..." = &Box::new(x) {}
    |            ^^^^^   ------------ this expression has type `&Box<_>`
@@ -25,7 +25,7 @@ LL |     if let "..." = &*Box::new(x) {}
    |                     +
 
 error[E0308]: mismatched types
-  --> $DIR/const-pats-do-not-mislead-inference.rs:45:12
+  --> $DIR/const-pats-do-not-mislead-inference.rs:44:12
    |
 LL |     if let b"..." = Box::new(&x) {}
    |            ^^^^^^   ------------ this expression has type `Box<&_>`
@@ -40,7 +40,7 @@ LL |     if let b"..." = *Box::new(&x) {}
    |                     +
 
 error[E0308]: mismatched types
-  --> $DIR/const-pats-do-not-mislead-inference.rs:51:12
+  --> $DIR/const-pats-do-not-mislead-inference.rs:50:12
    |
 LL |     if let "..." = &mut x {}
    |            ^^^^^   ------ this expression has type `&mut _`

--- a/tests/ui/pattern/deref-patterns/default-infer.rs
+++ b/tests/ui/pattern/deref-patterns/default-infer.rs
@@ -1,6 +1,5 @@
 //@ check-pass
 #![feature(deref_patterns)]
-#![expect(incomplete_features)]
 
 fn main() {
     match <_ as Default>::default() {

--- a/tests/ui/pattern/deref-patterns/deref-box.rs
+++ b/tests/ui/pattern/deref-patterns/deref-box.rs
@@ -3,7 +3,6 @@
 //! and `DerefMut::deref_mut`. Test that they work as expected.
 
 #![feature(deref_patterns)]
-#![expect(incomplete_features)]
 
 fn unbox_1<T>(b: Box<T>) -> T {
     let deref!(x) = b;

--- a/tests/ui/pattern/deref-patterns/dont-ice-on-slice-in-deref-pat-in-closure.rs
+++ b/tests/ui/pattern/deref-patterns/dont-ice-on-slice-in-deref-pat-in-closure.rs
@@ -3,7 +3,6 @@
 //! inside a deref pattern inside a closure: rust-lang/rust#125059
 
 #![feature(deref_patterns)]
-#![allow(incomplete_features, unused)]
 
 fn simple_vec(vec: Vec<u32>) -> u32 {
    (|| match Vec::<u32>::new() {

--- a/tests/ui/pattern/deref-patterns/fake_borrows.rs
+++ b/tests/ui/pattern/deref-patterns/fake_borrows.rs
@@ -1,5 +1,4 @@
 #![feature(deref_patterns)]
-#![allow(incomplete_features)]
 
 #[rustfmt::skip]
 fn main() {

--- a/tests/ui/pattern/deref-patterns/fake_borrows.stderr
+++ b/tests/ui/pattern/deref-patterns/fake_borrows.stderr
@@ -1,5 +1,5 @@
 error[E0502]: cannot borrow `v` as mutable because it is also borrowed as immutable
-  --> $DIR/fake_borrows.rs:9:16
+  --> $DIR/fake_borrows.rs:8:16
    |
 LL |     match v {
    |           - immutable borrow occurs here
@@ -10,7 +10,7 @@ LL |         _ if { v[0] = true; false } => {}
    |                mutable borrow occurs here
 
 error[E0502]: cannot borrow `v` as mutable because it is also borrowed as immutable
-  --> $DIR/fake_borrows.rs:16:16
+  --> $DIR/fake_borrows.rs:15:16
    |
 LL |     match v {
    |           - immutable borrow occurs here
@@ -21,7 +21,7 @@ LL |         _ if { v[0] = true; false } => {}
    |                mutable borrow occurs here
 
 error[E0510]: cannot assign `*b` in match guard
-  --> $DIR/fake_borrows.rs:26:16
+  --> $DIR/fake_borrows.rs:25:16
    |
 LL |     match b {
    |           - value is immutable in match guard
@@ -30,7 +30,7 @@ LL |         _ if { *b = true; false } => {}
    |                ^^^^^^^^^ cannot assign
 
 error[E0510]: cannot assign `*b` in match guard
-  --> $DIR/fake_borrows.rs:33:16
+  --> $DIR/fake_borrows.rs:32:16
    |
 LL |     match b {
    |           - value is immutable in match guard

--- a/tests/ui/pattern/deref-patterns/ice-adjust-mode-unimplemented-for-constblock.rs
+++ b/tests/ui/pattern/deref-patterns/ice-adjust-mode-unimplemented-for-constblock.rs
@@ -1,5 +1,4 @@
 #![feature(deref_patterns)]
-#![expect(incomplete_features)]
 
 fn main() {
     let vec![const { vec![] }]: Vec<usize> = vec![];

--- a/tests/ui/pattern/deref-patterns/ice-adjust-mode-unimplemented-for-constblock.stderr
+++ b/tests/ui/pattern/deref-patterns/ice-adjust-mode-unimplemented-for-constblock.stderr
@@ -1,5 +1,5 @@
 error[E0532]: expected a pattern, found a function call
-  --> $DIR/ice-adjust-mode-unimplemented-for-constblock.rs:5:9
+  --> $DIR/ice-adjust-mode-unimplemented-for-constblock.rs:4:9
    |
 LL |     let vec![const { vec![] }]: Vec<usize> = vec![];
    |         ^^^^^^^^^^^^^^^^^^^^^^ not a tuple struct or tuple variant
@@ -7,7 +7,7 @@ LL |     let vec![const { vec![] }]: Vec<usize> = vec![];
    = note: function calls are not allowed in patterns: <https://doc.rust-lang.org/book/ch19-00-patterns.html>
 
 error[E0532]: expected a pattern, found a function call
-  --> $DIR/ice-adjust-mode-unimplemented-for-constblock.rs:5:9
+  --> $DIR/ice-adjust-mode-unimplemented-for-constblock.rs:4:9
    |
 LL |     let vec![const { vec![] }]: Vec<usize> = vec![];
    |         ^^^^^^^^^^^^^^^^^^^^^^ not a tuple struct or tuple variant
@@ -15,7 +15,7 @@ LL |     let vec![const { vec![] }]: Vec<usize> = vec![];
    = note: function calls are not allowed in patterns: <https://doc.rust-lang.org/book/ch19-00-patterns.html>
 
 error: arbitrary expressions aren't allowed in patterns
-  --> $DIR/ice-adjust-mode-unimplemented-for-constblock.rs:5:14
+  --> $DIR/ice-adjust-mode-unimplemented-for-constblock.rs:4:14
    |
 LL |     let vec![const { vec![] }]: Vec<usize> = vec![];
    |              ^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL |     let vec![const { vec![] }]: Vec<usize> = vec![];
    = help: use a named `const`-item or an `if`-guard (`x if x == const { ... }`) instead
 
 error[E0164]: expected tuple struct or tuple variant, found associated function `::alloc::boxed::Box::new_uninit`
-  --> $DIR/ice-adjust-mode-unimplemented-for-constblock.rs:5:9
+  --> $DIR/ice-adjust-mode-unimplemented-for-constblock.rs:4:9
    |
 LL |     let vec![const { vec![] }]: Vec<usize> = vec![];
    |         ^^^^^^^^^^^^^^^^^^^^^^ `fn` calls are not allowed in patterns

--- a/tests/ui/pattern/deref-patterns/implicit-const-deref.rs
+++ b/tests/ui/pattern/deref-patterns/implicit-const-deref.rs
@@ -4,7 +4,6 @@
 //! scrutinee and end up with a type error; this would prevent us from reporting that only constants
 //! supporting structural equality can be used as patterns.
 #![feature(deref_patterns)]
-#![allow(incomplete_features)]
 
 const EMPTY: Vec<()> = Vec::new();
 

--- a/tests/ui/pattern/deref-patterns/implicit-const-deref.stderr
+++ b/tests/ui/pattern/deref-patterns/implicit-const-deref.stderr
@@ -1,5 +1,5 @@
 error: constant of non-structural type `Vec<()>` in a pattern
-  --> $DIR/implicit-const-deref.rs:15:9
+  --> $DIR/implicit-const-deref.rs:14:9
    |
 LL | const EMPTY: Vec<()> = Vec::new();
    | -------------------- constant defined here

--- a/tests/ui/pattern/deref-patterns/implicit-cow-deref.rs
+++ b/tests/ui/pattern/deref-patterns/implicit-cow-deref.rs
@@ -1,7 +1,6 @@
 //@ run-pass
 //! Test that implicit deref patterns interact as expected with `Cow` constructor patterns.
 #![feature(deref_patterns)]
-#![allow(incomplete_features)]
 
 use std::borrow::Cow;
 use std::rc::Rc;

--- a/tests/ui/pattern/deref-patterns/recursion-limit.rs
+++ b/tests/ui/pattern/deref-patterns/recursion-limit.rs
@@ -1,6 +1,5 @@
 //! Test that implicit deref patterns respect the recursion limit
 #![feature(deref_patterns)]
-#![allow(incomplete_features)]
 #![recursion_limit = "8"]
 
 use std::ops::Deref;

--- a/tests/ui/pattern/deref-patterns/recursion-limit.stderr
+++ b/tests/ui/pattern/deref-patterns/recursion-limit.stderr
@@ -1,5 +1,5 @@
 error[E0055]: reached the recursion limit while auto-dereferencing `Cyclic`
-  --> $DIR/recursion-limit.rs:18:9
+  --> $DIR/recursion-limit.rs:17:9
    |
 LL |         () => {}
    |         ^^ deref recursion limit reached
@@ -7,13 +7,13 @@ LL |         () => {}
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "16"]` attribute to your crate (`recursion_limit`)
 
 error[E0277]: the trait bound `Cyclic: DerefPure` is not satisfied
-  --> $DIR/recursion-limit.rs:18:9
+  --> $DIR/recursion-limit.rs:17:9
    |
 LL |         () => {}
    |         ^^ unsatisfied trait bound
    |
 help: the nightly-only, unstable trait `DerefPure` is not implemented for `Cyclic`
-  --> $DIR/recursion-limit.rs:8:1
+  --> $DIR/recursion-limit.rs:7:1
    |
 LL | struct Cyclic;
    | ^^^^^^^^^^^^^

--- a/tests/ui/pattern/deref-patterns/ref-mut.rs
+++ b/tests/ui/pattern/deref-patterns/ref-mut.rs
@@ -1,5 +1,4 @@
 #![feature(deref_patterns)]
-//~^ WARN the feature `deref_patterns` is incomplete
 
 use std::rc::Rc;
 

--- a/tests/ui/pattern/deref-patterns/ref-mut.stderr
+++ b/tests/ui/pattern/deref-patterns/ref-mut.stderr
@@ -1,14 +1,5 @@
-warning: the feature `deref_patterns` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/ref-mut.rs:1:12
-   |
-LL | #![feature(deref_patterns)]
-   |            ^^^^^^^^^^^^^^
-   |
-   = note: see issue #87121 <https://github.com/rust-lang/rust/issues/87121> for more information
-   = note: `#[warn(incomplete_features)]` on by default
-
 error[E0277]: the trait bound `Rc<{integer}>: DerefMut` is not satisfied
-  --> $DIR/ref-mut.rs:17:9
+  --> $DIR/ref-mut.rs:16:9
    |
 LL |         deref!(x) => {}
    |         ^^^^^^^^^ the trait `DerefMut` is not implemented for `Rc<{integer}>`
@@ -16,11 +7,11 @@ LL |         deref!(x) => {}
    = note: this error originates in the macro `deref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Rc<({integer},)>: DerefMut` is not satisfied
-  --> $DIR/ref-mut.rs:22:9
+  --> $DIR/ref-mut.rs:21:9
    |
 LL |         (x,) => {}
    |         ^^^^ the trait `DerefMut` is not implemented for `Rc<({integer},)>`
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/pattern/deref-patterns/refs.rs
+++ b/tests/ui/pattern/deref-patterns/refs.rs
@@ -1,6 +1,5 @@
 //@ check-pass
 #![feature(deref_patterns)]
-#![expect(incomplete_features)]
 
 fn foo(s: &String) -> i32 {
     match *s {

--- a/tests/ui/pattern/deref-patterns/strings.rs
+++ b/tests/ui/pattern/deref-patterns/strings.rs
@@ -2,7 +2,6 @@
 //! Test deref patterns using string and bytestring literals.
 
 #![feature(deref_patterns)]
-#![allow(incomplete_features)]
 
 fn main() {
     for (test_in, test_expect) in [("zero", 0), ("one", 1), ("two", 2)] {

--- a/tests/ui/pattern/deref-patterns/typeck.rs
+++ b/tests/ui/pattern/deref-patterns/typeck.rs
@@ -1,6 +1,5 @@
 //@ check-pass
 #![feature(deref_patterns)]
-#![allow(incomplete_features)]
 
 use std::rc::Rc;
 

--- a/tests/ui/pattern/deref-patterns/typeck_fail.rs
+++ b/tests/ui/pattern/deref-patterns/typeck_fail.rs
@@ -1,5 +1,4 @@
 #![feature(deref_patterns)]
-#![allow(incomplete_features)]
 
 fn main() {
     // Make sure we don't try implicitly dereferncing any ADT.

--- a/tests/ui/pattern/deref-patterns/typeck_fail.stderr
+++ b/tests/ui/pattern/deref-patterns/typeck_fail.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/typeck_fail.rs:7:9
+  --> $DIR/typeck_fail.rs:6:9
    |
 LL |     match Some(0) {
    |           ------- this expression has type `Option<{integer}>`

--- a/tests/ui/pattern/deref-patterns/unsatisfied-bounds.rs
+++ b/tests/ui/pattern/deref-patterns/unsatisfied-bounds.rs
@@ -1,5 +1,4 @@
 #![feature(deref_patterns)]
-#![allow(incomplete_features)]
 
 struct MyPointer;
 

--- a/tests/ui/pattern/deref-patterns/unsatisfied-bounds.stderr
+++ b/tests/ui/pattern/deref-patterns/unsatisfied-bounds.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `MyPointer: DerefPure` is not satisfied
-  --> $DIR/unsatisfied-bounds.rs:17:9
+  --> $DIR/unsatisfied-bounds.rs:16:9
    |
 LL |         () => {}
    |         ^^ unsatisfied trait bound
    |
 help: the nightly-only, unstable trait `DerefPure` is not implemented for `MyPointer`
-  --> $DIR/unsatisfied-bounds.rs:4:1
+  --> $DIR/unsatisfied-bounds.rs:3:1
    |
 LL | struct MyPointer;
    | ^^^^^^^^^^^^^^^^

--- a/tests/ui/pattern/deref-patterns/usefulness/empty-types.rs
+++ b/tests/ui/pattern/deref-patterns/usefulness/empty-types.rs
@@ -4,7 +4,6 @@
 // FIXME(deref_patterns): On stabilization, cases for deref patterns could be worked into that file
 // to keep the tests for empty types in one place and test more thoroughly.
 #![feature(deref_patterns)]
-#![expect(incomplete_features)]
 #![deny(unreachable_patterns)]
 
 enum Void {}

--- a/tests/ui/pattern/deref-patterns/usefulness/empty-types.stderr
+++ b/tests/ui/pattern/deref-patterns/usefulness/empty-types.stderr
@@ -1,5 +1,5 @@
 error[E0004]: non-exhaustive patterns: `deref!(Some(_))` not covered
-  --> $DIR/empty-types.rs:21:11
+  --> $DIR/empty-types.rs:20:11
    |
 LL |     match box_opt_void {
    |           ^^^^^^^^^^^^ pattern `deref!(Some(_))` not covered
@@ -15,7 +15,7 @@ LL +         deref!(Some(_)) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `Some(_)` not covered
-  --> $DIR/empty-types.rs:35:11
+  --> $DIR/empty-types.rs:34:11
    |
 LL |     match *box_opt_void {
    |           ^^^^^^^^^^^^^ pattern `Some(_)` not covered

--- a/tests/ui/pattern/deref-patterns/usefulness/mixed-constructors.rs
+++ b/tests/ui/pattern/deref-patterns/usefulness/mixed-constructors.rs
@@ -2,7 +2,6 @@
 //! doesn't support this, so make sure we catch it beforehand. As a consequence, it takes priority
 //! over non-exhaustive match and unreachable pattern errors.
 #![feature(deref_patterns)]
-#![expect(incomplete_features)]
 #![deny(unreachable_patterns)]
 
 use std::borrow::Cow;

--- a/tests/ui/pattern/deref-patterns/usefulness/mixed-constructors.stderr
+++ b/tests/ui/pattern/deref-patterns/usefulness/mixed-constructors.stderr
@@ -1,5 +1,5 @@
 error: mix of deref patterns and normal constructors
-  --> $DIR/mixed-constructors.rs:16:9
+  --> $DIR/mixed-constructors.rs:15:9
    |
 LL |         false => {}
    |         ^^^^^ matches on the result of dereferencing `Cow<'_, bool>`
@@ -7,7 +7,7 @@ LL |         Cow::Borrowed(_) => {}
    |         ^^^^^^^^^^^^^^^^ matches directly on `Cow<'_, bool>`
 
 error: mix of deref patterns and normal constructors
-  --> $DIR/mixed-constructors.rs:22:9
+  --> $DIR/mixed-constructors.rs:21:9
    |
 LL |         Cow::Borrowed(_) => {}
    |         ^^^^^^^^^^^^^^^^ matches directly on `Cow<'_, bool>`
@@ -15,7 +15,7 @@ LL |         true => {}
    |         ^^^^ matches on the result of dereferencing `Cow<'_, bool>`
 
 error: mix of deref patterns and normal constructors
-  --> $DIR/mixed-constructors.rs:29:9
+  --> $DIR/mixed-constructors.rs:28:9
    |
 LL |         Cow::Owned(_) => {}
    |         ^^^^^^^^^^^^^ matches directly on `Cow<'_, bool>`
@@ -23,7 +23,7 @@ LL |         false => {}
    |         ^^^^^ matches on the result of dereferencing `Cow<'_, bool>`
 
 error: mix of deref patterns and normal constructors
-  --> $DIR/mixed-constructors.rs:36:10
+  --> $DIR/mixed-constructors.rs:35:10
    |
 LL |         (Cow::Borrowed(_), 0) => {}
    |          ^^^^^^^^^^^^^^^^ matches directly on `Cow<'_, bool>`
@@ -31,7 +31,7 @@ LL |         (true, 0) => {}
    |          ^^^^ matches on the result of dereferencing `Cow<'_, bool>`
 
 error: mix of deref patterns and normal constructors
-  --> $DIR/mixed-constructors.rs:43:13
+  --> $DIR/mixed-constructors.rs:42:13
    |
 LL |         (0, Cow::Borrowed(_)) => {}
    |             ^^^^^^^^^^^^^^^^ matches directly on `Cow<'_, bool>`

--- a/tests/ui/pattern/deref-patterns/usefulness/non-exhaustive.rs
+++ b/tests/ui/pattern/deref-patterns/usefulness/non-exhaustive.rs
@@ -1,6 +1,5 @@
 //! Test non-exhaustive matches involving deref patterns.
 #![feature(deref_patterns)]
-#![expect(incomplete_features)]
 #![deny(unreachable_patterns)]
 
 fn main() {

--- a/tests/ui/pattern/deref-patterns/usefulness/non-exhaustive.stderr
+++ b/tests/ui/pattern/deref-patterns/usefulness/non-exhaustive.stderr
@@ -1,5 +1,5 @@
 error[E0004]: non-exhaustive patterns: `deref!(true)` not covered
-  --> $DIR/non-exhaustive.rs:7:11
+  --> $DIR/non-exhaustive.rs:6:11
    |
 LL |     match Box::new(false) {
    |           ^^^^^^^^^^^^^^^ pattern `deref!(true)` not covered
@@ -14,7 +14,7 @@ LL +         deref!(true) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `deref!(deref!(false))` not covered
-  --> $DIR/non-exhaustive.rs:12:11
+  --> $DIR/non-exhaustive.rs:11:11
    |
 LL |     match Box::new(Box::new(false)) {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `deref!(deref!(false))` not covered
@@ -29,7 +29,7 @@ LL +         deref!(deref!(false)) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `deref!((true, deref!(true)))` and `deref!((false, deref!(false)))` not covered
-  --> $DIR/non-exhaustive.rs:17:11
+  --> $DIR/non-exhaustive.rs:16:11
    |
 LL |     match Box::new((true, Box::new(false))) {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ patterns `deref!((true, deref!(true)))` and `deref!((false, deref!(false)))` not covered
@@ -44,7 +44,7 @@ LL +         deref!((true, deref!(true))) | deref!((false, deref!(false))) => to
    |
 
 error[E0004]: non-exhaustive patterns: `deref!((deref!(T::C), _))` not covered
-  --> $DIR/non-exhaustive.rs:24:11
+  --> $DIR/non-exhaustive.rs:23:11
    |
 LL |     match Box::new((Box::new(T::A), Box::new(T::A))) {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `deref!((deref!(T::C), _))` not covered

--- a/tests/ui/pattern/deref-patterns/usefulness/unreachable-patterns.rs
+++ b/tests/ui/pattern/deref-patterns/usefulness/unreachable-patterns.rs
@@ -1,6 +1,5 @@
 //! Test unreachable patterns involving deref patterns.
 #![feature(deref_patterns)]
-#![expect(incomplete_features)]
 #![deny(unreachable_patterns)]
 
 fn main() {

--- a/tests/ui/pattern/deref-patterns/usefulness/unreachable-patterns.stderr
+++ b/tests/ui/pattern/deref-patterns/usefulness/unreachable-patterns.stderr
@@ -1,5 +1,5 @@
 error: unreachable pattern
-  --> $DIR/unreachable-patterns.rs:10:9
+  --> $DIR/unreachable-patterns.rs:9:9
    |
 LL |         false => {}
    |         ----- matches all the relevant values
@@ -7,13 +7,13 @@ LL |         false => {}
    |         ^^^^^ no value can reach this
    |
 note: the lint level is defined here
-  --> $DIR/unreachable-patterns.rs:4:9
+  --> $DIR/unreachable-patterns.rs:3:9
    |
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/unreachable-patterns.rs:16:9
+  --> $DIR/unreachable-patterns.rs:15:9
    |
 LL |         true => {}
    |         ---- matches all the relevant values
@@ -22,13 +22,13 @@ LL |         true => {}
    |         ^^^^ no value can reach this
 
 error: unreachable pattern
-  --> $DIR/unreachable-patterns.rs:23:9
+  --> $DIR/unreachable-patterns.rs:22:9
    |
 LL |         _ => {}
    |         ^ no value can reach this
    |
 note: multiple earlier patterns match some of the same values
-  --> $DIR/unreachable-patterns.rs:23:9
+  --> $DIR/unreachable-patterns.rs:22:9
    |
 LL |         (true, _) => {}
    |         --------- matches some of the same values
@@ -40,7 +40,7 @@ LL |         _ => {}
    |         ^ collectively making this unreachable
 
 error: unreachable pattern
-  --> $DIR/unreachable-patterns.rs:29:9
+  --> $DIR/unreachable-patterns.rs:28:9
    |
 LL |         (T::A | T::B, T::A | T::C) => {}
    |         -------------------------- matches all the relevant values
@@ -48,7 +48,7 @@ LL |         (T::A, T::C) => {}
    |         ^^^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
-  --> $DIR/unreachable-patterns.rs:30:9
+  --> $DIR/unreachable-patterns.rs:29:9
    |
 LL |         (T::A | T::B, T::A | T::C) => {}
    |         -------------------------- matches all the relevant values


### PR DESCRIPTION
This PR removes the `incomplete_feature` warning for `deref_patterns`. The reason given for this in the tracking issue (rust-lang/rust#87121) was 
> Per policy, the `incomplete_feature` is supposed to stay on until the feature has an accepted RFC. We're slowly working on writing up that RFC so it'll take some more time unfortunately.
> 
> I don't know of any compiler crashes it causes today. The feature should be pretty usable.

However, I could not find any evidence of such a policy. The [lint documentation](https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#incomplete-features) for `incomplete_features` also only mentions features that are more likely to cause errors.
There are also many other features without an RFC that are not considered incomplete, e.g. `macro_metavar_expr_concat`, `negative_impls` or `yeet_expr`.
The feature does not cause any known ICEs either.

The concrete motivation is to use this feature to replace `box_patterns` in the compiler and pave the way towards removing that legacy feature.
