### PR TITLE
Don't emit rustdoc `missing_doc_code_examples` lint on impl items

### DIFF
--- a/src/librustdoc/passes/check_doc_test_visibility.rs
+++ b/src/librustdoc/passes/check_doc_test_visibility.rs
@@ -79,8 +79,7 @@ pub(crate) fn should_have_doc_example(cx: &DocContext<'_>, item: &clean::Item) -
                 | clean::ProvidedAssocConstItem(..)
                 | clean::ImplAssocConstItem(..)
                 | clean::RequiredAssocTypeItem(..)
-                // check for trait impl
-                | clean::ImplItem(box clean::Impl { trait_: Some(_), .. })
+                | clean::ImplItem(_)
         )
     {
         return false;

--- a/tests/rustdoc-ui/lints/lint-missing-doc-code-example.rs
+++ b/tests/rustdoc-ui/lints/lint-missing-doc-code-example.rs
@@ -78,7 +78,11 @@ impl Clone for Struct {
     }
 }
 
-
+impl Struct { // No doc or code example and it's fine!
+    pub fn bar() {}
+    //~^ ERROR missing code example in this documentation
+    //~| ERROR missing documentation for an associated function
+}
 
 /// doc
 ///

--- a/tests/rustdoc-ui/lints/lint-missing-doc-code-example.stderr
+++ b/tests/rustdoc-ui/lints/lint-missing-doc-code-example.stderr
@@ -1,3 +1,15 @@
+error: missing documentation for an associated function
+  --> $DIR/lint-missing-doc-code-example.rs:82:5
+   |
+LL |     pub fn bar() {}
+   |     ^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/lint-missing-doc-code-example.rs:2:9
+   |
+LL | #![deny(missing_docs)]
+   |         ^^^^^^^^^^^^
+
 error: missing code example in this documentation
   --> $DIR/lint-missing-doc-code-example.rs:38:3
    |
@@ -28,5 +40,11 @@ error: missing code example in this documentation
 LL | /// Doc
    | ^^^^^^^
 
-error: aborting due to 4 previous errors
+error: missing code example in this documentation
+  --> $DIR/lint-missing-doc-code-example.rs:82:5
+   |
+LL |     pub fn bar() {}
+   |     ^^^^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
@lolbinarycat realized in [this comment](https://github.com/rust-lang/rust/pull/153964#discussion_r2953956702) that we weren't testing some cases for the `missing_doc_code_examples` lint. Turns out that it was not handling this case well. =D

So in short: `missing_doc_code_examples` lint should not be emitted on impl items and this PR fixes that.

r? @lolbinarycat 