### PR TITLE
Allow merging all libcore/alloc doctests into a single binary

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0636.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0636.md
@@ -1,8 +1,10 @@
+#### Note: this error code is no longer emitted by the compiler.
+
 The same feature is enabled multiple times with `#![feature]` attributes
 
 Erroneous code example:
 
-```compile_fail,E0636
+```compile_fail
 #![allow(stable_features)]
 #![feature(rust1)]
 #![feature(rust1)] // error: the feature `rust1` has already been enabled

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -39,6 +39,7 @@ declare_lint_pass! {
         DEPRECATED_IN_FUTURE,
         DEPRECATED_SAFE_2024,
         DEPRECATED_WHERE_CLAUSE_LOCATION,
+        DUPLICATE_FEATURES,
         DUPLICATE_MACRO_ATTRIBUTES,
         ELIDED_LIFETIMES_IN_ASSOCIATED_CONSTANT,
         ELIDED_LIFETIMES_IN_PATHS,
@@ -1091,6 +1092,33 @@ declare_lint! {
     pub UNUSED_FEATURES,
     Warn,
     "unused features found in crate-level `#[feature]` directives"
+}
+
+declare_lint! {
+    /// The `duplicate_features` lint detects duplicate features found in
+    /// crate-level [`feature` attributes].
+    ///
+    /// Note: This lint used to be a hard error (E0636).
+    ///
+    /// [`feature` attributes]: https://doc.rust-lang.org/nightly/unstable-book/
+    ///
+    /// ### Example
+    ///
+    /// ```rust,compile_fail
+    /// # #![allow(internal_features)]
+    /// #![feature(rustc_attrs)]
+    /// #![feature(rustc_attrs)]
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// Enabling a feature more than once is a no-op.
+    /// To avoid this warning, remove the second `feature()` attribute.
+    pub DUPLICATE_FEATURES,
+    Deny,
+    "duplicate features found in crate-level `#[feature]` directives"
 }
 
 declare_lint! {

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -988,14 +988,6 @@ pub(crate) struct ImpliedFeatureNotExist {
 }
 
 #[derive(Diagnostic)]
-#[diag("the feature `{$feature}` has already been enabled", code = E0636)]
-pub(crate) struct DuplicateFeatureErr {
-    #[primary_span]
-    pub span: Span,
-    pub feature: Symbol,
-}
-
-#[derive(Diagnostic)]
 #[diag(
     "attributes `#[rustc_const_unstable]`, `#[rustc_const_stable]` and `#[rustc_const_stable_indirect]` require the function or method to be `const`"
 )]
@@ -1142,6 +1134,12 @@ pub(crate) struct ProcMacroBadSig {
     #[primary_span]
     pub span: Span,
     pub kind: ProcMacroKind,
+}
+
+#[derive(Diagnostic)]
+#[diag("the feature `{$feature}` has already been enabled")]
+pub(crate) struct DuplicateFeature {
+    pub feature: Symbol,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -969,7 +969,7 @@ pub fn check_unused_or_stable_features(tcx: TyCtxt<'_>) {
         }
         if !lang_features.insert(gate_name) {
             // Warn if the user enables a lang feature multiple times.
-            tcx.dcx().emit_err(errors::DuplicateFeatureErr { span: *attr_sp, feature: *gate_name });
+            duplicate_feature_lint(tcx, *attr_sp, *gate_name);
         }
     }
 
@@ -978,7 +978,7 @@ pub fn check_unused_or_stable_features(tcx: TyCtxt<'_>) {
     for EnabledLibFeature { gate_name, attr_sp } in enabled_lib_features {
         if remaining_lib_features.contains_key(gate_name) {
             // Warn if the user enables a lib feature multiple times.
-            tcx.dcx().emit_err(errors::DuplicateFeatureErr { span: *attr_sp, feature: *gate_name });
+            duplicate_feature_lint(tcx, *attr_sp, *gate_name);
         }
         remaining_lib_features.insert(*gate_name, *attr_sp);
     }
@@ -1158,5 +1158,14 @@ fn unnecessary_stable_feature_lint(
         hir::CRATE_HIR_ID,
         span,
         errors::UnnecessaryStableFeature { feature, since },
+    );
+}
+
+fn duplicate_feature_lint(tcx: TyCtxt<'_>, span: Span, feature: Symbol) {
+    tcx.emit_node_span_lint(
+        lint::builtin::DUPLICATE_FEATURES,
+        hir::CRATE_HIR_ID,
+        span,
+        errors::DuplicateFeature { feature },
     );
 }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1073,6 +1073,7 @@ symbols! {
         include_bytes,
         include_str,
         inclusive_range_syntax,
+        incomplete_features,
         index,
         index_mut,
         infer_outlives_requirements,

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -63,7 +63,7 @@
 #![doc(
     html_playground_url = "https://play.rust-lang.org/",
     issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
-    test(no_crate_inject, attr(allow(unused_variables), deny(warnings)))
+    test(no_crate_inject, attr(allow(unused_variables, duplicate_features), deny(warnings)))
 )]
 #![doc(auto_cfg(hide(no_global_oom_handling, no_rc, no_sync, target_has_atomic = "ptr")))]
 #![doc(rust_logo)]

--- a/library/core/src/alloc/global.rs
+++ b/library/core/src/alloc/global.rs
@@ -19,7 +19,7 @@ use crate::{cmp, ptr};
 ///
 /// # Example
 ///
-/// ```
+/// ```standalone_crate
 /// use std::alloc::{GlobalAlloc, Layout};
 /// use std::cell::UnsafeCell;
 /// use std::ptr::null_mut;

--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -514,7 +514,7 @@ pub const fn black_box<T>(dummy: T) -> T {
 /// macro_rules! make_error {
 ///     ($($args:expr),*) => {
 ///         core::hint::must_use({
-///             let error = $crate::make_error(core::format_args!($($args),*));
+///             let error = make_error(core::format_args!($($args),*));
 ///             error
 ///         })
 ///     };

--- a/library/core/src/intrinsics/mir.rs
+++ b/library/core/src/intrinsics/mir.rs
@@ -62,7 +62,9 @@
 //!
 //! # Examples
 //!
-//! ```rust
+#![cfg_attr(panic = "unwind", doc = "```rust")]
+// This test can't support panic=abort because it generates an UnwindContinue MIR terminator.
+#![cfg_attr(panic = "abort", doc = "```ignore")]
 //! #![feature(core_intrinsics, custom_mir)]
 //! #![allow(internal_features)]
 //! #![allow(unused_assignments)]

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -48,7 +48,7 @@
     html_playground_url = "https://play.rust-lang.org/",
     issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
     test(no_crate_inject, attr(deny(warnings))),
-    test(attr(allow(dead_code, deprecated, unused_variables, unused_mut)))
+    test(attr(allow(dead_code, deprecated, unused_variables, unused_mut, duplicate_features)))
 )]
 #![doc(rust_logo)]
 #![doc(auto_cfg(hide(

--- a/library/core/src/range.rs
+++ b/library/core/src/range.rs
@@ -584,7 +584,7 @@ impl<T> const From<legacy::RangeFrom<T>> for RangeFrom<T> {
 ///
 /// The `..=last` syntax is a `RangeToInclusive`:
 ///
-/// ```
+/// ```standalone_crate
 /// #![feature(new_range)]
 /// assert_eq!((..=5), std::range::RangeToInclusive { last: 5 });
 /// ```

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -600,6 +600,12 @@ impl Step for ErrorIndex {
     }
 
     fn run(self, builder: &Builder<'_>) -> ToolBuildResult {
+        builder.require_submodule(
+            "src/doc/reference",
+            Some("error_index_generator requires mdbook-spec"),
+        );
+        builder
+            .require_submodule("src/doc/book", Some("error_index_generator requires mdbook-trpl"));
         builder.ensure(ToolBuild {
             build_compiler: self.compilers.build_compiler,
             target: self.compilers.target(),

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -232,6 +232,9 @@ pub(crate) fn create_config(
         rustc_lint::builtin::RENAMED_AND_REMOVED_LINTS.name.to_string(),
         rustc_lint::builtin::UNKNOWN_LINTS.name.to_string(),
         rustc_lint::builtin::UNEXPECTED_CFGS.name.to_string(),
+        rustc_lint::builtin::DUPLICATE_FEATURES.name.to_string(),
+        rustc_lint::builtin::UNUSED_FEATURES.name.to_string(),
+        rustc_lint::builtin::STABLE_FEATURES.name.to_string(),
         // this lint is needed to support `#[expect]` attributes
         rustc_lint::builtin::UNFULFILLED_LINT_EXPECTATIONS.name.to_string(),
     ];

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -32,7 +32,7 @@ use rustc_span::edition::Edition;
 use rustc_span::{FileName, RemapPathScopeComponents, Span};
 use rustc_target::spec::{Target, TargetTuple};
 use tempfile::{Builder as TempFileBuilder, TempDir};
-use tracing::debug;
+use tracing::{debug, info};
 
 use self::rust::HirCollector;
 use crate::config::{MergeDoctests, Options as RustdocOptions, OutputFormat};
@@ -692,7 +692,7 @@ fn run_test(
         compiler.stderr(Stdio::piped());
     }
 
-    debug!("compiler invocation for doctest: {compiler:?}");
+    info!("compiler invocation for doctest: {compiler:?}");
 
     let mut child = match compiler.spawn() {
         Ok(child) => child,
@@ -759,7 +759,7 @@ fn run_test(
             runner_compiler.stderr(Stdio::inherit());
         }
         runner_compiler.arg("--error-format=short");
-        debug!("compiler invocation for doctest runner: {runner_compiler:?}");
+        info!("compiler invocation for doctest runner: {runner_compiler:?}");
 
         let status = if !status.success() {
             status
@@ -858,6 +858,8 @@ fn run_test(
     if let Some(run_directory) = &rustdoc_options.test_run_directory {
         cmd.current_dir(run_directory);
     }
+
+    info!("running doctest executable: {cmd:?}");
 
     let result = if doctest.is_multiple_tests() || rustdoc_options.no_capture {
         cmd.status().map(|status| process::Output {

--- a/src/librustdoc/doctest/make.rs
+++ b/src/librustdoc/doctest/make.rs
@@ -555,7 +555,10 @@ fn parse_source(
                     // consider it only as a crate-level attribute.
                     if attr.has_name(sym::allow)
                         && let Some(list) = attr.meta_item_list()
-                        && list.iter().any(|sub_attr| sub_attr.has_name(sym::internal_features))
+                        && list.iter().any(|sub_attr| {
+                            sub_attr.has_name(sym::internal_features)
+                                || sub_attr.has_name(sym::incomplete_features)
+                        })
                     {
                         push_to_s(&mut info.crate_attrs, source, attr.span, &mut prev_span_hi);
                     } else {

--- a/tests/rustdoc-html/assoc/assoc-type-bindings-20646.rs
+++ b/tests/rustdoc-html/assoc/assoc-type-bindings-20646.rs
@@ -3,7 +3,6 @@
 
 // https://github.com/rust-lang/rust/issues/20646
 #![crate_name="issue_20646"]
-#![feature(associated_types)]
 
 extern crate issue_20646;
 

--- a/tests/rustdoc-html/doc-cfg/doc-cfg.rs
+++ b/tests/rustdoc-html/doc-cfg/doc-cfg.rs
@@ -1,5 +1,4 @@
 #![feature(doc_cfg)]
-#![feature(target_feature, cfg_target_feature)]
 
 //@ has doc_cfg/struct.Portable.html
 //@ !has - '//*[@id="main-content"]/*[@class="item-info"]/*[@class="stab portability"]' ''

--- a/tests/rustdoc-ui/issues/issue-79494.rs
+++ b/tests/rustdoc-ui/issues/issue-79494.rs
@@ -1,6 +1,4 @@
 //@ only-64bit
 
-#![feature(const_transmute)]
-
 pub const ZST: &[u8] = unsafe { std::mem::transmute(1usize) };
 //~^ ERROR transmuting from 8-byte type to 16-byte type

--- a/tests/rustdoc-ui/issues/issue-79494.stderr
+++ b/tests/rustdoc-ui/issues/issue-79494.stderr
@@ -1,5 +1,5 @@
 error[E0080]: transmuting from 8-byte type to 16-byte type: `usize` -> `&[u8]`
-  --> $DIR/issue-79494.rs:5:33
+  --> $DIR/issue-79494.rs:3:33
    |
 LL | pub const ZST: &[u8] = unsafe { std::mem::transmute(1usize) };
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `ZST` failed here

--- a/tests/rustdoc-ui/rustc-check-passes.rs
+++ b/tests/rustdoc-ui/rustc-check-passes.rs
@@ -1,4 +1,4 @@
 #![feature(rustdoc_internals)]
-#![feature(rustdoc_internals)] //~ ERROR
+#![feature(rustdoc_internals)] //~ ERROR duplicate
 
 pub fn foo() {}

--- a/tests/rustdoc-ui/rustc-check-passes.stderr
+++ b/tests/rustdoc-ui/rustc-check-passes.stderr
@@ -1,9 +1,10 @@
-error[E0636]: the feature `rustdoc_internals` has already been enabled
+error: the feature `rustdoc_internals` has already been enabled
   --> $DIR/rustc-check-passes.rs:2:12
    |
 LL | #![feature(rustdoc_internals)]
    |            ^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[deny(duplicate_features)]` on by default
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0636`.

--- a/tests/ui/feature-gates/duplicate-features.stderr
+++ b/tests/ui/feature-gates/duplicate-features.stderr
@@ -1,10 +1,12 @@
-error[E0636]: the feature `if_let` has already been enabled
+error: the feature `if_let` has already been enabled
   --> $DIR/duplicate-features.rs:7:12
    |
 LL | #![feature(if_let)]
    |            ^^^^^^
+   |
+   = note: `#[deny(duplicate_features)]` on by default
 
-error[E0636]: the feature `rust1` has already been enabled
+error: the feature `rust1` has already been enabled
   --> $DIR/duplicate-features.rs:4:12
    |
 LL | #![feature(rust1)]
@@ -12,4 +14,3 @@ LL | #![feature(rust1)]
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0636`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/153072)*
<!-- homu-ignore:end -->

This is only the changes needed to *allow* merging the tests. This doesn't actually turn doctest merging on in bootstrap. I think that might be a useful follow-up, since it makes them much faster to run, but it's not without downsides because it means we'll no longer be testing that doctests have all necessary `feature()` attributes.

The motivation for this change is to run the tests with `-C instrument-coverage` and then generate a coverage report from the output. Currently, this is very expensive because it requires parsing DWARF for each doctest binary. Merging the binaries decreases the time taken from several hours to ~30 seconds.

---

There are several parts to this change, most of which are independent and I'm happy to split out into other PRs.

- Upgrade process spawning logging from debug->info so it's easier to see, including in a rustdoc built without debug symbols.
- Core doctests now support being run with `-C panic=abort`. Ferrocene needs this downstream for complicated reasons; it's a one-line change so I figured it's not a big deal.
- Downgrade errors about duplicate features from a hard error to a warning. The meaning is clear here, and doctest merging often creates duplicate features since it lifts them all to the crate root. This involves changes to the compiler but generally I expect this to be low-impact.
  - Enable this new warning, as well as several related feature lints, in rustdoc. By default rustdoc doesn't lint on anything except the lints it manually adds.
- Rustdoc now treats `allow(incomplete_features)` as a crate-level attribute, just like `internal_features`. Without this, it's possible to get hard errors if rustdoc lifts features to the crate level but not `allow`s.
- Core doctests now support being built with `--merge-doctests=yes`. In particular, I removed a few `$crate` usages and explicitly marked a few doctests as `standalone_crate`.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
