### PR TITLE
nvptx: Re-enable fixed merge-functions

### DIFF
--- a/compiler/rustc_target/src/spec/targets/nvptx64_nvidia_cuda.rs
+++ b/compiler/rustc_target/src/spec/targets/nvptx64_nvidia_cuda.rs
@@ -1,6 +1,6 @@
 use crate::spec::{
-    Arch, LinkSelfContainedDefault, LinkerFlavor, MergeFunctions, Os, PanicStrategy, Target,
-    TargetMetadata, TargetOptions,
+    Arch, LinkSelfContainedDefault, LinkerFlavor, Os, PanicStrategy, Target, TargetMetadata,
+    TargetOptions,
 };
 
 pub(crate) fn target() -> Target {
@@ -47,11 +47,6 @@ pub(crate) fn target() -> Target {
             dll_prefix: "".into(),
             dll_suffix: ".ptx".into(),
             exe_suffix: ".ptx".into(),
-
-            // Disable MergeFunctions LLVM optimisation pass because it can
-            // produce kernel functions that call other kernel functions.
-            // This behavior is not supported by PTX ISA.
-            merge_functions: MergeFunctions::Disabled,
 
             // The LLVM backend does not support stack canaries for this target
             supports_stack_protector: false,


### PR DESCRIPTION
The merge-functions pass generating calls to kernels was fixed in LLVM (released in LLVM 22), so we can remove the workaround and re-enable the merge-functions pass.

The bpf target also disables merge-functions, though from the comment there seem to be other reasons to do that.

Fixes rust-lang/rust#57356.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
