### PR TITLE
Fix ICE when macro-expanded extern crate shadows std

### DIFF
--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -1048,7 +1048,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 message,
             } => {
                 if no_ambiguity {
-                    assert!(import.imported_module.get().is_none());
+                    if !self.issue_145575_hack_applied {
+                        assert!(import.imported_module.get().is_none());
+                    }
                     self.report_error(
                         span,
                         ResolutionError::FailedToResolve {
@@ -1072,7 +1074,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 ..
             } => {
                 if no_ambiguity {
-                    assert!(import.imported_module.get().is_none());
+                    if !self.issue_145575_hack_applied {
+                        assert!(import.imported_module.get().is_none());
+                    }
                     let module = if let Some(ModuleOrUniformRoot::Module(m)) = module {
                         m.opt_def_id()
                     } else {

--- a/tests/ui/resolve/ice-on-shadowing-std-with-attr.rs
+++ b/tests/ui/resolve/ice-on-shadowing-std-with-attr.rs
@@ -1,0 +1,14 @@
+//@ edition: 2024
+// This test ensures that `extern crate` with attribute shadowing std does not cause ICE.
+// Issue link: https://github.com/rust-lang/rust/issues/152895
+
+#![crate_type = "lib"]
+
+#[foobar] //~ ERROR cannot find attribute `foobar` in this scope
+extern crate core as std; //~ ERROR macro-expanded `extern crate` items cannot shadow names passed with `--extern`
+mod inner {
+    use std::collections::hash_map::HashMap; //~ ERROR cannot find `collections` in `std`
+    use std::vec::IntoIter; //~ ERROR unresolved import `std::vec`
+
+    use crate::*;
+}

--- a/tests/ui/resolve/ice-on-shadowing-std-with-attr.stderr
+++ b/tests/ui/resolve/ice-on-shadowing-std-with-attr.stderr
@@ -1,0 +1,28 @@
+error: macro-expanded `extern crate` items cannot shadow names passed with `--extern`
+  --> $DIR/ice-on-shadowing-std-with-attr.rs:8:1
+   |
+LL | extern crate core as std;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0433]: cannot find `collections` in `std`
+  --> $DIR/ice-on-shadowing-std-with-attr.rs:10:14
+   |
+LL |     use std::collections::hash_map::HashMap;
+   |              ^^^^^^^^^^^ could not find `collections` in `std`
+
+error[E0432]: unresolved import `std::vec`
+  --> $DIR/ice-on-shadowing-std-with-attr.rs:11:14
+   |
+LL |     use std::vec::IntoIter;
+   |              ^^^ could not find `vec` in `std`
+
+error: cannot find attribute `foobar` in this scope
+  --> $DIR/ice-on-shadowing-std-with-attr.rs:7:3
+   |
+LL | #[foobar]
+   |   ^^^^^^
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0432, E0433.
+For more information about an error, try `rustc --explain E0432`.

--- a/tests/ui/resolve/ice-on-shadowing-std-with-macro.rs
+++ b/tests/ui/resolve/ice-on-shadowing-std-with-macro.rs
@@ -1,0 +1,19 @@
+//@ edition: 2024
+// This test ensures that a macro-expanded `extern crate` shadowing std does not cause ICE.
+// Issue link: https://github.com/rust-lang/rust/issues/152895
+
+#![crate_type = "lib"]
+
+mod inner {
+    use std::collections::hash_map::HashMap; //~ ERROR cannot find `collections` in `std`
+    use std::vec::IntoIter; //~ ERROR unresolved import `std::vec`
+
+    use crate::*;
+}
+
+macro_rules! define_other_core {
+    () => {
+        extern crate core as std; //~ ERROR macro-expanded `extern crate` items cannot shadow names passed with `--extern`
+    };
+}
+define_other_core! {}

--- a/tests/ui/resolve/ice-on-shadowing-std-with-macro.stderr
+++ b/tests/ui/resolve/ice-on-shadowing-std-with-macro.stderr
@@ -1,0 +1,27 @@
+error: macro-expanded `extern crate` items cannot shadow names passed with `--extern`
+  --> $DIR/ice-on-shadowing-std-with-macro.rs:16:9
+   |
+LL |         extern crate core as std;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | define_other_core! {}
+   | --------------------- in this macro invocation
+   |
+   = note: this error originates in the macro `define_other_core` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0433]: cannot find `collections` in `std`
+  --> $DIR/ice-on-shadowing-std-with-macro.rs:8:14
+   |
+LL |     use std::collections::hash_map::HashMap;
+   |              ^^^^^^^^^^^ could not find `collections` in `std`
+
+error[E0432]: unresolved import `std::vec`
+  --> $DIR/ice-on-shadowing-std-with-macro.rs:9:14
+   |
+LL |     use std::vec::IntoIter;
+   |              ^^^ could not find `vec` in `std`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0432, E0433.
+For more information about an error, try `rustc --explain E0432`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Fixes rust-lang/rust#152895

This PR fixes an ICE that occurs when a macro-expanded `extern crate` shadows a prelude name, which leaves the resolver in an inconsistent state due to `issue_145575_hack`.

I disabled the assertion when the `issue_145575_hack` flag is enabled.
The fix is applied in two locations to cover both cases (whether `is_error_from_last_segment` is true or false).
This approach was inspired by the context and fix discussed in rust-lang/rust#151213.