### PR TITLE
Delete some GDB debugvis cruft

### DIFF
--- a/src/etc/gdb_lookup.py
+++ b/src/etc/gdb_lookup.py
@@ -2,8 +2,8 @@ import gdb
 import gdb.printing
 import re
 
-from gdb_providers import *
-from rust_types import *
+import gdb_providers as providers
+from rust_types import RustType, classify_struct, classify_union
 
 
 _gdb_version_matched = re.search("([0-9]+)\\.([0-9]+)", gdb.VERSION)
@@ -42,31 +42,6 @@ def check_enum_discriminant(valobj):
     return True
 
 
-# Helper for enum printing that checks the discriminant.  Only used in
-# older gdb.
-def enum_provider(valobj):
-    if check_enum_discriminant(valobj):
-        return EnumProvider(valobj)
-    return None
-
-
-# Helper to handle both old and new hash maps.
-def hashmap_provider(valobj):
-    if is_hashbrown_hashmap(valobj):
-        return StdHashMapProvider(valobj)
-    else:
-        return StdOldHashMapProvider(valobj)
-
-
-# Helper to handle both old and new hash sets.
-def hashset_provider(valobj):
-    hash_map = valobj[valobj.type.fields()[0]]
-    if is_hashbrown_hashmap(hash_map):
-        return StdHashMapProvider(valobj, show_values=False)
-    else:
-        return StdOldHashMapProvider(hash_map, show_values=False)
-
-
 class PrintByRustType(gdb.printing.SubPrettyPrinter):
     def __init__(self, name, provider):
         super(PrintByRustType, self).__init__(name)
@@ -97,25 +72,23 @@ class RustPrettyPrinter(gdb.printing.PrettyPrinter):
 
 
 printer = RustPrettyPrinter("rust")
-# use enum provider only for GDB <7.12
-if gdb_version[0] < 7 or (gdb_version[0] == 7 and gdb_version[1] < 12):
-    printer.add(RustType.ENUM, enum_provider)
-printer.add(RustType.STD_STRING, StdStringProvider)
-printer.add(RustType.STD_OS_STRING, StdOsStringProvider)
-printer.add(RustType.STD_STR, StdStrProvider)
-printer.add(RustType.STD_SLICE, StdSliceProvider)
-printer.add(RustType.STD_VEC, StdVecProvider)
-printer.add(RustType.STD_VEC_DEQUE, StdVecDequeProvider)
-printer.add(RustType.STD_BTREE_SET, StdBTreeSetProvider)
-printer.add(RustType.STD_BTREE_MAP, StdBTreeMapProvider)
-printer.add(RustType.STD_HASH_MAP, hashmap_provider)
-printer.add(RustType.STD_HASH_SET, hashset_provider)
-printer.add(RustType.STD_RC, StdRcProvider)
-printer.add(RustType.STD_ARC, lambda valobj: StdRcProvider(valobj, is_atomic=True))
+printer.add(RustType.STD_STRING, providers.StdStringProvider)
+printer.add(RustType.STD_OS_STRING, providers.StdOsStringProvider)
+printer.add(RustType.STD_STR, providers.StdStrProvider)
+printer.add(RustType.STD_SLICE, providers.StdSliceProvider)
+printer.add(RustType.STD_VEC, providers.StdVecProvider)
+printer.add(RustType.STD_VEC_DEQUE, providers.StdVecDequeProvider)
+printer.add(RustType.STD_BTREE_SET, providers.StdBTreeSetProvider)
+printer.add(RustType.STD_BTREE_MAP, providers.StdBTreeMapProvider)
+printer.add(RustType.STD_HASH_MAP, providers.StdHashMapProvider)
+printer.add(RustType.STD_HASH_SET, providers.StdHashMapProvider)
+printer.add(RustType.STD_RC, providers.StdRcProvider)
+printer.add(
+    RustType.STD_ARC, lambda valobj: providers.StdRcProvider(valobj, is_atomic=True)
+)
 
-printer.add(RustType.STD_CELL, StdCellProvider)
-printer.add(RustType.STD_REF, StdRefProvider)
-printer.add(RustType.STD_REF_MUT, StdRefProvider)
-printer.add(RustType.STD_REF_CELL, StdRefCellProvider)
-
-printer.add(RustType.STD_NONZERO_NUMBER, StdNonZeroNumberProvider)
+printer.add(RustType.STD_CELL, providers.StdCellProvider)
+printer.add(RustType.STD_REF, providers.StdRefProvider)
+printer.add(RustType.STD_REF_MUT, providers.StdRefProvider)
+printer.add(RustType.STD_REF_CELL, providers.StdRefCellProvider)
+printer.add(RustType.STD_NONZERO_NUMBER, providers.StdNonZeroNumberProvider)

--- a/src/etc/gdb_providers.py
+++ b/src/etc/gdb_providers.py
@@ -1,19 +1,10 @@
-from sys import version_info
-
 import gdb
-
-if version_info[0] >= 3:
-    xrange = range
 
 ZERO_FIELD = "__0"
 FIRST_FIELD = "__1"
 
 
 def unwrap_unique_or_non_null(unique_or_nonnull):
-    # BACKCOMPAT: rust 1.32
-    # https://github.com/rust-lang/rust/commit/7a0911528058e87d22ea305695f4047572c5e067
-    # BACKCOMPAT: rust 1.60
-    # https://github.com/rust-lang/rust/commit/2a91eeac1a2d27dd3de1bf55515d765da20fd86f
     ptr = unique_or_nonnull["pointer"]
     return ptr if ptr.type.code == gdb.TYPE_CODE_PTR else ptr[ptr.type.fields()[0]]
 
@@ -31,30 +22,6 @@ if hasattr(gdb, "ValuePrinter"):
     printer_base = gdb.ValuePrinter
 else:
     printer_base = object
-
-
-class EnumProvider(printer_base):
-    def __init__(self, valobj):
-        content = valobj[valobj.type.fields()[0]]
-        fields = content.type.fields()
-        self._empty = len(fields) == 0
-        if not self._empty:
-            if len(fields) == 1:
-                discriminant = 0
-            else:
-                discriminant = int(content[fields[0]]) + 1
-            self._active_variant = content[fields[discriminant]]
-            self._name = fields[discriminant].name
-            self._full_name = "{}::{}".format(valobj.type.name, self._name)
-        else:
-            self._full_name = valobj.type.name
-
-    def to_string(self):
-        return self._full_name
-
-    def children(self):
-        if not self._empty:
-            yield self._name, self._active_variant
 
 
 class StdStringProvider(printer_base):
@@ -131,7 +98,7 @@ class StdSliceProvider(printer_base):
 
     def children(self):
         return _enumerate_array_elements(
-            self._data_ptr + index for index in xrange(self._length)
+            self._data_ptr + index for index in range(self._length)
         )
 
     def num_children(self):
@@ -155,7 +122,7 @@ class StdVecProvider(printer_base):
 
     def children(self):
         return _enumerate_array_elements(
-            self._data_ptr + index for index in xrange(self._length)
+            self._data_ptr + index for index in range(self._length)
         )
 
     def num_children(self):
@@ -171,10 +138,7 @@ class StdVecDequeProvider(printer_base):
         self._valobj = valobj
         self._head = int(valobj["head"])
         self._size = int(valobj["len"])
-        # BACKCOMPAT: rust 1.75
-        cap = valobj["buf"]["inner"]["cap"]
-        if cap.type.code != gdb.TYPE_CODE_INT:
-            cap = cap[ZERO_FIELD]
+        cap = valobj["buf"]["inner"]["cap"][ZERO_FIELD]
         self._cap = int(cap)
         self._data_ptr = unwrap_unique_or_non_null(valobj["buf"]["inner"]["ptr"])
         ptr_ty = gdb.Type.pointer(valobj.type.template_argument(0))
@@ -186,7 +150,7 @@ class StdVecDequeProvider(printer_base):
     def children(self):
         return _enumerate_array_elements(
             (self._data_ptr + ((self._head + index) % self._cap))
-            for index in xrange(self._size)
+            for index in range(self._size)
         )
 
     def num_children(self):
@@ -292,9 +256,6 @@ def children_of_btree_map(map):
             internal_type = gdb.lookup_type(internal_type_name)
             return node.cast(internal_type.pointer())
 
-        if node_ptr.type.name.startswith("alloc::collections::btree::node::BoxedNode<"):
-            # BACKCOMPAT: rust 1.49
-            node_ptr = node_ptr["ptr"]
         node_ptr = unwrap_unique_or_non_null(node_ptr)
         leaf = node_ptr.dereference()
         keys = leaf["keys"]
@@ -302,7 +263,7 @@ def children_of_btree_map(map):
         edges = cast_to_internal(node_ptr)["edges"] if height > 0 else None
         length = leaf["len"]
 
-        for i in xrange(0, length + 1):
+        for i in range(length + 1):
             if height > 0:
                 child_ptr = edges[i]["value"]["value"][ZERO_FIELD]
                 for child in children_of_node(child_ptr, height - 1):
@@ -367,73 +328,6 @@ class StdBTreeMapProvider(printer_base):
         return "map"
 
 
-# BACKCOMPAT: rust 1.35
-class StdOldHashMapProvider(printer_base):
-    def __init__(self, valobj, show_values=True):
-        self._valobj = valobj
-        self._show_values = show_values
-
-        self._table = self._valobj["table"]
-        self._size = int(self._table["size"])
-        self._hashes = self._table["hashes"]
-        self._hash_uint_type = self._hashes.type
-        self._hash_uint_size = self._hashes.type.sizeof
-        self._modulo = 2**self._hash_uint_size
-        self._data_ptr = self._hashes[ZERO_FIELD]["pointer"]
-
-        self._capacity_mask = int(self._table["capacity_mask"])
-        self._capacity = (self._capacity_mask + 1) % self._modulo
-
-        marker = self._table["marker"].type
-        self._pair_type = marker.template_argument(0)
-        self._pair_type_size = self._pair_type.sizeof
-
-        self._valid_indices = []
-        for idx in range(self._capacity):
-            data_ptr = self._data_ptr.cast(self._hash_uint_type.pointer())
-            address = data_ptr + idx
-            hash_uint = address.dereference()
-            hash_ptr = hash_uint[ZERO_FIELD]["pointer"]
-            if int(hash_ptr) != 0:
-                self._valid_indices.append(idx)
-
-    def to_string(self):
-        if self._show_values:
-            return "HashMap(size={})".format(self._size)
-        else:
-            return "HashSet(size={})".format(self._size)
-
-    def children(self):
-        start = int(self._data_ptr) & ~1
-
-        hashes = self._hash_uint_size * self._capacity
-        align = self._pair_type_size
-        len_rounded_up = (
-            (
-                (((hashes + align) % self._modulo - 1) % self._modulo)
-                & ~((align - 1) % self._modulo)
-            )
-            % self._modulo
-            - hashes
-        ) % self._modulo
-
-        pairs_offset = hashes + len_rounded_up
-        pairs_start = gdb.Value(start + pairs_offset).cast(self._pair_type.pointer())
-
-        for index in range(self._size):
-            table_index = self._valid_indices[index]
-            idx = table_index & self._capacity_mask
-            element = (pairs_start + idx).dereference()
-            if self._show_values:
-                yield "key{}".format(index), element[ZERO_FIELD]
-                yield "val{}".format(index), element[FIRST_FIELD]
-            else:
-                yield "[{}]".format(index), element[ZERO_FIELD]
-
-    def display_hint(self):
-        return "map" if self._show_values else "array"
-
-
 class StdHashMapProvider(printer_base):
     def __init__(self, valobj, show_values=True):
         self._valobj = valobj
@@ -464,10 +358,6 @@ class StdHashMapProvider(printer_base):
     def _table(self):
         if self._show_values:
             hashbrown_hashmap = self._valobj["base"]
-        elif self._valobj.type.fields()[0].name == "map":
-            # BACKCOMPAT: rust 1.47
-            # HashSet wraps std::collections::HashMap, which wraps hashbrown::HashMap
-            hashbrown_hashmap = self._valobj["map"]["base"]
         else:
             # HashSet wraps hashbrown::HashSet, which wraps hashbrown::HashMap
             hashbrown_hashmap = self._valobj["base"]["map"]

--- a/src/etc/lldb_lookup.py
+++ b/src/etc/lldb_lookup.py
@@ -1,12 +1,7 @@
 import lldb
 
-from lldb_providers import *
+import lldb_providers as providers
 from rust_types import RustType, classify_struct, classify_union
-
-
-# BACKCOMPAT: rust 1.35
-def is_hashbrown_hashmap(hash_map: lldb.SBValue) -> bool:
-    return len(hash_map.type.fields) == 1
 
 
 def classify_rust_type(type: lldb.SBType) -> str:
@@ -19,66 +14,66 @@ def classify_rust_type(type: lldb.SBType) -> str:
     return RustType.OTHER
 
 
-def summary_lookup(valobj: lldb.SBValue, _dict: LLDBOpaque) -> str:
+def summary_lookup(valobj: lldb.SBValue, _dict: providers.LLDBOpaque) -> str:
     """Returns the summary provider for the given value"""
     rust_type = classify_rust_type(valobj.GetType())
 
     if rust_type == RustType.STD_STRING:
-        return StdStringSummaryProvider(valobj, _dict)
+        return providers.StdStringSummaryProvider(valobj, _dict)
     if rust_type == RustType.STD_OS_STRING:
-        return StdOsStringSummaryProvider(valobj, _dict)
+        return providers.StdOsStringSummaryProvider(valobj, _dict)
     if rust_type == RustType.STD_STR:
-        return StdStrSummaryProvider(valobj, _dict)
+        return providers.StdStrSummaryProvider(valobj, _dict)
 
     if rust_type == RustType.STD_VEC:
-        return SizeSummaryProvider(valobj, _dict)
+        return providers.SizeSummaryProvider(valobj, _dict)
     if rust_type == RustType.STD_VEC_DEQUE:
-        return SizeSummaryProvider(valobj, _dict)
+        return providers.SizeSummaryProvider(valobj, _dict)
     if rust_type == RustType.STD_SLICE:
-        return SizeSummaryProvider(valobj, _dict)
+        return providers.SizeSummaryProvider(valobj, _dict)
 
     if rust_type == RustType.STD_HASH_MAP:
-        return SizeSummaryProvider(valobj, _dict)
+        return providers.SizeSummaryProvider(valobj, _dict)
     if rust_type == RustType.STD_HASH_SET:
-        return SizeSummaryProvider(valobj, _dict)
+        return providers.SizeSummaryProvider(valobj, _dict)
 
     if rust_type == RustType.STD_RC:
-        return StdRcSummaryProvider(valobj, _dict)
+        return providers.StdRcSummaryProvider(valobj, _dict)
     if rust_type == RustType.STD_ARC:
-        return StdRcSummaryProvider(valobj, _dict)
+        return providers.StdRcSummaryProvider(valobj, _dict)
 
     if rust_type == RustType.STD_REF:
-        return StdRefSummaryProvider(valobj, _dict)
+        return providers.StdRefSummaryProvider(valobj, _dict)
     if rust_type == RustType.STD_REF_MUT:
-        return StdRefSummaryProvider(valobj, _dict)
+        return providers.StdRefSummaryProvider(valobj, _dict)
     if rust_type == RustType.STD_REF_CELL:
-        return StdRefSummaryProvider(valobj, _dict)
+        return providers.StdRefSummaryProvider(valobj, _dict)
 
     if rust_type == RustType.STD_NONZERO_NUMBER:
-        return StdNonZeroNumberSummaryProvider(valobj, _dict)
+        return providers.StdNonZeroNumberSummaryProvider(valobj, _dict)
 
     if rust_type == RustType.STD_PATHBUF:
-        return StdPathBufSummaryProvider(valobj, _dict)
+        return providers.StdPathBufSummaryProvider(valobj, _dict)
     if rust_type == RustType.STD_PATH:
-        return StdPathSummaryProvider(valobj, _dict)
+        return providers.StdPathSummaryProvider(valobj, _dict)
 
     return ""
 
 
-def synthetic_lookup(valobj: lldb.SBValue, _dict: LLDBOpaque) -> object:
+def synthetic_lookup(valobj: lldb.SBValue, _dict: providers.LLDBOpaque) -> object:
     """Returns the synthetic provider for the given value"""
     rust_type = classify_rust_type(valobj.GetType())
 
     if rust_type == RustType.STRUCT:
-        return StructSyntheticProvider(valobj, _dict)
+        return providers.StructSyntheticProvider(valobj, _dict)
     if rust_type == RustType.STRUCT_VARIANT:
-        return StructSyntheticProvider(valobj, _dict, is_variant=True)
+        return providers.StructSyntheticProvider(valobj, _dict, is_variant=True)
     if rust_type == RustType.TUPLE:
-        return TupleSyntheticProvider(valobj, _dict)
+        return providers.TupleSyntheticProvider(valobj, _dict)
     if rust_type == RustType.TUPLE_VARIANT:
-        return TupleSyntheticProvider(valobj, _dict, is_variant=True)
+        return providers.TupleSyntheticProvider(valobj, _dict, is_variant=True)
     if rust_type == RustType.EMPTY:
-        return EmptySyntheticProvider(valobj, _dict)
+        return providers.EmptySyntheticProvider(valobj, _dict)
     if rust_type == RustType.REGULAR_ENUM:
         discriminant = valobj.GetChildAtIndex(0).GetChildAtIndex(0).GetValueAsUnsigned()
         return synthetic_lookup(valobj.GetChildAtIndex(discriminant), _dict)
@@ -105,38 +100,31 @@ def synthetic_lookup(valobj: lldb.SBValue, _dict: LLDBOpaque) -> object:
                 ),
             )
 
-        return ClangEncodedEnumProvider(valobj, _dict)
+        return providers.ClangEncodedEnumProvider(valobj, _dict)
     if rust_type == RustType.STD_VEC:
-        return StdVecSyntheticProvider(valobj, _dict)
+        return providers.StdVecSyntheticProvider(valobj, _dict)
     if rust_type == RustType.STD_VEC_DEQUE:
-        return StdVecDequeSyntheticProvider(valobj, _dict)
+        return providers.StdVecDequeSyntheticProvider(valobj, _dict)
     if rust_type == RustType.STD_SLICE or rust_type == RustType.STD_STR:
-        return StdSliceSyntheticProvider(valobj, _dict)
+        return providers.StdSliceSyntheticProvider(valobj, _dict)
 
     if rust_type == RustType.STD_HASH_MAP:
-        if is_hashbrown_hashmap(valobj):
-            return StdHashMapSyntheticProvider(valobj, _dict)
-        else:
-            return StdOldHashMapSyntheticProvider(valobj, _dict)
+        return providers.StdHashMapSyntheticProvider(valobj, _dict)
     if rust_type == RustType.STD_HASH_SET:
-        hash_map = valobj.GetChildAtIndex(0)
-        if is_hashbrown_hashmap(hash_map):
-            return StdHashMapSyntheticProvider(valobj, _dict, show_values=False)
-        else:
-            return StdOldHashMapSyntheticProvider(hash_map, _dict, show_values=False)
+        return providers.StdHashMapSyntheticProvider(valobj, _dict, show_values=False)
 
     if rust_type == RustType.STD_RC:
-        return StdRcSyntheticProvider(valobj, _dict)
+        return providers.StdRcSyntheticProvider(valobj, _dict)
     if rust_type == RustType.STD_ARC:
-        return StdRcSyntheticProvider(valobj, _dict, is_atomic=True)
+        return providers.StdRcSyntheticProvider(valobj, _dict, is_atomic=True)
 
     if rust_type == RustType.STD_CELL:
-        return StdCellSyntheticProvider(valobj, _dict)
+        return providers.StdCellSyntheticProvider(valobj, _dict)
     if rust_type == RustType.STD_REF:
-        return StdRefSyntheticProvider(valobj, _dict)
+        return providers.StdRefSyntheticProvider(valobj, _dict)
     if rust_type == RustType.STD_REF_MUT:
-        return StdRefSyntheticProvider(valobj, _dict)
+        return providers.StdRefSyntheticProvider(valobj, _dict)
     if rust_type == RustType.STD_REF_CELL:
-        return StdRefSyntheticProvider(valobj, _dict, is_cell=True)
+        return providers.StdRefSyntheticProvider(valobj, _dict, is_cell=True)
 
-    return DefaultSyntheticProvider(valobj, _dict)
+    return providers.DefaultSyntheticProvider(valobj, _dict)

--- a/src/etc/lldb_providers.py
+++ b/src/etc/lldb_providers.py
@@ -83,10 +83,6 @@ class ValueBuilder:
 
 
 def unwrap_unique_or_non_null(unique_or_nonnull: SBValue) -> SBValue:
-    # BACKCOMPAT: rust 1.32
-    # https://github.com/rust-lang/rust/commit/7a0911528058e87d22ea305695f4047572c5e067
-    # BACKCOMPAT: rust 1.60
-    # https://github.com/rust-lang/rust/commit/2a91eeac1a2d27dd3de1bf55515d765da20fd86f
     ptr = unique_or_nonnull.GetChildMemberWithName("pointer")
     return ptr if ptr.TypeIsPointerType() else ptr.GetChildAtIndex(0)
 
@@ -1050,100 +1046,6 @@ class StdVecDequeSyntheticProvider:
         return True
 
 
-# BACKCOMPAT: rust 1.35
-class StdOldHashMapSyntheticProvider:
-    """Pretty-printer for std::collections::hash::map::HashMap<K, V, S>
-
-    struct HashMap<K, V, S> {..., table: RawTable<K, V>, ... }
-    struct RawTable<K, V> { capacity_mask: usize, size: usize, hashes: TaggedHashUintPtr, ... }
-    """
-
-    def __init__(self, valobj: SBValue, _dict: LLDBOpaque, show_values: bool = True):
-        self.valobj = valobj
-        self.show_values = show_values
-        self.update()
-
-    def num_children(self) -> int:
-        return self.size
-
-    def get_child_index(self, name: str) -> int:
-        index = name.lstrip("[").rstrip("]")
-        if index.isdigit():
-            return int(index)
-        else:
-            return -1
-
-    def get_child_at_index(self, index: int) -> SBValue:
-        # logger = Logger.Logger()
-        start = self.data_ptr.GetValueAsUnsigned() & ~1
-
-        # See `libstd/collections/hash/table.rs:raw_bucket_at
-        hashes = self.hash_uint_size * self.capacity
-        align = self.pair_type_size
-        # See `libcore/alloc.rs:padding_needed_for`
-        len_rounded_up = (
-            (
-                (((hashes + align) % self.modulo - 1) % self.modulo)
-                & ~((align - 1) % self.modulo)
-            )
-            % self.modulo
-            - hashes
-        ) % self.modulo
-        # len_rounded_up = ((hashes + align - 1) & ~(align - 1)) - hashes
-
-        pairs_offset = hashes + len_rounded_up
-        pairs_start = start + pairs_offset
-
-        table_index = self.valid_indices[index]
-        idx = table_index & self.capacity_mask
-        address = pairs_start + idx * self.pair_type_size
-        element = self.data_ptr.CreateValueFromAddress(
-            "[%s]" % index, address, self.pair_type
-        )
-        if self.show_values:
-            return element
-        else:
-            key = element.GetChildAtIndex(0)
-            return self.valobj.CreateValueFromData(
-                "[%s]" % index, key.GetData(), key.GetType()
-            )
-
-    def update(self):
-        # logger = Logger.Logger()
-
-        self.table = self.valobj.GetChildMemberWithName("table")  # type: SBValue
-        self.size = self.table.GetChildMemberWithName("size").GetValueAsUnsigned()
-        self.hashes = self.table.GetChildMemberWithName("hashes")
-        self.hash_uint_type = self.hashes.GetType()
-        self.hash_uint_size = self.hashes.GetType().GetByteSize()
-        self.modulo = 2**self.hash_uint_size
-        self.data_ptr = self.hashes.GetChildAtIndex(0).GetChildAtIndex(0)
-
-        self.capacity_mask = self.table.GetChildMemberWithName(
-            "capacity_mask"
-        ).GetValueAsUnsigned()
-        self.capacity = (self.capacity_mask + 1) % self.modulo
-
-        marker = self.table.GetChildMemberWithName("marker").GetType()  # type: SBType
-        self.pair_type = marker.template_args[0]
-        self.pair_type_size = self.pair_type.GetByteSize()
-
-        self.valid_indices = []
-        for idx in range(self.capacity):
-            address = self.data_ptr.GetValueAsUnsigned() + idx * self.hash_uint_size
-            hash_uint = self.data_ptr.CreateValueFromAddress(
-                "[%s]" % idx, address, self.hash_uint_type
-            )
-            hash_ptr = hash_uint.GetChildAtIndex(0).GetChildAtIndex(0)
-            if hash_ptr.GetValueAsUnsigned() != 0:
-                self.valid_indices.append(idx)
-
-        # logger >> "Valid indices: {}".format(str(self.valid_indices))
-
-    def has_children(self) -> bool:
-        return True
-
-
 class StdHashMapSyntheticProvider:
     """Pretty-printer for hashbrown's HashMap"""
 
@@ -1229,7 +1131,6 @@ class StdHashMapSyntheticProvider:
         if self.show_values:
             hashbrown_hashmap = self.valobj.GetChildMemberWithName("base")
         else:
-            # BACKCOMPAT: rust 1.47
             # HashSet wraps either std HashMap or hashbrown::HashSet, which both
             # wrap hashbrown::HashMap, so either way we "unwrap" twice.
             hashbrown_hashmap = self.valobj.GetChildAtIndex(0).GetChildAtIndex(0)


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Based upon discussion on Zulip: [#t-compiler/debuginfo > GDB debugvis cruft](https://rust-lang.zulipchat.com/#narrow/channel/317568-t-compiler.2Fdebuginfo/topic/GDB.20debugvis.20cruft/with/580090079)

This ensures that `ruff check` passes, which will verify that it works on Python 3.9 (lowest valid version for Ruff to check). It removes:

* old `HashMap`/`HashSet` stuff (`rust-gdb` is managed by `rustup` now)
* Python 2 support (EOL, not really verifiable anyway)
* GDB <7.12 support (this is 10 years old)

It also replaces the glob imports with ones that `ruff check` will be able to verify.

I would like to do more refactoring here and potentially split apart the visualisers across the various libstd crates (core, alloc, and std) but that is a larger change that this one, and this is mostly just to get verification on the changes being acceptable.