### PR TITLE
Don't look for non-type-level assoc consts when checking trait object types

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs
@@ -230,8 +230,9 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                         ordered_associated_items.extend(
                             tcx.associated_items(pred.trait_ref.def_id)
                                 .in_definition_order()
-                                // Only associated types & consts can possibly be constrained via a binding.
-                                .filter(|item| item.is_type() || item.is_const())
+                                // Only associated types & type consts can possibly be
+                                // constrained in a trait object type via a binding.
+                                .filter(|item| item.is_type() || item.is_type_const())
                                 // Traits with RPITITs are simply not dyn compatible (for now).
                                 .filter(|item| !item.is_impl_trait_in_trait())
                                 .map(|item| (item.def_id, trait_ref)),

--- a/compiler/rustc_middle/src/ty/assoc.rs
+++ b/compiler/rustc_middle/src/ty/assoc.rs
@@ -137,8 +137,8 @@ impl AssocItem {
         self.kind.as_def_kind()
     }
 
-    pub fn is_const(&self) -> bool {
-        matches!(self.kind, ty::AssocKind::Const { .. })
+    pub fn is_type_const(&self) -> bool {
+        matches!(self.kind, ty::AssocKind::Const { is_type_const: true, .. })
     }
 
     pub fn is_fn(&self) -> bool {

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -753,7 +753,7 @@ impl<'tcx> Ty<'tcx> {
                     .map(|principal| {
                         tcx.associated_items(principal.def_id())
                             .in_definition_order()
-                            .filter(|item| item.is_type() || item.is_const())
+                            .filter(|item| item.is_type() || item.is_type_const())
                             .filter(|item| !item.is_impl_trait_in_trait())
                             .filter(|item| !tcx.generics_require_sized_self(item.def_id))
                             .count()

--- a/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
+++ b/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
@@ -239,7 +239,7 @@ fn trait_object_ty<'tcx>(tcx: TyCtxt<'tcx>, poly_trait_ref: ty::PolyTraitRef<'tc
         .flat_map(|super_poly_trait_ref| {
             tcx.associated_items(super_poly_trait_ref.def_id())
                 .in_definition_order()
-                .filter(|item| item.is_type() || item.is_const())
+                .filter(|item| item.is_type() || item.is_type_const())
                 .filter(|item| !tcx.generics_require_sized_self(item.def_id))
                 .map(move |assoc_item| {
                     super_poly_trait_ref.map_bound(|super_trait_ref| {

--- a/tests/ui/associated-consts/associated-const-in-trait.rs
+++ b/tests/ui/associated-consts/associated-const-in-trait.rs
@@ -7,6 +7,8 @@ trait Trait {
 impl dyn Trait {
     //~^ ERROR the trait `Trait` is not dyn compatible [E0038]
     const fn n() -> usize { Self::N }
+    //~^ ERROR the trait `Trait` is not dyn compatible [E0038]
+    //~| ERROR the trait `Trait` is not dyn compatible [E0038]
 }
 
 fn main() {}

--- a/tests/ui/associated-consts/associated-const-in-trait.stderr
+++ b/tests/ui/associated-consts/associated-const-in-trait.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Trait` is not dyn compatible
-  --> $DIR/associated-const-in-trait.rs:7:10
+  --> $DIR/associated-const-in-trait.rs:7:6
    |
 LL | impl dyn Trait {
-   |          ^^^^^ `Trait` is not dyn compatible
+   |      ^^^^^^^^^ `Trait` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
@@ -14,6 +14,38 @@ LL |     const N: usize;
    |           ^ ...because it contains associated const `N`
    = help: consider moving `N` to another trait
 
-error: aborting due to 1 previous error
+error[E0038]: the trait `Trait` is not dyn compatible
+  --> $DIR/associated-const-in-trait.rs:9:29
+   |
+LL |     const fn n() -> usize { Self::N }
+   |                             ^^^^ `Trait` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/associated-const-in-trait.rs:4:11
+   |
+LL | trait Trait {
+   |       ----- this trait is not dyn compatible...
+LL |     const N: usize;
+   |           ^ ...because it contains associated const `N`
+   = help: consider moving `N` to another trait
+
+error[E0038]: the trait `Trait` is not dyn compatible
+  --> $DIR/associated-const-in-trait.rs:9:29
+   |
+LL |     const fn n() -> usize { Self::N }
+   |                             ^^^^^^^ `Trait` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/associated-const-in-trait.rs:4:11
+   |
+LL | trait Trait {
+   |       ----- this trait is not dyn compatible...
+LL |     const N: usize;
+   |           ^ ...because it contains associated const `N`
+   = help: consider moving `N` to another trait
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/associated-item/issue-48027.stderr
+++ b/tests/ui/associated-item/issue-48027.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Bar` is not dyn compatible
-  --> $DIR/issue-48027.rs:6:10
+  --> $DIR/issue-48027.rs:6:6
    |
 LL | impl dyn Bar {}
-   |          ^^^ `Bar` is not dyn compatible
+   |      ^^^^^^^ `Bar` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/dyn-compatibility/associated-consts.stderr
+++ b/tests/ui/dyn-compatibility/associated-consts.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Bar` is not dyn compatible
-  --> $DIR/associated-consts.rs:8:35
+  --> $DIR/associated-consts.rs:8:31
    |
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
-   |                                   ^^^ `Bar` is not dyn compatible
+   |                               ^^^^^^^ `Bar` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/type-alias/lack-of-wfcheck.rs
+++ b/tests/ui/type-alias/lack-of-wfcheck.rs
@@ -1,0 +1,27 @@
+// Demonstrate that we don't check the definition site of (eager) type aliases for well-formedness.
+//
+// Listed below are ill-formed type system entities which we don't reject since they appear inside
+// the definition of (eager) type aliases. These type aliases are intentionally not referenced from
+// anywhere to prevent the eagerly expanded / instantiated aliased types from getting wfchecked
+// since that's not what we're testing here.
+
+//@ check-pass
+
+type UnsatTraitBound0 = [str]; // `str: Sized` unsatisfied
+type UnsatTraitBound1<T = Vec<str>> = T; // `str: Sized` unsatisfied
+type UnsatOutlivesBound<'a> = &'static &'a (); // `'a: 'static` unsatisfied
+
+type Diverging = [(); panic!()]; // `panic!()` diverging
+
+type DynIncompat0 = dyn Sized; // `Sized` axiomatically dyn incompatible
+// issue: <https://github.com/rust-lang/rust/issues/153731>
+type DynIncompat1 = dyn HasAssocConst; // dyn incompatible due to (non-type-level) assoc const
+
+// * dyn incompatible due to GAT
+// * `'a: 'static`, `String: Copy` and `[u8]: Sized` unsatisfied, `loop {}` diverging
+type Several<'a> = dyn HasGenericAssocType<Type<'a, String, { loop {} }> = [u8]>;
+
+trait HasAssocConst { const N: usize; }
+trait HasGenericAssocType { type Type<'a: 'static, T: Copy, const N: usize>; }
+
+fn main() {}

--- a/tests/ui/wf/issue-87495.stderr
+++ b/tests/ui/wf/issue-87495.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `T` is not dyn compatible
-  --> $DIR/issue-87495.rs:4:29
+  --> $DIR/issue-87495.rs:4:25
    |
 LL |     const CONST: (bool, dyn T);
-   |                             ^ `T` is not dyn compatible
+   |                         ^^^^^ `T` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
@@ -13,6 +13,11 @@ LL | trait T {
 LL |     const CONST: (bool, dyn T);
    |           ^^^^^ ...because it contains associated const `CONST`
    = help: consider moving `CONST` to another trait
+help: you might have meant to use `Self` to refer to the implementing type
+   |
+LL -     const CONST: (bool, dyn T);
+LL +     const CONST: (bool, Self);
+   |
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
On main, when looking for assoc items that weren't specified in a given trait object type (via binding), we comb through all (eligible) assoc consts whether type-level or not even though you're not allowed to bind non-type-level assoc consts.

That's usually fine because traits containing (eligible) non-type-level assoc consts are dyn incompatible, so the trait object type is ~already considered ill-formed. Therefore, in PR rust-lang/rust#150843, I saved myself the extra effort, esp. since back then it was more annoying to check if the const item was declared type-level.

<sub>(More concretely: In bodies, we check for all dyn compatibility violations when lowering the trait object type, so we will bail out early with an error; in contrast, item signatures / non-bodies get wfchecked (`WellFormed` obligation) after lowering which includes dyn compatiblity checking (`DynCompatible` obligation); however to reduce the amount of diags, during lowering if there are any unspecified assoc items, we'll check them for dyn compatibility and bail out early if any of them tests negative.)</sub>

Now, we obviously don't wfcheck the defsite of (eager) type aliases which breaks the assumption that such trait object types get rejected. This led to the regression found in rust-lang/rust#153731: The ill-formed trait object type doesn't get rejected (as is expected) but we now require the single (non-type-level) assoc const to be bound in the dyn-Trait which we didn't do before. The actual error talks about dyn incompatibility due to the aforementioned extra check that's usually there to contain the number of diags.

Fixes [after beta backport] rust-lang/rust#153731.

