### PR TITLE
`Alignment`: move from `ptr` to `mem` and rename `as_nonzero` to `as_nonzero_usize`

### DIFF
--- a/compiler/rustc_builtin_macros/src/global_allocator.rs
+++ b/compiler/rustc_builtin_macros/src/global_allocator.rs
@@ -180,7 +180,7 @@ impl AllocFnFactory<'_, '_> {
     }
 
     fn ptr_alignment(&self) -> Box<Ty> {
-        let path = self.cx.std_path(&[sym::ptr, sym::Alignment]);
+        let path = self.cx.std_path(&[sym::mem, sym::Alignment]);
         let path = self.cx.path(self.span, path);
         self.cx.ty_path(path)
     }

--- a/compiler/rustc_data_structures/src/aligned.rs
+++ b/compiler/rustc_data_structures/src/aligned.rs
@@ -1,4 +1,7 @@
 use std::marker::PointeeSized;
+#[cfg(not(bootstrap))]
+use std::mem::Alignment;
+#[cfg(bootstrap)]
 use std::ptr::Alignment;
 
 /// Returns the ABI-required minimum alignment of a type in bytes.

--- a/compiler/rustc_data_structures/src/tagged_ptr.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr.rs
@@ -55,7 +55,12 @@ pub unsafe trait Tag: Copy {
 /// Returns the number of bits available for use for tags in a pointer to `T`
 /// (this is based on `T`'s alignment).
 pub const fn bits_for<T: ?Sized + Aligned>() -> u32 {
-    crate::aligned::align_of::<T>().as_nonzero().trailing_zeros()
+    let alignment = crate::aligned::align_of::<T>();
+    #[cfg(bootstrap)]
+    let alignment = alignment.as_nonzero();
+    #[cfg(not(bootstrap))]
+    let alignment = alignment.as_nonzero_usize();
+    alignment.trailing_zeros()
 }
 
 /// Returns the correct [`Tag::BITS`] constant for a set of tag values.

--- a/compiler/rustc_middle/src/ty/list.rs
+++ b/compiler/rustc_middle/src/ty/list.rs
@@ -264,7 +264,10 @@ unsafe impl<H: DynSync, T: DynSync> DynSync for RawList<H, T> {}
 // Layouts of `ListSkeleton<H, T>` and `RawList<H, T>` are the same, modulo opaque tail,
 // thus aligns of `ListSkeleton<H, T>` and `RawList<H, T>` must be the same.
 unsafe impl<H, T> Aligned for RawList<H, T> {
+    #[cfg(bootstrap)]
     const ALIGN: ptr::Alignment = align_of::<ListSkeleton<H, T>>();
+    #[cfg(not(bootstrap))]
+    const ALIGN: mem::Alignment = align_of::<ListSkeleton<H, T>>();
 }
 
 /// A [`List`] that additionally stores type information inline to speed up

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1224,6 +1224,7 @@ symbols! {
         maybe_uninit,
         maybe_uninit_uninit,
         maybe_uninit_zeroed,
+        mem,
         mem_align_const,
         mem_discriminant,
         mem_drop,

--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -5,7 +5,8 @@
 #[stable(feature = "alloc_module", since = "1.28.0")]
 #[doc(inline)]
 pub use core::alloc::*;
-use core::ptr::{self, Alignment, NonNull};
+use core::mem::Alignment;
+use core::ptr::{self, NonNull};
 use core::{cmp, hint};
 
 unsafe extern "Rust" {

--- a/library/alloc/src/raw_vec/mod.rs
+++ b/library/alloc/src/raw_vec/mod.rs
@@ -5,8 +5,8 @@
 // run the tests. See the comment there for an explanation why this is the case.
 
 use core::marker::{Destruct, PhantomData};
-use core::mem::{ManuallyDrop, MaybeUninit, SizedTypeProperties};
-use core::ptr::{self, Alignment, NonNull, Unique};
+use core::mem::{Alignment, ManuallyDrop, MaybeUninit, SizedTypeProperties};
+use core::ptr::{self, NonNull, Unique};
 use core::{cmp, hint};
 
 #[cfg(not(no_global_oom_handling))]

--- a/library/alloc/src/raw_vec/mod.rs
+++ b/library/alloc/src/raw_vec/mod.rs
@@ -570,7 +570,7 @@ const impl<A: [const] Allocator + [const] Destruct> RawVecInner<A> {
 impl<A: Allocator> RawVecInner<A> {
     #[inline]
     const fn new_in(alloc: A, align: Alignment) -> Self {
-        let ptr = Unique::from_non_null(NonNull::without_provenance(align.as_nonzero()));
+        let ptr = Unique::from_non_null(NonNull::without_provenance(align.as_nonzero_usize()));
         // `cap: 0` means "unallocated". zero-sized types are ignored.
         Self { ptr, cap: ZERO_CAP, alloc }
     }

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -252,7 +252,7 @@ use core::intrinsics::abort;
 #[cfg(not(no_global_oom_handling))]
 use core::iter;
 use core::marker::{PhantomData, Unsize};
-use core::mem::{self, ManuallyDrop};
+use core::mem::{self, Alignment, ManuallyDrop};
 use core::num::NonZeroUsize;
 use core::ops::{CoerceUnsized, Deref, DerefMut, DerefPure, DispatchFromDyn, LegacyReceiver};
 #[cfg(not(no_global_oom_handling))]
@@ -261,7 +261,7 @@ use core::panic::{RefUnwindSafe, UnwindSafe};
 #[cfg(not(no_global_oom_handling))]
 use core::pin::Pin;
 use core::pin::PinCoerceUnsized;
-use core::ptr::{self, Alignment, NonNull, drop_in_place};
+use core::ptr::{self, NonNull, drop_in_place};
 #[cfg(not(no_global_oom_handling))]
 use core::slice::from_raw_parts_mut;
 use core::{borrow, fmt, hint};

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -19,14 +19,14 @@ use core::intrinsics::abort;
 #[cfg(not(no_global_oom_handling))]
 use core::iter;
 use core::marker::{PhantomData, Unsize};
-use core::mem::{self, ManuallyDrop};
+use core::mem::{self, Alignment, ManuallyDrop};
 use core::num::NonZeroUsize;
 use core::ops::{CoerceUnsized, Deref, DerefMut, DerefPure, DispatchFromDyn, LegacyReceiver};
 #[cfg(not(no_global_oom_handling))]
 use core::ops::{Residual, Try};
 use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::pin::{Pin, PinCoerceUnsized};
-use core::ptr::{self, Alignment, NonNull};
+use core::ptr::{self, NonNull};
 #[cfg(not(no_global_oom_handling))]
 use core::slice::from_raw_parts_mut;
 use core::sync::atomic::Ordering::{Acquire, Relaxed, Release};

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -268,7 +268,7 @@ impl Layout {
     #[must_use]
     #[inline]
     pub const fn dangling_ptr(&self) -> NonNull<u8> {
-        NonNull::without_provenance(self.align.as_nonzero())
+        NonNull::without_provenance(self.align.as_nonzero_usize())
     }
 
     /// Creates a layout describing the record that can hold a value

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -6,8 +6,8 @@
 
 use crate::error::Error;
 use crate::intrinsics::{unchecked_add, unchecked_mul, unchecked_sub};
-use crate::mem::SizedTypeProperties;
-use crate::ptr::{Alignment, NonNull};
+use crate::mem::{Alignment, SizedTypeProperties};
+use crate::ptr::NonNull;
 use crate::{assert_unsafe_precondition, fmt, mem};
 
 /// Layout of a block of memory.

--- a/library/core/src/mem/alignment.rs
+++ b/library/core/src/mem/alignment.rs
@@ -37,7 +37,7 @@ impl Alignment {
     ///
     /// ```
     /// #![feature(ptr_alignment_type)]
-    /// use std::ptr::Alignment;
+    /// use std::mem::Alignment;
     ///
     /// assert_eq!(Alignment::MIN.as_usize(), 1);
     /// ```
@@ -65,7 +65,7 @@ impl Alignment {
     ///
     /// ```
     /// #![feature(ptr_alignment_type)]
-    /// use std::ptr::Alignment;
+    /// use std::mem::Alignment;
     ///
     /// assert_eq!(Alignment::of_val(&5i32).as_usize(), 4);
     /// ```
@@ -112,14 +112,13 @@ impl Alignment {
     ///
     /// ```
     /// #![feature(ptr_alignment_type)]
-    /// use std::ptr::Alignment;
+    /// use std::mem::Alignment;
     ///
     /// assert_eq!(unsafe { Alignment::of_val_raw(&5i32) }.as_usize(), 4);
     /// ```
     #[inline]
     #[must_use]
     #[unstable(feature = "ptr_alignment_type", issue = "102070")]
-    // #[unstable(feature = "layout_for_ptr", issue = "69835")]
     pub const unsafe fn of_val_raw<T: MetaSized>(val: *const T) -> Self {
         // SAFETY: precondition propagated to the caller
         let align = unsafe { mem::align_of_val_raw(val) };
@@ -214,9 +213,10 @@ impl Alignment {
     /// # Examples
     ///
     /// ```
-    /// #![feature(ptr_alignment_type)]
     /// #![feature(ptr_mask)]
-    /// use std::ptr::{Alignment, NonNull};
+    /// #![feature(ptr_alignment_type)]
+    /// use std::mem::Alignment;
+    /// use std::ptr::NonNull;
     ///
     /// #[repr(align(1))] struct Align1(u8);
     /// #[repr(align(2))] struct Align2(u16);
@@ -294,7 +294,7 @@ impl const From<Alignment> for usize {
 impl cmp::Ord for Alignment {
     #[inline]
     fn cmp(&self, other: &Self) -> cmp::Ordering {
-        self.as_nonzero().get().cmp(&other.as_nonzero().get())
+        self.as_nonzero().cmp(&other.as_nonzero())
     }
 }
 

--- a/library/core/src/mem/alignment.rs
+++ b/library/core/src/mem/alignment.rs
@@ -168,16 +168,28 @@ impl Alignment {
     #[unstable(feature = "ptr_alignment_type", issue = "102070")]
     #[inline]
     pub const fn as_usize(self) -> usize {
-        // Going through `as_nonzero` helps this be more clearly the inverse of
+        // Going through `as_nonzero_usize` helps this be more clearly the inverse of
         // `new_unchecked`, letting MIR optimizations fold it away.
 
-        self.as_nonzero().get()
+        self.as_nonzero_usize().get()
+    }
+
+    /// Returns the alignment as a <code>[NonZero]<[usize]></code>.
+    #[unstable(feature = "ptr_alignment_type", issue = "102070")]
+    #[deprecated(
+        since = "CURRENT_RUSTC_VERSION",
+        note = "renamed to `as_nonzero_usize`",
+        suggestion = "as_nonzero_usize"
+    )]
+    #[inline]
+    pub const fn as_nonzero(self) -> NonZero<usize> {
+        self.as_nonzero_usize()
     }
 
     /// Returns the alignment as a <code>[NonZero]<[usize]></code>.
     #[unstable(feature = "ptr_alignment_type", issue = "102070")]
     #[inline]
-    pub const fn as_nonzero(self) -> NonZero<usize> {
+    pub const fn as_nonzero_usize(self) -> NonZero<usize> {
         // This transmutes directly to avoid the UbCheck in `NonZero::new_unchecked`
         // since there's no way for the user to trip that check anyway -- the
         // validity invariant of the type would have to have been broken earlier --
@@ -203,7 +215,7 @@ impl Alignment {
     #[unstable(feature = "ptr_alignment_type", issue = "102070")]
     #[inline]
     pub const fn log2(self) -> u32 {
-        self.as_nonzero().trailing_zeros()
+        self.as_nonzero_usize().trailing_zeros()
     }
 
     /// Returns a bit mask that can be used to match this alignment.
@@ -246,7 +258,7 @@ impl Alignment {
 #[unstable(feature = "ptr_alignment_type", issue = "102070")]
 impl fmt::Debug for Alignment {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?} (1 << {:?})", self.as_nonzero(), self.log2())
+        write!(f, "{:?} (1 << {:?})", self.as_nonzero_usize(), self.log2())
     }
 }
 
@@ -277,7 +289,7 @@ impl const TryFrom<usize> for Alignment {
 impl const From<Alignment> for NonZero<usize> {
     #[inline]
     fn from(align: Alignment) -> NonZero<usize> {
-        align.as_nonzero()
+        align.as_nonzero_usize()
     }
 }
 
@@ -294,7 +306,7 @@ impl const From<Alignment> for usize {
 impl cmp::Ord for Alignment {
     #[inline]
     fn cmp(&self, other: &Self) -> cmp::Ordering {
-        self.as_nonzero().cmp(&other.as_nonzero())
+        self.as_nonzero_usize().cmp(&other.as_nonzero_usize())
     }
 }
 
@@ -310,7 +322,7 @@ impl cmp::PartialOrd for Alignment {
 impl hash::Hash for Alignment {
     #[inline]
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        self.as_nonzero().hash(state)
+        self.as_nonzero_usize().hash(state)
     }
 }
 

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -34,8 +34,11 @@ use crate::alloc::Layout;
 use crate::clone::TrivialClone;
 use crate::marker::{Destruct, DiscriminantKind};
 use crate::panic::const_assert;
-use crate::ptr::Alignment;
 use crate::{clone, cmp, fmt, hash, intrinsics, ptr};
+
+mod alignment;
+#[unstable(feature = "ptr_alignment_type", issue = "102070")]
+pub use alignment::Alignment;
 
 mod manually_drop;
 #[stable(feature = "manually_drop", since = "1.20.0")]

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -412,9 +412,10 @@ use crate::mem::{self, MaybeUninit, SizedTypeProperties};
 use crate::num::NonZero;
 use crate::{fmt, hash, intrinsics, ub_checks};
 
-mod alignment;
 #[unstable(feature = "ptr_alignment_type", issue = "102070")]
-pub use alignment::Alignment;
+#[deprecated(since = "CURRENT_RUSTC_VERSION", note = "moved from `ptr` to `mem`")]
+/// Deprecated re-export of [mem::Alignment].
+pub type Alignment = mem::Alignment;
 
 mod metadata;
 #[unstable(feature = "ptr_metadata", issue = "81513")]

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -128,7 +128,7 @@ impl<T: Sized> NonNull<T> {
     #[must_use]
     #[inline]
     pub const fn dangling() -> Self {
-        let align = crate::ptr::Alignment::of::<T>();
+        let align = crate::mem::Alignment::of::<T>();
         NonNull::without_provenance(align.as_nonzero())
     }
 

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -129,7 +129,7 @@ impl<T: Sized> NonNull<T> {
     #[inline]
     pub const fn dangling() -> Self {
         let align = crate::mem::Alignment::of::<T>();
-        NonNull::without_provenance(align.as_nonzero())
+        NonNull::without_provenance(align.as_nonzero_usize())
     }
 
     /// Converts an address back to a mutable pointer, picking up some previously 'exposed'

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-abort.diff
@@ -17,12 +17,12 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }
                   }
-                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                  scope 7 (inlined std::mem::Alignment::of::<[bool; 0]>) {
                   }
               }
           }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-abort.diff
@@ -17,7 +17,7 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero_usize) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-unwind.diff
@@ -17,12 +17,12 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }
                   }
-                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                  scope 7 (inlined std::mem::Alignment::of::<[bool; 0]>) {
                   }
               }
           }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-unwind.diff
@@ -17,7 +17,7 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero_usize) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-abort.diff
@@ -17,12 +17,12 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }
                   }
-                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                  scope 7 (inlined std::mem::Alignment::of::<[bool; 0]>) {
                   }
               }
           }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-abort.diff
@@ -17,7 +17,7 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero_usize) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-unwind.diff
@@ -17,12 +17,12 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }
                   }
-                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                  scope 7 (inlined std::mem::Alignment::of::<[bool; 0]>) {
                   }
               }
           }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-unwind.diff
@@ -17,7 +17,7 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero_usize) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-abort.diff
@@ -17,12 +17,12 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }
                   }
-                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                  scope 7 (inlined std::mem::Alignment::of::<[bool; 0]>) {
                   }
               }
           }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-abort.diff
@@ -17,7 +17,7 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero_usize) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-unwind.diff
@@ -17,12 +17,12 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }
                   }
-                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                  scope 7 (inlined std::mem::Alignment::of::<[bool; 0]>) {
                   }
               }
           }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-unwind.diff
@@ -17,7 +17,7 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero_usize) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-abort.diff
@@ -17,12 +17,12 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }
                   }
-                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                  scope 7 (inlined std::mem::Alignment::of::<[bool; 0]>) {
                   }
               }
           }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-abort.diff
@@ -17,7 +17,7 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero_usize) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-unwind.diff
@@ -17,12 +17,12 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }
                   }
-                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                  scope 7 (inlined std::mem::Alignment::of::<[bool; 0]>) {
                   }
               }
           }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-unwind.diff
@@ -17,7 +17,7 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero_usize) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }

--- a/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.32bit.panic-abort.diff
@@ -51,7 +51,7 @@
           StorageLive(_12);
           StorageLive(_13);
 -         _13 = boxed::box_new_uninit(const <() as std::mem::SizedTypeProperties>::LAYOUT) -> [return: bb2, unwind unreachable];
-+         _13 = boxed::box_new_uninit(const Layout {{ size: 0_usize, align: std::ptr::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }} }}) -> [return: bb2, unwind unreachable];
++         _13 = boxed::box_new_uninit(const Layout {{ size: 0_usize, align: std::mem::Alignment {{ _inner_repr_trick: mem::alignment::AlignmentEnum::_Align1Shl0 }} }}) -> [return: bb2, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.64bit.panic-abort.diff
@@ -51,7 +51,7 @@
           StorageLive(_12);
           StorageLive(_13);
 -         _13 = boxed::box_new_uninit(const <() as std::mem::SizedTypeProperties>::LAYOUT) -> [return: bb2, unwind unreachable];
-+         _13 = boxed::box_new_uninit(const Layout {{ size: 0_usize, align: std::ptr::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }} }}) -> [return: bb2, unwind unreachable];
++         _13 = boxed::box_new_uninit(const Layout {{ size: 0_usize, align: std::mem::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }} }}) -> [return: bb2, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/gvn_ptr_eq_with_constant.main.GVN.diff
+++ b/tests/mir-opt/gvn_ptr_eq_with_constant.main.GVN.diff
@@ -7,14 +7,14 @@
       let mut _2: *mut u8;
       scope 1 (inlined dangling_mut::<u8>) {
           scope 2 (inlined NonNull::<u8>::dangling) {
-              let _3: std::ptr::Alignment;
+              let _3: std::mem::Alignment;
               scope 3 {
-                  scope 5 (inlined std::ptr::Alignment::as_nonzero) {
+                  scope 5 (inlined std::mem::Alignment::as_nonzero) {
                   }
                   scope 6 (inlined NonNull::<u8>::without_provenance) {
                   }
               }
-              scope 4 (inlined std::ptr::Alignment::of::<u8>) {
+              scope 4 (inlined std::mem::Alignment::of::<u8>) {
               }
           }
           scope 7 (inlined NonNull::<u8>::as_ptr) {
@@ -34,7 +34,7 @@
           StorageLive(_3);
 -         _3 = const <u8 as std::mem::SizedTypeProperties>::ALIGNMENT;
 -         _2 = copy _3 as *mut u8 (Transmute);
-+         _3 = const std::ptr::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }};
++         _3 = const std::mem::Alignment {{ _inner_repr_trick: mem::alignment::AlignmentEnum::_Align1Shl0 }};
 +         _2 = const {0x1 as *mut u8};
           StorageDead(_3);
           StorageLive(_4);

--- a/tests/mir-opt/gvn_ptr_eq_with_constant.main.GVN.diff
+++ b/tests/mir-opt/gvn_ptr_eq_with_constant.main.GVN.diff
@@ -9,7 +9,7 @@
           scope 2 (inlined NonNull::<u8>::dangling) {
               let _3: std::mem::Alignment;
               scope 3 {
-                  scope 5 (inlined std::mem::Alignment::as_nonzero) {
+                  scope 5 (inlined std::mem::Alignment::as_nonzero_usize) {
                   }
                   scope 6 (inlined NonNull::<u8>::without_provenance) {
                   }

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.PreCodegen.after.panic-abort.mir
@@ -48,9 +48,9 @@ fn drop_bytes(_1: *mut Box<[u8; 1024]>) -> () {
                     }
                     scope 9 (inlined size_of_val_raw::<[u8; 1024]>) {
                     }
-                    scope 10 (inlined std::ptr::Alignment::of_val_raw::<[u8; 1024]>) {
+                    scope 10 (inlined std::mem::Alignment::of_val_raw::<[u8; 1024]>) {
                         scope 11 {
-                            scope 13 (inlined #[track_caller] std::ptr::Alignment::new_unchecked) {
+                            scope 13 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
                                 scope 14 (inlined core::ub_checks::check_language_ub) {
                                     scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
                                     }
@@ -69,7 +69,7 @@ fn drop_bytes(_1: *mut Box<[u8; 1024]>) -> () {
         StorageLive(_3);
         _2 = copy (((*_1).0: std::ptr::Unique<[u8; 1024]>).0: std::ptr::NonNull<[u8; 1024]>);
         _3 = copy _2 as std::ptr::NonNull<u8> (Transmute);
-        _4 = alloc::alloc::__rust_dealloc(move _3, const 1024_usize, const std::ptr::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }}) -> [return: bb1, unwind unreachable];
+        _4 = alloc::alloc::__rust_dealloc(move _3, const 1024_usize, const std::mem::Alignment {{ _inner_repr_trick: mem::alignment::AlignmentEnum::_Align1Shl0 }}) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.PreCodegen.after.panic-unwind.mir
@@ -48,9 +48,9 @@ fn drop_bytes(_1: *mut Box<[u8; 1024]>) -> () {
                     }
                     scope 9 (inlined size_of_val_raw::<[u8; 1024]>) {
                     }
-                    scope 10 (inlined std::ptr::Alignment::of_val_raw::<[u8; 1024]>) {
+                    scope 10 (inlined std::mem::Alignment::of_val_raw::<[u8; 1024]>) {
                         scope 11 {
-                            scope 13 (inlined #[track_caller] std::ptr::Alignment::new_unchecked) {
+                            scope 13 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
                                 scope 14 (inlined core::ub_checks::check_language_ub) {
                                     scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
                                     }
@@ -69,7 +69,7 @@ fn drop_bytes(_1: *mut Box<[u8; 1024]>) -> () {
         StorageLive(_3);
         _2 = copy (((*_1).0: std::ptr::Unique<[u8; 1024]>).0: std::ptr::NonNull<[u8; 1024]>);
         _3 = copy _2 as std::ptr::NonNull<u8> (Transmute);
-        _4 = alloc::alloc::__rust_dealloc(move _3, const 1024_usize, const std::ptr::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }}) -> [return: bb1, unwind unreachable];
+        _4 = alloc::alloc::__rust_dealloc(move _3, const 1024_usize, const std::mem::Alignment {{ _inner_repr_trick: mem::alignment::AlignmentEnum::_Align1Shl0 }}) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-abort.mir
@@ -42,16 +42,16 @@ fn drop_generic(_1: *mut Box<T>) -> () {
                     }
                 }
                 scope 7 (inlined Layout::for_value_raw::<T>) {
-                    let mut _3: std::ptr::Alignment;
+                    let mut _3: std::mem::Alignment;
                     scope 8 {
                         scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
                         }
                     }
                     scope 9 (inlined size_of_val_raw::<T>) {
                     }
-                    scope 10 (inlined std::ptr::Alignment::of_val_raw::<T>) {
+                    scope 10 (inlined std::mem::Alignment::of_val_raw::<T>) {
                         scope 11 {
-                            scope 13 (inlined #[track_caller] std::ptr::Alignment::new_unchecked) {
+                            scope 13 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
                                 scope 14 (inlined core::ub_checks::check_language_ub) {
                                     scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
                                     }
@@ -69,7 +69,7 @@ fn drop_generic(_1: *mut Box<T>) -> () {
     bb0: {
         StorageLive(_4);
         _2 = copy (((*_1).0: std::ptr::Unique<T>).0: std::ptr::NonNull<T>);
-        _3 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
+        _3 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::mem::Alignment (Transmute);
         switchInt(const <T as std::mem::SizedTypeProperties>::SIZE) -> [0: bb3, otherwise: bb1];
     }
 

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-unwind.mir
@@ -42,16 +42,16 @@ fn drop_generic(_1: *mut Box<T>) -> () {
                     }
                 }
                 scope 7 (inlined Layout::for_value_raw::<T>) {
-                    let mut _3: std::ptr::Alignment;
+                    let mut _3: std::mem::Alignment;
                     scope 8 {
                         scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
                         }
                     }
                     scope 9 (inlined size_of_val_raw::<T>) {
                     }
-                    scope 10 (inlined std::ptr::Alignment::of_val_raw::<T>) {
+                    scope 10 (inlined std::mem::Alignment::of_val_raw::<T>) {
                         scope 11 {
-                            scope 13 (inlined #[track_caller] std::ptr::Alignment::new_unchecked) {
+                            scope 13 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
                                 scope 14 (inlined core::ub_checks::check_language_ub) {
                                     scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
                                     }
@@ -69,7 +69,7 @@ fn drop_generic(_1: *mut Box<T>) -> () {
     bb0: {
         StorageLive(_4);
         _2 = copy (((*_1).0: std::ptr::Unique<T>).0: std::ptr::NonNull<T>);
-        _3 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
+        _3 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::mem::Alignment (Transmute);
         switchInt(const <T as std::mem::SizedTypeProperties>::SIZE) -> [0: bb3, otherwise: bb1];
     }
 

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.rs
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.rs
@@ -6,7 +6,7 @@
 // EMIT_MIR drop_box_of_sized.drop_generic.PreCodegen.after.mir
 pub unsafe fn drop_generic<T: Copy>(x: *mut Box<T>) {
     // CHECK-LABEL: fn drop_generic
-    // CHECK: [[ALIGNMENT:_.+]] = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute)
+    // CHECK: [[ALIGNMENT:_.+]] = const <T as std::mem::SizedTypeProperties>::ALIGN as std::mem::Alignment (Transmute)
     // CHECK: alloc::alloc::__rust_dealloc({{.+}}, const <T as std::mem::SizedTypeProperties>::SIZE, move [[ALIGNMENT]])
     std::ptr::drop_in_place(x)
 }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-abort.mir
@@ -46,16 +46,16 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 }
                 scope 7 (inlined Layout::for_value_raw::<[T]>) {
                     let mut _5: usize;
-                    let mut _6: std::ptr::Alignment;
+                    let mut _6: std::mem::Alignment;
                     scope 8 {
                         scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
                         }
                     }
                     scope 9 (inlined size_of_val_raw::<[T]>) {
                     }
-                    scope 10 (inlined std::ptr::Alignment::of_val_raw::<[T]>) {
+                    scope 10 (inlined std::mem::Alignment::of_val_raw::<[T]>) {
                         scope 11 {
-                            scope 13 (inlined #[track_caller] std::ptr::Alignment::new_unchecked) {
+                            scope 13 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
                                 scope 14 (inlined core::ub_checks::check_language_ub) {
                                     scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
                                     }
@@ -82,7 +82,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
     }
 
     bb1: {
-        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
+        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::mem::Alignment (Transmute);
         StorageDead(_4);
         switchInt(copy _5) -> [0: bb3, otherwise: bb2];
     }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-unwind.mir
@@ -46,16 +46,16 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 }
                 scope 7 (inlined Layout::for_value_raw::<[T]>) {
                     let mut _5: usize;
-                    let mut _6: std::ptr::Alignment;
+                    let mut _6: std::mem::Alignment;
                     scope 8 {
                         scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
                         }
                     }
                     scope 9 (inlined size_of_val_raw::<[T]>) {
                     }
-                    scope 10 (inlined std::ptr::Alignment::of_val_raw::<[T]>) {
+                    scope 10 (inlined std::mem::Alignment::of_val_raw::<[T]>) {
                         scope 11 {
-                            scope 13 (inlined #[track_caller] std::ptr::Alignment::new_unchecked) {
+                            scope 13 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
                                 scope 14 (inlined core::ub_checks::check_language_ub) {
                                     scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
                                     }
@@ -82,7 +82,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
     }
 
     bb1: {
-        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
+        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::mem::Alignment (Transmute);
         StorageDead(_4);
         switchInt(copy _5) -> [0: bb3, otherwise: bb2];
     }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
@@ -46,16 +46,16 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 }
                 scope 7 (inlined Layout::for_value_raw::<[T]>) {
                     let mut _5: usize;
-                    let mut _6: std::ptr::Alignment;
+                    let mut _6: std::mem::Alignment;
                     scope 8 {
                         scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
                         }
                     }
                     scope 9 (inlined size_of_val_raw::<[T]>) {
                     }
-                    scope 10 (inlined std::ptr::Alignment::of_val_raw::<[T]>) {
+                    scope 10 (inlined std::mem::Alignment::of_val_raw::<[T]>) {
                         scope 11 {
-                            scope 13 (inlined #[track_caller] std::ptr::Alignment::new_unchecked) {
+                            scope 13 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
                                 scope 14 (inlined core::ub_checks::check_language_ub) {
                                     scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
                                     }
@@ -82,7 +82,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
     }
 
     bb1: {
-        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
+        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::mem::Alignment (Transmute);
         StorageDead(_4);
         switchInt(copy _5) -> [0: bb3, otherwise: bb2];
     }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-unwind.mir
@@ -46,16 +46,16 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 }
                 scope 7 (inlined Layout::for_value_raw::<[T]>) {
                     let mut _5: usize;
-                    let mut _6: std::ptr::Alignment;
+                    let mut _6: std::mem::Alignment;
                     scope 8 {
                         scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
                         }
                     }
                     scope 9 (inlined size_of_val_raw::<[T]>) {
                     }
-                    scope 10 (inlined std::ptr::Alignment::of_val_raw::<[T]>) {
+                    scope 10 (inlined std::mem::Alignment::of_val_raw::<[T]>) {
                         scope 11 {
-                            scope 13 (inlined #[track_caller] std::ptr::Alignment::new_unchecked) {
+                            scope 13 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
                                 scope 14 (inlined core::ub_checks::check_language_ub) {
                                     scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
                                     }
@@ -82,7 +82,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
     }
 
     bb1: {
-        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
+        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::mem::Alignment (Transmute);
         StorageDead(_4);
         switchInt(copy _5) -> [0: bb3, otherwise: bb2];
     }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.rs
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.rs
@@ -9,7 +9,7 @@ pub unsafe fn generic_in_place<T: Copy>(ptr: *mut Box<[T]>) {
     // CHECK-LABEL: fn generic_in_place(_1: *mut Box<[T]>)
     // CHECK: (inlined <Box<[T]> as Drop>::drop)
     // CHECK: [[SIZE:_.+]] = std::intrinsics::size_of_val::<[T]>
-    // CHECK: [[ALIGN:_.+]] = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
+    // CHECK: [[ALIGN:_.+]] = const <T as std::mem::SizedTypeProperties>::ALIGN as std::mem::Alignment (Transmute);
     // CHECK: = alloc::alloc::__rust_dealloc({{.+}}, move [[SIZE]], move [[ALIGN]]) ->
     std::ptr::drop_in_place(ptr)
 }

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-abort.diff
@@ -63,7 +63,7 @@
   
       bb3: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
-+         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment {{ _inner_repr_trick: Scalar(0x00000000): std::ptr::alignment::AlignmentEnum }} }};
++         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x00000000): mem::alignment::AlignmentEnum }} }};
           StorageDead(_8);
           StorageDead(_2);
           StorageLive(_3);
@@ -73,8 +73,8 @@
           StorageLive(_7);
 -         _7 = copy _1;
 -         _6 = std::alloc::Global::alloc_impl_runtime(move _7, const false) -> [return: bb4, unwind unreachable];
-+         _7 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment {{ _inner_repr_trick: Scalar(0x00000000): std::ptr::alignment::AlignmentEnum }} }};
-+         _6 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment {{ _inner_repr_trick: Scalar(0x00000000): std::ptr::alignment::AlignmentEnum }} }}, const false) -> [return: bb4, unwind unreachable];
++         _7 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x00000000): mem::alignment::AlignmentEnum }} }};
++         _6 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x00000000): mem::alignment::AlignmentEnum }} }}, const false) -> [return: bb4, unwind unreachable];
       }
   
       bb4: {

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-unwind.diff
@@ -64,7 +64,7 @@
   
       bb4: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
-+         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment {{ _inner_repr_trick: Scalar(0x00000000): std::ptr::alignment::AlignmentEnum }} }};
++         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x00000000): mem::alignment::AlignmentEnum }} }};
           StorageDead(_8);
           StorageDead(_2);
           StorageLive(_3);
@@ -74,8 +74,8 @@
           StorageLive(_7);
 -         _7 = copy _1;
 -         _6 = std::alloc::Global::alloc_impl_runtime(move _7, const false) -> [return: bb5, unwind continue];
-+         _7 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment {{ _inner_repr_trick: Scalar(0x00000000): std::ptr::alignment::AlignmentEnum }} }};
-+         _6 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment {{ _inner_repr_trick: Scalar(0x00000000): std::ptr::alignment::AlignmentEnum }} }}, const false) -> [return: bb5, unwind continue];
++         _7 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x00000000): mem::alignment::AlignmentEnum }} }};
++         _6 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x00000000): mem::alignment::AlignmentEnum }} }}, const false) -> [return: bb5, unwind continue];
       }
   
       bb5: {

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
@@ -63,7 +63,7 @@
   
       bb3: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
-+         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum }} }};
++         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum }} }};
           StorageDead(_8);
           StorageDead(_2);
           StorageLive(_3);
@@ -73,8 +73,8 @@
           StorageLive(_7);
 -         _7 = copy _1;
 -         _6 = std::alloc::Global::alloc_impl_runtime(move _7, const false) -> [return: bb4, unwind unreachable];
-+         _7 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum }} }};
-+         _6 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum }} }}, const false) -> [return: bb4, unwind unreachable];
++         _7 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum }} }};
++         _6 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum }} }}, const false) -> [return: bb4, unwind unreachable];
       }
   
       bb4: {

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-unwind.diff
@@ -64,7 +64,7 @@
   
       bb4: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
-+         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum }} }};
++         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): mem::alignment::AlignmentEnum }} }};
           StorageDead(_8);
           StorageDead(_2);
           StorageLive(_3);
@@ -74,8 +74,8 @@
           StorageLive(_7);
 -         _7 = copy _1;
 -         _6 = std::alloc::Global::alloc_impl_runtime(move _7, const false) -> [return: bb5, unwind continue];
-+         _7 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum }} }};
-+         _6 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum }} }}, const false) -> [return: bb5, unwind continue];
++         _7 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): mem::alignment::AlignmentEnum }} }};
++         _6 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): mem::alignment::AlignmentEnum }} }}, const false) -> [return: bb5, unwind continue];
       }
   
       bb5: {

--- a/tests/ui/precondition-checks/alignment.rs
+++ b/tests/ui/precondition-checks/alignment.rs
@@ -6,6 +6,6 @@
 
 fn main() {
     unsafe {
-        std::ptr::Alignment::new_unchecked(0);
+        std::mem::Alignment::new_unchecked(0);
     }
 }

--- a/tests/ui/traits/const-traits/const-traits-core.rs
+++ b/tests/ui/traits/const-traits/const-traits-core.rs
@@ -36,8 +36,8 @@ const PHANTOM: std::marker::PhantomData<()> = Default::default();
 const OPT: Option<i32> = Default::default();
 // core::iter::sources::empty
 const EMPTY: std::iter::Empty<()> = Default::default();
-// core::ptr::alignment
-const ALIGNMENT: std::ptr::Alignment = Default::default();
+// core::mem::alignment
+const ALIGNMENT: std::mem::Alignment = Default::default();
 // core::slice
 const SLICE: &[()] = Default::default();
 const MUT_SLICE: &mut [()] = Default::default();


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/154004)*
<!-- homu-ignore:end -->

- tracking issue: rust-lang/rust#102070
- split off from rust-lang/rust#153261