### PR TITLE
Compiletest: Fix compare-output-by-lines directive

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2718,18 +2718,19 @@ impl<'test> TestCx<'test> {
         // Wrapper tools set by `runner` might provide extra output on failure,
         // for example a WebAssembly runtime might print the stack trace of an
         // `unreachable` instruction by default.
-        //
+        let compare_output_by_lines_subset = self.config.runner.is_some();
+
         // Also, some tests like `ui/parallel-rustc` have non-deterministic
         // orders of output, so we need to compare by lines.
-        let compare_output_by_lines =
-            self.props.compare_output_by_lines || self.config.runner.is_some();
+        let compare_output_by_lines = self.props.compare_output_by_lines;
 
         let tmp;
-        let (expected, actual): (&str, &str) = if compare_output_by_lines {
+        let (expected, actual): (&str, &str) = if compare_output_by_lines_subset {
             let actual_lines: HashSet<_> = actual.lines().collect();
             let expected_lines: Vec<_> = expected.lines().collect();
             let mut used = expected_lines.clone();
             used.retain(|line| actual_lines.contains(line));
+
             // check if `expected` contains a subset of the lines of `actual`
             if used.len() == expected_lines.len() && (expected.is_empty() == actual.is_empty()) {
                 return CompareOutcome::Same;
@@ -2738,8 +2739,19 @@ impl<'test> TestCx<'test> {
                 // if we have no lines to check, force a full overwite
                 ("", actual)
             } else {
+                // this prints/blesses the subset, not the actual
                 tmp = (expected_lines.join("\n"), used.join("\n"));
                 (&tmp.0, &tmp.1)
+            }
+        } else if compare_output_by_lines {
+            let mut actual_lines: Vec<&str> = actual.lines().collect();
+            let mut expected_lines: Vec<&str> = expected.lines().collect();
+            actual_lines.sort_unstable();
+            expected_lines.sort_unstable();
+            if actual_lines == expected_lines {
+                return CompareOutcome::Same;
+            } else {
+                (expected, actual)
             }
         } else {
             (expected, actual)

--- a/tests/ui/parallel-rustc/cycle_crash-issue-135870.stderr
+++ b/tests/ui/parallel-rustc/cycle_crash-issue-135870.stderr
@@ -1,10 +1,20 @@
+error[E0391]: cycle detected when checking if `FOO` is a trivial const
   --> $DIR/cycle_crash-issue-135870.rs:6:1
    |
 LL | const FOO: usize = FOO;
    | ^^^^^^^^^^^^^^^^
    |
+note: ...which requires building MIR for `FOO`...
+  --> $DIR/cycle_crash-issue-135870.rs:6:1
    |
 LL | const FOO: usize = FOO;
+   | ^^^^^^^^^^^^^^^^
+   = note: ...which again requires checking if `FOO` is a trivial const, completing the cycle
+note: cycle used when simplifying constant for the type system `FOO`
+  --> $DIR/cycle_crash-issue-135870.rs:6:1
+   |
+LL | const FOO: usize = FOO;
+   | ^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 1 previous error

--- a/tests/ui/parallel-rustc/ty-variance-issue-124423.stderr
+++ b/tests/ui/parallel-rustc/ty-variance-issue-124423.stderr
@@ -244,10 +244,10 @@ LL | fn elided4(_: &impl Copy + 'a) ->  new  { x(x) }
    |                                    ^^^ not found in this scope
 
 error[E0224]: at least one trait is required for an object type
-  --> $DIR/ty-variance-issue-124423.rs:35:39
+  --> $DIR/ty-variance-issue-124423.rs:55:40
    |
-LL | fn elided3(_: &impl Copy + 'a) -> Box<dyn 'a> { Box::new(x) }
-   |                                       ^^^^^^
+LL | impl<'a> LifetimeTrait<'a> for &'a Box<dyn 'a> {}
+   |                                        ^^^^^^
 
 error[E0224]: at least one trait is required for an object type
   --> $DIR/ty-variance-issue-124423.rs:41:40
@@ -256,10 +256,10 @@ LL | fn x<'b>(_: &'a impl Copy + 'a) -> Box<dyn 'b> { Box::u32(x) }
    |                                        ^^^^^^
 
 error[E0224]: at least one trait is required for an object type
-  --> $DIR/ty-variance-issue-124423.rs:55:40
+  --> $DIR/ty-variance-issue-124423.rs:35:39
    |
-LL | impl<'a> LifetimeTrait<'a> for &'a Box<dyn 'a> {}
-   |                                        ^^^^^^
+LL | fn elided3(_: &impl Copy + 'a) -> Box<dyn 'a> { Box::new(x) }
+   |                                       ^^^^^^
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/ty-variance-issue-124423.rs:8:34
@@ -278,6 +278,7 @@ note: if you're trying to build a new `Box<_, _>` consider using one of the foll
       Box::<T>::new_uninit
       Box::<T>::new_zeroed
       Box::<T>::try_new
+      and 27 others
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
 
 error: aborting due to 30 previous errors

--- a/tests/ui/parallel-rustc/ty-variance-issue-127971.stderr
+++ b/tests/ui/parallel-rustc/ty-variance-issue-127971.stderr
@@ -104,6 +104,7 @@ note: if you're trying to build a new `Box<_, _>` consider using one of the foll
       Box::<T>::new_uninit
       Box::<T>::new_zeroed
       Box::<T>::try_new
+      and 27 others
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
 
 error: aborting due to 11 previous errors

--- a/tests/ui/parallel-rustc/unexpected-type-issue-120601.stderr
+++ b/tests/ui/parallel-rustc/unexpected-type-issue-120601.stderr
@@ -1,4 +1,5 @@
 error[E0670]: `async fn` is not permitted in Rust 2015
+  --> $DIR/unexpected-type-issue-120601.rs:10:1
    |
 LL | async fn foo() -> Result<(), ()> {
    | ^^^^^ to use `async fn`, switch to Rust 2018 or later
@@ -7,6 +8,7 @@ LL | async fn foo() -> Result<(), ()> {
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0670]: `async fn` is not permitted in Rust 2015
+  --> $DIR/unexpected-type-issue-120601.rs:16:1
    |
 LL | async fn tuple() -> Tuple {
    | ^^^^^ to use `async fn`, switch to Rust 2018 or later
@@ -15,6 +17,7 @@ LL | async fn tuple() -> Tuple {
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0670]: `async fn` is not permitted in Rust 2015
+  --> $DIR/unexpected-type-issue-120601.rs:21:1
    |
 LL | async fn match_() {
    | ^^^^^ to use `async fn`, switch to Rust 2018 or later
@@ -22,12 +25,8 @@ LL | async fn match_() {
    = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
-error[E0425]: cannot find function, tuple struct or tuple variant `Unstable2` in this scope
-   |
-LL |     Unstable2(())
-   |     ^^^^^^^^^ not found in this scope
-
 error[E0308]: mismatched types
+  --> $DIR/unexpected-type-issue-120601.rs:23:9
    |
 LL |     match tuple() {
    |           ------- this expression has type `impl Future<Output = Tuple>`
@@ -40,6 +39,12 @@ help: consider `await`ing on the `Future`
    |
 LL |     match tuple().await {
    |                  ++++++
+
+error[E0425]: cannot find function, tuple struct or tuple variant `Unstable2` in this scope
+  --> $DIR/unexpected-type-issue-120601.rs:11:5
+   |
+LL |     Unstable2(())
+   |     ^^^^^^^^^ not found in this scope
 
 error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Fixes: https://github.com/rust-lang/rust/issues/148235

This was checking that the blessed stderr was a subset of the stderr. Additionally, when re-blessing it would re-bless the subset that matched. So, when an extra line or comment was added and the line numbers changed, it would bless it without the line numbers.

I hope this is the intended behaviour now, my only concern is if the parallel frontend has cases where it sometimes emits less diagnostics than other times and so re-blessing the minimum was the intended behaviour? There used to be a flag called "compare-output-by-lines-subset" for this which used this logic.

r? @jieyouxu 
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
