### PR TITLE
docs: mention include_str! workaround for standalone Markdown in rustdoc

### DIFF
--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -823,7 +823,7 @@ pub const fn forget<T: ?Sized>(_: T);
 ///     unsafe {
 ///         let ptr = slice.as_mut_ptr();
 ///         // This now has three mutable references pointing at the same
-///         // memory. `slice`, the rvalue ret.0, and the rvalue ret.1.
+///         // memory: `slice`, and the two returned mutable slices.
 ///         // `slice` is never used after `let ptr = ...`, and so one can
 ///         // treat it as "dead", and therefore, you only have two real
 ///         // mutable slices.

--- a/library/core/src/iter/sources/repeat.rs
+++ b/library/core/src/iter/sources/repeat.rs
@@ -101,11 +101,37 @@ impl<A: Clone> Iterator for Repeat<A> {
         Some(self.element.clone())
     }
 
+    /// Always panics because the iterator is infinite.
+    ///
+    /// # Panics
+    ///
+    /// Always panics. Since `Repeat` yields elements endlessly, there is no
+    /// last element to return.
+    ///
+    /// # Examples
+    ///
+    /// ```should_panic
+    /// use std::iter;
+    /// let _ = iter::repeat(5).last();
+    /// ```
     #[track_caller]
     fn last(self) -> Option<A> {
         panic!("iterator is infinite");
     }
 
+    /// Always panics because the iterator is infinite.
+    ///
+    /// # Panics
+    ///
+    /// Always panics. Since `Repeat` yields elements endlessly, there is no
+    /// finite count to return.
+    ///
+    /// # Examples
+    ///
+    /// ```should_panic
+    /// use std::iter;
+    /// let _ = iter::repeat(5).count();
+    /// ```
     #[track_caller]
     fn count(self) -> usize {
         panic!("iterator is infinite");

--- a/src/doc/rustdoc/src/what-is-rustdoc.md
+++ b/src/doc/rustdoc/src/what-is-rustdoc.md
@@ -159,6 +159,15 @@ You will find an HTML file in `docs/doc/README.html` generated from its
 Markdown contents.
 
 Cargo currently does not understand standalone Markdown files, unfortunately.
+However, you can include the contents of a Markdown file in your crate-level
+documentation by adding the following to `src/lib.rs`:
+
+```rust,ignore
+#![doc = include_str!("../README.md")]
+```
+
+This way, the contents of `README.md` will be used as the crate's top-level
+documentation when running `cargo doc`.
 
 ## Summary
 


### PR DESCRIPTION
The "What is rustdoc?" page notes that Cargo does not understand standalone Markdown files, but doesn't mention the common workaround. This adds a short note showing `#![doc = include_str!("../README.md")]` so users know how to include their README as crate-level documentation.

Fixes rust-lang/rust#148592