### PR TITLE
Don't allow subdiagnostic to use variables from their parent

### DIFF
--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -88,6 +88,8 @@ pub(crate) enum AssocItemNotFoundLabel<'a> {
     NotFound {
         #[primary_span]
         span: Span,
+        assoc_ident: Ident,
+        assoc_kind: &'static str,
     },
     #[label(
         "there is {$identically_named ->
@@ -149,6 +151,7 @@ pub(crate) enum AssocItemNotFoundSugg<'a> {
         trait_ref: String,
         suggested_name: Symbol,
         identically_named: bool,
+        assoc_kind: &'static str,
         #[applicability]
         applicability: Applicability,
     },

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -2320,8 +2320,9 @@ impl EarlyLintPass for IncompleteInternalFeatures {
                 if features.incomplete(name) {
                     let note = rustc_feature::find_feature_issue(name, GateIssue::Language)
                         .map(|n| BuiltinFeatureIssueNote { n });
-                    let help =
-                        HAS_MIN_FEATURES.contains(&name).then_some(BuiltinIncompleteFeaturesHelp);
+                    let help = HAS_MIN_FEATURES
+                        .contains(&name)
+                        .then_some(BuiltinIncompleteFeaturesHelp { name });
 
                     cx.emit_span_lint(
                         INCOMPLETE_FEATURES,

--- a/compiler/rustc_lint/src/deref_into_dyn_supertrait.rs
+++ b/compiler/rustc_lint/src/deref_into_dyn_supertrait.rs
@@ -87,7 +87,10 @@ impl<'tcx> LateLintPass<'tcx> for DerefIntoDynSupertrait {
                     ty::AssocTag::Type,
                     item.owner_id.to_def_id(),
                 )
-                .map(|label| SupertraitAsDerefTargetLabel { label: tcx.def_span(label.def_id) });
+                .map(|label| SupertraitAsDerefTargetLabel {
+                    label: tcx.def_span(label.def_id),
+                    self_ty,
+                });
             let span = tcx.def_span(item.owner_id.def_id);
             cx.emit_span_lint(
                 DEREF_INTO_DYN_SUPERTRAIT,

--- a/compiler/rustc_lint/src/early/diagnostics.rs
+++ b/compiler/rustc_lint/src/early/diagnostics.rs
@@ -105,13 +105,11 @@ pub fn decorate_builtin_lint(
         BuiltinLintDiag::RedundantImport(spans, ident) => {
             let subs = spans
                 .into_iter()
-                .map(|(span, is_imported)| {
-                    (match (span.is_dummy(), is_imported) {
-                        (false, true) => lints::RedundantImportSub::ImportedHere,
-                        (false, false) => lints::RedundantImportSub::DefinedHere,
-                        (true, true) => lints::RedundantImportSub::ImportedPrelude,
-                        (true, false) => lints::RedundantImportSub::DefinedPrelude,
-                    })(span)
+                .map(|(span, is_imported)| match (span.is_dummy(), is_imported) {
+                    (false, true) => lints::RedundantImportSub::ImportedHere { span, ident },
+                    (false, false) => lints::RedundantImportSub::DefinedHere { span, ident },
+                    (true, true) => lints::RedundantImportSub::ImportedPrelude { span, ident },
+                    (true, false) => lints::RedundantImportSub::DefinedPrelude { span, ident },
                 })
                 .collect();
             lints::RedundantImport { subs, ident }.decorate_lint(diag);

--- a/compiler/rustc_lint/src/interior_mutable_consts.rs
+++ b/compiler/rustc_lint/src/interior_mutable_consts.rs
@@ -105,9 +105,10 @@ impl<'tcx> LateLintPass<'tcx> for InteriorMutableConsts {
                     Some(ConstItemInteriorMutationsSuggestionStatic::Spanful {
                         const_: const_item.vis_span.between(ident.span),
                         before: if !vis_span.is_empty() { " " } else { "" },
+                        const_name,
                     })
                 } else {
-                    Some(ConstItemInteriorMutationsSuggestionStatic::Spanless)
+                    Some(ConstItemInteriorMutationsSuggestionStatic::Spanless { const_name })
                 }
             } else {
                 None

--- a/compiler/rustc_lint/src/types/literal.rs
+++ b/compiler/rustc_lint/src/types/literal.rs
@@ -157,8 +157,21 @@ fn report_bin_hex_error(
             (t.name_str(), actually.to_string())
         }
     };
-    let sign =
-        if negative { OverflowingBinHexSign::Negative } else { OverflowingBinHexSign::Positive };
+    let sign = if negative {
+        OverflowingBinHexSign::Negative {
+            lit: repr_str.clone(),
+            dec: val,
+            actually: actually.clone(),
+            ty: t,
+        }
+    } else {
+        OverflowingBinHexSign::Positive {
+            lit: repr_str.clone(),
+            dec: val,
+            actually: actually.clone(),
+            ty: t,
+        }
+    };
     let sub = get_type_suggestion(cx.typeck_results().node_type(hir_id), val, negative).map(
         |suggestion_ty| {
             if let Some(pos) = repr_str.chars().position(|c| c == 'i' || c == 'u') {
@@ -194,7 +207,7 @@ fn report_bin_hex_error(
             Some(OverflowingBinHexSignBitSub {
                 span,
                 lit_no_suffix,
-                negative_val: actually.clone(),
+                negative_val: actually,
                 int_ty: int_ty.name_str(),
                 uint_ty: Integer::fit_unsigned(val).uint_ty_str(),
             })
@@ -204,15 +217,7 @@ fn report_bin_hex_error(
     cx.emit_span_lint(
         OVERFLOWING_LITERALS,
         span,
-        OverflowingBinHex {
-            ty: t,
-            lit: repr_str.clone(),
-            dec: val,
-            actually,
-            sign,
-            sub,
-            sign_bit_sub,
-        },
+        OverflowingBinHex { ty: t, sign, sub, sign_bit_sub },
     )
 }
 

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -350,6 +350,7 @@ trait UnusedDelimLint {
                 start_replace: lo_replace,
                 end_span: hi,
                 end_replace: hi_replace,
+                delim: Self::DELIM_STR,
             }
         });
         cx.emit_span_lint(

--- a/compiler/rustc_macros/src/diagnostics/subdiagnostic.rs
+++ b/compiler/rustc_macros/src/diagnostics/subdiagnostic.rs
@@ -535,7 +535,7 @@ impl<'parent, 'a> SubdiagnosticDeriveVariantBuilder<'parent, 'a> {
         let mut calls = TokenStream::new();
         for (kind, messages) in kind_messages {
             let message = format_ident!("__message");
-            let message_stream = messages.diag_message(None);
+            let message_stream = messages.diag_message(Some(self.variant));
             calls.extend(quote! { let #message = #diag.eagerly_translate(#message_stream); });
 
             let name = format_ident!("{}{}", if span_field.is_some() { "span_" } else { "" }, kind);

--- a/compiler/rustc_metadata/src/dependency_format.rs
+++ b/compiler/rustc_metadata/src/dependency_format.rs
@@ -315,7 +315,7 @@ fn add_library(
                     crate_name: tcx.crate_name(cnum),
                     non_static_deps: unavailable_as_static
                         .drain(..)
-                        .map(|cnum| NonStaticCrateDep { crate_name_: tcx.crate_name(cnum) })
+                        .map(|cnum| NonStaticCrateDep { sub_crate_name: tcx.crate_name(cnum) })
                         .collect(),
                     rustc_driver_help: linking_to_rustc_driver,
                 });

--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -48,10 +48,10 @@ pub struct CrateDepMultiple {
 }
 
 #[derive(Subdiagnostic)]
-#[note("`{$crate_name}` was unavailable as a static crate, preventing fully static linking")]
+#[note("`{$sub_crate_name}` was unavailable as a static crate, preventing fully static linking")]
 pub struct NonStaticCrateDep {
     /// It's different from `crate_name` in main Diagnostic.
-    pub crate_name_: Symbol,
+    pub sub_crate_name: Symbol,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -115,12 +115,12 @@ impl<'tcx> UnsafetyVisitor<'_, 'tcx> {
                     CallToDeprecatedSafeFnRequiresUnsafe {
                         span,
                         function: with_no_trimmed_paths!(self.tcx.def_path_str(id)),
-                        guarantee,
                         sub: CallToDeprecatedSafeFnRequiresUnsafeSub {
                             start_of_line_suggestion: suggestion,
                             start_of_line: sm.span_extend_to_line(span).shrink_to_lo(),
                             left: span.shrink_to_lo(),
                             right: span.shrink_to_hi(),
+                            guarantee,
                         },
                     },
                 );

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -15,7 +15,6 @@ pub(crate) struct CallToDeprecatedSafeFnRequiresUnsafe {
     #[label("call to unsafe function")]
     pub(crate) span: Span,
     pub(crate) function: String,
-    pub(crate) guarantee: String,
     #[subdiagnostic]
     pub(crate) sub: CallToDeprecatedSafeFnRequiresUnsafeSub,
 }
@@ -33,6 +32,7 @@ pub(crate) struct CallToDeprecatedSafeFnRequiresUnsafeSub {
     pub(crate) left: Span,
     #[suggestion_part(code = " }}")]
     pub(crate) right: Span,
+    pub(crate) guarantee: String,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_mir_transform/src/errors.rs
+++ b/compiler/rustc_mir_transform/src/errors.rs
@@ -389,4 +389,5 @@ pub(crate) struct ForceInlineFailure {
 #[note("`{$callee}` is required to be inlined to: {$sym}")]
 pub(crate) struct ForceInlineJustification {
     pub sym: Symbol,
+    pub callee: String,
 }

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -251,15 +251,17 @@ impl<'tcx> Inliner<'tcx> for ForceInliner<'tcx> {
         };
 
         let call_span = callsite.source_info.span;
+        let callee = tcx.def_path_str(callsite.callee.def_id());
         tcx.dcx().emit_err(crate::errors::ForceInlineFailure {
             call_span,
             attr_span,
             caller_span: tcx.def_span(self.def_id),
             caller: tcx.def_path_str(self.def_id),
             callee_span: tcx.def_span(callsite.callee.def_id()),
-            callee: tcx.def_path_str(callsite.callee.def_id()),
+            callee: callee.clone(),
             reason,
-            justification: justification.map(|sym| crate::errors::ForceInlineJustification { sym }),
+            justification: justification
+                .map(|sym| crate::errors::ForceInlineJustification { sym, callee }),
         });
     }
 }

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -1016,7 +1016,6 @@ pub(crate) struct LeadingPlusNotSupported {
 pub(crate) struct ParenthesesWithStructFields {
     #[primary_span]
     pub span: Span,
-    pub r#type: Path,
     #[subdiagnostic]
     pub braces_for_struct: BracesForStructLiteral,
     #[subdiagnostic]
@@ -1029,6 +1028,7 @@ pub(crate) struct ParenthesesWithStructFields {
     applicability = "maybe-incorrect"
 )]
 pub(crate) struct BracesForStructLiteral {
+    pub r#type: Path,
     #[suggestion_part(code = " {{ ")]
     pub first: Span,
     #[suggestion_part(code = " }}")]
@@ -1041,6 +1041,7 @@ pub(crate) struct BracesForStructLiteral {
     applicability = "maybe-incorrect"
 )]
 pub(crate) struct NoFieldsForFnCall {
+    pub r#type: Path,
     #[suggestion_part(code = "")]
     pub fields: Vec<Span>,
 }
@@ -3176,6 +3177,7 @@ pub(crate) struct UnexpectedVertVertInPattern {
 pub(crate) struct TrailingVertSuggestion {
     #[primary_span]
     pub span: Span,
+    pub token: Token,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1309,12 +1309,13 @@ impl<'a> Parser<'a> {
                             self.dcx()
                                 .create_err(errors::ParenthesesWithStructFields {
                                     span,
-                                    r#type: path,
                                     braces_for_struct: errors::BracesForStructLiteral {
                                         first: open_paren,
                                         second: close_paren,
+                                        r#type: path.clone(),
                                     },
                                     no_fields_for_fn: errors::NoFieldsForFnCall {
+                                        r#type: path,
                                         fields: fields
                                             .into_iter()
                                             .map(|field| field.span.until(field.expr.span))

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -364,6 +364,7 @@ impl<'a> Parser<'a> {
                     start: lo,
                     suggestion: TrailingVertSuggestion {
                         span: self.prev_token.span.shrink_to_hi().with_hi(self.token.span.hi()),
+                        token: self.token,
                     },
                     token: self.token,
                     note_double_vert: self.token.kind == token::OrOr,

--- a/compiler/rustc_query_impl/src/error.rs
+++ b/compiler/rustc_query_impl/src/error.rs
@@ -35,9 +35,9 @@ pub(crate) struct CycleStack {
 #[derive(Subdiagnostic)]
 pub(crate) enum StackCount {
     #[note("...which immediately requires {$stack_bottom} again")]
-    Single,
+    Single { stack_bottom: String },
     #[note("...which again requires {$stack_bottom}, completing the cycle")]
-    Multiple,
+    Multiple { stack_bottom: String },
 }
 
 #[derive(Subdiagnostic)]

--- a/compiler/rustc_query_impl/src/job.rs
+++ b/compiler/rustc_query_impl/src/job.rs
@@ -438,7 +438,12 @@ pub(crate) fn report_cycle<'a>(
     let mut cycle_stack = Vec::new();
 
     use crate::error::StackCount;
-    let stack_count = if stack.len() == 1 { StackCount::Single } else { StackCount::Multiple };
+    let stack_bottom = stack[0].frame.info.description.to_owned();
+    let stack_count = if stack.len() == 1 {
+        StackCount::Single { stack_bottom: stack_bottom.clone() }
+    } else {
+        StackCount::Multiple { stack_bottom: stack_bottom.clone() }
+    };
 
     for i in 1..stack.len() {
         let frame = &stack[i].frame;
@@ -467,7 +472,7 @@ pub(crate) fn report_cycle<'a>(
     let cycle_diag = crate::error::Cycle {
         span,
         cycle_stack,
-        stack_bottom: stack[0].frame.info.description.to_owned(),
+        stack_bottom,
         alias,
         cycle_usage,
         stack_count,

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -249,20 +249,23 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         };
 
         let label = match new_binding.is_import_user_facing() {
-            true => errors::NameDefinedMultipleTimeLabel::Reimported { span },
-            false => errors::NameDefinedMultipleTimeLabel::Redefined { span },
+            true => errors::NameDefinedMultipleTimeLabel::Reimported { span, name },
+            false => errors::NameDefinedMultipleTimeLabel::Redefined { span, name },
         };
 
         let old_binding_label =
             (!old_binding.span.is_dummy() && old_binding.span != span).then(|| {
                 let span = self.tcx.sess.source_map().guess_head_span(old_binding.span);
                 match old_binding.is_import_user_facing() {
-                    true => {
-                        errors::NameDefinedMultipleTimeOldBindingLabel::Import { span, old_kind }
-                    }
+                    true => errors::NameDefinedMultipleTimeOldBindingLabel::Import {
+                        span,
+                        old_kind,
+                        name,
+                    },
                     false => errors::NameDefinedMultipleTimeOldBindingLabel::Definition {
                         span,
                         old_kind,
+                        name,
                     },
                 }
             });

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -1126,11 +1126,13 @@ pub(crate) enum NameDefinedMultipleTimeLabel {
     Reimported {
         #[primary_span]
         span: Span,
+        name: Symbol,
     },
     #[label("`{$name}` redefined here")]
     Redefined {
         #[primary_span]
         span: Span,
+        name: Symbol,
     },
 }
 
@@ -1141,12 +1143,14 @@ pub(crate) enum NameDefinedMultipleTimeOldBindingLabel {
         #[primary_span]
         span: Span,
         old_kind: &'static str,
+        name: Symbol,
     },
     #[label("previous definition of the {$old_kind} `{$name}` here")]
     Definition {
         #[primary_span]
         span: Span,
         old_kind: &'static str,
+        name: Symbol,
     },
 }
 

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -3288,12 +3288,14 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     err.fn_once_label = Some(ClosureFnOnceLabel {
                         span: *span,
                         place: ty::place_to_string_for_capture(self.tcx, place),
+                        trait_prefix,
                     })
                 }
                 (ty::ClosureKind::FnMut, Some((span, place))) => {
                     err.fn_mut_label = Some(ClosureFnMutLabel {
                         span: *span,
                         place: ty::place_to_string_for_capture(self.tcx, place),
+                        trait_prefix,
                     })
                 }
                 _ => {}

--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -157,6 +157,7 @@ pub struct ClosureFnOnceLabel {
     #[primary_span]
     pub span: Span,
     pub place: String,
+    pub trait_prefix: &'static str,
 }
 
 #[derive(Subdiagnostic)]
@@ -165,6 +166,7 @@ pub struct ClosureFnMutLabel {
     #[primary_span]
     pub span: Span,
     pub place: String,
+    pub trait_prefix: &'static str,
 }
 
 #[derive(Diagnostic)]


### PR DESCRIPTION
Tangentially related to https://github.com/rust-lang/rust/issues/151366

This is PR 1/2 for structured diagnostics, will do the unstructured ones next. After the second PR I will be able to remove some code that should compensate for this PR being positive.

Regardless of this PR having a positive diff, I feel that subdiagnostics being able to use variables from their parent is very confusing, so this is for the better,.

r? @jdonszelmann 