### PR TITLE
Point turbofish inference errors at the uninferred generic arg

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
@@ -1260,21 +1260,33 @@ impl<'a, 'tcx> Visitor<'tcx> for FindInferSourceVisitor<'a, 'tcx> {
                 have_turbofish,
             } = args;
             let generics = tcx.generics_of(generics_def_id);
-            if let Some(mut argument_index) = generics
+            if let Some((argument_index, _)) = generics
                 .own_args(args)
                 .iter()
-                .position(|&arg| self.generic_arg_contains_target(arg))
+                .enumerate()
+                .find(|&(_, &arg)| self.generic_arg_contains_target(arg))
             {
-                if generics.has_own_self() {
-                    argument_index += 1;
-                }
                 let args = self.tecx.resolve_vars_if_possible(args);
                 let generic_args =
                     &generics.own_args_no_defaults(tcx, args)[generics.own_counts().lifetimes..];
                 let span = match expr.kind {
-                    ExprKind::MethodCall(path, ..) => path.ident.span,
+                    ExprKind::MethodCall(segment, ..)
+                        if have_turbofish
+                            && let Some(hir_args) = segment.args
+                            && let Some(idx) =
+                                argument_index.checked_sub(generics.own_counts().lifetimes)
+                            && let Some(arg) =
+                                hir_args.args.get(hir_args.num_lifetime_params() + idx) =>
+                    {
+                        arg.span()
+                    }
+                    ExprKind::MethodCall(segment, ..) => segment.ident.span,
                     _ => expr.span,
                 };
+                let mut argument_index = argument_index;
+                if generics.has_own_self() {
+                    argument_index += 1;
+                }
 
                 self.update_infer_source(InferSource {
                     span,

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
@@ -1260,11 +1260,10 @@ impl<'a, 'tcx> Visitor<'tcx> for FindInferSourceVisitor<'a, 'tcx> {
                 have_turbofish,
             } = args;
             let generics = tcx.generics_of(generics_def_id);
-            if let Some((argument_index, _)) = generics
+            if let Some(argument_index) = generics
                 .own_args(args)
                 .iter()
-                .enumerate()
-                .find(|&(_, &arg)| self.generic_arg_contains_target(arg))
+                .position(|&arg| self.generic_arg_contains_target(arg))
             {
                 let args = self.tecx.resolve_vars_if_possible(args);
                 let generic_args =

--- a/tests/ui/const-generics/generic_const_exprs/issue-105608.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-105608.stderr
@@ -1,8 +1,8 @@
 error[E0282]: type annotations needed
-  --> $DIR/issue-105608.rs:13:22
+  --> $DIR/issue-105608.rs:13:28
    |
 LL |     Combination::<0>.and::<_>().and::<_>();
-   |                      ^^^ cannot infer type of the type parameter `M` declared on the method `and`
+   |                            ^ cannot infer type of the type parameter `M` declared on the method `and`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inference/useless-turbofish-suggestion.rs
+++ b/tests/ui/inference/useless-turbofish-suggestion.rs
@@ -4,8 +4,8 @@
 // rewriting them — the suggestion just rewrites user syntax into
 // fully-qualified form without resolving anything.
 //
-// The span still points at the method name rather than the unresolved `_`;
-// fixing that is left as future work.
+// When a turbofish is present, the diagnostic points at the specific
+// uninferred generic argument rather than the method name.
 
 struct S;
 
@@ -15,8 +15,13 @@ impl S {
     }
 }
 
-fn with_turbofish() {
+fn turbofish_second_arg() {
     S.f::<u32, _>(42);
+    //~^ ERROR type annotations needed
+}
+
+fn turbofish_first_arg() {
+    S.f::<_, _>(42);
     //~^ ERROR type annotations needed
 }
 

--- a/tests/ui/inference/useless-turbofish-suggestion.stderr
+++ b/tests/ui/inference/useless-turbofish-suggestion.stderr
@@ -1,11 +1,17 @@
 error[E0282]: type annotations needed
-  --> $DIR/useless-turbofish-suggestion.rs:19:7
+  --> $DIR/useless-turbofish-suggestion.rs:19:16
    |
 LL |     S.f::<u32, _>(42);
-   |       ^ cannot infer type of the type parameter `B` declared on the method `f`
+   |                ^ cannot infer type of the type parameter `B` declared on the method `f`
 
 error[E0282]: type annotations needed
-  --> $DIR/useless-turbofish-suggestion.rs:24:7
+  --> $DIR/useless-turbofish-suggestion.rs:24:14
+   |
+LL |     S.f::<_, _>(42);
+   |              ^ cannot infer type of the type parameter `B` declared on the method `f`
+
+error[E0282]: type annotations needed
+  --> $DIR/useless-turbofish-suggestion.rs:29:7
    |
 LL |     S.f(42);
    |       ^ cannot infer type of the type parameter `B` declared on the method `f`
@@ -15,6 +21,6 @@ help: consider specifying the generic arguments
 LL |     S.f::<i32, B>(42);
    |        ++++++++++
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0282`.

--- a/tests/ui/issues/issue-23041.stderr
+++ b/tests/ui/issues/issue-23041.stderr
@@ -1,8 +1,8 @@
 error[E0282]: type annotations needed
-  --> $DIR/issue-23041.rs:6:7
+  --> $DIR/issue-23041.rs:6:22
    |
 LL |     b.downcast_ref::<fn(_)->_>();
-   |       ^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the method `downcast_ref`
+   |                      ^^^^^^^^ cannot infer type of the type parameter `T` declared on the method `downcast_ref`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/span/issue-42234-unknown-receiver-type.stderr
+++ b/tests/ui/span/issue-42234-unknown-receiver-type.stderr
@@ -12,10 +12,10 @@ LL |     let x: Option<_> = None::<T>;
    |                            +++++
 
 error[E0282]: type annotations needed
-  --> $DIR/issue-42234-unknown-receiver-type.rs:12:10
+  --> $DIR/issue-42234-unknown-receiver-type.rs:12:16
    |
 LL |         .sum::<_>()
-   |          ^^^ cannot infer type of the type parameter `S` declared on the method `sum`
+   |                ^ cannot infer type of the type parameter `S` declared on the method `sum`
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Follow-up to rust-lang/rust#153751.

When a method call has a turbofish with an uninferred generic argument, point the diagnostic span at the specific `_` that couldn't be inferred instead of the method name.

Before:
```rust
LL |     S.f::<u32, _>(42);
   |       ^ cannot infer type of the type parameter `B`
```

After:
```rust
LL |     S.f::<u32, _>(42);
   |                ^ cannot infer type of the type parameter `B`
```

Path expressions (`None::<_>`, `foo::<_>()`) are not handled yet, that's a separate code path.

cc @eggyal