### PR TITLE
parse: add machine-applicable suggestion to `FrontmatterExtraCharactersAfterClose`

### DIFF
--- a/compiler/rustc_lexer/src/lib.rs
+++ b/compiler/rustc_lexer/src/lib.rs
@@ -71,26 +71,28 @@ impl Token {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TokenKind {
     /// A line comment, e.g. `// comment`.
-    LineComment {
-        doc_style: Option<DocStyle>,
-    },
+    LineComment { doc_style: Option<DocStyle> },
 
     /// A block comment, e.g. `/* block comment */`.
     ///
     /// Block comments can be recursive, so a sequence like `/* /* */`
     /// will not be considered terminated and will result in a parsing error.
-    BlockComment {
-        doc_style: Option<DocStyle>,
-        terminated: bool,
-    },
+    BlockComment { doc_style: Option<DocStyle>, terminated: bool },
 
     /// Any whitespace character sequence.
     Whitespace,
 
-    Frontmatter {
-        has_invalid_preceding_whitespace: bool,
-        invalid_infostring: bool,
-    },
+    /// A frontmatter block delimited by `---` fences on their own lines.
+    /// Only recognized at the very beginning of a file, before any other
+    /// non-whitespace tokens. See [tracking issue #136889] for the feature.
+    ///
+    /// `has_invalid_preceding_whitespace` is set when the character immediately
+    /// before the opening `---` is not a newline.
+    /// `invalid_infostring` is set when the text following the opening `---`
+    /// does not form a valid single identifier.
+    ///
+    /// [tracking issue #136889]: https://github.com/rust-lang/rust/issues/136889
+    Frontmatter { has_invalid_preceding_whitespace: bool, invalid_infostring: bool },
 
     /// An identifier or keyword, e.g. `ident` or `continue`.
     Ident,
@@ -133,15 +135,10 @@ pub enum TokenKind {
     /// this type will need to check for and reject that case.
     ///
     /// See [LiteralKind] for more details.
-    Literal {
-        kind: LiteralKind,
-        suffix_start: u32,
-    },
+    Literal { kind: LiteralKind, suffix_start: u32 },
 
     /// A lifetime, e.g. `'a`.
-    Lifetime {
-        starts_with_number: bool,
-    },
+    Lifetime { starts_with_number: bool },
 
     /// `;`
     Semi,

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -928,6 +928,8 @@ pub(crate) struct FoundExprWouldBeStmt {
 pub(crate) struct FrontmatterExtraCharactersAfterClose {
     #[primary_span]
     pub span: Span,
+    #[suggestion("remove the extra characters", code = "", applicability = "machine-applicable")]
+    pub remove: Span,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -718,7 +718,13 @@ impl<'psess, 'src> Lexer<'psess, 'src> {
 
         if !rest.trim_matches(is_horizontal_whitespace).is_empty() {
             let span = self.mk_sp(last_line_start_pos, self.pos);
-            self.dcx().emit_err(errors::FrontmatterExtraCharactersAfterClose { span });
+            // The extra characters start right after the closing dashes.
+            // `last_line_trimmed` has any leading whitespace stripped, so we
+            // must account for that offset when computing the absolute position.
+            let whitespace_len = last_line.len() - last_line_trimmed.len();
+            let extra_start = last_line_start_pos + BytePos((whitespace_len + len_close) as u32);
+            let remove = self.mk_sp(extra_start, self.pos);
+            self.dcx().emit_err(errors::FrontmatterExtraCharactersAfterClose { span, remove });
         }
     }
 

--- a/tests/ui/frontmatter/fence-close-extra-after.fixed
+++ b/tests/ui/frontmatter/fence-close-extra-after.fixed
@@ -1,5 +1,5 @@
 ---
----cargo
+---
 //~^ ERROR: extra characters after frontmatter close are not allowed
 
 #![feature(frontmatter)]

--- a/tests/ui/frontmatter/fence-close-extra-after.stderr
+++ b/tests/ui/frontmatter/fence-close-extra-after.stderr
@@ -2,7 +2,9 @@ error: extra characters after frontmatter close are not allowed
   --> $DIR/fence-close-extra-after.rs:2:1
    |
 LL | ---cargo
-   | ^^^^^^^^
+   | ^^^-----
+   |    |
+   |    help: remove the extra characters
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/frontmatter/fence-mismatch-2.stderr
+++ b/tests/ui/frontmatter/fence-mismatch-2.stderr
@@ -16,7 +16,9 @@ error: extra characters after frontmatter close are not allowed
   --> $DIR/fence-mismatch-2.rs:3:1
    |
 LL | ---cargo
-   | ^^^^^^^^
+   | ^^^-----
+   |    |
+   |    help: remove the extra characters
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/frontmatter/fence-unclosed-3.stderr
+++ b/tests/ui/frontmatter/fence-unclosed-3.stderr
@@ -29,7 +29,9 @@ error: extra characters after frontmatter close are not allowed
   --> $DIR/fence-unclosed-3.rs:12:1
    |
 LL |     ---x
-   | ^^^^^^^^
+   | ^^^^^^^-
+   |        |
+   |        help: remove the extra characters
 
 error: unexpected closing delimiter: `}`
   --> $DIR/fence-unclosed-3.rs:15:1


### PR DESCRIPTION
`FrontmatterExtraCharactersAfterClose` previously emitted an error pointing at
  the entire closing fence line, but offered no automated fix. This PR adds a
  machine-applicable suggestion that removes the extra characters after the
  closing `---`, making it actionable via `rustfix` and `cargo fix`.

  The suggestion span is computed from the end of the closing dashes to the end
  of the line. The calculation accounts for any leading whitespace on the closing
  line (e.g. `  ---cargo`), so the suggestion correctly targets only the
  unexpected trailing text.

  In addition, this PR documents three previously undocumented items in
  `rustc_lexer`:

  `TokenKind::Frontmatter` — describes the two flag fields and when they are
    set, and links to the tracking issue.
  `FrontmatterAllowed` — explains why the enum exists and which variant callers
    should use.
  `Cursor::eat_until` — explains the `memchr`-based implementation and the
    "up to but not including" semantics.

Part of rust-lang/rust#136889
  r? @epage