### PR TITLE
rustdoc: add emoji icons for unstable and deprecated to search results

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1450,6 +1450,9 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	grid-area: search-result-type-signature;
 	white-space: pre-wrap;
 }
+.search-results .result-name > span.emoji {
+	padding-right: 0.5em;
+}
 
 .popover {
 	position: absolute;

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -4960,6 +4960,16 @@ async function addTab(results, query, display, finishedCallback, isTypeSearch) {
 <b>${obj.alias}</b><i class="grey">&nbsp;- see&nbsp;</i>\
 </div>`;
         }
+        if (obj.item.deprecated) {
+            resultName.insertAdjacentHTML(
+                "beforeend",
+                "<span class=emoji title=\"this item is deprecated\">👎</span>");
+        }
+        if (obj.item.unstable) {
+            resultName.insertAdjacentHTML(
+                "beforeend",
+                "<span class=emoji title=\"this item is unstable\">🔬</span>");
+        }
         resultName.insertAdjacentHTML(
             "beforeend",
             `<div class="path">${alias}\

--- a/tests/rustdoc-gui/search-result-unstable-deprecated.goml
+++ b/tests/rustdoc-gui/search-result-unstable-deprecated.goml
@@ -1,0 +1,9 @@
+// Check that the emoji indicators for unstable and deprecated search results are present.
+include: "utils.goml"
+go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
+call-function: ("perform-search", {"query": "replaced_function"})
+assert-text: ('.search-results [href="../test_docs/fn.replaced_function.html"]
+  > span.result-name > span.emoji[title="this item is deprecated', '👎')
+call-function: ("perform-search", {"query": "NewFoo"})
+assert-text: ('.search-results [href="../staged_api/struct.NewFoo.html"]
+  > span.result-name > span.emoji[title="this item is unstable', '🔬')

--- a/tests/rustdoc-gui/search-tab.goml
+++ b/tests/rustdoc-gui/search-tab.goml
@@ -79,7 +79,7 @@ call-function: ("check-colors", {
 set-window-size: (851, 600)
 
 // Check the size and count in tabs
-assert-text: ("#search-tabs > button:nth-child(1) > .count", " (25) ")
+assert-text: ("#search-tabs > button:nth-child(1) > .count", " (26) ")
 assert-text: ("#search-tabs > button:nth-child(2) > .count", " (7)  ")
 assert-text: ("#search-tabs > button:nth-child(3) > .count", " (0)  ")
 store-property: ("#search-tabs > button:nth-child(1)", {"offsetWidth": buttonWidth})

--- a/tests/rustdoc-gui/src/staged_api/lib.rs
+++ b/tests/rustdoc-gui/src/staged_api/lib.rs
@@ -21,3 +21,6 @@ impl Foo {
 impl X for Foo {
     fn vroum() {}
 }
+
+#[unstable(feature = "some_new_feature", issue = "none")]
+pub struct NewFoo {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

fixes rust-lang/rust#149943

r? @GuillaumeGomez 