### PR TITLE
Lint against iterator functions that panic when `N` is zero 

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -7,6 +7,7 @@ use rustc_hir::attrs::{
     BorrowckGraphvizFormatKind, CguFields, CguKind, DivergingBlockBehavior,
     DivergingFallbackBehavior, RustcCleanAttribute, RustcCleanQueries, RustcMirKind,
 };
+use rustc_hir::target::GenericParamKind;
 use rustc_span::Symbol;
 
 use super::prelude::*;
@@ -90,6 +91,20 @@ impl NoArgsAttributeParser for RustcNeverReturnsNullPtrParser {
 
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcNeverReturnsNullPtr;
 }
+
+pub(crate) struct RustcPanicsWhenZeroParser;
+
+impl NoArgsAttributeParser for RustcPanicsWhenZeroParser {
+    const PATH: &[Symbol] = &[sym::rustc_panics_when_zero];
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[
+        Allow(Target::GenericParam { kind: GenericParamKind::Const, has_default: true }),
+        Allow(Target::GenericParam { kind: GenericParamKind::Const, has_default: false }),
+    ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
+
+    const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcPanicsWhenZero;
+}
+
 pub(crate) struct RustcNoImplicitAutorefsParser;
 
 impl NoArgsAttributeParser for RustcNoImplicitAutorefsParser {

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -340,6 +340,7 @@ attribute_parsers!(
         Single<WithoutArgs<RustcNonnullOptimizationGuaranteedParser>>,
         Single<WithoutArgs<RustcNounwindParser>>,
         Single<WithoutArgs<RustcOffloadKernelParser>>,
+        Single<WithoutArgs<RustcPanicsWhenZeroParser>>,
         Single<WithoutArgs<RustcParenSugarParser>>,
         Single<WithoutArgs<RustcPassByValueParser>>,
         Single<WithoutArgs<RustcPassIndirectlyInNonRusticAbisParser>>,

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -353,6 +353,7 @@ pub static BUILTIN_ATTRIBUTES: &[Symbol] = &[
     sym::rustc_dyn_incompatible_trait,
     sym::rustc_has_incoherent_inherent_impls,
     sym::rustc_non_const_trait_method,
+    sym::rustc_panics_when_zero,
 
     sym::rustc_canonical_symbol,
     sym::rustc_diagnostic_item,

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -1588,6 +1588,9 @@ pub enum AttributeKind {
     /// Represents `#[rustc_offload_kernel]`
     RustcOffloadKernel,
 
+    /// Represents `#[rustc_panics_when_zero]` (used for linting).
+    RustcPanicsWhenZero,
+
     /// Represents `#[rustc_paren_sugar]`.
     RustcParenSugar,
 

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -175,6 +175,7 @@ impl AttributeKind {
             RustcObjcClass { .. } => No,
             RustcObjcSelector { .. } => No,
             RustcOffloadKernel => Yes,
+            RustcPanicsWhenZero => Yes,
             RustcParenSugar => No,
             RustcPassByValue => Yes,
             RustcPassIndirectlyInNonRusticAbis(..) => No,

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -948,6 +948,7 @@ fn should_encode_attrs(def_kind: DefKind) -> bool {
         | DefKind::AssocConst { .. }
         | DefKind::Macro(_)
         | DefKind::Field
+        | DefKind::ConstParam
         | DefKind::Impl { .. } => true,
         // Encoding attrs for `Use` items allows `#[doc(hidden)]` on re-exports
         // to be read cross-crate, which is needed for diagnostic path selection
@@ -960,7 +961,6 @@ fn should_encode_attrs(def_kind: DefKind) -> bool {
         DefKind::Closure => true,
         DefKind::SyntheticCoroutineBody => false,
         DefKind::TyParam
-        | DefKind::ConstParam
         | DefKind::Ctor(..)
         | DefKind::ExternCrate
         | DefKind::ForeignMod

--- a/compiler/rustc_mir_transform/src/diagnostics.rs
+++ b/compiler/rustc_mir_transform/src/diagnostics.rs
@@ -126,6 +126,14 @@ impl AssertLintKind {
 }
 
 #[derive(Diagnostic)]
+#[diag("this operation will panic at runtime")]
+pub(crate) struct ConstNIsZero {
+    #[label("const parameter `{$const_param_name}` is zero")]
+    pub const_param_span: Span,
+    pub const_param_name: Symbol,
+}
+
+#[derive(Diagnostic)]
 #[diag("call to inline assembly that may unwind")]
 pub(crate) struct AsmUnwindCall {
     #[label("call to inline assembly that may unwind")]

--- a/compiler/rustc_mir_transform/src/known_panics_lint.rs
+++ b/compiler/rustc_mir_transform/src/known_panics_lint.rs
@@ -10,19 +10,23 @@ use rustc_const_eval::interpret::{
     ImmTy, InterpCx, InterpResult, Projectable, Scalar, format_interp_error, interp_ok,
 };
 use rustc_data_structures::fx::FxHashSet;
-use rustc_hir::HirId;
 use rustc_hir::def::DefKind;
+use rustc_hir::{HirId, find_attr};
 use rustc_index::IndexVec;
 use rustc_index::bit_set::DenseBitSet;
 use rustc_middle::bug;
 use rustc_middle::mir::visit::{MutatingUseContext, NonMutatingUseContext, PlaceContext, Visitor};
 use rustc_middle::mir::*;
 use rustc_middle::ty::layout::{LayoutError, LayoutOf, LayoutOfHelpers, TyAndLayout};
-use rustc_middle::ty::{self, ConstInt, ScalarInt, Ty, TyCtxt, TypeVisitableExt, Unnormalized};
+use rustc_middle::ty::{
+    self, ConstInt, GenericArgKind, GenericParamDefKind, ScalarInt, Ty, TyCtxt, TypeVisitableExt,
+    Unnormalized,
+};
+use rustc_session::lint::builtin::UNCONDITIONAL_PANIC;
 use rustc_span::Span;
 use tracing::{debug, instrument, trace};
 
-use crate::diagnostics::{AssertLint, AssertLintKind};
+use crate::diagnostics::{AssertLint, AssertLintKind, ConstNIsZero};
 
 pub(super) struct KnownPanicsLint;
 
@@ -768,6 +772,38 @@ impl<'tcx> Visitor<'tcx> for ConstPropagator<'_, 'tcx> {
                 }
                 // We failed to evaluate the discriminant, fallback to visiting all successors.
             }
+            TerminatorKind::Call { func, args: _, .. } => {
+                if let Some((def_id, generic_args)) = func.const_fn_def() {
+                    for (index, arg) in generic_args.iter().enumerate() {
+                        if let GenericArgKind::Const(ct) = arg.kind() {
+                            let generics = self.tcx.generics_of(def_id);
+                            let param_def = generics.param_at(index, self.tcx);
+
+                            if let GenericParamDefKind::Const { .. } = param_def.kind
+                                && find_attr!(self.tcx, param_def.def_id, RustcPanicsWhenZero)
+                                && let Some(0) = ct.try_to_target_usize(self.tcx)
+                            {
+                                // We managed to figure-out that the value of a
+                                // `#[rustc_panics_when_zero]` const-generic parameter is zero.
+                                //
+                                // Let's report it as an unconditional panic.
+                                let source_info = self.body.source_info(location);
+                                if let Some(lint_root) = self.lint_root(*source_info) {
+                                    self.tcx.emit_node_span_lint(
+                                        UNCONDITIONAL_PANIC,
+                                        lint_root,
+                                        source_info.span,
+                                        ConstNIsZero {
+                                            const_param_span: source_info.span,
+                                            const_param_name: param_def.name,
+                                        },
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
             // None of these have Operands to const-propagate.
             TerminatorKind::Goto { .. }
             | TerminatorKind::UnwindResume
@@ -780,7 +816,6 @@ impl<'tcx> Visitor<'tcx> for ConstPropagator<'_, 'tcx> {
             | TerminatorKind::CoroutineDrop
             | TerminatorKind::FalseEdge { .. }
             | TerminatorKind::FalseUnwind { .. }
-            | TerminatorKind::Call { .. }
             | TerminatorKind::InlineAsm { .. } => {}
         }
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -373,6 +373,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
             AttributeKind::RustcObjcClass { .. } => (),
             AttributeKind::RustcObjcSelector { .. } => (),
             AttributeKind::RustcOffloadKernel => (),
+            AttributeKind::RustcPanicsWhenZero => (),
             AttributeKind::RustcParenSugar => (),
             AttributeKind::RustcPassByValue => (),
             AttributeKind::RustcPassIndirectlyInNonRusticAbis(..) => (),

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1835,6 +1835,7 @@ symbols! {
         rustc_objc_selector,
         rustc_offload_kernel,
         rustc_on_unimplemented,
+        rustc_panics_when_zero,
         rustc_paren_sugar,
         rustc_partition_codegened,
         rustc_partition_reused,

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1651,14 +1651,7 @@ pub const trait Iterator {
     ///
     /// # Panics
     ///
-    /// Panics if `N` is zero. This check will most probably get changed to a
-    /// compile time error before this method gets stabilized.
-    ///
-    /// ```should_panic
-    /// #![feature(iter_map_windows)]
-    ///
-    /// let iter = std::iter::repeat(0).map_windows(|&[]| ());
-    /// ```
+    /// Panics if `N` is zero.
     ///
     /// # Examples
     ///
@@ -1768,7 +1761,10 @@ pub const trait Iterator {
     /// ```
     #[inline]
     #[unstable(feature = "iter_map_windows", issue = "87155")]
-    fn map_windows<F, R, const N: usize>(self, f: F) -> MapWindows<Self, F, N>
+    fn map_windows<F, R, #[rustc_panics_when_zero] const N: usize>(
+        self,
+        f: F,
+    ) -> MapWindows<Self, F, N>
     where
         Self: Sized,
         F: FnMut(&[Self::Item; N]) -> R,
@@ -3630,7 +3626,7 @@ pub const trait Iterator {
     /// ```
     #[track_caller]
     #[unstable(feature = "iter_array_chunks", issue = "100450")]
-    fn array_chunks<const N: usize>(self) -> ArrayChunks<Self, N>
+    fn array_chunks<#[rustc_panics_when_zero] const N: usize>(self) -> ArrayChunks<Self, N>
     where
         Self: Sized,
     {

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1334,7 +1334,9 @@ impl<T> [T] {
     #[inline]
     #[must_use]
     #[track_caller]
-    pub const unsafe fn as_chunks_unchecked<const N: usize>(&self) -> &[[T; N]] {
+    pub const unsafe fn as_chunks_unchecked<#[rustc_panics_when_zero] const N: usize>(
+        &self,
+    ) -> &[[T; N]] {
         assert_unsafe_precondition!(
             check_language_ub,
             "slice::as_chunks_unchecked requires `N != 0` and the slice to split exactly into `N`-element chunks",
@@ -1392,7 +1394,7 @@ impl<T> [T] {
     #[inline]
     #[track_caller]
     #[must_use]
-    pub const fn as_chunks<const N: usize>(&self) -> (&[[T; N]], &[T]) {
+    pub const fn as_chunks<#[rustc_panics_when_zero] const N: usize>(&self) -> (&[[T; N]], &[T]) {
         assert!(N != 0, "chunk size must be non-zero");
         let len_rounded_down = self.len() / N * N;
         // SAFETY: The rounded-down value is always the same or smaller than the
@@ -1439,7 +1441,7 @@ impl<T> [T] {
     #[inline]
     #[track_caller]
     #[must_use]
-    pub const fn as_rchunks<const N: usize>(&self) -> (&[T], &[[T; N]]) {
+    pub const fn as_rchunks<#[rustc_panics_when_zero] const N: usize>(&self) -> (&[T], &[[T; N]]) {
         assert!(N != 0, "chunk size must be non-zero");
         let len = self.len() / N;
         let (remainder, multiple_of_n) = self.split_at(self.len() - len * N);
@@ -1494,7 +1496,9 @@ impl<T> [T] {
     #[inline]
     #[must_use]
     #[track_caller]
-    pub const unsafe fn as_chunks_unchecked_mut<const N: usize>(&mut self) -> &mut [[T; N]] {
+    pub const unsafe fn as_chunks_unchecked_mut<#[rustc_panics_when_zero] const N: usize>(
+        &mut self,
+    ) -> &mut [[T; N]] {
         assert_unsafe_precondition!(
             check_language_ub,
             "slice::as_chunks_unchecked requires `N != 0` and the slice to split exactly into `N`-element chunks",
@@ -1548,7 +1552,9 @@ impl<T> [T] {
     #[inline]
     #[track_caller]
     #[must_use]
-    pub const fn as_chunks_mut<const N: usize>(&mut self) -> (&mut [[T; N]], &mut [T]) {
+    pub const fn as_chunks_mut<#[rustc_panics_when_zero] const N: usize>(
+        &mut self,
+    ) -> (&mut [[T; N]], &mut [T]) {
         assert!(N != 0, "chunk size must be non-zero");
         let len_rounded_down = self.len() / N * N;
         // SAFETY: The rounded-down value is always the same or smaller than the
@@ -1601,7 +1607,9 @@ impl<T> [T] {
     #[inline]
     #[track_caller]
     #[must_use]
-    pub const fn as_rchunks_mut<const N: usize>(&mut self) -> (&mut [T], &mut [[T; N]]) {
+    pub const fn as_rchunks_mut<#[rustc_panics_when_zero] const N: usize>(
+        &mut self,
+    ) -> (&mut [T], &mut [[T; N]]) {
         assert!(N != 0, "chunk size must be non-zero");
         let len = self.len() / N;
         let (remainder, multiple_of_n) = self.split_at_mut(self.len() - len * N);
@@ -1642,7 +1650,9 @@ impl<T> [T] {
     #[rustc_const_unstable(feature = "const_slice_make_iter", issue = "137737")]
     #[inline]
     #[track_caller]
-    pub const fn array_windows<const N: usize>(&self) -> ArrayWindows<'_, T, N> {
+    pub const fn array_windows<#[rustc_panics_when_zero] const N: usize>(
+        &self,
+    ) -> ArrayWindows<'_, T, N> {
         assert!(N != 0, "window size must be non-zero");
         ArrayWindows::new(self)
     }

--- a/library/coretests/tests/iter/adapters/map_windows.rs
+++ b/library/coretests/tests/iter/adapters/map_windows.rs
@@ -217,6 +217,7 @@ fn test_case_from_pr_82413_comment() {
 
 #[test]
 #[should_panic = "array in `Iterator::map_windows` must contain more than 0 elements"]
+#[allow(unconditional_panic)]
 fn check_zero_window() {
     let _ = std::iter::repeat(0).map_windows(|_: &[_; 0]| ());
 }

--- a/tests/ui/lint/const-n-is-zero.rs
+++ b/tests/ui/lint/const-n-is-zero.rs
@@ -1,0 +1,65 @@
+// Test that core functions annotated with `#[rustc_panics_when_zero]` lint when `N` is zero
+
+//@ build-fail
+
+#![feature(iter_map_windows)]
+#![feature(iter_array_chunks)]
+
+const ZERO: usize = 0;
+const ONE: usize = 1;
+
+fn cond<const N: usize>(a: &[usize]) {
+    if N > 0 {
+        let _ = a.into_iter().array_chunks::<N>();
+    }
+}
+
+fn main() {
+    let s = [1, 2, 3, 4];
+
+    let _ = s.array_windows::<0>();
+    //~^ ERROR this operation will panic at runtime
+    //~| NOTE `#[deny(unconditional_panic)]` on by default
+    //~| NOTE const parameter `N` is zero
+
+    let _ = s.as_chunks::<{ 0 }>();
+    //~^ ERROR this operation will panic at runtime
+    //~| NOTE const parameter `N` is zero
+    //
+    let _ = s.as_rchunks::<{ 1 - 1 }>();
+    //~^ ERROR this operation will panic at runtime
+    //~| NOTE const parameter `N` is zero
+
+    let mut m = [1, 2, 3, 4];
+
+    let _ = m.as_chunks_mut::<ZERO>();
+    //~^ ERROR this operation will panic at runtime
+    //~| NOTE const parameter `N` is zero
+
+    let _ = m.as_rchunks_mut::<{ if ZERO == 0 { 0 } else { 1 } }>();
+    //~^ ERROR this operation will panic at runtime
+    //~| NOTE const parameter `N` is zero
+
+    let _ = s.array_windows().any(|[]| true);
+    //~^ ERROR this operation will panic at runtime
+    //~| NOTE const parameter `N` is zero
+
+    let _ = s.iter().map_windows(|[]| true);
+    //~^ ERROR this operation will panic at runtime
+    //~| NOTE const parameter `N` is zero
+
+    let _ = s.iter().array_chunks().any(|[]| true);
+    //~^ ERROR this operation will panic at runtime
+    //~| NOTE const parameter `N` is zero
+
+    // Shouldn't lint
+    let _ = s.array_windows::<2>();
+    let _ = s.as_chunks::<1>();
+    let _ = m.as_chunks_mut::<ONE>();
+    let _ = m.as_rchunks::<{ 1 + 1 }>();
+    let _ = m.as_rchunks_mut::<{ if ZERO == 1 { 0 } else { 5 } }>();
+
+    // Shouldn't lint either, as we don't look at monomorphized code
+    cond::<0>(&[12, 32]);
+    cond::<1>(&[12, 32]);
+}

--- a/tests/ui/lint/const-n-is-zero.stderr
+++ b/tests/ui/lint/const-n-is-zero.stderr
@@ -1,0 +1,52 @@
+error: this operation will panic at runtime
+  --> $DIR/const-n-is-zero.rs:20:13
+   |
+LL |     let _ = s.array_windows::<0>();
+   |             ^^^^^^^^^^^^^^^^^^^^^^ const parameter `N` is zero
+   |
+   = note: `#[deny(unconditional_panic)]` on by default
+
+error: this operation will panic at runtime
+  --> $DIR/const-n-is-zero.rs:25:13
+   |
+LL |     let _ = s.as_chunks::<{ 0 }>();
+   |             ^^^^^^^^^^^^^^^^^^^^^^ const parameter `N` is zero
+
+error: this operation will panic at runtime
+  --> $DIR/const-n-is-zero.rs:29:13
+   |
+LL |     let _ = s.as_rchunks::<{ 1 - 1 }>();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ const parameter `N` is zero
+
+error: this operation will panic at runtime
+  --> $DIR/const-n-is-zero.rs:35:13
+   |
+LL |     let _ = m.as_chunks_mut::<ZERO>();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^ const parameter `N` is zero
+
+error: this operation will panic at runtime
+  --> $DIR/const-n-is-zero.rs:39:13
+   |
+LL |     let _ = m.as_rchunks_mut::<{ if ZERO == 0 { 0 } else { 1 } }>();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ const parameter `N` is zero
+
+error: this operation will panic at runtime
+  --> $DIR/const-n-is-zero.rs:43:13
+   |
+LL |     let _ = s.array_windows().any(|[]| true);
+   |             ^^^^^^^^^^^^^^^^^ const parameter `N` is zero
+
+error: this operation will panic at runtime
+  --> $DIR/const-n-is-zero.rs:47:13
+   |
+LL |     let _ = s.iter().map_windows(|[]| true);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ const parameter `N` is zero
+
+error: this operation will panic at runtime
+  --> $DIR/const-n-is-zero.rs:51:13
+   |
+LL |     let _ = s.iter().array_chunks().any(|[]| true);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^ const parameter `N` is zero
+
+error: aborting due to 8 previous errors
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/153563)*
<!-- homu-ignore:end -->

This PR extends the deny-by-default `unconditional_panic` lint, by linting on iterator functions that panics when `N` (chunks/windows size) is zero[^attr].

Those methods are [documented](https://doc.rust-lang.org/std/primitive.slice.html#panics-11) to panic if `N` is zero.

```
error: this operation will panic at runtime
  --> $DIR/const-n-is-zero.rs:11:13
   |
LL |     let _ = s.array_windows::<0>();
   |             ^^^^^^^^^^^^^^^^^^^^^^ const parameter `N` is zero
   |
   = note: `#[deny(unconditional_panic)]` on by default
```

cc @rust-lang/libs-api

[^attr]: this is done by introducing a new internal attribute on the const parameter: `#[rustc_panics_when_zero]`