### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_abi/src/layout.rs
+++ b/compiler/rustc_abi/src/layout.rs
@@ -45,7 +45,7 @@ rustc_index::newtype_index! {
     /// `b` is `FieldIdx(1)` in `VariantIdx(0)`,
     /// `d` is `FieldIdx(1)` in `VariantIdx(1)`, and
     /// `f` is `FieldIdx(1)` in `VariantIdx(0)`.
-    #[cfg_attr(feature = "nightly", derive(rustc_macros::HashStable_Generic))]
+    #[stable_hash_generic]
     #[encodable]
     #[orderable]
     #[gate_rustc_only]
@@ -70,7 +70,7 @@ rustc_index::newtype_index! {
     ///
     /// `struct`s, `tuples`, and `unions`s are considered to have a single variant
     /// with variant index zero, aka [`FIRST_VARIANT`].
-    #[cfg_attr(feature = "nightly", derive(rustc_macros::HashStable_Generic))]
+    #[stable_hash_generic]
     #[encodable]
     #[orderable]
     #[gate_rustc_only]

--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -28,6 +28,8 @@
 #![feature(min_specialization)]
 #![feature(negative_impls)]
 #![feature(never_type)]
+#![feature(pattern_type_macro)]
+#![feature(pattern_types)]
 #![feature(ptr_alignment_type)]
 #![feature(rustc_attrs)]
 #![feature(sized_hierarchy)]

--- a/compiler/rustc_hir_analysis/src/delegation.rs
+++ b/compiler/rustc_hir_analysis/src/delegation.rs
@@ -597,31 +597,35 @@ fn get_delegation_user_specified_args<'tcx>(
             .as_slice()
     });
 
-    let child_args = info.child_args_segment_id.and_then(get_segment).map(|(segment, def_id)| {
-        let parent_args = if let Some(parent_args) = parent_args {
-            parent_args
-        } else {
-            let parent = tcx.parent(def_id);
-            if matches!(tcx.def_kind(parent), DefKind::Trait) {
-                ty::GenericArgs::identity_for_item(tcx, parent).as_slice()
+    let child_args = info
+        .child_args_segment_id
+        .and_then(get_segment)
+        .filter(|(_, def_id)| matches!(tcx.def_kind(*def_id), DefKind::Fn | DefKind::AssocFn))
+        .map(|(segment, def_id)| {
+            let parent_args = if let Some(parent_args) = parent_args {
+                parent_args
             } else {
-                &[]
-            }
-        };
+                let parent = tcx.parent(def_id);
+                if matches!(tcx.def_kind(parent), DefKind::Trait) {
+                    ty::GenericArgs::identity_for_item(tcx, parent).as_slice()
+                } else {
+                    &[]
+                }
+            };
 
-        let args = lowerer
-            .lower_generic_args_of_path(
-                segment.ident.span,
-                def_id,
-                parent_args,
-                segment,
-                None,
-                GenericArgPosition::Value,
-            )
-            .0;
+            let args = lowerer
+                .lower_generic_args_of_path(
+                    segment.ident.span,
+                    def_id,
+                    parent_args,
+                    segment,
+                    None,
+                    GenericArgPosition::Value,
+                )
+                .0;
 
-        &args[parent_args.len()..]
-    });
+            &args[parent_args.len()..]
+        });
 
     (parent_args.unwrap_or_default(), child_args.unwrap_or_default())
 }

--- a/compiler/rustc_hir_id/src/lib.rs
+++ b/compiler/rustc_hir_id/src/lib.rs
@@ -151,7 +151,7 @@ rustc_index::newtype_index! {
     /// integers starting at zero, so a mapping that maps all or most nodes within
     /// an "item-like" to something else can be implemented by a `Vec` instead of a
     /// tree or hash map.
-    #[derive(HashStable_Generic)]
+    #[stable_hash_generic]
     #[encodable]
     #[orderable]
     pub struct ItemLocalId {}

--- a/compiler/rustc_index_macros/src/lib.rs
+++ b/compiler/rustc_index_macros/src/lib.rs
@@ -34,7 +34,17 @@ mod newtype;
 ///   optimizations. The default max value is 0xFFFF_FF00.
 /// - `#[gate_rustc_only]`: makes parts of the generated code nightly-only.
 #[proc_macro]
-#[cfg_attr(feature = "nightly", allow_internal_unstable(step_trait, rustc_attrs, trusted_step))]
+#[cfg_attr(
+    feature = "nightly",
+    allow_internal_unstable(
+        step_trait,
+        rustc_attrs,
+        trusted_step,
+        pattern_types,
+        pattern_type_macro,
+        structural_match,
+    )
+)]
 pub fn newtype_index(input: TokenStream) -> TokenStream {
     newtype::newtype(input)
 }

--- a/compiler/rustc_middle/src/middle/region.rs
+++ b/compiler/rustc_middle/src/middle/region.rs
@@ -159,7 +159,7 @@ rustc_index::newtype_index! {
     ///
     /// * The subscope with `first_statement_index == 1` is scope of `c`,
     ///   and thus does not include EXPR_2, but covers the `...`.
-    #[derive(HashStable)]
+    #[stable_hash]
     #[encodable]
     #[orderable]
     pub struct FirstStatementIndex {}

--- a/compiler/rustc_middle/src/mir/coverage.rs
+++ b/compiler/rustc_middle/src/mir/coverage.rs
@@ -10,7 +10,7 @@ use rustc_span::Span;
 rustc_index::newtype_index! {
     /// Used by [`CoverageKind::BlockMarker`] to mark blocks during THIR-to-MIR
     /// lowering, so that those blocks can be identified later.
-    #[derive(HashStable)]
+    #[stable_hash]
     #[encodable]
     #[debug_format = "BlockMarkerId({})"]
     pub struct BlockMarkerId {}
@@ -26,7 +26,7 @@ rustc_index::newtype_index! {
     ///
     /// Note that LLVM handles counter IDs as `uint32_t`, so there is no need
     /// to use a larger representation on the Rust side.
-    #[derive(HashStable)]
+    #[stable_hash]
     #[encodable]
     #[orderable]
     #[debug_format = "CounterId({})"]
@@ -43,7 +43,7 @@ rustc_index::newtype_index! {
     ///
     /// Note that LLVM handles expression IDs as `uint32_t`, so there is no need
     /// to use a larger representation on the Rust side.
-    #[derive(HashStable)]
+    #[stable_hash]
     #[encodable]
     #[orderable]
     #[debug_format = "ExpressionId({})"]
@@ -203,7 +203,7 @@ rustc_index::newtype_index! {
     ///
     /// After that pass is complete, the coverage graph no longer exists, so a
     /// BCB is effectively an opaque ID.
-    #[derive(HashStable)]
+    #[stable_hash]
     #[encodable]
     #[orderable]
     #[debug_format = "bcb{}"]

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -840,7 +840,7 @@ impl SourceInfo {
 // Variables and temps
 
 rustc_index::newtype_index! {
-    #[derive(HashStable)]
+    #[stable_hash]
     #[encodable]
     #[orderable]
     #[debug_format = "_{}"]
@@ -1264,7 +1264,7 @@ rustc_index::newtype_index! {
     ///     https://rustc-dev-guide.rust-lang.org/appendix/background.html#what-is-a-dataflow-analysis
     /// [`CriticalCallEdges`]: ../../rustc_mir_transform/add_call_guards/enum.AddCallGuards.html#variant.CriticalCallEdges
     /// [guide-mir]: https://rustc-dev-guide.rust-lang.org/mir/
-    #[derive(HashStable)]
+    #[stable_hash]
     #[encodable]
     #[orderable]
     #[debug_format = "bb{}"]
@@ -1398,7 +1398,7 @@ impl<'tcx> BasicBlockData<'tcx> {
 // Scopes
 
 rustc_index::newtype_index! {
-    #[derive(HashStable)]
+    #[stable_hash]
     #[encodable]
     #[debug_format = "scope[{}]"]
     pub struct SourceScope {
@@ -1537,7 +1537,7 @@ pub struct UserTypeProjection {
 }
 
 rustc_index::newtype_index! {
-    #[derive(HashStable)]
+    #[stable_hash]
     #[encodable]
     #[orderable]
     #[debug_format = "promoted[{}]"]

--- a/compiler/rustc_middle/src/mir/query.rs
+++ b/compiler/rustc_middle/src/mir/query.rs
@@ -13,7 +13,7 @@ use super::{ConstValue, SourceInfo};
 use crate::ty::{self, CoroutineArgsExt, Ty};
 
 rustc_index::newtype_index! {
-    #[derive(HashStable)]
+    #[stable_hash]
     #[encodable]
     #[debug_format = "_s{}"]
     pub struct CoroutineSavedLocal {}

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -44,7 +44,7 @@ macro_rules! thir_with_elements {
     ) => {
         $(
             newtype_index! {
-                #[derive(HashStable)]
+                #[stable_hash]
                 #[debug_format = $format]
                 pub struct $id {}
             }

--- a/compiler/rustc_middle/src/ty/typeck_results.rs
+++ b/compiler/rustc_middle/src/ty/typeck_results.rs
@@ -716,7 +716,7 @@ impl<'a> LocalSetInContextMut<'a> {
 }
 
 rustc_index::newtype_index! {
-    #[derive(HashStable)]
+    #[stable_hash]
     #[encodable]
     #[debug_format = "UserType({})"]
     pub struct UserTypeAnnotationIndex {

--- a/compiler/rustc_mir_transform/src/jump_threading.rs
+++ b/compiler/rustc_mir_transform/src/jump_threading.rs
@@ -161,7 +161,7 @@ struct TOFinder<'a, 'tcx> {
 }
 
 rustc_index::newtype_index! {
-    #[derive(Ord, PartialOrd)]
+    #[orderable]
     #[debug_format = "_c{}"]
     struct ConditionIndex {}
 }

--- a/compiler/rustc_monomorphize/src/graph_checks/statics.rs
+++ b/compiler/rustc_monomorphize/src/graph_checks/statics.rs
@@ -30,7 +30,7 @@ impl From<usize> for StaticNodeIdx {
 }
 
 newtype_index! {
-    #[derive(Ord, PartialOrd)]
+    #[orderable]
     struct StaticSccIdx {}
 }
 

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -123,7 +123,7 @@ rustc_index::newtype_index! {
     /// is the outer fn.
     ///
     /// [dbi]: https://en.wikipedia.org/wiki/De_Bruijn_index
-    #[cfg_attr(feature = "nightly", derive(HashStable_NoContext))]
+    #[stable_hash_no_context]
     #[encodable]
     #[orderable]
     #[debug_format = "DebruijnIndex({})"]
@@ -333,7 +333,7 @@ rustc_index::newtype_index! {
     /// declared, but a type name in a non-zero universe is a placeholder
     /// type -- an idealized representative of "types in general" that we
     /// use for checking generic functions.
-    #[cfg_attr(feature = "nightly", derive(HashStable_NoContext))]
+    #[stable_hash_no_context]
     #[encodable]
     #[orderable]
     #[debug_format = "U{}"]
@@ -388,7 +388,7 @@ impl Default for UniverseIndex {
 }
 
 rustc_index::newtype_index! {
-    #[cfg_attr(feature = "nightly", derive(HashStable_NoContext))]
+    #[stable_hash_generic]
     #[encodable]
     #[orderable]
     #[debug_format = "{}"]

--- a/compiler/rustc_type_ir/src/region_kind.rs
+++ b/compiler/rustc_type_ir/src/region_kind.rs
@@ -4,7 +4,7 @@ use derive_where::derive_where;
 #[cfg(feature = "nightly")]
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 #[cfg(feature = "nightly")]
-use rustc_macros::{Decodable_NoContext, Encodable_NoContext, HashStable_NoContext};
+use rustc_macros::{Decodable_NoContext, Encodable_NoContext};
 use rustc_type_ir_macros::GenericTypeVisitable;
 
 use self::RegionKind::*;
@@ -16,7 +16,7 @@ rustc_index::newtype_index! {
     #[orderable]
     #[debug_format = "'?{}"]
     #[gate_rustc_only]
-    #[cfg_attr(feature = "nightly", derive(HashStable_NoContext))]
+    #[stable_hash_no_context]
     pub struct RegionVid {}
 }
 

--- a/library/alloctests/benches/lib.rs
+++ b/library/alloctests/benches/lib.rs
@@ -1,4 +1,4 @@
-// Disabling in Miri as these would take too long.
+// This is marked as `test = true` and hence picked up by `./x miri`, but that would be too slow.
 #![cfg(not(miri))]
 #![feature(iter_next_chunk)]
 #![feature(repr_simd)]

--- a/library/alloctests/benches/vec_deque_append.rs
+++ b/library/alloctests/benches/vec_deque_append.rs
@@ -6,11 +6,6 @@ const WARMUP_N: usize = 100;
 const BENCH_N: usize = 1000;
 
 fn main() {
-    if cfg!(miri) {
-        // Don't benchmark Miri...
-        // (Due to bootstrap quirks, this gets picked up by `x.py miri library/alloc --all-targets`.)
-        return;
-    }
     let a: VecDeque<i32> = (0..VECDEQUE_LEN).collect();
     let b: VecDeque<i32> = (0..VECDEQUE_LEN).collect();
 

--- a/library/coretests/benches/lib.rs
+++ b/library/coretests/benches/lib.rs
@@ -1,6 +1,6 @@
 // wasm32 does not support benches (no time).
 #![cfg(not(target_arch = "wasm32"))]
-// Disabling in Miri as these would take too long.
+// This is marked as `test = true` and hence picked up by `./x miri`, but that would be too slow.
 #![cfg(not(miri))]
 #![feature(flt2dec)]
 #![feature(test)]

--- a/library/std/benches/lib.rs
+++ b/library/std/benches/lib.rs
@@ -1,4 +1,4 @@
-// Disabling in Miri as these would take too long.
+// This is marked as `test = true` and hence picked up by `./x miri`, but that would be too slow.
 #![cfg(not(miri))]
 #![feature(test)]
 

--- a/library/std/benches/path.rs
+++ b/library/std/benches/path.rs
@@ -4,7 +4,6 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use std::path::*;
 
 #[bench]
-#[cfg_attr(miri, ignore)] // Miri isn't fast...
 fn bench_path_cmp_fast_path_buf_sort(b: &mut test::Bencher) {
     let prefix = "my/home";
     let mut paths: Vec<_> =
@@ -18,7 +17,6 @@ fn bench_path_cmp_fast_path_buf_sort(b: &mut test::Bencher) {
 }
 
 #[bench]
-#[cfg_attr(miri, ignore)] // Miri isn't fast...
 fn bench_path_cmp_fast_path_long(b: &mut test::Bencher) {
     let prefix = "/my/home/is/my/castle/and/my/castle/has/a/rusty/workbench/";
     let paths: Vec<_> =
@@ -37,7 +35,6 @@ fn bench_path_cmp_fast_path_long(b: &mut test::Bencher) {
 }
 
 #[bench]
-#[cfg_attr(miri, ignore)] // Miri isn't fast...
 fn bench_path_cmp_fast_path_short(b: &mut test::Bencher) {
     let prefix = "my/home";
     let paths: Vec<_> =
@@ -80,7 +77,6 @@ fn bench_path_file_name(b: &mut test::Bencher) {
 }
 
 #[bench]
-#[cfg_attr(miri, ignore)] // Miri isn't fast...
 fn bench_path_hashset(b: &mut test::Bencher) {
     let prefix = "/my/home/is/my/castle/and/my/castle/has/a/rusty/workbench/";
     let paths: Vec<_> =
@@ -99,7 +95,6 @@ fn bench_path_hashset(b: &mut test::Bencher) {
 }
 
 #[bench]
-#[cfg_attr(miri, ignore)] // Miri isn't fast...
 fn bench_path_hashset_miss(b: &mut test::Bencher) {
     let prefix = "/my/home/is/my/castle/and/my/castle/has/a/rusty/workbench/";
     let paths: Vec<_> =

--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -64,7 +64,7 @@ check-aux:
 		library/core \
 		library/alloc \
 		$(BOOTSTRAP_ARGS) \
-		--all-targets
+		--tests # exclude doc tests
 	# Some doctests use file system operations to demonstrate dealing with `Result`,
 	# so we have to run them with isolation disabled.
 	$(Q)MIRIFLAGS="-Zmiri-disable-isolation" \

--- a/tests/ui/delegation/reuse-trait-path-with-empty-generics.rs
+++ b/tests/ui/delegation/reuse-trait-path-with-empty-generics.rs
@@ -1,0 +1,14 @@
+//@ needs-rustc-debug-assertions
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+trait Trait {
+    fn bar4();
+}
+
+impl Trait for () {
+    reuse Trait::<> as bar4;
+    //~^ ERROR expected function, found trait `Trait`
+}
+
+fn main() {}

--- a/tests/ui/delegation/reuse-trait-path-with-empty-generics.stderr
+++ b/tests/ui/delegation/reuse-trait-path-with-empty-generics.stderr
@@ -1,0 +1,9 @@
+error[E0423]: expected function, found trait `Trait`
+  --> $DIR/reuse-trait-path-with-empty-generics.rs:10:11
+   |
+LL |     reuse Trait::<> as bar4;
+   |           ^^^^^^^^^ not a function
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0423`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#152569 (Stop using rustc_layout_scalar_valid_range_* in rustc)
 - rust-lang/rust#153421 (Fix ICE in fn_delegation when child segment resolves to a trait)
 - rust-lang/rust#153722 (miri-test-libstd: use --tests and update some comments)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=152569,153421,153722)
<!-- homu-ignore:end -->

