### PR TITLE
Remove `_description_fns` and `_cache_on_disk_if_fns` modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4492,6 +4492,7 @@ version = "0.0.0"
 dependencies = [
  "measureme",
  "rustc_abi",
+ "rustc_ast",
  "rustc_data_structures",
  "rustc_errors",
  "rustc_hir",

--- a/compiler/rustc_macros/src/query.rs
+++ b/compiler/rustc_macros/src/query.rs
@@ -406,7 +406,7 @@ pub(super) fn rustc_queries(input: TokenStream) -> TokenStream {
         // `(cache_on_disk { <closure > }`.
         if let Some(CacheOnDiskIf { block, .. }) = &modifiers.cache_on_disk_if {
             modifiers_out.push(quote! {
-                (cache_on_disk_if { 
+                (cache_on_disk_if {
                     // `pass_by_value`: some keys are marked with `rustc_pass_by_value`, but we
                     // take keys by reference here.
                     // FIXME: `pass_by_value` is badly named; `allow(rustc::pass_by_value)`

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -96,7 +96,6 @@ use rustc_session::cstore::{
     CrateDepKind, CrateSource, ExternCrate, ForeignModule, LinkagePreference, NativeLib,
 };
 use rustc_session::lint::LintExpectationId;
-use rustc_span::def_id::LOCAL_CRATE;
 use rustc_span::source_map::Spanned;
 use rustc_span::{DUMMY_SP, LocalExpnId, Span, Symbol};
 use rustc_target::spec::PanicStrategy;

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -120,7 +120,6 @@ use crate::mir::interpret::{
 use crate::mir::mono::{
     CodegenUnit, CollectionMode, MonoItem, MonoItemPartitions, NormalizationErrorInMono,
 };
-use crate::query::describe_as_module;
 use crate::query::plumbing::CyclePlaceholder;
 use crate::traits::query::{
     CanonicalAliasGoal, CanonicalDropckOutlivesGoal, CanonicalImpliedOutlivesBoundsGoal,
@@ -135,7 +134,6 @@ use crate::traits::{
 };
 use crate::ty::fast_reject::SimplifiedType;
 use crate::ty::layout::ValidityRequirement;
-use crate::ty::print::PrintTraitRefExt;
 use crate::ty::util::AlwaysRequiresDrop;
 use crate::ty::{
     self, CrateInherentImpls, GenericArg, GenericArgsRef, LitToConstInput, PseudoCanonicalInput,

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -170,42 +170,6 @@ impl<'tcx, C: QueryCache> fmt::Debug for QueryVTable<'tcx, C> {
 }
 
 impl<'tcx, C: QueryCache> QueryVTable<'tcx, C> {
-    #[inline(always)]
-    pub fn will_cache_on_disk_for_key(&self, tcx: TyCtxt<'tcx>, key: &C::Key) -> bool {
-        (self.will_cache_on_disk_for_key_fn)(tcx, key)
-    }
-
-    #[inline(always)]
-    pub fn try_load_from_disk(
-        &self,
-        tcx: TyCtxt<'tcx>,
-        key: &C::Key,
-        prev_index: SerializedDepNodeIndex,
-        index: DepNodeIndex,
-    ) -> Option<C::Value> {
-        (self.try_load_from_disk_fn)(tcx, key, prev_index, index)
-    }
-
-    #[inline]
-    pub fn is_loadable_from_disk(
-        &self,
-        tcx: TyCtxt<'tcx>,
-        key: &C::Key,
-        index: SerializedDepNodeIndex,
-    ) -> bool {
-        (self.is_loadable_from_disk_fn)(tcx, key, index)
-    }
-
-    /// Synthesize an error value to let compilation continue after a cycle.
-    pub fn value_from_cycle_error(
-        &self,
-        tcx: TyCtxt<'tcx>,
-        cycle_error: &CycleError,
-        guar: ErrorGuaranteed,
-    ) -> C::Value {
-        (self.value_from_cycle_error)(tcx, cycle_error, guar)
-    }
-
     pub fn construct_dep_node(&self, tcx: TyCtxt<'tcx>, key: &C::Key) -> DepNode {
         DepNode::construct(tcx, self.dep_kind, key)
     }

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -139,8 +139,10 @@ pub struct QueryVTable<'tcx, C: QueryCache> {
         prev_index: SerializedDepNodeIndex,
         index: DepNodeIndex,
     ) -> Option<C::Value>,
+
     pub is_loadable_from_disk_fn:
         fn(tcx: TyCtxt<'tcx>, key: &C::Key, index: SerializedDepNodeIndex) -> bool,
+
     pub hash_result: HashResult<C::Value>,
     pub value_from_cycle_error:
         fn(tcx: TyCtxt<'tcx>, cycle_error: &CycleError, guar: ErrorGuaranteed) -> C::Value,

--- a/compiler/rustc_query_impl/Cargo.toml
+++ b/compiler/rustc_query_impl/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 # tidy-alphabetical-start
 measureme = "12.0.1"
 rustc_abi = { path = "../rustc_abi" }
+rustc_ast = { path = "../rustc_ast" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_errors = { path = "../rustc_errors" }
 rustc_hir = { path = "../rustc_hir" }

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -9,12 +9,17 @@
 // tidy-alphabetical-end
 
 use rustc_data_structures::sync::AtomicU64;
+use rustc_hir::def::DefKind;
+use rustc_hir::def_id::LOCAL_CRATE;
 use rustc_middle::dep_graph;
 use rustc_middle::queries::{self, ExternProviders, Providers};
 use rustc_middle::query::on_disk_cache::{CacheEncoder, EncodedDepNodeIndex, OnDiskCache};
 use rustc_middle::query::plumbing::{QuerySystem, QuerySystemFns, QueryVTable};
-use rustc_middle::query::{AsLocalKey, QueryCache, QueryMode};
-use rustc_middle::ty::TyCtxt;
+use rustc_middle::query::{
+    AsLocalKey, QueryCache, QueryMode, describe_as_module,
+};
+use rustc_middle::ty::print::PrintTraitRefExt;
+use rustc_middle::ty::{self, TyCtxt};
 use rustc_span::Span;
 
 pub use crate::dep_kind_vtables::make_dep_kind_vtables;

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -19,9 +19,7 @@ use rustc_middle::mir::mono::CollectionMode;
 use rustc_middle::queries::{self, ExternProviders, Providers};
 use rustc_middle::query::on_disk_cache::{CacheEncoder, EncodedDepNodeIndex, OnDiskCache};
 use rustc_middle::query::plumbing::{QuerySystem, QuerySystemFns, QueryVTable};
-use rustc_middle::query::{
-    AsLocalKey, QueryCache, QueryMode, describe_as_module,
-};
+use rustc_middle::query::{AsLocalKey, QueryCache, QueryMode, describe_as_module};
 use rustc_middle::ty::print::PrintTraitRefExt;
 use rustc_middle::ty::{self, PseudoCanonicalInput, TyCtxt};
 use rustc_span::def_id::{CrateNum, DefId, LocalDefId, LocalModDefId};

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -5,13 +5,17 @@
 #![feature(core_intrinsics)]
 #![feature(min_specialization)]
 #![feature(rustc_attrs)]
+#![feature(stmt_expr_attributes)]
 #![feature(try_blocks)]
 // tidy-alphabetical-end
 
+use rustc_ast::tokenstream::TokenStream;
 use rustc_data_structures::sync::AtomicU64;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::LOCAL_CRATE;
 use rustc_middle::dep_graph;
+use rustc_middle::mir::interpret::GlobalId;
+use rustc_middle::mir::mono::CollectionMode;
 use rustc_middle::queries::{self, ExternProviders, Providers};
 use rustc_middle::query::on_disk_cache::{CacheEncoder, EncodedDepNodeIndex, OnDiskCache};
 use rustc_middle::query::plumbing::{QuerySystem, QuerySystemFns, QueryVTable};
@@ -19,8 +23,9 @@ use rustc_middle::query::{
     AsLocalKey, QueryCache, QueryMode, describe_as_module,
 };
 use rustc_middle::ty::print::PrintTraitRefExt;
-use rustc_middle::ty::{self, TyCtxt};
-use rustc_span::Span;
+use rustc_middle::ty::{self, PseudoCanonicalInput, TyCtxt};
+use rustc_span::def_id::{CrateNum, DefId, LocalDefId, LocalModDefId};
+use rustc_span::{LocalExpnId, Span};
 
 pub use crate::dep_kind_vtables::make_dep_kind_vtables;
 pub use crate::job::{QueryJobMap, break_query_cycles, print_query_stack};

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -358,7 +358,7 @@ pub(crate) fn encode_query_results_inner<'a, 'tcx, C, V>(
 
     assert!(all_inactive(&query.state));
     query.cache.iter(&mut |key, value, dep_node| {
-        if query.will_cache_on_disk_for_key(tcx, key) {
+        if (query.will_cache_on_disk_for_key_fn)(tcx, key) {
             let dep_node = SerializedDepNodeIndex::new(dep_node.index());
 
             // Record position of the cache entry.
@@ -411,7 +411,7 @@ pub(crate) fn try_load_from_on_disk_cache_inner<'tcx, C: QueryCache>(
             dep_node.key_fingerprint
         )
     });
-    if query.will_cache_on_disk_for_key(tcx, &key) {
+    if (query.will_cache_on_disk_for_key_fn)(tcx, &key) {
         // Call `tcx.$query(key)` for its side-effect of loading the disk-cached
         // value into memory.
         (query.call_query_method_fn)(tcx, key);


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/153065)*
<!-- homu-ignore:end -->

See rust-lang/rust#153064 for a description of these modules. This PR removes them. This greatly simplifies the `rustc_queries!` proc macro (which is hard to read and understand) at the cost of slightly complicating the `define_callbacks!` declarative macro (which is not easy to read and understand, but certainly easier than the proc macro).

r? @Zalathar