### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_middle/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node.rs
@@ -174,11 +174,6 @@ impl fmt::Debug for DepNode {
 /// of the `DepKind`. Overall, this allows to implement `DepContext` using this manual
 /// jump table instead of large matches.
 pub struct DepKindVTable<'tcx> {
-    /// Anonymous queries cannot be replayed from one compiler invocation to the next.
-    /// When their result is needed, it is recomputed. They are useful for fine-grained
-    /// dependency tracking, and caching within one compiler invocation.
-    pub is_anon: bool,
-
     /// Eval-always queries do not track their dependencies, and are always recomputed, even if
     /// their inputs have not changed since the last compiler invocation. The result is still
     /// cached within one compiler invocation.

--- a/compiler/rustc_middle/src/dep_graph/graph.rs
+++ b/compiler/rustc_middle/src/dep_graph/graph.rs
@@ -9,7 +9,7 @@ use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::profiling::QueryInvocationId;
 use rustc_data_structures::sharded::{self, ShardedHashMap};
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
-use rustc_data_structures::sync::{AtomicU64, Lock};
+use rustc_data_structures::sync::{AtomicU64, Lock, is_dyn_thread_safe};
 use rustc_data_structures::unord::UnordMap;
 use rustc_data_structures::{assert_matches, outline};
 use rustc_errors::DiagInner;
@@ -1311,7 +1311,9 @@ impl<D: Deps> CurrentDepGraph<D> {
         prev_graph: &SerializedDepGraph,
         prev_index: SerializedDepNodeIndex,
     ) {
-        if let Some(ref nodes_in_current_session) = self.nodes_in_current_session {
+        if !is_dyn_thread_safe()
+            && let Some(ref nodes_in_current_session) = self.nodes_in_current_session
+        {
             debug_assert!(
                 !nodes_in_current_session
                     .lock()

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -150,10 +150,10 @@ use crate::{dep_graph, mir, thir};
 // `Providers` that the driver creates (using several `rustc_*` crates).
 //
 // The result type of each query must implement `Clone`, and additionally
-// `ty::query::values::Value`, which produces an appropriate placeholder
-// (error) value if the query resulted in a query cycle.
+// `ty::query::from_cycle_error::FromCycleError`, which produces an appropriate
+// placeholder (error) value if the query resulted in a query cycle.
 // Queries marked with `cycle_fatal` do not need the latter implementation,
-// as they will raise an fatal error on query cycles instead.
+// as they will raise a fatal error on query cycles instead.
 rustc_queries! {
     /// Caches the expansion of a derive proc macro, e.g. `#[derive(Serialize)]`.
     /// The key is:

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -148,7 +148,7 @@ pub struct QueryVTable<'tcx, C: QueryCache> {
     pub is_loadable_from_disk_fn: Option<IsLoadableFromDiskFn<'tcx, C::Key>>,
     pub hash_result: HashResult<C::Value>,
     pub value_from_cycle_error:
-        fn(tcx: TyCtxt<'tcx>, cycle_error: &CycleError, guar: ErrorGuaranteed) -> C::Value,
+        fn(tcx: TyCtxt<'tcx>, cycle_error: CycleError, guar: ErrorGuaranteed) -> C::Value,
     pub format_value: fn(&C::Value) -> String,
 
     /// Formats a human-readable description of this query and its key, as
@@ -213,7 +213,7 @@ impl<'tcx, C: QueryCache> QueryVTable<'tcx, C> {
     pub fn value_from_cycle_error(
         &self,
         tcx: TyCtxt<'tcx>,
-        cycle_error: &CycleError,
+        cycle_error: CycleError,
         guar: ErrorGuaranteed,
     ) -> C::Value {
         (self.value_from_cycle_error)(tcx, cycle_error, guar)

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -643,18 +643,6 @@ macro_rules! define_callbacks {
     };
 }
 
-// Each of these queries corresponds to a function pointer field in the
-// `Providers` struct for requesting a value of that type, and a method
-// on `tcx: TyCtxt` (and `tcx.at(span)`) for doing that request in a way
-// which memoizes and does dep-graph tracking, wrapping around the actual
-// `Providers` that the driver creates (using several `rustc_*` crates).
-//
-// The result type of each query must implement `Clone`, and additionally
-// `ty::query::values::Value`, which produces an appropriate placeholder
-// (error) value if the query resulted in a query cycle.
-// Queries marked with `cycle_fatal` do not need the latter implementation,
-// as they will raise an fatal error on query cycles instead.
-
 mod sealed {
     use rustc_hir::def_id::{LocalModDefId, ModDefId};
 

--- a/compiler/rustc_query_impl/src/dep_kind_vtables.rs
+++ b/compiler/rustc_query_impl/src/dep_kind_vtables.rs
@@ -13,7 +13,6 @@ mod non_query {
     // We use this for most things when incr. comp. is turned off.
     pub(crate) fn Null<'tcx>() -> DepKindVTable<'tcx> {
         DepKindVTable {
-            is_anon: false,
             is_eval_always: false,
             key_fingerprint_style: KeyFingerprintStyle::Unit,
             force_from_dep_node: Some(|_, dep_node, _| {
@@ -26,7 +25,6 @@ mod non_query {
     // We use this for the forever-red node.
     pub(crate) fn Red<'tcx>() -> DepKindVTable<'tcx> {
         DepKindVTable {
-            is_anon: false,
             is_eval_always: false,
             key_fingerprint_style: KeyFingerprintStyle::Unit,
             force_from_dep_node: Some(|_, dep_node, _| {
@@ -38,7 +36,6 @@ mod non_query {
 
     pub(crate) fn SideEffect<'tcx>() -> DepKindVTable<'tcx> {
         DepKindVTable {
-            is_anon: false,
             is_eval_always: false,
             key_fingerprint_style: KeyFingerprintStyle::Unit,
             force_from_dep_node: Some(|tcx, _, prev_index| {
@@ -51,7 +48,6 @@ mod non_query {
 
     pub(crate) fn AnonZeroDeps<'tcx>() -> DepKindVTable<'tcx> {
         DepKindVTable {
-            is_anon: true,
             is_eval_always: false,
             key_fingerprint_style: KeyFingerprintStyle::Opaque,
             force_from_dep_node: Some(|_, _, _| bug!("cannot force an anon node")),
@@ -61,7 +57,6 @@ mod non_query {
 
     pub(crate) fn TraitSelect<'tcx>() -> DepKindVTable<'tcx> {
         DepKindVTable {
-            is_anon: true,
             is_eval_always: false,
             key_fingerprint_style: KeyFingerprintStyle::Unit,
             force_from_dep_node: None,
@@ -71,7 +66,6 @@ mod non_query {
 
     pub(crate) fn CompileCodegenUnit<'tcx>() -> DepKindVTable<'tcx> {
         DepKindVTable {
-            is_anon: false,
             is_eval_always: false,
             key_fingerprint_style: KeyFingerprintStyle::Opaque,
             force_from_dep_node: None,
@@ -81,7 +75,6 @@ mod non_query {
 
     pub(crate) fn CompileMonoItem<'tcx>() -> DepKindVTable<'tcx> {
         DepKindVTable {
-            is_anon: false,
             is_eval_always: false,
             key_fingerprint_style: KeyFingerprintStyle::Opaque,
             force_from_dep_node: None,
@@ -91,7 +84,6 @@ mod non_query {
 
     pub(crate) fn Metadata<'tcx>() -> DepKindVTable<'tcx> {
         DepKindVTable {
-            is_anon: false,
             is_eval_always: false,
             key_fingerprint_style: KeyFingerprintStyle::Unit,
             force_from_dep_node: None,
@@ -117,7 +109,6 @@ where
 
     if is_anon || !key_fingerprint_style.reconstructible() {
         return DepKindVTable {
-            is_anon,
             is_eval_always,
             key_fingerprint_style,
             force_from_dep_node: None,
@@ -126,7 +117,6 @@ where
     }
 
     DepKindVTable {
-        is_anon,
         is_eval_always,
         key_fingerprint_style,
         force_from_dep_node: Some(|tcx, dep_node, _| {

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -313,15 +313,15 @@ fn try_execute_query<'tcx, C: QueryCache, const INCR: bool>(
 
                         // Only call `wait_for_query` if we're using a Rayon thread pool
                         // as it will attempt to mark the worker thread as blocked.
-                        return wait_for_query(query, tcx, span, key, latch, current_job_id);
+                        wait_for_query(query, tcx, span, key, latch, current_job_id)
+                    } else {
+                        let id = job.id;
+                        drop(state_lock);
+
+                        // If we are single-threaded we know that we have cycle error,
+                        // so we just return the error.
+                        cycle_error(query, tcx, id, span)
                     }
-
-                    let id = job.id;
-                    drop(state_lock);
-
-                    // If we are single-threaded we know that we have cycle error,
-                    // so we just return the error.
-                    cycle_error(query, tcx, id, span)
                 }
                 ActiveKeyStatus::Poisoned => FatalError.raise(),
             }

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -111,7 +111,7 @@ fn mk_cycle<'tcx, C: QueryCache>(
     match query.cycle_error_handling {
         CycleErrorHandling::Error => {
             let guar = error.emit();
-            query.value_from_cycle_error(tcx, &cycle_error, guar)
+            query.value_from_cycle_error(tcx, cycle_error, guar)
         }
         CycleErrorHandling::Fatal => {
             error.emit();
@@ -120,7 +120,7 @@ fn mk_cycle<'tcx, C: QueryCache>(
         }
         CycleErrorHandling::DelayBug => {
             let guar = error.delay_as_bug();
-            query.value_from_cycle_error(tcx, &cycle_error, guar)
+            query.value_from_cycle_error(tcx, cycle_error, guar)
         }
         CycleErrorHandling::Stash => {
             let guar = if let Some(root) = cycle_error.cycle.first()
@@ -130,7 +130,7 @@ fn mk_cycle<'tcx, C: QueryCache>(
             } else {
                 error.emit()
             };
-            query.value_from_cycle_error(tcx, &cycle_error, guar)
+            query.value_from_cycle_error(tcx, cycle_error, guar)
         }
     }
 }

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -114,9 +114,8 @@ fn mk_cycle<'tcx, C: QueryCache>(
             query.value_from_cycle_error(tcx, cycle_error, guar)
         }
         CycleErrorHandling::Fatal => {
-            error.emit();
-            tcx.dcx().abort_if_errors();
-            unreachable!()
+            let guar = error.emit();
+            guar.raise_fatal();
         }
         CycleErrorHandling::DelayBug => {
             let guar = error.delay_as_bug();

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -4,7 +4,7 @@ use std::mem;
 use rustc_data_structures::hash_table::{Entry, HashTable};
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_data_structures::{outline, sharded, sync};
-use rustc_errors::{Diag, FatalError, StashKey};
+use rustc_errors::{FatalError, StashKey};
 use rustc_middle::dep_graph::{DepGraphData, DepNodeKey, SerializedDepNodeIndex};
 use rustc_middle::query::plumbing::QueryVTable;
 use rustc_middle::query::{
@@ -108,19 +108,10 @@ fn mk_cycle<'tcx, C: QueryCache>(
     cycle_error: CycleError,
 ) -> C::Value {
     let error = report_cycle(tcx.sess, &cycle_error);
-    handle_cycle_error(query, tcx, &cycle_error, error)
-}
-
-fn handle_cycle_error<'tcx, C: QueryCache>(
-    query: &'tcx QueryVTable<'tcx, C>,
-    tcx: TyCtxt<'tcx>,
-    cycle_error: &CycleError,
-    error: Diag<'_>,
-) -> C::Value {
     match query.cycle_error_handling {
         CycleErrorHandling::Error => {
             let guar = error.emit();
-            query.value_from_cycle_error(tcx, cycle_error, guar)
+            query.value_from_cycle_error(tcx, &cycle_error, guar)
         }
         CycleErrorHandling::Fatal => {
             error.emit();
@@ -129,7 +120,7 @@ fn handle_cycle_error<'tcx, C: QueryCache>(
         }
         CycleErrorHandling::DelayBug => {
             let guar = error.delay_as_bug();
-            query.value_from_cycle_error(tcx, cycle_error, guar)
+            query.value_from_cycle_error(tcx, &cycle_error, guar)
         }
         CycleErrorHandling::Stash => {
             let guar = if let Some(root) = cycle_error.cycle.first()
@@ -139,7 +130,7 @@ fn handle_cycle_error<'tcx, C: QueryCache>(
             } else {
                 error.emit()
             };
-            query.value_from_cycle_error(tcx, cycle_error, guar)
+            query.value_from_cycle_error(tcx, &cycle_error, guar)
         }
     }
 }

--- a/compiler/rustc_query_impl/src/from_cycle_error.rs
+++ b/compiler/rustc_query_impl/src/from_cycle_error.rs
@@ -56,18 +56,6 @@ impl<'tcx> FromCycleError<'tcx> for Result<ty::EarlyBinder<'_, Ty<'_>>, CyclePla
     }
 }
 
-impl<'tcx> FromCycleError<'tcx> for ty::SymbolName<'_> {
-    fn from_cycle_error(tcx: TyCtxt<'tcx>, _: CycleError, _guar: ErrorGuaranteed) -> Self {
-        // SAFETY: This is never called when `Self` is not `SymbolName<'tcx>`.
-        // FIXME: Represent the above fact in the trait system somehow.
-        unsafe {
-            std::mem::transmute::<ty::SymbolName<'tcx>, ty::SymbolName<'_>>(ty::SymbolName::new(
-                tcx, "<error>",
-            ))
-        }
-    }
-}
-
 impl<'tcx> FromCycleError<'tcx> for ty::Binder<'_, ty::FnSig<'_>> {
     fn from_cycle_error(tcx: TyCtxt<'tcx>, cycle_error: CycleError, guar: ErrorGuaranteed) -> Self {
         let err = Ty::new_error(tcx, guar);

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -18,12 +18,12 @@ use rustc_middle::ty::TyCtxt;
 use rustc_span::Span;
 
 pub use crate::dep_kind_vtables::make_dep_kind_vtables;
+use crate::from_cycle_error::FromCycleError;
 pub use crate::job::{QueryJobMap, break_query_cycles, print_query_stack};
 pub use crate::plumbing::{collect_active_jobs_from_all_queries, query_key_hash_verify_all};
 use crate::plumbing::{encode_all_query_results, try_mark_green};
 use crate::profiling_support::QueryKeyStringCache;
 pub use crate::profiling_support::alloc_self_profile_query_strings;
-use crate::values::Value;
 
 #[macro_use]
 mod plumbing;
@@ -31,9 +31,9 @@ mod plumbing;
 mod dep_kind_vtables;
 mod error;
 mod execution;
+mod from_cycle_error;
 mod job;
 mod profiling_support;
-mod values;
 
 /// Trait that knows how to look up the [`QueryVTable`] for a particular query.
 ///

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -603,7 +603,8 @@ macro_rules! define_queries {
                         None
                     }),
                     value_from_cycle_error: |tcx, cycle, guar| {
-                        let result: queries::$name::Value<'tcx> = Value::from_cycle_error(tcx, cycle, guar);
+                        let result: queries::$name::Value<'tcx> =
+                            FromCycleError::from_cycle_error(tcx, cycle, guar);
                         erase::erase_val(result)
                     },
                     hash_result: hash_result!([$($modifiers)*][queries::$name::Value<'tcx>]),

--- a/compiler/rustc_query_impl/src/values.rs
+++ b/compiler/rustc_query_impl/src/values.rs
@@ -27,12 +27,14 @@ impl<'tcx, T> Value<'tcx> for T {
         cycle_error: CycleError,
         _guar: ErrorGuaranteed,
     ) -> T {
-        tcx.sess.dcx().abort_if_errors();
-        bug!(
-            "<{} as Value>::from_cycle_error called without errors: {:#?}",
-            std::any::type_name::<T>(),
-            cycle_error.cycle,
-        );
+        let Some(guar) = tcx.sess.dcx().has_errors() else {
+            bug!(
+                "<{} as Value>::from_cycle_error called without errors: {:#?}",
+                std::any::type_name::<T>(),
+                cycle_error.cycle,
+            );
+        };
+        guar.raise_fatal();
     }
 }
 

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -798,6 +798,34 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             return false;
         }
 
+        // If this is a zero-argument async closure directly passed as an argument
+        // and the expected type is `Future`, suggest using `async {}` block instead
+        // of `async || {}`.
+        if let ty::CoroutineClosure(def_id, args) = *self_ty.kind()
+            && let sig = args.as_coroutine_closure().coroutine_closure_sig().skip_binder()
+            && let ty::Tuple(inputs) = *sig.tupled_inputs_ty.kind()
+            && inputs.is_empty()
+            && self.tcx.is_lang_item(trait_pred.def_id(), LangItem::Future)
+            && let Some(hir::Node::Expr(hir::Expr {
+                kind:
+                    hir::ExprKind::Closure(hir::Closure {
+                        kind: hir::ClosureKind::CoroutineClosure(CoroutineDesugaring::Async),
+                        fn_arg_span: Some(arg_span),
+                        ..
+                    }),
+                ..
+            })) = self.tcx.hir_get_if_local(def_id)
+            && obligation.cause.span.contains(*arg_span)
+        {
+            err.span_suggestion_verbose(
+                arg_span.with_hi(arg_span.hi() + rustc_span::BytePos(1)),
+                "use `async {}` instead of `async || {}` to introduce an async block",
+                "",
+                Applicability::MachineApplicable,
+            );
+            return true;
+        }
+
         // Get the name of the callable and the arguments to be used in the suggestion.
         let msg = match def_id_or_name {
             DefIdOrName::DefId(def_id) => match self.tcx.def_kind(def_id) {

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -800,7 +800,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 
         // If this is a zero-argument async closure directly passed as an argument
         // and the expected type is `Future`, suggest using `async {}` block instead
-        // of `async || {}`.
+        // of `async || {}`
         if let ty::CoroutineClosure(def_id, args) = *self_ty.kind()
             && let sig = args.as_coroutine_closure().coroutine_closure_sig().skip_binder()
             && let ty::Tuple(inputs) = *sig.tupled_inputs_ty.kind()
@@ -817,8 +817,18 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             })) = self.tcx.hir_get_if_local(def_id)
             && obligation.cause.span.contains(*arg_span)
         {
+            let sm = self.tcx.sess.source_map();
+            let removal_span = if let Ok(snippet) =
+                sm.span_to_snippet(arg_span.with_hi(arg_span.hi() + rustc_span::BytePos(1)))
+                && snippet.ends_with(' ')
+            {
+                // There's a space after `||`, include it in the removal
+                arg_span.with_hi(arg_span.hi() + rustc_span::BytePos(1))
+            } else {
+                *arg_span
+            };
             err.span_suggestion_verbose(
-                arg_span.with_hi(arg_span.hi() + rustc_span::BytePos(1)),
+                removal_span,
                 "use `async {}` instead of `async || {}` to introduce an async block",
                 "",
                 Applicability::MachineApplicable,

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1320,6 +1320,9 @@ impl Step for Tidy {
         if builder.config.cmd.bless() {
             cmd.arg("--bless");
         }
+        if builder.config.is_running_on_ci() {
+            cmd.arg("--ci=true");
+        }
         if let Some(s) =
             builder.config.cmd.extra_checks().or(builder.config.tidy_extra_checks.as_deref())
         {

--- a/src/tools/rustfmt/tests/target/field-representing-types.rs
+++ b/src/tools/rustfmt/tests/target/field-representing-types.rs
@@ -1,0 +1,2 @@
+type FRT = builtin # field_of(Type, ident);
+type FRT2 = builtin # field_of(Type<A, B>, ident);

--- a/src/tools/tidy/src/alphabetical/tests.rs
+++ b/src/tools/tidy/src/alphabetical/tests.rs
@@ -5,7 +5,7 @@ use crate::diagnostics::{TidyCtx, TidyFlags};
 
 #[track_caller]
 fn test(lines: &str, name: &str, expected_msg: &str, expected_bad: bool) {
-    let tidy_ctx = TidyCtx::new(Path::new("/"), false, TidyFlags::default());
+    let tidy_ctx = TidyCtx::new(Path::new("/"), false, None, TidyFlags::default());
     let mut check = tidy_ctx.start_check("alphabetical-test");
     check_lines(Path::new(name), lines, &tidy_ctx, &mut check);
 
@@ -37,7 +37,7 @@ fn bless_test(before: &str, after: &str) {
     let temp_path = tempfile::Builder::new().tempfile().unwrap().into_temp_path();
     std::fs::write(&temp_path, before).unwrap();
 
-    let tidy_ctx = TidyCtx::new(Path::new("/"), false, TidyFlags::new(true));
+    let tidy_ctx = TidyCtx::new(Path::new("/"), false, None, TidyFlags::new(true));
 
     let mut check = tidy_ctx.start_check("alphabetical-test");
     check_lines(&temp_path, before, &tidy_ctx, &mut check);

--- a/src/tools/tidy/src/arg_parser.rs
+++ b/src/tools/tidy/src/arg_parser.rs
@@ -15,6 +15,7 @@ pub struct TidyArgParser {
     pub npm: PathBuf,
     pub verbose: bool,
     pub bless: bool,
+    pub ci: Option<bool>,
     pub extra_checks: Option<Vec<String>>,
     pub pos_args: Vec<String>,
 }
@@ -59,6 +60,7 @@ impl TidyArgParser {
             )
             .arg(Arg::new("verbose").help("verbose").long("verbose").action(ArgAction::SetTrue))
             .arg(Arg::new("bless").help("target files are modified").long("bless").action(ArgAction::SetTrue))
+            .arg(Arg::new("ci").help("ci flag").long("ci").default_missing_value("true").num_args(0..=1).value_parser(value_parser!(bool)))
             .arg(
                 Arg::new("extra_checks")
                     .help("extra checks")
@@ -78,6 +80,7 @@ impl TidyArgParser {
             npm: matches.get_one::<PathBuf>("npm").unwrap().clone(),
             verbose: *matches.get_one::<bool>("verbose").unwrap(),
             bless: *matches.get_one::<bool>("bless").unwrap(),
+            ci: matches.get_one::<bool>("ci").cloned(),
             extra_checks: None,
             pos_args: vec![],
         };

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -6,7 +6,6 @@ use std::fs::{File, read_dir};
 use std::io::Write;
 use std::path::Path;
 
-use build_helper::ci::CiEnv;
 use cargo_metadata::semver::Version;
 use cargo_metadata::{Metadata, Package, PackageId};
 
@@ -637,7 +636,7 @@ pub fn check(root: &Path, cargo: &Path, tidy_ctx: TidyCtx) {
     check_proc_macro_dep_list(root, cargo, bless, &mut check);
 
     for &WorkspaceInfo { path, exceptions, crates_and_deps, submodules } in WORKSPACES {
-        if has_missing_submodule(root, submodules) {
+        if has_missing_submodule(root, submodules, tidy_ctx.is_running_on_ci()) {
             continue;
         }
 
@@ -757,8 +756,8 @@ pub static CRATES: &[&str] = &[
 /// Used to skip a check if a submodule is not checked out, and not in a CI environment.
 ///
 /// This helps prevent enforcing developers to fetch submodules for tidy.
-pub fn has_missing_submodule(root: &Path, submodules: &[&str]) -> bool {
-    !CiEnv::is_ci()
+pub fn has_missing_submodule(root: &Path, submodules: &[&str], is_ci: bool) -> bool {
+    !is_ci
         && submodules.iter().any(|submodule| {
             let path = root.join(submodule);
             !path.exists()

--- a/src/tools/tidy/src/error_codes.rs
+++ b/src/tools/tidy/src/error_codes.rs
@@ -36,11 +36,11 @@ const IGNORE_DOCTEST_CHECK: &[&str] = &["E0464", "E0570", "E0601", "E0602", "E07
 const IGNORE_UI_TEST_CHECK: &[&str] =
     &["E0461", "E0465", "E0514", "E0554", "E0640", "E0717", "E0729"];
 
-pub fn check(root_path: &Path, search_paths: &[&Path], ci_info: &crate::CiInfo, tidy_ctx: TidyCtx) {
+pub fn check(root_path: &Path, search_paths: &[&Path], tidy_ctx: TidyCtx) {
     let mut check = tidy_ctx.start_check("error_codes");
 
     // Check that no error code explanation was removed.
-    check_removed_error_code_explanation(ci_info, &mut check);
+    check_removed_error_code_explanation(&tidy_ctx.base_commit, &mut check);
 
     // Stage 1: create list
     let error_codes = extract_error_codes(root_path, &mut check);
@@ -57,8 +57,8 @@ pub fn check(root_path: &Path, search_paths: &[&Path], ci_info: &crate::CiInfo, 
     check_error_codes_used(search_paths, &error_codes, &mut check, &no_longer_emitted);
 }
 
-fn check_removed_error_code_explanation(ci_info: &crate::CiInfo, check: &mut RunningCheck) {
-    let Some(base_commit) = &ci_info.base_commit else {
+fn check_removed_error_code_explanation(base_commit: &Option<String>, check: &mut RunningCheck) {
+    let Some(base_commit) = base_commit else {
         check.verbose_msg("Skipping error code explanation removal check");
         return;
     };

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -19,7 +19,7 @@ pub fn check(root: &Path, tidy_ctx: TidyCtx) {
     let mut check = tidy_ctx.start_check("extdeps");
 
     for &WorkspaceInfo { path, submodules, .. } in crate::deps::WORKSPACES {
-        if crate::deps::has_missing_submodule(root, submodules) {
+        if crate::deps::has_missing_submodule(root, submodules, tidy_ctx.is_running_on_ci()) {
             continue;
         }
 

--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -40,11 +40,11 @@ fn main() {
 
     let verbose = parsed_args.verbose;
     let bless = parsed_args.bless;
+    let ci = parsed_args.ci;
     let extra_checks = parsed_args.extra_checks;
     let pos_args = parsed_args.pos_args;
 
-    let tidy_ctx = TidyCtx::new(&root_path, verbose, TidyFlags::new(bless));
-    let ci_info = CiInfo::new(tidy_ctx.clone());
+    let tidy_ctx = TidyCtx::new(&root_path, verbose, ci, TidyFlags::new(bless));
 
     let drain_handles = |handles: &mut VecDeque<ScopedJoinHandle<'_, ()>>| {
         // poll all threads for completion before awaiting the oldest one
@@ -101,12 +101,12 @@ fn main() {
         check!(rustdoc_gui_tests, &tests_path);
         check!(rustdoc_css_themes, &librustdoc_path);
         check!(rustdoc_templates, &librustdoc_path);
-        check!(rustdoc_json, &src_path, &ci_info);
+        check!(rustdoc_json, &src_path);
         check!(known_bug, &crashes_path);
         check!(unknown_revision, &tests_path);
 
         // Checks that only make sense for the compiler.
-        check!(error_codes, &root_path, &[&compiler_path, &librustdoc_path], &ci_info);
+        check!(error_codes, &root_path, &[&compiler_path, &librustdoc_path]);
         check!(target_policy, &root_path);
         check!(gcc_submodule, &root_path, &compiler_path);
 
@@ -154,7 +154,6 @@ fn main() {
             extra_checks,
             &root_path,
             &output_directory,
-            &ci_info,
             &librustdoc_path,
             &tools_path,
             &npm,

--- a/src/tools/tidy/src/rustdoc_json.rs
+++ b/src/tools/tidy/src/rustdoc_json.rs
@@ -8,16 +8,18 @@ use crate::diagnostics::{CheckId, TidyCtx};
 
 const RUSTDOC_JSON_TYPES: &str = "src/rustdoc-json-types";
 
-pub fn check(src_path: &Path, ci_info: &crate::CiInfo, tidy_ctx: TidyCtx) {
+pub fn check(src_path: &Path, tidy_ctx: TidyCtx) {
     let mut check = tidy_ctx.start_check(CheckId::new("rustdoc_json").path(src_path));
 
-    let Some(base_commit) = &ci_info.base_commit else {
+    let Some(base_commit) = &tidy_ctx.base_commit else {
         check.verbose_msg("No base commit, skipping rustdoc_json check");
         return;
     };
 
     // First we check that `src/rustdoc-json-types` was modified.
-    if !crate::files_modified(ci_info, |p| p.starts_with(RUSTDOC_JSON_TYPES)) {
+    if !crate::files_modified(&tidy_ctx.base_commit, tidy_ctx.is_running_on_ci(), |p| {
+        p.starts_with(RUSTDOC_JSON_TYPES)
+    }) {
         // `rustdoc-json-types` was not modified so nothing more to check here.
         return;
     }

--- a/tests/ui/async-await/async-closures/suggest-async-block-issue-140265.rs
+++ b/tests/ui/async-await/async-closures/suggest-async-block-issue-140265.rs
@@ -12,6 +12,12 @@ fn main() {
         println!("hi!");
     });
 
+    // Without space between `||` and `{`: should also suggest using async block
+    takes_future(async||{
+        //~^ ERROR is not a future
+        println!("no space!");
+    });
+
     // With arguments: should suggest calling the closure, not using async block
     takes_future(async |x: i32| {
         //~^ ERROR is not a future

--- a/tests/ui/async-await/async-closures/suggest-async-block-issue-140265.rs
+++ b/tests/ui/async-await/async-closures/suggest-async-block-issue-140265.rs
@@ -1,0 +1,20 @@
+//@ edition:2024
+// Test that we suggest using `async {}` block instead of `async || {}` closure if possible
+
+use std::future::Future;
+
+fn takes_future(_fut: impl Future<Output = ()>) {}
+
+fn main() {
+    // Basic case: suggest using async block
+    takes_future(async || {
+        //~^ ERROR is not a future
+        println!("hi!");
+    });
+
+    // With arguments: should suggest calling the closure, not using async block
+    takes_future(async |x: i32| {
+        //~^ ERROR is not a future
+        println!("{x}");
+    });
+}

--- a/tests/ui/async-await/async-closures/suggest-async-block-issue-140265.stderr
+++ b/tests/ui/async-await/async-closures/suggest-async-block-issue-140265.stderr
@@ -22,8 +22,32 @@ LL -     takes_future(async || {
 LL +     takes_future(async {
    |
 
-error[E0277]: `{async closure@$DIR/suggest-async-block-issue-140265.rs:16:18: 16:32}` is not a future
+error[E0277]: `{async closure@$DIR/suggest-async-block-issue-140265.rs:16:18: 16:25}` is not a future
   --> $DIR/suggest-async-block-issue-140265.rs:16:18
+   |
+LL |       takes_future(async||{
+   |  _____------------_^
+   | |     |
+   | |     required by a bound introduced by this call
+LL | |
+LL | |         println!("no space!");
+LL | |     });
+   | |_____^ `{async closure@$DIR/suggest-async-block-issue-140265.rs:16:18: 16:25}` is not a future
+   |
+   = help: the trait `Future` is not implemented for `{async closure@$DIR/suggest-async-block-issue-140265.rs:16:18: 16:25}`
+note: required by a bound in `takes_future`
+  --> $DIR/suggest-async-block-issue-140265.rs:6:28
+   |
+LL | fn takes_future(_fut: impl Future<Output = ()>) {}
+   |                            ^^^^^^^^^^^^^^^^^^^ required by this bound in `takes_future`
+help: use `async {}` instead of `async || {}` to introduce an async block
+   |
+LL -     takes_future(async||{
+LL +     takes_future(async{
+   |
+
+error[E0277]: `{async closure@$DIR/suggest-async-block-issue-140265.rs:22:18: 22:32}` is not a future
+  --> $DIR/suggest-async-block-issue-140265.rs:22:18
    |
 LL |       takes_future(async |x: i32| {
    |  _____------------_^
@@ -32,9 +56,9 @@ LL |       takes_future(async |x: i32| {
 LL | |
 LL | |         println!("{x}");
 LL | |     });
-   | |_____^ `{async closure@$DIR/suggest-async-block-issue-140265.rs:16:18: 16:32}` is not a future
+   | |_____^ `{async closure@$DIR/suggest-async-block-issue-140265.rs:22:18: 22:32}` is not a future
    |
-   = help: the trait `Future` is not implemented for `{async closure@$DIR/suggest-async-block-issue-140265.rs:16:18: 16:32}`
+   = help: the trait `Future` is not implemented for `{async closure@$DIR/suggest-async-block-issue-140265.rs:22:18: 22:32}`
 note: required by a bound in `takes_future`
   --> $DIR/suggest-async-block-issue-140265.rs:6:28
    |
@@ -45,6 +69,6 @@ help: use parentheses to call this closure
 LL |     }(/* i32 */));
    |      +++++++++++
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/async-await/async-closures/suggest-async-block-issue-140265.stderr
+++ b/tests/ui/async-await/async-closures/suggest-async-block-issue-140265.stderr
@@ -1,0 +1,50 @@
+error[E0277]: `{async closure@$DIR/suggest-async-block-issue-140265.rs:10:18: 10:26}` is not a future
+  --> $DIR/suggest-async-block-issue-140265.rs:10:18
+   |
+LL |       takes_future(async || {
+   |  _____------------_^
+   | |     |
+   | |     required by a bound introduced by this call
+LL | |
+LL | |         println!("hi!");
+LL | |     });
+   | |_____^ `{async closure@$DIR/suggest-async-block-issue-140265.rs:10:18: 10:26}` is not a future
+   |
+   = help: the trait `Future` is not implemented for `{async closure@$DIR/suggest-async-block-issue-140265.rs:10:18: 10:26}`
+note: required by a bound in `takes_future`
+  --> $DIR/suggest-async-block-issue-140265.rs:6:28
+   |
+LL | fn takes_future(_fut: impl Future<Output = ()>) {}
+   |                            ^^^^^^^^^^^^^^^^^^^ required by this bound in `takes_future`
+help: use `async {}` instead of `async || {}` to introduce an async block
+   |
+LL -     takes_future(async || {
+LL +     takes_future(async {
+   |
+
+error[E0277]: `{async closure@$DIR/suggest-async-block-issue-140265.rs:16:18: 16:32}` is not a future
+  --> $DIR/suggest-async-block-issue-140265.rs:16:18
+   |
+LL |       takes_future(async |x: i32| {
+   |  _____------------_^
+   | |     |
+   | |     required by a bound introduced by this call
+LL | |
+LL | |         println!("{x}");
+LL | |     });
+   | |_____^ `{async closure@$DIR/suggest-async-block-issue-140265.rs:16:18: 16:32}` is not a future
+   |
+   = help: the trait `Future` is not implemented for `{async closure@$DIR/suggest-async-block-issue-140265.rs:16:18: 16:32}`
+note: required by a bound in `takes_future`
+  --> $DIR/suggest-async-block-issue-140265.rs:6:28
+   |
+LL | fn takes_future(_fut: impl Future<Output = ()>) {}
+   |                            ^^^^^^^^^^^^^^^^^^^ required by this bound in `takes_future`
+help: use parentheses to call this closure
+   |
+LL |     }(/* i32 */));
+   |      +++++++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.fixed
+++ b/tests/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.fixed
@@ -8,7 +8,7 @@ async fn foo() {}
 fn bar(f: impl Future<Output=()>) {}
 
 fn main() {
-    bar(foo); //~ERROR E0277
+    bar(foo()); //~ERROR E0277
     let async_closure = async || ();
-    bar(async_closure); //~ERROR E0277
+    bar(async_closure()); //~ERROR E0277
 }

--- a/tests/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/tests/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `fn() -> impl Future<Output = ()> {foo}` is not a future
-  --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:9:9
+  --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:11:9
    |
 LL |     bar(foo);
    |     --- ^^^ `fn() -> impl Future<Output = ()> {foo}` is not a future
@@ -8,7 +8,7 @@ LL |     bar(foo);
    |
    = help: the trait `Future` is not implemented for fn item `fn() -> impl Future<Output = ()> {foo}`
 note: required by a bound in `bar`
-  --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:6:16
+  --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:8:16
    |
 LL | fn bar(f: impl Future<Output=()>) {}
    |                ^^^^^^^^^^^^^^^^^ required by this bound in `bar`
@@ -17,17 +17,17 @@ help: use parentheses to call this function
 LL |     bar(foo());
    |            ++
 
-error[E0277]: `{async closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:10:25: 10:33}` is not a future
-  --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:11:9
+error[E0277]: `{async closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:12:25: 12:33}` is not a future
+  --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:13:9
    |
 LL |     bar(async_closure);
-   |     --- ^^^^^^^^^^^^^ `{async closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:10:25: 10:33}` is not a future
+   |     --- ^^^^^^^^^^^^^ `{async closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:12:25: 12:33}` is not a future
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Future` is not implemented for `{async closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:10:25: 10:33}`
+   = help: the trait `Future` is not implemented for `{async closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:12:25: 12:33}`
 note: required by a bound in `bar`
-  --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:6:16
+  --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:8:16
    |
 LL | fn bar(f: impl Future<Output=()>) {}
    |                ^^^^^^^^^^^^^^^^^ required by this bound in `bar`


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#152042 (Suggest async block instead of async closure when possible)
 - rust-lang/rust#152949 (Introduce --ci flag in tidy)
 - rust-lang/rust#153169 (Various small query cleanups)
 - rust-lang/rust#152655 (Disable debug_assert_not_in_new_nodes for multiple threads)
 - rust-lang/rust#153229 (rustfmt: add test for field representing type builtin syntax)

Failed merges:

 - rust-lang/rust#153209 (Clean up `QueryVTable::hash_result` into `hash_value_fn`)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=152042,152949,153169,152655,153209,153229)
<!-- homu-ignore:end -->

