### PR TITLE
Avoid prematurely choosing a glob import

### DIFF
--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1366,7 +1366,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 &single_import.parent_scope,
                 None,
                 ignore_decl,
-                ignore_import,
+                None,
             ) {
                 Err(Determined) => continue,
                 Ok(binding)

--- a/tests/ui/imports/inconsistent-resolution-153842.rs
+++ b/tests/ui/imports/inconsistent-resolution-153842.rs
@@ -1,0 +1,17 @@
+mod a {
+    pub use crate::s::Trait as s;
+    //~^ ERROR cannot determine resolution for the import
+    //~| ERROR cannot determine resolution for the import
+    //~| ERROR unresolved imports `crate::s::Trait`, `a::s`
+}
+
+mod b {
+    pub mod s {
+        pub trait Trait {}
+    }
+}
+
+use a::s;
+use b::*;
+
+fn main() {}

--- a/tests/ui/imports/inconsistent-resolution-153842.stderr
+++ b/tests/ui/imports/inconsistent-resolution-153842.stderr
@@ -1,0 +1,26 @@
+error: cannot determine resolution for the import
+  --> $DIR/inconsistent-resolution-153842.rs:2:13
+   |
+LL |     pub use crate::s::Trait as s;
+   |             ^^^^^^^^^^^^^^^^^^^^
+
+error: cannot determine resolution for the import
+  --> $DIR/inconsistent-resolution-153842.rs:2:13
+   |
+LL |     pub use crate::s::Trait as s;
+   |             ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0432]: unresolved imports `crate::s::Trait`, `a::s`
+  --> $DIR/inconsistent-resolution-153842.rs:2:13
+   |
+LL |     pub use crate::s::Trait as s;
+   |             ^^^^^^^^^^^^^^^^^^^^
+...
+LL | use a::s;
+   |     ^^^^
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0432`.


### PR DESCRIPTION
Fixes rust-lang/rust#153842

Use the following without introducing trait to explain:
```rust
mod a {
    pub use crate::x::y as x; // single import #1
}

mod b {
    pub mod x {
        pub mod y {}
    }
}

use a::x; // single import #2
use b::*; // glob import #3

fn main() {}
```

In current implementation, when `#1` is first resolved, `crate::x` is temporarily taken from glob import `#3` as `crate::b::x`. This happens because `single_import_can_define_name` will see that `#2` cannot define `x` (because it depends on `#1` and `#1` is ignored) and then return `false`. Later, during finalization, `crate::x` in `#1` resolves through single import `#2` instead, which no longer matches the initially cached module `crate::b::x` and triggers the ICE.

I think the resolver should keep this unresolved because `#2` may still define `x` to avoid prematurely choosing a glob import.

r? petrochenkov