### PR TITLE
treat `if let` guard bindings as fallible for borrow checking

### DIFF
--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -2452,18 +2452,33 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 self.cfg.push_assign(block, scrutinee_source_info, Place::from(temp), borrow);
             }
 
-            let mut guard_span = rustc_span::DUMMY_SP;
+            let guard_span = self.thir[guard].span;
+            let source_info = self.source_info(guard_span);
 
             let (post_guard_block, otherwise_post_guard_block) =
                 self.in_if_then_scope(match_scope, guard_span, |this| {
-                    guard_span = this.thir[guard].span;
-                    this.then_else_break(
+                    let guard_end = this.then_else_break(
                         block,
                         guard,
                         None, // Use `self.local_scope()` as the temp scope
                         this.source_info(arm.span),
                         DeclareLetBindings::No, // For guards, `let` bindings are declared separately
-                    )
+                    );
+                    // Falsely branch to always treat guards as fallible when borrow-checking. In
+                    // particular, this means that `if let` guards' by-move bindings are treated as
+                    // as fallible. This matters because we can encounter errors after moving out
+                    // of a guard condition's scrutinee if we can then reach other arms (or a later
+                    // sub-branch's instance of this same guard). See #153263.
+                    let real_post_guard_block = this.cfg.start_new_block();
+                    let false_failure_block = this.cfg.start_new_block();
+                    this.false_edges(
+                        guard_end.into_block(),
+                        real_post_guard_block,
+                        false_failure_block,
+                        source_info,
+                    );
+                    this.break_for_else(false_failure_block, source_info);
+                    real_post_guard_block.unit()
                 });
 
             // If this isn't the final sub-branch being lowered, we need to unschedule drops of
@@ -2473,7 +2488,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 self.clear_match_arm_and_guard_scopes(arm.scope);
             }
 
-            let source_info = self.source_info(guard_span);
             let guard_end = self.source_info(tcx.sess.source_map().end_point(guard_span));
             let guard_frame = self.guard_context.pop().unwrap();
             debug!("Exiting guard building context with locals: {:?}", guard_frame);

--- a/tests/mir-opt/async_closure_fake_read_for_by_move.foo-{closure#0}-{closure#0}.built.after.mir
+++ b/tests/mir-opt/async_closure_fake_read_for_by_move.foo-{closure#0}-{closure#0}.built.after.mir
@@ -18,7 +18,7 @@ yields ()
 
     bb1: {
         _0 = const ();
-        goto -> bb10;
+        goto -> bb13;
     }
 
     bb2: {
@@ -47,34 +47,46 @@ yields ()
 
     bb7: {
         StorageDead(_6);
-        FakeRead(ForMatchGuard, _3);
-        FakeRead(ForMatchGuard, _4);
-        _0 = const ();
-        goto -> bb10;
+        falseEdge -> [real: bb9, imaginary: bb10];
     }
 
     bb8: {
-        goto -> bb9;
+        goto -> bb11;
     }
 
     bb9: {
-        StorageDead(_6);
-        goto -> bb6;
+        FakeRead(ForMatchGuard, _3);
+        FakeRead(ForMatchGuard, _4);
+        _0 = const ();
+        goto -> bb13;
     }
 
     bb10: {
-        drop(_1) -> [return: bb11, unwind: bb13, drop: bb12];
+        goto -> bb12;
     }
 
     bb11: {
-        return;
+        StorageDead(_6);
+        goto -> bb12;
     }
 
     bb12: {
+        goto -> bb6;
+    }
+
+    bb13: {
+        drop(_1) -> [return: bb14, unwind: bb16, drop: bb15];
+    }
+
+    bb14: {
+        return;
+    }
+
+    bb15: {
         coroutine_drop;
     }
 
-    bb13 (cleanup): {
+    bb16 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/async_closure_fake_read_for_by_move.foo-{closure#0}-{synthetic#0}.built.after.mir
+++ b/tests/mir-opt/async_closure_fake_read_for_by_move.foo-{closure#0}-{synthetic#0}.built.after.mir
@@ -18,7 +18,7 @@ yields ()
 
     bb1: {
         _0 = const ();
-        goto -> bb6;
+        goto -> bb8;
     }
 
     bb2: {
@@ -30,35 +30,43 @@ yields ()
         nop;
         StorageLive(_6);
         _6 = const true;
-        switchInt(move _6) -> [0: bb5, otherwise: bb4];
+        switchInt(move _6) -> [0: bb7, otherwise: bb5];
     }
 
     bb4: {
-        StorageDead(_6);
-        FakeRead(ForMatchGuard, _3);
-        FakeRead(ForMatchGuard, _4);
-        _0 = const ();
-        goto -> bb6;
+        falseEdge -> [real: bb1, imaginary: bb1];
     }
 
     bb5: {
         StorageDead(_6);
-        falseEdge -> [real: bb1, imaginary: bb1];
+        falseEdge -> [real: bb6, imaginary: bb4];
     }
 
     bb6: {
-        drop(_1) -> [return: bb7, unwind: bb9, drop: bb8];
+        FakeRead(ForMatchGuard, _3);
+        FakeRead(ForMatchGuard, _4);
+        _0 = const ();
+        goto -> bb8;
     }
 
     bb7: {
-        return;
+        StorageDead(_6);
+        goto -> bb4;
     }
 
     bb8: {
+        drop(_1) -> [return: bb9, unwind: bb11, drop: bb10];
+    }
+
+    bb9: {
+        return;
+    }
+
+    bb10: {
         coroutine_drop;
     }
 
-    bb9 (cleanup): {
+    bb11 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/match/match_false_edges.full_tested_match.built.after.mir
+++ b/tests/mir-opt/building/match/match_false_edges.full_tested_match.built.after.mir
@@ -50,7 +50,7 @@ fn full_tested_match() -> () {
 
     bb5: {
         _1 = (const 3_i32, const 3_i32);
-        goto -> bb14;
+        goto -> bb17;
     }
 
     bb6: {
@@ -65,7 +65,7 @@ fn full_tested_match() -> () {
         _1 = (const 2_i32, move _10);
         StorageDead(_10);
         StorageDead(_9);
-        goto -> bb14;
+        goto -> bb17;
     }
 
     bb8: {
@@ -73,7 +73,7 @@ fn full_tested_match() -> () {
         _6 = &((_2 as Some).0: i32);
         _3 = &fake shallow _2;
         StorageLive(_7);
-        _7 = guard() -> [return: bb10, unwind: bb16];
+        _7 = guard() -> [return: bb10, unwind: bb19];
     }
 
     bb9: {
@@ -86,6 +86,14 @@ fn full_tested_match() -> () {
 
     bb11: {
         StorageDead(_7);
+        falseEdge -> [real: bb13, imaginary: bb14];
+    }
+
+    bb12: {
+        goto -> bb15;
+    }
+
+    bb13: {
         FakeRead(ForMatchGuard, _3);
         FakeRead(ForGuardBinding, _6);
         StorageLive(_5);
@@ -96,20 +104,24 @@ fn full_tested_match() -> () {
         StorageDead(_8);
         StorageDead(_5);
         StorageDead(_6);
-        goto -> bb14;
+        goto -> bb17;
     }
 
-    bb12: {
-        goto -> bb13;
+    bb14: {
+        goto -> bb16;
     }
 
-    bb13: {
+    bb15: {
         StorageDead(_7);
+        goto -> bb16;
+    }
+
+    bb16: {
         StorageDead(_6);
         goto -> bb9;
     }
 
-    bb14: {
+    bb17: {
         PlaceMention(_1);
         StorageDead(_2);
         StorageDead(_1);
@@ -117,12 +129,12 @@ fn full_tested_match() -> () {
         return;
     }
 
-    bb15: {
+    bb18: {
         FakeRead(ForMatchedPlace(None), _1);
         unreachable;
     }
 
-    bb16 (cleanup): {
+    bb19 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/match/match_false_edges.full_tested_match2.built.after.mir
+++ b/tests/mir-opt/building/match/match_false_edges.full_tested_match2.built.after.mir
@@ -48,7 +48,7 @@ fn full_tested_match2() -> () {
         _1 = (const 2_i32, move _10);
         StorageDead(_10);
         StorageDead(_9);
-        goto -> bb14;
+        goto -> bb17;
     }
 
     bb4: {
@@ -65,7 +65,7 @@ fn full_tested_match2() -> () {
 
     bb7: {
         _1 = (const 3_i32, const 3_i32);
-        goto -> bb14;
+        goto -> bb17;
     }
 
     bb8: {
@@ -73,7 +73,7 @@ fn full_tested_match2() -> () {
         _6 = &((_2 as Some).0: i32);
         _3 = &fake shallow _2;
         StorageLive(_7);
-        _7 = guard() -> [return: bb10, unwind: bb16];
+        _7 = guard() -> [return: bb10, unwind: bb19];
     }
 
     bb9: {
@@ -86,6 +86,14 @@ fn full_tested_match2() -> () {
 
     bb11: {
         StorageDead(_7);
+        falseEdge -> [real: bb13, imaginary: bb14];
+    }
+
+    bb12: {
+        goto -> bb15;
+    }
+
+    bb13: {
         FakeRead(ForMatchGuard, _3);
         FakeRead(ForGuardBinding, _6);
         StorageLive(_5);
@@ -96,20 +104,24 @@ fn full_tested_match2() -> () {
         StorageDead(_8);
         StorageDead(_5);
         StorageDead(_6);
-        goto -> bb14;
+        goto -> bb17;
     }
 
-    bb12: {
-        goto -> bb13;
+    bb14: {
+        goto -> bb16;
     }
 
-    bb13: {
+    bb15: {
         StorageDead(_7);
+        goto -> bb16;
+    }
+
+    bb16: {
         StorageDead(_6);
         goto -> bb9;
     }
 
-    bb14: {
+    bb17: {
         PlaceMention(_1);
         StorageDead(_2);
         StorageDead(_1);
@@ -117,12 +129,12 @@ fn full_tested_match2() -> () {
         return;
     }
 
-    bb15: {
+    bb18: {
         FakeRead(ForMatchedPlace(None), _1);
         unreachable;
     }
 
-    bb16 (cleanup): {
+    bb19 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/match/match_false_edges.main.built.after.mir
+++ b/tests/mir-opt/building/match/match_false_edges.main.built.after.mir
@@ -64,7 +64,7 @@ fn main() -> () {
         _14 = copy _2;
         _1 = const 4_i32;
         StorageDead(_14);
-        goto -> bb22;
+        goto -> bb28;
     }
 
     bb6: {
@@ -87,7 +87,7 @@ fn main() -> () {
         StorageLive(_12);
         StorageLive(_13);
         _13 = copy (*_11);
-        _12 = guard2(move _13) -> [return: bb18, unwind: bb24];
+        _12 = guard2(move _13) -> [return: bb21, unwind: bb30];
     }
 
     bb10: {
@@ -99,7 +99,7 @@ fn main() -> () {
         _9 = copy _2;
         _1 = const 2_i32;
         StorageDead(_9);
-        goto -> bb22;
+        goto -> bb28;
     }
 
     bb12: {
@@ -107,7 +107,7 @@ fn main() -> () {
         _7 = &((_2 as Some).0: i32);
         _3 = &fake shallow _2;
         StorageLive(_8);
-        _8 = guard() -> [return: bb14, unwind: bb24];
+        _8 = guard() -> [return: bb14, unwind: bb30];
     }
 
     bb13: {
@@ -120,6 +120,14 @@ fn main() -> () {
 
     bb15: {
         StorageDead(_8);
+        falseEdge -> [real: bb17, imaginary: bb18];
+    }
+
+    bb16: {
+        goto -> bb19;
+    }
+
+    bb17: {
         FakeRead(ForMatchGuard, _3);
         FakeRead(ForGuardBinding, _7);
         StorageLive(_6);
@@ -127,26 +135,38 @@ fn main() -> () {
         _1 = const 1_i32;
         StorageDead(_6);
         StorageDead(_7);
-        goto -> bb22;
+        goto -> bb28;
     }
 
-    bb16: {
-        goto -> bb17;
+    bb18: {
+        goto -> bb20;
     }
 
-    bb17: {
+    bb19: {
         StorageDead(_8);
+        goto -> bb20;
+    }
+
+    bb20: {
         StorageDead(_7);
         goto -> bb13;
     }
 
-    bb18: {
-        switchInt(move _12) -> [0: bb20, otherwise: bb19];
+    bb21: {
+        switchInt(move _12) -> [0: bb23, otherwise: bb22];
     }
 
-    bb19: {
+    bb22: {
         StorageDead(_13);
         StorageDead(_12);
+        falseEdge -> [real: bb24, imaginary: bb25];
+    }
+
+    bb23: {
+        goto -> bb26;
+    }
+
+    bb24: {
         FakeRead(ForMatchGuard, _3);
         FakeRead(ForGuardBinding, _11);
         StorageLive(_10);
@@ -154,21 +174,25 @@ fn main() -> () {
         _1 = const 3_i32;
         StorageDead(_10);
         StorageDead(_11);
-        goto -> bb22;
+        goto -> bb28;
     }
 
-    bb20: {
-        goto -> bb21;
+    bb25: {
+        goto -> bb27;
     }
 
-    bb21: {
+    bb26: {
         StorageDead(_13);
         StorageDead(_12);
+        goto -> bb27;
+    }
+
+    bb27: {
         StorageDead(_11);
         goto -> bb10;
     }
 
-    bb22: {
+    bb28: {
         PlaceMention(_1);
         StorageDead(_2);
         StorageDead(_1);
@@ -176,12 +200,12 @@ fn main() -> () {
         return;
     }
 
-    bb23: {
+    bb29: {
         FakeRead(ForMatchedPlace(None), _1);
         unreachable;
     }
 
-    bb24 (cleanup): {
+    bb30 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/match/sort_candidates.constant_eq.SimplifyCfg-initial.after.mir
+++ b/tests/mir-opt/building/match/sort_candidates.constant_eq.SimplifyCfg-initial.after.mir
@@ -27,7 +27,7 @@ fn constant_eq(_1: &str, _2: bool) -> u32 {
         StorageDead(_4);
         PlaceMention(_3);
         _11 = &(*(_3.0: &str));
-        _12 = <str as PartialEq>::eq(copy _11, const "a") -> [return: bb9, unwind: bb19];
+        _12 = <str as PartialEq>::eq(copy _11, const "a") -> [return: bb9, unwind: bb21];
     }
 
     bb1: {
@@ -48,7 +48,7 @@ fn constant_eq(_1: &str, _2: bool) -> u32 {
 
     bb5: {
         _9 = &(*(_3.0: &str));
-        _10 = <str as PartialEq>::eq(copy _9, const "b") -> [return: bb8, unwind: bb19];
+        _10 = <str as PartialEq>::eq(copy _9, const "b") -> [return: bb8, unwind: bb21];
     }
 
     bb6: {
@@ -69,7 +69,7 @@ fn constant_eq(_1: &str, _2: bool) -> u32 {
 
     bb10: {
         _0 = const 5_u32;
-        goto -> bb18;
+        goto -> bb20;
     }
 
     bb11: {
@@ -78,17 +78,17 @@ fn constant_eq(_1: &str, _2: bool) -> u32 {
 
     bb12: {
         _0 = const 4_u32;
-        goto -> bb18;
+        goto -> bb20;
     }
 
     bb13: {
         _0 = const 3_u32;
-        goto -> bb18;
+        goto -> bb20;
     }
 
     bb14: {
         _0 = const 2_u32;
-        goto -> bb18;
+        goto -> bb20;
     }
 
     bb15: {
@@ -97,29 +97,37 @@ fn constant_eq(_1: &str, _2: bool) -> u32 {
         _8 = &fake shallow (_3.1: bool);
         StorageLive(_13);
         _13 = const true;
-        switchInt(move _13) -> [0: bb17, otherwise: bb16];
+        switchInt(move _13) -> [0: bb19, otherwise: bb17];
     }
 
     bb16: {
-        StorageDead(_13);
-        FakeRead(ForMatchGuard, _6);
-        FakeRead(ForMatchGuard, _7);
-        FakeRead(ForMatchGuard, _8);
-        _0 = const 1_u32;
-        goto -> bb18;
+        falseEdge -> [real: bb3, imaginary: bb5];
     }
 
     bb17: {
         StorageDead(_13);
-        falseEdge -> [real: bb3, imaginary: bb5];
+        falseEdge -> [real: bb18, imaginary: bb16];
     }
 
     bb18: {
+        FakeRead(ForMatchGuard, _6);
+        FakeRead(ForMatchGuard, _7);
+        FakeRead(ForMatchGuard, _8);
+        _0 = const 1_u32;
+        goto -> bb20;
+    }
+
+    bb19: {
+        StorageDead(_13);
+        goto -> bb16;
+    }
+
+    bb20: {
         StorageDead(_3);
         return;
     }
 
-    bb19 (cleanup): {
+    bb21 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/match/sort_candidates.disjoint_ranges.SimplifyCfg-initial.after.mir
+++ b/tests/mir-opt/building/match/sort_candidates.disjoint_ranges.SimplifyCfg-initial.after.mir
@@ -19,7 +19,7 @@ fn disjoint_ranges(_1: i32, _2: bool) -> u32 {
 
     bb1: {
         _0 = const 3_u32;
-        goto -> bb14;
+        goto -> bb16;
     }
 
     bb2: {
@@ -55,34 +55,42 @@ fn disjoint_ranges(_1: i32, _2: bool) -> u32 {
 
     bb9: {
         _0 = const 2_u32;
-        goto -> bb14;
+        goto -> bb16;
     }
 
     bb10: {
         _0 = const 1_u32;
-        goto -> bb14;
+        goto -> bb16;
     }
 
     bb11: {
         _3 = &fake shallow _1;
         StorageLive(_8);
         _8 = copy _2;
-        switchInt(move _8) -> [0: bb13, otherwise: bb12];
+        switchInt(move _8) -> [0: bb15, otherwise: bb13];
     }
 
     bb12: {
-        StorageDead(_8);
-        FakeRead(ForMatchGuard, _3);
-        _0 = const 0_u32;
-        goto -> bb14;
+        falseEdge -> [real: bb1, imaginary: bb3];
     }
 
     bb13: {
         StorageDead(_8);
-        falseEdge -> [real: bb1, imaginary: bb3];
+        falseEdge -> [real: bb14, imaginary: bb12];
     }
 
     bb14: {
+        FakeRead(ForMatchGuard, _3);
+        _0 = const 0_u32;
+        goto -> bb16;
+    }
+
+    bb15: {
+        StorageDead(_8);
+        goto -> bb12;
+    }
+
+    bb16: {
         return;
     }
 }

--- a/tests/mir-opt/match_arm_scopes.complicated_match.panic-abort.SimplifyCfg-initial.after-ElaborateDrops.after.diff
+++ b/tests/mir-opt/match_arm_scopes.complicated_match.panic-abort.SimplifyCfg-initial.after-ElaborateDrops.after.diff
@@ -63,7 +63,7 @@
           _15 = copy (_2.1: bool);
           StorageLive(_16);
           _16 = move (_2.2: std::string::String);
--         goto -> bb20;
+-         goto -> bb24;
 +         goto -> bb17;
       }
   
@@ -73,7 +73,7 @@
           _15 = copy (_2.1: bool);
           StorageLive(_16);
           _16 = move (_2.2: std::string::String);
--         goto -> bb20;
+-         goto -> bb24;
 +         goto -> bb17;
       }
   
@@ -103,14 +103,14 @@
           StorageLive(_12);
           StorageLive(_13);
           _13 = copy _1;
--         switchInt(move _13) -> [0: bb16, otherwise: bb15];
+-         switchInt(move _13) -> [0: bb18, otherwise: bb17];
 +         switchInt(move _13) -> [0: bb13, otherwise: bb12];
       }
   
 -     bb10: {
 +     bb7: {
           _0 = const 1_i32;
--         drop(_7) -> [return: bb19, unwind: bb25];
+-         drop(_7) -> [return: bb23, unwind: bb29];
 +         drop(_7) -> [return: bb16, unwind: bb22];
       }
   
@@ -119,7 +119,7 @@
           _0 = const 3_i32;
           StorageDead(_10);
           StorageDead(_9);
--         goto -> bb23;
+-         goto -> bb27;
 +         goto -> bb20;
       }
   
@@ -134,6 +134,16 @@
 +     bb10: {
           StorageDead(_10);
           StorageDead(_9);
+-         falseEdge -> [real: bb15, imaginary: bb16];
+-     }
+- 
+-     bb14: {
+-         StorageDead(_10);
+-         StorageDead(_9);
+-         goto -> bb16;
+-     }
+- 
+-     bb15: {
 -         FakeRead(ForMatchGuard, _3);
 -         FakeRead(ForMatchGuard, _4);
 -         FakeRead(ForGuardBinding, _6);
@@ -146,36 +156,46 @@
 +         goto -> bb7;
       }
   
--     bb14: {
+-     bb16: {
 +     bb11: {
-          StorageDead(_10);
-          StorageDead(_9);
++         StorageDead(_10);
++         StorageDead(_9);
           StorageDead(_8);
           StorageDead(_6);
 -         falseEdge -> [real: bb3, imaginary: bb3];
 +         goto -> bb2;
       }
   
--     bb15: {
+-     bb17: {
 +     bb12: {
           _0 = const 3_i32;
           StorageDead(_13);
           StorageDead(_12);
--         goto -> bb23;
+-         goto -> bb27;
 +         goto -> bb20;
       }
   
--     bb16: {
+-     bb18: {
 +     bb13: {
           _12 = copy (*_6);
--         switchInt(move _12) -> [0: bb18, otherwise: bb17];
+-         switchInt(move _12) -> [0: bb20, otherwise: bb19];
 +         switchInt(move _12) -> [0: bb15, otherwise: bb14];
       }
   
--     bb17: {
+-     bb19: {
 +     bb14: {
           StorageDead(_13);
           StorageDead(_12);
+-         falseEdge -> [real: bb21, imaginary: bb22];
+-     }
+- 
+-     bb20: {
+-         StorageDead(_13);
+-         StorageDead(_12);
+-         goto -> bb22;
+-     }
+- 
+-     bb21: {
 -         FakeRead(ForMatchGuard, _3);
 -         FakeRead(ForMatchGuard, _4);
 -         FakeRead(ForGuardBinding, _6);
@@ -188,67 +208,67 @@
 +         goto -> bb7;
       }
   
--     bb18: {
+-     bb22: {
 +     bb15: {
-          StorageDead(_13);
-          StorageDead(_12);
++         StorageDead(_13);
++         StorageDead(_12);
           StorageDead(_8);
           StorageDead(_6);
 -         falseEdge -> [real: bb1, imaginary: bb1];
 +         goto -> bb1;
       }
   
--     bb19: {
+-     bb23: {
 +     bb16: {
           StorageDead(_7);
           StorageDead(_5);
           StorageDead(_8);
           StorageDead(_6);
--         goto -> bb22;
+-         goto -> bb26;
 +         goto -> bb19;
       }
   
--     bb20: {
+-     bb24: {
 +     bb17: {
           _0 = const 2_i32;
--         drop(_16) -> [return: bb21, unwind: bb25];
+-         drop(_16) -> [return: bb25, unwind: bb29];
 +         drop(_16) -> [return: bb18, unwind: bb22];
       }
   
--     bb21: {
+-     bb25: {
 +     bb18: {
           StorageDead(_16);
           StorageDead(_15);
--         goto -> bb22;
+-         goto -> bb26;
 +         goto -> bb19;
       }
   
--     bb22: {
--         drop(_2) -> [return: bb24, unwind: bb26];
+-     bb26: {
+-         drop(_2) -> [return: bb28, unwind: bb30];
 +     bb19: {
 +         goto -> bb26;
       }
   
--     bb23: {
+-     bb27: {
 +     bb20: {
           StorageDead(_8);
           StorageDead(_6);
--         drop(_2) -> [return: bb24, unwind: bb26];
+-         drop(_2) -> [return: bb28, unwind: bb30];
 +         drop(_2) -> [return: bb21, unwind: bb23];
       }
   
--     bb24: {
+-     bb28: {
 +     bb21: {
           return;
       }
   
--     bb25 (cleanup): {
--         drop(_2) -> [return: bb26, unwind terminate(cleanup)];
+-     bb29 (cleanup): {
+-         drop(_2) -> [return: bb30, unwind terminate(cleanup)];
 +     bb22 (cleanup): {
 +         goto -> bb27;
       }
   
--     bb26 (cleanup): {
+-     bb30 (cleanup): {
 +     bb23 (cleanup): {
           resume;
 +     }

--- a/tests/mir-opt/match_arm_scopes.complicated_match.panic-unwind.SimplifyCfg-initial.after-ElaborateDrops.after.diff
+++ b/tests/mir-opt/match_arm_scopes.complicated_match.panic-unwind.SimplifyCfg-initial.after-ElaborateDrops.after.diff
@@ -63,7 +63,7 @@
           _15 = copy (_2.1: bool);
           StorageLive(_16);
           _16 = move (_2.2: std::string::String);
--         goto -> bb20;
+-         goto -> bb24;
 +         goto -> bb17;
       }
   
@@ -73,7 +73,7 @@
           _15 = copy (_2.1: bool);
           StorageLive(_16);
           _16 = move (_2.2: std::string::String);
--         goto -> bb20;
+-         goto -> bb24;
 +         goto -> bb17;
       }
   
@@ -103,14 +103,14 @@
           StorageLive(_12);
           StorageLive(_13);
           _13 = copy _1;
--         switchInt(move _13) -> [0: bb16, otherwise: bb15];
+-         switchInt(move _13) -> [0: bb18, otherwise: bb17];
 +         switchInt(move _13) -> [0: bb13, otherwise: bb12];
       }
   
 -     bb10: {
 +     bb7: {
           _0 = const 1_i32;
--         drop(_7) -> [return: bb19, unwind: bb25];
+-         drop(_7) -> [return: bb23, unwind: bb29];
 +         drop(_7) -> [return: bb16, unwind: bb22];
       }
   
@@ -119,7 +119,7 @@
           _0 = const 3_i32;
           StorageDead(_10);
           StorageDead(_9);
--         goto -> bb23;
+-         goto -> bb27;
 +         goto -> bb20;
       }
   
@@ -134,6 +134,16 @@
 +     bb10: {
           StorageDead(_10);
           StorageDead(_9);
+-         falseEdge -> [real: bb15, imaginary: bb16];
+-     }
+- 
+-     bb14: {
+-         StorageDead(_10);
+-         StorageDead(_9);
+-         goto -> bb16;
+-     }
+- 
+-     bb15: {
 -         FakeRead(ForMatchGuard, _3);
 -         FakeRead(ForMatchGuard, _4);
 -         FakeRead(ForGuardBinding, _6);
@@ -146,36 +156,46 @@
 +         goto -> bb7;
       }
   
--     bb14: {
+-     bb16: {
 +     bb11: {
-          StorageDead(_10);
-          StorageDead(_9);
++         StorageDead(_10);
++         StorageDead(_9);
           StorageDead(_8);
           StorageDead(_6);
 -         falseEdge -> [real: bb3, imaginary: bb3];
 +         goto -> bb2;
       }
   
--     bb15: {
+-     bb17: {
 +     bb12: {
           _0 = const 3_i32;
           StorageDead(_13);
           StorageDead(_12);
--         goto -> bb23;
+-         goto -> bb27;
 +         goto -> bb20;
       }
   
--     bb16: {
+-     bb18: {
 +     bb13: {
           _12 = copy (*_6);
--         switchInt(move _12) -> [0: bb18, otherwise: bb17];
+-         switchInt(move _12) -> [0: bb20, otherwise: bb19];
 +         switchInt(move _12) -> [0: bb15, otherwise: bb14];
       }
   
--     bb17: {
+-     bb19: {
 +     bb14: {
           StorageDead(_13);
           StorageDead(_12);
+-         falseEdge -> [real: bb21, imaginary: bb22];
+-     }
+- 
+-     bb20: {
+-         StorageDead(_13);
+-         StorageDead(_12);
+-         goto -> bb22;
+-     }
+- 
+-     bb21: {
 -         FakeRead(ForMatchGuard, _3);
 -         FakeRead(ForMatchGuard, _4);
 -         FakeRead(ForGuardBinding, _6);
@@ -188,67 +208,67 @@
 +         goto -> bb7;
       }
   
--     bb18: {
+-     bb22: {
 +     bb15: {
-          StorageDead(_13);
-          StorageDead(_12);
++         StorageDead(_13);
++         StorageDead(_12);
           StorageDead(_8);
           StorageDead(_6);
 -         falseEdge -> [real: bb1, imaginary: bb1];
 +         goto -> bb1;
       }
   
--     bb19: {
+-     bb23: {
 +     bb16: {
           StorageDead(_7);
           StorageDead(_5);
           StorageDead(_8);
           StorageDead(_6);
--         goto -> bb22;
+-         goto -> bb26;
 +         goto -> bb19;
       }
   
--     bb20: {
+-     bb24: {
 +     bb17: {
           _0 = const 2_i32;
--         drop(_16) -> [return: bb21, unwind: bb25];
+-         drop(_16) -> [return: bb25, unwind: bb29];
 +         drop(_16) -> [return: bb18, unwind: bb22];
       }
   
--     bb21: {
+-     bb25: {
 +     bb18: {
           StorageDead(_16);
           StorageDead(_15);
--         goto -> bb22;
+-         goto -> bb26;
 +         goto -> bb19;
       }
   
--     bb22: {
--         drop(_2) -> [return: bb24, unwind: bb26];
+-     bb26: {
+-         drop(_2) -> [return: bb28, unwind: bb30];
 +     bb19: {
 +         goto -> bb26;
       }
   
--     bb23: {
+-     bb27: {
 +     bb20: {
           StorageDead(_8);
           StorageDead(_6);
--         drop(_2) -> [return: bb24, unwind: bb26];
+-         drop(_2) -> [return: bb28, unwind: bb30];
 +         drop(_2) -> [return: bb21, unwind: bb23];
       }
   
--     bb24: {
+-     bb28: {
 +     bb21: {
           return;
       }
   
--     bb25 (cleanup): {
--         drop(_2) -> [return: bb26, unwind terminate(cleanup)];
+-     bb29 (cleanup): {
+-         drop(_2) -> [return: bb30, unwind terminate(cleanup)];
 +     bb22 (cleanup): {
 +         goto -> bb27;
       }
   
--     bb26 (cleanup): {
+-     bb30 (cleanup): {
 +     bb23 (cleanup): {
           resume;
 +     }

--- a/tests/mir-opt/remove_fake_borrows.match_guard.CleanupPostBorrowck.panic-abort.diff
+++ b/tests/mir-opt/remove_fake_borrows.match_guard.CleanupPostBorrowck.panic-abort.diff
@@ -20,7 +20,7 @@
   
       bb1: {
           _0 = const 1_i32;
-          goto -> bb7;
+          goto -> bb9;
       }
   
       bb2: {
@@ -43,11 +43,21 @@
 +         nop;
           StorageLive(_8);
           _8 = copy _2;
-          switchInt(move _8) -> [0: bb6, otherwise: bb5];
+          switchInt(move _8) -> [0: bb8, otherwise: bb6];
       }
   
       bb5: {
+-         falseEdge -> [real: bb1, imaginary: bb1];
++         goto -> bb1;
+      }
+  
+      bb6: {
           StorageDead(_8);
+-         falseEdge -> [real: bb7, imaginary: bb5];
++         goto -> bb7;
+      }
+  
+      bb7: {
 -         FakeRead(ForMatchGuard, _3);
 -         FakeRead(ForMatchGuard, _4);
 -         FakeRead(ForMatchGuard, _5);
@@ -57,16 +67,15 @@
 +         nop;
 +         nop;
           _0 = const 0_i32;
-          goto -> bb7;
+          goto -> bb9;
       }
   
-      bb6: {
+      bb8: {
           StorageDead(_8);
--         falseEdge -> [real: bb1, imaginary: bb1];
-+         goto -> bb1;
+          goto -> bb5;
       }
   
-      bb7: {
+      bb9: {
           return;
       }
   }

--- a/tests/mir-opt/remove_fake_borrows.match_guard.CleanupPostBorrowck.panic-unwind.diff
+++ b/tests/mir-opt/remove_fake_borrows.match_guard.CleanupPostBorrowck.panic-unwind.diff
@@ -20,7 +20,7 @@
   
       bb1: {
           _0 = const 1_i32;
-          goto -> bb7;
+          goto -> bb9;
       }
   
       bb2: {
@@ -43,11 +43,21 @@
 +         nop;
           StorageLive(_8);
           _8 = copy _2;
-          switchInt(move _8) -> [0: bb6, otherwise: bb5];
+          switchInt(move _8) -> [0: bb8, otherwise: bb6];
       }
   
       bb5: {
+-         falseEdge -> [real: bb1, imaginary: bb1];
++         goto -> bb1;
+      }
+  
+      bb6: {
           StorageDead(_8);
+-         falseEdge -> [real: bb7, imaginary: bb5];
++         goto -> bb7;
+      }
+  
+      bb7: {
 -         FakeRead(ForMatchGuard, _3);
 -         FakeRead(ForMatchGuard, _4);
 -         FakeRead(ForMatchGuard, _5);
@@ -57,16 +67,15 @@
 +         nop;
 +         nop;
           _0 = const 0_i32;
-          goto -> bb7;
+          goto -> bb9;
       }
   
-      bb6: {
+      bb8: {
           StorageDead(_8);
--         falseEdge -> [real: bb1, imaginary: bb1];
-+         goto -> bb1;
+          goto -> bb5;
       }
   
-      bb7: {
+      bb9: {
           return;
       }
   }

--- a/tests/ui/drop/dynamic-drop.rs
+++ b/tests/ui/drop/dynamic-drop.rs
@@ -336,10 +336,11 @@ fn move_ref_pattern(a: &Allocator) {
 
 fn if_let_guard(a: &Allocator, c: bool, d: i32) {
     let foo = if c { Some(a.alloc()) } else { None };
+    let bar = if c { Some(a.alloc()) } else { None };
 
     match d == 0 {
         false if let Some(a) = foo => { let b = a; }
-        true if let true = { drop(foo.unwrap_or_else(|| a.alloc())); d == 1 } => {}
+        true if let true = { drop(bar.unwrap_or_else(|| a.alloc())); d == 1 } => {}
         _ => {}
     }
 }

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/move-guard-if-let-chain.edition2021.stderr
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/move-guard-if-let-chain.edition2021.stderr
@@ -15,6 +15,22 @@ LL |         (1, 2) if let ref y = x && c => (),
    |                       +++
 
 error[E0382]: use of moved value: `x`
+  --> $DIR/move-guard-if-let-chain.rs:26:23
+   |
+LL |     let x: Box<_> = Box::new(1);
+   |         - move occurs because `x` has type `Box<i32>`, which does not implement the `Copy` trait
+...
+LL |         (1, 2) if c && let y = x => (),
+   |                            - value moved here
+LL |         (1, 2) if let z = x => (),
+   |                       ^ value used here after move
+   |
+help: borrow this binding in the pattern to avoid moving the value
+   |
+LL |         (1, 2) if c && let ref y = x => (),
+   |                            +++
+
+error[E0382]: use of moved value: `x`
   --> $DIR/move-guard-if-let-chain.rs:38:23
    |
 LL |     let x: Box<_> = Box::new(1);
@@ -31,6 +47,22 @@ LL |         (1, _) if let ref y = x && c => (),
    |                       +++
 
 error[E0382]: use of moved value: `x`
+  --> $DIR/move-guard-if-let-chain.rs:50:23
+   |
+LL |     let x: Box<_> = Box::new(1);
+   |         - move occurs because `x` has type `Box<i32>`, which does not implement the `Copy` trait
+...
+LL |         (1, _) if c && let y = x => (),
+   |                            - value moved here
+LL |         (_, 2) if let z = x => (),
+   |                       ^ value used here after move
+   |
+help: borrow this binding in the pattern to avoid moving the value
+   |
+LL |         (1, _) if c && let ref y = x => (),
+   |                            +++
+
+error[E0382]: use of moved value: `x`
   --> $DIR/move-guard-if-let-chain.rs:61:32
    |
 LL |     let x: Box<_> = Box::new(1);
@@ -43,6 +75,20 @@ help: borrow this binding in the pattern to avoid moving the value
    |
 LL |         (1, _) | (_, 2) if let ref y = x && c => (),
    |                                +++
+
+error[E0382]: use of moved value: `x`
+  --> $DIR/move-guard-if-let-chain.rs:72:37
+   |
+LL |     let x: Box<_> = Box::new(1);
+   |         - move occurs because `x` has type `Box<i32>`, which does not implement the `Copy` trait
+...
+LL |         (1, _) | (_, 2) if c && let y = x => (),
+   |                                     ^ value used here after move
+   |
+help: borrow this binding in the pattern to avoid moving the value
+   |
+LL |         (1, _) | (_, 2) if c && let ref y = x => (),
+   |                                     +++
 
 error[E0382]: use of moved value: `x`
   --> $DIR/move-guard-if-let-chain.rs:84:16
@@ -61,6 +107,22 @@ LL |         (1, 2) if let ref y = x && c => false,
    |                       +++
 
 error[E0382]: use of moved value: `x`
+  --> $DIR/move-guard-if-let-chain.rs:95:16
+   |
+LL |     let x: Box<_> = Box::new(1);
+   |         - move occurs because `x` has type `Box<i32>`, which does not implement the `Copy` trait
+...
+LL |         (1, 2) if c && let y = x => false,
+   |                            - value moved here
+LL |         _ => { *x == 1 },
+   |                ^^ value used here after move
+   |
+help: borrow this binding in the pattern to avoid moving the value
+   |
+LL |         (1, 2) if c && let ref y = x => false,
+   |                            +++
+
+error[E0382]: use of moved value: `x`
   --> $DIR/move-guard-if-let-chain.rs:105:41
    |
 LL |     let x: Box<_> = Box::new(1);
@@ -76,6 +138,6 @@ help: borrow this binding in the pattern to avoid moving the value
 LL |         (1, 2) if let ref y = x && c && let z = x => false,
    |                       +++
 
-error: aborting due to 5 previous errors
+error: aborting due to 9 previous errors
 
 For more information about this error, try `rustc --explain E0382`.

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/move-guard-if-let-chain.edition2024.stderr
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/move-guard-if-let-chain.edition2024.stderr
@@ -15,6 +15,22 @@ LL |         (1, 2) if let ref y = x && c => (),
    |                       +++
 
 error[E0382]: use of moved value: `x`
+  --> $DIR/move-guard-if-let-chain.rs:26:23
+   |
+LL |     let x: Box<_> = Box::new(1);
+   |         - move occurs because `x` has type `Box<i32>`, which does not implement the `Copy` trait
+...
+LL |         (1, 2) if c && let y = x => (),
+   |                            - value moved here
+LL |         (1, 2) if let z = x => (),
+   |                       ^ value used here after move
+   |
+help: borrow this binding in the pattern to avoid moving the value
+   |
+LL |         (1, 2) if c && let ref y = x => (),
+   |                            +++
+
+error[E0382]: use of moved value: `x`
   --> $DIR/move-guard-if-let-chain.rs:38:23
    |
 LL |     let x: Box<_> = Box::new(1);
@@ -31,6 +47,22 @@ LL |         (1, _) if let ref y = x && c => (),
    |                       +++
 
 error[E0382]: use of moved value: `x`
+  --> $DIR/move-guard-if-let-chain.rs:50:23
+   |
+LL |     let x: Box<_> = Box::new(1);
+   |         - move occurs because `x` has type `Box<i32>`, which does not implement the `Copy` trait
+...
+LL |         (1, _) if c && let y = x => (),
+   |                            - value moved here
+LL |         (_, 2) if let z = x => (),
+   |                       ^ value used here after move
+   |
+help: borrow this binding in the pattern to avoid moving the value
+   |
+LL |         (1, _) if c && let ref y = x => (),
+   |                            +++
+
+error[E0382]: use of moved value: `x`
   --> $DIR/move-guard-if-let-chain.rs:61:32
    |
 LL |     let x: Box<_> = Box::new(1);
@@ -43,6 +75,20 @@ help: borrow this binding in the pattern to avoid moving the value
    |
 LL |         (1, _) | (_, 2) if let ref y = x && c => (),
    |                                +++
+
+error[E0382]: use of moved value: `x`
+  --> $DIR/move-guard-if-let-chain.rs:72:37
+   |
+LL |     let x: Box<_> = Box::new(1);
+   |         - move occurs because `x` has type `Box<i32>`, which does not implement the `Copy` trait
+...
+LL |         (1, _) | (_, 2) if c && let y = x => (),
+   |                                     ^ value used here after move
+   |
+help: borrow this binding in the pattern to avoid moving the value
+   |
+LL |         (1, _) | (_, 2) if c && let ref y = x => (),
+   |                                     +++
 
 error[E0382]: use of moved value: `x`
   --> $DIR/move-guard-if-let-chain.rs:84:16
@@ -61,6 +107,22 @@ LL |         (1, 2) if let ref y = x && c => false,
    |                       +++
 
 error[E0382]: use of moved value: `x`
+  --> $DIR/move-guard-if-let-chain.rs:95:16
+   |
+LL |     let x: Box<_> = Box::new(1);
+   |         - move occurs because `x` has type `Box<i32>`, which does not implement the `Copy` trait
+...
+LL |         (1, 2) if c && let y = x => false,
+   |                            - value moved here
+LL |         _ => { *x == 1 },
+   |                ^^ value used here after move
+   |
+help: borrow this binding in the pattern to avoid moving the value
+   |
+LL |         (1, 2) if c && let ref y = x => false,
+   |                            +++
+
+error[E0382]: use of moved value: `x`
   --> $DIR/move-guard-if-let-chain.rs:105:41
    |
 LL |     let x: Box<_> = Box::new(1);
@@ -76,6 +138,6 @@ help: borrow this binding in the pattern to avoid moving the value
 LL |         (1, 2) if let ref y = x && c && let z = x => false,
    |                       +++
 
-error: aborting due to 5 previous errors
+error: aborting due to 9 previous errors
 
 For more information about this error, try `rustc --explain E0382`.

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/move-guard-if-let-chain.rs
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/move-guard-if-let-chain.rs
@@ -4,7 +4,7 @@
 
 #![allow(irrefutable_let_patterns)]
 
-fn same_pattern(c: bool) {
+fn same_pattern_initial(c: bool) {
     let x: Box<_> = Box::new(1);
 
     let v = (1, 2);
@@ -16,19 +16,19 @@ fn same_pattern(c: bool) {
     }
 }
 
-fn same_pattern_ok(c: bool) {
+fn same_pattern_final(c: bool) {
     let x: Box<_> = Box::new(1);
 
     let v = (1, 2);
 
     match v {
         (1, 2) if c && let y = x => (),
-        (1, 2) if let z = x => (),
+        (1, 2) if let z = x => (), //~ ERROR use of moved value: `x`
         _ => (),
     }
 }
 
-fn different_patterns(c: bool) {
+fn different_patterns_initial(c: bool) {
     let x: Box<_> = Box::new(1);
 
     let v = (1, 2);
@@ -40,19 +40,19 @@ fn different_patterns(c: bool) {
     }
 }
 
-fn different_patterns_ok(c: bool) {
+fn different_patterns_final(c: bool) {
     let x: Box<_> = Box::new(1);
 
     let v = (1, 2);
 
     match v {
         (1, _) if c && let y = x => (),
-        (_, 2) if let z = x => (),
+        (_, 2) if let z = x => (), //~ ERROR use of moved value: `x`
         _ => (),
     }
 }
 
-fn or_pattern(c: bool) {
+fn or_pattern_initial(c: bool) {
     let x: Box<_> = Box::new(1);
 
     let v = (1, 2);
@@ -63,18 +63,18 @@ fn or_pattern(c: bool) {
     }
 }
 
-fn or_pattern_ok(c: bool) {
+fn or_pattern_final(c: bool) {
     let x: Box<_> = Box::new(1);
 
     let v = (1, 2);
 
     match v {
-        (1, _) | (_, 2) if c && let y = x => (),
+        (1, _) | (_, 2) if c && let y = x => (), //~ ERROR use of moved value: `x`
         _ => (),
     }
 }
 
-fn use_in_arm(c: bool) {
+fn use_in_arm_initial(c: bool) {
     let x: Box<_> = Box::new(1);
 
     let v = (1, 2);
@@ -85,14 +85,14 @@ fn use_in_arm(c: bool) {
     };
 }
 
-fn use_in_arm_ok(c: bool) {
+fn use_in_arm_final(c: bool) {
     let x: Box<_> = Box::new(1);
 
     let v = (1, 2);
 
     match v {
         (1, 2) if c && let y = x => false,
-        _ => { *x == 1 },
+        _ => { *x == 1 }, //~ ERROR use of moved value: `x`
     };
 }
 

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/move-guard-if-let.rs
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/move-guard-if-let.rs
@@ -1,7 +1,6 @@
-// Check that borrowck knows that moves in the pattern for if-let guards
+// Check that borrowck doesn't know that moves in the pattern for if-let guards
 // only happen when the pattern is matched.
-
-//@ check-pass
+// See <https://github.com/rust-lang/rust/issues/153263>.
 
 #![allow(irrefutable_let_patterns)]
 
@@ -12,7 +11,7 @@ fn same_pattern() {
 
     match v {
         (1, 2) if let y = x => (),
-        (1, 2) if let z = x => (),
+        (1, 2) if let z = x => (), //~ ERROR use of moved value: `x`
         _ => (),
     }
 }
@@ -23,7 +22,7 @@ fn or_pattern() {
     let v = (1, 2);
 
     match v {
-        (1, _) | (_, 2) if let y = x => (),
+        (1, _) | (_, 2) if let y = x => (), //~ ERROR use of moved value: `x`
         _ => (),
     }
 }
@@ -35,6 +34,6 @@ fn main() {
 
     match v {
         (1, 2) if let y = x => false,
-        _ => *x == 1,
+        _ => *x == 1, //~ ERROR use of moved value: `x`
     };
 }

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/move-guard-if-let.stderr
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/move-guard-if-let.stderr
@@ -1,0 +1,49 @@
+error[E0382]: use of moved value: `x`
+  --> $DIR/move-guard-if-let.rs:14:23
+   |
+LL |     let x: Box<_> = Box::new(1);
+   |         - move occurs because `x` has type `Box<i32>`, which does not implement the `Copy` trait
+...
+LL |         (1, 2) if let y = x => (),
+   |                       - value moved here
+LL |         (1, 2) if let z = x => (),
+   |                       ^ value used here after move
+   |
+help: borrow this binding in the pattern to avoid moving the value
+   |
+LL |         (1, 2) if let ref y = x => (),
+   |                       +++
+
+error[E0382]: use of moved value: `x`
+  --> $DIR/move-guard-if-let.rs:25:32
+   |
+LL |     let x: Box<_> = Box::new(1);
+   |         - move occurs because `x` has type `Box<i32>`, which does not implement the `Copy` trait
+...
+LL |         (1, _) | (_, 2) if let y = x => (),
+   |                                ^ value used here after move
+   |
+help: borrow this binding in the pattern to avoid moving the value
+   |
+LL |         (1, _) | (_, 2) if let ref y = x => (),
+   |                                +++
+
+error[E0382]: use of moved value: `x`
+  --> $DIR/move-guard-if-let.rs:37:14
+   |
+LL |     let x: Box<_> = Box::new(1);
+   |         - move occurs because `x` has type `Box<i32>`, which does not implement the `Copy` trait
+...
+LL |         (1, 2) if let y = x => false,
+   |                       - value moved here
+LL |         _ => *x == 1,
+   |              ^^ value used here after move
+   |
+help: borrow this binding in the pattern to avoid moving the value
+   |
+LL |         (1, 2) if let ref y = x => false,
+   |                       +++
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0382`.


### PR DESCRIPTION
An `if let` guard's bindings are part of the guard; for borrowck to see the whole guard as fallible, the bindings should be treated as fallible too. This matters for by-move bindings, where we can encounter errors if we can reach other guards or arms after moving out of a guard condition's scrutinee.

Closes https://github.com/rust-lang/rust/issues/153263

Since `if let` guards are stable on nightly, I imagine this needs a T-lang FCP to determine what the stable behavior should be.

r? Nadrieril or reassign