### PR TITLE
Mark an unreachable match arm as such

### DIFF
--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -1474,7 +1474,9 @@ impl<'a, 'ra, 'tcx> Visitor<'a> for BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
                 return;
             }
 
-            AssocItemKind::DelegationMac(..) => bug!(),
+            AssocItemKind::DelegationMac(..) => {
+                span_bug!(item.span, "delegation mac should already have been removed")
+            }
         };
         let vis = self.resolve_visibility(&item.vis);
         let feed = self.r.feed(item.id);

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -358,8 +358,11 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
                 },
             ),
             AssocItemKind::Type(box TyAlias { ident, .. }) => (*ident, DefKind::AssocTy),
-            AssocItemKind::MacCall(..) | AssocItemKind::DelegationMac(..) => {
+            AssocItemKind::MacCall(..) => {
                 return self.visit_macro_invoc(i.id);
+            }
+            AssocItemKind::DelegationMac(..) => {
+                span_bug!(i.span, "degation mac invoc should have already been handled")
             }
         };
 


### PR DESCRIPTION
Synchronize which elements have code paths and which are unreachable betwen def collector and build reduced graph.

Found while analyzing on how to best merge these two visitors in a reviewable way

r? @petrochenkov 