### PR TITLE
UdpSocket: document `recv/recv_from` differences

### DIFF
--- a/library/std/src/net/udp.rs
+++ b/library/std/src/net/udp.rs
@@ -129,6 +129,10 @@ impl UdpSocket {
     /// hold the message bytes. If a message is too long to fit in the supplied buffer,
     /// excess bytes may be discarded.
     ///
+    /// Refer to the platform-specific documentation on this function; it is considered
+    /// correct for its behavior to differ from [`UdpSocket::recv`] if the underlying system
+    /// call does so.
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -710,6 +714,10 @@ impl UdpSocket {
     ///
     /// [`UdpSocket::connect`] will connect this socket to a remote address. This
     /// method will fail if the socket is not connected.
+    ///
+    /// Refer to the platform-specific documentation on this function; it is considered
+    /// correct for its behavior to differ from [`UdpSocket::recv_from`] if the underlying
+    /// system call does so.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Per libs-api consensus, fixes rust-lang/rust#149392 by documenting possible platform-specific behavior in `UdpSocket`.

r? libs