### PR TITLE
Cleanup handling of `f128` intrinsics in GCC

### DIFF
--- a/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
@@ -119,16 +119,6 @@ fn get_simple_function<'gcc, 'tcx>(
             ];
             (cx.double_type, parameters, "fminimum")
         }
-        sym::minimumf128 => {
-            let f128_type = cx.type_f128();
-            // GCC doesn't have the intrinsic we want so we use the compiler-builtins one
-            // https://docs.rs/compiler_builtins/latest/compiler_builtins/math/full_availability/fn.fminimumf128.html
-            let parameters = [
-                cx.context.new_parameter(None, f128_type, "a"),
-                cx.context.new_parameter(None, f128_type, "b"),
-            ];
-            (f128_type, parameters, "fminimumf128")
-        }
         sym::maximumf32 => {
             let parameters = [
                 cx.context.new_parameter(None, cx.float_type, "a"),
@@ -142,16 +132,6 @@ fn get_simple_function<'gcc, 'tcx>(
                 cx.context.new_parameter(None, cx.double_type, "b"),
             ];
             (cx.double_type, parameters, "fmaximum")
-        }
-        sym::maximumf128 => {
-            let f128_type = cx.type_f128();
-            // GCC doesn't have the intrinsic we want so we use the compiler-builtins one
-            // https://docs.rs/compiler_builtins/latest/compiler_builtins/math/full_availability/fn.fmaximumf128.html
-            let parameters = [
-                cx.context.new_parameter(None, f128_type, "a"),
-                cx.context.new_parameter(None, f128_type, "b"),
-            ];
-            (f128_type, parameters, "fmaximumf128")
         }
         _ => return None,
     };
@@ -197,6 +177,11 @@ fn get_simple_function_f128_2args<'gcc, 'tcx>(
 ) -> Option<Function<'gcc>> {
     let func_name = match name {
         _ if !cx.supports_f128_type => return None,
+        // GCC doesn't have the intrinsic we want so we use the compiler-builtins one
+        // https://docs.rs/compiler_builtins/latest/compiler_builtins/math/full_availability/fn.fmaximumf128.html
+        // https://docs.rs/compiler_builtins/latest/compiler_builtins/math/full_availability/fn.fminimumf128.html
+        sym::maximumf128 => "fmaximumf128",
+        sym::minimumf128 => "fminimumf128",
         sym::maxnumf128 => "fmaxf128",
         sym::minnumf128 => "fminf128",
         sym::copysignf128 => "copysignf128",

--- a/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
@@ -148,9 +148,8 @@ fn get_simple_function<'gcc, 'tcx>(
 fn get_simple_function_f128<'gcc, 'tcx>(
     cx: &CodegenCx<'gcc, 'tcx>,
     name: Symbol,
-) -> Option<Function<'gcc>> {
+) -> Function<'gcc> {
     let func_name = match name {
-        _ if !cx.supports_f128_type => return None,
         sym::ceilf128 => "ceilf128",
         sym::fabsf128 => "fabsf128",
         sym::floorf128 => "floorf128",
@@ -158,25 +157,24 @@ fn get_simple_function_f128<'gcc, 'tcx>(
         sym::roundf128 => "roundf128",
         sym::round_ties_even_f128 => "roundevenf128",
         sym::sqrtf128 => "sqrtf128",
-        _ => return None,
+        _ => unreachable!(),
     };
     let f128_type = cx.type_f128();
-    Some(cx.context.new_function(
+    cx.context.new_function(
         None,
         FunctionType::Extern,
         f128_type,
         &[cx.context.new_parameter(None, f128_type, "a")],
         func_name,
         false,
-    ))
+    )
 }
 
 fn get_simple_function_f128_2args<'gcc, 'tcx>(
     cx: &CodegenCx<'gcc, 'tcx>,
     name: Symbol,
-) -> Option<Function<'gcc>> {
+) -> Function<'gcc> {
     let func_name = match name {
-        _ if !cx.supports_f128_type => return None,
         // GCC doesn't have the intrinsic we want so we use the compiler-builtins one
         // https://docs.rs/compiler_builtins/latest/compiler_builtins/math/full_availability/fn.fmaximumf128.html
         // https://docs.rs/compiler_builtins/latest/compiler_builtins/math/full_availability/fn.fminimumf128.html
@@ -185,10 +183,10 @@ fn get_simple_function_f128_2args<'gcc, 'tcx>(
         sym::maxnumf128 => "fmaxf128",
         sym::minnumf128 => "fminf128",
         sym::copysignf128 => "copysignf128",
-        _ => return None,
+        _ => unreachable!(),
     };
     let f128_type = cx.type_f128();
-    Some(cx.context.new_function(
+    cx.context.new_function(
         None,
         FunctionType::Extern,
         f128_type,
@@ -198,7 +196,7 @@ fn get_simple_function_f128_2args<'gcc, 'tcx>(
         ],
         func_name,
         false,
-    ))
+    )
 }
 
 fn f16_builtin<'gcc, 'tcx>(
@@ -245,11 +243,7 @@ impl<'a, 'gcc, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'a, 'gcc, 'tc
         let fn_args = instance.args;
 
         let simple = get_simple_intrinsic(self, name);
-        // TODO(antoyo): Only call get_simple_function_f128 and get_simple_function_f128_2args when
-        // it is the symbols for the supported f128 builtins.
-        let simple_func = get_simple_function(self, name)
-            .or_else(|| get_simple_function_f128(self, name))
-            .or_else(|| get_simple_function_f128_2args(self, name));
+        let simple_func = get_simple_function(self, name);
 
         let value = match name {
             _ if simple.is_some() => {
@@ -280,6 +274,34 @@ impl<'a, 'gcc, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'a, 'gcc, 'tc
             | sym::round_ties_even_f16
             | sym::sqrtf16
             | sym::truncf16 => f16_builtin(self, name, args),
+            sym::ceilf128
+            | sym::fabsf128
+            | sym::floorf128
+            | sym::truncf128
+            | sym::roundf128
+            | sym::round_ties_even_f128
+            | sym::sqrtf128
+                if self.cx.supports_f128_type =>
+            {
+                self.cx.context.new_call(
+                    self.location,
+                    get_simple_function_f128(self, name),
+                    &args.iter().map(|arg| arg.immediate()).collect::<Vec<_>>(),
+                )
+            }
+            sym::maximumf128
+            | sym::minimumf128
+            | sym::maxnumf128
+            | sym::minnumf128
+            | sym::copysignf128
+                if self.cx.supports_f128_type =>
+            {
+                self.cx.context.new_call(
+                    self.location,
+                    get_simple_function_f128_2args(self, name),
+                    &args.iter().map(|arg| arg.immediate()).collect::<Vec<_>>(),
+                )
+            }
             sym::fmaf128 => {
                 let f128_type = self.cx.type_f128();
                 let func = self.cx.context.new_function(

--- a/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
@@ -169,12 +169,8 @@ fn get_simple_function_f128<'gcc, 'tcx>(
     cx: &CodegenCx<'gcc, 'tcx>,
     name: Symbol,
 ) -> Option<Function<'gcc>> {
-    if !cx.supports_f128_type {
-        return None;
-    }
-
-    let f128_type = cx.type_f128();
     let func_name = match name {
+        _ if !cx.supports_f128_type => return None,
         sym::ceilf128 => "ceilf128",
         sym::fabsf128 => "fabsf128",
         sym::floorf128 => "floorf128",
@@ -184,6 +180,7 @@ fn get_simple_function_f128<'gcc, 'tcx>(
         sym::sqrtf128 => "sqrtf128",
         _ => return None,
     };
+    let f128_type = cx.type_f128();
     Some(cx.context.new_function(
         None,
         FunctionType::Extern,
@@ -198,17 +195,14 @@ fn get_simple_function_f128_2args<'gcc, 'tcx>(
     cx: &CodegenCx<'gcc, 'tcx>,
     name: Symbol,
 ) -> Option<Function<'gcc>> {
-    if !cx.supports_f128_type {
-        return None;
-    }
-
-    let f128_type = cx.type_f128();
     let func_name = match name {
+        _ if !cx.supports_f128_type => return None,
         sym::maxnumf128 => "fmaxf128",
         sym::minnumf128 => "fminf128",
         sym::copysignf128 => "copysignf128",
         _ => return None,
     };
+    let f128_type = cx.type_f128();
     Some(cx.context.new_function(
         None,
         FunctionType::Extern,

--- a/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
@@ -76,42 +76,10 @@ fn get_simple_intrinsic<'gcc, 'tcx>(
         sym::minnumf64 => "fmin",
         sym::minimumf32 => "fminimumf",
         sym::minimumf64 => "fminimum",
-        sym::minimumf128 => {
-            // GCC doesn't have the intrinsic we want so we use the compiler-builtins one
-            // https://docs.rs/compiler_builtins/latest/compiler_builtins/math/full_availability/fn.fminimumf128.html
-            let f128_type = cx.type_f128();
-            return Some(cx.context.new_function(
-                None,
-                FunctionType::Extern,
-                f128_type,
-                &[
-                    cx.context.new_parameter(None, f128_type, "a"),
-                    cx.context.new_parameter(None, f128_type, "b"),
-                ],
-                "fminimumf128",
-                false,
-            ));
-        }
         sym::maxnumf32 => "fmaxf",
         sym::maxnumf64 => "fmax",
         sym::maximumf32 => "fmaximumf",
         sym::maximumf64 => "fmaximum",
-        sym::maximumf128 => {
-            // GCC doesn't have the intrinsic we want so we use the compiler-builtins one
-            // https://docs.rs/compiler_builtins/latest/compiler_builtins/math/full_availability/fn.fmaximumf128.html
-            let f128_type = cx.type_f128();
-            return Some(cx.context.new_function(
-                None,
-                FunctionType::Extern,
-                f128_type,
-                &[
-                    cx.context.new_parameter(None, f128_type, "a"),
-                    cx.context.new_parameter(None, f128_type, "b"),
-                ],
-                "fmaximumf128",
-                false,
-            ));
-        }
         sym::copysignf32 => "copysignf",
         sym::copysignf64 => "copysign",
         sym::floorf32 => "floorf",

--- a/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
@@ -231,13 +231,6 @@ fn f16_builtin<'gcc, 'tcx>(
         sym::maxnumf16 => "__builtin_fmaxf",
         sym::minnumf16 => "__builtin_fminf",
         sym::powf16 => "__builtin_powf",
-        sym::powif16 => {
-            let func = cx.context.get_builtin_function("__builtin_powif");
-            let arg0 = cx.context.new_cast(None, args[0].immediate(), f32_type);
-            let args = [arg0, args[1].immediate()];
-            let result = cx.context.new_call(None, func, &args);
-            return cx.context.new_cast(None, result, cx.type_f16());
-        }
         sym::roundf16 => "__builtin_roundf",
         sym::round_ties_even_f16 => "__builtin_rintf",
         sym::sqrtf16 => "__builtin_sqrtf",
@@ -298,7 +291,6 @@ impl<'a, 'gcc, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'a, 'gcc, 'tc
             | sym::maxnumf16
             | sym::minnumf16
             | sym::powf16
-            | sym::powif16
             | sym::roundf16
             | sym::round_ties_even_f16
             | sym::sqrtf16
@@ -322,6 +314,13 @@ impl<'a, 'gcc, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'a, 'gcc, 'tc
                     func,
                     &args.iter().map(|arg| arg.immediate()).collect::<Vec<_>>(),
                 )
+            }
+            sym::powif16 => {
+                let func = self.cx.context.get_builtin_function("__builtin_powif");
+                let arg0 = self.cx.context.new_cast(None, args[0].immediate(), self.cx.type_f32());
+                let args = [arg0, args[1].immediate()];
+                let result = self.cx.context.new_call(None, func, &args);
+                self.cx.context.new_cast(None, result, self.cx.type_f16())
             }
             sym::powif128 => {
                 let f128_type = self.cx.type_f128();

--- a/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
@@ -242,20 +242,11 @@ impl<'a, 'gcc, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'a, 'gcc, 'tc
         let name_str = name.as_str();
         let fn_args = instance.args;
 
-        let simple = get_simple_intrinsic(self, name);
-        let simple_func = get_simple_function(self, name);
+        let simple = get_simple_intrinsic(self, name).or_else(|| get_simple_function(self, name));
 
         let value = match name {
             _ if simple.is_some() => {
                 let func = simple.expect("simple intrinsic function");
-                self.cx.context.new_call(
-                    self.location,
-                    func,
-                    &args.iter().map(|arg| arg.immediate()).collect::<Vec<_>>(),
-                )
-            }
-            _ if simple_func.is_some() => {
-                let func = simple_func.expect("simple function");
                 self.cx.context.new_call(
                     self.location,
                     func,


### PR DESCRIPTION
Saw some duplication while working on https://github.com/rust-lang/rust/pull/153834 and thought i'd quickly address it

There is one behaviour change in this PR: the `minimumf128` and `maximumf128` intrinsics are now only generated if `self.cx.supports_f128_type`; they used to be generated unconditionally, inside `get_simple_intrinsic` (and duplicated in `get_simple_function`), now they are handled by `get_simple_function_f128_2args` with the other binary f128 functions.

r? antoyo