### PR TITLE
fix(thir): Include `NoneWithError` in Enum Struct Tail Assertion

### DIFF
--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -645,6 +645,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
                                     base,
                                     hir::StructTailExpr::None
                                         | hir::StructTailExpr::DefaultFields(_)
+                                        | hir::StructTailExpr::NoneWithError(_)
                                 ));
 
                                 let index = adt.variant_index_with_id(variant_id);

--- a/tests/ui/structs/syntax-error-not-missing-field.rs
+++ b/tests/ui/structs/syntax-error-not-missing-field.rs
@@ -6,6 +6,10 @@
 
 struct Foo { a: isize, b: isize }
 
+enum Bar {
+    Baz { a: isize, b: isize },
+}
+
 fn make_a() -> isize { 1234 }
 
 fn expr_wrong_separator() {
@@ -33,6 +37,14 @@ fn pat_missing_separator(Foo { a b }: Foo) { //~ ERROR expected `,`
 }
 
 fn pat_rest_trailing_comma(Foo { a, .., }: Foo) { //~ ERROR expected `}`, found `,`
+}
+
+fn enum_expr_wrong_separator() {
+    let e = Bar::Baz { a: make_a(); b: 2 }; //~ ERROR found `;`
+}
+
+fn enum_expr_missing_separator() {
+    let e = Bar::Baz { a: make_a() b: 2 }; //~ ERROR found `b`
 }
 
 fn main() {}

--- a/tests/ui/structs/syntax-error-not-missing-field.stderr
+++ b/tests/ui/structs/syntax-error-not-missing-field.stderr
@@ -1,5 +1,5 @@
 error: expected one of `,`, `.`, `?`, `}`, or an operator, found `;`
-  --> $DIR/syntax-error-not-missing-field.rs:12:30
+  --> $DIR/syntax-error-not-missing-field.rs:16:30
    |
 LL |     let f = Foo { a: make_a(); b: 2 };
    |             ---              ^
@@ -9,7 +9,7 @@ LL |     let f = Foo { a: make_a(); b: 2 };
    |             while parsing this struct
 
 error: expected one of `,`, `.`, `?`, `}`, or an operator, found `b`
-  --> $DIR/syntax-error-not-missing-field.rs:16:31
+  --> $DIR/syntax-error-not-missing-field.rs:20:31
    |
 LL |     let f = Foo { a: make_a() b: 2 };
    |             ---              -^ expected one of `,`, `.`, `?`, `}`, or an operator
@@ -18,7 +18,7 @@ LL |     let f = Foo { a: make_a() b: 2 };
    |             while parsing this struct
 
 error: cannot use a comma after the base struct
-  --> $DIR/syntax-error-not-missing-field.rs:20:32
+  --> $DIR/syntax-error-not-missing-field.rs:24:32
    |
 LL |     let f = Foo { a: make_a(), ..todo!(), };
    |                                ^^^^^^^^^
@@ -31,7 +31,7 @@ LL +     let f = Foo { a: make_a(), ..todo!() };
    |
 
 error: expected one of `,`, `:`, or `}`, found `(`
-  --> $DIR/syntax-error-not-missing-field.rs:24:25
+  --> $DIR/syntax-error-not-missing-field.rs:28:25
    |
 LL |     let f = Foo { make_a(), b: 2, };
    |             ---   ------^ expected one of `,`, `:`, or `}`
@@ -45,7 +45,7 @@ LL |     let f = Foo { make_a: make_a(), b: 2, };
    |                   +++++++
 
 error: expected `,`
-  --> $DIR/syntax-error-not-missing-field.rs:27:31
+  --> $DIR/syntax-error-not-missing-field.rs:31:31
    |
 LL | fn pat_wrong_separator(Foo { a; b }: Foo) {
    |                        ---    ^
@@ -53,7 +53,7 @@ LL | fn pat_wrong_separator(Foo { a; b }: Foo) {
    |                        while parsing the fields for this pattern
 
 error: expected `,`
-  --> $DIR/syntax-error-not-missing-field.rs:31:34
+  --> $DIR/syntax-error-not-missing-field.rs:35:34
    |
 LL | fn pat_missing_separator(Foo { a b }: Foo) {
    |                          ---     ^
@@ -61,7 +61,7 @@ LL | fn pat_missing_separator(Foo { a b }: Foo) {
    |                          while parsing the fields for this pattern
 
 error: expected `}`, found `,`
-  --> $DIR/syntax-error-not-missing-field.rs:35:39
+  --> $DIR/syntax-error-not-missing-field.rs:39:39
    |
 LL | fn pat_rest_trailing_comma(Foo { a, .., }: Foo) {
    |                                     --^
@@ -70,5 +70,24 @@ LL | fn pat_rest_trailing_comma(Foo { a, .., }: Foo) {
    |                                     | help: remove this comma
    |                                     `..` must be at the end and cannot have a trailing comma
 
-error: aborting due to 7 previous errors
+error: expected one of `,`, `.`, `?`, `}`, or an operator, found `;`
+  --> $DIR/syntax-error-not-missing-field.rs:43:35
+   |
+LL |     let e = Bar::Baz { a: make_a(); b: 2 };
+   |             --------              ^
+   |             |                     |
+   |             |                     expected one of `,`, `.`, `?`, `}`, or an operator
+   |             |                     help: try adding a comma: `,`
+   |             while parsing this struct
+
+error: expected one of `,`, `.`, `?`, `}`, or an operator, found `b`
+  --> $DIR/syntax-error-not-missing-field.rs:47:36
+   |
+LL |     let e = Bar::Baz { a: make_a() b: 2 };
+   |             --------              -^ expected one of `,`, `.`, `?`, `}`, or an operator
+   |             |                     |
+   |             |                     help: try adding a comma: `,`
+   |             while parsing this struct
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
### Summary:

Fixes the ICE triggered when a syntax error appears inside an enum variant struct literal.

PR rust-lang/rust#153227 added `StructTailExpr::NoneWithError` and updated the `match base` arm in the `AdtKind::Enum` branch of `thir/cx/expr.rs`, but overlooked the `assert!(matches!(...))` guard preceding it, which still only listed `None | DefaultFields(_)`.

Closes rust-lang/rust#153390 

r? @dingxiangfei2009 
cc @matthiaskrgr 