### PR TITLE
test(rustdoc): add regression tests for Self in submodule impl intra-doc links

### DIFF
--- a/tests/rustdoc-html/intra-doc/self-in-submodule-impl-84827.rs
+++ b/tests/rustdoc-html/intra-doc/self-in-submodule-impl-84827.rs
@@ -1,0 +1,25 @@
+// https://github.com/rust-lang/rust/issues/84827
+// Regression test: `Self` in intra-doc links inside `impl` blocks in submodules
+// should produce correct hrefs in generated HTML.
+
+#![crate_name = "foo"]
+#![deny(rustdoc::broken_intra_doc_links)]
+
+pub struct Foo {
+    pub foo: i32,
+}
+
+impl Foo {
+    pub fn method(&self) {}
+}
+
+pub mod bar {
+    impl crate::Foo {
+        //@ has foo/struct.Foo.html '//a[@href="struct.Foo.html"]' 'Self'
+        //@ has foo/struct.Foo.html '//a[@href="struct.Foo.html#structfield.foo"]' 'Self::foo'
+        //@ has foo/struct.Foo.html '//a[@href="struct.Foo.html#method.method"]' 'Self::method'
+        //@ has foo/struct.Foo.html '//a[@href="struct.Foo.html#method.baz"]' 'Self::baz'
+        /// Link to [`Self`], [`Self::foo`], [`Self::method`], and [`Self::baz`].
+        pub fn baz(&self) {}
+    }
+}

--- a/tests/rustdoc-ui/intra-doc/self-in-submodule-impl-84827.rs
+++ b/tests/rustdoc-ui/intra-doc/self-in-submodule-impl-84827.rs
@@ -1,0 +1,21 @@
+// https://github.com/rust-lang/rust/issues/84827
+// Regression test: `Self` in intra-doc links inside `impl` blocks in submodules
+// should resolve correctly even when the type is not directly in scope.
+
+//@ check-pass
+#![deny(rustdoc::broken_intra_doc_links)]
+
+pub struct Foo {
+    pub foo: i32,
+}
+
+impl Foo {
+    pub fn method(&self) {}
+}
+
+pub mod bar {
+    impl crate::Foo {
+        /// Link to [`Self`], [`Self::foo`], [`Self::method`], and [`Self::baz`].
+        pub fn baz(&self) {}
+    }
+}


### PR DESCRIPTION
## Summary

`Self` in intra-doc links inside `impl` blocks in submodules was not resolving correctly when the type was not directly in scope (e.g. `impl crate::Foo` inside `mod bar`). This was silently fixed but had no regression test coverage.

This PR adds:
- A `rustdoc-ui` check-pass test (`tests/rustdoc-ui/intra-doc/self-in-submodule-impl-84827.rs`)
- A `rustdoc-html` test with `//@ has` directives (`tests/rustdoc-html/intra-doc/self-in-submodule-impl-84827.rs`)

Both cover `Self`, `Self::field`, `Self::method` link resolution in submodule impl blocks.

Closes rust-lang/rust#84827

r? rustdoc

---
🤖 Generated with [SHIP](https://www.ship.tech/)