### PR TITLE
ci: Add dist-aarch64-freebsd

### DIFF
--- a/src/ci/docker/host-aarch64/dist-aarch64-freebsd/Dockerfile
+++ b/src/ci/docker/host-aarch64/dist-aarch64-freebsd/Dockerfile
@@ -1,0 +1,44 @@
+FROM ubuntu:26.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  clang \
+  make \
+  ninja-build \
+  file \
+  curl \
+  ca-certificates \
+  python3 \
+  git \
+  cmake \
+  sudo \
+  bzip2 \
+  xz-utils \
+  texinfo \
+  wget \
+  libssl-dev \
+  pkg-config \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY scripts/freebsd-toolchain.sh /tmp/
+RUN /tmp/freebsd-toolchain.sh aarch64
+
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
+COPY scripts/cmake.sh /scripts/
+RUN /scripts/cmake.sh
+
+ENV \
+    AR_aarch64_unknown_freebsd=aarch64-unknown-freebsd14-ar \
+    CC_aarch64_unknown_freebsd=aarch64-unknown-freebsd14-clang \
+    CXX_aarch64_unknown_freebsd=aarch64-unknown-freebsd14-clang++
+
+ENV HOSTS=aarch64-unknown-freebsd
+
+ENV RUST_CONFIGURE_ARGS="--enable-full-tools \
+    --enable-extended \
+    --enable-profiler \
+    --enable-sanitizers \
+    --disable-docs"
+
+ENV SCRIPT="python3 ../x.py dist --host $HOSTS --target $HOSTS"

--- a/src/ci/docker/scripts/freebsd-toolchain.sh
+++ b/src/ci/docker/scripts/freebsd-toolchain.sh
@@ -46,6 +46,7 @@ mkdir -p "$sysroot"
 case $arch in
   (x86_64) freebsd_arch=amd64 ;;
   (i686) freebsd_arch=i386 ;;
+  (aarch64) freebsd_arch=arm64 ;;
 esac
 
 files_to_extract=(

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -261,6 +261,9 @@ auto:
   - name: dist-x86_64-freebsd
     <<: *job-linux-4c
 
+  - name: dist-aarch64-freebsd
+    <<: *job-aarch64-linux
+
   - name: dist-x86_64-illumos
     <<: *job-linux-4c
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/154265)*
<!-- homu-ignore:end -->

Add scripts to build the aarch64-unknown-freebsd target in CI.
Implements MCP: https://github.com/rust-lang/compiler-team/issues/961

There is currently the issue of FreeBSD version support. See the following thread for more details:
https://github.com/rust-lang/rust/pull/132228

The current version supported by rust is FreeBSD 12, which is already EOL. This means it is no longer possible to download FreeBSD releases from their servers. The aarch64 build is not mirrored on the Rust servers, which is why I couldn't match the version used by already existing CI scripts and had to change this one to FreeBSD 13. FreeBSD 13 itself will be EOL a month from now, on April 30th. We might want to put aarch64 FreeBSD builds on the Rust mirror and update the support across the board to FreeBSD 14 prior to merging this.