### PR TITLE
docs: remove C++ 'rvalue' terminology from transmute example

### DIFF
--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -823,7 +823,7 @@ pub const fn forget<T: ?Sized>(_: T);
 ///     unsafe {
 ///         let ptr = slice.as_mut_ptr();
 ///         // This now has three mutable references pointing at the same
-///         // memory. `slice`, the rvalue ret.0, and the rvalue ret.1.
+///         // memory: `slice`, and the two returned mutable slices.
 ///         // `slice` is never used after `let ptr = ...`, and so one can
 ///         // treat it as "dead", and therefore, you only have two real
 ///         // mutable slices.


### PR DESCRIPTION
Replace "the rvalue ret.0, and the rvalue ret.1" with clearer wording in the `split_at_stdlib` example in `transmute` docs. Rust does not use "rvalue" as a term, and the comment is easier to follow when it simply refers to the returned slices.

Fixes rust-lang/rust#153350