### PR TITLE
Fix regression when dealing with generics/values with unresolved inference

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -2832,6 +2832,10 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         trait_predicate: ty::PolyTraitPredicate<'tcx>,
         root_obligation: &PredicateObligation<'tcx>,
     ) -> (PredicateObligation<'tcx>, ty::PolyTraitPredicate<'tcx>) {
+        if obligation.predicate.has_non_region_param() || obligation.has_non_region_infer() {
+            return (obligation.clone(), trait_predicate);
+        }
+
         let ocx = ObligationCtxt::new(self);
         let normalized_predicate = self.tcx.erase_and_anonymize_regions(
             self.tcx.instantiate_bound_regions_with_erased(trait_predicate),

--- a/tests/ui/transmutability/generic-transmute-from-regression.rs
+++ b/tests/ui/transmutability/generic-transmute-from-regression.rs
@@ -1,0 +1,11 @@
+//! Regression test for: <https://github.com/rust-lang/rust/issues/153755>
+#![feature(transmutability)]
+
+fn foo<T, U>(x: T) -> U {
+    unsafe {
+        std::mem::TransmuteFrom::transmute(x)
+        //~^ ERROR: the trait bound `U: TransmuteFrom<T, _>` is not satisfied [E0277]
+    }
+}
+
+fn main() {}

--- a/tests/ui/transmutability/generic-transmute-from-regression.stderr
+++ b/tests/ui/transmutability/generic-transmute-from-regression.stderr
@@ -1,0 +1,11 @@
+error[E0277]: the trait bound `U: TransmuteFrom<T, _>` is not satisfied
+  --> $DIR/generic-transmute-from-regression.rs:6:44
+   |
+LL |         std::mem::TransmuteFrom::transmute(x)
+   |         ---------------------------------- ^ the nightly-only, unstable trait `TransmuteFrom<T, _>` is not implemented for `U`
+   |         |
+   |         required by a bound introduced by this call
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Follow up for rust-lang/rust#151703, fixing regression caused in rollup rust-lang/rust#152825

Forgot to handle generics & unresolved inference variables (as in `get_safe_transmute_error_and_reason`) in my previous PR. This followup checks for them before trying to normalize.

I am not completely sure its right approach to have this check cloned but as `select_transmute_obligation_for_reporting` fn just chooses obligation and doesn't actually return an error, this check shouldn't be removed from `get_safe_transmute_error_and_reasnon`. If there is any better solution, let me kmow.

Fixes: rust-lang/rust#153755

r? @jdonszelmann 