### PR TITLE
Roll rustfmt reviewers for in-tree rustfmt

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1620,6 +1620,7 @@ dep-bumps = [
 "/src/tools/rustdoc" =                                   ["rustdoc"]
 "/src/tools/rustdoc-js" =                                ["rustdoc"]
 "/src/tools/rustdoc-themes" =                            ["rustdoc"]
+"/src/tools/rustfmt" =                                   ["rustfmt", "rustfmt-contributors"]
 "/src/tools/tidy" =                                      ["bootstrap"]
 "/src/tools/x" =                                         ["bootstrap"]
 "/src/tools/rustdoc-gui-test" =                          ["bootstrap"]


### PR DESCRIPTION
Noticed in https://github.com/rust-lang/rust/pull/153229#issuecomment-3977482140, where because `src/tools/rustfmt` has no corresponding `[assign.owners]` entry, it rolls one of the `fallback` reviewers (Mark and me) which is needless indirection, since if it rolls to Mark, Mark will have to reroll again.

This _can_ also be

```toml
"/src/tools/rustfmt" = ["rustfmt", "rustfmt-contributors"]
```

which corresponds to https://github.com/orgs/rust-lang/teams/rustfmt and https://github.com/orgs/rust-lang/teams/rustfmt-contributors respectively. I will double-check with triagebot team if we can use review rotation toggles for `rust-lang/rust` in-tree `rustfmt` specifically.

Discussion: [#t-rustfmt > review queue tracking for rust-lang/rust in-tree rustfmt](https://rust-lang.zulipchat.com/#narrow/channel/357797-t-rustfmt/topic/review.20queue.20tracking.20for.20rust-lang.2Frust.20in-tree.20rustfmt/with/576498516)

### Unresolved question

- ~~Do we want to start everyone off as off-rotation? Or on-rotation? I plan to start conservatively by preserving existing effective status, which is everyone off-rotation.~~ We will match existing defaults, with everyone starting off as off-team-rotation.

r? @ytmimi