### PR TITLE
Ping fmease on parser modifications

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1012,6 +1012,13 @@ cc = ["@lcnr"]
 message = "HIR ty lowering was modified"
 cc = ["@fmease"]
 
+[mentions."compiler/rustc_parse"]
+message = """
+The parser was modified, potentially altering the grammar of (stable) Rust
+which would be a breaking change.
+"""
+cc = ["@fmease"]
+
 [mentions."library/core/src/mem/type_info.rs"]
 message = """
 The reflection data structures are tied exactly to the implementation


### PR DESCRIPTION
From time to time innocuous-seeming PRs get submitted and sometimes even approved that unbeknownst to their author and to reviewers change the grammar of (stable) Rust which would be a breaking change; often they only meant to tweak diagnostics.

I sometimes catch such PRs before they get merged but I want to make it a lot harder for them to slip through the cracks going forward.

I'm going to list recent examples to paint a picture (note: this is not about blame!):

1. https://github.com/rust-lang/rust/pull/149728#pullrequestreview-3916816500 (2026)
   * caught before merge but after approval
   * PR unapproved for now
2. https://github.com/rust-lang/rust/issues/152501 (2026)
   * caught after merge of rust-lang/rust#149489
   * fixed & backported
3. https://github.com/rust-lang/rust/issues/152499 (2026)
   * caught after merge of rust-lang/rust#149667
   * fixed & backported
4. https://github.com/rust-lang/rust/pull/151960#discussion_r2751649272 (2026)
   * caught right after submission
   * the approach was thus changed
5. rust-lang/rust#148238 (2025)
   * caught after merge of rust-lang/rust#118947
   * still unaddressed
6. https://github.com/rust-lang/rust/pull/144386#pullrequestreview-3052288562 (2025)
   * caught right after submission
   * crater & T-lang were activated by me
7. https://github.com/rust-lang/rust/pull/119042#discussion_r1429189817 (2023)
   * caught right after submission
   * the approach was thus changed
8. https://github.com/rust-lang/rust/issues/103534 (2022)
   * caught way later
   * partially addressed

Why not just post a note without pinging me? Well, due to them not failing CI and generally due to (friendly) botspam, such comments just get lost or sometimes even actively ignored.

Of course, I'm not able to catch everything. E.g., I didn't notice issue https://github.com/rust-lang/rust/issues/146417 before PR https://github.com/rust-lang/rust/pull/139858 was merged despite having skimmed its diff and more importantly, I as a reviewer missed the blatantly obvious https://github.com/rust-lang/rust/issues/144958 before merge.

Separately, off and on over the span of one year I've worked on a Rust parser that now has >99% accuracy/parity with rustc according to some metrics (this includes stable + unstable + internal syntax) and which I'm now using to detect such regressions and issues in general among other things (e.g., https://github.com/rust-lang/rust/issues/152499 and https://github.com/rust-lang/rust/issues/152820 were found this way, more to come). I'm pretty invested, let's say.

r? me