### PR TITLE
fix: guard paren-sugar pretty-printing on short trait args

### DIFF
--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -3314,7 +3314,8 @@ define_print_and_forward_display! {
     TraitRefPrintSugared<'tcx> {
         if !with_reduced_queries()
             && p.tcx().trait_def(self.0.def_id).paren_sugar
-            && let ty::Tuple(args) = self.0.args.type_at(1).kind()
+            && let Some(args_ty) = self.0.args.get(1).and_then(|arg| arg.as_type())
+            && let ty::Tuple(args) = args_ty.kind()
         {
             write!(p, "{}(", p.tcx().item_name(self.0.def_id))?;
             for (i, arg) in args.iter().enumerate() {

--- a/tests/ui/unboxed-closures/paren-sugar-non-fn-trait-issue-153855.rs
+++ b/tests/ui/unboxed-closures/paren-sugar-non-fn-trait-issue-153855.rs
@@ -1,0 +1,12 @@
+#![feature(rustc_attrs, unboxed_closures)]
+#![allow(internal_features)]
+
+#[rustc_paren_sugar]
+trait Tr {
+    fn method();
+}
+
+fn main() {
+    <u8 as Tr>::method();
+    //~^ ERROR the trait bound `u8: Tr` is not satisfied
+}

--- a/tests/ui/unboxed-closures/paren-sugar-non-fn-trait-issue-153855.stderr
+++ b/tests/ui/unboxed-closures/paren-sugar-non-fn-trait-issue-153855.stderr
@@ -1,0 +1,15 @@
+error[E0277]: the trait bound `u8: Tr` is not satisfied
+  --> $DIR/paren-sugar-non-fn-trait-issue-153855.rs:10:6
+   |
+LL |     <u8 as Tr>::method();
+   |      ^^ the trait `Tr` is not implemented for `u8`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/paren-sugar-non-fn-trait-issue-153855.rs:5:1
+   |
+LL | trait Tr {
+   | ^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/unboxed-closures/paren-sugar-non-fn-trait-ufcs-issue-153855.rs
+++ b/tests/ui/unboxed-closures/paren-sugar-non-fn-trait-ufcs-issue-153855.rs
@@ -1,0 +1,16 @@
+#![feature(rustc_attrs, unboxed_closures)]
+#![allow(internal_features)]
+
+// Regression test for #153855: diagnostics should not ICE when a
+// `#[rustc_paren_sugar]` trait is used with parenthesized syntax but does not
+// have an `Fn`-family generic layout.
+#[rustc_paren_sugar]
+trait Tr<'a, 'b, T> {
+    fn method() {}
+}
+
+fn main() {
+    <u8 as Tr(&u8)>::method;
+    //~^ ERROR associated item constraints are not allowed here
+    //~| ERROR the trait bound `u8: Tr<'_, '_, (&u8,)>` is not satisfied
+}

--- a/tests/ui/unboxed-closures/paren-sugar-non-fn-trait-ufcs-issue-153855.stderr
+++ b/tests/ui/unboxed-closures/paren-sugar-non-fn-trait-ufcs-issue-153855.stderr
@@ -1,0 +1,22 @@
+error[E0229]: associated item constraints are not allowed here
+  --> $DIR/paren-sugar-non-fn-trait-ufcs-issue-153855.rs:13:12
+   |
+LL |     <u8 as Tr(&u8)>::method;
+   |            ^^^^^^^ associated item constraint not allowed here
+
+error[E0277]: the trait bound `u8: Tr<'_, '_, (&u8,)>` is not satisfied
+  --> $DIR/paren-sugar-non-fn-trait-ufcs-issue-153855.rs:13:6
+   |
+LL |     <u8 as Tr(&u8)>::method;
+   |      ^^ the trait `Tr<'_, '_, (&u8,)>` is not implemented for `u8`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/paren-sugar-non-fn-trait-ufcs-issue-153855.rs:8:1
+   |
+LL | trait Tr<'a, 'b, T> {
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0229, E0277.
+For more information about an error, try `rustc --explain E0229`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fix rust-lang/rust#153855 by adding a guard on trait with only one argument.
