### PR TITLE
Fix typo in doc comment for `char::to_titlecase`

### DIFF
--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1212,7 +1212,7 @@ impl char {
     /// returned by [`Self::to_uppercase`]. Prefer this method when seeking to capitalize
     /// Only The First Letter of a word, but use [`Self::to_uppercase`] for ALL CAPS.
     ///
-    /// If this `char` does not have an titlecase mapping, the iterator yields the same `char`.
+    /// If this `char` does not have a titlecase mapping, the iterator yields the same `char`.
     ///
     /// If this `char` has a one-to-one titlecase mapping given by the [Unicode Character
     /// Database][ucd] [`UnicodeData.txt`], the iterator yields that `char`.


### PR DESCRIPTION
@rustbot label A-docs
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
