### PR TITLE
Remove unused `SelectionCandidate::PointerLikeCandidate`

### DIFF
--- a/compiler/rustc_middle/src/traits/select.rs
+++ b/compiler/rustc_middle/src/traits/select.rs
@@ -163,9 +163,6 @@ pub enum SelectionCandidate<'tcx> {
     /// types generated for a fn pointer type (e.g., `fn(int) -> int`)
     FnPointerCandidate,
 
-    /// Builtin impl of the `PointerLike` trait.
-    PointerLikeCandidate,
-
     TraitAliasCandidate,
 
     /// Matching `dyn Trait` with a supertrait of `Trait`. The index is the

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -115,11 +115,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 ImplSource::Builtin(BuiltinImplSource::Misc, data)
             }
 
-            PointerLikeCandidate => {
-                let data = self.confirm_pointer_like_candidate(obligation);
-                ImplSource::Builtin(BuiltinImplSource::Misc, data)
-            }
-
             TraitAliasCandidate => {
                 let data = self.confirm_trait_alias_candidate(obligation);
                 ImplSource::Builtin(BuiltinImplSource::Misc, data)
@@ -636,25 +631,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         nested.push(Obligation::new(self.infcx.tcx, cause, obligation.param_env, tr));
 
         Ok(nested)
-    }
-
-    fn confirm_pointer_like_candidate(
-        &mut self,
-        obligation: &PolyTraitObligation<'tcx>,
-    ) -> PredicateObligations<'tcx> {
-        debug!(?obligation, "confirm_pointer_like_candidate");
-        let placeholder_predicate = self.infcx.enter_forall_and_leak_universe(obligation.predicate);
-        let self_ty = self.infcx.shallow_resolve(placeholder_predicate.self_ty());
-        let ty::Pat(base, _) = *self_ty.kind() else { bug!() };
-        let cause = obligation.derived_cause(ObligationCauseCode::BuiltinDerived);
-
-        self.collect_predicates_for_types(
-            obligation.param_env,
-            cause,
-            obligation.recursion_depth + 1,
-            placeholder_predicate.def_id(),
-            vec![base],
-        )
     }
 
     fn confirm_trait_alias_candidate(

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -2038,7 +2038,6 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
                 | TraitUpcastingUnsizeCandidate(_)
                 | BuiltinObjectCandidate
                 | BuiltinUnsizeCandidate
-                | PointerLikeCandidate
                 | BikeshedGuaranteedNoDropCandidate => false,
                 // Non-global param candidates have already been handled, global
                 // where-bounds get ignored.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

The `PointerLike` trait was removed in https://github.com/rust-lang/rust/pull/143308, as part of `dyn*` being removed.

`!null` pattern types were added in https://github.com/rust-lang/rust/pull/142339 , which added `SelectionCandidate::PointerLikeCandidate`, IIUC to allow pattern types to implement `PointerLike`, but `PointerLike` was removed after that PR was first written, so (I assume) that functionality was mostly removed on a rebase, but this part didn't get removed. (see an earlier version of that PR that mentioned `LangItem::PointerLike`: https://github.com/rust-lang/rust/commit/50cab826283cc94f0eb0180907545fbd7dd3d50a before it got rebased over the rollup containing 143308: https://github.com/rust-lang/rust/pull/142339#issuecomment-3037059069 )

cc @oli-obk