### PR TITLE
Emit visibility DI flags for union types and fields

### DIFF
--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -1263,7 +1263,7 @@ fn build_union_type_di_node<'ll, 'tcx>(
             def_location,
             size_and_align_of(union_ty_and_layout),
             Some(containing_scope),
-            DIFlags::FlagZero,
+            visibility_di_flags(cx, union_def_id, union_def_id),
         ),
         // Fields:
         |cx, owner| {
@@ -1284,7 +1284,7 @@ fn build_union_type_di_node<'ll, 'tcx>(
                         f.name.as_str(),
                         field_layout,
                         Size::ZERO,
-                        DIFlags::FlagZero,
+                        visibility_di_flags(cx, f.did, union_def_id),
                         type_di_node(cx, field_layout.ty),
                         def_id,
                     )

--- a/tests/codegen-llvm/debug-accessibility/crate-union.rs
+++ b/tests/codegen-llvm/debug-accessibility/crate-union.rs
@@ -1,0 +1,23 @@
+//@ compile-flags: -C debuginfo=2
+
+#![allow(dead_code)]
+
+// Checks that visibility information is present in the debuginfo for crate-visibility unions.
+
+mod module {
+    use std::hint::black_box;
+
+    pub(crate) union CrateFooUnion {
+        x: u32,
+    }
+
+    // CHECK: {{!.*}} = !DICompositeType(tag: DW_TAG_union_type, name: "CrateFooUnion"{{.*}}flags: DIFlagProtected{{.*}})
+
+    pub fn use_everything() {
+        black_box(CrateFooUnion { x: 2 });
+    }
+}
+
+fn main() {
+    module::use_everything();
+}

--- a/tests/codegen-llvm/debug-accessibility/private-union.rs
+++ b/tests/codegen-llvm/debug-accessibility/private-union.rs
@@ -1,0 +1,17 @@
+//@ compile-flags: -C debuginfo=2
+
+#![allow(dead_code)]
+
+// Checks that visibility information is present in the debuginfo for private unions.
+
+use std::hint::black_box;
+
+union PrivateFooUnion {
+    x: u32,
+}
+
+// CHECK: {{!.*}} = !DICompositeType(tag: DW_TAG_union_type, name: "PrivateFooUnion"{{.*}}flags: DIFlagPrivate{{.*}})
+
+fn main() {
+    black_box(PrivateFooUnion { x: 1 });
+}

--- a/tests/codegen-llvm/debug-accessibility/public-union.rs
+++ b/tests/codegen-llvm/debug-accessibility/public-union.rs
@@ -1,0 +1,17 @@
+//@ compile-flags: -C debuginfo=2
+
+#![allow(dead_code)]
+
+// Checks that visibility information is present in the debuginfo for public unions.
+
+use std::hint::black_box;
+
+pub union PublicFooUnion {
+    x: u32,
+}
+
+// CHECK: {{!.*}} = !DICompositeType(tag: DW_TAG_union_type, name: "PublicFooUnion"{{.*}}flags: DIFlagPublic{{.*}})
+
+fn main() {
+    black_box(PublicFooUnion { x: 4 });
+}

--- a/tests/codegen-llvm/debug-accessibility/super-union.rs
+++ b/tests/codegen-llvm/debug-accessibility/super-union.rs
@@ -1,0 +1,23 @@
+//@ compile-flags: -C debuginfo=2
+
+#![allow(dead_code)]
+
+// Checks that visibility information is present in the debuginfo for super-visibility unions.
+
+mod module {
+    use std::hint::black_box;
+
+    pub(super) union SuperFooUnion {
+        x: u32,
+    }
+
+    // CHECK: {{!.*}} = !DICompositeType(tag: DW_TAG_union_type, name: "SuperFooUnion"{{.*}}flags: DIFlagProtected{{.*}})
+
+    pub fn use_everything() {
+        black_box(SuperFooUnion { x: 3 });
+    }
+}
+
+fn main() {
+    module::use_everything();
+}

--- a/tests/codegen-llvm/debug-accessibility/union-fields.rs
+++ b/tests/codegen-llvm/debug-accessibility/union-fields.rs
@@ -1,0 +1,30 @@
+//@ compile-flags: -C debuginfo=2
+
+#![allow(dead_code)]
+
+// Checks that visibility information is present in the debuginfo for union fields.
+
+mod module {
+    use std::hint::black_box;
+
+    union UnionFields {
+        a: u32,
+        pub(crate) b: u32,
+        pub(super) c: u32,
+        pub d: u32,
+    }
+
+    // CHECK: [[UnionFields:!.*]] = !DICompositeType(tag: DW_TAG_union_type, name: "UnionFields"{{.*}}flags: DIFlagPrivate{{.*}})
+    // CHECK: {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: [[UnionFields]]{{.*}}flags: DIFlagPrivate{{.*}})
+    // CHECK: {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: [[UnionFields]]{{.*}}flags: DIFlagProtected{{.*}})
+    // CHECK: {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "c", scope: [[UnionFields]]{{.*}}flags: DIFlagProtected{{.*}})
+    // CHECK: {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "d", scope: [[UnionFields]]{{.*}}flags: DIFlagPublic{{.*}})
+
+    pub fn use_everything() {
+        black_box(UnionFields { a: 1 });
+    }
+}
+
+fn main() {
+    module::use_everything();
+}


### PR DESCRIPTION
## Summary

`build_union_type_di_node` passes `DIFlags::FlagZero` for both the union type stub and all field nodes, causing DWARF output to omit `DW_ACCESS_public`/`DW_ACCESS_private` visibility attributes. The equivalent `build_struct_type_di_node` correctly calls `visibility_di_flags` for both type and field nodes.

## Reproduction

```rust
pub struct MyStruct {
    pub x: i32,
    y: i32,
}

pub union MyUnion {
    pub a: i32,
    b: f32,
}

fn main() {
    let s = MyStruct { x: 1, y: 2 };
    let u = MyUnion { a: 42 };
    println!("{} {}", s.x, unsafe { u.a });
}
```

Compiling with `rustc -g --emit=llvm-ir` on nightly (1.96.0-nightly 2026-03-17) and inspecting the LLVM IR:

**Struct fields** — correct visibility flags:
```
!300 = !DIDerivedType(tag: DW_TAG_member, name: "x", ..., flags: DIFlagPublic)
!301 = !DIDerivedType(tag: DW_TAG_member, name: "y", ..., flags: DIFlagPrivate)
```

**Union fields** — missing visibility flags:
```
!306 = !DIDerivedType(tag: DW_TAG_member, name: "a", ...)
!307 = !DIDerivedType(tag: DW_TAG_member, name: "b", ...)
```

## Fix

Replace `DIFlags::FlagZero` with `visibility_di_flags(cx, ...)` on both the type stub and field nodes in `build_union_type_di_node`, matching the pattern already used in `build_struct_type_di_node`.

## Tests

Added 5 codegen tests in `tests/codegen-llvm/debug-accessibility/` covering union type visibility at all levels (private, public, crate, super) and union field visibility, matching the existing test coverage for structs and enums in the same directory.

## Note on C-ABI compatibility

While C/C++ unions do not have private fields, the DWARF standard itself supports `DW_ACCESS_*` attributes on `DW_TAG_union_type` members. GDB and LLDB both accept these flags — they already encounter them on Rust enums which are emitted as `DW_TAG_union_type` on MSVC targets with visibility flags (see existing tests in `debug-accessibility/`). This change does not introduce a novel DWARF pattern; it extends an existing one to cover a missing case.