### PR TITLE
editorconfig: css uses tabs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,9 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
+[*.css]
+indent_style = tab
+
 # some tests need trailing whitespace in output snapshots
 [tests/**]
 trim_trailing_whitespace = false


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Tidy enforces the fact that css files use tabs, but currently `.editorconfig` says everything that isn't llvm or a Makefile should always use spaces.  This PR makes it so all editors that honor `.editorconfig` will use the correct indentation for css files.