### PR TITLE
doc: clarify allocator invariant

### DIFF
--- a/library/core/src/alloc/mod.rs
+++ b/library/core/src/alloc/mod.rs
@@ -100,6 +100,13 @@ impl fmt::Display for AllocError {
 /// A memory block which is [*currently allocated*] may be passed to
 /// any method of the allocator that accepts such an argument.
 ///
+/// Additionally, any memory block returned by the allocator must
+/// satisfy the allocation invariants described in `core::ptr`.
+/// In particular, if a block has base address `p` and size `n`,
+/// then `p as usize + n <= usize::MAX` must hold.
+///
+/// This ensures that pointer arithmetic within the allocation
+/// (for example, `ptr.add(len)`) cannot overflow the address space.
 /// [*currently allocated*]: #currently-allocated-memory
 #[unstable(feature = "allocator_api", issue = "32838")]
 #[rustc_const_unstable(feature = "const_heap", issue = "79597")]


### PR DESCRIPTION
Added base + size <= usize::MAX to the Allocator documentation.

Please refer to issue [153542](https://github.com/rust-lang/rust/issues/153542).

Close rust-lang/rust#153542 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
