### PR TITLE
Make post-monomorphization error detection work with fatal errors

### DIFF
--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -210,6 +210,7 @@ mod autodiff;
 use std::cell::OnceCell;
 use std::ops::ControlFlow;
 
+use rustc_data_structures::defer;
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_data_structures::sync::{MTLock, par_for_each_in};
 use rustc_data_structures::unord::{UnordMap, UnordSet};
@@ -419,153 +420,165 @@ fn collect_items_rec<'tcx>(
     // current step of mono items collection.
     //
     // FIXME: don't rely on global state, instead bubble up errors. Note: this is very hard to do.
+    // FIXME: This detection can have false positives with the parallel compiler.
+    // FIXME: The notes may not be right after the original error with the parallel compiler.
     let error_count = tcx.dcx().err_count();
 
-    // In `mentioned_items` we collect items that were mentioned in this MIR but possibly do not
-    // need to be monomorphized. This is done to ensure that optimizing away function calls does not
-    // hide const-eval errors that those calls would otherwise have triggered.
-    match starting_item.node {
-        MonoItem::Static(def_id) => {
-            recursion_depth_reset = None;
+    {
+        // Use `defer` so detection works with fatal errors too.
+        let _guard = defer(|| {
+            // Check for PMEs and emit a diagnostic if one happened. To try to show relevant edges of the
+            // mono item graph.
+            if tcx.dcx().err_count() > error_count
+                && starting_item.node.is_generic_fn()
+                && starting_item.node.is_user_defined()
+            {
+                match starting_item.node {
+                    MonoItem::Fn(instance) => {
+                        tcx.dcx().emit_note(EncounteredErrorWhileInstantiating {
+                            span: starting_item.span,
+                            kind: "fn",
+                            instance,
+                        })
+                    }
+                    MonoItem::Static(def_id) => {
+                        tcx.dcx().emit_note(EncounteredErrorWhileInstantiating {
+                            span: starting_item.span,
+                            kind: "static",
+                            instance: Instance::new_raw(def_id, GenericArgs::empty()),
+                        })
+                    }
+                    MonoItem::GlobalAsm(_) => {
+                        tcx.dcx().emit_note(EncounteredErrorWhileInstantiatingGlobalAsm {
+                            span: starting_item.span,
+                        })
+                    }
+                }
+            }
+        });
 
-            // Statics always get evaluated (which is possible because they can't be generic), so for
-            // `MentionedItems` collection there's nothing to do here.
-            if mode == CollectionMode::UsedItems {
-                let instance = Instance::mono(tcx, def_id);
+        // In `mentioned_items` we collect items that were mentioned in this MIR but possibly do not
+        // need to be monomorphized. This is done to ensure that optimizing away function calls does not
+        // hide const-eval errors that those calls would otherwise have triggered.
+        match starting_item.node {
+            MonoItem::Static(def_id) => {
+                recursion_depth_reset = None;
 
+                // Statics always get evaluated (which is possible because they can't be generic), so for
+                // `MentionedItems` collection there's nothing to do here.
+                if mode == CollectionMode::UsedItems {
+                    let instance = Instance::mono(tcx, def_id);
+
+                    // Sanity check whether this ended up being collected accidentally
+                    debug_assert!(tcx.should_codegen_locally(instance));
+
+                    let DefKind::Static { nested, .. } = tcx.def_kind(def_id) else { bug!() };
+                    // Nested statics have no type.
+                    if !nested {
+                        let ty = instance.ty(tcx, ty::TypingEnv::fully_monomorphized());
+                        visit_drop_use(tcx, ty, true, starting_item.span, &mut used_items);
+                    }
+
+                    if let Ok(alloc) = tcx.eval_static_initializer(def_id) {
+                        for &prov in alloc.inner().provenance().ptrs().values() {
+                            collect_alloc(tcx, prov.alloc_id(), &mut used_items);
+                        }
+                    }
+
+                    if tcx.needs_thread_local_shim(def_id) {
+                        used_items.push(respan(
+                            starting_item.span,
+                            MonoItem::Fn(Instance {
+                                def: InstanceKind::ThreadLocalShim(def_id),
+                                args: GenericArgs::empty(),
+                            }),
+                        ));
+                    }
+                }
+
+                // mentioned_items stays empty since there's no codegen for statics. statics don't get
+                // optimized, and if they did then the const-eval interpreter would have to worry about
+                // mentioned_items.
+            }
+            MonoItem::Fn(instance) => {
                 // Sanity check whether this ended up being collected accidentally
                 debug_assert!(tcx.should_codegen_locally(instance));
 
-                let DefKind::Static { nested, .. } = tcx.def_kind(def_id) else { bug!() };
-                // Nested statics have no type.
-                if !nested {
-                    let ty = instance.ty(tcx, ty::TypingEnv::fully_monomorphized());
-                    visit_drop_use(tcx, ty, true, starting_item.span, &mut used_items);
-                }
+                // Keep track of the monomorphization recursion depth
+                recursion_depth_reset = Some(check_recursion_limit(
+                    tcx,
+                    instance,
+                    starting_item.span,
+                    recursion_depths,
+                    recursion_limit,
+                ));
 
-                if let Ok(alloc) = tcx.eval_static_initializer(def_id) {
-                    for &prov in alloc.inner().provenance().ptrs().values() {
-                        collect_alloc(tcx, prov.alloc_id(), &mut used_items);
-                    }
-                }
-
-                if tcx.needs_thread_local_shim(def_id) {
-                    used_items.push(respan(
-                        starting_item.span,
-                        MonoItem::Fn(Instance {
-                            def: InstanceKind::ThreadLocalShim(def_id),
-                            args: GenericArgs::empty(),
-                        }),
-                    ));
-                }
+                rustc_data_structures::stack::ensure_sufficient_stack(|| {
+                    let Ok((used, mentioned)) = tcx.items_of_instance((instance, mode)) else {
+                        // Normalization errors here are usually due to trait solving overflow.
+                        // FIXME: I assume that there are few type errors at post-analysis stage, but not
+                        // entirely sure.
+                        // We have to emit the error outside of `items_of_instance` to access the
+                        // span of the `starting_item`.
+                        let def_id = instance.def_id();
+                        let def_span = tcx.def_span(def_id);
+                        let def_path_str = tcx.def_path_str(def_id);
+                        tcx.dcx().emit_fatal(RecursionLimit {
+                            span: starting_item.span,
+                            instance,
+                            def_span,
+                            def_path_str,
+                        });
+                    };
+                    used_items.extend(used.into_iter().copied());
+                    mentioned_items.extend(mentioned.into_iter().copied());
+                });
             }
+            MonoItem::GlobalAsm(item_id) => {
+                assert!(
+                    mode == CollectionMode::UsedItems,
+                    "should never encounter global_asm when collecting mentioned items"
+                );
+                recursion_depth_reset = None;
 
-            // mentioned_items stays empty since there's no codegen for statics. statics don't get
-            // optimized, and if they did then the const-eval interpreter would have to worry about
-            // mentioned_items.
-        }
-        MonoItem::Fn(instance) => {
-            // Sanity check whether this ended up being collected accidentally
-            debug_assert!(tcx.should_codegen_locally(instance));
-
-            // Keep track of the monomorphization recursion depth
-            recursion_depth_reset = Some(check_recursion_limit(
-                tcx,
-                instance,
-                starting_item.span,
-                recursion_depths,
-                recursion_limit,
-            ));
-
-            rustc_data_structures::stack::ensure_sufficient_stack(|| {
-                let Ok((used, mentioned)) = tcx.items_of_instance((instance, mode)) else {
-                    // Normalization errors here are usually due to trait solving overflow.
-                    // FIXME: I assume that there are few type errors at post-analysis stage, but not
-                    // entirely sure.
-                    // We have to emit the error outside of `items_of_instance` to access the
-                    // span of the `starting_item`.
-                    let def_id = instance.def_id();
-                    let def_span = tcx.def_span(def_id);
-                    let def_path_str = tcx.def_path_str(def_id);
-                    tcx.dcx().emit_fatal(RecursionLimit {
-                        span: starting_item.span,
-                        instance,
-                        def_span,
-                        def_path_str,
-                    });
-                };
-                used_items.extend(used.into_iter().copied());
-                mentioned_items.extend(mentioned.into_iter().copied());
-            });
-        }
-        MonoItem::GlobalAsm(item_id) => {
-            assert!(
-                mode == CollectionMode::UsedItems,
-                "should never encounter global_asm when collecting mentioned items"
-            );
-            recursion_depth_reset = None;
-
-            let item = tcx.hir_item(item_id);
-            if let hir::ItemKind::GlobalAsm { asm, .. } = item.kind {
-                for (op, op_sp) in asm.operands {
-                    match *op {
-                        hir::InlineAsmOperand::Const { .. } => {
-                            // Only constants which resolve to a plain integer
-                            // are supported. Therefore the value should not
-                            // depend on any other items.
-                        }
-                        hir::InlineAsmOperand::SymFn { expr } => {
-                            let fn_ty = tcx.typeck(item_id.owner_id).expr_ty(expr);
-                            visit_fn_use(tcx, fn_ty, false, *op_sp, &mut used_items);
-                        }
-                        hir::InlineAsmOperand::SymStatic { path: _, def_id } => {
-                            let instance = Instance::mono(tcx, def_id);
-                            if tcx.should_codegen_locally(instance) {
-                                trace!("collecting static {:?}", def_id);
-                                used_items.push(dummy_spanned(MonoItem::Static(def_id)));
+                let item = tcx.hir_item(item_id);
+                if let hir::ItemKind::GlobalAsm { asm, .. } = item.kind {
+                    for (op, op_sp) in asm.operands {
+                        match *op {
+                            hir::InlineAsmOperand::Const { .. } => {
+                                // Only constants which resolve to a plain integer
+                                // are supported. Therefore the value should not
+                                // depend on any other items.
+                            }
+                            hir::InlineAsmOperand::SymFn { expr } => {
+                                let fn_ty = tcx.typeck(item_id.owner_id).expr_ty(expr);
+                                visit_fn_use(tcx, fn_ty, false, *op_sp, &mut used_items);
+                            }
+                            hir::InlineAsmOperand::SymStatic { path: _, def_id } => {
+                                let instance = Instance::mono(tcx, def_id);
+                                if tcx.should_codegen_locally(instance) {
+                                    trace!("collecting static {:?}", def_id);
+                                    used_items.push(dummy_spanned(MonoItem::Static(def_id)));
+                                }
+                            }
+                            hir::InlineAsmOperand::In { .. }
+                            | hir::InlineAsmOperand::Out { .. }
+                            | hir::InlineAsmOperand::InOut { .. }
+                            | hir::InlineAsmOperand::SplitInOut { .. }
+                            | hir::InlineAsmOperand::Label { .. } => {
+                                span_bug!(*op_sp, "invalid operand type for global_asm!")
                             }
                         }
-                        hir::InlineAsmOperand::In { .. }
-                        | hir::InlineAsmOperand::Out { .. }
-                        | hir::InlineAsmOperand::InOut { .. }
-                        | hir::InlineAsmOperand::SplitInOut { .. }
-                        | hir::InlineAsmOperand::Label { .. } => {
-                            span_bug!(*op_sp, "invalid operand type for global_asm!")
-                        }
                     }
+                } else {
+                    span_bug!(item.span, "Mismatch between hir::Item type and MonoItem type")
                 }
-            } else {
-                span_bug!(item.span, "Mismatch between hir::Item type and MonoItem type")
-            }
 
-            // mention_items stays empty as nothing gets optimized here.
-        }
-    };
-
-    // Check for PMEs and emit a diagnostic if one happened. To try to show relevant edges of the
-    // mono item graph.
-    if tcx.dcx().err_count() > error_count
-        && starting_item.node.is_generic_fn()
-        && starting_item.node.is_user_defined()
-    {
-        match starting_item.node {
-            MonoItem::Fn(instance) => tcx.dcx().emit_note(EncounteredErrorWhileInstantiating {
-                span: starting_item.span,
-                kind: "fn",
-                instance,
-            }),
-            MonoItem::Static(def_id) => tcx.dcx().emit_note(EncounteredErrorWhileInstantiating {
-                span: starting_item.span,
-                kind: "static",
-                instance: Instance::new_raw(def_id, GenericArgs::empty()),
-            }),
-            MonoItem::GlobalAsm(_) => {
-                tcx.dcx().emit_note(EncounteredErrorWhileInstantiatingGlobalAsm {
-                    span: starting_item.span,
-                })
+                // mention_items stays empty as nothing gets optimized here.
             }
-        }
+        };
     }
+
     // Only updating `usage_map` for used items as otherwise we may be inserting the same item
     // multiple times (if it is first 'mentioned' and then later actually used), and the usage map
     // logic does not like that.

--- a/tests/ui/async-await/async-closures/post-mono-higher-ranked-hang-2.stderr
+++ b/tests/ui/async-await/async-closures/post-mono-higher-ranked-hang-2.stderr
@@ -14,5 +14,15 @@ note: `recur` defined here
 LL | fn recur<'l>(closure: &'l impl AsyncFn()) -> Pin<Box<dyn Future<Output = ()> + 'l>> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+note: the above error was encountered while instantiating `fn recur::<{async closure@$DIR/post-mono-higher-ranked-hang-2.rs:13:24: 13:32}>`
+  --> $DIR/post-mono-higher-ranked-hang-2.rs:13:17
+   |
+LL |           let _ = recur(&async || {
+   |  _________________^
+LL | |
+LL | |             let _ = closure();
+LL | |         });
+   | |__________^
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/async-await/async-closures/post-mono-higher-ranked-hang.current.stderr
+++ b/tests/ui/async-await/async-closures/post-mono-higher-ranked-hang.current.stderr
@@ -17,5 +17,14 @@ LL | |         yield_chain: &'l mut impl AsyncFnMut(&SymPerm<'db>),
 LL | |     ) -> Pin<Box<dyn std::future::Future<Output = ()> + 'l>> {
    | |____________________________________________________________^
 
+note: the above error was encountered while instantiating `fn ToChain::<'_, '_>::perm_pairs::<{async closure@$DIR/post-mono-higher-ranked-hang.rs:47:45: 47:67}>`
+  --> $DIR/post-mono-higher-ranked-hang.rs:47:21
+   |
+LL | /                     self.perm_pairs(l, &mut async move |left_pair| {
+LL | |
+LL | |                         self.perm_pairs(r, yield_chain).await
+LL | |                     })
+   | |______________________^
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/async-await/async-closures/post-mono-higher-ranked-hang.next.stderr
+++ b/tests/ui/async-await/async-closures/post-mono-higher-ranked-hang.next.stderr
@@ -17,5 +17,14 @@ LL | |         yield_chain: &'l mut impl AsyncFnMut(&SymPerm<'db>),
 LL | |     ) -> Pin<Box<dyn std::future::Future<Output = ()> + 'l>> {
    | |____________________________________________________________^
 
+note: the above error was encountered while instantiating `fn ToChain::<'_, '_>::perm_pairs::<{async closure@$DIR/post-mono-higher-ranked-hang.rs:47:45: 47:67}>`
+  --> $DIR/post-mono-higher-ranked-hang.rs:47:21
+   |
+LL | /                     self.perm_pairs(l, &mut async move |left_pair| {
+LL | |
+LL | |                         self.perm_pairs(r, yield_chain).await
+LL | |                     })
+   | |______________________^
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/codegen/normalization-overflow/recursion-issue-105275.stderr
+++ b/tests/ui/codegen/normalization-overflow/recursion-issue-105275.stderr
@@ -10,5 +10,11 @@ note: `encode_num` defined here
 LL | pub fn encode_num<Writer: ExampleWriter>(n: u32, mut writer: Writer) -> Result<(), Writer::Error> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+note: the above error was encountered while instantiating `fn encode_num::<&mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut Error>`
+  --> $DIR/recursion-issue-105275.rs:6:9
+   |
+LL |         encode_num(n / 16, &mut writer)?;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/codegen/normalization-overflow/recursion-issue-105937.stderr
+++ b/tests/ui/codegen/normalization-overflow/recursion-issue-105937.stderr
@@ -10,5 +10,11 @@ note: `encode_num` defined here
 LL | pub fn encode_num<Writer: ExampleWriter>(n: u32, mut writer: Writer) -> Result<(), Writer::Error> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+note: the above error was encountered while instantiating `fn encode_num::<&mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut Error>`
+  --> $DIR/recursion-issue-105937.rs:6:9
+   |
+LL |         encode_num(n / 16, &mut writer)?;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/codegen/normalization-overflow/recursion-issue-117696-1.stderr
+++ b/tests/ui/codegen/normalization-overflow/recursion-issue-117696-1.stderr
@@ -7,5 +7,11 @@ LL |         T::count(it);
 note: `count` defined here
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 
+note: the above error was encountered while instantiating `fn <&mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut Empty as Iterator>::count`
+  --> $DIR/recursion-issue-117696-1.rs:25:9
+   |
+LL |         T::count(it);
+   |         ^^^^^^^^^^^^
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/codegen/normalization-overflow/recursion-issue-117696-2.stderr
+++ b/tests/ui/codegen/normalization-overflow/recursion-issue-117696-2.stderr
@@ -10,5 +10,11 @@ note: `rec` defined here
 LL | fn rec<T: Iterator>(mut it: T) {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+note: the above error was encountered while instantiating `fn rec::<&mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut std::option::IntoIter<()>>`
+  --> $DIR/recursion-issue-117696-2.rs:11:9
+   |
+LL |         rec(&mut it);
+   |         ^^^^^^^^^^^^
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/codegen/normalization-overflow/recursion-issue-118590.stderr
+++ b/tests/ui/codegen/normalization-overflow/recursion-issue-118590.stderr
@@ -7,5 +7,11 @@ LL |     recurse(nums.skip(42).peekable())
 note: `peekable` defined here
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 
+note: the above error was encountered while instantiating `fn <Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<Peekable<Skip<std::iter::Empty<()>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> as Iterator>::peekable`
+  --> $DIR/recursion-issue-118590.rs:10:13
+   |
+LL |     recurse(nums.skip(42).peekable())
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/codegen/normalization-overflow/recursion-issue-122823.stderr
+++ b/tests/ui/codegen/normalization-overflow/recursion-issue-122823.stderr
@@ -7,5 +7,11 @@ LL |         packets: decode_packets(&mut itr.take(0).peekable()),
 note: `peekable` defined here
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 
+note: the above error was encountered while instantiating `fn <std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::vec::IntoIter<u64>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> as Iterator>::peekable`
+  --> $DIR/recursion-issue-122823.rs:43:38
+   |
+LL |         packets: decode_packets(&mut itr.take(0).peekable()),
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/codegen/normalization-overflow/recursion-issue-131342.stderr
+++ b/tests/ui/codegen/normalization-overflow/recursion-issue-131342.stderr
@@ -7,5 +7,11 @@ LL |     let mut peeker = items.peekable();
 note: `peekable` defined here
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 
+note: the above error was encountered while instantiating `fn <&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut Peekable<&mut std::vec::IntoIter<u8>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> as Iterator>::peekable`
+  --> $DIR/recursion-issue-131342.rs:9:22
+   |
+LL |     let mut peeker = items.peekable();
+   |                      ^^^^^^^^^^^^^^^^
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/codegen/normalization-overflow/recursion-issue-137823.stderr
+++ b/tests/ui/codegen/normalization-overflow/recursion-issue-137823.stderr
@@ -10,5 +10,11 @@ note: `convert2` defined here
 LL | fn convert2<S: Converter>() -> S::Out {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+note: the above error was encountered while instantiating `fn convert2::<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<ConvertWrap<Ser>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>`
+  --> $DIR/recursion-issue-137823.rs:8:5
+   |
+LL |     convert2::<ConvertWrap<S>>()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/codegen/normalization-overflow/recursion-issue-92004.stderr
+++ b/tests/ui/codegen/normalization-overflow/recursion-issue-92004.stderr
@@ -7,5 +7,11 @@ LL |         packets: decode_packets(&mut itr.take(0).peekable()),
 note: `peekable` defined here
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 
+note: the above error was encountered while instantiating `fn <std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::iter::Take<&mut Peekable<std::vec::IntoIter<u64>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> as Iterator>::peekable`
+  --> $DIR/recursion-issue-92004.rs:44:38
+   |
+LL |         packets: decode_packets(&mut itr.take(0).peekable()),
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/codegen/normalization-overflow/recursion-issue-92470.stderr
+++ b/tests/ui/codegen/normalization-overflow/recursion-issue-92470.stderr
@@ -22,5 +22,11 @@ note: `encode` defined here
 LL | fn encode<E: Encoder>(mut encoder: E) {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+note: the above error was encountered while instantiating `fn encode::<&mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut EncoderImpl>`
+  --> $DIR/recursion-issue-92470.rs:15:5
+   |
+LL |     encode(&mut encoder);
+   |     ^^^^^^^^^^^^^^^^^^^^
+
 error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/codegen/normalization-overflow/recursion-issue-95134.stderr
+++ b/tests/ui/codegen/normalization-overflow/recursion-issue-95134.stderr
@@ -10,5 +10,11 @@ note: `encode_num` defined here
 LL | pub fn encode_num<Writer: ExampleWriter>(n: u32, mut writer: Writer) -> Result<(), Writer::Error> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+note: the above error was encountered while instantiating `fn encode_num::<&mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut &mut EmptyWriter>`
+  --> $DIR/recursion-issue-95134.rs:6:9
+   |
+LL |         encode_num(n / 16, &mut writer)?;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/codegen/overflow-during-mono.stderr
+++ b/tests/ui/codegen/overflow-during-mono.stderr
@@ -8,6 +8,15 @@ error[E0275]: overflow evaluating the requirement `for<'a> {closure@$DIR/overflo
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/overflow-during-mono.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 
+note: the above error was encountered while instantiating `fn quicksort::<Filter<Filter<Filter<..., ...>, ...>, ...>, ..., i32>`
+  --> $DIR/overflow-during-mono.rs:17:25
+   |
+LL |             let mut v = quicksort(less);
+   |                         ^^^^^^^^^^^^^^^
+   |
+   = note: the full name for the type has been written to '$TEST_BUILD_DIR/overflow-during-mono.long-type-$LONG_TYPE_HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
+
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/infinite/infinite-instantiation-struct-tail-ice-114484.stderr
+++ b/tests/ui/infinite/infinite-instantiation-struct-tail-ice-114484.stderr
@@ -92,5 +92,10 @@ LL |     fn virtualize(&self) -> &dyn MyTrait {
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/infinite-instantiation-struct-tail-ice-114484.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 
+note: the above error was encountered while instantiating `fn <VirtualWrapper<..., 1> as MyTrait>::virtualize`
+   |
+   = note: the full name for the type has been written to '$TEST_BUILD_DIR/infinite-instantiation-struct-tail-ice-114484.long-type-$LONG_TYPE_HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
+
 error: aborting due to 13 previous errors
 

--- a/tests/ui/infinite/infinite-instantiation.stderr
+++ b/tests/ui/infinite/infinite-instantiation.stderr
@@ -12,5 +12,14 @@ LL | fn function<T:ToOpt + Clone>(counter: usize, t: T) {
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/infinite-instantiation.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 
+note: the above error was encountered while instantiating `fn function::<Option<Option<Option<Option<...>>>>>`
+  --> $DIR/infinite-instantiation.rs:22:9
+   |
+LL |         function(counter - 1, t.to_option());
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the full name for the type has been written to '$TEST_BUILD_DIR/infinite-instantiation.long-type-$LONG_TYPE_HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-22638.stderr
+++ b/tests/ui/issues/issue-22638.stderr
@@ -10,5 +10,11 @@ note: `A::matches` defined here
 LL |     pub fn matches<F: Fn()>(&self, f: &F) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+note: the above error was encountered while instantiating `fn A::matches::<{closure@$DIR/issue-22638.rs:42:23: 42:25}>`
+  --> $DIR/issue-22638.rs:54:9
+   |
+LL |         a.matches(f)
+   |         ^^^^^^^^^^^^
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-37311-type-length-limit/issue-37311.stderr
+++ b/tests/ui/issues/issue-37311-type-length-limit/issue-37311.stderr
@@ -12,5 +12,14 @@ LL |     fn recurse(&self) {
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/issue-37311.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 
+note: the above error was encountered while instantiating `fn <(&(&(&..., ...), ...), ...) as Foo>::recurse`
+  --> $DIR/issue-37311.rs:17:9
+   |
+LL |         (self, self).recurse();
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the full name for the type has been written to '$TEST_BUILD_DIR/issue-37311.long-type-$LONG_TYPE_HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/limits/type-length-limit-enforcement.stderr
+++ b/tests/ui/limits/type-length-limit-enforcement.stderr
@@ -14,5 +14,7 @@ error: reached the type-length limit while instantiating `<{closure@...} as FnMu
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/type-length-limit-enforcement.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 
+note: the above error was encountered while instantiating `fn std::rt::lang_start::<()>`
+
 error: aborting due to 2 previous errors
 

--- a/tests/ui/privacy/missing-mir-priv-bounds-2.stderr
+++ b/tests/ui/privacy/missing-mir-priv-bounds-2.stderr
@@ -6,5 +6,11 @@ note: missing optimized MIR for this item (was the crate `missing_mir_priv_bound
 LL |         pub fn generic<T>() {}
    |         ^^^^^^^^^^^^^^^^^^^
 
+note: the above error was encountered while instantiating `fn <Handler as PubTrHandler>::handle::<dep::Dummy>`
+  --> $DIR/auxiliary/missing-mir-priv-bounds-extern-2.rs:26:5
+   |
+LL |     T::handle::<Dummy>();
+   |     ^^^^^^^^^^^^^^^^^^^^
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/privacy/missing-mir-priv-bounds-3.stderr
+++ b/tests/ui/privacy/missing-mir-priv-bounds-3.stderr
@@ -6,5 +6,11 @@ note: missing optimized MIR for this item (was the crate `missing_mir_priv_bound
 LL |         pub fn generic<T>() {}
    |         ^^^^^^^^^^^^^^^^^^^
 
+note: the above error was encountered while instantiating `fn <Handler as SubHandler>::handle::<dep::Dummy>`
+  --> $DIR/auxiliary/missing-mir-priv-bounds-extern-3.rs:20:5
+   |
+LL |     <T as SubHandler>::handle::<Dummy>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/privacy/missing-mir-priv-bounds.stderr
+++ b/tests/ui/privacy/missing-mir-priv-bounds.stderr
@@ -6,5 +6,11 @@ note: missing optimized MIR for this item (was the crate `missing_mir_priv_bound
 LL |         pub fn generic<T>() {}
    |         ^^^^^^^^^^^^^^^^^^^
 
+note: the above error was encountered while instantiating `fn wut::<dep::Dummy>`
+  --> $DIR/missing-mir-priv-bounds.rs:11:5
+   |
+LL |     wut(get_dummy());
+   |     ^^^^^^^^^^^^^^^^
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/recursion/infinite-function-recursion-error-8727.stderr
+++ b/tests/ui/recursion/infinite-function-recursion-error-8727.stderr
@@ -23,5 +23,14 @@ LL | fn generic<T>() {
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/infinite-function-recursion-error-8727.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 
+note: the above error was encountered while instantiating `fn generic::<Option<Option<Option<Option<...>>>>>`
+  --> $DIR/infinite-function-recursion-error-8727.rs:9:5
+   |
+LL |     generic::<Option<T>>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the full name for the type has been written to '$TEST_BUILD_DIR/infinite-function-recursion-error-8727.long-type-$LONG_TYPE_HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
+
 error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/recursion/issue-83150.stderr
+++ b/tests/ui/recursion/issue-83150.stderr
@@ -19,6 +19,15 @@ error[E0275]: overflow evaluating the requirement `Map<&mut std::ops::Range<u8>,
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/issue-83150.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 
+note: the above error was encountered while instantiating `fn func::<Map<&mut Map<&mut Map<&mut Map<..., ...>, ...>, ...>, ...>>`
+  --> $DIR/issue-83150.rs:12:5
+   |
+LL |     func(&mut iter.map(|x| x + 1))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the full name for the type has been written to '$TEST_BUILD_DIR/issue-83150.long-type-$LONG_TYPE_HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
+
 error: aborting due to 1 previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/recursion/recursion.stderr
+++ b/tests/ui/recursion/recursion.stderr
@@ -12,5 +12,14 @@ LL | fn test<T:Dot> (n:isize, i:isize, first:T, second:T) ->isize {
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/recursion.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 
+note: the above error was encountered while instantiating `fn test::<Cons<Cons<Cons<Cons<Cons<Cons<...>>>>>>>`
+  --> $DIR/recursion.rs:17:11
+   |
+LL |     _ => {test (n-1, i+1, Cons {head:2*i+1, tail:first}, Cons{head:i*i, tail:second})}
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the full name for the type has been written to '$TEST_BUILD_DIR/recursion.long-type-$LONG_TYPE_HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/recursion/recursive-impl-trait-iterator-by-ref-67552.stderr
+++ b/tests/ui/recursion/recursive-impl-trait-iterator-by-ref-67552.stderr
@@ -14,5 +14,14 @@ LL | |     T: Iterator,
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/recursive-impl-trait-iterator-by-ref-67552.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 
+note: the above error was encountered while instantiating `fn rec::<&mut &mut &mut &mut &mut &mut &mut &mut ...>`
+  --> $DIR/recursive-impl-trait-iterator-by-ref-67552.rs:28:9
+   |
+LL |         rec(identity(&mut it))
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the full name for the type has been written to '$TEST_BUILD_DIR/recursive-impl-trait-iterator-by-ref-67552.long-type-$LONG_TYPE_HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/recursion_limit/zero-overflow.stderr
+++ b/tests/ui/recursion_limit/zero-overflow.stderr
@@ -2,6 +2,8 @@ error[E0275]: overflow evaluating the requirement `&mut Self: DispatchFromDyn<&m
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "2"]` attribute to your crate (`zero_overflow`)
 
+note: the above error was encountered while instantiating `fn std::rt::lang_start::<()>`
+
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/traits/issue-91949-hangs-on-recursion.stderr
+++ b/tests/ui/traits/issue-91949-hangs-on-recursion.stderr
@@ -28,6 +28,15 @@ LL | impl<T, I: Iterator<Item = T>> Iterator for IteratorOfWrapped<T, I> {
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/issue-91949-hangs-on-recursion.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 
+note: the above error was encountered while instantiating `fn recurse::<Map<IteratorOfWrapped<(), Map<..., ...>>, ...>>`
+  --> $DIR/issue-91949-hangs-on-recursion.rs:26:5
+   |
+LL |     recurse(IteratorOfWrapped(elements).map(|t| t.0))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the full name for the type has been written to '$TEST_BUILD_DIR/issue-91949-hangs-on-recursion.long-type-$LONG_TYPE_HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
+
 error: aborting due to 1 previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0275`.


### PR DESCRIPTION
This makes post-monomorphization error detection work with fatal errors by using `defer` so it can catch fatal errors too.

Found this while working on making cycle errors fatal.

cc @lqd @oli-obk 