### PR TITLE
Respect RUSTC_LINK_STD_INTO_RUSTC_DRIVER=0 in link_std_into_rustc_driver

### DIFF
--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -1125,6 +1125,12 @@ impl<'a> Builder<'a> {
     /// Returns if `std` should be statically linked into `rustc_driver`.
     /// It's currently not done on `windows-gnu` due to linker bugs.
     pub fn link_std_into_rustc_driver(&self, target: TargetSelection) -> bool {
+        // Respect explicit environment variable override
+        if let Ok(val) = std::env::var("RUSTC_LINK_STD_INTO_RUSTC_DRIVER")
+            && val == "0"
+        {
+            return false;
+        }
         !target.triple.ends_with("-windows-gnu")
     }
 


### PR DESCRIPTION
This patch allows users to opt out of statically linking std into rustc_driver by setting the existing environment variable `RUSTC_LINK_STD_INTO_RUSTC_DRIVER=0`.

- If the variable is unset or set to any other value, the function falls back to the default behavior (linking std on all platforms    except Windows).

- Note: This does not introduce a new environment variable; it only respects an existing one.

- Defaults remain unchanged, so normal builds are unaffected.

Example usage:
```
export RUSTC_LINK_STD_INTO_RUSTC_DRIVER=0
./x.py build
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
