### PR TITLE
docs: document that Repeat::last and Repeat::count always panic

### DIFF
--- a/library/core/src/iter/sources/repeat.rs
+++ b/library/core/src/iter/sources/repeat.rs
@@ -101,11 +101,37 @@ impl<A: Clone> Iterator for Repeat<A> {
         Some(self.element.clone())
     }
 
+    /// Always panics because the iterator is infinite.
+    ///
+    /// # Panics
+    ///
+    /// Always panics. Since `Repeat` yields elements endlessly, there is no
+    /// last element to return.
+    ///
+    /// # Examples
+    ///
+    /// ```should_panic
+    /// use std::iter;
+    /// let _ = iter::repeat(5).last();
+    /// ```
     #[track_caller]
     fn last(self) -> Option<A> {
         panic!("iterator is infinite");
     }
 
+    /// Always panics because the iterator is infinite.
+    ///
+    /// # Panics
+    ///
+    /// Always panics. Since `Repeat` yields elements endlessly, there is no
+    /// finite count to return.
+    ///
+    /// # Examples
+    ///
+    /// ```should_panic
+    /// use std::iter;
+    /// let _ = iter::repeat(5).count();
+    /// ```
     #[track_caller]
     fn count(self) -> usize {
         panic!("iterator is infinite");


### PR DESCRIPTION
`Repeat::last` and `Repeat::count` were changed in 1.92 to panic instead of looping forever (rust-lang/rust#146410, rust-lang/rust#147258), but the panic was not documented on the `Repeat` impl. The trait-level docs for `Iterator::last` only say it "might" panic for infinite iterators — this adds doc comments on the `Repeat` overrides to clarify they always panic, with `should_panic` examples.

Fixes rust-lang/rust#149707