### PR TITLE
core(num): clarify that non-negative square root is returned by isqrt()

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1827,7 +1827,7 @@ macro_rules! int_impl {
             }
         }
 
-        /// Returns the square root of the number, rounded down.
+        /// Returns non-negative the square root of the number, rounded down.
         ///
         /// Returns `None` if `self` is negative.
         ///
@@ -3122,7 +3122,7 @@ macro_rules! int_impl {
             }
         }
 
-        /// Returns the square root of the number, rounded down.
+        /// Returns the non-negative square root of the number, rounded down.
         ///
         /// # Panics
         ///


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
See title.

This fixes rust-lang/rust#154000.

Outstanding question: there are quite a few other places in which the square-root operation is specified to return "the square root". Should we update those places too?