### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -583,8 +583,10 @@ Redddy <rust@redddy.com>
 Redddy <rust@redddy.com> <midzy0228@gmail.com>
 Redddy <rust@redddy.com> <78539407+reddevilmidzy@users.noreply.github.com>
 Rémy Rakic <remy.rakic@gmail.com>
+Rémy Rakic <remy.rakic@gmail.com> <remy.rakic@arm.com>
 Rémy Rakic <remy.rakic@gmail.com> <remy.rakic+github@gmail.com>
 Rémy Rakic <remy.rakic@gmail.com> <remy.rakic+rust@gmail.com>
+Rémy Rakic <remy.rakic@gmail.com> <lqd@users.noreply.github.com>
 Renato Riccieri Santos Zannon <renato@rrsz.com.br>
 Richard Diamond <wichard@vitalitystudios.com> <wichard@hahbee.co>
 Ricky Hosfelt <ricky@hosfelt.io>

--- a/compiler/rustc_error_messages/src/lib.rs
+++ b/compiler/rustc_error_messages/src/lib.rs
@@ -311,6 +311,8 @@ pub enum DiagArgValue {
     StrListSepByAnd(Vec<Cow<'static, str>>),
 }
 
+/// A mapping from diagnostic argument names to their values.
+/// This contains all the arguments necessary to format a diagnostic message.
 pub type DiagArgMap = FxIndexMap<DiagArgName, DiagArgValue>;
 
 /// Converts a value of a type into a `DiagArg` (typically a field of an `Diag` struct).

--- a/compiler/rustc_error_messages/src/lib.rs
+++ b/compiler/rustc_error_messages/src/lib.rs
@@ -13,6 +13,7 @@ pub use unic_langid::{LanguageIdentifier, langid};
 
 mod diagnostic_impls;
 pub use diagnostic_impls::DiagArgFromDisplay;
+use rustc_data_structures::fx::FxIndexMap;
 
 pub fn register_functions<R, M>(bundle: &mut fluent_bundle::bundle::FluentBundle<R, M>) {
     bundle
@@ -309,6 +310,8 @@ pub enum DiagArgValue {
     Number(i32),
     StrListSepByAnd(Vec<Cow<'static, str>>),
 }
+
+pub type DiagArgMap = FxIndexMap<DiagArgName, DiagArgValue>;
 
 /// Converts a value of a type into a `DiagArg` (typically a field of an `Diag` struct).
 /// Implemented as a custom trait rather than `From` so that it is implemented on the type being

--- a/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
+++ b/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
@@ -16,7 +16,7 @@ use annotate_snippets::{AnnotationKind, Group, Origin, Padding, Patch, Renderer,
 use anstream::ColorChoice;
 use derive_setters::Setters;
 use rustc_data_structures::sync::IntoDynSyncSend;
-use rustc_error_messages::{FluentArgs, SpanLabel};
+use rustc_error_messages::{DiagArgMap, SpanLabel};
 use rustc_lint_defs::pluralize;
 use rustc_span::source_map::SourceMap;
 use rustc_span::{BytePos, FileName, Pos, SourceFile, Span};
@@ -26,7 +26,7 @@ use crate::emitter::{
     ConfusionType, Destination, MAX_SUGGESTIONS, OutputTheme, detect_confusion_type, is_different,
     normalize_whitespace, should_show_source_code,
 };
-use crate::translation::{format_diag_message, format_diag_messages, to_fluent_args};
+use crate::translation::{format_diag_message, format_diag_messages};
 use crate::{
     CodeSuggestion, DiagInner, DiagMessage, Emitter, ErrCode, Level, MultiSpan, Style, Subdiag,
     SuggestionStyle, TerminalUrl,
@@ -70,14 +70,12 @@ impl Debug for AnnotateSnippetEmitter {
 impl Emitter for AnnotateSnippetEmitter {
     /// The entry point for the diagnostics generation
     fn emit_diagnostic(&mut self, mut diag: DiagInner) {
-        let fluent_args = to_fluent_args(diag.args.iter());
-
         if self.track_diagnostics && diag.span.has_primary_spans() && !diag.span.is_dummy() {
             diag.children.insert(0, diag.emitted_at_sub_diag());
         }
 
         let mut suggestions = diag.suggestions.unwrap_tag();
-        self.primary_span_formatted(&mut diag.span, &mut suggestions, &fluent_args);
+        self.primary_span_formatted(&mut diag.span, &mut suggestions, &diag.args);
 
         self.fix_multispans_in_extern_macros_and_render_macro_backtrace(
             &mut diag.span,
@@ -89,7 +87,7 @@ impl Emitter for AnnotateSnippetEmitter {
         self.emit_messages_default(
             &diag.level,
             &diag.messages,
-            &fluent_args,
+            &diag.args,
             &diag.code,
             &diag.span,
             &diag.children,
@@ -145,7 +143,7 @@ impl AnnotateSnippetEmitter {
         &mut self,
         level: &Level,
         msgs: &[(DiagMessage, Style)],
-        args: &FluentArgs<'_>,
+        args: &DiagArgMap,
         code: &Option<ErrCode>,
         msp: &MultiSpan,
         children: &[Subdiag],
@@ -539,7 +537,7 @@ impl AnnotateSnippetEmitter {
         &self,
         msgs: &[(DiagMessage, Style)],
         level: Level,
-        args: &FluentArgs<'_>,
+        args: &DiagArgMap,
     ) -> String {
         msgs.iter()
             .filter_map(|(m, style)| {
@@ -673,7 +671,7 @@ struct Annotation {
 }
 
 fn collect_annotations(
-    args: &FluentArgs<'_>,
+    args: &DiagArgMap,
     msp: &MultiSpan,
     sm: &Arc<SourceMap>,
 ) -> Vec<(Arc<SourceFile>, Vec<Annotation>)> {

--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -7,8 +7,7 @@ use std::panic;
 use std::path::PathBuf;
 use std::thread::panicking;
 
-use rustc_data_structures::fx::FxIndexMap;
-use rustc_error_messages::{DiagArgName, DiagArgValue, IntoDiagArg};
+use rustc_error_messages::{DiagArgMap, DiagArgName, DiagArgValue, IntoDiagArg};
 use rustc_lint_defs::{Applicability, LintExpectationId};
 use rustc_macros::{Decodable, Encodable};
 use rustc_span::source_map::Spanned;
@@ -19,8 +18,6 @@ use crate::{
     CodeSuggestion, DiagCtxtHandle, DiagMessage, ErrCode, ErrorGuaranteed, ExplicitBug, Level,
     MultiSpan, StashKey, Style, Substitution, SubstitutionPart, SuggestionStyle, Suggestions,
 };
-
-pub type DiagArgMap = FxIndexMap<DiagArgName, DiagArgValue>;
 
 /// Trait for types that `Diag::emit` can return as a "guarantee" (or "proof")
 /// token that the emission happened.

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -17,7 +17,7 @@ use anstream::{AutoStream, ColorChoice};
 use anstyle::{AnsiColor, Effects};
 use rustc_data_structures::fx::FxIndexSet;
 use rustc_data_structures::sync::DynSend;
-use rustc_error_messages::FluentArgs;
+use rustc_error_messages::DiagArgMap;
 use rustc_span::hygiene::{ExpnKind, MacroKind};
 use rustc_span::source_map::SourceMap;
 use rustc_span::{FileName, SourceFile, Span};
@@ -102,7 +102,7 @@ pub trait Emitter {
         &self,
         primary_span: &mut MultiSpan,
         suggestions: &mut Vec<CodeSuggestion>,
-        fluent_args: &FluentArgs<'_>,
+        fluent_args: &DiagArgMap,
     ) {
         if let Some((sugg, rest)) = suggestions.split_first() {
             let msg = format_diag_message(&sugg.msg, fluent_args);

--- a/compiler/rustc_errors/src/json.rs
+++ b/compiler/rustc_errors/src/json.rs
@@ -17,7 +17,7 @@ use std::vec;
 use anstream::{AutoStream, ColorChoice};
 use derive_setters::Setters;
 use rustc_data_structures::sync::IntoDynSyncSend;
-use rustc_error_messages::FluentArgs;
+use rustc_error_messages::DiagArgMap;
 use rustc_lint_defs::Applicability;
 use rustc_span::hygiene::ExpnData;
 use rustc_span::source_map::{FilePathMapping, SourceMap};
@@ -31,7 +31,7 @@ use crate::emitter::{
     should_show_source_code,
 };
 use crate::timings::{TimingRecord, TimingSection};
-use crate::translation::{format_diag_message, format_diag_messages, to_fluent_args};
+use crate::translation::{format_diag_message, format_diag_messages};
 use crate::{CodeSuggestion, MultiSpan, SpanLabel, Subdiag, Suggestions, TerminalUrl};
 
 #[cfg(test)]
@@ -298,14 +298,13 @@ struct UnusedExterns<'a> {
 impl Diagnostic {
     /// Converts from `rustc_errors::DiagInner` to `Diagnostic`.
     fn from_errors_diagnostic(diag: crate::DiagInner, je: &JsonEmitter) -> Diagnostic {
-        let args = to_fluent_args(diag.args.iter());
         let sugg_to_diag = |sugg: &CodeSuggestion| {
-            let translated_message = format_diag_message(&sugg.msg, &args);
+            let translated_message = format_diag_message(&sugg.msg, &diag.args);
             Diagnostic {
                 message: translated_message.to_string(),
                 code: None,
                 level: "help",
-                spans: DiagnosticSpan::from_suggestion(sugg, &args, je),
+                spans: DiagnosticSpan::from_suggestion(sugg, &diag.args, je),
                 children: vec![],
                 rendered: None,
             }
@@ -331,7 +330,7 @@ impl Diagnostic {
             }
         }
 
-        let translated_message = format_diag_messages(&diag.messages, &args);
+        let translated_message = format_diag_messages(&diag.messages, &diag.args);
 
         let code = if let Some(code) = diag.code {
             Some(DiagnosticCode {
@@ -344,16 +343,18 @@ impl Diagnostic {
             None
         };
         let level = diag.level.to_str();
-        let spans = DiagnosticSpan::from_multispan(&diag.span, &args, je);
+        let spans = DiagnosticSpan::from_multispan(&diag.span, &diag.args, je);
         let mut children: Vec<Diagnostic> = diag
             .children
             .iter()
-            .map(|c| Diagnostic::from_sub_diagnostic(c, &args, je))
+            .map(|c| Diagnostic::from_sub_diagnostic(c, &diag.args, je))
             .chain(sugg)
             .collect();
         if je.track_diagnostics && diag.span.has_primary_spans() && !diag.span.is_dummy() {
-            children
-                .insert(0, Diagnostic::from_sub_diagnostic(&diag.emitted_at_sub_diag(), &args, je));
+            children.insert(
+                0,
+                Diagnostic::from_sub_diagnostic(&diag.emitted_at_sub_diag(), &diag.args, je),
+            );
         }
         let buf = BufWriter(Arc::new(Mutex::new(Vec::new())));
         let dst: Destination = AutoStream::new(
@@ -388,11 +389,7 @@ impl Diagnostic {
         }
     }
 
-    fn from_sub_diagnostic(
-        subdiag: &Subdiag,
-        args: &FluentArgs<'_>,
-        je: &JsonEmitter,
-    ) -> Diagnostic {
+    fn from_sub_diagnostic(subdiag: &Subdiag, args: &DiagArgMap, je: &JsonEmitter) -> Diagnostic {
         let translated_message = format_diag_messages(&subdiag.messages, args);
         Diagnostic {
             message: translated_message.to_string(),
@@ -409,7 +406,7 @@ impl DiagnosticSpan {
     fn from_span_label(
         span: SpanLabel,
         suggestion: Option<(&String, Applicability)>,
-        args: &FluentArgs<'_>,
+        args: &DiagArgMap,
         je: &JsonEmitter,
     ) -> DiagnosticSpan {
         Self::from_span_etc(
@@ -509,11 +506,7 @@ impl DiagnosticSpan {
         }
     }
 
-    fn from_multispan(
-        msp: &MultiSpan,
-        args: &FluentArgs<'_>,
-        je: &JsonEmitter,
-    ) -> Vec<DiagnosticSpan> {
+    fn from_multispan(msp: &MultiSpan, args: &DiagArgMap, je: &JsonEmitter) -> Vec<DiagnosticSpan> {
         msp.span_labels()
             .into_iter()
             .map(|span_str| Self::from_span_label(span_str, None, args, je))
@@ -522,7 +515,7 @@ impl DiagnosticSpan {
 
     fn from_suggestion(
         suggestion: &CodeSuggestion,
-        args: &FluentArgs<'_>,
+        args: &DiagArgMap,
         je: &JsonEmitter,
     ) -> Vec<DiagnosticSpan> {
         suggestion

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -1434,7 +1434,7 @@ impl DiagCtxtInner {
         message: DiagMessage,
         args: impl Iterator<Item = DiagArg<'a>>,
     ) -> String {
-        let args = crate::translation::to_fluent_args(args);
+        let args = args.map(|(name, val)| (name.clone(), val.clone())).collect();
         format_diag_message(&message, &args).to_string()
     }
 

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -39,8 +39,8 @@ pub use anstyle::{
 pub use codes::*;
 pub use decorate_diag::{BufferedEarlyLint, DecorateDiagCompat, LintBuffer};
 pub use diagnostic::{
-    BugAbort, Diag, DiagArgMap, DiagInner, DiagStyledString, Diagnostic, EmissionGuarantee,
-    FatalAbort, LintDiagnostic, LintDiagnosticBox, StringPart, Subdiag, Subdiagnostic,
+    BugAbort, Diag, DiagInner, DiagStyledString, Diagnostic, EmissionGuarantee, FatalAbort,
+    LintDiagnostic, LintDiagnosticBox, StringPart, Subdiag, Subdiagnostic,
 };
 pub use diagnostic_impls::{
     DiagSymbolList, ElidedLifetimeInPathSubdiag, ExpectedLifetimeParameter,
@@ -53,7 +53,7 @@ use rustc_data_structures::stable_hasher::StableHasher;
 use rustc_data_structures::sync::{DynSend, Lock};
 use rustc_data_structures::{AtomicRef, assert_matches};
 pub use rustc_error_messages::{
-    DiagArg, DiagArgFromDisplay, DiagArgName, DiagArgValue, DiagMessage, IntoDiagArg,
+    DiagArg, DiagArgFromDisplay, DiagArgMap, DiagArgName, DiagArgValue, DiagMessage, IntoDiagArg,
     LanguageIdentifier, MultiSpan, SpanLabel, fluent_bundle, into_diag_arg_using_display,
 };
 use rustc_hashes::Hash128;

--- a/compiler/rustc_errors/src/translation.rs
+++ b/compiler/rustc_errors/src/translation.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 pub use rustc_error_messages::FluentArgs;
-use rustc_error_messages::{langid, register_functions};
+use rustc_error_messages::{DiagArgMap, langid, register_functions};
 use tracing::{debug, trace};
 
 use crate::fluent_bundle::FluentResource;
@@ -12,7 +12,7 @@ use crate::{DiagArg, DiagMessage, Style, fluent_bundle};
 ///
 /// Typically performed once for each diagnostic at the start of `emit_diagnostic` and then
 /// passed around as a reference thereafter.
-pub fn to_fluent_args<'iter>(iter: impl Iterator<Item = DiagArg<'iter>>) -> FluentArgs<'static> {
+fn to_fluent_args<'iter>(iter: impl Iterator<Item = DiagArg<'iter>>) -> FluentArgs<'static> {
     let mut args = if let Some(size) = iter.size_hint().1 {
         FluentArgs::with_capacity(size)
     } else {
@@ -29,14 +29,15 @@ pub fn to_fluent_args<'iter>(iter: impl Iterator<Item = DiagArg<'iter>>) -> Flue
 /// Convert `DiagMessage`s to a string
 pub fn format_diag_messages(
     messages: &[(DiagMessage, Style)],
-    args: &FluentArgs<'_>,
+    args: &DiagArgMap,
 ) -> Cow<'static, str> {
     Cow::Owned(messages.iter().map(|(m, _)| format_diag_message(m, args)).collect::<String>())
 }
 
 /// Convert a `DiagMessage` to a string
-pub fn format_diag_message<'a>(message: &'a DiagMessage, args: &'a FluentArgs<'_>) -> Cow<'a, str> {
+pub fn format_diag_message<'a>(message: &'a DiagMessage, args: &DiagArgMap) -> Cow<'a, str> {
     trace!(?message, ?args);
+
     match message {
         DiagMessage::Str(msg) => Cow::Borrowed(msg),
         // This translates an inline fluent diagnostic message
@@ -52,9 +53,10 @@ pub fn format_diag_message<'a>(message: &'a DiagMessage, args: &'a FluentArgs<'_
             register_functions(&mut bundle);
             let message = bundle.get_message(GENERATED_MSG_ID).unwrap();
             let value = message.value().unwrap();
+            let args = to_fluent_args(args.iter());
 
             let mut errs = vec![];
-            let translated = bundle.format_pattern(value, Some(args), &mut errs).to_string();
+            let translated = bundle.format_pattern(value, Some(&args), &mut errs).to_string();
             debug!(?translated, ?errs);
             if errs.is_empty() {
                 Cow::Owned(translated)

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -4566,7 +4566,7 @@ declare_lint! {
     ///
     /// [future-incompatible]: ../index.md#future-incompatible-lints
     pub AMBIGUOUS_GLOB_IMPORTS,
-    Warn,
+    Deny,
     "detects certain glob imports that require reporting an ambiguity error",
     @future_incompatible = FutureIncompatibleInfo {
         reason: fcw!(FutureReleaseError #114095),

--- a/library/panic_unwind/src/lib.rs
+++ b/library/panic_unwind/src/lib.rs
@@ -14,7 +14,7 @@
 #![no_std]
 #![unstable(feature = "panic_unwind", issue = "32837")]
 #![doc(issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/")]
-#![cfg_attr(all(target_os = "emscripten", not(emscripten_wasm_eh)), lang_items)]
+#![cfg_attr(all(target_os = "emscripten", not(emscripten_wasm_eh)), feature(lang_items))]
 #![feature(cfg_emscripten_wasm_eh)]
 #![feature(core_intrinsics)]
 #![feature(panic_unwind)]

--- a/library/std/src/os/unix/process.rs
+++ b/library/std/src/os/unix/process.rs
@@ -593,5 +593,5 @@ impl From<OwnedFd> for process::ChildStderr {
 #[must_use]
 #[stable(feature = "unix_ppid", since = "1.27.0")]
 pub fn parent_id() -> u32 {
-    crate::sys::os::getppid()
+    crate::sys::process::getppid()
 }

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -2545,7 +2545,7 @@ pub fn abort() -> ! {
 #[must_use]
 #[stable(feature = "getpid", since = "1.26.0")]
 pub fn id() -> u32 {
-    crate::sys::os::getpid()
+    imp::getpid()
 }
 
 /// A trait for implementing arbitrary return types in the `main` function.

--- a/library/std/src/sys/fs/vexos.rs
+++ b/library/std/src/sys/fs/vexos.rs
@@ -12,8 +12,8 @@ use crate::sys::{unsupported, unsupported_err};
 #[path = "unsupported.rs"]
 mod unsupported_fs;
 pub use unsupported_fs::{
-    DirBuilder, FileTimes, canonicalize, link, readlink, remove_dir_all, rename, rmdir, symlink,
-    unlink,
+    Dir, DirBuilder, FileTimes, canonicalize, link, readlink, remove_dir_all, rename, rmdir,
+    symlink, unlink,
 };
 
 /// VEXos file descriptor.

--- a/library/std/src/sys/pal/hermit/os.rs
+++ b/library/std/src/sys/pal/hermit/os.rs
@@ -1,4 +1,3 @@
-use super::hermit_abi;
 use crate::ffi::{OsStr, OsString};
 use crate::marker::PhantomData;
 use crate::path::{self, PathBuf};
@@ -55,8 +54,4 @@ pub fn temp_dir() -> PathBuf {
 
 pub fn home_dir() -> Option<PathBuf> {
     None
-}
-
-pub fn getpid() -> u32 {
-    unsafe { hermit_abi::getpid() as u32 }
 }

--- a/library/std/src/sys/pal/motor/os.rs
+++ b/library/std/src/sys/pal/motor/os.rs
@@ -62,7 +62,3 @@ pub fn temp_dir() -> PathBuf {
 pub fn home_dir() -> Option<PathBuf> {
     None
 }
-
-pub fn getpid() -> u32 {
-    panic!("Pids on Motor OS are u64.")
-}

--- a/library/std/src/sys/pal/sgx/os.rs
+++ b/library/std/src/sys/pal/sgx/os.rs
@@ -55,7 +55,3 @@ pub fn temp_dir() -> PathBuf {
 pub fn home_dir() -> Option<PathBuf> {
     None
 }
-
-pub fn getpid() -> u32 {
-    panic!("no pids in SGX")
-}

--- a/library/std/src/sys/pal/solid/os.rs
+++ b/library/std/src/sys/pal/solid/os.rs
@@ -62,7 +62,3 @@ pub fn temp_dir() -> PathBuf {
 pub fn home_dir() -> Option<PathBuf> {
     None
 }
-
-pub fn getpid() -> u32 {
-    panic!("no pids on this platform")
-}

--- a/library/std/src/sys/pal/teeos/os.rs
+++ b/library/std/src/sys/pal/teeos/os.rs
@@ -66,7 +66,3 @@ pub fn temp_dir() -> PathBuf {
 pub fn home_dir() -> Option<PathBuf> {
     None
 }
-
-pub fn getpid() -> u32 {
-    panic!("no pids on this platform")
-}

--- a/library/std/src/sys/pal/uefi/os.rs
+++ b/library/std/src/sys/pal/uefi/os.rs
@@ -101,7 +101,3 @@ pub fn temp_dir() -> PathBuf {
 pub fn home_dir() -> Option<PathBuf> {
     None
 }
-
-pub fn getpid() -> u32 {
-    panic!("no pids on this platform")
-}

--- a/library/std/src/sys/pal/unix/os.rs
+++ b/library/std/src/sys/pal/unix/os.rs
@@ -533,14 +533,6 @@ pub fn home_dir() -> Option<PathBuf> {
     }
 }
 
-pub fn getpid() -> u32 {
-    unsafe { libc::getpid() as u32 }
-}
-
-pub fn getppid() -> u32 {
-    unsafe { libc::getppid() as u32 }
-}
-
 #[cfg(all(target_os = "linux", target_env = "gnu"))]
 pub fn glibc_version() -> Option<(usize, usize)> {
     unsafe extern "C" {

--- a/library/std/src/sys/pal/unsupported/os.rs
+++ b/library/std/src/sys/pal/unsupported/os.rs
@@ -55,7 +55,3 @@ pub fn temp_dir() -> PathBuf {
 pub fn home_dir() -> Option<PathBuf> {
     None
 }
-
-pub fn getpid() -> u32 {
-    panic!("no pids on this platform")
-}

--- a/library/std/src/sys/pal/wasi/os.rs
+++ b/library/std/src/sys/pal/wasi/os.rs
@@ -102,10 +102,6 @@ pub fn home_dir() -> Option<PathBuf> {
     None
 }
 
-pub fn getpid() -> u32 {
-    panic!("unsupported");
-}
-
 #[doc(hidden)]
 pub trait IsMinusOne {
     fn is_minus_one(&self) -> bool;

--- a/library/std/src/sys/pal/windows/os.rs
+++ b/library/std/src/sys/pal/windows/os.rs
@@ -188,7 +188,3 @@ pub fn home_dir() -> Option<PathBuf> {
         .map(PathBuf::from)
         .or_else(home_dir_crt)
 }
-
-pub fn getpid() -> u32 {
-    unsafe { c::GetCurrentProcessId() }
-}

--- a/library/std/src/sys/pal/xous/os.rs
+++ b/library/std/src/sys/pal/xous/os.rs
@@ -118,7 +118,3 @@ pub fn temp_dir() -> PathBuf {
 pub fn home_dir() -> Option<PathBuf> {
     None
 }
-
-pub fn getpid() -> u32 {
-    panic!("no pids on this platform")
-}

--- a/library/std/src/sys/pal/zkvm/os.rs
+++ b/library/std/src/sys/pal/zkvm/os.rs
@@ -55,7 +55,3 @@ pub fn temp_dir() -> PathBuf {
 pub fn home_dir() -> Option<PathBuf> {
     None
 }
-
-pub fn getpid() -> u32 {
-    panic!("no pids on this platform")
-}

--- a/library/std/src/sys/process/mod.rs
+++ b/library/std/src/sys/process/mod.rs
@@ -27,9 +27,11 @@ cfg_select! {
 mod env;
 
 pub use env::CommandEnvs;
+#[cfg(target_family = "unix")]
+pub use imp::getppid;
 pub use imp::{
     ChildPipe, Command, CommandArgs, EnvKey, ExitCode, ExitStatus, ExitStatusError, Process, Stdio,
-    read_output,
+    getpid, read_output,
 };
 
 #[cfg(any(

--- a/library/std/src/sys/process/motor.rs
+++ b/library/std/src/sys/process/motor.rs
@@ -327,3 +327,7 @@ pub fn read_output(
 ) -> io::Result<()> {
     Err(io::Error::from_raw_os_error(moto_rt::E_NOT_IMPLEMENTED.into()))
 }
+
+pub fn getpid() -> u32 {
+    panic!("Pids on Motor OS are u64.")
+}

--- a/library/std/src/sys/process/uefi.rs
+++ b/library/std/src/sys/process/uefi.rs
@@ -900,3 +900,7 @@ fn env_changes(env: &CommandEnv) -> Option<BTreeMap<EnvKey, (Option<OsString>, O
 
     Some(result)
 }
+
+pub fn getpid() -> u32 {
+    panic!("no pids on this platform")
+}

--- a/library/std/src/sys/process/unix/common.rs
+++ b/library/std/src/sys/process/unix/common.rs
@@ -679,3 +679,11 @@ pub fn read_output(
         }
     }
 }
+
+pub fn getpid() -> u32 {
+    unsafe { libc::getpid() as u32 }
+}
+
+pub fn getppid() -> u32 {
+    unsafe { libc::getppid() as u32 }
+}

--- a/library/std/src/sys/process/unix/mod.rs
+++ b/library/std/src/sys/process/unix/mod.rs
@@ -23,5 +23,7 @@ cfg_select! {
 
 pub use imp::{ExitStatus, ExitStatusError, Process};
 
-pub use self::common::{ChildPipe, Command, CommandArgs, ExitCode, Stdio, read_output};
+pub use self::common::{
+    ChildPipe, Command, CommandArgs, ExitCode, Stdio, getpid, getppid, read_output,
+};
 pub use crate::ffi::OsString as EnvKey;

--- a/library/std/src/sys/process/unsupported.rs
+++ b/library/std/src/sys/process/unsupported.rs
@@ -327,3 +327,7 @@ pub fn read_output(
 ) -> io::Result<()> {
     match out.diverge() {}
 }
+
+pub fn getpid() -> u32 {
+    panic!("no pids on this platform")
+}

--- a/library/std/src/sys/process/windows.rs
+++ b/library/std/src/sys/process/windows.rs
@@ -976,3 +976,7 @@ impl<'a> fmt::Debug for CommandArgs<'a> {
         f.debug_list().entries(self.iter.clone()).finish()
     }
 }
+
+pub fn getpid() -> u32 {
+    unsafe { c::GetCurrentProcessId() }
+}

--- a/src/librustdoc/passes/lint/check_code_block_syntax.rs
+++ b/src/librustdoc/passes/lint/check_code_block_syntax.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use rustc_data_structures::sync::Lock;
 use rustc_errors::emitter::Emitter;
-use rustc_errors::translation::{format_diag_message, to_fluent_args};
+use rustc_errors::translation::format_diag_message;
 use rustc_errors::{Applicability, DiagCtxt, DiagInner};
 use rustc_parse::{source_str_to_stream, unwrap_or_emit_fatal};
 use rustc_resolve::rustdoc::source_span_for_markdown_range;
@@ -150,8 +150,7 @@ impl Emitter for BufferEmitter {
     fn emit_diagnostic(&mut self, diag: DiagInner) {
         let mut buffer = self.buffer.borrow_mut();
 
-        let fluent_args = to_fluent_args(diag.args.iter());
-        let translated_main_message = format_diag_message(&diag.messages[0].0, &fluent_args);
+        let translated_main_message = format_diag_message(&diag.messages[0].0, &diag.args);
 
         buffer.messages.push(format!("error from rustc: {translated_main_message}"));
         if diag.is_error() {

--- a/tests/ui/imports/ambiguous-10.rs
+++ b/tests/ui/imports/ambiguous-10.rs
@@ -1,5 +1,5 @@
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1637022296
-//@ check-pass
+
 mod a {
     pub enum Token {}
 }
@@ -13,6 +13,6 @@ mod b {
 use crate::a::*;
 use crate::b::*;
 fn c(_: Token) {}
-//~^ WARN `Token` is ambiguous
+//~^ ERROR `Token` is ambiguous
 //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 fn main() { }

--- a/tests/ui/imports/ambiguous-10.stderr
+++ b/tests/ui/imports/ambiguous-10.stderr
@@ -1,4 +1,4 @@
-warning: `Token` is ambiguous
+error: `Token` is ambiguous
   --> $DIR/ambiguous-10.rs:15:9
    |
 LL | fn c(_: Token) {}
@@ -19,12 +19,12 @@ note: `Token` could also refer to the enum imported here
 LL | use crate::b::*;
    |     ^^^^^^^^^^^
    = help: consider adding an explicit import of `Token` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `Token` is ambiguous
+error: `Token` is ambiguous
   --> $DIR/ambiguous-10.rs:15:9
    |
 LL | fn c(_: Token) {}
@@ -45,5 +45,5 @@ note: `Token` could also refer to the enum imported here
 LL | use crate::b::*;
    |     ^^^^^^^^^^^
    = help: consider adding an explicit import of `Token` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-12.rs
+++ b/tests/ui/imports/ambiguous-12.rs
@@ -1,5 +1,5 @@
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1637022296
-//@ check-pass
+
 macro_rules! m {
     () => {
         pub fn b() {}
@@ -19,6 +19,6 @@ use crate::public::*;
 
 fn main() {
     b();
-    //~^ WARN `b` is ambiguous
+    //~^ ERROR `b` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }

--- a/tests/ui/imports/ambiguous-12.stderr
+++ b/tests/ui/imports/ambiguous-12.stderr
@@ -1,4 +1,4 @@
-warning: `b` is ambiguous
+error: `b` is ambiguous
   --> $DIR/ambiguous-12.rs:21:5
    |
 LL |     b();
@@ -19,12 +19,12 @@ note: `b` could also refer to the function imported here
 LL | use crate::public::*;
    |     ^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `b` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `b` is ambiguous
+error: `b` is ambiguous
   --> $DIR/ambiguous-12.rs:21:5
    |
 LL |     b();
@@ -45,5 +45,5 @@ note: `b` could also refer to the function imported here
 LL | use crate::public::*;
    |     ^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `b` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-13.rs
+++ b/tests/ui/imports/ambiguous-13.rs
@@ -1,5 +1,5 @@
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1637022296
-//@ check-pass
+
 pub mod object {
     #[derive(Debug)]
     pub struct Rect;
@@ -16,6 +16,6 @@ use crate::object::*;
 use crate::content::*;
 
 fn a(_: Rect) {}
-//~^ WARN `Rect` is ambiguous
+//~^ ERROR `Rect` is ambiguous
 //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 fn main() { }

--- a/tests/ui/imports/ambiguous-13.stderr
+++ b/tests/ui/imports/ambiguous-13.stderr
@@ -1,4 +1,4 @@
-warning: `Rect` is ambiguous
+error: `Rect` is ambiguous
   --> $DIR/ambiguous-13.rs:18:9
    |
 LL | fn a(_: Rect) {}
@@ -19,12 +19,12 @@ note: `Rect` could also refer to the struct imported here
 LL | use crate::content::*;
    |     ^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `Rect` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `Rect` is ambiguous
+error: `Rect` is ambiguous
   --> $DIR/ambiguous-13.rs:18:9
    |
 LL | fn a(_: Rect) {}
@@ -45,5 +45,5 @@ note: `Rect` could also refer to the struct imported here
 LL | use crate::content::*;
    |     ^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `Rect` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-14.rs
+++ b/tests/ui/imports/ambiguous-14.rs
@@ -1,6 +1,6 @@
 //@ edition:2015
 // https://github.com/rust-lang/rust/issues/98467
-//@ check-pass
+
 mod a {
     pub fn foo() {}
 }
@@ -21,6 +21,6 @@ mod g {
 
 fn main() {
     g::foo();
-    //~^ WARN `foo` is ambiguous
+    //~^ ERROR `foo` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }

--- a/tests/ui/imports/ambiguous-14.stderr
+++ b/tests/ui/imports/ambiguous-14.stderr
@@ -1,4 +1,4 @@
-warning: `foo` is ambiguous
+error: `foo` is ambiguous
   --> $DIR/ambiguous-14.rs:23:8
    |
 LL |     g::foo();
@@ -19,12 +19,12 @@ note: `foo` could also refer to the function imported here
 LL |     pub use f::*;
    |             ^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `foo` is ambiguous
+error: `foo` is ambiguous
   --> $DIR/ambiguous-14.rs:23:8
    |
 LL |     g::foo();
@@ -45,5 +45,5 @@ note: `foo` could also refer to the function imported here
 LL |     pub use f::*;
    |             ^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-15.rs
+++ b/tests/ui/imports/ambiguous-15.rs
@@ -1,5 +1,5 @@
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1638206152
-//@ check-pass
+
 mod t2 {
     #[derive(Debug)]
     pub enum Error {}
@@ -20,7 +20,7 @@ mod t3 {
 
 use self::t3::*;
 fn a<E: Error>(_: E) {}
-//~^ WARN `Error` is ambiguous
+//~^ ERROR `Error` is ambiguous
 //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 fn main() {}

--- a/tests/ui/imports/ambiguous-15.stderr
+++ b/tests/ui/imports/ambiguous-15.stderr
@@ -1,4 +1,4 @@
-warning: `Error` is ambiguous
+error: `Error` is ambiguous
   --> $DIR/ambiguous-15.rs:22:9
    |
 LL | fn a<E: Error>(_: E) {}
@@ -19,12 +19,12 @@ note: `Error` could also refer to the enum imported here
 LL | pub use t2::*;
    |         ^^^^^
    = help: consider adding an explicit import of `Error` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `Error` is ambiguous
+error: `Error` is ambiguous
   --> $DIR/ambiguous-15.rs:22:9
    |
 LL | fn a<E: Error>(_: E) {}
@@ -45,5 +45,5 @@ note: `Error` could also refer to the enum imported here
 LL | pub use t2::*;
    |         ^^^^^
    = help: consider adding an explicit import of `Error` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-16.rs
+++ b/tests/ui/imports/ambiguous-16.rs
@@ -1,5 +1,5 @@
 // https://github.com/rust-lang/rust/pull/113099
-//@ check-pass
+
 mod framing {
     mod public_message {
         use super::*;
@@ -20,7 +20,7 @@ mod framing {
 }
 
 use crate::framing::ConfirmedTranscriptHashInput;
-//~^ WARN `ConfirmedTranscriptHashInput` is ambiguous
+//~^ ERROR `ConfirmedTranscriptHashInput` is ambiguous
 //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 fn main() { }

--- a/tests/ui/imports/ambiguous-16.stderr
+++ b/tests/ui/imports/ambiguous-16.stderr
@@ -1,4 +1,4 @@
-warning: `ConfirmedTranscriptHashInput` is ambiguous
+error: `ConfirmedTranscriptHashInput` is ambiguous
   --> $DIR/ambiguous-16.rs:22:21
    |
 LL | use crate::framing::ConfirmedTranscriptHashInput;
@@ -19,12 +19,12 @@ note: `ConfirmedTranscriptHashInput` could also refer to the struct imported her
 LL |     pub use self::public_message_in::*;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `ConfirmedTranscriptHashInput` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `ConfirmedTranscriptHashInput` is ambiguous
+error: `ConfirmedTranscriptHashInput` is ambiguous
   --> $DIR/ambiguous-16.rs:22:21
    |
 LL | use crate::framing::ConfirmedTranscriptHashInput;
@@ -45,5 +45,5 @@ note: `ConfirmedTranscriptHashInput` could also refer to the struct imported her
 LL |     pub use self::public_message_in::*;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `ConfirmedTranscriptHashInput` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-17.rs
+++ b/tests/ui/imports/ambiguous-17.rs
@@ -1,6 +1,6 @@
 //@ edition:2015
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1638206152
-//@ check-pass
+
 pub use evp::*; //~ WARNING ambiguous glob re-exports
 pub use handwritten::*;
 
@@ -24,6 +24,6 @@ mod handwritten {
 
 fn main() {
     id();
-    //~^ WARN `id` is ambiguous
+    //~^ ERROR `id` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }

--- a/tests/ui/imports/ambiguous-17.stderr
+++ b/tests/ui/imports/ambiguous-17.stderr
@@ -8,7 +8,7 @@ LL | pub use handwritten::*;
    |
    = note: `#[warn(ambiguous_glob_reexports)]` on by default
 
-warning: `id` is ambiguous
+error: `id` is ambiguous
   --> $DIR/ambiguous-17.rs:26:5
    |
 LL |     id();
@@ -29,12 +29,12 @@ note: `id` could also refer to the function imported here
 LL | pub use handwritten::*;
    |         ^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `id` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 2 warnings emitted
+error: aborting due to 1 previous error; 1 warning emitted
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `id` is ambiguous
+error: `id` is ambiguous
   --> $DIR/ambiguous-17.rs:26:5
    |
 LL |     id();
@@ -55,5 +55,5 @@ note: `id` could also refer to the function imported here
 LL | pub use handwritten::*;
    |         ^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `id` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-2.rs
+++ b/tests/ui/imports/ambiguous-2.rs
@@ -1,9 +1,9 @@
 //@ aux-build: ../ambiguous-1.rs
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1633574396
-//@ check-pass
+
 extern crate ambiguous_1;
 
 fn main() {
-    ambiguous_1::id(); //~ WARN `id` is ambiguous
+    ambiguous_1::id(); //~ ERROR `id` is ambiguous
                        //~| WARN this was previously accepted
 }

--- a/tests/ui/imports/ambiguous-2.stderr
+++ b/tests/ui/imports/ambiguous-2.stderr
@@ -1,4 +1,4 @@
-warning: `id` is ambiguous
+error: `id` is ambiguous
   --> $DIR/ambiguous-2.rs:7:18
    |
 LL |     ambiguous_1::id();
@@ -19,12 +19,12 @@ note: `id` could also refer to the function defined here
    |
 LL |     pub use self::handwritten::*;
    |             ^^^^^^^^^^^^^^^^^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `id` is ambiguous
+error: `id` is ambiguous
   --> $DIR/ambiguous-2.rs:7:18
    |
 LL |     ambiguous_1::id();
@@ -45,5 +45,5 @@ note: `id` could also refer to the function defined here
    |
 LL |     pub use self::handwritten::*;
    |             ^^^^^^^^^^^^^^^^^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-3.rs
+++ b/tests/ui/imports/ambiguous-3.rs
@@ -1,9 +1,9 @@
 // https://github.com/rust-lang/rust/issues/47525
-//@ check-pass
+
 fn main() {
     use a::*;
     x();
-    //~^ WARN `x` is ambiguous
+    //~^ ERROR `x` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }
 

--- a/tests/ui/imports/ambiguous-3.stderr
+++ b/tests/ui/imports/ambiguous-3.stderr
@@ -1,4 +1,4 @@
-warning: `x` is ambiguous
+error: `x` is ambiguous
   --> $DIR/ambiguous-3.rs:5:5
    |
 LL |     x();
@@ -19,12 +19,12 @@ note: `x` could also refer to the function imported here
 LL |     pub use self::c::*;
    |             ^^^^^^^^^^
    = help: consider adding an explicit import of `x` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `x` is ambiguous
+error: `x` is ambiguous
   --> $DIR/ambiguous-3.rs:5:5
    |
 LL |     x();
@@ -45,5 +45,5 @@ note: `x` could also refer to the function imported here
 LL |     pub use self::c::*;
    |             ^^^^^^^^^^
    = help: consider adding an explicit import of `x` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-4.rs
+++ b/tests/ui/imports/ambiguous-4.rs
@@ -1,9 +1,9 @@
 //@ edition:2015
 //@ aux-build: ../ambiguous-4-extern.rs
-//@ check-pass
+
 extern crate ambiguous_4_extern;
 
 fn main() {
-    ambiguous_4_extern::id(); //~ WARN `id` is ambiguous
+    ambiguous_4_extern::id(); //~ ERROR `id` is ambiguous
                               //~| WARN this was previously accepted
 }

--- a/tests/ui/imports/ambiguous-4.stderr
+++ b/tests/ui/imports/ambiguous-4.stderr
@@ -1,4 +1,4 @@
-warning: `id` is ambiguous
+error: `id` is ambiguous
   --> $DIR/ambiguous-4.rs:7:25
    |
 LL |     ambiguous_4_extern::id();
@@ -19,12 +19,12 @@ note: `id` could also refer to the function defined here
    |
 LL | pub use handwritten::*;
    |         ^^^^^^^^^^^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `id` is ambiguous
+error: `id` is ambiguous
   --> $DIR/ambiguous-4.rs:7:25
    |
 LL |     ambiguous_4_extern::id();
@@ -45,5 +45,5 @@ note: `id` could also refer to the function defined here
    |
 LL | pub use handwritten::*;
    |         ^^^^^^^^^^^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-5.rs
+++ b/tests/ui/imports/ambiguous-5.rs
@@ -1,5 +1,5 @@
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1637022296
-//@ check-pass
+
 mod a {
     pub struct Class(u16);
 }
@@ -10,7 +10,7 @@ mod gpos {
     use super::gsubgpos::*;
     use super::*;
     struct MarkRecord(Class);
-    //~^ WARN`Class` is ambiguous
+    //~^ ERROR`Class` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }
 

--- a/tests/ui/imports/ambiguous-5.stderr
+++ b/tests/ui/imports/ambiguous-5.stderr
@@ -1,4 +1,4 @@
-warning: `Class` is ambiguous
+error: `Class` is ambiguous
   --> $DIR/ambiguous-5.rs:12:23
    |
 LL |     struct MarkRecord(Class);
@@ -19,12 +19,12 @@ note: `Class` could also refer to the struct imported here
 LL |     use super::gsubgpos::*;
    |         ^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `Class` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `Class` is ambiguous
+error: `Class` is ambiguous
   --> $DIR/ambiguous-5.rs:12:23
    |
 LL |     struct MarkRecord(Class);
@@ -45,5 +45,5 @@ note: `Class` could also refer to the struct imported here
 LL |     use super::gsubgpos::*;
    |         ^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `Class` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-6.rs
+++ b/tests/ui/imports/ambiguous-6.rs
@@ -1,10 +1,10 @@
 //@ edition: 2021
 // https://github.com/rust-lang/rust/issues/112713
-//@ check-pass
+
 pub fn foo() -> u32 {
     use sub::*;
     C
-    //~^ WARN `C` is ambiguous
+    //~^ ERROR `C` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }
 

--- a/tests/ui/imports/ambiguous-6.stderr
+++ b/tests/ui/imports/ambiguous-6.stderr
@@ -1,4 +1,4 @@
-warning: `C` is ambiguous
+error: `C` is ambiguous
   --> $DIR/ambiguous-6.rs:6:5
    |
 LL |     C
@@ -19,12 +19,12 @@ note: `C` could also refer to the constant imported here
 LL |     pub use mod2::*;
    |             ^^^^^^^
    = help: consider adding an explicit import of `C` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `C` is ambiguous
+error: `C` is ambiguous
   --> $DIR/ambiguous-6.rs:6:5
    |
 LL |     C
@@ -45,5 +45,5 @@ note: `C` could also refer to the constant imported here
 LL |     pub use mod2::*;
    |             ^^^^^^^
    = help: consider adding an explicit import of `C` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-9.rs
+++ b/tests/ui/imports/ambiguous-9.rs
@@ -1,5 +1,5 @@
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1638206152
-//@ check-pass
+
 pub mod dsl {
     mod range {
         pub fn date_range() {}
@@ -21,8 +21,8 @@ use prelude::*;
 
 fn main() {
     date_range();
-    //~^ WARN `date_range` is ambiguous
+    //~^ ERROR `date_range` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-    //~| WARN `date_range` is ambiguous
+    //~| ERROR `date_range` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }

--- a/tests/ui/imports/ambiguous-9.stderr
+++ b/tests/ui/imports/ambiguous-9.stderr
@@ -8,7 +8,7 @@ LL |     use super::prelude::*;
    |
    = note: `#[warn(ambiguous_glob_reexports)]` on by default
 
-warning: `date_range` is ambiguous
+error: `date_range` is ambiguous
   --> $DIR/ambiguous-9.rs:23:5
    |
 LL |     date_range();
@@ -29,7 +29,7 @@ note: `date_range` could also refer to the function imported here
 LL |     use super::prelude::*;
    |         ^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `date_range` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 warning: ambiguous glob re-exports
   --> $DIR/ambiguous-9.rs:15:13
@@ -39,7 +39,7 @@ LL |     pub use self::t::*;
 LL |     pub use super::dsl::*;
    |             ------------- but the name `date_range` in the value namespace is also re-exported here
 
-warning: `date_range` is ambiguous
+error: `date_range` is ambiguous
   --> $DIR/ambiguous-9.rs:23:5
    |
 LL |     date_range();
@@ -61,10 +61,10 @@ LL | use prelude::*;
    |     ^^^^^^^^^^
    = help: consider adding an explicit import of `date_range` to disambiguate
 
-warning: 4 warnings emitted
+error: aborting due to 2 previous errors; 2 warnings emitted
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `date_range` is ambiguous
+error: `date_range` is ambiguous
   --> $DIR/ambiguous-9.rs:23:5
    |
 LL |     date_range();
@@ -85,10 +85,10 @@ note: `date_range` could also refer to the function imported here
 LL |     use super::prelude::*;
    |         ^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `date_range` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
-warning: `date_range` is ambiguous
+error: `date_range` is ambiguous
   --> $DIR/ambiguous-9.rs:23:5
    |
 LL |     date_range();
@@ -109,5 +109,5 @@ note: `date_range` could also refer to the function imported here
 LL | use prelude::*;
    |     ^^^^^^^^^^
    = help: consider adding an explicit import of `date_range` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-panic-globvsglob.rs
+++ b/tests/ui/imports/ambiguous-panic-globvsglob.rs
@@ -3,7 +3,7 @@
 mod m1 {
     pub use core::prelude::v1::*;
 }
-//@ check-pass
+
 mod m2 {
     pub use std::prelude::v1::*;
 }
@@ -18,6 +18,6 @@ fn foo() {
     panic!();
     //~^ WARN: `panic` is ambiguous [ambiguous_panic_imports]
     //~| WARN: this was previously accepted by the compiler
-    //~| WARN: `panic` is ambiguous [ambiguous_glob_imports]
+    //~| ERROR: `panic` is ambiguous [ambiguous_glob_imports]
     //~| WARN: this was previously accepted by the compiler
 }

--- a/tests/ui/imports/ambiguous-panic-globvsglob.stderr
+++ b/tests/ui/imports/ambiguous-panic-globvsglob.stderr
@@ -1,4 +1,4 @@
-warning: `panic` is ambiguous
+error: `panic` is ambiguous
   --> $DIR/ambiguous-panic-globvsglob.rs:18:5
    |
 LL |     panic!();
@@ -19,7 +19,7 @@ note: `panic` could also refer to the macro imported here
 LL |     use m2::*;
    |         ^^^^^
    = help: consider adding an explicit import of `panic` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 warning: `panic` is ambiguous
   --> $DIR/ambiguous-panic-globvsglob.rs:18:5
@@ -40,10 +40,10 @@ note: `panic` could also refer to a macro from prelude
   --> $SRC_DIR/std/src/prelude/mod.rs:LL:COL
    = note: `#[warn(ambiguous_panic_imports)]` (part of `#[warn(future_incompatible)]`) on by default
 
-warning: 2 warnings emitted
+error: aborting due to 1 previous error; 1 warning emitted
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `panic` is ambiguous
+error: `panic` is ambiguous
   --> $DIR/ambiguous-panic-globvsglob.rs:18:5
    |
 LL |     panic!();
@@ -64,5 +64,5 @@ note: `panic` could also refer to the macro imported here
 LL |     use m2::*;
    |         ^^^^^
    = help: consider adding an explicit import of `panic` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/duplicate.rs
+++ b/tests/ui/imports/duplicate.rs
@@ -34,7 +34,7 @@ fn main() {
     e::foo();
     f::foo(); //~ ERROR `foo` is ambiguous
     g::foo();
-    //~^ WARN `foo` is ambiguous
+    //~^ ERROR `foo` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }
 

--- a/tests/ui/imports/duplicate.stderr
+++ b/tests/ui/imports/duplicate.stderr
@@ -68,7 +68,7 @@ LL |     use self::m2::*;
    |         ^^^^^^^^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
 
-warning: `foo` is ambiguous
+error: `foo` is ambiguous
   --> $DIR/duplicate.rs:36:8
    |
 LL |     g::foo();
@@ -89,14 +89,14 @@ note: `foo` could also refer to the function imported here
 LL |     pub use crate::f::*;
    |             ^^^^^^^^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-error: aborting due to 4 previous errors; 1 warning emitted
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0252, E0659.
 For more information about an error, try `rustc --explain E0252`.
 Future incompatibility report: Future breakage diagnostic:
-warning: `foo` is ambiguous
+error: `foo` is ambiguous
   --> $DIR/duplicate.rs:36:8
    |
 LL |     g::foo();
@@ -117,5 +117,5 @@ note: `foo` could also refer to the function imported here
 LL |     pub use crate::f::*;
    |             ^^^^^^^^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/glob-conflict-cross-crate-1.rs
+++ b/tests/ui/imports/glob-conflict-cross-crate-1.rs
@@ -1,11 +1,11 @@
 //@ edition:2015
 //@ aux-build:glob-conflict.rs
-//@ check-pass
+
 extern crate glob_conflict;
 
 fn main() {
-    glob_conflict::f(); //~ WARN `f` is ambiguous
+    glob_conflict::f(); //~ ERROR `f` is ambiguous
                         //~| WARN this was previously accepted
-    glob_conflict::glob::f(); //~ WARN `f` is ambiguous
+    glob_conflict::glob::f(); //~ ERROR `f` is ambiguous
                               //~| WARN this was previously accepted
 }

--- a/tests/ui/imports/glob-conflict-cross-crate-1.stderr
+++ b/tests/ui/imports/glob-conflict-cross-crate-1.stderr
@@ -1,4 +1,4 @@
-warning: `f` is ambiguous
+error: `f` is ambiguous
   --> $DIR/glob-conflict-cross-crate-1.rs:7:20
    |
 LL |     glob_conflict::f();
@@ -19,9 +19,9 @@ note: `f` could also refer to the function defined here
    |
 LL | pub use m2::*;
    |         ^^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: `f` is ambiguous
+error: `f` is ambiguous
   --> $DIR/glob-conflict-cross-crate-1.rs:9:26
    |
 LL |     glob_conflict::glob::f();
@@ -43,10 +43,10 @@ note: `f` could also refer to the function defined here
 LL | pub use m2::*;
    |         ^^
 
-warning: 2 warnings emitted
+error: aborting due to 2 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `f` is ambiguous
+error: `f` is ambiguous
   --> $DIR/glob-conflict-cross-crate-1.rs:7:20
    |
 LL |     glob_conflict::f();
@@ -67,10 +67,10 @@ note: `f` could also refer to the function defined here
    |
 LL | pub use m2::*;
    |         ^^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
-warning: `f` is ambiguous
+error: `f` is ambiguous
   --> $DIR/glob-conflict-cross-crate-1.rs:9:26
    |
 LL |     glob_conflict::glob::f();
@@ -91,5 +91,5 @@ note: `f` could also refer to the function defined here
    |
 LL | pub use m2::*;
    |         ^^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/glob-conflict-cross-crate-2.rs
+++ b/tests/ui/imports/glob-conflict-cross-crate-2.rs
@@ -1,10 +1,10 @@
 //@ aux-build:glob-conflict-cross-crate-2-extern.rs
-//@ check-pass
+
 extern crate glob_conflict_cross_crate_2_extern;
 
 use glob_conflict_cross_crate_2_extern::*;
 
 fn main() {
-    let _a: C = 1; //~ WARN `C` is ambiguous
+    let _a: C = 1; //~ ERROR `C` is ambiguous
                    //~| WARN this was previously accepted
 }

--- a/tests/ui/imports/glob-conflict-cross-crate-2.stderr
+++ b/tests/ui/imports/glob-conflict-cross-crate-2.stderr
@@ -1,4 +1,4 @@
-warning: `C` is ambiguous
+error: `C` is ambiguous
   --> $DIR/glob-conflict-cross-crate-2.rs:8:13
    |
 LL |     let _a: C = 1;
@@ -19,12 +19,12 @@ note: `C` could also refer to the type alias defined here
    |
 LL | pub use b::*;
    |         ^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `C` is ambiguous
+error: `C` is ambiguous
   --> $DIR/glob-conflict-cross-crate-2.rs:8:13
    |
 LL |     let _a: C = 1;
@@ -45,5 +45,5 @@ note: `C` could also refer to the type alias defined here
    |
 LL | pub use b::*;
    |         ^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/glob-conflict-cross-crate-3.rs
+++ b/tests/ui/imports/glob-conflict-cross-crate-3.rs
@@ -1,5 +1,5 @@
 //@ aux-build:glob-conflict-cross-crate-2-extern.rs
-//@ check-pass
+
 extern crate glob_conflict_cross_crate_2_extern;
 
 mod a {
@@ -11,8 +11,8 @@ use a::*;
 
 fn main() {
     let _a: C = 1;
-    //~^ WARN `C` is ambiguous
-    //~| WARN `C` is ambiguous
+    //~^ ERROR `C` is ambiguous
+    //~| ERROR `C` is ambiguous
     //~| WARN this was previously accepted
     //~| WARN this was previously accepted
 }

--- a/tests/ui/imports/glob-conflict-cross-crate-3.stderr
+++ b/tests/ui/imports/glob-conflict-cross-crate-3.stderr
@@ -1,4 +1,4 @@
-warning: `C` is ambiguous
+error: `C` is ambiguous
   --> $DIR/glob-conflict-cross-crate-3.rs:13:13
    |
 LL |     let _a: C = 1;
@@ -19,9 +19,9 @@ note: `C` could also refer to the type alias defined here
    |
 LL | pub use b::*;
    |         ^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: `C` is ambiguous
+error: `C` is ambiguous
   --> $DIR/glob-conflict-cross-crate-3.rs:13:13
    |
 LL |     let _a: C = 1;
@@ -43,10 +43,10 @@ LL | use a::*;
    |     ^^^^
    = help: consider adding an explicit import of `C` to disambiguate
 
-warning: 2 warnings emitted
+error: aborting due to 2 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `C` is ambiguous
+error: `C` is ambiguous
   --> $DIR/glob-conflict-cross-crate-3.rs:13:13
    |
 LL |     let _a: C = 1;
@@ -67,10 +67,10 @@ note: `C` could also refer to the type alias defined here
    |
 LL | pub use b::*;
    |         ^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
-warning: `C` is ambiguous
+error: `C` is ambiguous
   --> $DIR/glob-conflict-cross-crate-3.rs:13:13
    |
 LL |     let _a: C = 1;
@@ -91,5 +91,5 @@ note: `C` could also refer to the type alias imported here
 LL | use a::*;
    |     ^^^^
    = help: consider adding an explicit import of `C` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/issue-114682-2.rs
+++ b/tests/ui/imports/issue-114682-2.rs
@@ -1,12 +1,12 @@
 //@ aux-build: issue-114682-2-extern.rs
 // https://github.com/rust-lang/rust/pull/114682#issuecomment-1879998900
-//@ check-pass
+
 extern crate issue_114682_2_extern;
 
-use issue_114682_2_extern::max; //~ WARN `max` is ambiguous
+use issue_114682_2_extern::max; //~ ERROR `max` is ambiguous
                                 //~| WARN this was previously accepted
 
-type A = issue_114682_2_extern::max; //~ WARN `max` is ambiguous
+type A = issue_114682_2_extern::max; //~ ERROR `max` is ambiguous
                                      //~| WARN this was previously accepted
 
 fn main() {}

--- a/tests/ui/imports/issue-114682-2.stderr
+++ b/tests/ui/imports/issue-114682-2.stderr
@@ -1,4 +1,4 @@
-warning: `max` is ambiguous
+error: `max` is ambiguous
   --> $DIR/issue-114682-2.rs:6:28
    |
 LL | use issue_114682_2_extern::max;
@@ -19,9 +19,9 @@ note: `max` could also refer to the module defined here
    |
 LL | pub use self::d::*;
    |         ^^^^^^^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: `max` is ambiguous
+error: `max` is ambiguous
   --> $DIR/issue-114682-2.rs:9:33
    |
 LL | type A = issue_114682_2_extern::max;
@@ -43,10 +43,10 @@ note: `max` could also refer to the module defined here
 LL | pub use self::d::*;
    |         ^^^^^^^
 
-warning: 2 warnings emitted
+error: aborting due to 2 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `max` is ambiguous
+error: `max` is ambiguous
   --> $DIR/issue-114682-2.rs:6:28
    |
 LL | use issue_114682_2_extern::max;
@@ -67,10 +67,10 @@ note: `max` could also refer to the module defined here
    |
 LL | pub use self::d::*;
    |         ^^^^^^^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
-warning: `max` is ambiguous
+error: `max` is ambiguous
   --> $DIR/issue-114682-2.rs:9:33
    |
 LL | type A = issue_114682_2_extern::max;
@@ -91,5 +91,5 @@ note: `max` could also refer to the module defined here
    |
 LL | pub use self::d::*;
    |         ^^^^^^^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/issue-114682-4.rs
+++ b/tests/ui/imports/issue-114682-4.rs
@@ -6,7 +6,7 @@ extern crate issue_114682_4_extern;
 use issue_114682_4_extern::*;
 
 //~v ERROR type alias takes 1 generic argument but 2 generic arguments were supplied
-fn a() -> Result<i32, ()> { //~ WARN `Result` is ambiguous
+fn a() -> Result<i32, ()> { //~ ERROR `Result` is ambiguous
                             //~| WARN this was previously accepted
     Ok(1)
 }

--- a/tests/ui/imports/issue-114682-4.stderr
+++ b/tests/ui/imports/issue-114682-4.stderr
@@ -1,4 +1,4 @@
-warning: `Result` is ambiguous
+error: `Result` is ambiguous
   --> $DIR/issue-114682-4.rs:9:11
    |
 LL | fn a() -> Result<i32, ()> {
@@ -19,7 +19,7 @@ note: `Result` could also refer to the type alias defined here
    |
 LL | pub use b::*;
    |         ^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error[E0107]: type alias takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/issue-114682-4.rs:9:11
@@ -35,11 +35,11 @@ note: type alias defined here, with 1 generic parameter: `T`
 LL |     pub type Result<T> = std::result::Result<T, ()>;
    |              ^^^^^^ -
 
-error: aborting due to 1 previous error; 1 warning emitted
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0107`.
 Future incompatibility report: Future breakage diagnostic:
-warning: `Result` is ambiguous
+error: `Result` is ambiguous
   --> $DIR/issue-114682-4.rs:9:11
    |
 LL | fn a() -> Result<i32, ()> {
@@ -60,5 +60,5 @@ note: `Result` could also refer to the type alias defined here
    |
 LL | pub use b::*;
    |         ^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/issue-114682-5.rs
+++ b/tests/ui/imports/issue-114682-5.rs
@@ -9,7 +9,7 @@ extern crate issue_114682_5_extern_2;
 use issue_114682_5_extern_2::p::*;
 use issue_114682_5_extern_1::Url;
 //~^ ERROR `issue_114682_5_extern_1` is ambiguous
-//~| WARN `issue_114682_5_extern_1` is ambiguous
+//~| ERROR `issue_114682_5_extern_1` is ambiguous
 //~| ERROR unresolved import `issue_114682_5_extern_1::Url`
 //~| WARN this was previously accepted
 

--- a/tests/ui/imports/issue-114682-5.stderr
+++ b/tests/ui/imports/issue-114682-5.stderr
@@ -26,7 +26,7 @@ LL | use issue_114682_5_extern_2::p::*;
    = help: consider adding an explicit import of `issue_114682_5_extern_1` to disambiguate
    = help: or use `crate::issue_114682_5_extern_1` to refer to this module unambiguously
 
-warning: `issue_114682_5_extern_1` is ambiguous
+error: `issue_114682_5_extern_1` is ambiguous
   --> $DIR/issue-114682-5.rs:10:5
    |
 LL | use issue_114682_5_extern_1::Url;
@@ -48,14 +48,14 @@ note: `issue_114682_5_extern_1` could also refer to the crate defined here
 LL |     pub use crate::*;
    |             ^^^^^
    = help: use `::issue_114682_5_extern_1` to refer to this crate unambiguously
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0432, E0659.
 For more information about an error, try `rustc --explain E0432`.
 Future incompatibility report: Future breakage diagnostic:
-warning: `issue_114682_5_extern_1` is ambiguous
+error: `issue_114682_5_extern_1` is ambiguous
   --> $DIR/issue-114682-5.rs:10:5
    |
 LL | use issue_114682_5_extern_1::Url;
@@ -77,5 +77,5 @@ note: `issue_114682_5_extern_1` could also refer to the crate defined here
 LL |     pub use crate::*;
    |             ^^^^^
    = help: use `::issue_114682_5_extern_1` to refer to this crate unambiguously
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/issue-114682-6.rs
+++ b/tests/ui/imports/issue-114682-6.rs
@@ -1,12 +1,12 @@
 //@ aux-build: issue-114682-6-extern.rs
 // https://github.com/rust-lang/rust/pull/114682#issuecomment-1880755441
-//@ check-pass
+
 extern crate issue_114682_6_extern;
 
 use issue_114682_6_extern::*;
 
 fn main() {
-    let log = 2; //~ WARN `log` is ambiguous
+    let log = 2; //~ ERROR `log` is ambiguous
                  //~| WARN this was previously accepted
     let _ = log;
 }

--- a/tests/ui/imports/issue-114682-6.stderr
+++ b/tests/ui/imports/issue-114682-6.stderr
@@ -1,4 +1,4 @@
-warning: `log` is ambiguous
+error: `log` is ambiguous
   --> $DIR/issue-114682-6.rs:9:9
    |
 LL |     let log = 2;
@@ -19,12 +19,12 @@ note: `log` could also refer to the function defined here
    |
 LL | pub use self::b::*;
    |         ^^^^^^^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `log` is ambiguous
+error: `log` is ambiguous
   --> $DIR/issue-114682-6.rs:9:9
    |
 LL |     let log = 2;
@@ -45,5 +45,5 @@ note: `log` could also refer to the function defined here
    |
 LL | pub use self::b::*;
    |         ^^^^^^^
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/overwrite-different-ambig-2.rs
+++ b/tests/ui/imports/overwrite-different-ambig-2.rs
@@ -1,5 +1,3 @@
-//@ check-pass
-
 mod m1 {
     mod inner {
         pub struct S {}
@@ -21,6 +19,6 @@ use m1::*;
 use m2::*;
 
 fn main() {
-    let _: m1::S = S {}; //~ WARN `S` is ambiguous
+    let _: m1::S = S {}; //~ ERROR `S` is ambiguous
                          //~| WARN this was previously accepted
 }

--- a/tests/ui/imports/overwrite-different-ambig-2.stderr
+++ b/tests/ui/imports/overwrite-different-ambig-2.stderr
@@ -1,5 +1,5 @@
-warning: `S` is ambiguous
-  --> $DIR/overwrite-different-ambig-2.rs:24:20
+error: `S` is ambiguous
+  --> $DIR/overwrite-different-ambig-2.rs:22:20
    |
 LL |     let _: m1::S = S {};
    |                    ^ ambiguous name
@@ -8,24 +8,24 @@ LL |     let _: m1::S = S {};
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `S` could refer to the struct imported here
-  --> $DIR/overwrite-different-ambig-2.rs:20:5
+  --> $DIR/overwrite-different-ambig-2.rs:18:5
    |
 LL | use m1::*;
    |     ^^^^^
    = help: consider adding an explicit import of `S` to disambiguate
 note: `S` could also refer to the struct imported here
-  --> $DIR/overwrite-different-ambig-2.rs:21:5
+  --> $DIR/overwrite-different-ambig-2.rs:19:5
    |
 LL | use m2::*;
    |     ^^^^^
    = help: consider adding an explicit import of `S` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: `S` is ambiguous
-  --> $DIR/overwrite-different-ambig-2.rs:24:20
+error: `S` is ambiguous
+  --> $DIR/overwrite-different-ambig-2.rs:22:20
    |
 LL |     let _: m1::S = S {};
    |                    ^ ambiguous name
@@ -34,16 +34,16 @@ LL |     let _: m1::S = S {};
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `S` could refer to the struct imported here
-  --> $DIR/overwrite-different-ambig-2.rs:20:5
+  --> $DIR/overwrite-different-ambig-2.rs:18:5
    |
 LL | use m1::*;
    |     ^^^^^
    = help: consider adding an explicit import of `S` to disambiguate
 note: `S` could also refer to the struct imported here
-  --> $DIR/overwrite-different-ambig-2.rs:21:5
+  --> $DIR/overwrite-different-ambig-2.rs:19:5
    |
 LL | use m2::*;
    |     ^^^^^
    = help: consider adding an explicit import of `S` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/unresolved-seg-after-ambiguous.rs
+++ b/tests/ui/imports/unresolved-seg-after-ambiguous.rs
@@ -18,7 +18,7 @@ mod a {
 
 use self::a::E::in_exist;
 //~^ ERROR: unresolved import `self::a::E`
-//~| WARN: `E` is ambiguous
+//~| ERROR: `E` is ambiguous
 //~| WARNING: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 fn main() {}

--- a/tests/ui/imports/unresolved-seg-after-ambiguous.stderr
+++ b/tests/ui/imports/unresolved-seg-after-ambiguous.stderr
@@ -4,7 +4,7 @@ error[E0432]: unresolved import `self::a::E`
 LL | use self::a::E::in_exist;
    |              ^ `E` is a struct, not a module
 
-warning: `E` is ambiguous
+error: `E` is ambiguous
   --> $DIR/unresolved-seg-after-ambiguous.rs:19:14
    |
 LL | use self::a::E::in_exist;
@@ -25,13 +25,13 @@ note: `E` could also refer to the struct imported here
 LL |         pub use self::d::*;
    |                 ^^^^^^^^^^
    = help: consider adding an explicit import of `E` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
-error: aborting due to 1 previous error; 1 warning emitted
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0432`.
 Future incompatibility report: Future breakage diagnostic:
-warning: `E` is ambiguous
+error: `E` is ambiguous
   --> $DIR/unresolved-seg-after-ambiguous.rs:19:14
    |
 LL | use self::a::E::in_exist;
@@ -52,5 +52,5 @@ note: `E` could also refer to the struct imported here
 LL |         pub use self::d::*;
    |                 ^^^^^^^^^^
    = help: consider adding an explicit import of `E` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#153130 (std: move `getpid` to `sys::process`)
 - rust-lang/rust#152549 (Revert "resolve: Downgrade `ambiguous_glob_imports` to warn-by-default")
 - rust-lang/rust#153231 (diags: Pass `DiagArgMap` instead of `FluentArgs` into `format_diag_message`)
 - rust-lang/rust#153246 (Fix compile error in std::fs impl on VEXos target)
 - rust-lang/rust#153255 (Recover feature lang_items for emscripten)
 - rust-lang/rust#153257 (update my mailmap)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=153130,152549,153231,153246,153255,153257)
<!-- homu-ignore:end -->

