### PR TITLE
Suppress self-referential associated type constraint suggestion

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/infer/note_and_explain.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/note_and_explain.rs
@@ -263,8 +263,13 @@ impl<T> Trait<T> for X {
                             cause.code(),
                         );
                     }
+                    // Don't suggest constraining a projection to something
+                    // containing itself, e.g. `Item = &<I as Iterator>::Item`.
                     (_, ty::Alias(ty::Projection | ty::Inherent, proj_ty))
-                        if !tcx.is_impl_trait_in_trait(proj_ty.def_id) =>
+                        if !tcx.is_impl_trait_in_trait(proj_ty.def_id)
+                            && !tcx
+                                .erase_and_anonymize_regions(values.expected)
+                                .contains(tcx.erase_and_anonymize_regions(values.found)) =>
                     {
                         let msg = || {
                             format!(

--- a/tests/ui/associated-types/dont-suggest-self-referential-constraint.rs
+++ b/tests/ui/associated-types/dont-suggest-self-referential-constraint.rs
@@ -1,0 +1,20 @@
+// Regression test for #112104.
+//
+// Don't suggest `Item = &<I as Iterator>::Item` when
+// the expected type wraps the found projection.
+
+fn option_of_ref_assoc<I: Iterator>(iter: &mut I) {
+    let _: Option<&I::Item> = iter.next();
+    //~^ ERROR mismatched types
+}
+
+// Valid constraint suggestions should still fire.
+trait Foo {
+    type Assoc;
+}
+
+fn assoc_to_concrete<T: Foo>(x: T::Assoc) -> u32 {
+    x //~ ERROR mismatched types
+}
+
+fn main() {}

--- a/tests/ui/associated-types/dont-suggest-self-referential-constraint.stderr
+++ b/tests/ui/associated-types/dont-suggest-self-referential-constraint.stderr
@@ -1,0 +1,33 @@
+error[E0308]: mismatched types
+  --> $DIR/dont-suggest-self-referential-constraint.rs:7:31
+   |
+LL |     let _: Option<&I::Item> = iter.next();
+   |            ----------------   ^^^^^^^^^^^ expected `Option<&<I as Iterator>::Item>`, found `Option<<I as Iterator>::Item>`
+   |            |
+   |            expected due to this
+   |
+   = note: expected enum `Option<&_>`
+              found enum `Option<_>`
+help: try using `.as_ref()` to convert `Option<<I as Iterator>::Item>` to `Option<&<I as Iterator>::Item>`
+   |
+LL |     let _: Option<&I::Item> = iter.next().as_ref();
+   |                                          +++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/dont-suggest-self-referential-constraint.rs:17:5
+   |
+LL | fn assoc_to_concrete<T: Foo>(x: T::Assoc) -> u32 {
+   |                                              --- expected `u32` because of return type
+LL |     x
+   |     ^ expected `u32`, found associated type
+   |
+   = note:         expected type `u32`
+           found associated type `<T as Foo>::Assoc`
+help: consider constraining the associated type `<T as Foo>::Assoc` to `u32`
+   |
+LL | fn assoc_to_concrete<T: Foo<Assoc = u32>>(x: T::Assoc) -> u32 {
+   |                            +++++++++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes rust-lang/rust#112104

When comparing `Option<&I::Item>` against `Option<I::Item>`, the compiler decomposes the mismatch into `expected = &<I as Iterator>::Item` vs `found = <I as Iterator>::Item`. ARM 2 in `note_and_explain_type_err` matches because `found` is a projection, and would suggest `Item = &<I as Iterator>::Item` — constraining the associated type to something that contains itself.

ARM 1 (`expected_projection`) already guards against this with `found.contains(expected)`. ARM 2 was missing the symmetric check. This adds `expected.contains(found)` to the match guard.

Before:
```rust
help: consider constraining the associated type `<I as Iterator>::Item` to `&<I as Iterator>::Item`
  |
1 | fn foo<I: Iterator<Item = &<I as Iterator>::Item>>(iter: &mut I) {
  |                   +++++++++++++++++++++++++++++++
```

After: bogus suggestion is gone, and the existing `.as_ref()` suggestion from `hir_typeck` still fires correctly.

r? @estebank