### PR TITLE
Make typeck a tcx method which calls typeck_root query

### DIFF
--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -82,7 +82,7 @@ fn used_trait_imports(tcx: TyCtxt<'_>, def_id: LocalDefId) -> &UnordSet<LocalDef
     &tcx.typeck(def_id).used_trait_imports
 }
 
-fn typeck<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> &'tcx ty::TypeckResults<'tcx> {
+fn typeck_root<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> &'tcx ty::TypeckResults<'tcx> {
     typeck_with_inspect(tcx, def_id, None)
 }
 
@@ -95,6 +95,13 @@ pub fn inspect_typeck<'tcx>(
     def_id: LocalDefId,
     inspect: ObligationInspector<'tcx>,
 ) -> &'tcx ty::TypeckResults<'tcx> {
+    // Closures' typeck results come from their outermost function,
+    // as they are part of the same "inference environment".
+    let typeck_root_def_id = tcx.typeck_root_def_id_local(def_id);
+    if typeck_root_def_id != def_id {
+        return tcx.typeck(typeck_root_def_id);
+    }
+
     typeck_with_inspect(tcx, def_id, Some(inspect))
 }
 
@@ -104,12 +111,7 @@ fn typeck_with_inspect<'tcx>(
     def_id: LocalDefId,
     inspector: Option<ObligationInspector<'tcx>>,
 ) -> &'tcx ty::TypeckResults<'tcx> {
-    // Closures' typeck results come from their outermost function,
-    // as they are part of the same "inference environment".
-    let typeck_root_def_id = tcx.typeck_root_def_id_local(def_id);
-    if typeck_root_def_id != def_id {
-        return tcx.typeck(typeck_root_def_id);
-    }
+    assert!(!tcx.is_typeck_child(def_id.to_def_id()));
 
     let id = tcx.local_def_id_to_hir_id(def_id);
     let node = tcx.hir_node(id);
@@ -660,7 +662,7 @@ fn fatally_break_rust(tcx: TyCtxt<'_>, span: Span) -> ! {
 pub fn provide(providers: &mut Providers) {
     *providers = Providers {
         method_autoderef_steps: method::probe::method_autoderef_steps,
-        typeck,
+        typeck_root,
         used_trait_imports,
         check_transmutes: intrinsicck::check_transmutes,
         ..*providers

--- a/compiler/rustc_incremental/src/persist/clean.rs
+++ b/compiler/rustc_incremental/src/persist/clean.rs
@@ -49,7 +49,7 @@ const BASE_FN: &[&str] = &[
     label_strs::type_of,
     // And a big part of compilation (that we eventually want to cache) is type inference
     // information:
-    label_strs::typeck,
+    label_strs::typeck_root,
 ];
 
 /// DepNodes for Hir, which is pretty much everything

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -1222,9 +1222,9 @@ rustc_queries! {
         separate_provide_extern
     }
 
-    query typeck(key: LocalDefId) -> &'tcx ty::TypeckResults<'tcx> {
+    query typeck_root(key: LocalDefId) -> &'tcx ty::TypeckResults<'tcx> {
         desc { "type-checking `{}`", tcx.def_path_str(key) }
-        cache_on_disk_if { !tcx.is_typeck_child(key.to_def_id()) }
+        cache_on_disk_if { true }
     }
 
     query used_trait_imports(key: LocalDefId) -> &'tcx UnordSet<LocalDefId> {

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -7,14 +7,15 @@ use rustc_data_structures::hash_table::HashTable;
 use rustc_data_structures::sharded::Sharded;
 use rustc_data_structures::sync::{AtomicU64, Lock, WorkerLocal};
 use rustc_errors::Diag;
+use rustc_hir::def_id::LocalDefId;
 use rustc_span::Span;
 
 use crate::dep_graph::{DepKind, DepNodeIndex, QuerySideEffect, SerializedDepNodeIndex};
 use crate::ich::StableHashingContext;
 use crate::queries::{ExternProviders, Providers, QueryArenas, QueryVTables, TaggedQueryKey};
 use crate::query::on_disk_cache::OnDiskCache;
-use crate::query::{QueryCache, QueryJob, QueryStackFrame};
-use crate::ty::TyCtxt;
+use crate::query::{IntoQueryKey, QueryCache, QueryJob, QueryStackFrame};
+use crate::ty::{self, TyCtxt};
 
 /// For a particular query, keeps track of "active" keys, i.e. keys whose
 /// evaluation has started but has not yet finished successfully.
@@ -200,7 +201,21 @@ pub struct TyCtxtEnsureDone<'tcx> {
     pub tcx: TyCtxt<'tcx>,
 }
 
+impl<'tcx> TyCtxtEnsureOk<'tcx> {
+    pub fn typeck(self, def_id: impl IntoQueryKey<LocalDefId>) {
+        self.typeck_root(
+            self.tcx.typeck_root_def_id(def_id.into_query_key().to_def_id()).expect_local(),
+        )
+    }
+}
+
 impl<'tcx> TyCtxt<'tcx> {
+    pub fn typeck(self, def_id: impl IntoQueryKey<LocalDefId>) -> &'tcx ty::TypeckResults<'tcx> {
+        self.typeck_root(
+            self.typeck_root_def_id(def_id.into_query_key().to_def_id()).expect_local(),
+        )
+    }
+
     /// Returns a transparent wrapper for `TyCtxt` which uses
     /// `span` as the location of queries performed through it.
     #[inline(always)]

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -309,19 +309,14 @@ pub(crate) fn create_config(
                 &EMPTY_SET
             };
             // In case typeck does end up being called, don't ICE in case there were name resolution errors
-            providers.queries.typeck = move |tcx, def_id| {
-                // Closures' tables come from their outermost function,
-                // as they are part of the same "inference environment".
-                // This avoids emitting errors for the parent twice (see similar code in `typeck_with_fallback`)
-                let typeck_root_def_id = tcx.typeck_root_def_id(def_id.to_def_id()).expect_local();
-                if typeck_root_def_id != def_id {
-                    return tcx.typeck(typeck_root_def_id);
-                }
+            providers.queries.typeck_root = move |tcx, def_id| {
+                // Panic before code below breaks in case of someone calls typeck_root directly
+                assert!(!tcx.is_typeck_child(def_id.to_def_id()));
 
                 let body = tcx.hir_body_owned_by(def_id);
                 debug!("visiting body for {def_id:?}");
                 EmitIgnoredResolutionErrors::new(tcx).visit_body(body);
-                (rustc_interface::DEFAULT_QUERY_PROVIDERS.queries.typeck)(tcx, def_id)
+                (rustc_interface::DEFAULT_QUERY_PROVIDERS.queries.typeck_root)(tcx, def_id)
             };
         }),
         extra_symbols: Vec::new(),

--- a/tests/incremental/callee_caller_cross_crate/b.rs
+++ b/tests/incremental/callee_caller_cross_crate/b.rs
@@ -7,7 +7,7 @@
 
 extern crate a;
 
-#[rustc_clean(except="typeck", cfg="rpass2")]
+#[rustc_clean(except="typeck_root", cfg="rpass2")]
 pub fn call_function0() {
     a::function0(77);
 }

--- a/tests/incremental/change_add_field/struct_point.rs
+++ b/tests/incremental/change_add_field/struct_point.rs
@@ -70,7 +70,7 @@ pub mod point {
 pub mod fn_with_type_in_sig {
     use point::Point;
 
-    #[rustc_clean(except="typeck,fn_sig,optimized_mir", cfg="cfail2")]
+    #[rustc_clean(except="typeck_root,fn_sig,optimized_mir", cfg="cfail2")]
     pub fn boop(p: Option<&Point>) -> f32 {
         p.map(|p| p.total()).unwrap_or(0.0)
     }
@@ -86,7 +86,7 @@ pub mod fn_with_type_in_sig {
 pub mod call_fn_with_type_in_sig {
     use fn_with_type_in_sig;
 
-    #[rustc_clean(except="typeck,optimized_mir", cfg="cfail2")]
+    #[rustc_clean(except="typeck_root,optimized_mir", cfg="cfail2")]
     pub fn bip() -> f32 {
         fn_with_type_in_sig::boop(None)
     }
@@ -102,7 +102,7 @@ pub mod call_fn_with_type_in_sig {
 pub mod fn_with_type_in_body {
     use point::Point;
 
-    #[rustc_clean(except="typeck,optimized_mir", cfg="cfail2")]
+    #[rustc_clean(except="typeck_root,optimized_mir", cfg="cfail2")]
     pub fn boop() -> f32 {
         Point::origin().total()
     }
@@ -125,7 +125,7 @@ pub mod call_fn_with_type_in_body {
 pub mod fn_make_struct {
     use point::Point;
 
-    #[rustc_clean(except="typeck,fn_sig,optimized_mir", cfg="cfail2")]
+    #[rustc_clean(except="typeck_root,fn_sig,optimized_mir", cfg="cfail2")]
     pub fn make_origin(p: Point) -> Point {
         Point { ..p }
     }
@@ -135,7 +135,7 @@ pub mod fn_make_struct {
 pub mod fn_read_field {
     use point::Point;
 
-    #[rustc_clean(except="typeck,fn_sig,optimized_mir", cfg="cfail2")]
+    #[rustc_clean(except="typeck_root,fn_sig,optimized_mir", cfg="cfail2")]
     pub fn get_x(p: Point) -> f32 {
         p.x
     }
@@ -145,7 +145,7 @@ pub mod fn_read_field {
 pub mod fn_write_field {
     use point::Point;
 
-    #[rustc_clean(except="typeck,fn_sig,optimized_mir", cfg="cfail2")]
+    #[rustc_clean(except="typeck_root,fn_sig,optimized_mir", cfg="cfail2")]
     pub fn inc_x(p: &mut Point) {
         p.x += 1.0;
     }

--- a/tests/incremental/change_crate_order/main.rs
+++ b/tests/incremental/change_crate_order/main.rs
@@ -19,7 +19,7 @@ extern crate a;
 use a::A;
 use b::B;
 
-//? #[rustc_clean(label="typeck", cfg="rpass2")]
+//? #[rustc_clean(label="typeck_root", cfg="rpass2")]
 pub fn main() {
     A + B;
 }

--- a/tests/incremental/change_private_fn/struct_point.rs
+++ b/tests/incremental/change_private_fn/struct_point.rs
@@ -54,8 +54,8 @@ pub mod fn_calls_methods_in_same_impl {
     // The cached result should actually be loaded from disk
     // (not just marked green) - for example, `DeadVisitor`
     // always runs during compilation as a "pass", and loads
-    // the typeck results for bodies.
-    #[rustc_clean(cfg="cfail2", loaded_from_disk="typeck")]
+    // the typeck_root results for bodies.
+    #[rustc_clean(cfg="cfail2", loaded_from_disk="typeck_root")]
     pub fn check() {
         let x = Point { x: 2.0, y: 2.0 };
         x.distance_from_origin();

--- a/tests/incremental/change_pub_inherent_method_sig/struct_point.rs
+++ b/tests/incremental/change_pub_inherent_method_sig/struct_point.rs
@@ -52,7 +52,7 @@ pub mod point {
 pub mod fn_calls_changed_method {
     use point::Point;
 
-    #[rustc_clean(except="typeck,optimized_mir", cfg="cfail2")]
+    #[rustc_clean(except="typeck_root,optimized_mir", cfg="cfail2")]
     pub fn check() {
         let p = Point { x: 2.0, y: 2.0 };
         p.distance_from_point(None);

--- a/tests/incremental/clean.rs
+++ b/tests/incremental/clean.rs
@@ -36,14 +36,14 @@ mod y {
         //[cfail2]~| ERROR `predicates_of(y)` should be dirty but is not
         //[cfail2]~| ERROR `type_of(y)` should be dirty but is not
         //[cfail2]~| ERROR `fn_sig(y)` should be dirty but is not
-        //[cfail2]~| ERROR `typeck(y)` should be clean but is not
+        //[cfail2]~| ERROR `typeck_root(y)` should be clean but is not
         x::x();
     }
 }
 
 mod z {
-    #[rustc_clean(except="typeck", cfg="cfail2")]
+    #[rustc_clean(except="typeck_root", cfg="cfail2")]
     pub fn z() {
-        //[cfail2]~^ ERROR `typeck(z)` should be dirty but is not
+        //[cfail2]~^ ERROR `typeck_root(z)` should be dirty but is not
     }
 }

--- a/tests/incremental/hashes/call_expressions.rs
+++ b/tests/incremental/hashes/call_expressions.rs
@@ -29,9 +29,9 @@ pub fn change_callee_function() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_callee_function() {
     callee2(1, 2)
@@ -63,9 +63,9 @@ mod change_callee_indirectly_function {
     #[cfg(not(any(cfail1,cfail4)))]
     use super::callee2 as callee;
 
-    #[rustc_clean(except="opt_hir_owner_nodes,typeck", cfg="cfail2")]
+    #[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,typeck", cfg="cfail5")]
+    #[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="cfail5")]
     #[rustc_clean(cfg="cfail6")]
     pub fn change_callee_indirectly_function() {
         callee(1, 2)
@@ -87,9 +87,9 @@ pub fn change_callee_method() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_callee_method() {
     let s = Struct;
@@ -125,9 +125,9 @@ pub fn change_ufcs_callee_method() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_ufcs_callee_method() {
     let s = Struct;
@@ -163,9 +163,9 @@ pub fn change_to_ufcs() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 // One might think this would be expanded in the opt_hir_owner_nodes/Mir, but it actually
 // results in slightly different hir_owner/Mir.
@@ -187,9 +187,9 @@ pub mod change_ufcs_callee_indirectly {
     #[cfg(not(any(cfail1,cfail4)))]
     use super::Struct2 as Struct;
 
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
     #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
     #[rustc_clean(cfg="cfail6")]
     pub fn change_ufcs_callee_indirectly() {
         let s = Struct;

--- a/tests/incremental/hashes/closure_expressions.rs
+++ b/tests/incremental/hashes/closure_expressions.rs
@@ -43,9 +43,9 @@ pub fn add_parameter() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn add_parameter() {
     let x = 0u32;
@@ -61,9 +61,9 @@ pub fn change_parameter_pattern() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_parameter_pattern() {
     let _ = |(x,): (u32,)| x;
@@ -96,9 +96,9 @@ pub fn add_type_ascription_to_parameter() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2", except = "opt_hir_owner_nodes, typeck")]
+#[rustc_clean(cfg = "cfail2", except = "opt_hir_owner_nodes, typeck_root")]
 #[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5", except = "opt_hir_owner_nodes, typeck")]
+#[rustc_clean(cfg = "cfail5", except = "opt_hir_owner_nodes, typeck_root")]
 #[rustc_clean(cfg = "cfail6")]
 pub fn add_type_ascription_to_parameter() {
     let closure = |x: u32| x + 1u32;
@@ -115,9 +115,9 @@ pub fn change_parameter_type() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir, typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir, typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_parameter_type() {
     let closure = |x: u16| (x as u64) + 1;

--- a/tests/incremental/hashes/enum_constructors.rs
+++ b/tests/incremental/hashes/enum_constructors.rs
@@ -63,9 +63,9 @@ pub fn change_field_order_struct_like() -> Enum {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 // FIXME(michaelwoerister):Interesting. I would have thought that that changes the MIR. And it
 // would if it were not all constants
@@ -104,9 +104,9 @@ pub fn change_constructor_path_struct_like() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_constructor_path_struct_like() {
     let _ = Enum2::Struct {
@@ -149,9 +149,9 @@ pub mod change_constructor_path_indirectly_struct_like {
     #[cfg(not(any(cfail1,cfail4)))]
     use super::Enum2 as TheEnum;
 
-    #[rustc_clean(cfg="cfail2", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck")]
+    #[rustc_clean(cfg="cfail2", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
     #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck")]
+    #[rustc_clean(cfg="cfail5", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
     #[rustc_clean(cfg="cfail6")]
     pub fn function() -> TheEnum {
         TheEnum::Struct {
@@ -211,12 +211,12 @@ pub fn change_constructor_path_tuple_like() {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(
     cfg="cfail2",
-    except="opt_hir_owner_nodes,typeck"
+    except="opt_hir_owner_nodes,typeck_root"
 )]
 #[rustc_clean(cfg="cfail3")]
 #[rustc_clean(
     cfg="cfail5",
-    except="opt_hir_owner_nodes,typeck"
+    except="opt_hir_owner_nodes,typeck_root"
 )]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_constructor_path_tuple_like() {
@@ -234,12 +234,12 @@ pub fn change_constructor_variant_tuple_like() {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(
     cfg="cfail2",
-    except="opt_hir_owner_nodes,typeck"
+    except="opt_hir_owner_nodes,typeck_root"
 )]
 #[rustc_clean(cfg="cfail3")]
 #[rustc_clean(
     cfg="cfail5",
-    except="opt_hir_owner_nodes,typeck"
+    except="opt_hir_owner_nodes,typeck_root"
 )]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_constructor_variant_tuple_like() {
@@ -254,9 +254,9 @@ pub mod change_constructor_path_indirectly_tuple_like {
     #[cfg(not(any(cfail1,cfail4)))]
     use super::Enum2 as TheEnum;
 
-    #[rustc_clean(cfg="cfail2", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck")]
+    #[rustc_clean(cfg="cfail2", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
     #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck")]
+    #[rustc_clean(cfg="cfail5", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
     #[rustc_clean(cfg="cfail6")]
     pub fn function() -> TheEnum {
         TheEnum::Tuple(0, 1, 2)
@@ -273,9 +273,9 @@ pub mod change_constructor_variant_indirectly_tuple_like {
     #[cfg(not(any(cfail1,cfail4)))]
     use super::Enum2::Tuple2 as Variant;
 
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
     #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
     #[rustc_clean(cfg="cfail6")]
     pub fn function() -> Enum2 {
         Variant(0, 1, 2)
@@ -302,9 +302,9 @@ pub fn change_constructor_path_c_like() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_constructor_path_c_like() {
     let _x = Clike2::B;
@@ -335,9 +335,9 @@ pub mod change_constructor_path_indirectly_c_like {
     #[cfg(not(any(cfail1,cfail4)))]
     use super::Clike2 as TheEnum;
 
-    #[rustc_clean(cfg="cfail2", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck")]
+    #[rustc_clean(cfg="cfail2", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
     #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck")]
+    #[rustc_clean(cfg="cfail5", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
     #[rustc_clean(cfg="cfail6")]
     pub fn function() -> TheEnum {
         TheEnum::B

--- a/tests/incremental/hashes/for_loops.rs
+++ b/tests/incremental/hashes/for_loops.rs
@@ -79,9 +79,9 @@ pub fn change_iteration_variable_pattern() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir, typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir, typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_iteration_variable_pattern() {
     let mut _x = 0;
@@ -129,9 +129,9 @@ pub fn add_break() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir, typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir, typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn add_break() {
     let mut _x = 0;

--- a/tests/incremental/hashes/function_interfaces.rs
+++ b/tests/incremental/hashes/function_interfaces.rs
@@ -26,12 +26,12 @@ pub fn add_parameter() {}
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(
     cfg = "cfail2",
-    except = "opt_hir_owner_nodes, optimized_mir, typeck, fn_sig"
+    except = "opt_hir_owner_nodes, optimized_mir, typeck_root, fn_sig"
 )]
 #[rustc_clean(cfg = "cfail3")]
 #[rustc_clean(
     cfg = "cfail5",
-    except = "opt_hir_owner_nodes, optimized_mir, typeck, fn_sig"
+    except = "opt_hir_owner_nodes, optimized_mir, typeck_root, fn_sig"
 )]
 #[rustc_clean(cfg = "cfail6")]
 pub fn add_parameter(p: i32) {}
@@ -56,12 +56,12 @@ pub fn type_of_parameter(p: i32) {}
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(
     cfg = "cfail2",
-    except = "opt_hir_owner_nodes, optimized_mir, typeck, fn_sig"
+    except = "opt_hir_owner_nodes, optimized_mir, typeck_root, fn_sig"
 )]
 #[rustc_clean(cfg = "cfail3")]
 #[rustc_clean(
     cfg = "cfail5",
-    except = "opt_hir_owner_nodes, optimized_mir, typeck, fn_sig"
+    except = "opt_hir_owner_nodes, optimized_mir, typeck_root, fn_sig"
 )]
 #[rustc_clean(cfg = "cfail6")]
 pub fn type_of_parameter(p: i64) {}
@@ -74,12 +74,12 @@ pub fn type_of_parameter_ref(p: &i32) {}
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(
     cfg = "cfail2",
-    except = "opt_hir_owner_nodes, optimized_mir, typeck, fn_sig"
+    except = "opt_hir_owner_nodes, optimized_mir, typeck_root, fn_sig"
 )]
 #[rustc_clean(cfg = "cfail3")]
 #[rustc_clean(
     cfg = "cfail5",
-    except = "opt_hir_owner_nodes, optimized_mir, typeck, fn_sig"
+    except = "opt_hir_owner_nodes, optimized_mir, typeck_root, fn_sig"
 )]
 #[rustc_clean(cfg = "cfail6")]
 pub fn type_of_parameter_ref(p: &mut i32) {}
@@ -92,12 +92,12 @@ pub fn order_of_parameters(p1: i32, p2: i64) {}
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(
     cfg = "cfail2",
-    except = "opt_hir_owner_nodes, optimized_mir, typeck, fn_sig"
+    except = "opt_hir_owner_nodes, optimized_mir, typeck_root, fn_sig"
 )]
 #[rustc_clean(cfg = "cfail3")]
 #[rustc_clean(
     cfg = "cfail5",
-    except = "opt_hir_owner_nodes, optimized_mir, typeck, fn_sig"
+    except = "opt_hir_owner_nodes, optimized_mir, typeck_root, fn_sig"
 )]
 #[rustc_clean(cfg = "cfail6")]
 pub fn order_of_parameters(p2: i64, p1: i32) {}
@@ -110,12 +110,12 @@ pub        fn make_unsafe() {}
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(
     cfg = "cfail2",
-    except = "opt_hir_owner_nodes, typeck, fn_sig"
+    except = "opt_hir_owner_nodes, typeck_root, fn_sig"
 )]
 #[rustc_clean(cfg = "cfail3")]
 #[rustc_clean(
     cfg = "cfail5",
-    except = "opt_hir_owner_nodes, typeck, fn_sig"
+    except = "opt_hir_owner_nodes, typeck_root, fn_sig"
 )]
 #[rustc_clean(cfg = "cfail6")]
 pub unsafe fn make_unsafe() {}
@@ -126,9 +126,9 @@ pub unsafe fn make_unsafe() {}
 pub            fn make_extern() {}
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2", except = "opt_hir_owner_nodes, typeck, fn_sig")]
+#[rustc_clean(cfg = "cfail2", except = "opt_hir_owner_nodes, typeck_root, fn_sig")]
 #[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5", except = "opt_hir_owner_nodes, typeck, fn_sig")]
+#[rustc_clean(cfg = "cfail5", except = "opt_hir_owner_nodes, typeck_root, fn_sig")]
 #[rustc_clean(cfg = "cfail6")]
 pub extern "C" fn make_extern() {}
 
@@ -303,9 +303,9 @@ pub fn return_impl_trait() -> i32        {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2", except = "opt_hir_owner_nodes, typeck, fn_sig")]
+#[rustc_clean(cfg = "cfail2", except = "opt_hir_owner_nodes, typeck_root, fn_sig")]
 #[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5", except = "opt_hir_owner_nodes, typeck, fn_sig, optimized_mir")]
+#[rustc_clean(cfg = "cfail5", except = "opt_hir_owner_nodes, typeck_root, fn_sig, optimized_mir")]
 #[rustc_clean(cfg = "cfail6")]
 pub fn return_impl_trait() -> impl Clone {
     0
@@ -321,7 +321,7 @@ pub fn change_return_impl_trait() -> impl Clone {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2", except = "opt_hir_owner_nodes")]
 #[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5", except = "opt_hir_owner_nodes, typeck")]
+#[rustc_clean(cfg = "cfail5", except = "opt_hir_owner_nodes, typeck_root")]
 #[rustc_clean(cfg = "cfail6")]
 pub fn change_return_impl_trait() -> impl  Copy {
     0u32
@@ -340,12 +340,12 @@ pub mod change_return_type_indirectly {
 
     #[rustc_clean(
         cfg = "cfail2",
-        except = "opt_hir_owner_nodes, optimized_mir, typeck, fn_sig"
+        except = "opt_hir_owner_nodes, optimized_mir, typeck_root, fn_sig"
     )]
     #[rustc_clean(cfg = "cfail3")]
     #[rustc_clean(
         cfg = "cfail5",
-        except = "opt_hir_owner_nodes, optimized_mir, typeck, fn_sig"
+        except = "opt_hir_owner_nodes, optimized_mir, typeck_root, fn_sig"
     )]
     #[rustc_clean(cfg = "cfail6")]
     pub fn indirect_return_type() -> ReturnType {
@@ -363,12 +363,12 @@ pub mod change_parameter_type_indirectly {
 
     #[rustc_clean(
         cfg = "cfail2",
-        except = "opt_hir_owner_nodes, optimized_mir, typeck, fn_sig"
+        except = "opt_hir_owner_nodes, optimized_mir, typeck_root, fn_sig"
     )]
     #[rustc_clean(cfg = "cfail3")]
     #[rustc_clean(
         cfg = "cfail5",
-        except = "opt_hir_owner_nodes, optimized_mir, typeck, fn_sig"
+        except = "opt_hir_owner_nodes, optimized_mir, typeck_root, fn_sig"
     )]
     #[rustc_clean(cfg = "cfail6")]
     pub fn indirect_parameter_type(p: ParameterType) {}

--- a/tests/incremental/hashes/if_expressions.rs
+++ b/tests/incremental/hashes/if_expressions.rs
@@ -28,9 +28,9 @@ pub fn change_condition(x: bool) -> u32 {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_condition(x: bool) -> u32 {
     if !x {
@@ -104,9 +104,9 @@ pub fn add_else_branch(x: bool) -> u32 {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn add_else_branch(x: bool) -> u32 {
     let mut ret = 1;
@@ -132,9 +132,9 @@ pub fn change_condition_if_let(x: Option<u32>) -> u32 {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_condition_if_let(x: Option<u32>) -> u32 {
     if let Some(_ ) = x {
@@ -157,9 +157,9 @@ pub fn change_then_branch_if_let(x: Option<u32>) -> u32 {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_then_branch_if_let(x: Option<u32>) -> u32 {
     if let Some(x) = x {
@@ -210,9 +210,9 @@ pub fn add_else_branch_if_let(x: Option<u32>) -> u32 {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
 #[rustc_clean(cfg="cfail6")]
 pub fn add_else_branch_if_let(x: Option<u32>) -> u32 {
     let mut ret = 1;

--- a/tests/incremental/hashes/indexing_expressions.rs
+++ b/tests/incremental/hashes/indexing_expressions.rs
@@ -75,9 +75,9 @@ fn add_lower_bound(slice: &[u32]) -> &[u32] {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,typeck", cfg="cfail2")]
+#[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,typeck", cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 fn add_lower_bound(slice: &[u32]) -> &[u32] {
     &slice[3..4]
@@ -92,9 +92,9 @@ fn add_upper_bound(slice: &[u32]) -> &[u32] {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,typeck", cfg="cfail2")]
+#[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,typeck", cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 fn add_upper_bound(slice: &[u32]) -> &[u32] {
     &slice[3..7]
@@ -109,9 +109,9 @@ fn change_mutability(slice: &mut [u32]) -> u32 {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,typeck", cfg="cfail2")]
+#[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,typeck", cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 fn change_mutability(slice: &mut [u32]) -> u32 {
     (&    slice[3..5])[0]
@@ -126,9 +126,9 @@ fn exclusive_to_inclusive_range(slice: &[u32]) -> &[u32] {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,typeck", cfg="cfail2")]
+#[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,typeck", cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 fn exclusive_to_inclusive_range(slice: &[u32]) -> &[u32] {
     &slice[3..=7]

--- a/tests/incremental/hashes/inherent_impls.rs
+++ b/tests/incremental/hashes/inherent_impls.rs
@@ -58,9 +58,9 @@ impl Foo {
 #[rustc_clean(cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl Foo {
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,promoted_mir,typeck")]
+    #[rustc_clean(cfg="cfail2",except="opt_hir_owner_nodes,optimized_mir,promoted_mir,typeck_root")]
     #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,promoted_mir,typeck")]
+    #[rustc_clean(cfg="cfail5",except="opt_hir_owner_nodes,optimized_mir,promoted_mir,typeck_root")]
     #[rustc_clean(cfg="cfail6")]
     pub fn method_body() {
         println!("Hello, world!");
@@ -89,9 +89,9 @@ impl Foo {
 #[rustc_clean(cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl Foo {
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
     #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
     #[rustc_clean(cfg="cfail6")]
     #[inline]
     pub fn method_body_inlined() {
@@ -147,12 +147,12 @@ impl Foo {
 impl Foo {
     #[rustc_clean(
         cfg="cfail2",
-        except="opt_hir_owner_nodes,fn_sig,generics_of,typeck,associated_item,optimized_mir",
+        except="opt_hir_owner_nodes,fn_sig,generics_of,typeck_root,associated_item,optimized_mir",
     )]
     #[rustc_clean(cfg="cfail3")]
     #[rustc_clean(
         cfg="cfail5",
-        except="opt_hir_owner_nodes,fn_sig,generics_of,typeck,associated_item,optimized_mir",
+        except="opt_hir_owner_nodes,fn_sig,generics_of,typeck_root,associated_item,optimized_mir",
     )]
     #[rustc_clean(cfg="cfail6")]
     pub fn method_selfness(&self) { }
@@ -174,9 +174,9 @@ impl Foo {
 #[rustc_clean(cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl Foo {
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,fn_sig,typeck,optimized_mir")]
+    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir")]
     #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,fn_sig,typeck,optimized_mir")]
+    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir")]
     #[rustc_clean(cfg="cfail6")]
     pub fn method_selfmutness(&mut self) { }
 }
@@ -224,9 +224,9 @@ impl Foo {
 #[rustc_clean(cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl Foo {
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,fn_sig,typeck,optimized_mir")]
+    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir")]
     #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,fn_sig,typeck,optimized_mir")]
+    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir")]
     #[rustc_clean(cfg="cfail6")]
     pub fn add_method_parameter(&self, _: i32) { }
 }
@@ -274,9 +274,9 @@ impl Foo {
 #[rustc_clean(cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl Foo {
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,fn_sig,optimized_mir,typeck")]
+    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,fn_sig,optimized_mir,typeck_root")]
     #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,fn_sig,optimized_mir,typeck")]
+    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,fn_sig,optimized_mir,typeck_root")]
     #[rustc_clean(cfg="cfail6")]
     pub fn change_method_return_type(&self) -> u32 { 0 }
 }
@@ -351,9 +351,9 @@ impl Foo {
 #[rustc_clean(cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl Foo {
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,fn_sig,typeck")]
+    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,fn_sig,typeck_root")]
     #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,fn_sig,typeck")]
+    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,fn_sig,typeck_root")]
     #[rustc_clean(cfg="cfail6")]
     pub unsafe fn make_method_unsafe(&self) { }
 }
@@ -376,9 +376,9 @@ impl Foo {
 #[rustc_clean(cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl Foo {
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,fn_sig,typeck")]
+    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,fn_sig,typeck_root")]
     #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,fn_sig,typeck")]
+    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,fn_sig,typeck_root")]
     #[rustc_clean(cfg="cfail6")]
     pub extern "C" fn make_method_extern(&self) { }
 }
@@ -401,9 +401,9 @@ impl Foo {
 #[rustc_clean(cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl Foo {
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,fn_sig,typeck")]
+    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,fn_sig,typeck_root")]
     #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,fn_sig,typeck")]
+    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,fn_sig,typeck_root")]
     #[rustc_clean(cfg="cfail6")]
     pub extern "system" fn change_method_calling_convention(&self) { }
 }
@@ -435,15 +435,15 @@ impl Foo {
 #[rustc_clean(cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl Foo {
-    // Warning: Note that `typeck` are coming up clean here.
+    // Warning: Note that `typeck_root` are coming up clean here.
     // The addition or removal of lifetime parameters that don't
     // appear in the arguments or fn body in any way does not, in
-    // fact, affect the `typeck` in any semantic way (at least
+    // fact, affect the `typeck_root` in any semantic way (at least
     // as of this writing). **However,** altering the order of
-    // lowering **can** cause it appear to affect the `typeck`:
+    // lowering **can** cause it appear to affect the `typeck_root`:
     // if we lower generics before the body, then the `HirId` for
     // things in the body will be affected. So if you start to see
-    // `typeck` appear dirty, that might be the cause. -nmatsakis
+    // `typeck_root` appear dirty, that might be the cause. -nmatsakis
     #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,fn_sig")]
     #[rustc_clean(cfg="cfail3")]
     #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,fn_sig,generics_of")]
@@ -484,14 +484,14 @@ impl Foo {
 #[rustc_clean(cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl Foo {
-    // Warning: Note that `typeck` are coming up clean here.
+    // Warning: Note that `typeck_root` are coming up clean here.
     // The addition or removal of type parameters that don't appear in
     // the arguments or fn body in any way does not, in fact, affect
-    // the `typeck` in any semantic way (at least as of this
+    // the `typeck_root` in any semantic way (at least as of this
     // writing). **However,** altering the order of lowering **can**
-    // cause it appear to affect the `typeck`: if we lower
+    // cause it appear to affect the `typeck_root`: if we lower
     // generics before the body, then the `HirId` for things in the
-    // body will be affected. So if you start to see `typeck`
+    // body will be affected. So if you start to see `typeck_root`
     // appear dirty, that might be the cause. -nmatsakis
     #[rustc_clean(
         cfg="cfail2",
@@ -576,14 +576,14 @@ impl Foo {
 #[rustc_clean(cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl Foo {
-    // Warning: Note that `typeck` are coming up clean here.
+    // Warning: Note that `typeck_root` are coming up clean here.
     // The addition or removal of bounds that don't appear in the
     // arguments or fn body in any way does not, in fact, affect the
-    // `typeck` in any semantic way (at least as of this
+    // `typeck_root` in any semantic way (at least as of this
     // writing). **However,** altering the order of lowering **can**
-    // cause it appear to affect the `typeck`: if we lower
+    // cause it appear to affect the `typeck_root`: if we lower
     // generics before the body, then the `HirId` for things in the
-    // body will be affected. So if you start to see `typeck`
+    // body will be affected. So if you start to see `typeck_root`
     // appear dirty, that might be the cause. -nmatsakis
     #[rustc_clean(
         cfg="cfail2",
@@ -625,14 +625,14 @@ impl Foo {
 #[rustc_clean(cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl Foo {
-    // Warning: Note that `typeck` are coming up clean here.
+    // Warning: Note that `typeck_root` are coming up clean here.
     // The addition or removal of bounds that don't appear in the
     // arguments or fn body in any way does not, in fact, affect the
-    // `typeck` in any semantic way (at least as of this
+    // `typeck_root` in any semantic way (at least as of this
     // writing). **However,** altering the order of lowering **can**
-    // cause it appear to affect the `typeck`: if we lower
+    // cause it appear to affect the `typeck_root`: if we lower
     // generics before the body, then the `HirId` for things in the
-    // body will be affected. So if you start to see `typeck`
+    // body will be affected. So if you start to see `typeck_root`
     // appear dirty, that might be the cause. -nmatsakis
     #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,predicates_of")]
     #[rustc_clean(cfg="cfail3")]
@@ -686,12 +686,12 @@ impl Bar<u32> {
 impl<T> Bar<T> {
     #[rustc_clean(
         cfg="cfail2",
-        except="generics_of,fn_sig,typeck,type_of,optimized_mir"
+        except="generics_of,fn_sig,typeck_root,type_of,optimized_mir"
     )]
     #[rustc_clean(cfg="cfail3")]
     #[rustc_clean(
         cfg="cfail5",
-        except="generics_of,fn_sig,typeck,type_of,optimized_mir"
+        except="generics_of,fn_sig,typeck_root,type_of,optimized_mir"
     )]
     #[rustc_clean(cfg="cfail6")]
     pub fn add_type_parameter_to_impl(&self) { }
@@ -711,9 +711,9 @@ impl Bar<u32> {
 #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
 #[rustc_clean(cfg="cfail6")]
 impl Bar<u64> {
-    #[rustc_clean(cfg="cfail2", except="fn_sig,optimized_mir,typeck")]
+    #[rustc_clean(cfg="cfail2", except="fn_sig,optimized_mir,typeck_root")]
     #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="fn_sig,optimized_mir,typeck")]
+    #[rustc_clean(cfg="cfail5", except="fn_sig,optimized_mir,typeck_root")]
     #[rustc_clean(cfg="cfail6")]
     pub fn change_impl_self_type(&self) { }
 }

--- a/tests/incremental/hashes/inherent_impls.rs
+++ b/tests/incremental/hashes/inherent_impls.rs
@@ -55,7 +55,7 @@ impl Foo {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl Foo {
     #[rustc_clean(cfg="cfail2",except="opt_hir_owner_nodes,optimized_mir,promoted_mir,typeck_root")]
@@ -86,7 +86,7 @@ impl Foo {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl Foo {
     #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
@@ -171,7 +171,7 @@ impl Foo {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl Foo {
     #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir")]
@@ -221,7 +221,7 @@ impl Foo {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl Foo {
     #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir")]
@@ -271,7 +271,7 @@ impl Foo {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl Foo {
     #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,fn_sig,optimized_mir,typeck_root")]
@@ -348,7 +348,7 @@ impl Foo {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl Foo {
     #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,fn_sig,typeck_root")]
@@ -373,7 +373,7 @@ impl Foo {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl Foo {
     #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,fn_sig,typeck_root")]
@@ -398,7 +398,7 @@ impl Foo {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl Foo {
     #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,fn_sig,typeck_root")]
@@ -432,7 +432,7 @@ impl Foo {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl Foo {
     // Warning: Note that `typeck_root` are coming up clean here.
@@ -481,7 +481,7 @@ impl Foo {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl Foo {
     // Warning: Note that `typeck_root` are coming up clean here.
@@ -573,7 +573,7 @@ impl Foo {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl Foo {
     // Warning: Note that `typeck_root` are coming up clean here.
@@ -622,7 +622,7 @@ impl Foo {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl Foo {
     // Warning: Note that `typeck_root` are coming up clean here.

--- a/tests/incremental/hashes/let_expressions.rs
+++ b/tests/incremental/hashes/let_expressions.rs
@@ -41,9 +41,9 @@ pub fn add_type() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn add_type() {
     let _x: u32 = 2u32;
@@ -58,9 +58,9 @@ pub fn change_type() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_type() {
     let _x: u8  = 2;
@@ -75,9 +75,9 @@ pub fn change_mutability_of_reference_type() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_mutability_of_reference_type() {
     let _x: &mut u64;
@@ -92,9 +92,9 @@ pub fn change_mutability_of_slot() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_mutability_of_slot() {
     let     _x: u64 = 0;
@@ -109,9 +109,9 @@ pub fn change_simple_binding_to_pattern() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_simple_binding_to_pattern() {
     let (_a, _b) = (0u8, 'x');
@@ -143,9 +143,9 @@ pub fn add_ref_in_pattern() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
 #[rustc_clean(cfg="cfail6")]
 pub fn add_ref_in_pattern() {
     let (ref _a, _b) = (1u8, 'y');
@@ -160,9 +160,9 @@ pub fn add_amp_in_pattern() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
 #[rustc_clean(cfg="cfail6")]
 pub fn add_amp_in_pattern() {
     let (&_a, _b) = (&1u8, 'y');
@@ -177,9 +177,9 @@ pub fn change_mutability_of_binding_in_pattern() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_mutability_of_binding_in_pattern() {
     let (mut _a, _b) = (99u8, 'q');
@@ -194,9 +194,9 @@ pub fn add_initializer() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
 #[rustc_clean(cfg="cfail6")]
 pub fn add_initializer() {
     let _x: i16 = 3i16;

--- a/tests/incremental/hashes/loop_expressions.rs
+++ b/tests/incremental/hashes/loop_expressions.rs
@@ -54,9 +54,9 @@ pub fn add_break() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir, typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir, typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn add_break() {
     let mut _x = 0;
@@ -131,9 +131,9 @@ pub fn change_break_label() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir, typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir, typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_break_label() {
     let mut _x = 0;
@@ -212,9 +212,9 @@ pub fn change_continue_to_break() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, typeck, optimized_mir")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, typeck_root, optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, typeck, optimized_mir")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, typeck_root, optimized_mir")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_continue_to_break() {
     let mut _x = 0;

--- a/tests/incremental/hashes/match_expressions.rs
+++ b/tests/incremental/hashes/match_expressions.rs
@@ -29,9 +29,9 @@ pub fn add_arm(x: u32) -> u32 {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn add_arm(x: u32) -> u32 {
     match x {
@@ -80,9 +80,9 @@ pub fn add_guard_clause(x: u32, y: bool) -> u32 {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn add_guard_clause(x: u32, y: bool) -> u32 {
     match x {
@@ -105,9 +105,9 @@ pub fn change_guard_clause(x: u32, y: bool) -> u32 {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_guard_clause(x: u32, y: bool) -> u32 {
     match x {
@@ -130,9 +130,9 @@ pub fn add_at_binding(x: u32) -> u32 {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn add_at_binding(x: u32) -> u32 {
     match x {
@@ -179,9 +179,9 @@ pub fn change_simple_name_to_pattern(x: u32) -> u32 {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_simple_name_to_pattern(x: u32) -> u32 {
     match (x, x & 1) {
@@ -228,9 +228,9 @@ pub fn change_mutability_of_binding_in_pattern(x: u32) -> u32 {
 
 // Ignore optimized_mir in cfail2, the only change to optimized MIR is a span.
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_mutability_of_binding_in_pattern(x: u32) -> u32 {
     match (x, x & 1) {
@@ -251,9 +251,9 @@ pub fn add_ref_to_binding_in_pattern(x: u32) -> u32 {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn add_ref_to_binding_in_pattern(x: u32) -> u32 {
     match (x, x & 1) {
@@ -274,9 +274,9 @@ pub fn add_amp_to_binding_in_pattern(x: u32) -> u32 {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn add_amp_to_binding_in_pattern(x: u32) -> u32 {
     match (&x, x & 1) {
@@ -323,9 +323,9 @@ pub fn add_alternative_to_arm(x: u32) -> u32 {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn add_alternative_to_arm(x: u32) -> u32 {
     match x {

--- a/tests/incremental/hashes/struct_constructors.rs
+++ b/tests/incremental/hashes/struct_constructors.rs
@@ -60,9 +60,9 @@ pub fn change_field_order_regular_struct() -> RegularStruct {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_field_order_regular_struct() -> RegularStruct {
     RegularStruct {
@@ -91,9 +91,9 @@ pub fn add_field_regular_struct() -> RegularStruct {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn add_field_regular_struct() -> RegularStruct {
     let struct1 = RegularStruct {
@@ -128,9 +128,9 @@ pub fn change_field_label_regular_struct() -> RegularStruct {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_field_label_regular_struct() -> RegularStruct {
     let struct1 = RegularStruct {
@@ -165,9 +165,9 @@ pub fn change_constructor_path_regular_struct() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_constructor_path_regular_struct() {
     let _ = RegularStruct2 {
@@ -186,9 +186,9 @@ pub mod change_constructor_path_indirectly_regular_struct {
     #[cfg(not(any(cfail1,cfail4)))]
     use super::RegularStruct2 as Struct;
 
-    #[rustc_clean(cfg="cfail2", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck")]
+    #[rustc_clean(cfg="cfail2", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
     #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck")]
+    #[rustc_clean(cfg="cfail5", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
     #[rustc_clean(cfg="cfail6")]
     pub fn function() -> Struct {
         Struct {
@@ -229,9 +229,9 @@ pub fn change_constructor_path_tuple_struct() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_constructor_path_tuple_struct() {
     let _ = TupleStruct2(0, 1, 2);
@@ -246,9 +246,9 @@ pub mod change_constructor_path_indirectly_tuple_struct {
     #[cfg(not(any(cfail1,cfail4)))]
     use super::TupleStruct2 as Struct;
 
-    #[rustc_clean(cfg="cfail5", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck")]
+    #[rustc_clean(cfg="cfail5", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
     #[rustc_clean(cfg="cfail6")]
-    #[rustc_clean(cfg="cfail2", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck")]
+    #[rustc_clean(cfg="cfail2", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
     #[rustc_clean(cfg="cfail3")]
     pub fn function() -> Struct {
         Struct(0, 1, 2)

--- a/tests/incremental/hashes/trait_defs.rs
+++ b/tests/incremental/hashes/trait_defs.rs
@@ -356,9 +356,9 @@ trait TraitChangeModeSelfOwnToMut: Sized {
 #[rustc_clean(cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 trait TraitChangeModeSelfOwnToMut: Sized {
-    #[rustc_clean(except="opt_hir_owner_nodes,typeck,optimized_mir", cfg="cfail2")]
+    #[rustc_clean(except="opt_hir_owner_nodes,typeck_root,optimized_mir", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,typeck,optimized_mir", cfg="cfail5")]
+    #[rustc_clean(except="opt_hir_owner_nodes,typeck_root,optimized_mir", cfg="cfail5")]
     #[rustc_clean(cfg="cfail6")]
     fn method(mut self) {}
 }

--- a/tests/incremental/hashes/trait_defs.rs
+++ b/tests/incremental/hashes/trait_defs.rs
@@ -353,7 +353,7 @@ trait TraitChangeModeSelfOwnToMut: Sized {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 trait TraitChangeModeSelfOwnToMut: Sized {
     #[rustc_clean(except="opt_hir_owner_nodes,typeck_root,optimized_mir", cfg="cfail2")]

--- a/tests/incremental/hashes/trait_impls.rs
+++ b/tests/incremental/hashes/trait_impls.rs
@@ -76,7 +76,7 @@ impl ChangeMethodBodyTrait for Foo {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl ChangeMethodBodyTrait for Foo {
     #[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="cfail2")]
@@ -111,7 +111,7 @@ impl ChangeMethodBodyTraitInlined for Foo {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl ChangeMethodBodyTraitInlined for Foo {
     #[rustc_clean(except="opt_hir_owner_nodes,typeck_root,optimized_mir", cfg="cfail2")]
@@ -222,7 +222,7 @@ pub trait ChangeMethodSelfmutnessTrait {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl ChangeMethodSelfmutnessTrait for Foo {
     #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir", cfg="cfail2")]
@@ -404,7 +404,7 @@ pub trait AddArgumentTrait {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl AddArgumentTrait for Foo {
     #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir", cfg="cfail2")]
@@ -438,7 +438,7 @@ pub trait ChangeArgumentTypeTrait {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl ChangeArgumentTypeTrait for Foo {
     #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir", cfg="cfail2")]

--- a/tests/incremental/hashes/trait_impls.rs
+++ b/tests/incremental/hashes/trait_impls.rs
@@ -79,9 +79,9 @@ impl ChangeMethodBodyTrait for Foo {
 #[rustc_clean(cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl ChangeMethodBodyTrait for Foo {
-    #[rustc_clean(except="opt_hir_owner_nodes,typeck", cfg="cfail2")]
+    #[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,typeck", cfg="cfail5")]
+    #[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="cfail5")]
     #[rustc_clean(cfg="cfail6")]
     fn method_name() {
         ()
@@ -114,9 +114,9 @@ impl ChangeMethodBodyTraitInlined for Foo {
 #[rustc_clean(cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl ChangeMethodBodyTraitInlined for Foo {
-    #[rustc_clean(except="opt_hir_owner_nodes,typeck,optimized_mir", cfg="cfail2")]
+    #[rustc_clean(except="opt_hir_owner_nodes,typeck_root,optimized_mir", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,typeck,optimized_mir", cfg="cfail5")]
+    #[rustc_clean(except="opt_hir_owner_nodes,typeck_root,optimized_mir", cfg="cfail5")]
     #[rustc_clean(cfg="cfail6")]
     #[inline]
     fn method_name() {
@@ -148,12 +148,12 @@ pub trait ChangeMethodSelfnessTrait {
 #[rustc_clean(cfg="cfail6")]
 impl ChangeMethodSelfnessTrait for Foo {
     #[rustc_clean(
-        except="opt_hir_owner_nodes,associated_item,generics_of,fn_sig,typeck,optimized_mir",
+        except="opt_hir_owner_nodes,associated_item,generics_of,fn_sig,typeck_root,optimized_mir",
         cfg="cfail2",
     )]
     #[rustc_clean(cfg="cfail3")]
     #[rustc_clean(
-        except="opt_hir_owner_nodes,associated_item,generics_of,fn_sig,typeck,optimized_mir",
+        except="opt_hir_owner_nodes,associated_item,generics_of,fn_sig,typeck_root,optimized_mir",
         cfg="cfail5",
     )]
     #[rustc_clean(cfg="cfail6")]
@@ -186,12 +186,12 @@ pub trait RemoveMethodSelfnessTrait {
 #[rustc_clean(cfg="cfail6")]
 impl RemoveMethodSelfnessTrait for Foo {
     #[rustc_clean(
-        except="opt_hir_owner_nodes,associated_item,generics_of,fn_sig,typeck,optimized_mir",
+        except="opt_hir_owner_nodes,associated_item,generics_of,fn_sig,typeck_root,optimized_mir",
         cfg="cfail2",
     )]
     #[rustc_clean(cfg="cfail3")]
     #[rustc_clean(
-        except="opt_hir_owner_nodes,associated_item,generics_of,fn_sig,typeck,optimized_mir",
+        except="opt_hir_owner_nodes,associated_item,generics_of,fn_sig,typeck_root,optimized_mir",
         cfg="cfail5",
     )]
     #[rustc_clean(cfg="cfail6")]
@@ -225,9 +225,9 @@ pub trait ChangeMethodSelfmutnessTrait {
 #[rustc_clean(cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl ChangeMethodSelfmutnessTrait for Foo {
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck,optimized_mir", cfg="cfail2")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck,optimized_mir", cfg="cfail5")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir", cfg="cfail5")]
     #[rustc_clean(cfg="cfail6")]
     fn method_name(&mut self) {}
 }
@@ -407,9 +407,9 @@ pub trait AddArgumentTrait {
 #[rustc_clean(cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl AddArgumentTrait for Foo {
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck,optimized_mir", cfg="cfail2")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck,optimized_mir", cfg="cfail5")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir", cfg="cfail5")]
     #[rustc_clean(cfg="cfail6")]
     fn method_name(&self, _x: u32) { }
 }
@@ -441,9 +441,9 @@ pub trait ChangeArgumentTypeTrait {
 #[rustc_clean(cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl ChangeArgumentTypeTrait for Foo {
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck,optimized_mir", cfg="cfail2")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck,optimized_mir", cfg="cfail5")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir", cfg="cfail5")]
     #[rustc_clean(cfg="cfail6")]
     fn method_name(&self, _x: char) { }
 }
@@ -469,12 +469,12 @@ impl AddTypeParameterToImpl<u32> for Bar<u32> {
 #[rustc_clean(cfg="cfail6")]
 impl<TTT> AddTypeParameterToImpl<TTT> for Bar<TTT> {
     #[rustc_clean(
-        except="opt_hir_owner_nodes,generics_of,fn_sig,type_of,typeck,optimized_mir",
+        except="opt_hir_owner_nodes,generics_of,fn_sig,type_of,typeck_root,optimized_mir",
         cfg="cfail2",
     )]
     #[rustc_clean(cfg="cfail3")]
     #[rustc_clean(
-        except="opt_hir_owner_nodes,generics_of,fn_sig,type_of,typeck,optimized_mir",
+        except="opt_hir_owner_nodes,generics_of,fn_sig,type_of,typeck_root,optimized_mir",
         cfg="cfail5",
     )]
     #[rustc_clean(cfg="cfail6")]
@@ -499,9 +499,9 @@ impl ChangeSelfTypeOfImpl for u32 {
 #[rustc_clean(except="opt_hir_owner_nodes,impl_trait_header", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl ChangeSelfTypeOfImpl for u64 {
-    #[rustc_clean(except="fn_sig,typeck,optimized_mir", cfg="cfail2")]
+    #[rustc_clean(except="fn_sig,typeck_root,optimized_mir", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="fn_sig,typeck,optimized_mir", cfg="cfail5")]
+    #[rustc_clean(except="fn_sig,typeck_root,optimized_mir", cfg="cfail5")]
     #[rustc_clean(cfg="cfail6")]
     fn id(self) -> Self { self }
 }

--- a/tests/incremental/hashes/unary_and_binary_exprs.rs
+++ b/tests/incremental/hashes/unary_and_binary_exprs.rs
@@ -418,9 +418,9 @@ pub fn type_cast(a: u8) -> u64 {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir,typeck", cfg="cfail2")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir,typeck_root", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir,typeck", cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir,typeck_root", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 pub fn type_cast(a: u8) -> u64 {
     let b = a as u32;

--- a/tests/incremental/hashes/while_let_loops.rs
+++ b/tests/incremental/hashes/while_let_loops.rs
@@ -79,9 +79,9 @@ pub fn add_break() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn add_break() {
     let mut _x = 0;

--- a/tests/incremental/hashes/while_loops.rs
+++ b/tests/incremental/hashes/while_loops.rs
@@ -79,9 +79,9 @@ pub fn add_break() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir, typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir, typeck")]
+#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
 #[rustc_clean(cfg="cfail6")]
 pub fn add_break() {
     let mut _x = 0;

--- a/tests/incremental/hygiene/auxiliary/cached_hygiene.rs
+++ b/tests/incremental/hygiene/auxiliary/cached_hygiene.rs
@@ -13,7 +13,7 @@ macro_rules! first_macro {
     }
 }
 
-#[rustc_clean(except="opt_hir_owner_nodes,typeck,optimized_mir", cfg="rpass2")]
+#[rustc_clean(except="opt_hir_owner_nodes,typeck_root,optimized_mir", cfg="rpass2")]
 #[inline(always)]
 pub fn changed_fn() {
     // This will cause additional hygiene to be generate,

--- a/tests/incremental/ich_method_call_trait_scope.rs
+++ b/tests/incremental/ich_method_call_trait_scope.rs
@@ -27,7 +27,7 @@ mod mod3 {
     #[cfg(rpass2)]
     use Trait2;
 
-    #[rustc_clean(except="typeck", cfg="rpass2")]
+    #[rustc_clean(except="typeck_root", cfg="rpass2")]
     fn bar() {
         ().method();
     }

--- a/tests/incremental/ich_resolve_results.rs
+++ b/tests/incremental/ich_resolve_results.rs
@@ -31,13 +31,13 @@ mod mod3 {
     use mod2::Foo;
 
     #[rustc_clean(cfg="rpass2")]
-    #[rustc_clean(except="opt_hir_owner_nodes,typeck", cfg="rpass3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="rpass3")]
     fn in_expr() {
         Foo(0);
     }
 
     #[rustc_clean(cfg="rpass2")]
-    #[rustc_clean(except="opt_hir_owner_nodes,typeck", cfg="rpass3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="rpass3")]
     fn in_type() {
         test::<Foo>();
     }

--- a/tests/incremental/issue-42602.rs
+++ b/tests/incremental/issue-42602.rs
@@ -1,7 +1,7 @@
 // Regression test for #42602. It used to be that we had
 // a dep-graph like
 //
-//     typeck(foo) -> FnOnce -> typeck(bar)
+//     typeck_root(foo) -> FnOnce -> typeck_root(bar)
 //
 // This was fixed by improving the resolution of the `FnOnce` trait
 // selection node.

--- a/tests/incremental/rlib_cross_crate/b.rs
+++ b/tests/incremental/rlib_cross_crate/b.rs
@@ -13,7 +13,7 @@
 
 extern crate a;
 
-#[rustc_clean(except="typeck,optimized_mir", cfg="rpass2")]
+#[rustc_clean(except="typeck_root,optimized_mir", cfg="rpass2")]
 #[rustc_clean(cfg="rpass3")]
 pub fn use_X() -> u32 {
     let x: a::X = 22;

--- a/tests/incremental/string_constant.rs
+++ b/tests/incremental/string_constant.rs
@@ -7,7 +7,7 @@
 #![crate_type = "rlib"]
 
 // Here the only thing which changes is the string constant in `x`.
-// Therefore, the compiler deduces (correctly) that typeck is not
+// Therefore, the compiler deduces (correctly) that typeck_root is not
 // needed even for callers of `x`.
 
 pub mod x {

--- a/tests/incremental/struct_add_field.rs
+++ b/tests/incremental/struct_add_field.rs
@@ -22,12 +22,12 @@ pub struct Y {
     pub y: char
 }
 
-#[rustc_clean(except="fn_sig,typeck", cfg="rpass2")]
+#[rustc_clean(except="fn_sig,typeck_root", cfg="rpass2")]
 pub fn use_X(x: X) -> u32 {
     x.x as u32
 }
 
-#[rustc_clean(except="typeck", cfg="rpass2")]
+#[rustc_clean(except="typeck_root", cfg="rpass2")]
 pub fn use_EmbedX(embed: EmbedX) -> u32 {
     embed.x.x as u32
 }

--- a/tests/incremental/struct_change_field_name.rs
+++ b/tests/incremental/struct_change_field_name.rs
@@ -26,7 +26,7 @@ pub struct Y {
     pub y: char
 }
 
-#[rustc_clean(except="typeck", cfg="cfail2")]
+#[rustc_clean(except="typeck_root", cfg="cfail2")]
 pub fn use_X() -> u32 {
     let x: X = X { x: 22 };
     //[cfail2]~^ ERROR struct `X` has no field named `x`
@@ -34,7 +34,7 @@ pub fn use_X() -> u32 {
     //[cfail2]~^ ERROR no field `x` on type `X`
 }
 
-#[rustc_clean(except="typeck", cfg="cfail2")]
+#[rustc_clean(except="typeck_root", cfg="cfail2")]
 pub fn use_EmbedX(embed: EmbedX) -> u32 {
     embed.x.x as u32
     //[cfail2]~^ ERROR no field `x` on type `X`

--- a/tests/incremental/struct_change_field_type.rs
+++ b/tests/incremental/struct_change_field_type.rs
@@ -25,13 +25,13 @@ pub struct Y {
     pub y: char
 }
 
-#[rustc_clean(except="typeck", cfg="rpass2")]
+#[rustc_clean(except="typeck_root", cfg="rpass2")]
 pub fn use_X() -> u32 {
     let x: X = X { x: 22 };
     x.x as u32
 }
 
-#[rustc_clean(except="typeck", cfg="rpass2")]
+#[rustc_clean(except="typeck_root", cfg="rpass2")]
 pub fn use_EmbedX(x: EmbedX) -> u32 {
     let x: X = X { x: 22 };
     x.x as u32

--- a/tests/incremental/struct_change_field_type_cross_crate/b.rs
+++ b/tests/incremental/struct_change_field_type_cross_crate/b.rs
@@ -9,13 +9,13 @@ extern crate a;
 
 use a::*;
 
-#[rustc_clean(except="typeck", cfg="rpass2")]
+#[rustc_clean(except="typeck_root", cfg="rpass2")]
 pub fn use_X() -> u32 {
     let x: X = X { x: 22 };
     x.x as u32
 }
 
-#[rustc_clean(except="typeck", cfg="rpass2")]
+#[rustc_clean(except="typeck_root", cfg="rpass2")]
 pub fn use_EmbedX(embed: EmbedX) -> u32 {
     embed.x.x as u32
 }

--- a/tests/incremental/struct_remove_field.rs
+++ b/tests/incremental/struct_remove_field.rs
@@ -26,12 +26,12 @@ pub struct Y {
     pub y: char
 }
 
-#[rustc_clean(except="typeck,fn_sig", cfg="rpass2")]
+#[rustc_clean(except="typeck_root,fn_sig", cfg="rpass2")]
 pub fn use_X(x: X) -> u32 {
     x.x as u32
 }
 
-#[rustc_clean(except="typeck", cfg="rpass2")]
+#[rustc_clean(except="typeck_root", cfg="rpass2")]
 pub fn use_EmbedX(embed: EmbedX) -> u32 {
     embed.x.x as u32
 }

--- a/tests/incremental/type_alias_cross_crate/b.rs
+++ b/tests/incremental/type_alias_cross_crate/b.rs
@@ -7,7 +7,7 @@
 
 extern crate a;
 
-#[rustc_clean(except="typeck", cfg="rpass2")]
+#[rustc_clean(except="typeck_root", cfg="rpass2")]
 #[rustc_clean(cfg="rpass3")]
 pub fn use_X() -> u32 {
     let x: a::X = 22;

--- a/tests/ui/dep-graph/dep-graph-assoc-type-codegen.rs
+++ b/tests/ui/dep-graph/dep-graph-assoc-type-codegen.rs
@@ -26,7 +26,7 @@ mod x {
 mod y {
     use crate::Foo;
 
-    #[rustc_then_this_would_need(typeck)] //~ ERROR OK
+    #[rustc_then_this_would_need(typeck_root)] //~ ERROR OK
     pub fn use_char_assoc() {
         // Careful here: in the representation, <char as Foo>::T gets
         // normalized away, so at a certain point we had no edge to

--- a/tests/ui/dep-graph/dep-graph-assoc-type-codegen.stderr
+++ b/tests/ui/dep-graph/dep-graph-assoc-type-codegen.stderr
@@ -1,8 +1,8 @@
 error: OK
   --> $DIR/dep-graph-assoc-type-codegen.rs:29:34
    |
-LL |     #[rustc_then_this_would_need(typeck)]
-   |                                  ^^^^^^
+LL |     #[rustc_then_this_would_need(typeck_root)]
+   |                                  ^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/dep-graph/dep-graph-caller-callee.rs
+++ b/tests/ui/dep-graph/dep-graph-caller-callee.rs
@@ -18,7 +18,7 @@ mod y {
     use crate::x;
 
     // These dependencies SHOULD exist:
-    #[rustc_then_this_would_need(typeck)] //~ ERROR OK
+    #[rustc_then_this_would_need(typeck_root)] //~ ERROR OK
     pub fn y() {
         x::x();
     }
@@ -29,7 +29,7 @@ mod z {
 
     // These are expected to yield errors, because changes to `x`
     // affect the BODY of `y`, but not its signature.
-    #[rustc_then_this_would_need(typeck)] //~ ERROR no path
+    #[rustc_then_this_would_need(typeck_root)] //~ ERROR no path
     pub fn z() {
         y::y();
     }

--- a/tests/ui/dep-graph/dep-graph-caller-callee.stderr
+++ b/tests/ui/dep-graph/dep-graph-caller-callee.stderr
@@ -1,14 +1,14 @@
 error: OK
   --> $DIR/dep-graph-caller-callee.rs:21:34
    |
-LL |     #[rustc_then_this_would_need(typeck)]
-   |                                  ^^^^^^
+LL |     #[rustc_then_this_would_need(typeck_root)]
+   |                                  ^^^^^^^^^^^
 
-error: no path from `x` to `typeck`
+error: no path from `x` to `typeck_root`
   --> $DIR/dep-graph-caller-callee.rs:32:34
    |
-LL |     #[rustc_then_this_would_need(typeck)]
-   |                                  ^^^^^^
+LL |     #[rustc_then_this_would_need(typeck_root)]
+   |                                  ^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/dep-graph/dep-graph-struct-signature.rs
+++ b/tests/ui/dep-graph/dep-graph-struct-signature.rs
@@ -34,11 +34,11 @@ mod signatures {
     }
 
     #[rustc_then_this_would_need(fn_sig)] //~ ERROR OK
-    #[rustc_then_this_would_need(typeck)] //~ ERROR OK
+    #[rustc_then_this_would_need(typeck_root)] //~ ERROR OK
     fn some_fn(x: WillChange) { }
 
     #[rustc_then_this_would_need(fn_sig)] //~ ERROR OK
-    #[rustc_then_this_would_need(typeck)] //~ ERROR OK
+    #[rustc_then_this_would_need(typeck_root)] //~ ERROR OK
     fn new_foo(x: u32, y: u32) -> WillChange {
         WillChange { x: x, y: y }
     }
@@ -46,14 +46,14 @@ mod signatures {
     #[rustc_then_this_would_need(type_of)] //~ ERROR OK
     impl WillChange {
         #[rustc_then_this_would_need(fn_sig)] //~ ERROR OK
-        #[rustc_then_this_would_need(typeck)] //~ ERROR OK
+        #[rustc_then_this_would_need(typeck_root)] //~ ERROR OK
         fn new(x: u32, y: u32) -> WillChange { loop { } }
     }
 
     #[rustc_then_this_would_need(type_of)] //~ ERROR OK
     impl WillChange {
         #[rustc_then_this_would_need(fn_sig)] //~ ERROR OK
-        #[rustc_then_this_would_need(typeck)] //~ ERROR OK
+        #[rustc_then_this_would_need(typeck_root)] //~ ERROR OK
         fn method(&self, x: u32) { }
     }
 
@@ -82,6 +82,6 @@ mod invalid_signatures {
     fn b(x: WontChange) { }
 
     #[rustc_then_this_would_need(fn_sig)] //~ ERROR no path from `WillChange`
-    #[rustc_then_this_would_need(typeck)] //~ ERROR no path from `WillChange`
+    #[rustc_then_this_would_need(typeck_root)] //~ ERROR no path from `WillChange`
     fn c(x: u32) { }
 }

--- a/tests/ui/dep-graph/dep-graph-struct-signature.stderr
+++ b/tests/ui/dep-graph/dep-graph-struct-signature.stderr
@@ -25,8 +25,8 @@ LL |     #[rustc_then_this_would_need(fn_sig)]
 error: OK
   --> $DIR/dep-graph-struct-signature.rs:37:34
    |
-LL |     #[rustc_then_this_would_need(typeck)]
-   |                                  ^^^^^^
+LL |     #[rustc_then_this_would_need(typeck_root)]
+   |                                  ^^^^^^^^^^^
 
 error: OK
   --> $DIR/dep-graph-struct-signature.rs:40:34
@@ -37,8 +37,8 @@ LL |     #[rustc_then_this_would_need(fn_sig)]
 error: OK
   --> $DIR/dep-graph-struct-signature.rs:41:34
    |
-LL |     #[rustc_then_this_would_need(typeck)]
-   |                                  ^^^^^^
+LL |     #[rustc_then_this_would_need(typeck_root)]
+   |                                  ^^^^^^^^^^^
 
 error: OK
   --> $DIR/dep-graph-struct-signature.rs:46:34
@@ -88,11 +88,11 @@ error: no path from `WillChange` to `fn_sig`
 LL |     #[rustc_then_this_would_need(fn_sig)]
    |                                  ^^^^^^
 
-error: no path from `WillChange` to `typeck`
+error: no path from `WillChange` to `typeck_root`
   --> $DIR/dep-graph-struct-signature.rs:85:34
    |
-LL |     #[rustc_then_this_would_need(typeck)]
-   |                                  ^^^^^^
+LL |     #[rustc_then_this_would_need(typeck_root)]
+   |                                  ^^^^^^^^^^^
 
 error: OK
   --> $DIR/dep-graph-struct-signature.rs:32:38
@@ -115,8 +115,8 @@ LL |         #[rustc_then_this_would_need(fn_sig)]
 error: OK
   --> $DIR/dep-graph-struct-signature.rs:49:38
    |
-LL |         #[rustc_then_this_would_need(typeck)]
-   |                                      ^^^^^^
+LL |         #[rustc_then_this_would_need(typeck_root)]
+   |                                      ^^^^^^^^^^^
 
 error: OK
   --> $DIR/dep-graph-struct-signature.rs:55:38
@@ -127,8 +127,8 @@ LL |         #[rustc_then_this_would_need(fn_sig)]
 error: OK
   --> $DIR/dep-graph-struct-signature.rs:56:38
    |
-LL |         #[rustc_then_this_would_need(typeck)]
-   |                                      ^^^^^^
+LL |         #[rustc_then_this_would_need(typeck_root)]
+   |                                      ^^^^^^^^^^^
 
 error: aborting due to 22 previous errors
 

--- a/tests/ui/dep-graph/dep-graph-trait-impl-two-traits-same-method.rs
+++ b/tests/ui/dep-graph/dep-graph-trait-impl-two-traits-same-method.rs
@@ -30,7 +30,7 @@ mod x {
 mod y {
     use crate::{Foo, Bar};
 
-    #[rustc_then_this_would_need(typeck)] //~ ERROR OK
+    #[rustc_then_this_would_need(typeck_root)] //~ ERROR OK
     pub fn with_char() {
         char::method('a');
     }
@@ -39,7 +39,7 @@ mod y {
 mod z {
     use crate::y;
 
-    #[rustc_then_this_would_need(typeck)] //~ ERROR no path
+    #[rustc_then_this_would_need(typeck_root)] //~ ERROR no path
     pub fn z() {
         y::with_char();
     }

--- a/tests/ui/dep-graph/dep-graph-trait-impl-two-traits-same-method.stderr
+++ b/tests/ui/dep-graph/dep-graph-trait-impl-two-traits-same-method.stderr
@@ -1,14 +1,14 @@
 error: OK
   --> $DIR/dep-graph-trait-impl-two-traits-same-method.rs:33:34
    |
-LL |     #[rustc_then_this_would_need(typeck)]
-   |                                  ^^^^^^
+LL |     #[rustc_then_this_would_need(typeck_root)]
+   |                                  ^^^^^^^^^^^
 
-error: no path from `x::<impl Foo for u32>` to `typeck`
+error: no path from `x::<impl Foo for u32>` to `typeck_root`
   --> $DIR/dep-graph-trait-impl-two-traits-same-method.rs:42:34
    |
-LL |     #[rustc_then_this_would_need(typeck)]
-   |                                  ^^^^^^
+LL |     #[rustc_then_this_would_need(typeck_root)]
+   |                                  ^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/dep-graph/dep-graph-trait-impl-two-traits.rs
+++ b/tests/ui/dep-graph/dep-graph-trait-impl-two-traits.rs
@@ -29,7 +29,7 @@ mod x {
 mod y {
     use crate::{Foo, Bar};
 
-    #[rustc_then_this_would_need(typeck)] //~ ERROR no path
+    #[rustc_then_this_would_need(typeck_root)] //~ ERROR no path
     pub fn call_bar() {
         char::bar('a');
     }
@@ -38,7 +38,7 @@ mod y {
 mod z {
     use crate::y;
 
-    #[rustc_then_this_would_need(typeck)] //~ ERROR no path
+    #[rustc_then_this_would_need(typeck_root)] //~ ERROR no path
     pub fn z() {
         y::call_bar();
     }

--- a/tests/ui/dep-graph/dep-graph-trait-impl-two-traits.stderr
+++ b/tests/ui/dep-graph/dep-graph-trait-impl-two-traits.stderr
@@ -1,14 +1,14 @@
-error: no path from `x::<impl Foo for char>` to `typeck`
+error: no path from `x::<impl Foo for char>` to `typeck_root`
   --> $DIR/dep-graph-trait-impl-two-traits.rs:32:34
    |
-LL |     #[rustc_then_this_would_need(typeck)]
-   |                                  ^^^^^^
+LL |     #[rustc_then_this_would_need(typeck_root)]
+   |                                  ^^^^^^^^^^^
 
-error: no path from `x::<impl Foo for char>` to `typeck`
+error: no path from `x::<impl Foo for char>` to `typeck_root`
   --> $DIR/dep-graph-trait-impl-two-traits.rs:41:34
    |
-LL |     #[rustc_then_this_would_need(typeck)]
-   |                                  ^^^^^^
+LL |     #[rustc_then_this_would_need(typeck_root)]
+   |                                  ^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/dep-graph/dep-graph-trait-impl.rs
+++ b/tests/ui/dep-graph/dep-graph-trait-impl.rs
@@ -25,22 +25,22 @@ mod x {
 mod y {
     use crate::Foo;
 
-    #[rustc_then_this_would_need(typeck)] //~ ERROR OK
+    #[rustc_then_this_would_need(typeck_root)] //~ ERROR OK
     pub fn with_char() {
         char::method('a');
     }
 
-    #[rustc_then_this_would_need(typeck)] //~ ERROR OK
+    #[rustc_then_this_would_need(typeck_root)] //~ ERROR OK
     pub fn take_foo_with_char() {
         take_foo::<char>('a');
     }
 
-    #[rustc_then_this_would_need(typeck)] //~ ERROR OK
+    #[rustc_then_this_would_need(typeck_root)] //~ ERROR OK
     pub fn with_u32() {
         u32::method(22);
     }
 
-    #[rustc_then_this_would_need(typeck)] //~ ERROR OK
+    #[rustc_then_this_would_need(typeck_root)] //~ ERROR OK
     pub fn take_foo_with_u32() {
         take_foo::<u32>(22);
     }
@@ -53,7 +53,7 @@ mod z {
 
     // These are expected to yield errors, because changes to `x`
     // affect the BODY of `y`, but not its signature.
-    #[rustc_then_this_would_need(typeck)] //~ ERROR no path
+    #[rustc_then_this_would_need(typeck_root)] //~ ERROR no path
     pub fn z() {
         y::with_char();
         y::with_u32();

--- a/tests/ui/dep-graph/dep-graph-trait-impl.stderr
+++ b/tests/ui/dep-graph/dep-graph-trait-impl.stderr
@@ -1,32 +1,32 @@
 error: OK
   --> $DIR/dep-graph-trait-impl.rs:28:34
    |
-LL |     #[rustc_then_this_would_need(typeck)]
-   |                                  ^^^^^^
+LL |     #[rustc_then_this_would_need(typeck_root)]
+   |                                  ^^^^^^^^^^^
 
 error: OK
   --> $DIR/dep-graph-trait-impl.rs:33:34
    |
-LL |     #[rustc_then_this_would_need(typeck)]
-   |                                  ^^^^^^
+LL |     #[rustc_then_this_would_need(typeck_root)]
+   |                                  ^^^^^^^^^^^
 
 error: OK
   --> $DIR/dep-graph-trait-impl.rs:38:34
    |
-LL |     #[rustc_then_this_would_need(typeck)]
-   |                                  ^^^^^^
+LL |     #[rustc_then_this_would_need(typeck_root)]
+   |                                  ^^^^^^^^^^^
 
 error: OK
   --> $DIR/dep-graph-trait-impl.rs:43:34
    |
-LL |     #[rustc_then_this_would_need(typeck)]
-   |                                  ^^^^^^
+LL |     #[rustc_then_this_would_need(typeck_root)]
+   |                                  ^^^^^^^^^^^
 
-error: no path from `x::<impl Foo for char>` to `typeck`
+error: no path from `x::<impl Foo for char>` to `typeck_root`
   --> $DIR/dep-graph-trait-impl.rs:56:34
    |
-LL |     #[rustc_then_this_would_need(typeck)]
-   |                                  ^^^^^^
+LL |     #[rustc_then_this_would_need(typeck_root)]
+   |                                  ^^^^^^^^^^^
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/dep-graph/dep-graph-type-alias.rs
+++ b/tests/ui/dep-graph/dep-graph-type-alias.rs
@@ -42,7 +42,7 @@ struct SomeType;
 #[rustc_then_this_would_need(type_of)] //~ ERROR no path
 impl SomeType {
     #[rustc_then_this_would_need(fn_sig)] //~ ERROR OK
-    #[rustc_then_this_would_need(typeck)] //~ ERROR OK
+    #[rustc_then_this_would_need(typeck_root)] //~ ERROR OK
     fn method(&self, _: TypeAlias) {}
 }
 
@@ -50,7 +50,7 @@ impl SomeType {
 type TypeAlias2 = TypeAlias;
 
 #[rustc_then_this_would_need(fn_sig)] //~ ERROR OK
-#[rustc_then_this_would_need(typeck)] //~ ERROR OK
+#[rustc_then_this_would_need(typeck_root)] //~ ERROR OK
 fn function(_: TypeAlias) {
 
 }

--- a/tests/ui/dep-graph/dep-graph-type-alias.stderr
+++ b/tests/ui/dep-graph/dep-graph-type-alias.stderr
@@ -49,8 +49,8 @@ LL | #[rustc_then_this_would_need(fn_sig)]
 error: OK
   --> $DIR/dep-graph-type-alias.rs:53:30
    |
-LL | #[rustc_then_this_would_need(typeck)]
-   |                              ^^^^^^
+LL | #[rustc_then_this_would_need(typeck_root)]
+   |                              ^^^^^^^^^^^
 
 error: OK
   --> $DIR/dep-graph-type-alias.rs:36:34
@@ -67,8 +67,8 @@ LL |     #[rustc_then_this_would_need(fn_sig)]
 error: OK
   --> $DIR/dep-graph-type-alias.rs:45:34
    |
-LL |     #[rustc_then_this_would_need(typeck)]
-   |                                  ^^^^^^
+LL |     #[rustc_then_this_would_need(typeck_root)]
+   |                                  ^^^^^^^^^^^
 
 error: aborting due to 12 previous errors
 

--- a/tests/ui/track-diagnostics/track.stderr
+++ b/tests/ui/track-diagnostics/track.stderr
@@ -40,7 +40,7 @@ note: rustc $VERSION running on $TARGET
 note: compiler flags: ... -Z ui-testing ... -Z track-diagnostics
 
 query stack during panic:
-#0 [typeck] type-checking `main`
+#0 [typeck_root] type-checking `main`
 #1 [analysis] running analysis passes on crate `track`
 end of query stack
 error: aborting due to 3 previous errors


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/154304)*
<!-- homu-ignore:end -->

Currently typeck query itself calls `tcx.typeck(tcx.typeck_root_def_id(key))` if its key isn't a type-check root. I thought this might be an overhead and made typeck a tcx method which calls typeck_root query instead.

This is a step to simplify `cache_on_disk_if` query modifier.

@petrochenkov please run perf