### PR TITLE
fix(interp): Treat `UnsafeBinder` as Compound Type in `try_visit_primitive`

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -991,7 +991,13 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
                 // Nothing to check.
                 interp_ok(true)
             }
-            ty::UnsafeBinder(_) => todo!("FIXME(unsafe_binder)"),
+            ty::UnsafeBinder(unsafe_binder_ty) => {
+                let inner_ty =
+                    self.ecx.tcx.instantiate_bound_regions_with_erased((*unsafe_binder_ty).into());
+                let inner = value.transmute(self.ecx.layout_of(inner_ty)?, self.ecx)?;
+                self.visit_value(&inner)?;
+                interp_ok(true)
+            }
             // The above should be all the primitive types. The rest is compound, we
             // check them by visiting their fields/variants.
             ty::Adt(..)

--- a/tests/ui/unsafe-binders/const-eval-validity-ref.rs
+++ b/tests/ui/unsafe-binders/const-eval-validity-ref.rs
@@ -1,0 +1,15 @@
+//@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
+//@ normalize-stderr: "([0-9a-f][0-9a-f] |╾─*A(LLOC)?[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ normalize-stderr: "HEX_DUMP\s*\n\s*HEX_DUMP" -> "HEX_DUMP"
+
+#![feature(unsafe_binders)]
+#![allow(incomplete_features)]
+
+struct RefDst {
+    b: unsafe<'a> &'a u32,
+}
+
+const C1: &RefDst = unsafe { std::mem::transmute(&1usize) };
+//~^ ERROR: encountered a dangling reference
+
+fn main() {}

--- a/tests/ui/unsafe-binders/const-eval-validity-ref.stderr
+++ b/tests/ui/unsafe-binders/const-eval-validity-ref.stderr
@@ -1,0 +1,14 @@
+error[E0080]: constructing invalid value of type &RefDst: at .<deref>.b, encountered a dangling reference (0x1[noalloc] has no provenance)
+  --> $DIR/const-eval-validity-ref.rs:12:1
+   |
+LL | const C1: &RefDst = unsafe { std::mem::transmute(&1usize) };
+   | ^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
+   |
+   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
+               HEX_DUMP
+           }
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/unsafe-binders/const-eval-validity.rs
+++ b/tests/ui/unsafe-binders/const-eval-validity.rs
@@ -1,0 +1,17 @@
+// regression test for <https://github.com/rust-lang/rust/issues/153362>.
+//@ check-pass
+
+#![feature(unsafe_binders)]
+#![allow(incomplete_features)]
+
+struct ThinDst {
+    b: unsafe<> (),
+}
+
+const fn t<const N: usize>(x: &[u8; N]) -> &ThinDst {
+    unsafe { std::mem::transmute(x.as_ptr()) }
+}
+
+const C1: &ThinDst = t(b"d");
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/153458)*
<!-- homu-ignore:end -->

### Summary:

Fixes ICE in const eval validity checking when a value contains an `UnsafeBinder`-typed field.

`try_visit_primitive` in `validity.rs` had `ty::UnsafeBinder(_) => todo!("FIXME(unsafe_binder)")`: a placeholder left by the initial unsafe binders type system implementation (9a1c5eb).

The fix is to remove the `todo!()` and move `UnsafeBinder` into the compound types arm.

Closes rust-lang/rust#153362 

r? @dingxiangfei2009 
cc @matthiaskrgr 