### PR TITLE
Optimize 128-bit integer formatting

### DIFF
--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -823,7 +823,7 @@ fn enc_16lsd<const OFFSET: usize>(buf: &mut [MaybeUninit<u8>], n: u64) {
     let mut remain = n;
 
     // Format per four digits from the lookup table.
-    for quad_index in (0..4).rev() {
+    for quad_index in (1..4).rev() {
         // pull two pairs
         let quad = remain % 1_00_00;
         remain /= 1_00_00;
@@ -834,6 +834,14 @@ fn enc_16lsd<const OFFSET: usize>(buf: &mut [MaybeUninit<u8>], n: u64) {
         buf[quad_index * 4 + OFFSET + 2].write(DECIMAL_PAIRS[pair2 * 2 + 0]);
         buf[quad_index * 4 + OFFSET + 3].write(DECIMAL_PAIRS[pair2 * 2 + 1]);
     }
+
+    // final two pairs
+    let pair1 = (remain / 100) as usize;
+    let pair2 = (remain % 100) as usize;
+    buf[OFFSET + 0].write(DECIMAL_PAIRS[pair1 * 2 + 0]);
+    buf[OFFSET + 1].write(DECIMAL_PAIRS[pair1 * 2 + 1]);
+    buf[OFFSET + 2].write(DECIMAL_PAIRS[pair2 * 2 + 0]);
+    buf[OFFSET + 3].write(DECIMAL_PAIRS[pair2 * 2 + 1]);
 }
 
 /// Euclidean division plus remainder with constant 1E16 basically consumes 16


### PR DESCRIPTION
The compiler is unaware of the restricted range of the input, so it is unable to optimize out the final division and modulus. By doing this manually, we get a nontrivial performance gain.

r? @dtolnay 

(copied from https://github.com/dtolnay/itoa/pull/68)