### PR TITLE
MGCA: fix type error handling for const array and tuple lowering logic

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -2416,11 +2416,15 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
     ) -> Const<'tcx> {
         let tcx = self.tcx();
 
-        let ty::Array(elem_ty, _) = ty.kind() else {
-            let e = tcx
-                .dcx()
-                .span_err(array_expr.span, format!("expected `{}`, found const array", ty));
-            return Const::new_error(tcx, e);
+        let elem_ty = match ty.kind() {
+            ty::Array(elem_ty, _) => elem_ty,
+            ty::Error(e) => return Const::new_error(tcx, *e),
+            _ => {
+                let e = tcx
+                    .dcx()
+                    .span_err(array_expr.span, format!("expected `{}`, found const array", ty));
+                return Const::new_error(tcx, e);
+            }
         };
 
         let elems = array_expr
@@ -2539,9 +2543,13 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
     ) -> Const<'tcx> {
         let tcx = self.tcx();
 
-        let ty::Tuple(tys) = ty.kind() else {
-            let e = tcx.dcx().span_err(span, format!("expected `{}`, found const tuple", ty));
-            return Const::new_error(tcx, e);
+        let tys = match ty.kind() {
+            ty::Tuple(tys) => tys,
+            ty::Error(e) => return Const::new_error(tcx, *e),
+            _ => {
+                let e = tcx.dcx().span_err(span, format!("expected `{}`, found const tuple", ty));
+                return Const::new_error(tcx, e);
+            }
         };
 
         let exprs = exprs

--- a/tests/ui/const-generics/mgca/syntactic-type-mismatch.rs
+++ b/tests/ui/const-generics/mgca/syntactic-type-mismatch.rs
@@ -1,0 +1,13 @@
+// This test ensures proper diagnostics emission during HIR ty lowering
+// See https://github.com/rust-lang/rust/issues/153254
+
+#![feature(min_generic_const_args)]
+#![expect(incomplete_features)]
+
+type const T0: _ = ();
+//~^ ERROR: the placeholder `_` is not allowed within types on item signatures for constants [E0121]
+
+type const T1 = [0];
+//~^ ERROR: missing type for `const` item
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/syntactic-type-mismatch.stderr
+++ b/tests/ui/const-generics/mgca/syntactic-type-mismatch.stderr
@@ -1,0 +1,20 @@
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
+  --> $DIR/syntactic-type-mismatch.rs:7:16
+   |
+LL | type const T0: _ = ();
+   |                ^ not allowed in type signatures
+
+error: missing type for `const` item
+  --> $DIR/syntactic-type-mismatch.rs:10:14
+   |
+LL | type const T1 = [0];
+   |              ^
+   |
+help: provide a type for the item
+   |
+LL | type const T1: <type> = [0];
+   |              ++++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0121`.


### PR DESCRIPTION
It's a simple fix; just needed to handle Ty::Error in `lower_const_arg_array` and `lower_const_arg_tup`

Fixes rust-lang/rust#153254

r? @fmease