### PR TITLE
Fix comment on `is_horizontal_whitespace`

### DIFF
--- a/compiler/rustc_lexer/src/lib.rs
+++ b/compiler/rustc_lexer/src/lib.rs
@@ -367,7 +367,8 @@ pub fn is_whitespace(c: char) -> bool {
 
 /// True if `c` is considered horizontal whitespace according to Rust language definition.
 pub fn is_horizontal_whitespace(c: char) -> bool {
-    // This is Pattern_White_Space.
+    // This is the horizontal space subset of `Pattern_White_Space` as
+    // categorized by UAX #31, Section 4.1.
     //
     // Note that this set is stable (ie, it doesn't change with different
     // Unicode versions), so it's ok to just hard-code the values.


### PR DESCRIPTION
The comment on `is_horizontal_whitespace` says "This is Pattern_White_Space", but the function matches only tab (U+0009) and space (U+0020) -- two of the eleven `Pattern_White_Space` code points. This has been the case since rust-lang/rust#146106, which narrowed the set from full `Pattern_White_Space` to the horizontal subset.

The correct characterization is that this is the horizontal space subset of `Pattern_White_Space`, as categorized by UAX 31, Section 4.1, which partitions `Pattern_White_Space` into line endings, ignorable format controls, and horizontal space.

r? fee1-dead (reviewer on rust-lang/rust#146106)

cc @ehuss @epage

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
