### PR TITLE
Fix ICE in `offset_of!` error recovery

### DIFF
--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -807,7 +807,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
                     user_ty: None,
                 };
                 let mk_usize_kind = |val: u64| ExprKind::NonHirLiteral {
-                    lit: ScalarInt::try_from_uint(val, tcx.data_layout.pointer_size()).unwrap(),
+                    lit: ScalarInt::try_from_target_usize(val, tcx).unwrap(),
                     user_ty: None,
                 };
                 let mk_call =

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -806,6 +806,10 @@ impl<'tcx> ThirBuildCx<'tcx> {
                     lit: ScalarInt::try_from_uint(val, Size::from_bits(32)).unwrap(),
                     user_ty: None,
                 };
+                let mk_usize_kind = |val: u64| ExprKind::NonHirLiteral {
+                    lit: ScalarInt::try_from_uint(val, tcx.data_layout.pointer_size()).unwrap(),
+                    user_ty: None,
+                };
                 let mk_call =
                     |thir: &mut Thir<'tcx>, ty: Ty<'tcx>, variant: VariantIdx, field: FieldIdx| {
                         let fun_ty =
@@ -842,7 +846,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
                     });
                 }
 
-                expr.unwrap_or(mk_u32_kind(0))
+                expr.unwrap_or_else(|| mk_usize_kind(0))
             }
 
             hir::ExprKind::ConstBlock(ref anon_const) => {

--- a/tests/ui/offset-of/offset-of-error-recovery.rs
+++ b/tests/ui/offset-of/offset-of-error-recovery.rs
@@ -1,0 +1,14 @@
+use std::mem::offset_of;
+
+struct S {
+    x: (),
+}
+
+impl S {
+    fn a() {
+        offset_of!(Self, Self::x);
+        //~^ ERROR offset_of expects dot-separated field and variant names
+    }
+}
+
+fn main() {}

--- a/tests/ui/offset-of/offset-of-error-recovery.stderr
+++ b/tests/ui/offset-of/offset-of-error-recovery.stderr
@@ -1,0 +1,8 @@
+error: offset_of expects dot-separated field and variant names
+  --> $DIR/offset-of-error-recovery.rs:9:26
+   |
+LL |         offset_of!(Self, Self::x);
+   |                          ^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#153236.

`offset_of!` was changed in rust-lang/rust#148151 to lower through THIR as a sum of calls to the `offset_of` intrinsic. In the error-recovery case, when no valid field indices are recorded, that lowering synthesized `0` as a `u32` even though the overall `offset_of!` expression has type `usize`.

On 64-bit targets, const-eval then tried to write a 4-byte immediate into an 8-byte destination, which caused the ICE.