### PR TITLE
Revert "Move aarch64-apple dist builder to dynamic llvm linking"

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -504,7 +504,7 @@ auto:
   - name: dist-aarch64-apple
     env:
       SCRIPT: >-
-        ./x.py dist bootstrap enzyme
+        ./x.py dist bootstrap
         --include-default-paths
         --host=aarch64-apple-darwin
         --target=aarch64-apple-darwin
@@ -513,7 +513,6 @@ auto:
         --enable-sanitizers
         --enable-profiler
         --set rust.jemalloc
-        --set llvm.link-shared=true
         --set rust.lto=thin
         --set rust.codegen-units=1
       # Aarch64 tooling only needs to support macOS 11.0 and up as nothing else


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/153079)*
<!-- homu-ignore:end -->

Reverts c033de932ec6f46ccb1fd14bf848aec0bc88eece (part of https://github.com/rust-lang/rust/pull/152768) in order to fix  https://github.com/rust-lang/rust/issues/153077.