### PR TITLE
Add missing impl PartialEq<Vec<T>> for [T; N]

### DIFF
--- a/library/alloc/src/vec/partial_eq.rs
+++ b/library/alloc/src/vec/partial_eq.rs
@@ -34,11 +34,11 @@ __impl_slice_eq1! { [] Cow<'_, [T]>, &[U] where T: Clone, #[stable(feature = "ru
 __impl_slice_eq1! { [] Cow<'_, [T]>, &mut [U] where T: Clone, #[stable(feature = "rust1", since = "1.0.0")] }
 __impl_slice_eq1! { [A: Allocator, const N: usize] Vec<T, A>, [U; N], #[stable(feature = "rust1", since = "1.0.0")] }
 __impl_slice_eq1! { [A: Allocator, const N: usize] Vec<T, A>, &[U; N], #[stable(feature = "rust1", since = "1.0.0")] }
+__impl_slice_eq1! { [A: Allocator, const N: usize] [T; N], Vec<U, A>, #[stable(feature = "partialeq_vec_for_array", since = "CURRENT_RUSTC_VERSION")] }
 
 // NOTE: some less important impls are omitted to reduce code bloat
 // FIXME(Centril): Reconsider this?
 //__impl_slice_eq1! { [const N: usize] Vec<A>, &mut [B; N], }
-//__impl_slice_eq1! { [const N: usize] [A; N], Vec<B>, }
 //__impl_slice_eq1! { [const N: usize] &[A; N], Vec<B>, }
 //__impl_slice_eq1! { [const N: usize] &mut [A; N], Vec<B>, }
 //__impl_slice_eq1! { [const N: usize] Cow<'a, [A]>, [B; N], }

--- a/tests/ui/consts/too_generic_eval_ice.current.stderr
+++ b/tests/ui/consts/too_generic_eval_ice.current.stderr
@@ -38,7 +38,7 @@ LL |         [5; Self::HOST_SIZE] == [6; 0]
              `&[u8]` implements `PartialEq<ByteString>`
              `&mut [T]` implements `PartialEq<Vec<U, A>>`
              `&mut [T]` implements `PartialEq<[U; N]>`
-           and 11 others
+           and 12 others
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
## Summary
- Adds the missing reverse `PartialEq` implementation: `impl<T, U, A: Allocator, const N: usize> PartialEq<Vec<U, A>> for [T; N]`
- The forward direction (`Vec<T> == [T; N]`) has been stable since 1.0.0, but `[T; N] == Vec<T>` was missing
- Uses the existing `__impl_slice_eq1` macro, following the same pattern as other reverse impls (e.g., `&[T] == Vec`, `[T] == Vec`)

Closes rust-lang/rust#149017

## Test plan
- [ ] `./x test tidy --bless` passes
- [ ] `./x test library/alloc` passes
- [ ] Verify `[1, 2, 3] == vec![1, 2, 3]` compiles on nightly