### PR TITLE
Compute the result of a projection type with region errors

### DIFF
--- a/compiler/rustc_middle/src/ty/region.rs
+++ b/compiler/rustc_middle/src/ty/region.rs
@@ -291,7 +291,7 @@ impl<'tcx> Region<'tcx> {
             }
             ty::ReError(_) => {
                 flags = flags | TypeFlags::HAS_FREE_REGIONS;
-                flags = flags | TypeFlags::HAS_ERROR;
+                flags = flags | TypeFlags::HAS_RE_ERROR;
             }
         }
 

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -659,7 +659,9 @@ fn project<'cx, 'tcx>(
         )));
     }
 
-    if let Err(guar) = obligation.predicate.error_reported() {
+    // We can still compute a projection type when there are only region errors,
+    // but type/const errors require early return.
+    if let Err(guar) = obligation.predicate.non_region_error_reported() {
         return Ok(Projected::Progress(Progress::error_for_term(
             selcx.tcx(),
             obligation.predicate,

--- a/compiler/rustc_type_ir/src/flags.rs
+++ b/compiler/rustc_type_ir/src/flags.rs
@@ -91,19 +91,24 @@ bitflags::bitflags! {
                                           | TypeFlags::HAS_TY_INHERENT.bits()
                                           | TypeFlags::HAS_CT_PROJECTION.bits();
 
+        /// Is a type or const error reachable?
+        const HAS_NON_REGION_ERROR          = 1 << 15;
+        /// Is a region error reachable?
+        const HAS_RE_ERROR                = 1 << 16;
         /// Is an error type/lifetime/const reachable?
-        const HAS_ERROR                   = 1 << 15;
+        const HAS_ERROR                   = TypeFlags::HAS_NON_REGION_ERROR.bits()
+                                          | TypeFlags::HAS_RE_ERROR.bits();
 
         /// Does this have any region that "appears free" in the type?
         /// Basically anything but `ReBound` and `ReErased`.
-        const HAS_FREE_REGIONS            = 1 << 16;
+        const HAS_FREE_REGIONS            = 1 << 17;
 
         /// Does this have any `ReBound` regions?
-        const HAS_RE_BOUND                = 1 << 17;
+        const HAS_RE_BOUND                = 1 << 18;
         /// Does this have any `Bound` types?
-        const HAS_TY_BOUND                = 1 << 18;
+        const HAS_TY_BOUND                = 1 << 19;
         /// Does this have any `ConstKind::Bound` consts?
-        const HAS_CT_BOUND                = 1 << 19;
+        const HAS_CT_BOUND                = 1 << 20;
         /// Does this have any bound variables?
         /// Used to check if a global bound is safe to evaluate.
         const HAS_BOUND_VARS              = TypeFlags::HAS_RE_BOUND.bits()
@@ -111,7 +116,7 @@ bitflags::bitflags! {
                                           | TypeFlags::HAS_CT_BOUND.bits();
 
         /// Does this have any `ReErased` regions?
-        const HAS_RE_ERASED               = 1 << 20;
+        const HAS_RE_ERASED               = 1 << 21;
 
         /// Does this value have parameters/placeholders/inference variables which could be
         /// replaced later, in a way that would change the results of `impl` specialization?
@@ -123,19 +128,19 @@ bitflags::bitflags! {
                                           | TypeFlags::HAS_CT_INFER.bits();
 
         /// Does this value have `InferTy::FreshTy/FreshIntTy/FreshFloatTy`?
-        const HAS_TY_FRESH                = 1 << 21;
+        const HAS_TY_FRESH                = 1 << 22;
 
         /// Does this value have `InferConst::Fresh`?
-        const HAS_CT_FRESH                = 1 << 22;
+        const HAS_CT_FRESH                = 1 << 23;
 
         /// Does this have any binders with bound vars (e.g. that need to be anonymized)?
-        const HAS_BINDER_VARS             = 1 << 23;
+        const HAS_BINDER_VARS             = 1 << 24;
 
         /// Does this type have any coroutines in it?
-        const HAS_TY_CORO                 = 1 << 24;
+        const HAS_TY_CORO                 = 1 << 25;
 
         /// Does this have have a `Bound(BoundVarIndexKind::Canonical, _)`?
-        const HAS_CANONICAL_BOUND         = 1 << 25;
+        const HAS_CANONICAL_BOUND         = 1 << 26;
     }
 }
 
@@ -240,7 +245,7 @@ impl<I: Interner> FlagComputation<I> {
             | ty::Str
             | ty::Foreign(..) => {}
 
-            ty::Error(_) => self.add_flags(TypeFlags::HAS_ERROR),
+            ty::Error(_) => self.add_flags(TypeFlags::HAS_NON_REGION_ERROR),
 
             ty::Param(_) => {
                 self.add_flags(TypeFlags::HAS_TY_PARAM);
@@ -489,7 +494,7 @@ impl<I: Interner> FlagComputation<I> {
                 }
             }
             ty::ConstKind::Expr(e) => self.add_args(e.args().as_slice()),
-            ty::ConstKind::Error(_) => self.add_flags(TypeFlags::HAS_ERROR),
+            ty::ConstKind::Error(_) => self.add_flags(TypeFlags::HAS_NON_REGION_ERROR),
         }
     }
 

--- a/compiler/rustc_type_ir/src/visit.rs
+++ b/compiler/rustc_type_ir/src/visit.rs
@@ -279,6 +279,8 @@ pub trait TypeVisitableExt<I: Interner>: TypeVisitable<I> {
 
     fn error_reported(&self) -> Result<(), I::ErrorGuaranteed>;
 
+    fn non_region_error_reported(&self) -> Result<(), I::ErrorGuaranteed>;
+
     fn has_non_region_param(&self) -> bool {
         self.has_type_flags(TypeFlags::HAS_PARAM - TypeFlags::HAS_RE_PARAM)
     }
@@ -352,6 +354,11 @@ pub trait TypeVisitableExt<I: Interner>: TypeVisitable<I> {
     fn still_further_specializable(&self) -> bool {
         self.has_type_flags(TypeFlags::STILL_FURTHER_SPECIALIZABLE)
     }
+
+    /// True if a type or const error is reachable
+    fn has_non_region_error(&self) -> bool {
+        self.has_type_flags(TypeFlags::HAS_NON_REGION_ERROR)
+    }
 }
 
 impl<I: Interner, T: TypeVisitable<I>> TypeVisitableExt<I> for T {
@@ -371,6 +378,18 @@ impl<I: Interner, T: TypeVisitable<I>> TypeVisitableExt<I> for T {
                 Err(guar)
             } else {
                 panic!("type flags said there was an error, but now there is not")
+            }
+        } else {
+            Ok(())
+        }
+    }
+
+    fn non_region_error_reported(&self) -> Result<(), I::ErrorGuaranteed> {
+        if self.has_non_region_error() {
+            if let ControlFlow::Break(guar) = self.visit_with(&mut HasErrorVisitor) {
+                Err(guar)
+            } else {
+                panic!("type flags said there was an non region error, but now there is not")
             }
         } else {
             Ok(())

--- a/tests/ui/dropck/dropck-after-failed-type-lowering.rs
+++ b/tests/ui/dropck/dropck-after-failed-type-lowering.rs
@@ -3,11 +3,12 @@
 trait B {
     type C<'a>;
     fn d<E>() -> F<E> {
+              //~^ ERROR: the trait bound `E: B` is not satisfied
         todo!()
     }
 }
 struct F<G> {
-    h: Option<<G as B>::C>,
+    h: Option<<G as B>::C>, //~ ERROR: the trait bound `G: B` is not satisfied
     //~^ ERROR missing generics for associated type `B::C`
 }
 

--- a/tests/ui/dropck/dropck-after-failed-type-lowering.stderr
+++ b/tests/ui/dropck/dropck-after-failed-type-lowering.stderr
@@ -1,5 +1,5 @@
 error[E0107]: missing generics for associated type `B::C`
-  --> $DIR/dropck-after-failed-type-lowering.rs:10:25
+  --> $DIR/dropck-after-failed-type-lowering.rs:11:25
    |
 LL |     h: Option<<G as B>::C>,
    |                         ^ expected 1 lifetime argument
@@ -14,6 +14,24 @@ help: add missing lifetime argument
 LL |     h: Option<<G as B>::C<'a>>,
    |                          ++++
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `G: B` is not satisfied
+  --> $DIR/dropck-after-failed-type-lowering.rs:11:8
+   |
+LL |     h: Option<<G as B>::C>,
+   |        ^^^^^^^^^^^^^^^^^^^ the trait `B` is not implemented for `G`
+   |
+help: consider restricting type parameter `G` with trait `B`
+   |
+LL | struct F<G: B> {
+   |           +++
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0277]: the trait bound `E: B` is not satisfied
+  --> $DIR/dropck-after-failed-type-lowering.rs:5:18
+   |
+LL |     fn d<E>() -> F<E> {
+   |                  ^^^^ the trait `B` is not implemented for `E`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0107, E0277.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/unsized/thin-ptr-to-unsized-projection.rs
+++ b/tests/ui/unsized/thin-ptr-to-unsized-projection.rs
@@ -1,0 +1,6 @@
+// This is a regression test for <https://github.com/rust-lang/rust/issues/152682>
+struct Foo<'a>(<& /*'a*/ [fn()] as core::ops::Deref>::Target); // adding the lifetime solves the ice
+             //~^ ERROR: missing lifetime specifier [E0106]
+const _: *const Foo = 0 as _;
+                        //~^ ERROR: cannot cast `i32` to a pointer that is wide [E0606]
+fn main() {}

--- a/tests/ui/unsized/thin-ptr-to-unsized-projection.stderr
+++ b/tests/ui/unsized/thin-ptr-to-unsized-projection.stderr
@@ -1,0 +1,23 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/thin-ptr-to-unsized-projection.rs:2:17
+   |
+LL | struct Foo<'a>(<& /*'a*/ [fn()] as core::ops::Deref>::Target); // adding the lifetime solves the ice
+   |                 ^ expected named lifetime parameter
+   |
+help: consider using the `'a` lifetime
+   |
+LL | struct Foo<'a>(<&'a  /*'a*/ [fn()] as core::ops::Deref>::Target); // adding the lifetime solves the ice
+   |                  ++
+
+error[E0606]: cannot cast `i32` to a pointer that is wide
+  --> $DIR/thin-ptr-to-unsized-projection.rs:4:28
+   |
+LL | const _: *const Foo = 0 as _;
+   |                       -    ^ creating a `*const Foo<'_>` requires both an address and a length
+   |                       |
+   |                       consider casting this expression to `*const ()`, then using `core::ptr::from_raw_parts`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0106, E0606.
+For more information about an error, try `rustc --explain E0106`.


### PR DESCRIPTION
Fixes: rust-lang/rust#152682

With the old trait solver, `type_known_to_meet_bound_modulo_regions()` isn't really operating "modulo regions" if there are any region errors, since `normalize` will just return a type error to the trait solver if given a ty with a region error, which then starts cascading when there are so many assumptions.

So I think it would be good to erase regions if there are any region errors before we normalize the type when collecting predicates for confirmation.

That said, I somehow feel like this is kind of ad-hoc... I'd really appreciate if someone more familiar with this code could take a closer look :3