### PR TITLE
Work around a false `err.emit();` type error in rust-analyzer

### DIFF
--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -300,7 +300,7 @@ internal compiler error: query cycle handler thread panicked, aborting process";
                     diag.help(
                         "try lowering `-Z threads` or checking the operating system's resource limits",
                     );
-                    diag.emit();
+                    diag.emit()
                 })
         })
     })

--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -132,7 +132,7 @@ pub fn new_parser_from_file<'a>(
         if let Some(sp) = sp {
             err.span(sp);
         }
-        err.emit();
+        err.emit()
     });
     new_parser_from_source_file(psess, source_file, strip_tokens)
 }

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1615,7 +1615,7 @@ pub fn build_target_config(
             let mut err =
                 early_dcx.early_struct_fatal(format!("error loading target specification: {e}"));
             err.help("run `rustc --print target-list` for a list of built-in targets");
-            err.emit();
+            err.emit()
         }
     }
 }


### PR DESCRIPTION
For whatever reason, rust-analyzer doesn't see that these calls to `err.emit();` are diverging, so the trailing semicolon makes r-a complain about a type mismatch between `()` and some other type.

Removing the trailing semicolon makes no functional difference (because the emit still unwinds the stack), but seems to be enough to allow rust-analyzer to see that emitting an error returns `!` in these cases, which silences the false error.