### PR TITLE
remove usages of to-be-deprecated numeric constants

### DIFF
--- a/compiler/rustc_middle/src/dep_graph/serialized.rs
+++ b/compiler/rustc_middle/src/dep_graph/serialized.rs
@@ -43,7 +43,7 @@ use std::cell::RefCell;
 use std::cmp::max;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
-use std::{iter, mem, u64};
+use std::{iter, mem};
 
 use rustc_data_structures::fingerprint::{Fingerprint, PackedFingerprint};
 use rustc_data_structures::fx::FxHashMap;

--- a/library/coretests/tests/array.rs
+++ b/library/coretests/tests/array.rs
@@ -646,7 +646,7 @@ fn array_mixed_equality_integers() {
 
 #[test]
 fn array_mixed_equality_nans() {
-    let array3: [f32; 3] = [1.0, std::f32::NAN, 3.0];
+    let array3: [f32; 3] = [1.0, f32::NAN, 3.0];
 
     let slice3: &[f32] = &{ array3 };
     assert!(!(array3 == slice3));

--- a/library/coretests/tests/num/int_macros.rs
+++ b/library/coretests/tests/num/int_macros.rs
@@ -2,7 +2,8 @@ macro_rules! int_module {
     ($T:ident, $U:ident) => {
         use core::num::ParseIntError;
         use core::ops::{BitAnd, BitOr, BitXor, Not, Shl, Shr};
-        use core::$T::*;
+        const MAX: $T = $T::MAX;
+        const MIN: $T = $T::MIN;
 
         const UMAX: $U = $U::MAX;
 

--- a/library/coretests/tests/num/uint_macros.rs
+++ b/library/coretests/tests/num/uint_macros.rs
@@ -2,15 +2,14 @@ macro_rules! uint_module {
     ($T:ident) => {
         use core::num::ParseIntError;
         use core::ops::{BitAnd, BitOr, BitXor, Not, Shl, Shr};
-        use core::$T::*;
 
         use crate::num;
 
         #[test]
         fn test_overflows() {
-            assert!(MAX > 0);
-            assert!(MIN <= 0);
-            assert!((MIN + MAX).wrapping_add(1) == 0);
+            assert!($T::MAX > 0);
+            assert!($T::MIN <= 0);
+            assert!(($T::MIN + $T::MAX).wrapping_add(1) == 0);
         }
 
         #[test]
@@ -25,7 +24,7 @@ macro_rules! uint_module {
             assert!(0b0110 as $T == (0b1100 as $T).bitxor(0b1010 as $T));
             assert!(0b1110 as $T == (0b0111 as $T).shl(1));
             assert!(0b0111 as $T == (0b1110 as $T).shr(1));
-            assert!(MAX - (0b1011 as $T) == (0b1011 as $T).not());
+            assert!($T::MAX - (0b1011 as $T) == (0b1011 as $T).not());
         }
 
         const A: $T = 0b0101100;
@@ -361,7 +360,7 @@ macro_rules! uint_module {
                     assert_eq_const_safe!($T: R.wrapping_pow(2), 1 as $T);
                     assert_eq_const_safe!(Option<$T>: R.checked_pow(2), None);
                     assert_eq_const_safe!(($T, bool): R.overflowing_pow(2), (1 as $T, true));
-                    assert_eq_const_safe!($T: R.saturating_pow(2), MAX);
+                    assert_eq_const_safe!($T: R.saturating_pow(2), $T::MAX);
                 }
             }
 
@@ -468,14 +467,14 @@ macro_rules! uint_module {
             fn test_next_multiple_of() {
                 assert_eq_const_safe!($T: (16 as $T).next_multiple_of(8), 16);
                 assert_eq_const_safe!($T: (23 as $T).next_multiple_of(8), 24);
-                assert_eq_const_safe!($T: MAX.next_multiple_of(1), MAX);
+                assert_eq_const_safe!($T: $T::MAX.next_multiple_of(1), $T::MAX);
             }
 
             fn test_checked_next_multiple_of() {
                 assert_eq_const_safe!(Option<$T>: (16 as $T).checked_next_multiple_of(8), Some(16));
                 assert_eq_const_safe!(Option<$T>: (23 as $T).checked_next_multiple_of(8), Some(24));
                 assert_eq_const_safe!(Option<$T>: (1 as $T).checked_next_multiple_of(0), None);
-                assert_eq_const_safe!(Option<$T>: MAX.checked_next_multiple_of(2), None);
+                assert_eq_const_safe!(Option<$T>: $T::MAX.checked_next_multiple_of(2), None);
             }
 
             fn test_is_next_multiple_of() {

--- a/library/stdarch/crates/core_arch/src/mips/msa.rs
+++ b/library/stdarch/crates/core_arch/src/mips/msa.rs
@@ -9187,7 +9187,6 @@ mod tests {
         core_arch::{mips::msa::*, simd::*},
         mem,
     };
-    use std::{f32, f64};
     use stdarch_test::simd_test;
 
     #[simd_test(enable = "msa")]

--- a/src/tools/rustfmt/src/vertical.rs
+++ b/src/tools/rustfmt/src/vertical.rs
@@ -198,7 +198,7 @@ fn struct_field_prefix_max_min_width<T: AlignedItem>(
                 .rewrite_prefix(context, shape)
                 .map(|field_str| trimmed_last_line_width(&field_str))
         })
-        .fold_ok((0, ::std::usize::MAX), |(max_len, min_len), len| {
+        .fold_ok((0, usize::MAX), |(max_len, min_len), len| {
             (cmp::max(max_len, len), cmp::min(min_len, len))
         })
         .unwrap_or((0, 0))

--- a/tests/ui/consts/issue-90762.rs
+++ b/tests/ui/consts/issue-90762.rs
@@ -27,5 +27,5 @@ fn main() {
     for (i, b) in FOO.iter().enumerate() {
         assert!(b.load(Ordering::Relaxed), "{} not set", i);
     }
-    assert_eq!(BAR.fetch_add(1, Ordering::Relaxed), usize::max_value());
+    assert_eq!(BAR.fetch_add(1, Ordering::Relaxed), usize::MAX);
 }


### PR DESCRIPTION
Split out from rust-lang/rust#146882.