### PR TITLE
Optimize dependency file search

### DIFF
--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -438,7 +438,7 @@ impl<'a> CrateLocator<'a> {
                 }
                 if let Some(matches) = spf.query(prefix, suffix) {
                     for (hash, spf) in matches {
-                        let spf_path = spf.path();
+                        let spf_path = spf.path(&search_path.dir);
                         info!("lib candidate: {}", spf_path.display());
 
                         let (rlibs, rmetas, dylibs, interfaces) =
@@ -471,9 +471,10 @@ impl<'a> CrateLocator<'a> {
                 .flatten()
             {
                 for (_, spf) in static_matches {
-                    crate_rejections
-                        .via_kind
-                        .push(CrateMismatch { path: spf.path(), got: "static".to_string() });
+                    crate_rejections.via_kind.push(CrateMismatch {
+                        path: spf.path(&search_path.dir),
+                        got: "static".to_string(),
+                    });
                 }
             }
         }

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -438,7 +438,8 @@ impl<'a> CrateLocator<'a> {
                 }
                 if let Some(matches) = spf.query(prefix, suffix) {
                     for (hash, spf) in matches {
-                        info!("lib candidate: {}", spf.path.display());
+                        let spf_path = spf.path();
+                        info!("lib candidate: {}", spf_path.display());
 
                         let (rlibs, rmetas, dylibs, interfaces) =
                             candidates.entry(hash).or_default();
@@ -447,8 +448,8 @@ impl<'a> CrateLocator<'a> {
                             // ones we've already seen. This allows us to ignore crates
                             // we know are exactual equal to ones we've already found.
                             // Going to the same crate through different symlinks does not change the result.
-                            let path = try_canonicalize(&spf.path)
-                                .unwrap_or_else(|_| spf.path.to_path_buf());
+                            let path =
+                                try_canonicalize(&spf_path).unwrap_or_else(|_| spf_path.clone());
                             if seen_paths.contains(&path) {
                                 continue;
                             };
@@ -456,12 +457,11 @@ impl<'a> CrateLocator<'a> {
                         }
                         // Use the original path (potentially with unresolved symlinks),
                         // filesystem code should not care, but this is nicer for diagnostics.
-                        let path = spf.path.to_path_buf();
                         match kind {
-                            CrateFlavor::Rlib => rlibs.insert(path),
-                            CrateFlavor::Rmeta => rmetas.insert(path),
-                            CrateFlavor::Dylib => dylibs.insert(path),
-                            CrateFlavor::SDylib => interfaces.insert(path),
+                            CrateFlavor::Rlib => rlibs.insert(spf_path),
+                            CrateFlavor::Rmeta => rmetas.insert(spf_path),
+                            CrateFlavor::Dylib => dylibs.insert(spf_path),
+                            CrateFlavor::SDylib => interfaces.insert(spf_path),
                         };
                     }
                 }
@@ -471,10 +471,9 @@ impl<'a> CrateLocator<'a> {
                 .flatten()
             {
                 for (_, spf) in static_matches {
-                    crate_rejections.via_kind.push(CrateMismatch {
-                        path: spf.path.to_path_buf(),
-                        got: "static".to_string(),
-                    });
+                    crate_rejections
+                        .via_kind
+                        .push(CrateMismatch { path: spf.path(), got: "static".to_string() });
                 }
             }
         }

--- a/compiler/rustc_session/src/search_paths.rs
+++ b/compiler/rustc_session/src/search_paths.rs
@@ -144,7 +144,7 @@ impl SearchPath {
 
             Err(..) => Default::default(),
         };
-        files.sort_by(|lhs, rhs| lhs.file_name_str.cmp(&rhs.file_name_str));
+        files.sort_unstable_by(|lhs, rhs| lhs.file_name_str.cmp(&rhs.file_name_str));
         let files = FilesIndex(files);
         SearchPath { kind, dir, files }
     }

--- a/compiler/rustc_session/src/search_paths.rs
+++ b/compiler/rustc_session/src/search_paths.rs
@@ -16,7 +16,7 @@ pub struct SearchPath {
 
 /// [FilesIndex] contains paths that can be efficiently looked up with (prefix, suffix) pairs.
 #[derive(Clone, Debug)]
-pub struct FilesIndex(Vec<(Arc<str>, SearchPathFile)>);
+pub struct FilesIndex(Vec<SearchPathFile>);
 
 impl FilesIndex {
     /// Look up [SearchPathFile] by (prefix, suffix) pair.
@@ -25,15 +25,15 @@ impl FilesIndex {
         prefix: &str,
         suffix: &str,
     ) -> Option<impl Iterator<Item = (String, &'s SearchPathFile)>> {
-        let start = self.0.partition_point(|(k, _)| **k < *prefix);
+        let start = self.0.partition_point(|v| *v.file_name_str < *prefix);
         if start == self.0.len() {
             return None;
         }
-        let end = self.0[start..].partition_point(|(k, _)| k.starts_with(prefix));
+        let end = self.0[start..].partition_point(|v| v.file_name_str.starts_with(prefix));
         let prefixed_items = &self.0[start..][..end];
 
-        let ret = prefixed_items.into_iter().filter_map(move |(k, v)| {
-            k.ends_with(suffix).then(|| {
+        let ret = prefixed_items.into_iter().filter_map(move |v| {
+            v.file_name_str.ends_with(suffix).then(|| {
                 (
                     String::from(
                         &v.file_name_str[prefix.len()..v.file_name_str.len() - suffix.len()],
@@ -45,7 +45,7 @@ impl FilesIndex {
         Some(ret)
     }
     pub fn retain(&mut self, prefixes: &[&str]) {
-        self.0.retain(|(k, _)| prefixes.iter().any(|prefix| k.starts_with(prefix)));
+        self.0.retain(|v| prefixes.iter().any(|prefix| v.file_name_str.starts_with(prefix)));
     }
 }
 /// The obvious implementation of `SearchPath::files` is a `Vec<PathBuf>`. But
@@ -136,10 +136,7 @@ impl SearchPath {
                     e.ok().and_then(|e| {
                         e.file_name().to_str().map(|s| {
                             let file_name_str: Arc<str> = s.into();
-                            (
-                                Arc::clone(&file_name_str),
-                                SearchPathFile { path: e.path().into(), file_name_str },
-                            )
+                            SearchPathFile { path: e.path().into(), file_name_str }
                         })
                     })
                 })
@@ -147,7 +144,7 @@ impl SearchPath {
 
             Err(..) => Default::default(),
         };
-        files.sort_by(|(lhs, _), (rhs, _)| lhs.cmp(rhs));
+        files.sort_by(|lhs, rhs| lhs.file_name_str.cmp(&rhs.file_name_str));
         let files = FilesIndex(files);
         SearchPath { kind, dir, files }
     }

--- a/compiler/rustc_session/src/search_paths.rs
+++ b/compiler/rustc_session/src/search_paths.rs
@@ -61,15 +61,13 @@ impl FilesIndex {
 /// UTF-8, and so a non-UTF-8 filename couldn't be one we're looking for.)
 #[derive(Clone, Debug)]
 pub struct SearchPathFile {
-    // We store the directory in a shared Arc, as many files can share the same directory.
-    dir: Arc<Path>,
     file_name_str: Arc<str>,
 }
 
 impl SearchPathFile {
     /// Constructs the full path to the file.
-    pub fn path(&self) -> PathBuf {
-        self.dir.join(&*self.file_name_str)
+    pub fn path(&self, dir: &Path) -> PathBuf {
+        dir.join(&*self.file_name_str)
     }
 }
 
@@ -137,16 +135,12 @@ impl SearchPath {
     }
 
     pub fn new(kind: PathKind, dir: PathBuf) -> Self {
-        let dir_file: Arc<Path> = dir.clone().into();
         // Get the files within the directory.
         let mut files = match std::fs::read_dir(&dir) {
             Ok(files) => files
                 .filter_map(|e| {
                     e.ok().and_then(|e| {
-                        e.file_name().to_str().map(|s| {
-                            let file_name_str: Arc<str> = s.into();
-                            SearchPathFile { dir: dir_file.clone(), file_name_str }
-                        })
+                        e.file_name().to_str().map(|s| SearchPathFile { file_name_str: s.into() })
                     })
                 })
                 .collect::<Vec<SearchPathFile>>(),


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/153131)*
<!-- homu-ignore:end -->

I tried to look into the slowdown reported in https://github.com/rust-lang/cargo/issues/16665.

I created a Rust hello world program, and used this Python script to create a directory containing 200k files:
```python
from pathlib import Path

dir = Path("deps")
dir.mkdir(parents=True, exist_ok=True)
for i in range(200000):
    path = dir / f"file{i:07}.o"
    with open(path, "w") as f:
        f.write("\n")
```

Then I tried to do various small microoptimalizations and simplifications to the code that iterates the search directories. Each individual commit improved performance, with the third one having the biggest effect.

Here are the results on `main` vs the last commit with the stage1 compiler on Linux, using `hyperfine "rustc +stage1 src/main.rs -L deps" -r 30` (there's IO involved, so it's good to let it run for a while):

```bash
Benchmark 1: rustc +stage1 src/main.rs -L deps
  Time (mean ± σ):     299.4 ms ±   2.7 ms    [User: 161.9 ms, System: 144.9 ms]
  Range (min … max):   294.8 ms … 307.1 ms    30 runs

Benchmark 1: rustc +stage1 src/main.rs -L deps
  Time (mean ± σ):     208.1 ms ±   4.5 ms    [User: 87.3 ms, System: 128.7 ms]
  Range (min … max):   202.4 ms … 219.6 ms    30 runs
```

Would be cool if someone could try this on macOS (maybe @ehuss - not sure if you have macOS or you only commented about its behavior on the Cargo issue :) ).

I also tried to prefilter the paths (not in this PR); right now we load everything and then we filter files with given prefixes, that's wasteful. Filtering just files starting with `lib` would get us down to ~150ms here. (The baseline without `-L` is ~80ms on my PC). The rest of the 70ms is essentially allocations from iterating the directory entries and sorting. That would be very hard to change - iterating the directory entries (de)allocates a lot of intermediate paths :( We'd have to implement the iteration by hand with either arena allocation, or at least some better management of memory.

r? @nnethercote