### PR TITLE
Consider try blocks as block-like for overflowed expr

### DIFF
--- a/src/tools/rustfmt/src/expr.rs
+++ b/src/tools/rustfmt/src/expr.rs
@@ -1553,7 +1553,10 @@ pub(crate) fn can_be_overflowed_expr(
         }
 
         // Handle always block-like expressions
-        ast::ExprKind::Gen(..) | ast::ExprKind::Block(..) | ast::ExprKind::Closure(..) => true,
+        ast::ExprKind::Gen(..)
+        | ast::ExprKind::Block(..)
+        | ast::ExprKind::Closure(..)
+        | ast::ExprKind::TryBlock(..) => true,
 
         // Handle `[]` and `{}`-like expressions
         ast::ExprKind::Array(..) | ast::ExprKind::Struct(..) => {

--- a/src/tools/rustfmt/tests/source/try_block.rs
+++ b/src/tools/rustfmt/tests/source/try_block.rs
@@ -27,5 +27,13 @@ fn baz() -> Option<i32> {
 
     let x: Option<i32> = try { baz()?; baz()?; baz()?; 7 };
 
+    let _ = overflowed_expr(
+        x,
+        try {
+            foo()?;
+            bar()?;
+        },
+    );
+
     return None;
 }

--- a/src/tools/rustfmt/tests/source/try_blocks_heterogeneous.rs
+++ b/src/tools/rustfmt/tests/source/try_blocks_heterogeneous.rs
@@ -35,5 +35,15 @@ fn baz() -> Option<i32> {
 
     let x = try bikeshed Foo<Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar> {};
 
+    let x = try bikeshed Result<VeryVeryVeryVeryVeryLongTypeForSuccess, VeryVeryVeryVeryVeryLongTypeForFailure> {};
+
+    let _ = overflowed_expr(
+        x,
+        try bikeshed Option<_> {
+            foo()?;
+            bar()?;
+        },
+    );
+
     return None;
 }

--- a/src/tools/rustfmt/tests/target/try_block.rs
+++ b/src/tools/rustfmt/tests/target/try_block.rs
@@ -26,5 +26,10 @@ fn baz() -> Option<i32> {
         7
     };
 
+    let _ = overflowed_expr(x, try {
+        foo()?;
+        bar()?;
+    });
+
     return None;
 }

--- a/src/tools/rustfmt/tests/target/try_blocks_heterogeneous.rs
+++ b/src/tools/rustfmt/tests/target/try_blocks_heterogeneous.rs
@@ -37,5 +37,16 @@ fn baz() -> Option<i32> {
     let x =
         try bikeshed Foo<Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar, Bar> {};
 
+    let x = try bikeshed Result<
+        VeryVeryVeryVeryVeryLongTypeForSuccess,
+        VeryVeryVeryVeryVeryLongTypeForFailure,
+    > {
+    };
+
+    let _ = overflowed_expr(x, try bikeshed Option<_> {
+        foo()?;
+        bar()?;
+    });
+
     return None;
 }


### PR DESCRIPTION
The tracking issue for `try_blocks` is https://github.com/rust-lang/rust/issues/31436.
The tracking issue for `try_blocks_heterogeneous` is https://github.com/rust-lang/rust/issues/149488.

Fixes https://github.com/rust-lang/rustfmt/issues/6799.