### PR TITLE
Remove `value_from_cycle_error` specializations

### DIFF
--- a/compiler/rustc_query_impl/src/from_cycle_error.rs
+++ b/compiler/rustc_query_impl/src/from_cycle_error.rs
@@ -26,11 +26,6 @@ pub(crate) fn specialize_query_vtables<'tcx>(vtables: &mut QueryVTables<'tcx>) {
         erase_val(ty::EarlyBinder::bind(Ty::new_error(tcx, guar)))
     };
 
-    vtables.erase_and_anonymize_regions_ty.value_from_cycle_error = |tcx, _, _, err| {
-        let guar = err.emit();
-        erase_val(Ty::new_error(tcx, guar))
-    };
-
     vtables.fn_sig.value_from_cycle_error = |tcx, key, _, err| {
         let guar = err.delay_as_bug();
         erase_val(fn_sig(tcx, key, guar))

--- a/compiler/rustc_query_impl/src/from_cycle_error.rs
+++ b/compiler/rustc_query_impl/src/from_cycle_error.rs
@@ -26,11 +26,6 @@ pub(crate) fn specialize_query_vtables<'tcx>(vtables: &mut QueryVTables<'tcx>) {
         erase_val(ty::EarlyBinder::bind(Ty::new_error(tcx, guar)))
     };
 
-    vtables.type_of_opaque_hir_typeck.value_from_cycle_error = |tcx, _, _, err| {
-        let guar = err.emit();
-        erase_val(ty::EarlyBinder::bind(Ty::new_error(tcx, guar)))
-    };
-
     vtables.erase_and_anonymize_regions_ty.value_from_cycle_error = |tcx, _, _, err| {
         let guar = err.emit();
         erase_val(Ty::new_error(tcx, guar))

--- a/compiler/rustc_query_impl/src/from_cycle_error.rs
+++ b/compiler/rustc_query_impl/src/from_cycle_error.rs
@@ -21,11 +21,6 @@ use rustc_span::{ErrorGuaranteed, Span};
 use crate::job::report_cycle;
 
 pub(crate) fn specialize_query_vtables<'tcx>(vtables: &mut QueryVTables<'tcx>) {
-    vtables.type_of.value_from_cycle_error = |tcx, _, _, err| {
-        let guar = err.emit();
-        erase_val(ty::EarlyBinder::bind(Ty::new_error(tcx, guar)))
-    };
-
     vtables.fn_sig.value_from_cycle_error = |tcx, key, _, err| {
         let guar = err.delay_as_bug();
         erase_val(fn_sig(tcx, key, guar))

--- a/tests/incremental/const-generic-type-cycle.rs
+++ b/tests/incremental/const-generic-type-cycle.rs
@@ -13,7 +13,5 @@ trait Bar<const N: usize> {}
 #[cfg(cfail)]
 trait Bar<const N: dyn BB> {}
 //[cfail]~^ ERROR cycle detected when computing type of `Bar::N`
-//[cfail]~| ERROR cycle detected when computing type of `Bar::N`
-//[cfail]~| ERROR `(dyn Bar<{ 2 + 1 }> + 'static)` is forbidden as the type of a const generic parameter
 
 trait BB = Bar<{ 2 + 1 }>;

--- a/tests/ui/consts/issue-103790.rs
+++ b/tests/ui/consts/issue-103790.rs
@@ -5,6 +5,5 @@ struct S<const S: (), const S: S = { S }>;
 //~^ ERROR the name `S` is already used for a generic parameter in this item's generic parameters
 //~| ERROR missing generics for struct `S`
 //~| ERROR cycle detected when computing type of `S::S`
-//~| ERROR `()` is forbidden as the type of a const generic parameter
 
 fn main() {}

--- a/tests/ui/consts/issue-103790.stderr
+++ b/tests/ui/consts/issue-103790.stderr
@@ -36,19 +36,7 @@ LL | struct S<const S: (), const S: S = { S }>;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error: `()` is forbidden as the type of a const generic parameter
-  --> $DIR/issue-103790.rs:4:19
-   |
-LL | struct S<const S: (), const S: S = { S }>;
-   |                   ^^
-   |
-   = note: the only supported types are integers, `bool`, and `char`
-help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
-   |
-LL + #![feature(adt_const_params)]
-   |
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0107, E0391, E0403.
 For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/delegation/unsupported.current.stderr
+++ b/tests/ui/delegation/unsupported.current.stderr
@@ -29,18 +29,13 @@ note: ...which requires comparing an impl and trait method signature, inferring 
 LL |         reuse ToReuse::opaque_ret;
    |                        ^^^^^^^^^^
    = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret::{anon_assoc#0}`, completing the cycle
-   = note: cycle used when checking effective visibilities
+note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret` is compatible with trait definition
+  --> $DIR/unsupported.rs:33:24
+   |
+LL |         reuse ToReuse::opaque_ret;
+   |                        ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error[E0283]: type annotations needed
-  --> $DIR/unsupported.rs:54:18
-   |
-LL |     reuse Trait::foo;
-   |                  ^^^ cannot infer type
-   |
-   = note: cannot satisfy `_: effects::Trait`
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-Some errors have detailed explanations: E0283, E0391.
-For more information about an error, try `rustc --explain E0283`.
+For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/delegation/unsupported.next.stderr
+++ b/tests/ui/delegation/unsupported.next.stderr
@@ -25,18 +25,9 @@ note: ...which requires comparing an impl and trait method signature, inferring 
 LL |         reuse ToReuse::opaque_ret;
    |                        ^^^^^^^^^^
    = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret::{anon_assoc#0}`, completing the cycle
-   = note: cycle used when checking effective visibilities
+   = note: cycle used when computing implied outlives bounds for `<u16 as opaque::ToReuse>::opaque_ret::{anon_assoc#0}` (hack disabled = false)
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error[E0283]: type annotations needed
-  --> $DIR/unsupported.rs:54:18
-   |
-LL |     reuse Trait::foo;
-   |                  ^^^ cannot infer type
-   |
-   = note: cannot satisfy `_: effects::Trait`
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-Some errors have detailed explanations: E0283, E0391.
-For more information about an error, try `rustc --explain E0283`.
+For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/delegation/unsupported.rs
+++ b/tests/ui/delegation/unsupported.rs
@@ -52,7 +52,6 @@ mod effects {
     }
 
     reuse Trait::foo;
-    //~^ ERROR type annotations needed
 }
 
 fn main() {}

--- a/tests/ui/impl-trait/in-trait/method-compatability-via-leakage-cycle.next.stderr
+++ b/tests/ui/impl-trait/in-trait/method-compatability-via-leakage-cycle.next.stderr
@@ -57,66 +57,6 @@ LL |     fn foo(b: bool) -> impl Sized {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error[E0391]: cycle detected when computing type of `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo::{anon_assoc#0}`
-  --> $DIR/method-compatability-via-leakage-cycle.rs:21:24
-   |
-LL |     fn foo(b: bool) -> impl Sized {
-   |                        ^^^^^^^^^^
-   |
-note: ...which requires comparing an impl and trait method signature, inferring any hidden `impl Trait` types in the process...
-  --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
-   |
-LL |     fn foo(b: bool) -> impl Sized {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires computing type of `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo::{opaque#0}`...
-  --> $DIR/method-compatability-via-leakage-cycle.rs:21:24
-   |
-LL |     fn foo(b: bool) -> impl Sized {
-   |                        ^^^^^^^^^^
-note: ...which requires computing type of opaque `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo::{opaque#0}`...
-  --> $DIR/method-compatability-via-leakage-cycle.rs:21:24
-   |
-LL |     fn foo(b: bool) -> impl Sized {
-   |                        ^^^^^^^^^^
-note: ...which requires borrow-checking `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
-  --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
-   |
-LL |     fn foo(b: bool) -> impl Sized {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires promoting constants in MIR for `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
-  --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
-   |
-LL |     fn foo(b: bool) -> impl Sized {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires checking if `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo` contains FFI-unwind calls...
-  --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
-   |
-LL |     fn foo(b: bool) -> impl Sized {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires building MIR for `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
-  --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
-   |
-LL |     fn foo(b: bool) -> impl Sized {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires match-checking `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
-  --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
-   |
-LL |     fn foo(b: bool) -> impl Sized {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires type-checking `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
-  --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
-   |
-LL |     fn foo(b: bool) -> impl Sized {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: ...which again requires computing type of `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo::{anon_assoc#0}`, completing the cycle
-note: cycle used when checking assoc item `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo` is compatible with trait definition
-  --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
-   |
-LL |     fn foo(b: bool) -> impl Sized {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/issues/issue-34373.rs
+++ b/tests/ui/issues/issue-34373.rs
@@ -6,7 +6,6 @@ trait Trait<T> {
 
 pub struct Foo<T = Box<dyn Trait<DefaultFoo>>>;
 //~^ ERROR cycle detected when computing type of `Foo::T`
-//~| ERROR type parameter `T` is never used
 type DefaultFoo = Foo;
 
 fn main() {

--- a/tests/ui/issues/issue-34373.stderr
+++ b/tests/ui/issues/issue-34373.stderr
@@ -5,7 +5,7 @@ LL | pub struct Foo<T = Box<dyn Trait<DefaultFoo>>>;
    |                                  ^^^^^^^^^^
    |
 note: ...which requires expanding type alias `DefaultFoo`...
-  --> $DIR/issue-34373.rs:10:19
+  --> $DIR/issue-34373.rs:9:19
    |
 LL | type DefaultFoo = Foo;
    |                   ^^^
@@ -17,16 +17,6 @@ LL | pub struct Foo<T = Box<dyn Trait<DefaultFoo>>>;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error[E0392]: type parameter `T` is never used
-  --> $DIR/issue-34373.rs:7:16
-   |
-LL | pub struct Foo<T = Box<dyn Trait<DefaultFoo>>>;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unused type parameter
-   |
-   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
+error: aborting due to 1 previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0391, E0392.
-For more information about an error, try `rustc --explain E0391`.
+For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122199.rs
+++ b/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122199.rs
@@ -4,7 +4,6 @@ trait Trait<const N: dyn Trait = bar> {
     fn fnc<const N: dyn Trait = u32>(&self) -> dyn Trait {
         //~^ ERROR the name `N` is already used for a generic parameter in this item's generic parameters
         //~| ERROR expected value, found builtin type `u32`
-        //~| ERROR defaults for generic parameters are not allowed here
         bar
         //~^ ERROR cannot find value `bar` in this scope
     }

--- a/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122199.stderr
+++ b/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122199.stderr
@@ -20,7 +20,7 @@ LL |     fn fnc<const N: dyn Trait = u32>(&self) -> dyn Trait {
    |                                 ^^^ not a value
 
 error[E0425]: cannot find value `bar` in this scope
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:8:9
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:7:9
    |
 LL |         bar
    |         ^^^ not found in this scope
@@ -39,13 +39,7 @@ LL | trait Trait<const N: dyn Trait = bar> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error: defaults for generic parameters are not allowed here
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:4:12
-   |
-LL |     fn fnc<const N: dyn Trait = u32>(&self) -> dyn Trait {
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0391, E0403, E0423, E0425.
 For more information about an error, try `rustc --explain E0391`.

--- a/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.rs
+++ b/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.rs
@@ -4,13 +4,11 @@ trait Foo<const N: Bar<2>> {
     //~^ WARN trait objects without an explicit `dyn` are deprecated
     //~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
     //~| ERROR cycle detected when computing type of `Foo::N`
-    //~| ERROR `(dyn Bar<2> + 'static)` is forbidden as the type of a const generic parameter
     fn func() {}
 }
 
 trait Bar<const M: Foo<2>> {}
 //~^ WARN trait objects without an explicit `dyn` are deprecated
 //~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-//~| ERROR `(dyn Foo<2> + 'static)` is forbidden as the type of a const generic parameter
 
 fn main() {}

--- a/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.stderr
+++ b/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.stderr
@@ -13,7 +13,7 @@ LL | trait Foo<const N: dyn Bar<2>> {
    |                    +++
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:11:20
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:10:20
    |
 LL | trait Bar<const M: Foo<2>> {}
    |                    ^^^^^^
@@ -32,7 +32,7 @@ LL | trait Foo<const N: Bar<2>> {
    |           ^^^^^^^^^^^^^^^
    |
 note: ...which requires computing type of `Bar::M`...
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:11:11
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:10:11
    |
 LL | trait Bar<const M: Foo<2>> {}
    |           ^^^^^^^^^^^^^^^
@@ -44,22 +44,6 @@ LL | trait Foo<const N: Bar<2>> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error: `(dyn Bar<2> + 'static)` is forbidden as the type of a const generic parameter
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:3:20
-   |
-LL | trait Foo<const N: Bar<2>> {
-   |                    ^^^^^^
-   |
-   = note: the only supported types are integers, `bool`, and `char`
-
-error: `(dyn Foo<2> + 'static)` is forbidden as the type of a const generic parameter
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:11:20
-   |
-LL | trait Bar<const M: Foo<2>> {}
-   |                    ^^^^^^
-   |
-   = note: the only supported types are integers, `bool`, and `char`
-
-error: aborting due to 3 previous errors; 2 warnings emitted
+error: aborting due to 1 previous error; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0391`.


### PR DESCRIPTION
This removes `value_from_cycle_error` specializations which are not involved in custom cycle error handling.

This is a step towards removing query cycle recovery.