### PR TITLE
add test for proc-macros with custom panic payloads

### DIFF
--- a/tests/ui/proc-macro/any-panic-payload.rs
+++ b/tests/ui/proc-macro/any-panic-payload.rs
@@ -1,0 +1,17 @@
+//! Make sure that proc-macros which panic with a payload other than
+//! `String` or `&'static str` do not ICE.
+//@ proc-macro: any-panic-payload.rs
+
+extern crate any_panic_payload;
+
+use any_panic_payload::*;
+
+cause_panic!(); //~ ERROR proc macro panicked
+
+#[cause_panic_attr] //~ ERROR custom attribute panicked
+struct A;
+
+#[derive(CausePanic)] //~ ERROR proc-macro derive panicked
+struct B;
+
+fn main() {}

--- a/tests/ui/proc-macro/any-panic-payload.stderr
+++ b/tests/ui/proc-macro/any-panic-payload.stderr
@@ -1,0 +1,20 @@
+error: proc macro panicked
+  --> $DIR/any-panic-payload.rs:9:1
+   |
+LL | cause_panic!();
+   | ^^^^^^^^^^^^^^
+
+error: custom attribute panicked
+  --> $DIR/any-panic-payload.rs:11:1
+   |
+LL | #[cause_panic_attr]
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: proc-macro derive panicked
+  --> $DIR/any-panic-payload.rs:14:10
+   |
+LL | #[derive(CausePanic)]
+   |          ^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/proc-macro/auxiliary/any-panic-payload.rs
+++ b/tests/ui/proc-macro/auxiliary/any-panic-payload.rs
@@ -1,0 +1,22 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+fn boom() -> TokenStream {
+    std::panic::panic_any(42)
+}
+
+#[proc_macro]
+pub fn cause_panic(_: TokenStream) -> TokenStream {
+    boom()
+}
+
+#[proc_macro_attribute]
+pub fn cause_panic_attr(_: TokenStream, _: TokenStream) -> TokenStream {
+    boom()
+}
+
+#[proc_macro_derive(CausePanic)]
+pub fn cause_panic_derive(_: TokenStream) -> TokenStream {
+    boom()
+}


### PR DESCRIPTION
This was not tested anywhere so far.