### PR TITLE
update panicking() docs for panic=abort

### DIFF
--- a/library/std/src/thread/functions.rs
+++ b/library/std/src/thread/functions.rs
@@ -168,7 +168,11 @@ pub fn yield_now() {
     imp::yield_now()
 }
 
-/// Determines whether the current thread is unwinding because of panic.
+/// Determines whether the current thread is panicking.
+///
+/// This returns `true` both when the thread is unwinding due to a panic,
+/// or executing a panic hook. Note that the latter case will still happen
+/// when `panic=abort` is set.
 ///
 /// A common use of this feature is to poison shared resources when writing
 /// unsafe code, by checking `panicking` when the `drop` is called.
@@ -309,14 +313,14 @@ pub fn sleep(dur: Duration) {
 ///
 /// |  Platform |               System call                                            |
 /// |-----------|----------------------------------------------------------------------|
-/// | Linux     | [clock_nanosleep] (Monotonic clock)                                  |
-/// | BSD except OpenBSD | [clock_nanosleep] (Monotonic Clock)]                        |
-/// | Android   | [clock_nanosleep] (Monotonic Clock)]                                 |
-/// | Solaris   | [clock_nanosleep] (Monotonic Clock)]                                 |
-/// | Illumos   | [clock_nanosleep] (Monotonic Clock)]                                 |
-/// | Dragonfly | [clock_nanosleep] (Monotonic Clock)]                                 |
-/// | Hurd      | [clock_nanosleep] (Monotonic Clock)]                                 |
-/// | Vxworks   | [clock_nanosleep] (Monotonic Clock)]                                 |
+/// | Linux     | [clock_nanosleep] (Monotonic Clock)                                  |
+/// | BSD except OpenBSD | [clock_nanosleep] (Monotonic Clock)                         |
+/// | Android   | [clock_nanosleep] (Monotonic Clock)                                  |
+/// | Solaris   | [clock_nanosleep] (Monotonic Clock)                                  |
+/// | Illumos   | [clock_nanosleep] (Monotonic Clock)                                  |
+/// | Dragonfly | [clock_nanosleep] (Monotonic Clock)                                  |
+/// | Hurd      | [clock_nanosleep] (Monotonic Clock)                                  |
+/// | Vxworks   | [clock_nanosleep] (Monotonic Clock)                                  |
 /// | Apple     | `mach_wait_until`                                                    |
 /// | Other     | `sleep_until` uses [`sleep`] and does not issue a syscall itself     |
 ///


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
fixes rust-lang/rust#151458

The documentation for `std::thread::panicking()` has not been changed since v1.0, even though panic hooks were added in v1.10.
Current documentation is misleading for `panic=abort`

`panicking()` can return `true` in 2 different cases:
1. Thread unwinds due to panic
2. Panic hook is executing with `panic=abort`

r? @SpriteOvO 