### PR TITLE
Hand-written Debug implementation for `TypeTest`

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::fmt;
 use std::rc::Rc;
 
 use rustc_data_structures::frozen::Frozen;
@@ -182,7 +183,7 @@ pub(crate) enum Cause {
 /// For more information about this translation, see
 /// `InferCtxt::process_registered_region_obligations` and
 /// `InferCtxt::type_must_outlive` in `rustc_infer::infer::InferCtxt`.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub(crate) struct TypeTest<'tcx> {
     /// The type `T` that must outlive the region.
     pub generic_kind: GenericKind<'tcx>,
@@ -196,6 +197,47 @@ pub(crate) struct TypeTest<'tcx> {
     /// A test which, if met by the region `'x`, proves that this type
     /// constraint is satisfied.
     pub verify_bound: VerifyBound<'tcx>,
+}
+
+impl fmt::Debug for TypeTest<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn fmt_bound(
+            f: &mut fmt::Formatter<'_>,
+            generic_kind: GenericKind<'_>,
+            lower: RegionVid,
+            bound: &VerifyBound<'_>,
+        ) -> fmt::Result {
+            let fmt_bounds =
+                |f: &mut fmt::Formatter<'_>, bounds: &[VerifyBound<'_>]| -> fmt::Result {
+                    let mut it = bounds.iter().peekable();
+                    while let Some(bound) = it.next() {
+                        fmt_bound(f, generic_kind, lower, bound)?;
+                        if it.peek().is_some() {
+                            write!(f, ", ")?
+                        }
+                    }
+                    Ok(())
+                };
+            match bound {
+                VerifyBound::IfEq(binder) => write!(f, "{:?} == {:?}", generic_kind, binder),
+                VerifyBound::OutlivedBy(region) => write!(f, "{region:?}: {lower:?}"),
+                VerifyBound::AnyBound(verify_bounds) => {
+                    write!(f, "Any[")?;
+                    fmt_bounds(f, verify_bounds)?;
+                    write!(f, "]")
+                }
+                VerifyBound::AllBounds(verify_bounds) => {
+                    write!(f, "All[")?;
+                    fmt_bounds(f, verify_bounds)?;
+                    write!(f, "]")
+                }
+                VerifyBound::IsEmpty => write!(f, "Empty({lower:?})"),
+            }
+        }
+        write!(f, "TypeTest from {:?}[", self.span)?;
+        fmt_bound(f, self.generic_kind, self.lower_bound, &self.verify_bound)?;
+        write!(f, "] ⊢ {:?}: {:?}", self.generic_kind, self.lower_bound)
+    }
 }
 
 /// When we have an unmet lifetime constraint, we try to propagate it outward (e.g. to a closure


### PR DESCRIPTION
This adds a hand-written debug format for `TypeTest`s that at least was helpful for me when debugging because I always struggle to remember which component is which. It formats a type test using the Unicode turnstile symbol (for "computes") to illustrate that the test encodes a typing rule that, if it holds, produces a conclusion.

The format is: `TypeTest from {originating span} {bound}  ⊢ T: 'lower_bound`, where `T` is the generic type being tested and `lower_bound` is the lower bound. Bounds are formatted as you would expect, but where the region for `'lower_bound` is included in the outlives constraints for context. I resisted the urge to turn `ALL [A, ..., Z]` into `[A  ∧ ...  ∧ Z]` etc.

## What it looks like

Here's an example of a simple type test from the test suite that says that some type `I/#0` will be lower-bounded (outlive) `?4` iff `'?1: '?4`:

Before:
```
$ RUSTC_LOG="rustc_borrowck::region_infer=debug" rustc +stage1 tests/ui/associated-types/associated-types-eq-3.rs
...
DEBUG rustc_borrowck::region_infer type tests: [
     TypeTest {
         generic_kind: I/#0,
         lower_bound: '?4,
         span: tests/ui/associated-types/associated-types-eq-3.rs:21:18: 21:25 (#0),
         verify_bound: OutlivedBy(
             '?1,
         ),
     },
     TypeTest {
         generic_kind: I/#0,
         lower_bound: '?4,
         span: tests/ui/associated-types/associated-types-eq-3.rs:21:18: 21:25 (#0),
         verify_bound: OutlivedBy(
             '?1,
         ),
     },
 ]
...
```

After:
```
$ RUSTC_LOG="rustc_borrowck::region_infer=debug" rustc +stage1 tests/ui/associated-types/associated-types-eq-3.rs
...
 DEBUG rustc_borrowck::region_infer type tests: [
     TypeTest from tests/ui/associated-types/associated-types-eq-3.rs:21:18: 21:25 (#0)['?1: '?4] ⊢ I/#0: '?4,
     TypeTest from tests/ui/associated-types/associated-types-eq-3.rs:21:18: 21:25 (#0)['?1: '?4] ⊢ I/#0: '?4,
 ]
...
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
