### PR TITLE
fix: fix the capture behavior of `if let` in closures

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
@@ -451,7 +451,7 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
             }
 
             hir::ExprKind::Let(hir::LetExpr { pat, init, .. }) => {
-                self.walk_local(init, pat, None, || self.borrow_expr(init, BorrowKind::Immutable))?;
+                self.walk_local(init, pat, None, || Ok(()))?;
             }
 
             hir::ExprKind::Match(discr, arms, _) => {

--- a/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
@@ -451,7 +451,7 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
             }
 
             hir::ExprKind::Let(hir::LetExpr { pat, init, .. }) => {
-                self.walk_local(init, pat, None, || Ok(()))?;
+                self.walk_local(init, pat, None)?;
             }
 
             hir::ExprKind::Match(discr, arms, _) => {
@@ -577,7 +577,7 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
     fn walk_stmt(&self, stmt: &hir::Stmt<'_>) -> Result<(), Cx::Error> {
         match stmt.kind {
             hir::StmtKind::Let(hir::LetStmt { pat, init: Some(expr), els, .. }) => {
-                self.walk_local(expr, pat, *els, || Ok(()))?;
+                self.walk_local(expr, pat, *els)?;
             }
 
             hir::StmtKind::Let(_) => {}
@@ -617,19 +617,14 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
         Ok(())
     }
 
-    fn walk_local<F>(
+    fn walk_local(
         &self,
         expr: &hir::Expr<'_>,
         pat: &hir::Pat<'_>,
         els: Option<&hir::Block<'_>>,
-        mut f: F,
-    ) -> Result<(), Cx::Error>
-    where
-        F: FnMut() -> Result<(), Cx::Error>,
-    {
+    ) -> Result<(), Cx::Error> {
         self.walk_expr(expr)?;
         let expr_place = self.cat_expr(expr)?;
-        f()?;
         self.fake_read_scrutinee(&expr_place, els.is_some())?;
         self.walk_pat(&expr_place, pat, false)?;
         if let Some(els) = els {

--- a/src/tools/miri/tests/fail/match/closures/if-let-deref-in-pattern.rs
+++ b/src/tools/miri/tests/fail/match/closures/if-let-deref-in-pattern.rs
@@ -1,0 +1,25 @@
+// This test serves to document the change in semantics introduced by
+// rust-lang/rust#138961, extended to `if let` closure captures.
+//
+// A corollary of partial-pattern.rs: while the tuple access testcase makes
+// it clear why these semantics are useful, it is actually the dereference
+// being performed by the pattern that matters.
+//
+// Before rust-lang/rust#154210, `if let` in closures captured all of `x`, so
+// this test did not fail because the closure is never called.
+//@normalize-stderr-test: "constructing invalid value of type [^:]+:" -> "constructing invalid value:"
+
+#![allow(irrefutable_let_patterns)]
+
+fn main() {
+    // the inner reference is dangling
+    let x: &&u32 = unsafe {
+        let x: u32 = 42;
+        &&*&raw const x
+    };
+
+    //~v ERROR: encountered a dangling reference
+    let _ = || {
+        if let &&_y = x {}
+    };
+}

--- a/src/tools/miri/tests/fail/match/closures/if-let-deref-in-pattern.stderr
+++ b/src/tools/miri/tests/fail/match/closures/if-let-deref-in-pattern.stderr
@@ -1,0 +1,16 @@
+error: Undefined Behavior: constructing invalid value: encountered a dangling reference (use-after-free)
+  --> tests/fail/match/closures/if-let-deref-in-pattern.rs:LL:CC
+   |
+LL |       let _ = || {
+   |  _____________^
+LL | |         if let &&_y = x {}
+LL | |     };
+   | |_____^ Undefined Behavior occurred here
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/src/tools/miri/tests/fail/match/closures/if-let-partial-pattern.rs
+++ b/src/tools/miri/tests/fail/match/closures/if-let-partial-pattern.rs
@@ -1,0 +1,33 @@
+// This test serves to document the change in semantics introduced by
+// rust-lang/rust#138961, extended to `if let` closure captures.
+//
+// Previously, the closure would capture the entirety of x, and access *(*x).0
+// when called. Now, the closure only captures *(*x).0, which means that
+// a &*(*x).0 reborrow happens when the closure is constructed.
+//
+// Hence, if one of the references is dangling, this constitutes newly introduced UB
+// in the case where the closure doesn't get called. This isn't a big deal,
+// because while opsem only now considers this to be UB, the unsafe code
+// guidelines have long recommended against any handling of dangling references.
+//
+// Before rust-lang/rust#154210, `if let` in closures captured all of `x`, so
+// this test did not fail because the closure is never called.
+//@normalize-stderr-test: "constructing invalid value of type [^:]+:" -> "constructing invalid value:"
+
+#![allow(irrefutable_let_patterns)]
+
+fn main() {
+    // the inner references are dangling
+    let x: &(&u32, &u32) = unsafe {
+        let a = 21;
+        let b = 37;
+        let ra = &*&raw const a;
+        let rb = &*&raw const b;
+        &(ra, rb)
+    };
+
+    //~v ERROR: encountered a dangling reference
+    let _ = || {
+        if let &(&_y, _) = x {}
+    };
+}

--- a/src/tools/miri/tests/fail/match/closures/if-let-partial-pattern.stderr
+++ b/src/tools/miri/tests/fail/match/closures/if-let-partial-pattern.stderr
@@ -1,0 +1,16 @@
+error: Undefined Behavior: constructing invalid value: encountered a dangling reference (use-after-free)
+  --> tests/fail/match/closures/if-let-partial-pattern.rs:LL:CC
+   |
+LL |       let _ = || {
+   |  _____________^
+LL | |         if let &(&_y, _) = x {}
+LL | |     };
+   | |_____^ Undefined Behavior occurred here
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/closures/2229_closure_analysis/capture-enums.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-enums.rs
@@ -20,7 +20,6 @@ fn multi_variant_enum() {
     //~| ERROR Min Capture analysis includes:
         if let Info::Point(_, _, str) = point {
             //~^ NOTE: Capturing point[] -> Immutable
-            //~| NOTE: Capturing point[] -> Immutable
             //~| NOTE: Capturing point[(2, 0)] -> ByValue
             //~| NOTE: Min Capture point[] -> ByValue
             println!("{}", str);
@@ -28,7 +27,6 @@ fn multi_variant_enum() {
 
         if let Info::Meta(_, v) = meta {
             //~^ NOTE: Capturing meta[] -> Immutable
-            //~| NOTE: Capturing meta[] -> Immutable
             //~| NOTE: Capturing meta[(1, 1)] -> ByValue
             //~| NOTE: Min Capture meta[] -> ByValue
             println!("{:?}", v);

--- a/tests/ui/closures/2229_closure_analysis/capture-enums.stderr
+++ b/tests/ui/closures/2229_closure_analysis/capture-enums.stderr
@@ -14,28 +14,18 @@ note: Capturing point[] -> Immutable
    |
 LL |         if let Info::Point(_, _, str) = point {
    |                                         ^^^^^
-note: Capturing point[] -> Immutable
-  --> $DIR/capture-enums.rs:21:41
-   |
-LL |         if let Info::Point(_, _, str) = point {
-   |                                         ^^^^^
 note: Capturing point[(2, 0)] -> ByValue
   --> $DIR/capture-enums.rs:21:41
    |
 LL |         if let Info::Point(_, _, str) = point {
    |                                         ^^^^^
 note: Capturing meta[] -> Immutable
-  --> $DIR/capture-enums.rs:29:35
-   |
-LL |         if let Info::Meta(_, v) = meta {
-   |                                   ^^^^
-note: Capturing meta[] -> Immutable
-  --> $DIR/capture-enums.rs:29:35
+  --> $DIR/capture-enums.rs:28:35
    |
 LL |         if let Info::Meta(_, v) = meta {
    |                                   ^^^^
 note: Capturing meta[(1, 1)] -> ByValue
-  --> $DIR/capture-enums.rs:29:35
+  --> $DIR/capture-enums.rs:28:35
    |
 LL |         if let Info::Meta(_, v) = meta {
    |                                   ^^^^
@@ -57,13 +47,13 @@ note: Min Capture point[] -> ByValue
 LL |         if let Info::Point(_, _, str) = point {
    |                                         ^^^^^
 note: Min Capture meta[] -> ByValue
-  --> $DIR/capture-enums.rs:29:35
+  --> $DIR/capture-enums.rs:28:35
    |
 LL |         if let Info::Meta(_, v) = meta {
    |                                   ^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/capture-enums.rs:49:5
+  --> $DIR/capture-enums.rs:47:5
    |
 LL | /     || {
 LL | |
@@ -75,13 +65,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing point[(2, 0)] -> ByValue
-  --> $DIR/capture-enums.rs:52:47
+  --> $DIR/capture-enums.rs:50:47
    |
 LL |         let SingleVariant::Point(_, _, str) = point;
    |                                               ^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/capture-enums.rs:49:5
+  --> $DIR/capture-enums.rs:47:5
    |
 LL | /     || {
 LL | |
@@ -93,7 +83,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture point[(2, 0)] -> ByValue
-  --> $DIR/capture-enums.rs:52:47
+  --> $DIR/capture-enums.rs:50:47
    |
 LL |         let SingleVariant::Point(_, _, str) = point;
    |                                               ^^^^^

--- a/tests/ui/closures/2229_closure_analysis/if-let-patterns-capture-analysis.rs
+++ b/tests/ui/closures/2229_closure_analysis/if-let-patterns-capture-analysis.rs
@@ -16,10 +16,10 @@ fn if_let_closure() {
     //~^ ERROR First Pass analysis includes:
     //~| ERROR Min Capture analysis includes:
         if let SingleVariant::Pair(ref n, s) = variant {
-            //~^ NOTE: Capturing variant[] -> Immutable
-            //~| NOTE: Capturing variant[(0, 0)] -> Immutable
+            //~^ NOTE: Capturing variant[(0, 0)] -> Immutable
             //~| NOTE: Capturing variant[(1, 0)] -> ByValue
-            //~| NOTE: Min Capture variant[] -> ByValue
+            //~| NOTE: Min Capture variant[(0, 0)] -> Immutable
+            //~| NOTE: Min Capture variant[(1, 0)] -> ByValue
             let _ = (n, s);
         }
     };

--- a/tests/ui/closures/2229_closure_analysis/if-let-patterns-capture-analysis.rs
+++ b/tests/ui/closures/2229_closure_analysis/if-let-patterns-capture-analysis.rs
@@ -1,0 +1,54 @@
+//@ edition:2021
+
+#![feature(rustc_attrs)]
+#![feature(stmt_expr_attributes)]
+#![allow(irrefutable_let_patterns)]
+
+enum SingleVariant {
+    Pair(i32, String),
+}
+
+fn if_let_closure() {
+    let variant = SingleVariant::Pair(1, "hello".into());
+
+    let c = #[rustc_capture_analysis]
+    || {
+    //~^ ERROR First Pass analysis includes:
+    //~| ERROR Min Capture analysis includes:
+        if let SingleVariant::Pair(ref n, s) = variant {
+            //~^ NOTE: Capturing variant[] -> Immutable
+            //~| NOTE: Capturing variant[(0, 0)] -> Immutable
+            //~| NOTE: Capturing variant[(1, 0)] -> ByValue
+            //~| NOTE: Min Capture variant[] -> ByValue
+            let _ = (n, s);
+        }
+    };
+
+    c();
+}
+
+fn match_closure() {
+    let variant = SingleVariant::Pair(1, "hello".into());
+
+    let c = #[rustc_capture_analysis]
+    || {
+    //~^ ERROR First Pass analysis includes:
+    //~| ERROR Min Capture analysis includes:
+        match variant {
+            //~^ NOTE: Capturing variant[(0, 0)] -> Immutable
+            //~| NOTE: Capturing variant[(1, 0)] -> ByValue
+            //~| NOTE: Min Capture variant[(0, 0)] -> Immutable
+            //~| NOTE: Min Capture variant[(1, 0)] -> ByValue
+            SingleVariant::Pair(ref n, s) => {
+                let _ = (n, s);
+            }
+        }
+    };
+
+    c();
+}
+
+fn main() {
+    if_let_closure();
+    match_closure();
+}

--- a/tests/ui/closures/2229_closure_analysis/if-let-patterns-capture-analysis.stderr
+++ b/tests/ui/closures/2229_closure_analysis/if-let-patterns-capture-analysis.stderr
@@ -1,0 +1,90 @@
+error: First Pass analysis includes:
+  --> $DIR/if-let-patterns-capture-analysis.rs:15:5
+   |
+LL | /     || {
+LL | |
+LL | |
+LL | |         if let SingleVariant::Pair(ref n, s) = variant {
+...  |
+LL | |     };
+   | |_____^
+   |
+note: Capturing variant[] -> Immutable
+  --> $DIR/if-let-patterns-capture-analysis.rs:18:48
+   |
+LL |         if let SingleVariant::Pair(ref n, s) = variant {
+   |                                                ^^^^^^^
+note: Capturing variant[(0, 0)] -> Immutable
+  --> $DIR/if-let-patterns-capture-analysis.rs:18:48
+   |
+LL |         if let SingleVariant::Pair(ref n, s) = variant {
+   |                                                ^^^^^^^
+note: Capturing variant[(1, 0)] -> ByValue
+  --> $DIR/if-let-patterns-capture-analysis.rs:18:48
+   |
+LL |         if let SingleVariant::Pair(ref n, s) = variant {
+   |                                                ^^^^^^^
+
+error: Min Capture analysis includes:
+  --> $DIR/if-let-patterns-capture-analysis.rs:15:5
+   |
+LL | /     || {
+LL | |
+LL | |
+LL | |         if let SingleVariant::Pair(ref n, s) = variant {
+...  |
+LL | |     };
+   | |_____^
+   |
+note: Min Capture variant[] -> ByValue
+  --> $DIR/if-let-patterns-capture-analysis.rs:18:48
+   |
+LL |         if let SingleVariant::Pair(ref n, s) = variant {
+   |                                                ^^^^^^^
+
+error: First Pass analysis includes:
+  --> $DIR/if-let-patterns-capture-analysis.rs:34:5
+   |
+LL | /     || {
+LL | |
+LL | |
+LL | |         match variant {
+...  |
+LL | |     };
+   | |_____^
+   |
+note: Capturing variant[(0, 0)] -> Immutable
+  --> $DIR/if-let-patterns-capture-analysis.rs:37:15
+   |
+LL |         match variant {
+   |               ^^^^^^^
+note: Capturing variant[(1, 0)] -> ByValue
+  --> $DIR/if-let-patterns-capture-analysis.rs:37:15
+   |
+LL |         match variant {
+   |               ^^^^^^^
+
+error: Min Capture analysis includes:
+  --> $DIR/if-let-patterns-capture-analysis.rs:34:5
+   |
+LL | /     || {
+LL | |
+LL | |
+LL | |         match variant {
+...  |
+LL | |     };
+   | |_____^
+   |
+note: Min Capture variant[(0, 0)] -> Immutable
+  --> $DIR/if-let-patterns-capture-analysis.rs:37:15
+   |
+LL |         match variant {
+   |               ^^^^^^^
+note: Min Capture variant[(1, 0)] -> ByValue
+  --> $DIR/if-let-patterns-capture-analysis.rs:37:15
+   |
+LL |         match variant {
+   |               ^^^^^^^
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/closures/2229_closure_analysis/if-let-patterns-capture-analysis.stderr
+++ b/tests/ui/closures/2229_closure_analysis/if-let-patterns-capture-analysis.stderr
@@ -9,11 +9,6 @@ LL | |         if let SingleVariant::Pair(ref n, s) = variant {
 LL | |     };
    | |_____^
    |
-note: Capturing variant[] -> Immutable
-  --> $DIR/if-let-patterns-capture-analysis.rs:18:48
-   |
-LL |         if let SingleVariant::Pair(ref n, s) = variant {
-   |                                                ^^^^^^^
 note: Capturing variant[(0, 0)] -> Immutable
   --> $DIR/if-let-patterns-capture-analysis.rs:18:48
    |
@@ -36,7 +31,12 @@ LL | |         if let SingleVariant::Pair(ref n, s) = variant {
 LL | |     };
    | |_____^
    |
-note: Min Capture variant[] -> ByValue
+note: Min Capture variant[(0, 0)] -> Immutable
+  --> $DIR/if-let-patterns-capture-analysis.rs:18:48
+   |
+LL |         if let SingleVariant::Pair(ref n, s) = variant {
+   |                                                ^^^^^^^
+note: Min Capture variant[(1, 0)] -> ByValue
   --> $DIR/if-let-patterns-capture-analysis.rs:18:48
    |
 LL |         if let SingleVariant::Pair(ref n, s) = variant {

--- a/tests/ui/closures/2229_closure_analysis/run_pass/if-let-capture.rs
+++ b/tests/ui/closures/2229_closure_analysis/run_pass/if-let-capture.rs
@@ -47,5 +47,9 @@ fn main() {
 
     assert_eq!(if_let_size, match_size);
     assert_eq!(if_let_size, let_size);
-    assert_ne!(if_let_size, size_of::<Thing>());
+
+    // The closure should capture only the moved field, so its size should be
+    // less than the size of `Thing`, which would indicate that it captures the
+    // entire struct.
+    assert!(if_let_size <= size_of::<Thing>());
 }

--- a/tests/ui/closures/2229_closure_analysis/run_pass/if-let-capture.rs
+++ b/tests/ui/closures/2229_closure_analysis/run_pass/if-let-capture.rs
@@ -1,0 +1,51 @@
+//@ edition:2021
+//@ run-pass
+
+// Regression test for #153982: `if let` in a closure should capture only the
+// moved field, matching `match` and plain `let` destructuring.
+
+#![allow(dead_code, irrefutable_let_patterns)]
+
+use std::mem::{size_of, size_of_val};
+
+struct Thing(String, String);
+
+fn if_let_capture_size(x: Thing) -> usize {
+    let closure = || {
+        if let Thing(_a, _) = x {}
+    };
+
+    size_of_val(&closure)
+}
+
+fn match_capture_size(x: Thing) -> usize {
+    let closure = || {
+        match x {
+            Thing(_a, _) => {}
+        }
+    };
+
+    size_of_val(&closure)
+}
+
+fn let_capture_size(x: Thing) -> usize {
+    let closure = || {
+        let Thing(_a, _) = x;
+    };
+
+    size_of_val(&closure)
+}
+
+fn main() {
+    let if_let_size = if_let_capture_size(Thing(String::from("a"), String::from("b")));
+    let match_size = match_capture_size(Thing(String::from("a"), String::from("b")));
+    let let_size = let_capture_size(Thing(String::from("a"), String::from("b")));
+
+    assert_eq!(if_let_size, size_of::<String>());
+    assert_eq!(match_size, size_of::<String>());
+    assert_eq!(let_size, size_of::<String>());
+
+    assert_eq!(if_let_size, match_size);
+    assert_eq!(if_let_size, let_size);
+    assert_ne!(if_let_size, size_of::<Thing>());
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/154210)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Closes rust-lang/rust#153982.
**TL;DR** This patch adds the missing capture behavior change for `if let` statements introduced in RFC 2229.

This patch converts
```rust
self.walk_local(init, pat, None, || self.borrow_expr(init, BorrowKind::Immutable))?;
```
into
```rust
self.walk_local(init, pat, None, || Ok(()))?;
```
so that `if let` now behaves like `let`.