### PR TITLE
[tiny] Tweak "use of `Deref`" suggestion message

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -392,7 +392,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     {
                         err.span_suggestion_verbose(
                             span,
-                            "consider dereferencing to access the inner value using the Deref trait",
+                            "consider dereferencing to access the inner value using the `Deref` trait",
                             format!("{prefix}{peeled_snippet}"),
                             Applicability::MaybeIncorrect,
                         );

--- a/tests/ui/closures/2229_closure_analysis/issue-118144.stderr
+++ b/tests/ui/closures/2229_closure_analysis/issue-118144.stderr
@@ -6,7 +6,7 @@ LL |         V(x) = func_arg;
    |         |
    |         expected `&mut V`, found `V`
    |
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |         V(x) = &*func_arg;
    |                ++

--- a/tests/ui/let-else/let-else-deref-coercion.stderr
+++ b/tests/ui/let-else/let-else-deref-coercion.stderr
@@ -6,7 +6,7 @@ LL |         let Bar::Present(z) = self else {
    |             |
    |             expected `Foo`, found `Bar`
    |
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |         let Bar::Present(z) = &**self else {
    |                               +++
@@ -19,7 +19,7 @@ LL |         let Bar(z) = x;
    |             |
    |             expected `Foo`, found `Bar`
    |
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |         let Bar(z) = &**x;
    |                      +++

--- a/tests/ui/pattern/deref-patterns/const-pats-do-not-mislead-inference.stable.stderr
+++ b/tests/ui/pattern/deref-patterns/const-pats-do-not-mislead-inference.stable.stderr
@@ -19,7 +19,7 @@ LL |     if let "..." = &Box::new(x) {}
    |
    = note: expected reference `&Box<_>`
               found reference `&'static str`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     if let "..." = &*Box::new(x) {}
    |                     +
@@ -34,7 +34,7 @@ LL |     if let b"..." = Box::new(&x) {}
    |
    = note: expected struct `Box<&_>`
            found reference `&'static [u8; 3]`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     if let b"..." = *Box::new(&x) {}
    |                     +

--- a/tests/ui/pattern/deref-patterns/needs-gate.stderr
+++ b/tests/ui/pattern/deref-patterns/needs-gate.stderr
@@ -18,7 +18,7 @@ LL |         0 => {}
    |
    = note: expected struct `Box<{integer}>`
                 found type `{integer}`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     match *Box::new(0) {
    |           +

--- a/tests/ui/pin-ergonomics/pattern-matching-mix-deref-pattern.normal.stderr
+++ b/tests/ui/pin-ergonomics/pattern-matching-mix-deref-pattern.normal.stderr
@@ -8,7 +8,7 @@ LL |     let Foo { x, y } = foo.as_mut();
    |
    = note: expected struct `Pin<&mut Foo<T, U>>`
               found struct `Foo<_, _>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     let Foo { x, y } = *foo.as_mut();
    |                        +
@@ -23,7 +23,7 @@ LL |         Foo { x, y } => {}
    |
    = note: expected struct `Pin<&mut Foo<T, U>>`
               found struct `Foo<_, _>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     match *foo.as_mut() {
    |           +
@@ -38,7 +38,7 @@ LL |         Foo { x, y } => {}
    |
    = note: expected struct `Pin<&mut Foo<T, U>>`
               found struct `Foo<_, _>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     let _ = || match *foo.as_mut() {
    |                      +
@@ -53,7 +53,7 @@ LL |     let Foo { x, y } = foo;
    |
    = note: expected struct `Pin<&Foo<T, U>>`
               found struct `Foo<_, _>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     let Foo { x, y } = *foo;
    |                        +
@@ -68,7 +68,7 @@ LL |         Foo { x, y } => {}
    |
    = note: expected struct `Pin<&Foo<T, U>>`
               found struct `Foo<_, _>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     match *foo {
    |           +
@@ -83,7 +83,7 @@ LL |         Foo { x, y } => {}
    |
    = note: expected struct `Pin<&Foo<T, U>>`
               found struct `Foo<_, _>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     let _ = || match *foo {
    |                      +
@@ -98,7 +98,7 @@ LL |     let Bar(x, y) = bar.as_mut();
    |
    = note: expected struct `Pin<&mut Bar<T, U>>`
               found struct `Bar<_, _>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     let Bar(x, y) = *bar.as_mut();
    |                     +
@@ -113,7 +113,7 @@ LL |         Bar(x, y) => {}
    |
    = note: expected struct `Pin<&mut Bar<T, U>>`
               found struct `Bar<_, _>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     match *bar.as_mut() {
    |           +
@@ -128,7 +128,7 @@ LL |         Bar(x, y) => {}
    |
    = note: expected struct `Pin<&mut Bar<T, U>>`
               found struct `Bar<_, _>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     let _ = || match *bar.as_mut() {
    |                      +
@@ -143,7 +143,7 @@ LL |     let Bar(x, y) = bar;
    |
    = note: expected struct `Pin<&Bar<T, U>>`
               found struct `Bar<_, _>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     let Bar(x, y) = *bar;
    |                     +
@@ -158,7 +158,7 @@ LL |         Bar(x, y) => {}
    |
    = note: expected struct `Pin<&Bar<T, U>>`
               found struct `Bar<_, _>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     match *bar {
    |           +
@@ -173,7 +173,7 @@ LL |         Bar(x, y) => {}
    |
    = note: expected struct `Pin<&Bar<T, U>>`
               found struct `Bar<_, _>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     let _ = || match *bar {
    |                      +
@@ -188,7 +188,7 @@ LL |     let NonPinProject { x } = foo;
    |
    = note: expected struct `Pin<&mut NonPinProject<T>>`
               found struct `NonPinProject<_>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     let NonPinProject { x } = *foo;
    |                               +
@@ -203,7 +203,7 @@ LL |     let NonPinProject { x } = bar;
    |
    = note: expected struct `Pin<&NonPinProject<U>>`
               found struct `NonPinProject<_>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     let NonPinProject { x } = *bar;
    |                               +
@@ -218,7 +218,7 @@ LL |         NonPinProject { x } => {}
    |
    = note: expected struct `Pin<&mut NonPinProject<T>>`
               found struct `NonPinProject<_>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     match *foo {
    |           +
@@ -233,7 +233,7 @@ LL |         NonPinProject { x } => {}
    |
    = note: expected struct `Pin<&NonPinProject<U>>`
               found struct `NonPinProject<_>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     match *bar {
    |           +

--- a/tests/ui/pin-ergonomics/pattern-matching.normal.stderr
+++ b/tests/ui/pin-ergonomics/pattern-matching.normal.stderr
@@ -28,7 +28,7 @@ LL |     let Foo { x, y } = foo_mut;
    |
    = note: expected struct `Pin<&mut Foo<T, U>>`
               found struct `Foo<_, _>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     let Foo { x, y } = *foo_mut;
    |                        +
@@ -43,7 +43,7 @@ LL |     let Foo { x, y } = foo_const;
    |
    = note: expected struct `Pin<&Foo<T, U>>`
               found struct `Foo<_, _>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     let Foo { x, y } = *foo_const;
    |                        +
@@ -58,7 +58,7 @@ LL |         Bar::Foo(x, y) => {
    |
    = note: expected struct `Pin<&mut Bar<T, U>>`
                 found enum `Bar<_, _>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     match *bar_mut {
    |           +
@@ -73,7 +73,7 @@ LL |         _ if let Bar::Bar { x, y } = bar_mut => {
    |
    = note: expected struct `Pin<&mut Bar<T, U>>`
                 found enum `Bar<_, _>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |         _ if let Bar::Bar { x, y } = *bar_mut => {
    |                                      +
@@ -88,7 +88,7 @@ LL |         Bar::Bar { x, y } => {
    |
    = note: expected struct `Pin<&Bar<T, U>>`
                 found enum `Bar<_, _>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     match *bar_const {
    |           +
@@ -103,7 +103,7 @@ LL |         _ if let Bar::Foo(x, y) = bar_const => {
    |
    = note: expected struct `Pin<&Bar<T, U>>`
                 found enum `Bar<_, _>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |         _ if let Bar::Foo(x, y) = *bar_const => {
    |                                   +
@@ -118,7 +118,7 @@ LL |     let (Foo { x, y },) = foo_mut;
    |
    = note: expected struct `Pin<&mut (Foo<T, U>,)>`
                found tuple `(_,)`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     let (Foo { x, y },) = *foo_mut;
    |                           +
@@ -133,7 +133,7 @@ LL |     let (Foo { x, y },) = foo_const;
    |
    = note: expected struct `Pin<&(Foo<T, U>,)>`
                found tuple `(_,)`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     let (Foo { x, y },) = *foo_const;
    |                           +

--- a/tests/ui/suggestions/suggest-deref-in-match-issue-132784.rs
+++ b/tests/ui/suggestions/suggest-deref-in-match-issue-132784.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 fn main() {
     let mut x = Arc::new(Some(1));
     match x {
-        //~^ HELP consider dereferencing to access the inner value using the Deref trait
-        //~| HELP consider dereferencing to access the inner value using the Deref trait
+        //~^ HELP consider dereferencing to access the inner value using the `Deref` trait
+        //~| HELP consider dereferencing to access the inner value using the `Deref` trait
         Some(_) => {}
         //~^ ERROR mismatched types
         None => {}
@@ -11,8 +11,8 @@ fn main() {
     }
 
     match &x {
-        //~^ HELP consider dereferencing to access the inner value using the Deref trait
-        //~| HELP consider dereferencing to access the inner value using the Deref trait
+        //~^ HELP consider dereferencing to access the inner value using the `Deref` trait
+        //~| HELP consider dereferencing to access the inner value using the `Deref` trait
         Some(_) => {}
         //~^ ERROR mismatched types
         None => {}
@@ -21,8 +21,8 @@ fn main() {
 
     let mut y = Box::new(Some(1));
     match y {
-        //~^ HELP consider dereferencing to access the inner value using the Deref trait
-        //~| HELP consider dereferencing to access the inner value using the Deref trait
+        //~^ HELP consider dereferencing to access the inner value using the `Deref` trait
+        //~| HELP consider dereferencing to access the inner value using the `Deref` trait
         Some(_) => {}
         //~^ ERROR mismatched types
         None => {}
@@ -31,8 +31,8 @@ fn main() {
 
     let mut z = Arc::new(Some(1));
     match z as Arc<Option<i32>> {
-        //~^ HELP consider dereferencing to access the inner value using the Deref trait
-        //~| HELP consider dereferencing to access the inner value using the Deref trait
+        //~^ HELP consider dereferencing to access the inner value using the `Deref` trait
+        //~| HELP consider dereferencing to access the inner value using the `Deref` trait
         Some(_) => {}
         //~^ ERROR mismatched types
         None => {}
@@ -41,8 +41,8 @@ fn main() {
 
     let z_const: &Arc<Option<i32>> = &z;
     match z_const {
-        //~^ HELP consider dereferencing to access the inner value using the Deref trait
-        //~| HELP consider dereferencing to access the inner value using the Deref trait
+        //~^ HELP consider dereferencing to access the inner value using the `Deref` trait
+        //~| HELP consider dereferencing to access the inner value using the `Deref` trait
         Some(_) => {}
         //~^ ERROR mismatched types
         None => {}
@@ -52,8 +52,8 @@ fn main() {
     // Normal reference because Arc doesn't implement DerefMut.
     let z_mut: &mut Arc<Option<i32>> = &mut z;
     match z_mut {
-        //~^ HELP consider dereferencing to access the inner value using the Deref trait
-        //~| HELP consider dereferencing to access the inner value using the Deref trait
+        //~^ HELP consider dereferencing to access the inner value using the `Deref` trait
+        //~| HELP consider dereferencing to access the inner value using the `Deref` trait
         Some(_) => {}
         //~^ ERROR mismatched types
         None => {}
@@ -63,8 +63,8 @@ fn main() {
     // Mutable reference because Box does implement DerefMut.
     let y_mut: &mut Box<Option<i32>> = &mut y;
     match y_mut {
-        //~^ HELP consider dereferencing to access the inner value using the Deref trait
-        //~| HELP consider dereferencing to access the inner value using the Deref trait
+        //~^ HELP consider dereferencing to access the inner value using the `Deref` trait
+        //~| HELP consider dereferencing to access the inner value using the `Deref` trait
         Some(_) => {}
         //~^ ERROR mismatched types
         None => {}
@@ -74,8 +74,8 @@ fn main() {
     // Difficult expression.
     let difficult = Arc::new(Some(1));
     match (& (&difficult)  ) {
-        //~^ HELP consider dereferencing to access the inner value using the Deref trait
-        //~| HELP consider dereferencing to access the inner value using the Deref trait
+        //~^ HELP consider dereferencing to access the inner value using the `Deref` trait
+        //~| HELP consider dereferencing to access the inner value using the `Deref` trait
         Some(_) => {}
         //~^ ERROR mismatched types
         None => {}

--- a/tests/ui/suggestions/suggest-deref-in-match-issue-132784.stderr
+++ b/tests/ui/suggestions/suggest-deref-in-match-issue-132784.stderr
@@ -9,7 +9,7 @@ LL |         Some(_) => {}
    |
    = note: expected struct `Arc<Option<{integer}>>`
                 found enum `Option<_>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     match *x {
    |           +
@@ -25,7 +25,7 @@ LL |         None => {}
    |
    = note: expected struct `Arc<Option<{integer}>>`
                 found enum `Option<_>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     match *x {
    |           +
@@ -41,7 +41,7 @@ LL |         Some(_) => {}
    |
    = note: expected struct `Arc<Option<{integer}>>`
                 found enum `Option<_>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     match &*x {
    |            +
@@ -57,7 +57,7 @@ LL |         None => {}
    |
    = note: expected struct `Arc<Option<{integer}>>`
                 found enum `Option<_>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     match &*x {
    |            +
@@ -73,7 +73,7 @@ LL |         Some(_) => {}
    |
    = note: expected struct `Box<Option<{integer}>>`
                 found enum `Option<_>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     match *y {
    |           +
@@ -89,7 +89,7 @@ LL |         None => {}
    |
    = note: expected struct `Box<Option<{integer}>>`
                 found enum `Option<_>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     match *y {
    |           +
@@ -105,7 +105,7 @@ LL |         Some(_) => {}
    |
    = note: expected struct `Arc<Option<i32>>`
                 found enum `Option<_>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL -     match z as Arc<Option<i32>> {
 LL +     match *(z as Arc<Option<i32>>) {
@@ -122,7 +122,7 @@ LL |         None => {}
    |
    = note: expected struct `Arc<Option<i32>>`
                 found enum `Option<_>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL -     match z as Arc<Option<i32>> {
 LL +     match *(z as Arc<Option<i32>>) {
@@ -139,7 +139,7 @@ LL |         Some(_) => {}
    |
    = note: expected struct `Arc<Option<i32>>`
                 found enum `Option<_>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     match &**z_const {
    |           +++
@@ -155,7 +155,7 @@ LL |         None => {}
    |
    = note: expected struct `Arc<Option<i32>>`
                 found enum `Option<_>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     match &**z_const {
    |           +++
@@ -171,7 +171,7 @@ LL |         Some(_) => {}
    |
    = note: expected struct `Arc<Option<i32>>`
                 found enum `Option<_>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     match &**z_mut {
    |           +++
@@ -187,7 +187,7 @@ LL |         None => {}
    |
    = note: expected struct `Arc<Option<i32>>`
                 found enum `Option<_>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     match &**z_mut {
    |           +++
@@ -203,7 +203,7 @@ LL |         Some(_) => {}
    |
    = note: expected struct `Box<Option<i32>>`
                 found enum `Option<_>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     match &**y_mut {
    |           +++
@@ -219,7 +219,7 @@ LL |         None => {}
    |
    = note: expected struct `Box<Option<i32>>`
                 found enum `Option<_>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL |     match &**y_mut {
    |           +++
@@ -235,7 +235,7 @@ LL |         Some(_) => {}
    |
    = note: expected struct `Arc<Option<{integer}>>`
                 found enum `Option<_>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL -     match (& (&difficult)  ) {
 LL +     match &*difficult {
@@ -252,7 +252,7 @@ LL |         None => {}
    |
    = note: expected struct `Arc<Option<{integer}>>`
                 found enum `Option<_>`
-help: consider dereferencing to access the inner value using the Deref trait
+help: consider dereferencing to access the inner value using the `Deref` trait
    |
 LL -     match (& (&difficult)  ) {
 LL +     match &*difficult {


### PR DESCRIPTION
Surround trait name with backticks.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
