### PR TITLE
rustfmt.toml: drop ignore of deleted test

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -20,7 +20,6 @@ ignore = [
     "/tests/incremental/",            # These tests are somewhat sensitive to source code layout.
     "/tests/pretty/",                 # These tests are very sensitive to source code layout.
     "/tests/run-make/export",         # These tests contain syntax errors.
-    "/tests/run-make/translation/test.rs", # This test contains syntax errors.
     "/tests/rustdoc-html/",           # Some have syntax errors, some are whitespace-sensitive.
     "/tests/rustdoc-gui/",            # Some tests are sensitive to source code layout.
     "/tests/rustdoc-ui/",             # Some have syntax errors, some are whitespace-sensitive.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->

Cross link rust-lang/rust#152455 where the test was deleted
<!-- homu-ignore:end -->
