### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -1,4 +1,6 @@
-use rustc_hir::attrs::{CoverageAttrKind, OptimizeAttr, RtsanSetting, SanitizerSet, UsedBy};
+use rustc_hir::attrs::{
+    CoverageAttrKind, ExportVisibilityAttrValue, OptimizeAttr, RtsanSetting, SanitizerSet, UsedBy,
+};
 use rustc_session::parse::feature_err;
 
 use super::prelude::*;
@@ -150,6 +152,43 @@ impl<S: Stage> SingleAttributeParser<S> for ExportNameParser {
             return None;
         }
         Some(AttributeKind::ExportName { name, span: cx.attr_span })
+    }
+}
+
+pub(crate) struct ExportVisibilityParser;
+
+impl<S: Stage> SingleAttributeParser<S> for ExportVisibilityParser {
+    const PATH: &[rustc_span::Symbol] = &[sym::export_visibility];
+    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
+    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
+    const ALLOWED_TARGETS: AllowedTargets =
+        AllowedTargets::AllowList(&[Allow(Target::Fn), Allow(Target::Static)]);
+    const TEMPLATE: AttributeTemplate = template!(NameValueStr: "visibility");
+
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+        let Some(nv) = args.name_value() else {
+            cx.expected_name_value(cx.attr_span, None);
+            return None;
+        };
+        let Some(sv) = nv.value_as_str() else {
+            cx.expected_string_literal(nv.value_span, Some(nv.value_as_lit()));
+            return None;
+        };
+
+        let str_to_visibility = [("target_default", ExportVisibilityAttrValue::TargetDefault)];
+        for &(s, visibility) in str_to_visibility.iter() {
+            if s == sv.as_str() {
+                return Some(AttributeKind::ExportVisibility { visibility, span: cx.attr_span });
+            }
+        }
+
+        let allowed_str_values = str_to_visibility
+            .into_iter()
+            .map(|(s, _visibility)| s)
+            .map(Symbol::intern)
+            .collect::<Vec<_>>();
+        cx.expected_specific_argument_strings(nv.value_span, &allowed_str_values);
+        None
     }
 }
 

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -184,6 +184,7 @@ attribute_parsers!(
         Single<DeprecatedParser>,
         Single<DoNotRecommendParser>,
         Single<ExportNameParser>,
+        Single<ExportVisibilityParser>,
         Single<IgnoreParser>,
         Single<InlineParser>,
         Single<InstructionSetParser>,

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -1,6 +1,7 @@
 use rustc_abi::{Align, ExternAbi};
 use rustc_hir::attrs::{
-    AttributeKind, EiiImplResolution, InlineAttr, Linkage, RtsanSetting, UsedBy,
+    AttributeKind, EiiImplResolution, ExportVisibilityAttrValue, InlineAttr, Linkage, RtsanSetting,
+    UsedBy,
 };
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LOCAL_CRATE, LocalDefId};
@@ -70,6 +71,13 @@ fn process_builtin_attrs(
         match attr {
             AttributeKind::Cold(_) => codegen_fn_attrs.flags |= CodegenFnAttrFlags::COLD,
             AttributeKind::ExportName { name, .. } => codegen_fn_attrs.symbol_name = Some(*name),
+            AttributeKind::ExportVisibility { visibility, .. } => {
+                codegen_fn_attrs.export_visibility = Some(match visibility {
+                    ExportVisibilityAttrValue::TargetDefault => {
+                        tcx.sess.default_visibility().into()
+                    }
+                });
+            }
             AttributeKind::Inline(inline, span) => {
                 codegen_fn_attrs.inline = *inline;
                 interesting_spans.inline = Some(*span);
@@ -532,6 +540,16 @@ fn handle_lang_items(
                 ))
         }
         err.emit();
+    }
+
+    if codegen_fn_attrs.export_visibility.is_some() {
+        let span = find_attr!(attrs, ExportVisibility{span, ..} => *span).unwrap_or_default();
+        if codegen_fn_attrs.flags.contains(CodegenFnAttrFlags::RUSTC_STD_INTERNAL_SYMBOL) {
+            tcx.dcx().emit_err(errors::ExportVisibilityWithRustcStdInternalSymbol { span });
+        }
+        if !codegen_fn_attrs.contains_extern_indicator() {
+            tcx.dcx().emit_err(errors::ExportVisibilityWithoutNoMangleNorExportName { span });
+        }
     }
 }
 

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -1268,3 +1268,20 @@ pub(crate) struct LtoProcMacro;
 #[diag("cannot prefer dynamic linking when performing LTO")]
 #[note("only 'staticlib', 'bin', and 'cdylib' outputs are supported with LTO")]
 pub(crate) struct DynamicLinkingWithLTO;
+
+#[derive(Diagnostic)]
+#[diag("`#[export_visibility = ...]` cannot be used on internal language items")]
+pub(crate) struct ExportVisibilityWithRustcStdInternalSymbol {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(
+    "`#[export_visibility = ...]` will be ignored \
+     without `export_name`, `no_mangle`, or similar attribute"
+)]
+pub(crate) struct ExportVisibilityWithoutNoMangleNorExportName {
+    #[primary_span]
+    pub span: Span,
+}

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -649,6 +649,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         template!(NameValueStr: "name", "https://doc.rust-lang.org/reference/abi.html#the-export_name-attribute"),
         FutureWarnPreceding, EncodeCrossCrate::No
     ),
+    gated!(export_visibility, Normal, template!(NameValueStr: "visibility"), ErrorPreceding, EncodeCrossCrate::No, experimental!(export_visibility)),
     ungated!(
         unsafe(Edition2024) link_section, Normal,
         template!(NameValueStr: "name", "https://doc.rust-lang.org/reference/abi.html#the-link_section-attribute"),

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -474,6 +474,8 @@ declare_features! (
     (incomplete, explicit_tail_calls, "1.72.0", Some(112788)),
     /// Allows using `#[export_stable]` which indicates that an item is exportable.
     (incomplete, export_stable, "1.88.0", Some(139939)),
+    /// Allows `#[export_visibility]` on definitions of statics and/or functions.
+    (unstable, export_visibility, "CURRENT_RUSTC_VERSION", Some(151425)),
     /// Externally implementable items
     (unstable, extern_item_impls, "1.94.0", Some(125418)),
     /// Allows defining `extern type`s.

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -251,6 +251,15 @@ impl Deprecation {
     }
 }
 
+/// Pre-parsed value of `#[export_visibility = ...]` attribute.
+///
+/// In a future RFC we may consider adding support for `Hidden`, `Protected`, and/or
+/// `Interposable`.
+#[derive(Clone, Copy, Debug, HashStable_Generic, Encodable, Decodable, PrintAttribute)]
+pub enum ExportVisibilityAttrValue {
+    TargetDefault,
+}
+
 /// There are three valid forms of the attribute:
 /// `#[used]`, which is equivalent to `#[used(linker)]` on targets that support it, but `#[used(compiler)]` if not.
 /// `#[used(compiler)]`
@@ -1044,6 +1053,12 @@ pub enum AttributeKind {
 
     /// Represents `#[export_stable]`.
     ExportStable,
+
+    /// Represents [`#[export_visibility = ...]`](https://github.com/rust-lang/rust/issues/151425)
+    ExportVisibility {
+        visibility: ExportVisibilityAttrValue,
+        span: Span,
+    },
 
     /// Represents `#[feature(...)]`
     Feature(ThinVec<Ident>, Span),

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -43,6 +43,7 @@ impl AttributeKind {
             EiiImpls(..) => No,
             ExportName { .. } => Yes,
             ExportStable => No,
+            ExportVisibility { .. } => Yes,
             Feature(..) => No,
             FfiConst(..) => No,
             FfiPure(..) => No,

--- a/compiler/rustc_infer/src/infer/lexical_region_resolve/indexed_edges.rs
+++ b/compiler/rustc_infer/src/infer/lexical_region_resolve/indexed_edges.rs
@@ -1,0 +1,68 @@
+use rustc_index::IndexVec;
+use rustc_type_ir::RegionVid;
+
+use crate::infer::SubregionOrigin;
+use crate::infer::region_constraints::{Constraint, ConstraintKind, RegionConstraintData};
+
+/// Selects either out-edges or in-edges for [`IndexedConstraintEdges::adjacent_edges`].
+#[derive(Clone, Copy, Debug)]
+pub(super) enum EdgeDirection {
+    Out,
+    In,
+}
+
+/// Type alias for the pairs stored in [`RegionConstraintData::constraints`],
+/// which we are indexing.
+type ConstraintPair<'tcx> = (Constraint<'tcx>, SubregionOrigin<'tcx>);
+
+/// An index from region variables to their corresponding constraint edges,
+/// used on some error paths.
+pub(super) struct IndexedConstraintEdges<'data, 'tcx> {
+    out_edges: IndexVec<RegionVid, Vec<&'data ConstraintPair<'tcx>>>,
+    in_edges: IndexVec<RegionVid, Vec<&'data ConstraintPair<'tcx>>>,
+}
+
+impl<'data, 'tcx> IndexedConstraintEdges<'data, 'tcx> {
+    pub(super) fn build_index(num_vars: usize, data: &'data RegionConstraintData<'tcx>) -> Self {
+        let mut out_edges = IndexVec::from_fn_n(|_| vec![], num_vars);
+        let mut in_edges = IndexVec::from_fn_n(|_| vec![], num_vars);
+
+        for pair @ (c, _) in &data.constraints {
+            // Only push a var out-edge for `VarSub...` constraints.
+            match c.kind {
+                ConstraintKind::VarSubVar | ConstraintKind::VarSubReg => {
+                    out_edges[c.sub.as_var()].push(pair)
+                }
+                ConstraintKind::RegSubVar | ConstraintKind::RegSubReg => {}
+            }
+        }
+
+        // Index in-edges in reverse order, to match what current tests expect.
+        // (It's unclear whether this is important or not.)
+        for pair @ (c, _) in data.constraints.iter().rev() {
+            // Only push a var in-edge for `...SubVar` constraints.
+            match c.kind {
+                ConstraintKind::VarSubVar | ConstraintKind::RegSubVar => {
+                    in_edges[c.sup.as_var()].push(pair)
+                }
+                ConstraintKind::VarSubReg | ConstraintKind::RegSubReg => {}
+            }
+        }
+
+        IndexedConstraintEdges { out_edges, in_edges }
+    }
+
+    /// Returns either the out-edges or in-edges of the specified region var,
+    /// as selected by `dir`.
+    pub(super) fn adjacent_edges(
+        &self,
+        region_vid: RegionVid,
+        dir: EdgeDirection,
+    ) -> &[&'data ConstraintPair<'tcx>] {
+        let edges = match dir {
+            EdgeDirection::Out => &self.out_edges,
+            EdgeDirection::In => &self.in_edges,
+        };
+        &edges[region_vid]
+    }
+}

--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -300,7 +300,7 @@ internal compiler error: query cycle handler thread panicked, aborting process";
                     diag.help(
                         "try lowering `-Z threads` or checking the operating system's resource limits",
                     );
-                    diag.emit();
+                    diag.emit()
                 })
         })
     })

--- a/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
+++ b/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
@@ -79,6 +79,12 @@ pub struct CodegenFnAttrs {
     /// be set when `link_name` is set. This is for foreign items with the
     /// "raw-dylib" kind.
     pub link_ordinal: Option<u16>,
+    /// The `#[export_visibility = "..."]` attribute, with values interpreted
+    /// as follows:
+    /// * `None` - use the "inherent" visibility (either based on the target platform, or provided via
+    ///   `-Zdefault-visibility=...` command-line flag)
+    /// * `Some(...)` - use the item/symbol-specific visibility
+    pub export_visibility: Option<Visibility>,
     /// The `#[target_feature(enable = "...")]` attribute and the enabled
     /// features (only enabled features are supported right now).
     /// Implied target features have already been applied.
@@ -224,6 +230,7 @@ impl CodegenFnAttrs {
             optimize: OptimizeAttr::Default,
             symbol_name: None,
             link_ordinal: None,
+            export_visibility: None,
             target_features: vec![],
             foreign_item_symbol_aliases: vec![],
             safe_target_features: false,

--- a/compiler/rustc_monomorphize/src/partitioning.rs
+++ b/compiler/rustc_monomorphize/src/partitioning.rs
@@ -931,6 +931,11 @@ fn mono_item_visibility<'tcx>(
 }
 
 fn default_visibility(tcx: TyCtxt<'_>, id: DefId, is_generic: bool) -> Visibility {
+    // If present, then symbol-specific `#[export_visibility = ...]` "wins".
+    if let Some(visibility) = tcx.codegen_fn_attrs(id).export_visibility {
+        return visibility;
+    }
+
     // Fast-path to avoid expensive query call below
     if tcx.sess.default_visibility() == SymbolVisibility::Interposable {
         return Visibility::Default;

--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -132,7 +132,7 @@ pub fn new_parser_from_file<'a>(
         if let Some(sp) = sp {
             err.span(sp);
         }
-        err.emit();
+        err.emit()
     });
     new_parser_from_source_file(psess, source_file, strip_tokens)
 }

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -254,6 +254,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     | AttributeKind::EiiDeclaration { .. }
                     | AttributeKind::ExportName { .. }
                     | AttributeKind::ExportStable
+                    | AttributeKind::ExportVisibility { .. }
                     | AttributeKind::Feature(..)
                     | AttributeKind::FfiConst(..)
                     | AttributeKind::Fundamental

--- a/compiler/rustc_public/src/crate_def.rs
+++ b/compiler/rustc_public/src/crate_def.rs
@@ -2,7 +2,7 @@
 //! such as, a function, a trait, an enum, and any other definitions.
 
 use crate::ty::{GenericArgs, Span, Ty, index_impl};
-use crate::{AssocItems, Crate, Symbol, ThreadLocalIndex, with};
+use crate::{Crate, Symbol, ThreadLocalIndex, with};
 
 /// A unique identification number for each item accessible for the current compilation unit.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
@@ -108,14 +108,6 @@ pub trait CrateDefType: CrateDef {
     }
 }
 
-/// A trait for retrieving all items from a definition within a crate.
-pub trait CrateDefItems: CrateDef {
-    /// Retrieve all associated items from a definition.
-    fn associated_items(&self) -> AssocItems {
-        with(|cx| cx.associated_items(self.def_id()))
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Attribute {
     value: String,
@@ -169,11 +161,5 @@ macro_rules! crate_def_with_ty {
         }
 
         impl CrateDefType for $name {}
-    };
-}
-
-macro_rules! impl_crate_def_items {
-    ( $name:ident $(;)? ) => {
-        impl CrateDefItems for $name {}
     };
 }

--- a/compiler/rustc_public/src/lib.rs
+++ b/compiler/rustc_public/src/lib.rs
@@ -30,7 +30,7 @@ pub mod rustc_internal;
 use serde::Serialize;
 
 use crate::compiler_interface::with;
-pub use crate::crate_def::{CrateDef, CrateDefItems, CrateDefType, DefId};
+pub use crate::crate_def::{CrateDef, CrateDefType, DefId};
 pub use crate::error::*;
 use crate::mir::mono::StaticDef;
 use crate::mir::{Body, Mutability};

--- a/compiler/rustc_public/src/lib.rs
+++ b/compiler/rustc_public/src/lib.rs
@@ -238,35 +238,40 @@ pub fn opaque<T: Debug>(value: &T) -> Opaque {
 }
 
 macro_rules! bridge_impl {
-    ($name: ident, $ty: ty) => {
-        impl rustc_public_bridge::bridge::$name<compiler_interface::BridgeTys> for $ty {
-            fn new(def: crate::DefId) -> Self {
-                Self(def)
+    ( $( $name:ident, $ty:ty ),* $(,)? ) => {
+        $(
+            impl rustc_public_bridge::bridge::$name<compiler_interface::BridgeTys> for $ty {
+                fn new(def: crate::DefId) -> Self {
+                    Self(def)
+                }
             }
-        }
+        )*
     };
 }
 
-bridge_impl!(CrateItem, crate::CrateItem);
-bridge_impl!(AdtDef, crate::ty::AdtDef);
-bridge_impl!(ForeignModuleDef, crate::ty::ForeignModuleDef);
-bridge_impl!(ForeignDef, crate::ty::ForeignDef);
-bridge_impl!(FnDef, crate::ty::FnDef);
-bridge_impl!(ClosureDef, crate::ty::ClosureDef);
-bridge_impl!(CoroutineDef, crate::ty::CoroutineDef);
-bridge_impl!(CoroutineClosureDef, crate::ty::CoroutineClosureDef);
-bridge_impl!(AliasDef, crate::ty::AliasDef);
-bridge_impl!(ParamDef, crate::ty::ParamDef);
-bridge_impl!(BrNamedDef, crate::ty::BrNamedDef);
-bridge_impl!(TraitDef, crate::ty::TraitDef);
-bridge_impl!(GenericDef, crate::ty::GenericDef);
-bridge_impl!(ConstDef, crate::ty::ConstDef);
-bridge_impl!(ImplDef, crate::ty::ImplDef);
-bridge_impl!(RegionDef, crate::ty::RegionDef);
-bridge_impl!(CoroutineWitnessDef, crate::ty::CoroutineWitnessDef);
-bridge_impl!(AssocDef, crate::ty::AssocDef);
-bridge_impl!(OpaqueDef, crate::ty::OpaqueDef);
-bridge_impl!(StaticDef, crate::mir::mono::StaticDef);
+#[rustfmt::skip]
+bridge_impl!(
+    CrateItem,           crate::CrateItem,
+    AdtDef,              crate::ty::AdtDef,
+    ForeignModuleDef,    crate::ty::ForeignModuleDef,
+    ForeignDef,          crate::ty::ForeignDef,
+    FnDef,               crate::ty::FnDef,
+    ClosureDef,          crate::ty::ClosureDef,
+    CoroutineDef,        crate::ty::CoroutineDef,
+    CoroutineClosureDef, crate::ty::CoroutineClosureDef,
+    AliasDef,            crate::ty::AliasDef,
+    ParamDef,            crate::ty::ParamDef,
+    BrNamedDef,          crate::ty::BrNamedDef,
+    TraitDef,            crate::ty::TraitDef,
+    GenericDef,          crate::ty::GenericDef,
+    ConstDef,            crate::ty::ConstDef,
+    ImplDef,             crate::ty::ImplDef,
+    RegionDef,           crate::ty::RegionDef,
+    CoroutineWitnessDef, crate::ty::CoroutineWitnessDef,
+    AssocDef,            crate::ty::AssocDef,
+    OpaqueDef,           crate::ty::OpaqueDef,
+    StaticDef,           crate::mir::mono::StaticDef
+);
 
 impl rustc_public_bridge::bridge::Prov<compiler_interface::BridgeTys> for crate::ty::Prov {
     fn new(aid: crate::mir::alloc::AllocId) -> Self {

--- a/compiler/rustc_public/src/ty.rs
+++ b/compiler/rustc_public/src/ty.rs
@@ -7,11 +7,11 @@ use super::abi::ReprOptions;
 use super::mir::{Body, Mutability, Safety};
 use super::{DefId, Error, Symbol, with};
 use crate::abi::{FnAbi, Layout};
-use crate::crate_def::{CrateDef, CrateDefItems, CrateDefType};
+use crate::crate_def::{CrateDef, CrateDefType};
 use crate::mir::alloc::{AllocId, read_target_int, read_target_uint};
 use crate::mir::mono::StaticDef;
 use crate::target::MachineInfo;
-use crate::{Filename, IndexedVal, Opaque, ThreadLocalIndex};
+use crate::{AssocItems, Filename, IndexedVal, Opaque, ThreadLocalIndex};
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Ty(usize, ThreadLocalIndex);
@@ -952,13 +952,13 @@ crate_def! {
     pub TraitDef;
 }
 
-impl_crate_def_items! {
-    TraitDef;
-}
-
 impl TraitDef {
     pub fn declaration(trait_def: &TraitDef) -> TraitDecl {
         with(|cx| cx.trait_decl(trait_def))
+    }
+
+    pub fn associated_items(&self) -> AssocItems {
+        with(|cx| cx.associated_items(self.def_id()))
     }
 }
 
@@ -978,14 +978,14 @@ crate_def! {
     pub ImplDef;
 }
 
-impl_crate_def_items! {
-    ImplDef;
-}
-
 impl ImplDef {
     /// Retrieve information about this implementation.
     pub fn trait_impl(&self) -> ImplTrait {
         with(|cx| cx.trait_impl(self))
+    }
+
+    pub fn associated_items(&self) -> AssocItems {
+        with(|cx| cx.associated_items(self.def_id()))
     }
 }
 

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -2504,7 +2504,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
 fn names_to_string(names: impl Iterator<Item = Symbol>) -> String {
     let mut result = String::new();
-    for (i, name) in names.filter(|name| *name != kw::PathRoot).enumerate() {
+    for (i, name) in names.enumerate().filter(|(_, name)| *name != kw::PathRoot) {
         if i > 0 {
             result.push_str("::");
         }

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1615,7 +1615,7 @@ pub fn build_target_config(
             let mut err =
                 early_dcx.early_struct_fatal(format!("error loading target specification: {e}"));
             err.help("run `rustc --print target-list` for a list of built-in targets");
-            err.emit();
+            err.emit()
         }
     }
 }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -907,6 +907,7 @@ symbols! {
         export_name,
         export_stable,
         export_symbols: "export-symbols",
+        export_visibility,
         expr,
         expr_2021,
         expr_fragment_specifier_2024,

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1488,12 +1488,13 @@ pub macro offset_of($Container:ty, $($fields:expr)+ $(,)?) {
 ///
 /// [inhabited]: https://doc.rust-lang.org/reference/glossary.html#inhabited
 #[unstable(feature = "mem_conjure_zst", issue = "95383")]
+#[rustc_const_unstable(feature = "mem_conjure_zst", issue = "95383")]
 pub const unsafe fn conjure_zst<T>() -> T {
     const_assert!(
         size_of::<T>() == 0,
-        "mem::conjure_zst invoked on a nonzero-sized type",
-        "mem::conjure_zst invoked on type {t}, which is not zero-sized",
-        t: &str = stringify!(T)
+        "mem::conjure_zst invoked on a non-zero-sized type",
+        "mem::conjure_zst invoked on type {name}, which is not zero-sized",
+        name: &str = crate::any::type_name::<T>()
     );
 
     // SAFETY: because the caller must guarantee that it's inhabited and zero-sized,

--- a/library/panic_unwind/src/lib.rs
+++ b/library/panic_unwind/src/lib.rs
@@ -14,6 +14,7 @@
 #![no_std]
 #![unstable(feature = "panic_unwind", issue = "32837")]
 #![doc(issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/")]
+#![cfg_attr(all(target_os = "emscripten", not(emscripten_wasm_eh)), lang_items)]
 #![feature(cfg_emscripten_wasm_eh)]
 #![feature(core_intrinsics)]
 #![feature(panic_unwind)]

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -712,28 +712,21 @@ pub fn temp_dir() -> PathBuf {
 ///
 /// # Security
 ///
-/// The output of this function should not be trusted for anything
-/// that might have security implications. Basically, if users can run
-/// the executable, they can change the output arbitrarily.
+/// The output of this function must be treated with care to avoid security
+/// vulnerabilities, particularly in processes that run with privileges higher
+/// than the user, such as setuid or setgid programs.
 ///
-/// As an example, you can easily introduce a race condition. It goes
-/// like this:
+/// For example, on some Unix platforms, the result is calculated by
+/// searching `$PATH` for an executable matching `argv[0]`, but both the
+/// environment and arguments can be be set arbitrarily by the user who
+/// invokes the program.
 ///
-/// 1. You get the path to the current executable using `current_exe()`, and
-///    store it in a variable.
-/// 2. Time passes. A malicious actor removes the current executable, and
-///    replaces it with a malicious one.
-/// 3. You then use the stored path to re-execute the current
-///    executable.
+/// On Linux, if `fs.secure_hardlinks` is not set, an attacker who can
+/// create hardlinks to the executable may be able to cause this function
+/// to return an attacker-controlled path, which they later replace with
+/// a different program.
 ///
-/// You expected to safely execute the current executable, but you're
-/// instead executing something completely different. The code you
-/// just executed runs with your privileges.
-///
-/// This sort of behavior has been known to [lead to privilege escalation] when
-/// used incorrectly.
-///
-/// [lead to privilege escalation]: https://securityvulns.com/Wdocument183.html
+/// This list of illustrative example attacks is not exhaustive.
 ///
 /// # Examples
 ///

--- a/src/bootstrap/download-ci-llvm-stamp
+++ b/src/bootstrap/download-ci-llvm-stamp
@@ -1,4 +1,4 @@
 Change this file to make users of the `download-ci-llvm` configuration download
 a new version of LLVM from CI, even if the LLVM submodule hasn’t changed.
 
-Last change is for: https://github.com/rust-lang/rust/pull/147935
+Last change is for: https://github.com/rust-lang/rust/pull/153179

--- a/src/tools/run-make-support/Cargo.toml
+++ b/src/tools/run-make-support/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2024"
 bstr = "1.12"
 gimli = "0.32"
 libc = "0.2"
-object = "0.37"
+object = { version = "0.37", features = ["read", "compression", "wasm"] }
 regex = "1.11"
 serde_json = "1.0"
 similar = "2.7"

--- a/src/tools/run-make-support/src/artifact_names.rs
+++ b/src/tools/run-make-support/src/artifact_names.rs
@@ -2,7 +2,7 @@
 //! libraries which are target-dependent.
 
 use crate::target;
-use crate::targets::is_windows_msvc;
+use crate::targets::{is_wasi, is_windows, is_windows_msvc};
 
 /// Construct the static library name based on the target.
 #[track_caller]
@@ -22,18 +22,24 @@ pub fn dynamic_lib_name(name: &str) -> String {
     format!("{}{name}.{}", dynamic_lib_prefix(), dynamic_lib_extension())
 }
 
+/// Returns the value of `DLL_PREFIX` from `library/std/src/sys/env_consts.rs`
+/// for the target platform indicated by `crate::target()`.
 fn dynamic_lib_prefix() -> &'static str {
-    if target().contains("windows") { "" } else { "lib" }
+    // FIXME: Cover more exotic platform like `uefi`.
+    if is_wasi() || is_windows() { "" } else { "lib" }
 }
 
-/// Construct the dynamic library extension based on the target.
+/// Returns the value of `DLL_EXTENSION` from `library/std/src/sys/env_consts.rs`
+/// for the target platform indicated by `crate::target()`.
 #[must_use]
 pub fn dynamic_lib_extension() -> &'static str {
+    // FIXME: Cover more exotic platform like `uefi`.
     let target = target();
-
     if target.contains("apple") {
         "dylib"
-    } else if target.contains("windows") {
+    } else if is_wasi() {
+        "wasm"
+    } else if is_windows() {
         "dll"
     } else if target.contains("aix") {
         "a"

--- a/src/tools/run-make-support/src/targets.rs
+++ b/src/tools/run-make-support/src/targets.rs
@@ -34,6 +34,20 @@ pub fn is_win7() -> bool {
     target().contains("win7")
 }
 
+/// Check if target uses WASI
+pub fn is_wasi() -> bool {
+    // The condition below is roughly equivalent to the following `cfg`
+    // attribute from `library/std/src/sys/env_consts.rs`.
+    //
+    // ```
+    // #[cfg(all(
+    //      target_family = "wasm",
+    //      not(any(target_os = "emscripten", target_os = "linux"))
+    // ))]
+    // ```
+    target().starts_with("wasm") && !target().contains("linux") && !target().contains("emscripten")
+}
+
 /// Check if target uses macOS.
 #[must_use]
 pub fn is_darwin() -> bool {

--- a/tests/codegen-llvm/export-visibility.rs
+++ b/tests/codegen-llvm/export-visibility.rs
@@ -1,0 +1,102 @@
+// Verifies that `#[export_visibility = ...]` can override the visibility
+// that is normally implied by `#[export_name]` or `#[no_mangle]`.
+//
+// High-level test expectations for items with `#[export_name = ...]`
+// (or with `#[no_mangle]`) and:
+//
+// * Without `#[export_visibility = ...]` => public
+// * `#[export_visibility = "target_default"]` => value inherited from the target
+//   platform or from the `-Zdefault-visibility=...` command-line flag
+//   (this expectation depends on whether the `...-HIDDEN` vs `...-PROTECTED`
+//   test revisions are used).
+//
+// Note that what we call "public" in the expectations above is also referred
+// to as "default" in LLVM docs - see
+// https://llvm.org/docs/LangRef.html#visibility-styles
+
+//@ revisions: LINUX-X86-HIDDEN LINUX-X86-PROTECTED
+//@[LINUX-X86-HIDDEN] compile-flags: -Zdefault-visibility=hidden
+//@[LINUX-X86-PROTECTED] compile-flags: -Zdefault-visibility=protected
+
+// Exact LLVM IR differs depending on the target triple (e.g. `hidden constant`
+// vs `internal constant` vs `constant`).  Because of this, we only apply the
+// specific test expectations below to one specific target triple.
+//
+// Note that `tests/run-make/cdylib-export-visibility` provides similar
+// test coverage, but in an LLVM-IR-agnostic / platform-agnostic way.
+//@[LINUX-X86-HIDDEN] needs-llvm-components: x86
+//@[LINUX-X86-HIDDEN] compile-flags: --target x86_64-unknown-linux-gnu
+//@[LINUX-X86-PROTECTED] needs-llvm-components: x86
+//@[LINUX-X86-PROTECTED] compile-flags: --target x86_64-unknown-linux-gnu
+
+// This test focuses on rlib to exercise the scenario described in
+// https://github.com/rust-lang/rust/issues/73958#issuecomment-2891711649
+#![crate_type = "rlib"]
+#![feature(export_visibility)]
+// Relying on `minicore` makes it easier to run the test, even if the host is
+// not a linux-x86 machine.
+//@ add-minicore
+//@ edition: 2024
+#![feature(no_core)]
+#![no_core]
+use minicore::*;
+
+///////////////////////////////////////////////////////////////////////
+// The tests below focus on how `#[export_visibility = ...]` works for
+// a `static`.  The tests are based on similar tests in
+// `tests/codegen/default-visibility.rs`
+
+#[unsafe(export_name = "static_export_name_no_attr")]
+pub static TEST_STATIC_NO_ATTR: u32 = 1101;
+
+#[unsafe(export_name = "static_export_name_target_default")]
+#[export_visibility = "target_default"]
+pub static TESTED_STATIC_ATTR_ASKS_TO_TARGET_DEFAULT: u32 = 1102;
+
+#[unsafe(no_mangle)]
+pub static static_no_mangle_no_attr: u32 = 1201;
+
+#[unsafe(no_mangle)]
+#[export_visibility = "target_default"]
+pub static static_no_mangle_target_default: u32 = 1202;
+
+// LINUX-X86-HIDDEN: @static_export_name_no_attr = local_unnamed_addr constant
+// LINUX-X86-HIDDEN: @static_export_name_target_default = hidden local_unnamed_addr constant
+// LINUX-X86-HIDDEN: @static_no_mangle_no_attr = local_unnamed_addr constant
+// LINUX-X86-HIDDEN: @static_no_mangle_target_default = hidden local_unnamed_addr constant
+
+// LINUX-X86-PROTECTED: @static_export_name_no_attr = local_unnamed_addr constant
+// LINUX-X86-PROTECTED: @static_export_name_target_default = protected local_unnamed_addr constant
+// LINUX-X86-PROTECTED: @static_no_mangle_no_attr = local_unnamed_addr constant
+// LINUX-X86-PROTECTED: @static_no_mangle_target_default = protected local_unnamed_addr constant
+
+///////////////////////////////////////////////////////////////////////
+// The tests below focus on how `#[export_visibility = ...]` works for
+// a `fn`.
+//
+// The tests below try to mimics how `cxx` exports known/hardcoded helpers (e.g.
+// `cxxbridge1$string$drop` [1]) as well as build-time-generated thunks (e.g.
+// `serde_json_lenient$cxxbridge1$decode_json` from https://crbug.com/418073233#comment7).
+//
+// [1]
+// https://github.com/dtolnay/cxx/blob/ebdd6a0c63ae10dc5224ed21970b7a0504657434/src/symbols/rust_string.rs#L83-L86
+
+#[unsafe(export_name = "test_fn_no_attr")]
+unsafe extern "C" fn test_fn_no_attr() -> u32 {
+    // We return a unique integer to ensure that each function has a unique body
+    // and therefore that identical code folding (ICF) won't fold the functions
+    // when linking.
+    2001
+}
+
+#[unsafe(export_name = "test_fn_target_default")]
+#[export_visibility = "target_default"]
+unsafe extern "C" fn test_fn_asks_for_target_default() -> u32 {
+    2002
+}
+
+// LINUX-X86-HIDDEN: define noundef i32 @test_fn_no_attr
+// LINUX-X86-HIDDEN: define hidden noundef i32 @test_fn_target_default
+
+// LINUX-X86-PROTECTED: define noundef i32 @test_fn_no_attr
+// LINUX-X86-PROTECTED: define protected noundef i32 @test_fn_target_default

--- a/tests/run-make/cdylib-export-visibility/foo.rs
+++ b/tests/run-make/cdylib-export-visibility/foo.rs
@@ -1,0 +1,29 @@
+#![crate_type = "cdylib"]
+#![feature(export_visibility)]
+// `no_std` makes it slightly easier to run the test when cross-compiling.
+// Ideally the test would use `no_core`, but `//@ add-minicore` doesn't seem
+// to work...
+#![no_std]
+//@ edition: 2024
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn test_fn_no_export_visibility_attribute() -> u32 {
+    // Using unique integer means that the functions return different results
+    // and therefore identical code folding (ICF) in the linker won't apply.
+    16 // line number;  can't use `line!` with `no_core`
+}
+
+#[unsafe(no_mangle)]
+#[export_visibility = "target_default"]
+unsafe extern "C" fn test_fn_export_visibility_asks_for_target_default() -> u32 {
+    // Using unique integer means that the functions return different results
+    // and therefore identical code folding (ICF) in the linker won't apply.
+    24 // line number;  can't use `line!` with `no_core`
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    // The infinite loop should never run - we only look at symbol visibilities
+    // of `test_fn_...` above.
+    loop {}
+}

--- a/tests/run-make/cdylib-export-visibility/rmake.rs
+++ b/tests/run-make/cdylib-export-visibility/rmake.rs
@@ -1,0 +1,87 @@
+// This test builds `foo.rs` into a `cdylib` and verifies that
+// `#[export_visibility = ...]` affects visibility of symbols.
+//
+// This test is loosely based on manual test steps described when
+// discussing the related RFC at:
+// https://github.com/rust-lang/rfcs/pull/3834#issuecomment-3403039933
+
+//@ needs-crate-type: cdylib
+//@ needs-dynamic-linking
+
+// See https://github.com/rust-lang/rust/pull/151431#issuecomment-3923604898
+// and earlier comments that explain the problems encountered when attempting
+// to enable this test for WASM.
+//@ ignore-wasm
+
+// See https://github.com/rust-lang/rust/pull/151431#issuecomment-3923203589
+// for why this test skips `nvptx64-nvidia-cuda` and similar targets.
+//@ ignore-nvptx64
+
+use std::collections::HashSet;
+
+use run_make_support::symbols::exported_dynamic_symbol_names;
+use run_make_support::targets::is_wasi;
+use run_make_support::{dynamic_lib_name, object, rustc};
+
+struct TestCase {
+    name: &'static str,
+    extra_rustc_arg: Option<&'static str>,
+    expected_exported_symbols: &'static [&'static str],
+    expected_private_symbols: &'static [&'static str],
+}
+
+impl TestCase {
+    fn run(&self) {
+        let test_name = self.name;
+
+        let mut rustc = rustc();
+        rustc.input("foo.rs");
+        rustc.arg("-Cpanic=abort");
+        if let Some(extra_arg) = self.extra_rustc_arg {
+            rustc.arg(extra_arg);
+        }
+        rustc.run();
+
+        let lib_path = dynamic_lib_name("foo");
+        let object_file_bytes = std::fs::read(&lib_path)
+            .unwrap_or_else(|e| panic!("{test_name}: failed to read `{lib_path}`: {e}"));
+        let object_file = object::File::parse(object_file_bytes.as_slice())
+            .unwrap_or_else(|e| panic!("{test_name}: failed to parse `{lib_path}`: {e}"));
+        let actual_exported_symbols =
+            exported_dynamic_symbol_names(&object_file).into_iter().collect::<HashSet<_>>();
+
+        for s in self.expected_exported_symbols {
+            assert!(
+                actual_exported_symbols.contains(s),
+                "{test_name}: Expecting `{s}` to be an actually exported symbol in `{lib_path}`",
+            );
+        }
+        for s in self.expected_private_symbols {
+            assert!(
+                !actual_exported_symbols.contains(s),
+                "{test_name}: Expecting `{s}` to *not* be exported from `{lib_path}`",
+            );
+        }
+    }
+}
+
+fn main() {
+    TestCase {
+        name: "Test #1",
+        extra_rustc_arg: Some("-Zdefault-visibility=hidden"),
+        expected_exported_symbols: &["test_fn_no_export_visibility_attribute"],
+        expected_private_symbols: &["test_fn_export_visibility_asks_for_target_default"],
+    }
+    .run();
+
+    TestCase {
+        name: "Test #2",
+        extra_rustc_arg: None,
+        expected_exported_symbols: &[
+            "test_fn_no_export_visibility_attribute",
+            "test_fn_export_visibility_asks_for_target_default",
+        ],
+        expected_private_symbols: &[],
+    }
+    .run();
+}

--- a/tests/ui/attributes/export-visibility-with-rustc-std-internal-symbol.rs
+++ b/tests/ui/attributes/export-visibility-with-rustc-std-internal-symbol.rs
@@ -1,0 +1,11 @@
+// This test verfies that `#[export_visibility = ...]` will report an error
+// when applied to an item that also has `#[rustc_std_internal_symbol]`
+// attribute.
+#![feature(export_visibility)]
+#![feature(rustc_attrs)]
+#[export_visibility = "target_default"]
+//~^ERROR: #[export_visibility = ...]` cannot be used on internal language items
+#[rustc_std_internal_symbol]
+pub static TESTED_STATIC: [u8; 6] = *b"foobar";
+
+fn main() {}

--- a/tests/ui/attributes/export-visibility-with-rustc-std-internal-symbol.stderr
+++ b/tests/ui/attributes/export-visibility-with-rustc-std-internal-symbol.stderr
@@ -1,0 +1,8 @@
+error: `#[export_visibility = ...]` cannot be used on internal language items
+  --> $DIR/export-visibility-with-rustc-std-internal-symbol.rs:6:1
+   |
+LL | #[export_visibility = "target_default"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/attributes/export-visibility-with-unrecognized-arg.rs
+++ b/tests/ui/attributes/export-visibility-with-unrecognized-arg.rs
@@ -1,0 +1,34 @@
+// This test verfies that `#[export_visibility = ...]` will report an error
+// when the argument cannot be parsed.
+#![feature(export_visibility)]
+#[no_mangle]
+#[export_visibility = "unrecognized visibility value"]
+//~^ ERROR: malformed `export_visibility` attribute input
+pub static TESTED_STATIC: [u8; 6] = *b"foobar";
+
+// The following `static`s verify that `hidden`, `protected`, and `interposable`
+// are not supported yet.
+#[no_mangle]
+#[export_visibility = "hidden"]
+//~^ ERROR: malformed `export_visibility` attribute input
+pub static TESTED_STATIC_HIDDEN: [u8; 6] = *b"foobar";
+#[no_mangle]
+#[export_visibility = "protected"]
+//~^ ERROR: malformed `export_visibility` attribute input
+pub static TESTED_STATIC_PROTECTED: [u8; 6] = *b"foobar";
+#[no_mangle]
+#[export_visibility = "interposable"]
+//~^ ERROR: malformed `export_visibility` attribute input
+pub static TESTED_STATIC_INTERPOSABLE: [u8; 6] = *b"foobar";
+
+// The following `static`s verify that other visibility spellings are also not supported.
+#[no_mangle]
+#[export_visibility = "default"]
+//~^ ERROR: malformed `export_visibility` attribute input
+pub static TESTED_STATIC_DEFAULT: [u8; 6] = *b"foobar";
+#[no_mangle]
+#[export_visibility = "public"]
+//~^ ERROR: malformed `export_visibility` attribute input
+pub static TESTED_STATIC_PUBLIC: [u8; 6] = *b"foobar";
+
+fn main() {}

--- a/tests/ui/attributes/export-visibility-with-unrecognized-arg.stderr
+++ b/tests/ui/attributes/export-visibility-with-unrecognized-arg.stderr
@@ -1,0 +1,57 @@
+error[E0539]: malformed `export_visibility` attribute input
+  --> $DIR/export-visibility-with-unrecognized-arg.rs:5:1
+   |
+LL | #[export_visibility = "unrecognized visibility value"]
+   | ^^^^^^^^^^^^^^^^^^^^^^-------------------------------^
+   | |                     |
+   | |                     the only valid argument here is "target_default"
+   | help: must be of the form: `#[export_visibility = "visibility"]`
+
+error[E0539]: malformed `export_visibility` attribute input
+  --> $DIR/export-visibility-with-unrecognized-arg.rs:12:1
+   |
+LL | #[export_visibility = "hidden"]
+   | ^^^^^^^^^^^^^^^^^^^^^^--------^
+   | |                     |
+   | |                     the only valid argument here is "target_default"
+   | help: must be of the form: `#[export_visibility = "visibility"]`
+
+error[E0539]: malformed `export_visibility` attribute input
+  --> $DIR/export-visibility-with-unrecognized-arg.rs:16:1
+   |
+LL | #[export_visibility = "protected"]
+   | ^^^^^^^^^^^^^^^^^^^^^^-----------^
+   | |                     |
+   | |                     the only valid argument here is "target_default"
+   | help: must be of the form: `#[export_visibility = "visibility"]`
+
+error[E0539]: malformed `export_visibility` attribute input
+  --> $DIR/export-visibility-with-unrecognized-arg.rs:20:1
+   |
+LL | #[export_visibility = "interposable"]
+   | ^^^^^^^^^^^^^^^^^^^^^^--------------^
+   | |                     |
+   | |                     the only valid argument here is "target_default"
+   | help: must be of the form: `#[export_visibility = "visibility"]`
+
+error[E0539]: malformed `export_visibility` attribute input
+  --> $DIR/export-visibility-with-unrecognized-arg.rs:26:1
+   |
+LL | #[export_visibility = "default"]
+   | ^^^^^^^^^^^^^^^^^^^^^^---------^
+   | |                     |
+   | |                     the only valid argument here is "target_default"
+   | help: must be of the form: `#[export_visibility = "visibility"]`
+
+error[E0539]: malformed `export_visibility` attribute input
+  --> $DIR/export-visibility-with-unrecognized-arg.rs:30:1
+   |
+LL | #[export_visibility = "public"]
+   | ^^^^^^^^^^^^^^^^^^^^^^--------^
+   | |                     |
+   | |                     the only valid argument here is "target_default"
+   | help: must be of the form: `#[export_visibility = "visibility"]`
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0539`.

--- a/tests/ui/attributes/export-visibility-without-export-name.rs
+++ b/tests/ui/attributes/export-visibility-without-export-name.rs
@@ -1,0 +1,8 @@
+// This test verfies that `#[export_visibility = ...]` cannot be used without
+// either `#[export_name = ...]` or `#[no_mangle]`.
+#![feature(export_visibility)]
+#[export_visibility = "target_default"]
+//~^ ERROR: #[export_visibility = ...]` will be ignored
+pub static TESTED_STATIC: [u8; 6] = *b"foobar";
+
+fn main() {}

--- a/tests/ui/attributes/export-visibility-without-export-name.stderr
+++ b/tests/ui/attributes/export-visibility-without-export-name.stderr
@@ -1,0 +1,8 @@
+error: `#[export_visibility = ...]` will be ignored without `export_name`, `no_mangle`, or similar attribute
+  --> $DIR/export-visibility-without-export-name.rs:4:1
+   |
+LL | #[export_visibility = "target_default"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/feature-gates/feature-gate-export-visibility.rs
+++ b/tests/ui/feature-gates/feature-gate-export-visibility.rs
@@ -1,0 +1,11 @@
+// This test verfies that `#[export_visibility = ...]` cannot be used without
+// opting into the corresponding unstable feature via
+// `#![feature(export_visibility)]`.
+#[export_visibility = "target_default"]
+//~^ ERROR: the `#[export_visibility]` attribute is an experimental feature
+// `#[export_name = ...]` is present to avoid hitting the following error:
+// export visibility will be ignored without `export_name`, `no_mangle`, or similar attribute
+#[unsafe(export_name = "exported_static")]
+pub static TESTED_STATIC: [u8; 6] = *b"foobar";
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-export-visibility.stderr
+++ b/tests/ui/feature-gates/feature-gate-export-visibility.stderr
@@ -1,0 +1,13 @@
+error[E0658]: the `#[export_visibility]` attribute is an experimental feature
+  --> $DIR/feature-gate-export-visibility.rs:4:1
+   |
+LL | #[export_visibility = "target_default"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #151425 <https://github.com/rust-lang/rust/issues/151425> for more information
+   = help: add `#![feature(export_visibility)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/resolve/dot-notation-type-namespace-suggest-path-sep.rs
+++ b/tests/ui/resolve/dot-notation-type-namespace-suggest-path-sep.rs
@@ -35,9 +35,9 @@ fn main() {
 macro_rules! Type {
     () => {
         ::std::cell::Cell
-        //~^ ERROR expected value, found struct `std::cell::Cell`
-        //~| ERROR expected value, found struct `std::cell::Cell`
-        //~| ERROR expected value, found struct `std::cell::Cell`
+        //~^ ERROR expected value, found struct `::std::cell::Cell`
+        //~| ERROR expected value, found struct `::std::cell::Cell`
+        //~| ERROR expected value, found struct `::std::cell::Cell`
     };
     (alias) => {
         Alias

--- a/tests/ui/resolve/dot-notation-type-namespace-suggest-path-sep.stderr
+++ b/tests/ui/resolve/dot-notation-type-namespace-suggest-path-sep.stderr
@@ -70,7 +70,7 @@ LL -     let _ = foo.bar;
 LL +     let _ = foo::bar;
    |
 
-error[E0423]: expected value, found struct `std::cell::Cell`
+error[E0423]: expected value, found struct `::std::cell::Cell`
   --> $DIR/dot-notation-type-namespace-suggest-path-sep.rs:37:9
    |
 LL |         ::std::cell::Cell
@@ -86,7 +86,7 @@ LL -     Type!().get();
 LL +     <Type!()>::get();
    |
 
-error[E0423]: expected value, found struct `std::cell::Cell`
+error[E0423]: expected value, found struct `::std::cell::Cell`
   --> $DIR/dot-notation-type-namespace-suggest-path-sep.rs:37:9
    |
 LL |         ::std::cell::Cell
@@ -166,7 +166,7 @@ LL -         Vec.new
 LL +         Vec::new
    |
 
-error[E0423]: expected value, found struct `std::cell::Cell`
+error[E0423]: expected value, found struct `::std::cell::Cell`
   --> $DIR/dot-notation-type-namespace-suggest-path-sep.rs:37:9
    |
 LL |         ::std::cell::Cell

--- a/tests/ui/resolve/issue-100365.rs
+++ b/tests/ui/resolve/issue-100365.rs
@@ -15,8 +15,8 @@ fn main() {
 macro_rules! Trait {
     () => {
         ::std::iter::Iterator
-        //~^ ERROR expected value, found trait `std::iter::Iterator`
-        //~| ERROR expected value, found trait `std::iter::Iterator`
+        //~^ ERROR expected value, found trait `::std::iter::Iterator`
+        //~| ERROR expected value, found trait `::std::iter::Iterator`
     };
 }
 

--- a/tests/ui/resolve/issue-100365.stderr
+++ b/tests/ui/resolve/issue-100365.stderr
@@ -34,7 +34,7 @@ LL -     let _ = Into::<()>.into;
 LL +     let _ = Into::<()>::into;
    |
 
-error[E0423]: expected value, found trait `std::iter::Iterator`
+error[E0423]: expected value, found trait `::std::iter::Iterator`
   --> $DIR/issue-100365.rs:17:9
    |
 LL |         ::std::iter::Iterator
@@ -45,7 +45,7 @@ LL |     Trait!().map(std::convert::identity); // no `help` here!
    |
    = note: this error originates in the macro `Trait` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0423]: expected value, found trait `std::iter::Iterator`
+error[E0423]: expected value, found trait `::std::iter::Iterator`
   --> $DIR/issue-100365.rs:17:9
    |
 LL |         ::std::iter::Iterator

--- a/tests/ui/resolve/resolve-bad-visibility.rs
+++ b/tests/ui/resolve/resolve-bad-visibility.rs
@@ -2,8 +2,8 @@
 enum E {}
 trait Tr {}
 
-pub(in E) struct S; //~ ERROR expected module, found enum `E`
-pub(in Tr) struct Z; //~ ERROR expected module, found trait `Tr`
+pub(in E) struct S; //~ ERROR expected module, found enum `::E`
+pub(in Tr) struct Z; //~ ERROR expected module, found trait `::Tr`
 pub(in std::vec) struct F; //~ ERROR visibilities can only be restricted to ancestor modules
 pub(in nonexistent) struct G; //~ ERROR cannot find
 pub(in too_soon) struct H; //~ ERROR cannot find

--- a/tests/ui/resolve/resolve-bad-visibility.stderr
+++ b/tests/ui/resolve/resolve-bad-visibility.stderr
@@ -1,10 +1,10 @@
-error[E0577]: expected module, found enum `E`
+error[E0577]: expected module, found enum `::E`
   --> $DIR/resolve-bad-visibility.rs:5:8
    |
 LL | pub(in E) struct S;
    |        ^ not a module
 
-error[E0577]: expected module, found trait `Tr`
+error[E0577]: expected module, found trait `::Tr`
   --> $DIR/resolve-bad-visibility.rs:6:8
    |
 LL | pub(in Tr) struct Z;

--- a/tests/ui/rfcs/rfc-2126-extern-absolute-paths/single-segment.rs
+++ b/tests/ui/rfcs/rfc-2126-extern-absolute-paths/single-segment.rs
@@ -6,6 +6,6 @@ use crate; //~ ERROR imports need to be explicitly named
 use *; //~ ERROR cannot glob-import all possible crates
 
 fn main() {
-    let s = ::xcrate; //~ ERROR expected value, found crate `xcrate`
+    let s = ::xcrate; //~ ERROR expected value, found crate `::xcrate`
                       //~^ NOTE not a value
 }

--- a/tests/ui/rfcs/rfc-2126-extern-absolute-paths/single-segment.stderr
+++ b/tests/ui/rfcs/rfc-2126-extern-absolute-paths/single-segment.stderr
@@ -15,7 +15,7 @@ error: cannot glob-import all possible crates
 LL | use *;
    |     ^
 
-error[E0423]: expected value, found crate `xcrate`
+error[E0423]: expected value, found crate `::xcrate`
   --> $DIR/single-segment.rs:9:13
    |
 LL |     let s = ::xcrate;


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#151431 (Add new unstable attribute: `#[export_visibility = ...]`.)
 - rust-lang/rust#153012 (Stop using `LinkedGraph` in `lexical_region_resolve`)
 - rust-lang/rust#153179 (Force a CI LLVM stamp bump)
 - rust-lang/rust#150828 (Improved security section in rustdoc for `current_exe`)
 - rust-lang/rust#152673 (rustc_public: rewrite `bridge_impl` to reduce boilerplate)
 - rust-lang/rust#152674 (rustc_public: remove the `CrateDefItems` trait)
 - rust-lang/rust#153073 (Fix mem::conjure_zst panic message to use any::type_name instead)
 - rust-lang/rust#153117 (Remove mutation from macro path URL construction)
 - rust-lang/rust#153128 (Recover feature lang_items for emscripten)
 - rust-lang/rust#153138 (Print path root when printing path)
 - rust-lang/rust#153159 (Work around a false `err.emit();` type error in rust-analyzer)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=151431,153012,153179,150828,152673,152674,153073,153117,153128,153138,153159)
<!-- homu-ignore:end -->

