### PR TITLE
std::net: clamp linger timeout value to prevent silent truncation.

### DIFF
--- a/library/std/src/sys/net/connection/socket/hermit.rs
+++ b/library/std/src/sys/net/connection/socket/hermit.rs
@@ -260,7 +260,7 @@ impl Socket {
     pub fn set_linger(&self, linger: Option<Duration>) -> io::Result<()> {
         let linger = netc::linger {
             l_onoff: linger.is_some() as i32,
-            l_linger: linger.unwrap_or_default().as_secs() as libc::c_int,
+            l_linger: cmp::min(linger.unwrap_or_default().as_secs(), c_int::MAX as u64) as c_int,
         };
 
         unsafe { setsockopt(self, netc::SOL_SOCKET, netc::SO_LINGER, linger) }

--- a/library/std/src/sys/net/connection/socket/solid.rs
+++ b/library/std/src/sys/net/connection/socket/solid.rs
@@ -319,7 +319,8 @@ impl Socket {
     pub fn set_linger(&self, linger: Option<Duration>) -> io::Result<()> {
         let linger = netc::linger {
             l_onoff: linger.is_some() as netc::c_int,
-            l_linger: linger.unwrap_or_default().as_secs() as netc::c_int,
+            l_linger: cmp::min(linger.unwrap_or_default().as_secs(), netc::c_int::MAX as u64)
+                as netc::c_int,
         };
 
         unsafe { setsockopt(self, netc::SOL_SOCKET, netc::SO_LINGER, linger) }

--- a/library/std/src/sys/net/connection/socket/unix.rs
+++ b/library/std/src/sys/net/connection/socket/unix.rs
@@ -432,8 +432,8 @@ impl Socket {
     #[cfg(not(target_os = "cygwin"))]
     pub fn set_linger(&self, linger: Option<Duration>) -> io::Result<()> {
         let linger = libc::linger {
-            l_onoff: linger.is_some() as libc::c_int,
-            l_linger: linger.unwrap_or_default().as_secs() as libc::c_int,
+            l_onoff: linger.is_some() as c_int,
+            l_linger: cmp::min(linger.unwrap_or_default().as_secs(), c_int::MAX as u64) as c_int,
         };
 
         unsafe { setsockopt(self, libc::SOL_SOCKET, SO_LINGER, linger) }
@@ -443,7 +443,8 @@ impl Socket {
     pub fn set_linger(&self, linger: Option<Duration>) -> io::Result<()> {
         let linger = libc::linger {
             l_onoff: linger.is_some() as libc::c_ushort,
-            l_linger: linger.unwrap_or_default().as_secs() as libc::c_ushort,
+            l_linger: cmp::min(linger.unwrap_or_default().as_secs(), libc::c_ushort::MAX as u64)
+                as libc::c_ushort,
         };
 
         unsafe { setsockopt(self, libc::SOL_SOCKET, SO_LINGER, linger) }

--- a/library/std/src/sys/net/connection/socket/windows.rs
+++ b/library/std/src/sys/net/connection/socket/windows.rs
@@ -413,7 +413,8 @@ impl Socket {
     pub fn set_linger(&self, linger: Option<Duration>) -> io::Result<()> {
         let linger = c::LINGER {
             l_onoff: linger.is_some() as c_ushort,
-            l_linger: linger.unwrap_or_default().as_secs() as c_ushort,
+            l_linger: cmp::min(linger.unwrap_or_default().as_secs(), c_ushort::MAX as u64)
+                as c_ushort,
         };
 
         unsafe { setsockopt(self, c::SOL_SOCKET, c::SO_LINGER, linger) }


### PR DESCRIPTION
Duration::as_secs() returns u64 but l_linger field type is narrower, c_int on most unix platforms, c_ushort on cygwin and windows. clamping before the cast, consistent with how set_timeout handles this.