### PR TITLE
Remove some dep-graph assertions.

### DIFF
--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -323,8 +323,6 @@ fn try_execute_query<'tcx, C: QueryCache, const INCR: bool>(
             // panic occurs while executing the query (or any intermediate plumbing).
             let job_guard = ActiveJobGuard { state: &query.state, key, key_hash };
 
-            debug_assert_eq!(tcx.dep_graph.is_fully_enabled(), INCR);
-
             // Delegate to another function to actually execute the query job.
             let (value, dep_node_index) = if INCR {
                 execute_job_incr(query, tcx, key, dep_node, id)
@@ -674,8 +672,6 @@ pub(super) fn execute_query_non_incr_inner<'tcx, C: QueryCache>(
     span: Span,
     key: C::Key,
 ) -> C::Value {
-    debug_assert!(!tcx.dep_graph.is_fully_enabled());
-
     ensure_sufficient_stack(|| try_execute_query::<C, false>(query, tcx, span, key, None).0)
 }
 
@@ -689,8 +685,6 @@ pub(super) fn execute_query_incr_inner<'tcx, C: QueryCache>(
     key: C::Key,
     mode: QueryMode,
 ) -> Option<C::Value> {
-    debug_assert!(tcx.dep_graph.is_fully_enabled());
-
     // Check if query execution can be skipped, for `ensure_ok` or `ensure_done`.
     // This might have the side-effect of creating a suitable DepNode, which
     // we should reuse for execution instead of creating a new one.


### PR DESCRIPTION
The call chain for a non-incremental query includes the following functions:

- execute_query_non_incr_inner (assert!)
- try_execute_query (assert!)
- execute_job_non_incr (assert!)

And likewise for an incremental query:

- execute_query_incr_inner (assert!)
- try_execute_query (assert!)
- execute_job_incr (expect)

That is five distinct functions. Every one of them has an `assert!` or `expect` call that checks that the dep-graph is/is not enabled as expected. Three cheers for defensive programming but this feels like overkill, particularly when `execute_job{,_non_incr,_incr}` each have a single call site.

This commit removes the assertions in `execute_query_*` and `try_execute_query`, leaving a check in each of the `execute_job_*` functions.

r? @cjgillot 