### PR TITLE
tests/debuginfo/basic-stepping.rs: Add lldb test

### DIFF
--- a/tests/debuginfo/basic-stepping.rs
+++ b/tests/debuginfo/basic-stepping.rs
@@ -14,9 +14,9 @@
 //@ revisions: default-mir-passes no-SingleUseConsts-mir-pass
 //@ [no-SingleUseConsts-mir-pass] compile-flags: -Zmir-enable-passes=-SingleUseConsts
 
+// === GDB TESTS ===================================================================================
+
 //@ gdb-command: run
-// FIXME(#97083): Should we be able to break on initialization of zero-sized types?
-// FIXME(#97083): Right now the first breakable line is:
 //@ gdb-check:   let mut c = 27;
 //@ gdb-command: next
 //@ gdb-check:   let d = c = 99;
@@ -39,9 +39,62 @@
 //@ gdb-command: next
 //@ gdb-check:   let m: *const() = &a;
 
+// === LLDB TESTS ==================================================================================
+
+// Unlike gdb, lldb will display 7 lines of context by default. It seems
+// impossible to get it down to 1. The best we can do is to show the current
+// line and one above. That is not ideal, but it will do for now.
+//@ lldb-command: settings set stop-line-count-before 1
+//@ lldb-command: settings set stop-line-count-after 0
+
+//@ lldb-command: run
+// In `breakpoint_callback()` in `./src/etc/lldb_batchmode.py` we do
+// `SetSelectedFrame()`, which causes LLDB to show the current line and one line
+// before (since we changed `stop-line-count-before`). Note that
+// `normalize_whitespace()` in `lldb_batchmode.py` removes the newlines of the
+// output. So the current line and the line before actually ends up on the same
+// output line. That's fine.
+//@ lldb-check:   [...]let mut c = 27;[...]
+//@ lldb-command: next
+// From now on we must manually `frame select` to see the current line (and one
+// line before).
+//@ lldb-command: frame select
+//@ lldb-check:   [...]let d = c = 99;[...]
+//@ lldb-command: next
+//@ lldb-command: frame select
+//@ [no-SingleUseConsts-mir-pass] lldb-check:   [...]let e = "hi bob";[...]
+//@ [no-SingleUseConsts-mir-pass] lldb-command: next
+//@ [no-SingleUseConsts-mir-pass] lldb-command: frame select
+//@ [no-SingleUseConsts-mir-pass] lldb-check:   [...]let f = b"hi bob";[...]
+//@ [no-SingleUseConsts-mir-pass] lldb-command: next
+//@ [no-SingleUseConsts-mir-pass] lldb-command: frame select
+//@ [no-SingleUseConsts-mir-pass] lldb-check:   [...]let g = b'9';[...]
+//@ [no-SingleUseConsts-mir-pass] lldb-command: next
+//@ [no-SingleUseConsts-mir-pass] lldb-command: frame select
+//@ lldb-check:   [...]let h = ["whatever"; 8];[...]
+//@ lldb-command: next
+//@ lldb-command: frame select
+//@ lldb-check:   [...]let i = [1,2,3,4];[...]
+//@ lldb-command: next
+//@ lldb-command: frame select
+//@ lldb-check:   [...]let j = (23, "hi");[...]
+//@ lldb-command: next
+//@ lldb-command: frame select
+//@ lldb-check:   [...]let k = 2..3;[...]
+//@ lldb-command: next
+//@ lldb-command: frame select
+//@ lldb-check:   [...]let l = &i[k];[...]
+//@ lldb-command: next
+//@ lldb-command: frame select
+//@ lldb-check:   [...]let m: *const() = &a;[...]
+
+#![allow(unused_assignments, unused_variables)]
+
 fn main () {
     let a = (); // #break
     let b : [i32; 0] = [];
+    // FIXME(#97083): Should we be able to break on initialization of zero-sized types?
+    // FIXME(#97083): Right now the first breakable line is:
     let mut c = 27;
     let d = c = 99;
     let e = "hi bob";


### PR DESCRIPTION
Also move the FIXME to the source code to avoid duplication, and also suppress harmless warnings that are annoying when you compile manually.

Takes us one step closer towards closing rust-lang/rust#33013.