### PR TITLE
Rewrite `query_ensure_result`.

### DIFF
--- a/compiler/rustc_middle/src/query/inner.rs
+++ b/compiler/rustc_middle/src/query/inner.rs
@@ -77,23 +77,34 @@ where
     C: QueryCache<Value = Erased<Result<T, ErrorGuaranteed>>>,
     Result<T, ErrorGuaranteed>: Erasable,
 {
+    let convert = |value: Erased<Result<T, ErrorGuaranteed>>| -> Result<(), ErrorGuaranteed> {
+        match erase::restore_val(value) {
+            Ok(_) => Ok(()),
+            Err(guar) => Err(guar),
+        }
+    };
+
     match try_get_cached(tcx, &query.cache, key) {
-        Some(value) => erase::restore_val(value).map(drop),
-        None => (query.execute_query_fn)(
-            tcx,
-            DUMMY_SP,
-            key,
-            QueryMode::Ensure { ensure_mode: EnsureMode::Ok },
-        )
-        .map(erase::restore_val)
-        .map(|value| value.map(drop))
-        // Either we actually executed the query, which means we got a full `Result`,
-        // or we can just assume the query succeeded, because it was green in the
-        // incremental cache. If it is green, that means that the previous compilation
-        // that wrote to the incremental cache compiles successfully. That is only
-        // possible if the cache entry was `Ok(())`, so we emit that here, without
-        // actually encoding the `Result` in the cache or loading it from there.
-        .unwrap_or(Ok(())),
+        Some(value) => convert(value),
+        None => {
+            match (query.execute_query_fn)(
+                tcx,
+                DUMMY_SP,
+                key,
+                QueryMode::Ensure { ensure_mode: EnsureMode::Ok },
+            ) {
+                // We executed the query. Convert the successful result.
+                Some(res) => convert(res),
+
+                // Reaching here means we didn't execute the query, but we can just assume the
+                // query succeeded, because it was green in the incremental cache. If it is green,
+                // that means that the previous compilation that wrote to the incremental cache
+                // compiles successfully. That is only possible if the cache entry was `Ok(())`, so
+                // we emit that here, without actually encoding the `Result` in the cache or
+                // loading it from there.
+                None => Ok(()),
+            }
+        }
     }
 }
 


### PR DESCRIPTION
It currently uses chaining which is concise but hard to read. There are up to four implicit matches occurring after the call to `execute_query_fn`.
- The first `map` on `Option<Erased<Result<T, ErrorGuaranteed>>>`.
- The second `map` on `Option<Result<T, ErrorGuaranteed>>`.
- The third `map` on `Result<T, ErrorGuaranteed>`.
- The `unwrap_or` on `Option<Result<(), ErrorGuaranteed>>`.

This commit rewrites it to use at most two matches.
- An explicit match on `Option<Erased<Result<T, ErrorGuaranteed>>>`.
- An explicit match on `Result<T, ErrorGuaranteed>`.

This is easier to read. It's also more efficient, though the code isn't hot enough for that to matter.

r? @Zalathar 