### PR TITLE
Remove a flaky `got_timeout` assert from two channel tests

### DIFF
--- a/library/std/tests/sync/mpmc.rs
+++ b/library/std/tests/sync/mpmc.rs
@@ -475,7 +475,6 @@ fn stress_recv_timeout_two_threads() {
     });
 
     let mut recv_count = 0;
-    let mut got_timeout = false;
     loop {
         match rx.recv_timeout(timeout) {
             Ok(n) => {
@@ -483,7 +482,6 @@ fn stress_recv_timeout_two_threads() {
                 recv_count += 1;
             }
             Err(RecvTimeoutError::Timeout) => {
-                got_timeout = true;
                 continue;
             }
             Err(RecvTimeoutError::Disconnected) => break,
@@ -491,7 +489,6 @@ fn stress_recv_timeout_two_threads() {
     }
 
     assert_eq!(recv_count, stress);
-    assert!(got_timeout);
 }
 
 #[test]

--- a/library/std/tests/sync/mpsc.rs
+++ b/library/std/tests/sync/mpsc.rs
@@ -438,7 +438,6 @@ fn stress_recv_timeout_two_threads() {
     });
 
     let mut recv_count = 0;
-    let mut got_timeout = false;
     loop {
         match rx.recv_timeout(timeout) {
             Ok(n) => {
@@ -446,7 +445,6 @@ fn stress_recv_timeout_two_threads() {
                 recv_count += 1;
             }
             Err(RecvTimeoutError::Timeout) => {
-                got_timeout = true;
                 continue;
             }
             Err(RecvTimeoutError::Disconnected) => break,
@@ -454,7 +452,6 @@ fn stress_recv_timeout_two_threads() {
     }
 
     assert_eq!(recv_count, stress);
-    assert!(got_timeout);
 }
 
 #[test]


### PR DESCRIPTION
In CI, the receiver thread can be descheduled for a surprisingly long time, so there's no guarantee that a timeout actually occurs.

One of these tests actually failed in https://github.com/rust-lang/rust/pull/153387#issuecomment-4016078983.

Earlier failures:
- https://github.com/rust-lang/rust/pull/150365#issuecomment-3691457455
- https://github.com/rust-lang/rust/pull/147775#issuecomment-3410454391

---

- Prior art: https://github.com/rust-lang/rust/pull/152878