### PR TITLE
Don't use incremental disk-cache for query `predicates_of`

### DIFF
--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -455,7 +455,6 @@ rustc_queries! {
     /// the result of this query for use in UI tests or for debugging purposes.
     query predicates_of(key: DefId) -> ty::GenericPredicates<'tcx> {
         desc { "computing predicates of `{}`", tcx.def_path_str(key) }
-        cache_on_disk_if { key.is_local() }
     }
 
     query opaque_types_defined_by(


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/153521)*
<!-- homu-ignore:end -->

The `predicates_of` query is a relatively modest wrapper around a few underlying queries that are themselves cached to disk. Removing the additional layer of disk caching appears to be a significant perf win.

This query also appears to be the only query that uses a crate-local `cache_on_disk_if` condition, without also using the `separate_provide_extern` modifier.

- Discovered via https://github.com/rust-lang/rust/pull/153487#discussion_r2895304051
