### PR TITLE
interpret: when passing an argument fails, point at that argument

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -88,7 +88,7 @@ fn eval_body_using_ecx<'tcx, R: InterpretationResult<'tcx>>(
         &ret.clone().into(),
         ReturnContinuation::Stop { cleanup: false },
     )?;
-    ecx.storage_live_for_always_live_locals()?;
+    ecx.push_stack_frame_done()?;
 
     // The main interpreter loop.
     while ecx.step()? {

--- a/compiler/rustc_const_eval/src/interpret/call.rs
+++ b/compiler/rustc_const_eval/src/interpret/call.rs
@@ -404,166 +404,158 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
 
         // Push the "raw" frame -- this leaves locals uninitialized.
         self.push_stack_frame_raw(instance, body, destination, cont)?;
+        let preamble_span = self.frame().loc.unwrap_right(); // the span used for preamble errors
 
-        // If an error is raised here, pop the frame again to get an accurate backtrace.
-        // To this end, we wrap it all in a `try` block.
-        let res: InterpResult<'tcx> = try {
-            trace!(
-                "caller ABI: {:#?}, args: {:#?}",
-                caller_fn_abi,
-                args.iter()
-                    .map(|arg| (
-                        arg.layout().ty,
-                        match arg {
-                            FnArg::Copy(op) => format!("copy({op:?})"),
-                            FnArg::InPlace(mplace) => format!("in-place({mplace:?})"),
-                        }
-                    ))
-                    .collect::<Vec<_>>()
-            );
-            trace!(
-                "spread_arg: {:?}, locals: {:#?}",
-                body.spread_arg,
-                body.args_iter()
-                    .map(|local| (
-                        local,
-                        self.layout_of_local(self.frame(), local, None).unwrap().ty,
-                    ))
-                    .collect::<Vec<_>>()
-            );
-
-            // In principle, we have two iterators: Where the arguments come from, and where
-            // they go to.
-
-            // The "where they come from" part is easy, we expect the caller to do any special handling
-            // that might be required here (e.g. for untupling).
-            // If `with_caller_location` is set we pretend there is an extra argument (that
-            // we will not pass; our `caller_location` intrinsic implementation walks the stack instead).
-            assert_eq!(
-                args.len() + if with_caller_location { 1 } else { 0 },
-                caller_fn_abi.args.len(),
-                "mismatch between caller ABI and caller arguments",
-            );
-            let mut caller_args = args
-                .iter()
-                .zip(caller_fn_abi.args.iter())
-                .filter(|arg_and_abi| !arg_and_abi.1.is_ignore());
-
-            // Now we have to spread them out across the callee's locals,
-            // taking into account the `spread_arg`. If we could write
-            // this is a single iterator (that handles `spread_arg`), then
-            // `pass_argument` would be the loop body. It takes care to
-            // not advance `caller_iter` for ignored arguments.
-            let mut callee_args_abis = callee_fn_abi.args.iter().enumerate();
-            // Determine whether there is a special VaList argument. This is always the
-            // last argument, and since arguments start at index 1 that's `arg_count`.
-            let va_list_arg =
-                callee_fn_abi.c_variadic.then(|| mir::Local::from_usize(body.arg_count));
-            for local in body.args_iter() {
-                // Construct the destination place for this argument. At this point all
-                // locals are still dead, so we cannot construct a `PlaceTy`.
-                let dest = mir::Place::from(local);
-                // `layout_of_local` does more than just the instantiation we need to get the
-                // type, but the result gets cached so this avoids calling the instantiation
-                // query *again* the next time this local is accessed.
-                let ty = self.layout_of_local(self.frame(), local, None)?.ty;
-                if Some(local) == va_list_arg {
-                    // This is the last callee-side argument of a variadic function.
-                    // This argument is a VaList holding the remaining caller-side arguments.
-                    self.storage_live(local)?;
-
-                    let place = self.eval_place(dest)?;
-                    let mplace = self.force_allocation(&place)?;
-
-                    // Consume the remaining arguments by putting them into the variable argument
-                    // list.
-                    let varargs = self.allocate_varargs(
-                        &mut caller_args,
-                        // "Ignored" arguments aren't actually passed, so the callee should also
-                        // ignore them. (`pass_argument` does this for regular arguments.)
-                        (&mut callee_args_abis).filter(|(_, abi)| !abi.is_ignore()),
-                    )?;
-                    // When the frame is dropped, these variable arguments are deallocated.
-                    self.frame_mut().va_list = varargs.clone();
-                    let key = self.va_list_ptr(varargs.into());
-
-                    // Zero the VaList, so it is fully initialized.
-                    self.write_bytes_ptr(
-                        mplace.ptr(),
-                        (0..mplace.layout.size.bytes()).map(|_| 0u8),
-                    )?;
-
-                    // Store the "key" pointer in the right field.
-                    let key_mplace = self.va_list_key_field(&mplace)?;
-                    self.write_pointer(key, &key_mplace)?;
-                } else if Some(local) == body.spread_arg {
-                    // Make the local live once, then fill in the value field by field.
-                    self.storage_live(local)?;
-                    // Must be a tuple
-                    let ty::Tuple(fields) = ty.kind() else {
-                        span_bug!(self.cur_span(), "non-tuple type for `spread_arg`: {ty}")
-                    };
-                    for (i, field_ty) in fields.iter().enumerate() {
-                        let dest = dest.project_deeper(
-                            &[mir::ProjectionElem::Field(FieldIdx::from_usize(i), field_ty)],
-                            *self.tcx,
-                        );
-                        let (idx, callee_abi) = callee_args_abis.next().unwrap();
-                        self.pass_argument(
-                            &mut caller_args,
-                            callee_abi,
-                            idx,
-                            &dest,
-                            field_ty,
-                            /* already_live */ true,
-                        )?;
+        trace!(
+            "caller ABI: {:#?}, args: {:#?}",
+            caller_fn_abi,
+            args.iter()
+                .map(|arg| (
+                    arg.layout().ty,
+                    match arg {
+                        FnArg::Copy(op) => format!("copy({op:?})"),
+                        FnArg::InPlace(mplace) => format!("in-place({mplace:?})"),
                     }
-                } else {
-                    // Normal argument. Cannot mark it as live yet, it might be unsized!
+                ))
+                .collect::<Vec<_>>()
+        );
+        trace!(
+            "spread_arg: {:?}, locals: {:#?}",
+            body.spread_arg,
+            body.args_iter()
+                .map(|local| (local, self.layout_of_local(self.frame(), local, None).unwrap().ty,))
+                .collect::<Vec<_>>()
+        );
+
+        // In principle, we have two iterators: Where the arguments come from, and where
+        // they go to.
+
+        // The "where they come from" part is easy, we expect the caller to do any special handling
+        // that might be required here (e.g. for untupling).
+        // If `with_caller_location` is set we pretend there is an extra argument (that
+        // we will not pass; our `caller_location` intrinsic implementation walks the stack instead).
+        assert_eq!(
+            args.len() + if with_caller_location { 1 } else { 0 },
+            caller_fn_abi.args.len(),
+            "mismatch between caller ABI and caller arguments",
+        );
+        let mut caller_args = args
+            .iter()
+            .zip(caller_fn_abi.args.iter())
+            .filter(|arg_and_abi| !arg_and_abi.1.is_ignore());
+
+        // Now we have to spread them out across the callee's locals,
+        // taking into account the `spread_arg`. If we could write
+        // this is a single iterator (that handles `spread_arg`), then
+        // `pass_argument` would be the loop body. It takes care to
+        // not advance `caller_iter` for ignored arguments.
+        let mut callee_args_abis = callee_fn_abi.args.iter().enumerate();
+        // Determine whether there is a special VaList argument. This is always the
+        // last argument, and since arguments start at index 1 that's `arg_count`.
+        let va_list_arg = callee_fn_abi.c_variadic.then(|| mir::Local::from_usize(body.arg_count));
+        for local in body.args_iter() {
+            // Update the span that we show in case of an error to point to this argument.
+            self.frame_mut().loc = Right(body.local_decls[local].source_info.span);
+            // Construct the destination place for this argument. At this point all
+            // locals are still dead, so we cannot construct a `PlaceTy`.
+            let dest = mir::Place::from(local);
+            // `layout_of_local` does more than just the instantiation we need to get the
+            // type, but the result gets cached so this avoids calling the instantiation
+            // query *again* the next time this local is accessed.
+            let ty = self.layout_of_local(self.frame(), local, None)?.ty;
+            if Some(local) == va_list_arg {
+                // This is the last callee-side argument of a variadic function.
+                // This argument is a VaList holding the remaining caller-side arguments.
+                self.storage_live(local)?;
+
+                let place = self.eval_place(dest)?;
+                let mplace = self.force_allocation(&place)?;
+
+                // Consume the remaining arguments by putting them into the variable argument
+                // list.
+                let varargs = self.allocate_varargs(
+                    &mut caller_args,
+                    // "Ignored" arguments aren't actually passed, so the callee should also
+                    // ignore them. (`pass_argument` does this for regular arguments.)
+                    (&mut callee_args_abis).filter(|(_, abi)| !abi.is_ignore()),
+                )?;
+                // When the frame is dropped, these variable arguments are deallocated.
+                self.frame_mut().va_list = varargs.clone();
+                let key = self.va_list_ptr(varargs.into());
+
+                // Zero the VaList, so it is fully initialized.
+                self.write_bytes_ptr(mplace.ptr(), (0..mplace.layout.size.bytes()).map(|_| 0u8))?;
+
+                // Store the "key" pointer in the right field.
+                let key_mplace = self.va_list_key_field(&mplace)?;
+                self.write_pointer(key, &key_mplace)?;
+            } else if Some(local) == body.spread_arg {
+                // Make the local live once, then fill in the value field by field.
+                self.storage_live(local)?;
+                // Must be a tuple
+                let ty::Tuple(fields) = ty.kind() else {
+                    span_bug!(self.cur_span(), "non-tuple type for `spread_arg`: {ty}")
+                };
+                for (i, field_ty) in fields.iter().enumerate() {
+                    let dest = dest.project_deeper(
+                        &[mir::ProjectionElem::Field(FieldIdx::from_usize(i), field_ty)],
+                        *self.tcx,
+                    );
                     let (idx, callee_abi) = callee_args_abis.next().unwrap();
                     self.pass_argument(
                         &mut caller_args,
                         callee_abi,
                         idx,
                         &dest,
-                        ty,
-                        /* already_live */ false,
+                        field_ty,
+                        /* already_live */ true,
                     )?;
                 }
+            } else {
+                // Normal argument. Cannot mark it as live yet, it might be unsized!
+                let (idx, callee_abi) = callee_args_abis.next().unwrap();
+                self.pass_argument(
+                    &mut caller_args,
+                    callee_abi,
+                    idx,
+                    &dest,
+                    ty,
+                    /* already_live */ false,
+                )?;
             }
-            // If the callee needs a caller location, pretend we consume one more argument from the ABI.
-            if instance.def.requires_caller_location(*self.tcx) {
-                callee_args_abis.next().unwrap();
-            }
-            // Now we should have no more caller args or callee arg ABIs.
-            assert!(
-                callee_args_abis.next().is_none(),
-                "mismatch between callee ABI and callee body arguments"
-            );
-            if caller_args.next().is_some() {
-                throw_ub_format!("calling a function with more arguments than it expected");
-            }
-            // Don't forget to check the return type!
-            if !self.check_argument_compat(&caller_fn_abi.ret, &callee_fn_abi.ret)? {
-                throw_ub!(AbiMismatchReturn {
-                    caller_ty: caller_fn_abi.ret.layout.ty,
-                    callee_ty: callee_fn_abi.ret.layout.ty
-                });
-            }
+        }
 
-            // Protect return place for in-place return value passing.
-            // We only need to protect anything if this is actually an in-memory place.
-            if let Some(mplace) = destination_mplace {
-                M::protect_in_place_function_argument(self, &mplace)?;
-            }
+        // Don't forget to check the return type!
+        self.frame_mut().loc = Right(body.local_decls[mir::RETURN_PLACE].source_info.span);
+        if !self.check_argument_compat(&caller_fn_abi.ret, &callee_fn_abi.ret)? {
+            throw_ub!(AbiMismatchReturn {
+                caller_ty: caller_fn_abi.ret.layout.ty,
+                callee_ty: callee_fn_abi.ret.layout.ty
+            });
+        }
+        // Protect return place for in-place return value passing.
+        // We only need to protect anything if this is actually an in-memory place.
+        if let Some(mplace) = destination_mplace {
+            M::protect_in_place_function_argument(self, &mplace)?;
+        }
 
-            // Don't forget to mark "initially live" locals as live.
-            self.storage_live_for_always_live_locals()?;
-        };
-        res.inspect_err_kind(|_| {
-            // Don't show the incomplete stack frame in the error stacktrace.
-            self.stack_mut().pop();
-        })
+        // For the final checks, use same span as preamble since it is unclear what else to do.
+        self.frame_mut().loc = Right(preamble_span);
+        // If the callee needs a caller location, pretend we consume one more argument from the ABI.
+        if instance.def.requires_caller_location(*self.tcx) {
+            callee_args_abis.next().unwrap();
+        }
+        // Now we should have no more caller args or callee arg ABIs.
+        assert!(
+            callee_args_abis.next().is_none(),
+            "mismatch between callee ABI and callee body arguments"
+        );
+        if caller_args.next().is_some() {
+            throw_ub_format!("calling a function with more arguments than it expected");
+        }
+
+        // Done!
+        self.push_stack_frame_done()
     }
 
     /// Initiate a call to this function -- pushing the stack frame and initializing the arguments.

--- a/compiler/rustc_const_eval/src/interpret/stack.rs
+++ b/compiler/rustc_const_eval/src/interpret/stack.rs
@@ -381,7 +381,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         let locals = IndexVec::from_elem(dead_local, &body.local_decls);
         let pre_frame = Frame {
             body,
-            loc: Right(body.span), // Span used for errors caused during preamble.
+            loc: Right(self.tcx.def_span(body.source.def_id())), // Span used for errors caused during preamble.
             return_cont,
             return_place: return_place.clone(),
             locals,
@@ -408,7 +408,6 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
 
         // Finish things up.
         M::after_stack_push(self)?;
-        self.frame_mut().loc = Left(mir::Location::START);
         // `tracing_separate_thread` is used to instruct the tracing_chrome [tracing::Layer] in Miri
         // to put the "frame" span on a separate trace thread/line than other spans, to make the
         // visualization in <https://ui.perfetto.dev> easier to interpret. It is set to a value of
@@ -466,9 +465,11 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         }
     }
 
-    /// In the current stack frame, mark all locals as live that are not arguments and don't have
-    /// `Storage*` annotations (this includes the return place).
-    pub(crate) fn storage_live_for_always_live_locals(&mut self) -> InterpResult<'tcx> {
+    /// Call this after `push_stack_frame_raw` and when all the other setup that needs to be done
+    /// is completed.
+    pub(crate) fn push_stack_frame_done(&mut self) -> InterpResult<'tcx> {
+        // Mark all locals as live that are not arguments and don't have `Storage*` annotations
+        // (this includes the return place, but not the arguments).
         self.storage_live(mir::RETURN_PLACE)?;
 
         let body = self.body();
@@ -478,6 +479,10 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 self.storage_live(local)?;
             }
         }
+
+        // Get ready to execute the first instruction in the stack frame.
+        self.frame_mut().loc = Left(mir::Location::START);
+
         interp_ok(())
     }
 

--- a/compiler/rustc_const_eval/src/lib.rs
+++ b/compiler/rustc_const_eval/src/lib.rs
@@ -5,7 +5,6 @@
 #![feature(never_type)]
 #![feature(slice_ptr_get)]
 #![feature(trait_alias)]
-#![feature(try_blocks)]
 #![feature(unqualified_local_imports)]
 #![feature(yeet_expr)]
 #![warn(unqualified_local_imports)]

--- a/src/tools/miri/tests/fail-dep/concurrency/libc_pthread_create_too_few_args.rs
+++ b/src/tools/miri/tests/fail-dep/concurrency/libc_pthread_create_too_few_args.rs
@@ -5,6 +5,7 @@
 use std::{mem, ptr};
 
 extern "C" fn thread_start() -> *mut libc::c_void {
+    //~^ERROR: calling a function with more arguments than it expected
     panic!()
 }
 
@@ -16,7 +17,6 @@ fn main() {
             mem::transmute(thread_start);
         assert_eq!(
             libc::pthread_create(&mut native, ptr::null(), thread_start, ptr::null_mut()),
-            //~^ERROR: calling a function with more arguments than it expected
             0
         );
         assert_eq!(libc::pthread_join(native, ptr::null_mut()), 0);

--- a/src/tools/miri/tests/fail-dep/concurrency/libc_pthread_create_too_few_args.stderr
+++ b/src/tools/miri/tests/fail-dep/concurrency/libc_pthread_create_too_few_args.stderr
@@ -1,14 +1,17 @@
 error: Undefined Behavior: calling a function with more arguments than it expected
   --> tests/fail-dep/concurrency/libc_pthread_create_too_few_args.rs:LL:CC
    |
-LL |             libc::pthread_create(&mut native, ptr::null(), thread_start, ptr::null_mut()),
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred due to this code
+LL | extern "C" fn thread_start() -> *mut libc::c_void {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: this is on thread `unnamed-ID`
-   = note: this error occurred while pushing a call frame onto an empty stack
-   = note: the span indicates which code caused the function to be called, but may not be the literal call site
+note: the current function got called indirectly due to this code
+  --> tests/fail-dep/concurrency/libc_pthread_create_too_few_args.rs:LL:CC
+   |
+LL |             libc::pthread_create(&mut native, ptr::null(), thread_start, ptr::null_mut()),
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/src/tools/miri/tests/fail-dep/concurrency/libc_pthread_create_too_many_args.rs
+++ b/src/tools/miri/tests/fail-dep/concurrency/libc_pthread_create_too_many_args.rs
@@ -5,6 +5,7 @@
 use std::{mem, ptr};
 
 extern "C" fn thread_start(_null: *mut libc::c_void, _x: i32) -> *mut libc::c_void {
+    //~^ERROR: calling a function with fewer arguments than it requires
     panic!()
 }
 
@@ -16,7 +17,6 @@ fn main() {
             mem::transmute(thread_start);
         assert_eq!(
             libc::pthread_create(&mut native, ptr::null(), thread_start, ptr::null_mut()),
-            //~^ERROR: calling a function with fewer arguments than it requires
             0
         );
         assert_eq!(libc::pthread_join(native, ptr::null_mut()), 0);

--- a/src/tools/miri/tests/fail-dep/concurrency/libc_pthread_create_too_many_args.stderr
+++ b/src/tools/miri/tests/fail-dep/concurrency/libc_pthread_create_too_many_args.stderr
@@ -1,14 +1,17 @@
 error: Undefined Behavior: calling a function with fewer arguments than it requires
   --> tests/fail-dep/concurrency/libc_pthread_create_too_many_args.rs:LL:CC
    |
-LL |             libc::pthread_create(&mut native, ptr::null(), thread_start, ptr::null_mut()),
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred due to this code
+LL | extern "C" fn thread_start(_null: *mut libc::c_void, _x: i32) -> *mut libc::c_void {
+   |                                                      ^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: this is on thread `unnamed-ID`
-   = note: this error occurred while pushing a call frame onto an empty stack
-   = note: the span indicates which code caused the function to be called, but may not be the literal call site
+note: the current function got called indirectly due to this code
+  --> tests/fail-dep/concurrency/libc_pthread_create_too_many_args.rs:LL:CC
+   |
+LL |             libc::pthread_create(&mut native, ptr::null(), thread_start, ptr::null_mut()),
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/src/tools/miri/tests/fail/function_calls/arg_inplace_locals_alias.rs
+++ b/src/tools/miri/tests/fail/function_calls/arg_inplace_locals_alias.rs
@@ -21,8 +21,6 @@ fn main() {
             // This specifically uses a type with scalar representation to tempt Miri to use the
             // efficient way of storing local variables (outside adressable memory).
             Call(_unit = callee(Move(non_copy), Move(non_copy)), ReturnTo(after_call), UnwindContinue())
-            //~[stack]^ ERROR: not granting access
-            //~[tree]| ERROR: /read access .* forbidden/
         }
         after_call = {
             Return()
@@ -32,6 +30,8 @@ fn main() {
 
 #[expect(unused_variables, unused_assignments)]
 fn callee(x: S, mut y: S) {
+    //~[stack]^ ERROR: not granting access
+    //~[tree]| ERROR: /read access .* forbidden/
     // With the setup above, if `x` and `y` are both moved,
     // then writing to `y` will change the value stored in `x`!
     y.0 = 0;

--- a/src/tools/miri/tests/fail/function_calls/arg_inplace_locals_alias.stack.stderr
+++ b/src/tools/miri/tests/fail/function_calls/arg_inplace_locals_alias.stack.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected
   --> tests/fail/function_calls/arg_inplace_locals_alias.rs:LL:CC
    |
-LL |             Call(_unit = callee(Move(non_copy), Move(non_copy)), ReturnTo(after_call), UnwindContinue())
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+LL | fn callee(x: S, mut y: S) {
+   |                 ^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
@@ -14,8 +14,13 @@ LL |             Call(_unit = callee(Move(non_copy), Move(non_copy)), ReturnTo(a
 help: <TAG> is this argument
   --> tests/fail/function_calls/arg_inplace_locals_alias.rs:LL:CC
    |
-LL |     y.0 = 0;
-   |     ^^^^^^^
+LL | fn callee(x: S, mut y: S) {
+   |           ^
+   = note: stack backtrace:
+           0: callee
+               at tests/fail/function_calls/arg_inplace_locals_alias.rs:LL:CC
+           1: main
+               at tests/fail/function_calls/arg_inplace_locals_alias.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/function_calls/arg_inplace_locals_alias.tree.stderr
+++ b/src/tools/miri/tests/fail/function_calls/arg_inplace_locals_alias.tree.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: read access through <TAG> (root of the allocation) at ALLOC[0x0] is forbidden
   --> tests/fail/function_calls/arg_inplace_locals_alias.rs:LL:CC
    |
-LL |             Call(_unit = callee(Move(non_copy), Move(non_copy)), ReturnTo(after_call), UnwindContinue())
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+LL | fn callee(x: S, mut y: S) {
+   |                 ^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/tree-borrows.md for further information
@@ -17,14 +17,19 @@ LL |             Call(_unit = callee(Move(non_copy), Move(non_copy)), ReturnTo(a
 help: the protected tag <TAG> was created here, in the initial state Reserved
   --> tests/fail/function_calls/arg_inplace_locals_alias.rs:LL:CC
    |
-LL |     y.0 = 0;
-   |     ^^^^^^^
+LL | fn callee(x: S, mut y: S) {
+   |           ^
 help: the protected tag <TAG> later transitioned to Unique due to a child write access at offsets [0x0..0x4]
   --> tests/fail/function_calls/arg_inplace_locals_alias.rs:LL:CC
    |
-LL |     y.0 = 0;
-   |     ^^^^^^^
+LL | fn callee(x: S, mut y: S) {
+   |           ^
    = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
+   = note: stack backtrace:
+           0: callee
+               at tests/fail/function_calls/arg_inplace_locals_alias.rs:LL:CC
+           1: main
+               at tests/fail/function_calls/arg_inplace_locals_alias.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/function_calls/arg_inplace_locals_alias_ret.rs
+++ b/src/tools/miri/tests/fail/function_calls/arg_inplace_locals_alias_ret.rs
@@ -20,8 +20,6 @@ fn main() {
             // This specifically uses a type with scalar representation to tempt Miri to use the
             // efficient way of storing local variables (outside adressable memory).
             Call(_non_copy = callee(Move(_non_copy)), ReturnTo(after_call), UnwindContinue())
-            //~[stack]^ ERROR: not granting access
-            //~[tree]| ERROR: /reborrow .* forbidden/
         }
         after_call = {
             Return()
@@ -30,5 +28,7 @@ fn main() {
 }
 
 fn callee(x: S) -> S {
+    //~[stack]^ ERROR: not granting access
+    //~[tree]| ERROR: /reborrow .* forbidden/
     x
 }

--- a/src/tools/miri/tests/fail/function_calls/arg_inplace_locals_alias_ret.stack.stderr
+++ b/src/tools/miri/tests/fail/function_calls/arg_inplace_locals_alias_ret.stack.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected
   --> tests/fail/function_calls/arg_inplace_locals_alias_ret.rs:LL:CC
    |
-LL |             Call(_non_copy = callee(Move(_non_copy)), ReturnTo(after_call), UnwindContinue())
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+LL | fn callee(x: S) -> S {
+   |                    ^ Undefined Behavior occurred here
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
@@ -14,8 +14,13 @@ LL |             Call(_non_copy = callee(Move(_non_copy)), ReturnTo(after_call),
 help: <TAG> is this argument
   --> tests/fail/function_calls/arg_inplace_locals_alias_ret.rs:LL:CC
    |
-LL |     x
-   |     ^
+LL | fn callee(x: S) -> S {
+   |           ^
+   = note: stack backtrace:
+           0: callee
+               at tests/fail/function_calls/arg_inplace_locals_alias_ret.rs:LL:CC
+           1: main
+               at tests/fail/function_calls/arg_inplace_locals_alias_ret.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/function_calls/arg_inplace_locals_alias_ret.tree.stderr
+++ b/src/tools/miri/tests/fail/function_calls/arg_inplace_locals_alias_ret.tree.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: reborrow through <TAG> (root of the allocation) at ALLOC[0x0] is forbidden
   --> tests/fail/function_calls/arg_inplace_locals_alias_ret.rs:LL:CC
    |
-LL |             Call(_non_copy = callee(Move(_non_copy)), ReturnTo(after_call), UnwindContinue())
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+LL | fn callee(x: S) -> S {
+   |                    ^ Undefined Behavior occurred here
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/tree-borrows.md for further information
@@ -17,14 +17,19 @@ LL |             Call(_non_copy = callee(Move(_non_copy)), ReturnTo(after_call),
 help: the protected tag <TAG> was created here, in the initial state Reserved
   --> tests/fail/function_calls/arg_inplace_locals_alias_ret.rs:LL:CC
    |
-LL |     x
-   |     ^
+LL | fn callee(x: S) -> S {
+   |           ^
 help: the protected tag <TAG> later transitioned to Unique due to a child write access at offsets [0x0..0x4]
   --> tests/fail/function_calls/arg_inplace_locals_alias_ret.rs:LL:CC
    |
-LL |     x
-   |     ^
+LL | fn callee(x: S) -> S {
+   |           ^
    = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
+   = note: stack backtrace:
+           0: callee
+               at tests/fail/function_calls/arg_inplace_locals_alias_ret.rs:LL:CC
+           1: main
+               at tests/fail/function_calls/arg_inplace_locals_alias_ret.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/function_calls/arg_inplace_mutate.stack.stderr
+++ b/src/tools/miri/tests/fail/function_calls/arg_inplace_mutate.stack.stderr
@@ -19,8 +19,8 @@ LL | |     }
 help: <TAG> is this argument
   --> tests/fail/function_calls/arg_inplace_mutate.rs:LL:CC
    |
-LL |     unsafe { ptr.write(S(0)) };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn callee(x: S, ptr: *mut S) {
+   |           ^
    = note: stack backtrace:
            0: callee
                at tests/fail/function_calls/arg_inplace_mutate.rs:LL:CC

--- a/src/tools/miri/tests/fail/function_calls/arg_inplace_mutate.tree.stderr
+++ b/src/tools/miri/tests/fail/function_calls/arg_inplace_mutate.tree.stderr
@@ -22,13 +22,13 @@ LL | |     }
 help: the protected tag <TAG> was created here, in the initial state Reserved
   --> tests/fail/function_calls/arg_inplace_mutate.rs:LL:CC
    |
-LL |     unsafe { ptr.write(S(0)) };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn callee(x: S, ptr: *mut S) {
+   |           ^
 help: the protected tag <TAG> later transitioned to Unique due to a child write access at offsets [0x0..0x4]
   --> tests/fail/function_calls/arg_inplace_mutate.rs:LL:CC
    |
-LL |     unsafe { ptr.write(S(0)) };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn callee(x: S, ptr: *mut S) {
+   |           ^
    = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
    = note: stack backtrace:
            0: callee

--- a/src/tools/miri/tests/fail/function_calls/arg_inplace_observe_during.stack.stderr
+++ b/src/tools/miri/tests/fail/function_calls/arg_inplace_observe_during.stack.stderr
@@ -19,8 +19,8 @@ LL | |     }
 help: <TAG> is this argument
   --> tests/fail/function_calls/arg_inplace_observe_during.rs:LL:CC
    |
-LL |     x.0 = 0;
-   |     ^^^^^^^
+LL | fn change_arg(mut x: S, ptr: *mut S) {
+   |               ^^^^^
    = note: stack backtrace:
            0: change_arg
                at tests/fail/function_calls/arg_inplace_observe_during.rs:LL:CC

--- a/src/tools/miri/tests/fail/function_calls/arg_inplace_observe_during.tree.stderr
+++ b/src/tools/miri/tests/fail/function_calls/arg_inplace_observe_during.tree.stderr
@@ -22,13 +22,13 @@ LL | |     }
 help: the protected tag <TAG> was created here, in the initial state Reserved
   --> tests/fail/function_calls/arg_inplace_observe_during.rs:LL:CC
    |
-LL |     x.0 = 0;
-   |     ^^^^^^^
+LL | fn change_arg(mut x: S, ptr: *mut S) {
+   |               ^^^^^
 help: the protected tag <TAG> later transitioned to Unique due to a child write access at offsets [0x0..0x4]
   --> tests/fail/function_calls/arg_inplace_observe_during.rs:LL:CC
    |
-LL |     x.0 = 0;
-   |     ^^^^^^^
+LL | fn change_arg(mut x: S, ptr: *mut S) {
+   |               ^^^^^
    = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
    = note: stack backtrace:
            0: change_arg

--- a/src/tools/miri/tests/fail/function_calls/exported_symbol_wrong_arguments.rs
+++ b/src/tools/miri/tests/fail/function_calls/exported_symbol_wrong_arguments.rs
@@ -1,9 +1,9 @@
 #[no_mangle]
-fn foo() {}
+fn foo() {} //~ ERROR: calling a function with more arguments than it expected
 
 fn main() {
     extern "Rust" {
         fn foo(_: i32);
     }
-    unsafe { foo(1) } //~ ERROR: calling a function with more arguments than it expected
+    unsafe { foo(1) }
 }

--- a/src/tools/miri/tests/fail/function_calls/exported_symbol_wrong_arguments.stderr
+++ b/src/tools/miri/tests/fail/function_calls/exported_symbol_wrong_arguments.stderr
@@ -1,11 +1,16 @@
 error: Undefined Behavior: calling a function with more arguments than it expected
   --> tests/fail/function_calls/exported_symbol_wrong_arguments.rs:LL:CC
    |
-LL |     unsafe { foo(1) }
-   |              ^^^^^^ Undefined Behavior occurred here
+LL | fn foo() {}
+   | ^^^^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = note: stack backtrace:
+           0: foo
+               at tests/fail/function_calls/exported_symbol_wrong_arguments.rs:LL:CC
+           1: main
+               at tests/fail/function_calls/exported_symbol_wrong_arguments.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/function_calls/return_pointer_aliasing_read.stack.stderr
+++ b/src/tools/miri/tests/fail/function_calls/return_pointer_aliasing_read.stack.stderr
@@ -19,8 +19,8 @@ LL | |     }
 help: <TAG> was later invalidated at offsets [0x0..0x4] by a Unique in-place function argument/return passing protection
   --> tests/fail/function_calls/return_pointer_aliasing_read.rs:LL:CC
    |
-LL |     unsafe { ptr.read() };
-   |     ^^^^^^^^^^^^^^^^^^^^^
+LL | fn myfun(ptr: *mut i32) -> i32 {
+   |                            ^^^
    = note: stack backtrace:
            0: myfun
                at tests/fail/function_calls/return_pointer_aliasing_read.rs:LL:CC

--- a/src/tools/miri/tests/fail/function_calls/return_pointer_aliasing_read.tree.stderr
+++ b/src/tools/miri/tests/fail/function_calls/return_pointer_aliasing_read.tree.stderr
@@ -22,13 +22,13 @@ LL | |     }
 help: the protected tag <TAG> was created here, in the initial state Reserved
   --> tests/fail/function_calls/return_pointer_aliasing_read.rs:LL:CC
    |
-LL |     unsafe { ptr.read() };
-   |     ^^^^^^^^^^^^^^^^^^^^^
+LL | fn myfun(ptr: *mut i32) -> i32 {
+   |                            ^^^
 help: the protected tag <TAG> later transitioned to Unique due to a child write access at offsets [0x0..0x4]
   --> tests/fail/function_calls/return_pointer_aliasing_read.rs:LL:CC
    |
-LL |     unsafe { ptr.read() };
-   |     ^^^^^^^^^^^^^^^^^^^^^
+LL | fn myfun(ptr: *mut i32) -> i32 {
+   |                            ^^^
    = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
    = note: stack backtrace:
            0: myfun

--- a/src/tools/miri/tests/fail/function_calls/return_pointer_aliasing_write.stack.stderr
+++ b/src/tools/miri/tests/fail/function_calls/return_pointer_aliasing_write.stack.stderr
@@ -19,8 +19,8 @@ LL | |     }
 help: <TAG> was later invalidated at offsets [0x0..0x4] by a Unique in-place function argument/return passing protection
   --> tests/fail/function_calls/return_pointer_aliasing_write.rs:LL:CC
    |
-LL |     unsafe { ptr.write(0) };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn myfun(ptr: *mut i32) -> i32 {
+   |                            ^^^
    = note: stack backtrace:
            0: myfun
                at tests/fail/function_calls/return_pointer_aliasing_write.rs:LL:CC

--- a/src/tools/miri/tests/fail/function_calls/return_pointer_aliasing_write.tree.stderr
+++ b/src/tools/miri/tests/fail/function_calls/return_pointer_aliasing_write.tree.stderr
@@ -22,13 +22,13 @@ LL | |     }
 help: the protected tag <TAG> was created here, in the initial state Reserved
   --> tests/fail/function_calls/return_pointer_aliasing_write.rs:LL:CC
    |
-LL |     unsafe { ptr.write(0) };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn myfun(ptr: *mut i32) -> i32 {
+   |                            ^^^
 help: the protected tag <TAG> later transitioned to Unique due to a child write access at offsets [0x0..0x4]
   --> tests/fail/function_calls/return_pointer_aliasing_write.rs:LL:CC
    |
-LL |     unsafe { ptr.write(0) };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn myfun(ptr: *mut i32) -> i32 {
+   |                            ^^^
    = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
    = note: stack backtrace:
            0: myfun

--- a/src/tools/miri/tests/fail/function_calls/return_pointer_aliasing_write_tail_call.stack.stderr
+++ b/src/tools/miri/tests/fail/function_calls/return_pointer_aliasing_write_tail_call.stack.stderr
@@ -19,8 +19,8 @@ LL | |     }
 help: <TAG> was later invalidated at offsets [0x0..0x4] by a Unique in-place function argument/return passing protection
   --> tests/fail/function_calls/return_pointer_aliasing_write_tail_call.rs:LL:CC
    |
-LL |     become myfun2(ptr)
-   |     ^^^^^^^^^^^^^^^^^^
+LL | fn myfun(ptr: *mut i32) -> i32 {
+   |                            ^^^
    = note: stack backtrace:
            0: myfun2
                at tests/fail/function_calls/return_pointer_aliasing_write_tail_call.rs:LL:CC

--- a/src/tools/miri/tests/fail/function_calls/return_pointer_aliasing_write_tail_call.tree.stderr
+++ b/src/tools/miri/tests/fail/function_calls/return_pointer_aliasing_write_tail_call.tree.stderr
@@ -22,13 +22,13 @@ LL | |     }
 help: the protected tag <TAG> was created here, in the initial state Reserved
   --> tests/fail/function_calls/return_pointer_aliasing_write_tail_call.rs:LL:CC
    |
-LL |     unsafe { ptr.write(0) };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn myfun2(ptr: *mut i32) -> i32 {
+   |                             ^^^
 help: the protected tag <TAG> later transitioned to Unique due to a child write access at offsets [0x0..0x4]
   --> tests/fail/function_calls/return_pointer_aliasing_write_tail_call.rs:LL:CC
    |
-LL |     unsafe { ptr.write(0) };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn myfun2(ptr: *mut i32) -> i32 {
+   |                             ^^^
    = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
    = note: stack backtrace:
            0: myfun2

--- a/src/tools/miri/tests/fail/function_pointers/abi_mismatch_array_vs_struct.rs
+++ b/src/tools/miri/tests/fail/function_pointers/abi_mismatch_array_vs_struct.rs
@@ -12,10 +12,10 @@ struct S(
 type A = [i32; 4];
 
 fn main() {
-    fn f(_: S) {}
+    fn f(_: S) {} //~ ERROR: type S passing argument of type [i32; 4]
 
     // These two types have the same size but are still not compatible.
     let g = unsafe { std::mem::transmute::<fn(S), fn(A)>(f) };
 
-    g(Default::default()) //~ ERROR: type S passing argument of type [i32; 4]
+    g(Default::default())
 }

--- a/src/tools/miri/tests/fail/function_pointers/abi_mismatch_array_vs_struct.stderr
+++ b/src/tools/miri/tests/fail/function_pointers/abi_mismatch_array_vs_struct.stderr
@@ -1,13 +1,18 @@
 error: Undefined Behavior: calling a function whose parameter #1 has type S passing argument of type [i32; 4]
   --> tests/fail/function_pointers/abi_mismatch_array_vs_struct.rs:LL:CC
    |
-LL |     g(Default::default())
-   |     ^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+LL |     fn f(_: S) {}
+   |          ^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = help: this means these two types are not *guaranteed* to be ABI-compatible across all targets
    = help: if you think this code should be accepted anyway, please report an issue with Miri
+   = note: stack backtrace:
+           0: main::f
+               at tests/fail/function_pointers/abi_mismatch_array_vs_struct.rs:LL:CC
+           1: main
+               at tests/fail/function_pointers/abi_mismatch_array_vs_struct.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/function_pointers/abi_mismatch_int_vs_float.rs
+++ b/src/tools/miri/tests/fail/function_pointers/abi_mismatch_int_vs_float.rs
@@ -1,7 +1,7 @@
 fn main() {
-    fn f(_: f32) {}
+    fn f(_: f32) {} //~ ERROR: type f32 passing argument of type i32
 
     let g = unsafe { std::mem::transmute::<fn(f32), fn(i32)>(f) };
 
-    g(42) //~ ERROR: type f32 passing argument of type i32
+    g(42)
 }

--- a/src/tools/miri/tests/fail/function_pointers/abi_mismatch_int_vs_float.stderr
+++ b/src/tools/miri/tests/fail/function_pointers/abi_mismatch_int_vs_float.stderr
@@ -1,13 +1,18 @@
 error: Undefined Behavior: calling a function whose parameter #1 has type f32 passing argument of type i32
   --> tests/fail/function_pointers/abi_mismatch_int_vs_float.rs:LL:CC
    |
-LL |     g(42)
-   |     ^^^^^ Undefined Behavior occurred here
+LL |     fn f(_: f32) {}
+   |          ^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = help: this means these two types are not *guaranteed* to be ABI-compatible across all targets
    = help: if you think this code should be accepted anyway, please report an issue with Miri
+   = note: stack backtrace:
+           0: main::f
+               at tests/fail/function_pointers/abi_mismatch_int_vs_float.rs:LL:CC
+           1: main
+               at tests/fail/function_pointers/abi_mismatch_int_vs_float.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/function_pointers/abi_mismatch_raw_pointer.rs
+++ b/src/tools/miri/tests/fail/function_pointers/abi_mismatch_raw_pointer.rs
@@ -1,7 +1,7 @@
 fn main() {
-    fn f(_: *const [i32]) {}
+    fn f(_: *const [i32]) {} //~ ERROR: type *const [i32] passing argument of type *const i32
 
     let g = unsafe { std::mem::transmute::<fn(*const [i32]), fn(*const i32)>(f) };
 
-    g(&42 as *const i32) //~ ERROR: type *const [i32] passing argument of type *const i32
+    g(&42 as *const i32)
 }

--- a/src/tools/miri/tests/fail/function_pointers/abi_mismatch_raw_pointer.stderr
+++ b/src/tools/miri/tests/fail/function_pointers/abi_mismatch_raw_pointer.stderr
@@ -1,13 +1,18 @@
 error: Undefined Behavior: calling a function whose parameter #1 has type *const [i32] passing argument of type *const i32
   --> tests/fail/function_pointers/abi_mismatch_raw_pointer.rs:LL:CC
    |
-LL |     g(&42 as *const i32)
-   |     ^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+LL |     fn f(_: *const [i32]) {}
+   |          ^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = help: this means these two types are not *guaranteed* to be ABI-compatible across all targets
    = help: if you think this code should be accepted anyway, please report an issue with Miri
+   = note: stack backtrace:
+           0: main::f
+               at tests/fail/function_pointers/abi_mismatch_raw_pointer.rs:LL:CC
+           1: main
+               at tests/fail/function_pointers/abi_mismatch_raw_pointer.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/function_pointers/abi_mismatch_repr_C.rs
+++ b/src/tools/miri/tests/fail/function_pointers/abi_mismatch_repr_C.rs
@@ -7,10 +7,10 @@ struct S1(NonZero<i32>);
 struct S2(i32);
 
 fn callee(_s: S2) {}
+//~^ ERROR: type S2 passing argument of type S1
 
 fn main() {
     let fnptr: fn(S2) = callee;
     let fnptr: fn(S1) = unsafe { std::mem::transmute(fnptr) };
     fnptr(S1(NonZero::new(1).unwrap()));
-    //~^ ERROR: type S2 passing argument of type S1
 }

--- a/src/tools/miri/tests/fail/function_pointers/abi_mismatch_repr_C.stderr
+++ b/src/tools/miri/tests/fail/function_pointers/abi_mismatch_repr_C.stderr
@@ -1,13 +1,18 @@
 error: Undefined Behavior: calling a function whose parameter #1 has type S2 passing argument of type S1
   --> tests/fail/function_pointers/abi_mismatch_repr_C.rs:LL:CC
    |
-LL |     fnptr(S1(NonZero::new(1).unwrap()));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+LL | fn callee(_s: S2) {}
+   |           ^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = help: this means these two types are not *guaranteed* to be ABI-compatible across all targets
    = help: if you think this code should be accepted anyway, please report an issue with Miri
+   = note: stack backtrace:
+           0: callee
+               at tests/fail/function_pointers/abi_mismatch_repr_C.rs:LL:CC
+           1: main
+               at tests/fail/function_pointers/abi_mismatch_repr_C.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/function_pointers/abi_mismatch_return_type.rs
+++ b/src/tools/miri/tests/fail/function_pointers/abi_mismatch_return_type.rs
@@ -1,9 +1,9 @@
 fn main() {
-    fn f() -> u32 {
+    fn f() -> u32 { //~ ERROR: type u32 passing return place of type ()
         42
     }
 
     let g = unsafe { std::mem::transmute::<fn() -> u32, fn()>(f) };
 
-    g() //~ ERROR: type u32 passing return place of type ()
+    g()
 }

--- a/src/tools/miri/tests/fail/function_pointers/abi_mismatch_return_type.stderr
+++ b/src/tools/miri/tests/fail/function_pointers/abi_mismatch_return_type.stderr
@@ -1,13 +1,18 @@
 error: Undefined Behavior: calling a function with return type u32 passing return place of type ()
   --> tests/fail/function_pointers/abi_mismatch_return_type.rs:LL:CC
    |
-LL |     g()
-   |     ^^^ Undefined Behavior occurred here
+LL |     fn f() -> u32 {
+   |               ^^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = help: this means these two types are not *guaranteed* to be ABI-compatible across all targets
    = help: if you think this code should be accepted anyway, please report an issue with Miri
+   = note: stack backtrace:
+           0: main::f
+               at tests/fail/function_pointers/abi_mismatch_return_type.rs:LL:CC
+           1: main
+               at tests/fail/function_pointers/abi_mismatch_return_type.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/function_pointers/abi_mismatch_simple.rs
+++ b/src/tools/miri/tests/fail/function_pointers/abi_mismatch_simple.rs
@@ -1,7 +1,7 @@
 fn main() {
-    fn f(_: (i32, i32)) {}
+    fn f(_: (i32, i32)) {} //~ ERROR: type (i32, i32) passing argument of type i32
 
     let g = unsafe { std::mem::transmute::<fn((i32, i32)), fn(i32)>(f) };
 
-    g(42) //~ ERROR: type (i32, i32) passing argument of type i32
+    g(42)
 }

--- a/src/tools/miri/tests/fail/function_pointers/abi_mismatch_simple.stderr
+++ b/src/tools/miri/tests/fail/function_pointers/abi_mismatch_simple.stderr
@@ -1,13 +1,18 @@
 error: Undefined Behavior: calling a function whose parameter #1 has type (i32, i32) passing argument of type i32
   --> tests/fail/function_pointers/abi_mismatch_simple.rs:LL:CC
    |
-LL |     g(42)
-   |     ^^^^^ Undefined Behavior occurred here
+LL |     fn f(_: (i32, i32)) {}
+   |          ^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = help: this means these two types are not *guaranteed* to be ABI-compatible across all targets
    = help: if you think this code should be accepted anyway, please report an issue with Miri
+   = note: stack backtrace:
+           0: main::f
+               at tests/fail/function_pointers/abi_mismatch_simple.rs:LL:CC
+           1: main
+               at tests/fail/function_pointers/abi_mismatch_simple.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/function_pointers/abi_mismatch_too_few_args.rs
+++ b/src/tools/miri/tests/fail/function_pointers/abi_mismatch_too_few_args.rs
@@ -1,7 +1,7 @@
 fn main() {
-    fn f(_: (i32, i32)) {}
+    fn f(_: (i32, i32)) {} //~ ERROR: calling a function with fewer arguments than it requires
 
     let g = unsafe { std::mem::transmute::<fn((i32, i32)), fn()>(f) };
 
-    g() //~ ERROR: calling a function with fewer arguments than it requires
+    g()
 }

--- a/src/tools/miri/tests/fail/function_pointers/abi_mismatch_too_few_args.stderr
+++ b/src/tools/miri/tests/fail/function_pointers/abi_mismatch_too_few_args.stderr
@@ -1,11 +1,16 @@
 error: Undefined Behavior: calling a function with fewer arguments than it requires
   --> tests/fail/function_pointers/abi_mismatch_too_few_args.rs:LL:CC
    |
-LL |     g()
-   |     ^^^ Undefined Behavior occurred here
+LL |     fn f(_: (i32, i32)) {}
+   |          ^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = note: stack backtrace:
+           0: main::f
+               at tests/fail/function_pointers/abi_mismatch_too_few_args.rs:LL:CC
+           1: main
+               at tests/fail/function_pointers/abi_mismatch_too_few_args.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/function_pointers/abi_mismatch_too_many_args.rs
+++ b/src/tools/miri/tests/fail/function_pointers/abi_mismatch_too_many_args.rs
@@ -1,7 +1,7 @@
 fn main() {
-    fn f() {}
+    fn f() {} //~ ERROR: calling a function with more arguments than it expected
 
     let g = unsafe { std::mem::transmute::<fn(), fn(i32)>(f) };
 
-    g(42) //~ ERROR: calling a function with more arguments than it expected
+    g(42)
 }

--- a/src/tools/miri/tests/fail/function_pointers/abi_mismatch_too_many_args.stderr
+++ b/src/tools/miri/tests/fail/function_pointers/abi_mismatch_too_many_args.stderr
@@ -1,11 +1,16 @@
 error: Undefined Behavior: calling a function with more arguments than it expected
   --> tests/fail/function_pointers/abi_mismatch_too_many_args.rs:LL:CC
    |
-LL |     g(42)
-   |     ^^^^^ Undefined Behavior occurred here
+LL |     fn f() {}
+   |     ^^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = note: stack backtrace:
+           0: main::f
+               at tests/fail/function_pointers/abi_mismatch_too_many_args.rs:LL:CC
+           1: main
+               at tests/fail/function_pointers/abi_mismatch_too_many_args.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/function_pointers/abi_mismatch_vector.rs
+++ b/src/tools/miri/tests/fail/function_pointers/abi_mismatch_vector.rs
@@ -2,10 +2,10 @@
 use std::simd;
 
 fn main() {
-    fn f(_: simd::u32x8) {}
+    fn f(_: simd::u32x8) {} //~ ERROR: type std::simd::Simd<u32, 8> passing argument of type std::simd::Simd<u64, 4>
 
     // These two vector types have the same size but are still not compatible.
     let g = unsafe { std::mem::transmute::<fn(simd::u32x8), fn(simd::u64x4)>(f) };
 
-    g(Default::default()) //~ ERROR: type std::simd::Simd<u32, 8> passing argument of type std::simd::Simd<u64, 4>
+    g(Default::default())
 }

--- a/src/tools/miri/tests/fail/function_pointers/abi_mismatch_vector.stderr
+++ b/src/tools/miri/tests/fail/function_pointers/abi_mismatch_vector.stderr
@@ -1,13 +1,18 @@
 error: Undefined Behavior: calling a function whose parameter #1 has type std::simd::Simd<u32, 8> passing argument of type std::simd::Simd<u64, 4>
   --> tests/fail/function_pointers/abi_mismatch_vector.rs:LL:CC
    |
-LL |     g(Default::default())
-   |     ^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+LL |     fn f(_: simd::u32x8) {}
+   |          ^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = help: this means these two types are not *guaranteed* to be ABI-compatible across all targets
    = help: if you think this code should be accepted anyway, please report an issue with Miri
+   = note: stack backtrace:
+           0: main::f
+               at tests/fail/function_pointers/abi_mismatch_vector.rs:LL:CC
+           1: main
+               at tests/fail/function_pointers/abi_mismatch_vector.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/shims/ctor_wrong_ret_type.rs
+++ b/src/tools/miri/tests/fail/shims/ctor_wrong_ret_type.rs
@@ -1,4 +1,5 @@
 unsafe extern "C" fn ctor() -> i32 {
+    //~^ERROR: calling a function with return type i32 passing return place of type ()
     0
 }
 
@@ -30,7 +31,6 @@ macro_rules! ctor {
         )]
         #[used]
         static $ident: unsafe extern "C" fn() -> i32 = $ctor;
-        //~^ERROR: calling a function with return type i32 passing return place of type ()
     };
 }
 

--- a/src/tools/miri/tests/fail/shims/ctor_wrong_ret_type.stderr
+++ b/src/tools/miri/tests/fail/shims/ctor_wrong_ret_type.stderr
@@ -1,18 +1,21 @@
 error: Undefined Behavior: calling a function with return type i32 passing return place of type ()
   --> tests/fail/shims/ctor_wrong_ret_type.rs:LL:CC
    |
-LL |         static $ident: unsafe extern "C" fn() -> i32 = $ctor;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred due to this code
-...
-LL | ctor! { CTOR = ctor }
-   | --------------------- in this macro invocation
+LL | unsafe extern "C" fn ctor() -> i32 {
+   |                                ^^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = help: this means these two types are not *guaranteed* to be ABI-compatible across all targets
    = help: if you think this code should be accepted anyway, please report an issue with Miri
-   = note: this error occurred while pushing a call frame onto an empty stack
-   = note: the span indicates which code caused the function to be called, but may not be the literal call site
+note: the current function got called indirectly due to this code
+  --> tests/fail/shims/ctor_wrong_ret_type.rs:LL:CC
+   |
+LL |         static $ident: unsafe extern "C" fn() -> i32 = $ctor;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | ctor! { CTOR = ctor }
+   | --------------------- in this macro invocation
    = note: this error originates in the macro `ctor` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/src/tools/miri/tests/fail/tail_calls/signature-mismatch-arg.rs
+++ b/src/tools/miri/tests/fail/tail_calls/signature-mismatch-arg.rs
@@ -2,16 +2,14 @@
 #![allow(incomplete_features)]
 
 fn main() {
-    // FIXME(explicit_tail_calls):
-    //   the error should point to `become g(x)`,
-    //   but tail calls mess up the backtrace it seems like...
     f(0);
-    //~^ error: type i32 passing argument of type u32
 }
 
 fn f(x: u32) {
     let g = unsafe { std::mem::transmute::<fn(i32), fn(u32)>(g) };
-    become g(x);
+    become g(x); // FIXME ideally this should also be involved in the error somehow,
+    // but by the time we pass the argument, `f`'s stackframe has already been popped.
 }
 
 fn g(_: i32) {}
+//~^ error: type i32 passing argument of type u32

--- a/src/tools/miri/tests/fail/tail_calls/signature-mismatch-arg.stderr
+++ b/src/tools/miri/tests/fail/tail_calls/signature-mismatch-arg.stderr
@@ -1,13 +1,18 @@
 error: Undefined Behavior: calling a function whose parameter #1 has type i32 passing argument of type u32
   --> tests/fail/tail_calls/signature-mismatch-arg.rs:LL:CC
    |
-LL |     f(0);
-   |     ^^^^ Undefined Behavior occurred here
+LL | fn g(_: i32) {}
+   |      ^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = help: this means these two types are not *guaranteed* to be ABI-compatible across all targets
    = help: if you think this code should be accepted anyway, please report an issue with Miri
+   = note: stack backtrace:
+           0: g
+               at tests/fail/tail_calls/signature-mismatch-arg.rs:LL:CC
+           1: main
+               at tests/fail/tail_calls/signature-mismatch-arg.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/validity/cast_fn_ptr_invalid_callee_arg.rs
+++ b/src/tools/miri/tests/fail/validity/cast_fn_ptr_invalid_callee_arg.rs
@@ -5,9 +5,9 @@ fn main() {
     // from raw ptr to reference. This is ABI-compatible, so it's not the call that
     // should fail, but validation should.
     fn f(_x: &i32) {}
+    //~^ ERROR: encountered a null reference
 
     let g: fn(*const i32) = unsafe { std::mem::transmute(f as fn(&i32)) };
 
     g(0usize as *const i32)
-    //~^ ERROR: encountered a null reference
 }

--- a/src/tools/miri/tests/fail/validity/cast_fn_ptr_invalid_callee_arg.stderr
+++ b/src/tools/miri/tests/fail/validity/cast_fn_ptr_invalid_callee_arg.stderr
@@ -1,11 +1,16 @@
 error: Undefined Behavior: constructing invalid value: encountered a null reference
   --> tests/fail/validity/cast_fn_ptr_invalid_callee_arg.rs:LL:CC
    |
-LL |     g(0usize as *const i32)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+LL |     fn f(_x: &i32) {}
+   |          ^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = note: stack backtrace:
+           0: main::f
+               at tests/fail/validity/cast_fn_ptr_invalid_callee_arg.rs:LL:CC
+           1: main
+               at tests/fail/validity/cast_fn_ptr_invalid_callee_arg.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/validity/cast_fn_ptr_invalid_caller_arg.rs
+++ b/src/tools/miri/tests/fail/validity/cast_fn_ptr_invalid_caller_arg.rs
@@ -5,7 +5,7 @@ use std::intrinsics::mir::*;
 use std::num::NonZero;
 use std::ptr;
 
-fn f(c: u32) {
+fn f(c: u32) { //~ERROR: expected something greater or equal to 1
     println!("{c}");
 }
 
@@ -20,7 +20,7 @@ fn call(f: fn(NonZero<u32>)) {
             let tmp = ptr::addr_of!(c);
             let ptr = tmp as *const NonZero<u32>;
             // The call site now is a `NonZero<u32>` to `u32` transmute.
-            Call(_res = f(*ptr), ReturnTo(retblock), UnwindContinue()) //~ERROR: expected something greater or equal to 1
+            Call(_res = f(*ptr), ReturnTo(retblock), UnwindContinue())
         }
         retblock = {
             Return()

--- a/src/tools/miri/tests/fail/validity/cast_fn_ptr_invalid_caller_arg.stderr
+++ b/src/tools/miri/tests/fail/validity/cast_fn_ptr_invalid_caller_arg.stderr
@@ -1,15 +1,17 @@
 error: Undefined Behavior: constructing invalid value at .0.0: encountered 0, but expected something greater or equal to 1
   --> tests/fail/validity/cast_fn_ptr_invalid_caller_arg.rs:LL:CC
    |
-LL |             Call(_res = f(*ptr), ReturnTo(retblock), UnwindContinue())
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+LL | fn f(c: u32) {
+   |      ^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: stack backtrace:
-           0: call
+           0: f
                at tests/fail/validity/cast_fn_ptr_invalid_caller_arg.rs:LL:CC
-           1: main
+           1: call
+               at tests/fail/validity/cast_fn_ptr_invalid_caller_arg.rs:LL:CC
+           2: main
                at tests/fail/validity/cast_fn_ptr_invalid_caller_arg.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace


### PR DESCRIPTION
For a long time now, we did some contortions so that when something goes wrong while initializing the arguments for a function, we point at the call site rather than the callee. Historically, this had to be done because the "current location" in the callee pointed at the first instruction, which would obviously be nonsense. A while ago we gained the ability in the interpreter for the "current location" to be just a span that we point at for errors, but we never reevaluated the decision for how spans are handled during function calls. (We did use this "just a span" location for [errors during the initial stack frame setup](https://github.com/rust-lang/rust/commit/d21e0118d0eefc8b0073fa47fa16699d37047abf), but not for argument initialization.)

There's no always-great choice for pointing at the caller vs the callee: when they disagree about the type of an argument, either side could be wrong. If We do *two* typed copies in that case, one at the caller type and one at the callee type. Arguably we should point at the one that goes wrong, but we don't have a good way to expose that.

What ultimately pushed me over the edge towards pointing at the callee are two points:
- This provides strictly more information. if we point at the callee, the caller is available in the stacktrace. But if we point at the caller, then it might be impossible to figure out the actual callee if a function pointer or dyn call is involved.
- As part of resolving some long-standing questions around retags I am moving retagging to become part of validation, which means the retag and protector initialization of function arguments will happen during argument initialization. These currently point at the argument inside the callee, which I think is strictly preferable for these errors.

The diff will be much smaller with whitespace changes hidden.