### PR TITLE
Comments and docs: add missing periods to "ie."

### DIFF
--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -371,7 +371,7 @@ impl DefKind {
         )
     }
 
-    /// Whether the corresponding item has generic parameters, ie. the `generics_of` query works.
+    /// Whether the corresponding item has generic parameters, i.e. the `generics_of` query works.
     pub fn has_generics(self) -> bool {
         match self {
             DefKind::AnonConst

--- a/compiler/rustc_lint/src/ptr_nulls.rs
+++ b/compiler/rustc_lint/src/ptr_nulls.rs
@@ -59,7 +59,7 @@ declare_lint! {
 declare_lint_pass!(PtrNullChecks => [USELESS_PTR_NULL_CHECKS, INVALID_NULL_ARGUMENTS]);
 
 /// This function checks if the expression is from a series of consecutive casts,
-/// ie. `(my_fn as *const _ as *mut _).cast_mut()` and whether the original expression is either
+/// i.e. `(my_fn as *const _ as *mut _).cast_mut()` and whether the original expression is either
 /// a fn ptr, a reference, or a function call whose definition is
 /// annotated with `#![rustc_never_returns_null_ptr]`.
 /// If this situation is present, the function returns the appropriate diagnostic.

--- a/compiler/rustc_middle/src/traits/specialization_graph.rs
+++ b/compiler/rustc_middle/src/traits/specialization_graph.rs
@@ -175,7 +175,7 @@ pub struct LeafDef {
     /// The node in the specialization graph containing the definition of `item`.
     pub defining_node: Node,
 
-    /// The "top-most" (ie. least specialized) specialization graph node that finalized the
+    /// The "top-most" (i.e. least specialized) specialization graph node that finalized the
     /// definition of `item`.
     ///
     /// Example:
@@ -210,7 +210,7 @@ impl LeafDef {
 }
 
 impl<'tcx> Ancestors<'tcx> {
-    /// Finds the bottom-most (ie. most specialized) definition of an associated
+    /// Finds the bottom-most (i.e. most specialized) definition of an associated
     /// item.
     pub fn leaf_def(mut self, tcx: TyCtxt<'tcx>, trait_item_def_id: DefId) -> Option<LeafDef> {
         let mut finalizing_node = None;

--- a/compiler/rustc_mir_transform/src/elaborate_drop.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drop.rs
@@ -160,7 +160,7 @@ where
 ///
 /// The passed `elaborator` is used to determine what should happen at the drop terminator. It
 /// decides whether the drop can be statically determined or whether it needs a dynamic drop flag,
-/// and whether the drop is "open", ie. should be expanded to drop all subfields of the dropped
+/// and whether the drop is "open", i.e. should be expanded to drop all subfields of the dropped
 /// value.
 ///
 /// When this returns, the MIR patch in the `elaborator` contains the necessary changes.

--- a/compiler/rustc_mir_transform/src/ref_prop.rs
+++ b/compiler/rustc_mir_transform/src/ref_prop.rs
@@ -245,7 +245,7 @@ fn compute_replacement<'tcx>(
         debug!(?rvalue);
         match rvalue {
             // This is a copy, just use the value we have in store for the previous one.
-            // As we are visiting in `assignment_order`, ie. reverse postorder, `rhs` should
+            // As we are visiting in `assignment_order`, i.e. reverse postorder, `rhs` should
             // have been visited before.
             Rvalue::Use(Operand::Copy(place) | Operand::Move(place)) => {
                 if let Some(rhs) = place.as_local()

--- a/compiler/rustc_mir_transform/src/ssa.rs
+++ b/compiler/rustc_mir_transform/src/ssa.rs
@@ -25,7 +25,7 @@ pub(super) struct SsaLocals {
     assignment_order: Vec<Local>,
     /// Copy equivalence classes between locals. See `copy_classes` for documentation.
     copy_classes: IndexVec<Local, Local>,
-    /// Number of "direct" uses of each local, ie. uses that are not dereferences.
+    /// Number of "direct" uses of each local, i.e. uses that are not dereferences.
     /// We ignore non-uses (Storage statements, debuginfo).
     direct_uses: IndexVec<Local, u32>,
     /// Set of SSA locals that are immutably borrowed.
@@ -314,7 +314,7 @@ fn compute_copy_classes(ssa: &mut SsaLocals, body: &Body<'_>) {
             continue;
         }
 
-        // We visit in `assignment_order`, ie. reverse post-order, so `rhs` has been
+        // We visit in `assignment_order`, i.e. reverse post-order, so `rhs` has been
         // visited before `local`, and we just have to copy the representing local.
         let head = copies[rhs];
 

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -2976,7 +2976,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             corrections.push((import.span, format!("{module_name}::{import_snippet}")));
         } else {
             // Find the binding span (and any trailing commas and spaces).
-            //   ie. `use a::b::{c, d, e};`
+            //   i.e. `use a::b::{c, d, e};`
             //                      ^^^
             let (found_closing_brace, binding_span) = find_span_of_binding_until_next_binding(
                 self.tcx.sess,
@@ -2988,11 +2988,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             let mut removal_span = binding_span;
 
             // If the binding span ended with a closing brace, as in the below example:
-            //   ie. `use a::b::{c, d};`
+            //   i.e. `use a::b::{c, d};`
             //                      ^
             // Then expand the span of characters to remove to include the previous
             // binding's trailing comma.
-            //   ie. `use a::b::{c, d};`
+            //   i.e. `use a::b::{c, d};`
             //                    ^^^
             if found_closing_brace
                 && let Some(previous_span) =
@@ -3008,7 +3008,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
             // Find the span after the crate name and if it has nested imports immediately
             // after the crate name already.
-            //   ie. `use a::b::{c, d};`
+            //   i.e. `use a::b::{c, d};`
             //               ^^^^^^^^^
             //   or  `use a::{b, c, d}};`
             //               ^^^^^^^^^^^
@@ -3172,16 +3172,16 @@ fn find_span_of_binding_until_next_binding(
     let source_map = sess.source_map();
 
     // Find the span of everything after the binding.
-    //   ie. `a, e};` or `a};`
+    //   i.e. `a, e};` or `a};`
     let binding_until_end = binding_span.with_hi(use_span.hi());
 
     // Find everything after the binding but not including the binding.
-    //   ie. `, e};` or `};`
+    //   i.e. `, e};` or `};`
     let after_binding_until_end = binding_until_end.with_lo(binding_span.hi());
 
     // Keep characters in the span until we encounter something that isn't a comma or
     // whitespace.
-    //   ie. `, ` or ``.
+    //   i.e. `, ` or ``.
     //
     // Also note whether a closing brace character was encountered. If there
     // was, then later go backwards to remove any trailing commas that are left.
@@ -3195,7 +3195,7 @@ fn find_span_of_binding_until_next_binding(
         });
 
     // Combine the two spans.
-    //   ie. `a, ` or `a`.
+    //   i.e. `a, ` or `a`.
     //
     // Removing these would leave `issue_52891::{d, e};` or `issue_52891::{d, e, };`
     let span = binding_span.with_hi(after_binding_until_next_binding.hi());
@@ -3219,7 +3219,7 @@ fn extend_span_to_previous_binding(sess: &Session, binding_span: Span) -> Option
     let source_map = sess.source_map();
 
     // `prev_source` will contain all of the source that came before the span.
-    // Then split based on a command and take the first (ie. closest to our span)
+    // Then split based on a command and take the first (i.e. closest to our span)
     // snippet. In the example, this is a space.
     let prev_source = source_map.span_to_prev_source(binding_span).ok()?;
 

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -70,7 +70,7 @@ pub(crate) enum ImportKind<'ra> {
         decls: PerNS<CmCell<PendingDecl<'ra>>>,
         /// `true` for `...::{self [as target]}` imports, `false` otherwise.
         type_ns_only: bool,
-        /// Did this import result from a nested import? ie. `use foo::{bar, baz};`
+        /// Did this import result from a nested import? i.e. `use foo::{bar, baz};`
         nested: bool,
         /// The ID of the `UseTree` that imported this `Import`.
         ///

--- a/compiler/rustc_session/src/config/cfg.rs
+++ b/compiler/rustc_session/src/config/cfg.rs
@@ -328,7 +328,7 @@ impl CheckCfg {
             return;
         }
 
-        // for `#[cfg(foo)]` (ie. cfg value is none)
+        // for `#[cfg(foo)]` (i.e. cfg value is none)
         let no_values = || {
             let mut values = FxHashSet::default();
             values.insert(None);

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/find_anon_type.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/find_anon_type.rs
@@ -160,7 +160,7 @@ impl<'tcx> Visitor<'tcx> for FindNestedTypeVisitor<'tcx> {
 }
 
 // The visitor captures the corresponding `hir::Ty` of the anonymous region
-// in the case of structs ie. `hir::TyKind::Path`.
+// in the case of structs i.e. `hir::TyKind::Path`.
 // This visitor would be invoked for each lifetime corresponding to a struct,
 // and would walk the types like Vec<Ref> in the above example and Ref looking for the HIR
 // where that lifetime appears. This allows us to highlight the

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -2680,7 +2680,7 @@ impl AsInner<fs_imp::DirEntry> for DirEntry {
 ///
 /// This function will only ever return an error of kind `NotFound` if the given
 /// path does not exist. Note that the inverse is not true,
-/// ie. if a path does not exist, its removal may fail for a number of reasons,
+/// i.e. if a path does not exist, its removal may fail for a number of reasons,
 /// such as insufficient permissions.
 ///
 /// # Examples
@@ -3150,7 +3150,7 @@ pub fn create_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
 ///
 /// This function will only ever return an error of kind `NotFound` if the given
 /// path does not exist. Note that the inverse is not true,
-/// ie. if a path does not exist, its removal may fail for a number of reasons,
+/// i.e. if a path does not exist, its removal may fail for a number of reasons,
 /// such as insufficient permissions.
 ///
 /// # Examples

--- a/src/doc/rustc/src/check-cfg.md
+++ b/src/doc/rustc/src/check-cfg.md
@@ -53,7 +53,7 @@ To check for the _none_ value (ie `#[cfg(foo)]`) one can use the `none()` predic
 `values()`: `values(none())`. It can be followed or preceded by any number of `"value"`.
 
 To enable checking of values, but to provide an *none*/empty set of expected values
-(ie. expect `#[cfg(name)]`), use these forms:
+(i.e. expect `#[cfg(name)]`), use these forms:
 
 ```bash
 rustc --check-cfg 'cfg(name)'

--- a/src/tools/clippy/clippy_lints/src/trait_bounds.rs
+++ b/src/tools/clippy/clippy_lints/src/trait_bounds.rs
@@ -110,7 +110,7 @@ impl<'tcx> LateLintPass<'tcx> for TraitBounds {
 
     fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
         // special handling for self trait bounds as these are not considered generics
-        // ie. trait Foo: Display {}
+        // i.e. trait Foo: Display {}
         if let Item {
             kind: ItemKind::Trait(_, _, _, _, _, bounds, ..),
             ..

--- a/src/tools/miri/tests/fail/shims/shim_arg_size.rs
+++ b/src/tools/miri/tests/fail/shims/shim_arg_size.rs
@@ -1,6 +1,6 @@
 fn main() {
     extern "C" {
-        // Use the wrong type (ie. not `i32`) for the `c` argument.
+        // Use the wrong type (i.e. not `i32`) for the `c` argument.
         fn memchr(s: *const std::ffi::c_void, c: u8, n: usize) -> *mut std::ffi::c_void;
     }
 

--- a/src/tools/rust-analyzer/crates/base-db/src/input.rs
+++ b/src/tools/rust-analyzer/crates/base-db/src/input.rs
@@ -742,7 +742,7 @@ impl CrateGraphBuilder {
         deps.into_iter()
     }
 
-    /// Returns all crates in the graph, sorted in topological order (ie. dependencies of a crate
+    /// Returns all crates in the graph, sorted in topological order (i.e. dependencies of a crate
     /// come before the crate itself).
     fn crates_in_topological_order(&self) -> Vec<CrateBuilderId> {
         let mut res = Vec::new();

--- a/src/tools/rust-analyzer/crates/hir-def/src/visibility.rs
+++ b/src/tools/rust-analyzer/crates/hir-def/src/visibility.rs
@@ -146,7 +146,7 @@ impl Visibility {
 
     /// Returns the most permissive visibility of `self` and `other`.
     ///
-    /// If there is no subset relation between `self` and `other`, returns `None` (ie. they're only
+    /// If there is no subset relation between `self` and `other`, returns `None` (i.e. they're only
     /// visible in unrelated modules).
     pub(crate) fn max(
         self,
@@ -212,7 +212,7 @@ impl Visibility {
 
     /// Returns the least permissive visibility of `self` and `other`.
     ///
-    /// If there is no subset relation between `self` and `other`, returns `None` (ie. they're only
+    /// If there is no subset relation between `self` and `other`, returns `None` (i.e. they're only
     /// visible in unrelated modules).
     pub(crate) fn min(
         self,

--- a/tests/run-make/print-cfg/rmake.rs
+++ b/tests/run-make/print-cfg/rmake.rs
@@ -1,7 +1,7 @@
 //! This checks the output of `--print=cfg`
 //!
 //! Specifically it checks that output is correctly formatted
-//! (ie. no duplicated cfgs, values are between "", names are not).
+//! (i.e. no duplicated cfgs, values are between "", names are not).
 //!
 //! It also checks that some targets have the correct set cfgs.
 

--- a/tests/run-make/remap-path-prefix-std/rmake.rs
+++ b/tests/run-make/remap-path-prefix-std/rmake.rs
@@ -1,5 +1,5 @@
 // This test makes sure that we do not leak paths to the checkout
-// (ie. /checkout in CI) in the distributed `libstd` debuginfo.
+// (i.e. /checkout in CI) in the distributed `libstd` debuginfo.
 //
 // This test only runs on Linux and dist builder (or with `rust.remap-debuginfo = true`
 // set in your `bootstrap.toml`).

--- a/tests/ui/associated-types/defaults-in-other-trait-items.rs
+++ b/tests/ui/associated-types/defaults-in-other-trait-items.rs
@@ -1,7 +1,7 @@
 #![feature(associated_type_defaults)]
 
 // Associated type defaults may not be assumed inside the trait defining them.
-// ie. they only resolve to `<Self as Tr>::A`, not the actual type `()`
+// i.e. they only resolve to `<Self as Tr>::A`, not the actual type `()`
 trait Tr {
     type A = (); //~ NOTE associated type defaults can't be assumed inside the trait defining them
 

--- a/tests/ui/associated-types/issue-54182-1.rs
+++ b/tests/ui/associated-types/issue-54182-1.rs
@@ -3,7 +3,7 @@
 // Tests that the return type of trait methods is correctly normalized when
 // checking that a method in an impl matches the trait definition when the
 // return type involves a defaulted associated type.
-// ie. the trait has a method with return type `-> Self::R`, and `type R = ()`,
+// i.e. the trait has a method with return type `-> Self::R`, and `type R = ()`,
 // but the impl leaves out the return type (resulting in `()`).
 // Note that specialization is not involved in this test; no items in
 // implementations may be overridden. If they were, the normalization wouldn't

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/struct.rs
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/struct.rs
@@ -39,7 +39,7 @@ fn main() {
 // Everything below this is expected to compile successfully.
 
 // We only test matching here as we cannot create non-exhaustive
-// structs from another crate. ie. they'll never pass in run-pass tests.
+// structs from another crate. i.e. they'll never pass in run-pass tests.
 fn match_structs(ns: NormalStruct, ts: TupleStruct, us: UnitStruct) {
     let NormalStruct { first_field, second_field, .. } = ns;
 


### PR DESCRIPTION
"i.e." is short for the Latin "id est" and thus both letters should be followed by periods.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
