### PR TITLE
Revert "Move aarch64-apple dist builder to dynamic llvm linking and e…

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -504,7 +504,7 @@ auto:
   - name: dist-aarch64-apple
     env:
       SCRIPT: >-
-        ./x.py dist bootstrap enzyme
+        ./x.py dist bootstrap
         --include-default-paths
         --host=aarch64-apple-darwin
         --target=aarch64-apple-darwin
@@ -513,7 +513,6 @@ auto:
         --enable-sanitizers
         --enable-profiler
         --set rust.jemalloc
-        --set llvm.link-shared=true
         --set rust.lto=thin
         --set rust.codegen-units=1
       # Aarch64 tooling only needs to support macOS 11.0 and up as nothing else


### PR DESCRIPTION
…nable autodiff in CI for it"

This reverts commit c033de932ec6f46ccb1fd14bf848aec0bc88eece, especially moving dist-apple to shared-llvm, which was previously discussed in https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Changing.20static.20linking.20of.20rustc.20to.20LLVM.20to.20dynamic, but caused a build failure for miri.

cc @RalfJung 

r? @jieyouxu 

