### PR TITLE
Couple of driver interface improvements

### DIFF
--- a/compiler/rustc_builtin_macros/src/env.rs
+++ b/compiler/rustc_builtin_macros/src/env.rs
@@ -51,7 +51,7 @@ pub(crate) fn expand_option_env<'cx>(
 
     let sp = cx.with_def_site_ctxt(sp);
     let value = lookup_env(cx, var);
-    cx.sess.psess.env_depinfo.borrow_mut().insert((var, value.as_ref().ok().copied()));
+    cx.sess.env_depinfo.borrow_mut().insert((var, value.as_ref().ok().copied()));
     let e = match value {
         Err(VarError::NotPresent) => {
             let lt = cx.lifetime(sp, Ident::new(kw::StaticLifetime, sp));
@@ -130,7 +130,7 @@ pub(crate) fn expand_env<'cx>(
 
     let span = cx.with_def_site_ctxt(sp);
     let value = lookup_env(cx, var);
-    cx.sess.psess.env_depinfo.borrow_mut().insert((var, value.as_ref().ok().copied()));
+    cx.sess.env_depinfo.borrow_mut().insert((var, value.as_ref().ok().copied()));
     let e = match value {
         Err(err) => {
             let ExprKind::Lit(token::Lit {

--- a/compiler/rustc_builtin_macros/src/source_util.rs
+++ b/compiler/rustc_builtin_macros/src/source_util.rs
@@ -277,7 +277,6 @@ fn load_binary_file(
     match cx.source_map().load_binary_file(&resolved_path) {
         Ok(data) => {
             cx.sess
-                .psess
                 .file_depinfo
                 .borrow_mut()
                 .insert(Symbol::intern(&resolved_path.to_string_lossy()));

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -214,7 +214,7 @@ pub fn run_compiler(at_args: &[String], callbacks: &mut (dyn Callbacks + Send)) 
         file_loader: None,
         lint_caps: Default::default(),
         psess_created: None,
-        hash_untracked_state: None,
+        track_state: None,
         register_lints: None,
         override_queries: None,
         extra_symbols: Vec::new(),

--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -475,14 +475,15 @@ impl server::Server for Rustc<'_, '_> {
     }
 
     fn track_env_var(&mut self, var: &str, value: Option<&str>) {
-        self.psess()
+        self.ecx
+            .sess
             .env_depinfo
             .borrow_mut()
             .insert((Symbol::intern(var), value.map(Symbol::intern)));
     }
 
     fn track_path(&mut self, path: &str) {
-        self.psess().file_depinfo.borrow_mut().insert(Symbol::intern(path));
+        self.ecx.sess.file_depinfo.borrow_mut().insert(Symbol::intern(path));
     }
 
     fn literal_from_str(&mut self, s: &str) -> Result<Literal<Self::Span, Self::Symbol>, String> {

--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -22,7 +22,6 @@ use rustc_session::parse::ParseSess;
 use rustc_session::{CompilerIO, EarlyDiagCtxt, Session, lint};
 use rustc_span::source_map::{FileLoader, RealFileLoader, SourceMapInputs};
 use rustc_span::{FileName, sym};
-use rustc_target::spec::Target;
 use tracing::trace;
 
 use crate::util;
@@ -364,8 +363,7 @@ pub struct Config {
     /// hotswapping branch of cg_clif" for "setting the codegen backend from a
     /// custom driver where the custom codegen backend has arbitrary data."
     /// (See #102759.)
-    pub make_codegen_backend:
-        Option<Box<dyn FnOnce(&config::Options, &Target) -> Box<dyn CodegenBackend> + Send>>,
+    pub make_codegen_backend: Option<Box<dyn FnOnce(&Session) -> Box<dyn CodegenBackend> + Send>>,
 
     /// The inner atomic value is set to true when a feature marked as `internal` is
     /// enabled. Makes it so that "please report a bug" is hidden, as ICEs with
@@ -419,20 +417,6 @@ pub fn run_compiler<R: Send>(config: Config, f: impl FnOnce(&Compiler) -> R + Se
             // impl `Send`. Creating a new one is fine.
             let early_dcx = EarlyDiagCtxt::new(config.opts.error_format);
 
-            let codegen_backend = match config.make_codegen_backend {
-                None => util::get_codegen_backend(
-                    &early_dcx,
-                    &config.opts.sysroot,
-                    config.opts.unstable_opts.codegen_backend.as_deref(),
-                    &target,
-                ),
-                Some(make_codegen_backend) => {
-                    // N.B. `make_codegen_backend` takes precedence over
-                    // `target.default_codegen_backend`, which is ignored in this case.
-                    make_codegen_backend(&config.opts, &target)
-                }
-            };
-
             let temps_dir = config.opts.unstable_opts.temps_dir.as_deref().map(PathBuf::from);
 
             let mut sess = rustc_session::build_session(
@@ -450,6 +434,19 @@ pub fn run_compiler<R: Send>(config: Config, f: impl FnOnce(&Compiler) -> R + Se
                 config.using_internal_features,
             );
 
+            let codegen_backend = match config.make_codegen_backend {
+                None => util::get_codegen_backend(
+                    &early_dcx,
+                    &sess.opts.sysroot,
+                    sess.opts.unstable_opts.codegen_backend.as_deref(),
+                    &sess.target,
+                ),
+                Some(make_codegen_backend) => {
+                    // N.B. `make_codegen_backend` takes precedence over
+                    // `target.default_codegen_backend`, which is ignored in this case.
+                    make_codegen_backend(&sess)
+                }
+            };
             codegen_backend.init(&sess);
             sess.replaced_intrinsics = FxHashSet::from_iter(codegen_backend.replaced_intrinsics());
             sess.thin_lto_supported = codegen_backend.thin_lto_supported();

--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -336,11 +336,14 @@ pub struct Config {
     /// This is a callback from the driver that is called when [`ParseSess`] is created.
     pub psess_created: Option<Box<dyn FnOnce(&mut ParseSess) + Send>>,
 
-    /// This is a callback to hash otherwise untracked state used by the caller, if the
-    /// hash changes between runs the incremental cache will be cleared.
+    /// This is a callback to track otherwise untracked state used by the caller.
     ///
-    /// e.g. used by Clippy to hash its config file
-    pub hash_untracked_state: Option<Box<dyn FnOnce(&Session, &mut StableHasher) + Send>>,
+    /// You can write to `sess.env_depinfo` and `sess.file_depinfo` to track env vars and files.
+    /// To track any other state you can write to the given hasher. If the hash changes between
+    /// runs the incremental cache will be cleared.
+    ///
+    /// The hashing functionality has no known user. FIXME should this be removed?
+    pub track_state: Option<Box<dyn FnOnce(&Session, &mut StableHasher) + Send>>,
 
     /// This is a callback from the driver that is called when we're registering lints;
     /// it is called during lint loading when we have the LintStore in a non-shared state.
@@ -464,9 +467,9 @@ pub fn run_compiler<R: Send>(config: Config, f: impl FnOnce(&Compiler) -> R + Se
                 psess_created(&mut sess.psess);
             }
 
-            if let Some(hash_untracked_state) = config.hash_untracked_state {
+            if let Some(track_state) = config.track_state {
                 let mut hasher = StableHasher::new();
-                hash_untracked_state(&sess, &mut hasher);
+                track_state(&sess, &mut hasher);
                 sess.opts.untracked_state_hash = hasher.finish()
             }
 

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -495,7 +495,7 @@ fn env_var_os<'tcx>(tcx: TyCtxt<'tcx>, key: &'tcx OsStr) -> Option<&'tcx OsStr> 
     // NOTE: This only works for passes run before `write_dep_info`. See that
     // for extension points for configuring environment variables to be
     // properly change-tracked.
-    tcx.sess.psess.env_depinfo.borrow_mut().insert((
+    tcx.sess.env_depinfo.borrow_mut().insert((
         Symbol::intern(&key.to_string_lossy()),
         value.as_ref().and_then(|value| value.to_str()).map(|value| Symbol::intern(value)),
     ));
@@ -607,7 +607,7 @@ fn write_out_deps(tcx: TyCtxt<'_>, outputs: &OutputFilenames, out_filenames: &[P
 
         // Account for explicitly marked-to-track files
         // (e.g. accessed in proc macros).
-        let file_depinfo = sess.psess.file_depinfo.borrow();
+        let file_depinfo = sess.file_depinfo.borrow();
 
         let normalize_path = |path: PathBuf| escape_dep_filename(&path.to_string_lossy());
 
@@ -719,7 +719,7 @@ fn write_out_deps(tcx: TyCtxt<'_>, outputs: &OutputFilenames, out_filenames: &[P
             }
 
             // Emit special comments with information about accessed environment variables.
-            let env_depinfo = sess.psess.env_depinfo.borrow();
+            let env_depinfo = sess.env_depinfo.borrow();
             if !env_depinfo.is_empty() {
                 // We will soon sort, so the initial order does not matter.
                 #[allow(rustc::potential_query_instability)]

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -419,9 +419,9 @@ top_level_options!(
         /// directory to store intermediate results.
         incremental: Option<PathBuf> [UNTRACKED],
         assert_incr_state: Option<IncrementalStateAssertion> [UNTRACKED],
-        /// Set by the `Config::hash_untracked_state` callback for custom
-        /// drivers to invalidate the incremental cache
-        #[rustc_lint_opt_deny_field_access("should only be used via `Config::hash_untracked_state`")]
+        /// Set based on the result of the `Config::track_state` callback
+        /// for custom drivers to invalidate the incremental cache.
+        #[rustc_lint_opt_deny_field_access("should only be used via `Config::track_state`")]
         untracked_state_hash: Hash64 [TRACKED_NO_CRATE_HASH],
 
         unstable_opts: UnstableOptions [SUBSTRUCT UnstableOptionsTargetModifiers UnstableOptions],

--- a/compiler/rustc_session/src/parse.rs
+++ b/compiler/rustc_session/src/parse.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use rustc_ast::attr::AttrIdGenerator;
 use rustc_ast::node_id::NodeId;
-use rustc_data_structures::fx::{FxHashMap, FxIndexMap, FxIndexSet};
+use rustc_data_structures::fx::{FxHashMap, FxIndexMap};
 use rustc_data_structures::sync::{AppendOnlyVec, Lock};
 use rustc_errors::annotate_snippet_emitter_writer::AnnotateSnippetEmitter;
 use rustc_errors::emitter::{EmitterWithNote, stderr_destination};
@@ -264,10 +264,6 @@ pub struct ParseSess {
     pub ambiguous_block_expr_parse: Lock<FxIndexMap<Span, Span>>,
     pub gated_spans: GatedSpans,
     pub symbol_gallery: SymbolGallery,
-    /// Environment variables accessed during the build and their values when they exist.
-    pub env_depinfo: Lock<FxIndexSet<(Symbol, Option<Symbol>)>>,
-    /// File paths accessed during the build.
-    pub file_depinfo: Lock<FxIndexSet<Symbol>>,
     /// Whether cfg(version) should treat the current release as incomplete
     pub assume_incomplete_release: bool,
     /// Spans passed to `proc_macro::quote_span`. Each span has a numerical
@@ -303,8 +299,6 @@ impl ParseSess {
             ambiguous_block_expr_parse: Lock::new(Default::default()),
             gated_spans: GatedSpans::default(),
             symbol_gallery: SymbolGallery::default(),
-            env_depinfo: Default::default(),
-            file_depinfo: Default::default(),
             assume_incomplete_release: false,
             proc_macro_quoted_spans: Default::default(),
             attr_id_generator: AttrIdGenerator::new(),

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -143,6 +143,12 @@ pub struct Session {
     /// None signifies that this is not tracked.
     pub using_internal_features: &'static AtomicBool,
 
+    /// Environment variables accessed during the build and their values when they exist.
+    pub env_depinfo: Lock<FxIndexSet<(Symbol, Option<Symbol>)>>,
+
+    /// File paths accessed during the build.
+    pub file_depinfo: Lock<FxIndexSet<Symbol>>,
+
     target_filesearch: FileSearch,
     host_filesearch: FileSearch,
 
@@ -1095,6 +1101,8 @@ pub fn build_session(
         unstable_target_features: Default::default(),
         cfg_version,
         using_internal_features,
+        env_depinfo: Default::default(),
+        file_depinfo: Default::default(),
         target_filesearch,
         host_filesearch,
         invocation_temp,

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -296,7 +296,7 @@ pub(crate) fn create_config(
         file_loader: None,
         lint_caps,
         psess_created: None,
-        hash_untracked_state: None,
+        track_state: None,
         register_lints: Some(Box::new(crate::lint::register_lints)),
         override_queries: Some(|_sess, providers| {
             // We do not register late module lints, so this only runs `MissingDoc`.

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -190,7 +190,7 @@ pub(crate) fn run(dcx: DiagCtxtHandle<'_>, input: Input, options: RustdocOptions
         file_loader: None,
         lint_caps,
         psess_created: None,
-        hash_untracked_state: None,
+        track_state: None,
         register_lints: Some(Box::new(crate::lint::register_lints)),
         override_queries: None,
         extra_symbols: Vec::new(),

--- a/src/tools/clippy/src/driver.rs
+++ b/src/tools/clippy/src/driver.rs
@@ -23,9 +23,8 @@ extern crate tikv_jemalloc_sys as _;
 use clippy_utils::sym;
 use declare_clippy_lint::LintListBuilder;
 use rustc_interface::interface;
-use rustc_session::EarlyDiagCtxt;
 use rustc_session::config::ErrorOutputType;
-use rustc_session::parse::ParseSess;
+use rustc_session::{EarlyDiagCtxt, Session};
 use rustc_span::symbol::Symbol;
 
 use std::env;
@@ -81,17 +80,16 @@ fn test_has_arg() {
     assert!(!has_arg(args, "--bar"));
 }
 
-fn track_clippy_args(psess: &mut ParseSess, args_env_var: Option<&str>) {
-    psess
-        .env_depinfo
-        .get_mut()
+fn track_clippy_args(sess: &Session, args_env_var: Option<&str>) {
+    sess.env_depinfo
+        .borrow_mut()
         .insert((sym::CLIPPY_ARGS, args_env_var.map(Symbol::intern)));
 }
 
 /// Track files that may be accessed at runtime in `file_depinfo` so that cargo will re-run clippy
 /// when any of them are modified
-fn track_files(psess: &mut ParseSess) {
-    let file_depinfo = psess.file_depinfo.get_mut();
+fn track_files(sess: &Session) {
+    let mut file_depinfo = sess.file_depinfo.borrow_mut();
 
     // Used by `clippy::cargo` lints and to determine the MSRV. `cargo clippy` executes `clippy-driver`
     // with the current directory set to `CARGO_MANIFEST_DIR` so a relative path is fine
@@ -123,8 +121,8 @@ struct RustcCallbacks {
 impl rustc_driver::Callbacks for RustcCallbacks {
     fn config(&mut self, config: &mut interface::Config) {
         let clippy_args_var = self.clippy_args_var.take();
-        config.psess_created = Some(Box::new(move |psess| {
-            track_clippy_args(psess, clippy_args_var.as_deref());
+        config.track_state = Some(Box::new(move |sess, _hasher| {
+            track_clippy_args(sess, clippy_args_var.as_deref());
         }));
         config.extra_symbols = sym::EXTRA_SYMBOLS.into();
     }
@@ -140,13 +138,13 @@ impl rustc_driver::Callbacks for ClippyCallbacks {
         let conf_path = clippy_config::lookup_conf_file();
         let previous = config.register_lints.take();
         let clippy_args_var = self.clippy_args_var.take();
-        config.psess_created = Some(Box::new(move |psess| {
-            track_clippy_args(psess, clippy_args_var.as_deref());
-            track_files(psess);
+        config.track_state = Some(Box::new(move |sess, _hasher| {
+            track_clippy_args(sess, clippy_args_var.as_deref());
+            track_files(sess);
 
             // Trigger a rebuild if CLIPPY_CONF_DIR changes. The value must be a valid string so
             // changes between dirs that are invalid UTF-8 will not trigger rebuilds
-            psess.env_depinfo.get_mut().insert((
+            sess.env_depinfo.borrow_mut().insert((
                 sym::CLIPPY_CONF_DIR,
                 env::var("CLIPPY_CONF_DIR").ok().map(|dir| Symbol::intern(&dir)),
             ));

--- a/src/tools/miri/src/bin/miri.rs
+++ b/src/tools/miri/src/bin/miri.rs
@@ -18,7 +18,6 @@ extern crate rustc_log;
 extern crate rustc_middle;
 extern crate rustc_session;
 extern crate rustc_span;
-extern crate rustc_target;
 
 /// See docs in https://github.com/rust-lang/rust/blob/HEAD/compiler/rustc/src/main.rs
 /// and https://github.com/rust-lang/rust/pull/146627 for why we need this.
@@ -42,7 +41,6 @@ use std::ops::Range;
 use std::process::ExitCode;
 use std::rc::Rc;
 use std::str::FromStr;
-use std::sync::Once;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use miri::{
@@ -66,10 +64,9 @@ use rustc_middle::middle::exported_symbols::{
 use rustc_middle::query::LocalCrate;
 use rustc_middle::traits::{ObligationCause, ObligationCauseCode};
 use rustc_middle::ty::{self, Ty, TyCtxt};
-use rustc_session::EarlyDiagCtxt;
-use rustc_session::config::{CrateType, ErrorOutputType, OptLevel, Options};
+use rustc_session::config::{CrateType, ErrorOutputType, OptLevel};
+use rustc_session::{EarlyDiagCtxt, Session};
 use rustc_span::def_id::DefId;
-use rustc_target::spec::Target;
 
 use crate::log::setup::{deinit_loggers, init_early_loggers, init_late_loggers};
 
@@ -174,18 +171,21 @@ fn run_many_seeds(
 /// Generates the codegen backend for code that Miri will interpret: we basically
 /// use the dummy backend, except that we put the LLVM backend in charge of
 /// target features.
-fn make_miri_codegen_backend(opts: &Options, target: &Target) -> Box<dyn CodegenBackend> {
-    let early_dcx = EarlyDiagCtxt::new(opts.error_format);
+fn make_miri_codegen_backend(sess: &Session) -> Box<dyn CodegenBackend> {
+    let early_dcx = EarlyDiagCtxt::new(sess.opts.error_format);
 
     // Use the target_config method of the default codegen backend (eg LLVM) to ensure the
     // calculated target features match said backend by respecting eg -Ctarget-cpu.
-    let target_config_backend =
-        rustc_interface::util::get_codegen_backend(&early_dcx, &opts.sysroot, None, target);
-    let target_config_backend_init = Once::new();
+    let target_config_backend = rustc_interface::util::get_codegen_backend(
+        &early_dcx,
+        &sess.opts.sysroot,
+        None,
+        &sess.target,
+    );
+    target_config_backend.init(sess);
 
     Box::new(DummyCodegenBackend {
         target_config_override: Some(Box::new(move |sess| {
-            target_config_backend_init.call_once(|| target_config_backend.init(sess));
             target_config_backend.target_config(sess)
         })),
     })

--- a/tests/ui-fulldeps/run-compiler-twice.rs
+++ b/tests/ui-fulldeps/run-compiler-twice.rs
@@ -66,7 +66,7 @@ fn compile(code: String, output: PathBuf, sysroot: Sysroot, linker: Option<&Path
         file_loader: None,
         lint_caps: Default::default(),
         psess_created: None,
-        hash_untracked_state: None,
+        track_state: None,
         register_lints: None,
         override_queries: None,
         extra_symbols: Vec::new(),


### PR DESCRIPTION
* Pass Session to `make_codegen_backend` callback. This simplifies some code in miri.
* Move env/file_depinfo from ParseSess to Session. There is no reason it has to be in ParseSess rather than Session.
* Rename hash_untracked_state to track_state to indicate that it isn't just used for hashing state, but also for adding env vars and files to be tracked through the dep info file.