### PR TITLE
GVN: transmute adts to their fields if a field projection is immediately transmuted anyway

### DIFF
--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -1649,7 +1649,7 @@ impl<'body, 'a, 'tcx> VnState<'body, 'a, 'tcx> {
                 from = field_ty;
                 value = field_values[field_idx.as_usize()];
                 was_updated_this_iteration = true;
-                if field_ty == to {
+                if from == to {
                     return Some(value);
                 }
             }

--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -1547,6 +1547,7 @@ impl<'body, 'a, 'tcx> VnState<'body, 'a, 'tcx> {
         }
     }
 
+    #[instrument(level = "trace", skip(self), ret)]
     fn simplify_cast(
         &mut self,
         initial_kind: &mut CastKind,
@@ -1599,6 +1600,30 @@ impl<'body, 'a, 'tcx> VnState<'body, 'a, 'tcx> {
                 was_updated_this_iteration = true;
                 if from == to {
                     return Some(pointer);
+                }
+            }
+
+            // Field-Access-then-Transmute can just transmute the original value,
+            // so long as the bytes of a value from only from a single field.
+            if let Transmute = kind
+                && let Value::Projection(aggregate_value, ProjectionElem::Field(field_idx, ())) =
+                    self.get(value)
+            {
+                if let Value::Projection(
+                    _downcast_value,
+                    ProjectionElem::Downcast(_, _variant_idx),
+                ) = self.get(aggregate_value)
+                {
+                } else if let Some((f_idx, field_ty)) =
+                    self.value_is_all_in_one_field(self.ty(aggregate_value), FIRST_VARIANT)
+                {
+                    assert_eq!(field_idx, f_idx, "{from} -> {field_ty}");
+                    from = self.ty(aggregate_value);
+                    value = aggregate_value;
+                    was_updated_this_iteration = true;
+                    if from == to {
+                        return Some(value);
+                    }
                 }
             }
 

--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -1610,10 +1610,22 @@ impl<'body, 'a, 'tcx> VnState<'body, 'a, 'tcx> {
                     self.get(value)
             {
                 if let Value::Projection(
-                    _downcast_value,
+                    downcast_value,
                     ProjectionElem::Downcast(_, _variant_idx),
                 ) = self.get(aggregate_value)
                 {
+                    let downcast_ty = self.ty(downcast_value);
+                    if let Ok(downcast_layout) = self.ecx.layout_of(downcast_ty)
+                        && let Ok(projected_layout) = self.ecx.layout_of(from)
+                        && downcast_layout.size == projected_layout.size
+                    {
+                        from = downcast_ty;
+                        value = downcast_value;
+                        was_updated_this_iteration = true;
+                        if from == to {
+                            return Some(value);
+                        }
+                    }
                 } else if let Some((f_idx, field_ty)) =
                     self.value_is_all_in_one_field(self.ty(aggregate_value), FIRST_VARIANT)
                 {

--- a/tests/mir-opt/const_prop/transmute.option_field.GVN.32bit.diff
+++ b/tests/mir-opt/const_prop/transmute.option_field.GVN.32bit.diff
@@ -1,0 +1,42 @@
+- // MIR for `option_field` before GVN
++ // MIR for `option_field` after GVN
+  
+  fn option_field(_1: Option<NonNull<()>>) -> *const () {
+      debug x => _1;
+      let mut _0: *const ();
+      let mut _2: isize;
+      let mut _4: std::ptr::NonNull<()>;
+      scope 1 {
+          debug x => _3;
+          let _3: std::ptr::NonNull<()>;
+      }
+  
+      bb0: {
+          _2 = discriminant(_1);
+          switchInt(move _2) -> [1: bb1, otherwise: bb2];
+      }
+  
+      bb1: {
+-         StorageLive(_3);
++         nop;
+          _3 = copy ((_1 as Some).0: std::ptr::NonNull<()>);
+          StorageLive(_4);
+          _4 = copy _3;
+-         _0 = move _4 as *const () (Transmute);
++         _0 = copy _3 as *const () (Transmute);
+          StorageDead(_4);
+-         StorageDead(_3);
++         nop;
+          goto -> bb3;
+      }
+  
+      bb2: {
+          _0 = const 0_usize as *const () (PointerWithExposedProvenance);
+          goto -> bb3;
+      }
+  
+      bb3: {
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/const_prop/transmute.option_field.GVN.32bit.diff
+++ b/tests/mir-opt/const_prop/transmute.option_field.GVN.32bit.diff
@@ -17,16 +17,14 @@
       }
   
       bb1: {
--         StorageLive(_3);
-+         nop;
+          StorageLive(_3);
           _3 = copy ((_1 as Some).0: std::ptr::NonNull<()>);
           StorageLive(_4);
           _4 = copy _3;
 -         _0 = move _4 as *const () (Transmute);
-+         _0 = copy _3 as *const () (Transmute);
++         _0 = copy _1 as *const () (Transmute);
           StorageDead(_4);
--         StorageDead(_3);
-+         nop;
+          StorageDead(_3);
           goto -> bb3;
       }
   

--- a/tests/mir-opt/const_prop/transmute.option_field.GVN.64bit.diff
+++ b/tests/mir-opt/const_prop/transmute.option_field.GVN.64bit.diff
@@ -1,0 +1,42 @@
+- // MIR for `option_field` before GVN
++ // MIR for `option_field` after GVN
+  
+  fn option_field(_1: Option<NonNull<()>>) -> *const () {
+      debug x => _1;
+      let mut _0: *const ();
+      let mut _2: isize;
+      let mut _4: std::ptr::NonNull<()>;
+      scope 1 {
+          debug x => _3;
+          let _3: std::ptr::NonNull<()>;
+      }
+  
+      bb0: {
+          _2 = discriminant(_1);
+          switchInt(move _2) -> [1: bb1, otherwise: bb2];
+      }
+  
+      bb1: {
+-         StorageLive(_3);
++         nop;
+          _3 = copy ((_1 as Some).0: std::ptr::NonNull<()>);
+          StorageLive(_4);
+          _4 = copy _3;
+-         _0 = move _4 as *const () (Transmute);
++         _0 = copy _3 as *const () (Transmute);
+          StorageDead(_4);
+-         StorageDead(_3);
++         nop;
+          goto -> bb3;
+      }
+  
+      bb2: {
+          _0 = const 0_usize as *const () (PointerWithExposedProvenance);
+          goto -> bb3;
+      }
+  
+      bb3: {
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/const_prop/transmute.option_field.GVN.64bit.diff
+++ b/tests/mir-opt/const_prop/transmute.option_field.GVN.64bit.diff
@@ -17,16 +17,14 @@
       }
   
       bb1: {
--         StorageLive(_3);
-+         nop;
+          StorageLive(_3);
           _3 = copy ((_1 as Some).0: std::ptr::NonNull<()>);
           StorageLive(_4);
           _4 = copy _3;
 -         _0 = move _4 as *const () (Transmute);
-+         _0 = copy _3 as *const () (Transmute);
++         _0 = copy _1 as *const () (Transmute);
           StorageDead(_4);
--         StorageDead(_3);
-+         nop;
+          StorageDead(_3);
           goto -> bb3;
       }
   

--- a/tests/mir-opt/const_prop/transmute.rs
+++ b/tests/mir-opt/const_prop/transmute.rs
@@ -84,4 +84,12 @@ pub unsafe fn unreachable_box() -> ! {
     match *x {}
 }
 
+// EMIT_MIR transmute.option_field.GVN.diff
+pub unsafe fn option_field(x: Option<std::ptr::NonNull<()>>) -> *const () {
+    // CHECK-LABEL: fn option_field(
+    // CHECK: _3 = copy ((_1 as Some).0: std::ptr::NonNull<()>)
+    // CHECK: _0 = copy _3 as *const () (Transmute)
+    if let Some(x) = x { unsafe { transmute(x) } } else { 0 as *const () }
+}
+
 enum Never {}

--- a/tests/mir-opt/const_prop/transmute.rs
+++ b/tests/mir-opt/const_prop/transmute.rs
@@ -88,7 +88,7 @@ pub unsafe fn unreachable_box() -> ! {
 pub unsafe fn option_field(x: Option<std::ptr::NonNull<()>>) -> *const () {
     // CHECK-LABEL: fn option_field(
     // CHECK: _3 = copy ((_1 as Some).0: std::ptr::NonNull<()>)
-    // CHECK: _0 = copy _3 as *const () (Transmute)
+    // CHECK: _0 = copy _1 as *const () (Transmute)
     if let Some(x) = x { unsafe { transmute(x) } } else { 0 as *const () }
 }
 

--- a/tests/mir-opt/const_prop/transmute.unreachable_box.GVN.32bit.diff
+++ b/tests/mir-opt/const_prop/transmute.unreachable_box.GVN.32bit.diff
@@ -14,7 +14,7 @@
 -         _1 = const 1_usize as std::boxed::Box<Never> (Transmute);
 -         _2 = copy ((_1.0: std::ptr::Unique<Never>).0: std::ptr::NonNull<Never>) as *const Never (Transmute);
 +         _1 = const Box::<Never>(std::ptr::Unique::<Never> {{ pointer: NonNull::<Never> {{ pointer: {0x1 as *const Never} is !null }}, _marker: PhantomData::<Never> }}, std::alloc::Global);
-+         _2 = const std::ptr::NonNull::<Never> {{ pointer: {0x1 as *const Never} is !null }} as *const Never (Transmute);
++         _2 = const std::boxed::Box::<Never>(std::ptr::Unique::<Never> {{ pointer: std::ptr::NonNull::<Never> {{ pointer: {0x1 as *const Never} is !null }}, _marker: std::marker::PhantomData::<Never> }}, std::alloc::Global) as *const Never (Transmute);
           unreachable;
       }
   }

--- a/tests/mir-opt/const_prop/transmute.unreachable_box.GVN.64bit.diff
+++ b/tests/mir-opt/const_prop/transmute.unreachable_box.GVN.64bit.diff
@@ -14,7 +14,7 @@
 -         _1 = const 1_usize as std::boxed::Box<Never> (Transmute);
 -         _2 = copy ((_1.0: std::ptr::Unique<Never>).0: std::ptr::NonNull<Never>) as *const Never (Transmute);
 +         _1 = const Box::<Never>(std::ptr::Unique::<Never> {{ pointer: NonNull::<Never> {{ pointer: {0x1 as *const Never} is !null }}, _marker: PhantomData::<Never> }}, std::alloc::Global);
-+         _2 = const std::ptr::NonNull::<Never> {{ pointer: {0x1 as *const Never} is !null }} as *const Never (Transmute);
++         _2 = const std::boxed::Box::<Never>(std::ptr::Unique::<Never> {{ pointer: std::ptr::NonNull::<Never> {{ pointer: {0x1 as *const Never} is !null }}, _marker: std::marker::PhantomData::<Never> }}, std::alloc::Global) as *const Never (Transmute);
           unreachable;
       }
   }

--- a/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.32bit.panic-abort.diff
@@ -73,7 +73,8 @@
           StorageDead(_2);
           StorageLive(_5);
           _10 = no_retag copy (*_1);
-          _11 = copy ((_10.0: std::ptr::Unique<()>).0: std::ptr::NonNull<()>) as *const () (Transmute);
+-         _11 = copy ((_10.0: std::ptr::Unique<()>).0: std::ptr::NonNull<()>) as *const () (Transmute);
++         _11 = copy _10 as *const () (Transmute);
           _5 = &raw const (*_11);
           StorageLive(_6);
           StorageLive(_7);

--- a/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.32bit.panic-unwind.diff
@@ -53,7 +53,8 @@
           StorageDead(_2);
           StorageLive(_5);
           _10 = no_retag copy (*_1);
-          _11 = copy ((_10.0: std::ptr::Unique<()>).0: std::ptr::NonNull<()>) as *const () (Transmute);
+-         _11 = copy ((_10.0: std::ptr::Unique<()>).0: std::ptr::NonNull<()>) as *const () (Transmute);
++         _11 = copy _10 as *const () (Transmute);
           _5 = &raw const (*_11);
           StorageLive(_6);
           StorageLive(_7);

--- a/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.64bit.panic-abort.diff
@@ -73,7 +73,8 @@
           StorageDead(_2);
           StorageLive(_5);
           _10 = no_retag copy (*_1);
-          _11 = copy ((_10.0: std::ptr::Unique<()>).0: std::ptr::NonNull<()>) as *const () (Transmute);
+-         _11 = copy ((_10.0: std::ptr::Unique<()>).0: std::ptr::NonNull<()>) as *const () (Transmute);
++         _11 = copy _10 as *const () (Transmute);
           _5 = &raw const (*_11);
           StorageLive(_6);
           StorageLive(_7);

--- a/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.64bit.panic-unwind.diff
@@ -53,7 +53,8 @@
           StorageDead(_2);
           StorageLive(_5);
           _10 = no_retag copy (*_1);
-          _11 = copy ((_10.0: std::ptr::Unique<()>).0: std::ptr::NonNull<()>) as *const () (Transmute);
+-         _11 = copy ((_10.0: std::ptr::Unique<()>).0: std::ptr::NonNull<()>) as *const () (Transmute);
++         _11 = copy _10 as *const () (Transmute);
           _5 = &raw const (*_11);
           StorageLive(_6);
           StorageLive(_7);

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-abort.diff
@@ -68,7 +68,8 @@
           StorageLive(_3);
           StorageLive(_4);
           StorageLive(_5);
-          StorageLive(_6);
+-         StorageLive(_6);
++         nop;
           StorageLive(_7);
 -         _7 = copy _1;
 -         _6 = std::alloc::Global::alloc_impl_runtime(move _7, const false) -> [return: bb4, unwind unreachable];
@@ -92,10 +93,13 @@
       }
   
       bb6: {
-          _5 = move ((_6 as Ok).0: std::ptr::NonNull<[u8]>);
+-         _5 = move ((_6 as Ok).0: std::ptr::NonNull<[u8]>);
++         _5 = copy ((_6 as Ok).0: std::ptr::NonNull<[u8]>);
           StorageDead(_10);
-          StorageDead(_6);
-          _4 = copy _5 as *mut [u8] (Transmute);
+-         StorageDead(_6);
+-         _4 = copy _5 as *mut [u8] (Transmute);
++         nop;
++         _4 = copy _6 as *mut [u8] (Transmute);
           StorageDead(_5);
           _3 = copy _4 as *mut u8 (PtrToPtr);
           StorageDead(_4);

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
@@ -68,7 +68,8 @@
           StorageLive(_3);
           StorageLive(_4);
           StorageLive(_5);
-          StorageLive(_6);
+-         StorageLive(_6);
++         nop;
           StorageLive(_7);
 -         _7 = copy _1;
 -         _6 = std::alloc::Global::alloc_impl_runtime(move _7, const false) -> [return: bb4, unwind unreachable];
@@ -92,10 +93,13 @@
       }
   
       bb6: {
-          _5 = move ((_6 as Ok).0: std::ptr::NonNull<[u8]>);
+-         _5 = move ((_6 as Ok).0: std::ptr::NonNull<[u8]>);
++         _5 = copy ((_6 as Ok).0: std::ptr::NonNull<[u8]>);
           StorageDead(_10);
-          StorageDead(_6);
-          _4 = copy _5 as *mut [u8] (Transmute);
+-         StorageDead(_6);
+-         _4 = copy _5 as *mut [u8] (Transmute);
++         nop;
++         _4 = copy _6 as *mut [u8] (Transmute);
           StorageDead(_5);
           _3 = copy _4 as *mut u8 (PtrToPtr);
           StorageDead(_4);


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/153085)*
<!-- homu-ignore:end -->

follow-up to rust-lang/rust#152702

commits best reviewed individually.

Basically does
```diff
-         _11 = copy ((_10.0: std::ptr::Unique<()>).0: std::ptr::NonNull<()>) as *const () (Transmute);
+         _11 = copy _10 as *const () (Transmute);
```

in various forms, including going from an `Option` directly to a value in its `Some` variant if the value got niche optimized into the `Option`

r? @scottmcm
cc @cjgillot 