### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -540,7 +540,6 @@ impl<'a> TraitDef<'a> {
                         .filter(|a| {
                             a.has_any_name(&[
                                 sym::allow,
-                                sym::expect,
                                 sym::warn,
                                 sym::deny,
                                 sym::forbid,

--- a/compiler/rustc_infer/src/infer/lexical_region_resolve/indexed_edges.rs
+++ b/compiler/rustc_infer/src/infer/lexical_region_resolve/indexed_edges.rs
@@ -1,0 +1,68 @@
+use rustc_index::IndexVec;
+use rustc_type_ir::RegionVid;
+
+use crate::infer::SubregionOrigin;
+use crate::infer::region_constraints::{Constraint, ConstraintKind, RegionConstraintData};
+
+/// Selects either out-edges or in-edges for [`IndexedConstraintEdges::adjacent_edges`].
+#[derive(Clone, Copy, Debug)]
+pub(super) enum EdgeDirection {
+    Out,
+    In,
+}
+
+/// Type alias for the pairs stored in [`RegionConstraintData::constraints`],
+/// which we are indexing.
+type ConstraintPair<'tcx> = (Constraint<'tcx>, SubregionOrigin<'tcx>);
+
+/// An index from region variables to their corresponding constraint edges,
+/// used on some error paths.
+pub(super) struct IndexedConstraintEdges<'data, 'tcx> {
+    out_edges: IndexVec<RegionVid, Vec<&'data ConstraintPair<'tcx>>>,
+    in_edges: IndexVec<RegionVid, Vec<&'data ConstraintPair<'tcx>>>,
+}
+
+impl<'data, 'tcx> IndexedConstraintEdges<'data, 'tcx> {
+    pub(super) fn build_index(num_vars: usize, data: &'data RegionConstraintData<'tcx>) -> Self {
+        let mut out_edges = IndexVec::from_fn_n(|_| vec![], num_vars);
+        let mut in_edges = IndexVec::from_fn_n(|_| vec![], num_vars);
+
+        for pair @ (c, _) in &data.constraints {
+            // Only push a var out-edge for `VarSub...` constraints.
+            match c.kind {
+                ConstraintKind::VarSubVar | ConstraintKind::VarSubReg => {
+                    out_edges[c.sub.as_var()].push(pair)
+                }
+                ConstraintKind::RegSubVar | ConstraintKind::RegSubReg => {}
+            }
+        }
+
+        // Index in-edges in reverse order, to match what current tests expect.
+        // (It's unclear whether this is important or not.)
+        for pair @ (c, _) in data.constraints.iter().rev() {
+            // Only push a var in-edge for `...SubVar` constraints.
+            match c.kind {
+                ConstraintKind::VarSubVar | ConstraintKind::RegSubVar => {
+                    in_edges[c.sup.as_var()].push(pair)
+                }
+                ConstraintKind::VarSubReg | ConstraintKind::RegSubReg => {}
+            }
+        }
+
+        IndexedConstraintEdges { out_edges, in_edges }
+    }
+
+    /// Returns either the out-edges or in-edges of the specified region var,
+    /// as selected by `dir`.
+    pub(super) fn adjacent_edges(
+        &self,
+        region_vid: RegionVid,
+        dir: EdgeDirection,
+    ) -> &[&'data ConstraintPair<'tcx>] {
+        let edges = match dir {
+            EdgeDirection::Out => &self.out_edges,
+            EdgeDirection::In => &self.in_edges,
+        };
+        &edges[region_vid]
+    }
+}

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -289,7 +289,6 @@ struct RcInner<T: ?Sized> {
 }
 
 /// Calculate layout for `RcInner<T>` using the inner value's layout
-#[inline]
 fn rc_inner_layout_for_value_layout(layout: Layout) -> Layout {
     // Calculate layout using the given value layout.
     // Previously, layout was calculated on the expression
@@ -2519,25 +2518,15 @@ impl<T: Default> Default for Rc<T> {
     /// ```
     #[inline]
     fn default() -> Self {
-        // First create an uninitialized allocation before creating an instance
-        // of `T`. This avoids having `T` on the stack and avoids the need to
-        // codegen a call to the destructor for `T` leading to generally better
-        // codegen. See #131460 for some more details.
-        let mut rc = Rc::new_uninit();
-
-        // SAFETY: this is a freshly allocated `Rc` so it's guaranteed there are
-        // no other strong or weak pointers other than `rc` itself.
         unsafe {
-            let raw = Rc::get_mut_unchecked(&mut rc);
-
-            // Note that `ptr::write` here is used specifically instead of
-            // `MaybeUninit::write` to avoid creating an extra stack copy of `T`
-            // in debug mode. See #136043 for more context.
-            ptr::write(raw.as_mut_ptr(), T::default());
+            Self::from_inner(
+                Box::leak(Box::write(
+                    Box::new_uninit(),
+                    RcInner { strong: Cell::new(1), weak: Cell::new(1), value: T::default() },
+                ))
+                .into(),
+            )
         }
-
-        // SAFETY: this allocation was just initialized above.
-        unsafe { rc.assume_init() }
     }
 }
 

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -392,7 +392,6 @@ struct ArcInner<T: ?Sized> {
 }
 
 /// Calculate layout for `ArcInner<T>` using the inner value's layout
-#[inline]
 fn arcinner_layout_for_value_layout(layout: Layout) -> Layout {
     // Calculate layout using the given value layout.
     // Previously, layout was calculated on the expression
@@ -3725,25 +3724,19 @@ impl<T: Default> Default for Arc<T> {
     /// assert_eq!(*x, 0);
     /// ```
     fn default() -> Arc<T> {
-        // First create an uninitialized allocation before creating an instance
-        // of `T`. This avoids having `T` on the stack and avoids the need to
-        // codegen a call to the destructor for `T` leading to generally better
-        // codegen. See #131460 for some more details.
-        let mut arc = Arc::new_uninit();
-
-        // SAFETY: this is a freshly allocated `Arc` so it's guaranteed there
-        // are no other strong or weak pointers other than `arc` itself.
         unsafe {
-            let raw = Arc::get_mut_unchecked(&mut arc);
-
-            // Note that `ptr::write` here is used specifically instead of
-            // `MaybeUninit::write` to avoid creating an extra stack copy of `T`
-            // in debug mode. See #136043 for more context.
-            ptr::write(raw.as_mut_ptr(), T::default());
+            Self::from_inner(
+                Box::leak(Box::write(
+                    Box::new_uninit(),
+                    ArcInner {
+                        strong: atomic::AtomicUsize::new(1),
+                        weak: atomic::AtomicUsize::new(1),
+                        data: T::default(),
+                    },
+                ))
+                .into(),
+            )
         }
-
-        // SAFETY: this allocation was just initialized above.
-        unsafe { arc.assume_init() }
     }
 }
 

--- a/library/panic_unwind/src/lib.rs
+++ b/library/panic_unwind/src/lib.rs
@@ -14,6 +14,7 @@
 #![no_std]
 #![unstable(feature = "panic_unwind", issue = "32837")]
 #![doc(issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/")]
+#![cfg_attr(all(target_os = "emscripten", not(emscripten_wasm_eh)), lang_items)]
 #![feature(cfg_emscripten_wasm_eh)]
 #![feature(core_intrinsics)]
 #![feature(panic_unwind)]

--- a/tests/codegen-llvm/issues/issue-111603.rs
+++ b/tests/codegen-llvm/issues/issue-111603.rs
@@ -10,9 +10,9 @@ use std::sync::Arc;
 pub fn new_from_array(x: u64) -> Arc<[u64]> {
     // Ensure that we only generate one alloca for the array.
 
-    // CHECK: %[[A:.+]] = alloca
+    // CHECK: alloca
     // CHECK-SAME: [8000 x i8]
-    // CHECK-NOT: %[[B:.+]] = alloca
+    // CHECK-NOT: alloca
     let array = [x; 1000];
     Arc::new(array)
 }
@@ -20,9 +20,8 @@ pub fn new_from_array(x: u64) -> Arc<[u64]> {
 // CHECK-LABEL: @new_uninit
 #[no_mangle]
 pub fn new_uninit(x: u64) -> Arc<[u64; 1000]> {
-    // CHECK: %[[A:.+]] = alloca
-    // CHECK-SAME: [8000 x i8]
-    // CHECK-NOT: %[[B:.+]] = alloca
+    // CHECK: call alloc::sync::arcinner_layout_for_value_layout
+    // CHECK-NOT: call alloc::sync::arcinner_layout_for_value_layout
     let mut arc = Arc::new_uninit();
     unsafe { Arc::get_mut_unchecked(&mut arc) }.write([x; 1000]);
     unsafe { arc.assume_init() }
@@ -31,7 +30,8 @@ pub fn new_uninit(x: u64) -> Arc<[u64; 1000]> {
 // CHECK-LABEL: @new_uninit_slice
 #[no_mangle]
 pub fn new_uninit_slice(x: u64) -> Arc<[u64]> {
-    // CHECK-NOT: %[[B:.+]] = alloca
+    // CHECK: call alloc::sync::arcinner_layout_for_value_layout
+    // CHECK-NOT: call alloc::sync::arcinner_layout_for_value_layout
     let mut arc = Arc::new_uninit_slice(1000);
     for elem in unsafe { Arc::get_mut_unchecked(&mut arc) } {
         elem.write(x);

--- a/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553-3.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553-3.rs
@@ -1,3 +1,5 @@
+// FIXME: Bring back duplication of the `#[expect]` attribute when deriving.
+//
 // Make sure we produce the unfulfilled expectation lint if neither the struct or the
 // derived code fulfilled it.
 
@@ -5,7 +7,7 @@
 
 #[expect(unexpected_cfgs)]
 //~^ WARN this lint expectation is unfulfilled
-//~^^ WARN this lint expectation is unfulfilled
+//FIXME ~^^ WARN this lint expectation is unfulfilled
 #[derive(Debug)]
 pub struct MyStruct {
     pub t_ref: i64,

--- a/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553-3.stderr
+++ b/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553-3.stderr
@@ -1,18 +1,10 @@
 warning: this lint expectation is unfulfilled
-  --> $DIR/derive-expect-issue-150553-3.rs:6:10
+  --> $DIR/derive-expect-issue-150553-3.rs:8:10
    |
 LL | #[expect(unexpected_cfgs)]
    |          ^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unfulfilled_lint_expectations)]` on by default
 
-warning: this lint expectation is unfulfilled
-  --> $DIR/derive-expect-issue-150553-3.rs:6:10
-   |
-LL | #[expect(unexpected_cfgs)]
-   |          ^^^^^^^^^^^^^^^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-warning: 2 warnings emitted
+warning: 1 warning emitted
 

--- a/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553-4.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553-4.rs
@@ -1,0 +1,15 @@
+// This test makes sure that expended items with derives don't interfear with lint expectations.
+//
+// See <https://github.com/rust-lang/rust/issues/153036> for some context.
+
+//@ check-pass
+
+#[derive(Clone, Debug)]
+#[expect(unused)]
+pub struct LoggingArgs {
+    #[cfg(false)]
+    x: i32,
+    y: i32,
+}
+
+fn main() {}

--- a/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553.rs
@@ -1,9 +1,11 @@
+// FIXME: Bring back duplication of the `#[expect]` attribute when deriving.
+//
 // Make sure we properly copy the `#[expect]` attr to the derived code and that no
 // unfulfilled expectations are trigerred.
 //
 // See <https://github.com/rust-lang/rust/issues/150553> for rational.
 
-//@ check-pass
+//@ check-fail
 
 #![deny(redundant_lifetimes)]
 
@@ -12,6 +14,7 @@ use std::fmt::Debug;
 #[derive(Debug)]
 #[expect(redundant_lifetimes)]
 pub struct RefWrapper<'a, T>
+//~^ ERROR redundant_lifetimes
 where
     'a: 'static,
     T: Debug,

--- a/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553.stderr
+++ b/tests/ui/lint/rfc-2383-lint-reason/derive-expect-issue-150553.stderr
@@ -1,0 +1,15 @@
+error: unnecessary lifetime parameter `'a`
+  --> $DIR/derive-expect-issue-150553.rs:16:23
+   |
+LL | pub struct RefWrapper<'a, T>
+   |                       ^^
+   |
+   = note: you can use the `'static` lifetime directly, in place of `'a`
+note: the lint level is defined here
+  --> $DIR/derive-expect-issue-150553.rs:10:9
+   |
+LL | #![deny(redundant_lifetimes)]
+   |         ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#153055 ( Revert "Also duplicate `#[expect]` attribute in `#[derive]`-ed code")
 - rust-lang/rust#153012 (Stop using `LinkedGraph` in `lexical_region_resolve`)
 - rust-lang/rust#153108 (Revert "Simplify internals of `{Rc,Arc}::default`")
 - rust-lang/rust#153117 (Remove mutation from macro path URL construction)
 - rust-lang/rust#153128 (Recover feature lang_items for emscripten)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=153055,153012,153108,153117,153128)
<!-- homu-ignore:end -->

