### PR TITLE
Fix ICE on empty file with -Zquery-dep-graph

### DIFF
--- a/compiler/rustc_middle/src/dep_graph/graph.rs
+++ b/compiler/rustc_middle/src/dep_graph/graph.rs
@@ -826,7 +826,13 @@ impl DepGraph {
     where
         F: FnOnce() -> String,
     {
-        let dep_node_debug = &self.data.as_ref().unwrap().dep_node_debug;
+        // Early queries (e.g., `-Z query-dep-graph` on empty crates) can reach here
+        // before the graph is initialized. Return early to prevent an ICE.
+        let data = match &self.data {
+            Some(d) => d,
+            None => return,
+        };
+        let dep_node_debug = &data.dep_node_debug;
 
         if dep_node_debug.borrow().contains_key(&dep_node) {
             return;

--- a/tests/ui/dep-graph/query-dep-graph-empty.rs
+++ b/tests/ui/dep-graph/query-dep-graph-empty.rs
@@ -1,0 +1,7 @@
+//@ build-pass
+//@ compile-flags: -Zquery-dep-graph --crate-type lib
+//@ edition: 2021
+
+// This file is intentionally left empty to reproduce issue #153199.
+// rustc used to ICE when generating a dependency graph for an empty file
+// because early queries would panic when unwrapping an uninitialized graph.


### PR DESCRIPTION
added a guard in `DepGraph::register_dep_node_debug_str` so it early-returns 
when `self.data` is still `None`. this happens for the first few dep-nodes 
in an empty crate with `-Z query-dep-graph`, which caused the previous 
`unwrap()` panic.

fixes rust-lang/rust#153199

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
