### PR TITLE
Fix non-module `parent_module` in stripped cfg diagnostics

### DIFF
--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -277,15 +277,15 @@ impl Default for MacroUseArgs {
 }
 
 #[derive(Debug, Clone, Encodable, Decodable, HashStable_Generic)]
-pub struct StrippedCfgItem<ModId = DefId> {
-    pub parent_module: ModId,
+pub struct StrippedCfgItem<ScopeId = DefId> {
+    pub parent_scope: ScopeId,
     pub ident: Ident,
     pub cfg: (CfgEntry, Span),
 }
 
-impl<ModId> StrippedCfgItem<ModId> {
-    pub fn map_mod_id<New>(self, f: impl FnOnce(ModId) -> New) -> StrippedCfgItem<New> {
-        StrippedCfgItem { parent_module: f(self.parent_module), ident: self.ident, cfg: self.cfg }
+impl<ScopeId> StrippedCfgItem<ScopeId> {
+    pub fn map_scope_id<New>(self, f: impl FnOnce(ScopeId) -> New) -> StrippedCfgItem<New> {
+        StrippedCfgItem { parent_scope: f(self.parent_scope), ident: self.ident, cfg: self.cfg }
     }
 }
 

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1223,7 +1223,7 @@ impl<'a> CrateMetadataRef<'a> {
             .root
             .stripped_cfg_items
             .decode((self, tcx))
-            .map(|item| item.map_mod_id(|index| DefId { krate: cnum, index }));
+            .map(|item| item.map_scope_id(|index| DefId { krate: cnum, index }));
         tcx.arena.alloc_from_iter(item_names)
     }
 

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -2145,7 +2145,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             self.tcx
                 .stripped_cfg_items(LOCAL_CRATE)
                 .into_iter()
-                .map(|item| item.clone().map_mod_id(|def_id| def_id.index)),
+                .map(|item| item.clone().map_scope_id(|def_id| def_id.index)),
         )
     }
 

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -3097,6 +3097,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 continue;
             }
 
+            let parent_module = self.get_nearest_non_block_module(parent_scope).def_id();
+
             fn comes_from_same_module_for_glob(
                 r: &Resolver<'_, '_>,
                 parent_module: DefId,

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -3083,12 +3083,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 .stripped_cfg_items
                 .iter()
                 .filter_map(|item| {
-                    let parent_module = self.opt_local_def_id(item.parent_module)?.to_def_id();
-                    Some(StrippedCfgItem {
-                        parent_module,
-                        ident: item.ident,
-                        cfg: item.cfg.clone(),
-                    })
+                    let parent_scope = self.opt_local_def_id(item.parent_scope)?.to_def_id();
+                    Some(StrippedCfgItem { parent_scope, ident: item.ident, cfg: item.cfg.clone() })
                 })
                 .collect::<Vec<_>>();
             local_items.as_slice()
@@ -3096,7 +3092,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             self.tcx.stripped_cfg_items(module.krate)
         };
 
-        for &StrippedCfgItem { parent_module, ident, ref cfg } in symbols {
+        for &StrippedCfgItem { parent_scope, ident, ref cfg } in symbols {
             if ident.name != *segment {
                 continue;
             }

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1817,9 +1817,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             .stripped_cfg_items
             .into_iter()
             .filter_map(|item| {
-                let parent_module =
-                    self.node_id_to_def_id.get(&item.parent_module)?.key().to_def_id();
-                Some(StrippedCfgItem { parent_module, ident: item.ident, cfg: item.cfg })
+                let parent_scope =
+                    self.node_id_to_def_id.get(&item.parent_scope)?.key().to_def_id();
+                Some(StrippedCfgItem { parent_scope, ident: item.ident, cfg: item.cfg })
             })
             .collect();
 

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -512,7 +512,7 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
         cfg_span: Span,
     ) {
         self.stripped_cfg_items.push(StrippedCfgItem {
-            parent_module: parent_node,
+            parent_scope: parent_node,
             ident,
             cfg: (cfg, cfg_span),
         });

--- a/tests/ui/resolve/pub-in-path-153848.rs
+++ b/tests/ui/resolve/pub-in-path-153848.rs
@@ -1,0 +1,9 @@
+//@ edition: 2015
+
+pub(in a) mod aa { //~ ERROR cannot find module or crate `a` in the crate root
+}
+mod test {
+    #[cfg(test)]
+    use super::a;
+}
+fn main() {}

--- a/tests/ui/resolve/pub-in-path-153848.stderr
+++ b/tests/ui/resolve/pub-in-path-153848.stderr
@@ -1,0 +1,21 @@
+error[E0433]: cannot find module or crate `a` in the crate root
+  --> $DIR/pub-in-path-153848.rs:3:8
+   |
+LL | pub(in a) mod aa {
+   |        ^ use of unresolved module or unlinked crate `a`
+   |
+note: found an item that was configured out
+  --> $DIR/pub-in-path-153848.rs:7:16
+   |
+LL |     #[cfg(test)]
+   |           ---- the item is gated here
+LL |     use super::a;
+   |                ^
+help: you might be missing a crate named `a`, add it to your project and import it in your code
+   |
+LL + extern crate a;
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0433`.


### PR DESCRIPTION
Fixes rust-lang/rust#153848

Old `parent_module` is from the `parent_node` in `append_stripped_cfg_item`, it cannot be assumed that it points to a real module. So call `expect_module` on it will cause ICE.

The first commit rename `parent_module` to `parent_scope`, and the second using `get_nearest_non_block_module` to find the nearest `module` of `parent_scope` in `find_cfg_stripped`, which should be the correct `parent_module`.