### PR TITLE
Update dispatch2 to v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "dispatch2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags",
  "block2",


### PR DESCRIPTION
rustc can fail to link on older versions of macOS, owing to versions of its transitive dependency [dispatch2] (via [ctrlc]) prior to v0.3.1.

Fixes rust-lang/rust#151573
r? madsmtm

[ctrlc]: https://crates.io/crates/ctrlc
[dispatch2]: https://crates.io/crates/dispatch2