### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -54,7 +54,7 @@ use crate::pin::UnsafePinned;
 /// ```
 #[unstable(feature = "internal_impls_macro", issue = "none")]
 // Allow implementations of `UnsizedConstParamTy` even though std cannot use that feature.
-#[allow_internal_unstable(unsized_const_params)]
+#[allow_internal_unstable(const_param_ty_trait)]
 macro marker_impls {
     ( $(#[$($meta:tt)*])* $Trait:ident for $({$($bounds:tt)*})? $T:ty $(, $($rest:tt)*)? ) => {
         $(#[$($meta)*])* impl< $($($bounds)*)? > $Trait for $T {}
@@ -1080,7 +1080,7 @@ pub trait Tuple {}
 /// that all fields are also `ConstParamTy`, which implies that recursively, all fields
 /// are `StructuralPartialEq`.
 #[lang = "const_param_ty"]
-#[unstable(feature = "unsized_const_params", issue = "95174")]
+#[unstable(feature = "const_param_ty_trait", issue = "95174", implied_by = "unsized_const_params")]
 #[diagnostic::on_unimplemented(message = "`{Self}` can't be used as a const parameter type")]
 #[allow(multiple_supertrait_upcastable)]
 // We name this differently than the derive macro so that the `adt_const_params` can
@@ -1090,7 +1090,7 @@ pub trait ConstParamTy_: StructuralPartialEq + Eq {}
 
 /// Derive macro generating an impl of the trait `ConstParamTy`.
 #[rustc_builtin_macro]
-#[allow_internal_unstable(unsized_const_params)]
+#[allow_internal_unstable(const_param_ty_trait)]
 #[unstable(feature = "adt_const_params", issue = "95174")]
 pub macro ConstParamTy($item:item) {
     /* compiler built-in */

--- a/tests/codegen-llvm/gep-index.rs
+++ b/tests/codegen-llvm/gep-index.rs
@@ -11,27 +11,27 @@ struct Foo(i32, i32);
 // CHECK-LABEL: @index_on_struct(
 #[no_mangle]
 fn index_on_struct(a: &[Foo], index: usize) -> &Foo {
-    // CHECK: getelementptr inbounds{{( nuw)?}} %Foo, ptr %a.0, {{i64|i32}} %index
+    // CHECK: getelementptr inbounds{{( nuw)?}} {{%Foo|\[8 x i8\]}}, ptr %a.0, {{i64|i32}} %index
     &a[index]
 }
 
 // CHECK-LABEL: @offset_on_struct(
 #[no_mangle]
 fn offset_on_struct(a: *const Foo, index: usize) -> *const Foo {
-    // CHECK: getelementptr inbounds{{( nuw)?}} %Foo, ptr %a, {{i64|i32}} %index
+    // CHECK: getelementptr inbounds{{( nuw)?}} {{%Foo|\[8 x i8\]}}, ptr %a, {{i64|i32}} %index
     unsafe { a.add(index) }
 }
 
 // CHECK-LABEL: @index_on_i32(
 #[no_mangle]
 fn index_on_i32(a: &[i32], index: usize) -> &i32 {
-    // CHECK: getelementptr inbounds{{( nuw)?}} i32, ptr %a.0, {{i64|i32}} %index
+    // CHECK: getelementptr inbounds{{( nuw)?}} {{i32|\[4 x i8\]}}, ptr %a.0, {{i64|i32}} %index
     &a[index]
 }
 
 // CHECK-LABEL: @offset_on_i32(
 #[no_mangle]
 fn offset_on_i32(a: *const i32, index: usize) -> *const i32 {
-    // CHECK: getelementptr inbounds{{( nuw)?}} i32, ptr %a, {{i64|i32}} %index
+    // CHECK: getelementptr inbounds{{( nuw)?}} {{i32|\[4 x i8\]}}, ptr %a, {{i64|i32}} %index
     unsafe { a.add(index) }
 }

--- a/tests/codegen-llvm/issues/issue-118306.rs
+++ b/tests/codegen-llvm/issues/issue-118306.rs
@@ -11,7 +11,7 @@ pub fn branchy(input: u64) -> u64 {
     // CHECK-LABEL: @branchy(
     // CHECK-NEXT:  start:
     // CHECK-NEXT:    [[_2:%.*]] = and i64 [[INPUT:%.*]], 3
-    // CHECK-NEXT:    [[SWITCH_GEP:%.*]] = getelementptr inbounds{{( nuw)?}} {{\[4 x i64\]|i64}}, ptr @switch.table.branchy{{(, i64 0)?}}, i64 [[_2]]
+    // CHECK-NEXT:    [[SWITCH_GEP:%.*]] = getelementptr inbounds{{( nuw)?}} {{\[4 x i64\]|i64|\[8 x i8\]}}, ptr @switch.table.branchy{{(, i64 0)?}}, i64 [[_2]]
     // CHECK-NEXT:    [[SWITCH_LOAD:%.*]] = load i64, ptr [[SWITCH_GEP]]
     // CHECK-NEXT:    ret i64 [[SWITCH_LOAD]]
     match input % 4 {

--- a/tests/codegen-llvm/ptr-arithmetic.rs
+++ b/tests/codegen-llvm/ptr-arithmetic.rs
@@ -6,7 +6,7 @@
 // CHECK-SAME: [[WORD:i[0-9]+]] noundef %n)
 #[no_mangle]
 pub unsafe fn i32_add(p: *const i32, n: usize) -> *const i32 {
-    // CHECK: %[[TEMP:.+]] = getelementptr inbounds{{( nuw)?}} i32, ptr %p, [[WORD]] %n
+    // CHECK: %[[TEMP:.+]] = getelementptr inbounds{{( nuw)?}} {{i32|\[4 x i8\]}}, ptr %p, [[WORD]] %n
     // CHECK: ret ptr %[[TEMP]]
     p.add(n)
 }
@@ -18,7 +18,7 @@ pub unsafe fn i32_add(p: *const i32, n: usize) -> *const i32 {
 #[no_mangle]
 pub unsafe fn i32_sub(p: *const i32, n: usize) -> *const i32 {
     // CHECK: %[[DELTA:.+]] = sub nsw [[WORD]] 0, %n
-    // CHECK: %[[TEMP:.+]] = getelementptr inbounds i32, ptr %p, [[WORD]] %[[DELTA]]
+    // CHECK: %[[TEMP:.+]] = getelementptr inbounds {{i32|\[4 x i8\]}}, ptr %p, [[WORD]] %[[DELTA]]
     // CHECK: ret ptr %[[TEMP]]
     p.sub(n)
 }
@@ -27,7 +27,7 @@ pub unsafe fn i32_sub(p: *const i32, n: usize) -> *const i32 {
 // CHECK-SAME: [[WORD:i[0-9]+]] noundef %d)
 #[no_mangle]
 pub unsafe fn i32_offset(p: *const i32, d: isize) -> *const i32 {
-    // CHECK: %[[TEMP:.+]] = getelementptr inbounds i32, ptr %p, [[WORD]] %d
+    // CHECK: %[[TEMP:.+]] = getelementptr inbounds {{i32|\[4 x i8\]}}, ptr %p, [[WORD]] %d
     // CHECK: ret ptr %[[TEMP]]
     p.offset(d)
 }

--- a/tests/codegen-llvm/slice-iter-nonnull.rs
+++ b/tests/codegen-llvm/slice-iter-nonnull.rs
@@ -55,7 +55,7 @@ pub fn slice_iter_next_back<'a>(it: &mut std::slice::Iter<'a, u32>) -> Option<&'
 #[no_mangle]
 pub fn slice_iter_new(slice: &[u32]) -> std::slice::Iter<'_, u32> {
     // CHECK-NOT: slice
-    // CHECK: %[[END:.+]] = getelementptr inbounds{{( nuw)?}} i32{{.+}} %slice.0{{.+}} %slice.1
+    // CHECK: %[[END:.+]] = getelementptr inbounds{{( nuw)?}} {{i32|\[4 x i8\]}}{{.+}} %slice.0{{.+}} %slice.1
     // CHECK-NOT: slice
     // CHECK: insertvalue {{.+}} ptr %slice.0, 0
     // CHECK-NOT: slice
@@ -70,7 +70,7 @@ pub fn slice_iter_new(slice: &[u32]) -> std::slice::Iter<'_, u32> {
 #[no_mangle]
 pub fn slice_iter_mut_new(slice: &mut [u32]) -> std::slice::IterMut<'_, u32> {
     // CHECK-NOT: slice
-    // CHECK: %[[END:.+]] = getelementptr inbounds{{( nuw)?}} i32{{.+}} %slice.0{{.+}} %slice.1
+    // CHECK: %[[END:.+]] = getelementptr inbounds{{( nuw)?}} {{i32|\[4 x i8\]}}{{.+}} %slice.0{{.+}} %slice.1
     // CHECK-NOT: slice
     // CHECK: insertvalue {{.+}} ptr %slice.0, 0
     // CHECK-NOT: slice

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_bad_empty_array.rs
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_bad_empty_array.rs
@@ -1,5 +1,5 @@
 #![allow(incomplete_features)]
-#![feature(adt_const_params, unsized_const_params)]
+#![feature(adt_const_params, const_param_ty_trait)]
 
 #[derive(PartialEq, Eq)]
 struct NotParam;

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_dyn_compatibility.rs
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_dyn_compatibility.rs
@@ -1,4 +1,4 @@
-#![feature(adt_const_params, unsized_const_params)]
+#![feature(adt_const_params, const_param_ty_trait)]
 #![allow(incomplete_features)]
 
 use std::marker::ConstParamTy_;

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_generic_bounds_do_not_hold.rs
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_generic_bounds_do_not_hold.rs
@@ -1,5 +1,5 @@
 #![allow(incomplete_features)]
-#![feature(adt_const_params, unsized_const_params)]
+#![feature(adt_const_params, const_param_ty_trait)]
 
 #[derive(PartialEq, Eq)]
 struct NotParam;

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_impl_bad_field.rs
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_impl_bad_field.rs
@@ -1,5 +1,5 @@
 #![allow(incomplete_features)]
-#![feature(adt_const_params, unsized_const_params)]
+#![feature(adt_const_params, const_param_ty_trait)]
 
 #[derive(PartialEq, Eq)]
 struct NotParam;

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_impl_no_structural_eq.rs
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_impl_no_structural_eq.rs
@@ -1,5 +1,5 @@
 #![allow(incomplete_features)]
-#![feature(adt_const_params, unsized_const_params)]
+#![feature(adt_const_params, const_param_ty_trait)]
 
 #[derive(PartialEq, Eq)]
 struct ImplementsConstParamTy;

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_impl_union.rs
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_impl_union.rs
@@ -1,5 +1,5 @@
 #![allow(incomplete_features)]
-#![feature(adt_const_params, unsized_const_params)]
+#![feature(adt_const_params, const_param_ty_trait)]
 
 union Union {
     a: u8,

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_trait_gate.rs
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_trait_gate.rs
@@ -1,0 +1,8 @@
+//@check-pass
+#![feature(const_param_ty_trait)]
+
+use std::marker::ConstParamTy_;
+
+fn meow<T: ConstParamTy_>() {}
+
+fn main() {}

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_trait_implied.rs
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_trait_implied.rs
@@ -1,0 +1,9 @@
+//@check-pass
+#![feature(unsized_const_params, adt_const_params)]
+#![allow(incomplete_features)]
+
+use std::marker::ConstParamTy_;
+
+fn miow<T: ConstParamTy_>() {}
+
+fn main() {}

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_trait_no_gate.rs
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_trait_no_gate.rs
@@ -1,0 +1,7 @@
+use std::marker::ConstParamTy_;
+ //~^ ERROR use of unstable library feature `const_param_ty_trait` [E0658]
+
+fn miaw<T: ConstParamTy_>() {}
+         //~^ ERROR use of unstable library feature `const_param_ty_trait` [E0658]
+
+fn main() {}

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_trait_no_gate.stderr
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_trait_no_gate.stderr
@@ -1,0 +1,23 @@
+error[E0658]: use of unstable library feature `const_param_ty_trait`
+  --> $DIR/const_param_ty_trait_no_gate.rs:1:5
+   |
+LL | use std::marker::ConstParamTy_;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #95174 <https://github.com/rust-lang/rust/issues/95174> for more information
+   = help: add `#![feature(const_param_ty_trait)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: use of unstable library feature `const_param_ty_trait`
+  --> $DIR/const_param_ty_trait_no_gate.rs:4:12
+   |
+LL | fn miaw<T: ConstParamTy_>() {}
+   |            ^^^^^^^^^^^^^
+   |
+   = note: see issue #95174 <https://github.com/rust-lang/rust/issues/95174> for more information
+   = help: add `#![feature(const_param_ty_trait)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/const-generics/associated-const-bindings/bound-var-in-ty-not-wf.rs
+++ b/tests/ui/const-generics/associated-const-bindings/bound-var-in-ty-not-wf.rs
@@ -3,7 +3,7 @@
 #![feature(
     min_generic_const_args,
     adt_const_params,
-    unsized_const_params,
+    const_param_ty_trait,
     generic_const_parameter_types,
 )]
 #![allow(incomplete_features)]

--- a/tests/ui/const-generics/associated-const-bindings/bound-var-in-ty.rs
+++ b/tests/ui/const-generics/associated-const-bindings/bound-var-in-ty.rs
@@ -6,7 +6,7 @@
 #![feature(
     min_generic_const_args,
     adt_const_params,
-    unsized_const_params,
+    const_param_ty_trait,
     generic_const_parameter_types,
 )]
 #![allow(incomplete_features)]

--- a/tests/ui/const-generics/associated-const-bindings/dyn-compat-assoc-const-ty-mentions-self.rs
+++ b/tests/ui/const-generics/associated-const-bindings/dyn-compat-assoc-const-ty-mentions-self.rs
@@ -7,7 +7,7 @@
 #![feature(generic_const_items)]
 #![feature(generic_const_parameter_types)]
 #![feature(min_generic_const_args)]
-#![feature(unsized_const_params)]
+#![feature(const_param_ty_trait)]
 #![expect(incomplete_features)]
 
 trait Trait {

--- a/tests/ui/const-generics/associated-const-bindings/dyn-compat-self-const-projections-in-assoc-const-ty.rs
+++ b/tests/ui/const-generics/associated-const-bindings/dyn-compat-self-const-projections-in-assoc-const-ty.rs
@@ -7,7 +7,7 @@
 #![feature(
     adt_const_params,
     min_generic_const_args,
-    unsized_const_params,
+    const_param_ty_trait,
     generic_const_parameter_types
 )]
 #![expect(incomplete_features)]

--- a/tests/ui/const-generics/associated-const-bindings/supertraits.rs
+++ b/tests/ui/const-generics/associated-const-bindings/supertraits.rs
@@ -6,7 +6,7 @@
 #![feature(
     min_generic_const_args,
     adt_const_params,
-    unsized_const_params,
+    const_param_ty_trait,
     generic_const_parameter_types,
 )]
 #![allow(incomplete_features)]

--- a/tests/ui/const-generics/const-param-with-additional-obligations.rs
+++ b/tests/ui/const-generics/const-param-with-additional-obligations.rs
@@ -1,4 +1,4 @@
-#![feature(adt_const_params, unsized_const_params)]
+#![feature(adt_const_params, const_param_ty_trait)]
 #![allow(incomplete_features)]
 
 use std::marker::ConstParamTy_;

--- a/tests/ui/const-generics/generic_const_parameter_types/bad_inference.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/bad_inference.rs
@@ -1,4 +1,4 @@
-#![feature(adt_const_params, unsized_const_params, generic_const_parameter_types)]
+#![feature(adt_const_params, const_param_ty_trait, generic_const_parameter_types)]
 #![allow(incomplete_features)]
 
 use std::marker::ConstParamTy_;

--- a/tests/ui/const-generics/generic_const_parameter_types/evaluate_const_parameter_in_mir.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/evaluate_const_parameter_in_mir.rs
@@ -1,6 +1,6 @@
 //@ check-pass
 
-#![feature(adt_const_params, unsized_const_params, generic_const_parameter_types)]
+#![feature(adt_const_params, const_param_ty_trait, generic_const_parameter_types)]
 #![allow(incomplete_features)]
 
 use std::marker::ConstParamTy_;

--- a/tests/ui/const-generics/generic_const_parameter_types/mismatched_args_with_value.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/mismatched_args_with_value.rs
@@ -1,4 +1,4 @@
-#![feature(adt_const_params, unsized_const_params, generic_const_parameter_types)]
+#![feature(adt_const_params, const_param_ty_trait, generic_const_parameter_types)]
 #![allow(incomplete_features)]
 
 use std::marker::ConstParamTy_;

--- a/tests/ui/const-generics/generic_const_parameter_types/no_const_param_ty_bound.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/no_const_param_ty_bound.rs
@@ -1,4 +1,4 @@
-#![feature(adt_const_params, unsized_const_params, generic_const_parameter_types)]
+#![feature(adt_const_params, const_param_ty_trait, generic_const_parameter_types)]
 #![expect(incomplete_features)]
 
 use std::marker::{ConstParamTy_, PhantomData};

--- a/tests/ui/const-generics/generic_const_parameter_types/unrelated_inferred_arg.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/unrelated_inferred_arg.rs
@@ -1,6 +1,6 @@
 //@ check-pass
 
-#![feature(adt_const_params, unsized_const_params, generic_const_parameter_types)]
+#![feature(adt_const_params, const_param_ty_trait, generic_const_parameter_types)]
 #![allow(incomplete_features)]
 
 use std::marker::ConstParamTy_;

--- a/tests/ui/const-generics/mgca/adt_expr_infers_from_value.rs
+++ b/tests/ui/const-generics/mgca/adt_expr_infers_from_value.rs
@@ -5,7 +5,7 @@
     min_generic_const_args,
     adt_const_params,
     generic_const_parameter_types,
-    unsized_const_params,
+    const_param_ty_trait,
 )]
 #![expect(incomplete_features)]
 

--- a/tests/ui/const-generics/mgca/const-ctor.rs
+++ b/tests/ui/const-generics/mgca/const-ctor.rs
@@ -8,7 +8,7 @@
     min_generic_const_args,
     adt_const_params,
     generic_const_parameter_types,
-    unsized_const_params
+    const_param_ty_trait
 )]
 #![expect(incomplete_features)]
 use std::marker::{ConstParamTy, ConstParamTy_};

--- a/tests/ui/const-generics/mgca/generic_const_type_mismatch.rs
+++ b/tests/ui/const-generics/mgca/generic_const_type_mismatch.rs
@@ -5,7 +5,7 @@
     generic_const_items,
     generic_const_parameter_types,
     min_generic_const_args,
-    unsized_const_params
+    const_param_ty_trait
 )]
 use std::marker::ConstParamTy_;
 

--- a/tests/ui/generic-const-items/assoc-const-bindings.rs
+++ b/tests/ui/generic-const-items/assoc-const-bindings.rs
@@ -1,7 +1,7 @@
 //@ check-pass
 
 #![feature(generic_const_items, min_generic_const_args)]
-#![feature(adt_const_params, unsized_const_params, generic_const_parameter_types)]
+#![feature(adt_const_params, const_param_ty_trait, generic_const_parameter_types)]
 #![expect(incomplete_features)]
 
 use std::marker::{ConstParamTy, ConstParamTy_};


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#153359 (Gate `ConstParamTy_` trait behind `const_param_ty_trait` feature)
 - rust-lang/rust#153505 (tests: accept new GEP source element type)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=153359,153505)
<!-- homu-ignore:end -->

