### PR TITLE
Remove `QueryInfo`.

### DIFF
--- a/compiler/rustc_middle/src/query/job.rs
+++ b/compiler/rustc_middle/src/query/job.rs
@@ -7,16 +7,7 @@ use parking_lot::{Condvar, Mutex};
 use rustc_span::Span;
 
 use crate::query::plumbing::CycleError;
-use crate::query::stack::QueryStackFrame;
 use crate::ty::TyCtxt;
-
-/// Represents a span and a query key.
-#[derive(Clone, Debug)]
-pub struct QueryInfo<'tcx> {
-    /// The span corresponding to the reason for which this query was required.
-    pub span: Span,
-    pub frame: QueryStackFrame<'tcx>,
-}
 
 /// A value uniquely identifying an active query job.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1,7 +1,7 @@
 use rustc_hir::def_id::LocalDefId;
 
 pub use self::caches::{DefIdCache, DefaultCache, QueryCache, SingleCache, VecCache};
-pub use self::job::{QueryInfo, QueryJob, QueryJobId, QueryLatch, QueryWaiter};
+pub use self::job::{QueryJob, QueryJobId, QueryLatch, QueryWaiter};
 pub use self::keys::{AsLocalQueryKey, LocalCrate, QueryKey};
 pub use self::plumbing::{
     ActiveKeyStatus, CycleError, EnsureMode, IntoQueryParam, QueryMode, QueryState, TyCtxtAt,

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -50,7 +50,7 @@ pub enum ActiveKeyStatus<'tcx> {
     Poisoned,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct CycleError<'tcx> {
     /// The query and related span that uses the cycle.
     pub usage: Option<Spanned<QueryStackFrame<'tcx>>>,

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -8,7 +8,7 @@ use rustc_data_structures::sync::{AtomicU64, WorkerLocal};
 use rustc_errors::Diag;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::hir_id::OwnerId;
-use rustc_span::Span;
+use rustc_span::{Span, Spanned};
 pub use sealed::IntoQueryParam;
 
 use crate::dep_graph::{DepKind, DepNodeIndex, SerializedDepNodeIndex};
@@ -16,7 +16,7 @@ use crate::ich::StableHashingContext;
 use crate::queries::{ExternProviders, Providers, QueryArenas, QueryVTables, TaggedQueryKey};
 use crate::query::on_disk_cache::OnDiskCache;
 use crate::query::stack::QueryStackFrame;
-use crate::query::{QueryCache, QueryInfo, QueryJob};
+use crate::query::{QueryCache, QueryJob};
 use crate::ty::TyCtxt;
 
 /// For a particular query, keeps track of "active" keys, i.e. keys whose
@@ -53,8 +53,10 @@ pub enum ActiveKeyStatus<'tcx> {
 #[derive(Clone, Debug)]
 pub struct CycleError<'tcx> {
     /// The query and related span that uses the cycle.
-    pub usage: Option<(Span, QueryStackFrame<'tcx>)>,
-    pub cycle: Vec<QueryInfo<'tcx>>,
+    pub usage: Option<Spanned<QueryStackFrame<'tcx>>>,
+
+    /// The span here corresponds to the reason for which this query was required.
+    pub cycle: Vec<Spanned<QueryStackFrame<'tcx>>>,
 }
 
 #[derive(Debug)]

--- a/compiler/rustc_query_impl/src/from_cycle_error.rs
+++ b/compiler/rustc_query_impl/src/from_cycle_error.rs
@@ -76,11 +76,11 @@ fn fn_sig<'tcx>(
 fn check_representability<'tcx>(tcx: TyCtxt<'tcx>, cycle_error: CycleError<'tcx>) -> ! {
     let mut item_and_field_ids = Vec::new();
     let mut representable_ids = FxHashSet::default();
-    for info in &cycle_error.cycle {
-        if info.frame.dep_kind == DepKind::check_representability
-            && let Some(field_id) = info.frame.def_id
+    for frame in &cycle_error.cycle {
+        if frame.node.dep_kind == DepKind::check_representability
+            && let Some(field_id) = frame.node.def_id
             && let Some(field_id) = field_id.as_local()
-            && let Some(DefKind::Field) = info.frame.tagged_key.def_kind(tcx)
+            && let Some(DefKind::Field) = frame.node.tagged_key.def_kind(tcx)
         {
             let parent_id = tcx.parent(field_id.to_def_id());
             let item_id = match tcx.def_kind(parent_id) {
@@ -90,8 +90,8 @@ fn check_representability<'tcx>(tcx: TyCtxt<'tcx>, cycle_error: CycleError<'tcx>
             item_and_field_ids.push((item_id.expect_local(), field_id));
         }
     }
-    for info in &cycle_error.cycle {
-        if let TaggedQueryKey::check_representability_adt_ty(key) = info.frame.tagged_key
+    for frame in &cycle_error.cycle {
+        if let TaggedQueryKey::check_representability_adt_ty(key) = frame.node.tagged_key
             && let Some(adt) = key.ty_adt_def()
             && let Some(def_id) = adt.did().as_local()
             && !item_and_field_ids.iter().any(|&(id, _)| id == def_id)
@@ -109,9 +109,9 @@ fn variances_of<'tcx>(tcx: TyCtxt<'tcx>, cycle_error: CycleError<'tcx>) -> &'tcx
     search_for_cycle_permutation(
         &cycle_error.cycle,
         |cycle| {
-            if let Some(info) = cycle.get(0)
-                && info.frame.dep_kind == DepKind::variances_of
-                && let Some(def_id) = info.frame.def_id
+            if let Some(frame) = cycle.get(0)
+                && frame.node.dep_kind == DepKind::variances_of
+                && let Some(def_id) = frame.node.def_id
             {
                 let n = tcx.generics_of(def_id).own_params.len();
                 ControlFlow::Break(tcx.arena.alloc_from_iter(iter::repeat_n(ty::Bivariant, n)))
@@ -121,7 +121,7 @@ fn variances_of<'tcx>(tcx: TyCtxt<'tcx>, cycle_error: CycleError<'tcx>) -> &'tcx
         },
         || {
             span_bug!(
-                cycle_error.usage.as_ref().unwrap().0,
+                cycle_error.usage.as_ref().unwrap().span,
                 "only `variances_of` returns `&[ty::Variance]`"
             )
         },
@@ -154,7 +154,7 @@ fn layout_of<'tcx>(
     let diag = search_for_cycle_permutation(
         &cycle_error.cycle,
         |cycle| {
-            if let TaggedQueryKey::layout_of(key) = cycle[0].frame.tagged_key
+            if let TaggedQueryKey::layout_of(key) = cycle[0].node.tagged_key
                 && let ty::Coroutine(def_id, _) = key.value.kind()
                 && let Some(def_id) = def_id.as_local()
                 && let def_kind = tcx.def_kind(def_id)
@@ -178,8 +178,8 @@ fn layout_of<'tcx>(
                     tcx.def_kind_descr_article(def_kind, def_id.to_def_id()),
                     tcx.def_kind_descr(def_kind, def_id.to_def_id()),
                 );
-                for (i, info) in cycle.iter().enumerate() {
-                    let TaggedQueryKey::layout_of(frame_key) = info.frame.tagged_key else {
+                for (i, frame) in cycle.iter().enumerate() {
+                    let TaggedQueryKey::layout_of(frame_key) = frame.node.tagged_key else {
                         continue;
                     };
                     let &ty::Coroutine(frame_def_id, _) = frame_key.value.kind() else {
@@ -189,7 +189,7 @@ fn layout_of<'tcx>(
                         continue;
                     };
                     let frame_span =
-                        info.frame.tagged_key.default_span(tcx, cycle[(i + 1) % cycle.len()].span);
+                        frame.node.tagged_key.default_span(tcx, cycle[(i + 1) % cycle.len()].span);
                     if frame_span.is_dummy() {
                         continue;
                     }

--- a/compiler/rustc_query_impl/src/job.rs
+++ b/compiler/rustc_query_impl/src/job.rs
@@ -7,10 +7,10 @@ use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_errors::{Diag, DiagCtxtHandle};
 use rustc_hir::def::DefKind;
 use rustc_middle::query::{
-    CycleError, QueryInfo, QueryJob, QueryJobId, QueryLatch, QueryStackFrame, QueryWaiter,
+    CycleError, QueryJob, QueryJobId, QueryLatch, QueryStackFrame, QueryWaiter,
 };
 use rustc_middle::ty::TyCtxt;
-use rustc_span::{DUMMY_SP, Span};
+use rustc_span::{DUMMY_SP, Span, respan};
 
 use crate::{CollectActiveJobsKind, collect_active_jobs_from_all_queries};
 
@@ -64,7 +64,7 @@ pub(crate) fn find_cycle_in_stack<'tcx>(
 
     while let Some(job) = current_job {
         let info = &job_map.map[&job];
-        cycle.push(QueryInfo { span: info.job.span, frame: info.frame.clone() });
+        cycle.push(respan(info.job.span, info.frame.clone()));
 
         if job == id {
             cycle.reverse();
@@ -77,7 +77,7 @@ pub(crate) fn find_cycle_in_stack<'tcx>(
             // Find out why the cycle itself was used
             let usage = try {
                 let parent = info.job.parent?;
-                (info.job.span, job_map.frame_of(parent).clone())
+                respan(info.job.span, job_map.frame_of(parent).clone())
             };
             return CycleError { usage, cycle };
         }
@@ -313,14 +313,14 @@ fn remove_cycle<'tcx>(
 
         let usage = entry_point
             .query_waiting_on_cycle
-            .map(|(span, job)| (span, job_map.frame_of(job).clone()));
+            .map(|(span, job)| respan(span, job_map.frame_of(job).clone()));
 
         // Create the cycle error
         let error = CycleError {
             usage,
             cycle: stack
                 .iter()
-                .map(|&(span, job)| QueryInfo { span, frame: job_map.frame_of(job).clone() })
+                .map(|&(span, job)| respan(span, job_map.frame_of(job).clone()))
                 .collect(),
         };
 
@@ -454,12 +454,12 @@ pub(crate) fn report_cycle<'tcx>(
 ) -> Diag<'tcx> {
     assert!(!stack.is_empty());
 
-    let span = stack[0].frame.tagged_key.default_span(tcx, stack[1 % stack.len()].span);
+    let span = stack[0].node.tagged_key.default_span(tcx, stack[1 % stack.len()].span);
 
     let mut cycle_stack = Vec::new();
 
     use crate::error::StackCount;
-    let stack_bottom = stack[0].frame.tagged_key.description(tcx);
+    let stack_bottom = stack[0].node.tagged_key.description(tcx);
     let stack_count = if stack.len() == 1 {
         StackCount::Single { stack_bottom: stack_bottom.clone() }
     } else {
@@ -467,28 +467,27 @@ pub(crate) fn report_cycle<'tcx>(
     };
 
     for i in 1..stack.len() {
-        let frame = &stack[i].frame;
-        let span = frame.tagged_key.default_span(tcx, stack[(i + 1) % stack.len()].span);
-        cycle_stack
-            .push(crate::error::CycleStack { span, desc: frame.tagged_key.description(tcx) });
+        let node = &stack[i].node;
+        let span = node.tagged_key.default_span(tcx, stack[(i + 1) % stack.len()].span);
+        cycle_stack.push(crate::error::CycleStack { span, desc: node.tagged_key.description(tcx) });
     }
 
     let mut cycle_usage = None;
-    if let Some((span, ref query)) = *usage {
+    if let Some(usage) = usage {
         cycle_usage = Some(crate::error::CycleUsage {
-            span: query.tagged_key.default_span(tcx, span),
-            usage: query.tagged_key.description(tcx),
+            span: usage.node.tagged_key.default_span(tcx, usage.span),
+            usage: usage.node.tagged_key.description(tcx),
         });
     }
 
     let alias = if stack
         .iter()
-        .all(|entry| matches!(entry.frame.tagged_key.def_kind(tcx), Some(DefKind::TyAlias)))
+        .all(|entry| matches!(entry.node.tagged_key.def_kind(tcx), Some(DefKind::TyAlias)))
     {
         Some(crate::error::Alias::Ty)
     } else if stack
         .iter()
-        .all(|entry| entry.frame.tagged_key.def_kind(tcx) == Some(DefKind::TraitAlias))
+        .all(|entry| entry.node.tagged_key.def_kind(tcx) == Some(DefKind::TraitAlias))
     {
         Some(crate::error::Alias::Trait)
     } else {


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/153639)*
<!-- homu-ignore:end -->

`CycleError` has one field containing a `(Span, QueryStackFrame<I>)` and another field containing a `QueryInfo`, which is a struct containing just a `Span` and a `QueryStackFrame<I>`.

We already have the `Spanned` type for adding a span to something. This commit uses it for both fields in `CycleError`, removing the need for `QueryInfo`. Which is good for the following reasons.
- Any type with `Info` in the name is suspect, IMO.
- `QueryInfo` can no longer be confused with the similar `QueryJobInfo`.
- The doc comment on `QueryInfo` was wrong; it didn't contain a query key.

r? @Mark-Simulacrum 