### PR TITLE
diagnostics: improve message when empty

### DIFF
--- a/compiler/rustc_ast_lowering/src/path.rs
+++ b/compiler/rustc_ast_lowering/src/path.rs
@@ -318,22 +318,23 @@ impl<'hir, R: ResolverAstLoweringExt<'hir>> LoweringContext<'_, 'hir, R> {
                         ),
                     GenericArgsMode::Err => {
                         // Suggest replacing parentheses with angle brackets `Trait(params...)` to `Trait<params...>`
-                        let sub = if !data.inputs.is_empty() {
+                        let sub = if !matches!(itctx, ImplTraitContext::Disallowed(_))
+                            || !data.inputs.is_empty()
+                        {
                             // Start of the span to the 1st character of 1st argument
-                            let open_param = data.inputs_span.shrink_to_lo().to(data
-                                .inputs
-                                .first()
-                                .unwrap()
-                                .span
-                                .shrink_to_lo());
+                            // (or just the first character if empty)
+                            let open_param = if let Some(first) = data.inputs.first() {
+                                data.inputs_span.shrink_to_lo().to(first.span.shrink_to_lo())
+                            } else {
+                                data.inputs_span.shrink_to_lo()
+                            };
                             // Last character position of last argument to the end of the span
-                            let close_param = data
-                                .inputs
-                                .last()
-                                .unwrap()
-                                .span
-                                .shrink_to_hi()
-                                .to(data.inputs_span.shrink_to_hi());
+                            // (or just the last character if empty)
+                            let close_param = if let Some(last) = data.inputs.last() {
+                                last.span.shrink_to_hi().to(data.inputs_span.shrink_to_hi())
+                            } else {
+                                data.inputs_span.shrink_to_hi()
+                            };
 
                             Some(UseAngleBrackets { open_param, close_param })
                         } else {

--- a/compiler/rustc_ast_lowering/src/path.rs
+++ b/compiler/rustc_ast_lowering/src/path.rs
@@ -318,9 +318,7 @@ impl<'hir, R: ResolverAstLoweringExt<'hir>> LoweringContext<'_, 'hir, R> {
                         ),
                     GenericArgsMode::Err => {
                         // Suggest replacing parentheses with angle brackets `Trait(params...)` to `Trait<params...>`
-                        let sub = if !matches!(itctx, ImplTraitContext::Disallowed(_))
-                            || !data.inputs.is_empty()
-                        {
+                        let sub = if !data.inputs.is_empty() {
                             // Start of the span to the 1st character of 1st argument
                             // (or just the first character if empty)
                             let open_param = if let Some(first) = data.inputs.first() {

--- a/compiler/rustc_hir_analysis/src/errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_hir_analysis/src/errors/wrong_number_of_generic_args.rs
@@ -770,8 +770,13 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
 
                 let [prefix, suffix] = if is_parenthesized { ["<", ">"] } else { ["(", ")"] };
                 let sugg_prefix = if is_first { prefix } else { ", " };
-                let sugg_suffix =
-                    if is_first && !self.gen_args.constraints.is_empty() { ", " } else { suffix };
+                let sugg_suffix = if is_first && !self.gen_args.constraints.is_empty() {
+                    ", "
+                } else if !self.gen_args.constraints.is_empty() {
+                    ""
+                } else {
+                    suffix
+                };
 
                 let sugg = format!("{sugg_prefix}{suggested_args}{sugg_suffix}");
                 debug!("sugg: {:?}", sugg);

--- a/compiler/rustc_hir_analysis/src/errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_hir_analysis/src/errors/wrong_number_of_generic_args.rs
@@ -723,12 +723,39 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
                 );
             }
             AngleBrackets::Available => {
-                let gen_args_span = self.gen_args.span().unwrap();
+                let gen_args_span = self.gen_args.span_ext().unwrap();
                 let sugg_offset =
                     self.get_lifetime_args_offset() + self.num_provided_type_or_const_args();
+                let is_parenthesized =
+                    matches!(self.gen_args.parenthesized, rustc_hir::GenericArgsParentheses::No);
+                // HACK cries in hacky b/c idk how to diff () and <> other than incidental stuff
+                // recalculate in face of possibility that one of the types is unit: `()`, which is
+                // detected as an empty angle bracket...
+                // so if we are detected to be parenthesized, but the gen_args does *not* contain any types
+                // (we are trying to write some form of empty parens),
+                // *and* the kind that is missing is at least 1 generic), *then* fudge the
+                // suggested args with the unit type instead.
+                // FIXME figure out the wizardry for more than one missing generic
+                let suggested_args = if is_parenthesized
+                    && num_missing_args == 1
+                    && self.kind() == "generic"
+                    && let None = self.gen_args.paren_sugar_inputs_output()
+                {
+                    "()".to_owned()
+                } else {
+                    format!("{suggested_args}",)
+                };
 
                 let (sugg_span, is_first) = if sugg_offset == 0 {
-                    (gen_args_span.shrink_to_lo(), true)
+                    // do not shrink to low if not parenthesized
+                    (
+                        if is_parenthesized && self.kind() == "generic" {
+                            gen_args_span
+                        } else {
+                            gen_args_span.shrink_to_lo()
+                        },
+                        true,
+                    )
                 } else {
                     let arg_span = self.gen_args.args[sugg_offset - 1].span();
                     // If we came here then inferred lifetime's spans can only point
@@ -741,9 +768,10 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
                     (arg_span.shrink_to_hi(), arg_span.hi() <= gen_args_span.lo())
                 };
 
-                let sugg_prefix = if is_first { "" } else { ", " };
+                let [prefix, suffix] = if is_parenthesized { ["<", ">"] } else { ["(", ")"] };
+                let sugg_prefix = if is_first { prefix } else { ", " };
                 let sugg_suffix =
-                    if is_first && !self.gen_args.constraints.is_empty() { ", " } else { "" };
+                    if is_first && !self.gen_args.constraints.is_empty() { ", " } else { suffix };
 
                 let sugg = format!("{sugg_prefix}{suggested_args}{sugg_suffix}");
                 debug!("sugg: {:?}", sugg);

--- a/tests/ui/suggestions/suboptimal-generic-suggestion-154220.rs
+++ b/tests/ui/suggestions/suboptimal-generic-suggestion-154220.rs
@@ -1,0 +1,6 @@
+fn main() {
+    fn foo(_: Option()) {} //~ ERROR parenthesized type parameters may only be used with a `Fn` trait [E0214]
+    //~^ HELP use angle brackets instead
+    //~| ERROR enum takes 1 generic argument but 0 generic arguments were supplied [E0107]
+    //~| HELP add missing generic argument
+}

--- a/tests/ui/suggestions/suboptimal-generic-suggestion-154220.rs
+++ b/tests/ui/suggestions/suboptimal-generic-suggestion-154220.rs
@@ -1,6 +1,5 @@
 fn main() {
     fn foo(_: Option()) {} //~ ERROR parenthesized type parameters may only be used with a `Fn` trait [E0214]
-    //~^ HELP use angle brackets instead
-    //~| ERROR enum takes 1 generic argument but 0 generic arguments were supplied [E0107]
+    //~^ ERROR enum takes 1 generic argument but 0 generic arguments were supplied [E0107]
     //~| HELP add missing generic argument
 }

--- a/tests/ui/suggestions/suboptimal-generic-suggestion-154220.stderr
+++ b/tests/ui/suggestions/suboptimal-generic-suggestion-154220.stderr
@@ -3,11 +3,6 @@ error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
    |
 LL |     fn foo(_: Option()) {}
    |               ^^^^^^^^ only `Fn` traits may use parentheses
-   |
-help: use angle brackets instead
-   |
-LL |     fn foo(_: Option<()>) {}
-   |                     +  +
 
 error[E0107]: enum takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/suboptimal-generic-suggestion-154220.rs:2:15
@@ -17,8 +12,9 @@ LL |     fn foo(_: Option()) {}
    |
 help: add missing generic argument
    |
-LL |     fn foo(_: Option(T)) {}
-   |                      +
+LL -     fn foo(_: Option()) {}
+LL +     fn foo(_: Option<()>) {}
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/suggestions/suboptimal-generic-suggestion-154220.stderr
+++ b/tests/ui/suggestions/suboptimal-generic-suggestion-154220.stderr
@@ -1,0 +1,26 @@
+error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
+  --> $DIR/suboptimal-generic-suggestion-154220.rs:2:15
+   |
+LL |     fn foo(_: Option()) {}
+   |               ^^^^^^^^ only `Fn` traits may use parentheses
+   |
+help: use angle brackets instead
+   |
+LL |     fn foo(_: Option<()>) {}
+   |                     +  +
+
+error[E0107]: enum takes 1 generic argument but 0 generic arguments were supplied
+  --> $DIR/suboptimal-generic-suggestion-154220.rs:2:15
+   |
+LL |     fn foo(_: Option()) {}
+   |               ^^^^^^ expected 1 generic argument
+   |
+help: add missing generic argument
+   |
+LL |     fn foo(_: Option(T)) {}
+   |                      +
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0107, E0214.
+For more information about an error, try `rustc --explain E0107`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
This adds a more accurate suggestion around the program
```rust
fn foo(_: Option()) {}
```

by suggesting a fix to

```rust
fn foo(_: Option<()>) {}
```

## TODO

- [ ] currently `Option(T)` is being suggested by the compiler in the second error (E0107)
  ```
  help: add missing generic argument
      |
    1 | fn foo(_: Option(T)) {}
      |                  + 
  ```
  fix to suggest `Option<T>` instead

Fixes rust-lang/rust#154220 