### PR TITLE
tests: Activate `must_not_suspend` test for `MutexGuard` dropped before `await`

### DIFF
--- a/src/tools/tidy/src/issues.txt
+++ b/src/tools/tidy/src/issues.txt
@@ -1476,7 +1476,6 @@ ui/lint/issue-97094.rs
 ui/lint/issue-99387.rs
 ui/lint/let_underscore/issue-119696-err-on-fn.rs
 ui/lint/let_underscore/issue-119697-extra-let.rs
-ui/lint/must_not_suspend/issue-89562.rs
 ui/lint/unused/issue-103320-must-use-ops.rs
 ui/lint/unused/issue-104397.rs
 ui/lint/unused/issue-105061-array-lint.rs

--- a/tests/ui/lint/must_not_suspend/mutex-guard-dropped-before-await.rs
+++ b/tests/ui/lint/must_not_suspend/mutex-guard-dropped-before-await.rs
@@ -1,9 +1,13 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/89562>
+
 //@ edition:2018
 //@ run-pass
 
+#![feature(must_not_suspend)]
+#![deny(must_not_suspend)]
+
 use std::sync::Mutex;
 
-// Copied from the issue. Allow-by-default for now, so run-pass
 pub async fn foo() {
     let foo = Mutex::new(1);
     let lock = foo.lock().unwrap();


### PR DESCRIPTION
After bisect it turns out that the test passes in `nightly-2023-09-24` but fails in `nightly-2023-09-23`:

    $ rustc +nightly-2023-09-23 --edition 2018 tests/ui/lint/must_not_suspend/mutex-guard-dropped-before-await.rs
    error: `MutexGuard` held across a suspend point, but should not be
      --> tests/ui/lint/must_not_suspend/mutex-guard-dropped-before-await.rs:13:9
       |
    13 |     let lock = foo.lock().unwrap();
       |         ^^^^
    ...
    18 |     bar().await;
       |           ----- the value is held across this suspend point
       |

That leaves us with

<details>
<summary>git log e4133ba9b1a150..13e6f24b9adda67 --no-merges --oneline </summary>

bffb3467e17 Make test more robust to opts.
44ac8dcc71c Remove GeneratorWitness and rename GeneratorWitnessMIR.
855a75b6d68 Remove useless wrapper.
baa64b0e770 Remove dead error code.
6aa12689005 Bless clippy.
d989e14cf28 Bless mir-opt
211d2ed07bb Bless tests.
286502c9ed7 Enable drop_tracking_mir by default.
a626caaad97 Revert duplication of tests.
ff032043653 Fold lifetimes before substitution.
9450b759865 Do not construct def_path_str for MustNotSuspend.
58ef3a0ec9a diagnostics: simpler 83556 handling by bailing out
79d685325c1 Check types live across yields in generators too
c21867f9f6a Check that closure's by-value captures are sized
d3dea30cb4c Point at cause of expectation of `break` value when possible
4ed4913e67c Merge `ExternProviders` into the general `Providers` struct
2ba911c8329 Have a single struct for queries and hook
9090ed81198 Fix test on targets with crt-static default
5db9a5ee385 Update cargo
9defc971f1e Add tracing instrumentation, just like queries automatically add it
2157f317316 Add a way to decouple the implementation and the declaration of a TyCtxt method.
d5ec9af09da Add test to guard against VecDeque optimization regression
3799af3337d diagnostics: avoid mismatch between variance index and hir generic
34c248d31f8 compiletest: load supports-xray from target spec
64e27cb4d9e compiletest: load supported sanitizers from target spec
bc7bb3c8e7f compiletest: use builder pattern to construct Config in tests

</details>

of which 286502c9ed7 (https://github.com/rust-lang/rust/pull/107421) seems most likely. I can't find an existing test except the "inactive" one, so let's simply activate it.

Closes rust-lang/rust#89562 which is where the activated test comes from. The test was originally added in rust-lang/rust#89826.

Tracking issue:
- rust-lang/rust#83310

