### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -4,7 +4,7 @@ use rustc_abi::ExternAbi;
 use rustc_ast::ParamKindOrd;
 use rustc_errors::codes::*;
 use rustc_errors::{Applicability, Diag, EmissionGuarantee, Subdiagnostic};
-use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
+use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_span::{Ident, Span, Symbol};
 
 #[derive(Diagnostic)]
@@ -671,7 +671,7 @@ pub(crate) struct MissingUnsafeOnExtern {
     pub span: Span,
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("extern blocks should be unsafe")]
 pub(crate) struct MissingUnsafeOnExternLint {
     #[suggestion(
@@ -1027,7 +1027,7 @@ pub(crate) struct MissingAbi {
     pub span: Span,
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("`extern` declarations without an explicit ABI are deprecated")]
 pub(crate) struct MissingAbiSugg {
     #[suggestion(

--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -3,26 +3,26 @@ use rustc_errors::{
     Diag, DiagCtxtHandle, Diagnostic, EmissionGuarantee, Level, MultiSpan, SingleLabelManySpans,
     Subdiagnostic, msg,
 };
-use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
+use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_span::{Ident, Span, Symbol};
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("avoid using `.intel_syntax`, Intel syntax is the default")]
 pub(crate) struct AvoidIntelSyntax;
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("avoid using `.att_syntax`, prefer using `options(att_syntax)` instead")]
 pub(crate) struct AvoidAttSyntax;
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("include macro expected single expression in source")]
 pub(crate) struct IncompleteInclude;
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("cannot test inner items")]
 pub(crate) struct UnnameableTestItems;
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("duplicated attribute")]
 pub(crate) struct DuplicateMacroAttribute;
 

--- a/compiler/rustc_errors/src/decorate_diag.rs
+++ b/compiler/rustc_errors/src/decorate_diag.rs
@@ -1,15 +1,16 @@
 /// This module provides types and traits for buffering lints until later in compilation.
 use rustc_ast::node_id::NodeId;
 use rustc_data_structures::fx::FxIndexMap;
+use rustc_data_structures::sync::DynSend;
 use rustc_error_messages::MultiSpan;
 use rustc_lint_defs::{BuiltinLintDiag, Lint, LintId};
 
-use crate::{DynSend, LintDiagnostic, LintDiagnosticBox};
+use crate::{Diag, DiagCtxtHandle, Diagnostic, Level};
 
 /// We can't implement `LintDiagnostic` for `BuiltinLintDiag`, because decorating some of its
 /// variants requires types we don't have yet. So, handle that case separately.
 pub enum DecorateDiagCompat {
-    Dynamic(Box<dyn for<'a> LintDiagnosticBox<'a, ()> + DynSend + 'static>),
+    Dynamic(Box<dyn for<'a> FnOnce(DiagCtxtHandle<'a>, Level) -> Diag<'a, ()> + DynSend + 'static>),
     Builtin(BuiltinLintDiag),
 }
 
@@ -19,12 +20,10 @@ impl std::fmt::Debug for DecorateDiagCompat {
     }
 }
 
-impl !LintDiagnostic<'_, ()> for BuiltinLintDiag {}
-
-impl<D: for<'a> LintDiagnostic<'a, ()> + DynSend + 'static> From<D> for DecorateDiagCompat {
+impl<D: for<'a> Diagnostic<'a, ()> + DynSend + 'static> From<D> for DecorateDiagCompat {
     #[inline]
     fn from(d: D) -> Self {
-        Self::Dynamic(Box::new(d))
+        Self::Dynamic(Box::new(|dcx, level| d.into_diag(dcx, level)))
     }
 }
 

--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -7,6 +7,7 @@ use std::panic;
 use std::path::PathBuf;
 use std::thread::panicking;
 
+use rustc_data_structures::sync::DynSend;
 use rustc_error_messages::{DiagArgMap, DiagArgName, DiagArgValue, IntoDiagArg};
 use rustc_lint_defs::{Applicability, LintExpectationId};
 use rustc_macros::{Decodable, Encodable};
@@ -115,6 +116,14 @@ where
 {
     fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, G> {
         self.node.into_diag(dcx, level).with_span(self.span)
+    }
+}
+
+impl<'a> Diagnostic<'a, ()>
+    for Box<dyn for<'b> FnOnce(DiagCtxtHandle<'b>, Level) -> Diag<'b, ()> + DynSend + 'static>
+{
+    fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, ()> {
+        self(dcx, level)
     }
 }
 

--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -137,16 +137,6 @@ pub trait LintDiagnostic<'a, G: EmissionGuarantee> {
     fn decorate_lint<'b>(self, diag: &'b mut Diag<'a, G>);
 }
 
-pub trait LintDiagnosticBox<'a, G: EmissionGuarantee> {
-    fn decorate_lint_box<'b>(self: Box<Self>, diag: &'b mut Diag<'a, G>);
-}
-
-impl<'a, G: EmissionGuarantee, D: LintDiagnostic<'a, G>> LintDiagnosticBox<'a, G> for D {
-    fn decorate_lint_box<'b>(self: Box<Self>, diag: &'b mut Diag<'a, G>) {
-        self.decorate_lint(diag);
-    }
-}
-
 #[derive(Clone, Debug, Encodable, Decodable)]
 pub(crate) struct DiagLocation {
     file: Cow<'static, str>,

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -40,7 +40,7 @@ pub use codes::*;
 pub use decorate_diag::{BufferedEarlyLint, DecorateDiagCompat, LintBuffer};
 pub use diagnostic::{
     BugAbort, Diag, DiagInner, DiagStyledString, Diagnostic, EmissionGuarantee, FatalAbort,
-    LintDiagnostic, LintDiagnosticBox, StringPart, Subdiag, Subdiagnostic,
+    LintDiagnostic, StringPart, Subdiag, Subdiagnostic,
 };
 pub use diagnostic_impls::{
     DiagSymbolList, ElidedLifetimeInPathSubdiag, ExpectedLifetimeParameter,

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -3,10 +3,10 @@ use std::borrow::Cow;
 use rustc_ast::ast;
 use rustc_errors::codes::*;
 use rustc_hir::limit::Limit;
-use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
+use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_span::{Ident, MacroRulesNormalizedIdent, Span, Symbol};
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("`#[cfg_attr]` does not expand to any attributes")]
 pub(crate) struct CfgAttrNoAttributes;
 
@@ -94,7 +94,7 @@ pub(crate) struct MacroVarStillRepeating {
     pub ident: MacroRulesNormalizedIdent,
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("variable `{$ident}` is still repeating at this depth")]
 pub(crate) struct MetaVarStillRepeatingLint {
     #[label("expected repetition")]
@@ -102,7 +102,7 @@ pub(crate) struct MetaVarStillRepeatingLint {
     pub ident: MacroRulesNormalizedIdent,
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("meta-variable repeats with different Kleene operator")]
 pub(crate) struct MetaVariableWrongOperator {
     #[label("expected repetition")]
@@ -119,7 +119,7 @@ pub(crate) struct MetaVarsDifSeqMatchers {
     pub msg: String,
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("unknown macro variable `{$name}`")]
 pub(crate) struct UnknownMacroVariable {
     pub name: MacroRulesNormalizedIdent,
@@ -391,7 +391,7 @@ pub(crate) struct DuplicateMatcherBinding {
     pub prev: Span,
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("duplicate matcher binding")]
 pub(crate) struct DuplicateMatcherBindingLint {
     #[label("duplicate binding")]
@@ -569,7 +569,7 @@ pub(crate) struct MacroArgsBadDelimSugg {
     pub close: Span,
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("unused doc comment")]
 #[help(
     "to document an item produced by a macro, the macro must produce the documentation as part of its expansion"
@@ -579,7 +579,7 @@ pub(crate) struct MacroCallUnusedDocComment {
     pub span: Span,
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag(
     "the meaning of the `pat` fragment specifier is changing in Rust 2021, which may affect this macro"
 )]
@@ -593,7 +593,7 @@ pub(crate) struct OrPatternsBackCompat {
     pub suggestion: String,
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("trailing semicolon in macro used in expression position")]
 pub(crate) struct TrailingMacro {
     #[note("macro invocations at the end of a block are treated as expressions")]
@@ -604,7 +604,7 @@ pub(crate) struct TrailingMacro {
     pub name: Ident,
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("unused attribute `{$attr_name}`")]
 pub(crate) struct UnusedBuiltinAttribute {
     #[note(

--- a/compiler/rustc_lint/src/early.rs
+++ b/compiler/rustc_lint/src/early.rs
@@ -7,7 +7,10 @@
 use rustc_ast::visit::{self as ast_visit, Visitor, walk_list};
 use rustc_ast::{self as ast, AttrVec, HasAttrs};
 use rustc_data_structures::stack::ensure_sufficient_stack;
-use rustc_errors::{BufferedEarlyLint, DecorateDiagCompat, LintBuffer};
+use rustc_data_structures::sync::DynSend;
+use rustc_errors::{
+    BufferedEarlyLint, DecorateDiagCompat, Diag, DiagCtxtHandle, Diagnostic, Level, LintBuffer,
+};
 use rustc_feature::Features;
 use rustc_middle::ty::{RegisteredTools, TyCtxt};
 use rustc_session::Session;
@@ -35,6 +38,16 @@ pub struct EarlyContextAndPass<'ecx, 'tcx, T: EarlyLintPass> {
 
 impl<'ecx, 'tcx, T: EarlyLintPass> EarlyContextAndPass<'ecx, 'tcx, T> {
     fn check_id(&mut self, id: ast::NodeId) {
+        struct BoxDiag(
+            Box<dyn for<'a> FnOnce(DiagCtxtHandle<'a>, Level) -> Diag<'a, ()> + DynSend + 'static>,
+        );
+
+        impl<'a> Diagnostic<'a, ()> for BoxDiag {
+            fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, ()> {
+                (self.0)(dcx, level)
+            }
+        }
+
         for early_lint in self.context.buffered.take(id) {
             let BufferedEarlyLint { span, node_id: _, lint_id, diagnostic } = early_lint;
             match diagnostic {
@@ -50,8 +63,7 @@ impl<'ecx, 'tcx, T: EarlyLintPass> EarlyContextAndPass<'ecx, 'tcx, T> {
                     );
                 }
                 DecorateDiagCompat::Dynamic(d) => {
-                    self.context
-                        .opt_span_lint(lint_id.lint, span, |diag| d.decorate_lint_box(diag));
+                    self.context.opt_span_diag_lint(lint_id.lint, span, BoxDiag(d));
                 }
             }
         }

--- a/compiler/rustc_lint/src/early.rs
+++ b/compiler/rustc_lint/src/early.rs
@@ -7,10 +7,7 @@
 use rustc_ast::visit::{self as ast_visit, Visitor, walk_list};
 use rustc_ast::{self as ast, AttrVec, HasAttrs};
 use rustc_data_structures::stack::ensure_sufficient_stack;
-use rustc_data_structures::sync::DynSend;
-use rustc_errors::{
-    BufferedEarlyLint, DecorateDiagCompat, Diag, DiagCtxtHandle, Diagnostic, Level, LintBuffer,
-};
+use rustc_errors::{BufferedEarlyLint, DecorateDiagCompat, LintBuffer};
 use rustc_feature::Features;
 use rustc_middle::ty::{RegisteredTools, TyCtxt};
 use rustc_session::Session;
@@ -38,16 +35,6 @@ pub struct EarlyContextAndPass<'ecx, 'tcx, T: EarlyLintPass> {
 
 impl<'ecx, 'tcx, T: EarlyLintPass> EarlyContextAndPass<'ecx, 'tcx, T> {
     fn check_id(&mut self, id: ast::NodeId) {
-        struct BoxDiag(
-            Box<dyn for<'a> FnOnce(DiagCtxtHandle<'a>, Level) -> Diag<'a, ()> + DynSend + 'static>,
-        );
-
-        impl<'a> Diagnostic<'a, ()> for BoxDiag {
-            fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, ()> {
-                (self.0)(dcx, level)
-            }
-        }
-
         for early_lint in self.context.buffered.take(id) {
             let BufferedEarlyLint { span, node_id: _, lint_id, diagnostic } = early_lint;
             match diagnostic {
@@ -63,7 +50,7 @@ impl<'ecx, 'tcx, T: EarlyLintPass> EarlyContextAndPass<'ecx, 'tcx, T> {
                     );
                 }
                 DecorateDiagCompat::Dynamic(d) => {
-                    self.context.opt_span_diag_lint(lint_id.lint, span, BoxDiag(d));
+                    self.context.opt_span_diag_lint(lint_id.lint, span, d);
                 }
             }
         }

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -11,7 +11,7 @@ use rustc_errors::{
     Applicability, Diag, DiagArgValue, DiagCtxtHandle, Diagnostic, EmissionGuarantee, IntoDiagArg,
     Level, Subdiagnostic, SuggestionStyle, msg,
 };
-use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
+use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_session::errors::ExprParenthesesNeeded;
 use rustc_span::edition::{Edition, LATEST_STABLE_EDITION};
 use rustc_span::{Ident, Span, Symbol};
@@ -4277,7 +4277,7 @@ pub(crate) struct ExpectedRegisterClassOrExplicitRegister {
     pub(crate) span: Span,
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("unicode codepoint changing visible direction of text present in {$label}")]
 #[note(
     "these kind of unicode codepoints change the way text flows on applications that support them, but can cause confusion because they change the order of characters on the screen"
@@ -4360,7 +4360,7 @@ impl Subdiagnostic for HiddenUnicodeCodepointsDiagSub {
     }
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("missing pattern for `...` argument")]
 pub(crate) struct VarargsWithoutPattern {
     #[suggestion(

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -136,7 +136,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         }
 
         for ambiguity_error in &self.ambiguity_errors {
-            let diag = self.ambiguity_diagnostic(ambiguity_error);
+            let mut diag = self.ambiguity_diagnostic(ambiguity_error);
 
             if let Some(ambiguity_warning) = ambiguity_error.warning {
                 let node_id = match ambiguity_error.b1.0.kind {
@@ -152,6 +152,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
                 self.lint_buffer.buffer_lint(lint, node_id, diag.ident.span, diag);
             } else {
+                diag.is_error = true;
                 self.dcx().emit_err(diag);
             }
         }
@@ -2093,6 +2094,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             b1_help_msgs,
             b2_note,
             b2_help_msgs,
+            is_error: false,
         }
     }
 

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -1,9 +1,9 @@
 use rustc_errors::codes::*;
 use rustc_errors::{
     Applicability, Diag, DiagCtxtHandle, DiagMessage, Diagnostic, ElidedLifetimeInPathSubdiag,
-    EmissionGuarantee, IntoDiagArg, Level, LintDiagnostic, MultiSpan, Subdiagnostic, msg,
+    EmissionGuarantee, IntoDiagArg, Level, MultiSpan, Subdiagnostic, msg,
 };
-use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
+use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_span::source_map::Spanned;
 use rustc_span::{Ident, Span, Symbol};
 
@@ -614,7 +614,7 @@ pub(crate) struct ProcMacroSameCrate {
     pub(crate) is_test: bool,
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("cannot find {$ns_descr} `{$ident}` in this scope")]
 pub(crate) struct ProcMacroDeriveResolutionFallback {
     #[label("names from parent modules are not accessible without an explicit import")]
@@ -623,7 +623,7 @@ pub(crate) struct ProcMacroDeriveResolutionFallback {
     pub ident: Symbol,
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag(
     "macro-expanded `macro_export` macros from the current crate cannot be referred to by absolute paths"
 )]
@@ -823,7 +823,7 @@ pub(crate) struct CannotBeReexportedCratePublicNS {
     pub(crate) ident: Ident,
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("extern crate `{$ident}` is private and cannot be re-exported", code = E0365)]
 pub(crate) struct PrivateExternCrateReexport {
     pub ident: Ident,
@@ -1393,14 +1393,14 @@ pub(crate) struct TraitImplMismatch {
     pub(crate) trait_item_span: Span,
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("derive helper attribute is used before it is introduced")]
 pub(crate) struct LegacyDeriveHelpers {
     #[label("the attribute is introduced here")]
     pub span: Span,
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("unused extern crate")]
 pub(crate) struct UnusedExternCrate {
     #[label("unused")]
@@ -1414,7 +1414,7 @@ pub(crate) struct UnusedExternCrate {
     pub removal_span: Span,
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("{$kind} `{$name}` from private dependency '{$krate}' is re-exported")]
 pub(crate) struct ReexportPrivateDependency {
     pub name: Symbol,
@@ -1422,32 +1422,32 @@ pub(crate) struct ReexportPrivateDependency {
     pub krate: Symbol,
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("unused label")]
 pub(crate) struct UnusedLabel;
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("unused `#[macro_use]` import")]
 pub(crate) struct UnusedMacroUse;
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("applying the `#[macro_use]` attribute to an `extern crate` item is deprecated")]
 #[help("remove it and import macros at use sites with a `use` item instead")]
 pub(crate) struct MacroUseDeprecated;
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("macro `{$ident}` is private")]
 pub(crate) struct MacroIsPrivate {
     pub ident: Ident,
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("unused macro definition: `{$name}`")]
 pub(crate) struct UnusedMacroDefinition {
     pub name: Symbol,
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("rule #{$n} of macro `{$name}` is never used")]
 pub(crate) struct MacroRuleNeverUsed {
     pub n: usize,
@@ -1458,13 +1458,14 @@ pub(crate) struct UnstableFeature {
     pub msg: DiagMessage,
 }
 
-impl<'a> LintDiagnostic<'a, ()> for UnstableFeature {
-    fn decorate_lint<'b>(self, diag: &'b mut Diag<'a, ()>) {
-        diag.primary_message(self.msg);
+impl<'a> Diagnostic<'a, ()> for UnstableFeature {
+    fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, ()> {
+        let Self { msg } = self;
+        Diag::new(dcx, level, msg)
     }
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("`extern crate` is not idiomatic in the new edition")]
 pub(crate) struct ExternCrateNotIdiomatic {
     #[suggestion(
@@ -1477,7 +1478,7 @@ pub(crate) struct ExternCrateNotIdiomatic {
     pub code: &'static str,
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("cannot find macro `{$path}` in the current scope when looking from {$location}")]
 #[help("import `macro_rules` with `use` to make it callable above its definition")]
 pub(crate) struct OutOfScopeMacroCalls {
@@ -1487,7 +1488,7 @@ pub(crate) struct OutOfScopeMacroCalls {
     pub location: String,
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag(
     "glob import doesn't reexport anything with visibility `{$import_vis}` because no imported item is public enough"
 )]
@@ -1500,7 +1501,7 @@ pub(crate) struct RedundantImportVisibility {
     pub max_vis: String,
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("unknown diagnostic attribute")]
 pub(crate) struct UnknownDiagnosticAttribute {
     #[subdiagnostic]
@@ -1530,43 +1531,48 @@ pub(crate) struct Ambiguity {
     pub b1_help_msgs: Vec<String>,
     pub b2_note: Spanned<String>,
     pub b2_help_msgs: Vec<String>,
-}
-
-impl Ambiguity {
-    fn decorate<'a>(self, diag: &mut Diag<'a, impl EmissionGuarantee>) {
-        if let Some(ambig_vis) = self.ambig_vis {
-            diag.primary_message(format!("ambiguous import visibility: {ambig_vis}"));
-        } else {
-            diag.primary_message(format!("`{}` is ambiguous", self.ident));
-            diag.span_label(self.ident.span, "ambiguous name");
-        }
-        diag.note(format!("ambiguous because of {}", self.kind));
-        diag.span_note(self.b1_note.span, self.b1_note.node);
-        if let Some(help) = self.help {
-            for help in help {
-                diag.help(*help);
-            }
-        }
-        for help_msg in self.b1_help_msgs {
-            diag.help(help_msg);
-        }
-        diag.span_note(self.b2_note.span, self.b2_note.node);
-        for help_msg in self.b2_help_msgs {
-            diag.help(help_msg);
-        }
-    }
+    /// If false, then it's a lint, if true, then it's an error with the `E0659` error code.
+    pub is_error: bool,
 }
 
 impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for Ambiguity {
     fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, G> {
-        let mut diag = Diag::new(dcx, level, "").with_span(self.ident.span).with_code(E0659);
-        self.decorate(&mut diag);
-        diag
-    }
-}
+        let Self {
+            ident,
+            ambig_vis,
+            kind,
+            help,
+            b1_note,
+            b1_help_msgs,
+            b2_note,
+            b2_help_msgs,
+            is_error,
+        } = self;
 
-impl<'a> LintDiagnostic<'a, ()> for Ambiguity {
-    fn decorate_lint<'b>(self, diag: &'b mut Diag<'a, ()>) {
-        self.decorate(diag);
+        let mut diag = Diag::new(dcx, level, "").with_span(ident.span);
+        if is_error {
+            diag.code(E0659);
+        }
+        if let Some(ambig_vis) = ambig_vis {
+            diag.primary_message(format!("ambiguous import visibility: {ambig_vis}"));
+        } else {
+            diag.primary_message(format!("`{}` is ambiguous", ident));
+            diag.span_label(ident.span, "ambiguous name");
+        }
+        diag.note(format!("ambiguous because of {}", kind));
+        diag.span_note(b1_note.span, b1_note.node);
+        if let Some(help) = help {
+            for help in help {
+                diag.help(*help);
+            }
+        }
+        for help_msg in b1_help_msgs {
+            diag.help(help_msg);
+        }
+        diag.span_note(b2_note.span, b2_note.node);
+        for help_msg in b2_help_msgs {
+            diag.help(help_msg);
+        }
+        diag
     }
 }

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -7,7 +7,7 @@ use rustc_errors::{
     Diag, DiagCtxtHandle, DiagMessage, Diagnostic, EmissionGuarantee, ErrorGuaranteed, Level,
     MultiSpan,
 };
-use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
+use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_span::{Span, Symbol};
 use rustc_target::spec::{SplitDebuginfo, StackProtector, TargetTuple};
 
@@ -528,7 +528,7 @@ pub(crate) struct SoftFloatIgnored;
 #[note("see issue #129893 <https://github.com/rust-lang/rust/issues/129893> for more information")]
 pub(crate) struct SoftFloatDeprecated;
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag("unexpected `--cfg {$cfg}` flag")]
 #[note("config `{$cfg_name}` is only supposed to be controlled by `{$controlled_by}`")]
 #[note("manually setting a built-in cfg can and does create incoherent behaviors")]

--- a/library/coretests/tests/time.rs
+++ b/library/coretests/tests/time.rs
@@ -598,3 +598,100 @@ fn from_neg_zero() {
     assert_eq!(Duration::from_secs_f32(-0.0), Duration::ZERO);
     assert_eq!(Duration::from_secs_f64(-0.0), Duration::ZERO);
 }
+
+#[test]
+#[should_panic(expected = "value is either too big or NaN")]
+fn duration_fp_mul_nan() {
+    let _ = Duration::NANOSECOND.mul_f64(f64::NAN);
+}
+
+#[test]
+#[should_panic(expected = "value is either too big or NaN")]
+fn duration_fp_mul_posinfinity() {
+    let _ = Duration::NANOSECOND.mul_f64(f64::INFINITY);
+}
+
+#[test]
+#[should_panic(expected = "value is negative")]
+fn duration_fp_mul_neginfinity() {
+    let _ = Duration::NANOSECOND.mul_f64(f64::NEG_INFINITY);
+}
+
+#[test]
+#[should_panic(expected = "value is either too big or NaN")]
+fn duration_fp_div_nan() {
+    let _ = Duration::NANOSECOND.div_f64(f64::NAN);
+}
+
+#[test]
+#[should_panic(expected = "value is either too big or NaN")]
+fn duration_fp_div_poszero() {
+    let _ = Duration::NANOSECOND.div_f64(0.0);
+}
+
+#[test]
+#[should_panic(expected = "value is negative")]
+fn duration_fp_div_negzero() {
+    let _ = Duration::NANOSECOND.div_f64(-0.0);
+}
+
+#[test]
+#[should_panic(expected = "value is negative")]
+fn duration_fp_div_negative() {
+    let _ = Duration::NANOSECOND.div_f64(f64::MIN);
+}
+
+const TOO_LARGE_FACTOR: f64 = Duration::MAX.as_nanos() as f64;
+const TOO_LARGE_DIVISOR: f64 = (Duration::MAX.as_secs_f64() * 2e9).next_up();
+const SMALLEST_DIVISOR: f64 = (TOO_LARGE_DIVISOR.recip() * 2.0).next_up().next_up();
+const SMALLEST_FACTOR: f64 = TOO_LARGE_FACTOR.recip() / 2.0;
+const SMALLEST_NEGFACTOR: f64 = (0.0f64.next_down() * 0.5e9).next_up();
+
+#[test]
+fn duration_fp_boundaries() {
+    const DURATION_BITS: u32 = Duration::MAX.as_nanos().ilog2() + 1;
+    const PRECISION: u32 = DURATION_BITS - f64::MANTISSA_DIGITS + 1;
+
+    assert_eq!(Duration::MAX.mul_f64(0.0), Duration::ZERO);
+    assert_eq!(Duration::MAX.mul_f64(-0.0), Duration::ZERO);
+
+    assert_eq!(Duration::MAX.mul_f64(SMALLEST_FACTOR), Duration::NANOSECOND);
+    assert_eq!(Duration::MAX.mul_f64(SMALLEST_FACTOR.next_down()), Duration::ZERO);
+
+    assert_eq!(Duration::MAX.div_f64(TOO_LARGE_DIVISOR), Duration::ZERO);
+    assert_eq!(Duration::MAX.div_f64(TOO_LARGE_DIVISOR.next_down()), Duration::NANOSECOND);
+
+    assert_eq!(Duration::MAX.div_f64(f64::INFINITY), Duration::ZERO);
+    assert_eq!(Duration::MAX.div_f64(f64::NEG_INFINITY), Duration::ZERO);
+
+    // the following assertions pair with the subsequent (`should_panic`) tests
+
+    assert_eq!(Duration::NANOSECOND.mul_f64(SMALLEST_NEGFACTOR), Duration::ZERO);
+
+    assert!(
+        Duration::MAX - Duration::NANOSECOND.mul_f64(TOO_LARGE_FACTOR.next_down())
+            < Duration::from_nanos(1 << PRECISION)
+    );
+    assert!(
+        Duration::MAX - Duration::NANOSECOND.div_f64(SMALLEST_DIVISOR)
+            < Duration::from_nanos(1 << PRECISION)
+    );
+}
+
+#[test]
+#[should_panic(expected = "value is negative")]
+fn duration_fp_mul_negative() {
+    let _ = Duration::NANOSECOND.mul_f64(SMALLEST_NEGFACTOR.next_down());
+}
+
+#[test]
+#[should_panic(expected = "value is either too big or NaN")]
+fn duration_fp_mul_overflow() {
+    let _ = Duration::NANOSECOND.mul_f64(TOO_LARGE_FACTOR);
+}
+
+#[test]
+#[should_panic(expected = "value is either too big or NaN")]
+fn duration_fp_div_overflow() {
+    let _ = Duration::NANOSECOND.div_f64(SMALLEST_DIVISOR.next_down());
+}

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -3308,6 +3308,34 @@ impl Path {
         fs::canonicalize(self)
     }
 
+    /// Makes the path absolute without accessing the filesystem.
+    ///
+    /// This is an alias to [`path::absolute`](absolute).
+    ///
+    /// # Errors
+    ///
+    /// This function may return an error in the following situations:
+    ///
+    /// * If the path is syntactically invalid; in particular, if it is empty.
+    /// * If getting the [current directory][crate::env::current_dir] fails.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// #![feature(path_absolute_method)]
+    /// use std::path::Path;
+    ///
+    /// let path = Path::new("foo/./bar");
+    /// let absolute = path.absolute()?;
+    /// assert!(absolute.is_absolute());
+    /// # Ok::<(), std::io::Error>(())
+    /// ```
+    #[unstable(feature = "path_absolute_method", issue = "153328")]
+    #[inline]
+    pub fn absolute(&self) -> io::Result<PathBuf> {
+        absolute(self)
+    }
+
     /// Normalize a path, including `..` without traversing the filesystem.
     ///
     /// Returns an error if normalization would leave leading `..` components.

--- a/library/std/src/thread/functions.rs
+++ b/library/std/src/thread/functions.rs
@@ -168,7 +168,11 @@ pub fn yield_now() {
     imp::yield_now()
 }
 
-/// Determines whether the current thread is unwinding because of panic.
+/// Determines whether the current thread is panicking.
+///
+/// This returns `true` both when the thread is unwinding due to a panic,
+/// or executing a panic hook. Note that the latter case will still happen
+/// when `panic=abort` is set.
 ///
 /// A common use of this feature is to poison shared resources when writing
 /// unsafe code, by checking `panicking` when the `drop` is called.
@@ -309,14 +313,14 @@ pub fn sleep(dur: Duration) {
 ///
 /// |  Platform |               System call                                            |
 /// |-----------|----------------------------------------------------------------------|
-/// | Linux     | [clock_nanosleep] (Monotonic clock)                                  |
-/// | BSD except OpenBSD | [clock_nanosleep] (Monotonic Clock)]                        |
-/// | Android   | [clock_nanosleep] (Monotonic Clock)]                                 |
-/// | Solaris   | [clock_nanosleep] (Monotonic Clock)]                                 |
-/// | Illumos   | [clock_nanosleep] (Monotonic Clock)]                                 |
-/// | Dragonfly | [clock_nanosleep] (Monotonic Clock)]                                 |
-/// | Hurd      | [clock_nanosleep] (Monotonic Clock)]                                 |
-/// | Vxworks   | [clock_nanosleep] (Monotonic Clock)]                                 |
+/// | Linux     | [clock_nanosleep] (Monotonic Clock)                                  |
+/// | BSD except OpenBSD | [clock_nanosleep] (Monotonic Clock)                         |
+/// | Android   | [clock_nanosleep] (Monotonic Clock)                                  |
+/// | Solaris   | [clock_nanosleep] (Monotonic Clock)                                  |
+/// | Illumos   | [clock_nanosleep] (Monotonic Clock)                                  |
+/// | Dragonfly | [clock_nanosleep] (Monotonic Clock)                                  |
+/// | Hurd      | [clock_nanosleep] (Monotonic Clock)                                  |
+/// | Vxworks   | [clock_nanosleep] (Monotonic Clock)                                  |
 /// | Apple     | `mach_wait_until`                                                    |
 /// | Other     | `sleep_until` uses [`sleep`] and does not issue a syscall itself     |
 ///

--- a/tests/rustdoc-html/primitive/auxiliary/reexport-fake_variadic.rs
+++ b/tests/rustdoc-html/primitive/auxiliary/reexport-fake_variadic.rs
@@ -1,0 +1,6 @@
+#![feature(rustdoc_internals)]
+
+pub trait Foo {}
+
+#[doc(fake_variadic)]
+impl<T> Foo for (T,) {}

--- a/tests/rustdoc-html/primitive/reexport-fake_variadic.rs
+++ b/tests/rustdoc-html/primitive/reexport-fake_variadic.rs
@@ -1,0 +1,12 @@
+// This test ensures that the `doc(fake_variadic)` attribute is correctly handled
+// through reexports.
+
+//@ aux-build:reexport-fake_variadic.rs
+
+#![crate_name = "foo"]
+
+extern crate reexport_fake_variadic as dep;
+
+//@ has foo/trait.Foo.html
+//@ has - '//section[@id="impl-Foo-for-(T,)"]/h3' 'impl<T> Foo for (T₁, T₂, …, Tₙ)'
+pub use dep::Foo;

--- a/tests/ui/attributes/key-value-expansion-scope.stderr
+++ b/tests/ui/attributes/key-value-expansion-scope.stderr
@@ -132,9 +132,9 @@ error: cannot find macro `in_root` in the current scope when looking from the cr
 LL | #![doc = in_root!()]
    |          ^^^^^^^ not found from the crate root
    |
+   = help: import `macro_rules` with `use` to make it callable above its definition
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
-   = help: import `macro_rules` with `use` to make it callable above its definition
    = note: `#[deny(out_of_scope_macro_calls)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: cannot find macro `in_mod_escape` in the current scope when looking from the crate root
@@ -143,9 +143,9 @@ error: cannot find macro `in_mod_escape` in the current scope when looking from 
 LL | #![doc = in_mod_escape!()]
    |          ^^^^^^^^^^^^^ not found from the crate root
    |
+   = help: import `macro_rules` with `use` to make it callable above its definition
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
-   = help: import `macro_rules` with `use` to make it callable above its definition
 
 error: cannot find macro `in_mod` in the current scope when looking from module `macros_stay`
   --> $DIR/key-value-expansion-scope.rs:31:9
@@ -153,9 +153,9 @@ error: cannot find macro `in_mod` in the current scope when looking from module 
 LL | #[doc = in_mod!()]
    |         ^^^^^^ not found from module `macros_stay`
    |
+   = help: import `macro_rules` with `use` to make it callable above its definition
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
-   = help: import `macro_rules` with `use` to make it callable above its definition
 
 error: cannot find macro `in_mod` in the current scope when looking from module `macros_stay`
   --> $DIR/key-value-expansion-scope.rs:34:14
@@ -163,9 +163,9 @@ error: cannot find macro `in_mod` in the current scope when looking from module 
 LL |     #![doc = in_mod!()]
    |              ^^^^^^ not found from module `macros_stay`
    |
+   = help: import `macro_rules` with `use` to make it callable above its definition
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
-   = help: import `macro_rules` with `use` to make it callable above its definition
 
 error: cannot find macro `in_mod_escape` in the current scope when looking from module `macros_escape`
   --> $DIR/key-value-expansion-scope.rs:46:9
@@ -173,9 +173,9 @@ error: cannot find macro `in_mod_escape` in the current scope when looking from 
 LL | #[doc = in_mod_escape!()]
    |         ^^^^^^^^^^^^^ not found from module `macros_escape`
    |
+   = help: import `macro_rules` with `use` to make it callable above its definition
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
-   = help: import `macro_rules` with `use` to make it callable above its definition
 
 error: cannot find macro `in_mod_escape` in the current scope when looking from module `macros_escape`
   --> $DIR/key-value-expansion-scope.rs:49:14
@@ -183,9 +183,9 @@ error: cannot find macro `in_mod_escape` in the current scope when looking from 
 LL |     #![doc = in_mod_escape!()]
    |              ^^^^^^^^^^^^^ not found from module `macros_escape`
    |
+   = help: import `macro_rules` with `use` to make it callable above its definition
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
-   = help: import `macro_rules` with `use` to make it callable above its definition
 
 error: attribute value must be a literal
   --> $DIR/key-value-expansion-scope.rs:3:10
@@ -292,9 +292,9 @@ error: cannot find macro `in_root` in the current scope when looking from the cr
 LL | #![doc = in_root!()]
    |          ^^^^^^^ not found from the crate root
    |
+   = help: import `macro_rules` with `use` to make it callable above its definition
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
-   = help: import `macro_rules` with `use` to make it callable above its definition
    = note: `#[deny(out_of_scope_macro_calls)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
@@ -304,9 +304,9 @@ error: cannot find macro `in_mod_escape` in the current scope when looking from 
 LL | #![doc = in_mod_escape!()]
    |          ^^^^^^^^^^^^^ not found from the crate root
    |
+   = help: import `macro_rules` with `use` to make it callable above its definition
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
-   = help: import `macro_rules` with `use` to make it callable above its definition
    = note: `#[deny(out_of_scope_macro_calls)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
@@ -316,9 +316,9 @@ error: cannot find macro `in_mod` in the current scope when looking from module 
 LL | #[doc = in_mod!()]
    |         ^^^^^^ not found from module `macros_stay`
    |
+   = help: import `macro_rules` with `use` to make it callable above its definition
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
-   = help: import `macro_rules` with `use` to make it callable above its definition
    = note: `#[deny(out_of_scope_macro_calls)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
@@ -328,9 +328,9 @@ error: cannot find macro `in_mod` in the current scope when looking from module 
 LL |     #![doc = in_mod!()]
    |              ^^^^^^ not found from module `macros_stay`
    |
+   = help: import `macro_rules` with `use` to make it callable above its definition
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
-   = help: import `macro_rules` with `use` to make it callable above its definition
    = note: `#[deny(out_of_scope_macro_calls)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
@@ -340,9 +340,9 @@ error: cannot find macro `in_mod_escape` in the current scope when looking from 
 LL | #[doc = in_mod_escape!()]
    |         ^^^^^^^^^^^^^ not found from module `macros_escape`
    |
+   = help: import `macro_rules` with `use` to make it callable above its definition
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
-   = help: import `macro_rules` with `use` to make it callable above its definition
    = note: `#[deny(out_of_scope_macro_calls)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
@@ -352,8 +352,8 @@ error: cannot find macro `in_mod_escape` in the current scope when looking from 
 LL |     #![doc = in_mod_escape!()]
    |              ^^^^^^^^^^^^^ not found from module `macros_escape`
    |
+   = help: import `macro_rules` with `use` to make it callable above its definition
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
-   = help: import `macro_rules` with `use` to make it callable above its definition
    = note: `#[deny(out_of_scope_macro_calls)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-1.stderr
+++ b/tests/ui/imports/ambiguous-1.stderr
@@ -15,8 +15,6 @@ warning: `id` is ambiguous
 LL |     id();
    |     ^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `id` could refer to the function imported here
   --> $DIR/ambiguous-1.rs:13:13
@@ -30,6 +28,8 @@ note: `id` could also refer to the function imported here
 LL |     pub use self::handwritten::*;
    |             ^^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `id` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
 note: the lint level is defined here
   --> $DIR/ambiguous-1.rs:4:9
    |
@@ -45,8 +45,6 @@ warning: `id` is ambiguous
 LL |     id();
    |     ^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `id` could refer to the function imported here
   --> $DIR/ambiguous-1.rs:13:13
@@ -60,6 +58,8 @@ note: `id` could also refer to the function imported here
 LL |     pub use self::handwritten::*;
    |             ^^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `id` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
 note: the lint level is defined here
   --> $DIR/ambiguous-1.rs:4:9
    |

--- a/tests/ui/imports/ambiguous-10.stderr
+++ b/tests/ui/imports/ambiguous-10.stderr
@@ -4,8 +4,6 @@ error: `Token` is ambiguous
 LL | fn c(_: Token) {}
    |         ^^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `Token` could refer to the enum imported here
   --> $DIR/ambiguous-10.rs:13:5
@@ -19,6 +17,8 @@ note: `Token` could also refer to the enum imported here
 LL | use crate::b::*;
    |     ^^^^^^^^^^^
    = help: consider adding an explicit import of `Token` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
@@ -30,8 +30,6 @@ error: `Token` is ambiguous
 LL | fn c(_: Token) {}
    |         ^^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `Token` could refer to the enum imported here
   --> $DIR/ambiguous-10.rs:13:5
@@ -45,5 +43,7 @@ note: `Token` could also refer to the enum imported here
 LL | use crate::b::*;
    |     ^^^^^^^^^^^
    = help: consider adding an explicit import of `Token` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-12.stderr
+++ b/tests/ui/imports/ambiguous-12.stderr
@@ -4,8 +4,6 @@ error: `b` is ambiguous
 LL |     b();
    |     ^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `b` could refer to the function imported here
   --> $DIR/ambiguous-12.rs:17:5
@@ -19,6 +17,8 @@ note: `b` could also refer to the function imported here
 LL | use crate::public::*;
    |     ^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `b` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
@@ -30,8 +30,6 @@ error: `b` is ambiguous
 LL |     b();
    |     ^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `b` could refer to the function imported here
   --> $DIR/ambiguous-12.rs:17:5
@@ -45,5 +43,7 @@ note: `b` could also refer to the function imported here
 LL | use crate::public::*;
    |     ^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `b` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-13.stderr
+++ b/tests/ui/imports/ambiguous-13.stderr
@@ -4,8 +4,6 @@ error: `Rect` is ambiguous
 LL | fn a(_: Rect) {}
    |         ^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `Rect` could refer to the struct imported here
   --> $DIR/ambiguous-13.rs:15:5
@@ -19,6 +17,8 @@ note: `Rect` could also refer to the struct imported here
 LL | use crate::content::*;
    |     ^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `Rect` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
@@ -30,8 +30,6 @@ error: `Rect` is ambiguous
 LL | fn a(_: Rect) {}
    |         ^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `Rect` could refer to the struct imported here
   --> $DIR/ambiguous-13.rs:15:5
@@ -45,5 +43,7 @@ note: `Rect` could also refer to the struct imported here
 LL | use crate::content::*;
    |     ^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `Rect` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-14.stderr
+++ b/tests/ui/imports/ambiguous-14.stderr
@@ -4,8 +4,6 @@ error: `foo` is ambiguous
 LL |     g::foo();
    |        ^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `foo` could refer to the function imported here
   --> $DIR/ambiguous-14.rs:18:13
@@ -19,6 +17,8 @@ note: `foo` could also refer to the function imported here
 LL |     pub use f::*;
    |             ^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
@@ -30,8 +30,6 @@ error: `foo` is ambiguous
 LL |     g::foo();
    |        ^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `foo` could refer to the function imported here
   --> $DIR/ambiguous-14.rs:18:13
@@ -45,5 +43,7 @@ note: `foo` could also refer to the function imported here
 LL |     pub use f::*;
    |             ^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-15.stderr
+++ b/tests/ui/imports/ambiguous-15.stderr
@@ -4,8 +4,6 @@ error: `Error` is ambiguous
 LL | fn a<E: Error>(_: E) {}
    |         ^^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `Error` could refer to the trait imported here
   --> $DIR/ambiguous-15.rs:21:5
@@ -19,6 +17,8 @@ note: `Error` could also refer to the enum imported here
 LL | pub use t2::*;
    |         ^^^^^
    = help: consider adding an explicit import of `Error` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
@@ -30,8 +30,6 @@ error: `Error` is ambiguous
 LL | fn a<E: Error>(_: E) {}
    |         ^^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `Error` could refer to the trait imported here
   --> $DIR/ambiguous-15.rs:21:5
@@ -45,5 +43,7 @@ note: `Error` could also refer to the enum imported here
 LL | pub use t2::*;
    |         ^^^^^
    = help: consider adding an explicit import of `Error` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-16.stderr
+++ b/tests/ui/imports/ambiguous-16.stderr
@@ -4,8 +4,6 @@ error: `ConfirmedTranscriptHashInput` is ambiguous
 LL | use crate::framing::ConfirmedTranscriptHashInput;
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `ConfirmedTranscriptHashInput` could refer to the struct imported here
   --> $DIR/ambiguous-16.rs:18:13
@@ -19,6 +17,8 @@ note: `ConfirmedTranscriptHashInput` could also refer to the struct imported her
 LL |     pub use self::public_message_in::*;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `ConfirmedTranscriptHashInput` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
@@ -30,8 +30,6 @@ error: `ConfirmedTranscriptHashInput` is ambiguous
 LL | use crate::framing::ConfirmedTranscriptHashInput;
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `ConfirmedTranscriptHashInput` could refer to the struct imported here
   --> $DIR/ambiguous-16.rs:18:13
@@ -45,5 +43,7 @@ note: `ConfirmedTranscriptHashInput` could also refer to the struct imported her
 LL |     pub use self::public_message_in::*;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `ConfirmedTranscriptHashInput` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-17.stderr
+++ b/tests/ui/imports/ambiguous-17.stderr
@@ -14,8 +14,6 @@ error: `id` is ambiguous
 LL |     id();
    |     ^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `id` could refer to the function imported here
   --> $DIR/ambiguous-17.rs:4:9
@@ -29,6 +27,8 @@ note: `id` could also refer to the function imported here
 LL | pub use handwritten::*;
    |         ^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `id` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error; 1 warning emitted
@@ -40,8 +40,6 @@ error: `id` is ambiguous
 LL |     id();
    |     ^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `id` could refer to the function imported here
   --> $DIR/ambiguous-17.rs:4:9
@@ -55,5 +53,7 @@ note: `id` could also refer to the function imported here
 LL | pub use handwritten::*;
    |         ^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `id` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-2.stderr
+++ b/tests/ui/imports/ambiguous-2.stderr
@@ -4,8 +4,6 @@ error: `id` is ambiguous
 LL |     ambiguous_1::id();
    |                  ^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `id` could refer to the function defined here
   --> $DIR/auxiliary/../ambiguous-1.rs:13:13
@@ -19,6 +17,8 @@ note: `id` could also refer to the function defined here
    |
 LL |     pub use self::handwritten::*;
    |             ^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
@@ -30,8 +30,6 @@ error: `id` is ambiguous
 LL |     ambiguous_1::id();
    |                  ^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `id` could refer to the function defined here
   --> $DIR/auxiliary/../ambiguous-1.rs:13:13
@@ -45,5 +43,7 @@ note: `id` could also refer to the function defined here
    |
 LL |     pub use self::handwritten::*;
    |             ^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-3.stderr
+++ b/tests/ui/imports/ambiguous-3.stderr
@@ -4,8 +4,6 @@ error: `x` is ambiguous
 LL |     x();
    |     ^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `x` could refer to the function imported here
   --> $DIR/ambiguous-3.rs:18:13
@@ -19,6 +17,8 @@ note: `x` could also refer to the function imported here
 LL |     pub use self::c::*;
    |             ^^^^^^^^^^
    = help: consider adding an explicit import of `x` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
@@ -30,8 +30,6 @@ error: `x` is ambiguous
 LL |     x();
    |     ^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `x` could refer to the function imported here
   --> $DIR/ambiguous-3.rs:18:13
@@ -45,5 +43,7 @@ note: `x` could also refer to the function imported here
 LL |     pub use self::c::*;
    |             ^^^^^^^^^^
    = help: consider adding an explicit import of `x` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-4-extern.stderr
+++ b/tests/ui/imports/ambiguous-4-extern.stderr
@@ -14,8 +14,6 @@ warning: `id` is ambiguous
 LL |     id();
    |     ^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `id` could refer to the function imported here
   --> $DIR/ambiguous-4-extern.rs:13:9
@@ -29,6 +27,8 @@ note: `id` could also refer to the function imported here
 LL | pub use handwritten::*;
    |         ^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `id` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
 note: the lint level is defined here
   --> $DIR/ambiguous-4-extern.rs:5:9
    |
@@ -44,8 +44,6 @@ warning: `id` is ambiguous
 LL |     id();
    |     ^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `id` could refer to the function imported here
   --> $DIR/ambiguous-4-extern.rs:13:9
@@ -59,6 +57,8 @@ note: `id` could also refer to the function imported here
 LL | pub use handwritten::*;
    |         ^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `id` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
 note: the lint level is defined here
   --> $DIR/ambiguous-4-extern.rs:5:9
    |

--- a/tests/ui/imports/ambiguous-4.stderr
+++ b/tests/ui/imports/ambiguous-4.stderr
@@ -4,8 +4,6 @@ error: `id` is ambiguous
 LL |     ambiguous_4_extern::id();
    |                         ^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `id` could refer to the function defined here
   --> $DIR/auxiliary/../ambiguous-4-extern.rs:13:9
@@ -19,6 +17,8 @@ note: `id` could also refer to the function defined here
    |
 LL | pub use handwritten::*;
    |         ^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
@@ -30,8 +30,6 @@ error: `id` is ambiguous
 LL |     ambiguous_4_extern::id();
    |                         ^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `id` could refer to the function defined here
   --> $DIR/auxiliary/../ambiguous-4-extern.rs:13:9
@@ -45,5 +43,7 @@ note: `id` could also refer to the function defined here
    |
 LL | pub use handwritten::*;
    |         ^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-5.stderr
+++ b/tests/ui/imports/ambiguous-5.stderr
@@ -4,8 +4,6 @@ error: `Class` is ambiguous
 LL |     struct MarkRecord(Class);
    |                       ^^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `Class` could refer to the struct imported here
   --> $DIR/ambiguous-5.rs:11:9
@@ -19,6 +17,8 @@ note: `Class` could also refer to the struct imported here
 LL |     use super::gsubgpos::*;
    |         ^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `Class` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
@@ -30,8 +30,6 @@ error: `Class` is ambiguous
 LL |     struct MarkRecord(Class);
    |                       ^^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `Class` could refer to the struct imported here
   --> $DIR/ambiguous-5.rs:11:9
@@ -45,5 +43,7 @@ note: `Class` could also refer to the struct imported here
 LL |     use super::gsubgpos::*;
    |         ^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `Class` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-6.stderr
+++ b/tests/ui/imports/ambiguous-6.stderr
@@ -4,8 +4,6 @@ error: `C` is ambiguous
 LL |     C
    |     ^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `C` could refer to the constant imported here
   --> $DIR/ambiguous-6.rs:15:13
@@ -19,6 +17,8 @@ note: `C` could also refer to the constant imported here
 LL |     pub use mod2::*;
    |             ^^^^^^^
    = help: consider adding an explicit import of `C` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
@@ -30,8 +30,6 @@ error: `C` is ambiguous
 LL |     C
    |     ^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `C` could refer to the constant imported here
   --> $DIR/ambiguous-6.rs:15:13
@@ -45,5 +43,7 @@ note: `C` could also refer to the constant imported here
 LL |     pub use mod2::*;
    |             ^^^^^^^
    = help: consider adding an explicit import of `C` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-9.stderr
+++ b/tests/ui/imports/ambiguous-9.stderr
@@ -14,8 +14,6 @@ error: `date_range` is ambiguous
 LL |     date_range();
    |     ^^^^^^^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `date_range` could refer to the function imported here
   --> $DIR/ambiguous-9.rs:7:13
@@ -29,6 +27,8 @@ note: `date_range` could also refer to the function imported here
 LL |     use super::prelude::*;
    |         ^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `date_range` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 warning: ambiguous glob re-exports
@@ -45,8 +45,6 @@ error: `date_range` is ambiguous
 LL |     date_range();
    |     ^^^^^^^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `date_range` could refer to the function imported here
   --> $DIR/ambiguous-9.rs:19:5
@@ -60,6 +58,8 @@ note: `date_range` could also refer to the function imported here
 LL | use prelude::*;
    |     ^^^^^^^^^^
    = help: consider adding an explicit import of `date_range` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
 
 error: aborting due to 2 previous errors; 2 warnings emitted
 
@@ -70,8 +70,6 @@ error: `date_range` is ambiguous
 LL |     date_range();
    |     ^^^^^^^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `date_range` could refer to the function imported here
   --> $DIR/ambiguous-9.rs:7:13
@@ -85,6 +83,8 @@ note: `date_range` could also refer to the function imported here
 LL |     use super::prelude::*;
    |         ^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `date_range` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
@@ -94,8 +94,6 @@ error: `date_range` is ambiguous
 LL |     date_range();
    |     ^^^^^^^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `date_range` could refer to the function imported here
   --> $DIR/ambiguous-9.rs:19:5
@@ -109,5 +107,7 @@ note: `date_range` could also refer to the function imported here
 LL | use prelude::*;
    |     ^^^^^^^^^^
    = help: consider adding an explicit import of `date_range` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-import-visibility-macro.stderr
+++ b/tests/ui/imports/ambiguous-import-visibility-macro.stderr
@@ -4,8 +4,6 @@ warning: ambiguous import visibility: pub(crate) or pub
 LL | pub use RustEmbed as Embed;
    |         ^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #149145 <https://github.com/rust-lang/rust/issues/149145>
    = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
 note: `RustEmbed` could refer to the derive macro imported here
   --> $DIR/ambiguous-import-visibility-macro.rs:7:17
@@ -22,6 +20,8 @@ note: `RustEmbed` could also refer to the derive macro imported here
    |
 LL | #[macro_use] // this imports the `RustEmbed` macro with `pub(crate)` visibility
    | ^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #149145 <https://github.com/rust-lang/rust/issues/149145>
    = note: `#[warn(ambiguous_import_visibilities)]` (part of `#[warn(future_incompatible)]`) on by default
    = note: this warning originates in the macro `globbing` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/imports/ambiguous-import-visibility-module.stderr
+++ b/tests/ui/imports/ambiguous-import-visibility-module.stderr
@@ -4,8 +4,6 @@ warning: ambiguous import visibility: pub or pub(in crate::reexport)
 LL |     pub use S as Z;
    |             ^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #149145 <https://github.com/rust-lang/rust/issues/149145>
    = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
 note: `S` could refer to the struct imported here
   --> $DIR/ambiguous-import-visibility-module.rs:11:17
@@ -22,6 +20,8 @@ note: `S` could also refer to the struct imported here
 LL |     pub use m::*;
    |             ^^^^
    = help: use `self::S` to refer to this struct unambiguously
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #149145 <https://github.com/rust-lang/rust/issues/149145>
    = note: `#[warn(ambiguous_import_visibilities)]` (part of `#[warn(future_incompatible)]`) on by default
    = note: this warning originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/imports/ambiguous-import-visibility.stderr
+++ b/tests/ui/imports/ambiguous-import-visibility.stderr
@@ -4,8 +4,6 @@ warning: ambiguous import visibility: pub(crate) or pub
 LL | pub use RustEmbed as Embed;
    |         ^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #149145 <https://github.com/rust-lang/rust/issues/149145>
    = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
 note: `RustEmbed` could refer to the derive macro imported here
   --> $DIR/ambiguous-import-visibility.rs:8:9
@@ -19,6 +17,8 @@ note: `RustEmbed` could also refer to the derive macro imported here
    |
 LL | #[macro_use] // this imports the `RustEmbed` macro with `pub(crate)` visibility
    | ^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #149145 <https://github.com/rust-lang/rust/issues/149145>
    = note: `#[warn(ambiguous_import_visibilities)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: 1 warning emitted

--- a/tests/ui/imports/ambiguous-panic-globvsglob.stderr
+++ b/tests/ui/imports/ambiguous-panic-globvsglob.stderr
@@ -4,8 +4,6 @@ error: `panic` is ambiguous
 LL |     panic!();
    |     ^^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `panic` could refer to the macro imported here
   --> $DIR/ambiguous-panic-globvsglob.rs:12:9
@@ -19,6 +17,8 @@ note: `panic` could also refer to the macro imported here
 LL |     use m2::*;
    |         ^^^^^
    = help: consider adding an explicit import of `panic` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 warning: `panic` is ambiguous
@@ -27,8 +27,6 @@ warning: `panic` is ambiguous
 LL |     panic!();
    |     ^^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #147319 <https://github.com/rust-lang/rust/issues/147319>
    = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
 note: `panic` could refer to the macro imported here
   --> $DIR/ambiguous-panic-globvsglob.rs:12:9
@@ -38,6 +36,8 @@ LL |     use m1::*;
    = help: consider adding an explicit import of `panic` to disambiguate
 note: `panic` could also refer to a macro from prelude
   --> $SRC_DIR/std/src/prelude/mod.rs:LL:COL
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #147319 <https://github.com/rust-lang/rust/issues/147319>
    = note: `#[warn(ambiguous_panic_imports)]` (part of `#[warn(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error; 1 warning emitted
@@ -49,8 +49,6 @@ error: `panic` is ambiguous
 LL |     panic!();
    |     ^^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `panic` could refer to the macro imported here
   --> $DIR/ambiguous-panic-globvsglob.rs:12:9
@@ -64,5 +62,7 @@ note: `panic` could also refer to the macro imported here
 LL |     use m2::*;
    |         ^^^^^
    = help: consider adding an explicit import of `panic` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-panic-non-prelude-core-glob.stderr
+++ b/tests/ui/imports/ambiguous-panic-non-prelude-core-glob.stderr
@@ -4,8 +4,6 @@ warning: `panic` is ambiguous
 LL |     panic!();
    |     ^^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #147319 <https://github.com/rust-lang/rust/issues/147319>
    = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
 note: `panic` could refer to the macro imported here
   --> $DIR/ambiguous-panic-non-prelude-core-glob.rs:5:5
@@ -16,6 +14,8 @@ LL | use ::core::*;
    = help: or use `crate::panic` to refer to this macro unambiguously
 note: `panic` could also refer to a macro from prelude
   --> $SRC_DIR/std/src/prelude/mod.rs:LL:COL
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #147319 <https://github.com/rust-lang/rust/issues/147319>
    = note: `#[warn(ambiguous_panic_imports)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: 1 warning emitted

--- a/tests/ui/imports/ambiguous-panic-non-prelude-std-glob.stderr
+++ b/tests/ui/imports/ambiguous-panic-non-prelude-std-glob.stderr
@@ -4,8 +4,6 @@ warning: `panic` is ambiguous
 LL |     panic!();
    |     ^^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #147319 <https://github.com/rust-lang/rust/issues/147319>
    = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
 note: `panic` could refer to the macro imported here
   --> $DIR/ambiguous-panic-non-prelude-std-glob.rs:6:5
@@ -16,6 +14,8 @@ LL | use ::std::*;
    = help: or use `crate::panic` to refer to this macro unambiguously
 note: `panic` could also refer to a macro from prelude
   --> $SRC_DIR/core/src/prelude/mod.rs:LL:COL
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #147319 <https://github.com/rust-lang/rust/issues/147319>
    = note: `#[warn(ambiguous_panic_imports)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: 1 warning emitted

--- a/tests/ui/imports/ambiguous-panic-pick-core.stderr
+++ b/tests/ui/imports/ambiguous-panic-pick-core.stderr
@@ -4,8 +4,6 @@ warning: `panic` is ambiguous
 LL |     panic!(&std::string::String::new());
    |     ^^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #147319 <https://github.com/rust-lang/rust/issues/147319>
    = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
 note: `panic` could refer to the macro imported here
   --> $DIR/ambiguous-panic-pick-core.rs:4:5
@@ -16,6 +14,8 @@ LL | use ::core::prelude::v1::*;
    = help: or use `crate::panic` to refer to this macro unambiguously
 note: `panic` could also refer to a macro from prelude
   --> $SRC_DIR/std/src/prelude/mod.rs:LL:COL
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #147319 <https://github.com/rust-lang/rust/issues/147319>
    = note: `#[warn(ambiguous_panic_imports)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: panic message is not a string literal

--- a/tests/ui/imports/ambiguous-panic-pick-std.stderr
+++ b/tests/ui/imports/ambiguous-panic-pick-std.stderr
@@ -4,8 +4,6 @@ warning: `panic` is ambiguous
 LL |     panic!(std::string::String::new());
    |     ^^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #147319 <https://github.com/rust-lang/rust/issues/147319>
    = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
 note: `panic` could refer to the macro imported here
   --> $DIR/ambiguous-panic-pick-std.rs:7:5
@@ -16,6 +14,8 @@ LL | use ::std::prelude::v1::*;
    = help: or use `crate::panic` to refer to this macro unambiguously
 note: `panic` could also refer to a macro from prelude
   --> $SRC_DIR/core/src/prelude/mod.rs:LL:COL
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #147319 <https://github.com/rust-lang/rust/issues/147319>
    = note: `#[warn(ambiguous_panic_imports)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: panic message is not a string literal

--- a/tests/ui/imports/ambiguous-panic-re-emit.stderr
+++ b/tests/ui/imports/ambiguous-panic-re-emit.stderr
@@ -10,8 +10,6 @@ warning: `panic` is ambiguous
 LL |     panic!();
    |     ^^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #147319 <https://github.com/rust-lang/rust/issues/147319>
    = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
 note: `panic` could refer to the macro imported here
   --> $DIR/ambiguous-panic-re-emit.rs:11:9
@@ -22,6 +20,8 @@ LL |     use std::prelude::v1::*;
    = help: or use `crate::panic` to refer to this macro unambiguously
 note: `panic` could also refer to a macro from prelude
   --> $SRC_DIR/core/src/prelude/mod.rs:LL:COL
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #147319 <https://github.com/rust-lang/rust/issues/147319>
    = note: `#[warn(ambiguous_panic_imports)]` (part of `#[warn(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error; 1 warning emitted

--- a/tests/ui/imports/ambiguous-panic.stderr
+++ b/tests/ui/imports/ambiguous-panic.stderr
@@ -4,8 +4,6 @@ error: `panic` is ambiguous
 LL |     panic!();
    |     ^^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #147319 <https://github.com/rust-lang/rust/issues/147319>
    = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
 note: `panic` could refer to the macro imported here
   --> $DIR/ambiguous-panic.rs:6:5
@@ -16,6 +14,8 @@ LL | use std::prelude::v1::*;
    = help: or use `crate::panic` to refer to this macro unambiguously
 note: `panic` could also refer to a macro from prelude
   --> $SRC_DIR/core/src/prelude/mod.rs:LL:COL
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #147319 <https://github.com/rust-lang/rust/issues/147319>
 note: the lint level is defined here
   --> $DIR/ambiguous-panic.rs:1:9
    |

--- a/tests/ui/imports/ambiguous-reachable.stderr
+++ b/tests/ui/imports/ambiguous-reachable.stderr
@@ -5,8 +5,6 @@ warning: `generic` is ambiguous
 LL |     ambiguous_reachable_extern::generic::<u8>();
    |                                 ^^^^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `generic` could refer to the function defined here
   --> $DIR/auxiliary/ambiguous-reachable-extern.rs:13:9
@@ -20,4 +18,6 @@ note: `generic` could also refer to the function defined here
    |
 LL | pub use m2::*;
    |         ^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
 

--- a/tests/ui/imports/duplicate.stderr
+++ b/tests/ui/imports/duplicate.stderr
@@ -74,8 +74,6 @@ error: `foo` is ambiguous
 LL |     g::foo();
    |        ^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `foo` could refer to the function imported here
   --> $DIR/duplicate.rs:29:13
@@ -89,6 +87,8 @@ note: `foo` could also refer to the function imported here
 LL |     pub use crate::f::*;
    |             ^^^^^^^^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 5 previous errors
@@ -102,8 +102,6 @@ error: `foo` is ambiguous
 LL |     g::foo();
    |        ^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `foo` could refer to the function imported here
   --> $DIR/duplicate.rs:29:13
@@ -117,5 +115,7 @@ note: `foo` could also refer to the function imported here
 LL |     pub use crate::f::*;
    |             ^^^^^^^^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/glob-conflict-cross-crate-1.stderr
+++ b/tests/ui/imports/glob-conflict-cross-crate-1.stderr
@@ -4,8 +4,6 @@ error: `f` is ambiguous
 LL |     glob_conflict::f();
    |                    ^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `f` could refer to the function defined here
   --> $DIR/auxiliary/glob-conflict.rs:12:9
@@ -19,6 +17,8 @@ note: `f` could also refer to the function defined here
    |
 LL | pub use m2::*;
    |         ^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: `f` is ambiguous
@@ -27,8 +27,6 @@ error: `f` is ambiguous
 LL |     glob_conflict::glob::f();
    |                          ^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `f` could refer to the function defined here
   --> $DIR/auxiliary/glob-conflict.rs:12:9
@@ -42,6 +40,8 @@ note: `f` could also refer to the function defined here
    |
 LL | pub use m2::*;
    |         ^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
 
 error: aborting due to 2 previous errors
 
@@ -52,8 +52,6 @@ error: `f` is ambiguous
 LL |     glob_conflict::f();
    |                    ^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `f` could refer to the function defined here
   --> $DIR/auxiliary/glob-conflict.rs:12:9
@@ -67,6 +65,8 @@ note: `f` could also refer to the function defined here
    |
 LL | pub use m2::*;
    |         ^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
@@ -76,8 +76,6 @@ error: `f` is ambiguous
 LL |     glob_conflict::glob::f();
    |                          ^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `f` could refer to the function defined here
   --> $DIR/auxiliary/glob-conflict.rs:12:9
@@ -91,5 +89,7 @@ note: `f` could also refer to the function defined here
    |
 LL | pub use m2::*;
    |         ^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/glob-conflict-cross-crate-2.stderr
+++ b/tests/ui/imports/glob-conflict-cross-crate-2.stderr
@@ -4,8 +4,6 @@ error: `C` is ambiguous
 LL |     let _a: C = 1;
    |             ^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `C` could refer to the type alias defined here
   --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:9:9
@@ -19,6 +17,8 @@ note: `C` could also refer to the type alias defined here
    |
 LL | pub use b::*;
    |         ^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
@@ -30,8 +30,6 @@ error: `C` is ambiguous
 LL |     let _a: C = 1;
    |             ^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `C` could refer to the type alias defined here
   --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:9:9
@@ -45,5 +43,7 @@ note: `C` could also refer to the type alias defined here
    |
 LL | pub use b::*;
    |         ^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/glob-conflict-cross-crate-3.stderr
+++ b/tests/ui/imports/glob-conflict-cross-crate-3.stderr
@@ -4,8 +4,6 @@ error: `C` is ambiguous
 LL |     let _a: C = 1;
    |             ^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `C` could refer to the type alias defined here
   --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:9:9
@@ -19,6 +17,8 @@ note: `C` could also refer to the type alias defined here
    |
 LL | pub use b::*;
    |         ^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: `C` is ambiguous
@@ -27,8 +27,6 @@ error: `C` is ambiguous
 LL |     let _a: C = 1;
    |             ^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `C` could refer to the type alias imported here
   --> $DIR/glob-conflict-cross-crate-3.rs:9:5
@@ -42,6 +40,8 @@ note: `C` could also refer to the type alias imported here
 LL | use a::*;
    |     ^^^^
    = help: consider adding an explicit import of `C` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
 
 error: aborting due to 2 previous errors
 
@@ -52,8 +52,6 @@ error: `C` is ambiguous
 LL |     let _a: C = 1;
    |             ^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `C` could refer to the type alias defined here
   --> $DIR/auxiliary/glob-conflict-cross-crate-2-extern.rs:9:9
@@ -67,6 +65,8 @@ note: `C` could also refer to the type alias defined here
    |
 LL | pub use b::*;
    |         ^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
@@ -76,8 +76,6 @@ error: `C` is ambiguous
 LL |     let _a: C = 1;
    |             ^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `C` could refer to the type alias imported here
   --> $DIR/glob-conflict-cross-crate-3.rs:9:5
@@ -91,5 +89,7 @@ note: `C` could also refer to the type alias imported here
 LL | use a::*;
    |     ^^^^
    = help: consider adding an explicit import of `C` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/issue-114682-2.stderr
+++ b/tests/ui/imports/issue-114682-2.stderr
@@ -4,8 +4,6 @@ error: `max` is ambiguous
 LL | use issue_114682_2_extern::max;
    |                            ^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `max` could refer to the type alias defined here
   --> $DIR/auxiliary/issue-114682-2-extern.rs:17:9
@@ -19,6 +17,8 @@ note: `max` could also refer to the module defined here
    |
 LL | pub use self::d::*;
    |         ^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: `max` is ambiguous
@@ -27,8 +27,6 @@ error: `max` is ambiguous
 LL | type A = issue_114682_2_extern::max;
    |                                 ^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `max` could refer to the type alias defined here
   --> $DIR/auxiliary/issue-114682-2-extern.rs:17:9
@@ -42,6 +40,8 @@ note: `max` could also refer to the module defined here
    |
 LL | pub use self::d::*;
    |         ^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
 
 error: aborting due to 2 previous errors
 
@@ -52,8 +52,6 @@ error: `max` is ambiguous
 LL | use issue_114682_2_extern::max;
    |                            ^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `max` could refer to the type alias defined here
   --> $DIR/auxiliary/issue-114682-2-extern.rs:17:9
@@ -67,6 +65,8 @@ note: `max` could also refer to the module defined here
    |
 LL | pub use self::d::*;
    |         ^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
@@ -76,8 +76,6 @@ error: `max` is ambiguous
 LL | type A = issue_114682_2_extern::max;
    |                                 ^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `max` could refer to the type alias defined here
   --> $DIR/auxiliary/issue-114682-2-extern.rs:17:9
@@ -91,5 +89,7 @@ note: `max` could also refer to the module defined here
    |
 LL | pub use self::d::*;
    |         ^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/issue-114682-4.stderr
+++ b/tests/ui/imports/issue-114682-4.stderr
@@ -4,8 +4,6 @@ error: `Result` is ambiguous
 LL | fn a() -> Result<i32, ()> {
    |           ^^^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `Result` could refer to the type alias defined here
   --> $DIR/auxiliary/issue-114682-4-extern.rs:9:9
@@ -19,6 +17,8 @@ note: `Result` could also refer to the type alias defined here
    |
 LL | pub use b::*;
    |         ^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error[E0107]: type alias takes 1 generic argument but 2 generic arguments were supplied
@@ -45,8 +45,6 @@ error: `Result` is ambiguous
 LL | fn a() -> Result<i32, ()> {
    |           ^^^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `Result` could refer to the type alias defined here
   --> $DIR/auxiliary/issue-114682-4-extern.rs:9:9
@@ -60,5 +58,7 @@ note: `Result` could also refer to the type alias defined here
    |
 LL | pub use b::*;
    |         ^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/issue-114682-5.stderr
+++ b/tests/ui/imports/issue-114682-5.stderr
@@ -32,8 +32,6 @@ error: `issue_114682_5_extern_1` is ambiguous
 LL | use issue_114682_5_extern_1::Url;
    |     ^^^^^^^^^^^^^^^^^^^^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `issue_114682_5_extern_1` could refer to the module defined here
   --> $DIR/auxiliary/issue-114682-5-extern-2.rs:6:13
@@ -48,6 +46,8 @@ note: `issue_114682_5_extern_1` could also refer to the crate defined here
 LL |     pub use crate::*;
    |             ^^^^^
    = help: use `::issue_114682_5_extern_1` to refer to this crate unambiguously
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 3 previous errors
@@ -61,8 +61,6 @@ error: `issue_114682_5_extern_1` is ambiguous
 LL | use issue_114682_5_extern_1::Url;
    |     ^^^^^^^^^^^^^^^^^^^^^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `issue_114682_5_extern_1` could refer to the module defined here
   --> $DIR/auxiliary/issue-114682-5-extern-2.rs:6:13
@@ -77,5 +75,7 @@ note: `issue_114682_5_extern_1` could also refer to the crate defined here
 LL |     pub use crate::*;
    |             ^^^^^
    = help: use `::issue_114682_5_extern_1` to refer to this crate unambiguously
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/issue-114682-6.stderr
+++ b/tests/ui/imports/issue-114682-6.stderr
@@ -4,8 +4,6 @@ error: `log` is ambiguous
 LL |     let log = 2;
    |         ^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `log` could refer to the function defined here
   --> $DIR/auxiliary/issue-114682-6-extern.rs:8:9
@@ -19,6 +17,8 @@ note: `log` could also refer to the function defined here
    |
 LL | pub use self::b::*;
    |         ^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
@@ -30,8 +30,6 @@ error: `log` is ambiguous
 LL |     let log = 2;
    |         ^^^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `log` could refer to the function defined here
   --> $DIR/auxiliary/issue-114682-6-extern.rs:8:9
@@ -45,5 +43,7 @@ note: `log` could also refer to the function defined here
    |
 LL | pub use self::b::*;
    |         ^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/local-modularized-tricky-fail-2.stderr
+++ b/tests/ui/imports/local-modularized-tricky-fail-2.stderr
@@ -4,8 +4,6 @@ error: macro-expanded `macro_export` macros from the current crate cannot be ref
 LL |     use crate::exported;
    |         ^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #52234 <https://github.com/rust-lang/rust/issues/52234>
 note: the macro is defined here
   --> $DIR/local-modularized-tricky-fail-2.rs:5:5
    |
@@ -16,6 +14,8 @@ LL | |     }
 ...
 LL |   define_exported!();
    |   ------------------ in this macro invocation
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #52234 <https://github.com/rust-lang/rust/issues/52234>
    = note: `#[deny(macro_expanded_macro_exports_accessed_by_absolute_paths)]` (part of `#[deny(future_incompatible)]`) on by default
    = note: this error originates in the macro `define_exported` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -25,8 +25,6 @@ error: macro-expanded `macro_export` macros from the current crate cannot be ref
 LL |     crate::exported!();
    |     ^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #52234 <https://github.com/rust-lang/rust/issues/52234>
 note: the macro is defined here
   --> $DIR/local-modularized-tricky-fail-2.rs:5:5
    |
@@ -37,6 +35,8 @@ LL | |     }
 ...
 LL |   define_exported!();
    |   ------------------ in this macro invocation
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #52234 <https://github.com/rust-lang/rust/issues/52234>
    = note: this error originates in the macro `define_exported` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
@@ -48,8 +48,6 @@ error: macro-expanded `macro_export` macros from the current crate cannot be ref
 LL |     use crate::exported;
    |         ^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #52234 <https://github.com/rust-lang/rust/issues/52234>
 note: the macro is defined here
   --> $DIR/local-modularized-tricky-fail-2.rs:5:5
    |
@@ -60,6 +58,8 @@ LL | |     }
 ...
 LL |   define_exported!();
    |   ------------------ in this macro invocation
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #52234 <https://github.com/rust-lang/rust/issues/52234>
    = note: `#[deny(macro_expanded_macro_exports_accessed_by_absolute_paths)]` (part of `#[deny(future_incompatible)]`) on by default
    = note: this error originates in the macro `define_exported` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -70,8 +70,6 @@ error: macro-expanded `macro_export` macros from the current crate cannot be ref
 LL |     crate::exported!();
    |     ^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #52234 <https://github.com/rust-lang/rust/issues/52234>
 note: the macro is defined here
   --> $DIR/local-modularized-tricky-fail-2.rs:5:5
    |
@@ -82,6 +80,8 @@ LL | |     }
 ...
 LL |   define_exported!();
    |   ------------------ in this macro invocation
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #52234 <https://github.com/rust-lang/rust/issues/52234>
    = note: `#[deny(macro_expanded_macro_exports_accessed_by_absolute_paths)]` (part of `#[deny(future_incompatible)]`) on by default
    = note: this error originates in the macro `define_exported` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/imports/overwrite-different-ambig-2.stderr
+++ b/tests/ui/imports/overwrite-different-ambig-2.stderr
@@ -4,8 +4,6 @@ error: `S` is ambiguous
 LL |     let _: m1::S = S {};
    |                    ^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `S` could refer to the struct imported here
   --> $DIR/overwrite-different-ambig-2.rs:18:5
@@ -19,6 +17,8 @@ note: `S` could also refer to the struct imported here
 LL | use m2::*;
    |     ^^^^^
    = help: consider adding an explicit import of `S` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
@@ -30,8 +30,6 @@ error: `S` is ambiguous
 LL |     let _: m1::S = S {};
    |                    ^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `S` could refer to the struct imported here
   --> $DIR/overwrite-different-ambig-2.rs:18:5
@@ -45,5 +43,7 @@ note: `S` could also refer to the struct imported here
 LL | use m2::*;
    |     ^^^^^
    = help: consider adding an explicit import of `S` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/unresolved-seg-after-ambiguous.stderr
+++ b/tests/ui/imports/unresolved-seg-after-ambiguous.stderr
@@ -10,8 +10,6 @@ error: `E` is ambiguous
 LL | use self::a::E::in_exist;
    |              ^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `E` could refer to the struct imported here
   --> $DIR/unresolved-seg-after-ambiguous.rs:13:17
@@ -25,6 +23,8 @@ note: `E` could also refer to the struct imported here
 LL |         pub use self::d::*;
    |                 ^^^^^^^^^^
    = help: consider adding an explicit import of `E` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 2 previous errors
@@ -37,8 +37,6 @@ error: `E` is ambiguous
 LL | use self::a::E::in_exist;
    |              ^ ambiguous name
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `E` could refer to the struct imported here
   --> $DIR/unresolved-seg-after-ambiguous.rs:13:17
@@ -52,5 +50,7 @@ note: `E` could also refer to the struct imported here
 LL |         pub use self::d::*;
    |                 ^^^^^^^^^^
    = help: consider adding an explicit import of `E` to disambiguate
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/lint/semicolon-in-expressions-from-macros/semicolon-in-expressions-from-macros.stderr
+++ b/tests/ui/lint/semicolon-in-expressions-from-macros/semicolon-in-expressions-from-macros.stderr
@@ -7,10 +7,10 @@ LL |         true;
 LL |         foo!(warn_in_block)
    |         ------------------- in this macro invocation
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: macro invocations at the end of a block are treated as expressions
    = note: to ignore the value produced by the macro, add a semicolon after the invocation of `foo`
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
 note: the lint level is defined here
   --> $DIR/semicolon-in-expressions-from-macros.rs:4:9
    |
@@ -69,10 +69,10 @@ LL |         true;
 LL |         foo!(first)
    |         ----------- in this macro invocation
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: macro invocations at the end of a block are treated as expressions
    = note: to ignore the value produced by the macro, add a semicolon after the invocation of `foo`
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: this warning originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 Future breakage diagnostic:
@@ -127,10 +127,10 @@ LL |         true;
 LL |         foo!(warn_in_block)
    |         ------------------- in this macro invocation
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: macro invocations at the end of a block are treated as expressions
    = note: to ignore the value produced by the macro, add a semicolon after the invocation of `foo`
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
 note: the lint level is defined here
   --> $DIR/semicolon-in-expressions-from-macros.rs:4:9
    |

--- a/tests/ui/macros/lint-trailing-macro-call.stderr
+++ b/tests/ui/macros/lint-trailing-macro-call.stderr
@@ -7,10 +7,10 @@ LL |         #[cfg(false)] 25;
 LL |     expand_it!()
    |     ------------ in this macro invocation
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: macro invocations at the end of a block are treated as expressions
    = note: to ignore the value produced by the macro, add a semicolon after the invocation of `expand_it`
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: `#[deny(semicolon_in_expressions_from_macros)]` (part of `#[deny(future_incompatible)]`) on by default
    = note: this error originates in the macro `expand_it` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -26,10 +26,10 @@ LL |         #[cfg(false)] 25;
 LL |     expand_it!()
    |     ------------ in this macro invocation
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: macro invocations at the end of a block are treated as expressions
    = note: to ignore the value produced by the macro, add a semicolon after the invocation of `expand_it`
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: `#[deny(semicolon_in_expressions_from_macros)]` (part of `#[deny(future_incompatible)]`) on by default
    = note: this error originates in the macro `expand_it` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/macros/macro-in-expression-context.stderr
+++ b/tests/ui/macros/macro-in-expression-context.stderr
@@ -22,10 +22,10 @@ LL |         assert_eq!("A", "A");
 LL |     foo!()
    |     ------ in this macro invocation
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: macro invocations at the end of a block are treated as expressions
    = note: to ignore the value produced by the macro, add a semicolon after the invocation of `foo`
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: `#[deny(semicolon_in_expressions_from_macros)]` (part of `#[deny(future_incompatible)]`) on by default
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -41,10 +41,10 @@ LL |         assert_eq!("A", "A");
 LL |     foo!()
    |     ------ in this macro invocation
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: macro invocations at the end of a block are treated as expressions
    = note: to ignore the value produced by the macro, add a semicolon after the invocation of `foo`
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: `#[deny(semicolon_in_expressions_from_macros)]` (part of `#[deny(future_incompatible)]`) on by default
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#153280 (Add regression test for `doc(fake_variadic)` on reexports)
 - rust-lang/rust#153358 (Boundary tests for various Duration-float operations)
 - rust-lang/rust#153272 (Add `Path::absolute` method as alias for `std::path::absolute`)
 - rust-lang/rust#153295 (update panicking() docs for panic=abort)
 - rust-lang/rust#153352 (Migration of `LintDiagnostic` - part 6)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=153280,153358,153272,153295,153352)
<!-- homu-ignore:end -->

