### PR TITLE
enable 128-bit atomics on x86_64

### DIFF
--- a/compiler/rustc_target/src/spec/targets/x86_64_fortanix_unknown_sgx.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_fortanix_unknown_sgx.rs
@@ -63,7 +63,7 @@ pub(crate) fn target() -> Target {
         abi: Abi::Fortanix,
         linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
         linker: Some("rust-lld".into()),
-        max_atomic_width: Some(64),
+        max_atomic_width: Some(128),
         cpu: "x86-64".into(),
         plt_by_default: false,
         features: "+rdrand,+rdseed,+lvi-cfi,+lvi-load-hardening".into(),

--- a/compiler/rustc_target/src/spec/targets/x86_64_linux_android.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_linux_android.rs
@@ -9,7 +9,7 @@ pub(crate) fn target() -> Target {
     base.plt_by_default = false;
     // https://developer.android.com/ndk/guides/abis.html#86-64
     base.features = "+mmx,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt".into();
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(128);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.stack_probes = StackProbeType::Inline;
     base.supports_xray = true;

--- a/compiler/rustc_target/src/spec/targets/x86_64_lynx_lynxos178.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_lynx_lynxos178.rs
@@ -4,7 +4,7 @@ pub(crate) fn target() -> Target {
     let mut base = base::lynxos178::opts();
     base.cpu = "x86-64".into();
     base.plt_by_default = false;
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(128);
     base.stack_probes = StackProbeType::Inline;
     base.static_position_independent_executables = false;
     base.supported_sanitizers = SanitizerSet::ADDRESS

--- a/compiler/rustc_target/src/spec/targets/x86_64_pc_cygwin.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_pc_cygwin.rs
@@ -5,7 +5,7 @@ pub(crate) fn target() -> Target {
     base.cpu = "x86-64".into();
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::No, Lld::No), &["-m", "i386pep"]);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(128);
     base.linker = Some("x86_64-pc-cygwin-gcc".into());
     Target {
         llvm_target: "x86_64-pc-cygwin".into(),

--- a/compiler/rustc_target/src/spec/targets/x86_64_pc_solaris.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_pc_solaris.rs
@@ -8,7 +8,7 @@ pub(crate) fn target() -> Target {
         cpu: "x86-64".into(),
         plt_by_default: false,
         vendor: "pc".into(),
-        max_atomic_width: Some(64),
+        max_atomic_width: Some(128),
         stack_probes: StackProbeType::Inline,
         supported_sanitizers: SanitizerSet::ADDRESS | SanitizerSet::CFI | SanitizerSet::THREAD,
         ..base::solaris::opts()

--- a/compiler/rustc_target/src/spec/targets/x86_64_unikraft_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unikraft_linux_musl.rs
@@ -19,7 +19,7 @@ pub(crate) fn target() -> Target {
             cpu: "x86-64".into(),
             plt_by_default: false,
             pre_link_args: TargetOptions::link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]),
-            max_atomic_width: Some(64),
+            max_atomic_width: Some(128),
             stack_probes: StackProbeType::Inline,
             ..base::unikraft_linux_musl::opts()
         },

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_dragonfly.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_dragonfly.rs
@@ -4,7 +4,7 @@ pub(crate) fn target() -> Target {
     let mut base = base::dragonfly::opts();
     base.cpu = "x86-64".into();
     base.plt_by_default = false;
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(128);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.stack_probes = StackProbeType::Inline;
 

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_freebsd.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_freebsd.rs
@@ -6,7 +6,7 @@ pub(crate) fn target() -> Target {
     let mut base = base::freebsd::opts();
     base.cpu = "x86-64".into();
     base.plt_by_default = false;
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(128);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.stack_probes = StackProbeType::Inline;
     base.supported_sanitizers =

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_haiku.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_haiku.rs
@@ -4,7 +4,7 @@ pub(crate) fn target() -> Target {
     let mut base = base::haiku::opts();
     base.cpu = "x86-64".into();
     base.plt_by_default = false;
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(128);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.stack_probes = StackProbeType::Inline;
     // This option is required to build executables on Haiku x86_64

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_helenos.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_helenos.rs
@@ -4,7 +4,7 @@ pub(crate) fn target() -> Target {
     let mut base = base::helenos::opts();
     base.cpu = "x86-64".into();
     base.plt_by_default = false;
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(128);
     base.linker = Some("amd64-helenos-gcc".into());
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
 

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_hermit.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_hermit.rs
@@ -17,7 +17,7 @@ pub(crate) fn target() -> Target {
             cpu: "x86-64".into(),
             features: "+rdrand,+rdseed".into(),
             plt_by_default: false,
-            max_atomic_width: Some(64),
+            max_atomic_width: Some(128),
             stack_probes: StackProbeType::Inline,
             ..base::hermit::opts()
         },

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_hurd_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_hurd_gnu.rs
@@ -4,7 +4,7 @@ pub(crate) fn target() -> Target {
     let mut base = base::hurd_gnu::opts();
     base.cpu = "x86-64".into();
     base.plt_by_default = false;
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(128);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.stack_probes = StackProbeType::Inline;
     base.supports_xray = true;

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_illumos.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_illumos.rs
@@ -5,7 +5,7 @@ pub(crate) fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Unix(Cc::Yes), &["-m64", "-std=c99"]);
     base.cpu = "x86-64".into();
     base.plt_by_default = false;
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(128);
     base.supported_sanitizers = SanitizerSet::ADDRESS | SanitizerSet::CFI | SanitizerSet::THREAD;
 
     Target {

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_l4re_uclibc.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_l4re_uclibc.rs
@@ -4,7 +4,7 @@ pub(crate) fn target() -> Target {
     let mut base = base::l4re::opts();
     base.cpu = "x86-64".into();
     base.plt_by_default = false;
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(128);
     base.panic_strategy = PanicStrategy::Abort;
 
     Target {

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnu.rs
@@ -6,7 +6,7 @@ pub(crate) fn target() -> Target {
     let mut base = base::linux_gnu::opts();
     base.cpu = "x86-64".into();
     base.plt_by_default = false;
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(128);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.stack_probes = StackProbeType::Inline;
     base.static_position_independent_executables = true;

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnux32.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_gnux32.rs
@@ -4,7 +4,7 @@ pub(crate) fn target() -> Target {
     let mut base = base::linux_gnu::opts();
     base.cpu = "x86-64".into();
     base.abi = Abi::X32;
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(128);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-mx32"]);
     base.stack_probes = StackProbeType::Inline;
     base.has_thread_local = false;

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_musl.rs
@@ -6,7 +6,7 @@ pub(crate) fn target() -> Target {
     let mut base = base::linux_musl::opts();
     base.cpu = "x86-64".into();
     base.plt_by_default = false;
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(128);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.stack_probes = StackProbeType::Inline;
     base.static_position_independent_executables = true;

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_none.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_none.rs
@@ -5,7 +5,7 @@ use crate::spec::{
 pub(crate) fn target() -> Target {
     let mut base = base::linux::opts();
     base.cpu = "x86-64".into();
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(128);
     base.stack_probes = StackProbeType::Inline;
     base.linker_flavor = LinkerFlavor::Gnu(Cc::No, Lld::Yes);
     base.linker = Some("rust-lld".into());

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_ohos.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_ohos.rs
@@ -5,7 +5,7 @@ use crate::spec::{
 pub(crate) fn target() -> Target {
     let mut base = base::linux_ohos::opts();
     base.cpu = "x86-64".into();
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(128);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.stack_probes = StackProbeType::Inline;
     base.static_position_independent_executables = true;

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_managarm_mlibc.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_managarm_mlibc.rs
@@ -3,7 +3,7 @@ use crate::spec::{Arch, Cc, LinkerFlavor, Lld, StackProbeType, Target, base};
 pub(crate) fn target() -> Target {
     let mut base = base::managarm_mlibc::opts();
     base.cpu = "x86-64".into();
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(128);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.stack_probes = StackProbeType::Inline;
 

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_motor.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_motor.rs
@@ -5,7 +5,7 @@ use crate::spec::{
 pub(crate) fn target() -> Target {
     let mut base = base::motor::opts();
     base.cpu = "x86-64".into();
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(128);
     base.code_model = Some(CodeModel::Small);
 
     // We want fully static relocatable binaries. It was surprisingly

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_netbsd.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_netbsd.rs
@@ -7,7 +7,7 @@ pub(crate) fn target() -> Target {
     let mut base = base::netbsd::opts();
     base.cpu = "x86-64".into();
     base.plt_by_default = false;
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(128);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.stack_probes = StackProbeType::Inline;
     base.supported_sanitizers = SanitizerSet::ADDRESS

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_none.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_none.rs
@@ -13,7 +13,7 @@ pub(crate) fn target() -> Target {
     let opts = TargetOptions {
         cpu: "x86-64".into(),
         plt_by_default: false,
-        max_atomic_width: Some(64),
+        max_atomic_width: Some(128),
         stack_probes: StackProbeType::Inline,
         position_independent_executables: true,
         static_position_independent_executables: true,

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_openbsd.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_openbsd.rs
@@ -4,7 +4,7 @@ pub(crate) fn target() -> Target {
     let mut base = base::openbsd::opts();
     base.cpu = "x86-64".into();
     base.plt_by_default = false;
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(128);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.stack_probes = StackProbeType::Inline;
     base.supports_xray = true;

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_redox.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_redox.rs
@@ -4,7 +4,7 @@ pub(crate) fn target() -> Target {
     let mut base = base::redox::opts();
     base.cpu = "x86-64".into();
     base.plt_by_default = false;
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(128);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.stack_probes = StackProbeType::Inline;
 

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_trusty.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_trusty.rs
@@ -20,7 +20,7 @@ pub(crate) fn target() -> Target {
         arch: Arch::X86_64,
         options: TargetOptions {
             executables: true,
-            max_atomic_width: Some(64),
+            max_atomic_width: Some(128),
             panic_strategy: PanicStrategy::Abort,
             os: Os::Trusty,
             link_self_contained: LinkSelfContainedDefault::InferredForMusl,

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_uefi.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_uefi.rs
@@ -13,7 +13,7 @@ pub(crate) fn target() -> Target {
     let mut base = base::uefi_msvc::opts();
     base.cpu = "x86-64".into();
     base.plt_by_default = false;
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(128);
     base.entry_abi = CanonAbi::X86(X86Call::Win64);
 
     // We disable MMX and SSE for now, even though UEFI allows using them. Problem is, you have to

--- a/compiler/rustc_target/src/spec/targets/x86_64_win7_windows_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_win7_windows_gnu.rs
@@ -5,7 +5,7 @@ pub(crate) fn target() -> Target {
         vendor: "win7".into(),
         cpu: "x86-64".into(),
         plt_by_default: false,
-        max_atomic_width: Some(64),
+        max_atomic_width: Some(128),
         linker: Some("x86_64-w64-mingw32-gcc".into()),
         ..base::windows_gnu::opts()
     };

--- a/compiler/rustc_target/src/spec/targets/x86_64_win7_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_win7_windows_msvc.rs
@@ -5,7 +5,7 @@ pub(crate) fn target() -> Target {
         vendor: "win7".into(),
         cpu: "x86-64".into(),
         plt_by_default: false,
-        max_atomic_width: Some(64),
+        max_atomic_width: Some(128),
         supported_sanitizers: SanitizerSet::ADDRESS,
         ..base::windows_msvc::opts()
     };

--- a/compiler/rustc_target/src/spec/targets/x86_64_wrs_vxworks.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_wrs_vxworks.rs
@@ -4,7 +4,7 @@ pub(crate) fn target() -> Target {
     let mut base = base::vxworks::opts();
     base.cpu = "x86-64".into();
     base.plt_by_default = false;
-    base.max_atomic_width = Some(64);
+    base.max_atomic_width = Some(128);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.stack_probes = StackProbeType::Inline;
     base.disable_redzone = true;

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -2540,7 +2540,9 @@ macro_rules! if_8_bit {
 
 #[cfg(target_has_atomic_load_store)]
 macro_rules! atomic_int {
-    ($cfg_cas:meta,
+    ($($cfg_target_feature:meta)*,
+     $($target_feature_enable:meta)*,
+     $cfg_cas:meta,
      $cfg_align:meta,
      $stable:meta,
      $stable_cxchg:meta,
@@ -2607,7 +2609,17 @@ macro_rules! atomic_int {
         #[$stable_debug]
         impl fmt::Debug for $atomic_type {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                fmt::Debug::fmt(&self.load(Ordering::Relaxed), f)
+                #[allow(unused_unsafe)]
+                $(#[$cfg_target_feature])*
+                // SAFETY:
+                // These features are enable in build-time.
+                unsafe {
+                    return fmt::Debug::fmt(&self.load(Ordering::Relaxed), f);
+                }
+                #[allow(unreachable_code)]
+                {
+                    f.debug_struct(stringify!($atomic_type)).finish()
+                }
             }
         }
 
@@ -2863,6 +2875,7 @@ macro_rules! atomic_int {
             /// assert_eq!(some_var.load(Ordering::Relaxed), 5);
             /// ```
             #[inline]
+            $(#[$target_feature_enable])*
             #[$stable]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
             pub fn load(&self, order: Ordering) -> $int_type {
@@ -2890,6 +2903,7 @@ macro_rules! atomic_int {
             /// assert_eq!(some_var.load(Ordering::Relaxed), 10);
             /// ```
             #[inline]
+            $(#[$target_feature_enable])*
             #[$stable]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
             #[rustc_should_not_be_called_on_const_items]
@@ -2918,6 +2932,7 @@ macro_rules! atomic_int {
             /// assert_eq!(some_var.swap(10, Ordering::Relaxed), 5);
             /// ```
             #[inline]
+            $(#[$target_feature_enable])*
             #[$stable]
             #[$cfg_cas]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
@@ -2979,6 +2994,7 @@ macro_rules! atomic_int {
             /// assert_eq!(some_var.load(Ordering::Relaxed), 10);
             /// ```
             #[inline]
+            $(#[$target_feature_enable])*
             #[$stable]
             #[deprecated(
                 since = "1.50.0",
@@ -3052,6 +3068,7 @@ macro_rules! atomic_int {
             /// [ABA Problem]: https://en.wikipedia.org/wiki/ABA_problem
             /// [compare-and-swap operation]: https://en.wikipedia.org/wiki/Compare-and-swap
             #[inline]
+            $(#[$target_feature_enable])*
             #[$stable_cxchg]
             #[$cfg_cas]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
@@ -3116,6 +3133,7 @@ macro_rules! atomic_int {
             /// [ABA Problem]: https://en.wikipedia.org/wiki/ABA_problem
             /// [compare-and-swap operation]: https://en.wikipedia.org/wiki/Compare-and-swap
             #[inline]
+            $(#[$target_feature_enable])*
             #[$stable_cxchg]
             #[$cfg_cas]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
@@ -3153,6 +3171,7 @@ macro_rules! atomic_int {
             /// assert_eq!(foo.load(Ordering::SeqCst), 10);
             /// ```
             #[inline]
+            $(#[$target_feature_enable])*
             #[$stable]
             #[$cfg_cas]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
@@ -3184,6 +3203,7 @@ macro_rules! atomic_int {
             /// assert_eq!(foo.load(Ordering::SeqCst), 10);
             /// ```
             #[inline]
+            $(#[$target_feature_enable])*
             #[$stable]
             #[$cfg_cas]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
@@ -3218,6 +3238,7 @@ macro_rules! atomic_int {
             /// assert_eq!(foo.load(Ordering::SeqCst), 0b100001);
             /// ```
             #[inline]
+            $(#[$target_feature_enable])*
             #[$stable]
             #[$cfg_cas]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
@@ -3252,6 +3273,7 @@ macro_rules! atomic_int {
             /// assert_eq!(foo.load(Ordering::SeqCst), !(0x13 & 0x31));
             /// ```
             #[inline]
+            $(#[$target_feature_enable])*
             #[$stable_nand]
             #[$cfg_cas]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
@@ -3286,6 +3308,7 @@ macro_rules! atomic_int {
             /// assert_eq!(foo.load(Ordering::SeqCst), 0b111111);
             /// ```
             #[inline]
+            $(#[$target_feature_enable])*
             #[$stable]
             #[$cfg_cas]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
@@ -3320,6 +3343,7 @@ macro_rules! atomic_int {
             /// assert_eq!(foo.load(Ordering::SeqCst), 0b011110);
             /// ```
             #[inline]
+            $(#[$target_feature_enable])*
             #[$stable]
             #[$cfg_cas]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
@@ -3333,6 +3357,7 @@ macro_rules! atomic_int {
             #[doc = concat!("[`", stringify!($atomic_type), "::try_update`]")]
             /// .
             #[inline]
+            $(#[$target_feature_enable])*
             #[stable(feature = "no_more_cas", since = "1.45.0")]
             #[$cfg_cas]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
@@ -3398,6 +3423,7 @@ macro_rules! atomic_int {
             /// assert_eq!(x.load(Ordering::SeqCst), 9);
             /// ```
             #[inline]
+            $(#[$target_feature_enable])*
             #[stable(feature = "atomic_try_update", since = "1.95.0")]
             #[$cfg_cas]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
@@ -3464,6 +3490,7 @@ macro_rules! atomic_int {
             /// assert_eq!(x.load(Ordering::SeqCst), 9);
             /// ```
             #[inline]
+            $(#[$target_feature_enable])*
             #[stable(feature = "atomic_try_update", since = "1.95.0")]
             #[$cfg_cas]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
@@ -3519,6 +3546,7 @@ macro_rules! atomic_int {
             /// assert!(max_foo == 42);
             /// ```
             #[inline]
+            $(#[$target_feature_enable])*
             #[stable(feature = "atomic_min_max", since = "1.45.0")]
             #[$cfg_cas]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
@@ -3566,6 +3594,7 @@ macro_rules! atomic_int {
             /// assert_eq!(min_foo, 12);
             /// ```
             #[inline]
+            $(#[$target_feature_enable])*
             #[stable(feature = "atomic_min_max", since = "1.45.0")]
             #[$cfg_cas]
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
@@ -3620,6 +3649,8 @@ macro_rules! atomic_int {
 
 #[cfg(target_has_atomic_load_store = "8")]
 atomic_int! {
+    ,
+    ,
     cfg(target_has_atomic = "8"),
     cfg(target_has_atomic_equal_alignment = "8"),
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
@@ -3638,6 +3669,8 @@ atomic_int! {
 }
 #[cfg(target_has_atomic_load_store = "8")]
 atomic_int! {
+    ,
+    ,
     cfg(target_has_atomic = "8"),
     cfg(target_has_atomic_equal_alignment = "8"),
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
@@ -3656,6 +3689,8 @@ atomic_int! {
 }
 #[cfg(target_has_atomic_load_store = "16")]
 atomic_int! {
+    ,
+    ,
     cfg(target_has_atomic = "16"),
     cfg(target_has_atomic_equal_alignment = "16"),
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
@@ -3674,6 +3709,8 @@ atomic_int! {
 }
 #[cfg(target_has_atomic_load_store = "16")]
 atomic_int! {
+    ,
+    ,
     cfg(target_has_atomic = "16"),
     cfg(target_has_atomic_equal_alignment = "16"),
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
@@ -3692,6 +3729,8 @@ atomic_int! {
 }
 #[cfg(target_has_atomic_load_store = "32")]
 atomic_int! {
+    ,
+    ,
     cfg(target_has_atomic = "32"),
     cfg(target_has_atomic_equal_alignment = "32"),
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
@@ -3710,6 +3749,8 @@ atomic_int! {
 }
 #[cfg(target_has_atomic_load_store = "32")]
 atomic_int! {
+    ,
+    ,
     cfg(target_has_atomic = "32"),
     cfg(target_has_atomic_equal_alignment = "32"),
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
@@ -3728,6 +3769,8 @@ atomic_int! {
 }
 #[cfg(target_has_atomic_load_store = "64")]
 atomic_int! {
+    ,
+    ,
     cfg(target_has_atomic = "64"),
     cfg(target_has_atomic_equal_alignment = "64"),
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
@@ -3746,6 +3789,8 @@ atomic_int! {
 }
 #[cfg(target_has_atomic_load_store = "64")]
 atomic_int! {
+    ,
+    ,
     cfg(target_has_atomic = "64"),
     cfg(target_has_atomic_equal_alignment = "64"),
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
@@ -3764,6 +3809,8 @@ atomic_int! {
 }
 #[cfg(target_has_atomic_load_store = "128")]
 atomic_int! {
+    cfg_attr(target_arch = "x86_64", cfg(target_feature = "cmpxchg16b")),
+    cfg_attr(target_arch = "x86_64", target_feature(enable = "cmpxchg16b")),
     cfg(target_has_atomic = "128"),
     cfg(target_has_atomic_equal_alignment = "128"),
     unstable(feature = "integer_atomics", issue = "99069"),
@@ -3782,6 +3829,8 @@ atomic_int! {
 }
 #[cfg(target_has_atomic_load_store = "128")]
 atomic_int! {
+    cfg_attr(target_arch = "x86_64", cfg(target_feature = "cmpxchg16b")),
+    cfg_attr(target_arch = "x86_64", target_feature(enable = "cmpxchg16b")),
     cfg(target_has_atomic = "128"),
     cfg(target_has_atomic_equal_alignment = "128"),
     unstable(feature = "integer_atomics", issue = "99069"),
@@ -3804,6 +3853,8 @@ macro_rules! atomic_int_ptr_sized {
     ( $($target_pointer_width:literal $align:literal)* ) => { $(
         #[cfg(target_pointer_width = $target_pointer_width)]
         atomic_int! {
+            ,
+            ,
             cfg(target_has_atomic = "ptr"),
             cfg(target_has_atomic_equal_alignment = "ptr"),
             stable(feature = "rust1", since = "1.0.0"),
@@ -3822,6 +3873,8 @@ macro_rules! atomic_int_ptr_sized {
         }
         #[cfg(target_pointer_width = $target_pointer_width)]
         atomic_int! {
+            ,
+            ,
             cfg(target_has_atomic = "ptr"),
             cfg(target_has_atomic_equal_alignment = "ptr"),
             stable(feature = "rust1", since = "1.0.0"),


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

tracking issue: https://github.com/rust-lang/rust/issues/99069

This API is inconvenient to use. Because one can't just write

```rust
// -Ctarget-feature=+cmpxchg16b
pub fn f(atomic: &core::sync::atomic::AtomicI128) -> i128 {
    atomic.load(core::sync::atomic::Ordering::SeqCst)
}
```

The call must be in an unsafe block, otherwise `rustc` complains

```
  = help: in order for the call to be safe, the context requires the following additional target feature: cmpxchg16b
  = note: the cmpxchg16b target feature being enabled in the build configuration does not remove the requirement to list it in `#[target_feature]`
```

blocked on https://github.com/llvm/llvm-project/issues/187503

context: https://rust-lang.zulipchat.com/#narrow/channel/327149-t-libs-api.2Fapi-changes/topic/AtomicU128.20if.20cmpexch16b.20is.20enabled

r? @Amanieu