### PR TITLE
Limit obligation processing depth

### DIFF
--- a/compiler/rustc_data_structures/src/obligation_forest/mod.rs
+++ b/compiler/rustc_data_structures/src/obligation_forest/mod.rs
@@ -434,7 +434,10 @@ impl<O: ForestObligation> ObligationForest<O> {
     where
         P: ObligationProcessor<Obligation = O>,
     {
+        const MAX_PROCESS_COUNT: usize = 200_000;
         let mut outcome = P::OUT::new();
+
+        let mut process_count = 0;
 
         // Fixpoint computation: we repeat until the inner loop stalls.
         loop {
@@ -466,6 +469,15 @@ impl<O: ForestObligation> ObligationForest<O> {
                 // `self.active_cache`. This means that `self.active_cache` can get
                 // out of sync with `nodes`. It's not very common, but it does
                 // happen, and code in `compress` has to allow for it.
+
+                if process_count >= MAX_PROCESS_COUNT {
+                    // It's possible for nodes to recursively add obligations in an endless cycle,
+                    // for example https://github.com/rust-lang/rust/issues/152857.
+                    self.error_at(index);
+                    return outcome;
+                }
+
+                process_count += 1;
 
                 // This code is much less hot.
                 match processor.process_obligation(&mut node.obligation) {


### PR DESCRIPTION
Related to https://github.com/rust-lang/rust/issues/152857

It's possible for `ObligationForest::process_cycles` to miss more complex cycles and this can lead to an endless fixpoint loop since it never reaches a settled state. It's desirable to adjust `find_cycles_from_node` to catch the cycle in
https://github.com/rust-lang/rust/issues/152857. At the same time the nature of the code risks an endless loop by some other unexpected or unhandled cycle, so this PR aims to provide a basic limit to the depth of the loop.

The value of the constant was derived to be ~20x the highest value seen when compiling rustc itself. The top 10 values out of ~70 million invocations are:

```
┌───────┐
│ 10852 │
│ 10852 │
│ 10433 │
│ 10433 │
│ 10433 │
│ 10433 │
│ 8498  │
│ 8498  │
│ 6361  │
│ 6361  │
└───────┘
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
