### PR TITLE
Give a better error when updating a submodule fails

### DIFF
--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -2426,7 +2426,7 @@ pub(crate) fn update_submodule<'a>(
     let actual_hash = recorded
         .split_whitespace()
         .nth(2)
-        .unwrap_or_else(|| panic!("unexpected output `{recorded}`"));
+        .unwrap_or_else(|| panic!("unexpected output `{recorded}` when updating {relative_path}"));
 
     if actual_hash == checked_out_hash {
         // already checked out


### PR DESCRIPTION
Previously this would sometimes just say "unexpected output ``", which was extremely unhelpful. The actual issue was that I had a `.jj` directory but not a `.git` directory, so it couldn't run `git submodule update.`

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
