### PR TITLE
fix(resolve): Warn on Self-Type Lifetime Elision for Non-`Self` Types

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0307.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0307.md
@@ -41,6 +41,7 @@ also be the underlying implementing type, like `Foo` in the following
 example:
 
 ```
+# #![allow(self_lifetime_elision_not_applicable)]
 # struct Foo;
 # trait Trait {
 #     fn foo(&self);

--- a/compiler/rustc_error_codes/src/error_codes/E0772.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0772.md
@@ -52,6 +52,7 @@ internal data was omitted, meaning that the compiler inferred the lifetime
 compiler to look like this:
 
 ```
+# #![allow(self_lifetime_elision_not_applicable)]
 # trait Person {}
 #
 # impl dyn Person {

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2922,7 +2922,7 @@ declare_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust
+    /// ```rust,compile_fail
     /// struct Foo<'a>(&'a ());
     ///
     /// impl<'a> Foo<'a> {
@@ -2940,7 +2940,7 @@ declare_lint! {
     /// aliases, ignores generic arguments, and may silently choose an
     /// incorrect lifetime. Use `&self` or `self: &Self` instead.
     pub SELF_LIFETIME_ELISION_NOT_APPLICABLE,
-    Warn,
+    Deny,
     "self-type lifetime elision for non-`Self` type",
     @future_incompatible = FutureIncompatibleInfo {
         reason: fcw!(FutureReleaseError #140611),

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -106,6 +106,7 @@ declare_lint_pass! {
         RUST_2024_INCOMPATIBLE_PAT,
         RUST_2024_PRELUDE_COLLISIONS,
         SELF_CONSTRUCTOR_FROM_OUTER_ITEM,
+        SELF_LIFETIME_ELISION_NOT_APPLICABLE,
         SEMICOLON_IN_EXPRESSIONS_FROM_MACROS,
         SHADOWING_SUPERTRAIT_ITEMS,
         SINGLE_USE_LIFETIMES,
@@ -2911,6 +2912,38 @@ declare_lint! {
     "detect unsupported use of `Self` from outer item",
     @future_incompatible = FutureIncompatibleInfo {
         reason: fcw!(FutureReleaseError #124186),
+    };
+}
+
+declare_lint! {
+    /// The `self_lifetime_elision_not_applicable` lint detects `self` parameters
+    /// whose type does not syntactically contain `Self`, causing lifetime
+    /// elision to rely on an unreliable name-matching heuristic.
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// struct Foo<'a>(&'a ());
+    ///
+    /// impl<'a> Foo<'a> {
+    ///     fn get(self: &Foo<'a>) -> &() { self.0 }
+    /// }
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// When a `self` parameter uses a concrete type name instead of `Self`,
+    /// the compiler uses a name-matching heuristic to determine if self-type
+    /// lifetime elision applies. This heuristic cannot see through type
+    /// aliases, ignores generic arguments, and may silently choose an
+    /// incorrect lifetime. Use `&self` or `self: &Self` instead.
+    pub SELF_LIFETIME_ELISION_NOT_APPLICABLE,
+    Warn,
+    "self-type lifetime elision for non-`Self` type",
+    @future_incompatible = FutureIncompatibleInfo {
+        reason: fcw!(FutureReleaseError #140611),
     };
 }
 

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -1776,3 +1776,11 @@ pub(crate) enum UnusedImportsSugg {
         num_to_remove: usize,
     },
 }
+
+#[derive(Diagnostic)]
+#[diag("`self` parameter type does not contain `Self`")]
+#[help("use `&self`, `&mut self`, or `self: &Self` for correct lifetime elision")]
+pub(crate) struct SelfLifetimeElisionNotApplicable {
+    #[primary_span]
+    pub span: Span,
+}

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -13,7 +13,8 @@ use std::mem::{replace, swap, take};
 use std::ops::{ControlFlow, Range};
 
 use rustc_ast::visit::{
-    AssocCtxt, BoundKind, FnCtxt, FnKind, Visitor, try_visit, visit_opt, walk_list,
+    AssocCtxt, BoundKind, FnCtxt, FnKind, LifetimeCtxt, Visitor, try_visit, visit_opt, walk_list,
+    walk_ty,
 };
 use rustc_ast::*;
 use rustc_data_structures::either::Either;
@@ -2448,9 +2449,10 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
             binder: fn_id,
             report_in_path: report_elided_lifetimes_in_path,
         };
+        let output_has_lifetime = fn_output_has_lifetime(output_ty);
         self.with_lifetime_rib(rib, |this| {
             // Add each argument to the rib.
-            let elision_lifetime = this.resolve_fn_params(has_self, inputs);
+            let elision_lifetime = this.resolve_fn_params(has_self, inputs, output_has_lifetime);
             debug!(?elision_lifetime);
 
             let outer_failures = take(&mut this.diag_metadata.current_elision_failures);
@@ -2493,6 +2495,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
         &mut self,
         has_self: bool,
         inputs: impl Iterator<Item = (Option<&'ast Pat>, &'ast Ty)> + Clone,
+        output_has_lifetime: bool,
     ) -> Result<LifetimeRes, (Vec<MissingLifetime>, Vec<ElisionFnParameter>)> {
         enum Elision {
             /// We have not found any candidate.
@@ -2583,7 +2586,8 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
             if index == 0 && has_self {
                 let self_lifetime = self.find_lifetime_for_self(ty);
 
-                if self.self_type_has_reference(ty)
+                if output_has_lifetime
+                    && self.self_type_has_reference(ty)
                     && !self.self_param_has_genuine_self(ty)
                 {
                     self.r.lint_buffer.buffer_lint(
@@ -5655,6 +5659,30 @@ impl ItemInfoCollector<'_, '_, '_> {
             .delegation_fn_sigs
             .insert(self.r.owner_def_id(id), DelegationFnSig { has_self: decl.has_self() });
     }
+}
+
+fn fn_output_has_lifetime(output_ty: &FnRetTy) -> bool {
+    struct Probe(bool);
+    impl<'ast> Visitor<'ast> for Probe {
+        fn visit_lifetime(&mut self, _: &'ast Lifetime, _: LifetimeCtxt) {
+            self.0 = true;
+        }
+        fn visit_ty(&mut self, ty: &'ast Ty) {
+            if self.0 {
+                return;
+            }
+            match &ty.kind {
+                TyKind::Ref(..) | TyKind::PinnedRef(..) | TyKind::TraitObject(..) => {
+                    self.0 = true;
+                }
+                _ => walk_ty(self, ty),
+            }
+        }
+    }
+    let FnRetTy::Ty(ty) = output_ty else { return false };
+    let mut p = Probe(false);
+    p.visit_ty(ty);
+    p.0
 }
 
 fn required_generic_args_suggestion(generics: &ast::Generics) -> Option<String> {

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -2582,6 +2582,18 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
             // Handle `self` specially.
             if index == 0 && has_self {
                 let self_lifetime = self.find_lifetime_for_self(ty);
+
+                if self.self_type_has_reference(ty)
+                    && !self.self_param_has_genuine_self(ty)
+                {
+                    self.r.lint_buffer.buffer_lint(
+                        lint::builtin::SELF_LIFETIME_ELISION_NOT_APPLICABLE,
+                        ty.id,
+                        ty.span,
+                        crate::errors::SelfLifetimeElisionNotApplicable { span: ty.span },
+                    );
+                }
+
                 elision_lifetime = match self_lifetime {
                     // We found `self` elision.
                     Set1::One(lifetime) => Elision::Self_(lifetime),
@@ -2608,6 +2620,58 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
 
         // We do not have a candidate.
         Err((all_candidates, parameter_info))
+    }
+
+    /// Returns `true` if `ty` syntactically contains `Self`.
+    fn self_param_has_genuine_self(&self, ty: &'ast Ty) -> bool {
+        struct GenuineSelfVisitor<'a, 'ra, 'tcx> {
+            r: &'a Resolver<'ra, 'tcx>,
+            found: bool,
+        }
+        impl<'ra> Visitor<'ra> for GenuineSelfVisitor<'_, '_, '_> {
+            fn visit_ty(&mut self, ty: &'ra Ty) {
+                match ty.kind {
+                    TyKind::ImplicitSelf => self.found = true,
+                    TyKind::Path(None, _) => {
+                        if matches!(
+                            self.r.partial_res_map[&ty.id].full_res(),
+                            Some(Res::SelfTyParam { .. } | Res::SelfTyAlias { .. })
+                        ) {
+                            self.found = true;
+                        }
+                    }
+                    _ => {}
+                }
+                if !self.found {
+                    visit::walk_ty(self, ty);
+                }
+            }
+            fn visit_expr(&mut self, _: &'ra Expr) {}
+        }
+        let mut visitor = GenuineSelfVisitor { r: self.r, found: false };
+        visitor.visit_ty(ty);
+        visitor.found
+    }
+
+    /// Returns `true` if `ty` contains a reference type (`&` or pinned `&`).
+    fn self_type_has_reference(&self, ty: &'ast Ty) -> bool {
+        struct RefVisitor {
+            found: bool,
+        }
+        impl<'ra> Visitor<'ra> for RefVisitor {
+            fn visit_ty(&mut self, ty: &'ra Ty) {
+                if matches!(ty.kind, TyKind::Ref(..) | TyKind::PinnedRef(..)) {
+                    self.found = true;
+                }
+                if !self.found {
+                    visit::walk_ty(self, ty);
+                }
+            }
+            fn visit_expr(&mut self, _: &'ra Expr) {}
+        }
+        let mut visitor = RefVisitor { found: false };
+        visitor.visit_ty(ty);
+        visitor.found
     }
 
     /// List all the lifetimes that appear in the provided type.

--- a/tests/ui/async-await/inference_var_self_argument.rs
+++ b/tests/ui/async-await/inference_var_self_argument.rs
@@ -1,3 +1,4 @@
+#![allow(self_lifetime_elision_not_applicable)]
 //! This is a regression test for an ICE.
 //@ edition: 2021
 

--- a/tests/ui/async-await/inference_var_self_argument.stderr
+++ b/tests/ui/async-await/inference_var_self_argument.stderr
@@ -1,5 +1,5 @@
 error[E0307]: invalid `self` parameter type: `&dyn Foo`
-  --> $DIR/inference_var_self_argument.rs:5:24
+  --> $DIR/inference_var_self_argument.rs:6:24
    |
 LL |     async fn foo(self: &dyn Foo) {
    |                        ^^^^^^^^
@@ -8,14 +8,14 @@ LL |     async fn foo(self: &dyn Foo) {
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/inference_var_self_argument.rs:5:33
+  --> $DIR/inference_var_self_argument.rs:6:33
    |
 LL |     async fn foo(self: &dyn Foo) {
    |                                 ^ `Foo` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/inference_var_self_argument.rs:5:14
+  --> $DIR/inference_var_self_argument.rs:6:14
    |
 LL | trait Foo {
    |       --- this trait is not dyn compatible...

--- a/tests/ui/borrowck/borrow-in-match-with-format-string.rs
+++ b/tests/ui/borrowck/borrow-in-match-with-format-string.rs
@@ -1,4 +1,5 @@
 //@ run-pass
+#![allow(self_lifetime_elision_not_applicable)]
 // Test for https://github.com/rust-lang/rust/issues/21400 extracted from
 // stackoverflow.com/questions/28031155/is-my-borrow-checker-drunk/28031580
 

--- a/tests/ui/closures/2229_closure_analysis/issue-88476.rs
+++ b/tests/ui/closures/2229_closure_analysis/issue-88476.rs
@@ -1,6 +1,7 @@
 //@ edition:2021
 
 #![feature(rustc_attrs)]
+#![allow(self_lifetime_elision_not_applicable)]
 
 // Test that we can't move out of struct that impls `Drop`.
 

--- a/tests/ui/closures/2229_closure_analysis/issue-88476.stderr
+++ b/tests/ui/closures/2229_closure_analysis/issue-88476.stderr
@@ -1,5 +1,5 @@
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/issue-88476.rs:20:13
+  --> $DIR/issue-88476.rs:21:13
    |
 LL |     let x = #[rustc_capture_analysis] move || {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL |     let x = #[rustc_capture_analysis] move || {
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/issue-88476.rs:48:13
+  --> $DIR/issue-88476.rs:49:13
    |
 LL |     let c = #[rustc_capture_analysis] move || {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL |     let c = #[rustc_capture_analysis] move || {
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
-  --> $DIR/issue-88476.rs:20:39
+  --> $DIR/issue-88476.rs:21:39
    |
 LL |       let x = #[rustc_capture_analysis] move || {
    |  _______________________________________^
@@ -28,13 +28,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing f[(0, 0)] -> Immutable
-  --> $DIR/issue-88476.rs:26:26
+  --> $DIR/issue-88476.rs:27:26
    |
 LL |         println!("{:?}", f.0);
    |                          ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/issue-88476.rs:20:39
+  --> $DIR/issue-88476.rs:21:39
    |
 LL |       let x = #[rustc_capture_analysis] move || {
    |  _______________________________________^
@@ -43,13 +43,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture f[] -> ByValue
-  --> $DIR/issue-88476.rs:26:26
+  --> $DIR/issue-88476.rs:27:26
    |
 LL |         println!("{:?}", f.0);
    |                          ^^^
 
 error: First Pass analysis includes:
-  --> $DIR/issue-88476.rs:48:39
+  --> $DIR/issue-88476.rs:49:39
    |
 LL |       let c = #[rustc_capture_analysis] move || {
    |  _______________________________________^
@@ -58,13 +58,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing character[(0, 0)] -> Immutable
-  --> $DIR/issue-88476.rs:54:24
+  --> $DIR/issue-88476.rs:55:24
    |
 LL |         println!("{}", character.hp)
    |                        ^^^^^^^^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/issue-88476.rs:48:39
+  --> $DIR/issue-88476.rs:49:39
    |
 LL |       let c = #[rustc_capture_analysis] move || {
    |  _______________________________________^
@@ -73,7 +73,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture character[(0, 0)] -> ByValue
-  --> $DIR/issue-88476.rs:54:24
+  --> $DIR/issue-88476.rs:55:24
    |
 LL |         println!("{}", character.hp)
    |                        ^^^^^^^^^^^^

--- a/tests/ui/closures/2229_closure_analysis/run_pass/issue-88476.rs
+++ b/tests/ui/closures/2229_closure_analysis/run_pass/issue-88476.rs
@@ -1,6 +1,8 @@
 //@ check-pass
 //@ edition:2021
 
+#![allow(self_lifetime_elision_not_applicable)]
+
 use std::rc::Rc;
 
 // Test that we restrict precision when moving not-`Copy` types, if any of the parent paths

--- a/tests/ui/internal-lints/rustc_pass_by_value_self.rs
+++ b/tests/ui/internal-lints/rustc_pass_by_value_self.rs
@@ -7,6 +7,7 @@
 #![feature(rustc_attrs)]
 #![deny(rustc::disallowed_pass_by_ref)]
 #![allow(unused)]
+#![allow(self_lifetime_elision_not_applicable)]
 
 #[rustc_pass_by_value]
 struct TyCtxt<'tcx> {

--- a/tests/ui/internal-lints/rustc_pass_by_value_self.stderr
+++ b/tests/ui/internal-lints/rustc_pass_by_value_self.stderr
@@ -1,5 +1,5 @@
 error: passing `TyCtxt<'tcx>` by reference
-  --> $DIR/rustc_pass_by_value_self.rs:18:15
+  --> $DIR/rustc_pass_by_value_self.rs:19:15
    |
 LL |     fn by_ref(&self) {}
    |               ^^^^^ help: try passing by value: `TyCtxt<'tcx>`
@@ -11,25 +11,25 @@ LL | #![deny(rustc::disallowed_pass_by_ref)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: passing `Ty<'tcx>` by reference
-  --> $DIR/rustc_pass_by_value_self.rs:30:21
+  --> $DIR/rustc_pass_by_value_self.rs:31:21
    |
 LL |     fn by_ref(self: &Ty<'tcx>) {}
    |                     ^^^^^^^^^ help: try passing by value: `Ty<'tcx>`
 
 error: passing `Foo` by reference
-  --> $DIR/rustc_pass_by_value_self.rs:37:17
+  --> $DIR/rustc_pass_by_value_self.rs:38:17
    |
 LL |     fn with_ref(&self) {}
    |                 ^^^^^ help: try passing by value: `Foo`
 
 error: passing `WithParameters<T, 1>` by reference
-  --> $DIR/rustc_pass_by_value_self.rs:47:17
+  --> $DIR/rustc_pass_by_value_self.rs:48:17
    |
 LL |     fn with_ref(&self) {}
    |                 ^^^^^ help: try passing by value: `WithParameters<T, 1>`
 
 error: passing `WithParameters<T, 1, u8>` by reference
-  --> $DIR/rustc_pass_by_value_self.rs:51:17
+  --> $DIR/rustc_pass_by_value_self.rs:52:17
    |
 LL |     fn with_ref(&self) {}
    |                 ^^^^^ help: try passing by value: `WithParameters<T, 1, u8>`

--- a/tests/ui/issues/issue-17905-2.rs
+++ b/tests/ui/issues/issue-17905-2.rs
@@ -1,3 +1,5 @@
+#![allow(self_lifetime_elision_not_applicable)]
+
 #[derive(Debug)]
 struct Pair<T, V> (T, V);
 

--- a/tests/ui/issues/issue-17905-2.stderr
+++ b/tests/ui/issues/issue-17905-2.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched `self` parameter type
-  --> $DIR/issue-17905-2.rs:8:18
+  --> $DIR/issue-17905-2.rs:10:18
    |
 LL |     fn say(self: &Pair<&str, isize>) {
    |                  ^^^^^^^^^^^^^^^^^^ lifetime mismatch
@@ -7,18 +7,18 @@ LL |     fn say(self: &Pair<&str, isize>) {
    = note: expected struct `Pair<&_, _>`
               found struct `Pair<&_, _>`
 note: the anonymous lifetime defined here...
-  --> $DIR/issue-17905-2.rs:8:24
+  --> $DIR/issue-17905-2.rs:10:24
    |
 LL |     fn say(self: &Pair<&str, isize>) {
    |                        ^^^^
 note: ...does not necessarily outlive the anonymous lifetime as defined here
-  --> $DIR/issue-17905-2.rs:5:5
+  --> $DIR/issue-17905-2.rs:7:5
    |
 LL |     &str,
    |     ^
 
 error[E0308]: mismatched `self` parameter type
-  --> $DIR/issue-17905-2.rs:8:18
+  --> $DIR/issue-17905-2.rs:10:18
    |
 LL |     fn say(self: &Pair<&str, isize>) {
    |                  ^^^^^^^^^^^^^^^^^^ lifetime mismatch
@@ -26,12 +26,12 @@ LL |     fn say(self: &Pair<&str, isize>) {
    = note: expected struct `Pair<&_, _>`
               found struct `Pair<&_, _>`
 note: the anonymous lifetime as defined here...
-  --> $DIR/issue-17905-2.rs:5:5
+  --> $DIR/issue-17905-2.rs:7:5
    |
 LL |     &str,
    |     ^
 note: ...does not necessarily outlive the anonymous lifetime defined here
-  --> $DIR/issue-17905-2.rs:8:24
+  --> $DIR/issue-17905-2.rs:10:24
    |
 LL |     fn say(self: &Pair<&str, isize>) {
    |                        ^^^^

--- a/tests/ui/lifetimes/explicit-self-lifetime-mismatch.rs
+++ b/tests/ui/lifetimes/explicit-self-lifetime-mismatch.rs
@@ -1,3 +1,4 @@
+#![allow(self_lifetime_elision_not_applicable)]
 //@ dont-require-annotations: NOTE
 //! regression test for <https://github.com/rust-lang/rust/issues/17740>
 

--- a/tests/ui/lifetimes/explicit-self-lifetime-mismatch.stderr
+++ b/tests/ui/lifetimes/explicit-self-lifetime-mismatch.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched `self` parameter type
-  --> $DIR/explicit-self-lifetime-mismatch.rs:11:15
+  --> $DIR/explicit-self-lifetime-mismatch.rs:12:15
    |
 LL |         self: Foo<'b, 'a>,
    |               ^^^^^^^^^^^ lifetime mismatch
@@ -7,18 +7,18 @@ LL |         self: Foo<'b, 'a>,
    = note: expected struct `Foo<'a, 'b>`
               found struct `Foo<'b, 'a>`
 note: the lifetime `'b` as defined here...
-  --> $DIR/explicit-self-lifetime-mismatch.rs:9:10
+  --> $DIR/explicit-self-lifetime-mismatch.rs:10:10
    |
 LL | impl<'a, 'b> Foo<'a, 'b> {
    |          ^^
 note: ...does not necessarily outlive the lifetime `'a` as defined here
-  --> $DIR/explicit-self-lifetime-mismatch.rs:9:6
+  --> $DIR/explicit-self-lifetime-mismatch.rs:10:6
    |
 LL | impl<'a, 'b> Foo<'a, 'b> {
    |      ^^
 
 error[E0308]: mismatched `self` parameter type
-  --> $DIR/explicit-self-lifetime-mismatch.rs:11:15
+  --> $DIR/explicit-self-lifetime-mismatch.rs:12:15
    |
 LL |         self: Foo<'b, 'a>,
    |               ^^^^^^^^^^^ lifetime mismatch
@@ -26,18 +26,18 @@ LL |         self: Foo<'b, 'a>,
    = note: expected struct `Foo<'a, 'b>`
               found struct `Foo<'b, 'a>`
 note: the lifetime `'a` as defined here...
-  --> $DIR/explicit-self-lifetime-mismatch.rs:9:6
+  --> $DIR/explicit-self-lifetime-mismatch.rs:10:6
    |
 LL | impl<'a, 'b> Foo<'a, 'b> {
    |      ^^
 note: ...does not necessarily outlive the lifetime `'b` as defined here
-  --> $DIR/explicit-self-lifetime-mismatch.rs:9:10
+  --> $DIR/explicit-self-lifetime-mismatch.rs:10:10
    |
 LL | impl<'a, 'b> Foo<'a, 'b> {
    |          ^^
 
 error[E0308]: mismatched `self` parameter type
-  --> $DIR/explicit-self-lifetime-mismatch.rs:29:18
+  --> $DIR/explicit-self-lifetime-mismatch.rs:30:18
    |
 LL |     fn bar(self: &mut Bar) {
    |                  ^^^^^^^^ lifetime mismatch
@@ -45,18 +45,18 @@ LL |     fn bar(self: &mut Bar) {
    = note: expected struct `Bar<'a>`
               found struct `Bar<'_>`
 note: the anonymous lifetime defined here...
-  --> $DIR/explicit-self-lifetime-mismatch.rs:29:23
+  --> $DIR/explicit-self-lifetime-mismatch.rs:30:23
    |
 LL |     fn bar(self: &mut Bar) {
    |                       ^^^
 note: ...does not necessarily outlive the lifetime `'a` as defined here
-  --> $DIR/explicit-self-lifetime-mismatch.rs:28:6
+  --> $DIR/explicit-self-lifetime-mismatch.rs:29:6
    |
 LL | impl<'a> Bar<'a> {
    |      ^^
 
 error[E0308]: mismatched `self` parameter type
-  --> $DIR/explicit-self-lifetime-mismatch.rs:29:18
+  --> $DIR/explicit-self-lifetime-mismatch.rs:30:18
    |
 LL |     fn bar(self: &mut Bar) {
    |                  ^^^^^^^^ lifetime mismatch
@@ -64,12 +64,12 @@ LL |     fn bar(self: &mut Bar) {
    = note: expected struct `Bar<'a>`
               found struct `Bar<'_>`
 note: the lifetime `'a` as defined here...
-  --> $DIR/explicit-self-lifetime-mismatch.rs:28:6
+  --> $DIR/explicit-self-lifetime-mismatch.rs:29:6
    |
 LL | impl<'a> Bar<'a> {
    |      ^^
 note: ...does not necessarily outlive the anonymous lifetime defined here
-  --> $DIR/explicit-self-lifetime-mismatch.rs:29:23
+  --> $DIR/explicit-self-lifetime-mismatch.rs:30:23
    |
 LL |     fn bar(self: &mut Bar) {
    |                       ^^^

--- a/tests/ui/resolve/issue-103202.rs
+++ b/tests/ui/resolve/issue-103202.rs
@@ -1,3 +1,4 @@
+#![allow(self_lifetime_elision_not_applicable)]
 struct S {}
 
 impl S {

--- a/tests/ui/resolve/issue-103202.stderr
+++ b/tests/ui/resolve/issue-103202.stderr
@@ -1,5 +1,5 @@
 error[E0223]: ambiguous associated type
-  --> $DIR/issue-103202.rs:4:17
+  --> $DIR/issue-103202.rs:5:17
    |
 LL |     fn f(self: &S::x) {}
    |                 ^^^^

--- a/tests/ui/self/arbitrary-self-from-method-substs.default.stderr
+++ b/tests/ui/self/arbitrary-self-from-method-substs.default.stderr
@@ -1,5 +1,5 @@
 error[E0801]: invalid generic `self` parameter type: `R`
-  --> $DIR/arbitrary-self-from-method-substs.rs:9:43
+  --> $DIR/arbitrary-self-from-method-substs.rs:10:43
    |
 LL |     fn get<R: Deref<Target = Self>>(self: R) -> u32 {
    |                                           ^
@@ -8,7 +8,7 @@ LL |     fn get<R: Deref<Target = Self>>(self: R) -> u32 {
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0801]: invalid generic `self` parameter type: `&R`
-  --> $DIR/arbitrary-self-from-method-substs.rs:13:44
+  --> $DIR/arbitrary-self-from-method-substs.rs:14:44
    |
 LL |     fn get1<R: Deref<Target = Self>>(self: &R) -> u32 {
    |                                            ^^
@@ -17,7 +17,7 @@ LL |     fn get1<R: Deref<Target = Self>>(self: &R) -> u32 {
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0801]: invalid generic `self` parameter type: `&mut R`
-  --> $DIR/arbitrary-self-from-method-substs.rs:17:44
+  --> $DIR/arbitrary-self-from-method-substs.rs:18:44
    |
 LL |     fn get2<R: Deref<Target = Self>>(self: &mut R) -> u32 {
    |                                            ^^^^^^
@@ -26,7 +26,7 @@ LL |     fn get2<R: Deref<Target = Self>>(self: &mut R) -> u32 {
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0801]: invalid generic `self` parameter type: `Rc<R>`
-  --> $DIR/arbitrary-self-from-method-substs.rs:21:44
+  --> $DIR/arbitrary-self-from-method-substs.rs:22:44
    |
 LL |     fn get3<R: Deref<Target = Self>>(self: std::rc::Rc<R>) -> u32 {
    |                                            ^^^^^^^^^^^^^^
@@ -35,7 +35,7 @@ LL |     fn get3<R: Deref<Target = Self>>(self: std::rc::Rc<R>) -> u32 {
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0801]: invalid generic `self` parameter type: `&Rc<R>`
-  --> $DIR/arbitrary-self-from-method-substs.rs:25:44
+  --> $DIR/arbitrary-self-from-method-substs.rs:26:44
    |
 LL |     fn get4<R: Deref<Target = Self>>(self: &std::rc::Rc<R>) -> u32 {
    |                                            ^^^^^^^^^^^^^^^
@@ -44,7 +44,7 @@ LL |     fn get4<R: Deref<Target = Self>>(self: &std::rc::Rc<R>) -> u32 {
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0801]: invalid generic `self` parameter type: `Rc<&R>`
-  --> $DIR/arbitrary-self-from-method-substs.rs:29:44
+  --> $DIR/arbitrary-self-from-method-substs.rs:30:44
    |
 LL |     fn get5<R: Deref<Target = Self>>(self: std::rc::Rc<&R>) -> u32 {
    |                                            ^^^^^^^^^^^^^^^
@@ -53,7 +53,7 @@ LL |     fn get5<R: Deref<Target = Self>>(self: std::rc::Rc<&R>) -> u32 {
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0658]: `<FR as FindReceiver>::Receiver` cannot be used as the type of `self` without the `arbitrary_self_types` feature
-  --> $DIR/arbitrary-self-from-method-substs.rs:33:37
+  --> $DIR/arbitrary-self-from-method-substs.rs:34:37
    |
 LL |     fn get6<FR: FindReceiver>(self: FR::Receiver, other: FR) -> u32 {
    |                                     ^^^^^^^^^^^^
@@ -64,7 +64,7 @@ LL |     fn get6<FR: FindReceiver>(self: FR::Receiver, other: FR) -> u32 {
    = help: consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`
 
 error[E0658]: `R` cannot be used as the type of `self` without the `arbitrary_self_types` feature
-  --> $DIR/arbitrary-self-from-method-substs.rs:61:18
+  --> $DIR/arbitrary-self-from-method-substs.rs:62:18
    |
 LL |     fn get(self: R) {}
    |                  ^
@@ -75,13 +75,13 @@ LL |     fn get(self: R) {}
    = help: consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`
 
 error[E0271]: type mismatch resolving `<Silly as FindReceiver>::Receiver == Foo`
-  --> $DIR/arbitrary-self-from-method-substs.rs:92:9
+  --> $DIR/arbitrary-self-from-method-substs.rs:93:9
    |
 LL |     foo.get6(Silly);
    |         ^^^^ type mismatch resolving `<Silly as FindReceiver>::Receiver == Foo`
    |
 note: expected this to be `Foo`
-  --> $DIR/arbitrary-self-from-method-substs.rs:71:21
+  --> $DIR/arbitrary-self-from-method-substs.rs:72:21
    |
 LL |     type Receiver = std::rc::Rc<Foo>;
    |                     ^^^^^^^^^^^^^^^^
@@ -89,13 +89,13 @@ LL |     type Receiver = std::rc::Rc<Foo>;
               found struct `Rc<Foo>`
 
 error[E0271]: type mismatch resolving `<Silly as FindReceiver>::Receiver == &Foo`
-  --> $DIR/arbitrary-self-from-method-substs.rs:96:9
+  --> $DIR/arbitrary-self-from-method-substs.rs:97:9
    |
 LL |     foo.get6(Silly);
    |         ^^^^ type mismatch resolving `<Silly as FindReceiver>::Receiver == &Foo`
    |
 note: expected this to be `&Foo`
-  --> $DIR/arbitrary-self-from-method-substs.rs:71:21
+  --> $DIR/arbitrary-self-from-method-substs.rs:72:21
    |
 LL |     type Receiver = std::rc::Rc<Foo>;
    |                     ^^^^^^^^^^^^^^^^
@@ -103,7 +103,7 @@ LL |     type Receiver = std::rc::Rc<Foo>;
                  found struct `Rc<Foo>`
 
 error[E0599]: the method `get` exists for struct `Rc<Bar<_>>`, but its trait bounds were not satisfied
-  --> $DIR/arbitrary-self-from-method-substs.rs:100:7
+  --> $DIR/arbitrary-self-from-method-substs.rs:101:7
    |
 LL | struct Bar<R>(std::marker::PhantomData<R>);
    | ------------- doesn't satisfy `Bar<_>: Deref`
@@ -118,7 +118,7 @@ note: the following trait bounds were not satisfied:
       `<&mut Rc<Bar<_>> as Deref>::Target = Bar<&mut Rc<Bar<_>>>`
       `<Rc<Bar<_>> as Deref>::Target = Bar<Rc<Bar<_>>>`
       `Bar<_>: Deref`
-  --> $DIR/arbitrary-self-from-method-substs.rs:60:9
+  --> $DIR/arbitrary-self-from-method-substs.rs:61:9
    |
 LL | impl<R: std::ops::Deref<Target = Self>> Bar<R> {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ------
@@ -132,7 +132,7 @@ note: the trait `Deref` must be implemented
            candidate #1: `SliceIndex`
 
 error[E0599]: the method `get` exists for reference `&Rc<Bar<_>>`, but its trait bounds were not satisfied
-  --> $DIR/arbitrary-self-from-method-substs.rs:108:7
+  --> $DIR/arbitrary-self-from-method-substs.rs:109:7
    |
 LL | struct Bar<R>(std::marker::PhantomData<R>);
    | ------------- doesn't satisfy `Bar<_>: Deref`
@@ -149,7 +149,7 @@ note: the following trait bounds were not satisfied:
       `<&mut Rc<Bar<_>> as Deref>::Target = Bar<&mut Rc<Bar<_>>>`
       `<Rc<Bar<_>> as Deref>::Target = Bar<Rc<Bar<_>>>`
       `Bar<_>: Deref`
-  --> $DIR/arbitrary-self-from-method-substs.rs:60:9
+  --> $DIR/arbitrary-self-from-method-substs.rs:61:9
    |
 LL | impl<R: std::ops::Deref<Target = Self>> Bar<R> {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ------

--- a/tests/ui/self/arbitrary-self-from-method-substs.feature.stderr
+++ b/tests/ui/self/arbitrary-self-from-method-substs.feature.stderr
@@ -1,5 +1,5 @@
 error[E0801]: invalid generic `self` parameter type: `R`
-  --> $DIR/arbitrary-self-from-method-substs.rs:9:43
+  --> $DIR/arbitrary-self-from-method-substs.rs:10:43
    |
 LL |     fn get<R: Deref<Target = Self>>(self: R) -> u32 {
    |                                           ^
@@ -8,7 +8,7 @@ LL |     fn get<R: Deref<Target = Self>>(self: R) -> u32 {
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0801]: invalid generic `self` parameter type: `&R`
-  --> $DIR/arbitrary-self-from-method-substs.rs:13:44
+  --> $DIR/arbitrary-self-from-method-substs.rs:14:44
    |
 LL |     fn get1<R: Deref<Target = Self>>(self: &R) -> u32 {
    |                                            ^^
@@ -17,7 +17,7 @@ LL |     fn get1<R: Deref<Target = Self>>(self: &R) -> u32 {
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0801]: invalid generic `self` parameter type: `&mut R`
-  --> $DIR/arbitrary-self-from-method-substs.rs:17:44
+  --> $DIR/arbitrary-self-from-method-substs.rs:18:44
    |
 LL |     fn get2<R: Deref<Target = Self>>(self: &mut R) -> u32 {
    |                                            ^^^^^^
@@ -26,7 +26,7 @@ LL |     fn get2<R: Deref<Target = Self>>(self: &mut R) -> u32 {
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0801]: invalid generic `self` parameter type: `Rc<R>`
-  --> $DIR/arbitrary-self-from-method-substs.rs:21:44
+  --> $DIR/arbitrary-self-from-method-substs.rs:22:44
    |
 LL |     fn get3<R: Deref<Target = Self>>(self: std::rc::Rc<R>) -> u32 {
    |                                            ^^^^^^^^^^^^^^
@@ -35,7 +35,7 @@ LL |     fn get3<R: Deref<Target = Self>>(self: std::rc::Rc<R>) -> u32 {
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0801]: invalid generic `self` parameter type: `&Rc<R>`
-  --> $DIR/arbitrary-self-from-method-substs.rs:25:44
+  --> $DIR/arbitrary-self-from-method-substs.rs:26:44
    |
 LL |     fn get4<R: Deref<Target = Self>>(self: &std::rc::Rc<R>) -> u32 {
    |                                            ^^^^^^^^^^^^^^^
@@ -44,7 +44,7 @@ LL |     fn get4<R: Deref<Target = Self>>(self: &std::rc::Rc<R>) -> u32 {
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0801]: invalid generic `self` parameter type: `Rc<&R>`
-  --> $DIR/arbitrary-self-from-method-substs.rs:29:44
+  --> $DIR/arbitrary-self-from-method-substs.rs:30:44
    |
 LL |     fn get5<R: Deref<Target = Self>>(self: std::rc::Rc<&R>) -> u32 {
    |                                            ^^^^^^^^^^^^^^^
@@ -53,13 +53,13 @@ LL |     fn get5<R: Deref<Target = Self>>(self: std::rc::Rc<&R>) -> u32 {
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0308]: mismatched types
-  --> $DIR/arbitrary-self-from-method-substs.rs:76:5
+  --> $DIR/arbitrary-self-from-method-substs.rs:77:5
    |
 LL |     foo.get::<&Foo>();
    |     ^^^ expected `&Foo`, found `Foo`
 
 error[E0308]: mismatched types
-  --> $DIR/arbitrary-self-from-method-substs.rs:78:5
+  --> $DIR/arbitrary-self-from-method-substs.rs:79:5
    |
 LL |     foo.get::<std::rc::Rc<Foo>>();
    |     ^^^ expected `Rc<Foo>`, found `Foo`
@@ -68,7 +68,7 @@ LL |     foo.get::<std::rc::Rc<Foo>>();
               found struct `Foo`
 
 error[E0308]: mismatched types
-  --> $DIR/arbitrary-self-from-method-substs.rs:84:5
+  --> $DIR/arbitrary-self-from-method-substs.rs:85:5
    |
 LL |     smart_ptr.get::<SmartPtr2<Foo>>();
    |     ^^^^^^^^^ expected `SmartPtr2<'_, Foo>`, found `SmartPtr<'_, Foo>`
@@ -77,7 +77,7 @@ LL |     smart_ptr.get::<SmartPtr2<Foo>>();
               found struct `SmartPtr<'_, Foo>`
 
 error[E0308]: mismatched types
-  --> $DIR/arbitrary-self-from-method-substs.rs:86:5
+  --> $DIR/arbitrary-self-from-method-substs.rs:87:5
    |
 LL |     smart_ptr.get::<&Foo>();
    |     ^^^^^^^^^ expected `&Foo`, found `SmartPtr<'_, Foo>`
@@ -86,13 +86,13 @@ LL |     smart_ptr.get::<&Foo>();
                  found struct `SmartPtr<'_, Foo>`
 
 error[E0271]: type mismatch resolving `<Silly as FindReceiver>::Receiver == Foo`
-  --> $DIR/arbitrary-self-from-method-substs.rs:92:9
+  --> $DIR/arbitrary-self-from-method-substs.rs:93:9
    |
 LL |     foo.get6(Silly);
    |         ^^^^ type mismatch resolving `<Silly as FindReceiver>::Receiver == Foo`
    |
 note: expected this to be `Foo`
-  --> $DIR/arbitrary-self-from-method-substs.rs:71:21
+  --> $DIR/arbitrary-self-from-method-substs.rs:72:21
    |
 LL |     type Receiver = std::rc::Rc<Foo>;
    |                     ^^^^^^^^^^^^^^^^
@@ -100,13 +100,13 @@ LL |     type Receiver = std::rc::Rc<Foo>;
               found struct `Rc<Foo>`
 
 error[E0271]: type mismatch resolving `<Silly as FindReceiver>::Receiver == &Foo`
-  --> $DIR/arbitrary-self-from-method-substs.rs:96:9
+  --> $DIR/arbitrary-self-from-method-substs.rs:97:9
    |
 LL |     foo.get6(Silly);
    |         ^^^^ type mismatch resolving `<Silly as FindReceiver>::Receiver == &Foo`
    |
 note: expected this to be `&Foo`
-  --> $DIR/arbitrary-self-from-method-substs.rs:71:21
+  --> $DIR/arbitrary-self-from-method-substs.rs:72:21
    |
 LL |     type Receiver = std::rc::Rc<Foo>;
    |                     ^^^^^^^^^^^^^^^^
@@ -114,7 +114,7 @@ LL |     type Receiver = std::rc::Rc<Foo>;
                  found struct `Rc<Foo>`
 
 error[E0599]: the method `get` exists for struct `Rc<Bar<_>>`, but its trait bounds were not satisfied
-  --> $DIR/arbitrary-self-from-method-substs.rs:100:7
+  --> $DIR/arbitrary-self-from-method-substs.rs:101:7
    |
 LL | struct Bar<R>(std::marker::PhantomData<R>);
    | ------------- doesn't satisfy `Bar<_>: Deref`
@@ -129,7 +129,7 @@ note: the following trait bounds were not satisfied:
       `<&mut Rc<Bar<_>> as Deref>::Target = Bar<&mut Rc<Bar<_>>>`
       `<Rc<Bar<_>> as Deref>::Target = Bar<Rc<Bar<_>>>`
       `Bar<_>: Deref`
-  --> $DIR/arbitrary-self-from-method-substs.rs:60:9
+  --> $DIR/arbitrary-self-from-method-substs.rs:61:9
    |
 LL | impl<R: std::ops::Deref<Target = Self>> Bar<R> {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ------
@@ -143,7 +143,7 @@ note: the trait `Deref` must be implemented
            candidate #1: `SliceIndex`
 
 error[E0599]: the method `get` exists for reference `&Rc<Bar<_>>`, but its trait bounds were not satisfied
-  --> $DIR/arbitrary-self-from-method-substs.rs:108:7
+  --> $DIR/arbitrary-self-from-method-substs.rs:109:7
    |
 LL | struct Bar<R>(std::marker::PhantomData<R>);
    | ------------- doesn't satisfy `Bar<_>: Deref`
@@ -160,7 +160,7 @@ note: the following trait bounds were not satisfied:
       `<&mut Rc<Bar<_>> as Deref>::Target = Bar<&mut Rc<Bar<_>>>`
       `<Rc<Bar<_>> as Deref>::Target = Bar<Rc<Bar<_>>>`
       `Bar<_>: Deref`
-  --> $DIR/arbitrary-self-from-method-substs.rs:60:9
+  --> $DIR/arbitrary-self-from-method-substs.rs:61:9
    |
 LL | impl<R: std::ops::Deref<Target = Self>> Bar<R> {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ------

--- a/tests/ui/self/arbitrary-self-from-method-substs.rs
+++ b/tests/ui/self/arbitrary-self-from-method-substs.rs
@@ -1,5 +1,6 @@
 //@ revisions: default feature
 #![cfg_attr(feature, feature(arbitrary_self_types))]
+#![allow(self_lifetime_elision_not_applicable)]
 
 use std::ops::Deref;
 use std::marker::PhantomData;

--- a/tests/ui/self/arbitrary_self_types_by_value_reborrow.rs
+++ b/tests/ui/self/arbitrary_self_types_by_value_reborrow.rs
@@ -2,6 +2,7 @@
 
 #![feature(arbitrary_self_types)]
 #![allow(dead_code)]
+#![allow(self_lifetime_elision_not_applicable)]
 
 // With arbitrary self types v2, we show an error if there are
 // multiple contenders for a method call in an inner and outer type.

--- a/tests/ui/self/arbitrary_self_types_generic_receiver.rs
+++ b/tests/ui/self/arbitrary_self_types_generic_receiver.rs
@@ -1,4 +1,5 @@
 #![feature(arbitrary_self_types)]
+#![allow(self_lifetime_elision_not_applicable)]
 
 struct PtrA<T>(T);
 

--- a/tests/ui/self/arbitrary_self_types_generic_receiver.stderr
+++ b/tests/ui/self/arbitrary_self_types_generic_receiver.stderr
@@ -1,5 +1,5 @@
 error[E0801]: invalid generic `self` parameter type: `&R`
-  --> $DIR/arbitrary_self_types_generic_receiver.rs:26:53
+  --> $DIR/arbitrary_self_types_generic_receiver.rs:27:53
    |
 LL |     fn a<R: core::ops::Receiver<Target=Self>>(self: &R) {}
    |                                                     ^^
@@ -8,7 +8,7 @@ LL |     fn a<R: core::ops::Receiver<Target=Self>>(self: &R) {}
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0801]: invalid generic `self` parameter type: `&mut R`
-  --> $DIR/arbitrary_self_types_generic_receiver.rs:28:53
+  --> $DIR/arbitrary_self_types_generic_receiver.rs:29:53
    |
 LL |     fn b<R: core::ops::Receiver<Target=Self>>(self: &mut R) {}
    |                                                     ^^^^^^
@@ -17,7 +17,7 @@ LL |     fn b<R: core::ops::Receiver<Target=Self>>(self: &mut R) {}
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0801]: invalid generic `self` parameter type: `R`
-  --> $DIR/arbitrary_self_types_generic_receiver.rs:30:53
+  --> $DIR/arbitrary_self_types_generic_receiver.rs:31:53
    |
 LL |     fn c<R: core::ops::Receiver<Target=Self>>(self: R) {}
    |                                                     ^
@@ -26,7 +26,7 @@ LL |     fn c<R: core::ops::Receiver<Target=Self>>(self: R) {}
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0801]: invalid generic `self` parameter type: `R`
-  --> $DIR/arbitrary_self_types_generic_receiver.rs:32:45
+  --> $DIR/arbitrary_self_types_generic_receiver.rs:33:45
    |
 LL |     fn d<R: SomePtr<SomeTarget=Self>>(self: R) {}
    |                                             ^
@@ -35,7 +35,7 @@ LL |     fn d<R: SomePtr<SomeTarget=Self>>(self: R) {}
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0801]: invalid generic `self` parameter type: `impl SomePtr<SomeTarget = Self>`
-  --> $DIR/arbitrary_self_types_generic_receiver.rs:34:16
+  --> $DIR/arbitrary_self_types_generic_receiver.rs:35:16
    |
 LL |     fn e(self: impl SomePtr<SomeTarget=Self>) {}
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/self/arbitrary_self_types_pin_getref.feature.stderr
+++ b/tests/ui/self/arbitrary_self_types_pin_getref.feature.stderr
@@ -1,11 +1,11 @@
 error[E0034]: multiple applicable items in scope
-  --> $DIR/arbitrary_self_types_pin_getref.rs:23:22
+  --> $DIR/arbitrary_self_types_pin_getref.rs:24:22
    |
 LL |     let _ = pinned_a.get_ref();
    |                      ^^^^^^^ multiple `get_ref` found
    |
 note: candidate #1 is defined in an impl for the type `A`
-  --> $DIR/arbitrary_self_types_pin_getref.rs:17:5
+  --> $DIR/arbitrary_self_types_pin_getref.rs:18:5
    |
 LL |     fn get_ref(self: &Pin<&A>) {}  // note &Pin
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/self/arbitrary_self_types_pin_getref.rs
+++ b/tests/ui/self/arbitrary_self_types_pin_getref.rs
@@ -7,6 +7,7 @@
 //@[default] check-pass
 
 #![allow(dead_code)]
+#![allow(self_lifetime_elision_not_applicable)]
 
 use std::pin::Pin;
 use std::pin::pin;

--- a/tests/ui/self/arbitrary_self_types_pin_lifetime-async.rs
+++ b/tests/ui/self/arbitrary_self_types_pin_lifetime-async.rs
@@ -1,3 +1,4 @@
+#![allow(self_lifetime_elision_not_applicable)]
 //@ check-pass
 //@ edition:2018
 

--- a/tests/ui/self/arbitrary_self_types_pin_lifetime.rs
+++ b/tests/ui/self/arbitrary_self_types_pin_lifetime.rs
@@ -1,3 +1,4 @@
+#![allow(self_lifetime_elision_not_applicable)]
 //@ check-pass
 
 use std::pin::Pin;

--- a/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.rs
+++ b/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.rs
@@ -1,3 +1,4 @@
+#![allow(self_lifetime_elision_not_applicable)]
 //@ edition:2018
 
 use std::pin::Pin;

--- a/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.stderr
+++ b/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:8:52
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:9:52
    |
 LL |     async fn a(self: Pin<&Foo>, f: &Foo) -> &Foo { f }
    |                          -         -               ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
@@ -13,7 +13,7 @@ LL |     async fn a<'a>(self: Pin<&Foo>, f: &'a Foo) -> &'a Foo { f }
    |               ++++                      ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:11:75
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:12:75
    |
 LL |     async fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
    |                          -          -                                     ^^^^^^^^^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
@@ -27,7 +27,7 @@ LL |     async fn c<'a>(self: Pin<&Self>, f: &'a Foo, g: &Foo) -> (Pin<&'a Foo>,
    |               ++++                       ++                        ++        ++
 
 error: lifetime may not live long enough
-  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:17:64
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:18:64
    |
 LL |     async fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() { arg }
    |                  --              -                             ^^^ method was supposed to return data with lifetime `'1` but it is returning data with lifetime `'a`

--- a/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch.rs
+++ b/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch.rs
@@ -1,3 +1,4 @@
+#![allow(self_lifetime_elision_not_applicable)]
 use std::pin::Pin;
 
 struct Foo;

--- a/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch.stderr
+++ b/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:7:9
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:8:9
    |
 LL |     fn a(self: Pin<&Foo>, f: &Foo) -> &Foo {
    |                    -         - let's call the lifetime of this reference `'1`
@@ -14,7 +14,7 @@ LL |     fn a<'a>(self: Pin<&Foo>, f: &'a Foo) -> &'a Foo {
    |         ++++                      ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:14:9
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:15:9
    |
 LL |     fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) {
    |                    -          - let's call the lifetime of this reference `'1`
@@ -29,7 +29,7 @@ LL |     fn c<'a>(self: Pin<&Self>, f: &'a Foo, g: &Foo) -> (Pin<&'a Foo>, &'a F
    |         ++++                       ++                        ++        ++
 
 error: lifetime may not live long enough
-  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:21:9
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:22:9
    |
 LL |     fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() {
    |            --  ---- has type `Pin<&'1 Foo>`

--- a/tests/ui/self/dispatch-dyn-incompatible-that-does-not-deref.rs
+++ b/tests/ui/self/dispatch-dyn-incompatible-that-does-not-deref.rs
@@ -1,3 +1,4 @@
+#![allow(self_lifetime_elision_not_applicable)]
 // Regression test for <https://github.com/rust-lang/rust/issues/141419>.
 
 use std::ops::Deref;

--- a/tests/ui/self/dispatch-dyn-incompatible-that-does-not-deref.stderr
+++ b/tests/ui/self/dispatch-dyn-incompatible-that-does-not-deref.stderr
@@ -1,5 +1,5 @@
 error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/dispatch-dyn-incompatible-that-does-not-deref.rs:12:13
+  --> $DIR/dispatch-dyn-incompatible-that-does-not-deref.rs:13:13
    |
 LL |     fn method(self: &W) {}
    |                     -- help: consider changing method `method`'s `self` parameter to be `&self`: `&Self`
@@ -9,7 +9,7 @@ LL | fn test(x: &dyn Foo) {
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/dispatch-dyn-incompatible-that-does-not-deref.rs:8:21
+  --> $DIR/dispatch-dyn-incompatible-that-does-not-deref.rs:9:21
    |
 LL | trait Foo: Deref<Target = W> {
    |       --- this trait is not dyn compatible...
@@ -17,7 +17,7 @@ LL |     fn method(self: &W) {}
    |                     ^^ ...because method `method`'s `self` parameter cannot be dispatched on
 
 error[E0307]: invalid `self` parameter type: `&W`
-  --> $DIR/dispatch-dyn-incompatible-that-does-not-deref.rs:8:21
+  --> $DIR/dispatch-dyn-incompatible-that-does-not-deref.rs:9:21
    |
 LL |     fn method(self: &W) {}
    |                     ^^
@@ -26,7 +26,7 @@ LL |     fn method(self: &W) {}
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/dispatch-dyn-incompatible-that-does-not-deref.rs:14:5
+  --> $DIR/dispatch-dyn-incompatible-that-does-not-deref.rs:15:5
    |
 LL |     fn method(self: &W) {}
    |                     -- help: consider changing method `method`'s `self` parameter to be `&self`: `&Self`
@@ -36,7 +36,7 @@ LL |     x.method();
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/dispatch-dyn-incompatible-that-does-not-deref.rs:8:21
+  --> $DIR/dispatch-dyn-incompatible-that-does-not-deref.rs:9:21
    |
 LL | trait Foo: Deref<Target = W> {
    |       --- this trait is not dyn compatible...

--- a/tests/ui/self/dispatch-from-dyn-layout-3.rs
+++ b/tests/ui/self/dispatch-from-dyn-layout-3.rs
@@ -5,6 +5,7 @@
 
 #![feature(dispatch_from_dyn)]
 #![feature(arbitrary_self_types)]
+#![allow(self_lifetime_elision_not_applicable)]
 
 use std::ops::Deref;
 use std::ops::DispatchFromDyn;

--- a/tests/ui/self/elision/ignore-non-reference-lifetimes.rs
+++ b/tests/ui/self/elision/ignore-non-reference-lifetimes.rs
@@ -1,3 +1,4 @@
+#![allow(self_lifetime_elision_not_applicable)]
 //@ check-pass
 
 struct Foo<'a>(&'a str);

--- a/tests/ui/self/elision/ignore-non-reference-lifetimes.stderr
+++ b/tests/ui/self/elision/ignore-non-reference-lifetimes.stderr
@@ -1,5 +1,5 @@
 warning: eliding a lifetime that's named elsewhere is confusing
-  --> $DIR/ignore-non-reference-lifetimes.rs:6:41
+  --> $DIR/ignore-non-reference-lifetimes.rs:7:41
    |
 LL |     fn a<'a>(self: Self, a: &'a str) -> &str {
    |                              --         ^^^^ the same lifetime is elided here
@@ -14,7 +14,7 @@ LL |     fn a<'a>(self: Self, a: &'a str) -> &'a str {
    |                                          ++
 
 warning: eliding a lifetime that's named elsewhere is confusing
-  --> $DIR/ignore-non-reference-lifetimes.rs:10:44
+  --> $DIR/ignore-non-reference-lifetimes.rs:11:44
    |
 LL |     fn b<'a>(self: Foo<'b>, a: &'a str) -> &str {
    |                                 --         ^^^^ the same lifetime is elided here

--- a/tests/ui/self/elision/ref-alias-async.rs
+++ b/tests/ui/self/elision/ref-alias-async.rs
@@ -2,6 +2,7 @@
 //@ check-pass
 
 #![allow(non_snake_case)]
+#![allow(self_lifetime_elision_not_applicable)]
 
 use std::pin::Pin;
 

--- a/tests/ui/self/elision/ref-alias.rs
+++ b/tests/ui/self/elision/ref-alias.rs
@@ -1,6 +1,7 @@
 //@ check-pass
 
 #![allow(non_snake_case)]
+#![allow(self_lifetime_elision_not_applicable)]
 
 use std::pin::Pin;
 

--- a/tests/ui/self/elision/ref-assoc-async.rs
+++ b/tests/ui/self/elision/ref-assoc-async.rs
@@ -1,6 +1,7 @@
 //@ edition:2018
 
 #![allow(non_snake_case)]
+#![allow(self_lifetime_elision_not_applicable)]
 
 use std::pin::Pin;
 

--- a/tests/ui/self/elision/ref-assoc-async.stderr
+++ b/tests/ui/self/elision/ref-assoc-async.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/ref-assoc-async.rs:19:9
+  --> $DIR/ref-assoc-async.rs:20:9
    |
 LL |     async fn ref_AssocType(self: &<Struct as Trait>::AssocType, f: &u32) -> &u32 {
    |                                  -                                 - let's call the lifetime of this reference `'1`
@@ -14,7 +14,7 @@ LL |     async fn ref_AssocType<'a>(self: &<Struct as Trait>::AssocType, f: &'a 
    |                           ++++                                          ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-assoc-async.rs:24:9
+  --> $DIR/ref-assoc-async.rs:25:9
    |
 LL |     async fn box_ref_AssocType(self: Box<&<Struct as Trait>::AssocType>, f: &u32) -> &u32 {
    |                                          -                                  - let's call the lifetime of this reference `'1`
@@ -29,7 +29,7 @@ LL |     async fn box_ref_AssocType<'a>(self: Box<&<Struct as Trait>::AssocType>
    |                               ++++                                               ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-assoc-async.rs:29:9
+  --> $DIR/ref-assoc-async.rs:30:9
    |
 LL |     async fn pin_ref_AssocType(self: Pin<&<Struct as Trait>::AssocType>, f: &u32) -> &u32 {
    |                                          -                                  - let's call the lifetime of this reference `'1`
@@ -44,7 +44,7 @@ LL |     async fn pin_ref_AssocType<'a>(self: Pin<&<Struct as Trait>::AssocType>
    |                               ++++                                               ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-assoc-async.rs:34:9
+  --> $DIR/ref-assoc-async.rs:35:9
    |
 LL |     async fn box_box_ref_AssocType(self: Box<Box<&<Struct as Trait>::AssocType>>, f: &u32) -> &u32 {
    |                                                  -                                   - let's call the lifetime of this reference `'1`
@@ -59,7 +59,7 @@ LL |     async fn box_box_ref_AssocType<'a>(self: Box<Box<&<Struct as Trait>::As
    |                                   ++++                                                    ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-assoc-async.rs:39:9
+  --> $DIR/ref-assoc-async.rs:40:9
    |
 LL |     async fn box_pin_ref_AssocType(self: Box<Pin<&<Struct as Trait>::AssocType>>, f: &u32) -> &u32 {
    |                                                  -                                   - let's call the lifetime of this reference `'1`

--- a/tests/ui/self/elision/ref-assoc.rs
+++ b/tests/ui/self/elision/ref-assoc.rs
@@ -1,4 +1,5 @@
 #![allow(non_snake_case)]
+#![allow(self_lifetime_elision_not_applicable)]
 
 use std::pin::Pin;
 

--- a/tests/ui/self/elision/ref-assoc.stderr
+++ b/tests/ui/self/elision/ref-assoc.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/ref-assoc.rs:17:9
+  --> $DIR/ref-assoc.rs:18:9
    |
 LL |     fn ref_AssocType(self: &<Struct as Trait>::AssocType, f: &u32) -> &u32 {
    |                            -                                 - let's call the lifetime of this reference `'1`
@@ -14,7 +14,7 @@ LL |     fn ref_AssocType<'a>(self: &<Struct as Trait>::AssocType, f: &'a u32) -
    |                     ++++                                          ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-assoc.rs:22:9
+  --> $DIR/ref-assoc.rs:23:9
    |
 LL |     fn box_ref_AssocType(self: Box<&<Struct as Trait>::AssocType>, f: &u32) -> &u32 {
    |                                    -                                  - let's call the lifetime of this reference `'1`
@@ -29,7 +29,7 @@ LL |     fn box_ref_AssocType<'a>(self: Box<&<Struct as Trait>::AssocType>, f: &
    |                         ++++                                               ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-assoc.rs:27:9
+  --> $DIR/ref-assoc.rs:28:9
    |
 LL |     fn pin_ref_AssocType(self: Pin<&<Struct as Trait>::AssocType>, f: &u32) -> &u32 {
    |                                    -                                  - let's call the lifetime of this reference `'1`
@@ -44,7 +44,7 @@ LL |     fn pin_ref_AssocType<'a>(self: Pin<&<Struct as Trait>::AssocType>, f: &
    |                         ++++                                               ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-assoc.rs:32:9
+  --> $DIR/ref-assoc.rs:33:9
    |
 LL |     fn box_box_ref_AssocType(self: Box<Box<&<Struct as Trait>::AssocType>>, f: &u32) -> &u32 {
    |                                            -                                   - let's call the lifetime of this reference `'1`
@@ -59,7 +59,7 @@ LL |     fn box_box_ref_AssocType<'a>(self: Box<Box<&<Struct as Trait>::AssocTyp
    |                             ++++                                                    ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-assoc.rs:37:9
+  --> $DIR/ref-assoc.rs:38:9
    |
 LL |     fn box_pin_ref_AssocType(self: Box<Pin<&<Struct as Trait>::AssocType>>, f: &u32) -> &u32 {
    |                                            -                                   - let's call the lifetime of this reference `'1`

--- a/tests/ui/self/elision/ref-mut-alias-async.rs
+++ b/tests/ui/self/elision/ref-mut-alias-async.rs
@@ -2,6 +2,7 @@
 //@ check-pass
 
 #![allow(non_snake_case)]
+#![allow(self_lifetime_elision_not_applicable)]
 
 use std::pin::Pin;
 

--- a/tests/ui/self/elision/ref-mut-alias.rs
+++ b/tests/ui/self/elision/ref-mut-alias.rs
@@ -1,6 +1,7 @@
 //@ check-pass
 
 #![allow(non_snake_case)]
+#![allow(self_lifetime_elision_not_applicable)]
 
 use std::pin::Pin;
 

--- a/tests/ui/self/elision/ref-mut-struct-async.rs
+++ b/tests/ui/self/elision/ref-mut-struct-async.rs
@@ -1,6 +1,7 @@
 //@ edition:2018
 
 #![allow(non_snake_case)]
+#![allow(self_lifetime_elision_not_applicable)]
 
 use std::pin::Pin;
 

--- a/tests/ui/self/elision/ref-mut-struct-async.stderr
+++ b/tests/ui/self/elision/ref-mut-struct-async.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/ref-mut-struct-async.rs:13:9
+  --> $DIR/ref-mut-struct-async.rs:14:9
    |
 LL |     async fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 {
    |                               -               - let's call the lifetime of this reference `'1`
@@ -14,7 +14,7 @@ LL |     async fn ref_Struct<'a>(self: &mut Struct, f: &'a u32) -> &'a u32 {
    |                        ++++                        ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-mut-struct-async.rs:18:9
+  --> $DIR/ref-mut-struct-async.rs:19:9
    |
 LL |     async fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 {
    |                                       -                - let's call the lifetime of this reference `'1`
@@ -29,7 +29,7 @@ LL |     async fn box_ref_Struct<'a>(self: Box<&mut Struct>, f: &'a u32) -> &'a 
    |                            ++++                             ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-mut-struct-async.rs:23:9
+  --> $DIR/ref-mut-struct-async.rs:24:9
    |
 LL |     async fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 {
    |                                       -                - let's call the lifetime of this reference `'1`
@@ -44,7 +44,7 @@ LL |     async fn pin_ref_Struct<'a>(self: Pin<&mut Struct>, f: &'a u32) -> &'a 
    |                            ++++                             ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-mut-struct-async.rs:28:9
+  --> $DIR/ref-mut-struct-async.rs:29:9
    |
 LL |     async fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u32 {
    |                                               -                 - let's call the lifetime of this reference `'1`
@@ -59,7 +59,7 @@ LL |     async fn box_box_ref_Struct<'a>(self: Box<Box<&mut Struct>>, f: &'a u32
    |                                ++++                                  ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-mut-struct-async.rs:33:9
+  --> $DIR/ref-mut-struct-async.rs:34:9
    |
 LL |     async fn box_pin_ref_Struct(self: Box<Pin<&mut Struct>>, f: &u32) -> &u32 {
    |                                               -                 - let's call the lifetime of this reference `'1`

--- a/tests/ui/self/elision/ref-mut-struct.fixed
+++ b/tests/ui/self/elision/ref-mut-struct.fixed
@@ -1,5 +1,6 @@
 //@ run-rustfix
 #![allow(non_snake_case, dead_code)]
+#![allow(self_lifetime_elision_not_applicable)]
 
 use std::pin::Pin;
 

--- a/tests/ui/self/elision/ref-mut-struct.rs
+++ b/tests/ui/self/elision/ref-mut-struct.rs
@@ -1,5 +1,6 @@
 //@ run-rustfix
 #![allow(non_snake_case, dead_code)]
+#![allow(self_lifetime_elision_not_applicable)]
 
 use std::pin::Pin;
 

--- a/tests/ui/self/elision/ref-mut-struct.stderr
+++ b/tests/ui/self/elision/ref-mut-struct.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/ref-mut-struct.rs:12:9
+  --> $DIR/ref-mut-struct.rs:13:9
    |
 LL |     fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 {
    |                         -               - let's call the lifetime of this reference `'1`
@@ -14,7 +14,7 @@ LL |     fn ref_Struct<'a>(self: &mut Struct, f: &'a u32) -> &'a u32 {
    |                  ++++                        ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-mut-struct.rs:17:9
+  --> $DIR/ref-mut-struct.rs:18:9
    |
 LL |     fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 {
    |                                 -                - let's call the lifetime of this reference `'1`
@@ -29,7 +29,7 @@ LL |     fn box_ref_Struct<'a>(self: Box<&mut Struct>, f: &'a u32) -> &'a u32 {
    |                      ++++                             ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-mut-struct.rs:22:9
+  --> $DIR/ref-mut-struct.rs:23:9
    |
 LL |     fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 {
    |                                 -                - let's call the lifetime of this reference `'1`
@@ -44,7 +44,7 @@ LL |     fn pin_ref_Struct<'a>(self: Pin<&mut Struct>, f: &'a u32) -> &'a u32 {
    |                      ++++                             ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-mut-struct.rs:27:9
+  --> $DIR/ref-mut-struct.rs:28:9
    |
 LL |     fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u32 {
    |                                         -                 - let's call the lifetime of this reference `'1`
@@ -59,7 +59,7 @@ LL |     fn box_box_ref_Struct<'a>(self: Box<Box<&mut Struct>>, f: &'a u32) -> &
    |                          ++++                                  ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-mut-struct.rs:32:9
+  --> $DIR/ref-mut-struct.rs:33:9
    |
 LL |     fn box_pin_ref_Struct(self: Box<Pin<&mut Struct>>, f: &u32) -> &u32 {
    |                                         -                 - let's call the lifetime of this reference `'1`

--- a/tests/ui/self/elision/ref-struct-async.rs
+++ b/tests/ui/self/elision/ref-struct-async.rs
@@ -1,6 +1,7 @@
 //@ edition:2018
 
 #![allow(non_snake_case)]
+#![allow(self_lifetime_elision_not_applicable)]
 
 use std::pin::Pin;
 

--- a/tests/ui/self/elision/ref-struct-async.stderr
+++ b/tests/ui/self/elision/ref-struct-async.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/ref-struct-async.rs:13:9
+  --> $DIR/ref-struct-async.rs:14:9
    |
 LL |     async fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
    |                               -           - let's call the lifetime of this reference `'1`
@@ -14,7 +14,7 @@ LL |     async fn ref_Struct<'a>(self: &Struct, f: &'a u32) -> &'a u32 {
    |                        ++++                    ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-struct-async.rs:18:9
+  --> $DIR/ref-struct-async.rs:19:9
    |
 LL |     async fn box_ref_Struct(self: Box<&Struct>, f: &u32) -> &u32 {
    |                                       -            - let's call the lifetime of this reference `'1`
@@ -29,7 +29,7 @@ LL |     async fn box_ref_Struct<'a>(self: Box<&Struct>, f: &'a u32) -> &'a u32 
    |                            ++++                         ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-struct-async.rs:23:9
+  --> $DIR/ref-struct-async.rs:24:9
    |
 LL |     async fn pin_ref_Struct(self: Pin<&Struct>, f: &u32) -> &u32 {
    |                                       -            - let's call the lifetime of this reference `'1`
@@ -44,7 +44,7 @@ LL |     async fn pin_ref_Struct<'a>(self: Pin<&Struct>, f: &'a u32) -> &'a u32 
    |                            ++++                         ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-struct-async.rs:28:9
+  --> $DIR/ref-struct-async.rs:29:9
    |
 LL |     async fn box_box_ref_Struct(self: Box<Box<&Struct>>, f: &u32) -> &u32 {
    |                                               -             - let's call the lifetime of this reference `'1`
@@ -59,7 +59,7 @@ LL |     async fn box_box_ref_Struct<'a>(self: Box<Box<&Struct>>, f: &'a u32) ->
    |                                ++++                              ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-struct-async.rs:33:9
+  --> $DIR/ref-struct-async.rs:34:9
    |
 LL |     async fn box_pin_Struct(self: Box<Pin<&Struct>>, f: &u32) -> &u32 {
    |                                           -             - let's call the lifetime of this reference `'1`

--- a/tests/ui/self/elision/ref-struct.fixed
+++ b/tests/ui/self/elision/ref-struct.fixed
@@ -1,5 +1,6 @@
 //@ run-rustfix
 #![allow(non_snake_case, dead_code)]
+#![allow(self_lifetime_elision_not_applicable)]
 
 use std::pin::Pin;
 

--- a/tests/ui/self/elision/ref-struct.rs
+++ b/tests/ui/self/elision/ref-struct.rs
@@ -1,5 +1,6 @@
 //@ run-rustfix
 #![allow(non_snake_case, dead_code)]
+#![allow(self_lifetime_elision_not_applicable)]
 
 use std::pin::Pin;
 

--- a/tests/ui/self/elision/ref-struct.stderr
+++ b/tests/ui/self/elision/ref-struct.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/ref-struct.rs:12:9
+  --> $DIR/ref-struct.rs:13:9
    |
 LL |     fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
    |                         -           - let's call the lifetime of this reference `'1`
@@ -14,7 +14,7 @@ LL |     fn ref_Struct<'a>(self: &Struct, f: &'a u32) -> &'a u32 {
    |                  ++++                    ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-struct.rs:17:9
+  --> $DIR/ref-struct.rs:18:9
    |
 LL |     fn box_ref_Struct(self: Box<&Struct>, f: &u32) -> &u32 {
    |                                 -            - let's call the lifetime of this reference `'1`
@@ -29,7 +29,7 @@ LL |     fn box_ref_Struct<'a>(self: Box<&Struct>, f: &'a u32) -> &'a u32 {
    |                      ++++                         ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-struct.rs:22:9
+  --> $DIR/ref-struct.rs:23:9
    |
 LL |     fn pin_ref_Struct(self: Pin<&Struct>, f: &u32) -> &u32 {
    |                                 -            - let's call the lifetime of this reference `'1`
@@ -44,7 +44,7 @@ LL |     fn pin_ref_Struct<'a>(self: Pin<&Struct>, f: &'a u32) -> &'a u32 {
    |                      ++++                         ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-struct.rs:27:9
+  --> $DIR/ref-struct.rs:28:9
    |
 LL |     fn box_box_ref_Struct(self: Box<Box<&Struct>>, f: &u32) -> &u32 {
    |                                         -             - let's call the lifetime of this reference `'1`
@@ -59,7 +59,7 @@ LL |     fn box_box_ref_Struct<'a>(self: Box<Box<&Struct>>, f: &'a u32) -> &'a u
    |                          ++++                              ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-struct.rs:32:9
+  --> $DIR/ref-struct.rs:33:9
    |
 LL |     fn box_pin_Struct(self: Box<Pin<&Struct>>, f: &u32) -> &u32 {
    |                                     -             - let's call the lifetime of this reference `'1`

--- a/tests/ui/self/elision/self-lifetime-elision-not-applicable.rs
+++ b/tests/ui/self/elision/self-lifetime-elision-not-applicable.rs
@@ -1,0 +1,68 @@
+#![deny(self_lifetime_elision_not_applicable)]
+#![allow(non_snake_case)]
+
+use std::pin::Pin;
+
+struct Foo<'a>(&'a ());
+type Alias<'a> = Foo<'a>;
+
+impl<'a> Foo<'a> {
+    // &self / self: &Self -> no lint (genuine Self)
+    fn ref_self(&self) -> &() {
+        self.0
+    }
+    fn ref_Self(self: &Self) -> &() {
+        self.0
+    }
+    fn box_ref_Self(self: Box<&Self>) -> &() {
+        self.0
+    }
+    fn pin_ref_Self(self: Pin<&Self>) -> &() {
+        self.0
+    }
+
+    // self: &Struct in impl Struct -> lint (name-match hack, not genuine Self)
+    fn ref_Foo(self: &Foo<'a>) -> &() {
+        self.0
+    }
+    //~^^^ ERROR `self` parameter type does not contain `Self`
+    //~| WARN this was previously accepted by the compiler
+    fn pin_ref_Foo(self: Pin<&Foo<'a>>) -> &() {
+        self.0
+    }
+    //~^^^ ERROR `self` parameter type does not contain `Self`
+    //~| WARN this was previously accepted by the compiler
+
+    // self: &Alias in impl Struct -> lint + E0106 (hack misses alias, elision fails)
+    fn ref_Alias_in_foo_impl(self: &Alias<'a>) -> &() {
+        self.0
+    }
+    //~^^^ ERROR `self` parameter type does not contain `Self`
+    //~| WARN this was previously accepted by the compiler
+    //~| ERROR missing lifetime specifier [E0106]
+}
+
+impl<'a> Alias<'a> {
+    // &self in impl Alias -> no lint (genuine Self)
+    fn ref_self_in_alias_impl(&self) -> &() {
+        self.0
+    }
+
+    // self: &Alias in impl Alias -> lint + E0106 (impl_self=None for TyAlias, elision fails)
+    fn ref_Alias(self: &Alias<'a>) -> &() {
+        self.0
+    }
+    //~^^^ ERROR `self` parameter type does not contain `Self`
+    //~| WARN this was previously accepted by the compiler
+    //~| ERROR missing lifetime specifier [E0106]
+
+    // self: &Struct in impl Alias -> lint + E0106 (impl_self=None for TyAlias, elision fails)
+    fn ref_Foo_in_alias_impl(self: &Foo<'a>) -> &() {
+        self.0
+    }
+    //~^^^ ERROR `self` parameter type does not contain `Self`
+    //~| WARN this was previously accepted by the compiler
+    //~| ERROR missing lifetime specifier [E0106]
+}
+
+fn main() {}

--- a/tests/ui/self/elision/self-lifetime-elision-not-applicable.rs
+++ b/tests/ui/self/elision/self-lifetime-elision-not-applicable.rs
@@ -65,4 +65,10 @@ impl<'a> Alias<'a> {
     //~| ERROR missing lifetime specifier [E0106]
 }
 
+impl<'a> Foo<'a> {
+    fn no_output_lifetime(self: &Foo<'a>) -> u32 {
+        0
+    }
+}
+
 fn main() {}

--- a/tests/ui/self/elision/self-lifetime-elision-not-applicable.stderr
+++ b/tests/ui/self/elision/self-lifetime-elision-not-applicable.stderr
@@ -1,0 +1,94 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/self-lifetime-elision-not-applicable.rs:43:51
+   |
+LL |     fn ref_Alias_in_foo_impl(self: &Alias<'a>) -> &() {
+   |                                    ----------     ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say which one of `self`'s 2 lifetimes it is borrowed from
+help: consider using the `'a` lifetime
+   |
+LL |     fn ref_Alias_in_foo_impl(self: &Alias<'a>) -> &'a () {
+   |                                                    ++
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/self-lifetime-elision-not-applicable.rs:60:39
+   |
+LL |     fn ref_Alias(self: &Alias<'a>) -> &() {
+   |                        ----------     ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say which one of `self`'s 2 lifetimes it is borrowed from
+help: consider using the `'a` lifetime
+   |
+LL |     fn ref_Alias(self: &Alias<'a>) -> &'a () {
+   |                                        ++
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/self-lifetime-elision-not-applicable.rs:68:49
+   |
+LL |     fn ref_Foo_in_alias_impl(self: &Foo<'a>) -> &() {
+   |                                    --------     ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say which one of `self`'s 2 lifetimes it is borrowed from
+help: consider using the `'a` lifetime
+   |
+LL |     fn ref_Foo_in_alias_impl(self: &Foo<'a>) -> &'a () {
+   |                                                  ++
+
+error: `self` parameter type does not contain `Self`
+  --> $DIR/self-lifetime-elision-not-applicable.rs:31:22
+   |
+LL |     fn ref_Foo(self: &Foo<'a>) -> &() {
+   |                      ^^^^^^^^
+   |
+   = help: use `&self`, `&mut self`, or `self: &Self` for correct lifetime elision
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #140611 <https://github.com/rust-lang/rust/issues/140611>
+note: the lint level is defined here
+  --> $DIR/self-lifetime-elision-not-applicable.rs:5:9
+   |
+LL | #![deny(self_lifetime_elision_not_applicable)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `self` parameter type does not contain `Self`
+  --> $DIR/self-lifetime-elision-not-applicable.rs:36:26
+   |
+LL |     fn pin_ref_Foo(self: Pin<&Foo<'a>>) -> &() {
+   |                          ^^^^^^^^^^^^^
+   |
+   = help: use `&self`, `&mut self`, or `self: &Self` for correct lifetime elision
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #140611 <https://github.com/rust-lang/rust/issues/140611>
+
+error: `self` parameter type does not contain `Self`
+  --> $DIR/self-lifetime-elision-not-applicable.rs:43:36
+   |
+LL |     fn ref_Alias_in_foo_impl(self: &Alias<'a>) -> &() {
+   |                                    ^^^^^^^^^^
+   |
+   = help: use `&self`, `&mut self`, or `self: &Self` for correct lifetime elision
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #140611 <https://github.com/rust-lang/rust/issues/140611>
+
+error: `self` parameter type does not contain `Self`
+  --> $DIR/self-lifetime-elision-not-applicable.rs:60:24
+   |
+LL |     fn ref_Alias(self: &Alias<'a>) -> &() {
+   |                        ^^^^^^^^^^
+   |
+   = help: use `&self`, `&mut self`, or `self: &Self` for correct lifetime elision
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #140611 <https://github.com/rust-lang/rust/issues/140611>
+
+error: `self` parameter type does not contain `Self`
+  --> $DIR/self-lifetime-elision-not-applicable.rs:68:36
+   |
+LL |     fn ref_Foo_in_alias_impl(self: &Foo<'a>) -> &() {
+   |                                    ^^^^^^^^
+   |
+   = help: use `&self`, `&mut self`, or `self: &Self` for correct lifetime elision
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #140611 <https://github.com/rust-lang/rust/issues/140611>
+
+error: aborting due to 8 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/self/elision/self-lifetime-elision-not-applicable.stderr
+++ b/tests/ui/self/elision/self-lifetime-elision-not-applicable.stderr
@@ -1,5 +1,5 @@
 error[E0106]: missing lifetime specifier
-  --> $DIR/self-lifetime-elision-not-applicable.rs:43:51
+  --> $DIR/self-lifetime-elision-not-applicable.rs:37:51
    |
 LL |     fn ref_Alias_in_foo_impl(self: &Alias<'a>) -> &() {
    |                                    ----------     ^ expected named lifetime parameter
@@ -11,7 +11,7 @@ LL |     fn ref_Alias_in_foo_impl(self: &Alias<'a>) -> &'a () {
    |                                                    ++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/self-lifetime-elision-not-applicable.rs:60:39
+  --> $DIR/self-lifetime-elision-not-applicable.rs:52:39
    |
 LL |     fn ref_Alias(self: &Alias<'a>) -> &() {
    |                        ----------     ^ expected named lifetime parameter
@@ -23,7 +23,7 @@ LL |     fn ref_Alias(self: &Alias<'a>) -> &'a () {
    |                                        ++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/self-lifetime-elision-not-applicable.rs:68:49
+  --> $DIR/self-lifetime-elision-not-applicable.rs:60:49
    |
 LL |     fn ref_Foo_in_alias_impl(self: &Foo<'a>) -> &() {
    |                                    --------     ^ expected named lifetime parameter
@@ -35,7 +35,7 @@ LL |     fn ref_Foo_in_alias_impl(self: &Foo<'a>) -> &'a () {
    |                                                  ++
 
 error: `self` parameter type does not contain `Self`
-  --> $DIR/self-lifetime-elision-not-applicable.rs:31:22
+  --> $DIR/self-lifetime-elision-not-applicable.rs:25:22
    |
 LL |     fn ref_Foo(self: &Foo<'a>) -> &() {
    |                      ^^^^^^^^
@@ -44,13 +44,13 @@ LL |     fn ref_Foo(self: &Foo<'a>) -> &() {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #140611 <https://github.com/rust-lang/rust/issues/140611>
 note: the lint level is defined here
-  --> $DIR/self-lifetime-elision-not-applicable.rs:5:9
+  --> $DIR/self-lifetime-elision-not-applicable.rs:1:9
    |
 LL | #![deny(self_lifetime_elision_not_applicable)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `self` parameter type does not contain `Self`
-  --> $DIR/self-lifetime-elision-not-applicable.rs:36:26
+  --> $DIR/self-lifetime-elision-not-applicable.rs:30:26
    |
 LL |     fn pin_ref_Foo(self: Pin<&Foo<'a>>) -> &() {
    |                          ^^^^^^^^^^^^^
@@ -60,7 +60,7 @@ LL |     fn pin_ref_Foo(self: Pin<&Foo<'a>>) -> &() {
    = note: for more information, see issue #140611 <https://github.com/rust-lang/rust/issues/140611>
 
 error: `self` parameter type does not contain `Self`
-  --> $DIR/self-lifetime-elision-not-applicable.rs:43:36
+  --> $DIR/self-lifetime-elision-not-applicable.rs:37:36
    |
 LL |     fn ref_Alias_in_foo_impl(self: &Alias<'a>) -> &() {
    |                                    ^^^^^^^^^^
@@ -70,7 +70,7 @@ LL |     fn ref_Alias_in_foo_impl(self: &Alias<'a>) -> &() {
    = note: for more information, see issue #140611 <https://github.com/rust-lang/rust/issues/140611>
 
 error: `self` parameter type does not contain `Self`
-  --> $DIR/self-lifetime-elision-not-applicable.rs:60:24
+  --> $DIR/self-lifetime-elision-not-applicable.rs:52:24
    |
 LL |     fn ref_Alias(self: &Alias<'a>) -> &() {
    |                        ^^^^^^^^^^
@@ -80,7 +80,7 @@ LL |     fn ref_Alias(self: &Alias<'a>) -> &() {
    = note: for more information, see issue #140611 <https://github.com/rust-lang/rust/issues/140611>
 
 error: `self` parameter type does not contain `Self`
-  --> $DIR/self-lifetime-elision-not-applicable.rs:68:36
+  --> $DIR/self-lifetime-elision-not-applicable.rs:60:36
    |
 LL |     fn ref_Foo_in_alias_impl(self: &Foo<'a>) -> &() {
    |                                    ^^^^^^^^

--- a/tests/ui/self/invalid-self-dyn-receiver.rs
+++ b/tests/ui/self/invalid-self-dyn-receiver.rs
@@ -3,6 +3,7 @@
 // in wfcheck.
 
 #![feature(arbitrary_self_types)]
+#![allow(self_lifetime_elision_not_applicable)]
 
 use std::ops::Deref;
 

--- a/tests/ui/self/invalid-self-dyn-receiver.stderr
+++ b/tests/ui/self/invalid-self-dyn-receiver.stderr
@@ -1,5 +1,5 @@
 error[E0307]: invalid `self` parameter type: `&dyn Bar`
-  --> $DIR/invalid-self-dyn-receiver.rs:10:22
+  --> $DIR/invalid-self-dyn-receiver.rs:11:22
    |
 LL |      fn method(self: &dyn Bar) {}
    |                      ^^^^^^^^

--- a/tests/ui/self/self-infer.rs
+++ b/tests/ui/self/self-infer.rs
@@ -1,3 +1,4 @@
+#![allow(self_lifetime_elision_not_applicable)]
 struct S;
 
 impl S {

--- a/tests/ui/self/self-infer.stderr
+++ b/tests/ui/self/self-infer.stderr
@@ -1,11 +1,11 @@
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for methods
-  --> $DIR/self-infer.rs:4:16
+  --> $DIR/self-infer.rs:5:16
    |
 LL |     fn f(self: _) {}
    |                ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for methods
-  --> $DIR/self-infer.rs:5:17
+  --> $DIR/self-infer.rs:6:17
    |
 LL |     fn g(self: &_) {}
    |                 ^ not allowed in type signatures

--- a/tests/ui/self/self_lifetime-async.rs
+++ b/tests/ui/self/self_lifetime-async.rs
@@ -1,3 +1,4 @@
+#![allow(self_lifetime_elision_not_applicable)]
 //@ check-pass
 //@ edition:2018
 

--- a/tests/ui/self/self_lifetime-async.stderr
+++ b/tests/ui/self/self_lifetime-async.stderr
@@ -1,5 +1,5 @@
 warning: eliding a lifetime that's named elsewhere is confusing
-  --> $DIR/self_lifetime-async.rs:6:44
+  --> $DIR/self_lifetime-async.rs:7:44
    |
 LL |     async fn foo<'b>(self: &'b Foo<'a>) -> &() { self.0 }
    |                             --             ^^^ the same lifetime is elided here
@@ -14,7 +14,7 @@ LL |     async fn foo<'b>(self: &'b Foo<'a>) -> &'b () { self.0 }
    |                                             ++
 
 warning: eliding a lifetime that's named elsewhere is confusing
-  --> $DIR/self_lifetime-async.rs:12:52
+  --> $DIR/self_lifetime-async.rs:13:52
    |
 LL |     async fn bar<'a>(self: &Alias, arg: &'a ()) -> &() { arg }
    |                                          --        ^^^ the same lifetime is elided here

--- a/tests/ui/self/self_lifetime.rs
+++ b/tests/ui/self/self_lifetime.rs
@@ -1,3 +1,4 @@
+#![allow(self_lifetime_elision_not_applicable)]
 //@ check-pass
 
 // https://github.com/rust-lang/rust/pull/60944#issuecomment-495346120

--- a/tests/ui/self/self_lifetime.stderr
+++ b/tests/ui/self/self_lifetime.stderr
@@ -1,5 +1,5 @@
 warning: eliding a lifetime that's named elsewhere is confusing
-  --> $DIR/self_lifetime.rs:7:38
+  --> $DIR/self_lifetime.rs:8:38
    |
 LL |     fn foo<'b>(self: &'b Foo<'a>) -> &() { self.0 }
    |                       --             ^^^ the same lifetime is elided here
@@ -14,7 +14,7 @@ LL |     fn foo<'b>(self: &'b Foo<'a>) -> &'b () { self.0 }
    |                                       ++
 
 warning: eliding a lifetime that's named elsewhere is confusing
-  --> $DIR/self_lifetime.rs:13:46
+  --> $DIR/self_lifetime.rs:14:46
    |
 LL |     fn bar<'a>(self: &Alias, arg: &'a ()) -> &() { arg }
    |                                    --        ^^^ the same lifetime is elided here

--- a/tests/ui/self/ufcs-explicit-self.rs
+++ b/tests/ui/self/ufcs-explicit-self.rs
@@ -1,5 +1,6 @@
 //@ run-pass
 #![allow(dead_code)]
+#![allow(self_lifetime_elision_not_applicable)]
 
 #[derive(Copy, Clone)]
 struct Foo {

--- a/tests/ui/span/issue-27522.rs
+++ b/tests/ui/span/issue-27522.rs
@@ -1,3 +1,4 @@
+#![allow(self_lifetime_elision_not_applicable)]
 // Point at correct span for self type
 
 struct SomeType {}

--- a/tests/ui/span/issue-27522.stderr
+++ b/tests/ui/span/issue-27522.stderr
@@ -1,5 +1,5 @@
 error[E0307]: invalid `self` parameter type: `&SomeType`
-  --> $DIR/issue-27522.rs:6:22
+  --> $DIR/issue-27522.rs:7:22
    |
 LL |     fn handler(self: &SomeType);
    |                      ^^^^^^^^^

--- a/tests/ui/suggestions/double-reference-ty-in-self-ty.rs
+++ b/tests/ui/suggestions/double-reference-ty-in-self-ty.rs
@@ -1,3 +1,4 @@
+#![allow(self_lifetime_elision_not_applicable)]
 // issue#135863
 
 struct A;

--- a/tests/ui/suggestions/double-reference-ty-in-self-ty.stderr
+++ b/tests/ui/suggestions/double-reference-ty-in-self-ty.stderr
@@ -1,5 +1,5 @@
 error[E0599]: no method named `len` found for struct `A` in the current scope
-  --> $DIR/double-reference-ty-in-self-ty.rs:10:7
+  --> $DIR/double-reference-ty-in-self-ty.rs:11:7
    |
 LL | struct A;
    | -------- method `len` not found for this struct

--- a/tests/ui/type-alias-impl-trait/method_resolution3.current.stderr
+++ b/tests/ui/type-alias-impl-trait/method_resolution3.current.stderr
@@ -1,5 +1,5 @@
 error[E0307]: invalid `self` parameter type: `Bar<u32>`
-  --> $DIR/method_resolution3.rs:16:18
+  --> $DIR/method_resolution3.rs:17:18
    |
 LL |     fn bar(self: Bar<u32>) {
    |                  ^^^^^^^^
@@ -8,7 +8,7 @@ LL |     fn bar(self: Bar<u32>) {
    = help: consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`
 
 error[E0307]: invalid `self` parameter type: `&Bar<u32>`
-  --> $DIR/method_resolution3.rs:20:18
+  --> $DIR/method_resolution3.rs:21:18
    |
 LL |     fn baz(self: &Bar<u32>) {
    |                  ^^^^^^^^^

--- a/tests/ui/type-alias-impl-trait/method_resolution3.next.stderr
+++ b/tests/ui/type-alias-impl-trait/method_resolution3.next.stderr
@@ -1,5 +1,5 @@
 error[E0307]: invalid `self` parameter type: `Bar<u32>`
-  --> $DIR/method_resolution3.rs:16:18
+  --> $DIR/method_resolution3.rs:17:18
    |
 LL |     fn bar(self: Bar<u32>) {
    |                  ^^^^^^^^
@@ -8,7 +8,7 @@ LL |     fn bar(self: Bar<u32>) {
    = help: consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`
 
 error[E0307]: invalid `self` parameter type: `&Bar<u32>`
-  --> $DIR/method_resolution3.rs:20:18
+  --> $DIR/method_resolution3.rs:21:18
    |
 LL |     fn baz(self: &Bar<u32>) {
    |                  ^^^^^^^^^

--- a/tests/ui/type-alias-impl-trait/method_resolution3.rs
+++ b/tests/ui/type-alias-impl-trait/method_resolution3.rs
@@ -6,6 +6,7 @@
 //@[next] compile-flags: -Znext-solver
 
 #![feature(type_alias_impl_trait, arbitrary_self_types)]
+#![allow(self_lifetime_elision_not_applicable)]
 
 type Foo = impl Copy;
 

--- a/tests/ui/type-alias-impl-trait/method_resolution4.current.stderr
+++ b/tests/ui/type-alias-impl-trait/method_resolution4.current.stderr
@@ -1,5 +1,5 @@
 error[E0307]: invalid `self` parameter type: `Bar<Foo>`
-  --> $DIR/method_resolution4.rs:25:18
+  --> $DIR/method_resolution4.rs:26:18
    |
 LL |     fn foo(self: Bar<Foo>) {
    |                  ^^^^^^^^
@@ -8,7 +8,7 @@ LL |     fn foo(self: Bar<Foo>) {
    = help: consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`
 
 error[E0307]: invalid `self` parameter type: `&Bar<Foo>`
-  --> $DIR/method_resolution4.rs:29:20
+  --> $DIR/method_resolution4.rs:30:20
    |
 LL |     fn foomp(self: &Bar<Foo>) {
    |                    ^^^^^^^^^

--- a/tests/ui/type-alias-impl-trait/method_resolution4.next.stderr
+++ b/tests/ui/type-alias-impl-trait/method_resolution4.next.stderr
@@ -1,5 +1,5 @@
 error[E0307]: invalid `self` parameter type: `Bar<Foo>`
-  --> $DIR/method_resolution4.rs:25:18
+  --> $DIR/method_resolution4.rs:26:18
    |
 LL |     fn foo(self: Bar<Foo>) {
    |                  ^^^^^^^^
@@ -8,7 +8,7 @@ LL |     fn foo(self: Bar<Foo>) {
    = help: consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`
 
 error[E0307]: invalid `self` parameter type: `&Bar<Foo>`
-  --> $DIR/method_resolution4.rs:29:20
+  --> $DIR/method_resolution4.rs:30:20
    |
 LL |     fn foomp(self: &Bar<Foo>) {
    |                    ^^^^^^^^^

--- a/tests/ui/type-alias-impl-trait/method_resolution4.rs
+++ b/tests/ui/type-alias-impl-trait/method_resolution4.rs
@@ -6,6 +6,7 @@
 //@[next] compile-flags: -Znext-solver
 
 #![feature(type_alias_impl_trait, arbitrary_self_types)]
+#![allow(self_lifetime_elision_not_applicable)]
 
 pub type Foo = impl Copy;
 

--- a/tests/ui/typeck/pin-unsound-issue-85099-derefmut.rs
+++ b/tests/ui/typeck/pin-unsound-issue-85099-derefmut.rs
@@ -1,4 +1,5 @@
 //@ check-fail
+#![allow(self_lifetime_elision_not_applicable)]
 
 // Should fail. Can coerce `Pin<T>` into `Pin<U>` where
 // `T: Deref<Target: Unpin>` and `U: Deref<Target: !Unpin>`, using the

--- a/tests/ui/typeck/pin-unsound-issue-85099-derefmut.stderr
+++ b/tests/ui/typeck/pin-unsound-issue-85099-derefmut.stderr
@@ -1,5 +1,5 @@
 error[E0119]: conflicting implementations of trait `DerefMut` for type `Pin<&dyn SomeTrait<'_, _>>`
-  --> $DIR/pin-unsound-issue-85099-derefmut.rs:44:1
+  --> $DIR/pin-unsound-issue-85099-derefmut.rs:45:1
    |
 LL | impl<'b, 'a, Fut> DerefMut for Pin<&'b dyn SomeTrait<'a, Fut>> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/ufcs/ufcs-explicit-self-bad.rs
+++ b/tests/ui/ufcs/ufcs-explicit-self-bad.rs
@@ -1,3 +1,4 @@
+#![allow(self_lifetime_elision_not_applicable)]
 //@ dont-require-annotations: NOTE
 
 struct Foo {

--- a/tests/ui/ufcs/ufcs-explicit-self-bad.stderr
+++ b/tests/ui/ufcs/ufcs-explicit-self-bad.stderr
@@ -1,11 +1,11 @@
 error[E0053]: method `dummy2` has an incompatible type for trait
-  --> $DIR/ufcs-explicit-self-bad.rs:37:21
+  --> $DIR/ufcs-explicit-self-bad.rs:38:21
    |
 LL |     fn dummy2(self: &Bar<T>) {}
    |                     ^^^^^^^ expected `&'a Bar<T>`, found `Bar<T>`
    |
 note: type in trait
-  --> $DIR/ufcs-explicit-self-bad.rs:31:15
+  --> $DIR/ufcs-explicit-self-bad.rs:32:15
    |
 LL |     fn dummy2(&self);
    |               ^^^^^
@@ -18,7 +18,7 @@ LL +     fn dummy2(&self) {}
    |
 
 error[E0307]: invalid `self` parameter type: `isize`
-  --> $DIR/ufcs-explicit-self-bad.rs:8:18
+  --> $DIR/ufcs-explicit-self-bad.rs:9:18
    |
 LL |     fn foo(self: isize, x: isize) -> isize {
    |                  ^^^^^
@@ -27,7 +27,7 @@ LL |     fn foo(self: isize, x: isize) -> isize {
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0307]: invalid `self` parameter type: `Bar<isize>`
-  --> $DIR/ufcs-explicit-self-bad.rs:19:18
+  --> $DIR/ufcs-explicit-self-bad.rs:20:18
    |
 LL |     fn foo(self: Bar<isize>, x: isize) -> isize {
    |                  ^^^^^^^^^^
@@ -36,7 +36,7 @@ LL |     fn foo(self: Bar<isize>, x: isize) -> isize {
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0307]: invalid `self` parameter type: `&Bar<usize>`
-  --> $DIR/ufcs-explicit-self-bad.rs:23:18
+  --> $DIR/ufcs-explicit-self-bad.rs:24:18
    |
 LL |     fn bar(self: &Bar<usize>, x: isize) -> isize {
    |                  ^^^^^^^^^^^
@@ -45,7 +45,7 @@ LL |     fn bar(self: &Bar<usize>, x: isize) -> isize {
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0308]: mismatched `self` parameter type
-  --> $DIR/ufcs-explicit-self-bad.rs:37:21
+  --> $DIR/ufcs-explicit-self-bad.rs:38:21
    |
 LL |     fn dummy2(self: &Bar<T>) {}
    |                     ^^^^^^^ lifetime mismatch
@@ -53,18 +53,18 @@ LL |     fn dummy2(self: &Bar<T>) {}
    = note: expected reference `&'a Bar<_>`
               found reference `&Bar<_>`
 note: the anonymous lifetime defined here...
-  --> $DIR/ufcs-explicit-self-bad.rs:37:21
+  --> $DIR/ufcs-explicit-self-bad.rs:38:21
    |
 LL |     fn dummy2(self: &Bar<T>) {}
    |                     ^^^^^^^
 note: ...does not necessarily outlive the lifetime `'a` as defined here
-  --> $DIR/ufcs-explicit-self-bad.rs:35:6
+  --> $DIR/ufcs-explicit-self-bad.rs:36:6
    |
 LL | impl<'a, T> SomeTrait for &'a Bar<T> {
    |      ^^
 
 error[E0308]: mismatched `self` parameter type
-  --> $DIR/ufcs-explicit-self-bad.rs:37:21
+  --> $DIR/ufcs-explicit-self-bad.rs:38:21
    |
 LL |     fn dummy2(self: &Bar<T>) {}
    |                     ^^^^^^^ lifetime mismatch
@@ -72,18 +72,18 @@ LL |     fn dummy2(self: &Bar<T>) {}
    = note: expected reference `&'a Bar<_>`
               found reference `&Bar<_>`
 note: the lifetime `'a` as defined here...
-  --> $DIR/ufcs-explicit-self-bad.rs:35:6
+  --> $DIR/ufcs-explicit-self-bad.rs:36:6
    |
 LL | impl<'a, T> SomeTrait for &'a Bar<T> {
    |      ^^
 note: ...does not necessarily outlive the anonymous lifetime defined here
-  --> $DIR/ufcs-explicit-self-bad.rs:37:21
+  --> $DIR/ufcs-explicit-self-bad.rs:38:21
    |
 LL |     fn dummy2(self: &Bar<T>) {}
    |                     ^^^^^^^
 
 error[E0308]: mismatched `self` parameter type
-  --> $DIR/ufcs-explicit-self-bad.rs:40:21
+  --> $DIR/ufcs-explicit-self-bad.rs:41:21
    |
 LL |     fn dummy3(self: &&Bar<T>) {}
    |                     ^^^^^^^^ lifetime mismatch
@@ -91,18 +91,18 @@ LL |     fn dummy3(self: &&Bar<T>) {}
    = note: expected reference `&'a Bar<_>`
               found reference `&Bar<_>`
 note: the anonymous lifetime defined here...
-  --> $DIR/ufcs-explicit-self-bad.rs:40:22
+  --> $DIR/ufcs-explicit-self-bad.rs:41:22
    |
 LL |     fn dummy3(self: &&Bar<T>) {}
    |                      ^^^^^^^
 note: ...does not necessarily outlive the lifetime `'a` as defined here
-  --> $DIR/ufcs-explicit-self-bad.rs:35:6
+  --> $DIR/ufcs-explicit-self-bad.rs:36:6
    |
 LL | impl<'a, T> SomeTrait for &'a Bar<T> {
    |      ^^
 
 error[E0308]: mismatched `self` parameter type
-  --> $DIR/ufcs-explicit-self-bad.rs:40:21
+  --> $DIR/ufcs-explicit-self-bad.rs:41:21
    |
 LL |     fn dummy3(self: &&Bar<T>) {}
    |                     ^^^^^^^^ lifetime mismatch
@@ -110,30 +110,30 @@ LL |     fn dummy3(self: &&Bar<T>) {}
    = note: expected reference `&'a Bar<_>`
               found reference `&Bar<_>`
 note: the lifetime `'a` as defined here...
-  --> $DIR/ufcs-explicit-self-bad.rs:35:6
+  --> $DIR/ufcs-explicit-self-bad.rs:36:6
    |
 LL | impl<'a, T> SomeTrait for &'a Bar<T> {
    |      ^^
 note: ...does not necessarily outlive the anonymous lifetime defined here
-  --> $DIR/ufcs-explicit-self-bad.rs:40:22
+  --> $DIR/ufcs-explicit-self-bad.rs:41:22
    |
 LL |     fn dummy3(self: &&Bar<T>) {}
    |                      ^^^^^^^
 
 error[E0610]: `isize` is a primitive type and therefore doesn't have fields
-  --> $DIR/ufcs-explicit-self-bad.rs:10:14
+  --> $DIR/ufcs-explicit-self-bad.rs:11:14
    |
 LL |         self.f + x
    |              ^
 
 error[E0599]: no method named `foo` found for struct `Box<Foo>` in the current scope
-  --> $DIR/ufcs-explicit-self-bad.rs:55:24
+  --> $DIR/ufcs-explicit-self-bad.rs:56:24
    |
 LL |     println!("{}", foo.foo(2));
    |                        ^^^ method not found in `Box<Foo>`
 
 error[E0599]: no method named `bar` found for struct `Box<Bar<isize>>` in the current scope
-  --> $DIR/ufcs-explicit-self-bad.rs:60:39
+  --> $DIR/ufcs-explicit-self-bad.rs:61:39
    |
 LL |     println!("{} {}", bar.foo(2), bar.bar(2));
    |                                       ^^^ method not found in `Box<Bar<isize>>`


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/153692)*
<!-- homu-ignore:end -->

### Summary

FCW lint `self_lifetime_elision_not_applicable`: fires when a `self` parameter contains `&` but does not syntactically contain `Self`.

Tracking: rust-lang/rust#140611

### Context

Self-type lifetime elision in `rustc_resolve` relies on a name-matching hack (`is_self_ty`) that shallow-compares `Res` values between the self parameter type and the impl self type. As @compiler-errors identified in rust-lang/rust#140611, this hack cannot see through type aliases (different `Res`) and only fires for `Struct|Union|Enum|PrimTy` impls (excludes `TyAlias`). When it misses, `find_lifetime_for_self` returns `Empty`, self-elision silently fails, and a later parameter's lifetime may leak into the return type.

@lcnr proposed restricting self-elision to genuine `Self` and FCW'ing everything else. This PR implements that.

### Behavior

```rust
pub struct W<'a>(&'a ());
pub type Alias<'a> = W<'a>;
```

| Case | Code                                       | Before               | After     |
| ---- | ------------------------------------------ | -------------------- | --------- |
| f1   | `impl Alias { fn f(self: &W) -> &() }`     | silent wrong `'_`    | **FCW**   |
| f2   | `impl Alias { fn f(self: &Alias) -> &() }` | silent wrong `'_`    | **FCW**   |
| f3   | `impl Alias { fn f(&self) -> &() }`        | correct              | unchanged |
| f4   | `impl W { fn f(self: &W) -> &() }`         | correct (hack fires) | **FCW**   |
| f5   | `impl W { fn f(self: &Alias) -> &() }`     | silent wrong `'_`    | **FCW**   |
| f6   | `impl W { fn f(&self) -> &() }`            | correct              | unchanged |

A follow-up PR will remove the hack after a warning period.

r? @lcnr
cc @compiler-errors @traviscross