### PR TITLE
Add coherency check for query cycle breaking

### DIFF
--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -50,7 +50,7 @@ pub enum ActiveKeyStatus<'tcx> {
     Poisoned,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct CycleError<'tcx> {
     /// The query and related span that uses the cycle.
     pub usage: Option<Spanned<QueryStackFrame<'tcx>>>,
@@ -505,7 +505,7 @@ macro_rules! define_callbacks {
 
         /// Identifies a query by kind and key. This is in contrast to `QueryJobId` which is just a number.
         #[allow(non_camel_case_types)]
-        #[derive(Clone, Debug)]
+        #[derive(Clone, Debug, PartialEq, Eq)]
         pub enum TaggedQueryKey<'tcx> {
             $(
                 $name($name::Key<'tcx>),

--- a/compiler/rustc_middle/src/query/stack.rs
+++ b/compiler/rustc_middle/src/query/stack.rs
@@ -8,7 +8,7 @@ use crate::queries::TaggedQueryKey;
 /// Description of a frame in the query stack.
 ///
 /// This is mostly used in case of cycles for error reporting.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct QueryStackFrame<'tcx> {
     pub tagged_key: TaggedQueryKey<'tcx>,
     pub dep_kind: DepKind,

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -221,7 +221,8 @@ fn cycle_error<'tcx, C: QueryCache>(
     let job_map =
         collect_active_jobs_from_all_queries(tcx, CollectActiveJobsKind::FullNoContention);
 
-    let error = find_cycle_in_stack(try_execute, job_map, &current_query_job(), span);
+    let error = find_cycle_in_stack(try_execute, &job_map, current_query_job(), span)
+        .expect("did not find a cycle");
     (mk_cycle(query, tcx, key, error), None)
 }
 

--- a/compiler/rustc_query_impl/src/job.rs
+++ b/compiler/rustc_query_impl/src/job.rs
@@ -314,6 +314,8 @@ fn remove_cycle<'tcx>(
             .query_waiting_on_cycle
             .map(|(span, job)| respan(span, job_map.frame_of(job).clone()));
 
+        let span = entry_point.query_waiting_on_cycle.map_or(DUMMY_SP, |(s, _)| s);
+        stack[0].0 = span;
         // Create the cycle error
         let error = CycleError {
             usage,
@@ -324,17 +326,16 @@ fn remove_cycle<'tcx>(
         };
 
         if cfg!(debug_assertions)
-            && let Some(query_waiting_on_cycle) = entry_point.query_waiting_on_cycle
             && let Some(expected) = find_cycle_in_stack(
-                query_waiting_on_cycle.1,
+                entry_point.query_in_cycle,
                 job_map,
                 stack.last().map(|&(_, job)| job),
-                query_waiting_on_cycle.0,
+                span,
             )
         {
             if error != expected {
                 panic!(
-                    "CycleError coherency check failed:\n  expected: {expected:#?}\n  got: {error:#?}"
+                    "CycleError coherency check failed:\nexpected: {expected:#?}\ngot: {error:#?}"
                 );
             }
         }

--- a/compiler/rustc_query_impl/src/job.rs
+++ b/compiler/rustc_query_impl/src/job.rs
@@ -54,13 +54,12 @@ pub(crate) struct QueryJobInfo<'tcx> {
 
 pub(crate) fn find_cycle_in_stack<'tcx>(
     id: QueryJobId,
-    job_map: QueryJobMap<'tcx>,
-    current_job: &Option<QueryJobId>,
+    job_map: &QueryJobMap<'tcx>,
+    mut current_job: Option<QueryJobId>,
     span: Span,
-) -> CycleError<'tcx> {
+) -> Option<CycleError<'tcx>> {
     // Find the waitee amongst `current_job` parents
     let mut cycle = Vec::new();
-    let mut current_job = Option::clone(current_job);
 
     while let Some(job) = current_job {
         let info = &job_map.map[&job];
@@ -79,13 +78,13 @@ pub(crate) fn find_cycle_in_stack<'tcx>(
                 let parent = info.job.parent?;
                 respan(info.job.span, job_map.frame_of(parent).clone())
             };
-            return CycleError { usage, cycle };
+            return Some(CycleError { usage, cycle });
         }
 
         current_job = info.job.parent;
     }
 
-    panic!("did not find a cycle")
+    None
 }
 
 /// Finds the job closest to the root with a `DepKind` matching the `DepKind` of `id` and returns
@@ -324,6 +323,21 @@ fn remove_cycle<'tcx>(
                 .collect(),
         };
 
+        if cfg!(debug_assertions)
+            && let Some(query_waiting_on_cycle) = entry_point.query_waiting_on_cycle
+            && let Some(expected) = find_cycle_in_stack(
+                query_waiting_on_cycle.1,
+                job_map,
+                stack.last().map(|&(_, job)| job),
+                query_waiting_on_cycle.0,
+            )
+        {
+            if error != expected {
+                panic!(
+                    "CycleError coherency check failed:\n  expected: {expected:#?}\n  got: {error:#?}"
+                );
+            }
+        }
         // We unwrap `resumable` here since there must always be one
         // edge which is resumable / waited using a query latch
         let (waitee_query, waiter_idx) = resumable.unwrap();

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -183,6 +183,11 @@ where
     SESSION_GLOBALS.with(f)
 }
 
+#[inline]
+pub fn are_session_globals_set() -> bool {
+    SESSION_GLOBALS.is_set()
+}
+
 /// Default edition, no source map.
 pub fn create_default_session_globals_then<R>(f: impl FnOnce() -> R) -> R {
     create_session_globals_then(edition::DEFAULT_EDITION, &[], None, f)

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -14,7 +14,7 @@ use rustc_data_structures::sync::Lock;
 use rustc_macros::{Decodable, Encodable, HashStable_Generic, symbols};
 
 use crate::edit_distance::find_best_match_for_name;
-use crate::{DUMMY_SP, Edition, Span, with_session_globals};
+use crate::{DUMMY_SP, Edition, Span, are_session_globals_set, with_session_globals};
 
 #[cfg(test)]
 mod tests;
@@ -2545,6 +2545,10 @@ impl Symbol {
         })
     }
 
+    pub fn opt_as_str(&self) -> Option<&str> {
+        are_session_globals_set().then(|| self.as_str())
+    }
+
     pub fn as_u32(self) -> u32 {
         self.0.as_u32()
     }
@@ -2586,13 +2590,21 @@ impl Symbol {
 
 impl fmt::Debug for Symbol {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(self.as_str(), f)
+        if let Some(s) = self.opt_as_str() {
+            fmt::Debug::fmt(s, f)
+        } else {
+            fmt::Debug::fmt(&self.0, f)
+        }
     }
 }
 
 impl fmt::Display for Symbol {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(self.as_str(), f)
+        if let Some(s) = self.opt_as_str() {
+            fmt::Display::fmt(s, f)
+        } else {
+            fmt::Debug::fmt(&self.0, f)
+        }
     }
 }
 


### PR DESCRIPTION
With `debug_assertions` compare if generated `CycleError`s differ between single-threaded and multi-threaded versions of query cycle breaking code and panic if so.

I reasonably assume multi-threaded cycle breaking prioritizes breaking single-threaded cycles. I've made `find_cycle_in_stack` to be a fallible function, always finding single-threaded cycle if there is any relative to the query argument.

There are also some changes to Symbol's Debug and Display impls to make those panic less.

Split from rust-lang/rust#153185.

r? @nnethercote 

cc @Zoxc