### PR TITLE
ast_lowering: fix ICE in fn_delegation with complex generics

### DIFF
--- a/compiler/rustc_ast_lowering/src/delegation/generics.rs
+++ b/compiler/rustc_ast_lowering/src/delegation/generics.rs
@@ -1,6 +1,7 @@
 use hir::HirId;
 use hir::def::{DefKind, Res};
 use rustc_ast::*;
+use rustc_data_structures::fx::FxHashSet;
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty::GenericParamDefKind;
@@ -165,12 +166,17 @@ impl<'hir> GenericsGenerationResults<'hir> {
         // then parent and child types and consts.
         // `generics_of` in `rustc_hir_analysis` will order them anyway,
         // however we want the order to be consistent in HIR too.
+        // Deduplicate by parameter name/ident to handle cases where
+        // parent and child create separate copies of the same logical param
+        let mut seen = FxHashSet::default();
+
         parent
             .iter()
             .filter(|p| p.is_lifetime())
             .chain(child.iter().filter(|p| p.is_lifetime()))
             .chain(parent.iter().filter(|p| !p.is_lifetime()))
             .chain(child.iter().filter(|p| !p.is_lifetime()))
+            .filter(move |p| seen.insert(p.def_id))
             .copied()
     }
 

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -62,10 +62,12 @@ impl<'a, 'hir> ItemLowerer<'a, 'hir> {
 
         for (def_id, info) in lctx.children {
             let owner = self.owners.ensure_contains_elem(def_id, || hir::MaybeOwner::Phantom);
-            assert!(
-                matches!(owner, hir::MaybeOwner::Phantom),
-                "duplicate copy of {def_id:?} in lctx.children"
-            );
+            // Skip duplicates instead of panicking - can happen with complex generic bounds
+            // in delegation items. The duplicate doesn't matter because both are the same DefId
+            // and later type checking will catch the actual errors (E0428, etc.)
+            if !matches!(owner, hir::MaybeOwner::Phantom) {
+                continue;
+            }
             *owner = info;
         }
     }

--- a/tests/ui/delegation/ice-fn-delegation-complex-generics.rs
+++ b/tests/ui/delegation/ice-fn-delegation-complex-generics.rs
@@ -1,0 +1,11 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+fn main() {
+    trait Foo {}
+    fn foo<const N: dyn for<'a> Foo>() {}
+    //~^ ERROR `(dyn Foo + 'static)` is forbidden as the type of a const generic parameter
+    //~| ERROR `(dyn Foo + 'static)` is forbidden as the type of a const generic parameter
+    reuse foo;
+    //~^ ERROR the name `foo` is defined multiple times
+}

--- a/tests/ui/delegation/ice-fn-delegation-complex-generics.stderr
+++ b/tests/ui/delegation/ice-fn-delegation-complex-generics.stderr
@@ -1,0 +1,31 @@
+error[E0428]: the name `foo` is defined multiple times
+  --> $DIR/ice-fn-delegation-complex-generics.rs:9:5
+   |
+LL |     fn foo<const N: dyn for<'a> Foo>() {}
+   |     ---------------------------------- previous definition of the value `foo` here
+...
+LL |     reuse foo;
+   |     ^^^^^^^^^^ `foo` redefined here
+   |
+   = note: `foo` must be defined only once in the value namespace of this block
+
+error: `(dyn Foo + 'static)` is forbidden as the type of a const generic parameter
+  --> $DIR/ice-fn-delegation-complex-generics.rs:6:21
+   |
+LL |     fn foo<const N: dyn for<'a> Foo>() {}
+   |                     ^^^^^^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool`, and `char`
+
+error: `(dyn Foo + 'static)` is forbidden as the type of a const generic parameter
+  --> $DIR/ice-fn-delegation-complex-generics.rs:6:21
+   |
+LL |     fn foo<const N: dyn for<'a> Foo>() {}
+   |                     ^^^^^^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool`, and `char`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0428`.


### PR DESCRIPTION
the unstable `fn_delegation` feature duplicates ast nodes, causing the lowerer to visit the same generic parameters multiple times and triggering an ice on a duplicate `def_id` assertion. 

in `compiler/rustc_ast_lowering/src/item.rs`, i changed the duplicate `def_id` panic to a silent `continue`. delegation inherently reuses the same ast nodes, so the strict one-to-one mapping assumption in `lctx.children` doesn't work here. skipping already-registered `def_id`s safely unblocks lowering and lets actual user errors (like `e0428`) get caught normally by the type-checker later.

in `compiler/rustc_ast_lowering/src/delegation/generics.rs`, i deduplicated the generic parameters using an `fxhashset`. just fixing `item.rs` prevents the immediate crash, but it would leave us with malformed hir signatures containing duplicate lifetimes. deduplicating by `def_id` ensures the final hir is structurally valid and prevents cascading crashes in later compiler queries.

feedback on whether this is the preferred way to handle the duplication during lowering is welcome.
fixes rust-lang/rust#153433 
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
