### PR TITLE
fix: Check associated type bounds from supertraits for trait object well-formedness

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
@@ -854,6 +854,12 @@ where
 {
     let cx = ecx.cx();
     let mut requirements = vec![];
+    // We use `explicit_implied_predicates_of` instead of `explicit_super_predicates_of`
+    // to also include associated type bounds from supertrait constraints.
+    // For example, `trait Sub: Super<Assoc: Copy>` expands to both `Self: Super` and
+    // `<Self as Super>::Assoc: Copy`. Both need to be checked for the trait object
+    // to be well-formed.
+    //
     // Elaborating all supertrait outlives obligations here is not soundness critical,
     // since if we just used the unelaborated set, then the transitive supertraits would
     // be reachable when proving the former. However, since we elaborate all supertrait
@@ -863,7 +869,7 @@ where
     // make impls coinductive always, since they'll always need to prove their supertraits.
     requirements.extend(elaborate::elaborate(
         cx,
-        cx.explicit_super_predicates_of(trait_ref.def_id)
+        cx.explicit_implied_predicates_of(trait_ref.def_id.into())
             .iter_instantiated(cx, trait_ref.args)
             .map(|(pred, _)| pred),
     ));

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -537,10 +537,12 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 .map_err(|_| SelectionError::Unimplemented)?,
         );
 
-        // Check supertraits hold. This is so that their associated type bounds
-        // will be checked in the code below.
+        // Check supertraits hold, including their associated type bounds.
+        // For example, `trait Sub: Super<Assoc: Copy>` expands to both
+        // `Self: Super` and `<Self as Super>::Assoc: Copy`. We need to check
+        // both for the trait object to be well-formed.
         for (supertrait, _) in tcx
-            .explicit_super_predicates_of(trait_predicate.def_id())
+            .explicit_implied_predicates_of(trait_predicate.def_id())
             .iter_instantiated_copied(tcx, trait_predicate.trait_ref.args)
         {
             let normalized_supertrait = normalize_with_depth_to(

--- a/tests/ui/traits/object/supertrait-assoc-type-bounds-pass.rs
+++ b/tests/ui/traits/object/supertrait-assoc-type-bounds-pass.rs
@@ -1,0 +1,20 @@
+//@ check-pass
+// Regression test for #152607
+// Tests that associated type bounds from supertraits are properly checked
+// when forming trait objects, and that valid cases compile successfully.
+
+trait Super {
+    type Assoc;
+}
+
+trait Sub: Super<Assoc: Copy> {}
+
+fn checked_copy<T: Sub<Assoc = i32> + ?Sized>(x: &i32) -> i32 {
+    *x
+}
+
+fn main() {
+    let x: i32 = 42;
+    // This should work because i32: Copy
+    let _y: i32 = checked_copy::<dyn Sub<Assoc = i32>>(&x);
+}

--- a/tests/ui/traits/object/supertrait-assoc-type-bounds.rs
+++ b/tests/ui/traits/object/supertrait-assoc-type-bounds.rs
@@ -1,0 +1,19 @@
+// Regression test for #152607
+// Tests that associated type bounds from supertraits are checked
+// when forming trait objects.
+
+trait Super {
+    type Assoc;
+}
+
+trait Sub: Super<Assoc: Copy> {}
+
+fn unchecked_copy<T: Sub<Assoc = String> + ?Sized>(x: &String) -> String {
+    *x
+}
+
+fn main() {
+    let x: String = String::from("abc");
+    let _y: String = unchecked_copy::<dyn Sub<Assoc = String>>(&x);
+    //~^ ERROR the trait bound `String: Copy` is not satisfied
+}

--- a/tests/ui/traits/object/supertrait-assoc-type-bounds.stderr
+++ b/tests/ui/traits/object/supertrait-assoc-type-bounds.stderr
@@ -1,0 +1,15 @@
+error[E0277]: the trait bound `String: Copy` is not satisfied
+  --> $DIR/supertrait-assoc-type-bounds.rs:17:39
+   |
+LL |     let _y: String = unchecked_copy::<dyn Sub<Assoc = String>>(&x);
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `String`
+   |
+note: required by a bound in `unchecked_copy`
+  --> $DIR/supertrait-assoc-type-bounds.rs:11:22
+   |
+LL | fn unchecked_copy<T: Sub<Assoc = String> + ?Sized>(x: &String) -> String {
+   |                      ^^^^^^^^^^^^^^^^^^^ required by this bound in `unchecked_copy`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
## Summary

Fixes rust-lang/rust#152607

When forming a trait object like `dyn Sub<Assoc = String>` where `trait Sub: Super<Assoc: Copy>`, the compiler was not verifying that `String: Copy`. This allowed unsound code to compile, potentially leading to use-after-free vulnerabilities.

## Root Cause

Both the old and new trait solvers used `explicit_super_predicates_of` which only yields `Self: SuperTrait` predicates (e.g., `Self: Super`), but not the associated type bounds from those supertraits (e.g., `<Self as Super>::Assoc: Copy`).

## The Fix

Changed both solvers to use `explicit_implied_predicates_of` instead, which yields both supertrait predicates AND their associated type bounds:

- **Old solver** (`compiler/rustc_trait_selection/src/traits/select/confirmation.rs`)
- **New solver** (`compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs`)

## Test Plan

- [x] Added regression test `tests/ui/traits/object/supertrait-assoc-type-bounds.rs` that now correctly fails with "the trait bound `String: Copy` is not satisfied"
- [x] Added positive test `tests/ui/traits/object/supertrait-assoc-type-bounds-pass.rs` confirming valid cases still compile
- [x] All trait object tests pass
- [x] All associated type bounds tests pass