### PR TITLE
Remove divergence check from check_expr_array

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -1660,14 +1660,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expr: &'tcx hir::Expr<'tcx>,
     ) -> Ty<'tcx> {
         let element_ty = if !args.is_empty() {
-            // This shouldn't happen unless there's another error
-            // (e.g., never patterns in inappropriate contexts).
-            if self.diverges.get() != Diverges::Maybe {
-                self.dcx()
-                    .struct_span_err(expr.span, "unexpected divergence state in checking array")
-                    .delay_as_bug();
-            }
-
             let coerce_to = expected
                 .to_option(self)
                 .and_then(|uty| {

--- a/tests/ui/reachable/never-pattern-closure-param-array.rs
+++ b/tests/ui/reachable/never-pattern-closure-param-array.rs
@@ -1,0 +1,13 @@
+//@ check-pass
+//@ edition: 2024
+
+#![feature(never_patterns)]
+#![allow(incomplete_features)]
+#![allow(unreachable_code)]
+
+fn main() {
+    let _ = Some({
+        return;
+    })
+    .map(|!| [1]);
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#153695.

`check_expr_array` currently assumes it should only be entered with` self.diverges == Diverges::Maybe`, but that assumption does not appear to hold in all valid cases. A never-pattern parameter can seed a function or closure body with inherited `Diverges::Always`, and exprs in that body are still typecked.