### PR TITLE
re-enable debuginfo/generic-enums-... lldb test

### DIFF
--- a/tests/debuginfo/generic-enum-with-different-disr-sizes.rs
+++ b/tests/debuginfo/generic-enum-with-different-disr-sizes.rs
@@ -1,5 +1,3 @@
-//@ ignore-lldb: FIXME(#27089)
-
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc
@@ -38,22 +36,22 @@
 //@ lldb-command:run
 
 //@ lldb-command:v eight_bytes1
-//@ lldb-check:[...] Variant1(100)
+//@ lldb-check:[...] Variant1(100) { 0 = 100 }
 //@ lldb-command:v four_bytes1
-//@ lldb-check:[...] Variant1(101)
+//@ lldb-check:[...] Variant1(101) { 0 = 101 }
 //@ lldb-command:v two_bytes1
-//@ lldb-check:[...] Variant1(102)
+//@ lldb-check:[...] Variant1(102) { 0 = 102 }
 //@ lldb-command:v one_byte1
-//@ lldb-check:[...] Variant1('A')
+//@ lldb-check:[...] Variant1('A') { 0 = 'A' }
 
 //@ lldb-command:v eight_bytes2
-//@ lldb-check:[...] Variant2(100)
+//@ lldb-check:[...] Variant2(100) { 0 = 100 }
 //@ lldb-command:v four_bytes2
-//@ lldb-check:[...] Variant2(101)
+//@ lldb-check:[...] Variant2(101) { 0 = 101 }
 //@ lldb-command:v two_bytes2
-//@ lldb-check:[...] Variant2(102)
+//@ lldb-check:[...] Variant2(102) { 0 = 102 }
 //@ lldb-command:v one_byte2
-//@ lldb-check:[...] Variant2('A')
+//@ lldb-check:[...] Variant2('A') { 0 = 'A' }
 
 //@ lldb-command:continue
 


### PR DESCRIPTION
This test was failing a while ago for lldb with some error related to
> `NotImplementedError: Wrong number of arguments for overloaded function 'SBValue_GetChildAtIndex'.`

When I run the test, it no longer outputs this error.

This change removes the `ignore-lldb: FIXME(27089)` line and adds this test back. It seems the `v var` command now has a slightly different output, so I've updated the corresponding `lldb-check` lines as well.

fixes rust-lang/rust#27089