### PR TITLE
`define_queries!` module tweaks

### DIFF
--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -17,9 +17,9 @@ use rustc_middle::verify_ich::incremental_verify_ich;
 use rustc_span::{DUMMY_SP, Span};
 
 use crate::dep_graph::{DepNode, DepNodeIndex};
-use crate::for_each_query_vtable;
 use crate::job::{QueryJobInfo, QueryJobMap, find_cycle_in_stack, report_cycle};
 use crate::plumbing::{current_query_job, next_job_id, start_query};
+use crate::query_impl::for_each_query_vtable;
 
 #[inline]
 fn equivalent_key<K: Eq, V>(k: K) -> impl Fn(&(K, V)) -> bool {

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -63,7 +63,9 @@ pub fn query_system<'tcx>(
     }
 }
 
-rustc_middle::rustc_with_all_queries! { define_queries! }
+mod query_impl {
+    rustc_middle::rustc_with_all_queries! { define_queries! }
+}
 
 pub fn provide(providers: &mut rustc_middle::util::Providers) {
     providers.hooks.alloc_self_profile_query_strings =

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -10,7 +10,7 @@
 
 use rustc_data_structures::sync::AtomicU64;
 use rustc_middle::dep_graph;
-use rustc_middle::queries::{self, ExternProviders, Providers};
+use rustc_middle::queries::{ExternProviders, Providers};
 use rustc_middle::query::on_disk_cache::OnDiskCache;
 use rustc_middle::query::plumbing::{QuerySystem, QueryVTable};
 use rustc_middle::query::{AsLocalQueryKey, QueryCache, QueryMode};

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -51,7 +51,7 @@ pub fn query_system<'tcx>(
     on_disk_cache: Option<OnDiskCache>,
     incremental: bool,
 ) -> QuerySystem<'tcx> {
-    let mut query_vtables = make_query_vtables(incremental);
+    let mut query_vtables = query_impl::make_query_vtables(incremental);
     from_cycle_error::specialize_query_vtables(&mut query_vtables);
     QuerySystem {
         arenas: Default::default(),

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -351,7 +351,7 @@ macro_rules! define_queries {
     ) => {
         pub(crate) mod query_impl { $(pub(crate) mod $name {
             use super::super::*;
-            use ::rustc_middle::query::erase::{self, Erased};
+            use rustc_middle::query::erase::{self, Erased};
 
             // It seems to be important that every query has its own monomorphic
             // copy of `execute_query_incr` and `execute_query_non_incr`.
@@ -367,9 +367,9 @@ macro_rules! define_queries {
                 pub(crate) fn __rust_end_short_backtrace<'tcx>(
                     tcx: TyCtxt<'tcx>,
                     span: Span,
-                    key: queries::$name::Key<'tcx>,
+                    key: rustc_middle::queries::$name::Key<'tcx>,
                     mode: QueryMode,
-                ) -> Option<Erased<queries::$name::Value<'tcx>>> {
+                ) -> Option<Erased<rustc_middle::queries::$name::Value<'tcx>>> {
                     #[cfg(debug_assertions)]
                     let _guard = tracing::span!(tracing::Level::TRACE, stringify!($name), ?key).entered();
                     execution::execute_query_incr_inner(
@@ -389,9 +389,9 @@ macro_rules! define_queries {
                 pub(crate) fn __rust_end_short_backtrace<'tcx>(
                     tcx: TyCtxt<'tcx>,
                     span: Span,
-                    key: queries::$name::Key<'tcx>,
+                    key: rustc_middle::queries::$name::Key<'tcx>,
                     __mode: QueryMode,
-                ) -> Option<Erased<queries::$name::Value<'tcx>>> {
+                ) -> Option<Erased<rustc_middle::queries::$name::Value<'tcx>>> {
                     Some(execution::execute_query_non_incr_inner(
                         &tcx.query_system.query_vtables.$name,
                         tcx,
@@ -408,7 +408,7 @@ macro_rules! define_queries {
             /// (after demangling) must be `__rust_begin_short_backtrace`.
             mod invoke_provider_fn {
                 use super::*;
-                use ::rustc_middle::queries::$name::{Key, Value, provided_to_erased};
+                use rustc_middle::queries::$name::{Key, Value, provided_to_erased};
 
                 #[inline(never)]
                 pub(crate) fn __rust_begin_short_backtrace<'tcx>(
@@ -441,7 +441,7 @@ macro_rules! define_queries {
             }
 
             pub(crate) fn make_query_vtable<'tcx>(incremental: bool)
-                -> QueryVTable<'tcx, queries::$name::Cache<'tcx>>
+                -> QueryVTable<'tcx, rustc_middle::queries::$name::Cache<'tcx>>
             {
                 QueryVTable {
                     name: stringify!($name),
@@ -470,11 +470,11 @@ macro_rules! define_queries {
                             return None;
                         }
 
-                        let value: queries::$name::ProvidedValue<'tcx> =
+                        let value: rustc_middle::queries::$name::ProvidedValue<'tcx> =
                             $crate::plumbing::try_load_from_disk(tcx, prev_index, index)?;
 
                         // Arena-alloc the value if appropriate, and erase it.
-                        Some(queries::$name::provided_to_erased(tcx, value))
+                        Some(rustc_middle::queries::$name::provided_to_erased(tcx, value))
                     },
                     #[cfg(not($cache_on_disk))]
                     try_load_from_disk_fn: |_tcx, _key, _prev_index, _index| None,
@@ -494,13 +494,19 @@ macro_rules! define_queries {
                     #[cfg($no_hash)]
                     hash_value_fn: None,
                     #[cfg(not($no_hash))]
-                    hash_value_fn: Some(|hcx, erased_value: &erase::Erased<queries::$name::Value<'tcx>>| {
+                    hash_value_fn: Some(|
+                        hcx,
+                        erased_value: &erase::Erased<rustc_middle::queries::$name::Value<'tcx>>
+                    | {
                         let value = erase::restore_val(*erased_value);
                         rustc_middle::dep_graph::hash_result(hcx, &value)
                     }),
 
-                    format_value: |value| format!("{:?}", erase::restore_val::<queries::$name::Value<'tcx>>(*value)),
-                    description_fn: $crate::queries::_description_fns::$name,
+                    format_value: |value| format!(
+                        "{:?}",
+                        erase::restore_val::<rustc_middle::queries::$name::Value<'tcx>>(*value)
+                    ),
+                    description_fn: rustc_middle::queries::_description_fns::$name,
                     execute_query_fn: if incremental {
                         query_impl::$name::execute_query_incr::__rust_end_short_backtrace
                     } else {
@@ -522,8 +528,10 @@ macro_rules! define_queries {
             }
         })*}
 
-        pub fn make_query_vtables<'tcx>(incremental: bool) -> queries::QueryVTables<'tcx> {
-            queries::QueryVTables {
+        pub fn make_query_vtables<'tcx>(incremental: bool)
+            -> rustc_middle::queries::QueryVTables<'tcx>
+        {
+            rustc_middle::queries::QueryVTables {
                 $(
                     $name: query_impl::$name::make_query_vtable(incremental),
                 )*

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -350,7 +350,8 @@ macro_rules! define_queries {
         // Non-queries are unused here.
         non_queries { $($_:tt)* }
     ) => {
-        pub(crate) mod query_impl { $(pub(crate) mod $name {
+        // This macro expects to be expanded into `mod query_impl` in the crate root.
+        $(pub(crate) mod $name {
             use super::*;
             use rustc_middle::query::erase::{self, Erased};
 
@@ -585,5 +586,5 @@ macro_rules! define_queries {
         }
 
         pub(crate) use for_each_query_vtable;
-    }}
+    }
 }

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -33,7 +33,8 @@ use rustc_span::def_id::LOCAL_CRATE;
 use crate::error::{QueryOverflow, QueryOverflowNote};
 use crate::execution::{all_inactive, force_query};
 use crate::job::find_dep_kind_root;
-use crate::{GetQueryVTable, collect_active_jobs_from_all_queries, for_each_query_vtable};
+use crate::query_impl::for_each_query_vtable;
+use crate::{GetQueryVTable, collect_active_jobs_from_all_queries};
 
 fn depth_limit_error<'tcx>(tcx: TyCtxt<'tcx>, job: QueryJobId) {
     let job_map =
@@ -350,7 +351,7 @@ macro_rules! define_queries {
         non_queries { $($_:tt)* }
     ) => {
         pub(crate) mod query_impl { $(pub(crate) mod $name {
-            use super::super::*;
+            use super::*;
             use rustc_middle::query::erase::{self, Erased};
 
             // It seems to be important that every query has its own monomorphic
@@ -361,8 +362,9 @@ macro_rules! define_queries {
             pub(crate) mod execute_query_incr {
                 use super::*;
 
-                // Adding `__rust_end_short_backtrace` marker to backtraces so that we emit the frames
-                // when `RUST_BACKTRACE=1`, add a new mod with `$name` here is to allow duplicate naming
+                // Adding `__rust_end_short_backtrace` marker to backtraces so that we emit the
+                // frames when `RUST_BACKTRACE=1`, add a new mod with `$name` here is to allow
+                // duplicate naming.
                 #[inline(never)]
                 pub(crate) fn __rust_end_short_backtrace<'tcx>(
                     tcx: TyCtxt<'tcx>,
@@ -526,14 +528,16 @@ macro_rules! define_queries {
                     &tcx.query_system.query_vtables.$name
                 }
             }
-        })*}
+        })*
 
-        pub fn make_query_vtables<'tcx>(incremental: bool)
+        use super::*;
+
+        pub(crate) fn make_query_vtables<'tcx>(incremental: bool)
             -> rustc_middle::queries::QueryVTables<'tcx>
         {
             rustc_middle::queries::QueryVTables {
                 $(
-                    $name: query_impl::$name::make_query_vtable(incremental),
+                    $name: $name::make_query_vtable(incremental),
                 )*
             }
         }
@@ -581,5 +585,5 @@ macro_rules! define_queries {
         }
 
         pub(crate) use for_each_query_vtable;
-    }
+    }}
 }

--- a/compiler/rustc_query_impl/src/profiling_support.rs
+++ b/compiler/rustc_query_impl/src/profiling_support.rs
@@ -10,7 +10,7 @@ use rustc_middle::query::QueryCache;
 use rustc_middle::query::plumbing::QueryVTable;
 use rustc_middle::ty::TyCtxt;
 
-use crate::for_each_query_vtable;
+use crate::query_impl::for_each_query_vtable;
 
 pub(crate) struct QueryKeyStringCache {
     def_id_cache: FxHashMap<DefId, StringId>,


### PR DESCRIPTION
Minor module structure tweaks, trying to make `define_queries!` nicer and more like `define_callbacks!`. Details in individual commits.

r? @Zalathar