### PR TITLE
fix ICE in note_and_explain when handling cross crate DefIds

### DIFF
--- a/compiler/rustc_trait_selection/src/errors/note_and_explain.rs
+++ b/compiler/rustc_trait_selection/src/errors/note_and_explain.rs
@@ -21,15 +21,15 @@ impl<'a> DescriptionCtx<'a> {
     ) -> Option<Self> {
         let (span, kind, arg) = match region.kind() {
             ty::ReEarlyParam(br) => {
-                let scope = tcx
-                    .parent(tcx.generics_of(generic_param_scope).region_param(br, tcx).def_id)
-                    .expect_local();
-                let span = if let Some(param) =
-                    tcx.hir_get_generics(scope).and_then(|generics| generics.get_named(br.name))
+                let scope_def_id = tcx
+                    .parent(tcx.generics_of(generic_param_scope).region_param(br, tcx).def_id);
+                let span = if let Some(scope) = scope_def_id.as_local()
+                    && let Some(param) =
+                        tcx.hir_get_generics(scope).and_then(|generics| generics.get_named(br.name))
                 {
                     param.span
                 } else {
-                    tcx.def_span(scope)
+                    tcx.def_span(scope_def_id)
                 };
                 if br.is_named() {
                     (Some(span), "as_defined", br.name.to_string())
@@ -43,17 +43,17 @@ impl<'a> DescriptionCtx<'a> {
                 {
                     (Some(ty.span), "defined_here", String::new())
                 } else {
-                    let scope = fr.scope.expect_local();
                     match fr.kind {
                         ty::LateParamRegionKind::Named(def_id) => {
                             let name = tcx.item_name(def_id);
-                            let span = if let Some(param) = tcx
-                                .hir_get_generics(scope)
-                                .and_then(|generics| generics.get_named(name))
+                            let span = if let Some(scope) = fr.scope.as_local()
+                                && let Some(param) = tcx
+                                    .hir_get_generics(scope)
+                                    .and_then(|generics| generics.get_named(name))
                             {
                                 param.span
                             } else {
-                                tcx.def_span(scope)
+                                tcx.def_span(fr.scope)
                             };
                             if name == kw::UnderscoreLifetime {
                                 (Some(span), "as_defined_anon", String::new())
@@ -62,10 +62,10 @@ impl<'a> DescriptionCtx<'a> {
                             }
                         }
                         ty::LateParamRegionKind::Anon(_) => {
-                            let span = Some(tcx.def_span(scope));
+                            let span = Some(tcx.def_span(fr.scope));
                             (span, "defined_here", String::new())
                         }
-                        _ => (Some(tcx.def_span(scope)), "defined_here_reg", region.to_string()),
+                        _ => (Some(tcx.def_span(fr.scope)), "defined_here_reg", region.to_string()),
                     }
                 }
             }

--- a/compiler/rustc_trait_selection/src/errors/note_and_explain.rs
+++ b/compiler/rustc_trait_selection/src/errors/note_and_explain.rs
@@ -21,8 +21,8 @@ impl<'a> DescriptionCtx<'a> {
     ) -> Option<Self> {
         let (span, kind, arg) = match region.kind() {
             ty::ReEarlyParam(br) => {
-                let scope_def_id = tcx
-                    .parent(tcx.generics_of(generic_param_scope).region_param(br, tcx).def_id);
+                let scope_def_id =
+                    tcx.parent(tcx.generics_of(generic_param_scope).region_param(br, tcx).def_id);
                 let span = if let Some(scope) = scope_def_id.as_local()
                     && let Some(param) =
                         tcx.hir_get_generics(scope).and_then(|generics| generics.get_named(br.name))

--- a/tests/ui/lifetimes/auxiliary/ice_trait.rs
+++ b/tests/ui/lifetimes/auxiliary/ice_trait.rs
@@ -1,0 +1,3 @@
+pub trait ExternalTrait {
+    fn build_request(&mut self) -> impl std::future::Future<Output = ()>;
+}

--- a/tests/ui/lifetimes/auxiliary/ice_trait.rs
+++ b/tests/ui/lifetimes/auxiliary/ice_trait.rs
@@ -1,3 +1,1 @@
-pub trait ExternalTrait {
-    fn build_request(&mut self) -> impl std::future::Future<Output = ()>;
-}
+pub trait ExternalTrait { fn build_request<'b>(&'b self) -> impl std::future::Future<Output = ()>; }

--- a/tests/ui/lifetimes/ice-cross-crate-defid.rs
+++ b/tests/ui/lifetimes/ice-cross-crate-defid.rs
@@ -1,0 +1,17 @@
+//@ aux-build:ice_trait.rs
+extern crate ice_trait;
+use ice_trait::ExternalTrait;
+
+// This test ensures that the compiler doesn't crash (ICE) when explaining
+// lifetimes involving cross-crate traits. See gh-153375.
+
+struct LocalWrapper<T>(T);
+
+impl<T: ExternalTrait> LocalWrapper<T> {
+    fn do_thing(&mut self) {
+        // This exercises the note_and_explain logic on an external trait.
+        let _ = self.0.build_request();
+    }
+}
+
+fn main() {}

--- a/tests/ui/lifetimes/ice-cross-crate-defid.rs
+++ b/tests/ui/lifetimes/ice-cross-crate-defid.rs
@@ -1,17 +1,10 @@
 //@ aux-build:ice_trait.rs
 extern crate ice_trait;
 use ice_trait::ExternalTrait;
-
-// This test ensures that the compiler doesn't crash (ICE) when explaining
-// lifetimes involving cross-crate traits. See gh-153375.
-
-struct LocalWrapper<T>(T);
-
-impl<T: ExternalTrait> LocalWrapper<T> {
-    fn do_thing(&mut self) {
-        // This exercises the note_and_explain logic on an external trait.
-        let _ = self.0.build_request();
-    }
+// Forcing a lifetime error here, The compiler will try to explain 
+// This should forces it to look at the ExternalTrait definition in the other crate.
+fn test<'a, T: ExternalTrait>(a: &'a mut T) -> impl std::future::Future<Output = ()> + 'static {
+    a.build_request() 
 }
 
 fn main() {}

--- a/tests/ui/lifetimes/ice-cross-crate-defid.rs
+++ b/tests/ui/lifetimes/ice-cross-crate-defid.rs
@@ -1,7 +1,7 @@
 //@ aux-build:ice_trait.rs
 extern crate ice_trait;
 use ice_trait::ExternalTrait;
-// Forcing a lifetime error here, The compiler will try to explain 
+// Forcing a lifetime error here, The compiler will try to explain
 // This should forces it to look at the ExternalTrait definition in the other crate.
 fn test<'a, T: ExternalTrait>(a: &'a mut T) -> impl std::future::Future<Output = ()> + 'static {
     a.build_request()

--- a/tests/ui/lifetimes/ice-cross-crate-defid.rs
+++ b/tests/ui/lifetimes/ice-cross-crate-defid.rs
@@ -3,6 +3,6 @@
 extern crate ice_trait;
 use ice_trait::ExternalTrait;
 fn test<'a, T: ExternalTrait>(a: &'a mut T) -> impl std::future::Future<Output = ()> + 'static {
-    a.build_request() 
+    a.build_request()
 }
 fn main() {}

--- a/tests/ui/lifetimes/ice-cross-crate-defid.rs
+++ b/tests/ui/lifetimes/ice-cross-crate-defid.rs
@@ -4,7 +4,6 @@ use ice_trait::ExternalTrait;
 // Forcing a lifetime error here, The compiler will try to explain 
 // This should forces it to look at the ExternalTrait definition in the other crate.
 fn test<'a, T: ExternalTrait>(a: &'a mut T) -> impl std::future::Future<Output = ()> + 'static {
-    a.build_request() 
+    a.build_request()
 }
-
 fn main() {}

--- a/tests/ui/lifetimes/ice-cross-crate-defid.rs
+++ b/tests/ui/lifetimes/ice-cross-crate-defid.rs
@@ -1,9 +1,8 @@
 //@ aux-build:ice_trait.rs
+//@ check-fail
 extern crate ice_trait;
 use ice_trait::ExternalTrait;
-// Forcing a lifetime error here, The compiler will try to explain
-// This should forces it to look at the ExternalTrait definition in the other crate.
 fn test<'a, T: ExternalTrait>(a: &'a mut T) -> impl std::future::Future<Output = ()> + 'static {
-    a.build_request()
+    a.build_request() 
 }
 fn main() {}

--- a/tests/ui/lifetimes/ice-cross-crate-defid.stderr
+++ b/tests/ui/lifetimes/ice-cross-crate-defid.stderr
@@ -1,0 +1,19 @@
+error: lifetime may not live long enough
+  --> $DIR/ice-cross-crate-defid.rs:11:5
+   |
+LL | fn test<'a, T: ExternalTrait>(a: &'a mut T) -> impl std::future::Future<Output = ()> + 'static {
+   |         -- lifetime `'a` defined here
+LL |     a.build_request()
+   |     ^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
+   |
+help: consider changing `impl Future<Output = ()> + 'static`'s explicit `'static` bound to the lifetime of argument `a`
+   |
+LL - fn test<'a, T: ExternalTrait>(a: &'a mut T) -> impl std::future::Future<Output = ()> + 'static {
+LL + fn test<'a, T: ExternalTrait>(a: &'a mut T) -> impl std::future::Future<Output = ()> + 'a {
+   |
+help: alternatively, add an explicit `'static` bound to this reference
+   |
+LL - fn test<'a, T: ExternalTrait>(a: &'a mut T) -> impl std::future::Future<Output = ()> + 'static {
+LL + fn test<'a, T: ExternalTrait>(a: &'static mut T) -> impl std::future::Future<Output = ()> + 'static {
+   |
+error: aborting due to 1 previous error

--- a/tests/ui/lifetimes/ice-cross-crate-defid.stderr
+++ b/tests/ui/lifetimes/ice-cross-crate-defid.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/ice-cross-crate-defid.rs:11:5
+  --> $DIR/ice-cross-crate-defid.rs:7:5
    |
 LL | fn test<'a, T: ExternalTrait>(a: &'a mut T) -> impl std::future::Future<Output = ()> + 'static {
    |         -- lifetime `'a` defined here
@@ -16,4 +16,5 @@ help: alternatively, add an explicit `'static` bound to this reference
 LL - fn test<'a, T: ExternalTrait>(a: &'a mut T) -> impl std::future::Future<Output = ()> + 'static {
 LL + fn test<'a, T: ExternalTrait>(a: &'static mut T) -> impl std::future::Future<Output = ()> + 'static {
    |
+
 error: aborting due to 1 previous error


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/153382)*
<!-- homu-ignore:end -->

Fixes an Internal Compiler Error (ICE) in `note_and_explain` where the compiler would panic with `DefId::expect_local: DefId(...) isn't local` when attempting to explain lifetime errors involving definitions from external crates.
The crash occurred because the diagnostic logic assumed that items being explained were always local to the current crate. This replaces `.expect_local()` with `.as_local()` to safely handle cross crate `DefId`s, falling back to `tcx.def_span()` for external definitions.
A regression test is included in `tests/ui/lifetimes/ice-cross-crate-defid.rs` using an auxiliary crate to reproduce the cross-crate boundary condition.
### Fixes
Fixes rust-lang/rust#153375