### PR TITLE
bootstrap: add -q/--quiet to x.py

### DIFF
--- a/src/bootstrap/README.md
+++ b/src/bootstrap/README.md
@@ -182,8 +182,13 @@ bootstrap binary.
 
 Because there are two separate codebases behind `x.py`, they need to
 be kept in sync. In particular, both `bootstrap.py` and the bootstrap binary
-parse `bootstrap.toml` and read the same command line arguments. `bootstrap.py`
-keeps these in sync by setting various environment variables, and the
+parse `bootstrap.toml` and read the same command line arguments.
+
+A small exception is `-q/--quiet`: it is handled by `bootstrap.py` only (to reduce
+wrapper-level informational output) and is stripped before invoking the bootstrap
+binary.
+
+`bootstrap.py` keeps these in sync by setting various environment variables, and the
 programs sometimes have to add arguments that are explicitly ignored, to be
 read by the other.
 

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -556,6 +556,7 @@ class FakeArgs:
         self.json_output = False
         self.color = "auto"
         self.warnings = "default"
+        self.quiet = False
 
 
 class RustBuild(object):
@@ -576,6 +577,11 @@ class RustBuild(object):
         self.verbose = args.verbose
         self.color = args.color
         self.warnings = args.warnings
+        self.quiet = getattr(args, "quiet", False)
+        if self.quiet:
+            # `-q/--quiet` is a convenience flag. It is intentionally *not* forwarded to the
+            # Rust bootstrap binary, which would otherwise error on an unknown option.
+            self.verbose = 0
 
         config_verbose_count = self.get_toml("verbose", "build")
         if config_verbose_count is not None:
@@ -801,7 +807,8 @@ class RustBuild(object):
 
         answer = self._should_fix_bins_and_dylibs = get_answer()
         if answer:
-            eprint("INFO: You seem to be using Nix.")
+            if not self.quiet:
+                eprint("INFO: You seem to be using Nix.")
         return answer
 
     def fix_bin_or_dylib(self, fname):
@@ -1217,9 +1224,10 @@ class RustBuild(object):
         if "SUDO_USER" in os.environ and not self.use_vendored_sources:
             if os.getuid() == 0:
                 self.use_vendored_sources = True
-                eprint("INFO: looks like you're trying to run this command as root")
-                eprint("      and so in order to preserve your $HOME this will now")
-                eprint("      use vendored sources by default.")
+                if not self.quiet:
+                    eprint("INFO: looks like you're trying to run this command as root")
+                    eprint("      and so in order to preserve your $HOME this will now")
+                    eprint("      use vendored sources by default.")
 
         cargo_dir = os.path.join(self.rust_root, ".cargo")
         commit = self.get_latest_commit()
@@ -1271,6 +1279,7 @@ def parse_args(args):
         "--warnings", choices=["deny", "warn", "default"], default="default"
     )
     parser.add_argument("-v", "--verbose", action="count", default=0)
+    parser.add_argument("-q", "--quiet", action="store_true")
 
     return parser.parse_known_args(args)[0]
 
@@ -1365,7 +1374,8 @@ def bootstrap(args):
 
     # Run the bootstrap
     args = [build.bootstrap_binary()]
-    args.extend(sys.argv[1:])
+    filtered_argv = [a for a in sys.argv[1:] if a not in ("-q", "--quiet")]
+    args.extend(filtered_argv)
     env = os.environ.copy()
     env["BOOTSTRAP_PYTHON"] = sys.executable
     run(args, env=env, verbose=build.verbose, is_bootstrap=True)
@@ -1401,7 +1411,7 @@ def main():
 
     # If the user is asking for other helps, let them know that the whole download-and-build
     # process has to happen before anything is printed out.
-    if args.help:
+    if args.help and not getattr(args, "quiet", False):
         eprint(
             "INFO: Downloading and building bootstrap before processing --help command.\n"
             "      See src/bootstrap/README.md for help with common commands."
@@ -1419,7 +1429,7 @@ def main():
             eprint(error)
         success_word = "unsuccessfully"
 
-    if not args.help:
+    if not args.help and not getattr(args, "quiet", False):
         eprint(
             "Build completed",
             success_word,

--- a/src/etc/xhelp
+++ b/src/etc/xhelp
@@ -26,8 +26,6 @@ Arguments:
 Options:
   -v, --verbose...
           use verbose output (-vv for very verbose)
-  -q, --quiet
-          reduce bootstrap output (suppresses some INFO messages; not forwarded to the bootstrap binary)
   -i, --incremental
           use incremental compilation
       --config <FILE>

--- a/src/etc/xhelp
+++ b/src/etc/xhelp
@@ -26,6 +26,8 @@ Arguments:
 Options:
   -v, --verbose...
           use verbose output (-vv for very verbose)
+  -q, --quiet
+          reduce bootstrap output (suppresses some INFO messages; not forwarded to the bootstrap binary)
   -i, --incremental
           use incremental compilation
       --config <FILE>


### PR DESCRIPTION
This adds a small quality-of-life flag to the Python `x.py` wrapper.

### Why
It’s pretty common to reach for `-q` out of habit. Today, `./x.py … -q` fails with an “unexpected argument '-q'” error because the Rust bootstrap binary doesn’t accept it.

### What this PR does
- Accept `-q/--quiet` in `src/bootstrap/bootstrap.py`.
- Filter it out before forwarding argv to the bootstrap binary (so it can’t error on an unknown option).
- When quiet, suppress a few wrapper-level informational messages (errors still print).
- Document the flag in `x.py --help` (`src/etc/xhelp`).

### Testing
- `python -m py_compile src/bootstrap/bootstrap.py`
- Manual: `./x.py -q --help`
