### PR TITLE
rustdoc: error out on `--test` with `--emit`

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -462,8 +462,13 @@ impl Options {
             return None;
         }
 
+        let should_test = matches.opt_present("test");
+
         let mut emit = FxIndexMap::<_, EmitType>::default();
         for list in matches.opt_strs("emit") {
+            if should_test {
+                dcx.fatal("the `--test` flag and the `--emit` flag are not supported together");
+            }
             for kind in list.split(',') {
                 match kind.parse() {
                     Ok(kind) => {
@@ -634,7 +639,6 @@ impl Options {
         let test_args: Vec<String> =
             test_args.iter().flat_map(|s| s.split_whitespace()).map(|s| s.to_string()).collect();
 
-        let should_test = matches.opt_present("test");
         let no_run = matches.opt_present("no-run");
 
         if !should_test && no_run {

--- a/tests/rustdoc-ui/doctest/emit-test.rs
+++ b/tests/rustdoc-ui/doctest/emit-test.rs
@@ -1,0 +1,5 @@
+//@ compile-flags:--test --emit=dep-info -Z unstable-options
+//@ check-fail
+//~? ERROR the `--test` flag and the `--emit` flag
+
+//! This example intentionally left blank.

--- a/tests/rustdoc-ui/doctest/emit-test.stderr
+++ b/tests/rustdoc-ui/doctest/emit-test.stderr
@@ -1,0 +1,2 @@
+error: the `--test` flag and the `--emit` flag are not supported together
+


### PR DESCRIPTION
These options don't behave reasonably when combined right now, and there are no tests and no docs for how they should.

For the short term, make this a fatal error. If we decide to assign this some semantics, then we can do that at any time.
