### PR TITLE
Correctly handle `#[doc(alias = "...")]` attribute on inlined reexports

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2701,7 +2701,29 @@ fn add_without_unwanted_attributes<'hir>(
             }
             hir::Attribute::Parsed(AttributeKind::Doc(box d)) => {
                 // Remove attributes from `normal` that should not be inherited by `use` re-export.
-                let DocAttribute { hidden, inline, cfg, aliases, .. } = d;
+                let DocAttribute {
+                    aliases,
+                    hidden,
+                    inline,
+                    cfg,
+                    auto_cfg: _,
+                    auto_cfg_change: _,
+                    fake_variadic: _,
+                    keyword: _,
+                    attribute: _,
+                    masked: _,
+                    notable_trait: _,
+                    search_unbox: _,
+                    html_favicon_url: _,
+                    html_logo_url: _,
+                    html_playground_url: _,
+                    html_root_url: _,
+                    html_no_source: _,
+                    issue_tracker_base_url: _,
+                    rust_logo: _,
+                    test_attrs: _,
+                    no_crate_inject: _,
+                } = d;
                 let mut attr = DocAttribute::default();
                 if is_inline {
                     attr.cfg = cfg.clone();

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2701,7 +2701,7 @@ fn add_without_unwanted_attributes<'hir>(
             }
             hir::Attribute::Parsed(AttributeKind::Doc(box d)) => {
                 // Remove attributes from `normal` that should not be inherited by `use` re-export.
-                let DocAttribute { hidden, inline, cfg, .. } = d;
+                let DocAttribute { hidden, inline, cfg, aliases, .. } = d;
                 let mut attr = DocAttribute::default();
                 if is_inline {
                     attr.cfg = cfg.clone();
@@ -2709,6 +2709,7 @@ fn add_without_unwanted_attributes<'hir>(
                     attr.inline = inline.clone();
                     attr.hidden = hidden.clone();
                 }
+                attr.aliases = aliases.clone();
                 attrs.push((
                     Cow::Owned(hir::Attribute::Parsed(AttributeKind::Doc(Box::new(attr)))),
                     import_parent,

--- a/tests/rustdoc-js/auxiliary/reexport-alias.rs
+++ b/tests/rustdoc-js/auxiliary/reexport-alias.rs
@@ -1,0 +1,2 @@
+#[doc(alias = "answer")]
+pub fn number() {}

--- a/tests/rustdoc-js/auxiliary/reexport-search_unbox.rs
+++ b/tests/rustdoc-js/auxiliary/reexport-search_unbox.rs
@@ -1,0 +1,20 @@
+#![feature(rustdoc_internals)]
+
+#[doc(search_unbox)]
+pub struct Inside<T>(T);
+
+#[doc(search_unbox)]
+pub struct Out<A, B = ()> {
+    a: A,
+    b: B,
+}
+
+#[doc(search_unbox)]
+pub struct Out1<A, const N: usize> {
+    a: [A; N],
+}
+
+#[doc(search_unbox)]
+pub struct Out2<A, const N: usize> {
+    a: [A; N],
+}

--- a/tests/rustdoc-js/reexport-alias.js
+++ b/tests/rustdoc-js/reexport-alias.js
@@ -1,0 +1,12 @@
+// exact-check
+
+// This test ensures that inlined reexport items keep the `#[doc(alias = "...")]`
+// information.
+// This is a regression test for <https://github.com/rust-lang/rust/issues/152939>.
+
+const EXPECTED = {
+    'query': 'answer',
+    'others': [
+        { 'path': 'foo', 'name': 'number', 'is_alias': true },
+    ],
+};

--- a/tests/rustdoc-js/reexport-alias.rs
+++ b/tests/rustdoc-js/reexport-alias.rs
@@ -1,0 +1,8 @@
+//@ aux-crate:priv:reexport_alias=reexport-alias.rs
+//@ compile-flags: -Zunstable-options --extern equivalent
+
+#![crate_name = "foo"]
+
+extern crate reexport_alias;
+
+pub use reexport_alias::number;

--- a/tests/rustdoc-js/reexport-search_unbox.js
+++ b/tests/rustdoc-js/reexport-search_unbox.js
@@ -1,0 +1,12 @@
+// exact-check
+
+// This test ensures that `search_unbox` works even on inlined reexports.
+
+const EXPECTED = [
+    {
+        'query': 'Inside<T> -> Out1<T>',
+        'others': [
+            { 'path': 'foo', 'name': 'alpha' },
+        ],
+    },
+]

--- a/tests/rustdoc-js/reexport-search_unbox.rs
+++ b/tests/rustdoc-js/reexport-search_unbox.rs
@@ -1,0 +1,12 @@
+//@ aux-crate:priv:reexport_search_unbox=reexport-search_unbox.rs
+//@ compile-flags: -Zunstable-options --extern equivalent
+
+#![crate_name = "foo"]
+
+extern crate reexport_search_unbox;
+
+pub use reexport_search_unbox::{Inside, Out, Out1, Out2};
+
+pub fn alpha<const N: usize, T>(_: Inside<T>) -> Out<Out1<T, N>, Out2<T, N>> {
+    loop {}
+}


### PR DESCRIPTION
Fixes rust-lang/rust#152939.

During the doc attributing migration to the new API, this information got lost. At least now we have a test for it. :)

r? @lolbinarycat 