### PR TITLE
 Revert "Also duplicate `#[expect]` attribute in `#[derive]`-ed code"

### DIFF
--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -540,7 +540,6 @@ impl<'a> TraitDef<'a> {
                         .filter(|a| {
                             a.has_any_name(&[
                                 sym::allow,
-                                sym::expect,
                                 sym::warn,
                                 sym::deny,
                                 sym::forbid,

--- a/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553-3.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553-3.rs
@@ -1,3 +1,5 @@
+// FIXME: Bring back duplication of the `#[expect]` attribute when deriving.
+//
 // Make sure we produce the unfulfilled expectation lint if neither the struct or the
 // derived code fulfilled it.
 
@@ -5,7 +7,7 @@
 
 #[expect(unexpected_cfgs)]
 //~^ WARN this lint expectation is unfulfilled
-//~^^ WARN this lint expectation is unfulfilled
+//FIXME ~^^ WARN this lint expectation is unfulfilled
 #[derive(Debug)]
 pub struct MyStruct {
     pub t_ref: i64,

--- a/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553-3.stderr
+++ b/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553-3.stderr
@@ -1,18 +1,10 @@
 warning: this lint expectation is unfulfilled
-  --> $DIR/derive-expect-issue-150553-3.rs:6:10
+  --> $DIR/derive-expect-issue-150553-3.rs:8:10
    |
 LL | #[expect(unexpected_cfgs)]
    |          ^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unfulfilled_lint_expectations)]` on by default
 
-warning: this lint expectation is unfulfilled
-  --> $DIR/derive-expect-issue-150553-3.rs:6:10
-   |
-LL | #[expect(unexpected_cfgs)]
-   |          ^^^^^^^^^^^^^^^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-warning: 2 warnings emitted
+warning: 1 warning emitted
 

--- a/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553-4.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553-4.rs
@@ -1,0 +1,15 @@
+// This test makes sure that expended items with derives don't interfear with lint expectations.
+//
+// See <https://github.com/rust-lang/rust/issues/153036> for some context.
+
+//@ check-pass
+
+#[derive(Clone, Debug)]
+#[expect(unused)]
+pub struct LoggingArgs {
+    #[cfg(false)]
+    x: i32,
+    y: i32,
+}
+
+fn main() {}

--- a/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553.rs
@@ -1,9 +1,11 @@
+// FIXME: Bring back duplication of the `#[expect]` attribute when deriving.
+//
 // Make sure we properly copy the `#[expect]` attr to the derived code and that no
 // unfulfilled expectations are trigerred.
 //
 // See <https://github.com/rust-lang/rust/issues/150553> for rational.
 
-//@ check-pass
+//@ check-fail
 
 #![deny(redundant_lifetimes)]
 
@@ -12,6 +14,7 @@ use std::fmt::Debug;
 #[derive(Debug)]
 #[expect(redundant_lifetimes)]
 pub struct RefWrapper<'a, T>
+//~^ ERROR redundant_lifetimes
 where
     'a: 'static,
     T: Debug,

--- a/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553.stderr
+++ b/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553.stderr
@@ -1,0 +1,15 @@
+error: unnecessary lifetime parameter `'a`
+  --> $DIR/derive-expect-issue-150553.rs:16:23
+   |
+LL | pub struct RefWrapper<'a, T>
+   |                       ^^
+   |
+   = note: you can use the `'static` lifetime directly, in place of `'a`
+note: the lint level is defined here
+  --> $DIR/derive-expect-issue-150553.rs:10:9
+   |
+LL | #![deny(redundant_lifetimes)]
+   |         ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Turns out rust-lang/rust#152289 doesn't work, not because cloning an attribute doesn't keep the same attribute id, but because `#[cfg]` and `#[cfg_attr]` [re-parse items from scratch](https://github.com/rust-lang/rust/blob/859951e3c7c9d0322c39bad49221937455bdffcd/compiler/rustc_builtin_macros/src/cfg_eval.rs#L100-L109) bypassing any cloning on AST and forcing the creation of new attribute IDs. :confused:

Fixes rust-lang/rust#153036
Fixes rust-lang/rust#152401
Reopens rust-lang/rust#150553

<!-- homu-ignore:start -->
r? @jdonszelmann
<!-- homu-ignore:end -->
