### PR TITLE
Rename `rustc_middle::lint::diag_lint_level` into `lint_level`

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -30,7 +30,7 @@ use rustc_metadata::{
     walk_native_lib_search_dirs,
 };
 use rustc_middle::bug;
-use rustc_middle::lint::diag_lint_level;
+use rustc_middle::lint::emit_lint_base;
 use rustc_middle::middle::debugger_visualizer::DebuggerVisualizerFile;
 use rustc_middle::middle::dependency_format::Linkage;
 use rustc_middle::middle::exported_symbols::SymbolExportKind;
@@ -784,7 +784,7 @@ fn report_linker_output(sess: &Session, levels: CodegenLintLevels, stdout: &[u8]
     }
 
     let lint_msg = |msg| {
-        diag_lint_level(
+        emit_lint_base(
             sess,
             LINKER_MESSAGES,
             levels.linker_messages,
@@ -793,7 +793,7 @@ fn report_linker_output(sess: &Session, levels: CodegenLintLevels, stdout: &[u8]
         );
     };
     let lint_info = |msg| {
-        diag_lint_level(sess, LINKER_INFO, levels.linker_info, None, LinkerOutput { inner: msg });
+        emit_lint_base(sess, LINKER_INFO, levels.linker_info, None, LinkerOutput { inner: msg });
     };
 
     if !escaped_stderr.is_empty() {

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -514,7 +514,7 @@ pub trait LintContext {
     // set the span in their `decorate` function (preferably using set_span).
     /// Emit a lint at the appropriate level, with an optional associated span.
     ///
-    /// [`diag_lint_level`]: rustc_middle::lint::diag_lint_level#decorate-signature
+    /// [`emit_lint_base`]: rustc_middle::lint::emit_lint_base#decorate-signature
     #[track_caller]
     fn opt_span_diag_lint<S: Into<MultiSpan>>(
         &self,

--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -12,7 +12,7 @@ use rustc_index::IndexVec;
 use rustc_middle::bug;
 use rustc_middle::hir::nested_filter;
 use rustc_middle::lint::{
-    LevelAndSource, LintExpectation, LintLevelSource, ShallowLintLevelMap, diag_lint_level,
+    LevelAndSource, LintExpectation, LintLevelSource, ShallowLintLevelMap, emit_lint_base,
     reveal_actual_level,
 };
 use rustc_middle::query::Providers;
@@ -981,7 +981,7 @@ impl<'s, P: LintLevelsProvider> LintLevelsBuilder<'s, P> {
         if self.lint_added_lints {
             let lint = builtin::UNKNOWN_LINTS;
             let level = self.lint_level(builtin::UNKNOWN_LINTS);
-            diag_lint_level(
+            emit_lint_base(
                 self.sess,
                 lint,
                 level,
@@ -1008,7 +1008,7 @@ impl<'s, P: LintLevelsProvider> LintLevelsBuilder<'s, P> {
         decorator: impl for<'a> Diagnostic<'a, ()>,
     ) {
         let level = self.lint_level(lint);
-        diag_lint_level(self.sess, lint, level, span, decorator)
+        emit_lint_base(self.sess, lint, level, span, decorator)
     }
 
     #[track_caller]
@@ -1019,13 +1019,13 @@ impl<'s, P: LintLevelsProvider> LintLevelsBuilder<'s, P> {
         decorator: impl for<'a> Diagnostic<'a, ()>,
     ) {
         let level = self.lint_level(lint);
-        diag_lint_level(self.sess, lint, level, Some(span), decorator);
+        emit_lint_base(self.sess, lint, level, Some(span), decorator);
     }
 
     #[track_caller]
     pub fn emit_lint(&self, lint: &'static Lint, decorator: impl for<'a> Diagnostic<'a, ()>) {
         let level = self.lint_level(lint);
-        diag_lint_level(self.sess, lint, level, None, decorator);
+        emit_lint_base(self.sess, lint, level, None, decorator);
     }
 }
 

--- a/compiler/rustc_middle/src/lint.rs
+++ b/compiler/rustc_middle/src/lint.rs
@@ -300,11 +300,8 @@ fn explain_lint_level_source(
 ///
 /// - [`TyCtxt::emit_node_span_lint`]
 /// - `LintContext::opt_span_lint`
-///
-/// This function will replace `lint_level` once all its callers have been replaced
-/// with `diag_lint_level`.
 #[track_caller]
-pub fn diag_lint_level<'a, D: Diagnostic<'a, ()> + 'a>(
+pub fn emit_lint_base<'a, D: Diagnostic<'a, ()> + 'a>(
     sess: &'a Session,
     lint: &'static Lint,
     level: LevelAndSource,
@@ -314,7 +311,7 @@ pub fn diag_lint_level<'a, D: Diagnostic<'a, ()> + 'a>(
     // Avoid codegen bloat from monomorphization by immediately doing dyn dispatch of `decorate` to
     // the "real" work.
     #[track_caller]
-    fn diag_lint_level_impl<'a>(
+    fn emit_lint_base_impl<'a>(
         sess: &'a Session,
         lint: &'static Lint,
         level: LevelAndSource,
@@ -498,7 +495,7 @@ pub fn diag_lint_level<'a, D: Diagnostic<'a, ()> + 'a>(
         explain_lint_level_source(sess, lint, level, src, &mut err);
         err.emit();
     }
-    diag_lint_level_impl(
+    emit_lint_base_impl(
         sess,
         lint,
         level,

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -55,7 +55,7 @@ use crate::dep_graph::dep_node::make_metadata;
 use crate::dep_graph::{DepGraph, DepKindVTable, DepNodeIndex};
 use crate::ich::StableHashingContext;
 use crate::infer::canonical::{CanonicalParamEnvCache, CanonicalVarKind};
-use crate::lint::diag_lint_level;
+use crate::lint::emit_lint_base;
 use crate::metadata::ModChild;
 use crate::middle::codegen_fn_attrs::{CodegenFnAttrs, TargetFeature};
 use crate::middle::resolve_bound_vars;
@@ -2539,7 +2539,7 @@ impl<'tcx> TyCtxt<'tcx> {
         decorator: impl for<'a> Diagnostic<'a, ()>,
     ) {
         let level = self.lint_level_at_node(lint, hir_id);
-        diag_lint_level(self.sess, lint, level, Some(span.into()), decorator)
+        emit_lint_base(self.sess, lint, level, Some(span.into()), decorator)
     }
 
     /// Find the appropriate span where `use` and outer attributes can be inserted at.
@@ -2582,7 +2582,7 @@ impl<'tcx> TyCtxt<'tcx> {
         decorator: impl for<'a> Diagnostic<'a, ()>,
     ) {
         let level = self.lint_level_at_node(lint, id);
-        diag_lint_level(self.sess, lint, level, None, decorator);
+        emit_lint_base(self.sess, lint, level, None, decorator);
     }
 
     pub fn in_scope_traits(self, id: HirId) -> Option<&'tcx [TraitCandidate<'tcx>]> {


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/153099.

Renaming back `diag_lint_level` into `lint_level` since the original function was completely replaced and removed.

r? @JonathanBrouwer 