### PR TITLE
bootstrap: Switch download-rustc back on by default for `profile = library`

### DIFF
--- a/src/bootstrap/defaults/bootstrap.library.toml
+++ b/src/bootstrap/defaults/bootstrap.library.toml
@@ -1,8 +1,4 @@
 # These defaults are meant for contributors to the standard library and documentation.
-[build]
-bench-stage = 1
-test-stage = 1
-
 [rust]
 # This greatly increases the speed of rebuilds, especially when there are only minor changes. However, it makes the initial build slightly slower.
 incremental = true
@@ -12,8 +8,7 @@ lto = "off"
 #
 # If compiler-affecting directories are not modified, use precompiled rustc to speed up
 # library development by skipping compiler builds.
-# FIXME: download-rustc is currently broken: https://github.com/rust-lang/rust/issues/142505
-download-rustc = false
+download-rustc = "if-unchanged"
 
 [llvm]
 # Will download LLVM from CI if available on your platform.

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -2237,17 +2237,31 @@ pub fn download_ci_rustc_commit<'a>(
         });
         match freshness {
             PathFreshness::LastModifiedUpstream { upstream } => upstream,
-            PathFreshness::HasLocalModifications { upstream } => {
-                if if_unchanged {
-                    return None;
-                }
-
+            PathFreshness::HasLocalModifications { upstream, modifications } => {
                 if dwn_ctx.is_running_on_ci() {
                     eprintln!("CI rustc commit matches with HEAD and we are in CI.");
                     eprintln!(
                         "`rustc.download-ci` functionality will be skipped as artifacts are not available."
                     );
                     return None;
+                }
+
+                eprintln!(
+                    "NOTE: detected {} modifications that could affect a build of rustc",
+                    modifications.len()
+                );
+                for file in modifications.iter().take(10) {
+                    eprintln!("- {}", file.display());
+                }
+                if modifications.len() > 10 {
+                    eprintln!("- ...");
+                }
+
+                if if_unchanged {
+                    eprintln!("skipping rustc download due to `download-rustc = 'if-unchanged'`");
+                    return None;
+                } else {
+                    eprintln!("downloading anyway due to `download-rustc = true`");
                 }
 
                 upstream

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -78,6 +78,7 @@ pub const RUSTC_IF_UNCHANGED_ALLOWED_PATHS: &[&str] = &[
     ":!src/rustdoc-json-types",
     ":!tests",
     ":!triagebot.toml",
+    ":!src/bootstrap/defaults",
 ];
 
 /// Global configuration for the entire build and/or bootstrap.

--- a/src/bootstrap/src/core/config/tests.rs
+++ b/src/bootstrap/src/core/config/tests.rs
@@ -32,6 +32,13 @@ fn get_toml(file: &Path) -> Result<TomlConfig, toml::de::Error> {
     toml::from_str(&contents).and_then(|table: toml::Value| TomlConfig::deserialize(table))
 }
 
+fn modified(upstream: impl Into<String>, changes: &[&str]) -> PathFreshness {
+    PathFreshness::HasLocalModifications {
+        upstream: upstream.into(),
+        modifications: changes.iter().copied().map(PathBuf::from).collect(),
+    }
+}
+
 #[test]
 fn download_ci_llvm() {
     let config = TestCtx::new().config("check").create_config();
@@ -692,7 +699,7 @@ fn test_pr_ci_changed_in_pr() {
         let sha = ctx.create_upstream_merge(&["a"]);
         ctx.create_nonupstream_merge(&["b"]);
         let src = ctx.check_modifications(&["b"], CiEnv::GitHubActions);
-        assert_eq!(src, PathFreshness::HasLocalModifications { upstream: sha });
+        assert_eq!(src, modified(sha, &["b"]));
     });
 }
 
@@ -712,7 +719,7 @@ fn test_auto_ci_changed_in_pr() {
         let sha = ctx.create_upstream_merge(&["a"]);
         ctx.create_upstream_merge(&["b", "c"]);
         let src = ctx.check_modifications(&["c", "d"], CiEnv::GitHubActions);
-        assert_eq!(src, PathFreshness::HasLocalModifications { upstream: sha });
+        assert_eq!(src, modified(sha, &["c"]));
     });
 }
 
@@ -723,10 +730,7 @@ fn test_local_uncommitted_modifications() {
         ctx.create_branch("feature");
         ctx.modify("a");
 
-        assert_eq!(
-            ctx.check_modifications(&["a", "d"], CiEnv::None),
-            PathFreshness::HasLocalModifications { upstream: sha }
-        );
+        assert_eq!(ctx.check_modifications(&["a", "d"], CiEnv::None), modified(sha, &["a"]),);
     });
 }
 
@@ -741,10 +745,7 @@ fn test_local_committed_modifications() {
         ctx.modify("a");
         ctx.commit();
 
-        assert_eq!(
-            ctx.check_modifications(&["a", "d"], CiEnv::None),
-            PathFreshness::HasLocalModifications { upstream: sha }
-        );
+        assert_eq!(ctx.check_modifications(&["a", "d"], CiEnv::None), modified(sha, &["a"]),);
     });
 }
 
@@ -757,10 +758,7 @@ fn test_local_committed_modifications_subdirectory() {
         ctx.modify("a/b/d");
         ctx.commit();
 
-        assert_eq!(
-            ctx.check_modifications(&["a/b"], CiEnv::None),
-            PathFreshness::HasLocalModifications { upstream: sha }
-        );
+        assert_eq!(ctx.check_modifications(&["a/b"], CiEnv::None), modified(sha, &["a/b/d"]),);
     });
 }
 
@@ -836,11 +834,11 @@ fn test_local_changes_negative_path() {
         );
         assert_eq!(
             ctx.check_modifications(&[":!c"], CiEnv::None),
-            PathFreshness::HasLocalModifications { upstream: upstream.clone() }
+            modified(&upstream, &["b", "d"]),
         );
         assert_eq!(
             ctx.check_modifications(&[":!d", ":!x"], CiEnv::None),
-            PathFreshness::HasLocalModifications { upstream }
+            modified(&upstream, &["b"]),
         );
     });
 }

--- a/src/bootstrap/src/core/download.rs
+++ b/src/bootstrap/src/core/download.rs
@@ -266,7 +266,7 @@ impl Config {
         });
         let llvm_sha = match llvm_freshness {
             PathFreshness::LastModifiedUpstream { upstream } => upstream,
-            PathFreshness::HasLocalModifications { upstream } => upstream,
+            PathFreshness::HasLocalModifications { upstream, modifications: _ } => upstream,
             PathFreshness::MissingUpstream => {
                 eprintln!("error: could not find commit hash for downloading LLVM");
                 eprintln!("HELP: maybe your repository history is too shallow?");

--- a/src/build_helper/src/git.rs
+++ b/src/build_helper/src/git.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use crate::ci::CiEnv;
@@ -38,7 +38,7 @@ pub enum PathFreshness {
     /// "Local" essentially means "not-upstream" here.
     /// `upstream` is the latest upstream merge commit that made modifications to the
     /// set of paths.
-    HasLocalModifications { upstream: String },
+    HasLocalModifications { upstream: String, modifications: Vec<PathBuf> },
     /// No upstream commit was found.
     /// This should not happen in most reasonable circumstances, but one never knows.
     MissingUpstream,
@@ -134,21 +134,34 @@ pub fn check_path_modifications(
     // However, that should be equivalent to checking if something has changed
     // from the latest upstream commit *that modified `target_paths`*, and
     // with this approach we do not need to invoke git an additional time.
-    if has_changed_since(git_dir, &upstream_sha, target_paths) {
-        Ok(PathFreshness::HasLocalModifications { upstream: upstream_sha })
+    let modifications = changes_since(git_dir, &upstream_sha, target_paths)?;
+    if !modifications.is_empty() {
+        Ok(PathFreshness::HasLocalModifications { upstream: upstream_sha, modifications })
     } else {
         Ok(PathFreshness::LastModifiedUpstream { upstream: upstream_sha })
     }
 }
 
 /// Returns true if any of the passed `paths` have changed since the `base` commit.
-pub fn has_changed_since(git_dir: &Path, base: &str, paths: &[&str]) -> bool {
-    run_git_diff_index(Some(git_dir), |cmd| {
-        cmd.args(["--quiet", base, "--"]).args(paths);
+pub fn changes_since(git_dir: &Path, base: &str, paths: &[&str]) -> Result<Vec<PathBuf>, String> {
+    use std::io::BufRead;
 
-        // Exit code 0 => no changes
-        // Exit code 1 => some changes were detected
-        !cmd.status().expect("cannot run git diff-index").success()
+    run_git_diff_index(Some(git_dir), |cmd| {
+        cmd.args([base, "--name-only", "--"]).args(paths);
+
+        let output = cmd.stderr(Stdio::inherit()).output().expect("cannot run git diff-index");
+        if !output.status.success() {
+            return Err(format!("failed to run: {cmd:?}: {:?}", output.status));
+        }
+
+        output
+            .stdout
+            .lines()
+            .map(|res| match res {
+                Ok(line) => Ok(PathBuf::from(line)),
+                Err(e) => Err(format!("invalid UTF-8 in diff-index: {e:?}")),
+            })
+            .collect()
     })
 }
 


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/142505 for context. There are actually three changes here, I left detailed commit messages.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
