### PR TITLE
Add regression tests for Self resolution in submodule impl blocks

### DIFF
--- a/tests/rustdoc-html/intra-doc/self-in-submodule-impl-84827.rs
+++ b/tests/rustdoc-html/intra-doc/self-in-submodule-impl-84827.rs
@@ -1,0 +1,24 @@
+// https://github.com/rust-lang/rust/issues/84827
+// `Self` in a doc link inside an impl block in a submodule should resolve
+// correctly even when the type is not in scope in that submodule.
+
+#![crate_name = "foo"]
+#![deny(rustdoc::broken_intra_doc_links)]
+
+pub struct Foo {
+    pub foo: i32,
+}
+
+pub mod bar {
+    impl crate::Foo {
+        //@ has foo/struct.Foo.html '//a[@href="struct.Foo.html#structfield.foo"]' 'Self::foo'
+        /// Baz the [`Self::foo`] field.
+        pub fn baz(&self) {
+            let _ = self.foo;
+        }
+
+        //@ has foo/struct.Foo.html '//a[@href="struct.Foo.html#method.baz"]' 'Self::baz'
+        /// See also [`Self::baz`].
+        pub fn qux(&self) {}
+    }
+}

--- a/tests/rustdoc-ui/intra-doc/self-in-submodule-impl-84827.rs
+++ b/tests/rustdoc-ui/intra-doc/self-in-submodule-impl-84827.rs
@@ -1,0 +1,28 @@
+//@ check-pass
+// https://github.com/rust-lang/rust/issues/84827
+
+// rustdoc should resolve `Self` in doc links inside an `impl` block that lives
+// in a submodule where the type is not directly in scope.
+
+#![deny(rustdoc::broken_intra_doc_links)]
+
+pub struct Foo {
+    pub foo: i32,
+}
+
+pub mod bar {
+    impl crate::Foo {
+        /// Baz the [`Self::foo`] field.
+        pub fn baz(&self) {
+            let _ = self.foo;
+        }
+
+        /// Returns a new [`Self`].
+        pub fn new() -> Self {
+            Self { foo: 0 }
+        }
+
+        /// See also [`Self::baz`].
+        pub fn qux(&self) {}
+    }
+}


### PR DESCRIPTION
## Summary

- Add `rustdoc-ui` and `rustdoc-html` regression tests for rust-lang/rust#84827
- Verifies that `Self` in intra-doc links (`[`Self::foo`]`, `[`Self::baz`]`, `[`Self`]`) resolves correctly inside `impl` blocks in submodules where the type is brought in via `crate::` path
- This issue was silently fixed at some point but never had dedicated regression tests

## Test Details

- **`tests/rustdoc-ui/intra-doc/self-in-submodule-impl-84827.rs`**: `check-pass` test with `#![deny(rustdoc::broken_intra_doc_links)]` ensuring no warnings
- **`tests/rustdoc-html/intra-doc/self-in-submodule-impl-84827.rs`**: HTML output test verifying correct `href` targets for `Self::foo` (structfield) and `Self::baz` (method)

## Test Plan

- [x] `./x.py test tests/rustdoc-ui --test-args self-in-submodule-impl-84827` — 1 passed
- [x] `./x.py test tests/rustdoc-html --test-args self-in-submodule-impl-84827` — 1 passed

Closes rust-lang/rust#84827

`Ship-Session-Id: dev-tool-13e29d1f`