### PR TITLE
rustdoc-json: fix incorrect documentation for VariantKind::Struct

### DIFF
--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -856,10 +856,10 @@ pub enum VariantKind {
     /// }
     /// ```
     Struct {
-        /// The list of variants in the enum.
-        /// All of the corresponding [`Item`]s are of kind [`ItemEnum::Variant`].
+        /// The list of named fields in the variant.
+        /// All of the corresponding [`Item`]s are of kind [`ItemEnum::StructField`].
         fields: Vec<Id>,
-        /// Whether any variants have been removed from the result, due to being private or hidden.
+        /// Whether any fields have been removed from the result, due to being private or hidden.
         has_stripped_fields: bool,
     },
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Seems to have been copy-and-pasted from `Enum::variants`, but `VariantKind::Struct::fields` is for struct variant fields, not enum variants.