### PR TITLE
core: remove FIXME comment in option.rs FromIterator

### DIFF
--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -155,6 +155,9 @@ where
     for<'a> F: FnMut(GenericShunt<'a, I, R>) -> U,
     R: Residual<U>,
 {
+    // FIXME(#11084): we might be able to get rid of GenericShunt in favor of
+    // Iterator::scan, as performance should be comparable
+
     let mut residual = None;
     let shunt = GenericShunt { iter, residual: &mut residual };
     let value = f(shunt);

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -2758,9 +2758,6 @@ impl<A, V: FromIterator<A>> FromIterator<Option<A>> for Option<V> {
     /// so the final value of `shared` is 6 (= `3 + 2 + 1`), not 16.
     #[inline]
     fn from_iter<I: IntoIterator<Item = Option<A>>>(iter: I) -> Option<V> {
-        // FIXME(#11084): This could be replaced with Iterator::scan when this
-        // performance bug is closed.
-
         iter::try_process(iter.into_iter(), |i| i.collect())
     }
 }


### PR DESCRIPTION
The referenced issue rust-lang/rust#11084 was closed in 2021, and the related PR rust-lang/rust#59605 was not merged due to inconclusive results. Similar code (in result.rs, for example) doesn't have this FIXME comment; this is the only reference to issue 11084 (or pull request 59605).

This FIXME was not mentioned in issue rust-lang/rust#44366.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
