### PR TITLE
fix(traits): Bail on Error `FnSig` in `virtual_call_violations_for_method`

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/dyn_compatibility.rs
+++ b/compiler/rustc_trait_selection/src/traits/dyn_compatibility.rs
@@ -405,6 +405,11 @@ fn virtual_call_violations_for_method<'tcx>(
 ) -> Vec<MethodViolation> {
     let sig = tcx.fn_sig(method.def_id).instantiate_identity();
 
+    // Parallel cycle recovery may produce wrong-arity FnSig (#153391).
+    if sig.references_error() {
+        return vec![];
+    }
+
     // The method's first parameter must be named `self`
     if !method.is_method() {
         let sugg = if let Some(hir::Node::TraitItem(hir::TraitItem {

--- a/tests/ui/parallel-rustc/fn-sig-cycle-ice-153391.rs
+++ b/tests/ui/parallel-rustc/fn-sig-cycle-ice-153391.rs
@@ -1,0 +1,16 @@
+// regression test for <https://github.com/rust-lang/rust/issues/153391>.
+//@ edition:2024
+//@ compile-flags: -Z threads=16
+//@ compare-output-by-lines
+
+trait A {
+    fn g() -> B;
+    //~^ ERROR expected a type, found a trait
+}
+
+trait B {
+    fn bar(&self, x: &A);
+    //~^ ERROR expected a type, found a trait
+}
+
+fn main() {}

--- a/tests/ui/parallel-rustc/fn-sig-cycle-ice-153391.stderr
+++ b/tests/ui/parallel-rustc/fn-sig-cycle-ice-153391.stderr
@@ -1,0 +1,36 @@
+error[E0782]: expected a type, found a trait
+   |
+LL |     fn g() -> B;
+   |               ^
+   |
+help: use `impl B` to return an opaque type, as long as you return a single underlying type
+   |
+LL |     fn g() -> impl B;
+   |               ++++
+help: alternatively, you can return an owned trait object
+   |
+LL |     fn g() -> Box<dyn B>;
+   |               +++++++  +
+
+error[E0782]: expected a type, found a trait
+   |
+LL |     fn bar(&self, x: &A);
+   |                       ^
+   |
+help: use a new generic type parameter, constrained by `A`
+   |
+LL -     fn bar(&self, x: &A);
+LL +     fn bar<T: A>(&self, x: &T);
+   |
+help: you can also use an opaque type, but users won't be able to specify the type parameter when calling the `fn`, having to rely exclusively on type inference
+   |
+LL |     fn bar(&self, x: &impl A);
+   |                       ++++
+help: alternatively, use a trait object to accept any type that implements `A`, accessing its methods at runtime using dynamic dispatch
+   |
+LL |     fn bar(&self, x: &dyn A);
+   |                       +++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0782`.


### PR DESCRIPTION
### Summary:

Two traits mutually referencing each other as bare trait objects form a `fn_sig` -> `is_dyn_compatible` cycle. In parallel mode, the deadlock handler rotates cycle entries, so `from_cycle_error` for `FnSig` may pick the wrong entry and produce a wrong arity signature. `virtual_call_violations_for_method` then panics at `sig.input(0)`.

Fix: bail early on `sig.references_error()`.

Closes rust-lang/rust#153391 

r? @dingxiangfei2009 
cc @matthiaskrgr 