### PR TITLE
Remove `MTLock`

### DIFF
--- a/compiler/rustc_data_structures/src/sync.rs
+++ b/compiler/rustc_data_structures/src/sync.rs
@@ -21,11 +21,6 @@
 //! | `Lock<T>`               | `RefCell<T>`        | `RefCell<T>` or                 |
 //! |                         |                     | `parking_lot::Mutex<T>`         |
 //! | `RwLock<T>`             | `RefCell<T>`        | `parking_lot::RwLock<T>`        |
-//! | `MTLock<T>`        [^1] | `T`                 | `Lock<T>`                       |
-//!
-//! [^1]: `MTLock` is similar to `Lock`, but the serial version avoids the cost
-//! of a `RefCell`. This is appropriate when interior mutability is not
-//! required.
 
 use std::collections::HashMap;
 use std::hash::{BuildHasher, Hash};
@@ -103,38 +98,6 @@ mod mode {
 
         // Check that the mode was either uninitialized or was already set to the requested mode.
         assert!(previous.is_ok() || previous == Err(set));
-    }
-}
-
-// FIXME(parallel_compiler): Get rid of these aliases across the compiler.
-
-#[derive(Debug, Default)]
-pub struct MTLock<T>(Lock<T>);
-
-impl<T> MTLock<T> {
-    #[inline(always)]
-    pub fn new(inner: T) -> Self {
-        MTLock(Lock::new(inner))
-    }
-
-    #[inline(always)]
-    pub fn into_inner(self) -> T {
-        self.0.into_inner()
-    }
-
-    #[inline(always)]
-    pub fn get_mut(&mut self) -> &mut T {
-        self.0.get_mut()
-    }
-
-    #[inline(always)]
-    pub fn lock(&self) -> LockGuard<'_, T> {
-        self.0.lock()
-    }
-
-    #[inline(always)]
-    pub fn lock_mut(&self) -> LockGuard<'_, T> {
-        self.lock()
     }
 }
 

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -209,7 +209,7 @@ use std::cell::OnceCell;
 use std::ops::ControlFlow;
 
 use rustc_data_structures::fx::FxIndexMap;
-use rustc_data_structures::sync::{MTLock, par_for_each_in};
+use rustc_data_structures::sync::{Lock, par_for_each_in};
 use rustc_data_structures::unord::{UnordMap, UnordSet};
 use rustc_hir as hir;
 use rustc_hir::attrs::InlineAttr;
@@ -251,12 +251,12 @@ pub(crate) enum MonoItemCollectionStrategy {
 /// The state that is shared across the concurrent threads that are doing collection.
 struct SharedState<'tcx> {
     /// Items that have been or are currently being recursively collected.
-    visited: MTLock<UnordSet<MonoItem<'tcx>>>,
+    visited: Lock<UnordSet<MonoItem<'tcx>>>,
     /// Items that have been or are currently being recursively treated as "mentioned", i.e., their
     /// consts are evaluated but nothing is added to the collection.
-    mentioned: MTLock<UnordSet<MonoItem<'tcx>>>,
+    mentioned: Lock<UnordSet<MonoItem<'tcx>>>,
     /// Which items are being used where, for better errors.
-    usage_map: MTLock<UsageMap<'tcx>>,
+    usage_map: Lock<UsageMap<'tcx>>,
 }
 
 pub(crate) struct UsageMap<'tcx> {
@@ -359,7 +359,7 @@ fn collect_items_root<'tcx>(
     state: &SharedState<'tcx>,
     recursion_limit: Limit,
 ) {
-    if !state.visited.lock_mut().insert(starting_item.node) {
+    if !state.visited.lock().insert(starting_item.node) {
         // We've been here already, no need to search again.
         return;
     }
@@ -568,7 +568,7 @@ fn collect_items_rec<'tcx>(
     // This is part of the output of collection and hence only relevant for "used" items.
     // ("Mentioned" items are only considered internally during collection.)
     if mode == CollectionMode::UsedItems {
-        state.usage_map.lock_mut().record_used(starting_item.node, &used_items);
+        state.usage_map.lock().record_used(starting_item.node, &used_items);
     }
 
     {
@@ -576,13 +576,13 @@ fn collect_items_rec<'tcx>(
         if mode == CollectionMode::UsedItems {
             used_items
                 .items
-                .retain(|k, _| visited.get_mut_or_init(|| state.visited.lock_mut()).insert(*k));
+                .retain(|k, _| visited.get_mut_or_init(|| state.visited.lock()).insert(*k));
         }
 
         let mut mentioned = OnceCell::default();
         mentioned_items.items.retain(|k, _| {
             !visited.get_or_init(|| state.visited.lock()).contains(k)
-                && mentioned.get_mut_or_init(|| state.mentioned.lock_mut()).insert(*k)
+                && mentioned.get_mut_or_init(|| state.mentioned.lock()).insert(*k)
         });
     }
     if mode == CollectionMode::MentionedItems {
@@ -1810,9 +1810,9 @@ pub(crate) fn collect_crate_mono_items<'tcx>(
     debug!("building mono item graph, beginning at roots");
 
     let state = SharedState {
-        visited: MTLock::new(UnordSet::default()),
-        mentioned: MTLock::new(UnordSet::default()),
-        usage_map: MTLock::new(UsageMap::new()),
+        visited: Lock::new(UnordSet::default()),
+        mentioned: Lock::new(UnordSet::default()),
+        usage_map: Lock::new(UsageMap::new()),
     };
     let recursion_limit = tcx.recursion_limit();
 

--- a/src/doc/rustc-dev-guide/src/parallel-rustc.md
+++ b/src/doc/rustc-dev-guide/src/parallel-rustc.md
@@ -48,7 +48,6 @@ are implemented differently depending on whether `parallel-compiler` is true.
 | -------------------------------- | --------------------------------------------------- | ------------ |
 | Lock\<T> | (parking_lot::Mutex\<T>) | (std::cell::RefCell) |
 | RwLock\<T> | (parking_lot::RwLock\<T>) | (std::cell::RefCell) |
-| MTLock\<T> | (Lock\<T>) | (T) |
 | ReadGuard | parking_lot::RwLockReadGuard | std::cell::Ref |
 | MappedReadGuard | parking_lot::MappedRwLockReadGuard | std::cell::Ref |
 | WriteGuard | parking_lot::RwLockWriteGuard | std::cell::RefMut |


### PR DESCRIPTION
This removes the `MTLock` type and replaces it users with the regular `Lock`. It no longer makes sense now that we don't have a compile-time toggle for parallelism.