### PR TITLE
Don't define `ensure_ok` and `ensure_done` for `anon` queries

### DIFF
--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -432,6 +432,7 @@ macro_rules! define_callbacks {
             $(
                 $(#[$attr])*
                 #[inline(always)]
+                #[cfg(not($anon))]
                 pub fn $name(
                     self,
                     key: query_helper_param_ty!($($K)*),
@@ -456,6 +457,7 @@ macro_rules! define_callbacks {
             $(
                 $(#[$attr])*
                 #[inline(always)]
+                #[cfg(not($anon))]
                 pub fn $name(self, key: query_helper_param_ty!($($K)*)) {
                     crate::query::inner::query_ensure(
                         self.tcx,


### PR DESCRIPTION
`ensure_ok` and `ensure_done` will panic for `anon` queries, so this avoids defining them.