### PR TITLE
Fix missing space in deprecated_where_clause_location suggestion

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -177,6 +177,8 @@ impl<'a> AstValidator<'a> {
             if !ty_alias.after_where_clause.has_where_token {
                 state.space();
                 state.word_space("where");
+            } else if ty_alias.after_where_clause.predicates.is_empty() {
+                state.space();
             }
 
             let mut first = ty_alias.after_where_clause.predicates.is_empty();

--- a/tests/ui/where-clauses/where-clause-placement-assoc-type-in-impl.fixed
+++ b/tests/ui/where-clauses/where-clause-placement-assoc-type-in-impl.fixed
@@ -10,6 +10,7 @@ trait Trait {
     type Assoc2 where u32: Copy, i32: Copy;
     //
     type Assoc3;
+    type Assoc4;
 }
 
 impl Trait for u32 {
@@ -21,6 +22,7 @@ impl Trait for u32 {
     //~^ WARNING where clause not allowed here
     type Assoc3  = () where;
     //~^ WARNING where clause not allowed here
+    type Assoc4 = ();
 }
 
 impl Trait for i32 {
@@ -30,6 +32,8 @@ impl Trait for i32 {
     type Assoc2  = () where u32: Copy, i32: Copy;
     //~^ WARNING where clause not allowed here
     type Assoc3  = () where;
+    //~^ WARNING where clause not allowed here
+    type Assoc4  = () where i32: Copy;
     //~^ WARNING where clause not allowed here
 }
 

--- a/tests/ui/where-clauses/where-clause-placement-assoc-type-in-impl.rs
+++ b/tests/ui/where-clauses/where-clause-placement-assoc-type-in-impl.rs
@@ -10,6 +10,7 @@ trait Trait {
     type Assoc2 where u32: Copy, i32: Copy;
     //
     type Assoc3;
+    type Assoc4;
 }
 
 impl Trait for u32 {
@@ -21,6 +22,7 @@ impl Trait for u32 {
     //~^ WARNING where clause not allowed here
     type Assoc3 where = ();
     //~^ WARNING where clause not allowed here
+    type Assoc4 = ();
 }
 
 impl Trait for i32 {
@@ -30,6 +32,8 @@ impl Trait for i32 {
     type Assoc2 where u32: Copy, i32: Copy = ();
     //~^ WARNING where clause not allowed here
     type Assoc3 where = () where;
+    //~^ WARNING where clause not allowed here
+    type Assoc4 where i32: Copy = () where;
     //~^ WARNING where clause not allowed here
 }
 

--- a/tests/ui/where-clauses/where-clause-placement-assoc-type-in-impl.stderr
+++ b/tests/ui/where-clauses/where-clause-placement-assoc-type-in-impl.stderr
@@ -1,5 +1,5 @@
 warning: where clause not allowed here
-  --> $DIR/where-clause-placement-assoc-type-in-impl.rs:17:16
+  --> $DIR/where-clause-placement-assoc-type-in-impl.rs:18:16
    |
 LL |     type Assoc where u32: Copy = ();
    |                ^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL +     type Assoc  = () where u32: Copy;
    |
 
 warning: where clause not allowed here
-  --> $DIR/where-clause-placement-assoc-type-in-impl.rs:20:17
+  --> $DIR/where-clause-placement-assoc-type-in-impl.rs:21:17
    |
 LL |     type Assoc2 where u32: Copy = () where i32: Copy;
    |                 ^^^^^^^^^^^^^^^
@@ -26,7 +26,7 @@ LL +     type Assoc2  = () where i32: Copy, u32: Copy;
    |
 
 warning: where clause not allowed here
-  --> $DIR/where-clause-placement-assoc-type-in-impl.rs:22:17
+  --> $DIR/where-clause-placement-assoc-type-in-impl.rs:23:17
    |
 LL |     type Assoc3 where = ();
    |                 ^^^^^
@@ -39,7 +39,7 @@ LL +     type Assoc3  = () where;
    |
 
 warning: where clause not allowed here
-  --> $DIR/where-clause-placement-assoc-type-in-impl.rs:30:17
+  --> $DIR/where-clause-placement-assoc-type-in-impl.rs:32:17
    |
 LL |     type Assoc2 where u32: Copy, i32: Copy = ();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -52,12 +52,25 @@ LL +     type Assoc2  = () where u32: Copy, i32: Copy;
    |
 
 warning: where clause not allowed here
-  --> $DIR/where-clause-placement-assoc-type-in-impl.rs:32:17
+  --> $DIR/where-clause-placement-assoc-type-in-impl.rs:34:17
    |
 LL |     type Assoc3 where = () where;
    |                 ^^^^^ help: remove this `where`
    |
    = note: see issue #89122 <https://github.com/rust-lang/rust/issues/89122> for more information
 
-warning: 5 warnings emitted
+warning: where clause not allowed here
+  --> $DIR/where-clause-placement-assoc-type-in-impl.rs:36:17
+   |
+LL |     type Assoc4 where i32: Copy = () where;
+   |                 ^^^^^^^^^^^^^^^
+   |
+   = note: see issue #89122 <https://github.com/rust-lang/rust/issues/89122> for more information
+help: move it to the end of the type declaration
+   |
+LL -     type Assoc4 where i32: Copy = () where;
+LL +     type Assoc4  = () where i32: Copy;
+   |
+
+warning: 6 warnings emitted
 


### PR DESCRIPTION
When a type alias has predicates in a where clause before `=` and an empty trailing `where;` after, the `deprecated_where_clause_location` suggestion to move predicates produced invalid syntax:

```rust
// Input:
type Assoc4 where i32: Copy = () where;

// Before (broken): missing space
type Assoc4  = () wherei32: Copy;

// After (fixed): space inserted
type Assoc4  = () where i32: Copy;
```

The fix adds `state.space()` in `check_type_alias_where_clause_location` when the after-where-clause has a `where` token but no existing predicates, so the moved predicates don't run into the `where` keyword.

Also adds a regression test for this specific case.

Fixes rust-lang/rust#153567

This contribution was developed with AI assistance (Claude Code).