### PR TITLE
Better closure requirement propagation V2

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -713,8 +713,34 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         for ur in self.scc_values.universal_regions_outlived_by(r_scc) {
             found_outlived_universal_region = true;
             debug!("universal_region_outlived_by ur={:?}", ur);
-            let non_local_ub = self.universal_region_relations.non_local_upper_bounds(ur);
+            let mut non_local_ub = self.universal_region_relations.non_local_upper_bounds(ur);
             debug!(?non_local_ub);
+
+            // We don't need to propagate every `T: 'ub` for soundness:
+            // Say we have the following outlives constraints given (`'b: 'a` == `a -> b`):
+            //
+            // a
+            //  \
+            //   -> c
+            //  /
+            // b
+            //
+            // And we are doing the type test `T: 'a`.
+            //
+            // The `lower_bound_universal_regions` of `'a` are `['a, 'c]`. The `upper_bounds` of `'a`
+            // is `['a]`, so we propagate `T: 'a`.
+            // The `upper_bounds` of `'c` are `['a, 'b]`, propagating `T: 'a` is correct;
+            // `T: 'b` is redundant because it provides no value to proving `T: 'a`.
+            //
+            // So we filter the set of upper_bounds to regions already outliving `lower_bound`,
+            // but if this subset is empty, we fall back to the original one.
+            let subset: Vec<_> = non_local_ub
+                .iter()
+                .copied()
+                .filter(|ub| self.eval_outlives(*ub, lower_bound))
+                .collect();
+            non_local_ub = if subset.is_empty() { non_local_ub } else { subset };
+            debug!(?non_local_ub, "upper_bounds after filtering");
 
             // This is slightly too conservative. To show T: '1, given `'2: '1`
             // and `'3: '1` we only need to prove that T: '2 *or* T: '3, but to

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -589,7 +589,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     fn check_type_tests(
         &self,
         infcx: &InferCtxt<'tcx>,
-        mut propagated_outlives_requirements: Option<&mut Vec<ClosureOutlivesRequirement<'tcx>>>,
+        propagated_outlives_requirements: Option<&mut Vec<ClosureOutlivesRequirement<'tcx>>>,
         errors_buffer: &mut RegionErrors<'tcx>,
     ) {
         let tcx = infcx.tcx;
@@ -598,6 +598,9 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         // result in basically the exact same error being reported to
         // the user. Avoid that.
         let mut deduplicate_errors = FxIndexSet::default();
+
+        let mut conjunctive_propagated_outlives_requirements =
+            propagated_outlives_requirements.is_some().then_some(vec![]);
 
         for type_test in &self.type_tests {
             debug!("check_type_test: {:?}", type_test);
@@ -612,8 +615,13 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 continue;
             }
 
-            if let Some(propagated_outlives_requirements) = &mut propagated_outlives_requirements
-                && self.try_promote_type_test(infcx, type_test, propagated_outlives_requirements)
+            if let Some(conjunctive_propagated_outlives_requirements) =
+                &mut conjunctive_propagated_outlives_requirements
+                && self.try_promote_type_test(
+                    infcx,
+                    type_test,
+                    conjunctive_propagated_outlives_requirements,
+                )
             {
                 continue;
             }
@@ -636,6 +644,69 @@ impl<'tcx> RegionInferenceContext<'tcx> {
 
                 errors_buffer.push(RegionErrorKind::TypeTestError { type_test: type_test.clone() });
             }
+        }
+
+        if let Some(mut conjunctive_requirements) = conjunctive_propagated_outlives_requirements
+            && !conjunctive_requirements.is_empty()
+        {
+            // We can simplify this list of list of requirements.
+            //
+            // Say we did some number of type tests and it results in following requirements:
+            //
+            // R1: (T: 'a OR T: 'b)
+            // R2: (T: 'a)
+            //
+            // * See `try_promote_type_test` below on why we obtain OR requirements implicitly.
+            //
+            // Full requirement is then: R1 AND R2. *BUT*, we can remove R1 entirely, because we already
+            // require `T: 'a`, which implies `T:'a OR T: 'b`, making R1 redundant.
+            //
+            // The requirements can be seen as a boolean conjunctive normal form expression:
+            // Treat a requirement `T: 'region` as a boolean value, then this problem is (almost)
+            // equivalent to "Unit Propagation". However, this problem we are trying to solve is much
+            // simpler: Unit Propagation considers any form of subexpression, even containing negation
+            // of values, making it a multi-pass algorithm. The only subexpressions we encounter are of
+            // the form (R1 OR ... OR RN), thus if even on R is required on their own (a unit), this
+            // whole subexpression can be removed.
+            //
+            // So we can filter redundant OR requirements with the following algorithm:
+            // Collect every Unit requirement. Then for every other requirement, if one of the units is
+            // contained within them we can remove the entire requirement from the list.
+
+            fn requirement_key<'a>(subject: ClosureOutlivesRequirement<'a>) -> (Ty<'a>, RegionVid) {
+                let ClosureOutlivesSubject::Ty(ClosureOutlivesSubjectTy { inner: ty }) =
+                    subject.subject
+                else {
+                    unreachable!("ClosureOutliveSubject of a type test is always a Ty");
+                };
+                (ty, subject.outlived_free_region)
+            }
+
+            let units: Vec<_> = conjunctive_requirements
+                .iter()
+                .filter_map(|r| {
+                    let [r] = r.as_slice() else { return None };
+                    Some(requirement_key(*r))
+                })
+                .collect();
+
+            // Remove the `or_requirement`s that contain any of the unit requirements.
+            conjunctive_requirements.retain(|or_requirement| {
+                or_requirement.len() == 1
+                    || !or_requirement.iter().any(|r| {
+                        let key = requirement_key(*r);
+                        units.contains(&key)
+                    })
+            });
+
+            assert!(
+                !conjunctive_requirements.is_empty(),
+                "It should not be possible to remove every requirement."
+            );
+            // Propagate all requirements as is.
+            propagated_outlives_requirements
+                .expect("conjunctive_requirements is `Some`, so this should be as well")
+                .extend(conjunctive_requirements.into_iter().flatten());
         }
     }
 
@@ -668,7 +739,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         &self,
         infcx: &InferCtxt<'tcx>,
         type_test: &TypeTest<'tcx>,
-        propagated_outlives_requirements: &mut Vec<ClosureOutlivesRequirement<'tcx>>,
+        propagated_outlives_requirements: &mut Vec<Vec<ClosureOutlivesRequirement<'tcx>>>,
     ) -> bool {
         let tcx = infcx.tcx;
         let TypeTest { generic_kind, lower_bound, span: blame_span, verify_bound: _ } = *type_test;
@@ -694,58 +765,52 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         if let Some(p) = self.scc_values.placeholders_contained_in(r_scc).next() {
             debug!("encountered placeholder in higher universe: {:?}, requiring 'static", p);
             let static_r = self.universal_regions().fr_static;
-            propagated_outlives_requirements.push(ClosureOutlivesRequirement {
+            propagated_outlives_requirements.push(vec![ClosureOutlivesRequirement {
                 subject,
                 outlived_free_region: static_r,
                 blame_span,
                 category: ConstraintCategory::Boring,
-            });
+            }]);
 
             // we can return here -- the code below might push add'l constraints
             // but they would all be weaker than this one.
             return true;
         }
 
-        // For each region outlived by lower_bound find a non-local,
-        // universal region (it may be the same region) and add it to
-        // `ClosureOutlivesRequirement`.
+        let universal_regions: Vec<_> =
+            self.scc_values.universal_regions_outlived_by(r_scc).collect();
+        debug!(?universal_regions);
+
+        // Filter to only the "minimal" universal regions:
+        // Drop any region `a` that strictly outlives another region `b`.
+        let minimal_universal_regions: Vec<_> = universal_regions
+            .iter()
+            .copied()
+            .filter(|&a| {
+                !universal_regions.iter().copied().any(|b| {
+                    !self.universal_region_relations.outlives(a, b)
+                        && self.universal_region_relations.outlives(b, a)
+                })
+            })
+            .collect();
+
+        assert!(
+            !minimal_universal_regions.is_empty(),
+            "There should always be at least 1 minimal region"
+        );
+
         let mut found_outlived_universal_region = false;
-        for ur in self.scc_values.universal_regions_outlived_by(r_scc) {
+        for ur in minimal_universal_regions {
             found_outlived_universal_region = true;
             debug!("universal_region_outlived_by ur={:?}", ur);
-            let mut non_local_ub = self.universal_region_relations.non_local_upper_bounds(ur);
+            let non_local_ub = self.universal_region_relations.non_local_upper_bounds(ur);
             debug!(?non_local_ub);
-
-            // We don't need to propagate every `T: 'ub` for soundness:
-            // Say we have the following outlives constraints given (`'b: 'a` == `a -> b`):
-            //
-            // a
-            //  \
-            //   -> c
-            //  /
-            // b
-            //
-            // And we are doing the type test `T: 'a`.
-            //
-            // The `lower_bound_universal_regions` of `'a` are `['a, 'c]`. The `upper_bounds` of `'a`
-            // is `['a]`, so we propagate `T: 'a`.
-            // The `upper_bounds` of `'c` are `['a, 'b]`, propagating `T: 'a` is correct;
-            // `T: 'b` is redundant because it provides no value to proving `T: 'a`.
-            //
-            // So we filter the set of upper_bounds to regions already outliving `lower_bound`,
-            // but if this subset is empty, we fall back to the original one.
-            let subset: Vec<_> = non_local_ub
-                .iter()
-                .copied()
-                .filter(|ub| self.eval_outlives(*ub, lower_bound))
-                .collect();
-            non_local_ub = if subset.is_empty() { non_local_ub } else { subset };
-            debug!(?non_local_ub, "upper_bounds after filtering");
 
             // This is slightly too conservative. To show T: '1, given `'2: '1`
             // and `'3: '1` we only need to prove that T: '2 *or* T: '3, but to
             // avoid potential non-determinism we approximate this by requiring
             // T: '1 and T: '2.
+            let mut or_requirements = Vec::with_capacity(non_local_ub.len());
             for upper_bound in non_local_ub {
                 debug_assert!(self.universal_regions().is_universal_region(upper_bound));
                 debug_assert!(!self.universal_regions().is_local_free_region(upper_bound));
@@ -757,8 +822,9 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                     category: ConstraintCategory::Boring,
                 };
                 debug!(?requirement, "adding closure requirement");
-                propagated_outlives_requirements.push(requirement);
+                or_requirements.push(requirement);
             }
+            propagated_outlives_requirements.push(or_requirements);
         }
         // If we succeed to promote the subject, i.e. it only contains non-local regions,
         // and fail to prove the type test inside of the closure, the `lower_bound` has to

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -599,7 +599,11 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         // the user. Avoid that.
         let mut deduplicate_errors = FxIndexSet::default();
 
-        let mut conjunctive_propagated_outlives_requirements =
+        // Each type test introduces one or more OR-constraints (e.g. T: 'a OR T: 'b),
+        // where at least one option in each constraint must be satisfied. All such
+        // constraints must be satisfied simultaneously: i.e., they form a conjunction (AND).
+        // We'll use this conjunctive requirement later on.
+        let mut conjunctive_propagated_outlives_requirement =
             propagated_outlives_requirements.is_some().then_some(vec![]);
 
         for type_test in &self.type_tests {
@@ -616,7 +620,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             }
 
             if let Some(conjunctive_propagated_outlives_requirements) =
-                &mut conjunctive_propagated_outlives_requirements
+                &mut conjunctive_propagated_outlives_requirement
                 && self.try_promote_type_test(
                     infcx,
                     type_test,
@@ -646,8 +650,8 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             }
         }
 
-        if let Some(mut conjunctive_requirements) = conjunctive_propagated_outlives_requirements
-            && !conjunctive_requirements.is_empty()
+        if let Some(mut conjunctive_requirement) = conjunctive_propagated_outlives_requirement
+            && !conjunctive_requirement.is_empty()
         {
             // We can simplify this list of list of requirements.
             //
@@ -682,7 +686,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 (ty, subject.outlived_free_region)
             }
 
-            let units: Vec<_> = conjunctive_requirements
+            let units: Vec<_> = conjunctive_requirement
                 .iter()
                 .filter_map(|r| {
                     let [r] = r.as_slice() else { return None };
@@ -691,7 +695,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 .collect();
 
             // Remove the `or_requirement`s that contain any of the unit requirements.
-            conjunctive_requirements.retain(|or_requirement| {
+            conjunctive_requirement.retain(|or_requirement| {
                 or_requirement.len() == 1
                     || !or_requirement.iter().any(|r| {
                         let key = requirement_key(*r);
@@ -700,13 +704,13 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             });
 
             assert!(
-                !conjunctive_requirements.is_empty(),
+                !conjunctive_requirement.is_empty(),
                 "It should not be possible to remove every requirement."
             );
             // Propagate all requirements as is.
             propagated_outlives_requirements
                 .expect("conjunctive_requirements is `Some`, so this should be as well")
-                .extend(conjunctive_requirements.into_iter().flatten());
+                .extend(conjunctive_requirement.into_iter().flatten());
         }
     }
 
@@ -799,9 +803,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             "There should always be at least 1 minimal region"
         );
 
-        let mut found_outlived_universal_region = false;
         for ur in minimal_universal_regions {
-            found_outlived_universal_region = true;
             debug!("universal_region_outlived_by ur={:?}", ur);
             let non_local_ub = self.universal_region_relations.non_local_upper_bounds(ur);
             debug!(?non_local_ub);
@@ -826,11 +828,6 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             }
             propagated_outlives_requirements.push(or_requirements);
         }
-        // If we succeed to promote the subject, i.e. it only contains non-local regions,
-        // and fail to prove the type test inside of the closure, the `lower_bound` has to
-        // also be at least as large as some universal region, as the type test is otherwise
-        // trivial.
-        assert!(found_outlived_universal_region);
         true
     }
 

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -673,9 +673,20 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             // the form (R1 OR ... OR RN), thus if even on R is required on their own (a unit), this
             // whole subexpression can be removed.
             //
+            // Because of the outlives relations, we can actually have a stronger redundancy check,
+            // say we have following requirements that create a conjunctive requirement:
+            // R1: T: 'a
+            // R2: T: 'b OR T: 'c
+            // R: R1 AND R2
+            //
+            // And we have we an assumption in our environment that `'a: 'b`, we can thus remove R2
+            // as well. `T: 'b` is implied by `T: 'a` because of the assumption `'a: 'b`:
+            // T -> 'a -> 'b
+            //
             // So we can filter redundant OR requirements with the following algorithm:
-            // Collect every Unit requirement. Then for every other requirement, if one of the units is
-            // contained within them we can remove the entire requirement from the list.
+            // Collect every Unit requirement. Then for every OR requirement, loop over its
+            // individual requirements and if the region is outlived by the region of one of the
+            // units, remove the entire OR requirement.
 
             fn requirement_key<'a>(subject: ClosureOutlivesRequirement<'a>) -> (Ty<'a>, RegionVid) {
                 let ClosureOutlivesSubject::Ty(ClosureOutlivesSubjectTy { inner: ty }) =
@@ -698,8 +709,13 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             conjunctive_requirement.retain(|or_requirement| {
                 or_requirement.len() == 1
                     || !or_requirement.iter().any(|r| {
-                        let key = requirement_key(*r);
-                        units.contains(&key)
+                        let (ty, region) = requirement_key(*r);
+                        units.iter().any(|&(unit_subj, unit_region)| {
+                            // Same type, and the unit region outlives the disjunct region,
+                            // meaning T: unit_region implies T: region.
+                            unit_subj == ty
+                                && self.universal_region_relations.outlives(unit_region, region)
+                        })
                     })
             });
 

--- a/tests/ui/borrowck/unconstrained-closure-lifetime-generic.rs
+++ b/tests/ui/borrowck/unconstrained-closure-lifetime-generic.rs
@@ -13,8 +13,6 @@ impl Foo {
         //~| ERROR the parameter type `impl for<'a> Fn(&'a usize) -> Box<I>` may not live long enough
         //~| ERROR the parameter type `impl for<'a> Fn(&'a usize) -> Box<I>` may not live long enough
         //~| ERROR the parameter type `I` may not live long enough
-        //~| ERROR the parameter type `I` may not live long enough
-        //~| ERROR the parameter type `I` may not live long enough
         //~| ERROR `f` does not live long enough
     }
 }

--- a/tests/ui/borrowck/unconstrained-closure-lifetime-generic.stderr
+++ b/tests/ui/borrowck/unconstrained-closure-lifetime-generic.stderr
@@ -69,34 +69,6 @@ help: consider adding an explicit lifetime bound
 LL |     pub fn ack<I: 'static>(&mut self, f: impl for<'a> Fn(&'a usize) -> Box<I>) {
    |                 +++++++++
 
-error[E0310]: the parameter type `I` may not live long enough
-  --> $DIR/unconstrained-closure-lifetime-generic.rs:10:35
-   |
-LL |         self.bar = Box::new(|baz| Box::new(f(baz)));
-   |                                   ^^^^^^^^^^^^^^^^
-   |                                   |
-   |                                   the parameter type `I` must be valid for the static lifetime...
-   |                                   ...so that the type `I` will meet its required lifetime bounds
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: consider adding an explicit lifetime bound
-   |
-LL |     pub fn ack<I: 'static>(&mut self, f: impl for<'a> Fn(&'a usize) -> Box<I>) {
-   |                 +++++++++
-
-error[E0311]: the parameter type `I` may not live long enough
-  --> $DIR/unconstrained-closure-lifetime-generic.rs:10:35
-   |
-LL |     pub fn ack<I>(&mut self, f: impl for<'a> Fn(&'a usize) -> Box<I>) {
-   |                   --------- the parameter type `I` must be valid for the anonymous lifetime defined here...
-LL |         self.bar = Box::new(|baz| Box::new(f(baz)));
-   |                                   ^^^^^^^^^^^^^^^^ ...so that the type `I` will meet its required lifetime bounds
-   |
-help: consider adding an explicit lifetime bound
-   |
-LL |     pub fn ack<'a, I: 'a>(&'a mut self, f: impl for<'a> Fn(&'a usize) -> Box<I>) {
-   |                +++  ++++   ++
-
 error[E0597]: `f` does not live long enough
   --> $DIR/unconstrained-closure-lifetime-generic.rs:10:44
    |
@@ -113,7 +85,7 @@ LL |     }
    |
    = note: due to object lifetime defaults, `Box<dyn for<'a> Fn(&'a usize) -> Box<(dyn Any + 'a)>>` actually means `Box<(dyn for<'a> Fn(&'a usize) -> Box<(dyn Any + 'a)> + 'static)>`
 
-error: aborting due to 8 previous errors
+error: aborting due to 6 previous errors
 
-Some errors have detailed explanations: E0310, E0311, E0597.
+Some errors have detailed explanations: E0310, E0597.
 For more information about an error, try `rustc --explain E0310`.

--- a/tests/ui/consts/issue-102117.rs
+++ b/tests/ui/consts/issue-102117.rs
@@ -16,7 +16,6 @@ impl VTable {
                 layout: Layout::new::<T>(),
                 type_id: TypeId::of::<T>(),
                 //~^ ERROR the parameter type `T` may not live long enough
-                //~| ERROR the parameter type `T` may not live long enough
                 drop_in_place: unsafe {
                     transmute::<unsafe fn(*mut T), unsafe fn(*mut ())>(drop_in_place::<T>)
                 },

--- a/tests/ui/consts/issue-102117.stderr
+++ b/tests/ui/consts/issue-102117.stderr
@@ -12,21 +12,6 @@ help: consider adding an explicit lifetime bound
 LL |     pub fn new<T: 'static>() -> &'static Self {
    |                 +++++++++
 
-error[E0310]: the parameter type `T` may not live long enough
-  --> $DIR/issue-102117.rs:17:26
-   |
-LL |                 type_id: TypeId::of::<T>(),
-   |                          ^^^^^^^^^^^^^^^
-   |                          |
-   |                          the parameter type `T` must be valid for the static lifetime...
-   |                          ...so that the type `T` will meet its required lifetime bounds
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: consider adding an explicit lifetime bound
-   |
-LL |     pub fn new<T: 'static>() -> &'static Self {
-   |                 +++++++++
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0310`.

--- a/tests/ui/nll/closure-requirements/type-test-issue-154267-stronger.rs
+++ b/tests/ui/nll/closure-requirements/type-test-issue-154267-stronger.rs
@@ -1,0 +1,22 @@
+//@ check-pass
+//
+// Check that the compiler correctly detects that we don't need to propagate `T: 'b` and `T: 'c`
+// when doing the type tests of `constrain`. This is a stronger version of issue-154267.
+
+struct Arg<'a: 'b, 'b: 'd, 'c: 'd, 'd, T> {
+    field: *mut (&'a (), &'b (), &'c (), &'d (), T),
+}
+impl<'a: 'b, 'b, 'c, 'd, T> Arg<'a, 'b, 'c, 'd, T> {
+    fn constrain(self)
+    where
+        T: 'a,
+        T: 'd,
+    {
+    }
+}
+fn takes_closure<'a, 'b, 'c, T>(_: impl for<'d> FnOnce(Arg<'a, 'b, 'c, 'd, T>)) {}
+
+fn error<'a, 'b, 'c, T: 'a>() {
+    takes_closure::<'a, 'b, 'c, T>(|arg| arg.constrain());
+}
+fn main() {}

--- a/tests/ui/nll/closure-requirements/type-test-issue-154267.rs
+++ b/tests/ui/nll/closure-requirements/type-test-issue-154267.rs
@@ -1,0 +1,25 @@
+//@ check-pass
+// This test checks that the compiler doesn't propagate `T: 'b` during the `T: 'a` type test.
+// If it did, it would fail to compile, even though the program is sound.
+
+struct Arg<'a: 'c, 'b: 'c, 'c, T> {
+    field: *mut (&'a (), &'b (), &'c (), T),
+}
+
+impl<'a, 'b, 'c, T> Arg<'a, 'b, 'c, T> {
+    fn constrain(self)
+    where
+        T: 'a,
+    {
+    }
+}
+
+fn takes_closure<'a, 'b, T>(_: impl for<'c> FnOnce(Arg<'a, 'b, 'c, T>)) {}
+
+// We have `'a: 'c` and `'b: 'c`, requiring `T: 'a` in `constrain` should not need
+// `T: 'b` here.
+fn error<'a, 'b, T: 'a>() {
+    takes_closure::<'a, 'b, T>(|arg| arg.constrain());
+}
+
+fn main() {}

--- a/tests/ui/nll/closure-requirements/type-test-issue-154267.rs
+++ b/tests/ui/nll/closure-requirements/type-test-issue-154267.rs
@@ -10,6 +10,7 @@ impl<'a, 'b, 'c, T> Arg<'a, 'b, 'c, T> {
     fn constrain(self)
     where
         T: 'a,
+        T: 'c,
     {
     }
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/154271)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#154267
Unblocks rust-lang/rust#151510.

## Summary

### Background

While we borrowck closures and their parent body in the same query to handle opaque types, each body is otherwise handled separately. When checking closures (and const blocks), we don't know the region constraints of the parent body, so we don't know anything about non-late bound regions of the closure.

These regions are represented as *external universal regions* of the closure, e.g. in 
```rust
fn foo<'a>(mut x: &'a str) {
    let upvar = "hi there";
    let _: Box<dyn FnOnce(&mut &'a str) -> &'a str> = Box::new(|s| {
        let prev = *s;
        *s = upvar;
        prev
    });
}
```
When borrow checking the closure, it's signature is `for<'anon> fn(&'anon &'ext0 str) -> &'ext1 str)` and it has an upvar of type `&'ext2 str`.

Because of its signature it can assume that `'ext0: 'anon` holds. It does not know anything else about its external regions. Notably even though the expected signature will use `'a` twice, we still use two separate external regions here.

Borrow checking the closure now requires `'ext0: 'ext1` because of the return statement and `'ext2: 'ext0` because of the assignment. We don't know whether these outlive requirements hold and we propagate them to the parent function instead.

If both regions we have to propagate are already external, that's easy. However, we may also have to handle constraints which reference regions internal to the closure. In this case, we can't propagate the constraint to the caller, as the caller cannot name these regions of the closure. In these cases we propagate constrains which *imply* the constraint we actually have to prove.

E.g. in the above example if the closure ended up requiring `'ext2: 'anon` we can't propagate this to the caller directly. However, as we know that `'ext0: 'anon` holds, we can instead propagate `'ext2: 'ext0` which then transitively implies `'ext2: 'anon`.

Given `longer_fr: shorter_fr` we need to propagate at least one constraint `fr-: shorter_fr+` for which the closure knows that `longer_fr: longer_fr-` and `shorter_fr+: 'shorter_fr` hold.

### The behavior on stable

For a constraint like `T: 'a`, `T` is promoted first, replacing all free regions in `T` with `'static` or equal region parameters, producing a constraint subject, free of closure-local regions - failing if any region has no such replacement.`'a` is promoted to the caller's context, we then find non-local universal regions that `'a` outlives. Then for each such region `'ub`, we propagate `T: 'ub`.

> [!note] These constraints are to conservative:
> We find some universal regions `'ur` in the SCC of `'a`, then for each of those `'ur` we find their non-local upper bounds and propagate `T: 'ub`. Though, we actually need only one `T: 'ub` to prove `T: 'ur`. However, the compiler does not support OR constraints (e.g. `T: 'ub1` OR `T: 'ub2`), so we require them all.



### The behavior of this PR

There are 2 changes made in this PR relevant to the current behaviour on stable: We minimize the amount of universal regions found for `'a` and we minimize the amount of OR requirements we propagate to the closure creator.


### Example for Universal Regions Minization

Consider this program:
```rust
struct Arg<'a: 'c, 'b: 'c, 'c, T> {
    field: *mut (&'a (), &'b (), &'c (), T),
}

impl<'a, 'b, 'c, T> Arg<'a, 'b, 'c, T> {
    fn constrain(self)
    where
        T: 'a,
    {
    }
}

fn takes_closure<'a, 'b, T>(
    _: impl for<'c> FnOnce(Arg<'a, 'b, 'c, T>)
) {}

fn error<'a, 'b, T: 'a>() {
    takes_closure::<'a, 'b, T>(|arg| arg.constrain());
}
```

It currently fails to compile and gives the following error:
```
error[E0309]: the parameter type `T` may not live long enough
  --> src/lib.rs:20:38
   |
19 | fn error<'a, 'b, T: 'a>() {
   |              -- the parameter type `T` must be valid for the lifetime `'b` as defined here...
20 |     takes_closure::<'a, 'b, T>(|arg| arg.constrain());
   |                                      ^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
   |
help: consider adding an explicit lifetime bound
   |
19 | fn error<'a, 'b, T: 'a + 'b>() {
   |                        ++++

```

The closure tries to prove `T: 'a`, but it can't, so it tries to promote it to the creator. 
On stable, [fn try_promote_type_test](https://github.com/rust-lang/rust/blob/8afb6a8b1b32fce2f8aa7520517833338dc36c5e/compiler/rustc_borrowck/src/region_infer/mod.rs#L672) finds all universal regions in the constraint graph for the lower bound `'a`:
```rust=
let r_scc = self.constraint_sccs.scc(lower_bound);
// ...
for ur in self.scc_values.universal_regions_outlived_by(r_scc) {
```

These are `'a` and `'c`, then for each of those regions, we find their non-local upper bounds `'ub` and propagate `T: 'ub`:
- for `'a`, this is just `'a` -> `T: 'a`
- for `'c`, these are `'a` and `'b` -> `T: 'a` OR `T: 'b`

Clearly, there is no outlives relation between `'a` and `'b` that requires `T: 'b` to prove `T: 'a`.


This pr first minimizes the regions returned by `self.scc_values.universal_regions_outlived_by(r_scc)` by removing any region already outlived by another region in the set. For the example above we would get `['a, 'c]`, which we would be minimized to `['a]`, because `'c: 'a`. Thus never propagating `T: 'b`.

The reason we can do this "minimization" is somewhat trivial. If we need to prove `T: '1` and `T: '2`, but `'1: '2` holds, there is no reason to prove `T: '2` as well.

### Example for OR Requirement minimization

Say we introduce another type test on the first example:
```rust=
struct Arg<'a: 'c, 'b: 'c, 'c, T> {
    field: *mut (&'a (), &'b (), &'c (), T),
}

impl<'a, 'b, 'c, T> Arg<'a, 'b, 'c, T> {
    fn constrain(self)
    where
        T: 'a,
        T: 'c,
    {
    }
}

fn takes_closure<'a, 'b, T>(_: impl for<'c> FnOnce(Arg<'a, 'b, 'c, T>)) {}

// We have `'a: 'c` and `'b: 'c`, requiring `T: 'a` in `constrain` should not need
// `T: 'b` here.
fn error<'a, 'b, T: 'a>() {
    takes_closure::<'a, 'b, T>(|arg| arg.constrain());
}
```

This `T: 'c` type-test now introduces an implicit OR requirement: the non-local upper bounds of `'c` are `['a, 'b]`, thus propagating `T: 'a OR T: 'b` as two standalone requirements, both of which should hold. Even though our example shows that `constrain` already requires `T: 'a`, making `T: 'b` redundant.

This PR changes the way these requirements are propagated, essentially propagating a list of requirements for each univeral regions. This list is seen as a collection of OR requirements and if we have multiple such lists, we require all of them to hold. In our above example this would result in 2 OR requirements: 
- `R1`: `T: 'a` from type test `T: 'a`.
- `R2`: `T: 'a OR T: 'b` from type test `T: 'c`.

With full requirement `R1 AND R2` represented by `[R1, R2]`. We then loop over these OR requirements and collect all "unit" requirements (R1 above). We then loop again over the OR requirements and remove every OR requirement which contains at least one unit requirement. For our example, this would result in removing `R2`, because it contains `R1`.

Note that we can be even smarter during this removal process, say we had following OR requirements:
- `R1`: `T: 'a`
- `R2`: `T: 'b OR T: 'c`

With full requirement `R1 AND R2` **and** assumption `'a: 'b`. This assumption would allow us to remove `R2`, because `T: 'a` implies `T: 'b` through the assumption.

## Design

### Reference

We currently don't document borrowck in the reference. Once we do this, this is PR requires a localized change to how we propagate requirements from nested bodies.

### Other

RFC history, Answers to unresolved questions, Post-RFC changes, Key points, Nightly extensions, Doors closed, Feedback, Call for testing, Nightly use: n/a

## Implementation n/a see summary

### Major parts n/a

### Coverage

All examples shown above are covered as tests in this PR.

### Outstanding bugs

We sometimes still propagate multiple constraints even though a single one would be sufficient, potentially causing unnecessary errors.

To avoid any such errors here, we'd probably have to support OR constraints. There may also be some future improvements to closure constraint propagation, but :shrug: we want to avoid introducing non-determinstic or surprising behavior here.

### Outstanding FIXMEs n/a

### Tool changes n/a

### Breaking changes n/a

## Type system, opsem

### Compile-time checks n/a

### Type system rules n/a

### Sound by default? n/a

### Breaks the AM? n/a

## Common interactions

### Temporaries n/a

### Drop order n/a

### Pre-expansion / post-expansion n/a

### Edition hygiene n/a

### SemVer implications n/a

### Exposing other features n/a

## History

Propagating closure requirements was originally implemented by @nikomatsakis in https://github.com/rust-lang/rust/pull/46509 and then improved by @matthewjasper in https://github.com/rust-lang/rust/pull/58347.
It was then improved by @LorrensP-2158466 in https://github.com/rust-lang/rust/pull/148329.

## Acknowledgments

## Open items

Rustc Dev Guide should be updated: [type-outlive constraints](https://rustc-dev-guide.rust-lang.org/borrow-check/region-inference/closure-constraints.html#type-outlive-constraints).


r? @lcnr 