### PR TITLE
Inject the `hermit` crate if necessary

### DIFF
--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -25,8 +25,8 @@ use rustc_middle::ty::{TyCtxt, TyCtxtFeed};
 use rustc_proc_macro::bridge::client::ProcMacro;
 use rustc_session::Session;
 use rustc_session::config::{
-    CrateType, ExtendedTargetModifierInfo, ExternLocation, Externs, OptionsTargetModifiers,
-    TargetModifier,
+    CrateType, ExtendedTargetModifierInfo, ExternEntry, ExternLocation, Externs,
+    OptionsTargetModifiers, TargetModifier,
 };
 use rustc_session::cstore::{CrateDepKind, CrateSource, ExternCrate, ExternCrateSource};
 use rustc_session::lint::{self, BuiltinLintDiag};
@@ -35,7 +35,7 @@ use rustc_session::search_paths::PathKind;
 use rustc_span::def_id::DefId;
 use rustc_span::edition::Edition;
 use rustc_span::{DUMMY_SP, Ident, Span, Symbol, sym};
-use rustc_target::spec::{PanicStrategy, Target};
+use rustc_target::spec::{HasTargetSpec, Os, PanicStrategy, Target};
 use tracing::{debug, info, trace};
 
 use crate::errors;
@@ -1128,6 +1128,53 @@ impl CStore {
         }
     }
 
+    /// Injects the `hermit` crate if necessary.
+    ///
+    /// On Hermit, the OS is included in the `hermit` crate. This method makes
+    /// sure we link against the possibly renamed `hermit` crate if it is
+    /// provided even if there is no explicit `extern hermit`.
+    ///
+    /// This is similar to replacing `--extern hermit` with `--extern force:hermit`.
+    fn inject_hermit_crate(&mut self, tcx: TyCtxt<'_>) {
+        let Os::Hermit = tcx.target_spec().os else {
+            return;
+        };
+
+        let hermit_names = tcx
+            .sess
+            .opts
+            .externs
+            .iter()
+            .filter_map(|(name, entry)| is_hermit(entry).then_some(name.as_str()))
+            .map(Symbol::intern);
+
+        for name in hermit_names {
+            if self.used_extern_options.contains(&name) {
+                continue;
+            }
+
+            self.resolve_crate(
+                tcx,
+                name,
+                DUMMY_SP,
+                CrateDepKind::Unconditional,
+                CrateOrigin::Extern,
+            );
+        }
+
+        fn is_hermit(ext_ent: &ExternEntry) -> bool {
+            ext_ent
+                .files()
+                .into_iter()
+                .flatten()
+                .filter_map(|file| file.original().file_name())
+                .filter_map(|file_name| file_name.to_str())
+                .any(|file_name| {
+                    file_name.starts_with("libhermit-") && file_name.ends_with(".rlib")
+                })
+        }
+    }
+
     fn inject_forced_externs(&mut self, tcx: TyCtxt<'_>) {
         for (name, entry) in tcx.sess.opts.externs.iter() {
             if entry.force {
@@ -1254,6 +1301,7 @@ impl CStore {
 
     pub fn postprocess(&mut self, tcx: TyCtxt<'_>, krate: &ast::Crate) {
         self.inject_compiler_builtins(tcx, krate);
+        self.inject_hermit_crate(tcx);
         self.inject_forced_externs(tcx);
         self.inject_profiler_runtime(tcx);
         self.inject_allocator_crate(tcx, krate);


### PR DESCRIPTION
This PR makes rustc always link against the `hermit` crate on Hermit if the crate is present.

For Hermit, the static library OS (`libhermit.a`) is compiled in the `hermit` crate's build script and then linked against. Users just add `hermit` to the application's `Cargo.toml`. This causes Cargo to call rustc with `--extern hermit=$PATH_TO_libhermit-hash.rlib`. Unless users also specify `extern crate hermit`, though, rustc calls the linker without `libhermit.rlib`, which is intended:

> `--extern` merely makes the crate a candidate for being linked; it does not actually link it unless it’s actively used.

[Command-line Arguments - The rustc book](https://doc.rust-lang.org/stable/rustc/command-line-arguments.html#--extern-specify-where-an-external-library-is-located)

This PR makes sure that rustc links against the `hermit` crate if some `libhermit-hash.rlib` file is being supplied. From the outside, this is similar to replacing `--extern hermit` with `--extern force:hermit` but also supports crate renaming. Internally, the crate mechanism works similarly to the one that is used for compiler builtins, forced externs, the profiler runtime, the allocator crate, and the panic runtime. This allows users to avoid modifying their Rust applications to use Hermit. Putting the crate into the `Cargo.toml` is sufficient.

This approach is very similar to what we do in our GCC cross compiler ([hermit-os/gcc/gcc/config/i386/hermit.h#L5](https://github.com/hermit-os/gcc/blob/8fc6b9498b5cc18f2d0c9b3b849480852e32c313/gcc/config/i386/hermit.h#L5)): we put `-lhermit` into `LIB_SPEC` to ensure that each Hermit application links against `libhermit.a`. This PR applies the same approach to rustc but has to account for the hash in `libhermit-hash.rlib` and accounts for the possibility of users renaming the `hermit` crate.

An alternative for a more general approach to avoid adding more target-specific code to `rustc-metadate` could be stabilizing `--extern force` (https://github.com/rust-lang/rust/issues/111302) and making this available for dependencies. Then, the `hermit` crate could enable `extern force` in its `Cargo.toml`, which would ensure it is linked even if unused. This would likely take a while, though, and I am not sure if we have the resources to put significant effort into such a more general approach. Meanwhile, this small patch might be bearable.