### PR TITLE
Fix ICEs due to incomplete typechecking on struct literals with syntax errors.

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -2203,7 +2203,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 };
                 self.typeck_results.borrow_mut().fru_field_types_mut().insert(expr.hir_id, fru_tys);
             }
-            rustc_hir::StructTailExpr::NoneWithError(ErrorGuaranteed { .. }) => {
+            rustc_hir::StructTailExpr::NoneWithError(guaranteed) => {
                 // If parsing the struct recovered from a syntax error, do not report missing
                 // fields. This prevents spurious errors when a field is intended to be present
                 // but a preceding syntax error caused it not to be parsed. For example, if a
@@ -2211,6 +2211,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 //     StructName { foo(), bar: 2 }
                 // will not successfully parse a field `foo`, but we will not mention that,
                 // since the syntax error has already been reported.
+
+                // Signal that type checking has failed, even though we haven’t emitted a diagnostic
+                // about it ourselves.
+                self.infcx.set_tainted_by_errors(guaranteed);
             }
             rustc_hir::StructTailExpr::None => {
                 if adt_kind != AdtKind::Union

--- a/tests/ui/structs/syntax-error-not-missing-field.rs
+++ b/tests/ui/structs/syntax-error-not-missing-field.rs
@@ -47,4 +47,21 @@ fn enum_expr_missing_separator() {
     let e = Bar::Baz { a: make_a() b: 2 }; //~ ERROR found `b`
 }
 
+// Should error but not then ICE due to lack of type checking
+fn regression_test_for_issue_153388_a() {
+    struct TheStruct;
+    struct MyStruct {
+        value: i32,
+        s: TheStruct,
+    }
+    static A: MyStruct = MyStruct { ,s: TheStruct }; //~ ERROR expected identifier, found `,`
+}
+
+fn regression_test_for_issue_153388_b() {
+    struct MyStruct {
+        value: i32,
+    }
+    static A: MyStruct = MyStruct {,}; //~ ERROR expected identifier, found `,`
+}
+
 fn main() {}

--- a/tests/ui/structs/syntax-error-not-missing-field.stderr
+++ b/tests/ui/structs/syntax-error-not-missing-field.stderr
@@ -89,5 +89,27 @@ LL |     let e = Bar::Baz { a: make_a() b: 2 };
    |             |                     help: try adding a comma: `,`
    |             while parsing this struct
 
-error: aborting due to 9 previous errors
+error: expected identifier, found `,`
+  --> $DIR/syntax-error-not-missing-field.rs:57:37
+   |
+LL |     static A: MyStruct = MyStruct { ,s: TheStruct };
+   |                          --------   ^ expected identifier
+   |                          |
+   |                          while parsing this struct
+   |
+help: remove this comma
+   |
+LL -     static A: MyStruct = MyStruct { ,s: TheStruct };
+LL +     static A: MyStruct = MyStruct { s: TheStruct };
+   |
+
+error: expected identifier, found `,`
+  --> $DIR/syntax-error-not-missing-field.rs:64:36
+   |
+LL |     static A: MyStruct = MyStruct {,};
+   |                          --------  ^ expected identifier
+   |                          |
+   |                          while parsing this struct
+
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust#153388.
Followup to rust-lang/rust#153227.

Today I have learned that when we don’t emit a diagnostic *specifically from typeck*, we need to call `self.infcx.set_tainted_by_errors()` to signal that the type checking is incomplete despite the lack of error.

r? fmease
