### PR TITLE
Actually enable the AIX Extended Altivec ABI in LLVM

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -367,6 +367,11 @@ extern "C" LLVMTargetMachineRef LLVMRustCreateTargetMachine(
 
   Options.EmitStackSizeSection = EmitStackSizeSection;
 
+  // We only support the AIX Extended Altivec ABI and not the legacy AIX ABI.
+  // This is required for using the non-volatile vector registers.
+  if (Trip.isOSAIX())
+    Options.EnableAIXExtendedAltivecABI = true;
+
 #if LLVM_VERSION_GE(21, 0)
   TargetMachine *TM = TheTarget->createTargetMachine(Trip, CPU, Feature,
                                                      Options, RM, CM, OptLevel);


### PR DESCRIPTION
As far as I can tell, the intent for the powerpc64-ibm-aix target was to enable the AIX Extended Altivec ABI, since `abi` in the target spec was set to `vec-extabi`. This field however has no effect on LLVM codegen and the AIX vector ABI is not set via `llvm_abiname`, but rather enabled in the global TargetOptions struct.

Since we only have one AIX target and I believe it should be using the newer ABI, we can unconditionally enable the target option if the target triple is an AIX triple.

r? @RalfJung perhaps? I don't think anyone in the team has AIX expertise

Also cc @nikic, I think this is a bit ugly on the LLVM side, is there perhaps a better way?