### PR TITLE
improve `#[track_caller]` invalid ABI error

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -1487,6 +1487,15 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     ident,
                     sig,
                 );
+
+                if let Some(attr) = attr::find_by_name(fi.attrs(), sym::track_caller)
+                    && self.extern_mod_abi != Some(ExternAbi::Rust)
+                {
+                    self.dcx().emit_err(errors::RequiresRustAbi {
+                        track_caller_span: attr.span,
+                        extern_abi_span: self.current_extern_span(),
+                    });
+                }
             }
             ForeignItemKind::TyAlias(box TyAlias {
                 defaultness,
@@ -1672,10 +1681,19 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
         }
 
         if let FnKind::Fn(ctxt, _, fun) = fk
-            && let Extern::Explicit(str_lit, _) = fun.sig.header.ext
+            && let Extern::Explicit(str_lit, extern_abi_span) = fun.sig.header.ext
             && let Ok(abi) = ExternAbi::from_str(str_lit.symbol.as_str())
         {
             self.check_extern_fn_signature(abi, ctxt, &fun.ident, &fun.sig);
+
+            if let Some(attr) = attr::find_by_name(attrs, sym::track_caller)
+                && abi != ExternAbi::Rust
+            {
+                self.dcx().emit_err(errors::RequiresRustAbi {
+                    track_caller_span: attr.span,
+                    extern_abi_span,
+                });
+            }
         }
 
         self.check_c_variadic_type(fk, attrs);

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -1140,3 +1140,13 @@ pub(crate) struct ScalableVectorBadArch {
     #[primary_span]
     pub span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag("`#[track_caller]` can only be used with the Rust ABI", code = E0737)]
+pub(crate) struct RequiresRustAbi {
+    #[primary_span]
+    #[label("using `#[track_caller]` here")]
+    pub track_caller_span: Span,
+    #[label("not using the Rust ABI because of this")]
+    pub extern_abi_span: Span,
+}

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -150,7 +150,8 @@ fn process_builtin_attrs(
                     && let Some(fn_sig) = try_fn_sig(tcx, did, *attr_span)
                     && fn_sig.skip_binder().abi() != ExternAbi::Rust
                 {
-                    tcx.dcx().emit_err(errors::RequiresRustAbi { span: *attr_span });
+                    // This error is already reported in `rustc_ast_passes/src/ast_validation.rs`.
+                    tcx.dcx().delayed_bug("`#[track_caller]` requires the Rust ABI");
                 }
                 if is_closure
                     && !tcx.features().closure_track_caller()

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -112,13 +112,6 @@ pub(crate) struct NoSavedObjectFile<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag("`#[track_caller]` requires Rust ABI", code = E0737)]
-pub(crate) struct RequiresRustAbi {
-    #[primary_span]
-    pub span: Span,
-}
-
-#[derive(Diagnostic)]
 #[diag("unable to copy {$source_file} to {$output_path}: {$error}")]
 pub(crate) struct CopyPathBuf {
     pub source_file: PathBuf,

--- a/tests/ui/rfcs/rfc-2091-track-caller/error-with-invalid-abi.rs
+++ b/tests/ui/rfcs/rfc-2091-track-caller/error-with-invalid-abi.rs
@@ -1,11 +1,30 @@
 #[track_caller]
-extern "C" fn f() {}
-//~^^ ERROR `#[track_caller]` requires Rust ABI
+//~^ ERROR `#[track_caller]` can only be used with the Rust ABI
+extern "C" fn c_fn() {}
+
+#[track_caller]
+extern "Rust" fn rust_fn() {}
 
 extern "C" {
     #[track_caller]
-    fn g();
-    //~^^ ERROR `#[track_caller]` requires Rust ABI
+    //~^ ERROR `#[track_caller]` can only be used with the Rust ABI
+    fn c_extern();
+}
+
+extern "Rust" {
+    #[track_caller]
+    fn rust_extern();
+}
+
+struct S;
+
+impl S {
+    #[track_caller]
+    //~^ ERROR `#[track_caller]` can only be used with the Rust ABI
+    extern "C" fn c_method() {}
+
+    #[track_caller]
+    extern "Rust" fn rust_method() {}
 }
 
 fn main() {}

--- a/tests/ui/rfcs/rfc-2091-track-caller/error-with-invalid-abi.stderr
+++ b/tests/ui/rfcs/rfc-2091-track-caller/error-with-invalid-abi.stderr
@@ -1,15 +1,29 @@
-error[E0737]: `#[track_caller]` requires Rust ABI
+error[E0737]: `#[track_caller]` can only be used with the Rust ABI
   --> $DIR/error-with-invalid-abi.rs:1:1
    |
 LL | #[track_caller]
-   | ^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^ using `#[track_caller]` here
+LL |
+LL | extern "C" fn c_fn() {}
+   | ---------- not using the Rust ABI because of this
 
-error[E0737]: `#[track_caller]` requires Rust ABI
-  --> $DIR/error-with-invalid-abi.rs:6:5
+error[E0737]: `#[track_caller]` can only be used with the Rust ABI
+  --> $DIR/error-with-invalid-abi.rs:9:5
+   |
+LL | extern "C" {
+   | ---------- not using the Rust ABI because of this
+LL |     #[track_caller]
+   |     ^^^^^^^^^^^^^^^ using `#[track_caller]` here
+
+error[E0737]: `#[track_caller]` can only be used with the Rust ABI
+  --> $DIR/error-with-invalid-abi.rs:22:5
    |
 LL |     #[track_caller]
-   |     ^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^ using `#[track_caller]` here
+LL |
+LL |     extern "C" fn c_method() {}
+   |     ---------- not using the Rust ABI because of this
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0737`.

--- a/tests/ui/rfcs/rfc-2091-track-caller/error-with-naked.rs
+++ b/tests/ui/rfcs/rfc-2091-track-caller/error-with-naked.rs
@@ -3,7 +3,7 @@
 use std::arch::naked_asm;
 
 #[track_caller] //~ ERROR [E0736]
-//~^ ERROR `#[track_caller]` requires Rust ABI
+//~^ ERROR `#[track_caller]` can only be used with the Rust ABI
 #[unsafe(naked)]
 extern "C" fn f() {
     unsafe {
@@ -15,7 +15,7 @@ struct S;
 
 impl S {
     #[track_caller] //~ ERROR [E0736]
-    //~^ ERROR `#[track_caller]` requires Rust ABI
+    //~^ ERROR `#[track_caller]` can only be used with the Rust ABI
     #[unsafe(naked)]
     extern "C" fn g() {
         unsafe {

--- a/tests/ui/rfcs/rfc-2091-track-caller/error-with-naked.stderr
+++ b/tests/ui/rfcs/rfc-2091-track-caller/error-with-naked.stderr
@@ -1,3 +1,21 @@
+error[E0737]: `#[track_caller]` can only be used with the Rust ABI
+  --> $DIR/error-with-naked.rs:5:1
+   |
+LL | #[track_caller]
+   | ^^^^^^^^^^^^^^^ using `#[track_caller]` here
+...
+LL | extern "C" fn f() {
+   | ---------- not using the Rust ABI because of this
+
+error[E0737]: `#[track_caller]` can only be used with the Rust ABI
+  --> $DIR/error-with-naked.rs:17:5
+   |
+LL |     #[track_caller]
+   |     ^^^^^^^^^^^^^^^ using `#[track_caller]` here
+...
+LL |     extern "C" fn g() {
+   |     ---------- not using the Rust ABI because of this
+
 error[E0736]: attribute incompatible with `#[unsafe(naked)]`
   --> $DIR/error-with-naked.rs:5:3
    |
@@ -15,18 +33,6 @@ LL |     #[track_caller]
 LL |
 LL |     #[unsafe(naked)]
    |     ---------------- function marked with `#[unsafe(naked)]` here
-
-error[E0737]: `#[track_caller]` requires Rust ABI
-  --> $DIR/error-with-naked.rs:5:1
-   |
-LL | #[track_caller]
-   | ^^^^^^^^^^^^^^^
-
-error[E0737]: `#[track_caller]` requires Rust ABI
-  --> $DIR/error-with-naked.rs:17:5
-   |
-LL |     #[track_caller]
-   |     ^^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Niche but we can provide more context by emitting the error earlier.
