### PR TITLE
interpret: avoid dummy spans in the stacktrace

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/error.rs
+++ b/compiler/rustc_const_eval/src/const_eval/error.rs
@@ -110,7 +110,7 @@ pub fn get_span_and_frames<'tcx>(
     tcx: TyCtxtAt<'tcx>,
     stack: &[Frame<'tcx, impl Provenance, impl Sized>],
 ) -> (Span, Vec<errors::FrameNote>) {
-    let mut stacktrace = Frame::generate_stacktrace_from_stack(stack);
+    let mut stacktrace = Frame::generate_stacktrace_from_stack(stack, *tcx);
     // Filter out `requires_caller_location` frames.
     stacktrace.retain(|frame| !frame.instance.def.requires_caller_location(*tcx));
     let span = stacktrace.last().map(|f| f.span).unwrap_or(tcx.span);

--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -635,7 +635,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
 
     #[must_use]
     pub fn generate_stacktrace(&self) -> Vec<FrameInfo<'tcx>> {
-        Frame::generate_stacktrace_from_stack(self.stack())
+        Frame::generate_stacktrace_from_stack(self.stack(), *self.tcx)
     }
 
     pub fn adjust_nan<F1, F2>(&self, f: F2, inputs: &[F1]) -> F2

--- a/src/tools/miri/src/diagnostics.rs
+++ b/src/tools/miri/src/diagnostics.rs
@@ -257,7 +257,7 @@ pub fn report_result<'tcx>(
                 // The "active" thread might actually be terminated, so we ignore it.
                 let mut any_pruned = false;
                 for (thread, stack) in ecx.machine.threads.all_blocked_stacks() {
-                    let stacktrace = Frame::generate_stacktrace_from_stack(stack);
+                    let stacktrace = Frame::generate_stacktrace_from_stack(stack, *ecx.tcx);
                     let (stacktrace, was_pruned) = prune_stacktrace(stacktrace, &ecx.machine);
                     any_pruned |= was_pruned;
                     report_msg(
@@ -633,7 +633,8 @@ impl<'tcx> MiriMachine<'tcx> {
     pub fn emit_diagnostic(&self, e: NonHaltingDiagnostic) {
         use NonHaltingDiagnostic::*;
 
-        let stacktrace = Frame::generate_stacktrace_from_stack(self.threads.active_thread_stack());
+        let stacktrace =
+            Frame::generate_stacktrace_from_stack(self.threads.active_thread_stack(), self.tcx);
         let (stacktrace, _was_pruned) = prune_stacktrace(stacktrace, self);
 
         let (label, diag_level) = match &e {


### PR DESCRIPTION
This should fix https://github.com/rust-lang/miri/issues/4871