### PR TITLE
Suppress closure suggestion for E0434 inside trait impl methods

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -921,8 +921,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
                 err
             }
-            ResolutionError::CannotCaptureDynamicEnvironmentInFnItem => {
-                self.dcx().create_err(errs::CannotCaptureDynamicEnvironmentInFnItem { span })
+            ResolutionError::CannotCaptureDynamicEnvironmentInFnItem { is_assoc_item } => {
+                self.dcx().create_err(errs::CannotCaptureDynamicEnvironmentInFnItem {
+                    span,
+                    show_closure_help: !is_assoc_item,
+                })
             }
             ResolutionError::AttemptToUseNonConstantValueInConstant {
                 ident,

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -252,10 +252,11 @@ pub(crate) struct UnreachableLabelWithSimilarNameExists {
 
 #[derive(Diagnostic)]
 #[diag("can't capture dynamic environment in a fn item", code = E0434)]
-#[help("use the `|| {\"{\"} ... {\"}\"}` closure form instead")]
 pub(crate) struct CannotCaptureDynamicEnvironmentInFnItem {
     #[primary_span]
     pub(crate) span: Span,
+    #[help("use the `|| {\"{\"} ... {\"}\"}` closure form instead")]
+    pub(crate) show_closure_help: bool,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1437,7 +1437,10 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                 // emitted for `ConstantItemRibKind` below) to take
                                 // precedence.
                                 let is_assoc_item = matches!(rib.kind, RibKind::AssocItem);
-                                res_err = Some((span, CannotCaptureDynamicEnvironmentInFnItem { is_assoc_item }));
+                                res_err = Some((
+                                    span,
+                                    CannotCaptureDynamicEnvironmentInFnItem { is_assoc_item },
+                                ));
                             }
                         }
                         RibKind::ConstantItem(_, item) => {

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1436,7 +1436,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                 // we want certain other resolution errors (namely those
                                 // emitted for `ConstantItemRibKind` below) to take
                                 // precedence.
-                                res_err = Some((span, CannotCaptureDynamicEnvironmentInFnItem));
+                                let is_assoc_item = matches!(rib.kind, RibKind::AssocItem);
+                                res_err = Some((span, CannotCaptureDynamicEnvironmentInFnItem { is_assoc_item }));
                             }
                         }
                         RibKind::ConstantItem(_, item) => {

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -280,7 +280,7 @@ enum ResolutionError<'ra> {
         message: String,
     },
     /// Error E0434: can't capture dynamic environment in a fn item.
-    CannotCaptureDynamicEnvironmentInFnItem,
+    CannotCaptureDynamicEnvironmentInFnItem { is_assoc_item: bool },
     /// Error E0435: attempt to use a non-constant value in a constant.
     AttemptToUseNonConstantValueInConstant {
         ident: Ident,

--- a/tests/ui/resolve/e0434-no-closure-hint-in-trait-impl.rs
+++ b/tests/ui/resolve/e0434-no-closure-hint-in-trait-impl.rs
@@ -1,0 +1,18 @@
+// Verify that E0434 inside a trait impl method does not suggest
+// "use the closure form instead" since trait methods cannot be closures.
+
+trait T {
+    fn t() -> impl FnOnce() -> ();
+}
+
+fn f(x: String) {
+    struct S;
+    impl T for S {
+        fn t() -> impl FnOnce() -> () {
+            move || {let _ = x;}
+            //~^ ERROR can't capture dynamic environment in a fn item
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/resolve/e0434-no-closure-hint-in-trait-impl.stderr
+++ b/tests/ui/resolve/e0434-no-closure-hint-in-trait-impl.stderr
@@ -1,0 +1,9 @@
+error[E0434]: can't capture dynamic environment in a fn item
+  --> $DIR/e0434-no-closure-hint-in-trait-impl.rs:12:28
+   |
+LL |             move || {let _ = x;}
+   |                              ^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0434`.


### PR DESCRIPTION
When E0434 ("can't capture dynamic environment in a fn item") fires inside a trait impl method, the compiler suggests "use the `|| { ... }` closure form instead." This is wrong - you can't implement a trait method as a closure.

```rust
impl T for S {
    fn t() -> impl FnOnce() -> () {
        move || { let _ = x; }
        // error: can't capture dynamic environment in a fn item
        // help: use the `|| { ... }` closure form instead  <-- misleading!
    }
}
```

This PR makes the help message conditional: it's shown for regular fn items (where converting to a closure is possible) but suppressed for associated items (trait/impl methods, where it's not).

**Changes:**
- `CannotCaptureDynamicEnvironmentInFnItem` now carries `is_assoc_item: bool`
- The closure help is shown only when `!is_assoc_item`
- The distinction comes from `RibKind::AssocItem` vs `RibKind::Item`

**Note:** The `.stderr` test file was written by hand. If the exact output format differs slightly, I'll update with `--bless`.

Fixes rust-lang/rust#153363

This contribution was developed with AI assistance (Claude Code).