### PR TITLE
fix(delegation): Filter Out Module Segments in Generic Args Inheritance

### DIFF
--- a/tests/ui/delegation/ice-non-fn-target-in-trait-impl.rs
+++ b/tests/ui/delegation/ice-non-fn-target-in-trait-impl.rs
@@ -1,0 +1,20 @@
+// Regression test for #153743 and #153744.
+// Delegation to a module or crate root inside a trait impl
+// should emit a resolution error, not ICE.
+
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+trait Trait {
+    fn bar();
+    fn bar2();
+}
+
+impl Trait for () {
+    reuse std::path::<> as bar;
+    //~^ ERROR expected function, found module `std::path`
+    reuse core::<> as bar2;
+    //~^ ERROR expected function, found crate `core`
+}
+
+fn main() {}

--- a/tests/ui/delegation/ice-non-fn-target-in-trait-impl.stderr
+++ b/tests/ui/delegation/ice-non-fn-target-in-trait-impl.stderr
@@ -1,0 +1,15 @@
+error[E0423]: expected function, found module `std::path`
+  --> $DIR/ice-non-fn-target-in-trait-impl.rs:14:11
+   |
+LL |     reuse std::path::<> as bar;
+   |           ^^^^^^^^^^^^^ not a function
+
+error[E0423]: expected function, found crate `core`
+  --> $DIR/ice-non-fn-target-in-trait-impl.rs:16:11
+   |
+LL |     reuse core::<> as bar2;
+   |           ^^^^^^^^ not a function
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0423`.


### PR DESCRIPTION
### Summary:

> #153421 (merged not so long ago) fixed those issues by adding check that child segment resolves only to `Fn` or `AssocFn`, they should not produce ICEs on `main` now.
@aerooneqq

~~Fixes ICE when delegating to a module or crate root inside a trait impl.~~

~~Filters `DefKind::Mod` in `get_segment`, returning `None` for such segments so compilation fails gracefully with the pre-existing _E0423_ error from the resolver.~~

> > So this PR superseded by #153421? Should I close this?
> 
> Adding tests for the fixed issues is still good. @rustbot author
@petrochenkov

Adds regression tests for rust-lang/rust#153743 and rust-lang/rust#153744.

rust-lang/rust#153421 already fixed the root cause; this PR adds test coverage.

Closes rust-lang/rust#153743
Closes rust-lang/rust#153744

r? @dingxiangfei2009
cc @matthiaskrgr