### PR TITLE
Fix EII function aliases eliminated by LTO

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
+++ b/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
@@ -199,6 +199,14 @@ fn exported_non_generic_symbols_provider_local<'tcx>(
         }))
     }
 
+    symbols.extend(sorted.iter().flat_map(|&(&def_id, &info)| {
+        tcx.codegen_fn_attrs(def_id).foreign_item_symbol_aliases.iter().map(
+            move |&(foreign_item, _linkage, _visibility)| {
+                (ExportedSymbol::NonGeneric(foreign_item), info)
+            },
+        )
+    }));
+
     if tcx.entry_fn(()).is_some() {
         let exported_symbol =
             ExportedSymbol::NoDefId(SymbolName::new(tcx, tcx.sess.target.entry_name.as_ref()));


### PR DESCRIPTION
Add EII function aliases to `llvm.compiler.used` so that LLVM's LTO passes do not eliminate them.

Fixes rust-lang/rust#153645

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Tracking issue: https://github.com/rust-lang/rust/issues/125418
