### PR TITLE
rustc_expand: improve diagnostics for non-repeatable metavars

### DIFF
--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -277,7 +277,8 @@ impl<'cx> MacroExpanderResult<'cx> {
         // Emit the SEMICOLON_IN_EXPRESSIONS_FROM_MACROS deprecation lint.
         let is_local = true;
 
-        let parser = ParserAnyMacro::from_tts(cx, tts, site_span, arm_span, is_local, macro_ident);
+        let parser =
+            ParserAnyMacro::from_tts(cx, tts, site_span, arm_span, is_local, macro_ident, &[], &[]);
         ExpandResult::Ready(Box::new(parser))
     }
 }
@@ -377,8 +378,8 @@ where
 
 /// Represents a thing that maps token trees to Macro Results
 pub trait TTMacroExpander: Any {
-    fn expand<'cx>(
-        &self,
+    fn expand<'cx, 'a: 'cx>(
+        &'a self,
         ecx: &'cx mut ExtCtxt<'_>,
         span: Span,
         input: TokenStream,
@@ -394,8 +395,8 @@ impl<F: 'static> TTMacroExpander for F
 where
     F: for<'cx> Fn(&'cx mut ExtCtxt<'_>, Span, TokenStream) -> MacroExpanderResult<'cx>,
 {
-    fn expand<'cx>(
-        &self,
+    fn expand<'cx, 'a: 'cx>(
+        &'a self,
         ecx: &'cx mut ExtCtxt<'_>,
         span: Span,
         input: TokenStream,

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -182,8 +182,8 @@ macro_rules! ast_fragments {
             }
         }
 
-        impl<'a> MacResult for crate::mbe::macro_rules::ParserAnyMacro<'a> {
-            $(fn $make_ast(self: Box<crate::mbe::macro_rules::ParserAnyMacro<'a>>)
+        impl<'a, 'b> MacResult for crate::mbe::macro_rules::ParserAnyMacro<'a, 'b> {
+            $(fn $make_ast(self: Box<crate::mbe::macro_rules::ParserAnyMacro<'a, 'b>>)
                            -> Option<$AstTy> {
                 Some(self.make(AstFragmentKind::$Kind).$make_ast())
             })*

--- a/compiler/rustc_expand/src/mbe/diagnostics.rs
+++ b/compiler/rustc_expand/src/mbe/diagnostics.rs
@@ -222,11 +222,13 @@ impl<'dcx> CollectTrackerAndEmitter<'dcx, '_> {
 
 pub(super) fn emit_frag_parse_err(
     mut e: Diag<'_>,
-    parser: &Parser<'_>,
+    parser: &mut Parser<'_>,
     orig_parser: &mut Parser<'_>,
     site_span: Span,
     arm_span: Span,
     kind: AstFragmentKind,
+    bindings: &[MacroRule],
+    matched_rule_bindings: &[MatcherLoc],
 ) -> ErrorGuaranteed {
     // FIXME(davidtwco): avoid depending on the error message text
     if parser.token == token::Eof
@@ -285,6 +287,69 @@ pub(super) fn emit_frag_parse_err(
         },
         _ => annotate_err_with_kind(&mut e, kind, site_span),
     };
+
+    let mut bindings_rules = vec![];
+    for rule in bindings {
+        let MacroRule::Func { lhs, .. } = rule else { continue };
+        for param in lhs {
+            let MatcherLoc::MetaVarDecl { bind, .. } = param else { continue };
+            bindings_rules.push(*bind);
+        }
+    }
+
+    let mut matched_rule_bindings_rules = vec![];
+    for param in matched_rule_bindings {
+        let MatcherLoc::MetaVarDecl { bind, .. } = param else { continue };
+        matched_rule_bindings_rules.push(*bind);
+    }
+
+    let matched_rule_bindings_names: Vec<_> =
+        matched_rule_bindings_rules.iter().map(|bind| bind.name).collect();
+    let bindings_name: Vec<_> = bindings_rules.iter().map(|bind| bind.name).collect();
+    if parser.token.kind == token::Dollar {
+        parser.bump();
+        if let token::Ident(name, _) = parser.token.kind {
+            if let Some(matched_name) = rustc_span::edit_distance::find_best_match_for_name(
+                &matched_rule_bindings_names[..],
+                name,
+                None,
+            ) {
+                e.span_suggestion_verbose(
+                    parser.token.span,
+                    "there is a macro metavariable with similar name",
+                    format!("{matched_name}"),
+                    Applicability::MaybeIncorrect,
+                );
+            } else if bindings_name.contains(&name) {
+                e.span_label(
+                    parser.token.span,
+                    format!(
+                        "there is an macro metavariable with this name in another macro matcher"
+                    ),
+                );
+            } else if let Some(matched_name) =
+                rustc_span::edit_distance::find_best_match_for_name(&bindings_name[..], name, None)
+            {
+                e.span_suggestion_verbose(
+                    parser.token.span,
+                    "there is a macro metavariable with a similar name in another macro matcher",
+                    format!("{matched_name}"),
+                    Applicability::MaybeIncorrect,
+                );
+            } else {
+                let msg = matched_rule_bindings_names
+                    .iter()
+                    .map(|sym| format!("${}", sym))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+
+                e.span_label(parser.token.span, format!("macro metavariable not found"));
+                if !matched_rule_bindings_names.is_empty() {
+                    e.note(format!("available metavariable names are: {msg}"));
+                }
+            }
+        }
+    }
     e.emit()
 }
 

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -43,7 +43,7 @@ use crate::mbe::quoted::{RulePart, parse_one_tt};
 use crate::mbe::transcribe::transcribe;
 use crate::mbe::{self, KleeneOp};
 
-pub(crate) struct ParserAnyMacro<'a> {
+pub(crate) struct ParserAnyMacro<'a, 'b> {
     parser: Parser<'a>,
 
     /// Span of the expansion site of the macro this parser is for
@@ -55,10 +55,15 @@ pub(crate) struct ParserAnyMacro<'a> {
     arm_span: Span,
     /// Whether or not this macro is defined in the current crate
     is_local: bool,
+    bindings: &'b [MacroRule],
+    matched_rule_bindings: &'b [MatcherLoc],
 }
 
-impl<'a> ParserAnyMacro<'a> {
-    pub(crate) fn make(mut self: Box<ParserAnyMacro<'a>>, kind: AstFragmentKind) -> AstFragment {
+impl<'a, 'b> ParserAnyMacro<'a, 'b> {
+    pub(crate) fn make(
+        mut self: Box<ParserAnyMacro<'a, 'b>>,
+        kind: AstFragmentKind,
+    ) -> AstFragment {
         let ParserAnyMacro {
             site_span,
             macro_ident,
@@ -67,13 +72,22 @@ impl<'a> ParserAnyMacro<'a> {
             arm_span,
             is_trailing_mac,
             is_local,
+            bindings,
+            matched_rule_bindings,
         } = *self;
         let snapshot = &mut parser.create_snapshot_for_diagnostic();
         let fragment = match parse_ast_fragment(parser, kind) {
             Ok(f) => f,
             Err(err) => {
                 let guar = diagnostics::emit_frag_parse_err(
-                    err, parser, snapshot, site_span, arm_span, kind,
+                    err,
+                    parser,
+                    snapshot,
+                    site_span,
+                    arm_span,
+                    kind,
+                    bindings,
+                    matched_rule_bindings,
                 );
                 return kind.dummy(site_span, guar);
             }
@@ -100,7 +114,7 @@ impl<'a> ParserAnyMacro<'a> {
         fragment
     }
 
-    #[instrument(skip(cx, tts))]
+    #[instrument(skip(cx, tts, bindings, matched_rule_bindings))]
     pub(crate) fn from_tts<'cx>(
         cx: &'cx mut ExtCtxt<'a>,
         tts: TokenStream,
@@ -108,6 +122,9 @@ impl<'a> ParserAnyMacro<'a> {
         arm_span: Span,
         is_local: bool,
         macro_ident: Ident,
+        // bindings and lhs is for diagnostics
+        bindings: &'b [MacroRule],
+        matched_rule_bindings: &'b [MatcherLoc],
     ) -> Self {
         Self {
             parser: Parser::new(&cx.sess.psess, tts, None),
@@ -121,11 +138,13 @@ impl<'a> ParserAnyMacro<'a> {
             is_trailing_mac: cx.current_expansion.is_trailing_mac,
             arm_span,
             is_local,
+            bindings,
+            matched_rule_bindings,
         }
     }
 }
 
-pub(super) enum MacroRule {
+pub(crate) enum MacroRule {
     /// A function-style rule, for use with `m!()`
     Func { lhs: Vec<MatcherLoc>, lhs_span: Span, rhs: mbe::TokenTree },
     /// An attr rule, for use with `#[m]`
@@ -226,8 +245,8 @@ impl MacroRulesMacroExpander {
 }
 
 impl TTMacroExpander for MacroRulesMacroExpander {
-    fn expand<'cx>(
-        &self,
+    fn expand<'cx, 'a: 'cx>(
+        &'a self,
         cx: &'cx mut ExtCtxt<'_>,
         sp: Span,
         input: TokenStream,
@@ -337,7 +356,7 @@ impl<'matcher> Tracker<'matcher> for NoopTracker {
 
 /// Expands the rules based macro defined by `rules` for a given input `arg`.
 #[instrument(skip(cx, transparency, arg, rules))]
-fn expand_macro<'cx>(
+fn expand_macro<'cx, 'a: 'cx>(
     cx: &'cx mut ExtCtxt<'_>,
     sp: Span,
     def_span: Span,
@@ -345,7 +364,7 @@ fn expand_macro<'cx>(
     name: Ident,
     transparency: Transparency,
     arg: TokenStream,
-    rules: &[MacroRule],
+    rules: &'a [MacroRule],
 ) -> Box<dyn MacResult + 'cx> {
     let psess = &cx.sess.psess;
 
@@ -359,7 +378,7 @@ fn expand_macro<'cx>(
 
     match try_success_result {
         Ok((rule_index, rule, named_matches)) => {
-            let MacroRule::Func { rhs, .. } = rule else {
+            let MacroRule::Func { lhs, rhs, .. } = rule else {
                 panic!("try_match_macro returned non-func rule");
             };
             let mbe::TokenTree::Delimited(rhs_span, _, rhs) = rhs else {
@@ -388,7 +407,7 @@ fn expand_macro<'cx>(
             }
 
             // Let the context choose how to interpret the result. Weird, but useful for X-macros.
-            Box::new(ParserAnyMacro::from_tts(cx, tts, sp, arm_span, is_local, name))
+            Box::new(ParserAnyMacro::from_tts(cx, tts, sp, arm_span, is_local, name, rules, lhs))
         }
         Err(CanRetry::No(guar)) => {
             debug!("Will not retry matching as an error was emitted already");

--- a/tests/ui/macros/issue-6596-1.stderr
+++ b/tests/ui/macros/issue-6596-1.stderr
@@ -2,11 +2,15 @@ error: expected expression, found `$`
   --> $DIR/issue-6596-1.rs:3:9
    |
 LL |         $nonexistent
-   |         ^^^^^^^^^^^^ expected expression
+   |         ^-----------
+   |         ||
+   |         |macro metavariable not found
+   |         expected expression
 ...
 LL |     e!(foo);
    |     ------- in this macro invocation
    |
+   = note: available metavariable names are: $inp
    = note: this error originates in the macro `e` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/macros/typo-in-norepeat-expr-2.rs
+++ b/tests/ui/macros/typo-in-norepeat-expr-2.rs
@@ -1,0 +1,42 @@
+macro_rules! err {
+    (begin $follow:ident end $arg:expr) => {
+        [$arg]
+    };
+    (begin1 $arg1:ident end $agr2:expr) => {
+        [$follow] //~ ERROR: expected expression, found `$`
+        //~^ NOTE: there is an macro metavariable with this name in another macro matcher
+        //~| NOTE: expected expression
+    };
+}
+
+macro_rules! err1 {
+    (begin $follow:ident end $arg:expr) => {
+        [$arg]
+    };
+    (begin1 $arg1:ident end) => {
+        [$follo] //~ ERROR: expected expression, found `$`
+        //~| NOTE: expected expression
+        //~| HELP: there is a macro metavariable with a similar name in another macro matcher
+    };
+}
+
+macro_rules! err2 {
+    (begin $follow:ident end $arg:expr) => {
+        [$arg]
+    };
+    (begin1 $arg1:ident end) => {
+        [$xyz] //~ ERROR: expected expression, found `$`
+        //~^ NOTE: expected expression
+        //~| NOTE available metavariable names are: $arg1
+        //~| NOTE: macro metavariable not found
+    };
+}
+
+fn main () {
+    let _ = err![begin1 x  end ig]; //~ NOTE: in this expansion of err!
+    let _ = err1![begin1 x  end]; //~ NOTE: in this expansion of err1!
+            //~| NOTE: in this expansion of err1!
+
+    let _ = err2![begin1 x  end]; //~ NOTE: in this expansion of err2!
+            //~| NOTE in this expansion of err2!
+}

--- a/tests/ui/macros/typo-in-norepeat-expr-2.stderr
+++ b/tests/ui/macros/typo-in-norepeat-expr-2.stderr
@@ -1,0 +1,46 @@
+error: expected expression, found `$`
+  --> $DIR/typo-in-norepeat-expr-2.rs:6:10
+   |
+LL |         [$follow]
+   |          ^------
+   |          ||
+   |          |there is an macro metavariable with this name in another macro matcher
+   |          expected expression
+...
+LL |     let _ = err![begin1 x  end ig];
+   |             ---------------------- in this macro invocation
+   |
+   = note: this error originates in the macro `err` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: expected expression, found `$`
+  --> $DIR/typo-in-norepeat-expr-2.rs:17:10
+   |
+LL |         [$follo]
+   |          ^^^^^^ expected expression
+...
+LL |     let _ = err1![begin1 x  end];
+   |             -------------------- in this macro invocation
+   |
+   = note: this error originates in the macro `err1` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: there is a macro metavariable with a similar name in another macro matcher
+   |
+LL |         [$follow]
+   |                +
+
+error: expected expression, found `$`
+  --> $DIR/typo-in-norepeat-expr-2.rs:28:10
+   |
+LL |         [$xyz]
+   |          ^---
+   |          ||
+   |          |macro metavariable not found
+   |          expected expression
+...
+LL |     let _ = err2![begin1 x  end];
+   |             -------------------- in this macro invocation
+   |
+   = note: available metavariable names are: $arg1
+   = note: this error originates in the macro `err2` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/macros/typo-in-norepeat-expr.fixed
+++ b/tests/ui/macros/typo-in-norepeat-expr.fixed
@@ -1,0 +1,12 @@
+//@ run-rustfix
+macro_rules! m {
+    (begin $ard:ident end) => {
+        [$ard] //~ ERROR: expected expression, found `$`
+        //~^ HELP: there is a macro metavariable with similar name
+    };
+}
+
+fn main() {
+    let x = 1;
+    let _ = m![begin x end];
+}

--- a/tests/ui/macros/typo-in-norepeat-expr.rs
+++ b/tests/ui/macros/typo-in-norepeat-expr.rs
@@ -1,0 +1,12 @@
+//@ run-rustfix
+macro_rules! m {
+    (begin $ard:ident end) => {
+        [$arg] //~ ERROR: expected expression, found `$`
+        //~^ HELP: there is a macro metavariable with similar name
+    };
+}
+
+fn main() {
+    let x = 1;
+    let _ = m![begin x end];
+}

--- a/tests/ui/macros/typo-in-norepeat-expr.stderr
+++ b/tests/ui/macros/typo-in-norepeat-expr.stderr
@@ -1,0 +1,18 @@
+error: expected expression, found `$`
+  --> $DIR/typo-in-norepeat-expr.rs:4:10
+   |
+LL |         [$arg]
+   |          ^^^^ expected expression
+...
+LL |     let _ = m![begin x end];
+   |             --------------- in this macro invocation
+   |
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: there is a macro metavariable with similar name
+   |
+LL -         [$arg]
+LL +         [$ard]
+   |
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/154014)*
<!-- homu-ignore:end -->

There was an initally opened pr which solve this issue here https://github.com/rust-lang/rust/pull/152679. It got merged but, there was a perf regression. And this new pr is opened to address the problem. The first did the computation of binding and matched_rule and then passed them as owned value down to `diagnostics::emit_frag_parse_err(` but, now this pr address the issue by passing `lhs` and `rules` as borrowed value to from_tts and the move the logic to `diagnostics::emit_frag_parse_err(`.

Fix https://github.com/rust-lang/rust/issues/47452.
