### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_middle/src/dep_graph/graph.rs
+++ b/compiler/rustc_middle/src/dep_graph/graph.rs
@@ -9,7 +9,7 @@ use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::profiling::QueryInvocationId;
 use rustc_data_structures::sharded::{self, ShardedHashMap};
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
-use rustc_data_structures::sync::{AtomicU64, Lock};
+use rustc_data_structures::sync::{AtomicU64, Lock, is_dyn_thread_safe};
 use rustc_data_structures::unord::UnordMap;
 use rustc_data_structures::{assert_matches, outline};
 use rustc_errors::DiagInner;
@@ -1311,7 +1311,9 @@ impl<D: Deps> CurrentDepGraph<D> {
         prev_graph: &SerializedDepGraph,
         prev_index: SerializedDepNodeIndex,
     ) {
-        if let Some(ref nodes_in_current_session) = self.nodes_in_current_session {
+        if !is_dyn_thread_safe()
+            && let Some(ref nodes_in_current_session) = self.nodes_in_current_session
+        {
             debug_assert!(
                 !nodes_in_current_session
                     .lock()

--- a/compiler/rustc_middle/src/query/inner.rs
+++ b/compiler/rustc_middle/src/query/inner.rs
@@ -116,9 +116,9 @@ pub(crate) fn query_feed<'tcx, C>(
             // The query already has a cached value for this key.
             // That's OK if both values are the same, i.e. they have the same hash,
             // so now we check their hashes.
-            if let Some(hasher_fn) = query_vtable.hash_result {
+            if let Some(hash_value_fn) = query_vtable.hash_value_fn {
                 let (old_hash, value_hash) = tcx.with_stable_hashing_context(|ref mut hcx| {
-                    (hasher_fn(hcx, &old), hasher_fn(hcx, &value))
+                    (hash_value_fn(hcx, &old), hash_value_fn(hcx, &value))
                 });
                 if old_hash != value_hash {
                     // We have an inconsistency. This can happen if one of the two
@@ -151,7 +151,7 @@ pub(crate) fn query_feed<'tcx, C>(
                 dep_node,
                 tcx,
                 &value,
-                query_vtable.hash_result,
+                query_vtable.hash_value_fn,
                 query_vtable.format_value,
             );
             query_vtable.cache.complete(key, value, dep_node_index);

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -74,8 +74,6 @@ pub type TryLoadFromDiskFn<'tcx, Key, Value> = fn(
 pub type IsLoadableFromDiskFn<'tcx, Key> =
     fn(tcx: TyCtxt<'tcx>, key: &Key, index: SerializedDepNodeIndex) -> bool;
 
-pub type HashResult<V> = Option<fn(&mut StableHashingContext<'_>, &V) -> Fingerprint>;
-
 #[derive(Clone, Debug)]
 pub struct CycleError<I = QueryStackFrameExtra> {
     /// The query and related span that uses the cycle.
@@ -146,7 +144,12 @@ pub struct QueryVTable<'tcx, C: QueryCache> {
 
     pub try_load_from_disk_fn: Option<TryLoadFromDiskFn<'tcx, C::Key, C::Value>>,
     pub is_loadable_from_disk_fn: Option<IsLoadableFromDiskFn<'tcx, C::Key>>,
-    pub hash_result: HashResult<C::Value>,
+
+    /// Function pointer that hashes this query's result values.
+    ///
+    /// For `no_hash` queries, this function pointer is None.
+    pub hash_value_fn: Option<fn(&mut StableHashingContext<'_>, &C::Value) -> Fingerprint>,
+
     pub value_from_cycle_error:
         fn(tcx: TyCtxt<'tcx>, cycle_error: &CycleError, guar: ErrorGuaranteed) -> C::Value,
     pub format_value: fn(&C::Value) -> String,

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -354,7 +354,7 @@ fn execute_job<'tcx, C: QueryCache, const INCR: bool>(
     debug_assert_eq!(tcx.dep_graph.is_fully_enabled(), INCR);
 
     // Delegate to another function to actually execute the query job.
-    let (result, dep_node_index) = if INCR {
+    let (value, dep_node_index) = if INCR {
         execute_job_incr(query, tcx, key, dep_node, id)
     } else {
         execute_job_non_incr(query, tcx, key, id)
@@ -366,18 +366,18 @@ fn execute_job<'tcx, C: QueryCache, const INCR: bool>(
         // This can't happen, as query feeding adds the very dependencies to the fed query
         // as its feeding query had. So if the fed query is red, so is its feeder, which will
         // get evaluated first, and re-feed the query.
-        if let Some((cached_result, _)) = cache.lookup(&key) {
-            let Some(hasher) = query.hash_result else {
+        if let Some((cached_value, _)) = cache.lookup(&key) {
+            let Some(hash_value_fn) = query.hash_value_fn else {
                 panic!(
                     "no_hash fed query later has its value computed.\n\
                     Remove `no_hash` modifier to allow recomputation.\n\
                     The already cached value: {}",
-                    (query.format_value)(&cached_result)
+                    (query.format_value)(&cached_value)
                 );
             };
 
             let (old_hash, new_hash) = tcx.with_stable_hashing_context(|mut hcx| {
-                (hasher(&mut hcx, &cached_result), hasher(&mut hcx, &result))
+                (hash_value_fn(&mut hcx, &cached_value), hash_value_fn(&mut hcx, &value))
             });
             let formatter = query.format_value;
             if old_hash != new_hash {
@@ -389,17 +389,17 @@ fn execute_job<'tcx, C: QueryCache, const INCR: bool>(
                         computed={:#?}\nfed={:#?}",
                     query.dep_kind,
                     key,
-                    formatter(&result),
-                    formatter(&cached_result),
+                    formatter(&value),
+                    formatter(&cached_value),
                 );
             }
         }
     }
 
     // Tell the guard to perform completion bookkeeping, and also to not poison the query.
-    job_guard.complete(cache, result, dep_node_index);
+    job_guard.complete(cache, value, dep_node_index);
 
-    (result, Some(dep_node_index))
+    (value, Some(dep_node_index))
 }
 
 // Fast path for when incr. comp. is off.
@@ -420,7 +420,7 @@ fn execute_job_non_incr<'tcx, C: QueryCache>(
 
     let prof_timer = tcx.prof.query_provider();
     // Call the query provider.
-    let result =
+    let value =
         start_query(tcx, job_id, query.depth_limit, || (query.invoke_provider_fn)(tcx, key));
     let dep_node_index = tcx.dep_graph.next_virtual_depnode_index();
     prof_timer.finish_with_query_invocation_id(dep_node_index.into());
@@ -428,14 +428,14 @@ fn execute_job_non_incr<'tcx, C: QueryCache>(
     // Similarly, fingerprint the result to assert that
     // it doesn't have anything not considered hashable.
     if cfg!(debug_assertions)
-        && let Some(hash_result) = query.hash_result
+        && let Some(hash_value_fn) = query.hash_value_fn
     {
         tcx.with_stable_hashing_context(|mut hcx| {
-            hash_result(&mut hcx, &result);
+            hash_value_fn(&mut hcx, &value);
         });
     }
 
-    (result, dep_node_index)
+    (value, dep_node_index)
 }
 
 #[inline(always)]
@@ -491,7 +491,7 @@ fn execute_job_incr<'tcx, C: QueryCache>(
             tcx,
             (query, key),
             |tcx, (query, key)| (query.invoke_provider_fn)(tcx, key),
-            query.hash_result,
+            query.hash_value_fn,
         )
     });
 
@@ -542,7 +542,7 @@ fn load_from_disk_or_invoke_provider_green<'tcx, C: QueryCache>(
                 dep_graph_data,
                 &value,
                 prev_index,
-                query.hash_result,
+                query.hash_value_fn,
                 query.format_value,
             );
         }
@@ -589,7 +589,7 @@ fn load_from_disk_or_invoke_provider_green<'tcx, C: QueryCache>(
         dep_graph_data,
         &value,
         prev_index,
-        query.hash_result,
+        query.hash_value_fn,
         query.format_value,
     );
 

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -210,19 +210,13 @@ macro_rules! is_feedable {
     };
 }
 
-macro_rules! hash_result {
-    ([][$V:ty]) => {{
-        Some(|hcx, result| {
-            let result = rustc_middle::query::erase::restore_val::<$V>(*result);
-            rustc_middle::dep_graph::hash_result(hcx, &result)
-        })
-    }};
-    ([(no_hash) $($rest:tt)*][$V:ty]) => {{
-        None
-    }};
-    ([$other:tt $($modifiers:tt)*][$($args:tt)*]) => {
-        hash_result!([$($modifiers)*][$($args)*])
-    };
+/// Expands to `$yes` if the `no_hash` modifier is present, or `$no` otherwise.
+macro_rules! if_no_hash {
+    ([] $yes:tt $no:tt) => { $no };
+    ([(no_hash) $($modifiers:tt)*] $yes:tt $no:tt) => { $yes };
+    ([$other:tt $($modifiers:tt)*] $yes:tt $no:tt) => {
+        if_no_hash!([$($modifiers)*] $yes $no)
+    }
 }
 
 macro_rules! call_provider {
@@ -606,7 +600,16 @@ macro_rules! define_queries {
                         let result: queries::$name::Value<'tcx> = Value::from_cycle_error(tcx, cycle, guar);
                         erase::erase_val(result)
                     },
-                    hash_result: hash_result!([$($modifiers)*][queries::$name::Value<'tcx>]),
+                    hash_value_fn: if_no_hash!(
+                        [$($modifiers)*]
+                        None
+                        {
+                            Some(|hcx, erased_value: &erase::Erased<queries::$name::Value<'tcx>>| {
+                                let value = erase::restore_val(*erased_value);
+                                rustc_middle::dep_graph::hash_result(hcx, &value)
+                            })
+                        }
+                    ),
                     format_value: |value| format!("{:?}", erase::restore_val::<queries::$name::Value<'tcx>>(*value)),
                     description_fn: $crate::queries::_description_fns::$name,
                     execute_query_fn: if incremental {

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -798,6 +798,34 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             return false;
         }
 
+        // If this is a zero-argument async closure directly passed as an argument
+        // and the expected type is `Future`, suggest using `async {}` block instead
+        // of `async || {}`.
+        if let ty::CoroutineClosure(def_id, args) = *self_ty.kind()
+            && let sig = args.as_coroutine_closure().coroutine_closure_sig().skip_binder()
+            && let ty::Tuple(inputs) = *sig.tupled_inputs_ty.kind()
+            && inputs.is_empty()
+            && self.tcx.is_lang_item(trait_pred.def_id(), LangItem::Future)
+            && let Some(hir::Node::Expr(hir::Expr {
+                kind:
+                    hir::ExprKind::Closure(hir::Closure {
+                        kind: hir::ClosureKind::CoroutineClosure(CoroutineDesugaring::Async),
+                        fn_arg_span: Some(arg_span),
+                        ..
+                    }),
+                ..
+            })) = self.tcx.hir_get_if_local(def_id)
+            && obligation.cause.span.contains(*arg_span)
+        {
+            err.span_suggestion_verbose(
+                arg_span.with_hi(arg_span.hi() + rustc_span::BytePos(1)),
+                "use `async {}` instead of `async || {}` to introduce an async block",
+                "",
+                Applicability::MachineApplicable,
+            );
+            return true;
+        }
+
         // Get the name of the callable and the arguments to be used in the suggestion.
         let msg = match def_id_or_name {
             DefIdOrName::DefId(def_id) => match self.tcx.def_kind(def_id) {

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -800,7 +800,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 
         // If this is a zero-argument async closure directly passed as an argument
         // and the expected type is `Future`, suggest using `async {}` block instead
-        // of `async || {}`.
+        // of `async || {}`
         if let ty::CoroutineClosure(def_id, args) = *self_ty.kind()
             && let sig = args.as_coroutine_closure().coroutine_closure_sig().skip_binder()
             && let ty::Tuple(inputs) = *sig.tupled_inputs_ty.kind()
@@ -817,8 +817,18 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             })) = self.tcx.hir_get_if_local(def_id)
             && obligation.cause.span.contains(*arg_span)
         {
+            let sm = self.tcx.sess.source_map();
+            let removal_span = if let Ok(snippet) =
+                sm.span_to_snippet(arg_span.with_hi(arg_span.hi() + rustc_span::BytePos(1)))
+                && snippet.ends_with(' ')
+            {
+                // There's a space after `||`, include it in the removal
+                arg_span.with_hi(arg_span.hi() + rustc_span::BytePos(1))
+            } else {
+                *arg_span
+            };
             err.span_suggestion_verbose(
-                arg_span.with_hi(arg_span.hi() + rustc_span::BytePos(1)),
+                removal_span,
                 "use `async {}` instead of `async || {}` to introduce an async block",
                 "",
                 Applicability::MachineApplicable,

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1320,6 +1320,9 @@ impl Step for Tidy {
         if builder.config.cmd.bless() {
             cmd.arg("--bless");
         }
+        if builder.config.is_running_on_ci() {
+            cmd.arg("--ci=true");
+        }
         if let Some(s) =
             builder.config.cmd.extra_checks().or(builder.config.tidy_extra_checks.as_deref())
         {

--- a/src/tools/rustfmt/tests/target/field-representing-types.rs
+++ b/src/tools/rustfmt/tests/target/field-representing-types.rs
@@ -1,0 +1,2 @@
+type FRT = builtin # field_of(Type, ident);
+type FRT2 = builtin # field_of(Type<A, B>, ident);

--- a/src/tools/tidy/src/alphabetical/tests.rs
+++ b/src/tools/tidy/src/alphabetical/tests.rs
@@ -5,7 +5,7 @@ use crate::diagnostics::{TidyCtx, TidyFlags};
 
 #[track_caller]
 fn test(lines: &str, name: &str, expected_msg: &str, expected_bad: bool) {
-    let tidy_ctx = TidyCtx::new(Path::new("/"), false, TidyFlags::default());
+    let tidy_ctx = TidyCtx::new(Path::new("/"), false, None, TidyFlags::default());
     let mut check = tidy_ctx.start_check("alphabetical-test");
     check_lines(Path::new(name), lines, &tidy_ctx, &mut check);
 
@@ -37,7 +37,7 @@ fn bless_test(before: &str, after: &str) {
     let temp_path = tempfile::Builder::new().tempfile().unwrap().into_temp_path();
     std::fs::write(&temp_path, before).unwrap();
 
-    let tidy_ctx = TidyCtx::new(Path::new("/"), false, TidyFlags::new(true));
+    let tidy_ctx = TidyCtx::new(Path::new("/"), false, None, TidyFlags::new(true));
 
     let mut check = tidy_ctx.start_check("alphabetical-test");
     check_lines(&temp_path, before, &tidy_ctx, &mut check);

--- a/src/tools/tidy/src/arg_parser.rs
+++ b/src/tools/tidy/src/arg_parser.rs
@@ -15,6 +15,7 @@ pub struct TidyArgParser {
     pub npm: PathBuf,
     pub verbose: bool,
     pub bless: bool,
+    pub ci: Option<bool>,
     pub extra_checks: Option<Vec<String>>,
     pub pos_args: Vec<String>,
 }
@@ -59,6 +60,7 @@ impl TidyArgParser {
             )
             .arg(Arg::new("verbose").help("verbose").long("verbose").action(ArgAction::SetTrue))
             .arg(Arg::new("bless").help("target files are modified").long("bless").action(ArgAction::SetTrue))
+            .arg(Arg::new("ci").help("ci flag").long("ci").default_missing_value("true").num_args(0..=1).value_parser(value_parser!(bool)))
             .arg(
                 Arg::new("extra_checks")
                     .help("extra checks")
@@ -78,6 +80,7 @@ impl TidyArgParser {
             npm: matches.get_one::<PathBuf>("npm").unwrap().clone(),
             verbose: *matches.get_one::<bool>("verbose").unwrap(),
             bless: *matches.get_one::<bool>("bless").unwrap(),
+            ci: matches.get_one::<bool>("ci").cloned(),
             extra_checks: None,
             pos_args: vec![],
         };

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -6,7 +6,6 @@ use std::fs::{File, read_dir};
 use std::io::Write;
 use std::path::Path;
 
-use build_helper::ci::CiEnv;
 use cargo_metadata::semver::Version;
 use cargo_metadata::{Metadata, Package, PackageId};
 
@@ -637,7 +636,7 @@ pub fn check(root: &Path, cargo: &Path, tidy_ctx: TidyCtx) {
     check_proc_macro_dep_list(root, cargo, bless, &mut check);
 
     for &WorkspaceInfo { path, exceptions, crates_and_deps, submodules } in WORKSPACES {
-        if has_missing_submodule(root, submodules) {
+        if has_missing_submodule(root, submodules, tidy_ctx.is_running_on_ci()) {
             continue;
         }
 
@@ -757,8 +756,8 @@ pub static CRATES: &[&str] = &[
 /// Used to skip a check if a submodule is not checked out, and not in a CI environment.
 ///
 /// This helps prevent enforcing developers to fetch submodules for tidy.
-pub fn has_missing_submodule(root: &Path, submodules: &[&str]) -> bool {
-    !CiEnv::is_ci()
+pub fn has_missing_submodule(root: &Path, submodules: &[&str], is_ci: bool) -> bool {
+    !is_ci
         && submodules.iter().any(|submodule| {
             let path = root.join(submodule);
             !path.exists()

--- a/src/tools/tidy/src/error_codes.rs
+++ b/src/tools/tidy/src/error_codes.rs
@@ -36,11 +36,11 @@ const IGNORE_DOCTEST_CHECK: &[&str] = &["E0464", "E0570", "E0601", "E0602", "E07
 const IGNORE_UI_TEST_CHECK: &[&str] =
     &["E0461", "E0465", "E0514", "E0554", "E0640", "E0717", "E0729"];
 
-pub fn check(root_path: &Path, search_paths: &[&Path], ci_info: &crate::CiInfo, tidy_ctx: TidyCtx) {
+pub fn check(root_path: &Path, search_paths: &[&Path], tidy_ctx: TidyCtx) {
     let mut check = tidy_ctx.start_check("error_codes");
 
     // Check that no error code explanation was removed.
-    check_removed_error_code_explanation(ci_info, &mut check);
+    check_removed_error_code_explanation(&tidy_ctx.base_commit, &mut check);
 
     // Stage 1: create list
     let error_codes = extract_error_codes(root_path, &mut check);
@@ -57,8 +57,8 @@ pub fn check(root_path: &Path, search_paths: &[&Path], ci_info: &crate::CiInfo, 
     check_error_codes_used(search_paths, &error_codes, &mut check, &no_longer_emitted);
 }
 
-fn check_removed_error_code_explanation(ci_info: &crate::CiInfo, check: &mut RunningCheck) {
-    let Some(base_commit) = &ci_info.base_commit else {
+fn check_removed_error_code_explanation(base_commit: &Option<String>, check: &mut RunningCheck) {
+    let Some(base_commit) = base_commit else {
         check.verbose_msg("Skipping error code explanation removal check");
         return;
     };

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -19,7 +19,7 @@ pub fn check(root: &Path, tidy_ctx: TidyCtx) {
     let mut check = tidy_ctx.start_check("extdeps");
 
     for &WorkspaceInfo { path, submodules, .. } in crate::deps::WORKSPACES {
-        if crate::deps::has_missing_submodule(root, submodules) {
+        if crate::deps::has_missing_submodule(root, submodules, tidy_ctx.is_running_on_ci()) {
             continue;
         }
 

--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -40,11 +40,11 @@ fn main() {
 
     let verbose = parsed_args.verbose;
     let bless = parsed_args.bless;
+    let ci = parsed_args.ci;
     let extra_checks = parsed_args.extra_checks;
     let pos_args = parsed_args.pos_args;
 
-    let tidy_ctx = TidyCtx::new(&root_path, verbose, TidyFlags::new(bless));
-    let ci_info = CiInfo::new(tidy_ctx.clone());
+    let tidy_ctx = TidyCtx::new(&root_path, verbose, ci, TidyFlags::new(bless));
 
     let drain_handles = |handles: &mut VecDeque<ScopedJoinHandle<'_, ()>>| {
         // poll all threads for completion before awaiting the oldest one
@@ -101,12 +101,12 @@ fn main() {
         check!(rustdoc_gui_tests, &tests_path);
         check!(rustdoc_css_themes, &librustdoc_path);
         check!(rustdoc_templates, &librustdoc_path);
-        check!(rustdoc_json, &src_path, &ci_info);
+        check!(rustdoc_json, &src_path);
         check!(known_bug, &crashes_path);
         check!(unknown_revision, &tests_path);
 
         // Checks that only make sense for the compiler.
-        check!(error_codes, &root_path, &[&compiler_path, &librustdoc_path], &ci_info);
+        check!(error_codes, &root_path, &[&compiler_path, &librustdoc_path]);
         check!(target_policy, &root_path);
         check!(gcc_submodule, &root_path, &compiler_path);
 
@@ -154,7 +154,6 @@ fn main() {
             extra_checks,
             &root_path,
             &output_directory,
-            &ci_info,
             &librustdoc_path,
             &tools_path,
             &npm,

--- a/src/tools/tidy/src/rustdoc_json.rs
+++ b/src/tools/tidy/src/rustdoc_json.rs
@@ -8,16 +8,18 @@ use crate::diagnostics::{CheckId, TidyCtx};
 
 const RUSTDOC_JSON_TYPES: &str = "src/rustdoc-json-types";
 
-pub fn check(src_path: &Path, ci_info: &crate::CiInfo, tidy_ctx: TidyCtx) {
+pub fn check(src_path: &Path, tidy_ctx: TidyCtx) {
     let mut check = tidy_ctx.start_check(CheckId::new("rustdoc_json").path(src_path));
 
-    let Some(base_commit) = &ci_info.base_commit else {
+    let Some(base_commit) = &tidy_ctx.base_commit else {
         check.verbose_msg("No base commit, skipping rustdoc_json check");
         return;
     };
 
     // First we check that `src/rustdoc-json-types` was modified.
-    if !crate::files_modified(ci_info, |p| p.starts_with(RUSTDOC_JSON_TYPES)) {
+    if !crate::files_modified(&tidy_ctx.base_commit, tidy_ctx.is_running_on_ci(), |p| {
+        p.starts_with(RUSTDOC_JSON_TYPES)
+    }) {
         // `rustdoc-json-types` was not modified so nothing more to check here.
         return;
     }

--- a/tests/ui/async-await/async-closures/suggest-async-block-issue-140265.rs
+++ b/tests/ui/async-await/async-closures/suggest-async-block-issue-140265.rs
@@ -12,6 +12,12 @@ fn main() {
         println!("hi!");
     });
 
+    // Without space between `||` and `{`: should also suggest using async block
+    takes_future(async||{
+        //~^ ERROR is not a future
+        println!("no space!");
+    });
+
     // With arguments: should suggest calling the closure, not using async block
     takes_future(async |x: i32| {
         //~^ ERROR is not a future

--- a/tests/ui/async-await/async-closures/suggest-async-block-issue-140265.rs
+++ b/tests/ui/async-await/async-closures/suggest-async-block-issue-140265.rs
@@ -1,0 +1,20 @@
+//@ edition:2024
+// Test that we suggest using `async {}` block instead of `async || {}` closure if possible
+
+use std::future::Future;
+
+fn takes_future(_fut: impl Future<Output = ()>) {}
+
+fn main() {
+    // Basic case: suggest using async block
+    takes_future(async || {
+        //~^ ERROR is not a future
+        println!("hi!");
+    });
+
+    // With arguments: should suggest calling the closure, not using async block
+    takes_future(async |x: i32| {
+        //~^ ERROR is not a future
+        println!("{x}");
+    });
+}

--- a/tests/ui/async-await/async-closures/suggest-async-block-issue-140265.stderr
+++ b/tests/ui/async-await/async-closures/suggest-async-block-issue-140265.stderr
@@ -22,8 +22,32 @@ LL -     takes_future(async || {
 LL +     takes_future(async {
    |
 
-error[E0277]: `{async closure@$DIR/suggest-async-block-issue-140265.rs:16:18: 16:32}` is not a future
+error[E0277]: `{async closure@$DIR/suggest-async-block-issue-140265.rs:16:18: 16:25}` is not a future
   --> $DIR/suggest-async-block-issue-140265.rs:16:18
+   |
+LL |       takes_future(async||{
+   |  _____------------_^
+   | |     |
+   | |     required by a bound introduced by this call
+LL | |
+LL | |         println!("no space!");
+LL | |     });
+   | |_____^ `{async closure@$DIR/suggest-async-block-issue-140265.rs:16:18: 16:25}` is not a future
+   |
+   = help: the trait `Future` is not implemented for `{async closure@$DIR/suggest-async-block-issue-140265.rs:16:18: 16:25}`
+note: required by a bound in `takes_future`
+  --> $DIR/suggest-async-block-issue-140265.rs:6:28
+   |
+LL | fn takes_future(_fut: impl Future<Output = ()>) {}
+   |                            ^^^^^^^^^^^^^^^^^^^ required by this bound in `takes_future`
+help: use `async {}` instead of `async || {}` to introduce an async block
+   |
+LL -     takes_future(async||{
+LL +     takes_future(async{
+   |
+
+error[E0277]: `{async closure@$DIR/suggest-async-block-issue-140265.rs:22:18: 22:32}` is not a future
+  --> $DIR/suggest-async-block-issue-140265.rs:22:18
    |
 LL |       takes_future(async |x: i32| {
    |  _____------------_^
@@ -32,9 +56,9 @@ LL |       takes_future(async |x: i32| {
 LL | |
 LL | |         println!("{x}");
 LL | |     });
-   | |_____^ `{async closure@$DIR/suggest-async-block-issue-140265.rs:16:18: 16:32}` is not a future
+   | |_____^ `{async closure@$DIR/suggest-async-block-issue-140265.rs:22:18: 22:32}` is not a future
    |
-   = help: the trait `Future` is not implemented for `{async closure@$DIR/suggest-async-block-issue-140265.rs:16:18: 16:32}`
+   = help: the trait `Future` is not implemented for `{async closure@$DIR/suggest-async-block-issue-140265.rs:22:18: 22:32}`
 note: required by a bound in `takes_future`
   --> $DIR/suggest-async-block-issue-140265.rs:6:28
    |
@@ -45,6 +69,6 @@ help: use parentheses to call this closure
 LL |     }(/* i32 */));
    |      +++++++++++
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/async-await/async-closures/suggest-async-block-issue-140265.stderr
+++ b/tests/ui/async-await/async-closures/suggest-async-block-issue-140265.stderr
@@ -1,0 +1,50 @@
+error[E0277]: `{async closure@$DIR/suggest-async-block-issue-140265.rs:10:18: 10:26}` is not a future
+  --> $DIR/suggest-async-block-issue-140265.rs:10:18
+   |
+LL |       takes_future(async || {
+   |  _____------------_^
+   | |     |
+   | |     required by a bound introduced by this call
+LL | |
+LL | |         println!("hi!");
+LL | |     });
+   | |_____^ `{async closure@$DIR/suggest-async-block-issue-140265.rs:10:18: 10:26}` is not a future
+   |
+   = help: the trait `Future` is not implemented for `{async closure@$DIR/suggest-async-block-issue-140265.rs:10:18: 10:26}`
+note: required by a bound in `takes_future`
+  --> $DIR/suggest-async-block-issue-140265.rs:6:28
+   |
+LL | fn takes_future(_fut: impl Future<Output = ()>) {}
+   |                            ^^^^^^^^^^^^^^^^^^^ required by this bound in `takes_future`
+help: use `async {}` instead of `async || {}` to introduce an async block
+   |
+LL -     takes_future(async || {
+LL +     takes_future(async {
+   |
+
+error[E0277]: `{async closure@$DIR/suggest-async-block-issue-140265.rs:16:18: 16:32}` is not a future
+  --> $DIR/suggest-async-block-issue-140265.rs:16:18
+   |
+LL |       takes_future(async |x: i32| {
+   |  _____------------_^
+   | |     |
+   | |     required by a bound introduced by this call
+LL | |
+LL | |         println!("{x}");
+LL | |     });
+   | |_____^ `{async closure@$DIR/suggest-async-block-issue-140265.rs:16:18: 16:32}` is not a future
+   |
+   = help: the trait `Future` is not implemented for `{async closure@$DIR/suggest-async-block-issue-140265.rs:16:18: 16:32}`
+note: required by a bound in `takes_future`
+  --> $DIR/suggest-async-block-issue-140265.rs:6:28
+   |
+LL | fn takes_future(_fut: impl Future<Output = ()>) {}
+   |                            ^^^^^^^^^^^^^^^^^^^ required by this bound in `takes_future`
+help: use parentheses to call this closure
+   |
+LL |     }(/* i32 */));
+   |      +++++++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.fixed
+++ b/tests/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.fixed
@@ -8,7 +8,7 @@ async fn foo() {}
 fn bar(f: impl Future<Output=()>) {}
 
 fn main() {
-    bar(foo); //~ERROR E0277
+    bar(foo()); //~ERROR E0277
     let async_closure = async || ();
-    bar(async_closure); //~ERROR E0277
+    bar(async_closure()); //~ERROR E0277
 }

--- a/tests/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/tests/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `fn() -> impl Future<Output = ()> {foo}` is not a future
-  --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:9:9
+  --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:11:9
    |
 LL |     bar(foo);
    |     --- ^^^ `fn() -> impl Future<Output = ()> {foo}` is not a future
@@ -8,7 +8,7 @@ LL |     bar(foo);
    |
    = help: the trait `Future` is not implemented for fn item `fn() -> impl Future<Output = ()> {foo}`
 note: required by a bound in `bar`
-  --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:6:16
+  --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:8:16
    |
 LL | fn bar(f: impl Future<Output=()>) {}
    |                ^^^^^^^^^^^^^^^^^ required by this bound in `bar`
@@ -17,17 +17,17 @@ help: use parentheses to call this function
 LL |     bar(foo());
    |            ++
 
-error[E0277]: `{async closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:10:25: 10:33}` is not a future
-  --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:11:9
+error[E0277]: `{async closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:12:25: 12:33}` is not a future
+  --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:13:9
    |
 LL |     bar(async_closure);
-   |     --- ^^^^^^^^^^^^^ `{async closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:10:25: 10:33}` is not a future
+   |     --- ^^^^^^^^^^^^^ `{async closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:12:25: 12:33}` is not a future
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Future` is not implemented for `{async closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:10:25: 10:33}`
+   = help: the trait `Future` is not implemented for `{async closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:12:25: 12:33}`
 note: required by a bound in `bar`
-  --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:6:16
+  --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:8:16
    |
 LL | fn bar(f: impl Future<Output=()>) {}
    |                ^^^^^^^^^^^^^^^^^ required by this bound in `bar`


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#152042 (Suggest async block instead of async closure when possible)
 - rust-lang/rust#152949 (Introduce --ci flag in tidy)
 - rust-lang/rust#152655 (Disable debug_assert_not_in_new_nodes for multiple threads)
 - rust-lang/rust#153209 (Clean up `QueryVTable::hash_result` into `hash_value_fn`)
 - rust-lang/rust#153229 (rustfmt: add test for field representing type builtin syntax)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=152042,152949,152655,153209,153229)
<!-- homu-ignore:end -->

