### PR TITLE
Avoid projection-only suggestions for inherent assoc types

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/infer/note_and_explain.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/note_and_explain.rs
@@ -272,18 +272,21 @@ impl<T> Trait<T> for X {
                                 values.found, values.expected,
                             )
                         };
-                        if !(self.suggest_constraining_opaque_associated_type(
-                            diag,
-                            msg,
-                            proj_ty,
-                            values.expected,
-                        ) || self.suggest_constraint(
-                            diag,
-                            &msg,
-                            body_owner_def_id,
-                            proj_ty,
-                            values.expected,
-                        )) {
+                        let suggested_projection_constraint = proj_ty.kind(tcx)
+                            == ty::AliasTyKind::Projection
+                            && (self.suggest_constraining_opaque_associated_type(
+                                diag,
+                                msg,
+                                proj_ty,
+                                values.expected,
+                            ) || self.suggest_constraint(
+                                diag,
+                                &msg,
+                                body_owner_def_id,
+                                proj_ty,
+                                values.expected,
+                            ));
+                        if !suggested_projection_constraint {
                             diag.help(msg());
                             diag.note(
                                 "for more information, visit \

--- a/tests/ui/associated-inherent-types/inherent-assoc-ty-mismatch-issue-153539.rs
+++ b/tests/ui/associated-inherent-types/inherent-assoc-ty-mismatch-issue-153539.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: -Znext-solver=globally
 #![feature(inherent_associated_types)]
-//~^ WARN the feature `inherent_associated_types` is incomplete
+#![expect(incomplete_features)]
 
 // Regression test for https://github.com/rust-lang/rust/issues/153539:
 

--- a/tests/ui/associated-inherent-types/inherent-assoc-ty-mismatch-issue-153539.rs
+++ b/tests/ui/associated-inherent-types/inherent-assoc-ty-mismatch-issue-153539.rs
@@ -1,0 +1,21 @@
+//@ compile-flags: -Znext-solver=globally
+#![feature(inherent_associated_types)]
+//~^ WARN the feature `inherent_associated_types` is incomplete
+
+// Regression test for https://github.com/rust-lang/rust/issues/153539:
+
+struct S<'a>(&'a ());
+
+impl<X> S<'_> {
+    //~^ ERROR the type parameter `X` is not constrained by the impl trait, self type, or predicates
+    type P = ();
+}
+
+fn ret_ref_local<'e>() -> &'e i32 {
+    let f: for<'a> fn(&'a i32) -> S<'a>::P = |x| _ = x;
+
+    f(&1)
+    //~^ ERROR mismatched types
+}
+
+fn main() {}

--- a/tests/ui/associated-inherent-types/inherent-assoc-ty-mismatch-issue-153539.stderr
+++ b/tests/ui/associated-inherent-types/inherent-assoc-ty-mismatch-issue-153539.stderr
@@ -1,0 +1,31 @@
+warning: the feature `inherent_associated_types` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/inherent-assoc-ty-mismatch-issue-153539.rs:2:12
+   |
+LL | #![feature(inherent_associated_types)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0207]: the type parameter `X` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/inherent-assoc-ty-mismatch-issue-153539.rs:9:6
+   |
+LL | impl<X> S<'_> {
+   |      ^ unconstrained type parameter
+
+error[E0308]: mismatched types
+  --> $DIR/inherent-assoc-ty-mismatch-issue-153539.rs:17:5
+   |
+LL | fn ret_ref_local<'e>() -> &'e i32 {
+   |                           ------- expected `&'e i32` because of return type
+...
+LL |     f(&1)
+   |     ^^^^^ expected `&i32`, found associated type
+   |
+   = help: consider constraining the associated type `S<'_>::P` to `&'e i32`
+   = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+
+error: aborting due to 2 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0207, E0308.
+For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/associated-inherent-types/inherent-assoc-ty-mismatch-issue-153539.stderr
+++ b/tests/ui/associated-inherent-types/inherent-assoc-ty-mismatch-issue-153539.stderr
@@ -1,12 +1,3 @@
-warning: the feature `inherent_associated_types` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/inherent-assoc-ty-mismatch-issue-153539.rs:2:12
-   |
-LL | #![feature(inherent_associated_types)]
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
-   = note: `#[warn(incomplete_features)]` on by default
-
 error[E0207]: the type parameter `X` is not constrained by the impl trait, self type, or predicates
   --> $DIR/inherent-assoc-ty-mismatch-issue-153539.rs:9:6
    |
@@ -25,7 +16,7 @@ LL |     f(&1)
    = help: consider constraining the associated type `S<'_>::P` to `&'e i32`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors
 
 Some errors have detailed explanations: E0207, E0308.
 For more information about an error, try `rustc --explain E0207`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#153539.

Type mismatch diagnostics in `note_and_explain_type_err` currently route both `ty::Projectio`n and `ty::Inherent`
through the same associated-type suggestion path. For inherent associated types, that path can reach helpers that
are only valid for trait projections.