### PR TITLE
diagnostics: avoid ICE in confusable_method_name for associated functions

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -2291,8 +2291,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             fn_sig,
                         );
                         let name = inherent_method.name();
+                        let inputs = fn_sig.inputs();
+                        let expected_inputs =
+                            if inherent_method.is_method() { &inputs[1..] } else { inputs };
                         if let Some(ref args) = call_args
-                            && fn_sig.inputs()[1..]
+                            && expected_inputs
                                 .iter()
                                 .eq_by(args, |expected, found| self.may_coerce(*expected, *found))
                         {

--- a/tests/ui/attributes/rustc_confusables_assoc_fn.rs
+++ b/tests/ui/attributes/rustc_confusables_assoc_fn.rs
@@ -1,0 +1,22 @@
+#![feature(rustc_attrs)]
+
+struct S;
+
+impl S {
+    #[rustc_confusables("bar")]
+    fn foo() {}
+
+    #[rustc_confusables("baz")]
+    fn qux(&self, x: i32) {}
+}
+
+fn main() {
+    S::bar();
+    //~^ ERROR no function or associated item named `bar`
+    //~| HELP you might have meant to use `foo`
+
+    let s = S;
+    s.baz(10);
+    //~^ ERROR no method named `baz`
+    //~| HELP you might have meant to use `qux`
+}

--- a/tests/ui/attributes/rustc_confusables_assoc_fn.stderr
+++ b/tests/ui/attributes/rustc_confusables_assoc_fn.stderr
@@ -1,0 +1,33 @@
+error[E0599]: no function or associated item named `bar` found for struct `S` in the current scope
+  --> $DIR/rustc_confusables_assoc_fn.rs:14:8
+   |
+LL | struct S;
+   | -------- function or associated item `bar` not found for this struct
+...
+LL |     S::bar();
+   |        ^^^ function or associated item not found in `S`
+   |
+help: you might have meant to use `foo`
+   |
+LL -     S::bar();
+LL +     S::foo();
+   |
+
+error[E0599]: no method named `baz` found for struct `S` in the current scope
+  --> $DIR/rustc_confusables_assoc_fn.rs:19:7
+   |
+LL | struct S;
+   | -------- method `baz` not found for this struct
+...
+LL |     s.baz(10);
+   |       ^^^ method not found in `S`
+   |
+help: you might have meant to use `qux`
+   |
+LL -     s.baz(10);
+LL +     s.qux(10);
+   |
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Avoid unconditionally slicing `inputs()[1..]`, which assumes a `self` parameter. Use `is_method()` to conditionally skip the receiver, preventing out-of-bounds access and fixing suggestions for associated functions.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
