### PR TITLE
miri: make read_discriminant UB when the tag is not in the validity range of the tag field

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/discriminant.rs
+++ b/compiler/rustc_const_eval/src/interpret/discriminant.rs
@@ -111,23 +111,30 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                     .try_to_scalar_int()
                     .map_err(|dbg_val| err_ub!(InvalidTag(dbg_val)))?
                     .to_bits(tag_layout.size);
+                // Ensure the tag is in its layout range. Codegen adds range metadata on the
+                // discriminant load so we really have to make this UB.
+                if !tag_scalar_layout.valid_range(self).contains(tag_bits) {
+                    throw_ub!(InvalidTag(Scalar::from_uint(tag_bits, tag_layout.size)))
+                }
                 // Cast bits from tag layout to discriminant layout.
                 // After the checks we did above, this cannot fail, as
                 // discriminants are int-like.
                 let discr_val = self.int_to_int_or_float(&tag_val, discr_layout).unwrap();
                 let discr_bits = discr_val.to_scalar().to_bits(discr_layout.size)?;
-                // Convert discriminant to variant index, and catch invalid discriminants.
+                // Convert discriminant to variant index. Since we validated the tag against the
+                // layout range above, this cannot fail.
                 let index = match *ty.kind() {
                     ty::Adt(adt, _) => {
-                        adt.discriminants(*self.tcx).find(|(_, var)| var.val == discr_bits)
+                        adt.discriminants(*self.tcx).find(|(_, var)| var.val == discr_bits).unwrap()
                     }
                     ty::Coroutine(def_id, args) => {
                         let args = args.as_coroutine();
-                        args.discriminants(def_id, *self.tcx).find(|(_, var)| var.val == discr_bits)
+                        args.discriminants(def_id, *self.tcx)
+                            .find(|(_, var)| var.val == discr_bits)
+                            .unwrap()
                     }
                     _ => span_bug!(self.cur_span(), "tagged layout for non-adt non-coroutine"),
-                }
-                .ok_or_else(|| err_ub!(InvalidTag(Scalar::from_uint(tag_bits, tag_layout.size))))?;
+                };
                 // Return the cast value, and the index.
                 index.0
             }
@@ -174,13 +181,22 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                             let variants =
                                 ty.ty_adt_def().expect("tagged layout for non adt").variants();
                             assert!(variant_index < variants.next_index());
+                            // This should imply that the tag is in its layout range.
+                            assert!(tag_scalar_layout.valid_range(self).contains(tag_bits));
+
                             if variant_index == untagged_variant {
                                 // The untagged variant can be in the niche range, but even then it
-                                // is not a valid encoding.
+                                // is not a valid encoding. Codegen inserts an `assume` here
+                                // so we really have to make this UB.
                                 throw_ub!(InvalidTag(Scalar::from_uint(tag_bits, tag_layout.size)))
                             }
                             variant_index
                         } else {
+                            // Ensure the tag is in its layout range. Codegen adds range metadata on
+                            // the discriminant load so we really have to make this UB.
+                            if !tag_scalar_layout.valid_range(self).contains(tag_bits) {
+                                throw_ub!(InvalidTag(Scalar::from_uint(tag_bits, tag_layout.size)))
+                            }
                             untagged_variant
                         }
                     }

--- a/src/tools/miri/tests/fail/enum-untagged-variant-invalid-encoding.rs
+++ b/src/tools/miri/tests/fail/enum-untagged-variant-invalid-encoding.rs
@@ -20,8 +20,8 @@ fn main() {
         assert!(Foo::Var1 == mem::transmute(2u8));
         assert!(Foo::Var3 == mem::transmute(4u8));
 
-        let invalid: Foo = mem::transmute(3u8);
-        assert!(matches!(invalid, Foo::Var2(_)));
+        let invalid: *const Foo = mem::transmute(&3u8);
+        assert!(matches!(*invalid, Foo::Var2(_)));
         //~^ ERROR: invalid tag
     }
 }

--- a/src/tools/miri/tests/fail/validity/invalid_enum_op_discr_uninhabited.rs
+++ b/src/tools/miri/tests/fail/validity/invalid_enum_op_discr_uninhabited.rs
@@ -1,0 +1,27 @@
+// Make sure we find these even with many checks disabled.
+//@compile-flags: -Zmiri-disable-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-disable-validation
+#![feature(never_type)]
+
+enum Never {}
+
+// An enum with 4 variants of which only some are uninhabited -- so the uninhabited variants *do*
+// have a discriminant.
+#[allow(unused)]
+enum UninhDiscriminant {
+    A,
+    B(!),
+    C,
+    D(Never),
+}
+
+fn main() {
+    unsafe {
+        let x = 3u8;
+        let x_ptr: *const u8 = &x;
+        let cast_ptr = x_ptr as *const UninhDiscriminant;
+        // Reading the discriminant should fail since the tag value is not in the valid
+        // range for the tag field.
+        let _val = matches!(*cast_ptr, UninhDiscriminant::A);
+        //~^ ERROR: invalid tag
+    }
+}

--- a/src/tools/miri/tests/fail/validity/invalid_enum_op_discr_uninhabited.stderr
+++ b/src/tools/miri/tests/fail/validity/invalid_enum_op_discr_uninhabited.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: enum value has invalid tag: 0x03
-  --> tests/fail/enum-untagged-variant-invalid-encoding.rs:LL:CC
+  --> tests/fail/validity/invalid_enum_op_discr_uninhabited.rs:LL:CC
    |
-LL |         assert!(matches!(*invalid, Foo::Var2(_)));
-   |                          ^^^^^^^^ Undefined Behavior occurred here
+LL |         let _val = matches!(*cast_ptr, UninhDiscriminant::A);
+   |                             ^^^^^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/miri/tests/fail/validity/invalid_enum_op_niche_out_of_range.rs
+++ b/src/tools/miri/tests/fail/validity/invalid_enum_op_niche_out_of_range.rs
@@ -1,0 +1,14 @@
+// Make sure we find these even with many checks disabled.
+//@compile-flags: -Zmiri-disable-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-disable-validation
+
+fn main() {
+    unsafe {
+        let x = 12u8;
+        let x_ptr: *const u8 = &x;
+        let cast_ptr = x_ptr as *const Option<bool>;
+        // Reading the discriminant should fail since the tag value is not in the valid
+        // range for the tag field.
+        let _val = matches!(*cast_ptr, None);
+        //~^ ERROR: invalid tag
+    }
+}

--- a/src/tools/miri/tests/fail/validity/invalid_enum_op_niche_out_of_range.stderr
+++ b/src/tools/miri/tests/fail/validity/invalid_enum_op_niche_out_of_range.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: enum value has invalid tag: 0x03
-  --> tests/fail/enum-untagged-variant-invalid-encoding.rs:LL:CC
+error: Undefined Behavior: enum value has invalid tag: 0x0c
+  --> tests/fail/validity/invalid_enum_op_niche_out_of_range.rs:LL:CC
    |
-LL |         assert!(matches!(*invalid, Foo::Var2(_)));
-   |                          ^^^^^^^^ Undefined Behavior occurred here
+LL |         let _val = matches!(*cast_ptr, None);
+   |                             ^^^^^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/ui/consts/const-eval/raw-bytes.32bit.stderr
+++ b/tests/ui/consts/const-eval/raw-bytes.32bit.stderr
@@ -31,7 +31,7 @@ LL | const BAD_UNINHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute
                01                                              │ .
            }
 
-error[E0080]: constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
+error[E0080]: constructing invalid value at .<enum-tag>: encountered 0x03, but expected a valid enum tag
   --> $DIR/raw-bytes.rs:47:1
    |
 LL | const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute(3u8) };

--- a/tests/ui/consts/const-eval/raw-bytes.64bit.stderr
+++ b/tests/ui/consts/const-eval/raw-bytes.64bit.stderr
@@ -31,7 +31,7 @@ LL | const BAD_UNINHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute
                01                                              │ .
            }
 
-error[E0080]: constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
+error[E0080]: constructing invalid value at .<enum-tag>: encountered 0x03, but expected a valid enum tag
   --> $DIR/raw-bytes.rs:47:1
    |
 LL | const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute(3u8) };

--- a/tests/ui/consts/const-eval/ub-enum.rs
+++ b/tests/ui/consts/const-eval/ub-enum.rs
@@ -83,7 +83,7 @@ const GOOD_INHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute(2u8) 
 const BAD_UNINHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute(1u8) };
 //~^ ERROR uninhabited enum variant
 const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute(3u8) };
-//~^ ERROR uninhabited enum variant
+//~^ ERROR expected a valid enum tag
 
 // # other
 

--- a/tests/ui/consts/const-eval/ub-enum.stderr
+++ b/tests/ui/consts/const-eval/ub-enum.stderr
@@ -86,7 +86,7 @@ LL | const BAD_UNINHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
+error[E0080]: constructing invalid value at .<enum-tag>: encountered 0x03, but expected a valid enum tag
   --> $DIR/ub-enum.rs:85:1
    |
 LL | const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute(3u8) };


### PR DESCRIPTION
Arguably, reading an enum discriminant is an operation that uses the "type" of the discriminant field -- and therefore it should fail when the value in that field isn't valid at that type. Therefore, code like this should be UB:
```rust
fn main() {
    unsafe {
        let x = 12u8;
        let x_ptr: *const u8 = &x;
        let cast_ptr = x_ptr as *const Option<bool>;
        // Reading the discriminant should fail since the tag value is not in the valid
        // range for the tag field.
        let _val = matches!(*cast_ptr, None);
        //~^ ERROR: invalid tag
    }
}
```
However, Miri currently sees no UB here. (MiniRust does see UB.) This is because we never actually check whether the tag we read is in the validity range for its field. So let's add such a check, and a corresponding test.

In fact, we have to do this check, since the codegen backend adds range metadata on the discriminant load, as can be seen in [this example](https://play.rust-lang.org/?version=stable&mode=release&edition=2024&gist=02ef5e80fdfe61540e44198dd827b630). In other words, the above code has UB in LLVM IR but not in Miri, which is a critical Miri bug.