### PR TITLE
[EXPERIMENT] Cache-on-disk perf experiments for `check_liveness`

### DIFF
--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -1251,7 +1251,6 @@ rustc_queries! {
 
     query typeck(key: LocalDefId) -> &'tcx ty::TypeckResults<'tcx> {
         desc { "type-checking `{}`", tcx.def_path_str(key) }
-        cache_on_disk_if { !tcx.is_typeck_child(key.to_def_id()) }
     }
 
     query used_trait_imports(key: LocalDefId) -> &'tcx UnordSet<LocalDefId> {


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/153441)*
<!-- homu-ignore:end -->

(Checking the perf impact of changing the `cache_on_disk_if` condition for this query, in the hopes that we can get rid of the only non-trivial condition in the query list.)

EDIT: Via https://github.com/rust-lang/rust/pull/153487#discussion_r2895309615, the `typeck` query is another exception.