### PR TITLE
Preserve parentheses around `Fn` trait bounds in pretty printer

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1415,6 +1415,9 @@ impl<'a> State<'a> {
     }
 
     fn print_poly_trait_ref(&mut self, t: &ast::PolyTraitRef) {
+        if let ast::Parens::Yes = t.parens {
+            self.popen();
+        }
         self.print_formal_generic_params(&t.bound_generic_params);
 
         let ast::TraitBoundModifiers { constness, asyncness, polarity } = t.modifiers;
@@ -1437,7 +1440,10 @@ impl<'a> State<'a> {
             }
         }
 
-        self.print_trait_ref(&t.trait_ref)
+        self.print_trait_ref(&t.trait_ref);
+        if let ast::Parens::Yes = t.parens {
+            self.pclose();
+        }
     }
 
     fn print_stmt(&mut self, st: &ast::Stmt) {

--- a/tests/pretty/paren-trait-bound.rs
+++ b/tests/pretty/paren-trait-bound.rs
@@ -1,0 +1,11 @@
+//@ pp-exact
+
+trait Dummy {}
+
+// Without parens, `+ Send` would bind to `dyn Dummy` instead of the outer `dyn`.
+fn f1(_: Box<dyn (Fn() -> Box<dyn Dummy>) + Send>) {}
+
+// Without parens, `+ Send + Sync` would bind to `dyn Dummy` instead of the outer `impl`.
+fn f2(_: impl (FnMut(&mut u8) -> &mut dyn Dummy) + Send + Sync) {}
+
+fn main() {}


### PR DESCRIPTION
The AST pretty printer was dropping parentheses around `Fn` trait bounds in `dyn`/`impl` types when additional `+` bounds were present. For example:

    dyn (FnMut(&mut T) -> &mut dyn ResourceLimiter) + Send + Sync

was pretty-printed as:

    dyn FnMut(&mut T) -> &mut dyn ResourceLimiter + Send + Sync

Without parens, `+ Send + Sync` binds to the inner `dyn ResourceLimiter` instead of the outer type, producing invalid Rust.

The parser already tracks parentheses via `PolyTraitRef.parens`, but `print_poly_trait_ref` never checked this field. This adds `popen()` and `pclose()` calls when `parens == Parens::Yes`.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
