### PR TITLE
Improve the forcing/promotion functions in `DepKindVTable`

### DIFF
--- a/compiler/rustc_middle/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node.rs
@@ -121,7 +121,7 @@ impl DepNode {
 
         #[cfg(debug_assertions)]
         {
-            if !tcx.key_fingerprint_style(kind).reconstructible()
+            if !tcx.key_fingerprint_style(kind).is_maybe_recoverable()
                 && (tcx.sess.opts.unstable_opts.incremental_info
                     || tcx.sess.opts.unstable_opts.query_dep_graph)
             {

--- a/compiler/rustc_middle/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node.rs
@@ -225,12 +225,12 @@ pub struct DepKindVTable<'tcx> {
     /// with kind `mir_promoted`, we know that the key fingerprint of the `DepNode`
     /// is actually a `DefPathHash`, and can therefore just look up the corresponding
     /// `DefId` in `tcx.def_path_hash_to_def_id`.
-    pub force_from_dep_node: Option<
+    pub force_from_dep_node_fn: Option<
         fn(tcx: TyCtxt<'tcx>, dep_node: DepNode, prev_index: SerializedDepNodeIndex) -> bool,
     >,
 
     /// Invoke a query to put the on-disk cached value in memory.
-    pub try_load_from_on_disk_cache: Option<fn(TyCtxt<'tcx>, DepNode)>,
+    pub promote_from_disk_fn: Option<fn(TyCtxt<'tcx>, DepNode)>,
 }
 
 /// A "work product" corresponds to a `.o` (or other) file that we

--- a/compiler/rustc_middle/src/dep_graph/graph.rs
+++ b/compiler/rustc_middle/src/dep_graph/graph.rs
@@ -1064,7 +1064,11 @@ impl DepGraph {
             match data.colors.get(prev_index) {
                 DepNodeColor::Green(_) => {
                     let dep_node = data.previous.index_to_node(prev_index);
-                    tcx.try_load_from_on_disk_cache(dep_node);
+                    if let Some(promote_fn) =
+                        tcx.dep_kind_vtable(dep_node.kind).promote_from_disk_fn
+                    {
+                        promote_fn(tcx, *dep_node)
+                    };
                 }
                 DepNodeColor::Unknown | DepNodeColor::Red => {
                     // We can skip red nodes because a node can only be marked

--- a/compiler/rustc_middle/src/dep_graph/mod.rs
+++ b/compiler/rustc_middle/src/dep_graph/mod.rs
@@ -103,7 +103,7 @@ impl<'tcx> TyCtxt<'tcx> {
         prev_index: SerializedDepNodeIndex,
         frame: &MarkFrame<'_>,
     ) -> bool {
-        if let Some(force_fn) = self.dep_kind_vtable(dep_node.kind).force_from_dep_node {
+        if let Some(force_fn) = self.dep_kind_vtable(dep_node.kind).force_from_dep_node_fn {
             match panic::catch_unwind(panic::AssertUnwindSafe(|| {
                 force_fn(self, dep_node, prev_index)
             })) {
@@ -117,13 +117,6 @@ impl<'tcx> TyCtxt<'tcx> {
             }
         } else {
             false
-        }
-    }
-
-    /// Load data from the on-disk cache.
-    fn try_load_from_on_disk_cache(self, dep_node: &DepNode) {
-        if let Some(try_load_fn) = self.dep_kind_vtable(dep_node.kind).try_load_from_on_disk_cache {
-            try_load_fn(self, *dep_node)
         }
     }
 }

--- a/compiler/rustc_middle/src/dep_graph/mod.rs
+++ b/compiler/rustc_middle/src/dep_graph/mod.rs
@@ -42,8 +42,12 @@ pub enum KeyFingerprintStyle {
 }
 
 impl KeyFingerprintStyle {
+    /// True if a key can _potentially_ be recovered from a key fingerprint
+    /// with this style.
+    ///
+    /// For some key types, recovery is possible but not guaranteed.
     #[inline]
-    pub const fn reconstructible(self) -> bool {
+    pub const fn is_maybe_recoverable(self) -> bool {
         match self {
             KeyFingerprintStyle::DefPathHash
             | KeyFingerprintStyle::Unit

--- a/compiler/rustc_query_impl/src/dep_kind_vtables.rs
+++ b/compiler/rustc_query_impl/src/dep_kind_vtables.rs
@@ -104,6 +104,7 @@ mod non_query {
 /// Called from macro-generated code for each query.
 pub(crate) fn make_dep_kind_vtable_for_query<'tcx, Q>(
     is_anon: bool,
+    is_cache_on_disk: bool,
     is_eval_always: bool,
 ) -> DepKindVTable<'tcx>
 where
@@ -127,7 +128,8 @@ where
         is_eval_always,
         key_fingerprint_style,
         force_from_dep_node_fn: can_recover.then_some(force_from_dep_node_inner::<Q>),
-        promote_from_disk_fn: can_recover.then_some(promote_from_disk_inner::<Q>),
+        promote_from_disk_fn: (can_recover && is_cache_on_disk)
+            .then_some(promote_from_disk_inner::<Q>),
     }
 }
 

--- a/compiler/rustc_query_impl/src/dep_kind_vtables.rs
+++ b/compiler/rustc_query_impl/src/dep_kind_vtables.rs
@@ -129,12 +129,8 @@ where
         is_anon,
         is_eval_always,
         key_fingerprint_style,
-        force_from_dep_node_fn: Some(|tcx, dep_node, _| {
-            force_from_dep_node_inner(Q::query_vtable(tcx), tcx, dep_node)
-        }),
-        promote_from_disk_fn: Some(|tcx, dep_node| {
-            promote_from_disk_inner(Q::query_vtable(tcx), tcx, dep_node)
-        }),
+        force_from_dep_node_fn: Some(force_from_dep_node_inner::<Q>),
+        promote_from_disk_fn: Some(promote_from_disk_inner::<Q>),
     }
 }
 

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -572,7 +572,7 @@ fn load_from_disk_or_invoke_provider_green<'tcx, C: QueryCache>(
     // can be forced from `DepNode`.
     debug_assert!(
         !query.will_cache_on_disk_for_key(tcx, key)
-            || !tcx.key_fingerprint_style(dep_node.kind).reconstructible(),
+            || !tcx.key_fingerprint_style(dep_node.kind).is_maybe_recoverable(),
         "missing on-disk cache entry for {dep_node:?}"
     );
 

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -697,6 +697,7 @@ macro_rules! define_queries {
                     use $crate::query_impl::$name::VTableGetter;
                     make_dep_kind_vtable_for_query::<VTableGetter>(
                         is_anon!([$($modifiers)*]),
+                        if_cache_on_disk!([$($modifiers)*] true false),
                         is_eval_always!([$($modifiers)*]),
                     )
                 }

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -332,8 +332,8 @@ pub(crate) fn query_key_hash_verify<'tcx, C: QueryCache>(
     });
 }
 
-/// Implementation of [`DepKindVTable::try_load_from_on_disk_cache`] for queries.
-pub(crate) fn try_load_from_on_disk_cache_inner<'tcx, C: QueryCache>(
+/// Implementation of [`DepKindVTable::promote_from_disk_fn`] for queries.
+pub(crate) fn promote_from_disk_inner<'tcx, C: QueryCache>(
     query: &'tcx QueryVTable<'tcx, C>,
     tcx: TyCtxt<'tcx>,
     dep_node: DepNode,
@@ -385,7 +385,7 @@ where
     value
 }
 
-/// Implementation of [`DepKindVTable::force_from_dep_node`] for queries.
+/// Implementation of [`DepKindVTable::force_from_dep_node_fn`] for queries.
 pub(crate) fn force_from_dep_node_inner<'tcx, C: QueryCache>(
     query: &'tcx QueryVTable<'tcx, C>,
     tcx: TyCtxt<'tcx>,


### PR DESCRIPTION
This is a bundle of changes to the two function pointers in `DepKindVTable` that are responsible for forcing dep nodes, or promoting disk-cached values from the previous session into memory.

The perf improvements to incr-unchanged and incr-patched are likely from skipping more of the “promotion” plumbing for queries that never cache to disk.