### PR TITLE
tests/ui/async-await/gat-is-send-across-await.rs: New regression test

### DIFF
--- a/tests/ui/async-await/gat-is-send-across-await.rs
+++ b/tests/ui/async-await/gat-is-send-across-await.rs
@@ -1,0 +1,23 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/111852>.
+
+//@ edition:2018
+//@ check-pass
+
+#![allow(unused)]
+
+trait G: Send {
+    type Gat<'l>: Send
+    where
+        Self: 'l;
+
+    fn as_gat(&self) -> Self::Gat<'_>;
+}
+
+fn a(g: impl G) {
+    let _: &dyn Send = &async move {
+        let _gat = g.as_gat();
+        async{}.await
+    };
+}
+
+fn main() { }


### PR DESCRIPTION
The test began passing in `nightly-2025-10-16`. Probably by c50aebba787 (rust-lang/rust#144064) because it fixed two "does not live long enough" errors. The test fails to compile with `nightly-2025-10-15` with such an error:

    $ rustc +nightly-2025-10-15 --edition 2018 tests/ui/async-await/gat-is-send-across-await.rs
    error: `impl G` does not live long enough
      --> tests/ui/async-await/gat-is-send-across-await.rs:16:24
       |
    16 |       let _: &dyn Send = &async move {
       |  ________________________^
    17 | |         let _gat = g.as_gat();
    18 | |         async{}.await
    19 | |     };
       | |_____^

Closes rust-lang/rust#111852 since that's where the test comes from.