### PR TITLE
Fix ICE in fn_delegation when child segment resolves to a trait

### DIFF
--- a/compiler/rustc_hir_analysis/src/delegation.rs
+++ b/compiler/rustc_hir_analysis/src/delegation.rs
@@ -597,31 +597,35 @@ fn get_delegation_user_specified_args<'tcx>(
             .as_slice()
     });
 
-    let child_args = info.child_args_segment_id.and_then(get_segment).map(|(segment, def_id)| {
-        let parent_args = if let Some(parent_args) = parent_args {
-            parent_args
-        } else {
-            let parent = tcx.parent(def_id);
-            if matches!(tcx.def_kind(parent), DefKind::Trait) {
-                ty::GenericArgs::identity_for_item(tcx, parent).as_slice()
+    let child_args = info
+        .child_args_segment_id
+        .and_then(get_segment)
+        .filter(|(_, def_id)| matches!(tcx.def_kind(*def_id), DefKind::Fn | DefKind::AssocFn))
+        .map(|(segment, def_id)| {
+            let parent_args = if let Some(parent_args) = parent_args {
+                parent_args
             } else {
-                &[]
-            }
-        };
+                let parent = tcx.parent(def_id);
+                if matches!(tcx.def_kind(parent), DefKind::Trait) {
+                    ty::GenericArgs::identity_for_item(tcx, parent).as_slice()
+                } else {
+                    &[]
+                }
+            };
 
-        let args = lowerer
-            .lower_generic_args_of_path(
-                segment.ident.span,
-                def_id,
-                parent_args,
-                segment,
-                None,
-                GenericArgPosition::Value,
-            )
-            .0;
+            let args = lowerer
+                .lower_generic_args_of_path(
+                    segment.ident.span,
+                    def_id,
+                    parent_args,
+                    segment,
+                    None,
+                    GenericArgPosition::Value,
+                )
+                .0;
 
-        &args[parent_args.len()..]
-    });
+            &args[parent_args.len()..]
+        });
 
     (parent_args.unwrap_or_default(), child_args.unwrap_or_default())
 }

--- a/tests/ui/delegation/reuse-trait-path-with-empty-generics.rs
+++ b/tests/ui/delegation/reuse-trait-path-with-empty-generics.rs
@@ -1,0 +1,14 @@
+//@ needs-rustc-debug-assertions
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+trait Trait {
+    fn bar4();
+}
+
+impl Trait for () {
+    reuse Trait::<> as bar4;
+    //~^ ERROR expected function, found trait `Trait`
+}
+
+fn main() {}

--- a/tests/ui/delegation/reuse-trait-path-with-empty-generics.stderr
+++ b/tests/ui/delegation/reuse-trait-path-with-empty-generics.stderr
@@ -1,0 +1,9 @@
+error[E0423]: expected function, found trait `Trait`
+  --> $DIR/reuse-trait-path-with-empty-generics.rs:10:11
+   |
+LL |     reuse Trait::<> as bar4;
+   |           ^^^^^^^^^ not a function
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0423`.


### PR DESCRIPTION
Fixes rust-lang/rust#153420

When a delegation path like `reuse Trait::<> as bar4` has only one segment resolving to a trait (not a function), the child args processing in `get_delegation_user_specified_args` called `lower_generic_args_of_path` with `self_ty = None`. Since the trait's generics have `has_self = true`, this triggered
`assert!(self_ty.is_some())`.

Fix by computing and providing `self_ty` when the child segment's `def_id` has `has_self`. In valid delegation code the child segment always resolves to a function, so this only affects error recovery.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
