### PR TITLE
Add regression test for `doc(fake_variadic)` on reexports

### DIFF
--- a/tests/rustdoc-html/primitive/auxiliary/reexport-fake_variadic.rs
+++ b/tests/rustdoc-html/primitive/auxiliary/reexport-fake_variadic.rs
@@ -1,0 +1,6 @@
+#![feature(rustdoc_internals)]
+
+pub trait Foo {}
+
+#[doc(fake_variadic)]
+impl<T> Foo for (T,) {}

--- a/tests/rustdoc-html/primitive/reexport-fake_variadic.rs
+++ b/tests/rustdoc-html/primitive/reexport-fake_variadic.rs
@@ -1,0 +1,12 @@
+// This test ensures that the `doc(fake_variadic)` attribute is correctly handled
+// through reexports.
+
+//@ aux-build:reexport-fake_variadic.rs
+
+#![crate_name = "foo"]
+
+extern crate reexport_fake_variadic as dep;
+
+//@ has foo/trait.Foo.html
+//@ has - '//section[@id="impl-Foo-for-(T,)"]/h3' 'impl<T> Foo for (T₁, T₂, …, Tₙ)'
+pub use dep::Foo;


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/rust/pull/153136. Out of the four doc attributes remaining to be tested (`fake_variadic`, `keyword`, `attribute` and `notable_trait`), only `fake_variadic` could have been impacted by reexports:

* `attribute` and `keyword` are not supposed to be reexported (they're supposed to be used on private modules)
* `notable_trait` is applied to a trait, so whether it's reexported or not, it still works.

r? @lolbinarycat 