### PR TITLE
Detect existing turbofish on method calls to suppress useless suggestion

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
@@ -1030,12 +1030,15 @@ impl<'a, 'tcx> FindInferSourceVisitor<'a, 'tcx> {
                         let args = self.node_args_opt(expr.hir_id)?;
                         let span = tcx.hir_span(segment.hir_id);
                         let insert_span = segment.ident.span.shrink_to_hi().with_hi(span.hi());
+                        let have_turbofish = segment.args.is_some_and(|args| {
+                            args.args.iter().any(|arg| arg.is_ty_or_const())
+                        });
                         InsertableGenericArgs {
                             insert_span,
                             args,
                             generics_def_id: def_id,
                             def_id,
-                            have_turbofish: false,
+                            have_turbofish,
                         }
                     };
                     return Box::new(insertable.into_iter());

--- a/tests/ui/inference/useless-turbofish-suggestion.rs
+++ b/tests/ui/inference/useless-turbofish-suggestion.rs
@@ -1,0 +1,28 @@
+// Regression test for #153732.
+//
+// When a method call already has turbofish type arguments, don't suggest
+// rewriting them — the suggestion just rewrites user syntax into
+// fully-qualified form without resolving anything.
+//
+// The span still points at the method name rather than the unresolved `_`;
+// fixing that is left as future work.
+
+struct S;
+
+impl S {
+    fn f<A, B>(self, _a: A) -> B {
+        todo!()
+    }
+}
+
+fn with_turbofish() {
+    S.f::<u32, _>(42);
+    //~^ ERROR type annotations needed
+}
+
+fn without_turbofish() {
+    S.f(42);
+    //~^ ERROR type annotations needed
+}
+
+fn main() {}

--- a/tests/ui/inference/useless-turbofish-suggestion.stderr
+++ b/tests/ui/inference/useless-turbofish-suggestion.stderr
@@ -1,0 +1,20 @@
+error[E0282]: type annotations needed
+  --> $DIR/useless-turbofish-suggestion.rs:19:7
+   |
+LL |     S.f::<u32, _>(42);
+   |       ^ cannot infer type of the type parameter `B` declared on the method `f`
+
+error[E0282]: type annotations needed
+  --> $DIR/useless-turbofish-suggestion.rs:24:7
+   |
+LL |     S.f(42);
+   |       ^ cannot infer type of the type parameter `B` declared on the method `f`
+   |
+help: consider specifying the generic arguments
+   |
+LL |     S.f::<i32, B>(42);
+   |        ++++++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0282`.

--- a/tests/ui/issues/issue-23041.stderr
+++ b/tests/ui/issues/issue-23041.stderr
@@ -3,12 +3,6 @@ error[E0282]: type annotations needed
    |
 LL |     b.downcast_ref::<fn(_)->_>();
    |       ^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the method `downcast_ref`
-   |
-help: consider specifying the generic argument
-   |
-LL -     b.downcast_ref::<fn(_)->_>();
-LL +     b.downcast_ref::<fn(_) -> _>();
-   |
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
`expr_inferred_arg_iter` hardcoded `have_turbofish: false` for `MethodCall` expressions, while the `Path` case properly checked for existing type arguments via `segment.args`. This meant the "consider specifying the generic arguments" suggestion always fired on method calls, even when the user already had a turbofish, producing a suggestion that just rewrote user syntax into fully qualified form without resolving anything.

Fixes rust-lang/rust#153732.

cc @eggyal