### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -131,10 +131,10 @@ use crate::{mir, thir};
 // `Providers` that the driver creates (using several `rustc_*` crates).
 //
 // The result type of each query must implement `Clone`. Additionally
-// `ty::query::from_cycle_error::FromCycleError` can be implemented which produces an appropriate
+// `QueryVTable::handle_cycle_error_fn` can be used to produce an appropriate
 // placeholder (error) value if the query resulted in a query cycle.
-// Queries without a `FromCycleError` implementation will raise a fatal error on query
-// cycles instead.
+// Queries without a custom `handle_cycle_error_fn` implementation will raise a
+// fatal error on query cycles instead.
 rustc_queries! {
     /// Caches the expansion of a derive proc macro, e.g. `#[derive(Serialize)]`.
     /// The key is:
@@ -577,7 +577,7 @@ rustc_queries! {
 
     /// Checks whether a type is representable or infinitely sized
     //
-    // Infinitely sized types will cause a cycle. The `value_from_cycle_error` impl will print
+    // Infinitely sized types will cause a cycle. The query's `handle_cycle_error_fn` will print
     // a custom error about the infinite size and then abort compilation. (In the past we
     // recovered and continued, but in practice that leads to confusing subsequent error
     // messages about cycles that then abort.)

--- a/compiler/rustc_middle/src/query/job.rs
+++ b/compiler/rustc_middle/src/query/job.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use parking_lot::{Condvar, Mutex};
 use rustc_span::Span;
 
-use crate::query::CycleError;
+use crate::query::Cycle;
 use crate::ty::TyCtxt;
 
 /// A value uniquely identifying an active query job.
@@ -59,7 +59,7 @@ pub struct QueryWaiter<'tcx> {
     pub parent: Option<QueryJobId>,
     pub condvar: Condvar,
     pub span: Span,
-    pub cycle: Mutex<Option<CycleError<'tcx>>>,
+    pub cycle: Mutex<Option<Cycle<'tcx>>>,
 }
 
 #[derive(Clone, Debug)]
@@ -79,7 +79,7 @@ impl<'tcx> QueryLatch<'tcx> {
         tcx: TyCtxt<'tcx>,
         query: Option<QueryJobId>,
         span: Span,
-    ) -> Result<(), CycleError<'tcx>> {
+    ) -> Result<(), Cycle<'tcx>> {
         let mut waiters_guard = self.waiters.lock();
         let Some(waiters) = &mut *waiters_guard else {
             return Ok(()); // already complete

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -5,8 +5,8 @@ pub use self::into_query_key::IntoQueryKey;
 pub use self::job::{QueryJob, QueryJobId, QueryLatch, QueryWaiter};
 pub use self::keys::{AsLocalQueryKey, LocalCrate, QueryKey};
 pub use self::plumbing::{
-    ActiveKeyStatus, CycleError, EnsureMode, QueryMode, QueryState, QuerySystem, QueryVTable,
-    TyCtxtAt, TyCtxtEnsureDone, TyCtxtEnsureOk, TyCtxtEnsureResult,
+    ActiveKeyStatus, Cycle, EnsureMode, QueryMode, QueryState, QuerySystem, QueryVTable, TyCtxtAt,
+    TyCtxtEnsureDone, TyCtxtEnsureOk, TyCtxtEnsureResult,
 };
 pub use self::stack::QueryStackFrame;
 pub use crate::queries::Providers;

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -47,12 +47,12 @@ pub enum ActiveKeyStatus<'tcx> {
 }
 
 #[derive(Debug)]
-pub struct CycleError<'tcx> {
+pub struct Cycle<'tcx> {
     /// The query and related span that uses the cycle.
     pub usage: Option<QueryStackFrame<'tcx>>,
 
     /// The span here corresponds to the reason for which this query was required.
-    pub cycle: Vec<QueryStackFrame<'tcx>>,
+    pub frames: Vec<QueryStackFrame<'tcx>>,
 }
 
 #[derive(Debug)]
@@ -111,13 +111,10 @@ pub struct QueryVTable<'tcx, C: QueryCache> {
 
     /// Function pointer that handles a cycle error. `error` must be consumed, e.g. with `emit` (if
     /// it should be emitted) or `delay_as_bug` (if it need not be emitted because an alternative
-    /// error is created and emitted).
-    pub value_from_cycle_error: fn(
-        tcx: TyCtxt<'tcx>,
-        key: C::Key,
-        cycle_error: CycleError<'tcx>,
-        error: Diag<'_>,
-    ) -> C::Value,
+    /// error is created and emitted). A value may be returned, or (more commonly) the function may
+    /// just abort after emitting the error.
+    pub handle_cycle_error_fn:
+        fn(tcx: TyCtxt<'tcx>, key: C::Key, cycle: Cycle<'tcx>, error: Diag<'_>) -> C::Value,
 
     pub format_value: fn(&C::Value) -> String,
 

--- a/compiler/rustc_query_impl/src/dep_kind_vtables.rs
+++ b/compiler/rustc_query_impl/src/dep_kind_vtables.rs
@@ -117,8 +117,10 @@ where
                 crate::execution::force_query_dep_node(tcx, query, dep_node)
             },
         ),
-        promote_from_disk_fn: (can_recover && is_cache_on_disk)
-            .then_some(promote_from_disk_inner::<Q>),
+        promote_from_disk_fn: (can_recover && is_cache_on_disk).then_some(|tcx, dep_node| {
+            let query = Q::query_vtable(tcx);
+            promote_from_disk_inner(tcx, query, dep_node)
+        }),
     }
 }
 

--- a/compiler/rustc_query_impl/src/dep_kind_vtables.rs
+++ b/compiler/rustc_query_impl/src/dep_kind_vtables.rs
@@ -4,7 +4,7 @@ use rustc_middle::dep_graph::{DepKindVTable, DepNodeKey, KeyFingerprintStyle};
 use rustc_middle::query::QueryCache;
 
 use crate::GetQueryVTable;
-use crate::plumbing::{force_from_dep_node_inner, promote_from_disk_inner};
+use crate::plumbing::promote_from_disk_inner;
 
 /// [`DepKindVTable`] constructors for special dep kinds that aren't queries.
 #[expect(non_snake_case, reason = "use non-snake case to avoid collision with query names")]
@@ -111,8 +111,12 @@ where
     DepKindVTable {
         is_eval_always,
         key_fingerprint_style,
-        force_from_dep_node_fn: (can_recover && !is_no_force)
-            .then_some(force_from_dep_node_inner::<Q>),
+        force_from_dep_node_fn: (can_recover && !is_no_force).then_some(
+            |tcx, dep_node, _prev_index| {
+                let query = Q::query_vtable(tcx);
+                crate::execution::force_query_dep_node(tcx, query, dep_node)
+            },
+        ),
         promote_from_disk_fn: (can_recover && is_cache_on_disk)
             .then_some(promote_from_disk_inner::<Q>),
     }

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -680,13 +680,26 @@ pub(super) fn execute_query_incr_inner<'tcx, C: QueryCache>(
     Some(result)
 }
 
-pub(crate) fn force_query<'tcx, C: QueryCache>(
-    query: &'tcx QueryVTable<'tcx, C>,
+/// Inner implementation of [`DepKindVTable::force_from_dep_node_fn`][force_fn]
+/// for query nodes.
+///
+/// [force_fn]: rustc_middle::dep_graph::DepKindVTable::force_from_dep_node_fn
+pub(crate) fn force_query_dep_node<'tcx, C: QueryCache>(
     tcx: TyCtxt<'tcx>,
-    key: C::Key,
+    query: &'tcx QueryVTable<'tcx, C>,
     dep_node: DepNode,
-) {
+) -> bool {
+    let Some(key) = C::Key::try_recover_key(tcx, &dep_node) else {
+        // We couldn't recover a key from the node's key fingerprint.
+        // Tell the caller that we couldn't force the node.
+        return false;
+    };
+
     ensure_sufficient_stack(|| {
         try_execute_query::<C, true>(query, tcx, DUMMY_SP, key, Some(dep_node))
     });
+
+    // We did manage to recover a key and force the node, though it's up to
+    // the caller to check whether the node ended up marked red or green.
+    true
 }

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -8,8 +8,8 @@ use rustc_data_structures::{outline, sharded, sync};
 use rustc_errors::FatalError;
 use rustc_middle::dep_graph::{DepGraphData, DepNodeKey, SerializedDepNodeIndex};
 use rustc_middle::query::{
-    ActiveKeyStatus, CycleError, EnsureMode, QueryCache, QueryJob, QueryJobId, QueryKey,
-    QueryLatch, QueryMode, QueryState, QueryVTable,
+    ActiveKeyStatus, Cycle, EnsureMode, QueryCache, QueryJob, QueryJobId, QueryKey, QueryLatch,
+    QueryMode, QueryState, QueryVTable,
 };
 use rustc_middle::ty::TyCtxt;
 use rustc_middle::verify_ich::incremental_verify_ich;
@@ -17,7 +17,7 @@ use rustc_span::{DUMMY_SP, Span};
 use tracing::warn;
 
 use crate::dep_graph::{DepNode, DepNodeIndex};
-use crate::job::{QueryJobInfo, QueryJobMap, find_cycle_in_stack, report_cycle};
+use crate::job::{QueryJobInfo, QueryJobMap, create_cycle_error, find_cycle_in_stack};
 use crate::plumbing::{current_query_job, loadable_from_disk, next_job_id, start_query};
 use crate::query_impl::for_each_query_vtable;
 
@@ -108,14 +108,14 @@ fn collect_active_query_jobs_inner<'tcx, C>(
 
 #[cold]
 #[inline(never)]
-fn mk_cycle<'tcx, C: QueryCache>(
+fn handle_cycle<'tcx, C: QueryCache>(
     query: &'tcx QueryVTable<'tcx, C>,
     tcx: TyCtxt<'tcx>,
     key: C::Key,
-    cycle_error: CycleError<'tcx>,
+    cycle: Cycle<'tcx>,
 ) -> C::Value {
-    let error = report_cycle(tcx, &cycle_error);
-    (query.value_from_cycle_error)(tcx, key, cycle_error, error)
+    let error = create_cycle_error(tcx, &cycle);
+    (query.handle_cycle_error_fn)(tcx, key, cycle, error)
 }
 
 /// Guard object representing the responsibility to execute a query job and
@@ -194,7 +194,7 @@ where
 
 #[cold]
 #[inline(never)]
-fn cycle_error<'tcx, C: QueryCache>(
+fn find_and_handle_cycle<'tcx, C: QueryCache>(
     query: &'tcx QueryVTable<'tcx, C>,
     tcx: TyCtxt<'tcx>,
     key: C::Key,
@@ -205,8 +205,8 @@ fn cycle_error<'tcx, C: QueryCache>(
     // We need the complete map to ensure we find a cycle to break.
     let job_map = collect_active_query_jobs(tcx, CollectActiveJobsKind::FullNoContention);
 
-    let error = find_cycle_in_stack(try_execute, job_map, &current_query_job(), span);
-    (mk_cycle(query, tcx, key, error), None)
+    let cycle = find_cycle_in_stack(try_execute, job_map, &current_query_job(), span);
+    (handle_cycle(query, tcx, key, cycle), None)
 }
 
 #[inline(always)]
@@ -250,7 +250,7 @@ fn wait_for_query<'tcx, C: QueryCache>(
 
             (v, Some(index))
         }
-        Err(cycle) => (mk_cycle(query, tcx, key, cycle), None),
+        Err(cycle) => (handle_cycle(query, tcx, key, cycle), None),
     }
 }
 
@@ -334,7 +334,7 @@ fn try_execute_query<'tcx, C: QueryCache, const INCR: bool>(
 
                         // If we are single-threaded we know that we have cycle error,
                         // so we just return the error.
-                        cycle_error(query, tcx, key, id, span)
+                        find_and_handle_cycle(query, tcx, key, id, span)
                     }
                 }
                 ActiveKeyStatus::Poisoned => FatalError.raise(),

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -686,13 +686,6 @@ pub(crate) fn force_query<'tcx, C: QueryCache>(
     key: C::Key,
     dep_node: DepNode,
 ) {
-    // We may be concurrently trying both execute and force a query.
-    // Ensure that only one of them runs the query.
-    if let Some((_, index)) = query.cache.lookup(&key) {
-        tcx.prof.query_cache_hit(index.into());
-        return;
-    }
-
     ensure_sufficient_stack(|| {
         try_execute_query::<C, true>(query, tcx, DUMMY_SP, key, Some(dep_node))
     });

--- a/compiler/rustc_query_impl/src/handle_cycle_error.rs
+++ b/compiler/rustc_query_impl/src/handle_cycle_error.rs
@@ -10,33 +10,33 @@ use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
 use rustc_middle::bug;
 use rustc_middle::queries::{QueryVTables, TaggedQueryKey};
-use rustc_middle::query::CycleError;
+use rustc_middle::query::Cycle;
 use rustc_middle::query::erase::erase_val;
 use rustc_middle::ty::layout::LayoutError;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_span::def_id::{DefId, LocalDefId};
 use rustc_span::{ErrorGuaranteed, Span};
 
-use crate::job::report_cycle;
+use crate::job::create_cycle_error;
 
 pub(crate) fn specialize_query_vtables<'tcx>(vtables: &mut QueryVTables<'tcx>) {
-    vtables.fn_sig.value_from_cycle_error = |tcx, key, _, err| {
+    vtables.fn_sig.handle_cycle_error_fn = |tcx, key, _, err| {
         let guar = err.delay_as_bug();
         erase_val(fn_sig(tcx, key, guar))
     };
 
-    vtables.check_representability.value_from_cycle_error =
+    vtables.check_representability.handle_cycle_error_fn =
         |tcx, _, cycle, _err| check_representability(tcx, cycle);
 
-    vtables.check_representability_adt_ty.value_from_cycle_error =
+    vtables.check_representability_adt_ty.handle_cycle_error_fn =
         |tcx, _, cycle, _err| check_representability(tcx, cycle);
 
-    vtables.variances_of.value_from_cycle_error = |tcx, key, _, err| {
+    vtables.variances_of.handle_cycle_error_fn = |tcx, key, _, err| {
         let _guar = err.delay_as_bug();
         erase_val(variances_of(tcx, key))
     };
 
-    vtables.layout_of.value_from_cycle_error = |tcx, _, cycle, err| {
+    vtables.layout_of.handle_cycle_error_fn = |tcx, _, cycle, err| {
         let _guar = err.delay_as_bug();
         erase_val(Err(layout_of(tcx, cycle)))
     }
@@ -72,10 +72,10 @@ fn fn_sig<'tcx>(
     )))
 }
 
-fn check_representability<'tcx>(tcx: TyCtxt<'tcx>, cycle_error: CycleError<'tcx>) -> ! {
+fn check_representability<'tcx>(tcx: TyCtxt<'tcx>, cycle: Cycle<'tcx>) -> ! {
     let mut item_and_field_ids = Vec::new();
     let mut representable_ids = FxHashSet::default();
-    for frame in &cycle_error.cycle {
+    for frame in &cycle.frames {
         if let TaggedQueryKey::check_representability(def_id) = frame.tagged_key
             && tcx.def_kind(def_id) == DefKind::Field
         {
@@ -88,7 +88,7 @@ fn check_representability<'tcx>(tcx: TyCtxt<'tcx>, cycle_error: CycleError<'tcx>
             item_and_field_ids.push((item_id.expect_local(), field_id));
         }
     }
-    for frame in &cycle_error.cycle {
+    for frame in &cycle.frames {
         if let TaggedQueryKey::check_representability_adt_ty(key) = frame.tagged_key
             && let Some(adt) = key.ty_adt_def()
             && let Some(def_id) = adt.did().as_local()
@@ -127,14 +127,11 @@ fn search_for_cycle_permutation<Q, T>(
     otherwise()
 }
 
-fn layout_of<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    cycle_error: CycleError<'tcx>,
-) -> &'tcx ty::layout::LayoutError<'tcx> {
+fn layout_of<'tcx>(tcx: TyCtxt<'tcx>, cycle: Cycle<'tcx>) -> &'tcx ty::layout::LayoutError<'tcx> {
     let diag = search_for_cycle_permutation(
-        &cycle_error.cycle,
-        |cycle| {
-            if let TaggedQueryKey::layout_of(key) = cycle[0].tagged_key
+        &cycle.frames,
+        |frames| {
+            if let TaggedQueryKey::layout_of(key) = frames[0].tagged_key
                 && let ty::Coroutine(def_id, _) = key.value.kind()
                 && let Some(def_id) = def_id.as_local()
                 && let def_kind = tcx.def_kind(def_id)
@@ -158,7 +155,7 @@ fn layout_of<'tcx>(
                     tcx.def_kind_descr_article(def_kind, def_id.to_def_id()),
                     tcx.def_kind_descr(def_kind, def_id.to_def_id()),
                 );
-                for (i, frame) in cycle.iter().enumerate() {
+                for (i, frame) in frames.iter().enumerate() {
                     let TaggedQueryKey::layout_of(frame_key) = frame.tagged_key else {
                         continue;
                     };
@@ -169,7 +166,7 @@ fn layout_of<'tcx>(
                         continue;
                     };
                     let frame_span =
-                        frame.tagged_key.default_span(tcx, cycle[(i + 1) % cycle.len()].span);
+                        frame.tagged_key.default_span(tcx, frames[(i + 1) % frames.len()].span);
                     if frame_span.is_dummy() {
                         continue;
                     }
@@ -203,7 +200,7 @@ fn layout_of<'tcx>(
                 ControlFlow::Continue(())
             }
         },
-        || report_cycle(tcx, &cycle_error),
+        || create_cycle_error(tcx, &cycle),
     );
 
     let guar = diag.emit();

--- a/compiler/rustc_query_impl/src/job.rs
+++ b/compiler/rustc_query_impl/src/job.rs
@@ -7,9 +7,7 @@ use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_errors::{Diag, DiagCtxtHandle};
 use rustc_hir::def::DefKind;
 use rustc_middle::queries::TaggedQueryKey;
-use rustc_middle::query::{
-    CycleError, QueryJob, QueryJobId, QueryLatch, QueryStackFrame, QueryWaiter,
-};
+use rustc_middle::query::{Cycle, QueryJob, QueryJobId, QueryLatch, QueryStackFrame, QueryWaiter};
 use rustc_middle::ty::TyCtxt;
 use rustc_span::{DUMMY_SP, Span};
 
@@ -58,29 +56,28 @@ pub(crate) fn find_cycle_in_stack<'tcx>(
     job_map: QueryJobMap<'tcx>,
     current_job: &Option<QueryJobId>,
     span: Span,
-) -> CycleError<'tcx> {
-    // Find the waitee amongst `current_job` parents
-    let mut cycle = Vec::new();
+) -> Cycle<'tcx> {
+    // Find the waitee amongst `current_job` parents.
+    let mut frames = Vec::new();
     let mut current_job = Option::clone(current_job);
 
     while let Some(job) = current_job {
         let info = &job_map.map[&job];
-        cycle.push(QueryStackFrame { span: info.job.span, tagged_key: info.tagged_key });
+        frames.push(QueryStackFrame { span: info.job.span, tagged_key: info.tagged_key });
 
         if job == id {
-            cycle.reverse();
+            frames.reverse();
 
-            // This is the end of the cycle
-            // The span entry we included was for the usage
-            // of the cycle itself, and not part of the cycle
-            // Replace it with the span which caused the cycle to form
-            cycle[0].span = span;
-            // Find out why the cycle itself was used
+            // This is the end of the cycle. The span entry we included was for
+            // the usage of the cycle itself, and not part of the cycle.
+            // Replace it with the span which caused the cycle to form.
+            frames[0].span = span;
+            // Find out why the cycle itself was used.
             let usage = try {
                 let parent = info.job.parent?;
                 QueryStackFrame { span: info.job.span, tagged_key: job_map.tagged_key_of(parent) }
             };
-            return CycleError { usage, cycle };
+            return Cycle { usage, frames };
         }
 
         current_job = info.job.parent;
@@ -319,9 +316,9 @@ fn remove_cycle<'tcx>(
             .map(|(span, job)| QueryStackFrame { span, tagged_key: job_map.tagged_key_of(job) });
 
         // Create the cycle error
-        let error = CycleError {
+        let error = Cycle {
             usage,
-            cycle: stack
+            frames: stack
                 .iter()
                 .map(|&(span, job)| QueryStackFrame {
                     span,
@@ -454,27 +451,27 @@ pub fn print_query_stack<'tcx>(
 
 #[inline(never)]
 #[cold]
-pub(crate) fn report_cycle<'tcx>(
+pub(crate) fn create_cycle_error<'tcx>(
     tcx: TyCtxt<'tcx>,
-    CycleError { usage, cycle: stack }: &CycleError<'tcx>,
+    Cycle { usage, frames }: &Cycle<'tcx>,
 ) -> Diag<'tcx> {
-    assert!(!stack.is_empty());
+    assert!(!frames.is_empty());
 
-    let span = stack[0].tagged_key.default_span(tcx, stack[1 % stack.len()].span);
+    let span = frames[0].tagged_key.default_span(tcx, frames[1 % frames.len()].span);
 
     let mut cycle_stack = Vec::new();
 
     use crate::error::StackCount;
-    let stack_bottom = stack[0].tagged_key.description(tcx);
-    let stack_count = if stack.len() == 1 {
+    let stack_bottom = frames[0].tagged_key.description(tcx);
+    let stack_count = if frames.len() == 1 {
         StackCount::Single { stack_bottom: stack_bottom.clone() }
     } else {
         StackCount::Multiple { stack_bottom: stack_bottom.clone() }
     };
 
-    for i in 1..stack.len() {
-        let frame = &stack[i];
-        let span = frame.tagged_key.default_span(tcx, stack[(i + 1) % stack.len()].span);
+    for i in 1..frames.len() {
+        let frame = &frames[i];
+        let span = frame.tagged_key.default_span(tcx, frames[(i + 1) % frames.len()].span);
         cycle_stack
             .push(crate::error::CycleStack { span, desc: frame.tagged_key.description(tcx) });
     }
@@ -484,12 +481,12 @@ pub(crate) fn report_cycle<'tcx>(
         usage: usage.tagged_key.description(tcx),
     });
 
-    let alias = if stack
+    let alias = if frames
         .iter()
         .all(|frame| frame.tagged_key.def_kind(tcx) == Some(DefKind::TyAlias))
     {
         Some(crate::error::Alias::Ty)
-    } else if stack.iter().all(|frame| frame.tagged_key.def_kind(tcx) == Some(DefKind::TraitAlias))
+    } else if frames.iter().all(|frame| frame.tagged_key.def_kind(tcx) == Some(DefKind::TraitAlias))
     {
         Some(crate::error::Alias::Trait)
     } else {

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -22,7 +22,7 @@ pub use crate::job::{QueryJobMap, break_query_cycles, print_query_stack};
 mod dep_kind_vtables;
 mod error;
 mod execution;
-mod from_cycle_error;
+mod handle_cycle_error;
 mod job;
 mod plumbing;
 mod profiling_support;
@@ -49,7 +49,7 @@ pub fn query_system<'tcx>(
     incremental: bool,
 ) -> QuerySystem<'tcx> {
     let mut query_vtables = query_impl::make_query_vtables(incremental);
-    from_cycle_error::specialize_query_vtables(&mut query_vtables);
+    handle_cycle_error::specialize_query_vtables(&mut query_vtables);
     QuerySystem {
         arenas: Default::default(),
         query_vtables,

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -20,7 +20,7 @@ use rustc_span::DUMMY_SP;
 use rustc_span::def_id::LOCAL_CRATE;
 
 use crate::error::{QueryOverflow, QueryOverflowNote};
-use crate::execution::{all_inactive, force_query};
+use crate::execution::all_inactive;
 use crate::job::find_dep_kind_root;
 use crate::query_impl::for_each_query_vtable;
 use crate::{CollectActiveJobsKind, GetQueryVTable, collect_active_query_jobs};
@@ -219,21 +219,4 @@ where
     prof_timer.finish_with_query_invocation_id(index.into());
 
     value
-}
-
-/// Implementation of [`DepKindVTable::force_from_dep_node_fn`] for queries.
-pub(crate) fn force_from_dep_node_inner<'tcx, Q: GetQueryVTable<'tcx>>(
-    tcx: TyCtxt<'tcx>,
-    dep_node: DepNode,
-    // Needed by the vtable function signature, but not used when forcing queries.
-    _prev_index: SerializedDepNodeIndex,
-) -> bool {
-    let query = Q::query_vtable(tcx);
-
-    if let Some(key) = <Q::Cache as QueryCache>::Key::try_recover_key(tcx, &dep_node) {
-        force_query(query, tcx, key, dep_node);
-        true
-    } else {
-        false
-    }
 }

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -23,7 +23,7 @@ use crate::error::{QueryOverflow, QueryOverflowNote};
 use crate::execution::all_inactive;
 use crate::job::find_dep_kind_root;
 use crate::query_impl::for_each_query_vtable;
-use crate::{CollectActiveJobsKind, GetQueryVTable, collect_active_query_jobs};
+use crate::{CollectActiveJobsKind, collect_active_query_jobs};
 
 fn depth_limit_error<'tcx>(tcx: TyCtxt<'tcx>, job: QueryJobId) {
     let job_map = collect_active_query_jobs(tcx, CollectActiveJobsKind::Full);
@@ -151,15 +151,15 @@ fn verify_query_key_hashes_inner<'tcx, C: QueryCache>(
     });
 }
 
-/// Implementation of [`DepKindVTable::promote_from_disk_fn`] for queries.
-pub(crate) fn promote_from_disk_inner<'tcx, Q: GetQueryVTable<'tcx>>(
+/// Inner implementation of [`DepKindVTable::promote_from_disk_fn`] for queries.
+pub(crate) fn promote_from_disk_inner<'tcx, C: QueryCache>(
     tcx: TyCtxt<'tcx>,
+    query: &'tcx QueryVTable<'tcx, C>,
     dep_node: DepNode,
 ) {
-    let query = Q::query_vtable(tcx);
     debug_assert!(tcx.dep_graph.is_green(&dep_node));
 
-    let key = <Q::Cache as QueryCache>::Key::try_recover_key(tcx, &dep_node).unwrap_or_else(|| {
+    let key = C::Key::try_recover_key(tcx, &dep_node).unwrap_or_else(|| {
         panic!(
             "Failed to recover key for {dep_node:?} with key fingerprint {}",
             dep_node.key_fingerprint

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -6,7 +6,7 @@ use rustc_index::Idx;
 use rustc_middle::bug;
 #[expect(unused_imports, reason = "used by doc comments")]
 use rustc_middle::dep_graph::DepKindVTable;
-use rustc_middle::dep_graph::{DepKind, DepNode, DepNodeIndex, DepNodeKey, SerializedDepNodeIndex};
+use rustc_middle::dep_graph::{DepNode, DepNodeIndex, DepNodeKey, SerializedDepNodeIndex};
 use rustc_middle::query::erase::{Erasable, Erased};
 use rustc_middle::query::on_disk_cache::{
     AbsoluteBytePos, CacheDecoder, CacheEncoder, EncodedDepNodeIndex,
@@ -229,24 +229,6 @@ pub(crate) fn force_from_dep_node_inner<'tcx, Q: GetQueryVTable<'tcx>>(
     _prev_index: SerializedDepNodeIndex,
 ) -> bool {
     let query = Q::query_vtable(tcx);
-
-    // We must avoid ever having to call `force_from_dep_node()` for a
-    // `DepNode::codegen_unit`:
-    // Since we cannot reconstruct the query key of a `DepNode::codegen_unit`, we
-    // would always end up having to evaluate the first caller of the
-    // `codegen_unit` query that *is* reconstructible. This might very well be
-    // the `compile_codegen_unit` query, thus re-codegenning the whole CGU just
-    // to re-trigger calling the `codegen_unit` query with the right key. At
-    // that point we would already have re-done all the work we are trying to
-    // avoid doing in the first place.
-    // The solution is simple: Just explicitly call the `codegen_unit` query for
-    // each CGU, right after partitioning. This way `try_mark_green` will always
-    // hit the cache instead of having to go through `force_from_dep_node`.
-    // This assertion makes sure, we actually keep applying the solution above.
-    debug_assert!(
-        dep_node.kind != DepKind::codegen_unit,
-        "calling force_from_dep_node() on dep_kinds::codegen_unit"
-    );
 
     if let Some(key) = <Q::Cache as QueryCache>::Key::try_recover_key(tcx, &dep_node) {
         force_query(query, tcx, key, dep_node);

--- a/compiler/rustc_query_impl/src/query_impl.rs
+++ b/compiler/rustc_query_impl/src/query_impl.rs
@@ -166,10 +166,10 @@ macro_rules! define_queries {
                         try_load_from_disk_fn: |_tcx, _key, _prev_index, _index| None,
 
                         // The default just emits `err` and then aborts.
-                        // `from_cycle_error::specialize_query_vtables` overwrites this default for
-                        // certain queries.
-                        value_from_cycle_error: |_tcx, _key, _cycle, err| {
-                            $crate::from_cycle_error::default(err)
+                        // `handle_cycle_error::specialize_query_vtables` overwrites this default
+                        // for certain queries.
+                        handle_cycle_error_fn: |_tcx, _key, _cycle, err| {
+                            $crate::handle_cycle_error::default(err)
                         },
 
                         #[cfg($no_hash)]

--- a/compiler/rustc_ty_utils/src/representability.rs
+++ b/compiler/rustc_ty_utils/src/representability.rs
@@ -58,7 +58,7 @@ fn check_representability_ty<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) {
 //     -> check_representability_adt_ty(Bar<Foo>)
 //     -> check_representability(Foo)
 //
-// For the diagnostic output (in `Value::from_cycle_error`), we want to detect
+// For the diagnostic output (in `check_representability`), we want to detect
 // that the `Foo` in the *second* field of the struct is culpable. This
 // requires traversing the HIR of the struct and calling `params_in_repr(Bar)`.
 // But we can't call params_in_repr for a given type unless it is known to be

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2776,7 +2776,9 @@ fn clean_maybe_renamed_item<'tcx>(
         // These kinds of item either don't need a `name` or accept a `None` one so we handle them
         // before.
         match item.kind {
-            ItemKind::Impl(ref impl_) => return clean_impl(impl_, item.owner_id.def_id, cx),
+            ItemKind::Impl(ref impl_) => {
+                return clean_impl(impl_, item.owner_id.def_id, cx, renamed);
+            }
             ItemKind::Use(path, kind) => {
                 return clean_use_statement(
                     item,
@@ -2909,10 +2911,27 @@ fn clean_impl<'tcx>(
     impl_: &hir::Impl<'tcx>,
     def_id: LocalDefId,
     cx: &mut DocContext<'tcx>,
+    // If `renamed` is some, then this is an inlined impl and it will be handled later on in the
+    // code. In here, we will generate a placeholder for it in order to be able to compute its
+    // `doc_cfg` info.
+    renamed: Option<Symbol>,
 ) -> Vec<Item> {
     let tcx = cx.tcx;
     let mut ret = Vec::new();
-    let trait_ = impl_.of_trait.map(|t| clean_trait_ref(&t.trait_ref, cx));
+    let trait_ = match impl_.of_trait {
+        Some(t) => {
+            if renamed.is_some() {
+                return vec![Item::from_def_id_and_parts(
+                    def_id.to_def_id(),
+                    None,
+                    PlaceholderImplItem,
+                    cx,
+                )];
+            }
+            Some(clean_trait_ref(&t.trait_ref, cx))
+        }
+        None => None,
+    };
     let items = impl_
         .items
         .iter()

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2777,10 +2777,10 @@ fn clean_maybe_renamed_item<'tcx>(
         // before.
         match item.kind {
             ItemKind::Impl(ref impl_) => {
-                // `renamed` is passed down to `clean_impl` because we use it as a marker to
-                // indicate that this is an inlined impl and that we should generate an impl
-                // placeholder and not a "real" impl item.
-                return clean_impl(impl_, item.owner_id.def_id, cx, renamed);
+                // If `renamed` is `Some()` for an `impl`, it means it's been inlined because we use
+                // it as a marker to indicate that this is an inlined impl and that we should
+                // generate an impl placeholder and not a "real" impl item.
+                return clean_impl(impl_, item.owner_id.def_id, cx, renamed.is_some());
             }
             ItemKind::Use(path, kind) => {
                 return clean_use_statement(
@@ -2914,16 +2914,16 @@ fn clean_impl<'tcx>(
     impl_: &hir::Impl<'tcx>,
     def_id: LocalDefId,
     cx: &mut DocContext<'tcx>,
-    // If `renamed` is some, then `impl_` is an inlined impl and it will be handled later on in the
-    // code. In here, we will generate a placeholder for it in order to be able to compute its
+    // If true, this is an inlined impl and it will be handled later on in the code.
+    // In here, we will generate a placeholder for it in order to be able to compute its
     // `doc_cfg` info.
-    renamed: Option<Symbol>,
+    is_inlined: bool,
 ) -> Vec<Item> {
     let tcx = cx.tcx;
     let mut ret = Vec::new();
     let trait_ = match impl_.of_trait {
         Some(t) => {
-            if renamed.is_some() {
+            if is_inlined {
                 return vec![Item::from_def_id_and_parts(
                     def_id.to_def_id(),
                     None,

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2777,6 +2777,9 @@ fn clean_maybe_renamed_item<'tcx>(
         // before.
         match item.kind {
             ItemKind::Impl(ref impl_) => {
+                // `renamed` is passed down to `clean_impl` because we use it as a marker to
+                // indicate that this is an inlined impl and that we should generate an impl
+                // placeholder and not a "real" impl item.
                 return clean_impl(impl_, item.owner_id.def_id, cx, renamed);
             }
             ItemKind::Use(path, kind) => {
@@ -2911,7 +2914,7 @@ fn clean_impl<'tcx>(
     impl_: &hir::Impl<'tcx>,
     def_id: LocalDefId,
     cx: &mut DocContext<'tcx>,
-    // If `renamed` is some, then this is an inlined impl and it will be handled later on in the
+    // If `renamed` is some, then `impl_` is an inlined impl and it will be handled later on in the
     // code. In here, we will generate a placeholder for it in order to be able to compute its
     // `doc_cfg` info.
     renamed: Option<Symbol>,

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -885,6 +885,9 @@ pub(crate) enum ItemKind {
     TraitItem(Box<Trait>),
     TraitAliasItem(TraitAlias),
     ImplItem(Box<Impl>),
+    /// This variant is used only as a placeholder for trait impls in order to correctly compute
+    /// `doc_cfg` as trait impls are added to `clean::Crate` after we went through the whole tree.
+    PlaceholderImplItem,
     /// A required method in a trait declaration meaning it's only a function signature.
     RequiredMethodItem(Box<Function>, Defaultness),
     /// A method in a trait impl or a provided method in a trait declaration.
@@ -964,7 +967,8 @@ impl ItemKind {
             | AssocTypeItem(..)
             | StrippedItem(_)
             | KeywordItem
-            | AttributeItem => [].iter(),
+            | AttributeItem
+            | PlaceholderImplItem => [].iter(),
         }
     }
 }

--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -97,7 +97,8 @@ pub(crate) trait DocFolder: Sized {
             | RequiredAssocTypeItem(..)
             | AssocTypeItem(..)
             | KeywordItem
-            | AttributeItem => kind,
+            | AttributeItem
+            | PlaceholderImplItem => kind,
         }
     }
 

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -389,6 +389,8 @@ impl DocFolder for CacheBuilder<'_, '_> {
                 // So would rather leave them to an expert,
                 // as at least the list is better than `_ => {}`.
             }
+
+            clean::PlaceholderImplItem => return None,
         }
 
         // Maintain the parent stack.

--- a/src/librustdoc/formats/item_type.rs
+++ b/src/librustdoc/formats/item_type.rs
@@ -122,7 +122,7 @@ impl<'a> From<&'a clean::Item> for ItemType {
             clean::StaticItem(..) => ItemType::Static,
             clean::ConstantItem(..) => ItemType::Constant,
             clean::TraitItem(..) => ItemType::Trait,
-            clean::ImplItem(..) => ItemType::Impl,
+            clean::ImplItem(..) | clean::PlaceholderImplItem => ItemType::Impl,
             clean::RequiredMethodItem(..) => ItemType::TyMethod,
             clean::MethodItem(..) => ItemType::Method,
             clean::StructFieldItem(..) => ItemType::StructField,

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -353,6 +353,7 @@ fn from_clean_item(item: &clean::Item, renderer: &JsonRenderer<'_>) -> ItemEnum 
             name: name.as_ref().unwrap().to_string(),
             rename: src.map(|x| x.to_string()),
         },
+        // All placeholder impl items should have been removed in the stripper passes.
         PlaceholderImplItem => unreachable!(),
     }
 }

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -353,6 +353,7 @@ fn from_clean_item(item: &clean::Item, renderer: &JsonRenderer<'_>) -> ItemEnum 
             name: name.as_ref().unwrap().to_string(),
             rename: src.map(|x| x.to_string()),
         },
+        PlaceholderImplItem => unreachable!(),
     }
 }
 

--- a/src/librustdoc/passes/calculate_doc_coverage.rs
+++ b/src/librustdoc/passes/calculate_doc_coverage.rs
@@ -199,8 +199,12 @@ impl DocVisitor<'_> for CoverageCalculator<'_, '_> {
         }
 
         match i.kind {
-            clean::StrippedItem(..) | clean::PlaceholderImplItem => {
+            clean::StrippedItem(..) => {
                 // don't count items in stripped modules
+                return;
+            }
+            clean::PlaceholderImplItem => {
+                // The "real" impl items are handled below.
                 return;
             }
             // docs on `use` and `extern crate` statements are not displayed, so they're not

--- a/src/librustdoc/passes/calculate_doc_coverage.rs
+++ b/src/librustdoc/passes/calculate_doc_coverage.rs
@@ -199,7 +199,7 @@ impl DocVisitor<'_> for CoverageCalculator<'_, '_> {
         }
 
         match i.kind {
-            clean::StrippedItem(..) => {
+            clean::StrippedItem(..) | clean::PlaceholderImplItem => {
                 // don't count items in stripped modules
                 return;
             }

--- a/src/librustdoc/passes/check_doc_test_visibility.rs
+++ b/src/librustdoc/passes/check_doc_test_visibility.rs
@@ -80,6 +80,7 @@ pub(crate) fn should_have_doc_example(cx: &DocContext<'_>, item: &clean::Item) -
                 | clean::ImplAssocConstItem(..)
                 | clean::RequiredAssocTypeItem(..)
                 | clean::ImplItem(_)
+                | clean::PlaceholderImplItem
         )
     {
         return false;

--- a/src/librustdoc/passes/propagate_doc_cfg.rs
+++ b/src/librustdoc/passes/propagate_doc_cfg.rs
@@ -29,7 +29,7 @@ struct CfgPropagator<'a, 'tcx> {
     cx: &'a mut DocContext<'tcx>,
     cfg_info: CfgInfo,
 
-    /// To ensure the `doc_cfg` feature works with how `rustdoc` handles impl, we need to store
+    /// To ensure the `doc_cfg` feature works with how `rustdoc` handles impls, we need to store
     /// the `cfg` info of `impl`s placeholder to use them later on the "real" impl item.
     impl_cfg_info: FxHashMap<ItemId, CfgInfo>,
 }
@@ -85,7 +85,7 @@ impl DocFolder for CfgPropagator<'_, '_> {
         let old_cfg_info = self.cfg_info.clone();
 
         // If we have an impl, we check if it has an associated `cfg` "context", and if so we will
-        // use this context instead of the actual (wrong) one.
+        // use that context instead of the actual (wrong) one.
         if let ItemKind::ImplItem(_) = item.kind
             && let Some(cfg_info) = self.impl_cfg_info.remove(&item.item_id)
         {

--- a/src/librustdoc/passes/propagate_doc_cfg.rs
+++ b/src/librustdoc/passes/propagate_doc_cfg.rs
@@ -1,10 +1,11 @@
 //! Propagates [`#[doc(cfg(...))]`](https://github.com/rust-lang/rust/issues/43781) to child items.
 
+use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::Attribute;
 use rustc_hir::attrs::{AttributeKind, DocAttribute};
 
 use crate::clean::inline::{load_attrs, merge_attrs};
-use crate::clean::{CfgInfo, Crate, Item, ItemKind};
+use crate::clean::{CfgInfo, Crate, Item, ItemId, ItemKind};
 use crate::core::DocContext;
 use crate::fold::DocFolder;
 use crate::passes::Pass;
@@ -17,7 +18,8 @@ pub(crate) const PROPAGATE_DOC_CFG: Pass = Pass {
 
 pub(crate) fn propagate_doc_cfg(cr: Crate, cx: &mut DocContext<'_>) -> Crate {
     if cx.tcx.features().doc_cfg() {
-        CfgPropagator { cx, cfg_info: CfgInfo::default() }.fold_crate(cr)
+        CfgPropagator { cx, cfg_info: CfgInfo::default(), impl_cfg_info: FxHashMap::default() }
+            .fold_crate(cr)
     } else {
         cr
     }
@@ -26,6 +28,10 @@ pub(crate) fn propagate_doc_cfg(cr: Crate, cx: &mut DocContext<'_>) -> Crate {
 struct CfgPropagator<'a, 'tcx> {
     cx: &'a mut DocContext<'tcx>,
     cfg_info: CfgInfo,
+
+    /// To ensure the `doc_cfg` feature works with how `rustdoc` handles impl, we need to store
+    /// the `cfg` info of `impl`s placeholder to use them later on the "real" impl item.
+    impl_cfg_info: FxHashMap<ItemId, CfgInfo>,
 }
 
 /// This function goes through the attributes list (`new_attrs`) and extract the `cfg` tokens from
@@ -78,7 +84,22 @@ impl DocFolder for CfgPropagator<'_, '_> {
     fn fold_item(&mut self, mut item: Item) -> Option<Item> {
         let old_cfg_info = self.cfg_info.clone();
 
-        self.merge_with_parent_attributes(&mut item);
+        // If we have an impl, we check if it has an associated `cfg` "context", and if so we will
+        // use this context instead of the actual (wrong) one.
+        if let ItemKind::ImplItem(_) = item.kind
+            && let Some(cfg_info) = self.impl_cfg_info.remove(&item.item_id)
+        {
+            self.cfg_info = cfg_info;
+        }
+
+        if let ItemKind::PlaceholderImplItem = item.kind {
+            // If we have a placeholder impl, we store the current `cfg` "context" to be used
+            // on the actual impl later on (the impls are generated after we go through the whole
+            // AST so they're stored in the `krate` object at the end).
+            self.impl_cfg_info.insert(item.item_id, self.cfg_info.clone());
+        } else {
+            self.merge_with_parent_attributes(&mut item);
+        }
 
         let result = self.fold_item_recur(item);
         self.cfg_info = old_cfg_info;

--- a/src/librustdoc/passes/propagate_stability.rs
+++ b/src/librustdoc/passes/propagate_stability.rs
@@ -107,7 +107,8 @@ impl DocFolder for StabilityPropagator<'_, '_> {
                     | ItemKind::AssocTypeItem(..)
                     | ItemKind::PrimitiveItem(..)
                     | ItemKind::KeywordItem
-                    | ItemKind::AttributeItem => own_stability,
+                    | ItemKind::AttributeItem
+                    | ItemKind::PlaceholderImplItem => own_stability,
 
                     ItemKind::StrippedItem(..) => unreachable!(),
                 }

--- a/src/librustdoc/passes/stripper.rs
+++ b/src/librustdoc/passes/stripper.rs
@@ -120,7 +120,8 @@ impl DocFolder for Stripper<'_, '_> {
 
             clean::ImplItem(..) => {}
 
-            // They have no use anymore, so always remove them.
+            // Since the `doc_cfg` propagation was handled before the current pass, we can (and
+            // should) remove all placeholder impl items.
             clean::PlaceholderImplItem => return None,
 
             // tymethods etc. have no control over privacy

--- a/src/librustdoc/passes/stripper.rs
+++ b/src/librustdoc/passes/stripper.rs
@@ -120,6 +120,9 @@ impl DocFolder for Stripper<'_, '_> {
 
             clean::ImplItem(..) => {}
 
+            // They have no use anymore, so always remove them.
+            clean::PlaceholderImplItem => return None,
+
             // tymethods etc. have no control over privacy
             clean::RequiredMethodItem(..)
             | clean::RequiredAssocConstItem(..)

--- a/src/librustdoc/scrape_examples.rs
+++ b/src/librustdoc/scrape_examples.rs
@@ -3,7 +3,7 @@
 use std::fs;
 use std::path::PathBuf;
 
-use rustc_data_structures::fx::FxIndexMap;
+use rustc_data_structures::fx::{FxHashSet, FxIndexMap};
 use rustc_errors::DiagCtxtHandle;
 use rustc_hir as hir;
 use rustc_hir::intravisit::{self, Visitor};
@@ -15,7 +15,7 @@ use rustc_serialize::{Decodable, Encodable};
 use rustc_session::getopts;
 use rustc_span::def_id::{CrateNum, DefPathHash, LOCAL_CRATE};
 use rustc_span::edition::Edition;
-use rustc_span::{BytePos, FileName, SourceFile};
+use rustc_span::{BytePos, FileName, SourceFile, Span};
 use tracing::{debug, trace, warn};
 
 use crate::html::render::Context;
@@ -114,6 +114,7 @@ struct FindCalls<'a, 'tcx> {
     target_crates: Vec<CrateNum>,
     calls: &'a mut AllCallLocations,
     bin_crate: bool,
+    call_ident_spans: FxHashSet<Span>,
 }
 
 impl<'a, 'tcx> Visitor<'tcx> for FindCalls<'a, 'tcx>
@@ -164,6 +165,10 @@ where
                 return;
             }
         };
+
+        if !self.call_ident_spans.insert(ident_span) {
+            return;
+        }
 
         // If this span comes from a macro expansion, then the source code may not actually show
         // a use of the given item, so it would be a poor example. Hence, we skip all uses in
@@ -300,7 +305,13 @@ pub(crate) fn run(
 
         // Run call-finder on all items
         let mut calls = FxIndexMap::default();
-        let mut finder = FindCalls { calls: &mut calls, cx, target_crates, bin_crate };
+        let mut finder = FindCalls {
+            calls: &mut calls,
+            cx,
+            target_crates,
+            bin_crate,
+            call_ident_spans: FxHashSet::default(),
+        };
         tcx.hir_visit_all_item_likes_in_crate(&mut finder);
 
         // The visitor might have found a type error, which we need to

--- a/src/librustdoc/visit.rs
+++ b/src/librustdoc/visit.rs
@@ -50,7 +50,8 @@ pub(crate) trait DocVisitor<'a>: Sized {
             | RequiredAssocTypeItem(..)
             | AssocTypeItem(..)
             | KeywordItem
-            | AttributeItem => {}
+            | AttributeItem
+            | PlaceholderImplItem => {}
         }
     }
 

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -429,6 +429,10 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             if let hir::ItemKind::Impl(impl_) = item.kind {
                 self.add_to_current_mod(
                     item,
+                    // The symbol here is used as a "sentinel" value and has no meaning in
+                    // itself. It just tells that this is an inlined impl and that it should not
+                    // be cleaned as a normal `ImplItem` but instead as a `PlaceholderImplItem`.
+                    // It's to ensure that `doc_cfg` inheritance works as expected.
                     if impl_.of_trait.is_none() {
                         None
                     } else {
@@ -539,6 +543,10 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                 if !self.inlining {
                     self.add_to_current_mod(
                         item,
+                        // The symbol here is used as a "sentinel" value and has no meaning in
+                        // itself. It just tells that this is an inlined impl and that it should not
+                        // be cleaned as a normal `ImplItem` but instead as a `PlaceholderImplItem`.
+                        // It's to ensure that `doc_cfg` inheritance works as expected.
                         if impl_.of_trait.is_none() {
                             None
                         } else {

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -426,12 +426,16 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             // }
             // Bar::bar();
             // ```
-            if let hir::ItemKind::Impl(impl_) = item.kind &&
-                // Don't duplicate impls when inlining or if it's implementing a trait, we'll pick
-                // them up regardless of where they're located.
-                impl_.of_trait.is_none()
-            {
-                self.add_to_current_mod(item, None, None);
+            if let hir::ItemKind::Impl(impl_) = item.kind {
+                self.add_to_current_mod(
+                    item,
+                    if impl_.of_trait.is_none() {
+                        None
+                    } else {
+                        Some(rustc_span::symbol::kw::Impl)
+                    },
+                    None,
+                );
             }
             return;
         }
@@ -530,10 +534,18 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                 }
             }
             hir::ItemKind::Impl(impl_) => {
-                // Don't duplicate impls when inlining or if it's implementing a trait, we'll pick
+                // Don't duplicate impls when inlining, we'll pick
                 // them up regardless of where they're located.
-                if !self.inlining && impl_.of_trait.is_none() {
-                    self.add_to_current_mod(item, None, None);
+                if !self.inlining {
+                    self.add_to_current_mod(
+                        item,
+                        if impl_.of_trait.is_none() {
+                            None
+                        } else {
+                            Some(rustc_span::symbol::kw::Impl)
+                        },
+                        None,
+                    );
                 }
             }
         }

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -373,6 +373,19 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
     }
 
     #[inline]
+    fn add_impl_to_current_mod(&mut self, item: &'tcx hir::Item<'_>, impl_: hir::Impl<'_>) {
+        self.add_to_current_mod(
+            item,
+            // The symbol here is used as a "sentinel" value and has no meaning in
+            // itself. It just tells that this is an inlined impl and that it should not
+            // be cleaned as a normal `ImplItem` but instead as a `PlaceholderImplItem`.
+            // It's to ensure that `doc_cfg` inheritance works as expected.
+            if impl_.of_trait.is_none() { None } else { Some(rustc_span::symbol::kw::Impl) },
+            None,
+        );
+    }
+
+    #[inline]
     fn add_to_current_mod(
         &mut self,
         item: &'tcx hir::Item<'_>,
@@ -427,19 +440,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             // Bar::bar();
             // ```
             if let hir::ItemKind::Impl(impl_) = item.kind {
-                self.add_to_current_mod(
-                    item,
-                    // The symbol here is used as a "sentinel" value and has no meaning in
-                    // itself. It just tells that this is an inlined impl and that it should not
-                    // be cleaned as a normal `ImplItem` but instead as a `PlaceholderImplItem`.
-                    // It's to ensure that `doc_cfg` inheritance works as expected.
-                    if impl_.of_trait.is_none() {
-                        None
-                    } else {
-                        Some(rustc_span::symbol::kw::Impl)
-                    },
-                    None,
-                );
+                self.add_impl_to_current_mod(item, impl_);
             }
             return;
         }
@@ -541,19 +542,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                 // Don't duplicate impls when inlining, we'll pick
                 // them up regardless of where they're located.
                 if !self.inlining {
-                    self.add_to_current_mod(
-                        item,
-                        // The symbol here is used as a "sentinel" value and has no meaning in
-                        // itself. It just tells that this is an inlined impl and that it should not
-                        // be cleaned as a normal `ImplItem` but instead as a `PlaceholderImplItem`.
-                        // It's to ensure that `doc_cfg` inheritance works as expected.
-                        if impl_.of_trait.is_none() {
-                            None
-                        } else {
-                            Some(rustc_span::symbol::kw::Impl)
-                        },
-                        None,
-                    );
+                    self.add_impl_to_current_mod(item, impl_);
                 }
             }
         }

--- a/tests/run-make-cargo/rustdoc-scrape-examples-duplicated-calls/Cargo.toml
+++ b/tests/run-make-cargo/rustdoc-scrape-examples-duplicated-calls/Cargo.toml
@@ -1,0 +1,10 @@
+[workspace]
+
+[package]
+edition = "2024"
+name = "tester"
+version = "0.1.0"
+
+[[example]]
+doc-scrape-examples = true
+name = "window"

--- a/tests/run-make-cargo/rustdoc-scrape-examples-duplicated-calls/examples/window.rs
+++ b/tests/run-make-cargo/rustdoc-scrape-examples-duplicated-calls/examples/window.rs
@@ -1,0 +1,24 @@
+#![allow(dead_code)]
+use tester::Window;
+
+macro_rules! info {
+    ($s:literal, $x:expr) => {{
+        let _ = $x;
+    }};
+}
+
+struct WindowState {
+    window: Window,
+}
+
+impl WindowState {
+    fn takes_ref(&self) {
+        info!("{:?}", self.window.id());
+    }
+
+    fn takes_mut(&mut self) {
+        info!("{:?}", self.window.id());
+    }
+}
+
+fn main() {}

--- a/tests/run-make-cargo/rustdoc-scrape-examples-duplicated-calls/rmake.rs
+++ b/tests/run-make-cargo/rustdoc-scrape-examples-duplicated-calls/rmake.rs
@@ -1,0 +1,11 @@
+//! This test ensures that the call locations are not duplicated when generating scraped examples.
+//! To ensure that, we check that this call doesn't fail.
+//! Regression test for <https://github.com/rust-lang/rust/issues/153837>.
+
+use run_make_support::{cargo, htmldocck};
+
+fn main() {
+    cargo().args(["rustdoc", "-Zunstable-options", "-Zrustdoc-scrape-examples"]).run();
+
+    htmldocck().arg("target/doc").arg("src/lib.rs").run();
+}

--- a/tests/run-make-cargo/rustdoc-scrape-examples-duplicated-calls/src/lib.rs
+++ b/tests/run-make-cargo/rustdoc-scrape-examples-duplicated-calls/src/lib.rs
@@ -1,0 +1,13 @@
+//@has tester/struct.Window.html
+//@count - '//*[@class="docblock scraped-example-list"]//span[@class="highlight"]' 1
+//@has - '//*[@class="docblock scraped-example-list"]//span[@class="highlight"]' 'id'
+//@count - '//*[@class="docblock scraped-example-list"]//span[@class="highlight focus"]' 1
+//@has - '//*[@class="docblock scraped-example-list"]//span[@class="highlight focus"]' 'id'
+
+pub struct Window {}
+
+impl Window {
+    pub fn id(&self) -> u64 {
+        todo!()
+    }
+}

--- a/tests/rustdoc-html/doc-cfg/trait-impls-manual.rs
+++ b/tests/rustdoc-html/doc-cfg/trait-impls-manual.rs
@@ -1,0 +1,92 @@
+// This test ensures that `doc_cfg` feature is working as expected on trait impls.
+// Regression test for <https://github.com/rust-lang/rust/issues/153655>.
+
+#![feature(doc_cfg)]
+#![doc(auto_cfg(hide(
+    target_pointer_width = "64",
+)))]
+
+#![crate_name = "foo"]
+
+pub trait Trait {
+    fn f(&self) {}
+}
+
+pub trait Bob {
+    fn bob(&self) {}
+}
+
+pub trait Foo {
+    fn foo(&self) {}
+}
+
+pub struct X;
+
+//@has 'foo/struct.X.html'
+//@count - '//*[@id="impl-Bob-for-X"]' 1
+//@count - '//*[@id="impl-Bob-for-X"]/*[@class="item-info"]' 0
+//@count - '//*[@id="impl-Trait-for-X"]' 1
+//@count - '//*[@id="impl-Trait-for-X"]/*[@class="item-info"]' 0
+
+// If you need to update this XPath, in particular `item-info`, update all
+// the others in this file.
+//@count - '//*[@id="impl-Foo-for-X"]/*[@class="item-info"]' 1
+
+//@has 'foo/trait.Trait.html'
+//@count - '//*[@id="impl-Trait-for-X"]' 1
+//@count - '//*[@id="impl-Trait-for-X"]/*[@class="item-info"]' 0
+#[doc(cfg(any(target_pointer_width = "64", target_arch = "wasm32")))]
+#[doc(auto_cfg(hide(target_arch = "wasm32")))]
+mod imp {
+    impl super::Trait for super::X { fn f(&self) {} }
+}
+
+//@has 'foo/trait.Bob.html'
+//@count - '//*[@id="impl-Bob-for-X"]' 1
+//@count - '//*[@id="impl-Bob-for-X"]/*[@class="item-info"]' 0
+#[doc(cfg(any(target_pointer_width = "64", target_arch = "wasm32")))]
+#[doc(auto_cfg = false)]
+mod imp2 {
+    impl super::Bob for super::X { fn bob(&self) {} }
+}
+
+//@has 'foo/trait.Foo.html'
+//@count - '//*[@id="impl-Foo-for-X"]/*[@class="item-info"]' 1
+// We use this to force xpath tests to be updated if `item-info` class is changed.
+#[doc(cfg(any(target_pointer_width = "64", target_arch = "wasm32")))]
+mod imp3 {
+    impl super::Foo for super::X { fn foo(&self) {} }
+}
+
+pub struct Y;
+
+//@has 'foo/struct.Y.html'
+//@count - '//*[@id="implementations-list"]/*[@class="impl-items"]' 1
+//@count - '//*[@id="implementations-list"]/*[@class="impl-items"]/*[@class="item-info"]' 0
+#[doc(cfg(any(target_pointer_width = "64", target_arch = "wasm32")))]
+#[doc(auto_cfg(hide(target_arch = "wasm32")))]
+mod imp4 {
+    impl super::Y { pub fn plain_auto() {} }
+}
+
+pub struct Z;
+
+//@has 'foo/struct.Z.html'
+//@count - '//*[@id="implementations-list"]/*[@class="impl-items"]' 1
+//@count - '//*[@id="implementations-list"]/*[@class="impl-items"]/*[@class="item-info"]' 0
+#[doc(cfg(any(target_pointer_width = "64", target_arch = "wasm32")))]
+#[doc(auto_cfg = false)]
+mod imp5 {
+    impl super::Z { pub fn plain_auto() {} }
+}
+
+// The "witness" which has the item info.
+pub struct W;
+
+//@has 'foo/struct.W.html'
+//@count - '//*[@id="implementations-list"]/*[@class="impl-items"]' 1
+//@count - '//*[@id="implementations-list"]/*[@class="impl-items"]/*[@class="item-info"]' 1
+#[doc(cfg(any(target_pointer_width = "64", target_arch = "wasm32")))]
+mod imp6 {
+    impl super::W { pub fn plain_auto() {} }
+}

--- a/tests/rustdoc-html/doc-cfg/trait-impls.rs
+++ b/tests/rustdoc-html/doc-cfg/trait-impls.rs
@@ -1,0 +1,92 @@
+// This test ensures that `doc_cfg` feature is working as expected on trait impls.
+// Regression test for <https://github.com/rust-lang/rust/issues/153655>.
+
+#![feature(doc_cfg)]
+#![doc(auto_cfg(hide(
+    target_pointer_width = "64",
+)))]
+
+#![crate_name = "foo"]
+
+pub trait Trait {
+    fn f(&self) {}
+}
+
+pub trait Bob {
+    fn bob(&self) {}
+}
+
+pub trait Foo {
+    fn foo(&self) {}
+}
+
+pub struct X;
+
+//@has 'foo/struct.X.html'
+//@count - '//*[@id="impl-Bob-for-X"]' 1
+//@count - '//*[@id="impl-Bob-for-X"]/*[@class="item-info"]' 0
+//@count - '//*[@id="impl-Trait-for-X"]' 1
+//@count - '//*[@id="impl-Trait-for-X"]/*[@class="item-info"]' 0
+
+// If you need to update this XPath, in particular `item-info`, update all
+// the others in this file.
+//@count - '//*[@id="impl-Foo-for-X"]/*[@class="item-info"]' 1
+
+//@has 'foo/trait.Trait.html'
+//@count - '//*[@id="impl-Trait-for-X"]' 1
+//@count - '//*[@id="impl-Trait-for-X"]/*[@class="item-info"]' 0
+#[cfg(any(target_pointer_width = "64", target_arch = "wasm32"))]
+#[doc(auto_cfg(hide(target_arch = "wasm32")))]
+mod imp {
+    impl super::Trait for super::X { fn f(&self) {} }
+}
+
+//@has 'foo/trait.Bob.html'
+//@count - '//*[@id="impl-Bob-for-X"]' 1
+//@count - '//*[@id="impl-Bob-for-X"]/*[@class="item-info"]' 0
+#[cfg(any(target_pointer_width = "64", target_arch = "wasm32"))]
+#[doc(auto_cfg = false)]
+mod imp2 {
+    impl super::Bob for super::X { fn bob(&self) {} }
+}
+
+//@has 'foo/trait.Foo.html'
+//@count - '//*[@id="impl-Foo-for-X"]/*[@class="item-info"]' 1
+// We use this to force xpath tests to be updated if `item-info` class is changed.
+#[cfg(any(target_pointer_width = "64", target_arch = "wasm32"))]
+mod imp3 {
+    impl super::Foo for super::X { fn foo(&self) {} }
+}
+
+pub struct Y;
+
+//@has 'foo/struct.Y.html'
+//@count - '//*[@id="implementations-list"]/*[@class="impl-items"]' 1
+//@count - '//*[@id="implementations-list"]/*[@class="impl-items"]/*[@class="item-info"]' 0
+#[cfg(any(target_pointer_width = "64", target_arch = "wasm32"))]
+#[doc(auto_cfg(hide(target_arch = "wasm32")))]
+mod imp4 {
+    impl super::Y { pub fn plain_auto() {} }
+}
+
+pub struct Z;
+
+//@has 'foo/struct.Z.html'
+//@count - '//*[@id="implementations-list"]/*[@class="impl-items"]' 1
+//@count - '//*[@id="implementations-list"]/*[@class="impl-items"]/*[@class="item-info"]' 0
+#[cfg(any(target_pointer_width = "64", target_arch = "wasm32"))]
+#[doc(auto_cfg = false)]
+mod imp5 {
+    impl super::Z { pub fn plain_auto() {} }
+}
+
+// The "witness" which has the item info.
+pub struct W;
+
+//@has 'foo/struct.W.html'
+//@count - '//*[@id="implementations-list"]/*[@class="impl-items"]' 1
+//@count - '//*[@id="implementations-list"]/*[@class="impl-items"]/*[@class="item-info"]' 1
+#[cfg(any(target_pointer_width = "64", target_arch = "wasm32"))]
+mod imp6 {
+    impl super::W { pub fn plain_auto() {} }
+}

--- a/tests/ui/parser/shebang/multiline-attrib.rs
+++ b/tests/ui/parser/shebang/multiline-attrib.rs
@@ -1,7 +1,7 @@
 #!
 [allow(unused_variables)]
 //@ check-pass
-//@ reference: input.shebang.inner-attribute
+//@ reference: shebang.syntax-description
 
 fn main() {
     let x = 5;

--- a/tests/ui/parser/shebang/regular-attrib.rs
+++ b/tests/ui/parser/shebang/regular-attrib.rs
@@ -1,6 +1,6 @@
 #![allow(unused_variables)]
 //@ check-pass
-//@ reference: input.shebang.inner-attribute
+//@ reference: shebang.syntax-description
 fn main() {
     let x = 5;
 }

--- a/tests/ui/parser/shebang/shebang-and-attrib.rs
+++ b/tests/ui/parser/shebang/shebang-and-attrib.rs
@@ -1,7 +1,7 @@
 #!/usr/bin/env run-cargo-script
 
 //@ check-pass
-//@ reference: input.shebang.inner-attribute
+//@ reference: shebang.syntax-description
 #![allow(unused_variables)]
 
 

--- a/tests/ui/parser/shebang/shebang-doc-comment.rs
+++ b/tests/ui/parser/shebang/shebang-doc-comment.rs
@@ -2,4 +2,4 @@
 [allow(unused_variables)]
 //~^ ERROR expected item, found `[`
 
-//@ reference: input.shebang.inner-attribute
+//@ reference: shebang.syntax-description

--- a/tests/ui/parser/shebang/sneaky-attrib.rs
+++ b/tests/ui/parser/shebang/sneaky-attrib.rs
@@ -11,7 +11,7 @@
 [allow(unused_variables)]
 
 //@ check-pass
-//@ reference: input.shebang.inner-attribute
+//@ reference: shebang.syntax-description
 fn main() {
     let x = 5;
 }


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#153964 (Fix `doc_cfg` not working as expected on trait impls)
 - rust-lang/rust#153979 (Rename various query cycle things.)
 - rust-lang/rust#154236 (Clean up query-forcing functions)
 - rust-lang/rust#154017 ( Fix invalid add of duplicated call locations for the rustdoc scraped examples feature)
 - rust-lang/rust#154163 (enzyme submodule update)
 - rust-lang/rust#154264 (Update books)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=153964,153979,154236,154017,154163,154264)
<!-- homu-ignore:end -->

