### PR TITLE
Add `PartialEq` and `Eq` impls to the character case iterators

### DIFF
--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -852,6 +852,9 @@ impl char {
     /// `Lowercase` is described in Chapter 4 (Character Properties) of the [Unicode Standard] and
     /// specified in the [Unicode Character Database][ucd] [`DerivedCoreProperties.txt`].
     ///
+    /// For any `c: char`, `c.is_lowercase()` implies `c.to_lowercase() == c`.
+    /// However, the reverse is not necessarily true, even for cased characters.
+    ///
     /// [Unicode Standard]: https://www.unicode.org/versions/latest/
     /// [ucd]: https://www.unicode.org/reports/tr44/
     /// [`DerivedCoreProperties.txt`]: https://www.unicode.org/Public/UCD/latest/ucd/DerivedCoreProperties.txt
@@ -896,6 +899,9 @@ impl char {
     /// (Character Properties) of the [Unicode Standard] and specified in the [Unicode Character
     /// Database][ucd] [`UnicodeData.txt`].
     ///
+    /// For any `c: char`, `c.is_titlecase()` implies `c.to_titlecase() == c`.
+    /// However, the reverse is not usually true, even for cased characters.
+    ///
     /// [Unicode Standard]: https://www.unicode.org/versions/latest/
     /// [ucd]: https://www.unicode.org/reports/tr44/
     /// [`UnicodeData.txt`]: https://www.unicode.org/Public/UCD/latest/ucd/UnicodeData.txt
@@ -927,6 +933,9 @@ impl char {
     ///
     /// `Uppercase` is described in Chapter 4 (Character Properties) of the [Unicode Standard] and
     /// specified in the [Unicode Character Database][ucd] [`DerivedCoreProperties.txt`].
+    ///
+    /// For any `c: char`, `c.is_uppercase()` implies `c.to_uppercase() == c`.
+    /// However, the reverse is not necessarily true, even for cased characters.
     ///
     /// [Unicode Standard]: https://www.unicode.org/versions/latest/
     /// [ucd]: https://www.unicode.org/reports/tr44/

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1139,7 +1139,8 @@ impl char {
     }
 
     /// Returns an iterator that yields the lowercase mapping of this `char` as one or more
-    /// `char`s.
+    /// `char`s. The iterator also has implementations of [`Display`][core::fmt::Display],
+    /// [`PartialEq`], and [`Eq`].
     ///
     /// If this `char` does not have a lowercase mapping, the iterator yields the same `char`.
     ///
@@ -1197,6 +1198,13 @@ impl char {
     /// // convert into themselves.
     /// assert_eq!('山'.to_lowercase().to_string(), "山");
     /// ```
+    ///
+    /// Check if a string is in lowercase:
+    ///
+    /// ```
+    /// let s = "abcde\u{0301} 山";
+    /// assert!(s.chars().all(|c| c.to_lowercase() == c));
+    /// ```
     #[must_use = "this returns the lowercased character as a new iterator, \
                   without modifying the original"]
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -1206,7 +1214,8 @@ impl char {
     }
 
     /// Returns an iterator that yields the titlecase mapping of this `char` as one or more
-    /// `char`s.
+    /// `char`s. The iterator also has implementations of [`Display`][core::fmt::Display],
+    /// [`PartialEq`], and [`Eq`].
     ///
     /// This is usually, but not always, equivalent to the uppercase mapping
     /// returned by [`Self::to_uppercase`]. Prefer this method when seeking to capitalize
@@ -1274,6 +1283,21 @@ impl char {
     /// assert_eq!('山'.to_titlecase().to_string(), "山");
     /// ```
     ///
+    /// Check if a word is in titlecase:
+    ///
+    /// ```
+    /// #![feature(titlecase)]
+    /// let word = "Dross";
+    /// let mut chars = word.chars();
+    /// let first_cased_char = chars.find(|c| c.is_cased());
+    /// let word_is_in_titlecase = if let Some(f) = first_cased_char {
+    ///     f.to_titlecase() == f && chars.all(|c| c.to_lowercase() == c)
+    /// } else {
+    ///     true
+    /// };
+    /// assert!(word_is_in_titlecase);
+    /// ```
+    ///
     /// # Note on locale
     ///
     /// In Turkish and Azeri, the equivalent of 'i' in Latin has five forms instead of two:
@@ -1309,7 +1333,8 @@ impl char {
     }
 
     /// Returns an iterator that yields the uppercase mapping of this `char` as one or more
-    /// `char`s.
+    /// `char`s. The iterator also has implementations of [`Display`][core::fmt::Display],
+    /// [`PartialEq`], and [`Eq`].
     ///
     /// Prefer this method when converting a word into ALL CAPS, but consider [`Self::to_titlecase`]
     /// instead if you seek to capitalize Only The First Letter.
@@ -1372,6 +1397,13 @@ impl char {
     /// // Characters that do not have both uppercase and lowercase
     /// // convert into themselves.
     /// assert_eq!('山'.to_uppercase().to_string(), "山");
+    /// ```
+    ///
+    /// Check if a string is in uppercase:
+    ///
+    /// ```
+    /// let s = "ABCDE\u{0301} 山";
+    /// assert!(s.chars().all(|c| c.to_uppercase() == c));
     /// ```
     ///
     /// # Note on locale

--- a/library/core/src/char/mod.rs
+++ b/library/core/src/char/mod.rs
@@ -369,6 +369,7 @@ macro_rules! casemappingiter_impls {
         #[$fusedstab:meta]
         #[$exactstab:meta]
         #[$displaystab:meta]
+        #[$eqstab:meta]
         $(#[$attr:meta])*
         $ITER_NAME:ident
     ) => {
@@ -468,6 +469,41 @@ macro_rules! casemappingiter_impls {
                 fmt::Display::fmt(&self.0, f)
             }
         }
+
+        #[$eqstab]
+        impl PartialEq<ToUppercase> for $ITER_NAME {
+            #[inline]
+            fn eq(&self, other: &ToUppercase) -> bool {
+                self.0 == other.0
+            }
+        }
+
+        #[unstable(feature = "titlecase", issue = "153892")]
+        impl PartialEq<ToTitlecase> for $ITER_NAME {
+            #[inline]
+            fn eq(&self, other: &ToTitlecase) -> bool {
+                self.0 == other.0
+            }
+        }
+
+        #[$eqstab]
+        impl PartialEq<ToLowercase> for $ITER_NAME {
+            #[inline]
+            fn eq(&self, other: &ToLowercase) -> bool {
+                self.0 == other.0
+            }
+        }
+
+        #[$eqstab]
+        impl PartialEq<char> for $ITER_NAME {
+            #[inline]
+            fn eq(&self, other: &char) -> bool {
+                self.0 == *other
+            }
+        }
+
+        #[$eqstab]
+        impl Eq for $ITER_NAME {}
     }
 }
 
@@ -477,6 +513,7 @@ casemappingiter_impls! {
     #[stable(feature = "fused", since = "1.26.0")]
     #[stable(feature = "exact_size_case_mapping_iter", since = "1.35.0")]
     #[stable(feature = "char_struct_display", since = "1.16.0")]
+    #[stable(feature = "iter_partialeq", since = "CURRENT_RUSTC_VERSION")]
     /// Returns an iterator that yields the uppercase equivalent of a `char`.
     ///
     /// This `struct` is created by the [`to_uppercase`] method on [`char`]. See
@@ -487,6 +524,7 @@ casemappingiter_impls! {
 }
 
 casemappingiter_impls! {
+    #[unstable(feature = "titlecase", issue = "153892")]
     #[unstable(feature = "titlecase", issue = "153892")]
     #[unstable(feature = "titlecase", issue = "153892")]
     #[unstable(feature = "titlecase", issue = "153892")]
@@ -507,6 +545,7 @@ casemappingiter_impls! {
     #[stable(feature = "fused", since = "1.26.0")]
     #[stable(feature = "exact_size_case_mapping_iter", since = "1.35.0")]
     #[stable(feature = "char_struct_display", since = "1.16.0")]
+    #[stable(feature = "iter_partialeq", since = "CURRENT_RUSTC_VERSION")]
     /// Returns an iterator that yields the lowercase equivalent of a `char`.
     ///
     /// This `struct` is created by the [`to_lowercase`] method on [`char`]. See
@@ -619,6 +658,22 @@ impl fmt::Display for CaseMappingIter {
             f.write_char(c)?;
         }
         Ok(())
+    }
+}
+
+impl PartialEq for CaseMappingIter {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.0.as_slice() == other.0.as_slice()
+    }
+}
+
+impl Eq for CaseMappingIter {}
+
+impl PartialEq<char> for CaseMappingIter {
+    #[inline]
+    fn eq(&self, other: &char) -> bool {
+        self.0.as_slice() == &[*other]
     }
 }
 

--- a/library/coretests/tests/char.rs
+++ b/library/coretests/tests/char.rs
@@ -56,10 +56,26 @@ fn test_is_cased() {
 fn test_char_case() {
     for c in '\0'..='\u{10FFFF}' {
         match c.case() {
-            None => assert!(!c.is_cased()),
-            Some(CharCase::Lower) => assert!(c.is_lowercase()),
-            Some(CharCase::Upper) => assert!(c.is_uppercase()),
-            Some(CharCase::Title) => assert!(c.is_titlecase()),
+            None => {
+                assert!(
+                    !c.is_cased() && !c.is_lowercase() && !c.is_titlecase() && !c.is_uppercase()
+                );
+                assert_eq!(c.to_lowercase(), c);
+                assert_eq!(c.to_uppercase(), c);
+                assert_eq!(c.to_titlecase(), c);
+            }
+            Some(CharCase::Lower) => {
+                assert!(c.is_cased() && c.is_lowercase() && !c.is_titlecase() && !c.is_uppercase());
+                assert_eq!(c.to_lowercase(), c)
+            }
+            Some(CharCase::Upper) => {
+                assert!(c.is_cased() && !c.is_lowercase() && !c.is_titlecase() && c.is_uppercase());
+                assert_eq!(c.to_uppercase(), c)
+            }
+            Some(CharCase::Title) => {
+                assert!(c.is_cased() && !c.is_lowercase() && c.is_titlecase() && !c.is_uppercase());
+                assert_eq!(c.to_titlecase(), c)
+            }
         }
     }
 }


### PR DESCRIPTION
Allows easily checking whether a string is in a particular case.

Adds `impl PartialEq<{ToUppercase, ToLowercase, ToTitlecase, char}> for {ToUppercase, ToLowercase, ToTitlecase}` and  `impl Eq for {ToUppercase, ToLowercase, ToTitlecase}`.

@rustbot label needs-fcp T-libs-api A-unicode

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
