### PR TITLE
Update the name of the Hermit operating system

### DIFF
--- a/library/std/src/os/hermit/ffi.rs
+++ b/library/std/src/os/hermit/ffi.rs
@@ -1,4 +1,4 @@
-//! HermitCore-specific extension to the primitives in the `std::ffi` module
+//! Hermit-specific extension to the primitives in the `std::ffi` module
 //!
 //! # Examples
 //!

--- a/library/std/src/sys/pal/hermit/mod.rs
+++ b/library/std/src/sys/pal/hermit/mod.rs
@@ -1,7 +1,7 @@
-//! System bindings for HermitCore
+//! System bindings for Hermit
 //!
 //! This module contains the facade (aka platform-specific) implementations of
-//! OS level functionality for HermitCore.
+//! OS level functionality for Hermit.
 //!
 //! This is all super highly experimental and not actually intended for
 //! wide/production use yet, it's still all in the experimental category. This
@@ -30,7 +30,7 @@ pub fn unsupported<T>() -> io::Result<T> {
 }
 
 pub fn unsupported_err() -> io::Error {
-    io::const_error!(io::ErrorKind::Unsupported, "operation not supported on HermitCore yet")
+    io::const_error!(io::ErrorKind::Unsupported, "operation not supported on Hermit yet")
 }
 
 pub fn abort_internal() -> ! {

--- a/src/librustdoc/clean/cfg.rs
+++ b/src/librustdoc/clean/cfg.rs
@@ -429,7 +429,7 @@ impl fmt::Display for Display<'_> {
                         "freebsd" => "FreeBSD",
                         "fuchsia" => "Fuchsia",
                         "haiku" => "Haiku",
-                        "hermit" => "HermitCore",
+                        "hermit" => "Hermit",
                         "illumos" => "illumos",
                         "ios" => "iOS",
                         "l4re" => "L4Re",


### PR DESCRIPTION
The HermitCore name was dropped a while ago, the project is now simply called "Hermit". See for example [the website](https://hermit-os.org/).

cc @stlankes @mkroening 