### PR TITLE
use `minicore` more in testing inline assembly

### DIFF
--- a/tests/auxiliary/minicore.rs
+++ b/tests/auxiliary/minicore.rs
@@ -238,6 +238,8 @@ impl_marker_trait!(
 
 impl Sync for () {}
 
+impl<T, const N: usize> Sync for [T; N] {}
+
 #[lang = "drop_in_place"]
 fn drop_in_place<T>(_: *mut T) {}
 

--- a/tests/ui/asm/aarch64/aarch64-sve.rs
+++ b/tests/ui/asm/aarch64/aarch64-sve.rs
@@ -1,12 +1,16 @@
-//@ only-aarch64
 //@ build-pass
-//@ needs-asm-support
-
+//@ add-minicore
+//@ compile-flags: --target aarch64-unknown-linux-gnu
+//@ needs-llvm-components: aarch64
+//@ ignore-backends: gcc
 #![crate_type = "rlib"]
+#![feature(no_core)]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
 
 // AArch64 test corresponding to arm64ec-sve.rs.
-
-use std::arch::asm;
 
 fn f(x: f64) {
     unsafe {

--- a/tests/ui/asm/aarch64/bad-options.rs
+++ b/tests/ui/asm/aarch64/bad-options.rs
@@ -1,6 +1,13 @@
-//@ only-aarch64
+//@ add-minicore
+//@ compile-flags: --target aarch64-unknown-linux-gnu
+//@ needs-llvm-components: aarch64
+//@ ignore-backends: gcc
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
 
-use std::arch::{asm, global_asm};
+extern crate minicore;
+use minicore::*;
 
 fn main() {
     let mut foo = 0;

--- a/tests/ui/asm/aarch64/bad-options.stderr
+++ b/tests/ui/asm/aarch64/bad-options.stderr
@@ -1,35 +1,35 @@
 error: the `nomem` and `readonly` options are mutually exclusive
-  --> $DIR/bad-options.rs:8:18
+  --> $DIR/bad-options.rs:15:18
    |
 LL |         asm!("", options(nomem, readonly));
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: the `pure` and `noreturn` options are mutually exclusive
-  --> $DIR/bad-options.rs:10:18
+  --> $DIR/bad-options.rs:17:18
    |
 LL |         asm!("", options(pure, nomem, noreturn));
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: asm with the `pure` option must have at least one output
-  --> $DIR/bad-options.rs:10:18
+  --> $DIR/bad-options.rs:17:18
    |
 LL |         asm!("", options(pure, nomem, noreturn));
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: asm with the `pure` option must have at least one output
-  --> $DIR/bad-options.rs:13:33
+  --> $DIR/bad-options.rs:20:33
    |
 LL |         asm!("{}", in(reg) foo, options(pure, nomem));
    |                                 ^^^^^^^^^^^^^^^^^^^^
 
 error: asm outputs are not allowed with the `noreturn` option
-  --> $DIR/bad-options.rs:15:20
+  --> $DIR/bad-options.rs:22:20
    |
 LL |         asm!("{}", out(reg) foo, options(noreturn));
    |                    ^^^^^^^^^^^^
 
 error: asm with `clobber_abi` must specify explicit registers for outputs
-  --> $DIR/bad-options.rs:22:20
+  --> $DIR/bad-options.rs:29:20
    |
 LL |         asm!("{}", out(reg) foo, clobber_abi("C"));
    |                    ^^^^^^^^^^^^  ---------------- clobber_abi
@@ -37,43 +37,43 @@ LL |         asm!("{}", out(reg) foo, clobber_abi("C"));
    |                    generic outputs
 
 error: the `nomem` option cannot be used with `global_asm!`
-  --> $DIR/bad-options.rs:28:25
+  --> $DIR/bad-options.rs:35:25
    |
 LL | global_asm!("", options(nomem));
    |                         ^^^^^ the `nomem` option is not meaningful for global-scoped inline assembly
 
 error: the `readonly` option cannot be used with `global_asm!`
-  --> $DIR/bad-options.rs:30:25
+  --> $DIR/bad-options.rs:37:25
    |
 LL | global_asm!("", options(readonly));
    |                         ^^^^^^^^ the `readonly` option is not meaningful for global-scoped inline assembly
 
 error: the `noreturn` option cannot be used with `global_asm!`
-  --> $DIR/bad-options.rs:32:25
+  --> $DIR/bad-options.rs:39:25
    |
 LL | global_asm!("", options(noreturn));
    |                         ^^^^^^^^ the `noreturn` option is not meaningful for global-scoped inline assembly
 
 error: the `pure` option cannot be used with `global_asm!`
-  --> $DIR/bad-options.rs:34:25
+  --> $DIR/bad-options.rs:41:25
    |
 LL | global_asm!("", options(pure));
    |                         ^^^^ the `pure` option is not meaningful for global-scoped inline assembly
 
 error: the `nostack` option cannot be used with `global_asm!`
-  --> $DIR/bad-options.rs:36:25
+  --> $DIR/bad-options.rs:43:25
    |
 LL | global_asm!("", options(nostack));
    |                         ^^^^^^^ the `nostack` option is not meaningful for global-scoped inline assembly
 
 error: the `preserves_flags` option cannot be used with `global_asm!`
-  --> $DIR/bad-options.rs:38:25
+  --> $DIR/bad-options.rs:45:25
    |
 LL | global_asm!("", options(preserves_flags));
    |                         ^^^^^^^^^^^^^^^ the `preserves_flags` option is not meaningful for global-scoped inline assembly
 
 error: invalid ABI for `clobber_abi`
-  --> $DIR/bad-options.rs:20:18
+  --> $DIR/bad-options.rs:27:18
    |
 LL |         asm!("", clobber_abi("foo"));
    |                  ^^^^^^^^^^^^^^^^^^

--- a/tests/ui/asm/aarch64/bad-reg.rs
+++ b/tests/ui/asm/aarch64/bad-reg.rs
@@ -1,6 +1,7 @@
 //@ add-minicore
-//@ only-aarch64
-//@ compile-flags: -C target-feature=+neon
+//@ compile-flags: --target aarch64-unknown-linux-gnu -C target-feature=+neon
+//@ needs-llvm-components: aarch64
+//@ ignore-backends: gcc
 #![crate_type = "lib"]
 #![feature(no_core)]
 #![no_core]

--- a/tests/ui/asm/aarch64/bad-reg.stderr
+++ b/tests/ui/asm/aarch64/bad-reg.stderr
@@ -1,5 +1,5 @@
 error: invalid register class `foo`: unknown register class
-  --> $DIR/bad-reg.rs:17:20
+  --> $DIR/bad-reg.rs:18:20
    |
 LL |         asm!("{}", in(foo) foo);
    |                    ^^^^^^^^^^^
@@ -7,13 +7,13 @@ LL |         asm!("{}", in(foo) foo);
    = note: the following register classes are supported on this target: `reg`, `vreg`, `vreg_low16`, and `preg`
 
 error: invalid register `foo`: unknown register
-  --> $DIR/bad-reg.rs:19:18
+  --> $DIR/bad-reg.rs:20:18
    |
 LL |         asm!("", in("foo") foo);
    |                  ^^^^^^^^^^^^^
 
 error: invalid asm template modifier `z` for this register class
-  --> $DIR/bad-reg.rs:21:15
+  --> $DIR/bad-reg.rs:22:15
    |
 LL |         asm!("{:z}", in(reg) foo);
    |               ^^^^   ----------- argument
@@ -23,7 +23,7 @@ LL |         asm!("{:z}", in(reg) foo);
    = note: the `reg` register class supports the following template modifiers: `w` and `x`
 
 error: invalid asm template modifier `r` for this register class
-  --> $DIR/bad-reg.rs:23:15
+  --> $DIR/bad-reg.rs:24:15
    |
 LL |         asm!("{:r}", in(vreg) foo);
    |               ^^^^   ------------ argument
@@ -33,7 +33,7 @@ LL |         asm!("{:r}", in(vreg) foo);
    = note: the `vreg` register class supports the following template modifiers: `b`, `h`, `s`, `d`, `q`, and `v`
 
 error: invalid asm template modifier `r` for this register class
-  --> $DIR/bad-reg.rs:25:15
+  --> $DIR/bad-reg.rs:26:15
    |
 LL |         asm!("{:r}", in(vreg_low16) foo);
    |               ^^^^   ------------------ argument
@@ -43,7 +43,7 @@ LL |         asm!("{:r}", in(vreg_low16) foo);
    = note: the `vreg_low16` register class supports the following template modifiers: `b`, `h`, `s`, `d`, `q`, and `v`
 
 error: asm template modifiers are not allowed for `const` arguments
-  --> $DIR/bad-reg.rs:27:15
+  --> $DIR/bad-reg.rs:28:15
    |
 LL |         asm!("{:a}", const 0);
    |               ^^^^   ------- argument
@@ -51,7 +51,7 @@ LL |         asm!("{:a}", const 0);
    |               template modifier
 
 error: asm template modifiers are not allowed for `sym` arguments
-  --> $DIR/bad-reg.rs:29:15
+  --> $DIR/bad-reg.rs:30:15
    |
 LL |         asm!("{:a}", sym main);
    |               ^^^^   -------- argument
@@ -59,49 +59,49 @@ LL |         asm!("{:a}", sym main);
    |               template modifier
 
 error: invalid register `x29`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:31:18
+  --> $DIR/bad-reg.rs:32:18
    |
 LL |         asm!("", in("x29") foo);
    |                  ^^^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:33:18
+  --> $DIR/bad-reg.rs:34:18
    |
 LL |         asm!("", in("sp") foo);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `xzr`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:35:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", in("xzr") foo);
    |                  ^^^^^^^^^^^^^
 
 error: invalid register `x19`: x19 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:38:18
    |
 LL |         asm!("", in("x19") foo);
    |                  ^^^^^^^^^^^^^
 
 error: register class `preg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", in("p0") foo);
    |                  ^^^^^^^^^^^^
 
 error: register class `preg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:44:20
+  --> $DIR/bad-reg.rs:45:20
    |
 LL |         asm!("{}", in(preg) foo);
    |                    ^^^^^^^^^^^^
 
 error: register class `preg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:47:20
+  --> $DIR/bad-reg.rs:48:20
    |
 LL |         asm!("{}", out(preg) _);
    |                    ^^^^^^^^^^^
 
 error: register `w0` conflicts with register `x0`
-  --> $DIR/bad-reg.rs:53:32
+  --> $DIR/bad-reg.rs:54:32
    |
 LL |         asm!("", in("x0") foo, in("w0") bar);
    |                  ------------  ^^^^^^^^^^^^ register `w0`
@@ -109,7 +109,7 @@ LL |         asm!("", in("x0") foo, in("w0") bar);
    |                  register `x0`
 
 error: register `x0` conflicts with register `x0`
-  --> $DIR/bad-reg.rs:55:32
+  --> $DIR/bad-reg.rs:56:32
    |
 LL |         asm!("", in("x0") foo, out("x0") bar);
    |                  ------------  ^^^^^^^^^^^^^ register `x0`
@@ -117,13 +117,13 @@ LL |         asm!("", in("x0") foo, out("x0") bar);
    |                  register `x0`
    |
 help: use `lateout` instead of `out` to avoid conflict
-  --> $DIR/bad-reg.rs:55:18
+  --> $DIR/bad-reg.rs:56:18
    |
 LL |         asm!("", in("x0") foo, out("x0") bar);
    |                  ^^^^^^^^^^^^
 
 error: register `q0` conflicts with register `v0`
-  --> $DIR/bad-reg.rs:58:32
+  --> $DIR/bad-reg.rs:59:32
    |
 LL |         asm!("", in("v0") foo, in("q0") bar);
    |                  ------------  ^^^^^^^^^^^^ register `q0`
@@ -131,7 +131,7 @@ LL |         asm!("", in("v0") foo, in("q0") bar);
    |                  register `v0`
 
 error: register `q0` conflicts with register `v0`
-  --> $DIR/bad-reg.rs:60:32
+  --> $DIR/bad-reg.rs:61:32
    |
 LL |         asm!("", in("v0") foo, out("q0") bar);
    |                  ------------  ^^^^^^^^^^^^^ register `q0`
@@ -139,13 +139,13 @@ LL |         asm!("", in("v0") foo, out("q0") bar);
    |                  register `v0`
    |
 help: use `lateout` instead of `out` to avoid conflict
-  --> $DIR/bad-reg.rs:60:18
+  --> $DIR/bad-reg.rs:61:18
    |
 LL |         asm!("", in("v0") foo, out("q0") bar);
    |                  ^^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:40:27
+  --> $DIR/bad-reg.rs:41:27
    |
 LL |         asm!("", in("p0") foo);
    |                           ^^^
@@ -153,7 +153,7 @@ LL |         asm!("", in("p0") foo);
    = note: register class `preg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:44:29
+  --> $DIR/bad-reg.rs:45:29
    |
 LL |         asm!("{}", in(preg) foo);
    |                             ^^^

--- a/tests/ui/asm/aarch64/duplicate-options.fixed
+++ b/tests/ui/asm/aarch64/duplicate-options.fixed
@@ -1,8 +1,14 @@
-//@ only-aarch64
-//@ needs-asm-support
 //@ run-rustfix
+//@ add-minicore
+//@ compile-flags: --target aarch64-unknown-linux-gnu
+//@ needs-llvm-components: aarch64
+//@ needs-asm-support
+//@ ignore-backends: gcc
+#![feature(no_core)]
+#![no_core]
 
-use std::arch::asm;
+extern crate minicore;
+use minicore::*;
 
 fn main() {
     unsafe {

--- a/tests/ui/asm/aarch64/duplicate-options.rs
+++ b/tests/ui/asm/aarch64/duplicate-options.rs
@@ -1,8 +1,14 @@
-//@ only-aarch64
-//@ needs-asm-support
 //@ run-rustfix
+//@ add-minicore
+//@ compile-flags: --target aarch64-unknown-linux-gnu
+//@ needs-llvm-components: aarch64
+//@ needs-asm-support
+//@ ignore-backends: gcc
+#![feature(no_core)]
+#![no_core]
 
-use std::arch::asm;
+extern crate minicore;
+use minicore::*;
 
 fn main() {
     unsafe {

--- a/tests/ui/asm/aarch64/duplicate-options.stderr
+++ b/tests/ui/asm/aarch64/duplicate-options.stderr
@@ -1,53 +1,53 @@
 error: the `nomem` option was already provided
-  --> $DIR/duplicate-options.rs:9:33
+  --> $DIR/duplicate-options.rs:15:33
    |
 LL |         asm!("", options(nomem, nomem));
    |                                 ^^^^^ this option was already provided
 
 error: the `preserves_flags` option was already provided
-  --> $DIR/duplicate-options.rs:11:43
+  --> $DIR/duplicate-options.rs:17:43
    |
 LL |         asm!("", options(preserves_flags, preserves_flags));
    |                                           ^^^^^^^^^^^^^^^ this option was already provided
 
 error: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:13:61
+  --> $DIR/duplicate-options.rs:19:61
    |
 LL |         asm!("", options(nostack, preserves_flags), options(nostack));
    |                                                             ^^^^^^^ this option was already provided
 
 error: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:15:35
+  --> $DIR/duplicate-options.rs:21:35
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
    |                                   ^^^^^^^ this option was already provided
 
 error: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:15:53
+  --> $DIR/duplicate-options.rs:21:53
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
    |                                                     ^^^^^^^ this option was already provided
 
 error: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:15:71
+  --> $DIR/duplicate-options.rs:21:71
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
    |                                                                       ^^^^^^^ this option was already provided
 
 error: the `noreturn` option was already provided
-  --> $DIR/duplicate-options.rs:22:38
+  --> $DIR/duplicate-options.rs:28:38
    |
 LL |             options(preserves_flags, noreturn),
    |                                      ^^^^^^^^ this option was already provided
 
 error: the `nomem` option was already provided
-  --> $DIR/duplicate-options.rs:23:21
+  --> $DIR/duplicate-options.rs:29:21
    |
 LL |             options(nomem, nostack),
    |                     ^^^^^ this option was already provided
 
 error: the `noreturn` option was already provided
-  --> $DIR/duplicate-options.rs:24:21
+  --> $DIR/duplicate-options.rs:30:21
    |
 LL |             options(noreturn),
    |                     ^^^^^^^^ this option was already provided

--- a/tests/ui/asm/aarch64/interpolated-idents.rs
+++ b/tests/ui/asm/aarch64/interpolated-idents.rs
@@ -1,6 +1,13 @@
-//@ only-aarch64
-//@ needs-asm-support
-use std::arch::asm;
+//@ add-minicore
+//@ compile-flags: --target aarch64-unknown-linux-gnu
+//@ needs-llvm-components: aarch64
+//@ ignore-backends: gcc
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
 
 macro_rules! m {
     ($in:ident $out:ident $lateout:ident $inout:ident $inlateout:ident $const:ident $sym:ident

--- a/tests/ui/asm/aarch64/interpolated-idents.stderr
+++ b/tests/ui/asm/aarch64/interpolated-idents.stderr
@@ -1,5 +1,5 @@
 error: the `nomem` and `readonly` options are mutually exclusive
-  --> $DIR/interpolated-idents.rs:13:13
+  --> $DIR/interpolated-idents.rs:20:13
    |
 LL |               $options($pure, $nomem, $readonly, $preserves_flags, $noreturn, $nostack));
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -12,7 +12,7 @@ LL | |        noreturn nostack options);
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: the `pure` and `noreturn` options are mutually exclusive
-  --> $DIR/interpolated-idents.rs:13:13
+  --> $DIR/interpolated-idents.rs:20:13
    |
 LL |               $options($pure, $nomem, $readonly, $preserves_flags, $noreturn, $nostack));
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL | |        noreturn nostack options);
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: asm outputs are not allowed with the `noreturn` option
-  --> $DIR/interpolated-idents.rs:10:32
+  --> $DIR/interpolated-idents.rs:17:32
    |
 LL |               asm!("", $in(x) x, $out(x) x, $lateout(x) x, $inout(x) x, $inlateout(x) x,
    |                                  ^^^^^^^^^  ^^^^^^^^^^^^^  ^^^^^^^^^^^  ^^^^^^^^^^^^^^^

--- a/tests/ui/asm/aarch64/parse-error.rs
+++ b/tests/ui/asm/aarch64/parse-error.rs
@@ -1,6 +1,13 @@
-//@ only-aarch64
+//@ add-minicore
+//@ compile-flags: --target aarch64-unknown-linux-gnu
+//@ needs-llvm-components: aarch64
+//@ ignore-backends: gcc
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
 
-use std::arch::asm;
+extern crate minicore;
+use minicore::*;
 
 fn main() {
     let mut foo = 0;

--- a/tests/ui/asm/aarch64/parse-error.stderr
+++ b/tests/ui/asm/aarch64/parse-error.stderr
@@ -1,11 +1,11 @@
 error: explicit register arguments cannot have names
-  --> $DIR/parse-error.rs:9:18
+  --> $DIR/parse-error.rs:16:18
    |
 LL |         asm!("", a = in("x0") foo);
    |                  ^^^^^^^^^^^^^^^^
 
 error: positional arguments cannot follow named arguments or explicit register arguments
-  --> $DIR/parse-error.rs:15:35
+  --> $DIR/parse-error.rs:22:35
    |
 LL |         asm!("{1}", in("x0") foo, const bar);
    |                     ------------  ^^^^^^^^^ positional argument
@@ -13,7 +13,7 @@ LL |         asm!("{1}", in("x0") foo, const bar);
    |                     explicit register argument
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:11:45
+  --> $DIR/parse-error.rs:18:45
    |
 LL |         asm!("{a}", in("x0") foo, a = const bar);
    |                                             ^^^ non-constant value
@@ -25,7 +25,7 @@ LL +     const bar: /* Type */ = 0;
    |
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:13:45
+  --> $DIR/parse-error.rs:20:45
    |
 LL |         asm!("{a}", in("x0") foo, a = const bar);
    |                                             ^^^ non-constant value
@@ -37,7 +37,7 @@ LL +     const bar: /* Type */ = 0;
    |
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:15:41
+  --> $DIR/parse-error.rs:22:41
    |
 LL |         asm!("{1}", in("x0") foo, const bar);
    |                                         ^^^ non-constant value

--- a/tests/ui/asm/aarch64/srcloc.rs
+++ b/tests/ui/asm/aarch64/srcloc.rs
@@ -1,12 +1,19 @@
-//@ only-aarch64
+//@ add-minicore
 //@ build-fail
 //@ needs-asm-support
-//@ compile-flags: -Ccodegen-units=1
+//@ compile-flags: --target aarch64-unknown-linux-gnu -Ccodegen-units=1
+//@ needs-llvm-components: aarch64
+//@ ignore-backends: gcc
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
 
-use std::arch::asm;
+extern crate minicore;
+use minicore::*;
 
 // Checks that inline asm errors are mapped to the correct line in the source code.
-
+#[unsafe(no_mangle)]
+#[rustfmt::skip]
 fn main() {
     unsafe {
         asm!("invalid_instruction");

--- a/tests/ui/asm/aarch64/srcloc.stderr
+++ b/tests/ui/asm/aarch64/srcloc.stderr
@@ -1,5 +1,5 @@
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:12:15
+  --> $DIR/srcloc.rs:19:15
    |
 LL |         asm!("invalid_instruction");
    |               ^^^^^^^^^^^^^^^^^^^
@@ -11,7 +11,7 @@ LL |     invalid_instruction
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:16:13
+  --> $DIR/srcloc.rs:23:13
    |
 LL |             invalid_instruction
    |             ^^^^^^^^^^^^^^^^^^^
@@ -23,25 +23,13 @@ LL |             invalid_instruction
    |             ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:21:13
+  --> $DIR/srcloc.rs:28:13
    |
 LL |             invalid_instruction
    |             ^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:2:13
-   |
-LL |             invalid_instruction
-   |             ^
-
-error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:27:13
-   |
-LL |             invalid_instruction
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-note: instantiated into assembly here
-  --> <inline asm>:3:13
    |
 LL |             invalid_instruction
    |             ^
@@ -59,7 +47,19 @@ LL |             invalid_instruction
    |             ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:39:14
+  --> $DIR/srcloc.rs:41:13
+   |
+LL |             invalid_instruction
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:3:13
+   |
+LL |             invalid_instruction
+   |             ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:46:14
    |
 LL |         asm!(concat!("invalid", "_", "instruction"));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -71,7 +71,7 @@ LL |     invalid_instruction
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:43:14
+  --> $DIR/srcloc.rs:50:14
    |
 LL |             "invalid_instruction",
    |              ^^^^^^^^^^^^^^^^^^^
@@ -83,37 +83,25 @@ LL |     invalid_instruction
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:49:14
-   |
-LL |             "invalid_instruction",
-   |              ^^^^^^^^^^^^^^^^^^^
-   |
-note: instantiated into assembly here
-  --> <inline asm>:2:1
-   |
-LL | invalid_instruction
-   | ^
-
-error: unrecognized instruction mnemonic
   --> $DIR/srcloc.rs:56:14
    |
 LL |             "invalid_instruction",
    |              ^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
-  --> <inline asm>:3:1
+  --> <inline asm>:2:1
    |
 LL | invalid_instruction
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:63:13
+  --> $DIR/srcloc.rs:63:14
    |
-LL |             concat!("invalid", "_", "instruction"),
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |             "invalid_instruction",
+   |              ^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
-  --> <inline asm>:2:1
+  --> <inline asm>:3:1
    |
 LL | invalid_instruction
    | ^
@@ -131,7 +119,19 @@ LL | invalid_instruction
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:77:14
+  --> $DIR/srcloc.rs:77:13
+   |
+LL |             concat!("invalid", "_", "instruction"),
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:2:1
+   |
+LL | invalid_instruction
+   | ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:84:14
    |
 LL |             "invalid_instruction1",
    |              ^^^^^^^^^^^^^^^^^^^^
@@ -143,7 +143,7 @@ LL |     invalid_instruction1
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:78:14
+  --> $DIR/srcloc.rs:85:14
    |
 LL |             "invalid_instruction2",
    |              ^^^^^^^^^^^^^^^^^^^^
@@ -155,7 +155,7 @@ LL | invalid_instruction2
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:84:13
+  --> $DIR/srcloc.rs:91:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction1", "\n",
@@ -170,7 +170,7 @@ LL |     invalid_instruction1
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:84:13
+  --> $DIR/srcloc.rs:91:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction1", "\n",
@@ -185,7 +185,7 @@ LL | invalid_instruction2
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:93:13
+  --> $DIR/srcloc.rs:100:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction1", "\n",
@@ -200,7 +200,7 @@ LL |     invalid_instruction1
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:93:13
+  --> $DIR/srcloc.rs:100:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction1", "\n",
@@ -215,7 +215,7 @@ LL | invalid_instruction2
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:97:13
+  --> $DIR/srcloc.rs:104:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction3", "\n",
@@ -230,7 +230,7 @@ LL | invalid_instruction3
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:97:13
+  --> $DIR/srcloc.rs:104:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction3", "\n",
@@ -245,7 +245,7 @@ LL | invalid_instruction4
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:108:13
+  --> $DIR/srcloc.rs:115:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction1", "\n",
@@ -260,7 +260,7 @@ LL |     invalid_instruction1
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:108:13
+  --> $DIR/srcloc.rs:115:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction1", "\n",
@@ -275,7 +275,7 @@ LL | invalid_instruction2
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:112:13
+  --> $DIR/srcloc.rs:119:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction3", "\n",
@@ -290,7 +290,7 @@ LL | invalid_instruction3
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:112:13
+  --> $DIR/srcloc.rs:119:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction3", "\n",
@@ -305,7 +305,7 @@ LL | invalid_instruction4
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:125:14
+  --> $DIR/srcloc.rs:132:14
    |
 LL |             "invalid_instruction"
    |              ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/asm/aarch64/ttbr0_el2.rs
+++ b/tests/ui/asm/aarch64/ttbr0_el2.rs
@@ -1,7 +1,15 @@
 //! Regression test for #97724, recognising ttbr0_el2 as a valid armv8 system register
-//@ only-aarch64
+//@ add-minicore
 //@ build-pass
-use std::arch::asm;
+//@ compile-flags: --target aarch64-unknown-linux-gnu
+//@ needs-llvm-components: aarch64
+//@ ignore-backends: gcc
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
 
 static PT: [u64; 512] = [0; 512];
 fn main() {

--- a/tests/ui/asm/x86_64/bad-clobber-abi.rs
+++ b/tests/ui/asm/x86_64/bad-clobber-abi.rs
@@ -1,7 +1,12 @@
-//@ needs-asm-support
-//@ only-x86_64
+//@ add-minicore
+//@ compile-flags: --target x86_64-unknown-linux-gnu
+//@ needs-llvm-components: x86
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
 
-use std::arch::asm;
+extern crate minicore;
+use minicore::*;
 
 // checks various modes of failure for the `clobber_abi` argument (after parsing)
 

--- a/tests/ui/asm/x86_64/bad-clobber-abi.stderr
+++ b/tests/ui/asm/x86_64/bad-clobber-abi.stderr
@@ -1,5 +1,5 @@
 error: invalid ABI for `clobber_abi`
-  --> $DIR/bad-clobber-abi.rs:11:18
+  --> $DIR/bad-clobber-abi.rs:16:18
    |
 LL |         asm!("", clobber_abi("foo"));
    |                  ^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |         asm!("", clobber_abi("foo"));
    = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, and `sysv64`
 
 error: invalid ABI for `clobber_abi`
-  --> $DIR/bad-clobber-abi.rs:13:35
+  --> $DIR/bad-clobber-abi.rs:18:35
    |
 LL |         asm!("", clobber_abi("C", "foo"));
    |                                   ^^^^^
@@ -15,7 +15,7 @@ LL |         asm!("", clobber_abi("C", "foo"));
    = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, and `sysv64`
 
 error: `C` ABI specified multiple times
-  --> $DIR/bad-clobber-abi.rs:15:35
+  --> $DIR/bad-clobber-abi.rs:20:35
    |
 LL |         asm!("", clobber_abi("C", "C"));
    |                              ---  ^^^
@@ -23,7 +23,7 @@ LL |         asm!("", clobber_abi("C", "C"));
    |                              previously specified here
 
 error: `win64` ABI specified multiple times
-  --> $DIR/bad-clobber-abi.rs:18:39
+  --> $DIR/bad-clobber-abi.rs:23:39
    |
 LL |         asm!("", clobber_abi("win64", "efiapi"));
    |                              -------  ^^^^^^^^
@@ -33,7 +33,7 @@ LL |         asm!("", clobber_abi("win64", "efiapi"));
    = note: these ABIs are equivalent on the current target
 
 error: invalid ABI for `clobber_abi`
-  --> $DIR/bad-clobber-abi.rs:20:35
+  --> $DIR/bad-clobber-abi.rs:25:35
    |
 LL |         asm!("", clobber_abi("C", "foo", "C"));
    |                                   ^^^^^
@@ -41,7 +41,7 @@ LL |         asm!("", clobber_abi("C", "foo", "C"));
    = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, and `sysv64`
 
 error: `C` ABI specified multiple times
-  --> $DIR/bad-clobber-abi.rs:20:42
+  --> $DIR/bad-clobber-abi.rs:25:42
    |
 LL |         asm!("", clobber_abi("C", "foo", "C"));
    |                              ---         ^^^
@@ -49,7 +49,7 @@ LL |         asm!("", clobber_abi("C", "foo", "C"));
    |                              previously specified here
 
 error: invalid ABI for `clobber_abi`
-  --> $DIR/bad-clobber-abi.rs:23:39
+  --> $DIR/bad-clobber-abi.rs:28:39
    |
 LL |         asm!("", clobber_abi("win64", "foo", "efiapi"));
    |                                       ^^^^^
@@ -57,7 +57,7 @@ LL |         asm!("", clobber_abi("win64", "foo", "efiapi"));
    = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, and `sysv64`
 
 error: `win64` ABI specified multiple times
-  --> $DIR/bad-clobber-abi.rs:23:46
+  --> $DIR/bad-clobber-abi.rs:28:46
    |
 LL |         asm!("", clobber_abi("win64", "foo", "efiapi"));
    |                              -------         ^^^^^^^^
@@ -67,7 +67,7 @@ LL |         asm!("", clobber_abi("win64", "foo", "efiapi"));
    = note: these ABIs are equivalent on the current target
 
 error: `C` ABI specified multiple times
-  --> $DIR/bad-clobber-abi.rs:26:36
+  --> $DIR/bad-clobber-abi.rs:31:36
    |
 LL |         asm!("", clobber_abi("C"), clobber_abi("C"));
    |                  ----------------  ^^^^^^^^^^^^^^^^
@@ -75,7 +75,7 @@ LL |         asm!("", clobber_abi("C"), clobber_abi("C"));
    |                  previously specified here
 
 error: `win64` ABI specified multiple times
-  --> $DIR/bad-clobber-abi.rs:29:40
+  --> $DIR/bad-clobber-abi.rs:34:40
    |
 LL |         asm!("", clobber_abi("win64"), clobber_abi("efiapi"));
    |                  --------------------  ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/asm/x86_64/bad-options.rs
+++ b/tests/ui/asm/x86_64/bad-options.rs
@@ -1,8 +1,13 @@
-//@ only-x86_64
-
+//@ add-minicore
+//@ compile-flags: --target x86_64-unknown-linux-gnu
+//@ needs-llvm-components: x86
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
 #![feature(asm_unwind)]
 
-use std::arch::{asm, global_asm};
+extern crate minicore;
+use minicore::*;
 
 fn main() {
     let mut foo = 0;

--- a/tests/ui/asm/x86_64/bad-options.stderr
+++ b/tests/ui/asm/x86_64/bad-options.stderr
@@ -1,41 +1,41 @@
 error: the `nomem` and `readonly` options are mutually exclusive
-  --> $DIR/bad-options.rs:10:18
+  --> $DIR/bad-options.rs:15:18
    |
 LL |         asm!("", options(nomem, readonly));
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: the `pure` and `noreturn` options are mutually exclusive
-  --> $DIR/bad-options.rs:12:18
+  --> $DIR/bad-options.rs:17:18
    |
 LL |         asm!("", options(pure, nomem, noreturn));
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: asm with the `pure` option must have at least one output
-  --> $DIR/bad-options.rs:12:18
+  --> $DIR/bad-options.rs:17:18
    |
 LL |         asm!("", options(pure, nomem, noreturn));
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: asm with the `pure` option must have at least one output
-  --> $DIR/bad-options.rs:15:33
+  --> $DIR/bad-options.rs:20:33
    |
 LL |         asm!("{}", in(reg) foo, options(pure, nomem));
    |                                 ^^^^^^^^^^^^^^^^^^^^
 
 error: asm outputs are not allowed with the `noreturn` option
-  --> $DIR/bad-options.rs:17:20
+  --> $DIR/bad-options.rs:22:20
    |
 LL |         asm!("{}", out(reg) foo, options(noreturn));
    |                    ^^^^^^^^^^^^
 
 error: asm labels are not allowed with the `may_unwind` option
-  --> $DIR/bad-options.rs:19:20
+  --> $DIR/bad-options.rs:24:20
    |
 LL |         asm!("{}", label {}, options(may_unwind));
    |                    ^^^^^^^^
 
 error: asm with `clobber_abi` must specify explicit registers for outputs
-  --> $DIR/bad-options.rs:26:20
+  --> $DIR/bad-options.rs:31:20
    |
 LL |         asm!("{}", out(reg) foo, clobber_abi("C"));
    |                    ^^^^^^^^^^^^  ---------------- clobber_abi
@@ -43,7 +43,7 @@ LL |         asm!("{}", out(reg) foo, clobber_abi("C"));
    |                    generic outputs
 
 error: asm with `clobber_abi` must specify explicit registers for outputs
-  --> $DIR/bad-options.rs:28:20
+  --> $DIR/bad-options.rs:33:20
    |
 LL |         asm!("{}", out(reg) foo, clobber_abi("C"), clobber_abi("C"));
    |                    ^^^^^^^^^^^^  ----------------  ---------------- clobber_abi
@@ -52,43 +52,43 @@ LL |         asm!("{}", out(reg) foo, clobber_abi("C"), clobber_abi("C"));
    |                    generic outputs
 
 error: the `nomem` option cannot be used with `global_asm!`
-  --> $DIR/bad-options.rs:35:25
+  --> $DIR/bad-options.rs:40:25
    |
 LL | global_asm!("", options(nomem));
    |                         ^^^^^ the `nomem` option is not meaningful for global-scoped inline assembly
 
 error: the `readonly` option cannot be used with `global_asm!`
-  --> $DIR/bad-options.rs:37:25
+  --> $DIR/bad-options.rs:42:25
    |
 LL | global_asm!("", options(readonly));
    |                         ^^^^^^^^ the `readonly` option is not meaningful for global-scoped inline assembly
 
 error: the `noreturn` option cannot be used with `global_asm!`
-  --> $DIR/bad-options.rs:39:25
+  --> $DIR/bad-options.rs:44:25
    |
 LL | global_asm!("", options(noreturn));
    |                         ^^^^^^^^ the `noreturn` option is not meaningful for global-scoped inline assembly
 
 error: the `pure` option cannot be used with `global_asm!`
-  --> $DIR/bad-options.rs:41:25
+  --> $DIR/bad-options.rs:46:25
    |
 LL | global_asm!("", options(pure));
    |                         ^^^^ the `pure` option is not meaningful for global-scoped inline assembly
 
 error: the `nostack` option cannot be used with `global_asm!`
-  --> $DIR/bad-options.rs:43:25
+  --> $DIR/bad-options.rs:48:25
    |
 LL | global_asm!("", options(nostack));
    |                         ^^^^^^^ the `nostack` option is not meaningful for global-scoped inline assembly
 
 error: the `preserves_flags` option cannot be used with `global_asm!`
-  --> $DIR/bad-options.rs:45:25
+  --> $DIR/bad-options.rs:50:25
    |
 LL | global_asm!("", options(preserves_flags));
    |                         ^^^^^^^^^^^^^^^ the `preserves_flags` option is not meaningful for global-scoped inline assembly
 
 error: invalid ABI for `clobber_abi`
-  --> $DIR/bad-options.rs:24:18
+  --> $DIR/bad-options.rs:29:18
    |
 LL |         asm!("", clobber_abi("foo"));
    |                  ^^^^^^^^^^^^^^^^^^
@@ -96,7 +96,7 @@ LL |         asm!("", clobber_abi("foo"));
    = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, and `sysv64`
 
 error: `C` ABI specified multiple times
-  --> $DIR/bad-options.rs:28:52
+  --> $DIR/bad-options.rs:33:52
    |
 LL |         asm!("{}", out(reg) foo, clobber_abi("C"), clobber_abi("C"));
    |                                  ----------------  ^^^^^^^^^^^^^^^^

--- a/tests/ui/asm/x86_64/bad-reg.rs
+++ b/tests/ui/asm/x86_64/bad-reg.rs
@@ -1,7 +1,7 @@
 //@ add-minicore
-//@ only-x86_64
 //@ revisions: stable experimental_reg
-//@ compile-flags: -C target-feature=+avx2,+avx512f
+//@ compile-flags: --target x86_64-unknown-linux-gnu -C target-feature=+avx2,+avx512f
+//@ needs-llvm-components: x86
 #![cfg_attr(experimental_reg, feature(asm_experimental_reg))]
 
 #![crate_type = "lib"]

--- a/tests/ui/asm/x86_64/goto-block-safe.rs
+++ b/tests/ui/asm/x86_64/goto-block-safe.rs
@@ -1,16 +1,22 @@
-//@ only-x86_64
+//@ add-minicore
+//@ compile-flags: --target x86_64-unknown-linux-gnu
+//@ needs-llvm-components: x86
 //@ needs-asm-support
-
+#![feature(no_core)]
+#![no_core]
 #![deny(unreachable_code)]
 
-use std::arch::asm;
+extern crate minicore;
+use minicore::*;
+
+unsafe fn such_unsafe() {}
 
 fn goto_fallthough() {
     unsafe {
         asm!(
             "/* {} */",
             label {
-                core::hint::unreachable_unchecked();
+                such_unsafe()
                 //~^ ERROR [E0133]
             }
         )

--- a/tests/ui/asm/x86_64/goto-block-safe.stderr
+++ b/tests/ui/asm/x86_64/goto-block-safe.stderr
@@ -1,11 +1,11 @@
-error[E0133]: call to unsafe function `unreachable_unchecked` is unsafe and requires unsafe function or block
-  --> $DIR/goto-block-safe.rs:13:17
+error[E0133]: call to unsafe function `such_unsafe` is unsafe and requires unsafe function or block
+  --> $DIR/goto-block-safe.rs:19:17
    |
 LL |     unsafe {
    |     ------ items do not inherit unsafety from separate enclosing items
 ...
-LL |                 core::hint::unreachable_unchecked();
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+LL |                 such_unsafe()
+   |                 ^^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/tests/ui/asm/x86_64/interpolated-idents.rs
+++ b/tests/ui/asm/x86_64/interpolated-idents.rs
@@ -1,6 +1,12 @@
-//@ only-x86_64
+//@ add-minicore
+//@ compile-flags: --target x86_64-unknown-linux-gnu
+//@ needs-llvm-components: x86
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
 
-use std::arch::asm;
+extern crate minicore;
+use minicore::*;
 
 macro_rules! m {
     ($in:ident $out:ident $lateout:ident $inout:ident $inlateout:ident $const:ident $sym:ident

--- a/tests/ui/asm/x86_64/interpolated-idents.stderr
+++ b/tests/ui/asm/x86_64/interpolated-idents.stderr
@@ -1,5 +1,5 @@
 error: the `nomem` and `readonly` options are mutually exclusive
-  --> $DIR/interpolated-idents.rs:13:13
+  --> $DIR/interpolated-idents.rs:19:13
    |
 LL |               $options($pure, $nomem, $readonly, $preserves_flags, $noreturn, $nostack, $att_syntax));
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -12,7 +12,7 @@ LL | |        noreturn nostack att_syntax options);
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: the `pure` and `noreturn` options are mutually exclusive
-  --> $DIR/interpolated-idents.rs:13:13
+  --> $DIR/interpolated-idents.rs:19:13
    |
 LL |               $options($pure, $nomem, $readonly, $preserves_flags, $noreturn, $nostack, $att_syntax));
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL | |        noreturn nostack att_syntax options);
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: asm outputs are not allowed with the `noreturn` option
-  --> $DIR/interpolated-idents.rs:10:32
+  --> $DIR/interpolated-idents.rs:16:32
    |
 LL |               asm!("", $in(x) x, $out(x) x, $lateout(x) x, $inout(x) x, $inlateout(x) x,
    |                                  ^^^^^^^^^  ^^^^^^^^^^^^^  ^^^^^^^^^^^  ^^^^^^^^^^^^^^^

--- a/tests/ui/asm/x86_64/issue-82869.rs
+++ b/tests/ui/asm/x86_64/issue-82869.rs
@@ -1,10 +1,14 @@
-//@ needs-asm-support
-//@ only-x86_64
-// Make sure rustc doesn't ICE on asm! for a foreign architecture.
-
+//@ add-minicore
+//@ compile-flags: --target x86_64-unknown-linux-gnu
+//@ needs-llvm-components: x86
 #![crate_type = "rlib"]
+#![feature(no_core)]
+#![no_core]
 
-use std::arch::asm;
+extern crate minicore;
+use minicore::*;
+
+// Make sure rustc doesn't ICE on asm! for a foreign architecture.
 
 pub unsafe fn aarch64(a: f64, b: f64) -> f64 {
     let c;

--- a/tests/ui/asm/x86_64/issue-82869.stderr
+++ b/tests/ui/asm/x86_64/issue-82869.stderr
@@ -1,5 +1,5 @@
 error: invalid register class `vreg`: unknown register class
-  --> $DIR/issue-82869.rs:11:32
+  --> $DIR/issue-82869.rs:15:32
    |
 LL |     asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
    |                                ^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |     asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
    = note: the following register classes are supported on this target: `reg`, `reg_abcd`, `reg_byte`, `xmm_reg`, `ymm_reg`, `zmm_reg`, `kreg`, `kreg0`, `mmx_reg`, `x87_reg`, and `tmm_reg`
 
 error: invalid register class `vreg`: unknown register class
-  --> $DIR/issue-82869.rs:11:45
+  --> $DIR/issue-82869.rs:15:45
    |
 LL |     asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
    |                                             ^^^^^^^^^^
@@ -15,7 +15,7 @@ LL |     asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
    = note: the following register classes are supported on this target: `reg`, `reg_abcd`, `reg_byte`, `xmm_reg`, `ymm_reg`, `zmm_reg`, `kreg`, `kreg0`, `mmx_reg`, `x87_reg`, and `tmm_reg`
 
 error: invalid register `d0`: unknown register
-  --> $DIR/issue-82869.rs:11:57
+  --> $DIR/issue-82869.rs:15:57
    |
 LL |       asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
    |  _________________________________________________________^

--- a/tests/ui/asm/x86_64/issue-89875.rs
+++ b/tests/ui/asm/x86_64/issue-89875.rs
@@ -1,9 +1,16 @@
 //@ build-pass
+//@ add-minicore
+//@ compile-flags: --target x86_64-unknown-linux-gnu
+//@ needs-llvm-components: x86
 //@ needs-asm-support
-//@ only-x86_64
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
 
-use std::arch::asm;
+extern crate minicore;
+use minicore::*;
 
+#[unsafe(no_mangle)]
 #[target_feature(enable = "avx")]
 fn foo() {
     unsafe {
@@ -13,5 +20,3 @@ fn foo() {
         );
     }
 }
-
-fn main() {}

--- a/tests/ui/asm/x86_64/issue-96797.rs
+++ b/tests/ui/asm/x86_64/issue-96797.rs
@@ -1,12 +1,16 @@
+//@ add-minicore
 //@ build-pass
-//@ compile-flags: -O
-//@ needs-asm-support
-//@ only-x86_64
-//@ only-linux
+//@ compile-flags: --target x86_64-unknown-linux-gnu -O
+//@ needs-llvm-components: x86
+//@ ignore-backends: gcc
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
 
 // regression test for #96797
-
-use std::arch::global_asm;
 
 #[no_mangle]
 fn my_func() {}

--- a/tests/ui/asm/x86_64/srcloc.rs
+++ b/tests/ui/asm/x86_64/srcloc.rs
@@ -1,12 +1,19 @@
-//@ only-x86_64
+//@ add-minicore
 //@ build-fail
-//@ compile-flags: -Ccodegen-units=1
+//@ compile-flags: --target x86_64-unknown-linux-gnu -Ccodegen-units=1
+//@ needs-llvm-components: x86
 //@ ignore-backends: gcc
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
 
-use std::arch::asm;
+extern crate minicore;
+use minicore::*;
 
 // Checks that inline asm errors are mapped to the correct line in the source code.
 
+#[unsafe(no_mangle)]
+#[rustfmt::skip]
 fn main() {
     unsafe {
         asm!("invalid_instruction");

--- a/tests/ui/asm/x86_64/srcloc.stderr
+++ b/tests/ui/asm/x86_64/srcloc.stderr
@@ -1,5 +1,5 @@
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:12:15
+  --> $DIR/srcloc.rs:19:15
    |
 LL |         asm!("invalid_instruction");
    |               ^^^^^^^^^^^^^^^^^^^
@@ -11,7 +11,7 @@ LL |     invalid_instruction
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:16:13
+  --> $DIR/srcloc.rs:23:13
    |
 LL |             invalid_instruction
    |             ^^^^^^^^^^^^^^^^^^^
@@ -23,25 +23,13 @@ LL |             invalid_instruction
    |             ^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:21:13
+  --> $DIR/srcloc.rs:28:13
    |
 LL |             invalid_instruction
    |             ^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:3:13
-   |
-LL |             invalid_instruction
-   |             ^^^^^^^^^^^^^^^^^^^
-
-error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:27:13
-   |
-LL |             invalid_instruction
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-note: instantiated into assembly here
-  --> <inline asm>:4:13
    |
 LL |             invalid_instruction
    |             ^^^^^^^^^^^^^^^^^^^
@@ -59,7 +47,19 @@ LL |             invalid_instruction
    |             ^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:39:14
+  --> $DIR/srcloc.rs:41:13
+   |
+LL |             invalid_instruction
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:4:13
+   |
+LL |             invalid_instruction
+   |             ^^^^^^^^^^^^^^^^^^^
+
+error: invalid instruction mnemonic 'invalid_instruction'
+  --> $DIR/srcloc.rs:46:14
    |
 LL |         asm!(concat!("invalid", "_", "instruction"));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -71,7 +71,7 @@ LL |     invalid_instruction
    |     ^^^^^^^^^^^^^^^^^^^
 
 warning: scale factor without index register is ignored
-  --> $DIR/srcloc.rs:42:15
+  --> $DIR/srcloc.rs:49:15
    |
 LL |         asm!("movaps %xmm3, (%esi, 2)", options(att_syntax));
    |               ^^^^^^^^^^^^^^^^^^^^^^^
@@ -83,7 +83,7 @@ LL |     movaps %xmm3, (%esi, 2)
    |                          ^
 
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:46:14
+  --> $DIR/srcloc.rs:53:14
    |
 LL |             "invalid_instruction",
    |              ^^^^^^^^^^^^^^^^^^^
@@ -95,37 +95,25 @@ LL |     invalid_instruction
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:52:14
-   |
-LL |             "invalid_instruction",
-   |              ^^^^^^^^^^^^^^^^^^^
-   |
-note: instantiated into assembly here
-  --> <inline asm>:3:1
-   |
-LL | invalid_instruction
-   | ^^^^^^^^^^^^^^^^^^^
-
-error: invalid instruction mnemonic 'invalid_instruction'
   --> $DIR/srcloc.rs:59:14
    |
 LL |             "invalid_instruction",
    |              ^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
-  --> <inline asm>:4:1
+  --> <inline asm>:3:1
    |
 LL | invalid_instruction
    | ^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:66:13
+  --> $DIR/srcloc.rs:66:14
    |
-LL |             concat!("invalid", "_", "instruction"),
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |             "invalid_instruction",
+   |              ^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
-  --> <inline asm>:3:1
+  --> <inline asm>:4:1
    |
 LL | invalid_instruction
    | ^^^^^^^^^^^^^^^^^^^
@@ -142,8 +130,20 @@ note: instantiated into assembly here
 LL | invalid_instruction
    | ^^^^^^^^^^^^^^^^^^^
 
+error: invalid instruction mnemonic 'invalid_instruction'
+  --> $DIR/srcloc.rs:80:13
+   |
+LL |             concat!("invalid", "_", "instruction"),
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:3:1
+   |
+LL | invalid_instruction
+   | ^^^^^^^^^^^^^^^^^^^
+
 error: invalid instruction mnemonic 'invalid_instruction1'
-  --> $DIR/srcloc.rs:80:14
+  --> $DIR/srcloc.rs:87:14
    |
 LL |             "invalid_instruction1",
    |              ^^^^^^^^^^^^^^^^^^^^
@@ -155,7 +155,7 @@ LL |     invalid_instruction1
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction2'
-  --> $DIR/srcloc.rs:81:14
+  --> $DIR/srcloc.rs:88:14
    |
 LL |             "invalid_instruction2",
    |              ^^^^^^^^^^^^^^^^^^^^
@@ -167,7 +167,7 @@ LL | invalid_instruction2
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction1'
-  --> $DIR/srcloc.rs:87:13
+  --> $DIR/srcloc.rs:94:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction1", "\n",
@@ -182,7 +182,7 @@ LL |     invalid_instruction1
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction2'
-  --> $DIR/srcloc.rs:87:13
+  --> $DIR/srcloc.rs:94:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction1", "\n",
@@ -197,7 +197,7 @@ LL | invalid_instruction2
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction1'
-  --> $DIR/srcloc.rs:96:13
+  --> $DIR/srcloc.rs:103:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction1", "\n",
@@ -212,7 +212,7 @@ LL |     invalid_instruction1
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction2'
-  --> $DIR/srcloc.rs:96:13
+  --> $DIR/srcloc.rs:103:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction1", "\n",
@@ -227,7 +227,7 @@ LL | invalid_instruction2
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction3'
-  --> $DIR/srcloc.rs:100:13
+  --> $DIR/srcloc.rs:107:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction3", "\n",
@@ -242,7 +242,7 @@ LL | invalid_instruction3
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction4'
-  --> $DIR/srcloc.rs:100:13
+  --> $DIR/srcloc.rs:107:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction3", "\n",
@@ -257,7 +257,7 @@ LL | invalid_instruction4
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction1'
-  --> $DIR/srcloc.rs:111:13
+  --> $DIR/srcloc.rs:118:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction1", "\n",
@@ -272,7 +272,7 @@ LL |     invalid_instruction1
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction2'
-  --> $DIR/srcloc.rs:111:13
+  --> $DIR/srcloc.rs:118:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction1", "\n",
@@ -287,7 +287,7 @@ LL | invalid_instruction2
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction3'
-  --> $DIR/srcloc.rs:115:13
+  --> $DIR/srcloc.rs:122:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction3", "\n",
@@ -302,7 +302,7 @@ LL | invalid_instruction3
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction4'
-  --> $DIR/srcloc.rs:115:13
+  --> $DIR/srcloc.rs:122:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction3", "\n",
@@ -317,7 +317,7 @@ LL | invalid_instruction4
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:128:14
+  --> $DIR/srcloc.rs:135:14
    |
 LL |             "invalid_instruction"
    |              ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/asm/x86_64/target-feature-attr.rs
+++ b/tests/ui/asm/x86_64/target-feature-attr.rs
@@ -1,15 +1,20 @@
-//@ only-x86_64
+//@ add-minicore
 // Set the base cpu explicitly, in case the default has been changed.
-//@ compile-flags: -C target-cpu=x86-64
+//@ compile-flags: --target x86_64-unknown-linux-gnu -C target-cpu=x86-64
+//@ needs-llvm-components: x86
+#![crate_type = "rlib"]
+#![feature(no_core)]
+#![no_core]
 
-use std::arch::asm;
+extern crate minicore;
+use minicore::*;
 
 #[target_feature(enable = "avx")]
 unsafe fn foo() {
     let mut x = 1;
     let y = 2;
     asm!("vaddps {2:y}, {0:y}, {1:y}", in(ymm_reg) x, in(ymm_reg) y, lateout(ymm_reg) x);
-    assert_eq!(x, 3);
+    let _ = x;
 }
 
 unsafe fn bar() {
@@ -19,7 +24,7 @@ unsafe fn bar() {
     //~^ ERROR: register class `ymm_reg` requires the `avx` target feature
     //~| ERROR: register class `ymm_reg` requires the `avx` target feature
     //~| ERROR: register class `ymm_reg` requires the `avx` target feature
-    assert_eq!(x, 3);
+    let _ = x;
 }
 
 #[target_feature(enable = "avx512bw")]

--- a/tests/ui/asm/x86_64/target-feature-attr.stderr
+++ b/tests/ui/asm/x86_64/target-feature-attr.stderr
@@ -1,23 +1,23 @@
 error: register class `ymm_reg` requires the `avx` target feature
-  --> $DIR/target-feature-attr.rs:18:40
+  --> $DIR/target-feature-attr.rs:23:40
    |
 LL |     asm!("vaddps {2:y}, {0:y}, {1:y}", in(ymm_reg) x, in(ymm_reg) y, lateout(ymm_reg) x);
    |                                        ^^^^^^^^^^^^^
 
 error: register class `ymm_reg` requires the `avx` target feature
-  --> $DIR/target-feature-attr.rs:18:55
+  --> $DIR/target-feature-attr.rs:23:55
    |
 LL |     asm!("vaddps {2:y}, {0:y}, {1:y}", in(ymm_reg) x, in(ymm_reg) y, lateout(ymm_reg) x);
    |                                                       ^^^^^^^^^^^^^
 
 error: register class `ymm_reg` requires the `avx` target feature
-  --> $DIR/target-feature-attr.rs:18:70
+  --> $DIR/target-feature-attr.rs:23:70
    |
 LL |     asm!("vaddps {2:y}, {0:y}, {1:y}", in(ymm_reg) x, in(ymm_reg) y, lateout(ymm_reg) x);
    |                                                                      ^^^^^^^^^^^^^^^^^^
 
 error: register class `kreg` requires at least one of the following target features: avx512bw, avx512f
-  --> $DIR/target-feature-attr.rs:33:23
+  --> $DIR/target-feature-attr.rs:38:23
    |
 LL |     asm!("/* {0} */", in(kreg) x);
    |                       ^^^^^^^^^^

--- a/tests/ui/asm/x86_64/x86_64_parse_error.rs
+++ b/tests/ui/asm/x86_64/x86_64_parse_error.rs
@@ -1,6 +1,12 @@
-//@ only-x86_64
+//@ add-minicore
+//@ compile-flags: --target x86_64-unknown-linux-gnu
+//@ needs-llvm-components: x86
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
 
-use std::arch::asm;
+extern crate minicore;
+use minicore::*;
 
 fn main() {
     let mut foo = 0;
@@ -14,6 +20,6 @@ fn main() {
         //~^ ERROR attempt to use a non-constant value in a constant
         asm!("{1}", in("eax") foo, const bar);
         //~^ ERROR positional arguments cannot follow named arguments or explicit register arguments
-        //~^^ ERROR attempt to use a non-constant value in a constant
+        //~| ERROR attempt to use a non-constant value in a constant
     }
 }

--- a/tests/ui/asm/x86_64/x86_64_parse_error.stderr
+++ b/tests/ui/asm/x86_64/x86_64_parse_error.stderr
@@ -1,11 +1,11 @@
 error: explicit register arguments cannot have names
-  --> $DIR/x86_64_parse_error.rs:9:18
+  --> $DIR/x86_64_parse_error.rs:15:18
    |
 LL |         asm!("", a = in("eax") foo);
    |                  ^^^^^^^^^^^^^^^^^
 
 error: positional arguments cannot follow named arguments or explicit register arguments
-  --> $DIR/x86_64_parse_error.rs:15:36
+  --> $DIR/x86_64_parse_error.rs:21:36
    |
 LL |         asm!("{1}", in("eax") foo, const bar);
    |                     -------------  ^^^^^^^^^ positional argument
@@ -13,7 +13,7 @@ LL |         asm!("{1}", in("eax") foo, const bar);
    |                     explicit register argument
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/x86_64_parse_error.rs:11:46
+  --> $DIR/x86_64_parse_error.rs:17:46
    |
 LL |         asm!("{a}", in("eax") foo, a = const bar);
    |                                              ^^^ non-constant value
@@ -25,7 +25,7 @@ LL +     const bar: /* Type */ = 0;
    |
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/x86_64_parse_error.rs:13:46
+  --> $DIR/x86_64_parse_error.rs:19:46
    |
 LL |         asm!("{a}", in("eax") foo, a = const bar);
    |                                              ^^^ non-constant value
@@ -37,7 +37,7 @@ LL +     const bar: /* Type */ = 0;
    |
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/x86_64_parse_error.rs:15:42
+  --> $DIR/x86_64_parse_error.rs:21:42
    |
 LL |         asm!("{1}", in("eax") foo, const bar);
    |                                          ^^^ non-constant value


### PR DESCRIPTION
Both for easier development and because some niche assembly features were only tested on one platform.

try-job: aarch64-gnu
try-job: x86_64-gnu
try-job: x86_64-gnu-debug
