### PR TITLE
library: std: fs: skip tests on Hermit

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -37,6 +37,7 @@
         target_env = "sgx",
         target_os = "xous",
         target_os = "trusty",
+        target_os = "hermit",
     ))
 ))]
 mod tests;


### PR DESCRIPTION
The tests make use of symlinks, which are not currently supported on Hermit.