### PR TITLE
Remove redundant clone

### DIFF
--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -118,14 +118,14 @@ pub fn new_parser_from_file<'a>(
         let msg = format!("couldn't read `{}`: {}", path.display(), e);
         let mut err = psess.dcx().struct_fatal(msg);
         if let Ok(contents) = std::fs::read(path)
-            && let Err(utf8err) = String::from_utf8(contents.clone())
+            && let Err(utf8err) = std::str::from_utf8(&contents)
         {
             utf8_error(
                 sm,
                 &path.display().to_string(),
                 sp,
                 &mut err,
-                utf8err.utf8_error(),
+                utf8err,
                 &contents,
             );
         }

--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -120,14 +120,7 @@ pub fn new_parser_from_file<'a>(
         if let Ok(contents) = std::fs::read(path)
             && let Err(utf8err) = std::str::from_utf8(&contents)
         {
-            utf8_error(
-                sm,
-                &path.display().to_string(),
-                sp,
-                &mut err,
-                utf8err,
-                &contents,
-            );
+            utf8_error(sm, &path.display().to_string(), sp, &mut err, utf8err, &contents);
         }
         if let Some(sp) = sp {
             err.span(sp);


### PR DESCRIPTION
Don't clone file content just for utf8 checks.
