### PR TITLE
scalable vector: type renames and simple checks

### DIFF
--- a/compiler/rustc_abi/src/callconv.rs
+++ b/compiler/rustc_abi/src/callconv.rs
@@ -83,7 +83,7 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
                 }))
             }
 
-            BackendRepr::ScalableVector { .. } => {
+            BackendRepr::SimdScalableVector { .. } => {
                 unreachable!("`homogeneous_aggregate` should not be called for scalable vectors")
             }
 

--- a/compiler/rustc_abi/src/layout.rs
+++ b/compiler/rustc_abi/src/layout.rs
@@ -210,7 +210,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
         VariantIdx: Idx,
         F: AsRef<LayoutData<FieldIdx, VariantIdx>> + fmt::Debug,
     {
-        vector_type_layout(VectorKind::Scalable, self.cx.data_layout(), element, count)
+        vector_type_layout(SimdVectorKind::Scalable, self.cx.data_layout(), element, count)
     }
 
     pub fn simd_type<FieldIdx, VariantIdx, F>(
@@ -224,7 +224,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
         VariantIdx: Idx,
         F: AsRef<LayoutData<FieldIdx, VariantIdx>> + fmt::Debug,
     {
-        let kind = if repr_packed { VectorKind::PackedFixed } else { VectorKind::Fixed };
+        let kind = if repr_packed { SimdVectorKind::PackedFixed } else { SimdVectorKind::Fixed };
         vector_type_layout(kind, self.cx.data_layout(), element, count)
     }
 
@@ -1524,7 +1524,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
     }
 }
 
-enum VectorKind {
+enum SimdVectorKind {
     /// `#[rustc_scalable_vector]`
     Scalable,
     /// `#[repr(simd, packed)]`
@@ -1534,7 +1534,7 @@ enum VectorKind {
 }
 
 fn vector_type_layout<FieldIdx, VariantIdx, F>(
-    kind: VectorKind,
+    kind: SimdVectorKind,
     dl: &TargetDataLayout,
     element: F,
     count: u64,
@@ -1559,16 +1559,16 @@ where
     let size =
         elt.size.checked_mul(count, dl).ok_or_else(|| LayoutCalculatorError::SizeOverflow)?;
     let (repr, align) = match kind {
-        VectorKind::Scalable => {
+        SimdVectorKind::Scalable => {
             (BackendRepr::SimdScalableVector { element, count }, dl.llvmlike_vector_align(size))
         }
         // Non-power-of-two vectors have padding up to the next power-of-two.
         // If we're a packed repr, remove the padding while keeping the alignment as close
         // to a vector as possible.
-        VectorKind::PackedFixed if !count.is_power_of_two() => {
+        SimdVectorKind::PackedFixed if !count.is_power_of_two() => {
             (BackendRepr::Memory { sized: true }, Align::max_aligned_factor(size))
         }
-        VectorKind::PackedFixed | VectorKind::Fixed => {
+        SimdVectorKind::PackedFixed | SimdVectorKind::Fixed => {
             (BackendRepr::SimdVector { element, count }, dl.llvmlike_vector_align(size))
         }
     };

--- a/compiler/rustc_abi/src/layout.rs
+++ b/compiler/rustc_abi/src/layout.rs
@@ -484,7 +484,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
                 BackendRepr::Scalar(..)
                 | BackendRepr::ScalarPair(..)
                 | BackendRepr::SimdVector { .. }
-                | BackendRepr::ScalableVector { .. }
+                | BackendRepr::SimdScalableVector { .. }
                 | BackendRepr::Memory { .. } => repr,
             },
         };
@@ -557,7 +557,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
                     hide_niches(b);
                 }
                 BackendRepr::SimdVector { element, .. }
-                | BackendRepr::ScalableVector { element, .. } => hide_niches(element),
+                | BackendRepr::SimdScalableVector { element, .. } => hide_niches(element),
                 BackendRepr::Memory { sized: _ } => {}
             }
             st.largest_niche = None;
@@ -1560,7 +1560,7 @@ where
         elt.size.checked_mul(count, dl).ok_or_else(|| LayoutCalculatorError::SizeOverflow)?;
     let (repr, align) = match kind {
         VectorKind::Scalable => {
-            (BackendRepr::ScalableVector { element, count }, dl.llvmlike_vector_align(size))
+            (BackendRepr::SimdScalableVector { element, count }, dl.llvmlike_vector_align(size))
         }
         // Non-power-of-two vectors have padding up to the next power-of-two.
         // If we're a packed repr, remove the padding while keeping the alignment as close

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -1731,7 +1731,7 @@ impl AddressSpace {
 pub enum BackendRepr {
     Scalar(Scalar),
     ScalarPair(Scalar, Scalar),
-    ScalableVector {
+    SimdScalableVector {
         element: Scalar,
         count: u64,
     },
@@ -1758,7 +1758,7 @@ impl BackendRepr {
             // fully implemented, scalable vectors will remain `Sized`, they just won't be
             // `const Sized` - whether `is_unsized` continues to return `false` at that point will
             // need to be revisited and will depend on what `is_unsized` is used for.
-            | BackendRepr::ScalableVector { .. }
+            | BackendRepr::SimdScalableVector { .. }
             | BackendRepr::SimdVector { .. } => false,
             BackendRepr::Memory { sized } => !sized,
         }
@@ -1801,7 +1801,7 @@ impl BackendRepr {
             // The align of a Vector can vary in surprising ways
             BackendRepr::SimdVector { .. }
             | BackendRepr::Memory { .. }
-            | BackendRepr::ScalableVector { .. } => None,
+            | BackendRepr::SimdScalableVector { .. } => None,
         }
     }
 
@@ -1825,7 +1825,7 @@ impl BackendRepr {
             // The size of a Vector can vary in surprising ways
             BackendRepr::SimdVector { .. }
             | BackendRepr::Memory { .. }
-            | BackendRepr::ScalableVector { .. } => None,
+            | BackendRepr::SimdScalableVector { .. } => None,
         }
     }
 
@@ -1840,8 +1840,8 @@ impl BackendRepr {
                 BackendRepr::SimdVector { element: element.to_union(), count }
             }
             BackendRepr::Memory { .. } => BackendRepr::Memory { sized: true },
-            BackendRepr::ScalableVector { element, count } => {
-                BackendRepr::ScalableVector { element: element.to_union(), count }
+            BackendRepr::SimdScalableVector { element, count } => {
+                BackendRepr::SimdScalableVector { element: element.to_union(), count }
             }
         }
     }
@@ -2085,7 +2085,7 @@ impl<FieldIdx: Idx, VariantIdx: Idx> LayoutData<FieldIdx, VariantIdx> {
         match self.backend_repr {
             BackendRepr::Scalar(_)
             | BackendRepr::SimdVector { .. }
-            | BackendRepr::ScalableVector { .. } => false,
+            | BackendRepr::SimdScalableVector { .. } => false,
             BackendRepr::ScalarPair(..) | BackendRepr::Memory { .. } => true,
         }
     }
@@ -2182,13 +2182,13 @@ impl<FieldIdx: Idx, VariantIdx: Idx> LayoutData<FieldIdx, VariantIdx> {
 
     /// Returns `true` if the size of the type is only known at runtime.
     pub fn is_runtime_sized(&self) -> bool {
-        matches!(self.backend_repr, BackendRepr::ScalableVector { .. })
+        matches!(self.backend_repr, BackendRepr::SimdScalableVector { .. })
     }
 
     /// Returns the elements count of a scalable vector.
     pub fn scalable_vector_element_count(&self) -> Option<u64> {
         match self.backend_repr {
-            BackendRepr::ScalableVector { count, .. } => Some(count),
+            BackendRepr::SimdScalableVector { count, .. } => Some(count),
             _ => None,
         }
     }
@@ -2201,7 +2201,7 @@ impl<FieldIdx: Idx, VariantIdx: Idx> LayoutData<FieldIdx, VariantIdx> {
         match self.backend_repr {
             BackendRepr::Scalar(_)
             | BackendRepr::ScalarPair(..)
-            | BackendRepr::ScalableVector { .. }
+            | BackendRepr::SimdScalableVector { .. }
             | BackendRepr::SimdVector { .. } => false,
             BackendRepr::Memory { sized } => sized && self.size.bytes() == 0,
         }

--- a/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
@@ -505,7 +505,7 @@ impl<'a, 'gcc, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'a, 'gcc, 'tc
                 let layout = self.layout_of(tp_ty).layout;
                 let _use_integer_compare = match layout.backend_repr() {
                     Scalar(_) | ScalarPair(_, _) => true,
-                    SimdVector { .. } | ScalableVector { .. } => false,
+                    SimdVector { .. } | SimdScalableVector { .. } => false,
                     Memory { .. } => {
                         // For rusty ABIs, small aggregates are actually passed
                         // as `RegKind::Integer` (see `FnAbi::adjust_for_abi`),

--- a/compiler/rustc_codegen_gcc/src/type_of.rs
+++ b/compiler/rustc_codegen_gcc/src/type_of.rs
@@ -85,7 +85,7 @@ fn uncached_gcc_type<'gcc, 'tcx>(
             );
         }
         BackendRepr::Memory { .. } => {}
-        BackendRepr::ScalableVector { .. } => todo!(),
+        BackendRepr::SimdScalableVector { .. } => todo!(),
     }
 
     let name = match *layout.ty.kind() {
@@ -181,7 +181,7 @@ impl<'tcx> LayoutGccExt<'tcx> for TyAndLayout<'tcx> {
         match self.backend_repr {
             BackendRepr::Scalar(_) | BackendRepr::SimdVector { .. } => true,
             // FIXME(rustc_scalable_vector): Not yet implemented in rustc_codegen_gcc.
-            BackendRepr::ScalableVector { .. } => todo!(),
+            BackendRepr::SimdScalableVector { .. } => todo!(),
             BackendRepr::ScalarPair(..) | BackendRepr::Memory { .. } => false,
         }
     }
@@ -191,7 +191,7 @@ impl<'tcx> LayoutGccExt<'tcx> for TyAndLayout<'tcx> {
             BackendRepr::ScalarPair(..) => true,
             BackendRepr::Scalar(_)
             | BackendRepr::SimdVector { .. }
-            | BackendRepr::ScalableVector { .. }
+            | BackendRepr::SimdScalableVector { .. }
             | BackendRepr::Memory { .. } => false,
         }
     }

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -493,7 +493,7 @@ impl<'ll, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'_, 'll, 'tcx> {
                 let use_integer_compare = match layout.backend_repr() {
                     Scalar(_) | ScalarPair(_, _) => true,
                     SimdVector { .. } => false,
-                    ScalableVector { .. } => {
+                    SimdScalableVector { .. } => {
                         tcx.dcx().emit_err(InvalidMonomorphization::NonScalableType {
                             span,
                             name: sym::raw_eq,

--- a/compiler/rustc_codegen_llvm/src/type_of.rs
+++ b/compiler/rustc_codegen_llvm/src/type_of.rs
@@ -24,7 +24,7 @@ fn uncached_llvm_type<'a, 'tcx>(
             let element = layout.scalar_llvm_type_at(cx, element);
             return cx.type_vector(element, count);
         }
-        BackendRepr::ScalableVector { ref element, count } => {
+        BackendRepr::SimdScalableVector { ref element, count } => {
             let element = if element.is_bool() {
                 cx.type_i1()
             } else {
@@ -187,7 +187,7 @@ impl<'tcx> LayoutLlvmExt<'tcx> for TyAndLayout<'tcx> {
         match self.backend_repr {
             BackendRepr::Scalar(_)
             | BackendRepr::SimdVector { .. }
-            | BackendRepr::ScalableVector { .. } => true,
+            | BackendRepr::SimdScalableVector { .. } => true,
             BackendRepr::ScalarPair(..) | BackendRepr::Memory { .. } => false,
         }
     }
@@ -197,7 +197,7 @@ impl<'tcx> LayoutLlvmExt<'tcx> for TyAndLayout<'tcx> {
             BackendRepr::ScalarPair(..) => true,
             BackendRepr::Scalar(_)
             | BackendRepr::SimdVector { .. }
-            | BackendRepr::ScalableVector { .. }
+            | BackendRepr::SimdScalableVector { .. }
             | BackendRepr::Memory { .. } => false,
         }
     }

--- a/compiler/rustc_codegen_llvm/src/va_arg.rs
+++ b/compiler/rustc_codegen_llvm/src/va_arg.rs
@@ -551,7 +551,7 @@ fn emit_x86_64_sysv64_va_arg<'ll, 'tcx>(
             registers_for_primitive(scalar1.primitive());
             registers_for_primitive(scalar2.primitive());
         }
-        BackendRepr::SimdVector { .. } | BackendRepr::ScalableVector { .. } => {
+        BackendRepr::SimdVector { .. } | BackendRepr::SimdScalableVector { .. } => {
             // Because no instance of VaArgSafe uses a non-scalar `BackendRepr`.
             unreachable!(
                 "No x86-64 SysV va_arg implementation for {:?}",
@@ -692,7 +692,7 @@ fn emit_x86_64_sysv64_va_arg<'ll, 'tcx>(
         }
         // The Previous match on `BackendRepr` means control flow already escaped.
         BackendRepr::SimdVector { .. }
-        | BackendRepr::ScalableVector { .. }
+        | BackendRepr::SimdScalableVector { .. }
         | BackendRepr::Memory { .. } => unreachable!(),
     };
 

--- a/compiler/rustc_codegen_ssa/src/mir/operand.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/operand.rs
@@ -404,7 +404,7 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
                 }
                 BackendRepr::ScalarPair(_, _)
                 | BackendRepr::Memory { .. }
-                | BackendRepr::ScalableVector { .. } => bug!(),
+                | BackendRepr::SimdScalableVector { .. } => bug!(),
             })
         };
 
@@ -691,7 +691,7 @@ impl<'a, 'tcx, V: CodegenObject> OperandRefBuilder<'tcx, V> {
             BackendRepr::ScalarPair(a, b) => {
                 OperandValueBuilder::Pair(Either::Right(a), Either::Right(b))
             }
-            BackendRepr::SimdVector { .. } | BackendRepr::ScalableVector { .. } => {
+            BackendRepr::SimdVector { .. } | BackendRepr::SimdScalableVector { .. } => {
                 OperandValueBuilder::Vector(Either::Right(()))
             }
             BackendRepr::Memory { .. } => {

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -904,7 +904,7 @@ where
             }
             // Everything else can only exist in memory anyway, so it doesn't matter.
             BackendRepr::SimdVector { .. }
-            | BackendRepr::ScalableVector { .. }
+            | BackendRepr::SimdScalableVector { .. }
             | BackendRepr::Memory { .. } => true,
         };
 

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -1331,7 +1331,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValueVisitor<'tcx, M> for ValidityVisitor<'rt,
                     self.visit_scalar(b, b_layout)?;
                 }
             }
-            BackendRepr::SimdVector { .. } | BackendRepr::ScalableVector { .. } => {
+            BackendRepr::SimdVector { .. } | BackendRepr::SimdScalableVector { .. } => {
                 // No checks here, we assume layout computation gets this right.
                 // (This is harder to check since Miri does not represent these as `Immediate`. We
                 // also cannot use field projections since this might be a newtype around a vector.)

--- a/compiler/rustc_const_eval/src/util/check_validity_requirement.rs
+++ b/compiler/rustc_const_eval/src/util/check_validity_requirement.rs
@@ -119,7 +119,7 @@ fn check_validity_requirement_lax<'tcx>(
             }
             BackendRepr::SimdVector { element: s, count } => count == 0 || scalar_allows_raw_init(s),
             BackendRepr::Memory { .. } => true, // Fields are checked below.
-            BackendRepr::ScalableVector { element, .. } => scalar_allows_raw_init(element),
+            BackendRepr::SimdScalableVector { element, .. } => scalar_allows_raw_init(element),
         };
 
     if !valid {

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -1489,8 +1489,17 @@ fn check_scalable_vector(tcx: TyCtxt<'_>, span: Span, def_id: LocalDefId, scalab
             return;
         }
         ScalableElt::Container if fields.is_empty() => {
-            let mut err =
-                tcx.dcx().struct_span_err(span, "scalable vectors must have a single field");
+            let mut err = tcx
+                .dcx()
+                .struct_span_err(span, "scalable vector tuples must have at least one field");
+            err.help("tuples of scalable vectors can only contain multiple of the same scalable vector type");
+            err.emit();
+            return;
+        }
+        ScalableElt::Container if fields.len() > 8 => {
+            let mut err = tcx
+                .dcx()
+                .struct_span_err(span, "scalable vector tuples can have at most eight fields");
             err.help("tuples of scalable vectors can only contain multiple of the same scalable vector type");
             err.emit();
             return;

--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -1699,7 +1699,7 @@ impl<'body, 'a, 'tcx> VnState<'body, 'a, 'tcx> {
                 !a.is_always_valid(&self.ecx) || !b.is_always_valid(&self.ecx)
             }
             BackendRepr::SimdVector { .. }
-            | BackendRepr::ScalableVector { .. }
+            | BackendRepr::SimdScalableVector { .. }
             | BackendRepr::Memory { .. } => false,
         }
     }

--- a/compiler/rustc_monomorphize/src/mono_checks/abi_check.rs
+++ b/compiler/rustc_monomorphize/src/mono_checks/abi_check.rs
@@ -36,7 +36,7 @@ fn passes_vectors_by_value(mode: &PassMode, repr: &BackendRepr) -> UsesVectorReg
             UsesVectorRegisters::FixedVector
         }
         PassMode::Direct(..) | PassMode::Pair(..)
-            if matches!(repr, BackendRepr::ScalableVector { .. }) =>
+            if matches!(repr, BackendRepr::SimdScalableVector { .. }) =>
         {
             UsesVectorRegisters::ScalableVector
         }

--- a/compiler/rustc_public/src/unstable/convert/stable/abi.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/abi.rs
@@ -265,7 +265,7 @@ impl<'tcx> Stable<'tcx> for rustc_abi::BackendRepr {
             rustc_abi::BackendRepr::SimdVector { element, count } => {
                 ValueAbi::Vector { element: element.stable(tables, cx), count }
             }
-            rustc_abi::BackendRepr::ScalableVector { element, count } => {
+            rustc_abi::BackendRepr::SimdScalableVector { element, count } => {
                 ValueAbi::ScalableVector { element: element.stable(tables, cx), count }
             }
             rustc_abi::BackendRepr::Memory { sized } => ValueAbi::Aggregate { sized },

--- a/compiler/rustc_target/src/callconv/loongarch.rs
+++ b/compiler/rustc_target/src/callconv/loongarch.rs
@@ -88,7 +88,7 @@ where
         BackendRepr::SimdVector { .. } => {
             return Err(CannotUseFpConv);
         }
-        BackendRepr::ScalableVector { .. } => panic!("scalable vectors are unsupported"),
+        BackendRepr::SimdScalableVector { .. } => panic!("scalable vectors are unsupported"),
         BackendRepr::ScalarPair(..) | BackendRepr::Memory { .. } => match arg_layout.fields {
             FieldsShape::Primitive => {
                 unreachable!("aggregates can't have `FieldsShape::Primitive`")

--- a/compiler/rustc_target/src/callconv/mod.rs
+++ b/compiler/rustc_target/src/callconv/mod.rs
@@ -392,7 +392,7 @@ impl<'a, Ty> ArgAbi<'a, Ty> {
             ),
             BackendRepr::SimdVector { .. } => PassMode::Direct(ArgAttributes::new()),
             BackendRepr::Memory { .. } => Self::indirect_pass_mode(&layout),
-            BackendRepr::ScalableVector { .. } => PassMode::Direct(ArgAttributes::new()),
+            BackendRepr::SimdScalableVector { .. } => PassMode::Direct(ArgAttributes::new()),
         };
         ArgAbi { layout, mode }
     }
@@ -878,7 +878,7 @@ where
                 matches!(layout.variants, Variants::Single { .. }) && fields_are_noundef(layout, cx)
             }
         },
-        BackendRepr::SimdVector { .. } | BackendRepr::ScalableVector { .. } => false,
+        BackendRepr::SimdVector { .. } | BackendRepr::SimdScalableVector { .. } => false,
     }
 }
 

--- a/compiler/rustc_target/src/callconv/riscv.rs
+++ b/compiler/rustc_target/src/callconv/riscv.rs
@@ -91,7 +91,7 @@ where
                 }
             }
         },
-        BackendRepr::SimdVector { .. } | BackendRepr::ScalableVector { .. } => {
+        BackendRepr::SimdVector { .. } | BackendRepr::SimdScalableVector { .. } => {
             return Err(CannotUseFpConv);
         }
         BackendRepr::ScalarPair(..) | BackendRepr::Memory { .. } => match arg_layout.fields {

--- a/compiler/rustc_target/src/callconv/sparc64.rs
+++ b/compiler/rustc_target/src/callconv/sparc64.rs
@@ -65,7 +65,7 @@ fn classify<'a, Ty, C>(
             Primitive::Int(_, _) | Primitive::Pointer(_) => { /* pass in integer registers */ }
         },
         BackendRepr::SimdVector { .. } => {}
-        BackendRepr::ScalableVector { .. } => {}
+        BackendRepr::SimdScalableVector { .. } => {}
         BackendRepr::ScalarPair(..) | BackendRepr::Memory { .. } => match arg_layout.fields {
             FieldsShape::Primitive => {
                 unreachable!("aggregates can't have `FieldsShape::Primitive`")

--- a/compiler/rustc_target/src/callconv/x86.rs
+++ b/compiler/rustc_target/src/callconv/x86.rs
@@ -103,7 +103,7 @@ where
                         }
                         false
                     }
-                    BackendRepr::ScalableVector { .. } => {
+                    BackendRepr::SimdScalableVector { .. } => {
                         panic!("scalable vectors are unsupported")
                     }
                 }

--- a/compiler/rustc_target/src/callconv/x86_64.rs
+++ b/compiler/rustc_target/src/callconv/x86_64.rs
@@ -59,7 +59,7 @@ where
 
             BackendRepr::SimdVector { .. } => Class::Sse,
 
-            BackendRepr::ScalableVector { .. } => panic!("scalable vectors are unsupported"),
+            BackendRepr::SimdScalableVector { .. } => panic!("scalable vectors are unsupported"),
 
             BackendRepr::ScalarPair(..) | BackendRepr::Memory { .. } => {
                 for i in 0..layout.fields.count() {

--- a/compiler/rustc_target/src/callconv/x86_win64.rs
+++ b/compiler/rustc_target/src/callconv/x86_win64.rs
@@ -25,7 +25,7 @@ where
                 // FIXME(eddyb) there should be a size cap here
                 // (probably what clang calls "illegal vectors").
             }
-            BackendRepr::ScalableVector { .. } => panic!("scalable vectors are unsupported"),
+            BackendRepr::SimdScalableVector { .. } => panic!("scalable vectors are unsupported"),
             BackendRepr::Scalar(scalar) => {
                 if is_ret && matches!(scalar.primitive(), Primitive::Int(Integer::I128, _)) {
                     if cx.target_spec().rustc_abi == Some(RustcAbi::Softfloat) {

--- a/compiler/rustc_ty_utils/src/abi.rs
+++ b/compiler/rustc_ty_utils/src/abi.rs
@@ -485,7 +485,7 @@ fn fn_abi_sanity_check<'tcx>(
                 match arg.layout.backend_repr {
                     BackendRepr::Scalar(_)
                     | BackendRepr::SimdVector { .. }
-                    | BackendRepr::ScalableVector { .. } => {}
+                    | BackendRepr::SimdScalableVector { .. } => {}
                     BackendRepr::ScalarPair(..) => {
                         panic!("`PassMode::Direct` used for ScalarPair type {}", arg.layout.ty)
                     }

--- a/compiler/rustc_ty_utils/src/layout/invariant.rs
+++ b/compiler/rustc_ty_utils/src/layout/invariant.rs
@@ -250,7 +250,7 @@ pub(super) fn layout_sanity_check<'tcx>(cx: &LayoutCx<'tcx>, layout: &TyAndLayou
                 // And the size has to be element * count plus alignment padding, of course
                 assert!(size == (element_size * count).align_to(align));
             }
-            BackendRepr::Memory { .. } | BackendRepr::ScalableVector { .. } => {} // Nothing to check.
+            BackendRepr::Memory { .. } | BackendRepr::SimdScalableVector { .. } => {} // Nothing to check.
         }
     }
 

--- a/tests/ui/scalable-vectors/illformed.rs
+++ b/tests/ui/scalable-vectors/illformed.rs
@@ -4,6 +4,9 @@
 #![feature(rustc_attrs)]
 
 #[rustc_scalable_vector(4)]
+struct Valid(f32);
+
+#[rustc_scalable_vector(4)]
 struct NoFieldsStructWithElementCount {}
 //~^ ERROR: scalable vectors must have a single field
 //~^^ ERROR: scalable vectors must be tuple structs
@@ -19,16 +22,16 @@ struct NoFieldsUnitWithElementCount;
 
 #[rustc_scalable_vector]
 struct NoFieldsStructWithoutElementCount {}
-//~^ ERROR: scalable vectors must have a single field
+//~^ ERROR: scalable vector tuples must have at least one field
 //~^^ ERROR: scalable vectors must be tuple structs
 
 #[rustc_scalable_vector]
 struct NoFieldsTupleWithoutElementCount();
-//~^ ERROR: scalable vectors must have a single field
+//~^ ERROR: scalable vector tuples must have at least one field
 
 #[rustc_scalable_vector]
 struct NoFieldsUnitWithoutElementCount;
-//~^ ERROR: scalable vectors must have a single field
+//~^ ERROR: scalable vector tuples must have at least one field
 //~^^ ERROR: scalable vectors must be tuple structs
 
 #[rustc_scalable_vector(4)]
@@ -58,3 +61,8 @@ struct MultipleFieldsTupleWithoutElementCount(f32, u32);
 #[rustc_scalable_vector(2)]
 struct SingleFieldStruct { _ty: f64 }
 //~^ ERROR: scalable vectors must be tuple structs
+
+#[rustc_scalable_vector]
+struct TooManyFieldsWithoutElementCount(
+    Valid, Valid, Valid, Valid, Valid, Valid, Valid, Valid, Valid);
+//~^^ ERROR: scalable vector tuples can have at most eight fields

--- a/tests/ui/scalable-vectors/illformed.stderr
+++ b/tests/ui/scalable-vectors/illformed.stderr
@@ -1,29 +1,29 @@
 error: scalable vectors must be tuple structs
-  --> $DIR/illformed.rs:7:1
+  --> $DIR/illformed.rs:10:1
    |
 LL | struct NoFieldsStructWithElementCount {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: scalable vectors must be tuple structs
-  --> $DIR/illformed.rs:16:1
+  --> $DIR/illformed.rs:19:1
    |
 LL | struct NoFieldsUnitWithElementCount;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: scalable vectors must be tuple structs
-  --> $DIR/illformed.rs:21:1
+  --> $DIR/illformed.rs:24:1
    |
 LL | struct NoFieldsStructWithoutElementCount {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: scalable vectors must be tuple structs
-  --> $DIR/illformed.rs:30:1
+  --> $DIR/illformed.rs:33:1
    |
 LL | struct NoFieldsUnitWithoutElementCount;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: scalable vectors must be tuple structs
-  --> $DIR/illformed.rs:35:1
+  --> $DIR/illformed.rs:38:1
    |
 LL | / struct MultipleFieldsStructWithElementCount {
 LL | |
@@ -34,7 +34,7 @@ LL | | }
    | |_^
 
 error: scalable vectors must be tuple structs
-  --> $DIR/illformed.rs:47:1
+  --> $DIR/illformed.rs:50:1
    |
 LL | / struct MultipleFieldsStructWithoutElementCount {
 LL | |
@@ -44,13 +44,13 @@ LL | | }
    | |_^
 
 error: scalable vectors must be tuple structs
-  --> $DIR/illformed.rs:59:1
+  --> $DIR/illformed.rs:62:1
    |
 LL | struct SingleFieldStruct { _ty: f64 }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: scalable vectors must have a single field
-  --> $DIR/illformed.rs:7:1
+  --> $DIR/illformed.rs:10:1
    |
 LL | struct NoFieldsStructWithElementCount {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -58,7 +58,7 @@ LL | struct NoFieldsStructWithElementCount {}
    = help: scalable vector types' only field must be a primitive scalar type
 
 error: scalable vectors must have a single field
-  --> $DIR/illformed.rs:12:1
+  --> $DIR/illformed.rs:15:1
    |
 LL | struct NoFieldsTupleWithElementCount();
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -66,31 +66,31 @@ LL | struct NoFieldsTupleWithElementCount();
    = help: scalable vector types' only field must be a primitive scalar type
 
 error: scalable vectors must have a single field
-  --> $DIR/illformed.rs:16:1
+  --> $DIR/illformed.rs:19:1
    |
 LL | struct NoFieldsUnitWithElementCount;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: scalable vector types' only field must be a primitive scalar type
 
-error: scalable vectors must have a single field
-  --> $DIR/illformed.rs:21:1
+error: scalable vector tuples must have at least one field
+  --> $DIR/illformed.rs:24:1
    |
 LL | struct NoFieldsStructWithoutElementCount {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: tuples of scalable vectors can only contain multiple of the same scalable vector type
 
-error: scalable vectors must have a single field
-  --> $DIR/illformed.rs:26:1
+error: scalable vector tuples must have at least one field
+  --> $DIR/illformed.rs:29:1
    |
 LL | struct NoFieldsTupleWithoutElementCount();
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: tuples of scalable vectors can only contain multiple of the same scalable vector type
 
-error: scalable vectors must have a single field
-  --> $DIR/illformed.rs:30:1
+error: scalable vector tuples must have at least one field
+  --> $DIR/illformed.rs:33:1
    |
 LL | struct NoFieldsUnitWithoutElementCount;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -98,28 +98,36 @@ LL | struct NoFieldsUnitWithoutElementCount;
    = help: tuples of scalable vectors can only contain multiple of the same scalable vector type
 
 error: scalable vectors cannot have multiple fields
-  --> $DIR/illformed.rs:35:1
+  --> $DIR/illformed.rs:38:1
    |
 LL | struct MultipleFieldsStructWithElementCount {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: scalable vectors cannot have multiple fields
-  --> $DIR/illformed.rs:43:1
+  --> $DIR/illformed.rs:46:1
    |
 LL | struct MultipleFieldsTupleWithElementCount(f32, u32);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: scalable vector structs can only have scalable vector fields
-  --> $DIR/illformed.rs:49:5
+  --> $DIR/illformed.rs:52:5
    |
 LL |     _ty: f32,
    |     ^^^^^^^^
 
 error: scalable vector structs can only have scalable vector fields
-  --> $DIR/illformed.rs:55:47
+  --> $DIR/illformed.rs:58:47
    |
 LL | struct MultipleFieldsTupleWithoutElementCount(f32, u32);
    |                                               ^^^
 
-error: aborting due to 17 previous errors
+error: scalable vector tuples can have at most eight fields
+  --> $DIR/illformed.rs:66:1
+   |
+LL | struct TooManyFieldsWithoutElementCount(
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: tuples of scalable vectors can only contain multiple of the same scalable vector type
+
+error: aborting due to 18 previous errors
 


### PR DESCRIPTION
Split out from rust-lang/rust#153286

Per https://github.com/rust-lang/rust/pull/153286#discussion_r2872677044, renames `VectorKind` type to `SimdVectorKind` and `BackendRepr::ScalableVector` to `BackendRepr::SimdScalableVector`. Also adds a new check in `rustc_hir_analysis` enforcing that tuples of scalable vectors should only up to eight vectors.

r? @lqd
