### PR TITLE
compiletest: show rustdoc logs when `--no-capture`

### DIFF
--- a/src/tools/compiletest/src/runtest/rustdoc_json.rs
+++ b/src/tools/compiletest/src/runtest/rustdoc_json.rs
@@ -14,6 +14,11 @@ impl TestCx<'_> {
         });
 
         let proc_res = self.document(&out_dir, DocKind::Json);
+
+        if !self.config.capture {
+            writeln!(self.stdout, "{}", proc_res.format_info());
+        }
+
         if !proc_res.status.success() {
             self.fatal_proc_rec("rustdoc failed!", &proc_res);
         }


### PR DESCRIPTION
This should make rustdoc debug log output actually visible in `./x test tests/rustdoc-json/ --no-capture` invocations.

Reported in [#t-infra/bootstrap > Help with &#96;./x test --no-capture&#96; to get logs.](https://rust-lang.zulipchat.com/#narrow/channel/326414-t-infra.2Fbootstrap/topic/Help.20with.20.60.2E.2Fx.20test.20--no-capture.60.20to.20get.20logs.2E/with/579547276).


### Example

<details>
<summary>Output</summary>

```bash
$ RUSTDOC_LOG=rustdoc::formats::cache=trace ./x test ./tests/rustdoc-json/span.rs --force-rerun --no-capture
[...]

running 1 tests
status: exit status: 0
command: cd "/home/joe/repos/rust/build/x86_64-unknown-linux-gnu/test/rustdoc-json/span" && env -u RUSTC_LOG_COLOR RUSTC_ICE="0" RUST_BACKTRACE="short" "/home/joe/repos/rust/build/x86_64-unknown-linux-gnu/stage1/bin/rustdoc" "-L" "/home/joe/repos/rust/build/x86_64-unknown-linux-gnu/stage1/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-L" "/home/joe/repos/rust/build/x86_64-unknown-linux-gnu/test/rustdoc-json/span/auxiliary" "-o" "/home/joe/repos/rust/build/x86_64-unknown-linux-gnu/test/rustdoc-json/span" "--deny" "warnings" "/home/joe/repos/rust/tests/rustdoc-json/span.rs" "-A" "internal_features" "--output-format" "json" "-Zunstable-options"
stdout: none
--- stderr -------------------------------
2:rustc DEBUG rustdoc::formats::cache cx.cache.crate_version=None
2:rustc DEBUG rustdoc::formats::cache folding mod (stripped: false) "Some("span")", id DefId(DefId(0:0 ~ span[c5a1]))
2:rustc DEBUG rustdoc::formats::cache folding mod (stripped: false) "Some("bar")", id DefId(DefId(0:3 ~ span[c5a1]::bar))
------------------------------------------

.

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 177 filtered out; finished in 345.34ms

Build completed successfully in 0:00:02
```
</details>
