### PR TITLE
fix float classify runtime const test failure on s390x

### DIFF
--- a/tests/ui/float/classify-runtime-const.opt_s390x.run.stderr
+++ b/tests/ui/float/classify-runtime-const.opt_s390x.run.stderr
@@ -1,0 +1,6 @@
+
+thread 'main' ($TID) panicked at $DIR/classify-runtime-const.rs:109:1:
+assertion `left == right` failed: f16 :: is_normal (1.0 / black_box(T::MAX)) produces wrong result
+  left: true
+ right: false
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/ui/float/classify-runtime-const.rs
+++ b/tests/ui/float/classify-runtime-const.rs
@@ -1,7 +1,15 @@
-//@ run-pass
-//@ revisions: opt noopt ctfe
+//@ revisions: opt opt_s390x noopt ctfe
+//@[opt] run-pass
 //@[opt] compile-flags: -O
+// optimized f16 if broken on s390x
+// https://github.com/rust-lang/rust/issues/154101
+//@[opt_s390x] only-s390x
+//@[opt_s390x] compile-flags: -O
+//@[opt_s390x] run-fail
+//@[opt_s390x] check-run-results
+//@[noopt] run-pass
 //@[noopt] compile-flags: -Zmir-opt-level=0
+//@[ctfe] run-pass
 //@ min-llvm-version: 22
 //@ compile-flags: --check-cfg=cfg(target_has_reliable_f16)
 // ignore-tidy-linelength
@@ -120,8 +128,10 @@ suite! { T => // type alias for the type we are testing
                     [ Infinite,  false,        true,     false,     false,             true,            false],
     -2.0 * black_box(T::MAX) =>
                     [ Infinite,  false,        true,     false,     false,            false,             true],
+    @cfg: not(all(target_arch = "s390x", opt))
     1.0 / black_box(T::MAX) =>
                     [Subnormal,  false,       false,      true,     false,             true,            false],
+    @cfg: not(all(target_arch = "s390x", opt))
    -1.0 / black_box(T::MAX) =>
                     [Subnormal,  false,       false,      true,     false,            false,             true],
     // This specific expression causes trouble on x87 due to


### PR DESCRIPTION
on s390x optimization will break some f16 tests.[^1]
for now disable the tests in normal runs and expect them to fail on s390x.

[^1]: https://github.com/rust-lang/rust/issues/154101

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
