### PR TITLE
tests: Add regression test for async closures involving HRTBs

### DIFF
--- a/tests/ui/async-await/async-closures/unifying-function-types-involving-hrtb.rs
+++ b/tests/ui/async-await/async-closures/unifying-function-types-involving-hrtb.rs
@@ -1,0 +1,33 @@
+//! Regresssion test for <https://github.com/rust-lang/rust/issues/59337>.
+
+//@ edition:2018
+//@ check-pass
+
+use std::future::Future;
+
+trait Foo<'a> {
+    type Future: Future<Output = u8> + 'a;
+
+    fn start(self, f: &'a u8) -> Self::Future;
+}
+
+impl<'a, Fn, Fut> Foo<'a> for Fn
+where
+    Fn: FnOnce(&'a u8) -> Fut,
+    Fut: Future<Output = u8> + 'a,
+{
+    type Future = Fut;
+
+    fn start(self, f: &'a u8) -> Self::Future { (self)(f) }
+}
+
+fn foo<F>(f: F) where F: for<'a> Foo<'a> {
+    let bar = 5;
+    f.start(&bar);
+}
+
+fn main() {
+    foo(async move | f: &u8 | { *f });
+
+    foo({ async fn baz(f: &u8) -> u8 { *f } baz });
+}


### PR DESCRIPTION
I suspect the original code from rust-lang/rust#59337 had several problems. The last problem fixed that made the code compile entered `nightly-2024-02-11`. The code fails to build with `nightly-2024-02-10`:

    $ rustc +nightly-2024-02-10 --edition 2018 tests/ui/async-await/async-closures/unifying-function-types-involving-hrtb.rs
    error[E0277]: expected a `FnOnce(&u8)` closure, found `{coroutine-closure@tests/ui/async-await/async-closures/unifying-function-types-involving-hrtb.rs:31:9: 31:30}`
      --> tests/ui/async-await/async-closures/unifying-function-types-involving-hrtb.rs:31:9
       |
    31 |     foo(async move | f: &u8 | { *f });
       |     --- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an `FnOnce(&u8)` closure, found `{coroutine-closure@tests/ui/async-await/async-closures/unifying-function-types-involving-hrtb.rs:31:9: 31:30}`
       |     |
       |     required by a bound introduced by this call
       |

(Note that you must add `#![feature(async_closure)]` to test with such old nightlies, since they are from before stabilization of async closures.)

So one of the following commits made the code build:

<details>

<summary>git log d44e3b95cb9d4..6cc4843512d613f  --no-merges --oneline</summary>

4def37386c1 manually bless an aarch64 test
04bc624ea0a rebless after rebase
77f8c3caea9 detect consts that reference extern statics
9c0623fe8f2 validation: descend from consts into statics
4e77e368ebc unstably allow constants to refer to statics and read from immutable statics
a2479a4ae75 Remove unnecessary `min_specialization` after bootstrap
7b73e4fd44c Allow restricted trait impls in macros with `min_specialization`
e6f5af96713 Remove unused fn
fde695a2d19 Add a helpful suggestion
d7263d7aada Change wording
973bbfbd23d No more associated type bounds in dyn trait
cf1096eb72e Remove unnecessary `#![feature(min_specialization)]`
3d4a9f50478 Turn the "no saved object file in work product" ICE into a translatable fatal error
bb60ded24b6 Loosen an assertion to account for stashed errors.
69a5264a521 Move some tests
4ef1790b4e5 tidy
e59d9b171ed Avoid a collection and iteration on empty passes
8b6b9c5efc6 ast_lowering: Fix regression in `use ::{}` imports.
83f3bc42714 Update jobserver-rs to 0.1.28
14e0dab96bb Unify item relative path computation in one function
f3c24833c5a Add regression test for non local items link generation
f0d002b890a Correctly generate path for non-local items in source code pages
c94bbb24db3 Clarify that atomic and regular integers can differ in alignment
7057188c549 make it recursive
7a63d3f16a4 Add tests for untested capabilities
548929dc5e7 Don't unnecessarily lower associated type bounds to impl trait
22d582a38d3 For a rigid projection, recursively look at the self type's item bounds
540be28f6c2 sort suggestions for object diagnostic
9322882adeb Add a couple more tests
3bb384aad6e Prefer AsyncFn* over Fn* for coroutine-closures
aa6f45eb791 Use `ensure` when the result of the query is not needed beyond its `Result`ness
8ff1994ec06 Fix whitespace issues that tidy caught
f0c6f5a7feb Add documentation on `str::starts_with`
63cc3c7b8f4 test `llvm_out` behaviour
7fb4512ee8d fix `llvm_out` to use the correct LLVM root
b8c93f12236 Coroutine closures implement regular Fn traits, when possible
08af64e96be Regular closures now built-in impls for AsyncFn*
0dd40786b55 Harmonize blanket implementations for AsyncFn* traits
f3d32f2f0cd Flatten confirmation logic
9a819ab8f7f static mut: allow reference to arbitrary types, not just slices and arrays

</details>

This was probably fixed by 3bb384aad6e7f6 (https://github.com/rust-lang/rust/pull/120712). That PR does not have a big tests diff, so I assume the test we add does not exist elsewhere. It's hard to know for sure.

Closes rust-lang/rust#59337 since we add the test from that issue. In that issue there is a [proposal](https://github.com/rust-lang/rust/issues/59337#issuecomment-826441716) for two minimized versions, but they both fail to compile with `nightly-2024-02-11`, so those reproducers are for different problem(s).

### Tracking Issue
- https://github.com/rust-lang/rust/issues/62290