### PR TITLE
Don't add empty target features for target-cpu=native on macOS

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -702,7 +702,9 @@ pub(crate) fn global_llvm_features(sess: &Session, only_base_features: bool) -> 
 
                 features_string
             };
-            features.extend(features_string.split(',').map(String::from));
+            if !features_string.is_empty() {
+                features.extend(features_string.split(',').map(String::from));
+            }
         }
         Some(_) | None => {}
     };

--- a/tests/run-make/target-cpu-native/foo.rs
+++ b/tests/run-make/target-cpu-native/foo.rs
@@ -1,1 +1,9 @@
 fn main() {}
+
+// This forces explicit emission of a +neon target feature on targets
+// where it is implied by the target-cpu, like aarch64-apple-darwin.
+// This is a regression test for #153397.
+#[cfg(target_feature = "neon")]
+#[target_feature(enable = "neon")]
+#[unsafe(no_mangle)]
+pub fn with_neon() {}

--- a/tests/run-make/target-cpu-native/rmake.rs
+++ b/tests/run-make/target-cpu-native/rmake.rs
@@ -8,7 +8,12 @@
 use run_make_support::{run, rustc};
 
 fn main() {
-    let out = rustc().input("foo.rs").arg("-Ctarget-cpu=native").run().stderr_utf8();
+    let out = rustc()
+        .input("foo.rs")
+        .arg("-Ctarget-cpu=native")
+        .arg("-Zverify-llvm-ir")
+        .run()
+        .stderr_utf8();
     run("foo");
     // There should be zero warnings emitted - the bug would cause "unknown CPU `native`"
     // to be printed out.


### PR DESCRIPTION
LLVM does not support host feature detection (only host cpu detection) on apple platforms. As such, the returned feature string will be empty. Adding this empty string to the target-features attribute results in a verifier error on LLVM 22.

Fix this by not adding the empty string to the target features. The reason why this was not caught by the target-cpu-native test is that it requires a function that adds *some* target features, otherwise the attribute is omitted entirely. We achieve this with a somewhat peculiar construction that enables `neon` if it's already enabled. (This is to avoid enabling it on softfloat targets.)

Fixes https://github.com/rust-lang/rust/issues/153397.