### PR TITLE
Adapt codegen test to accept operand bundles

### DIFF
--- a/tests/codegen-llvm/issues/issue-37945.rs
+++ b/tests/codegen-llvm/issues/issue-37945.rs
@@ -1,5 +1,8 @@
 //@ compile-flags: -Copt-level=3 -Zmerge-functions=disabled
 //@ ignore-32bit LLVM has a bug with them
+//@ revisions: new old
+//@ [old] max-llvm-major-version: 22
+//@ [new] min-llvm-version: 23
 
 // Check that LLVM understands that `Iter` pointer is not null. Issue #37945.
 
@@ -11,8 +14,9 @@ use std::slice::Iter;
 pub fn is_empty_1(xs: Iter<f32>) -> bool {
     // CHECK-LABEL: @is_empty_1(
     // CHECK-NEXT:  start:
-    // CHECK-NEXT:    [[A:%.*]] = icmp ne ptr {{%xs.0|%xs.1}}, null
-    // CHECK-NEXT:    tail call void @llvm.assume(i1 [[A]])
+    // old-NEXT:    [[A:%.*]] = icmp ne ptr {{%xs.0|%xs.1}}, null
+    // old-NEXT:    tail call void @llvm.assume(i1 [[A]])
+    // new-NEXT:    call void @llvm.assume(i1 true) [ "nonnull"(ptr {{%xs.0|%xs.1}}) ]
     // The order between %xs.0 and %xs.1 on the next line doesn't matter
     // and different LLVM versions produce different order.
     // CHECK-NEXT:    [[B:%.*]] = icmp eq ptr {{%xs.0, %xs.1|%xs.1, %xs.0}}
@@ -24,8 +28,9 @@ pub fn is_empty_1(xs: Iter<f32>) -> bool {
 pub fn is_empty_2(xs: Iter<f32>) -> bool {
     // CHECK-LABEL: @is_empty_2
     // CHECK-NEXT:  start:
-    // CHECK-NEXT:    [[C:%.*]] = icmp ne ptr {{%xs.0|%xs.1}}, null
-    // CHECK-NEXT:    tail call void @llvm.assume(i1 [[C]])
+    // old-NEXT:    [[C:%.*]] = icmp ne ptr {{%xs.0|%xs.1}}, null
+    // old-NEXT:    tail call void @llvm.assume(i1 [[C]])
+    // new-NEXT:    call void @llvm.assume(i1 true) [ "nonnull"(ptr {{%xs.0|%xs.1}}) ]
     // The order between %xs.0 and %xs.1 on the next line doesn't matter
     // and different LLVM versions produce different order.
     // CHECK-NEXT:    [[D:%.*]] = icmp eq ptr {{%xs.0, %xs.1|%xs.1, %xs.0}}


### PR DESCRIPTION
The updated test current fails when rustc is built with HEAD LLVM: https://buildkite.com/llvm-project/rust-llvm-integrate-prototype/builds/44013/steps/canvas?sid=019cafec-3cca-44b2-aa9f-b41c0a940e8b

Likely as a result of https://github.com/llvm/llvm-project/pull/169923

Since the new codegen merges two lines into one, I couldn't figure out a way to make the test work on both LLVM versions without introducing revisions. (Though I could instead make the test run on only LLVM 23+).

@rustbot label llvm-main