### PR TITLE
actually make the is-fn test test what it says it tests

### DIFF
--- a/tests/ui/async-await/async-closures/is-fn.rs
+++ b/tests/ui/async-await/async-closures/is-fn.rs
@@ -9,11 +9,11 @@ use std::future::Future;
 
 extern crate block_on;
 
-// Check that closures that don't capture any state may implement `Fn`.
+// Check that async closures that don't capture any state may implement `Fn`.
 
 fn main() {
     block_on::block_on(async {
-        async fn call_once<F: Future>(x: impl FnOnce(&'static str) -> F) -> F::Output {
+        async fn call_once<F: Future>(x: impl Fn(&'static str) -> F) -> F::Output {
             x("hello, world").await
         }
         call_once(async |x: &'static str| {


### PR DESCRIPTION
r? @lcnr

Previously this test was (apart from the comment) identical to tests/ui/async-await/async-closures/once.rs