### PR TITLE
Gate `ConstParamTy_` trait behind `const_param_ty_trait` feature

### DIFF
--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -54,7 +54,7 @@ use crate::pin::UnsafePinned;
 /// ```
 #[unstable(feature = "internal_impls_macro", issue = "none")]
 // Allow implementations of `UnsizedConstParamTy` even though std cannot use that feature.
-#[allow_internal_unstable(unsized_const_params)]
+#[allow_internal_unstable(const_param_ty_trait)]
 macro marker_impls {
     ( $(#[$($meta:tt)*])* $Trait:ident for $({$($bounds:tt)*})? $T:ty $(, $($rest:tt)*)? ) => {
         $(#[$($meta)*])* impl< $($($bounds)*)? > $Trait for $T {}
@@ -1080,7 +1080,7 @@ pub trait Tuple {}
 /// that all fields are also `ConstParamTy`, which implies that recursively, all fields
 /// are `StructuralPartialEq`.
 #[lang = "const_param_ty"]
-#[unstable(feature = "unsized_const_params", issue = "95174")]
+#[unstable(feature = "const_param_ty_trait", issue = "95174", implied_by = "unsized_const_params")]
 #[diagnostic::on_unimplemented(message = "`{Self}` can't be used as a const parameter type")]
 #[allow(multiple_supertrait_upcastable)]
 // We name this differently than the derive macro so that the `adt_const_params` can
@@ -1090,7 +1090,7 @@ pub trait ConstParamTy_: StructuralPartialEq + Eq {}
 
 /// Derive macro generating an impl of the trait `ConstParamTy`.
 #[rustc_builtin_macro]
-#[allow_internal_unstable(unsized_const_params)]
+#[allow_internal_unstable(const_param_ty_trait)]
 #[unstable(feature = "adt_const_params", issue = "95174")]
 pub macro ConstParamTy($item:item) {
     /* compiler built-in */

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_bad_empty_array.rs
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_bad_empty_array.rs
@@ -1,5 +1,5 @@
 #![allow(incomplete_features)]
-#![feature(adt_const_params, unsized_const_params)]
+#![feature(adt_const_params, const_param_ty_trait)]
 
 #[derive(PartialEq, Eq)]
 struct NotParam;

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_dyn_compatibility.rs
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_dyn_compatibility.rs
@@ -1,4 +1,4 @@
-#![feature(adt_const_params, unsized_const_params)]
+#![feature(adt_const_params, const_param_ty_trait)]
 #![allow(incomplete_features)]
 
 use std::marker::ConstParamTy_;

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_generic_bounds_do_not_hold.rs
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_generic_bounds_do_not_hold.rs
@@ -1,5 +1,5 @@
 #![allow(incomplete_features)]
-#![feature(adt_const_params, unsized_const_params)]
+#![feature(adt_const_params, const_param_ty_trait)]
 
 #[derive(PartialEq, Eq)]
 struct NotParam;

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_impl_bad_field.rs
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_impl_bad_field.rs
@@ -1,5 +1,5 @@
 #![allow(incomplete_features)]
-#![feature(adt_const_params, unsized_const_params)]
+#![feature(adt_const_params, const_param_ty_trait)]
 
 #[derive(PartialEq, Eq)]
 struct NotParam;

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_impl_no_structural_eq.rs
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_impl_no_structural_eq.rs
@@ -1,5 +1,5 @@
 #![allow(incomplete_features)]
-#![feature(adt_const_params, unsized_const_params)]
+#![feature(adt_const_params, const_param_ty_trait)]
 
 #[derive(PartialEq, Eq)]
 struct ImplementsConstParamTy;

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_impl_union.rs
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_impl_union.rs
@@ -1,5 +1,5 @@
 #![allow(incomplete_features)]
-#![feature(adt_const_params, unsized_const_params)]
+#![feature(adt_const_params, const_param_ty_trait)]
 
 union Union {
     a: u8,

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_trait_gate.rs
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_trait_gate.rs
@@ -1,0 +1,8 @@
+//@check-pass
+#![feature(const_param_ty_trait)]
+
+use std::marker::ConstParamTy_;
+
+fn meow<T: ConstParamTy_>() {}
+
+fn main() {}

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_trait_implied.rs
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_trait_implied.rs
@@ -1,0 +1,9 @@
+//@check-pass
+#![feature(unsized_const_params, adt_const_params)]
+#![allow(incomplete_features)]
+
+use std::marker::ConstParamTy_;
+
+fn miow<T: ConstParamTy_>() {}
+
+fn main() {}

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_trait_no_gate.rs
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_trait_no_gate.rs
@@ -1,0 +1,7 @@
+use std::marker::ConstParamTy_;
+ //~^ ERROR use of unstable library feature `const_param_ty_trait` [E0658]
+
+fn miaw<T: ConstParamTy_>() {}
+         //~^ ERROR use of unstable library feature `const_param_ty_trait` [E0658]
+
+fn main() {}

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_trait_no_gate.stderr
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_trait_no_gate.stderr
@@ -1,0 +1,23 @@
+error[E0658]: use of unstable library feature `const_param_ty_trait`
+  --> $DIR/const_param_ty_trait_no_gate.rs:1:5
+   |
+LL | use std::marker::ConstParamTy_;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #95174 <https://github.com/rust-lang/rust/issues/95174> for more information
+   = help: add `#![feature(const_param_ty_trait)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: use of unstable library feature `const_param_ty_trait`
+  --> $DIR/const_param_ty_trait_no_gate.rs:4:12
+   |
+LL | fn miaw<T: ConstParamTy_>() {}
+   |            ^^^^^^^^^^^^^
+   |
+   = note: see issue #95174 <https://github.com/rust-lang/rust/issues/95174> for more information
+   = help: add `#![feature(const_param_ty_trait)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/const-generics/associated-const-bindings/bound-var-in-ty-not-wf.rs
+++ b/tests/ui/const-generics/associated-const-bindings/bound-var-in-ty-not-wf.rs
@@ -3,7 +3,7 @@
 #![feature(
     min_generic_const_args,
     adt_const_params,
-    unsized_const_params,
+    const_param_ty_trait,
     generic_const_parameter_types,
 )]
 #![allow(incomplete_features)]

--- a/tests/ui/const-generics/associated-const-bindings/bound-var-in-ty.rs
+++ b/tests/ui/const-generics/associated-const-bindings/bound-var-in-ty.rs
@@ -6,7 +6,7 @@
 #![feature(
     min_generic_const_args,
     adt_const_params,
-    unsized_const_params,
+    const_param_ty_trait,
     generic_const_parameter_types,
 )]
 #![allow(incomplete_features)]

--- a/tests/ui/const-generics/associated-const-bindings/dyn-compat-assoc-const-ty-mentions-self.rs
+++ b/tests/ui/const-generics/associated-const-bindings/dyn-compat-assoc-const-ty-mentions-self.rs
@@ -7,7 +7,7 @@
 #![feature(generic_const_items)]
 #![feature(generic_const_parameter_types)]
 #![feature(min_generic_const_args)]
-#![feature(unsized_const_params)]
+#![feature(const_param_ty_trait)]
 #![expect(incomplete_features)]
 
 trait Trait {

--- a/tests/ui/const-generics/associated-const-bindings/dyn-compat-self-const-projections-in-assoc-const-ty.rs
+++ b/tests/ui/const-generics/associated-const-bindings/dyn-compat-self-const-projections-in-assoc-const-ty.rs
@@ -7,7 +7,7 @@
 #![feature(
     adt_const_params,
     min_generic_const_args,
-    unsized_const_params,
+    const_param_ty_trait,
     generic_const_parameter_types
 )]
 #![expect(incomplete_features)]

--- a/tests/ui/const-generics/associated-const-bindings/supertraits.rs
+++ b/tests/ui/const-generics/associated-const-bindings/supertraits.rs
@@ -6,7 +6,7 @@
 #![feature(
     min_generic_const_args,
     adt_const_params,
-    unsized_const_params,
+    const_param_ty_trait,
     generic_const_parameter_types,
 )]
 #![allow(incomplete_features)]

--- a/tests/ui/const-generics/const-param-with-additional-obligations.rs
+++ b/tests/ui/const-generics/const-param-with-additional-obligations.rs
@@ -1,4 +1,4 @@
-#![feature(adt_const_params, unsized_const_params)]
+#![feature(adt_const_params, const_param_ty_trait)]
 #![allow(incomplete_features)]
 
 use std::marker::ConstParamTy_;

--- a/tests/ui/const-generics/generic_const_parameter_types/bad_inference.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/bad_inference.rs
@@ -1,4 +1,4 @@
-#![feature(adt_const_params, unsized_const_params, generic_const_parameter_types)]
+#![feature(adt_const_params, const_param_ty_trait, generic_const_parameter_types)]
 #![allow(incomplete_features)]
 
 use std::marker::ConstParamTy_;

--- a/tests/ui/const-generics/generic_const_parameter_types/evaluate_const_parameter_in_mir.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/evaluate_const_parameter_in_mir.rs
@@ -1,6 +1,6 @@
 //@ check-pass
 
-#![feature(adt_const_params, unsized_const_params, generic_const_parameter_types)]
+#![feature(adt_const_params, const_param_ty_trait, generic_const_parameter_types)]
 #![allow(incomplete_features)]
 
 use std::marker::ConstParamTy_;

--- a/tests/ui/const-generics/generic_const_parameter_types/mismatched_args_with_value.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/mismatched_args_with_value.rs
@@ -1,4 +1,4 @@
-#![feature(adt_const_params, unsized_const_params, generic_const_parameter_types)]
+#![feature(adt_const_params, const_param_ty_trait, generic_const_parameter_types)]
 #![allow(incomplete_features)]
 
 use std::marker::ConstParamTy_;

--- a/tests/ui/const-generics/generic_const_parameter_types/no_const_param_ty_bound.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/no_const_param_ty_bound.rs
@@ -1,4 +1,4 @@
-#![feature(adt_const_params, unsized_const_params, generic_const_parameter_types)]
+#![feature(adt_const_params, const_param_ty_trait, generic_const_parameter_types)]
 #![expect(incomplete_features)]
 
 use std::marker::{ConstParamTy_, PhantomData};

--- a/tests/ui/const-generics/generic_const_parameter_types/unrelated_inferred_arg.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/unrelated_inferred_arg.rs
@@ -1,6 +1,6 @@
 //@ check-pass
 
-#![feature(adt_const_params, unsized_const_params, generic_const_parameter_types)]
+#![feature(adt_const_params, const_param_ty_trait, generic_const_parameter_types)]
 #![allow(incomplete_features)]
 
 use std::marker::ConstParamTy_;

--- a/tests/ui/const-generics/mgca/adt_expr_infers_from_value.rs
+++ b/tests/ui/const-generics/mgca/adt_expr_infers_from_value.rs
@@ -5,7 +5,7 @@
     min_generic_const_args,
     adt_const_params,
     generic_const_parameter_types,
-    unsized_const_params,
+    const_param_ty_trait,
 )]
 #![expect(incomplete_features)]
 

--- a/tests/ui/const-generics/mgca/const-ctor.rs
+++ b/tests/ui/const-generics/mgca/const-ctor.rs
@@ -8,7 +8,7 @@
     min_generic_const_args,
     adt_const_params,
     generic_const_parameter_types,
-    unsized_const_params
+    const_param_ty_trait
 )]
 #![expect(incomplete_features)]
 use std::marker::{ConstParamTy, ConstParamTy_};

--- a/tests/ui/const-generics/mgca/generic_const_type_mismatch.rs
+++ b/tests/ui/const-generics/mgca/generic_const_type_mismatch.rs
@@ -5,7 +5,7 @@
     generic_const_items,
     generic_const_parameter_types,
     min_generic_const_args,
-    unsized_const_params
+    const_param_ty_trait
 )]
 use std::marker::ConstParamTy_;
 

--- a/tests/ui/generic-const-items/assoc-const-bindings.rs
+++ b/tests/ui/generic-const-items/assoc-const-bindings.rs
@@ -1,7 +1,7 @@
 //@ check-pass
 
 #![feature(generic_const_items, min_generic_const_args)]
-#![feature(adt_const_params, unsized_const_params, generic_const_parameter_types)]
+#![feature(adt_const_params, const_param_ty_trait, generic_const_parameter_types)]
 #![expect(incomplete_features)]
 
 use std::marker::{ConstParamTy, ConstParamTy_};


### PR DESCRIPTION
Initially even when user wasn't using unsized const params, the only way to implement/name `ConstParamTy_` was to use `#![feature(unsized_const_params]`, now its gated under `const_param_ty_trait` feature, implied by `unsized_const_params`.

I've also changed use of `unsized_const_params` in tests which were using it only to implement `ConstParamTy_` without using unsized

r? BoxyUwU