### PR TITLE
`rust-analyzer` subtree update

### DIFF
--- a/src/tools/rust-analyzer/crates/hir-ty/src/infer/cast.rs
+++ b/src/tools/rust-analyzer/crates/hir-ty/src/infer/cast.rs
@@ -328,11 +328,7 @@ impl<'db> CastCheck<'db> {
                     //
                     // Note that trait upcasting goes through a different mechanism (`coerce_unsized`)
                     // and is unaffected by this check.
-                    (Some(src_principal), Some(dst_principal)) => {
-                        if src_principal == dst_principal {
-                            return Ok(());
-                        }
-
+                    (Some(src_principal), Some(_)) => {
                         // We need to reconstruct trait object types.
                         // `m_src` and `m_dst` won't work for us here because they will potentially
                         // contain wrappers, which we do not care about.

--- a/src/tools/rust-analyzer/crates/ide-completion/src/completions/pattern.rs
+++ b/src/tools/rust-analyzer/crates/ide-completion/src/completions/pattern.rs
@@ -95,7 +95,7 @@ pub(crate) fn complete_pattern(
                     if refutable || single_variant_enum(variant.parent_enum(ctx.db)) =>
                 {
                     acc.add_variant_pat(ctx, pattern_ctx, None, variant, Some(name.clone()));
-                    true
+                    false
                 }
                 hir::ModuleDef::Adt(hir::Adt::Enum(e)) => refutable || single_variant_enum(e),
                 hir::ModuleDef::Const(..) => refutable,

--- a/src/tools/rust-analyzer/crates/ide-completion/src/tests/pattern.rs
+++ b/src/tools/rust-analyzer/crates/ide-completion/src/tests/pattern.rs
@@ -122,7 +122,6 @@ fn foo() {
             st Record
             st Tuple
             st Unit
-            ev TupleV
             bn Record {…} Record { field$1 }$0
             bn Tuple(…)            Tuple($1)$0
             bn TupleV(…)          TupleV($1)$0
@@ -159,8 +158,6 @@ fn foo(foo: Foo) { match foo { Foo { x: $0 } } }
         expect![[r#"
             en Bar
             st Foo
-            ev Nil
-            ev Value
             bn Foo {…} Foo { x$1 }$0
             bn Nil             Nil$0
             bn Value         Value$0
@@ -189,7 +186,6 @@ fn foo() {
             st Record
             st Tuple
             st Unit
-            ev Variant
             bn Record {…} Record { field$1 }$0
             bn Tuple(…)            Tuple($1)$0
             bn Variant               Variant$0
@@ -350,6 +346,34 @@ fn func() {
             bn RecordV {…} RecordV { field$1 }$0
             bn TupleV(…)            TupleV($1)$0
             bn UnitV                     UnitV$0
+        "#]],
+    );
+}
+
+#[test]
+fn enum_unqualified() {
+    check_with_base_items(
+        r#"
+use Enum::*;
+fn func() {
+    if let $0 = unknown {}
+}
+"#,
+        expect![[r#"
+            ct CONST
+            en Enum
+            ma makro!(…)      macro_rules! makro
+            md module
+            st Record
+            st Tuple
+            st Unit
+            bn Record {…}   Record { field$1 }$0
+            bn RecordV {…} RecordV { field$1 }$0
+            bn Tuple(…)              Tuple($1)$0
+            bn TupleV(…)            TupleV($1)$0
+            bn UnitV                     UnitV$0
+            kw mut
+            kw ref
         "#]],
     );
 }

--- a/src/tools/rust-analyzer/crates/ide-completion/src/tests/record.rs
+++ b/src/tools/rust-analyzer/crates/ide-completion/src/tests/record.rs
@@ -61,8 +61,6 @@ fn foo(baz: Baz) {
             en Baz
             en Result
             md core
-            ev Err
-            ev Ok
             bn Baz::Bar Baz::Bar$0
             bn Baz::Foo Baz::Foo$0
             bn Err(…)    Err($1)$0
@@ -89,10 +87,6 @@ fn foo(baz: Baz) {
             en Baz
             en Result
             md core
-            ev Bar
-            ev Err
-            ev Foo
-            ev Ok
             bn Bar        Bar$0
             bn Err(…) Err($1)$0
             bn Foo        Foo$0

--- a/src/tools/rust-analyzer/crates/ide-diagnostics/src/handlers/invalid_cast.rs
+++ b/src/tools/rust-analyzer/crates/ide-diagnostics/src/handlers/invalid_cast.rs
@@ -517,11 +517,13 @@ trait Trait<'a> {}
 
 fn add_auto<'a>(x: *mut dyn Trait<'a>) -> *mut (dyn Trait<'a> + Send) {
     x as _
+  //^^^^^^ error: cannot add auto trait to dyn bound via pointer cast
 }
 
 // (to test diagnostic list formatting)
 fn add_multiple_auto<'a>(x: *mut dyn Trait<'a>) -> *mut (dyn Trait<'a> + Send + Sync + Unpin) {
     x as _
+  //^^^^^^ error: cannot add auto trait to dyn bound via pointer cast
 }
 "#,
         );

--- a/src/tools/rust-analyzer/crates/proc-macro-api/src/bidirectional_protocol/msg.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-api/src/bidirectional_protocol/msg.rs
@@ -22,6 +22,7 @@ pub enum SubRequest {
     LineColumn { file_id: u32, ast_id: u32, offset: u32 },
     ByteRange { file_id: u32, ast_id: u32, start: u32, end: u32 },
     SpanSource { file_id: u32, ast_id: u32, start: u32, end: u32, ctx: u32 },
+    SpanParent { file_id: u32, ast_id: u32, start: u32, end: u32, ctx: u32 },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -50,9 +51,21 @@ pub enum SubResponse {
         end: u32,
         ctx: u32,
     },
+    SpanParentResult {
+        parent_span: Option<ParentSpan>,
+    },
     Cancel {
         reason: String,
     },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ParentSpan {
+    pub file_id: u32,
+    pub ast_id: u32,
+    pub start: u32,
+    pub end: u32,
+    pub ctx: u32,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/lib.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/lib.rs
@@ -121,6 +121,7 @@ pub trait ProcMacroClientInterface {
 
     fn byte_range(&mut self, span: Span) -> Range<usize>;
     fn span_source(&mut self, span: Span) -> Span;
+    fn span_parent(&mut self, span: Span) -> Option<Span>;
 }
 
 const EXPANDER_STACK_SIZE: usize = 8 * 1024 * 1024;

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/server_impl/rust_analyzer_span.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/server_impl/rust_analyzer_span.rs
@@ -168,8 +168,10 @@ impl server::Server for RaSpanServer<'_> {
         self.callback.as_mut()?.source_text(span)
     }
 
-    fn span_parent(&mut self, _span: Self::Span) -> Option<Self::Span> {
-        // FIXME requires db, looks up the parent call site
+    fn span_parent(&mut self, span: Self::Span) -> Option<Self::Span> {
+        if let Some(ref mut callback) = self.callback {
+            return callback.span_parent(span);
+        }
         None
     }
     fn span_source(&mut self, span: Self::Span) -> Self::Span {

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/tests/utils.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/tests/utils.rs
@@ -146,6 +146,10 @@ impl ProcMacroClientInterface for MockCallback<'_> {
     fn span_source(&mut self, span: Span) -> Span {
         span
     }
+
+    fn span_parent(&mut self, _span: Span) -> Option<Span> {
+        None
+    }
 }
 
 pub fn assert_expand_with_callback(

--- a/src/tools/rust-analyzer/crates/project-model/src/cargo_config_file.rs
+++ b/src/tools/rust-analyzer/crates/project-model/src/cargo_config_file.rs
@@ -158,14 +158,15 @@ pub(crate) fn make_lockfile_copy(
             build: semver::BuildMetadata::EMPTY,
         };
 
-    const MINIMUM_TOOLCHAIN_VERSION_SUPPORTING_LOCKFILE_PATH_ENV: semver::Version =
-        semver::Version {
-            major: 1,
-            minor: 95,
-            patch: 0,
-            pre: semver::Prerelease::EMPTY,
-            build: semver::BuildMetadata::EMPTY,
-        };
+    // TODO: turn this into a const and remove pre once 1.95 is stable
+    #[allow(non_snake_case)]
+    let MINIMUM_TOOLCHAIN_VERSION_SUPPORTING_LOCKFILE_PATH_ENV: semver::Version = semver::Version {
+        major: 1,
+        minor: 95,
+        patch: 0,
+        pre: semver::Prerelease::new("nightly").unwrap(),
+        build: semver::BuildMetadata::EMPTY,
+    };
 
     let usage = if *toolchain_version >= MINIMUM_TOOLCHAIN_VERSION_SUPPORTING_LOCKFILE_PATH_ENV {
         LockfileUsage::WithEnvVar

--- a/src/tools/rust-analyzer/crates/rust-analyzer/src/handlers/dispatch.rs
+++ b/src/tools/rust-analyzer/crates/rust-analyzer/src/handlers/dispatch.rs
@@ -414,7 +414,8 @@ impl NotificationDispatcher<'_> {
         let params = match not.extract::<N::Params>(N::METHOD) {
             Ok(it) => it,
             Err(ExtractError::JsonError { method, error }) => {
-                panic!("Invalid request\nMethod: {method}\n error: {error}",)
+                tracing::error!(method = %method, error = %error, "invalid notification");
+                return self;
             }
             Err(ExtractError::MethodMismatch(not)) => {
                 self.not = Some(not);

--- a/src/tools/rust-analyzer/crates/rust-analyzer/tests/slow-tests/main.rs
+++ b/src/tools/rust-analyzer/crates/rust-analyzer/tests/slow-tests/main.rs
@@ -22,6 +22,7 @@ mod testdir;
 
 use std::{collections::HashMap, path::PathBuf, time::Instant};
 
+use ide_db::FxHashMap;
 use lsp_types::{
     CodeActionContext, CodeActionParams, CompletionParams, DidOpenTextDocumentParams,
     DocumentFormattingParams, DocumentRangeFormattingParams, FileRename, FormattingOptions,
@@ -670,6 +671,17 @@ fn main() {}
 #[test]
 fn test_format_document_range() {
     if skip_slow_tests() {
+        return;
+    }
+
+    // This test requires a nightly toolchain, so skip if it's not available.
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let has_nightly_rustfmt = toolchain::command("rustfmt", cwd, &FxHashMap::default())
+        .args(["+nightly", "--version"])
+        .output()
+        .is_ok_and(|out| out.status.success());
+    if !has_nightly_rustfmt {
+        tracing::warn!("skipping test_format_document_range: nightly rustfmt not available");
         return;
     }
 

--- a/src/tools/rust-analyzer/crates/syntax/src/ast/syntax_factory/constructors.rs
+++ b/src/tools/rust-analyzer/crates/syntax/src/ast/syntax_factory/constructors.rs
@@ -79,8 +79,12 @@ impl SyntaxFactory {
         make::path_concat(first, second).clone_for_update()
     }
 
+    pub fn visibility_pub_crate(&self) -> ast::Visibility {
+        make::visibility_pub_crate().clone_for_update()
+    }
+
     pub fn visibility_pub(&self) -> ast::Visibility {
-        make::visibility_pub()
+        make::visibility_pub().clone_for_update()
     }
 
     pub fn struct_(


### PR DESCRIPTION
Subtree update of `rust-analyzer` to https://github.com/rust-lang/rust-analyzer/commit/fbc7b76b27d2029d8000ad63225546ff59789752.

Created using https://github.com/rust-lang/josh-sync.

r? @ghost