### PR TITLE
Include optional `dso_local` marker for functions in `enum-[match,transparent-extract].rs`

### DIFF
--- a/tests/codegen-llvm/enum/enum-match.rs
+++ b/tests/codegen-llvm/enum/enum-match.rs
@@ -739,7 +739,7 @@ pub enum Tricky {
 
 const _: () = assert!(std::intrinsics::discriminant_value(&Tricky::V100) == 100);
 
-// CHECK-LABEL: define noundef{{( range\(i8 [0-9]+, [0-9]+\))?}} i8 @discriminant6(i8 noundef{{( zeroext)?}} %e)
+// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i8 [0-9]+, [0-9]+\))?}} i8 @discriminant6(i8 noundef{{( zeroext)?}} %e)
 // CHECK-NEXT: start:
 // CHECK-NEXT: %[[REL_VAR:.+]] = add i8 %e, -66
 // CHECK-NEXT: %[[IS_NICHE:.+]] = icmp ult i8 %[[REL_VAR]], -56
@@ -767,7 +767,7 @@ pub enum TransportErr {
 
 #[no_mangle]
 pub fn match7(result: OpenResult) -> u8 {
-    // CHECK-LABEL: define noundef{{( range\(i8 [0-9]+, [0-9]+\))?}} i8 @match7(i32{{.+}}%result)
+    // CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i8 [0-9]+, [0-9]+\))?}} i8 @match7(i32{{.+}}%result)
     // CHECK-NEXT: start:
     // CHECK-NEXT: %[[NOT_OK:.+]] = icmp ne i32 %result, -1
     // CHECK-NEXT: %[[RET:.+]] = zext i1 %[[NOT_OK]] to i8

--- a/tests/codegen-llvm/enum/enum-transparent-extract.rs
+++ b/tests/codegen-llvm/enum/enum-transparent-extract.rs
@@ -9,7 +9,7 @@ pub enum Never {}
 
 #[no_mangle]
 pub fn make_unmake_result_never(x: i32) -> i32 {
-    // CHECK-LABEL: define i32 @make_unmake_result_never(i32{{( signext)?}} %x)
+    // CHECK-LABEL: define{{( dso_local)?}} i32 @make_unmake_result_never(i32{{( signext)?}} %x)
     // CHECK: start:
     // CHECK-NEXT: br label %[[next:bb.*]]
     // CHECK: [[next]]:
@@ -22,7 +22,7 @@ pub fn make_unmake_result_never(x: i32) -> i32 {
 
 #[no_mangle]
 pub fn extract_control_flow_never(x: ControlFlow<&str, Never>) -> &str {
-    // CHECK-LABEL: define { ptr, i64 } @extract_control_flow_never(ptr %x.0, i64 %x.1)
+    // CHECK-LABEL: define{{( dso_local)?}} { ptr, i64 } @extract_control_flow_never(ptr %x.0, i64 %x.1)
     // CHECK: start:
     // CHECK-NEXT: br label %[[next:bb.*]]
     // CHECK: [[next]]:


### PR DESCRIPTION
This PR adds some more `dso_local` markers to the `enum-match.rs` and `enum-transparent-extract.rs` test annotations. These markers are added by LLVM when targeting `aarch64-unknown-none` even though they are missing in `aarch64-unknown-linux-gnu`. This is causing a CI error when running the codegen suite on the `aarch64-unknown-none` target for Ferrocene.

This is a follow up of https://github.com/rust-lang/rust/pull/139891.
