### PR TITLE
remove unnecessary variables and delimiter check

### DIFF
--- a/compiler/rustc_parse/src/lexer/tokentrees.rs
+++ b/compiler/rustc_parse/src/lexer/tokentrees.rs
@@ -72,12 +72,11 @@ impl<'psess, 'src> Lexer<'psess, 'src> {
         let close_spacing = if let Some(close_delim) = self.token.kind.close_delim() {
             if close_delim == open_delim {
                 // Correct delimiter.
-                let (open_delimiter, open_delimiter_span) =
-                    self.diag_info.open_delimiters.pop().unwrap();
+                self.diag_info.open_delimiters.pop().unwrap();
                 let close_delimiter_span = self.token.span;
 
                 if tts.is_empty() && close_delim == Delimiter::Brace {
-                    let empty_block_span = open_delimiter_span.to(close_delimiter_span);
+                    let empty_block_span = pre_span.to(close_delimiter_span);
                     if !sm.is_multiline(empty_block_span) {
                         // Only track if the block is in the form of `{}`, otherwise it is
                         // likely that it was written on purpose.
@@ -86,11 +85,9 @@ impl<'psess, 'src> Lexer<'psess, 'src> {
                 }
 
                 // only add braces
-                if let (Delimiter::Brace, Delimiter::Brace) = (open_delimiter, open_delim) {
+                if Delimiter::Brace == open_delim {
                     // Add all the matching spans, we will sort by span later
-                    self.diag_info
-                        .matching_block_spans
-                        .push((open_delimiter_span, close_delimiter_span));
+                    self.diag_info.matching_block_spans.push((pre_span, close_delimiter_span));
                 }
 
                 // Move past the closing delimiter.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Zulip discussion: https://rust-lang.zulipchat.com/#narrow/channel/182449-t-compiler.2Fhelp/topic/question.20about.20lex_token_tree_open_delim.20in.20rustc_parse/with/580552157

In `lex_token_tree_open_delim`, after calling `self.lex_token_trees(/* is_delimited */ true)`:
 - If the delimiters are well-balanced, the value  popped from the stack will always equal to `open_delim` and `pre_span`.
 - If the delimiters are not balanced, `self.lex_token_trees(/* is_delimited */ true)` will return an error so this branch will not be reached

Therefore `open_delimiter` and `open_delimiter_span` can be removed. 

Test `tests/ui/parser` all passed



