### PR TITLE
Fix ICE when combining #[eii] with #[core::contracts::ensures]

### DIFF
--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -814,6 +814,15 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                         {
                             rustc_parse::fake_token_stream_for_item(&self.cx.sess.psess, item_inner)
                         }
+                        Annotatable::Item(item_inner) if item_inner.tokens.is_none() => {
+                            rustc_parse::fake_token_stream_for_item(&self.cx.sess.psess, item_inner)
+                        }
+                        Annotatable::ForeignItem(item_inner) if item_inner.tokens.is_none() => {
+                            rustc_parse::fake_token_stream_for_foreign_item(
+                                &self.cx.sess.psess,
+                                item_inner,
+                            )
+                        }
                         _ => item.to_tokens(),
                     };
                     let attr_item = attr.get_normal_item();

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -817,6 +817,18 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                         Annotatable::Item(item_inner) if item_inner.tokens.is_none() => {
                             rustc_parse::fake_token_stream_for_item(&self.cx.sess.psess, item_inner)
                         }
+                        // When a function has EII implementations attached (via `eii_impls`),
+                        // use fake tokens so the pretty-printer re-emits the EII attribute
+                        // (e.g. `#[hello]`) in the token stream. Without this, the EII
+                        // attribute is lost during the token roundtrip performed by
+                        // `AttrProcMacro` expanders like `contracts::requires/ensures`,
+                        // breaking the EII link on the resulting re-parsed item.
+                        Annotatable::Item(item_inner)
+                            if matches!(&item_inner.kind,
+                                ItemKind::Fn(f) if !f.eii_impls.is_empty()) =>
+                        {
+                            rustc_parse::fake_token_stream_for_item(&self.cx.sess.psess, item_inner)
+                        }
                         Annotatable::ForeignItem(item_inner) if item_inner.tokens.is_none() => {
                             rustc_parse::fake_token_stream_for_foreign_item(
                                 &self.cx.sess.psess,

--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -257,6 +257,15 @@ pub fn fake_token_stream_for_item(psess: &ParseSess, item: &ast::Item) -> TokenS
     unwrap_or_emit_fatal(source_str_to_stream(psess, filename, source, Some(item.span)))
 }
 
+pub fn fake_token_stream_for_foreign_item(
+    psess: &ParseSess,
+    item: &ast::ForeignItem,
+) -> TokenStream {
+    let source = pprust::foreign_item_to_string(item);
+    let filename = FileName::macro_expansion_source_code(&source);
+    unwrap_or_emit_fatal(source_str_to_stream(psess, filename, source, Some(item.span)))
+}
+
 pub fn fake_token_stream_for_crate(psess: &ParseSess, krate: &ast::Crate) -> TokenStream {
     let source = pprust::crate_to_string_for_macros(krate);
     let filename = FileName::macro_expansion_source_code(&source);

--- a/tests/ui/eii/eii_impl_with_contract.rs
+++ b/tests/ui/eii/eii_impl_with_contract.rs
@@ -1,0 +1,20 @@
+//@ run-pass
+//@ ignore-backends: gcc
+//@ ignore-windows
+
+#![feature(extern_item_impls)]
+#![feature(contracts)]
+#![allow(incomplete_features)]
+
+#[eii(hello)]
+fn hello(x: u64);
+
+#[hello]
+#[core::contracts::requires(x > 0)]
+fn hello_impl(x: u64) {
+    println!("{x:?}")
+}
+
+fn main() {
+    hello(42);
+}

--- a/tests/ui/eii/ice_contract_attr_on_eii_generated_item.rs
+++ b/tests/ui/eii/ice_contract_attr_on_eii_generated_item.rs
@@ -1,0 +1,12 @@
+//@ compile-flags: --crate-type rlib
+
+#![feature(extern_item_impls)]
+#![feature(contracts)]
+//~^ WARN the feature `contracts` is incomplete
+
+#[eii]
+#[core::contracts::ensures]
+//~^ ERROR contract annotations is only supported in functions with bodies
+//~| ERROR contract annotations can only be used on functions
+fn implementation() {}
+//~^ ERROR cannot find value `implementation` in module `self`

--- a/tests/ui/eii/ice_contract_attr_on_eii_generated_item.rs
+++ b/tests/ui/eii/ice_contract_attr_on_eii_generated_item.rs
@@ -2,11 +2,10 @@
 
 #![feature(extern_item_impls)]
 #![feature(contracts)]
-//~^ WARN the feature `contracts` is incomplete
+#![allow(incomplete_features)]
 
 #[eii]
 #[core::contracts::ensures]
 //~^ ERROR contract annotations is only supported in functions with bodies
 //~| ERROR contract annotations can only be used on functions
-fn implementation() {}
-//~^ ERROR cannot find value `implementation` in module `self`
+fn implementation();

--- a/tests/ui/eii/ice_contract_attr_on_eii_generated_item.stderr
+++ b/tests/ui/eii/ice_contract_attr_on_eii_generated_item.stderr
@@ -1,0 +1,30 @@
+error: contract annotations is only supported in functions with bodies
+  --> $DIR/ice_contract_attr_on_eii_generated_item.rs:8:1
+   |
+LL | #[core::contracts::ensures]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: contract annotations can only be used on functions
+  --> $DIR/ice_contract_attr_on_eii_generated_item.rs:8:1
+   |
+LL | #[core::contracts::ensures]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0425]: cannot find value `implementation` in module `self`
+  --> $DIR/ice_contract_attr_on_eii_generated_item.rs:11:4
+   |
+LL | fn implementation() {}
+   |    ^^^^^^^^^^^^^^ not found in `self`
+
+warning: the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/ice_contract_attr_on_eii_generated_item.rs:4:12
+   |
+LL | #![feature(contracts)]
+   |            ^^^^^^^^^
+   |
+   = note: see issue #128044 <https://github.com/rust-lang/rust/issues/128044> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: aborting due to 3 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/eii/ice_contract_attr_on_eii_generated_item.stderr
+++ b/tests/ui/eii/ice_contract_attr_on_eii_generated_item.stderr
@@ -10,21 +10,5 @@ error: contract annotations can only be used on functions
 LL | #[core::contracts::ensures]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0425]: cannot find value `implementation` in module `self`
-  --> $DIR/ice_contract_attr_on_eii_generated_item.rs:11:4
-   |
-LL | fn implementation() {}
-   |    ^^^^^^^^^^^^^^ not found in `self`
+error: aborting due to 2 previous errors
 
-warning: the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/ice_contract_attr_on_eii_generated_item.rs:4:12
-   |
-LL | #![feature(contracts)]
-   |            ^^^^^^^^^
-   |
-   = note: see issue #128044 <https://github.com/rust-lang/rust/issues/128044> for more information
-   = note: `#[warn(incomplete_features)]` on by default
-
-error: aborting due to 3 previous errors; 1 warning emitted
-
-For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
Fixes rust-lang/rust#153745

Builtin attribute macros like #[eii] generate AST items programmatically without collected tokens. When another attribute macro was present on the same item, the compiler would panic in TokenStream::from_ast() trying to tokenize the generated items during subsequent attribute expansion.

Generate fake token streams (via pretty-print and re-parse) for Item and ForeignItem nodes that lack collected tokens, following the existing pattern used for Crate and out-of-line modules.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
