### PR TITLE
Add optional CI job to build the compiler with the parallel frontend

### DIFF
--- a/src/ci/citool/src/jobs.rs
+++ b/src/ci/citool/src/jobs.rs
@@ -200,12 +200,14 @@ fn validate_job_database(db: &JobDatabase) -> anyhow::Result<()> {
         equivalent_modulo_carve_out(pr_job, auto_job)?;
     }
 
-    // Auto CI jobs must all "fail-fast" to avoid wasting Auto CI resources. For instance, `tidy`.
+    // Auto CI should "fail-fast" to avoid wasting Auto CI resources.
+    // However, some experimental auto jobs can be made optional, for example if we are unsure about
+    // their flakiness. Those have to be prefixed with `optional-`.
     for auto_job in &db.auto_jobs {
-        if auto_job.continue_on_error == Some(true) {
+        if auto_job.continue_on_error == Some(true) && !auto_job.name.starts_with("optional-") {
             return Err(anyhow!(
-                "Auto job `{}` cannot have `continue_on_error: true`",
-                auto_job.name
+                "Auto job `{job}` cannot have `continue_on_error: true`. If the job should be optional, name it `optional-{job}`.",
+                job = auto_job.name
             ));
         }
     }

--- a/src/ci/docker/host-x86_64/optional-x86_64-gnu-parallel-frontend/Dockerfile
+++ b/src/ci/docker/host-x86_64/optional-x86_64-gnu-parallel-frontend/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  g++ \
+  make \
+  ninja-build \
+  file \
+  curl \
+  ca-certificates \
+  python3 \
+  git \
+  cmake \
+  sudo \
+  gdb \
+  libssl-dev \
+  pkg-config \
+  xz-utils \
+  mingw-w64 \
+  zlib1g-dev \
+  libzstd-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
+ENV RUST_CONFIGURE_ARGS \
+ --build=x86_64-unknown-linux-gnu \
+ --enable-sanitizers \
+ --enable-profiler \
+ --enable-compiler-docs \
+ --set llvm.libzstd=true
+
+# Build the toolchain with multiple parallel frontend threads and then run tests
+# Tests are still compiled serially at the moment (intended to be changed in follow-ups).
+ENV SCRIPT python3 ../x.py --stage 2 test --set rust.parallel-frontend-threads=4

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -348,6 +348,11 @@ auto:
   - name: x86_64-gnu
     <<: *job-linux-4c
 
+  - name: optional-x86_64-gnu-parallel-frontend
+    # This test can be flaky, so do not cancel CI if it fails, for now.
+    continue_on_error: true
+    <<: *job-linux-4c
+
   - name: x86_64-gnu-gcc
     doc_url: https://rustc-dev-guide.rust-lang.org/tests/codegen-backend-tests/cg_gcc.html
     <<: *job-linux-4c

--- a/src/doc/rustc-dev-guide/src/tests/ci.md
+++ b/src/doc/rustc-dev-guide/src/tests/ci.md
@@ -109,6 +109,12 @@ The live results can be seen on [the GitHub Actions workflows page].
 At any given time, at most a single `auto` build is being executed.
 Find out more in [Merging PRs serially with bors](#merging-prs-serially-with-bors).
 
+Normally, when an auto job fails, the whole CI workflow immediately ends. However, it can be useful to
+create auto jobs that are "non-blocking", or optional, to test them on CI for some time before blocking
+merges on them. This can be useful if those jobs can be flaky.
+
+To do that, prefix such a job with `optional-`, and set `continue_on_error: true` for it in [`jobs.yml`]. 
+
 [platform tiers]: https://forge.rust-lang.org/release/platform-support.html#rust-platform-support
 [auto]: https://github.com/rust-lang/rust/tree/automation/bors/auto
 


### PR DESCRIPTION
Discussed on [Zulip](https://rust-lang.zulipchat.com/#narrow/channel/187679-t-compiler.2Fparallel-rustc/topic/Add.20the.20parallel.20front-end.20test.20suite/with/578684794).

Note: this only builds the compiler, stdlib, etc. with 2 threads. UI tests are still compiled serially. I'd add that in a follow-up PR if we see that this new job works well (and if optional auto jobs work well in the first place).

r? @jieyouxu