### PR TITLE
constify const Fn*: Destruct

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
@@ -797,12 +797,16 @@ pub(in crate::solve) fn const_conditions_for_destruct<I: Interner>(
         | ty::Infer(ty::InferTy::FloatVar(_) | ty::InferTy::IntVar(_))
         | ty::Error(_) => Ok(vec![]),
 
-        // Coroutines and closures could implement `[const] Drop`,
+        // Closures are [const] Destruct when all of their upvars (captures) are [const] Destruct.
+        ty::Closure(_, args) => {
+            let closure_args = args.as_closure();
+            Ok(vec![ty::TraitRef::new(cx, destruct_def_id, [closure_args.tupled_upvars_ty()])])
+        }
+        // Coroutines could implement `[const] Drop`,
         // but they don't really need to right now.
-        ty::Closure(_, _)
-        | ty::CoroutineClosure(_, _)
-        | ty::Coroutine(_, _)
-        | ty::CoroutineWitness(_, _) => Err(NoSolution),
+        ty::CoroutineClosure(_, _) | ty::Coroutine(_, _) | ty::CoroutineWitness(_, _) => {
+            Err(NoSolution)
+        }
 
         // FIXME(unsafe_binders): Unsafe binders could implement `[const] Drop`
         // if their inner type implements it.

--- a/compiler/rustc_trait_selection/src/traits/effects.rs
+++ b/compiler/rustc_trait_selection/src/traits/effects.rs
@@ -472,12 +472,17 @@ fn evaluate_host_effect_for_destruct_goal<'tcx>(
         | ty::Infer(ty::InferTy::FloatVar(_) | ty::InferTy::IntVar(_))
         | ty::Error(_) => thin_vec![],
 
-        // Coroutines and closures could implement `[const] Drop`,
+        // Closures are [const] Destruct when all of their upvars (captures) are [const] Destruct.
+        ty::Closure(_, args) => {
+            let closure_args = args.as_closure();
+            thin_vec![ty::TraitRef::new(tcx, destruct_def_id, [closure_args.tupled_upvars_ty()])]
+        }
+
+        // Coroutines could implement `[const] Drop`,
         // but they don't really need to right now.
-        ty::Closure(_, _)
-        | ty::CoroutineClosure(_, _)
-        | ty::Coroutine(_, _)
-        | ty::CoroutineWitness(_, _) => return Err(EvaluationFailure::NoSolution),
+        ty::CoroutineClosure(_, _) | ty::Coroutine(_, _) | ty::CoroutineWitness(_, _) => {
+            return Err(EvaluationFailure::NoSolution);
+        }
 
         // FIXME(unsafe_binders): Unsafe binders could implement `[const] Drop`
         // if their inner type implements it.

--- a/library/coretests/tests/array.rs
+++ b/library/coretests/tests/array.rs
@@ -741,3 +741,18 @@ fn const_array_ops() {
     struct Zst;
     assert_eq!([(); 10].try_map(|()| Some(Zst)), Some([const { Zst }; 10]));
 }
+
+#[test]
+const fn extra_const_array_ops() {
+    let x: [u8; 4] =
+        { std::array::from_fn(const |i| i + 4).map(const |x| x * 2).map(const |x| x as _) };
+    let y = 4;
+    struct Z(u16);
+    impl const Drop for Z {
+        fn drop(&mut self) {}
+    }
+    let w = Z(2);
+    let _x: [u8; 4] = {
+        std::array::from_fn(const |_| x[0] + y).map(const |x| x * (w.0 as u8)).map(const |x| x as _)
+    };
+}

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -17,6 +17,7 @@
 #![feature(const_bool)]
 #![feature(const_cell_traits)]
 #![feature(const_clone)]
+#![feature(const_closures)]
 #![feature(const_cmp)]
 #![feature(const_convert)]
 #![feature(const_default)]

--- a/tests/ui/traits/const-traits/const-closure-with-indestructible-indestructible.next.stderr
+++ b/tests/ui/traits/const-traits/const-closure-with-indestructible-indestructible.next.stderr
@@ -1,0 +1,21 @@
+error[E0277]: the trait bound `Vec<u8>: const Destruct` is not satisfied
+  --> $DIR/const-closure-with-indestructible-indestructible.rs:10:16
+   |
+LL |           i_need(const || {
+   |  _________------_^
+   | |         |
+   | |         required by a bound introduced by this call
+LL | |
+LL | |             let y = v;
+LL | |         })
+   | |_________^
+   |
+note: required by a bound in `i_need`
+  --> $DIR/const-closure-with-indestructible-indestructible.rs:5:20
+   |
+LL | const fn i_need<F: [const] std::marker::Destruct>(x: F) {}
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `i_need`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/const-traits/const-closure-with-indestructible-indestructible.old.stderr
+++ b/tests/ui/traits/const-traits/const-closure-with-indestructible-indestructible.old.stderr
@@ -1,0 +1,21 @@
+error[E0277]: the trait bound `Vec<u8>: const Destruct` is not satisfied
+  --> $DIR/const-closure-with-indestructible-indestructible.rs:10:16
+   |
+LL |           i_need(const || {
+   |  _________------_^
+   | |         |
+   | |         required by a bound introduced by this call
+LL | |
+LL | |             let y = v;
+LL | |         })
+   | |_________^
+   |
+note: required by a bound in `i_need`
+  --> $DIR/const-closure-with-indestructible-indestructible.rs:5:20
+   |
+LL | const fn i_need<F: [const] std::marker::Destruct>(x: F) {}
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `i_need`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/const-traits/const-closure-with-indestructible-indestructible.rs
+++ b/tests/ui/traits/const-traits/const-closure-with-indestructible-indestructible.rs
@@ -1,0 +1,15 @@
+//@revisions: next old
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+#![feature(const_trait_impl, const_closures, const_destruct)]
+const fn i_need<F: [const] std::marker::Destruct>(x: F) {}
+
+fn main() {
+    const {
+        let v = Vec::<u8>::new();
+        i_need(const || {
+            //~^ ERROR the trait bound
+            let y = v;
+        })
+    };
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/153874)*
<!-- homu-ignore:end -->

makes closures const destruct where their upvars are. i think this makes sense
and is how this should be implemented.

r? @oli-obk

