### PR TITLE
[win] Fix truncated unwinds for Arm64 Windows

### DIFF
--- a/tests/ui/runtime/backtrace-debuginfo.rs
+++ b/tests/ui/runtime/backtrace-debuginfo.rs
@@ -47,14 +47,9 @@ macro_rules! dump_and_die {
         // there, even on i686-pc-windows-msvc. We do the best we can in
         // rust-lang/rust to test it as well, but sometimes we just gotta keep
         // landing PRs.
-        //
-        // aarch64-msvc/arm64ec-msvc is broken as its backtraces are truncated.
-        // See https://github.com/rust-lang/rust/issues/140489
         if cfg!(any(target_os = "android",
                     all(target_os = "linux", target_arch = "arm"),
                     all(target_env = "msvc", target_arch = "x86"),
-                    all(target_env = "msvc", target_arch = "aarch64"),
-                    all(target_env = "msvc", target_arch = "arm64ec"),
                     target_os = "freebsd",
                     target_os = "dragonfly",
                     target_os = "openbsd")) {


### PR DESCRIPTION
Panic backtraces on ARM64 Windows are truncated because Rust's LLVM configuration sets `NoTrapAfterNoreturn = true`, which suppresses the generation of `brk #0x1` (trap) instructions after calls to `noreturn` functions. Without this trap instruction, the return address from a `noreturn` call points past the end of the calling function into an unrelated function, causing `RtlLookupFunctionEntry` to return the wrong unwind information, which terminates the stack walk prematurely.

In general, `NoTrapAfterNoreturn = true` is recommended against for Windows, since we have seen security vulnerabilities in the past where an attacker has managed to return from a noreturn function, or the function wasn't actually noereturn, resulting in executing whatever was after the call.

This change disables setting `NoTrapAfterNoreturn = true` for Windows.

Fixes rust-lang/rust#140489