### PR TITLE
Avoid ICE when an EII declaration conflicts with a constructor

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/compare_eii.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_eii.rs
@@ -9,6 +9,7 @@ use std::iter;
 use rustc_data_structures::fx::FxIndexSet;
 use rustc_errors::{Applicability, E0806, struct_span_code_err};
 use rustc_hir::attrs::EiiImplResolution;
+use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::{self as hir, FnSig, HirId, ItemKind, find_attr};
 use rustc_infer::infer::{self, InferCtxt, TyCtxtInferExt};
@@ -37,6 +38,14 @@ pub(crate) fn compare_eii_function_types<'tcx>(
     eii_name: Symbol,
     eii_attr_span: Span,
 ) -> Result<(), ErrorGuaranteed> {
+    // Error recovery can resolve the EII target to another value item with the same name,
+    // such as a tuple-struct constructor. Skip the comparison in that case and rely on the
+    // earlier name-resolution error instead of ICEing while building EII diagnostics.
+    // See <https://github.com/rust-lang/rust/issues/153502>.
+    if !is_foreign_function(tcx, foreign_item) {
+        return Ok(());
+    }
+
     check_is_structurally_compatible(tcx, external_impl, foreign_item, eii_name, eii_attr_span)?;
 
     let external_impl_span = tcx.def_span(external_impl);
@@ -441,4 +450,8 @@ fn extract_spans_for_error_reporting<'tcx>(
 fn get_declaration_sig<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> Option<&'tcx FnSig<'tcx>> {
     let hir_id: HirId = tcx.local_def_id_to_hir_id(def_id);
     tcx.hir_fn_sig_by_hir_id(hir_id)
+}
+
+fn is_foreign_function(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
+    tcx.is_foreign_item(def_id) && matches!(tcx.def_kind(def_id), DefKind::Fn)
 }

--- a/tests/ui/eii/duplicate/eii-declaration-conflicts-with-constructor.rs
+++ b/tests/ui/eii/duplicate/eii-declaration-conflicts-with-constructor.rs
@@ -1,0 +1,11 @@
+#![feature(extern_item_impls)]
+
+// Regression test for <https://github.com/rust-lang/rust/issues/153502>:
+
+struct Foo(i32);
+
+#[eii]
+pub fn Foo(x: u64) {}
+//~^ ERROR the name `Foo` is defined multiple times
+
+fn main() {}

--- a/tests/ui/eii/duplicate/eii-declaration-conflicts-with-constructor.stderr
+++ b/tests/ui/eii/duplicate/eii-declaration-conflicts-with-constructor.stderr
@@ -1,0 +1,14 @@
+error[E0428]: the name `Foo` is defined multiple times
+  --> $DIR/eii-declaration-conflicts-with-constructor.rs:8:1
+   |
+LL | struct Foo(i32);
+   | ---------------- previous definition of the value `Foo` here
+...
+LL | pub fn Foo(x: u64) {}
+   | ^^^^^^^^^^^^^^^^^^ `Foo` redefined here
+   |
+   = note: `Foo` must be defined only once in the value namespace of this module
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0428`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#153502

When an `#[eii]` declaration conflicts with a tuple-struct constructor of the same name, error recovery can resolve
the EII target to the constructor instead of the generated foreign item. `compare_eii_function_types` then assumes
that target is a foreign function and later ICEs while building diagnostics.

This pull request adds an early guard in `compare_eii_function_types` to skip EII signature comparison unless the resolved target is actually a foreign function.