### PR TITLE
std: move `getpid` to `sys::process`

### DIFF
--- a/library/std/src/os/unix/process.rs
+++ b/library/std/src/os/unix/process.rs
@@ -593,5 +593,5 @@ impl From<OwnedFd> for process::ChildStderr {
 #[must_use]
 #[stable(feature = "unix_ppid", since = "1.27.0")]
 pub fn parent_id() -> u32 {
-    crate::sys::os::getppid()
+    crate::sys::process::getppid()
 }

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -2545,7 +2545,7 @@ pub fn abort() -> ! {
 #[must_use]
 #[stable(feature = "getpid", since = "1.26.0")]
 pub fn id() -> u32 {
-    crate::sys::os::getpid()
+    imp::getpid()
 }
 
 /// A trait for implementing arbitrary return types in the `main` function.

--- a/library/std/src/sys/pal/hermit/os.rs
+++ b/library/std/src/sys/pal/hermit/os.rs
@@ -1,4 +1,3 @@
-use super::hermit_abi;
 use crate::ffi::{OsStr, OsString};
 use crate::marker::PhantomData;
 use crate::path::{self, PathBuf};
@@ -55,8 +54,4 @@ pub fn temp_dir() -> PathBuf {
 
 pub fn home_dir() -> Option<PathBuf> {
     None
-}
-
-pub fn getpid() -> u32 {
-    unsafe { hermit_abi::getpid() as u32 }
 }

--- a/library/std/src/sys/pal/motor/os.rs
+++ b/library/std/src/sys/pal/motor/os.rs
@@ -62,7 +62,3 @@ pub fn temp_dir() -> PathBuf {
 pub fn home_dir() -> Option<PathBuf> {
     None
 }
-
-pub fn getpid() -> u32 {
-    panic!("Pids on Motor OS are u64.")
-}

--- a/library/std/src/sys/pal/sgx/os.rs
+++ b/library/std/src/sys/pal/sgx/os.rs
@@ -55,7 +55,3 @@ pub fn temp_dir() -> PathBuf {
 pub fn home_dir() -> Option<PathBuf> {
     None
 }
-
-pub fn getpid() -> u32 {
-    panic!("no pids in SGX")
-}

--- a/library/std/src/sys/pal/solid/os.rs
+++ b/library/std/src/sys/pal/solid/os.rs
@@ -62,7 +62,3 @@ pub fn temp_dir() -> PathBuf {
 pub fn home_dir() -> Option<PathBuf> {
     None
 }
-
-pub fn getpid() -> u32 {
-    panic!("no pids on this platform")
-}

--- a/library/std/src/sys/pal/teeos/os.rs
+++ b/library/std/src/sys/pal/teeos/os.rs
@@ -66,7 +66,3 @@ pub fn temp_dir() -> PathBuf {
 pub fn home_dir() -> Option<PathBuf> {
     None
 }
-
-pub fn getpid() -> u32 {
-    panic!("no pids on this platform")
-}

--- a/library/std/src/sys/pal/uefi/os.rs
+++ b/library/std/src/sys/pal/uefi/os.rs
@@ -101,7 +101,3 @@ pub fn temp_dir() -> PathBuf {
 pub fn home_dir() -> Option<PathBuf> {
     None
 }
-
-pub fn getpid() -> u32 {
-    panic!("no pids on this platform")
-}

--- a/library/std/src/sys/pal/unix/os.rs
+++ b/library/std/src/sys/pal/unix/os.rs
@@ -533,14 +533,6 @@ pub fn home_dir() -> Option<PathBuf> {
     }
 }
 
-pub fn getpid() -> u32 {
-    unsafe { libc::getpid() as u32 }
-}
-
-pub fn getppid() -> u32 {
-    unsafe { libc::getppid() as u32 }
-}
-
 #[cfg(all(target_os = "linux", target_env = "gnu"))]
 pub fn glibc_version() -> Option<(usize, usize)> {
     unsafe extern "C" {

--- a/library/std/src/sys/pal/unsupported/os.rs
+++ b/library/std/src/sys/pal/unsupported/os.rs
@@ -55,7 +55,3 @@ pub fn temp_dir() -> PathBuf {
 pub fn home_dir() -> Option<PathBuf> {
     None
 }
-
-pub fn getpid() -> u32 {
-    panic!("no pids on this platform")
-}

--- a/library/std/src/sys/pal/wasi/os.rs
+++ b/library/std/src/sys/pal/wasi/os.rs
@@ -102,10 +102,6 @@ pub fn home_dir() -> Option<PathBuf> {
     None
 }
 
-pub fn getpid() -> u32 {
-    panic!("unsupported");
-}
-
 #[doc(hidden)]
 pub trait IsMinusOne {
     fn is_minus_one(&self) -> bool;

--- a/library/std/src/sys/pal/windows/os.rs
+++ b/library/std/src/sys/pal/windows/os.rs
@@ -188,7 +188,3 @@ pub fn home_dir() -> Option<PathBuf> {
         .map(PathBuf::from)
         .or_else(home_dir_crt)
 }
-
-pub fn getpid() -> u32 {
-    unsafe { c::GetCurrentProcessId() }
-}

--- a/library/std/src/sys/pal/xous/os.rs
+++ b/library/std/src/sys/pal/xous/os.rs
@@ -118,7 +118,3 @@ pub fn temp_dir() -> PathBuf {
 pub fn home_dir() -> Option<PathBuf> {
     None
 }
-
-pub fn getpid() -> u32 {
-    panic!("no pids on this platform")
-}

--- a/library/std/src/sys/pal/zkvm/os.rs
+++ b/library/std/src/sys/pal/zkvm/os.rs
@@ -55,7 +55,3 @@ pub fn temp_dir() -> PathBuf {
 pub fn home_dir() -> Option<PathBuf> {
     None
 }
-
-pub fn getpid() -> u32 {
-    panic!("no pids on this platform")
-}

--- a/library/std/src/sys/process/mod.rs
+++ b/library/std/src/sys/process/mod.rs
@@ -27,9 +27,11 @@ cfg_select! {
 mod env;
 
 pub use env::CommandEnvs;
+#[cfg(target_family = "unix")]
+pub use imp::getppid;
 pub use imp::{
     ChildPipe, Command, CommandArgs, EnvKey, ExitCode, ExitStatus, ExitStatusError, Process, Stdio,
-    read_output,
+    getpid, read_output,
 };
 
 #[cfg(any(

--- a/library/std/src/sys/process/motor.rs
+++ b/library/std/src/sys/process/motor.rs
@@ -327,3 +327,7 @@ pub fn read_output(
 ) -> io::Result<()> {
     Err(io::Error::from_raw_os_error(moto_rt::E_NOT_IMPLEMENTED.into()))
 }
+
+pub fn getpid() -> u32 {
+    panic!("Pids on Motor OS are u64.")
+}

--- a/library/std/src/sys/process/uefi.rs
+++ b/library/std/src/sys/process/uefi.rs
@@ -900,3 +900,7 @@ fn env_changes(env: &CommandEnv) -> Option<BTreeMap<EnvKey, (Option<OsString>, O
 
     Some(result)
 }
+
+pub fn getpid() -> u32 {
+    panic!("no pids on this platform")
+}

--- a/library/std/src/sys/process/unix/common.rs
+++ b/library/std/src/sys/process/unix/common.rs
@@ -679,3 +679,11 @@ pub fn read_output(
         }
     }
 }
+
+pub fn getpid() -> u32 {
+    unsafe { libc::getpid() as u32 }
+}
+
+pub fn getppid() -> u32 {
+    unsafe { libc::getppid() as u32 }
+}

--- a/library/std/src/sys/process/unix/mod.rs
+++ b/library/std/src/sys/process/unix/mod.rs
@@ -23,5 +23,7 @@ cfg_select! {
 
 pub use imp::{ExitStatus, ExitStatusError, Process};
 
-pub use self::common::{ChildPipe, Command, CommandArgs, ExitCode, Stdio, read_output};
+pub use self::common::{
+    ChildPipe, Command, CommandArgs, ExitCode, Stdio, getpid, getppid, read_output,
+};
 pub use crate::ffi::OsString as EnvKey;

--- a/library/std/src/sys/process/unsupported.rs
+++ b/library/std/src/sys/process/unsupported.rs
@@ -327,3 +327,7 @@ pub fn read_output(
 ) -> io::Result<()> {
     match out.diverge() {}
 }
+
+pub fn getpid() -> u32 {
+    panic!("no pids on this platform")
+}

--- a/library/std/src/sys/process/windows.rs
+++ b/library/std/src/sys/process/windows.rs
@@ -976,3 +976,7 @@ impl<'a> fmt::Debug for CommandArgs<'a> {
         f.debug_list().entries(self.iter.clone()).finish()
     }
 }
+
+pub fn getpid() -> u32 {
+    unsafe { c::GetCurrentProcessId() }
+}


### PR DESCRIPTION
Part of rust-lang/rust#117276.

Availability of process IDs is highly correlated with availability of processes, so moving the `getpid` implementations to `sys::process` makes a lot of sense (and removes quite some code duplication). The only notable change here is on Hermit, which doesn't have processes but does have `getpid`. But that [always returns 0](https://github.com/hermit-os/kernel/blob/ef27b798856b50d562a42c4ffd2edcb7493c5b5f/src/syscalls/tasks.rs#L21), so I doubt it is useful. If the change to a panic is problematic we could always copy the stub implementation and return zero ourselves (this also applies to the other single-process platforms).

CC @stlankes @mkroening