### PR TITLE
When multiple traits are applicable for method, do not specialize main message to the first one that applied

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -4404,6 +4404,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     name = item_name,
                 )
             };
+            if candidates_len > 1 {
+                let rcvr_ty_kind = match rcvr_ty.peel_refs().kind() {
+                    ty::Param(_) => "type parameter",
+                    ty::Adt(def, _) => self.tcx.def_descr(def.did()),
+                    _ => "type",
+                };
+                err.primary_message(format!(
+                    "no method named `{item_name}` found for {rcvr_ty_kind} `{rcvr_ty}` in the \
+                     current scope",
+                ));
+            }
             // Obtain the span for `param` and use it for a structured suggestion.
             if let Some(param) = param_type {
                 let generics = self.tcx.generics_of(self.body_id.to_def_id());

--- a/tests/ui/methods/method-call-err-msg.rs
+++ b/tests/ui/methods/method-call-err-msg.rs
@@ -10,13 +10,13 @@ impl Foo {
 
 fn main() {
     let x = Foo;
-    x.zero(0)   //~ ERROR this method takes 0 arguments but 1 argument was supplied
-     .one()     //~ ERROR this method takes 1 argument but 0 arguments were supplied
-     .two(0);   //~ ERROR this method takes 2 arguments but 1 argument was supplied
+    x.zero(0)   //~ ERROR: this method takes 0 arguments but 1 argument was supplied
+     .one()     //~ ERROR: this method takes 1 argument but 0 arguments were supplied
+     .two(0);   //~ ERROR: this method takes 2 arguments but 1 argument was supplied
 
     let y = Foo;
     y.zero()
-     .take()    //~ ERROR not an iterator
+     .take()    //~ ERROR: no method named `take` found for struct `Foo` in the current scope
      .one(0);
-    y.three::<usize>(); //~ ERROR this method takes 3 arguments but 0 arguments were supplied
+    y.three::<usize>(); //~ ERROR: this method takes 3 arguments but 0 arguments were supplied
 }

--- a/tests/ui/methods/method-call-err-msg.stderr
+++ b/tests/ui/methods/method-call-err-msg.stderr
@@ -47,7 +47,7 @@ help: provide the argument
 LL |      .two(0, /* isize */);
    |            +++++++++++++
 
-error[E0599]: `Foo` is not an iterator
+error[E0599]: no method named `take` found for struct `Foo` in the current scope
   --> $DIR/method-call-err-msg.rs:19:7
    |
 LL |   pub struct Foo;

--- a/tests/ui/traits/method-on-unbounded-type-param.stderr
+++ b/tests/ui/traits/method-on-unbounded-type-param.stderr
@@ -14,7 +14,7 @@ LL | fn f<T: Iterator>(a: T, b: T) -> std::cmp::Ordering {
 LL | fn f<T: Ord>(a: T, b: T) -> std::cmp::Ordering {
    |       +++++
 
-error[E0599]: the method `cmp` exists for reference `&T`, but its trait bounds were not satisfied
+error[E0599]: no method named `cmp` found for type parameter `&T` in the current scope
   --> $DIR/method-on-unbounded-type-param.rs:5:10
    |
 LL |     (&a).cmp(&b)
@@ -35,7 +35,7 @@ LL | fn g<T: Iterator>(a: T, b: T) -> std::cmp::Ordering {
 LL | fn g<T: Ord>(a: T, b: T) -> std::cmp::Ordering {
    |       +++++
 
-error[E0599]: the method `cmp` exists for reference `&T`, but its trait bounds were not satisfied
+error[E0599]: no method named `cmp` found for type parameter `&T` in the current scope
   --> $DIR/method-on-unbounded-type-param.rs:8:7
    |
 LL |     a.cmp(&b)
@@ -56,7 +56,7 @@ LL | fn h<T: Iterator>(a: &T, b: T) -> std::cmp::Ordering {
 LL | fn h<T: Ord>(a: &T, b: T) -> std::cmp::Ordering {
    |       +++++
 
-error[E0599]: the method `cmp` exists for struct `Box<dyn T>`, but its trait bounds were not satisfied
+error[E0599]: no method named `cmp` found for struct `Box<dyn T>` in the current scope
   --> $DIR/method-on-unbounded-type-param.rs:14:7
    |
 LL | trait T {}


### PR DESCRIPTION
When calling a method that appears on `Iterator`, we often say "`Foo` is not an iterator", even if that method exists in other traits, which is quite confusing and many times nonsensical. Now, if we mention multiple traits we revert the main message back:

```
error[E0599]: no method named `take` found for struct `Foo` in the current scope
  --> $DIR/method-call-err-msg.rs:19:7
   |
LL |   pub struct Foo;
   |   -------------- method `take` not found for this struct because it doesn't satisfy `Foo: Iterator`
...
LL | /     y.zero()
LL | |      .take()
   | |      -^^^^ `Foo` is not an iterator
   | |______|
   |
   |
   = note: the following trait bounds were not satisfied:
           `Foo: Iterator`
           which is required by `&mut Foo: Iterator`
note: the trait `Iterator` must be implemented
  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
   = help: items from traits can only be used if the trait is implemented and in scope
   = note: the following traits define an item `take`, perhaps you need to implement one of them:
           candidate #1: `Iterator`
           candidate #2: `std::io::Read`
```

Fix rust-lang/rust#113550.