### PR TITLE
`std::any::TypeId`: remove misplaced "and" in `Unique<T>` example

### DIFF
--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -666,7 +666,7 @@ impl dyn Any + Send + Sync {
 ///
 /// The following is an example program that tries to use `TypeId::of` to
 /// implement a generic type `Unique<T>` that guarantees unique instances for each `Unique<T>`,
-/// that is, and for each type `T` there can be at most one value of type `Unique<T>` at any time.
+/// that is, for each type `T` there can be at most one value of type `Unique<T>` at any time.
 ///
 /// ```
 /// mod unique {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->

@rustbot label +A-docs
<!-- homu-ignore:end -->
