### PR TITLE
tests/debuginfo/basic-stepping.rs: Remove ignore-aarch64

### DIFF
--- a/tests/debuginfo/basic-stepping.rs
+++ b/tests/debuginfo/basic-stepping.rs
@@ -2,7 +2,6 @@
 //! time works intuitively, e.g. that `next` takes you to the next source line.
 //! Regression test for <https://github.com/rust-lang/rust/issues/33013>.
 
-//@ ignore-aarch64: Doesn't work yet.
 //@ ignore-loongarch64: Doesn't work yet.
 //@ ignore-riscv64: Doesn't work yet.
 //@ ignore-backends: gcc


### PR DESCRIPTION
This test passes for me both with `gdb` and `lldb` when I run it on an aarch64 machine (namely [dev-desktop-eu-1](https://forge.rust-lang.org/infra/docs/dev-desktop.html)).

And as can be seen below, it now passes PR CI, including **aarch64-gnu-llvm-21-1**.
This test used to [fail](https://github.com/rust-lang/rust/pull/144497#issuecomment-3121598361) PR CI, in particular **aarch64-gnu-llvm-19-1**.

I suggest we put this in a rollup as an iffy PR to see if we can get it through. If we can, we are one step closer towards closing rust-lang/rust#33013.