### PR TITLE
Add regression test for #78568

### DIFF
--- a/tests/ui/inference/issue-78568-inference-error-order.rs
+++ b/tests/ui/inference/issue-78568-inference-error-order.rs
@@ -1,0 +1,16 @@
+//! Regression test for issue #78568
+//!
+//! This test ensures that type inference errors are reported with the correct
+//! error ordering. Previously, the compiler would emit a confusing error about
+//! `Display` not being implemented for `()` in the `println!` macro, instead
+//! of pointing to the actual type inference problem at the `parse()` call.
+
+fn main() {
+    let guess = "123";
+    let guess = match guess.trim().parse() {
+        //~^ ERROR type annotations needed
+        Ok(num) => num + 1,
+        Err(_) => todo!(),
+    };
+    println!("guess: {}", guess);
+}

--- a/tests/ui/inference/issue-78568-inference-error-order.stderr
+++ b/tests/ui/inference/issue-78568-inference-error-order.stderr
@@ -1,0 +1,15 @@
+error[E0283]: type annotations needed
+  --> $DIR/issue-78568-inference-error-order.rs:10:37
+   |
+LL |     let guess = match guess.trim().parse() {
+   |                                     ^^^^^
+   |
+   = note: cannot infer type of the type parameter `F` declared on the method `parse`
+help: consider specifying the generic argument
+   |
+LL |     let guess = match guess.trim().parse::<F>() {
+   |                                          +++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0283`.


### PR DESCRIPTION
This PR adds a regression test for rust-lang/rust#78568.

## Summary

The issue reported that type inference errors were being reported with confusing error ordering. The compiler would emit an error about `Display` not being implemented for `()` in the `println!` macro, instead of pointing to the actual type inference problem at the `parse()` call.

This bug has already been fixed. This PR adds a UI test to ensure the issue doesn't regress.

## Test

The test in `tests/ui/inference/issue-78568-inference-error-order.rs` verifies that:
- The compiler correctly identifies the type inference error at the `parse()` call
- The error message is helpful and points to the right location

Closes rust-lang/rust#78568