### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_middle/src/traits/select.rs
+++ b/compiler/rustc_middle/src/traits/select.rs
@@ -163,9 +163,6 @@ pub enum SelectionCandidate<'tcx> {
     /// types generated for a fn pointer type (e.g., `fn(int) -> int`)
     FnPointerCandidate,
 
-    /// Builtin impl of the `PointerLike` trait.
-    PointerLikeCandidate,
-
     TraitAliasCandidate,
 
     /// Matching `dyn Trait` with a supertrait of `Trait`. The index is the

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -115,11 +115,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 ImplSource::Builtin(BuiltinImplSource::Misc, data)
             }
 
-            PointerLikeCandidate => {
-                let data = self.confirm_pointer_like_candidate(obligation);
-                ImplSource::Builtin(BuiltinImplSource::Misc, data)
-            }
-
             TraitAliasCandidate => {
                 let data = self.confirm_trait_alias_candidate(obligation);
                 ImplSource::Builtin(BuiltinImplSource::Misc, data)
@@ -636,25 +631,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         nested.push(Obligation::new(self.infcx.tcx, cause, obligation.param_env, tr));
 
         Ok(nested)
-    }
-
-    fn confirm_pointer_like_candidate(
-        &mut self,
-        obligation: &PolyTraitObligation<'tcx>,
-    ) -> PredicateObligations<'tcx> {
-        debug!(?obligation, "confirm_pointer_like_candidate");
-        let placeholder_predicate = self.infcx.enter_forall_and_leak_universe(obligation.predicate);
-        let self_ty = self.infcx.shallow_resolve(placeholder_predicate.self_ty());
-        let ty::Pat(base, _) = *self_ty.kind() else { bug!() };
-        let cause = obligation.derived_cause(ObligationCauseCode::BuiltinDerived);
-
-        self.collect_predicates_for_types(
-            obligation.param_env,
-            cause,
-            obligation.recursion_depth + 1,
-            placeholder_predicate.def_id(),
-            vec![base],
-        )
     }
 
     fn confirm_trait_alias_candidate(

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -2038,7 +2038,6 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
                 | TraitUpcastingUnsizeCandidate(_)
                 | BuiltinObjectCandidate
                 | BuiltinUnsizeCandidate
-                | PointerLikeCandidate
                 | BikeshedGuaranteedNoDropCandidate => false,
                 // Non-global param candidates have already been handled, global
                 // where-bounds get ignored.

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -155,6 +155,9 @@ where
     for<'a> F: FnMut(GenericShunt<'a, I, R>) -> U,
     R: Residual<U>,
 {
+    // FIXME(#11084): we might be able to get rid of GenericShunt in favor of
+    // Iterator::scan, as performance should be comparable
+
     let mut residual = None;
     let shunt = GenericShunt { iter, residual: &mut residual };
     let value = f(shunt);

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -2758,9 +2758,6 @@ impl<A, V: FromIterator<A>> FromIterator<Option<A>> for Option<V> {
     /// so the final value of `shared` is 6 (= `3 + 2 + 1`), not 16.
     #[inline]
     fn from_iter<I: IntoIterator<Item = Option<A>>>(iter: I) -> Option<V> {
-        // FIXME(#11084): This could be replaced with Iterator::scan when this
-        // performance bug is closed.
-
         iter::try_process(iter.into_iter(), |i| i.collect())
     }
 }

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -600,7 +600,7 @@
 //! automatically called [`Pin::get_unchecked_mut`].
 //!
 //! This can never cause a problem in purely safe code because creating a pinning pointer to
-//! a type which has an address-sensitive (thus does not implement `Unpin`) requires `unsafe`,
+//! a type which has address-sensitive states (and thus does not implement `Unpin`) requires `unsafe`,
 //! but it is important to note that choosing to take advantage of pinning-related guarantees
 //! to justify validity in the implementation of your type has consequences for that type's
 //! [`Drop`][Drop] implementation as well: if an element of your type could have been pinned,


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#153418 (core: remove FIXME comment in option.rs FromIterator)
 - rust-lang/rust#153569 (Fix grammar in Pin documentation)
 - rust-lang/rust#153798 (Remove unused `SelectionCandidate::PointerLikeCandidate`)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=153418,153569,153798)
<!-- homu-ignore:end -->

