### PR TITLE
Update `__rust_[rd]ealloc` to take `NonNull<u8>` instead of `*mut u8`

### DIFF
--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.PreCodegen.after.panic-abort.mir
@@ -12,8 +12,8 @@ fn drop_bytes(_1: *mut Box<[u8; 1024]>) -> () {
                     scope 17 (inlined Layout::size) {
                     }
                     scope 18 (inlined std::ptr::Unique::<[u8; 1024]>::cast::<u8>) {
+                        let mut _3: std::ptr::NonNull<u8>;
                         scope 19 (inlined NonNull::<[u8; 1024]>::cast::<u8>) {
-                            let mut _3: *mut u8;
                             scope 20 (inlined NonNull::<[u8; 1024]>::as_ptr) {
                             }
                         }
@@ -27,12 +27,10 @@ fn drop_bytes(_1: *mut Box<[u8; 1024]>) -> () {
                             scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
                                 scope 26 (inlined Layout::size) {
                                 }
-                                scope 27 (inlined NonNull::<u8>::as_ptr) {
-                                }
-                                scope 28 (inlined std::alloc::dealloc) {
-                                    scope 29 (inlined Layout::size) {
+                                scope 27 (inlined alloc::alloc::dealloc_nonnull) {
+                                    scope 28 (inlined Layout::size) {
                                     }
-                                    scope 30 (inlined Layout::alignment) {
+                                    scope 29 (inlined Layout::alignment) {
                                     }
                                 }
                             }
@@ -68,12 +66,14 @@ fn drop_bytes(_1: *mut Box<[u8; 1024]>) -> () {
     }
 
     bb0: {
+        StorageLive(_3);
         _2 = copy (((*_1).0: std::ptr::Unique<[u8; 1024]>).0: std::ptr::NonNull<[u8; 1024]>);
-        _3 = copy _2 as *mut u8 (Transmute);
+        _3 = copy _2 as std::ptr::NonNull<u8> (Transmute);
         _4 = alloc::alloc::__rust_dealloc(move _3, const 1024_usize, const std::ptr::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }}) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
+        StorageDead(_3);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.PreCodegen.after.panic-unwind.mir
@@ -12,8 +12,8 @@ fn drop_bytes(_1: *mut Box<[u8; 1024]>) -> () {
                     scope 17 (inlined Layout::size) {
                     }
                     scope 18 (inlined std::ptr::Unique::<[u8; 1024]>::cast::<u8>) {
+                        let mut _3: std::ptr::NonNull<u8>;
                         scope 19 (inlined NonNull::<[u8; 1024]>::cast::<u8>) {
-                            let mut _3: *mut u8;
                             scope 20 (inlined NonNull::<[u8; 1024]>::as_ptr) {
                             }
                         }
@@ -27,12 +27,10 @@ fn drop_bytes(_1: *mut Box<[u8; 1024]>) -> () {
                             scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
                                 scope 26 (inlined Layout::size) {
                                 }
-                                scope 27 (inlined NonNull::<u8>::as_ptr) {
-                                }
-                                scope 28 (inlined std::alloc::dealloc) {
-                                    scope 29 (inlined Layout::size) {
+                                scope 27 (inlined alloc::alloc::dealloc_nonnull) {
+                                    scope 28 (inlined Layout::size) {
                                     }
-                                    scope 30 (inlined Layout::alignment) {
+                                    scope 29 (inlined Layout::alignment) {
                                     }
                                 }
                             }
@@ -68,12 +66,14 @@ fn drop_bytes(_1: *mut Box<[u8; 1024]>) -> () {
     }
 
     bb0: {
+        StorageLive(_3);
         _2 = copy (((*_1).0: std::ptr::Unique<[u8; 1024]>).0: std::ptr::NonNull<[u8; 1024]>);
-        _3 = copy _2 as *mut u8 (Transmute);
+        _3 = copy _2 as std::ptr::NonNull<u8> (Transmute);
         _4 = alloc::alloc::__rust_dealloc(move _3, const 1024_usize, const std::ptr::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }}) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
+        StorageDead(_3);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-abort.mir
@@ -12,8 +12,8 @@ fn drop_generic(_1: *mut Box<T>) -> () {
                     scope 17 (inlined Layout::size) {
                     }
                     scope 18 (inlined std::ptr::Unique::<T>::cast::<u8>) {
+                        let mut _4: std::ptr::NonNull<u8>;
                         scope 19 (inlined NonNull::<T>::cast::<u8>) {
-                            let mut _4: *mut u8;
                             scope 20 (inlined NonNull::<T>::as_ptr) {
                             }
                         }
@@ -27,12 +27,10 @@ fn drop_generic(_1: *mut Box<T>) -> () {
                             scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
                                 scope 26 (inlined Layout::size) {
                                 }
-                                scope 27 (inlined NonNull::<u8>::as_ptr) {
-                                }
-                                scope 28 (inlined std::alloc::dealloc) {
-                                    scope 29 (inlined Layout::size) {
+                                scope 27 (inlined alloc::alloc::dealloc_nonnull) {
+                                    scope 28 (inlined Layout::size) {
                                     }
-                                    scope 30 (inlined Layout::alignment) {
+                                    scope 29 (inlined Layout::alignment) {
                                     }
                                 }
                             }
@@ -69,13 +67,14 @@ fn drop_generic(_1: *mut Box<T>) -> () {
     }
 
     bb0: {
+        StorageLive(_4);
         _2 = copy (((*_1).0: std::ptr::Unique<T>).0: std::ptr::NonNull<T>);
         _3 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
         switchInt(const <T as std::mem::SizedTypeProperties>::SIZE) -> [0: bb3, otherwise: bb1];
     }
 
     bb1: {
-        _4 = copy _2 as *mut u8 (Transmute);
+        _4 = copy _2 as std::ptr::NonNull<u8> (Transmute);
         switchInt(const <T as std::mem::SizedTypeProperties>::SIZE) -> [0: bb3, otherwise: bb2];
     }
 
@@ -84,6 +83,7 @@ fn drop_generic(_1: *mut Box<T>) -> () {
     }
 
     bb3: {
+        StorageDead(_4);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-unwind.mir
@@ -12,8 +12,8 @@ fn drop_generic(_1: *mut Box<T>) -> () {
                     scope 17 (inlined Layout::size) {
                     }
                     scope 18 (inlined std::ptr::Unique::<T>::cast::<u8>) {
+                        let mut _4: std::ptr::NonNull<u8>;
                         scope 19 (inlined NonNull::<T>::cast::<u8>) {
-                            let mut _4: *mut u8;
                             scope 20 (inlined NonNull::<T>::as_ptr) {
                             }
                         }
@@ -27,12 +27,10 @@ fn drop_generic(_1: *mut Box<T>) -> () {
                             scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
                                 scope 26 (inlined Layout::size) {
                                 }
-                                scope 27 (inlined NonNull::<u8>::as_ptr) {
-                                }
-                                scope 28 (inlined std::alloc::dealloc) {
-                                    scope 29 (inlined Layout::size) {
+                                scope 27 (inlined alloc::alloc::dealloc_nonnull) {
+                                    scope 28 (inlined Layout::size) {
                                     }
-                                    scope 30 (inlined Layout::alignment) {
+                                    scope 29 (inlined Layout::alignment) {
                                     }
                                 }
                             }
@@ -69,13 +67,14 @@ fn drop_generic(_1: *mut Box<T>) -> () {
     }
 
     bb0: {
+        StorageLive(_4);
         _2 = copy (((*_1).0: std::ptr::Unique<T>).0: std::ptr::NonNull<T>);
         _3 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
         switchInt(const <T as std::mem::SizedTypeProperties>::SIZE) -> [0: bb3, otherwise: bb1];
     }
 
     bb1: {
-        _4 = copy _2 as *mut u8 (Transmute);
+        _4 = copy _2 as std::ptr::NonNull<u8> (Transmute);
         switchInt(const <T as std::mem::SizedTypeProperties>::SIZE) -> [0: bb3, otherwise: bb2];
     }
 
@@ -84,6 +83,7 @@ fn drop_generic(_1: *mut Box<T>) -> () {
     }
 
     bb3: {
+        StorageDead(_4);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-abort.mir
@@ -8,7 +8,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
             let _2: std::ptr::NonNull<[T]>;
             let mut _3: *mut [T];
             let mut _4: *const [T];
-            let _10: ();
+            let _9: ();
             scope 3 {
                 scope 4 {
                     scope 17 (inlined Layout::size) {
@@ -28,15 +28,12 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                     scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
                         scope 24 (inlined std::alloc::Global::deallocate_impl) {
                             scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                let mut _9: *mut u8;
                                 scope 26 (inlined Layout::size) {
                                 }
-                                scope 27 (inlined NonNull::<u8>::as_ptr) {
-                                }
-                                scope 28 (inlined std::alloc::dealloc) {
-                                    scope 29 (inlined Layout::size) {
+                                scope 27 (inlined alloc::alloc::dealloc_nonnull) {
+                                    scope 28 (inlined Layout::size) {
                                     }
-                                    scope 30 (inlined Layout::alignment) {
+                                    scope 29 (inlined Layout::alignment) {
                                     }
                                 }
                             }
@@ -87,7 +84,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
     bb1: {
         _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
         StorageDead(_4);
-        switchInt(copy _5) -> [0: bb4, otherwise: bb2];
+        switchInt(copy _5) -> [0: bb3, otherwise: bb2];
     }
 
     bb2: {
@@ -95,17 +92,10 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
         _7 = copy _3 as *mut u8 (PtrToPtr);
         _8 = copy _7 as std::ptr::NonNull<u8> (Transmute);
         StorageDead(_7);
-        StorageLive(_9);
-        _9 = copy _8 as *mut u8 (Transmute);
-        _10 = alloc::alloc::__rust_dealloc(move _9, move _5, move _6) -> [return: bb3, unwind unreachable];
+        _9 = alloc::alloc::__rust_dealloc(move _8, move _5, move _6) -> [return: bb3, unwind unreachable];
     }
 
     bb3: {
-        StorageDead(_9);
-        goto -> bb4;
-    }
-
-    bb4: {
         StorageDead(_2);
         StorageDead(_8);
         StorageDead(_3);

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-unwind.mir
@@ -8,7 +8,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
             let _2: std::ptr::NonNull<[T]>;
             let mut _3: *mut [T];
             let mut _4: *const [T];
-            let _10: ();
+            let _9: ();
             scope 3 {
                 scope 4 {
                     scope 17 (inlined Layout::size) {
@@ -28,15 +28,12 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                     scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
                         scope 24 (inlined std::alloc::Global::deallocate_impl) {
                             scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                let mut _9: *mut u8;
                                 scope 26 (inlined Layout::size) {
                                 }
-                                scope 27 (inlined NonNull::<u8>::as_ptr) {
-                                }
-                                scope 28 (inlined std::alloc::dealloc) {
-                                    scope 29 (inlined Layout::size) {
+                                scope 27 (inlined alloc::alloc::dealloc_nonnull) {
+                                    scope 28 (inlined Layout::size) {
                                     }
-                                    scope 30 (inlined Layout::alignment) {
+                                    scope 29 (inlined Layout::alignment) {
                                     }
                                 }
                             }
@@ -87,7 +84,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
     bb1: {
         _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
         StorageDead(_4);
-        switchInt(copy _5) -> [0: bb4, otherwise: bb2];
+        switchInt(copy _5) -> [0: bb3, otherwise: bb2];
     }
 
     bb2: {
@@ -95,17 +92,10 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
         _7 = copy _3 as *mut u8 (PtrToPtr);
         _8 = copy _7 as std::ptr::NonNull<u8> (Transmute);
         StorageDead(_7);
-        StorageLive(_9);
-        _9 = copy _8 as *mut u8 (Transmute);
-        _10 = alloc::alloc::__rust_dealloc(move _9, move _5, move _6) -> [return: bb3, unwind unreachable];
+        _9 = alloc::alloc::__rust_dealloc(move _8, move _5, move _6) -> [return: bb3, unwind unreachable];
     }
 
     bb3: {
-        StorageDead(_9);
-        goto -> bb4;
-    }
-
-    bb4: {
         StorageDead(_2);
         StorageDead(_8);
         StorageDead(_3);

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
@@ -8,7 +8,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
             let _2: std::ptr::NonNull<[T]>;
             let mut _3: *mut [T];
             let mut _4: *const [T];
-            let _10: ();
+            let _9: ();
             scope 3 {
                 scope 4 {
                     scope 17 (inlined Layout::size) {
@@ -28,15 +28,12 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                     scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
                         scope 24 (inlined std::alloc::Global::deallocate_impl) {
                             scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                let mut _9: *mut u8;
                                 scope 26 (inlined Layout::size) {
                                 }
-                                scope 27 (inlined NonNull::<u8>::as_ptr) {
-                                }
-                                scope 28 (inlined std::alloc::dealloc) {
-                                    scope 29 (inlined Layout::size) {
+                                scope 27 (inlined alloc::alloc::dealloc_nonnull) {
+                                    scope 28 (inlined Layout::size) {
                                     }
-                                    scope 30 (inlined Layout::alignment) {
+                                    scope 29 (inlined Layout::alignment) {
                                     }
                                 }
                             }
@@ -87,7 +84,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
     bb1: {
         _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
         StorageDead(_4);
-        switchInt(copy _5) -> [0: bb4, otherwise: bb2];
+        switchInt(copy _5) -> [0: bb3, otherwise: bb2];
     }
 
     bb2: {
@@ -95,17 +92,10 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
         _7 = copy _3 as *mut u8 (PtrToPtr);
         _8 = copy _7 as std::ptr::NonNull<u8> (Transmute);
         StorageDead(_7);
-        StorageLive(_9);
-        _9 = copy _8 as *mut u8 (Transmute);
-        _10 = alloc::alloc::__rust_dealloc(move _9, move _5, move _6) -> [return: bb3, unwind unreachable];
+        _9 = alloc::alloc::__rust_dealloc(move _8, move _5, move _6) -> [return: bb3, unwind unreachable];
     }
 
     bb3: {
-        StorageDead(_9);
-        goto -> bb4;
-    }
-
-    bb4: {
         StorageDead(_2);
         StorageDead(_8);
         StorageDead(_3);

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-unwind.mir
@@ -8,7 +8,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
             let _2: std::ptr::NonNull<[T]>;
             let mut _3: *mut [T];
             let mut _4: *const [T];
-            let _10: ();
+            let _9: ();
             scope 3 {
                 scope 4 {
                     scope 17 (inlined Layout::size) {
@@ -28,15 +28,12 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                     scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
                         scope 24 (inlined std::alloc::Global::deallocate_impl) {
                             scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                let mut _9: *mut u8;
                                 scope 26 (inlined Layout::size) {
                                 }
-                                scope 27 (inlined NonNull::<u8>::as_ptr) {
-                                }
-                                scope 28 (inlined std::alloc::dealloc) {
-                                    scope 29 (inlined Layout::size) {
+                                scope 27 (inlined alloc::alloc::dealloc_nonnull) {
+                                    scope 28 (inlined Layout::size) {
                                     }
-                                    scope 30 (inlined Layout::alignment) {
+                                    scope 29 (inlined Layout::alignment) {
                                     }
                                 }
                             }
@@ -87,7 +84,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
     bb1: {
         _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
         StorageDead(_4);
-        switchInt(copy _5) -> [0: bb4, otherwise: bb2];
+        switchInt(copy _5) -> [0: bb3, otherwise: bb2];
     }
 
     bb2: {
@@ -95,17 +92,10 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
         _7 = copy _3 as *mut u8 (PtrToPtr);
         _8 = copy _7 as std::ptr::NonNull<u8> (Transmute);
         StorageDead(_7);
-        StorageLive(_9);
-        _9 = copy _8 as *mut u8 (Transmute);
-        _10 = alloc::alloc::__rust_dealloc(move _9, move _5, move _6) -> [return: bb3, unwind unreachable];
+        _9 = alloc::alloc::__rust_dealloc(move _8, move _5, move _6) -> [return: bb3, unwind unreachable];
     }
 
     bb3: {
-        StorageDead(_9);
-        goto -> bb4;
-    }
-
-    bb4: {
         StorageDead(_2);
         StorageDead(_8);
         StorageDead(_3);


### PR DESCRIPTION
Passing null to it is [already UB per Miri](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2024&gist=8dcd25a549c11de72adc94a668277779) anyway, and this is ABI-compatible as `NonNull` is `repr(transparent)`.

Inspired by https://github.com/rust-lang/rust/pull/152702#discussion_r2829961575 ; Similar to rust-lang/rust#152605 which changed `align: usize` to `align: ptr::Alignment`.
