### PR TITLE
mark two polonius tests as known-bug

### DIFF
--- a/tests/ui/impl-trait/alias-liveness/rpit-hide-lifetime-for-swap.edition2015.stderr
+++ b/tests/ui/impl-trait/alias-liveness/rpit-hide-lifetime-for-swap.edition2015.stderr
@@ -1,5 +1,5 @@
 error[E0700]: hidden type for `impl Swap + 'a` captures lifetime that does not appear in bounds
-  --> $DIR/rpit-hide-lifetime-for-swap.rs:20:5
+  --> $DIR/rpit-hide-lifetime-for-swap.rs:26:5
    |
 LL | fn hide<'a, 'b: 'a, T: 'static>(x: Rc<RefCell<&'b T>>) -> impl Swap + 'a {
    |             --                                            -------------- opaque type defined here

--- a/tests/ui/impl-trait/alias-liveness/rpit-hide-lifetime-for-swap.edition2024.stderr
+++ b/tests/ui/impl-trait/alias-liveness/rpit-hide-lifetime-for-swap.edition2024.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `x` does not live long enough
-  --> $DIR/rpit-hide-lifetime-for-swap.rs:27:38
+  --> $DIR/rpit-hide-lifetime-for-swap.rs:33:38
    |
 LL |     let x = [1, 2, 3];
    |         - binding `x` declared here

--- a/tests/ui/impl-trait/alias-liveness/rpit-hide-lifetime-for-swap.rs
+++ b/tests/ui/impl-trait/alias-liveness/rpit-hide-lifetime-for-swap.rs
@@ -1,6 +1,12 @@
-//@revisions: edition2015 edition2024
-//@[edition2015] edition:2015
-//@[edition2024] edition:2024
+//@ revisions: edition2015 edition2024 polonius_alpha
+//@ ignore-compare-mode-polonius (explicit revisions)
+//@ [edition2015] edition: 2015
+//@ [edition2024] edition: 2024
+//@ [polonius_alpha] known-bug: #153215
+//@ [polonius_alpha] check-pass
+//@ [polonius_alpha] edition: 2024
+//@ [polonius_alpha] compile-flags: -Zpolonius=next
+
 // This test should never pass!
 
 use std::cell::RefCell;

--- a/tests/ui/impl-trait/hidden-lifetimes.edition2015.stderr
+++ b/tests/ui/impl-trait/hidden-lifetimes.edition2015.stderr
@@ -1,5 +1,5 @@
 error[E0700]: hidden type for `impl Swap + 'a` captures lifetime that does not appear in bounds
-  --> $DIR/hidden-lifetimes.rs:33:5
+  --> $DIR/hidden-lifetimes.rs:38:5
    |
 LL | fn hide_ref<'a, 'b, T: 'static>(x: &'a mut &'b T) -> impl Swap + 'a {
    |                 --                                   -------------- opaque type defined here
@@ -14,7 +14,7 @@ LL | fn hide_ref<'a, 'b, T: 'static>(x: &'a mut &'b T) -> impl Swap + 'a + use<'
    |                                                                     ++++++++++++++++
 
 error[E0700]: hidden type for `impl Swap + 'a` captures lifetime that does not appear in bounds
-  --> $DIR/hidden-lifetimes.rs:50:5
+  --> $DIR/hidden-lifetimes.rs:55:5
    |
 LL | fn hide_rc_refcell<'a, 'b: 'a, T: 'static>(x: Rc<RefCell<&'b T>>) -> impl Swap + 'a {
    |                        --                                            -------------- opaque type defined here

--- a/tests/ui/impl-trait/hidden-lifetimes.edition2024.stderr
+++ b/tests/ui/impl-trait/hidden-lifetimes.edition2024.stderr
@@ -1,5 +1,5 @@
 error[E0515]: cannot return value referencing local variable `x`
-  --> $DIR/hidden-lifetimes.rs:41:5
+  --> $DIR/hidden-lifetimes.rs:46:5
    |
 LL |     hide_ref(&mut res).swap(hide_ref(&mut &x));
    |                                           -- `x` is borrowed here
@@ -7,7 +7,7 @@ LL |     res
    |     ^^^ returns a value referencing data owned by the current function
 
 error[E0597]: `x` does not live long enough
-  --> $DIR/hidden-lifetimes.rs:57:38
+  --> $DIR/hidden-lifetimes.rs:62:38
    |
 LL |     let x = [1, 2, 3];
    |         - binding `x` declared here

--- a/tests/ui/impl-trait/hidden-lifetimes.rs
+++ b/tests/ui/impl-trait/hidden-lifetimes.rs
@@ -1,6 +1,11 @@
-//@revisions: edition2015 edition2024
-//@[edition2015] edition:2015
-//@[edition2024] edition:2024
+//@ revisions: edition2015 edition2024 polonius_alpha
+//@ ignore-compare-mode-polonius (explicit revisions)
+//@ [edition2015] edition: 2015
+//@ [edition2024] edition: 2024
+//@ [polonius_alpha] known-bug: #153215
+//@ [polonius_alpha] check-pass
+//@ [polonius_alpha] edition: 2024
+//@ [polonius_alpha] compile-flags: -Zpolonius=next
 
 // Test to show what happens if we were not careful and allowed invariant
 // lifetimes to escape though an impl trait.


### PR DESCRIPTION
As described in https://github.com/rust-lang/rust/issues/153215, we want to track these two tests in case anything changes and when/if other fixes land.

As discussed in this week's meeting, r? @jackh726 (or anyone)