### PR TITLE
Make E0434 help message context-aware

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0434.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0434.md
@@ -6,8 +6,7 @@ Erroneous code example:
 fn foo() {
     let y = 5;
     fn bar() -> u32 {
-        y // error: can't capture dynamic environment in a fn item; use the
-          //        || { ... } closure form instead.
+        y // error: can't capture dynamic environment in a fn item
     }
 }
 ```

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -921,8 +921,14 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
                 err
             }
-            ResolutionError::CannotCaptureDynamicEnvironmentInFnItem => {
-                self.dcx().create_err(errs::CannotCaptureDynamicEnvironmentInFnItem { span })
+            ResolutionError::CannotCaptureDynamicEnvironmentInFnItem { is_nested_fn } => {
+                let help = if is_nested_fn {
+                    Some(errs::CannotCaptureDynamicEnvironmentInFnItemHelp::UseClosureInstead)
+                } else {
+                    Some(errs::CannotCaptureDynamicEnvironmentInFnItemHelp::PassAsParameter)
+                };
+                self.dcx()
+                    .create_err(errs::CannotCaptureDynamicEnvironmentInFnItem { span, help })
             }
             ResolutionError::AttemptToUseNonConstantValueInConstant {
                 ident,

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -927,8 +927,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 } else {
                     Some(errs::CannotCaptureDynamicEnvironmentInFnItemHelp::PassAsParameter)
                 };
-                self.dcx()
-                    .create_err(errs::CannotCaptureDynamicEnvironmentInFnItem { span, help })
+                self.dcx().create_err(errs::CannotCaptureDynamicEnvironmentInFnItem { span, help })
             }
             ResolutionError::AttemptToUseNonConstantValueInConstant {
                 ident,

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -252,10 +252,19 @@ pub(crate) struct UnreachableLabelWithSimilarNameExists {
 
 #[derive(Diagnostic)]
 #[diag("can't capture dynamic environment in a fn item", code = E0434)]
-#[help("use the `|| {\"{\"} ... {\"}\"}` closure form instead")]
 pub(crate) struct CannotCaptureDynamicEnvironmentInFnItem {
     #[primary_span]
     pub(crate) span: Span,
+    #[subdiagnostic]
+    pub(crate) help: Option<CannotCaptureDynamicEnvironmentInFnItemHelp>,
+}
+
+#[derive(Subdiagnostic)]
+pub(crate) enum CannotCaptureDynamicEnvironmentInFnItemHelp {
+    #[help("consider converting this fn item to a closure to capture the dynamic environment")]
+    UseClosureInstead,
+    #[help("consider passing the value as a function parameter instead of capturing it")]
+    PassAsParameter,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1446,9 +1446,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                         matches!(rib.kind, RibKind::Item(_, DefKind::Fn));
                                     res_err = Some((
                                         span,
-                                        CannotCaptureDynamicEnvironmentInFnItem {
-                                            is_nested_fn,
-                                        },
+                                        CannotCaptureDynamicEnvironmentInFnItem { is_nested_fn },
                                     ));
                                 }
                             }

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1436,7 +1436,21 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                 // we want certain other resolution errors (namely those
                                 // emitted for `ConstantItemRibKind` below) to take
                                 // precedence.
-                                res_err = Some((span, CannotCaptureDynamicEnvironmentInFnItem));
+                                //
+                                // Use the first (innermost) blocking rib to determine
+                                // the context for the help message: a nested fn item
+                                // can be converted to a closure, but associated items
+                                // and other item kinds cannot.
+                                if res_err.is_none() {
+                                    let is_nested_fn =
+                                        matches!(rib.kind, RibKind::Item(_, DefKind::Fn));
+                                    res_err = Some((
+                                        span,
+                                        CannotCaptureDynamicEnvironmentInFnItem {
+                                            is_nested_fn,
+                                        },
+                                    ));
+                                }
                             }
                         }
                         RibKind::ConstantItem(_, item) => {

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -280,7 +280,11 @@ enum ResolutionError<'ra> {
         message: String,
     },
     /// Error E0434: can't capture dynamic environment in a fn item.
-    CannotCaptureDynamicEnvironmentInFnItem,
+    CannotCaptureDynamicEnvironmentInFnItem {
+        /// Whether the innermost blocking rib is a nested fn item,
+        /// where converting to a closure is conceptually possible.
+        is_nested_fn: bool,
+    },
     /// Error E0435: attempt to use a non-constant value in a constant.
     AttemptToUseNonConstantValueInConstant {
         ident: Ident,

--- a/tests/ui/error-codes/E0434.stderr
+++ b/tests/ui/error-codes/E0434.stderr
@@ -4,7 +4,7 @@ error[E0434]: can't capture dynamic environment in a fn item
 LL |         y
    |         ^
    |
-   = help: use the `|| { ... }` closure form instead
+   = help: consider converting this fn item to a closure to capture the dynamic environment
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-3021-b.stderr
+++ b/tests/ui/issues/issue-3021-b.stderr
@@ -4,7 +4,7 @@ error[E0434]: can't capture dynamic environment in a fn item
 LL |            self.v0 = k0 ^ 0x736f6d6570736575;
    |                      ^^
    |
-   = help: use the `|| { ... }` closure form instead
+   = help: consider passing the value as a function parameter instead of capturing it
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-3021-d.stderr
+++ b/tests/ui/issues/issue-3021-d.stderr
@@ -4,7 +4,7 @@ error[E0434]: can't capture dynamic environment in a fn item
 LL |             self.v0 = k0 ^ 0x736f6d6570736575;
    |                       ^^
    |
-   = help: use the `|| { ... }` closure form instead
+   = help: consider passing the value as a function parameter instead of capturing it
 
 error[E0434]: can't capture dynamic environment in a fn item
   --> $DIR/issue-3021-d.rs:22:23
@@ -12,7 +12,7 @@ error[E0434]: can't capture dynamic environment in a fn item
 LL |             self.v1 = k1 ^ 0x646f72616e646f6d;
    |                       ^^
    |
-   = help: use the `|| { ... }` closure form instead
+   = help: consider passing the value as a function parameter instead of capturing it
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/resolve/bad-env-capture.stderr
+++ b/tests/ui/resolve/bad-env-capture.stderr
@@ -4,7 +4,7 @@ error[E0434]: can't capture dynamic environment in a fn item
 LL |     fn bar() { log(debug, x); }
    |                           ^
    |
-   = help: use the `|| { ... }` closure form instead
+   = help: consider converting this fn item to a closure to capture the dynamic environment
 
 error[E0425]: cannot find value `debug` in this scope
   --> $DIR/bad-env-capture.rs:3:20

--- a/tests/ui/resolve/bad-env-capture2.stderr
+++ b/tests/ui/resolve/bad-env-capture2.stderr
@@ -4,7 +4,7 @@ error[E0434]: can't capture dynamic environment in a fn item
 LL |     fn bar() { log(debug, x); }
    |                           ^
    |
-   = help: use the `|| { ... }` closure form instead
+   = help: consider converting this fn item to a closure to capture the dynamic environment
 
 error[E0425]: cannot find value `debug` in this scope
   --> $DIR/bad-env-capture2.rs:2:20

--- a/tests/ui/resolve/bad-env-capture3.stderr
+++ b/tests/ui/resolve/bad-env-capture3.stderr
@@ -4,7 +4,7 @@ error[E0434]: can't capture dynamic environment in a fn item
 LL |         fn bar() { log(debug, x); }
    |                               ^
    |
-   = help: use the `|| { ... }` closure form instead
+   = help: consider converting this fn item to a closure to capture the dynamic environment
 
 error[E0425]: cannot find value `debug` in this scope
   --> $DIR/bad-env-capture3.rs:3:24

--- a/tests/ui/resolve/e0434-context-aware-hint.rs
+++ b/tests/ui/resolve/e0434-context-aware-hint.rs
@@ -1,0 +1,42 @@
+// Verify that E0434 gives context-appropriate help messages.
+// Regression test for https://github.com/rust-lang/rust/issues/153363
+
+// Case 1: Nested fn item - closure conversion is possible.
+fn nested_fn(x: String) {
+    fn inner() {
+        let _ = x; //~ ERROR can't capture dynamic environment in a fn item
+    }
+}
+
+// Case 2: Nested fn returning a closure - closure conversion is possible.
+fn nested_fn_with_closure(x: String) {
+    fn inner() -> impl FnOnce() -> () {
+        move || { let _ = x; } //~ ERROR can't capture dynamic environment in a fn item
+    }
+}
+
+// Case 3: Trait impl method - closure conversion is impossible.
+trait T {
+    fn method() -> impl FnOnce() -> ();
+}
+
+fn trait_impl(x: String) {
+    struct S;
+    impl T for S {
+        fn method() -> impl FnOnce() -> () {
+            move || { let _ = x; } //~ ERROR can't capture dynamic environment in a fn item
+        }
+    }
+}
+
+// Case 4: Inherent impl method - closure conversion is impossible.
+fn inherent_impl(x: String) {
+    struct S;
+    impl S {
+        fn method() {
+            let _ = x; //~ ERROR can't capture dynamic environment in a fn item
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/resolve/e0434-context-aware-hint.stderr
+++ b/tests/ui/resolve/e0434-context-aware-hint.stderr
@@ -1,0 +1,35 @@
+error[E0434]: can't capture dynamic environment in a fn item
+  --> $DIR/e0434-context-aware-hint.rs:7:17
+   |
+LL |         let _ = x;
+   |                 ^
+   |
+   = help: consider converting this fn item to a closure to capture the dynamic environment
+
+error[E0434]: can't capture dynamic environment in a fn item
+  --> $DIR/e0434-context-aware-hint.rs:14:27
+   |
+LL |         move || { let _ = x; }
+   |                           ^
+   |
+   = help: consider converting this fn item to a closure to capture the dynamic environment
+
+error[E0434]: can't capture dynamic environment in a fn item
+  --> $DIR/e0434-context-aware-hint.rs:27:31
+   |
+LL |             move || { let _ = x; }
+   |                               ^
+   |
+   = help: consider passing the value as a function parameter instead of capturing it
+
+error[E0434]: can't capture dynamic environment in a fn item
+  --> $DIR/e0434-context-aware-hint.rs:37:21
+   |
+LL |             let _ = x;
+   |                     ^
+   |
+   = help: consider passing the value as a function parameter instead of capturing it
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0434`.

--- a/tests/ui/resolve/fn-item-cant-capture-dynamic-env.stderr
+++ b/tests/ui/resolve/fn-item-cant-capture-dynamic-env.stderr
@@ -4,7 +4,7 @@ error[E0434]: can't capture dynamic environment in a fn item
 LL |     fn foo() -> isize { return bar; }
    |                                ^^^
    |
-   = help: use the `|| { ... }` closure form instead
+   = help: consider converting this fn item to a closure to capture the dynamic environment
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/issue-3021.stderr
+++ b/tests/ui/resolve/issue-3021.stderr
@@ -4,7 +4,7 @@ error[E0434]: can't capture dynamic environment in a fn item
 LL |            self.v0 = k0 ^ 0x736f6d6570736575;
    |                      ^^
    |
-   = help: use the `|| { ... }` closure form instead
+   = help: consider passing the value as a function parameter instead of capturing it
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
This is a revised approach to rust-lang/rust#153587, addressing @fee1-dead's feedback that the previous fix was too narrow.

## Problem

E0434 ("can't capture dynamic environment in a fn item") unconditionally suggests `use the || { ... } closure form instead`. This hint is misleading in multiple contexts:

1. **Trait/inherent impl methods** — converting an associated fn to a closure is impossible
2. **Nested fns returning closures** — the user already has a closure; the hint is ambiguous about *what* should become a closure  
3. **Non-fn items** — the closure suggestion doesn't apply at all

As @fee1-dead pointed out, simply suppressing the hint for `AssocItem` ribs doesn't address the broader issue - the same misleading hint fires for all nested fn items regardless of context.

## Approach

The resolver already knows which `RibKind` blocks capture. This PR uses the **innermost blocking rib** to determine appropriate help text:

| Rib kind | Help message |
|----------|-------------|
| `Item(_, DefKind::Fn)` (nested fn) | "consider converting this fn item to a closure to capture the dynamic environment" |
| `AssocItem` or other `Item` kinds | "consider passing the value as a function parameter instead of capturing it" |

The key change is using `res_err.is_none()` to capture the *first* (innermost) blocking rib rather than letting subsequent ribs overwrite. This matters for cases like `fn f(x) { impl S { fn g() { x } } }` where the innermost rib (`AssocItem` for `fn g`) correctly identifies that closure conversion isn't possible, while the outer rib (`Item` for `impl S`) would lose that context.

## Changes

- `compiler/rustc_resolve/src/errors.rs` — added `CannotCaptureDynamicEnvironmentInFnItemHelp` subdiagnostic enum with context-specific messages
- `compiler/rustc_resolve/src/ident.rs` — use innermost blocking rib kind to set `is_nested_fn`
- `compiler/rustc_resolve/src/lib.rs` — added `is_nested_fn` field to `ResolutionError::CannotCaptureDynamicEnvironmentInFnItem`
- `compiler/rustc_resolve/src/diagnostics.rs` — map `is_nested_fn` to appropriate help variant
- `compiler/rustc_error_codes/src/error_codes/E0434.md` — updated error explanation
- Added `tests/ui/resolve/e0434-context-aware-hint.rs` covering all four contexts (nested fn, nested fn with closure, trait impl, inherent impl)
- Updated 8 existing `.stderr` test expectations

Fixes rust-lang/rust#153363

r? @fee1-dead

@rustbot label +A-diagnostics +A-suggestion-diagnostics +T-compiler

This contribution was developed with AI assistance (Claude Code).