### PR TITLE
remove forever-deprecated and hidden `f64` methods

### DIFF
--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -763,15 +763,6 @@ impl f64 {
         !self.is_sign_negative()
     }
 
-    #[must_use]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[deprecated(since = "1.0.0", note = "renamed to is_sign_positive")]
-    #[inline]
-    #[doc(hidden)]
-    pub fn is_positive(self) -> bool {
-        self.is_sign_positive()
-    }
-
     /// Returns `true` if `self` has a negative sign, including `-0.0`, NaNs with
     /// negative sign bit and negative infinity.
     ///
@@ -797,15 +788,6 @@ impl f64 {
         // IEEE754 says: isSignMinus(x) is true if and only if x has negative sign. isSignMinus
         // applies to zeros and NaNs as well.
         self.to_bits() & Self::SIGN_MASK != 0
-    }
-
-    #[must_use]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[deprecated(since = "1.0.0", note = "renamed to is_sign_negative")]
-    #[inline]
-    #[doc(hidden)]
-    pub fn is_negative(self) -> bool {
-        self.is_sign_negative()
     }
 
     /// Returns the least number greater than `self`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/153975)*
<!-- homu-ignore:end -->

The methods `f64::is_positive` and `f64::is_negative` were deprecated since 1.0 and marked as `#[doc(hidden)]` in favor of `f64::is_sign_positive` and `f64::is_sign_negative`. They also only exist on `f64`, not on `f32`. But for some unknown reason, they have been marked as stable.

This PR proposes to remove both methods as they were never a part of the documented API, assuming that a crater run finds no significant breakage.
 