### PR TITLE
Fix incorrect rustdoc JSON representation of `#[doc(test(..))]` attrs.

### DIFF
--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -1041,10 +1041,10 @@ fn maybe_from_hir_attr(attr: &hir::Attribute, item_id: ItemId, tcx: TyCtxt<'_>) 
             for attr_span in test_attrs {
                 // FIXME: This is ugly, remove when `test_attrs` has been ported to new attribute API.
                 if let Ok(snippet) = source_map.span_to_snippet(*attr_span) {
-                    ret.push(Attribute::Other(format!("#[doc(test(attr({snippet})))")));
+                    ret.push(Attribute::Other(format!("#[doc(test(attr({snippet})))]")));
                 }
             }
-            toggle_attr(&mut ret, "no_crate_inject", no_crate_inject);
+            toggle_attr(&mut ret, "test(no_crate_inject)", no_crate_inject);
             return ret;
         }
 

--- a/tests/rustdoc-json/attrs/no_crate_inject.rs
+++ b/tests/rustdoc-json/attrs/no_crate_inject.rs
@@ -1,0 +1,7 @@
+// Regression test for rustdoc JSON emitting
+// `#[doc(no_crate_inject)]` instead of `#[doc(test(no_crate_inject))]`:
+// https://github.com/rust-lang/rust/pull/153465
+
+//@ is "$.index[?(@.inner.module.is_crate)].attrs" '[{"other": "#[doc(test(no_crate_inject))]"}]'
+
+#![doc(test(no_crate_inject))]

--- a/tests/rustdoc-json/attrs/trailing_bracket.rs
+++ b/tests/rustdoc-json/attrs/trailing_bracket.rs
@@ -1,0 +1,7 @@
+// Regression test for rustdoc JSON emitting
+// `#[doc(test(attr(deny(rust_2018_idioms))))` without the trailing `]`:
+// https://github.com/rust-lang/rust/pull/153465
+
+//@ is "$.index[?(@.inner.module.is_crate)].attrs" '[{"other": "#[doc(test(attr(deny(rust_2018_idioms))))]"}]'
+
+#![doc(test(attr(deny(rust_2018_idioms))))]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Attributes like `#[doc(test(attr(deny(rust_2018_idioms))))]` are accidentally emitted without the final `]`.

Also, the `#[doc(test(no_crate_inject))]` attribute is mistakenly emitted as `#[doc(no_crate_inject)]` — note the missing `test` wrapper.

This PR adds the missing `]` and fixes the `no_crate_inject`, and adds regression tests for both.

Thanks to the folks working on `tonic` and `pyo3` for reporting a `cargo-semver-checks` crash on Rust 1.94 in their projects, which led me to finding this bug. Refs:
- https://github.com/hyperium/tonic/actions/runs/22732044107/job/65957306230?pr=2536
- https://github.com/PyO3/pyo3/actions/runs/22745106403/job/65967167797
- https://github.com/obi1kenobi/cargo-semver-checks/issues/1590

r? @aDotInTheVoid