### PR TITLE
Optimize `simd::Mask::first_set`

### DIFF
--- a/library/portable-simd/crates/core_simd/src/masks.rs
+++ b/library/portable-simd/crates/core_simd/src/masks.rs
@@ -371,22 +371,21 @@ where
         // * perform _unsigned_ reduce-min
         // * check if the result is -1 or an index
 
-        let index = Simd::from_array(
-            const {
-                let mut index = [0; N];
-                let mut i = 0;
-                while i < N {
-                    index[i] = i;
-                    i += 1;
-                }
-                index
-            },
-        );
+        let index: Simd<T, N> = const {
+            let mut index = [0usize; N];
+            let mut i = 0;
+            while i < N {
+                index[i] = i;
+                i += 1;
+            }
+            // Safety: input is a vector of integers. Truncation is not UB and
+            // in any case is impossible because N is always less than
+            // usize::MAX.
+            unsafe { core::intrinsics::simd::simd_cast(Simd::from_array(index)) }
+        };
 
-        // Safety: the input and output are integer vectors
-        let index: Simd<T, N> = unsafe { core::intrinsics::simd::simd_cast(index) };
-
-        let masked_index = self.select(index, Self::splat(true).to_simd());
+        // Safety: both inputs are integer vectors
+        let masked_index = unsafe { core::intrinsics::simd::simd_or((!self).to_simd(), index) };
 
         // Safety: the input and output are integer vectors
         let masked_index: Simd<T::Unsigned, N> =

--- a/library/portable-simd/crates/core_simd/tests/masks.rs
+++ b/library/portable-simd/crates/core_simd/tests/masks.rs
@@ -133,6 +133,16 @@ macro_rules! test_mask_api {
                 cast_impl::<i64>();
                 cast_impl::<isize>();
             }
+
+            #[test]
+            #[cfg_attr(miri, ignore)] // Miri is too slow.
+            fn first_set() {
+                for bitmask in 0..=u8::MAX {
+                    let vec_mask = Mask::<$type, 8>::from_bitmask(bitmask);
+                    let expected = if bitmask == 0 { None } else { Some(bitmask.trailing_zeros() as usize) };
+                    assert_eq!(vec_mask.first_set(), expected);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Optimize `simd::Mask::first_set`

Move the call to `simd_cast` into the `const` block when initializing `index`. This removes runtime shuffles necessary to translate a `Simd<usize, N>` to a `Simd<T, N>`.

Replace the call to `mask.select` with `simd_or(!self, index)`. This is cheaper than doing a comparison and on some architectures the `or` can be combined with the `not` into a single instruction.

See https://godbolt.org/z/YebG6aoMY for evidence.