### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_middle/src/lint.rs
+++ b/compiler/rustc_middle/src/lint.rs
@@ -298,7 +298,6 @@ fn explain_lint_level_source(
 /// If you are looking to implement a lint, look for higher level functions,
 /// for example:
 /// - [`TyCtxt::emit_node_span_lint`]
-/// - [`TyCtxt::node_span_lint`]
 /// - [`TyCtxt::node_lint`]
 /// - `LintContext::opt_span_lint`
 ///
@@ -488,7 +487,6 @@ pub fn lint_level(
 /// for example:
 ///
 /// - [`TyCtxt::emit_node_span_lint`]
-/// - [`TyCtxt::node_span_lint`]
 /// - [`TyCtxt::node_lint`]
 /// - `LintContext::opt_span_lint`
 ///

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2542,21 +2542,6 @@ impl<'tcx> TyCtxt<'tcx> {
         diag_lint_level(self.sess, lint, level, Some(span.into()), decorator)
     }
 
-    /// Emit a lint at the appropriate level for a hir node, with an associated span.
-    ///
-    /// [`lint_level`]: rustc_middle::lint::lint_level#decorate-signature
-    #[track_caller]
-    pub fn node_span_lint(
-        self,
-        lint: &'static Lint,
-        hir_id: HirId,
-        span: impl Into<MultiSpan>,
-        decorate: impl for<'a, 'b> FnOnce(&'b mut Diag<'a, ()>),
-    ) {
-        let level = self.lint_level_at_node(lint, hir_id);
-        lint_level(self.sess, lint, level, Some(span.into()), decorate);
-    }
-
     /// Find the appropriate span where `use` and outer attributes can be inserted at.
     pub fn crate_level_attribute_injection_span(self) -> Span {
         let node = self.hir_node(hir::CRATE_HIR_ID);

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1776,7 +1776,7 @@ impl<T> Option<T> {
     #[rustc_const_unstable(feature = "const_option_ops", issue = "143956")]
     pub const fn get_or_insert_default(&mut self) -> &mut T
     where
-        T: [const] Default + [const] Destruct,
+        T: [const] Default,
     {
         self.get_or_insert_with(T::default)
     }
@@ -1804,10 +1804,25 @@ impl<T> Option<T> {
     pub const fn get_or_insert_with<F>(&mut self, f: F) -> &mut T
     where
         F: [const] FnOnce() -> T + [const] Destruct,
-        T: [const] Destruct,
     {
         if let None = self {
-            *self = Some(f());
+            // The effect of the following statement is identical to
+            //     *self = Some(f());
+            // except that it does not drop the old value of `*self`. This is not a leak, because
+            // we just checked that the old value is `None`, which contains no fields to drop.
+            // This implementation strategy
+            //
+            // * avoids needing a `T: [const] Destruct` bound, to the benefit of `const` callers,
+            // * and avoids possibly compiling needless drop code (as would sometimes happen in the
+            //   previous implementation), to the benefit of non-`const` callers.
+            //
+            // FIXME(const-hack): It would be nice if this weird trick were made obsolete
+            // (though that is likely to be hard/wontfix).
+            //
+            // It could also be expressed as `unsafe { core::ptr::write(self, Some(f())) }`, but
+            // no reason is currently known to use additional unsafe code here.
+
+            mem::forget(mem::replace(self, Some(f())));
         }
 
         // SAFETY: a `None` variant for `self` would have been replaced by a `Some`

--- a/library/coretests/tests/option.rs
+++ b/library/coretests/tests/option.rs
@@ -495,6 +495,30 @@ const fn option_const_mut() {
     */
 }
 
+/// Test that `Option::get_or_insert_default` is usable in const contexts, including with types that
+/// do not satisfy `T: const Destruct`.
+#[test]
+fn const_get_or_insert_default() {
+    const OPT_DEFAULT: Option<Vec<bool>> = {
+        let mut x = None;
+        x.get_or_insert_default();
+        x
+    };
+    assert!(OPT_DEFAULT.is_some());
+}
+
+/// Test that `Option::get_or_insert_with` is usable in const contexts, including with types that
+/// do not satisfy `T: const Destruct`.
+#[test]
+fn const_get_or_insert_with() {
+    const OPT_WITH: Option<Vec<bool>> = {
+        let mut x = None;
+        x.get_or_insert_with(Vec::new);
+        x
+    };
+    assert!(OPT_WITH.is_some());
+}
+
 #[test]
 fn test_unwrap_drop() {
     struct Dtor<'a> {

--- a/src/librustdoc/passes/lint/bare_urls.rs
+++ b/src/librustdoc/passes/lint/bare_urls.rs
@@ -6,7 +6,7 @@ use std::mem;
 use std::sync::LazyLock;
 
 use regex::Regex;
-use rustc_errors::Applicability;
+use rustc_errors::{Applicability, DiagDecorator};
 use rustc_hir::HirId;
 use rustc_resolve::rustdoc::pulldown_cmark::{Event, Parser, Tag};
 use rustc_resolve::rustdoc::source_span_for_markdown_range;
@@ -24,30 +24,35 @@ pub(super) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &
         let maybe_sp = source_span_for_markdown_range(cx.tcx, dox, &range, &item.attrs.doc_strings)
             .map(|(sp, _)| sp);
         let sp = maybe_sp.unwrap_or_else(|| item.attr_span(cx.tcx));
-        cx.tcx.node_span_lint(crate::lint::BARE_URLS, hir_id, sp, |lint| {
-            lint.primary_message(msg)
-                .note("bare URLs are not automatically turned into clickable links");
-            // The fallback of using the attribute span is suitable for
-            // highlighting where the error is, but not for placing the < and >
-            if let Some(sp) = maybe_sp {
-                if let Some(without_brackets) = without_brackets {
-                    lint.multipart_suggestion(
-                        "use an automatic link instead",
-                        vec![(sp, format!("<{without_brackets}>"))],
-                        Applicability::MachineApplicable,
-                    );
-                } else {
-                    lint.multipart_suggestion(
-                        "use an automatic link instead",
-                        vec![
-                            (sp.shrink_to_lo(), "<".to_string()),
-                            (sp.shrink_to_hi(), ">".to_string()),
-                        ],
-                        Applicability::MachineApplicable,
-                    );
+        cx.tcx.emit_node_span_lint(
+            crate::lint::BARE_URLS,
+            hir_id,
+            sp,
+            DiagDecorator(|lint| {
+                lint.primary_message(msg)
+                    .note("bare URLs are not automatically turned into clickable links");
+                // The fallback of using the attribute span is suitable for
+                // highlighting where the error is, but not for placing the < and >
+                if let Some(sp) = maybe_sp {
+                    if let Some(without_brackets) = without_brackets {
+                        lint.multipart_suggestion(
+                            "use an automatic link instead",
+                            vec![(sp, format!("<{without_brackets}>"))],
+                            Applicability::MachineApplicable,
+                        );
+                    } else {
+                        lint.multipart_suggestion(
+                            "use an automatic link instead",
+                            vec![
+                                (sp.shrink_to_lo(), "<".to_string()),
+                                (sp.shrink_to_hi(), ">".to_string()),
+                            ],
+                            Applicability::MachineApplicable,
+                        );
+                    }
                 }
-            }
-        });
+            }),
+        );
     };
 
     let mut p = Parser::new_ext(dox, main_body_opts()).into_offset_iter();

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -683,7 +683,13 @@ pub enum ItemEnum {
 }
 
 impl ItemEnum {
-    /// Returns the [`ItemKind`] of this item.
+    /// Get just the kind of this item, but with no further data.
+    ///
+    /// ```rust
+    /// # use rustdoc_json_types::{ItemKind, ItemEnum};
+    /// let item = ItemEnum::ExternCrate { name: "libc".to_owned(), rename: None };
+    /// assert_eq!(item.item_kind(), ItemKind::ExternCrate);
+    /// ```
     pub fn item_kind(&self) -> ItemKind {
         match self {
             ItemEnum::Module(_) => ItemKind::Module,

--- a/src/tools/clippy/clippy.toml
+++ b/src/tools/clippy/clippy.toml
@@ -13,5 +13,5 @@ path = "rustc_lint::context::LintContext::span_lint"
 reason = "this function does not add a link to our documentation; please use the `clippy_utils::diagnostics::span_lint*` functions instead"
 
 [[disallowed-methods]]
-path = "rustc_middle::ty::context::TyCtxt::node_span_lint"
+path = "rustc_middle::ty::context::TyCtxt::emit_node_span_lint"
 reason = "this function does not add a link to our documentation; please use the `clippy_utils::diagnostics::span_lint_hir*` functions instead"

--- a/src/tools/clippy/clippy_utils/src/diagnostics.rs
+++ b/src/tools/clippy/clippy_utils/src/diagnostics.rs
@@ -326,14 +326,14 @@ pub fn span_lint_hir_and_then(
     f: impl FnOnce(&mut Diag<'_, ()>),
 ) {
     #[expect(clippy::disallowed_methods)]
-    cx.tcx.node_span_lint(lint, hir_id, sp, |diag| {
+    cx.tcx.emit_node_span_lint(lint, hir_id, sp, rustc_errors::DiagDecorator(|diag| {
         diag.primary_message(msg);
         f(diag);
         docs_link(diag, lint);
 
         #[cfg(debug_assertions)]
         validate_diag(diag);
-    });
+    }));
 }
 
 /// Add a span lint with a suggestion on how to fix it.

--- a/src/tools/clippy/tests/ui-internal/disallow_span_lint.rs
+++ b/src/tools/clippy/tests/ui-internal/disallow_span_lint.rs
@@ -6,7 +6,7 @@ extern crate rustc_hir;
 extern crate rustc_lint;
 extern crate rustc_middle;
 
-use rustc_errors::{DiagMessage, MultiSpan};
+use rustc_errors::{DiagDecorator, DiagMessage, MultiSpan};
 use rustc_hir::hir_id::HirId;
 use rustc_lint::{Lint, LintContext};
 use rustc_middle::ty::TyCtxt;
@@ -19,10 +19,10 @@ pub fn a(cx: impl LintContext, lint: &'static Lint, span: impl Into<MultiSpan>, 
 }
 
 pub fn b(tcx: TyCtxt<'_>, lint: &'static Lint, hir_id: HirId, span: impl Into<MultiSpan>, msg: impl Into<DiagMessage>) {
-    tcx.node_span_lint(lint, hir_id, span, |lint| {
+    tcx.emit_node_span_lint(lint, hir_id, span, DiagDecorator(|lint| {
         //~^ disallowed_methods
         lint.primary_message(msg);
-    });
+    }));
 }
 
 fn main() {}

--- a/tests/ui/cfg/both-true-false.rs
+++ b/tests/ui/cfg/both-true-false.rs
@@ -1,5 +1,6 @@
 /// Test that placing a `cfg(true)` and `cfg(false)` on the same item result in
 //. it being disabled.`
+//@ reference: cfg.attr.duplicates
 
 #[cfg(false)]
 #[cfg(true)]

--- a/tests/ui/cfg/both-true-false.stderr
+++ b/tests/ui/cfg/both-true-false.stderr
@@ -1,11 +1,11 @@
 error[E0425]: cannot find function `foo` in this scope
-  --> $DIR/both-true-false.rs:13:5
+  --> $DIR/both-true-false.rs:14:5
    |
 LL |     foo();
    |     ^^^ not found in this scope
    |
 note: found an item that was configured out
-  --> $DIR/both-true-false.rs:6:4
+  --> $DIR/both-true-false.rs:7:4
    |
 LL | #[cfg(false)]
    |       ----- the item is gated here
@@ -13,7 +13,7 @@ LL | #[cfg(true)]
 LL | fn foo() {}
    |    ^^^
 note: found an item that was configured out
-  --> $DIR/both-true-false.rs:10:4
+  --> $DIR/both-true-false.rs:11:4
    |
 LL | #[cfg(false)]
    |       ----- the item is gated here

--- a/tests/ui/cfg/cfg-false-use-item.rs
+++ b/tests/ui/cfg/cfg-false-use-item.rs
@@ -1,6 +1,8 @@
 //! Test that use items with cfg(false) are properly filtered out
 
 //@ run-pass
+//@ reference: cfg.predicate.literal
+//@ reference: cfg.attr.effect
 
 pub fn main() {
     // Make sure that this view item is filtered out because otherwise it would

--- a/tests/ui/cfg/cfg-family.rs
+++ b/tests/ui/cfg/cfg-family.rs
@@ -1,6 +1,8 @@
 //@ build-pass
 //@ ignore-wasm32 no bare family
 //@ ignore-sgx
+//@ reference: cfg.target_family.unix
+//@ reference: cfg.target_family.windows
 
 #[cfg(windows)]
 pub fn main() {

--- a/tests/ui/cfg/cfg-panic-abort.rs
+++ b/tests/ui/cfg/cfg-panic-abort.rs
@@ -2,6 +2,8 @@
 //@ compile-flags: -C panic=abort
 //@ no-prefer-dynamic
 //@ ignore-backends: gcc
+//@ reference: cfg.panic.def
+//@ reference: cfg.panic.values
 
 #[cfg(panic = "unwind")]
 pub fn bad() -> i32 { }

--- a/tests/ui/cfg/cfg-panic.rs
+++ b/tests/ui/cfg/cfg-panic.rs
@@ -1,6 +1,8 @@
 //@ build-pass
 //@ compile-flags: -C panic=unwind
 //@ needs-unwind
+//@ reference: cfg.panic.def
+//@ reference: cfg.panic.values
 
 #[cfg(panic = "abort")]
 pub fn bad() -> i32 { }

--- a/tests/ui/cfg/cfg-path-error.rs
+++ b/tests/ui/cfg/cfg-path-error.rs
@@ -1,4 +1,5 @@
 //@ check-fail
+//@ reference: cfg.option-spec
 
 #![allow(unexpected_cfgs)] // invalid cfgs
 

--- a/tests/ui/cfg/cfg-path-error.stderr
+++ b/tests/ui/cfg/cfg-path-error.stderr
@@ -1,5 +1,5 @@
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/cfg-path-error.rs:5:1
+  --> $DIR/cfg-path-error.rs:6:1
    |
 LL | #[cfg(any(foo, foo::bar))]
    | ^^^^^^^^^^^^^^^--------^^^
@@ -10,7 +10,7 @@ LL | #[cfg(any(foo, foo::bar))]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/cfg-path-error.rs:11:1
+  --> $DIR/cfg-path-error.rs:12:1
    |
 LL | #[cfg(any(foo::bar, foo))]
    | ^^^^^^^^^^--------^^^^^^^^
@@ -21,7 +21,7 @@ LL | #[cfg(any(foo::bar, foo))]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/cfg-path-error.rs:17:1
+  --> $DIR/cfg-path-error.rs:18:1
    |
 LL | #[cfg(all(foo, foo::bar))]
    | ^^^^^^^^^^^^^^^--------^^^
@@ -32,7 +32,7 @@ LL | #[cfg(all(foo, foo::bar))]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/cfg-path-error.rs:23:1
+  --> $DIR/cfg-path-error.rs:24:1
    |
 LL | #[cfg(all(foo::bar, foo))]
    | ^^^^^^^^^^--------^^^^^^^^

--- a/tests/ui/cfg/cfg-target-abi.rs
+++ b/tests/ui/cfg/cfg-target-abi.rs
@@ -1,4 +1,6 @@
 //@ run-pass
+//@ reference: cfg.target_abi.def
+//@ reference: cfg.target_abi.values
 
 #[cfg(target_abi = "eabihf")]
 pub fn main() {

--- a/tests/ui/cfg/cfg-target-family.rs
+++ b/tests/ui/cfg/cfg-target-family.rs
@@ -1,5 +1,7 @@
 //@ build-pass
 //@ ignore-sgx
+//@ reference: cfg.target_family.def
+//@ reference: cfg.target_family.values
 
 
 #[cfg(target_family = "windows")]

--- a/tests/ui/cfg/cfg-target-vendor.rs
+++ b/tests/ui/cfg/cfg-target-vendor.rs
@@ -1,4 +1,6 @@
 //@ run-pass
+//@ reference: cfg.target_vendor.def
+//@ reference: cfg.target_vendor.values
 #[cfg(target_vendor = "unknown")]
 pub fn main() {
 }

--- a/tests/ui/cfg/cfg_attr.rs
+++ b/tests/ui/cfg/cfg_attr.rs
@@ -1,5 +1,7 @@
 //@ run-pass
 //@ compile-flags:--cfg set1 --cfg set2
+//@ reference: cfg.cfg_attr.intro
+//@ reference: cfg.cfg_attr.syntax
 
 #![allow(dead_code, unexpected_cfgs)]
 

--- a/tests/ui/cfg/cfg_false_no_std-1.rs
+++ b/tests/ui/cfg/cfg_false_no_std-1.rs
@@ -2,6 +2,7 @@
 
 //@ check-pass
 //@ aux-build: cfg_false_lib_no_std_after.rs
+//@ reference: cfg.attr.crate-level-attrs
 
 #![no_std]
 

--- a/tests/ui/cfg/cfg_false_no_std-2.rs
+++ b/tests/ui/cfg/cfg_false_no_std-2.rs
@@ -7,6 +7,7 @@
 //@ compile-flags: -Cpanic=abort
 
 //@ aux-build: cfg_false_lib_no_std_before.rs
+//@ reference: cfg.attr.crate-level-attrs
 
 #![no_std]
 

--- a/tests/ui/cfg/cfg_false_no_std.rs
+++ b/tests/ui/cfg/cfg_false_no_std.rs
@@ -2,6 +2,7 @@
 
 //@ check-pass
 //@ aux-build: cfg_false_lib.rs
+//@ reference: cfg.attr.crate-level-attrs
 
 #![no_std]
 

--- a/tests/ui/cfg/cfg_stmt_expr.rs
+++ b/tests/ui/cfg/cfg_stmt_expr.rs
@@ -1,4 +1,5 @@
 //@ run-pass
+//@ reference: cfg.attr.allowed-positions
 #![allow(dead_code)]
 #![allow(unused_mut)]
 #![allow(unused_variables)]

--- a/tests/ui/cfg/cfgs-on-items.rs
+++ b/tests/ui/cfg/cfgs-on-items.rs
@@ -1,5 +1,8 @@
 //@ run-pass
 //@ compile-flags: --cfg fooA --cfg fooB --check-cfg=cfg(fooA,fooB,fooC,bar)
+//@ reference: cfg.predicate.all
+//@ reference: cfg.predicate.any
+//@ reference: cfg.predicate.not
 
 // fooA AND !bar
 #[cfg(all(fooA, not(bar)))]

--- a/tests/ui/cfg/conditional-compile-arch.rs
+++ b/tests/ui/cfg/conditional-compile-arch.rs
@@ -1,4 +1,6 @@
 //@ run-pass
+//@ reference: cfg.target_arch.def
+//@ reference: cfg.target_arch.values
 
 #[cfg(target_arch = "x86")]
 pub fn main() { }

--- a/tests/ui/cfg/conditional-compile.rs
+++ b/tests/ui/cfg/conditional-compile.rs
@@ -1,4 +1,5 @@
 //@ run-pass
+//@ reference: cfg.attr.allowed-positions
 #![allow(dead_code)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]

--- a/tests/ui/cfg/crate-attributes-using-cfg_attr.rs
+++ b/tests/ui/cfg/crate-attributes-using-cfg_attr.rs
@@ -1,5 +1,6 @@
 //@ check-fail
 //@ compile-flags:--cfg foo --check-cfg=cfg(foo)
+//@ reference: cfg.cfg_attr.attr-restriction
 
 #![cfg_attr(foo, crate_type="bin")]
 //~^ERROR `crate_type` within

--- a/tests/ui/cfg/crate-attributes-using-cfg_attr.stderr
+++ b/tests/ui/cfg/crate-attributes-using-cfg_attr.stderr
@@ -1,17 +1,17 @@
 error: `crate_type` within an `#![cfg_attr]` attribute is forbidden
-  --> $DIR/crate-attributes-using-cfg_attr.rs:4:18
+  --> $DIR/crate-attributes-using-cfg_attr.rs:5:18
    |
 LL | #![cfg_attr(foo, crate_type="bin")]
    |                  ^^^^^^^^^^^^^^^^
 
 error: `crate_name` within an `#![cfg_attr]` attribute is forbidden
-  --> $DIR/crate-attributes-using-cfg_attr.rs:7:18
+  --> $DIR/crate-attributes-using-cfg_attr.rs:8:18
    |
 LL | #![cfg_attr(foo, crate_name="bar")]
    |                  ^^^^^^^^^^^^^^^^
 
 error: `crate_type` within an `#![cfg_attr]` attribute is forbidden
-  --> $DIR/crate-attributes-using-cfg_attr.rs:4:18
+  --> $DIR/crate-attributes-using-cfg_attr.rs:5:18
    |
 LL | #![cfg_attr(foo, crate_type="bin")]
    |                  ^^^^^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL | #![cfg_attr(foo, crate_type="bin")]
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `crate_name` within an `#![cfg_attr]` attribute is forbidden
-  --> $DIR/crate-attributes-using-cfg_attr.rs:7:18
+  --> $DIR/crate-attributes-using-cfg_attr.rs:8:18
    |
 LL | #![cfg_attr(foo, crate_name="bar")]
    |                  ^^^^^^^^^^^^^^^^

--- a/tests/ui/cfg/invalid-cli-cfg-pred.rs
+++ b/tests/ui/cfg/invalid-cli-cfg-pred.rs
@@ -1,4 +1,7 @@
 //@ compile-flags: --cfg foo=1x
+//@ reference: cfg.option-spec
+//@ reference: cfg.option-name
+//@ reference: cfg.option-key-value
 
 fn main() {}
 

--- a/tests/ui/cfg/invalid-cli-check-cfg-pred.rs
+++ b/tests/ui/cfg/invalid-cli-check-cfg-pred.rs
@@ -1,4 +1,7 @@
 //@ compile-flags: --check-cfg 'foo=1x'
+//@ reference: cfg.option-spec
+//@ reference: cfg.option-name
+//@ reference: cfg.option-key-value
 
 fn main() {}
 

--- a/tests/ui/cfg/path-kw-as-cfg-pred.rs
+++ b/tests/ui/cfg/path-kw-as-cfg-pred.rs
@@ -1,4 +1,6 @@
 //@ edition: 2024
+//@ reference: cfg.attr.syntax
+//@ reference: cfg.cfg_attr.syntax
 
 #![allow(unexpected_cfgs)]
 

--- a/tests/ui/cfg/path-kw-as-cfg-pred.stderr
+++ b/tests/ui/cfg/path-kw-as-cfg-pred.stderr
@@ -1,125 +1,125 @@
 error: `crate` cannot be a raw identifier
-  --> $DIR/path-kw-as-cfg-pred.rs:70:10
+  --> $DIR/path-kw-as-cfg-pred.rs:72:10
    |
 LL |     cfg!(r#crate);
    |          ^^^^^^^
 
 error: `super` cannot be a raw identifier
-  --> $DIR/path-kw-as-cfg-pred.rs:72:10
+  --> $DIR/path-kw-as-cfg-pred.rs:74:10
    |
 LL |     cfg!(r#super);
    |          ^^^^^^^
 
 error: `self` cannot be a raw identifier
-  --> $DIR/path-kw-as-cfg-pred.rs:74:10
+  --> $DIR/path-kw-as-cfg-pred.rs:76:10
    |
 LL |     cfg!(r#self);
    |          ^^^^^^
 
 error: `Self` cannot be a raw identifier
-  --> $DIR/path-kw-as-cfg-pred.rs:76:10
+  --> $DIR/path-kw-as-cfg-pred.rs:78:10
    |
 LL |     cfg!(r#Self);
    |          ^^^^^^
 
 error: `_` cannot be a raw identifier
-  --> $DIR/path-kw-as-cfg-pred.rs:85:10
+  --> $DIR/path-kw-as-cfg-pred.rs:87:10
    |
 LL |     cfg!(r#_);
    |          ^^^
 
 error: `crate` cannot be a raw identifier
-  --> $DIR/path-kw-as-cfg-pred.rs:88:7
+  --> $DIR/path-kw-as-cfg-pred.rs:90:7
    |
 LL | #[cfg(r#crate)]
    |       ^^^^^^^
 
 error: `super` cannot be a raw identifier
-  --> $DIR/path-kw-as-cfg-pred.rs:91:7
+  --> $DIR/path-kw-as-cfg-pred.rs:93:7
    |
 LL | #[cfg(r#super)]
    |       ^^^^^^^
 
 error: `self` cannot be a raw identifier
-  --> $DIR/path-kw-as-cfg-pred.rs:94:7
+  --> $DIR/path-kw-as-cfg-pred.rs:96:7
    |
 LL | #[cfg(r#self)]
    |       ^^^^^^
 
 error: `Self` cannot be a raw identifier
-  --> $DIR/path-kw-as-cfg-pred.rs:97:7
+  --> $DIR/path-kw-as-cfg-pred.rs:99:7
    |
 LL | #[cfg(r#Self)]
    |       ^^^^^^
 
 error: `crate` cannot be a raw identifier
-  --> $DIR/path-kw-as-cfg-pred.rs:100:12
+  --> $DIR/path-kw-as-cfg-pred.rs:102:12
    |
 LL | #[cfg_attr(r#crate, cfg(r#crate))]
    |            ^^^^^^^
 
 error: `crate` cannot be a raw identifier
-  --> $DIR/path-kw-as-cfg-pred.rs:100:25
+  --> $DIR/path-kw-as-cfg-pred.rs:102:25
    |
 LL | #[cfg_attr(r#crate, cfg(r#crate))]
    |                         ^^^^^^^
 
 error: `super` cannot be a raw identifier
-  --> $DIR/path-kw-as-cfg-pred.rs:104:12
+  --> $DIR/path-kw-as-cfg-pred.rs:106:12
    |
 LL | #[cfg_attr(r#super, cfg(r#super))]
    |            ^^^^^^^
 
 error: `super` cannot be a raw identifier
-  --> $DIR/path-kw-as-cfg-pred.rs:104:25
+  --> $DIR/path-kw-as-cfg-pred.rs:106:25
    |
 LL | #[cfg_attr(r#super, cfg(r#super))]
    |                         ^^^^^^^
 
 error: `self` cannot be a raw identifier
-  --> $DIR/path-kw-as-cfg-pred.rs:108:12
+  --> $DIR/path-kw-as-cfg-pred.rs:110:12
    |
 LL | #[cfg_attr(r#self, cfg(r#self))]
    |            ^^^^^^
 
 error: `self` cannot be a raw identifier
-  --> $DIR/path-kw-as-cfg-pred.rs:108:24
+  --> $DIR/path-kw-as-cfg-pred.rs:110:24
    |
 LL | #[cfg_attr(r#self, cfg(r#self))]
    |                        ^^^^^^
 
 error: `Self` cannot be a raw identifier
-  --> $DIR/path-kw-as-cfg-pred.rs:112:12
+  --> $DIR/path-kw-as-cfg-pred.rs:114:12
    |
 LL | #[cfg_attr(r#Self, cfg(r#Self))]
    |            ^^^^^^
 
 error: `Self` cannot be a raw identifier
-  --> $DIR/path-kw-as-cfg-pred.rs:112:24
+  --> $DIR/path-kw-as-cfg-pred.rs:114:24
    |
 LL | #[cfg_attr(r#Self, cfg(r#Self))]
    |                        ^^^^^^
 
 error: `_` cannot be a raw identifier
-  --> $DIR/path-kw-as-cfg-pred.rs:121:7
+  --> $DIR/path-kw-as-cfg-pred.rs:123:7
    |
 LL | #[cfg(r#_)]
    |       ^^^
 
 error: `_` cannot be a raw identifier
-  --> $DIR/path-kw-as-cfg-pred.rs:127:12
+  --> $DIR/path-kw-as-cfg-pred.rs:129:12
    |
 LL | #[cfg_attr(r#_, cfg(r#_))]
    |            ^^^
 
 error: `_` cannot be a raw identifier
-  --> $DIR/path-kw-as-cfg-pred.rs:127:21
+  --> $DIR/path-kw-as-cfg-pred.rs:129:21
    |
 LL | #[cfg_attr(r#_, cfg(r#_))]
    |                     ^^^
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:18:1
+  --> $DIR/path-kw-as-cfg-pred.rs:20:1
    |
 LL | #[cfg(crate)]
    | ^^^^^^-----^^
@@ -130,7 +130,7 @@ LL | #[cfg(crate)]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:20:1
+  --> $DIR/path-kw-as-cfg-pred.rs:22:1
    |
 LL | #[cfg(super)]
    | ^^^^^^-----^^
@@ -141,7 +141,7 @@ LL | #[cfg(super)]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:22:1
+  --> $DIR/path-kw-as-cfg-pred.rs:24:1
    |
 LL | #[cfg(self)]
    | ^^^^^^----^^
@@ -152,7 +152,7 @@ LL | #[cfg(self)]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:24:1
+  --> $DIR/path-kw-as-cfg-pred.rs:26:1
    |
 LL | #[cfg(Self)]
    | ^^^^^^----^^
@@ -163,7 +163,7 @@ LL | #[cfg(Self)]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:26:1
+  --> $DIR/path-kw-as-cfg-pred.rs:28:1
    |
 LL | #[cfg_attr(crate, path = "foo")]
    | ^^^^^^^^^^^-----^^^^^^^^^^^^^^^^
@@ -174,7 +174,7 @@ LL | #[cfg_attr(crate, path = "foo")]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:28:1
+  --> $DIR/path-kw-as-cfg-pred.rs:30:1
    |
 LL | #[cfg_attr(super, path = "foo")]
    | ^^^^^^^^^^^-----^^^^^^^^^^^^^^^^
@@ -185,7 +185,7 @@ LL | #[cfg_attr(super, path = "foo")]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:30:1
+  --> $DIR/path-kw-as-cfg-pred.rs:32:1
    |
 LL | #[cfg_attr(self, path = "foo")]
    | ^^^^^^^^^^^----^^^^^^^^^^^^^^^^
@@ -196,7 +196,7 @@ LL | #[cfg_attr(self, path = "foo")]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:32:1
+  --> $DIR/path-kw-as-cfg-pred.rs:34:1
    |
 LL | #[cfg_attr(Self, path = "foo")]
    | ^^^^^^^^^^^----^^^^^^^^^^^^^^^^
@@ -207,7 +207,7 @@ LL | #[cfg_attr(Self, path = "foo")]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:34:18
+  --> $DIR/path-kw-as-cfg-pred.rs:36:18
    |
 LL | #[cfg_attr(true, cfg(crate))]
    |                  ^^^^-----^
@@ -218,7 +218,7 @@ LL | #[cfg_attr(true, cfg(crate))]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:36:18
+  --> $DIR/path-kw-as-cfg-pred.rs:38:18
    |
 LL | #[cfg_attr(true, cfg(super))]
    |                  ^^^^-----^
@@ -229,7 +229,7 @@ LL | #[cfg_attr(true, cfg(super))]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:38:18
+  --> $DIR/path-kw-as-cfg-pred.rs:40:18
    |
 LL | #[cfg_attr(true, cfg(self))]
    |                  ^^^^----^
@@ -240,7 +240,7 @@ LL | #[cfg_attr(true, cfg(self))]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:40:18
+  --> $DIR/path-kw-as-cfg-pred.rs:42:18
    |
 LL | #[cfg_attr(true, cfg(Self))]
    |                  ^^^^----^
@@ -251,25 +251,25 @@ LL | #[cfg_attr(true, cfg(Self))]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error: expected identifier, found keyword `struct`
-  --> $DIR/path-kw-as-cfg-pred.rs:43:7
+  --> $DIR/path-kw-as-cfg-pred.rs:45:7
    |
 LL | #[cfg(struct)]
    |       ^^^^^^ expected identifier, found keyword
 
 error: expected identifier, found reserved keyword `priv`
-  --> $DIR/path-kw-as-cfg-pred.rs:45:7
+  --> $DIR/path-kw-as-cfg-pred.rs:47:7
    |
 LL | #[cfg(priv)]
    |       ^^^^ expected identifier, found reserved keyword
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/path-kw-as-cfg-pred.rs:47:7
+  --> $DIR/path-kw-as-cfg-pred.rs:49:7
    |
 LL | #[cfg(_)]
    |       ^ expected identifier, found reserved identifier
 
 error: expected identifier, found keyword `struct`
-  --> $DIR/path-kw-as-cfg-pred.rs:49:12
+  --> $DIR/path-kw-as-cfg-pred.rs:51:12
    |
 LL | #[cfg_attr(struct, path = "foo")]
    |            ^^^^^^ expected identifier, found keyword
@@ -280,7 +280,7 @@ LL | #[cfg_attr(r#struct, path = "foo")]
    |            ++
 
 error: expected identifier, found reserved keyword `priv`
-  --> $DIR/path-kw-as-cfg-pred.rs:51:12
+  --> $DIR/path-kw-as-cfg-pred.rs:53:12
    |
 LL | #[cfg_attr(priv, path = "foo")]
    |            ^^^^ expected identifier, found reserved keyword
@@ -291,31 +291,31 @@ LL | #[cfg_attr(r#priv, path = "foo")]
    |            ++
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/path-kw-as-cfg-pred.rs:53:12
+  --> $DIR/path-kw-as-cfg-pred.rs:55:12
    |
 LL | #[cfg_attr(_, path = "foo")]
    |            ^ expected identifier, found reserved identifier
 
 error: expected identifier, found keyword `struct`
-  --> $DIR/path-kw-as-cfg-pred.rs:55:22
+  --> $DIR/path-kw-as-cfg-pred.rs:57:22
    |
 LL | #[cfg_attr(true, cfg(struct))]
    |                      ^^^^^^ expected identifier, found keyword
 
 error: expected identifier, found reserved keyword `priv`
-  --> $DIR/path-kw-as-cfg-pred.rs:57:22
+  --> $DIR/path-kw-as-cfg-pred.rs:59:22
    |
 LL | #[cfg_attr(true, cfg(priv))]
    |                      ^^^^ expected identifier, found reserved keyword
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/path-kw-as-cfg-pred.rs:59:22
+  --> $DIR/path-kw-as-cfg-pred.rs:61:22
    |
 LL | #[cfg_attr(true, cfg(_))]
    |                      ^ expected identifier, found reserved identifier
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:88:1
+  --> $DIR/path-kw-as-cfg-pred.rs:90:1
    |
 LL | #[cfg(r#crate)]
    | ^^^^^^-------^^
@@ -326,7 +326,7 @@ LL | #[cfg(r#crate)]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:91:1
+  --> $DIR/path-kw-as-cfg-pred.rs:93:1
    |
 LL | #[cfg(r#super)]
    | ^^^^^^-------^^
@@ -337,7 +337,7 @@ LL | #[cfg(r#super)]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:94:1
+  --> $DIR/path-kw-as-cfg-pred.rs:96:1
    |
 LL | #[cfg(r#self)]
    | ^^^^^^------^^
@@ -348,7 +348,7 @@ LL | #[cfg(r#self)]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:97:1
+  --> $DIR/path-kw-as-cfg-pred.rs:99:1
    |
 LL | #[cfg(r#Self)]
    | ^^^^^^------^^
@@ -359,7 +359,7 @@ LL | #[cfg(r#Self)]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:100:1
+  --> $DIR/path-kw-as-cfg-pred.rs:102:1
    |
 LL | #[cfg_attr(r#crate, cfg(r#crate))]
    | ^^^^^^^^^^^-------^^^^^^^^^^^^^^^^
@@ -370,7 +370,7 @@ LL | #[cfg_attr(r#crate, cfg(r#crate))]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:104:1
+  --> $DIR/path-kw-as-cfg-pred.rs:106:1
    |
 LL | #[cfg_attr(r#super, cfg(r#super))]
    | ^^^^^^^^^^^-------^^^^^^^^^^^^^^^^
@@ -381,7 +381,7 @@ LL | #[cfg_attr(r#super, cfg(r#super))]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:108:1
+  --> $DIR/path-kw-as-cfg-pred.rs:110:1
    |
 LL | #[cfg_attr(r#self, cfg(r#self))]
    | ^^^^^^^^^^^------^^^^^^^^^^^^^^^
@@ -392,7 +392,7 @@ LL | #[cfg_attr(r#self, cfg(r#self))]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:112:1
+  --> $DIR/path-kw-as-cfg-pred.rs:114:1
    |
 LL | #[cfg_attr(r#Self, cfg(r#Self))]
    | ^^^^^^^^^^^------^^^^^^^^^^^^^^^
@@ -403,7 +403,7 @@ LL | #[cfg_attr(r#Self, cfg(r#Self))]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:7:9
+  --> $DIR/path-kw-as-cfg-pred.rs:9:9
    |
 LL |         #[cfg($crate)]
    |         ^^^^^^------^^
@@ -418,7 +418,7 @@ LL |     foo!();
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:9:9
+  --> $DIR/path-kw-as-cfg-pred.rs:11:9
    |
 LL |         #[cfg_attr($crate, path = "foo")]
    |         ^^^^^^^^^^^------^^^^^^^^^^^^^^^^
@@ -433,7 +433,7 @@ LL |     foo!();
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/path-kw-as-cfg-pred.rs:11:26
+  --> $DIR/path-kw-as-cfg-pred.rs:13:26
    |
 LL |         #[cfg_attr(true, cfg($crate))]
    |                          ^^^^------^
@@ -448,7 +448,7 @@ LL |     foo!();
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0539]: malformed `cfg` macro input
-  --> $DIR/path-kw-as-cfg-pred.rs:14:9
+  --> $DIR/path-kw-as-cfg-pred.rs:16:9
    |
 LL |         cfg!($crate);
    |         ^^^^^------^
@@ -463,7 +463,7 @@ LL |     foo!();
    = note: this error originates in the macro `cfg` which comes from the expansion of the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0539]: malformed `cfg` macro input
-  --> $DIR/path-kw-as-cfg-pred.rs:65:5
+  --> $DIR/path-kw-as-cfg-pred.rs:67:5
    |
 LL |     cfg!(crate);
    |     ^^^^^-----^
@@ -474,7 +474,7 @@ LL |     cfg!(crate);
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error[E0539]: malformed `cfg` macro input
-  --> $DIR/path-kw-as-cfg-pred.rs:66:5
+  --> $DIR/path-kw-as-cfg-pred.rs:68:5
    |
 LL |     cfg!(super);
    |     ^^^^^-----^
@@ -485,7 +485,7 @@ LL |     cfg!(super);
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error[E0539]: malformed `cfg` macro input
-  --> $DIR/path-kw-as-cfg-pred.rs:67:5
+  --> $DIR/path-kw-as-cfg-pred.rs:69:5
    |
 LL |     cfg!(self);
    |     ^^^^^----^
@@ -496,7 +496,7 @@ LL |     cfg!(self);
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error[E0539]: malformed `cfg` macro input
-  --> $DIR/path-kw-as-cfg-pred.rs:68:5
+  --> $DIR/path-kw-as-cfg-pred.rs:70:5
    |
 LL |     cfg!(Self);
    |     ^^^^^----^
@@ -507,7 +507,7 @@ LL |     cfg!(Self);
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error[E0539]: malformed `cfg` macro input
-  --> $DIR/path-kw-as-cfg-pred.rs:70:5
+  --> $DIR/path-kw-as-cfg-pred.rs:72:5
    |
 LL |     cfg!(r#crate);
    |     ^^^^^-------^
@@ -518,7 +518,7 @@ LL |     cfg!(r#crate);
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error[E0539]: malformed `cfg` macro input
-  --> $DIR/path-kw-as-cfg-pred.rs:72:5
+  --> $DIR/path-kw-as-cfg-pred.rs:74:5
    |
 LL |     cfg!(r#super);
    |     ^^^^^-------^
@@ -529,7 +529,7 @@ LL |     cfg!(r#super);
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error[E0539]: malformed `cfg` macro input
-  --> $DIR/path-kw-as-cfg-pred.rs:74:5
+  --> $DIR/path-kw-as-cfg-pred.rs:76:5
    |
 LL |     cfg!(r#self);
    |     ^^^^^------^
@@ -540,7 +540,7 @@ LL |     cfg!(r#self);
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error[E0539]: malformed `cfg` macro input
-  --> $DIR/path-kw-as-cfg-pred.rs:76:5
+  --> $DIR/path-kw-as-cfg-pred.rs:78:5
    |
 LL |     cfg!(r#Self);
    |     ^^^^^------^
@@ -551,19 +551,19 @@ LL |     cfg!(r#Self);
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 
 error: expected identifier, found keyword `struct`
-  --> $DIR/path-kw-as-cfg-pred.rs:79:10
+  --> $DIR/path-kw-as-cfg-pred.rs:81:10
    |
 LL |     cfg!(struct);
    |          ^^^^^^ expected identifier, found keyword
 
 error: expected identifier, found reserved keyword `priv`
-  --> $DIR/path-kw-as-cfg-pred.rs:80:10
+  --> $DIR/path-kw-as-cfg-pred.rs:82:10
    |
 LL |     cfg!(priv);
    |          ^^^^ expected identifier, found reserved keyword
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/path-kw-as-cfg-pred.rs:81:10
+  --> $DIR/path-kw-as-cfg-pred.rs:83:10
    |
 LL |     cfg!(_);
    |          ^ expected identifier, found reserved identifier

--- a/tests/ui/cfg/true-false.rs
+++ b/tests/ui/cfg/true-false.rs
@@ -1,4 +1,5 @@
 //@ run-pass
+//@ reference: cfg.predicate.literal
 
 #![feature(link_cfg)]
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/153642)*
<!-- homu-ignore:end -->

Successful merges:

 - rust-lang/rust#148562 (In `Option::get_or_insert_with()`, forget the `None` instead of dropping it.)
 - rust-lang/rust#153325 (tests/ui/cfg: add annotations for reference rules)
 - rust-lang/rust#153621 (Remove `TyCtxt::node_span_lint` method)
 - rust-lang/rust#153627 (rustdoc-json: Improve docs for `ItemEnum::item_kind`)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=148562,153325,153621,153627)
<!-- homu-ignore:end -->

