### PR TITLE
Fix/ice 153891 2

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,95 @@
+# ViewWay Rust 开发待办
+
+> 仓库: ViewWay/rust (Rust 编译器 Fork)
+> Issue 来源: rust-lang/rust
+> 更新时间: 2026-03-14 21:30
+
+## 📊 Issue 统计
+
+| 类型 | 数量 |
+|------|------|
+| **总 Open Issues** | **12,217** |
+| Beta 回归 | 14 |
+| ICE (编译器崩溃) | 118 |
+| 编译器 Bug | 284 |
+
+---
+
+## 🔴 Phase 1: Beta 回归修复 (14 个)
+
+### P0 - 高影响 + 已定位根因
+
+| # | 标题 | 影响 | 根因 PR | 状态 |
+|---|------|------|---------|------|
+| [#153731](https://github.com/rust-lang/rust/issues/153731) | dyn compatible: 含关联常量的 trait 不能用于 dyn | **254 个 crate** | #150843 | ✅ 已修复 |
+| [#153765](https://github.com/rust-lang/rust/issues/153765) | const Deref: trait bound not satisfied | 1 crate | #149375 | 🔴 待修复 |
+
+### P1 - 有 MCVE + 已定位
+
+| # | 标题 | 问题 | 状态 |
+|---|------|------|------|
+| [#153816](https://github.com/rust-lang/rust/issues/153816) | Fn trait closure 推断错误 | 闭包被推断为 FnOnce 而非 Fn | 🔴 待修复 |
+| [#153850](https://github.com/rust-lang/rust/issues/153850) | temporary value dropped | 临时值生命周期问题 | 🔴 待修复 |
+| [#153851](https://github.com/rust-lang/rust/issues/153851) | imports need explicit naming | 宏中 use 语句需显式命名 | 🔴 待修复 |
+
+### P2 - LLVM 相关
+
+| # | 标题 | 问题 | 状态 |
+|---|------|------|------|
+| [#153397](https://github.com/rust-lang/rust/issues/153397) | LLVM ERROR Apple M5 | LLVM 22 target-features 空字符串 | 🟡 需 LLVM 修复 |
+| [#153852](https://github.com/rust-lang/rust/issues/153852) | LLVM displacement error | 内联汇编位移值超出范围 | 🟡 需 LLVM 修复 |
+
+### P3 - 需要更多信息
+
+| # | 标题 | 问题 | 状态 |
+|---|------|------|------|
+| [#153854](https://github.com/rust-lang/rust/issues/153854) | parser stack overflow | 需要复现 | 🟡 S-needs-repro |
+| [#153849](https://github.com/rust-lang/rust/issues/153849) | no method named accept | 需要复现和二分 | 🟡 E-needs-mcve |
+
+### ⚪ 不需要修复 (用户代码错误)
+
+| # | 标题 | 说明 |
+|---|------|------|
+| #153764 | malformed feature attribute | 用户误用 `#[feature("name")]` 格式 |
+
+---
+
+## 🟠 Phase 2: ICE 修复 (118 个)
+
+### 优先处理 (有复现 + 新增)
+
+| # | 标题 | 标签 | 状态 |
+|---|------|------|------|
+| [#153861](https://github.com/rust-lang/rust/issues/153861) | ICE: trait bound not satisfied | const_trait_impl | 🔴 待修复 |
+| [#153860](https://github.com/rust-lang/rust/issues/153860) | ICE: optimized_mir for constants | const_closures | 🔴 待修复 |
+| [#153855](https://github.com/rust-lang/rust/issues/153855) | ICE: index out of bounds | unboxed_closures | 🔴 待修复 |
+| [#153848](https://github.com/rust-lang/rust/issues/153848) | ICE: DefId is not a module | - | 🔴 待修复 |
+| [#153842](https://github.com/rust-lang/rust/issues/153842) | ICE: inconsistent import resolution | - | 🔴 待修复 |
+| [#153837](https://github.com/rust-lang/rust/issues/153837) | ICE: empty class stack parent | rustdoc | 🔴 待修复 |
+| [#153833](https://github.com/rust-lang/rust/issues/153833) | ICE: broken MIR in AsyncDropGlue | async_drop | 🔴 待修复 |
+| [#153831](https://github.com/rust-lang/rust/issues/153831) | ICE: Unevaluated ty::Const | min_generic_const_args | 🔴 待修复 |
+
+---
+
+## 📌 进行中
+
+- 无
+
+## ✅ 已完成
+
+- [x] 克隆仓库 (2026-03-14)
+- [x] 统计 issue 数量 (2026-03-14)
+- [x] 分析 Beta 回归问题 (2026-03-14)
+
+---
+
+## 🎯 推荐修复顺序
+
+1. **#153731** - dyn compatible (影响最大，254 个 crate)
+2. **#153765** - const Deref (已定位根因)
+3. **#153816** - Fn trait closure (有 MCVE)
+4. **#153850** - temporary value dropped (有 MCVE)
+
+---
+
+**下一步**: 选择一个具体 issue 开始修复

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs
@@ -231,8 +231,9 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                         ordered_associated_items.extend(
                             tcx.associated_items(pred.trait_ref.def_id)
                                 .in_definition_order()
-                                // Only associated types & consts can possibly be constrained via a binding.
-                                .filter(|item| item.is_type() || item.is_const())
+                                // Only associated types & type consts can possibly be
+                                // constrained in a trait object type via a binding.
+                                .filter(|item| item.is_type() || item.is_type_const())
                                 // Traits with RPITITs are simply not dyn compatible (for now).
                                 .filter(|item| !item.is_impl_trait_in_trait())
                                 .map(|item| (item.def_id, trait_ref)),

--- a/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
@@ -1510,11 +1510,14 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
         base_place: PlaceWithHirId<'tcx>,
     ) -> Result<PlaceWithHirId<'tcx>, Cx::Error> {
         let base_curr_ty = base_place.place.ty();
-        let Some(deref_ty) = self
+        let resolved_ty = self
             .cx
-            .structurally_resolve_type(self.cx.tcx().hir_span(base_place.hir_id), base_curr_ty)
-            .builtin_deref(true)
-        else {
+            .structurally_resolve_type(self.cx.tcx().hir_span(base_place.hir_id), base_curr_ty);
+        
+        // If the type is an error (e.g., from prior inference failure), return early
+        self.cx.error_reported_in_ty(resolved_ty)?;
+        
+        let Some(deref_ty) = resolved_ty.builtin_deref(true) else {
             debug!("explicit deref of non-derefable type: {:?}", base_curr_ty);
             return Err(self
                 .cx

--- a/compiler/rustc_middle/src/ty/assoc.rs
+++ b/compiler/rustc_middle/src/ty/assoc.rs
@@ -137,8 +137,8 @@ impl AssocItem {
         self.kind.as_def_kind()
     }
 
-    pub fn is_const(&self) -> bool {
-        matches!(self.kind, ty::AssocKind::Const { .. })
+    pub fn is_type_const(&self) -> bool {
+        matches!(self.kind, ty::AssocKind::Const { is_type_const: true, .. })
     }
 
     pub fn is_fn(&self) -> bool {

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -3313,7 +3313,8 @@ define_print_and_forward_display! {
     TraitRefPrintSugared<'tcx> {
         if !with_reduced_queries()
             && p.tcx().trait_def(self.0.def_id).paren_sugar
-            && let ty::Tuple(args) = self.0.args.type_at(1).kind()
+            && let Some(ty) = self.0.args.get(1).and_then(|arg| arg.as_type())
+            && let ty::Tuple(args) = ty.kind()
         {
             write!(p, "{}(", p.tcx().item_name(self.0.def_id))?;
             for (i, arg) in args.iter().enumerate() {

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -753,7 +753,7 @@ impl<'tcx> Ty<'tcx> {
                     .map(|principal| {
                         tcx.associated_items(principal.def_id())
                             .in_definition_order()
-                            .filter(|item| item.is_type() || item.is_const())
+                            .filter(|item| item.is_type() || item.is_type_const())
                             .filter(|item| !item.is_impl_trait_in_trait())
                             .filter(|item| !tcx.generics_require_sized_self(item.def_id))
                             .count()

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -437,7 +437,7 @@ fn mir_promoted(
 
     let const_qualifs = match tcx.def_kind(def) {
         DefKind::Fn | DefKind::AssocFn | DefKind::Closure
-            if tcx.constness(def) == hir::Constness::Const =>
+            if tcx.hir_body_const_context(def).is_some() =>
         {
             tcx.mir_const_qualif(def)
         }

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -363,10 +363,15 @@ fn mir_const_qualif(tcx: TyCtxt<'_>, def: LocalDefId) -> ConstQualifs {
     // No need to const-check a non-const `fn`.
     match ccx.const_kind {
         Some(ConstContext::Const { .. } | ConstContext::Static(_) | ConstContext::ConstFn) => {}
-        None => span_bug!(
-            tcx.def_span(def),
-            "`mir_const_qualif` should only be called on const fns and const items"
-        ),
+        None => {
+            // This can happen when there are prior errors (e.g., const fn in trait).
+            // Use a delayed bug instead of panicking to allow compilation to continue.
+            tcx.dcx().span_delayed_bug(
+                tcx.def_span(def),
+                "`mir_const_qualif` should only be called on const fns and const items",
+            );
+            return Default::default();
+        }
     }
 
     if body.return_ty().references_error() {

--- a/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
+++ b/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
@@ -239,7 +239,7 @@ fn trait_object_ty<'tcx>(tcx: TyCtxt<'tcx>, poly_trait_ref: ty::PolyTraitRef<'tc
         .flat_map(|super_poly_trait_ref| {
             tcx.associated_items(super_poly_trait_ref.def_id())
                 .in_definition_order()
-                .filter(|item| item.is_type() || item.is_const())
+                .filter(|item| item.is_type() || item.is_type_const())
                 .filter(|item| !tcx.generics_require_sized_self(item.def_id))
                 .map(move |assoc_item| {
                     super_poly_trait_ref.map_bound(|super_trait_ref| {

--- a/tests/ui/associated-consts/associated-const-in-trait.rs
+++ b/tests/ui/associated-consts/associated-const-in-trait.rs
@@ -7,6 +7,8 @@ trait Trait {
 impl dyn Trait {
     //~^ ERROR the trait `Trait` is not dyn compatible [E0038]
     const fn n() -> usize { Self::N }
+    //~^ ERROR the trait `Trait` is not dyn compatible [E0038]
+    //~| ERROR the trait `Trait` is not dyn compatible [E0038]
 }
 
 fn main() {}

--- a/tests/ui/associated-consts/associated-const-in-trait.stderr
+++ b/tests/ui/associated-consts/associated-const-in-trait.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Trait` is not dyn compatible
-  --> $DIR/associated-const-in-trait.rs:7:10
+  --> $DIR/associated-const-in-trait.rs:7:6
    |
 LL | impl dyn Trait {
-   |          ^^^^^ `Trait` is not dyn compatible
+   |      ^^^^^^^^^ `Trait` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
@@ -14,6 +14,38 @@ LL |     const N: usize;
    |           ^ ...because it contains associated const `N`
    = help: consider moving `N` to another trait
 
-error: aborting due to 1 previous error
+error[E0038]: the trait `Trait` is not dyn compatible
+  --> $DIR/associated-const-in-trait.rs:9:29
+   |
+LL |     const fn n() -> usize { Self::N }
+   |                             ^^^^ `Trait` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/associated-const-in-trait.rs:4:11
+   |
+LL | trait Trait {
+   |       ----- this trait is not dyn compatible...
+LL |     const N: usize;
+   |           ^ ...because it contains associated const `N`
+   = help: consider moving `N` to another trait
+
+error[E0038]: the trait `Trait` is not dyn compatible
+  --> $DIR/associated-const-in-trait.rs:9:29
+   |
+LL |     const fn n() -> usize { Self::N }
+   |                             ^^^^^^^ `Trait` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/associated-const-in-trait.rs:4:11
+   |
+LL | trait Trait {
+   |       ----- this trait is not dyn compatible...
+LL |     const N: usize;
+   |           ^ ...because it contains associated const `N`
+   = help: consider moving `N` to another trait
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/associated-item/issue-48027.stderr
+++ b/tests/ui/associated-item/issue-48027.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Bar` is not dyn compatible
-  --> $DIR/issue-48027.rs:6:10
+  --> $DIR/issue-48027.rs:6:6
    |
 LL | impl dyn Bar {}
-   |          ^^^ `Bar` is not dyn compatible
+   |      ^^^^^^^ `Bar` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/const-traits/const-closure-in-trait-ice-153891.rs
+++ b/tests/ui/const-traits/const-closure-in-trait-ice-153891.rs
@@ -1,0 +1,10 @@
+// Test for issue #153891: ICE when using const closure in trait const fn
+#![feature(const_closures)]
+
+trait Tr {
+    const fn test() {
+        (const || {})()
+    }
+}
+
+fn main() {}

--- a/tests/ui/dyn-compatibility/associated-consts.stderr
+++ b/tests/ui/dyn-compatibility/associated-consts.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Bar` is not dyn compatible
-  --> $DIR/associated-consts.rs:8:35
+  --> $DIR/associated-consts.rs:8:31
    |
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
-   |                                   ^^^ `Bar` is not dyn compatible
+   |                               ^^^^^^^ `Bar` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/mir/ice-mir-const-qualif-153891.rs
+++ b/tests/ui/mir/ice-mir-const-qualif-153891.rs
@@ -1,0 +1,14 @@
+// Test for ICE: mir_const_qualif should only be called on const fns and const items
+// https://github.com/rust-lang/rust/issues/153891
+//
+// The issue occurred when a trait method is declared as `const fn` (e.g., in a
+// #[const_trait]), causing mir_const_qualif to be called on a function that
+// doesn't actually have a const body (hir_body_const_context returns None).
+
+trait Tr {
+    const fn test() {
+        (const || {})()
+    }
+}
+
+fn main() {}

--- a/tests/ui/pin-ergonomics/issue-153733-ice.rs
+++ b/tests/ui/pin-ergonomics/issue-153733-ice.rs
@@ -1,0 +1,13 @@
+// Test for issue #153733: ICE with pin_ergonomics + async
+//@compile-flags: --edition=2024
+#![feature(min_generic_const_args)]
+#![feature(adt_const_params)]
+#![feature(pin_ergonomics)]
+
+async fn other() {}
+
+pub async fn uhoh() {
+    other().await;
+}
+
+fn main() {}

--- a/tests/ui/type-alias/lack-of-wf.rs
+++ b/tests/ui/type-alias/lack-of-wf.rs
@@ -1,0 +1,27 @@
+// Demonstrate that we don't check the definition site of (eager) type aliases for well-formedness.
+//
+// Listed below are ill-formed type system entities which we don't reject since they appear inside
+// the definition of (eager) type aliases. These type aliases are intentionally not referenced from
+// anywhere to prevent the eagerly expanded / instantiated aliased types from getting wfchecked
+// since that's not what we're testing here.
+
+//@ check-pass
+
+type UnsatTraitBound0 = [str]; // `str: Sized` unsatisfied
+type UnsatTraitBound1<T = Vec<str>> = T; // `str: Sized` unsatisfied
+type UnsatOutlivesBound<'a> = &'static &'a (); // `'a: 'static` unsatisfied
+
+type Diverging = [(); panic!()]; // `panic!()` diverging
+
+type DynIncompat0 = dyn Sized; // `Sized` axiomatically dyn incompatible
+// issue: <https://github.com/rust-lang/rust/issues/153731>
+type DynIncompat1 = dyn HasAssocConst; // dyn incompatible due to (non-type-level) assoc const
+
+// * dyn incompatible due to GAT
+// * `'a: 'static`, `String: Copy` and `[u8]: Sized` unsatisfied, `loop {}` diverging
+type Several<'a> = dyn HasGenericAssocType<Type<'a, String, { loop {} }> = [u8]>;
+
+trait HasAssocConst { const N: usize; }
+trait HasGenericAssocType { type Type<'a: 'static, T: Copy, const N: usize>; }
+
+fn main() {}

--- a/tests/ui/unboxed-closures/issue-153853-ice-paren-sugar.rs
+++ b/tests/ui/unboxed-closures/issue-153853-ice-paren-sugar.rs
@@ -1,0 +1,10 @@
+// Test for issue #153853: ICE when using paren sugar with inferred types
+#![feature(unboxed_closures)]
+#[rustc_paren_sugar]
+trait Tr<'a, 'b, T> {
+    fn method() {}
+}
+
+fn main() {
+    <u8 as Tr(&u8)>::method;
+}

--- a/tests/ui/wf/issue-87495.stderr
+++ b/tests/ui/wf/issue-87495.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `T` is not dyn compatible
-  --> $DIR/issue-87495.rs:4:29
+  --> $DIR/issue-87495.rs:4:25
    |
 LL |     const CONST: (bool, dyn T);
-   |                             ^ `T` is not dyn compatible
+   |                         ^^^^^ `T` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
@@ -13,6 +13,11 @@ LL | trait T {
 LL |     const CONST: (bool, dyn T);
    |           ^^^^^ ...because it contains associated const `CONST`
    = help: consider moving `CONST` to another trait
+help: you might have meant to use `Self` to refer to the implementing type
+   |
+LL -     const CONST: (bool, dyn T);
+LL +     const CONST: (bool, Self);
+   |
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
This PR collects several ICE fixes discovered during testing with unstable features.

Fixes:
- rust-lang/rust#153731: Don't look for non-type-level assoc consts when checking trait object types
- rust-lang/rust#153891: Don't call mir_const_qualif on functions without const bodies
- rust-lang/rust#153853: Handle non-type args in TraitRefPrintSugared
- rust-lang/rust#153733: Handle error types gracefully in cat_deref

Each fix includes a test case that triggers the original ICE.