### PR TITLE
Merge env and alias candidates modulo region constraints

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/mod.rs
@@ -269,6 +269,63 @@ where
             return Some((c.result, MergeCandidateInfo::AlwaysApplicable(i)));
         }
 
+        // We merge identical responses modulo region constraints if one's region constraints is a
+        // superset of another's. This is to avoid unnecessary ambiguity due to lazy param_env
+        // normalization.
+        // See trait-system-refactor-initiative#265.
+        if candidates.iter().all(|candidate| {
+            matches!(
+                candidate.source,
+                CandidateSource::AliasBound(_) | CandidateSource::ParamEnv(_)
+            )
+        }) {
+            let one: CanonicalResponse<I> = candidates[0].result;
+            let eq_modulo_region_constraint =
+                |a: &CanonicalResponse<I>, b: &CanonicalResponse<I>| {
+                    // We ignore var_kinds as well since it changes with region constraints.
+                    // It shouldn't be a problem since it's entirely determined by the response.
+                    // FIXME: use an override approach? This is too fragile w.r.t field changes.
+                    a.max_universe == b.max_universe
+                        && a.value.certainty == b.value.certainty
+                        && a.value.var_values == b.value.var_values
+                        && a.value.external_constraints.normalization_nested_goals
+                            == b.value.external_constraints.normalization_nested_goals
+                        && a.value.external_constraints.opaque_types
+                            == b.value.external_constraints.opaque_types
+                };
+            if candidates[1..]
+                .iter()
+                .all(|candidate| eq_modulo_region_constraint(&candidate.result, &one))
+            {
+                let (largest_candidate_index, largest_candidate) = candidates
+                    .iter()
+                    .enumerate()
+                    .max_by_key(|(_, candidate)| {
+                        candidate.result.value.external_constraints.region_constraints.len()
+                    })
+                    .unwrap();
+                let largest_region_constraints =
+                    &largest_candidate.result.value.external_constraints.region_constraints;
+                // FIXME: Linear search has bad perf for large amount of constraints.
+                // Maybe make constraints ordered so that we can use binary search or use sets.
+                if candidates.iter().enumerate().filter(|(i, _)| *i != largest_candidate_index).all(
+                    |(_, candidate)| {
+                        candidate
+                            .result
+                            .value
+                            .external_constraints
+                            .region_constraints
+                            .iter()
+                            .all(|constraint| largest_region_constraints.contains(constraint))
+                    },
+                ) {
+                    // FIXME: Seems unnecessary to create a new `MergeCandidateInfo` kind.
+                    // Though the naming is kinda confusing if we reuse it here.
+                    return Some((largest_candidate.result, MergeCandidateInfo::EqualResponse));
+                }
+            }
+        }
+
         let one: CanonicalResponse<I> = candidates[0].result;
         if candidates[1..].iter().all(|candidate| candidate.result == one) {
             return Some((one, MergeCandidateInfo::EqualResponse));

--- a/tests/ui/traits/next-solver/merge_candidates_with_subset_region_constraints.rs
+++ b/tests/ui/traits/next-solver/merge_candidates_with_subset_region_constraints.rs
@@ -1,0 +1,101 @@
+//@ edition: 2024
+//@ compile-flags: -Znext-solver
+//@ check-pass
+
+// A regression test for trait-system-refactor-initiative#265.
+// We can have duplicate param env candidates modulo region constraints due to
+// lazy param env normalization. This previouly prevents us from merging them and
+// causes ambiguity.
+// Now we merge param env and alias bound candidates if one's region constraints
+// is a superset of another's.
+
+// The region parameter is needed to disable `always-applicable` candidates.
+trait Bound<'a> {}
+fn impls_bound<'a, T: Bound<'a>>() {}
+
+trait Id {
+    type SelfType<'a>
+    where
+        Self: 'a;
+}
+
+fn test_single_generic_region_param<'a, T>()
+where
+    T: 'a,
+    T: Id<SelfType<'a> = T>,
+    T::SelfType<'a>: Bound<'a>,
+    T: Bound<'a>,
+
+{
+    impls_bound::<'_, T>();
+}
+
+fn test_single_higher_ranked_region<'a, T>()
+where
+    T: 'static,
+    for<'b> T: Id<SelfType<'b> = T>,
+    for<'b> T::SelfType<'b>: Bound<'a>,
+    T: Bound<'a>,
+{
+    impls_bound::<'_, T>();
+}
+
+trait Id1 {
+    type SelfType<'a, 'b>
+    where
+        Self: 'a,
+        Self: 'b;
+}
+
+trait Id2 {
+    type SelfType<'a, 'b, 'c>
+    where
+        Self: 'a,
+        Self: 'b,
+        Self: 'c;
+}
+
+fn test_multiple_higher_ranked_region<'a, T>()
+where
+    T: 'static,
+    T: Bound<'a>,
+    for<'b> T: Id<SelfType<'b> = T>,
+    for<'b> <T as Id>::SelfType<'b>: Bound<'a>,
+    for<'b, 'c> T: Id1<SelfType<'b, 'c> = T>,
+    for<'b, 'c> <T as Id1>::SelfType<'b, 'c>: Bound<'a>,
+    for<'b, 'c, 'd> T: Id2<SelfType<'b, 'c, 'd> = T>,
+    for<'b, 'c, 'd> <T as Id2>::SelfType<'b, 'c, 'd>: Bound<'a>,
+{
+    impls_bound::<'_, T>();
+}
+
+trait Id3 {
+    type SelfType<'a, 'b>
+    where
+        Self: 'a,
+        'a: 'b;
+}
+
+trait Id4 {
+    type SelfType<'a, 'b, 'c>
+    where
+        Self: 'a,
+        'a: 'b,
+        'b: 'c;
+}
+
+fn test_multiple_higher_ranked_region_with_region_outlives<'a, T>()
+where
+    T: 'static,
+    T: Bound<'a>,
+    for<'b> T: Id<SelfType<'b> = T>,
+    for<'b> <T as Id>::SelfType<'b>: Bound<'a>,
+    for<'b, 'c> T: Id3<SelfType<'b, 'c> = T>,
+    for<'b, 'c> <T as Id3>::SelfType<'b, 'c>: Bound<'a>,
+    for<'b, 'c, 'd> T: Id4<SelfType<'b, 'c, 'd> = T>,
+    for<'b, 'c, 'd> <T as Id4>::SelfType<'b, 'c, 'd>: Bound<'a>,
+{
+    impls_bound::<'_, T>();
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/merge_candidates_with_subset_region_constraints_1.rs
+++ b/tests/ui/traits/next-solver/merge_candidates_with_subset_region_constraints_1.rs
@@ -1,0 +1,29 @@
+//@ edition: 2024
+//@ compile-flags: -Znext-solver
+
+// We merge param env and alias bound candidates if their only differences are region constraints
+// and one's region constraints is a superset of another's.
+// This checks that we don't do that for impl candidates.
+
+#![feature(min_specialization)]
+
+trait Bound {
+    fn dummy() {}
+}
+fn impls_bound<T: Bound>() {}
+
+impl<'a, T> Bound for (T, &'a i32) where T: 'a {
+    default fn dummy() {}
+}
+
+impl<'a> Bound for ((), &'a i32) {
+    fn dummy() {}
+}
+
+fn do_not_merge_overlapping_impl_candidates()
+{
+    impls_bound::<((), _)>();
+    //~^ ERROR: type annotations needed [E0283]
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/merge_candidates_with_subset_region_constraints_1.stderr
+++ b/tests/ui/traits/next-solver/merge_candidates_with_subset_region_constraints_1.stderr
@@ -1,0 +1,23 @@
+error[E0283]: type annotations needed
+  --> $DIR/merge_candidates_with_subset_region_constraints_1.rs:25:5
+   |
+LL |     impls_bound::<((), _)>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `impls_bound`
+   |
+note: multiple `impl`s satisfying `((), _): Bound` found
+  --> $DIR/merge_candidates_with_subset_region_constraints_1.rs:15:1
+   |
+LL | impl<'a, T> Bound for (T, &'a i32) where T: 'a {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | impl<'a> Bound for ((), &'a i32) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `impls_bound`
+  --> $DIR/merge_candidates_with_subset_region_constraints_1.rs:13:19
+   |
+LL | fn impls_bound<T: Bound>() {}
+   |                   ^^^^^ required by this bound in `impls_bound`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0283`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Partial fix for https://github.com/rust-lang/trait-system-refactor-initiative/issues/265

We merge identical responses modulo region constraints if one's region constraints is a superset of another's.
The case we currently can't fix is [here](https://github.com/rust-lang/trait-system-refactor-initiative/issues/265#issuecomment-4105735324).

There's no test case for alias bound candidates because they don't have nested goals thus no region_constraints.

r? @lcnr