### PR TITLE
improve the current debugger autodetection functionality.

### DIFF
--- a/src/bootstrap/src/core/debuggers/cdb.rs
+++ b/src/bootstrap/src/core/debuggers/cdb.rs
@@ -14,28 +14,42 @@ pub(crate) fn discover_cdb(target: TargetSelection) -> Option<Cdb> {
         return None;
     }
 
-    let pf86 =
-        PathBuf::from(env::var_os("ProgramFiles(x86)").or_else(|| env::var_os("ProgramFiles"))?);
-    let cdb_arch = if cfg!(target_arch = "x86") {
-        "x86"
-    } else if cfg!(target_arch = "x86_64") {
-        "x64"
-    } else if cfg!(target_arch = "aarch64") {
-        "arm64"
-    } else if cfg!(target_arch = "arm") {
-        "arm"
-    } else {
-        return None; // No compatible CDB.exe in the Windows 10 SDK
-    };
-
-    let mut path = pf86;
-    path.push(r"Windows Kits\10\Debuggers"); // We could check 8.1 etc. too?
-    path.push(cdb_arch);
-    path.push(r"cdb.exe");
-
-    if !path.exists() {
-        return None;
+    if let Some(path) = env::var_os("RUSTC_CDB") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(Cdb { cdb: path });
+        }
     }
 
-    Some(Cdb { cdb: path })
+    let cdb_arch = if target.starts_with("x86_64") {
+        "x64"
+    } else if target.starts_with("x86") || target.starts_with("i686") || target.starts_with("i586")
+    {
+        "x86"
+    } else if target.starts_with("aarch64") {
+        "arm64"
+    } else if target.starts_with("arm") {
+        "arm"
+    } else {
+        return None;
+    };
+
+    let program_files = [env::var_os("ProgramFiles(x86)"), env::var_os("ProgramFiles")];
+
+    let sdk_versions = ["11", "10", "8.1"];
+
+    for base in program_files.iter().flatten() {
+        for version in &sdk_versions {
+            let mut path = PathBuf::from(base);
+            path.push(format!(r"Windows Kits\{}\Debuggers", version));
+            path.push(cdb_arch);
+            path.push("cdb.exe");
+
+            if path.exists() {
+                return Some(Cdb { cdb: path });
+            }
+        }
+    }
+
+    None
 }

--- a/src/bootstrap/src/core/debuggers/gdb.rs
+++ b/src/bootstrap/src/core/debuggers/gdb.rs
@@ -15,10 +15,16 @@ pub(crate) fn discover_gdb<'a>(
 ) -> Option<Gdb<'a>> {
     // If there's an explicitly-configured gdb, use that.
     if let Some(gdb) = builder.config.gdb.as_deref() {
-        // FIXME(Zalathar): Consider returning None if gdb is an empty string,
-        // as a way to explicitly disable ambient gdb discovery.
+        if gdb.as_os_str().is_empty() {
+            return None;
+        }
+
         let gdb = Cow::Borrowed(gdb);
-        return Some(Gdb { gdb });
+        if verify_gdb(builder, &gdb) {
+            return Some(Gdb { gdb });
+        } else {
+            return None;
+        }
     }
 
     // Otherwise, fall back to whatever gdb is sitting around in PATH.
@@ -31,12 +37,12 @@ pub(crate) fn discover_gdb<'a>(
         None => Path::new("gdb").into(),
     };
 
-    // Check whether an ambient gdb exists, by running `gdb --version`.
-    let output = {
-        let mut gdb_command = BootstrapCommand::new(gdb.as_ref()).allow_failure();
-        gdb_command.arg("--version");
-        gdb_command.run_capture(builder)
-    };
+    if verify_gdb(builder, &gdb) { Some(Gdb { gdb }) } else { None }
+}
 
-    if output.is_success() { Some(Gdb { gdb }) } else { None }
+// Check whether an ambient gdb exists, by running `gdb --version`.
+fn verify_gdb(builder: &Builder<'_>, gdb: &Path) -> bool {
+    let mut cmd = BootstrapCommand::new(gdb).allow_failure();
+    cmd.arg("--version");
+    cmd.run_capture(builder).is_success()
 }


### PR DESCRIPTION
CDB:
- Add support for overriding via `RUSTC_CDB`.
- Derive architecture from the target triple instead of `cfg!(target_arch)`.
- Search multiple Windows SDK versions (11, 10, 8.1).
- Probe both `ProgramFiles(x86)` and `ProgramFiles`.

GDB:
- Treat empty `config.gdb` as an explicit opt-out.
- Extract validation logic into a `verify_gdb` helper.

Discussion:

- [#gsoc > Idea: Improve Rust compiler debuginfo test suite](https://rust-lang.zulipchat.com/#narrow/channel/421156-gsoc/topic/Idea.3A.20Improve.20Rust.20compiler.20debuginfo.20test.20suite/with/576682005)