### PR TITLE
Lex lifetimes as identifiers, recover from emoji and emit appropriate error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4558,6 +4558,7 @@ dependencies = [
  "thin-vec",
  "tracing",
  "unicode-normalization",
+ "unicode-properties",
  "unicode-width 0.2.2",
 ]
 

--- a/compiler/rustc_lexer/src/lib.rs
+++ b/compiler/rustc_lexer/src/lib.rs
@@ -141,6 +141,7 @@ pub enum TokenKind {
     /// A lifetime, e.g. `'a`.
     Lifetime {
         starts_with_number: bool,
+        has_emoji: bool,
     },
 
     /// `;`
@@ -975,6 +976,7 @@ impl<'a> Cursor<'a> {
     fn lifetime_or_char(&mut self) -> TokenKind {
         debug_assert!(self.prev() == '\'');
 
+        let mut has_emoji = false;
         let can_be_a_lifetime = if self.second() == '\'' {
             // It's surely not a lifetime.
             false
@@ -982,7 +984,12 @@ impl<'a> Cursor<'a> {
             // If the first symbol is valid for identifier, it can be a lifetime.
             // Also check if it's a number for a better error reporting (so '0 will
             // be reported as invalid lifetime and not as unterminated char literal).
-            is_id_start(self.first()) || self.first().is_ascii_digit()
+            let c = self.first();
+            let is_emoji = !c.is_ascii() && c.is_emoji_char();
+            if is_emoji {
+                has_emoji = true;
+            }
+            is_id_start(c) || c.is_ascii_digit() || is_emoji
         };
 
         if !can_be_a_lifetime {
@@ -1012,7 +1019,13 @@ impl<'a> Cursor<'a> {
         // First symbol can be a number (which isn't a valid identifier start),
         // so skip it without any checks.
         self.bump();
-        self.eat_while(is_id_continue);
+        self.eat_while(|c| {
+            let is_emoji = !c.is_ascii() && c.is_emoji_char();
+            if is_emoji {
+                has_emoji = true;
+            }
+            is_id_continue(c) || is_emoji
+        });
 
         match self.first() {
             // Check if after skipping literal contents we've met a closing
@@ -1024,7 +1037,7 @@ impl<'a> Cursor<'a> {
                 Literal { kind, suffix_start: self.pos_within_token() }
             }
             '#' if !starts_with_number => UnknownPrefixLifetime,
-            _ => Lifetime { starts_with_number },
+            _ => Lifetime { starts_with_number, has_emoji },
         }
     }
 

--- a/compiler/rustc_lexer/src/lib.rs
+++ b/compiler/rustc_lexer/src/lib.rs
@@ -140,8 +140,7 @@ pub enum TokenKind {
 
     /// A lifetime, e.g. `'a`.
     Lifetime {
-        starts_with_number: bool,
-        has_emoji: bool,
+        invalid: bool,
     },
 
     /// `;`
@@ -585,7 +584,7 @@ impl<'a> Cursor<'a> {
                     let kind = RawStr { n_hashes: res.ok() };
                     Literal { kind, suffix_start }
                 }
-                _ => self.ident_or_unknown_prefix(),
+                _ => self.ident_or_unknown_prefix(false),
             },
 
             // Byte literal, byte string literal, raw byte string literal or identifier.
@@ -604,7 +603,7 @@ impl<'a> Cursor<'a> {
 
             // Identifier (this should be checked after other variant that can
             // start as identifier).
-            c if is_id_start(c) => self.ident_or_unknown_prefix(),
+            c if is_id_start(c) => self.ident_or_unknown_prefix(false),
 
             // Numeric literal.
             c @ '0'..='9' => {
@@ -662,7 +661,7 @@ impl<'a> Cursor<'a> {
                 Literal { kind, suffix_start }
             }
             // Identifier starting with an emoji. Only lexed for graceful error recovery.
-            c if !c.is_ascii() && c.is_emoji_char() => self.invalid_ident(),
+            c if is_emoji(c) => self.invalid_ident(),
             _ => Unknown,
         };
         if matches!(self.frontmatter_allowed, FrontmatterAllowed::Yes)
@@ -833,25 +832,22 @@ impl<'a> Cursor<'a> {
         RawIdent
     }
 
-    fn ident_or_unknown_prefix(&mut self) -> TokenKind {
-        debug_assert!(is_id_start(self.prev()));
+    fn ident_or_unknown_prefix(&mut self, already_invalid: bool) -> TokenKind {
+        debug_assert!(is_id_start(self.prev()) || already_invalid);
         // Start is already eaten, eat the rest of identifier.
         self.eat_while(is_id_continue);
         // Known prefixes must have been handled earlier. So if
         // we see a prefix here, it is definitely an unknown prefix.
         match self.first() {
             '#' | '"' | '\'' => UnknownPrefix,
-            c if !c.is_ascii() && c.is_emoji_char() => self.invalid_ident(),
+            c if is_emoji(c) => self.invalid_ident(),
             _ => Ident,
         }
     }
 
     fn invalid_ident(&mut self) -> TokenKind {
         // Start is already eaten, eat the rest of identifier.
-        self.eat_while(|c| {
-            const ZERO_WIDTH_JOINER: char = '\u{200d}';
-            is_id_continue(c) || (!c.is_ascii() && c.is_emoji_char()) || c == ZERO_WIDTH_JOINER
-        });
+        self.eat_while(|c| is_id_continue(c) || is_emoji(c));
         // An invalid identifier followed by '#' or '"' or '\'' could be
         // interpreted as an invalid literal prefix. We don't bother doing that
         // because the treatment of invalid identifiers and invalid prefixes
@@ -896,7 +892,7 @@ impl<'a> Cursor<'a> {
                 let kind = mk_kind_raw(res.ok());
                 Literal { kind, suffix_start }
             }
-            _ => self.ident_or_unknown_prefix(),
+            _ => self.ident_or_unknown_prefix(false),
         }
     }
 
@@ -976,7 +972,7 @@ impl<'a> Cursor<'a> {
     fn lifetime_or_char(&mut self) -> TokenKind {
         debug_assert!(self.prev() == '\'');
 
-        let mut has_emoji = false;
+        let mut invalid = false;
         let can_be_a_lifetime = if self.second() == '\'' {
             // It's surely not a lifetime.
             false
@@ -985,11 +981,9 @@ impl<'a> Cursor<'a> {
             // Also check if it's a number for a better error reporting (so '0 will
             // be reported as invalid lifetime and not as unterminated char literal).
             let c = self.first();
-            let is_emoji = !c.is_ascii() && c.is_emoji_char();
-            if is_emoji {
-                has_emoji = true;
-            }
-            is_id_start(c) || c.is_ascii_digit() || is_emoji
+            invalid |= c.is_ascii_digit();
+            invalid |= is_emoji(c);
+            is_id_start(c) || invalid
         };
 
         if !can_be_a_lifetime {
@@ -1019,13 +1013,7 @@ impl<'a> Cursor<'a> {
         // First symbol can be a number (which isn't a valid identifier start),
         // so skip it without any checks.
         self.bump();
-        self.eat_while(|c| {
-            let is_emoji = !c.is_ascii() && c.is_emoji_char();
-            if is_emoji {
-                has_emoji = true;
-            }
-            is_id_continue(c) || is_emoji
-        });
+        invalid |= matches!(self.ident_or_unknown_prefix(invalid), InvalidIdent);
 
         match self.first() {
             // Check if after skipping literal contents we've met a closing
@@ -1037,7 +1025,7 @@ impl<'a> Cursor<'a> {
                 Literal { kind, suffix_start: self.pos_within_token() }
             }
             '#' if !starts_with_number => UnknownPrefixLifetime,
-            _ => Lifetime { starts_with_number, has_emoji },
+            _ => Lifetime { invalid },
         }
     }
 
@@ -1289,4 +1277,8 @@ impl<'a> Cursor<'a> {
 
         self.eat_while(is_id_continue);
     }
+}
+
+fn is_emoji(c: char) -> bool {
+    !c.is_ascii() && c.is_emoji_char()
 }

--- a/compiler/rustc_lexer/src/tests.rs
+++ b/compiler/rustc_lexer/src/tests.rs
@@ -231,7 +231,7 @@ fn lifetime() {
         "'abc",
         FrontmatterAllowed::No,
         expect![[r#"
-            Token { kind: Lifetime { starts_with_number: false }, len: 4 }
+            Token { kind: Lifetime { invalid: false }, len: 4 }
         "#]],
     );
 }

--- a/compiler/rustc_parse/Cargo.toml
+++ b/compiler/rustc_parse/Cargo.toml
@@ -20,6 +20,7 @@ rustc_span = { path = "../rustc_span" }
 thin-vec = "0.2.18"
 tracing = "0.1"
 unicode-normalization = "0.1.25"
+unicode-properties = { version = "0.1.4", default-features = false, features = ["emoji"] }
 unicode-width = "0.2.2"
 # tidy-alphabetical-end
 

--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -330,48 +330,28 @@ impl<'psess, 'src> Lexer<'psess, 'src> {
                             name.chars().skip(1).next(),
                             Some(c) if c.is_ascii_digit()
                         );
-                        let mut emoji = vec![];
-                        for (i, c) in name.char_indices().skip(1) {
-                            let i = i as u32;
-                            if !c.is_ascii() && c.is_emoji_char() {
-                                let lo = start + BytePos(i);
-                                emoji.push(self.mk_sp(lo, lo + Pos::from_usize(c.len_utf8())));
-                            }
+                        if name.chars().any(|c| !c.is_ascii() && c.is_emoji_char()) {
+                            self.psess
+                                .bad_unicode_identifiers
+                                .borrow_mut()
+                                .entry(lifetime_name)
+                                .or_default()
+                                .push(span);
                         }
-                        let err = match (starts_with_number, &emoji[..]) {
-                            (false, []) => {
-                                unreachable!("lifetime {name:?} incorrectly marked as invalid?");
-                            }
-                            (true, []) if name.len() > 2 => {
+                        if starts_with_number {
+                            let mut err = self.dcx()
+                                .struct_err(format!(
+                                    "lifetimes cannot start with a number: `{name}`"
+                                ))
+                                .with_span(span);
+                            if name.len() > 2 {
                                 // Point at the first lifetime name character.
                                 let start_span = self.mk_sp(start + BytePos(1), start + BytePos(2));
-                                self.dcx()
-                                    .struct_err(format!(
-                                        "lifetimes cannot start with a number: `{name}`"
-                                    ))
-                                    .with_span(start_span)
-                                    .with_span_label(span, "")
+                                err.span(start_span);
+                                err.span_label(span, "");
                             }
-                            (true, []) => {
-                                // Point at the whole lifetime name.
-                                self.dcx()
-                                    .struct_err(format!(
-                                        "lifetimes cannot start with a number: `{name}`"
-                                    ))
-                                    .with_span(span)
-                            }
-                            (false, [_, ..]) => self.dcx()
-                                .struct_err(format!("lifetimes cannot have emoji: `{name}`"))
-                                .with_span(emoji.clone())
-                                .with_span_label(span, ""),
-                            (true, [_, ..]) => self.dcx()
-                                .struct_err(format!(
-                                    "invalid lifetime name: `{}`",
-                                    name.escape_default(),
-                                ))
-                                .with_span(span),
-                        };
-                        err.stash(span, StashKey::LifetimeIsChar);
+                            err.stash(span, StashKey::LifetimeIsChar);
+                        }
                     }
                     token::Lifetime(lifetime_name, IdentIsRaw::No)
                 }

--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -16,6 +16,7 @@ use rustc_session::lint::builtin::{
 use rustc_session::parse::ParseSess;
 use rustc_span::{BytePos, Pos, Span, Symbol, sym};
 use tracing::debug;
+use unicode_properties::emoji::UnicodeEmoji;
 
 use crate::errors;
 use crate::lexer::diagnostics::TokenTreeDiagInfo;
@@ -315,21 +316,62 @@ impl<'psess, 'src> Lexer<'psess, 'src> {
                     self.lint_literal_unicode_text_flow(symbol, kind, self.mk_sp(start, self.pos), "literal");
                     token::Literal(token::Lit { kind, symbol, suffix })
                 }
-                rustc_lexer::TokenKind::Lifetime { starts_with_number, has_emoji } => {
+                rustc_lexer::TokenKind::Lifetime { invalid } => {
                     // Include the leading `'` in the real identifier, for macro
                     // expansion purposes. See #12512 for the gory details of why
                     // this is necessary.
                     let lifetime_name = nfc_normalize(self.str_from(start));
                     self.last_lifetime = Some(self.mk_sp(start, start + BytePos(1)));
                     let span = self.mk_sp(start, self.pos);
-                    if starts_with_number {
-                        self.dcx()
-                            .struct_err("lifetimes cannot start with a number")
-                            .with_span(span)
-                            .stash(span, StashKey::LifetimeIsChar);
-                    }
-                    if has_emoji {
-                        self.dcx().struct_span_err(span, "lifetimes cannot contain emoji").emit();
+                    if invalid {
+                        let name = lifetime_name.as_str();
+                        // skip(1) to skip the `'`
+                        let starts_with_number = matches!(
+                            name.chars().skip(1).next(),
+                            Some(c) if c.is_ascii_digit()
+                        );
+                        let mut emoji = vec![];
+                        for (i, c) in name.char_indices().skip(1) {
+                            let i = i as u32;
+                            if !c.is_ascii() && c.is_emoji_char() {
+                                let lo = start + BytePos(i);
+                                emoji.push(self.mk_sp(lo, lo + Pos::from_usize(c.len_utf8())));
+                            }
+                        }
+                        let err = match (starts_with_number, &emoji[..]) {
+                            (false, []) => {
+                                unreachable!("lifetime {name:?} incorrectly marked as invalid?");
+                            }
+                            (true, []) if name.len() > 2 => {
+                                // Point at the first lifetime name character.
+                                let start_span = self.mk_sp(start + BytePos(1), start + BytePos(2));
+                                self.dcx()
+                                    .struct_err(format!(
+                                        "lifetimes cannot start with a number: `{name}`"
+                                    ))
+                                    .with_span(start_span)
+                                    .with_span_label(span, "")
+                            }
+                            (true, []) => {
+                                // Point at the whole lifetime name.
+                                self.dcx()
+                                    .struct_err(format!(
+                                        "lifetimes cannot start with a number: `{name}`"
+                                    ))
+                                    .with_span(span)
+                            }
+                            (false, [_, ..]) => self.dcx()
+                                .struct_err(format!("lifetimes cannot have emoji: `{name}`"))
+                                .with_span(emoji.clone())
+                                .with_span_label(span, ""),
+                            (true, [_, ..]) => self.dcx()
+                                .struct_err(format!(
+                                    "invalid lifetime name: `{}`",
+                                    name.escape_default(),
+                                ))
+                                .with_span(span),
+                        };
+                        err.stash(span, StashKey::LifetimeIsChar);
                     }
                     token::Lifetime(lifetime_name, IdentIsRaw::No)
                 }

--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -315,18 +315,21 @@ impl<'psess, 'src> Lexer<'psess, 'src> {
                     self.lint_literal_unicode_text_flow(symbol, kind, self.mk_sp(start, self.pos), "literal");
                     token::Literal(token::Lit { kind, symbol, suffix })
                 }
-                rustc_lexer::TokenKind::Lifetime { starts_with_number } => {
+                rustc_lexer::TokenKind::Lifetime { starts_with_number, has_emoji } => {
                     // Include the leading `'` in the real identifier, for macro
                     // expansion purposes. See #12512 for the gory details of why
                     // this is necessary.
                     let lifetime_name = nfc_normalize(self.str_from(start));
                     self.last_lifetime = Some(self.mk_sp(start, start + BytePos(1)));
+                    let span = self.mk_sp(start, self.pos);
                     if starts_with_number {
-                        let span = self.mk_sp(start, self.pos);
                         self.dcx()
                             .struct_err("lifetimes cannot start with a number")
                             .with_span(span)
                             .stash(span, StashKey::LifetimeIsChar);
+                    }
+                    if has_emoji {
+                        self.dcx().struct_span_err(span, "lifetimes cannot contain emoji").emit();
                     }
                     token::Lifetime(lifetime_name, IdentIsRaw::No)
                 }

--- a/src/tools/rust-analyzer/crates/parser/src/lexed_str.rs
+++ b/src/tools/rust-analyzer/crates/parser/src/lexed_str.rs
@@ -255,9 +255,9 @@ impl<'a> Converter<'a> {
                     return;
                 }
 
-                rustc_lexer::TokenKind::Lifetime { starts_with_number } => {
-                    if *starts_with_number {
-                        errors.push("Lifetime name cannot start with a number".into());
+                rustc_lexer::TokenKind::Lifetime { invalid } => {
+                    if *invalid {
+                        errors.push("Lifetime name contains invalid characters".into());
                     }
                     LIFETIME_IDENT
                 }

--- a/src/tools/rust-analyzer/crates/parser/test_data/lexer/err/lifetime_starts_with_a_number.rast
+++ b/src/tools/rust-analyzer/crates/parser/test_data/lexer/err/lifetime_starts_with_a_number.rast
@@ -1,4 +1,4 @@
-LIFETIME_IDENT "'1" error: Lifetime name cannot start with a number
+LIFETIME_IDENT "'1" error: Lifetime name contains invalid characters
 WHITESPACE "\n"
-LIFETIME_IDENT "'1lifetime" error: Lifetime name cannot start with a number
+LIFETIME_IDENT "'1lifetime" error: Lifetime name contains invalid characters
 WHITESPACE "\n"

--- a/src/tools/rust-analyzer/crates/parser/test_data/lexer/err/lifetime_starts_with_a_number.txt
+++ b/src/tools/rust-analyzer/crates/parser/test_data/lexer/err/lifetime_starts_with_a_number.txt
@@ -1,4 +1,4 @@
-LIFETIME_IDENT "'1" error: Lifetime name cannot start with a number
+LIFETIME_IDENT "'1" error: Lifetime name contains invalid characters
 WHITESPACE "\n"
-LIFETIME_IDENT "'1lifetime" error: Lifetime name cannot start with a number
+LIFETIME_IDENT "'1lifetime" error: Lifetime name contains invalid characters
 WHITESPACE "\n"

--- a/src/tools/rust-analyzer/crates/parser/test_data/lexer/err/unclosed_char_with_ferris.rast
+++ b/src/tools/rust-analyzer/crates/parser/test_data/lexer/err/unclosed_char_with_ferris.rast
@@ -1,1 +1,1 @@
-CHAR "'🦀" error: Missing trailing `'` symbol to terminate the character literal
+LIFETIME_IDENT "'🦀" error: Lifetime name contains invalid characters

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/token_stream.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/token_stream.rs
@@ -302,9 +302,9 @@ impl<S> TokenStream<S> {
                         span: span.derive_ranged(range),
                     }))
                 }
-                rustc_lexer::TokenKind::Lifetime { starts_with_number } => {
-                    if starts_with_number {
-                        return Err("Lifetime cannot start with a number".to_owned());
+                rustc_lexer::TokenKind::Lifetime { invalid } => {
+                    if invalid {
+                        return Err(format!("Invalid lifetime identifier: `{}`", &s[range]));
                     }
                     let range = range.start + 1..range.end;
                     tokenstream.push(TokenTree::Punct(Punct {

--- a/tests/ui/lexer/emoji-in-lifetime.rs
+++ b/tests/ui/lexer/emoji-in-lifetime.rs
@@ -1,9 +1,20 @@
 // #141081
-fn bad_lifetime_name<'🐛🐛🐛family👨‍👩‍👧‍👦>(_: &'🐛🐛🐛family👨‍👩‍👧‍👦 ()) {}
-//~^ ERROR: lifetimes cannot contain emoji
-//~| ERROR: lifetimes cannot contain emoji
+fn bad_lifetime_name<
+    '🐛🐛🐛family👨‍👩‍👧‍👦,//~ ERROR: lifetimes cannot have emoji
+    '12, //~ ERROR: lifetimes cannot start with a number
+    'a🐛, //~ ERROR: lifetimes cannot have emoji
+    '1🐛, //~ ERROR: invalid lifetime name
+    '1, //~ ERROR: lifetimes cannot start with a number
+    'a‌b // bare zero-width-joiners are accepted as XID_Continue
+>() {}
+
+
+
+
+
+
 fn main() {
-    '🐛: { //~ ERROR: lifetimes cannot contain emoji
+    '🐛: { //~ ERROR: lifetimes cannot have emoji
         todo!();
     };
 }

--- a/tests/ui/lexer/emoji-in-lifetime.rs
+++ b/tests/ui/lexer/emoji-in-lifetime.rs
@@ -1,9 +1,10 @@
 // #141081
 fn bad_lifetime_name<
-    '🐛🐛🐛family👨‍👩‍👧‍👦,//~ ERROR: lifetimes cannot have emoji
+    '🐛🐛🐛family👨‍👩‍👧‍👦,//~ ERROR: identifiers cannot contain emoji
     '12, //~ ERROR: lifetimes cannot start with a number
-    'a🐛, //~ ERROR: lifetimes cannot have emoji
-    '1🐛, //~ ERROR: invalid lifetime name
+    'a🐛, //~ ERROR: identifiers cannot contain emoji
+    '1🐛, //~ ERROR: identifiers cannot contain emoji
+    //~^ ERROR: lifetimes cannot start with a number
     '1, //~ ERROR: lifetimes cannot start with a number
     'a‌b // bare zero-width-joiners are accepted as XID_Continue
 >() {}
@@ -14,7 +15,7 @@ fn bad_lifetime_name<
 
 
 fn main() {
-    '🐛: { //~ ERROR: lifetimes cannot have emoji
+    'a🐛: { // pointed at on the error from line 5
         todo!();
     };
 }

--- a/tests/ui/lexer/emoji-in-lifetime.rs
+++ b/tests/ui/lexer/emoji-in-lifetime.rs
@@ -1,0 +1,9 @@
+// #141081
+fn bad_lifetime_name<'🐛🐛🐛family👨‍👩‍👧‍👦>(_: &'🐛🐛🐛family👨‍👩‍👧‍👦 ()) {}
+//~^ ERROR: lifetimes cannot contain emoji
+//~| ERROR: lifetimes cannot contain emoji
+fn main() {
+    '🐛: { //~ ERROR: lifetimes cannot contain emoji
+        todo!();
+    };
+}

--- a/tests/ui/lexer/emoji-in-lifetime.rs
+++ b/tests/ui/lexer/emoji-in-lifetime.rs
@@ -9,11 +9,6 @@ fn bad_lifetime_name<
     'a‌b // bare zero-width-joiners are accepted as XID_Continue
 >() {}
 
-
-
-
-
-
 fn main() {
     'a🐛: { // pointed at on the error from line 5
         todo!();

--- a/tests/ui/lexer/emoji-in-lifetime.stderr
+++ b/tests/ui/lexer/emoji-in-lifetime.stderr
@@ -1,8 +1,23 @@
-error: lifetimes cannot have emoji: `'🐛🐛🐛family👨👩👧👦`
-  --> $DIR/emoji-in-lifetime.rs:3:6
+error: identifiers cannot contain emoji: `'🐛🐛🐛family👨👩👧👦`
+  --> $DIR/emoji-in-lifetime.rs:3:5
    |
 LL |     '🐛🐛🐛family👨👩👧👦,
-   |     -^^^^^^------^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^
+
+error: identifiers cannot contain emoji: `'a🐛`
+  --> $DIR/emoji-in-lifetime.rs:5:5
+   |
+LL |     'a🐛,
+   |     ^^^^
+...
+LL |     'a🐛: { // pointed at on the error from line 5
+   |     ^^^^
+
+error: identifiers cannot contain emoji: `'1🐛`
+  --> $DIR/emoji-in-lifetime.rs:6:5
+   |
+LL |     '1🐛,
+   |     ^^^^
 
 error: lifetimes cannot start with a number: `'12`
   --> $DIR/emoji-in-lifetime.rs:4:6
@@ -10,29 +25,17 @@ error: lifetimes cannot start with a number: `'12`
 LL |     '12,
    |     -^-
 
-error: lifetimes cannot have emoji: `'a🐛`
-  --> $DIR/emoji-in-lifetime.rs:5:7
-   |
-LL |     'a🐛,
-   |     --^^
-
-error: invalid lifetime name: `\'1\u{1f41b}`
-  --> $DIR/emoji-in-lifetime.rs:6:5
+error: lifetimes cannot start with a number: `'1🐛`
+  --> $DIR/emoji-in-lifetime.rs:6:6
    |
 LL |     '1🐛,
-   |     ^^^^
+   |     -^--
 
 error: lifetimes cannot start with a number: `'1`
-  --> $DIR/emoji-in-lifetime.rs:7:5
+  --> $DIR/emoji-in-lifetime.rs:8:5
    |
 LL |     '1,
    |     ^^
-
-error: lifetimes cannot have emoji: `'🐛`
-  --> $DIR/emoji-in-lifetime.rs:17:6
-   |
-LL |     '🐛: {
-   |     -^^
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/lexer/emoji-in-lifetime.stderr
+++ b/tests/ui/lexer/emoji-in-lifetime.stderr
@@ -1,20 +1,38 @@
-error: lifetimes cannot contain emoji
-  --> $DIR/emoji-in-lifetime.rs:2:22
+error: lifetimes cannot have emoji: `'🐛🐛🐛family👨👩👧👦`
+  --> $DIR/emoji-in-lifetime.rs:3:6
    |
-LL | fn bad_lifetime_name<'🐛🐛🐛family👨👩👧👦>(_: &'🐛🐛🐛family👨👩👧👦 ()) {}
-   |                      ^^^^^^^^^^^^^^^^^^^^^
+LL |     '🐛🐛🐛family👨👩👧👦,
+   |     -^^^^^^------^^^^^^^^
 
-error: lifetimes cannot contain emoji
-  --> $DIR/emoji-in-lifetime.rs:2:45
+error: lifetimes cannot start with a number: `'12`
+  --> $DIR/emoji-in-lifetime.rs:4:6
    |
-LL | fn bad_lifetime_name<'🐛🐛🐛family👨👩👧👦>(_: &'🐛🐛🐛family👨👩👧👦 ()) {}
-   |                                                 ^^^^^^^^^^^^^^^^^^^^^
+LL |     '12,
+   |     -^-
 
-error: lifetimes cannot contain emoji
+error: lifetimes cannot have emoji: `'a🐛`
+  --> $DIR/emoji-in-lifetime.rs:5:7
+   |
+LL |     'a🐛,
+   |     --^^
+
+error: invalid lifetime name: `\'1\u{1f41b}`
   --> $DIR/emoji-in-lifetime.rs:6:5
    |
-LL |     '🐛: {
-   |     ^^^
+LL |     '1🐛,
+   |     ^^^^
 
-error: aborting due to 3 previous errors
+error: lifetimes cannot start with a number: `'1`
+  --> $DIR/emoji-in-lifetime.rs:7:5
+   |
+LL |     '1,
+   |     ^^
+
+error: lifetimes cannot have emoji: `'🐛`
+  --> $DIR/emoji-in-lifetime.rs:17:6
+   |
+LL |     '🐛: {
+   |     -^^
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui/lexer/emoji-in-lifetime.stderr
+++ b/tests/ui/lexer/emoji-in-lifetime.stderr
@@ -1,0 +1,20 @@
+error: lifetimes cannot contain emoji
+  --> $DIR/emoji-in-lifetime.rs:2:22
+   |
+LL | fn bad_lifetime_name<'🐛🐛🐛family👨👩👧👦>(_: &'🐛🐛🐛family👨👩👧👦 ()) {}
+   |                      ^^^^^^^^^^^^^^^^^^^^^
+
+error: lifetimes cannot contain emoji
+  --> $DIR/emoji-in-lifetime.rs:2:45
+   |
+LL | fn bad_lifetime_name<'🐛🐛🐛family👨👩👧👦>(_: &'🐛🐛🐛family👨👩👧👦 ()) {}
+   |                                                 ^^^^^^^^^^^^^^^^^^^^^
+
+error: lifetimes cannot contain emoji
+  --> $DIR/emoji-in-lifetime.rs:6:5
+   |
+LL |     '🐛: {
+   |     ^^^
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/lexer/lex-bad-str-literal-as-char-1.stderr
+++ b/tests/ui/lexer/lex-bad-str-literal-as-char-1.stderr
@@ -10,7 +10,7 @@ LL -     println!('1 + 1');
 LL +     println!("1 + 1");
    |
 
-error: lifetimes cannot start with a number
+error: lifetimes cannot start with a number: `'1`
   --> $DIR/lex-bad-str-literal-as-char-1.rs:3:14
    |
 LL |     println!('1 + 1');

--- a/tests/ui/parser/numeric-lifetime.stderr
+++ b/tests/ui/parser/numeric-lifetime.stderr
@@ -6,13 +6,13 @@ LL |     let x: usize = "";
    |            |
    |            expected due to this
 
-error: lifetimes cannot start with a number
+error: lifetimes cannot start with a number: `'1`
   --> $DIR/numeric-lifetime.rs:1:10
    |
 LL | struct S<'1> { s: &'1 usize }
    |          ^^
 
-error: lifetimes cannot start with a number
+error: lifetimes cannot start with a number: `'1`
   --> $DIR/numeric-lifetime.rs:1:20
    |
 LL | struct S<'1> { s: &'1 usize }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/153893)*
<!-- homu-ignore:end -->

Lex and parse emoji in lifetimes by using the identifier logic, and disallow them in the parser with a hard error. Allow emoji to start a lifetime name even if they are not XID_Start.

```
error: identifiers cannot contain emoji: `'🐛🐛🐛family👨👩👧👦`
  --> $DIR/emoji-in-lifetime.rs:1:22
   |
LL | fn bad_lifetime_name<'🐛🐛🐛family👨👩👧👦>(
   |                      ^^^^^^^^^^^^^^^^^^^^^
```

Address rust-lang/rust#141081 (but we could provide more information in the diagnostic, pointing at the specific chars, providing a link to the reference on identifiers and/or some other extra information).

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
