### PR TITLE
tweak r-a default settings

### DIFF
--- a/src/bootstrap/src/core/build_steps/setup.rs
+++ b/src/bootstrap/src/core/build_steps/setup.rs
@@ -607,6 +607,7 @@ Select which editor you would like to set up [default: None]: ";
                 "1c43ead340b20792b91d02b08494ee68708e7e09f56b6766629b4b72079208f1",
                 "eec09a09452682060afd23dd5d3536ccac5615b3cdbf427366446901215fb9f6",
                 "cb653043852d9d5ff4a5be56407b859ff9928be055ad3f307eb309aad04765e6",
+                "e28b1930d16d3d8bbdeed7bd4a995613e648b49e08c9b6f5271880f520637fed",
             ],
             EditorKind::Vim | EditorKind::VsCode => &[
                 "ea67e259dedf60d4429b6c349a564ffcd1563cf41c920a856d1f5b16b4701ac8",
@@ -626,6 +627,7 @@ Select which editor you would like to set up [default: None]: ";
                 "02a49ac2d31f00ef6e4531c44e00dac51cea895112e480553f1ba060b3942a47",
                 "0aa4748848de0d1cb7ece92a0123c8897fef6de2f58aff8fda1426f098b7a798",
                 "e5e357862e5d6d0d9da335e9823c07b8a7dc42bbf18d72cc5206ad1049cd8fcc",
+                "a68fd5828e75f3e921f265e29ce1e9efa554083c3773fdb4b8e1ab3b2d9dc6cd",
             ],
             EditorKind::Zed => &[
                 "bbce727c269d1bd0c98afef4d612eb4ce27aea3c3a8968c5f10b31affbc40b6c",
@@ -636,6 +638,7 @@ Select which editor you would like to set up [default: None]: ";
                 "5ef83292111d9a8bb63b6afc3abf42d0bc78fe24985f0d2e039e73258b5dab8f",
                 "74420c13094b530a986b37c4f1d23cb58c0e8e2295f5858ded129fb1574e66f9",
                 "2d3b592c089b2ad2c528686a1e371af49922edad1c59accd5d5f31612a441568",
+                "0767a2398ccc253274b184adbb9e018ce931bd0ef45baad06dad19b652c52951",
             ],
         }
     }

--- a/src/etc/rust_analyzer_helix.toml
+++ b/src/etc/rust_analyzer_helix.toml
@@ -9,6 +9,9 @@
 # x fmt --check
 # ```
 # (if that doesn't work -- do `x clean` first)
+#
+# NOTE: helix doesn't support getting workspace root in configs, for this config
+# to work replace WORKSPACE_ROOT with the path to your rustc checkout
 
 [language-server.rust-analyzer.config]
 linkedProjects = [
@@ -33,7 +36,7 @@ overrideCommand = [
 
 [language-server.rust-analyzer.config.rustfmt]
 overrideCommand = [
-    "build/host/rustfmt/bin/rustfmt",
+    "WORKSPACE_ROOT/build/host/rustfmt/bin/rustfmt",
     "--edition=2024"
 ]
 
@@ -64,7 +67,8 @@ overrideCommand = [
 ]
 
 [language-server.rust-analyzer.environment]
-RUSTUP_TOOLCHAIN = "nightly"
+RUSTC = "WORKSPACE_ROOT/build/host/stage0/bin/rustc"
+CARGO = "WORKSPACE_ROOT/build/host/stage0/bin/cargo"
 
 [[language]]
 name = "rust"

--- a/src/etc/rust_analyzer_settings.json
+++ b/src/etc/rust_analyzer_settings.json
@@ -1,3 +1,14 @@
+// This config uses a separate build directory for rust-analyzer,
+// so that r-a's checks don't block user `x` commands and vice-verse.
+// R-a's build directory is located in `build-rust-analyzer`.
+//
+// To download rustfmt and proc macro server for r-a run the following command
+// (proc macro server is downloaded automatically with pretty much any command,
+// this specific one also downloads rustfmt):
+// ```
+// x fmt --check
+// ```
+// (if that doesn't work -- do `x clean` first)
 {
     "git.detectSubmodulesLimit": 20,
     "rust-analyzer.linkedProjects": [
@@ -40,7 +51,8 @@
         "build-rust-analyzer"
     ],
     "rust-analyzer.server.extraEnv": {
-        "RUSTUP_TOOLCHAIN": "nightly"
+        "RUSTC": "${workspaceFolder}/build/host/stage0/bin/rustc",
+        "CARGO": "${workspaceFolder}/build/host/stage0/bin/cargo"
     },
     "files.associations": {
         "*.fixed": "rust",

--- a/src/etc/rust_analyzer_zed.json
+++ b/src/etc/rust_analyzer_zed.json
@@ -1,3 +1,14 @@
+// This config uses a separate build directory for rust-analyzer,
+// so that r-a's checks don't block user `x` commands and vice-verse.
+// R-a's build directory is located in `build-rust-analyzer`.
+//
+// To download rustfmt and proc macro server for r-a run the following command
+// (proc macro server is downloaded automatically with pretty much any command,
+// this specific one also downloads rustfmt):
+// ```
+// x fmt --check
+// ```
+// (if that doesn't work -- do `x clean` first)
 {
   "lsp": {
     "rust-analyzer": {
@@ -55,7 +66,8 @@
         },
         "server": {
           "extraEnv": {
-            "RUSTUP_TOOLCHAIN": "nightly"
+            "RUSTC": "build/host/stage0/bin/rustc",
+            "CARGO": "build/host/stage0/bin/cargo"
           }
         }
       }


### PR DESCRIPTION
1. Explain that you need to make paths absolute in helix settings
2. Use the correct compiler (set `RUSTC` and `CARGO` to stage0, instead of `RUSTUP_TOOLCHAIN=nightly`)
3. Add comments to vscode and zed settings

NB: I only tested helix settings, but am pretty sure that the other changes shouldn't break anything.