### PR TITLE
Fix docs: remove rvalue terminology from transmute comment

### DIFF
--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -823,10 +823,9 @@ pub const fn forget<T: ?Sized>(_: T);
 ///     unsafe {
 ///         let ptr = slice.as_mut_ptr();
 ///         // This now has three mutable references pointing at the same
-///         // memory. `slice`, the rvalue ret.0, and the rvalue ret.1.
-///         // `slice` is never used after `let ptr = ...`, and so one can
-///         // treat it as "dead", and therefore, you only have two real
-///         // mutable slices.
+///         // memory: `slice`, `ret.0` and `ret.1`. `slice` is never used after
+///         // `let ptr = ...`, and so one can treat it as "dead", and therefore,
+///         // you only have two real mutable slices.
 ///         (slice::from_raw_parts_mut(ptr, mid),
 ///          slice::from_raw_parts_mut(ptr.add(mid), len - mid))
 ///     }


### PR DESCRIPTION
Fixes rust-lang/rust#153350. Changes comment in transmute documentation to remove confusing "rvalue" terminology and simplifies the wording for better clarity.