### PR TITLE
Rename `QueryCache::iter` to `for_each`

### DIFF
--- a/compiler/rustc_data_structures/src/vec_cache.rs
+++ b/compiler/rustc_data_structures/src/vec_cache.rs
@@ -341,7 +341,7 @@ where
         }
     }
 
-    pub fn iter(&self, f: &mut dyn FnMut(&K, &V, I)) {
+    pub fn for_each(&self, f: &mut dyn FnMut(&K, &V, I)) {
         for idx in 0..self.len.load(Ordering::Acquire) {
             let key = SlotIndex::from_index(idx as u32);
             match unsafe { key.get(&self.present) } {

--- a/compiler/rustc_middle/src/query/caches.rs
+++ b/compiler/rustc_middle/src/query/caches.rs
@@ -28,8 +28,13 @@ pub trait QueryCache: Sized {
     /// value by executing the query or loading a cached value from disk.
     fn complete(&self, key: Self::Key, value: Self::Value, index: DepNodeIndex);
 
-    fn iter(&self, f: &mut dyn FnMut(&Self::Key, &Self::Value, DepNodeIndex));
+    /// Calls a closure on each entry in this cache.
+    fn for_each(&self, f: &mut dyn FnMut(&Self::Key, &Self::Value, DepNodeIndex));
 
+    /// Returns the number of entries currently in this cache.
+    ///
+    /// Useful for reserving capacity in data structures that will hold the
+    /// output of a call to [`Self::for_each`].
     fn len(&self) -> usize;
 }
 
@@ -65,7 +70,7 @@ where
         self.cache.insert(key, (value, index));
     }
 
-    fn iter(&self, f: &mut dyn FnMut(&Self::Key, &Self::Value, DepNodeIndex)) {
+    fn for_each(&self, f: &mut dyn FnMut(&Self::Key, &Self::Value, DepNodeIndex)) {
         for shard in self.cache.lock_shards() {
             for (k, v) in shard.iter() {
                 f(k, &v.0, v.1);
@@ -107,7 +112,7 @@ where
         self.cache.set((value, index)).ok();
     }
 
-    fn iter(&self, f: &mut dyn FnMut(&Self::Key, &Self::Value, DepNodeIndex)) {
+    fn for_each(&self, f: &mut dyn FnMut(&Self::Key, &Self::Value, DepNodeIndex)) {
         if let Some(value) = self.cache.get() {
             f(&(), &value.0, value.1)
         }
@@ -160,11 +165,11 @@ where
         }
     }
 
-    fn iter(&self, f: &mut dyn FnMut(&Self::Key, &Self::Value, DepNodeIndex)) {
-        self.local.iter(&mut |key, value, index| {
+    fn for_each(&self, f: &mut dyn FnMut(&Self::Key, &Self::Value, DepNodeIndex)) {
+        self.local.for_each(&mut |key, value, index| {
             f(&DefId { krate: LOCAL_CRATE, index: *key }, value, index);
         });
-        self.foreign.iter(f);
+        self.foreign.for_each(f);
     }
 
     fn len(&self) -> usize {
@@ -190,8 +195,8 @@ where
         self.complete(key, value, index)
     }
 
-    fn iter(&self, f: &mut dyn FnMut(&Self::Key, &Self::Value, DepNodeIndex)) {
-        self.iter(f)
+    fn for_each(&self, f: &mut dyn FnMut(&Self::Key, &Self::Value, DepNodeIndex)) {
+        self.for_each(f)
     }
 
     fn len(&self) -> usize {

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -167,7 +167,7 @@ pub(crate) fn encode_query_results<'a, 'tcx, C, V>(
     let _timer = tcx.prof.generic_activity_with_arg("encode_query_results_for", query.name);
 
     assert!(all_inactive(&query.state));
-    query.cache.iter(&mut |key, value, dep_node| {
+    query.cache.for_each(&mut |key, value, dep_node| {
         if (query.will_cache_on_disk_for_key_fn)(tcx, key) {
             let dep_node = SerializedDepNodeIndex::new(dep_node.index());
 
@@ -189,7 +189,7 @@ pub(crate) fn query_key_hash_verify<'tcx, C: QueryCache>(
 
     let cache = &query.cache;
     let mut map = UnordMap::with_capacity(cache.len());
-    cache.iter(&mut |key, _, _| {
+    cache.for_each(&mut |key, _, _| {
         let node = DepNode::construct(tcx, query.dep_kind, key);
         if let Some(other_key) = map.insert(node, *key) {
             bug!(

--- a/compiler/rustc_query_impl/src/profiling_support.rs
+++ b/compiler/rustc_query_impl/src/profiling_support.rs
@@ -200,7 +200,7 @@ pub(crate) fn alloc_self_profile_query_strings_for_query_cache<'tcx, C>(
             // locked while doing so. Instead we copy out the
             // `(query_key, dep_node_index)` pairs and release the lock again.
             let mut query_keys_and_indices = Vec::new();
-            query_cache.iter(&mut |k, _, i| query_keys_and_indices.push((*k, i)));
+            query_cache.for_each(&mut |k, _, i| query_keys_and_indices.push((*k, i)));
 
             // Now actually allocate the strings. If allocating the strings
             // generates new entries in the query cache, we'll miss them but
@@ -228,7 +228,7 @@ pub(crate) fn alloc_self_profile_query_strings_for_query_cache<'tcx, C>(
             // instead of passing the `DepNodeIndex` to `finish_with_query_invocation_id`,
             // when recording the event in the first place.
             let mut query_invocation_ids = Vec::new();
-            query_cache.iter(&mut |_, _, i| {
+            query_cache.for_each(&mut |_, _, i| {
                 query_invocation_ids.push(i.into());
             });
 


### PR DESCRIPTION
Methods that perform internal iteration are typically named `for_each`.
