### PR TITLE
add test that an incomplete feature emits a warning

### DIFF
--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -257,6 +257,8 @@ declare_features! (
     (internal, rustc_attrs, "1.0.0", None),
     /// Allows using the `#[stable]` and `#[unstable]` attributes.
     (internal, staged_api, "1.0.0", None),
+    /// Perma-unstable, only used to test the `incomplete_features` lint.
+    (incomplete, test_incomplete_feature, "CURRENT_RUSTC_VERSION", None),
     /// Added for testing unstable lints; perma-unstable.
     (internal, test_unstable_lint, "1.60.0", None),
     /// Use for stable + negative coherence and strict coherence depending on trait's

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2005,6 +2005,7 @@ symbols! {
         test_2018_feature,
         test_accepted_feature,
         test_case,
+        test_incomplete_feature,
         test_removed_feature,
         test_runner,
         test_unstable_lint,

--- a/tests/ui/feature-gates/incomplete-features.rs
+++ b/tests/ui/feature-gates/incomplete-features.rs
@@ -1,0 +1,13 @@
+//! Make sure that incomplete features emit the `incomplete_features` lint.
+
+// gate-test-test_incomplete_feature
+
+//@ check-pass
+//@ revisions: warn expect
+
+#![cfg_attr(warn, warn(incomplete_features))]
+#![cfg_attr(expect, expect(incomplete_features))]
+
+#![feature(test_incomplete_feature)] //[warn]~ WARN the feature `test_incomplete_feature` is incomplete
+
+fn main() {}

--- a/tests/ui/feature-gates/incomplete-features.warn.stderr
+++ b/tests/ui/feature-gates/incomplete-features.warn.stderr
@@ -1,0 +1,14 @@
+warning: the feature `test_incomplete_feature` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/incomplete-features.rs:11:12
+   |
+LL | #![feature(test_incomplete_feature)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/incomplete-features.rs:8:24
+   |
+LL | #![cfg_attr(warn, warn(incomplete_features))]
+   |                        ^^^^^^^^^^^^^^^^^^^
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Related to https://github.com/rust-lang/compiler-team/issues/974, this PR adds a new test to specifically check that a dummy incomplete feature triggers the `incomplete_features` lint. (since this seemed to be the favored approach on Zulip)

Alternative to https://github.com/rust-lang/rust/pull/153706.

r? fmease