### PR TITLE
library: std: process: skip tests on Hermit

### DIFF
--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -156,6 +156,7 @@
         target_env = "sgx",
         target_os = "xous",
         target_os = "trusty",
+        target_os = "hermit",
     ))
 ))]
 mod tests;


### PR DESCRIPTION
Hermit does not yet support spawning processes.