### PR TITLE
Add missing `track_caller` to overflowing trait methods

### DIFF
--- a/library/core/src/ops/arith.rs
+++ b/library/core/src/ops/arith.rs
@@ -716,6 +716,7 @@ macro_rules! neg_impl {
             type Output = $t;
 
             #[inline]
+            #[track_caller]
             #[rustc_inherit_overflow_checks]
             fn neg(self) -> $t { -self }
         }

--- a/library/core/src/ops/bit.rs
+++ b/library/core/src/ops/bit.rs
@@ -484,6 +484,7 @@ macro_rules! shl_impl {
             type Output = $t;
 
             #[inline]
+            #[track_caller]
             #[rustc_inherit_overflow_checks]
             fn shl(self, other: $f) -> $t {
                 self << other
@@ -606,6 +607,7 @@ macro_rules! shr_impl {
             type Output = $t;
 
             #[inline]
+            #[track_caller]
             #[rustc_inherit_overflow_checks]
             fn shr(self, other: $f) -> $t {
                 self >> other
@@ -958,6 +960,7 @@ macro_rules! shl_assign_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const ShlAssign<$f> for $t {
             #[inline]
+            #[track_caller]
             #[rustc_inherit_overflow_checks]
             fn shl_assign(&mut self, other: $f) {
                 *self <<= other
@@ -1044,6 +1047,7 @@ macro_rules! shr_assign_impl {
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const ShrAssign<$f> for $t {
             #[inline]
+            #[track_caller]
             #[rustc_inherit_overflow_checks]
             fn shr_assign(&mut self, other: $f) {
                 *self >>= other


### PR DESCRIPTION
Fixes rust-lang/rust#152599 by adding `#[track_caller]` to arithmetic trait methods (`Neg`, `Shl`, `ShlAssign`, `Shr` and `ShrAssign`) so overflow panics report the correct call site instead of the trait definition.