### PR TITLE
Reduce `rustc_errors::DecorateDiagCompat` size by boxing all its variants

### DIFF
--- a/compiler/rustc_errors/src/decorate_diag.rs
+++ b/compiler/rustc_errors/src/decorate_diag.rs
@@ -11,7 +11,7 @@ use crate::{Diag, DiagCtxtHandle, Diagnostic, Level};
 /// variants requires types we don't have yet. So, handle that case separately.
 pub enum DecorateDiagCompat {
     Dynamic(Box<dyn for<'a> FnOnce(DiagCtxtHandle<'a>, Level) -> Diag<'a, ()> + DynSend + 'static>),
-    Builtin(BuiltinLintDiag),
+    Builtin(Box<BuiltinLintDiag>),
 }
 
 impl std::fmt::Debug for DecorateDiagCompat {
@@ -30,7 +30,7 @@ impl<D: for<'a> Diagnostic<'a, ()> + DynSend + 'static> From<D> for DecorateDiag
 impl From<BuiltinLintDiag> for DecorateDiagCompat {
     #[inline]
     fn from(b: BuiltinLintDiag) -> Self {
-        Self::Builtin(b)
+        Self::Builtin(Box::new(b))
     }
 }
 

--- a/compiler/rustc_lint/src/early/diagnostics.rs
+++ b/compiler/rustc_lint/src/early/diagnostics.rs
@@ -22,12 +22,12 @@ mod check_cfg;
 pub struct DecorateBuiltinLint<'sess, 'tcx> {
     pub sess: &'sess Session,
     pub tcx: Option<TyCtxt<'tcx>>,
-    pub diagnostic: BuiltinLintDiag,
+    pub diagnostic: Box<BuiltinLintDiag>,
 }
 
 impl<'a> Diagnostic<'a, ()> for DecorateBuiltinLint<'_, '_> {
     fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, ()> {
-        match self.diagnostic {
+        match *self.diagnostic {
             BuiltinLintDiag::UnicodeTextFlow(comment_span, content) => {
                 let spans: Vec<_> = content
                     .char_indices()


### PR DESCRIPTION
Let's see if it has any performance impact.

r? ghost