### PR TITLE
Fix obtaining def_id from unresolved segment

### DIFF
--- a/compiler/rustc_hir_analysis/src/delegation.rs
+++ b/compiler/rustc_hir_analysis/src/delegation.rs
@@ -572,17 +572,15 @@ fn get_delegation_user_specified_args<'tcx>(
         .opt_delegation_generics()
         .expect("Lowering delegation");
 
-    let get_segment = |hir_id: HirId| -> (&'tcx PathSegment<'tcx>, DefId) {
+    let get_segment = |hir_id: HirId| -> Option<(&'tcx PathSegment<'tcx>, DefId)> {
         let segment = tcx.hir_node(hir_id).expect_path_segment();
-        let def_id = segment.res.def_id();
-
-        (segment, def_id)
+        segment.res.opt_def_id().map(|def_id| (segment, def_id))
     };
 
     let ctx = ItemCtxt::new(tcx, delegation_id);
     let lowerer = ctx.lowerer();
 
-    let parent_args = info.parent_args_segment_id.map(get_segment).map(|(segment, def_id)| {
+    let parent_args = info.parent_args_segment_id.and_then(get_segment).map(|(segment, def_id)| {
         let self_ty = get_delegation_self_ty(tcx, delegation_id);
 
         lowerer
@@ -598,7 +596,7 @@ fn get_delegation_user_specified_args<'tcx>(
             .as_slice()
     });
 
-    let child_args = info.child_args_segment_id.map(get_segment).map(|(segment, def_id)| {
+    let child_args = info.child_args_segment_id.and_then(get_segment).map(|(segment, def_id)| {
         let parent_args = if let Some(parent_args) = parent_args {
             parent_args
         } else {

--- a/tests/ui/delegation/generics/unresolved-segment-ice-153389.rs
+++ b/tests/ui/delegation/generics/unresolved-segment-ice-153389.rs
@@ -1,0 +1,13 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+trait Trait{
+    fn bar();
+}
+
+impl Trait for () {
+    reuse missing::<> as bar;
+    //~^ ERROR: cannot find function `missing` in this scope
+}
+
+fn main() {}

--- a/tests/ui/delegation/generics/unresolved-segment-ice-153389.stderr
+++ b/tests/ui/delegation/generics/unresolved-segment-ice-153389.stderr
@@ -1,0 +1,9 @@
+error[E0425]: cannot find function `missing` in this scope
+  --> $DIR/unresolved-segment-ice-153389.rs:9:11
+   |
+LL |     reuse missing::<> as bar;
+   |           ^^^^^^^ not found in this scope
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
This PR fixes ICE when trying to obtain `def_id` from an unresolved segment, part of rust-lang/rust#118212, fixes rust-lang/rust#153389.

r? @petrochenkov