### PR TITLE
add test for param-env shadowing

### DIFF
--- a/tests/ui/associated-types/always-applicable-impls-shadowed-in-trait-def.next.stderr
+++ b/tests/ui/associated-types/always-applicable-impls-shadowed-in-trait-def.next.stderr
@@ -1,0 +1,19 @@
+error[E0277]: the trait bound `Self: Eq<<Self as Trait>::Assoc>` is not satisfied
+  --> $DIR/always-applicable-impls-shadowed-in-trait-def.rs:13:17
+   |
+LL |     fn foo() -> IsEqual<Self, Self::Assoc> {
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Eq<<Self as Trait>::Assoc>` is not implemented for `Self`
+   |
+note: required by a bound in `IsEqual`
+  --> $DIR/always-applicable-impls-shadowed-in-trait-def.rs:9:19
+   |
+LL | struct IsEqual<T: Eq<U>, U>(T, U);
+   |                   ^^^^^ required by this bound in `IsEqual`
+help: consider further restricting `Self`
+   |
+LL |     fn foo() -> IsEqual<Self, Self::Assoc> where Self: Eq<<Self as Trait>::Assoc> {
+   |                                            ++++++++++++++++++++++++++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/always-applicable-impls-shadowed-in-trait-def.old.stderr
+++ b/tests/ui/associated-types/always-applicable-impls-shadowed-in-trait-def.old.stderr
@@ -1,0 +1,19 @@
+error[E0277]: the trait bound `Self: Eq<<Self as Trait>::Assoc>` is not satisfied
+  --> $DIR/always-applicable-impls-shadowed-in-trait-def.rs:13:17
+   |
+LL |     fn foo() -> IsEqual<Self, Self::Assoc> {
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Eq<<Self as Trait>::Assoc>` is not implemented for `Self`
+   |
+note: required by a bound in `IsEqual`
+  --> $DIR/always-applicable-impls-shadowed-in-trait-def.rs:9:19
+   |
+LL | struct IsEqual<T: Eq<U>, U>(T, U);
+   |                   ^^^^^ required by this bound in `IsEqual`
+help: consider further restricting `Self`
+   |
+LL |     fn foo() -> IsEqual<Self, Self::Assoc> where Self: Eq<<Self as Trait>::Assoc> {
+   |                                            ++++++++++++++++++++++++++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/always-applicable-impls-shadowed-in-trait-def.rs
+++ b/tests/ui/associated-types/always-applicable-impls-shadowed-in-trait-def.rs
@@ -1,0 +1,23 @@
+//@ revisions: old next
+//@[next] compile-flags: -Znext-solver
+
+// Testing that even if there's an always applicable blanket impl, the trait
+// definition cannot use that impl to normalize its own associated types.
+
+trait Eq<T> {}
+impl<T> Eq<T> for T {}
+struct IsEqual<T: Eq<U>, U>(T, U);
+
+trait Trait: Sized {
+    type Assoc;
+    fn foo() -> IsEqual<Self, Self::Assoc> {
+        //~^ ERROR the trait bound `Self: Eq<<Self as Trait>::Assoc>` is not satisfied
+        todo!()
+    }
+}
+
+impl<T> Trait for T {
+    type Assoc = T;
+}
+
+fn main() {}


### PR DESCRIPTION
Subtle somewhat desirable effect of where-bounds shadowing impls