### PR TITLE
Add high-priority ICEs to tests/crashes

### DIFF
--- a/tests/crashes/146965.rs
+++ b/tests/crashes/146965.rs
@@ -1,5 +1,5 @@
 //@ known-bug: #146965
-//@ compile-flags: --crate-type lib
+//@ compile-flags: --crate-type lib -C opt-level=3
 
 fn conjure<T>() -> T {
     panic!()

--- a/tests/crashes/146965.rs
+++ b/tests/crashes/146965.rs
@@ -1,0 +1,29 @@
+//@ known-bug: #146965
+//@ compile-flags: --crate-type lib
+
+fn conjure<T>() -> T {
+    panic!()
+}
+
+pub trait Ring {
+    type Element;
+}
+impl<T> Ring for T {
+    type Element = u16;
+}
+
+// Removing the : Ring bound makes it not ICE
+fn map_coeff<T: Ring>(f: impl Fn(<T as Ring>::Element)) {
+    let c = conjure::<<T as Ring>::Element>();
+    f(c);
+}
+
+// Adding a : Ring bound makes it not ICE
+fn gcd<T>() {
+    map_coeff::<T>(|_: u16| {});
+}
+
+// Removing the : Ring bound makes it not ICE
+pub fn bivariate_factorization<T: Ring>() {
+    gcd::<T>();
+}

--- a/tests/crashes/150263.rs
+++ b/tests/crashes/150263.rs
@@ -1,0 +1,21 @@
+//@ known-bug: #150263
+//@ compile-flags: --crate-type lib
+
+pub trait Scope {
+    type Timestamp;
+}
+impl<G> Scope for G {
+    type Timestamp = ();
+}
+
+pub fn create<G: Scope>() {
+    enter::<G>();
+}
+
+fn enter<G>() {
+    unary::<G>(|_: <G as Scope>::Timestamp| {});
+}
+
+fn unary<G: Scope>(constructor: impl FnOnce(G::Timestamp)) {
+    constructor(None.unwrap());
+}

--- a/tests/crashes/150263.rs
+++ b/tests/crashes/150263.rs
@@ -1,5 +1,5 @@
 //@ known-bug: #150263
-//@ compile-flags: --crate-type lib
+//@ compile-flags: --crate-type lib -C opt-level=3
 
 pub trait Scope {
     type Timestamp;


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

As of when I opened this PR, these two issues, rust-lang/rust#146965 and rust-lang/rust#150263, have been assigned as P-high.
Per [the dev guide](https://rustc-dev-guide.rust-lang.org/tests/compiletest#crash-tests), I am adding these "untracked" crashes to the test suite, if that's okay with the relevant stakeholders.

(I used to contribute to [glacier](https://github.com/rust-lang/glacier) about 5-6 years ago. Let me know if anything needs to change in these tests.)
