### PR TITLE
refactor: move doc(rust_logo) check to parser

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/doc.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/doc.rs
@@ -483,15 +483,19 @@ impl DocParser {
         }
         macro_rules! no_args_and_crate_level {
             ($ident: ident) => {{
+                no_args_and_crate_level!($ident, |span| {});
+            }};
+            ($ident: ident, |$span:ident| $extra_validation:block) => {{
                 if let Err(span) = args.no_args() {
                     expected_no_args(cx, span);
                     return;
                 }
-                let span = path.span();
-                if !check_attr_crate_level(cx, span) {
+                let $span = path.span();
+                if !check_attr_crate_level(cx, $span) {
                     return;
                 }
-                self.attribute.$ident = Some(span);
+                $extra_validation
+                self.attribute.$ident = Some($span);
             }};
         }
         macro_rules! string_arg_and_crate_level {
@@ -555,15 +559,7 @@ impl DocParser {
             ),
             Some(sym::fake_variadic) => no_args_and_not_crate_level!(fake_variadic),
             Some(sym::search_unbox) => no_args_and_not_crate_level!(search_unbox),
-            Some(sym::rust_logo) => {
-                if let Err(span) = args.no_args() {
-                    expected_no_args(cx, span);
-                    return;
-                }
-                let span = path.span();
-                if !check_attr_crate_level(cx, span) {
-                    return;
-                }
+            Some(sym::rust_logo) => no_args_and_crate_level!(rust_logo, |span| {
                 if !cx.features().rustdoc_internals() {
                     feature_err(
                         cx.sess(),
@@ -573,8 +569,7 @@ impl DocParser {
                     )
                     .emit();
                 }
-                self.attribute.rust_logo = Some(span);
-            }
+            }),
             Some(sym::auto_cfg) => self.parse_auto_cfg(cx, path, args),
             Some(sym::test) => {
                 let Some(list) = args.list() else {

--- a/compiler/rustc_attr_parsing/src/attributes/doc.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/doc.rs
@@ -1,10 +1,12 @@
 use rustc_ast::ast::{AttrStyle, LitKind, MetaItemLit};
+use rustc_errors::msg;
 use rustc_feature::template;
 use rustc_hir::Target;
 use rustc_hir::attrs::{
     AttributeKind, CfgEntry, CfgHideShow, CfgInfo, DocAttribute, DocInline, HideOrShow,
 };
 use rustc_hir::lints::AttributeLintKind;
+use rustc_session::parse::feature_err;
 use rustc_span::{Span, Symbol, edition, sym};
 use thin_vec::ThinVec;
 
@@ -553,7 +555,26 @@ impl DocParser {
             ),
             Some(sym::fake_variadic) => no_args_and_not_crate_level!(fake_variadic),
             Some(sym::search_unbox) => no_args_and_not_crate_level!(search_unbox),
-            Some(sym::rust_logo) => no_args_and_crate_level!(rust_logo),
+            Some(sym::rust_logo) => {
+                if let Err(span) = args.no_args() {
+                    expected_no_args(cx, span);
+                    return;
+                }
+                let span = path.span();
+                if !check_attr_crate_level(cx, span) {
+                    return;
+                }
+                if !cx.features().rustdoc_internals() {
+                    feature_err(
+                        cx.sess(),
+                        sym::rustdoc_internals,
+                        span,
+                        msg!("the `#[doc(rust_logo)]` attribute is used for Rust branding"),
+                    )
+                    .emit();
+                }
+                self.attribute.rust_logo = Some(span);
+            }
             Some(sym::auto_cfg) => self.parse_auto_cfg(cx, path, args),
             Some(sym::test) => {
                 let Some(list) = args.list() else {

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1145,7 +1145,8 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
             html_no_source: _,
             // already checked in attr_parsing
             issue_tracker_base_url: _,
-            rust_logo,
+            // already checked in attr_parsing
+            rust_logo: _,
             // allowed anywhere
             test_attrs: _,
             // already checked in attr_parsing
@@ -1173,18 +1174,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
         }
 
         self.check_doc_inline(hir_id, target, inline);
-
-        if let Some(span) = rust_logo
-            && !self.tcx.features().rustdoc_internals()
-        {
-            feature_err(
-                &self.tcx.sess,
-                sym::rustdoc_internals,
-                *span,
-                msg!("the `#[doc(rust_logo)]` attribute is used for Rust branding"),
-            )
-            .emit();
-        }
 
         if let Some(span) = masked {
             self.check_doc_masked(*span, hir_id, target);


### PR DESCRIPTION

Reducing `check_attr.rs` size by moving the `#[doc(rust_logo)]` feature gate into `DocParser`.
