### PR TITLE
Use `horde`'s `SyncTable` for default query caches and `CtxtInterners`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1769,6 +1769,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "horde"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a61c061cf5c6363cbd605c6907dc1bf95a90e2d1da0461264b2395e0c47cb41f"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
 name = "html-checker"
 version = "0.1.0"
 dependencies = [
@@ -3935,6 +3944,7 @@ dependencies = [
  "elsa",
  "ena",
  "hashbrown 0.17.0",
+ "horde",
  "indexmap",
  "jobserver",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1722,6 +1722,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "horde"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a61c061cf5c6363cbd605c6907dc1bf95a90e2d1da0461264b2395e0c47cb41f"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
 name = "html-checker"
 version = "0.1.0"
 dependencies = [
@@ -3902,6 +3911,7 @@ dependencies = [
  "elsa",
  "ena",
  "hashbrown",
+ "horde",
  "indexmap",
  "jobserver",
  "libc",

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -10,6 +10,7 @@ bitflags = "2.4.1"
 either = "1.0"
 elsa = "1.11.0"
 ena = "0.14.3"
+horde = { version = "0.1.5", features = ["nightly"] }
 indexmap = "2.14.0"
 jobserver_crate = { version = "0.1.28", package = "jobserver" }
 measureme = "12.0.1"

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -10,6 +10,7 @@ bitflags = "2.4.1"
 either = "1.0"
 elsa = "1.11.0"
 ena = "0.14.4"
+horde = { version = "0.1.5", features = ["nightly"] }
 indexmap = "2.14.0"
 jobserver_crate = { version = "0.1.28", package = "jobserver" }
 measureme = "12.0.1"

--- a/compiler/rustc_data_structures/src/sharded.rs
+++ b/compiler/rustc_data_structures/src/sharded.rs
@@ -209,60 +209,6 @@ impl<K: Eq + Hash, V> ShardedHashMap<K, V> {
     }
 }
 
-impl<K: Eq + Hash + Copy> ShardedHashMap<K, ()> {
-    #[inline]
-    pub fn intern_ref<Q: ?Sized>(&self, value: &Q, make: impl FnOnce() -> K) -> K
-    where
-        K: Borrow<Q>,
-        Q: Hash + Eq,
-    {
-        let hash = make_hash(value);
-        let mut shard = self.lock_shard_by_hash(hash);
-
-        match table_entry(&mut shard, hash, value) {
-            Entry::Occupied(e) => e.get().0,
-            Entry::Vacant(e) => {
-                let v = make();
-                e.insert((v, ()));
-                v
-            }
-        }
-    }
-
-    #[inline]
-    pub fn intern<Q>(&self, value: Q, make: impl FnOnce(Q) -> K) -> K
-    where
-        K: Borrow<Q>,
-        Q: Hash + Eq,
-    {
-        let hash = make_hash(&value);
-        let mut shard = self.lock_shard_by_hash(hash);
-
-        match table_entry(&mut shard, hash, &value) {
-            Entry::Occupied(e) => e.get().0,
-            Entry::Vacant(e) => {
-                let v = make(value);
-                e.insert((v, ()));
-                v
-            }
-        }
-    }
-}
-
-pub trait IntoPointer {
-    /// Returns a pointer which outlives `self`.
-    fn into_pointer(&self) -> *const ();
-}
-
-impl<K: Eq + Hash + Copy + IntoPointer> ShardedHashMap<K, ()> {
-    pub fn contains_pointer_to<T: Hash + IntoPointer>(&self, value: &T) -> bool {
-        let hash = make_hash(&value);
-        let shard = self.lock_shard_by_hash(hash);
-        let value = value.into_pointer();
-        shard.find(hash, |(k, ())| k.into_pointer() == value).is_some()
-    }
-}
-
 #[inline]
 pub fn make_hash<K: Hash + ?Sized>(val: &K) -> u64 {
     let mut state = FxHasher::default();

--- a/compiler/rustc_data_structures/src/sharded.rs
+++ b/compiler/rustc_data_structures/src/sharded.rs
@@ -210,60 +210,6 @@ impl<K: Eq + Hash, V> ShardedHashMap<K, V> {
     }
 }
 
-impl<K: Eq + Hash + Copy> ShardedHashMap<K, ()> {
-    #[inline]
-    pub fn intern_ref<Q: ?Sized>(&self, value: &Q, make: impl FnOnce() -> K) -> K
-    where
-        K: Borrow<Q>,
-        Q: Hash + Eq,
-    {
-        let hash = make_hash(value);
-        let mut shard = self.lock_shard_by_hash(hash);
-
-        match table_entry(&mut shard, hash, value) {
-            Entry::Occupied(e) => e.get().0,
-            Entry::Vacant(e) => {
-                let v = make();
-                e.insert((v, ()));
-                v
-            }
-        }
-    }
-
-    #[inline]
-    pub fn intern<Q>(&self, value: Q, make: impl FnOnce(Q) -> K) -> K
-    where
-        K: Borrow<Q>,
-        Q: Hash + Eq,
-    {
-        let hash = make_hash(&value);
-        let mut shard = self.lock_shard_by_hash(hash);
-
-        match table_entry(&mut shard, hash, &value) {
-            Entry::Occupied(e) => e.get().0,
-            Entry::Vacant(e) => {
-                let v = make(value);
-                e.insert((v, ()));
-                v
-            }
-        }
-    }
-}
-
-pub trait IntoPointer {
-    /// Returns a pointer which outlives `self`.
-    fn into_pointer(&self) -> *const ();
-}
-
-impl<K: Eq + Hash + Copy + IntoPointer> ShardedHashMap<K, ()> {
-    pub fn contains_pointer_to<T: Hash + IntoPointer>(&self, value: &T) -> bool {
-        let hash = make_hash(&value);
-        let shard = self.lock_shard_by_hash(hash);
-        let value = value.into_pointer();
-        shard.find(hash, |(k, ())| k.into_pointer() == value).is_some()
-    }
-}
-
 #[inline]
 pub fn make_hash<K: Hash + ?Sized>(val: &K) -> u64 {
     let mut state = FxHasher::default();

--- a/compiler/rustc_data_structures/src/sync.rs
+++ b/compiler/rustc_data_structures/src/sync.rs
@@ -25,6 +25,7 @@
 use std::collections::HashMap;
 use std::hash::{BuildHasher, Hash};
 
+pub use horde::collect;
 pub use parking_lot::{
     MappedRwLockReadGuard as MappedReadGuard, MappedRwLockWriteGuard as MappedWriteGuard,
     RwLockReadGuard as ReadGuard, RwLockWriteGuard as WriteGuard,
@@ -41,6 +42,7 @@ pub use self::parallel::{
     broadcast, par_fns, par_for_each_in, par_join, par_map, parallel_guard, spawn,
     try_par_for_each_in,
 };
+pub use self::sync_table::{IntoPointer, LockedWrite, Read, SyncTable};
 pub use self::vec::{AppendOnlyIndexVec, AppendOnlyVec};
 pub use self::worker_local::{Registry, WorkerLocal};
 pub use crate::marker::*;
@@ -48,6 +50,7 @@ pub use crate::marker::*;
 mod freeze;
 mod lock;
 mod parallel;
+mod sync_table;
 mod vec;
 mod worker_local;
 

--- a/compiler/rustc_data_structures/src/sync.rs
+++ b/compiler/rustc_data_structures/src/sync.rs
@@ -25,6 +25,7 @@
 use std::collections::HashMap;
 use std::hash::{BuildHasher, Hash};
 
+pub use horde::collect;
 pub use parking_lot::{
     MappedRwLockReadGuard as MappedReadGuard, MappedRwLockWriteGuard as MappedWriteGuard,
     RwLockReadGuard as ReadGuard, RwLockWriteGuard as WriteGuard,
@@ -41,6 +42,7 @@ pub use self::parallel::{
     broadcast, par_fns, par_for_each_in, par_for_each_slice, par_join, par_map, parallel_guard,
     spawn, try_par_for_each_in,
 };
+pub use self::sync_table::{IntoPointer, LockedWrite, Read, SyncTable};
 pub use self::vec::{AppendOnlyIndexVec, AppendOnlyVec};
 pub use self::worker_local::{Registry, WorkerLocal};
 pub use crate::marker::*;
@@ -48,6 +50,7 @@ pub use crate::marker::*;
 mod freeze;
 mod lock;
 mod parallel;
+mod sync_table;
 mod vec;
 mod worker_local;
 

--- a/compiler/rustc_data_structures/src/sync/lock.rs
+++ b/compiler/rustc_data_structures/src/sync/lock.rs
@@ -113,6 +113,11 @@ impl<T> Lock<T> {
     }
 
     #[inline(always)]
+    pub fn mode(&self) -> Mode {
+        self.mode
+    }
+
+    #[inline(always)]
     pub fn try_lock(&self) -> Option<LockGuard<'_, T>> {
         let mode = self.mode;
         // SAFETY: This is safe since the union fields are used in accordance with `self.mode`.

--- a/compiler/rustc_data_structures/src/sync/sync_table.rs
+++ b/compiler/rustc_data_structures/src/sync/sync_table.rs
@@ -1,0 +1,229 @@
+use std::borrow::Borrow;
+use std::hash::{BuildHasher, Hash, Hasher};
+use std::hint::cold_path;
+use std::ops::{Deref, DerefMut};
+
+use horde::collect::{Pin, pin};
+pub use horde::sync_table::Read;
+use horde::sync_table::Write;
+use rustc_hash::FxBuildHasher;
+
+use crate::sync::{DynSync, Lock, LockGuard, Mode};
+
+pub struct SyncTable<K, V> {
+    // We use this lock to protect `table` instead of the internal mutex in `horde::SyncTable`
+    // as it's faster when synchronization is disabled.
+    lock: Lock<()>,
+
+    table: horde::SyncTable<K, V, FxBuildHasher>,
+}
+
+unsafe impl<K: DynSync, V: DynSync> DynSync for SyncTable<K, V> where FxBuildHasher: Sync {}
+
+impl<K, V> Default for SyncTable<K, V> {
+    fn default() -> Self {
+        Self { lock: Lock::default(), table: horde::SyncTable::default() }
+    }
+}
+
+impl<K, V> SyncTable<K, V> {
+    /// Creates a [Read] handle from a pinned region.
+    ///
+    /// Use [horde::collect::pin] to get a `Pin` instance.
+    #[inline]
+    pub fn read<'a>(&'a self, pin: Pin<'a>) -> Read<'a, K, V, FxBuildHasher> {
+        self.table.read(pin)
+    }
+
+    /// Creates a [LockedWrite] handle by taking the underlying mutex that protects writes.
+    #[inline]
+    pub fn lock(&self) -> LockedWrite<'_, K, V> {
+        LockedWrite {
+            _guard: self.lock.lock(),
+            table: {
+                // SAFETY: We ensure there's only 1 writer at a time using our own lock
+                unsafe { self.table.unsafe_write() }
+            },
+        }
+    }
+
+    /// Creates a [LockedWrite] handle by taking the underlying mutex that protects writes.
+    ///
+    /// This does not prune old tables unlike `lock`.
+    #[inline]
+    pub fn lock_no_prune(&self) -> LockedWrite<'_, K, V> {
+        LockedWrite {
+            _guard: self.lock.lock(),
+            table: {
+                // SAFETY: We ensure there's only 1 writer at a time using our own lock
+                unsafe { self.table.unsafe_write_no_prune() }
+            },
+        }
+    }
+
+    /// Hashes a key with the table's hasher.
+    #[inline]
+    pub fn hash_key<Q>(&self, key: &Q) -> u64
+    where
+        K: Borrow<Q>,
+        Q: ?Sized + Hash,
+    {
+        self.table.hash_key::<Q>(key)
+    }
+
+    pub fn len(&self) -> usize {
+        pin(|pin| self.read(pin).len())
+    }
+
+    pub fn with_capacity(cap: usize) -> Self {
+        Self { lock: Lock::new(()), table: horde::SyncTable::new_with(FxBuildHasher, cap) }
+    }
+}
+
+/// A handle to a [SyncTable] with write access protected by a lock.
+pub struct LockedWrite<'a, K, V> {
+    table: Write<'a, K, V, FxBuildHasher>,
+    _guard: LockGuard<'a, ()>,
+}
+
+impl<'a, K, V> Deref for LockedWrite<'a, K, V> {
+    type Target = Write<'a, K, V, FxBuildHasher>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.table
+    }
+}
+
+impl<'a, K, V> DerefMut for LockedWrite<'a, K, V> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.table
+    }
+}
+
+pub trait IntoPointer {
+    /// Returns a pointer which outlives `self`.
+    fn into_pointer(&self) -> *const ();
+}
+
+impl<K: Eq + Hash + Copy> SyncTable<K, ()> {
+    pub fn contains_pointer_to<T: Hash + IntoPointer>(&self, value: &T) -> bool
+    where
+        K: IntoPointer,
+    {
+        pin(|pin| {
+            let mut state = FxBuildHasher.build_hasher();
+            value.hash(&mut state);
+            let hash = state.finish();
+            let value = value.into_pointer();
+            self.read(pin).get_from_hash(hash, |entry| entry.into_pointer() == value).is_some()
+        })
+    }
+
+    #[inline]
+    pub fn intern_ref<Q: ?Sized>(&self, value: &Q, make: impl FnOnce() -> K) -> K
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        if self.lock.mode() == Mode::Sync {
+            pin(|pin| {
+                let hash = self.hash_key(value);
+
+                let potential = match self.read(pin).get_potential(&value, Some(hash)) {
+                    Ok(entry) => return *entry.0,
+                    Err(potential) => {
+                        cold_path();
+                        potential
+                    }
+                };
+
+                let mut write = self.lock();
+
+                let potential = match potential.refresh(self.read(pin), &value, Some(hash)) {
+                    Ok(entry) => {
+                        cold_path();
+                        return *entry.0;
+                    }
+                    Err(potential) => potential,
+                };
+
+                let result = make();
+
+                potential.insert_new(&mut write, result, (), Some(hash));
+
+                result
+            })
+        } else {
+            let mut write = self.lock_no_prune();
+
+            let hash = self.hash_key(&value);
+
+            let entry = write.read().get(&value, Some(hash));
+            if let Some(entry) = entry {
+                return *entry.0;
+            }
+            write.prune();
+
+            let result = make();
+
+            write.insert_new(result, (), Some(hash));
+
+            result
+        }
+    }
+
+    #[inline]
+    pub fn intern<Q>(&self, value: Q, make: impl FnOnce(Q) -> K) -> K
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        if self.lock.mode() == Mode::Sync {
+            pin(|pin| {
+                let hash = self.hash_key(&value);
+
+                let potential = match self.read(pin).get_potential(&value, Some(hash)) {
+                    Ok(entry) => return *entry.0,
+                    Err(potential) => {
+                        cold_path();
+                        potential
+                    }
+                };
+
+                let mut write = self.lock();
+
+                let potential = match potential.refresh(self.read(pin), &value, Some(hash)) {
+                    Ok(entry) => {
+                        cold_path();
+                        return *entry.0;
+                    }
+                    Err(potential) => potential,
+                };
+
+                let result = make(value);
+
+                potential.insert_new(&mut write, result, (), Some(hash));
+
+                result
+            })
+        } else {
+            let mut write = self.lock_no_prune();
+
+            let hash = self.hash_key(&value);
+
+            let entry = write.read().get(&value, Some(hash));
+            if let Some(entry) = entry {
+                return *entry.0;
+            }
+            write.prune();
+
+            let result = make(value);
+
+            write.insert_new(result, (), Some(hash));
+
+            result
+        }
+    }
+}

--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -15,7 +15,7 @@ use rustc_codegen_ssa::traits::CodegenBackend;
 use rustc_codegen_ssa::{CompiledModules, CrateInfo, TargetConfig};
 use rustc_data_structures::base_n::{CASE_INSENSITIVE, ToBaseN};
 use rustc_data_structures::jobserver::Proxy;
-use rustc_data_structures::sync;
+use rustc_data_structures::sync::{self, collect};
 use rustc_metadata::{DylibError, EncodedMetadata, load_symbol_from_dylib};
 use rustc_middle::dep_graph::WorkProductMap;
 use rustc_middle::ty::{CurrentGcx, TyCtxt};
@@ -214,7 +214,10 @@ pub(crate) fn run_in_thread_pool_with_globals<F: FnOnce(CurrentGcx) -> R + Send,
     let builder = rustc_thread_pool::ThreadPoolBuilder::new()
         .thread_name(|_| "rustc".to_string())
         .acquire_thread_handler(move || proxy.acquire_thread())
-        .release_thread_handler(move || proxy_.release_thread())
+        .release_thread_handler(move || {
+            collect::release();
+            proxy_.release_thread()
+        })
         .num_threads(threads)
         .deadlock_handler(move || {
             // On deadlock, creates a new thread and forwards information in thread

--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -16,7 +16,7 @@ use rustc_codegen_ssa::traits::CodegenBackend;
 use rustc_codegen_ssa::{CompiledModules, CrateInfo, TargetConfig};
 use rustc_data_structures::base_n::{CASE_INSENSITIVE, ToBaseN};
 use rustc_data_structures::jobserver::Proxy;
-use rustc_data_structures::sync;
+use rustc_data_structures::sync::{self, collect};
 use rustc_metadata::{DylibError, EncodedMetadata, load_symbol_from_dylib};
 use rustc_middle::dep_graph::WorkProductMap;
 use rustc_middle::ty::{CurrentGcx, TyCtxt};
@@ -230,7 +230,10 @@ pub(crate) fn run_in_thread_pool_with_globals<F: FnOnce(CurrentGcx) -> R + Send,
     let builder = rustc_thread_pool::ThreadPoolBuilder::new()
         .thread_name(|_| "rustc".to_string())
         .acquire_thread_handler(move || proxy.acquire_thread())
-        .release_thread_handler(move || proxy_.release_thread())
+        .release_thread_handler(move || {
+            collect::release();
+            proxy_.release_thread()
+        })
         .num_threads(jobs_frontend.get())
         .deadlock_handler(move || {
             // On deadlock, creates a new thread and forwards information in thread

--- a/compiler/rustc_middle/src/query/caches.rs
+++ b/compiler/rustc_middle/src/query/caches.rs
@@ -1,6 +1,7 @@
 use std::sync::OnceLock;
 
-use rustc_data_structures::sharded::ShardedHashMap;
+use rustc_data_structures::sync::SyncTable;
+use rustc_data_structures::sync::collect::pin;
 pub use rustc_data_structures::vec_cache::VecCache;
 use rustc_hir::def_id::LOCAL_CRATE;
 use rustc_index::Idx;
@@ -41,7 +42,7 @@ pub trait QueryCache: Sized {
 /// In-memory cache for queries whose keys aren't suitable for any of the
 /// more specialized kinds of cache. Backed by a sharded hashmap.
 pub struct DefaultCache<K, V> {
-    cache: ShardedHashMap<K, (V, DepNodeIndex)>,
+    cache: SyncTable<K, (V, DepNodeIndex)>,
 }
 
 impl<K, V> Default for DefaultCache<K, V> {
@@ -60,24 +61,31 @@ where
 
     #[inline(always)]
     fn lookup(&self, key: &K) -> Option<(V, DepNodeIndex)> {
-        self.cache.get(key)
+        pin(|pin| {
+            let result = self.cache.read(pin).get(key, None);
+            if let Some((_, value)) = result { Some(*value) } else { None }
+        })
     }
 
     #[inline]
     fn complete(&self, key: K, value: V, index: DepNodeIndex) {
-        self.cache.insert_unique(key, (value, index));
-    }
-
-    fn for_each(&self, f: &mut dyn FnMut(&Self::Key, &Self::Value, DepNodeIndex)) {
-        for shard in self.cache.lock_shards() {
-            for (k, v) in shard.iter() {
-                f(k, &v.0, v.1);
-            }
+        if cfg!(debug_assertions) {
+            assert!(self.cache.lock().insert(key, (value, index), None));
+        } else {
+            self.cache.lock().insert_new(key, (value, index), None);
         }
     }
 
+    fn for_each(&self, f: &mut dyn FnMut(&Self::Key, &Self::Value, DepNodeIndex)) {
+        pin(|pin| {
+            for (k, v) in self.cache.read(pin).iter() {
+                f(k, &v.0, v.1);
+            }
+        })
+    }
+
     fn len(&self) -> usize {
-        self.cache.len()
+        pin(|pin| self.cache.read(pin).len())
     }
 }
 

--- a/compiler/rustc_middle/src/query/job.rs
+++ b/compiler/rustc_middle/src/query/job.rs
@@ -4,6 +4,7 @@ use std::num::NonZero;
 use std::sync::Arc;
 
 use parking_lot::{Condvar, Mutex};
+use rustc_data_structures::sync::collect;
 use rustc_span::Span;
 
 use crate::query::Cycle;
@@ -93,6 +94,7 @@ impl<'tcx> QueryLatch<'tcx> {
         // If this detects a deadlock and the deadlock handler wants to resume this thread
         // we have to be in the `wait` call. This is ensured by the deadlock handler
         // getting the self.info lock.
+        collect::release();
         rustc_thread_pool::mark_blocked_and_wait(|| {
             waiter.condvar.wait(&mut waiters_guard);
             // Release the lock before we potentially block when acquiring jobserver token.

--- a/compiler/rustc_middle/src/query/job.rs
+++ b/compiler/rustc_middle/src/query/job.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use parking_lot::{Condvar, Mutex};
 use rustc_data_structures::hash_table::HashTable;
 use rustc_data_structures::sharded::Sharded;
+use rustc_data_structures::sync::collect;
 use rustc_span::Span;
 
 use crate::queries::TaggedQueryKey;
@@ -150,6 +151,7 @@ impl<'tcx> QueryLatch<'tcx> {
         // If this detects a deadlock and the deadlock handler wants to resume this thread
         // we have to be in the `wait` call. This is ensured by the deadlock handler
         // getting the self.info lock.
+        collect::release();
         rustc_thread_pool::mark_blocked_and_wait(|| {
             waiter.condvar.wait(&mut waiters_guard);
             // Release the lock before we potentially block when acquiring jobserver token.

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -21,11 +21,10 @@ use rustc_data_structures::defer;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::intern::Interned;
 use rustc_data_structures::profiling::SelfProfilerRef;
-use rustc_data_structures::sharded::{IntoPointer, ShardedHashMap};
 use rustc_data_structures::stable_hash::StableHash;
 use rustc_data_structures::steal::Steal;
 use rustc_data_structures::sync::{
-    self, DynSend, DynSync, FreezeReadGuard, Lock, RwLock, WorkerLocal,
+    self, DynSend, DynSync, FreezeReadGuard, IntoPointer, Lock, RwLock, SyncTable, WorkerLocal,
 };
 use rustc_errors::{Applicability, Diag, DiagCtxtHandle, Diagnostic, MultiSpan};
 use rustc_hir::def::DefKind;
@@ -128,7 +127,7 @@ impl<'tcx> rustc_type_ir::inherent::Span<TyCtxt<'tcx>> for Span {
     }
 }
 
-type InternedSet<'tcx, T> = ShardedHashMap<InternedInSet<'tcx, T>, ()>;
+type InternedSet<'tcx, T> = SyncTable<InternedInSet<'tcx, T>, ()>;
 
 pub struct CtxtInterners<'tcx> {
     /// The arena that types, regions, etc. are allocated from.
@@ -1731,6 +1730,7 @@ macro_rules! sty_debug_print {
         mod inner {
             use crate::ty::{self, TyCtxt};
             use crate::ty::context::InternedInSet;
+            use rustc_data_structures::sync::collect::pin;
 
             #[derive(Copy, Clone)]
             struct DebugStat {
@@ -1751,11 +1751,11 @@ macro_rules! sty_debug_print {
                 };
                 $(let mut $variant = total;)*
 
-                for shard in tcx.interners.type_.lock_shards() {
+                pin(|pin| {
                     // It seems that ordering doesn't affect anything here.
                     #[allow(rustc::potential_query_instability)]
-                    let types = shard.iter();
-                    for &(InternedInSet(t), ()) in types {
+                    let types = tcx.interners.type_.read(pin);
+                    for (&InternedInSet(t), _) in types.iter() {
                         let variant = match t.internee {
                             ty::Bool | ty::Char | ty::Int(..) | ty::Uint(..) |
                                 ty::Float(..) | ty::Str | ty::Never => continue,
@@ -1773,7 +1773,7 @@ macro_rules! sty_debug_print {
                         if ct { total.ct_infer += 1; variant.ct_infer += 1 }
                         if lt && ty && ct { total.all_infer += 1; variant.all_infer += 1 }
                     }
-                }
+                });
                 writeln!(fmt, "Ty interner             total           ty lt ct all")?;
                 $(writeln!(fmt, "    {:18}: {uses:6} {usespc:4.1}%, \
                             {ty:4.1}% {lt:5.1}% {ct:4.1}% {all:4.1}%",

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -22,11 +22,10 @@ use rustc_data_structures::defer;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::intern::Interned;
 use rustc_data_structures::profiling::SelfProfilerRef;
-use rustc_data_structures::sharded::{IntoPointer, ShardedHashMap};
 use rustc_data_structures::stable_hash::StableHash;
 use rustc_data_structures::steal::Steal;
 use rustc_data_structures::sync::{
-    self, DynSend, DynSync, FreezeReadGuard, Lock, RwLock, WorkerLocal,
+    self, DynSend, DynSync, FreezeReadGuard, IntoPointer, Lock, RwLock, SyncTable, WorkerLocal,
 };
 use rustc_errors::{Applicability, Diag, DiagCtxtHandle, Diagnostic, MultiSpan};
 use rustc_hir::attrs::lang_items::LangItem;
@@ -129,7 +128,7 @@ impl<'tcx> rustc_type_ir::inherent::Span<TyCtxt<'tcx>> for Span {
     }
 }
 
-type InternedSet<'tcx, T> = ShardedHashMap<InternedInSet<'tcx, T>, ()>;
+type InternedSet<'tcx, T> = SyncTable<InternedInSet<'tcx, T>, ()>;
 
 pub struct CtxtInterners<'tcx> {
     /// The arena that types, regions, etc. are allocated from.
@@ -1745,6 +1744,7 @@ macro_rules! sty_debug_print {
         mod inner {
             use crate::ty::{self, TyCtxt};
             use crate::ty::context::InternedInSet;
+            use rustc_data_structures::sync::collect::pin;
 
             #[derive(Copy, Clone)]
             struct DebugStat {
@@ -1765,11 +1765,11 @@ macro_rules! sty_debug_print {
                 };
                 $(let mut $variant = total;)*
 
-                for shard in tcx.interners.type_.lock_shards() {
+                pin(|pin| {
                     // It seems that ordering doesn't affect anything here.
                     #[allow(rustc::potential_query_instability)]
-                    let types = shard.iter();
-                    for &(InternedInSet(t), ()) in types {
+                    let types = tcx.interners.type_.read(pin);
+                    for (&InternedInSet(t), _) in types.iter() {
                         let variant = match t.internee {
                             ty::Bool | ty::Char | ty::Int(..) | ty::Uint(..) |
                                 ty::Float(..) | ty::Str | ty::Never => continue,
@@ -1787,7 +1787,7 @@ macro_rules! sty_debug_print {
                         if ct { total.ct_infer += 1; variant.ct_infer += 1 }
                         if lt && ty && ct { total.all_infer += 1; variant.all_infer += 1 }
                     }
-                }
+                });
                 writeln!(fmt, "Ty interner             total           ty lt ct all")?;
                 $(writeln!(fmt, "    {:18}: {uses:6} {usespc:4.1}%, \
                             {ty:4.1}% {lt:5.1}% {ct:4.1}% {all:4.1}%",

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -3,7 +3,7 @@ use std::mem::ManuallyDrop;
 
 use rustc_data_structures::hash_table::{Entry, HashTable};
 use rustc_data_structures::stack::ensure_sufficient_stack;
-use rustc_data_structures::sync::{DynSend, DynSync};
+use rustc_data_structures::sync::{DynSend, DynSync, collect};
 use rustc_data_structures::{defer, outline, sharded, sync};
 use rustc_errors::FatalError;
 use rustc_middle::dep_graph::{DepGraphData, DepNodeKey, SerializedDepNodeIndex};
@@ -337,6 +337,10 @@ fn try_execute_query<'tcx, C: QueryCache, const INCR: bool>(
             // Tell the guard to insert `value` in the cache and remove the status entry from
             // `query.state`.
             job_guard.complete(&query.cache, value, dep_node_index);
+
+            // Periodic memory reclamation trigger.
+            // We do this after `complete` since the default caches may have memory to free due to table expansion.
+            collect::collect();
 
             (value, Some(dep_node_index))
         }

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -3,6 +3,7 @@ use std::mem::ManuallyDrop;
 use std::num::NonZero;
 
 use rustc_data_structures::hash_table::Entry;
+use rustc_data_structures::sync::collect;
 use rustc_data_structures::{defer, outline, sharded, sync};
 use rustc_errors::FatalError;
 use rustc_middle::dep_graph::{
@@ -269,6 +270,10 @@ fn try_execute_query<'tcx, C: QueryCache, const INCR: bool>(
             // Tell the guard to insert `value` in the cache and remove the status entry from
             // `query.state`.
             job_guard.complete(&query.cache, value, dep_node_index);
+
+            // Periodic memory reclamation trigger.
+            // We do this after `complete` since the default caches may have memory to free due to table expansion.
+            collect::collect();
 
             (value, Some(dep_node_index))
         }

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -354,6 +354,7 @@ const PERMITTED_RUSTC_DEPENDENCIES: &[&str] = &[
     "gimli",
     "gsgdt",
     "hashbrown",
+    "horde",
     "icu_collections",
     "icu_list",
     "icu_locale",

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -351,6 +351,7 @@ const PERMITTED_RUSTC_DEPENDENCIES: &[&str] = &[
     "gimli",
     "gsgdt",
     "hashbrown",
+    "horde",
     "icu_collections",
     "icu_list",
     "icu_locale",


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/153826)*
<!-- homu-ignore:end -->

This uses the hash map from my [horde](https://crates.io/crates/horde) crate as the default query cache map and in `CtxtInterners`. The main benefit of it is that it offers lock-free reads.

This is a proper version of the test in https://github.com/rust-lang/rust/pull/138419.

This adds a intermediary `SyncTable` type which uses our dynamic `Lock` instead of the always-on lock integrated in `horde::SyncTable`, as this avoids lock overhead for the `-Zthreads=1` case.

This integrates the quiescent state based memory reclamation scheme by marking query execution as quiescent with `collect` and calling `release` when we're blocking.