### PR TITLE
Tweak E0599 note

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -14,7 +14,7 @@ use rustc_data_structures::sorted_map::SortedMap;
 use rustc_data_structures::unord::UnordSet;
 use rustc_errors::codes::*;
 use rustc_errors::{
-    Applicability, Diag, MultiSpan, StashKey, listify, pluralize, struct_span_code_err,
+    Applicability, Diag, MultiSpan, StashKey, StringPart, listify, pluralize, struct_span_code_err,
 };
 use rustc_hir::attrs::diagnostic::OnUnimplementedNote;
 use rustc_hir::def::{CtorKind, DefKind, Res};
@@ -1413,33 +1413,45 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         }
                     })
                     .collect::<Vec<_>>();
-                if !inherent_impls_candidate.is_empty() {
-                    inherent_impls_candidate.sort_by_key(|&id| self.tcx.def_path_str(id));
-                    inherent_impls_candidate.dedup();
-
-                    // number of types to show at most
-                    let limit = if inherent_impls_candidate.len() == 5 { 5 } else { 4 };
-                    let type_candidates = inherent_impls_candidate
-                        .iter()
-                        .take(limit)
-                        .map(|impl_item| {
-                            format!(
-                                "- `{}`",
-                                self.tcx.at(span).type_of(*impl_item).instantiate_identity()
-                            )
-                        })
-                        .collect::<Vec<_>>()
-                        .join("\n");
-                    let additional_types = if inherent_impls_candidate.len() > limit {
-                        format!("\nand {} more types", inherent_impls_candidate.len() - limit)
-                    } else {
-                        "".to_string()
-                    };
-                    err.note(format!(
-                        "the {item_kind} was found for\n{type_candidates}{additional_types}"
-                    ));
-                    *find_candidate_for_method = mode == Mode::MethodCall;
-                }
+                inherent_impls_candidate.sort_by_key(|&id| self.tcx.def_path_str(id));
+                inherent_impls_candidate.dedup();
+                let msg = match &inherent_impls_candidate[..] {
+                    [] => return,
+                    [only] => {
+                        vec![
+                            StringPart::normal(format!("the {item_kind} was found for `")),
+                            StringPart::highlighted(
+                                self.tcx.at(span).type_of(*only).instantiate_identity().to_string(),
+                            ),
+                            StringPart::normal(format!("`")),
+                        ]
+                    }
+                    candidates => {
+                        // number of types to show at most
+                        let limit = if candidates.len() == 5 { 5 } else { 4 };
+                        let type_candidates = candidates
+                            .iter()
+                            .take(limit)
+                            .map(|impl_item| {
+                                format!(
+                                    "- `{}`",
+                                    self.tcx.at(span).type_of(*impl_item).instantiate_identity()
+                                )
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        let additional_types = if candidates.len() > limit {
+                            format!("\nand {} more types", candidates.len() - limit)
+                        } else {
+                            "".to_string()
+                        };
+                        vec![StringPart::normal(format!(
+                            "the {item_kind} was found for\n{type_candidates}{additional_types}"
+                        ))]
+                    }
+                };
+                err.highlighted_note(msg);
+                *find_candidate_for_method = mode == Mode::MethodCall;
             }
         } else {
             let ty_str = if ty_str.len() > 50 { String::new() } else { format!("on `{ty_str}` ") };

--- a/tests/ui/associated-consts/wrong-projection-self-ty-invalid-bivariant-arg.stderr
+++ b/tests/ui/associated-consts/wrong-projection-self-ty-invalid-bivariant-arg.stderr
@@ -16,8 +16,7 @@ LL | struct Fail<T>;
 LL |     Fail::<()>::C
    |                 ^ associated item not found in `Fail<()>`
    |
-   = note: the associated item was found for
-           - `Fail<i32>`
+   = note: the associated item was found for `Fail<i32>`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/associated-consts/wrong-projection-self-ty-invalid-bivariant-arg2.stderr
+++ b/tests/ui/associated-consts/wrong-projection-self-ty-invalid-bivariant-arg2.stderr
@@ -24,8 +24,7 @@ LL | struct Fail<T: Proj<Assoc = U>, U>(T);
 LL |     Fail::<i32, u32>::C
    |                       ^ associated item not found in `Fail<i32, u32>`
    |
-   = note: the associated item was found for
-           - `Fail<i32, i32>`
+   = note: the associated item was found for `Fail<i32, i32>`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/lookup-method.stderr
+++ b/tests/ui/const-generics/lookup-method.stderr
@@ -7,8 +7,7 @@ LL | struct Builder<const A: bool, const B: bool>;
 LL |     b.cast().build();
    |              ^^^^^ method not found in `Builder<false, true>`
    |
-   = note: the method was found for
-           - `Builder<true, true>`
+   = note: the method was found for `Builder<true, true>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-30123.stderr
+++ b/tests/ui/issues/issue-30123.stderr
@@ -9,8 +9,7 @@ note: if you're trying to build a new `issue_30123_aux::Graph<i32, i32>`, consid
    |
 LL |     pub fn new() -> Self {
    |     ^^^^^^^^^^^^^^^^^^^^
-   = note: the function or associated item was found for
-           - `issue_30123_aux::Graph<N, E, Undirected>`
+   = note: the function or associated item was found for `issue_30123_aux::Graph<N, E, Undirected>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/methods/method-not-found-generic-arg-elision.stderr
+++ b/tests/ui/methods/method-not-found-generic-arg-elision.stderr
@@ -7,8 +7,7 @@ LL | struct Point<T> {
 LL |     let d = point_i32.distance();
    |                       ^^^^^^^^ method not found in `Point<i32>`
    |
-   = note: the method was found for
-           - `Point<f64>`
+   = note: the method was found for `Point<f64>`
 
 error[E0599]: no method named `other` found for struct `Point<T>` in the current scope
   --> $DIR/method-not-found-generic-arg-elision.rs:84:23

--- a/tests/ui/privacy/ufc-method-call.different_name.stderr
+++ b/tests/ui/privacy/ufc-method-call.different_name.stderr
@@ -7,8 +7,7 @@ LL |     pub struct Foo<T>(T);
 LL |     test::Foo::<test::B>::foo();
    |                           ^^^ function or associated item not found in `Foo<B>`
    |
-   = note: the function or associated item was found for
-           - `Foo<A>`
+   = note: the function or associated item was found for `Foo<A>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-alias-impl-trait/method_resolution.current.stderr
+++ b/tests/ui/type-alias-impl-trait/method_resolution.current.stderr
@@ -7,8 +7,7 @@ LL | struct Bar<T>(T);
 LL |         self.bar()
    |              ^^^ method not found in `Bar<u32>`
    |
-   = note: the method was found for
-           - `Bar<Foo>`
+   = note: the method was found for `Bar<Foo>`
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
When not finding a method for a type, but finding it for a single other impl, special case the output to emit a single message instead of a list.

```
error[E0599]: no associated item named `C` found for struct `Fail<i32, u32>` in the current scope
  --> $DIR/wrong-projection-self-ty-invalid-bivariant-arg2.rs:15:23
   |
LL | struct Fail<T: Proj<Assoc = U>, U>(T);
   | ---------------------------------- associated item `C` not found for this struct
...
LL |     Fail::<i32, u32>::C
   |                       ^ associated item not found in `Fail<i32, u32>`
   |
   = note: the associated item was found for `Fail<i32, i32>`
```
instead of

```
   = note: the associated item was found for
           - `Fail<i32, i32>`
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
