### PR TITLE
fix(query): Rotate Parallel Cycle Entries to Match Recovery Target

### DIFF
--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -270,7 +270,16 @@ fn wait_for_query<'tcx, C: QueryCache>(
 
             (v, Some(index))
         }
-        Err(cycle) => (mk_cycle(query, tcx, cycle.lift()), None),
+        Err(mut cycle) => {
+            if let Some(def_id) = key.key_as_def_id() {
+                if let Some(pos) = cycle.cycle.iter().position(|entry| {
+                    entry.frame.dep_kind == query.dep_kind && entry.frame.def_id == Some(def_id)
+                }) {
+                    cycle.cycle.rotate_left(pos);
+                }
+            }
+            (mk_cycle(query, tcx, cycle.lift()), None)
+        }
     }
 }
 

--- a/tests/ui/parallel-rustc/fn-sig-cycle-ice-153391.rs
+++ b/tests/ui/parallel-rustc/fn-sig-cycle-ice-153391.rs
@@ -1,0 +1,17 @@
+// Regression test for #153391.
+//
+//@ edition:2024
+//@ compile-flags: -Z threads=16
+//@ compare-output-by-lines
+
+trait A {
+    fn g() -> B;
+    //~^ ERROR expected a type, found a trait
+}
+
+trait B {
+    fn bar(&self, x: &A);
+    //~^ ERROR expected a type, found a trait
+}
+
+fn main() {}

--- a/tests/ui/parallel-rustc/fn-sig-cycle-ice-153391.stderr
+++ b/tests/ui/parallel-rustc/fn-sig-cycle-ice-153391.stderr
@@ -1,0 +1,30 @@
+error[E0782]: expected a type, found a trait
+   |
+LL |     fn bar(&self, x: &A);
+   |                       ^
+   |
+   = note: `A` is dyn-incompatible, otherwise a trait object could be used
+help: use a new generic type parameter, constrained by `A`
+   |
+LL -     fn bar(&self, x: &A);
+LL +     fn bar<T: A>(&self, x: &T);
+   |
+help: you can also use an opaque type, but users won't be able to specify the type parameter when calling the `fn`, having to rely exclusively on type inference
+   |
+LL |     fn bar(&self, x: &impl A);
+   |                       ++++
+
+error[E0782]: expected a type, found a trait
+  --> $DIR/fn-sig-cycle-ice-153391.rs:8:15
+   |
+LL |     fn g() -> B;
+   |               ^
+   |
+   |
+LL |     fn g() -> impl B;
+   |               ++++
+   |
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0782`.


### PR DESCRIPTION
### Summary:

Mutual trait references as bare trait objects cause a `fn_sig` -> `is_dyn_compatible` cycle. In parallel mode, `remove_cycle` may rotate the cycle entries arbitrarily, causing `from_cycle_error` to pick an incorrect query as the entry point. This leads to an invalid recovery signature with wrong arity, eventually triggering a panic in `virtual_call_violations_for_method`.

Fix: in `wait_for_query`, rotate `cycle` entries so `cycle[0]` matches the query being recovered, restoring the invariant that `find_cycle_in_stack` naturally maintains in single-threaded mode.

Closes rust-lang/rust#153391 

cc @matthiaskrgr @lqd 