### PR TITLE
Replace the `try_mark_green` hook with direct calls to `tcx.dep_graph`

### DIFF
--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -1118,7 +1118,7 @@ pub fn determine_cgu_reuse<'tcx>(tcx: TyCtxt<'tcx>, cgu: &CodegenUnit<'tcx>) -> 
         )
     });
 
-    if tcx.try_mark_green(&dep_node) {
+    if tcx.dep_graph.try_mark_green(tcx, &dep_node).is_some() {
         // We can re-use either the pre- or the post-thinlto state. If no LTO is
         // being performed then we can use post-LTO artifacts, otherwise we must
         // reuse pre-LTO artifacts

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -2443,7 +2443,7 @@ pub fn encode_metadata(tcx: TyCtxt<'_>, path: &Path, ref_path: Option<&Path>) {
     if tcx.dep_graph.is_fully_enabled()
         && let work_product_id = WorkProductId::from_cgu_name("metadata")
         && let Some(work_product) = tcx.dep_graph.previous_work_product(&work_product_id)
-        && tcx.try_mark_green(&dep_node)
+        && tcx.dep_graph.try_mark_green(tcx, &dep_node).is_some()
     {
         let saved_path = &work_product.saved_files["rmeta"];
         let incr_comp_session_dir = tcx.sess.incr_comp_session_dir_opt().unwrap();

--- a/compiler/rustc_middle/src/dep_graph/graph.rs
+++ b/compiler/rustc_middle/src/dep_graph/graph.rs
@@ -881,7 +881,7 @@ impl DepGraph {
         tcx: TyCtxt<'tcx>,
         dep_node: &DepNode,
     ) -> Option<(SerializedDepNodeIndex, DepNodeIndex)> {
-        self.data().and_then(|data| data.try_mark_green(tcx, dep_node))
+        self.data()?.try_mark_green(tcx, dep_node)
     }
 }
 

--- a/compiler/rustc_middle/src/hooks/mod.rs
+++ b/compiler/rustc_middle/src/hooks/mod.rs
@@ -109,8 +109,6 @@ declare_hooks! {
     /// Creates the MIR for a given `DefId`, including unreachable code.
     hook build_mir_inner_impl(def: LocalDefId) -> mir::Body<'tcx>;
 
-    hook try_mark_green(dep_node: &crate::dep_graph::DepNode) -> bool;
-
     hook encode_all_query_results(
         encoder: &mut CacheEncoder<'_, 'tcx>,
         query_result_index: &mut EncodedDepNodeIndex

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -628,8 +628,7 @@ fn check_if_ensure_can_skip_execution<'tcx, C: QueryCache>(
 
     let dep_node = DepNode::construct(tcx, query.dep_kind, key);
 
-    let dep_graph = &tcx.dep_graph;
-    let serialized_dep_node_index = match dep_graph.try_mark_green(tcx, &dep_node) {
+    let serialized_dep_node_index = match tcx.dep_graph.try_mark_green(tcx, &dep_node) {
         None => {
             // A None return from `try_mark_green` means that this is either
             // a new dep node or that the dep node has already been marked red.
@@ -640,7 +639,7 @@ fn check_if_ensure_can_skip_execution<'tcx, C: QueryCache>(
             return EnsureCanSkip { skip_execution: false, dep_node: Some(dep_node) };
         }
         Some((serialized_dep_node_index, dep_node_index)) => {
-            dep_graph.read_index(dep_node_index);
+            tcx.dep_graph.read_index(dep_node_index);
             tcx.prof.query_cache_hit(dep_node_index.into());
             serialized_dep_node_index
         }

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -20,7 +20,6 @@ use rustc_span::Span;
 pub use crate::dep_kind_vtables::make_dep_kind_vtables;
 use crate::from_cycle_error::FromCycleError;
 pub use crate::job::{QueryJobMap, break_query_cycles, print_query_stack};
-use crate::plumbing::try_mark_green;
 use crate::profiling_support::QueryKeyStringCache;
 
 #[macro_use]
@@ -69,5 +68,4 @@ pub fn provide(providers: &mut rustc_middle::util::Providers) {
     providers.hooks.alloc_self_profile_query_strings = alloc_self_profile_query_strings;
     providers.hooks.query_key_hash_verify_all = query_key_hash_verify_all;
     providers.hooks.encode_all_query_results = encode_all_query_results;
-    providers.hooks.try_mark_green = try_mark_green;
 }

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -90,10 +90,6 @@ pub(crate) fn start_query<R>(
     })
 }
 
-pub(super) fn try_mark_green<'tcx>(tcx: TyCtxt<'tcx>, dep_node: &DepNode) -> bool {
-    tcx.dep_graph.try_mark_green(tcx, dep_node).is_some()
-}
-
 /// The deferred part of a deferred query stack frame.
 fn mk_query_stack_frame_extra<'tcx, Cache>(
     (tcx, vtable, key): (TyCtxt<'tcx>, &'tcx QueryVTable<'tcx, Cache>, Cache::Key),


### PR DESCRIPTION
All of the existing call sites are directly touching `tcx.dep_graph` anyway, so the extra layer of indirection provides no real benefit.

There should be no change to compiler behaviour.

r? nnethercote (or compiler)