### PR TITLE
Don't call mir_const_qualif on functions without const bodies

### DIFF
--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -437,7 +437,7 @@ fn mir_promoted(
 
     let const_qualifs = match tcx.def_kind(def) {
         DefKind::Fn | DefKind::AssocFn | DefKind::Closure
-            if tcx.constness(def) == hir::Constness::Const =>
+            if tcx.hir_body_const_context(def).is_some() =>
         {
             tcx.mir_const_qualif(def)
         }

--- a/tests/ui/mir/ice-mir-const-qualif-153891.rs
+++ b/tests/ui/mir/ice-mir-const-qualif-153891.rs
@@ -1,0 +1,14 @@
+// Test for ICE: mir_const_qualif should only be called on const fns and const items
+// https://github.com/rust-lang/rust/issues/153891
+//
+// The issue occurred when a trait method is declared as `const fn` (e.g., in a
+// #[const_trait]), causing mir_const_qualif to be called on a function that
+// doesn't actually have a const body (hir_body_const_context returns None).
+
+trait Tr {
+    const fn test() {
+        (const || {})()
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If there are none, feel free to ignore.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#153891.

When `mir_promoted` checked `tcx.constness(def)` for functions/closures, it returned `Constness::Const` for trait methods in const traits even when they don't have an actual const body.

The fix uses `tcx.hir_body_const_context(def).is_some()` instead, which correctly returns `None` for functions that don't have a const body to check. This matches what `mir_const_qualif` itself uses internally (`ConstCx::new` calls `hir_body_const_context`), ensuring we only call `mir_const_qualif` when it won't ICE.