### PR TITLE
library: replace return types of constructors with Self

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -780,7 +780,7 @@ impl<T: ?Sized + CloneToUninit> Box<T> {
     #[unstable(feature = "clone_from_ref", issue = "149075")]
     #[must_use]
     #[inline]
-    pub fn clone_from_ref(src: &T) -> Box<T> {
+    pub fn clone_from_ref(src: &T) -> Self {
         Box::clone_from_ref_in(src, Global)
     }
 
@@ -826,7 +826,7 @@ impl<T: ?Sized + CloneToUninit, A: Allocator> Box<T, A> {
     //#[unstable(feature = "allocator_api", issue = "32838")]
     #[must_use]
     #[inline]
-    pub fn clone_from_ref_in(src: &T, alloc: A) -> Box<T, A> {
+    pub fn clone_from_ref_in(src: &T, alloc: A) -> Self {
         let layout = Layout::for_value::<T>(src);
         match Box::try_clone_from_ref_in(src, alloc) {
             Ok(bx) => bx,

--- a/library/alloc/src/collections/binary_heap/mod.rs
+++ b/library/alloc/src/collections/binary_heap/mod.rs
@@ -511,7 +511,7 @@ impl<T> BinaryHeap<T> {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_stable(feature = "const_binary_heap_constructor", since = "1.80.0")]
     #[must_use]
-    pub const fn new() -> BinaryHeap<T> {
+    pub const fn new() -> Self {
         BinaryHeap { data: vec![] }
     }
 
@@ -532,7 +532,7 @@ impl<T> BinaryHeap<T> {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[must_use]
-    pub fn with_capacity(capacity: usize) -> BinaryHeap<T> {
+    pub fn with_capacity(capacity: usize) -> Self {
         BinaryHeap { data: Vec::with_capacity(capacity) }
     }
 }
@@ -554,7 +554,7 @@ impl<T, A: Allocator> BinaryHeap<T, A> {
     /// ```
     #[unstable(feature = "allocator_api", issue = "32838")]
     #[must_use]
-    pub const fn new_in(alloc: A) -> BinaryHeap<T, A> {
+    pub const fn new_in(alloc: A) -> Self {
         BinaryHeap { data: Vec::new_in(alloc) }
     }
 
@@ -578,7 +578,7 @@ impl<T, A: Allocator> BinaryHeap<T, A> {
     /// ```
     #[unstable(feature = "allocator_api", issue = "32838")]
     #[must_use]
-    pub fn with_capacity_in(capacity: usize, alloc: A) -> BinaryHeap<T, A> {
+    pub fn with_capacity_in(capacity: usize, alloc: A) -> Self {
         BinaryHeap { data: Vec::with_capacity_in(capacity, alloc) }
     }
 
@@ -612,7 +612,7 @@ impl<T, A: Allocator> BinaryHeap<T, A> {
     /// ```
     #[unstable(feature = "binary_heap_from_raw_vec", issue = "152500")]
     #[must_use]
-    pub unsafe fn from_raw_vec(vec: Vec<T, A>) -> BinaryHeap<T, A> {
+    pub unsafe fn from_raw_vec(vec: Vec<T, A>) -> Self {
         BinaryHeap { data: vec }
     }
 }

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -648,7 +648,7 @@ impl<K, V> BTreeMap<K, V> {
     #[rustc_const_stable(feature = "const_btree_new", since = "1.66.0")]
     #[inline]
     #[must_use]
-    pub const fn new() -> BTreeMap<K, V> {
+    pub const fn new() -> Self {
         BTreeMap { root: None, length: 0, alloc: ManuallyDrop::new(Global), _marker: PhantomData }
     }
 }
@@ -694,7 +694,7 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     /// ```
     #[unstable(feature = "btreemap_alloc", issue = "32838")]
     #[must_use]
-    pub const fn new_in(alloc: A) -> BTreeMap<K, V, A> {
+    pub const fn new_in(alloc: A) -> Self {
         BTreeMap { root: None, length: 0, alloc: ManuallyDrop::new(alloc), _marker: PhantomData }
     }
 }

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -341,7 +341,7 @@ impl<T> BTreeSet<T> {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_stable(feature = "const_btree_new", since = "1.66.0")]
     #[must_use]
-    pub const fn new() -> BTreeSet<T> {
+    pub const fn new() -> Self {
         BTreeSet { map: BTreeMap::new() }
     }
 }
@@ -362,7 +362,7 @@ impl<T, A: Allocator + Clone> BTreeSet<T, A> {
     /// ```
     #[unstable(feature = "btreemap_alloc", issue = "32838")]
     #[must_use]
-    pub const fn new_in(alloc: A) -> BTreeSet<T, A> {
+    pub const fn new_in(alloc: A) -> Self {
         BTreeSet { map: BTreeMap::new_in(alloc) }
     }
 

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -778,7 +778,7 @@ impl<T> VecDeque<T> {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_stable(feature = "const_vec_deque_new", since = "1.68.0")]
     #[must_use]
-    pub const fn new() -> VecDeque<T> {
+    pub const fn new() -> Self {
         // FIXME(const-hack): This should just be `VecDeque::new_in(Global)` once that hits stable.
         VecDeque { head: 0, len: 0, buf: RawVec::new() }
     }
@@ -795,7 +795,7 @@ impl<T> VecDeque<T> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[must_use]
-    pub fn with_capacity(capacity: usize) -> VecDeque<T> {
+    pub fn with_capacity(capacity: usize) -> Self {
         Self::with_capacity_in(capacity, Global)
     }
 

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -3214,7 +3214,7 @@ impl<T> Weak<T> {
     #[stable(feature = "downgraded_weak", since = "1.10.0")]
     #[rustc_const_stable(feature = "const_weak_new", since = "1.73.0")]
     #[must_use]
-    pub const fn new() -> Weak<T> {
+    pub const fn new() -> Self {
         Weak { ptr: NonNull::without_provenance(NonZeroUsize::MAX), alloc: Global }
     }
 }

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -434,7 +434,7 @@ impl String {
     #[rustc_diagnostic_item = "string_new"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[must_use]
-    pub const fn new() -> String {
+    pub const fn new() -> Self {
         String { vec: Vec::new() }
     }
 
@@ -481,7 +481,7 @@ impl String {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[must_use]
-    pub fn with_capacity(capacity: usize) -> String {
+    pub fn with_capacity(capacity: usize) -> Self {
         String { vec: Vec::with_capacity(capacity) }
     }
 
@@ -681,7 +681,7 @@ impl String {
     #[must_use]
     #[cfg(not(no_global_oom_handling))]
     #[unstable(feature = "string_from_utf8_lossy_owned", issue = "129436")]
-    pub fn from_utf8_lossy_owned(v: Vec<u8>) -> String {
+    pub fn from_utf8_lossy_owned(v: Vec<u8>) -> Self {
         if let Cow::Owned(string) = String::from_utf8_lossy(&v) {
             string
         } else {
@@ -752,7 +752,7 @@ impl String {
     #[must_use]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn from_utf16_lossy(v: &[u16]) -> String {
+    pub fn from_utf16_lossy(v: &[u16]) -> Self {
         char::decode_utf16(v.iter().cloned())
             .map(|r| r.unwrap_or(char::REPLACEMENT_CHARACTER))
             .collect()
@@ -1010,7 +1010,7 @@ impl String {
     #[inline]
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub unsafe fn from_utf8_unchecked(bytes: Vec<u8>) -> String {
+    pub unsafe fn from_utf8_unchecked(bytes: Vec<u8>) -> Self {
         String { vec: bytes }
     }
 

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -2948,7 +2948,7 @@ impl<T> Weak<T> {
     #[stable(feature = "downgraded_weak", since = "1.10.0")]
     #[rustc_const_stable(feature = "const_weak_new", since = "1.73.0")]
     #[must_use]
-    pub const fn new() -> Weak<T> {
+    pub const fn new() -> Self {
         Weak { ptr: NonNull::without_provenance(NonZeroUsize::MAX), alloc: Global }
     }
 }

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -268,7 +268,7 @@ impl<K, V> HashMap<K, V, RandomState> {
     #[inline]
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn new() -> HashMap<K, V, RandomState> {
+    pub fn new() -> Self {
         Default::default()
     }
 
@@ -287,7 +287,7 @@ impl<K, V> HashMap<K, V, RandomState> {
     #[inline]
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn with_capacity(capacity: usize) -> HashMap<K, V, RandomState> {
+    pub fn with_capacity(capacity: usize) -> Self {
         HashMap::with_capacity_and_hasher(capacity, Default::default())
     }
 }
@@ -360,7 +360,7 @@ impl<K, V, S> HashMap<K, V, S> {
     #[must_use]
     #[stable(feature = "hashmap_build_hasher", since = "1.7.0")]
     #[rustc_const_stable(feature = "const_collections_with_hasher", since = "1.85.0")]
-    pub const fn with_hasher(hash_builder: S) -> HashMap<K, V, S> {
+    pub const fn with_hasher(hash_builder: S) -> Self {
         HashMap { base: base::HashMap::with_hasher(hash_builder) }
     }
 
@@ -392,7 +392,7 @@ impl<K, V, S> HashMap<K, V, S> {
     #[inline]
     #[must_use]
     #[stable(feature = "hashmap_build_hasher", since = "1.7.0")]
-    pub fn with_capacity_and_hasher(capacity: usize, hasher: S) -> HashMap<K, V, S> {
+    pub fn with_capacity_and_hasher(capacity: usize, hasher: S) -> Self {
         HashMap { base: base::HashMap::with_capacity_and_hasher(capacity, hasher) }
     }
 }

--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -146,7 +146,7 @@ impl<T> HashSet<T, RandomState> {
     #[inline]
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn new() -> HashSet<T, RandomState> {
+    pub fn new() -> Self {
         Default::default()
     }
 
@@ -166,7 +166,7 @@ impl<T> HashSet<T, RandomState> {
     #[inline]
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn with_capacity(capacity: usize) -> HashSet<T, RandomState> {
+    pub fn with_capacity(capacity: usize) -> Self {
         HashSet::with_capacity_and_hasher(capacity, Default::default())
     }
 }
@@ -179,7 +179,7 @@ impl<T, A: Allocator> HashSet<T, RandomState, A> {
     #[inline]
     #[must_use]
     #[unstable(feature = "allocator_api", issue = "32838")]
-    pub fn new_in(alloc: A) -> HashSet<T, RandomState, A> {
+    pub fn new_in(alloc: A) -> Self {
         HashSet::with_hasher_in(Default::default(), alloc)
     }
 
@@ -199,7 +199,7 @@ impl<T, A: Allocator> HashSet<T, RandomState, A> {
     #[inline]
     #[must_use]
     #[unstable(feature = "allocator_api", issue = "32838")]
-    pub fn with_capacity_in(capacity: usize, alloc: A) -> HashSet<T, RandomState, A> {
+    pub fn with_capacity_in(capacity: usize, alloc: A) -> Self {
         HashSet::with_capacity_and_hasher_in(capacity, Default::default(), alloc)
     }
 }
@@ -232,7 +232,7 @@ impl<T, S> HashSet<T, S> {
     #[must_use]
     #[stable(feature = "hashmap_build_hasher", since = "1.7.0")]
     #[rustc_const_stable(feature = "const_collections_with_hasher", since = "1.85.0")]
-    pub const fn with_hasher(hasher: S) -> HashSet<T, S> {
+    pub const fn with_hasher(hasher: S) -> Self {
         HashSet { base: base::HashSet::with_hasher(hasher) }
     }
 
@@ -264,7 +264,7 @@ impl<T, S> HashSet<T, S> {
     #[inline]
     #[must_use]
     #[stable(feature = "hashmap_build_hasher", since = "1.7.0")]
-    pub fn with_capacity_and_hasher(capacity: usize, hasher: S) -> HashSet<T, S> {
+    pub fn with_capacity_and_hasher(capacity: usize, hasher: S) -> Self {
         HashSet { base: base::HashSet::with_capacity_and_hasher(capacity, hasher) }
     }
 }
@@ -285,7 +285,7 @@ impl<T, S, A: Allocator> HashSet<T, S, A> {
     #[inline]
     #[must_use]
     #[unstable(feature = "allocator_api", issue = "32838")]
-    pub fn with_hasher_in(hasher: S, alloc: A) -> HashSet<T, S, A> {
+    pub fn with_hasher_in(hasher: S, alloc: A) -> Self {
         HashSet { base: base::HashSet::with_hasher_in(hasher, alloc) }
     }
 
@@ -306,7 +306,7 @@ impl<T, S, A: Allocator> HashSet<T, S, A> {
     #[inline]
     #[must_use]
     #[unstable(feature = "allocator_api", issue = "32838")]
-    pub fn with_capacity_and_hasher_in(capacity: usize, hasher: S, alloc: A) -> HashSet<T, S, A> {
+    pub fn with_capacity_and_hasher_in(capacity: usize, hasher: S, alloc: A) -> Self {
         HashSet { base: base::HashSet::with_capacity_and_hasher_in(capacity, hasher, alloc) }
     }
 

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -138,7 +138,7 @@ impl OsString {
     #[must_use]
     #[inline]
     #[rustc_const_stable(feature = "const_pathbuf_osstring_new", since = "1.91.0")]
-    pub const fn new() -> OsString {
+    pub const fn new() -> Self {
         OsString { inner: Buf::from_string(String::new()) }
     }
 
@@ -309,7 +309,7 @@ impl OsString {
     #[stable(feature = "osstring_simple_functions", since = "1.9.0")]
     #[must_use]
     #[inline]
-    pub fn with_capacity(capacity: usize) -> OsString {
+    pub fn with_capacity(capacity: usize) -> Self {
         OsString { inner: Buf::with_capacity(capacity) }
     }
 

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -3395,7 +3395,7 @@ impl DirBuilder {
     /// ```
     #[stable(feature = "dir_builder", since = "1.6.0")]
     #[must_use]
-    pub fn new() -> DirBuilder {
+    pub fn new() -> Self {
         DirBuilder { inner: fs_imp::DirBuilder::new(), recursive: false }
     }
 

--- a/library/std/src/hash/random.rs
+++ b/library/std/src/hash/random.rs
@@ -52,7 +52,7 @@ impl RandomState {
     // rand
     #[must_use]
     #[stable(feature = "hashmap_build_hasher", since = "1.7.0")]
-    pub fn new() -> RandomState {
+    pub fn new() -> Self {
         // Historically this function did not cache keys from the OS and instead
         // simply always called `rand::thread_rng().gen()` twice. In #31356 it
         // was discovered, however, that because we re-seed the thread-local RNG
@@ -103,7 +103,7 @@ impl DefaultHasher {
     #[inline]
     #[rustc_const_unstable(feature = "const_default", issue = "143894")]
     #[must_use]
-    pub const fn new() -> DefaultHasher {
+    pub const fn new() -> Self {
         DefaultHasher(SipHasher13::new_with_keys(0, 0))
     }
 }

--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -652,7 +652,7 @@ impl Error {
     #[doc(alias = "errno")]
     #[must_use]
     #[inline]
-    pub fn last_os_error() -> Error {
+    pub fn last_os_error() -> Self {
         Error::from_raw_os_error(sys::io::errno())
     }
 
@@ -684,7 +684,7 @@ impl Error {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[must_use]
     #[inline]
-    pub fn from_raw_os_error(code: RawOsError) -> Error {
+    pub fn from_raw_os_error(code: RawOsError) -> Self {
         Error { repr: Repr::new_os(code) }
     }
 

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -1538,7 +1538,7 @@ impl<'a> IoSlice<'a> {
     #[stable(feature = "iovec", since = "1.36.0")]
     #[must_use]
     #[inline]
-    pub fn new(buf: &'a [u8]) -> IoSlice<'a> {
+    pub fn new(buf: &'a [u8]) -> Self {
         IoSlice(sys::io::IoSlice::new(buf))
     }
 

--- a/library/std/src/os/unix/net/ancillary.rs
+++ b/library/std/src/os/unix/net/ancillary.rs
@@ -227,7 +227,7 @@ impl SocketCred {
     /// PID, UID and GID is set to 0.
     #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
     #[must_use]
-    pub fn new() -> SocketCred {
+    pub fn new() -> Self {
         SocketCred(libc::ucred { pid: 0, uid: 0, gid: 0 })
     }
 
@@ -278,7 +278,7 @@ impl SocketCred {
     /// PID, UID and GID is set to 0.
     #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
     #[must_use]
-    pub fn new() -> SocketCred {
+    pub fn new() -> Self {
         SocketCred(libc::sockcred2 {
             sc_version: 0,
             sc_pid: 0,

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -1229,7 +1229,7 @@ impl PathBuf {
     #[must_use]
     #[inline]
     #[rustc_const_stable(feature = "const_pathbuf_osstring_new", since = "1.91.0")]
-    pub const fn new() -> PathBuf {
+    pub const fn new() -> Self {
         PathBuf { inner: OsString::new() }
     }
 
@@ -1254,7 +1254,7 @@ impl PathBuf {
     #[stable(feature = "path_buf_capacity", since = "1.44.0")]
     #[must_use]
     #[inline]
-    pub fn with_capacity(capacity: usize) -> PathBuf {
+    pub fn with_capacity(capacity: usize) -> Self {
         PathBuf { inner: OsString::with_capacity(capacity) }
     }
 

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1478,7 +1478,7 @@ impl Stdio {
     ///
     #[must_use]
     #[stable(feature = "process", since = "1.0.0")]
-    pub fn piped() -> Stdio {
+    pub fn piped() -> Self {
         Stdio(imp::Stdio::MakePipe)
     }
 
@@ -1518,7 +1518,7 @@ impl Stdio {
     /// ```
     #[must_use]
     #[stable(feature = "process", since = "1.0.0")]
-    pub fn inherit() -> Stdio {
+    pub fn inherit() -> Self {
         Stdio(imp::Stdio::Inherit)
     }
 
@@ -1558,7 +1558,7 @@ impl Stdio {
     /// ```
     #[must_use]
     #[stable(feature = "process", since = "1.0.0")]
-    pub fn null() -> Stdio {
+    pub fn null() -> Self {
         Stdio(imp::Stdio::Null)
     }
 

--- a/library/std/src/sync/barrier.rs
+++ b/library/std/src/sync/barrier.rs
@@ -81,7 +81,7 @@ impl Barrier {
     #[rustc_const_stable(feature = "const_barrier", since = "1.78.0")]
     #[must_use]
     #[inline]
-    pub const fn new(n: usize) -> Barrier {
+    pub const fn new(n: usize) -> Self {
         Barrier {
             lock: Mutex::new(BarrierState { count: 0, generation_id: 0 }),
             cvar: Condvar::new(),

--- a/library/std/src/sync/nonpoison/condvar.rs
+++ b/library/std/src/sync/nonpoison/condvar.rs
@@ -64,7 +64,7 @@ impl Condvar {
     #[unstable(feature = "nonpoison_condvar", issue = "134645")]
     #[must_use]
     #[inline]
-    pub const fn new() -> Condvar {
+    pub const fn new() -> Self {
         Condvar { inner: sys::Condvar::new() }
     }
 

--- a/library/std/src/sync/once.rs
+++ b/library/std/src/sync/once.rs
@@ -80,7 +80,7 @@ impl Once {
     #[stable(feature = "once_new", since = "1.2.0")]
     #[rustc_const_stable(feature = "const_once_new", since = "1.32.0")]
     #[must_use]
-    pub const fn new() -> Once {
+    pub const fn new() -> Self {
         Once { inner: sys::Once::new() }
     }
 

--- a/library/std/src/sync/once_lock.rs
+++ b/library/std/src/sync/once_lock.rs
@@ -137,7 +137,7 @@ impl<T> OnceLock<T> {
     #[must_use]
     #[stable(feature = "once_cell", since = "1.70.0")]
     #[rustc_const_stable(feature = "once_cell", since = "1.70.0")]
-    pub const fn new() -> OnceLock<T> {
+    pub const fn new() -> Self {
         OnceLock {
             once: Once::new(),
             value: UnsafeCell::new(MaybeUninit::uninit()),

--- a/library/std/src/sync/poison/condvar.rs
+++ b/library/std/src/sync/poison/condvar.rs
@@ -61,7 +61,7 @@ impl Condvar {
     #[rustc_const_stable(feature = "const_locks", since = "1.63.0")]
     #[must_use]
     #[inline]
-    pub const fn new() -> Condvar {
+    pub const fn new() -> Self {
         Condvar { inner: sys::Condvar::new() }
     }
 

--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -284,7 +284,7 @@ impl Instant {
     #[must_use]
     #[stable(feature = "time2", since = "1.8.0")]
     #[cfg_attr(not(test), rustc_diagnostic_item = "instant_now")]
-    pub fn now() -> Instant {
+    pub fn now() -> Self {
         Instant(time::Instant::now())
     }
 
@@ -598,7 +598,7 @@ impl SystemTime {
     /// ```
     #[must_use]
     #[stable(feature = "time2", since = "1.8.0")]
-    pub fn now() -> SystemTime {
+    pub fn now() -> Self {
         SystemTime(time::SystemTime::now())
     }
 


### PR DESCRIPTION
Fix some instances of [`clippy::use_self`](https://rust-lang.github.io/rust-clippy/master/index.html#use_self)