### PR TITLE
Suggest `:` when `;` is used before a `macro_rules!` fragment specifier

### DIFF
--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -415,6 +415,8 @@ pub(crate) struct MissingFragmentSpecifier {
     )]
     pub add_span: Span,
     pub valid: &'static str,
+    #[suggestion("use `:` instead of `;`", code = ":", applicability = "maybe-incorrect")]
+    pub semi_span: Option<Span>,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -413,9 +413,14 @@ pub(crate) struct MissingFragmentSpecifier {
         code = ":spec",
         applicability = "maybe-incorrect"
     )]
-    pub add_span: Span,
+    pub add_span: Option<Span>,
     pub valid: &'static str,
-    #[suggestion("use `:` instead of `;`", code = ":", applicability = "maybe-incorrect")]
+    #[suggestion(
+        "use `:` instead of `;`",
+        style = "verbose",
+        code = ":",
+        applicability = "maybe-incorrect"
+    )]
     pub semi_span: Option<Span>,
 }
 

--- a/compiler/rustc_expand/src/mbe/quoted.rs
+++ b/compiler/rustc_expand/src/mbe/quoted.rs
@@ -92,7 +92,7 @@ fn parse(
         let mut missing_fragment_specifier = |span| {
             sess.dcx().emit_err(errors::MissingFragmentSpecifier {
                 span,
-                add_span: span.shrink_to_hi(),
+                add_span: Some(span.shrink_to_hi()),
                 valid: VALID_FRAGMENT_NAMES_MSG,
                 semi_span: None,
             });
@@ -146,31 +146,39 @@ fn parse(
             result.push(TokenTree::MetaVarDecl { span, name: ident, kind });
         } else {
             // Check for typo: `;` instead of `:` before a valid fragment specifier.
-            let semi_span = {
+            let typo_recovery = {
                 let mut clone = iter.clone();
                 if let Some(tokenstream::TokenTree::Token(semi_token, _)) = clone.next()
                     && semi_token.kind == token::Semi
                     && let Some(tokenstream::TokenTree::Token(frag_token, _)) = clone.next()
                     && let Some((fragment, _)) = frag_token.ident()
-                    && NonterminalKind::from_symbol(fragment.name, || edition).is_some()
                 {
-                    Some(semi_token.span)
+                    let span = frag_token.span.with_lo(start_sp.lo());
+                    let edition = || {
+                        // FIXME(#85708) - once we properly decode a foreign
+                        // crate's `SyntaxContext::root`, then we can replace
+                        // this with just `span.edition()`. A
+                        // `SyntaxContext::root()` from the current crate will
+                        // have the edition of the current crate, and a
+                        // `SyntaxContext::root()` from a foreign crate will
+                        // have the edition of that crate (which we manually
+                        // retrieve via the `edition` parameter).
+                        if !span.from_expansion() { edition } else { span.edition() }
+                    };
+                    NonterminalKind::from_symbol(fragment.name, edition)
+                        .map(|kind| (semi_token.span, span, kind))
                 } else {
                     None
                 }
             };
-            if semi_span.is_some() {
+            if let Some((semi_span, span, kind)) = typo_recovery {
                 sess.dcx().emit_err(errors::MissingFragmentSpecifier {
                     span: start_sp,
-                    add_span: start_sp.shrink_to_hi(),
+                    add_span: None,
                     valid: VALID_FRAGMENT_NAMES_MSG,
-                    semi_span,
+                    semi_span: Some(semi_span),
                 });
-                result.push(TokenTree::MetaVarDecl {
-                    span: start_sp,
-                    name: ident,
-                    kind: NonterminalKind::TT,
-                });
+                result.push(TokenTree::MetaVarDecl { span, name: ident, kind });
             } else {
                 missing_fragment_specifier(start_sp);
             }

--- a/compiler/rustc_expand/src/mbe/quoted.rs
+++ b/compiler/rustc_expand/src/mbe/quoted.rs
@@ -94,6 +94,7 @@ fn parse(
                 span,
                 add_span: span.shrink_to_hi(),
                 valid: VALID_FRAGMENT_NAMES_MSG,
+                semi_span: None,
             });
 
             // Fall back to a `TokenTree` since that will match anything if we continue expanding.
@@ -144,9 +145,35 @@ fn parse(
             });
             result.push(TokenTree::MetaVarDecl { span, name: ident, kind });
         } else {
-            // Whether it's none or some other tree, it doesn't belong to
-            // the current meta variable, returning the original span.
-            missing_fragment_specifier(start_sp);
+            // Check for typo: `;` instead of `:` before a valid fragment specifier.
+            let semi_span = {
+                let mut clone = iter.clone();
+                if let Some(tokenstream::TokenTree::Token(semi_token, _)) = clone.next()
+                    && semi_token.kind == token::Semi
+                    && let Some(tokenstream::TokenTree::Token(frag_token, _)) = clone.next()
+                    && let Some((fragment, _)) = frag_token.ident()
+                    && NonterminalKind::from_symbol(fragment.name, || edition).is_some()
+                {
+                    Some(semi_token.span)
+                } else {
+                    None
+                }
+            };
+            if semi_span.is_some() {
+                sess.dcx().emit_err(errors::MissingFragmentSpecifier {
+                    span: start_sp,
+                    add_span: start_sp.shrink_to_hi(),
+                    valid: VALID_FRAGMENT_NAMES_MSG,
+                    semi_span,
+                });
+                result.push(TokenTree::MetaVarDecl {
+                    span: start_sp,
+                    name: ident,
+                    kind: NonterminalKind::TT,
+                });
+            } else {
+                missing_fragment_specifier(start_sp);
+            }
         }
     }
     result

--- a/tests/ui/macros/macro-semicolon-for-colon.rs
+++ b/tests/ui/macros/macro-semicolon-for-colon.rs
@@ -2,8 +2,7 @@
 // produces a helpful suggestion.
 
 macro_rules! m {
-    ($x;tt) => {};
-    //~^ ERROR missing fragment specifier
+    ($x;ty) => {}; //~ ERROR missing fragment specifier
 }
 
 fn main() {}

--- a/tests/ui/macros/macro-semicolon-for-colon.rs
+++ b/tests/ui/macros/macro-semicolon-for-colon.rs
@@ -1,0 +1,9 @@
+// Ensure that using `;` instead of `:` in a macro fragment specifier
+// produces a helpful suggestion.
+
+macro_rules! m {
+    ($x;tt) => {};
+    //~^ ERROR missing fragment specifier
+}
+
+fn main() {}

--- a/tests/ui/macros/macro-semicolon-for-colon.stderr
+++ b/tests/ui/macros/macro-semicolon-for-colon.stderr
@@ -1,0 +1,19 @@
+error: missing fragment specifier
+  --> $DIR/macro-semicolon-for-colon.rs:5:6
+   |
+LL |     ($x;tt) => {};
+   |      ^^
+   |
+   = note: fragment specifiers must be provided
+   = help: valid fragment specifiers are `ident`, `block`, `stmt`, `expr`, `pat`, `ty`, `lifetime`, `literal`, `path`, `meta`, `tt`, `item` and `vis`, along with `expr_2021` and `pat_param` for edition compatibility
+help: try adding a specifier here
+   |
+LL |     ($x:spec;tt) => {};
+   |        +++++
+help: use `:` instead of `;`
+   |
+LL -     ($x;tt) => {};
+LL +     ($x:tt) => {};
+   |
+
+error: aborting due to 1 previous error

--- a/tests/ui/macros/macro-semicolon-for-colon.stderr
+++ b/tests/ui/macros/macro-semicolon-for-colon.stderr
@@ -1,19 +1,15 @@
 error: missing fragment specifier
   --> $DIR/macro-semicolon-for-colon.rs:5:6
    |
-LL |     ($x;tt) => {};
+LL |     ($x;ty) => {};
    |      ^^
    |
    = note: fragment specifiers must be provided
    = help: valid fragment specifiers are `ident`, `block`, `stmt`, `expr`, `pat`, `ty`, `lifetime`, `literal`, `path`, `meta`, `tt`, `item` and `vis`, along with `expr_2021` and `pat_param` for edition compatibility
-help: try adding a specifier here
-   |
-LL |     ($x:spec;tt) => {};
-   |        +++++
 help: use `:` instead of `;`
    |
-LL -     ($x;tt) => {};
-LL +     ($x:tt) => {};
+LL -     ($x;ty) => {};
+LL +     ($x:ty) => {};
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/macros/macro-semicolon-for-colon.stderr
+++ b/tests/ui/macros/macro-semicolon-for-colon.stderr
@@ -17,3 +17,4 @@ LL +     ($x:tt) => {};
    |
 
 error: aborting due to 1 previous error
+


### PR DESCRIPTION
Closes rust-lang/rust#153320

Add a suggestion for the case where `;` is written instead of `:` before a valid `macro_rules!` fragment specifier.

For that semicolon typo case, this also removes the generic “try adding a specifier here” help and keeps the parsed fragment kind during recovery, so `$x;ty` recovers as `$x:ty`.