### PR TITLE
Unify same-span labels in move error diagnostics

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
@@ -990,30 +990,25 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
             let bind_to = &self.body.local_decls[*local];
             let binding_span = bind_to.source_info.span;
 
-            if j == 0 {
-                err.span_label(binding_span, "data moved here");
-            } else {
-                err.span_label(binding_span, "...and here");
-            }
-
             if binds_to.len() == 1 {
                 let place_desc = self.local_name(*local).map(|sym| format!("`{sym}`"));
 
-                if !desugar_spans.contains(&binding_span)
-                    && let Some(expr) = self.find_expr(binding_span)
-                {
-                    // The binding_span doesn't correspond to a let binding desugaring
-                    // and is an expression where calling `.clone()` would be valid.
-                    let local_place: PlaceRef<'tcx> = (*local).into();
-                    self.suggest_cloning(err, local_place, bind_to.ty, expr, None);
-                }
-
-                err.subdiagnostic(crate::session_diagnostics::TypeNoCopy::Label {
-                    is_partial_move: false,
+                err.subdiagnostic(crate::session_diagnostics::TypeNoCopy::LabelMovedHere {
                     ty: bind_to.ty,
                     place: place_desc.as_deref().unwrap_or("the place"),
                     span: binding_span,
                 });
+
+                if !desugar_spans.contains(&binding_span)
+                    && let Some(expr) = self.find_expr(binding_span)
+                {
+                    let local_place: PlaceRef<'tcx> = (*local).into();
+                    self.suggest_cloning(err, local_place, bind_to.ty, expr, None);
+                }
+            } else if j == 0 {
+                err.span_label(binding_span, "data moved here");
+            } else {
+                err.span_label(binding_span, "...and here");
             }
         }
 

--- a/compiler/rustc_borrowck/src/session_diagnostics.rs
+++ b/compiler/rustc_borrowck/src/session_diagnostics.rs
@@ -570,6 +570,16 @@ pub(crate) enum TypeNoCopy<'a, 'tcx> {
         #[primary_span]
         span: Span,
     },
+    #[label(
+        "data moved here because {$place} has type `{$ty}`, which does not implement the `Copy` \
+         trait"
+    )]
+    LabelMovedHere {
+        ty: Ty<'tcx>,
+        place: &'a str,
+        #[primary_span]
+        span: Span,
+    },
     #[note(
         "{$is_partial_move ->
             [true] partial move

--- a/tests/ui/borrowck/access-mode-in-closures.stderr
+++ b/tests/ui/borrowck/access-mode-in-closures.stderr
@@ -2,10 +2,7 @@ error[E0507]: cannot move out of `s` which is behind a shared reference
   --> $DIR/access-mode-in-closures.rs:8:15
    |
 LL |         match *s { S(v) => v }
-   |               ^^     -
-   |                      |
-   |                      data moved here
-   |                      move occurs because `v` has type `Vec<isize>`, which does not implement the `Copy` trait
+   |               ^^     - data moved here because `v` has type `Vec<isize>`, which does not implement the `Copy` trait
    |
 help: consider removing the dereference here
    |

--- a/tests/ui/borrowck/borrowck-for-loop-correct-cmt-for-pattern.stderr
+++ b/tests/ui/borrowck/borrowck-for-loop-correct-cmt-for-pattern.stderr
@@ -4,8 +4,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     for &a in x.iter() {
    |          -    ^^^^^^^^
    |          |
-   |          data moved here
-   |          move occurs because `a` has type `&mut i32`, which does not implement the `Copy` trait
+   |          data moved here because `a` has type `&mut i32`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -19,8 +18,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     for &a in &f.a {
    |          -    ^^^^
    |          |
-   |          data moved here
-   |          move occurs because `a` has type `Box<isize>`, which does not implement the `Copy` trait
+   |          data moved here because `a` has type `Box<isize>`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -34,8 +32,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     for &a in x.iter() {
    |          -    ^^^^^^^^
    |          |
-   |          data moved here
-   |          move occurs because `a` has type `Box<i32>`, which does not implement the `Copy` trait
+   |          data moved here because `a` has type `Box<i32>`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |

--- a/tests/ui/borrowck/borrowck-move-error-with-note.stderr
+++ b/tests/ui/borrowck/borrowck-move-error-with-note.stderr
@@ -44,10 +44,7 @@ error[E0507]: cannot move out of `a.a` which is behind a shared reference
 LL |     match a.a {
    |           ^^^
 LL |         n => {
-   |         -
-   |         |
-   |         data moved here
-   |         move occurs because `n` has type `Box<isize>`, which does not implement the `Copy` trait
+   |         - data moved here because `n` has type `Box<isize>`, which does not implement the `Copy` trait
    |
 help: consider borrowing here
    |

--- a/tests/ui/borrowck/borrowck-move-in-irrefut-pat.stderr
+++ b/tests/ui/borrowck/borrowck-move-in-irrefut-pat.stderr
@@ -4,8 +4,7 @@ error[E0507]: cannot move out of a shared reference
 LL | fn arg_item(&_x: &String) {}
    |             ^--
    |              |
-   |              data moved here
-   |              move occurs because `_x` has type `String`, which does not implement the `Copy` trait
+   |              data moved here because `_x` has type `String`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -19,8 +18,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     with(|&_x| ())
    |           ^--
    |            |
-   |            data moved here
-   |            move occurs because `_x` has type `String`, which does not implement the `Copy` trait
+   |            data moved here because `_x` has type `String`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -34,8 +32,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     let &_x = &"hi".to_string();
    |          --   ^^^^^^^^^^^^^^^^^
    |          |
-   |          data moved here
-   |          move occurs because `_x` has type `String`, which does not implement the `Copy` trait
+   |          data moved here because `_x` has type `String`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |

--- a/tests/ui/borrowck/borrowck-move-out-of-struct-with-dtor.stderr
+++ b/tests/ui/borrowck/borrowck-move-out-of-struct-with-dtor.stderr
@@ -5,10 +5,7 @@ LL |     match (S {f:"foo".to_string()}) {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^ cannot move out of here
 LL |
 LL |         S {f:_s} => {}
-   |              --
-   |              |
-   |              data moved here
-   |              move occurs because `_s` has type `String`, which does not implement the `Copy` trait
+   |              -- data moved here because `_s` has type `String`, which does not implement the `Copy` trait
    |
 help: consider borrowing the pattern binding
    |
@@ -21,8 +18,7 @@ error[E0509]: cannot move out of type `S`, which implements the `Drop` trait
 LL |     let S {f:_s} = S {f:"foo".to_string()};
    |              --    ^^^^^^^^^^^^^^^^^^^^^^^ cannot move out of here
    |              |
-   |              data moved here
-   |              move occurs because `_s` has type `String`, which does not implement the `Copy` trait
+   |              data moved here because `_s` has type `String`, which does not implement the `Copy` trait
    |
 help: consider borrowing the pattern binding
    |
@@ -35,8 +31,7 @@ error[E0509]: cannot move out of type `S`, which implements the `Drop` trait
 LL | fn move_in_fn_arg(S {f:_s}: S) {
    |                   ^^^^^--^
    |                   |    |
-   |                   |    data moved here
-   |                   |    move occurs because `_s` has type `String`, which does not implement the `Copy` trait
+   |                   |    data moved here because `_s` has type `String`, which does not implement the `Copy` trait
    |                   cannot move out of here
    |
 help: consider borrowing the pattern binding

--- a/tests/ui/borrowck/borrowck-move-out-of-tuple-struct-with-dtor.stderr
+++ b/tests/ui/borrowck/borrowck-move-out-of-tuple-struct-with-dtor.stderr
@@ -5,10 +5,7 @@ LL |     match S("foo".to_string()) {
    |           ^^^^^^^^^^^^^^^^^^^^ cannot move out of here
 LL |
 LL |         S(_s) => {}
-   |           --
-   |           |
-   |           data moved here
-   |           move occurs because `_s` has type `String`, which does not implement the `Copy` trait
+   |           -- data moved here because `_s` has type `String`, which does not implement the `Copy` trait
    |
 help: consider borrowing the pattern binding
    |
@@ -21,8 +18,7 @@ error[E0509]: cannot move out of type `S`, which implements the `Drop` trait
 LL |     let S(_s) = S("foo".to_string());
    |           --    ^^^^^^^^^^^^^^^^^^^^ cannot move out of here
    |           |
-   |           data moved here
-   |           move occurs because `_s` has type `String`, which does not implement the `Copy` trait
+   |           data moved here because `_s` has type `String`, which does not implement the `Copy` trait
    |
 help: consider borrowing the pattern binding
    |
@@ -35,8 +31,7 @@ error[E0509]: cannot move out of type `S`, which implements the `Drop` trait
 LL | fn move_in_fn_arg(S(_s): S) {
    |                   ^^--^
    |                   | |
-   |                   | data moved here
-   |                   | move occurs because `_s` has type `String`, which does not implement the `Copy` trait
+   |                   | data moved here because `_s` has type `String`, which does not implement the `Copy` trait
    |                   cannot move out of here
    |
 help: consider borrowing the pattern binding

--- a/tests/ui/borrowck/borrowck-vec-pattern-nesting.rs
+++ b/tests/ui/borrowck/borrowck-vec-pattern-nesting.rs
@@ -35,8 +35,7 @@ fn c() {
         //~^ ERROR cannot move out
         //~| NOTE cannot move out
         &mut [_a,
-        //~^ NOTE data moved here
-        //~| NOTE move occurs because `_a` has type
+        //~^ NOTE data moved here because `_a` has type
         //~| HELP consider removing the mutable borrow
             ..
         ] => {
@@ -59,8 +58,7 @@ fn d() {
         &mut [
         //~^ HELP consider removing the mutable borrow
          _b] => {}
-        //~^ NOTE data moved here
-        //~| NOTE move occurs because `_b` has type
+        //~^ NOTE data moved here because `_b` has type
         _ => {}
     }
     let a = vec[0]; //~ ERROR cannot move out

--- a/tests/ui/borrowck/borrowck-vec-pattern-nesting.stderr
+++ b/tests/ui/borrowck/borrowck-vec-pattern-nesting.stderr
@@ -29,10 +29,7 @@ LL |     match vec {
    |           ^^^ cannot move out of here
 ...
 LL |         &mut [_a,
-   |               --
-   |               |
-   |               data moved here
-   |               move occurs because `_a` has type `Box<isize>`, which does not implement the `Copy` trait
+   |               -- data moved here because `_a` has type `Box<isize>`, which does not implement the `Copy` trait
    |
 help: consider removing the mutable borrow
    |
@@ -41,7 +38,7 @@ LL +         [_a,
    |
 
 error[E0508]: cannot move out of type `[Box<isize>]`, a non-copy slice
-  --> $DIR/borrowck-vec-pattern-nesting.rs:46:13
+  --> $DIR/borrowck-vec-pattern-nesting.rs:45:13
    |
 LL |     let a = vec[0];
    |             ^^^^^^
@@ -59,16 +56,13 @@ LL |     let a = vec[0].clone();
    |                   ++++++++
 
 error[E0508]: cannot move out of type `[Box<isize>]`, a non-copy slice
-  --> $DIR/borrowck-vec-pattern-nesting.rs:56:11
+  --> $DIR/borrowck-vec-pattern-nesting.rs:55:11
    |
 LL |     match vec {
    |           ^^^ cannot move out of here
 ...
 LL |          _b] => {}
-   |          --
-   |          |
-   |          data moved here
-   |          move occurs because `_b` has type `Box<isize>`, which does not implement the `Copy` trait
+   |          -- data moved here because `_b` has type `Box<isize>`, which does not implement the `Copy` trait
    |
 help: consider removing the mutable borrow
    |
@@ -77,7 +71,7 @@ LL +         [
    |
 
 error[E0508]: cannot move out of type `[Box<isize>]`, a non-copy slice
-  --> $DIR/borrowck-vec-pattern-nesting.rs:66:13
+  --> $DIR/borrowck-vec-pattern-nesting.rs:64:13
    |
 LL |     let a = vec[0];
    |             ^^^^^^
@@ -95,7 +89,7 @@ LL |     let a = vec[0].clone();
    |                   ++++++++
 
 error[E0508]: cannot move out of type `[Box<isize>]`, a non-copy slice
-  --> $DIR/borrowck-vec-pattern-nesting.rs:76:11
+  --> $DIR/borrowck-vec-pattern-nesting.rs:74:11
    |
 LL |     match vec {
    |           ^^^ cannot move out of here
@@ -114,7 +108,7 @@ LL +         [_a, _b, _c] => {}
    |
 
 error[E0508]: cannot move out of type `[Box<isize>]`, a non-copy slice
-  --> $DIR/borrowck-vec-pattern-nesting.rs:87:13
+  --> $DIR/borrowck-vec-pattern-nesting.rs:85:13
    |
 LL |     let a = vec[0];
    |             ^^^^^^

--- a/tests/ui/borrowck/issue-51301.stderr
+++ b/tests/ui/borrowck/issue-51301.stderr
@@ -4,8 +4,7 @@ error[E0507]: cannot move out of a shared reference
 LL |             .find(|(&event_type, _)| event == event_type)
    |                    ^^----------^^^^
    |                      |
-   |                      data moved here
-   |                      move occurs because `event_type` has type `EventType`, which does not implement the `Copy` trait
+   |                      data moved here because `event_type` has type `EventType`, which does not implement the `Copy` trait
    |
 help: consider borrowing the pattern binding
    |

--- a/tests/ui/borrowck/issue-51415.stderr
+++ b/tests/ui/borrowck/issue-51415.stderr
@@ -4,8 +4,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     let opt = a.iter().enumerate().find(|(_, &s)| {
    |                                          ^^^^^-^
    |                                               |
-   |                                               data moved here
-   |                                               move occurs because `s` has type `String`, which does not implement the `Copy` trait
+   |                                               data moved here because `s` has type `String`, which does not implement the `Copy` trait
    |
 help: consider borrowing the pattern binding
    |

--- a/tests/ui/disallowed-deconstructing/disallowed-deconstructing-destructing-struct-let.stderr
+++ b/tests/ui/disallowed-deconstructing/disallowed-deconstructing-destructing-struct-let.stderr
@@ -4,8 +4,7 @@ error[E0509]: cannot move out of type `X`, which implements the `Drop` trait
 LL |     let X { x: y } = x;
    |                -     ^ cannot move out of here
    |                |
-   |                data moved here
-   |                move occurs because `y` has type `String`, which does not implement the `Copy` trait
+   |                data moved here because `y` has type `String`, which does not implement the `Copy` trait
    |
 help: consider borrowing the pattern binding
    |

--- a/tests/ui/disallowed-deconstructing/disallowed-deconstructing-destructing-struct-match.stderr
+++ b/tests/ui/disallowed-deconstructing/disallowed-deconstructing-destructing-struct-match.stderr
@@ -5,10 +5,7 @@ LL |     match x {
    |           ^ cannot move out of here
 LL |
 LL |         X { x: y } => println!("contents: {}", y)
-   |                -
-   |                |
-   |                data moved here
-   |                move occurs because `y` has type `String`, which does not implement the `Copy` trait
+   |                - data moved here because `y` has type `String`, which does not implement the `Copy` trait
    |
 help: consider borrowing the pattern binding
    |

--- a/tests/ui/moves/do-not-suggest-removing-wrong-ref-pattern-issue-132806.stderr
+++ b/tests/ui/moves/do-not-suggest-removing-wrong-ref-pattern-issue-132806.stderr
@@ -4,8 +4,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     let _ = HashMap::<String, i32>::new().iter().filter(|&(&_k, &_v)| { true });
    |                                                          ^^^--^^^^^^
    |                                                             |
-   |                                                             data moved here
-   |                                                             move occurs because `_k` has type `String`, which does not implement the `Copy` trait
+   |                                                             data moved here because `_k` has type `String`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |

--- a/tests/ui/moves/invalid-suggestions-destructuring-assignment-drop.stderr
+++ b/tests/ui/moves/invalid-suggestions-destructuring-assignment-drop.stderr
@@ -4,8 +4,7 @@ error[E0509]: cannot move out of type `Thing`, which implements the `Drop` trait
 LL |     Thing(*&mut String::new()) = Thing(String::new());
    |           -------------------    ^^^^^^^^^^^^^^^^^^^^ cannot move out of here
    |           |
-   |           data moved here
-   |           move occurs because the place has type `String`, which does not implement the `Copy` trait
+   |           data moved here because the place has type `String`, which does not implement the `Copy` trait
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/moves/issue-99470-move-out-of-some.stderr
+++ b/tests/ui/moves/issue-99470-move-out-of-some.stderr
@@ -5,10 +5,7 @@ LL |     match x {
    |           ^
 LL |
 LL |         &Some(_y) => (),
-   |               --
-   |               |
-   |               data moved here
-   |               move occurs because `_y` has type `Box<i32>`, which does not implement the `Copy` trait
+   |               -- data moved here because `_y` has type `Box<i32>`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |

--- a/tests/ui/moves/move-out-of-array-ref.stderr
+++ b/tests/ui/moves/move-out-of-array-ref.stderr
@@ -4,8 +4,7 @@ error[E0508]: cannot move out of type `[D; 4]`, a non-copy array
 LL |     let [_, e, _, _] = *a;
    |             -          ^^ cannot move out of here
    |             |
-   |             data moved here
-   |             move occurs because `e` has type `D`, which does not implement the `Copy` trait
+   |             data moved here because `e` has type `D`, which does not implement the `Copy` trait
    |
 help: consider removing the dereference here
    |
@@ -19,8 +18,7 @@ error[E0508]: cannot move out of type `[D; 4]`, a non-copy array
 LL |     let [_, s @ .. , _] = *a;
    |             -             ^^ cannot move out of here
    |             |
-   |             data moved here
-   |             move occurs because `s` has type `[D; 2]`, which does not implement the `Copy` trait
+   |             data moved here because `s` has type `[D; 2]`, which does not implement the `Copy` trait
    |
 help: consider removing the dereference here
    |
@@ -34,8 +32,7 @@ error[E0508]: cannot move out of type `[D; 4]`, a non-copy array
 LL |     let [_, e, _, _] = *a;
    |             -          ^^ cannot move out of here
    |             |
-   |             data moved here
-   |             move occurs because `e` has type `D`, which does not implement the `Copy` trait
+   |             data moved here because `e` has type `D`, which does not implement the `Copy` trait
    |
 help: consider removing the dereference here
    |
@@ -49,8 +46,7 @@ error[E0508]: cannot move out of type `[D; 4]`, a non-copy array
 LL |     let [_, s @ .. , _] = *a;
    |             -             ^^ cannot move out of here
    |             |
-   |             data moved here
-   |             move occurs because `s` has type `[D; 2]`, which does not implement the `Copy` trait
+   |             data moved here because `s` has type `[D; 2]`, which does not implement the `Copy` trait
    |
 help: consider removing the dereference here
    |

--- a/tests/ui/moves/move-out-of-slice-1.stderr
+++ b/tests/ui/moves/move-out-of-slice-1.stderr
@@ -4,10 +4,7 @@ error[E0508]: cannot move out of type `[A]`, a non-copy slice
 LL |     match a {
    |           ^ cannot move out of here
 LL |         box [a] => {},
-   |              -
-   |              |
-   |              data moved here
-   |              move occurs because `a` has type `A`, which does not implement the `Copy` trait
+   |              - data moved here because `a` has type `A`, which does not implement the `Copy` trait
    |
 help: consider borrowing the pattern binding
    |

--- a/tests/ui/moves/moves-based-on-type-block-bad.stderr
+++ b/tests/ui/moves/moves-based-on-type-block-bad.stderr
@@ -5,10 +5,7 @@ LL |             match hellothere.x {
    |                   ^^^^^^^^^^^^
 LL |                 box E::Foo(_) => {}
 LL |                 box E::Bar(x) => println!("{}", x.to_string()),
-   |                            -
-   |                            |
-   |                            data moved here
-   |                            move occurs because `x` has type `Box<isize>`, which does not implement the `Copy` trait
+   |                            - data moved here because `x` has type `Box<isize>`, which does not implement the `Copy` trait
    |
 help: consider borrowing here
    |

--- a/tests/ui/nll/move-errors.stderr
+++ b/tests/ui/nll/move-errors.stderr
@@ -108,8 +108,7 @@ error[E0507]: cannot move out of `a` which is behind a shared reference
 LL |     let A(s) = *a;
    |           -    ^^
    |           |
-   |           data moved here
-   |           move occurs because `s` has type `String`, which does not implement the `Copy` trait
+   |           data moved here because `s` has type `String`, which does not implement the `Copy` trait
    |
 help: consider removing the dereference here
    |
@@ -123,8 +122,7 @@ error[E0509]: cannot move out of type `D`, which implements the `Drop` trait
 LL |     let C(D(s)) = c;
    |             -     ^ cannot move out of here
    |             |
-   |             data moved here
-   |             move occurs because `s` has type `String`, which does not implement the `Copy` trait
+   |             data moved here because `s` has type `String`, which does not implement the `Copy` trait
    |
 help: consider borrowing the pattern binding
    |
@@ -170,10 +168,7 @@ LL |     match x {
    |           ^ cannot move out of here
 ...
 LL |         B::U(D(s)) => (),
-   |                -
-   |                |
-   |                data moved here
-   |                move occurs because `s` has type `String`, which does not implement the `Copy` trait
+   |                - data moved here because `s` has type `String`, which does not implement the `Copy` trait
    |
 help: consider borrowing the pattern binding
    |
@@ -187,10 +182,7 @@ LL |     match x {
    |           ^ cannot move out of here
 ...
 LL |         (D(s), &t) => (),
-   |            -
-   |            |
-   |            data moved here
-   |            move occurs because `s` has type `String`, which does not implement the `Copy` trait
+   |            - data moved here because `s` has type `String`, which does not implement the `Copy` trait
    |
 help: consider borrowing the pattern binding
    |
@@ -204,10 +196,7 @@ LL |     match x {
    |           ^
 ...
 LL |         (D(s), &t) => (),
-   |                 -
-   |                 |
-   |                 data moved here
-   |                 move occurs because `t` has type `String`, which does not implement the `Copy` trait
+   |                 - data moved here because `t` has type `String`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -243,10 +232,7 @@ LL |     match *x {
    |           ^^
 LL |
 LL |         Ok(s) | Err(s) => (),
-   |            -
-   |            |
-   |            data moved here
-   |            move occurs because `s` has type `String`, which does not implement the `Copy` trait
+   |            - data moved here because `s` has type `String`, which does not implement the `Copy` trait
    |
 help: consider removing the dereference here
    |

--- a/tests/ui/pattern/by-move-pattern-binding.stderr
+++ b/tests/ui/pattern/by-move-pattern-binding.stderr
@@ -5,10 +5,7 @@ LL |     match &s.x {
    |           ^^^^
 LL |         &E::Foo => {}
 LL |         &E::Bar(identifier) => f(identifier.clone())
-   |                 ----------
-   |                 |
-   |                 data moved here
-   |                 move occurs because `identifier` has type `String`, which does not implement the `Copy` trait
+   |                 ---------- data moved here because `identifier` has type `String`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -22,8 +19,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     if let &E::Bar(identifier) = &s.x {
    |                    ----------    ^^^^
    |                    |
-   |                    data moved here
-   |                    move occurs because `identifier` has type `String`, which does not implement the `Copy` trait
+   |                    data moved here because `identifier` has type `String`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -37,8 +33,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     let &E::Bar(identifier) = &s.x else {
    |                 ----------    ^^^^
    |                 |
-   |                 data moved here
-   |                 move occurs because `identifier` has type `String`, which does not implement the `Copy` trait
+   |                 data moved here because `identifier` has type `String`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |

--- a/tests/ui/pattern/deref-patterns/cant_move_out_of_pattern.stderr
+++ b/tests/ui/pattern/deref-patterns/cant_move_out_of_pattern.stderr
@@ -5,10 +5,7 @@ LL |     match b {
    |           ^ cannot move out of here
 LL |
 LL |         deref!([x]) => x,
-   |                 -
-   |                 |
-   |                 data moved here
-   |                 move occurs because `x` has type `Struct`, which does not implement the `Copy` trait
+   |                 - data moved here because `x` has type `Struct`, which does not implement the `Copy` trait
    |
 help: consider borrowing the pattern binding
    |
@@ -22,10 +19,7 @@ LL |     match rc {
    |           ^^
 LL |
 LL |         deref!(x) => x,
-   |                -
-   |                |
-   |                data moved here
-   |                move occurs because `x` has type `Struct`, which does not implement the `Copy` trait
+   |                - data moved here because `x` has type `Struct`, which does not implement the `Copy` trait
    |
 help: consider borrowing the pattern binding
    |
@@ -39,10 +33,7 @@ LL |     match b {
    |           ^ cannot move out of here
 LL |
 LL |         [x] => x,
-   |          -
-   |          |
-   |          data moved here
-   |          move occurs because `x` has type `Struct`, which does not implement the `Copy` trait
+   |          - data moved here because `x` has type `Struct`, which does not implement the `Copy` trait
    |
 help: consider borrowing the pattern binding
    |
@@ -56,10 +47,7 @@ LL |     match rc {
    |           ^^
 LL |
 LL |         Container(x) => x,
-   |                   -
-   |                   |
-   |                   data moved here
-   |                   move occurs because `x` has type `Struct`, which does not implement the `Copy` trait
+   |                   - data moved here because `x` has type `Struct`, which does not implement the `Copy` trait
    |
 help: consider borrowing the pattern binding
    |

--- a/tests/ui/pattern/move-ref-patterns/move-ref-patterns-default-binding-modes-fixable.stderr
+++ b/tests/ui/pattern/move-ref-patterns/move-ref-patterns-default-binding-modes-fixable.stderr
@@ -4,8 +4,7 @@ error[E0507]: cannot move out of a mutable reference
 LL |     let (a, mut b) = &mut p;
    |             -----    ^^^^^^
    |             |
-   |             data moved here
-   |             move occurs because `b` has type `U`, which does not implement the `Copy` trait
+   |             data moved here because `b` has type `U`, which does not implement the `Copy` trait
    |
 help: consider borrowing the pattern binding
    |

--- a/tests/ui/pattern/move-ref-patterns/move-ref-patterns-default-binding-modes.stderr
+++ b/tests/ui/pattern/move-ref-patterns/move-ref-patterns-default-binding-modes.stderr
@@ -4,8 +4,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     let (a, mut b) = &p;
    |             -----    ^^
    |             |
-   |             data moved here
-   |             move occurs because `b` has type `U`, which does not implement the `Copy` trait
+   |             data moved here because `b` has type `U`, which does not implement the `Copy` trait
    |
 help: consider borrowing the pattern binding
    |

--- a/tests/ui/pattern/mut-pattern-of-immutable-borrow.stderr
+++ b/tests/ui/pattern/mut-pattern-of-immutable-borrow.stderr
@@ -4,10 +4,7 @@ error[E0507]: cannot move out of `arg.field` as enum variant `Some` which is beh
 LL |     match arg.field {
    |           ^^^^^^^^^
 LL |         Some(s) => s.push('a'),
-   |              -
-   |              |
-   |              data moved here
-   |              move occurs because `s` has type `String`, which does not implement the `Copy` trait
+   |              - data moved here because `s` has type `String`, which does not implement the `Copy` trait
    |
 help: consider borrowing here
    |
@@ -31,10 +28,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     match &arg.field {
    |           ^^^^^^^^^^
 LL |         Some(mut s) => s.push('a'),
-   |              -----
-   |              |
-   |              data moved here
-   |              move occurs because `s` has type `String`, which does not implement the `Copy` trait
+   |              ----- data moved here because `s` has type `String`, which does not implement the `Copy` trait
    |
 help: consider borrowing the pattern binding
    |

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.classic2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.classic2021.stderr
@@ -4,8 +4,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     if let Some(&Some(x)) = Some(&Some(&mut 0)) {
    |                       -     ^^^^^^^^^^^^^^^^^^^
    |                       |
-   |                       data moved here
-   |                       move occurs because `x` has type `&mut u32`, which does not implement the `Copy` trait
+   |                       data moved here because `x` has type `&mut u32`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.classic2024.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.classic2024.stderr
@@ -4,8 +4,7 @@ error[E0508]: cannot move out of type `[&mut i32; 1]`, a non-copy array
 LL |     let [&x] = &[&mut 0];
    |           -    ^^^^^^^^^ cannot move out of here
    |           |
-   |           data moved here
-   |           move occurs because `x` has type `&mut i32`, which does not implement the `Copy` trait
+   |           data moved here because `x` has type `&mut i32`, which does not implement the `Copy` trait
    |
 help: consider borrowing the pattern binding
    |
@@ -18,8 +17,7 @@ error[E0508]: cannot move out of type `[&mut i32; 1]`, a non-copy array
 LL |     let [&x] = &mut [&mut 0];
    |           -    ^^^^^^^^^^^^^ cannot move out of here
    |           |
-   |           data moved here
-   |           move occurs because `x` has type `&mut i32`, which does not implement the `Copy` trait
+   |           data moved here because `x` has type `&mut i32`, which does not implement the `Copy` trait
    |
 help: consider borrowing the pattern binding
    |
@@ -32,8 +30,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     if let Some(&Some(x)) = Some(&Some(&mut 0)) {
    |                       -     ^^^^^^^^^^^^^^^^^^^
    |                       |
-   |                       data moved here
-   |                       move occurs because `x` has type `&mut u32`, which does not implement the `Copy` trait
+   |                       data moved here because `x` has type `&mut u32`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -69,8 +66,7 @@ error[E0508]: cannot move out of type `[&mut i32; 1]`, a non-copy array
 LL |     let [&mut x] = &mut [&mut 0];
    |               -    ^^^^^^^^^^^^^ cannot move out of here
    |               |
-   |               data moved here
-   |               move occurs because `x` has type `&mut i32`, which does not implement the `Copy` trait
+   |               data moved here because `x` has type `&mut i32`, which does not implement the `Copy` trait
    |
 help: consider borrowing the pattern binding
    |

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.stable2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.stable2021.stderr
@@ -36,8 +36,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     if let Some(&Some(x)) = Some(&Some(&mut 0)) {
    |                       -     ^^^^^^^^^^^^^^^^^^^
    |                       |
-   |                       data moved here
-   |                       move occurs because `x` has type `&mut u32`, which does not implement the `Copy` trait
+   |                       data moved here because `x` has type `&mut u32`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.structural2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.structural2021.stderr
@@ -4,8 +4,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     if let Some(&Some(x)) = Some(&Some(&mut 0)) {
    |                       -     ^^^^^^^^^^^^^^^^^^^
    |                       |
-   |                       data moved here
-   |                       move occurs because `x` has type `&mut u32`, which does not implement the `Copy` trait
+   |                       data moved here because `x` has type `&mut u32`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.structural2024.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.structural2024.stderr
@@ -4,8 +4,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     if let Some(&Some(x)) = Some(&Some(&mut 0)) {
    |                       -     ^^^^^^^^^^^^^^^^^^^
    |                       |
-   |                       data moved here
-   |                       move occurs because `x` has type `&mut u32`, which does not implement the `Copy` trait
+   |                       data moved here because `x` has type `&mut u32`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |

--- a/tests/ui/pin-ergonomics/pin-pattern.stderr
+++ b/tests/ui/pin-ergonomics/pin-pattern.stderr
@@ -91,8 +91,7 @@ error[E0507]: cannot move out of `foo_mut.pointer` which is behind a mutable ref
 LL |     let &pin mut Foo(x) = foo_mut;
    |                      -    ^^^^^^^
    |                      |
-   |                      data moved here
-   |                      move occurs because `x` has type `T`, which does not implement the `Copy` trait
+   |                      data moved here because `x` has type `T`, which does not implement the `Copy` trait
    |
 help: consider removing the pinned mutable borrow
    |
@@ -106,8 +105,7 @@ error[E0507]: cannot move out of `foo_const.pointer` which is behind a shared re
 LL |     let &pin const Foo(x) = foo_const;
    |                        -    ^^^^^^^^^
    |                        |
-   |                        data moved here
-   |                        move occurs because `x` has type `T`, which does not implement the `Copy` trait
+   |                        data moved here because `x` has type `T`, which does not implement the `Copy` trait
    |
 help: consider removing the pinned borrow
    |
@@ -138,8 +136,7 @@ error[E0507]: cannot move out of a mutable reference
 LL |     ((&pin mut x,),): &'a pin mut (&'a mut (&'a pin mut Foo<T>,),),
    |     ^^^^^^^^^^^-^^^^
    |                |
-   |                data moved here
-   |                move occurs because `x` has type `Foo<T>`, which does not implement the `Copy` trait
+   |                data moved here because `x` has type `Foo<T>`, which does not implement the `Copy` trait
    |
 help: consider borrowing the pattern binding
    |

--- a/tests/ui/rfcs/rfc-2005-default-binding-mode/for.stderr
+++ b/tests/ui/rfcs/rfc-2005-default-binding-mode/for.stderr
@@ -4,8 +4,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     for (n, mut m) in &tups {
    |             -----     ^^^^^
    |             |
-   |             data moved here
-   |             move occurs because `m` has type `Foo`, which does not implement the `Copy` trait
+   |             data moved here because `m` has type `Foo`, which does not implement the `Copy` trait
    |
 help: consider borrowing the pattern binding
    |

--- a/tests/ui/suggestions/dont-suggest-ref/move-into-closure.stderr
+++ b/tests/ui/suggestions/dont-suggest-ref/move-into-closure.stderr
@@ -9,8 +9,7 @@ LL |     consume_fn(|| {
 LL |         let X(_t) = x;
    |               --    ^
    |               |
-   |               data moved here
-   |               move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |               data moved here because `_t` has type `Y`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:14:18
@@ -34,8 +33,7 @@ LL |     consume_fn(|| {
 LL |         if let Either::One(_t) = e { }
    |                            --    ^
    |                            |
-   |                            data moved here
-   |                            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                            data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:14:18
@@ -59,8 +57,7 @@ LL |     consume_fn(|| {
 LL |         while let Either::One(_t) = e { }
    |                               --    ^
    |                               |
-   |                               data moved here
-   |                               move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                               data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:14:18
@@ -85,10 +82,7 @@ LL |         match e {
    |               ^
 ...
 LL |             Either::One(_t)
-   |                         --
-   |                         |
-   |                         data moved here
-   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                         -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:14:18
@@ -113,10 +107,7 @@ LL |         match e {
    |               ^
 ...
 LL |             Either::One(_t) => (),
-   |                         --
-   |                         |
-   |                         data moved here
-   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                         -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:14:18
@@ -140,8 +131,7 @@ LL |     consume_fn(|| {
 LL |         let X(mut _t) = x;
    |               ------    ^
    |               |
-   |               data moved here
-   |               move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |               data moved here because `_t` has type `Y`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:14:18
@@ -165,8 +155,7 @@ LL |     consume_fn(|| {
 LL |         if let Either::One(mut _t) = em { }
    |                            ------    ^^
    |                            |
-   |                            data moved here
-   |                            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                            data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:14:18
@@ -190,8 +179,7 @@ LL |     consume_fn(|| {
 LL |         while let Either::One(mut _t) = em { }
    |                               ------    ^^
    |                               |
-   |                               data moved here
-   |                               move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                               data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:14:18
@@ -216,10 +204,7 @@ LL |         match em {
    |               ^^
 ...
 LL |             Either::One(mut _t)
-   |                         ------
-   |                         |
-   |                         data moved here
-   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                         ------ data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:14:18
@@ -244,10 +229,7 @@ LL |         match em {
    |               ^^
 ...
 LL |             Either::One(mut _t) => (),
-   |                         ------
-   |                         |
-   |                         data moved here
-   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                         ------ data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:14:18
@@ -270,8 +252,7 @@ LL |     <() as T>::consume_fn(|| {
 LL |         let X(_t) = x;
    |               --    ^
    |               |
-   |               data moved here
-   |               move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |               data moved here because `_t` has type `Y`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:40:22
@@ -295,8 +276,7 @@ LL |     <() as T>::consume_fn(|| {
 LL |         if let Either::One(_t) = e { }
    |                            --    ^
    |                            |
-   |                            data moved here
-   |                            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                            data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:40:22
@@ -320,8 +300,7 @@ LL |     <() as T>::consume_fn(|| {
 LL |         while let Either::One(_t) = e { }
    |                               --    ^
    |                               |
-   |                               data moved here
-   |                               move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                               data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:40:22
@@ -346,10 +325,7 @@ LL |         match e {
    |               ^
 ...
 LL |             Either::One(_t)
-   |                         --
-   |                         |
-   |                         data moved here
-   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                         -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:40:22
@@ -374,10 +350,7 @@ LL |         match e {
    |               ^
 ...
 LL |             Either::One(_t) => (),
-   |                         --
-   |                         |
-   |                         data moved here
-   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                         -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:40:22
@@ -401,8 +374,7 @@ LL |     <() as T>::consume_fn(|| {
 LL |         let X(mut _t) = x;
    |               ------    ^
    |               |
-   |               data moved here
-   |               move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |               data moved here because `_t` has type `Y`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:40:22
@@ -426,8 +398,7 @@ LL |     <() as T>::consume_fn(|| {
 LL |         if let Either::One(mut _t) = em { }
    |                            ------    ^^
    |                            |
-   |                            data moved here
-   |                            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                            data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:40:22
@@ -451,8 +422,7 @@ LL |     <() as T>::consume_fn(|| {
 LL |         while let Either::One(mut _t) = em { }
    |                               ------    ^^
    |                               |
-   |                               data moved here
-   |                               move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                               data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:40:22
@@ -477,10 +447,7 @@ LL |         match em {
    |               ^^
 ...
 LL |             Either::One(mut _t)
-   |                         ------
-   |                         |
-   |                         data moved here
-   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                         ------ data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:40:22
@@ -505,10 +472,7 @@ LL |         match em {
    |               ^^
 ...
 LL |             Either::One(mut _t) => (),
-   |                         ------
-   |                         |
-   |                         data moved here
-   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                         ------ data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:40:22
@@ -531,8 +495,7 @@ LL |     ().method_consume_fn(|| {
 LL |         let X(_t) = x;
    |               --    ^
    |               |
-   |               data moved here
-   |               move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |               data moved here because `_t` has type `Y`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:51:29
@@ -556,8 +519,7 @@ LL |     ().method_consume_fn(|| {
 LL |         if let Either::One(_t) = e { }
    |                            --    ^
    |                            |
-   |                            data moved here
-   |                            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                            data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:51:29
@@ -581,8 +543,7 @@ LL |     ().method_consume_fn(|| {
 LL |         while let Either::One(_t) = e { }
    |                               --    ^
    |                               |
-   |                               data moved here
-   |                               move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                               data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:51:29
@@ -607,10 +568,7 @@ LL |         match e {
    |               ^
 ...
 LL |             Either::One(_t)
-   |                         --
-   |                         |
-   |                         data moved here
-   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                         -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:51:29
@@ -635,10 +593,7 @@ LL |         match e {
    |               ^
 ...
 LL |             Either::One(_t) => (),
-   |                         --
-   |                         |
-   |                         data moved here
-   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                         -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:51:29
@@ -662,8 +617,7 @@ LL |     ().method_consume_fn(|| {
 LL |         let X(mut _t) = x;
    |               ------    ^
    |               |
-   |               data moved here
-   |               move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |               data moved here because `_t` has type `Y`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:51:29
@@ -687,8 +641,7 @@ LL |     ().method_consume_fn(|| {
 LL |         if let Either::One(mut _t) = em { }
    |                            ------    ^^
    |                            |
-   |                            data moved here
-   |                            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                            data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:51:29
@@ -712,8 +665,7 @@ LL |     ().method_consume_fn(|| {
 LL |         while let Either::One(mut _t) = em { }
    |                               ------    ^^
    |                               |
-   |                               data moved here
-   |                               move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                               data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:51:29
@@ -738,10 +690,7 @@ LL |         match em {
    |               ^^
 ...
 LL |             Either::One(mut _t)
-   |                         ------
-   |                         |
-   |                         data moved here
-   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                         ------ data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:51:29
@@ -766,10 +715,7 @@ LL |         match em {
    |               ^^
 ...
 LL |             Either::One(mut _t) => (),
-   |                         ------
-   |                         |
-   |                         data moved here
-   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                         ------ data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:51:29
@@ -792,8 +738,7 @@ LL |     consume_fnmut(|| {
 LL |         let X(_t) = x;
    |               --    ^
    |               |
-   |               data moved here
-   |               move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |               data moved here because `_t` has type `Y`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:26:21
@@ -817,8 +762,7 @@ LL |     consume_fnmut(|| {
 LL |         if let Either::One(_t) = e { }
    |                            --    ^
    |                            |
-   |                            data moved here
-   |                            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                            data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:26:21
@@ -842,8 +786,7 @@ LL |     consume_fnmut(|| {
 LL |         while let Either::One(_t) = e { }
    |                               --    ^
    |                               |
-   |                               data moved here
-   |                               move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                               data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:26:21
@@ -868,10 +811,7 @@ LL |         match e {
    |               ^
 ...
 LL |             Either::One(_t)
-   |                         --
-   |                         |
-   |                         data moved here
-   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                         -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:26:21
@@ -896,10 +836,7 @@ LL |         match e {
    |               ^
 ...
 LL |             Either::One(_t) => (),
-   |                         --
-   |                         |
-   |                         data moved here
-   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                         -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:26:21
@@ -923,8 +860,7 @@ LL |     consume_fnmut(|| {
 LL |         let X(mut _t) = x;
    |               ------    ^
    |               |
-   |               data moved here
-   |               move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |               data moved here because `_t` has type `Y`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:26:21
@@ -948,8 +884,7 @@ LL |     consume_fnmut(|| {
 LL |         if let Either::One(mut _t) = em { }
    |                            ------    ^^
    |                            |
-   |                            data moved here
-   |                            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                            data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:26:21
@@ -973,8 +908,7 @@ LL |     consume_fnmut(|| {
 LL |         while let Either::One(mut _t) = em { }
    |                               ------    ^^
    |                               |
-   |                               data moved here
-   |                               move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                               data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:26:21
@@ -999,10 +933,7 @@ LL |         match em {
    |               ^^
 ...
 LL |             Either::One(mut _t)
-   |                         ------
-   |                         |
-   |                         data moved here
-   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                         ------ data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:26:21
@@ -1027,10 +958,7 @@ LL |         match em {
    |               ^^
 ...
 LL |             Either::One(mut _t) => (),
-   |                         ------
-   |                         |
-   |                         data moved here
-   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                         ------ data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:26:21
@@ -1055,10 +983,7 @@ LL |         match em {
    |               ^^
 ...
 LL |             Either::One(mut _t) => (),
-   |                         ------
-   |                         |
-   |                         data moved here
-   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                         ------ data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but `FnOnce` closures may consume them only once
   --> $DIR/move-into-closure.rs:26:21

--- a/tests/ui/suggestions/dont-suggest-ref/simple.stderr
+++ b/tests/ui/suggestions/dont-suggest-ref/simple.stderr
@@ -4,8 +4,7 @@ error[E0507]: cannot move out of `s` which is behind a shared reference
 LL |     let X(_t) = *s;
    |           --    ^^
    |           |
-   |           data moved here
-   |           move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |           data moved here because `_t` has type `Y`, which does not implement the `Copy` trait
    |
 help: consider removing the dereference here
    |
@@ -19,8 +18,7 @@ error[E0507]: cannot move out of `r` as enum variant `One` which is behind a sha
 LL |     if let Either::One(_t) = *r { }
    |                        --    ^^
    |                        |
-   |                        data moved here
-   |                        move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                        data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the dereference here
    |
@@ -34,8 +32,7 @@ error[E0507]: cannot move out of `r` as enum variant `One` which is behind a sha
 LL |     while let Either::One(_t) = *r { }
    |                           --    ^^
    |                           |
-   |                           data moved here
-   |                           move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                           data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the dereference here
    |
@@ -50,10 +47,7 @@ LL |     match *r {
    |           ^^
 ...
 LL |         Either::One(_t)
-   |                     --
-   |                     |
-   |                     data moved here
-   |                     move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                     -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the dereference here
    |
@@ -68,10 +62,7 @@ LL |     match *r {
    |           ^^
 ...
 LL |         Either::One(_t) => (),
-   |                     --
-   |                     |
-   |                     data moved here
-   |                     move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                     -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the dereference here
    |
@@ -85,8 +76,7 @@ error[E0507]: cannot move out of `sm` which is behind a mutable reference
 LL |     let X(_t) = *sm;
    |           --    ^^^
    |           |
-   |           data moved here
-   |           move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |           data moved here because `_t` has type `Y`, which does not implement the `Copy` trait
    |
 help: consider removing the dereference here
    |
@@ -100,8 +90,7 @@ error[E0507]: cannot move out of `rm` as enum variant `One` which is behind a mu
 LL |     if let Either::One(_t) = *rm { }
    |                        --    ^^^
    |                        |
-   |                        data moved here
-   |                        move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                        data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the dereference here
    |
@@ -115,8 +104,7 @@ error[E0507]: cannot move out of `rm` as enum variant `One` which is behind a mu
 LL |     while let Either::One(_t) = *rm { }
    |                           --    ^^^
    |                           |
-   |                           data moved here
-   |                           move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                           data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the dereference here
    |
@@ -131,10 +119,7 @@ LL |     match *rm {
    |           ^^^
 ...
 LL |         Either::One(_t)
-   |                     --
-   |                     |
-   |                     data moved here
-   |                     move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                     -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the dereference here
    |
@@ -149,10 +134,7 @@ LL |     match *rm {
    |           ^^^
 ...
 LL |         Either::One(_t) => (),
-   |                     --
-   |                     |
-   |                     data moved here
-   |                     move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                     -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the dereference here
    |
@@ -167,10 +149,7 @@ LL |     match *rm {
    |           ^^^
 ...
 LL |         Either::One(_t) => (),
-   |                     --
-   |                     |
-   |                     data moved here
-   |                     move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                     -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the dereference here
    |
@@ -184,8 +163,7 @@ error[E0507]: cannot move out of index of `Vec<X>`
 LL |     let X(_t) = vs[0];
    |           --    ^^^^^
    |           |
-   |           data moved here
-   |           move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |           data moved here because `_t` has type `Y`, which does not implement the `Copy` trait
    |
 help: consider borrowing here
    |
@@ -198,8 +176,7 @@ error[E0507]: cannot move out of index of `Vec<Either>`
 LL |     if let Either::One(_t) = vr[0] { }
    |                        --    ^^^^^
    |                        |
-   |                        data moved here
-   |                        move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                        data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider borrowing here
    |
@@ -212,8 +189,7 @@ error[E0507]: cannot move out of index of `Vec<Either>`
 LL |     while let Either::One(_t) = vr[0] { }
    |                           --    ^^^^^
    |                           |
-   |                           data moved here
-   |                           move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                           data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider borrowing here
    |
@@ -227,10 +203,7 @@ LL |     match vr[0] {
    |           ^^^^^
 ...
 LL |         Either::One(_t)
-   |                     --
-   |                     |
-   |                     data moved here
-   |                     move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                     -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider borrowing here
    |
@@ -244,10 +217,7 @@ LL |     match vr[0] {
    |           ^^^^^
 ...
 LL |         Either::One(_t) => (),
-   |                     --
-   |                     |
-   |                     data moved here
-   |                     move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                     -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider borrowing here
    |
@@ -260,8 +230,7 @@ error[E0507]: cannot move out of index of `Vec<X>`
 LL |     let X(_t) = vsm[0];
    |           --    ^^^^^^
    |           |
-   |           data moved here
-   |           move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |           data moved here because `_t` has type `Y`, which does not implement the `Copy` trait
    |
 help: consider borrowing here
    |
@@ -274,8 +243,7 @@ error[E0507]: cannot move out of index of `Vec<Either>`
 LL |     if let Either::One(_t) = vrm[0] { }
    |                        --    ^^^^^^
    |                        |
-   |                        data moved here
-   |                        move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                        data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider borrowing here
    |
@@ -288,8 +256,7 @@ error[E0507]: cannot move out of index of `Vec<Either>`
 LL |     while let Either::One(_t) = vrm[0] { }
    |                           --    ^^^^^^
    |                           |
-   |                           data moved here
-   |                           move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                           data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider borrowing here
    |
@@ -303,10 +270,7 @@ LL |     match vrm[0] {
    |           ^^^^^^
 ...
 LL |         Either::One(_t)
-   |                     --
-   |                     |
-   |                     data moved here
-   |                     move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                     -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider borrowing here
    |
@@ -320,10 +284,7 @@ LL |     match vrm[0] {
    |           ^^^^^^
 ...
 LL |         Either::One(_t) => (),
-   |                     --
-   |                     |
-   |                     data moved here
-   |                     move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                     -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider borrowing here
    |
@@ -337,10 +298,7 @@ LL |     match vrm[0] {
    |           ^^^^^^
 ...
 LL |         Either::One(_t) => (),
-   |                     --
-   |                     |
-   |                     data moved here
-   |                     move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                     -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider borrowing here
    |
@@ -353,8 +311,7 @@ error[E0507]: cannot move out of `s` which is behind a shared reference
 LL |     let &X(_t) = s;
    |            --    ^
    |            |
-   |            data moved here
-   |            move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |            data moved here because `_t` has type `Y`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -368,8 +325,7 @@ error[E0507]: cannot move out of `r` as enum variant `One` which is behind a sha
 LL |     if let &Either::One(_t) = r { }
    |                         --    ^
    |                         |
-   |                         data moved here
-   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                         data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -383,8 +339,7 @@ error[E0507]: cannot move out of `r` as enum variant `One` which is behind a sha
 LL |     while let &Either::One(_t) = r { }
    |                            --    ^
    |                            |
-   |                            data moved here
-   |                            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                            data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -399,10 +354,7 @@ LL |     match r {
    |           ^
 LL |
 LL |         &Either::One(_t)
-   |                      --
-   |                      |
-   |                      data moved here
-   |                      move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                      -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -417,10 +369,7 @@ LL |     match r {
    |           ^
 LL |
 LL |         &Either::One(_t) => (),
-   |                      --
-   |                      |
-   |                      data moved here
-   |                      move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                      -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -435,10 +384,7 @@ LL |     match r {
    |           ^
 LL |
 LL |         &Either::One(_t) => (),
-   |                      --
-   |                      |
-   |                      data moved here
-   |                      move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                      -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -452,8 +398,7 @@ error[E0507]: cannot move out of `sm` which is behind a mutable reference
 LL |     let &mut X(_t) = sm;
    |                --    ^^
    |                |
-   |                data moved here
-   |                move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |                data moved here because `_t` has type `Y`, which does not implement the `Copy` trait
    |
 help: consider removing the mutable borrow
    |
@@ -467,8 +412,7 @@ error[E0507]: cannot move out of `rm` as enum variant `One` which is behind a mu
 LL |     if let &mut Either::One(_t) = rm { }
    |                             --    ^^
    |                             |
-   |                             data moved here
-   |                             move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                             data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the mutable borrow
    |
@@ -482,8 +426,7 @@ error[E0507]: cannot move out of `rm` as enum variant `One` which is behind a mu
 LL |     while let &mut Either::One(_t) = rm { }
    |                                --    ^^
    |                                |
-   |                                data moved here
-   |                                move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                                data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the mutable borrow
    |
@@ -522,10 +465,7 @@ LL |     match rm {
    |           ^^
 LL |
 LL |         &mut Either::One(_t) => (),
-   |                          --
-   |                          |
-   |                          data moved here
-   |                          move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                          -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the mutable borrow
    |
@@ -540,10 +480,7 @@ LL |     match rm {
    |           ^^
 LL |
 LL |         &mut Either::One(_t) => (),
-   |                          --
-   |                          |
-   |                          data moved here
-   |                          move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                          -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the mutable borrow
    |
@@ -558,10 +495,7 @@ LL |     match rm {
    |           ^^
 LL |
 LL |         &mut Either::One(_t) => (),
-   |                          --
-   |                          |
-   |                          data moved here
-   |                          move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                          -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the mutable borrow
    |
@@ -575,8 +509,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     let (&X(_t),) = (&x.clone(),);
    |             --      ^^^^^^^^^^^^^
    |             |
-   |             data moved here
-   |             move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |             data moved here because `_t` has type `Y`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -590,8 +523,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     if let (&Either::One(_t),) = (&e.clone(),) { }
    |                          --      ^^^^^^^^^^^^^
    |                          |
-   |                          data moved here
-   |                          move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                          data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -605,8 +537,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     while let (&Either::One(_t),) = (&e.clone(),) { }
    |                             --      ^^^^^^^^^^^^^
    |                             |
-   |                             data moved here
-   |                             move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                             data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -621,10 +552,7 @@ LL |     match (&e.clone(),) {
    |           ^^^^^^^^^^^^^
 LL |
 LL |         (&Either::One(_t),)
-   |                       --
-   |                       |
-   |                       data moved here
-   |                       move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                       -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -638,8 +566,7 @@ error[E0507]: cannot move out of a mutable reference
 LL |     let (&mut X(_t),) = (&mut xm.clone(),);
    |                 --      ^^^^^^^^^^^^^^^^^^
    |                 |
-   |                 data moved here
-   |                 move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |                 data moved here because `_t` has type `Y`, which does not implement the `Copy` trait
    |
 help: consider removing the mutable borrow
    |
@@ -653,8 +580,7 @@ error[E0507]: cannot move out of a mutable reference
 LL |     if let (&mut Either::One(_t),) = (&mut em.clone(),) { }
    |                              --      ^^^^^^^^^^^^^^^^^^
    |                              |
-   |                              data moved here
-   |                              move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                              data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the mutable borrow
    |
@@ -668,8 +594,7 @@ error[E0507]: cannot move out of a mutable reference
 LL |     while let (&mut Either::One(_t),) = (&mut em.clone(),) { }
    |                                 --      ^^^^^^^^^^^^^^^^^^
    |                                 |
-   |                                 data moved here
-   |                                 move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                                 data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the mutable borrow
    |
@@ -707,8 +632,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     let &X(_t) = &x;
    |            --    ^^
    |            |
-   |            data moved here
-   |            move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |            data moved here because `_t` has type `Y`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -722,8 +646,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     if let &Either::One(_t) = &e { }
    |                         --    ^^
    |                         |
-   |                         data moved here
-   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                         data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -737,8 +660,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     while let &Either::One(_t) = &e { }
    |                            --    ^^
    |                            |
-   |                            data moved here
-   |                            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                            data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -753,10 +675,7 @@ LL |     match &e {
    |           ^^
 LL |
 LL |         &Either::One(_t)
-   |                      --
-   |                      |
-   |                      data moved here
-   |                      move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                      -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -771,10 +690,7 @@ LL |     match &e {
    |           ^^
 LL |
 LL |         &Either::One(_t) => (),
-   |                      --
-   |                      |
-   |                      data moved here
-   |                      move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                      -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -789,10 +705,7 @@ LL |     match &e {
    |           ^^
 LL |
 LL |         &Either::One(_t) => (),
-   |                      --
-   |                      |
-   |                      data moved here
-   |                      move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                      -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -806,8 +719,7 @@ error[E0507]: cannot move out of a mutable reference
 LL |     let &mut X(_t) = &mut xm;
    |                --    ^^^^^^^
    |                |
-   |                data moved here
-   |                move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |                data moved here because `_t` has type `Y`, which does not implement the `Copy` trait
    |
 help: consider removing the mutable borrow
    |
@@ -821,8 +733,7 @@ error[E0507]: cannot move out of a mutable reference
 LL |     if let &mut Either::One(_t) = &mut em { }
    |                             --    ^^^^^^^
    |                             |
-   |                             data moved here
-   |                             move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                             data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the mutable borrow
    |
@@ -836,8 +747,7 @@ error[E0507]: cannot move out of a mutable reference
 LL |     while let &mut Either::One(_t) = &mut em { }
    |                                --    ^^^^^^^
    |                                |
-   |                                data moved here
-   |                                move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                                data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the mutable borrow
    |
@@ -852,10 +762,7 @@ LL |     match &mut em {
    |           ^^^^^^^
 LL |
 LL |         &mut Either::One(_t)
-   |                          --
-   |                          |
-   |                          data moved here
-   |                          move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                          -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the mutable borrow
    |
@@ -870,10 +777,7 @@ LL |     match &mut em {
    |           ^^^^^^^
 LL |
 LL |         &mut Either::One(_t) => (),
-   |                          --
-   |                          |
-   |                          data moved here
-   |                          move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                          -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the mutable borrow
    |
@@ -888,10 +792,7 @@ LL |     match &mut em {
    |           ^^^^^^^
 LL |
 LL |         &mut Either::One(_t) => (),
-   |                          --
-   |                          |
-   |                          data moved here
-   |                          move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                          -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the mutable borrow
    |
@@ -906,10 +807,7 @@ LL |     match &mut em {
    |           ^^^^^^^
 LL |
 LL |         &mut Either::One(_t) => (),
-   |                          --
-   |                          |
-   |                          data moved here
-   |                          move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |                          -- data moved here because `_t` has type `X`, which does not implement the `Copy` trait
    |
 help: consider removing the mutable borrow
    |
@@ -923,8 +821,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     fn f1(&X(_t): &X) { }
    |           ^^^--^
    |              |
-   |              data moved here
-   |              move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |              data moved here because `_t` has type `Y`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -938,8 +835,7 @@ error[E0507]: cannot move out of a mutable reference
 LL |     fn f2(&mut X(_t): &mut X) { }
    |           ^^^^^^^--^
    |                  |
-   |                  data moved here
-   |                  move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |                  data moved here because `_t` has type `Y`, which does not implement the `Copy` trait
    |
 help: consider removing the mutable borrow
    |
@@ -953,8 +849,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     fn f3((&X(_t),): (&X,)) { }
    |           ^^^^--^^^
    |               |
-   |               data moved here
-   |               move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |               data moved here because `_t` has type `Y`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -968,8 +863,7 @@ error[E0507]: cannot move out of a mutable reference
 LL |     fn f4((&mut X(_t),): (&mut X,)) { }
    |           ^^^^^^^^--^^^
    |                   |
-   |                   data moved here
-   |                   move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |                   data moved here because `_t` has type `Y`, which does not implement the `Copy` trait
    |
 help: consider removing the mutable borrow
    |
@@ -983,8 +877,7 @@ error[E0507]: cannot move out of `a.a` as enum variant `Some` which is behind a 
 LL |     let Some(_s) = a.a else {
    |              --    ^^^
    |              |
-   |              data moved here
-   |              move occurs because `_s` has type `String`, which does not implement the `Copy` trait
+   |              data moved here because `_s` has type `String`, which does not implement the `Copy` trait
    |
 help: consider borrowing the pattern binding
    |

--- a/tests/ui/suggestions/non_copy_move_out_of_tuple.stderr
+++ b/tests/ui/suggestions/non_copy_move_out_of_tuple.stderr
@@ -4,8 +4,7 @@ error[E0507]: cannot move out of `tuple.0` which is behind a shared reference
 LL |     (b,) = *tuple;
    |      -     ^^^^^^
    |      |
-   |      data moved here
-   |      move occurs because the place has type `NonCopy`, which does not implement the `Copy` trait
+   |      data moved here because the place has type `NonCopy`, which does not implement the `Copy` trait
    |
 note: if `NonCopy` implemented `Clone`, you could clone the value
   --> $DIR/non_copy_move_out_of_tuple.rs:3:1

--- a/tests/ui/suggestions/option-content-move-from-tuple-match.stderr
+++ b/tests/ui/suggestions/option-content-move-from-tuple-match.stderr
@@ -5,10 +5,7 @@ LL |     match (a, b) {
    |           ^^^^^^
 LL |
 LL |         (None, &c) => &c.unwrap(),
-   |                 -
-   |                 |
-   |                 data moved here
-   |                 move occurs because `c` has type `Option<String>`, which does not implement the `Copy` trait
+   |                 - data moved here because `c` has type `Option<String>`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |

--- a/tests/ui/type-alias-impl-trait/error-tainting-issue-122904.stderr
+++ b/tests/ui/type-alias-impl-trait/error-tainting-issue-122904.stderr
@@ -16,8 +16,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     with_positive(|&n| ());
    |                    ^-
    |                     |
-   |                     data moved here
-   |                     move occurs because `n` has type `S`, which does not implement the `Copy` trait
+   |                     data moved here because `n` has type `S`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |

--- a/tests/ui/type-alias-impl-trait/recursive-drop-elaboration-2.stderr
+++ b/tests/ui/type-alias-impl-trait/recursive-drop-elaboration-2.stderr
@@ -16,8 +16,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     with_positive(|&n| ());
    |                    ^-
    |                     |
-   |                     data moved here
-   |                     move occurs because `n` has type `S`, which does not implement the `Copy` trait
+   |                     data moved here because `n` has type `S`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |

--- a/tests/ui/type-alias-impl-trait/recursive-drop-elaboration.stderr
+++ b/tests/ui/type-alias-impl-trait/recursive-drop-elaboration.stderr
@@ -16,8 +16,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     with_positive(|&n| ());
    |                    ^-
    |                     |
-   |                     data moved here
-   |                     move occurs because `n` has type `S`, which does not implement the `Copy` trait
+   |                     data moved here because `n` has type `S`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |
@@ -31,8 +30,7 @@ error[E0507]: cannot move out of a shared reference
 LL |     with_positive(|&a| ());
    |                    ^-
    |                     |
-   |                     data moved here
-   |                     move occurs because `a` has type `S`, which does not implement the `Copy` trait
+   |                     data moved here because `a` has type `S`, which does not implement the `Copy` trait
    |
 help: consider removing the borrow
    |


### PR DESCRIPTION
Fixes rust-lang/rust#153506.

When there's a single binding in a move error, we emit "data moved here" and "move occurs because ... does not implement the Copy trait" as two separate labels on the same span. This combines them into one label via a new `TypeNoCopy::LabelMovedHere` variant.

The multi-binding case still uses separate labels + a note since they point at different spans.

cc @estebank 