### PR TITLE
Preserve braces around `self` in use tree pretty printing

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state/item.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/item.rs
@@ -881,7 +881,13 @@ impl<'a> State<'a> {
                 }
                 if items.is_empty() {
                     self.word("{}");
-                } else if let [(item, _)] = items.as_slice() {
+                } else if let [(item, _)] = items.as_slice()
+                    && !item
+                        .prefix
+                        .segments
+                        .first()
+                        .is_some_and(|seg| seg.ident.name == rustc_span::symbol::kw::SelfLower)
+                {
                     self.print_use_tree(item);
                 } else {
                     let cb = self.cbox(INDENT_UNIT);

--- a/tests/pretty/use-self-braces.rs
+++ b/tests/pretty/use-self-braces.rs
@@ -1,0 +1,10 @@
+//@ pp-exact
+//@ edition:2021
+
+#![allow(unused_imports)]
+
+// Braces around `self` must be preserved, because `use foo::self` is not valid Rust.
+use std::io::{self};
+use std::fmt::{self, Debug};
+
+fn main() {}


### PR DESCRIPTION
The AST pretty printer strips braces from single-item `use` sub-groups, simplifying `use foo::{Bar}` to `use foo::Bar`. However, when the single item is `self`, this produces `use foo::self` which is not valid Rust (E0429) — the grammar requires `use foo::{self}`.

This affects both `stringify!` and `rustc -Zunpretty=expanded`, causing `cargo expand` output to be unparseable when a crate uses `use path::{self}` imports (a common pattern in the ecosystem).

The fix checks whether the single nested item's path starts with `self` before stripping braces. If so, the braces are preserved.

## Example

**before** (`rustc 1.96.0-nightly (3b1b0ef4d 2026-03-11)`):

```rust
#![feature(prelude_import)]
//@ pp-exact
//@ edition:2021

#![allow(unused_imports)]
extern crate std;
#[prelude_import]
use std::prelude::rust_2021::*;

// Braces around `self` must be preserved, because `use foo::self` is not valid Rust.
use std::io::self;
use std::fmt::{self, Debug};

fn main() {}
```

**after** (this branch):

```rust
#![feature(prelude_import)]
//@ pp-exact
//@ edition:2021

#![allow(unused_imports)]
extern crate std;
#[prelude_import]
use std::prelude::rust_2021::*;

// Braces around `self` must be preserved, because `use foo::self` is not valid Rust.
use std::io::{self};
use std::fmt::{self, Debug};

fn main() {}
```

Notice the `use std::io::self` (invalid, E0429) in the before becomes `use std::io::{self}` in the after.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
