### PR TITLE
library/test: always enable unstable features for miri

### DIFF
--- a/library/test/build.rs
+++ b/library/test/build.rs
@@ -2,11 +2,16 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rustc-check-cfg=cfg(enable_unstable_features)");
 
-    let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".into());
-    let version = std::process::Command::new(rustc).arg("-vV").output().unwrap();
-    let stdout = String::from_utf8(version.stdout).unwrap();
+    // Miri testing uses unstable features, so always enable that for its sysroot.
+    // Otherwise, only enable unstable if rustc looks like a nightly or dev build.
+    let enable_unstable_features = std::env::var("MIRI_CALLED_FROM_SETUP").is_ok() || {
+        let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".into());
+        let version = std::process::Command::new(rustc).arg("-vV").output().unwrap();
+        let stdout = String::from_utf8(version.stdout).unwrap();
+        stdout.contains("nightly") || stdout.contains("dev")
+    };
 
-    if stdout.contains("nightly") || stdout.contains("dev") {
+    if enable_unstable_features {
         println!("cargo:rustc-cfg=enable_unstable_features");
     }
 }


### PR DESCRIPTION
The unstable features of the `test` crate used to be default-enabled,
and manually disabled when building the beta and stable channels. Commit
dae8ea92a733 flipped that to default-disabled, only enabled for nightly
and dev channels.

However, this broke miri testing on the beta/stable channels, because it
also uses unstable features -- which should be fine to enable just for
its own sysroot build. Now the `test` build script makes that happen by
noticing the `MIRI_CALLED_FROM_SETUP` environment variable.
