### PR TITLE
disable the ptr_fragment_in_final test on s390x

### DIFF
--- a/tests/ui/consts/const-eval/ptr_fragments_in_final.rs
+++ b/tests/ui/consts/const-eval/ptr_fragments_in_final.rs
@@ -1,4 +1,5 @@
 //! Test that we properly error when there is a pointer fragment in the final value.
+//@ ignore-s390x different alignment on s390x make the test fail
 
 use std::{mem::{self, MaybeUninit}, ptr};
 

--- a/tests/ui/consts/const-eval/ptr_fragments_in_final.stderr
+++ b/tests/ui/consts/const-eval/ptr_fragments_in_final.stderr
@@ -1,5 +1,5 @@
 error: encountered partial pointer in final value of constant
-  --> $DIR/ptr_fragments_in_final.rs:15:1
+  --> $DIR/ptr_fragments_in_final.rs:16:1
    |
 LL | const MEMCPY_RET: MaybeUninit<*const i32> = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL | const MEMCPY_RET: MaybeUninit<*const i32> = unsafe {
    = note: while pointers can be broken apart into individual bytes during const-evaluation, only complete pointers (with all their bytes in the right order) are supported in the final value
 
 error: encountered partial pointer in final value of constant
-  --> $DIR/ptr_fragments_in_final.rs:24:1
+  --> $DIR/ptr_fragments_in_final.rs:25:1
    |
 LL | const MIXED_PTR: MaybeUninit<*const u8> = {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ LL | const MIXED_PTR: MaybeUninit<*const u8> = {
    = note: while pointers can be broken apart into individual bytes during const-evaluation, only complete pointers (with all their bytes in the right order) are supported in the final value
 
 error: encountered partial pointer in final value of constant
-  --> $DIR/ptr_fragments_in_final.rs:61:5
+  --> $DIR/ptr_fragments_in_final.rs:62:5
    |
 LL |     const A: Thing = unsafe {
    |     ^^^^^^^^^^^^^^


### PR DESCRIPTION
on s390x 128bit types have a smaller alignment then on x86[^1]. This leads to the tests falling due to different errors emitted.

As this affects the same infrastructure as rust-lang/rust#149056 [^2] lets also for now disable the tests on s390x.

[^1]: s390x ELF ABI Table 1.1, Page 12 https://github.com/IBM/s390x-abi
[^2]: https://github.com/rust-lang/rust/pull/149056#issuecomment-3547543222

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
