### PR TITLE
Fallback to fat LTO for -Clto=thin in cg_gcc

### DIFF
--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -539,5 +539,5 @@ pub(crate) struct UnexpectedBuiltinCfg {
 }
 
 #[derive(Diagnostic)]
-#[diag("ThinLTO is not supported by the codegen backend")]
+#[diag("ThinLTO is not supported by the codegen backend, using fat LTO instead")]
 pub(crate) struct ThinLtoNotSupportedByBackend;

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -620,9 +620,9 @@ impl Session {
             config::LtoCli::Thin => {
                 // The user explicitly asked for ThinLTO
                 if !self.thin_lto_supported {
-                    // Backend doesn't support ThinLTO, disable LTO.
+                    // Backend doesn't support ThinLTO, fallback to fat LTO.
                     self.dcx().emit_warn(errors::ThinLtoNotSupportedByBackend);
-                    return config::Lto::No;
+                    return config::Lto::Fat;
                 }
                 return config::Lto::Thin;
             }


### PR DESCRIPTION
Fallback to no LTO doesn't work in practice as Cargo asks rustc to produce LTO-only rlibs with -Clinker-plugin-lto without providing any indication if they will be used for thin or fat LTO, so we can't disable -Clinker-plugin-lto for ThinLTO when using cg_gcc.

r? @antoyo