### PR TITLE
Add missing safety doc for CString::from_vec_unchecked and async_drop_in_place

### DIFF
--- a/library/alloc/src/ffi/c_str.rs
+++ b/library/alloc/src/ffi/c_str.rs
@@ -321,6 +321,10 @@ impl CString {
     /// assertion is made that `v` contains no 0 bytes, and it requires an
     /// actual byte vector, not anything that can be converted to one with Into.
     ///
+    /// # Safety
+    ///
+    /// The caller must ensure `v` contains no nul bytes in its contents.
+    ///
     /// # Examples
     ///
     /// ```

--- a/library/core/src/future/async_drop.rs
+++ b/library/core/src/future/async_drop.rs
@@ -41,6 +41,15 @@ pub trait AsyncDrop {
 }
 
 /// Async drop.
+///
+/// # Safety
+///
+/// The pointer `_to_drop` must be valid for both reads and writes,
+/// not only for the duration of this function call,
+/// but also until the returned future has completed.
+/// See [ptr::drop_in_place] for additional safety concerns.
+///
+/// [ptr::drop_in_place]: crate::ptr::drop_in_place()
 #[unstable(feature = "async_drop", issue = "126482")]
 #[lang = "async_drop_in_place"]
 pub async unsafe fn async_drop_in_place<T: ?Sized>(_to_drop: *mut T) {


### PR DESCRIPTION
Add missing safety documentation for two unsafe APIs:

* `CString::from_vec_unchecked` – # Safety: the caller must ensure `v` contains no NUL bytes in its contents.
* `async_drop_in_place` – # Safety: see [`ptr::drop_in_place`] for safety requirements.