### PR TITLE
Rename trait `IntoQueryParam` to `IntoQueryKey`

### DIFF
--- a/compiler/rustc_middle/src/query/into_query_key.rs
+++ b/compiler/rustc_middle/src/query/into_query_key.rs
@@ -1,59 +1,70 @@
 use rustc_hir::OwnerId;
 use rustc_hir::def_id::{DefId, LocalDefId, LocalModDefId, ModDefId};
 
-/// An analogue of the `Into` trait that's intended only for query parameters.
+/// Argument-conversion trait used by some queries and other `TyCtxt` methods.
 ///
-/// This exists to allow queries to accept either `DefId` or `LocalDefId` while requiring that the
-/// user call `to_def_id` to convert between them everywhere else.
-pub trait IntoQueryParam<P> {
-    fn into_query_param(self) -> P;
+/// A function that accepts an `impl IntoQueryKey<DefId>` argument can be thought
+/// of as taking a [`DefId`], except that callers can also pass a [`LocalDefId`]
+/// or values of other narrower ID types, as long as they have a trivial conversion
+/// to `DefId`.
+///
+/// Using a dedicated trait instead of [`Into`] makes the purpose of the conversion
+/// more explicit, and makes occurrences easier to search for.
+pub trait IntoQueryKey<K> {
+    /// Argument conversion from `Self` to `K`.
+    /// This should always be a very cheap conversion, e.g. [`LocalDefId::to_def_id`].
+    fn into_query_key(self) -> K;
 }
 
-impl<P> IntoQueryParam<P> for P {
+/// Any type can be converted to itself.
+///
+/// This is useful in generic or macro-generated code where we don't know whether
+/// conversion is actually needed, so that we can do a conversion unconditionally.
+impl<K> IntoQueryKey<K> for K {
     #[inline(always)]
-    fn into_query_param(self) -> P {
+    fn into_query_key(self) -> K {
         self
     }
 }
 
-impl IntoQueryParam<LocalDefId> for OwnerId {
+impl IntoQueryKey<LocalDefId> for OwnerId {
     #[inline(always)]
-    fn into_query_param(self) -> LocalDefId {
+    fn into_query_key(self) -> LocalDefId {
         self.def_id
     }
 }
 
-impl IntoQueryParam<DefId> for LocalDefId {
+impl IntoQueryKey<DefId> for LocalDefId {
     #[inline(always)]
-    fn into_query_param(self) -> DefId {
+    fn into_query_key(self) -> DefId {
         self.to_def_id()
     }
 }
 
-impl IntoQueryParam<DefId> for OwnerId {
+impl IntoQueryKey<DefId> for OwnerId {
     #[inline(always)]
-    fn into_query_param(self) -> DefId {
+    fn into_query_key(self) -> DefId {
         self.to_def_id()
     }
 }
 
-impl IntoQueryParam<DefId> for ModDefId {
+impl IntoQueryKey<DefId> for ModDefId {
     #[inline(always)]
-    fn into_query_param(self) -> DefId {
+    fn into_query_key(self) -> DefId {
         self.to_def_id()
     }
 }
 
-impl IntoQueryParam<DefId> for LocalModDefId {
+impl IntoQueryKey<DefId> for LocalModDefId {
     #[inline(always)]
-    fn into_query_param(self) -> DefId {
+    fn into_query_key(self) -> DefId {
         self.to_def_id()
     }
 }
 
-impl IntoQueryParam<LocalDefId> for LocalModDefId {
+impl IntoQueryKey<LocalDefId> for LocalModDefId {
     #[inline(always)]
-    fn into_query_param(self) -> LocalDefId {
+    fn into_query_key(self) -> LocalDefId {
         self.into()
     }
 }

--- a/compiler/rustc_middle/src/query/into_query_key.rs
+++ b/compiler/rustc_middle/src/query/into_query_key.rs
@@ -1,0 +1,59 @@
+use rustc_hir::OwnerId;
+use rustc_hir::def_id::{DefId, LocalDefId, LocalModDefId, ModDefId};
+
+/// An analogue of the `Into` trait that's intended only for query parameters.
+///
+/// This exists to allow queries to accept either `DefId` or `LocalDefId` while requiring that the
+/// user call `to_def_id` to convert between them everywhere else.
+pub trait IntoQueryParam<P> {
+    fn into_query_param(self) -> P;
+}
+
+impl<P> IntoQueryParam<P> for P {
+    #[inline(always)]
+    fn into_query_param(self) -> P {
+        self
+    }
+}
+
+impl IntoQueryParam<LocalDefId> for OwnerId {
+    #[inline(always)]
+    fn into_query_param(self) -> LocalDefId {
+        self.def_id
+    }
+}
+
+impl IntoQueryParam<DefId> for LocalDefId {
+    #[inline(always)]
+    fn into_query_param(self) -> DefId {
+        self.to_def_id()
+    }
+}
+
+impl IntoQueryParam<DefId> for OwnerId {
+    #[inline(always)]
+    fn into_query_param(self) -> DefId {
+        self.to_def_id()
+    }
+}
+
+impl IntoQueryParam<DefId> for ModDefId {
+    #[inline(always)]
+    fn into_query_param(self) -> DefId {
+        self.to_def_id()
+    }
+}
+
+impl IntoQueryParam<DefId> for LocalModDefId {
+    #[inline(always)]
+    fn into_query_param(self) -> DefId {
+        self.to_def_id()
+    }
+}
+
+impl IntoQueryParam<LocalDefId> for LocalModDefId {
+    #[inline(always)]
+    fn into_query_param(self) -> LocalDefId {
+        self.into()
+    }
+}

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1,11 +1,12 @@
 use rustc_hir::def_id::LocalDefId;
 
 pub use self::caches::{DefIdCache, DefaultCache, QueryCache, SingleCache, VecCache};
+pub use self::into_query_key::IntoQueryParam;
 pub use self::job::{QueryJob, QueryJobId, QueryLatch, QueryWaiter};
 pub use self::keys::{AsLocalQueryKey, LocalCrate, QueryKey};
 pub use self::plumbing::{
-    ActiveKeyStatus, CycleError, EnsureMode, IntoQueryParam, QueryMode, QueryState, QuerySystem,
-    QueryVTable, TyCtxtAt, TyCtxtEnsureDone, TyCtxtEnsureOk, TyCtxtEnsureResult,
+    ActiveKeyStatus, CycleError, EnsureMode, QueryMode, QueryState, QuerySystem, QueryVTable,
+    TyCtxtAt, TyCtxtEnsureDone, TyCtxtEnsureOk, TyCtxtEnsureResult,
 };
 pub use self::stack::QueryStackFrame;
 pub use crate::queries::Providers;
@@ -15,6 +16,7 @@ pub(crate) mod arena_cached;
 mod caches;
 pub mod erase;
 pub(crate) mod inner;
+mod into_query_key;
 mod job;
 mod keys;
 pub(crate) mod modifiers;

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1,7 +1,7 @@
 use rustc_hir::def_id::LocalDefId;
 
 pub use self::caches::{DefIdCache, DefaultCache, QueryCache, SingleCache, VecCache};
-pub use self::into_query_key::IntoQueryParam;
+pub use self::into_query_key::IntoQueryKey;
 pub use self::job::{QueryJob, QueryJobId, QueryLatch, QueryWaiter};
 pub use self::keys::{AsLocalQueryKey, LocalCrate, QueryKey};
 pub use self::plumbing::{

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -6,10 +6,7 @@ use rustc_data_structures::hash_table::HashTable;
 use rustc_data_structures::sharded::Sharded;
 use rustc_data_structures::sync::{AtomicU64, WorkerLocal};
 use rustc_errors::Diag;
-use rustc_hir::def_id::{DefId, LocalDefId};
-use rustc_hir::hir_id::OwnerId;
 use rustc_span::Span;
-pub use sealed::IntoQueryParam;
 
 use crate::dep_graph::{DepKind, DepNodeIndex, SerializedDepNodeIndex};
 use crate::ich::StableHashingContext;
@@ -646,69 +643,6 @@ macro_rules! define_callbacks {
 // Re-export `macro_rules!` macros as normal items, so that they can be imported normally.
 pub(crate) use define_callbacks;
 pub(crate) use query_helper_param_ty;
-
-mod sealed {
-    use rustc_hir::def_id::{LocalModDefId, ModDefId};
-
-    use super::{DefId, LocalDefId, OwnerId};
-
-    /// An analogue of the `Into` trait that's intended only for query parameters.
-    ///
-    /// This exists to allow queries to accept either `DefId` or `LocalDefId` while requiring that the
-    /// user call `to_def_id` to convert between them everywhere else.
-    pub trait IntoQueryParam<P> {
-        fn into_query_param(self) -> P;
-    }
-
-    impl<P> IntoQueryParam<P> for P {
-        #[inline(always)]
-        fn into_query_param(self) -> P {
-            self
-        }
-    }
-
-    impl IntoQueryParam<LocalDefId> for OwnerId {
-        #[inline(always)]
-        fn into_query_param(self) -> LocalDefId {
-            self.def_id
-        }
-    }
-
-    impl IntoQueryParam<DefId> for LocalDefId {
-        #[inline(always)]
-        fn into_query_param(self) -> DefId {
-            self.to_def_id()
-        }
-    }
-
-    impl IntoQueryParam<DefId> for OwnerId {
-        #[inline(always)]
-        fn into_query_param(self) -> DefId {
-            self.to_def_id()
-        }
-    }
-
-    impl IntoQueryParam<DefId> for ModDefId {
-        #[inline(always)]
-        fn into_query_param(self) -> DefId {
-            self.to_def_id()
-        }
-    }
-
-    impl IntoQueryParam<DefId> for LocalModDefId {
-        #[inline(always)]
-        fn into_query_param(self) -> DefId {
-            self.to_def_id()
-        }
-    }
-
-    impl IntoQueryParam<LocalDefId> for LocalModDefId {
-        #[inline(always)]
-        fn into_query_param(self) -> LocalDefId {
-            self.into()
-        }
-    }
-}
 
 #[cold]
 pub(crate) fn default_query(name: &str, key: &dyn std::fmt::Debug) -> ! {

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -268,8 +268,8 @@ impl<'tcx> TyCtxt<'tcx> {
 }
 
 macro_rules! query_helper_param_ty {
-    (DefId) => { impl $crate::query::IntoQueryParam<DefId> };
-    (LocalDefId) => { impl $crate::query::IntoQueryParam<LocalDefId> };
+    (DefId) => { impl $crate::query::IntoQueryKey<DefId> };
+    (LocalDefId) => { impl $crate::query::IntoQueryKey<LocalDefId> };
     ($K:ty) => { $K };
 }
 
@@ -410,7 +410,7 @@ macro_rules! define_callbacks {
                     crate::query::inner::query_ensure_ok_or_done(
                         self.tcx,
                         &self.tcx.query_system.query_vtables.$name,
-                        $crate::query::IntoQueryParam::into_query_param(key),
+                        $crate::query::IntoQueryKey::into_query_key(key),
                         $crate::query::EnsureMode::Ok,
                     )
                 }
@@ -430,7 +430,7 @@ macro_rules! define_callbacks {
                     crate::query::inner::query_ensure_result(
                         self.tcx,
                         &self.tcx.query_system.query_vtables.$name,
-                        $crate::query::IntoQueryParam::into_query_param(key),
+                        $crate::query::IntoQueryKey::into_query_key(key),
                     )
                 }
             )*
@@ -444,7 +444,7 @@ macro_rules! define_callbacks {
                     crate::query::inner::query_ensure_ok_or_done(
                         self.tcx,
                         &self.tcx.query_system.query_vtables.$name,
-                        $crate::query::IntoQueryParam::into_query_param(key),
+                        $crate::query::IntoQueryKey::into_query_key(key),
                         $crate::query::EnsureMode::Done,
                     );
                 }
@@ -473,7 +473,7 @@ macro_rules! define_callbacks {
                         self.tcx,
                         self.span,
                         &self.tcx.query_system.query_vtables.$name,
-                        $crate::query::IntoQueryParam::into_query_param(key),
+                        $crate::query::IntoQueryKey::into_query_key(key),
                     ))
                 }
             )*
@@ -481,13 +481,13 @@ macro_rules! define_callbacks {
 
         $(
             #[cfg($feedable)]
-            impl<'tcx, K: $crate::query::IntoQueryParam<$name::Key<'tcx>> + Copy>
+            impl<'tcx, K: $crate::query::IntoQueryKey<$name::Key<'tcx>> + Copy>
                 TyCtxtFeed<'tcx, K>
             {
                 $(#[$attr])*
                 #[inline(always)]
                 pub fn $name(self, value: $name::ProvidedValue<'tcx>) {
-                    let key = self.key().into_query_param();
+                    let key = self.key().into_query_key();
                     let erased_value = $name::provided_to_erased(self.tcx, value);
                     $crate::query::inner::query_feed(
                         self.tcx,

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -61,7 +61,7 @@ use crate::middle::codegen_fn_attrs::{CodegenFnAttrs, TargetFeature};
 use crate::middle::resolve_bound_vars;
 use crate::mir::interpret::{self, Allocation, ConstAllocation};
 use crate::mir::{Body, Local, Place, PlaceElem, ProjectionKind, Promoted};
-use crate::query::{IntoQueryParam, LocalCrate, Providers, QuerySystem, TyCtxtAt};
+use crate::query::{IntoQueryKey, LocalCrate, Providers, QuerySystem, TyCtxtAt};
 use crate::thir::Thir;
 use crate::traits;
 use crate::traits::solve::{ExternalConstraints, ExternalConstraintsData, PredefinedOpaques};
@@ -1111,10 +1111,9 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 
     /// Check if the given `def_id` is a `type const` (mgca)
-    pub fn is_type_const<I: Copy + IntoQueryParam<DefId>>(self, def_id: I) -> bool {
-        // No need to call the query directly in this case always false.
-        let def_kind = self.def_kind(def_id.into_query_param());
-        match def_kind {
+    pub fn is_type_const(self, def_id: impl IntoQueryKey<DefId>) -> bool {
+        let def_id = def_id.into_query_key();
+        match self.def_kind(def_id) {
             DefKind::Const { is_type_const } | DefKind::AssocConst { is_type_const } => {
                 is_type_const
             }
@@ -1168,8 +1167,8 @@ impl<'tcx> TyCtxt<'tcx> {
         self.features_query(())
     }
 
-    pub fn def_key(self, id: impl IntoQueryParam<DefId>) -> rustc_hir::definitions::DefKey {
-        let id = id.into_query_param();
+    pub fn def_key(self, id: impl IntoQueryKey<DefId>) -> rustc_hir::definitions::DefKey {
+        let id = id.into_query_key();
         // Accessing the DefKey is ok, since it is part of DefPathHash.
         if let Some(id) = id.as_local() {
             self.definitions_untracked().def_key(id)
@@ -2705,7 +2704,8 @@ impl<'tcx> TyCtxt<'tcx> {
         self.sess.opts.unstable_opts.build_sdylib_interface
     }
 
-    pub fn intrinsic(self, def_id: impl IntoQueryParam<DefId> + Copy) -> Option<ty::IntrinsicDef> {
+    pub fn intrinsic(self, def_id: impl IntoQueryKey<DefId>) -> Option<ty::IntrinsicDef> {
+        let def_id = def_id.into_query_key();
         match self.def_kind(def_id) {
             DefKind::Fn | DefKind::AssocFn => self.intrinsic_raw(def_id),
             _ => None,
@@ -2774,10 +2774,8 @@ impl<'tcx> TyCtxt<'tcx> {
         find_attr!(self, def_id, DoNotRecommend { .. })
     }
 
-    pub fn is_trivial_const<P>(self, def_id: P) -> bool
-    where
-        P: IntoQueryParam<DefId>,
-    {
+    pub fn is_trivial_const(self, def_id: impl IntoQueryKey<DefId>) -> bool {
+        let def_id = def_id.into_query_key();
         self.trivial_const(def_id).is_some()
     }
 

--- a/compiler/rustc_middle/src/ty/context/impl_interner.rs
+++ b/compiler/rustc_middle/src/ty/context/impl_interner.rs
@@ -14,7 +14,6 @@ use rustc_type_ir::{CollectAndApply, Interner, TypeFoldable, search_graph};
 
 use crate::dep_graph::{DepKind, DepNodeIndex};
 use crate::infer::canonical::CanonicalVarKinds;
-use crate::query::IntoQueryParam;
 use crate::traits::cache::WithDepNode;
 use crate::traits::solve::{
     self, CanonicalInput, ExternalConstraints, ExternalConstraintsData, QueryResult, inspect,
@@ -720,7 +719,6 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
     }
 
     fn item_name(self, id: DefId) -> Symbol {
-        let id = id.into_query_param();
         self.opt_item_name(id).unwrap_or_else(|| {
             bug!("item_name: no name for {:?}", self.def_path(id));
         })

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -117,7 +117,7 @@ use crate::ich::StableHashingContext;
 use crate::metadata::{AmbigModChild, ModChild};
 use crate::middle::privacy::EffectiveVisibilities;
 use crate::mir::{Body, CoroutineLayout, CoroutineSavedLocal, SourceInfo};
-use crate::query::{IntoQueryParam, Providers};
+use crate::query::{IntoQueryKey, Providers};
 use crate::ty;
 use crate::ty::codec::{TyDecoder, TyEncoder};
 pub use crate::ty::diagnostics::*;
@@ -1031,12 +1031,14 @@ impl<'tcx> TypingEnv<'tcx> {
     /// converted to use proper canonical inputs instead.
     pub fn non_body_analysis(
         tcx: TyCtxt<'tcx>,
-        def_id: impl IntoQueryParam<DefId>,
+        def_id: impl IntoQueryKey<DefId>,
     ) -> TypingEnv<'tcx> {
+        let def_id = def_id.into_query_key();
         TypingEnv { typing_mode: TypingMode::non_body_analysis(), param_env: tcx.param_env(def_id) }
     }
 
-    pub fn post_analysis(tcx: TyCtxt<'tcx>, def_id: impl IntoQueryParam<DefId>) -> TypingEnv<'tcx> {
+    pub fn post_analysis(tcx: TyCtxt<'tcx>, def_id: impl IntoQueryKey<DefId>) -> TypingEnv<'tcx> {
+        let def_id = def_id.into_query_key();
         tcx.typing_env_normalized_for_post_analysis(def_id)
     }
 
@@ -1528,8 +1530,8 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 
     /// Look up the name of a definition across crates. This does not look at HIR.
-    pub fn opt_item_name(self, def_id: impl IntoQueryParam<DefId>) -> Option<Symbol> {
-        let def_id = def_id.into_query_param();
+    pub fn opt_item_name(self, def_id: impl IntoQueryKey<DefId>) -> Option<Symbol> {
+        let def_id = def_id.into_query_key();
         if let Some(cnum) = def_id.as_crate_root() {
             Some(self.crate_name(cnum))
         } else {
@@ -1549,8 +1551,8 @@ impl<'tcx> TyCtxt<'tcx> {
     /// [`opt_item_name`] instead.
     ///
     /// [`opt_item_name`]: Self::opt_item_name
-    pub fn item_name(self, id: impl IntoQueryParam<DefId>) -> Symbol {
-        let id = id.into_query_param();
+    pub fn item_name(self, id: impl IntoQueryKey<DefId>) -> Symbol {
+        let id = id.into_query_key();
         self.opt_item_name(id).unwrap_or_else(|| {
             bug!("item_name: no name for {:?}", self.def_path(id));
         })
@@ -1559,8 +1561,8 @@ impl<'tcx> TyCtxt<'tcx> {
     /// Look up the name and span of a definition.
     ///
     /// See [`item_name`][Self::item_name] for more information.
-    pub fn opt_item_ident(self, def_id: impl IntoQueryParam<DefId>) -> Option<Ident> {
-        let def_id = def_id.into_query_param();
+    pub fn opt_item_ident(self, def_id: impl IntoQueryKey<DefId>) -> Option<Ident> {
+        let def_id = def_id.into_query_key();
         let def = self.opt_item_name(def_id)?;
         let span = self
             .def_ident_span(def_id)
@@ -1571,8 +1573,8 @@ impl<'tcx> TyCtxt<'tcx> {
     /// Look up the name and span of a definition.
     ///
     /// See [`item_name`][Self::item_name] for more information.
-    pub fn item_ident(self, def_id: impl IntoQueryParam<DefId>) -> Ident {
-        let def_id = def_id.into_query_param();
+    pub fn item_ident(self, def_id: impl IntoQueryKey<DefId>) -> Ident {
+        let def_id = def_id.into_query_key();
         self.opt_item_ident(def_id).unwrap_or_else(|| {
             bug!("item_ident: no name for {:?}", self.def_path(def_id));
         })
@@ -1902,8 +1904,9 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 
     /// Returns the trait item that is implemented by the given item `DefId`.
-    pub fn trait_item_of(self, def_id: impl IntoQueryParam<DefId>) -> Option<DefId> {
-        self.opt_associated_item(def_id.into_query_param())?.trait_item_def_id()
+    pub fn trait_item_of(self, def_id: impl IntoQueryKey<DefId>) -> Option<DefId> {
+        let def_id = def_id.into_query_key();
+        self.opt_associated_item(def_id)?.trait_item_def_id()
     }
 
     /// If the given `DefId` is an associated item of a trait,
@@ -1915,8 +1918,8 @@ impl<'tcx> TyCtxt<'tcx> {
         }
     }
 
-    pub fn impl_is_of_trait(self, def_id: impl IntoQueryParam<DefId>) -> bool {
-        let def_id = def_id.into_query_param();
+    pub fn impl_is_of_trait(self, def_id: impl IntoQueryKey<DefId>) -> bool {
+        let def_id = def_id.into_query_key();
         let DefKind::Impl { of_trait } = self.def_kind(def_id) else {
             panic!("expected Impl for {def_id:?}");
         };
@@ -1950,15 +1953,17 @@ impl<'tcx> TyCtxt<'tcx> {
         }
     }
 
-    pub fn impl_polarity(self, def_id: impl IntoQueryParam<DefId>) -> ty::ImplPolarity {
+    pub fn impl_polarity(self, def_id: impl IntoQueryKey<DefId>) -> ty::ImplPolarity {
+        let def_id = def_id.into_query_key();
         self.impl_trait_header(def_id).polarity
     }
 
     /// Given an `impl_id`, return the trait it implements.
     pub fn impl_trait_ref(
         self,
-        def_id: impl IntoQueryParam<DefId>,
+        def_id: impl IntoQueryKey<DefId>,
     ) -> ty::EarlyBinder<'tcx, ty::TraitRef<'tcx>> {
+        let def_id = def_id.into_query_key();
         self.impl_trait_header(def_id).trait_ref
     }
 
@@ -1966,21 +1971,22 @@ impl<'tcx> TyCtxt<'tcx> {
     /// Returns `None` if it is an inherent impl.
     pub fn impl_opt_trait_ref(
         self,
-        def_id: impl IntoQueryParam<DefId>,
+        def_id: impl IntoQueryKey<DefId>,
     ) -> Option<ty::EarlyBinder<'tcx, ty::TraitRef<'tcx>>> {
-        let def_id = def_id.into_query_param();
+        let def_id = def_id.into_query_key();
         self.impl_is_of_trait(def_id).then(|| self.impl_trait_ref(def_id))
     }
 
     /// Given the `DefId` of an impl, returns the `DefId` of the trait it implements.
-    pub fn impl_trait_id(self, def_id: impl IntoQueryParam<DefId>) -> DefId {
+    pub fn impl_trait_id(self, def_id: impl IntoQueryKey<DefId>) -> DefId {
+        let def_id = def_id.into_query_key();
         self.impl_trait_ref(def_id).skip_binder().def_id
     }
 
     /// Given the `DefId` of an impl, returns the `DefId` of the trait it implements.
     /// Returns `None` if it is an inherent impl.
-    pub fn impl_opt_trait_id(self, def_id: impl IntoQueryParam<DefId>) -> Option<DefId> {
-        let def_id = def_id.into_query_param();
+    pub fn impl_opt_trait_id(self, def_id: impl IntoQueryKey<DefId>) -> Option<DefId> {
+        let def_id = def_id.into_query_key();
         self.impl_is_of_trait(def_id).then(|| self.impl_trait_id(def_id))
     }
 

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -23,7 +23,7 @@ use smallvec::SmallVec;
 // `pretty` is a separate module only for organization.
 use super::*;
 use crate::mir::interpret::{AllocRange, GlobalAlloc, Pointer, Provenance, Scalar};
-use crate::query::{IntoQueryParam, Providers};
+use crate::query::{IntoQueryKey, Providers};
 use crate::ty::{
     ConstInt, Expr, GenericArgKind, ParamConst, ScalarInt, Term, TermKind, TraitPredicate,
     TypeFoldable, TypeSuperFoldable, TypeSuperVisitable, TypeVisitable, TypeVisitableExt,
@@ -2180,17 +2180,18 @@ fn guess_def_namespace(tcx: TyCtxt<'_>, def_id: DefId) -> Namespace {
 impl<'t> TyCtxt<'t> {
     /// Returns a string identifying this `DefId`. This string is
     /// suitable for user output.
-    pub fn def_path_str(self, def_id: impl IntoQueryParam<DefId>) -> String {
+    pub fn def_path_str(self, def_id: impl IntoQueryKey<DefId>) -> String {
+        let def_id = def_id.into_query_key();
         self.def_path_str_with_args(def_id, &[])
     }
 
     /// For this one we determine the appropriate namespace for the `def_id`.
     pub fn def_path_str_with_args(
         self,
-        def_id: impl IntoQueryParam<DefId>,
+        def_id: impl IntoQueryKey<DefId>,
         args: &'t [GenericArg<'t>],
     ) -> String {
-        let def_id = def_id.into_query_param();
+        let def_id = def_id.into_query_key();
         let ns = guess_def_namespace(self, def_id);
         debug!("def_path_str: def_id={:?}, ns={:?}", def_id, ns);
 
@@ -2200,10 +2201,10 @@ impl<'t> TyCtxt<'t> {
     /// For this one we always use value namespace.
     pub fn value_path_str_with_args(
         self,
-        def_id: impl IntoQueryParam<DefId>,
+        def_id: impl IntoQueryKey<DefId>,
         args: &'t [GenericArg<'t>],
     ) -> String {
-        let def_id = def_id.into_query_param();
+        let def_id = def_id.into_query_key();
         let ns = Namespace::ValueNS;
         debug!("value_path_str: def_id={:?}, ns={:?}", def_id, ns);
 


### PR DESCRIPTION
This is in line with the general trend towards consistently referring to a query method parameter/argument as a “key”.

In addition to the actual renaming, this PR also moves the trait out of `plumbing` and into its own file, and tweaks some of the occurrences of the trait to be more consistent with each other.

r? nnethercote