### PR TITLE
std::net: clamp multicast ttl value to u8 max.

### DIFF
--- a/library/std/src/net/udp.rs
+++ b/library/std/src/net/udp.rs
@@ -478,8 +478,8 @@ impl UdpSocket {
     ///
     /// Note that this might not have any effect on IPv6 sockets.
     ///
-    /// Since the underlying socket option type is a byte-sized value
-    /// on some platforms, any value above 255 will be clamped to 255.
+    /// Since the underlying socket option value is byte-sized,
+    /// any value above 255 will result in an error.
     ///
     /// # Examples
     ///

--- a/library/std/src/net/udp.rs
+++ b/library/std/src/net/udp.rs
@@ -478,6 +478,9 @@ impl UdpSocket {
     ///
     /// Note that this might not have any effect on IPv6 sockets.
     ///
+    /// Since the underlying socket option type is a byte-sized value
+    /// on some platforms, any value above 255 will be clamped to 255.
+    ///
     /// # Examples
     ///
     /// ```no_run

--- a/library/std/src/sys/net/connection/socket/mod.rs
+++ b/library/std/src/sys/net/connection/socket/mod.rs
@@ -759,11 +759,11 @@ impl UdpSocket {
     }
 
     pub fn set_multicast_ttl_v4(&self, multicast_ttl_v4: u32) -> io::Result<()> {
+        let ttl: u8 = multicast_ttl_v4
+            .try_into()
+            .map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?;
         unsafe {
-            let ttl: IpV4MultiCastType = multicast_ttl_v4
-                .try_into()
-                .map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?;
-            setsockopt(&self.inner, c::IPPROTO_IP, c::IP_MULTICAST_TTL, ttl)
+            setsockopt(&self.inner, c::IPPROTO_IP, c::IP_MULTICAST_TTL, ttl as IpV4MultiCastType)
         }
     }
 

--- a/library/std/src/sys/net/connection/socket/mod.rs
+++ b/library/std/src/sys/net/connection/socket/mod.rs
@@ -764,7 +764,7 @@ impl UdpSocket {
                 &self.inner,
                 c::IPPROTO_IP,
                 c::IP_MULTICAST_TTL,
-                multicast_ttl_v4 as IpV4MultiCastType,
+                cmp::min(multicast_ttl_v4, u8::MAX as u32) as IpV4MultiCastType,
             )
         }
     }

--- a/library/std/src/sys/net/connection/socket/mod.rs
+++ b/library/std/src/sys/net/connection/socket/mod.rs
@@ -760,12 +760,10 @@ impl UdpSocket {
 
     pub fn set_multicast_ttl_v4(&self, multicast_ttl_v4: u32) -> io::Result<()> {
         unsafe {
-            setsockopt(
-                &self.inner,
-                c::IPPROTO_IP,
-                c::IP_MULTICAST_TTL,
-                cmp::min(multicast_ttl_v4, u8::MAX as u32) as IpV4MultiCastType,
-            )
+            let ttl: IpV4MultiCastType = multicast_ttl_v4
+                .try_into()
+                .map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?;
+            setsockopt(&self.inner, c::IPPROTO_IP, c::IP_MULTICAST_TTL, ttl)
         }
     }
 


### PR DESCRIPTION
on some platforms the underlying type is c_uchar,
values above 255 would silently truncate.