### PR TITLE
hir_typeck: suggest removing redundant .iter() and iter_mut() calls

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -97,6 +97,92 @@ impl TraitBoundDuplicateTracker {
 }
 
 impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
+    /// Returns the byte offset of the last `.` in `s` that lies outside any
+    /// comment: line comments (`//`) or block comments (`/* ... */`, including nested).
+    fn find_last_real_dot(s: &str) -> Option<usize> {
+        enum State {
+            Code,
+            LineComment,
+            BlockComment { depth: u32 },
+        }
+
+        let mut state = State::Code;
+        let mut last_dot = None;
+        let mut chars = s.char_indices().peekable();
+
+        while let Some((i, c)) = chars.next() {
+            let peeked = chars.peek().map(|&(_, c)| c);
+
+            state = match state {
+                State::Code => match (c, peeked) {
+                    ('/', Some('/')) => {
+                        chars.next();
+                        State::LineComment
+                    }
+                    ('/', Some('*')) => {
+                        chars.next();
+                        State::BlockComment { depth: 1 }
+                    }
+                    ('.', _) => {
+                        last_dot = Some(i);
+                        State::Code
+                    }
+                    _ => State::Code,
+                },
+                State::LineComment => match c {
+                    '\n' => State::Code,
+                    _ => State::LineComment,
+                },
+                State::BlockComment { depth } => match (c, peeked) {
+                    ('/', Some('*')) => {
+                        chars.next();
+                        State::BlockComment { depth: depth + 1 }
+                    }
+                    ('*', Some('/')) => {
+                        chars.next();
+                        if depth == 1 {
+                            State::Code
+                        } else {
+                            State::BlockComment { depth: depth - 1 }
+                        }
+                    }
+                    _ => State::BlockComment { depth },
+                },
+            };
+        }
+
+        last_dot
+    }
+
+    /// Computes the exact span to delete and its applicability for removing a
+    /// redundant `.iter()` call.
+    /// Returns `None` if the suggestion cannot be safely derived from the source map.
+    fn compute_iter_removal_suggestion(
+        &self,
+        rcvr_expr: &hir::Expr<'_>,
+        span: Span,
+        sugg_span: Span,
+    ) -> Option<(Span, Applicability)> {
+        // Between receiver and method name (the part containing the dot)
+        let dot_part_span = rcvr_expr.span.between(span);
+        let dot_snippet = self.tcx.sess.source_map().span_to_snippet(dot_part_span).ok()?;
+        let dot_offset = Self::find_last_real_dot(&dot_snippet)?;
+
+        let replacement_span = sugg_span
+            .with_lo(dot_part_span.lo() + rustc_span::BytePos(u32::try_from(dot_offset).ok()?));
+
+        // A comment in the section being removed risks deleting user documentation,
+        // so we downgrade applicability to signal that human review is warranted.
+        let deleted_snippet = self.tcx.sess.source_map().span_to_snippet(replacement_span).ok()?;
+        let applicability = if deleted_snippet.contains("//") || deleted_snippet.contains("/*") {
+            Applicability::MaybeIncorrect
+        } else {
+            Applicability::MachineApplicable
+        };
+
+        Some((replacement_span, applicability))
+    }
+
     fn is_slice_ty(&self, ty: Ty<'tcx>, span: Span) -> bool {
         self.autoderef(span, ty)
             .silence_errors()
@@ -758,6 +844,45 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
     }
 
+    /// Suggests removing a redundant `.iter()` or `.iter_mut()` call if the
+    /// receiver already implements the `Iterator` trait.
+    /// Returns `true` if a suggestion or note was emitted, signaling that
+    /// further diagnostic fallback should be suppressed.
+    fn suggest_removing_iter_call(
+        &self,
+        err: &mut Diag<'_>,
+        rcvr_expr: &hir::Expr<'_>,
+        rcvr_ty: Ty<'tcx>,
+        item_name: Symbol,
+        span: Span,
+        sugg_span: Span,
+    ) -> bool {
+        // Ensure the receiver and the suggestion are in the same macro context.
+        if !rcvr_expr.span.eq_ctxt(sugg_span) || !rcvr_expr.span.eq_ctxt(span) {
+            return false;
+        }
+
+        // Guard against constructing an invalid span across macro edges.
+        if rcvr_expr.span.hi() > sugg_span.hi() {
+            return false;
+        }
+
+        match self.compute_iter_removal_suggestion(rcvr_expr, span, sugg_span) {
+            Some((replacement_span, applicability)) => {
+                let ty_str = self.tcx.short_string(rcvr_ty, err.long_ty_path());
+                err.note(format!("`{ty_str}` already implements `Iterator`"));
+                err.span_suggestion_verbose(
+                    replacement_span,
+                    format!("consider removing the `.{item_name}()` call"),
+                    "",
+                    applicability,
+                );
+                true
+            }
+            None => false,
+        }
+    }
+
     fn suggest_static_method_candidates(
         &self,
         err: &mut Diag<'_>,
@@ -828,6 +953,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         source: SelfSource<'tcx>,
         unsatisfied_predicates: &UnsatisfiedPredicates<'tcx>,
         static_candidates: &[CandidateSource],
+        sugg_span: Span,
     ) -> Result<(bool, bool, bool, bool, SortedMap<Span, Vec<String>>), ()> {
         let mut restrict_type_params = false;
         let mut suggested_derive = false;
@@ -835,6 +961,28 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let mut custom_span_label = !static_candidates.is_empty();
         let mut bound_spans: SortedMap<Span, Vec<String>> = Default::default();
         let tcx = self.tcx;
+
+        if (item_ident.name == sym::iter || item_ident.name == sym::iter_mut)
+            && let SelfSource::MethodCall(rcvr_expr) = source
+            && let Some(iterator_trait) = self.tcx.get_diagnostic_item(sym::Iterator)
+            && self.predicate_must_hold_modulo_regions(&Obligation::new(
+                self.tcx,
+                self.misc(span),
+                self.param_env,
+                ty::TraitRef::new(self.tcx, iterator_trait, [rcvr_ty]),
+            ))
+        {
+            if self.suggest_removing_iter_call(
+                err,
+                rcvr_expr,
+                rcvr_ty,
+                item_ident.name,
+                span,
+                sugg_span,
+            ) {
+                return Err(());
+            }
+        }
 
         if item_ident.name == sym::count && self.is_slice_ty(rcvr_ty, span) {
             let msg = "consider using `len` instead";
@@ -1268,6 +1416,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             source,
             unsatisfied_predicates,
             &static_candidates,
+            sugg_span,
         )
         else {
             return err.emit();

--- a/tests/ui/iterators/iter-on-already-iterator-competing-suggestions.fixed
+++ b/tests/ui/iterators/iter-on-already-iterator-competing-suggestions.fixed
@@ -1,0 +1,19 @@
+//@ run-rustfix
+#![allow(dead_code, unused_imports)]
+// Regression test for short-circuiting redundant iter() diagnostics
+// to prevent competing suggestions.
+
+mod out_of_scope {
+    pub trait MyIterExt {
+        fn iter(&self) {}
+    }
+    impl<T: Iterator> MyIterExt for T {}
+}
+
+fn out_of_scope_trait(iter: impl Iterator<Item = i32>) {
+    // Out-of-scope trait that actually has `.iter()`.
+    let _ = iter;
+    //~^ ERROR no method named `iter` found
+}
+
+fn main() {}

--- a/tests/ui/iterators/iter-on-already-iterator-competing-suggestions.rs
+++ b/tests/ui/iterators/iter-on-already-iterator-competing-suggestions.rs
@@ -1,0 +1,19 @@
+//@ run-rustfix
+#![allow(dead_code, unused_imports)]
+// Regression test for short-circuiting redundant iter() diagnostics
+// to prevent competing suggestions.
+
+mod out_of_scope {
+    pub trait MyIterExt {
+        fn iter(&self) {}
+    }
+    impl<T: Iterator> MyIterExt for T {}
+}
+
+fn out_of_scope_trait(iter: impl Iterator<Item = i32>) {
+    // Out-of-scope trait that actually has `.iter()`.
+    let _ = iter.iter();
+    //~^ ERROR no method named `iter` found
+}
+
+fn main() {}

--- a/tests/ui/iterators/iter-on-already-iterator-competing-suggestions.stderr
+++ b/tests/ui/iterators/iter-on-already-iterator-competing-suggestions.stderr
@@ -1,0 +1,16 @@
+error[E0599]: no method named `iter` found for type parameter `impl Iterator<Item = i32>` in the current scope
+  --> $DIR/iter-on-already-iterator-competing-suggestions.rs:15:18
+   |
+LL |     let _ = iter.iter();
+   |                  ^^^^
+   |
+   = note: `impl Iterator<Item = i32>` already implements `Iterator`
+help: consider removing the `.iter()` call
+   |
+LL -     let _ = iter.iter();
+LL +     let _ = iter;
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0599`.

--- a/tests/ui/iterators/iter-on-already-iterator-unfixable.rs
+++ b/tests/ui/iterators/iter-on-already-iterator-unfixable.rs
@@ -1,0 +1,18 @@
+//! Tests for the targeted diagnostic that suggests removing redundant `.iter()` calls.
+//! This file focuses on "unfixable" cases where a comment is present *inside* the
+//! portion being deleted (e.g. `. /* comment */ iter()`).
+//!
+//! These are marked as `MaybeIncorrect` to ensure `cargo fix` does not
+//! automatically delete user comments.
+#![allow(unused)]
+
+#[rustfmt::skip]
+fn main() {
+    let receiver = vec![1, 2, 3].into_iter();
+
+    // A comment containing a dot shouldn't trick the span parser.
+    // The comment is BETWEEN the dot and the method name, so it would be deleted.
+    let _ = receiver . /* . */ iter();
+    //~^ ERROR no method named `iter`
+    //~| HELP consider removing the `.iter()` call
+}

--- a/tests/ui/iterators/iter-on-already-iterator-unfixable.stderr
+++ b/tests/ui/iterators/iter-on-already-iterator-unfixable.stderr
@@ -1,0 +1,16 @@
+error[E0599]: no method named `iter` found for struct `std::vec::IntoIter<T, A>` in the current scope
+  --> $DIR/iter-on-already-iterator-unfixable.rs:15:32
+   |
+LL |     let _ = receiver . /* . */ iter();
+   |                                ^^^^
+   |
+   = note: `std::vec::IntoIter<{integer}>` already implements `Iterator`
+help: consider removing the `.iter()` call
+   |
+LL -     let _ = receiver . /* . */ iter();
+LL +     let _ = receiver ;
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0599`.

--- a/tests/ui/iterators/iter-on-already-iterator.fixed
+++ b/tests/ui/iterators/iter-on-already-iterator.fixed
@@ -1,0 +1,93 @@
+//@ run-rustfix
+//! Exhaustive tests for the targeted diagnostic that suggests removing redundant `.iter()` calls.
+//! This file focuses on "safe" cases (marked as `MachineApplicable`) that are
+//! automatically handled by `cargo fix`. This includes verifying that comments
+//! OUTSIDE the removal span are correctly preserved.
+#![allow(unused)]
+
+#[rustfmt::skip]
+fn main() {
+    let receiver = vec![1, 2, 3].into_iter();
+
+    // Simple inline call.
+    let _ = receiver;
+    //~^ ERROR no method named `iter`
+
+    let receiver = vec![1, 2, 3].into_iter();
+    // Call with extra horizontal whitespace between receiver and dot.
+    let _ = receiver   ;
+    //~^ ERROR no method named `iter`
+
+    let receiver = vec![1, 2, 3].into_iter();
+    // Call with a newline and indentation before the dot.
+    let _ = receiver
+        ;
+        //~^ ERROR no method named `iter`
+
+    let receiver = vec![1, 2, 3].into_iter();
+    // Call with a block comment between the receiver and the dot.
+    // The comment is before the dot, so it is preserved.
+    let _ = receiver /* info */ ;
+    //~^ ERROR no method named `iter`
+
+    let receiver = vec![1, 2, 3].into_iter();
+    // Call with a line comment on the preceding line.
+    let _ = receiver // info
+        ;
+        //~^ ERROR no method named `iter`
+
+    let receiver = vec![1, 2, 3].into_iter();
+    // A comment containing a dot shouldn't trick the span parser.
+    let _ = receiver /* . */ ;
+    //~^ ERROR no method named `iter`
+
+    let receiver = vec![1, 2, 3].into_iter();
+    // Verify trailing comments after the call are preserved.
+    let _ = receiver /* wait, keep this! */;
+    //~^ ERROR no method named `iter`
+
+    let receiver = vec![1, 2, 3].into_iter();
+    // Chained method call after `.iter()`: only `.iter()` is removed.
+    let _ = receiver.map(|x| x);
+    //~^ ERROR no method named `iter`
+
+    // Multi-segment path receiver.
+    let _ = std::iter::empty::<i32>();
+    //~^ ERROR no method named `iter`
+}
+
+// Concrete user-defined struct implementing Iterator directly.
+struct MyIter;
+
+impl Iterator for MyIter {
+    type Item = i32;
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+fn concrete_iterator() {
+    let it = MyIter;
+    let _ = it;
+    //~^ ERROR no method named `iter`
+}
+
+// `Box<dyn Iterator>` -- verify the trait check fires through trait objects.
+fn dyn_iterator(it: Box<dyn Iterator<Item = i32>>) {
+    let _ = it;
+    //~^ ERROR no method named `iter`
+}
+
+// Generic context with an explicit bound.
+fn generic_iterator<I: Iterator<Item = i32>>(it: I) {
+    let _ = it;
+    //~^ ERROR no method named `iter`
+}
+
+// Redundant `.iter_mut()` on a mutable iterator.
+fn iter_mut_on_mutable_iterator() {
+    let mut vec = vec![1, 2, 3];
+    let it = vec.iter_mut();
+    let _ = it;
+    //~^ ERROR no method named `iter_mut`
+}

--- a/tests/ui/iterators/iter-on-already-iterator.rs
+++ b/tests/ui/iterators/iter-on-already-iterator.rs
@@ -1,0 +1,93 @@
+//@ run-rustfix
+//! Exhaustive tests for the targeted diagnostic that suggests removing redundant `.iter()` calls.
+//! This file focuses on "safe" cases (marked as `MachineApplicable`) that are
+//! automatically handled by `cargo fix`. This includes verifying that comments
+//! OUTSIDE the removal span are correctly preserved.
+#![allow(unused)]
+
+#[rustfmt::skip]
+fn main() {
+    let receiver = vec![1, 2, 3].into_iter();
+
+    // Simple inline call.
+    let _ = receiver.iter();
+    //~^ ERROR no method named `iter`
+
+    let receiver = vec![1, 2, 3].into_iter();
+    // Call with extra horizontal whitespace between receiver and dot.
+    let _ = receiver   .iter();
+    //~^ ERROR no method named `iter`
+
+    let receiver = vec![1, 2, 3].into_iter();
+    // Call with a newline and indentation before the dot.
+    let _ = receiver
+        .iter();
+        //~^ ERROR no method named `iter`
+
+    let receiver = vec![1, 2, 3].into_iter();
+    // Call with a block comment between the receiver and the dot.
+    // The comment is before the dot, so it is preserved.
+    let _ = receiver /* info */ .iter();
+    //~^ ERROR no method named `iter`
+
+    let receiver = vec![1, 2, 3].into_iter();
+    // Call with a line comment on the preceding line.
+    let _ = receiver // info
+        .iter();
+        //~^ ERROR no method named `iter`
+
+    let receiver = vec![1, 2, 3].into_iter();
+    // A comment containing a dot shouldn't trick the span parser.
+    let _ = receiver /* . */ . iter();
+    //~^ ERROR no method named `iter`
+
+    let receiver = vec![1, 2, 3].into_iter();
+    // Verify trailing comments after the call are preserved.
+    let _ = receiver.iter() /* wait, keep this! */;
+    //~^ ERROR no method named `iter`
+
+    let receiver = vec![1, 2, 3].into_iter();
+    // Chained method call after `.iter()`: only `.iter()` is removed.
+    let _ = receiver.iter().map(|x| x);
+    //~^ ERROR no method named `iter`
+
+    // Multi-segment path receiver.
+    let _ = std::iter::empty::<i32>().iter();
+    //~^ ERROR no method named `iter`
+}
+
+// Concrete user-defined struct implementing Iterator directly.
+struct MyIter;
+
+impl Iterator for MyIter {
+    type Item = i32;
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+fn concrete_iterator() {
+    let it = MyIter;
+    let _ = it.iter();
+    //~^ ERROR no method named `iter`
+}
+
+// `Box<dyn Iterator>` -- verify the trait check fires through trait objects.
+fn dyn_iterator(it: Box<dyn Iterator<Item = i32>>) {
+    let _ = it.iter();
+    //~^ ERROR no method named `iter`
+}
+
+// Generic context with an explicit bound.
+fn generic_iterator<I: Iterator<Item = i32>>(it: I) {
+    let _ = it.iter();
+    //~^ ERROR no method named `iter`
+}
+
+// Redundant `.iter_mut()` on a mutable iterator.
+fn iter_mut_on_mutable_iterator() {
+    let mut vec = vec![1, 2, 3];
+    let it = vec.iter_mut();
+    let _ = it.iter_mut();
+    //~^ ERROR no method named `iter_mut`
+}

--- a/tests/ui/iterators/iter-on-already-iterator.stderr
+++ b/tests/ui/iterators/iter-on-already-iterator.stderr
@@ -1,0 +1,176 @@
+error[E0599]: no method named `iter` found for struct `std::vec::IntoIter<T, A>` in the current scope
+  --> $DIR/iter-on-already-iterator.rs:13:22
+   |
+LL |     let _ = receiver.iter();
+   |                      ^^^^
+   |
+   = note: `std::vec::IntoIter<{integer}>` already implements `Iterator`
+help: consider removing the `.iter()` call
+   |
+LL -     let _ = receiver.iter();
+LL +     let _ = receiver;
+   |
+
+error[E0599]: no method named `iter` found for struct `std::vec::IntoIter<T, A>` in the current scope
+  --> $DIR/iter-on-already-iterator.rs:18:25
+   |
+LL |     let _ = receiver   .iter();
+   |                         ^^^^
+   |
+   = note: `std::vec::IntoIter<{integer}>` already implements `Iterator`
+help: consider removing the `.iter()` call
+   |
+LL -     let _ = receiver   .iter();
+LL +     let _ = receiver   ;
+   |
+
+error[E0599]: no method named `iter` found for struct `std::vec::IntoIter<T, A>` in the current scope
+  --> $DIR/iter-on-already-iterator.rs:24:10
+   |
+LL |       let _ = receiver
+   |  _____________-
+LL | |         .iter();
+   | |_________-^^^^
+   |
+   = note: `std::vec::IntoIter<{integer}>` already implements `Iterator`
+help: consider removing the `.iter()` call
+   |
+LL -         .iter();
+LL +         ;
+   |
+
+error[E0599]: no method named `iter` found for struct `std::vec::IntoIter<T, A>` in the current scope
+  --> $DIR/iter-on-already-iterator.rs:30:34
+   |
+LL |     let _ = receiver /* info */ .iter();
+   |                                  ^^^^
+   |
+   = note: `std::vec::IntoIter<{integer}>` already implements `Iterator`
+help: consider removing the `.iter()` call
+   |
+LL -     let _ = receiver /* info */ .iter();
+LL +     let _ = receiver /* info */ ;
+   |
+
+error[E0599]: no method named `iter` found for struct `std::vec::IntoIter<T, A>` in the current scope
+  --> $DIR/iter-on-already-iterator.rs:36:10
+   |
+LL |       let _ = receiver // info
+   |  _____________-
+LL | |         .iter();
+   | |_________-^^^^
+   |
+   = note: `std::vec::IntoIter<{integer}>` already implements `Iterator`
+help: consider removing the `.iter()` call
+   |
+LL -         .iter();
+LL +         ;
+   |
+
+error[E0599]: no method named `iter` found for struct `std::vec::IntoIter<T, A>` in the current scope
+  --> $DIR/iter-on-already-iterator.rs:41:32
+   |
+LL |     let _ = receiver /* . */ . iter();
+   |                                ^^^^
+   |
+   = note: `std::vec::IntoIter<{integer}>` already implements `Iterator`
+help: consider removing the `.iter()` call
+   |
+LL -     let _ = receiver /* . */ . iter();
+LL +     let _ = receiver /* . */ ;
+   |
+
+error[E0599]: no method named `iter` found for struct `std::vec::IntoIter<T, A>` in the current scope
+  --> $DIR/iter-on-already-iterator.rs:46:22
+   |
+LL |     let _ = receiver.iter() /* wait, keep this! */;
+   |                      ^^^^
+   |
+   = note: `std::vec::IntoIter<{integer}>` already implements `Iterator`
+help: consider removing the `.iter()` call
+   |
+LL -     let _ = receiver.iter() /* wait, keep this! */;
+LL +     let _ = receiver /* wait, keep this! */;
+   |
+
+error[E0599]: no method named `iter` found for struct `std::vec::IntoIter<T, A>` in the current scope
+  --> $DIR/iter-on-already-iterator.rs:51:22
+   |
+LL |     let _ = receiver.iter().map(|x| x);
+   |                      ^^^^
+   |
+   = note: `std::vec::IntoIter<{integer}>` already implements `Iterator`
+help: consider removing the `.iter()` call
+   |
+LL -     let _ = receiver.iter().map(|x| x);
+LL +     let _ = receiver.map(|x| x);
+   |
+
+error[E0599]: no method named `iter` found for struct `std::iter::Empty<T>` in the current scope
+  --> $DIR/iter-on-already-iterator.rs:55:39
+   |
+LL |     let _ = std::iter::empty::<i32>().iter();
+   |                                       ^^^^
+   |
+   = note: `std::iter::Empty<i32>` already implements `Iterator`
+help: consider removing the `.iter()` call
+   |
+LL -     let _ = std::iter::empty::<i32>().iter();
+LL +     let _ = std::iter::empty::<i32>();
+   |
+
+error[E0599]: no method named `iter` found for struct `MyIter` in the current scope
+  --> $DIR/iter-on-already-iterator.rs:71:16
+   |
+LL |     let _ = it.iter();
+   |                ^^^^
+   |
+   = note: `MyIter` already implements `Iterator`
+help: consider removing the `.iter()` call
+   |
+LL -     let _ = it.iter();
+LL +     let _ = it;
+   |
+
+error[E0599]: no method named `iter` found for struct `Box<(dyn Iterator<Item = i32> + 'static)>` in the current scope
+  --> $DIR/iter-on-already-iterator.rs:77:16
+   |
+LL |     let _ = it.iter();
+   |                ^^^^
+   |
+   = note: `Box<(dyn Iterator<Item = i32> + 'static)>` already implements `Iterator`
+help: consider removing the `.iter()` call
+   |
+LL -     let _ = it.iter();
+LL +     let _ = it;
+   |
+
+error[E0599]: no method named `iter` found for type parameter `I` in the current scope
+  --> $DIR/iter-on-already-iterator.rs:83:16
+   |
+LL |     let _ = it.iter();
+   |                ^^^^
+   |
+   = note: `I` already implements `Iterator`
+help: consider removing the `.iter()` call
+   |
+LL -     let _ = it.iter();
+LL +     let _ = it;
+   |
+
+error[E0599]: no method named `iter_mut` found for struct `std::slice::IterMut<'a, T>` in the current scope
+  --> $DIR/iter-on-already-iterator.rs:91:16
+   |
+LL |     let _ = it.iter_mut();
+   |                ^^^^^^^^
+   |
+   = note: `std::slice::IterMut<'_, {integer}>` already implements `Iterator`
+help: consider removing the `.iter_mut()` call
+   |
+LL -     let _ = it.iter_mut();
+LL +     let _ = it;
+   |
+
+error: aborting due to 13 previous errors
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
This diagnostic intercepts cases where `.iter()` or `.iter_mut()` is called on a type that already implements `Iterator`

Instead of confusing trait fallback suggestions, it explicitly guides the user to remove the `.iter()` call. It implements precise span computation to support `cargo fix` while carefully preserving all inline comments and horizontal whitespace during the AST string replacement.

Fixes rust-lang/rust#153667
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
