### PR TITLE
tests/debuginfo/basic-stepping.rs: Add ignore-aarch64-pc-windows-msvc

### DIFF
--- a/tests/debuginfo/basic-stepping.rs
+++ b/tests/debuginfo/basic-stepping.rs
@@ -2,6 +2,9 @@
 //! time works intuitively, e.g. that `next` takes you to the next source line.
 //! Regression test for <https://github.com/rust-lang/rust/issues/33013>.
 
+// Flaky. See https://github.com/rust-lang/rust/pull/153877#issuecomment-4064897776.
+//@ ignore-aarch64-pc-windows-msvc
+
 //@ ignore-loongarch64: Doesn't work yet.
 //@ ignore-riscv64: Doesn't work yet.
 //@ ignore-backends: gcc


### PR DESCRIPTION
This is just a preparatory PR in case we need it. If it turns out `tests/debuginfo/basic-stepping.rs` is flaky on `aarch64-pc-windows-msvc`, we can land this PR. It is a partial revert of rust-lang/rust#153877. See https://github.com/rust-lang/rust/pull/153877#issuecomment-4064897776.

