### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -425,7 +425,7 @@ fn const_validate_mplace<'tcx>(
     cid: GlobalId<'tcx>,
 ) -> Result<(), ErrorHandled> {
     let alloc_id = mplace.ptr().provenance.unwrap().alloc_id();
-    let mut ref_tracking = RefTracking::new(mplace.clone());
+    let mut ref_tracking = RefTracking::new(mplace.clone(), mplace.layout.ty);
     let mut inner = false;
     while let Some((mplace, path)) = ref_tracking.next() {
         let mode = match ecx.tcx.static_mutability(cid.instance.def_id()) {

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -47,9 +47,9 @@ use super::UnsupportedOpInfo::*;
 macro_rules! err_validation_failure {
     ($where:expr,  $msg:expr ) => {{
         let where_ = &$where;
-        let path = if !where_.is_empty() {
+        let path = if !where_.projs.is_empty() {
             let mut path = String::new();
-            write_path(&mut path, where_);
+            write_path(&mut path, &where_.projs);
             Some(path)
         } else {
             None
@@ -59,6 +59,7 @@ macro_rules! err_validation_failure {
         use ValidationErrorKind::*;
         let msg = ValidationErrorKind::from($msg);
         err_ub!(ValidationError {
+            orig_ty: where_.orig_ty,
             path,
             ptr_bytes_warning: msg.ptr_bytes_warning(),
             msg: msg.to_string(),
@@ -236,7 +237,7 @@ fn fmt_range(r: WrappingRange, max_hi: u128) -> String {
 /// So we track a `Vec<PathElem>` where `PathElem` contains all the data we
 /// need to later print something for the user.
 #[derive(Copy, Clone, Debug)]
-pub enum PathElem {
+pub enum PathElem<'tcx> {
     Field(Symbol),
     Variant(Symbol),
     CoroutineState(VariantIdx),
@@ -246,8 +247,20 @@ pub enum PathElem {
     Deref,
     EnumTag,
     CoroutineTag,
-    DynDowncast,
+    DynDowncast(Ty<'tcx>),
     Vtable,
+}
+
+#[derive(Clone, Debug)]
+pub struct Path<'tcx> {
+    orig_ty: Ty<'tcx>,
+    projs: Vec<PathElem<'tcx>>,
+}
+
+impl<'tcx> Path<'tcx> {
+    fn new(ty: Ty<'tcx>) -> Self {
+        Self { orig_ty: ty, projs: vec![] }
+    }
 }
 
 /// Extra things to check for during validation of CTFE results.
@@ -282,15 +295,9 @@ pub struct RefTracking<T, PATH = ()> {
     todo: Vec<(T, PATH)>,
 }
 
-impl<T: Clone + Eq + Hash + std::fmt::Debug, PATH: Default> RefTracking<T, PATH> {
+impl<T: Clone + Eq + Hash + std::fmt::Debug, PATH> RefTracking<T, PATH> {
     pub fn empty() -> Self {
         RefTracking { seen: FxHashSet::default(), todo: vec![] }
-    }
-    pub fn new(val: T) -> Self {
-        let mut ref_tracking_for_consts =
-            RefTracking { seen: FxHashSet::default(), todo: vec![(val.clone(), PATH::default())] };
-        ref_tracking_for_consts.seen.insert(val);
-        ref_tracking_for_consts
     }
     pub fn next(&mut self) -> Option<(T, PATH)> {
         self.todo.pop()
@@ -306,8 +313,17 @@ impl<T: Clone + Eq + Hash + std::fmt::Debug, PATH: Default> RefTracking<T, PATH>
     }
 }
 
+impl<'tcx, T: Clone + Eq + Hash + std::fmt::Debug> RefTracking<T, Path<'tcx>> {
+    pub fn new(val: T, ty: Ty<'tcx>) -> Self {
+        let mut ref_tracking_for_consts =
+            RefTracking { seen: FxHashSet::default(), todo: vec![(val.clone(), Path::new(ty))] };
+        ref_tracking_for_consts.seen.insert(val);
+        ref_tracking_for_consts
+    }
+}
+
 /// Format a path
-fn write_path(out: &mut String, path: &[PathElem]) {
+fn write_path(out: &mut String, path: &[PathElem<'_>]) {
     use self::PathElem::*;
 
     for elem in path.iter() {
@@ -325,7 +341,7 @@ fn write_path(out: &mut String, path: &[PathElem]) {
             // even use the usual syntax because we are just showing the projections,
             // not the root.
             Deref => write!(out, ".<deref>"),
-            DynDowncast => write!(out, ".<dyn-downcast>"),
+            DynDowncast(ty) => write!(out, ".<dyn-downcast({ty})>"),
             Vtable => write!(out, ".<vtable>"),
         }
         .unwrap()
@@ -384,10 +400,9 @@ impl RangeSet {
 
 struct ValidityVisitor<'rt, 'tcx, M: Machine<'tcx>> {
     /// The `path` may be pushed to, but the part that is present when a function
-    /// starts must not be changed!  `visit_fields` and `visit_array` rely on
-    /// this stack discipline.
-    path: Vec<PathElem>,
-    ref_tracking: Option<&'rt mut RefTracking<MPlaceTy<'tcx, M::Provenance>, Vec<PathElem>>>,
+    /// starts must not be changed!  `with_elem` relies on this stack discipline.
+    path: Path<'tcx>,
+    ref_tracking: Option<&'rt mut RefTracking<MPlaceTy<'tcx, M::Provenance>, Path<'tcx>>>,
     /// `None` indicates this is not validating for CTFE (but for runtime).
     ctfe_mode: Option<CtfeValidationMode>,
     ecx: &'rt mut InterpCx<'tcx, M>,
@@ -406,7 +421,12 @@ struct ValidityVisitor<'rt, 'tcx, M: Machine<'tcx>> {
 }
 
 impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
-    fn aggregate_field_path_elem(&mut self, layout: TyAndLayout<'tcx>, field: usize) -> PathElem {
+    fn aggregate_field_path_elem(
+        &mut self,
+        layout: TyAndLayout<'tcx>,
+        field: usize,
+        field_ty: Ty<'tcx>,
+    ) -> PathElem<'tcx> {
         // First, check if we are projecting to a variant.
         match layout.variants {
             Variants::Multiple { tag_field, .. } => {
@@ -476,7 +496,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
             // dyn traits
             ty::Dynamic(..) => {
                 assert_eq!(field, 0);
-                PathElem::DynDowncast
+                PathElem::DynDowncast(field_ty)
             }
 
             // nothing else has an aggregate layout
@@ -486,17 +506,17 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
 
     fn with_elem<R>(
         &mut self,
-        elem: PathElem,
+        elem: PathElem<'tcx>,
         f: impl FnOnce(&mut Self) -> InterpResult<'tcx, R>,
     ) -> InterpResult<'tcx, R> {
         // Remember the old state
-        let path_len = self.path.len();
+        let path_len = self.path.projs.len();
         // Record new element
-        self.path.push(elem);
+        self.path.projs.push(elem);
         // Perform operation
         let r = f(self)?;
         // Undo changes
-        self.path.truncate(path_len);
+        self.path.projs.truncate(path_len);
         // Done
         interp_ok(r)
     }
@@ -795,10 +815,10 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
             ref_tracking.track(place, || {
                 // We need to clone the path anyway, make sure it gets created
                 // with enough space for the additional `Deref`.
-                let mut new_path = Vec::with_capacity(path.len() + 1);
-                new_path.extend(path);
-                new_path.push(PathElem::Deref);
-                new_path
+                let mut new_projs = Vec::with_capacity(path.projs.len() + 1);
+                new_projs.extend(&path.projs);
+                new_projs.push(PathElem::Deref);
+                Path { projs: new_projs, orig_ty: path.orig_ty }
             });
         }
         interp_ok(())
@@ -1219,7 +1239,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValueVisitor<'tcx, M> for ValidityVisitor<'rt,
         field: usize,
         new_val: &PlaceTy<'tcx, M::Provenance>,
     ) -> InterpResult<'tcx> {
-        let elem = self.aggregate_field_path_elem(old_val.layout, field);
+        let elem = self.aggregate_field_path_elem(old_val.layout, field, new_val.layout.ty);
         self.with_elem(elem, move |this| this.visit_value(new_val))
     }
 
@@ -1384,7 +1404,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValueVisitor<'tcx, M> for ValidityVisitor<'rt,
                                 access.bad.start.bytes() / layout.size.bytes(),
                             )
                             .unwrap();
-                            self.path.push(PathElem::ArrayElem(i));
+                            self.path.projs.push(PathElem::ArrayElem(i));
 
                             if matches!(kind, Ub(InvalidUninitBytes(_))) {
                                 err_validation_failure!(self.path, Uninit { expected })
@@ -1511,8 +1531,8 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     fn validate_operand_internal(
         &mut self,
         val: &PlaceTy<'tcx, M::Provenance>,
-        path: Vec<PathElem>,
-        ref_tracking: Option<&mut RefTracking<MPlaceTy<'tcx, M::Provenance>, Vec<PathElem>>>,
+        path: Path<'tcx>,
+        ref_tracking: Option<&mut RefTracking<MPlaceTy<'tcx, M::Provenance>, Path<'tcx>>>,
         ctfe_mode: Option<CtfeValidationMode>,
         reset_provenance_and_padding: bool,
     ) -> InterpResult<'tcx> {
@@ -1565,8 +1585,8 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     pub(crate) fn const_validate_operand(
         &mut self,
         val: &PlaceTy<'tcx, M::Provenance>,
-        path: Vec<PathElem>,
-        ref_tracking: &mut RefTracking<MPlaceTy<'tcx, M::Provenance>, Vec<PathElem>>,
+        path: Path<'tcx>,
+        ref_tracking: &mut RefTracking<MPlaceTy<'tcx, M::Provenance>, Path<'tcx>>,
         ctfe_mode: CtfeValidationMode,
     ) -> InterpResult<'tcx> {
         self.validate_operand_internal(
@@ -1595,14 +1615,13 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             reset_provenance_and_padding,
             ?val,
         );
-
         // Note that we *could* actually be in CTFE here with `-Zextra-const-ub-checks`, but it's
         // still correct to not use `ctfe_mode`: that mode is for validation of the final constant
         // value, it rules out things like `UnsafeCell` in awkward places.
         if !recursive {
             return self.validate_operand_internal(
                 val,
-                vec![],
+                Path::new(val.layout.ty),
                 None,
                 None,
                 reset_provenance_and_padding,
@@ -1612,7 +1631,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         let mut ref_tracking = RefTracking::empty();
         self.validate_operand_internal(
             val,
-            vec![],
+            Path::new(val.layout.ty),
             Some(&mut ref_tracking),
             None,
             reset_provenance_and_padding,

--- a/compiler/rustc_data_structures/src/fingerprint.rs
+++ b/compiler/rustc_data_structures/src/fingerprint.rs
@@ -181,22 +181,24 @@ impl<D: Decoder> Decodable<D> for Fingerprint {
     }
 }
 
-// `PackedFingerprint` wraps a `Fingerprint`. Its purpose is to, on certain
-// architectures, behave like a `Fingerprint` without alignment requirements.
-// This behavior is only enabled on x86 and x86_64, where the impact of
-// unaligned accesses is tolerable in small doses.
-//
-// This may be preferable to use in large collections of structs containing
-// fingerprints, as it can reduce memory consumption by preventing the padding
-// that the more strictly-aligned `Fingerprint` can introduce. An application of
-// this is in the query dependency graph, which contains a large collection of
-// `DepNode`s. As of this writing, the size of a `DepNode` decreases by ~30%
-// (from 24 bytes to 17) by using the packed representation here, which
-// noticeably decreases total memory usage when compiling large crates.
-//
-// The wrapped `Fingerprint` is private to reduce the chance of a client
-// invoking undefined behavior by taking a reference to the packed field.
-#[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), repr(packed))]
+/// `PackedFingerprint` wraps a `Fingerprint`.
+/// Its purpose is to behave like a `Fingerprint` without alignment requirements.
+///
+/// This may be preferable to use in large collections of structs containing
+/// fingerprints, as it can reduce memory consumption by preventing the padding
+/// that the more strictly-aligned `Fingerprint` can introduce. An application of
+/// this is in the query dependency graph, which contains a large collection of
+/// `DepNode`s. As of this writing, the size of a `DepNode` decreases by 25%
+/// (from 24 bytes to 18) by using the packed representation here, which
+/// noticeably decreases total memory usage when compiling large crates.
+///
+/// (Unalignment was previously restricted to `x86` and `x86_64` hosts, but is
+/// now enabled by default for all host architectures, in the hope that the
+/// memory and cache savings should outweigh any unaligned access penalty.)
+///
+/// The wrapped `Fingerprint` is private to reduce the chance of a client
+/// invoking undefined behavior by taking a reference to the packed field.
+#[repr(packed)]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Copy, Hash)]
 pub struct PackedFingerprint(Fingerprint);
 

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -2947,7 +2947,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             );
             if def_id.is_local() {
                 let name = tcx.def_path_str(def_id);
-                err.span_suggestion(
+                err.span_suggestion_verbose(
                     tcx.def_span(def_id).shrink_to_lo(),
                     format!("add `type` before `const` for `{name}`"),
                     format!("type "),

--- a/compiler/rustc_middle/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node.rs
@@ -506,9 +506,6 @@ mod size_asserts {
     use super::*;
     // tidy-alphabetical-start
     static_assert_size!(DepKind, 2);
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     static_assert_size!(DepNode, 18);
-    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
-    static_assert_size!(DepNode, 24);
     // tidy-alphabetical-end
 }

--- a/compiler/rustc_middle/src/mir/interpret/error.rs
+++ b/compiler/rustc_middle/src/mir/interpret/error.rs
@@ -318,7 +318,12 @@ pub enum UndefinedBehaviorInfo<'tcx> {
     /// Free-form case. Only for errors that are never caught! Used by miri
     Ub(String),
     /// Validation error.
-    ValidationError { path: Option<String>, msg: String, ptr_bytes_warning: bool },
+    ValidationError {
+        orig_ty: Ty<'tcx>,
+        path: Option<String>,
+        msg: String,
+        ptr_bytes_warning: bool,
+    },
 
     /// Unreachable code was executed.
     Unreachable,
@@ -457,11 +462,11 @@ impl<'tcx> fmt::Display for UndefinedBehaviorInfo<'tcx> {
         match self {
             Ub(msg) => write!(f, "{msg}"),
 
-            ValidationError { path: None, msg, .. } => {
-                write!(f, "constructing invalid value: {msg}")
+            ValidationError { orig_ty, path: None, msg, .. } => {
+                write!(f, "constructing invalid value of type {orig_ty}: {msg}")
             }
-            ValidationError { path: Some(path), msg, .. } => {
-                write!(f, "constructing invalid value at {path}: {msg}")
+            ValidationError { orig_ty, path: Some(path), msg, .. } => {
+                write!(f, "constructing invalid value of type {orig_ty}: at {path}, {msg}")
             }
 
             Unreachable => write!(f, "entering unreachable code"),

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
@@ -797,12 +797,16 @@ pub(in crate::solve) fn const_conditions_for_destruct<I: Interner>(
         | ty::Infer(ty::InferTy::FloatVar(_) | ty::InferTy::IntVar(_))
         | ty::Error(_) => Ok(vec![]),
 
-        // Coroutines and closures could implement `[const] Drop`,
+        // Closures are [const] Destruct when all of their upvars (captures) are [const] Destruct.
+        ty::Closure(_, args) => {
+            let closure_args = args.as_closure();
+            Ok(vec![ty::TraitRef::new(cx, destruct_def_id, [closure_args.tupled_upvars_ty()])])
+        }
+        // Coroutines could implement `[const] Drop`,
         // but they don't really need to right now.
-        ty::Closure(_, _)
-        | ty::CoroutineClosure(_, _)
-        | ty::Coroutine(_, _)
-        | ty::CoroutineWitness(_, _) => Err(NoSolution),
+        ty::CoroutineClosure(_, _) | ty::Coroutine(_, _) | ty::CoroutineWitness(_, _) => {
+            Err(NoSolution)
+        }
 
         // FIXME(unsafe_binders): Unsafe binders could implement `[const] Drop`
         // if their inner type implements it.

--- a/compiler/rustc_trait_selection/src/traits/effects.rs
+++ b/compiler/rustc_trait_selection/src/traits/effects.rs
@@ -472,12 +472,17 @@ fn evaluate_host_effect_for_destruct_goal<'tcx>(
         | ty::Infer(ty::InferTy::FloatVar(_) | ty::InferTy::IntVar(_))
         | ty::Error(_) => thin_vec![],
 
-        // Coroutines and closures could implement `[const] Drop`,
+        // Closures are [const] Destruct when all of their upvars (captures) are [const] Destruct.
+        ty::Closure(_, args) => {
+            let closure_args = args.as_closure();
+            thin_vec![ty::TraitRef::new(tcx, destruct_def_id, [closure_args.tupled_upvars_ty()])]
+        }
+
+        // Coroutines could implement `[const] Drop`,
         // but they don't really need to right now.
-        ty::Closure(_, _)
-        | ty::CoroutineClosure(_, _)
-        | ty::Coroutine(_, _)
-        | ty::CoroutineWitness(_, _) => return Err(EvaluationFailure::NoSolution),
+        ty::CoroutineClosure(_, _) | ty::Coroutine(_, _) | ty::CoroutineWitness(_, _) => {
+            return Err(EvaluationFailure::NoSolution);
+        }
 
         // FIXME(unsafe_binders): Unsafe binders could implement `[const] Drop`
         // if their inner type implements it.

--- a/library/coretests/tests/array.rs
+++ b/library/coretests/tests/array.rs
@@ -741,3 +741,18 @@ fn const_array_ops() {
     struct Zst;
     assert_eq!([(); 10].try_map(|()| Some(Zst)), Some([const { Zst }; 10]));
 }
+
+#[test]
+const fn extra_const_array_ops() {
+    let x: [u8; 4] =
+        { std::array::from_fn(const |i| i + 4).map(const |x| x * 2).map(const |x| x as _) };
+    let y = 4;
+    struct Z(u16);
+    impl const Drop for Z {
+        fn drop(&mut self) {}
+    }
+    let w = Z(2);
+    let _x: [u8; 4] = {
+        std::array::from_fn(const |_| x[0] + y).map(const |x| x * (w.0 as u8)).map(const |x| x as _)
+    };
+}

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -17,6 +17,7 @@
 #![feature(const_bool)]
 #![feature(const_cell_traits)]
 #![feature(const_clone)]
+#![feature(const_closures)]
 #![feature(const_cmp)]
 #![feature(const_convert)]
 #![feature(const_default)]

--- a/src/tools/miri/tests/fail-dep/libc/libc-read-and-uninit-premature-eof.stderr
+++ b/src/tools/miri/tests/fail-dep/libc/libc-read-and-uninit-premature-eof.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value at [3]: encountered uninitialized memory, but expected an integer
+error: Undefined Behavior: constructing invalid value of type [u8; 4]: at [3], encountered uninitialized memory, but expected an integer
   --> tests/fail-dep/libc/libc-read-and-uninit-premature-eof.rs:LL:CC
    |
 LL |         buf.assume_init();

--- a/src/tools/miri/tests/fail/branchless-select-i128-pointer.rs
+++ b/src/tools/miri/tests/fail/branchless-select-i128-pointer.rs
@@ -14,7 +14,7 @@ fn main() {
         // However, it drops provenance when transmuting to TwoPtrs, so this is UB.
         let val = unsafe {
             transmute::<_, &str>(
-                //~^ ERROR: constructing invalid value: encountered a dangling reference
+                //~^ ERROR: encountered a dangling reference
                 !mask & transmute::<_, TwoPtrs>("false !")
                     | mask & transmute::<_, TwoPtrs>("true !"),
             )

--- a/src/tools/miri/tests/fail/branchless-select-i128-pointer.stderr
+++ b/src/tools/miri/tests/fail/branchless-select-i128-pointer.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered a dangling reference ($HEX[noalloc] has no provenance)
+error: Undefined Behavior: constructing invalid value of type &str: encountered a dangling reference ($HEX[noalloc] has no provenance)
   --> tests/fail/branchless-select-i128-pointer.rs:LL:CC
    |
 LL | /             transmute::<_, &str>(

--- a/src/tools/miri/tests/fail/dangling_pointers/deref_dangling_box.stderr
+++ b/src/tools/miri/tests/fail/dangling_pointers/deref_dangling_box.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered a dangling box (0x18[noalloc] has no provenance)
+error: Undefined Behavior: constructing invalid value of type std::boxed::Box<i32>: encountered a dangling box (0x18[noalloc] has no provenance)
   --> tests/fail/dangling_pointers/deref_dangling_box.rs:LL:CC
    |
 LL |     let _val = unsafe { addr_of_mut!(**outer) };

--- a/src/tools/miri/tests/fail/dangling_pointers/deref_dangling_ref.stderr
+++ b/src/tools/miri/tests/fail/dangling_pointers/deref_dangling_ref.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered a dangling reference (0x18[noalloc] has no provenance)
+error: Undefined Behavior: constructing invalid value of type &mut i32: encountered a dangling reference (0x18[noalloc] has no provenance)
   --> tests/fail/dangling_pointers/deref_dangling_ref.rs:LL:CC
    |
 LL |     let _val = unsafe { addr_of_mut!(**outer) };

--- a/src/tools/miri/tests/fail/dangling_pointers/dyn_size.stderr
+++ b/src/tools/miri/tests/fail/dangling_pointers/dyn_size.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered a dangling reference (going beyond the bounds of its allocation)
+error: Undefined Behavior: constructing invalid value of type &SliceWithHead: encountered a dangling reference (going beyond the bounds of its allocation)
   --> tests/fail/dangling_pointers/dyn_size.rs:LL:CC
    |
 LL |     let _ptr = unsafe { &*ptr };

--- a/src/tools/miri/tests/fail/dyn-upcast-nop-wrong-trait.stderr
+++ b/src/tools/miri/tests/fail/dyn-upcast-nop-wrong-trait.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: wrong trait in wide pointer vtable: expected `std::fmt::Debug + std::marker::Send + std::marker::Sync`, but encountered `std::fmt::Display`
+error: Undefined Behavior: constructing invalid value of type *const dyn std::fmt::Debug + std::marker::Send + std::marker::Sync: wrong trait in wide pointer vtable: expected `std::fmt::Debug + std::marker::Send + std::marker::Sync`, but encountered `std::fmt::Display`
   --> tests/fail/dyn-upcast-nop-wrong-trait.rs:LL:CC
    |
 LL |     let ptr: *const (dyn fmt::Debug + Send + Sync) = unsafe { std::mem::transmute(ptr) };

--- a/src/tools/miri/tests/fail/intrinsics/typed-swap-invalid-array.stderr
+++ b/src/tools/miri/tests/fail/intrinsics/typed-swap-invalid-array.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value at [0]: encountered 0x02, but expected a boolean
+error: Undefined Behavior: constructing invalid value of type [bool; 100]: at [0], encountered 0x02, but expected a boolean
   --> tests/fail/intrinsics/typed-swap-invalid-array.rs:LL:CC
    |
 LL |         typed_swap_nonoverlapping(a, b);

--- a/src/tools/miri/tests/fail/intrinsics/typed-swap-invalid-scalar.left.stderr
+++ b/src/tools/miri/tests/fail/intrinsics/typed-swap-invalid-scalar.left.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered 0x02, but expected a boolean
+error: Undefined Behavior: constructing invalid value of type bool: encountered 0x02, but expected a boolean
   --> tests/fail/intrinsics/typed-swap-invalid-scalar.rs:LL:CC
    |
 LL |         typed_swap_nonoverlapping(a, b);

--- a/src/tools/miri/tests/fail/intrinsics/typed-swap-invalid-scalar.right.stderr
+++ b/src/tools/miri/tests/fail/intrinsics/typed-swap-invalid-scalar.right.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered 0x03, but expected a boolean
+error: Undefined Behavior: constructing invalid value of type bool: encountered 0x03, but expected a boolean
   --> tests/fail/intrinsics/typed-swap-invalid-scalar.rs:LL:CC
    |
 LL |         typed_swap_nonoverlapping(a, b);

--- a/src/tools/miri/tests/fail/intrinsics/uninit_uninhabited_type.stderr
+++ b/src/tools/miri/tests/fail/intrinsics/uninit_uninhabited_type.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered a value of the never type `!`
+error: Undefined Behavior: constructing invalid value of type !: encountered a value of the never type `!`
   --> tests/fail/intrinsics/uninit_uninhabited_type.rs:LL:CC
    |
 LL |     let _ = unsafe { std::mem::uninitialized::<!>() };

--- a/src/tools/miri/tests/fail/intrinsics/zero_fn_ptr.stderr
+++ b/src/tools/miri/tests/fail/intrinsics/zero_fn_ptr.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered a null function pointer
+error: Undefined Behavior: constructing invalid value of type fn(): encountered a null function pointer
   --> tests/fail/intrinsics/zero_fn_ptr.rs:LL:CC
    |
 LL |     let _ = unsafe { std::mem::zeroed::<fn()>() };

--- a/src/tools/miri/tests/fail/issue-miri-1112.stderr
+++ b/src/tools/miri/tests/fail/issue-miri-1112.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered $HEX[ALLOC]<TAG>, but expected a vtable pointer
+error: Undefined Behavior: constructing invalid value of type *mut FunnyPointer: encountered $HEX[ALLOC]<TAG>, but expected a vtable pointer
   --> tests/fail/issue-miri-1112.rs:LL:CC
    |
 LL |         let obj = std::mem::transmute::<FatPointer, *mut FunnyPointer>(obj);

--- a/src/tools/miri/tests/fail/match/closures/deref-in-pattern.stderr
+++ b/src/tools/miri/tests/fail/match/closures/deref-in-pattern.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered a dangling reference (use-after-free)
+error: Undefined Behavior: constructing invalid value of type &u32: encountered a dangling reference (use-after-free)
   --> tests/fail/match/closures/deref-in-pattern.rs:LL:CC
    |
 LL |       let _ = || {

--- a/src/tools/miri/tests/fail/match/closures/partial-pattern.stderr
+++ b/src/tools/miri/tests/fail/match/closures/partial-pattern.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered a dangling reference (use-after-free)
+error: Undefined Behavior: constructing invalid value of type &u32: encountered a dangling reference (use-after-free)
   --> tests/fail/match/closures/partial-pattern.rs:LL:CC
    |
 LL |       let _ = || {

--- a/src/tools/miri/tests/fail/provenance/int_copy_looses_provenance0.stderr
+++ b/src/tools/miri/tests/fail/provenance/int_copy_looses_provenance0.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered a dangling reference ($HEX[noalloc] has no provenance)
+error: Undefined Behavior: constructing invalid value of type &i32: encountered a dangling reference ($HEX[noalloc] has no provenance)
   --> tests/fail/provenance/int_copy_looses_provenance0.rs:LL:CC
    |
 LL |     let _val = unsafe { *ptr.read() };

--- a/src/tools/miri/tests/fail/provenance/int_copy_looses_provenance1.stderr
+++ b/src/tools/miri/tests/fail/provenance/int_copy_looses_provenance1.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered a dangling reference ($HEX[noalloc] has no provenance)
+error: Undefined Behavior: constructing invalid value of type &i32: encountered a dangling reference ($HEX[noalloc] has no provenance)
   --> tests/fail/provenance/int_copy_looses_provenance1.rs:LL:CC
    |
 LL |     let _val = unsafe { *ptr.read() };

--- a/src/tools/miri/tests/fail/provenance/int_copy_looses_provenance2.stderr
+++ b/src/tools/miri/tests/fail/provenance/int_copy_looses_provenance2.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered a dangling reference ($HEX[noalloc] has no provenance)
+error: Undefined Behavior: constructing invalid value of type &i32: encountered a dangling reference ($HEX[noalloc] has no provenance)
   --> tests/fail/provenance/int_copy_looses_provenance2.rs:LL:CC
    |
 LL |     let _val = unsafe { *ptr.read() };

--- a/src/tools/miri/tests/fail/storage-live-resets-var.stderr
+++ b/src/tools/miri/tests/fail/storage-live-resets-var.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered uninitialized memory, but expected an integer
+error: Undefined Behavior: constructing invalid value of type i32: encountered uninitialized memory, but expected an integer
   --> tests/fail/storage-live-resets-var.rs:LL:CC
    |
 LL |             _val2 = val;

--- a/src/tools/miri/tests/fail/unaligned_pointers/drop_in_place.stderr
+++ b/src/tools/miri/tests/fail/unaligned_pointers/drop_in_place.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered an unaligned reference (required ALIGN byte alignment but found ALIGN)
+error: Undefined Behavior: constructing invalid value of type &mut PartialDrop: encountered an unaligned reference (required ALIGN byte alignment but found ALIGN)
   --> RUSTLIB/core/src/ptr/mod.rs:LL:CC
    |
 LL | / pub const unsafe fn drop_in_place<T: PointeeSized>(to_drop: *mut T)

--- a/src/tools/miri/tests/fail/unaligned_pointers/dyn_alignment.stderr
+++ b/src/tools/miri/tests/fail/unaligned_pointers/dyn_alignment.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered an unaligned reference (required ALIGN byte alignment but found ALIGN)
+error: Undefined Behavior: constructing invalid value of type &dyn std::fmt::Debug: encountered an unaligned reference (required ALIGN byte alignment but found ALIGN)
   --> tests/fail/unaligned_pointers/dyn_alignment.rs:LL:CC
    |
 LL |         let _ptr = &*ptr;

--- a/src/tools/miri/tests/fail/unaligned_pointers/maybe_dangling_unalighed.rs
+++ b/src/tools/miri/tests/fail/unaligned_pointers/maybe_dangling_unalighed.rs
@@ -10,6 +10,6 @@ fn main() {
     unsafe {
         let unaligned = MaybeDangling::new(a.as_ptr().byte_add(1));
         transmute::<MaybeDangling<*const u16>, MaybeDangling<&u16>>(unaligned)
-        //~^ ERROR: Undefined Behavior: constructing invalid value: encountered an unaligned reference
+        //~^ ERROR: encountered an unaligned reference
     };
 }

--- a/src/tools/miri/tests/fail/unaligned_pointers/maybe_dangling_unalighed.stderr
+++ b/src/tools/miri/tests/fail/unaligned_pointers/maybe_dangling_unalighed.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered an unaligned reference (required ALIGN byte alignment but found ALIGN)
+error: Undefined Behavior: constructing invalid value of type std::mem::MaybeDangling<&u16>: encountered an unaligned reference (required ALIGN byte alignment but found ALIGN)
   --> tests/fail/unaligned_pointers/maybe_dangling_unalighed.rs:LL:CC
    |
 LL |         transmute::<MaybeDangling<*const u16>, MaybeDangling<&u16>>(unaligned)

--- a/src/tools/miri/tests/fail/unaligned_pointers/reference_to_packed.stderr
+++ b/src/tools/miri/tests/fail/unaligned_pointers/reference_to_packed.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered an unaligned reference (required ALIGN byte alignment but found ALIGN)
+error: Undefined Behavior: constructing invalid value of type &i32: encountered an unaligned reference (required ALIGN byte alignment but found ALIGN)
   --> tests/fail/unaligned_pointers/reference_to_packed.rs:LL:CC
    |
 LL |     mem::transmute(x)

--- a/src/tools/miri/tests/fail/unaligned_pointers/unaligned_ref_addr_of.stderr
+++ b/src/tools/miri/tests/fail/unaligned_pointers/unaligned_ref_addr_of.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered an unaligned reference (required ALIGN byte alignment but found ALIGN)
+error: Undefined Behavior: constructing invalid value of type &u32: encountered an unaligned reference (required ALIGN byte alignment but found ALIGN)
   --> tests/fail/unaligned_pointers/unaligned_ref_addr_of.rs:LL:CC
    |
 LL |         let _x = unsafe { &*x };

--- a/src/tools/miri/tests/fail/uninit/padding-struct-in-union.stderr
+++ b/src/tools/miri/tests/fail/uninit/padding-struct-in-union.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value at .bytes[2]: encountered uninitialized memory, but expected an integer
+error: Undefined Behavior: constructing invalid value of type Bar: at .bytes[2], encountered uninitialized memory, but expected an integer
   --> tests/fail/uninit/padding-struct-in-union.rs:LL:CC
    |
 LL |     let _val = unsafe { (foobar.foo, foobar.bar) };

--- a/src/tools/miri/tests/fail/uninit/padding-union.stderr
+++ b/src/tools/miri/tests/fail/uninit/padding-union.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value at [1]: encountered uninitialized memory, but expected an integer
+error: Undefined Behavior: constructing invalid value of type [u8; 4]: at [1], encountered uninitialized memory, but expected an integer
   --> tests/fail/uninit/padding-union.rs:LL:CC
    |
 LL |         let _val = *c;

--- a/src/tools/miri/tests/fail/uninit/uninit-after-aggregate-assign.stderr
+++ b/src/tools/miri/tests/fail/uninit/uninit-after-aggregate-assign.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value at [1]: encountered uninitialized memory, but expected an integer
+error: Undefined Behavior: constructing invalid value of type [u8; 4]: at [1], encountered uninitialized memory, but expected an integer
   --> tests/fail/uninit/uninit-after-aggregate-assign.rs:LL:CC
    |
 LL |             _val = *sptr2; // should hence be UB

--- a/src/tools/miri/tests/fail/validity/box-custom-alloc-dangling-ptr.stderr
+++ b/src/tools/miri/tests/fail/validity/box-custom-alloc-dangling-ptr.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered a dangling box (0x4[noalloc] has no provenance)
+error: Undefined Behavior: constructing invalid value of type std::boxed::Box<i32, MyAlloc>: encountered a dangling box (0x4[noalloc] has no provenance)
   --> tests/fail/validity/box-custom-alloc-dangling-ptr.rs:LL:CC
    |
 LL |         std::mem::transmute(b)

--- a/src/tools/miri/tests/fail/validity/box-custom-alloc-invalid-alloc.stderr
+++ b/src/tools/miri/tests/fail/validity/box-custom-alloc-invalid-alloc.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value at .1.my_alloc_field1: encountered uninitialized memory, but expected an integer
+error: Undefined Behavior: constructing invalid value of type std::boxed::Box<i32, MyAlloc>: at .1.my_alloc_field1, encountered uninitialized memory, but expected an integer
   --> tests/fail/validity/box-custom-alloc-invalid-alloc.rs:LL:CC
    |
 LL |         std::mem::transmute(b)

--- a/src/tools/miri/tests/fail/validity/cast_fn_ptr_invalid_callee_arg.stderr
+++ b/src/tools/miri/tests/fail/validity/cast_fn_ptr_invalid_callee_arg.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered a null reference
+error: Undefined Behavior: constructing invalid value of type &i32: encountered a null reference
   --> tests/fail/validity/cast_fn_ptr_invalid_callee_arg.rs:LL:CC
    |
 LL |     g(0usize as *const i32)

--- a/src/tools/miri/tests/fail/validity/cast_fn_ptr_invalid_callee_ret.stderr
+++ b/src/tools/miri/tests/fail/validity/cast_fn_ptr_invalid_callee_ret.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value at .0.0: encountered 0, but expected something greater or equal to 1
+error: Undefined Behavior: constructing invalid value of type std::num::NonZero<u32>: at .0.0, encountered 0, but expected something greater or equal to 1
   --> tests/fail/validity/cast_fn_ptr_invalid_callee_ret.rs:LL:CC
    |
 LL |     f();

--- a/src/tools/miri/tests/fail/validity/cast_fn_ptr_invalid_caller_arg.stderr
+++ b/src/tools/miri/tests/fail/validity/cast_fn_ptr_invalid_caller_arg.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value at .0.0: encountered 0, but expected something greater or equal to 1
+error: Undefined Behavior: constructing invalid value of type std::num::NonZero<u32>: at .0.0, encountered 0, but expected something greater or equal to 1
   --> tests/fail/validity/cast_fn_ptr_invalid_caller_arg.rs:LL:CC
    |
 LL |             Call(_res = f(*ptr), ReturnTo(retblock), UnwindContinue())

--- a/src/tools/miri/tests/fail/validity/cast_fn_ptr_invalid_caller_ret.stderr
+++ b/src/tools/miri/tests/fail/validity/cast_fn_ptr_invalid_caller_ret.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered a null reference
+error: Undefined Behavior: constructing invalid value of type &i32: encountered a null reference
   --> tests/fail/validity/cast_fn_ptr_invalid_caller_ret.rs:LL:CC
    |
 LL |     let _x = g();

--- a/src/tools/miri/tests/fail/validity/dangling_ref1.stderr
+++ b/src/tools/miri/tests/fail/validity/dangling_ref1.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered a dangling reference (0x10[noalloc] has no provenance)
+error: Undefined Behavior: constructing invalid value of type &i32: encountered a dangling reference (0x10[noalloc] has no provenance)
   --> tests/fail/validity/dangling_ref1.rs:LL:CC
    |
 LL |     let _x: &i32 = unsafe { mem::transmute(16usize) };

--- a/src/tools/miri/tests/fail/validity/dangling_ref2.stderr
+++ b/src/tools/miri/tests/fail/validity/dangling_ref2.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered a dangling reference (going beyond the bounds of its allocation)
+error: Undefined Behavior: constructing invalid value of type &i32: encountered a dangling reference (going beyond the bounds of its allocation)
   --> tests/fail/validity/dangling_ref2.rs:LL:CC
    |
 LL |     let _x: &i32 = unsafe { mem::transmute(ptr) };

--- a/src/tools/miri/tests/fail/validity/dangling_ref3.stderr
+++ b/src/tools/miri/tests/fail/validity/dangling_ref3.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered a dangling reference (use-after-free)
+error: Undefined Behavior: constructing invalid value of type &i32: encountered a dangling reference (use-after-free)
   --> tests/fail/validity/dangling_ref3.rs:LL:CC
    |
 LL |     let _x: &i32 = unsafe { mem::transmute(dangling()) };

--- a/src/tools/miri/tests/fail/validity/dyn-transmute-inner-binder.stderr
+++ b/src/tools/miri/tests/fail/validity/dyn-transmute-inner-binder.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: wrong trait in wide pointer vtable: expected `Trait<for<'a> fn(&'a ())>`, but encountered `Trait<fn(&())>`
+error: Undefined Behavior: constructing invalid value of type &dyn Trait<for<'a> fn(&'a ())>: wrong trait in wide pointer vtable: expected `Trait<for<'a> fn(&'a ())>`, but encountered `Trait<fn(&())>`
   --> tests/fail/validity/dyn-transmute-inner-binder.rs:LL:CC
    |
 LL |     let y: &dyn Trait<for<'a> fn(&'a ())> = unsafe { std::mem::transmute(x) };

--- a/src/tools/miri/tests/fail/validity/invalid_bool.stderr
+++ b/src/tools/miri/tests/fail/validity/invalid_bool.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered 0x02, but expected a boolean
+error: Undefined Behavior: constructing invalid value of type bool: encountered 0x02, but expected a boolean
   --> tests/fail/validity/invalid_bool.rs:LL:CC
    |
 LL |     let _b = unsafe { std::mem::transmute::<u8, bool>(2) };

--- a/src/tools/miri/tests/fail/validity/invalid_bool_uninit.stderr
+++ b/src/tools/miri/tests/fail/validity/invalid_bool_uninit.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value at [0]: encountered uninitialized memory, but expected a boolean
+error: Undefined Behavior: constructing invalid value of type [bool; 1]: at [0], encountered uninitialized memory, but expected a boolean
   --> tests/fail/validity/invalid_bool_uninit.rs:LL:CC
    |
 LL |     let _b = unsafe { MyUninit { init: () }.uninit };

--- a/src/tools/miri/tests/fail/validity/invalid_char.stderr
+++ b/src/tools/miri/tests/fail/validity/invalid_char.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered $HEX, but expected a valid unicode scalar value (in `0..=$HEX` but not in `$HEX..=$HEX`)
+error: Undefined Behavior: constructing invalid value of type char: encountered $HEX, but expected a valid unicode scalar value (in `0..=$HEX` but not in `$HEX..=$HEX`)
   --> tests/fail/validity/invalid_char.rs:LL:CC
    |
 LL |     let _val = match unsafe { std::mem::transmute::<i32, char>(-1) } {

--- a/src/tools/miri/tests/fail/validity/invalid_char_uninit.stderr
+++ b/src/tools/miri/tests/fail/validity/invalid_char_uninit.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value at [0]: encountered uninitialized memory, but expected a unicode scalar value
+error: Undefined Behavior: constructing invalid value of type [char; 1]: at [0], encountered uninitialized memory, but expected a unicode scalar value
   --> tests/fail/validity/invalid_char_uninit.rs:LL:CC
    |
 LL |     let _b = unsafe { MyUninit { init: () }.uninit };

--- a/src/tools/miri/tests/fail/validity/invalid_enum_tag.rs
+++ b/src/tools/miri/tests/fail/validity/invalid_enum_tag.rs
@@ -7,5 +7,5 @@ pub enum Foo {
 }
 
 fn main() {
-    let _f = unsafe { std::mem::transmute::<i32, Foo>(42) }; //~ ERROR: constructing invalid value at .<enum-tag>: encountered 0x0000002a, but expected a valid enum tag
+    let _f = unsafe { std::mem::transmute::<i32, Foo>(42) }; //~ ERROR: constructing invalid value of type Foo: at .<enum-tag>, encountered 0x0000002a, but expected a valid enum tag
 }

--- a/src/tools/miri/tests/fail/validity/invalid_enum_tag.stderr
+++ b/src/tools/miri/tests/fail/validity/invalid_enum_tag.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value at .<enum-tag>: encountered $HEX, but expected a valid enum tag
+error: Undefined Behavior: constructing invalid value of type Foo: at .<enum-tag>, encountered $HEX, but expected a valid enum tag
   --> tests/fail/validity/invalid_enum_tag.rs:LL:CC
    |
 LL |     let _f = unsafe { std::mem::transmute::<i32, Foo>(42) };

--- a/src/tools/miri/tests/fail/validity/invalid_fnptr_null.stderr
+++ b/src/tools/miri/tests/fail/validity/invalid_fnptr_null.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered a null function pointer
+error: Undefined Behavior: constructing invalid value of type fn(): encountered a null function pointer
   --> tests/fail/validity/invalid_fnptr_null.rs:LL:CC
    |
 LL |     let _b: fn() = unsafe { std::mem::transmute(0usize) };

--- a/src/tools/miri/tests/fail/validity/invalid_fnptr_uninit.stderr
+++ b/src/tools/miri/tests/fail/validity/invalid_fnptr_uninit.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value at [0]: encountered uninitialized memory, but expected a function pointer
+error: Undefined Behavior: constructing invalid value of type [fn(); 1]: at [0], encountered uninitialized memory, but expected a function pointer
   --> tests/fail/validity/invalid_fnptr_uninit.rs:LL:CC
    |
 LL |     let _b = unsafe { MyUninit { init: () }.uninit };

--- a/src/tools/miri/tests/fail/validity/invalid_wide_raw.stderr
+++ b/src/tools/miri/tests/fail/validity/invalid_wide_raw.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered null pointer, but expected a vtable pointer
+error: Undefined Behavior: constructing invalid value of type *mut dyn main::T: encountered null pointer, but expected a vtable pointer
   --> tests/fail/validity/invalid_wide_raw.rs:LL:CC
    |
 LL |     dbg!(S { x: unsafe { std::mem::transmute((0usize, 0usize)) } });

--- a/src/tools/miri/tests/fail/validity/match_binder_checks_validity1.stderr
+++ b/src/tools/miri/tests/fail/validity/match_binder_checks_validity1.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered a value of uninhabited type `main::Void`
+error: Undefined Behavior: constructing invalid value of type main::Void: encountered a value of uninhabited type `main::Void`
   --> tests/fail/validity/match_binder_checks_validity1.rs:LL:CC
    |
 LL |             _x => println!("hi from the void!"),

--- a/src/tools/miri/tests/fail/validity/match_binder_checks_validity2.stderr
+++ b/src/tools/miri/tests/fail/validity/match_binder_checks_validity2.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered 0x03, but expected a boolean
+error: Undefined Behavior: constructing invalid value of type bool: encountered 0x03, but expected a boolean
   --> tests/fail/validity/match_binder_checks_validity2.rs:LL:CC
    |
 LL |             _x => println!("hi from the void!"),

--- a/src/tools/miri/tests/fail/validity/maybe_dangling_null.rs
+++ b/src/tools/miri/tests/fail/validity/maybe_dangling_null.rs
@@ -9,5 +9,5 @@ use std::ptr::null;
 fn main() {
     let null = MaybeDangling::new(null());
     unsafe { transmute::<MaybeDangling<*const u8>, MaybeDangling<&u8>>(null) };
-    //~^ ERROR: Undefined Behavior: constructing invalid value: encountered a null reference
+    //~^ ERROR: encountered a null reference
 }

--- a/src/tools/miri/tests/fail/validity/maybe_dangling_null.stderr
+++ b/src/tools/miri/tests/fail/validity/maybe_dangling_null.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered a null reference
+error: Undefined Behavior: constructing invalid value of type std::mem::MaybeDangling<&u8>: encountered a null reference
   --> tests/fail/validity/maybe_dangling_null.rs:LL:CC
    |
 LL |     unsafe { transmute::<MaybeDangling<*const u8>, MaybeDangling<&u8>>(null) };

--- a/src/tools/miri/tests/fail/validity/nonzero.stderr
+++ b/src/tools/miri/tests/fail/validity/nonzero.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered 0, but expected something greater or equal to 1
+error: Undefined Behavior: constructing invalid value of type NonZero<i32>: encountered 0, but expected something greater or equal to 1
   --> tests/fail/validity/nonzero.rs:LL:CC
    |
 LL |     let _x = Some(unsafe { NonZero(0) });

--- a/src/tools/miri/tests/fail/validity/recursive-validity-box-bool.stderr
+++ b/src/tools/miri/tests/fail/validity/recursive-validity-box-bool.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value at .<deref>: encountered 0x03, but expected a boolean
+error: Undefined Behavior: constructing invalid value of type std::boxed::Box<bool>: at .<deref>, encountered 0x03, but expected a boolean
   --> tests/fail/validity/recursive-validity-box-bool.rs:LL:CC
    |
 LL |     let xref_wrong_type: Box<bool> = unsafe { std::mem::transmute(xref) };

--- a/src/tools/miri/tests/fail/validity/recursive-validity-ref-bool.stderr
+++ b/src/tools/miri/tests/fail/validity/recursive-validity-ref-bool.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value at .<deref>: encountered 0x03, but expected a boolean
+error: Undefined Behavior: constructing invalid value of type &bool: at .<deref>, encountered 0x03, but expected a boolean
   --> tests/fail/validity/recursive-validity-ref-bool.rs:LL:CC
    |
 LL |     let xref_wrong_type: &bool = unsafe { std::mem::transmute(xref) };

--- a/src/tools/miri/tests/fail/validity/ref_to_uninhabited1.stderr
+++ b/src/tools/miri/tests/fail/validity/ref_to_uninhabited1.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered a box pointing to uninhabited type !
+error: Undefined Behavior: constructing invalid value of type std::boxed::Box<!>: encountered a box pointing to uninhabited type !
   --> tests/fail/validity/ref_to_uninhabited1.rs:LL:CC
    |
 LL |         let x: Box<!> = transmute(&mut 42);

--- a/src/tools/miri/tests/fail/validity/ref_to_uninhabited2.stderr
+++ b/src/tools/miri/tests/fail/validity/ref_to_uninhabited2.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered a reference pointing to uninhabited type (i32, Void)
+error: Undefined Behavior: constructing invalid value of type &(i32, Void): encountered a reference pointing to uninhabited type (i32, Void)
   --> tests/fail/validity/ref_to_uninhabited2.rs:LL:CC
    |
 LL |         let _x: &(i32, Void) = transmute(&42);

--- a/src/tools/miri/tests/fail/validity/too-big-slice.stderr
+++ b/src/tools/miri/tests/fail/validity/too-big-slice.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
+error: Undefined Behavior: constructing invalid value of type &[u8]: encountered invalid reference metadata: slice is bigger than largest supported object
   --> tests/fail/validity/too-big-slice.rs:LL:CC
    |
 LL | ...   let _x: &[u8] = mem::transmute((ptr, usize::MAX));

--- a/src/tools/miri/tests/fail/validity/too-big-unsized.stderr
+++ b/src/tools/miri/tests/fail/validity/too-big-unsized.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered invalid reference metadata: total size is bigger than largest supported object
+error: Undefined Behavior: constructing invalid value of type &MySlice: encountered invalid reference metadata: total size is bigger than largest supported object
   --> tests/fail/validity/too-big-unsized.rs:LL:CC
    |
 LL | ...   let _x: &MySlice = mem::transmute((ptr, isize::MAX as usize));

--- a/src/tools/miri/tests/fail/validity/transmute_through_ptr.rs
+++ b/src/tools/miri/tests/fail/validity/transmute_through_ptr.rs
@@ -14,6 +14,6 @@ fn main() {
     let mut x = Bool::True;
     evil(&mut x);
     let y = x; // reading this ought to be enough to trigger validation
-    //~^ ERROR: constructing invalid value at .<enum-tag>: encountered 0x0000002c, but expected a valid enum tag
+    //~^ ERROR: constructing invalid value of type Bool: at .<enum-tag>, encountered 0x0000002c, but expected a valid enum tag
     println!("{:?}", y); // make sure it is used (and not optimized away)
 }

--- a/src/tools/miri/tests/fail/validity/transmute_through_ptr.stderr
+++ b/src/tools/miri/tests/fail/validity/transmute_through_ptr.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value at .<enum-tag>: encountered $HEX, but expected a valid enum tag
+error: Undefined Behavior: constructing invalid value of type Bool: at .<enum-tag>, encountered $HEX, but expected a valid enum tag
   --> tests/fail/validity/transmute_through_ptr.rs:LL:CC
    |
 LL |     let y = x; // reading this ought to be enough to trigger validation

--- a/src/tools/miri/tests/fail/validity/uninhabited_variant.stderr
+++ b/src/tools/miri/tests/fail/validity/uninhabited_variant.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
+error: Undefined Behavior: constructing invalid value of type E: at .<enum-tag>, encountered an uninhabited enum variant
   --> tests/fail/validity/uninhabited_variant.rs:LL:CC
    |
 LL |         std::mem::transmute::<u32, E>(1);

--- a/src/tools/miri/tests/fail/validity/uninit_float.stderr
+++ b/src/tools/miri/tests/fail/validity/uninit_float.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value at [0]: encountered uninitialized memory, but expected a floating point number
+error: Undefined Behavior: constructing invalid value of type [f32; 1]: at [0], encountered uninitialized memory, but expected a floating point number
   --> tests/fail/validity/uninit_float.rs:LL:CC
    |
 LL |     let _val: [f32; 1] = unsafe { std::mem::uninitialized() };

--- a/src/tools/miri/tests/fail/validity/uninit_integer.stderr
+++ b/src/tools/miri/tests/fail/validity/uninit_integer.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value at [0]: encountered uninitialized memory, but expected an integer
+error: Undefined Behavior: constructing invalid value of type [usize; 1]: at [0], encountered uninitialized memory, but expected an integer
   --> tests/fail/validity/uninit_integer.rs:LL:CC
    |
 LL |     let _val = unsafe { std::mem::MaybeUninit::<[usize; 1]>::uninit().assume_init() };

--- a/src/tools/miri/tests/fail/validity/uninit_raw_ptr.stderr
+++ b/src/tools/miri/tests/fail/validity/uninit_raw_ptr.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value at [0]: encountered uninitialized memory, but expected a raw pointer
+error: Undefined Behavior: constructing invalid value of type [*const u8; 1]: at [0], encountered uninitialized memory, but expected a raw pointer
   --> tests/fail/validity/uninit_raw_ptr.rs:LL:CC
    |
 LL |     let _val = unsafe { std::mem::MaybeUninit::<[*const u8; 1]>::uninit().assume_init() };

--- a/src/tools/miri/tests/fail/validity/wrong-dyn-trait-assoc-type.stderr
+++ b/src/tools/miri/tests/fail/validity/wrong-dyn-trait-assoc-type.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: wrong trait in wide pointer vtable: expected `Trait<Assoc = bool>`, but encountered `Trait<Assoc = u8>`
+error: Undefined Behavior: constructing invalid value of type std::boxed::Box<dyn Trait<Assoc = bool>>: wrong trait in wide pointer vtable: expected `Trait<Assoc = bool>`, but encountered `Trait<Assoc = u8>`
   --> tests/fail/validity/wrong-dyn-trait-assoc-type.rs:LL:CC
    |
 LL |     let v: Box<dyn Trait<Assoc = bool>> = unsafe { std::mem::transmute(v) };

--- a/src/tools/miri/tests/fail/validity/wrong-dyn-trait-generic.stderr
+++ b/src/tools/miri/tests/fail/validity/wrong-dyn-trait-generic.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: wrong trait in wide pointer vtable: expected `Trait<u32>`, but encountered `Trait<i32>`
+error: Undefined Behavior: constructing invalid value of type *const dyn Trait<u32>: wrong trait in wide pointer vtable: expected `Trait<u32>`, but encountered `Trait<i32>`
   --> tests/fail/validity/wrong-dyn-trait-generic.rs:LL:CC
    |
 LL |     let _y: *const dyn Trait<u32> = unsafe { mem::transmute(x) };

--- a/src/tools/miri/tests/fail/validity/wrong-dyn-trait.stderr
+++ b/src/tools/miri/tests/fail/validity/wrong-dyn-trait.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: wrong trait in wide pointer vtable: expected `std::fmt::Debug`, but encountered `std::marker::Send`
+error: Undefined Behavior: constructing invalid value of type *const dyn std::fmt::Debug: wrong trait in wide pointer vtable: expected `std::fmt::Debug`, but encountered `std::marker::Send`
   --> tests/fail/validity/wrong-dyn-trait.rs:LL:CC
    |
 LL |     let _y: *const dyn fmt::Debug = unsafe { mem::transmute(x) };

--- a/src/tools/miri/tests/native-lib/fail/invalid_retval.rs
+++ b/src/tools/miri/tests/native-lib/fail/invalid_retval.rs
@@ -9,6 +9,6 @@ extern "C" {
 
 fn main() {
     unsafe {
-        u8_id(2); //~ ERROR: invalid value: encountered 0x02, but expected a boolean
+        u8_id(2); //~ ERROR: encountered 0x02, but expected a boolean
     }
 }

--- a/src/tools/miri/tests/native-lib/fail/invalid_retval.stderr
+++ b/src/tools/miri/tests/native-lib/fail/invalid_retval.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value: encountered 0x02, but expected a boolean
+error: Undefined Behavior: constructing invalid value of type bool: encountered 0x02, but expected a boolean
   --> tests/native-lib/fail/invalid_retval.rs:LL:CC
    |
 LL |         u8_id(2);

--- a/src/tools/miri/tests/native-lib/fail/uninit_struct.stderr
+++ b/src/tools/miri/tests/native-lib/fail/uninit_struct.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value at .part_1.high: encountered uninitialized memory, but expected an integer
+error: Undefined Behavior: constructing invalid value of type ComplexStruct: at .part_1.high, encountered uninitialized memory, but expected an integer
   --> tests/native-lib/fail/uninit_struct.rs:LL:CC
    |
 LL |     unsafe { pass_struct_complex(*arg.as_ptr(), 0, 0, 0) };

--- a/tests/auxiliary/minicore.rs
+++ b/tests/auxiliary/minicore.rs
@@ -238,6 +238,8 @@ impl_marker_trait!(
 
 impl Sync for () {}
 
+impl<T, const N: usize> Sync for [T; N] {}
+
 #[lang = "drop_in_place"]
 fn drop_in_place<T>(_: *mut T) {}
 

--- a/tests/ui/asm/aarch64/aarch64-sve.rs
+++ b/tests/ui/asm/aarch64/aarch64-sve.rs
@@ -1,12 +1,16 @@
-//@ only-aarch64
 //@ build-pass
-//@ needs-asm-support
-
+//@ add-minicore
+//@ compile-flags: --target aarch64-unknown-linux-gnu
+//@ needs-llvm-components: aarch64
+//@ ignore-backends: gcc
 #![crate_type = "rlib"]
+#![feature(no_core)]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
 
 // AArch64 test corresponding to arm64ec-sve.rs.
-
-use std::arch::asm;
 
 fn f(x: f64) {
     unsafe {

--- a/tests/ui/asm/aarch64/bad-options.rs
+++ b/tests/ui/asm/aarch64/bad-options.rs
@@ -1,6 +1,13 @@
-//@ only-aarch64
+//@ add-minicore
+//@ compile-flags: --target aarch64-unknown-linux-gnu
+//@ needs-llvm-components: aarch64
+//@ ignore-backends: gcc
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
 
-use std::arch::{asm, global_asm};
+extern crate minicore;
+use minicore::*;
 
 fn main() {
     let mut foo = 0;

--- a/tests/ui/asm/aarch64/bad-options.stderr
+++ b/tests/ui/asm/aarch64/bad-options.stderr
@@ -1,35 +1,35 @@
 error: the `nomem` and `readonly` options are mutually exclusive
-  --> $DIR/bad-options.rs:8:18
+  --> $DIR/bad-options.rs:15:18
    |
 LL |         asm!("", options(nomem, readonly));
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: the `pure` and `noreturn` options are mutually exclusive
-  --> $DIR/bad-options.rs:10:18
+  --> $DIR/bad-options.rs:17:18
    |
 LL |         asm!("", options(pure, nomem, noreturn));
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: asm with the `pure` option must have at least one output
-  --> $DIR/bad-options.rs:10:18
+  --> $DIR/bad-options.rs:17:18
    |
 LL |         asm!("", options(pure, nomem, noreturn));
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: asm with the `pure` option must have at least one output
-  --> $DIR/bad-options.rs:13:33
+  --> $DIR/bad-options.rs:20:33
    |
 LL |         asm!("{}", in(reg) foo, options(pure, nomem));
    |                                 ^^^^^^^^^^^^^^^^^^^^
 
 error: asm outputs are not allowed with the `noreturn` option
-  --> $DIR/bad-options.rs:15:20
+  --> $DIR/bad-options.rs:22:20
    |
 LL |         asm!("{}", out(reg) foo, options(noreturn));
    |                    ^^^^^^^^^^^^
 
 error: asm with `clobber_abi` must specify explicit registers for outputs
-  --> $DIR/bad-options.rs:22:20
+  --> $DIR/bad-options.rs:29:20
    |
 LL |         asm!("{}", out(reg) foo, clobber_abi("C"));
    |                    ^^^^^^^^^^^^  ---------------- clobber_abi
@@ -37,43 +37,43 @@ LL |         asm!("{}", out(reg) foo, clobber_abi("C"));
    |                    generic outputs
 
 error: the `nomem` option cannot be used with `global_asm!`
-  --> $DIR/bad-options.rs:28:25
+  --> $DIR/bad-options.rs:35:25
    |
 LL | global_asm!("", options(nomem));
    |                         ^^^^^ the `nomem` option is not meaningful for global-scoped inline assembly
 
 error: the `readonly` option cannot be used with `global_asm!`
-  --> $DIR/bad-options.rs:30:25
+  --> $DIR/bad-options.rs:37:25
    |
 LL | global_asm!("", options(readonly));
    |                         ^^^^^^^^ the `readonly` option is not meaningful for global-scoped inline assembly
 
 error: the `noreturn` option cannot be used with `global_asm!`
-  --> $DIR/bad-options.rs:32:25
+  --> $DIR/bad-options.rs:39:25
    |
 LL | global_asm!("", options(noreturn));
    |                         ^^^^^^^^ the `noreturn` option is not meaningful for global-scoped inline assembly
 
 error: the `pure` option cannot be used with `global_asm!`
-  --> $DIR/bad-options.rs:34:25
+  --> $DIR/bad-options.rs:41:25
    |
 LL | global_asm!("", options(pure));
    |                         ^^^^ the `pure` option is not meaningful for global-scoped inline assembly
 
 error: the `nostack` option cannot be used with `global_asm!`
-  --> $DIR/bad-options.rs:36:25
+  --> $DIR/bad-options.rs:43:25
    |
 LL | global_asm!("", options(nostack));
    |                         ^^^^^^^ the `nostack` option is not meaningful for global-scoped inline assembly
 
 error: the `preserves_flags` option cannot be used with `global_asm!`
-  --> $DIR/bad-options.rs:38:25
+  --> $DIR/bad-options.rs:45:25
    |
 LL | global_asm!("", options(preserves_flags));
    |                         ^^^^^^^^^^^^^^^ the `preserves_flags` option is not meaningful for global-scoped inline assembly
 
 error: invalid ABI for `clobber_abi`
-  --> $DIR/bad-options.rs:20:18
+  --> $DIR/bad-options.rs:27:18
    |
 LL |         asm!("", clobber_abi("foo"));
    |                  ^^^^^^^^^^^^^^^^^^

--- a/tests/ui/asm/aarch64/bad-reg.rs
+++ b/tests/ui/asm/aarch64/bad-reg.rs
@@ -1,6 +1,7 @@
 //@ add-minicore
-//@ only-aarch64
-//@ compile-flags: -C target-feature=+neon
+//@ compile-flags: --target aarch64-unknown-linux-gnu -C target-feature=+neon
+//@ needs-llvm-components: aarch64
+//@ ignore-backends: gcc
 #![crate_type = "lib"]
 #![feature(no_core)]
 #![no_core]

--- a/tests/ui/asm/aarch64/bad-reg.stderr
+++ b/tests/ui/asm/aarch64/bad-reg.stderr
@@ -1,5 +1,5 @@
 error: invalid register class `foo`: unknown register class
-  --> $DIR/bad-reg.rs:17:20
+  --> $DIR/bad-reg.rs:18:20
    |
 LL |         asm!("{}", in(foo) foo);
    |                    ^^^^^^^^^^^
@@ -7,13 +7,13 @@ LL |         asm!("{}", in(foo) foo);
    = note: the following register classes are supported on this target: `reg`, `vreg`, `vreg_low16`, and `preg`
 
 error: invalid register `foo`: unknown register
-  --> $DIR/bad-reg.rs:19:18
+  --> $DIR/bad-reg.rs:20:18
    |
 LL |         asm!("", in("foo") foo);
    |                  ^^^^^^^^^^^^^
 
 error: invalid asm template modifier `z` for this register class
-  --> $DIR/bad-reg.rs:21:15
+  --> $DIR/bad-reg.rs:22:15
    |
 LL |         asm!("{:z}", in(reg) foo);
    |               ^^^^   ----------- argument
@@ -23,7 +23,7 @@ LL |         asm!("{:z}", in(reg) foo);
    = note: the `reg` register class supports the following template modifiers: `w` and `x`
 
 error: invalid asm template modifier `r` for this register class
-  --> $DIR/bad-reg.rs:23:15
+  --> $DIR/bad-reg.rs:24:15
    |
 LL |         asm!("{:r}", in(vreg) foo);
    |               ^^^^   ------------ argument
@@ -33,7 +33,7 @@ LL |         asm!("{:r}", in(vreg) foo);
    = note: the `vreg` register class supports the following template modifiers: `b`, `h`, `s`, `d`, `q`, and `v`
 
 error: invalid asm template modifier `r` for this register class
-  --> $DIR/bad-reg.rs:25:15
+  --> $DIR/bad-reg.rs:26:15
    |
 LL |         asm!("{:r}", in(vreg_low16) foo);
    |               ^^^^   ------------------ argument
@@ -43,7 +43,7 @@ LL |         asm!("{:r}", in(vreg_low16) foo);
    = note: the `vreg_low16` register class supports the following template modifiers: `b`, `h`, `s`, `d`, `q`, and `v`
 
 error: asm template modifiers are not allowed for `const` arguments
-  --> $DIR/bad-reg.rs:27:15
+  --> $DIR/bad-reg.rs:28:15
    |
 LL |         asm!("{:a}", const 0);
    |               ^^^^   ------- argument
@@ -51,7 +51,7 @@ LL |         asm!("{:a}", const 0);
    |               template modifier
 
 error: asm template modifiers are not allowed for `sym` arguments
-  --> $DIR/bad-reg.rs:29:15
+  --> $DIR/bad-reg.rs:30:15
    |
 LL |         asm!("{:a}", sym main);
    |               ^^^^   -------- argument
@@ -59,49 +59,49 @@ LL |         asm!("{:a}", sym main);
    |               template modifier
 
 error: invalid register `x29`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:31:18
+  --> $DIR/bad-reg.rs:32:18
    |
 LL |         asm!("", in("x29") foo);
    |                  ^^^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:33:18
+  --> $DIR/bad-reg.rs:34:18
    |
 LL |         asm!("", in("sp") foo);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `xzr`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:35:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", in("xzr") foo);
    |                  ^^^^^^^^^^^^^
 
 error: invalid register `x19`: x19 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:38:18
    |
 LL |         asm!("", in("x19") foo);
    |                  ^^^^^^^^^^^^^
 
 error: register class `preg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", in("p0") foo);
    |                  ^^^^^^^^^^^^
 
 error: register class `preg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:44:20
+  --> $DIR/bad-reg.rs:45:20
    |
 LL |         asm!("{}", in(preg) foo);
    |                    ^^^^^^^^^^^^
 
 error: register class `preg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:47:20
+  --> $DIR/bad-reg.rs:48:20
    |
 LL |         asm!("{}", out(preg) _);
    |                    ^^^^^^^^^^^
 
 error: register `w0` conflicts with register `x0`
-  --> $DIR/bad-reg.rs:53:32
+  --> $DIR/bad-reg.rs:54:32
    |
 LL |         asm!("", in("x0") foo, in("w0") bar);
    |                  ------------  ^^^^^^^^^^^^ register `w0`
@@ -109,7 +109,7 @@ LL |         asm!("", in("x0") foo, in("w0") bar);
    |                  register `x0`
 
 error: register `x0` conflicts with register `x0`
-  --> $DIR/bad-reg.rs:55:32
+  --> $DIR/bad-reg.rs:56:32
    |
 LL |         asm!("", in("x0") foo, out("x0") bar);
    |                  ------------  ^^^^^^^^^^^^^ register `x0`
@@ -117,13 +117,13 @@ LL |         asm!("", in("x0") foo, out("x0") bar);
    |                  register `x0`
    |
 help: use `lateout` instead of `out` to avoid conflict
-  --> $DIR/bad-reg.rs:55:18
+  --> $DIR/bad-reg.rs:56:18
    |
 LL |         asm!("", in("x0") foo, out("x0") bar);
    |                  ^^^^^^^^^^^^
 
 error: register `q0` conflicts with register `v0`
-  --> $DIR/bad-reg.rs:58:32
+  --> $DIR/bad-reg.rs:59:32
    |
 LL |         asm!("", in("v0") foo, in("q0") bar);
    |                  ------------  ^^^^^^^^^^^^ register `q0`
@@ -131,7 +131,7 @@ LL |         asm!("", in("v0") foo, in("q0") bar);
    |                  register `v0`
 
 error: register `q0` conflicts with register `v0`
-  --> $DIR/bad-reg.rs:60:32
+  --> $DIR/bad-reg.rs:61:32
    |
 LL |         asm!("", in("v0") foo, out("q0") bar);
    |                  ------------  ^^^^^^^^^^^^^ register `q0`
@@ -139,13 +139,13 @@ LL |         asm!("", in("v0") foo, out("q0") bar);
    |                  register `v0`
    |
 help: use `lateout` instead of `out` to avoid conflict
-  --> $DIR/bad-reg.rs:60:18
+  --> $DIR/bad-reg.rs:61:18
    |
 LL |         asm!("", in("v0") foo, out("q0") bar);
    |                  ^^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:40:27
+  --> $DIR/bad-reg.rs:41:27
    |
 LL |         asm!("", in("p0") foo);
    |                           ^^^
@@ -153,7 +153,7 @@ LL |         asm!("", in("p0") foo);
    = note: register class `preg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:44:29
+  --> $DIR/bad-reg.rs:45:29
    |
 LL |         asm!("{}", in(preg) foo);
    |                             ^^^

--- a/tests/ui/asm/aarch64/duplicate-options.fixed
+++ b/tests/ui/asm/aarch64/duplicate-options.fixed
@@ -1,8 +1,14 @@
-//@ only-aarch64
-//@ needs-asm-support
 //@ run-rustfix
+//@ add-minicore
+//@ compile-flags: --target aarch64-unknown-linux-gnu
+//@ needs-llvm-components: aarch64
+//@ needs-asm-support
+//@ ignore-backends: gcc
+#![feature(no_core)]
+#![no_core]
 
-use std::arch::asm;
+extern crate minicore;
+use minicore::*;
 
 fn main() {
     unsafe {

--- a/tests/ui/asm/aarch64/duplicate-options.rs
+++ b/tests/ui/asm/aarch64/duplicate-options.rs
@@ -1,8 +1,14 @@
-//@ only-aarch64
-//@ needs-asm-support
 //@ run-rustfix
+//@ add-minicore
+//@ compile-flags: --target aarch64-unknown-linux-gnu
+//@ needs-llvm-components: aarch64
+//@ needs-asm-support
+//@ ignore-backends: gcc
+#![feature(no_core)]
+#![no_core]
 
-use std::arch::asm;
+extern crate minicore;
+use minicore::*;
 
 fn main() {
     unsafe {

--- a/tests/ui/asm/aarch64/duplicate-options.stderr
+++ b/tests/ui/asm/aarch64/duplicate-options.stderr
@@ -1,53 +1,53 @@
 error: the `nomem` option was already provided
-  --> $DIR/duplicate-options.rs:9:33
+  --> $DIR/duplicate-options.rs:15:33
    |
 LL |         asm!("", options(nomem, nomem));
    |                                 ^^^^^ this option was already provided
 
 error: the `preserves_flags` option was already provided
-  --> $DIR/duplicate-options.rs:11:43
+  --> $DIR/duplicate-options.rs:17:43
    |
 LL |         asm!("", options(preserves_flags, preserves_flags));
    |                                           ^^^^^^^^^^^^^^^ this option was already provided
 
 error: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:13:61
+  --> $DIR/duplicate-options.rs:19:61
    |
 LL |         asm!("", options(nostack, preserves_flags), options(nostack));
    |                                                             ^^^^^^^ this option was already provided
 
 error: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:15:35
+  --> $DIR/duplicate-options.rs:21:35
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
    |                                   ^^^^^^^ this option was already provided
 
 error: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:15:53
+  --> $DIR/duplicate-options.rs:21:53
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
    |                                                     ^^^^^^^ this option was already provided
 
 error: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:15:71
+  --> $DIR/duplicate-options.rs:21:71
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
    |                                                                       ^^^^^^^ this option was already provided
 
 error: the `noreturn` option was already provided
-  --> $DIR/duplicate-options.rs:22:38
+  --> $DIR/duplicate-options.rs:28:38
    |
 LL |             options(preserves_flags, noreturn),
    |                                      ^^^^^^^^ this option was already provided
 
 error: the `nomem` option was already provided
-  --> $DIR/duplicate-options.rs:23:21
+  --> $DIR/duplicate-options.rs:29:21
    |
 LL |             options(nomem, nostack),
    |                     ^^^^^ this option was already provided
 
 error: the `noreturn` option was already provided
-  --> $DIR/duplicate-options.rs:24:21
+  --> $DIR/duplicate-options.rs:30:21
    |
 LL |             options(noreturn),
    |                     ^^^^^^^^ this option was already provided

--- a/tests/ui/asm/aarch64/interpolated-idents.rs
+++ b/tests/ui/asm/aarch64/interpolated-idents.rs
@@ -1,6 +1,13 @@
-//@ only-aarch64
-//@ needs-asm-support
-use std::arch::asm;
+//@ add-minicore
+//@ compile-flags: --target aarch64-unknown-linux-gnu
+//@ needs-llvm-components: aarch64
+//@ ignore-backends: gcc
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
 
 macro_rules! m {
     ($in:ident $out:ident $lateout:ident $inout:ident $inlateout:ident $const:ident $sym:ident

--- a/tests/ui/asm/aarch64/interpolated-idents.stderr
+++ b/tests/ui/asm/aarch64/interpolated-idents.stderr
@@ -1,5 +1,5 @@
 error: the `nomem` and `readonly` options are mutually exclusive
-  --> $DIR/interpolated-idents.rs:13:13
+  --> $DIR/interpolated-idents.rs:20:13
    |
 LL |               $options($pure, $nomem, $readonly, $preserves_flags, $noreturn, $nostack));
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -12,7 +12,7 @@ LL | |        noreturn nostack options);
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: the `pure` and `noreturn` options are mutually exclusive
-  --> $DIR/interpolated-idents.rs:13:13
+  --> $DIR/interpolated-idents.rs:20:13
    |
 LL |               $options($pure, $nomem, $readonly, $preserves_flags, $noreturn, $nostack));
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL | |        noreturn nostack options);
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: asm outputs are not allowed with the `noreturn` option
-  --> $DIR/interpolated-idents.rs:10:32
+  --> $DIR/interpolated-idents.rs:17:32
    |
 LL |               asm!("", $in(x) x, $out(x) x, $lateout(x) x, $inout(x) x, $inlateout(x) x,
    |                                  ^^^^^^^^^  ^^^^^^^^^^^^^  ^^^^^^^^^^^  ^^^^^^^^^^^^^^^

--- a/tests/ui/asm/aarch64/parse-error.rs
+++ b/tests/ui/asm/aarch64/parse-error.rs
@@ -1,6 +1,13 @@
-//@ only-aarch64
+//@ add-minicore
+//@ compile-flags: --target aarch64-unknown-linux-gnu
+//@ needs-llvm-components: aarch64
+//@ ignore-backends: gcc
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
 
-use std::arch::asm;
+extern crate minicore;
+use minicore::*;
 
 fn main() {
     let mut foo = 0;

--- a/tests/ui/asm/aarch64/parse-error.stderr
+++ b/tests/ui/asm/aarch64/parse-error.stderr
@@ -1,11 +1,11 @@
 error: explicit register arguments cannot have names
-  --> $DIR/parse-error.rs:9:18
+  --> $DIR/parse-error.rs:16:18
    |
 LL |         asm!("", a = in("x0") foo);
    |                  ^^^^^^^^^^^^^^^^
 
 error: positional arguments cannot follow named arguments or explicit register arguments
-  --> $DIR/parse-error.rs:15:35
+  --> $DIR/parse-error.rs:22:35
    |
 LL |         asm!("{1}", in("x0") foo, const bar);
    |                     ------------  ^^^^^^^^^ positional argument
@@ -13,7 +13,7 @@ LL |         asm!("{1}", in("x0") foo, const bar);
    |                     explicit register argument
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:11:45
+  --> $DIR/parse-error.rs:18:45
    |
 LL |         asm!("{a}", in("x0") foo, a = const bar);
    |                                             ^^^ non-constant value
@@ -25,7 +25,7 @@ LL +     const bar: /* Type */ = 0;
    |
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:13:45
+  --> $DIR/parse-error.rs:20:45
    |
 LL |         asm!("{a}", in("x0") foo, a = const bar);
    |                                             ^^^ non-constant value
@@ -37,7 +37,7 @@ LL +     const bar: /* Type */ = 0;
    |
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:15:41
+  --> $DIR/parse-error.rs:22:41
    |
 LL |         asm!("{1}", in("x0") foo, const bar);
    |                                         ^^^ non-constant value

--- a/tests/ui/asm/aarch64/srcloc.rs
+++ b/tests/ui/asm/aarch64/srcloc.rs
@@ -1,12 +1,19 @@
-//@ only-aarch64
+//@ add-minicore
 //@ build-fail
 //@ needs-asm-support
-//@ compile-flags: -Ccodegen-units=1
+//@ compile-flags: --target aarch64-unknown-linux-gnu -Ccodegen-units=1
+//@ needs-llvm-components: aarch64
+//@ ignore-backends: gcc
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
 
-use std::arch::asm;
+extern crate minicore;
+use minicore::*;
 
 // Checks that inline asm errors are mapped to the correct line in the source code.
-
+#[unsafe(no_mangle)]
+#[rustfmt::skip]
 fn main() {
     unsafe {
         asm!("invalid_instruction");

--- a/tests/ui/asm/aarch64/srcloc.stderr
+++ b/tests/ui/asm/aarch64/srcloc.stderr
@@ -1,5 +1,5 @@
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:12:15
+  --> $DIR/srcloc.rs:19:15
    |
 LL |         asm!("invalid_instruction");
    |               ^^^^^^^^^^^^^^^^^^^
@@ -11,7 +11,7 @@ LL |     invalid_instruction
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:16:13
+  --> $DIR/srcloc.rs:23:13
    |
 LL |             invalid_instruction
    |             ^^^^^^^^^^^^^^^^^^^
@@ -23,25 +23,13 @@ LL |             invalid_instruction
    |             ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:21:13
+  --> $DIR/srcloc.rs:28:13
    |
 LL |             invalid_instruction
    |             ^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:2:13
-   |
-LL |             invalid_instruction
-   |             ^
-
-error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:27:13
-   |
-LL |             invalid_instruction
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-note: instantiated into assembly here
-  --> <inline asm>:3:13
    |
 LL |             invalid_instruction
    |             ^
@@ -59,7 +47,19 @@ LL |             invalid_instruction
    |             ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:39:14
+  --> $DIR/srcloc.rs:41:13
+   |
+LL |             invalid_instruction
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:3:13
+   |
+LL |             invalid_instruction
+   |             ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:46:14
    |
 LL |         asm!(concat!("invalid", "_", "instruction"));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -71,7 +71,7 @@ LL |     invalid_instruction
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:43:14
+  --> $DIR/srcloc.rs:50:14
    |
 LL |             "invalid_instruction",
    |              ^^^^^^^^^^^^^^^^^^^
@@ -83,37 +83,25 @@ LL |     invalid_instruction
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:49:14
-   |
-LL |             "invalid_instruction",
-   |              ^^^^^^^^^^^^^^^^^^^
-   |
-note: instantiated into assembly here
-  --> <inline asm>:2:1
-   |
-LL | invalid_instruction
-   | ^
-
-error: unrecognized instruction mnemonic
   --> $DIR/srcloc.rs:56:14
    |
 LL |             "invalid_instruction",
    |              ^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
-  --> <inline asm>:3:1
+  --> <inline asm>:2:1
    |
 LL | invalid_instruction
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:63:13
+  --> $DIR/srcloc.rs:63:14
    |
-LL |             concat!("invalid", "_", "instruction"),
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |             "invalid_instruction",
+   |              ^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
-  --> <inline asm>:2:1
+  --> <inline asm>:3:1
    |
 LL | invalid_instruction
    | ^
@@ -131,7 +119,19 @@ LL | invalid_instruction
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:77:14
+  --> $DIR/srcloc.rs:77:13
+   |
+LL |             concat!("invalid", "_", "instruction"),
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:2:1
+   |
+LL | invalid_instruction
+   | ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:84:14
    |
 LL |             "invalid_instruction1",
    |              ^^^^^^^^^^^^^^^^^^^^
@@ -143,7 +143,7 @@ LL |     invalid_instruction1
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:78:14
+  --> $DIR/srcloc.rs:85:14
    |
 LL |             "invalid_instruction2",
    |              ^^^^^^^^^^^^^^^^^^^^
@@ -155,7 +155,7 @@ LL | invalid_instruction2
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:84:13
+  --> $DIR/srcloc.rs:91:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction1", "\n",
@@ -170,7 +170,7 @@ LL |     invalid_instruction1
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:84:13
+  --> $DIR/srcloc.rs:91:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction1", "\n",
@@ -185,7 +185,7 @@ LL | invalid_instruction2
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:93:13
+  --> $DIR/srcloc.rs:100:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction1", "\n",
@@ -200,7 +200,7 @@ LL |     invalid_instruction1
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:93:13
+  --> $DIR/srcloc.rs:100:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction1", "\n",
@@ -215,7 +215,7 @@ LL | invalid_instruction2
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:97:13
+  --> $DIR/srcloc.rs:104:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction3", "\n",
@@ -230,7 +230,7 @@ LL | invalid_instruction3
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:97:13
+  --> $DIR/srcloc.rs:104:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction3", "\n",
@@ -245,7 +245,7 @@ LL | invalid_instruction4
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:108:13
+  --> $DIR/srcloc.rs:115:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction1", "\n",
@@ -260,7 +260,7 @@ LL |     invalid_instruction1
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:108:13
+  --> $DIR/srcloc.rs:115:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction1", "\n",
@@ -275,7 +275,7 @@ LL | invalid_instruction2
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:112:13
+  --> $DIR/srcloc.rs:119:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction3", "\n",
@@ -290,7 +290,7 @@ LL | invalid_instruction3
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:112:13
+  --> $DIR/srcloc.rs:119:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction3", "\n",
@@ -305,7 +305,7 @@ LL | invalid_instruction4
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:125:14
+  --> $DIR/srcloc.rs:132:14
    |
 LL |             "invalid_instruction"
    |              ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/asm/aarch64/ttbr0_el2.rs
+++ b/tests/ui/asm/aarch64/ttbr0_el2.rs
@@ -1,7 +1,15 @@
 //! Regression test for #97724, recognising ttbr0_el2 as a valid armv8 system register
-//@ only-aarch64
+//@ add-minicore
 //@ build-pass
-use std::arch::asm;
+//@ compile-flags: --target aarch64-unknown-linux-gnu
+//@ needs-llvm-components: aarch64
+//@ ignore-backends: gcc
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
 
 static PT: [u64; 512] = [0; 512];
 fn main() {

--- a/tests/ui/asm/x86_64/bad-clobber-abi.rs
+++ b/tests/ui/asm/x86_64/bad-clobber-abi.rs
@@ -1,7 +1,12 @@
-//@ needs-asm-support
-//@ only-x86_64
+//@ add-minicore
+//@ compile-flags: --target x86_64-unknown-linux-gnu
+//@ needs-llvm-components: x86
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
 
-use std::arch::asm;
+extern crate minicore;
+use minicore::*;
 
 // checks various modes of failure for the `clobber_abi` argument (after parsing)
 

--- a/tests/ui/asm/x86_64/bad-clobber-abi.stderr
+++ b/tests/ui/asm/x86_64/bad-clobber-abi.stderr
@@ -1,5 +1,5 @@
 error: invalid ABI for `clobber_abi`
-  --> $DIR/bad-clobber-abi.rs:11:18
+  --> $DIR/bad-clobber-abi.rs:16:18
    |
 LL |         asm!("", clobber_abi("foo"));
    |                  ^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |         asm!("", clobber_abi("foo"));
    = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, and `sysv64`
 
 error: invalid ABI for `clobber_abi`
-  --> $DIR/bad-clobber-abi.rs:13:35
+  --> $DIR/bad-clobber-abi.rs:18:35
    |
 LL |         asm!("", clobber_abi("C", "foo"));
    |                                   ^^^^^
@@ -15,7 +15,7 @@ LL |         asm!("", clobber_abi("C", "foo"));
    = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, and `sysv64`
 
 error: `C` ABI specified multiple times
-  --> $DIR/bad-clobber-abi.rs:15:35
+  --> $DIR/bad-clobber-abi.rs:20:35
    |
 LL |         asm!("", clobber_abi("C", "C"));
    |                              ---  ^^^
@@ -23,7 +23,7 @@ LL |         asm!("", clobber_abi("C", "C"));
    |                              previously specified here
 
 error: `win64` ABI specified multiple times
-  --> $DIR/bad-clobber-abi.rs:18:39
+  --> $DIR/bad-clobber-abi.rs:23:39
    |
 LL |         asm!("", clobber_abi("win64", "efiapi"));
    |                              -------  ^^^^^^^^
@@ -33,7 +33,7 @@ LL |         asm!("", clobber_abi("win64", "efiapi"));
    = note: these ABIs are equivalent on the current target
 
 error: invalid ABI for `clobber_abi`
-  --> $DIR/bad-clobber-abi.rs:20:35
+  --> $DIR/bad-clobber-abi.rs:25:35
    |
 LL |         asm!("", clobber_abi("C", "foo", "C"));
    |                                   ^^^^^
@@ -41,7 +41,7 @@ LL |         asm!("", clobber_abi("C", "foo", "C"));
    = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, and `sysv64`
 
 error: `C` ABI specified multiple times
-  --> $DIR/bad-clobber-abi.rs:20:42
+  --> $DIR/bad-clobber-abi.rs:25:42
    |
 LL |         asm!("", clobber_abi("C", "foo", "C"));
    |                              ---         ^^^
@@ -49,7 +49,7 @@ LL |         asm!("", clobber_abi("C", "foo", "C"));
    |                              previously specified here
 
 error: invalid ABI for `clobber_abi`
-  --> $DIR/bad-clobber-abi.rs:23:39
+  --> $DIR/bad-clobber-abi.rs:28:39
    |
 LL |         asm!("", clobber_abi("win64", "foo", "efiapi"));
    |                                       ^^^^^
@@ -57,7 +57,7 @@ LL |         asm!("", clobber_abi("win64", "foo", "efiapi"));
    = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, and `sysv64`
 
 error: `win64` ABI specified multiple times
-  --> $DIR/bad-clobber-abi.rs:23:46
+  --> $DIR/bad-clobber-abi.rs:28:46
    |
 LL |         asm!("", clobber_abi("win64", "foo", "efiapi"));
    |                              -------         ^^^^^^^^
@@ -67,7 +67,7 @@ LL |         asm!("", clobber_abi("win64", "foo", "efiapi"));
    = note: these ABIs are equivalent on the current target
 
 error: `C` ABI specified multiple times
-  --> $DIR/bad-clobber-abi.rs:26:36
+  --> $DIR/bad-clobber-abi.rs:31:36
    |
 LL |         asm!("", clobber_abi("C"), clobber_abi("C"));
    |                  ----------------  ^^^^^^^^^^^^^^^^
@@ -75,7 +75,7 @@ LL |         asm!("", clobber_abi("C"), clobber_abi("C"));
    |                  previously specified here
 
 error: `win64` ABI specified multiple times
-  --> $DIR/bad-clobber-abi.rs:29:40
+  --> $DIR/bad-clobber-abi.rs:34:40
    |
 LL |         asm!("", clobber_abi("win64"), clobber_abi("efiapi"));
    |                  --------------------  ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/asm/x86_64/bad-options.rs
+++ b/tests/ui/asm/x86_64/bad-options.rs
@@ -1,8 +1,13 @@
-//@ only-x86_64
-
+//@ add-minicore
+//@ compile-flags: --target x86_64-unknown-linux-gnu
+//@ needs-llvm-components: x86
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
 #![feature(asm_unwind)]
 
-use std::arch::{asm, global_asm};
+extern crate minicore;
+use minicore::*;
 
 fn main() {
     let mut foo = 0;

--- a/tests/ui/asm/x86_64/bad-options.stderr
+++ b/tests/ui/asm/x86_64/bad-options.stderr
@@ -1,41 +1,41 @@
 error: the `nomem` and `readonly` options are mutually exclusive
-  --> $DIR/bad-options.rs:10:18
+  --> $DIR/bad-options.rs:15:18
    |
 LL |         asm!("", options(nomem, readonly));
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: the `pure` and `noreturn` options are mutually exclusive
-  --> $DIR/bad-options.rs:12:18
+  --> $DIR/bad-options.rs:17:18
    |
 LL |         asm!("", options(pure, nomem, noreturn));
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: asm with the `pure` option must have at least one output
-  --> $DIR/bad-options.rs:12:18
+  --> $DIR/bad-options.rs:17:18
    |
 LL |         asm!("", options(pure, nomem, noreturn));
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: asm with the `pure` option must have at least one output
-  --> $DIR/bad-options.rs:15:33
+  --> $DIR/bad-options.rs:20:33
    |
 LL |         asm!("{}", in(reg) foo, options(pure, nomem));
    |                                 ^^^^^^^^^^^^^^^^^^^^
 
 error: asm outputs are not allowed with the `noreturn` option
-  --> $DIR/bad-options.rs:17:20
+  --> $DIR/bad-options.rs:22:20
    |
 LL |         asm!("{}", out(reg) foo, options(noreturn));
    |                    ^^^^^^^^^^^^
 
 error: asm labels are not allowed with the `may_unwind` option
-  --> $DIR/bad-options.rs:19:20
+  --> $DIR/bad-options.rs:24:20
    |
 LL |         asm!("{}", label {}, options(may_unwind));
    |                    ^^^^^^^^
 
 error: asm with `clobber_abi` must specify explicit registers for outputs
-  --> $DIR/bad-options.rs:26:20
+  --> $DIR/bad-options.rs:31:20
    |
 LL |         asm!("{}", out(reg) foo, clobber_abi("C"));
    |                    ^^^^^^^^^^^^  ---------------- clobber_abi
@@ -43,7 +43,7 @@ LL |         asm!("{}", out(reg) foo, clobber_abi("C"));
    |                    generic outputs
 
 error: asm with `clobber_abi` must specify explicit registers for outputs
-  --> $DIR/bad-options.rs:28:20
+  --> $DIR/bad-options.rs:33:20
    |
 LL |         asm!("{}", out(reg) foo, clobber_abi("C"), clobber_abi("C"));
    |                    ^^^^^^^^^^^^  ----------------  ---------------- clobber_abi
@@ -52,43 +52,43 @@ LL |         asm!("{}", out(reg) foo, clobber_abi("C"), clobber_abi("C"));
    |                    generic outputs
 
 error: the `nomem` option cannot be used with `global_asm!`
-  --> $DIR/bad-options.rs:35:25
+  --> $DIR/bad-options.rs:40:25
    |
 LL | global_asm!("", options(nomem));
    |                         ^^^^^ the `nomem` option is not meaningful for global-scoped inline assembly
 
 error: the `readonly` option cannot be used with `global_asm!`
-  --> $DIR/bad-options.rs:37:25
+  --> $DIR/bad-options.rs:42:25
    |
 LL | global_asm!("", options(readonly));
    |                         ^^^^^^^^ the `readonly` option is not meaningful for global-scoped inline assembly
 
 error: the `noreturn` option cannot be used with `global_asm!`
-  --> $DIR/bad-options.rs:39:25
+  --> $DIR/bad-options.rs:44:25
    |
 LL | global_asm!("", options(noreturn));
    |                         ^^^^^^^^ the `noreturn` option is not meaningful for global-scoped inline assembly
 
 error: the `pure` option cannot be used with `global_asm!`
-  --> $DIR/bad-options.rs:41:25
+  --> $DIR/bad-options.rs:46:25
    |
 LL | global_asm!("", options(pure));
    |                         ^^^^ the `pure` option is not meaningful for global-scoped inline assembly
 
 error: the `nostack` option cannot be used with `global_asm!`
-  --> $DIR/bad-options.rs:43:25
+  --> $DIR/bad-options.rs:48:25
    |
 LL | global_asm!("", options(nostack));
    |                         ^^^^^^^ the `nostack` option is not meaningful for global-scoped inline assembly
 
 error: the `preserves_flags` option cannot be used with `global_asm!`
-  --> $DIR/bad-options.rs:45:25
+  --> $DIR/bad-options.rs:50:25
    |
 LL | global_asm!("", options(preserves_flags));
    |                         ^^^^^^^^^^^^^^^ the `preserves_flags` option is not meaningful for global-scoped inline assembly
 
 error: invalid ABI for `clobber_abi`
-  --> $DIR/bad-options.rs:24:18
+  --> $DIR/bad-options.rs:29:18
    |
 LL |         asm!("", clobber_abi("foo"));
    |                  ^^^^^^^^^^^^^^^^^^
@@ -96,7 +96,7 @@ LL |         asm!("", clobber_abi("foo"));
    = note: the following ABIs are supported on this target: `C`, `system`, `efiapi`, `win64`, and `sysv64`
 
 error: `C` ABI specified multiple times
-  --> $DIR/bad-options.rs:28:52
+  --> $DIR/bad-options.rs:33:52
    |
 LL |         asm!("{}", out(reg) foo, clobber_abi("C"), clobber_abi("C"));
    |                                  ----------------  ^^^^^^^^^^^^^^^^

--- a/tests/ui/asm/x86_64/bad-reg.rs
+++ b/tests/ui/asm/x86_64/bad-reg.rs
@@ -1,7 +1,7 @@
 //@ add-minicore
-//@ only-x86_64
 //@ revisions: stable experimental_reg
-//@ compile-flags: -C target-feature=+avx2,+avx512f
+//@ compile-flags: --target x86_64-unknown-linux-gnu -C target-feature=+avx2,+avx512f
+//@ needs-llvm-components: x86
 #![cfg_attr(experimental_reg, feature(asm_experimental_reg))]
 
 #![crate_type = "lib"]

--- a/tests/ui/asm/x86_64/goto-block-safe.rs
+++ b/tests/ui/asm/x86_64/goto-block-safe.rs
@@ -1,16 +1,22 @@
-//@ only-x86_64
+//@ add-minicore
+//@ compile-flags: --target x86_64-unknown-linux-gnu
+//@ needs-llvm-components: x86
 //@ needs-asm-support
-
+#![feature(no_core)]
+#![no_core]
 #![deny(unreachable_code)]
 
-use std::arch::asm;
+extern crate minicore;
+use minicore::*;
+
+unsafe fn such_unsafe() {}
 
 fn goto_fallthough() {
     unsafe {
         asm!(
             "/* {} */",
             label {
-                core::hint::unreachable_unchecked();
+                such_unsafe()
                 //~^ ERROR [E0133]
             }
         )

--- a/tests/ui/asm/x86_64/goto-block-safe.stderr
+++ b/tests/ui/asm/x86_64/goto-block-safe.stderr
@@ -1,11 +1,11 @@
-error[E0133]: call to unsafe function `unreachable_unchecked` is unsafe and requires unsafe function or block
-  --> $DIR/goto-block-safe.rs:13:17
+error[E0133]: call to unsafe function `such_unsafe` is unsafe and requires unsafe function or block
+  --> $DIR/goto-block-safe.rs:19:17
    |
 LL |     unsafe {
    |     ------ items do not inherit unsafety from separate enclosing items
 ...
-LL |                 core::hint::unreachable_unchecked();
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+LL |                 such_unsafe()
+   |                 ^^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/tests/ui/asm/x86_64/interpolated-idents.rs
+++ b/tests/ui/asm/x86_64/interpolated-idents.rs
@@ -1,6 +1,12 @@
-//@ only-x86_64
+//@ add-minicore
+//@ compile-flags: --target x86_64-unknown-linux-gnu
+//@ needs-llvm-components: x86
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
 
-use std::arch::asm;
+extern crate minicore;
+use minicore::*;
 
 macro_rules! m {
     ($in:ident $out:ident $lateout:ident $inout:ident $inlateout:ident $const:ident $sym:ident

--- a/tests/ui/asm/x86_64/interpolated-idents.stderr
+++ b/tests/ui/asm/x86_64/interpolated-idents.stderr
@@ -1,5 +1,5 @@
 error: the `nomem` and `readonly` options are mutually exclusive
-  --> $DIR/interpolated-idents.rs:13:13
+  --> $DIR/interpolated-idents.rs:19:13
    |
 LL |               $options($pure, $nomem, $readonly, $preserves_flags, $noreturn, $nostack, $att_syntax));
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -12,7 +12,7 @@ LL | |        noreturn nostack att_syntax options);
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: the `pure` and `noreturn` options are mutually exclusive
-  --> $DIR/interpolated-idents.rs:13:13
+  --> $DIR/interpolated-idents.rs:19:13
    |
 LL |               $options($pure, $nomem, $readonly, $preserves_flags, $noreturn, $nostack, $att_syntax));
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL | |        noreturn nostack att_syntax options);
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: asm outputs are not allowed with the `noreturn` option
-  --> $DIR/interpolated-idents.rs:10:32
+  --> $DIR/interpolated-idents.rs:16:32
    |
 LL |               asm!("", $in(x) x, $out(x) x, $lateout(x) x, $inout(x) x, $inlateout(x) x,
    |                                  ^^^^^^^^^  ^^^^^^^^^^^^^  ^^^^^^^^^^^  ^^^^^^^^^^^^^^^

--- a/tests/ui/asm/x86_64/issue-82869.rs
+++ b/tests/ui/asm/x86_64/issue-82869.rs
@@ -1,10 +1,14 @@
-//@ needs-asm-support
-//@ only-x86_64
-// Make sure rustc doesn't ICE on asm! for a foreign architecture.
-
+//@ add-minicore
+//@ compile-flags: --target x86_64-unknown-linux-gnu
+//@ needs-llvm-components: x86
 #![crate_type = "rlib"]
+#![feature(no_core)]
+#![no_core]
 
-use std::arch::asm;
+extern crate minicore;
+use minicore::*;
+
+// Make sure rustc doesn't ICE on asm! for a foreign architecture.
 
 pub unsafe fn aarch64(a: f64, b: f64) -> f64 {
     let c;

--- a/tests/ui/asm/x86_64/issue-82869.stderr
+++ b/tests/ui/asm/x86_64/issue-82869.stderr
@@ -1,5 +1,5 @@
 error: invalid register class `vreg`: unknown register class
-  --> $DIR/issue-82869.rs:11:32
+  --> $DIR/issue-82869.rs:15:32
    |
 LL |     asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
    |                                ^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |     asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
    = note: the following register classes are supported on this target: `reg`, `reg_abcd`, `reg_byte`, `xmm_reg`, `ymm_reg`, `zmm_reg`, `kreg`, `kreg0`, `mmx_reg`, `x87_reg`, and `tmm_reg`
 
 error: invalid register class `vreg`: unknown register class
-  --> $DIR/issue-82869.rs:11:45
+  --> $DIR/issue-82869.rs:15:45
    |
 LL |     asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
    |                                             ^^^^^^^^^^
@@ -15,7 +15,7 @@ LL |     asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
    = note: the following register classes are supported on this target: `reg`, `reg_abcd`, `reg_byte`, `xmm_reg`, `ymm_reg`, `zmm_reg`, `kreg`, `kreg0`, `mmx_reg`, `x87_reg`, and `tmm_reg`
 
 error: invalid register `d0`: unknown register
-  --> $DIR/issue-82869.rs:11:57
+  --> $DIR/issue-82869.rs:15:57
    |
 LL |       asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
    |  _________________________________________________________^

--- a/tests/ui/asm/x86_64/issue-89875.rs
+++ b/tests/ui/asm/x86_64/issue-89875.rs
@@ -1,9 +1,16 @@
 //@ build-pass
+//@ add-minicore
+//@ compile-flags: --target x86_64-unknown-linux-gnu
+//@ needs-llvm-components: x86
 //@ needs-asm-support
-//@ only-x86_64
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
 
-use std::arch::asm;
+extern crate minicore;
+use minicore::*;
 
+#[unsafe(no_mangle)]
 #[target_feature(enable = "avx")]
 fn foo() {
     unsafe {
@@ -13,5 +20,3 @@ fn foo() {
         );
     }
 }
-
-fn main() {}

--- a/tests/ui/asm/x86_64/issue-96797.rs
+++ b/tests/ui/asm/x86_64/issue-96797.rs
@@ -1,12 +1,16 @@
+//@ add-minicore
 //@ build-pass
-//@ compile-flags: -O
-//@ needs-asm-support
-//@ only-x86_64
-//@ only-linux
+//@ compile-flags: --target x86_64-unknown-linux-gnu -O
+//@ needs-llvm-components: x86
+//@ ignore-backends: gcc
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
 
 // regression test for #96797
-
-use std::arch::global_asm;
 
 #[no_mangle]
 fn my_func() {}

--- a/tests/ui/asm/x86_64/srcloc.rs
+++ b/tests/ui/asm/x86_64/srcloc.rs
@@ -1,12 +1,19 @@
-//@ only-x86_64
+//@ add-minicore
 //@ build-fail
-//@ compile-flags: -Ccodegen-units=1
+//@ compile-flags: --target x86_64-unknown-linux-gnu -Ccodegen-units=1
+//@ needs-llvm-components: x86
 //@ ignore-backends: gcc
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
 
-use std::arch::asm;
+extern crate minicore;
+use minicore::*;
 
 // Checks that inline asm errors are mapped to the correct line in the source code.
 
+#[unsafe(no_mangle)]
+#[rustfmt::skip]
 fn main() {
     unsafe {
         asm!("invalid_instruction");

--- a/tests/ui/asm/x86_64/srcloc.stderr
+++ b/tests/ui/asm/x86_64/srcloc.stderr
@@ -1,5 +1,5 @@
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:12:15
+  --> $DIR/srcloc.rs:19:15
    |
 LL |         asm!("invalid_instruction");
    |               ^^^^^^^^^^^^^^^^^^^
@@ -11,7 +11,7 @@ LL |     invalid_instruction
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:16:13
+  --> $DIR/srcloc.rs:23:13
    |
 LL |             invalid_instruction
    |             ^^^^^^^^^^^^^^^^^^^
@@ -23,25 +23,13 @@ LL |             invalid_instruction
    |             ^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:21:13
+  --> $DIR/srcloc.rs:28:13
    |
 LL |             invalid_instruction
    |             ^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:3:13
-   |
-LL |             invalid_instruction
-   |             ^^^^^^^^^^^^^^^^^^^
-
-error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:27:13
-   |
-LL |             invalid_instruction
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-note: instantiated into assembly here
-  --> <inline asm>:4:13
    |
 LL |             invalid_instruction
    |             ^^^^^^^^^^^^^^^^^^^
@@ -59,7 +47,19 @@ LL |             invalid_instruction
    |             ^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:39:14
+  --> $DIR/srcloc.rs:41:13
+   |
+LL |             invalid_instruction
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:4:13
+   |
+LL |             invalid_instruction
+   |             ^^^^^^^^^^^^^^^^^^^
+
+error: invalid instruction mnemonic 'invalid_instruction'
+  --> $DIR/srcloc.rs:46:14
    |
 LL |         asm!(concat!("invalid", "_", "instruction"));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -71,7 +71,7 @@ LL |     invalid_instruction
    |     ^^^^^^^^^^^^^^^^^^^
 
 warning: scale factor without index register is ignored
-  --> $DIR/srcloc.rs:42:15
+  --> $DIR/srcloc.rs:49:15
    |
 LL |         asm!("movaps %xmm3, (%esi, 2)", options(att_syntax));
    |               ^^^^^^^^^^^^^^^^^^^^^^^
@@ -83,7 +83,7 @@ LL |     movaps %xmm3, (%esi, 2)
    |                          ^
 
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:46:14
+  --> $DIR/srcloc.rs:53:14
    |
 LL |             "invalid_instruction",
    |              ^^^^^^^^^^^^^^^^^^^
@@ -95,37 +95,25 @@ LL |     invalid_instruction
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:52:14
-   |
-LL |             "invalid_instruction",
-   |              ^^^^^^^^^^^^^^^^^^^
-   |
-note: instantiated into assembly here
-  --> <inline asm>:3:1
-   |
-LL | invalid_instruction
-   | ^^^^^^^^^^^^^^^^^^^
-
-error: invalid instruction mnemonic 'invalid_instruction'
   --> $DIR/srcloc.rs:59:14
    |
 LL |             "invalid_instruction",
    |              ^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
-  --> <inline asm>:4:1
+  --> <inline asm>:3:1
    |
 LL | invalid_instruction
    | ^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:66:13
+  --> $DIR/srcloc.rs:66:14
    |
-LL |             concat!("invalid", "_", "instruction"),
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |             "invalid_instruction",
+   |              ^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
-  --> <inline asm>:3:1
+  --> <inline asm>:4:1
    |
 LL | invalid_instruction
    | ^^^^^^^^^^^^^^^^^^^
@@ -142,8 +130,20 @@ note: instantiated into assembly here
 LL | invalid_instruction
    | ^^^^^^^^^^^^^^^^^^^
 
+error: invalid instruction mnemonic 'invalid_instruction'
+  --> $DIR/srcloc.rs:80:13
+   |
+LL |             concat!("invalid", "_", "instruction"),
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:3:1
+   |
+LL | invalid_instruction
+   | ^^^^^^^^^^^^^^^^^^^
+
 error: invalid instruction mnemonic 'invalid_instruction1'
-  --> $DIR/srcloc.rs:80:14
+  --> $DIR/srcloc.rs:87:14
    |
 LL |             "invalid_instruction1",
    |              ^^^^^^^^^^^^^^^^^^^^
@@ -155,7 +155,7 @@ LL |     invalid_instruction1
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction2'
-  --> $DIR/srcloc.rs:81:14
+  --> $DIR/srcloc.rs:88:14
    |
 LL |             "invalid_instruction2",
    |              ^^^^^^^^^^^^^^^^^^^^
@@ -167,7 +167,7 @@ LL | invalid_instruction2
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction1'
-  --> $DIR/srcloc.rs:87:13
+  --> $DIR/srcloc.rs:94:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction1", "\n",
@@ -182,7 +182,7 @@ LL |     invalid_instruction1
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction2'
-  --> $DIR/srcloc.rs:87:13
+  --> $DIR/srcloc.rs:94:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction1", "\n",
@@ -197,7 +197,7 @@ LL | invalid_instruction2
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction1'
-  --> $DIR/srcloc.rs:96:13
+  --> $DIR/srcloc.rs:103:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction1", "\n",
@@ -212,7 +212,7 @@ LL |     invalid_instruction1
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction2'
-  --> $DIR/srcloc.rs:96:13
+  --> $DIR/srcloc.rs:103:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction1", "\n",
@@ -227,7 +227,7 @@ LL | invalid_instruction2
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction3'
-  --> $DIR/srcloc.rs:100:13
+  --> $DIR/srcloc.rs:107:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction3", "\n",
@@ -242,7 +242,7 @@ LL | invalid_instruction3
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction4'
-  --> $DIR/srcloc.rs:100:13
+  --> $DIR/srcloc.rs:107:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction3", "\n",
@@ -257,7 +257,7 @@ LL | invalid_instruction4
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction1'
-  --> $DIR/srcloc.rs:111:13
+  --> $DIR/srcloc.rs:118:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction1", "\n",
@@ -272,7 +272,7 @@ LL |     invalid_instruction1
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction2'
-  --> $DIR/srcloc.rs:111:13
+  --> $DIR/srcloc.rs:118:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction1", "\n",
@@ -287,7 +287,7 @@ LL | invalid_instruction2
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction3'
-  --> $DIR/srcloc.rs:115:13
+  --> $DIR/srcloc.rs:122:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction3", "\n",
@@ -302,7 +302,7 @@ LL | invalid_instruction3
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction4'
-  --> $DIR/srcloc.rs:115:13
+  --> $DIR/srcloc.rs:122:13
    |
 LL | /             concat!(
 LL | |                 "invalid", "_", "instruction3", "\n",
@@ -317,7 +317,7 @@ LL | invalid_instruction4
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:128:14
+  --> $DIR/srcloc.rs:135:14
    |
 LL |             "invalid_instruction"
    |              ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/asm/x86_64/target-feature-attr.rs
+++ b/tests/ui/asm/x86_64/target-feature-attr.rs
@@ -1,15 +1,20 @@
-//@ only-x86_64
+//@ add-minicore
 // Set the base cpu explicitly, in case the default has been changed.
-//@ compile-flags: -C target-cpu=x86-64
+//@ compile-flags: --target x86_64-unknown-linux-gnu -C target-cpu=x86-64
+//@ needs-llvm-components: x86
+#![crate_type = "rlib"]
+#![feature(no_core)]
+#![no_core]
 
-use std::arch::asm;
+extern crate minicore;
+use minicore::*;
 
 #[target_feature(enable = "avx")]
 unsafe fn foo() {
     let mut x = 1;
     let y = 2;
     asm!("vaddps {2:y}, {0:y}, {1:y}", in(ymm_reg) x, in(ymm_reg) y, lateout(ymm_reg) x);
-    assert_eq!(x, 3);
+    let _ = x;
 }
 
 unsafe fn bar() {
@@ -19,7 +24,7 @@ unsafe fn bar() {
     //~^ ERROR: register class `ymm_reg` requires the `avx` target feature
     //~| ERROR: register class `ymm_reg` requires the `avx` target feature
     //~| ERROR: register class `ymm_reg` requires the `avx` target feature
-    assert_eq!(x, 3);
+    let _ = x;
 }
 
 #[target_feature(enable = "avx512bw")]

--- a/tests/ui/asm/x86_64/target-feature-attr.stderr
+++ b/tests/ui/asm/x86_64/target-feature-attr.stderr
@@ -1,23 +1,23 @@
 error: register class `ymm_reg` requires the `avx` target feature
-  --> $DIR/target-feature-attr.rs:18:40
+  --> $DIR/target-feature-attr.rs:23:40
    |
 LL |     asm!("vaddps {2:y}, {0:y}, {1:y}", in(ymm_reg) x, in(ymm_reg) y, lateout(ymm_reg) x);
    |                                        ^^^^^^^^^^^^^
 
 error: register class `ymm_reg` requires the `avx` target feature
-  --> $DIR/target-feature-attr.rs:18:55
+  --> $DIR/target-feature-attr.rs:23:55
    |
 LL |     asm!("vaddps {2:y}, {0:y}, {1:y}", in(ymm_reg) x, in(ymm_reg) y, lateout(ymm_reg) x);
    |                                                       ^^^^^^^^^^^^^
 
 error: register class `ymm_reg` requires the `avx` target feature
-  --> $DIR/target-feature-attr.rs:18:70
+  --> $DIR/target-feature-attr.rs:23:70
    |
 LL |     asm!("vaddps {2:y}, {0:y}, {1:y}", in(ymm_reg) x, in(ymm_reg) y, lateout(ymm_reg) x);
    |                                                                      ^^^^^^^^^^^^^^^^^^
 
 error: register class `kreg` requires at least one of the following target features: avx512bw, avx512f
-  --> $DIR/target-feature-attr.rs:33:23
+  --> $DIR/target-feature-attr.rs:38:23
    |
 LL |     asm!("/* {0} */", in(kreg) x);
    |                       ^^^^^^^^^^

--- a/tests/ui/asm/x86_64/x86_64_parse_error.rs
+++ b/tests/ui/asm/x86_64/x86_64_parse_error.rs
@@ -1,6 +1,12 @@
-//@ only-x86_64
+//@ add-minicore
+//@ compile-flags: --target x86_64-unknown-linux-gnu
+//@ needs-llvm-components: x86
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
 
-use std::arch::asm;
+extern crate minicore;
+use minicore::*;
 
 fn main() {
     let mut foo = 0;
@@ -14,6 +20,6 @@ fn main() {
         //~^ ERROR attempt to use a non-constant value in a constant
         asm!("{1}", in("eax") foo, const bar);
         //~^ ERROR positional arguments cannot follow named arguments or explicit register arguments
-        //~^^ ERROR attempt to use a non-constant value in a constant
+        //~| ERROR attempt to use a non-constant value in a constant
     }
 }

--- a/tests/ui/asm/x86_64/x86_64_parse_error.stderr
+++ b/tests/ui/asm/x86_64/x86_64_parse_error.stderr
@@ -1,11 +1,11 @@
 error: explicit register arguments cannot have names
-  --> $DIR/x86_64_parse_error.rs:9:18
+  --> $DIR/x86_64_parse_error.rs:15:18
    |
 LL |         asm!("", a = in("eax") foo);
    |                  ^^^^^^^^^^^^^^^^^
 
 error: positional arguments cannot follow named arguments or explicit register arguments
-  --> $DIR/x86_64_parse_error.rs:15:36
+  --> $DIR/x86_64_parse_error.rs:21:36
    |
 LL |         asm!("{1}", in("eax") foo, const bar);
    |                     -------------  ^^^^^^^^^ positional argument
@@ -13,7 +13,7 @@ LL |         asm!("{1}", in("eax") foo, const bar);
    |                     explicit register argument
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/x86_64_parse_error.rs:11:46
+  --> $DIR/x86_64_parse_error.rs:17:46
    |
 LL |         asm!("{a}", in("eax") foo, a = const bar);
    |                                              ^^^ non-constant value
@@ -25,7 +25,7 @@ LL +     const bar: /* Type */ = 0;
    |
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/x86_64_parse_error.rs:13:46
+  --> $DIR/x86_64_parse_error.rs:19:46
    |
 LL |         asm!("{a}", in("eax") foo, a = const bar);
    |                                              ^^^ non-constant value
@@ -37,7 +37,7 @@ LL +     const bar: /* Type */ = 0;
    |
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/x86_64_parse_error.rs:15:42
+  --> $DIR/x86_64_parse_error.rs:21:42
    |
 LL |         asm!("{1}", in("eax") foo, const bar);
    |                                          ^^^ non-constant value

--- a/tests/ui/const-generics/mgca/assoc-const-without-type_const.stderr
+++ b/tests/ui/const-generics/mgca/assoc-const-without-type_const.stderr
@@ -1,20 +1,24 @@
 error: use of `const` in the type system not defined as `type const`
   --> $DIR/assoc-const-without-type_const.rs:8:35
    |
-LL |     const SIZE: usize;
-   |     - help: add `type` before `const` for `Tr::SIZE`: `type`
-...
 LL | fn mk_array<T: Tr>(_x: T) -> [(); T::SIZE] {
    |                                   ^^^^^^^
+   |
+help: add `type` before `const` for `Tr::SIZE`
+   |
+LL |     type const SIZE: usize;
+   |     ++++
 
 error: use of `const` in the type system not defined as `type const`
   --> $DIR/assoc-const-without-type_const.rs:10:10
    |
-LL |     const SIZE: usize;
-   |     - help: add `type` before `const` for `Tr::SIZE`: `type`
-...
 LL |     [(); T::SIZE]
    |          ^^^^^^^
+   |
+help: add `type` before `const` for `Tr::SIZE`
+   |
+LL |     type const SIZE: usize;
+   |     ++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/mgca/unmarked-free-const.stderr
+++ b/tests/ui/const-generics/mgca/unmarked-free-const.stderr
@@ -1,11 +1,13 @@
 error: use of `const` in the type system not defined as `type const`
   --> $DIR/unmarked-free-const.rs:9:18
    |
-LL | const N: usize = 4;
-   | - help: add `type` before `const` for `N`: `type`
-...
 LL |     let x = [(); N];
    |                  ^
+   |
+help: add `type` before `const` for `N`
+   |
+LL | type const N: usize = 4;
+   | ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/min_const_generics/invalid-patterns.32bit.stderr
+++ b/tests/ui/const-generics/min_const_generics/invalid-patterns.32bit.stderr
@@ -56,7 +56,7 @@ LL |   get_flag::<false, { unsafe { char_raw.character } }>();
                ff __ __ __                                     │ .░░░
            }
 
-error[E0080]: constructing invalid value: encountered 0x42, but expected a boolean
+error[E0080]: constructing invalid value of type bool: encountered 0x42, but expected a boolean
   --> $DIR/invalid-patterns.rs:42:14
    |
 LL |   get_flag::<{ unsafe { bool_raw.boolean } }, 'z'>();
@@ -67,7 +67,7 @@ LL |   get_flag::<{ unsafe { bool_raw.boolean } }, 'z'>();
                42                                              │ B
            }
 
-error[E0080]: constructing invalid value: encountered 0x42, but expected a boolean
+error[E0080]: constructing invalid value of type bool: encountered 0x42, but expected a boolean
   --> $DIR/invalid-patterns.rs:44:14
    |
 LL |   get_flag::<{ unsafe { bool_raw.boolean } }, { unsafe { char_raw.character } }>();

--- a/tests/ui/const-generics/min_const_generics/invalid-patterns.64bit.stderr
+++ b/tests/ui/const-generics/min_const_generics/invalid-patterns.64bit.stderr
@@ -56,7 +56,7 @@ LL |   get_flag::<false, { unsafe { char_raw.character } }>();
                ff __ __ __                                     │ .░░░
            }
 
-error[E0080]: constructing invalid value: encountered 0x42, but expected a boolean
+error[E0080]: constructing invalid value of type bool: encountered 0x42, but expected a boolean
   --> $DIR/invalid-patterns.rs:42:14
    |
 LL |   get_flag::<{ unsafe { bool_raw.boolean } }, 'z'>();
@@ -67,7 +67,7 @@ LL |   get_flag::<{ unsafe { bool_raw.boolean } }, 'z'>();
                42                                              │ B
            }
 
-error[E0080]: constructing invalid value: encountered 0x42, but expected a boolean
+error[E0080]: constructing invalid value of type bool: encountered 0x42, but expected a boolean
   --> $DIR/invalid-patterns.rs:44:14
    |
 LL |   get_flag::<{ unsafe { bool_raw.boolean } }, { unsafe { char_raw.character } }>();

--- a/tests/ui/const-ptr/forbidden_slices.stderr
+++ b/tests/ui/const-ptr/forbidden_slices.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value: encountered a null reference
+error[E0080]: constructing invalid value of type &[u32]: encountered a null reference
   --> $DIR/forbidden_slices.rs:16:1
    |
 LL | pub static S0: &[u32] = unsafe { from_raw_parts(ptr::null(), 0) };
@@ -9,7 +9,7 @@ LL | pub static S0: &[u32] = unsafe { from_raw_parts(ptr::null(), 0) };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered a null reference
+error[E0080]: constructing invalid value of type &[()]: encountered a null reference
   --> $DIR/forbidden_slices.rs:18:1
    |
 LL | pub static S1: &[()] = unsafe { from_raw_parts(ptr::null(), 0) };
@@ -20,7 +20,7 @@ LL | pub static S1: &[()] = unsafe { from_raw_parts(ptr::null(), 0) };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered a dangling reference (going beyond the bounds of its allocation)
+error[E0080]: constructing invalid value of type &[u32]: encountered a dangling reference (going beyond the bounds of its allocation)
   --> $DIR/forbidden_slices.rs:22:1
    |
 LL | pub static S2: &[u32] = unsafe { from_raw_parts(&D0, 2) };
@@ -31,7 +31,7 @@ LL | pub static S2: &[u32] = unsafe { from_raw_parts(&D0, 2) };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered uninitialized memory, but expected an integer
+error[E0080]: constructing invalid value of type &[u8]: at .<deref>[0], encountered uninitialized memory, but expected an integer
   --> $DIR/forbidden_slices.rs:26:1
    |
 LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) };
@@ -42,7 +42,7 @@ LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) }
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered a pointer, but expected an integer
+error[E0080]: constructing invalid value of type &[u8]: at .<deref>[0], encountered a pointer, but expected an integer
   --> $DIR/forbidden_slices.rs:28:1
    |
 LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, size_of::<&u32>()) };
@@ -55,7 +55,7 @@ LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, size
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered 0x11, but expected a boolean
+error[E0080]: constructing invalid value of type &[bool]: at .<deref>[0], encountered 0x11, but expected a boolean
   --> $DIR/forbidden_slices.rs:30:1
    |
 LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4) };
@@ -66,7 +66,7 @@ LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4)
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .<deref>[1]: encountered uninitialized memory, but expected an integer
+error[E0080]: constructing invalid value of type &[u16]: at .<deref>[1], encountered uninitialized memory, but expected an integer
   --> $DIR/forbidden_slices.rs:33:1
    |
 LL | pub static S7: &[u16] = unsafe {
@@ -77,7 +77,7 @@ LL | pub static S7: &[u16] = unsafe {
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered a dangling reference (going beyond the bounds of its allocation)
+error[E0080]: constructing invalid value of type &[u64]: encountered a dangling reference (going beyond the bounds of its allocation)
   --> $DIR/forbidden_slices.rs:41:1
    |
 LL | pub static S8: &[u64] = unsafe {
@@ -88,7 +88,7 @@ LL | pub static S8: &[u64] = unsafe {
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered a null reference
+error[E0080]: constructing invalid value of type &[u32]: encountered a null reference
   --> $DIR/forbidden_slices.rs:48:1
    |
 LL | pub static R0: &[u32] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
@@ -111,7 +111,7 @@ error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer 
 LL |     from_ptr_range(ptr..ptr.add(2)) // errors inside libcore
    |                         ^^^^^^^^^^ evaluation of `R2` failed here
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered uninitialized memory, but expected an integer
+error[E0080]: constructing invalid value of type &[u8]: at .<deref>[0], encountered uninitialized memory, but expected an integer
   --> $DIR/forbidden_slices.rs:57:1
    |
 LL | pub static R4: &[u8] = unsafe {
@@ -122,7 +122,7 @@ LL | pub static R4: &[u8] = unsafe {
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered a pointer, but expected an integer
+error[E0080]: constructing invalid value of type &[u8]: at .<deref>[0], encountered a pointer, but expected an integer
   --> $DIR/forbidden_slices.rs:62:1
    |
 LL | pub static R5: &[u8] = unsafe {
@@ -135,7 +135,7 @@ LL | pub static R5: &[u8] = unsafe {
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered 0x11, but expected a boolean
+error[E0080]: constructing invalid value of type &[bool]: at .<deref>[0], encountered 0x11, but expected a boolean
   --> $DIR/forbidden_slices.rs:67:1
    |
 LL | pub static R6: &[bool] = unsafe {
@@ -146,7 +146,7 @@ LL | pub static R6: &[bool] = unsafe {
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered an unaligned reference (required 2 byte alignment but found 1)
+error[E0080]: constructing invalid value of type &[u16]: encountered an unaligned reference (required 2 byte alignment but found 1)
   --> $DIR/forbidden_slices.rs:72:1
    |
 LL | pub static R7: &[u16] = unsafe {

--- a/tests/ui/consts/const-eval/heap/alloc_intrinsic_uninit.32bit.stderr
+++ b/tests/ui/consts/const-eval/heap/alloc_intrinsic_uninit.32bit.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value at .<deref>: encountered uninitialized memory, but expected an integer
+error[E0080]: constructing invalid value of type &i32: at .<deref>, encountered uninitialized memory, but expected an integer
   --> $DIR/alloc_intrinsic_uninit.rs:7:1
    |
 LL | const BAR: &i32 = unsafe {

--- a/tests/ui/consts/const-eval/heap/alloc_intrinsic_uninit.64bit.stderr
+++ b/tests/ui/consts/const-eval/heap/alloc_intrinsic_uninit.64bit.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value at .<deref>: encountered uninitialized memory, but expected an integer
+error[E0080]: constructing invalid value of type &i32: at .<deref>, encountered uninitialized memory, but expected an integer
   --> $DIR/alloc_intrinsic_uninit.rs:7:1
    |
 LL | const BAR: &i32 = unsafe {

--- a/tests/ui/consts/const-eval/heap/dealloc_intrinsic_dangling.stderr
+++ b/tests/ui/consts/const-eval/heap/dealloc_intrinsic_dangling.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value: encountered a dangling reference (use-after-free)
+error[E0080]: constructing invalid value of type &u8: encountered a dangling reference (use-after-free)
   --> $DIR/dealloc_intrinsic_dangling.rs:11:1
    |
 LL | const _X: &'static u8 = unsafe {

--- a/tests/ui/consts/const-eval/raw-bytes.32bit.stderr
+++ b/tests/ui/consts/const-eval/raw-bytes.32bit.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value at .<enum-tag>: encountered 0x00000001, but expected a valid enum tag
+error[E0080]: constructing invalid value of type Enum: at .<enum-tag>, encountered 0x00000001, but expected a valid enum tag
   --> $DIR/raw-bytes.rs:23:1
    |
 LL | const BAD_ENUM: Enum = unsafe { mem::transmute(1usize) };
@@ -9,7 +9,7 @@ LL | const BAD_ENUM: Enum = unsafe { mem::transmute(1usize) };
                01 00 00 00                                     │ ....
            }
 
-error[E0080]: constructing invalid value at .<enum-tag>: encountered 0x00000000, but expected a valid enum tag
+error[E0080]: constructing invalid value of type Enum2: at .<enum-tag>, encountered 0x00000000, but expected a valid enum tag
   --> $DIR/raw-bytes.rs:31:1
    |
 LL | const BAD_ENUM2: Enum2 = unsafe { mem::transmute(0usize) };
@@ -20,7 +20,7 @@ LL | const BAD_ENUM2: Enum2 = unsafe { mem::transmute(0usize) };
                00 00 00 00                                     │ ....
            }
 
-error[E0080]: constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
+error[E0080]: constructing invalid value of type UninhDiscriminant: at .<enum-tag>, encountered an uninhabited enum variant
   --> $DIR/raw-bytes.rs:45:1
    |
 LL | const BAD_UNINHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute(1u8) };
@@ -31,7 +31,7 @@ LL | const BAD_UNINHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute
                01                                              │ .
            }
 
-error[E0080]: constructing invalid value at .<enum-tag>: encountered 0x03, but expected a valid enum tag
+error[E0080]: constructing invalid value of type UninhDiscriminant: at .<enum-tag>, encountered 0x03, but expected a valid enum tag
   --> $DIR/raw-bytes.rs:47:1
    |
 LL | const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute(3u8) };
@@ -42,7 +42,7 @@ LL | const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute
                03                                              │ .
            }
 
-error[E0080]: constructing invalid value at .<enum-variant(Some)>.0.1: encountered 0xffffffff, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
+error[E0080]: constructing invalid value of type Option<(char, char)>: at .<enum-variant(Some)>.0.1, encountered 0xffffffff, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
   --> $DIR/raw-bytes.rs:53:1
    |
 LL | const BAD_OPTION_CHAR: Option<(char, char)> = Some(('x', unsafe { mem::transmute(!0u32) }));
@@ -53,7 +53,7 @@ LL | const BAD_OPTION_CHAR: Option<(char, char)> = Some(('x', unsafe { mem::tran
                78 00 00 00 ff ff ff ff                         │ x.......
            }
 
-error[E0080]: constructing invalid value: encountered 0, but expected something greater or equal to 1
+error[E0080]: constructing invalid value of type NonNull<u8>: encountered 0, but expected something greater or equal to 1
   --> $DIR/raw-bytes.rs:58:1
    |
 LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
@@ -64,7 +64,7 @@ LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
                00 00 00 00                                     │ ....
            }
 
-error[E0080]: constructing invalid value at .0.0: encountered 0, but expected something greater or equal to 1
+error[E0080]: constructing invalid value of type NonZero<u8>: at .0.0, encountered 0, but expected something greater or equal to 1
   --> $DIR/raw-bytes.rs:61:1
    |
 LL | const NULL_U8: NonZero<u8> = unsafe { mem::transmute(0u8) };
@@ -75,7 +75,7 @@ LL | const NULL_U8: NonZero<u8> = unsafe { mem::transmute(0u8) };
                00                                              │ .
            }
 
-error[E0080]: constructing invalid value at .0.0: encountered 0, but expected something greater or equal to 1
+error[E0080]: constructing invalid value of type NonZero<usize>: at .0.0, encountered 0, but expected something greater or equal to 1
   --> $DIR/raw-bytes.rs:63:1
    |
 LL | const NULL_USIZE: NonZero<usize> = unsafe { mem::transmute(0usize) };
@@ -86,7 +86,7 @@ LL | const NULL_USIZE: NonZero<usize> = unsafe { mem::transmute(0usize) };
                00 00 00 00                                     │ ....
            }
 
-error[E0080]: constructing invalid value: encountered 42, but expected something in the range 10..=30
+error[E0080]: constructing invalid value of type RestrictedRange1: encountered 42, but expected something in the range 10..=30
   --> $DIR/raw-bytes.rs:69:1
    |
 LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
@@ -97,7 +97,7 @@ LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
                2a 00 00 00                                     │ *...
            }
 
-error[E0080]: constructing invalid value: encountered 20, but expected something less or equal to 10, or greater or equal to 30
+error[E0080]: constructing invalid value of type RestrictedRange2: encountered 20, but expected something less or equal to 10, or greater or equal to 30
   --> $DIR/raw-bytes.rs:75:1
    |
 LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
@@ -108,7 +108,7 @@ LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
                14 00 00 00                                     │ ....
            }
 
-error[E0080]: constructing invalid value: encountered 0, but expected something greater or equal to 1
+error[E0080]: constructing invalid value of type NonNull<dyn Send>: encountered 0, but expected something greater or equal to 1
   --> $DIR/raw-bytes.rs:78:1
    |
 LL | const NULL_FAT_PTR: NonNull<dyn Send> = unsafe {
@@ -119,7 +119,7 @@ LL | const NULL_FAT_PTR: NonNull<dyn Send> = unsafe {
                00 00 00 00 ╾ALLOC_ID╼                         │ ....╾──╼
            }
 
-error[E0080]: constructing invalid value: encountered an unaligned reference (required 2 byte alignment but found 1)
+error[E0080]: constructing invalid value of type &u16: encountered an unaligned reference (required 2 byte alignment but found 1)
   --> $DIR/raw-bytes.rs:85:1
    |
 LL | const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
@@ -130,7 +130,7 @@ LL | const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
                ╾ALLOC_ID╼                                     │ ╾──╼
            }
 
-error[E0080]: constructing invalid value: encountered an unaligned box (required 2 byte alignment but found 1)
+error[E0080]: constructing invalid value of type Box<u16>: encountered an unaligned box (required 2 byte alignment but found 1)
   --> $DIR/raw-bytes.rs:88:1
    |
 LL | const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
@@ -141,7 +141,7 @@ LL | const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
                ╾ALLOC_ID╼                                     │ ╾──╼
            }
 
-error[E0080]: constructing invalid value: encountered a null reference
+error[E0080]: constructing invalid value of type &u16: encountered a null reference
   --> $DIR/raw-bytes.rs:91:1
    |
 LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
@@ -152,7 +152,7 @@ LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
                00 00 00 00                                     │ ....
            }
 
-error[E0080]: constructing invalid value: encountered a null box
+error[E0080]: constructing invalid value of type Box<u16>: encountered a null box
   --> $DIR/raw-bytes.rs:94:1
    |
 LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
@@ -163,7 +163,7 @@ LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
                00 00 00 00                                     │ ....
            }
 
-error[E0080]: constructing invalid value: encountered a dangling reference (0x539[noalloc] has no provenance)
+error[E0080]: constructing invalid value of type &u8: encountered a dangling reference (0x539[noalloc] has no provenance)
   --> $DIR/raw-bytes.rs:97:1
    |
 LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
@@ -174,7 +174,7 @@ LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
                39 05 00 00                                     │ 9...
            }
 
-error[E0080]: constructing invalid value: encountered a dangling box (0x539[noalloc] has no provenance)
+error[E0080]: constructing invalid value of type Box<u8>: encountered a dangling box (0x539[noalloc] has no provenance)
   --> $DIR/raw-bytes.rs:100:1
    |
 LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
@@ -185,7 +185,7 @@ LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
                39 05 00 00                                     │ 9...
            }
 
-error[E0080]: constructing invalid value: encountered null pointer, but expected a function pointer
+error[E0080]: constructing invalid value of type fn(): encountered null pointer, but expected a function pointer
   --> $DIR/raw-bytes.rs:103:1
    |
 LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
@@ -196,7 +196,7 @@ LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
                00 00 00 00                                     │ ....
            }
 
-error[E0080]: constructing invalid value: encountered 0xd[noalloc], but expected a function pointer
+error[E0080]: constructing invalid value of type fn(): encountered 0xd[noalloc], but expected a function pointer
   --> $DIR/raw-bytes.rs:105:1
    |
 LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
@@ -207,7 +207,7 @@ LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
                0d 00 00 00                                     │ ....
            }
 
-error[E0080]: constructing invalid value: encountered ALLOC3<imm>, but expected a function pointer
+error[E0080]: constructing invalid value of type fn(): encountered ALLOC3<imm>, but expected a function pointer
   --> $DIR/raw-bytes.rs:107:1
    |
 LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
@@ -218,7 +218,7 @@ LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
                ╾ALLOC_ID╼                                     │ ╾──╼
            }
 
-error[E0080]: constructing invalid value: encountered a reference pointing to uninhabited type Bar
+error[E0080]: constructing invalid value of type &Bar: encountered a reference pointing to uninhabited type Bar
   --> $DIR/raw-bytes.rs:113:1
    |
 LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
@@ -229,7 +229,7 @@ LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
                01 00 00 00                                     │ ....
            }
 
-error[E0080]: constructing invalid value: encountered a dangling reference (going beyond the bounds of its allocation)
+error[E0080]: constructing invalid value of type &str: encountered a dangling reference (going beyond the bounds of its allocation)
   --> $DIR/raw-bytes.rs:137:1
    |
 LL | const STR_TOO_LONG: &str = unsafe { mem::transmute((&42u8, 999usize)) };
@@ -240,7 +240,7 @@ LL | const STR_TOO_LONG: &str = unsafe { mem::transmute((&42u8, 999usize)) };
                ╾ALLOC_ID╼ e7 03 00 00                         │ ╾──╼....
            }
 
-error[E0080]: constructing invalid value at .0: encountered invalid reference metadata: slice is bigger than largest supported object
+error[E0080]: constructing invalid value of type (&str,): at .0, encountered invalid reference metadata: slice is bigger than largest supported object
   --> $DIR/raw-bytes.rs:139:1
    |
 LL | const NESTED_STR_MUCH_TOO_LONG: (&str,) = (unsafe { mem::transmute((&42, usize::MAX)) },);
@@ -251,7 +251,7 @@ LL | const NESTED_STR_MUCH_TOO_LONG: (&str,) = (unsafe { mem::transmute((&42, us
                ╾ALLOC_ID╼ ff ff ff ff                         │ ╾──╼....
            }
 
-error[E0080]: constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
+error[E0080]: constructing invalid value of type &MyStr: encountered invalid reference metadata: slice is bigger than largest supported object
   --> $DIR/raw-bytes.rs:141:1
    |
 LL | const MY_STR_MUCH_TOO_LONG: &MyStr = unsafe { mem::transmute((&42u8, usize::MAX)) };
@@ -262,7 +262,7 @@ LL | const MY_STR_MUCH_TOO_LONG: &MyStr = unsafe { mem::transmute((&42u8, usize:
                ╾ALLOC_ID╼ ff ff ff ff                         │ ╾──╼....
            }
 
-error[E0080]: constructing invalid value at .<deref>: encountered uninitialized memory, but expected a string
+error[E0080]: constructing invalid value of type &str: at .<deref>, encountered uninitialized memory, but expected a string
   --> $DIR/raw-bytes.rs:144:1
    |
 LL | const STR_NO_INIT: &str = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit::<u8> { uninit: () }]) };
@@ -273,7 +273,7 @@ LL | const STR_NO_INIT: &str = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit:
                ╾ALLOC_ID╼ 01 00 00 00                         │ ╾──╼....
            }
 
-error[E0080]: constructing invalid value at .<deref>.0: encountered uninitialized memory, but expected a string
+error[E0080]: constructing invalid value of type &MyStr: at .<deref>.0, encountered uninitialized memory, but expected a string
   --> $DIR/raw-bytes.rs:146:1
    |
 LL | const MYSTR_NO_INIT: &MyStr = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit::<u8> { uninit: () }]) };
@@ -284,7 +284,7 @@ LL | const MYSTR_NO_INIT: &MyStr = unsafe { mem::transmute::<&[_], _>(&[MaybeUni
                ╾ALLOC_ID╼ 01 00 00 00                         │ ╾──╼....
            }
 
-error[E0080]: constructing invalid value at .<deref>.0: encountered a pointer, but expected a string
+error[E0080]: constructing invalid value of type &MyStr: at .<deref>.0, encountered a pointer, but expected a string
   --> $DIR/raw-bytes.rs:148:1
    |
 LL | const MYSTR_NO_INIT_ISSUE83182: &MyStr = unsafe { mem::transmute::<&[_], _>(&[&()]) };
@@ -297,7 +297,7 @@ LL | const MYSTR_NO_INIT_ISSUE83182: &MyStr = unsafe { mem::transmute::<&[_], _>
                ╾ALLOC_ID╼ 01 00 00 00                         │ ╾──╼....
            }
 
-error[E0080]: constructing invalid value: encountered a dangling reference (going beyond the bounds of its allocation)
+error[E0080]: constructing invalid value of type &[u8]: encountered a dangling reference (going beyond the bounds of its allocation)
   --> $DIR/raw-bytes.rs:152:1
    |
 LL | const SLICE_TOO_LONG: &[u8] = unsafe { mem::transmute((&42u8, 999usize)) };
@@ -308,7 +308,7 @@ LL | const SLICE_TOO_LONG: &[u8] = unsafe { mem::transmute((&42u8, 999usize)) };
                ╾ALLOC_ID╼ e7 03 00 00                         │ ╾──╼....
            }
 
-error[E0080]: constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
+error[E0080]: constructing invalid value of type &[u32]: encountered invalid reference metadata: slice is bigger than largest supported object
   --> $DIR/raw-bytes.rs:154:1
    |
 LL | const SLICE_TOO_LONG_OVERFLOW: &[u32] = unsafe { mem::transmute((&42u32, isize::MAX)) };
@@ -319,7 +319,7 @@ LL | const SLICE_TOO_LONG_OVERFLOW: &[u32] = unsafe { mem::transmute((&42u32, is
                ╾ALLOC_ID╼ ff ff ff 7f                         │ ╾──╼....
            }
 
-error[E0080]: constructing invalid value: encountered a dangling box (going beyond the bounds of its allocation)
+error[E0080]: constructing invalid value of type Box<[u8]>: encountered a dangling box (going beyond the bounds of its allocation)
   --> $DIR/raw-bytes.rs:157:1
    |
 LL | const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999usize)) };
@@ -330,7 +330,7 @@ LL | const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999us
                ╾ALLOC_ID╼ e7 03 00 00                         │ ╾──╼....
            }
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered 0x03, but expected a boolean
+error[E0080]: constructing invalid value of type &[bool; 1]: at .<deref>[0], encountered 0x03, but expected a boolean
   --> $DIR/raw-bytes.rs:160:1
    |
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
@@ -347,7 +347,7 @@ note: erroneous constant encountered
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: constructing invalid value at .<deref>.0: encountered 0x03, but expected a boolean
+error[E0080]: constructing invalid value of type &MySlice<[bool; 1]>: at .<deref>.0, encountered 0x03, but expected a boolean
   --> $DIR/raw-bytes.rs:164:1
    |
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
@@ -364,7 +364,7 @@ note: erroneous constant encountered
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: constructing invalid value at .<deref>.1[0]: encountered 0x03, but expected a boolean
+error[E0080]: constructing invalid value of type &MySlice<[bool; 1]>: at .<deref>.1[0], encountered 0x03, but expected a boolean
   --> $DIR/raw-bytes.rs:167:1
    |
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
@@ -381,7 +381,7 @@ note: erroneous constant encountered
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: constructing invalid value at .0: encountered ALLOC17<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC17<imm>, but expected a vtable pointer
   --> $DIR/raw-bytes.rs:171:1
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_1: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u8))) };
@@ -392,7 +392,7 @@ LL | const TRAIT_OBJ_SHORT_VTABLE_1: W<&dyn Trait> = unsafe { mem::transmute(W((
                ╾ALLOC_ID╼ ╾ALLOC_ID╼                         │ ╾──╼╾──╼
            }
 
-error[E0080]: constructing invalid value at .0: encountered ALLOC19<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC19<imm>, but expected a vtable pointer
   --> $DIR/raw-bytes.rs:174:1
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_2: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u64))) };
@@ -403,7 +403,7 @@ LL | const TRAIT_OBJ_SHORT_VTABLE_2: W<&dyn Trait> = unsafe { mem::transmute(W((
                ╾ALLOC_ID╼ ╾ALLOC_ID╼                         │ ╾──╼╾──╼
            }
 
-error[E0080]: constructing invalid value at .0: encountered 0x4[noalloc], but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered 0x4[noalloc], but expected a vtable pointer
   --> $DIR/raw-bytes.rs:177:1
    |
 LL | const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, 4usize))) };
@@ -414,7 +414,7 @@ LL | const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u
                ╾ALLOC_ID╼ 04 00 00 00                         │ ╾──╼....
            }
 
-error[E0080]: constructing invalid value at .0: encountered ALLOC22<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC22<imm>, but expected a vtable pointer
   --> $DIR/raw-bytes.rs:179:1
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &[&42u8; 8]))) };
@@ -425,7 +425,7 @@ LL | const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> = unsafe { mem::trans
                ╾ALLOC_ID╼ ╾ALLOC_ID╼                         │ ╾──╼╾──╼
            }
 
-error[E0080]: constructing invalid value at .<deref>.<dyn-downcast>: encountered 0x03, but expected a boolean
+error[E0080]: constructing invalid value of type &dyn Trait: at .<deref>.<dyn-downcast(bool)>, encountered 0x03, but expected a boolean
   --> $DIR/raw-bytes.rs:182:1
    |
 LL | const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, &bool>(&3u8) };
@@ -436,7 +436,7 @@ LL | const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, 
                ╾ALLOC_ID╼ ╾ALLOC_ID╼                         │ ╾──╼╾──╼
            }
 
-error[E0080]: constructing invalid value: encountered null pointer, but expected a vtable pointer
+error[E0080]: constructing invalid value of type *const dyn Trait: encountered null pointer, but expected a vtable pointer
   --> $DIR/raw-bytes.rs:185:1
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_NULL: *const dyn Trait = unsafe { mem::transmute((&92u8, 0usize)) };
@@ -447,7 +447,7 @@ LL | const RAW_TRAIT_OBJ_VTABLE_NULL: *const dyn Trait = unsafe { mem::transmute
                ╾ALLOC_ID╼ 00 00 00 00                         │ ╾──╼....
            }
 
-error[E0080]: constructing invalid value: encountered ALLOC27<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type *const dyn Trait: encountered ALLOC27<imm>, but expected a vtable pointer
   --> $DIR/raw-bytes.rs:187:1
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transmute((&92u8, &3u64)) };
@@ -458,7 +458,7 @@ LL | const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transm
                ╾ALLOC_ID╼ ╾ALLOC_ID╼                         │ ╾──╼╾──╼
            }
 
-error[E0080]: constructing invalid value: encountered a reference pointing to uninhabited type [!; 1]
+error[E0080]: constructing invalid value of type &[!; 1]: encountered a reference pointing to uninhabited type [!; 1]
   --> $DIR/raw-bytes.rs:191:1
    |
 LL | const _: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) };
@@ -469,7 +469,7 @@ LL | const _: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) };
                01 00 00 00                                     │ ....
            }
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered a value of the never type `!`
+error[E0080]: constructing invalid value of type &[!]: at .<deref>[0], encountered a value of the never type `!`
   --> $DIR/raw-bytes.rs:192:1
    |
 LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 1]) };
@@ -480,7 +480,7 @@ LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 1]) };
                01 00 00 00 01 00 00 00                         │ ........
            }
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered a value of the never type `!`
+error[E0080]: constructing invalid value of type &[!]: at .<deref>[0], encountered a value of the never type `!`
   --> $DIR/raw-bytes.rs:193:1
    |
 LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 42]) };
@@ -491,7 +491,7 @@ LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 42]) };
                01 00 00 00 2a 00 00 00                         │ ....*...
            }
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered uninitialized memory, but expected an integer
+error[E0080]: constructing invalid value of type &[u8]: at .<deref>[0], encountered uninitialized memory, but expected an integer
   --> $DIR/raw-bytes.rs:196:1
    |
 LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) };
@@ -502,7 +502,7 @@ LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) }
                ╾ALLOC_ID╼ 01 00 00 00                         │ ╾──╼....
            }
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered a pointer, but expected an integer
+error[E0080]: constructing invalid value of type &[u8]: at .<deref>[0], encountered a pointer, but expected an integer
   --> $DIR/raw-bytes.rs:199:1
    |
 LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, mem::size_of::<&u32>()) };
@@ -515,7 +515,7 @@ LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, mem:
                ╾ALLOC_ID╼ 04 00 00 00                         │ ╾──╼....
            }
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered 0x11, but expected a boolean
+error[E0080]: constructing invalid value of type &[bool]: at .<deref>[0], encountered 0x11, but expected a boolean
   --> $DIR/raw-bytes.rs:202:1
    |
 LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4) };
@@ -526,7 +526,7 @@ LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4)
                ╾ALLOC_ID╼ 04 00 00 00                         │ ╾──╼....
            }
 
-error[E0080]: constructing invalid value at .<deref>[1]: encountered uninitialized memory, but expected an integer
+error[E0080]: constructing invalid value of type &[u16]: at .<deref>[1], encountered uninitialized memory, but expected an integer
   --> $DIR/raw-bytes.rs:206:1
    |
 LL | pub static S7: &[u16] = unsafe {
@@ -537,7 +537,7 @@ LL | pub static S7: &[u16] = unsafe {
                ╾ALLOC_ID+0x2╼ 04 00 00 00                         │ ╾──╼....
            }
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered uninitialized memory, but expected an integer
+error[E0080]: constructing invalid value of type &[u8]: at .<deref>[0], encountered uninitialized memory, but expected an integer
   --> $DIR/raw-bytes.rs:213:1
    |
 LL | pub static R4: &[u8] = unsafe {
@@ -548,7 +548,7 @@ LL | pub static R4: &[u8] = unsafe {
                ╾ALLOC_ID╼ 01 00 00 00                         │ ╾──╼....
            }
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered a pointer, but expected an integer
+error[E0080]: constructing invalid value of type &[u8]: at .<deref>[0], encountered a pointer, but expected an integer
   --> $DIR/raw-bytes.rs:218:1
    |
 LL | pub static R5: &[u8] = unsafe {
@@ -561,7 +561,7 @@ LL | pub static R5: &[u8] = unsafe {
                ╾ALLOC_ID╼ 04 00 00 00                         │ ╾──╼....
            }
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered 0x11, but expected a boolean
+error[E0080]: constructing invalid value of type &[bool]: at .<deref>[0], encountered 0x11, but expected a boolean
   --> $DIR/raw-bytes.rs:223:1
    |
 LL | pub static R6: &[bool] = unsafe {

--- a/tests/ui/consts/const-eval/raw-bytes.64bit.stderr
+++ b/tests/ui/consts/const-eval/raw-bytes.64bit.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value at .<enum-tag>: encountered 0x0000000000000001, but expected a valid enum tag
+error[E0080]: constructing invalid value of type Enum: at .<enum-tag>, encountered 0x0000000000000001, but expected a valid enum tag
   --> $DIR/raw-bytes.rs:23:1
    |
 LL | const BAD_ENUM: Enum = unsafe { mem::transmute(1usize) };
@@ -9,7 +9,7 @@ LL | const BAD_ENUM: Enum = unsafe { mem::transmute(1usize) };
                01 00 00 00 00 00 00 00                         │ ........
            }
 
-error[E0080]: constructing invalid value at .<enum-tag>: encountered 0x0000000000000000, but expected a valid enum tag
+error[E0080]: constructing invalid value of type Enum2: at .<enum-tag>, encountered 0x0000000000000000, but expected a valid enum tag
   --> $DIR/raw-bytes.rs:31:1
    |
 LL | const BAD_ENUM2: Enum2 = unsafe { mem::transmute(0usize) };
@@ -20,7 +20,7 @@ LL | const BAD_ENUM2: Enum2 = unsafe { mem::transmute(0usize) };
                00 00 00 00 00 00 00 00                         │ ........
            }
 
-error[E0080]: constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
+error[E0080]: constructing invalid value of type UninhDiscriminant: at .<enum-tag>, encountered an uninhabited enum variant
   --> $DIR/raw-bytes.rs:45:1
    |
 LL | const BAD_UNINHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute(1u8) };
@@ -31,7 +31,7 @@ LL | const BAD_UNINHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute
                01                                              │ .
            }
 
-error[E0080]: constructing invalid value at .<enum-tag>: encountered 0x03, but expected a valid enum tag
+error[E0080]: constructing invalid value of type UninhDiscriminant: at .<enum-tag>, encountered 0x03, but expected a valid enum tag
   --> $DIR/raw-bytes.rs:47:1
    |
 LL | const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute(3u8) };
@@ -42,7 +42,7 @@ LL | const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute
                03                                              │ .
            }
 
-error[E0080]: constructing invalid value at .<enum-variant(Some)>.0.1: encountered 0xffffffff, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
+error[E0080]: constructing invalid value of type Option<(char, char)>: at .<enum-variant(Some)>.0.1, encountered 0xffffffff, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
   --> $DIR/raw-bytes.rs:53:1
    |
 LL | const BAD_OPTION_CHAR: Option<(char, char)> = Some(('x', unsafe { mem::transmute(!0u32) }));
@@ -53,7 +53,7 @@ LL | const BAD_OPTION_CHAR: Option<(char, char)> = Some(('x', unsafe { mem::tran
                78 00 00 00 ff ff ff ff                         │ x.......
            }
 
-error[E0080]: constructing invalid value: encountered 0, but expected something greater or equal to 1
+error[E0080]: constructing invalid value of type NonNull<u8>: encountered 0, but expected something greater or equal to 1
   --> $DIR/raw-bytes.rs:58:1
    |
 LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
@@ -64,7 +64,7 @@ LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
                00 00 00 00 00 00 00 00                         │ ........
            }
 
-error[E0080]: constructing invalid value at .0.0: encountered 0, but expected something greater or equal to 1
+error[E0080]: constructing invalid value of type NonZero<u8>: at .0.0, encountered 0, but expected something greater or equal to 1
   --> $DIR/raw-bytes.rs:61:1
    |
 LL | const NULL_U8: NonZero<u8> = unsafe { mem::transmute(0u8) };
@@ -75,7 +75,7 @@ LL | const NULL_U8: NonZero<u8> = unsafe { mem::transmute(0u8) };
                00                                              │ .
            }
 
-error[E0080]: constructing invalid value at .0.0: encountered 0, but expected something greater or equal to 1
+error[E0080]: constructing invalid value of type NonZero<usize>: at .0.0, encountered 0, but expected something greater or equal to 1
   --> $DIR/raw-bytes.rs:63:1
    |
 LL | const NULL_USIZE: NonZero<usize> = unsafe { mem::transmute(0usize) };
@@ -86,7 +86,7 @@ LL | const NULL_USIZE: NonZero<usize> = unsafe { mem::transmute(0usize) };
                00 00 00 00 00 00 00 00                         │ ........
            }
 
-error[E0080]: constructing invalid value: encountered 42, but expected something in the range 10..=30
+error[E0080]: constructing invalid value of type RestrictedRange1: encountered 42, but expected something in the range 10..=30
   --> $DIR/raw-bytes.rs:69:1
    |
 LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
@@ -97,7 +97,7 @@ LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
                2a 00 00 00                                     │ *...
            }
 
-error[E0080]: constructing invalid value: encountered 20, but expected something less or equal to 10, or greater or equal to 30
+error[E0080]: constructing invalid value of type RestrictedRange2: encountered 20, but expected something less or equal to 10, or greater or equal to 30
   --> $DIR/raw-bytes.rs:75:1
    |
 LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
@@ -108,7 +108,7 @@ LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
                14 00 00 00                                     │ ....
            }
 
-error[E0080]: constructing invalid value: encountered 0, but expected something greater or equal to 1
+error[E0080]: constructing invalid value of type NonNull<dyn Send>: encountered 0, but expected something greater or equal to 1
   --> $DIR/raw-bytes.rs:78:1
    |
 LL | const NULL_FAT_PTR: NonNull<dyn Send> = unsafe {
@@ -119,7 +119,7 @@ LL | const NULL_FAT_PTR: NonNull<dyn Send> = unsafe {
                00 00 00 00 00 00 00 00 ╾ALLOC_ID╼ │ ........╾──────╼
            }
 
-error[E0080]: constructing invalid value: encountered an unaligned reference (required 2 byte alignment but found 1)
+error[E0080]: constructing invalid value of type &u16: encountered an unaligned reference (required 2 byte alignment but found 1)
   --> $DIR/raw-bytes.rs:85:1
    |
 LL | const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
@@ -130,7 +130,7 @@ LL | const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
                ╾ALLOC_ID╼                         │ ╾──────╼
            }
 
-error[E0080]: constructing invalid value: encountered an unaligned box (required 2 byte alignment but found 1)
+error[E0080]: constructing invalid value of type Box<u16>: encountered an unaligned box (required 2 byte alignment but found 1)
   --> $DIR/raw-bytes.rs:88:1
    |
 LL | const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
@@ -141,7 +141,7 @@ LL | const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
                ╾ALLOC_ID╼                         │ ╾──────╼
            }
 
-error[E0080]: constructing invalid value: encountered a null reference
+error[E0080]: constructing invalid value of type &u16: encountered a null reference
   --> $DIR/raw-bytes.rs:91:1
    |
 LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
@@ -152,7 +152,7 @@ LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
                00 00 00 00 00 00 00 00                         │ ........
            }
 
-error[E0080]: constructing invalid value: encountered a null box
+error[E0080]: constructing invalid value of type Box<u16>: encountered a null box
   --> $DIR/raw-bytes.rs:94:1
    |
 LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
@@ -163,7 +163,7 @@ LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
                00 00 00 00 00 00 00 00                         │ ........
            }
 
-error[E0080]: constructing invalid value: encountered a dangling reference (0x539[noalloc] has no provenance)
+error[E0080]: constructing invalid value of type &u8: encountered a dangling reference (0x539[noalloc] has no provenance)
   --> $DIR/raw-bytes.rs:97:1
    |
 LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
@@ -174,7 +174,7 @@ LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
                39 05 00 00 00 00 00 00                         │ 9.......
            }
 
-error[E0080]: constructing invalid value: encountered a dangling box (0x539[noalloc] has no provenance)
+error[E0080]: constructing invalid value of type Box<u8>: encountered a dangling box (0x539[noalloc] has no provenance)
   --> $DIR/raw-bytes.rs:100:1
    |
 LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
@@ -185,7 +185,7 @@ LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
                39 05 00 00 00 00 00 00                         │ 9.......
            }
 
-error[E0080]: constructing invalid value: encountered null pointer, but expected a function pointer
+error[E0080]: constructing invalid value of type fn(): encountered null pointer, but expected a function pointer
   --> $DIR/raw-bytes.rs:103:1
    |
 LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
@@ -196,7 +196,7 @@ LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
                00 00 00 00 00 00 00 00                         │ ........
            }
 
-error[E0080]: constructing invalid value: encountered 0xd[noalloc], but expected a function pointer
+error[E0080]: constructing invalid value of type fn(): encountered 0xd[noalloc], but expected a function pointer
   --> $DIR/raw-bytes.rs:105:1
    |
 LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
@@ -207,7 +207,7 @@ LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
                0d 00 00 00 00 00 00 00                         │ ........
            }
 
-error[E0080]: constructing invalid value: encountered ALLOC3<imm>, but expected a function pointer
+error[E0080]: constructing invalid value of type fn(): encountered ALLOC3<imm>, but expected a function pointer
   --> $DIR/raw-bytes.rs:107:1
    |
 LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
@@ -218,7 +218,7 @@ LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
                ╾ALLOC_ID╼                         │ ╾──────╼
            }
 
-error[E0080]: constructing invalid value: encountered a reference pointing to uninhabited type Bar
+error[E0080]: constructing invalid value of type &Bar: encountered a reference pointing to uninhabited type Bar
   --> $DIR/raw-bytes.rs:113:1
    |
 LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
@@ -229,7 +229,7 @@ LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
                01 00 00 00 00 00 00 00                         │ ........
            }
 
-error[E0080]: constructing invalid value: encountered a dangling reference (going beyond the bounds of its allocation)
+error[E0080]: constructing invalid value of type &str: encountered a dangling reference (going beyond the bounds of its allocation)
   --> $DIR/raw-bytes.rs:137:1
    |
 LL | const STR_TOO_LONG: &str = unsafe { mem::transmute((&42u8, 999usize)) };
@@ -240,7 +240,7 @@ LL | const STR_TOO_LONG: &str = unsafe { mem::transmute((&42u8, 999usize)) };
                ╾ALLOC_ID╼ e7 03 00 00 00 00 00 00 │ ╾──────╼........
            }
 
-error[E0080]: constructing invalid value at .0: encountered invalid reference metadata: slice is bigger than largest supported object
+error[E0080]: constructing invalid value of type (&str,): at .0, encountered invalid reference metadata: slice is bigger than largest supported object
   --> $DIR/raw-bytes.rs:139:1
    |
 LL | const NESTED_STR_MUCH_TOO_LONG: (&str,) = (unsafe { mem::transmute((&42, usize::MAX)) },);
@@ -251,7 +251,7 @@ LL | const NESTED_STR_MUCH_TOO_LONG: (&str,) = (unsafe { mem::transmute((&42, us
                ╾ALLOC_ID╼ ff ff ff ff ff ff ff ff │ ╾──────╼........
            }
 
-error[E0080]: constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
+error[E0080]: constructing invalid value of type &MyStr: encountered invalid reference metadata: slice is bigger than largest supported object
   --> $DIR/raw-bytes.rs:141:1
    |
 LL | const MY_STR_MUCH_TOO_LONG: &MyStr = unsafe { mem::transmute((&42u8, usize::MAX)) };
@@ -262,7 +262,7 @@ LL | const MY_STR_MUCH_TOO_LONG: &MyStr = unsafe { mem::transmute((&42u8, usize:
                ╾ALLOC_ID╼ ff ff ff ff ff ff ff ff │ ╾──────╼........
            }
 
-error[E0080]: constructing invalid value at .<deref>: encountered uninitialized memory, but expected a string
+error[E0080]: constructing invalid value of type &str: at .<deref>, encountered uninitialized memory, but expected a string
   --> $DIR/raw-bytes.rs:144:1
    |
 LL | const STR_NO_INIT: &str = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit::<u8> { uninit: () }]) };
@@ -273,7 +273,7 @@ LL | const STR_NO_INIT: &str = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit:
                ╾ALLOC_ID╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
-error[E0080]: constructing invalid value at .<deref>.0: encountered uninitialized memory, but expected a string
+error[E0080]: constructing invalid value of type &MyStr: at .<deref>.0, encountered uninitialized memory, but expected a string
   --> $DIR/raw-bytes.rs:146:1
    |
 LL | const MYSTR_NO_INIT: &MyStr = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit::<u8> { uninit: () }]) };
@@ -284,7 +284,7 @@ LL | const MYSTR_NO_INIT: &MyStr = unsafe { mem::transmute::<&[_], _>(&[MaybeUni
                ╾ALLOC_ID╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
-error[E0080]: constructing invalid value at .<deref>.0: encountered a pointer, but expected a string
+error[E0080]: constructing invalid value of type &MyStr: at .<deref>.0, encountered a pointer, but expected a string
   --> $DIR/raw-bytes.rs:148:1
    |
 LL | const MYSTR_NO_INIT_ISSUE83182: &MyStr = unsafe { mem::transmute::<&[_], _>(&[&()]) };
@@ -297,7 +297,7 @@ LL | const MYSTR_NO_INIT_ISSUE83182: &MyStr = unsafe { mem::transmute::<&[_], _>
                ╾ALLOC_ID╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
-error[E0080]: constructing invalid value: encountered a dangling reference (going beyond the bounds of its allocation)
+error[E0080]: constructing invalid value of type &[u8]: encountered a dangling reference (going beyond the bounds of its allocation)
   --> $DIR/raw-bytes.rs:152:1
    |
 LL | const SLICE_TOO_LONG: &[u8] = unsafe { mem::transmute((&42u8, 999usize)) };
@@ -308,7 +308,7 @@ LL | const SLICE_TOO_LONG: &[u8] = unsafe { mem::transmute((&42u8, 999usize)) };
                ╾ALLOC_ID╼ e7 03 00 00 00 00 00 00 │ ╾──────╼........
            }
 
-error[E0080]: constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
+error[E0080]: constructing invalid value of type &[u32]: encountered invalid reference metadata: slice is bigger than largest supported object
   --> $DIR/raw-bytes.rs:154:1
    |
 LL | const SLICE_TOO_LONG_OVERFLOW: &[u32] = unsafe { mem::transmute((&42u32, isize::MAX)) };
@@ -319,7 +319,7 @@ LL | const SLICE_TOO_LONG_OVERFLOW: &[u32] = unsafe { mem::transmute((&42u32, is
                ╾ALLOC_ID╼ ff ff ff ff ff ff ff 7f │ ╾──────╼........
            }
 
-error[E0080]: constructing invalid value: encountered a dangling box (going beyond the bounds of its allocation)
+error[E0080]: constructing invalid value of type Box<[u8]>: encountered a dangling box (going beyond the bounds of its allocation)
   --> $DIR/raw-bytes.rs:157:1
    |
 LL | const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999usize)) };
@@ -330,7 +330,7 @@ LL | const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999us
                ╾ALLOC_ID╼ e7 03 00 00 00 00 00 00 │ ╾──────╼........
            }
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered 0x03, but expected a boolean
+error[E0080]: constructing invalid value of type &[bool; 1]: at .<deref>[0], encountered 0x03, but expected a boolean
   --> $DIR/raw-bytes.rs:160:1
    |
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
@@ -347,7 +347,7 @@ note: erroneous constant encountered
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: constructing invalid value at .<deref>.0: encountered 0x03, but expected a boolean
+error[E0080]: constructing invalid value of type &MySlice<[bool; 1]>: at .<deref>.0, encountered 0x03, but expected a boolean
   --> $DIR/raw-bytes.rs:164:1
    |
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
@@ -364,7 +364,7 @@ note: erroneous constant encountered
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: constructing invalid value at .<deref>.1[0]: encountered 0x03, but expected a boolean
+error[E0080]: constructing invalid value of type &MySlice<[bool; 1]>: at .<deref>.1[0], encountered 0x03, but expected a boolean
   --> $DIR/raw-bytes.rs:167:1
    |
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
@@ -381,7 +381,7 @@ note: erroneous constant encountered
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: constructing invalid value at .0: encountered ALLOC17<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC17<imm>, but expected a vtable pointer
   --> $DIR/raw-bytes.rs:171:1
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_1: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u8))) };
@@ -392,7 +392,7 @@ LL | const TRAIT_OBJ_SHORT_VTABLE_1: W<&dyn Trait> = unsafe { mem::transmute(W((
                ╾ALLOC_ID╼ ╾ALLOC_ID╼ │ ╾──────╼╾──────╼
            }
 
-error[E0080]: constructing invalid value at .0: encountered ALLOC19<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC19<imm>, but expected a vtable pointer
   --> $DIR/raw-bytes.rs:174:1
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_2: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u64))) };
@@ -403,7 +403,7 @@ LL | const TRAIT_OBJ_SHORT_VTABLE_2: W<&dyn Trait> = unsafe { mem::transmute(W((
                ╾ALLOC_ID╼ ╾ALLOC_ID╼ │ ╾──────╼╾──────╼
            }
 
-error[E0080]: constructing invalid value at .0: encountered 0x4[noalloc], but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered 0x4[noalloc], but expected a vtable pointer
   --> $DIR/raw-bytes.rs:177:1
    |
 LL | const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, 4usize))) };
@@ -414,7 +414,7 @@ LL | const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u
                ╾ALLOC_ID╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
-error[E0080]: constructing invalid value at .0: encountered ALLOC22<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC22<imm>, but expected a vtable pointer
   --> $DIR/raw-bytes.rs:179:1
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &[&42u8; 8]))) };
@@ -425,7 +425,7 @@ LL | const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> = unsafe { mem::trans
                ╾ALLOC_ID╼ ╾ALLOC_ID╼ │ ╾──────╼╾──────╼
            }
 
-error[E0080]: constructing invalid value at .<deref>.<dyn-downcast>: encountered 0x03, but expected a boolean
+error[E0080]: constructing invalid value of type &dyn Trait: at .<deref>.<dyn-downcast(bool)>, encountered 0x03, but expected a boolean
   --> $DIR/raw-bytes.rs:182:1
    |
 LL | const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, &bool>(&3u8) };
@@ -436,7 +436,7 @@ LL | const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, 
                ╾ALLOC_ID╼ ╾ALLOC_ID╼ │ ╾──────╼╾──────╼
            }
 
-error[E0080]: constructing invalid value: encountered null pointer, but expected a vtable pointer
+error[E0080]: constructing invalid value of type *const dyn Trait: encountered null pointer, but expected a vtable pointer
   --> $DIR/raw-bytes.rs:185:1
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_NULL: *const dyn Trait = unsafe { mem::transmute((&92u8, 0usize)) };
@@ -447,7 +447,7 @@ LL | const RAW_TRAIT_OBJ_VTABLE_NULL: *const dyn Trait = unsafe { mem::transmute
                ╾ALLOC_ID╼ 00 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
-error[E0080]: constructing invalid value: encountered ALLOC27<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type *const dyn Trait: encountered ALLOC27<imm>, but expected a vtable pointer
   --> $DIR/raw-bytes.rs:187:1
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transmute((&92u8, &3u64)) };
@@ -458,7 +458,7 @@ LL | const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transm
                ╾ALLOC_ID╼ ╾ALLOC_ID╼ │ ╾──────╼╾──────╼
            }
 
-error[E0080]: constructing invalid value: encountered a reference pointing to uninhabited type [!; 1]
+error[E0080]: constructing invalid value of type &[!; 1]: encountered a reference pointing to uninhabited type [!; 1]
   --> $DIR/raw-bytes.rs:191:1
    |
 LL | const _: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) };
@@ -469,7 +469,7 @@ LL | const _: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) };
                01 00 00 00 00 00 00 00                         │ ........
            }
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered a value of the never type `!`
+error[E0080]: constructing invalid value of type &[!]: at .<deref>[0], encountered a value of the never type `!`
   --> $DIR/raw-bytes.rs:192:1
    |
 LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 1]) };
@@ -480,7 +480,7 @@ LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 1]) };
                01 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00 │ ................
            }
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered a value of the never type `!`
+error[E0080]: constructing invalid value of type &[!]: at .<deref>[0], encountered a value of the never type `!`
   --> $DIR/raw-bytes.rs:193:1
    |
 LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 42]) };
@@ -491,7 +491,7 @@ LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 42]) };
                01 00 00 00 00 00 00 00 2a 00 00 00 00 00 00 00 │ ........*.......
            }
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered uninitialized memory, but expected an integer
+error[E0080]: constructing invalid value of type &[u8]: at .<deref>[0], encountered uninitialized memory, but expected an integer
   --> $DIR/raw-bytes.rs:196:1
    |
 LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) };
@@ -502,7 +502,7 @@ LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) }
                ╾ALLOC_ID╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered a pointer, but expected an integer
+error[E0080]: constructing invalid value of type &[u8]: at .<deref>[0], encountered a pointer, but expected an integer
   --> $DIR/raw-bytes.rs:199:1
    |
 LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, mem::size_of::<&u32>()) };
@@ -515,7 +515,7 @@ LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, mem:
                ╾ALLOC_ID╼ 08 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered 0x11, but expected a boolean
+error[E0080]: constructing invalid value of type &[bool]: at .<deref>[0], encountered 0x11, but expected a boolean
   --> $DIR/raw-bytes.rs:202:1
    |
 LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4) };
@@ -526,7 +526,7 @@ LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4)
                ╾ALLOC_ID╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
-error[E0080]: constructing invalid value at .<deref>[1]: encountered uninitialized memory, but expected an integer
+error[E0080]: constructing invalid value of type &[u16]: at .<deref>[1], encountered uninitialized memory, but expected an integer
   --> $DIR/raw-bytes.rs:206:1
    |
 LL | pub static S7: &[u16] = unsafe {
@@ -537,7 +537,7 @@ LL | pub static S7: &[u16] = unsafe {
                ╾ALLOC_ID+0x2╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered uninitialized memory, but expected an integer
+error[E0080]: constructing invalid value of type &[u8]: at .<deref>[0], encountered uninitialized memory, but expected an integer
   --> $DIR/raw-bytes.rs:213:1
    |
 LL | pub static R4: &[u8] = unsafe {
@@ -548,7 +548,7 @@ LL | pub static R4: &[u8] = unsafe {
                ╾ALLOC_ID╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered a pointer, but expected an integer
+error[E0080]: constructing invalid value of type &[u8]: at .<deref>[0], encountered a pointer, but expected an integer
   --> $DIR/raw-bytes.rs:218:1
    |
 LL | pub static R5: &[u8] = unsafe {
@@ -561,7 +561,7 @@ LL | pub static R5: &[u8] = unsafe {
                ╾ALLOC_ID╼ 08 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered 0x11, but expected a boolean
+error[E0080]: constructing invalid value of type &[bool]: at .<deref>[0], encountered 0x11, but expected a boolean
   --> $DIR/raw-bytes.rs:223:1
    |
 LL | pub static R6: &[bool] = unsafe {

--- a/tests/ui/consts/const-eval/raw-bytes.rs
+++ b/tests/ui/consts/const-eval/raw-bytes.rs
@@ -83,10 +83,10 @@ const NULL_FAT_PTR: NonNull<dyn Send> = unsafe {
 };
 
 const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
-//~^ ERROR constructing invalid value: encountered an unaligned reference (required 2 byte alignment but found 1)
+//~^ ERROR encountered an unaligned reference (required 2 byte alignment but found 1)
 
 const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
-//~^ ERROR constructing invalid value: encountered an unaligned box (required 2 byte alignment but found 1)
+//~^ ERROR encountered an unaligned box (required 2 byte alignment but found 1)
 
 const NULL: &u16 = unsafe { mem::transmute(0usize) };
 //~^ ERROR constructing invalid value

--- a/tests/ui/consts/const-eval/transmute-const.stderr
+++ b/tests/ui/consts/const-eval/transmute-const.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value: encountered 0x03, but expected a boolean
+error[E0080]: constructing invalid value of type bool: encountered 0x03, but expected a boolean
   --> $DIR/transmute-const.rs:4:1
    |
 LL | static FOO: bool = unsafe { mem::transmute(3u8) };

--- a/tests/ui/consts/const-eval/ub-enum.stderr
+++ b/tests/ui/consts/const-eval/ub-enum.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value at .<enum-tag>: encountered 0x01, but expected a valid enum tag
+error[E0080]: constructing invalid value of type Enum: at .<enum-tag>, encountered 0x01, but expected a valid enum tag
   --> $DIR/ub-enum.rs:30:1
    |
 LL | const BAD_ENUM: Enum = unsafe { mem::transmute(1usize) };
@@ -27,7 +27,7 @@ LL | const BAD_ENUM_WRAPPED: Wrap<Enum> = unsafe { mem::transmute(&1) };
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: constructing invalid value at .<enum-tag>: encountered 0x0, but expected a valid enum tag
+error[E0080]: constructing invalid value of type Enum2: at .<enum-tag>, encountered 0x0, but expected a valid enum tag
   --> $DIR/ub-enum.rs:48:1
    |
 LL | const BAD_ENUM2: Enum2 = unsafe { mem::transmute(0usize) };
@@ -75,7 +75,7 @@ LL | const BAD_ENUM2_OPTION_PTR: Option<Enum2> = unsafe { mem::transmute(&0) };
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
+error[E0080]: constructing invalid value of type UninhDiscriminant: at .<enum-tag>, encountered an uninhabited enum variant
   --> $DIR/ub-enum.rs:83:1
    |
 LL | const BAD_UNINHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute(1u8) };
@@ -86,7 +86,7 @@ LL | const BAD_UNINHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .<enum-tag>: encountered 0x03, but expected a valid enum tag
+error[E0080]: constructing invalid value of type UninhDiscriminant: at .<enum-tag>, encountered 0x03, but expected a valid enum tag
   --> $DIR/ub-enum.rs:85:1
    |
 LL | const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute(3u8) };
@@ -97,7 +97,7 @@ LL | const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .<enum-variant(Some)>.0.1: encountered 0xffffffff, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
+error[E0080]: constructing invalid value of type Option<(char, char)>: at .<enum-variant(Some)>.0.1, encountered 0xffffffff, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
   --> $DIR/ub-enum.rs:93:1
    |
 LL | const BAD_OPTION_CHAR: Option<(char, char)> = Some(('x', unsafe { mem::transmute(!0u32) }));
@@ -108,13 +108,13 @@ LL | const BAD_OPTION_CHAR: Option<(char, char)> = Some(('x', unsafe { mem::tran
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
+error[E0080]: constructing invalid value of type Result<(i32, Never), (i32, !)>: at .<enum-tag>, encountered an uninhabited enum variant
   --> $DIR/ub-enum.rs:98:77
    |
 LL | const BAD_UNINHABITED_WITH_DATA1: Result<(i32, Never), (i32, !)> = unsafe { mem::transmute(0u64) };
    |                                                                             ^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_UNINHABITED_WITH_DATA1` failed here
 
-error[E0080]: constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
+error[E0080]: constructing invalid value of type Result<(i32, !), (i32, Never)>: at .<enum-tag>, encountered an uninhabited enum variant
   --> $DIR/ub-enum.rs:100:77
    |
 LL | const BAD_UNINHABITED_WITH_DATA2: Result<(i32, !), (i32, Never)> = unsafe { mem::transmute(0u64) };

--- a/tests/ui/consts/const-eval/ub-incorrect-vtable.32bit.stderr
+++ b/tests/ui/consts/const-eval/ub-incorrect-vtable.32bit.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value: encountered ALLOC1<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC1<imm>, but expected a vtable pointer
   --> $DIR/ub-incorrect-vtable.rs:18:1
    |
 LL | const INVALID_VTABLE_ALIGNMENT: &dyn Trait =
@@ -9,7 +9,7 @@ LL | const INVALID_VTABLE_ALIGNMENT: &dyn Trait =
                ╾ALLOC0<imm>╼ ╾ALLOC1<imm>╼                         │ ╾──╼╾──╼
            }
 
-error[E0080]: constructing invalid value: encountered ALLOC3<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC3<imm>, but expected a vtable pointer
   --> $DIR/ub-incorrect-vtable.rs:22:1
    |
 LL | const INVALID_VTABLE_SIZE: &dyn Trait =
@@ -20,7 +20,7 @@ LL | const INVALID_VTABLE_SIZE: &dyn Trait =
                ╾ALLOC2<imm>╼ ╾ALLOC3<imm>╼                         │ ╾──╼╾──╼
            }
 
-error[E0080]: constructing invalid value at .0: encountered ALLOC5<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC5<imm>, but expected a vtable pointer
   --> $DIR/ub-incorrect-vtable.rs:31:1
    |
 LL | const INVALID_VTABLE_ALIGNMENT_UB: W<&dyn Trait> =
@@ -31,7 +31,7 @@ LL | const INVALID_VTABLE_ALIGNMENT_UB: W<&dyn Trait> =
                ╾ALLOC4<imm>╼ ╾ALLOC5<imm>╼                         │ ╾──╼╾──╼
            }
 
-error[E0080]: constructing invalid value at .0: encountered ALLOC7<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC7<imm>, but expected a vtable pointer
   --> $DIR/ub-incorrect-vtable.rs:35:1
    |
 LL | const INVALID_VTABLE_SIZE_UB: W<&dyn Trait> =
@@ -42,7 +42,7 @@ LL | const INVALID_VTABLE_SIZE_UB: W<&dyn Trait> =
                ╾ALLOC6<imm>╼ ╾ALLOC7<imm>╼                         │ ╾──╼╾──╼
            }
 
-error[E0080]: constructing invalid value at .0: encountered ALLOC9<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC9<imm>, but expected a vtable pointer
   --> $DIR/ub-incorrect-vtable.rs:40:1
    |
 LL | const INVALID_VTABLE_UB: W<&dyn Trait> =
@@ -53,7 +53,7 @@ LL | const INVALID_VTABLE_UB: W<&dyn Trait> =
                ╾ALLOC8<imm>╼ ╾ALLOC9<imm>╼                         │ ╾──╼╾──╼
            }
 
-error[E0080]: constructing invalid value at .1: encountered a dangling reference (going beyond the bounds of its allocation)
+error[E0080]: constructing invalid value of type Wide<'_>: at .1, encountered a dangling reference (going beyond the bounds of its allocation)
   --> $DIR/ub-incorrect-vtable.rs:86:1
    |
 LL | const G: Wide = unsafe { Transmute { t: FOO }.u };

--- a/tests/ui/consts/const-eval/ub-incorrect-vtable.64bit.stderr
+++ b/tests/ui/consts/const-eval/ub-incorrect-vtable.64bit.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value: encountered ALLOC1<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC1<imm>, but expected a vtable pointer
   --> $DIR/ub-incorrect-vtable.rs:18:1
    |
 LL | const INVALID_VTABLE_ALIGNMENT: &dyn Trait =
@@ -9,7 +9,7 @@ LL | const INVALID_VTABLE_ALIGNMENT: &dyn Trait =
                ╾ALLOC0<imm>╼ ╾ALLOC1<imm>╼ │ ╾──────╼╾──────╼
            }
 
-error[E0080]: constructing invalid value: encountered ALLOC3<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC3<imm>, but expected a vtable pointer
   --> $DIR/ub-incorrect-vtable.rs:22:1
    |
 LL | const INVALID_VTABLE_SIZE: &dyn Trait =
@@ -20,7 +20,7 @@ LL | const INVALID_VTABLE_SIZE: &dyn Trait =
                ╾ALLOC2<imm>╼ ╾ALLOC3<imm>╼ │ ╾──────╼╾──────╼
            }
 
-error[E0080]: constructing invalid value at .0: encountered ALLOC5<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC5<imm>, but expected a vtable pointer
   --> $DIR/ub-incorrect-vtable.rs:31:1
    |
 LL | const INVALID_VTABLE_ALIGNMENT_UB: W<&dyn Trait> =
@@ -31,7 +31,7 @@ LL | const INVALID_VTABLE_ALIGNMENT_UB: W<&dyn Trait> =
                ╾ALLOC4<imm>╼ ╾ALLOC5<imm>╼ │ ╾──────╼╾──────╼
            }
 
-error[E0080]: constructing invalid value at .0: encountered ALLOC7<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC7<imm>, but expected a vtable pointer
   --> $DIR/ub-incorrect-vtable.rs:35:1
    |
 LL | const INVALID_VTABLE_SIZE_UB: W<&dyn Trait> =
@@ -42,7 +42,7 @@ LL | const INVALID_VTABLE_SIZE_UB: W<&dyn Trait> =
                ╾ALLOC6<imm>╼ ╾ALLOC7<imm>╼ │ ╾──────╼╾──────╼
            }
 
-error[E0080]: constructing invalid value at .0: encountered ALLOC9<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC9<imm>, but expected a vtable pointer
   --> $DIR/ub-incorrect-vtable.rs:40:1
    |
 LL | const INVALID_VTABLE_UB: W<&dyn Trait> =
@@ -53,7 +53,7 @@ LL | const INVALID_VTABLE_UB: W<&dyn Trait> =
                ╾ALLOC8<imm>╼ ╾ALLOC9<imm>╼ │ ╾──────╼╾──────╼
            }
 
-error[E0080]: constructing invalid value at .1: encountered a dangling reference (going beyond the bounds of its allocation)
+error[E0080]: constructing invalid value of type Wide<'_>: at .1, encountered a dangling reference (going beyond the bounds of its allocation)
   --> $DIR/ub-incorrect-vtable.rs:86:1
    |
 LL | const G: Wide = unsafe { Transmute { t: FOO }.u };

--- a/tests/ui/consts/const-eval/ub-int-array.rs
+++ b/tests/ui/consts/const-eval/ub-int-array.rs
@@ -18,7 +18,7 @@ impl<T: Copy> MaybeUninit<T> {
 }
 
 const UNINIT_INT_0: [u32; 3] = unsafe {
-    //~^ ERROR invalid value at [0]
+    //~^ ERROR invalid value of type [u32; 3]: at [0]
     mem::transmute([
         MaybeUninit { uninit: () },
         // Constants chosen to achieve endianness-independent hex dump.
@@ -27,7 +27,7 @@ const UNINIT_INT_0: [u32; 3] = unsafe {
     ])
 };
 const UNINIT_INT_1: [u32; 3] = unsafe {
-    //~^ ERROR invalid value at [1]
+    //~^ ERROR invalid value of type [u32; 3]: at [1]
     mem::transmute([
         MaybeUninit::new(0u8),
         MaybeUninit::new(0u8),
@@ -44,7 +44,7 @@ const UNINIT_INT_1: [u32; 3] = unsafe {
     ])
 };
 const UNINIT_INT_2: [u32; 3] = unsafe {
-    //~^ ERROR invalid value at [2]
+    //~^ ERROR invalid value of type [u32; 3]: at [2]
     mem::transmute([
         MaybeUninit::new(0u8),
         MaybeUninit::new(0u8),

--- a/tests/ui/consts/const-eval/ub-int-array.stderr
+++ b/tests/ui/consts/const-eval/ub-int-array.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value at [0]: encountered uninitialized memory, but expected an integer
+error[E0080]: constructing invalid value of type [u32; 3]: at [0], encountered uninitialized memory, but expected an integer
   --> $DIR/ub-int-array.rs:20:1
    |
 LL | const UNINIT_INT_0: [u32; 3] = unsafe {
@@ -9,7 +9,7 @@ LL | const UNINIT_INT_0: [u32; 3] = unsafe {
                __ __ __ __ 11 11 11 11 22 22 22 22             │ ░░░░....""""
            }
 
-error[E0080]: constructing invalid value at [1]: encountered uninitialized memory, but expected an integer
+error[E0080]: constructing invalid value of type [u32; 3]: at [1], encountered uninitialized memory, but expected an integer
   --> $DIR/ub-int-array.rs:29:1
    |
 LL | const UNINIT_INT_1: [u32; 3] = unsafe {
@@ -20,7 +20,7 @@ LL | const UNINIT_INT_1: [u32; 3] = unsafe {
                00 00 00 00 01 __ 01 01 02 02 __ 02             │ .....░....░.
            }
 
-error[E0080]: constructing invalid value at [2]: encountered uninitialized memory, but expected an integer
+error[E0080]: constructing invalid value of type [u32; 3]: at [2], encountered uninitialized memory, but expected an integer
   --> $DIR/ub-int-array.rs:46:1
    |
 LL | const UNINIT_INT_2: [u32; 3] = unsafe {

--- a/tests/ui/consts/const-eval/ub-nonnull.stderr
+++ b/tests/ui/consts/const-eval/ub-nonnull.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value: encountered 0, but expected something greater or equal to 1
+error[E0080]: constructing invalid value of type NonNull<u8>: encountered 0, but expected something greater or equal to 1
   --> $DIR/ub-nonnull.rs:16:1
    |
 LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
@@ -15,7 +15,7 @@ error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer 
 LL |     let out_of_bounds_ptr = &ptr[255];
    |                             ^^^^^^^^^ evaluation of `OUT_OF_BOUNDS_PTR` failed here
 
-error[E0080]: constructing invalid value at .0.0: encountered 0, but expected something greater or equal to 1
+error[E0080]: constructing invalid value of type NonZero<u8>: at .0.0, encountered 0, but expected something greater or equal to 1
   --> $DIR/ub-nonnull.rs:26:1
    |
 LL | const NULL_U8: NonZero<u8> = unsafe { mem::transmute(0u8) };
@@ -26,7 +26,7 @@ LL | const NULL_U8: NonZero<u8> = unsafe { mem::transmute(0u8) };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .0.0: encountered 0, but expected something greater or equal to 1
+error[E0080]: constructing invalid value of type NonZero<usize>: at .0.0, encountered 0, but expected something greater or equal to 1
   --> $DIR/ub-nonnull.rs:28:1
    |
 LL | const NULL_USIZE: NonZero<usize> = unsafe { mem::transmute(0usize) };
@@ -47,7 +47,7 @@ LL | const UNINIT: NonZero<u8> = unsafe { MaybeUninit { uninit: () }.init };
                __                                              │ ░
            }
 
-error[E0080]: constructing invalid value: encountered 42, but expected something in the range 10..=30
+error[E0080]: constructing invalid value of type RestrictedRange1: encountered 42, but expected something in the range 10..=30
   --> $DIR/ub-nonnull.rs:44:1
    |
 LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
@@ -58,7 +58,7 @@ LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered 20, but expected something less or equal to 10, or greater or equal to 30
+error[E0080]: constructing invalid value of type RestrictedRange2: encountered 20, but expected something less or equal to 10, or greater or equal to 30
   --> $DIR/ub-nonnull.rs:50:1
    |
 LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
@@ -69,7 +69,7 @@ LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered 0, but expected something greater or equal to 1
+error[E0080]: constructing invalid value of type NonNull<dyn Send>: encountered 0, but expected something greater or equal to 1
   --> $DIR/ub-nonnull.rs:53:1
    |
 LL | const NULL_FAT_PTR: NonNull<dyn Send> = unsafe {
@@ -80,7 +80,7 @@ LL | const NULL_FAT_PTR: NonNull<dyn Send> = unsafe {
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered a maybe-null pointer, but expected something that is definitely non-zero
+error[E0080]: constructing invalid value of type NonNull<()>: encountered a maybe-null pointer, but expected something that is definitely non-zero
   --> $DIR/ub-nonnull.rs:61:1
    |
 LL | const MAYBE_NULL_PTR: NonNull<()> = unsafe { mem::transmute((&raw const S).wrapping_add(4)) };

--- a/tests/ui/consts/const-eval/ub-ref-ptr.rs
+++ b/tests/ui/consts/const-eval/ub-ref-ptr.rs
@@ -16,10 +16,10 @@ union MaybeUninit<T: Copy> {
 }
 
 const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
-//~^ ERROR constructing invalid value: encountered an unaligned reference (required 2 byte alignment but found 1)
+//~^ ERROR encountered an unaligned reference (required 2 byte alignment but found 1)
 
 const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
-//~^ ERROR constructing invalid value: encountered an unaligned box (required 2 byte alignment but found 1)
+//~^ ERROR encountered an unaligned box (required 2 byte alignment but found 1)
 
 const NULL: &u16 = unsafe { mem::transmute(0usize) };
 //~^ ERROR invalid value

--- a/tests/ui/consts/const-eval/ub-ref-ptr.stderr
+++ b/tests/ui/consts/const-eval/ub-ref-ptr.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value: encountered an unaligned reference (required 2 byte alignment but found 1)
+error[E0080]: constructing invalid value of type &u16: encountered an unaligned reference (required 2 byte alignment but found 1)
   --> $DIR/ub-ref-ptr.rs:18:1
    |
 LL | const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
@@ -9,7 +9,7 @@ LL | const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered an unaligned box (required 2 byte alignment but found 1)
+error[E0080]: constructing invalid value of type Box<u16>: encountered an unaligned box (required 2 byte alignment but found 1)
   --> $DIR/ub-ref-ptr.rs:21:1
    |
 LL | const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
@@ -20,7 +20,7 @@ LL | const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered a null reference
+error[E0080]: constructing invalid value of type &u16: encountered a null reference
   --> $DIR/ub-ref-ptr.rs:24:1
    |
 LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
@@ -31,7 +31,7 @@ LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered a null box
+error[E0080]: constructing invalid value of type Box<u16>: encountered a null box
   --> $DIR/ub-ref-ptr.rs:27:1
    |
 LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
@@ -42,7 +42,7 @@ LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered a maybe-null box
+error[E0080]: constructing invalid value of type Box<()>: encountered a maybe-null box
   --> $DIR/ub-ref-ptr.rs:30:1
    |
 LL | const MAYBE_NULL_BOX: Box<()> = unsafe { mem::transmute({
@@ -92,7 +92,7 @@ note: erroneous constant encountered
 LL | const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[usize], _>(&[mem::transmute(&0)]) };
    |                                                                                     ^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: constructing invalid value: encountered a dangling reference (0x539[noalloc] has no provenance)
+error[E0080]: constructing invalid value of type &u8: encountered a dangling reference (0x539[noalloc] has no provenance)
   --> $DIR/ub-ref-ptr.rs:48:1
    |
 LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
@@ -103,7 +103,7 @@ LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered a dangling box (0x539[noalloc] has no provenance)
+error[E0080]: constructing invalid value of type Box<u8>: encountered a dangling box (0x539[noalloc] has no provenance)
   --> $DIR/ub-ref-ptr.rs:51:1
    |
 LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
@@ -124,7 +124,7 @@ LL | const UNINIT_PTR: *const i32 = unsafe { MaybeUninit { uninit: () }.init };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered null pointer, but expected a function pointer
+error[E0080]: constructing invalid value of type fn(): encountered null pointer, but expected a function pointer
   --> $DIR/ub-ref-ptr.rs:57:1
    |
 LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
@@ -145,7 +145,7 @@ LL | const UNINIT_FN_PTR: fn() = unsafe { MaybeUninit { uninit: () }.init };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered 0xd[noalloc], but expected a function pointer
+error[E0080]: constructing invalid value of type fn(): encountered 0xd[noalloc], but expected a function pointer
   --> $DIR/ub-ref-ptr.rs:61:1
    |
 LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
@@ -156,7 +156,7 @@ LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered ALLOC3<imm>, but expected a function pointer
+error[E0080]: constructing invalid value of type fn(): encountered ALLOC3<imm>, but expected a function pointer
   --> $DIR/ub-ref-ptr.rs:63:1
    |
 LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
@@ -167,7 +167,7 @@ LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered ALLOC4+0xa, but expected a function pointer
+error[E0080]: constructing invalid value of type fn(): encountered ALLOC4+0xa, but expected a function pointer
   --> $DIR/ub-ref-ptr.rs:65:1
    |
 LL | const MAYBE_NULL_FN_PTR: fn() = unsafe { mem::transmute({
@@ -184,7 +184,7 @@ error[E0080]: accessing memory based on pointer with alignment 1, but alignment 
 LL |     ptr.read();
    |     ^^^^^^^^^^ evaluation of `UNALIGNED_READ` failed here
 
-error[E0080]: constructing invalid value: encountered a pointer with unknown absolute address, but expected something that is definitely greater or equal to 1000
+error[E0080]: constructing invalid value of type High: encountered a pointer with unknown absolute address, but expected something that is definitely greater or equal to 1000
   --> $DIR/ub-ref-ptr.rs:84:1
    |
 LL | const INVALID_VALUE_PTR: High = unsafe { mem::transmute(&S) };

--- a/tests/ui/consts/const-eval/ub-uninhabit.stderr
+++ b/tests/ui/consts/const-eval/ub-uninhabit.stderr
@@ -1,10 +1,10 @@
-error[E0080]: constructing invalid value: encountered a value of uninhabited type `Bar`
+error[E0080]: constructing invalid value of type Bar: encountered a value of uninhabited type `Bar`
   --> $DIR/ub-uninhabit.rs:20:35
    |
 LL | const BAD_BAD_BAD: Bar = unsafe { MaybeUninit { uninit: () }.init };
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_BAD_BAD` failed here
 
-error[E0080]: constructing invalid value: encountered a reference pointing to uninhabited type Bar
+error[E0080]: constructing invalid value of type &Bar: encountered a reference pointing to uninhabited type Bar
   --> $DIR/ub-uninhabit.rs:23:1
    |
 LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
@@ -15,13 +15,13 @@ LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at [0]: encountered a value of uninhabited type `Bar`
+error[E0080]: constructing invalid value of type [Bar; 1]: at [0], encountered a value of uninhabited type `Bar`
   --> $DIR/ub-uninhabit.rs:26:42
    |
 LL | const BAD_BAD_ARRAY: [Bar; 1] = unsafe { MaybeUninit { uninit: () }.init };
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_BAD_ARRAY` failed here
 
-error[E0080]: constructing invalid value: encountered a value of the never type `!`
+error[E0080]: constructing invalid value of type !: encountered a value of the never type `!`
   --> $DIR/ub-uninhabit.rs:32:16
    |
 LL |     let _val = intrinsics::read_via_copy(ptr);

--- a/tests/ui/consts/const-eval/ub-upvars.32bit.stderr
+++ b/tests/ui/consts/const-eval/ub-upvars.32bit.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value at .<deref>.<dyn-downcast>.<captured-var(bad_ref)>: encountered a null reference
+error[E0080]: constructing invalid value of type &dyn FnOnce(): at .<deref>.<dyn-downcast({closure@$DIR/ub-upvars.rs:10:5: 10:12})>.<captured-var(bad_ref)>, encountered a null reference
   --> $DIR/ub-upvars.rs:7:1
    |
 LL | const BAD_UPVAR: &dyn FnOnce() = &{

--- a/tests/ui/consts/const-eval/ub-upvars.64bit.stderr
+++ b/tests/ui/consts/const-eval/ub-upvars.64bit.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value at .<deref>.<dyn-downcast>.<captured-var(bad_ref)>: encountered a null reference
+error[E0080]: constructing invalid value of type &dyn FnOnce(): at .<deref>.<dyn-downcast({closure@$DIR/ub-upvars.rs:10:5: 10:12})>.<captured-var(bad_ref)>, encountered a null reference
   --> $DIR/ub-upvars.rs:7:1
    |
 LL | const BAD_UPVAR: &dyn FnOnce() = &{

--- a/tests/ui/consts/const-eval/ub-wide-ptr.stderr
+++ b/tests/ui/consts/const-eval/ub-wide-ptr.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value: encountered a dangling reference (going beyond the bounds of its allocation)
+error[E0080]: constructing invalid value of type &str: encountered a dangling reference (going beyond the bounds of its allocation)
   --> $DIR/ub-wide-ptr.rs:40:1
    |
 LL | const STR_TOO_LONG: &str = unsafe { mem::transmute((&42u8, 999usize)) };
@@ -9,7 +9,7 @@ LL | const STR_TOO_LONG: &str = unsafe { mem::transmute((&42u8, 999usize)) };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .0: encountered invalid reference metadata: slice is bigger than largest supported object
+error[E0080]: constructing invalid value of type (&str,): at .0, encountered invalid reference metadata: slice is bigger than largest supported object
   --> $DIR/ub-wide-ptr.rs:42:1
    |
 LL | const NESTED_STR_MUCH_TOO_LONG: (&str,) = (unsafe { mem::transmute((&42, usize::MAX)) },);
@@ -38,7 +38,7 @@ LL | const MY_STR_LENGTH_PTR: &MyStr = unsafe { mem::transmute((&42u8, &3)) };
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
+error[E0080]: constructing invalid value of type &MyStr: encountered invalid reference metadata: slice is bigger than largest supported object
   --> $DIR/ub-wide-ptr.rs:50:1
    |
 LL | const MY_STR_MUCH_TOO_LONG: &MyStr = unsafe { mem::transmute((&42u8, usize::MAX)) };
@@ -49,7 +49,7 @@ LL | const MY_STR_MUCH_TOO_LONG: &MyStr = unsafe { mem::transmute((&42u8, usize:
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .<deref>: encountered uninitialized memory, but expected a string
+error[E0080]: constructing invalid value of type &str: at .<deref>, encountered uninitialized memory, but expected a string
   --> $DIR/ub-wide-ptr.rs:54:1
    |
 LL | const STR_NO_INIT: &str = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit::<u8> { uninit: () }]) };
@@ -60,7 +60,7 @@ LL | const STR_NO_INIT: &str = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit:
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .<deref>.0: encountered uninitialized memory, but expected a string
+error[E0080]: constructing invalid value of type &MyStr: at .<deref>.0, encountered uninitialized memory, but expected a string
   --> $DIR/ub-wide-ptr.rs:57:1
    |
 LL | const MYSTR_NO_INIT: &MyStr = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit::<u8> { uninit: () }]) };
@@ -81,7 +81,7 @@ LL | const SLICE_LENGTH_UNINIT: &[u8] = unsafe {
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered a dangling reference (going beyond the bounds of its allocation)
+error[E0080]: constructing invalid value of type &[u8]: encountered a dangling reference (going beyond the bounds of its allocation)
   --> $DIR/ub-wide-ptr.rs:70:1
    |
 LL | const SLICE_TOO_LONG: &[u8] = unsafe { mem::transmute((&42u8, 999usize)) };
@@ -92,7 +92,7 @@ LL | const SLICE_TOO_LONG: &[u8] = unsafe { mem::transmute((&42u8, 999usize)) };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
+error[E0080]: constructing invalid value of type &[u32]: encountered invalid reference metadata: slice is bigger than largest supported object
   --> $DIR/ub-wide-ptr.rs:73:1
    |
 LL | const SLICE_TOO_LONG_OVERFLOW: &[u32] = unsafe { mem::transmute((&42u32, isize::MAX)) };
@@ -112,7 +112,7 @@ LL | const SLICE_LENGTH_PTR: &[u8] = unsafe { mem::transmute((&42u8, &3)) };
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: constructing invalid value: encountered a dangling box (going beyond the bounds of its allocation)
+error[E0080]: constructing invalid value of type Box<[u8]>: encountered a dangling box (going beyond the bounds of its allocation)
   --> $DIR/ub-wide-ptr.rs:79:1
    |
 LL | const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999usize)) };
@@ -132,7 +132,7 @@ LL | const SLICE_LENGTH_PTR_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, &3)
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered 0x03, but expected a boolean
+error[E0080]: constructing invalid value of type &[bool; 1]: at .<deref>[0], encountered 0x03, but expected a boolean
   --> $DIR/ub-wide-ptr.rs:86:1
    |
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
@@ -149,7 +149,7 @@ note: erroneous constant encountered
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: constructing invalid value at .<deref>.0: encountered 0x03, but expected a boolean
+error[E0080]: constructing invalid value of type &MySlice<[bool; 1]>: at .<deref>.0, encountered 0x03, but expected a boolean
   --> $DIR/ub-wide-ptr.rs:92:1
    |
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
@@ -166,7 +166,7 @@ note: erroneous constant encountered
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: constructing invalid value at .<deref>.1[0]: encountered 0x03, but expected a boolean
+error[E0080]: constructing invalid value of type &MySlice<[bool; 1]>: at .<deref>.1[0], encountered 0x03, but expected a boolean
   --> $DIR/ub-wide-ptr.rs:95:1
    |
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
@@ -193,7 +193,7 @@ LL | const RAW_SLICE_LENGTH_UNINIT: *const [u8] = unsafe {
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .0: encountered ALLOC12<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC12<imm>, but expected a vtable pointer
   --> $DIR/ub-wide-ptr.rs:110:1
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_1: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u8))) };
@@ -204,7 +204,7 @@ LL | const TRAIT_OBJ_SHORT_VTABLE_1: W<&dyn Trait> = unsafe { mem::transmute(W((
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .0: encountered ALLOC14<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC14<imm>, but expected a vtable pointer
   --> $DIR/ub-wide-ptr.rs:113:1
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_2: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u64))) };
@@ -215,7 +215,7 @@ LL | const TRAIT_OBJ_SHORT_VTABLE_2: W<&dyn Trait> = unsafe { mem::transmute(W((
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .0: encountered 0x4[noalloc], but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered 0x4[noalloc], but expected a vtable pointer
   --> $DIR/ub-wide-ptr.rs:116:1
    |
 LL | const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, 4usize))) };
@@ -226,7 +226,7 @@ LL | const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered ALLOC17<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC17<imm>, but expected a vtable pointer
   --> $DIR/ub-wide-ptr.rs:118:1
    |
 LL | const TRAIT_OBJ_UNALIGNED_VTABLE: &dyn Trait = unsafe { mem::transmute((&92u8, &[0u8; 128])) };
@@ -237,7 +237,7 @@ LL | const TRAIT_OBJ_UNALIGNED_VTABLE: &dyn Trait = unsafe { mem::transmute((&92
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered ALLOC19<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC19<imm>, but expected a vtable pointer
   --> $DIR/ub-wide-ptr.rs:120:1
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_NULL: &dyn Trait = unsafe { mem::transmute((&92u8, &[0usize; 8])) };
@@ -248,7 +248,7 @@ LL | const TRAIT_OBJ_BAD_DROP_FN_NULL: &dyn Trait = unsafe { mem::transmute((&92
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered ALLOC21<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC21<imm>, but expected a vtable pointer
   --> $DIR/ub-wide-ptr.rs:122:1
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_INT: &dyn Trait = unsafe { mem::transmute((&92u8, &[1usize; 8])) };
@@ -259,7 +259,7 @@ LL | const TRAIT_OBJ_BAD_DROP_FN_INT: &dyn Trait = unsafe { mem::transmute((&92u
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .0: encountered ALLOC23<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC23<imm>, but expected a vtable pointer
   --> $DIR/ub-wide-ptr.rs:124:1
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &[&42u8; 8]))) };
@@ -270,7 +270,7 @@ LL | const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> = unsafe { mem::trans
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .<deref>.<dyn-downcast>: encountered 0x03, but expected a boolean
+error[E0080]: constructing invalid value of type &dyn Trait: at .<deref>.<dyn-downcast(bool)>, encountered 0x03, but expected a boolean
   --> $DIR/ub-wide-ptr.rs:128:1
    |
 LL | const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, &bool>(&3u8) };
@@ -281,7 +281,7 @@ LL | const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, 
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered null pointer, but expected a vtable pointer
+error[E0080]: constructing invalid value of type *const dyn Trait: encountered null pointer, but expected a vtable pointer
   --> $DIR/ub-wide-ptr.rs:132:1
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_NULL: *const dyn Trait = unsafe { mem::transmute((&92u8, 0usize)) };
@@ -292,7 +292,7 @@ LL | const RAW_TRAIT_OBJ_VTABLE_NULL: *const dyn Trait = unsafe { mem::transmute
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered ALLOC28<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type *const dyn Trait: encountered ALLOC28<imm>, but expected a vtable pointer
   --> $DIR/ub-wide-ptr.rs:134:1
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transmute((&92u8, &3u64)) };
@@ -303,7 +303,7 @@ LL | const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transm
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered null pointer, but expected a vtable pointer
+error[E0080]: constructing invalid value of type *const dyn Trait: encountered null pointer, but expected a vtable pointer
   --> $DIR/ub-wide-ptr.rs:141:1
    |
 LL | static mut RAW_TRAIT_OBJ_VTABLE_NULL_THROUGH_REF: *const dyn Trait = unsafe {
@@ -314,7 +314,7 @@ LL | static mut RAW_TRAIT_OBJ_VTABLE_NULL_THROUGH_REF: *const dyn Trait = unsafe
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered ALLOC31<imm>, but expected a vtable pointer
+error[E0080]: constructing invalid value of type *const dyn Trait: encountered ALLOC31<imm>, but expected a vtable pointer
   --> $DIR/ub-wide-ptr.rs:145:1
    |
 LL | static mut RAW_TRAIT_OBJ_VTABLE_INVALID_THROUGH_REF: *const dyn Trait = unsafe {

--- a/tests/ui/consts/const-eval/union-ub.32bit.stderr
+++ b/tests/ui/consts/const-eval/union-ub.32bit.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value: encountered 0x2a, but expected a boolean
+error[E0080]: constructing invalid value of type bool: encountered 0x2a, but expected a boolean
   --> $DIR/union-ub.rs:33:1
    |
 LL | const BAD_BOOL: bool = unsafe { DummyUnion { u8: 42 }.bool };

--- a/tests/ui/consts/const-eval/union-ub.64bit.stderr
+++ b/tests/ui/consts/const-eval/union-ub.64bit.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value: encountered 0x2a, but expected a boolean
+error[E0080]: constructing invalid value of type bool: encountered 0x2a, but expected a boolean
   --> $DIR/union-ub.rs:33:1
    |
 LL | const BAD_BOOL: bool = unsafe { DummyUnion { u8: 42 }.bool };

--- a/tests/ui/consts/const-eval/validate_uninhabited_zsts.stderr
+++ b/tests/ui/consts/const-eval/validate_uninhabited_zsts.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value: encountered a value of the never type `!`
+error[E0080]: constructing invalid value of type !: encountered a value of the never type `!`
   --> $DIR/validate_uninhabited_zsts.rs:17:33
    |
 LL | const FOO: [empty::Empty; 3] = [foo(); 3];
@@ -10,7 +10,7 @@ note: inside `foo`
 LL |     unsafe { std::mem::transmute(()) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
 
-error[E0080]: constructing invalid value at .0: encountered a value of uninhabited type `Void`
+error[E0080]: constructing invalid value of type empty::Empty: at .0, encountered a value of uninhabited type `Void`
   --> $DIR/validate_uninhabited_zsts.rs:20:42
    |
 LL | const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];

--- a/tests/ui/consts/const-mut-refs/mut_ref_in_final.stderr
+++ b/tests/ui/consts/const-mut-refs/mut_ref_in_final.stderr
@@ -28,7 +28,7 @@ LL | const B4: Option<&mut i32> = helper(&mut 42);
    |                              |           creates a temporary value which is freed while still in use
    |                              using this value as a constant requires that borrow lasts for `'static`
 
-error[E0080]: constructing invalid value: encountered mutable reference or box pointing to read-only memory
+error[E0080]: constructing invalid value of type &mut u16: encountered mutable reference or box pointing to read-only memory
   --> $DIR/mut_ref_in_final.rs:27:1
    |
 LL | const IMMUT_MUT_REF: &mut u16 = unsafe { mem::transmute(&13) };
@@ -39,7 +39,7 @@ LL | const IMMUT_MUT_REF: &mut u16 = unsafe { mem::transmute(&13) };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered mutable reference or box pointing to read-only memory
+error[E0080]: constructing invalid value of type &mut u16: encountered mutable reference or box pointing to read-only memory
   --> $DIR/mut_ref_in_final.rs:29:1
    |
 LL | static IMMUT_MUT_REF_STATIC: &mut u16 = unsafe { mem::transmute(&13) };
@@ -120,7 +120,7 @@ LL | const RAW_MUT_COERCE_C: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
    = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
-error[E0080]: constructing invalid value at .<enum-variant(Some)>.0: encountered a dangling reference (0x2a[noalloc] has no provenance)
+error[E0080]: constructing invalid value of type Option<&mut i32>: at .<enum-variant(Some)>.0, encountered a dangling reference (0x2a[noalloc] has no provenance)
   --> $DIR/mut_ref_in_final.rs:86:5
    |
 LL |     const INT2PTR: Option<&mut i32> = helper_int2ptr();
@@ -131,7 +131,7 @@ LL |     const INT2PTR: Option<&mut i32> = helper_int2ptr();
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .<enum-variant(Some)>.0: encountered a dangling reference (0x2a[noalloc] has no provenance)
+error[E0080]: constructing invalid value of type Option<&mut i32>: at .<enum-variant(Some)>.0, encountered a dangling reference (0x2a[noalloc] has no provenance)
   --> $DIR/mut_ref_in_final.rs:87:5
    |
 LL |     static INT2PTR_STATIC: Option<&mut i32> = helper_int2ptr();
@@ -142,7 +142,7 @@ LL |     static INT2PTR_STATIC: Option<&mut i32> = helper_int2ptr();
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .<enum-variant(Some)>.0: encountered a dangling reference (use-after-free)
+error[E0080]: constructing invalid value of type Option<&mut i32>: at .<enum-variant(Some)>.0, encountered a dangling reference (use-after-free)
   --> $DIR/mut_ref_in_final.rs:93:5
    |
 LL |     const DANGLING: Option<&mut i32> = helper_dangling();
@@ -153,7 +153,7 @@ LL |     const DANGLING: Option<&mut i32> = helper_dangling();
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .<enum-variant(Some)>.0: encountered a dangling reference (use-after-free)
+error[E0080]: constructing invalid value of type Option<&mut i32>: at .<enum-variant(Some)>.0, encountered a dangling reference (use-after-free)
   --> $DIR/mut_ref_in_final.rs:94:5
    |
 LL |     static DANGLING_STATIC: Option<&mut i32> = helper_dangling();

--- a/tests/ui/consts/const_refs_to_static_fail_invalid.stderr
+++ b/tests/ui/consts/const_refs_to_static_fail_invalid.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value at .<deref>: encountered 0x0a, but expected a boolean
+error[E0080]: constructing invalid value of type &bool: at .<deref>, encountered 0x0a, but expected a boolean
   --> $DIR/const_refs_to_static_fail_invalid.rs:10:5
    |
 LL |     const C: &bool = unsafe { std::mem::transmute(&S) };

--- a/tests/ui/consts/const_transmute_type_id7.rs
+++ b/tests/ui/consts/const_transmute_type_id7.rs
@@ -2,6 +2,7 @@
 //! (see <https://github.com/rust-lang/rust/issues/146748>)
 
 // Strip out raw byte dumps to make comparison platform-independent:
+//@ normalize-stderr: "\[&\(\); \d\]" -> "ARRAY"
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |╾─*A(LLOC)?[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
 

--- a/tests/ui/consts/const_transmute_type_id7.stderr
+++ b/tests/ui/consts/const_transmute_type_id7.stderr
@@ -1,5 +1,5 @@
-error[E0080]: constructing invalid value at [0]: encountered a maybe-null reference
-  --> $DIR/const_transmute_type_id7.rs:13:1
+error[E0080]: constructing invalid value of type ARRAY: at [0], encountered a maybe-null reference
+  --> $DIR/const_transmute_type_id7.rs:14:1
    |
 LL | const A: [&(); 16 / size_of::<*const ()>()] = unsafe { transmute(TypeId::of::<i32>()) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value

--- a/tests/ui/consts/dangling-alloc-id-ice.stderr
+++ b/tests/ui/consts/dangling-alloc-id-ice.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value: encountered a dangling reference (use-after-free)
+error[E0080]: constructing invalid value of type &(): encountered a dangling reference (use-after-free)
   --> $DIR/dangling-alloc-id-ice.rs:12:1
    |
 LL | const FOO: &() = {

--- a/tests/ui/consts/dangling-zst-ice-issue-126393.stderr
+++ b/tests/ui/consts/dangling-zst-ice-issue-126393.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value: encountered a dangling reference (use-after-free)
+error[E0080]: constructing invalid value of type &Wrapper: encountered a dangling reference (use-after-free)
   --> $DIR/dangling-zst-ice-issue-126393.rs:7:1
    |
 LL | pub static MAGIC_FFI_REF: &'static Wrapper = unsafe {

--- a/tests/ui/consts/extra-const-ub/detect-extra-ub.with_flag.stderr
+++ b/tests/ui/consts/extra-const-ub/detect-extra-ub.with_flag.stderr
@@ -1,10 +1,10 @@
-error[E0080]: constructing invalid value: encountered 0x03, but expected a boolean
+error[E0080]: constructing invalid value of type bool: encountered 0x03, but expected a boolean
   --> $DIR/detect-extra-ub.rs:30:20
    |
 LL |     let _x: bool = transmute(3u8);
    |                    ^^^^^^^^^^^^^^ evaluation of `INVALID_BOOL` failed here
 
-error[E0080]: constructing invalid value: encountered a pointer, but expected an integer
+error[E0080]: constructing invalid value of type usize: encountered a pointer, but expected an integer
   --> $DIR/detect-extra-ub.rs:35:21
    |
 LL |     let _x: usize = transmute(&3u8);
@@ -13,7 +13,7 @@ LL |     let _x: usize = transmute(&3u8);
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: constructing invalid value at .<enum-tag>: encountered a pointer, but expected an integer
+error[E0080]: constructing invalid value of type PtrSizedEnum: at .<enum-tag>, encountered a pointer, but expected an integer
   --> $DIR/detect-extra-ub.rs:40:28
    |
 LL |     let _x: PtrSizedEnum = transmute(&3u8);
@@ -22,7 +22,7 @@ LL |     let _x: PtrSizedEnum = transmute(&3u8);
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: constructing invalid value at .0: encountered a pointer, but expected an integer
+error[E0080]: constructing invalid value of type (usize, usize): at .0, encountered a pointer, but expected an integer
   --> $DIR/detect-extra-ub.rs:46:30
    |
 LL |     let _x: (usize, usize) = transmute(x);
@@ -31,13 +31,13 @@ LL |     let _x: (usize, usize) = transmute(x);
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: constructing invalid value: encountered an unaligned reference (required 4 byte alignment but found 1)
+error[E0080]: constructing invalid value of type &u32: encountered an unaligned reference (required 4 byte alignment but found 1)
   --> $DIR/detect-extra-ub.rs:51:20
    |
 LL |     let _x: &u32 = transmute(&[0u8; 4]);
    |                    ^^^^^^^^^^^^^^^^^^^^ evaluation of `UNALIGNED_PTR` failed here
 
-error[E0080]: constructing invalid value: encountered a maybe-null function pointer
+error[E0080]: constructing invalid value of type fn(): encountered a maybe-null function pointer
   --> $DIR/detect-extra-ub.rs:57:20
    |
 LL |       let _x: fn() = transmute({
@@ -49,13 +49,13 @@ LL | |         (ptr as *const u8).wrapping_add(10)
 LL | |     });
    | |______^ evaluation of `MAYBE_NULL_FN_PTR` failed here
 
-error[E0080]: constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
+error[E0080]: constructing invalid value of type UninhDiscriminant: at .<enum-tag>, encountered an uninhabited enum variant
   --> $DIR/detect-extra-ub.rs:68:13
    |
 LL |     let v = *addr_of!(data).cast::<UninhDiscriminant>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `UNINHABITED_VARIANT` failed here
 
-error[E0080]: constructing invalid value at [0]: encountered a partial pointer or a mix of pointers
+error[E0080]: constructing invalid value of type [*const u8; 2]: at [0], encountered a partial pointer or a mix of pointers
   --> $DIR/detect-extra-ub.rs:87:16
    |
 LL |     let _val = *(&mem as *const Align as *const [*const u8; 2]);
@@ -64,7 +64,7 @@ LL |     let _val = *(&mem as *const Align as *const [*const u8; 2]);
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
+error[E0080]: constructing invalid value of type &[u8]: encountered invalid reference metadata: slice is bigger than largest supported object
   --> $DIR/detect-extra-ub.rs:101:16
    |
 LL |     let _val = &*slice;

--- a/tests/ui/consts/interior-mut-const-via-union.32bit.stderr
+++ b/tests/ui/consts/interior-mut-const-via-union.32bit.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value at .<deref>.y.<enum-variant(B)>.0: encountered `UnsafeCell` in read-only memory
+error[E0080]: constructing invalid value of type &S: at .<deref>.y.<enum-variant(B)>.0, encountered `UnsafeCell` in read-only memory
   --> $DIR/interior-mut-const-via-union.rs:34:1
    |
 LL | fn main() {

--- a/tests/ui/consts/interior-mut-const-via-union.64bit.stderr
+++ b/tests/ui/consts/interior-mut-const-via-union.64bit.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value at .<deref>.y.<enum-variant(B)>.0: encountered `UnsafeCell` in read-only memory
+error[E0080]: constructing invalid value of type &S: at .<deref>.y.<enum-variant(B)>.0, encountered `UnsafeCell` in read-only memory
   --> $DIR/interior-mut-const-via-union.rs:34:1
    |
 LL | fn main() {

--- a/tests/ui/consts/issue-63952.32bit.stderr
+++ b/tests/ui/consts/issue-63952.32bit.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
+error[E0080]: constructing invalid value of type &[u8]: encountered invalid reference metadata: slice is bigger than largest supported object
   --> $DIR/issue-63952.rs:17:1
    |
 LL | const SLICE_WAY_TOO_LONG: &[u8] = unsafe {

--- a/tests/ui/consts/issue-63952.64bit.stderr
+++ b/tests/ui/consts/issue-63952.64bit.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
+error[E0080]: constructing invalid value of type &[u8]: encountered invalid reference metadata: slice is bigger than largest supported object
   --> $DIR/issue-63952.rs:17:1
    |
 LL | const SLICE_WAY_TOO_LONG: &[u8] = unsafe {

--- a/tests/ui/consts/issue-64506.stderr
+++ b/tests/ui/consts/issue-64506.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value at .inner: encountered a value of uninhabited type `AnonPipe`
+error[E0080]: constructing invalid value of type ChildStdin: at .inner, encountered a value of uninhabited type `AnonPipe`
   --> $DIR/issue-64506.rs:16:22
    |
 LL |     let x = unsafe { Foo { b: () }.a };

--- a/tests/ui/consts/issue-79690.64bit.stderr
+++ b/tests/ui/consts/issue-79690.64bit.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value at .1: encountered a dangling reference (going beyond the bounds of its allocation)
+error[E0080]: constructing invalid value of type Fat<'_>: at .1, encountered a dangling reference (going beyond the bounds of its allocation)
   --> $DIR/issue-79690.rs:30:1
    |
 LL | const G: Fat = unsafe { Transmute { t: FOO }.u };

--- a/tests/ui/consts/miri_unleashed/mutable_references.stderr
+++ b/tests/ui/consts/miri_unleashed/mutable_references.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value at .<deref>: encountered mutable reference or box pointing to read-only memory
+error[E0080]: constructing invalid value of type &&mut u32: at .<deref>, encountered mutable reference or box pointing to read-only memory
   --> $DIR/mutable_references.rs:13:1
    |
 LL | static FOO: &&mut u32 = &&mut 42;
@@ -9,7 +9,7 @@ LL | static FOO: &&mut u32 = &&mut 42;
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered mutable reference or box pointing to read-only memory
+error[E0080]: constructing invalid value of type &mut i32: encountered mutable reference or box pointing to read-only memory
   --> $DIR/mutable_references.rs:15:1
    |
 LL | static OH_YES: &mut i32 = &mut 42;
@@ -32,7 +32,7 @@ error: encountered mutable pointer in final value of static
 LL | static BOO: &mut Foo<()> = &mut Foo(());
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: constructing invalid value: encountered mutable reference or box pointing to read-only memory
+error[E0080]: constructing invalid value of type &mut i32: encountered mutable reference or box pointing to read-only memory
   --> $DIR/mutable_references.rs:25:1
    |
 LL | const BLUNT: &mut i32 = &mut 42;
@@ -43,7 +43,7 @@ LL | const BLUNT: &mut i32 = &mut 42;
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .x.<deref>: encountered `UnsafeCell` in read-only memory
+error[E0080]: constructing invalid value of type Meh: at .x.<deref>, encountered `UnsafeCell` in read-only memory
   --> $DIR/mutable_references.rs:40:1
    |
 LL | static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
@@ -54,7 +54,7 @@ LL | static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .x.<deref>: encountered `UnsafeCell` in read-only memory
+error[E0080]: constructing invalid value of type Meh: at .x.<deref>, encountered `UnsafeCell` in read-only memory
   --> $DIR/mutable_references.rs:45:1
    |
 LL | const MUH: Meh = Meh {
@@ -65,7 +65,7 @@ LL | const MUH: Meh = Meh {
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .<deref>.<dyn-downcast>.x: encountered `UnsafeCell` in read-only memory
+error[E0080]: constructing invalid value of type &dyn Sync: at .<deref>.<dyn-downcast(Synced)>.x, encountered `UnsafeCell` in read-only memory
   --> $DIR/mutable_references.rs:56:1
    |
 LL | const SNEAKY: &dyn Sync = &Synced { x: UnsafeCell::new(42) };
@@ -76,7 +76,7 @@ LL | const SNEAKY: &dyn Sync = &Synced { x: UnsafeCell::new(42) };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered mutable reference or box pointing to read-only memory
+error[E0080]: constructing invalid value of type &mut i32: encountered mutable reference or box pointing to read-only memory
   --> $DIR/mutable_references.rs:62:1
    |
 LL | static mut MUT_TO_READONLY: &mut i32 = unsafe { &mut *(&READONLY as *const _ as *mut _) };

--- a/tests/ui/consts/miri_unleashed/static-no-inner-mut.32bit.stderr
+++ b/tests/ui/consts/miri_unleashed/static-no-inner-mut.32bit.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value at .<deref>.v: encountered `UnsafeCell` in read-only memory
+error[E0080]: constructing invalid value of type &Atomic<i32>: at .<deref>.v, encountered `UnsafeCell` in read-only memory
   --> $DIR/static-no-inner-mut.rs:8:1
    |
 LL | static REF: &AtomicI32 = &AtomicI32::new(42);
@@ -9,7 +9,7 @@ LL | static REF: &AtomicI32 = &AtomicI32::new(42);
                ╾ALLOC0╼                                     │ ╾──╼
            }
 
-error[E0080]: constructing invalid value: encountered mutable reference or box pointing to read-only memory
+error[E0080]: constructing invalid value of type &mut i32: encountered mutable reference or box pointing to read-only memory
   --> $DIR/static-no-inner-mut.rs:11:1
    |
 LL | static REFMUT: &mut i32 = &mut 0;
@@ -20,7 +20,7 @@ LL | static REFMUT: &mut i32 = &mut 0;
                ╾ALLOC1╼                                     │ ╾──╼
            }
 
-error[E0080]: constructing invalid value at .<deref>.v: encountered `UnsafeCell` in read-only memory
+error[E0080]: constructing invalid value of type &Atomic<i32>: at .<deref>.v, encountered `UnsafeCell` in read-only memory
   --> $DIR/static-no-inner-mut.rs:15:1
    |
 LL | static REF2: &AtomicI32 = {let x = AtomicI32::new(42); &{x}};
@@ -31,7 +31,7 @@ LL | static REF2: &AtomicI32 = {let x = AtomicI32::new(42); &{x}};
                ╾ALLOC2╼                                     │ ╾──╼
            }
 
-error[E0080]: constructing invalid value: encountered mutable reference or box pointing to read-only memory
+error[E0080]: constructing invalid value of type &mut i32: encountered mutable reference or box pointing to read-only memory
   --> $DIR/static-no-inner-mut.rs:17:1
    |
 LL | static REFMUT2: &mut i32 = {let mut x = 0; &mut {x}};

--- a/tests/ui/consts/miri_unleashed/static-no-inner-mut.64bit.stderr
+++ b/tests/ui/consts/miri_unleashed/static-no-inner-mut.64bit.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value at .<deref>.v: encountered `UnsafeCell` in read-only memory
+error[E0080]: constructing invalid value of type &Atomic<i32>: at .<deref>.v, encountered `UnsafeCell` in read-only memory
   --> $DIR/static-no-inner-mut.rs:8:1
    |
 LL | static REF: &AtomicI32 = &AtomicI32::new(42);
@@ -9,7 +9,7 @@ LL | static REF: &AtomicI32 = &AtomicI32::new(42);
                ╾ALLOC0╼                         │ ╾──────╼
            }
 
-error[E0080]: constructing invalid value: encountered mutable reference or box pointing to read-only memory
+error[E0080]: constructing invalid value of type &mut i32: encountered mutable reference or box pointing to read-only memory
   --> $DIR/static-no-inner-mut.rs:11:1
    |
 LL | static REFMUT: &mut i32 = &mut 0;
@@ -20,7 +20,7 @@ LL | static REFMUT: &mut i32 = &mut 0;
                ╾ALLOC1╼                         │ ╾──────╼
            }
 
-error[E0080]: constructing invalid value at .<deref>.v: encountered `UnsafeCell` in read-only memory
+error[E0080]: constructing invalid value of type &Atomic<i32>: at .<deref>.v, encountered `UnsafeCell` in read-only memory
   --> $DIR/static-no-inner-mut.rs:15:1
    |
 LL | static REF2: &AtomicI32 = {let x = AtomicI32::new(42); &{x}};
@@ -31,7 +31,7 @@ LL | static REF2: &AtomicI32 = {let x = AtomicI32::new(42); &{x}};
                ╾ALLOC2╼                         │ ╾──────╼
            }
 
-error[E0080]: constructing invalid value: encountered mutable reference or box pointing to read-only memory
+error[E0080]: constructing invalid value of type &mut i32: encountered mutable reference or box pointing to read-only memory
   --> $DIR/static-no-inner-mut.rs:17:1
    |
 LL | static REFMUT2: &mut i32 = {let mut x = 0; &mut {x}};

--- a/tests/ui/consts/validate_never_arrays.stderr
+++ b/tests/ui/consts/validate_never_arrays.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value: encountered a reference pointing to uninhabited type [!; 1]
+error[E0080]: constructing invalid value of type &[!; 1]: encountered a reference pointing to uninhabited type [!; 1]
   --> $DIR/validate_never_arrays.rs:6:1
    |
 LL | const _: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) };
@@ -9,7 +9,7 @@ LL | const _: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered a value of the never type `!`
+error[E0080]: constructing invalid value of type &[!]: at .<deref>[0], encountered a value of the never type `!`
   --> $DIR/validate_never_arrays.rs:9:1
    |
 LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 1]) };
@@ -20,7 +20,7 @@ LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 1]) };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered a value of the never type `!`
+error[E0080]: constructing invalid value of type &[!]: at .<deref>[0], encountered a value of the never type `!`
   --> $DIR/validate_never_arrays.rs:10:1
    |
 LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 42]) };

--- a/tests/ui/statics/mutable_memory_validation.rs
+++ b/tests/ui/statics/mutable_memory_validation.rs
@@ -11,7 +11,7 @@ struct Meh {
 }
 
 const MUH: Meh = Meh { x: unsafe { &mut *(&READONLY as *const _ as *mut _) } };
-//~^ ERROR: invalid value at .x.<deref>: encountered `UnsafeCell` in read-only memory
+//~^ ERROR: at .x.<deref>, encountered `UnsafeCell` in read-only memory
 
 static READONLY: i32 = 0;
 

--- a/tests/ui/statics/mutable_memory_validation.stderr
+++ b/tests/ui/statics/mutable_memory_validation.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value at .x.<deref>: encountered `UnsafeCell` in read-only memory
+error[E0080]: constructing invalid value of type Meh: at .x.<deref>, encountered `UnsafeCell` in read-only memory
   --> $DIR/mutable_memory_validation.rs:13:1
    |
 LL | const MUH: Meh = Meh { x: unsafe { &mut *(&READONLY as *const _ as *mut _) } };

--- a/tests/ui/statics/uninhabited-static.stderr
+++ b/tests/ui/statics/uninhabited-static.stderr
@@ -43,13 +43,13 @@ LL |     static NEVER: !;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
 
-error[E0080]: constructing invalid value: encountered a value of uninhabited type `Void`
+error[E0080]: constructing invalid value of type Void: encountered a value of uninhabited type `Void`
   --> $DIR/uninhabited-static.rs:12:31
    |
 LL | static VOID2: Void = unsafe { std::mem::transmute(()) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `VOID2` failed here
 
-error[E0080]: constructing invalid value: encountered a value of uninhabited type `Void`
+error[E0080]: constructing invalid value of type Void: encountered a value of uninhabited type `Void`
   --> $DIR/uninhabited-static.rs:15:32
    |
 LL | static NEVER2: Void = unsafe { std::mem::transmute(()) };

--- a/tests/ui/traits/const-traits/const-closure-with-indestructible-indestructible.next.stderr
+++ b/tests/ui/traits/const-traits/const-closure-with-indestructible-indestructible.next.stderr
@@ -1,0 +1,21 @@
+error[E0277]: the trait bound `Vec<u8>: const Destruct` is not satisfied
+  --> $DIR/const-closure-with-indestructible-indestructible.rs:10:16
+   |
+LL |           i_need(const || {
+   |  _________------_^
+   | |         |
+   | |         required by a bound introduced by this call
+LL | |
+LL | |             let y = v;
+LL | |         })
+   | |_________^
+   |
+note: required by a bound in `i_need`
+  --> $DIR/const-closure-with-indestructible-indestructible.rs:5:20
+   |
+LL | const fn i_need<F: [const] std::marker::Destruct>(x: F) {}
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `i_need`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/const-traits/const-closure-with-indestructible-indestructible.old.stderr
+++ b/tests/ui/traits/const-traits/const-closure-with-indestructible-indestructible.old.stderr
@@ -1,0 +1,21 @@
+error[E0277]: the trait bound `Vec<u8>: const Destruct` is not satisfied
+  --> $DIR/const-closure-with-indestructible-indestructible.rs:10:16
+   |
+LL |           i_need(const || {
+   |  _________------_^
+   | |         |
+   | |         required by a bound introduced by this call
+LL | |
+LL | |             let y = v;
+LL | |         })
+   | |_________^
+   |
+note: required by a bound in `i_need`
+  --> $DIR/const-closure-with-indestructible-indestructible.rs:5:20
+   |
+LL | const fn i_need<F: [const] std::marker::Destruct>(x: F) {}
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `i_need`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/const-traits/const-closure-with-indestructible-indestructible.rs
+++ b/tests/ui/traits/const-traits/const-closure-with-indestructible-indestructible.rs
@@ -1,0 +1,15 @@
+//@revisions: next old
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+#![feature(const_trait_impl, const_closures, const_destruct)]
+const fn i_need<F: [const] std::marker::Destruct>(x: F) {}
+
+fn main() {
+    const {
+        let v = Vec::<u8>::new();
+        i_need(const || {
+            //~^ ERROR the trait bound
+            let y = v;
+        })
+    };
+}

--- a/tests/ui/type/pattern_types/validity.rs
+++ b/tests/ui/type/pattern_types/validity.rs
@@ -8,7 +8,7 @@
 use std::pat::pattern_type;
 
 const BAD: pattern_type!(u32 is 1..) = unsafe { std::mem::transmute(0) };
-//~^ ERROR: constructing invalid value: encountered 0
+//~^ ERROR: encountered 0
 
 const BAD_UNINIT: pattern_type!(u32 is 1..) =
     //~^ ERROR: this operation requires initialized memory
@@ -18,22 +18,22 @@ const BAD_PTR: pattern_type!(usize is 1..) = unsafe { std::mem::transmute(&42) }
 //~^ ERROR: unable to turn pointer into integer
 
 const BAD_AGGREGATE: (pattern_type!(u32 is 1..), u32) = (unsafe { std::mem::transmute(0) }, 0);
-//~^ ERROR: constructing invalid value at .0: encountered 0
+//~^ ERROR: at .0, encountered 0
 
 struct Foo(Bar);
 struct Bar(pattern_type!(u32 is 1..));
 
 const BAD_FOO: Foo = Foo(Bar(unsafe { std::mem::transmute(0) }));
-//~^ ERROR: constructing invalid value at .0.0: encountered 0
+//~^ ERROR: at .0.0, encountered 0
 
 const CHAR_UNINIT: pattern_type!(char is 'A'..'Z') =
     //~^ ERROR: this operation requires initialized memory
     unsafe { std::mem::transmute(std::mem::MaybeUninit::<u32>::uninit()) };
 
 const CHAR_OOB_PAT: pattern_type!(char is 'A'..'Z') = unsafe { std::mem::transmute('a') };
-//~^ ERROR: constructing invalid value: encountered 97, but expected something in the range 65..=89
+//~^ ERROR: encountered 97, but expected something in the range 65..=89
 
 const CHAR_OOB: pattern_type!(char is 'A'..'Z') = unsafe { std::mem::transmute(u32::MAX) };
-//~^ ERROR: constructing invalid value: encountered 0xffffffff
+//~^ ERROR: encountered 0xffffffff
 
 fn main() {}

--- a/tests/ui/type/pattern_types/validity.stderr
+++ b/tests/ui/type/pattern_types/validity.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value: encountered 0, but expected something greater or equal to 1
+error[E0080]: constructing invalid value of type (u32) is 1..: encountered 0, but expected something greater or equal to 1
   --> $DIR/validity.rs:10:1
    |
 LL | const BAD: pattern_type!(u32 is 1..) = unsafe { std::mem::transmute(0) };
@@ -28,7 +28,7 @@ LL | const BAD_PTR: pattern_type!(usize is 1..) = unsafe { std::mem::transmute(&
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
+error[E0080]: constructing invalid value of type ((u32) is 1.., u32): at .0, encountered 0, but expected something greater or equal to 1
   --> $DIR/validity.rs:20:1
    |
 LL | const BAD_AGGREGATE: (pattern_type!(u32 is 1..), u32) = (unsafe { std::mem::transmute(0) }, 0);
@@ -39,7 +39,7 @@ LL | const BAD_AGGREGATE: (pattern_type!(u32 is 1..), u32) = (unsafe { std::mem:
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value at .0.0: encountered 0, but expected something greater or equal to 1
+error[E0080]: constructing invalid value of type Foo: at .0.0, encountered 0, but expected something greater or equal to 1
   --> $DIR/validity.rs:26:1
    |
 LL | const BAD_FOO: Foo = Foo(Bar(unsafe { std::mem::transmute(0) }));
@@ -60,7 +60,7 @@ LL | const CHAR_UNINIT: pattern_type!(char is 'A'..'Z') =
                __ __ __ __                                     │ ░░░░
            }
 
-error[E0080]: constructing invalid value: encountered 97, but expected something in the range 65..=89
+error[E0080]: constructing invalid value of type (char) is 'A'..='Y': encountered 97, but expected something in the range 65..=89
   --> $DIR/validity.rs:33:1
    |
 LL | const CHAR_OOB_PAT: pattern_type!(char is 'A'..'Z') = unsafe { std::mem::transmute('a') };
@@ -71,7 +71,7 @@ LL | const CHAR_OOB_PAT: pattern_type!(char is 'A'..'Z') = unsafe { std::mem::tr
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered 0xffffffff, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
+error[E0080]: constructing invalid value of type (char) is 'A'..='Y': encountered 0xffffffff, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
   --> $DIR/validity.rs:36:1
    |
 LL | const CHAR_OOB: pattern_type!(char is 'A'..'Z') = unsafe { std::mem::transmute(u32::MAX) };


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#152710 (Unalign `PackedFingerprint` on all hosts, not just x86 and x86-64)
 - rust-lang/rust#153874 (constify const Fn*: Destruct)
 - rust-lang/rust#154097 (improve validation error messages: show surrounding type)
 - rust-lang/rust#154277 (use `minicore` more in testing inline assembly)
 - rust-lang/rust#154293 (Use verbose span suggestion for type const)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=152710,153874,154097,154277,154293)
<!-- homu-ignore:end -->

