### PR TITLE
Expand `OptionFlatten`'s iterator methods

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -584,6 +584,7 @@
 use crate::clone::TrivialClone;
 use crate::iter::{self, FusedIterator, TrustedLen};
 use crate::marker::Destruct;
+use crate::num::NonZero;
 use crate::ops::{self, ControlFlow, Deref, DerefMut, Residual, Try};
 use crate::panicking::{panic, panic_display};
 use crate::pin::Pin;
@@ -2651,18 +2652,111 @@ impl<A: Iterator> Iterator for OptionFlatten<A> {
     type Item = A::Item;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.as_mut()?.next()
+        match &mut self.iter {
+            Some(iter) => iter.next(),
+            None => None,
+        }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.iter.as_ref().map(|i| i.size_hint()).unwrap_or((0, Some(0)))
+        match &self.iter {
+            Some(iter) => iter.size_hint(),
+            None => (0, Some(0)),
+        }
+    }
+
+    fn advance_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
+        match &mut self.iter {
+            Some(iter) => iter.advance_by(n),
+            None => NonZero::new(n).map_or(Ok(()), Err),
+        }
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        match &mut self.iter {
+            Some(iter) => iter.nth(n),
+            None => None,
+        }
+    }
+
+    fn fold<Acc, Fold>(self, init: Acc, fold: Fold) -> Acc
+    where
+        Fold: FnMut(Acc, Self::Item) -> Acc,
+    {
+        match self.iter {
+            Some(iter) => iter.fold(init, fold),
+            None => init,
+        }
+    }
+
+    fn try_fold<Acc, Fold, R>(&mut self, init: Acc, fold: Fold) -> R
+    where
+        Fold: FnMut(Acc, Self::Item) -> R,
+        R: Try<Output = Acc>,
+    {
+        match &mut self.iter {
+            Some(iter) => iter.try_fold(init, fold),
+            None => try { init },
+        }
+    }
+
+    fn count(self) -> usize {
+        match self.iter {
+            Some(iter) => iter.count(),
+            None => 0,
+        }
+    }
+
+    fn last(self) -> Option<Self::Item> {
+        match self.iter {
+            Some(iter) => iter.last(),
+            None => None,
+        }
     }
 }
 
 #[unstable(feature = "option_into_flat_iter", issue = "148441")]
 impl<A: DoubleEndedIterator> DoubleEndedIterator for OptionFlatten<A> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.as_mut()?.next_back()
+        match &mut self.iter {
+            Some(iter) => iter.next_back(),
+            None => None,
+        }
+    }
+
+    fn advance_back_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
+        match &mut self.iter {
+            Some(iter) => iter.advance_back_by(n),
+            None => NonZero::new(n).map_or(Ok(()), Err),
+        }
+    }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        match &mut self.iter {
+            Some(iter) => iter.nth_back(n),
+            None => None,
+        }
+    }
+
+    fn rfold<Acc, Fold>(self, init: Acc, fold: Fold) -> Acc
+    where
+        Fold: FnMut(Acc, Self::Item) -> Acc,
+    {
+        match self.iter {
+            Some(iter) => iter.rfold(init, fold),
+            None => init,
+        }
+    }
+
+    fn try_rfold<Acc, Fold, R>(&mut self, init: Acc, fold: Fold) -> R
+    where
+        Fold: FnMut(Acc, Self::Item) -> R,
+        R: Try<Output = Acc>,
+    {
+        match &mut self.iter {
+            Some(iter) => iter.try_rfold(init, fold),
+            None => try { init },
+        }
     }
 }
 


### PR DESCRIPTION
If someone considers moving from `option.into_iter().flatten()` to
`option.into_flat_iter()`, it may be important for performance that this
iterator "specializes" methods the same way `Flatten` does, especially
forwarding to underlying `fold`, etc.
