### PR TITLE
Do not ping kobzol on rustc-dev-guide changes

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1371,7 +1371,7 @@ cc = ["@ehuss"]
 
 [mentions."src/doc/rustc-dev-guide"]
 message = "The rustc-dev-guide subtree was changed. If this PR *only* touches the dev guide consider submitting a PR directly to [rust-lang/rustc-dev-guide](https://github.com/rust-lang/rustc-dev-guide/pulls) otherwise thank you for updating the dev guide with your changes."
-cc = ["@BoxyUwU", "@jieyouxu", "@kobzol", "@tshepang"]
+cc = ["@BoxyUwU", "@jieyouxu", "@tshepang"]
 
 [mentions."compiler/rustc_passes/src/check_attr.rs"]
 cc = ["@jdonszelmann", "@JonathanBrouwer"]


### PR DESCRIPTION
I don't really react to those pings anyway.
