### PR TITLE
style-guide: remove mention of 2024 being nightly-only

### DIFF
--- a/src/doc/style-guide/src/editions.md
+++ b/src/doc/style-guide/src/editions.md
@@ -32,10 +32,6 @@ instance, Rust 2015, Rust 2018, and Rust 2021 all use the same style edition.
 
 ## Rust 2024 style edition
 
-This style guide describes the Rust 2024 style edition. The Rust 2024 style
-edition is currently nightly-only and may change before the release of Rust
-2024.
-
 For a full history of changes in the Rust 2024 style edition, see the git
 history of the style guide. Notable changes in the Rust 2024 style edition
 include:


### PR DESCRIPTION
The preceding sentence is also dropped as this is not a guide exclusively about the 2024 style edition.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
