### PR TITLE
tests/ui/async-await/drop-option-future.rs: New regression test

### DIFF
--- a/tests/ui/async-await/drop-option-future.rs
+++ b/tests/ui/async-await/drop-option-future.rs
@@ -1,0 +1,16 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/98077>.
+
+//@ edition:2018
+//@ check-pass
+
+#![allow(dead_code)]
+#![allow(unused_assignments)]
+
+async fn foo() {
+    let mut f = None;
+    let value = 0;
+    f = Some(async { value });
+    core::mem::drop(f);
+}
+
+fn main() { }


### PR DESCRIPTION
The test began compiling with `nightly-2022-11-25`. I bisected it further, and the commit that made it compile was 9f36f988ad873f5 (rust-lang/rust#104321). The test fails to compile with `nightly-2022-11-24`:

    $ rustc +nightly-2022-11-24 --edition 2018 tests/ui/async-await/drop-option-future.rs
    error[E0597]: `value` does not live long enough
      --> tests/ui/async-await/drop-option-future.rs:12:22
       |
    12 |     f = Some(async { value });
       |                    --^^^^^--
       |                    | |
       |                    | borrowed value does not live long enough
       |                    value captured here by generator
    13 |     core::mem::drop(f);
    14 | }
       | -
       | |
       | `value` dropped here while still borrowed
       | borrow might be used here, when `f` is dropped and runs the destructor for type `Option<impl Future<Output = i32>>`

The fix 9f36f988ad873f5 does not appear to affect or include a regression test for the rust-lang/rust#98077 case, so let's add that test.

Closes rust-lang/rust#98077 since we add the test from that issue.
