### PR TITLE
const validity checking: do not recurse to references inside MaybeDangling

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -680,8 +680,11 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
                 format!("encountered a {ptr_kind} pointing to uninhabited type {ty}")
             )
         }
-        // Recursive checking
-        if let Some(ref_tracking) = self.ref_tracking.as_deref_mut() {
+
+        // Recursive checking (but not inside `MaybeDangling` of course).
+        if let Some(ref_tracking) = self.ref_tracking.as_deref_mut()
+            && !self.may_dangle
+        {
             // Proceed recursively even for ZST, no reason to skip them!
             // `!` is a ZST and we want to validate it.
             if let Some(ctfe_mode) = self.ctfe_mode {

--- a/tests/ui/consts/const-eval/valid-const.rs
+++ b/tests/ui/consts/const-eval/valid-const.rs
@@ -1,10 +1,12 @@
 //@ check-pass
 //
 // Some constants that *are* valid
+#![feature(maybe_dangling)]
 
 use std::mem;
 use std::ptr::NonNull;
 use std::num::NonZero;
+use std::mem::MaybeDangling;
 
 const NON_NULL_PTR1: NonNull<u8> = unsafe { mem::transmute(1usize) };
 const NON_NULL_PTR2: NonNull<u8> = unsafe { mem::transmute(&0) };
@@ -13,5 +15,7 @@ const NON_NULL_U8: NonZero<u8> = unsafe { mem::transmute(1u8) };
 const NON_NULL_USIZE: NonZero<usize> = unsafe { mem::transmute(1usize) };
 
 const UNIT: () = ();
+
+const INVALID_INSIDE_MAYBE_DANGLING: MaybeDangling<&bool> = unsafe { std::mem::transmute(&5u8) };
 
 fn main() {}


### PR DESCRIPTION
This arguably should be allowed, but we currently reject it:
```rust
#![feature(maybe_dangling)]
use std::mem::MaybeDangling;

const X: MaybeDangling<&bool> = unsafe { std::mem::transmute(&5u8) };
```

r? @WaffleLapkin 