### PR TITLE
tools: remote-test-server: Add UEFI run support

### DIFF
--- a/src/tools/remote-test-server/src/main.rs
+++ b/src/tools/remote-test-server/src/main.rs
@@ -123,6 +123,8 @@ fn main() {
     let listener = bind_socket(config.bind);
     let (work, tmp): (PathBuf, PathBuf) = if cfg!(target_os = "android") {
         ("/data/local/tmp/work".into(), "/data/local/tmp/work/tmp".into())
+    } else if cfg!(target_os = "uefi") {
+        ("tmp\\work".into(), "tmp\\work\\tmp".into())
     } else {
         let mut work_dir = env::temp_dir();
         work_dir.push("work");
@@ -274,6 +276,8 @@ fn handle_run(socket: TcpStream, work: &Path, tmp: &Path, lock: &Mutex<()>, conf
     } else if cfg!(target_vendor = "apple") {
         // On Apple platforms, the environment variable is named differently.
         "DYLD_LIBRARY_PATH"
+    } else if cfg!(target_os = "uefi") {
+        "path"
     } else {
         "LD_LIBRARY_PATH"
     };


### PR DESCRIPTION
Tested with OVMF on QEMU with Linux as the host running remote-test-client. The instructions for running tests are provided below:

1. Use rust-lld linker: `bootstrap.toml`

```toml
[rust]
lld = true

[target.x86_64-unknown-uefi]
linker = "rust-lld"
```

2. Use a custom startup.nsh script to auto-launch remote-test-server. This is optional.

```shell
fs1:
run.efi --sequential --bind "10.0.2.15:12345" --batch
```

3. Launch remote-test-server in QEMU. I am using uefi-run script [0].

```shell
uefi-run build/x86_64-unknown-linux-gnu/stage2-tools/x86_64-unknown-uefi/release/remote-test-server.efi  -n --startup startup.nsh --tcp-port 12345
```

4. Run tests:

```shell
RUST_TEST_THREADS=1 TEST_DEVICE_ADDR="localhost:12345" ./x.py test tests/ui/abi --target x86_64-unknown-uefi --stage 1
```

Requires: https://github.com/rust-lang/rust/pull/151014
@rustbot label +O-UEFI
cc @nicholasbishop

[0]: https://github.com/Ayush1325/dotfiles/blob/2d13056bf8ca1931a234b72967d9e857c4afbf1a/uefi/.local/bin/uefi-run
