### PR TITLE
Use closures more consistently in `dep_graph.rs`.

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/driver/aot.rs
+++ b/compiler/rustc_codegen_cranelift/src/driver/aot.rs
@@ -380,11 +380,9 @@ fn codegen_cgu_content(
 
 fn module_codegen(
     tcx: TyCtxt<'_>,
-    (global_asm_config, cgu_name, token): (
-        Arc<GlobalAsmConfig>,
-        rustc_span::Symbol,
-        ConcurrencyLimiterToken,
-    ),
+    global_asm_config: Arc<GlobalAsmConfig>,
+    cgu_name: rustc_span::Symbol,
+    token: ConcurrencyLimiterToken,
 ) -> OngoingModuleCodegen {
     let mut module = make_module(tcx.sess, cgu_name.as_str().to_string());
 
@@ -513,8 +511,14 @@ pub(crate) fn run_aot(tcx: TyCtxt<'_>) -> Box<OngoingCodegen> {
                 let (module, _) = tcx.dep_graph.with_task(
                     dep_node,
                     tcx,
-                    (global_asm_config.clone(), cgu.name(), concurrency_limiter.acquire(tcx.dcx())),
-                    module_codegen,
+                    || {
+                        module_codegen(
+                            tcx,
+                            global_asm_config.clone(),
+                            cgu.name(),
+                            concurrency_limiter.acquire(tcx.dcx()),
+                        )
+                    },
                     Some(rustc_middle::dep_graph::hash_result),
                 );
                 IntoDynSyncSend(module)

--- a/compiler/rustc_codegen_gcc/src/base.rs
+++ b/compiler/rustc_codegen_gcc/src/base.rs
@@ -83,8 +83,7 @@ pub fn compile_codegen_unit(
     let (module, _) = tcx.dep_graph.with_task(
         dep_node,
         tcx,
-        (cgu_name, target_info, lto_supported),
-        module_codegen,
+        || module_codegen(tcx, cgu_name, target_info, lto_supported),
         Some(dep_graph::hash_result),
     );
     let time_to_codegen = start_time.elapsed();
@@ -96,7 +95,9 @@ pub fn compile_codegen_unit(
 
     fn module_codegen(
         tcx: TyCtxt<'_>,
-        (cgu_name, target_info, lto_supported): (Symbol, LockedTargetInfo, bool),
+        cgu_name: Symbol,
+        target_info: LockedTargetInfo,
+        lto_supported: bool,
     ) -> ModuleCodegen<GccContext> {
         let cgu = tcx.codegen_unit(cgu_name);
         // Instantiate monomorphizations without filling out definitions yet...

--- a/compiler/rustc_codegen_llvm/src/base.rs
+++ b/compiler/rustc_codegen_llvm/src/base.rs
@@ -65,8 +65,7 @@ pub(crate) fn compile_codegen_unit(
     let (module, _) = tcx.dep_graph.with_task(
         dep_node,
         tcx,
-        cgu_name,
-        module_codegen,
+        || module_codegen(tcx, cgu_name),
         Some(dep_graph::hash_result),
     );
     let time_to_codegen = start_time.elapsed();

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -2474,8 +2474,7 @@ pub fn encode_metadata(tcx: TyCtxt<'_>, path: &Path, ref_path: Option<&Path>) {
     tcx.dep_graph.with_task(
         dep_node,
         tcx,
-        path,
-        |tcx, path| {
+        || {
             with_encode_metadata_header(tcx, path, |ecx| {
                 // Encode all the entries and extra information in the crate,
                 // culminating in the `CrateRoot` which points to all of it.

--- a/compiler/rustc_middle/src/dep_graph/graph.rs
+++ b/compiler/rustc_middle/src/dep_graph/graph.rs
@@ -52,6 +52,7 @@ pub enum QuerySideEffect {
     /// the side effect dep node as a dependency.
     CheckFeature { symbol: Symbol },
 }
+
 #[derive(Clone)]
 pub struct DepGraph {
     data: Option<Arc<DepGraphData>>,
@@ -277,17 +278,19 @@ impl DepGraph {
     }
 
     #[inline(always)]
-    pub fn with_task<'tcx, A: Debug, R>(
+    pub fn with_task<'tcx, OP, R>(
         &self,
         dep_node: DepNode,
         tcx: TyCtxt<'tcx>,
-        task_arg: A,
-        task_fn: fn(tcx: TyCtxt<'tcx>, task_arg: A) -> R,
+        op: OP,
         hash_result: Option<fn(&mut StableHashingContext<'_>, &R) -> Fingerprint>,
-    ) -> (R, DepNodeIndex) {
+    ) -> (R, DepNodeIndex)
+    where
+        OP: FnOnce() -> R,
+    {
         match self.data() {
-            Some(data) => data.with_task(dep_node, tcx, task_arg, task_fn, hash_result),
-            None => (task_fn(tcx, task_arg), self.next_virtual_depnode_index()),
+            Some(data) => data.with_task(dep_node, tcx, op, hash_result),
+            None => (op(), self.next_virtual_depnode_index()),
         }
     }
 
@@ -312,44 +315,27 @@ impl DepGraph {
 }
 
 impl DepGraphData {
-    /// Starts a new dep-graph task. Dep-graph tasks are specified
-    /// using a free function (`task`) and **not** a closure -- this
-    /// is intentional because we want to exercise tight control over
-    /// what state they have access to. In particular, we want to
-    /// prevent implicit 'leaks' of tracked state into the task (which
-    /// could then be read without generating correct edges in the
-    /// dep-graph -- see the [rustc dev guide] for more details on
-    /// the dep-graph).
-    ///
-    /// Therefore, the task function takes a `TyCtxt`, plus exactly one
-    /// additional argument, `task_arg`. The additional argument type can be
-    /// `()` if no argument is needed, or a tuple if multiple arguments are
-    /// needed.
-    ///
-    /// [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/queries/incremental-compilation.html
     #[inline(always)]
-    pub fn with_task<'tcx, A: Debug, R>(
+    pub fn with_task<'tcx, OP, R>(
         &self,
         dep_node: DepNode,
         tcx: TyCtxt<'tcx>,
-        task_arg: A,
-        task_fn: fn(tcx: TyCtxt<'tcx>, task_arg: A) -> R,
+        op: OP,
         hash_result: Option<fn(&mut StableHashingContext<'_>, &R) -> Fingerprint>,
-    ) -> (R, DepNodeIndex) {
+    ) -> (R, DepNodeIndex)
+    where
+        OP: FnOnce() -> R,
+    {
         // If the following assertion triggers, it can have two reasons:
         // 1. Something is wrong with DepNode creation, either here or
         //    in `DepGraph::try_mark_green()`.
         // 2. Two distinct query keys get mapped to the same `DepNode`
         //    (see for example #48923).
         self.assert_dep_node_not_yet_allocated_in_current_session(tcx.sess, &dep_node, || {
-            format!(
-                "forcing query with already existing `DepNode`\n\
-                 - query-key: {task_arg:?}\n\
-                 - dep-node: {dep_node:?}"
-            )
+            format!("forcing query with already existing `DepNode`: {dep_node:?}")
         });
 
-        let with_deps = |task_deps| with_deps(task_deps, || task_fn(tcx, task_arg));
+        let with_deps = |task_deps| with_deps(task_deps, op);
         let (result, edges) = if tcx.is_eval_always(dep_node.kind) {
             (with_deps(TaskDepsRef::EvalAlways), EdgesVec::new())
         } else {

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -447,8 +447,7 @@ fn execute_job_incr<'tcx, C: QueryCache>(
         dep_graph_data.with_task(
             dep_node,
             tcx,
-            (query, key),
-            |tcx, (query, key)| (query.invoke_provider_fn)(tcx, key),
+            || (query.invoke_provider_fn)(tcx, key),
             query.hash_value_fn,
         )
     });


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/153997)*
<!-- homu-ignore:end -->

This file has several methods that take a `FnOnce() -> R` closure:
- `DepGraph::with_ignore`
- `DepGraph::with_query_deserialization`
- `DepGraph::with_anon_task`
- `DepGraphData::with_anon_task_inner`

It also has two methods that take a faux closure via an `A` argument and a `fn(TyCtxt<'tcx>, A) -> R` argument:
- DepGraph::with_task
- DepGraphData::with_task

The rationale is that the faux closure exercises tight control over what state they have access to. This seems silly when (a) they are passed a `TyCtxt`, and (b) when similar nearby functions take real closures. And they are more awkward to use, e.g. requiring multiple arguments to be gathered into a tuple. This commit changes the faux closures to real closures.

r? @Zalathar