### PR TITLE
Fix thread::available_parallelism on WASI targets with threads

### DIFF
--- a/library/std/src/sys/thread/unix.rs
+++ b/library/std/src/sys/thread/unix.rs
@@ -155,6 +155,7 @@ pub fn available_parallelism() -> io::Result<NonZero<usize>> {
             target_os = "aix",
             target_vendor = "apple",
             target_os = "cygwin",
+            target_os = "wasi",
         ) => {
             #[allow(unused_assignments)]
             #[allow(unused_mut)]

--- a/library/std/tests/thread.rs
+++ b/library/std/tests/thread.rs
@@ -85,7 +85,6 @@ fn thread_local_hygeiene() {
         target_env = "sgx",
         target_os = "solid_asp3",
         target_os = "teeos",
-        target_os = "wasi"
     ),
     should_panic
 )]


### PR DESCRIPTION
The refactoring in ba462864f11 ("std: Use more unix.rs code on WASI targets") moved WASI from its own thread module into the shared unix.rs module. However, it did not carry over the available_parallelism() implementation for WASI with threads, causing it to fall through to the unsupported catch-all. This silently regressed the support originally added in f0b7008648d.

Fix this by adding WASI to the standard UNIX cfg_select branch.

Depends on rust-lang/rust#155057 (Update libc to v0.2.184).

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
