### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -8,7 +8,8 @@ use std::process::ExitStatus;
 
 use rustc_errors::codes::*;
 use rustc_errors::{
-    Diag, DiagArgValue, DiagCtxtHandle, Diagnostic, EmissionGuarantee, IntoDiagArg, Level, msg,
+    Diag, DiagArgValue, DiagCtxtHandle, DiagSymbolList, Diagnostic, EmissionGuarantee, IntoDiagArg,
+    Level, msg,
 };
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_middle::ty::layout::LayoutError;
@@ -1249,20 +1250,29 @@ pub(crate) struct FeatureNotValid<'a> {
     #[label("`{$feature}` is not valid for this target")]
     pub span: Span,
     #[subdiagnostic]
-    pub plus_hint: Option<RemovePlusFromFeatureName<'a>>,
+    pub hint: FeatureNotValidHint<'a>,
 }
 
 #[derive(Subdiagnostic)]
-#[suggestion(
-    "consider removing the leading `+` in the feature name",
-    code = "enable = \"{stripped}\"",
-    applicability = "maybe-incorrect",
-    style = "verbose"
-)]
-pub struct RemovePlusFromFeatureName<'a> {
-    #[primary_span]
-    pub span: Span,
-    pub stripped: &'a str,
+pub(crate) enum FeatureNotValidHint<'a> {
+    #[suggestion(
+        "consider removing the leading `+` in the feature name",
+        code = "enable = \"{stripped}\"",
+        applicability = "maybe-incorrect",
+        style = "verbose"
+    )]
+    RemovePlusFromFeatureName {
+        #[primary_span]
+        span: Span,
+        stripped: &'a str,
+    },
+    #[help(
+        "valid names are: {$possibilities}{$and_more ->
+            [0] {\"\"}
+            *[other] {\" \"}and {$and_more} more
+        }"
+    )]
+    ValidFeatureNames { possibilities: DiagSymbolList<&'a str>, and_more: usize },
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -9,12 +9,12 @@ use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
 use rustc_session::lint::builtin::AARCH64_SOFTFLOAT_NEON;
 use rustc_session::parse::feature_err;
-use rustc_span::{Span, Symbol, sym};
+use rustc_span::{Span, Symbol, edit_distance, sym};
 use rustc_target::spec::Arch;
 use rustc_target::target_features::{RUSTC_SPECIFIC_FEATURES, Stability};
 use smallvec::SmallVec;
 
-use crate::errors::{FeatureNotValid, RemovePlusFromFeatureName};
+use crate::errors::{FeatureNotValid, FeatureNotValidHint};
 use crate::{errors, target_features};
 
 /// Compute the enabled target features from the `#[target_feature]` function attribute.
@@ -32,15 +32,25 @@ pub(crate) fn from_target_feature_attr(
     for &(feature, feature_span) in features {
         let feature_str = feature.as_str();
         let Some(stability) = rust_target_features.get(feature_str) else {
-            let plus_hint = feature_str
-                .strip_prefix('+')
-                .filter(|stripped| rust_target_features.contains_key(*stripped))
-                .map(|stripped| RemovePlusFromFeatureName { span: feature_span, stripped });
-            tcx.dcx().emit_err(FeatureNotValid {
-                feature: feature_str,
-                span: feature_span,
-                plus_hint,
-            });
+            let hint = if let Some(stripped) = feature_str.strip_prefix('+')
+                && rust_target_features.contains_key(stripped)
+            {
+                FeatureNotValidHint::RemovePlusFromFeatureName { span: feature_span, stripped }
+            } else {
+                // Show the 5 feature names that are most similar to the input.
+                let mut valid_names: Vec<_> =
+                    rust_target_features.keys().map(|name| name.as_str()).into_sorted_stable_ord();
+                valid_names.sort_by_key(|name| {
+                    edit_distance::edit_distance(name, feature.as_str(), 5).unwrap_or(usize::MAX)
+                });
+                valid_names.truncate(5);
+
+                FeatureNotValidHint::ValidFeatureNames {
+                    possibilities: valid_names.into(),
+                    and_more: rust_target_features.len().saturating_sub(5),
+                }
+            };
+            tcx.dcx().emit_err(FeatureNotValid { feature: feature_str, span: feature_span, hint });
             continue;
         };
 

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs
@@ -230,8 +230,9 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                         ordered_associated_items.extend(
                             tcx.associated_items(pred.trait_ref.def_id)
                                 .in_definition_order()
-                                // Only associated types & consts can possibly be constrained via a binding.
-                                .filter(|item| item.is_type() || item.is_const())
+                                // Only associated types & type consts can possibly be
+                                // constrained in a trait object type via a binding.
+                                .filter(|item| item.is_type() || item.is_type_const())
                                 // Traits with RPITITs are simply not dyn compatible (for now).
                                 .filter(|item| !item.is_impl_trait_in_trait())
                                 .map(|item| (item.def_id, trait_ref)),

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -513,6 +513,18 @@ macro_rules! define_callbacks {
         }
 
         impl<'tcx> TaggedQueryKey<'tcx> {
+            /// Returns the name of the query this key is tagged with.
+            ///
+            /// This is useful for error/debug output, but don't use it to check for
+            /// specific query names. Instead, match on the `TaggedQueryKey` variant.
+            pub fn query_name(&self) -> &'static str {
+                match self {
+                    $(
+                        TaggedQueryKey::$name(_) => stringify!($name),
+                    )*
+                }
+            }
+
             /// Formats a human-readable description of this query and its key, as
             /// specified by the `desc` query modifier.
             ///

--- a/compiler/rustc_middle/src/query/stack.rs
+++ b/compiler/rustc_middle/src/query/stack.rs
@@ -1,8 +1,3 @@
-use std::fmt::Debug;
-
-use rustc_span::def_id::DefId;
-
-use crate::dep_graph::DepKind;
 use crate::queries::TaggedQueryKey;
 
 /// Description of a frame in the query stack.
@@ -10,7 +5,10 @@ use crate::queries::TaggedQueryKey;
 /// This is mostly used in case of cycles for error reporting.
 #[derive(Clone, Debug)]
 pub struct QueryStackFrame<'tcx> {
+    /// The query and key of the query method call that this stack frame
+    /// corresponds to.
+    ///
+    /// Code that doesn't care about the specific key can still use this to
+    /// check which query it's for, or obtain the query's name.
     pub tagged_key: TaggedQueryKey<'tcx>,
-    pub dep_kind: DepKind,
-    pub def_id: Option<DefId>,
 }

--- a/compiler/rustc_middle/src/ty/assoc.rs
+++ b/compiler/rustc_middle/src/ty/assoc.rs
@@ -137,8 +137,8 @@ impl AssocItem {
         self.kind.as_def_kind()
     }
 
-    pub fn is_const(&self) -> bool {
-        matches!(self.kind, ty::AssocKind::Const { .. })
+    pub fn is_type_const(&self) -> bool {
+        matches!(self.kind, ty::AssocKind::Const { is_type_const: true, .. })
     }
 
     pub fn is_fn(&self) -> bool {

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -753,7 +753,7 @@ impl<'tcx> Ty<'tcx> {
                     .map(|principal| {
                         tcx.associated_items(principal.def_id())
                             .in_definition_order()
-                            .filter(|item| item.is_type() || item.is_const())
+                            .filter(|item| item.is_type() || item.is_type_const())
                             .filter(|item| !item.is_impl_trait_in_trait())
                             .filter(|item| !tcx.generics_require_sized_self(item.def_id))
                             .count()

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -9,7 +9,7 @@ use rustc_errors::FatalError;
 use rustc_middle::dep_graph::{DepGraphData, DepNodeKey, SerializedDepNodeIndex};
 use rustc_middle::query::{
     ActiveKeyStatus, CycleError, EnsureMode, QueryCache, QueryJob, QueryJobId, QueryKey,
-    QueryLatch, QueryMode, QueryState, QueryVTable,
+    QueryLatch, QueryMode, QueryStackFrame, QueryState, QueryVTable,
 };
 use rustc_middle::ty::TyCtxt;
 use rustc_middle::verify_ich::incremental_verify_ich;
@@ -73,8 +73,9 @@ fn collect_active_query_jobs_inner<'tcx, C>(
     let mut collect_shard_jobs = |shard: &HashTable<(C::Key, ActiveKeyStatus<'tcx>)>| {
         for (key, status) in shard.iter() {
             if let ActiveKeyStatus::Started(job) = status {
-                // This function is safe to call with the shard locked because it is very simple.
-                let frame = crate::plumbing::create_query_stack_frame(query, *key);
+                // It's fine to call `create_tagged_key` with the shard locked,
+                // because it's just a `TaggedQueryKey` variant constructor.
+                let frame = QueryStackFrame { tagged_key: (query.create_tagged_key)(*key) };
                 job_map.insert(job.id, QueryJobInfo { frame, job: job.clone() });
             }
         }

--- a/compiler/rustc_query_impl/src/from_cycle_error.rs
+++ b/compiler/rustc_query_impl/src/from_cycle_error.rs
@@ -8,7 +8,6 @@ use rustc_errors::codes::*;
 use rustc_errors::{Applicability, Diag, MultiSpan, pluralize, struct_span_code_err};
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
-use rustc_middle::dep_graph::DepKind;
 use rustc_middle::queries::{QueryVTables, TaggedQueryKey};
 use rustc_middle::query::CycleError;
 use rustc_middle::query::erase::erase_val;
@@ -77,11 +76,10 @@ fn check_representability<'tcx>(tcx: TyCtxt<'tcx>, cycle_error: CycleError<'tcx>
     let mut item_and_field_ids = Vec::new();
     let mut representable_ids = FxHashSet::default();
     for frame in &cycle_error.cycle {
-        if frame.node.dep_kind == DepKind::check_representability
-            && let Some(field_id) = frame.node.def_id
-            && let Some(field_id) = field_id.as_local()
-            && let Some(DefKind::Field) = frame.node.tagged_key.def_kind(tcx)
+        if let TaggedQueryKey::check_representability(def_id) = frame.node.tagged_key
+            && tcx.def_kind(def_id) == DefKind::Field
         {
+            let field_id: LocalDefId = def_id;
             let parent_id = tcx.parent(field_id.to_def_id());
             let item_id = match tcx.def_kind(parent_id) {
                 DefKind::Variant => tcx.parent(parent_id),
@@ -110,8 +108,7 @@ fn variances_of<'tcx>(tcx: TyCtxt<'tcx>, cycle_error: CycleError<'tcx>) -> &'tcx
         &cycle_error.cycle,
         |cycle| {
             if let Some(frame) = cycle.get(0)
-                && frame.node.dep_kind == DepKind::variances_of
-                && let Some(def_id) = frame.node.def_id
+                && let TaggedQueryKey::variances_of(def_id) = frame.node.tagged_key
             {
                 let n = tcx.generics_of(def_id).own_params.len();
                 ControlFlow::Break(tcx.arena.alloc_from_iter(iter::repeat_n(ty::Bivariant, n)))

--- a/compiler/rustc_query_impl/src/job.rs
+++ b/compiler/rustc_query_impl/src/job.rs
@@ -1,11 +1,12 @@
 use std::io::Write;
-use std::iter;
 use std::ops::ControlFlow;
 use std::sync::Arc;
+use std::{iter, mem};
 
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_errors::{Diag, DiagCtxtHandle};
 use rustc_hir::def::DefKind;
+use rustc_middle::queries::TaggedQueryKey;
 use rustc_middle::query::{
     CycleError, QueryJob, QueryJobId, QueryLatch, QueryStackFrame, QueryWaiter,
 };
@@ -88,8 +89,8 @@ pub(crate) fn find_cycle_in_stack<'tcx>(
     panic!("did not find a cycle")
 }
 
-/// Finds the job closest to the root with a `DepKind` matching the `DepKind` of `id` and returns
-/// information about it.
+/// Finds the query job closest to the root that is for the same query method as `id`
+/// (but not necessarily the same query key), and returns information about it.
 #[cold]
 #[inline(never)]
 pub(crate) fn find_dep_kind_root<'tcx>(
@@ -99,12 +100,14 @@ pub(crate) fn find_dep_kind_root<'tcx>(
 ) -> (Span, String, usize) {
     let mut depth = 1;
     let mut info = &job_map.map[&id];
-    let dep_kind = info.frame.dep_kind;
+    // Two query stack frames are for the same query method if they have the same
+    // `TaggedQueryKey` discriminant.
+    let expected_query = mem::discriminant::<TaggedQueryKey<'tcx>>(&info.frame.tagged_key);
     let mut last_info = info;
 
     while let Some(id) = info.job.parent {
         info = &job_map.map[&id];
-        if info.frame.dep_kind == dep_kind {
+        if mem::discriminant(&info.frame.tagged_key) == expected_query {
             depth += 1;
             last_info = info;
         }
@@ -420,8 +423,8 @@ pub fn print_query_stack<'tcx>(
         if Some(count_printed) < limit_frames || limit_frames.is_none() {
             // Only print to stderr as many stack frames as `num_frames` when present.
             dcx.struct_failure_note(format!(
-                "#{} [{:?}] {}",
-                count_printed, query_info.frame.dep_kind, description
+                "#{count_printed} [{query_name}] {description}",
+                query_name = query_info.frame.tagged_key.query_name(),
             ))
             .with_span(query_info.job.span)
             .emit();
@@ -431,8 +434,8 @@ pub fn print_query_stack<'tcx>(
         if let Some(ref mut file) = file {
             let _ = writeln!(
                 file,
-                "#{} [{:?}] {}",
-                count_total, query_info.frame.dep_kind, description
+                "#{count_total} [{query_name}] {description}",
+                query_name = query_info.frame.tagged_key.query_name(),
             );
         }
 

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -1,8 +1,6 @@
 use std::num::NonZero;
 
-use rustc_data_structures::sync::{DynSend, DynSync};
 use rustc_data_structures::unord::UnordMap;
-use rustc_hir::def_id::DefId;
 use rustc_hir::limit::Limit;
 use rustc_index::Idx;
 use rustc_middle::bug;
@@ -13,9 +11,7 @@ use rustc_middle::query::erase::{Erasable, Erased};
 use rustc_middle::query::on_disk_cache::{
     AbsoluteBytePos, CacheDecoder, CacheEncoder, EncodedDepNodeIndex,
 };
-use rustc_middle::query::{
-    QueryCache, QueryJobId, QueryKey, QueryMode, QueryStackFrame, QueryVTable, erase,
-};
+use rustc_middle::query::{QueryCache, QueryJobId, QueryMode, QueryVTable, erase};
 use rustc_middle::ty::TyCtxt;
 use rustc_middle::ty::codec::TyEncoder;
 use rustc_middle::ty::tls::{self, ImplicitCtxt};
@@ -81,23 +77,6 @@ pub(crate) fn start_query<R>(
         // Use the `ImplicitCtxt` while we execute the query.
         tls::enter_context(&icx, compute)
     })
-}
-
-pub(crate) fn create_query_stack_frame<'tcx, C>(
-    vtable: &'tcx QueryVTable<'tcx, C>,
-    key: C::Key,
-) -> QueryStackFrame<'tcx>
-where
-    C: QueryCache<Key: QueryKey + DynSend + DynSync>,
-    QueryVTable<'tcx, C>: DynSync,
-{
-    let def_id: Option<DefId> = key.key_as_def_id();
-
-    QueryStackFrame {
-        tagged_key: (vtable.create_tagged_key)(key),
-        dep_kind: vtable.dep_kind,
-        def_id,
-    }
 }
 
 pub(crate) fn encode_query_values<'tcx>(

--- a/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
+++ b/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
@@ -239,7 +239,7 @@ fn trait_object_ty<'tcx>(tcx: TyCtxt<'tcx>, poly_trait_ref: ty::PolyTraitRef<'tc
         .flat_map(|super_poly_trait_ref| {
             tcx.associated_items(super_poly_trait_ref.def_id())
                 .in_definition_order()
-                .filter(|item| item.is_type() || item.is_const())
+                .filter(|item| item.is_type() || item.is_type_const())
                 .filter(|item| !tcx.generics_require_sized_self(item.def_id))
                 .map(move |assoc_item| {
                     super_poly_trait_ref.map_bound(|super_trait_ref| {

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/note_and_explain.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/note_and_explain.rs
@@ -263,8 +263,13 @@ impl<T> Trait<T> for X {
                             cause.code(),
                         );
                     }
+                    // Don't suggest constraining a projection to something
+                    // containing itself, e.g. `Item = &<I as Iterator>::Item`.
                     (_, ty::Alias(ty::Projection | ty::Inherent, proj_ty))
-                        if !tcx.is_impl_trait_in_trait(proj_ty.def_id) =>
+                        if !tcx.is_impl_trait_in_trait(proj_ty.def_id)
+                            && !tcx
+                                .erase_and_anonymize_regions(values.expected)
+                                .contains(tcx.erase_and_anonymize_regions(values.found)) =>
                     {
                         let msg = || {
                             format!(

--- a/src/ci/docker/host-x86_64/x86_64-gnu-aux/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-aux/Dockerfile
@@ -29,5 +29,5 @@ RUN sh /scripts/sccache.sh
 ENV NO_DEBUG_ASSERTIONS=1
 ENV NO_OVERFLOW_CHECKS=1
 
-ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu
-ENV RUST_CHECK_TARGET check-aux
+ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu"
+ENV RUST_CHECK_TARGET="check-aux"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-debug/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-debug/Dockerfile
@@ -29,20 +29,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-ENV RUSTBUILD_FORCE_CLANG_BASED_TESTS 1
+ENV RUSTBUILD_FORCE_CLANG_BASED_TESTS="1"
 
 # llvm.use-linker conflicts with downloading CI LLVM
-ENV NO_DOWNLOAD_CI_LLVM 1
+ENV NO_DOWNLOAD_CI_LLVM="1"
 
-ENV RUST_CONFIGURE_ARGS \
-      --build=x86_64-unknown-linux-gnu \
+ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu \
       --enable-debug \
       --enable-lld \
       --set rust.debuginfo-level-tests=2 \
       --set llvm.use-linker=lld \
       --set target.x86_64-unknown-linux-gnu.linker=clang \
       --set target.x86_64-unknown-linux-gnu.cc=clang \
-      --set target.x86_64-unknown-linux-gnu.cxx=clang++
+      --set target.x86_64-unknown-linux-gnu.cxx=clang++"
 
 # This job checks:
 # - That ui tests can be built with `-Cdebuginfo=1`
@@ -53,7 +52,6 @@ ENV RUST_CONFIGURE_ARGS \
 # - That the tests with `//@ needs-force-clang-based-tests` pass, since they
 #   don't run by default unless RUSTBUILD_FORCE_CLANG_BASED_TESTS is set.
 
-ENV SCRIPT \
-  python3 ../x.py --stage 2 build && \
+ENV SCRIPT="python3 ../x.py --stage 2 build && \
   python3 ../x.py --stage 2 test tests/ui && \
-  python3 ../x.py --stage 2 test tests/run-make tests/run-make-cargo
+  python3 ../x.py --stage 2 test tests/run-make tests/run-make-cargo"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-distcheck/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-distcheck/Dockerfile
@@ -1,5 +1,5 @@
 # Runs `distcheck`, which is a collection of smoke tests:
-# 
+#
 # - Run `make check` from an unpacked dist tarball to make sure we can at the
 #   minimum run check steps from those sources.
 # - Check that selected dist components at least have expected directory shape
@@ -34,6 +34,6 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 # Make distcheck builds faster
-ENV DISTCHECK_CONFIGURE_ARGS "--enable-sccache"
+ENV DISTCHECK_CONFIGURE_ARGS="--enable-sccache"
 
-ENV SCRIPT python3 ../x.py test distcheck
+ENV SCRIPT="python3 ../x.py test distcheck"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-gcc/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-gcc/Dockerfile
@@ -31,15 +31,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-ENV NO_DEBUG_ASSERTIONS 1
-ENV RUST_CONFIGURE_ARGS \
- --build=x86_64-unknown-linux-gnu \
+ENV NO_DEBUG_ASSERTIONS="1"
+ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu \
  --enable-sanitizers \
  --enable-profiler \
  --enable-compiler-docs \
  --set llvm.libzstd=true \
- --set 'rust.codegen-backends=[\"llvm\",\"gcc\"]'
-ENV SCRIPT python3 ../x.py \
+ --set rust.codegen-backends=[\\\"llvm\\\",\\\"gcc\\\"]"
+ENV SCRIPT="python3 ../x.py \
   --stage 2 \
   test tests \
   --test-codegen-backend gcc \
@@ -51,4 +50,4 @@ ENV SCRIPT python3 ../x.py \
   --skip tests/rustdoc-js-std \
   --skip tests/rustdoc-json \
   --skip tests/rustdoc-ui \
-  --set 'rust.codegen-backends=[\"llvm\",\"gcc\"]'
+  --set rust.codegen-backends=[\\\"llvm\\\",\\\"gcc\\\"]"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-21/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-21/Dockerfile
@@ -44,16 +44,15 @@ RUN sh /scripts/sccache.sh
 
 # We are disabling CI LLVM since this builder is intentionally using a host
 # LLVM, rather than the typical src/llvm-project LLVM.
-ENV NO_DOWNLOAD_CI_LLVM 1
-ENV EXTERNAL_LLVM 1
+ENV NO_DOWNLOAD_CI_LLVM="1"
+ENV EXTERNAL_LLVM="1"
 
 # Using llvm-link-shared due to libffi issues -- see #34486
-ENV RUST_CONFIGURE_ARGS \
-      --build=x86_64-unknown-linux-gnu \
+ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu \
       --llvm-root=/usr/lib/llvm-21 \
       --enable-llvm-link-shared \
       --set rust.randomize-layout=true \
-      --set rust.thin-lto-import-instr-limit=10
+      --set rust.thin-lto-import-instr-limit=10"
 
 COPY scripts/shared.sh /scripts/
 
@@ -63,4 +62,4 @@ COPY scripts/x86_64-gnu-llvm3.sh /scripts/
 COPY scripts/stage_2_test_set1.sh /scripts/
 COPY scripts/stage_2_test_set2.sh /scripts/
 
-ENV SCRIPT "Must specify DOCKER_SCRIPT for this image"
+ENV SCRIPT="Must specify DOCKER_SCRIPT for this image"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-miri/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-miri/Dockerfile
@@ -34,11 +34,10 @@ ENV GCC_EXEC_PREFIX="/usr/lib/gcc/"
 
 COPY host-x86_64/x86_64-gnu-miri/check-miri.sh /tmp/
 
-ENV RUST_CONFIGURE_ARGS \
-  --build=x86_64-unknown-linux-gnu \
-  --enable-new-symbol-mangling
+ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu \
+  --enable-new-symbol-mangling"
 
-ENV HOST_TARGET x86_64-unknown-linux-gnu
+ENV HOST_TARGET="x86_64-unknown-linux-gnu"
 
 # FIXME(#133381): currently rustc alt builds do *not* have rustc debug
 # assertions enabled! Therefore, we cannot force download CI rustc.
@@ -46,4 +45,4 @@ ENV HOST_TARGET x86_64-unknown-linux-gnu
 
 COPY scripts/shared.sh /scripts/
 
-ENV SCRIPT /tmp/check-miri.sh ../x.py
+ENV SCRIPT="/tmp/check-miri.sh ../x.py"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-nopt/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-nopt/Dockerfile
@@ -22,8 +22,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu \
+ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu \
   --disable-optimize-tests \
-  --set rust.test-compare-mode
-ENV SCRIPT python3 ../x.py test --stage 1 --set rust.optimize=false library/std \
-  && python3 ../x.py --stage 2 test
+  --set rust.test-compare-mode"
+ENV SCRIPT="python3 ../x.py test --stage 1 --set rust.optimize=false library/std \
+  && python3 ../x.py --stage 2 test"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
@@ -76,12 +76,11 @@ COPY scripts/nodejs.sh /scripts/
 RUN sh /scripts/nodejs.sh /node
 ENV PATH="/node/bin:${PATH}"
 
-ENV RUST_CONFIGURE_ARGS \
-  --build=x86_64-unknown-linux-gnu \
+ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu \
   --save-toolstates=/tmp/toolstate/toolstates.json \
-  --enable-new-symbol-mangling
+  --enable-new-symbol-mangling"
 
-ENV HOST_TARGET x86_64-unknown-linux-gnu
+ENV HOST_TARGET="x86_64-unknown-linux-gnu"
 
 # FIXME(#133381): currently rustc alt builds do *not* have rustc debug
 # assertions enabled! Therefore, we cannot force download CI rustc.
@@ -89,5 +88,5 @@ ENV HOST_TARGET x86_64-unknown-linux-gnu
 
 COPY scripts/shared.sh /scripts/
 
-ENV SCRIPT /tmp/checktools.sh ../x.py && \
-  python3 ../x.py test tests/rustdoc-gui --stage 2 --test-args "'--jobs 1'"
+ENV SCRIPT="/tmp/checktools.sh ../x.py && \
+  python3 ../x.py test tests/rustdoc-gui --stage 2 --test-args '--jobs 1'"

--- a/src/ci/docker/host-x86_64/x86_64-gnu/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu/Dockerfile
@@ -24,10 +24,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-ENV RUST_CONFIGURE_ARGS \
- --build=x86_64-unknown-linux-gnu \
+ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu \
  --enable-sanitizers \
  --enable-profiler \
  --enable-compiler-docs \
- --set llvm.libzstd=true
-ENV SCRIPT python3 ../x.py --stage 2 test
+ --set llvm.libzstd=true"
+ENV SCRIPT="python3 ../x.py --stage 2 test"

--- a/tests/ui/associated-consts/associated-const-in-trait.rs
+++ b/tests/ui/associated-consts/associated-const-in-trait.rs
@@ -7,6 +7,8 @@ trait Trait {
 impl dyn Trait {
     //~^ ERROR the trait `Trait` is not dyn compatible [E0038]
     const fn n() -> usize { Self::N }
+    //~^ ERROR the trait `Trait` is not dyn compatible [E0038]
+    //~| ERROR the trait `Trait` is not dyn compatible [E0038]
 }
 
 fn main() {}

--- a/tests/ui/associated-consts/associated-const-in-trait.stderr
+++ b/tests/ui/associated-consts/associated-const-in-trait.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Trait` is not dyn compatible
-  --> $DIR/associated-const-in-trait.rs:7:10
+  --> $DIR/associated-const-in-trait.rs:7:6
    |
 LL | impl dyn Trait {
-   |          ^^^^^ `Trait` is not dyn compatible
+   |      ^^^^^^^^^ `Trait` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
@@ -14,6 +14,38 @@ LL |     const N: usize;
    |           ^ ...because it contains associated const `N`
    = help: consider moving `N` to another trait
 
-error: aborting due to 1 previous error
+error[E0038]: the trait `Trait` is not dyn compatible
+  --> $DIR/associated-const-in-trait.rs:9:29
+   |
+LL |     const fn n() -> usize { Self::N }
+   |                             ^^^^ `Trait` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/associated-const-in-trait.rs:4:11
+   |
+LL | trait Trait {
+   |       ----- this trait is not dyn compatible...
+LL |     const N: usize;
+   |           ^ ...because it contains associated const `N`
+   = help: consider moving `N` to another trait
+
+error[E0038]: the trait `Trait` is not dyn compatible
+  --> $DIR/associated-const-in-trait.rs:9:29
+   |
+LL |     const fn n() -> usize { Self::N }
+   |                             ^^^^^^^ `Trait` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/associated-const-in-trait.rs:4:11
+   |
+LL | trait Trait {
+   |       ----- this trait is not dyn compatible...
+LL |     const N: usize;
+   |           ^ ...because it contains associated const `N`
+   = help: consider moving `N` to another trait
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/associated-item/issue-48027.stderr
+++ b/tests/ui/associated-item/issue-48027.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Bar` is not dyn compatible
-  --> $DIR/issue-48027.rs:6:10
+  --> $DIR/issue-48027.rs:6:6
    |
 LL | impl dyn Bar {}
-   |          ^^^ `Bar` is not dyn compatible
+   |      ^^^^^^^ `Bar` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/associated-types/dont-suggest-self-referential-constraint.rs
+++ b/tests/ui/associated-types/dont-suggest-self-referential-constraint.rs
@@ -1,0 +1,20 @@
+// Regression test for #112104.
+//
+// Don't suggest `Item = &<I as Iterator>::Item` when
+// the expected type wraps the found projection.
+
+fn option_of_ref_assoc<I: Iterator>(iter: &mut I) {
+    let _: Option<&I::Item> = iter.next();
+    //~^ ERROR mismatched types
+}
+
+// Valid constraint suggestions should still fire.
+trait Foo {
+    type Assoc;
+}
+
+fn assoc_to_concrete<T: Foo>(x: T::Assoc) -> u32 {
+    x //~ ERROR mismatched types
+}
+
+fn main() {}

--- a/tests/ui/associated-types/dont-suggest-self-referential-constraint.stderr
+++ b/tests/ui/associated-types/dont-suggest-self-referential-constraint.stderr
@@ -1,0 +1,33 @@
+error[E0308]: mismatched types
+  --> $DIR/dont-suggest-self-referential-constraint.rs:7:31
+   |
+LL |     let _: Option<&I::Item> = iter.next();
+   |            ----------------   ^^^^^^^^^^^ expected `Option<&<I as Iterator>::Item>`, found `Option<<I as Iterator>::Item>`
+   |            |
+   |            expected due to this
+   |
+   = note: expected enum `Option<&_>`
+              found enum `Option<_>`
+help: try using `.as_ref()` to convert `Option<<I as Iterator>::Item>` to `Option<&<I as Iterator>::Item>`
+   |
+LL |     let _: Option<&I::Item> = iter.next().as_ref();
+   |                                          +++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/dont-suggest-self-referential-constraint.rs:17:5
+   |
+LL | fn assoc_to_concrete<T: Foo>(x: T::Assoc) -> u32 {
+   |                                              --- expected `u32` because of return type
+LL |     x
+   |     ^ expected `u32`, found associated type
+   |
+   = note:         expected type `u32`
+           found associated type `<T as Foo>::Assoc`
+help: consider constraining the associated type `<T as Foo>::Assoc` to `u32`
+   |
+LL | fn assoc_to_concrete<T: Foo<Assoc = u32>>(x: T::Assoc) -> u32 {
+   |                            +++++++++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/dyn-compatibility/associated-consts.stderr
+++ b/tests/ui/dyn-compatibility/associated-consts.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Bar` is not dyn compatible
-  --> $DIR/associated-consts.rs:8:35
+  --> $DIR/associated-consts.rs:8:31
    |
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
-   |                                   ^^^ `Bar` is not dyn compatible
+   |                               ^^^^^^^ `Bar` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/target-feature/invalid-attribute.rs
+++ b/tests/ui/target-feature/invalid-attribute.rs
@@ -119,7 +119,12 @@ fn main() {
 //~| NOTE `+sse2` is not valid for this target
 unsafe fn hey() {}
 
-#[target_feature(enable = "+sse5")]
-//~^ ERROR `+sse5` is not valid for this target
-//~| NOTE `+sse5` is not valid for this target
-unsafe fn typo() {}
+#[target_feature(enable = "sse5")]
+//~^ ERROR `sse5` is not valid for this target
+//~| NOTE `sse5` is not valid for this target
+unsafe fn typo_sse() {}
+
+#[target_feature(enable = "avx512")]
+//~^ ERROR `avx512` is not valid for this target
+//~| NOTE `avx512` is not valid for this target
+unsafe fn typo_avx512() {}

--- a/tests/ui/target-feature/invalid-attribute.stderr
+++ b/tests/ui/target-feature/invalid-attribute.stderr
@@ -160,6 +160,8 @@ error: the feature named `foo` is not valid for this target
    |
 LL | #[target_feature(enable = "foo")]
    |                  ^^^^^^^^^^^^^^ `foo` is not valid for this target
+   |
+   = help: valid names are: `fma`, `xop`, `adx`, `aes`, and `avx` and 74 more
 
 error[E0046]: not all trait items implemented, missing: `foo`
   --> $DIR/invalid-attribute.rs:81:1
@@ -205,13 +207,23 @@ LL - #[target_feature(enable = "+sse2")]
 LL + #[target_feature(enable = "sse2")]
    |
 
-error: the feature named `+sse5` is not valid for this target
+error: the feature named `sse5` is not valid for this target
   --> $DIR/invalid-attribute.rs:122:18
    |
-LL | #[target_feature(enable = "+sse5")]
-   |                  ^^^^^^^^^^^^^^^^ `+sse5` is not valid for this target
+LL | #[target_feature(enable = "sse5")]
+   |                  ^^^^^^^^^^^^^^^ `sse5` is not valid for this target
+   |
+   = help: valid names are: `sse`, `sse2`, `sse3`, `sse4a`, and `ssse3` and 74 more
 
-error: aborting due to 25 previous errors
+error: the feature named `avx512` is not valid for this target
+  --> $DIR/invalid-attribute.rs:127:18
+   |
+LL | #[target_feature(enable = "avx512")]
+   |                  ^^^^^^^^^^^^^^^^^ `avx512` is not valid for this target
+   |
+   = help: valid names are: `avx512f`, `avx2`, `avx512bw`, `avx512cd`, and `avx512dq` and 74 more
+
+error: aborting due to 26 previous errors
 
 Some errors have detailed explanations: E0046, E0053, E0539, E0658.
 For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/type-alias/lack-of-wfcheck.rs
+++ b/tests/ui/type-alias/lack-of-wfcheck.rs
@@ -1,0 +1,27 @@
+// Demonstrate that we don't check the definition site of (eager) type aliases for well-formedness.
+//
+// Listed below are ill-formed type system entities which we don't reject since they appear inside
+// the definition of (eager) type aliases. These type aliases are intentionally not referenced from
+// anywhere to prevent the eagerly expanded / instantiated aliased types from getting wfchecked
+// since that's not what we're testing here.
+
+//@ check-pass
+
+type UnsatTraitBound0 = [str]; // `str: Sized` unsatisfied
+type UnsatTraitBound1<T = Vec<str>> = T; // `str: Sized` unsatisfied
+type UnsatOutlivesBound<'a> = &'static &'a (); // `'a: 'static` unsatisfied
+
+type Diverging = [(); panic!()]; // `panic!()` diverging
+
+type DynIncompat0 = dyn Sized; // `Sized` axiomatically dyn incompatible
+// issue: <https://github.com/rust-lang/rust/issues/153731>
+type DynIncompat1 = dyn HasAssocConst; // dyn incompatible due to (non-type-level) assoc const
+
+// * dyn incompatible due to GAT
+// * `'a: 'static`, `String: Copy` and `[u8]: Sized` unsatisfied, `loop {}` diverging
+type Several<'a> = dyn HasGenericAssocType<Type<'a, String, { loop {} }> = [u8]>;
+
+trait HasAssocConst { const N: usize; }
+trait HasGenericAssocType { type Type<'a: 'static, T: Copy, const N: usize>; }
+
+fn main() {}

--- a/tests/ui/wf/issue-87495.stderr
+++ b/tests/ui/wf/issue-87495.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `T` is not dyn compatible
-  --> $DIR/issue-87495.rs:4:29
+  --> $DIR/issue-87495.rs:4:25
    |
 LL |     const CONST: (bool, dyn T);
-   |                             ^ `T` is not dyn compatible
+   |                         ^^^^^ `T` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
@@ -13,6 +13,11 @@ LL | trait T {
 LL |     const CONST: (bool, dyn T);
    |           ^^^^^ ...because it contains associated const `CONST`
    = help: consider moving `CONST` to another trait
+help: you might have meant to use `Self` to refer to the implementing type
+   |
+LL -     const CONST: (bool, dyn T);
+LL +     const CONST: (bool, Self);
+   |
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#153966 (suggest valid features when target feature is invalid)
 - rust-lang/rust#153372 (Fix LegacyKeyValueFormat report from docker build: x86_64-gnu)
 - rust-lang/rust#153738 (Don't look for non-type-level assoc consts when checking trait object types)
 - rust-lang/rust#153907 (Remove redundant fields from `QueryStackFrame`)
 - rust-lang/rust#153921 (Suppress self-referential associated type constraint suggestion)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=153966,153372,153738,153907,153921)
<!-- homu-ignore:end -->

