### PR TITLE
docs: clarify that float Rem formula uses exact arithmetic

### DIFF
--- a/library/core/src/ops/arith.rs
+++ b/library/core/src/ops/arith.rs
@@ -620,17 +620,21 @@ macro_rules! rem_impl_float {
 
         /// The remainder from the division of two floats.
         ///
-        /// The remainder has the same sign as the dividend and is computed as:
-        /// `x - (x / y).trunc() * y`.
+        /// The remainder has the same sign as the dividend and is computed
+        /// as the exact value `x - trunc(x / y) * y` (using infinite
+        /// precision arithmetic, then rounded to the result type). This is
+        /// the IEEE 754 remainder as implemented by C's `fmod`.
+        ///
+        /// Note that evaluating `x - (x / y).trunc() * y` literally as a
+        /// Rust expression may give a different result due to intermediate
+        /// rounding, since each floating-point operation can introduce
+        /// rounding error.
         ///
         /// # Examples
         /// ```
         /// let x: f32 = 50.50;
         /// let y: f32 = 8.125;
-        /// let remainder = x - (x / y).trunc() * y;
-        ///
-        /// // The answer to both operations is 1.75
-        /// assert_eq!(x % y, remainder);
+        /// assert_eq!(x % y, 1.75);
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "143802")]


### PR DESCRIPTION
## Summary

Fixes rust-lang/rust#133758.

The documentation for `<{f16,f32,f64,f128} as Rem>::rem` previously described the remainder as being "computed as: `x - (x / y).trunc() * y`", which reads as a literal Rust expression. In reality, the operation is mathematically defined as *exact* `x - trunc(x/y) * y` (computed in infinite precision, then rounded to the result type), equivalent to C's `fmod`. Evaluating the expression literally in Rust produces different results for many inputs due to intermediate floating-point rounding.

For example, as noted in the issue:
```rust
let (x, y) = (11f64, 1.1f64);
// These are NOT equal:
assert_eq!(x - (x / y).trunc() * y, x % y);  // panics: left=0.0, right≈1.1
```

This PR:
- Rewrites the formula using mathematical notation (`trunc(x / y)`) rather than Rust method syntax, making it clear this is not meant as literal code
- Explicitly states the computation uses infinite precision arithmetic
- Adds a note explaining why the literal Rust expression differs
- Simplifies the example to avoid suggesting the expressions are equivalent

This aligns with the consensus in rust-lang/rust#133758 and the IEEE 754 / C `fmod` semantics documented in [RFC 3514](https://rust-lang.github.io/rfcs/3514-float-semantics.html).