### PR TITLE
Account for ownership mismatch on argument that doesn't meet bound

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -1653,6 +1653,44 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let imm_ref_self_ty_satisfies_pred = mk_result(trait_pred_and_imm_ref);
         let mut_ref_self_ty_satisfies_pred = mk_result(trait_pred_and_mut_ref);
 
+        let mut point_at_relevant_args =
+            |pred_ty: Ty<'tcx>, args_and_inputs: Vec<(hir::Expr<'_>, Ty<'tcx>)>| {
+                let Some(typeck_results) = &self.typeck_results else { return false };
+
+                let erased_self_ty =
+                    self.tcx.instantiate_bound_regions_with_erased(poly_trait_pred.self_ty());
+                let mut spans = vec![];
+                for (arg, input) in args_and_inputs {
+                    let Some(arg_ty) = typeck_results.expr_ty_adjusted_opt(&arg) else { continue };
+                    let pred_has_arg_type = self.infcx.can_eq(param_env, arg_ty, erased_self_ty);
+                    let arg_is_type_param = self.infcx.can_eq(param_env, pred_ty, input);
+                    if pred_has_arg_type && arg_is_type_param {
+                        err.span_label(
+                            arg.span,
+                            format!("`{arg_ty}` doesn't satisfy the trait bound"),
+                        );
+                        spans.push(arg.span);
+                    }
+                }
+                let this = pluralize!("this", spans.len());
+                if !spans.is_empty() {
+                    if imm_ref_self_ty_satisfies_pred {
+                        err.multipart_suggestion(
+                            format!("consider borrowing {this} argument"),
+                            spans.iter().map(|sp| (sp.shrink_to_lo(), "&".into())).collect(),
+                            Applicability::MaybeIncorrect,
+                        );
+                    }
+                    if mut_ref_self_ty_satisfies_pred {
+                        err.multipart_suggestion(
+                            format!("consider mutably borrowing {this} argument"),
+                            spans.iter().map(|sp| (sp.shrink_to_lo(), "&mut ".into())).collect(),
+                            Applicability::MaybeIncorrect,
+                        );
+                    }
+                }
+                !spans.is_empty()
+            };
         let code = match obligation.cause.code() {
             ObligationCauseCode::FunctionArg { parent_code, .. } => parent_code,
             // FIXME(compiler-errors): This is kind of a mess, but required for obligations
@@ -1726,12 +1764,11 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         // If we didn't return early here, we would instead suggest `&&str::from("")`.
                         return false;
                     } else if let hir::ExprKind::Call(_, args) = expr.kind {
-                        if let Some(typeck_results) = &self.typeck_results
-                            && let Some(pred) = self
+                        if let Some(pred) = self
                                 .tcx
-                                .predicates_of(*def_id)
+                                .clauses_of(*def_id)
                                 .instantiate_identity(self.tcx)
-                                .predicates
+                                .clauses
                                 .into_iter()
                                 .nth(*idx)
                             && let Some(pred) = pred.as_trait_clause()
@@ -1745,48 +1782,13 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                             let fn_sig = self.tcx.instantiate_bound_regions_with_erased(
                                 self.tcx.fn_sig(*def_id).instantiate_identity().skip_norm_wip(),
                             );
-
-                            let mut spans = vec![];
-                            for (arg, input) in args.into_iter().zip(fn_sig.inputs()) {
-                                if let Some(arg_ty) = typeck_results.expr_ty_adjusted_opt(arg) {
-                                    let ty = self.tcx.instantiate_bound_regions_with_erased(
-                                        poly_trait_pred.self_ty(),
-                                    );
-                                    let pred_has_arg_type =
-                                        self.infcx.can_eq(param_env, arg_ty, ty);
-                                    let arg_is_type_param =
-                                        self.infcx.can_eq(param_env, pred_ty, *input);
-                                    if pred_has_arg_type && arg_is_type_param {
-                                        err.span_label(
-                                            arg.span,
-                                            format!("`{arg_ty}` doesn't satisfy the trait bound"),
-                                        );
-                                        spans.push(arg.span);
-                                    }
-                                }
-                            }
-                            let this = pluralize!("this", spans.len());
-                            if !spans.is_empty() {
-                                if imm_ref_self_ty_satisfies_pred {
-                                    err.multipart_suggestion(
-                                        format!("consider borrowing {this} argument"),
-                                        spans
-                                            .iter()
-                                            .map(|sp| (sp.shrink_to_lo(), "&".into()))
-                                            .collect(),
-                                        Applicability::MaybeIncorrect,
-                                    );
-                                }
-                                if mut_ref_self_ty_satisfies_pred {
-                                    err.multipart_suggestion(
-                                        format!("consider mutably borrowing {this} argument"),
-                                        spans
-                                            .iter()
-                                            .map(|sp| (sp.shrink_to_lo(), "&mut ".into()))
-                                            .collect(),
-                                        Applicability::MaybeIncorrect,
-                                    );
-                                }
+                            if point_at_relevant_args(
+                                pred_ty,
+                                args.into_iter()
+                                    .zip(fn_sig.inputs())
+                                    .map(|(e, t)| (*e, *t))
+                                    .collect(),
+                            ) {
                                 return false;
                             }
                         }
@@ -1794,15 +1796,14 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 }
                 c
             }
-            ObligationCauseCode::WhereClauseInExpr(def_id, _, hir_id, idx)
+            c @ ObligationCauseCode::WhereClauseInExpr(def_id, _, hir_id, idx)
                 if let hir::Node::Expr(expr) = self.tcx.hir_node(*hir_id)
                     && let hir::ExprKind::MethodCall(_segment, rcvr, args, ..) = expr.kind
-                    && let Some(typeck_results) = &self.typeck_results
                     && let Some(pred) = self
                         .tcx
-                        .predicates_of(*def_id)
+                        .clauses_of(*def_id)
                         .instantiate_identity(self.tcx)
-                        .predicates
+                        .clauses
                         .into_iter()
                         .nth(*idx)
                     && let Some(pred) = pred.as_trait_clause()
@@ -1810,47 +1811,24 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     // `instantiate_bound_regions_with_erased`. Avoid suggesting for now.
                     && !self.tcx.features().non_lifetime_binders() =>
             {
-                // We've got a method call where likely one of the arguments didn't meet a bound.
-                let pred_ty =
-                    self.tcx.instantiate_bound_regions_with_erased(pred.self_ty().skip_norm_wip());
                 let fn_sig = self.tcx.instantiate_bound_regions_with_erased(
                     self.tcx.fn_sig(*def_id).instantiate_identity().skip_norm_wip(),
                 );
-
-                let mut spans = vec![];
-                for (arg, input) in [rcvr].into_iter().chain(args.into_iter()).zip(fn_sig.inputs())
-                {
-                    let Some(arg_ty) = typeck_results.expr_ty_adjusted_opt(arg) else { continue };
-                    let ty =
-                        self.tcx.instantiate_bound_regions_with_erased(poly_trait_pred.self_ty());
-                    let pred_has_arg_type = self.infcx.can_eq(param_env, arg_ty, ty);
-                    let arg_is_type_param = self.infcx.can_eq(param_env, pred_ty, *input);
-                    if pred_has_arg_type && arg_is_type_param {
-                        err.span_label(
-                            arg.span,
-                            format!("`{arg_ty}` doesn't satisfy the trait bound"),
-                        );
-                        spans.push(arg.span);
-                    }
+                // We've got a method call where likely one of the arguments didn't meet a bound.
+                let pred_ty =
+                    self.tcx.instantiate_bound_regions_with_erased(pred.self_ty().skip_norm_wip());
+                if point_at_relevant_args(
+                    pred_ty,
+                    [rcvr]
+                        .into_iter()
+                        .chain(args.into_iter())
+                        .zip(fn_sig.inputs())
+                        .map(|(e, t)| (*e, *t))
+                        .collect(),
+                ) {
+                    return false;
                 }
-                let this = pluralize!("this", spans.len());
-                if !spans.is_empty() {
-                    if imm_ref_self_ty_satisfies_pred {
-                        err.multipart_suggestion(
-                            format!("consider borrowing {this} argument"),
-                            spans.iter().map(|sp| (sp.shrink_to_lo(), "&".into())).collect(),
-                            Applicability::MaybeIncorrect,
-                        );
-                    }
-                    if mut_ref_self_ty_satisfies_pred {
-                        err.multipart_suggestion(
-                            format!("consider mutably borrowing {this} argument"),
-                            spans.iter().map(|sp| (sp.shrink_to_lo(), "&mut ".into())).collect(),
-                            Applicability::MaybeIncorrect,
-                        );
-                    }
-                }
-                return false;
+                c
             }
             c if matches!(
                 span.ctxt().outer_expn_data().kind,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -1643,84 +1643,214 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             self.predicate_must_hold_modulo_regions(&obligation)
         };
 
+        let trait_pred_and_imm_ref = poly_trait_pred.map_bound(|p| {
+            (p, Ty::new_imm_ref(self.tcx, self.tcx.lifetimes.re_static, p.self_ty()))
+        });
+        let trait_pred_and_mut_ref = poly_trait_pred.map_bound(|p| {
+            (p, Ty::new_mut_ref(self.tcx, self.tcx.lifetimes.re_static, p.self_ty()))
+        });
+
+        let imm_ref_self_ty_satisfies_pred = mk_result(trait_pred_and_imm_ref);
+        let mut_ref_self_ty_satisfies_pred = mk_result(trait_pred_and_mut_ref);
+
         let code = match obligation.cause.code() {
             ObligationCauseCode::FunctionArg { parent_code, .. } => parent_code,
             // FIXME(compiler-errors): This is kind of a mess, but required for obligations
             // that come from a path expr to affect the *call* expr.
-            c @ ObligationCauseCode::WhereClauseInExpr(_, _, hir_id, _)
+            c @ ObligationCauseCode::WhereClauseInExpr(def_id, _, hir_id, idx)
                 if self.tcx.hir_span(*hir_id).lo() == span.lo() =>
             {
                 // `hir_id` corresponds to the HIR node that introduced a `where`-clause obligation.
-                // If that obligation comes from a type in an associated method call, we need
-                // special handling here.
-                if let hir::Node::Expr(expr) = self.tcx.parent_hir_node(*hir_id)
-                    && let hir::ExprKind::Call(base, _) = expr.kind
-                    && let hir::ExprKind::Path(hir::QPath::TypeRelative(ty, segment)) = base.kind
-                    && let hir::Node::Expr(outer) = self.tcx.parent_hir_node(expr.hir_id)
-                    && let hir::ExprKind::AddrOf(hir::BorrowKind::Ref, mtbl, _) = outer.kind
-                    && ty.span == span
-                {
-                    // We've encountered something like `&str::from("")`, where the intended code
-                    // was likely `<&str>::from("")`. The former is interpreted as "call method
-                    // `from` on `str` and borrow the result", while the latter means "call method
-                    // `from` on `&str`".
+                if let hir::Node::Expr(expr) = self.tcx.parent_hir_node(*hir_id) {
+                    // If that obligation comes from a type in an associated method call, we need
+                    // special handling here.
+                    if let hir::ExprKind::Call(base, _) = expr.kind
+                        && let hir::ExprKind::Path(hir::QPath::TypeRelative(ty, segment)) =
+                            base.kind
+                        && let hir::Node::Expr(outer) = self.tcx.parent_hir_node(expr.hir_id)
+                        && let hir::ExprKind::AddrOf(hir::BorrowKind::Ref, mtbl, _) = outer.kind
+                        && ty.span == span
+                    {
+                        // We've encountered something like `&str::from("")`, where the intended code
+                        // was likely `<&str>::from("")`. The former is interpreted as "call method
+                        // `from` on `str` and borrow the result", while the latter means "call method
+                        // `from` on `&str`".
 
-                    let trait_pred_and_imm_ref = poly_trait_pred.map_bound(|p| {
-                        (p, Ty::new_imm_ref(self.tcx, self.tcx.lifetimes.re_static, p.self_ty()))
-                    });
-                    let trait_pred_and_mut_ref = poly_trait_pred.map_bound(|p| {
-                        (p, Ty::new_mut_ref(self.tcx, self.tcx.lifetimes.re_static, p.self_ty()))
-                    });
+                        let sugg_msg = |pre: &str| {
+                            format!(
+                                "you likely meant to call the associated function `{FN}` for type \
+                                 `&{pre}{TY}`, but the code as written calls associated function `{FN}` on \
+                                 type `{TY}`",
+                                FN = segment.ident,
+                                TY = poly_trait_pred.self_ty(),
+                            )
+                        };
+                        match (imm_ref_self_ty_satisfies_pred, mut_ref_self_ty_satisfies_pred, mtbl)
+                        {
+                            (true, _, hir::Mutability::Not) | (_, true, hir::Mutability::Mut) => {
+                                err.multipart_suggestion(
+                                    sugg_msg(mtbl.prefix_str()),
+                                    vec![
+                                        (outer.span.shrink_to_lo(), "<".to_string()),
+                                        (span.shrink_to_hi(), ">".to_string()),
+                                    ],
+                                    Applicability::MachineApplicable,
+                                );
+                            }
+                            (true, _, hir::Mutability::Mut) => {
+                                // There's an associated function found on the immutable borrow of the
+                                err.multipart_suggestion(
+                                    sugg_msg("mut "),
+                                    vec![
+                                        (outer.span.shrink_to_lo().until(span), "<&".to_string()),
+                                        (span.shrink_to_hi(), ">".to_string()),
+                                    ],
+                                    Applicability::MachineApplicable,
+                                );
+                            }
+                            (_, true, hir::Mutability::Not) => {
+                                err.multipart_suggestion(
+                                    sugg_msg(""),
+                                    vec![
+                                        (
+                                            outer.span.shrink_to_lo().until(span),
+                                            "<&mut ".to_string(),
+                                        ),
+                                        (span.shrink_to_hi(), ">".to_string()),
+                                    ],
+                                    Applicability::MachineApplicable,
+                                );
+                            }
+                            _ => {}
+                        }
+                        // If we didn't return early here, we would instead suggest `&&str::from("")`.
+                        return false;
+                    } else if let hir::ExprKind::Call(_, args) = expr.kind {
+                        if let Some(typeck_results) = &self.typeck_results
+                            && let Some(pred) = self
+                                .tcx
+                                .predicates_of(*def_id)
+                                .instantiate_identity(self.tcx)
+                                .predicates
+                                .into_iter()
+                                .nth(*idx)
+                            && let Some(pred) = pred.as_trait_clause()
+                            // This feature allows for `for<T> T: Trait`, which fails
+                            // `instantiate_bound_regions_with_erased`. Avoid suggesting for now.
+                            && !self.tcx.features().non_lifetime_binders()
+                        {
+                            let pred_ty = self.tcx.instantiate_bound_regions_with_erased(
+                                pred.self_ty().skip_norm_wip(),
+                            );
+                            let fn_sig = self.tcx.instantiate_bound_regions_with_erased(
+                                self.tcx.fn_sig(*def_id).instantiate_identity().skip_norm_wip(),
+                            );
 
-                    let imm_ref_self_ty_satisfies_pred = mk_result(trait_pred_and_imm_ref);
-                    let mut_ref_self_ty_satisfies_pred = mk_result(trait_pred_and_mut_ref);
-                    let sugg_msg = |pre: &str| {
-                        format!(
-                            "you likely meant to call the associated function `{FN}` for type \
-                             `&{pre}{TY}`, but the code as written calls associated function `{FN}` on \
-                             type `{TY}`",
-                            FN = segment.ident,
-                            TY = poly_trait_pred.self_ty(),
-                        )
-                    };
-                    match (imm_ref_self_ty_satisfies_pred, mut_ref_self_ty_satisfies_pred, mtbl) {
-                        (true, _, hir::Mutability::Not) | (_, true, hir::Mutability::Mut) => {
-                            err.multipart_suggestion(
-                                sugg_msg(mtbl.prefix_str()),
-                                vec![
-                                    (outer.span.shrink_to_lo(), "<".to_string()),
-                                    (span.shrink_to_hi(), ">".to_string()),
-                                ],
-                                Applicability::MachineApplicable,
-                            );
+                            let mut spans = vec![];
+                            for (arg, input) in args.into_iter().zip(fn_sig.inputs()) {
+                                if let Some(arg_ty) = typeck_results.expr_ty_adjusted_opt(arg) {
+                                    let ty = self.tcx.instantiate_bound_regions_with_erased(
+                                        poly_trait_pred.self_ty(),
+                                    );
+                                    let pred_has_arg_type =
+                                        self.infcx.can_eq(param_env, arg_ty, ty);
+                                    let arg_is_type_param =
+                                        self.infcx.can_eq(param_env, pred_ty, *input);
+                                    if pred_has_arg_type && arg_is_type_param {
+                                        err.span_label(
+                                            arg.span,
+                                            format!("`{arg_ty}` doesn't satisfy the trait bound"),
+                                        );
+                                        spans.push(arg.span);
+                                    }
+                                }
+                            }
+                            let this = pluralize!("this", spans.len());
+                            if !spans.is_empty() {
+                                if imm_ref_self_ty_satisfies_pred {
+                                    err.multipart_suggestion(
+                                        format!("consider borrowing {this} argument"),
+                                        spans
+                                            .iter()
+                                            .map(|sp| (sp.shrink_to_lo(), "&".into()))
+                                            .collect(),
+                                        Applicability::MaybeIncorrect,
+                                    );
+                                }
+                                if mut_ref_self_ty_satisfies_pred {
+                                    err.multipart_suggestion(
+                                        format!("consider mutably borrowing {this} argument"),
+                                        spans
+                                            .iter()
+                                            .map(|sp| (sp.shrink_to_lo(), "&mut ".into()))
+                                            .collect(),
+                                        Applicability::MaybeIncorrect,
+                                    );
+                                }
+                                return false;
+                            }
                         }
-                        (true, _, hir::Mutability::Mut) => {
-                            // There's an associated function found on the immutable borrow of the
-                            err.multipart_suggestion(
-                                sugg_msg("mut "),
-                                vec![
-                                    (outer.span.shrink_to_lo().until(span), "<&".to_string()),
-                                    (span.shrink_to_hi(), ">".to_string()),
-                                ],
-                                Applicability::MachineApplicable,
-                            );
-                        }
-                        (_, true, hir::Mutability::Not) => {
-                            err.multipart_suggestion(
-                                sugg_msg(""),
-                                vec![
-                                    (outer.span.shrink_to_lo().until(span), "<&mut ".to_string()),
-                                    (span.shrink_to_hi(), ">".to_string()),
-                                ],
-                                Applicability::MachineApplicable,
-                            );
-                        }
-                        _ => {}
                     }
-                    // If we didn't return early here, we would instead suggest `&&str::from("")`.
-                    return false;
                 }
                 c
+            }
+            ObligationCauseCode::WhereClauseInExpr(def_id, _, hir_id, idx)
+                if let hir::Node::Expr(expr) = self.tcx.hir_node(*hir_id)
+                    && let hir::ExprKind::MethodCall(_segment, rcvr, args, ..) = expr.kind
+                    && let Some(typeck_results) = &self.typeck_results
+                    && let Some(pred) = self
+                        .tcx
+                        .predicates_of(*def_id)
+                        .instantiate_identity(self.tcx)
+                        .predicates
+                        .into_iter()
+                        .nth(*idx)
+                    && let Some(pred) = pred.as_trait_clause()
+                    // This feature allows for `for<T> T: Trait`, which fails
+                    // `instantiate_bound_regions_with_erased`. Avoid suggesting for now.
+                    && !self.tcx.features().non_lifetime_binders() =>
+            {
+                // We've got a method call where likely one of the arguments didn't meet a bound.
+                let pred_ty =
+                    self.tcx.instantiate_bound_regions_with_erased(pred.self_ty().skip_norm_wip());
+                let fn_sig = self.tcx.instantiate_bound_regions_with_erased(
+                    self.tcx.fn_sig(*def_id).instantiate_identity().skip_norm_wip(),
+                );
+
+                let mut spans = vec![];
+                for (arg, input) in [rcvr].into_iter().chain(args.into_iter()).zip(fn_sig.inputs())
+                {
+                    let Some(arg_ty) = typeck_results.expr_ty_adjusted_opt(arg) else { continue };
+                    let ty =
+                        self.tcx.instantiate_bound_regions_with_erased(poly_trait_pred.self_ty());
+                    let pred_has_arg_type = self.infcx.can_eq(param_env, arg_ty, ty);
+                    let arg_is_type_param = self.infcx.can_eq(param_env, pred_ty, *input);
+                    if pred_has_arg_type && arg_is_type_param {
+                        err.span_label(
+                            arg.span,
+                            format!("`{arg_ty}` doesn't satisfy the trait bound"),
+                        );
+                        spans.push(arg.span);
+                    }
+                }
+                let this = pluralize!("this", spans.len());
+                if !spans.is_empty() {
+                    if imm_ref_self_ty_satisfies_pred {
+                        err.multipart_suggestion(
+                            format!("consider borrowing {this} argument"),
+                            spans.iter().map(|sp| (sp.shrink_to_lo(), "&".into())).collect(),
+                            Applicability::MaybeIncorrect,
+                        );
+                    }
+                    if mut_ref_self_ty_satisfies_pred {
+                        err.multipart_suggestion(
+                            format!("consider mutably borrowing {this} argument"),
+                            spans.iter().map(|sp| (sp.shrink_to_lo(), "&mut ".into())).collect(),
+                            Applicability::MaybeIncorrect,
+                        );
+                    }
+                }
+                return false;
             }
             c if matches!(
                 span.ctxt().outer_expn_data().kind,

--- a/tests/ui/delegation/self-mapping-arguments-errors.stderr
+++ b/tests/ui/delegation/self-mapping-arguments-errors.stderr
@@ -22,11 +22,16 @@ LL | |     }
 error[E0277]: the trait bound `(): target_expr_doesnt_relower_when_defs_inside::MyAdd` is not satisfied
   --> $DIR/self-mapping-arguments-errors.rs:14:5
    |
-LL | /     reuse impl MyAdd for W {
-...  |
-LL | |         self.0
-LL | |     }
-   | |_____^ the trait `target_expr_doesnt_relower_when_defs_inside::MyAdd` is not implemented for `()`
+LL |        reuse impl MyAdd for W {
+   |   _____^                      -
+   |  |____________________________|
+...  ||
+LL | ||         self.0
+LL | ||     }
+   | ||     ^
+   | ||_____|
+   |  |_____`{type error}` doesn't satisfy the trait bound
+   |        the trait `target_expr_doesnt_relower_when_defs_inside::MyAdd` is not implemented for `()`
    |
 help: the following other types implement trait `target_expr_doesnt_relower_when_defs_inside::MyAdd`
   --> $DIR/self-mapping-arguments-errors.rs:8:5

--- a/tests/ui/diagnostic_namespace/do_not_recommend/as_expression.current.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/as_expression.current.stderr
@@ -16,7 +16,9 @@ error[E0277]: the trait bound `X: A` is not satisfied
   --> $DIR/as_expression.rs:60:15
    |
 LL |     X.start().foo().finish();
-   |               ^^^ unsatisfied trait bound
+   |     --------- ^^^ unsatisfied trait bound
+   |     |
+   |     `X` doesn't satisfy the trait bound
    |
 help: the trait `A` is not implemented for `X`
   --> $DIR/as_expression.rs:70:1

--- a/tests/ui/intrinsics/bad-intrinsic-monomorphization-bounds.stderr
+++ b/tests/ui/intrinsics/bad-intrinsic-monomorphization-bounds.stderr
@@ -2,7 +2,10 @@ error[E0277]: the trait bound `Foo: intrinsics::bounds::FloatPrimitive` is not s
   --> $DIR/bad-intrinsic-monomorphization-bounds.rs:16:5
    |
 LL |     intrinsics::fadd_fast(a, b)
-   |     ^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |     ^^^^^^^^^^^^^^^^^^^^^ -  - `Foo` doesn't satisfy the trait bound
+   |     |                     |
+   |     |                     `Foo` doesn't satisfy the trait bound
+   |     unsatisfied trait bound
    |
 help: the nightly-only, unstable trait `intrinsics::bounds::FloatPrimitive` is not implemented for `Foo`
   --> $DIR/bad-intrinsic-monomorphization-bounds.rs:13:1

--- a/tests/ui/trait-bounds/ownership-mismatch-on-arg.rs
+++ b/tests/ui/trait-bounds/ownership-mismatch-on-arg.rs
@@ -1,0 +1,47 @@
+// #134805
+mod needs_deref {
+    #[derive(Clone, Copy, Debug)]
+    struct Hello;
+
+    trait Tr: Clone + Copy {}
+    impl Tr for Hello {}
+
+    fn foo<T: Tr, K: std::fmt::Debug>(_v: T, _w: T, _k: K) {}
+
+    struct S;
+    impl S {
+        fn foo<K: std::fmt::Debug, T: Tr>(&self, _v: T, _w: T, _k: K) {}
+    }
+
+    fn bar() {
+        let hellos = [Hello; 3];
+        for hi in hellos.iter() {
+            foo(hi, hi, hi); //~ ERROR: the trait bound `&needs_deref::Hello: needs_deref::Tr` is not satisfied
+            S.foo(hi, hi, hi); //~ ERROR: the trait bound `&needs_deref::Hello: needs_deref::Tr` is not satisfied
+        }
+    }
+}
+
+mod needs_borrow {
+    #[derive(Clone, Copy, Debug)]
+    struct Hello;
+
+    trait Tr: Clone + Copy {}
+    impl Tr for &Hello {}
+
+    fn foo<T: Tr, K: std::fmt::Debug>(_v: T, _w: T, _k: K) {}
+
+    struct S;
+    impl S {
+        fn foo<T: Tr, K: std::fmt::Debug>(&self, _v: T, _w: T, _k: K) {}
+    }
+
+    fn bar() {
+        let hellos = [Hello; 3];
+        for hi in hellos {
+            foo(hi, hi, hi); //~ ERROR: the trait bound `needs_borrow::Hello: needs_borrow::Tr` is not satisfied
+            S.foo(hi, hi, hi); //~ ERROR: the trait bound `needs_borrow::Hello: needs_borrow::Tr` is not satisfied
+        }
+    }
+}
+fn main() {}

--- a/tests/ui/trait-bounds/ownership-mismatch-on-arg.stderr
+++ b/tests/ui/trait-bounds/ownership-mismatch-on-arg.stderr
@@ -1,0 +1,96 @@
+error[E0277]: the trait bound `&needs_deref::Hello: needs_deref::Tr` is not satisfied
+  --> $DIR/ownership-mismatch-on-arg.rs:19:13
+   |
+LL |             foo(hi, hi, hi);
+   |             ^^^ --  -- `&needs_deref::Hello` doesn't satisfy the trait bound
+   |             |   |
+   |             |   `&needs_deref::Hello` doesn't satisfy the trait bound
+   |             the trait `needs_deref::Tr` is not implemented for `&needs_deref::Hello`
+   |
+note: required by a bound in `needs_deref::foo`
+  --> $DIR/ownership-mismatch-on-arg.rs:9:15
+   |
+LL |     fn foo<T: Tr, K: std::fmt::Debug>(_v: T, _w: T, _k: K) {}
+   |               ^^ required by this bound in `foo`
+
+error[E0277]: the trait bound `&needs_deref::Hello: needs_deref::Tr` is not satisfied
+  --> $DIR/ownership-mismatch-on-arg.rs:20:15
+   |
+LL |             S.foo(hi, hi, hi);
+   |               ^^^ --  -- `&needs_deref::Hello` doesn't satisfy the trait bound
+   |               |   |
+   |               |   `&needs_deref::Hello` doesn't satisfy the trait bound
+   |               the trait `needs_deref::Tr` is not implemented for `&needs_deref::Hello`
+   |
+help: the trait `needs_deref::Tr` is implemented for `needs_deref::Hello`
+  --> $DIR/ownership-mismatch-on-arg.rs:7:5
+   |
+LL |     impl Tr for Hello {}
+   |     ^^^^^^^^^^^^^^^^^
+note: required by a bound in `needs_deref::S::foo`
+  --> $DIR/ownership-mismatch-on-arg.rs:13:39
+   |
+LL |         fn foo<K: std::fmt::Debug, T: Tr>(&self, _v: T, _w: T, _k: K) {}
+   |                                       ^^ required by this bound in `S::foo`
+
+error[E0277]: the trait bound `needs_borrow::Hello: needs_borrow::Tr` is not satisfied
+  --> $DIR/ownership-mismatch-on-arg.rs:42:13
+   |
+LL |             foo(hi, hi, hi);
+   |             ^^^ --  -- `needs_borrow::Hello` doesn't satisfy the trait bound
+   |             |   |
+   |             |   `needs_borrow::Hello` doesn't satisfy the trait bound
+   |             unsatisfied trait bound
+   |
+help: the trait `needs_borrow::Tr` is not implemented for `needs_borrow::Hello`
+  --> $DIR/ownership-mismatch-on-arg.rs:27:5
+   |
+LL |     struct Hello;
+   |     ^^^^^^^^^^^^
+help: the trait `needs_borrow::Tr` is implemented for `&needs_borrow::Hello`
+  --> $DIR/ownership-mismatch-on-arg.rs:30:5
+   |
+LL |     impl Tr for &Hello {}
+   |     ^^^^^^^^^^^^^^^^^^
+note: required by a bound in `needs_borrow::foo`
+  --> $DIR/ownership-mismatch-on-arg.rs:32:15
+   |
+LL |     fn foo<T: Tr, K: std::fmt::Debug>(_v: T, _w: T, _k: K) {}
+   |               ^^ required by this bound in `foo`
+help: consider borrowing these argument
+   |
+LL |             foo(&hi, &hi, hi);
+   |                 +    +
+
+error[E0277]: the trait bound `needs_borrow::Hello: needs_borrow::Tr` is not satisfied
+  --> $DIR/ownership-mismatch-on-arg.rs:43:15
+   |
+LL |             S.foo(hi, hi, hi);
+   |               ^^^ --  -- `needs_borrow::Hello` doesn't satisfy the trait bound
+   |               |   |
+   |               |   `needs_borrow::Hello` doesn't satisfy the trait bound
+   |               unsatisfied trait bound
+   |
+help: the trait `needs_borrow::Tr` is not implemented for `needs_borrow::Hello`
+  --> $DIR/ownership-mismatch-on-arg.rs:27:5
+   |
+LL |     struct Hello;
+   |     ^^^^^^^^^^^^
+help: the trait `needs_borrow::Tr` is implemented for `&needs_borrow::Hello`
+  --> $DIR/ownership-mismatch-on-arg.rs:30:5
+   |
+LL |     impl Tr for &Hello {}
+   |     ^^^^^^^^^^^^^^^^^^
+note: required by a bound in `needs_borrow::S::foo`
+  --> $DIR/ownership-mismatch-on-arg.rs:36:19
+   |
+LL |         fn foo<T: Tr, K: std::fmt::Debug>(&self, _v: T, _w: T, _k: K) {}
+   |                   ^^ required by this bound in `S::foo`
+help: consider borrowing these argument
+   |
+LL |             S.foo(&hi, &hi, hi);
+   |                   +    +
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
```
error[E0277]: the trait bound `needs_borrow::Hello: needs_borrow::Tr` is not satisfied
  --> $DIR/ownership-mismatch-on-arg.rs:42:13
   |
LL |             foo(hi, hi, hi);
   |             ^^^ --  -- `needs_borrow::Hello` doesn't satisfy the trait bound
   |             |   |
   |             |   `needs_borrow::Hello` doesn't satisfy the trait bound
   |             unsatisfied trait bound
   |
help: the trait `needs_borrow::Tr` is not implemented for `needs_borrow::Hello`
  --> $DIR/ownership-mismatch-on-arg.rs:27:5
   |
LL |     struct Hello;
   |     ^^^^^^^^^^^^
help: the trait `needs_borrow::Tr` is implemented for `&needs_borrow::Hello`
  --> $DIR/ownership-mismatch-on-arg.rs:30:5
   |
LL |     impl Tr for &Hello {}
   |     ^^^^^^^^^^^^^^^^^^
note: required by a bound in `needs_borrow::foo`
  --> $DIR/ownership-mismatch-on-arg.rs:32:15
   |
LL |     fn foo<T: Tr, K: std::fmt::Debug>(_v: T, _w: T, _k: K) {}
   |               ^^ required by this bound in `foo`
help: consider borrowing these argument
   |
LL |             foo(&hi, &hi, hi);
   |                 +    +
```

Fix rust-lang/rust#134805.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
