### PR TITLE
Use less `#[macro_use]` in the query system

### DIFF
--- a/compiler/rustc_macros/src/query.rs
+++ b/compiler/rustc_macros/src/query.rs
@@ -498,8 +498,8 @@ pub(super) fn rustc_queries(input: TokenStream) -> TokenStream {
         /// Higher-order macro that invokes the specified macro with (a) a list of all query
         /// signatures (including modifiers), and (b) a list of non-query names. This allows
         /// multiple simpler macros to each have access to these lists.
-        #[macro_export]
-        macro_rules! rustc_with_all_queries {
+        #[rustc_macro_transparency = "semiopaque"] // Use `macro_rules!` hygiene.
+        pub macro rustc_with_all_queries {
             (
                 // The macro to invoke once, on all queries and non-queries.
                 $macro:ident!
@@ -510,9 +510,6 @@ pub(super) fn rustc_queries(input: TokenStream) -> TokenStream {
                 }
             }
         }
-        // Re-export the macro as a normal item, so that other modules in `rustc_middle`
-        // can import it normally, without `#[macro_use]`.
-        pub(crate) use rustc_with_all_queries;
 
         // Add hints for rust-analyzer
         mod _analyzer_hints {

--- a/compiler/rustc_macros/src/query.rs
+++ b/compiler/rustc_macros/src/query.rs
@@ -510,6 +510,9 @@ pub(super) fn rustc_queries(input: TokenStream) -> TokenStream {
                 }
             }
         }
+        // Re-export the macro as a normal item, so that other modules in `rustc_middle`
+        // can import it normally, without `#[macro_use]`.
+        pub(crate) use rustc_with_all_queries;
 
         // Add hints for rust-analyzer
         mod _analyzer_hints {

--- a/compiler/rustc_middle/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node.rs
@@ -331,7 +331,7 @@ macro_rules! define_dep_nodes {
 }
 
 // Create various data structures for each query, and also for a few things that aren't queries.
-rustc_with_all_queries! { define_dep_nodes! }
+crate::queries::rustc_with_all_queries! { define_dep_nodes! }
 
 // WARNING: `construct` is generic and does not know that `CompileCodegenUnit` takes `Symbol`s as keys.
 // Be very careful changing this type signature!

--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -67,6 +67,8 @@ mod macros;
 
 #[macro_use]
 pub mod arena;
+
+pub mod dep_graph;
 pub mod error;
 pub mod hir;
 pub mod hooks;
@@ -76,18 +78,13 @@ pub mod lint;
 pub mod metadata;
 pub mod middle;
 pub mod mir;
+pub mod queries;
+pub mod query;
 pub mod thir;
 pub mod traits;
 pub mod ty;
 pub mod util;
 pub mod verify_ich;
-
-#[macro_use]
-pub mod query;
-#[macro_use]
-pub mod queries;
-#[macro_use]
-pub mod dep_graph;
 
 // Allows macros to refer to this crate as `::rustc_middle`
 extern crate self as rustc_middle;

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -101,6 +101,7 @@ use crate::mir::mono::{
     CodegenUnit, CollectionMode, MonoItem, MonoItemPartitions, NormalizationErrorInMono,
 };
 use crate::query::describe_as_module;
+use crate::query::plumbing::{define_callbacks, query_helper_param_ty};
 use crate::traits::query::{
     CanonicalAliasGoal, CanonicalDropckOutlivesGoal, CanonicalImpliedOutlivesBoundsGoal,
     CanonicalMethodAutoderefStepsGoal, CanonicalPredicateGoal, CanonicalTypeOpAscribeUserTypeGoal,

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -17,10 +17,9 @@ pub mod erase;
 pub(crate) mod inner;
 mod job;
 mod keys;
-pub mod on_disk_cache;
-#[macro_use]
-pub mod plumbing;
 pub(crate) mod modifiers;
+pub mod on_disk_cache;
+pub mod plumbing;
 mod stack;
 
 pub fn describe_as_module(def_id: impl Into<LocalDefId>, tcx: TyCtxt<'_>) -> String {

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -630,6 +630,10 @@ macro_rules! define_callbacks {
     };
 }
 
+// Re-export `macro_rules!` macros as normal items, so that they can be imported normally.
+pub(crate) use define_callbacks;
+pub(crate) use query_helper_param_ty;
+
 mod sealed {
     use rustc_hir::def_id::{LocalModDefId, ModDefId};
 

--- a/compiler/rustc_query_impl/src/dep_kind_vtables.rs
+++ b/compiler/rustc_query_impl/src/dep_kind_vtables.rs
@@ -179,7 +179,7 @@ macro_rules! define_dep_kind_vtables {
 // Create an array of vtables, one for each dep kind (non-query and query).
 pub fn make_dep_kind_vtables<'tcx>(arena: &'tcx Arena<'tcx>) -> &'tcx [DepKindVTable<'tcx>] {
     let (nq_vtables, q_vtables) =
-        rustc_middle::rustc_with_all_queries! { define_dep_kind_vtables! };
+        rustc_middle::queries::rustc_with_all_queries! { define_dep_kind_vtables! };
 
     // Non-query vtables must come before query vtables, to match the order of `DepKind`.
     arena.alloc_from_iter(nq_vtables.into_iter().chain(q_vtables.into_iter()))

--- a/compiler/rustc_query_impl/src/query_impl.rs
+++ b/compiler/rustc_query_impl/src/query_impl.rs
@@ -272,4 +272,4 @@ macro_rules! define_queries {
     }
 }
 
-rustc_middle::rustc_with_all_queries! { define_queries! }
+rustc_middle::queries::rustc_with_all_queries! { define_queries! }


### PR DESCRIPTION
Macro-rules namespacing and import/export is a bit of a nightmare in general. We can tame it a bit by avoiding `#[macro_use]` as much as possible, and instead putting a `pub(crate) use` after the macro-rules declaration to make the macro importable as a normal item.

I've split this PR into two commits. The first one should hopefully be uncontroversial, while the second commit takes the extra step of declaring `rustc_with_all_queries!` as a macros-2.0 macro, which gives much nicer import/export behaviour, at the expense of having to specify `#[rustc_macro_transparency = "semiopaque"]` to still have access to macro-rules hygiene, because the default macros-2.0 hygiene is too strict here.

There should be no change to compiler behaviour.

---

I stumbled into this while investigating some other changes, such as re-exporting `rustc_middle::query::QueryVTable` or moving the big callback macro out of `rustc_middle::query::plumbing`. I think it makes sense to make this change first, to make other module-juggling tasks easier.

r? nnethercote (or compiler)