### PR TITLE
use `minicore` in some `run-make` tests

### DIFF
--- a/src/tools/run-make-support/src/external_deps/rustc.rs
+++ b/src/tools/run-make-support/src/external_deps/rustc.rs
@@ -4,7 +4,7 @@ use std::str::FromStr as _;
 
 use crate::command::Command;
 use crate::env::env_var;
-use crate::path_helpers::cwd;
+use crate::path_helpers::{cwd, source_root};
 use crate::util::set_host_compiler_dylib_path;
 use crate::{is_aix, is_darwin, is_windows, is_windows_msvc, target, uname};
 
@@ -20,6 +20,37 @@ pub fn rustc() -> Rustc {
 #[track_caller]
 pub fn bare_rustc() -> Rustc {
     Rustc::bare()
+}
+
+/// Construct a `rustc` invocation for building `minicore`.
+///
+/// This function:
+///
+/// - adds `tests/auxiliary/minicore.rs` as an input
+/// - sets the crate name to `"minicore"`
+/// - sets the crate type to `rlib`
+///
+/// # Example
+///
+/// ```ignore (illustrative)
+/// rustc_minicore().target("wasm32-wasip1").target_cpu("mvp").output("libminicore.rlib").run();
+///
+/// rustc()
+///     .input("foo.rs")
+///     .target("wasm32-wasip1")
+///     .target_cpu("mvp")
+///     .extern_("minicore", path("libminicore.rlib"))
+///     // ...
+///     .run()
+/// ```
+#[track_caller]
+pub fn rustc_minicore() -> Rustc {
+    let mut builder = rustc();
+
+    let minicore_path = source_root().join("tests/auxiliary/minicore.rs");
+    builder.input(minicore_path).crate_name("minicore").crate_type("rlib");
+
+    builder
 }
 
 /// A `rustc` invocation builder.

--- a/src/tools/run-make-support/src/lib.rs
+++ b/src/tools/run-make-support/src/lib.rs
@@ -72,13 +72,12 @@ pub use crate::external_deps::llvm::{
     llvm_readobj,
 };
 pub use crate::external_deps::python::python_command;
-pub use crate::external_deps::rustc::{self, Rustc, bare_rustc, rustc, rustc_path};
+pub use crate::external_deps::rustc::{self, Rustc, bare_rustc, rustc, rustc_minicore, rustc_path};
 pub use crate::external_deps::rustdoc::{Rustdoc, bare_rustdoc, rustdoc};
 // Path-related helpers.
 pub use crate::path_helpers::{
     build_root, cwd, filename_contains, filename_not_in_denylist, has_extension, has_prefix,
-    has_suffix, minicore_path, not_contains, path, shallow_find_directories, shallow_find_files,
-    source_root,
+    has_suffix, not_contains, path, shallow_find_directories, shallow_find_files, source_root,
 };
 // Convenience helpers for running binaries and other commands.
 pub use crate::run::{cmd, run, run_fail, run_with_args};

--- a/src/tools/run-make-support/src/lib.rs
+++ b/src/tools/run-make-support/src/lib.rs
@@ -77,7 +77,8 @@ pub use crate::external_deps::rustdoc::{Rustdoc, bare_rustdoc, rustdoc};
 // Path-related helpers.
 pub use crate::path_helpers::{
     build_root, cwd, filename_contains, filename_not_in_denylist, has_extension, has_prefix,
-    has_suffix, not_contains, path, shallow_find_directories, shallow_find_files, source_root,
+    has_suffix, minicore_path, not_contains, path, shallow_find_directories, shallow_find_files,
+    source_root,
 };
 // Convenience helpers for running binaries and other commands.
 pub use crate::run::{cmd, run, run_fail, run_with_args};

--- a/src/tools/run-make-support/src/path_helpers.rs
+++ b/src/tools/run-make-support/src/path_helpers.rs
@@ -40,12 +40,6 @@ pub fn build_root() -> PathBuf {
     env_var("BUILD_ROOT").into()
 }
 
-/// Path to minicore.
-#[must_use]
-pub fn minicore_path() -> PathBuf {
-    source_root().join("tests/auxiliary/minicore.rs")
-}
-
 /// Browse the directory `path` non-recursively and return all files which respect the parameters
 /// outlined by `closure`.
 #[track_caller]

--- a/src/tools/run-make-support/src/path_helpers.rs
+++ b/src/tools/run-make-support/src/path_helpers.rs
@@ -40,6 +40,12 @@ pub fn build_root() -> PathBuf {
     env_var("BUILD_ROOT").into()
 }
 
+/// Path to minicore.
+#[must_use]
+pub fn minicore_path() -> PathBuf {
+    source_root().join("tests/auxiliary/minicore.rs")
+}
+
 /// Browse the directory `path` non-recursively and return all files which respect the parameters
 /// outlined by `closure`.
 #[track_caller]

--- a/tests/auxiliary/minicore.rs
+++ b/tests/auxiliary/minicore.rs
@@ -288,6 +288,17 @@ pub mod mem {
     pub const fn align_of<T>() -> usize;
 }
 
+pub mod ptr {
+    #[inline]
+    #[rustc_diagnostic_item = "ptr_write_volatile"]
+    pub unsafe fn write_volatile<T>(dst: *mut T, src: T) {
+        #[rustc_intrinsic]
+        pub unsafe fn volatile_store<T>(dst: *mut T, val: T);
+
+        unsafe { volatile_store(dst, src) };
+    }
+}
+
 #[lang = "c_void"]
 #[repr(u8)]
 pub enum c_void {

--- a/tests/run-make/avr-rjmp-offset/avr-rjmp-offsets.rs
+++ b/tests/run-make/avr-rjmp-offset/avr-rjmp-offsets.rs
@@ -7,7 +7,8 @@
 #![no_main]
 #![allow(internal_features)]
 
-use minicore::ptr;
+extern crate minicore;
+use minicore::*;
 
 #[no_mangle]
 pub fn main() -> ! {
@@ -19,34 +20,5 @@ pub fn main() -> ! {
     loop {
         unsafe { ptr::write_volatile(port_b, 1) };
         unsafe { ptr::write_volatile(port_b, 2) };
-    }
-}
-
-// FIXME: replace with proper minicore once available (#130693)
-mod minicore {
-    #[lang = "pointee_sized"]
-    pub trait PointeeSized {}
-
-    #[lang = "meta_sized"]
-    pub trait MetaSized: PointeeSized {}
-
-    #[lang = "sized"]
-    pub trait Sized: MetaSized {}
-
-    #[lang = "copy"]
-    pub trait Copy {}
-    impl Copy for u32 {}
-    impl Copy for &u32 {}
-    impl<T: PointeeSized> Copy for *mut T {}
-
-    pub mod ptr {
-        #[inline]
-        #[rustc_diagnostic_item = "ptr_write_volatile"]
-        pub unsafe fn write_volatile<T>(dst: *mut T, src: T) {
-            #[rustc_intrinsic]
-            pub unsafe fn volatile_store<T>(dst: *mut T, val: T);
-
-            unsafe { volatile_store(dst, src) };
-        }
     }
 }

--- a/tests/run-make/avr-rjmp-offset/rmake.rs
+++ b/tests/run-make/avr-rjmp-offset/rmake.rs
@@ -15,17 +15,10 @@
 // crashes... so I'm going to disable this test for windows for now.
 //@ ignore-windows-gnu
 
-use run_make_support::{llvm_objdump, minicore_path, path, rustc};
+use run_make_support::{llvm_objdump, path, rustc, rustc_minicore};
 
 fn main() {
-    rustc()
-        .input(minicore_path())
-        .crate_name("minicore")
-        .crate_type("rlib")
-        .target("avr-none")
-        .target_cpu("avr")
-        .output("libminicore.rlib")
-        .run();
+    rustc_minicore().target("avr-none").target_cpu("avr").output("libminicore.rlib").run();
 
     rustc()
         .input("avr-rjmp-offsets.rs")

--- a/tests/run-make/avr-rjmp-offset/rmake.rs
+++ b/tests/run-make/avr-rjmp-offset/rmake.rs
@@ -15,9 +15,18 @@
 // crashes... so I'm going to disable this test for windows for now.
 //@ ignore-windows-gnu
 
-use run_make_support::{llvm_objdump, rustc};
+use run_make_support::{llvm_objdump, minicore_path, path, rustc};
 
 fn main() {
+    rustc()
+        .input(minicore_path())
+        .crate_name("minicore")
+        .crate_type("rlib")
+        .target("avr-none")
+        .target_cpu("avr")
+        .output("libminicore.rlib")
+        .run();
+
     rustc()
         .input("avr-rjmp-offsets.rs")
         .opt_level("s")
@@ -36,6 +45,7 @@ fn main() {
         .linker("rust-lld")
         .link_arg("--entry=main")
         .output("compiled")
+        .extern_("minicore", path("libminicore.rlib"))
         .run();
 
     let disassembly = llvm_objdump().disassemble().input("compiled").run().stdout_utf8();

--- a/tests/run-make/thumb-interworking/rmake.rs
+++ b/tests/run-make/thumb-interworking/rmake.rs
@@ -1,6 +1,8 @@
 //@ needs-llvm-components: arm
 //@ needs-rust-lld
-use run_make_support::{llvm_filecheck, llvm_objdump, path, rfs, run, rustc, source_root};
+use run_make_support::{
+    llvm_filecheck, llvm_objdump, minicore_path, path, rfs, run, rustc, source_root,
+};
 
 // Test a thumb target calling arm functions. Doing so requires switching from thumb mode to arm
 // mode, calling the arm code, then switching back to thumb mode. Depending on the thumb version,
@@ -26,20 +28,18 @@ fn main() {
 
 fn helper(prefix: &str, target: &str) {
     rustc()
-        .input(source_root().join("tests/auxiliary/minicore.rs"))
+        .input(minicore_path())
         .crate_name("minicore")
         .crate_type("rlib")
         .target(target)
         .output("libminicore.rlib")
         .run();
-    let minicore = path("libminicore.rlib");
 
     rustc()
         .input("main.rs")
         .panic("abort")
         .link_arg("-Tlink.ld")
-        .arg("--extern")
-        .arg(format!("minicore={}", minicore.display()))
+        .extern_("minicore", path("libminicore.rlib"))
         .target(target)
         .output(prefix)
         .run();

--- a/tests/run-make/thumb-interworking/rmake.rs
+++ b/tests/run-make/thumb-interworking/rmake.rs
@@ -1,7 +1,7 @@
 //@ needs-llvm-components: arm
 //@ needs-rust-lld
 use run_make_support::{
-    llvm_filecheck, llvm_objdump, minicore_path, path, rfs, run, rustc, source_root,
+    llvm_filecheck, llvm_objdump, path, rfs, run, rustc, rustc_minicore, source_root,
 };
 
 // Test a thumb target calling arm functions. Doing so requires switching from thumb mode to arm
@@ -27,13 +27,7 @@ fn main() {
 }
 
 fn helper(prefix: &str, target: &str) {
-    rustc()
-        .input(minicore_path())
-        .crate_name("minicore")
-        .crate_type("rlib")
-        .target(target)
-        .output("libminicore.rlib")
-        .run();
+    rustc_minicore().target(target).output("libminicore.rlib").run();
 
     rustc()
         .input("main.rs")

--- a/tests/run-make/wasm-unexpected-features/foo.rs
+++ b/tests/run-make/wasm-unexpected-features/foo.rs
@@ -4,6 +4,9 @@
 #![needs_allocator]
 #![allow(internal_features)]
 
+extern crate minicore;
+use minicore::*;
+
 #[rustc_std_internal_symbol]
 unsafe fn __rust_alloc(_size: usize, _align: usize) -> *mut u8 {
     0 as *mut u8
@@ -22,22 +25,4 @@ extern "C" fn init() {
     unsafe {
         __rust_alloc_error_handler(0, 0);
     }
-}
-
-mod minicore {
-    #[lang = "pointee_sized"]
-    pub trait PointeeSized {}
-
-    #[lang = "meta_sized"]
-    pub trait MetaSized: PointeeSized {}
-
-    #[lang = "sized"]
-    pub trait Sized: MetaSized {}
-
-    #[lang = "copy"]
-    pub trait Copy {}
-    impl Copy for u8 {}
-
-    #[lang = "drop_in_place"]
-    fn drop_in_place<T>(_: *mut T) {}
 }

--- a/tests/run-make/wasm-unexpected-features/rmake.rs
+++ b/tests/run-make/wasm-unexpected-features/rmake.rs
@@ -1,10 +1,18 @@
-//@ only-wasm32-wasip1
-
+//@ needs-rust-lld
 use std::path::Path;
 
-use run_make_support::{rfs, rustc, wasmparser};
+use run_make_support::{minicore_path, path, rfs, rustc, wasmparser};
 
 fn main() {
+    rustc()
+        .input(minicore_path())
+        .crate_name("minicore")
+        .crate_type("rlib")
+        .target("wasm32-wasip1")
+        .target_cpu("mvp")
+        .output("libminicore.rlib")
+        .run();
+
     rustc()
         .input("foo.rs")
         .target("wasm32-wasip1")
@@ -13,6 +21,7 @@ fn main() {
         .lto("fat")
         .linker_plugin_lto("on")
         .link_arg("--import-memory")
+        .extern_("minicore", path("libminicore.rlib"))
         .run();
     verify_features(Path::new("foo.wasm"));
 }

--- a/tests/run-make/wasm-unexpected-features/rmake.rs
+++ b/tests/run-make/wasm-unexpected-features/rmake.rs
@@ -1,17 +1,10 @@
 //@ needs-rust-lld
 use std::path::Path;
 
-use run_make_support::{minicore_path, path, rfs, rustc, wasmparser};
+use run_make_support::{path, rfs, rustc, rustc_minicore, wasmparser};
 
 fn main() {
-    rustc()
-        .input(minicore_path())
-        .crate_name("minicore")
-        .crate_type("rlib")
-        .target("wasm32-wasip1")
-        .target_cpu("mvp")
-        .output("libminicore.rlib")
-        .run();
+    rustc_minicore().target("wasm32-wasip1").target_cpu("mvp").output("libminicore.rlib").run();
 
     rustc()
         .input("foo.rs")


### PR DESCRIPTION
r? jieyouxu 

This manually builds `minicore` in two more `rmake` tests that rolled their own before, and adds a helper for the path of the minicore source. I tried adding a true minicore helper in `run_make_support` but unfortunately the minicore build needs to inherit some (but probably not all) arguments of the final rustc invocation (notably `target` and `target_cpu`), so a one-size-fits-all helper doesn't really work as far as I can see.

For now with 3 uses this is probably fine, but there are probably other `run-make` tests that could use `minicore` but didn't document/simulate that.

follow-up to discussion in https://github.com/rust-lang/rust/pull/153153.