### PR TITLE
Rollup of 13 pull requests

### DIFF
--- a/compiler/rustc_ast_lowering/src/asm.rs
+++ b/compiler/rustc_ast_lowering/src/asm.rs
@@ -1,5 +1,4 @@
 use std::collections::hash_map::Entry;
-use std::fmt::Write;
 
 use rustc_ast::*;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap};
@@ -124,13 +123,9 @@ impl<'hir, R: ResolverAstLoweringExt<'hir>> LoweringContext<'_, 'hir, R> {
                         self.dcx().emit_err(ClobberAbiNotSupported { abi_span: *abi_span });
                     }
                     Err(supported_abis) => {
-                        let mut abis = format!("`{}`", supported_abis[0]);
-                        for m in &supported_abis[1..] {
-                            let _ = write!(abis, ", `{m}`");
-                        }
                         self.dcx().emit_err(InvalidAbiClobberAbi {
                             abi_span: *abi_span,
-                            supported_abis: abis,
+                            supported_abis: supported_abis.to_vec().into(),
                         });
                     }
                 }
@@ -164,15 +159,12 @@ impl<'hir, R: ResolverAstLoweringExt<'hir>> LoweringContext<'_, 'hir, R> {
                         asm::InlineAsmRegOrRegClass::RegClass(if let Some(asm_arch) = asm_arch {
                             asm::InlineAsmRegClass::parse(asm_arch, reg_class).unwrap_or_else(
                                 |supported_register_classes| {
-                                    let mut register_classes =
-                                        format!("`{}`", supported_register_classes[0]);
-                                    for m in &supported_register_classes[1..] {
-                                        let _ = write!(register_classes, ", `{m}`");
-                                    }
                                     self.dcx().emit_err(InvalidRegisterClass {
                                         op_span: *op_sp,
                                         reg_class,
-                                        supported_register_classes: register_classes,
+                                        supported_register_classes: supported_register_classes
+                                            .to_vec()
+                                            .into(),
                                     });
                                     asm::InlineAsmRegClass::Err
                                 },
@@ -272,23 +264,20 @@ impl<'hir, R: ResolverAstLoweringExt<'hir>> LoweringContext<'_, 'hir, R> {
                         }
                         let valid_modifiers = class.valid_modifiers(asm_arch.unwrap());
                         if !valid_modifiers.contains(&modifier) {
-                            let sub = if !valid_modifiers.is_empty() {
-                                let mut mods = format!("`{}`", valid_modifiers[0]);
-                                for m in &valid_modifiers[1..] {
-                                    let _ = write!(mods, ", `{m}`");
-                                }
-                                InvalidAsmTemplateModifierRegClassSub::SupportModifier {
-                                    class_name: class.name(),
-                                    modifiers: mods,
-                                }
-                            } else {
+                            let sub = if valid_modifiers.is_empty() {
                                 InvalidAsmTemplateModifierRegClassSub::DoesNotSupportModifier {
                                     class_name: class.name(),
+                                }
+                            } else {
+                                InvalidAsmTemplateModifierRegClassSub::SupportModifier {
+                                    class_name: class.name(),
+                                    modifiers: valid_modifiers.to_vec().into(),
                                 }
                             };
                             self.dcx().emit_err(InvalidAsmTemplateModifierRegClass {
                                 placeholder_span,
                                 op_span: op_sp,
+                                modifier: modifier.to_string(),
                                 sub,
                             });
                         }

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -1,5 +1,5 @@
-use rustc_errors::DiagArgFromDisplay;
 use rustc_errors::codes::*;
+use rustc_errors::{DiagArgFromDisplay, DiagSymbolList};
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_span::{Ident, Span, Symbol};
 
@@ -191,10 +191,10 @@ pub(crate) struct ClobberAbiNotSupported {
 #[derive(Diagnostic)]
 #[note("the following ABIs are supported on this target: {$supported_abis}")]
 #[diag("invalid ABI for `clobber_abi`")]
-pub(crate) struct InvalidAbiClobberAbi {
+pub(crate) struct InvalidAbiClobberAbi<'a> {
     #[primary_span]
     pub abi_span: Span,
-    pub supported_abis: String,
+    pub supported_abis: DiagSymbolList<&'a str>,
 }
 
 #[derive(Diagnostic)]
@@ -215,17 +215,18 @@ pub(crate) struct InvalidRegisterClass {
     #[primary_span]
     pub op_span: Span,
     pub reg_class: Symbol,
-    pub supported_register_classes: String,
+    pub supported_register_classes: DiagSymbolList<Symbol>,
 }
 
 #[derive(Diagnostic)]
-#[diag("invalid asm template modifier for this register class")]
+#[diag("invalid asm template modifier `{$modifier}` for this register class")]
 pub(crate) struct InvalidAsmTemplateModifierRegClass {
     #[primary_span]
     #[label("template modifier")]
     pub placeholder_span: Span,
     #[label("argument")]
     pub op_span: Span,
+    pub modifier: String,
     #[subdiagnostic]
     pub sub: InvalidAsmTemplateModifierRegClassSub,
 }
@@ -235,7 +236,7 @@ pub(crate) enum InvalidAsmTemplateModifierRegClassSub {
     #[note(
         "the `{$class_name}` register class supports the following template modifiers: {$modifiers}"
     )]
-    SupportModifier { class_name: Symbol, modifiers: String },
+    SupportModifier { class_name: Symbol, modifiers: DiagSymbolList<char> },
     #[note("the `{$class_name}` register class does not support template modifiers")]
     DoesNotSupportModifier { class_name: Symbol },
 }

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1749,6 +1749,23 @@ impl<'a> State<'a> {
         }
     }
 
+    /// Print a pattern, parenthesizing it if it is an or-pattern (`A | B`).
+    ///
+    /// Or-patterns have the lowest precedence among patterns, so they need
+    /// parentheses when nested inside `@` bindings, `&` references, or `box`
+    /// patterns — otherwise `x @ A | B` parses as `(x @ A) | B`, `&A | B`
+    /// parses as `(&A) | B`, etc.
+    fn print_pat_paren_if_or(&mut self, pat: &ast::Pat) {
+        let needs_paren = matches!(pat.kind, PatKind::Or(..));
+        if needs_paren {
+            self.popen();
+        }
+        self.print_pat(pat);
+        if needs_paren {
+            self.pclose();
+        }
+    }
+
     fn print_pat(&mut self, pat: &ast::Pat) {
         self.maybe_print_comment(pat.span.lo());
         self.ann.pre(self, AnnNode::Pat(pat));
@@ -1776,7 +1793,7 @@ impl<'a> State<'a> {
                 if let Some(p) = sub {
                     self.space();
                     self.word_space("@");
-                    self.print_pat(p);
+                    self.print_pat_paren_if_or(p);
                 }
             }
             PatKind::TupleStruct(qself, path, elts) => {
@@ -1848,7 +1865,7 @@ impl<'a> State<'a> {
             }
             PatKind::Box(inner) => {
                 self.word("box ");
-                self.print_pat(inner);
+                self.print_pat_paren_if_or(inner);
             }
             PatKind::Deref(inner) => {
                 self.word("deref!");
@@ -1872,7 +1889,7 @@ impl<'a> State<'a> {
                     self.print_pat(inner);
                     self.pclose();
                 } else {
-                    self.print_pat(inner);
+                    self.print_pat_paren_if_or(inner);
                 }
             }
             PatKind::Expr(e) => self.print_expr(e, FixupContext::default()),

--- a/compiler/rustc_attr_parsing/src/attributes/autodiff.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/autodiff.rs
@@ -9,7 +9,7 @@ use rustc_span::{Symbol, sym};
 use thin_vec::ThinVec;
 
 use crate::attributes::prelude::Allow;
-use crate::attributes::{AttributeOrder, OnDuplicate, SingleAttributeParser};
+use crate::attributes::{OnDuplicate, SingleAttributeParser};
 use crate::context::{AcceptContext, Stage};
 use crate::parser::{ArgParser, MetaItemOrLitParser};
 use crate::target_checking::AllowedTargets;
@@ -18,7 +18,6 @@ pub(crate) struct RustcAutodiffParser;
 
 impl<S: Stage> SingleAttributeParser<S> for RustcAutodiffParser {
     const PATH: &[Symbol] = &[sym::rustc_autodiff];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),

--- a/compiler/rustc_attr_parsing/src/attributes/cfi_encoding.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfi_encoding.rs
@@ -8,7 +8,6 @@ impl<S: Stage> SingleAttributeParser<S> for CfiEncodingParser {
         Allow(Target::Enum),
         Allow(Target::Union),
     ]);
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "encoding");
 

--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -12,7 +12,6 @@ pub(crate) struct OptimizeParser;
 
 impl<S: Stage> SingleAttributeParser<S> for OptimizeParser {
     const PATH: &[Symbol] = &[sym::optimize];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::WarnButFutureError;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
@@ -68,7 +67,6 @@ pub(crate) struct CoverageParser;
 
 impl<S: Stage> SingleAttributeParser<S> for CoverageParser {
     const PATH: &[Symbol] = &[sym::coverage];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
@@ -119,7 +117,6 @@ pub(crate) struct ExportNameParser;
 
 impl<S: Stage> SingleAttributeParser<S> for ExportNameParser {
     const PATH: &[rustc_span::Symbol] = &[sym::export_name];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::WarnButFutureError;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Static),
@@ -157,7 +154,6 @@ pub(crate) struct RustcObjcClassParser;
 
 impl<S: Stage> SingleAttributeParser<S> for RustcObjcClassParser {
     const PATH: &[rustc_span::Symbol] = &[sym::rustc_objc_class];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::ForeignStatic)]);
@@ -189,7 +185,6 @@ pub(crate) struct RustcObjcSelectorParser;
 
 impl<S: Stage> SingleAttributeParser<S> for RustcObjcSelectorParser {
     const PATH: &[rustc_span::Symbol] = &[sym::rustc_objc_selector];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::ForeignStatic)]);
@@ -595,7 +590,6 @@ impl<S: Stage> SingleAttributeParser<S> for SanitizeParser {
         r#"realtime = "nonblocking|blocking|caller""#,
     ]);
 
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
 
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
@@ -723,7 +717,6 @@ pub(crate) struct PatchableFunctionEntryParser;
 impl<S: Stage> SingleAttributeParser<S> for PatchableFunctionEntryParser {
     const PATH: &[Symbol] = &[sym::patchable_function_entry];
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
     const TEMPLATE: AttributeTemplate = template!(List: &["prefix_nops = m, entry_nops = n"]);
 

--- a/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
@@ -10,7 +10,6 @@ pub(crate) struct CrateNameParser;
 
 impl<S: Stage> SingleAttributeParser<S> for CrateNameParser {
     const PATH: &[Symbol] = &[sym::crate_name];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::WarnButFutureError;
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "name");
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
@@ -84,7 +83,6 @@ pub(crate) struct RecursionLimitParser;
 
 impl<S: Stage> SingleAttributeParser<S> for RecursionLimitParser {
     const PATH: &[Symbol] = &[sym::recursion_limit];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::WarnButFutureError;
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "N", "https://doc.rust-lang.org/reference/attributes/limits.html#the-recursion_limit-attribute");
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
@@ -107,7 +105,6 @@ pub(crate) struct MoveSizeLimitParser;
 
 impl<S: Stage> SingleAttributeParser<S> for MoveSizeLimitParser {
     const PATH: &[Symbol] = &[sym::move_size_limit];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "N");
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
@@ -130,7 +127,6 @@ pub(crate) struct TypeLengthLimitParser;
 
 impl<S: Stage> SingleAttributeParser<S> for TypeLengthLimitParser {
     const PATH: &[Symbol] = &[sym::type_length_limit];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::WarnButFutureError;
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "N");
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
@@ -153,7 +149,6 @@ pub(crate) struct PatternComplexityLimitParser;
 
 impl<S: Stage> SingleAttributeParser<S> for PatternComplexityLimitParser {
     const PATH: &[Symbol] = &[sym::pattern_complexity_limit];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "N");
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
@@ -213,7 +208,6 @@ pub(crate) struct WindowsSubsystemParser;
 impl<S: Stage> SingleAttributeParser<S> for WindowsSubsystemParser {
     const PATH: &[Symbol] = &[sym::windows_subsystem];
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::WarnButFutureError;
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: ["windows", "console"], "https://doc.rust-lang.org/reference/runtime.html#the-windows_subsystem-attribute");
 

--- a/compiler/rustc_attr_parsing/src/attributes/deprecation.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/deprecation.rs
@@ -34,7 +34,6 @@ fn get<S: Stage>(
 pub(crate) struct DeprecatedParser;
 impl<S: Stage> SingleAttributeParser<S> for DeprecatedParser {
     const PATH: &[Symbol] = &[sym::deprecated];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::Fn),

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/do_not_recommend.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/do_not_recommend.rs
@@ -4,7 +4,7 @@ use rustc_hir::lints::AttributeLintKind;
 use rustc_session::lint::builtin::MALFORMED_DIAGNOSTIC_ATTRIBUTES;
 use rustc_span::{Symbol, sym};
 
-use crate::attributes::{AttributeOrder, OnDuplicate, SingleAttributeParser};
+use crate::attributes::{OnDuplicate, SingleAttributeParser};
 use crate::context::{AcceptContext, Stage};
 use crate::parser::ArgParser;
 use crate::target_checking::{ALL_TARGETS, AllowedTargets};
@@ -12,7 +12,6 @@ use crate::target_checking::{ALL_TARGETS, AllowedTargets};
 pub(crate) struct DoNotRecommendParser;
 impl<S: Stage> SingleAttributeParser<S> for DoNotRecommendParser {
     const PATH: &[Symbol] = &[sym::diagnostic, sym::do_not_recommend];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS); // Checked in check_attr.
     const TEMPLATE: AttributeTemplate = template!(Word /*doesn't matter */);

--- a/compiler/rustc_attr_parsing/src/attributes/dummy.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/dummy.rs
@@ -2,7 +2,7 @@ use rustc_feature::{AttributeTemplate, template};
 use rustc_hir::attrs::AttributeKind;
 use rustc_span::{Symbol, sym};
 
-use crate::attributes::{AttributeOrder, OnDuplicate, SingleAttributeParser};
+use crate::attributes::{OnDuplicate, SingleAttributeParser};
 use crate::context::{AcceptContext, Stage};
 use crate::parser::ArgParser;
 use crate::target_checking::{ALL_TARGETS, AllowedTargets};
@@ -10,7 +10,6 @@ use crate::target_checking::{ALL_TARGETS, AllowedTargets};
 pub(crate) struct RustcDummyParser;
 impl<S: Stage> SingleAttributeParser<S> for RustcDummyParser {
     const PATH: &[Symbol] = &[sym::rustc_dummy];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Ignore;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
     const TEMPLATE: AttributeTemplate = template!(Word); // Anything, really

--- a/compiler/rustc_attr_parsing/src/attributes/inline.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/inline.rs
@@ -11,7 +11,6 @@ pub(crate) struct InlineParser;
 
 impl<S: Stage> SingleAttributeParser<S> for InlineParser {
     const PATH: &[Symbol] = &[sym::inline];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::WarnButFutureError;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
@@ -68,7 +67,6 @@ pub(crate) struct RustcForceInlineParser;
 
 impl<S: Stage> SingleAttributeParser<S> for RustcForceInlineParser {
     const PATH: &[Symbol] = &[sym::rustc_force_inline];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::WarnButFutureError;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),

--- a/compiler/rustc_attr_parsing/src/attributes/instruction_set.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/instruction_set.rs
@@ -16,7 +16,6 @@ impl<S: Stage> SingleAttributeParser<S> for InstructionSetParser {
     ]);
     const TEMPLATE: AttributeTemplate = template!(List: &["set"], "https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute");
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
 
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         const POSSIBLE_SYMBOLS: &[Symbol] = &[sym::arm_a32, sym::arm_t32];

--- a/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
@@ -22,7 +22,6 @@ pub(crate) struct LinkNameParser;
 
 impl<S: Stage> SingleAttributeParser<S> for LinkNameParser {
     const PATH: &[Symbol] = &[sym::link_name];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::WarnButFutureError;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::ForeignFn),
@@ -466,7 +465,6 @@ pub(crate) struct LinkSectionParser;
 
 impl<S: Stage> SingleAttributeParser<S> for LinkSectionParser {
     const PATH: &[Symbol] = &[sym::link_section];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::WarnButFutureError;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::Static),
@@ -541,7 +539,6 @@ pub(crate) struct LinkOrdinalParser;
 
 impl<S: Stage> SingleAttributeParser<S> for LinkOrdinalParser {
     const PATH: &[Symbol] = &[sym::link_ordinal];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::ForeignFn),
@@ -582,8 +579,6 @@ pub(crate) struct LinkageParser;
 
 impl<S: Stage> SingleAttributeParser<S> for LinkageParser {
     const PATH: &[Symbol] = &[sym::linkage];
-
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
 
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[

--- a/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
@@ -130,7 +130,6 @@ pub(crate) struct MacroExportParser;
 
 impl<S: Stage> SingleAttributeParser<S> for MacroExportParser {
     const PATH: &[Symbol] = &[sym::macro_export];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
     const TEMPLATE: AttributeTemplate = template!(Word, List: &["local_inner_macros"]);
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
@@ -168,7 +167,6 @@ pub(crate) struct CollapseDebugInfoParser;
 
 impl<S: Stage> SingleAttributeParser<S> for CollapseDebugInfoParser {
     const PATH: &[Symbol] = &[sym::collapse_debuginfo];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const TEMPLATE: AttributeTemplate = template!(
         List: &["no", "external", "yes"],

--- a/compiler/rustc_attr_parsing/src/attributes/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/mod.rs
@@ -124,14 +124,8 @@ pub(crate) trait SingleAttributeParser<S: Stage>: 'static {
     /// If you need the parser to accept more than one path, use [`AttributeParser`] instead
     const PATH: &[Symbol];
 
-    /// Configures the precedence of attributes with the same `PATH` on a syntax node.
-    const ATTRIBUTE_ORDER: AttributeOrder;
-
     /// Configures what to do when when the same attribute is
     /// applied more than once on the same syntax node.
-    ///
-    /// [`ATTRIBUTE_ORDER`](Self::ATTRIBUTE_ORDER) specified which one is assumed to be correct,
-    /// and this specified whether to, for example, warn or error on the other one.
     const ON_DUPLICATE: OnDuplicate<S>;
 
     const ALLOWED_TARGETS: AllowedTargets;
@@ -162,21 +156,8 @@ impl<T: SingleAttributeParser<S>, S: Stage> AttributeParser<S> for Single<T, S> 
         <T as SingleAttributeParser<S>>::TEMPLATE,
         |group: &mut Single<T, S>, cx, args| {
             if let Some(pa) = T::convert(cx, args) {
-                match T::ATTRIBUTE_ORDER {
-                    // keep the first and report immediately. ignore this attribute
-                    AttributeOrder::KeepInnermost => {
-                        if let Some((_, unused)) = group.1 {
-                            T::ON_DUPLICATE.exec::<T>(cx, cx.attr_span, unused);
-                            return;
-                        }
-                    }
-                    // keep the new one and warn about the previous,
-                    // then replace
-                    AttributeOrder::KeepOutermost => {
-                        if let Some((_, used)) = group.1 {
-                            T::ON_DUPLICATE.exec::<T>(cx, used, cx.attr_span);
-                        }
-                    }
+                if let Some((_, used)) = group.1 {
+                    T::ON_DUPLICATE.exec::<T>(cx, used, cx.attr_span);
                 }
 
                 group.1 = Some((pa, cx.attr_span));
@@ -206,7 +187,7 @@ pub(crate) enum OnDuplicate<S: Stage> {
     /// Custom function called when a duplicate attribute is found.
     ///
     /// - `unused` is the span of the attribute that was unused or bad because of some
-    ///   duplicate reason (see [`AttributeOrder`])
+    ///   duplicate reason
     /// - `used` is the span of the attribute that was used in favor of the unused attribute
     Custom(fn(cx: &AcceptContext<'_, '_, S>, used: Span, unused: Span)),
 }
@@ -223,8 +204,8 @@ impl<S: Stage> OnDuplicate<S> {
             OnDuplicate::WarnButFutureError => cx.warn_unused_duplicate_future_error(used, unused),
             OnDuplicate::Error => {
                 cx.emit_err(UnusedMultiple {
-                    this: used,
-                    other: unused,
+                    this: unused,
+                    other: used,
                     name: Symbol::intern(
                         &P::PATH.into_iter().map(|i| i.to_string()).collect::<Vec<_>>().join(".."),
                     ),
@@ -234,30 +215,6 @@ impl<S: Stage> OnDuplicate<S> {
             OnDuplicate::Custom(f) => f(cx, used, unused),
         }
     }
-}
-
-pub(crate) enum AttributeOrder {
-    /// Duplicates after the innermost instance of the attribute will be an error/warning.
-    /// Only keep the lowest attribute.
-    ///
-    /// Attributes are processed from bottom to top, so this raises a warning/error on all the attributes
-    /// further above the lowest one:
-    /// ```
-    /// #[stable(since="1.0")] //~ WARNING duplicated attribute
-    /// #[stable(since="2.0")]
-    /// ```
-    KeepInnermost,
-
-    /// Duplicates before the outermost instance of the attribute will be an error/warning.
-    /// Only keep the highest attribute.
-    ///
-    /// Attributes are processed from bottom to top, so this raises a warning/error on all the attributes
-    /// below the highest one:
-    /// ```
-    /// #[path="foo.rs"]
-    /// #[path="bar.rs"] //~ WARNING duplicated attribute
-    /// ```
-    KeepOutermost,
 }
 
 /// An even simpler version of [`SingleAttributeParser`]:
@@ -284,7 +241,6 @@ impl<T: NoArgsAttributeParser<S>, S: Stage> Default for WithoutArgs<T, S> {
 
 impl<T: NoArgsAttributeParser<S>, S: Stage> SingleAttributeParser<S> for WithoutArgs<T, S> {
     const PATH: &[Symbol] = T::PATH;
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ON_DUPLICATE: OnDuplicate<S> = T::ON_DUPLICATE;
     const ALLOWED_TARGETS: AllowedTargets = T::ALLOWED_TARGETS;
     const TEMPLATE: AttributeTemplate = template!(Word);

--- a/compiler/rustc_attr_parsing/src/attributes/must_not_suspend.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/must_not_suspend.rs
@@ -4,7 +4,6 @@ pub(crate) struct MustNotSuspendParser;
 
 impl<S: Stage> SingleAttributeParser<S> for MustNotSuspendParser {
     const PATH: &[rustc_span::Symbol] = &[sym::must_not_suspend];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Struct),

--- a/compiler/rustc_attr_parsing/src/attributes/must_use.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/must_use.rs
@@ -4,7 +4,6 @@ pub(crate) struct MustUseParser;
 
 impl<S: Stage> SingleAttributeParser<S> for MustUseParser {
     const PATH: &[Symbol] = &[sym::must_use];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::WarnButFutureError;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::Fn),

--- a/compiler/rustc_attr_parsing/src/attributes/path.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/path.rs
@@ -4,7 +4,6 @@ pub(crate) struct PathParser;
 
 impl<S: Stage> SingleAttributeParser<S> for PathParser {
     const PATH: &[Symbol] = &[sym::path];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::WarnButFutureError;
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowListWarnRest(&[Allow(Target::Mod), Error(Target::Crate)]);

--- a/compiler/rustc_attr_parsing/src/attributes/prelude.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/prelude.rs
@@ -12,8 +12,8 @@ pub(super) use thin_vec::ThinVec;
 
 #[doc(hidden)]
 pub(super) use crate::attributes::{
-    AcceptMapping, AttributeOrder, AttributeParser, CombineAttributeParser, ConvertFn,
-    NoArgsAttributeParser, OnDuplicate, SingleAttributeParser,
+    AcceptMapping, AttributeParser, CombineAttributeParser, ConvertFn, NoArgsAttributeParser,
+    OnDuplicate, SingleAttributeParser,
 };
 // contexts
 #[doc(hidden)]

--- a/compiler/rustc_attr_parsing/src/attributes/proc_macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/proc_macro_attrs.rs
@@ -25,7 +25,6 @@ impl<S: Stage> NoArgsAttributeParser<S> for ProcMacroAttributeParser {
 pub(crate) struct ProcMacroDeriveParser;
 impl<S: Stage> SingleAttributeParser<S> for ProcMacroDeriveParser {
     const PATH: &[Symbol] = &[sym::proc_macro_derive];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const ALLOWED_TARGETS: AllowedTargets = PROC_MACRO_ALLOWED_TARGETS;
     const TEMPLATE: AttributeTemplate = template!(
@@ -46,7 +45,6 @@ impl<S: Stage> SingleAttributeParser<S> for ProcMacroDeriveParser {
 pub(crate) struct RustcBuiltinMacroParser;
 impl<S: Stage> SingleAttributeParser<S> for RustcBuiltinMacroParser {
     const PATH: &[Symbol] = &[sym::rustc_builtin_macro];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::MacroDef)]);
     const TEMPLATE: AttributeTemplate =

--- a/compiler/rustc_attr_parsing/src/attributes/prototype.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/prototype.rs
@@ -5,7 +5,7 @@ use rustc_hir::Target;
 use rustc_hir::attrs::{AttributeKind, MirDialect, MirPhase};
 use rustc_span::{Span, Symbol, sym};
 
-use super::{AttributeOrder, OnDuplicate};
+use super::OnDuplicate;
 use crate::attributes::SingleAttributeParser;
 use crate::context::{AcceptContext, Stage};
 use crate::parser::ArgParser;
@@ -16,8 +16,6 @@ pub(crate) struct CustomMirParser;
 
 impl<S: Stage> SingleAttributeParser<S> for CustomMirParser {
     const PATH: &[rustc_span::Symbol] = &[sym::custom_mir];
-
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
 
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
 

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_allocator.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_allocator.rs
@@ -28,7 +28,6 @@ impl<S: Stage> SingleAttributeParser<S> for RustcAllocatorZeroedVariantParser {
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Fn), Allow(Target::ForeignFn)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "function");
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(name) = args.name_value().and_then(NameValueParser::value_as_str) else {
             cx.expected_name_value(cx.attr_span, None);

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -31,7 +31,6 @@ impl<S: Stage> SingleAttributeParser<S> for RustcMustImplementOneOfParser {
     const PATH: &[Symbol] = &[sym::rustc_must_implement_one_of];
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const TEMPLATE: AttributeTemplate = template!(List: &["function1, function2, ..."]);
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(list) = args.list() else {
@@ -105,7 +104,6 @@ pub(crate) struct RustcLayoutScalarValidRangeStartParser;
 
 impl<S: Stage> SingleAttributeParser<S> for RustcLayoutScalarValidRangeStartParser {
     const PATH: &[Symbol] = &[sym::rustc_layout_scalar_valid_range_start];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
     const TEMPLATE: AttributeTemplate = template!(List: &["start"]);
@@ -120,7 +118,6 @@ pub(crate) struct RustcLayoutScalarValidRangeEndParser;
 
 impl<S: Stage> SingleAttributeParser<S> for RustcLayoutScalarValidRangeEndParser {
     const PATH: &[Symbol] = &[sym::rustc_layout_scalar_valid_range_end];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
     const TEMPLATE: AttributeTemplate = template!(List: &["end"]);
@@ -135,7 +132,6 @@ pub(crate) struct RustcLegacyConstGenericsParser;
 
 impl<S: Stage> SingleAttributeParser<S> for RustcLegacyConstGenericsParser {
     const PATH: &[Symbol] = &[sym::rustc_legacy_const_generics];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
     const TEMPLATE: AttributeTemplate = template!(List: &["N"]);
@@ -193,7 +189,6 @@ pub(crate) struct RustcLintOptDenyFieldAccessParser;
 
 impl<S: Stage> SingleAttributeParser<S> for RustcLintOptDenyFieldAccessParser {
     const PATH: &[Symbol] = &[sym::rustc_lint_opt_deny_field_access];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Field)]);
     const TEMPLATE: AttributeTemplate = template!(Word);
@@ -373,7 +368,6 @@ impl<S: Stage> SingleAttributeParser<S> for RustcDeprecatedSafe2024Parser {
         Allow(Target::Method(MethodKind::Trait { body: true })),
         Allow(Target::Method(MethodKind::TraitImpl)),
     ]);
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const TEMPLATE: AttributeTemplate = template!(List: &[r#"audit_that = "...""#]);
 
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
@@ -441,7 +435,6 @@ impl<S: Stage> SingleAttributeParser<S> for RustcNeverTypeOptionsParser {
     const PATH: &[Symbol] = &[sym::rustc_never_type_options];
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const TEMPLATE: AttributeTemplate = template!(List: &[
         r#"fallback = "unit", "never", "no""#,
         r#"diverging_block_default = "unit", "never""#,
@@ -601,7 +594,6 @@ pub(crate) struct RustcSimdMonomorphizeLaneLimitParser;
 
 impl<S: Stage> SingleAttributeParser<S> for RustcSimdMonomorphizeLaneLimitParser {
     const PATH: &[Symbol] = &[sym::rustc_simd_monomorphize_lane_limit];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "N");
@@ -619,7 +611,6 @@ pub(crate) struct RustcScalableVectorParser;
 
 impl<S: Stage> SingleAttributeParser<S> for RustcScalableVectorParser {
     const PATH: &[Symbol] = &[sym::rustc_scalable_vector];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
     const TEMPLATE: AttributeTemplate = template!(Word, List: &["count"]);
@@ -645,7 +636,6 @@ pub(crate) struct LangParser;
 
 impl<S: Stage> SingleAttributeParser<S> for LangParser {
     const PATH: &[Symbol] = &[sym::lang];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS); // Targets are checked per lang item in `rustc_passes`
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "name");
@@ -990,8 +980,6 @@ pub(crate) struct RustcIfThisChangedParser;
 impl<S: Stage> SingleAttributeParser<S> for RustcIfThisChangedParser {
     const PATH: &[Symbol] = &[sym::rustc_if_this_changed];
 
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
-
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
 
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
@@ -1156,7 +1144,6 @@ pub(crate) struct RustcDiagnosticItemParser;
 
 impl<S: Stage> SingleAttributeParser<S> for RustcDiagnosticItemParser {
     const PATH: &[Symbol] = &[sym::rustc_diagnostic_item];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Trait),
@@ -1229,7 +1216,6 @@ impl<S: Stage> SingleAttributeParser<S> for RustcSymbolNameParser {
         Allow(Target::Impl { of_trait: false }),
     ]);
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const TEMPLATE: AttributeTemplate = template!(Word);
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         if let Err(span) = args.no_args() {
@@ -1254,7 +1240,6 @@ impl<S: Stage> SingleAttributeParser<S> for RustcDefPathParser {
         Allow(Target::Impl { of_trait: false }),
     ]);
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const TEMPLATE: AttributeTemplate = template!(Word);
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         if let Err(span) = args.no_args() {
@@ -1284,7 +1269,6 @@ pub(crate) struct RustcReservationImplParser;
 
 impl<S: Stage> SingleAttributeParser<S> for RustcReservationImplParser {
     const PATH: &[Symbol] = &[sym::rustc_reservation_impl];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Impl { of_trait: true })]);
@@ -1320,7 +1304,6 @@ pub(crate) struct RustcDocPrimitiveParser;
 impl<S: Stage> SingleAttributeParser<S> for RustcDocPrimitiveParser {
     const PATH: &[Symbol] = &[sym::rustc_doc_primitive];
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Mod)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "primitive name");
 

--- a/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
@@ -7,7 +7,6 @@ pub(crate) struct IgnoreParser;
 
 impl<S: Stage> SingleAttributeParser<S> for IgnoreParser {
     const PATH: &[Symbol] = &[sym::ignore];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowListWarnRest(&[Allow(Target::Fn), Error(Target::WherePredicate)]);
@@ -41,7 +40,6 @@ pub(crate) struct ShouldPanicParser;
 
 impl<S: Stage> SingleAttributeParser<S> for ShouldPanicParser {
     const PATH: &[Symbol] = &[sym::should_panic];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::WarnButFutureError;
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowListWarnRest(&[Allow(Target::Fn), Error(Target::WherePredicate)]);
@@ -120,7 +118,6 @@ pub(crate) struct ReexportTestHarnessMainParser;
 impl<S: Stage> SingleAttributeParser<S> for ReexportTestHarnessMainParser {
     const PATH: &[Symbol] = &[sym::reexport_test_harness_main];
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "name");
 
@@ -148,7 +145,6 @@ impl<S: Stage> SingleAttributeParser<S> for RustcAbiParser {
     const PATH: &[Symbol] = &[sym::rustc_abi];
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
     const TEMPLATE: AttributeTemplate = template!(OneOf: &[sym::debug, sym::assert_eq]);
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::TyAlias),
         Allow(Target::Fn),
@@ -233,7 +229,6 @@ pub(crate) struct TestRunnerParser;
 
 impl<S: Stage> SingleAttributeParser<S> for TestRunnerParser {
     const PATH: &[Symbol] = &[sym::test_runner];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const TEMPLATE: AttributeTemplate = template!(List: &["path"]);
@@ -262,7 +257,6 @@ pub(crate) struct RustcTestMarkerParser;
 
 impl<S: Stage> SingleAttributeParser<S> for RustcTestMarkerParser {
     const PATH: &[Symbol] = &[sym::rustc_test_marker];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepOutermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Const),

--- a/compiler/rustc_attr_parsing/src/attributes/traits.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/traits.rs
@@ -1,9 +1,7 @@
 use std::mem;
 
 use super::prelude::*;
-use crate::attributes::{
-    AttributeOrder, NoArgsAttributeParser, OnDuplicate, SingleAttributeParser,
-};
+use crate::attributes::{NoArgsAttributeParser, OnDuplicate, SingleAttributeParser};
 use crate::context::{AcceptContext, Stage};
 use crate::parser::ArgParser;
 use crate::target_checking::Policy::{Allow, Warn};
@@ -12,7 +10,6 @@ use crate::target_checking::{ALL_TARGETS, AllowedTargets};
 pub(crate) struct RustcSkipDuringMethodDispatchParser;
 impl<S: Stage> SingleAttributeParser<S> for RustcSkipDuringMethodDispatchParser {
     const PATH: &[Symbol] = &[sym::rustc_skip_during_method_dispatch];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
 

--- a/compiler/rustc_attr_parsing/src/attributes/transparency.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/transparency.rs
@@ -6,7 +6,6 @@ pub(crate) struct RustcMacroTransparencyParser;
 
 impl<S: Stage> SingleAttributeParser<S> for RustcMacroTransparencyParser {
     const PATH: &[Symbol] = &[sym::rustc_macro_transparency];
-    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepInnermost;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Custom(|cx, used, unused| {
         cx.dcx().span_err(vec![used, unused], "multiple macro transparency attributes");
     });

--- a/compiler/rustc_attr_parsing/src/errors.rs
+++ b/compiler/rustc_attr_parsing/src/errors.rs
@@ -1,0 +1,26 @@
+use rustc_macros::{Diagnostic, Subdiagnostic};
+use rustc_span::{Span, Symbol};
+
+#[derive(Diagnostic)]
+#[diag("`{$name}` attribute cannot be used at crate level")]
+pub(crate) struct InvalidAttrAtCrateLevel {
+    #[primary_span]
+    pub span: Span,
+    #[suggestion(
+        "perhaps you meant to use an outer attribute",
+        code = "#[",
+        applicability = "machine-applicable",
+        style = "verbose"
+    )]
+    pub pound_to_opening_bracket: Span,
+    pub name: Symbol,
+    #[subdiagnostic]
+    pub item: Option<ItemFollowingInnerAttr>,
+}
+
+#[derive(Clone, Copy, Subdiagnostic)]
+#[label("the inner attribute doesn't annotate this item")]
+pub(crate) struct ItemFollowingInnerAttr {
+    #[primary_span]
+    pub span: Span,
+}

--- a/compiler/rustc_attr_parsing/src/errors.rs
+++ b/compiler/rustc_attr_parsing/src/errors.rs
@@ -1,3 +1,4 @@
+use rustc_errors::MultiSpan;
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_span::{Span, Symbol};
 
@@ -23,4 +24,12 @@ pub(crate) struct InvalidAttrAtCrateLevel {
 pub(crate) struct ItemFollowingInnerAttr {
     #[primary_span]
     pub span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag("most attributes are not supported in `where` clauses")]
+#[help("only `#[cfg]` and `#[cfg_attr]` are supported")]
+pub(crate) struct UnsupportedAttributesInWhere {
+    #[primary_span]
+    pub span: MultiSpan,
 }

--- a/compiler/rustc_attr_parsing/src/interface.rs
+++ b/compiler/rustc_attr_parsing/src/interface.rs
@@ -269,6 +269,11 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
         mut emit_lint: impl FnMut(LintId, Span, AttributeLintKind),
     ) -> Vec<Attribute> {
         let mut attributes = Vec::new();
+        // We store the attributes we intend to discard at the end of this function in order to
+        // check they are applied to the right target and error out if necessary. In practice, we
+        // end up dropping only derive attributes and derive helpers, both being fully processed
+        // at macro expansion.
+        let mut dropped_attributes = Vec::new();
         let mut attr_paths: Vec<RefPathParser<'_>> = Vec::new();
         let mut early_parsed_state = EarlyParsedState::default();
 
@@ -393,21 +398,6 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
                             Self::check_target(&accept.allowed_targets, target, &mut cx);
                         }
                     } else {
-                        // If we're here, we must be compiling a tool attribute... Or someone
-                        // forgot to parse their fancy new attribute. Let's warn them in any case.
-                        // If you are that person, and you really think your attribute should
-                        // remain unparsed, carefully read the documentation in this module and if
-                        // you still think so you can add an exception to this assertion.
-
-                        // FIXME(jdonszelmann): convert other attributes, and check with this that
-                        // we caught em all
-                        // const FIXME_TEMPORARY_ATTR_ALLOWLIST: &[Symbol] = &[sym::cfg];
-                        // assert!(
-                        //     self.tools.contains(&parts[0]) || true,
-                        //     // || FIXME_TEMPORARY_ATTR_ALLOWLIST.contains(&parts[0]),
-                        //     "attribute {path} wasn't parsed and isn't a know tool attribute",
-                        // );
-
                         let attr = AttrItem {
                             path: attr_path.clone(),
                             args: self
@@ -423,8 +413,19 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
                             self.check_invalid_crate_level_attr_item(&attr, n.item.span());
                         }
 
-                        attributes.push(Attribute::Unparsed(Box::new(attr)));
-                    };
+                        let attr = Attribute::Unparsed(Box::new(attr));
+
+                        if self.tools.contains(&parts[0])
+                            // FIXME: this can be removed once #152369 has been merged.
+                            // https://github.com/rust-lang/rust/pull/152369
+                            || [sym::allow, sym::deny, sym::expect, sym::forbid, sym::warn]
+                                .contains(&parts[0])
+                        {
+                            attributes.push(attr);
+                        } else {
+                            dropped_attributes.push(attr);
+                        }
+                    }
                 }
             }
         }
@@ -442,7 +443,7 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
         if !matches!(self.stage.should_emit(), ShouldEmit::Nothing)
             && target == Target::WherePredicate
         {
-            self.check_invalid_where_predicate_attrs(attributes.iter());
+            self.check_invalid_where_predicate_attrs(attributes.iter().chain(&dropped_attributes));
         }
 
         attributes

--- a/compiler/rustc_attr_parsing/src/interface.rs
+++ b/compiler/rustc_attr_parsing/src/interface.rs
@@ -304,7 +304,7 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
                         kind: DocFragmentKind::Sugared(*comment_kind),
                         span: attr_span,
                         comment: *symbol,
-                    }))
+                    }));
                 }
                 ast::AttrKind::Normal(n) => {
                     attr_paths.push(PathParser(&n.item.path));
@@ -408,15 +408,23 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
                         //     "attribute {path} wasn't parsed and isn't a know tool attribute",
                         // );
 
-                        attributes.push(Attribute::Unparsed(Box::new(AttrItem {
+                        let attr = AttrItem {
                             path: attr_path.clone(),
                             args: self
                                 .lower_attr_args(n.item.args.unparsed_ref().unwrap(), lower_span),
                             id: HashIgnoredAttrId { attr_id: attr.id },
                             style: attr.style,
                             span: attr_span,
-                        })));
-                    }
+                        };
+
+                        if !matches!(self.stage.should_emit(), ShouldEmit::Nothing)
+                            && target == Target::Crate
+                        {
+                            self.check_invalid_crate_level_attr_item(&attr, n.item.span());
+                        }
+
+                        attributes.push(Attribute::Unparsed(Box::new(attr)));
+                    };
                 }
             }
         }

--- a/compiler/rustc_attr_parsing/src/interface.rs
+++ b/compiler/rustc_attr_parsing/src/interface.rs
@@ -439,6 +439,12 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
             }
         }
 
+        if !matches!(self.stage.should_emit(), ShouldEmit::Nothing)
+            && target == Target::WherePredicate
+        {
+            self.check_invalid_where_predicate_attrs(attributes.iter());
+        }
+
         attributes
     }
 

--- a/compiler/rustc_attr_parsing/src/lib.rs
+++ b/compiler/rustc_attr_parsing/src/lib.rs
@@ -79,6 +79,7 @@
 // tidy-alphabetical-start
 #![feature(decl_macro)]
 #![feature(iter_intersperse)]
+#![feature(try_blocks)]
 #![recursion_limit = "256"]
 // tidy-alphabetical-end
 
@@ -99,6 +100,7 @@ mod interface;
 pub mod parser;
 
 mod early_parsed;
+mod errors;
 mod safety;
 mod session_diagnostics;
 mod target_checking;

--- a/compiler/rustc_attr_parsing/src/target_checking.rs
+++ b/compiler/rustc_attr_parsing/src/target_checking.rs
@@ -1,14 +1,15 @@
 use std::borrow::Cow;
 
 use rustc_ast::AttrStyle;
-use rustc_errors::DiagArgValue;
+use rustc_errors::{DiagArgValue, StashKey};
 use rustc_feature::Features;
 use rustc_hir::lints::AttributeLintKind;
-use rustc_hir::{MethodKind, Target};
-use rustc_span::sym;
+use rustc_hir::{AttrItem, MethodKind, Target};
+use rustc_span::{BytePos, Span, Symbol, sym};
 
 use crate::AttributeParser;
 use crate::context::{AcceptContext, Stage};
+use crate::errors::{InvalidAttrAtCrateLevel, ItemFollowingInnerAttr};
 use crate::session_diagnostics::InvalidTarget;
 use crate::target_checking::Policy::Allow;
 
@@ -96,6 +97,25 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
             return;
         }
 
+        if matches!(cx.attr_path.segments.as_ref(), [sym::repr]) && target == Target::Crate {
+            // The allowed targets of `repr` depend on its arguments. They can't be checked using
+            // the `AttributeParser` code.
+            let span = cx.attr_span;
+            let item =
+                cx.cx.first_line_of_next_item(span).map(|span| ItemFollowingInnerAttr { span });
+
+            let pound_to_opening_bracket = cx.attr_span.until(cx.inner_span);
+
+            cx.dcx()
+                .create_err(InvalidAttrAtCrateLevel {
+                    span,
+                    pound_to_opening_bracket,
+                    name: sym::repr,
+                    item,
+                })
+                .emit();
+        }
+
         match allowed_targets.is_allowed(target) {
             AllowedResult::Allowed => {}
             AllowedResult::Warn => {
@@ -162,6 +182,87 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
         let attr_span = cx.attr_span;
 
         cx.emit_lint(rustc_session::lint::builtin::UNUSED_ATTRIBUTES, kind, attr_span);
+    }
+
+    // FIXME: Fix "Cannot determine resolution" error and remove built-in macros
+    // from this check.
+    pub(crate) fn check_invalid_crate_level_attr_item(&self, attr: &AttrItem, inner_span: Span) {
+        // Check for builtin attributes at the crate level
+        // which were unsuccessfully resolved due to cannot determine
+        // resolution for the attribute macro error.
+        const ATTRS_TO_CHECK: &[Symbol] =
+            &[sym::derive, sym::test, sym::test_case, sym::global_allocator, sym::bench];
+
+        // FIXME(jdonszelmann): all attrs should be combined here cleaning this up some day.
+        if let Some(name) = ATTRS_TO_CHECK.iter().find(|attr_to_check| matches!(attr.path.segments.as_ref(), [segment] if segment == *attr_to_check)) {
+            let span = attr.span;
+            let name = *name;
+
+            let item = self.first_line_of_next_item(span).map(|span| ItemFollowingInnerAttr { span });
+
+            let err = self.dcx().create_err(InvalidAttrAtCrateLevel {
+                span,
+                pound_to_opening_bracket: span.until(inner_span),
+                name,
+                item,
+            });
+
+            self.dcx().try_steal_replace_and_emit_err(
+                attr.path.span,
+                StashKey::UndeterminedMacroResolution,
+                err,
+            );
+        }
+    }
+
+    fn first_line_of_next_item(&self, span: Span) -> Option<Span> {
+        // We can't exactly call `tcx.hir_free_items()` here because it's too early and querying
+        // this would create a circular dependency. Instead, we resort to getting the original
+        // source code that follows `span` and find the next item from here.
+
+        self.sess()
+            .source_map()
+            .span_to_source(span, |content, _, span_end| {
+                let mut source = &content[span_end..];
+                let initial_source_len = source.len();
+                let span = try {
+                    loop {
+                        let first = source.chars().next()?;
+
+                        if first.is_whitespace() {
+                            let split_idx = source.find(|c: char| !c.is_whitespace())?;
+                            source = &source[split_idx..];
+                        } else if source.starts_with("//") {
+                            let line_idx = source.find('\n')?;
+                            source = &source[line_idx + '\n'.len_utf8()..];
+                        } else if source.starts_with("/*") {
+                            // FIXME: support nested comments.
+                            let close_idx = source.find("*/")?;
+                            source = &source[close_idx + "*/".len()..];
+                        } else if first == '#' {
+                            // FIXME: properly find the end of the attributes in order to accurately
+                            // skip them. This version just consumes the source code until the next
+                            // `]`.
+                            let close_idx = source.find(']')?;
+                            source = &source[close_idx + ']'.len_utf8()..];
+                        } else {
+                            let lo = span_end + initial_source_len - source.len();
+                            let last_line = source.split('\n').next().map(|s| s.trim_end())?;
+
+                            let hi = lo + last_line.len();
+                            let lo = BytePos(lo as u32);
+                            let hi = BytePos(hi as u32);
+                            let next_item_span = Span::new(lo, hi, span.ctxt(), None);
+
+                            break next_item_span;
+                        }
+                    }
+                };
+
+                Ok(span)
+            })
+            .ok()
+            .flatten()
     }
 }
 

--- a/compiler/rustc_attr_parsing/src/target_checking.rs
+++ b/compiler/rustc_attr_parsing/src/target_checking.rs
@@ -1,15 +1,18 @@
 use std::borrow::Cow;
 
 use rustc_ast::AttrStyle;
-use rustc_errors::{DiagArgValue, StashKey};
+use rustc_errors::{DiagArgValue, MultiSpan, StashKey};
 use rustc_feature::Features;
+use rustc_hir::attrs::AttributeKind;
 use rustc_hir::lints::AttributeLintKind;
-use rustc_hir::{AttrItem, MethodKind, Target};
+use rustc_hir::{AttrItem, Attribute, MethodKind, Target};
 use rustc_span::{BytePos, Span, Symbol, sym};
 
 use crate::AttributeParser;
 use crate::context::{AcceptContext, Stage};
-use crate::errors::{InvalidAttrAtCrateLevel, ItemFollowingInnerAttr};
+use crate::errors::{
+    InvalidAttrAtCrateLevel, ItemFollowingInnerAttr, UnsupportedAttributesInWhere,
+};
 use crate::session_diagnostics::InvalidTarget;
 use crate::target_checking::Policy::Allow;
 
@@ -263,6 +266,32 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
             })
             .ok()
             .flatten()
+    }
+
+    pub(crate) fn check_invalid_where_predicate_attrs<'attr>(
+        &self,
+        attrs: impl IntoIterator<Item = &'attr Attribute>,
+    ) {
+        // FIXME(where_clause_attrs): Currently, as the following check shows,
+        // only `#[cfg]` and `#[cfg_attr]` are allowed, but it should be removed
+        // if we allow more attributes (e.g., tool attributes and `allow/deny/warn`)
+        // in where clauses. After that, this function would become useless.
+        let spans = attrs
+            .into_iter()
+            // FIXME: We shouldn't need to special-case `doc`!
+            .filter(|attr| {
+                matches!(
+                    attr,
+                    Attribute::Parsed(AttributeKind::DocComment { .. } | AttributeKind::Doc(_))
+                        | Attribute::Unparsed(_)
+                )
+            })
+            .map(|attr| attr.span())
+            .collect::<Vec<_>>();
+        if !spans.is_empty() {
+            self.dcx()
+                .emit_err(UnsupportedAttributesInWhere { span: MultiSpan::from_spans(spans) });
+        }
     }
 }
 

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -252,7 +252,10 @@ pub(crate) fn to_llvm_features<'a>(sess: &Session, s: &'a str) -> Option<LLVMFea
             "fp16" => Some(LLVMFeature::new("fullfp16")),
             s => Some(LLVMFeature::new(s)),
         },
-
+        Arch::Bpf => match s {
+            "allows-misaligned-mem-access" if major < 22 => None,
+            s => Some(LLVMFeature::new(s)),
+        },
         // Filter out features that are not supported by the current LLVM version
         Arch::LoongArch32 | Arch::LoongArch64 => match s {
             "32s" if major < 21 => None,

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -128,7 +128,6 @@ enum ExpectedKind {
     Reference,
     Box,
     RawPtr,
-    InitScalar,
     Bool,
     Char,
     Float,
@@ -143,7 +142,6 @@ impl fmt::Display for ExpectedKind {
             ExpectedKind::Reference => "expected a reference",
             ExpectedKind::Box => "expected a box",
             ExpectedKind::RawPtr => "expected a raw pointer",
-            ExpectedKind::InitScalar => "expected initialized scalar value",
             ExpectedKind::Bool => "expected a boolean",
             ExpectedKind::Char => "expected a unicode scalar value",
             ExpectedKind::Float => "expected a floating point number",
@@ -1478,7 +1476,9 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValueVisitor<'tcx, M> for ValidityVisitor<'rt,
             BackendRepr::Scalar(scalar_layout) => {
                 if !scalar_layout.is_uninit_valid() {
                     // There is something to check here.
-                    let scalar = self.read_scalar(val, ExpectedKind::InitScalar)?;
+                    // We read directly via `ecx` since the read cannot fail -- we already read
+                    // this field above when recursing into the field.
+                    let scalar = self.ecx.read_scalar(val)?;
                     self.visit_scalar(scalar, scalar_layout)?;
                 }
             }
@@ -1487,8 +1487,9 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValueVisitor<'tcx, M> for ValidityVisitor<'rt,
                 // FIXME: find a way to also check ScalarPair when one side can be uninit but
                 // the other must be init.
                 if !a_layout.is_uninit_valid() && !b_layout.is_uninit_valid() {
-                    let (a, b) =
-                        self.read_immediate(val, ExpectedKind::InitScalar)?.to_scalar_pair();
+                    // We read directly via `ecx` since the read cannot fail -- we already read
+                    // this field above when recursing into the field.
+                    let (a, b) = self.ecx.read_immediate(val)?.to_scalar_pair();
                     self.visit_scalar(a, a_layout)?;
                     self.visit_scalar(b, b_layout)?;
                 }

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -2291,8 +2291,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             fn_sig,
                         );
                         let name = inherent_method.name();
+                        let inputs = fn_sig.inputs();
+                        let expected_inputs =
+                            if inherent_method.is_method() { &inputs[1..] } else { inputs };
                         if let Some(ref args) = call_args
-                            && fn_sig.inputs()[1..]
+                            && expected_inputs
                                 .iter()
                                 .eq_by(args, |expected, found| self.may_coerce(*expected, *found))
                         {

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -104,9 +104,6 @@ pub struct QueryVTable<'tcx, C: QueryCache> {
         index: DepNodeIndex,
     ) -> Option<C::Value>,
 
-    pub is_loadable_from_disk_fn:
-        fn(tcx: TyCtxt<'tcx>, key: C::Key, index: SerializedDepNodeIndex) -> bool,
-
     /// Function pointer that hashes this query's result values.
     ///
     /// For `no_hash` queries, this function pointer is None.

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -15,7 +15,7 @@ use rustc_attr_parsing::{AttributeParser, Late};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::thin_vec::ThinVec;
 use rustc_data_structures::unord::UnordMap;
-use rustc_errors::{DiagCtxtHandle, IntoDiagArg, MultiSpan, StashKey, msg};
+use rustc_errors::{DiagCtxtHandle, IntoDiagArg, MultiSpan, msg};
 use rustc_feature::{AttributeDuplicates, AttributeType, BUILTIN_ATTRIBUTE_MAP, BuiltinAttribute};
 use rustc_hir::attrs::diagnostic::Directive;
 use rustc_hir::attrs::{
@@ -45,7 +45,7 @@ use rustc_session::lint::builtin::{
 };
 use rustc_session::parse::feature_err;
 use rustc_span::edition::Edition;
-use rustc_span::{BytePos, DUMMY_SP, Ident, Span, Symbol, sym};
+use rustc_span::{DUMMY_SP, Ident, Span, Symbol, sym};
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;
 use rustc_trait_selection::infer::{TyCtxtInferExt, ValuePairs};
 use rustc_trait_selection::traits::ObligationCtxt;
@@ -2025,64 +2025,6 @@ fn is_c_like_enum(item: &Item<'_>) -> bool {
     }
 }
 
-// FIXME: Fix "Cannot determine resolution" error and remove built-in macros
-// from this check.
-fn check_invalid_crate_level_attr(tcx: TyCtxt<'_>, attrs: &[Attribute]) {
-    // Check for builtin attributes at the crate level
-    // which were unsuccessfully resolved due to cannot determine
-    // resolution for the attribute macro error.
-    const ATTRS_TO_CHECK: &[Symbol] =
-        &[sym::derive, sym::test, sym::test_case, sym::global_allocator, sym::bench];
-
-    for attr in attrs {
-        // FIXME(jdonszelmann): all attrs should be combined here cleaning this up some day.
-        let (span, name) = if let Some(a) =
-            ATTRS_TO_CHECK.iter().find(|attr_to_check| attr.has_name(**attr_to_check))
-        {
-            (attr.span(), *a)
-        } else if let Attribute::Parsed(AttributeKind::Repr {
-            reprs: _,
-            first_span: first_attr_span,
-        }) = attr
-        {
-            (*first_attr_span, sym::repr)
-        } else {
-            continue;
-        };
-
-        let item = tcx
-            .hir_free_items()
-            .map(|id| tcx.hir_item(id))
-            .find(|item| !item.span.is_dummy()) // Skip prelude `use`s
-            .map(|item| errors::ItemFollowingInnerAttr {
-                span: if let Some(ident) = item.kind.ident() { ident.span } else { item.span },
-                kind: tcx.def_descr(item.owner_id.to_def_id()),
-            });
-        let err = tcx.dcx().create_err(errors::InvalidAttrAtCrateLevel {
-            span,
-            sugg_span: tcx
-                .sess
-                .source_map()
-                .span_to_snippet(span)
-                .ok()
-                .filter(|src| src.starts_with("#!["))
-                .map(|_| span.with_lo(span.lo() + BytePos(1)).with_hi(span.lo() + BytePos(2))),
-            name,
-            item,
-        });
-
-        if let Attribute::Unparsed(p) = attr {
-            tcx.dcx().try_steal_replace_and_emit_err(
-                p.path.span,
-                StashKey::UndeterminedMacroResolution,
-                err,
-            );
-        } else {
-            err.emit();
-        }
-    }
-}
-
 fn check_non_exported_macro_for_invalid_attrs(tcx: TyCtxt<'_>, item: &Item<'_>) {
     let attrs = tcx.hir_attrs(item.hir_id());
 
@@ -2098,7 +2040,6 @@ fn check_mod_attrs(tcx: TyCtxt<'_>, module_def_id: LocalModDefId) {
     tcx.hir_visit_item_likes_in_module(module_def_id, check_attr_visitor);
     if module_def_id.to_local_def_id().is_top_level_module() {
         check_attr_visitor.check_attributes(CRATE_HIR_ID, DUMMY_SP, Target::Mod, None);
-        check_invalid_crate_level_attr(tcx, tcx.hir_krate_attrs());
     }
     if check_attr_visitor.abort.get() {
         tcx.dcx().abort_if_errors()

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1907,27 +1907,6 @@ impl<'tcx> Visitor<'tcx> for CheckAttrVisitor<'tcx> {
     }
 
     fn visit_where_predicate(&mut self, where_predicate: &'tcx hir::WherePredicate<'tcx>) {
-        // FIXME(where_clause_attrs): Currently, as the following check shows,
-        // only `#[cfg]` and `#[cfg_attr]` are allowed, but it should be removed
-        // if we allow more attributes (e.g., tool attributes and `allow/deny/warn`)
-        // in where clauses. After that, only `self.check_attributes` should be enough.
-        let spans = self
-            .tcx
-            .hir_attrs(where_predicate.hir_id)
-            .iter()
-            // FIXME: We shouldn't need to special-case `doc`!
-            .filter(|attr| {
-                matches!(
-                    attr,
-                    Attribute::Parsed(AttributeKind::DocComment { .. } | AttributeKind::Doc(_))
-                        | Attribute::Unparsed(_)
-                )
-            })
-            .map(|attr| attr.span())
-            .collect::<Vec<_>>();
-        if !spans.is_empty() {
-            self.tcx.dcx().emit_err(errors::UnsupportedAttributesInWhere { span: spans.into() });
-        }
         self.check_attributes(
             where_predicate.hir_id,
             where_predicate.span,

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -3,8 +3,7 @@ use std::path::{Path, PathBuf};
 
 use rustc_errors::codes::*;
 use rustc_errors::{
-    Applicability, Diag, DiagCtxtHandle, DiagSymbolList, Diagnostic, EmissionGuarantee, Level,
-    MultiSpan, msg,
+    Diag, DiagCtxtHandle, DiagSymbolList, Diagnostic, EmissionGuarantee, Level, MultiSpan, msg,
 };
 use rustc_hir::Target;
 use rustc_macros::{Diagnostic, Subdiagnostic};
@@ -445,44 +444,6 @@ pub(crate) struct LangItemOnIncorrectTarget {
     pub name: Symbol,
     pub expected_target: Target,
     pub actual_target: Target,
-}
-
-pub(crate) struct InvalidAttrAtCrateLevel {
-    pub span: Span,
-    pub sugg_span: Option<Span>,
-    pub name: Symbol,
-    pub item: Option<ItemFollowingInnerAttr>,
-}
-
-#[derive(Clone, Copy)]
-pub(crate) struct ItemFollowingInnerAttr {
-    pub span: Span,
-    pub kind: &'static str,
-}
-
-impl<G: EmissionGuarantee> Diagnostic<'_, G> for InvalidAttrAtCrateLevel {
-    #[track_caller]
-    fn into_diag(self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
-        let mut diag =
-            Diag::new(dcx, level, msg!("`{$name}` attribute cannot be used at crate level"));
-        diag.span(self.span);
-        diag.arg("name", self.name);
-        // Only emit an error with a suggestion if we can create a string out
-        // of the attribute span
-        if let Some(span) = self.sugg_span {
-            diag.span_suggestion_verbose(
-                span,
-                msg!("perhaps you meant to use an outer attribute"),
-                String::new(),
-                Applicability::MachineApplicable,
-            );
-        }
-        if let Some(item) = self.item {
-            diag.arg("kind", item.kind);
-            diag.span_label(item.span, msg!("the inner attribute doesn't annotate this {$kind}"));
-        }
-        diag
-    }
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -1151,14 +1151,6 @@ pub(crate) struct RustcConstStableIndirectPairing {
 }
 
 #[derive(Diagnostic)]
-#[diag("most attributes are not supported in `where` clauses")]
-#[help("only `#[cfg]` and `#[cfg_attr]` are supported")]
-pub(crate) struct UnsupportedAttributesInWhere {
-    #[primary_span]
-    pub span: MultiSpan,
-}
-
-#[derive(Diagnostic)]
 pub(crate) enum UnexportableItem<'a> {
     #[diag("{$descr}'s are not exportable")]
     Item {

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -528,13 +528,6 @@ fn load_from_disk_or_invoke_provider_green<'tcx, C: QueryCache>(
         "missing on-disk cache entry for {dep_node:?}"
     );
 
-    // Sanity check for the logic in `ensure`: if the node is green and the result loadable,
-    // we should actually be able to load it.
-    debug_assert!(
-        !((query.will_cache_on_disk_for_key_fn)(tcx, key) && loadable_from_disk(tcx, prev_index)),
-        "missing on-disk cache entry for loadable {dep_node:?}"
-    );
-
     // We could not load a result from the on-disk cache, so
     // recompute.
     let prof_timer = tcx.prof.query_provider();

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -18,7 +18,7 @@ use tracing::warn;
 
 use crate::dep_graph::{DepNode, DepNodeIndex};
 use crate::job::{QueryJobInfo, QueryJobMap, find_cycle_in_stack, report_cycle};
-use crate::plumbing::{current_query_job, next_job_id, start_query};
+use crate::plumbing::{current_query_job, loadable_from_disk, next_job_id, start_query};
 use crate::query_impl::for_each_query_vtable;
 
 #[inline]
@@ -531,7 +531,7 @@ fn load_from_disk_or_invoke_provider_green<'tcx, C: QueryCache>(
     // Sanity check for the logic in `ensure`: if the node is green and the result loadable,
     // we should actually be able to load it.
     debug_assert!(
-        !(query.is_loadable_from_disk_fn)(tcx, key, prev_index),
+        !((query.will_cache_on_disk_for_key_fn)(tcx, key) && loadable_from_disk(tcx, prev_index)),
         "missing on-disk cache entry for loadable {dep_node:?}"
     );
 
@@ -624,7 +624,8 @@ fn check_if_ensure_can_skip_execution<'tcx, C: QueryCache>(
             // In ensure-done mode, we can only skip execution for this key if
             // there's a disk-cached value available to load later if needed,
             // which guarantees the query provider will never run for this key.
-            let is_loadable = (query.is_loadable_from_disk_fn)(tcx, key, serialized_dep_node_index);
+            let is_loadable = (query.will_cache_on_disk_for_key_fn)(tcx, key)
+                && loadable_from_disk(tcx, serialized_dep_node_index);
             EnsureCanSkip { skip_execution: is_loadable, dep_node: Some(dep_node) }
         }
     }

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -520,14 +520,6 @@ fn load_from_disk_or_invoke_provider_green<'tcx, C: QueryCache>(
         return value;
     }
 
-    // We always expect to find a cached result for things that
-    // can be forced from `DepNode`.
-    debug_assert!(
-        !(query.will_cache_on_disk_for_key_fn)(tcx, key)
-            || !tcx.key_fingerprint_style(dep_node.kind).is_maybe_recoverable(),
-        "missing on-disk cache entry for {dep_node:?}"
-    );
-
     // We could not load a result from the on-disk cache, so
     // recompute.
     let prof_timer = tcx.prof.query_provider();

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -488,65 +488,58 @@ fn load_from_disk_or_invoke_provider_green<'tcx, C: QueryCache>(
 
     debug_assert!(dep_graph_data.is_index_green(prev_index));
 
-    // First we try to load the result from the on-disk cache.
-    // Some things are never cached on disk.
-    if let Some(value) = (query.try_load_from_disk_fn)(tcx, key, prev_index, dep_node_index) {
-        if std::intrinsics::unlikely(tcx.sess.opts.unstable_opts.query_dep_graph) {
-            dep_graph_data.mark_debug_loaded_from_disk(*dep_node)
-        }
+    // First try to load the result from the on-disk cache. Some things are never cached on disk.
+    let value;
+    let verify;
+    match (query.try_load_from_disk_fn)(tcx, key, prev_index, dep_node_index) {
+        Some(loaded_value) => {
+            if std::intrinsics::unlikely(tcx.sess.opts.unstable_opts.query_dep_graph) {
+                dep_graph_data.mark_debug_loaded_from_disk(*dep_node)
+            }
 
-        let prev_fingerprint = dep_graph_data.prev_value_fingerprint_of(prev_index);
-        // If `-Zincremental-verify-ich` is specified, re-hash results from
-        // the cache and make sure that they have the expected fingerprint.
+            value = loaded_value;
+
+            let prev_fingerprint = dep_graph_data.prev_value_fingerprint_of(prev_index);
+            // If `-Zincremental-verify-ich` is specified, re-hash results from
+            // the cache and make sure that they have the expected fingerprint.
+            //
+            // If not, we still seek to verify a subset of fingerprints loaded
+            // from disk. Re-hashing results is fairly expensive, so we can't
+            // currently afford to verify every hash. This subset should still
+            // give us some coverage of potential bugs.
+            verify = prev_fingerprint.split().1.as_u64().is_multiple_of(32)
+                || tcx.sess.opts.unstable_opts.incremental_verify_ich;
+        }
+        None => {
+            // We could not load a result from the on-disk cache, so recompute. The dep-graph for
+            // this computation is already in-place, so we can just call the query provider.
+            let prof_timer = tcx.prof.query_provider();
+            value = tcx.dep_graph.with_ignore(|| (query.invoke_provider_fn)(tcx, key));
+            prof_timer.finish_with_query_invocation_id(dep_node_index.into());
+
+            verify = true;
+        }
+    };
+
+    if verify {
+        // Verify that re-running the query produced a result with the expected hash.
+        // This catches bugs in query implementations, turning them into ICEs.
+        // For example, a query might sort its result by `DefId` - since `DefId`s are
+        // not stable across compilation sessions, the result could get up getting sorted
+        // in a different order when the query is re-run, even though all of the inputs
+        // (e.g. `DefPathHash` values) were green.
         //
-        // If not, we still seek to verify a subset of fingerprints loaded
-        // from disk. Re-hashing results is fairly expensive, so we can't
-        // currently afford to verify every hash. This subset should still
-        // give us some coverage of potential bugs though.
-        let try_verify = prev_fingerprint.split().1.as_u64().is_multiple_of(32);
-        if std::intrinsics::unlikely(
-            try_verify || tcx.sess.opts.unstable_opts.incremental_verify_ich,
-        ) {
-            incremental_verify_ich(
-                tcx,
-                dep_graph_data,
-                &value,
-                prev_index,
-                query.hash_value_fn,
-                query.format_value,
-            );
-        }
-
-        return value;
+        // See issue #82920 for an example of a miscompilation that would get turned into
+        // an ICE by this check
+        incremental_verify_ich(
+            tcx,
+            dep_graph_data,
+            &value,
+            prev_index,
+            query.hash_value_fn,
+            query.format_value,
+        );
     }
-
-    // We could not load a result from the on-disk cache, so
-    // recompute.
-    let prof_timer = tcx.prof.query_provider();
-
-    // The dep-graph for this computation is already in-place.
-    // Call the query provider.
-    let value = tcx.dep_graph.with_ignore(|| (query.invoke_provider_fn)(tcx, key));
-
-    prof_timer.finish_with_query_invocation_id(dep_node_index.into());
-
-    // Verify that re-running the query produced a result with the expected hash
-    // This catches bugs in query implementations, turning them into ICEs.
-    // For example, a query might sort its result by `DefId` - since `DefId`s are
-    // not stable across compilation sessions, the result could get up getting sorted
-    // in a different order when the query is re-run, even though all of the inputs
-    // (e.g. `DefPathHash` values) were green.
-    //
-    // See issue #82920 for an example of a miscompilation that would get turned into
-    // an ICE by this check
-    incremental_verify_ich(
-        tcx,
-        dep_graph_data,
-        &value,
-        prev_index,
-        query.hash_value_fn,
-        query.format_value,
-    );
 
     value
 }

--- a/compiler/rustc_query_impl/src/query_impl.rs
+++ b/compiler/rustc_query_impl/src/query_impl.rs
@@ -165,14 +165,6 @@ macro_rules! define_queries {
                         #[cfg(not($cache_on_disk))]
                         try_load_from_disk_fn: |_tcx, _key, _prev_index, _index| None,
 
-                        #[cfg($cache_on_disk)]
-                        is_loadable_from_disk_fn: |tcx, key, index| -> bool {
-                            rustc_middle::queries::_cache_on_disk_if_fns::$name(tcx, key) &&
-                                $crate::plumbing::loadable_from_disk(tcx, index)
-                        },
-                        #[cfg(not($cache_on_disk))]
-                        is_loadable_from_disk_fn: |_tcx, _key, _index| false,
-
                         // The default just emits `err` and then aborts.
                         // `from_cycle_error::specialize_query_vtables` overwrites this default for
                         // certain queries.

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -756,8 +756,10 @@ static WASM_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     // tidy-alphabetical-end
 ];
 
-const BPF_FEATURES: &[(&str, Stability, ImpliedFeatures)] =
-    &[("alu32", Unstable(sym::bpf_target_feature), &[])];
+const BPF_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
+    ("alu32", Unstable(sym::bpf_target_feature), &[]),
+    ("allows-misaligned-mem-access", Unstable(sym::bpf_target_feature), &[]),
+];
 
 static CSKY_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     // tidy-alphabetical-start

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -2299,6 +2299,11 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             // FIXME: this could use a better heuristic, like just checking
             // that args[1..] is the same.
             let all_traits_equal = traits.len() == 1;
+            let mut types: Vec<_> =
+                candidates.iter().map(|(c, _)| c.self_ty().to_string()).collect();
+            types.sort();
+            types.dedup();
+            let all_types_equal = types.len() == 1;
 
             let end = if candidates.len() <= 9 || self.tcx.sess.opts.verbose {
                 candidates.len()
@@ -2312,6 +2317,11 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 for (c, def_id) in &candidates {
                     let msg = if all_traits_equal {
                         format!("`{}`", self.tcx.short_string(c.self_ty(), err.long_ty_path()))
+                    } else if all_types_equal {
+                        format!(
+                            "`{}`",
+                            self.tcx.short_string(c.print_only_trait_path(), err.long_ty_path())
+                        )
                     } else {
                         format!(
                             "`{}` implements `{}`",
@@ -2321,13 +2331,19 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     };
                     span.push_span_label(self.tcx.def_span(*def_id), msg);
                 }
-                err.span_help(
-                    span,
+                let msg = if all_types_equal {
+                    format!(
+                        "`{}` implements trait `{}`",
+                        self.tcx.short_string(candidates[0].0.self_ty(), err.long_ty_path()),
+                        self.tcx.short_string(trait_ref.print_trait_sugared(), err.long_ty_path()),
+                    )
+                } else {
                     format!(
                         "the following {other}types implement trait `{}`",
-                        trait_ref.print_trait_sugared(),
-                    ),
-                );
+                        self.tcx.short_string(trait_ref.print_trait_sugared(), err.long_ty_path()),
+                    )
+                };
+                err.span_help(span, msg);
             } else {
                 let candidate_names: Vec<String> = candidates
                     .iter()
@@ -2336,6 +2352,12 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                             format!(
                                 "\n  {}",
                                 self.tcx.short_string(c.self_ty(), err.long_ty_path())
+                            )
+                        } else if all_types_equal {
+                            format!(
+                                "\n  {}",
+                                self.tcx
+                                    .short_string(c.print_only_trait_path(), err.long_ty_path())
                             )
                         } else {
                             format!(
@@ -2347,9 +2369,21 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         }
                     })
                     .collect();
+                let msg = if all_types_equal {
+                    format!(
+                        "`{}` implements trait `{}`",
+                        self.tcx.short_string(candidates[0].0.self_ty(), err.long_ty_path()),
+                        self.tcx.short_string(trait_ref.print_trait_sugared(), err.long_ty_path()),
+                    )
+                } else {
+                    format!(
+                        "the following {other}types implement trait `{}`",
+                        self.tcx.short_string(trait_ref.print_trait_sugared(), err.long_ty_path()),
+                    )
+                };
+
                 err.help(format!(
-                    "the following {other}types implement trait `{}`:{}{}",
-                    trait_ref.print_trait_sugared(),
+                    "{msg}:{}{}",
                     candidate_names[..end].join(""),
                     if candidates.len() > 9 && !self.tcx.sess.opts.verbose {
                         format!("\nand {} others", candidates.len() - 8)

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2502,14 +2502,6 @@ pub(crate) macro const_eval_select {
 /// particular value, ever. However, the compiler will generally make it
 /// return `true` only if the value of the argument is actually known.
 ///
-/// # Stability concerns
-///
-/// While it is safe to call, this intrinsic may behave differently in
-/// a `const` context than otherwise. See the [`const_eval_select()`]
-/// documentation for an explanation of the issues this can cause. Unlike
-/// `const_eval_select`, this intrinsic isn't guaranteed to behave
-/// deterministically even in a `const` context.
-///
 /// # Type Requirements
 ///
 /// `T` must be either a `bool`, a `char`, a primitive numeric type (e.g. `f32`,

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2590,6 +2590,12 @@ pub const unsafe fn typed_swap_nonoverlapping<T>(x: *mut T, y: *mut T) {
 /// assertions are enabled whenever the *user crate* has UB checks enabled. However, if the
 /// user has UB checks disabled, the checks will still get optimized out. This intrinsic is
 /// primarily used by [`crate::ub_checks::assert_unsafe_precondition`].
+///
+/// # Consteval
+///
+/// In consteval, this function currently returns `true`. This is because the value of the `ub_checks`
+/// configuration can differ across crates, but we need this function to always return the same
+/// value in consteval in order to avoid unsoundness.
 #[rustc_intrinsic_const_stable_indirect] // just for UB checks
 #[inline(always)]
 #[rustc_intrinsic]
@@ -2609,6 +2615,12 @@ pub const fn ub_checks() -> bool {
 /// `#[inline]`), gating assertions on `overflow_checks()` rather than `cfg!(overflow_checks)` means that
 /// assertions are enabled whenever the *user crate* has overflow checks enabled. However if the
 /// user has overflow checks disabled, the checks will still get optimized out.
+///
+/// # Consteval
+///
+/// In consteval, this function currently returns `true`. This is because the value of the `overflow_checks`
+/// configuration can differ across crates, but we need this function to always return the same
+/// value in consteval in order to avoid unsoundness.
 #[inline(always)]
 #[rustc_intrinsic]
 pub const fn overflow_checks() -> bool {

--- a/library/core/src/range/iter.rs
+++ b/library/core/src/range/iter.rs
@@ -298,9 +298,9 @@ range_incl_exact_iter_impl! {
 #[derive(Debug, Clone)]
 pub struct RangeFromIter<A> {
     start: A,
-    /// Whether the first element of the iterator has yielded.
+    /// Whether the maximum value of the iterator has yielded.
     /// Only used when overflow checks are enabled.
-    first: bool,
+    exhausted: bool,
 }
 
 impl<A: Step> RangeFromIter<A> {
@@ -309,10 +309,12 @@ impl<A: Step> RangeFromIter<A> {
     #[rustc_inherit_overflow_checks]
     #[unstable(feature = "new_range_api", issue = "125687")]
     pub fn remainder(self) -> RangeFrom<A> {
-        if intrinsics::overflow_checks() {
-            if !self.first {
-                return RangeFrom { start: Step::forward(self.start, 1) };
-            }
+        // Need to handle this case even if overflow-checks are disabled,
+        // because a `RangeFromIter` could be exhausted in a crate with
+        // overflow-checks enabled, but then passed to a crate with them
+        // disabled before this is called.
+        if self.exhausted {
+            return RangeFrom { start: Step::forward(self.start, 1) };
         }
 
         RangeFrom { start: self.start }
@@ -326,14 +328,29 @@ impl<A: Step> Iterator for RangeFromIter<A> {
     #[inline]
     #[rustc_inherit_overflow_checks]
     fn next(&mut self) -> Option<A> {
-        if intrinsics::overflow_checks() {
-            if self.first {
-                self.first = false;
-                return Some(self.start.clone());
-            }
-
+        if self.exhausted {
+            // This should panic if overflow checks are enabled, since
+            // `forward_checked` returned `None` in prior iteration.
             self.start = Step::forward(self.start.clone(), 1);
-            return Some(self.start.clone());
+
+            // If we get here, if means this iterator was exhausted by a crate
+            // with overflow-checks enabled, but now we're iterating in a crate with
+            // overflow-checks disabled. Since we successfully incremented `self.start`
+            // above (in many cases this will wrap around to MIN), we now unset
+            // the flag so we don't repeat this process in the next iteration.
+            //
+            // This could also happen if `forward_checked` returned None but
+            // (for whatever reason, not applicable to any std implementors)
+            // `forward` doesn't panic when overflow-checks are enabled. In that
+            // case, this is also the correct behavior.
+            self.exhausted = false;
+        }
+        if intrinsics::overflow_checks() {
+            let Some(n) = Step::forward_checked(self.start.clone(), 1) else {
+                self.exhausted = true;
+                return Some(self.start.clone());
+            };
+            return Some(mem::replace(&mut self.start, n));
         }
 
         let n = Step::forward(self.start.clone(), 1);
@@ -348,18 +365,22 @@ impl<A: Step> Iterator for RangeFromIter<A> {
     #[inline]
     #[rustc_inherit_overflow_checks]
     fn nth(&mut self, n: usize) -> Option<A> {
+        // Typically `forward` will cause an overflow-check panic here,
+        // but unset the exhausted flag to handle the uncommon cases.
+        // See the comments in `next` for more details.
+        if self.exhausted {
+            self.start = Step::forward(self.start.clone(), 1);
+            self.exhausted = false;
+        }
         if intrinsics::overflow_checks() {
-            if self.first {
-                self.first = false;
-
-                let plus_n = Step::forward(self.start.clone(), n);
-                self.start = plus_n.clone();
-                return Some(plus_n);
-            }
-
             let plus_n = Step::forward(self.start.clone(), n);
-            self.start = Step::forward(plus_n.clone(), 1);
-            return Some(self.start.clone());
+            if let Some(plus_n1) = Step::forward_checked(plus_n.clone(), 1) {
+                self.start = plus_n1;
+            } else {
+                self.start = plus_n.clone();
+                self.exhausted = true;
+            }
+            return Some(plus_n);
         }
 
         let plus_n = Step::forward(self.start.clone(), n);
@@ -380,6 +401,6 @@ impl<A: Step> IntoIterator for RangeFrom<A> {
     type IntoIter = RangeFromIter<A>;
 
     fn into_iter(self) -> Self::IntoIter {
-        RangeFromIter { start: self.start, first: true }
+        RangeFromIter { start: self.start, exhausted: false }
     }
 }

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -62,7 +62,7 @@ path = "../windows_link"
 rand = { version = "0.9.0", default-features = false, features = ["alloc"] }
 rand_xorshift = "0.4.0"
 
-[target.'cfg(any(all(target_family = "wasm", not(target_os = "wasi")), target_os = "xous", target_os = "vexos", all(target_vendor = "fortanix", target_env = "sgx")))'.dependencies]
+[target.'cfg(any(all(target_family = "wasm", not(any(unix, target_os = "wasi"))), target_os = "xous", target_os = "vexos", all(target_vendor = "fortanix", target_env = "sgx")))'.dependencies]
 dlmalloc = { version = "0.2.10", features = ['rustc-dep-of-std'] }
 
 [target.x86_64-fortanix-unknown-sgx.dependencies]

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -62,7 +62,7 @@ path = "../windows_link"
 rand = { version = "0.9.0", default-features = false, features = ["alloc"] }
 rand_xorshift = "0.4.0"
 
-[target.'cfg(any(all(target_family = "wasm", target_os = "unknown"), target_os = "xous", target_os = "vexos", all(target_vendor = "fortanix", target_env = "sgx")))'.dependencies]
+[target.'cfg(any(all(target_family = "wasm", not(target_os = "wasi")), target_os = "xous", target_os = "vexos", all(target_vendor = "fortanix", target_env = "sgx")))'.dependencies]
 dlmalloc = { version = "0.2.10", features = ['rustc-dep-of-std'] }
 
 [target.x86_64-fortanix-unknown-sgx.dependencies]

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -883,6 +883,12 @@ impl Build {
             features.push("check_only");
         }
 
+        if crates.iter().any(|c| c == "rustc_transmute") {
+            // for `x test rustc_transmute`, this feature isn't enabled automatically by a
+            // dependent crate.
+            features.push("rustc");
+        }
+
         // If debug logging is on, then we want the default for tracing:
         // https://github.com/tokio-rs/tracing/blob/3dd5c03d907afdf2c39444a29931833335171554/tracing/src/level_filters.rs#L26
         // which is everything (including debug/trace/etc.)

--- a/src/tools/clippy/tests/ui/unnested_or_patterns2.fixed
+++ b/src/tools/clippy/tests/ui/unnested_or_patterns2.fixed
@@ -23,6 +23,6 @@ fn main() {
     //~^ unnested_or_patterns
     if let box (0 | 1 | 2 | 3 | 4) = Box::new(0) {}
     //~^ unnested_or_patterns
-    if let box box (0 | 2 | 4) = Box::new(Box::new(0)) {}
+    if let box (box (0 | 2 | 4)) = Box::new(Box::new(0)) {}
     //~^ unnested_or_patterns
 }

--- a/src/tools/clippy/tests/ui/unnested_or_patterns2.stderr
+++ b/src/tools/clippy/tests/ui/unnested_or_patterns2.stderr
@@ -93,7 +93,7 @@ LL |     if let box box 0 | box (box 2 | box 4) = Box::new(Box::new(0)) {}
 help: nest the patterns
    |
 LL -     if let box box 0 | box (box 2 | box 4) = Box::new(Box::new(0)) {}
-LL +     if let box box (0 | 2 | 4) = Box::new(Box::new(0)) {}
+LL +     if let box (box (0 | 2 | 4)) = Box::new(Box::new(0)) {}
    |
 
 error: aborting due to 8 previous errors

--- a/src/tools/rust-analyzer/crates/hir-ty/src/target_feature.rs
+++ b/src/tools/rust-analyzer/crates/hir-ty/src/target_feature.rs
@@ -217,6 +217,7 @@ const TARGET_FEATURE_IMPLICATIONS_RAW: &[(&str, &[&str])] = &[
     ("relaxed-simd", &["simd128"]),
     // BPF
     ("alu32", &[]),
+    ("allows-misaligned-mem-access", &[]),
     // CSKY
     ("10e60", &["7e10"]),
     ("2e3", &["e2"]),

--- a/tests/assembly-llvm/bpf_unaligned.rs
+++ b/tests/assembly-llvm/bpf_unaligned.rs
@@ -1,0 +1,27 @@
+//@ add-minicore
+//@ assembly-output: emit-asm
+//@ compile-flags: --target bpfel-unknown-none -C target_feature=+allows-misaligned-mem-access
+//@ min-llvm-version: 22
+//@ needs-llvm-components: bpf
+#![feature(no_core)]
+#![crate_type = "rlib"]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
+
+// CHECK-LABEL: test_load_i64:
+// CHECK:       r0 = *(u64 *)(r1 + 0)
+#[no_mangle]
+pub unsafe fn test_load_i64(p: *const u64) -> u64 {
+    let mut tmp: u64 = 0;
+    copy_nonoverlapping(p as *const u8, &mut tmp as *mut u64 as *mut u8, 8);
+    tmp
+}
+
+// CHECK-LABEL: test_store_i64:
+// CHECK:       *(u64 *)(r1 + 0) = r2
+#[no_mangle]
+pub unsafe fn test_store_i64(p: *mut u64, v: u64) {
+    copy_nonoverlapping(&v as *const u64 as *const u8, p as *mut u8, 8);
+}

--- a/tests/auxiliary/minicore.rs
+++ b/tests/auxiliary/minicore.rs
@@ -275,6 +275,10 @@ trait Drop {
     fn drop(&mut self);
 }
 
+#[rustc_nounwind]
+#[rustc_intrinsic]
+pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
+
 pub mod mem {
     #[rustc_nounwind]
     #[rustc_intrinsic]

--- a/tests/codegen-llvm/bpf-allows-unaligned.rs
+++ b/tests/codegen-llvm/bpf-allows-unaligned.rs
@@ -1,0 +1,11 @@
+//@ only-bpf
+#![crate_type = "lib"]
+#![feature(bpf_target_feature)]
+#![no_std]
+
+#[no_mangle]
+#[target_feature(enable = "allows-misaligned-mem-access")]
+// CHECK: define noundef zeroext i8 @foo(i8 noundef returned %arg) unnamed_addr #0 {
+pub unsafe fn foo(arg: u8) -> u8 {
+    arg
+}

--- a/tests/codegen-llvm/fromrangeiter-overflow-checks.rs
+++ b/tests/codegen-llvm/fromrangeiter-overflow-checks.rs
@@ -2,7 +2,7 @@
 // runtime check that panics after yielding the maximum value of the range bound type. That is
 // tested for by tests/ui/iterators/rangefrom-overflow-overflow-checks.rs
 //
-// This test ensures that such a runtime check is *not* emitted when debug-assertions are
+// This test ensures such runtime checks are optimized out when debug-assertions are
 // enabled, but overflow-checks are explicitly disabled.
 
 //@ revisions: DEBUG NOCHECKS
@@ -11,17 +11,24 @@
 
 #![crate_type = "lib"]
 #![feature(new_range_api)]
-use std::range::{RangeFrom, RangeFromIter};
+use std::range::RangeFrom;
 
-// CHECK-LABEL: @iterrangefrom_remainder(
+// CHECK-LABEL: @rangefrom_increments(
 #[no_mangle]
-pub unsafe fn iterrangefrom_remainder(x: RangeFromIter<i32>) -> RangeFrom<i32> {
-    //        DEBUG: i32 noundef %x
-    //     NOCHECKS: i32 noundef returned %x
-    //        DEBUG: br i1
-    //        DEBUG: call core::panicking::panic_const::panic_const_add_overflow
-    //        DEBUG: unreachable
-    // NOCHECKS-NOT: unreachable
-    //     NOCHECKS: ret i32 %x
-    x.remainder()
+pub unsafe fn rangefrom_increments(range: RangeFrom<i32>) -> RangeFrom<i32> {
+    // Iterator is contained entirely within this function, so the optimizer should
+    // be able to see that `exhausted` is never set and optimize out any branches.
+
+    //         CHECK: i32 noundef %range
+    //         DEBUG: switch i32 %range
+    //         DEBUG: call core::panicking::panic_const::panic_const_add_overflow
+    //         DEBUG: unreachable
+    //  NOCHECKS-NOT: unreachable
+    //      NOCHECKS: [[REM:%[a-z_0-9.]+]] = add i32 %range, 2
+    // NOCHECKS-NEXT: ret i32 [[REM]]
+
+    let mut iter = range.into_iter();
+    let _ = iter.next();
+    let _ = iter.next();
+    iter.remainder()
 }

--- a/tests/pretty/or-pattern-paren.pp
+++ b/tests/pretty/or-pattern-paren.pp
@@ -1,0 +1,27 @@
+#![feature(prelude_import)]
+#![no_std]
+#![feature(box_patterns)]
+extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+
+//@ pretty-compare-only
+//@ pretty-mode:expanded
+//@ pp-exact:or-pattern-paren.pp
+
+macro_rules! or_pat { ($($name:pat),+) => { $($name)|+ } }
+
+fn check_at(x: Option<i32>) {
+    match x {
+        Some(v @ (1 | 2 | 3)) =>
+
+
+            {
+            ::std::io::_print(format_args!("{0}\n", v));
+        }
+        _ => {}
+    }
+}
+fn check_ref(x: &i32) { match x { &(1 | 2 | 3) => {} _ => {} } }
+fn check_box(x: Box<i32>) { match x { box (1 | 2 | 3) => {} _ => {} } }
+fn main() { check_at(Some(2)); check_ref(&1); check_box(Box::new(1)); }

--- a/tests/pretty/or-pattern-paren.rs
+++ b/tests/pretty/or-pattern-paren.rs
@@ -1,0 +1,36 @@
+#![feature(box_patterns)]
+
+//@ pretty-compare-only
+//@ pretty-mode:expanded
+//@ pp-exact:or-pattern-paren.pp
+
+macro_rules! or_pat {
+    ($($name:pat),+) => { $($name)|+ }
+}
+
+fn check_at(x: Option<i32>) {
+    match x {
+        Some(v @ or_pat!(1, 2, 3)) => println!("{v}"),
+        _ => {}
+    }
+}
+
+fn check_ref(x: &i32) {
+    match x {
+        &or_pat!(1, 2, 3) => {}
+        _ => {}
+    }
+}
+
+fn check_box(x: Box<i32>) {
+    match x {
+        box or_pat!(1, 2, 3) => {}
+        _ => {}
+    }
+}
+
+fn main() {
+    check_at(Some(2));
+    check_ref(&1);
+    check_box(Box::new(1));
+}

--- a/tests/run-make/crate-loading/multiple-dep-versions.stderr
+++ b/tests/run-make/crate-loading/multiple-dep-versions.stderr
@@ -177,14 +177,14 @@ LL |     Err(Error2)?;
    |     this can't be annotated with `?` because it has type `Result<_, Error2>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-help: the following other types implement trait `From<T>`
+help: `dependency::OtherError` implements trait `From<T>`
   --> replaced
    |
 LL | impl From<()> for OtherError {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dependency::OtherError` implements `From<()>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `From<()>`
 ...
 LL | impl From<i32> for OtherError {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dependency::OtherError` implements `From<i32>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `From<i32>`
    = note: there are multiple different versions of crate `dependency` in the dependency graph
    = help: you can use `cargo tree` to explore your dependency tree
 

--- a/tests/ui/asm/aarch64/bad-options.stderr
+++ b/tests/ui/asm/aarch64/bad-options.stderr
@@ -78,7 +78,7 @@ error: invalid ABI for `clobber_abi`
 LL |         asm!("", clobber_abi("foo"));
    |                  ^^^^^^^^^^^^^^^^^^
    |
-   = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`
+   = note: the following ABIs are supported on this target: `C`, `system`, and `efiapi`
 
 error: aborting due to 13 previous errors
 

--- a/tests/ui/asm/aarch64/bad-reg.rs
+++ b/tests/ui/asm/aarch64/bad-reg.rs
@@ -1,7 +1,12 @@
+//@ add-minicore
 //@ only-aarch64
 //@ compile-flags: -C target-feature=+neon
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
 
-use std::arch::asm;
+extern crate minicore;
+use minicore::*;
 
 fn main() {
     let mut foo = 0;
@@ -14,11 +19,11 @@ fn main() {
         asm!("", in("foo") foo);
         //~^ ERROR invalid register `foo`: unknown register
         asm!("{:z}", in(reg) foo);
-        //~^ ERROR invalid asm template modifier for this register class
+        //~^ ERROR invalid asm template modifier `z` for this register class
         asm!("{:r}", in(vreg) foo);
-        //~^ ERROR invalid asm template modifier for this register class
+        //~^ ERROR invalid asm template modifier `r` for this register class
         asm!("{:r}", in(vreg_low16) foo);
-        //~^ ERROR invalid asm template modifier for this register class
+        //~^ ERROR invalid asm template modifier `r` for this register class
         asm!("{:a}", const 0);
         //~^ ERROR asm template modifiers are not allowed for `const` arguments
         asm!("{:a}", sym main);

--- a/tests/ui/asm/aarch64/bad-reg.stderr
+++ b/tests/ui/asm/aarch64/bad-reg.stderr
@@ -1,49 +1,49 @@
 error: invalid register class `foo`: unknown register class
-  --> $DIR/bad-reg.rs:12:20
+  --> $DIR/bad-reg.rs:17:20
    |
 LL |         asm!("{}", in(foo) foo);
    |                    ^^^^^^^^^^^
    |
-   = note: the following register classes are supported on this target: `reg`, `vreg`, `vreg_low16`, `preg`
+   = note: the following register classes are supported on this target: `reg`, `vreg`, `vreg_low16`, and `preg`
 
 error: invalid register `foo`: unknown register
-  --> $DIR/bad-reg.rs:14:18
+  --> $DIR/bad-reg.rs:19:18
    |
 LL |         asm!("", in("foo") foo);
    |                  ^^^^^^^^^^^^^
 
-error: invalid asm template modifier for this register class
-  --> $DIR/bad-reg.rs:16:15
+error: invalid asm template modifier `z` for this register class
+  --> $DIR/bad-reg.rs:21:15
    |
 LL |         asm!("{:z}", in(reg) foo);
    |               ^^^^   ----------- argument
    |               |
    |               template modifier
    |
-   = note: the `reg` register class supports the following template modifiers: `w`, `x`
+   = note: the `reg` register class supports the following template modifiers: `w` and `x`
 
-error: invalid asm template modifier for this register class
-  --> $DIR/bad-reg.rs:18:15
+error: invalid asm template modifier `r` for this register class
+  --> $DIR/bad-reg.rs:23:15
    |
 LL |         asm!("{:r}", in(vreg) foo);
    |               ^^^^   ------------ argument
    |               |
    |               template modifier
    |
-   = note: the `vreg` register class supports the following template modifiers: `b`, `h`, `s`, `d`, `q`, `v`
+   = note: the `vreg` register class supports the following template modifiers: `b`, `h`, `s`, `d`, `q`, and `v`
 
-error: invalid asm template modifier for this register class
-  --> $DIR/bad-reg.rs:20:15
+error: invalid asm template modifier `r` for this register class
+  --> $DIR/bad-reg.rs:25:15
    |
 LL |         asm!("{:r}", in(vreg_low16) foo);
    |               ^^^^   ------------------ argument
    |               |
    |               template modifier
    |
-   = note: the `vreg_low16` register class supports the following template modifiers: `b`, `h`, `s`, `d`, `q`, `v`
+   = note: the `vreg_low16` register class supports the following template modifiers: `b`, `h`, `s`, `d`, `q`, and `v`
 
 error: asm template modifiers are not allowed for `const` arguments
-  --> $DIR/bad-reg.rs:22:15
+  --> $DIR/bad-reg.rs:27:15
    |
 LL |         asm!("{:a}", const 0);
    |               ^^^^   ------- argument
@@ -51,7 +51,7 @@ LL |         asm!("{:a}", const 0);
    |               template modifier
 
 error: asm template modifiers are not allowed for `sym` arguments
-  --> $DIR/bad-reg.rs:24:15
+  --> $DIR/bad-reg.rs:29:15
    |
 LL |         asm!("{:a}", sym main);
    |               ^^^^   -------- argument
@@ -59,49 +59,49 @@ LL |         asm!("{:a}", sym main);
    |               template modifier
 
 error: invalid register `x29`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:26:18
+  --> $DIR/bad-reg.rs:31:18
    |
 LL |         asm!("", in("x29") foo);
    |                  ^^^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:28:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", in("sp") foo);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `xzr`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:30:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", in("xzr") foo);
    |                  ^^^^^^^^^^^^^
 
 error: invalid register `x19`: x19 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:32:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", in("x19") foo);
    |                  ^^^^^^^^^^^^^
 
 error: register class `preg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:35:18
+  --> $DIR/bad-reg.rs:40:18
    |
 LL |         asm!("", in("p0") foo);
    |                  ^^^^^^^^^^^^
 
 error: register class `preg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:39:20
+  --> $DIR/bad-reg.rs:44:20
    |
 LL |         asm!("{}", in(preg) foo);
    |                    ^^^^^^^^^^^^
 
 error: register class `preg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:42:20
+  --> $DIR/bad-reg.rs:47:20
    |
 LL |         asm!("{}", out(preg) _);
    |                    ^^^^^^^^^^^
 
 error: register `w0` conflicts with register `x0`
-  --> $DIR/bad-reg.rs:48:32
+  --> $DIR/bad-reg.rs:53:32
    |
 LL |         asm!("", in("x0") foo, in("w0") bar);
    |                  ------------  ^^^^^^^^^^^^ register `w0`
@@ -109,7 +109,7 @@ LL |         asm!("", in("x0") foo, in("w0") bar);
    |                  register `x0`
 
 error: register `x0` conflicts with register `x0`
-  --> $DIR/bad-reg.rs:50:32
+  --> $DIR/bad-reg.rs:55:32
    |
 LL |         asm!("", in("x0") foo, out("x0") bar);
    |                  ------------  ^^^^^^^^^^^^^ register `x0`
@@ -117,13 +117,13 @@ LL |         asm!("", in("x0") foo, out("x0") bar);
    |                  register `x0`
    |
 help: use `lateout` instead of `out` to avoid conflict
-  --> $DIR/bad-reg.rs:50:18
+  --> $DIR/bad-reg.rs:55:18
    |
 LL |         asm!("", in("x0") foo, out("x0") bar);
    |                  ^^^^^^^^^^^^
 
 error: register `q0` conflicts with register `v0`
-  --> $DIR/bad-reg.rs:53:32
+  --> $DIR/bad-reg.rs:58:32
    |
 LL |         asm!("", in("v0") foo, in("q0") bar);
    |                  ------------  ^^^^^^^^^^^^ register `q0`
@@ -131,7 +131,7 @@ LL |         asm!("", in("v0") foo, in("q0") bar);
    |                  register `v0`
 
 error: register `q0` conflicts with register `v0`
-  --> $DIR/bad-reg.rs:55:32
+  --> $DIR/bad-reg.rs:60:32
    |
 LL |         asm!("", in("v0") foo, out("q0") bar);
    |                  ------------  ^^^^^^^^^^^^^ register `q0`
@@ -139,13 +139,13 @@ LL |         asm!("", in("v0") foo, out("q0") bar);
    |                  register `v0`
    |
 help: use `lateout` instead of `out` to avoid conflict
-  --> $DIR/bad-reg.rs:55:18
+  --> $DIR/bad-reg.rs:60:18
    |
 LL |         asm!("", in("v0") foo, out("q0") bar);
    |                  ^^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:35:27
+  --> $DIR/bad-reg.rs:40:27
    |
 LL |         asm!("", in("p0") foo);
    |                           ^^^
@@ -153,7 +153,7 @@ LL |         asm!("", in("p0") foo);
    = note: register class `preg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:39:29
+  --> $DIR/bad-reg.rs:44:29
    |
 LL |         asm!("{}", in(preg) foo);
    |                             ^^^

--- a/tests/ui/asm/x86_64/bad-clobber-abi.stderr
+++ b/tests/ui/asm/x86_64/bad-clobber-abi.stderr
@@ -4,7 +4,7 @@ error: invalid ABI for `clobber_abi`
 LL |         asm!("", clobber_abi("foo"));
    |                  ^^^^^^^^^^^^^^^^^^
    |
-   = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, `sysv64`
+   = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, and `sysv64`
 
 error: invalid ABI for `clobber_abi`
   --> $DIR/bad-clobber-abi.rs:13:35
@@ -12,7 +12,7 @@ error: invalid ABI for `clobber_abi`
 LL |         asm!("", clobber_abi("C", "foo"));
    |                                   ^^^^^
    |
-   = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, `sysv64`
+   = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, and `sysv64`
 
 error: `C` ABI specified multiple times
   --> $DIR/bad-clobber-abi.rs:15:35
@@ -38,7 +38,7 @@ error: invalid ABI for `clobber_abi`
 LL |         asm!("", clobber_abi("C", "foo", "C"));
    |                                   ^^^^^
    |
-   = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, `sysv64`
+   = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, and `sysv64`
 
 error: `C` ABI specified multiple times
   --> $DIR/bad-clobber-abi.rs:20:42
@@ -54,7 +54,7 @@ error: invalid ABI for `clobber_abi`
 LL |         asm!("", clobber_abi("win64", "foo", "efiapi"));
    |                                       ^^^^^
    |
-   = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, `sysv64`
+   = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, and `sysv64`
 
 error: `win64` ABI specified multiple times
   --> $DIR/bad-clobber-abi.rs:23:46

--- a/tests/ui/asm/x86_64/bad-options.stderr
+++ b/tests/ui/asm/x86_64/bad-options.stderr
@@ -93,7 +93,7 @@ error: invalid ABI for `clobber_abi`
 LL |         asm!("", clobber_abi("foo"));
    |                  ^^^^^^^^^^^^^^^^^^
    |
-   = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, `sysv64`
+   = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, and `sysv64`
 
 error: `C` ABI specified multiple times
   --> $DIR/bad-options.rs:28:52

--- a/tests/ui/asm/x86_64/bad-reg.experimental_reg.stderr
+++ b/tests/ui/asm/x86_64/bad-reg.experimental_reg.stderr
@@ -4,7 +4,7 @@ error: invalid register class `foo`: unknown register class
 LL |         asm!("{}", in(foo) foo);
    |                    ^^^^^^^^^^^
    |
-   = note: the following register classes are supported on this target: `reg`, `reg_abcd`, `reg_byte`, `xmm_reg`, `ymm_reg`, `zmm_reg`, `kreg`, `kreg0`, `mmx_reg`, `x87_reg`, `tmm_reg`
+   = note: the following register classes are supported on this target: `reg`, `reg_abcd`, `reg_byte`, `xmm_reg`, `ymm_reg`, `zmm_reg`, `kreg`, `kreg0`, `mmx_reg`, `x87_reg`, and `tmm_reg`
 
 error: invalid register `foo`: unknown register
   --> $DIR/bad-reg.rs:22:18
@@ -12,7 +12,7 @@ error: invalid register `foo`: unknown register
 LL |         asm!("", in("foo") foo);
    |                  ^^^^^^^^^^^^^
 
-error: invalid asm template modifier for this register class
+error: invalid asm template modifier `z` for this register class
   --> $DIR/bad-reg.rs:24:15
    |
 LL |         asm!("{:z}", in(reg) foo);
@@ -20,9 +20,9 @@ LL |         asm!("{:z}", in(reg) foo);
    |               |
    |               template modifier
    |
-   = note: the `reg` register class supports the following template modifiers: `l`, `x`, `e`, `r`
+   = note: the `reg` register class supports the following template modifiers: `l`, `x`, `e`, and `r`
 
-error: invalid asm template modifier for this register class
+error: invalid asm template modifier `r` for this register class
   --> $DIR/bad-reg.rs:26:15
    |
 LL |         asm!("{:r}", in(xmm_reg) foo);
@@ -30,7 +30,7 @@ LL |         asm!("{:r}", in(xmm_reg) foo);
    |               |
    |               template modifier
    |
-   = note: the `xmm_reg` register class supports the following template modifiers: `x`, `y`, `z`
+   = note: the `xmm_reg` register class supports the following template modifiers: `x`, `y`, and `z`
 
 error: asm template modifiers are not allowed for `const` arguments
   --> $DIR/bad-reg.rs:28:15

--- a/tests/ui/asm/x86_64/bad-reg.rs
+++ b/tests/ui/asm/x86_64/bad-reg.rs
@@ -22,9 +22,9 @@ fn main() {
         asm!("", in("foo") foo);
         //~^ ERROR invalid register `foo`: unknown register
         asm!("{:z}", in(reg) foo);
-        //~^ ERROR invalid asm template modifier for this register class
+        //~^ ERROR invalid asm template modifier `z` for this register class
         asm!("{:r}", in(xmm_reg) foo);
-        //~^ ERROR invalid asm template modifier for this register class
+        //~^ ERROR invalid asm template modifier `r` for this register class
         asm!("{:a}", const 0);
         //~^ ERROR asm template modifiers are not allowed for `const` arguments
         asm!("{:a}", sym main);

--- a/tests/ui/asm/x86_64/bad-reg.stable.stderr
+++ b/tests/ui/asm/x86_64/bad-reg.stable.stderr
@@ -4,7 +4,7 @@ error: invalid register class `foo`: unknown register class
 LL |         asm!("{}", in(foo) foo);
    |                    ^^^^^^^^^^^
    |
-   = note: the following register classes are supported on this target: `reg`, `reg_abcd`, `reg_byte`, `xmm_reg`, `ymm_reg`, `zmm_reg`, `kreg`, `kreg0`, `mmx_reg`, `x87_reg`, `tmm_reg`
+   = note: the following register classes are supported on this target: `reg`, `reg_abcd`, `reg_byte`, `xmm_reg`, `ymm_reg`, `zmm_reg`, `kreg`, `kreg0`, `mmx_reg`, `x87_reg`, and `tmm_reg`
 
 error: invalid register `foo`: unknown register
   --> $DIR/bad-reg.rs:22:18
@@ -12,7 +12,7 @@ error: invalid register `foo`: unknown register
 LL |         asm!("", in("foo") foo);
    |                  ^^^^^^^^^^^^^
 
-error: invalid asm template modifier for this register class
+error: invalid asm template modifier `z` for this register class
   --> $DIR/bad-reg.rs:24:15
    |
 LL |         asm!("{:z}", in(reg) foo);
@@ -20,9 +20,9 @@ LL |         asm!("{:z}", in(reg) foo);
    |               |
    |               template modifier
    |
-   = note: the `reg` register class supports the following template modifiers: `l`, `x`, `e`, `r`
+   = note: the `reg` register class supports the following template modifiers: `l`, `x`, `e`, and `r`
 
-error: invalid asm template modifier for this register class
+error: invalid asm template modifier `r` for this register class
   --> $DIR/bad-reg.rs:26:15
    |
 LL |         asm!("{:r}", in(xmm_reg) foo);
@@ -30,7 +30,7 @@ LL |         asm!("{:r}", in(xmm_reg) foo);
    |               |
    |               template modifier
    |
-   = note: the `xmm_reg` register class supports the following template modifiers: `x`, `y`, `z`
+   = note: the `xmm_reg` register class supports the following template modifiers: `x`, `y`, and `z`
 
 error: asm template modifiers are not allowed for `const` arguments
   --> $DIR/bad-reg.rs:28:15

--- a/tests/ui/asm/x86_64/issue-82869.stderr
+++ b/tests/ui/asm/x86_64/issue-82869.stderr
@@ -4,7 +4,7 @@ error: invalid register class `vreg`: unknown register class
 LL |     asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
    |                                ^^^^^^^^^^^
    |
-   = note: the following register classes are supported on this target: `reg`, `reg_abcd`, `reg_byte`, `xmm_reg`, `ymm_reg`, `zmm_reg`, `kreg`, `kreg0`, `mmx_reg`, `x87_reg`, `tmm_reg`
+   = note: the following register classes are supported on this target: `reg`, `reg_abcd`, `reg_byte`, `xmm_reg`, `ymm_reg`, `zmm_reg`, `kreg`, `kreg0`, `mmx_reg`, `x87_reg`, and `tmm_reg`
 
 error: invalid register class `vreg`: unknown register class
   --> $DIR/issue-82869.rs:11:45
@@ -12,7 +12,7 @@ error: invalid register class `vreg`: unknown register class
 LL |     asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
    |                                             ^^^^^^^^^^
    |
-   = note: the following register classes are supported on this target: `reg`, `reg_abcd`, `reg_byte`, `xmm_reg`, `ymm_reg`, `zmm_reg`, `kreg`, `kreg0`, `mmx_reg`, `x87_reg`, `tmm_reg`
+   = note: the following register classes are supported on this target: `reg`, `reg_abcd`, `reg_byte`, `xmm_reg`, `ymm_reg`, `zmm_reg`, `kreg`, `kreg0`, `mmx_reg`, `x87_reg`, and `tmm_reg`
 
 error: invalid register `d0`: unknown register
   --> $DIR/issue-82869.rs:11:57

--- a/tests/ui/attributes/malformed-reprs.stderr
+++ b/tests/ui/attributes/malformed-reprs.stderr
@@ -6,12 +6,6 @@ LL | #![repr]
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html#representations>
 
-error[E0589]: invalid `repr(align)` attribute: not a power of two
-  --> $DIR/malformed-reprs.rs:9:14
-   |
-LL | #[repr(align(0))]
-   |              ^
-
 error: `repr` attribute cannot be used at crate level
   --> $DIR/malformed-reprs.rs:4:1
    |
@@ -19,13 +13,19 @@ LL | #![repr]
    | ^^^^^^^^
 ...
 LL | enum Foo {}
-   |      --- the inner attribute doesn't annotate this enum
+   | ----------- the inner attribute doesn't annotate this item
    |
 help: perhaps you meant to use an outer attribute
    |
 LL - #![repr]
 LL + #[repr]
    |
+
+error[E0589]: invalid `repr(align)` attribute: not a power of two
+  --> $DIR/malformed-reprs.rs:9:14
+   |
+LL | #[repr(align(0))]
+   |              ^
 
 error[E0084]: unsupported representation for zero-variant enum
   --> $DIR/malformed-reprs.rs:9:1

--- a/tests/ui/attributes/rustc_confusables_assoc_fn.rs
+++ b/tests/ui/attributes/rustc_confusables_assoc_fn.rs
@@ -1,0 +1,22 @@
+#![feature(rustc_attrs)]
+
+struct S;
+
+impl S {
+    #[rustc_confusables("bar")]
+    fn foo() {}
+
+    #[rustc_confusables("baz")]
+    fn qux(&self, x: i32) {}
+}
+
+fn main() {
+    S::bar();
+    //~^ ERROR no function or associated item named `bar`
+    //~| HELP you might have meant to use `foo`
+
+    let s = S;
+    s.baz(10);
+    //~^ ERROR no method named `baz`
+    //~| HELP you might have meant to use `qux`
+}

--- a/tests/ui/attributes/rustc_confusables_assoc_fn.stderr
+++ b/tests/ui/attributes/rustc_confusables_assoc_fn.stderr
@@ -1,0 +1,33 @@
+error[E0599]: no function or associated item named `bar` found for struct `S` in the current scope
+  --> $DIR/rustc_confusables_assoc_fn.rs:14:8
+   |
+LL | struct S;
+   | -------- function or associated item `bar` not found for this struct
+...
+LL |     S::bar();
+   |        ^^^ function or associated item not found in `S`
+   |
+help: you might have meant to use `foo`
+   |
+LL -     S::bar();
+LL +     S::foo();
+   |
+
+error[E0599]: no method named `baz` found for struct `S` in the current scope
+  --> $DIR/rustc_confusables_assoc_fn.rs:19:7
+   |
+LL | struct S;
+   | -------- method `baz` not found for this struct
+...
+LL |     s.baz(10);
+   |       ^^^ method not found in `S`
+   |
+help: you might have meant to use `qux`
+   |
+LL -     s.baz(10);
+LL +     s.qux(10);
+   |
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0599`.

--- a/tests/ui/check-cfg/target_feature.stderr
+++ b/tests/ui/check-cfg/target_feature.stderr
@@ -17,6 +17,7 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `addsubiw`
 `adx`
 `aes`
+`allows-misaligned-mem-access`
 `altivec`
 `alu32`
 `amx-avx512`

--- a/tests/ui/const-generics/exhaustive-value.stderr
+++ b/tests/ui/const-generics/exhaustive-value.stderr
@@ -4,15 +4,15 @@ error[E0277]: the trait bound `(): Foo<N>` is not satisfied
 LL |     <() as Foo<N>>::test()
    |      ^^ the trait `Foo<N>` is not implemented for `()`
    |
-   = help: the following other types implement trait `Foo<N>`:
-             `()` implements `Foo<0>`
-             `()` implements `Foo<100>`
-             `()` implements `Foo<101>`
-             `()` implements `Foo<102>`
-             `()` implements `Foo<103>`
-             `()` implements `Foo<104>`
-             `()` implements `Foo<105>`
-             `()` implements `Foo<106>`
+   = help: `()` implements trait `Foo<N>`:
+             Foo<0>
+             Foo<100>
+             Foo<101>
+             Foo<102>
+             Foo<103>
+             Foo<104>
+             Foo<105>
+             Foo<106>
            and 248 others
 
 error: aborting due to 1 previous error

--- a/tests/ui/coverage-attr/bad-syntax.rs
+++ b/tests/ui/coverage-attr/bad-syntax.rs
@@ -6,12 +6,12 @@
 // Tests the error messages produced (or not produced) by various unusual
 // uses of the `#[coverage(..)]` attribute.
 
-#[coverage(off)] //~ ERROR multiple `coverage` attributes
 #[coverage(off)]
+#[coverage(off)] //~ ERROR multiple `coverage` attributes
 fn multiple_consistent() {}
 
-#[coverage(off)] //~ ERROR multiple `coverage` attributes
-#[coverage(on)]
+#[coverage(off)]
+#[coverage(on)] //~ ERROR multiple `coverage` attributes
 fn multiple_inconsistent() {}
 
 #[coverage] //~ ERROR malformed `coverage` attribute input

--- a/tests/ui/coverage-attr/bad-syntax.stderr
+++ b/tests/ui/coverage-attr/bad-syntax.stderr
@@ -1,26 +1,26 @@
 error: multiple `coverage` attributes
-  --> $DIR/bad-syntax.rs:9:1
+  --> $DIR/bad-syntax.rs:10:1
    |
 LL | #[coverage(off)]
    | ^^^^^^^^^^^^^^^^ help: remove this attribute
    |
 note: attribute also specified here
-  --> $DIR/bad-syntax.rs:10:1
+  --> $DIR/bad-syntax.rs:9:1
    |
 LL | #[coverage(off)]
    | ^^^^^^^^^^^^^^^^
 
 error: multiple `coverage` attributes
-  --> $DIR/bad-syntax.rs:13:1
-   |
-LL | #[coverage(off)]
-   | ^^^^^^^^^^^^^^^^ help: remove this attribute
-   |
-note: attribute also specified here
   --> $DIR/bad-syntax.rs:14:1
    |
 LL | #[coverage(on)]
-   | ^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/bad-syntax.rs:13:1
+   |
+LL | #[coverage(off)]
+   | ^^^^^^^^^^^^^^^^
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/bad-syntax.rs:17:1

--- a/tests/ui/derives/issue-36617.stderr
+++ b/tests/ui/derives/issue-36617.stderr
@@ -5,7 +5,7 @@ LL | #![derive(Copy)]
    | ^^^^^^^^^^^^^^^^
 ...
 LL | fn main() {}
-   |    ---- the inner attribute doesn't annotate this function
+   | ------------ the inner attribute doesn't annotate this item
    |
 help: perhaps you meant to use an outer attribute
    |
@@ -20,7 +20,7 @@ LL | #![test]
    | ^^^^^^^^
 ...
 LL | fn main() {}
-   |    ---- the inner attribute doesn't annotate this function
+   | ------------ the inner attribute doesn't annotate this item
    |
 help: perhaps you meant to use an outer attribute
    |
@@ -35,7 +35,7 @@ LL | #![test_case]
    | ^^^^^^^^^^^^^
 ...
 LL | fn main() {}
-   |    ---- the inner attribute doesn't annotate this function
+   | ------------ the inner attribute doesn't annotate this item
    |
 help: perhaps you meant to use an outer attribute
    |
@@ -50,7 +50,7 @@ LL | #![bench]
    | ^^^^^^^^^
 ...
 LL | fn main() {}
-   |    ---- the inner attribute doesn't annotate this function
+   | ------------ the inner attribute doesn't annotate this item
    |
 help: perhaps you meant to use an outer attribute
    |
@@ -65,7 +65,7 @@ LL | #![global_allocator]
    | ^^^^^^^^^^^^^^^^^^^^
 ...
 LL | fn main() {}
-   |    ---- the inner attribute doesn't annotate this function
+   | ------------ the inner attribute doesn't annotate this item
    |
 help: perhaps you meant to use an outer attribute
    |

--- a/tests/ui/did_you_mean/issue-21659-show-relevant-trait-impls-1.stderr
+++ b/tests/ui/did_you_mean/issue-21659-show-relevant-trait-impls-1.stderr
@@ -11,14 +11,14 @@ help: the trait `Foo<usize>` is not implemented for `Bar`
    |
 LL | struct Bar;
    | ^^^^^^^^^^
-help: the following other types implement trait `Foo<A>`
+help: `Bar` implements trait `Foo<A>`
   --> $DIR/issue-21659-show-relevant-trait-impls-1.rs:15:1
    |
 LL | impl Foo<i32> for Bar {}
-   | ^^^^^^^^^^^^^^^^^^^^^ `Bar` implements `Foo<i32>`
+   | ^^^^^^^^^^^^^^^^^^^^^ `Foo<i32>`
 LL |
 LL | impl Foo<u8> for Bar {}
-   | ^^^^^^^^^^^^^^^^^^^^ `Bar` implements `Foo<u8>`
+   | ^^^^^^^^^^^^^^^^^^^^ `Foo<u8>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/did_you_mean/issue-21659-show-relevant-trait-impls-2.stderr
+++ b/tests/ui/did_you_mean/issue-21659-show-relevant-trait-impls-2.stderr
@@ -11,13 +11,13 @@ help: the trait `Foo<usize>` is not implemented for `Bar`
    |
 LL | struct Bar;
    | ^^^^^^^^^^
-   = help: the following other types implement trait `Foo<A>`:
-             `Bar` implements `Foo<i16>`
-             `Bar` implements `Foo<i32>`
-             `Bar` implements `Foo<i8>`
-             `Bar` implements `Foo<u16>`
-             `Bar` implements `Foo<u32>`
-             `Bar` implements `Foo<u8>`
+   = help: `Bar` implements trait `Foo<A>`:
+             Foo<i16>
+             Foo<i32>
+             Foo<i8>
+             Foo<u16>
+             Foo<u32>
+             Foo<u8>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/did_you_mean/issue-39802-show-5-trait-impls.stderr
+++ b/tests/ui/did_you_mean/issue-39802-show-5-trait-impls.stderr
@@ -6,12 +6,12 @@ LL |     Foo::<i32>::bar(&1i8);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the following other types implement trait `Foo<B>`:
-             `i8` implements `Foo<bool>`
-             `i8` implements `Foo<u16>`
-             `i8` implements `Foo<u32>`
-             `i8` implements `Foo<u64>`
-             `i8` implements `Foo<u8>`
+   = help: `i8` implements trait `Foo<B>`:
+             Foo<bool>
+             Foo<u16>
+             Foo<u32>
+             Foo<u64>
+             Foo<u8>
 
 error[E0277]: the trait bound `u8: Foo<i32>` is not satisfied
   --> $DIR/issue-39802-show-5-trait-impls.rs:25:21
@@ -21,17 +21,17 @@ LL |     Foo::<i32>::bar(&1u8);
    |     |
    |     required by a bound introduced by this call
    |
-help: the following other types implement trait `Foo<B>`
+help: `u8` implements trait `Foo<B>`
   --> $DIR/issue-39802-show-5-trait-impls.rs:11:1
    |
 LL | impl Foo<u16> for u8 {}
-   | ^^^^^^^^^^^^^^^^^^^^ `u8` implements `Foo<u16>`
+   | ^^^^^^^^^^^^^^^^^^^^ `Foo<u16>`
 LL | impl Foo<u32> for u8 {}
-   | ^^^^^^^^^^^^^^^^^^^^ `u8` implements `Foo<u32>`
+   | ^^^^^^^^^^^^^^^^^^^^ `Foo<u32>`
 LL | impl Foo<u64> for u8 {}
-   | ^^^^^^^^^^^^^^^^^^^^ `u8` implements `Foo<u64>`
+   | ^^^^^^^^^^^^^^^^^^^^ `Foo<u64>`
 LL | impl Foo<bool> for u8 {}
-   | ^^^^^^^^^^^^^^^^^^^^^ `u8` implements `Foo<bool>`
+   | ^^^^^^^^^^^^^^^^^^^^^ `Foo<bool>`
 
 error[E0277]: the trait bound `bool: Foo<i32>` is not satisfied
   --> $DIR/issue-39802-show-5-trait-impls.rs:26:21
@@ -41,13 +41,13 @@ LL |     Foo::<i32>::bar(&true);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the following other types implement trait `Foo<B>`:
-             `bool` implements `Foo<bool>`
-             `bool` implements `Foo<i8>`
-             `bool` implements `Foo<u16>`
-             `bool` implements `Foo<u32>`
-             `bool` implements `Foo<u64>`
-             `bool` implements `Foo<u8>`
+   = help: `bool` implements trait `Foo<B>`:
+             Foo<bool>
+             Foo<i8>
+             Foo<u16>
+             Foo<u32>
+             Foo<u64>
+             Foo<u8>
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/feature-gates/issue-43106-gating-of-bench.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-bench.stderr
@@ -5,7 +5,7 @@ LL | #![bench                   = "4100"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL | fn main() {}
-   |    ---- the inner attribute doesn't annotate this function
+   | ------------ the inner attribute doesn't annotate this item
    |
 help: perhaps you meant to use an outer attribute
    |

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.rs
@@ -37,7 +37,7 @@
 #[inline]
 //~^ ERROR attribute cannot be used on
 mod inline {
-    //~^ NOTE the inner attribute doesn't annotate this module
+    //~^ NOTE the inner attribute doesn't annotate this item
 
     mod inner { #![inline] }
     //~^ ERROR attribute cannot be used on

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
@@ -24,6 +24,21 @@ LL | #![rustc_main]
    |
    = help: `#[rustc_main]` can only be applied to functions
 
+error: `repr` attribute cannot be used at crate level
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:16:1
+   |
+LL | #![repr()]
+   | ^^^^^^^^^^
+...
+LL | mod inline {
+   | ------------ the inner attribute doesn't annotate this item
+   |
+help: perhaps you meant to use an outer attribute
+   |
+LL - #![repr()]
+LL + #[repr()]
+   |
+
 error: `#[path]` attribute cannot be used on crates
   --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:20:1
    |
@@ -241,21 +256,6 @@ LL | #![export_name = "2200"]
 help: remove the `#[no_mangle]` attribute
    |
 LL - #![no_mangle]
-   |
-
-error: `repr` attribute cannot be used at crate level
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:16:1
-   |
-LL | #![repr()]
-   | ^^^^^^^^^^
-...
-LL | mod inline {
-   |     ------ the inner attribute doesn't annotate this module
-   |
-help: perhaps you meant to use an outer attribute
-   |
-LL - #![repr()]
-LL + #[repr()]
    |
 
 error[E0517]: attribute should be applied to a struct, enum, or union

--- a/tests/ui/feature-gates/issue-43106-gating-of-test.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-test.stderr
@@ -5,7 +5,7 @@ LL | #![test                    = "4200"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL | fn main() {}
-   |    ---- the inner attribute doesn't annotate this function
+   | ------------ the inner attribute doesn't annotate this item
    |
 help: perhaps you meant to use an outer attribute
    |

--- a/tests/ui/indexing/index-help.stderr
+++ b/tests/ui/indexing/index-help.stderr
@@ -5,13 +5,13 @@ LL |     x[0i32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[{integer}]>` is not implemented for `i32`
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `Vec<{integer}>` to implement `Index<i32>`
 
 error: aborting due to 1 previous error

--- a/tests/ui/indexing/indexing-integral-types.stderr
+++ b/tests/ui/indexing/indexing-integral-types.stderr
@@ -5,13 +5,13 @@ LL |     v[3u8];
    |       ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[isize]>` is not implemented for `u8`
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `Vec<isize>` to implement `Index<u8>`
 
 error[E0277]: the type `[isize]` cannot be indexed by `i8`
@@ -21,13 +21,13 @@ LL |     v[3i8];
    |       ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[isize]>` is not implemented for `i8`
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `Vec<isize>` to implement `Index<i8>`
 
 error[E0277]: the type `[isize]` cannot be indexed by `u32`
@@ -37,13 +37,13 @@ LL |     v[3u32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[isize]>` is not implemented for `u32`
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `Vec<isize>` to implement `Index<u32>`
 
 error[E0277]: the type `[isize]` cannot be indexed by `i32`
@@ -53,13 +53,13 @@ LL |     v[3i32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[isize]>` is not implemented for `i32`
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `Vec<isize>` to implement `Index<i32>`
 
 error[E0277]: the type `[u8]` cannot be indexed by `u8`
@@ -69,13 +69,13 @@ LL |     s.as_bytes()[3u8];
    |                  ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[u8]>` is not implemented for `u8`
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `[u8]` to implement `Index<u8>`
 
 error[E0277]: the type `[u8]` cannot be indexed by `i8`
@@ -85,13 +85,13 @@ LL |     s.as_bytes()[3i8];
    |                  ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[u8]>` is not implemented for `i8`
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `[u8]` to implement `Index<i8>`
 
 error[E0277]: the type `[u8]` cannot be indexed by `u32`
@@ -101,13 +101,13 @@ LL |     s.as_bytes()[3u32];
    |                  ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[u8]>` is not implemented for `u32`
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `[u8]` to implement `Index<u32>`
 
 error[E0277]: the type `[u8]` cannot be indexed by `i32`
@@ -117,13 +117,13 @@ LL |     s.as_bytes()[3i32];
    |                  ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[u8]>` is not implemented for `i32`
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `[u8]` to implement `Index<i32>`
 
 error: aborting due to 8 previous errors

--- a/tests/ui/indexing/indexing-requires-a-uint.stderr
+++ b/tests/ui/indexing/indexing-requires-a-uint.stderr
@@ -5,13 +5,13 @@ LL |     [0][0u8];
    |         ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[{integer}]>` is not implemented for `u8`
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `[{integer}]` to implement `Index<u8>`
 
 error[E0308]: mismatched types

--- a/tests/ui/iterators/auxiliary/rangefrom-overflow-2crates-ocno.rs
+++ b/tests/ui/iterators/auxiliary/rangefrom-overflow-2crates-ocno.rs
@@ -1,0 +1,10 @@
+//@ compile-flags: -C overflow-checks=no
+
+#![crate_type = "lib"]
+#![feature(new_range_api)]
+
+use std::range::RangeFromIter;
+
+pub fn next(iter: &mut RangeFromIter<u8>) -> u8 {
+    iter.next().unwrap()
+}

--- a/tests/ui/iterators/auxiliary/rangefrom-overflow-2crates-ocyes.rs
+++ b/tests/ui/iterators/auxiliary/rangefrom-overflow-2crates-ocyes.rs
@@ -1,0 +1,10 @@
+//@ compile-flags: -C overflow-checks=yes
+
+#![crate_type = "lib"]
+#![feature(new_range_api)]
+
+use std::range::RangeFromIter;
+
+pub fn next(iter: &mut RangeFromIter<u8>) -> u8 {
+    iter.next().unwrap()
+}

--- a/tests/ui/iterators/invalid-iterator-chain-fixable.stderr
+++ b/tests/ui/iterators/invalid-iterator-chain-fixable.stderr
@@ -33,13 +33,13 @@ LL |     println!("{}", scores.sum::<i32>());
    |                           required by a bound introduced by this call
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
-help: the following other types implement trait `Sum<A>`
+help: `i32` implements trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum`
+   = note: `Sum`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
+   = note: `Sum<&i32>`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
    = note: in this macro invocation
@@ -74,13 +74,13 @@ LL |             .sum::<i32>(),
    |              required by a bound introduced by this call
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
-help: the following other types implement trait `Sum<A>`
+help: `i32` implements trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum`
+   = note: `Sum`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
+   = note: `Sum<&i32>`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
    = note: in this macro invocation
@@ -115,13 +115,13 @@ LL |     println!("{}", vec![0, 1].iter().map(|x| { x; }).sum::<i32>());
    |                                                      required by a bound introduced by this call
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
-help: the following other types implement trait `Sum<A>`
+help: `i32` implements trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum`
+   = note: `Sum`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
+   = note: `Sum<&i32>`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
    = note: in this macro invocation

--- a/tests/ui/iterators/invalid-iterator-chain-with-int-infer.stderr
+++ b/tests/ui/iterators/invalid-iterator-chain-with-int-infer.stderr
@@ -7,13 +7,13 @@ LL |     let x = Some(()).iter().map(|()| 1).sum::<f32>();
    |                                         required by a bound introduced by this call
    |
    = help: the trait `Sum<{integer}>` is not implemented for `f32`
-help: the following other types implement trait `Sum<A>`
+help: `f32` implements trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `f32` implements `Sum`
+   = note: `Sum`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `f32` implements `Sum<&f32>`
+   = note: `Sum<&f32>`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
    = note: in this macro invocation

--- a/tests/ui/iterators/invalid-iterator-chain.stderr
+++ b/tests/ui/iterators/invalid-iterator-chain.stderr
@@ -33,13 +33,13 @@ LL |     println!("{}", scores.sum::<i32>());
    |                           required by a bound introduced by this call
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
-help: the following other types implement trait `Sum<A>`
+help: `i32` implements trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum`
+   = note: `Sum`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
+   = note: `Sum<&i32>`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
    = note: in this macro invocation
@@ -73,13 +73,13 @@ LL |             .sum::<i32>(),
    |              required by a bound introduced by this call
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
-help: the following other types implement trait `Sum<A>`
+help: `i32` implements trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum`
+   = note: `Sum`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
+   = note: `Sum<&i32>`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
    = note: in this macro invocation
@@ -120,13 +120,13 @@ LL |             .sum::<i32>(),
    |              required by a bound introduced by this call
    |
    = help: the trait `Sum<f64>` is not implemented for `i32`
-help: the following other types implement trait `Sum<A>`
+help: `i32` implements trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum`
+   = note: `Sum`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
+   = note: `Sum<&i32>`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
    = note: in this macro invocation
@@ -158,13 +158,13 @@ LL |     println!("{}", vec![0, 1].iter().map(|x| { x; }).sum::<i32>());
    |                                                      required by a bound introduced by this call
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
-help: the following other types implement trait `Sum<A>`
+help: `i32` implements trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum`
+   = note: `Sum`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
+   = note: `Sum<&i32>`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
    = note: in this macro invocation
@@ -194,13 +194,13 @@ LL |     println!("{}", vec![(), ()].iter().sum::<i32>());
    |                                        required by a bound introduced by this call
    |
    = help: the trait `Sum<&()>` is not implemented for `i32`
-help: the following other types implement trait `Sum<A>`
+help: `i32` implements trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum`
+   = note: `Sum`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
+   = note: `Sum<&i32>`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
    = note: in this macro invocation

--- a/tests/ui/iterators/rangefrom-overflow-2crates.rs
+++ b/tests/ui/iterators/rangefrom-overflow-2crates.rs
@@ -1,0 +1,40 @@
+//@ run-pass
+//@ needs-unwind
+//@ aux-build:rangefrom-overflow-2crates-ocno.rs
+//@ aux-build:rangefrom-overflow-2crates-ocyes.rs
+
+// For #154124
+// Test that two crates with different overflow-checks have the same results,
+// even when the iterator is passed between them.
+
+#![feature(new_range_api)]
+
+extern crate rangefrom_overflow_2crates_ocno;
+extern crate rangefrom_overflow_2crates_ocyes;
+
+use rangefrom_overflow_2crates_ocno::next as next_ocno;
+use rangefrom_overflow_2crates_ocyes::next as next_ocyes;
+
+fn main() {
+    let mut iter_ocyes = std::range::RangeFrom::from(0_u8..).into_iter();
+    let mut iter_ocno = iter_ocyes.clone();
+
+    for n in 0_u8..=255 {
+        assert_eq!(n, next_ocno(&mut iter_ocyes.clone()));
+        assert_eq!(n, next_ocyes(&mut iter_ocyes));
+        assert_eq!(n, next_ocyes(&mut iter_ocno.clone()));
+        assert_eq!(n, next_ocno(&mut iter_ocno));
+    }
+
+    // `iter_ocno` should have wrapped
+    assert_eq!(0, next_ocyes(&mut iter_ocno.clone()));
+    assert_eq!(0, next_ocno(&mut iter_ocno));
+    // `iter_ocyes` should be exhausted,
+    // which will wrap when called without overflow-checks
+    assert_eq!(0, next_ocno(&mut iter_ocyes.clone()));
+    // and panic when called with overflow-checks
+    let r = std::panic::catch_unwind(move || {
+        let _ = next_ocyes(&mut iter_ocyes);
+    });
+    assert!(r.is_err());
+}

--- a/tests/ui/lazy-type-alias/trailing-where-clause.stderr
+++ b/tests/ui/lazy-type-alias/trailing-where-clause.stderr
@@ -4,13 +4,13 @@ error[E0277]: the trait bound `String: From<()>` is not satisfied
 LL |     let _: Alias<()>;
    |                  ^^ the trait `From<()>` is not implemented for `String`
    |
-   = help: the following other types implement trait `From<T>`:
-             `String` implements `From<&String>`
-             `String` implements `From<&mut str>`
-             `String` implements `From<&str>`
-             `String` implements `From<Box<str>>`
-             `String` implements `From<Cow<'_, str>>`
-             `String` implements `From<char>`
+   = help: `String` implements trait `From<T>`:
+             From<&String>
+             From<&mut str>
+             From<&str>
+             From<Box<str>>
+             From<Cow<'_, str>>
+             From<char>
 note: required by a bound in `Alias`
   --> $DIR/trailing-where-clause.rs:8:13
    |

--- a/tests/ui/lint/unused/unused-attr-duplicate.rs
+++ b/tests/ui/lint/unused/unused-attr-duplicate.rs
@@ -61,7 +61,7 @@ pub mod from_path;
 fn t1() {}
 
 #[must_use]
-#[must_use = "some message"] //~ ERROR unused attribute
+#[must_use = "some message"]  //~ ERROR unused attribute
 //~^ WARN this was previously accepted
 // No warnings for #[repr], would require more logic.
 #[repr(C)]
@@ -89,15 +89,15 @@ pub fn xyz() {}
 #[link(name = "rust_test_helpers", kind = "static")]
 #[link(name = "rust_test_helpers", kind = "static")]
 extern "C" {
-    #[link_name = "this_does_not_exist"] //~ ERROR unused attribute
+    #[link_name = "this_does_not_exist"]
+    #[link_name = "rust_dbg_extern_identity_u32"] //~ ERROR unused attribute
     //~^ WARN this was previously accepted
-    #[link_name = "rust_dbg_extern_identity_u32"]
     pub fn name_in_rust(v: u32) -> u32;
 }
 
-#[export_name = "exported_symbol_name"] //~ ERROR unused attribute
+#[export_name = "exported_symbol_name"]
+#[export_name = "exported_symbol_name2"]  //~ ERROR unused attribute
 //~^ WARN this was previously accepted
-#[export_name = "exported_symbol_name2"]
 pub fn export_test() {}
 
 #[no_mangle]
@@ -109,9 +109,9 @@ pub fn no_mangle_test() {}
 static FOO: u32 = 0;
 
 #[link_section = ".text"]
+#[link_section = ".bss"]
 //~^ ERROR unused attribute
 //~| WARN this was previously accepted
-#[link_section = ".bss"]
 pub extern "C" fn example() {}
 
 fn main() {}

--- a/tests/ui/lint/unused/unused-attr-duplicate.stderr
+++ b/tests/ui/lint/unused/unused-attr-duplicate.stderr
@@ -165,29 +165,29 @@ LL | #[track_caller]
    | ^^^^^^^^^^^^^^^
 
 error: unused attribute
+  --> $DIR/unused-attr-duplicate.rs:93:5
+   |
+LL |     #[link_name = "rust_dbg_extern_identity_u32"]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
   --> $DIR/unused-attr-duplicate.rs:92:5
    |
 LL |     #[link_name = "this_does_not_exist"]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
-   |
-note: attribute also specified here
-  --> $DIR/unused-attr-duplicate.rs:94:5
-   |
-LL |     #[link_name = "rust_dbg_extern_identity_u32"]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: unused attribute
+  --> $DIR/unused-attr-duplicate.rs:99:1
+   |
+LL | #[export_name = "exported_symbol_name2"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
   --> $DIR/unused-attr-duplicate.rs:98:1
    |
 LL | #[export_name = "exported_symbol_name"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
-   |
-note: attribute also specified here
-  --> $DIR/unused-attr-duplicate.rs:100:1
-   |
-LL | #[export_name = "exported_symbol_name2"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: unused attribute
@@ -215,16 +215,16 @@ LL | #[used]
    | ^^^^^^^
 
 error: unused attribute
+  --> $DIR/unused-attr-duplicate.rs:112:1
+   |
+LL | #[link_section = ".bss"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
   --> $DIR/unused-attr-duplicate.rs:111:1
    |
 LL | #[link_section = ".text"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
-   |
-note: attribute also specified here
-  --> $DIR/unused-attr-duplicate.rs:114:1
-   |
-LL | #[link_section = ".bss"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: unused attribute

--- a/tests/ui/lowering/issue-121108.stderr
+++ b/tests/ui/lowering/issue-121108.stderr
@@ -5,7 +5,7 @@ LL | #![derive(Clone, Copy)]
    | ^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL | use std::ptr::addr_of;
-   |               ------- the inner attribute doesn't annotate this import
+   | ---------------------- the inner attribute doesn't annotate this item
    |
 help: perhaps you meant to use an outer attribute
    |

--- a/tests/ui/on-unimplemented/slice-index.stderr
+++ b/tests/ui/on-unimplemented/slice-index.stderr
@@ -5,13 +5,13 @@ LL |     x[1i32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[i32]>` is not implemented for `i32`
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `[i32]` to implement `Index<i32>`
 
 error[E0277]: the type `[i32]` cannot be indexed by `RangeTo<i32>`
@@ -21,19 +21,19 @@ LL |     x[..1i32];
    |       ^^^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[i32]>` is not implemented for `RangeTo<i32>`
-help: the following other types implement trait `SliceIndex<T>`
+help: `RangeTo<usize>` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `RangeTo<usize>` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `RangeTo<usize>` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
   ::: $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
    = note: in this macro invocation
   --> $SRC_DIR/core/src/str/traits.rs:LL:COL
    |
-   = note: `RangeTo<usize>` implements `SliceIndex<str>`
+   = note: `SliceIndex<str>`
    = note: required for `[i32]` to implement `Index<RangeTo<i32>>`
    = note: this error originates in the macro `impl_slice_index` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/on-unimplemented/suggest_tuple_wrap_root_obligation.rs
+++ b/tests/ui/on-unimplemented/suggest_tuple_wrap_root_obligation.rs
@@ -5,7 +5,7 @@ impl From<(u8,)> for Tuple {
         todo!()
     }
 }
-impl From<(u8, u8)> for Tuple { //~ HELP the following other types implement trait `From<T>`
+impl From<(u8, u8)> for Tuple { //~ HELP `Tuple` implements trait `From<T>`
     fn from(_: (u8, u8)) -> Self {
         todo!()
     }

--- a/tests/ui/on-unimplemented/suggest_tuple_wrap_root_obligation.stderr
+++ b/tests/ui/on-unimplemented/suggest_tuple_wrap_root_obligation.stderr
@@ -11,17 +11,17 @@ help: the trait `From<u8>` is not implemented for `Tuple`
    |
 LL | struct Tuple;
    | ^^^^^^^^^^^^
-help: the following other types implement trait `From<T>`
+help: `Tuple` implements trait `From<T>`
   --> $DIR/suggest_tuple_wrap_root_obligation.rs:3:1
    |
 LL | impl From<(u8,)> for Tuple {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ `Tuple` implements `From<(u8,)>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ `From<(u8,)>`
 ...
 LL | impl From<(u8, u8)> for Tuple {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Tuple` implements `From<(u8, u8)>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `From<(u8, u8)>`
 ...
 LL | impl From<(u8, u8, u8)> for Tuple {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Tuple` implements `From<(u8, u8, u8)>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `From<(u8, u8, u8)>`
    = note: required for `u8` to implement `Into<Tuple>`
 note: required by a bound in `convert_into_tuple`
   --> $DIR/suggest_tuple_wrap_root_obligation.rs:19:32

--- a/tests/ui/on-unimplemented/sum.stderr
+++ b/tests/ui/on-unimplemented/sum.stderr
@@ -7,13 +7,13 @@ LL |     vec![(), ()].iter().sum::<i32>();
    |                         required by a bound introduced by this call
    |
    = help: the trait `Sum<&()>` is not implemented for `i32`
-help: the following other types implement trait `Sum<A>`
+help: `i32` implements trait `Sum<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum`
+   = note: `Sum`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Sum<&i32>`
+   = note: `Sum<&i32>`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
    = note: in this macro invocation
@@ -37,13 +37,13 @@ LL |     vec![(), ()].iter().product::<i32>();
    |                         required by a bound introduced by this call
    |
    = help: the trait `Product<&()>` is not implemented for `i32`
-help: the following other types implement trait `Product<A>`
+help: `i32` implements trait `Product<A>`
   --> $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Product`
+   = note: `Product`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
-   = note: `i32` implements `Product<&i32>`
+   = note: `Product<&i32>`
   ::: $SRC_DIR/core/src/iter/traits/accum.rs:LL:COL
    |
    = note: in this macro invocation

--- a/tests/ui/proc-macro/issue-89566-suggest-fix-invalid-top-level-macro-attr.stderr
+++ b/tests/ui/proc-macro/issue-89566-suggest-fix-invalid-top-level-macro-attr.stderr
@@ -5,7 +5,7 @@ LL | #![derive(Debug)]
    | ^^^^^^^^^^^^^^^^^
 LL | #[allow(dead_code)]
 LL | struct Test {}
-   |        ---- the inner attribute doesn't annotate this struct
+   | -------------- the inner attribute doesn't annotate this item
    |
 help: perhaps you meant to use an outer attribute
    |

--- a/tests/ui/sanitize-attr/invalid-sanitize.rs
+++ b/tests/ui/sanitize-attr/invalid-sanitize.rs
@@ -4,12 +4,12 @@
 #[sanitize(brontosaurus = "off")] //~ ERROR malformed `sanitize` attribute input
 fn main() {}
 
-#[sanitize(address = "off")] //~ ERROR multiple `sanitize` attributes
 #[sanitize(address = "off")]
+#[sanitize(address = "off")] //~ ERROR multiple `sanitize` attributes
 fn multiple_consistent() {}
 
-#[sanitize(address = "on")] //~ ERROR multiple `sanitize` attributes
-#[sanitize(address = "off")]
+#[sanitize(address = "on")]
+#[sanitize(address = "off")] //~ ERROR multiple `sanitize` attributes
 fn multiple_inconsistent() {}
 
 #[sanitize(address = "bogus")] //~ ERROR malformed `sanitize` attribute input

--- a/tests/ui/sanitize-attr/invalid-sanitize.stderr
+++ b/tests/ui/sanitize-attr/invalid-sanitize.stderr
@@ -7,28 +7,28 @@ LL | #[sanitize(brontosaurus = "off")]
    |            valid arguments are "address", "cfi", "kcfi", "memory", "memtag", "shadow_call_stack", "thread", "hwaddress" or "realtime"
 
 error: multiple `sanitize` attributes
-  --> $DIR/invalid-sanitize.rs:7:1
+  --> $DIR/invalid-sanitize.rs:8:1
    |
 LL | #[sanitize(address = "off")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
    |
 note: attribute also specified here
-  --> $DIR/invalid-sanitize.rs:8:1
+  --> $DIR/invalid-sanitize.rs:7:1
    |
 LL | #[sanitize(address = "off")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: multiple `sanitize` attributes
-  --> $DIR/invalid-sanitize.rs:11:1
-   |
-LL | #[sanitize(address = "on")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
-   |
-note: attribute also specified here
   --> $DIR/invalid-sanitize.rs:12:1
    |
 LL | #[sanitize(address = "off")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/invalid-sanitize.rs:11:1
+   |
+LL | #[sanitize(address = "on")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0539]: malformed `sanitize` attribute input
   --> $DIR/invalid-sanitize.rs:15:1

--- a/tests/ui/span/issue-43927-non-ADT-derive.stderr
+++ b/tests/ui/span/issue-43927-non-ADT-derive.stderr
@@ -5,7 +5,7 @@ LL | #![derive(Debug, PartialEq, Eq)] // should be an outer attribute!
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL | struct DerivedOn;
-   |        --------- the inner attribute doesn't annotate this struct
+   | ----------------- the inner attribute doesn't annotate this item
    |
 help: perhaps you meant to use an outer attribute
    |

--- a/tests/ui/str/str-idx.stderr
+++ b/tests/ui/str/str-idx.stderr
@@ -7,13 +7,13 @@ LL |     let _: u8 = s[4];
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `str` to implement `Index<{integer}>`
 
 error[E0277]: the type `str` cannot be indexed by `{integer}`
@@ -27,13 +27,13 @@ LL |     let _ = s.get(4);
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
 note: required by a bound in `core::str::<impl str>::get`
   --> $SRC_DIR/core/src/str/mod.rs:LL:COL
 
@@ -48,13 +48,13 @@ LL |     let _ = s.get_unchecked(4);
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
 note: required by a bound in `core::str::<impl str>::get_unchecked`
   --> $SRC_DIR/core/src/str/mod.rs:LL:COL
 

--- a/tests/ui/str/str-mut-idx.stderr
+++ b/tests/ui/str/str-mut-idx.stderr
@@ -31,13 +31,13 @@ LL |     s[1usize] = bot();
    |       ^^^^^^ string indices are ranges of `usize`
    |
    = help: the trait `SliceIndex<str>` is not implemented for `usize`
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `str` to implement `Index<usize>`
 
 error[E0277]: the type `str` cannot be indexed by `{integer}`
@@ -51,13 +51,13 @@ LL |     s.get_mut(1);
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
 note: required by a bound in `core::str::<impl str>::get_mut`
   --> $SRC_DIR/core/src/str/mod.rs:LL:COL
 
@@ -72,13 +72,13 @@ LL |     s.get_unchecked_mut(1);
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
 note: required by a bound in `core::str::<impl str>::get_unchecked_mut`
   --> $SRC_DIR/core/src/str/mod.rs:LL:COL
 

--- a/tests/ui/suggestions/dont-suggest-borrowing-existing-borrow.stderr
+++ b/tests/ui/suggestions/dont-suggest-borrowing-existing-borrow.stderr
@@ -4,13 +4,13 @@ error[E0277]: the trait bound `str: From<_>` is not satisfied
 LL |     let _ = &str::from("value");
    |              ^^^ the trait `From<_>` is not implemented for `str`
    |
-   = help: the following other types implement trait `From<T>`:
-             `String` implements `From<&String>`
-             `String` implements `From<&mut str>`
-             `String` implements `From<&str>`
-             `String` implements `From<Box<str>>`
-             `String` implements `From<Cow<'_, str>>`
-             `String` implements `From<char>`
+   = help: `String` implements trait `From<T>`:
+             From<&String>
+             From<&mut str>
+             From<&str>
+             From<Box<str>>
+             From<Cow<'_, str>>
+             From<char>
 help: you likely meant to call the associated function `from` for type `&str`, but the code as written calls associated function `from` on type `str`
    |
 LL |     let _ = <&str>::from("value");

--- a/tests/ui/suggestions/into-str.stderr
+++ b/tests/ui/suggestions/into-str.stderr
@@ -7,13 +7,13 @@ LL |     foo(String::new());
    |     required by a bound introduced by this call
    |
    = note: to coerce a `String` into a `&str`, use `&*` as a prefix
-   = help: the following other types implement trait `From<T>`:
-             `String` implements `From<&String>`
-             `String` implements `From<&mut str>`
-             `String` implements `From<&str>`
-             `String` implements `From<Box<str>>`
-             `String` implements `From<Cow<'_, str>>`
-             `String` implements `From<char>`
+   = help: `String` implements trait `From<T>`:
+             From<&String>
+             From<&mut str>
+             From<&str>
+             From<Box<str>>
+             From<Cow<'_, str>>
+             From<char>
    = note: required for `String` to implement `Into<&str>`
 note: required by a bound in `foo`
   --> $DIR/into-str.rs:1:31

--- a/tests/ui/suggestions/partialeq_suggest_swap_on_e0277.stderr
+++ b/tests/ui/suggestions/partialeq_suggest_swap_on_e0277.stderr
@@ -5,15 +5,15 @@ LL |     String::from("Girls Band Cry") == T(String::from("Girls Band Cry"));
    |                                    ^^ no implementation for `String == T`
    |
    = help: the trait `PartialEq<T>` is not implemented for `String`
-   = help: the following other types implement trait `PartialEq<Rhs>`:
-             `String` implements `PartialEq<&str>`
-             `String` implements `PartialEq<ByteStr>`
-             `String` implements `PartialEq<ByteString>`
-             `String` implements `PartialEq<Cow<'_, str>>`
-             `String` implements `PartialEq<Path>`
-             `String` implements `PartialEq<PathBuf>`
-             `String` implements `PartialEq<str>`
-             `String` implements `PartialEq`
+   = help: `String` implements trait `PartialEq<Rhs>`:
+             PartialEq<&str>
+             PartialEq<ByteStr>
+             PartialEq<ByteString>
+             PartialEq<Cow<'_, str>>
+             PartialEq<Path>
+             PartialEq<PathBuf>
+             PartialEq<str>
+             PartialEq
    = note: `T` implements `PartialEq<String>`
 help: consider swapping the equality
    |

--- a/tests/ui/suggestions/semi-suggestion-when-stmt-and-expr-span-equal.stderr
+++ b/tests/ui/suggestions/semi-suggestion-when-stmt-and-expr-span-equal.stderr
@@ -20,15 +20,15 @@ LL |         .collect::<String>();
    |          required by a bound introduced by this call
    |
    = help: the trait `FromIterator<()>` is not implemented for `String`
-   = help: the following other types implement trait `FromIterator<A>`:
-             `String` implements `FromIterator<&char>`
-             `String` implements `FromIterator<&std::ascii::Char>`
-             `String` implements `FromIterator<&str>`
-             `String` implements `FromIterator<Box<str, A>>`
-             `String` implements `FromIterator<Cow<'_, str>>`
-             `String` implements `FromIterator<String>`
-             `String` implements `FromIterator<char>`
-             `String` implements `FromIterator<std::ascii::Char>`
+   = help: `String` implements trait `FromIterator<A>`:
+             FromIterator<&char>
+             FromIterator<&std::ascii::Char>
+             FromIterator<&str>
+             FromIterator<Box<str, A>>
+             FromIterator<Cow<'_, str>>
+             FromIterator<String>
+             FromIterator<char>
+             FromIterator<std::ascii::Char>
 note: the method call chain might not have had the expected associated types
   --> $DIR/semi-suggestion-when-stmt-and-expr-span-equal.rs:20:10
    |

--- a/tests/ui/suggestions/suggest-dereferencing-index.stderr
+++ b/tests/ui/suggestions/suggest-dereferencing-index.stderr
@@ -5,13 +5,13 @@ LL |     let one_item_please: i32 = [1, 2, 3][i];
    |                                          ^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[{integer}]>` is not implemented for `&usize`
-help: the following other types implement trait `SliceIndex<T>`
+help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<[T]>`
+   = note: `SliceIndex<[T]>`
   --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
    |
-   = note: `usize` implements `SliceIndex<ByteStr>`
+   = note: `SliceIndex<ByteStr>`
    = note: required for `[{integer}]` to implement `Index<&usize>`
 help: dereference this index
    |

--- a/tests/ui/traits/explicit-reference-cast.rs
+++ b/tests/ui/traits/explicit-reference-cast.rs
@@ -7,7 +7,7 @@ pub struct ToolA(PathBuf);
 //~^ HELP the trait `From<&PathBuf>` is not implemented for `ToolA`
 
 impl From<&Path> for ToolA {
-    //~^ HELP the following other types implement trait `From<T>`
+    //~^ HELP `ToolA` implements trait `From<T>`
     fn from(p: &Path) -> ToolA {
         ToolA(p.to_path_buf())
     }

--- a/tests/ui/traits/explicit-reference-cast.stderr
+++ b/tests/ui/traits/explicit-reference-cast.stderr
@@ -10,14 +10,14 @@ help: the trait `From<&PathBuf>` is not implemented for `ToolA`
    |
 LL | pub struct ToolA(PathBuf);
    | ^^^^^^^^^^^^^^^^
-help: the following other types implement trait `From<T>`
+help: `ToolA` implements trait `From<T>`
   --> $DIR/explicit-reference-cast.rs:9:1
    |
 LL | impl From<&Path> for ToolA {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ `ToolA` implements `From<&Path>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ `From<&Path>`
 ...
 LL | impl From<&str> for ToolA {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ `ToolA` implements `From<&str>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ `From<&str>`
 
 error[E0277]: the trait bound `ToolB: TryFrom<&PathBuf>` is not satisfied
   --> $DIR/explicit-reference-cast.rs:43:13

--- a/tests/ui/traits/inheritance/repeated-supertrait-ambig.stderr
+++ b/tests/ui/traits/inheritance/repeated-supertrait-ambig.stderr
@@ -6,14 +6,14 @@ LL |     c.same_as(22)
    |       |
    |       required by a bound introduced by this call
    |
-help: the following other types implement trait `CompareTo<T>`
+help: `i64` implements trait `CompareTo<T>`
   --> $DIR/repeated-supertrait-ambig.rs:15:1
    |
 LL | impl CompareTo<i64> for i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `i64` implements `CompareTo<i64>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `CompareTo<i64>`
 ...
 LL | impl CompareTo<u64> for i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `i64` implements `CompareTo<u64>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `CompareTo<u64>`
 
 error[E0277]: the trait bound `C: CompareTo<i32>` is not satisfied
   --> $DIR/repeated-supertrait-ambig.rs:30:15
@@ -34,14 +34,14 @@ error[E0277]: the trait bound `dyn CompareToInts: CompareTo<i32>` is not satisfi
 LL |     <dyn CompareToInts>::same_as(c, 22)
    |      ^^^^^^^^^^^^^^^^^ the trait `CompareTo<i32>` is not implemented for `dyn CompareToInts`
    |
-help: the following other types implement trait `CompareTo<T>`
+help: `i64` implements trait `CompareTo<T>`
   --> $DIR/repeated-supertrait-ambig.rs:15:1
    |
 LL | impl CompareTo<i64> for i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `i64` implements `CompareTo<i64>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `CompareTo<i64>`
 ...
 LL | impl CompareTo<u64> for i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `i64` implements `CompareTo<u64>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `CompareTo<u64>`
 
 error[E0277]: the trait bound `C: CompareTo<i32>` is not satisfied
   --> $DIR/repeated-supertrait-ambig.rs:38:24
@@ -64,14 +64,14 @@ LL |     assert_eq!(22_i64.same_as(22), true);
    |                       |
    |                       required by a bound introduced by this call
    |
-help: the following other types implement trait `CompareTo<T>`
+help: `i64` implements trait `CompareTo<T>`
   --> $DIR/repeated-supertrait-ambig.rs:15:1
    |
 LL | impl CompareTo<i64> for i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `i64` implements `CompareTo<i64>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `CompareTo<i64>`
 ...
 LL | impl CompareTo<u64> for i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `i64` implements `CompareTo<u64>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `CompareTo<u64>`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/traits/next-solver/cycles/forced_ambiguity-use-head-maybe-cause.stderr
+++ b/tests/ui/traits/next-solver/cycles/forced_ambiguity-use-head-maybe-cause.stderr
@@ -5,7 +5,7 @@ LL |     impls_trait::<Root<_>>()
    |                   ^^^^^^^ cannot infer type for struct `Head<_>`
    |
    = note: cannot satisfy `Head<_>: Trait`
-help: the following types implement trait `Trait`
+help: `Head<T>` implements trait `Trait`
   --> $DIR/forced_ambiguity-use-head-maybe-cause.rs:23:1
    |
 LL | / impl<T> Trait for Head<T>

--- a/tests/ui/traits/next-solver/cycles/inductive-cycle-but-err.stderr
+++ b/tests/ui/traits/next-solver/cycles/inductive-cycle-but-err.stderr
@@ -21,7 +21,7 @@ help: the trait `Trait` is not implemented for `MultipleCandidates`
    |
 LL | struct MultipleCandidates;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
-help: the following other types implement trait `Trait`
+help: `MultipleCandidates` implements trait `Trait`
   --> $DIR/inductive-cycle-but-err.rs:26:1
    |
 LL | / impl Trait for MultipleCandidates

--- a/tests/ui/traits/next-solver/unevaluated-const-impl-trait-ref.fails.stderr
+++ b/tests/ui/traits/next-solver/unevaluated-const-impl-trait-ref.fails.stderr
@@ -4,13 +4,13 @@ error[E0277]: the trait bound `(): Trait<1>` is not satisfied
 LL |     needs::<1>();
    |             ^ the trait `Trait<1>` is not implemented for `()`
    |
-help: the following other types implement trait `Trait<N>`
+help: `()` implements trait `Trait<N>`
   --> $DIR/unevaluated-const-impl-trait-ref.rs:7:1
    |
 LL | impl Trait<{ 1 - 1 }> for () {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `()` implements `Trait<0>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Trait<0>`
 LL | impl Trait<{ 1 + 1 }> for () {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `()` implements `Trait<2>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Trait<2>`
 note: required by a bound in `needs`
   --> $DIR/unevaluated-const-impl-trait-ref.rs:10:38
    |

--- a/tests/ui/traits/question-mark-result-err-mismatch.rs
+++ b/tests/ui/traits/question-mark-result-err-mismatch.rs
@@ -35,7 +35,7 @@ fn bar() -> Result<(), String> { //~ NOTE expected `String` because of this
     //~| NOTE the trait `From<()>` is not implemented for `String`
     //~| NOTE the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
     //~| NOTE required for `Result<(), String>` to implement `FromResidual<Result<Infallible, ()>>`
-    //~| HELP the following other types implement trait `From<T>`:
+    //~| HELP `String` implements trait `From<T>`:
     Ok(one)
 }
 

--- a/tests/ui/traits/question-mark-result-err-mismatch.stderr
+++ b/tests/ui/traits/question-mark-result-err-mismatch.stderr
@@ -30,13 +30,13 @@ LL |         .map_err(|_| ())?;
    |          this can't be annotated with `?` because it has type `Result<_, ()>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-   = help: the following other types implement trait `From<T>`:
-             `String` implements `From<&String>`
-             `String` implements `From<&mut str>`
-             `String` implements `From<&str>`
-             `String` implements `From<Box<str>>`
-             `String` implements `From<Cow<'_, str>>`
-             `String` implements `From<char>`
+   = help: `String` implements trait `From<T>`:
+             From<&String>
+             From<&mut str>
+             From<&str>
+             From<Box<str>>
+             From<Cow<'_, str>>
+             From<char>
    = note: required for `Result<(), String>` to implement `FromResidual<Result<Infallible, ()>>`
 
 error[E0277]: `?` couldn't convert the error to `String`

--- a/tests/ui/traits/question-mark-span-144304.stderr
+++ b/tests/ui/traits/question-mark-span-144304.stderr
@@ -9,12 +9,12 @@ LL |     Err("str").map_err(|e| e)?;
    |     this has type `Result<_, &str>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-   = help: the following other types implement trait `From<T>`:
-             `i32` implements `From<bool>`
-             `i32` implements `From<i16>`
-             `i32` implements `From<i8>`
-             `i32` implements `From<u16>`
-             `i32` implements `From<u8>`
+   = help: `i32` implements trait `From<T>`:
+             From<bool>
+             From<i16>
+             From<i8>
+             From<u16>
+             From<u8>
 
 error[E0277]: `?` couldn't convert the error to `i32`
   --> $DIR/question-mark-span-144304.rs:4:42
@@ -29,12 +29,12 @@ LL |     Err("str").map_err(|e| e.to_string())?;
    |     this has type `Result<_, &str>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-   = help: the following other types implement trait `From<T>`:
-             `i32` implements `From<bool>`
-             `i32` implements `From<i16>`
-             `i32` implements `From<i8>`
-             `i32` implements `From<u16>`
-             `i32` implements `From<u8>`
+   = help: `i32` implements trait `From<T>`:
+             From<bool>
+             From<i16>
+             From<i8>
+             From<u16>
+             From<u8>
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/try-trait/bad-interconversion.stderr
+++ b/tests/ui/try-trait/bad-interconversion.stderr
@@ -9,16 +9,16 @@ LL |     Ok(Err(123_i32)?)
    |        this can't be annotated with `?` because it has type `Result<_, i32>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-help: the following other types implement trait `From<T>`
+help: `u8` implements trait `From<T>`
   --> $SRC_DIR/core/src/convert/num.rs:LL:COL
    |
-   = note: `u8` implements `From<bool>`
+   = note: `From<bool>`
   ::: $SRC_DIR/core/src/convert/num.rs:LL:COL
    |
    = note: in this macro invocation
   --> $SRC_DIR/core/src/ascii/ascii_char.rs:LL:COL
    |
-   = note: `u8` implements `From<std::ascii::Char>`
+   = note: `From<std::ascii::Char>`
   ::: $SRC_DIR/core/src/ascii/ascii_char.rs:LL:COL
    |
    = note: in this macro invocation

--- a/tests/ui/type-alias-impl-trait/constrain_in_projection2.current.stderr
+++ b/tests/ui/type-alias-impl-trait/constrain_in_projection2.current.stderr
@@ -9,14 +9,14 @@ help: the trait `Trait<Bar>` is not implemented for `Foo`
    |
 LL | struct Foo;
    | ^^^^^^^^^^
-help: the following other types implement trait `Trait<T>`
+help: `Foo` implements trait `Trait<T>`
   --> $DIR/constrain_in_projection2.rs:18:1
    |
 LL | impl Trait<()> for Foo {
-   | ^^^^^^^^^^^^^^^^^^^^^^ `Foo` implements `Trait<()>`
+   | ^^^^^^^^^^^^^^^^^^^^^^ `Trait<()>`
 ...
 LL | impl Trait<u32> for Foo {
-   | ^^^^^^^^^^^^^^^^^^^^^^^ `Foo` implements `Trait<u32>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^ `Trait<u32>`
 
 error[E0277]: the trait bound `Foo: Trait<Bar>` is not satisfied
   --> $DIR/constrain_in_projection2.rs:28:13
@@ -29,14 +29,14 @@ help: the trait `Trait<Bar>` is not implemented for `Foo`
    |
 LL | struct Foo;
    | ^^^^^^^^^^
-help: the following other types implement trait `Trait<T>`
+help: `Foo` implements trait `Trait<T>`
   --> $DIR/constrain_in_projection2.rs:18:1
    |
 LL | impl Trait<()> for Foo {
-   | ^^^^^^^^^^^^^^^^^^^^^^ `Foo` implements `Trait<()>`
+   | ^^^^^^^^^^^^^^^^^^^^^^ `Trait<()>`
 ...
 LL | impl Trait<u32> for Foo {
-   | ^^^^^^^^^^^^^^^^^^^^^^^ `Foo` implements `Trait<u32>`
+   | ^^^^^^^^^^^^^^^^^^^^^^^ `Trait<u32>`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/type-alias-impl-trait/nested-tait-inference2.current.stderr
+++ b/tests/ui/type-alias-impl-trait/nested-tait-inference2.current.stderr
@@ -7,13 +7,13 @@ LL |
 LL |     ()
    |     -- return type was inferred to be `()` here
    |
-help: the following other types implement trait `Foo<A>`
+help: `()` implements trait `Foo<A>`
   --> $DIR/nested-tait-inference2.rs:14:1
    |
 LL | impl Foo<()> for () {}
-   | ^^^^^^^^^^^^^^^^^^^ `()` implements `Foo<()>`
+   | ^^^^^^^^^^^^^^^^^^^ `Foo<()>`
 LL | impl Foo<u32> for () {}
-   | ^^^^^^^^^^^^^^^^^^^^ `()` implements `Foo<u32>`
+   | ^^^^^^^^^^^^^^^^^^^^ `Foo<u32>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/issue-90101.stderr
+++ b/tests/ui/typeck/issue-90101.stderr
@@ -6,12 +6,12 @@ LL |     func(Path::new("hello").to_path_buf().to_string_lossy(), "world")
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the following other types implement trait `From<T>`:
-             `PathBuf` implements `From<&T>`
-             `PathBuf` implements `From<Box<Path>>`
-             `PathBuf` implements `From<Cow<'_, Path>>`
-             `PathBuf` implements `From<OsString>`
-             `PathBuf` implements `From<String>`
+   = help: `PathBuf` implements trait `From<T>`:
+             From<&T>
+             From<Box<Path>>
+             From<Cow<'_, Path>>
+             From<OsString>
+             From<String>
    = note: required for `Cow<'_, str>` to implement `Into<PathBuf>`
 note: required by a bound in `func`
   --> $DIR/issue-90101.rs:3:20

--- a/tests/ui/where-clauses/cfg_attribute.a.stderr
+++ b/tests/ui/where-clauses/cfg_attribute.a.stderr
@@ -93,6 +93,38 @@ LL |     #[rustfmt::skip] ():,
    = help: only `#[cfg]` and `#[cfg_attr]` are supported
 
 error: most attributes are not supported in `where` clauses
+  --> $DIR/cfg_attribute.rs:42:9
+   |
+LL |         #[derive(Clone)] ():,
+   |         ^^^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: most attributes are not supported in `where` clauses
+  --> $DIR/cfg_attribute.rs:45:9
+   |
+LL |         #[rustfmt::skip] ():;
+   |         ^^^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: most attributes are not supported in `where` clauses
+  --> $DIR/cfg_attribute.rs:53:9
+   |
+LL |         #[derive(Clone)] ():,
+   |         ^^^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: most attributes are not supported in `where` clauses
+  --> $DIR/cfg_attribute.rs:56:9
+   |
+LL |         #[rustfmt::skip] ():;
+   |         ^^^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: most attributes are not supported in `where` clauses
   --> $DIR/cfg_attribute.rs:65:5
    |
 LL |     #[derive(Clone)] ():,
@@ -105,6 +137,38 @@ error: most attributes are not supported in `where` clauses
    |
 LL |     #[rustfmt::skip] ():,
    |     ^^^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: most attributes are not supported in `where` clauses
+  --> $DIR/cfg_attribute.rs:75:9
+   |
+LL |         #[derive(Clone)] ():,
+   |         ^^^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: most attributes are not supported in `where` clauses
+  --> $DIR/cfg_attribute.rs:78:9
+   |
+LL |         #[rustfmt::skip] ():;
+   |         ^^^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: most attributes are not supported in `where` clauses
+  --> $DIR/cfg_attribute.rs:86:9
+   |
+LL |         #[derive(Clone)] ():,
+   |         ^^^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: most attributes are not supported in `where` clauses
+  --> $DIR/cfg_attribute.rs:89:9
+   |
+LL |         #[rustfmt::skip] ():,
+   |         ^^^^^^^^^^^^^^^^
    |
    = help: only `#[cfg]` and `#[cfg_attr]` are supported
 
@@ -189,86 +253,6 @@ LL |     #[rustfmt::skip] ():,
    = help: only `#[cfg]` and `#[cfg_attr]` are supported
 
 error: most attributes are not supported in `where` clauses
-  --> $DIR/cfg_attribute.rs:177:5
-   |
-LL |     #[derive(Clone)] ():,
-   |     ^^^^^^^^^^^^^^^^
-   |
-   = help: only `#[cfg]` and `#[cfg_attr]` are supported
-
-error: most attributes are not supported in `where` clauses
-  --> $DIR/cfg_attribute.rs:180:5
-   |
-LL |     #[rustfmt::skip] ():,
-   |     ^^^^^^^^^^^^^^^^
-   |
-   = help: only `#[cfg]` and `#[cfg_attr]` are supported
-
-error: most attributes are not supported in `where` clauses
-  --> $DIR/cfg_attribute.rs:42:9
-   |
-LL |         #[derive(Clone)] ():,
-   |         ^^^^^^^^^^^^^^^^
-   |
-   = help: only `#[cfg]` and `#[cfg_attr]` are supported
-
-error: most attributes are not supported in `where` clauses
-  --> $DIR/cfg_attribute.rs:45:9
-   |
-LL |         #[rustfmt::skip] ():;
-   |         ^^^^^^^^^^^^^^^^
-   |
-   = help: only `#[cfg]` and `#[cfg_attr]` are supported
-
-error: most attributes are not supported in `where` clauses
-  --> $DIR/cfg_attribute.rs:53:9
-   |
-LL |         #[derive(Clone)] ():,
-   |         ^^^^^^^^^^^^^^^^
-   |
-   = help: only `#[cfg]` and `#[cfg_attr]` are supported
-
-error: most attributes are not supported in `where` clauses
-  --> $DIR/cfg_attribute.rs:56:9
-   |
-LL |         #[rustfmt::skip] ():;
-   |         ^^^^^^^^^^^^^^^^
-   |
-   = help: only `#[cfg]` and `#[cfg_attr]` are supported
-
-error: most attributes are not supported in `where` clauses
-  --> $DIR/cfg_attribute.rs:75:9
-   |
-LL |         #[derive(Clone)] ():,
-   |         ^^^^^^^^^^^^^^^^
-   |
-   = help: only `#[cfg]` and `#[cfg_attr]` are supported
-
-error: most attributes are not supported in `where` clauses
-  --> $DIR/cfg_attribute.rs:78:9
-   |
-LL |         #[rustfmt::skip] ():;
-   |         ^^^^^^^^^^^^^^^^
-   |
-   = help: only `#[cfg]` and `#[cfg_attr]` are supported
-
-error: most attributes are not supported in `where` clauses
-  --> $DIR/cfg_attribute.rs:86:9
-   |
-LL |         #[derive(Clone)] ():,
-   |         ^^^^^^^^^^^^^^^^
-   |
-   = help: only `#[cfg]` and `#[cfg_attr]` are supported
-
-error: most attributes are not supported in `where` clauses
-  --> $DIR/cfg_attribute.rs:89:9
-   |
-LL |         #[rustfmt::skip] ():,
-   |         ^^^^^^^^^^^^^^^^
-   |
-   = help: only `#[cfg]` and `#[cfg_attr]` are supported
-
-error: most attributes are not supported in `where` clauses
   --> $DIR/cfg_attribute.rs:164:9
    |
 LL |         #[derive(Clone)] ():,
@@ -281,6 +265,22 @@ error: most attributes are not supported in `where` clauses
    |
 LL |         #[rustfmt::skip] ():,
    |         ^^^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: most attributes are not supported in `where` clauses
+  --> $DIR/cfg_attribute.rs:177:5
+   |
+LL |     #[derive(Clone)] ():,
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: most attributes are not supported in `where` clauses
+  --> $DIR/cfg_attribute.rs:180:5
+   |
+LL |     #[rustfmt::skip] ():,
+   |     ^^^^^^^^^^^^^^^^
    |
    = help: only `#[cfg]` and `#[cfg_attr]` are supported
 

--- a/tests/ui/where-clauses/cfg_attribute.b.stderr
+++ b/tests/ui/where-clauses/cfg_attribute.b.stderr
@@ -93,6 +93,38 @@ LL |     #[rustfmt::skip] ():,
    = help: only `#[cfg]` and `#[cfg_attr]` are supported
 
 error: most attributes are not supported in `where` clauses
+  --> $DIR/cfg_attribute.rs:42:9
+   |
+LL |         #[derive(Clone)] ():,
+   |         ^^^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: most attributes are not supported in `where` clauses
+  --> $DIR/cfg_attribute.rs:45:9
+   |
+LL |         #[rustfmt::skip] ():;
+   |         ^^^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: most attributes are not supported in `where` clauses
+  --> $DIR/cfg_attribute.rs:53:9
+   |
+LL |         #[derive(Clone)] ():,
+   |         ^^^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: most attributes are not supported in `where` clauses
+  --> $DIR/cfg_attribute.rs:56:9
+   |
+LL |         #[rustfmt::skip] ():;
+   |         ^^^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: most attributes are not supported in `where` clauses
   --> $DIR/cfg_attribute.rs:65:5
    |
 LL |     #[derive(Clone)] ():,
@@ -105,6 +137,38 @@ error: most attributes are not supported in `where` clauses
    |
 LL |     #[rustfmt::skip] ():,
    |     ^^^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: most attributes are not supported in `where` clauses
+  --> $DIR/cfg_attribute.rs:75:9
+   |
+LL |         #[derive(Clone)] ():,
+   |         ^^^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: most attributes are not supported in `where` clauses
+  --> $DIR/cfg_attribute.rs:78:9
+   |
+LL |         #[rustfmt::skip] ():;
+   |         ^^^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: most attributes are not supported in `where` clauses
+  --> $DIR/cfg_attribute.rs:86:9
+   |
+LL |         #[derive(Clone)] ():,
+   |         ^^^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: most attributes are not supported in `where` clauses
+  --> $DIR/cfg_attribute.rs:89:9
+   |
+LL |         #[rustfmt::skip] ():,
+   |         ^^^^^^^^^^^^^^^^
    |
    = help: only `#[cfg]` and `#[cfg_attr]` are supported
 
@@ -189,86 +253,6 @@ LL |     #[rustfmt::skip] ():,
    = help: only `#[cfg]` and `#[cfg_attr]` are supported
 
 error: most attributes are not supported in `where` clauses
-  --> $DIR/cfg_attribute.rs:177:5
-   |
-LL |     #[derive(Clone)] ():,
-   |     ^^^^^^^^^^^^^^^^
-   |
-   = help: only `#[cfg]` and `#[cfg_attr]` are supported
-
-error: most attributes are not supported in `where` clauses
-  --> $DIR/cfg_attribute.rs:180:5
-   |
-LL |     #[rustfmt::skip] ():,
-   |     ^^^^^^^^^^^^^^^^
-   |
-   = help: only `#[cfg]` and `#[cfg_attr]` are supported
-
-error: most attributes are not supported in `where` clauses
-  --> $DIR/cfg_attribute.rs:42:9
-   |
-LL |         #[derive(Clone)] ():,
-   |         ^^^^^^^^^^^^^^^^
-   |
-   = help: only `#[cfg]` and `#[cfg_attr]` are supported
-
-error: most attributes are not supported in `where` clauses
-  --> $DIR/cfg_attribute.rs:45:9
-   |
-LL |         #[rustfmt::skip] ():;
-   |         ^^^^^^^^^^^^^^^^
-   |
-   = help: only `#[cfg]` and `#[cfg_attr]` are supported
-
-error: most attributes are not supported in `where` clauses
-  --> $DIR/cfg_attribute.rs:53:9
-   |
-LL |         #[derive(Clone)] ():,
-   |         ^^^^^^^^^^^^^^^^
-   |
-   = help: only `#[cfg]` and `#[cfg_attr]` are supported
-
-error: most attributes are not supported in `where` clauses
-  --> $DIR/cfg_attribute.rs:56:9
-   |
-LL |         #[rustfmt::skip] ():;
-   |         ^^^^^^^^^^^^^^^^
-   |
-   = help: only `#[cfg]` and `#[cfg_attr]` are supported
-
-error: most attributes are not supported in `where` clauses
-  --> $DIR/cfg_attribute.rs:75:9
-   |
-LL |         #[derive(Clone)] ():,
-   |         ^^^^^^^^^^^^^^^^
-   |
-   = help: only `#[cfg]` and `#[cfg_attr]` are supported
-
-error: most attributes are not supported in `where` clauses
-  --> $DIR/cfg_attribute.rs:78:9
-   |
-LL |         #[rustfmt::skip] ():;
-   |         ^^^^^^^^^^^^^^^^
-   |
-   = help: only `#[cfg]` and `#[cfg_attr]` are supported
-
-error: most attributes are not supported in `where` clauses
-  --> $DIR/cfg_attribute.rs:86:9
-   |
-LL |         #[derive(Clone)] ():,
-   |         ^^^^^^^^^^^^^^^^
-   |
-   = help: only `#[cfg]` and `#[cfg_attr]` are supported
-
-error: most attributes are not supported in `where` clauses
-  --> $DIR/cfg_attribute.rs:89:9
-   |
-LL |         #[rustfmt::skip] ():,
-   |         ^^^^^^^^^^^^^^^^
-   |
-   = help: only `#[cfg]` and `#[cfg_attr]` are supported
-
-error: most attributes are not supported in `where` clauses
   --> $DIR/cfg_attribute.rs:164:9
    |
 LL |         #[derive(Clone)] ():,
@@ -281,6 +265,22 @@ error: most attributes are not supported in `where` clauses
    |
 LL |         #[rustfmt::skip] ():,
    |         ^^^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: most attributes are not supported in `where` clauses
+  --> $DIR/cfg_attribute.rs:177:5
+   |
+LL |     #[derive(Clone)] ():,
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: most attributes are not supported in `where` clauses
+  --> $DIR/cfg_attribute.rs:180:5
+   |
+LL |     #[rustfmt::skip] ():,
+   |     ^^^^^^^^^^^^^^^^
    |
    = help: only `#[cfg]` and `#[cfg_attr]` are supported
 

--- a/tests/ui/where-clauses/unsupported_attribute.stderr
+++ b/tests/ui/where-clauses/unsupported_attribute.stderr
@@ -10,6 +10,22 @@ error: expected non-macro attribute, found attribute macro `derive`
 LL |     #[derive(Clone)] 'a: 'static,
    |       ^^^^^^ not a non-macro attribute
 
+error: most attributes are not supported in `where` clauses
+  --> $DIR/unsupported_attribute.rs:13:5
+   |
+LL |     #[doc = "doc"] T: Trait,
+   |     ^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: most attributes are not supported in `where` clauses
+  --> $DIR/unsupported_attribute.rs:14:5
+   |
+LL |     #[doc = "doc"] 'a: 'static,
+   |     ^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
 error: `#[ignore]` attribute cannot be used on where predicates
   --> $DIR/unsupported_attribute.rs:15:5
    |
@@ -58,6 +74,22 @@ LL |     #[macro_use] 'a: 'static,
    |
    = help: `#[macro_use]` can be applied to crates, extern crates, and modules
 
+error: most attributes are not supported in `where` clauses
+  --> $DIR/unsupported_attribute.rs:21:5
+   |
+LL |     #[allow(unused)] T: Trait,
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: most attributes are not supported in `where` clauses
+  --> $DIR/unsupported_attribute.rs:22:5
+   |
+LL |     #[allow(unused)] 'a: 'static,
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
 error: `#[deprecated]` attribute cannot be used on where predicates
   --> $DIR/unsupported_attribute.rs:23:5
    |
@@ -89,38 +121,6 @@ LL |     #[automatically_derived] 'a: 'static,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
-
-error: most attributes are not supported in `where` clauses
-  --> $DIR/unsupported_attribute.rs:13:5
-   |
-LL |     #[doc = "doc"] T: Trait,
-   |     ^^^^^^^^^^^^^^
-   |
-   = help: only `#[cfg]` and `#[cfg_attr]` are supported
-
-error: most attributes are not supported in `where` clauses
-  --> $DIR/unsupported_attribute.rs:14:5
-   |
-LL |     #[doc = "doc"] 'a: 'static,
-   |     ^^^^^^^^^^^^^^
-   |
-   = help: only `#[cfg]` and `#[cfg_attr]` are supported
-
-error: most attributes are not supported in `where` clauses
-  --> $DIR/unsupported_attribute.rs:21:5
-   |
-LL |     #[allow(unused)] T: Trait,
-   |     ^^^^^^^^^^^^^^^^
-   |
-   = help: only `#[cfg]` and `#[cfg_attr]` are supported
-
-error: most attributes are not supported in `where` clauses
-  --> $DIR/unsupported_attribute.rs:22:5
-   |
-LL |     #[allow(unused)] 'a: 'static,
-   |     ^^^^^^^^^^^^^^^^
-   |
-   = help: only `#[cfg]` and `#[cfg_attr]` are supported
 
 error: most attributes are not supported in `where` clauses
   --> $DIR/unsupported_attribute.rs:27:5


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#153686 (`std`: include `dlmalloc` for all non-wasi Wasm targets)
 - rust-lang/rust#154105 (bootstrap: Pass `--features=rustc` to rustc_transmute)
 - rust-lang/rust#153041 (Remove `ATTRIBUTE_ORDER`)
 - rust-lang/rust#153069 ([BPF] add target feature allows-misaligned-mem-access)
 - rust-lang/rust#154085 (Parenthesize or-patterns in prefix pattern positions in pretty printer)
 - rust-lang/rust#154191 (refactor RangeFromIter overflow-checks impl)
 - rust-lang/rust#154207 (Refactor query loading)
 - rust-lang/rust#153540 (drop derive helpers during attribute parsing)
 - rust-lang/rust#154140 (Document consteval behavior of ub_checks, overflow_checks, is_val_statically_known.)
 - rust-lang/rust#154161 (On E0277 tweak help when single type impls traits)
 - rust-lang/rust#154218 (interpret/validity: remove unreachable error kind)
 - rust-lang/rust#154225 (diagnostics: avoid ICE in confusable_method_name for associated functions)
 - rust-lang/rust#154228 (Improve inline assembly error messages)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=153686,154105,153041,153069,154085,154191,154207,153540,154140,154161,154218,154225,154228)
<!-- homu-ignore:end -->

