### PR TITLE
fix(layout): dont wrap coroutines fields in MaybeUninit

### DIFF
--- a/compiler/rustc_abi/src/layout.rs
+++ b/compiler/rustc_abi/src/layout.rs
@@ -543,24 +543,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
         st.variants = Variants::Single { index: v };
 
         if is_special_no_niche {
-            let hide_niches = |scalar: &mut _| match scalar {
-                Scalar::Initialized { value, valid_range } => {
-                    *valid_range = WrappingRange::full(value.size(dl))
-                }
-                // Already doesn't have any niches
-                Scalar::Union { .. } => {}
-            };
-            match &mut st.backend_repr {
-                BackendRepr::Scalar(scalar) => hide_niches(scalar),
-                BackendRepr::ScalarPair(a, b) => {
-                    hide_niches(a);
-                    hide_niches(b);
-                }
-                BackendRepr::SimdVector { element, .. }
-                | BackendRepr::ScalableVector { element, .. } => hide_niches(element),
-                BackendRepr::Memory { sized: _ } => {}
-            }
-            st.largest_niche = None;
+            st.hide_niches(dl);
             return Ok(st);
         }
 

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -2091,6 +2091,32 @@ impl<FieldIdx: Idx, VariantIdx: Idx> LayoutData<FieldIdx, VariantIdx> {
         }
     }
 
+    /// Removes all niches from this layout.
+    ///
+    /// This would
+    ///
+    /// * expand scalar valid ranges to their full range
+    /// * clear the largest niche
+    pub fn hide_niches(&mut self, dl: &TargetDataLayout) {
+        let hide = |scalar: &mut Scalar| match scalar {
+            Scalar::Initialized { value, valid_range } => {
+                *valid_range = WrappingRange::full(value.size(dl))
+            }
+            Scalar::Union { .. } => {}
+        };
+        match &mut self.backend_repr {
+            BackendRepr::Scalar(s) => hide(s),
+            BackendRepr::ScalarPair(a, b) => {
+                hide(a);
+                hide(b);
+            }
+            BackendRepr::SimdVector { element, .. }
+            | BackendRepr::ScalableVector { element, .. } => hide(element),
+            BackendRepr::Memory { .. } => {}
+        }
+        self.largest_niche = None;
+    }
+
     /// Returns `true` if this is an uninhabited type
     pub fn is_uninhabited(&self) -> bool {
         self.uninhabited

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -520,8 +520,17 @@ fn layout_of_uncached<'tcx>(
                 .iter()
                 .map(|local| {
                     let field_ty = EarlyBinder::bind(local.ty);
-                    let uninit_ty = Ty::new_maybe_uninit(tcx, field_ty.instantiate(tcx, args));
-                    cx.spanned_layout_of(uninit_ty, local.source_info.span)
+                    let ty = field_ty.instantiate(tcx, args);
+                    let layout = cx.spanned_layout_of(ty, local.source_info.span)?;
+                    // Coroutine fields may be uninitialized in some variants,
+                    // so we hide niches (same effect as wrapping in MaybeUninit<T>,
+                    // but without the 3 extra layout_of depth levels from
+                    // MaybeUninit -> ManuallyDrop -> MaybeDangling -> T).
+                    // See https://github.com/rust-lang/rust/issues/152942
+                    let mut data = rustc_abi::LayoutData::clone(&layout.layout.0);
+                    data.hide_niches(cx.data_layout());
+                    data.uninhabited = false;
+                    Ok(TyAndLayout { ty: layout.ty, layout: tcx.mk_layout(data) })
                 })
                 .try_collect::<IndexVec<_, _>>()?;
 

--- a/tests/ui/async-await/coroutine-query-depth.rs
+++ b/tests/ui/async-await/coroutine-query-depth.rs
@@ -1,30 +1,21 @@
-//~ ERROR: queries overflow the depth limit!
-
 // Regression test for https://github.com/rust-lang/rust/issues/152942
 //
-// When computing coroutine layout,
-// each saved local is wrapped in `MaybeUninit<T>`,
-// which chains through `ManuallyDrop<T>`
-// and `MaybeDangling<T>` before reaching `T`.
-// This adds 3 extra layout_of queries per field.
-//
-// Query depth for computing layout of `deep()`'s coroutine body
-// (before fix, with recursion_limit = 8):
+// Query depth for computing layout of `deep()`'s coroutine body:
 //
 //   layout_of(coroutine)               depth 1
-//     layout_of(MaybeUninit<S4>)       depth 2  <- wrapping adds
-//       layout_of(ManuallyDrop<S4>)    depth 3  <- 3 extra
-//         layout_of(MaybeDangling<S4>) depth 4  <- queries
-//           layout_of(S4)              depth 5
-//             layout_of(S3)            depth 6
-//               layout_of(S2)          depth 7
-//                 layout_of(S1)        depth 8
-//                   layout_of(S0)      depth 9
-//                     layout_of(u8)    depth 10
+//     layout_of(S4)                    depth 2
+//       layout_of(S3)                  depth 3
+//         layout_of(S2)                depth 4
+//           layout_of(S1)              depth 5
+//             layout_of(S0)            depth 6
+//               layout_of(u8)          depth 7
 //
-//   total: 10 > 8 -> overflow!
+//   total: 7 < 8 -> won't overflow
+//
+// We used to have `MaybeUninit` wrap coroutine locals
+// and that made query depth 10 which exceeds 8
 
-//@ check-fail
+//@ check-pass
 //@ edition: 2024
 
 #![recursion_limit = "8"]

--- a/tests/ui/async-await/coroutine-query-depth.rs
+++ b/tests/ui/async-await/coroutine-query-depth.rs
@@ -1,0 +1,50 @@
+//~ ERROR: queries overflow the depth limit!
+
+// Regression test for https://github.com/rust-lang/rust/issues/152942
+//
+// When computing coroutine layout,
+// each saved local is wrapped in `MaybeUninit<T>`,
+// which chains through `ManuallyDrop<T>`
+// and `MaybeDangling<T>` before reaching `T`.
+// This adds 3 extra layout_of queries per field.
+//
+// Query depth for computing layout of `deep()`'s coroutine body
+// (before fix, with recursion_limit = 8):
+//
+//   layout_of(coroutine)               depth 1
+//     layout_of(MaybeUninit<S4>)       depth 2  <- wrapping adds
+//       layout_of(ManuallyDrop<S4>)    depth 3  <- 3 extra
+//         layout_of(MaybeDangling<S4>) depth 4  <- queries
+//           layout_of(S4)              depth 5
+//             layout_of(S3)            depth 6
+//               layout_of(S2)          depth 7
+//                 layout_of(S1)        depth 8
+//                   layout_of(S0)      depth 9
+//                     layout_of(u8)    depth 10
+//
+//   total: 10 > 8 -> overflow!
+
+//@ check-fail
+//@ edition: 2024
+
+#![recursion_limit = "8"]
+
+struct S0(u8);
+struct S1(S0);
+struct S2(S1);
+struct S3(S2);
+struct S4(S3);
+
+async fn yield_now() {}
+
+fn use_val<T>(_: &T) {}
+
+async fn deep() {
+    let x = S4(S3(S2(S1(S0(0)))));
+    yield_now().await;
+    use_val(&x);
+}
+
+fn main() {
+    std::mem::size_of_val(&deep());
+}

--- a/tests/ui/async-await/coroutine-query-depth.stderr
+++ b/tests/ui/async-await/coroutine-query-depth.stderr
@@ -1,0 +1,7 @@
+error: queries overflow the depth limit!
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "16"]` attribute to your crate (`coroutine_query_depth`)
+   = note: query depth increased by 10 when computing layout of `{async fn body of deep()}`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/async-await/coroutine-query-depth.stderr
+++ b/tests/ui/async-await/coroutine-query-depth.stderr
@@ -1,7 +1,0 @@
-error: queries overflow the depth limit!
-   |
-   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "16"]` attribute to your crate (`coroutine_query_depth`)
-   = note: query depth increased by 10 when computing layout of `{async fn body of deep()}`
-
-error: aborting due to 1 previous error
-

--- a/tests/ui/async-await/future-sizes/async-awaiting-fut.stdout
+++ b/tests/ui/async-await/future-sizes/async-awaiting-fut.stdout
@@ -5,14 +5,6 @@ print-type-size     variant `Suspend0`: 3077 bytes
 print-type-size         local `.__awaitee`: 3077 bytes, type: {async fn body of calls_fut<{async fn body of big_fut()}>()}
 print-type-size     variant `Returned`: 0 bytes
 print-type-size     variant `Panicked`: 0 bytes
-print-type-size type: `std::mem::ManuallyDrop<{async fn body of calls_fut<{async fn body of big_fut()}>()}>`: 3077 bytes, alignment: 1 bytes
-print-type-size     field `.value`: 3077 bytes
-print-type-size type: `std::mem::MaybeDangling<{async fn body of calls_fut<{async fn body of big_fut()}>()}>`: 3077 bytes, alignment: 1 bytes
-print-type-size     field `.0`: 3077 bytes
-print-type-size type: `std::mem::MaybeUninit<{async fn body of calls_fut<{async fn body of big_fut()}>()}>`: 3077 bytes, alignment: 1 bytes
-print-type-size     variant `MaybeUninit`: 3077 bytes
-print-type-size         field `.uninit`: 0 bytes
-print-type-size         field `.value`: 3077 bytes
 print-type-size type: `{async fn body of calls_fut<{async fn body of big_fut()}>()}`: 3077 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Unresumed`: 1025 bytes
@@ -36,14 +28,6 @@ print-type-size     variant `Returned`: 1025 bytes
 print-type-size         upvar `.fut`: 1025 bytes
 print-type-size     variant `Panicked`: 1025 bytes
 print-type-size         upvar `.fut`: 1025 bytes
-print-type-size type: `std::mem::ManuallyDrop<{async fn body of big_fut()}>`: 1025 bytes, alignment: 1 bytes
-print-type-size     field `.value`: 1025 bytes
-print-type-size type: `std::mem::MaybeDangling<{async fn body of big_fut()}>`: 1025 bytes, alignment: 1 bytes
-print-type-size     field `.0`: 1025 bytes
-print-type-size type: `std::mem::MaybeUninit<{async fn body of big_fut()}>`: 1025 bytes, alignment: 1 bytes
-print-type-size     variant `MaybeUninit`: 1025 bytes
-print-type-size         field `.uninit`: 0 bytes
-print-type-size         field `.value`: 1025 bytes
 print-type-size type: `{async fn body of big_fut()}`: 1025 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Unresumed`: 1024 bytes
@@ -85,22 +69,6 @@ print-type-size     field `._vtable_ptr`: 8 bytes
 print-type-size     field `._phantom`: 0 bytes
 print-type-size type: `std::ptr::NonNull<std::ptr::metadata::VTable>`: 8 bytes, alignment: 8 bytes
 print-type-size     field `.pointer`: 8 bytes
-print-type-size type: `std::mem::ManuallyDrop<bool>`: 1 bytes, alignment: 1 bytes
-print-type-size     field `.value`: 1 bytes
-print-type-size type: `std::mem::ManuallyDrop<{async fn body of wait()}>`: 1 bytes, alignment: 1 bytes
-print-type-size     field `.value`: 1 bytes
-print-type-size type: `std::mem::MaybeDangling<bool>`: 1 bytes, alignment: 1 bytes
-print-type-size     field `.0`: 1 bytes
-print-type-size type: `std::mem::MaybeDangling<{async fn body of wait()}>`: 1 bytes, alignment: 1 bytes
-print-type-size     field `.0`: 1 bytes
-print-type-size type: `std::mem::MaybeUninit<bool>`: 1 bytes, alignment: 1 bytes
-print-type-size     variant `MaybeUninit`: 1 bytes
-print-type-size         field `.uninit`: 0 bytes
-print-type-size         field `.value`: 1 bytes
-print-type-size type: `std::mem::MaybeUninit<{async fn body of wait()}>`: 1 bytes, alignment: 1 bytes
-print-type-size     variant `MaybeUninit`: 1 bytes
-print-type-size         field `.uninit`: 0 bytes
-print-type-size         field `.value`: 1 bytes
 print-type-size type: `std::task::Poll<()>`: 1 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Ready`: 0 bytes

--- a/tests/ui/async-await/future-sizes/large-arg.stdout
+++ b/tests/ui/async-await/future-sizes/large-arg.stdout
@@ -5,14 +5,6 @@ print-type-size     variant `Suspend0`: 3075 bytes
 print-type-size         local `.__awaitee`: 3075 bytes, type: {async fn body of a<[u8; 1024]>()}
 print-type-size     variant `Returned`: 0 bytes
 print-type-size     variant `Panicked`: 0 bytes
-print-type-size type: `std::mem::ManuallyDrop<{async fn body of a<[u8; 1024]>()}>`: 3075 bytes, alignment: 1 bytes
-print-type-size     field `.value`: 3075 bytes
-print-type-size type: `std::mem::MaybeDangling<{async fn body of a<[u8; 1024]>()}>`: 3075 bytes, alignment: 1 bytes
-print-type-size     field `.0`: 3075 bytes
-print-type-size type: `std::mem::MaybeUninit<{async fn body of a<[u8; 1024]>()}>`: 3075 bytes, alignment: 1 bytes
-print-type-size     variant `MaybeUninit`: 3075 bytes
-print-type-size         field `.uninit`: 0 bytes
-print-type-size         field `.value`: 3075 bytes
 print-type-size type: `{async fn body of a<[u8; 1024]>()}`: 3075 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Unresumed`: 1024 bytes
@@ -24,14 +16,6 @@ print-type-size     variant `Returned`: 1024 bytes
 print-type-size         upvar `.t`: 1024 bytes
 print-type-size     variant `Panicked`: 1024 bytes
 print-type-size         upvar `.t`: 1024 bytes
-print-type-size type: `std::mem::ManuallyDrop<{async fn body of b<[u8; 1024]>()}>`: 2050 bytes, alignment: 1 bytes
-print-type-size     field `.value`: 2050 bytes
-print-type-size type: `std::mem::MaybeDangling<{async fn body of b<[u8; 1024]>()}>`: 2050 bytes, alignment: 1 bytes
-print-type-size     field `.0`: 2050 bytes
-print-type-size type: `std::mem::MaybeUninit<{async fn body of b<[u8; 1024]>()}>`: 2050 bytes, alignment: 1 bytes
-print-type-size     variant `MaybeUninit`: 2050 bytes
-print-type-size         field `.uninit`: 0 bytes
-print-type-size         field `.value`: 2050 bytes
 print-type-size type: `{async fn body of b<[u8; 1024]>()}`: 2050 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Unresumed`: 1024 bytes
@@ -43,14 +27,6 @@ print-type-size     variant `Returned`: 1024 bytes
 print-type-size         upvar `.t`: 1024 bytes
 print-type-size     variant `Panicked`: 1024 bytes
 print-type-size         upvar `.t`: 1024 bytes
-print-type-size type: `std::mem::ManuallyDrop<{async fn body of c<[u8; 1024]>()}>`: 1025 bytes, alignment: 1 bytes
-print-type-size     field `.value`: 1025 bytes
-print-type-size type: `std::mem::MaybeDangling<{async fn body of c<[u8; 1024]>()}>`: 1025 bytes, alignment: 1 bytes
-print-type-size     field `.0`: 1025 bytes
-print-type-size type: `std::mem::MaybeUninit<{async fn body of c<[u8; 1024]>()}>`: 1025 bytes, alignment: 1 bytes
-print-type-size     variant `MaybeUninit`: 1025 bytes
-print-type-size         field `.uninit`: 0 bytes
-print-type-size         field `.value`: 1025 bytes
 print-type-size type: `std::task::Poll<[u8; 1024]>`: 1025 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Ready`: 1024 bytes

--- a/tests/ui/print_type_sizes/async.stdout
+++ b/tests/ui/print_type_sizes/async.stdout
@@ -10,14 +10,6 @@ print-type-size     variant `Returned`: 8192 bytes
 print-type-size         upvar `.arg`: 8192 bytes
 print-type-size     variant `Panicked`: 8192 bytes
 print-type-size         upvar `.arg`: 8192 bytes
-print-type-size type: `std::mem::ManuallyDrop<[u8; 8192]>`: 8192 bytes, alignment: 1 bytes
-print-type-size     field `.value`: 8192 bytes
-print-type-size type: `std::mem::MaybeDangling<[u8; 8192]>`: 8192 bytes, alignment: 1 bytes
-print-type-size     field `.0`: 8192 bytes
-print-type-size type: `std::mem::MaybeUninit<[u8; 8192]>`: 8192 bytes, alignment: 1 bytes
-print-type-size     variant `MaybeUninit`: 8192 bytes
-print-type-size         field `.uninit`: 0 bytes
-print-type-size         field `.value`: 8192 bytes
 print-type-size type: `std::task::Context<'_>`: 32 bytes, alignment: 8 bytes
 print-type-size     field `.waker`: 8 bytes
 print-type-size     field `.local_waker`: 8 bytes
@@ -47,14 +39,6 @@ print-type-size     field `._vtable_ptr`: 8 bytes
 print-type-size     field `._phantom`: 0 bytes
 print-type-size type: `std::ptr::NonNull<std::ptr::metadata::VTable>`: 8 bytes, alignment: 8 bytes
 print-type-size     field `.pointer`: 8 bytes
-print-type-size type: `std::mem::ManuallyDrop<{async fn body of wait()}>`: 1 bytes, alignment: 1 bytes
-print-type-size     field `.value`: 1 bytes
-print-type-size type: `std::mem::MaybeDangling<{async fn body of wait()}>`: 1 bytes, alignment: 1 bytes
-print-type-size     field `.0`: 1 bytes
-print-type-size type: `std::mem::MaybeUninit<{async fn body of wait()}>`: 1 bytes, alignment: 1 bytes
-print-type-size     variant `MaybeUninit`: 1 bytes
-print-type-size         field `.uninit`: 0 bytes
-print-type-size         field `.value`: 1 bytes
 print-type-size type: `std::task::Poll<()>`: 1 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Ready`: 0 bytes

--- a/tests/ui/print_type_sizes/coroutine_discr_placement.stdout
+++ b/tests/ui/print_type_sizes/coroutine_discr_placement.stdout
@@ -9,11 +9,3 @@ print-type-size         padding: 3 bytes
 print-type-size         local `.z`: 4 bytes, alignment: 4 bytes
 print-type-size     variant `Returned`: 0 bytes
 print-type-size     variant `Panicked`: 0 bytes
-print-type-size type: `std::mem::ManuallyDrop<i32>`: 4 bytes, alignment: 4 bytes
-print-type-size     field `.value`: 4 bytes
-print-type-size type: `std::mem::MaybeDangling<i32>`: 4 bytes, alignment: 4 bytes
-print-type-size     field `.0`: 4 bytes
-print-type-size type: `std::mem::MaybeUninit<i32>`: 4 bytes, alignment: 4 bytes
-print-type-size     variant `MaybeUninit`: 4 bytes
-print-type-size         field `.uninit`: 0 bytes
-print-type-size         field `.value`: 4 bytes


### PR DESCRIPTION
When computing coroutine layout, each saved local is wrapped in `MaybeUninit`, which chains through `ManuallyDrop` and `MaybeDangling` before reaching `T`. This adds 3 extra layout_of queries per field.

For deeply nested async functions (e.g. matrix-sdk with many `#[instrument]`-ed async calls), this extra `MaybeUninit` accumulated across all nesting levels and easily overflowed the default recursion limit (128 as of 1.94)

Instead, compute `layout_of(T)` directly and apply the two effects that `MaybeUninit` provided:

* hide niches:
  uninitialized fields have no valid_range guarantees,
  so reset scalar ranges to their full width
  like other `is_special_no_niche` types.
* mark variants inhabited:
  `MaybeUninit` hardcoded `uninhabited: false`, so we follow.
  Otherwise the field may be seen as unreachable and get optimized away
  
According to [WaffleLapkin's analysis](https://github.com/rust-lang/rust/issues/152942#issuecomment-4025155066), the extra layer added 32 queries in the repro. Along with this fix, as we completely remove `MaybeUninit`, I guess the queries will be down to `131 - (32 * 3) = 35` queries. We save around 96 queries! See <https://github.com/rust-lang/rust/pull/153620#issuecomment-4028217953>

Fixes rust-lang/rust#152942