### PR TITLE
Fix std doctest build for SGX target.

### DIFF
--- a/library/std/src/os/fd/raw.rs
+++ b/library/std/src/os/fd/raw.rs
@@ -16,7 +16,7 @@ use crate::io;
 use crate::os::hermit::io::OwnedFd;
 #[cfg(all(not(target_os = "hermit"), not(target_os = "motor")))]
 use crate::os::raw;
-#[cfg(all(doc, not(target_arch = "wasm32")))]
+#[cfg(all(doc, not(any(target_arch = "wasm32", target_env = "sgx"))))]
 use crate::os::unix::io::AsFd;
 #[cfg(unix)]
 use crate::os::unix::io::OwnedFd;

--- a/library/std/src/sys/net/connection/sgx.rs
+++ b/library/std/src/sys/net/connection/sgx.rs
@@ -68,8 +68,8 @@ impl fmt::Debug for TcpStream {
 ///
 /// SGX doesn't support DNS resolution but rather accepts hostnames in
 /// the same place as socket addresses. So, to make e.g.
-/// ```rust
-/// TcpStream::connect("example.com:80")`
+/// ```rust,ignore (incomplete example)
+/// TcpStream::connect("example.com:80")
 /// ```
 /// work, the DNS lookup returns a special error (`NonIpSockAddr`) instead,
 /// which contains the hostname being looked up. When `.to_socket_addrs()`


### PR DESCRIPTION
This PR fixes standard library doctest build for `x86_64-fortanix-unknown-sgx` target.
