### PR TITLE
std: add wasm64 to sync::Once and thread_parking atomics cfg guards

### DIFF
--- a/library/std/src/sys/sync/once/mod.rs
+++ b/library/std/src/sys/sync/once/mod.rs
@@ -12,7 +12,7 @@ cfg_select! {
         all(target_os = "windows", not(target_vendor="win7")),
         target_os = "linux",
         target_os = "android",
-        all(target_arch = "wasm32", target_feature = "atomics"),
+        all(target_family = "wasm", target_feature = "atomics"),
         target_os = "freebsd",
         target_os = "motor",
         target_os = "openbsd",

--- a/library/std/src/sys/sync/thread_parking/mod.rs
+++ b/library/std/src/sys/sync/thread_parking/mod.rs
@@ -3,7 +3,7 @@ cfg_select! {
         all(target_os = "windows", not(target_vendor = "win7")),
         target_os = "linux",
         target_os = "android",
-        all(target_arch = "wasm32", target_feature = "atomics"),
+        all(target_family = "wasm", target_feature = "atomics"),
         target_os = "freebsd",
         target_os = "openbsd",
         target_os = "dragonfly",


### PR DESCRIPTION
When targeting `wasm64-unknown-unknown` with atomics enabled, `std::sync::Once` and `thread_parking` fall through to the `no_threads`/`unsupported` implementations because the cfg guards only check for `wasm32`. This causes worker threads to panic with `unreachable` at runtime. The underlying futex implementations already handle both wasm32 and wasm64 correctly, only the cfg guards were missing wasm64.


I tested this manually with a multithreaded wasm64 application ([o1js](https://github.com/o1-labs/o1js/)) compiled with `-Z build-std=panic_abort,std` and `-C target-feature=+atomics,+bulk-memory,+mutable-globals`

Related: rust-lang/rust#83879 rust-lang/rust#77839

Happy to adjust anything based on feedback