### PR TITLE
improve error message when a cfg-ed out item is resolved

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -3204,11 +3204,19 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 continue;
             }
 
-            let item_was = if let CfgEntry::NameValue { value: Some(feature), .. } = cfg.0 {
-                errors::ItemWas::BehindFeature { feature, span: cfg.1 }
-            } else {
-                errors::ItemWas::CfgOut { span: cfg.1 }
+            let span = cfg.1;
+            let item_was = match cfg.0 {
+                CfgEntry::Bool(false, _) => errors::ItemWas::Disabled { span },
+                CfgEntry::Any(ref any, _) if any.is_empty() => errors::ItemWas::Disabled { span },
+                CfgEntry::NameValue { name: sym::feature, value: Some(name), .. } => {
+                    errors::ItemWas::BehindCargoFeature { name, span }
+                }
+                CfgEntry::NameValue { name, value, .. } => {
+                    errors::ItemWas::BehindFeature { name, value, span }
+                }
+                _ => errors::ItemWas::CfgOut { span },
             };
+
             let note = errors::FoundItemConfigureOut { span: ident.span, item_was };
             err.subdiagnostic(note);
         }

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -1384,7 +1384,9 @@ pub(crate) struct FoundItemConfigureOut {
 }
 
 pub(crate) enum ItemWas {
-    BehindFeature { feature: Symbol, span: Span },
+    BehindFeature { name: Symbol, value: Option<Symbol>, span: Span },
+    BehindCargoFeature { name: Symbol, span: Span },
+    Disabled { span: Span },
     CfgOut { span: Span },
 }
 
@@ -1392,12 +1394,30 @@ impl Subdiagnostic for FoundItemConfigureOut {
     fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
         let mut multispan: MultiSpan = self.span.into();
         match self.item_was {
-            ItemWas::BehindFeature { feature, span } => {
-                let value = feature.into_diag_arg(&mut None);
-                let msg = msg!("the item is gated behind the `{$feature}` feature")
-                    .arg("feature", value)
-                    .format();
+            ItemWas::BehindFeature { name, value, span } => {
+                let name = name.into_diag_arg(&mut None);
+                let msg = match value {
+                    Some(value) => {
+                        let value = value.into_diag_arg(&mut None);
+                        msg!("the item is gated behind `{$name} = \"{$value}\"`")
+                            .arg("name", name)
+                            .arg("value", value)
+                            .format()
+                    }
+                    None => msg!("the item is gated behind `{$name}`").arg("name", name).format(),
+                };
                 multispan.push_span_label(span, msg);
+            }
+            ItemWas::BehindCargoFeature { name, span } => {
+                multispan.push_span_label(
+                    span,
+                    msg!("the item is gated behind the `{$name}` feature")
+                        .arg("name", name)
+                        .format(),
+                );
+            }
+            ItemWas::Disabled { span } => {
+                multispan.push_span_label(span, msg!("the item is disabled"))
             }
             ItemWas::CfgOut { span } => {
                 multispan.push_span_label(span, msg!("the item is gated here"));

--- a/tests/ui/cfg/both-true-false.stderr
+++ b/tests/ui/cfg/both-true-false.stderr
@@ -8,7 +8,7 @@ note: found an item that was configured out
   --> $DIR/both-true-false.rs:7:4
    |
 LL | #[cfg(false)]
-   |       ----- the item is gated here
+   |       ----- the item is disabled
 LL | #[cfg(true)]
 LL | fn foo() {}
    |    ^^^
@@ -16,7 +16,7 @@ note: found an item that was configured out
   --> $DIR/both-true-false.rs:11:4
    |
 LL | #[cfg(false)]
-   |       ----- the item is gated here
+   |       ----- the item is disabled
 LL | fn foo() {}
    |    ^^^
 

--- a/tests/ui/cfg/cfg-version/syntax.stderr
+++ b/tests/ui/cfg/cfg-version/syntax.stderr
@@ -133,7 +133,7 @@ note: found an item that was configured out
   --> $DIR/syntax.rs:32:4
    |
 LL | #[cfg(version = "1.43")]
-   |       ---------------- the item is gated behind the `1.43` feature
+   |       ---------------- the item is gated behind `version = "1.43"`
 LL |
 LL | fn key_value_form() {}
    |    ^^^^^^^^^^^^^^

--- a/tests/ui/cfg/cmdline-false.stderr
+++ b/tests/ui/cfg/cmdline-false.stderr
@@ -8,7 +8,7 @@ note: found an item that was configured out
   --> $DIR/cmdline-false.rs:5:4
    |
 LL | #[cfg(false)]
-   |       ----- the item is gated here
+   |       ----- the item is disabled
 LL | fn foo() {}
    |    ^^^
 

--- a/tests/ui/cfg/diagnostics-cross-crate.stderr
+++ b/tests/ui/cfg/diagnostics-cross-crate.stderr
@@ -8,7 +8,7 @@ note: found an item that was configured out
   --> $DIR/auxiliary/cfged_out.rs:6:13
    |
 LL |     #[cfg(false)]
-   |           ----- the item is gated here
+   |           ----- the item is disabled
 LL |     pub mod doesnt_exist {
    |             ^^^^^^^^^^^^
 
@@ -28,7 +28,7 @@ note: found an item that was configured out
   --> $DIR/auxiliary/cfged_out.rs:3:12
    |
 LL |     #[cfg(false)]
-   |           ----- the item is gated here
+   |           ----- the item is disabled
 LL |     pub fn uwu() {}
    |            ^^^
 
@@ -56,7 +56,7 @@ note: found an item that was configured out
   --> $DIR/auxiliary/cfged_out.rs:22:8
    |
 LL | #[cfg(i_dont_exist_and_you_can_do_nothing_about_it)]
-   |       -------------------------------------------- the item is gated here
+   |       -------------------------------------------- the item is gated behind `i_dont_exist_and_you_can_do_nothing_about_it`
 LL | pub fn vanished() {}
    |        ^^^^^^^^
 

--- a/tests/ui/cfg/diagnostics-reexport-2.rs
+++ b/tests/ui/cfg/diagnostics-reexport-2.rs
@@ -2,11 +2,11 @@
 
 mod original {
     #[cfg(false)]
-    //~^ NOTE the item is gated here
-    //~| NOTE the item is gated here
-    //~| NOTE the item is gated here
-    //~| NOTE the item is gated here
-    //~| NOTE the item is gated here
+    //~^ NOTE the item is disabled
+    //~| NOTE the item is disabled
+    //~| NOTE the item is disabled
+    //~| NOTE the item is disabled
+    //~| NOTE the item is disabled
     pub mod gated {
     //~^ NOTE found an item that was configured out
     //~| NOTE found an item that was configured out

--- a/tests/ui/cfg/diagnostics-reexport-2.stderr
+++ b/tests/ui/cfg/diagnostics-reexport-2.stderr
@@ -8,7 +8,7 @@ note: found an item that was configured out
   --> $DIR/diagnostics-reexport-2.rs:10:13
    |
 LL |     #[cfg(false)]
-   |           ----- the item is gated here
+   |           ----- the item is disabled
 ...
 LL |     pub mod gated {
    |             ^^^^^
@@ -23,7 +23,7 @@ note: found an item that was configured out
   --> $DIR/diagnostics-reexport-2.rs:10:13
    |
 LL |     #[cfg(false)]
-   |           ----- the item is gated here
+   |           ----- the item is disabled
 ...
 LL |     pub mod gated {
    |             ^^^^^
@@ -38,7 +38,7 @@ note: found an item that was configured out
   --> $DIR/diagnostics-reexport-2.rs:10:13
    |
 LL |     #[cfg(false)]
-   |           ----- the item is gated here
+   |           ----- the item is disabled
 ...
 LL |     pub mod gated {
    |             ^^^^^
@@ -53,7 +53,7 @@ note: found an item that was configured out
   --> $DIR/diagnostics-reexport-2.rs:10:13
    |
 LL |     #[cfg(false)]
-   |           ----- the item is gated here
+   |           ----- the item is disabled
 ...
 LL |     pub mod gated {
    |             ^^^^^
@@ -68,7 +68,7 @@ note: found an item that was configured out
   --> $DIR/diagnostics-reexport-2.rs:10:13
    |
 LL |     #[cfg(false)]
-   |           ----- the item is gated here
+   |           ----- the item is disabled
 ...
 LL |     pub mod gated {
    |             ^^^^^

--- a/tests/ui/cfg/diagnostics-reexport.rs
+++ b/tests/ui/cfg/diagnostics-reexport.rs
@@ -4,7 +4,7 @@ pub mod inner {
         pub fn uwu() {}
     }
 
-    #[cfg(false)] //~ NOTE the item is gated here
+    #[cfg(false)] //~ NOTE the item is disabled
     pub use super::uwu;
     //~^ NOTE found an item that was configured out
 }
@@ -14,7 +14,7 @@ pub use a::x;
 //~| NOTE no `x` in `a`
 
 mod a {
-    #[cfg(false)] //~ NOTE the item is gated here
+    #[cfg(false)] //~ NOTE the item is disabled
     pub fn x() {}
     //~^ NOTE found an item that was configured out
 }
@@ -25,10 +25,10 @@ pub use b::{x, y};
 //~| NOTE no `y` in `b`
 
 mod b {
-    #[cfg(false)] //~ NOTE the item is gated here
+    #[cfg(false)] //~ NOTE the item is disabled
     pub fn x() {}
     //~^ NOTE found an item that was configured out
-    #[cfg(false)] //~ NOTE the item is gated here
+    #[cfg(false)] //~ NOTE the item is disabled
     pub fn y() {}
     //~^ NOTE found an item that was configured out
 }

--- a/tests/ui/cfg/diagnostics-reexport.stderr
+++ b/tests/ui/cfg/diagnostics-reexport.stderr
@@ -8,7 +8,7 @@ note: found an item that was configured out
   --> $DIR/diagnostics-reexport.rs:18:12
    |
 LL |     #[cfg(false)]
-   |           ----- the item is gated here
+   |           ----- the item is disabled
 LL |     pub fn x() {}
    |            ^
 
@@ -24,14 +24,14 @@ note: found an item that was configured out
   --> $DIR/diagnostics-reexport.rs:29:12
    |
 LL |     #[cfg(false)]
-   |           ----- the item is gated here
+   |           ----- the item is disabled
 LL |     pub fn x() {}
    |            ^
 note: found an item that was configured out
   --> $DIR/diagnostics-reexport.rs:32:12
    |
 LL |     #[cfg(false)]
-   |           ----- the item is gated here
+   |           ----- the item is disabled
 LL |     pub fn y() {}
    |            ^
 
@@ -45,7 +45,7 @@ note: found an item that was configured out
   --> $DIR/diagnostics-reexport.rs:8:20
    |
 LL |     #[cfg(false)]
-   |           ----- the item is gated here
+   |           ----- the item is disabled
 LL |     pub use super::uwu;
    |                    ^^^
 

--- a/tests/ui/cfg/diagnostics-same-crate.rs
+++ b/tests/ui/cfg/diagnostics-same-crate.rs
@@ -1,13 +1,13 @@
 #![allow(unexpected_cfgs)] // since we want to recognize them as unexpected
 
 pub mod inner {
-    #[cfg(false)] //~ NOTE the item is gated here
+    #[cfg(false)] //~ NOTE the item is disabled
     pub fn uwu() {}
     //~^ NOTE found an item that was configured out
 
-    #[cfg(false)] //~ NOTE the item is gated here
-    //~^ NOTE the item is gated here
-    //~| NOTE the item is gated here
+    #[cfg(false)] //~ NOTE the item is disabled
+    //~^ NOTE the item is disabled
+    //~| NOTE the item is disabled
     pub mod doesnt_exist {
         //~^ NOTE found an item that was configured out
         //~| NOTE found an item that was configured out
@@ -37,7 +37,7 @@ mod placeholder {
     //~| NOTE could not find `doesnt_exist` in `inner`
 }
 
-#[cfg(i_dont_exist_and_you_can_do_nothing_about_it)] //~ NOTE the item is gated here
+#[cfg(i_dont_exist_and_you_can_do_nothing_about_it)] //~ NOTE the item is gated behind `i_dont_exist_and_you_can_do_nothing_about_it`
 pub fn vanished() {} //~ NOTE found an item that was configured out
 
 fn main() {

--- a/tests/ui/cfg/diagnostics-same-crate.stderr
+++ b/tests/ui/cfg/diagnostics-same-crate.stderr
@@ -8,7 +8,7 @@ note: found an item that was configured out
   --> $DIR/diagnostics-same-crate.rs:11:13
    |
 LL |     #[cfg(false)]
-   |           ----- the item is gated here
+   |           ----- the item is disabled
 ...
 LL |     pub mod doesnt_exist {
    |             ^^^^^^^^^^^^
@@ -23,7 +23,7 @@ note: found an item that was configured out
   --> $DIR/diagnostics-same-crate.rs:11:13
    |
 LL |     #[cfg(false)]
-   |           ----- the item is gated here
+   |           ----- the item is disabled
 ...
 LL |     pub mod doesnt_exist {
    |             ^^^^^^^^^^^^
@@ -38,7 +38,7 @@ note: found an item that was configured out
   --> $DIR/diagnostics-same-crate.rs:11:13
    |
 LL |     #[cfg(false)]
-   |           ----- the item is gated here
+   |           ----- the item is disabled
 ...
 LL |     pub mod doesnt_exist {
    |             ^^^^^^^^^^^^
@@ -53,7 +53,7 @@ note: found an item that was configured out
   --> $DIR/diagnostics-same-crate.rs:5:12
    |
 LL |     #[cfg(false)]
-   |           ----- the item is gated here
+   |           ----- the item is disabled
 LL |     pub fn uwu() {}
    |            ^^^
 
@@ -87,7 +87,7 @@ note: found an item that was configured out
   --> $DIR/diagnostics-same-crate.rs:41:8
    |
 LL | #[cfg(i_dont_exist_and_you_can_do_nothing_about_it)]
-   |       -------------------------------------------- the item is gated here
+   |       -------------------------------------------- the item is gated behind `i_dont_exist_and_you_can_do_nothing_about_it`
 LL | pub fn vanished() {}
    |        ^^^^^^^^
 

--- a/tests/ui/cfg/nested-cfg-attr-conditional-compilation.rs
+++ b/tests/ui/cfg/nested-cfg-attr-conditional-compilation.rs
@@ -10,7 +10,7 @@
 //!
 //! Added in <https://github.com/rust-lang/rust/pull/34216>.
 
-#[cfg_attr(true, cfg_attr(true, cfg(false)))] //~ NOTE the item is gated here
+#[cfg_attr(true, cfg_attr(true, cfg(false)))] //~ NOTE the item is disabled
 fn f() {} //~ NOTE found an item that was configured out
 
 fn main() {

--- a/tests/ui/cfg/nested-cfg-attr-conditional-compilation.stderr
+++ b/tests/ui/cfg/nested-cfg-attr-conditional-compilation.stderr
@@ -8,7 +8,7 @@ note: found an item that was configured out
   --> $DIR/nested-cfg-attr-conditional-compilation.rs:14:4
    |
 LL | #[cfg_attr(true, cfg_attr(true, cfg(false)))]
-   |                                     ----- the item is gated here
+   |                                     ----- the item is disabled
 LL | fn f() {}
    |    ^
 

--- a/tests/ui/conditional-compilation/cfg-empty-any-all.stderr
+++ b/tests/ui/conditional-compilation/cfg-empty-any-all.stderr
@@ -8,7 +8,7 @@ note: found an item that was configured out
   --> $DIR/cfg-empty-any-all.rs:4:8
    |
 LL | #[cfg(any())]  // Equivalent to cfg(false)
-   |          -- the item is gated here
+   |          -- the item is disabled
 LL | struct Disabled;
    |        ^^^^^^^^
 help: consider importing this unit variant

--- a/tests/ui/conditional-compilation/test-cfg.rs
+++ b/tests/ui/conditional-compilation/test-cfg.rs
@@ -1,10 +1,35 @@
 //@ compile-flags: --cfg foo --check-cfg=cfg(foo,bar)
+#![allow(unexpected_cfgs)]
 
 #[cfg(all(foo, bar))] // foo AND bar
-//~^ NOTE the item is gated here
+//~^ NOTE the item is gated behind `bar`
 fn foo() {} //~ NOTE found an item that was configured out
+
+#[cfg(feature = "meow")]
+//~^ NOTE the item is gated behind the `meow` feature
+fn bar() {} //~ NOTE found an item that was configured out
+
+#[cfg(false)]
+//~^ NOTE the item is disabled
+fn baz() {} //~ NOTE found an item that was configured out
+
+#[cfg(any(bar))]
+//~^ NOTE the item is gated here
+fn quux() {} //~ NOTE found an item that was configured out
+
+#[cfg(any())]
+//~^ NOTE the item is disabled
+fn qsdf() {} //~ NOTE found an item that was configured out
 
 fn main() {
     foo(); //~ ERROR cannot find function `foo` in this scope
+    //~^ NOTE not found in this scope
+    bar(); //~ ERROR cannot find function `bar` in this scope
+    //~^ NOTE not found in this scope
+    baz(); //~ ERROR cannot find function `baz` in this scope
+    //~^ NOTE not found in this scope
+    quux(); //~ ERROR cannot find function `quux` in this scope
+    //~^ NOTE not found in this scope
+    qsdf(); //~ ERROR cannot find function `qsdf` in this scope
     //~^ NOTE not found in this scope
 }

--- a/tests/ui/conditional-compilation/test-cfg.stderr
+++ b/tests/ui/conditional-compilation/test-cfg.stderr
@@ -1,18 +1,78 @@
 error[E0425]: cannot find function `foo` in this scope
-  --> $DIR/test-cfg.rs:8:5
+  --> $DIR/test-cfg.rs:25:5
    |
 LL |     foo();
    |     ^^^ not found in this scope
    |
 note: found an item that was configured out
-  --> $DIR/test-cfg.rs:5:4
+  --> $DIR/test-cfg.rs:6:4
    |
 LL | #[cfg(all(foo, bar))] // foo AND bar
-   |                --- the item is gated here
+   |                --- the item is gated behind `bar`
 LL |
 LL | fn foo() {}
    |    ^^^
 
-error: aborting due to 1 previous error
+error[E0425]: cannot find function `bar` in this scope
+  --> $DIR/test-cfg.rs:27:5
+   |
+LL |     bar();
+   |     ^^^ not found in this scope
+   |
+note: found an item that was configured out
+  --> $DIR/test-cfg.rs:10:4
+   |
+LL | #[cfg(feature = "meow")]
+   |       ---------------- the item is gated behind the `meow` feature
+LL |
+LL | fn bar() {}
+   |    ^^^
+
+error[E0425]: cannot find function `baz` in this scope
+  --> $DIR/test-cfg.rs:29:5
+   |
+LL |     baz();
+   |     ^^^ not found in this scope
+   |
+note: found an item that was configured out
+  --> $DIR/test-cfg.rs:14:4
+   |
+LL | #[cfg(false)]
+   |       ----- the item is disabled
+LL |
+LL | fn baz() {}
+   |    ^^^
+
+error[E0425]: cannot find function `quux` in this scope
+  --> $DIR/test-cfg.rs:31:5
+   |
+LL |     quux();
+   |     ^^^^ not found in this scope
+   |
+note: found an item that was configured out
+  --> $DIR/test-cfg.rs:18:4
+   |
+LL | #[cfg(any(bar))]
+   |          ----- the item is gated here
+LL |
+LL | fn quux() {}
+   |    ^^^^
+
+error[E0425]: cannot find function `qsdf` in this scope
+  --> $DIR/test-cfg.rs:33:5
+   |
+LL |     qsdf();
+   |     ^^^^ not found in this scope
+   |
+note: found an item that was configured out
+  --> $DIR/test-cfg.rs:22:4
+   |
+LL | #[cfg(any())]
+   |          -- the item is disabled
+LL |
+LL | fn qsdf() {}
+   |    ^^^^
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/macros/builtin-std-paths-fail.stderr
+++ b/tests/ui/macros/builtin-std-paths-fail.stderr
@@ -105,7 +105,7 @@ LL | #[std::test]
 note: found an item that was configured out
   --> $SRC_DIR/std/src/lib.rs:LL:COL
    |
-   = note: the item is gated here
+   = note: the item is gated behind `test`
 
 error: aborting due to 16 previous errors
 

--- a/tests/ui/macros/macro-inner-attributes.rs
+++ b/tests/ui/macros/macro-inner-attributes.rs
@@ -5,7 +5,7 @@ macro_rules! test { ($nm:ident,
                      $i:item) => (mod $nm { #![$a] $i }); }
 
 test!(a, //~ NOTE: found an item that was configured out
-      #[cfg(false)], //~ NOTE: the item is gated here
+      #[cfg(false)], //~ NOTE: the item is disabled
       pub fn bar() { });
 
 test!(b,

--- a/tests/ui/macros/macro-inner-attributes.stderr
+++ b/tests/ui/macros/macro-inner-attributes.stderr
@@ -10,7 +10,7 @@ note: found an item that was configured out
 LL | test!(a,
    |       ^
 LL |       #[cfg(false)],
-   |             ----- the item is gated here
+   |             ----- the item is disabled
 help: there is a crate or module with a similar name
    |
 LL -     a::bar();

--- a/tests/ui/macros/macro-outer-attributes.stderr
+++ b/tests/ui/macros/macro-outer-attributes.stderr
@@ -8,7 +8,7 @@ note: found an item that was configured out
   --> $DIR/macro-outer-attributes.rs:10:14
    |
 LL |       #[cfg(false)],
-   |             ----- the item is gated here
+   |             ----- the item is disabled
 LL |       pub fn bar() { });
    |              ^^^
 help: consider importing this function

--- a/tests/ui/rustdoc/cfg-rustdoc.rs
+++ b/tests/ui/rustdoc/cfg-rustdoc.rs
@@ -1,4 +1,4 @@
-#[cfg(doc)] //~ NOTE the item is gated here
+#[cfg(doc)] //~ NOTE the item is gated behind `doc`
 pub struct Foo; //~ NOTE found an item that was configured out
 
 fn main() {

--- a/tests/ui/rustdoc/cfg-rustdoc.stderr
+++ b/tests/ui/rustdoc/cfg-rustdoc.stderr
@@ -8,7 +8,7 @@ note: found an item that was configured out
   --> $DIR/cfg-rustdoc.rs:2:12
    |
 LL | #[cfg(doc)]
-   |       --- the item is gated here
+   |       --- the item is gated behind `doc`
 LL | pub struct Foo;
    |            ^^^
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
the current note for "cannot find function `f` in this scope" is:

```
note: found an item that was configured out
 --> src/main.rs:4:4
  |
3 | #[cfg(foo = "bar")]
  |       ----------- the item is gated behind the `bar` feature
4 | fn f() {}
  |    ^
```

i think mentioning only `bar` in the label is misleading. in more complicated setups, this leads to obscure notes such as "[the item is gated behind the `ptr` feature](https://github.com/rust-lang/annotate-snippets-rs/actions/runs/23159606243/job/67283591574#step:6:24)".

this PR improves the situation by naming both the name and value in the label (in the example i linked, `target_has_atomic` and `ptr`). while i was at it, i also special-cased `#[cfg(false)]`, `#[cfg(any())]` and `#[cfg(feature = "meow")]` (aka Cargo features).

i also tried to use `#[derive(SubDiagnostic)]` on `FoundItemConfigureOut`, with no success (the resulting diagnostic was showing multiple help snippets, i couldn't figure out how to merge them). any help would be appreciated.

~~r? you Esteban, as you added the diagnostic initially - feel free to unassign yourself if necessary :)~~

~~r? @estebank~~

nevermind apparently that's not possible --'

<!-- homu-ignore:end -->
