### PR TITLE
Add a note on iterator exhaustion to the `iter` module docs

### DIFF
--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -364,11 +364,15 @@
 //! The [`Iterator`] trait *itself* doesn't impose any particular meaning on what will
 //! happen if its methods are called again after becoming exhausted.
 //!
+//! Note that [infinite iterators], mentioned above, are never exhausted and thus
+//! this section is not relevant to them.
+//!
 //! Many iterators implement [`FusedIterator`] to convey that once they have reached
 //! exhaustion, they will remain exhausted forever, with `next` returning `None`
 //! for all future calls, `position` returning `None` for all future calls, etc.
 //! The structure of implementing iterators frequently makes this doable for no extra
 //! cost, as a simple consequence of ever returning `None`, so is preferred in those cases.
+//! This is particularly common for iterators over collections.
 //!
 //! Some iterators define what it means to use them again after hitting exhaustion.
 //! For example, [`mpsc::TryIter`] continues to return more items from the channel
@@ -376,11 +380,16 @@
 //! that their implementation is simplest if they re-iterate the same items again
 //! when called again after exhaustion.
 //!
-//! Occasionally, iterators exist where calling again after exhaustion will misbehave
-//! in some way.  That of course must not cause *Undefined Behaviour*, as `Iterator`
-//! is a safe trait.  However, if the iterator is non-fused and avoiding doing so
-//! would cause extra cost, a particular iterator might end up panicking in `next`
-//! (or `fold` or `find_map` or ...) if called after exhaustion.
+//! Occasionally, iterators exist where their authors do not want to promise any
+//! specific behaviour after exhaustion, particularly if making such a guarantee
+//! would add overhead.  Such iterators must not implement `FusedIterator`, as
+//! that trait does promise a particular behavior.  And like *all* safe methods,
+//! calling safe `Iterator` methods must never cause *Undefined Behaviour* -- even
+//! after exhaustion.  However, absent a trait- or documentation-based guarantee
+//! to the contrary, an iterator might end up returning strange results from or
+//! panicking in `next` (or `fold` or `find_map` or ...) if called after exhaustion.
+//! For example, an iterator which is not fused needn't go out of its way to avoid
+//! integer overflows if its methods are called after exhaustion.
 //!
 //! As such, you should be cognizant of how you handle iterators at exhaustion.
 //! Calling `next` on a general `impl Iterator` after exhaustion, only to throw
@@ -402,6 +411,7 @@
 //! for some reason that iterating causes side effects, it can be useful.
 //!
 //! [`mpsc::TryIter`]: ../../std/sync/mpsc/struct.TryIter.html
+//! [infinite iterators]: #infinity
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -398,6 +398,11 @@
 //! be helpful to call [`Iterator::fuse`] on the iterator you're processing so
 //! that you can (vacuously) use it after exhaustion without worry.
 //!
+//! Using an exhausted iterator with an iterator adapter may similarly
+//! produce varying results; check the documentation of the individual
+//! iterator adapter and do not rely on any particular behavior that
+//! is not documented.
+//!
 //! Generally you'll also want to convey, in some way, whether you hit exhaustion
 //! when processing an iterator.  That might be returning `None` like `next` and
 //! `nth`, could be a more complex strategy like returning an `Err` with a

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -393,7 +393,7 @@
 //! when processing an iterator.  That might be returning `None` like `next` and
 //! `nth`, could be a more complex strategy like returning an `Err` with a
 //! partial result on exhaustion, and many other things are possible as well.
-//! The is most important if you take `&mut` iterators directly, but because
+//! This is most important if you take `&mut` iterators directly, but because
 //! [`Iterator::by_ref`] exists your caller may want to know whether you hit
 //! exhaustion even if you took ownership of the iterator.
 //!

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -352,6 +352,56 @@
 //!
 //! [`take`]: Iterator::take
 //! [`min`]: Iterator::min
+//!
+//! # Exhaustion
+//!
+//! An iterator is *exhausted* once [`Iterator::next`] returns `None` -- aka when a
+//! `for` loop would stop -- or similarly for the other `&mut`-taking methods.
+//! For example, an iterator is exhausted if [`Iterator::nth`] returns `None`,
+//! if [`Iterator::all`] returns `true`, if [`Iterator::any`] returns `false`,
+//! if [`Iterator::try_fold`] returns `Continue(_)`, and so on.
+//!
+//! The [`Iterator`] trait *itself* doesn't impose any particular meaning on what will
+//! happen if its methods are called again after becoming exhausted.
+//!
+//! Many iterators implement [`FusedIterator`] to convey that once they have reached
+//! exhaustion, they will remain exhausted forever, with `next` returning `None`
+//! for all future calls, `position` returning `None` for all future calls, etc.
+//! The structure of implementing iterators frequently makes this doable for no extra
+//! cost, as a simple consequence of ever returning `None`, so is preferred in those cases.
+//!
+//! Some iterators define what it means to use them again after hitting exhaustion.
+//! For example, [`mpsc::TryIter`] continues to return more items from the channel
+//! (if there are any) when it's called again after exhaustion.  Others might find
+//! that their implementation is simplest if they re-iterate the same items again
+//! when called again after exhaustion.
+//!
+//! Occasionally, iterators exist where calling again after exhaustion will misbehave
+//! in some way.  That of course must not cause *Undefined Behaviour*, as `Iterator`
+//! is a safe trait.  However, if the iterator is non-fused and avoiding doing so
+//! would cause extra cost, a particular iterator might end up panicking in `next`
+//! (or `fold` or `find_map` or ...) if called after exhaustion.
+//!
+//! As such, you should be cognizant of how you handle iterators at exhaustion.
+//! Calling `next` on a general `impl Iterator` after exhaustion, only to throw
+//! those results away, risks losing items from an `mpsc` channel that the caller
+//! might have wanted to see, for example.  Depending what you're doing, it might
+//! be helpful to call [`Iterator::fuse`] on the iterator you're processing so
+//! that you can (vacuously) use it after exhaustion without worry.
+//!
+//! Generally you'll also want to convey, in some way, whether you hit exhaustion
+//! when processing an iterator.  That might be returning `None` like `next` and
+//! `nth`, could be a more complex strategy like returning an `Err` with a
+//! partial result on exhaustion, and many other things are possible as well.
+//! The is most important if you take `&mut` iterators directly, but because
+//! [`Iterator::by_ref`] exists your caller may want to know whether you hit
+//! exhaustion even if you took ownership of the iterator.
+//!
+//! If you want to force an iterator to run to exhaustion, the canonical way is
+//! with `.for_each(drop)`.  Most of the time you don't need to, but if you know
+//! for some reason that iterating causes side effects, it can be useful.
+//!
+//! [`mpsc::TryIter`]: ../../std/sync/mpsc/struct.TryIter.html
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -49,9 +49,10 @@ pub const trait Iterator {
     /// Returns [`None`] when iteration is finished. Individual iterator
     /// implementations may choose to resume iteration, and so calling `next()`
     /// again may or may not eventually start returning [`Some(Item)`] again at some
-    /// point.
+    /// point.  For more on this, see [exhaustion] in the module documentation.
     ///
     /// [`Some(Item)`]: Some
+    /// [exhaustion]: index.html#exhaustion
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Since this keeps coming up ([#t-libs > &#96;next&#96; after &#96;None&#96; @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/219381-t-libs/topic/.60next.60.20after.20.60None.60/near/580857436)), I wrote up some text about it.

In short,

```text
//! The [`Iterator`] trait *itself* doesn't impose any particular meaning on what will
//! happen if its methods are called again after becoming exhausted.
```

with various things that are possibilities, and some implications thereof.

In my opinion this adds no new requirements on users or implementors of `Iterator`, just describes what's de-facto already true: there are various things that concrete iterators do after they're exhausted.

There is one thing this describes as "preferred", but that's basically just "if the obvious implementation fuses you should probably be fused", which I hope is non-controversial.