### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2622,9 +2622,9 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-foundation"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags",
 ]
@@ -2637,9 +2637,9 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-io-kit"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
@@ -5315,9 +5315,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.38.2"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efc19935b4b66baa6f654ac7924c192f55b175c00a7ab72410fc24284dacda8"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
 dependencies = [
  "libc",
  "objc2-core-foundation",

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -1371,11 +1371,16 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
             ItemKind::Struct(ident, generics, vdata) => {
                 self.with_tilde_const(Some(TildeConstReason::Struct { span: item.span }), |this| {
                     // Scalable vectors can only be tuple structs
-                    let is_scalable_vector =
-                        item.attrs.iter().any(|attr| attr.has_name(sym::rustc_scalable_vector));
-                    if is_scalable_vector && !matches!(vdata, VariantData::Tuple(..)) {
-                        this.dcx()
-                            .emit_err(errors::ScalableVectorNotTupleStruct { span: item.span });
+                    let scalable_vector_attr =
+                        item.attrs.iter().find(|attr| attr.has_name(sym::rustc_scalable_vector));
+                    if let Some(attr) = scalable_vector_attr {
+                        if !matches!(vdata, VariantData::Tuple(..)) {
+                            this.dcx()
+                                .emit_err(errors::ScalableVectorNotTupleStruct { span: item.span });
+                        }
+                        if !self.sess.target.arch.supports_scalable_vectors() {
+                            this.dcx().emit_err(errors::ScalableVectorBadArch { span: attr.span });
+                        }
                     }
 
                     match vdata {

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -1133,3 +1133,10 @@ pub(crate) struct ScalableVectorNotTupleStruct {
     #[primary_span]
     pub span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag("scalable vectors are not supported on this architecture")]
+pub(crate) struct ScalableVectorBadArch {
+    #[primary_span]
+    pub span: Span,
+}

--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -934,6 +934,7 @@ impl<'a, G: EmissionGuarantee> Diag<'a, G> {
         self
     } }
 
+    with_fn! { with_span_suggestion_with_style,
     /// [`Diag::span_suggestion()`] but you can set the [`SuggestionStyle`].
     pub fn span_suggestion_with_style(
         &mut self,
@@ -956,7 +957,7 @@ impl<'a, G: EmissionGuarantee> Diag<'a, G> {
             applicability,
         });
         self
-    }
+    } }
 
     with_fn! { with_span_suggestion_verbose,
     /// Always show the suggested change.

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -964,6 +964,9 @@ pub fn check_unused_or_stable_features(tcx: TyCtxt<'_>) {
     let mut lang_features = UnordSet::default();
     for EnabledLangFeature { gate_name, attr_sp, stable_since } in enabled_lang_features {
         if let Some(version) = stable_since {
+            // Mark the feature as enabled, to ensure that it is not marked as unused.
+            let _ = tcx.features().enabled(*gate_name);
+
             // Warn if the user has enabled an already-stable lang feature.
             unnecessary_stable_feature_lint(tcx, *attr_sp, *gate_name, *version);
         }
@@ -1021,6 +1024,9 @@ pub fn check_unused_or_stable_features(tcx: TyCtxt<'_>) {
             if let FeatureStability::AcceptedSince(since) = stability
                 && let Some(span) = remaining_lib_features.get(&feature)
             {
+                // Mark the feature as enabled, to ensure that it is not marked as unused.
+                let _ = tcx.features().enabled(feature);
+
                 // Warn if the user has enabled an already-stable lib feature.
                 if let Some(implies) = all_implications.get(&feature) {
                     unnecessary_partially_stable_feature_lint(tcx, *span, feature, *implies, since);

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1956,6 +1956,19 @@ impl Arch {
             | X86_64 | Xtensa => true,
         }
     }
+
+    /// Whether `#[rustc_scalable_vector]` is supported for a target architecture
+    pub fn supports_scalable_vectors(&self) -> bool {
+        use Arch::*;
+
+        match self {
+            AArch64 | RiscV32 | RiscV64 => true,
+            AmdGpu | Arm | Arm64EC | Avr | Bpf | CSky | Hexagon | LoongArch32 | LoongArch64
+            | M68k | Mips | Mips32r6 | Mips64 | Mips64r6 | Msp430 | Nvptx64 | PowerPC
+            | PowerPC64 | S390x | Sparc | Sparc64 | SpirV | Wasm32 | Wasm64 | X86 | X86_64
+            | Xtensa | Other(_) => false,
+        }
+    }
 }
 
 crate::target_spec_enum! {

--- a/src/bootstrap/Cargo.lock
+++ b/src/bootstrap/Cargo.lock
@@ -472,18 +472,18 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-foundation"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "objc2-io-kit"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
@@ -743,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.38.2"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efc19935b4b66baa6f654ac7924c192f55b175c00a7ab72410fc24284dacda8"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
 dependencies = [
  "libc",
  "memchr",

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -57,7 +57,7 @@ walkdir = "2.4"
 xz2 = "0.1"
 
 # Dependencies needed by the build-metrics feature
-sysinfo = { version = "0.38.2", default-features = false, optional = true, features = ["system"] }
+sysinfo = { version = "0.38.4", default-features = false, optional = true, features = ["system"] }
 
 # Dependencies needed by the `tracing` feature
 chrono = { version = "0.4", default-features = false, optional = true, features = ["now", "std"] }

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -109,13 +109,15 @@ pub(crate) struct MarkdownWithToc<'a> {
     pub(crate) edition: Edition,
     pub(crate) playground: &'a Option<Playground>,
 }
-/// A tuple struct like `Markdown` that renders the markdown escaping HTML tags
+
+/// A struct like `Markdown` that renders the markdown escaping HTML tags
 /// and includes no paragraph tags.
 pub(crate) struct MarkdownItemInfo<'a> {
     pub(crate) content: &'a str,
     pub(crate) links: &'a [RenderedLink],
     pub(crate) ids: &'a mut IdMap,
 }
+
 /// A tuple struct like `Markdown` that renders only the first paragraph.
 pub(crate) struct MarkdownSummaryLine<'a>(pub &'a str, pub &'a [RenderedLink]);
 
@@ -1497,10 +1499,10 @@ impl<'a> MarkdownItemInfo<'a> {
             let p = SpannedLinkReplacer::new(p, links);
             let p = footnotes::Footnotes::new(p, existing_footnotes);
             let p = TableWrapper::new(p.map(|(ev, _)| ev));
-            let p = p.filter(|event| {
-                !matches!(event, Event::Start(Tag::Paragraph) | Event::End(TagEnd::Paragraph))
-            });
-            html::write_html_fmt(&mut f, p)
+            // in legacy wrap mode, strip <p> elements to avoid them inserting newlines
+            html::write_html_fmt(&mut f, p)?;
+
+            Ok(())
         })
     }
 }

--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -472,7 +472,7 @@ fn test_markdown_html_escape() {
         let mut idmap = IdMap::new();
         let mut output = String::new();
         MarkdownItemInfo::new(input, &[], &mut idmap).write_into(&mut output).unwrap();
-        assert_eq!(output, expect, "original: {}", input);
+        assert_eq!(output, format!("<p>{}</p>\n", expect), "original: {}", input);
     }
 
     t("`Struct<'a, T>`", "<code>Struct&lt;'a, T&gt;</code>");

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1585,7 +1585,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	color: var(--main-color);
 	background-color: var(--stab-background-color);
 	width: fit-content;
-	white-space: pre-wrap;
 	border-radius: 3px;
 	display: inline;
 	vertical-align: baseline;

--- a/src/librustdoc/passes/lint/redundant_explicit_links.rs
+++ b/src/librustdoc/passes/lint/redundant_explicit_links.rs
@@ -165,7 +165,7 @@ fn check_inline_or_reference_unknown_redundancy(
         fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, ()> {
             let Self { explicit_span, display_span, link_span, display_link } = self;
 
-            let mut diag = Diag::new(dcx, level, "redundant explicit link target")
+            Diag::new(dcx, level, "redundant explicit link target")
                 .with_span_label(
                     explicit_span,
                     "explicit target is redundant",
@@ -176,17 +176,15 @@ fn check_inline_or_reference_unknown_redundancy(
                 )
                 .with_note(
                     "when a link's destination is not specified,\nthe label is used to resolve intra-doc links"
-                );
-            // FIXME (GuillaumeGomez): We cannot use `derive(Diagnostic)` because of this method.
-            // FIXME2 (GuillaumeGomez): Why isn't there a `with_` equivalent for this method?
-            diag.span_suggestion_with_style(
-                link_span,
-                "remove explicit link target",
-                format!("[{}]", display_link),
-                Applicability::MaybeIncorrect,
-                SuggestionStyle::ShowAlways,
-            );
-            diag
+                )
+                // FIXME (GuillaumeGomez): We cannot use `derive(Diagnostic)` because of this method.
+                .with_span_suggestion_with_style(
+                    link_span,
+                    "remove explicit link target",
+                    format!("[{}]", display_link),
+                    Applicability::MaybeIncorrect,
+                    SuggestionStyle::ShowAlways,
+                )
         }
     }
 
@@ -267,7 +265,7 @@ fn check_reference_redundancy(
         fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, ()> {
             let Self { explicit_span, display_span, def_span, link_span, display_link } = self;
 
-            let mut diag = Diag::new(dcx, level, "redundant explicit link target")
+            Diag::new(dcx, level, "redundant explicit link target")
                 .with_span_label(explicit_span, "explicit target is redundant")
                 .with_span_label(
                     display_span,
@@ -276,17 +274,15 @@ fn check_reference_redundancy(
                 .with_span_note(def_span, "referenced explicit link target defined here")
                 .with_note(
                     "when a link's destination is not specified,\nthe label is used to resolve intra-doc links"
-                );
-            // FIXME (GuillaumeGomez): We cannot use `derive(Diagnostic)` because of this method.
-            // FIXME2 (GuillaumeGomez): Why isn't there a `with_` equivalent for this method?
-            diag.span_suggestion_with_style(
-                link_span,
-                "remove explicit link target",
-                format!("[{}]", display_link),
-                Applicability::MaybeIncorrect,
-                SuggestionStyle::ShowAlways,
-            );
-            diag
+                )
+                // FIXME (GuillaumeGomez): We cannot use `derive(Diagnostic)` because of this method.
+                .with_span_suggestion_with_style(
+                    link_span,
+                    "remove explicit link target",
+                    format!("[{}]", display_link),
+                    Applicability::MaybeIncorrect,
+                    SuggestionStyle::ShowAlways,
+                )
         }
     }
 

--- a/src/tools/compiletest/src/directives/directive_names.rs
+++ b/src/tools/compiletest/src/directives/directive_names.rs
@@ -105,6 +105,7 @@ pub(crate) const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "ignore-powerpc",
     "ignore-powerpc64",
     "ignore-remote",
+    "ignore-riscv32",
     "ignore-riscv64",
     "ignore-rustc-debug-assertions",
     "ignore-rustc_abi-x86-sse2",

--- a/src/tools/opt-dist/Cargo.toml
+++ b/src/tools/opt-dist/Cargo.toml
@@ -10,7 +10,7 @@ log = "0.4"
 anyhow = "1"
 humantime = "2"
 humansize = "2"
-sysinfo = { version = "0.38.2", default-features = false, features = ["disk"] }
+sysinfo = { version = "0.38.4", default-features = false, features = ["disk"] }
 fs_extra = "1"
 camino = "1"
 tar = "0.4"

--- a/tests/rustdoc-html/deprecated.rs
+++ b/tests/rustdoc-html/deprecated.rs
@@ -30,3 +30,8 @@ pub struct W;
 //      'Deprecated: shorthand reason: code$'
 #[deprecated = "shorthand reason: `code`"]
 pub struct X;
+
+//@ matches deprecated/struct.Y.html '//*[@class="stab deprecated"]//p[1]' 'multiple'
+//@ matches deprecated/struct.Y.html '//*[@class="stab deprecated"]//p[2]' 'paragraphs'
+#[deprecated = "multiple\n\nparagraphs"]
+pub struct Y;

--- a/tests/ui/lint/unused-features/stable-features.rs
+++ b/tests/ui/lint/unused-features/stable-features.rs
@@ -1,0 +1,17 @@
+//@ check-pass
+
+#![deny(warnings)]
+#![allow(stable_features)]
+
+// Lang feature
+#![feature(lint_reasons)]
+
+// Lib feature
+#![feature(euclidean_division)]
+
+#[allow(unused_variables, reason = "my reason")]
+fn main() {
+    let x = ();
+
+    let _ = 42.0_f32.div_euclid(3.0);
+}

--- a/tests/ui/lint/unused-features/unused-library-features.rs
+++ b/tests/ui/lint/unused-features/unused-library-features.rs
@@ -5,8 +5,7 @@
 #![feature(step_trait)]
 //~^ ERROR feature `step_trait` is declared but not used
 #![feature(is_sorted)]
-//~^ ERROR feature `is_sorted` is declared but not used
-//~^^ WARN the feature `is_sorted` has been stable since 1.82.0 and no longer requires an attribute to enable
+//~^ WARN the feature `is_sorted` has been stable since 1.82.0 and no longer requires an attribute to enable
 
 // Enabled via cfg_attr, unused
 #![cfg_attr(all(), feature(slice_ptr_get))]

--- a/tests/ui/lint/unused-features/unused-library-features.stderr
+++ b/tests/ui/lint/unused-features/unused-library-features.stderr
@@ -18,17 +18,11 @@ note: the lint level is defined here
 LL | #![deny(unused_features)]
    |         ^^^^^^^^^^^^^^^
 
-error: feature `is_sorted` is declared but not used
-  --> $DIR/unused-library-features.rs:7:12
-   |
-LL | #![feature(is_sorted)]
-   |            ^^^^^^^^^
-
 error: feature `slice_ptr_get` is declared but not used
-  --> $DIR/unused-library-features.rs:12:28
+  --> $DIR/unused-library-features.rs:11:28
    |
 LL | #![cfg_attr(all(), feature(slice_ptr_get))]
    |                            ^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/scalable-vectors/bad-architectures.rs
+++ b/tests/ui/scalable-vectors/bad-architectures.rs
@@ -1,0 +1,13 @@
+//@ ignore-aarch64
+//@ ignore-riscv32
+//@ ignore-riscv64
+
+// Confirm that non-AArch64 and non-RISC-V targets error when compiling scalable vectors
+// (see #153593)
+
+#![crate_type = "lib"]
+#![feature(rustc_attrs)]
+
+#[rustc_scalable_vector(4)]
+//~^ ERROR: scalable vectors are not supported on this architecture
+struct ScalableVec(i32);

--- a/tests/ui/scalable-vectors/bad-architectures.stderr
+++ b/tests/ui/scalable-vectors/bad-architectures.stderr
@@ -1,0 +1,8 @@
+error: scalable vectors are not supported on this architecture
+  --> $DIR/bad-architectures.rs:11:1
+   |
+LL | #[rustc_scalable_vector(4)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/scalable-vectors/fn-trait.rs
+++ b/tests/ui/scalable-vectors/fn-trait.rs
@@ -1,3 +1,4 @@
+//@ only-aarch64
 #![allow(internal_features)]
 #![feature(rustc_attrs)]
 

--- a/tests/ui/scalable-vectors/fn-trait.stderr
+++ b/tests/ui/scalable-vectors/fn-trait.stderr
@@ -1,5 +1,5 @@
 error: scalable vectors cannot be tuple fields
-  --> $DIR/fn-trait.rs:9:8
+  --> $DIR/fn-trait.rs:10:8
    |
 LL |     T: Fn(ScalableSimdFloat),
    |        ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/scalable-vectors/illegal-init.rs
+++ b/tests/ui/scalable-vectors/illegal-init.rs
@@ -1,3 +1,4 @@
+//@ only-aarch64
 #![allow(incomplete_features, internal_features)]
 #![feature(rustc_attrs)]
 

--- a/tests/ui/scalable-vectors/illegal-init.stderr
+++ b/tests/ui/scalable-vectors/illegal-init.stderr
@@ -1,5 +1,5 @@
 error: scalable vector types cannot be initialised using their constructor
-  --> $DIR/illegal_init.rs:8:15
+  --> $DIR/illegal-init.rs:9:15
    |
 LL |     let foo = svint32_t(1);
    |               ^^^^^^^^^ you can create scalable vectors using intrinsics

--- a/tests/ui/scalable-vectors/illformed-element-type.rs
+++ b/tests/ui/scalable-vectors/illformed-element-type.rs
@@ -1,4 +1,5 @@
 //@ compile-flags: --crate-type=lib
+//@ only-aarch64
 #![allow(internal_features)]
 #![feature(extern_types)]
 #![feature(never_type)]

--- a/tests/ui/scalable-vectors/illformed-element-type.stderr
+++ b/tests/ui/scalable-vectors/illformed-element-type.stderr
@@ -1,5 +1,5 @@
 error: element type of a scalable vector must be a primitive scalar
-  --> $DIR/illformed-element-type.rs:15:1
+  --> $DIR/illformed-element-type.rs:16:1
    |
 LL | struct TyChar(char);
    | ^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL | struct TyChar(char);
    = help: only `u*`, `i*`, `f*` and `bool` types are accepted
 
 error: element type of a scalable vector must be a primitive scalar
-  --> $DIR/illformed-element-type.rs:19:1
+  --> $DIR/illformed-element-type.rs:20:1
    |
 LL | struct TyConstPtr(*const u8);
    | ^^^^^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ LL | struct TyConstPtr(*const u8);
    = help: only `u*`, `i*`, `f*` and `bool` types are accepted
 
 error: element type of a scalable vector must be a primitive scalar
-  --> $DIR/illformed-element-type.rs:23:1
+  --> $DIR/illformed-element-type.rs:24:1
    |
 LL | struct TyMutPtr(*mut u8);
    | ^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL | struct TyMutPtr(*mut u8);
    = help: only `u*`, `i*`, `f*` and `bool` types are accepted
 
 error: element type of a scalable vector must be a primitive scalar
-  --> $DIR/illformed-element-type.rs:27:1
+  --> $DIR/illformed-element-type.rs:28:1
    |
 LL | struct TyStruct(Foo);
    | ^^^^^^^^^^^^^^^
@@ -31,7 +31,7 @@ LL | struct TyStruct(Foo);
    = help: only `u*`, `i*`, `f*` and `bool` types are accepted
 
 error: element type of a scalable vector must be a primitive scalar
-  --> $DIR/illformed-element-type.rs:31:1
+  --> $DIR/illformed-element-type.rs:32:1
    |
 LL | struct TyEnum(Bar);
    | ^^^^^^^^^^^^^
@@ -39,7 +39,7 @@ LL | struct TyEnum(Bar);
    = help: only `u*`, `i*`, `f*` and `bool` types are accepted
 
 error: element type of a scalable vector must be a primitive scalar
-  --> $DIR/illformed-element-type.rs:35:1
+  --> $DIR/illformed-element-type.rs:36:1
    |
 LL | struct TyUnion(Baz);
    | ^^^^^^^^^^^^^^
@@ -47,7 +47,7 @@ LL | struct TyUnion(Baz);
    = help: only `u*`, `i*`, `f*` and `bool` types are accepted
 
 error: element type of a scalable vector must be a primitive scalar
-  --> $DIR/illformed-element-type.rs:39:1
+  --> $DIR/illformed-element-type.rs:40:1
    |
 LL | struct TyForeign(Qux);
    | ^^^^^^^^^^^^^^^^
@@ -55,7 +55,7 @@ LL | struct TyForeign(Qux);
    = help: only `u*`, `i*`, `f*` and `bool` types are accepted
 
 error: element type of a scalable vector must be a primitive scalar
-  --> $DIR/illformed-element-type.rs:43:1
+  --> $DIR/illformed-element-type.rs:44:1
    |
 LL | struct TyArray([u32; 4]);
    | ^^^^^^^^^^^^^^
@@ -63,7 +63,7 @@ LL | struct TyArray([u32; 4]);
    = help: only `u*`, `i*`, `f*` and `bool` types are accepted
 
 error: element type of a scalable vector must be a primitive scalar
-  --> $DIR/illformed-element-type.rs:47:1
+  --> $DIR/illformed-element-type.rs:48:1
    |
 LL | struct TySlice([u32]);
    | ^^^^^^^^^^^^^^
@@ -71,7 +71,7 @@ LL | struct TySlice([u32]);
    = help: only `u*`, `i*`, `f*` and `bool` types are accepted
 
 error: element type of a scalable vector must be a primitive scalar
-  --> $DIR/illformed-element-type.rs:51:1
+  --> $DIR/illformed-element-type.rs:52:1
    |
 LL | struct TyRef<'a>(&'a u32);
    | ^^^^^^^^^^^^^^^^
@@ -79,7 +79,7 @@ LL | struct TyRef<'a>(&'a u32);
    = help: only `u*`, `i*`, `f*` and `bool` types are accepted
 
 error: element type of a scalable vector must be a primitive scalar
-  --> $DIR/illformed-element-type.rs:55:1
+  --> $DIR/illformed-element-type.rs:56:1
    |
 LL | struct TyFnPtr(fn(u32) -> u32);
    | ^^^^^^^^^^^^^^
@@ -87,7 +87,7 @@ LL | struct TyFnPtr(fn(u32) -> u32);
    = help: only `u*`, `i*`, `f*` and `bool` types are accepted
 
 error: element type of a scalable vector must be a primitive scalar
-  --> $DIR/illformed-element-type.rs:59:1
+  --> $DIR/illformed-element-type.rs:60:1
    |
 LL | struct TyDyn(dyn std::io::Write);
    | ^^^^^^^^^^^^
@@ -95,7 +95,7 @@ LL | struct TyDyn(dyn std::io::Write);
    = help: only `u*`, `i*`, `f*` and `bool` types are accepted
 
 error: element type of a scalable vector must be a primitive scalar
-  --> $DIR/illformed-element-type.rs:63:1
+  --> $DIR/illformed-element-type.rs:64:1
    |
 LL | struct TyNever(!);
    | ^^^^^^^^^^^^^^
@@ -103,7 +103,7 @@ LL | struct TyNever(!);
    = help: only `u*`, `i*`, `f*` and `bool` types are accepted
 
 error: element type of a scalable vector must be a primitive scalar
-  --> $DIR/illformed-element-type.rs:67:1
+  --> $DIR/illformed-element-type.rs:68:1
    |
 LL | struct TyTuple((u32, u32));
    | ^^^^^^^^^^^^^^
@@ -111,7 +111,7 @@ LL | struct TyTuple((u32, u32));
    = help: only `u*`, `i*`, `f*` and `bool` types are accepted
 
 error: element type of a scalable vector must be a primitive scalar
-  --> $DIR/illformed-element-type.rs:77:1
+  --> $DIR/illformed-element-type.rs:78:1
    |
 LL | struct TyInvalidAlias(InvalidAlias);
    | ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/scalable-vectors/illformed-tuples-of-scalable-vectors.rs
+++ b/tests/ui/scalable-vectors/illformed-tuples-of-scalable-vectors.rs
@@ -1,4 +1,5 @@
 //@ compile-flags: --crate-type=lib
+//@ only-aarch64
 #![allow(internal_features)]
 #![feature(rustc_attrs)]
 

--- a/tests/ui/scalable-vectors/illformed-tuples-of-scalable-vectors.stderr
+++ b/tests/ui/scalable-vectors/illformed-tuples-of-scalable-vectors.stderr
@@ -1,35 +1,35 @@
 error: scalable vectors must be tuple structs
-  --> $DIR/illformed-tuples-of-scalable-vectors.rs:15:1
+  --> $DIR/illformed-tuples-of-scalable-vectors.rs:16:1
    |
 LL | struct Struct { x: ValidI64, y: ValidI64 }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: all fields in a scalable vector struct must be the same type
-  --> $DIR/illformed-tuples-of-scalable-vectors.rs:19:39
+  --> $DIR/illformed-tuples-of-scalable-vectors.rs:20:39
    |
 LL | struct DifferentVectorTypes(ValidI64, ValidI32);
    |                                       ^^^^^^^^
 
 error: scalable vector structs can only have scalable vector fields
-  --> $DIR/illformed-tuples-of-scalable-vectors.rs:23:23
+  --> $DIR/illformed-tuples-of-scalable-vectors.rs:24:23
    |
 LL | struct NonVectorTypes(u32, u64);
    |                       ^^^
 
 error: scalable vector structs can only have scalable vector fields
-  --> $DIR/illformed-tuples-of-scalable-vectors.rs:27:32
+  --> $DIR/illformed-tuples-of-scalable-vectors.rs:28:32
    |
 LL | struct DifferentNonVectorTypes(u32, u64);
    |                                ^^^
 
 error: scalable vector structs can only have scalable vector fields
-  --> $DIR/illformed-tuples-of-scalable-vectors.rs:31:34
+  --> $DIR/illformed-tuples-of-scalable-vectors.rs:32:34
    |
 LL | struct SomeVectorTypes(ValidI64, u64);
    |                                  ^^^
 
 error: scalable vector structs cannot contain other scalable vector structs
-  --> $DIR/illformed-tuples-of-scalable-vectors.rs:35:20
+  --> $DIR/illformed-tuples-of-scalable-vectors.rs:36:20
    |
 LL | struct NestedTuple(ValidTuple, ValidTuple);
    |                    ^^^^^^^^^^

--- a/tests/ui/scalable-vectors/illformed-within-types.rs
+++ b/tests/ui/scalable-vectors/illformed-within-types.rs
@@ -1,4 +1,5 @@
 //@ compile-flags: --crate-type=lib
+//@ only-aarch64
 #![allow(internal_features)]
 #![feature(rustc_attrs)]
 

--- a/tests/ui/scalable-vectors/illformed-within-types.stderr
+++ b/tests/ui/scalable-vectors/illformed-within-types.stderr
@@ -1,29 +1,29 @@
 error: scalable vectors cannot be fields of a struct
-  --> $DIR/illformed-within-types.rs:9:8
+  --> $DIR/illformed-within-types.rs:10:8
    |
 LL |     x: ValidI64,
    |        ^^^^^^^^
 
 error: scalable vectors cannot be tuple fields
-  --> $DIR/illformed-within-types.rs:11:15
+  --> $DIR/illformed-within-types.rs:12:15
    |
 LL |     in_tuple: (ValidI64,),
    |               ^^^^^^^^^^^
 
 error: scalable vectors cannot be fields of a struct
-  --> $DIR/illformed-within-types.rs:15:20
+  --> $DIR/illformed-within-types.rs:16:20
    |
 LL | struct TupleStruct(ValidI64);
    |                    ^^^^^^^^
 
 error: scalable vectors cannot be fields of a variant
-  --> $DIR/illformed-within-types.rs:19:26
+  --> $DIR/illformed-within-types.rs:20:26
    |
 LL |     StructVariant { _ty: ValidI64 },
    |                          ^^^^^^^^
 
 error: scalable vectors cannot be fields of a variant
-  --> $DIR/illformed-within-types.rs:21:18
+  --> $DIR/illformed-within-types.rs:22:18
    |
 LL |     TupleVariant(ValidI64),
    |                  ^^^^^^^^

--- a/tests/ui/scalable-vectors/illformed.rs
+++ b/tests/ui/scalable-vectors/illformed.rs
@@ -1,4 +1,5 @@
 //@ compile-flags: --crate-type=lib
+//@ only-aarch64
 #![allow(internal_features)]
 #![feature(rustc_attrs)]
 

--- a/tests/ui/scalable-vectors/illformed.stderr
+++ b/tests/ui/scalable-vectors/illformed.stderr
@@ -1,29 +1,29 @@
 error: scalable vectors must be tuple structs
-  --> $DIR/illformed.rs:6:1
+  --> $DIR/illformed.rs:7:1
    |
 LL | struct NoFieldsStructWithElementCount {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: scalable vectors must be tuple structs
-  --> $DIR/illformed.rs:15:1
+  --> $DIR/illformed.rs:16:1
    |
 LL | struct NoFieldsUnitWithElementCount;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: scalable vectors must be tuple structs
-  --> $DIR/illformed.rs:20:1
+  --> $DIR/illformed.rs:21:1
    |
 LL | struct NoFieldsStructWithoutElementCount {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: scalable vectors must be tuple structs
-  --> $DIR/illformed.rs:29:1
+  --> $DIR/illformed.rs:30:1
    |
 LL | struct NoFieldsUnitWithoutElementCount;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: scalable vectors must be tuple structs
-  --> $DIR/illformed.rs:34:1
+  --> $DIR/illformed.rs:35:1
    |
 LL | / struct MultipleFieldsStructWithElementCount {
 LL | |
@@ -34,7 +34,7 @@ LL | | }
    | |_^
 
 error: scalable vectors must be tuple structs
-  --> $DIR/illformed.rs:46:1
+  --> $DIR/illformed.rs:47:1
    |
 LL | / struct MultipleFieldsStructWithoutElementCount {
 LL | |
@@ -44,13 +44,13 @@ LL | | }
    | |_^
 
 error: scalable vectors must be tuple structs
-  --> $DIR/illformed.rs:58:1
+  --> $DIR/illformed.rs:59:1
    |
 LL | struct SingleFieldStruct { _ty: f64 }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: scalable vectors must have a single field
-  --> $DIR/illformed.rs:6:1
+  --> $DIR/illformed.rs:7:1
    |
 LL | struct NoFieldsStructWithElementCount {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -58,7 +58,7 @@ LL | struct NoFieldsStructWithElementCount {}
    = help: scalable vector types' only field must be a primitive scalar type
 
 error: scalable vectors must have a single field
-  --> $DIR/illformed.rs:11:1
+  --> $DIR/illformed.rs:12:1
    |
 LL | struct NoFieldsTupleWithElementCount();
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -66,7 +66,7 @@ LL | struct NoFieldsTupleWithElementCount();
    = help: scalable vector types' only field must be a primitive scalar type
 
 error: scalable vectors must have a single field
-  --> $DIR/illformed.rs:15:1
+  --> $DIR/illformed.rs:16:1
    |
 LL | struct NoFieldsUnitWithElementCount;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -74,7 +74,7 @@ LL | struct NoFieldsUnitWithElementCount;
    = help: scalable vector types' only field must be a primitive scalar type
 
 error: scalable vectors must have a single field
-  --> $DIR/illformed.rs:20:1
+  --> $DIR/illformed.rs:21:1
    |
 LL | struct NoFieldsStructWithoutElementCount {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -82,7 +82,7 @@ LL | struct NoFieldsStructWithoutElementCount {}
    = help: tuples of scalable vectors can only contain multiple of the same scalable vector type
 
 error: scalable vectors must have a single field
-  --> $DIR/illformed.rs:25:1
+  --> $DIR/illformed.rs:26:1
    |
 LL | struct NoFieldsTupleWithoutElementCount();
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -90,7 +90,7 @@ LL | struct NoFieldsTupleWithoutElementCount();
    = help: tuples of scalable vectors can only contain multiple of the same scalable vector type
 
 error: scalable vectors must have a single field
-  --> $DIR/illformed.rs:29:1
+  --> $DIR/illformed.rs:30:1
    |
 LL | struct NoFieldsUnitWithoutElementCount;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -98,25 +98,25 @@ LL | struct NoFieldsUnitWithoutElementCount;
    = help: tuples of scalable vectors can only contain multiple of the same scalable vector type
 
 error: scalable vectors cannot have multiple fields
-  --> $DIR/illformed.rs:34:1
+  --> $DIR/illformed.rs:35:1
    |
 LL | struct MultipleFieldsStructWithElementCount {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: scalable vectors cannot have multiple fields
-  --> $DIR/illformed.rs:42:1
+  --> $DIR/illformed.rs:43:1
    |
 LL | struct MultipleFieldsTupleWithElementCount(f32, u32);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: scalable vector structs can only have scalable vector fields
-  --> $DIR/illformed.rs:48:5
+  --> $DIR/illformed.rs:49:5
    |
 LL |     _ty: f32,
    |     ^^^^^^^^
 
 error: scalable vector structs can only have scalable vector fields
-  --> $DIR/illformed.rs:54:47
+  --> $DIR/illformed.rs:55:47
    |
 LL | struct MultipleFieldsTupleWithoutElementCount(f32, u32);
    |                                               ^^^

--- a/tests/ui/scalable-vectors/invalid.rs
+++ b/tests/ui/scalable-vectors/invalid.rs
@@ -1,4 +1,5 @@
 //@ edition: 2024
+//@ only-aarch64
 #![allow(internal_features, unused_imports, unused_macros)]
 #![feature(extern_types)]
 #![feature(gen_blocks)]

--- a/tests/ui/scalable-vectors/invalid.stderr
+++ b/tests/ui/scalable-vectors/invalid.stderr
@@ -1,11 +1,11 @@
 error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
-  --> $DIR/invalid.rs:109:11
+  --> $DIR/invalid.rs:110:11
    |
 LL | fn barqux(#[rustc_scalable_vector(4)] _x: u32) {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on extern crates
-  --> $DIR/invalid.rs:9:1
+  --> $DIR/invalid.rs:10:1
    |
 LL | #[rustc_scalable_vector(4)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on use statements
-  --> $DIR/invalid.rs:13:1
+  --> $DIR/invalid.rs:14:1
    |
 LL | #[rustc_scalable_vector(4)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -21,7 +21,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on statics
-  --> $DIR/invalid.rs:17:1
+  --> $DIR/invalid.rs:18:1
    |
 LL | #[rustc_scalable_vector(4)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -29,7 +29,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on constants
-  --> $DIR/invalid.rs:21:1
+  --> $DIR/invalid.rs:22:1
    |
 LL | #[rustc_scalable_vector(4)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -37,7 +37,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on modules
-  --> $DIR/invalid.rs:25:1
+  --> $DIR/invalid.rs:26:1
    |
 LL | #[rustc_scalable_vector(4)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -45,7 +45,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on foreign modules
-  --> $DIR/invalid.rs:30:1
+  --> $DIR/invalid.rs:31:1
    |
 LL | #[rustc_scalable_vector(4)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -53,7 +53,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on foreign statics
-  --> $DIR/invalid.rs:33:5
+  --> $DIR/invalid.rs:34:5
    |
 LL |     #[rustc_scalable_vector(4)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -61,7 +61,7 @@ LL |     #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on foreign types
-  --> $DIR/invalid.rs:36:5
+  --> $DIR/invalid.rs:37:5
    |
 LL |     #[rustc_scalable_vector(4)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,7 +69,7 @@ LL |     #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on foreign functions
-  --> $DIR/invalid.rs:39:5
+  --> $DIR/invalid.rs:40:5
    |
 LL |     #[rustc_scalable_vector(4)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -77,7 +77,7 @@ LL |     #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on type aliases
-  --> $DIR/invalid.rs:44:1
+  --> $DIR/invalid.rs:45:1
    |
 LL | #[rustc_scalable_vector(4)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -85,7 +85,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on enums
-  --> $DIR/invalid.rs:48:1
+  --> $DIR/invalid.rs:49:1
    |
 LL | #[rustc_scalable_vector(4)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -93,7 +93,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on type parameters
-  --> $DIR/invalid.rs:50:10
+  --> $DIR/invalid.rs:51:10
    |
 LL | enum Bar<#[rustc_scalable_vector(4)] T> {
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -101,7 +101,7 @@ LL | enum Bar<#[rustc_scalable_vector(4)] T> {
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on enum variants
-  --> $DIR/invalid.rs:52:5
+  --> $DIR/invalid.rs:53:5
    |
 LL |     #[rustc_scalable_vector(4)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -109,7 +109,7 @@ LL |     #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on struct fields
-  --> $DIR/invalid.rs:58:5
+  --> $DIR/invalid.rs:59:5
    |
 LL |     #[rustc_scalable_vector(4)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -117,7 +117,7 @@ LL |     #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on unions
-  --> $DIR/invalid.rs:63:1
+  --> $DIR/invalid.rs:64:1
    |
 LL | #[rustc_scalable_vector(4)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -125,7 +125,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on traits
-  --> $DIR/invalid.rs:70:1
+  --> $DIR/invalid.rs:71:1
    |
 LL | #[rustc_scalable_vector(4)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -133,7 +133,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on associated types
-  --> $DIR/invalid.rs:73:5
+  --> $DIR/invalid.rs:74:5
    |
 LL |     #[rustc_scalable_vector(4)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -141,7 +141,7 @@ LL |     #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on associated consts
-  --> $DIR/invalid.rs:76:5
+  --> $DIR/invalid.rs:77:5
    |
 LL |     #[rustc_scalable_vector(4)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -149,7 +149,7 @@ LL |     #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on provided trait methods
-  --> $DIR/invalid.rs:79:5
+  --> $DIR/invalid.rs:80:5
    |
 LL |     #[rustc_scalable_vector(4)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -157,7 +157,7 @@ LL |     #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on trait aliases
-  --> $DIR/invalid.rs:84:1
+  --> $DIR/invalid.rs:85:1
    |
 LL | #[rustc_scalable_vector(4)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -165,7 +165,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on inherent impl blocks
-  --> $DIR/invalid.rs:88:1
+  --> $DIR/invalid.rs:89:1
    |
 LL | #[rustc_scalable_vector(4)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -173,7 +173,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on inherent methods
-  --> $DIR/invalid.rs:91:5
+  --> $DIR/invalid.rs:92:5
    |
 LL |     #[rustc_scalable_vector(4)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -181,7 +181,7 @@ LL |     #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on trait impl blocks
-  --> $DIR/invalid.rs:96:1
+  --> $DIR/invalid.rs:97:1
    |
 LL | #[rustc_scalable_vector(4)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -189,7 +189,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on macro defs
-  --> $DIR/invalid.rs:103:1
+  --> $DIR/invalid.rs:104:1
    |
 LL | #[rustc_scalable_vector(4)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -197,7 +197,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on functions
-  --> $DIR/invalid.rs:107:1
+  --> $DIR/invalid.rs:108:1
    |
 LL | #[rustc_scalable_vector(4)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -205,7 +205,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on function params
-  --> $DIR/invalid.rs:109:11
+  --> $DIR/invalid.rs:110:11
    |
 LL | fn barqux(#[rustc_scalable_vector(4)] _x: u32) {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -213,7 +213,7 @@ LL | fn barqux(#[rustc_scalable_vector(4)] _x: u32) {}
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on functions
-  --> $DIR/invalid.rs:113:1
+  --> $DIR/invalid.rs:114:1
    |
 LL | #[rustc_scalable_vector(4)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -221,7 +221,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on functions
-  --> $DIR/invalid.rs:117:1
+  --> $DIR/invalid.rs:118:1
    |
 LL | #[rustc_scalable_vector(4)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -229,7 +229,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on functions
-  --> $DIR/invalid.rs:121:1
+  --> $DIR/invalid.rs:122:1
    |
 LL | #[rustc_scalable_vector(4)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -237,7 +237,7 @@ LL | #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on closures
-  --> $DIR/invalid.rs:126:14
+  --> $DIR/invalid.rs:127:14
    |
 LL |     let _x = #[rustc_scalable_vector(4)] || { };
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -245,7 +245,7 @@ LL |     let _x = #[rustc_scalable_vector(4)] || { };
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on expressions
-  --> $DIR/invalid.rs:128:14
+  --> $DIR/invalid.rs:129:14
    |
 LL |     let _y = #[rustc_scalable_vector(4)] 3 + 4;
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -253,7 +253,7 @@ LL |     let _y = #[rustc_scalable_vector(4)] 3 + 4;
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on statements
-  --> $DIR/invalid.rs:130:5
+  --> $DIR/invalid.rs:131:5
    |
 LL |     #[rustc_scalable_vector(4)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -261,7 +261,7 @@ LL |     #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error: `#[rustc_scalable_vector]` attribute cannot be used on match arms
-  --> $DIR/invalid.rs:135:9
+  --> $DIR/invalid.rs:136:9
    |
 LL |         #[rustc_scalable_vector(4)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -269,7 +269,7 @@ LL |         #[rustc_scalable_vector(4)]
    = help: `#[rustc_scalable_vector]` can only be applied to structs
 
 error[E0539]: malformed `rustc_scalable_vector` attribute input
-  --> $DIR/invalid.rs:142:1
+  --> $DIR/invalid.rs:143:1
    |
 LL | #[rustc_scalable_vector("4")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^---^^
@@ -286,7 +286,7 @@ LL + #[rustc_scalable_vector]
    |
 
 error[E0805]: malformed `rustc_scalable_vector` attribute input
-  --> $DIR/invalid.rs:146:1
+  --> $DIR/invalid.rs:147:1
    |
 LL | #[rustc_scalable_vector(4, 2)]
    | ^^^^^^^^^^^^^^^^^^^^^^^------^
@@ -303,7 +303,7 @@ LL + #[rustc_scalable_vector]
    |
 
 error[E0539]: malformed `rustc_scalable_vector` attribute input
-  --> $DIR/invalid.rs:150:1
+  --> $DIR/invalid.rs:151:1
    |
 LL | #[rustc_scalable_vector(count = "4")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^-----------^^
@@ -320,7 +320,7 @@ LL + #[rustc_scalable_vector]
    |
 
 error: element count in `rustc_scalable_vector` is too large: `65536`
-  --> $DIR/invalid.rs:154:1
+  --> $DIR/invalid.rs:155:1
    |
 LL | #[rustc_scalable_vector(65536)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -328,7 +328,7 @@ LL | #[rustc_scalable_vector(65536)]
    = note: the value may not exceed `u16::MAX`
 
 error: scalable vector structs can only have scalable vector fields
-  --> $DIR/invalid.rs:162:18
+  --> $DIR/invalid.rs:163:18
    |
 LL | struct OkayNoArg(f32);
    |                  ^^^

--- a/tests/ui/scalable-vectors/wellformed-arrays.rs
+++ b/tests/ui/scalable-vectors/wellformed-arrays.rs
@@ -1,5 +1,6 @@
 //@ check-pass
 //@ compile-flags: --crate-type=lib
+//@ only-aarch64
 #![feature(rustc_attrs)]
 
 #[rustc_scalable_vector(16)]

--- a/tests/ui/scalable-vectors/wellformed.rs
+++ b/tests/ui/scalable-vectors/wellformed.rs
@@ -1,5 +1,6 @@
 //@ check-pass
 //@ compile-flags: --crate-type=lib
+//@ only-aarch64
 #![feature(rustc_attrs)]
 
 #[rustc_scalable_vector(16)]

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1012,6 +1012,13 @@ cc = ["@lcnr"]
 message = "HIR ty lowering was modified"
 cc = ["@fmease"]
 
+[mentions."compiler/rustc_parse"]
+message = """
+The parser was modified, potentially altering the grammar of (stable) Rust
+which would be a breaking change.
+"""
+cc = ["@fmease"]
+
 [mentions."library/core/src/mem/type_info.rs"]
 message = """
 The reflection data structures are tied exactly to the implementation


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#149931 (rustdoc: don't give depreciation notes special handling)
 - rust-lang/rust#153608 (ast_passes: unsupported arch w/ scalable vectors)
 - rust-lang/rust#153609 (Add missing `Diag::with_span_suggestion_with_style` method)
 - rust-lang/rust#153610 (Only lint unused features if they are unstable)
 - rust-lang/rust#153616 (Update `sysinfo` version to `0.38.4`)
 - rust-lang/rust#153619 (Update books)
 - rust-lang/rust#153624 (Ping fmease on parser modifications)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=149931,153608,153609,153610,153616,153619,153624)
<!-- homu-ignore:end -->

