### PR TITLE
Add `Wake` diagnostic item for `alloc::task::Wake`

### DIFF
--- a/library/alloc/src/task.rs
+++ b/library/alloc/src/task.rs
@@ -87,6 +87,7 @@ use crate::sync::Arc;
 /// ```
 #[cfg(target_has_atomic = "ptr")]
 #[stable(feature = "wake_trait", since = "1.51.0")]
+#[rustc_diagnostic_item = "Wake"]
 pub trait Wake {
     /// Wake this task.
     #[stable(feature = "wake_trait", since = "1.51.0")]


### PR DESCRIPTION
The symbol will be defined in Clippy, as Clippy will be the sole user of the diagnostic item so far.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
