### PR TITLE
Remove `def_id_for_ty_in_cycle`

### DIFF
--- a/compiler/rustc_middle/src/query/keys.rs
+++ b/compiler/rustc_middle/src/query/keys.rs
@@ -45,11 +45,6 @@ pub trait QueryKey: Sized + QueryKeyBounds {
     fn key_as_def_id(&self) -> Option<DefId> {
         None
     }
-
-    /// Used to detect when ADT def ids are used as keys in a cycle for better error reporting.
-    fn def_id_for_ty_in_cycle(&self) -> Option<DefId> {
-        None
-    }
 }
 
 pub trait AsLocalQueryKey: QueryKey {
@@ -265,14 +260,6 @@ impl<'tcx> QueryKey for Ty<'tcx> {
     fn default_span(&self, _: TyCtxt<'_>) -> Span {
         DUMMY_SP
     }
-
-    fn def_id_for_ty_in_cycle(&self) -> Option<DefId> {
-        match *self.kind() {
-            ty::Adt(adt, _) => Some(adt.did()),
-            ty::Coroutine(def_id, ..) => Some(def_id),
-            _ => None,
-        }
-    }
 }
 
 impl<'tcx> QueryKey for (Ty<'tcx>, Ty<'tcx>) {
@@ -290,10 +277,6 @@ impl<'tcx> QueryKey for ty::Clauses<'tcx> {
 impl<'tcx, T: QueryKey> QueryKey for ty::PseudoCanonicalInput<'tcx, T> {
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         self.value.default_span(tcx)
-    }
-
-    fn def_id_for_ty_in_cycle(&self) -> Option<DefId> {
-        self.value.def_id_for_ty_in_cycle()
     }
 }
 
@@ -370,13 +353,6 @@ impl<'tcx> QueryKey for (ValidityRequirement, ty::PseudoCanonicalInput<'tcx, Ty<
 
     fn default_span(&self, _: TyCtxt<'_>) -> Span {
         DUMMY_SP
-    }
-
-    fn def_id_for_ty_in_cycle(&self) -> Option<DefId> {
-        match self.1.value.kind() {
-            ty::Adt(adt, _) => Some(adt.did()),
-            _ => None,
-        }
     }
 }
 

--- a/compiler/rustc_middle/src/query/stack.rs
+++ b/compiler/rustc_middle/src/query/stack.rs
@@ -13,6 +13,4 @@ pub struct QueryStackFrame<'tcx> {
     pub tagged_key: TaggedQueryKey<'tcx>,
     pub dep_kind: DepKind,
     pub def_id: Option<DefId>,
-    /// A def-id that is extracted from a `Ty` in a query key
-    pub def_id_for_ty_in_cycle: Option<DefId>,
 }

--- a/compiler/rustc_query_impl/src/from_cycle_error.rs
+++ b/compiler/rustc_query_impl/src/from_cycle_error.rs
@@ -9,7 +9,7 @@ use rustc_errors::{Applicability, Diag, MultiSpan, pluralize, struct_span_code_e
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
 use rustc_middle::dep_graph::DepKind;
-use rustc_middle::queries::QueryVTables;
+use rustc_middle::queries::{QueryVTables, TaggedQueryKey};
 use rustc_middle::query::CycleError;
 use rustc_middle::query::erase::erase_val;
 use rustc_middle::ty::layout::LayoutError;
@@ -91,9 +91,9 @@ fn check_representability<'tcx>(tcx: TyCtxt<'tcx>, cycle_error: CycleError<'tcx>
         }
     }
     for info in &cycle_error.cycle {
-        if info.frame.dep_kind == DepKind::check_representability_adt_ty
-            && let Some(def_id) = info.frame.def_id_for_ty_in_cycle
-            && let Some(def_id) = def_id.as_local()
+        if let TaggedQueryKey::check_representability_adt_ty(key) = info.frame.tagged_key
+            && let Some(adt) = key.ty_adt_def()
+            && let Some(def_id) = adt.did().as_local()
             && !item_and_field_ids.iter().any(|&(id, _)| id == def_id)
         {
             representable_ids.insert(def_id);
@@ -154,8 +154,8 @@ fn layout_of<'tcx>(
     let diag = search_for_cycle_permutation(
         &cycle_error.cycle,
         |cycle| {
-            if cycle[0].frame.dep_kind == DepKind::layout_of
-                && let Some(def_id) = cycle[0].frame.def_id_for_ty_in_cycle
+            if let TaggedQueryKey::layout_of(key) = cycle[0].frame.tagged_key
+                && let ty::Coroutine(def_id, _) = key.value.kind()
                 && let Some(def_id) = def_id.as_local()
                 && let def_kind = tcx.def_kind(def_id)
                 && matches!(def_kind, DefKind::Closure)
@@ -179,10 +179,10 @@ fn layout_of<'tcx>(
                     tcx.def_kind_descr(def_kind, def_id.to_def_id()),
                 );
                 for (i, info) in cycle.iter().enumerate() {
-                    if info.frame.dep_kind != DepKind::layout_of {
+                    let TaggedQueryKey::layout_of(frame_key) = info.frame.tagged_key else {
                         continue;
-                    }
-                    let Some(frame_def_id) = info.frame.def_id_for_ty_in_cycle else {
+                    };
+                    let &ty::Coroutine(frame_def_id, _) = frame_key.value.kind() else {
                         continue;
                     };
                     let Some(frame_coroutine_kind) = tcx.coroutine_kind(frame_def_id) else {

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -91,13 +91,11 @@ where
     QueryVTable<'tcx, C>: DynSync,
 {
     let def_id: Option<DefId> = key.key_as_def_id();
-    let def_id_for_ty_in_cycle: Option<DefId> = key.def_id_for_ty_in_cycle();
 
     QueryStackFrame {
         tagged_key: (vtable.create_tagged_key)(key),
         dep_kind: vtable.dep_kind,
         def_id,
-        def_id_for_ty_in_cycle,
     }
 }
 


### PR DESCRIPTION
This removes `QueryKey::def_id_for_ty_in_cycle` and `QueryStackFrame.def_id_for_ty_in_cycle` by computing it instead from `TaggedQueryKey`.