### PR TITLE
derive Debug diagnostics with type parameters add test

### DIFF
--- a/tests/ui/derives/derive-debug-type-param-issue-52560.rs
+++ b/tests/ui/derives/derive-debug-type-param-issue-52560.rs
@@ -1,0 +1,25 @@
+//! Test for issue #52560 - derive Debug should show improved diagnostics
+//! when type parameters are incorrectly assumed to need Debug bound
+
+use std::fmt::Debug;
+
+#[derive(Debug)]
+struct Foo<B: Bar>(B::Item);
+
+trait Bar {
+    type Item: Debug;
+}
+
+fn foo<B: Bar>(f: Foo<B>) {
+    println!("{:?}", f); //~ ERROR `B` doesn't implement `Debug`
+}
+
+struct ABC();
+
+impl Bar for ABC {
+    type Item = String;
+}
+
+fn main() {
+    foo(Foo::<ABC>("a".into()));
+}

--- a/tests/ui/derives/derive-debug-type-param-issue-52560.stderr
+++ b/tests/ui/derives/derive-debug-type-param-issue-52560.stderr
@@ -1,0 +1,21 @@
+error[E0277]: `B` doesn't implement `Debug`
+  --> $DIR/derive-debug-type-param-issue-52560.rs:14:22
+   |
+LL |     println!("{:?}", f);
+   |               ----   ^ `B` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |               |
+   |               required by this formatting parameter
+   |
+note: required for `Foo<B>` to implement `Debug`
+  --> $DIR/derive-debug-type-param-issue-52560.rs:6:10
+   |
+LL | #[derive(Debug)]
+   |          ^^^^^ unsatisfied trait bound introduced in this `derive` macro
+help: consider further restricting type parameter `B` with trait `Debug`
+   |
+LL | fn foo<B: Bar + std::fmt::Debug>(f: Foo<B>) {
+   |               +++++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
CC rust-lang/rust#52560

  This PR adds a test for improved derive Debug diagnostics when type parameters are incorrectly assumed to need Debug bounds.

  ## What this PR does:
  - Adds test file `tests/ui/derives/derive-debug-type-param-issue-52560.rs`
  - Adds expected stderr output `tests/ui/derives/derive-debug-type-param-issue-52560.stderr`
  - Tests the improved diagnostic that points to the derive macro as the source of the bound

  The test verifies that the compiler correctly identifies when derive Debug incorrectly requires type parameter bounds when only associated types are
  actually used.

  r? rust-lang/compiler
