### PR TITLE
.mailmap: fix broken line with multiple emails

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -83,7 +83,8 @@ Ben Sago <ogham@users.noreply.github.com> <ogham@bsago.me>
 Ben Striegel <ben.striegel@gmail.com>
 Benjamin Jackman <ben@jackman.biz>
 Benoît Cortier <benoit.cortier@fried-world.eu>
-binarycat <binarycat@envs.net> lolbinarycat <dogedoge61+github@gmail.com> <dogedoge61@gmail.com>
+binarycat <binarycat@envs.net> lolbinarycat <dogedoge61+github@gmail.com>
+binarycat <binarycat@envs.net> lolbinarycat <dogedoge61@gmail.com>
 Bheesham Persaud <bheesham123@hotmail.com> Bheesham Persaud <bheesham.persaud@live.ca>
 bjorn3 <17426603+bjorn3@users.noreply.github.com> <bjorn3@users.noreply.github.com>
 bjorn3 <17426603+bjorn3@users.noreply.github.com> <bjorn3_gh@protonmail.com>


### PR DESCRIPTION
Split binarycat's entry into multiple lines, one for each extra email

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->

Follow-up to rust-lang/rust#149739, CC @lolbinarycat @Kivooeo
<!-- homu-ignore:end -->
