### PR TITLE
rustc_codegen_ssa: Define ELF flag value for sparc-unknown-linux-gnu

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -401,6 +401,7 @@ pub(super) fn elf_e_flags(architecture: Architecture, sess: &Session) -> u32 {
                 _ => EF_PPC64_ABI_UNKNOWN,
             }
         }
+        Architecture::Sparc32Plus => elf::EF_SPARC_32PLUS,
         _ => 0,
     }
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Currently, attempting to build this target using Ubuntu/Debian's sparc64-multilib toolchain results in the following link error ([full log](https://github.com/taiki-e/atomic-maybe-uninit/actions/runs/22798868888/job/66137493862#step:15:442)):

```
  = note: /usr/lib/gcc-cross/sparc64-linux-gnu/13/../../../../sparc64-linux-gnu/bin/ld: unknown architecture of input file `/home/runner/work/atomic-maybe-uninit/atomic-maybe-uninit/target/sparc-unknown-linux-gnu/debug/deps/rustcYzaDYW/symbols.o' is incompatible with sparc:v8plus output
```

This appears to be caused by the required e_flag being missing and can be fixed by setting `EF_SPARC_32PLUS`.

Tested using rustc with this patch applied and qemu-user (https://github.com/taiki-e/atomic-maybe-uninit/commit/57d7e7f9905cb5f7bc1254e5527af27b42c99c6a, [log](https://github.com/taiki-e/atomic-maybe-uninit/actions/runs/22798793270/job/66137298093)). 

Related discussion: https://github.com/rust-lang/rust/pull/131222#issuecomment-2393473488

r? workingjubilee
cc @glaubitz

@rustbot label +O-SPARC