### PR TITLE
Move ui/issues tests to relevant subdirectories

### DIFF
--- a/tests/ui/variants/variant-result-noresult-used-as-type.rs
+++ b/tests/ui/variants/variant-result-noresult-used-as-type.rs
@@ -1,5 +1,6 @@
 //@ edition:2015
 //@ ignore-sgx std::os::fortanix_sgx::usercalls::raw::Result changes compiler suggestions
+// https://github.com/rust-lang/rust/issues/17546
 
 use foo::MyEnum::Result;
 use foo::NoResult; // Through a re-export

--- a/tests/ui/variants/variant-result-noresult-used-as-type.stderr
+++ b/tests/ui/variants/variant-result-noresult-used-as-type.stderr
@@ -1,5 +1,5 @@
 error[E0573]: expected type, found variant `NoResult`
-  --> $DIR/issue-17546.rs:15:17
+  --> $DIR/variant-result-noresult-used-as-type.rs:16:17
    |
 LL |     fn new() -> NoResult<MyEnum, String> {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL +     fn new() -> Result<MyEnum, String> {
    |
 
 error[E0573]: expected type, found variant `Result`
-  --> $DIR/issue-17546.rs:25:17
+  --> $DIR/variant-result-noresult-used-as-type.rs:26:17
    |
 LL |     fn new() -> Result<foo::MyEnum, String> {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a type
@@ -36,7 +36,7 @@ LL +     use std::thread::Result;
    |
 
 error[E0573]: expected type, found variant `Result`
-  --> $DIR/issue-17546.rs:31:13
+  --> $DIR/variant-result-noresult-used-as-type.rs:32:13
    |
 LL | fn new() -> Result<foo::MyEnum, String> {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a type
@@ -53,7 +53,7 @@ LL + use std::thread::Result;
    |
 
 error[E0573]: expected type, found variant `NoResult`
-  --> $DIR/issue-17546.rs:36:15
+  --> $DIR/variant-result-noresult-used-as-type.rs:37:15
    |
 LL | fn newer() -> NoResult<foo::MyEnum, String> {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Related to https://github.com/rust-lang/rust/issues/133895 and [Reorganisation of tests/ui/issues for GSOC](https://github.com/rust-lang/google-summer-of-code?tab=readme-ov-file#reorganisation-of-testsuiissues)

This is the first PR in a batch of PRs.

Moves `ui/issues/issue-17546.rs‎`  ‎-> `ui/variants/variant-result-noresult-used-as-type.rs`

Approach:
1. Check linked issue and test contents, determine new target directory
2. Move / rename tests to reflect purpose.
3. Add issue link / comments in separate commit.
4. Rebless if necessary and remove obsolete stderr.



r? @Kivooeo 