### PR TITLE
Remove `TaggedQueryKey::def_kind`

### DIFF
--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -448,30 +448,6 @@ macro_rules! define_callbacks {
                     )*
                 }
             }
-
-            pub fn def_kind(&self, tcx: TyCtxt<'tcx>) -> Option<DefKind> {
-                // This is used to reduce code generation as it
-                // can be reused for queries with the same key type.
-                fn inner<'tcx>(key: &impl $crate::query::QueryKey, tcx: TyCtxt<'tcx>)
-                    -> Option<DefKind>
-                {
-                    key
-                        .key_as_def_id()
-                        .and_then(|def_id| def_id.as_local())
-                        .map(|def_id| tcx.def_kind(def_id))
-                }
-
-                if let TaggedQueryKey::def_kind(..) = self {
-                    // Try to avoid infinite recursion.
-                    return None
-                }
-
-                match self {
-                    $(
-                        TaggedQueryKey::$name(key) => inner(key, tcx),
-                    )*
-                }
-            }
         }
 
         /// Holds a `QueryVTable` for each query.

--- a/compiler/rustc_query_impl/src/job.rs
+++ b/compiler/rustc_query_impl/src/job.rs
@@ -481,13 +481,23 @@ pub(crate) fn create_cycle_error<'tcx>(
         usage: usage.tagged_key.description(tcx),
     });
 
-    let alias = if frames
-        .iter()
-        .all(|frame| frame.tagged_key.def_kind(tcx) == Some(DefKind::TyAlias))
-    {
+    let is_all_def_kind = |def_kind| {
+        // Trivial type alias and trait alias cycles consists of `type_of` and
+        // `explicit_implied_predicates_of` queries, so we just check just these here.
+        frames.iter().all(|frame| match frame.tagged_key {
+            TaggedQueryKey::type_of(def_id)
+            | TaggedQueryKey::explicit_implied_predicates_of(def_id)
+                if tcx.def_kind(def_id) == def_kind =>
+            {
+                true
+            }
+            _ => false,
+        })
+    };
+
+    let alias = if is_all_def_kind(DefKind::TyAlias) {
         Some(crate::error::Alias::Ty)
-    } else if frames.iter().all(|frame| frame.tagged_key.def_kind(tcx) == Some(DefKind::TraitAlias))
-    {
+    } else if is_all_def_kind(DefKind::TraitAlias) {
         Some(crate::error::Alias::Trait)
     } else {
         None


### PR DESCRIPTION
This removes `TaggedQueryKey::def_kind` by accessing the relevant query keys directly.