### PR TITLE
Implement context-aware validation for SIMD MIR projections (MCP#838)

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/place.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/place.rs
@@ -276,9 +276,15 @@ impl<'a, 'tcx, V: CodegenObject> PlaceRef<'tcx, V> {
         bx: &mut Bx,
         llindex: V,
     ) -> Self {
+        // MCP#838: If we are indexing a SIMD type, we need to reach past the
+        // struct wrapper to the internal array so we can index the lanes.
+        let mut base_layout = self.layout;
+        if base_layout.ty.is_simd() {
+            base_layout = base_layout.field(bx, 0);
+        }
         // Statically compute the offset if we can, otherwise just use the element size,
         // as this will yield the lowest alignment.
-        let layout = self.layout.field(bx, 0);
+        let layout = base_layout.field(bx, 0);
         let offset = if let Some(llindex) = bx.const_to_opt_uint(llindex) {
             layout.size.checked_mul(llindex, bx).unwrap_or(layout.size)
         } else {

--- a/compiler/rustc_middle/src/mir/statement.rs
+++ b/compiler/rustc_middle/src/mir/statement.rs
@@ -219,7 +219,18 @@ impl<'tcx> PlaceTy<'tcx> {
                 PlaceTy::from_ty(ty)
             }
             ProjectionElem::Index(_) | ProjectionElem::ConstantIndex { .. } => {
-                PlaceTy::from_ty(structurally_normalize(self.ty).builtin_index().unwrap())
+                let normalized_ty = structurally_normalize(self.ty);
+                let ty = if let ty::Adt(def, args) = normalized_ty.kind()
+                    && def.repr().simd()
+                {
+                    // MCP#838: SIMD types are indexable. The element type is
+                    // the element type of the internal array (field 0).
+                    let array_ty = def.non_enum_variant().fields.raw[0].ty(tcx, args);
+                    array_ty.builtin_index().expect("SIMD internal field must be an array")
+                } else {
+                    normalized_ty.builtin_index().expect("indexing non-indexable type")
+                };
+                PlaceTy::from_ty(ty)
             }
             ProjectionElem::Subslice { from, to, from_end } => {
                 PlaceTy::from_ty(match structurally_normalize(self.ty).kind() {

--- a/compiler/rustc_mir_build/src/builder/expr/as_place.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_place.rs
@@ -436,9 +436,22 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let lhs_expr = &this.thir[lhs];
                 let mut place_builder =
                     unpack!(block = this.expr_as_place(block, lhs, mutability, fake_borrow_temps,));
-                if let ty::Adt(adt_def, _) = lhs_expr.ty.kind() {
+
+                if let ty::Adt(adt_def, args) = lhs_expr.ty.kind() {
                     if adt_def.is_enum() {
                         place_builder = place_builder.downcast(*adt_def, variant_index);
+                    }
+
+                    // MCP#838: SIMD types are atomic. Do not allow a standalone field projection.
+                    if adt_def.repr().simd() {
+                        // However, we MUST allow Field 0 to be mapped if it is the internal array,
+                        // otherwise references like `&simd.0` will have a mismatched struct type.
+                        if name.as_u32() == 0 {
+                            let field_ty =
+                                adt_def.non_enum_variant().fields.raw[0].ty(this.tcx, args);
+                            return block.and(place_builder.field(name, field_ty));
+                        }
+                        return block.and(place_builder);
                     }
                 }
                 block.and(place_builder.field(name, expr.ty))
@@ -712,6 +725,19 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 );
 
                 Operand::Move(len)
+            }
+            ty::Adt(def, args) if def.repr().simd() => {
+                // Reach into the ADT definition to find the internal array type
+                let field_ty = def.non_enum_variant().fields.raw[0].ty(self.tcx, args);
+                if let ty::Array(_, len_const) = field_ty.kind() {
+                    let const_ = Const::Ty(self.tcx.types.usize, *len_const);
+                    return Operand::Constant(Box::new(ConstOperand {
+                        span,
+                        user_ty: None,
+                        const_,
+                    }));
+                }
+                span_bug!(span, "SIMD type without internal array: {place_ty:?}");
             }
             _ => {
                 span_bug!(span, "len called on place of type {place_ty:?}")

--- a/compiler/rustc_mir_transform/src/validate.rs
+++ b/compiler/rustc_mir_transform/src/validate.rs
@@ -713,15 +713,6 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                             );
                         }
 
-                        if adt_def.repr().simd() {
-                            self.fail(
-                                location,
-                                format!(
-                                    "Projecting into SIMD type {adt_def:?} is banned by MCP#838"
-                                ),
-                            );
-                        }
-
                         let var = parent_ty.variant_index.unwrap_or(FIRST_VARIANT);
                         let Some(field) = adt_def.variant(var).fields.get(f) else {
                             fail_out_of_bounds(self, location);
@@ -811,6 +802,8 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                 let indexed_ty = place_ref.ty(&self.body.local_decls, self.tcx).ty;
                 match indexed_ty.kind() {
                     ty::Array(_, _) | ty::Slice(_) => {}
+                    // MCP#838: Allow direct indexing on SIMD types
+                    ty::Adt(def, _) if def.repr().simd() => {}
                     _ => self.fail(location, format!("{indexed_ty:?} cannot be indexed")),
                 }
 
@@ -944,6 +937,32 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
     fn visit_place(&mut self, place: &Place<'tcx>, cntxt: PlaceContext, location: Location) {
         // Set off any `bug!`s in the type computation code
         let _ = place.ty(&self.body.local_decls, self.tcx);
+        // MCP#838: Ban standalone field projections on SIMD types.
+        // They are only permitted as an intermediate step for indexing.
+        for i in 0..place.projection.len() {
+            if let ProjectionElem::Field(_, _) = place.projection[i] {
+                let parent_place =
+                    PlaceRef { local: place.local, projection: &place.projection[..i] };
+                let parent_ty = parent_place.ty(&self.body.local_decls, self.tcx).ty;
+
+                if let ty::Adt(adt_def, _) = parent_ty.kind() {
+                    if adt_def.repr().simd() {
+                        let allowed = matches!(
+                            place.projection.get(i + 1),
+                            Some(ProjectionElem::Index(_) | ProjectionElem::ConstantIndex { .. })
+                        );
+                        if !allowed {
+                            self.fail(
+                                location,
+                                format!(
+                                    "Projecting into SIMD type {adt_def:?} is banned by MCP#838"
+                                ),
+                            );
+                        }
+                    }
+                }
+            }
+        }
 
         if self.body.phase >= MirPhase::Runtime(RuntimePhase::Initial)
             && place.projection.len() > 1

--- a/tests/ui/simd/ice-broken-mir.rs
+++ b/tests/ui/simd/ice-broken-mir.rs
@@ -1,0 +1,19 @@
+//@ build-pass
+
+#![feature(repr_simd)]
+#[repr(simd)]
+struct T<const N: usize>([i32; N]);
+trait SimdExtract {
+    type Value;
+    fn extract(self) -> Self::Value;
+}
+impl<const N: usize> SimdExtract for T<N> {
+    type Value = i32;
+    fn extract(self) -> Self::Value {
+        self.0[2]
+    }
+}
+fn main() {
+    let t = T([5, 6, 7, 8]);
+    let _ = t.extract();
+}


### PR DESCRIPTION
Allow expressions like `self.0[2]` on simd types by permitting `field 0` as an intermediate projection step when followed by an index projection. standalone field access like `a.0` remains banned.

changes:
- `as_place.rs`: allow `field 0` through for simd, block all other fields
- `statement.rs`: teach `projection_ty_core` the element type of simd index
- `place.rs`: peel simd struct wrapper before computing codegen offsets
- `validate.rs`: ban field projections on simd unless followed by an index

Fixes rust-lang/rust#153636 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
