### PR TITLE
miri-test-libstd: use --tests and update some comments

### DIFF
--- a/library/alloctests/benches/lib.rs
+++ b/library/alloctests/benches/lib.rs
@@ -1,4 +1,4 @@
-// Disabling in Miri as these would take too long.
+// This is marked as `test = true` and hence picked up by `./x miri`, but that would be too slow.
 #![cfg(not(miri))]
 #![feature(iter_next_chunk)]
 #![feature(repr_simd)]

--- a/library/alloctests/benches/vec_deque_append.rs
+++ b/library/alloctests/benches/vec_deque_append.rs
@@ -6,11 +6,6 @@ const WARMUP_N: usize = 100;
 const BENCH_N: usize = 1000;
 
 fn main() {
-    if cfg!(miri) {
-        // Don't benchmark Miri...
-        // (Due to bootstrap quirks, this gets picked up by `x.py miri library/alloc --all-targets`.)
-        return;
-    }
     let a: VecDeque<i32> = (0..VECDEQUE_LEN).collect();
     let b: VecDeque<i32> = (0..VECDEQUE_LEN).collect();
 

--- a/library/coretests/benches/lib.rs
+++ b/library/coretests/benches/lib.rs
@@ -1,6 +1,6 @@
 // wasm32 does not support benches (no time).
 #![cfg(not(target_arch = "wasm32"))]
-// Disabling in Miri as these would take too long.
+// This is marked as `test = true` and hence picked up by `./x miri`, but that would be too slow.
 #![cfg(not(miri))]
 #![feature(flt2dec)]
 #![feature(test)]

--- a/library/std/benches/lib.rs
+++ b/library/std/benches/lib.rs
@@ -1,4 +1,4 @@
-// Disabling in Miri as these would take too long.
+// This is marked as `test = true` and hence picked up by `./x miri`, but that would be too slow.
 #![cfg(not(miri))]
 #![feature(test)]
 

--- a/library/std/benches/path.rs
+++ b/library/std/benches/path.rs
@@ -4,7 +4,6 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use std::path::*;
 
 #[bench]
-#[cfg_attr(miri, ignore)] // Miri isn't fast...
 fn bench_path_cmp_fast_path_buf_sort(b: &mut test::Bencher) {
     let prefix = "my/home";
     let mut paths: Vec<_> =
@@ -18,7 +17,6 @@ fn bench_path_cmp_fast_path_buf_sort(b: &mut test::Bencher) {
 }
 
 #[bench]
-#[cfg_attr(miri, ignore)] // Miri isn't fast...
 fn bench_path_cmp_fast_path_long(b: &mut test::Bencher) {
     let prefix = "/my/home/is/my/castle/and/my/castle/has/a/rusty/workbench/";
     let paths: Vec<_> =
@@ -37,7 +35,6 @@ fn bench_path_cmp_fast_path_long(b: &mut test::Bencher) {
 }
 
 #[bench]
-#[cfg_attr(miri, ignore)] // Miri isn't fast...
 fn bench_path_cmp_fast_path_short(b: &mut test::Bencher) {
     let prefix = "my/home";
     let paths: Vec<_> =
@@ -80,7 +77,6 @@ fn bench_path_file_name(b: &mut test::Bencher) {
 }
 
 #[bench]
-#[cfg_attr(miri, ignore)] // Miri isn't fast...
 fn bench_path_hashset(b: &mut test::Bencher) {
     let prefix = "/my/home/is/my/castle/and/my/castle/has/a/rusty/workbench/";
     let paths: Vec<_> =
@@ -99,7 +95,6 @@ fn bench_path_hashset(b: &mut test::Bencher) {
 }
 
 #[bench]
-#[cfg_attr(miri, ignore)] // Miri isn't fast...
 fn bench_path_hashset_miss(b: &mut test::Bencher) {
     let prefix = "/my/home/is/my/castle/and/my/castle/has/a/rusty/workbench/";
     let paths: Vec<_> =

--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -64,7 +64,7 @@ check-aux:
 		library/core \
 		library/alloc \
 		$(BOOTSTRAP_ARGS) \
-		--all-targets
+		--tests # exclude doc tests
 	# Some doctests use file system operations to demonstrate dealing with `Result`,
 	# so we have to run them with isolation disabled.
 	$(Q)MIRIFLAGS="-Zmiri-disable-isolation" \


### PR DESCRIPTION
rust-lang/rust#153143 added `./x test --tests` matching `cargo --tests`, which is exactly what Miri wants when testing the standard library. So let's use it for that. We can then also remove a hack in `library/alloctests/benches/vec_deque_append.rs`.

Also update the comment for why the other benchmarks still need to be disabled in Miri, and remove some `cfg_attr` that seem unnecessary since the entire crate that contains them is already disabled in Miri. Those were copied over in https://github.com/rust-lang/rust/commit/b8fa843a1a60146b93ca5b1d11bbe23c1b1076f3 -- they used to be needed since benches and tests were in the same crate, but they aren't any more.