### PR TITLE
diagnostics: avoid ICE for undeclared generic parameter in impl

### DIFF
--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -3381,7 +3381,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
             && def_id.is_local()
             && let Some(local_def_id) = def_id.as_local()
             && let Some(struct_generics) = self.r.struct_generics.get(&local_def_id)
-            && let target_param = &struct_generics.params[idx]
+            && let Some(target_param) = &struct_generics.params.get(idx)
             && let GenericParamKind::Const { ty, .. } = &target_param.kind
             && let TyKind::Path(_, path) = &ty.kind
         {

--- a/tests/ui/missing/undeclared-generic-parameter.rs
+++ b/tests/ui/missing/undeclared-generic-parameter.rs
@@ -1,0 +1,5 @@
+struct A;
+impl A<B> {}
+//~^ ERROR cannot find type `B` in this scope
+//~| ERROR struct takes 0 generic arguments but 1 generic argument was supplied
+fn main() {}

--- a/tests/ui/missing/undeclared-generic-parameter.stderr
+++ b/tests/ui/missing/undeclared-generic-parameter.stderr
@@ -1,0 +1,36 @@
+error[E0425]: cannot find type `B` in this scope
+  --> $DIR/undeclared-generic-parameter.rs:2:8
+   |
+LL | struct A;
+   | --------- similarly named struct `A` defined here
+LL | impl A<B> {}
+   |        ^
+   |
+help: a struct with a similar name exists
+   |
+LL - impl A<B> {}
+LL + impl A<A> {}
+   |
+help: you might be missing a type parameter
+   |
+LL | impl<B> A<B> {}
+   |     +++
+
+error[E0107]: struct takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/undeclared-generic-parameter.rs:2:6
+   |
+LL | impl A<B> {}
+   |      ^--- help: remove the unnecessary generics
+   |      |
+   |      expected 0 generic arguments
+   |
+note: struct defined here, with 0 generic parameters
+  --> $DIR/undeclared-generic-parameter.rs:1:8
+   |
+LL | struct A;
+   |        ^
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0107, E0425.
+For more information about an error, try `rustc --explain E0107`.


### PR DESCRIPTION
Avoid an ICE for:

    struct A;
    impl A<B> {}

The compiler no longer panics and can proceed to emit existing diagnostics.

Adds `tests/ui/missing/undeclared-generic-parameter.rs`.

Fixes rust-lang/rust#154165 and introduced by rust-lang/rust#152913

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
