### PR TITLE
docs: note env var influence on `temp_dir` and `env_clear` on Windows

### DIFF
--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -670,6 +670,17 @@ pub fn home_dir() -> Option<PathBuf> {
 ///
 /// On Windows, the behavior is equivalent to that of [`GetTempPath2`][GetTempPath2] /
 /// [`GetTempPath`][GetTempPath], which this function uses internally.
+/// Specifically, for non-SYSTEM processes, the function checks for the
+/// following environment variables in order and returns the first path found:
+///
+/// 1. The path specified by the `TMP` environment variable.
+/// 2. The path specified by the `TEMP` environment variable.
+/// 3. The path specified by the `USERPROFILE` environment variable.
+/// 4. The Windows directory.
+///
+/// When called from a process running as SYSTEM,
+/// [`GetTempPath2`][GetTempPath2] returns `C:\Windows\SystemTemp`
+/// regardless of environment variables.
 ///
 /// Note that, this [may change in the future][changes].
 ///


### PR DESCRIPTION
On Windows, `env::temp_dir()` internally calls `GetTempPath2`/`GetTempPath`,
which checks the `TMP`, `TEMP`, and `USERPROFILE` environment variables in
order before falling back to the Windows directory. This lookup order was
previously only discoverable by following links to Microsoft documentation.

This PR documents the env var lookup order directly in `env::temp_dir` docs
and notes `GetTempPath2`'s SYSTEM-identity behavior (`C:\Windows\SystemTemp`).

Addresses rust-lang/rust#125439.