### PR TITLE
Recover feature lang_items for emscripten

### DIFF
--- a/library/panic_unwind/src/lib.rs
+++ b/library/panic_unwind/src/lib.rs
@@ -14,7 +14,7 @@
 #![no_std]
 #![unstable(feature = "panic_unwind", issue = "32837")]
 #![doc(issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/")]
-#![cfg_attr(all(target_os = "emscripten", not(emscripten_wasm_eh)), lang_items)]
+#![cfg_attr(all(target_os = "emscripten", not(emscripten_wasm_eh)), feature(lang_items))]
 #![feature(cfg_emscripten_wasm_eh)]
 #![feature(core_intrinsics)]
 #![feature(panic_unwind)]


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/pull/152469#discussion_r2858304043

The previous https://github.com/rust-lang/rust/pull/153128 lacks of `feature`