### PR TITLE
The compiler now prints to debug! compiled if the error code is success...

### DIFF
--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -846,7 +846,7 @@ fn get_metadata_section<'p>(
             };
 
             let crate_name = crate_name.unwrap();
-            debug!("compiling {}", filename.display());
+            debug!("compiling {} \r", filename.display());
             // FIXME: This will need to be done either within the current compiler session or
             // as a separate compiler session in the same process.
             let res = std::process::Command::new(compiler)
@@ -865,6 +865,8 @@ fn get_metadata_section<'p>(
                     "couldn't compile interface: {}",
                     std::str::from_utf8(&res.stderr).unwrap_or_default()
                 )));
+            } else {
+                debug!("compiled {}", filename.display());
             }
 
             // Load interface metadata instead of crate metadata.


### PR DESCRIPTION

# Before:
<img width="729" height="455" alt="image" src="https://github.com/user-attachments/assets/e9b1c8aa-5c65-4d63-b162-ac518f1a489e" />

# Code changes
It didnt work with debug! macro... maybe i can use print! instead of debug!
<img width="761" height="497" alt="image" src="https://github.com/user-attachments/assets/a5d374cf-aca5-4b91-9c1b-7e98d536edd9" />


<img width="724" height="267" alt="image" src="https://github.com/user-attachments/assets/fa763890-cc49-4420-a838-772c5de10085" />

# Rust code:
```
use std::io;
use std::io::Write;
use std::{thread, time::Duration};

fn main() {
    for i in 0..100 {
        print!("compiling test{}", i);
        io::stdout().flush().unwrap();

        thread::sleep(Duration::from_secs(1));
        print!("\rcompiled test{} \n", i);
    }
}

```