### PR TITLE
Simplify `AppendOnlyVec` iterators

### DIFF
--- a/compiler/rustc_data_structures/src/sync/vec.rs
+++ b/compiler/rustc_data_structures/src/sync/vec.rs
@@ -46,20 +46,17 @@ impl<T: Copy> AppendOnlyVec<T> {
     }
 
     pub fn iter_enumerated(&self) -> impl Iterator<Item = (usize, T)> {
-        (0..)
-            .map(|i| (i, self.get(i)))
-            .take_while(|(_, o)| o.is_some())
-            .filter_map(|(i, o)| Some((i, o?)))
+        (0..).map_while(|i| Some((i, self.get(i)?)))
     }
 
     pub fn iter(&self) -> impl Iterator<Item = T> {
-        (0..).map(|i| self.get(i)).take_while(|o| o.is_some()).flatten()
+        (0..).map_while(|i| self.get(i))
     }
 }
 
 impl<T: Copy + PartialEq> AppendOnlyVec<T> {
     pub fn contains(&self, val: T) -> bool {
-        self.iter_enumerated().any(|(_, v)| v == val)
+        self.iter().any(|v| v == val)
     }
 }
 


### PR DESCRIPTION
This isn't a big deal, but I noticed that these iterators were more complicated than they need to be.