### PR TITLE
compiletest: Use PYTHONPATH for lldb too, not only gdb

### DIFF
--- a/src/tools/compiletest/src/runtest/debuginfo.rs
+++ b/src/tools/compiletest/src/runtest/debuginfo.rs
@@ -310,12 +310,7 @@ impl TestCx<'_> {
 
             let mut gdb = Command::new(self.config.gdb.as_ref().unwrap());
 
-            // FIXME: we are propagating `PYTHONPATH` from the environment, not a compiletest flag!
-            let pythonpath = if let Ok(pp) = std::env::var("PYTHONPATH") {
-                format!("{pp}:{rust_pp_module_abs_path}")
-            } else {
-                rust_pp_module_abs_path.to_string()
-            };
+            let pythonpath = with_pythonpath_prepended(&rust_pp_module_abs_path);
             gdb.args(debugger_opts).env("PYTHONPATH", pythonpath);
 
             debugger_run_result =
@@ -458,7 +453,8 @@ impl TestCx<'_> {
         debugger_script: &Utf8Path,
     ) -> ProcRes {
         // Path containing `lldb_batchmode.py`, so that the `script` command can import it.
-        let pythonpath = self.config.src_root.join("src/etc");
+        let rust_pp_module_abs_path = self.config.src_root.join("src/etc");
+        let pythonpath = with_pythonpath_prepended(&rust_pp_module_abs_path);
 
         let mut cmd = Command::new(lldb);
         cmd.arg("--one-line")
@@ -469,5 +465,14 @@ impl TestCx<'_> {
             .env("PYTHONPATH", pythonpath);
 
         self.run_command_to_procres(&mut cmd)
+    }
+}
+
+fn with_pythonpath_prepended(some_path: &Utf8Path) -> String {
+    // FIXME: we are propagating `PYTHONPATH` from the environment, not a compiletest flag!
+    if let Ok(pp) = std::env::var("PYTHONPATH") {
+        format!("{pp}:{some_path}")
+    } else {
+        some_path.to_string()
     }
 }


### PR DESCRIPTION
That allows you to e.g. run debuginfo tests with lldb-15 on Ubuntu 24.04 like this:

    sudo apt install lldb-15 python3-six
    PYTHONPATH=/usr/lib/python3/dist-packages ./x --set build.lldb=lldb-15 test tests/debuginfo/basic-stepping.rs

See https://github.com/rust-lang/rust/pull/153792#discussion_r2929190748 for context.