### PR TITLE
[beta] prepare Rust 1.95.0-beta

### DIFF
--- a/compiler/rustc_feature/src/accepted.rs
+++ b/compiler/rustc_feature/src/accepted.rs
@@ -103,7 +103,7 @@ declare_features! (
     /// Enables `#[cfg(panic = "...")]` config key.
     (accepted, cfg_panic, "1.60.0", Some(77443)),
     /// Provides a native way to easily manage multiple conditional flags without having to rewrite each clause multiple times.
-    (accepted, cfg_select, "CURRENT_RUSTC_VERSION", Some(115585)),
+    (accepted, cfg_select, "1.95.0", Some(115585)),
     /// Allows `cfg(target_abi = "...")`.
     (accepted, cfg_target_abi, "1.78.0", Some(80970)),
     /// Allows `cfg(target_feature = "...")`.
@@ -243,7 +243,7 @@ declare_features! (
     /// Allows the use of `if let` expressions.
     (accepted, if_let, "1.0.0", None),
     /// Allows `if let` guard in match arms.
-    (accepted, if_let_guard, "CURRENT_RUSTC_VERSION", Some(51114)),
+    (accepted, if_let_guard, "1.95.0", Some(51114)),
     /// Rescoping temporaries in `if let` to align with Rust 2024.
     (accepted, if_let_rescope, "1.84.0", Some(124085)),
     /// Allows top level or-patterns (`p | q`) in `if let` and `while let`.

--- a/compiler/rustc_feature/src/removed.rs
+++ b/compiler/rustc_feature/src/removed.rs
@@ -103,7 +103,7 @@ declare_features! (
     (removed, default_type_parameter_fallback, "1.82.0", Some(27336),
      Some("never properly implemented; requires significant design work"), 127655),
     /// Allows using `#[deprecated_safe]` to deprecate the safeness of a function or trait
-    (removed, deprecated_safe, "CURRENT_RUSTC_VERSION", Some(94978), Some("never properly implemented, in the way of attribute refactor"), 152554),
+    (removed, deprecated_safe, "1.95.0", Some(94978), Some("never properly implemented, in the way of attribute refactor"), 152554),
     /// Allows deriving traits as per `SmartPointer` specification
     (removed, derive_smart_pointer, "1.84.0", Some(123430), Some("replaced by `CoercePointee`"), 131284),
     /// Tells rustdoc to automatically generate `#[doc(cfg(...))]`.
@@ -174,7 +174,7 @@ declare_features! (
      Some("removed due to implementation concerns as it requires significant refactorings"), 138492),
     /// A temporary feature gate used to enable parser extensions needed
     /// to bootstrap fix for #5723.
-    (removed, issue_5723_bootstrap, "CURRENT_RUSTC_VERSION", None, None),
+    (removed, issue_5723_bootstrap, "1.95.0", None, None),
     /// Lazily evaluate constants. This allows constants to depend on type parameters.
     (removed, lazy_normalization_consts, "1.56.0", Some(72219), Some("superseded by `generic_const_exprs`"), 88369),
     /// Changes `impl Trait` to capture all lifetimes in scope.

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -368,7 +368,7 @@ declare_features! (
     /// Allows `async` trait bound modifier.
     (unstable, async_trait_bounds, "1.85.0", Some(62290)),
     /// Target features on avr.
-    (unstable, avr_target_feature, "CURRENT_RUSTC_VERSION", Some(146889)),
+    (unstable, avr_target_feature, "1.95.0", Some(146889)),
     /// Allows using Intel AVX10 target features and intrinsics
     (unstable, avx10_target_feature, "1.88.0", Some(138843)),
     /// Target features on bpf.
@@ -411,9 +411,9 @@ declare_features! (
     /// Allows `async {}` expressions in const contexts.
     (unstable, const_async_blocks, "1.53.0", Some(85368)),
     /// Allows `const { ... }` as a shorthand for `const _: () = const { ... };` for module items.
-    (unstable, const_block_items, "CURRENT_RUSTC_VERSION", Some(149226)),
+    (unstable, const_block_items, "1.95.0", Some(149226)),
     /// Allows defining and calling c-variadic functions in const contexts.
-    (unstable, const_c_variadic, "CURRENT_RUSTC_VERSION", Some(151787)),
+    (unstable, const_c_variadic, "1.95.0", Some(151787)),
     /// Allows `const || {}` closures in const contexts.
     (incomplete, const_closures, "1.68.0", Some(106003)),
     /// Allows using `[const] Destruct` bounds and calling drop impls in const contexts.
@@ -487,7 +487,7 @@ declare_features! (
     /// Allows the use of `#[ffi_pure]` on foreign functions.
     (unstable, ffi_pure, "1.45.0", Some(58329)),
     /// Allows marking trait functions as `final` to prevent overriding impls
-    (unstable, final_associated_functions, "CURRENT_RUSTC_VERSION", Some(131179)),
+    (unstable, final_associated_functions, "1.95.0", Some(131179)),
     /// Controlling the behavior of fmt::Debug
     (unstable, fmt_debug, "1.82.0", Some(129709)),
     /// Allows using `#[align(...)]` on function items
@@ -554,7 +554,7 @@ declare_features! (
     /// Allows `#[marker]` on certain traits allowing overlapping implementations.
     (unstable, marker_trait_attr, "1.30.0", Some(29864)),
     /// Enable mgca `type const` syntax before expansion.
-    (incomplete, mgca_type_const_syntax, "CURRENT_RUSTC_VERSION", Some(132980)),
+    (incomplete, mgca_type_const_syntax, "1.95.0", Some(132980)),
     /// Enables the generic const args MVP (only bare paths, not arbitrary computation).
     (incomplete, min_generic_const_args, "1.84.0", Some(132980)),
     /// A minimal, sound subset of specialization intended to be used by the
@@ -600,7 +600,7 @@ declare_features! (
     /// Allows using fields with slice type in offset_of!
     (unstable, offset_of_slice, "1.81.0", Some(126151)),
     /// Allows using generics in more complex const expressions, based on definitional equality.
-    (unstable, opaque_generic_const_args, "CURRENT_RUSTC_VERSION", Some(151972)),
+    (unstable, opaque_generic_const_args, "1.95.0", Some(151972)),
     /// Allows using `#[optimize(X)]`.
     (unstable, optimize_attribute, "1.34.0", Some(54882)),
     /// Allows specifying nop padding on functions for dynamic patching.
@@ -635,7 +635,7 @@ declare_features! (
     /// Allows `extern "rust-cold"`.
     (unstable, rust_cold_cc, "1.63.0", Some(97544)),
     /// Allows `extern "rust-preserve-none"`.
-    (unstable, rust_preserve_none_cc, "CURRENT_RUSTC_VERSION", Some(151401)),
+    (unstable, rust_preserve_none_cc, "1.95.0", Some(151401)),
     /// Target features on s390x.
     (unstable, s390x_target_feature, "1.82.0", Some(150259)),
     /// Allows the use of the `sanitize` attribute.

--- a/library/alloc/src/collections/linked_list.rs
+++ b/library/alloc/src/collections/linked_list.rs
@@ -862,7 +862,7 @@ impl<T, A: Allocator> LinkedList<T, A> {
     /// *ptr += 4;
     /// assert_eq!(dl.front().unwrap(), &6);
     /// ```
-    #[stable(feature = "push_mut", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "push_mut", since = "1.95.0")]
     #[must_use = "if you don't need a reference to the value, use `LinkedList::push_front` instead"]
     pub fn push_front_mut(&mut self, elt: T) -> &mut T {
         let mut node =
@@ -933,7 +933,7 @@ impl<T, A: Allocator> LinkedList<T, A> {
     /// *ptr += 4;
     /// assert_eq!(dl.back().unwrap(), &6);
     /// ```
-    #[stable(feature = "push_mut", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "push_mut", since = "1.95.0")]
     #[must_use = "if you don't need a reference to the value, use `LinkedList::push_back` instead"]
     pub fn push_back_mut(&mut self, elt: T) -> &mut T {
         let mut node =

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -2175,7 +2175,7 @@ impl<T, A: Allocator> VecDeque<T, A> {
     /// *x -= 1;
     /// assert_eq!(d.front(), Some(&7));
     /// ```
-    #[stable(feature = "push_mut", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "push_mut", since = "1.95.0")]
     #[must_use = "if you don't need a reference to the value, use `VecDeque::push_front` instead"]
     pub fn push_front_mut(&mut self, value: T) -> &mut T {
         if self.is_full() {
@@ -2218,7 +2218,7 @@ impl<T, A: Allocator> VecDeque<T, A> {
     /// *x += 1;
     /// assert_eq!(d.back(), Some(&10));
     /// ```
-    #[stable(feature = "push_mut", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "push_mut", since = "1.95.0")]
     #[must_use = "if you don't need a reference to the value, use `VecDeque::push_back` instead"]
     pub fn push_back_mut(&mut self, value: T) -> &mut T {
         if self.is_full() {
@@ -2425,7 +2425,7 @@ impl<T, A: Allocator> VecDeque<T, A> {
     /// *x += 7;
     /// assert_eq!(vec_deque, &[1, 12, 2, 3]);
     /// ```
-    #[stable(feature = "push_mut", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "push_mut", since = "1.95.0")]
     #[must_use = "if you don't need a reference to the value, use `VecDeque::insert` instead"]
     pub fn insert_mut(&mut self, index: usize, value: T) -> &mut T {
         assert!(index <= self.len(), "index out of bounds");

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1018,7 +1018,7 @@ const impl<T, A: [const] Allocator + [const] Destruct> Vec<T, A> {
     /// vector's elements to a larger allocation. This expensive operation is
     /// offset by the *capacity* *O*(1) insertions it allows.
     #[inline]
-    #[stable(feature = "push_mut", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "push_mut", since = "1.95.0")]
     #[must_use = "if you don't need a reference to the value, use `Vec::push` instead"]
     pub fn push_mut(&mut self, value: T) -> &mut T {
         // Inform codegen that the length does not change across grow_one().
@@ -2271,7 +2271,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// the insertion index is 0.
     #[cfg(not(no_global_oom_handling))]
     #[inline]
-    #[stable(feature = "push_mut", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "push_mut", since = "1.95.0")]
     #[track_caller]
     #[must_use = "if you don't need a reference to the value, use `Vec::insert` instead"]
     pub fn insert_mut(&mut self, index: usize, element: T) -> &mut T {

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -263,8 +263,8 @@ impl Layout {
     /// be that of a valid pointer, which means this must not be used
     /// as a "not yet initialized" sentinel value.
     /// Types that lazily allocate must track initialization by some other means.
-    #[stable(feature = "alloc_layout_extra", since = "CURRENT_RUSTC_VERSION")]
-    #[rustc_const_stable(feature = "alloc_layout_extra", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "alloc_layout_extra", since = "1.95.0")]
+    #[rustc_const_stable(feature = "alloc_layout_extra", since = "1.95.0")]
     #[must_use]
     #[inline]
     pub const fn dangling_ptr(&self) -> NonNull<u8> {
@@ -423,8 +423,8 @@ impl Layout {
     /// let repeated = padding_needed.repeat(0).unwrap();
     /// assert_eq!(repeated, (Layout::from_size_align(0, 4).unwrap(), 8));
     /// ```
-    #[stable(feature = "alloc_layout_extra", since = "CURRENT_RUSTC_VERSION")]
-    #[rustc_const_stable(feature = "alloc_layout_extra", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "alloc_layout_extra", since = "1.95.0")]
+    #[rustc_const_stable(feature = "alloc_layout_extra", since = "1.95.0")]
     #[inline]
     pub const fn repeat(&self, n: usize) -> Result<(Self, usize), LayoutError> {
         // FIXME(const-hack): the following could be way shorter with `?`
@@ -520,8 +520,8 @@ impl Layout {
     /// aligned.
     ///
     /// On arithmetic overflow, returns `LayoutError`.
-    #[stable(feature = "alloc_layout_extra", since = "CURRENT_RUSTC_VERSION")]
-    #[rustc_const_stable(feature = "alloc_layout_extra", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "alloc_layout_extra", since = "1.95.0")]
+    #[rustc_const_stable(feature = "alloc_layout_extra", since = "1.95.0")]
     #[inline]
     pub const fn repeat_packed(&self, n: usize) -> Result<Self, LayoutError> {
         if let Some(size) = self.size.checked_mul(n) {
@@ -538,8 +538,8 @@ impl Layout {
     /// and is not incorporated *at all* into the resulting layout.
     ///
     /// On arithmetic overflow, returns `LayoutError`.
-    #[stable(feature = "alloc_layout_extra", since = "CURRENT_RUSTC_VERSION")]
-    #[rustc_const_stable(feature = "alloc_layout_extra", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "alloc_layout_extra", since = "1.95.0")]
+    #[rustc_const_stable(feature = "alloc_layout_extra", since = "1.95.0")]
     #[inline]
     pub const fn extend_packed(&self, next: Self) -> Result<Self, LayoutError> {
         // SAFETY: each `size` is at most `isize::MAX == usize::MAX/2`, so the

--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -689,7 +689,7 @@ impl<T: CoerceUnsized<U>, U> CoerceUnsized<Cell<U>> for Cell<T> {}
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
 impl<T: DispatchFromDyn<U>, U> DispatchFromDyn<Cell<U>> for Cell<T> {}
 
-#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "more_conversion_trait_impls", since = "1.95.0")]
 impl<T, const N: usize> AsRef<[Cell<T>; N]> for Cell<[T; N]> {
     #[inline]
     fn as_ref(&self) -> &[Cell<T>; N] {
@@ -697,7 +697,7 @@ impl<T, const N: usize> AsRef<[Cell<T>; N]> for Cell<[T; N]> {
     }
 }
 
-#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "more_conversion_trait_impls", since = "1.95.0")]
 impl<T, const N: usize> AsRef<[Cell<T>]> for Cell<[T; N]> {
     #[inline]
     fn as_ref(&self) -> &[Cell<T>] {
@@ -705,7 +705,7 @@ impl<T, const N: usize> AsRef<[Cell<T>]> for Cell<[T; N]> {
     }
 }
 
-#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "more_conversion_trait_impls", since = "1.95.0")]
 impl<T> AsRef<[Cell<T>]> for Cell<[T]> {
     #[inline]
     fn as_ref(&self) -> &[Cell<T>] {

--- a/library/core/src/fmt/builders.rs
+++ b/library/core/src/fmt/builders.rs
@@ -1227,7 +1227,7 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
 /// assert_eq!(format!("{:?}", wrapped), "'a'");
 /// ```
 #[stable(feature = "fmt_from_fn", since = "1.93.0")]
-#[rustc_const_stable(feature = "const_fmt_from_fn", since = "CURRENT_RUSTC_VERSION")]
+#[rustc_const_stable(feature = "const_fmt_from_fn", since = "1.95.0")]
 #[must_use = "returns a type implementing Debug and Display, which do not have any effects unless they are used"]
 pub const fn from_fn<F: Fn(&mut fmt::Formatter<'_>) -> fmt::Result>(f: F) -> FromFn<F> {
     FromFn(f)

--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -775,8 +775,8 @@ pub const fn unlikely(b: bool) -> bool {
 ///     }
 /// }
 /// ```
-#[stable(feature = "cold_path", since = "CURRENT_RUSTC_VERSION")]
-#[rustc_const_stable(feature = "cold_path", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "cold_path", since = "1.95.0")]
+#[rustc_const_stable(feature = "cold_path", since = "1.95.0")]
 #[inline(always)]
 pub const fn cold_path() {
     crate::intrinsics::cold_path()

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -205,7 +205,7 @@ use prelude::rust_2024::*;
 #[macro_use]
 mod macros;
 
-#[stable(feature = "assert_matches", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "assert_matches", since = "1.95.0")]
 pub use crate::macros::{assert_matches, debug_assert_matches};
 
 #[unstable(feature = "derive_from", issue = "144889")]
@@ -226,7 +226,7 @@ pub mod autodiff {
 #[unstable(feature = "contracts", issue = "128044")]
 pub mod contracts;
 
-#[stable(feature = "cfg_select", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "cfg_select", since = "1.95.0")]
 pub use crate::macros::cfg_select;
 
 #[macro_use]
@@ -304,7 +304,7 @@ pub mod pat;
 pub mod pin;
 #[unstable(feature = "random", issue = "130703")]
 pub mod random;
-#[stable(feature = "new_range_inclusive_api", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
 pub mod range;
 pub mod result;
 pub mod sync;

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -164,7 +164,7 @@ macro_rules! assert_ne {
 /// assert_matches!(a, Some(x) if x > 100);
 /// // assert_matches!(a, Some(x) if x < 100); // panics
 /// ```
-#[stable(feature = "assert_matches", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "assert_matches", since = "1.95.0")]
 #[allow_internal_unstable(panic_internals)]
 #[rustc_macro_transparency = "semiopaque"]
 pub macro assert_matches {
@@ -228,7 +228,7 @@ pub macro assert_matches {
 ///     _ => { "Behind every successful diet is an unwatched pizza" }
 /// };
 /// ```
-#[stable(feature = "cfg_select", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "cfg_select", since = "1.95.0")]
 #[rustc_diagnostic_item = "cfg_select"]
 #[rustc_builtin_macro]
 pub macro cfg_select($($tt:tt)*) {
@@ -391,7 +391,7 @@ macro_rules! debug_assert_ne {
 /// debug_assert_matches!(a, Some(x) if x > 100);
 /// // debug_assert_matches!(a, Some(x) if x < 100); // panics
 /// ```
-#[stable(feature = "assert_matches", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "assert_matches", since = "1.95.0")]
 #[allow_internal_unstable(assert_matches)]
 #[rustc_macro_transparency = "semiopaque"]
 pub macro debug_assert_matches($($arg:tt)*) {

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -1532,7 +1532,7 @@ impl<T, const N: usize> MaybeUninit<[T; N]> {
     }
 }
 
-#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "more_conversion_trait_impls", since = "1.95.0")]
 impl<T, const N: usize> From<[MaybeUninit<T>; N]> for MaybeUninit<[T; N]> {
     #[inline]
     fn from(arr: [MaybeUninit<T>; N]) -> Self {
@@ -1540,7 +1540,7 @@ impl<T, const N: usize> From<[MaybeUninit<T>; N]> for MaybeUninit<[T; N]> {
     }
 }
 
-#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "more_conversion_trait_impls", since = "1.95.0")]
 impl<T, const N: usize> AsRef<[MaybeUninit<T>; N]> for MaybeUninit<[T; N]> {
     #[inline]
     fn as_ref(&self) -> &[MaybeUninit<T>; N] {
@@ -1549,7 +1549,7 @@ impl<T, const N: usize> AsRef<[MaybeUninit<T>; N]> for MaybeUninit<[T; N]> {
     }
 }
 
-#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "more_conversion_trait_impls", since = "1.95.0")]
 impl<T, const N: usize> AsRef<[MaybeUninit<T>]> for MaybeUninit<[T; N]> {
     #[inline]
     fn as_ref(&self) -> &[MaybeUninit<T>] {
@@ -1557,7 +1557,7 @@ impl<T, const N: usize> AsRef<[MaybeUninit<T>]> for MaybeUninit<[T; N]> {
     }
 }
 
-#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "more_conversion_trait_impls", since = "1.95.0")]
 impl<T, const N: usize> AsMut<[MaybeUninit<T>; N]> for MaybeUninit<[T; N]> {
     #[inline]
     fn as_mut(&mut self) -> &mut [MaybeUninit<T>; N] {
@@ -1566,7 +1566,7 @@ impl<T, const N: usize> AsMut<[MaybeUninit<T>; N]> for MaybeUninit<[T; N]> {
     }
 }
 
-#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "more_conversion_trait_impls", since = "1.95.0")]
 impl<T, const N: usize> AsMut<[MaybeUninit<T>]> for MaybeUninit<[T; N]> {
     #[inline]
     fn as_mut(&mut self) -> &mut [MaybeUninit<T>] {
@@ -1574,7 +1574,7 @@ impl<T, const N: usize> AsMut<[MaybeUninit<T>]> for MaybeUninit<[T; N]> {
     }
 }
 
-#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "more_conversion_trait_impls", since = "1.95.0")]
 impl<T, const N: usize> From<MaybeUninit<[T; N]>> for [MaybeUninit<T>; N] {
     #[inline]
     fn from(arr: MaybeUninit<[T; N]>) -> Self {

--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -151,7 +151,7 @@ impl<B, C> ControlFlow<B, C> {
     /// ```
     #[inline]
     #[stable(feature = "control_flow_enum_is", since = "1.59.0")]
-    #[rustc_const_stable(feature = "min_const_control_flow", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "min_const_control_flow", since = "1.95.0")]
     pub const fn is_break(&self) -> bool {
         matches!(*self, ControlFlow::Break(_))
     }
@@ -168,7 +168,7 @@ impl<B, C> ControlFlow<B, C> {
     /// ```
     #[inline]
     #[stable(feature = "control_flow_enum_is", since = "1.59.0")]
-    #[rustc_const_stable(feature = "min_const_control_flow", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "min_const_control_flow", since = "1.95.0")]
     pub const fn is_continue(&self) -> bool {
         matches!(*self, ControlFlow::Continue(_))
     }

--- a/library/core/src/prelude/v1.rs
+++ b/library/core/src/prelude/v1.rs
@@ -80,7 +80,7 @@ mod ambiguous_macros_only {
 #[doc(no_inline)]
 pub use self::ambiguous_macros_only::{env, panic};
 
-#[stable(feature = "cfg_select", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "cfg_select", since = "1.95.0")]
 #[doc(no_inline)]
 pub use crate::cfg_select;
 

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -290,8 +290,8 @@ impl<T: PointeeSized> *const T {
     ///     assert_eq!(ptr.as_ref_unchecked(), &10);
     /// }
     /// ```
-    #[stable(feature = "ptr_as_ref_unchecked", since = "CURRENT_RUSTC_VERSION")]
-    #[rustc_const_stable(feature = "ptr_as_ref_unchecked", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "ptr_as_ref_unchecked", since = "1.95.0")]
+    #[rustc_const_stable(feature = "ptr_as_ref_unchecked", since = "1.95.0")]
     #[inline]
     #[must_use]
     pub const unsafe fn as_ref_unchecked<'a>(self) -> &'a T {

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -288,8 +288,8 @@ impl<T: PointeeSized> *mut T {
     ///     println!("We got back the value: {}!", ptr.as_ref_unchecked());
     /// }
     /// ```
-    #[stable(feature = "ptr_as_ref_unchecked", since = "CURRENT_RUSTC_VERSION")]
-    #[rustc_const_stable(feature = "ptr_as_ref_unchecked", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "ptr_as_ref_unchecked", since = "1.95.0")]
+    #[rustc_const_stable(feature = "ptr_as_ref_unchecked", since = "1.95.0")]
     #[inline]
     #[must_use]
     pub const unsafe fn as_ref_unchecked<'a>(self) -> &'a T {
@@ -611,8 +611,8 @@ impl<T: PointeeSized> *mut T {
     /// # assert_eq!(s, [4, 2, 3]);
     /// println!("{s:?}"); // It'll print: "[4, 2, 3]".
     /// ```
-    #[stable(feature = "ptr_as_ref_unchecked", since = "CURRENT_RUSTC_VERSION")]
-    #[rustc_const_stable(feature = "ptr_as_ref_unchecked", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "ptr_as_ref_unchecked", since = "1.95.0")]
+    #[rustc_const_stable(feature = "ptr_as_ref_unchecked", since = "1.95.0")]
     #[inline]
     #[must_use]
     pub const unsafe fn as_mut_unchecked<'a>(self) -> &'a mut T {

--- a/library/core/src/range.rs
+++ b/library/core/src/range.rs
@@ -25,7 +25,7 @@ mod iter;
 pub mod legacy;
 
 #[doc(inline)]
-#[stable(feature = "new_range_inclusive_api", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
 pub use iter::RangeInclusiveIter;
 #[doc(inline)]
 #[unstable(feature = "new_range_api", issue = "125687")]
@@ -245,17 +245,17 @@ impl<T> const From<legacy::Range<T>> for Range<T> {
 /// ```
 #[lang = "RangeInclusiveCopy"]
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
-#[stable(feature = "new_range_inclusive_api", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
 pub struct RangeInclusive<Idx> {
     /// The lower bound of the range (inclusive).
-    #[stable(feature = "new_range_inclusive_api", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
     pub start: Idx,
     /// The upper bound of the range (inclusive).
-    #[stable(feature = "new_range_inclusive_api", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
     pub last: Idx,
 }
 
-#[stable(feature = "new_range_inclusive_api", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
 impl<Idx: fmt::Debug> fmt::Debug for RangeInclusive<Idx> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.start.fmt(fmt)?;
@@ -288,7 +288,7 @@ impl<Idx: PartialOrd<Idx>> RangeInclusive<Idx> {
     /// assert!(!RangeInclusive::from(f32::NAN..=1.0).contains(&1.0));
     /// ```
     #[inline]
-    #[stable(feature = "new_range_inclusive_api", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
     #[rustc_const_unstable(feature = "const_range", issue = "none")]
     pub const fn contains<U>(&self, item: &U) -> bool
     where
@@ -319,7 +319,7 @@ impl<Idx: PartialOrd<Idx>> RangeInclusive<Idx> {
     /// assert!( RangeInclusive::from(3.0..=f32::NAN).is_empty());
     /// assert!( RangeInclusive::from(f32::NAN..=5.0).is_empty());
     /// ```
-    #[stable(feature = "new_range_inclusive_api", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
     #[inline]
     #[rustc_const_unstable(feature = "const_range", issue = "none")]
     pub const fn is_empty(&self) -> bool
@@ -345,14 +345,14 @@ impl<Idx: Step> RangeInclusive<Idx> {
     /// assert_eq!(i.next(), Some(16));
     /// assert_eq!(i.next(), Some(25));
     /// ```
-    #[stable(feature = "new_range_inclusive_api", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
     #[inline]
     pub fn iter(&self) -> RangeInclusiveIter<Idx> {
         self.clone().into_iter()
     }
 }
 
-#[stable(feature = "new_range_inclusive_api", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
 #[rustc_const_unstable(feature = "const_range", issue = "none")]
 impl<T> const RangeBounds<T> for RangeInclusive<T> {
     fn start_bound(&self) -> Bound<&T> {
@@ -369,7 +369,7 @@ impl<T> const RangeBounds<T> for RangeInclusive<T> {
 /// If you need to use this implementation where `T` is unsized,
 /// consider using the `RangeBounds` impl for a 2-tuple of [`Bound<&T>`][Bound],
 /// i.e. replace `start..=end` with `(Bound::Included(start), Bound::Included(end))`.
-#[stable(feature = "new_range_inclusive_api", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
 #[rustc_const_unstable(feature = "const_range", issue = "none")]
 impl<T> const RangeBounds<T> for RangeInclusive<&T> {
     fn start_bound(&self) -> Bound<&T> {
@@ -380,7 +380,7 @@ impl<T> const RangeBounds<T> for RangeInclusive<&T> {
     }
 }
 
-// #[stable(feature = "new_range_inclusive_api", since = "CURRENT_RUSTC_VERSION")]
+// #[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
 #[unstable(feature = "range_into_bounds", issue = "136903")]
 #[rustc_const_unstable(feature = "const_range", issue = "none")]
 impl<T> const IntoBounds<T> for RangeInclusive<T> {
@@ -389,7 +389,7 @@ impl<T> const IntoBounds<T> for RangeInclusive<T> {
     }
 }
 
-#[stable(feature = "new_range_inclusive_api", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 impl<T> const From<RangeInclusive<T>> for legacy::RangeInclusive<T> {
     #[inline]
@@ -397,7 +397,7 @@ impl<T> const From<RangeInclusive<T>> for legacy::RangeInclusive<T> {
         Self::new(value.start, value.last)
     }
 }
-#[stable(feature = "new_range_inclusive_api", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 impl<T> const From<legacy::RangeInclusive<T>> for RangeInclusive<T> {
     #[inline]

--- a/library/core/src/range/iter.rs
+++ b/library/core/src/range/iter.rs
@@ -153,7 +153,7 @@ impl<A: Step> IntoIterator for Range<A> {
 }
 
 /// By-value [`RangeInclusive`] iterator.
-#[stable(feature = "new_range_inclusive_api", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
 #[derive(Debug, Clone)]
 pub struct RangeInclusiveIter<A>(legacy::RangeInclusive<A>);
 
@@ -161,7 +161,7 @@ impl<A: Step> RangeInclusiveIter<A> {
     /// Returns the remainder of the range being iterated over.
     ///
     /// If the iterator is exhausted or empty, returns `None`.
-    #[stable(feature = "new_range_inclusive_api", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
     pub fn remainder(self) -> Option<RangeInclusive<A>> {
         if self.0.is_empty() {
             return None;
@@ -171,7 +171,7 @@ impl<A: Step> RangeInclusiveIter<A> {
     }
 }
 
-#[stable(feature = "new_range_inclusive_api", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
 impl<A: Step> Iterator for RangeInclusiveIter<A> {
     type Item = A;
 
@@ -227,7 +227,7 @@ impl<A: Step> Iterator for RangeInclusiveIter<A> {
     }
 }
 
-#[stable(feature = "new_range_inclusive_api", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
 impl<A: Step> DoubleEndedIterator for RangeInclusiveIter<A> {
     #[inline]
     fn next_back(&mut self) -> Option<A> {
@@ -248,10 +248,10 @@ impl<A: Step> DoubleEndedIterator for RangeInclusiveIter<A> {
 #[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<A: TrustedStep> TrustedLen for RangeInclusiveIter<A> {}
 
-#[stable(feature = "new_range_inclusive_api", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
 impl<A: Step> FusedIterator for RangeInclusiveIter<A> {}
 
-#[stable(feature = "new_range_inclusive_api", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
 impl<A: Step> IntoIterator for RangeInclusive<A> {
     type Item = A;
     type IntoIter = RangeInclusiveIter<A>;
@@ -278,7 +278,7 @@ macro_rules! range_exact_iter_impl {
 
 macro_rules! range_incl_exact_iter_impl {
     ($($t:ty)*) => ($(
-        #[stable(feature = "new_range_inclusive_api", since = "CURRENT_RUSTC_VERSION")]
+        #[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
         impl ExactSizeIterator for RangeInclusiveIter<$t> { }
     )*)
 }

--- a/library/core/src/slice/index.rs
+++ b/library/core/src/slice/index.rs
@@ -127,7 +127,7 @@ mod private_slice_index {
 
     #[unstable(feature = "new_range_api", issue = "125687")]
     impl Sealed for range::Range<usize> {}
-    #[stable(feature = "new_range_inclusive_api", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
     impl Sealed for range::RangeInclusive<usize> {}
     #[unstable(feature = "new_range_api", issue = "125687")]
     impl Sealed for range::RangeToInclusive<usize> {}
@@ -723,7 +723,7 @@ unsafe impl<T> const SliceIndex<[T]> for ops::RangeInclusive<usize> {
     }
 }
 
-#[stable(feature = "new_range_inclusive_api", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
 #[rustc_const_unstable(feature = "const_index", issue = "143775")]
 unsafe impl<T> const SliceIndex<[T]> for range::RangeInclusive<usize> {
     type Output = [T];

--- a/library/core/src/str/traits.rs
+++ b/library/core/src/str/traits.rs
@@ -685,7 +685,7 @@ unsafe impl const SliceIndex<str> for ops::RangeInclusive<usize> {
     }
 }
 
-#[stable(feature = "new_range_inclusive_api", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
 #[rustc_const_unstable(feature = "const_index", issue = "143775")]
 unsafe impl const SliceIndex<str> for range::RangeInclusive<usize> {
     type Output = str;

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -1358,7 +1358,7 @@ impl AtomicBool {
     /// assert_eq!(x.load(Ordering::SeqCst), false);
     /// ```
     #[inline]
-    #[stable(feature = "atomic_try_update", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "atomic_try_update", since = "1.95.0")]
     #[cfg(target_has_atomic = "8")]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[rustc_should_not_be_called_on_const_items]
@@ -1421,7 +1421,7 @@ impl AtomicBool {
     /// assert_eq!(x.load(Ordering::SeqCst), false);
     /// ```
     #[inline]
-    #[stable(feature = "atomic_try_update", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "atomic_try_update", since = "1.95.0")]
     #[cfg(target_has_atomic = "8")]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[rustc_should_not_be_called_on_const_items]
@@ -2037,7 +2037,7 @@ impl<T> AtomicPtr<T> {
     /// assert_eq!(some_ptr.load(Ordering::SeqCst), new);
     /// ```
     #[inline]
-    #[stable(feature = "atomic_try_update", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "atomic_try_update", since = "1.95.0")]
     #[cfg(target_has_atomic = "ptr")]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[rustc_should_not_be_called_on_const_items]
@@ -2105,7 +2105,7 @@ impl<T> AtomicPtr<T> {
     /// assert_eq!(some_ptr.load(Ordering::SeqCst), new);
     /// ```
     #[inline]
-    #[stable(feature = "atomic_try_update", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "atomic_try_update", since = "1.95.0")]
     #[cfg(target_has_atomic = "8")]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[rustc_should_not_be_called_on_const_items]
@@ -3372,7 +3372,7 @@ macro_rules! atomic_int {
             /// assert_eq!(x.load(Ordering::SeqCst), 9);
             /// ```
             #[inline]
-            #[stable(feature = "atomic_try_update", since = "CURRENT_RUSTC_VERSION")]
+            #[stable(feature = "atomic_try_update", since = "1.95.0")]
             #[$cfg_cas]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
             #[rustc_should_not_be_called_on_const_items]
@@ -3438,7 +3438,7 @@ macro_rules! atomic_int {
             /// assert_eq!(x.load(Ordering::SeqCst), 9);
             /// ```
             #[inline]
-            #[stable(feature = "atomic_try_update", since = "CURRENT_RUSTC_VERSION")]
+            #[stable(feature = "atomic_try_update", since = "1.95.0")]
             #[$cfg_cas]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
             #[rustc_should_not_be_called_on_const_items]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -694,7 +694,7 @@ mod panicking;
 #[allow(dead_code, unused_attributes, fuzzy_provenance_casts, unsafe_op_in_unsafe_fn)]
 mod backtrace_rs;
 
-#[stable(feature = "cfg_select", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "cfg_select", since = "1.95.0")]
 pub use core::cfg_select;
 #[unstable(
     feature = "concat_bytes",
@@ -724,7 +724,7 @@ pub use core::{
     assert_eq, assert_ne, debug_assert, debug_assert_eq, debug_assert_ne, r#try, unimplemented,
     unreachable, write, writeln,
 };
-#[stable(feature = "assert_matches", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "assert_matches", since = "1.95.0")]
 pub use core::{assert_matches, debug_assert_matches};
 
 // Re-export unstable derive macro defined through core.

--- a/library/std/src/prelude/v1.rs
+++ b/library/std/src/prelude/v1.rs
@@ -79,7 +79,7 @@ mod ambiguous_macros_only {
 #[doc(no_inline)]
 pub use self::ambiguous_macros_only::{vec, panic};
 
-#[stable(feature = "cfg_select", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "cfg_select", since = "1.95.0")]
 #[doc(no_inline)]
 pub use core::prelude::v1::cfg_select;
 

--- a/library/stdarch/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/library/stdarch/crates/core_arch/src/aarch64/neon/generated.rs
@@ -49,7 +49,7 @@ pub fn __crc32d(crc: u32, data: u64) -> u32 {
 #[inline(always)]
 #[target_feature(enable = "jsconv")]
 #[cfg_attr(test, assert_instr(fjcvtzs))]
-#[stable(feature = "stdarch_aarch64_jscvt", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "stdarch_aarch64_jscvt", since = "1.95.0")]
 pub fn __jcvt(a: f64) -> i32 {
     unsafe extern "unadjusted" {
         #[cfg_attr(

--- a/library/stdarch/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
+++ b/library/stdarch/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
@@ -64,7 +64,7 @@ neon-unstable-feat-lut: &neon-unstable-feat-lut
   FnCall: [unstable, ['feature = "stdarch_neon_feat_lut"', 'issue = "138050"']]
 
 aarch64-stable-jscvt: &aarch64-stable-jscvt
-  FnCall: [stable, ['feature = "stdarch_aarch64_jscvt"', 'since = "CURRENT_RUSTC_VERSION"']]
+  FnCall: [stable, ['feature = "stdarch_aarch64_jscvt"', 'since = "1.95.0"']]
 
 # #[unstable(feature = "stdarch_neon_feat_lrcpc3", issue = "none")]
 neon-unstable-feat-lrcpc3: &neon-unstable-feat-lrcpc3

--- a/library/test/build.rs
+++ b/library/test/build.rs
@@ -2,11 +2,16 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rustc-check-cfg=cfg(enable_unstable_features)");
 
-    let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".into());
-    let version = std::process::Command::new(rustc).arg("-vV").output().unwrap();
-    let stdout = String::from_utf8(version.stdout).unwrap();
+    // Miri testing uses unstable features, so always enable that for its sysroot.
+    // Otherwise, only enable unstable if rustc looks like a nightly or dev build.
+    let enable_unstable_features = std::env::var("MIRI_CALLED_FROM_SETUP").is_ok() || {
+        let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".into());
+        let version = std::process::Command::new(rustc).arg("-vV").output().unwrap();
+        let stdout = String::from_utf8(version.stdout).unwrap();
+        stdout.contains("nightly") || stdout.contains("dev")
+    };
 
-    if stdout.contains("nightly") || stdout.contains("dev") {
+    if enable_unstable_features {
         println!("cargo:rustc-cfg=enable_unstable_features");
     }
 }

--- a/src/ci/channel
+++ b/src/ci/channel
@@ -1,1 +1,1 @@
-nightly
+beta


### PR DESCRIPTION
Ref: https://forge.rust-lang.org/release/process.html#beta-pr

- Replace version placeholders with 1.95.0
- Bump to beta release
- library/test: always enable unstable features for miri rust-lang/rust#153369 

r? cuviper
