### PR TITLE
Add missing num_internals feature gate to coretests/benches

### DIFF
--- a/library/coretests/benches/lib.rs
+++ b/library/coretests/benches/lib.rs
@@ -8,7 +8,9 @@
 #![feature(iter_array_chunks)]
 #![feature(iter_next_chunk)]
 #![feature(iter_advance_by)]
+#![feature(num_internals)]
 #![feature(uint_gather_scatter_bits)]
+#![allow(internal_features)]
 
 extern crate test;
 


### PR DESCRIPTION
This will allow getting rid of the patch at https://github.com/rust-lang/rustc_codegen_cranelift/blob/main/patches/0030-sysroot_tests-Add-missing-feature-gate.patch