### PR TITLE
Use non-Copy type in Box module doc examples

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -10,15 +10,15 @@
 //! Move a value from the stack to the heap by creating a [`Box`]:
 //!
 //! ```
-//! let val: u8 = 5;
-//! let boxed: Box<u8> = Box::new(val);
+//! let val: String = String::from("hello");
+//! let boxed: Box<String> = Box::new(val);
 //! ```
 //!
 //! Move a value from a [`Box`] back to the stack by [dereferencing]:
 //!
 //! ```
-//! let boxed: Box<u8> = Box::new(5);
-//! let val: u8 = *boxed;
+//! let boxed: Box<String> = Box::new(String::from("hello"));
+//! let val: String = *boxed;
 //! ```
 //!
 //! Creating a recursive data structure:


### PR DESCRIPTION
The module-level doc examples for `Box` use `u8` to demonstrate moving values to/from the heap, but `u8` implements `Copy` so no move actually occurs — the original value remains valid after `Box::new(val)`. This is misleading for readers learning about ownership and move semantics.

This switches the examples to use `String`, which does not implement `Copy`, so the examples accurately illustrate what the surrounding text describes.

Fixes rust-lang/rust#153562

This contribution was developed with AI assistance (Claude Code).