### PR TITLE
WIP: Use `final` to make `Error::type_id` un-overridable

### DIFF
--- a/library/core/src/error.rs
+++ b/library/core/src/error.rs
@@ -119,7 +119,7 @@ pub trait Error: Debug + Display {
         reason = "this is memory-unsafe to override in user code",
         issue = "60784"
     )]
-    fn type_id(&self, _: private::Internal) -> TypeId
+    final fn type_id(&self) -> TypeId
     where
         Self: 'static,
     {
@@ -260,14 +260,6 @@ pub trait Error: Debug + Display {
     fn provide<'a>(&'a self, request: &mut Request<'a>) {}
 }
 
-mod private {
-    // This is a hack to prevent `type_id` from being overridden by `Error`
-    // implementations, since that can enable unsound downcasting.
-    #[unstable(feature = "error_type_id", issue = "60784")]
-    #[derive(Debug)]
-    pub struct Internal;
-}
-
 #[unstable(feature = "never_type", issue = "35121")]
 impl Error for ! {}
 
@@ -281,7 +273,7 @@ impl dyn Error + 'static {
         let t = TypeId::of::<T>();
 
         // Get `TypeId` of the type in the trait object (`self`).
-        let concrete = self.type_id(private::Internal);
+        let concrete = self.type_id();
 
         // Compare both `TypeId`s on equality.
         t == concrete

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -138,6 +138,7 @@
 #![feature(f16)]
 #![feature(f128)]
 #![feature(field_projections)]
+#![feature(final_associated_functions)]
 #![feature(freeze_impls)]
 #![feature(fundamental)]
 #![feature(funnel_shifts)]

--- a/tests/ui/std/impl-error-type-id.rs
+++ b/tests/ui/std/impl-error-type-id.rs
@@ -1,0 +1,19 @@
+#![feature(error_type_id)]
+
+#[derive(Debug)]
+struct T;
+
+impl std::fmt::Display for T {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "T")
+    }
+}
+
+impl std::error::Error for T {
+    fn type_id(&self) -> std::any::TypeId {
+    //~^ ERROR cannot override `type_id` because it already has a `final` definition in the trait
+        std::any::TypeId::of::<Self>()
+    }
+}
+
+fn main() {}

--- a/tests/ui/std/impl-error-type-id.stderr
+++ b/tests/ui/std/impl-error-type-id.stderr
@@ -1,0 +1,11 @@
+error: cannot override `type_id` because it already has a `final` definition in the trait
+  --> $DIR/impl-error-type-id.rs:13:5
+   |
+LL |     fn type_id(&self) -> std::any::TypeId {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: `type_id` is marked final here
+  --> $SRC_DIR/core/src/error.rs:LL:COL
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Tracking: https://github.com/rust-lang/rust/issues/60784

After rust-lang/rust#151783, we can declare `final` assoc functions. And `Error::type_id` is one motivation of [RFC-3678](https://github.com/rust-lang/rfcs/blob/master/text/3678-final.md#motivation). This PR uses `final` to make `Error::type_id` un-overridable and this should helps the stabilization of `Error::type_id`.