### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_data_structures/src/sync.rs
+++ b/compiler/rustc_data_structures/src/sync.rs
@@ -21,11 +21,6 @@
 //! | `Lock<T>`               | `RefCell<T>`        | `RefCell<T>` or                 |
 //! |                         |                     | `parking_lot::Mutex<T>`         |
 //! | `RwLock<T>`             | `RefCell<T>`        | `parking_lot::RwLock<T>`        |
-//! | `MTLock<T>`        [^1] | `T`                 | `Lock<T>`                       |
-//!
-//! [^1]: `MTLock` is similar to `Lock`, but the serial version avoids the cost
-//! of a `RefCell`. This is appropriate when interior mutability is not
-//! required.
 
 use std::collections::HashMap;
 use std::hash::{BuildHasher, Hash};
@@ -103,38 +98,6 @@ mod mode {
 
         // Check that the mode was either uninitialized or was already set to the requested mode.
         assert!(previous.is_ok() || previous == Err(set));
-    }
-}
-
-// FIXME(parallel_compiler): Get rid of these aliases across the compiler.
-
-#[derive(Debug, Default)]
-pub struct MTLock<T>(Lock<T>);
-
-impl<T> MTLock<T> {
-    #[inline(always)]
-    pub fn new(inner: T) -> Self {
-        MTLock(Lock::new(inner))
-    }
-
-    #[inline(always)]
-    pub fn into_inner(self) -> T {
-        self.0.into_inner()
-    }
-
-    #[inline(always)]
-    pub fn get_mut(&mut self) -> &mut T {
-        self.0.get_mut()
-    }
-
-    #[inline(always)]
-    pub fn lock(&self) -> LockGuard<'_, T> {
-        self.0.lock()
-    }
-
-    #[inline(always)]
-    pub fn lock_mut(&self) -> LockGuard<'_, T> {
-        self.lock()
     }
 }
 

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -209,7 +209,7 @@ use std::cell::OnceCell;
 use std::ops::ControlFlow;
 
 use rustc_data_structures::fx::FxIndexMap;
-use rustc_data_structures::sync::{MTLock, par_for_each_in};
+use rustc_data_structures::sync::{Lock, par_for_each_in};
 use rustc_data_structures::unord::{UnordMap, UnordSet};
 use rustc_hir as hir;
 use rustc_hir::attrs::InlineAttr;
@@ -251,12 +251,12 @@ pub(crate) enum MonoItemCollectionStrategy {
 /// The state that is shared across the concurrent threads that are doing collection.
 struct SharedState<'tcx> {
     /// Items that have been or are currently being recursively collected.
-    visited: MTLock<UnordSet<MonoItem<'tcx>>>,
+    visited: Lock<UnordSet<MonoItem<'tcx>>>,
     /// Items that have been or are currently being recursively treated as "mentioned", i.e., their
     /// consts are evaluated but nothing is added to the collection.
-    mentioned: MTLock<UnordSet<MonoItem<'tcx>>>,
+    mentioned: Lock<UnordSet<MonoItem<'tcx>>>,
     /// Which items are being used where, for better errors.
-    usage_map: MTLock<UsageMap<'tcx>>,
+    usage_map: Lock<UsageMap<'tcx>>,
 }
 
 pub(crate) struct UsageMap<'tcx> {
@@ -359,7 +359,7 @@ fn collect_items_root<'tcx>(
     state: &SharedState<'tcx>,
     recursion_limit: Limit,
 ) {
-    if !state.visited.lock_mut().insert(starting_item.node) {
+    if !state.visited.lock().insert(starting_item.node) {
         // We've been here already, no need to search again.
         return;
     }
@@ -568,7 +568,7 @@ fn collect_items_rec<'tcx>(
     // This is part of the output of collection and hence only relevant for "used" items.
     // ("Mentioned" items are only considered internally during collection.)
     if mode == CollectionMode::UsedItems {
-        state.usage_map.lock_mut().record_used(starting_item.node, &used_items);
+        state.usage_map.lock().record_used(starting_item.node, &used_items);
     }
 
     {
@@ -576,13 +576,13 @@ fn collect_items_rec<'tcx>(
         if mode == CollectionMode::UsedItems {
             used_items
                 .items
-                .retain(|k, _| visited.get_mut_or_init(|| state.visited.lock_mut()).insert(*k));
+                .retain(|k, _| visited.get_mut_or_init(|| state.visited.lock()).insert(*k));
         }
 
         let mut mentioned = OnceCell::default();
         mentioned_items.items.retain(|k, _| {
             !visited.get_or_init(|| state.visited.lock()).contains(k)
-                && mentioned.get_mut_or_init(|| state.mentioned.lock_mut()).insert(*k)
+                && mentioned.get_mut_or_init(|| state.mentioned.lock()).insert(*k)
         });
     }
     if mode == CollectionMode::MentionedItems {
@@ -1810,9 +1810,9 @@ pub(crate) fn collect_crate_mono_items<'tcx>(
     debug!("building mono item graph, beginning at roots");
 
     let state = SharedState {
-        visited: MTLock::new(UnordSet::default()),
-        mentioned: MTLock::new(UnordSet::default()),
-        usage_map: MTLock::new(UsageMap::new()),
+        visited: Lock::new(UnordSet::default()),
+        mentioned: Lock::new(UnordSet::default()),
+        usage_map: Lock::new(UsageMap::new()),
     };
     let recursion_limit = tcx.recursion_limit();
 

--- a/compiler/rustc_target/src/callconv/hexagon.rs
+++ b/compiler/rustc_target/src/callconv/hexagon.rs
@@ -1,36 +1,74 @@
-use rustc_abi::TyAbiInterface;
+use rustc_abi::{HasDataLayout, TyAbiInterface};
 
-use crate::callconv::{ArgAbi, FnAbi};
+use crate::callconv::{ArgAbi, FnAbi, Reg, Uniform};
 
-fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
-    if ret.layout.is_aggregate() && ret.layout.size.bits() > 64 {
-        ret.make_indirect();
-    } else {
-        ret.extend_integer_width_to(32);
+fn classify_ret<'a, Ty, C>(_cx: &C, ret: &mut ArgAbi<'a, Ty>)
+where
+    Ty: TyAbiInterface<'a, C> + Copy,
+    C: HasDataLayout,
+{
+    if !ret.layout.is_sized() {
+        return;
     }
+    if !ret.layout.is_aggregate() {
+        ret.extend_integer_width_to(32);
+        return;
+    }
+
+    let size = ret.layout.size;
+    let bits = size.bits();
+
+    // Aggregates larger than 64 bits are returned indirectly
+    if bits > 64 {
+        ret.make_indirect();
+        return;
+    }
+
+    // Small aggregates are returned in registers
+    // Cast to appropriate register type to ensure proper ABI
+    let align = ret.layout.align.bytes();
+    ret.cast_to(Uniform::consecutive(if align <= 4 { Reg::i32() } else { Reg::i64() }, size));
 }
 
 fn classify_arg<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>)
 where
     Ty: TyAbiInterface<'a, C> + Copy,
+    C: HasDataLayout,
 {
+    if !arg.layout.is_sized() {
+        return;
+    }
     if arg.layout.pass_indirectly_in_non_rustic_abis(cx) {
         arg.make_indirect();
         return;
     }
-    if arg.layout.is_aggregate() && arg.layout.size.bits() > 64 {
-        arg.make_indirect();
-    } else {
+    if !arg.layout.is_aggregate() {
         arg.extend_integer_width_to(32);
+        return;
     }
+
+    let size = arg.layout.size;
+    let bits = size.bits();
+
+    // Aggregates larger than 64 bits are passed indirectly
+    if bits > 64 {
+        arg.make_indirect();
+        return;
+    }
+
+    // Small aggregates are passed in registers
+    // Cast to consecutive register-sized chunks to match the C ABI
+    let align = arg.layout.align.bytes();
+    arg.cast_to(Uniform::consecutive(if align <= 4 { Reg::i32() } else { Reg::i64() }, size));
 }
 
 pub(crate) fn compute_abi_info<'a, Ty, C>(cx: &C, fn_abi: &mut FnAbi<'a, Ty>)
 where
     Ty: TyAbiInterface<'a, C> + Copy,
+    C: HasDataLayout,
 {
     if !fn_abi.ret.is_ignore() {
-        classify_ret(&mut fn_abi.ret);
+        classify_ret(cx, &mut fn_abi.ret);
     }
 
     for arg in fn_abi.args.iter_mut() {

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
@@ -1030,12 +1030,15 @@ impl<'a, 'tcx> FindInferSourceVisitor<'a, 'tcx> {
                         let args = self.node_args_opt(expr.hir_id)?;
                         let span = tcx.hir_span(segment.hir_id);
                         let insert_span = segment.ident.span.shrink_to_hi().with_hi(span.hi());
+                        let have_turbofish = segment.args.is_some_and(|args| {
+                            args.args.iter().any(|arg| arg.is_ty_or_const())
+                        });
                         InsertableGenericArgs {
                             insert_span,
                             args,
                             generics_def_id: def_id,
                             def_id,
-                            have_turbofish: false,
+                            have_turbofish,
                         }
                     };
                     return Box::new(insertable.into_iter());

--- a/src/bootstrap/src/core/config/flags.rs
+++ b/src/bootstrap/src/core/config/flags.rs
@@ -570,16 +570,21 @@ impl Subcommand {
 
     pub fn test_target(&self) -> TestTarget {
         match *self {
-            Subcommand::Test { all_targets, doc, tests, .. }
-            | Subcommand::Miri { all_targets, doc, tests, .. } => match (all_targets, doc, tests) {
-                (true, true, _) | (true, _, true) | (_, true, true) => {
-                    panic!("You can only set one of `--all-targets`, `--doc` and `--tests`.")
+            Subcommand::Test { mut all_targets, doc, tests, no_doc, .. }
+            | Subcommand::Miri { mut all_targets, doc, tests, no_doc, .. } => {
+                // for backwards compatibility --no-doc keeps working
+                all_targets = all_targets || no_doc;
+
+                match (all_targets, doc, tests) {
+                    (true, true, _) | (true, _, true) | (_, true, true) => {
+                        panic!("You can only set one of `--all-targets`, `--doc` and `--tests`.")
+                    }
+                    (true, false, false) => TestTarget::AllTargets,
+                    (false, true, false) => TestTarget::DocOnly,
+                    (false, false, true) => TestTarget::Tests,
+                    (false, false, false) => TestTarget::Default,
                 }
-                (true, false, false) => TestTarget::AllTargets,
-                (false, true, false) => TestTarget::DocOnly,
-                (false, false, true) => TestTarget::Tests,
-                (false, false, false) => TestTarget::Default,
-            },
+            }
             _ => TestTarget::Default,
         }
     }

--- a/src/doc/rustc-dev-guide/src/parallel-rustc.md
+++ b/src/doc/rustc-dev-guide/src/parallel-rustc.md
@@ -48,7 +48,6 @@ are implemented differently depending on whether `parallel-compiler` is true.
 | -------------------------------- | --------------------------------------------------- | ------------ |
 | Lock\<T> | (parking_lot::Mutex\<T>) | (std::cell::RefCell) |
 | RwLock\<T> | (parking_lot::RwLock\<T>) | (std::cell::RefCell) |
-| MTLock\<T> | (Lock\<T>) | (T) |
 | ReadGuard | parking_lot::RwLockReadGuard | std::cell::Ref |
 | MappedReadGuard | parking_lot::MappedRwLockReadGuard | std::cell::Ref |
 | WriteGuard | parking_lot::RwLockWriteGuard | std::cell::RefMut |

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_bad.stderr
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_bad.stderr
@@ -32,9 +32,8 @@ LL | fn check(_: impl std::marker::ConstParamTy_) {}
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `check`
 help: use parentheses to call this closure
    |
-LL -     check(|| {});
-LL +     check((|| {})());
-   |
+LL |     check((|| {})());
+   |           +     +++
 
 error[E0277]: `fn()` can't be used as a const parameter type
   --> $DIR/const_param_ty_bad.rs:9:11

--- a/tests/ui/inference/useless-turbofish-suggestion.rs
+++ b/tests/ui/inference/useless-turbofish-suggestion.rs
@@ -1,0 +1,28 @@
+// Regression test for #153732.
+//
+// When a method call already has turbofish type arguments, don't suggest
+// rewriting them — the suggestion just rewrites user syntax into
+// fully-qualified form without resolving anything.
+//
+// The span still points at the method name rather than the unresolved `_`;
+// fixing that is left as future work.
+
+struct S;
+
+impl S {
+    fn f<A, B>(self, _a: A) -> B {
+        todo!()
+    }
+}
+
+fn with_turbofish() {
+    S.f::<u32, _>(42);
+    //~^ ERROR type annotations needed
+}
+
+fn without_turbofish() {
+    S.f(42);
+    //~^ ERROR type annotations needed
+}
+
+fn main() {}

--- a/tests/ui/inference/useless-turbofish-suggestion.stderr
+++ b/tests/ui/inference/useless-turbofish-suggestion.stderr
@@ -1,0 +1,20 @@
+error[E0282]: type annotations needed
+  --> $DIR/useless-turbofish-suggestion.rs:19:7
+   |
+LL |     S.f::<u32, _>(42);
+   |       ^ cannot infer type of the type parameter `B` declared on the method `f`
+
+error[E0282]: type annotations needed
+  --> $DIR/useless-turbofish-suggestion.rs:24:7
+   |
+LL |     S.f(42);
+   |       ^ cannot infer type of the type parameter `B` declared on the method `f`
+   |
+help: consider specifying the generic arguments
+   |
+LL |     S.f::<i32, B>(42);
+   |        ++++++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0282`.

--- a/tests/ui/issues/issue-23041.stderr
+++ b/tests/ui/issues/issue-23041.stderr
@@ -3,12 +3,6 @@ error[E0282]: type annotations needed
    |
 LL |     b.downcast_ref::<fn(_)->_>();
    |       ^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the method `downcast_ref`
-   |
-help: consider specifying the generic argument
-   |
-LL -     b.downcast_ref::<fn(_)->_>();
-LL +     b.downcast_ref::<fn(_) -> _>();
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/suggest-create-closure-issue-150701.fixed
+++ b/tests/ui/suggestions/suggest-create-closure-issue-150701.fixed
@@ -1,0 +1,15 @@
+// Regression test for #150701
+
+//@ run-rustfix
+//@ edition: 2024
+
+use std::future::Future;
+
+fn f(_c: impl Future<Output = ()>) {}
+
+fn main() {
+    f((async || {})()); //~ ERROR: expected function, found `()`
+    //~^ ERROR: is not a future
+    f((async || {})());
+    //~^ ERROR: is not a future
+}

--- a/tests/ui/suggestions/suggest-create-closure-issue-150701.rs
+++ b/tests/ui/suggestions/suggest-create-closure-issue-150701.rs
@@ -1,0 +1,15 @@
+// Regression test for #150701
+
+//@ run-rustfix
+//@ edition: 2024
+
+use std::future::Future;
+
+fn f(_c: impl Future<Output = ()>) {}
+
+fn main() {
+    f(async || {}()); //~ ERROR: expected function, found `()`
+    //~^ ERROR: is not a future
+    f(async || {});
+    //~^ ERROR: is not a future
+}

--- a/tests/ui/suggestions/suggest-create-closure-issue-150701.stderr
+++ b/tests/ui/suggestions/suggest-create-closure-issue-150701.stderr
@@ -1,0 +1,51 @@
+error[E0618]: expected function, found `()`
+  --> $DIR/suggest-create-closure-issue-150701.rs:11:16
+   |
+LL |     f(async || {}());
+   |                ^^--
+   |                |
+   |                call expression requires function
+   |
+help: if you meant to create this closure and immediately call it, surround the closure with parentheses
+   |
+LL |     f((async || {})());
+   |       +           +
+
+error[E0277]: `{async closure@$DIR/suggest-create-closure-issue-150701.rs:11:7: 11:15}` is not a future
+  --> $DIR/suggest-create-closure-issue-150701.rs:11:7
+   |
+LL |     f(async || {}());
+   |     - ^^^^^^^^^^^^^ `{async closure@$DIR/suggest-create-closure-issue-150701.rs:11:7: 11:15}` is not a future
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Future` is not implemented for `{async closure@$DIR/suggest-create-closure-issue-150701.rs:11:7: 11:15}`
+note: required by a bound in `f`
+  --> $DIR/suggest-create-closure-issue-150701.rs:8:15
+   |
+LL | fn f(_c: impl Future<Output = ()>) {}
+   |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `f`
+
+error[E0277]: `{async closure@$DIR/suggest-create-closure-issue-150701.rs:13:7: 13:15}` is not a future
+  --> $DIR/suggest-create-closure-issue-150701.rs:13:7
+   |
+LL |     f(async || {});
+   |     - ^^^^^^^^^^^ `{async closure@$DIR/suggest-create-closure-issue-150701.rs:13:7: 13:15}` is not a future
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Future` is not implemented for `{async closure@$DIR/suggest-create-closure-issue-150701.rs:13:7: 13:15}`
+note: required by a bound in `f`
+  --> $DIR/suggest-create-closure-issue-150701.rs:8:15
+   |
+LL | fn f(_c: impl Future<Output = ()>) {}
+   |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `f`
+help: use parentheses to call this closure
+   |
+LL |     f((async || {})());
+   |       +           +++
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0277, E0618.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/suggestions/use-parentheses-to-call-closure-issue-145404.stderr
+++ b/tests/ui/suggestions/use-parentheses-to-call-closure-issue-145404.stderr
@@ -14,9 +14,8 @@ LL |     fn call(&self, _: impl Display) {}
    |                            ^^^^^^^ required by this bound in `S::call`
 help: use parentheses to call this closure
    |
-LL -     S.call(|| "hello");
-LL +     S.call((|| "hello")());
-   |
+LL |     S.call((|| "hello")());
+   |            +          +++
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#153751 (Detect existing turbofish on method calls to suppress useless suggestion)
 - rust-lang/rust#153780 (Remove `MTLock`)
 - rust-lang/rust#151194 (Fix wrong suggestion for returning async closure)
 - rust-lang/rust#151572 (Fix Hexagon ABI calling convention for small aggregates)
 - rust-lang/rust#153725 (Fix that `./x test --no-doc` actually keeps the same behaviour for backwards compatability)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=153751,153780,151194,151572,153725)
<!-- homu-ignore:end -->

