### PR TITLE
Fix mem::conjure_zst panic message to use any::type_name instead

### DIFF
--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1488,12 +1488,13 @@ pub macro offset_of($Container:ty, $($fields:expr)+ $(,)?) {
 ///
 /// [inhabited]: https://doc.rust-lang.org/reference/glossary.html#inhabited
 #[unstable(feature = "mem_conjure_zst", issue = "95383")]
+#[rustc_const_unstable(feature = "mem_conjure_zst", issue = "95383")]
 pub const unsafe fn conjure_zst<T>() -> T {
     const_assert!(
         size_of::<T>() == 0,
-        "mem::conjure_zst invoked on a nonzero-sized type",
-        "mem::conjure_zst invoked on type {t}, which is not zero-sized",
-        t: &str = stringify!(T)
+        "mem::conjure_zst invoked on a non-zero-sized type",
+        "mem::conjure_zst invoked on type {name}, which is not zero-sized",
+        name: &str = crate::any::type_name::<T>()
     );
 
     // SAFETY: because the caller must guarantee that it's inhabited and zero-sized,


### PR DESCRIPTION
Use `crate::any::type_name::<T>()` instead of `stringify!(T)` in the
runtime panic message of `conjure_zst` , so the actual type name (e.g.
`i32`) is shown rather than the literal string `[T]`.


