### PR TITLE
Update the tracking issue for #[diagnostic::on_move]

### DIFF
--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -473,7 +473,7 @@ declare_features! (
     /// Allows giving non-const impls custom diagnostic messages if attempted to be used as const
     (unstable, diagnostic_on_const, "1.93.0", Some(143874)),
     /// Allows giving on-move borrowck custom diagnostic messages for a type
-    (unstable, diagnostic_on_move, "CURRENT_RUSTC_VERSION", Some(150935)),
+    (unstable, diagnostic_on_move, "CURRENT_RUSTC_VERSION", Some(154181)),
     /// Allows `#[doc(cfg(...))]`.
     (unstable, doc_cfg, "1.21.0", Some(43781)),
     /// Allows `#[doc(masked)]`.


### PR DESCRIPTION

PR rust-lang/rust#150935 has been merged and then I have opened the tracking issue (whoops ?). So this update `compiler/rustc_feature/src/unstable.rs` to point to the right tracking issue.

This is related to the tracking issue rust-lang/rust#154181 
