### PR TITLE
Re-enable relative paths for std links in rustc-docs

### DIFF
--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -953,6 +953,16 @@ impl Step for Rustc {
         cargo.rustdocflag("--extern-html-root-url");
         cargo.rustdocflag("ena=https://docs.rs/ena/latest/");
 
+        // Link std crates to local docs. Installed layout:
+        //   html/            <- std docs (core/, std/, alloc/, ...)
+        //   html/rustc-docs/ <- compiler docs
+        // `../../` from rustc-docs/*/index.html reaches html/.
+        for krate in STD_PUBLIC_CRATES {
+            cargo.rustdocflag("--extern-html-root-url");
+            cargo.rustdocflag(&format!("{krate}=../../"));
+        }
+        cargo.rustdocflag("--extern-html-root-takes-precedence");
+
         let mut to_open = None;
 
         let out_dir = builder.stage_out(build_compiler, Mode::Rustc).join(target).join("doc");


### PR DESCRIPTION
Closes rust-lang/rust#151496.

PR rust-lang/rust#152243 added `--extern-html-root-url core=../` so rustc-docs would link to local std docs for offline usage. It caused rust-lang/rust#152917 because `../` was the wrong depth — at depth 2+ pages the links resolved inside the compiler docs tree instead of reaching the std docs. rust-lang/rust#152976 reverted it.

From `rustc-docs/rustc_middle/index.html`, `../../core/` reaches `html/core/`. The published layout on doc.rust-lang.org works the same way (`nightly/nightly-rustc/` → `../../` → `nightly/`).

Rustdoc's `remote_url_prefix` (rust-lang/rust#152977) handles deeper module pages by adding extra `../` segments automatically. Source pages get correct depth via `remote_item_depth` (rust-lang/rust#153160).


r? @GuillaumeGomez