### PR TITLE
Remove `TyCtxt::node_span_lint` method

### DIFF
--- a/compiler/rustc_middle/src/lint.rs
+++ b/compiler/rustc_middle/src/lint.rs
@@ -298,7 +298,6 @@ fn explain_lint_level_source(
 /// If you are looking to implement a lint, look for higher level functions,
 /// for example:
 /// - [`TyCtxt::emit_node_span_lint`]
-/// - [`TyCtxt::node_span_lint`]
 /// - [`TyCtxt::node_lint`]
 /// - `LintContext::opt_span_lint`
 ///
@@ -488,7 +487,6 @@ pub fn lint_level(
 /// for example:
 ///
 /// - [`TyCtxt::emit_node_span_lint`]
-/// - [`TyCtxt::node_span_lint`]
 /// - [`TyCtxt::node_lint`]
 /// - `LintContext::opt_span_lint`
 ///

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2542,21 +2542,6 @@ impl<'tcx> TyCtxt<'tcx> {
         diag_lint_level(self.sess, lint, level, Some(span.into()), decorator)
     }
 
-    /// Emit a lint at the appropriate level for a hir node, with an associated span.
-    ///
-    /// [`lint_level`]: rustc_middle::lint::lint_level#decorate-signature
-    #[track_caller]
-    pub fn node_span_lint(
-        self,
-        lint: &'static Lint,
-        hir_id: HirId,
-        span: impl Into<MultiSpan>,
-        decorate: impl for<'a, 'b> FnOnce(&'b mut Diag<'a, ()>),
-    ) {
-        let level = self.lint_level_at_node(lint, hir_id);
-        lint_level(self.sess, lint, level, Some(span.into()), decorate);
-    }
-
     /// Find the appropriate span where `use` and outer attributes can be inserted at.
     pub fn crate_level_attribute_injection_span(self) -> Span {
         let node = self.hir_node(hir::CRATE_HIR_ID);

--- a/src/librustdoc/passes/lint/bare_urls.rs
+++ b/src/librustdoc/passes/lint/bare_urls.rs
@@ -6,7 +6,7 @@ use std::mem;
 use std::sync::LazyLock;
 
 use regex::Regex;
-use rustc_errors::Applicability;
+use rustc_errors::{Applicability, DiagDecorator};
 use rustc_hir::HirId;
 use rustc_resolve::rustdoc::pulldown_cmark::{Event, Parser, Tag};
 use rustc_resolve::rustdoc::source_span_for_markdown_range;
@@ -24,30 +24,35 @@ pub(super) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &
         let maybe_sp = source_span_for_markdown_range(cx.tcx, dox, &range, &item.attrs.doc_strings)
             .map(|(sp, _)| sp);
         let sp = maybe_sp.unwrap_or_else(|| item.attr_span(cx.tcx));
-        cx.tcx.node_span_lint(crate::lint::BARE_URLS, hir_id, sp, |lint| {
-            lint.primary_message(msg)
-                .note("bare URLs are not automatically turned into clickable links");
-            // The fallback of using the attribute span is suitable for
-            // highlighting where the error is, but not for placing the < and >
-            if let Some(sp) = maybe_sp {
-                if let Some(without_brackets) = without_brackets {
-                    lint.multipart_suggestion(
-                        "use an automatic link instead",
-                        vec![(sp, format!("<{without_brackets}>"))],
-                        Applicability::MachineApplicable,
-                    );
-                } else {
-                    lint.multipart_suggestion(
-                        "use an automatic link instead",
-                        vec![
-                            (sp.shrink_to_lo(), "<".to_string()),
-                            (sp.shrink_to_hi(), ">".to_string()),
-                        ],
-                        Applicability::MachineApplicable,
-                    );
+        cx.tcx.emit_node_span_lint(
+            crate::lint::BARE_URLS,
+            hir_id,
+            sp,
+            DiagDecorator(|lint| {
+                lint.primary_message(msg)
+                    .note("bare URLs are not automatically turned into clickable links");
+                // The fallback of using the attribute span is suitable for
+                // highlighting where the error is, but not for placing the < and >
+                if let Some(sp) = maybe_sp {
+                    if let Some(without_brackets) = without_brackets {
+                        lint.multipart_suggestion(
+                            "use an automatic link instead",
+                            vec![(sp, format!("<{without_brackets}>"))],
+                            Applicability::MachineApplicable,
+                        );
+                    } else {
+                        lint.multipart_suggestion(
+                            "use an automatic link instead",
+                            vec![
+                                (sp.shrink_to_lo(), "<".to_string()),
+                                (sp.shrink_to_hi(), ">".to_string()),
+                            ],
+                            Applicability::MachineApplicable,
+                        );
+                    }
                 }
-            }
-        });
+            }),
+        );
     };
 
     let mut p = Parser::new_ext(dox, main_body_opts()).into_offset_iter();

--- a/src/tools/clippy/clippy.toml
+++ b/src/tools/clippy/clippy.toml
@@ -13,5 +13,5 @@ path = "rustc_lint::context::LintContext::span_lint"
 reason = "this function does not add a link to our documentation; please use the `clippy_utils::diagnostics::span_lint*` functions instead"
 
 [[disallowed-methods]]
-path = "rustc_middle::ty::context::TyCtxt::node_span_lint"
+path = "rustc_middle::ty::context::TyCtxt::emit_node_span_lint"
 reason = "this function does not add a link to our documentation; please use the `clippy_utils::diagnostics::span_lint_hir*` functions instead"

--- a/src/tools/clippy/clippy_utils/src/diagnostics.rs
+++ b/src/tools/clippy/clippy_utils/src/diagnostics.rs
@@ -326,14 +326,14 @@ pub fn span_lint_hir_and_then(
     f: impl FnOnce(&mut Diag<'_, ()>),
 ) {
     #[expect(clippy::disallowed_methods)]
-    cx.tcx.node_span_lint(lint, hir_id, sp, |diag| {
+    cx.tcx.emit_node_span_lint(lint, hir_id, sp, rustc_errors::DiagDecorator(|diag| {
         diag.primary_message(msg);
         f(diag);
         docs_link(diag, lint);
 
         #[cfg(debug_assertions)]
         validate_diag(diag);
-    });
+    }));
 }
 
 /// Add a span lint with a suggestion on how to fix it.

--- a/src/tools/clippy/tests/ui-internal/disallow_span_lint.rs
+++ b/src/tools/clippy/tests/ui-internal/disallow_span_lint.rs
@@ -6,7 +6,7 @@ extern crate rustc_hir;
 extern crate rustc_lint;
 extern crate rustc_middle;
 
-use rustc_errors::{DiagMessage, MultiSpan};
+use rustc_errors::{DiagDecorator, DiagMessage, MultiSpan};
 use rustc_hir::hir_id::HirId;
 use rustc_lint::{Lint, LintContext};
 use rustc_middle::ty::TyCtxt;
@@ -19,10 +19,10 @@ pub fn a(cx: impl LintContext, lint: &'static Lint, span: impl Into<MultiSpan>, 
 }
 
 pub fn b(tcx: TyCtxt<'_>, lint: &'static Lint, hir_id: HirId, span: impl Into<MultiSpan>, msg: impl Into<DiagMessage>) {
-    tcx.node_span_lint(lint, hir_id, span, |lint| {
+    tcx.emit_node_span_lint(lint, hir_id, span, DiagDecorator(|lint| {
         //~^ disallowed_methods
         lint.primary_message(msg);
-    });
+    }));
 }
 
 fn main() {}


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/153099.

One less obstacle before we can remove `lint_level` function. :)

r? @JonathanBrouwer 