### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -8,7 +8,8 @@ use std::process::ExitStatus;
 
 use rustc_errors::codes::*;
 use rustc_errors::{
-    Diag, DiagArgValue, DiagCtxtHandle, Diagnostic, EmissionGuarantee, IntoDiagArg, Level, msg,
+    Diag, DiagArgValue, DiagCtxtHandle, DiagSymbolList, Diagnostic, EmissionGuarantee, IntoDiagArg,
+    Level, msg,
 };
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_middle::ty::layout::LayoutError;
@@ -1249,20 +1250,29 @@ pub(crate) struct FeatureNotValid<'a> {
     #[label("`{$feature}` is not valid for this target")]
     pub span: Span,
     #[subdiagnostic]
-    pub plus_hint: Option<RemovePlusFromFeatureName<'a>>,
+    pub hint: FeatureNotValidHint<'a>,
 }
 
 #[derive(Subdiagnostic)]
-#[suggestion(
-    "consider removing the leading `+` in the feature name",
-    code = "enable = \"{stripped}\"",
-    applicability = "maybe-incorrect",
-    style = "verbose"
-)]
-pub struct RemovePlusFromFeatureName<'a> {
-    #[primary_span]
-    pub span: Span,
-    pub stripped: &'a str,
+pub(crate) enum FeatureNotValidHint<'a> {
+    #[suggestion(
+        "consider removing the leading `+` in the feature name",
+        code = "enable = \"{stripped}\"",
+        applicability = "maybe-incorrect",
+        style = "verbose"
+    )]
+    RemovePlusFromFeatureName {
+        #[primary_span]
+        span: Span,
+        stripped: &'a str,
+    },
+    #[help(
+        "valid names are: {$possibilities}{$and_more ->
+            [0] {\"\"}
+            *[other] {\" \"}and {$and_more} more
+        }"
+    )]
+    ValidFeatureNames { possibilities: DiagSymbolList<&'a str>, and_more: usize },
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -9,12 +9,12 @@ use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
 use rustc_session::lint::builtin::AARCH64_SOFTFLOAT_NEON;
 use rustc_session::parse::feature_err;
-use rustc_span::{Span, Symbol, sym};
+use rustc_span::{Span, Symbol, edit_distance, sym};
 use rustc_target::spec::Arch;
 use rustc_target::target_features::{RUSTC_SPECIFIC_FEATURES, Stability};
 use smallvec::SmallVec;
 
-use crate::errors::{FeatureNotValid, RemovePlusFromFeatureName};
+use crate::errors::{FeatureNotValid, FeatureNotValidHint};
 use crate::{errors, target_features};
 
 /// Compute the enabled target features from the `#[target_feature]` function attribute.
@@ -32,15 +32,25 @@ pub(crate) fn from_target_feature_attr(
     for &(feature, feature_span) in features {
         let feature_str = feature.as_str();
         let Some(stability) = rust_target_features.get(feature_str) else {
-            let plus_hint = feature_str
-                .strip_prefix('+')
-                .filter(|stripped| rust_target_features.contains_key(*stripped))
-                .map(|stripped| RemovePlusFromFeatureName { span: feature_span, stripped });
-            tcx.dcx().emit_err(FeatureNotValid {
-                feature: feature_str,
-                span: feature_span,
-                plus_hint,
-            });
+            let hint = if let Some(stripped) = feature_str.strip_prefix('+')
+                && rust_target_features.contains_key(stripped)
+            {
+                FeatureNotValidHint::RemovePlusFromFeatureName { span: feature_span, stripped }
+            } else {
+                // Show the 5 feature names that are most similar to the input.
+                let mut valid_names: Vec<_> =
+                    rust_target_features.keys().map(|name| name.as_str()).into_sorted_stable_ord();
+                valid_names.sort_by_key(|name| {
+                    edit_distance::edit_distance(name, feature.as_str(), 5).unwrap_or(usize::MAX)
+                });
+                valid_names.truncate(5);
+
+                FeatureNotValidHint::ValidFeatureNames {
+                    possibilities: valid_names.into(),
+                    and_more: rust_target_features.len().saturating_sub(5),
+                }
+            };
+            tcx.dcx().emit_err(FeatureNotValid { feature: feature_str, span: feature_span, hint });
             continue;
         };
 

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -138,6 +138,14 @@ impl Suggestions {
             Suggestions::Disabled => Vec::new(),
         }
     }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Suggestions::Enabled(suggestions) => suggestions.len(),
+            Suggestions::Sealed(suggestions) => suggestions.len(),
+            Suggestions::Disabled => 0,
+        }
+    }
 }
 
 impl Default for Suggestions {

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs
@@ -230,8 +230,9 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                         ordered_associated_items.extend(
                             tcx.associated_items(pred.trait_ref.def_id)
                                 .in_definition_order()
-                                // Only associated types & consts can possibly be constrained via a binding.
-                                .filter(|item| item.is_type() || item.is_const())
+                                // Only associated types & type consts can possibly be
+                                // constrained in a trait object type via a binding.
+                                .filter(|item| item.is_type() || item.is_type_const())
                                 // Traits with RPITITs are simply not dyn compatible (for now).
                                 .filter(|item| !item.is_impl_trait_in_trait())
                                 .map(|item| (item.def_id, trait_ref)),

--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -1644,7 +1644,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 return;
             }
         };
-        if let [hir::PathSegment { ident, args: None, .. }] = segments {
+        if let [hir::PathSegment { ident, args: None, .. }] = segments
+            && e.suggestions.len() == 0
+        {
             e.span_label(span, format!("{} defined here", res.descr()));
             e.span_label(
                 pat_span,

--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -1636,69 +1636,75 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             span_bug!(pat_span, "unexpected resolution for path pattern: {resolved_pat:?}");
         };
 
-        if let Some(span) = self.tcx.hir_res_span(pat_res) {
+        let span = match (self.tcx.hir_res_span(pat_res), res.opt_def_id()) {
+            (Some(span), _) => span,
+            (None, Some(def_id)) => self.tcx.def_span(def_id),
+            (None, None) => {
+                e.emit();
+                return;
+            }
+        };
+        if let [hir::PathSegment { ident, args: None, .. }] = segments {
             e.span_label(span, format!("{} defined here", res.descr()));
-            if let [hir::PathSegment { ident, .. }] = segments {
-                e.span_label(
-                    pat_span,
-                    format!(
-                        "`{}` is interpreted as {} {}, not a new binding",
-                        ident,
-                        res.article(),
-                        res.descr(),
-                    ),
-                );
-                match self.tcx.parent_hir_node(hir_id) {
-                    hir::Node::PatField(..) => {
+            e.span_label(
+                pat_span,
+                format!(
+                    "`{}` is interpreted as {} {}, not a new binding",
+                    ident,
+                    res.article(),
+                    res.descr(),
+                ),
+            );
+            match self.tcx.parent_hir_node(hir_id) {
+                hir::Node::PatField(..) => {
+                    e.span_suggestion_verbose(
+                        ident.span.shrink_to_hi(),
+                        "bind the struct field to a different name instead",
+                        format!(": other_{}", ident.as_str().to_lowercase()),
+                        Applicability::HasPlaceholders,
+                    );
+                }
+                _ => {
+                    let (type_def_id, item_def_id) = match resolved_pat.ty.kind() {
+                        ty::Adt(def, _) => match res {
+                            Res::Def(DefKind::Const { .. }, def_id) => {
+                                (Some(def.did()), Some(def_id))
+                            }
+                            _ => (None, None),
+                        },
+                        _ => (None, None),
+                    };
+
+                    let is_range = matches!(
+                        type_def_id.and_then(|id| self.tcx.as_lang_item(id)),
+                        Some(
+                            LangItem::Range
+                                | LangItem::RangeFrom
+                                | LangItem::RangeTo
+                                | LangItem::RangeFull
+                                | LangItem::RangeInclusiveStruct
+                                | LangItem::RangeToInclusive,
+                        )
+                    );
+                    if is_range {
+                        if !self.maybe_suggest_range_literal(&mut e, item_def_id, *ident) {
+                            let msg = "constants only support matching by type, \
+                                if you meant to match against a range of values, \
+                                consider using a range pattern like `min ..= max` in the match block";
+                            e.note(msg);
+                        }
+                    } else {
+                        let msg = "introduce a new binding instead";
+                        let sugg = format!("other_{}", ident.as_str().to_lowercase());
                         e.span_suggestion_verbose(
-                            ident.span.shrink_to_hi(),
-                            "bind the struct field to a different name instead",
-                            format!(": other_{}", ident.as_str().to_lowercase()),
+                            ident.span,
+                            msg,
+                            sugg,
                             Applicability::HasPlaceholders,
                         );
                     }
-                    _ => {
-                        let (type_def_id, item_def_id) = match resolved_pat.ty.kind() {
-                            ty::Adt(def, _) => match res {
-                                Res::Def(DefKind::Const { .. }, def_id) => {
-                                    (Some(def.did()), Some(def_id))
-                                }
-                                _ => (None, None),
-                            },
-                            _ => (None, None),
-                        };
-
-                        let is_range = matches!(
-                            type_def_id.and_then(|id| self.tcx.as_lang_item(id)),
-                            Some(
-                                LangItem::Range
-                                    | LangItem::RangeFrom
-                                    | LangItem::RangeTo
-                                    | LangItem::RangeFull
-                                    | LangItem::RangeInclusiveStruct
-                                    | LangItem::RangeToInclusive,
-                            )
-                        );
-                        if is_range {
-                            if !self.maybe_suggest_range_literal(&mut e, item_def_id, *ident) {
-                                let msg = "constants only support matching by type, \
-                                    if you meant to match against a range of values, \
-                                    consider using a range pattern like `min ..= max` in the match block";
-                                e.note(msg);
-                            }
-                        } else {
-                            let msg = "introduce a new binding instead";
-                            let sugg = format!("other_{}", ident.as_str().to_lowercase());
-                            e.span_suggestion(
-                                ident.span,
-                                msg,
-                                sugg,
-                                Applicability::HasPlaceholders,
-                            );
-                        }
-                    }
-                };
-            }
+                }
+            };
         }
         e.emit();
     }

--- a/compiler/rustc_middle/src/ty/assoc.rs
+++ b/compiler/rustc_middle/src/ty/assoc.rs
@@ -137,8 +137,8 @@ impl AssocItem {
         self.kind.as_def_kind()
     }
 
-    pub fn is_const(&self) -> bool {
-        matches!(self.kind, ty::AssocKind::Const { .. })
+    pub fn is_type_const(&self) -> bool {
+        matches!(self.kind, ty::AssocKind::Const { is_type_const: true, .. })
     }
 
     pub fn is_fn(&self) -> bool {

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -753,7 +753,7 @@ impl<'tcx> Ty<'tcx> {
                     .map(|principal| {
                         tcx.associated_items(principal.def_id())
                             .in_definition_order()
-                            .filter(|item| item.is_type() || item.is_const())
+                            .filter(|item| item.is_type() || item.is_type_const())
                             .filter(|item| !item.is_impl_trait_in_trait())
                             .filter(|item| !tcx.generics_require_sized_self(item.def_id))
                             .count()

--- a/compiler/rustc_query_impl/src/from_cycle_error.rs
+++ b/compiler/rustc_query_impl/src/from_cycle_error.rs
@@ -8,13 +8,13 @@ use rustc_errors::codes::*;
 use rustc_errors::{Applicability, Diag, MultiSpan, pluralize, struct_span_code_err};
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
+use rustc_middle::bug;
 use rustc_middle::dep_graph::DepKind;
 use rustc_middle::queries::{QueryVTables, TaggedQueryKey};
 use rustc_middle::query::CycleError;
 use rustc_middle::query::erase::erase_val;
 use rustc_middle::ty::layout::LayoutError;
 use rustc_middle::ty::{self, Ty, TyCtxt};
-use rustc_middle::{bug, span_bug};
 use rustc_span::def_id::{DefId, LocalDefId};
 use rustc_span::{ErrorGuaranteed, Span};
 
@@ -32,9 +32,9 @@ pub(crate) fn specialize_query_vtables<'tcx>(vtables: &mut QueryVTables<'tcx>) {
     vtables.check_representability_adt_ty.value_from_cycle_error =
         |tcx, _, cycle, _err| check_representability(tcx, cycle);
 
-    vtables.variances_of.value_from_cycle_error = |tcx, _, cycle, err| {
+    vtables.variances_of.value_from_cycle_error = |tcx, key, _, err| {
         let _guar = err.delay_as_bug();
-        erase_val(variances_of(tcx, cycle))
+        erase_val(variances_of(tcx, key))
     };
 
     vtables.layout_of.value_from_cycle_error = |tcx, _, cycle, err| {
@@ -105,27 +105,9 @@ fn check_representability<'tcx>(tcx: TyCtxt<'tcx>, cycle_error: CycleError<'tcx>
     guar.raise_fatal()
 }
 
-fn variances_of<'tcx>(tcx: TyCtxt<'tcx>, cycle_error: CycleError<'tcx>) -> &'tcx [ty::Variance] {
-    search_for_cycle_permutation(
-        &cycle_error.cycle,
-        |cycle| {
-            if let Some(frame) = cycle.get(0)
-                && frame.node.dep_kind == DepKind::variances_of
-                && let Some(def_id) = frame.node.def_id
-            {
-                let n = tcx.generics_of(def_id).own_params.len();
-                ControlFlow::Break(tcx.arena.alloc_from_iter(iter::repeat_n(ty::Bivariant, n)))
-            } else {
-                ControlFlow::Continue(())
-            }
-        },
-        || {
-            span_bug!(
-                cycle_error.usage.as_ref().unwrap().span,
-                "only `variances_of` returns `&[ty::Variance]`"
-            )
-        },
-    )
+fn variances_of<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> &'tcx [ty::Variance] {
+    let n = tcx.generics_of(def_id).own_params.len();
+    tcx.arena.alloc_from_iter(iter::repeat_n(ty::Bivariant, n))
 }
 
 // Take a cycle of `Q` and try `try_cycle` on every permutation, falling back to `otherwise`.

--- a/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
+++ b/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
@@ -239,7 +239,7 @@ fn trait_object_ty<'tcx>(tcx: TyCtxt<'tcx>, poly_trait_ref: ty::PolyTraitRef<'tc
         .flat_map(|super_poly_trait_ref| {
             tcx.associated_items(super_poly_trait_ref.def_id())
                 .in_definition_order()
-                .filter(|item| item.is_type() || item.is_const())
+                .filter(|item| item.is_type() || item.is_type_const())
                 .filter(|item| !tcx.generics_require_sized_self(item.def_id))
                 .map(move |assoc_item| {
                     super_poly_trait_ref.map_bound(|super_trait_ref| {

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/note_and_explain.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/note_and_explain.rs
@@ -263,8 +263,13 @@ impl<T> Trait<T> for X {
                             cause.code(),
                         );
                     }
+                    // Don't suggest constraining a projection to something
+                    // containing itself, e.g. `Item = &<I as Iterator>::Item`.
                     (_, ty::Alias(ty::Projection | ty::Inherent, proj_ty))
-                        if !tcx.is_impl_trait_in_trait(proj_ty.def_id) =>
+                        if !tcx.is_impl_trait_in_trait(proj_ty.def_id)
+                            && !tcx
+                                .erase_and_anonymize_regions(values.expected)
+                                .contains(tcx.erase_and_anonymize_regions(values.found)) =>
                     {
                         let msg = || {
                             format!(

--- a/src/ci/docker/host-x86_64/x86_64-gnu-aux/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-aux/Dockerfile
@@ -29,5 +29,5 @@ RUN sh /scripts/sccache.sh
 ENV NO_DEBUG_ASSERTIONS=1
 ENV NO_OVERFLOW_CHECKS=1
 
-ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu
-ENV RUST_CHECK_TARGET check-aux
+ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu"
+ENV RUST_CHECK_TARGET="check-aux"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-debug/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-debug/Dockerfile
@@ -29,20 +29,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-ENV RUSTBUILD_FORCE_CLANG_BASED_TESTS 1
+ENV RUSTBUILD_FORCE_CLANG_BASED_TESTS="1"
 
 # llvm.use-linker conflicts with downloading CI LLVM
-ENV NO_DOWNLOAD_CI_LLVM 1
+ENV NO_DOWNLOAD_CI_LLVM="1"
 
-ENV RUST_CONFIGURE_ARGS \
-      --build=x86_64-unknown-linux-gnu \
+ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu \
       --enable-debug \
       --enable-lld \
       --set rust.debuginfo-level-tests=2 \
       --set llvm.use-linker=lld \
       --set target.x86_64-unknown-linux-gnu.linker=clang \
       --set target.x86_64-unknown-linux-gnu.cc=clang \
-      --set target.x86_64-unknown-linux-gnu.cxx=clang++
+      --set target.x86_64-unknown-linux-gnu.cxx=clang++"
 
 # This job checks:
 # - That ui tests can be built with `-Cdebuginfo=1`
@@ -53,7 +52,6 @@ ENV RUST_CONFIGURE_ARGS \
 # - That the tests with `//@ needs-force-clang-based-tests` pass, since they
 #   don't run by default unless RUSTBUILD_FORCE_CLANG_BASED_TESTS is set.
 
-ENV SCRIPT \
-  python3 ../x.py --stage 2 build && \
+ENV SCRIPT="python3 ../x.py --stage 2 build && \
   python3 ../x.py --stage 2 test tests/ui && \
-  python3 ../x.py --stage 2 test tests/run-make tests/run-make-cargo
+  python3 ../x.py --stage 2 test tests/run-make tests/run-make-cargo"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-distcheck/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-distcheck/Dockerfile
@@ -1,5 +1,5 @@
 # Runs `distcheck`, which is a collection of smoke tests:
-# 
+#
 # - Run `make check` from an unpacked dist tarball to make sure we can at the
 #   minimum run check steps from those sources.
 # - Check that selected dist components at least have expected directory shape
@@ -34,6 +34,6 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 # Make distcheck builds faster
-ENV DISTCHECK_CONFIGURE_ARGS "--enable-sccache"
+ENV DISTCHECK_CONFIGURE_ARGS="--enable-sccache"
 
-ENV SCRIPT python3 ../x.py test distcheck
+ENV SCRIPT="python3 ../x.py test distcheck"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-gcc/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-gcc/Dockerfile
@@ -31,15 +31,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-ENV NO_DEBUG_ASSERTIONS 1
-ENV RUST_CONFIGURE_ARGS \
- --build=x86_64-unknown-linux-gnu \
+ENV NO_DEBUG_ASSERTIONS="1"
+ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu \
  --enable-sanitizers \
  --enable-profiler \
  --enable-compiler-docs \
  --set llvm.libzstd=true \
- --set 'rust.codegen-backends=[\"llvm\",\"gcc\"]'
-ENV SCRIPT python3 ../x.py \
+ --set rust.codegen-backends=[\\\"llvm\\\",\\\"gcc\\\"]"
+ENV SCRIPT="python3 ../x.py \
   --stage 2 \
   test tests \
   --test-codegen-backend gcc \
@@ -51,4 +50,4 @@ ENV SCRIPT python3 ../x.py \
   --skip tests/rustdoc-js-std \
   --skip tests/rustdoc-json \
   --skip tests/rustdoc-ui \
-  --set 'rust.codegen-backends=[\"llvm\",\"gcc\"]'
+  --set rust.codegen-backends=[\\\"llvm\\\",\\\"gcc\\\"]"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-21/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-21/Dockerfile
@@ -44,16 +44,15 @@ RUN sh /scripts/sccache.sh
 
 # We are disabling CI LLVM since this builder is intentionally using a host
 # LLVM, rather than the typical src/llvm-project LLVM.
-ENV NO_DOWNLOAD_CI_LLVM 1
-ENV EXTERNAL_LLVM 1
+ENV NO_DOWNLOAD_CI_LLVM="1"
+ENV EXTERNAL_LLVM="1"
 
 # Using llvm-link-shared due to libffi issues -- see #34486
-ENV RUST_CONFIGURE_ARGS \
-      --build=x86_64-unknown-linux-gnu \
+ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu \
       --llvm-root=/usr/lib/llvm-21 \
       --enable-llvm-link-shared \
       --set rust.randomize-layout=true \
-      --set rust.thin-lto-import-instr-limit=10
+      --set rust.thin-lto-import-instr-limit=10"
 
 COPY scripts/shared.sh /scripts/
 
@@ -63,4 +62,4 @@ COPY scripts/x86_64-gnu-llvm3.sh /scripts/
 COPY scripts/stage_2_test_set1.sh /scripts/
 COPY scripts/stage_2_test_set2.sh /scripts/
 
-ENV SCRIPT "Must specify DOCKER_SCRIPT for this image"
+ENV SCRIPT="Must specify DOCKER_SCRIPT for this image"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-miri/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-miri/Dockerfile
@@ -34,11 +34,10 @@ ENV GCC_EXEC_PREFIX="/usr/lib/gcc/"
 
 COPY host-x86_64/x86_64-gnu-miri/check-miri.sh /tmp/
 
-ENV RUST_CONFIGURE_ARGS \
-  --build=x86_64-unknown-linux-gnu \
-  --enable-new-symbol-mangling
+ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu \
+  --enable-new-symbol-mangling"
 
-ENV HOST_TARGET x86_64-unknown-linux-gnu
+ENV HOST_TARGET="x86_64-unknown-linux-gnu"
 
 # FIXME(#133381): currently rustc alt builds do *not* have rustc debug
 # assertions enabled! Therefore, we cannot force download CI rustc.
@@ -46,4 +45,4 @@ ENV HOST_TARGET x86_64-unknown-linux-gnu
 
 COPY scripts/shared.sh /scripts/
 
-ENV SCRIPT /tmp/check-miri.sh ../x.py
+ENV SCRIPT="/tmp/check-miri.sh ../x.py"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-nopt/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-nopt/Dockerfile
@@ -22,8 +22,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu \
+ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu \
   --disable-optimize-tests \
-  --set rust.test-compare-mode
-ENV SCRIPT python3 ../x.py test --stage 1 --set rust.optimize=false library/std \
-  && python3 ../x.py --stage 2 test
+  --set rust.test-compare-mode"
+ENV SCRIPT="python3 ../x.py test --stage 1 --set rust.optimize=false library/std \
+  && python3 ../x.py --stage 2 test"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
@@ -76,12 +76,11 @@ COPY scripts/nodejs.sh /scripts/
 RUN sh /scripts/nodejs.sh /node
 ENV PATH="/node/bin:${PATH}"
 
-ENV RUST_CONFIGURE_ARGS \
-  --build=x86_64-unknown-linux-gnu \
+ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu \
   --save-toolstates=/tmp/toolstate/toolstates.json \
-  --enable-new-symbol-mangling
+  --enable-new-symbol-mangling"
 
-ENV HOST_TARGET x86_64-unknown-linux-gnu
+ENV HOST_TARGET="x86_64-unknown-linux-gnu"
 
 # FIXME(#133381): currently rustc alt builds do *not* have rustc debug
 # assertions enabled! Therefore, we cannot force download CI rustc.
@@ -89,5 +88,5 @@ ENV HOST_TARGET x86_64-unknown-linux-gnu
 
 COPY scripts/shared.sh /scripts/
 
-ENV SCRIPT /tmp/checktools.sh ../x.py && \
-  python3 ../x.py test tests/rustdoc-gui --stage 2 --test-args "'--jobs 1'"
+ENV SCRIPT="/tmp/checktools.sh ../x.py && \
+  python3 ../x.py test tests/rustdoc-gui --stage 2 --test-args '--jobs 1'"

--- a/src/ci/docker/host-x86_64/x86_64-gnu/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu/Dockerfile
@@ -24,10 +24,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-ENV RUST_CONFIGURE_ARGS \
- --build=x86_64-unknown-linux-gnu \
+ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu \
  --enable-sanitizers \
  --enable-profiler \
  --enable-compiler-docs \
- --set llvm.libzstd=true
-ENV SCRIPT python3 ../x.py --stage 2 test
+ --set llvm.libzstd=true"
+ENV SCRIPT="python3 ../x.py --stage 2 test"

--- a/tests/ui/associated-consts/associated-const-in-trait.rs
+++ b/tests/ui/associated-consts/associated-const-in-trait.rs
@@ -7,6 +7,8 @@ trait Trait {
 impl dyn Trait {
     //~^ ERROR the trait `Trait` is not dyn compatible [E0038]
     const fn n() -> usize { Self::N }
+    //~^ ERROR the trait `Trait` is not dyn compatible [E0038]
+    //~| ERROR the trait `Trait` is not dyn compatible [E0038]
 }
 
 fn main() {}

--- a/tests/ui/associated-consts/associated-const-in-trait.stderr
+++ b/tests/ui/associated-consts/associated-const-in-trait.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Trait` is not dyn compatible
-  --> $DIR/associated-const-in-trait.rs:7:10
+  --> $DIR/associated-const-in-trait.rs:7:6
    |
 LL | impl dyn Trait {
-   |          ^^^^^ `Trait` is not dyn compatible
+   |      ^^^^^^^^^ `Trait` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
@@ -14,6 +14,38 @@ LL |     const N: usize;
    |           ^ ...because it contains associated const `N`
    = help: consider moving `N` to another trait
 
-error: aborting due to 1 previous error
+error[E0038]: the trait `Trait` is not dyn compatible
+  --> $DIR/associated-const-in-trait.rs:9:29
+   |
+LL |     const fn n() -> usize { Self::N }
+   |                             ^^^^ `Trait` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/associated-const-in-trait.rs:4:11
+   |
+LL | trait Trait {
+   |       ----- this trait is not dyn compatible...
+LL |     const N: usize;
+   |           ^ ...because it contains associated const `N`
+   = help: consider moving `N` to another trait
+
+error[E0038]: the trait `Trait` is not dyn compatible
+  --> $DIR/associated-const-in-trait.rs:9:29
+   |
+LL |     const fn n() -> usize { Self::N }
+   |                             ^^^^^^^ `Trait` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/associated-const-in-trait.rs:4:11
+   |
+LL | trait Trait {
+   |       ----- this trait is not dyn compatible...
+LL |     const N: usize;
+   |           ^ ...because it contains associated const `N`
+   = help: consider moving `N` to another trait
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/associated-item/issue-48027.stderr
+++ b/tests/ui/associated-item/issue-48027.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Bar` is not dyn compatible
-  --> $DIR/issue-48027.rs:6:10
+  --> $DIR/issue-48027.rs:6:6
    |
 LL | impl dyn Bar {}
-   |          ^^^ `Bar` is not dyn compatible
+   |      ^^^^^^^ `Bar` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/associated-types/dont-suggest-self-referential-constraint.rs
+++ b/tests/ui/associated-types/dont-suggest-self-referential-constraint.rs
@@ -1,0 +1,20 @@
+// Regression test for #112104.
+//
+// Don't suggest `Item = &<I as Iterator>::Item` when
+// the expected type wraps the found projection.
+
+fn option_of_ref_assoc<I: Iterator>(iter: &mut I) {
+    let _: Option<&I::Item> = iter.next();
+    //~^ ERROR mismatched types
+}
+
+// Valid constraint suggestions should still fire.
+trait Foo {
+    type Assoc;
+}
+
+fn assoc_to_concrete<T: Foo>(x: T::Assoc) -> u32 {
+    x //~ ERROR mismatched types
+}
+
+fn main() {}

--- a/tests/ui/associated-types/dont-suggest-self-referential-constraint.stderr
+++ b/tests/ui/associated-types/dont-suggest-self-referential-constraint.stderr
@@ -1,0 +1,33 @@
+error[E0308]: mismatched types
+  --> $DIR/dont-suggest-self-referential-constraint.rs:7:31
+   |
+LL |     let _: Option<&I::Item> = iter.next();
+   |            ----------------   ^^^^^^^^^^^ expected `Option<&<I as Iterator>::Item>`, found `Option<<I as Iterator>::Item>`
+   |            |
+   |            expected due to this
+   |
+   = note: expected enum `Option<&_>`
+              found enum `Option<_>`
+help: try using `.as_ref()` to convert `Option<<I as Iterator>::Item>` to `Option<&<I as Iterator>::Item>`
+   |
+LL |     let _: Option<&I::Item> = iter.next().as_ref();
+   |                                          +++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/dont-suggest-self-referential-constraint.rs:17:5
+   |
+LL | fn assoc_to_concrete<T: Foo>(x: T::Assoc) -> u32 {
+   |                                              --- expected `u32` because of return type
+LL |     x
+   |     ^ expected `u32`, found associated type
+   |
+   = note:         expected type `u32`
+           found associated type `<T as Foo>::Assoc`
+help: consider constraining the associated type `<T as Foo>::Assoc` to `u32`
+   |
+LL | fn assoc_to_concrete<T: Foo<Assoc = u32>>(x: T::Assoc) -> u32 {
+   |                            +++++++++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/blind/blind-item-block-middle.stderr
+++ b/tests/ui/blind/blind-item-block-middle.stderr
@@ -9,7 +9,11 @@ LL |     let bar = 5;
    |         |
    |         expected integer, found `bar`
    |         `bar` is interpreted as a unit struct, not a new binding
-   |         help: introduce a new binding instead: `other_bar`
+   |
+help: introduce a new binding instead
+   |
+LL |     let other_bar = 5;
+   |         ++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const_in_pattern/arrays-and-slices.stderr
+++ b/tests/ui/consts/const_in_pattern/arrays-and-slices.stderr
@@ -11,10 +11,14 @@ LL |         BSTR_SIZED => {}
    |         |
    |         expected `&[u8]`, found `&[u8; 3]`
    |         `BSTR_SIZED` is interpreted as a constant, not a new binding
-   |         help: introduce a new binding instead: `other_bstr_sized`
    |
    = note: expected reference `&[u8]`
               found reference `&'static [u8; 3]`
+help: introduce a new binding instead
+   |
+LL -         BSTR_SIZED => {}
+LL +         other_bstr_sized => {}
+   |
 
 error[E0308]: mismatched types
   --> $DIR/arrays-and-slices.rs:23:9
@@ -29,10 +33,14 @@ LL |         STRUCT_SIZED => {}
    |         |
    |         expected `&SomeStruct<[u8]>`, found `&SomeStruct<[u8; 3]>`
    |         `STRUCT_SIZED` is interpreted as a constant, not a new binding
-   |         help: introduce a new binding instead: `other_struct_sized`
    |
    = note: expected reference `&SomeStruct<[u8]>`
               found reference `&'static SomeStruct<[u8; 3]>`
+help: introduce a new binding instead
+   |
+LL -         STRUCT_SIZED => {}
+LL +         other_struct_sized => {}
+   |
 
 error[E0308]: mismatched types
   --> $DIR/arrays-and-slices.rs:30:9
@@ -47,10 +55,14 @@ LL |         BSTR_SIZED => {}
    |         |
    |         expected `&[u8]`, found `&[u8; 3]`
    |         `BSTR_SIZED` is interpreted as a constant, not a new binding
-   |         help: introduce a new binding instead: `other_bstr_sized`
    |
    = note: expected reference `&[u8]`
               found reference `&'static [u8; 3]`
+help: introduce a new binding instead
+   |
+LL -         BSTR_SIZED => {}
+LL +         other_bstr_sized => {}
+   |
 
 error[E0308]: mismatched types
   --> $DIR/arrays-and-slices.rs:37:9
@@ -65,10 +77,14 @@ LL |         STRUCT_SIZED => {}
    |         |
    |         expected `&SomeStruct<[u8]>`, found `&SomeStruct<[u8; 3]>`
    |         `STRUCT_SIZED` is interpreted as a constant, not a new binding
-   |         help: introduce a new binding instead: `other_struct_sized`
    |
    = note: expected reference `&SomeStruct<[u8]>`
               found reference `&'static SomeStruct<[u8; 3]>`
+help: introduce a new binding instead
+   |
+LL -         STRUCT_SIZED => {}
+LL +         other_struct_sized => {}
+   |
 
 error: cannot use unsized non-slice type `SomeStruct<[u8]>` in constant patterns
   --> $DIR/arrays-and-slices.rs:47:9

--- a/tests/ui/did_you_mean/compatible-variants-in-pat.rs
+++ b/tests/ui/did_you_mean/compatible-variants-in-pat.rs
@@ -21,7 +21,6 @@ fn b(s: Option<S>) {
         S => {
             //~^ ERROR mismatched types
             //~| HELP try wrapping
-            //~| HELP introduce a new binding instead
         }
         _ => {}
     }
@@ -32,7 +31,6 @@ fn c(s: Result<S, S>) {
         S => {
             //~^ ERROR mismatched types
             //~| HELP try wrapping
-            //~| HELP introduce a new binding instead
         }
         _ => {}
     }

--- a/tests/ui/did_you_mean/compatible-variants-in-pat.stderr
+++ b/tests/ui/did_you_mean/compatible-variants-in-pat.stderr
@@ -14,16 +14,10 @@ LL |         Foo::Bar(Bar { x }) => {
 error[E0308]: mismatched types
   --> $DIR/compatible-variants-in-pat.rs:21:9
    |
-LL | struct S;
-   | -------- unit struct defined here
-...
 LL |     match s {
    |           - this expression has type `Option<S>`
 LL |         S => {
-   |         ^
-   |         |
-   |         expected `Option<S>`, found `S`
-   |         `S` is interpreted as a unit struct, not a new binding
+   |         ^ expected `Option<S>`, found `S`
    |
    = note: expected enum `Option<S>`
             found struct `S`
@@ -31,25 +25,14 @@ help: try wrapping the pattern in `Some`
    |
 LL |         Some(S) => {
    |         +++++ +
-help: introduce a new binding instead
-   |
-LL -         S => {
-LL +         other_s => {
-   |
 
 error[E0308]: mismatched types
-  --> $DIR/compatible-variants-in-pat.rs:32:9
+  --> $DIR/compatible-variants-in-pat.rs:31:9
    |
-LL | struct S;
-   | -------- unit struct defined here
-...
 LL |     match s {
    |           - this expression has type `Result<S, S>`
 LL |         S => {
-   |         ^
-   |         |
-   |         expected `Result<S, S>`, found `S`
-   |         `S` is interpreted as a unit struct, not a new binding
+   |         ^ expected `Result<S, S>`, found `S`
    |
    = note: expected enum `Result<S, S>`
             found struct `S`
@@ -59,11 +42,6 @@ LL |         Ok(S) => {
    |         +++ +
 LL |         Err(S) => {
    |         ++++ +
-help: introduce a new binding instead
-   |
-LL -         S => {
-LL +         other_s => {
-   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/dyn-compatibility/associated-consts.stderr
+++ b/tests/ui/dyn-compatibility/associated-consts.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Bar` is not dyn compatible
-  --> $DIR/associated-consts.rs:8:35
+  --> $DIR/associated-consts.rs:8:31
    |
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
-   |                                   ^^^ `Bar` is not dyn compatible
+   |                               ^^^^^^^ `Bar` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/issues/issue-33504.stderr
+++ b/tests/ui/issues/issue-33504.stderr
@@ -9,7 +9,12 @@ LL |         let Test = 1;
    |             |
    |             expected integer, found `Test`
    |             `Test` is interpreted as a unit struct, not a new binding
-   |             help: introduce a new binding instead: `other_test`
+   |
+help: introduce a new binding instead
+   |
+LL -         let Test = 1;
+LL +         let other_test = 1;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-5100.stderr
+++ b/tests/ui/issues/issue-5100.stderr
@@ -1,9 +1,6 @@
 error[E0308]: mismatched types
   --> $DIR/issue-5100.rs:9:9
    |
-LL | enum A { B, C }
-   |          - unit variant defined here
-...
 LL |     match (true, false) {
    |           ------------- this expression has type `(bool, bool)`
 LL |         A::B => (),

--- a/tests/ui/match/issue-12552.stderr
+++ b/tests/ui/match/issue-12552.stderr
@@ -20,14 +20,7 @@ LL |   match t {
    |         - this expression has type `Result<_, {integer}>`
 ...
 LL |     None => ()
-   |     ^^^^
-   |     |
-   |     expected `Result<_, {integer}>`, found `Option<_>`
-   |     `None` is interpreted as a unit variant, not a new binding
-   |
-  --> $SRC_DIR/core/src/option.rs:LL:COL
-   |
-   = note: unit variant defined here
+   |     ^^^^ expected `Result<_, {integer}>`, found `Option<_>`
    |
    = note: expected enum `Result<_, {integer}>`
               found enum `Option<_>`
@@ -35,11 +28,6 @@ help: try wrapping the pattern in `Ok`
    |
 LL |     Ok(None) => ()
    |     +++    +
-help: introduce a new binding instead
-   |
-LL -     None => ()
-LL +     other_none => ()
-   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/match/issue-12552.stderr
+++ b/tests/ui/match/issue-12552.stderr
@@ -20,7 +20,14 @@ LL |   match t {
    |         - this expression has type `Result<_, {integer}>`
 ...
 LL |     None => ()
-   |     ^^^^ expected `Result<_, {integer}>`, found `Option<_>`
+   |     ^^^^
+   |     |
+   |     expected `Result<_, {integer}>`, found `Option<_>`
+   |     `None` is interpreted as a unit variant, not a new binding
+   |
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   |
+   = note: unit variant defined here
    |
    = note: expected enum `Result<_, {integer}>`
               found enum `Option<_>`
@@ -28,6 +35,11 @@ help: try wrapping the pattern in `Ok`
    |
 LL |     Ok(None) => ()
    |     +++    +
+help: introduce a new binding instead
+   |
+LL -     None => ()
+LL +     other_none => ()
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/match/match-const-tuple-type-mismatch.stderr
+++ b/tests/ui/match/match-const-tuple-type-mismatch.stderr
@@ -11,10 +11,14 @@ LL |         A => (),
    |         |
    |         expected integer, found `(isize, isize)`
    |         `A` is interpreted as a constant, not a new binding
-   |         help: introduce a new binding instead: `other_a`
    |
    = note: expected type `{integer}`
              found tuple `(isize, isize)`
+help: introduce a new binding instead
+   |
+LL -         A => (),
+LL +         other_a => (),
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/match/match-tag-nullary.stderr
+++ b/tests/ui/match/match-tag-nullary.stderr
@@ -1,9 +1,6 @@
 error[E0308]: mismatched types
   --> $DIR/match-tag-nullary.rs:4:40
    |
-LL | enum B { B }
-   |          - unit variant defined here
-LL |
 LL | fn main() { let x: A = A::A; match x { B::B => { } } }
    |                                    -   ^^^^ expected `A`, found `B`
    |                                    |

--- a/tests/ui/match/mismatched-types-in-match-7867.stderr
+++ b/tests/ui/match/mismatched-types-in-match-7867.stderr
@@ -1,9 +1,6 @@
 error[E0308]: mismatched types
   --> $DIR/mismatched-types-in-match-7867.rs:10:9
    |
-LL | enum A { B, C }
-   |          - unit variant defined here
-...
 LL |     match (true, false) {
    |           ------------- this expression has type `(bool, bool)`
 LL |         A::B => (),

--- a/tests/ui/privacy/private-unit-struct-assignment.stderr
+++ b/tests/ui/privacy/private-unit-struct-assignment.stderr
@@ -13,9 +13,6 @@ LL |     struct C;
 error[E0308]: mismatched types
   --> $DIR/private-unit-struct-assignment.rs:8:5
    |
-LL |     struct C;
-   |     -------- unit struct defined here
-...
 LL |     A::C = 1;
    |     ^^^^   - this expression has type `{integer}`
    |     |

--- a/tests/ui/resolve/name-clash-nullary.stderr
+++ b/tests/ui/resolve/name-clash-nullary.stderr
@@ -5,9 +5,19 @@ LL |   let None: isize = 42;
    |       ^^^^  ----- expected due to this
    |       |
    |       expected `isize`, found `Option<_>`
+   |       `None` is interpreted as a unit variant, not a new binding
+   |
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   |
+   = note: unit variant defined here
    |
    = note: expected type `isize`
               found enum `Option<_>`
+help: introduce a new binding instead
+   |
+LL -   let None: isize = 42;
+LL +   let other_none: isize = 42;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rfcs/rfc-2005-default-binding-mode/const.stderr
+++ b/tests/ui/rfcs/rfc-2005-default-binding-mode/const.stderr
@@ -11,7 +11,12 @@ LL |         FOO => {},
    |         |
    |         expected `&Foo`, found `Foo`
    |         `FOO` is interpreted as a constant, not a new binding
-   |         help: introduce a new binding instead: `other_foo`
+   |
+help: introduce a new binding instead
+   |
+LL -         FOO => {},
+LL +         other_foo => {},
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/field-access.stderr
+++ b/tests/ui/suggestions/field-access.stderr
@@ -1,9 +1,6 @@
 error[E0308]: mismatched types
   --> $DIR/field-access.rs:20:12
    |
-LL |     Fst,
-   |     --- unit variant defined here
-...
 LL |     if let B::Fst = a {};
    |            ^^^^^^   - this expression has type `A`
    |            |
@@ -17,9 +14,6 @@ LL |     if let B::Fst = a.b {};
 error[E0308]: mismatched types
   --> $DIR/field-access.rs:25:9
    |
-LL |     Fst,
-   |     --- unit variant defined here
-...
 LL |     match a {
    |           - this expression has type `A`
 ...
@@ -34,9 +28,6 @@ LL |     match a.b {
 error[E0308]: mismatched types
   --> $DIR/field-access.rs:26:9
    |
-LL |     Snd,
-   |     --- unit variant defined here
-...
 LL |     match a {
    |           - this expression has type `A`
 ...

--- a/tests/ui/suggestions/suggest-deref-in-match-issue-132784.rs
+++ b/tests/ui/suggestions/suggest-deref-in-match-issue-132784.rs
@@ -8,6 +8,7 @@ fn main() {
         //~^ ERROR mismatched types
         None => {}
         //~^ ERROR mismatched types
+        //~| HELP introduce a new binding instead
     }
 
     match &x {
@@ -17,6 +18,7 @@ fn main() {
         //~^ ERROR mismatched types
         None => {}
         //~^ ERROR mismatched types
+        //~| HELP introduce a new binding instead
     }
 
     let mut y = Box::new(Some(1));
@@ -27,6 +29,7 @@ fn main() {
         //~^ ERROR mismatched types
         None => {}
         //~^ ERROR mismatched types
+        //~| HELP introduce a new binding instead
     }
 
     let mut z = Arc::new(Some(1));
@@ -37,6 +40,7 @@ fn main() {
         //~^ ERROR mismatched types
         None => {}
         //~^ ERROR mismatched types
+        //~| HELP introduce a new binding instead
     }
 
     let z_const: &Arc<Option<i32>> = &z;
@@ -47,6 +51,7 @@ fn main() {
         //~^ ERROR mismatched types
         None => {}
         //~^ ERROR mismatched types
+        //~| HELP introduce a new binding instead
     }
 
     // Normal reference because Arc doesn't implement DerefMut.
@@ -58,6 +63,7 @@ fn main() {
         //~^ ERROR mismatched types
         None => {}
         //~^ ERROR mismatched types
+        //~| HELP introduce a new binding instead
     }
 
     // Mutable reference because Box does implement DerefMut.
@@ -69,6 +75,7 @@ fn main() {
         //~^ ERROR mismatched types
         None => {}
         //~^ ERROR mismatched types
+        //~| HELP introduce a new binding instead
     }
 
     // Difficult expression.
@@ -80,5 +87,6 @@ fn main() {
         //~^ ERROR mismatched types
         None => {}
         //~^ ERROR mismatched types
+        //~| HELP introduce a new binding instead
     }
 }

--- a/tests/ui/suggestions/suggest-deref-in-match-issue-132784.rs
+++ b/tests/ui/suggestions/suggest-deref-in-match-issue-132784.rs
@@ -8,7 +8,6 @@ fn main() {
         //~^ ERROR mismatched types
         None => {}
         //~^ ERROR mismatched types
-        //~| HELP introduce a new binding instead
     }
 
     match &x {
@@ -18,7 +17,6 @@ fn main() {
         //~^ ERROR mismatched types
         None => {}
         //~^ ERROR mismatched types
-        //~| HELP introduce a new binding instead
     }
 
     let mut y = Box::new(Some(1));
@@ -29,7 +27,6 @@ fn main() {
         //~^ ERROR mismatched types
         None => {}
         //~^ ERROR mismatched types
-        //~| HELP introduce a new binding instead
     }
 
     let mut z = Arc::new(Some(1));
@@ -40,7 +37,6 @@ fn main() {
         //~^ ERROR mismatched types
         None => {}
         //~^ ERROR mismatched types
-        //~| HELP introduce a new binding instead
     }
 
     let z_const: &Arc<Option<i32>> = &z;
@@ -51,7 +47,6 @@ fn main() {
         //~^ ERROR mismatched types
         None => {}
         //~^ ERROR mismatched types
-        //~| HELP introduce a new binding instead
     }
 
     // Normal reference because Arc doesn't implement DerefMut.
@@ -63,7 +58,6 @@ fn main() {
         //~^ ERROR mismatched types
         None => {}
         //~^ ERROR mismatched types
-        //~| HELP introduce a new binding instead
     }
 
     // Mutable reference because Box does implement DerefMut.
@@ -75,7 +69,6 @@ fn main() {
         //~^ ERROR mismatched types
         None => {}
         //~^ ERROR mismatched types
-        //~| HELP introduce a new binding instead
     }
 
     // Difficult expression.
@@ -87,6 +80,5 @@ fn main() {
         //~^ ERROR mismatched types
         None => {}
         //~^ ERROR mismatched types
-        //~| HELP introduce a new binding instead
     }
 }

--- a/tests/ui/suggestions/suggest-deref-in-match-issue-132784.stderr
+++ b/tests/ui/suggestions/suggest-deref-in-match-issue-132784.stderr
@@ -21,7 +21,14 @@ LL |     match x {
    |           - this expression has type `Arc<Option<{integer}>>`
 ...
 LL |         None => {}
-   |         ^^^^ expected `Arc<Option<{integer}>>`, found `Option<_>`
+   |         ^^^^
+   |         |
+   |         expected `Arc<Option<{integer}>>`, found `Option<_>`
+   |         `None` is interpreted as a unit variant, not a new binding
+   |
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   |
+   = note: unit variant defined here
    |
    = note: expected struct `Arc<Option<{integer}>>`
                 found enum `Option<_>`
@@ -29,9 +36,14 @@ help: consider dereferencing to access the inner value using the Deref trait
    |
 LL |     match *x {
    |           +
+help: introduce a new binding instead
+   |
+LL -         None => {}
+LL +         other_none => {}
+   |
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:16:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:17:9
    |
 LL |     match &x {
    |           -- this expression has type `&Arc<Option<{integer}>>`
@@ -47,13 +59,20 @@ LL |     match &*x {
    |            +
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:18:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:19:9
    |
 LL |     match &x {
    |           -- this expression has type `&Arc<Option<{integer}>>`
 ...
 LL |         None => {}
-   |         ^^^^ expected `Arc<Option<{integer}>>`, found `Option<_>`
+   |         ^^^^
+   |         |
+   |         expected `Arc<Option<{integer}>>`, found `Option<_>`
+   |         `None` is interpreted as a unit variant, not a new binding
+   |
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   |
+   = note: unit variant defined here
    |
    = note: expected struct `Arc<Option<{integer}>>`
                 found enum `Option<_>`
@@ -61,9 +80,14 @@ help: consider dereferencing to access the inner value using the Deref trait
    |
 LL |     match &*x {
    |            +
+help: introduce a new binding instead
+   |
+LL -         None => {}
+LL +         other_none => {}
+   |
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:26:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:28:9
    |
 LL |     match y {
    |           - this expression has type `Box<Option<{integer}>>`
@@ -79,13 +103,20 @@ LL |     match *y {
    |           +
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:28:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:30:9
    |
 LL |     match y {
    |           - this expression has type `Box<Option<{integer}>>`
 ...
 LL |         None => {}
-   |         ^^^^ expected `Box<Option<{integer}>>`, found `Option<_>`
+   |         ^^^^
+   |         |
+   |         expected `Box<Option<{integer}>>`, found `Option<_>`
+   |         `None` is interpreted as a unit variant, not a new binding
+   |
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   |
+   = note: unit variant defined here
    |
    = note: expected struct `Box<Option<{integer}>>`
                 found enum `Option<_>`
@@ -93,9 +124,14 @@ help: consider dereferencing to access the inner value using the Deref trait
    |
 LL |     match *y {
    |           +
+help: introduce a new binding instead
+   |
+LL -         None => {}
+LL +         other_none => {}
+   |
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:36:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:39:9
    |
 LL |     match z as Arc<Option<i32>> {
    |           --------------------- this expression has type `Arc<Option<i32>>`
@@ -112,13 +148,20 @@ LL +     match *(z as Arc<Option<i32>>) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:38:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:41:9
    |
 LL |     match z as Arc<Option<i32>> {
    |           --------------------- this expression has type `Arc<Option<i32>>`
 ...
 LL |         None => {}
-   |         ^^^^ expected `Arc<Option<i32>>`, found `Option<_>`
+   |         ^^^^
+   |         |
+   |         expected `Arc<Option<i32>>`, found `Option<_>`
+   |         `None` is interpreted as a unit variant, not a new binding
+   |
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   |
+   = note: unit variant defined here
    |
    = note: expected struct `Arc<Option<i32>>`
                 found enum `Option<_>`
@@ -127,9 +170,14 @@ help: consider dereferencing to access the inner value using the Deref trait
 LL -     match z as Arc<Option<i32>> {
 LL +     match *(z as Arc<Option<i32>>) {
    |
+help: introduce a new binding instead
+   |
+LL -         None => {}
+LL +         other_none => {}
+   |
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:46:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:50:9
    |
 LL |     match z_const {
    |           ------- this expression has type `&Arc<Option<i32>>`
@@ -145,13 +193,20 @@ LL |     match &**z_const {
    |           +++
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:48:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:52:9
    |
 LL |     match z_const {
    |           ------- this expression has type `&Arc<Option<i32>>`
 ...
 LL |         None => {}
-   |         ^^^^ expected `Arc<Option<i32>>`, found `Option<_>`
+   |         ^^^^
+   |         |
+   |         expected `Arc<Option<i32>>`, found `Option<_>`
+   |         `None` is interpreted as a unit variant, not a new binding
+   |
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   |
+   = note: unit variant defined here
    |
    = note: expected struct `Arc<Option<i32>>`
                 found enum `Option<_>`
@@ -159,9 +214,14 @@ help: consider dereferencing to access the inner value using the Deref trait
    |
 LL |     match &**z_const {
    |           +++
+help: introduce a new binding instead
+   |
+LL -         None => {}
+LL +         other_none => {}
+   |
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:57:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:62:9
    |
 LL |     match z_mut {
    |           ----- this expression has type `&mut Arc<Option<i32>>`
@@ -177,13 +237,20 @@ LL |     match &**z_mut {
    |           +++
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:59:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:64:9
    |
 LL |     match z_mut {
    |           ----- this expression has type `&mut Arc<Option<i32>>`
 ...
 LL |         None => {}
-   |         ^^^^ expected `Arc<Option<i32>>`, found `Option<_>`
+   |         ^^^^
+   |         |
+   |         expected `Arc<Option<i32>>`, found `Option<_>`
+   |         `None` is interpreted as a unit variant, not a new binding
+   |
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   |
+   = note: unit variant defined here
    |
    = note: expected struct `Arc<Option<i32>>`
                 found enum `Option<_>`
@@ -191,9 +258,14 @@ help: consider dereferencing to access the inner value using the Deref trait
    |
 LL |     match &**z_mut {
    |           +++
+help: introduce a new binding instead
+   |
+LL -         None => {}
+LL +         other_none => {}
+   |
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:68:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:74:9
    |
 LL |     match y_mut {
    |           ----- this expression has type `&mut Box<Option<i32>>`
@@ -209,13 +281,20 @@ LL |     match &**y_mut {
    |           +++
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:70:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:76:9
    |
 LL |     match y_mut {
    |           ----- this expression has type `&mut Box<Option<i32>>`
 ...
 LL |         None => {}
-   |         ^^^^ expected `Box<Option<i32>>`, found `Option<_>`
+   |         ^^^^
+   |         |
+   |         expected `Box<Option<i32>>`, found `Option<_>`
+   |         `None` is interpreted as a unit variant, not a new binding
+   |
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   |
+   = note: unit variant defined here
    |
    = note: expected struct `Box<Option<i32>>`
                 found enum `Option<_>`
@@ -223,9 +302,14 @@ help: consider dereferencing to access the inner value using the Deref trait
    |
 LL |     match &**y_mut {
    |           +++
+help: introduce a new binding instead
+   |
+LL -         None => {}
+LL +         other_none => {}
+   |
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:79:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:86:9
    |
 LL |     match (& (&difficult)  ) {
    |           ------------------ this expression has type `&&Arc<Option<{integer}>>`
@@ -242,13 +326,20 @@ LL +     match &*difficult {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:81:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:88:9
    |
 LL |     match (& (&difficult)  ) {
    |           ------------------ this expression has type `&&Arc<Option<{integer}>>`
 ...
 LL |         None => {}
-   |         ^^^^ expected `Arc<Option<{integer}>>`, found `Option<_>`
+   |         ^^^^
+   |         |
+   |         expected `Arc<Option<{integer}>>`, found `Option<_>`
+   |         `None` is interpreted as a unit variant, not a new binding
+   |
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   |
+   = note: unit variant defined here
    |
    = note: expected struct `Arc<Option<{integer}>>`
                 found enum `Option<_>`
@@ -256,6 +347,11 @@ help: consider dereferencing to access the inner value using the Deref trait
    |
 LL -     match (& (&difficult)  ) {
 LL +     match &*difficult {
+   |
+help: introduce a new binding instead
+   |
+LL -         None => {}
+LL +         other_none => {}
    |
 
 error: aborting due to 16 previous errors

--- a/tests/ui/suggestions/suggest-deref-in-match-issue-132784.stderr
+++ b/tests/ui/suggestions/suggest-deref-in-match-issue-132784.stderr
@@ -21,14 +21,7 @@ LL |     match x {
    |           - this expression has type `Arc<Option<{integer}>>`
 ...
 LL |         None => {}
-   |         ^^^^
-   |         |
-   |         expected `Arc<Option<{integer}>>`, found `Option<_>`
-   |         `None` is interpreted as a unit variant, not a new binding
-   |
-  --> $SRC_DIR/core/src/option.rs:LL:COL
-   |
-   = note: unit variant defined here
+   |         ^^^^ expected `Arc<Option<{integer}>>`, found `Option<_>`
    |
    = note: expected struct `Arc<Option<{integer}>>`
                 found enum `Option<_>`
@@ -36,14 +29,9 @@ help: consider dereferencing to access the inner value using the Deref trait
    |
 LL |     match *x {
    |           +
-help: introduce a new binding instead
-   |
-LL -         None => {}
-LL +         other_none => {}
-   |
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:17:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:16:9
    |
 LL |     match &x {
    |           -- this expression has type `&Arc<Option<{integer}>>`
@@ -59,20 +47,13 @@ LL |     match &*x {
    |            +
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:19:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:18:9
    |
 LL |     match &x {
    |           -- this expression has type `&Arc<Option<{integer}>>`
 ...
 LL |         None => {}
-   |         ^^^^
-   |         |
-   |         expected `Arc<Option<{integer}>>`, found `Option<_>`
-   |         `None` is interpreted as a unit variant, not a new binding
-   |
-  --> $SRC_DIR/core/src/option.rs:LL:COL
-   |
-   = note: unit variant defined here
+   |         ^^^^ expected `Arc<Option<{integer}>>`, found `Option<_>`
    |
    = note: expected struct `Arc<Option<{integer}>>`
                 found enum `Option<_>`
@@ -80,14 +61,9 @@ help: consider dereferencing to access the inner value using the Deref trait
    |
 LL |     match &*x {
    |            +
-help: introduce a new binding instead
-   |
-LL -         None => {}
-LL +         other_none => {}
-   |
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:28:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:26:9
    |
 LL |     match y {
    |           - this expression has type `Box<Option<{integer}>>`
@@ -103,20 +79,13 @@ LL |     match *y {
    |           +
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:30:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:28:9
    |
 LL |     match y {
    |           - this expression has type `Box<Option<{integer}>>`
 ...
 LL |         None => {}
-   |         ^^^^
-   |         |
-   |         expected `Box<Option<{integer}>>`, found `Option<_>`
-   |         `None` is interpreted as a unit variant, not a new binding
-   |
-  --> $SRC_DIR/core/src/option.rs:LL:COL
-   |
-   = note: unit variant defined here
+   |         ^^^^ expected `Box<Option<{integer}>>`, found `Option<_>`
    |
    = note: expected struct `Box<Option<{integer}>>`
                 found enum `Option<_>`
@@ -124,14 +93,9 @@ help: consider dereferencing to access the inner value using the Deref trait
    |
 LL |     match *y {
    |           +
-help: introduce a new binding instead
-   |
-LL -         None => {}
-LL +         other_none => {}
-   |
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:39:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:36:9
    |
 LL |     match z as Arc<Option<i32>> {
    |           --------------------- this expression has type `Arc<Option<i32>>`
@@ -148,20 +112,13 @@ LL +     match *(z as Arc<Option<i32>>) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:41:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:38:9
    |
 LL |     match z as Arc<Option<i32>> {
    |           --------------------- this expression has type `Arc<Option<i32>>`
 ...
 LL |         None => {}
-   |         ^^^^
-   |         |
-   |         expected `Arc<Option<i32>>`, found `Option<_>`
-   |         `None` is interpreted as a unit variant, not a new binding
-   |
-  --> $SRC_DIR/core/src/option.rs:LL:COL
-   |
-   = note: unit variant defined here
+   |         ^^^^ expected `Arc<Option<i32>>`, found `Option<_>`
    |
    = note: expected struct `Arc<Option<i32>>`
                 found enum `Option<_>`
@@ -170,14 +127,9 @@ help: consider dereferencing to access the inner value using the Deref trait
 LL -     match z as Arc<Option<i32>> {
 LL +     match *(z as Arc<Option<i32>>) {
    |
-help: introduce a new binding instead
-   |
-LL -         None => {}
-LL +         other_none => {}
-   |
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:50:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:46:9
    |
 LL |     match z_const {
    |           ------- this expression has type `&Arc<Option<i32>>`
@@ -193,20 +145,13 @@ LL |     match &**z_const {
    |           +++
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:52:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:48:9
    |
 LL |     match z_const {
    |           ------- this expression has type `&Arc<Option<i32>>`
 ...
 LL |         None => {}
-   |         ^^^^
-   |         |
-   |         expected `Arc<Option<i32>>`, found `Option<_>`
-   |         `None` is interpreted as a unit variant, not a new binding
-   |
-  --> $SRC_DIR/core/src/option.rs:LL:COL
-   |
-   = note: unit variant defined here
+   |         ^^^^ expected `Arc<Option<i32>>`, found `Option<_>`
    |
    = note: expected struct `Arc<Option<i32>>`
                 found enum `Option<_>`
@@ -214,14 +159,9 @@ help: consider dereferencing to access the inner value using the Deref trait
    |
 LL |     match &**z_const {
    |           +++
-help: introduce a new binding instead
-   |
-LL -         None => {}
-LL +         other_none => {}
-   |
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:62:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:57:9
    |
 LL |     match z_mut {
    |           ----- this expression has type `&mut Arc<Option<i32>>`
@@ -237,20 +177,13 @@ LL |     match &**z_mut {
    |           +++
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:64:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:59:9
    |
 LL |     match z_mut {
    |           ----- this expression has type `&mut Arc<Option<i32>>`
 ...
 LL |         None => {}
-   |         ^^^^
-   |         |
-   |         expected `Arc<Option<i32>>`, found `Option<_>`
-   |         `None` is interpreted as a unit variant, not a new binding
-   |
-  --> $SRC_DIR/core/src/option.rs:LL:COL
-   |
-   = note: unit variant defined here
+   |         ^^^^ expected `Arc<Option<i32>>`, found `Option<_>`
    |
    = note: expected struct `Arc<Option<i32>>`
                 found enum `Option<_>`
@@ -258,14 +191,9 @@ help: consider dereferencing to access the inner value using the Deref trait
    |
 LL |     match &**z_mut {
    |           +++
-help: introduce a new binding instead
-   |
-LL -         None => {}
-LL +         other_none => {}
-   |
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:74:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:68:9
    |
 LL |     match y_mut {
    |           ----- this expression has type `&mut Box<Option<i32>>`
@@ -281,20 +209,13 @@ LL |     match &**y_mut {
    |           +++
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:76:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:70:9
    |
 LL |     match y_mut {
    |           ----- this expression has type `&mut Box<Option<i32>>`
 ...
 LL |         None => {}
-   |         ^^^^
-   |         |
-   |         expected `Box<Option<i32>>`, found `Option<_>`
-   |         `None` is interpreted as a unit variant, not a new binding
-   |
-  --> $SRC_DIR/core/src/option.rs:LL:COL
-   |
-   = note: unit variant defined here
+   |         ^^^^ expected `Box<Option<i32>>`, found `Option<_>`
    |
    = note: expected struct `Box<Option<i32>>`
                 found enum `Option<_>`
@@ -302,14 +223,9 @@ help: consider dereferencing to access the inner value using the Deref trait
    |
 LL |     match &**y_mut {
    |           +++
-help: introduce a new binding instead
-   |
-LL -         None => {}
-LL +         other_none => {}
-   |
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:86:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:79:9
    |
 LL |     match (& (&difficult)  ) {
    |           ------------------ this expression has type `&&Arc<Option<{integer}>>`
@@ -326,20 +242,13 @@ LL +     match &*difficult {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/suggest-deref-in-match-issue-132784.rs:88:9
+  --> $DIR/suggest-deref-in-match-issue-132784.rs:81:9
    |
 LL |     match (& (&difficult)  ) {
    |           ------------------ this expression has type `&&Arc<Option<{integer}>>`
 ...
 LL |         None => {}
-   |         ^^^^
-   |         |
-   |         expected `Arc<Option<{integer}>>`, found `Option<_>`
-   |         `None` is interpreted as a unit variant, not a new binding
-   |
-  --> $SRC_DIR/core/src/option.rs:LL:COL
-   |
-   = note: unit variant defined here
+   |         ^^^^ expected `Arc<Option<{integer}>>`, found `Option<_>`
    |
    = note: expected struct `Arc<Option<{integer}>>`
                 found enum `Option<_>`
@@ -347,11 +256,6 @@ help: consider dereferencing to access the inner value using the Deref trait
    |
 LL -     match (& (&difficult)  ) {
 LL +     match &*difficult {
-   |
-help: introduce a new binding instead
-   |
-LL -         None => {}
-LL +         other_none => {}
    |
 
 error: aborting due to 16 previous errors

--- a/tests/ui/target-feature/invalid-attribute.rs
+++ b/tests/ui/target-feature/invalid-attribute.rs
@@ -119,7 +119,12 @@ fn main() {
 //~| NOTE `+sse2` is not valid for this target
 unsafe fn hey() {}
 
-#[target_feature(enable = "+sse5")]
-//~^ ERROR `+sse5` is not valid for this target
-//~| NOTE `+sse5` is not valid for this target
-unsafe fn typo() {}
+#[target_feature(enable = "sse5")]
+//~^ ERROR `sse5` is not valid for this target
+//~| NOTE `sse5` is not valid for this target
+unsafe fn typo_sse() {}
+
+#[target_feature(enable = "avx512")]
+//~^ ERROR `avx512` is not valid for this target
+//~| NOTE `avx512` is not valid for this target
+unsafe fn typo_avx512() {}

--- a/tests/ui/target-feature/invalid-attribute.stderr
+++ b/tests/ui/target-feature/invalid-attribute.stderr
@@ -160,6 +160,8 @@ error: the feature named `foo` is not valid for this target
    |
 LL | #[target_feature(enable = "foo")]
    |                  ^^^^^^^^^^^^^^ `foo` is not valid for this target
+   |
+   = help: valid names are: `fma`, `xop`, `adx`, `aes`, and `avx` and 74 more
 
 error[E0046]: not all trait items implemented, missing: `foo`
   --> $DIR/invalid-attribute.rs:81:1
@@ -205,13 +207,23 @@ LL - #[target_feature(enable = "+sse2")]
 LL + #[target_feature(enable = "sse2")]
    |
 
-error: the feature named `+sse5` is not valid for this target
+error: the feature named `sse5` is not valid for this target
   --> $DIR/invalid-attribute.rs:122:18
    |
-LL | #[target_feature(enable = "+sse5")]
-   |                  ^^^^^^^^^^^^^^^^ `+sse5` is not valid for this target
+LL | #[target_feature(enable = "sse5")]
+   |                  ^^^^^^^^^^^^^^^ `sse5` is not valid for this target
+   |
+   = help: valid names are: `sse`, `sse2`, `sse3`, `sse4a`, and `ssse3` and 74 more
 
-error: aborting due to 25 previous errors
+error: the feature named `avx512` is not valid for this target
+  --> $DIR/invalid-attribute.rs:127:18
+   |
+LL | #[target_feature(enable = "avx512")]
+   |                  ^^^^^^^^^^^^^^^^^ `avx512` is not valid for this target
+   |
+   = help: valid names are: `avx512f`, `avx2`, `avx512bw`, `avx512cd`, and `avx512dq` and 74 more
+
+error: aborting due to 26 previous errors
 
 Some errors have detailed explanations: E0046, E0053, E0539, E0658.
 For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/type-alias/lack-of-wfcheck.rs
+++ b/tests/ui/type-alias/lack-of-wfcheck.rs
@@ -1,0 +1,27 @@
+// Demonstrate that we don't check the definition site of (eager) type aliases for well-formedness.
+//
+// Listed below are ill-formed type system entities which we don't reject since they appear inside
+// the definition of (eager) type aliases. These type aliases are intentionally not referenced from
+// anywhere to prevent the eagerly expanded / instantiated aliased types from getting wfchecked
+// since that's not what we're testing here.
+
+//@ check-pass
+
+type UnsatTraitBound0 = [str]; // `str: Sized` unsatisfied
+type UnsatTraitBound1<T = Vec<str>> = T; // `str: Sized` unsatisfied
+type UnsatOutlivesBound<'a> = &'static &'a (); // `'a: 'static` unsatisfied
+
+type Diverging = [(); panic!()]; // `panic!()` diverging
+
+type DynIncompat0 = dyn Sized; // `Sized` axiomatically dyn incompatible
+// issue: <https://github.com/rust-lang/rust/issues/153731>
+type DynIncompat1 = dyn HasAssocConst; // dyn incompatible due to (non-type-level) assoc const
+
+// * dyn incompatible due to GAT
+// * `'a: 'static`, `String: Copy` and `[u8]: Sized` unsatisfied, `loop {}` diverging
+type Several<'a> = dyn HasGenericAssocType<Type<'a, String, { loop {} }> = [u8]>;
+
+trait HasAssocConst { const N: usize; }
+trait HasGenericAssocType { type Type<'a: 'static, T: Copy, const N: usize>; }
+
+fn main() {}

--- a/tests/ui/type/pattern_types/matching_fail.stderr
+++ b/tests/ui/type/pattern_types/matching_fail.stderr
@@ -33,10 +33,14 @@ LL |     THREE => {}
    |     |
    |     expected integer, found `(u32) is 1..`
    |     `THREE` is interpreted as a constant, not a new binding
-   |     help: introduce a new binding instead: `other_three`
    |
    = note:      expected type `{integer}`
            found pattern type `(u32) is 1..`
+help: introduce a new binding instead
+   |
+LL -     THREE => {}
+LL +     other_three => {}
+   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/wf/issue-87495.stderr
+++ b/tests/ui/wf/issue-87495.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `T` is not dyn compatible
-  --> $DIR/issue-87495.rs:4:29
+  --> $DIR/issue-87495.rs:4:25
    |
 LL |     const CONST: (bool, dyn T);
-   |                             ^ `T` is not dyn compatible
+   |                         ^^^^^ `T` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
@@ -13,6 +13,11 @@ LL | trait T {
 LL |     const CONST: (bool, dyn T);
    |           ^^^^^ ...because it contains associated const `CONST`
    = help: consider moving `CONST` to another trait
+help: you might have meant to use `Self` to refer to the implementing type
+   |
+LL -     const CONST: (bool, dyn T);
+LL +     const CONST: (bool, Self);
+   |
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#153966 (suggest valid features when target feature is invalid)
 - rust-lang/rust#153372 (Fix LegacyKeyValueFormat report from docker build: x86_64-gnu)
 - rust-lang/rust#153709 (Fix hypothetical ICE in `variances_of`)
 - rust-lang/rust#153738 (Don't look for non-type-level assoc consts when checking trait object types)
 - rust-lang/rust#153894 (Point at unit structs on foreign crates in type errors when they are the pattern of a binding)
 - rust-lang/rust#153921 (Suppress self-referential associated type constraint suggestion)

Failed merges:

 - rust-lang/rust#153907 (Remove redundant fields from `QueryStackFrame`)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=153966,153372,153709,153738,153894,153907,153921)
<!-- homu-ignore:end -->

