### PR TITLE
  don't emit `unused_results` lint for tuples of "trivial" types 

### DIFF
--- a/compiler/rustc_lint/src/unused/must_use.rs
+++ b/compiler/rustc_lint/src/unused/must_use.rs
@@ -108,13 +108,6 @@ impl IsTyMustUse {
             _ => self,
         }
     }
-
-    fn yes(self) -> Option<MustUsePath> {
-        match self {
-            Self::Yes(must_use_path) => Some(must_use_path),
-            _ => None,
-        }
-    }
 }
 
 /// A path through a type to a `must_use` source. Contains useful info for the lint.
@@ -254,16 +247,23 @@ pub fn is_ty_must_use<'tcx>(
             // Default to `expr`.
             let elem_exprs = elem_exprs.iter().chain(iter::repeat(expr));
 
-            let nested_must_use = tys
-                .iter()
-                .zip(elem_exprs)
-                .enumerate()
-                .filter_map(|(i, (ty, expr))| {
-                    is_ty_must_use(cx, ty, expr, simplify_uninhabited).yes().map(|path| (i, path))
-                })
-                .collect::<Vec<_>>();
+            let mut all_trivial = true;
+            let mut nested_must_use = Vec::new();
 
-            if !nested_must_use.is_empty() {
+            tys.iter().zip(elem_exprs).enumerate().for_each(|(i, (ty, expr))| {
+                let must_use = is_ty_must_use(cx, ty, expr, simplify_uninhabited);
+
+                all_trivial &= matches!(must_use, IsTyMustUse::Trivial);
+                if let IsTyMustUse::Yes(path) = must_use {
+                    nested_must_use.push((i, path));
+                }
+            });
+
+            if all_trivial {
+                // If all tuple elements are trivial, mark the whole tuple as such.
+                // i.e. don't emit `unused_results` for types such as `((), ())`
+                IsTyMustUse::Trivial
+            } else if !nested_must_use.is_empty() {
                 IsTyMustUse::Yes(MustUsePath::TupleElement(nested_must_use))
             } else {
                 IsTyMustUse::No

--- a/tests/ui/lint/unused/unused-result.rs
+++ b/tests/ui/lint/unused/unused-result.rs
@@ -44,11 +44,12 @@ fn main() {
     let _ = foo::<MustUse>();
     let _ = foo::<MustUseMsg>();
 
+    // "trivial" types
     ();
-    ((), ()); //~ ERROR: unused result of type
+    ((), ());
     Ok::<(), Nothing>(());
     ControlFlow::<Nothing>::Continue(());
-    ((), Ok::<(), Nothing>(()), ((((), ())), ((),))); //~ ERROR: unused result of type
+    ((), Ok::<(), Nothing>(()), ((((), ())), ((),)));
     foo::<Nothing>();
 
     ((), 1); //~ ERROR: unused result of type `((), i32)`

--- a/tests/ui/lint/unused/unused-result.rs
+++ b/tests/ui/lint/unused/unused-result.rs
@@ -3,11 +3,15 @@
 //~^ NOTE: the lint level is defined here
 //~| NOTE: the lint level is defined here
 
+use std::ops::ControlFlow;
+
 #[must_use]
 enum MustUse { Test }
 
 #[must_use = "some message"]
 enum MustUseMsg { Test2 }
+
+enum Nothing {}
 
 fn foo<T>() -> T { panic!() }
 
@@ -39,4 +43,14 @@ fn main() {
     let _ = foo::<isize>();
     let _ = foo::<MustUse>();
     let _ = foo::<MustUseMsg>();
+
+    ();
+    ((), ()); //~ ERROR: unused result of type
+    Ok::<(), Nothing>(());
+    ControlFlow::<Nothing>::Continue(());
+    ((), Ok::<(), Nothing>(()), ((((), ())), ((),))); //~ ERROR: unused result of type
+    foo::<Nothing>();
+
+    ((), 1); //~ ERROR: unused result of type `((), i32)`
+    (1, ()); //~ ERROR: unused result of type `(i32, ())`
 }

--- a/tests/ui/lint/unused/unused-result.stderr
+++ b/tests/ui/lint/unused/unused-result.stderr
@@ -61,29 +61,17 @@ help: use `let _ = ...` to ignore the resulting value
 LL |     let _ = foo::<MustUseMsg>();
    |     +++++++
 
-error: unused result of type `((), ())`
-  --> $DIR/unused-result.rs:48:5
-   |
-LL |     ((), ());
-   |     ^^^^^^^^^
-
-error: unused result of type `((), Result<(), Nothing>, (((), ()), ((),)))`
-  --> $DIR/unused-result.rs:51:5
-   |
-LL |     ((), Ok::<(), Nothing>(()), ((((), ())), ((),)));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error: unused result of type `((), i32)`
-  --> $DIR/unused-result.rs:54:5
+  --> $DIR/unused-result.rs:55:5
    |
 LL |     ((), 1);
    |     ^^^^^^^^
 
 error: unused result of type `(i32, ())`
-  --> $DIR/unused-result.rs:55:5
+  --> $DIR/unused-result.rs:56:5
    |
 LL |     (1, ());
    |     ^^^^^^^^
 
-error: aborting due to 9 previous errors
+error: aborting due to 7 previous errors
 

--- a/tests/ui/lint/unused/unused-result.stderr
+++ b/tests/ui/lint/unused/unused-result.stderr
@@ -1,5 +1,5 @@
 error: unused `MustUse` that must be used
-  --> $DIR/unused-result.rs:21:5
+  --> $DIR/unused-result.rs:25:5
    |
 LL |     foo::<MustUse>();
    |     ^^^^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ LL |     let _ = foo::<MustUse>();
    |     +++++++
 
 error: unused `MustUseMsg` that must be used
-  --> $DIR/unused-result.rs:22:5
+  --> $DIR/unused-result.rs:26:5
    |
 LL |     foo::<MustUseMsg>();
    |     ^^^^^^^^^^^^^^^^^^^
@@ -27,7 +27,7 @@ LL |     let _ = foo::<MustUseMsg>();
    |     +++++++
 
 error: unused result of type `isize`
-  --> $DIR/unused-result.rs:34:5
+  --> $DIR/unused-result.rs:38:5
    |
 LL |     foo::<isize>();
    |     ^^^^^^^^^^^^^^^
@@ -39,7 +39,7 @@ LL | #![deny(unused_results, unused_must_use)]
    |         ^^^^^^^^^^^^^^
 
 error: unused `MustUse` that must be used
-  --> $DIR/unused-result.rs:35:5
+  --> $DIR/unused-result.rs:39:5
    |
 LL |     foo::<MustUse>();
    |     ^^^^^^^^^^^^^^^^
@@ -50,7 +50,7 @@ LL |     let _ = foo::<MustUse>();
    |     +++++++
 
 error: unused `MustUseMsg` that must be used
-  --> $DIR/unused-result.rs:36:5
+  --> $DIR/unused-result.rs:40:5
    |
 LL |     foo::<MustUseMsg>();
    |     ^^^^^^^^^^^^^^^^^^^
@@ -61,5 +61,29 @@ help: use `let _ = ...` to ignore the resulting value
 LL |     let _ = foo::<MustUseMsg>();
    |     +++++++
 
-error: aborting due to 5 previous errors
+error: unused result of type `((), ())`
+  --> $DIR/unused-result.rs:48:5
+   |
+LL |     ((), ());
+   |     ^^^^^^^^^
+
+error: unused result of type `((), Result<(), Nothing>, (((), ()), ((),)))`
+  --> $DIR/unused-result.rs:51:5
+   |
+LL |     ((), Ok::<(), Nothing>(()), ((((), ())), ((),)));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: unused result of type `((), i32)`
+  --> $DIR/unused-result.rs:54:5
+   |
+LL |     ((), 1);
+   |     ^^^^^^^^
+
+error: unused result of type `(i32, ())`
+  --> $DIR/unused-result.rs:55:5
+   |
+LL |     (1, ());
+   |     ^^^^^^^^
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

r? @jdonszelmann 
Fixes rust-lang/rust#153144.

So it turns out rust-lang/rust#153018 had a sneaky behavior change in the way tuples are handled and the old behavior wasn't tested.

Consider these tuples:

```rust
((), ());
((), 1);
```

Neither of them is `must_use`, so they are potential candidates for `unused_results`. So the question is whatever said tuples are considered "trivial" and thus if they end up emitting `unused_results` or not.

Here is a comparison table between PRs: 
<table>
<tr><td>stable</td><td>After #153018</td><td>After this PR</td></tr><tr><td>

```rust
((), ()); // trivial
((), 1); // trivial
```
</td>
<td>

```rust
((), ()); //~ warn: unused_results
((), 1); //~ warn: unused_results
```
</td>
<td>

```rust
((), ()); // trivial
((), 1); //~ warn: unused_results
```
</td>
</tr>
  <tr>
    <td>

tuples are trivial if **any** of their fields are trivial
    </td>
    <td>

tuples are never trivial
    </td>
    <td>

tuples are trivial if **all** of their fields are trivial
    </td>
  </tr>
</table>