### PR TITLE
Remove `cycle_fatal` query modifier

### DIFF
--- a/compiler/rustc_macros/src/query.rs
+++ b/compiler/rustc_macros/src/query.rs
@@ -144,7 +144,6 @@ struct QueryModifiers {
     arena_cache: Option<Ident>,
     cache_on_disk_if: Option<CacheOnDiskIf>,
     cycle_delay_bug: Option<Ident>,
-    cycle_fatal: Option<Ident>,
     cycle_stash: Option<Ident>,
     depth_limit: Option<Ident>,
     desc: Desc,
@@ -160,7 +159,6 @@ fn parse_query_modifiers(input: ParseStream<'_>) -> Result<QueryModifiers> {
     let mut arena_cache = None;
     let mut cache_on_disk_if = None;
     let mut desc = None;
-    let mut cycle_fatal = None;
     let mut cycle_delay_bug = None;
     let mut cycle_stash = None;
     let mut no_hash = None;
@@ -197,8 +195,6 @@ fn parse_query_modifiers(input: ParseStream<'_>) -> Result<QueryModifiers> {
             try_insert!(cache_on_disk_if = CacheOnDiskIf { modifier, block });
         } else if modifier == "arena_cache" {
             try_insert!(arena_cache = modifier);
-        } else if modifier == "cycle_fatal" {
-            try_insert!(cycle_fatal = modifier);
         } else if modifier == "cycle_delay_bug" {
             try_insert!(cycle_delay_bug = modifier);
         } else if modifier == "cycle_stash" {
@@ -228,7 +224,6 @@ fn parse_query_modifiers(input: ParseStream<'_>) -> Result<QueryModifiers> {
         arena_cache,
         cache_on_disk_if,
         desc,
-        cycle_fatal,
         cycle_delay_bug,
         cycle_stash,
         no_hash,
@@ -248,7 +243,6 @@ fn make_modifiers_stream(query: &Query, modifiers: &QueryModifiers) -> proc_macr
         arena_cache,
         cache_on_disk_if,
         cycle_delay_bug,
-        cycle_fatal,
         cycle_stash,
         depth_limit,
         desc: _,
@@ -266,8 +260,6 @@ fn make_modifiers_stream(query: &Query, modifiers: &QueryModifiers) -> proc_macr
 
     let cycle_error_handling = if cycle_delay_bug.is_some() {
         quote! { DelayBug }
-    } else if cycle_fatal.is_some() {
-        quote! { Fatal }
     } else if cycle_stash.is_some() {
         quote! { Stash }
     } else {
@@ -407,7 +399,6 @@ fn add_to_analyzer_stream(query: &Query, analyzer_stream: &mut proc_macro2::Toke
 
     doc_link!(
         arena_cache,
-        cycle_fatal,
         cycle_delay_bug,
         cycle_stash,
         no_hash,

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -32,7 +32,6 @@
 //! - `arena_cache`: Use an arena for in-memory caching of the query result.
 //! - `cache_on_disk_if { ... }`: Cache the query result to disk if the provided block evaluates to
 //!   true. The query key identifier is available for use within the block, as is `tcx`.
-//! - `cycle_fatal`: If a dependency cycle is detected, abort compilation with a fatal error.
 //! - `cycle_delay_bug`: If a dependency cycle is detected, emit a delayed bug instead of aborting immediately.
 //! - `cycle_stash`: If a dependency cycle is detected, stash the error for later handling.
 //! - `no_hash`: Do not hash the query result for incremental compilation; just mark as dirty if recomputed.
@@ -149,11 +148,11 @@ use crate::{dep_graph, mir, thir};
 // which memoizes and does dep-graph tracking, wrapping around the actual
 // `Providers` that the driver creates (using several `rustc_*` crates).
 //
-// The result type of each query must implement `Clone`, and additionally
-// `ty::query::from_cycle_error::FromCycleError`, which produces an appropriate
+// The result type of each query must implement `Clone`. Additionally
+// `ty::query::from_cycle_error::FromCycleError` can be implemented which produces an appropriate
 // placeholder (error) value if the query resulted in a query cycle.
-// Queries marked with `cycle_fatal` do not need the latter implementation,
-// as they will raise a fatal error on query cycles instead.
+// Queries without a `FromCycleError` implementation will raise a fatal error on query
+// cycles instead.
 rustc_queries! {
     /// Caches the expansion of a derive proc macro, e.g. `#[derive(Serialize)]`.
     /// The key is:
@@ -587,7 +586,6 @@ rustc_queries! {
     }
 
     query is_panic_runtime(_: CrateNum) -> bool {
-        cycle_fatal
         desc { "checking if the crate is_panic_runtime" }
         separate_provide_extern
     }
@@ -1318,7 +1316,6 @@ rustc_queries! {
     /// Return the set of (transitive) callees that may result in a recursive call to `key`,
     /// if we were able to walk all callees.
     query mir_callgraph_cyclic(key: LocalDefId) -> &'tcx Option<UnordSet<LocalDefId>> {
-        cycle_fatal
         arena_cache
         desc {
             "computing (transitive) callees of `{}` that may recurse",
@@ -1329,7 +1326,6 @@ rustc_queries! {
 
     /// Obtain all the calls into other local functions
     query mir_inliner_callees(key: ty::InstanceKind<'tcx>) -> &'tcx [(DefId, GenericArgsRef<'tcx>)] {
-        cycle_fatal
         desc {
             "computing all local function calls in `{}`",
             tcx.def_path_str(key.def_id()),
@@ -1824,31 +1820,26 @@ rustc_queries! {
     }
 
     query is_compiler_builtins(_: CrateNum) -> bool {
-        cycle_fatal
         desc { "checking if the crate is_compiler_builtins" }
         separate_provide_extern
     }
     query has_global_allocator(_: CrateNum) -> bool {
         // This query depends on untracked global state in CStore
         eval_always
-        cycle_fatal
         desc { "checking if the crate has_global_allocator" }
         separate_provide_extern
     }
     query has_alloc_error_handler(_: CrateNum) -> bool {
         // This query depends on untracked global state in CStore
         eval_always
-        cycle_fatal
         desc { "checking if the crate has_alloc_error_handler" }
         separate_provide_extern
     }
     query has_panic_handler(_: CrateNum) -> bool {
-        cycle_fatal
         desc { "checking if the crate has_panic_handler" }
         separate_provide_extern
     }
     query is_profiler_runtime(_: CrateNum) -> bool {
-        cycle_fatal
         desc { "checking if a crate is `#![profiler_runtime]`" }
         separate_provide_extern
     }
@@ -1857,22 +1848,18 @@ rustc_queries! {
         cache_on_disk_if { true }
     }
     query required_panic_strategy(_: CrateNum) -> Option<PanicStrategy> {
-        cycle_fatal
         desc { "getting a crate's required panic strategy" }
         separate_provide_extern
     }
     query panic_in_drop_strategy(_: CrateNum) -> PanicStrategy {
-        cycle_fatal
         desc { "getting a crate's configured panic-in-drop strategy" }
         separate_provide_extern
     }
     query is_no_builtins(_: CrateNum) -> bool {
-        cycle_fatal
         desc { "getting whether a crate has `#![no_builtins]`" }
         separate_provide_extern
     }
     query symbol_mangling_version(_: CrateNum) -> SymbolManglingVersion {
-        cycle_fatal
         desc { "getting a crate's symbol mangling version" }
         separate_provide_extern
     }

--- a/compiler/rustc_middle/src/query/modifiers.rs
+++ b/compiler/rustc_middle/src/query/modifiers.rs
@@ -28,11 +28,6 @@ pub(crate) struct cache_on_disk_if;
 /// A cycle error results in a delay_bug call
 pub(crate) struct cycle_delay_bug;
 
-/// # `cycle_fatal` query modifier
-///
-/// A cycle error for this query aborting the compilation with a fatal error.
-pub(crate) struct cycle_fatal;
-
 /// # `cycle_stash` query modifier
 ///
 /// A cycle error results in a stashed cycle error that can be unstashed and canceled later

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -57,7 +57,6 @@ pub enum ActiveKeyStatus<'tcx> {
 #[derive(Copy, Clone)]
 pub enum CycleErrorHandling {
     Error,
-    Fatal,
     DelayBug,
     Stash,
 }

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -131,10 +131,6 @@ fn mk_cycle<'tcx, C: QueryCache>(
             let guar = error.emit();
             query.value_from_cycle_error(tcx, cycle_error, guar)
         }
-        CycleErrorHandling::Fatal => {
-            let guar = error.emit();
-            guar.raise_fatal();
-        }
         CycleErrorHandling::DelayBug => {
             let guar = error.delay_as_bug();
             query.value_from_cycle_error(tcx, cycle_error, guar)


### PR DESCRIPTION
This removes the `cycle_fatal` query modifier as it has no effect on its current users.

The default `CycleErrorHandling::Error` mode does the same as `cycle_fatal` when the default impl of `FromCycleError` is used. The return types of queries using `cycle_fatal` however have no specialized `FromCycleError` impl.