### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/compiler/rustc_ast_lowering/src/asm.rs
+++ b/compiler/rustc_ast_lowering/src/asm.rs
@@ -1,5 +1,4 @@
 use std::collections::hash_map::Entry;
-use std::fmt::Write;
 
 use rustc_ast::*;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap};
@@ -124,13 +123,9 @@ impl<'hir, R: ResolverAstLoweringExt<'hir>> LoweringContext<'_, 'hir, R> {
                         self.dcx().emit_err(ClobberAbiNotSupported { abi_span: *abi_span });
                     }
                     Err(supported_abis) => {
-                        let mut abis = format!("`{}`", supported_abis[0]);
-                        for m in &supported_abis[1..] {
-                            let _ = write!(abis, ", `{m}`");
-                        }
                         self.dcx().emit_err(InvalidAbiClobberAbi {
                             abi_span: *abi_span,
-                            supported_abis: abis,
+                            supported_abis: supported_abis.to_vec().into(),
                         });
                     }
                 }
@@ -164,15 +159,12 @@ impl<'hir, R: ResolverAstLoweringExt<'hir>> LoweringContext<'_, 'hir, R> {
                         asm::InlineAsmRegOrRegClass::RegClass(if let Some(asm_arch) = asm_arch {
                             asm::InlineAsmRegClass::parse(asm_arch, reg_class).unwrap_or_else(
                                 |supported_register_classes| {
-                                    let mut register_classes =
-                                        format!("`{}`", supported_register_classes[0]);
-                                    for m in &supported_register_classes[1..] {
-                                        let _ = write!(register_classes, ", `{m}`");
-                                    }
                                     self.dcx().emit_err(InvalidRegisterClass {
                                         op_span: *op_sp,
                                         reg_class,
-                                        supported_register_classes: register_classes,
+                                        supported_register_classes: supported_register_classes
+                                            .to_vec()
+                                            .into(),
                                     });
                                     asm::InlineAsmRegClass::Err
                                 },
@@ -272,23 +264,20 @@ impl<'hir, R: ResolverAstLoweringExt<'hir>> LoweringContext<'_, 'hir, R> {
                         }
                         let valid_modifiers = class.valid_modifiers(asm_arch.unwrap());
                         if !valid_modifiers.contains(&modifier) {
-                            let sub = if !valid_modifiers.is_empty() {
-                                let mut mods = format!("`{}`", valid_modifiers[0]);
-                                for m in &valid_modifiers[1..] {
-                                    let _ = write!(mods, ", `{m}`");
-                                }
-                                InvalidAsmTemplateModifierRegClassSub::SupportModifier {
-                                    class_name: class.name(),
-                                    modifiers: mods,
-                                }
-                            } else {
+                            let sub = if valid_modifiers.is_empty() {
                                 InvalidAsmTemplateModifierRegClassSub::DoesNotSupportModifier {
                                     class_name: class.name(),
+                                }
+                            } else {
+                                InvalidAsmTemplateModifierRegClassSub::SupportModifier {
+                                    class_name: class.name(),
+                                    modifiers: valid_modifiers.to_vec().into(),
                                 }
                             };
                             self.dcx().emit_err(InvalidAsmTemplateModifierRegClass {
                                 placeholder_span,
                                 op_span: op_sp,
+                                modifier: modifier.to_string(),
                                 sub,
                             });
                         }

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -1,5 +1,5 @@
-use rustc_errors::DiagArgFromDisplay;
 use rustc_errors::codes::*;
+use rustc_errors::{DiagArgFromDisplay, DiagSymbolList};
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_span::{Ident, Span, Symbol};
 
@@ -191,10 +191,10 @@ pub(crate) struct ClobberAbiNotSupported {
 #[derive(Diagnostic)]
 #[note("the following ABIs are supported on this target: {$supported_abis}")]
 #[diag("invalid ABI for `clobber_abi`")]
-pub(crate) struct InvalidAbiClobberAbi {
+pub(crate) struct InvalidAbiClobberAbi<'a> {
     #[primary_span]
     pub abi_span: Span,
-    pub supported_abis: String,
+    pub supported_abis: DiagSymbolList<&'a str>,
 }
 
 #[derive(Diagnostic)]
@@ -215,17 +215,18 @@ pub(crate) struct InvalidRegisterClass {
     #[primary_span]
     pub op_span: Span,
     pub reg_class: Symbol,
-    pub supported_register_classes: String,
+    pub supported_register_classes: DiagSymbolList<Symbol>,
 }
 
 #[derive(Diagnostic)]
-#[diag("invalid asm template modifier for this register class")]
+#[diag("invalid asm template modifier `{$modifier}` for this register class")]
 pub(crate) struct InvalidAsmTemplateModifierRegClass {
     #[primary_span]
     #[label("template modifier")]
     pub placeholder_span: Span,
     #[label("argument")]
     pub op_span: Span,
+    pub modifier: String,
     #[subdiagnostic]
     pub sub: InvalidAsmTemplateModifierRegClassSub,
 }
@@ -235,7 +236,7 @@ pub(crate) enum InvalidAsmTemplateModifierRegClassSub {
     #[note(
         "the `{$class_name}` register class supports the following template modifiers: {$modifiers}"
     )]
-    SupportModifier { class_name: Symbol, modifiers: String },
+    SupportModifier { class_name: Symbol, modifiers: DiagSymbolList<char> },
     #[note("the `{$class_name}` register class does not support template modifiers")]
     DoesNotSupportModifier { class_name: Symbol },
 }

--- a/compiler/rustc_builtin_macros/src/global_allocator.rs
+++ b/compiler/rustc_builtin_macros/src/global_allocator.rs
@@ -180,7 +180,7 @@ impl AllocFnFactory<'_, '_> {
     }
 
     fn ptr_alignment(&self) -> Box<Ty> {
-        let path = self.cx.std_path(&[sym::ptr, sym::Alignment]);
+        let path = self.cx.std_path(&[sym::mem, sym::Alignment]);
         let path = self.cx.path(self.span, path);
         self.cx.ty_path(path)
     }

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -128,7 +128,6 @@ enum ExpectedKind {
     Reference,
     Box,
     RawPtr,
-    InitScalar,
     Bool,
     Char,
     Float,
@@ -143,7 +142,6 @@ impl fmt::Display for ExpectedKind {
             ExpectedKind::Reference => "expected a reference",
             ExpectedKind::Box => "expected a box",
             ExpectedKind::RawPtr => "expected a raw pointer",
-            ExpectedKind::InitScalar => "expected initialized scalar value",
             ExpectedKind::Bool => "expected a boolean",
             ExpectedKind::Char => "expected a unicode scalar value",
             ExpectedKind::Float => "expected a floating point number",
@@ -1478,7 +1476,9 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValueVisitor<'tcx, M> for ValidityVisitor<'rt,
             BackendRepr::Scalar(scalar_layout) => {
                 if !scalar_layout.is_uninit_valid() {
                     // There is something to check here.
-                    let scalar = self.read_scalar(val, ExpectedKind::InitScalar)?;
+                    // We read directly via `ecx` since the read cannot fail -- we already read
+                    // this field above when recursing into the field.
+                    let scalar = self.ecx.read_scalar(val)?;
                     self.visit_scalar(scalar, scalar_layout)?;
                 }
             }
@@ -1487,8 +1487,9 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValueVisitor<'tcx, M> for ValidityVisitor<'rt,
                 // FIXME: find a way to also check ScalarPair when one side can be uninit but
                 // the other must be init.
                 if !a_layout.is_uninit_valid() && !b_layout.is_uninit_valid() {
-                    let (a, b) =
-                        self.read_immediate(val, ExpectedKind::InitScalar)?.to_scalar_pair();
+                    // We read directly via `ecx` since the read cannot fail -- we already read
+                    // this field above when recursing into the field.
+                    let (a, b) = self.ecx.read_immediate(val)?.to_scalar_pair();
                     self.visit_scalar(a, a_layout)?;
                     self.visit_scalar(b, b_layout)?;
                 }

--- a/compiler/rustc_data_structures/src/aligned.rs
+++ b/compiler/rustc_data_structures/src/aligned.rs
@@ -1,4 +1,7 @@
 use std::marker::PointeeSized;
+#[cfg(not(bootstrap))]
+use std::mem::Alignment;
+#[cfg(bootstrap)]
 use std::ptr::Alignment;
 
 /// Returns the ABI-required minimum alignment of a type in bytes.

--- a/compiler/rustc_data_structures/src/tagged_ptr.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr.rs
@@ -55,7 +55,12 @@ pub unsafe trait Tag: Copy {
 /// Returns the number of bits available for use for tags in a pointer to `T`
 /// (this is based on `T`'s alignment).
 pub const fn bits_for<T: ?Sized + Aligned>() -> u32 {
-    crate::aligned::align_of::<T>().as_nonzero().trailing_zeros()
+    let alignment = crate::aligned::align_of::<T>();
+    #[cfg(bootstrap)]
+    let alignment = alignment.as_nonzero();
+    #[cfg(not(bootstrap))]
+    let alignment = alignment.as_nonzero_usize();
+    alignment.trailing_zeros()
 }
 
 /// Returns the correct [`Tag::BITS`] constant for a set of tag values.

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -2291,8 +2291,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             fn_sig,
                         );
                         let name = inherent_method.name();
+                        let inputs = fn_sig.inputs();
+                        let expected_inputs =
+                            if inherent_method.is_method() { &inputs[1..] } else { inputs };
                         if let Some(ref args) = call_args
-                            && fn_sig.inputs()[1..]
+                            && expected_inputs
                                 .iter()
                                 .eq_by(args, |expected, found| self.may_coerce(*expected, *found))
                         {

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -104,9 +104,6 @@ pub struct QueryVTable<'tcx, C: QueryCache> {
         index: DepNodeIndex,
     ) -> Option<C::Value>,
 
-    pub is_loadable_from_disk_fn:
-        fn(tcx: TyCtxt<'tcx>, key: C::Key, index: SerializedDepNodeIndex) -> bool,
-
     /// Function pointer that hashes this query's result values.
     ///
     /// For `no_hash` queries, this function pointer is None.

--- a/compiler/rustc_middle/src/ty/list.rs
+++ b/compiler/rustc_middle/src/ty/list.rs
@@ -264,7 +264,10 @@ unsafe impl<H: DynSync, T: DynSync> DynSync for RawList<H, T> {}
 // Layouts of `ListSkeleton<H, T>` and `RawList<H, T>` are the same, modulo opaque tail,
 // thus aligns of `ListSkeleton<H, T>` and `RawList<H, T>` must be the same.
 unsafe impl<H, T> Aligned for RawList<H, T> {
+    #[cfg(bootstrap)]
     const ALIGN: ptr::Alignment = align_of::<ListSkeleton<H, T>>();
+    #[cfg(not(bootstrap))]
+    const ALIGN: mem::Alignment = align_of::<ListSkeleton<H, T>>();
 }
 
 /// A [`List`] that additionally stores type information inline to speed up

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -528,13 +528,6 @@ fn load_from_disk_or_invoke_provider_green<'tcx, C: QueryCache>(
         "missing on-disk cache entry for {dep_node:?}"
     );
 
-    // Sanity check for the logic in `ensure`: if the node is green and the result loadable,
-    // we should actually be able to load it.
-    debug_assert!(
-        !((query.will_cache_on_disk_for_key_fn)(tcx, key) && loadable_from_disk(tcx, prev_index)),
-        "missing on-disk cache entry for loadable {dep_node:?}"
-    );
-
     // We could not load a result from the on-disk cache, so
     // recompute.
     let prof_timer = tcx.prof.query_provider();

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -18,7 +18,7 @@ use tracing::warn;
 
 use crate::dep_graph::{DepNode, DepNodeIndex};
 use crate::job::{QueryJobInfo, QueryJobMap, find_cycle_in_stack, report_cycle};
-use crate::plumbing::{current_query_job, next_job_id, start_query};
+use crate::plumbing::{current_query_job, loadable_from_disk, next_job_id, start_query};
 use crate::query_impl::for_each_query_vtable;
 
 #[inline]
@@ -531,7 +531,7 @@ fn load_from_disk_or_invoke_provider_green<'tcx, C: QueryCache>(
     // Sanity check for the logic in `ensure`: if the node is green and the result loadable,
     // we should actually be able to load it.
     debug_assert!(
-        !(query.is_loadable_from_disk_fn)(tcx, key, prev_index),
+        !((query.will_cache_on_disk_for_key_fn)(tcx, key) && loadable_from_disk(tcx, prev_index)),
         "missing on-disk cache entry for loadable {dep_node:?}"
     );
 
@@ -624,7 +624,8 @@ fn check_if_ensure_can_skip_execution<'tcx, C: QueryCache>(
             // In ensure-done mode, we can only skip execution for this key if
             // there's a disk-cached value available to load later if needed,
             // which guarantees the query provider will never run for this key.
-            let is_loadable = (query.is_loadable_from_disk_fn)(tcx, key, serialized_dep_node_index);
+            let is_loadable = (query.will_cache_on_disk_for_key_fn)(tcx, key)
+                && loadable_from_disk(tcx, serialized_dep_node_index);
             EnsureCanSkip { skip_execution: is_loadable, dep_node: Some(dep_node) }
         }
     }

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -520,14 +520,6 @@ fn load_from_disk_or_invoke_provider_green<'tcx, C: QueryCache>(
         return value;
     }
 
-    // We always expect to find a cached result for things that
-    // can be forced from `DepNode`.
-    debug_assert!(
-        !(query.will_cache_on_disk_for_key_fn)(tcx, key)
-            || !tcx.key_fingerprint_style(dep_node.kind).is_maybe_recoverable(),
-        "missing on-disk cache entry for {dep_node:?}"
-    );
-
     // We could not load a result from the on-disk cache, so
     // recompute.
     let prof_timer = tcx.prof.query_provider();

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -488,65 +488,58 @@ fn load_from_disk_or_invoke_provider_green<'tcx, C: QueryCache>(
 
     debug_assert!(dep_graph_data.is_index_green(prev_index));
 
-    // First we try to load the result from the on-disk cache.
-    // Some things are never cached on disk.
-    if let Some(value) = (query.try_load_from_disk_fn)(tcx, key, prev_index, dep_node_index) {
-        if std::intrinsics::unlikely(tcx.sess.opts.unstable_opts.query_dep_graph) {
-            dep_graph_data.mark_debug_loaded_from_disk(*dep_node)
-        }
+    // First try to load the result from the on-disk cache. Some things are never cached on disk.
+    let value;
+    let verify;
+    match (query.try_load_from_disk_fn)(tcx, key, prev_index, dep_node_index) {
+        Some(loaded_value) => {
+            if std::intrinsics::unlikely(tcx.sess.opts.unstable_opts.query_dep_graph) {
+                dep_graph_data.mark_debug_loaded_from_disk(*dep_node)
+            }
 
-        let prev_fingerprint = dep_graph_data.prev_value_fingerprint_of(prev_index);
-        // If `-Zincremental-verify-ich` is specified, re-hash results from
-        // the cache and make sure that they have the expected fingerprint.
+            value = loaded_value;
+
+            let prev_fingerprint = dep_graph_data.prev_value_fingerprint_of(prev_index);
+            // If `-Zincremental-verify-ich` is specified, re-hash results from
+            // the cache and make sure that they have the expected fingerprint.
+            //
+            // If not, we still seek to verify a subset of fingerprints loaded
+            // from disk. Re-hashing results is fairly expensive, so we can't
+            // currently afford to verify every hash. This subset should still
+            // give us some coverage of potential bugs.
+            verify = prev_fingerprint.split().1.as_u64().is_multiple_of(32)
+                || tcx.sess.opts.unstable_opts.incremental_verify_ich;
+        }
+        None => {
+            // We could not load a result from the on-disk cache, so recompute. The dep-graph for
+            // this computation is already in-place, so we can just call the query provider.
+            let prof_timer = tcx.prof.query_provider();
+            value = tcx.dep_graph.with_ignore(|| (query.invoke_provider_fn)(tcx, key));
+            prof_timer.finish_with_query_invocation_id(dep_node_index.into());
+
+            verify = true;
+        }
+    };
+
+    if verify {
+        // Verify that re-running the query produced a result with the expected hash.
+        // This catches bugs in query implementations, turning them into ICEs.
+        // For example, a query might sort its result by `DefId` - since `DefId`s are
+        // not stable across compilation sessions, the result could get up getting sorted
+        // in a different order when the query is re-run, even though all of the inputs
+        // (e.g. `DefPathHash` values) were green.
         //
-        // If not, we still seek to verify a subset of fingerprints loaded
-        // from disk. Re-hashing results is fairly expensive, so we can't
-        // currently afford to verify every hash. This subset should still
-        // give us some coverage of potential bugs though.
-        let try_verify = prev_fingerprint.split().1.as_u64().is_multiple_of(32);
-        if std::intrinsics::unlikely(
-            try_verify || tcx.sess.opts.unstable_opts.incremental_verify_ich,
-        ) {
-            incremental_verify_ich(
-                tcx,
-                dep_graph_data,
-                &value,
-                prev_index,
-                query.hash_value_fn,
-                query.format_value,
-            );
-        }
-
-        return value;
+        // See issue #82920 for an example of a miscompilation that would get turned into
+        // an ICE by this check
+        incremental_verify_ich(
+            tcx,
+            dep_graph_data,
+            &value,
+            prev_index,
+            query.hash_value_fn,
+            query.format_value,
+        );
     }
-
-    // We could not load a result from the on-disk cache, so
-    // recompute.
-    let prof_timer = tcx.prof.query_provider();
-
-    // The dep-graph for this computation is already in-place.
-    // Call the query provider.
-    let value = tcx.dep_graph.with_ignore(|| (query.invoke_provider_fn)(tcx, key));
-
-    prof_timer.finish_with_query_invocation_id(dep_node_index.into());
-
-    // Verify that re-running the query produced a result with the expected hash
-    // This catches bugs in query implementations, turning them into ICEs.
-    // For example, a query might sort its result by `DefId` - since `DefId`s are
-    // not stable across compilation sessions, the result could get up getting sorted
-    // in a different order when the query is re-run, even though all of the inputs
-    // (e.g. `DefPathHash` values) were green.
-    //
-    // See issue #82920 for an example of a miscompilation that would get turned into
-    // an ICE by this check
-    incremental_verify_ich(
-        tcx,
-        dep_graph_data,
-        &value,
-        prev_index,
-        query.hash_value_fn,
-        query.format_value,
-    );
 
     value
 }

--- a/compiler/rustc_query_impl/src/query_impl.rs
+++ b/compiler/rustc_query_impl/src/query_impl.rs
@@ -165,14 +165,6 @@ macro_rules! define_queries {
                         #[cfg(not($cache_on_disk))]
                         try_load_from_disk_fn: |_tcx, _key, _prev_index, _index| None,
 
-                        #[cfg($cache_on_disk)]
-                        is_loadable_from_disk_fn: |tcx, key, index| -> bool {
-                            rustc_middle::queries::_cache_on_disk_if_fns::$name(tcx, key) &&
-                                $crate::plumbing::loadable_from_disk(tcx, index)
-                        },
-                        #[cfg(not($cache_on_disk))]
-                        is_loadable_from_disk_fn: |_tcx, _key, _index| false,
-
                         // The default just emits `err` and then aborts.
                         // `from_cycle_error::specialize_query_vtables` overwrites this default for
                         // certain queries.

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1223,6 +1223,7 @@ symbols! {
         maybe_uninit,
         maybe_uninit_uninit,
         maybe_uninit_zeroed,
+        mem,
         mem_align_const,
         mem_discriminant,
         mem_drop,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -2299,6 +2299,11 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             // FIXME: this could use a better heuristic, like just checking
             // that args[1..] is the same.
             let all_traits_equal = traits.len() == 1;
+            let mut types: Vec<_> =
+                candidates.iter().map(|(c, _)| c.self_ty().to_string()).collect();
+            types.sort();
+            types.dedup();
+            let all_types_equal = types.len() == 1;
 
             let end = if candidates.len() <= 9 || self.tcx.sess.opts.verbose {
                 candidates.len()
@@ -2312,6 +2317,11 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 for (c, def_id) in &candidates {
                     let msg = if all_traits_equal {
                         format!("`{}`", self.tcx.short_string(c.self_ty(), err.long_ty_path()))
+                    } else if all_types_equal {
+                        format!(
+                            "`{}`",
+                            self.tcx.short_string(c.print_only_trait_path(), err.long_ty_path())
+                        )
                     } else {
                         format!(
                             "`{}` implements `{}`",
@@ -2321,13 +2331,19 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     };
                     span.push_span_label(self.tcx.def_span(*def_id), msg);
                 }
-                err.span_help(
-                    span,
+                let msg = if all_types_equal {
+                    format!(
+                        "`{}` implements trait `{}`",
+                        self.tcx.short_string(candidates[0].0.self_ty(), err.long_ty_path()),
+                        self.tcx.short_string(trait_ref.print_trait_sugared(), err.long_ty_path()),
+                    )
+                } else {
                     format!(
                         "the following {other}types implement trait `{}`",
-                        trait_ref.print_trait_sugared(),
-                    ),
-                );
+                        self.tcx.short_string(trait_ref.print_trait_sugared(), err.long_ty_path()),
+                    )
+                };
+                err.span_help(span, msg);
             } else {
                 let candidate_names: Vec<String> = candidates
                     .iter()
@@ -2336,6 +2352,12 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                             format!(
                                 "\n  {}",
                                 self.tcx.short_string(c.self_ty(), err.long_ty_path())
+                            )
+                        } else if all_types_equal {
+                            format!(
+                                "\n  {}",
+                                self.tcx
+                                    .short_string(c.print_only_trait_path(), err.long_ty_path())
                             )
                         } else {
                             format!(
@@ -2347,9 +2369,21 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         }
                     })
                     .collect();
+                let msg = if all_types_equal {
+                    format!(
+                        "`{}` implements trait `{}`",
+                        self.tcx.short_string(candidates[0].0.self_ty(), err.long_ty_path()),
+                        self.tcx.short_string(trait_ref.print_trait_sugared(), err.long_ty_path()),
+                    )
+                } else {
+                    format!(
+                        "the following {other}types implement trait `{}`",
+                        self.tcx.short_string(trait_ref.print_trait_sugared(), err.long_ty_path()),
+                    )
+                };
+
                 err.help(format!(
-                    "the following {other}types implement trait `{}`:{}{}",
-                    trait_ref.print_trait_sugared(),
+                    "{msg}:{}{}",
                     candidate_names[..end].join(""),
                     if candidates.len() > 9 && !self.tcx.sess.opts.verbose {
                         format!("\nand {} others", candidates.len() - 8)

--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -5,7 +5,8 @@
 #[stable(feature = "alloc_module", since = "1.28.0")]
 #[doc(inline)]
 pub use core::alloc::*;
-use core::ptr::{self, Alignment, NonNull};
+use core::mem::Alignment;
+use core::ptr::{self, NonNull};
 use core::{cmp, hint};
 
 unsafe extern "Rust" {

--- a/library/alloc/src/raw_vec/mod.rs
+++ b/library/alloc/src/raw_vec/mod.rs
@@ -5,8 +5,8 @@
 // run the tests. See the comment there for an explanation why this is the case.
 
 use core::marker::{Destruct, PhantomData};
-use core::mem::{ManuallyDrop, MaybeUninit, SizedTypeProperties};
-use core::ptr::{self, Alignment, NonNull, Unique};
+use core::mem::{Alignment, ManuallyDrop, MaybeUninit, SizedTypeProperties};
+use core::ptr::{self, NonNull, Unique};
 use core::{cmp, hint};
 
 #[cfg(not(no_global_oom_handling))]

--- a/library/alloc/src/raw_vec/mod.rs
+++ b/library/alloc/src/raw_vec/mod.rs
@@ -570,7 +570,7 @@ const impl<A: [const] Allocator + [const] Destruct> RawVecInner<A> {
 impl<A: Allocator> RawVecInner<A> {
     #[inline]
     const fn new_in(alloc: A, align: Alignment) -> Self {
-        let ptr = Unique::from_non_null(NonNull::without_provenance(align.as_nonzero()));
+        let ptr = Unique::from_non_null(NonNull::without_provenance(align.as_nonzero_usize()));
         // `cap: 0` means "unallocated". zero-sized types are ignored.
         Self { ptr, cap: ZERO_CAP, alloc }
     }

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -252,7 +252,7 @@ use core::intrinsics::abort;
 #[cfg(not(no_global_oom_handling))]
 use core::iter;
 use core::marker::{PhantomData, Unsize};
-use core::mem::{self, ManuallyDrop};
+use core::mem::{self, Alignment, ManuallyDrop};
 use core::num::NonZeroUsize;
 use core::ops::{CoerceUnsized, Deref, DerefMut, DerefPure, DispatchFromDyn, LegacyReceiver};
 #[cfg(not(no_global_oom_handling))]
@@ -261,7 +261,7 @@ use core::panic::{RefUnwindSafe, UnwindSafe};
 #[cfg(not(no_global_oom_handling))]
 use core::pin::Pin;
 use core::pin::PinCoerceUnsized;
-use core::ptr::{self, Alignment, NonNull, drop_in_place};
+use core::ptr::{self, NonNull, drop_in_place};
 #[cfg(not(no_global_oom_handling))]
 use core::slice::from_raw_parts_mut;
 use core::{borrow, fmt, hint};

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -19,14 +19,14 @@ use core::intrinsics::abort;
 #[cfg(not(no_global_oom_handling))]
 use core::iter;
 use core::marker::{PhantomData, Unsize};
-use core::mem::{self, ManuallyDrop};
+use core::mem::{self, Alignment, ManuallyDrop};
 use core::num::NonZeroUsize;
 use core::ops::{CoerceUnsized, Deref, DerefMut, DerefPure, DispatchFromDyn, LegacyReceiver};
 #[cfg(not(no_global_oom_handling))]
 use core::ops::{Residual, Try};
 use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::pin::{Pin, PinCoerceUnsized};
-use core::ptr::{self, Alignment, NonNull};
+use core::ptr::{self, NonNull};
 #[cfg(not(no_global_oom_handling))]
 use core::slice::from_raw_parts_mut;
 use core::sync::atomic::Ordering::{Acquire, Relaxed, Release};

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -268,7 +268,7 @@ impl Layout {
     #[must_use]
     #[inline]
     pub const fn dangling_ptr(&self) -> NonNull<u8> {
-        NonNull::without_provenance(self.align.as_nonzero())
+        NonNull::without_provenance(self.align.as_nonzero_usize())
     }
 
     /// Creates a layout describing the record that can hold a value

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -6,8 +6,8 @@
 
 use crate::error::Error;
 use crate::intrinsics::{unchecked_add, unchecked_mul, unchecked_sub};
-use crate::mem::SizedTypeProperties;
-use crate::ptr::{Alignment, NonNull};
+use crate::mem::{Alignment, SizedTypeProperties};
+use crate::ptr::NonNull;
 use crate::{assert_unsafe_precondition, fmt, mem};
 
 /// Layout of a block of memory.

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2502,14 +2502,6 @@ pub(crate) macro const_eval_select {
 /// particular value, ever. However, the compiler will generally make it
 /// return `true` only if the value of the argument is actually known.
 ///
-/// # Stability concerns
-///
-/// While it is safe to call, this intrinsic may behave differently in
-/// a `const` context than otherwise. See the [`const_eval_select()`]
-/// documentation for an explanation of the issues this can cause. Unlike
-/// `const_eval_select`, this intrinsic isn't guaranteed to behave
-/// deterministically even in a `const` context.
-///
 /// # Type Requirements
 ///
 /// `T` must be either a `bool`, a `char`, a primitive numeric type (e.g. `f32`,

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2590,6 +2590,12 @@ pub const unsafe fn typed_swap_nonoverlapping<T>(x: *mut T, y: *mut T) {
 /// assertions are enabled whenever the *user crate* has UB checks enabled. However, if the
 /// user has UB checks disabled, the checks will still get optimized out. This intrinsic is
 /// primarily used by [`crate::ub_checks::assert_unsafe_precondition`].
+///
+/// # Consteval
+///
+/// In consteval, this function currently returns `true`. This is because the value of the `ub_checks`
+/// configuration can differ across crates, but we need this function to always return the same
+/// value in consteval in order to avoid unsoundness.
 #[rustc_intrinsic_const_stable_indirect] // just for UB checks
 #[inline(always)]
 #[rustc_intrinsic]
@@ -2609,6 +2615,12 @@ pub const fn ub_checks() -> bool {
 /// `#[inline]`), gating assertions on `overflow_checks()` rather than `cfg!(overflow_checks)` means that
 /// assertions are enabled whenever the *user crate* has overflow checks enabled. However if the
 /// user has overflow checks disabled, the checks will still get optimized out.
+///
+/// # Consteval
+///
+/// In consteval, this function currently returns `true`. This is because the value of the `overflow_checks`
+/// configuration can differ across crates, but we need this function to always return the same
+/// value in consteval in order to avoid unsoundness.
 #[inline(always)]
 #[rustc_intrinsic]
 pub const fn overflow_checks() -> bool {

--- a/library/core/src/mem/alignment.rs
+++ b/library/core/src/mem/alignment.rs
@@ -37,7 +37,7 @@ impl Alignment {
     ///
     /// ```
     /// #![feature(ptr_alignment_type)]
-    /// use std::ptr::Alignment;
+    /// use std::mem::Alignment;
     ///
     /// assert_eq!(Alignment::MIN.as_usize(), 1);
     /// ```
@@ -65,7 +65,7 @@ impl Alignment {
     ///
     /// ```
     /// #![feature(ptr_alignment_type)]
-    /// use std::ptr::Alignment;
+    /// use std::mem::Alignment;
     ///
     /// assert_eq!(Alignment::of_val(&5i32).as_usize(), 4);
     /// ```
@@ -112,14 +112,13 @@ impl Alignment {
     ///
     /// ```
     /// #![feature(ptr_alignment_type)]
-    /// use std::ptr::Alignment;
+    /// use std::mem::Alignment;
     ///
     /// assert_eq!(unsafe { Alignment::of_val_raw(&5i32) }.as_usize(), 4);
     /// ```
     #[inline]
     #[must_use]
     #[unstable(feature = "ptr_alignment_type", issue = "102070")]
-    // #[unstable(feature = "layout_for_ptr", issue = "69835")]
     pub const unsafe fn of_val_raw<T: MetaSized>(val: *const T) -> Self {
         // SAFETY: precondition propagated to the caller
         let align = unsafe { mem::align_of_val_raw(val) };
@@ -214,9 +213,10 @@ impl Alignment {
     /// # Examples
     ///
     /// ```
-    /// #![feature(ptr_alignment_type)]
     /// #![feature(ptr_mask)]
-    /// use std::ptr::{Alignment, NonNull};
+    /// #![feature(ptr_alignment_type)]
+    /// use std::mem::Alignment;
+    /// use std::ptr::NonNull;
     ///
     /// #[repr(align(1))] struct Align1(u8);
     /// #[repr(align(2))] struct Align2(u16);
@@ -294,7 +294,7 @@ impl const From<Alignment> for usize {
 impl cmp::Ord for Alignment {
     #[inline]
     fn cmp(&self, other: &Self) -> cmp::Ordering {
-        self.as_nonzero().get().cmp(&other.as_nonzero().get())
+        self.as_nonzero().cmp(&other.as_nonzero())
     }
 }
 

--- a/library/core/src/mem/alignment.rs
+++ b/library/core/src/mem/alignment.rs
@@ -168,16 +168,28 @@ impl Alignment {
     #[unstable(feature = "ptr_alignment_type", issue = "102070")]
     #[inline]
     pub const fn as_usize(self) -> usize {
-        // Going through `as_nonzero` helps this be more clearly the inverse of
+        // Going through `as_nonzero_usize` helps this be more clearly the inverse of
         // `new_unchecked`, letting MIR optimizations fold it away.
 
-        self.as_nonzero().get()
+        self.as_nonzero_usize().get()
+    }
+
+    /// Returns the alignment as a <code>[NonZero]<[usize]></code>.
+    #[unstable(feature = "ptr_alignment_type", issue = "102070")]
+    #[deprecated(
+        since = "CURRENT_RUSTC_VERSION",
+        note = "renamed to `as_nonzero_usize`",
+        suggestion = "as_nonzero_usize"
+    )]
+    #[inline]
+    pub const fn as_nonzero(self) -> NonZero<usize> {
+        self.as_nonzero_usize()
     }
 
     /// Returns the alignment as a <code>[NonZero]<[usize]></code>.
     #[unstable(feature = "ptr_alignment_type", issue = "102070")]
     #[inline]
-    pub const fn as_nonzero(self) -> NonZero<usize> {
+    pub const fn as_nonzero_usize(self) -> NonZero<usize> {
         // This transmutes directly to avoid the UbCheck in `NonZero::new_unchecked`
         // since there's no way for the user to trip that check anyway -- the
         // validity invariant of the type would have to have been broken earlier --
@@ -203,7 +215,7 @@ impl Alignment {
     #[unstable(feature = "ptr_alignment_type", issue = "102070")]
     #[inline]
     pub const fn log2(self) -> u32 {
-        self.as_nonzero().trailing_zeros()
+        self.as_nonzero_usize().trailing_zeros()
     }
 
     /// Returns a bit mask that can be used to match this alignment.
@@ -246,7 +258,7 @@ impl Alignment {
 #[unstable(feature = "ptr_alignment_type", issue = "102070")]
 impl fmt::Debug for Alignment {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?} (1 << {:?})", self.as_nonzero(), self.log2())
+        write!(f, "{:?} (1 << {:?})", self.as_nonzero_usize(), self.log2())
     }
 }
 
@@ -277,7 +289,7 @@ impl const TryFrom<usize> for Alignment {
 impl const From<Alignment> for NonZero<usize> {
     #[inline]
     fn from(align: Alignment) -> NonZero<usize> {
-        align.as_nonzero()
+        align.as_nonzero_usize()
     }
 }
 
@@ -294,7 +306,7 @@ impl const From<Alignment> for usize {
 impl cmp::Ord for Alignment {
     #[inline]
     fn cmp(&self, other: &Self) -> cmp::Ordering {
-        self.as_nonzero().cmp(&other.as_nonzero())
+        self.as_nonzero_usize().cmp(&other.as_nonzero_usize())
     }
 }
 
@@ -310,7 +322,7 @@ impl cmp::PartialOrd for Alignment {
 impl hash::Hash for Alignment {
     #[inline]
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        self.as_nonzero().hash(state)
+        self.as_nonzero_usize().hash(state)
     }
 }
 

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -34,8 +34,11 @@ use crate::alloc::Layout;
 use crate::clone::TrivialClone;
 use crate::marker::{Destruct, DiscriminantKind};
 use crate::panic::const_assert;
-use crate::ptr::Alignment;
 use crate::{clone, cmp, fmt, hash, intrinsics, ptr};
+
+mod alignment;
+#[unstable(feature = "ptr_alignment_type", issue = "102070")]
+pub use alignment::Alignment;
 
 mod manually_drop;
 #[stable(feature = "manually_drop", since = "1.20.0")]

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -412,9 +412,10 @@ use crate::mem::{self, MaybeUninit, SizedTypeProperties};
 use crate::num::NonZero;
 use crate::{fmt, hash, intrinsics, ub_checks};
 
-mod alignment;
 #[unstable(feature = "ptr_alignment_type", issue = "102070")]
-pub use alignment::Alignment;
+#[deprecated(since = "CURRENT_RUSTC_VERSION", note = "moved from `ptr` to `mem`")]
+/// Deprecated re-export of [mem::Alignment].
+pub type Alignment = mem::Alignment;
 
 mod metadata;
 #[unstable(feature = "ptr_metadata", issue = "81513")]

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -128,7 +128,7 @@ impl<T: Sized> NonNull<T> {
     #[must_use]
     #[inline]
     pub const fn dangling() -> Self {
-        let align = crate::ptr::Alignment::of::<T>();
+        let align = crate::mem::Alignment::of::<T>();
         NonNull::without_provenance(align.as_nonzero())
     }
 

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -129,7 +129,7 @@ impl<T: Sized> NonNull<T> {
     #[inline]
     pub const fn dangling() -> Self {
         let align = crate::mem::Alignment::of::<T>();
-        NonNull::without_provenance(align.as_nonzero())
+        NonNull::without_provenance(align.as_nonzero_usize())
     }
 
     /// Converts an address back to a mutable pointer, picking up some previously 'exposed'

--- a/library/core/src/range/iter.rs
+++ b/library/core/src/range/iter.rs
@@ -298,9 +298,9 @@ range_incl_exact_iter_impl! {
 #[derive(Debug, Clone)]
 pub struct RangeFromIter<A> {
     start: A,
-    /// Whether the first element of the iterator has yielded.
+    /// Whether the maximum value of the iterator has yielded.
     /// Only used when overflow checks are enabled.
-    first: bool,
+    exhausted: bool,
 }
 
 impl<A: Step> RangeFromIter<A> {
@@ -309,10 +309,12 @@ impl<A: Step> RangeFromIter<A> {
     #[rustc_inherit_overflow_checks]
     #[unstable(feature = "new_range_api", issue = "125687")]
     pub fn remainder(self) -> RangeFrom<A> {
-        if intrinsics::overflow_checks() {
-            if !self.first {
-                return RangeFrom { start: Step::forward(self.start, 1) };
-            }
+        // Need to handle this case even if overflow-checks are disabled,
+        // because a `RangeFromIter` could be exhausted in a crate with
+        // overflow-checks enabled, but then passed to a crate with them
+        // disabled before this is called.
+        if self.exhausted {
+            return RangeFrom { start: Step::forward(self.start, 1) };
         }
 
         RangeFrom { start: self.start }
@@ -326,14 +328,29 @@ impl<A: Step> Iterator for RangeFromIter<A> {
     #[inline]
     #[rustc_inherit_overflow_checks]
     fn next(&mut self) -> Option<A> {
-        if intrinsics::overflow_checks() {
-            if self.first {
-                self.first = false;
-                return Some(self.start.clone());
-            }
-
+        if self.exhausted {
+            // This should panic if overflow checks are enabled, since
+            // `forward_checked` returned `None` in prior iteration.
             self.start = Step::forward(self.start.clone(), 1);
-            return Some(self.start.clone());
+
+            // If we get here, if means this iterator was exhausted by a crate
+            // with overflow-checks enabled, but now we're iterating in a crate with
+            // overflow-checks disabled. Since we successfully incremented `self.start`
+            // above (in many cases this will wrap around to MIN), we now unset
+            // the flag so we don't repeat this process in the next iteration.
+            //
+            // This could also happen if `forward_checked` returned None but
+            // (for whatever reason, not applicable to any std implementors)
+            // `forward` doesn't panic when overflow-checks are enabled. In that
+            // case, this is also the correct behavior.
+            self.exhausted = false;
+        }
+        if intrinsics::overflow_checks() {
+            let Some(n) = Step::forward_checked(self.start.clone(), 1) else {
+                self.exhausted = true;
+                return Some(self.start.clone());
+            };
+            return Some(mem::replace(&mut self.start, n));
         }
 
         let n = Step::forward(self.start.clone(), 1);
@@ -348,18 +365,22 @@ impl<A: Step> Iterator for RangeFromIter<A> {
     #[inline]
     #[rustc_inherit_overflow_checks]
     fn nth(&mut self, n: usize) -> Option<A> {
+        // Typically `forward` will cause an overflow-check panic here,
+        // but unset the exhausted flag to handle the uncommon cases.
+        // See the comments in `next` for more details.
+        if self.exhausted {
+            self.start = Step::forward(self.start.clone(), 1);
+            self.exhausted = false;
+        }
         if intrinsics::overflow_checks() {
-            if self.first {
-                self.first = false;
-
-                let plus_n = Step::forward(self.start.clone(), n);
-                self.start = plus_n.clone();
-                return Some(plus_n);
-            }
-
             let plus_n = Step::forward(self.start.clone(), n);
-            self.start = Step::forward(plus_n.clone(), 1);
-            return Some(self.start.clone());
+            if let Some(plus_n1) = Step::forward_checked(plus_n.clone(), 1) {
+                self.start = plus_n1;
+            } else {
+                self.start = plus_n.clone();
+                self.exhausted = true;
+            }
+            return Some(plus_n);
         }
 
         let plus_n = Step::forward(self.start.clone(), n);
@@ -380,6 +401,6 @@ impl<A: Step> IntoIterator for RangeFrom<A> {
     type IntoIter = RangeFromIter<A>;
 
     fn into_iter(self) -> Self::IntoIter {
-        RangeFromIter { start: self.start, first: true }
+        RangeFromIter { start: self.start, exhausted: false }
     }
 }

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -62,7 +62,7 @@ path = "../windows_link"
 rand = { version = "0.9.0", default-features = false, features = ["alloc"] }
 rand_xorshift = "0.4.0"
 
-[target.'cfg(any(all(target_family = "wasm", not(target_os = "wasi")), target_os = "xous", target_os = "vexos", all(target_vendor = "fortanix", target_env = "sgx")))'.dependencies]
+[target.'cfg(any(all(target_family = "wasm", not(any(unix, target_os = "wasi"))), target_os = "xous", target_os = "vexos", all(target_vendor = "fortanix", target_env = "sgx")))'.dependencies]
 dlmalloc = { version = "0.2.10", features = ['rustc-dep-of-std'] }
 
 [target.x86_64-fortanix-unknown-sgx.dependencies]

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -62,7 +62,7 @@ path = "../windows_link"
 rand = { version = "0.9.0", default-features = false, features = ["alloc"] }
 rand_xorshift = "0.4.0"
 
-[target.'cfg(any(all(target_family = "wasm", target_os = "unknown"), target_os = "xous", target_os = "vexos", all(target_vendor = "fortanix", target_env = "sgx")))'.dependencies]
+[target.'cfg(any(all(target_family = "wasm", not(target_os = "wasi")), target_os = "xous", target_os = "vexos", all(target_vendor = "fortanix", target_env = "sgx")))'.dependencies]
 dlmalloc = { version = "0.2.10", features = ['rustc-dep-of-std'] }
 
 [target.x86_64-fortanix-unknown-sgx.dependencies]

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -883,6 +883,12 @@ impl Build {
             features.push("check_only");
         }
 
+        if crates.iter().any(|c| c == "rustc_transmute") {
+            // for `x test rustc_transmute`, this feature isn't enabled automatically by a
+            // dependent crate.
+            features.push("rustc");
+        }
+
         // If debug logging is on, then we want the default for tracing:
         // https://github.com/tokio-rs/tracing/blob/3dd5c03d907afdf2c39444a29931833335171554/tracing/src/level_filters.rs#L26
         // which is everything (including debug/trace/etc.)

--- a/tests/codegen-llvm/fromrangeiter-overflow-checks.rs
+++ b/tests/codegen-llvm/fromrangeiter-overflow-checks.rs
@@ -2,7 +2,7 @@
 // runtime check that panics after yielding the maximum value of the range bound type. That is
 // tested for by tests/ui/iterators/rangefrom-overflow-overflow-checks.rs
 //
-// This test ensures that such a runtime check is *not* emitted when debug-assertions are
+// This test ensures such runtime checks are optimized out when debug-assertions are
 // enabled, but overflow-checks are explicitly disabled.
 
 //@ revisions: DEBUG NOCHECKS
@@ -11,17 +11,24 @@
 
 #![crate_type = "lib"]
 #![feature(new_range_api)]
-use std::range::{RangeFrom, RangeFromIter};
+use std::range::RangeFrom;
 
-// CHECK-LABEL: @iterrangefrom_remainder(
+// CHECK-LABEL: @rangefrom_increments(
 #[no_mangle]
-pub unsafe fn iterrangefrom_remainder(x: RangeFromIter<i32>) -> RangeFrom<i32> {
-    //        DEBUG: i32 noundef %x
-    //     NOCHECKS: i32 noundef returned %x
-    //        DEBUG: br i1
-    //        DEBUG: call core::panicking::panic_const::panic_const_add_overflow
-    //        DEBUG: unreachable
-    // NOCHECKS-NOT: unreachable
-    //     NOCHECKS: ret i32 %x
-    x.remainder()
+pub unsafe fn rangefrom_increments(range: RangeFrom<i32>) -> RangeFrom<i32> {
+    // Iterator is contained entirely within this function, so the optimizer should
+    // be able to see that `exhausted` is never set and optimize out any branches.
+
+    //         CHECK: i32 noundef %range
+    //         DEBUG: switch i32 %range
+    //         DEBUG: call core::panicking::panic_const::panic_const_add_overflow
+    //         DEBUG: unreachable
+    //  NOCHECKS-NOT: unreachable
+    //      NOCHECKS: [[REM:%[a-z_0-9.]+]] = add i32 %range, 2
+    // NOCHECKS-NEXT: ret i32 [[REM]]
+
+    let mut iter = range.into_iter();
+    let _ = iter.next();
+    let _ = iter.next();
+    iter.remainder()
 }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-abort.diff
@@ -17,12 +17,12 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }
                   }
-                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                  scope 7 (inlined std::mem::Alignment::of::<[bool; 0]>) {
                   }
               }
           }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-abort.diff
@@ -17,7 +17,7 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero_usize) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-unwind.diff
@@ -17,12 +17,12 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }
                   }
-                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                  scope 7 (inlined std::mem::Alignment::of::<[bool; 0]>) {
                   }
               }
           }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-unwind.diff
@@ -17,7 +17,7 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero_usize) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-abort.diff
@@ -17,12 +17,12 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }
                   }
-                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                  scope 7 (inlined std::mem::Alignment::of::<[bool; 0]>) {
                   }
               }
           }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-abort.diff
@@ -17,7 +17,7 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero_usize) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-unwind.diff
@@ -17,12 +17,12 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }
                   }
-                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                  scope 7 (inlined std::mem::Alignment::of::<[bool; 0]>) {
                   }
               }
           }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-unwind.diff
@@ -17,7 +17,7 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero_usize) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-abort.diff
@@ -17,12 +17,12 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }
                   }
-                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                  scope 7 (inlined std::mem::Alignment::of::<[bool; 0]>) {
                   }
               }
           }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-abort.diff
@@ -17,7 +17,7 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero_usize) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-unwind.diff
@@ -17,12 +17,12 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }
                   }
-                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                  scope 7 (inlined std::mem::Alignment::of::<[bool; 0]>) {
                   }
               }
           }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-unwind.diff
@@ -17,7 +17,7 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero_usize) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-abort.diff
@@ -17,12 +17,12 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }
                   }
-                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                  scope 7 (inlined std::mem::Alignment::of::<[bool; 0]>) {
                   }
               }
           }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-abort.diff
@@ -17,7 +17,7 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero_usize) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-unwind.diff
@@ -17,12 +17,12 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }
                   }
-                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
+                  scope 7 (inlined std::mem::Alignment::of::<[bool; 0]>) {
                   }
               }
           }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-unwind.diff
@@ -17,7 +17,7 @@
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
                   scope 6 {
-                      scope 8 (inlined std::mem::Alignment::as_nonzero) {
+                      scope 8 (inlined std::mem::Alignment::as_nonzero_usize) {
                       }
                       scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
                       }

--- a/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.32bit.panic-abort.diff
@@ -51,7 +51,7 @@
           StorageLive(_12);
           StorageLive(_13);
 -         _13 = boxed::box_new_uninit(const <() as std::mem::SizedTypeProperties>::LAYOUT) -> [return: bb2, unwind unreachable];
-+         _13 = boxed::box_new_uninit(const Layout {{ size: 0_usize, align: std::ptr::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }} }}) -> [return: bb2, unwind unreachable];
++         _13 = boxed::box_new_uninit(const Layout {{ size: 0_usize, align: std::mem::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }} }}) -> [return: bb2, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.64bit.panic-abort.diff
@@ -51,7 +51,7 @@
           StorageLive(_12);
           StorageLive(_13);
 -         _13 = boxed::box_new_uninit(const <() as std::mem::SizedTypeProperties>::LAYOUT) -> [return: bb2, unwind unreachable];
-+         _13 = boxed::box_new_uninit(const Layout {{ size: 0_usize, align: std::ptr::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }} }}) -> [return: bb2, unwind unreachable];
++         _13 = boxed::box_new_uninit(const Layout {{ size: 0_usize, align: std::mem::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }} }}) -> [return: bb2, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/gvn_ptr_eq_with_constant.main.GVN.diff
+++ b/tests/mir-opt/gvn_ptr_eq_with_constant.main.GVN.diff
@@ -7,14 +7,14 @@
       let mut _2: *mut u8;
       scope 1 (inlined dangling_mut::<u8>) {
           scope 2 (inlined NonNull::<u8>::dangling) {
-              let _3: std::ptr::Alignment;
+              let _3: std::mem::Alignment;
               scope 3 {
-                  scope 5 (inlined std::ptr::Alignment::as_nonzero) {
+                  scope 5 (inlined std::mem::Alignment::as_nonzero) {
                   }
                   scope 6 (inlined NonNull::<u8>::without_provenance) {
                   }
               }
-              scope 4 (inlined std::ptr::Alignment::of::<u8>) {
+              scope 4 (inlined std::mem::Alignment::of::<u8>) {
               }
           }
           scope 7 (inlined NonNull::<u8>::as_ptr) {
@@ -34,7 +34,7 @@
           StorageLive(_3);
 -         _3 = const <u8 as std::mem::SizedTypeProperties>::ALIGNMENT;
 -         _2 = copy _3 as *mut u8 (Transmute);
-+         _3 = const std::ptr::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }};
++         _3 = const std::mem::Alignment {{ _inner_repr_trick: mem::alignment::AlignmentEnum::_Align1Shl0 }};
 +         _2 = const {0x1 as *mut u8};
           StorageDead(_3);
           StorageLive(_4);

--- a/tests/mir-opt/gvn_ptr_eq_with_constant.main.GVN.diff
+++ b/tests/mir-opt/gvn_ptr_eq_with_constant.main.GVN.diff
@@ -9,7 +9,7 @@
           scope 2 (inlined NonNull::<u8>::dangling) {
               let _3: std::mem::Alignment;
               scope 3 {
-                  scope 5 (inlined std::mem::Alignment::as_nonzero) {
+                  scope 5 (inlined std::mem::Alignment::as_nonzero_usize) {
                   }
                   scope 6 (inlined NonNull::<u8>::without_provenance) {
                   }

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.PreCodegen.after.panic-abort.mir
@@ -48,9 +48,9 @@ fn drop_bytes(_1: *mut Box<[u8; 1024]>) -> () {
                     }
                     scope 9 (inlined size_of_val_raw::<[u8; 1024]>) {
                     }
-                    scope 10 (inlined std::ptr::Alignment::of_val_raw::<[u8; 1024]>) {
+                    scope 10 (inlined std::mem::Alignment::of_val_raw::<[u8; 1024]>) {
                         scope 11 {
-                            scope 13 (inlined #[track_caller] std::ptr::Alignment::new_unchecked) {
+                            scope 13 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
                                 scope 14 (inlined core::ub_checks::check_language_ub) {
                                     scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
                                     }
@@ -69,7 +69,7 @@ fn drop_bytes(_1: *mut Box<[u8; 1024]>) -> () {
         StorageLive(_3);
         _2 = copy (((*_1).0: std::ptr::Unique<[u8; 1024]>).0: std::ptr::NonNull<[u8; 1024]>);
         _3 = copy _2 as std::ptr::NonNull<u8> (Transmute);
-        _4 = alloc::alloc::__rust_dealloc(move _3, const 1024_usize, const std::ptr::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }}) -> [return: bb1, unwind unreachable];
+        _4 = alloc::alloc::__rust_dealloc(move _3, const 1024_usize, const std::mem::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }}) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.PreCodegen.after.panic-unwind.mir
@@ -48,9 +48,9 @@ fn drop_bytes(_1: *mut Box<[u8; 1024]>) -> () {
                     }
                     scope 9 (inlined size_of_val_raw::<[u8; 1024]>) {
                     }
-                    scope 10 (inlined std::ptr::Alignment::of_val_raw::<[u8; 1024]>) {
+                    scope 10 (inlined std::mem::Alignment::of_val_raw::<[u8; 1024]>) {
                         scope 11 {
-                            scope 13 (inlined #[track_caller] std::ptr::Alignment::new_unchecked) {
+                            scope 13 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
                                 scope 14 (inlined core::ub_checks::check_language_ub) {
                                     scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
                                     }
@@ -69,7 +69,7 @@ fn drop_bytes(_1: *mut Box<[u8; 1024]>) -> () {
         StorageLive(_3);
         _2 = copy (((*_1).0: std::ptr::Unique<[u8; 1024]>).0: std::ptr::NonNull<[u8; 1024]>);
         _3 = copy _2 as std::ptr::NonNull<u8> (Transmute);
-        _4 = alloc::alloc::__rust_dealloc(move _3, const 1024_usize, const std::ptr::Alignment {{ _inner_repr_trick: std::ptr::alignment::AlignmentEnum::_Align1Shl0 }}) -> [return: bb1, unwind unreachable];
+        _4 = alloc::alloc::__rust_dealloc(move _3, const 1024_usize, const std::mem::Alignment {{ _inner_repr_trick: mem::alignment::AlignmentEnum::_Align1Shl0 }}) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-abort.mir
@@ -42,16 +42,16 @@ fn drop_generic(_1: *mut Box<T>) -> () {
                     }
                 }
                 scope 7 (inlined Layout::for_value_raw::<T>) {
-                    let mut _3: std::ptr::Alignment;
+                    let mut _3: std::mem::Alignment;
                     scope 8 {
                         scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
                         }
                     }
                     scope 9 (inlined size_of_val_raw::<T>) {
                     }
-                    scope 10 (inlined std::ptr::Alignment::of_val_raw::<T>) {
+                    scope 10 (inlined std::mem::Alignment::of_val_raw::<T>) {
                         scope 11 {
-                            scope 13 (inlined #[track_caller] std::ptr::Alignment::new_unchecked) {
+                            scope 13 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
                                 scope 14 (inlined core::ub_checks::check_language_ub) {
                                     scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
                                     }
@@ -69,7 +69,7 @@ fn drop_generic(_1: *mut Box<T>) -> () {
     bb0: {
         StorageLive(_4);
         _2 = copy (((*_1).0: std::ptr::Unique<T>).0: std::ptr::NonNull<T>);
-        _3 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
+        _3 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::mem::Alignment (Transmute);
         switchInt(const <T as std::mem::SizedTypeProperties>::SIZE) -> [0: bb3, otherwise: bb1];
     }
 

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-unwind.mir
@@ -42,16 +42,16 @@ fn drop_generic(_1: *mut Box<T>) -> () {
                     }
                 }
                 scope 7 (inlined Layout::for_value_raw::<T>) {
-                    let mut _3: std::ptr::Alignment;
+                    let mut _3: std::mem::Alignment;
                     scope 8 {
                         scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
                         }
                     }
                     scope 9 (inlined size_of_val_raw::<T>) {
                     }
-                    scope 10 (inlined std::ptr::Alignment::of_val_raw::<T>) {
+                    scope 10 (inlined std::mem::Alignment::of_val_raw::<T>) {
                         scope 11 {
-                            scope 13 (inlined #[track_caller] std::ptr::Alignment::new_unchecked) {
+                            scope 13 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
                                 scope 14 (inlined core::ub_checks::check_language_ub) {
                                     scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
                                     }
@@ -69,7 +69,7 @@ fn drop_generic(_1: *mut Box<T>) -> () {
     bb0: {
         StorageLive(_4);
         _2 = copy (((*_1).0: std::ptr::Unique<T>).0: std::ptr::NonNull<T>);
-        _3 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
+        _3 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::mem::Alignment (Transmute);
         switchInt(const <T as std::mem::SizedTypeProperties>::SIZE) -> [0: bb3, otherwise: bb1];
     }
 

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.rs
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.rs
@@ -6,7 +6,7 @@
 // EMIT_MIR drop_box_of_sized.drop_generic.PreCodegen.after.mir
 pub unsafe fn drop_generic<T: Copy>(x: *mut Box<T>) {
     // CHECK-LABEL: fn drop_generic
-    // CHECK: [[ALIGNMENT:_.+]] = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute)
+    // CHECK: [[ALIGNMENT:_.+]] = const <T as std::mem::SizedTypeProperties>::ALIGN as std::mem::Alignment (Transmute)
     // CHECK: alloc::alloc::__rust_dealloc({{.+}}, const <T as std::mem::SizedTypeProperties>::SIZE, move [[ALIGNMENT]])
     std::ptr::drop_in_place(x)
 }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-abort.mir
@@ -46,16 +46,16 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 }
                 scope 7 (inlined Layout::for_value_raw::<[T]>) {
                     let mut _5: usize;
-                    let mut _6: std::ptr::Alignment;
+                    let mut _6: std::mem::Alignment;
                     scope 8 {
                         scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
                         }
                     }
                     scope 9 (inlined size_of_val_raw::<[T]>) {
                     }
-                    scope 10 (inlined std::ptr::Alignment::of_val_raw::<[T]>) {
+                    scope 10 (inlined std::mem::Alignment::of_val_raw::<[T]>) {
                         scope 11 {
-                            scope 13 (inlined #[track_caller] std::ptr::Alignment::new_unchecked) {
+                            scope 13 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
                                 scope 14 (inlined core::ub_checks::check_language_ub) {
                                     scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
                                     }
@@ -82,7 +82,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
     }
 
     bb1: {
-        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
+        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::mem::Alignment (Transmute);
         StorageDead(_4);
         switchInt(copy _5) -> [0: bb3, otherwise: bb2];
     }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-unwind.mir
@@ -46,16 +46,16 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 }
                 scope 7 (inlined Layout::for_value_raw::<[T]>) {
                     let mut _5: usize;
-                    let mut _6: std::ptr::Alignment;
+                    let mut _6: std::mem::Alignment;
                     scope 8 {
                         scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
                         }
                     }
                     scope 9 (inlined size_of_val_raw::<[T]>) {
                     }
-                    scope 10 (inlined std::ptr::Alignment::of_val_raw::<[T]>) {
+                    scope 10 (inlined std::mem::Alignment::of_val_raw::<[T]>) {
                         scope 11 {
-                            scope 13 (inlined #[track_caller] std::ptr::Alignment::new_unchecked) {
+                            scope 13 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
                                 scope 14 (inlined core::ub_checks::check_language_ub) {
                                     scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
                                     }
@@ -82,7 +82,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
     }
 
     bb1: {
-        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
+        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::mem::Alignment (Transmute);
         StorageDead(_4);
         switchInt(copy _5) -> [0: bb3, otherwise: bb2];
     }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
@@ -46,16 +46,16 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 }
                 scope 7 (inlined Layout::for_value_raw::<[T]>) {
                     let mut _5: usize;
-                    let mut _6: std::ptr::Alignment;
+                    let mut _6: std::mem::Alignment;
                     scope 8 {
                         scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
                         }
                     }
                     scope 9 (inlined size_of_val_raw::<[T]>) {
                     }
-                    scope 10 (inlined std::ptr::Alignment::of_val_raw::<[T]>) {
+                    scope 10 (inlined std::mem::Alignment::of_val_raw::<[T]>) {
                         scope 11 {
-                            scope 13 (inlined #[track_caller] std::ptr::Alignment::new_unchecked) {
+                            scope 13 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
                                 scope 14 (inlined core::ub_checks::check_language_ub) {
                                     scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
                                     }
@@ -82,7 +82,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
     }
 
     bb1: {
-        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
+        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::mem::Alignment (Transmute);
         StorageDead(_4);
         switchInt(copy _5) -> [0: bb3, otherwise: bb2];
     }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-unwind.mir
@@ -46,16 +46,16 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                 }
                 scope 7 (inlined Layout::for_value_raw::<[T]>) {
                     let mut _5: usize;
-                    let mut _6: std::ptr::Alignment;
+                    let mut _6: std::mem::Alignment;
                     scope 8 {
                         scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
                         }
                     }
                     scope 9 (inlined size_of_val_raw::<[T]>) {
                     }
-                    scope 10 (inlined std::ptr::Alignment::of_val_raw::<[T]>) {
+                    scope 10 (inlined std::mem::Alignment::of_val_raw::<[T]>) {
                         scope 11 {
-                            scope 13 (inlined #[track_caller] std::ptr::Alignment::new_unchecked) {
+                            scope 13 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
                                 scope 14 (inlined core::ub_checks::check_language_ub) {
                                     scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
                                     }
@@ -82,7 +82,7 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
     }
 
     bb1: {
-        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
+        _6 = const <T as std::mem::SizedTypeProperties>::ALIGN as std::mem::Alignment (Transmute);
         StorageDead(_4);
         switchInt(copy _5) -> [0: bb3, otherwise: bb2];
     }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.rs
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.rs
@@ -9,7 +9,7 @@ pub unsafe fn generic_in_place<T: Copy>(ptr: *mut Box<[T]>) {
     // CHECK-LABEL: fn generic_in_place(_1: *mut Box<[T]>)
     // CHECK: (inlined <Box<[T]> as Drop>::drop)
     // CHECK: [[SIZE:_.+]] = std::intrinsics::size_of_val::<[T]>
-    // CHECK: [[ALIGN:_.+]] = const <T as std::mem::SizedTypeProperties>::ALIGN as std::ptr::Alignment (Transmute);
+    // CHECK: [[ALIGN:_.+]] = const <T as std::mem::SizedTypeProperties>::ALIGN as std::mem::Alignment (Transmute);
     // CHECK: = alloc::alloc::__rust_dealloc({{.+}}, move [[SIZE]], move [[ALIGN]]) ->
     std::ptr::drop_in_place(ptr)
 }

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-abort.diff
@@ -63,7 +63,7 @@
   
       bb3: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
-+         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment {{ _inner_repr_trick: Scalar(0x00000000): std::ptr::alignment::AlignmentEnum }} }};
++         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x00000000): std::ptr::alignment::AlignmentEnum }} }};
           StorageDead(_8);
           StorageDead(_2);
           StorageLive(_3);
@@ -73,8 +73,8 @@
           StorageLive(_7);
 -         _7 = copy _1;
 -         _6 = std::alloc::Global::alloc_impl_runtime(move _7, const false) -> [return: bb4, unwind unreachable];
-+         _7 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment {{ _inner_repr_trick: Scalar(0x00000000): std::ptr::alignment::AlignmentEnum }} }};
-+         _6 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment {{ _inner_repr_trick: Scalar(0x00000000): std::ptr::alignment::AlignmentEnum }} }}, const false) -> [return: bb4, unwind unreachable];
++         _7 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x00000000): std::ptr::alignment::AlignmentEnum }} }};
++         _6 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x00000000): std::ptr::alignment::AlignmentEnum }} }}, const false) -> [return: bb4, unwind unreachable];
       }
   
       bb4: {

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-unwind.diff
@@ -64,7 +64,7 @@
   
       bb4: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
-+         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment {{ _inner_repr_trick: Scalar(0x00000000): std::ptr::alignment::AlignmentEnum }} }};
++         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x00000000): mem::alignment::AlignmentEnum }} }};
           StorageDead(_8);
           StorageDead(_2);
           StorageLive(_3);
@@ -74,8 +74,8 @@
           StorageLive(_7);
 -         _7 = copy _1;
 -         _6 = std::alloc::Global::alloc_impl_runtime(move _7, const false) -> [return: bb5, unwind continue];
-+         _7 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment {{ _inner_repr_trick: Scalar(0x00000000): std::ptr::alignment::AlignmentEnum }} }};
-+         _6 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment {{ _inner_repr_trick: Scalar(0x00000000): std::ptr::alignment::AlignmentEnum }} }}, const false) -> [return: bb5, unwind continue];
++         _7 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x00000000): mem::alignment::AlignmentEnum }} }};
++         _6 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x00000000): mem::alignment::AlignmentEnum }} }}, const false) -> [return: bb5, unwind continue];
       }
   
       bb5: {

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
@@ -63,7 +63,7 @@
   
       bb3: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
-+         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum }} }};
++         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum }} }};
           StorageDead(_8);
           StorageDead(_2);
           StorageLive(_3);
@@ -73,8 +73,8 @@
           StorageLive(_7);
 -         _7 = copy _1;
 -         _6 = std::alloc::Global::alloc_impl_runtime(move _7, const false) -> [return: bb4, unwind unreachable];
-+         _7 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum }} }};
-+         _6 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum }} }}, const false) -> [return: bb4, unwind unreachable];
++         _7 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum }} }};
++         _6 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum }} }}, const false) -> [return: bb4, unwind unreachable];
       }
   
       bb4: {

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-unwind.diff
@@ -64,7 +64,7 @@
   
       bb4: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
-+         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum }} }};
++         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): mem::alignment::AlignmentEnum }} }};
           StorageDead(_8);
           StorageDead(_2);
           StorageLive(_3);
@@ -74,8 +74,8 @@
           StorageLive(_7);
 -         _7 = copy _1;
 -         _6 = std::alloc::Global::alloc_impl_runtime(move _7, const false) -> [return: bb5, unwind continue];
-+         _7 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum }} }};
-+         _6 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum }} }}, const false) -> [return: bb5, unwind continue];
++         _7 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): mem::alignment::AlignmentEnum }} }};
++         _6 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): mem::alignment::AlignmentEnum }} }}, const false) -> [return: bb5, unwind continue];
       }
   
       bb5: {

--- a/tests/run-make/crate-loading/multiple-dep-versions.stderr
+++ b/tests/run-make/crate-loading/multiple-dep-versions.stderr
@@ -177,14 +177,14 @@ LL |     Err(Error2)?;
    |     this can't be annotated with `?` because it has type `Result<_, Error2>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-help: the following other types implement trait `From<T>`
+help: `dependency::OtherError` implements trait `From<T>`
   --> replaced
    |
 LL | impl From<()> for OtherError {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dependency::OtherError` implements `From<()>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `From<()>`
 ...
 LL | impl From<i32> for OtherError {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dependency::OtherError` implements `From<i32>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `From<i32>`
    = note: there are multiple different versions of crate `dependency` in the dependency graph
    = help: you can use `cargo tree` to explore your dependency tree
 

--- a/tests/ui/asm/aarch64/bad-options.stderr
+++ b/tests/ui/asm/aarch64/bad-options.stderr
@@ -78,7 +78,7 @@ error: invalid ABI for `clobber_abi`
 LL |         asm!("", clobber_abi("foo"));
    |                  ^^^^^^^^^^^^^^^^^^
    |
-   = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`
+   = note: the following ABIs are supported on this target: `C`, `system`, and `efiapi`
 
 error: aborting due to 13 previous errors
 

--- a/tests/ui/asm/aarch64/bad-reg.rs
+++ b/tests/ui/asm/aarch64/bad-reg.rs
@@ -1,7 +1,12 @@
+//@ add-minicore
 //@ only-aarch64
 //@ compile-flags: -C target-feature=+neon
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
 
-use std::arch::asm;
+extern crate minicore;
+use minicore::*;
 
 fn main() {
     let mut foo = 0;
@@ -14,11 +19,11 @@ fn main() {
         asm!("", in("foo") foo);
         //~^ ERROR invalid register `foo`: unknown register
         asm!("{:z}", in(reg) foo);
-        //~^ ERROR invalid asm template modifier for this register class
+        //~^ ERROR invalid asm template modifier `z` for this register class
         asm!("{:r}", in(vreg) foo);
-        //~^ ERROR invalid asm template modifier for this register class
+        //~^ ERROR invalid asm template modifier `r` for this register class
         asm!("{:r}", in(vreg_low16) foo);
-        //~^ ERROR invalid asm template modifier for this register class
+        //~^ ERROR invalid asm template modifier `r` for this register class
         asm!("{:a}", const 0);
         //~^ ERROR asm template modifiers are not allowed for `const` arguments
         asm!("{:a}", sym main);

--- a/tests/ui/asm/aarch64/bad-reg.stderr
+++ b/tests/ui/asm/aarch64/bad-reg.stderr
@@ -1,49 +1,49 @@
 error: invalid register class `foo`: unknown register class
-  --> $DIR/bad-reg.rs:12:20
+  --> $DIR/bad-reg.rs:17:20
    |
 LL |         asm!("{}", in(foo) foo);
    |                    ^^^^^^^^^^^
    |
-   = note: the following register classes are supported on this target: `reg`, `vreg`, `vreg_low16`, `preg`
+   = note: the following register classes are supported on this target: `reg`, `vreg`, `vreg_low16`, and `preg`
 
 error: invalid register `foo`: unknown register
-  --> $DIR/bad-reg.rs:14:18
+  --> $DIR/bad-reg.rs:19:18
    |
 LL |         asm!("", in("foo") foo);
    |                  ^^^^^^^^^^^^^
 
-error: invalid asm template modifier for this register class
-  --> $DIR/bad-reg.rs:16:15
+error: invalid asm template modifier `z` for this register class
+  --> $DIR/bad-reg.rs:21:15
    |
 LL |         asm!("{:z}", in(reg) foo);
    |               ^^^^   ----------- argument
    |               |
    |               template modifier
    |
-   = note: the `reg` register class supports the following template modifiers: `w`, `x`
+   = note: the `reg` register class supports the following template modifiers: `w` and `x`
 
-error: invalid asm template modifier for this register class
-  --> $DIR/bad-reg.rs:18:15
+error: invalid asm template modifier `r` for this register class
+  --> $DIR/bad-reg.rs:23:15
    |
 LL |         asm!("{:r}", in(vreg) foo);
    |               ^^^^   ------------ argument
    |               |
    |               template modifier
    |
-   = note: the `vreg` register class supports the following template modifiers: `b`, `h`, `s`, `d`, `q`, `v`
+   = note: the `vreg` register class supports the following template modifiers: `b`, `h`, `s`, `d`, `q`, and `v`
 
-error: invalid asm template modifier for this register class
-  --> $DIR/bad-reg.rs:20:15
+error: invalid asm template modifier `r` for this register class
+  --> $DIR/bad-reg.rs:25:15
    |
 LL |         asm!("{:r}", in(vreg_low16) foo);
    |               ^^^^   ------------------ argument
    |               |
    |               template modifier
    |
-   = note: the `vreg_low16` register class supports the following template modifiers: `b`, `h`, `s`, `d`, `q`, `v`
+   = note: the `vreg_low16` register class supports the following template modifiers: `b`, `h`, `s`, `d`, `q`, and `v`
 
 error: asm template modifiers are not allowed for `const` arguments
-  --> $DIR/bad-reg.rs:22:15
+  --> $DIR/bad-reg.rs:27:15
    |
 LL |         asm!("{:a}", const 0);
    |               ^^^^   ------- argument
@@ -51,7 +51,7 @@ LL |         asm!("{:a}", const 0);
    |               template modifier
 
 error: asm template modifiers are not allowed for `sym` arguments
-  --> $DIR/bad-reg.rs:24:15
+  --> $DIR/bad-reg.rs:29:15
    |
 LL |         asm!("{:a}", sym main);
    |               ^^^^   -------- argument
@@ -59,49 +59,49 @@ LL |         asm!("{:a}", sym main);
    |               template modifier
 
 error: invalid register `x29`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:26:18
+  --> $DIR/bad-reg.rs:31:18
    |
 LL |         asm!("", in("x29") foo);
    |                  ^^^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:28:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", in("sp") foo);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `xzr`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:30:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", in("xzr") foo);
    |                  ^^^^^^^^^^^^^
 
 error: invalid register `x19`: x19 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:32:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", in("x19") foo);
    |                  ^^^^^^^^^^^^^
 
 error: register class `preg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:35:18
+  --> $DIR/bad-reg.rs:40:18
    |
 LL |         asm!("", in("p0") foo);
    |                  ^^^^^^^^^^^^
 
 error: register class `preg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:39:20
+  --> $DIR/bad-reg.rs:44:20
    |
 LL |         asm!("{}", in(preg) foo);
    |                    ^^^^^^^^^^^^
 
 error: register class `preg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:42:20
+  --> $DIR/bad-reg.rs:47:20
    |
 LL |         asm!("{}", out(preg) _);
    |                    ^^^^^^^^^^^
 
 error: register `w0` conflicts with register `x0`
-  --> $DIR/bad-reg.rs:48:32
+  --> $DIR/bad-reg.rs:53:32
    |
 LL |         asm!("", in("x0") foo, in("w0") bar);
    |                  ------------  ^^^^^^^^^^^^ register `w0`
@@ -109,7 +109,7 @@ LL |         asm!("", in("x0") foo, in("w0") bar);
    |                  register `x0`
 
 error: register `x0` conflicts with register `x0`
-  --> $DIR/bad-reg.rs:50:32
+  --> $DIR/bad-reg.rs:55:32
    |
 LL |         asm!("", in("x0") foo, out("x0") bar);
    |                  ------------  ^^^^^^^^^^^^^ register `x0`
@@ -117,13 +117,13 @@ LL |         asm!("", in("x0") foo, out("x0") bar);
    |                  register `x0`
    |
 help: use `lateout` instead of `out` to avoid conflict
-  --> $DIR/bad-reg.rs:50:18
+  --> $DIR/bad-reg.rs:55:18
    |
 LL |         asm!("", in("x0") foo, out("x0") bar);
    |                  ^^^^^^^^^^^^
 
 error: register `q0` conflicts with register `v0`
-  --> $DIR/bad-reg.rs:53:32
+  --> $DIR/bad-reg.rs:58:32
    |
 LL |         asm!("", in("v0") foo, in("q0") bar);
    |                  ------------  ^^^^^^^^^^^^ register `q0`
@@ -131,7 +131,7 @@ LL |         asm!("", in("v0") foo, in("q0") bar);
    |                  register `v0`
 
 error: register `q0` conflicts with register `v0`
-  --> $DIR/bad-reg.rs:55:32
+  --> $DIR/bad-reg.rs:60:32
    |
 LL |         asm!("", in("v0") foo, out("q0") bar);
    |                  ------------  ^^^^^^^^^^^^^ register `q0`
@@ -139,13 +139,13 @@ LL |         asm!("", in("v0") foo, out("q0") bar);
    |                  register `v0`
    |
 help: use `lateout` instead of `out` to avoid conflict
-  --> $DIR/bad-reg.rs:55:18
+  --> $DIR/bad-reg.rs:60:18
    |
 LL |         asm!("", in("v0") foo, out("q0") bar);
    |                  ^^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:35:27
+  --> $DIR/bad-reg.rs:40:27
    |
 LL |         asm!("", in("p0") foo);
    |                           ^^^
@@ -153,7 +153,7 @@ LL |         asm!("", in("p0") foo);
    = note: register class `preg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:39:29
+  --> $DIR/bad-reg.rs:44:29
    |
 LL |         asm!("{}", in(preg) foo);
    |                             ^^^

--- a/tests/ui/asm/x86_64/bad-clobber-abi.stderr
+++ b/tests/ui/asm/x86_64/bad-clobber-abi.stderr
@@ -4,7 +4,7 @@ error: invalid ABI for `clobber_abi`
 LL |         asm!("", clobber_abi("foo"));
    |                  ^^^^^^^^^^^^^^^^^^
    |
-   = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, `sysv64`
+   = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, and `sysv64`
 
 error: invalid ABI for `clobber_abi`
   --> $DIR/bad-clobber-abi.rs:13:35
@@ -12,7 +12,7 @@ error: invalid ABI for `clobber_abi`
 LL |         asm!("", clobber_abi("C", "foo"));
    |                                   ^^^^^
    |
-   = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, `sysv64`
+   = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, and `sysv64`
 
 error: `C` ABI specified multiple times
   --> $DIR/bad-clobber-abi.rs:15:35
@@ -38,7 +38,7 @@ error: invalid ABI for `clobber_abi`
 LL |         asm!("", clobber_abi("C", "foo", "C"));
    |                                   ^^^^^
    |
-   = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, `sysv64`
+   = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, and `sysv64`
 
 error: `C` ABI specified multiple times
   --> $DIR/bad-clobber-abi.rs:20:42
@@ -54,7 +54,7 @@ error: invalid ABI for `clobber_abi`
 LL |         asm!("", clobber_abi("win64", "foo", "efiapi"));
    |                                       ^^^^^
    |
-   = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, `sysv64`
+   = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, and `sysv64`
 
 error: `win64` ABI specified multiple times
   --> $DIR/bad-clobber-abi.rs:23:46

--- a/tests/ui/asm/x86_64/bad-options.stderr
+++ b/tests/ui/asm/x86_64/bad-options.stderr
@@ -93,7 +93,7 @@ error: invalid ABI for `clobber_abi`
 LL |         asm!("", clobber_abi("foo"));
    |                  ^^^^^^^^^^^^^^^^^^
    |
-   = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, `sysv64`
+   = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, and `sysv64`
 
 error: `C` ABI specified multiple times
   --> $DIR/bad-options.rs:28:52

--- a/tests/ui/asm/x86_64/bad-reg.experimental_reg.stderr
+++ b/tests/ui/asm/x86_64/bad-reg.experimental_reg.stderr
@@ -4,7 +4,7 @@ error: invalid register class `foo`: unknown register class
 LL |         asm!("{}", in(foo) foo);
    |                    ^^^^^^^^^^^
    |
-   = note: the following register classes are supported on this target: `reg`, `reg_abcd`, `reg_byte`, `xmm_reg`, `ymm_reg`, `zmm_reg`, `kreg`, `kreg0`, `mmx_reg`, `x87_reg`, `tmm_reg`
+   = note: the following register classes are supported on this target: `reg`, `reg_abcd`, `reg_byte`, `xmm_reg`, `ymm_reg`, `zmm_reg`, `kreg`, `kreg0`, `mmx_reg`, `x87_reg`, and `tmm_reg`
 
 error: invalid register `foo`: unknown register
   --> $DIR/bad-reg.rs:22:18
@@ -12,7 +12,7 @@ error: invalid register `foo`: unknown register
 LL |         asm!("", in("foo") foo);
    |                  ^^^^^^^^^^^^^
 
-error: invalid asm template modifier for this register class
+error: invalid asm template modifier `z` for this register class
   --> $DIR/bad-reg.rs:24:15
    |
 LL |         asm!("{:z}", in(reg) foo);
@@ -20,9 +20,9 @@ LL |         asm!("{:z}", in(reg) foo);
    |               |
    |               template modifier
    |
-   = note: the `reg` register class supports the following template modifiers: `l`, `x`, `e`, `r`
+   = note: the `reg` register class supports the following template modifiers: `l`, `x`, `e`, and `r`
 
-error: invalid asm template modifier for this register class
+error: invalid asm template modifier `r` for this register class
   --> $DIR/bad-reg.rs:26:15
    |
 LL |         asm!("{:r}", in(xmm_reg) foo);
@@ -30,7 +30,7 @@ LL |         asm!("{:r}", in(xmm_reg) foo);
    |               |
    |               template modifier
    |
-   = note: the `xmm_reg` register class supports the following template modifiers: `x`, `y`, `z`
+   = note: the `xmm_reg` register class supports the following template modifiers: `x`, `y`, and `z`
 
 error: asm template modifiers are not allowed for `const` arguments
   --> $DIR/bad-reg.rs:28:15

--- a/tests/ui/asm/x86_64/bad-reg.rs
+++ b/tests/ui/asm/x86_64/bad-reg.rs
@@ -22,9 +22,9 @@ fn main() {
         asm!("", in("foo") foo);
         //~^ ERROR invalid register `foo`: unknown register
         asm!("{:z}", in(reg) foo);
-        //~^ ERROR invalid asm template modifier for this register class
+        //~^ ERROR invalid asm template modifier `z` for this register class
         asm!("{:r}", in(xmm_reg) foo);
-        //~^ ERROR invalid asm template modifier for this register class
+        //~^ ERROR invalid asm template modifier `r` for this register class
         asm!("{:a}", const 0);
         //~^ ERROR asm template modifiers are not allowed for `const` arguments
         asm!("{:a}", sym main);

--- a/tests/ui/asm/x86_64/bad-reg.stable.stderr
+++ b/tests/ui/asm/x86_64/bad-reg.stable.stderr
@@ -4,7 +4,7 @@ error: invalid register class `foo`: unknown register class
 LL |         asm!("{}", in(foo) foo);
    |                    ^^^^^^^^^^^
    |
-   = note: the following register classes are supported on this target: `reg`, `reg_abcd`, `reg_byte`, `xmm_reg`, `ymm_reg`, `zmm_reg`, `kreg`, `kreg0`, `mmx_reg`, `x87_reg`, `tmm_reg`
+   = note: the following register classes are supported on this target: `reg`, `reg_abcd`, `reg_byte`, `xmm_reg`, `ymm_reg`, `zmm_reg`, `kreg`, `kreg0`, `mmx_reg`, `x87_reg`, and `tmm_reg`
 
 error: invalid register `foo`: unknown register
   --> $DIR/bad-reg.rs:22:18
@@ -12,7 +12,7 @@ error: invalid register `foo`: unknown register
 LL |         asm!("", in("foo") foo);
    |                  ^^^^^^^^^^^^^
 
-error: invalid asm template modifier for this register class
+error: invalid asm template modifier `z` for this register class
   --> $DIR/bad-reg.rs:24:15
    |
 LL |         asm!("{:z}", in(reg) foo);
@@ -20,9 +20,9 @@ LL |         asm!("{:z}", in(reg) foo);
    |               |
    |               template modifier
    |
-   = note: the `reg` register class supports the following template modifiers: `l`, `x`, `e`, `r`
+   = note: the `reg` register class supports the following template modifiers: `l`, `x`, `e`, and `r`
 
-error: invalid asm template modifier for this register class
+error: invalid asm template modifier `r` for this register class
   --> $DIR/bad-reg.rs:26:15
    |
 LL |         asm!("{:r}", in(xmm_reg) foo);
@@ -30,7 +30,7 @@ LL |         asm!("{:r}", in(xmm_reg) foo);
    |               |
    |               template modifier
    |
-   = note: the `xmm_reg` register class supports the following template modifiers: `x`, `y`, `z`
+   = note: the `xmm_reg` register class supports the following template modifiers: `x`, `y`, and `z`
 
 error: asm template modifiers are not allowed for `const` arguments
   --> $DIR/bad-reg.rs:28:15

--- a/tests/ui/asm/x86_64/issue-82869.stderr
+++ b/tests/ui/asm/x86_64/issue-82869.stderr
@@ -4,7 +4,7 @@ error: invalid register class `vreg`: unknown register class
 LL |     asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
    |                                ^^^^^^^^^^^
    |
-   = note: the following register classes are supported on this target: `reg`, `reg_abcd`, `reg_byte`, `xmm_reg`, `ymm_reg`, `zmm_reg`, `kreg`, `kreg0`, `mmx_reg`, `x87_reg`, `tmm_reg`
+   = note: the following register classes are supported on this target: `reg`, `reg_abcd`, `reg_byte`, `xmm_reg`, `ymm_reg`, `zmm_reg`, `kreg`, `kreg0`, `mmx_reg`, `x87_reg`, and `tmm_reg`
 
 error: invalid register class `vreg`: unknown register class
   --> $DIR/issue-82869.rs:11:45
@@ -12,7 +12,7 @@ error: invalid register class `vreg`: unknown register class
 LL |     asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
    |                                             ^^^^^^^^^^
    |
-   = note: the following register classes are supported on this target: `reg`, `reg_abcd`, `reg_byte`, `xmm_reg`, `ymm_reg`, `zmm_reg`, `kreg`, `kreg0`, `mmx_reg`, `x87_reg`, `tmm_reg`
+   = note: the following register classes are supported on this target: `reg`, `reg_abcd`, `reg_byte`, `xmm_reg`, `ymm_reg`, `zmm_reg`, `kreg`, `kreg0`, `mmx_reg`, `x87_reg`, and `tmm_reg`
 
 error: invalid register `d0`: unknown register
   --> $DIR/issue-82869.rs:11:57

--- a/tests/ui/attributes/rustc_confusables_assoc_fn.rs
+++ b/tests/ui/attributes/rustc_confusables_assoc_fn.rs
@@ -1,0 +1,22 @@
+#![feature(rustc_attrs)]
+
+struct S;
+
+impl S {
+    #[rustc_confusables("bar")]
+    fn foo() {}
+
+    #[rustc_confusables("baz")]
+    fn qux(&self, x: i32) {}
+}
+
+fn main() {
+    S::bar();
+    //~^ ERROR no function or associated item named `bar`
+    //~| HELP you might have meant to use `foo`
+
+    let s = S;
+    s.baz(10);
+    //~^ ERROR no method named `baz`
+    //~| HELP you might have meant to use `qux`
+}

--- a/tests/ui/attributes/rustc_confusables_assoc_fn.stderr
+++ b/tests/ui/attributes/rustc_confusables_assoc_fn.stderr
@@ -1,0 +1,33 @@
+error[E0599]: no function or associated item named `bar` found for struct `S` in the current scope
+  --> $DIR/rustc_confusables_assoc_fn.rs:14:8
+   |
+LL | struct S;
+   | -------- function or associated item `bar` not found for this struct
+...
+LL |     S::bar();
+   |        ^^^ function or associated item not found in `S`
+   |
+help: you might have meant to use `foo`
+   |
+LL -     S::bar();
+LL +     S::foo();
+   |
+
+error[E0599]: no method named `baz` found for struct `S` in the current scope
+  --> $DIR/rustc_confusables_assoc_fn.rs:19:7
+   |
+LL | struct S;
+   | -------- method `baz` not found for this struct
+...
+LL |     s.baz(10);
+   |       ^^^ method not found in `S`
+   |
+help: you might have meant to use `qux`
+   |
+LL -     s.baz(10);
+LL +     s.qux(10);
+   |
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0599`.

--- a/tests/ui/const-generics/exhaustive-value.stderr
+++ b/tests/ui/const-generics/exhaustive-value.stderr
@@ -4,15 +4,15 @@ error[E0277]: the trait bound `(): Foo<N>` is not satisfied
 LL |     <() as Foo<N>>::test()
    |      ^^ the trait `Foo<N>` is not implemented for `()`
    |
-   = help: the following other types implement trait `Foo<N>`:
-             `()` implements `Foo<0>`
-             `()` implements `Foo<100>`
-             `()` implements `Foo<101>`
-             `()` implements `Foo<102>`
-             `()` implements `Foo<103>`
-             `()` implements `Foo<104>`
-             `()` implements `Foo<105>`
-             `()` implements `Foo<106>`
+   = help: `()` implements trait `Foo<N>`:
+             Foo<0>
+             Foo<100>
+             Foo<101>
+             Foo<102>
+             Foo<103>
+             Foo<104>
+             Foo<105>
+             Foo<106>
            and 248 others
 
 error: aborting due to 1 previous error

--- a/tests/ui/did_you_mean/issue-21659-show-relevant-trait-impls-1.stderr
+++ b/tests/ui/did_you_mean/issue-21659-show-relevant-trait-impls-1.stderr
@@ -11,14 +11,14 @@ help: the trait `Foo<usize>` is not implemented for `Bar`
    |
 LL | struct Bar;
    | ^^^^^^^^^^
-help: the following other types implement trait `Foo<A>`
+help: `Bar` implements trait `Foo<A>`
   --> $DIR/issue-21659-show-relevant-trait-impls-1.rs:15:1
    |
 LL | impl Foo<i32> for Bar {}
-   | ^^^^^^^^^^^^^^^^^^^^^ `Bar` implements `Foo<i32>`
+   | ^^^^^^^^^^^^^^^^^^^^^ `Foo<i32>`
 LL |
 LL | impl Foo<u8> for Bar {}
-   | ^^^^^^^^^^^^^^^^^^^^ `Bar` implements `Foo<u8>`
+   | ^^^^^^^^^^^^^^^^^^^^ `Foo<u8>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/did_you_mean/issue-21659-show-relevant-trait-impls-2.stderr
+++ b/tests/ui/did_you_mean/issue-21659-show-relevant-trait-impls-2.stderr
@@ -11,13 +11,13 @@ help: the trait `Foo<usize>` is not implemented for `Bar`
    |
 LL | struct Bar;
    | ^^^^^^^^^^
-   = help: the following other types implement trait `Foo<A>`:
-             `Bar` implements `Foo<i16>`
-             `Bar` implements `Foo<i32>`
-             `Bar` implements `Foo<i8>`
-             `Bar` implements `Foo<u16>`
-             `Bar` implements `Foo<u32>`
-             `Bar` implements `Foo<u8>`
+   = help: `Bar` implements trait `Foo<A>`:
+             Foo<i16>
+             Foo<i32>
+             Foo<i8>
+             Foo<u16>
+             Foo<u32>
+             Foo<u8>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/did_you_mean/issue-39802-show-5-trait-impls.stderr
+++ b/tests/ui/did_you_mean/issue-39802-show-5-trait-impls.stderr
@@ -6,12 +6,12 @@ LL |     Foo::<i32>::bar(&1i8);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the following other types implement trait `Foo<B>`:
-             `i8` implements `Foo<bool>`
-             `i8` implements `Foo<u16>`
-             `i8` implements `Foo<u32>`
-             `i8` implements `Foo<u64>`
-             `i8` implements `Foo<u8>`
+   = help: `i8` implements trait `Foo<B>`:
+             Foo<bool>
+             Foo<u16>
+             Foo<u32>
+             Foo<u64>
+             Foo<u8>
 
 error[E0277]: the trait bound `u8: Foo<i32>` is not satisfied
   --> $DIR/issue-39802-show-5-trait-impls.rs:25:21
@@ -21,17 +21,17 @@ LL |     Foo::<i32>::bar(&1u8);
    |     |
    |     required by a bound introduced by this call
    |
-help: the following other types implement trait `Foo<B>`
+help: `u8` implements trait `Foo<B>`
   --> $DIR/issue-39802-show-5-trait-impls.rs:11:1
    |
 LL | impl Foo<u16> for u8 {}
-   | ^^^^^^^^^^^^^^^^^^^^ `u8` implements `Foo<u16>`
+   | ^^^^^^^^^^^^^^^^^^^^ `Foo<u16>`
 LL | impl Foo<u32> for u8 {}
-   | ^^^^^^^^^^^^^^^^^^^^ `u8` implements `Foo<u32>`
+   | ^^^^^^^^^^^^^^^^^^^^ `Foo<u32>`
 LL | impl Foo<u64> for u8 {}
-   | ^^^^^^^^^^^^^^^^^^^^ `u8` implements `Foo<u64>`
+   | ^^^^^^^^^^^^^^^^^^^^ `Foo<u64>`
 LL | impl Foo<bool> for u8 {}
-   | ^^^^^^^^^^^^^^^^^^^^^ `u8` implements `Foo<bool>`
+   | ^^^^^^^^^^^^^^^^^^^^^ `Foo<bool>`
 
 error[E0277]: the trait bound `bool: Foo<i32>` is not satisfied
   --> $DIR/issue-39802-show-5-trait-impls.rs:26:21
@@ -41,13 +41,13 @@ LL |     Foo::<i32>::bar(&true);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the following other types implement trait `Foo<B>`:
-             `bool` implements `Foo<bool>`
-             `bool` implements `Foo<i8>`
-             `bool` implements `Foo<u16>`
-             `bool` implements `Foo<u32>`
-             `bool` implements `Foo<u64>`
-             `bool` implements `Foo<u8>`
+   = help: `bool` implements trait `Foo<B>`:
+             Foo<bool>
+             Foo<i8>
+             Foo<u16>
+             Foo<u32>
+             Foo<u64>
+             Foo<u8>
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/indexing/index-help.stderr
+++ b/tests/ui/indexing/index-help.stderr
@@ -5,13 +5,13 @@ LL |     x[0i32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[{integer}]>` is not implemented for `i32`
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `Vec<{integer}>` to implement `Index<i32>`
 
 error: aborting due to 1 previous error

--- a/tests/ui/indexing/indexing-integral-types.stderr
+++ b/tests/ui/indexing/indexing-integral-types.stderr
@@ -5,13 +5,13 @@ LL |     v[3u8];
    |       ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[isize]>` is not implemented for `u8`
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `Vec<isize>` to implement `Index<u8>`
 
 error[E0277]: the type `[isize]` cannot be indexed by `i8`
@@ -21,13 +21,13 @@ LL |     v[3i8];
    |       ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[isize]>` is not implemented for `i8`
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `Vec<isize>` to implement `Index<i8>`
 
 error[E0277]: the type `[isize]` cannot be indexed by `u32`
@@ -37,13 +37,13 @@ LL |     v[3u32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[isize]>` is not implemented for `u32`
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `Vec<isize>` to implement `Index<u32>`
 
 error[E0277]: the type `[isize]` cannot be indexed by `i32`
@@ -53,13 +53,13 @@ LL |     v[3i32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[isize]>` is not implemented for `i32`
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `Vec<isize>` to implement `Index<i32>`
 
 error[E0277]: the type `[u8]` cannot be indexed by `u8`
@@ -69,13 +69,13 @@ LL |     s.as_bytes()[3u8];
    |                  ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[u8]>` is not implemented for `u8`
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `[u8]` to implement `Index<u8>`
 
 error[E0277]: the type `[u8]` cannot be indexed by `i8`
@@ -85,13 +85,13 @@ LL |     s.as_bytes()[3i8];
    |                  ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[u8]>` is not implemented for `i8`
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `[u8]` to implement `Index<i8>`
 
 error[E0277]: the type `[u8]` cannot be indexed by `u32`
@@ -101,13 +101,13 @@ LL |     s.as_bytes()[3u32];
    |                  ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[u8]>` is not implemented for `u32`
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `[u8]` to implement `Index<u32>`
 
 error[E0277]: the type `[u8]` cannot be indexed by `i32`
@@ -117,13 +117,13 @@ LL |     s.as_bytes()[3i32];
    |                  ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[u8]>` is not implemented for `i32`
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `[u8]` to implement `Index<i32>`
 
 error: aborting due to 8 previous errors

--- a/tests/ui/indexing/indexing-requires-a-uint.stderr
+++ b/tests/ui/indexing/indexing-requires-a-uint.stderr
@@ -5,13 +5,13 @@ LL |     [0][0u8];
    |         ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[{integer}]>` is not implemented for `u8`
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `[{integer}]` to implement `Index<u8>`
 
 error[E0308]: mismatched types

--- a/tests/ui/iterators/auxiliary/rangefrom-overflow-2crates-ocno.rs
+++ b/tests/ui/iterators/auxiliary/rangefrom-overflow-2crates-ocno.rs
@@ -1,0 +1,10 @@
+//@ compile-flags: -C overflow-checks=no
+
+#![crate_type = "lib"]
+#![feature(new_range_api)]
+
+use std::range::RangeFromIter;
+
+pub fn next(iter: &mut RangeFromIter<u8>) -> u8 {
+    iter.next().unwrap()
+}

--- a/tests/ui/iterators/auxiliary/rangefrom-overflow-2crates-ocyes.rs
+++ b/tests/ui/iterators/auxiliary/rangefrom-overflow-2crates-ocyes.rs
@@ -1,0 +1,10 @@
+//@ compile-flags: -C overflow-checks=yes
+
+#![crate_type = "lib"]
+#![feature(new_range_api)]
+
+use std::range::RangeFromIter;
+
+pub fn next(iter: &mut RangeFromIter<u8>) -> u8 {
+    iter.next().unwrap()
+}

--- a/tests/ui/iterators/invalid-iterator-chain-fixable.stderr
+++ b/tests/ui/iterators/invalid-iterator-chain-fixable.stderr
@@ -33,13 +33,13 @@ LL |     println!("{}", scores.sum::<i32>());
    |                           required by a bound introduced by this call
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
-help: the following other types implement trait `Sum<A>`
+help: `i32` implements trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum`
+   = note: `Sum`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
+   = note: `Sum<&i32>`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
    = note: in this macro invocation
@@ -74,13 +74,13 @@ LL |             .sum::<i32>(),
    |              required by a bound introduced by this call
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
-help: the following other types implement trait `Sum<A>`
+help: `i32` implements trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum`
+   = note: `Sum`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
+   = note: `Sum<&i32>`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
    = note: in this macro invocation
@@ -115,13 +115,13 @@ LL |     println!("{}", vec![0, 1].iter().map(|x| { x; }).sum::<i32>());
    |                                                      required by a bound introduced by this call
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
-help: the following other types implement trait `Sum<A>`
+help: `i32` implements trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum`
+   = note: `Sum`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
+   = note: `Sum<&i32>`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
    = note: in this macro invocation

--- a/tests/ui/iterators/invalid-iterator-chain-with-int-infer.stderr
+++ b/tests/ui/iterators/invalid-iterator-chain-with-int-infer.stderr
@@ -7,13 +7,13 @@ LL |     let x = Some(()).iter().map(|()| 1).sum::<f32>();
    |                                         required by a bound introduced by this call
    |
    = help: the trait `Sum<{integer}>` is not implemented for `f32`
-help: the following other types implement trait `Sum<A>`
+help: `f32` implements trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `f32` implements `Sum`
+   = note: `Sum`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `f32` implements `Sum<&f32>`
+   = note: `Sum<&f32>`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
    = note: in this macro invocation

--- a/tests/ui/iterators/invalid-iterator-chain.stderr
+++ b/tests/ui/iterators/invalid-iterator-chain.stderr
@@ -33,13 +33,13 @@ LL |     println!("{}", scores.sum::<i32>());
    |                           required by a bound introduced by this call
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
-help: the following other types implement trait `Sum<A>`
+help: `i32` implements trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum`
+   = note: `Sum`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
+   = note: `Sum<&i32>`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
    = note: in this macro invocation
@@ -73,13 +73,13 @@ LL |             .sum::<i32>(),
    |              required by a bound introduced by this call
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
-help: the following other types implement trait `Sum<A>`
+help: `i32` implements trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum`
+   = note: `Sum`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
+   = note: `Sum<&i32>`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
    = note: in this macro invocation
@@ -120,13 +120,13 @@ LL |             .sum::<i32>(),
    |              required by a bound introduced by this call
    |
    = help: the trait `Sum<f64>` is not implemented for `i32`
-help: the following other types implement trait `Sum<A>`
+help: `i32` implements trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum`
+   = note: `Sum`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
+   = note: `Sum<&i32>`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
    = note: in this macro invocation
@@ -158,13 +158,13 @@ LL |     println!("{}", vec![0, 1].iter().map(|x| { x; }).sum::<i32>());
    |                                                      required by a bound introduced by this call
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
-help: the following other types implement trait `Sum<A>`
+help: `i32` implements trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum`
+   = note: `Sum`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
+   = note: `Sum<&i32>`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
    = note: in this macro invocation
@@ -194,13 +194,13 @@ LL |     println!("{}", vec![(), ()].iter().sum::<i32>());
    |                                        required by a bound introduced by this call
    |
    = help: the trait `Sum<&()>` is not implemented for `i32`
-help: the following other types implement trait `Sum<A>`
+help: `i32` implements trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum`
+   = note: `Sum`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
+   = note: `Sum<&i32>`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
    = note: in this macro invocation

--- a/tests/ui/iterators/rangefrom-overflow-2crates.rs
+++ b/tests/ui/iterators/rangefrom-overflow-2crates.rs
@@ -1,0 +1,40 @@
+//@ run-pass
+//@ needs-unwind
+//@ aux-build:rangefrom-overflow-2crates-ocno.rs
+//@ aux-build:rangefrom-overflow-2crates-ocyes.rs
+
+// For #154124
+// Test that two crates with different overflow-checks have the same results,
+// even when the iterator is passed between them.
+
+#![feature(new_range_api)]
+
+extern crate rangefrom_overflow_2crates_ocno;
+extern crate rangefrom_overflow_2crates_ocyes;
+
+use rangefrom_overflow_2crates_ocno::next as next_ocno;
+use rangefrom_overflow_2crates_ocyes::next as next_ocyes;
+
+fn main() {
+    let mut iter_ocyes = std::range::RangeFrom::from(0_u8..).into_iter();
+    let mut iter_ocno = iter_ocyes.clone();
+
+    for n in 0_u8..=255 {
+        assert_eq!(n, next_ocno(&mut iter_ocyes.clone()));
+        assert_eq!(n, next_ocyes(&mut iter_ocyes));
+        assert_eq!(n, next_ocyes(&mut iter_ocno.clone()));
+        assert_eq!(n, next_ocno(&mut iter_ocno));
+    }
+
+    // `iter_ocno` should have wrapped
+    assert_eq!(0, next_ocyes(&mut iter_ocno.clone()));
+    assert_eq!(0, next_ocno(&mut iter_ocno));
+    // `iter_ocyes` should be exhausted,
+    // which will wrap when called without overflow-checks
+    assert_eq!(0, next_ocno(&mut iter_ocyes.clone()));
+    // and panic when called with overflow-checks
+    let r = std::panic::catch_unwind(move || {
+        let _ = next_ocyes(&mut iter_ocyes);
+    });
+    assert!(r.is_err());
+}

--- a/tests/ui/lazy-type-alias/trailing-where-clause.stderr
+++ b/tests/ui/lazy-type-alias/trailing-where-clause.stderr
@@ -4,13 +4,13 @@ error[E0277]: the trait bound `String: From<()>` is not satisfied
 LL |     let _: Alias<()>;
    |                  ^^ the trait `From<()>` is not implemented for `String`
    |
-   = help: the following other types implement trait `From<T>`:
-             `String` implements `From<&String>`
-             `String` implements `From<&mut str>`
-             `String` implements `From<&str>`
-             `String` implements `From<Box<str>>`
-             `String` implements `From<Cow<'_, str>>`
-             `String` implements `From<char>`
+   = help: `String` implements trait `From<T>`:
+             From<&String>
+             From<&mut str>
+             From<&str>
+             From<Box<str>>
+             From<Cow<'_, str>>
+             From<char>
 note: required by a bound in `Alias`
   --> $DIR/trailing-where-clause.rs:8:13
    |

--- a/tests/ui/on-unimplemented/slice-index.stderr
+++ b/tests/ui/on-unimplemented/slice-index.stderr
@@ -5,13 +5,13 @@ LL |     x[1i32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[i32]>` is not implemented for `i32`
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `[i32]` to implement `Index<i32>`
 
 error[E0277]: the type `[i32]` cannot be indexed by `RangeTo<i32>`
@@ -21,19 +21,19 @@ LL |     x[..1i32];
    |       ^^^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[i32]>` is not implemented for `RangeTo<i32>`
-help: the following other types implement trait `SliceIndex<T>`
+help: `RangeTo<usize>` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `RangeTo<usize>` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `RangeTo<usize>` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
   ::: $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
    = note: in this macro invocation
   --> $SRC_DIR/core/src/str/traits.rs:LL:COL
    |
-   = note: `RangeTo<usize>` implements `SliceIndex<str>`
+   = note: `SliceIndex<str>`
    = note: required for `[i32]` to implement `Index<RangeTo<i32>>`
    = note: this error originates in the macro `impl_slice_index` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/on-unimplemented/suggest_tuple_wrap_root_obligation.rs
+++ b/tests/ui/on-unimplemented/suggest_tuple_wrap_root_obligation.rs
@@ -5,7 +5,7 @@ impl From<(u8,)> for Tuple {
         todo!()
     }
 }
-impl From<(u8, u8)> for Tuple { //~ HELP the following other types implement trait `From<T>`
+impl From<(u8, u8)> for Tuple { //~ HELP `Tuple` implements trait `From<T>`
     fn from(_: (u8, u8)) -> Self {
         todo!()
     }

--- a/tests/ui/on-unimplemented/suggest_tuple_wrap_root_obligation.stderr
+++ b/tests/ui/on-unimplemented/suggest_tuple_wrap_root_obligation.stderr
@@ -11,17 +11,17 @@ help: the trait `From<u8>` is not implemented for `Tuple`
    |
 LL | struct Tuple;
    | ^^^^^^^^^^^^
-help: the following other types implement trait `From<T>`
+help: `Tuple` implements trait `From<T>`
   --> $DIR/suggest_tuple_wrap_root_obligation.rs:3:1
    |
 LL | impl From<(u8,)> for Tuple {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ `Tuple` implements `From<(u8,)>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ `From<(u8,)>`
 ...
 LL | impl From<(u8, u8)> for Tuple {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Tuple` implements `From<(u8, u8)>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `From<(u8, u8)>`
 ...
 LL | impl From<(u8, u8, u8)> for Tuple {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Tuple` implements `From<(u8, u8, u8)>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `From<(u8, u8, u8)>`
    = note: required for `u8` to implement `Into<Tuple>`
 note: required by a bound in `convert_into_tuple`
   --> $DIR/suggest_tuple_wrap_root_obligation.rs:19:32

--- a/tests/ui/on-unimplemented/sum.stderr
+++ b/tests/ui/on-unimplemented/sum.stderr
@@ -7,13 +7,13 @@ LL |     vec![(), ()].iter().sum::<i32>();
    |                         required by a bound introduced by this call
    |
    = help: the trait `Sum<&()>` is not implemented for `i32`
-help: the following other types implement trait `Sum<A>`
+help: `i32` implements trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum`
+   = note: `Sum`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
+   = note: `Sum<&i32>`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
    = note: in this macro invocation
@@ -37,13 +37,13 @@ LL |     vec![(), ()].iter().product::<i32>();
    |                         required by a bound introduced by this call
    |
    = help: the trait `Product<&()>` is not implemented for `i32`
-help: the following other types implement trait `Product<A>`
+help: `i32` implements trait `Product<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Product`
+   = note: `Product`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Product<&i32>`
+   = note: `Product<&i32>`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
    = note: in this macro invocation

--- a/tests/ui/precondition-checks/alignment.rs
+++ b/tests/ui/precondition-checks/alignment.rs
@@ -6,6 +6,6 @@
 
 fn main() {
     unsafe {
-        std::ptr::Alignment::new_unchecked(0);
+        std::mem::Alignment::new_unchecked(0);
     }
 }

--- a/tests/ui/str/str-idx.stderr
+++ b/tests/ui/str/str-idx.stderr
@@ -7,13 +7,13 @@ LL |     let _: u8 = s[4];
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `str` to implement `Index<{integer}>`
 
 error[E0277]: the type `str` cannot be indexed by `{integer}`
@@ -27,13 +27,13 @@ LL |     let _ = s.get(4);
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
 note: required by a bound in `core::str::<impl str>::get`
   --> $SRC_DIR/core/src/str/mod.rs:LL:COL
 
@@ -48,13 +48,13 @@ LL |     let _ = s.get_unchecked(4);
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
 note: required by a bound in `core::str::<impl str>::get_unchecked`
   --> $SRC_DIR/core/src/str/mod.rs:LL:COL
 

--- a/tests/ui/str/str-mut-idx.stderr
+++ b/tests/ui/str/str-mut-idx.stderr
@@ -31,13 +31,13 @@ LL |     s[1usize] = bot();
    |       ^^^^^^ string indices are ranges of `usize`
    |
    = help: the trait `SliceIndex<str>` is not implemented for `usize`
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `str` to implement `Index<usize>`
 
 error[E0277]: the type `str` cannot be indexed by `{integer}`
@@ -51,13 +51,13 @@ LL |     s.get_mut(1);
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
 note: required by a bound in `core::str::<impl str>::get_mut`
   --> $SRC_DIR/core/src/str/mod.rs:LL:COL
 
@@ -72,13 +72,13 @@ LL |     s.get_unchecked_mut(1);
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
 note: required by a bound in `core::str::<impl str>::get_unchecked_mut`
   --> $SRC_DIR/core/src/str/mod.rs:LL:COL
 

--- a/tests/ui/suggestions/dont-suggest-borrowing-existing-borrow.stderr
+++ b/tests/ui/suggestions/dont-suggest-borrowing-existing-borrow.stderr
@@ -4,13 +4,13 @@ error[E0277]: the trait bound `str: From<_>` is not satisfied
 LL |     let _ = &str::from("value");
    |              ^^^ the trait `From<_>` is not implemented for `str`
    |
-   = help: the following other types implement trait `From<T>`:
-             `String` implements `From<&String>`
-             `String` implements `From<&mut str>`
-             `String` implements `From<&str>`
-             `String` implements `From<Box<str>>`
-             `String` implements `From<Cow<'_, str>>`
-             `String` implements `From<char>`
+   = help: `String` implements trait `From<T>`:
+             From<&String>
+             From<&mut str>
+             From<&str>
+             From<Box<str>>
+             From<Cow<'_, str>>
+             From<char>
 help: you likely meant to call the associated function `from` for type `&str`, but the code as written calls associated function `from` on type `str`
    |
 LL |     let _ = <&str>::from("value");

--- a/tests/ui/suggestions/into-str.stderr
+++ b/tests/ui/suggestions/into-str.stderr
@@ -7,13 +7,13 @@ LL |     foo(String::new());
    |     required by a bound introduced by this call
    |
    = note: to coerce a `String` into a `&str`, use `&*` as a prefix
-   = help: the following other types implement trait `From<T>`:
-             `String` implements `From<&String>`
-             `String` implements `From<&mut str>`
-             `String` implements `From<&str>`
-             `String` implements `From<Box<str>>`
-             `String` implements `From<Cow<'_, str>>`
-             `String` implements `From<char>`
+   = help: `String` implements trait `From<T>`:
+             From<&String>
+             From<&mut str>
+             From<&str>
+             From<Box<str>>
+             From<Cow<'_, str>>
+             From<char>
    = note: required for `String` to implement `Into<&str>`
 note: required by a bound in `foo`
   --> $DIR/into-str.rs:1:31

--- a/tests/ui/suggestions/partialeq_suggest_swap_on_e0277.stderr
+++ b/tests/ui/suggestions/partialeq_suggest_swap_on_e0277.stderr
@@ -5,15 +5,15 @@ LL |     String::from("Girls Band Cry") == T(String::from("Girls Band Cry"));
    |                                    ^^ no implementation for `String == T`
    |
    = help: the trait `PartialEq<T>` is not implemented for `String`
-   = help: the following other types implement trait `PartialEq<Rhs>`:
-             `String` implements `PartialEq<&str>`
-             `String` implements `PartialEq<ByteStr>`
-             `String` implements `PartialEq<ByteString>`
-             `String` implements `PartialEq<Cow<'_, str>>`
-             `String` implements `PartialEq<Path>`
-             `String` implements `PartialEq<PathBuf>`
-             `String` implements `PartialEq<str>`
-             `String` implements `PartialEq`
+   = help: `String` implements trait `PartialEq<Rhs>`:
+             PartialEq<&str>
+             PartialEq<ByteStr>
+             PartialEq<ByteString>
+             PartialEq<Cow<'_, str>>
+             PartialEq<Path>
+             PartialEq<PathBuf>
+             PartialEq<str>
+             PartialEq
    = note: `T` implements `PartialEq<String>`
 help: consider swapping the equality
    |

--- a/tests/ui/suggestions/semi-suggestion-when-stmt-and-expr-span-equal.stderr
+++ b/tests/ui/suggestions/semi-suggestion-when-stmt-and-expr-span-equal.stderr
@@ -20,15 +20,15 @@ LL |         .collect::<String>();
    |          required by a bound introduced by this call
    |
    = help: the trait `FromIterator<()>` is not implemented for `String`
-   = help: the following other types implement trait `FromIterator<A>`:
-             `String` implements `FromIterator<&char>`
-             `String` implements `FromIterator<&std::ascii::Char>`
-             `String` implements `FromIterator<&str>`
-             `String` implements `FromIterator<Box<str, A>>`
-             `String` implements `FromIterator<Cow<'_, str>>`
-             `String` implements `FromIterator<String>`
-             `String` implements `FromIterator<char>`
-             `String` implements `FromIterator<std::ascii::Char>`
+   = help: `String` implements trait `FromIterator<A>`:
+             FromIterator<&char>
+             FromIterator<&std::ascii::Char>
+             FromIterator<&str>
+             FromIterator<Box<str, A>>
+             FromIterator<Cow<'_, str>>
+             FromIterator<String>
+             FromIterator<char>
+             FromIterator<std::ascii::Char>
 note: the method call chain might not have had the expected associated types
   --> $DIR/semi-suggestion-when-stmt-and-expr-span-equal.rs:20:10
    |

--- a/tests/ui/suggestions/suggest-dereferencing-index.stderr
+++ b/tests/ui/suggestions/suggest-dereferencing-index.stderr
@@ -5,13 +5,13 @@ LL |     let one_item_please: i32 = [1, 2, 3][i];
    |                                          ^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[{integer}]>` is not implemented for `&usize`
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `[{integer}]` to implement `Index<&usize>`
 help: dereference this index
    |

--- a/tests/ui/traits/const-traits/const-traits-core.rs
+++ b/tests/ui/traits/const-traits/const-traits-core.rs
@@ -36,8 +36,8 @@ const PHANTOM: std::marker::PhantomData<()> = Default::default();
 const OPT: Option<i32> = Default::default();
 // core::iter::sources::empty
 const EMPTY: std::iter::Empty<()> = Default::default();
-// core::ptr::alignment
-const ALIGNMENT: std::ptr::Alignment = Default::default();
+// core::mem::alignment
+const ALIGNMENT: std::mem::Alignment = Default::default();
 // core::slice
 const SLICE: &[()] = Default::default();
 const MUT_SLICE: &mut [()] = Default::default();

--- a/tests/ui/traits/explicit-reference-cast.rs
+++ b/tests/ui/traits/explicit-reference-cast.rs
@@ -7,7 +7,7 @@ pub struct ToolA(PathBuf);
 //~^ HELP the trait `From<&PathBuf>` is not implemented for `ToolA`
 
 impl From<&Path> for ToolA {
-    //~^ HELP the following other types implement trait `From<T>`
+    //~^ HELP `ToolA` implements trait `From<T>`
     fn from(p: &Path) -> ToolA {
         ToolA(p.to_path_buf())
     }

--- a/tests/ui/traits/explicit-reference-cast.stderr
+++ b/tests/ui/traits/explicit-reference-cast.stderr
@@ -10,14 +10,14 @@ help: the trait `From<&PathBuf>` is not implemented for `ToolA`
    |
 LL | pub struct ToolA(PathBuf);
    | ^^^^^^^^^^^^^^^^
-help: the following other types implement trait `From<T>`
+help: `ToolA` implements trait `From<T>`
   --> $DIR/explicit-reference-cast.rs:9:1
    |
 LL | impl From<&Path> for ToolA {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ `ToolA` implements `From<&Path>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ `From<&Path>`
 ...
 LL | impl From<&str> for ToolA {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ `ToolA` implements `From<&str>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ `From<&str>`
 
 error[E0277]: the trait bound `ToolB: TryFrom<&PathBuf>` is not satisfied
   --> $DIR/explicit-reference-cast.rs:43:13

--- a/tests/ui/traits/inheritance/repeated-supertrait-ambig.stderr
+++ b/tests/ui/traits/inheritance/repeated-supertrait-ambig.stderr
@@ -6,14 +6,14 @@ LL |     c.same_as(22)
    |       |
    |       required by a bound introduced by this call
    |
-help: the following other types implement trait `CompareTo<T>`
+help: `i64` implements trait `CompareTo<T>`
   --> $DIR/repeated-supertrait-ambig.rs:15:1
    |
 LL | impl CompareTo<i64> for i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `i64` implements `CompareTo<i64>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `CompareTo<i64>`
 ...
 LL | impl CompareTo<u64> for i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `i64` implements `CompareTo<u64>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `CompareTo<u64>`
 
 error[E0277]: the trait bound `C: CompareTo<i32>` is not satisfied
   --> $DIR/repeated-supertrait-ambig.rs:30:15
@@ -34,14 +34,14 @@ error[E0277]: the trait bound `dyn CompareToInts: CompareTo<i32>` is not satisfi
 LL |     <dyn CompareToInts>::same_as(c, 22)
    |      ^^^^^^^^^^^^^^^^^ the trait `CompareTo<i32>` is not implemented for `dyn CompareToInts`
    |
-help: the following other types implement trait `CompareTo<T>`
+help: `i64` implements trait `CompareTo<T>`
   --> $DIR/repeated-supertrait-ambig.rs:15:1
    |
 LL | impl CompareTo<i64> for i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `i64` implements `CompareTo<i64>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `CompareTo<i64>`
 ...
 LL | impl CompareTo<u64> for i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `i64` implements `CompareTo<u64>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `CompareTo<u64>`
 
 error[E0277]: the trait bound `C: CompareTo<i32>` is not satisfied
   --> $DIR/repeated-supertrait-ambig.rs:38:24
@@ -64,14 +64,14 @@ LL |     assert_eq!(22_i64.same_as(22), true);
    |                       |
    |                       required by a bound introduced by this call
    |
-help: the following other types implement trait `CompareTo<T>`
+help: `i64` implements trait `CompareTo<T>`
   --> $DIR/repeated-supertrait-ambig.rs:15:1
    |
 LL | impl CompareTo<i64> for i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `i64` implements `CompareTo<i64>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `CompareTo<i64>`
 ...
 LL | impl CompareTo<u64> for i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `i64` implements `CompareTo<u64>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `CompareTo<u64>`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/traits/next-solver/cycles/forced_ambiguity-use-head-maybe-cause.stderr
+++ b/tests/ui/traits/next-solver/cycles/forced_ambiguity-use-head-maybe-cause.stderr
@@ -5,7 +5,7 @@ LL |     impls_trait::<Root<_>>()
    |                   ^^^^^^^ cannot infer type for struct `Head<_>`
    |
    = note: cannot satisfy `Head<_>: Trait`
-help: the following types implement trait `Trait`
+help: `Head<T>` implements trait `Trait`
   --> $DIR/forced_ambiguity-use-head-maybe-cause.rs:23:1
    |
 LL | / impl<T> Trait for Head<T>

--- a/tests/ui/traits/next-solver/cycles/inductive-cycle-but-err.stderr
+++ b/tests/ui/traits/next-solver/cycles/inductive-cycle-but-err.stderr
@@ -21,7 +21,7 @@ help: the trait `Trait` is not implemented for `MultipleCandidates`
    |
 LL | struct MultipleCandidates;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
-help: the following other types implement trait `Trait`
+help: `MultipleCandidates` implements trait `Trait`
   --> $DIR/inductive-cycle-but-err.rs:26:1
    |
 LL | / impl Trait for MultipleCandidates

--- a/tests/ui/traits/next-solver/unevaluated-const-impl-trait-ref.fails.stderr
+++ b/tests/ui/traits/next-solver/unevaluated-const-impl-trait-ref.fails.stderr
@@ -4,13 +4,13 @@ error[E0277]: the trait bound `(): Trait<1>` is not satisfied
 LL |     needs::<1>();
    |             ^ the trait `Trait<1>` is not implemented for `()`
    |
-help: the following other types implement trait `Trait<N>`
+help: `()` implements trait `Trait<N>`
   --> $DIR/unevaluated-const-impl-trait-ref.rs:7:1
    |
 LL | impl Trait<{ 1 - 1 }> for () {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `()` implements `Trait<0>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Trait<0>`
 LL | impl Trait<{ 1 + 1 }> for () {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `()` implements `Trait<2>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Trait<2>`
 note: required by a bound in `needs`
   --> $DIR/unevaluated-const-impl-trait-ref.rs:10:38
    |

--- a/tests/ui/traits/question-mark-result-err-mismatch.rs
+++ b/tests/ui/traits/question-mark-result-err-mismatch.rs
@@ -35,7 +35,7 @@ fn bar() -> Result<(), String> { //~ NOTE expected `String` because of this
     //~| NOTE the trait `From<()>` is not implemented for `String`
     //~| NOTE the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
     //~| NOTE required for `Result<(), String>` to implement `FromResidual<Result<Infallible, ()>>`
-    //~| HELP the following other types implement trait `From<T>`:
+    //~| HELP `String` implements trait `From<T>`:
     Ok(one)
 }
 

--- a/tests/ui/traits/question-mark-result-err-mismatch.stderr
+++ b/tests/ui/traits/question-mark-result-err-mismatch.stderr
@@ -30,13 +30,13 @@ LL |         .map_err(|_| ())?;
    |          this can't be annotated with `?` because it has type `Result<_, ()>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-   = help: the following other types implement trait `From<T>`:
-             `String` implements `From<&String>`
-             `String` implements `From<&mut str>`
-             `String` implements `From<&str>`
-             `String` implements `From<Box<str>>`
-             `String` implements `From<Cow<'_, str>>`
-             `String` implements `From<char>`
+   = help: `String` implements trait `From<T>`:
+             From<&String>
+             From<&mut str>
+             From<&str>
+             From<Box<str>>
+             From<Cow<'_, str>>
+             From<char>
    = note: required for `Result<(), String>` to implement `FromResidual<Result<Infallible, ()>>`
 
 error[E0277]: `?` couldn't convert the error to `String`

--- a/tests/ui/traits/question-mark-span-144304.stderr
+++ b/tests/ui/traits/question-mark-span-144304.stderr
@@ -9,12 +9,12 @@ LL |     Err("str").map_err(|e| e)?;
    |     this has type `Result<_, &str>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-   = help: the following other types implement trait `From<T>`:
-             `i32` implements `From<bool>`
-             `i32` implements `From<i16>`
-             `i32` implements `From<i8>`
-             `i32` implements `From<u16>`
-             `i32` implements `From<u8>`
+   = help: `i32` implements trait `From<T>`:
+             From<bool>
+             From<i16>
+             From<i8>
+             From<u16>
+             From<u8>
 
 error[E0277]: `?` couldn't convert the error to `i32`
   --> $DIR/question-mark-span-144304.rs:4:42
@@ -29,12 +29,12 @@ LL |     Err("str").map_err(|e| e.to_string())?;
    |     this has type `Result<_, &str>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-   = help: the following other types implement trait `From<T>`:
-             `i32` implements `From<bool>`
-             `i32` implements `From<i16>`
-             `i32` implements `From<i8>`
-             `i32` implements `From<u16>`
-             `i32` implements `From<u8>`
+   = help: `i32` implements trait `From<T>`:
+             From<bool>
+             From<i16>
+             From<i8>
+             From<u16>
+             From<u8>
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/try-trait/bad-interconversion.stderr
+++ b/tests/ui/try-trait/bad-interconversion.stderr
@@ -9,16 +9,16 @@ LL |     Ok(Err(123_i32)?)
    |        this can't be annotated with `?` because it has type `Result<_, i32>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-help: the following other types implement trait `From<T>`
+help: `u8` implements trait `From<T>`
   --> $SRC_DIR/core/src/convert/num.rs:LL:COL
    |
-   = note: `u8` implements `From<bool>`
+   = note: `From<bool>`
   ::: $SRC_DIR/core/src/convert/num.rs:LL:COL
    |
    = note: in this macro invocation
   --> $SRC_DIR/core/src/ascii/ascii_char.rs:LL:COL
    |
-   = note: `u8` implements `From<std::ascii::Char>`
+   = note: `From<std::ascii::Char>`
   ::: $SRC_DIR/core/src/ascii/ascii_char.rs:LL:COL
    |
    = note: in this macro invocation

--- a/tests/ui/type-alias-impl-trait/constrain_in_projection2.current.stderr
+++ b/tests/ui/type-alias-impl-trait/constrain_in_projection2.current.stderr
@@ -9,14 +9,14 @@ help: the trait `Trait<Bar>` is not implemented for `Foo`
    |
 LL | struct Foo;
    | ^^^^^^^^^^
-help: the following other types implement trait `Trait<T>`
+help: `Foo` implements trait `Trait<T>`
   --> $DIR/constrain_in_projection2.rs:18:1
    |
 LL | impl Trait<()> for Foo {
-   | ^^^^^^^^^^^^^^^^^^^^^^ `Foo` implements `Trait<()>`
+   | ^^^^^^^^^^^^^^^^^^^^^^ `Trait<()>`
 ...
 LL | impl Trait<u32> for Foo {
-   | ^^^^^^^^^^^^^^^^^^^^^^^ `Foo` implements `Trait<u32>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^ `Trait<u32>`
 
 error[E0277]: the trait bound `Foo: Trait<Bar>` is not satisfied
   --> $DIR/constrain_in_projection2.rs:28:13
@@ -29,14 +29,14 @@ help: the trait `Trait<Bar>` is not implemented for `Foo`
    |
 LL | struct Foo;
    | ^^^^^^^^^^
-help: the following other types implement trait `Trait<T>`
+help: `Foo` implements trait `Trait<T>`
   --> $DIR/constrain_in_projection2.rs:18:1
    |
 LL | impl Trait<()> for Foo {
-   | ^^^^^^^^^^^^^^^^^^^^^^ `Foo` implements `Trait<()>`
+   | ^^^^^^^^^^^^^^^^^^^^^^ `Trait<()>`
 ...
 LL | impl Trait<u32> for Foo {
-   | ^^^^^^^^^^^^^^^^^^^^^^^ `Foo` implements `Trait<u32>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^ `Trait<u32>`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/type-alias-impl-trait/nested-tait-inference2.current.stderr
+++ b/tests/ui/type-alias-impl-trait/nested-tait-inference2.current.stderr
@@ -7,13 +7,13 @@ LL |
 LL |     ()
    |     -- return type was inferred to be `()` here
    |
-help: the following other types implement trait `Foo<A>`
+help: `()` implements trait `Foo<A>`
   --> $DIR/nested-tait-inference2.rs:14:1
    |
 LL | impl Foo<()> for () {}
-   | ^^^^^^^^^^^^^^^^^^^ `()` implements `Foo<()>`
+   | ^^^^^^^^^^^^^^^^^^^ `Foo<()>`
 LL | impl Foo<u32> for () {}
-   | ^^^^^^^^^^^^^^^^^^^^ `()` implements `Foo<u32>`
+   | ^^^^^^^^^^^^^^^^^^^^ `Foo<u32>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/issue-90101.stderr
+++ b/tests/ui/typeck/issue-90101.stderr
@@ -6,12 +6,12 @@ LL |     func(Path::new("hello").to_path_buf().to_string_lossy(), "world")
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the following other types implement trait `From<T>`:
-             `PathBuf` implements `From<&T>`
-             `PathBuf` implements `From<Box<Path>>`
-             `PathBuf` implements `From<Cow<'_, Path>>`
-             `PathBuf` implements `From<OsString>`
-             `PathBuf` implements `From<String>`
+   = help: `PathBuf` implements trait `From<T>`:
+             From<&T>
+             From<Box<Path>>
+             From<Cow<'_, Path>>
+             From<OsString>
+             From<String>
    = note: required for `Cow<'_, str>` to implement `Into<PathBuf>`
 note: required by a bound in `func`
   --> $DIR/issue-90101.rs:3:20


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#153686 (`std`: include `dlmalloc` for all non-wasi Wasm targets)
 - rust-lang/rust#154004 (`Alignment`: move from `ptr` to `mem` and rename `as_nonzero` to `as_nonzero_usize`)
 - rust-lang/rust#154105 (bootstrap: Pass `--features=rustc` to rustc_transmute)
 - rust-lang/rust#154191 (refactor RangeFromIter overflow-checks impl)
 - rust-lang/rust#154207 (Refactor query loading)
 - rust-lang/rust#154140 (Document consteval behavior of ub_checks, overflow_checks, is_val_statically_known.)
 - rust-lang/rust#154161 (On E0277 tweak help when single type impls traits)
 - rust-lang/rust#154218 (interpret/validity: remove unreachable error kind)
 - rust-lang/rust#154225 (diagnostics: avoid ICE in confusable_method_name for associated functions)
 - rust-lang/rust#154228 (Improve inline assembly error messages)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=153686,154004,154105,154191,154207,154140,154161,154218,154225,154228)
<!-- homu-ignore:end -->

