### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -840,11 +840,8 @@ extern "C" LLVMRustResult LLVMRustOptimize(
         }
         break;
       case LLVMRustOptStage::PreLinkThinLTO:
-        MPM = PB.buildThinLTOPreLinkDefaultPipeline(OptLevel);
-        NeedThinLTOBufferPasses = false;
-        break;
       case LLVMRustOptStage::PreLinkFatLTO:
-        MPM = PB.buildLTOPreLinkDefaultPipeline(OptLevel);
+        MPM = PB.buildThinLTOPreLinkDefaultPipeline(OptLevel);
         NeedThinLTOBufferPasses = false;
         break;
       case LLVMRustOptStage::ThinLTO:

--- a/library/test/build.rs
+++ b/library/test/build.rs
@@ -2,16 +2,11 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rustc-check-cfg=cfg(enable_unstable_features)");
 
-    // Miri testing uses unstable features, so always enable that for its sysroot.
-    // Otherwise, only enable unstable if rustc looks like a nightly or dev build.
-    let enable_unstable_features = std::env::var("MIRI_CALLED_FROM_SETUP").is_ok() || {
-        let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".into());
-        let version = std::process::Command::new(rustc).arg("-vV").output().unwrap();
-        let stdout = String::from_utf8(version.stdout).unwrap();
-        stdout.contains("nightly") || stdout.contains("dev")
-    };
+    let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".into());
+    let version = std::process::Command::new(rustc).arg("-vV").output().unwrap();
+    let stdout = String::from_utf8(version.stdout).unwrap();
 
-    if enable_unstable_features {
+    if stdout.contains("nightly") || stdout.contains("dev") {
         println!("cargo:rustc-cfg=enable_unstable_features");
     }
 }

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -741,7 +741,13 @@ impl Step for Miri {
 
         // Run it again for mir-opt-level 4 to catch some miscompilations.
         if builder.config.test_args().is_empty() {
-            cargo.env("MIRIFLAGS", "-O -Zmir-opt-level=4 -Cdebug-assertions=yes");
+            cargo.env(
+                "MIRIFLAGS",
+                format!(
+                    "{} -O -Zmir-opt-level=4 -Cdebug-assertions=yes",
+                    env::var("MIRIFLAGS").unwrap_or_default()
+                ),
+            );
             // Optimizations can change backtraces
             cargo.env("MIRI_SKIP_UI_CHECKS", "1");
             // `MIRI_SKIP_UI_CHECKS` and `RUSTC_BLESS` are incompatible
@@ -3108,6 +3114,17 @@ impl Step for Crate {
             // does not set this directly, but relies on the rustc wrapper to set it, and we are not using
             // the wrapper -- hence we have to set it ourselves.
             cargo.rustflag("-Zforce-unstable-if-unmarked");
+            // Miri is told to invoke the libtest runner and bootstrap sets unstable flags
+            // for that runner. That only works when RUSTC_BOOTSTRAP is set. Bootstrap sets
+            // that flag but Miri by default does not forward the host environment to the test.
+            // Here we set up MIRIFLAGS to forward that env var.
+            cargo.env(
+                "MIRIFLAGS",
+                format!(
+                    "{} -Zmiri-env-forward=RUSTC_BOOTSTRAP",
+                    env::var("MIRIFLAGS").unwrap_or_default()
+                ),
+            );
             cargo
         } else {
             // Also prepare a sysroot for the target.

--- a/tests/ui/proc-macro/identity-closure-preserving.rs
+++ b/tests/ui/proc-macro/identity-closure-preserving.rs
@@ -1,0 +1,22 @@
+//! Make sure that the closure still gets the correct precedence when round-tripping
+//! through a proc macro.
+//! The correct precendence is `(|| ()) as fn()`, even though these parentheses are not
+//! directly part of the code.
+//! If it would get lost, the code would be `|| () as fn()`, get parsed as
+//! `|| (() as fn())` and fail to compile.
+//! Notably, this will also fail to compile if we use `recollect` instead of `identity`.
+//! Regression test for https://github.com/rust-lang/rust/pull/151830#issuecomment-4010899019.
+//@ proc-macro: test-macros.rs
+//@ check-pass
+
+macro_rules! operator_impl {
+    ($target_expr:expr) => {
+        test_macros::identity! {
+            $target_expr as fn()
+        };
+    };
+}
+
+fn main() {
+    operator_impl!(|| ());
+}

--- a/tests/ui/runtime/backtrace-debuginfo.rs
+++ b/tests/ui/runtime/backtrace-debuginfo.rs
@@ -47,14 +47,9 @@ macro_rules! dump_and_die {
         // there, even on i686-pc-windows-msvc. We do the best we can in
         // rust-lang/rust to test it as well, but sometimes we just gotta keep
         // landing PRs.
-        //
-        // aarch64-msvc/arm64ec-msvc is broken as its backtraces are truncated.
-        // See https://github.com/rust-lang/rust/issues/140489
         if cfg!(any(target_os = "android",
                     all(target_os = "linux", target_arch = "arm"),
                     all(target_env = "msvc", target_arch = "x86"),
-                    all(target_env = "msvc", target_arch = "aarch64"),
-                    all(target_env = "msvc", target_arch = "arm64ec"),
                     target_os = "freebsd",
                     target_os = "dragonfly",
                     target_os = "openbsd")) {


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#153202 ([win] Fix truncated unwinds for Arm64 Windows)
 - rust-lang/rust#153437 (coretest in miri: fix using unstable libtest features)
 - rust-lang/rust#153446 (Always use the ThinLTO pipeline for pre-link optimizations)
 - rust-lang/rust#153548 (add test for closure precedence in `TokenStream`s)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=153202,153437,153446,153548)
<!-- homu-ignore:end -->

