### PR TITLE
Add test for issue #101532: dead code warnings in const _

### DIFF
--- a/tests/ui/lint/dead-code/const-underscore-issue-101532.rs
+++ b/tests/ui/lint/dead-code/const-underscore-issue-101532.rs
@@ -1,0 +1,14 @@
+//@ check-pass
+// Test for issue #101532 - dead code warnings should work inside const _
+
+#![warn(dead_code)]
+
+const _: () = {
+    let a: ();
+    struct B {} //~ WARN struct `B` is never constructed
+    enum C {}   //~ WARN enum `C` is never used
+    fn d() {}   //~ WARN function `d` is never used
+    const E: () = {}; //~ WARN constant `E` is never used
+};
+
+fn main() {}

--- a/tests/ui/lint/dead-code/const-underscore-issue-101532.stderr
+++ b/tests/ui/lint/dead-code/const-underscore-issue-101532.stderr
@@ -1,0 +1,32 @@
+warning: struct `B` is never constructed
+  --> $DIR/const-underscore-issue-101532.rs:8:12
+   |
+LL |     struct B {}
+   |            ^
+   |
+note: the lint level is defined here
+  --> $DIR/const-underscore-issue-101532.rs:4:9
+   |
+LL | #![warn(dead_code)]
+   |         ^^^^^^^^^
+
+warning: enum `C` is never used
+  --> $DIR/const-underscore-issue-101532.rs:9:10
+   |
+LL |     enum C {}
+   |          ^
+
+warning: function `d` is never used
+  --> $DIR/const-underscore-issue-101532.rs:10:8
+   |
+LL |     fn d() {}
+   |        ^
+
+warning: constant `E` is never used
+  --> $DIR/const-underscore-issue-101532.rs:11:11
+   |
+LL |     const E: () = {};
+   |           ^
+
+warning: 4 warnings emitted
+


### PR DESCRIPTION
Closes rust-lang/rust#101532

Adds a test for dead code warnings in `const _`.

This was already fixed, just adding coverage to avoid regressions.