### PR TITLE
Don't use disk-cache for query `def_kind`

### DIFF
--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -1436,8 +1436,10 @@ rustc_queries! {
 
     query def_kind(def_id: DefId) -> DefKind {
         desc { "looking up definition kind of `{}`", tcx.def_path_str(def_id) }
-        cache_on_disk
         separate_provide_extern
+        // This query has no local provider. For defs in the current crate,
+        // its value is always set by feeding when the `DefId` is created,
+        // usually in `TyCtxt::create_def`.
         feedable
     }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/154292)*
<!-- homu-ignore:end -->

From what I can tell, the `def_kind` query has no local provider, and is always given its value via query feeding, usually from `TyCtxt::create_def`.

If that's the case, there should never be any opportunity for a previous value to be loaded from disk-cache, so serializing the current-session values is a waste of time.
