### PR TITLE
Flatten control-flow in `DepGraph::with_feed_task`

### DIFF
--- a/compiler/rustc_middle/src/dep_graph/graph.rs
+++ b/compiler/rustc_middle/src/dep_graph/graph.rs
@@ -572,13 +572,13 @@ impl DepGraph {
     /// FIXME: If the code is changed enough for this node to be marked before requiring the
     /// caller's node, we suppose that those changes will be enough to mark this node red and
     /// force a recomputation using the "normal" way.
-    pub fn with_feed_task<'tcx, R>(
+    pub(crate) fn with_feed_task<'tcx, V>(
         &self,
-        node: DepNode,
         tcx: TyCtxt<'tcx>,
-        result: &R,
-        hash_result: Option<fn(&mut StableHashingContext<'_>, &R) -> Fingerprint>,
-        format_value_fn: fn(&R) -> String,
+        node: DepNode,
+        value: &V,
+        hash_value_fn: Option<fn(&mut StableHashingContext<'_>, &V) -> Fingerprint>,
+        format_value_fn: fn(&V) -> String,
     ) -> DepNodeIndex {
         let Some(data) = self.data() else {
             // Incremental compilation is turned off. We just execute the task
@@ -597,10 +597,10 @@ impl DepGraph {
         if let Some(prev_index) = data.previous.node_to_index_opt(&node)
             && let Some(dep_node_index) = data.colors.current(prev_index)
         {
-            incremental_verify_ich(tcx, data, result, prev_index, hash_result, format_value_fn);
+            incremental_verify_ich(tcx, data, value, prev_index, hash_value_fn, format_value_fn);
 
             #[cfg(debug_assertions)]
-            if hash_result.is_some() {
+            if hash_value_fn.is_some() {
                 data.current.record_edge(
                     dep_node_index,
                     node,
@@ -621,7 +621,7 @@ impl DepGraph {
             TaskDepsRef::Forbid => panic!("Tried to feed while dependencies are forbidden"),
         });
 
-        data.hash_result_and_alloc_node(tcx, node, edges, result, hash_result)
+        data.hash_result_and_alloc_node(tcx, node, edges, value, hash_value_fn)
     }
 }
 

--- a/compiler/rustc_middle/src/dep_graph/graph.rs
+++ b/compiler/rustc_middle/src/dep_graph/graph.rs
@@ -580,58 +580,48 @@ impl DepGraph {
         hash_result: Option<fn(&mut StableHashingContext<'_>, &R) -> Fingerprint>,
         format_value_fn: fn(&R) -> String,
     ) -> DepNodeIndex {
-        if let Some(data) = self.data.as_ref() {
-            // The caller query has more dependencies than the node we are creating. We may
-            // encounter a case where this created node is marked as green, but the caller query is
-            // subsequently marked as red or recomputed. In this case, we will end up feeding a
-            // value to an existing node.
-            //
-            // For sanity, we still check that the loaded stable hash and the new one match.
-            if let Some(prev_index) = data.previous.node_to_index_opt(&node) {
-                let dep_node_index = data.colors.current(prev_index);
-                if let Some(dep_node_index) = dep_node_index {
-                    incremental_verify_ich(
-                        tcx,
-                        data,
-                        result,
-                        prev_index,
-                        hash_result,
-                        format_value_fn,
-                    );
-
-                    #[cfg(debug_assertions)]
-                    if hash_result.is_some() {
-                        data.current.record_edge(
-                            dep_node_index,
-                            node,
-                            data.prev_value_fingerprint_of(prev_index),
-                        );
-                    }
-
-                    return dep_node_index;
-                }
-            }
-
-            let mut edges = EdgesVec::new();
-            read_deps(|task_deps| match task_deps {
-                TaskDepsRef::Allow(deps) => edges.extend(deps.lock().reads.iter().copied()),
-                TaskDepsRef::EvalAlways => {
-                    edges.push(DepNodeIndex::FOREVER_RED_NODE);
-                }
-                TaskDepsRef::Ignore => {}
-                TaskDepsRef::Forbid => {
-                    panic!("Cannot summarize when dependencies are not recorded.")
-                }
-            });
-
-            data.hash_result_and_alloc_node(tcx, node, edges, result, hash_result)
-        } else {
+        let Some(data) = self.data() else {
             // Incremental compilation is turned off. We just execute the task
             // without tracking. We still provide a dep-node index that uniquely
             // identifies the task so that we have a cheap way of referring to
             // the query for self-profiling.
-            self.next_virtual_depnode_index()
+            return self.next_virtual_depnode_index();
+        };
+
+        // The caller query has more dependencies than the node we are creating. We may
+        // encounter a case where this created node is marked as green, but the caller query is
+        // subsequently marked as red or recomputed. In this case, we will end up feeding a
+        // value to an existing node.
+        //
+        // For sanity, we still check that the loaded stable hash and the new one match.
+        if let Some(prev_index) = data.previous.node_to_index_opt(&node)
+            && let Some(dep_node_index) = data.colors.current(prev_index)
+        {
+            incremental_verify_ich(tcx, data, result, prev_index, hash_result, format_value_fn);
+
+            #[cfg(debug_assertions)]
+            if hash_result.is_some() {
+                data.current.record_edge(
+                    dep_node_index,
+                    node,
+                    data.prev_value_fingerprint_of(prev_index),
+                );
+            }
+
+            return dep_node_index;
         }
+
+        // Incr-comp is enabled, and there isn't a pre-existing node, so create one.
+        // Its dependencies are a clone of the enclosing query job's dependencies so far.
+        let mut edges = EdgesVec::new();
+        read_deps(|task_deps| match task_deps {
+            TaskDepsRef::Allow(deps) => edges.extend(deps.lock().reads.iter().copied()),
+            TaskDepsRef::EvalAlways => edges.push(DepNodeIndex::FOREVER_RED_NODE),
+            TaskDepsRef::Ignore => {}
+            TaskDepsRef::Forbid => panic!("Tried to feed while dependencies are forbidden"),
+        });
+
+        data.hash_result_and_alloc_node(tcx, node, edges, result, hash_result)
     }
 }
 

--- a/compiler/rustc_middle/src/query/inner.rs
+++ b/compiler/rustc_middle/src/query/inner.rs
@@ -148,8 +148,8 @@ pub(crate) fn query_feed<'tcx, C>(
             // adding the provided value to the cache.
             let dep_node = dep_graph::DepNode::construct(tcx, query.dep_kind, &key);
             let dep_node_index = tcx.dep_graph.with_feed_task(
-                dep_node,
                 tcx,
+                dep_node,
                 &value,
                 query.hash_value_fn,
                 query.format_value,


### PR DESCRIPTION
- Flatten the simpler non-incremental case into an early return
- Flatten a nested if-let into a let-chain
- Collapse some single-line match arms

A second commit also renames query "result" to query "value" in this method, to be more consistent with how query caches and vtables refer to a query's return value.

Hopefully the result should be nicer to read.

r? nnethercote (or compiler)