### PR TITLE
Point at definition of item with type parameters that couldn't be inferred

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
@@ -68,6 +68,7 @@ pub struct InferenceDiagnosticsData {
 pub struct InferenceDiagnosticsParentData {
     prefix: &'static str,
     name: String,
+    span: Span,
 }
 
 #[derive(Clone)]
@@ -124,10 +125,12 @@ impl InferenceDiagnosticsParentData {
     ) -> Option<InferenceDiagnosticsParentData> {
         let parent_name =
             tcx.def_key(parent_def_id).disambiguated_data.data.get_opt_name()?.to_string();
+        let span = tcx.def_span(parent_def_id);
 
         Some(InferenceDiagnosticsParentData {
             prefix: tcx.def_descr(parent_def_id),
             name: parent_name,
+            span,
         })
     }
 
@@ -423,16 +426,18 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         error_code: TypeAnnotationNeeded,
     ) -> Diag<'a> {
         let source_kind = "other";
-        let source_name = "";
+        let bad_error = arg_data.make_bad_error(span);
+        let source_name = &bad_error.name.clone();
         let failure_span = None;
         let infer_subdiags = Vec::new();
         let multi_suggestions = Vec::new();
-        let bad_label = Some(arg_data.make_bad_error(span));
+        let bad_label = Some(bad_error);
         match error_code {
             TypeAnnotationNeeded::E0282 => self.dcx().create_err(AnnotationRequired {
                 span,
                 source_kind,
                 source_name,
+                source_span: arg_data.parent.as_ref().map(|p| p.span),
                 failure_span,
                 infer_subdiags,
                 multi_suggestions,
@@ -442,6 +447,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 span,
                 source_kind,
                 source_name,
+                source_span: arg_data.parent.as_ref().map(|p| p.span),
                 failure_span,
                 infer_subdiags,
                 multi_suggestions,
@@ -451,6 +457,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 span,
                 source_kind,
                 source_name,
+                source_span: arg_data.parent.as_ref().map(|p| p.span),
                 failure_span,
                 infer_subdiags,
                 multi_suggestions,
@@ -677,6 +684,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 span,
                 source_kind,
                 source_name: &name,
+                source_span: arg_data.parent.as_ref().map(|p| p.span),
                 failure_span,
                 infer_subdiags,
                 multi_suggestions,
@@ -686,6 +694,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 span,
                 source_kind,
                 source_name: &name,
+                source_span: arg_data.parent.as_ref().map(|p| p.span),
                 failure_span,
                 infer_subdiags,
                 multi_suggestions,
@@ -695,6 +704,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 span,
                 source_kind,
                 source_name: &name,
+                source_span: arg_data.parent.as_ref().map(|p| p.span),
                 failure_span,
                 infer_subdiags,
                 multi_suggestions,

--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -192,6 +192,8 @@ pub struct AnnotationRequired<'a> {
     pub span: Span,
     pub source_kind: &'static str,
     pub source_name: &'a str,
+    #[note("type must be known for type parameter in this")]
+    pub source_span: Option<Span>,
     #[label("type must be known at this point")]
     pub failure_span: Option<Span>,
     #[subdiagnostic]
@@ -214,6 +216,8 @@ pub struct AmbiguousImpl<'a> {
     pub span: Span,
     pub source_kind: &'static str,
     pub source_name: &'a str,
+    #[note("type must be known for type parameter in this")]
+    pub source_span: Option<Span>,
     #[label("type must be known at this point")]
     pub failure_span: Option<Span>,
     #[subdiagnostic]
@@ -236,6 +240,8 @@ pub struct AmbiguousReturn<'a> {
     pub span: Span,
     pub source_kind: &'static str,
     pub source_name: &'a str,
+    #[note("type must be known for type parameter in this")]
+    pub source_span: Option<Span>,
     #[label("type must be known at this point")]
     pub failure_span: Option<Span>,
     #[subdiagnostic]

--- a/tests/ui/array-slice-vec/vector-no-ann.stderr
+++ b/tests/ui/array-slice-vec/vector-no-ann.stderr
@@ -4,6 +4,8 @@ error[E0282]: type annotations needed for `Vec<_>`
 LL |     let _foo = Vec::new();
    |         ^^^^   ---------- type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 help: consider giving `_foo` an explicit type, where the type for type parameter `T` is specified
    |
 LL |     let _foo: Vec<T> = Vec::new();

--- a/tests/ui/associated-type-bounds/dedup-normalized-2-higher-ranked.current.stderr
+++ b/tests/ui/associated-type-bounds/dedup-normalized-2-higher-ranked.current.stderr
@@ -6,6 +6,11 @@ LL |     impls(rigid);
    |     |
    |     cannot infer type of the type parameter `U` declared on the function `impls`
    |
+note: type must be known for type parameter in this
+  --> $DIR/dedup-normalized-2-higher-ranked.rs:25:1
+   |
+LL | fn impls<T: for<'b> Bound<'b, U>, U>(_: T) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: cannot satisfy `for<'b> <P as Trait>::Rigid: Bound<'b, _>`
 note: required by a bound in `impls`
   --> $DIR/dedup-normalized-2-higher-ranked.rs:25:13

--- a/tests/ui/associated-type-bounds/duplicate-bound-err.stderr
+++ b/tests/ui/associated-type-bounds/duplicate-bound-err.stderr
@@ -4,6 +4,8 @@ error[E0282]: type annotations needed
 LL |     iter::empty()
    |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/iter/sources/empty.rs:LL:COL
 help: consider specifying the generic argument
    |
 LL |     iter::empty::<T>()
@@ -15,6 +17,8 @@ error[E0282]: type annotations needed
 LL |     iter::empty()
    |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/iter/sources/empty.rs:LL:COL
 help: consider specifying the generic argument
    |
 LL |     iter::empty::<T>()
@@ -26,6 +30,8 @@ error[E0282]: type annotations needed
 LL |     iter::empty()
    |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/iter/sources/empty.rs:LL:COL
 help: consider specifying the generic argument
    |
 LL |     iter::empty::<T>()

--- a/tests/ui/async-await/unresolved_type_param.stderr
+++ b/tests/ui/async-await/unresolved_type_param.stderr
@@ -4,6 +4,11 @@ error[E0282]: type annotations needed
 LL |     bar().await;
    |     ^^^ cannot infer type of the type parameter `T` declared on the function `bar`
    |
+note: type must be known for type parameter in this
+  --> $DIR/unresolved_type_param.rs:6:1
+   |
+LL | async fn bar<T>() -> () {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^
 help: consider specifying the generic argument
    |
 LL |     bar::<T>().await;

--- a/tests/ui/closure-expected-type/expect-two-infer-vars-supply-ty-with-bound-region.stderr
+++ b/tests/ui/closure-expected-type/expect-two-infer-vars-supply-ty-with-bound-region.stderr
@@ -4,6 +4,12 @@ error[E0282]: type annotations needed
 LL |     with_closure(|x: u32, y| {});
    |                           ^
    |
+note: type must be known for type parameter in this
+  --> $DIR/expect-two-infer-vars-supply-ty-with-bound-region.rs:1:1
+   |
+LL | / fn with_closure<F, A, B>(_: F)
+LL | |     where F: FnOnce(A, B)
+   | |_________________________^
 help: consider giving this closure parameter an explicit type
    |
 LL |     with_closure(|x: u32, y: /* Type */| {});

--- a/tests/ui/closures/issue-99565.stderr
+++ b/tests/ui/closures/issue-99565.stderr
@@ -4,6 +4,11 @@ error[E0282]: type annotations needed
 LL |     foo(|| {});
    |     ^^^ cannot infer type of the type parameter `T` declared on the function `foo`
    |
+note: type must be known for type parameter in this
+  --> $DIR/issue-99565.rs:3:1
+   |
+LL | fn foo<T, U>(_: U) {}
+   | ^^^^^^^^^^^^^^^^^^
 help: consider specifying the generic arguments
    |
 LL |     foo::<T, _>(|| {});

--- a/tests/ui/const-generics/defaults/rp_impl_trait_fail.stderr
+++ b/tests/ui/const-generics/defaults/rp_impl_trait_fail.stderr
@@ -56,6 +56,11 @@ error[E0284]: type annotations needed
 LL |     uwu();
    |     ^^^ cannot infer the value of the const parameter `N` declared on the function `uwu`
    |
+note: type must be known for type parameter in this
+  --> $DIR/rp_impl_trait_fail.rs:16:1
+   |
+LL | fn uwu<const N: u8>() -> impl Traitor<N> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a const generic parameter in `uwu`
   --> $DIR/rp_impl_trait_fail.rs:16:8
    |

--- a/tests/ui/const-generics/fn-const-param-infer.adt_const_params.stderr
+++ b/tests/ui/const-generics/fn-const-param-infer.adt_const_params.stderr
@@ -19,6 +19,11 @@ error[E0282]: type annotations needed
 LL |     let _ = Checked::<generic>;
    |                       ^^^^^^^ cannot infer type of the type parameter `T` declared on the function `generic`
    |
+note: type must be known for type parameter in this
+  --> $DIR/fn-const-param-infer.rs:22:1
+   |
+LL | fn generic<T>(val: usize) -> bool {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider specifying the generic argument
    |
 LL |     let _ = Checked::<generic::<T>>;

--- a/tests/ui/const-generics/fn-const-param-infer.full.stderr
+++ b/tests/ui/const-generics/fn-const-param-infer.full.stderr
@@ -19,6 +19,11 @@ error[E0282]: type annotations needed
 LL |     let _ = Checked::<generic>;
    |                       ^^^^^^^ cannot infer type of the type parameter `T` declared on the function `generic`
    |
+note: type must be known for type parameter in this
+  --> $DIR/fn-const-param-infer.rs:22:1
+   |
+LL | fn generic<T>(val: usize) -> bool {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider specifying the generic argument
    |
 LL |     let _ = Checked::<generic::<T>>;

--- a/tests/ui/const-generics/fn-const-param-infer.min.stderr
+++ b/tests/ui/const-generics/fn-const-param-infer.min.stderr
@@ -21,6 +21,11 @@ error[E0282]: type annotations needed
 LL |     let _ = Checked::<generic>;
    |                       ^^^^^^^ cannot infer type of the type parameter `T` declared on the function `generic`
    |
+note: type must be known for type parameter in this
+  --> $DIR/fn-const-param-infer.rs:22:1
+   |
+LL | fn generic<T>(val: usize) -> bool {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider specifying the generic argument
    |
 LL |     let _ = Checked::<generic::<T>>;

--- a/tests/ui/const-generics/generic_const_exprs/dyn-compatibility-ok-infer-err.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/dyn-compatibility-ok-infer-err.stderr
@@ -4,6 +4,11 @@ error[E0284]: type annotations needed
 LL |     use_dyn(&());
    |     ^^^^^^^ cannot infer the value of the const parameter `N` declared on the function `use_dyn`
    |
+note: type must be known for type parameter in this
+  --> $DIR/dyn-compatibility-ok-infer-err.rs:14:1
+   |
+LL | fn use_dyn<const N: usize>(v: &dyn Foo<N>) where [u8; N + 1]: Sized {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a const generic parameter in `use_dyn`
   --> $DIR/dyn-compatibility-ok-infer-err.rs:14:12
    |

--- a/tests/ui/const-generics/infer/cannot-infer-const-args.stderr
+++ b/tests/ui/const-generics/infer/cannot-infer-const-args.stderr
@@ -4,6 +4,11 @@ error[E0284]: type annotations needed
 LL |     foo();
    |     ^^^ cannot infer the value of the const parameter `X` declared on the function `foo`
    |
+note: type must be known for type parameter in this
+  --> $DIR/cannot-infer-const-args.rs:1:1
+   |
+LL | fn foo<const X: usize>() -> usize {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a const generic parameter in `foo`
   --> $DIR/cannot-infer-const-args.rs:1:8
    |

--- a/tests/ui/const-generics/infer/issue-77092.stderr
+++ b/tests/ui/const-generics/infer/issue-77092.stderr
@@ -4,6 +4,11 @@ error[E0284]: type annotations needed
 LL |         println!("{:?}", take_array_from_mut(&mut arr, i));
    |                          ^^^^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `N` declared on the function `take_array_from_mut`
    |
+note: type must be known for type parameter in this
+  --> $DIR/issue-77092.rs:3:1
+   |
+LL | fn take_array_from_mut<T, const N: usize>(data: &mut [T], start: usize) -> &mut [T; N] {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a const generic parameter in `take_array_from_mut`
   --> $DIR/issue-77092.rs:3:27
    |

--- a/tests/ui/const-generics/infer/method-chain.stderr
+++ b/tests/ui/const-generics/infer/method-chain.stderr
@@ -4,6 +4,11 @@ error[E0284]: type annotations needed
 LL |     Foo.bar().bar().bar().bar().baz();
    |                                 ^^^ cannot infer the value of the const parameter `N` declared on the method `baz`
    |
+note: type must be known for type parameter in this
+  --> $DIR/method-chain.rs:8:5
+   |
+LL |     fn baz<const N: usize>(self) -> Foo {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a const generic parameter in `Foo::baz`
   --> $DIR/method-chain.rs:8:12
    |

--- a/tests/ui/const-generics/infer/one-param-uninferred.stderr
+++ b/tests/ui/const-generics/infer/one-param-uninferred.stderr
@@ -4,6 +4,11 @@ error[E0284]: type annotations needed
 LL |     let _: [u8; 17] = foo();
    |                       ^^^ cannot infer the value of the const parameter `M` declared on the function `foo`
    |
+note: type must be known for type parameter in this
+  --> $DIR/one-param-uninferred.rs:2:1
+   |
+LL | fn foo<const N: usize, const M: usize>() -> [u8; N] {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a const generic parameter in `foo`
   --> $DIR/one-param-uninferred.rs:2:24
    |

--- a/tests/ui/const-generics/infer/uninferred-consts.stderr
+++ b/tests/ui/const-generics/infer/uninferred-consts.stderr
@@ -4,6 +4,11 @@ error[E0284]: type annotations needed
 LL |     Foo.foo();
    |         ^^^ cannot infer the value of the const parameter `A` declared on the method `foo`
    |
+note: type must be known for type parameter in this
+  --> $DIR/uninferred-consts.rs:6:5
+   |
+LL |     fn foo<const A: usize, const B: usize>(self) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a const generic parameter in `Foo::foo`
   --> $DIR/uninferred-consts.rs:6:12
    |
@@ -20,6 +25,11 @@ error[E0284]: type annotations needed
 LL |     Foo.foo();
    |         ^^^ cannot infer the value of the const parameter `B` declared on the method `foo`
    |
+note: type must be known for type parameter in this
+  --> $DIR/uninferred-consts.rs:6:5
+   |
+LL |     fn foo<const A: usize, const B: usize>(self) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a const generic parameter in `Foo::foo`
   --> $DIR/uninferred-consts.rs:6:28
    |

--- a/tests/ui/const-generics/issues/issue-83249.stderr
+++ b/tests/ui/const-generics/issues/issue-83249.stderr
@@ -6,6 +6,11 @@ LL |     let _ = foo([0; 1]);
    |             |
    |             required by a bound introduced by this call
    |
+note: type must be known for type parameter in this
+  --> $DIR/issue-83249.rs:12:1
+   |
+LL | fn foo<T: Foo>(_: [u8; T::N]) -> T {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: the type must implement `Foo`
 help: the trait `Foo` is implemented for `u8`
   --> $DIR/issue-83249.rs:8:1

--- a/tests/ui/const-generics/parent_generics_of_encoding_impl_trait.stderr
+++ b/tests/ui/const-generics/parent_generics_of_encoding_impl_trait.stderr
@@ -4,6 +4,11 @@ error[E0284]: type annotations needed
 LL |     generics_of_parent_impl_trait::foo([()]);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of const parameter `N` declared on the function `foo`
    |
+note: type must be known for type parameter in this
+  --> $DIR/auxiliary/generics_of_parent_impl_trait.rs:5:1
+   |
+LL | pub fn foo<const N: usize>(foo: impl Into<[(); N + 1]>) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a const generic parameter in `foo`
   --> $DIR/auxiliary/generics_of_parent_impl_trait.rs:5:12
    |

--- a/tests/ui/const-generics/try-from-with-const-genericsrs-98299.stderr
+++ b/tests/ui/const-generics/try-from-with-const-genericsrs-98299.stderr
@@ -6,6 +6,11 @@ LL |     SmallCString::try_from(p).map(|cstr| cstr);
    |     |
    |     type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $DIR/try-from-with-const-genericsrs-98299.rs:9:1
+   |
+LL | pub struct SmallCString<const N: usize> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a const generic parameter in `SmallCString`
   --> $DIR/try-from-with-const-genericsrs-98299.rs:9:25
    |

--- a/tests/ui/const-generics/unify_with_nested_expr.stderr
+++ b/tests/ui/const-generics/unify_with_nested_expr.stderr
@@ -4,6 +4,13 @@ error[E0284]: type annotations needed
 LL |     bar();
    |     ^^^ cannot infer the value of the const parameter `N` declared on the function `bar`
    |
+note: type must be known for type parameter in this
+  --> $DIR/unify_with_nested_expr.rs:12:1
+   |
+LL | / fn bar<const N: usize>()
+LL | | where
+LL | |     [(); N + 1]:,
+   | |_________________^
 note: required by a const generic parameter in `bar`
   --> $DIR/unify_with_nested_expr.rs:12:8
    |

--- a/tests/ui/consts/issue-64662.stderr
+++ b/tests/ui/consts/issue-64662.stderr
@@ -4,6 +4,11 @@ error[E0282]: type annotations needed
 LL |     A = foo(),
    |         ^^^ cannot infer type of the type parameter `T` declared on the function `foo`
    |
+note: type must be known for type parameter in this
+  --> $DIR/issue-64662.rs:6:1
+   |
+LL | const fn foo<T>() -> isize {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider specifying the generic argument
    |
 LL |     A = foo::<T>(),
@@ -15,6 +20,11 @@ error[E0282]: type annotations needed
 LL |     B = foo(),
    |         ^^^ cannot infer type of the type parameter `T` declared on the function `foo`
    |
+note: type must be known for type parameter in this
+  --> $DIR/issue-64662.rs:6:1
+   |
+LL | const fn foo<T>() -> isize {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider specifying the generic argument
    |
 LL |     B = foo::<T>(),

--- a/tests/ui/delegation/generics/impl-to-trait-method.stderr
+++ b/tests/ui/delegation/generics/impl-to-trait-method.stderr
@@ -51,6 +51,12 @@ error[E0282]: type annotations needed
    |
 LL |         reuse Trait::foo { &self.0 }
    |                      ^^^ cannot infer type for type parameter `T` declared on the trait `Trait`
+   |
+note: type must be known for type parameter in this
+  --> $DIR/impl-to-trait-method.rs:30:5
+   |
+LL |     trait Trait<T> {
+   |     ^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/delegation/generics/trait-impl-wrong-args-count.stderr
+++ b/tests/ui/delegation/generics/trait-impl-wrong-args-count.stderr
@@ -31,6 +31,11 @@ error[E0284]: type annotations needed
 LL |         reuse to_reuse::bar2;
    |                         ^^^^ cannot infer the value of the const parameter `X` declared on the function `bar2`
    |
+note: type must be known for type parameter in this
+  --> $DIR/trait-impl-wrong-args-count.rs:9:9
+   |
+LL |         pub fn bar2<A, B, C, D, E, F, const X: usize, const Y: bool>(x: &super::XX) {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a const generic parameter in `bar2`
   --> $DIR/trait-impl-wrong-args-count.rs:9:39
    |
@@ -47,6 +52,11 @@ error[E0284]: type annotations needed
 LL |         reuse to_reuse::bar2;
    |                         ^^^^ cannot infer the value of the const parameter `Y` declared on the function `bar2`
    |
+note: type must be known for type parameter in this
+  --> $DIR/trait-impl-wrong-args-count.rs:9:9
+   |
+LL |         pub fn bar2<A, B, C, D, E, F, const X: usize, const Y: bool>(x: &super::XX) {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a const generic parameter in `bar2`
   --> $DIR/trait-impl-wrong-args-count.rs:9:55
    |
@@ -134,6 +144,12 @@ error[E0282]: type annotations needed
    |
 LL |         reuse <X as Trait1::<(), ()>>::foo as bar2;
    |                                        ^^^ cannot infer type of the type parameter `X` declared on the associated function `foo`
+   |
+note: type must be known for type parameter in this
+  --> $DIR/trait-impl-wrong-args-count.rs:88:9
+   |
+LL |         fn foo<X, Y>() {}
+   |         ^^^^^^^^^^^^^^
 
 error[E0107]: associated function takes at most 2 generic arguments but 3 generic arguments were supplied
   --> $DIR/trait-impl-wrong-args-count.rs:105:40

--- a/tests/ui/error-codes/E0283.stderr
+++ b/tests/ui/error-codes/E0283.stderr
@@ -20,6 +20,8 @@ error[E0283]: type annotations needed
 LL |     let bar = foo_impl.into() * 1u32;
    |                        ^^^^
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
 note: multiple `impl`s satisfying `Impl: Into<_>` found
   --> $DIR/E0283.rs:17:1
    |

--- a/tests/ui/for-loop-while/for-loop-unconstrained-element-type.stderr
+++ b/tests/ui/for-loop-while/for-loop-unconstrained-element-type.stderr
@@ -4,6 +4,8 @@ error[E0282]: type annotations needed
 LL |     for i in Vec::new() {}
    |              ^^^^^^^^ cannot infer type of the type parameter `T` declared on the struct `Vec`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 help: consider specifying the generic argument
    |
 LL |     for i in Vec::<T>::new() {}

--- a/tests/ui/generic-associated-types/ambig-hr-projection-issue-93340.next.stderr
+++ b/tests/ui/generic-associated-types/ambig-hr-projection-issue-93340.next.stderr
@@ -4,6 +4,11 @@ error[E0282]: type annotations needed
 LL |     cmp_eq
    |     ^^^^^^ cannot infer type of the type parameter `A` declared on the function `cmp_eq`
    |
+note: type must be known for type parameter in this
+  --> $DIR/ambig-hr-projection-issue-93340.rs:10:1
+   |
+LL | fn cmp_eq<'a, 'b, A: Scalar, B: Scalar, O: Scalar>(a: A::RefType<'a>, b: B::RefType<'b>) -> O {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider specifying the generic arguments
    |
 LL |     cmp_eq::<A, B, O>

--- a/tests/ui/generic-associated-types/ambig-hr-projection-issue-93340.old.stderr
+++ b/tests/ui/generic-associated-types/ambig-hr-projection-issue-93340.old.stderr
@@ -4,6 +4,11 @@ error[E0283]: type annotations needed
 LL |     cmp_eq
    |     ^^^^^^ cannot infer type of the type parameter `A` declared on the function `cmp_eq`
    |
+note: type must be known for type parameter in this
+  --> $DIR/ambig-hr-projection-issue-93340.rs:10:1
+   |
+LL | fn cmp_eq<'a, 'b, A: Scalar, B: Scalar, O: Scalar>(a: A::RefType<'a>, b: B::RefType<'b>) -> O {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: the type must implement `Scalar`
 note: required by a bound in `cmp_eq`
   --> $DIR/ambig-hr-projection-issue-93340.rs:10:22

--- a/tests/ui/generic-associated-types/bugs/issue-88382.stderr
+++ b/tests/ui/generic-associated-types/bugs/issue-88382.stderr
@@ -4,6 +4,11 @@ error[E0283]: type annotations needed
 LL |     do_something(SomeImplementation(), test);
    |                                        ^^^^ cannot infer type of the type parameter `I` declared on the function `test`
    |
+note: type must be known for type parameter in this
+  --> $DIR/issue-88382.rs:29:1
+   |
+LL | fn test<'a, I: Iterable>(_: &mut I::Iterator<'a>) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: the type must implement `Iterable`
 help: the trait `Iterable` is implemented for `SomeImplementation`
   --> $DIR/issue-88382.rs:13:1

--- a/tests/ui/generic-associated-types/bugs/issue-91762.stderr
+++ b/tests/ui/generic-associated-types/bugs/issue-91762.stderr
@@ -4,6 +4,11 @@ error[E0284]: type annotations needed
 LL |         ret = <Self::Base as Functor>::fmap(arg);
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the associated function `fmap`
    |
+note: type must be known for type parameter in this
+  --> $DIR/issue-91762.rs:13:5
+   |
+LL |     fn fmap<T, U>(this: Self::With<T>) -> Self::With<U>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: cannot satisfy `<<Self as FunctorExt<T>>::Base as Functor>::With<_> == Self`
 help: consider specifying the generic arguments
    |

--- a/tests/ui/generic-const-items/inference-failure.stderr
+++ b/tests/ui/generic-const-items/inference-failure.stderr
@@ -4,6 +4,11 @@ error[E0282]: type annotations needed for `Option<_>`
 LL |     let _ = NONE;
    |         ^   ---- type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $DIR/inference-failure.rs:4:1
+   |
+LL | const NONE<T>: Option<T> = None::<T>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider giving this pattern a type, where the type for type parameter `T` is specified
    |
 LL |     let _: Option<T> = NONE;
@@ -14,6 +19,12 @@ error[E0282]: type annotations needed
    |
 LL |     let _ = IGNORE;
    |             ^^^^^^ cannot infer type for type parameter `T` declared on the constant `IGNORE`
+   |
+note: type must be known for type parameter in this
+  --> $DIR/inference-failure.rs:5:1
+   |
+LL | const IGNORE<T>: () = ();
+   | ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/generic-const-items/parameter-defaults.stderr
+++ b/tests/ui/generic-const-items/parameter-defaults.stderr
@@ -16,6 +16,11 @@ error[E0282]: type annotations needed for `Option<_>`
 LL | fn body0() { let _ = NONE; }
    |                  ^   ---- type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $DIR/parameter-defaults.rs:10:1
+   |
+LL | const NONE<T = ()>: Option<T> = None::<T>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider giving this pattern a type, where the type for type parameter `T` is specified
    |
 LL | fn body0() { let _: Option<T> = NONE; }
@@ -27,6 +32,11 @@ error[E0282]: type annotations needed for `Option<_>`
 LL | fn body1() { let _ = Host::NADA; }
    |                  ^   ---------- type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $DIR/parameter-defaults.rs:14:5
+   |
+LL |     const NADA<T = ()>: Option<T> = None::<T>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider giving this pattern a type, where the type for type parameter `T` is specified
    |
 LL | fn body1() { let _: Option<T> = Host::NADA; }

--- a/tests/ui/impl-trait/auto-trait-selection-freeze.old.stderr
+++ b/tests/ui/impl-trait/auto-trait-selection-freeze.old.stderr
@@ -6,6 +6,11 @@ LL |     if false { is_trait(foo()) } else { Default::default() }
    |                |
    |                cannot infer type of the type parameter `U` declared on the function `is_trait`
    |
+note: type must be known for type parameter in this
+  --> $DIR/auto-trait-selection-freeze.rs:11:1
+   |
+LL | fn is_trait<T: Trait<U>, U: Default>(_: T) -> U {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `impl Sized: Trait<_>` found
   --> $DIR/auto-trait-selection-freeze.rs:16:1
    |

--- a/tests/ui/impl-trait/auto-trait-selection.old.stderr
+++ b/tests/ui/impl-trait/auto-trait-selection.old.stderr
@@ -6,6 +6,11 @@ LL |     if false { is_trait(foo()) } else { Default::default() }
    |                |
    |                cannot infer type of the type parameter `U` declared on the function `is_trait`
    |
+note: type must be known for type parameter in this
+  --> $DIR/auto-trait-selection.rs:7:1
+   |
+LL | fn is_trait<T: Trait<U>, U: Default>(_: T) -> U {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `impl Sized: Trait<_>` found
   --> $DIR/auto-trait-selection.rs:12:1
    |

--- a/tests/ui/impl-trait/cross-return-site-inference.stderr
+++ b/tests/ui/impl-trait/cross-return-site-inference.stderr
@@ -4,6 +4,8 @@ error[E0282]: type annotations needed
 LL |     Ok(())
    |     ^^ cannot infer type of the type parameter `E` declared on the enum `Result`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/result.rs:LL:COL
 help: consider specifying the generic arguments
    |
 LL |     Ok::<(), E>(())

--- a/tests/ui/impl-trait/diagnostics/fully-qualified-path-impl-trait.stderr
+++ b/tests/ui/impl-trait/diagnostics/fully-qualified-path-impl-trait.stderr
@@ -3,6 +3,12 @@ error[E0282]: type annotations needed
    |
 LL |     ().foo(|| ())
    |        ^^^ cannot infer type for type parameter `T` declared on the trait `Foo`
+   |
+note: type must be known for type parameter in this
+  --> $DIR/fully-qualified-path-impl-trait.rs:1:1
+   |
+LL | trait Foo<T> {
+   | ^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/fallback_inference.stderr
+++ b/tests/ui/impl-trait/fallback_inference.stderr
@@ -4,6 +4,8 @@ error[E0282]: type annotations needed
 LL |     PhantomData
    |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the struct `PhantomData`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/marker.rs:LL:COL
 help: consider specifying the generic argument
    |
 LL |     PhantomData::<T>

--- a/tests/ui/impl-trait/in-trait/not-inferred-generic.stderr
+++ b/tests/ui/impl-trait/in-trait/not-inferred-generic.stderr
@@ -4,6 +4,13 @@ error[E0283]: type annotations needed
 LL |     ().publish_typed();
    |        ^^^^^^^^^^^^^ cannot infer type of the type parameter `F` declared on the method `publish_typed`
    |
+note: type must be known for type parameter in this
+  --> $DIR/not-inferred-generic.rs:2:5
+   |
+LL | /     fn publish_typed<F>(&self) -> impl Sized
+LL | |     where
+LL | |         F: Clone;
+   | |_________________^
    = note: the type must implement `Clone`
    = note: opaque types cannot be accessed directly on a `trait`, they can only be accessed through a specific `impl`
 note: required by a bound in `TypedClient::publish_typed::{anon_assoc#0}`

--- a/tests/ui/inference/cannot-infer-async.stderr
+++ b/tests/ui/inference/cannot-infer-async.stderr
@@ -4,6 +4,8 @@ error[E0282]: type annotations needed
 LL |         Ok(())
    |         ^^ cannot infer type of the type parameter `E` declared on the enum `Result`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/result.rs:LL:COL
 help: consider specifying the generic arguments
    |
 LL |         Ok::<(), E>(())

--- a/tests/ui/inference/cannot-infer-closure-circular.stderr
+++ b/tests/ui/inference/cannot-infer-closure-circular.stderr
@@ -7,6 +7,8 @@ LL |         let v = r?;
 LL |         Ok(v)
    |         ----- type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/result.rs:LL:COL
 help: consider giving this closure parameter an explicit type, where the type for type parameter `E` is specified
    |
 LL |     let x = |r: Result<_, E>| {

--- a/tests/ui/inference/cannot-infer-closure.stderr
+++ b/tests/ui/inference/cannot-infer-closure.stderr
@@ -4,6 +4,8 @@ error[E0282]: type annotations needed
 LL |         Ok(b)
    |         ^^ cannot infer type of the type parameter `E` declared on the enum `Result`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/result.rs:LL:COL
 help: consider specifying the generic arguments
    |
 LL |         Ok::<(), E>(b)

--- a/tests/ui/inference/dont-collect-stmts-from-parent-body.stderr
+++ b/tests/ui/inference/dont-collect-stmts-from-parent-body.stderr
@@ -13,6 +13,11 @@ error[E0282]: type annotations needed
 LL |                 Type
    |                 ^^^^ cannot infer type of the type parameter `T` declared on the struct `Type`
    |
+note: type must be known for type parameter in this
+  --> $DIR/dont-collect-stmts-from-parent-body.rs:3:1
+   |
+LL | struct Type<T>;
+   | ^^^^^^^^^^^^^^
 help: consider specifying the generic argument
    |
 LL |                 Type::<T>

--- a/tests/ui/inference/erase-type-params-in-label.stderr
+++ b/tests/ui/inference/erase-type-params-in-label.stderr
@@ -4,6 +4,11 @@ error[E0283]: type annotations needed for `Foo<i32, &str, _, _>`
 LL |     let foo = foo(1, "");
    |         ^^^   ---------- type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $DIR/erase-type-params-in-label.rs:25:1
+   |
+LL | fn foo<T, K, W: Default, Z: Default>(t: T, k: K) -> Foo<T, K, W, Z> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: the type must implement `Default`
 note: required by a bound in `foo`
   --> $DIR/erase-type-params-in-label.rs:25:17
@@ -21,6 +26,11 @@ error[E0283]: type annotations needed for `Bar<i32, &str, _>`
 LL |     let bar = bar(1, "");
    |         ^^^   ---------- type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $DIR/erase-type-params-in-label.rs:14:1
+   |
+LL | fn bar<T, K, Z: Default>(t: T, k: K) -> Bar<T, K, Z> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: the type must implement `Default`
 note: required by a bound in `bar`
   --> $DIR/erase-type-params-in-label.rs:14:17

--- a/tests/ui/inference/issue-104649.stderr
+++ b/tests/ui/inference/issue-104649.stderr
@@ -4,6 +4,11 @@ error[E0282]: type annotations needed for `A<std::result::Result<std::result::Re
 LL |     let a = A(Result::Ok(Result::Ok(())));
    |         ^                -------------- type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $DIR/issue-104649.rs:1:1
+   |
+LL | type Result<T, E = Error> = ::std::result::Result<T, E>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider giving `a` an explicit type, where the type for type parameter `E` is specified
    |
 LL |     let a: A<std::result::Result<std::result::Result<_, E>, _>> = A(Result::Ok(Result::Ok(())));

--- a/tests/ui/inference/issue-12028.stderr
+++ b/tests/ui/inference/issue-12028.stderr
@@ -4,6 +4,11 @@ error[E0284]: type annotations needed
 LL |         self.input_stream(&mut stream);
    |              ^^^^^^^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/issue-12028.rs:20:1
+   |
+LL | trait StreamHash<H: StreamHasher>: Hash<H> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: cannot satisfy `<_ as StreamHasher>::S == <H as StreamHasher>::S`
 help: try using a fully qualified path to specify the expected types
    |

--- a/tests/ui/inference/issue-71732.stderr
+++ b/tests/ui/inference/issue-71732.stderr
@@ -6,6 +6,8 @@ LL |         .get(&"key".into())
    |          |
    |          cannot infer type of the type parameter `Q` declared on the method `get`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/std/src/collections/hash/map.rs:LL:COL
    = note: multiple `impl`s satisfying `String: Borrow<_>` found in the following crates: `alloc`, `core`:
            - impl Borrow<str> for String;
            - impl<T> Borrow<T> for T

--- a/tests/ui/inference/issue-72690.stderr
+++ b/tests/ui/inference/issue-72690.stderr
@@ -14,6 +14,8 @@ error[E0283]: type annotations needed
 LL |     String::from("x".as_ref());
    |                      ^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
    = note: multiple `impl`s satisfying `str: AsRef<_>` found in the following crates: `core`, `std`:
            - impl AsRef<ByteStr> for str;
            - impl AsRef<OsStr> for str;
@@ -42,6 +44,8 @@ error[E0283]: type annotations needed
 LL |     |x| String::from("x".as_ref());
    |                          ^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
    = note: multiple `impl`s satisfying `str: AsRef<_>` found in the following crates: `core`, `std`:
            - impl AsRef<ByteStr> for str;
            - impl AsRef<OsStr> for str;
@@ -60,6 +64,8 @@ error[E0283]: type annotations needed for `&_`
 LL |     let _ = "x".as_ref();
    |         ^       ------ type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
    = note: multiple `impl`s satisfying `str: AsRef<_>` found in the following crates: `core`, `std`:
            - impl AsRef<ByteStr> for str;
            - impl AsRef<OsStr> for str;
@@ -87,6 +93,8 @@ error[E0283]: type annotations needed
 LL |     String::from("x".as_ref());
    |                      ^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
    = note: multiple `impl`s satisfying `str: AsRef<_>` found in the following crates: `core`, `std`:
            - impl AsRef<ByteStr> for str;
            - impl AsRef<OsStr> for str;
@@ -115,6 +123,8 @@ error[E0283]: type annotations needed
 LL |     String::from("x".as_ref());
    |                      ^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
    = note: multiple `impl`s satisfying `str: AsRef<_>` found in the following crates: `core`, `std`:
            - impl AsRef<ByteStr> for str;
            - impl AsRef<OsStr> for str;
@@ -143,6 +153,8 @@ error[E0283]: type annotations needed
 LL |     String::from("x".as_ref());
    |                      ^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
    = note: multiple `impl`s satisfying `str: AsRef<_>` found in the following crates: `core`, `std`:
            - impl AsRef<ByteStr> for str;
            - impl AsRef<OsStr> for str;
@@ -171,6 +183,8 @@ error[E0283]: type annotations needed
 LL |     String::from("x".as_ref());
    |                      ^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
    = note: multiple `impl`s satisfying `str: AsRef<_>` found in the following crates: `core`, `std`:
            - impl AsRef<ByteStr> for str;
            - impl AsRef<OsStr> for str;
@@ -199,6 +213,8 @@ error[E0283]: type annotations needed
 LL |     String::from("x".as_ref());
    |                      ^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
    = note: multiple `impl`s satisfying `str: AsRef<_>` found in the following crates: `core`, `std`:
            - impl AsRef<ByteStr> for str;
            - impl AsRef<OsStr> for str;
@@ -227,6 +243,8 @@ error[E0283]: type annotations needed
 LL |     String::from("x".as_ref());
    |                      ^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
    = note: multiple `impl`s satisfying `str: AsRef<_>` found in the following crates: `core`, `std`:
            - impl AsRef<ByteStr> for str;
            - impl AsRef<OsStr> for str;

--- a/tests/ui/inference/issue-80816.rs
+++ b/tests/ui/inference/issue-80816.rs
@@ -22,7 +22,7 @@ impl<T> Deref for DirectDeref<Arc<T>> {
     }
 }
 
-pub trait Access<T> {
+pub trait Access<T> { //~ NOTE: type must be known for type parameter in this
     type Guard: Deref<Target = T>;
     fn load(&self) -> Self::Guard {
         unimplemented!()
@@ -30,7 +30,7 @@ pub trait Access<T> {
 }
 impl<T, A: Access<T>, P: Deref<Target = A>> Access<T> for P {
     //~^ NOTE: required for `Arc<ArcSwapAny<Arc<usize>>>` to implement `Access<_>`
-    //~| NOTE unsatisfied trait bound introduced here
+    //~| NOTE: unsatisfied trait bound introduced here
     type Guard = A::Guard;
 }
 impl<T> Access<T> for ArcSwapAny<T> {

--- a/tests/ui/inference/issue-80816.stderr
+++ b/tests/ui/inference/issue-80816.stderr
@@ -4,6 +4,11 @@ error[E0283]: type annotations needed
 LL |     let guard: Guard<Arc<usize>> = s.load();
    |                                      ^^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/issue-80816.rs:25:1
+   |
+LL | pub trait Access<T> {
+   | ^^^^^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `ArcSwapAny<Arc<usize>>: Access<_>` found
   --> $DIR/issue-80816.rs:36:1
    |

--- a/tests/ui/inference/issue-83606.stderr
+++ b/tests/ui/inference/issue-83606.stderr
@@ -4,6 +4,11 @@ error[E0284]: type annotations needed for `[usize; _]`
 LL |     let _ = foo("foo");
    |         ^   ---------- type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $DIR/issue-83606.rs:3:1
+   |
+LL | fn foo<const N: usize>(_: impl std::fmt::Display) -> [usize; N] {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a const generic parameter in `foo`
   --> $DIR/issue-83606.rs:3:8
    |

--- a/tests/ui/inference/issue-86094-suggest-add-return-to-coerce-ret-ty.stderr
+++ b/tests/ui/inference/issue-86094-suggest-add-return-to-coerce-ret-ty.stderr
@@ -4,6 +4,8 @@ error[E0282]: type annotations needed
 LL |         Err(MyError);
    |         ^^^ cannot infer type of the type parameter `T` declared on the enum `Result`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/result.rs:LL:COL
 help: consider specifying the generic arguments
    |
 LL |         Err::<T, MyError>(MyError);
@@ -15,6 +17,8 @@ error[E0282]: type annotations needed
 LL |         Ok(());
    |         ^^ cannot infer type of the type parameter `E` declared on the enum `Result`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/result.rs:LL:COL
 help: consider specifying the generic arguments
    |
 LL |         Ok::<(), E>(());
@@ -68,6 +72,8 @@ error[E0282]: type annotations needed
 LL |     Err(MyError);
    |     ^^^ cannot infer type of the type parameter `T` declared on the enum `Result`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/result.rs:LL:COL
 help: consider specifying the generic arguments
    |
 LL |     Err::<T, MyError>(MyError);
@@ -79,6 +85,13 @@ error[E0282]: type annotations needed
 LL |     with_closure(|x: u32, y| {});
    |                           ^
    |
+note: type must be known for type parameter in this
+  --> $DIR/issue-86094-suggest-add-return-to-coerce-ret-ty.rs:49:1
+   |
+LL | / fn with_closure<F, A, B>(_: F) -> i32
+LL | | where
+LL | |     F: FnOnce(A, B),
+   | |____________________^
 help: consider giving this closure parameter an explicit type
    |
 LL |     with_closure(|x: u32, y: /* Type */| {});

--- a/tests/ui/inference/issue-86162-1.stderr
+++ b/tests/ui/inference/issue-86162-1.stderr
@@ -6,6 +6,11 @@ LL |     foo(gen()); //<- Do not suggest `foo::<impl Clone>()`!
    |     |
    |     required by a bound introduced by this call
    |
+note: type must be known for type parameter in this
+  --> $DIR/issue-86162-1.rs:3:1
+   |
+LL | fn foo(x: impl Clone) {}
+   | ^^^^^^^^^^^^^^^^^^^^^
    = note: the type must implement `Clone`
 note: required by a bound in `foo`
   --> $DIR/issue-86162-1.rs:3:16

--- a/tests/ui/inference/issue-86162-2.stderr
+++ b/tests/ui/inference/issue-86162-2.stderr
@@ -6,6 +6,11 @@ LL |     Foo::bar(gen()); //<- Do not suggest `Foo::bar::<impl Clone>()`!
    |     |
    |     required by a bound introduced by this call
    |
+note: type must be known for type parameter in this
+  --> $DIR/issue-86162-2.rs:8:5
+   |
+LL |     fn bar(x: impl Clone) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^
    = note: the type must implement `Clone`
 note: required by a bound in `Foo::bar`
   --> $DIR/issue-86162-2.rs:8:20

--- a/tests/ui/inference/multiple-impl-apply.stderr
+++ b/tests/ui/inference/multiple-impl-apply.stderr
@@ -4,6 +4,8 @@ error[E0283]: type annotations needed
 LL |     let y = x.into();
    |         ^     ---- type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
 note: multiple `impl`s satisfying `_: From<Baz>` found
   --> $DIR/multiple-impl-apply.rs:14:1
    |

--- a/tests/ui/inference/need_type_info/channel.stderr
+++ b/tests/ui/inference/need_type_info/channel.stderr
@@ -4,6 +4,8 @@ error[E0282]: type annotations needed
 LL |         channel();
    |         ^^^^^^^ cannot infer type of the type parameter `T` declared on the function `channel`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/std/src/sync/mpsc.rs:LL:COL
 help: consider specifying the generic argument
    |
 LL |         channel::<T>();
@@ -15,6 +17,8 @@ error[E0282]: type annotations needed
 LL |         channel();
    |         ^^^^^^^ cannot infer type of the type parameter `T` declared on the function `channel`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/std/src/sync/mpsc.rs:LL:COL
 help: consider specifying the generic argument
    |
 LL |         channel::<T>();

--- a/tests/ui/inference/need_type_info/expr-struct-type-relative-enum.stderr
+++ b/tests/ui/inference/need_type_info/expr-struct-type-relative-enum.stderr
@@ -4,6 +4,11 @@ error[E0282]: type annotations needed
 LL |         needs_infer();
    |         ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `needs_infer`
    |
+note: type must be known for type parameter in this
+  --> $DIR/expr-struct-type-relative-enum.rs:7:1
+   |
+LL | fn needs_infer<T>() {}
+   | ^^^^^^^^^^^^^^^^^^^
 help: consider specifying the generic argument
    |
 LL |         needs_infer::<T>();

--- a/tests/ui/inference/need_type_info/expr-struct-type-relative-gat.stderr
+++ b/tests/ui/inference/need_type_info/expr-struct-type-relative-gat.stderr
@@ -3,6 +3,12 @@ error[E0282]: type annotations needed
    |
 LL |         Self::Output::Simple {};
    |         ^^^^^^^^^^^^ cannot infer type for type parameter `T` declared on the associated type `Output`
+   |
+note: type must be known for type parameter in this
+  --> $DIR/expr-struct-type-relative-gat.rs:2:5
+   |
+LL |     type Output<T>;
+   |     ^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inference/need_type_info/expr-struct-type-relative.stderr
+++ b/tests/ui/inference/need_type_info/expr-struct-type-relative.stderr
@@ -4,6 +4,11 @@ error[E0282]: type annotations needed
 LL |         needs_infer();
    |         ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `needs_infer`
    |
+note: type must be known for type parameter in this
+  --> $DIR/expr-struct-type-relative.rs:9:1
+   |
+LL | fn needs_infer<T>() {}
+   | ^^^^^^^^^^^^^^^^^^^
 help: consider specifying the generic argument
    |
 LL |         needs_infer::<T>();

--- a/tests/ui/inference/need_type_info/issue-103053.stderr
+++ b/tests/ui/inference/need_type_info/issue-103053.stderr
@@ -4,6 +4,8 @@ error[E0282]: type annotations needed
 LL |     None;
    |     ^^^^ cannot infer type of the type parameter `T` declared on the enum `Option`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/option.rs:LL:COL
 help: consider specifying the generic argument
    |
 LL |     None::<T>;

--- a/tests/ui/inference/need_type_info/issue-113264-incorrect-impl-trait-in-path-suggestion.stderr
+++ b/tests/ui/inference/need_type_info/issue-113264-incorrect-impl-trait-in-path-suggestion.stderr
@@ -6,6 +6,11 @@ LL |     (S {}).owo(None)
    |            |
    |            required by a bound introduced by this call
    |
+note: type must be known for type parameter in this
+  --> $DIR/issue-113264-incorrect-impl-trait-in-path-suggestion.rs:6:5
+   |
+LL |     fn owo(&self, _: Option<&impl T>) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: the type must implement `T`
 note: required by a bound in `S::owo`
   --> $DIR/issue-113264-incorrect-impl-trait-in-path-suggestion.rs:6:35

--- a/tests/ui/inference/need_type_info/self-ty-in-path.stderr
+++ b/tests/ui/inference/need_type_info/self-ty-in-path.stderr
@@ -4,6 +4,11 @@ error[E0282]: type annotations needed
 LL |         Self::func_a();
    |         ^^^^^^^^^^^^ cannot infer type of the type parameter `U` declared on the associated function `func_a`
    |
+note: type must be known for type parameter in this
+  --> $DIR/self-ty-in-path.rs:5:5
+   |
+LL |     fn func_a<U>() {}
+   |     ^^^^^^^^^^^^^^
 help: consider specifying the generic argument
    |
 LL |         Self::func_a::<U>();

--- a/tests/ui/inference/need_type_info/type-alias-indirect.stderr
+++ b/tests/ui/inference/need_type_info/type-alias-indirect.stderr
@@ -3,6 +3,12 @@ error[E0282]: type annotations needed
    |
 LL |     IndirectAlias::new();
    |     ^^^^^^^^^^^^^ cannot infer type for type parameter `T` declared on the type alias `IndirectAlias`
+   |
+note: type must be known for type parameter in this
+  --> $DIR/type-alias-indirect.rs:12:1
+   |
+LL | type IndirectAlias<T> = Ty<Box<T>>;
+   | ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inference/need_type_info/type-alias.stderr
+++ b/tests/ui/inference/need_type_info/type-alias.stderr
@@ -3,18 +3,36 @@ error[E0282]: type annotations needed
    |
 LL |     DirectAlias::new()
    |     ^^^^^^^^^^^ cannot infer type for type parameter `T` declared on the type alias `DirectAlias`
+   |
+note: type must be known for type parameter in this
+  --> $DIR/type-alias.rs:10:1
+   |
+LL | type DirectAlias<T> = Ty<T>;
+   | ^^^^^^^^^^^^^^^^^^^
 
 error[E0282]: type annotations needed
   --> $DIR/type-alias.rs:18:5
    |
 LL |     IndirectAlias::new();
    |     ^^^^^^^^^^^^^ cannot infer type for type parameter `T` declared on the type alias `IndirectAlias`
+   |
+note: type must be known for type parameter in this
+  --> $DIR/type-alias.rs:16:1
+   |
+LL | type IndirectAlias<T> = Ty<Box<T>>;
+   | ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0282]: type annotations needed
   --> $DIR/type-alias.rs:32:5
    |
 LL |     DirectButWithDefaultAlias::new();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `T` declared on the type alias `DirectButWithDefaultAlias`
+   |
+note: type must be known for type parameter in this
+  --> $DIR/type-alias.rs:30:1
+   |
+LL | type DirectButWithDefaultAlias<T> = TyDefault<T>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/inference/question-mark-type-infer.stderr
+++ b/tests/ui/inference/question-mark-type-infer.stderr
@@ -4,6 +4,8 @@ error[E0283]: type annotations needed
 LL |     l.iter().map(f).collect()?
    |                     ^^^^^^^ cannot infer type of the type parameter `B` declared on the method `collect`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    = note: the type must implement `FromIterator<Result<i32, ()>>`
 note: required by a bound in `collect`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
@@ -18,6 +20,8 @@ error[E0283]: type annotations needed
 LL |     let x = l.iter().map(f).collect()?;
    |                             ^^^^^^^ cannot infer type of the type parameter `B` declared on the method `collect`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    = note: the type must implement `FromIterator<Result<i32, ()>>`
 note: required by a bound in `collect`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
@@ -32,6 +36,8 @@ error[E0283]: type annotations needed
 LL |     let x: Vec<i32> = l.iter().map(f).collect()?;
    |                                       ^^^^^^^ cannot infer type of the type parameter `B` declared on the method `collect`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    = note: the type must implement `FromIterator<Result<i32, ()>>`
 note: required by a bound in `collect`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL

--- a/tests/ui/inference/question-mark-type-inference-in-chain.rs
+++ b/tests/ui/inference/question-mark-type-inference-in-chain.rs
@@ -42,6 +42,7 @@ pub fn error2(lines: &[&str]) -> Result<Vec<Version>> {
     //~^ ERROR: type annotations needed
     //~| NOTE: cannot infer type of the type parameter `B`
     //~| NOTE: the type must implement `FromIterator<std::result::Result<Version, Error>>`
+    //~| NOTE: type must be known for type parameter in this
     //~| NOTE: required by a bound in `collect`
     //~| HELP: consider specifying the generic argument
     tags.sort();

--- a/tests/ui/inference/question-mark-type-inference-in-chain.stderr
+++ b/tests/ui/inference/question-mark-type-inference-in-chain.stderr
@@ -18,6 +18,8 @@ error[E0283]: type annotations needed
 LL |     let mut tags: Vec<Version> = lines.iter().map(|e| parse(e)).collect()?;
    |                                                                 ^^^^^^^ cannot infer type of the type parameter `B` declared on the method `collect`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    = note: the type must implement `FromIterator<std::result::Result<Version, Error>>`
 note: required by a bound in `collect`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
@@ -27,7 +29,7 @@ LL |     let mut tags: Vec<Version> = lines.iter().map(|e| parse(e)).collect::<R
    |                                                                        ++++++++++++++++
 
 error[E0277]: the `?` operator can only be applied to values that implement `Try`
-  --> $DIR/question-mark-type-inference-in-chain.rs:53:20
+  --> $DIR/question-mark-type-inference-in-chain.rs:54:20
    |
 LL |     let mut tags = lines.iter().map(|e| parse(e)).collect::<Vec<_>>()?;
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `Vec<std::result::Result<Version, Error>>`
@@ -35,7 +37,7 @@ LL |     let mut tags = lines.iter().map(|e| parse(e)).collect::<Vec<_>>()?;
    = help: the nightly-only, unstable trait `Try` is not implemented for `Vec<std::result::Result<Version, Error>>`
 
 error[E0277]: a value of type `std::result::Result<Vec<Version>, AnotherError>` cannot be built from an iterator over elements of type `std::result::Result<Version, Error>`
-  --> $DIR/question-mark-type-inference-in-chain.rs:72:20
+  --> $DIR/question-mark-type-inference-in-chain.rs:73:20
    |
 LL |         .collect::<Result<Vec<Version>>>()?;
    |          -------   ^^^^^^^^^^^^^^^^^^^^ value of type `std::result::Result<Vec<Version>, AnotherError>` cannot be built from `std::iter::Iterator<Item=std::result::Result<Version, Error>>`
@@ -47,7 +49,7 @@ help: the trait `FromIterator<std::result::Result<_, Error>>` is not implemented
   --> $SRC_DIR/core/src/result.rs:LL:COL
    = help: for that trait implementation, expected `AnotherError`, found `Error`
 note: the method call chain might not have had the expected associated types
-  --> $DIR/question-mark-type-inference-in-chain.rs:69:10
+  --> $DIR/question-mark-type-inference-in-chain.rs:70:10
    |
 LL |     let mut tags = lines
    |                    ----- this expression has type `&[&str]`

--- a/tests/ui/inference/really-long-type-in-let-binding-without-sufficient-type-info.stderr
+++ b/tests/ui/inference/really-long-type-in-let-binding-without-sufficient-type-info.stderr
@@ -4,6 +4,8 @@ error[E0282]: type annotations needed for `Result<_, (((..., ..., ..., ...), ...
 LL |     let y = Err(x);
    |         ^   ------ type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/result.rs:LL:COL
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/really-long-type-in-let-binding-without-sufficient-type-info.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 help: consider giving `y` an explicit type, where the type for type parameter `T` is specified

--- a/tests/ui/inference/useless-turbofish-suggestion.stderr
+++ b/tests/ui/inference/useless-turbofish-suggestion.stderr
@@ -10,6 +10,11 @@ error[E0282]: type annotations needed
 LL |     S.f(42);
    |       ^ cannot infer type of the type parameter `B` declared on the method `f`
    |
+note: type must be known for type parameter in this
+  --> $DIR/useless-turbofish-suggestion.rs:13:5
+   |
+LL |     fn f<A, B>(self, _a: A) -> B {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider specifying the generic arguments
    |
 LL |     S.f::<i32, B>(42);

--- a/tests/ui/issues/issue-17551.stderr
+++ b/tests/ui/issues/issue-17551.stderr
@@ -4,6 +4,8 @@ error[E0282]: type annotations needed for `B<_>`
 LL |     let foo = B(marker::PhantomData);
    |         ^^^     ------------------- type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/marker.rs:LL:COL
 help: consider giving `foo` an explicit type, where the type for type parameter `T` is specified
    |
 LL |     let foo: B<T> = B(marker::PhantomData);

--- a/tests/ui/issues/issue-23046.stderr
+++ b/tests/ui/issues/issue-23046.stderr
@@ -4,6 +4,12 @@ error[E0282]: type annotations needed for `Expr<'_, _>`
 LL |     let ex = |x| {
    |               ^
    |
+note: type must be known for type parameter in this
+  --> $DIR/issue-23046.rs:11:1
+   |
+LL | / pub fn let_<'var, VAR, F: for<'v> Fn(Expr<'v, VAR>) -> Expr<'v, VAR>>
+LL | |                        (a: Expr<'var, VAR>, b: F) -> Expr<'var, VAR> {
+   | |____________________________________________________________________^
 help: consider giving this closure parameter an explicit type, where the type for type parameter `VAR` is specified
    |
 LL |     let ex = |x: Expr<'_, VAR>| {

--- a/tests/ui/methods/method-ambig-one-trait-unknown-int-type.stderr
+++ b/tests/ui/methods/method-ambig-one-trait-unknown-int-type.stderr
@@ -4,6 +4,8 @@ error[E0282]: type annotations needed for `Vec<_>`
 LL |     let mut x = Vec::new();
    |         ^^^^^   ---------- type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 help: consider giving `x` an explicit type, where the type for type parameter `T` is specified
    |
 LL |     let mut x: Vec<T> = Vec::new();

--- a/tests/ui/missing/missing-items/missing-type-parameter.stderr
+++ b/tests/ui/missing/missing-items/missing-type-parameter.stderr
@@ -4,6 +4,11 @@ error[E0282]: type annotations needed
 LL |     foo();
    |     ^^^ cannot infer type of the type parameter `X` declared on the function `foo`
    |
+note: type must be known for type parameter in this
+  --> $DIR/missing-type-parameter.rs:1:1
+   |
+LL | fn foo<X>() { }
+   | ^^^^^^^^^^^
 help: consider specifying the generic argument
    |
 LL |     foo::<X>();

--- a/tests/ui/parser/issue-12187-1.stderr
+++ b/tests/ui/parser/issue-12187-1.stderr
@@ -4,6 +4,11 @@ error[E0282]: type annotations needed for `&_`
 LL |     let &v = new();
    |         ^^   ----- type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $DIR/issue-12187-1.rs:1:1
+   |
+LL | fn new<T>() -> &'static T {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider giving this pattern a type, where the type for type parameter `T` is specified
    |
 LL |     let &v: &_ = new();

--- a/tests/ui/parser/issue-12187-2.stderr
+++ b/tests/ui/parser/issue-12187-2.stderr
@@ -4,6 +4,11 @@ error[E0282]: type annotations needed for `&_`
 LL |     let &v = new();
    |         ^^   ----- type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $DIR/issue-12187-2.rs:1:1
+   |
+LL | fn new<'r, T>() -> &'r T {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider giving this pattern a type, where the type for type parameter `T` is specified
    |
 LL |     let &v: &_ = new();

--- a/tests/ui/repeat-expr/copy-check-deferred-after-fallback.stderr
+++ b/tests/ui/repeat-expr/copy-check-deferred-after-fallback.stderr
@@ -4,6 +4,11 @@ error[E0282]: type annotations needed for `[Foo<{integer}>; _]`
 LL |     let b = [Foo(PhantomData); _];
    |         ^    ---------------- type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $DIR/copy-check-deferred-after-fallback.rs:32:1
+   |
+LL | fn tie_and_make_goal<const N: usize, T: Trait<N>>(_: &T, _: &[Foo<T>; N]) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider giving `b` an explicit type, where the value of const parameter `N` is specified
    |
 LL |     let b: [Foo<{integer}>; N] = [Foo(PhantomData); _];

--- a/tests/ui/repeat-expr/copy-check-inference-side-effects.stderr
+++ b/tests/ui/repeat-expr/copy-check-inference-side-effects.stderr
@@ -7,6 +7,11 @@ LL |
 LL |     let b /* : [String; ?x] */ = ["string".to_string(); _];
    |                                   -------------------- type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $DIR/copy-check-inference-side-effects.rs:10:1
+   |
+LL | fn unify<const N: usize>(_: &[Foo<N>; 2], _: &[String; N]) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider giving `a` an explicit type, where the value of const parameter `N` is specified
    |
 LL |     let a: [Foo<N>; 2] /* : [Foo<?x>; 2] */ = [Foo::<_>; 2];
@@ -18,6 +23,11 @@ error[E0282]: type annotations needed for `[String; _]`
 LL |     let b /* : [String; ?x] */ = ["string".to_string(); _];
    |         ^                         -------------------- type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $DIR/copy-check-inference-side-effects.rs:10:1
+   |
+LL | fn unify<const N: usize>(_: &[Foo<N>; 2], _: &[String; N]) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider giving `b` an explicit type, where the value of const parameter `N` is specified
    |
 LL |     let b: [_; N] /* : [String; ?x] */ = ["string".to_string(); _];

--- a/tests/ui/repeat-expr/copy-inference-side-effects-are-lazy.stderr
+++ b/tests/ui/repeat-expr/copy-inference-side-effects-are-lazy.stderr
@@ -7,6 +7,11 @@ LL |
 LL |     extract(x).max(2);
    |     ---------- type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $DIR/copy-inference-side-effects-are-lazy.rs:12:1
+   |
+LL | fn extract<T, const N: usize>(_: [Foo<T>; N]) -> T {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider giving `x` an explicit type, where the type for type parameter `T` is specified
    |
 LL |     let x: [Foo<T>; 2] = [Foo(PhantomData); 2];

--- a/tests/ui/repeat-expr/no-conservative-copy-impl-requirement.stderr
+++ b/tests/ui/repeat-expr/no-conservative-copy-impl-requirement.stderr
@@ -4,6 +4,11 @@ error[E0282]: type annotations needed for `&[Foo<_>; _]`
 LL |     let x = &[Foo::<_>; _];
    |         ^     -------- type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $DIR/no-conservative-copy-impl-requirement.rs:10:1
+   |
+LL | fn unify<const N: usize>(_: &[Foo<N>; N]) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider giving `x` an explicit type, where the value of const parameter `N` is specified
    |
 LL |     let x: &[Foo<N>; N] = &[Foo::<_>; _];

--- a/tests/ui/return/tail-expr-as-potential-return.stderr
+++ b/tests/ui/return/tail-expr-as-potential-return.stderr
@@ -53,6 +53,11 @@ error[E0282]: type annotations needed
 LL |         Receiver.generic();
    |                  ^^^^^^^ cannot infer type of the type parameter `T` declared on the method `generic`
    |
+note: type must be known for type parameter in this
+  --> $DIR/tail-expr-as-potential-return.rs:54:5
+   |
+LL |     fn generic<T>(self) -> Option<T> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider specifying the generic argument
    |
 LL |         Receiver.generic::<T>();

--- a/tests/ui/span/type-annotations-needed-expr.stderr
+++ b/tests/ui/span/type-annotations-needed-expr.stderr
@@ -4,6 +4,8 @@ error[E0282]: type annotations needed
 LL |     let _ = (vec![1,2,3]).into_iter().sum() as f64;
    |                                       ^^^ cannot infer type of the type parameter `S` declared on the method `sum`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 help: consider specifying the generic argument
    |
 LL |     let _ = (vec![1,2,3]).into_iter().sum::<S>() as f64;

--- a/tests/ui/suggestions/fn-needing-specified-return-type-param.stderr
+++ b/tests/ui/suggestions/fn-needing-specified-return-type-param.stderr
@@ -4,6 +4,11 @@ error[E0282]: type annotations needed
 LL |     let _ = f;
    |             ^ cannot infer type of the type parameter `A` declared on the function `f`
    |
+note: type must be known for type parameter in this
+  --> $DIR/fn-needing-specified-return-type-param.rs:1:1
+   |
+LL | fn f<A>() -> A { unimplemented!() }
+   | ^^^^^^^^^^^^^^
 help: consider specifying the generic argument
    |
 LL |     let _ = f::<A>;

--- a/tests/ui/suggestions/types/into-inference-needs-type.stderr
+++ b/tests/ui/suggestions/types/into-inference-needs-type.stderr
@@ -4,6 +4,8 @@ error[E0283]: type annotations needed
 LL |         .into()?;
    |          ^^^^
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
    = note: the type must implement `From<FilterMap<Map<std::slice::Iter<'_, &str>, {closure@$DIR/into-inference-needs-type.rs:10:14: 10:17}>, fn(Option<&str>) -> Option<Option<&str>> {Option::<Option<&str>>::Some}>>`
    = note: required for `FilterMap<Map<std::slice::Iter<'_, &str>, {closure@$DIR/into-inference-needs-type.rs:10:14: 10:17}>, fn(Option<&str>) -> Option<Option<&str>> {Option::<Option<&str>>::Some}>` to implement `Into<_>`
 help: try using a fully qualified path to specify the expected types

--- a/tests/ui/trait-bounds/argument-with-unnecessary-method-call.stderr
+++ b/tests/ui/trait-bounds/argument-with-unnecessary-method-call.stderr
@@ -6,6 +6,11 @@ LL |     qux(Bar.into());
    |     |
    |     required by a bound introduced by this call
    |
+note: type must be known for type parameter in this
+  --> $DIR/argument-with-unnecessary-method-call.rs:6:1
+   |
+LL | fn qux(_: impl From<Bar>) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: the type must implement `From<Bar>`
 note: required by a bound in `qux`
   --> $DIR/argument-with-unnecessary-method-call.rs:6:16

--- a/tests/ui/trait-bounds/projection-predicate-not-satisfied-69455.stderr
+++ b/tests/ui/trait-bounds/projection-predicate-not-satisfied-69455.stderr
@@ -6,6 +6,11 @@ LL |     println!("{}", 23u64.test(xs.iter().sum()));
    |                          |
    |                          type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $DIR/projection-predicate-not-satisfied-69455.rs:5:1
+   |
+LL | pub trait Test<Rhs = Self> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: cannot satisfy `<u64 as Test<_>>::Output == _`
 help: consider specifying the generic argument
    |
@@ -20,6 +25,11 @@ LL |     println!("{}", 23u64.test(xs.iter().sum()));
    |                          |
    |                          required by a bound introduced by this call
    |
+note: type must be known for type parameter in this
+  --> $DIR/projection-predicate-not-satisfied-69455.rs:5:1
+   |
+LL | pub trait Test<Rhs = Self> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `u64: Test<_>` found
   --> $DIR/projection-predicate-not-satisfied-69455.rs:11:1
    |

--- a/tests/ui/traits/copy-guessing.stderr
+++ b/tests/ui/traits/copy-guessing.stderr
@@ -4,6 +4,8 @@ error[E0282]: type annotations needed for `Option<_>`
 LL |     let n = None;
    |         ^   ---- type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/option.rs:LL:COL
 help: consider giving `n` an explicit type, where the type for type parameter `T` is specified
    |
 LL |     let n: Option<T> = None;

--- a/tests/ui/traits/do-not-mention-type-params-by-name-in-suggestion-issue-96292.stderr
+++ b/tests/ui/traits/do-not-mention-type-params-by-name-in-suggestion-issue-96292.stderr
@@ -4,6 +4,11 @@ error[E0283]: type annotations needed
 LL |     thing.method(42);
    |           ^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/do-not-mention-type-params-by-name-in-suggestion-issue-96292.rs:3:1
+   |
+LL | trait Method<T> {
+   | ^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `Thing<bool>: Method<_>` found
   --> $DIR/do-not-mention-type-params-by-name-in-suggestion-issue-96292.rs:7:1
    |

--- a/tests/ui/traits/issue-77982.stderr
+++ b/tests/ui/traits/issue-77982.stderr
@@ -6,6 +6,8 @@ LL |     opts.get(opt.as_ref());
    |          |
    |          cannot infer type of the type parameter `Q` declared on the method `get`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/std/src/collections/hash/map.rs:LL:COL
    = note: multiple `impl`s satisfying `String: Borrow<_>` found in the following crates: `alloc`, `core`:
            - impl Borrow<str> for String;
            - impl<T> Borrow<T> for T
@@ -25,6 +27,8 @@ LL |     opts.get(opt.as_ref());
    |          |
    |          cannot infer type of the type parameter `Q` declared on the method `get`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
    = note: multiple `impl`s satisfying `String: AsRef<_>` found in the following crates: `alloc`, `std`:
            - impl AsRef<OsStr> for String;
            - impl AsRef<Path> for String;
@@ -43,6 +47,8 @@ LL |     let ips: Vec<_> = (0..100_000).map(|_| u32::from(0u32.into())).collect(
    |                                            |
    |                                            type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
    = note: multiple `impl`s satisfying `u32: From<_>` found in the `core` crate:
            - impl From<Ipv4Addr> for u32;
            - impl From<bool> for u32;
@@ -62,6 +68,11 @@ error[E0283]: type annotations needed for `Box<_>`
 LL |     let _ = ().foo();
    |         ^      --- type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $DIR/issue-77982.rs:20:1
+   |
+LL | trait Foo<'a, T: ?Sized> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `(): Foo<'_, _>` found
   --> $DIR/issue-77982.rs:32:1
    |
@@ -80,6 +91,11 @@ error[E0283]: type annotations needed for `Box<_>`
 LL |     let _ = (&()).bar();
    |         ^         --- type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $DIR/issue-77982.rs:26:1
+   |
+LL | trait Bar<'a, T: ?Sized> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `&(): Bar<'_, _>` found
   --> $DIR/issue-77982.rs:35:1
    |

--- a/tests/ui/traits/multidispatch-convert-ambig-dest.stderr
+++ b/tests/ui/traits/multidispatch-convert-ambig-dest.stderr
@@ -6,6 +6,12 @@ LL |     test(22, std::default::Default::default());
    |     |
    |     cannot infer type of the type parameter `U` declared on the function `test`
    |
+note: type must be known for type parameter in this
+  --> $DIR/multidispatch-convert-ambig-dest.rs:20:1
+   |
+LL | / fn test<T,U>(_: T, _: U)
+LL | | where T : Convert<U>
+   | |____________________^
 note: multiple `impl`s satisfying `i32: Convert<_>` found
   --> $DIR/multidispatch-convert-ambig-dest.rs:8:1
    |

--- a/tests/ui/traits/next-solver/well-formed-in-relate.stderr
+++ b/tests/ui/traits/next-solver/well-formed-in-relate.stderr
@@ -7,6 +7,11 @@ LL |     let x;
 LL |     x = unconstrained_map();
    |         ------------------- type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $DIR/well-formed-in-relate.rs:21:1
+   |
+LL | fn unconstrained_map<T: Fn() -> U, U>() -> <Map<T, U> as Mirror>::Assoc { todo!() }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: multiple `impl`s satisfying `_: Fn()` found in the following crates: `alloc`, `core`:
            - impl<A, F> Fn<A> for &F
              where A: std::marker::Tuple, F: Fn<A>, F: ?Sized;

--- a/tests/ui/traits/not-suggest-non-existing-fully-qualified-path.stderr
+++ b/tests/ui/traits/not-suggest-non-existing-fully-qualified-path.stderr
@@ -4,6 +4,11 @@ error[E0283]: type annotations needed
 LL |     a.method();
    |       ^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/not-suggest-non-existing-fully-qualified-path.rs:8:1
+   |
+LL | trait V<U> {
+   | ^^^^^^^^^^
 note: multiple `impl`s satisfying `B: I<_>` found
   --> $DIR/not-suggest-non-existing-fully-qualified-path.rs:5:1
    |

--- a/tests/ui/traits/overflow-computing-ambiguity.stderr
+++ b/tests/ui/traits/overflow-computing-ambiguity.stderr
@@ -4,6 +4,11 @@ error[E0283]: type annotations needed
 LL |     hello();
    |     ^^^^^ cannot infer type of the type parameter `T` declared on the function `hello`
    |
+note: type must be known for type parameter in this
+  --> $DIR/overflow-computing-ambiguity.rs:12:1
+   |
+LL | fn hello<T: Hello>() {}
+   | ^^^^^^^^^^^^^^^^^^^^
    = note: the type must implement `Hello`
 help: the following types implement trait `Hello`
   --> $DIR/overflow-computing-ambiguity.rs:8:1

--- a/tests/ui/traits/suggest-fully-qualified-closure.stderr
+++ b/tests/ui/traits/suggest-fully-qualified-closure.stderr
@@ -4,6 +4,11 @@ error[E0283]: type annotations needed
 LL |     q.lol(||());
    |       ^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/suggest-fully-qualified-closure.rs:6:1
+   |
+LL | trait MyTrait<T> {
+   | ^^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `Qqq: MyTrait<_>` found
   --> $DIR/suggest-fully-qualified-closure.rs:12:1
    |

--- a/tests/ui/traits/suggest-fully-qualified-path-with-adjustment.stderr
+++ b/tests/ui/traits/suggest-fully-qualified-path-with-adjustment.stderr
@@ -4,6 +4,11 @@ error[E0283]: type annotations needed
 LL |     thing.method();
    |           ^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/suggest-fully-qualified-path-with-adjustment.rs:5:1
+   |
+LL | trait Method<T> {
+   | ^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `Thing: Method<_>` found
   --> $DIR/suggest-fully-qualified-path-with-adjustment.rs:10:1
    |
@@ -24,6 +29,11 @@ error[E0283]: type annotations needed
 LL |     thing.mut_method();
    |           ^^^^^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/suggest-fully-qualified-path-with-adjustment.rs:5:1
+   |
+LL | trait Method<T> {
+   | ^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `Thing: Method<_>` found
   --> $DIR/suggest-fully-qualified-path-with-adjustment.rs:10:1
    |
@@ -44,6 +54,11 @@ error[E0283]: type annotations needed
 LL |     thing.by_self();
    |           ^^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/suggest-fully-qualified-path-with-adjustment.rs:19:1
+   |
+LL | trait MethodRef<T> {
+   | ^^^^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `&Thing: MethodRef<_>` found
   --> $DIR/suggest-fully-qualified-path-with-adjustment.rs:22:1
    |
@@ -64,6 +79,11 @@ error[E0283]: type annotations needed
 LL |     deref_to.method();
    |              ^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/suggest-fully-qualified-path-with-adjustment.rs:5:1
+   |
+LL | trait Method<T> {
+   | ^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `Thing: Method<_>` found
   --> $DIR/suggest-fully-qualified-path-with-adjustment.rs:10:1
    |
@@ -84,6 +104,11 @@ error[E0283]: type annotations needed
 LL |     deref_to.mut_method();
    |              ^^^^^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/suggest-fully-qualified-path-with-adjustment.rs:5:1
+   |
+LL | trait Method<T> {
+   | ^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `Thing: Method<_>` found
   --> $DIR/suggest-fully-qualified-path-with-adjustment.rs:10:1
    |
@@ -104,6 +129,11 @@ error[E0283]: type annotations needed
 LL |     deref_to.by_self();
    |              ^^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/suggest-fully-qualified-path-with-adjustment.rs:19:1
+   |
+LL | trait MethodRef<T> {
+   | ^^^^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `&Thing: MethodRef<_>` found
   --> $DIR/suggest-fully-qualified-path-with-adjustment.rs:22:1
    |
@@ -124,6 +154,11 @@ error[E0283]: type annotations needed
 LL |     deref_deref_to.method();
    |                    ^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/suggest-fully-qualified-path-with-adjustment.rs:5:1
+   |
+LL | trait Method<T> {
+   | ^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `Thing: Method<_>` found
   --> $DIR/suggest-fully-qualified-path-with-adjustment.rs:10:1
    |
@@ -144,6 +179,11 @@ error[E0283]: type annotations needed
 LL |     deref_deref_to.mut_method();
    |                    ^^^^^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/suggest-fully-qualified-path-with-adjustment.rs:5:1
+   |
+LL | trait Method<T> {
+   | ^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `Thing: Method<_>` found
   --> $DIR/suggest-fully-qualified-path-with-adjustment.rs:10:1
    |
@@ -164,6 +204,11 @@ error[E0283]: type annotations needed
 LL |     deref_deref_to.by_self();
    |                    ^^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/suggest-fully-qualified-path-with-adjustment.rs:19:1
+   |
+LL | trait MethodRef<T> {
+   | ^^^^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `&Thing: MethodRef<_>` found
   --> $DIR/suggest-fully-qualified-path-with-adjustment.rs:22:1
    |

--- a/tests/ui/traits/suggest-fully-qualified-path-without-adjustment.stderr
+++ b/tests/ui/traits/suggest-fully-qualified-path-without-adjustment.stderr
@@ -4,6 +4,11 @@ error[E0283]: type annotations needed
 LL |     ref_thing.method();
    |               ^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/suggest-fully-qualified-path-without-adjustment.rs:5:1
+   |
+LL | trait Method<T> {
+   | ^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `Thing: Method<_>` found
   --> $DIR/suggest-fully-qualified-path-without-adjustment.rs:10:1
    |
@@ -24,6 +29,11 @@ error[E0283]: type annotations needed
 LL |     ref_thing.by_self();
    |               ^^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/suggest-fully-qualified-path-without-adjustment.rs:20:1
+   |
+LL | trait MethodRef<T> {
+   | ^^^^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `&Thing: MethodRef<_>` found
   --> $DIR/suggest-fully-qualified-path-without-adjustment.rs:23:1
    |
@@ -44,6 +54,11 @@ error[E0283]: type annotations needed
 LL |     mut_thing.method();
    |               ^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/suggest-fully-qualified-path-without-adjustment.rs:5:1
+   |
+LL | trait Method<T> {
+   | ^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `Thing: Method<_>` found
   --> $DIR/suggest-fully-qualified-path-without-adjustment.rs:10:1
    |
@@ -64,6 +79,11 @@ error[E0283]: type annotations needed
 LL |     mut_thing.mut_method();
    |               ^^^^^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/suggest-fully-qualified-path-without-adjustment.rs:5:1
+   |
+LL | trait Method<T> {
+   | ^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `Thing: Method<_>` found
   --> $DIR/suggest-fully-qualified-path-without-adjustment.rs:10:1
    |
@@ -84,6 +104,11 @@ error[E0283]: type annotations needed
 LL |     mut_thing.by_self();
    |               ^^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/suggest-fully-qualified-path-without-adjustment.rs:20:1
+   |
+LL | trait MethodRef<T> {
+   | ^^^^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `&Thing: MethodRef<_>` found
   --> $DIR/suggest-fully-qualified-path-without-adjustment.rs:23:1
    |
@@ -104,6 +129,11 @@ error[E0283]: type annotations needed
 LL |     deref_to.method();
    |              ^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/suggest-fully-qualified-path-without-adjustment.rs:5:1
+   |
+LL | trait Method<T> {
+   | ^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `Thing: Method<_>` found
   --> $DIR/suggest-fully-qualified-path-without-adjustment.rs:10:1
    |
@@ -124,6 +154,11 @@ error[E0283]: type annotations needed
 LL |     deref_to.mut_method();
    |              ^^^^^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/suggest-fully-qualified-path-without-adjustment.rs:5:1
+   |
+LL | trait Method<T> {
+   | ^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `Thing: Method<_>` found
   --> $DIR/suggest-fully-qualified-path-without-adjustment.rs:10:1
    |
@@ -144,6 +179,11 @@ error[E0283]: type annotations needed
 LL |     deref_to.by_self();
    |              ^^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/suggest-fully-qualified-path-without-adjustment.rs:20:1
+   |
+LL | trait MethodRef<T> {
+   | ^^^^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `&Thing: MethodRef<_>` found
   --> $DIR/suggest-fully-qualified-path-without-adjustment.rs:23:1
    |
@@ -164,6 +204,11 @@ error[E0283]: type annotations needed
 LL |     deref_deref_to.method();
    |                    ^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/suggest-fully-qualified-path-without-adjustment.rs:5:1
+   |
+LL | trait Method<T> {
+   | ^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `Thing: Method<_>` found
   --> $DIR/suggest-fully-qualified-path-without-adjustment.rs:10:1
    |
@@ -184,6 +229,11 @@ error[E0283]: type annotations needed
 LL |     deref_deref_to.mut_method();
    |                    ^^^^^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/suggest-fully-qualified-path-without-adjustment.rs:5:1
+   |
+LL | trait Method<T> {
+   | ^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `Thing: Method<_>` found
   --> $DIR/suggest-fully-qualified-path-without-adjustment.rs:10:1
    |
@@ -204,6 +254,11 @@ error[E0283]: type annotations needed
 LL |     deref_deref_to.by_self();
    |                    ^^^^^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/suggest-fully-qualified-path-without-adjustment.rs:20:1
+   |
+LL | trait MethodRef<T> {
+   | ^^^^^^^^^^^^^^^^^^
 note: multiple `impl`s satisfying `&Thing: MethodRef<_>` found
   --> $DIR/suggest-fully-qualified-path-without-adjustment.rs:23:1
    |

--- a/tests/ui/type-alias-impl-trait/incomplete-inference.stderr
+++ b/tests/ui/type-alias-impl-trait/incomplete-inference.stderr
@@ -4,6 +4,8 @@ error[E0282]: type annotations needed
 LL |     None
    |     ^^^^ cannot infer type of the type parameter `T` declared on the enum `Option`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/option.rs:LL:COL
 help: consider specifying the generic argument
    |
 LL |     None::<T>

--- a/tests/ui/type-inference/or_else-multiple-type-params.stderr
+++ b/tests/ui/type-inference/or_else-multiple-type-params.stderr
@@ -4,6 +4,8 @@ error[E0282]: type annotations needed for `Result<Child, _>`
 LL |         .or_else(|err| {
    |                  ^^^^^
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/result.rs:LL:COL
 help: try giving this closure an explicit return type
    |
 LL |         .or_else(|err| -> Result<_, F> {

--- a/tests/ui/type-inference/send-with-unspecified-type.stderr
+++ b/tests/ui/type-inference/send-with-unspecified-type.stderr
@@ -4,6 +4,8 @@ error[E0282]: type annotations needed
 LL |         tx.send(Foo{ foo: PhantomData });
    |                           ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the struct `PhantomData`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/marker.rs:LL:COL
 help: consider specifying the generic argument
    |
 LL |         tx.send(Foo{ foo: PhantomData::<T> });

--- a/tests/ui/type-inference/sort_by_key.stderr
+++ b/tests/ui/type-inference/sort_by_key.stderr
@@ -6,6 +6,8 @@ LL |     lst.sort_by_key(|&(v, _)| v.iter().sum());
    |         |
    |         type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/alloc/src/slice.rs:LL:COL
    = note: the type must implement `Ord`
 note: required by a bound in `slice::<impl [T]>::sort_by_key`
   --> $SRC_DIR/alloc/src/slice.rs:LL:COL

--- a/tests/ui/type-inference/type-inference-none-in-generic-ref.stderr
+++ b/tests/ui/type-inference/type-inference-none-in-generic-ref.stderr
@@ -4,6 +4,8 @@ error[E0282]: type annotations needed
 LL |     S { o: &None };
    |     ^^^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the struct `S`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/option.rs:LL:COL
 help: consider specifying the generic argument
    |
 LL |     S::<T> { o: &None };

--- a/tests/ui/type-inference/type-inference-unconstrained-none.stderr
+++ b/tests/ui/type-inference/type-inference-unconstrained-none.stderr
@@ -4,6 +4,8 @@ error[E0282]: type annotations needed
 LL |     format!("{:?}", None);
    |                     ^^^^ cannot infer type of the type parameter `T` declared on the enum `Option`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/option.rs:LL:COL
 help: consider specifying the generic argument
    |
 LL |     format!("{:?}", None::<T>);
@@ -15,6 +17,8 @@ error[E0282]: type annotations needed
 LL |     None;
    |     ^^^^ cannot infer type of the type parameter `T` declared on the enum `Option`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/option.rs:LL:COL
 help: consider specifying the generic argument
    |
 LL |     None::<T>;

--- a/tests/ui/type-inference/unbounded-associated-type.stderr
+++ b/tests/ui/type-inference/unbounded-associated-type.stderr
@@ -4,6 +4,8 @@ error[E0282]: type annotations needed
 LL |     S(std::marker::PhantomData).foo();
    |       ^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the struct `PhantomData`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/marker.rs:LL:COL
 help: consider specifying the generic argument
    |
 LL |     S(std::marker::PhantomData::<T>).foo();

--- a/tests/ui/type-inference/unbounded-type-param-in-fn-with-assoc-type.stderr
+++ b/tests/ui/type-inference/unbounded-type-param-in-fn-with-assoc-type.stderr
@@ -4,6 +4,11 @@ error[E0282]: type annotations needed
 LL |     foo();
    |     ^^^ cannot infer type of the type parameter `T` declared on the function `foo`
    |
+note: type must be known for type parameter in this
+  --> $DIR/unbounded-type-param-in-fn-with-assoc-type.rs:3:1
+   |
+LL | fn foo<T, U = u64>() -> (T, U) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider specifying the generic arguments
    |
 LL |     foo::<T, U>();

--- a/tests/ui/type-inference/unbounded-type-param-in-fn.stderr
+++ b/tests/ui/type-inference/unbounded-type-param-in-fn.stderr
@@ -4,6 +4,11 @@ error[E0282]: type annotations needed
 LL |     foo();
    |     ^^^ cannot infer type of the type parameter `T` declared on the function `foo`
    |
+note: type must be known for type parameter in this
+  --> $DIR/unbounded-type-param-in-fn.rs:1:1
+   |
+LL | fn foo<T>() -> T {
+   | ^^^^^^^^^^^^^^^^
 help: consider specifying the generic argument
    |
 LL |     foo::<T>();

--- a/tests/ui/type/type-annotation-needed.rs
+++ b/tests/ui/type/type-annotation-needed.rs
@@ -1,6 +1,7 @@
 fn foo<T: Into<String>>(x: i32) {}
 //~^ NOTE required by
 //~| NOTE required by
+//~| NOTE type must be known for type parameter in this
 
 fn main() {
     foo(42);

--- a/tests/ui/type/type-annotation-needed.stderr
+++ b/tests/ui/type/type-annotation-needed.stderr
@@ -1,9 +1,14 @@
 error[E0283]: type annotations needed
-  --> $DIR/type-annotation-needed.rs:6:5
+  --> $DIR/type-annotation-needed.rs:7:5
    |
 LL |     foo(42);
    |     ^^^ cannot infer type of the type parameter `T` declared on the function `foo`
    |
+note: type must be known for type parameter in this
+  --> $DIR/type-annotation-needed.rs:1:1
+   |
+LL | fn foo<T: Into<String>>(x: i32) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: the type must implement `Into<String>`
 note: required by a bound in `foo`
   --> $DIR/type-annotation-needed.rs:1:11

--- a/tests/ui/type/type-check/unknown_type_for_closure.stderr
+++ b/tests/ui/type/type-check/unknown_type_for_closure.stderr
@@ -27,6 +27,8 @@ error[E0282]: type annotations needed
 LL |     let x = || -> Vec<_> { Vec::new() };
    |                            ^^^^^^^^ cannot infer type of the type parameter `T` declared on the struct `Vec`
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 help: consider specifying the generic argument
    |
 LL |     let x = || -> Vec<_> { Vec::<T>::new() };

--- a/tests/ui/typeck/type-inference-for-associated-types-69683.stderr
+++ b/tests/ui/typeck/type-inference-for-associated-types-69683.stderr
@@ -4,6 +4,11 @@ error[E0284]: type annotations needed
 LL |     0u16.foo(b);
    |          ^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/type-inference-for-associated-types-69683.rs:14:1
+   |
+LL | trait Foo<I>
+   | ^^^^^^^^^^^^
    = note: cannot satisfy `<u8 as Element<_>>::Array == [u8; 3]`
 help: try using a fully qualified path to specify the expected types
    |
@@ -17,6 +22,11 @@ error[E0283]: type annotations needed
 LL |     0u16.foo(b);
    |          ^^^
    |
+note: type must be known for type parameter in this
+  --> $DIR/type-inference-for-associated-types-69683.rs:14:1
+   |
+LL | trait Foo<I>
+   | ^^^^^^^^^^^^
 note: multiple `impl`s satisfying `u8: Element<_>` found
   --> $DIR/type-inference-for-associated-types-69683.rs:6:1
    |

--- a/tests/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-2.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-2.stderr
@@ -7,6 +7,8 @@ LL |     let mut closure0 = None;
 LL |                         return c();
    |                                - type must be known at this point
    |
+note: type must be known for type parameter in this
+  --> $SRC_DIR/core/src/option.rs:LL:COL
 help: consider giving `closure0` an explicit type, where the type for type parameter `T` is specified
    |
 LL |     let mut closure0: Option<T> = None;


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/153890)*
<!-- homu-ignore:end -->

When calling a function with type parameters that are unconstrained by the call expression, we mention the type parameter that couldn't be inferred, but the user previously didn't see where the name was coming from. By pointing at the function itself, including the type parameter, we give better context on what they should have done, specially when the inference machinery fails to provide any other context.

```
error[E0282]: type annotations needed
  --> $DIR/unresolved_type_param.rs:9:5
   |
LL |     bar().await;
   |     ^^^ cannot infer type of the type parameter `T` declared on the function `bar`
   |
note: type must be known for this
  --> $DIR/unresolved_type_param.rs:6:1
   |
LL | async fn bar<T>() -> () {}
   | ^^^^^^^^^^^^^^^^^^^^^^^
help: consider specifying the generic argument
   |
LL |     bar::<T>().await;
   |        +++++
```

We should further refine when we present this info to make sure we don't provide redundant notes in some cases. Also, there are cases (like those in issue 94969) that don't provide any new information with this change.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
