### PR TITLE
must_use: ignore `Result<Uninhabited, ()>` and `ControlFlow<(), Uninhabited>`

### DIFF
--- a/compiler/rustc_lint/src/unused/must_use.rs
+++ b/compiler/rustc_lint/src/unused/must_use.rs
@@ -193,11 +193,27 @@ pub fn is_ty_must_use<'tcx>(
         {
             IsTyMustUse::Trivial
         }
+        // Suppress warnings on `Result<Uninhabited, ()>` (e.g. `Result<!, ()>`).
+        ty::Adt(def, args)
+            if cx.tcx.is_diagnostic_item(sym::Result, def.did())
+                && is_uninhabited(args.type_at(0))
+                && args.type_at(1).is_unit() =>
+        {
+            IsTyMustUse::Trivial
+        }
         // Suppress warnings on `ControlFlow<Uninhabited, ()>` (e.g. `ControlFlow<!, ()>`).
         ty::Adt(def, args)
             if cx.tcx.is_diagnostic_item(sym::ControlFlow, def.did())
                 && args.type_at(1).is_unit()
                 && is_uninhabited(args.type_at(0)) =>
+        {
+            IsTyMustUse::Trivial
+        }
+        // Suppress warnings on `ControlFlow<(), Uninhabited>` (e.g. `ControlFlow<(), !>`).
+        ty::Adt(def, args)
+            if cx.tcx.is_diagnostic_item(sym::ControlFlow, def.did())
+                && args.type_at(0).is_unit()
+                && is_uninhabited(args.type_at(1)) =>
         {
             IsTyMustUse::Trivial
         }

--- a/tests/ui/lint/unused/must_use-result-uninhabited-unit.rs
+++ b/tests/ui/lint/unused/must_use-result-uninhabited-unit.rs
@@ -78,18 +78,18 @@ fn controlflow_unit_never() -> ControlFlow<(), !> {
 
 fn main() {
     result_unit_unit(); //~ ERROR: unused `Result` that must be used
-    result_infallible_unit(); //~ ERROR: unused `Result` that must be used
-    result_never_unit(); //~ ERROR: unused `Result` that must be used
-    result_myuninhabited_unit(); //~ ERROR: unused `Result` that must be used
+    result_infallible_unit();
+    result_never_unit();
+    result_myuninhabited_unit();
     result_myuninhabited_nonexhaustive_unit(); //~ ERROR: unused `Result` that must be used
-    result_unit_assoctype(S1); //~ ERROR: unused `Result` that must be used
+    result_unit_assoctype(S1);
     result_unit_assoctype(S2); //~ ERROR: unused `Result` that must be used
-    S1.method_use_assoc_type(); //~ ERROR: unused `Result` that must be used
+    S1.method_use_assoc_type();
     S2.method_use_assoc_type(); //~ ERROR: unused `Result` that must be used
 
     controlflow_unit_unit(); //~ ERROR: unused `ControlFlow` that must be used
-    controlflow_unit_infallible(); //~ ERROR: unused `ControlFlow` that must be used
-    controlflow_unit_never(); //~ ERROR: unused `ControlFlow` that must be used
+    controlflow_unit_infallible();
+    controlflow_unit_never();
 }
 
 trait AssocTypeBeforeMonomorphisation {

--- a/tests/ui/lint/unused/must_use-result-uninhabited-unit.rs
+++ b/tests/ui/lint/unused/must_use-result-uninhabited-unit.rs
@@ -1,0 +1,101 @@
+//@ edition: 2024
+//@ aux-crate:dep=must_use_result_unit_uninhabited_extern_crate.rs
+
+#![deny(unused_must_use)]
+#![feature(never_type)]
+
+use core::ops::{ControlFlow, ControlFlow::Break};
+use dep::{MyUninhabited, MyUninhabitedNonexhaustive};
+
+fn result_unit_unit() -> Result<(), ()> {
+    Err(())
+}
+
+fn result_infallible_unit() -> Result<core::convert::Infallible, ()> {
+    Err(())
+}
+
+fn result_never_unit() -> Result<!, ()> {
+    Err(())
+}
+
+fn result_myuninhabited_unit() -> Result<MyUninhabited, ()> {
+    Err(())
+}
+
+fn result_myuninhabited_nonexhaustive_unit() -> Result<MyUninhabitedNonexhaustive, ()> {
+    Err(())
+}
+
+trait AssocType {
+    type Error;
+}
+
+struct S1;
+impl AssocType for S1 {
+    type Error = !;
+}
+
+struct S2;
+impl AssocType for S2 {
+    type Error = ();
+}
+
+fn result_unit_assoctype<AT: AssocType>(_: AT) -> Result<AT::Error, ()> {
+    Err(())
+}
+
+trait UsesAssocType {
+    type Error;
+    fn method_use_assoc_type(&self) -> Result<Self::Error, ()>;
+}
+
+impl UsesAssocType for S1 {
+    type Error = !;
+    fn method_use_assoc_type(&self) -> Result<Self::Error, ()> {
+        Err(())
+    }
+}
+
+impl UsesAssocType for S2 {
+    type Error = ();
+    fn method_use_assoc_type(&self) -> Result<Self::Error, ()> {
+        Ok(())
+    }
+}
+
+fn controlflow_unit_unit() -> ControlFlow<()> {
+    Break(())
+}
+
+fn controlflow_unit_infallible() -> ControlFlow<(), core::convert::Infallible> {
+    Break(())
+}
+
+fn controlflow_unit_never() -> ControlFlow<(), !> {
+    Break(())
+}
+
+fn main() {
+    result_unit_unit(); //~ ERROR: unused `Result` that must be used
+    result_infallible_unit(); //~ ERROR: unused `Result` that must be used
+    result_never_unit(); //~ ERROR: unused `Result` that must be used
+    result_myuninhabited_unit(); //~ ERROR: unused `Result` that must be used
+    result_myuninhabited_nonexhaustive_unit(); //~ ERROR: unused `Result` that must be used
+    result_unit_assoctype(S1); //~ ERROR: unused `Result` that must be used
+    result_unit_assoctype(S2); //~ ERROR: unused `Result` that must be used
+    S1.method_use_assoc_type(); //~ ERROR: unused `Result` that must be used
+    S2.method_use_assoc_type(); //~ ERROR: unused `Result` that must be used
+
+    controlflow_unit_unit(); //~ ERROR: unused `ControlFlow` that must be used
+    controlflow_unit_infallible(); //~ ERROR: unused `ControlFlow` that must be used
+    controlflow_unit_never(); //~ ERROR: unused `ControlFlow` that must be used
+}
+
+trait AssocTypeBeforeMonomorphisation {
+    type Error;
+    fn generate(&self) -> Result<Self::Error, ()>;
+    fn process(&self) {
+        self.generate(); //~ ERROR: unused `Result` that must be used
+    }
+}

--- a/tests/ui/lint/unused/must_use-result-uninhabited-unit.stderr
+++ b/tests/ui/lint/unused/must_use-result-uninhabited-unit.stderr
@@ -16,42 +16,6 @@ LL |     let _ = result_unit_unit();
    |     +++++++
 
 error: unused `Result` that must be used
-  --> $DIR/must_use-result-uninhabited-unit.rs:81:5
-   |
-LL |     result_infallible_unit();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this `Result` may be an `Err` variant, which should be handled
-help: use `let _ = ...` to ignore the resulting value
-   |
-LL |     let _ = result_infallible_unit();
-   |     +++++++
-
-error: unused `Result` that must be used
-  --> $DIR/must_use-result-uninhabited-unit.rs:82:5
-   |
-LL |     result_never_unit();
-   |     ^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this `Result` may be an `Err` variant, which should be handled
-help: use `let _ = ...` to ignore the resulting value
-   |
-LL |     let _ = result_never_unit();
-   |     +++++++
-
-error: unused `Result` that must be used
-  --> $DIR/must_use-result-uninhabited-unit.rs:83:5
-   |
-LL |     result_myuninhabited_unit();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this `Result` may be an `Err` variant, which should be handled
-help: use `let _ = ...` to ignore the resulting value
-   |
-LL |     let _ = result_myuninhabited_unit();
-   |     +++++++
-
-error: unused `Result` that must be used
   --> $DIR/must_use-result-uninhabited-unit.rs:84:5
    |
 LL |     result_myuninhabited_nonexhaustive_unit();
@@ -64,18 +28,6 @@ LL |     let _ = result_myuninhabited_nonexhaustive_unit();
    |     +++++++
 
 error: unused `Result` that must be used
-  --> $DIR/must_use-result-uninhabited-unit.rs:85:5
-   |
-LL |     result_unit_assoctype(S1);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this `Result` may be an `Err` variant, which should be handled
-help: use `let _ = ...` to ignore the resulting value
-   |
-LL |     let _ = result_unit_assoctype(S1);
-   |     +++++++
-
-error: unused `Result` that must be used
   --> $DIR/must_use-result-uninhabited-unit.rs:86:5
    |
 LL |     result_unit_assoctype(S2);
@@ -85,18 +37,6 @@ LL |     result_unit_assoctype(S2);
 help: use `let _ = ...` to ignore the resulting value
    |
 LL |     let _ = result_unit_assoctype(S2);
-   |     +++++++
-
-error: unused `Result` that must be used
-  --> $DIR/must_use-result-uninhabited-unit.rs:87:5
-   |
-LL |     S1.method_use_assoc_type();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this `Result` may be an `Err` variant, which should be handled
-help: use `let _ = ...` to ignore the resulting value
-   |
-LL |     let _ = S1.method_use_assoc_type();
    |     +++++++
 
 error: unused `Result` that must be used
@@ -122,28 +62,6 @@ help: use `let _ = ...` to ignore the resulting value
 LL |     let _ = controlflow_unit_unit();
    |     +++++++
 
-error: unused `ControlFlow` that must be used
-  --> $DIR/must_use-result-uninhabited-unit.rs:91:5
-   |
-LL |     controlflow_unit_infallible();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `let _ = ...` to ignore the resulting value
-   |
-LL |     let _ = controlflow_unit_infallible();
-   |     +++++++
-
-error: unused `ControlFlow` that must be used
-  --> $DIR/must_use-result-uninhabited-unit.rs:92:5
-   |
-LL |     controlflow_unit_never();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `let _ = ...` to ignore the resulting value
-   |
-LL |     let _ = controlflow_unit_never();
-   |     +++++++
-
 error: unused `Result` that must be used
   --> $DIR/must_use-result-uninhabited-unit.rs:99:9
    |
@@ -156,5 +74,5 @@ help: use `let _ = ...` to ignore the resulting value
 LL |         let _ = self.generate();
    |         +++++++
 
-error: aborting due to 13 previous errors
+error: aborting due to 6 previous errors
 

--- a/tests/ui/lint/unused/must_use-result-uninhabited-unit.stderr
+++ b/tests/ui/lint/unused/must_use-result-uninhabited-unit.stderr
@@ -1,0 +1,160 @@
+error: unused `Result` that must be used
+  --> $DIR/must_use-result-uninhabited-unit.rs:80:5
+   |
+LL |     result_unit_unit();
+   |     ^^^^^^^^^^^^^^^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+note: the lint level is defined here
+  --> $DIR/must_use-result-uninhabited-unit.rs:4:9
+   |
+LL | #![deny(unused_must_use)]
+   |         ^^^^^^^^^^^^^^^
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = result_unit_unit();
+   |     +++++++
+
+error: unused `Result` that must be used
+  --> $DIR/must_use-result-uninhabited-unit.rs:81:5
+   |
+LL |     result_infallible_unit();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = result_infallible_unit();
+   |     +++++++
+
+error: unused `Result` that must be used
+  --> $DIR/must_use-result-uninhabited-unit.rs:82:5
+   |
+LL |     result_never_unit();
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = result_never_unit();
+   |     +++++++
+
+error: unused `Result` that must be used
+  --> $DIR/must_use-result-uninhabited-unit.rs:83:5
+   |
+LL |     result_myuninhabited_unit();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = result_myuninhabited_unit();
+   |     +++++++
+
+error: unused `Result` that must be used
+  --> $DIR/must_use-result-uninhabited-unit.rs:84:5
+   |
+LL |     result_myuninhabited_nonexhaustive_unit();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = result_myuninhabited_nonexhaustive_unit();
+   |     +++++++
+
+error: unused `Result` that must be used
+  --> $DIR/must_use-result-uninhabited-unit.rs:85:5
+   |
+LL |     result_unit_assoctype(S1);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = result_unit_assoctype(S1);
+   |     +++++++
+
+error: unused `Result` that must be used
+  --> $DIR/must_use-result-uninhabited-unit.rs:86:5
+   |
+LL |     result_unit_assoctype(S2);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = result_unit_assoctype(S2);
+   |     +++++++
+
+error: unused `Result` that must be used
+  --> $DIR/must_use-result-uninhabited-unit.rs:87:5
+   |
+LL |     S1.method_use_assoc_type();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = S1.method_use_assoc_type();
+   |     +++++++
+
+error: unused `Result` that must be used
+  --> $DIR/must_use-result-uninhabited-unit.rs:88:5
+   |
+LL |     S2.method_use_assoc_type();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = S2.method_use_assoc_type();
+   |     +++++++
+
+error: unused `ControlFlow` that must be used
+  --> $DIR/must_use-result-uninhabited-unit.rs:90:5
+   |
+LL |     controlflow_unit_unit();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = controlflow_unit_unit();
+   |     +++++++
+
+error: unused `ControlFlow` that must be used
+  --> $DIR/must_use-result-uninhabited-unit.rs:91:5
+   |
+LL |     controlflow_unit_infallible();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = controlflow_unit_infallible();
+   |     +++++++
+
+error: unused `ControlFlow` that must be used
+  --> $DIR/must_use-result-uninhabited-unit.rs:92:5
+   |
+LL |     controlflow_unit_never();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = controlflow_unit_never();
+   |     +++++++
+
+error: unused `Result` that must be used
+  --> $DIR/must_use-result-uninhabited-unit.rs:99:9
+   |
+LL |         self.generate();
+   |         ^^^^^^^^^^^^^^^
+   |
+   = note: this `Result` may be an `Err` variant, which should be handled
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |         let _ = self.generate();
+   |         +++++++
+
+error: aborting due to 13 previous errors
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->

Based on rust-lang/rust#147382 which ignored them in the opposite orders
@rustbot label +A-lints L-unused_must_use
<!-- homu-ignore:end -->
