### PR TITLE
bootstrap: add initial stdarch test step for core_arch

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -3029,6 +3029,65 @@ fn prepare_cargo_test(
 /// step for testing standard library crates, and an internal step used for both
 /// library crates and compiler crates.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Stdarch {
+    build_compiler: Compiler,
+    target: TargetSelection,
+}
+
+impl Step for Stdarch {
+    type Output = ();
+    const IS_HOST: bool = true;
+
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
+        run.path("library/stdarch").path("library/stdarch/crates/core_arch")
+    }
+
+    fn is_default_step(_builder: &Builder<'_>) -> bool {
+        false
+    }
+
+    fn make_run(run: RunConfig<'_>) {
+        let builder = run.builder;
+        let host = run.build_triple();
+        let build_compiler = builder.compiler(builder.top_stage, host);
+
+        builder.ensure(Stdarch { build_compiler, target: run.target });
+    }
+
+    fn run(self, builder: &Builder<'_>) {
+        let build_compiler = self.build_compiler;
+        let target = self.target;
+
+        builder.ensure(Std::new(build_compiler, build_compiler.host).force_recompile(true));
+
+        if !builder.config.is_host_target(target) {
+            builder.ensure(compile::Std::new(build_compiler, target).force_recompile(true));
+            builder.ensure(RemoteCopyLibs { build_compiler, target });
+        }
+
+        let mut cargo = builder::Cargo::new(
+            builder,
+            build_compiler,
+            Mode::Std,
+            SourceType::InTree,
+            target,
+            builder.kind,
+        );
+
+        cargo
+            .arg("--manifest-path")
+            .arg(builder.src.join("library/stdarch/Cargo.toml"));
+
+        let crates = vec!["core_arch".to_owned()];
+        run_cargo_test(cargo, &[], &crates, "stdarch", target, builder);
+    }
+
+    fn metadata(&self) -> Option<StepMetadata> {
+        Some(StepMetadata::test("stdarch", self.target).built_by(self.build_compiler))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Crate {
     /// The compiler that will *build* libstd or rustc in test mode.
     build_compiler: Compiler,

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -871,6 +871,7 @@ impl<'a> Builder<'a> {
                 test::CrateRustdoc,
                 test::CrateRustdocJsonTypes,
                 test::CrateBootstrap,
+                test::Stdarch,
                 test::RemoteTestClientTests,
                 test::Linkcheck,
                 test::TierCheck,

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -39,6 +39,17 @@ fn run_build(paths: &[PathBuf], config: Config) -> Cache {
     builder.cache
 }
 
+fn configure_stdarch_test(paths: &[&str]) -> Config {
+    let ctx = TestCtx::new();
+    ctx.config("test")
+        .args(paths)
+        .args(&["--ci", "true"])
+        .hosts(&[TEST_TRIPLE_1])
+        .targets(&[TEST_TRIPLE_1])
+        .no_override_download_ci_llvm()
+        .create_config()
+}
+
 fn check_cli<const N: usize>(paths: [&str; N]) {
     run_build(
         &paths.map(PathBuf::from),
@@ -138,6 +149,16 @@ fn validate_path_remap() {
         .for_each(|path| {
             assert!(path.exists(), "{} should exist.", path.display());
         });
+}
+
+#[test]
+fn test_stdarch_workspace_metadata_is_loaded() {
+    let build = Build::new(configure_stdarch_test(&[]));
+
+    assert_eq!(
+        build.crate_paths.get(&PathBuf::from("library/stdarch/crates/core_arch")),
+        Some(&"core_arch".to_owned())
+    );
 }
 
 #[test]
@@ -318,6 +339,14 @@ fn test_test_compiler() {
     let gcc = cache.contains::<test::CodegenGCC>();
 
     assert_eq!((compiler, cranelift, gcc), (true, false, false));
+}
+
+#[test]
+fn test_test_stdarch() {
+    let config = configure_stdarch_test(&["library/stdarch"]);
+    let cache = run_build(&config.paths.clone(), config);
+
+    assert!(cache.contains::<test::Stdarch>());
 }
 
 #[test]

--- a/src/bootstrap/src/core/metadata.rs
+++ b/src/bootstrap/src/core/metadata.rs
@@ -93,9 +93,11 @@ fn workspace_members(build: &Build) -> Vec<Package> {
         packages
     };
 
-    // Collects `metadata.packages` from the root and library workspaces.
+    // Collect `metadata.packages` from the workspaces that bootstrap may need
+    // to resolve from CLI paths.
     let mut packages = vec![];
     packages.extend(collect_metadata("Cargo.toml"));
     packages.extend(collect_metadata("library/Cargo.toml"));
+    packages.extend(collect_metadata("library/stdarch/Cargo.toml"));
     packages
 }


### PR DESCRIPTION
## Summary

This is an initial step toward the GSoC idea of incrementally integrating deterministic stdarch tests into `rust-lang/rust`'s bootstrap/CI flow.

This patch extends bootstrap to collect workspace metadata from `library/stdarch` and introduces an initial `x test library/stdarch` step for a small deterministic subset of stdarch tests.

For now, this step is intentionally limited to `core_arch`.

Related discussion:
- GSoC idea: https://github.com/rust-lang/google-summer-of-code/blob/main/README.md
- Zulip topic: [<ZULIP_TOPIC_LINK>](https://rust-lang.zulipchat.com/#narrow/channel/421156-gsoc/topic/Idea.3A.20Port.20.60std.3A.3Aarch.60.20test.20suite.20to.20.60rust-lang.2Frust.60)

## Motivation

`library/stdarch` is already synced into `rust-lang/rust` via Josh subtree, but `x test library/stdarch` does not currently map to a dedicated bootstrap test step.

This patch lays the groundwork for incrementally integrating stdarch tests into the main repository without trying to port the entire upstream CI surface at once.

## What this changes

- includes `library/stdarch/Cargo.toml` in bootstrap's workspace metadata collection
- adds a new `test::Stdarch` bootstrap step
- registers that step in `Kind::Test` descriptions
- routes `library/stdarch` and `library/stdarch/crates/core_arch` to this step
- runs the initial subset with:
  - `cargo test -p core_arch --manifest-path library/stdarch/Cargo.toml`

## Why only `core_arch` for now?

This is intended as a small first incremental step rather than a full port of stdarch's existing CI surface.

The initial integration intentionally excludes the following in order to keep the first step deterministic and straightforward to review:

- `intrinsic-test` and `stdarch-verify` (different tooling and determinism concerns)
- examples and doc steps
- broader CI matrix integration

Starting with `core_arch` gives bootstrap a concrete entry point while keeping CI risk low.

## Testing

Added bootstrap tests covering:
- loading stdarch workspace metadata
- routing `x test library/stdarch` to the new `test::Stdarch` step

Locally verified with:

```bash
./x test bootstrap --test-args test_stdarch_workspace_metadata_is_loaded
./x test library/stdarch