### PR TITLE
change the type of the argument of `drop_in_place` lang item to `&mut _`

### DIFF
--- a/compiler/rustc_codegen_cranelift/example/mini_core.rs
+++ b/compiler/rustc_codegen_cranelift/example/mini_core.rs
@@ -575,14 +575,10 @@ unsafe extern "C" {
     fn _Unwind_Resume(exc: *mut ()) -> !;
 }
 
-#[lang = "drop_in_place"]
-#[allow(unconditional_recursion)]
-pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T) {
+#[lang = "drop_glue"]
+pub unsafe fn drop_glue<T: ?Sized>(_to_drop: &mut T) {
     // Code here does not matter - this is replaced by the
     // real drop glue by the compiler.
-    unsafe {
-        drop_in_place(to_drop);
-    }
 }
 
 #[lang = "unpin"]

--- a/compiler/rustc_codegen_cranelift/src/abi/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/abi/mod.rs
@@ -701,7 +701,7 @@ pub(crate) fn codegen_drop<'tcx>(
     unwind: UnwindAction,
 ) {
     let ty = drop_place.layout().ty;
-    let drop_instance = Instance::resolve_drop_in_place(fx.tcx, ty);
+    let drop_instance = Instance::resolve_drop_glue(fx.tcx, ty);
     let ret_block = fx.get_block(target);
 
     // AsyncDropGlueCtorShim can't be here
@@ -734,7 +734,7 @@ pub(crate) fn codegen_drop<'tcx>(
                 fx.bcx.switch_to_block(continued);
 
                 // FIXME(eddyb) perhaps move some of this logic into
-                // `Instance::resolve_drop_in_place`?
+                // `Instance::resolve_drop_glue`?
                 let virtual_drop = Instance {
                     def: ty::InstanceKind::Virtual(drop_instance.def_id(), 0),
                     args: drop_instance.args,

--- a/compiler/rustc_codegen_gcc/example/mini_core.rs
+++ b/compiler/rustc_codegen_gcc/example/mini_core.rs
@@ -577,12 +577,10 @@ fn eh_personality() -> ! {
     loop {}
 }
 
-#[lang = "drop_in_place"]
-#[allow(unconditional_recursion)]
-pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T) {
+#[lang = "drop_glue"]
+pub unsafe fn drop_glue<T: ?Sized>(_to_drop: &mut T) {
     // Code here does not matter - this is replaced by the
     // real drop glue by the compiler.
-    drop_in_place(to_drop);
 }
 
 #[lang = "unpin"]

--- a/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
+++ b/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
@@ -403,7 +403,7 @@ fn upstream_monomorphizations_provider(
 
     let mut instances: DefIdMap<UnordMap<_, _>> = Default::default();
 
-    let drop_in_place_fn_def_id = tcx.lang_items().drop_in_place_fn();
+    let drop_glue_fn_def_id = tcx.lang_items().drop_glue_fn();
     let async_drop_in_place_fn_def_id = tcx.lang_items().async_drop_in_place_fn();
 
     for &cnum in cnums.iter() {
@@ -411,11 +411,10 @@ fn upstream_monomorphizations_provider(
             let (def_id, args) = match *exported_symbol {
                 ExportedSymbol::Generic(def_id, args) => (def_id, args),
                 ExportedSymbol::DropGlue(ty) => {
-                    if let Some(drop_in_place_fn_def_id) = drop_in_place_fn_def_id {
+                    if let Some(drop_in_place_fn_def_id) = drop_glue_fn_def_id {
                         (drop_in_place_fn_def_id, tcx.mk_args(&[ty.into()]))
                     } else {
-                        // `drop_in_place` in place does not exist, don't try
-                        // to use it.
+                        // `drop_glue` does not exist, don't try to use it.
                         continue;
                     }
                 }
@@ -465,7 +464,7 @@ fn upstream_drop_glue_for_provider<'tcx>(
     tcx: TyCtxt<'tcx>,
     args: GenericArgsRef<'tcx>,
 ) -> Option<CrateNum> {
-    let def_id = tcx.lang_items().drop_in_place_fn()?;
+    let def_id = tcx.lang_items().drop_glue_fn()?;
     tcx.upstream_monomorphizations_for(def_id)?.get(&args).cloned()
 }
 
@@ -587,7 +586,7 @@ pub(crate) fn symbol_name_for_instance_in_crate<'tcx>(
         }
         ExportedSymbol::DropGlue(ty) => rustc_symbol_mangling::symbol_name_for_instance_in_crate(
             tcx,
-            Instance::resolve_drop_in_place(tcx, ty),
+            Instance::resolve_drop_glue(tcx, ty),
             instantiating_crate,
         ),
         ExportedSymbol::AsyncDropGlueCtorShim(ty) => {

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -603,7 +603,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     ) -> MergingSucc {
         let ty = location.ty(self.mir, bx.tcx()).ty;
         let ty = self.monomorphize(ty);
-        let drop_fn = Instance::resolve_drop_in_place(bx.tcx(), ty);
+        let drop_fn = Instance::resolve_drop_glue(bx.tcx(), ty);
 
         if let ty::InstanceKind::DropGlue(_, None) = drop_fn.def {
             // we don't actually need to drop anything.
@@ -621,7 +621,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         };
         let (maybe_null, drop_fn, fn_abi, drop_instance) = match ty.kind() {
             // FIXME(eddyb) perhaps move some of this logic into
-            // `Instance::resolve_drop_in_place`?
+            // `Instance::resolve_drop_glue`?
             ty::Dynamic(_, _) => {
                 // IN THIS ARM, WE HAVE:
                 // ty = *mut (dyn Trait)

--- a/compiler/rustc_const_eval/src/interpret/call.rs
+++ b/compiler/rustc_const_eval/src/interpret/call.rs
@@ -895,16 +895,15 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             _ => {
                 debug_assert_eq!(
                     instance,
-                    ty::Instance::resolve_drop_in_place(*self.tcx, place.layout.ty)
+                    ty::Instance::resolve_drop_glue(*self.tcx, place.layout.ty)
                 );
                 place
             }
         };
 
         let instance = {
-            let _trace =
-                enter_trace_span!(M, resolve::resolve_drop_in_place, ty = ?place.layout.ty);
-            ty::Instance::resolve_drop_in_place(*self.tcx, place.layout.ty)
+            let _trace = enter_trace_span!(M, resolve::resolve_drop_glue, ty = ?place.layout.ty);
+            ty::Instance::resolve_drop_glue(*self.tcx, place.layout.ty)
         };
         let fn_abi = self.fn_abi_of_instance_no_deduced_attrs(instance, ty::List::empty())?;
 

--- a/compiler/rustc_const_eval/src/interpret/call.rs
+++ b/compiler/rustc_const_eval/src/interpret/call.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 use either::{Left, Right};
 use rustc_abi::{self as abi, ExternAbi, FieldIdx, Integer, VariantIdx};
 use rustc_hir::def_id::DefId;
-use rustc_hir::{LangItem, find_attr};
+use rustc_hir::find_attr;
 use rustc_middle::ty::layout::{IntegerExt, TyAndLayout};
 use rustc_middle::ty::{self, AdtDef, Instance, Ty, Unnormalized, VariantDef};
 use rustc_middle::{bug, mir, span_bug};
@@ -278,7 +278,6 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         callee_arg: &mir::Place<'tcx>,
         callee_ty: Ty<'tcx>,
         already_live: bool,
-        is_drop_in_place: bool,
     ) -> InterpResult<'tcx>
     where
         'tcx: 'x,
@@ -323,16 +322,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             self.storage_live_dyn(local, meta)?;
         }
         // Now we can finally actually evaluate the callee place.
-        let mut callee_arg = self.eval_place(*callee_arg)?;
-        // drop_in_place has a signature which says that the first argument is `*mut T`
-        // but really it's `&mut T`. This is where we handle that terrible hack in
-        // the MIR semantics.
-        // FIXME(#154274): remove this hack.
-        if is_drop_in_place && callee_arg_idx == 0 {
-            let pointee_ty = callee_arg.layout.ty.builtin_deref(true).unwrap();
-            let mutref_ty = Ty::new_mut_ref(*self.tcx, self.tcx.lifetimes.re_erased, pointee_ty);
-            callee_arg = callee_arg.transmute(self.layout_of(mutref_ty)?, self)?;
-        }
+        let callee_arg = self.eval_place(*callee_arg)?;
         // We allow some transmutes here.
         // FIXME: Depending on the PassMode, this should reset some padding to uninitialized. (This
         // is true for all `copy_op`, but there are a lot of special cases for argument passing
@@ -464,12 +454,6 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         // Determine whether there is a special VaList argument. This is always the
         // last argument, and since arguments start at index 1 that's `arg_count`.
         let va_list_arg = callee_fn_abi.c_variadic.then(|| mir::Local::from_usize(body.arg_count));
-        // Part of the hack for #154274, see `pass_argument`.
-        let is_drop_in_place = {
-            let def_id = body.source.def_id();
-            self.tcx.is_lang_item(def_id, LangItem::DropInPlace)
-                || self.tcx.is_lang_item(def_id, LangItem::AsyncDropInPlace)
-        };
 
         // During argument passing, we want retagging with protectors.
         M::with_retag_mode(self, RetagMode::FnEntry, |ecx| {
@@ -532,7 +516,6 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                             &dest,
                             field_ty,
                             /* already_live */ true,
-                            is_drop_in_place,
                         )?;
                     }
                 } else {
@@ -545,7 +528,6 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                         &dest,
                         ty,
                         /* already_live */ false,
-                        is_drop_in_place,
                     )?;
                 }
             }
@@ -918,6 +900,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 place
             }
         };
+
         let instance = {
             let _trace =
                 enter_trace_span!(M, resolve::resolve_drop_in_place, ty = ?place.layout.ty);
@@ -925,7 +908,9 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         };
         let fn_abi = self.fn_abi_of_instance_no_deduced_attrs(instance, ty::List::empty())?;
 
-        let arg = self.mplace_to_imm_ptr(&place, None)?;
+        let ref_ty = Ty::new_mut_ref(self.tcx.tcx, self.tcx.lifetimes.re_erased, place.layout.ty);
+        let arg = self.mplace_to_imm_ptr(&place, Some(ref_ty))?;
+
         let ret = MPlaceTy::fake_alloc_zst(self.layout_of(self.tcx.types.unit)?);
 
         self.init_fn_call(

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -593,8 +593,8 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 let place = self.eval_place(place)?;
                 let instance = {
                     let _trace =
-                        enter_trace_span!(M, resolve::resolve_drop_in_place, ty = ?place.layout.ty);
-                    Instance::resolve_drop_in_place(*self.tcx, place.layout.ty)
+                        enter_trace_span!(M, resolve::resolve_drop_glue, ty = ?place.layout.ty);
+                    Instance::resolve_drop_glue(*self.tcx, place.layout.ty)
                 };
                 if let ty::InstanceKind::DropGlue(_, None) = instance.def {
                     // This is the branch we enter if and only if the dropped type has no drop glue

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -321,7 +321,8 @@ language_item_table! {
     FormatArgument,          sym::format_argument,     format_argument,            Target::Struct,         GenericRequirement::None;
     FormatArguments,         sym::format_arguments,    format_arguments,           Target::Struct,         GenericRequirement::None;
 
-    DropInPlace,             sym::drop_in_place,       drop_in_place_fn,           Target::Fn,             GenericRequirement::Minimum(1);
+    // Compiler-generated drop glue function, aka `core::ptr::drop_glue`
+    DropGlue,                sym::drop_glue,           drop_glue_fn,               Target::Fn,             GenericRequirement::Exact(1);
     AllocLayout,             sym::alloc_layout,        alloc_layout,               Target::Struct,         GenericRequirement::None;
 
     /// For all binary crates without `#![no_main]`, Rust will generate a "main" function.

--- a/compiler/rustc_middle/src/hir/mod.rs
+++ b/compiler/rustc_middle/src/hir/mod.rs
@@ -300,8 +300,8 @@ impl<'tcx> TyCtxt<'tcx> {
             Node::Expr(parent_expr) => {
                 match parent_expr.kind {
                     // Addr-of, field projections, and LHS of assignment don't constitute reads.
-                    // Assignment does call `drop_in_place`, though, but its safety
-                    // requirements are not the same.
+                    // Assignment does call `drop_glue`, though, but its safety requirements are
+                    // not the same.
                     ExprKind::AddrOf(..) | ExprKind::Field(..) => false,
 
                     // Place-preserving expressions only constitute reads if their

--- a/compiler/rustc_middle/src/middle/exported_symbols.rs
+++ b/compiler/rustc_middle/src/middle/exported_symbols.rs
@@ -66,7 +66,7 @@ impl<'tcx> ExportedSymbol<'tcx> {
                 tcx.symbol_name(ty::Instance::new_raw(def_id, args))
             }
             ExportedSymbol::DropGlue(ty) => {
-                tcx.symbol_name(ty::Instance::resolve_drop_in_place(tcx, ty))
+                tcx.symbol_name(ty::Instance::resolve_drop_glue(tcx, ty))
             }
             ExportedSymbol::AsyncDropGlueCtorShim(ty) => {
                 tcx.symbol_name(ty::Instance::resolve_async_drop_in_place(tcx, ty))

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -743,7 +743,7 @@ pub enum TerminatorKind<'tcx> {
     ///
     /// After drop elaboration: `Drop` terminators are a complete nop for types that have no drop
     /// glue. For other types, `Drop` terminators behave exactly like a call to
-    /// `core::mem::drop_in_place` with a pointer to the given place.
+    /// `core::mem::drop_glue` with a reference to the given place.
     ///
     /// `Drop` before drop elaboration is a *conditional* execution of the drop glue. Specifically,
     /// the `Drop` will be executed if...

--- a/compiler/rustc_middle/src/mono.rs
+++ b/compiler/rustc_middle/src/mono.rs
@@ -70,7 +70,7 @@ fn opt_incr_drop_glue_mode<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Instantiati
     let Some(dtor) = adt_def.destructor(tcx) else {
         // We use LocalCopy for drops of enums only; this code is inherited from
         // https://github.com/rust-lang/rust/pull/67332 and the theory is that we get to optimize
-        // out code like drop_in_place(Option::None) before crate-local ThinLTO, which improves
+        // out code like `drop_glue(&mut Option::None)` before crate-local ThinLTO, which improves
         // compile time. At the time of writing, simply removing this entire check does seem to
         // regress incr-opt compile times. But it sure seems like a more sophisticated check could
         // do better here.
@@ -81,8 +81,8 @@ fn opt_incr_drop_glue_mode<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Instantiati
         }
     };
 
-    // We've gotten to a drop_in_place for a type that directly implements Drop.
-    // The drop glue is a wrapper for the Drop::drop impl, and we are an optimized build, so in an
+    // We've gotten to a `drop_glue` for a type that directly implements Drop.
+    // The drop glue is a wrapper for the `Drop::drop` impl, and we are an optimized build, so in an
     // effort to coordinate with the mode that the actual impl will get, we make the glue also
     // LocalCopy.
     if tcx.cross_crate_inlinable(dtor.did) {

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -147,11 +147,10 @@ pub enum InstanceKind<'tcx> {
     /// Proxy shim for async drop of future (def_id, proxy_cor_ty, impl_cor_ty)
     FutureDropPollShim(DefId, Ty<'tcx>, Ty<'tcx>),
 
-    /// `core::ptr::drop_in_place::<T>`.
+    /// `core::ptr::drop_glue::<T>`.
     ///
-    /// The `DefId` is for `core::ptr::drop_in_place`.
-    /// The `Option<Ty<'tcx>>` is either `Some(T)`, or `None` for empty drop
-    /// glue.
+    /// The `DefId` is for `core::ptr::drop_glue`.
+    /// The `Option<Ty<'tcx>>` is either `Some(T)`, or `None` for empty drop glue.
     DropGlue(DefId, Option<Ty<'tcx>>),
 
     /// Compiler-generated `<T as Clone>::clone` implementation.
@@ -716,8 +715,8 @@ impl<'tcx> Instance<'tcx> {
         }
     }
 
-    pub fn resolve_drop_in_place(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> ty::Instance<'tcx> {
-        let def_id = tcx.require_lang_item(LangItem::DropInPlace, DUMMY_SP);
+    pub fn resolve_drop_glue(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> ty::Instance<'tcx> {
+        let def_id = tcx.require_lang_item(LangItem::DropGlue, DUMMY_SP);
         let args = tcx.mk_args(&[ty.into()]);
         Instance::expect_resolve(
             tcx,

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -1221,12 +1221,12 @@ pub fn fn_can_unwind(tcx: TyCtxt<'_>, fn_def_id: Option<DefId>, abi: ExternAbi) 
             return false;
         }
 
-        // With -Z panic-in-drop=abort, drop_in_place never unwinds.
+        // With -Z panic-in-drop=abort, `drop_glue` never unwinds.
         //
         // This is not part of `codegen_fn_attrs` as it can differ between crates
         // and therefore cannot be computed in core.
         if !tcx.sess.opts.unstable_opts.panic_in_drop.unwinds()
-            && tcx.is_lang_item(did, LangItem::DropInPlace)
+            && tcx.is_lang_item(did, LangItem::DropGlue)
         {
             return false;
         }

--- a/compiler/rustc_middle/src/ty/vtable.rs
+++ b/compiler/rustc_middle/src/ty/vtable.rs
@@ -122,7 +122,7 @@ pub(super) fn vtable_allocation_provider<'tcx>(
         let scalar = match *entry {
             VtblEntry::MetadataDropInPlace => {
                 if ty.needs_drop(tcx, ty::TypingEnv::fully_monomorphized()) {
-                    let instance = ty::Instance::resolve_drop_in_place(tcx, ty);
+                    let instance = ty::Instance::resolve_drop_glue(tcx, ty);
                     let fn_alloc_id = tcx.reserve_and_set_fn_alloc(instance, CTFE_ALLOC_SALT);
                     let fn_ptr = Pointer::from(fn_alloc_id);
                     Scalar::from_pointer(fn_ptr, &tcx)

--- a/compiler/rustc_mir_transform/src/add_moves_for_packed_drops.rs
+++ b/compiler/rustc_mir_transform/src/add_moves_for_packed_drops.rs
@@ -10,6 +10,7 @@ use crate::util;
 /// they are dropped from an aligned address.
 ///
 /// For example, if we have something like
+///
 /// ```ignore (illustrative)
 /// #[repr(packed)]
 /// struct Foo {
@@ -20,9 +21,8 @@ use crate::util;
 /// let foo = ...;
 /// ```
 ///
-/// We want to call `drop_in_place::<Vec<u8>>` on `data` from an aligned
-/// address. This means we can't simply drop `foo.data` directly, because
-/// its address is not aligned.
+/// We want to call `drop_glue::<Vec<u8>>` with a reference to `data`, which must be aligned.
+/// This means we can't simply drop `foo.data` directly, because its address is not aligned.
 ///
 /// Instead, we move `foo.data` to a local and drop that:
 /// ```ignore (illustrative)

--- a/compiler/rustc_mir_transform/src/coroutine/drop.rs
+++ b/compiler/rustc_mir_transform/src/coroutine/drop.rs
@@ -596,10 +596,6 @@ pub(super) fn create_coroutine_drop_shim<'tcx>(
 
     make_coroutine_state_argument_indirect(tcx, &mut body);
 
-    // Change the coroutine argument from &mut to *mut
-    body.local_decls[SELF_ARG] =
-        LocalDecl::with_source_info(Ty::new_mut_ptr(tcx, coroutine_ty), source_info);
-
     // Make sure we remove dead blocks to remove
     // unrelated code from the resume part of the function
     simplify::remove_dead_blocks(&mut body);

--- a/compiler/rustc_mir_transform/src/coroutine/drop.rs
+++ b/compiler/rustc_mir_transform/src/coroutine/drop.rs
@@ -569,7 +569,7 @@ pub(super) fn create_coroutine_drop_shim<'tcx>(
     // not a coroutine body itself; it just has its drop built out of it.
     let _ = body.coroutine.take();
     // Make sure the resume argument is not included here, since we're
-    // building a body for `drop_in_place`.
+    // building a body for `drop_glue`.
     body.arg_count = 1;
 
     let source_info = SourceInfo::outermost(body.span);
@@ -602,8 +602,8 @@ pub(super) fn create_coroutine_drop_shim<'tcx>(
 
     // Update the body's def to become the drop glue.
     let coroutine_instance = body.source.instance;
-    let drop_in_place = tcx.require_lang_item(LangItem::DropInPlace, body.span);
-    let drop_instance = InstanceKind::DropGlue(drop_in_place, Some(coroutine_ty));
+    let drop_glue = tcx.require_lang_item(LangItem::DropGlue, body.span);
+    let drop_instance = InstanceKind::DropGlue(drop_glue, Some(coroutine_ty));
 
     // Temporary change MirSource to coroutine's instance so that dump_mir produces more sensible
     // filename.

--- a/compiler/rustc_mir_transform/src/elaborate_drop.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drop.rs
@@ -354,7 +354,6 @@ where
             let ty::Adt(adt_def, adt_args) = pin_obj_ty.kind() else {
                 bug!();
             };
-            let obj_ptr_ty = Ty::new_mut_ptr(tcx, drop_ty);
             let unwrap_ty = adt_def.non_enum_variant().fields[FieldIdx::ZERO].ty(tcx, adt_args);
             let obj_ref_place = Place::from(self.new_temp(unwrap_ty));
             call_statements.push(self.assign(
@@ -365,11 +364,7 @@ where
                 ),
             ));
 
-            let obj_ptr_place = Place::from(self.new_temp(obj_ptr_ty));
-
-            let addr = Rvalue::RawPtr(RawPtrKind::Mut, tcx.mk_place_deref(obj_ref_place));
-            call_statements.push(self.assign(obj_ptr_place, addr));
-            obj_ptr_place
+            obj_ref_place
         };
         call_statements
             .push(Statement::new(self.source_info, StatementKind::StorageLive(fut.local)));

--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -324,7 +324,6 @@ fn build_drop_shim<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, ty: Option<Ty<'tcx>>)
     let mut body =
         new_body(source, blocks, local_decls_for_sig(&sig, span), sig.inputs().len(), span);
 
-    // The first argument (index 0), but local 1 (after the return place).
     let dropee_ptr = Place::from(Local::arg(0));
 
     if ty.is_some() {

--- a/compiler/rustc_mir_transform/src/shim/async_destructor_ctor.rs
+++ b/compiler/rustc_mir_transform/src/shim/async_destructor_ctor.rs
@@ -51,7 +51,7 @@ pub(super) fn build_async_drop_shim<'tcx>(
     let typing_env = ty::TypingEnv::fully_monomorphized();
 
     let drop_ty = parent_args.first().unwrap().expect_ty();
-    let drop_ptr_ty = Ty::new_mut_ptr(tcx, drop_ty);
+    let drop_ptr_ty = Ty::new_mut_ref(tcx, tcx.lifetimes.re_erased, drop_ty);
 
     assert!(tcx.is_coroutine(def_id));
     let coroutine_kind = tcx.coroutine_kind(def_id).unwrap();
@@ -202,7 +202,7 @@ fn build_adrop_for_coroutine_shim<'tcx>(
     let source_info = SourceInfo::outermost(span);
     // converting `(_1: Pin<&mut CorLayout>, _2: &mut Context<'_>) -> Poll<()>`
     // into `(_1: Pin<&mut ProxyLayout>, _2: &mut Context<'_>) -> Poll<()>`
-    // let mut _x: &mut CorLayout = &*_1.0.0;
+    // let mut _x: &mut CorLayout = &mut *_1.0.0;
     // Replace old _1.0 accesses into _x accesses;
     let body = tcx.optimized_mir(*coroutine_def_id).future_drop_poll().unwrap();
     let mut body: Body<'tcx> =
@@ -225,7 +225,7 @@ fn build_adrop_for_coroutine_shim<'tcx>(
 
     {
         let mut idx: usize = 0;
-        // _proxy = _1.0 : Pin<&ProxyLayout> ==> &ProxyLayout
+        // _proxy = _1.0 : Pin<&mut ProxyLayout> ==> &mut ProxyLayout
         let proxy_ref_place = Place::from(pin_proxy_layout_local)
             .project_deeper(&[PlaceElem::Field(FieldIdx::ZERO, proxy_ref)], tcx);
         body.basic_blocks_mut()[START_BLOCK].statements.insert(
@@ -239,22 +239,23 @@ fn build_adrop_for_coroutine_shim<'tcx>(
             ),
         );
         idx += 1;
-        let mut cor_ptr_local = proxy_ref_local;
+
+        // _cor_ref_tmp = (*(*_proxy).0).0...
+        let mut cor_ref_tmp_local = proxy_ref_local;
         proxy_ty.find_async_drop_impl_coroutine(tcx, |ty| {
             if ty != proxy_ty {
-                let ty_ptr = Ty::new_mut_ptr(tcx, ty);
-                let impl_ptr_place = Place::from(cor_ptr_local).project_deeper(
-                    &[PlaceElem::Deref, PlaceElem::Field(FieldIdx::ZERO, ty_ptr)],
+                let ty_ref = Ty::new_mut_ref(tcx, tcx.lifetimes.re_erased, ty);
+                let impl_ptr_place = Place::from(cor_ref_tmp_local).project_deeper(
+                    &[PlaceElem::Deref, PlaceElem::Field(FieldIdx::ZERO, ty_ref)],
                     tcx,
                 );
-                cor_ptr_local = body.local_decls.push(LocalDecl::new(ty_ptr, span));
-                // _cor_ptr = _proxy.0.0 (... .0)
+                cor_ref_tmp_local = body.local_decls.push(LocalDecl::new(ty_ref, span));
                 body.basic_blocks_mut()[START_BLOCK].statements.insert(
                     idx,
                     Statement::new(
                         source_info,
                         StatementKind::Assign(Box::new((
-                            Place::from(cor_ptr_local),
+                            Place::from(cor_ref_tmp_local),
                             Rvalue::Use(Operand::Copy(impl_ptr_place), WithRetag::Yes),
                         ))),
                     ),
@@ -263,17 +264,15 @@ fn build_adrop_for_coroutine_shim<'tcx>(
             }
         });
 
-        // _cor_ref = &*cor_ptr
-        let reborrow = Rvalue::Ref(
-            tcx.lifetimes.re_erased,
-            BorrowKind::Mut { kind: MutBorrowKind::Default },
-            tcx.mk_place_deref(Place::from(cor_ptr_local)),
-        );
+        // _cor_ref = cor_ref_tmp
         body.basic_blocks_mut()[START_BLOCK].statements.insert(
             idx,
             Statement::new(
                 source_info,
-                StatementKind::Assign(Box::new((Place::from(cor_ref_local), reborrow))),
+                StatementKind::Assign(Box::new((
+                    Place::from(cor_ref_local),
+                    Rvalue::Use(Operand::Move(Place::from(cor_ref_tmp_local)), WithRetag::Yes),
+                ))),
             ),
         );
     }
@@ -329,7 +328,7 @@ fn build_adrop_for_adrop_shim<'tcx>(
     let mut cor_ptr_local = proxy_ref_local;
     proxy_ty.find_async_drop_impl_coroutine(tcx, |ty| {
         if ty != proxy_ty {
-            let ty_ptr = Ty::new_mut_ptr(tcx, ty);
+            let ty_ptr = Ty::new_mut_ref(tcx, tcx.lifetimes.re_erased, ty);
             let impl_ptr_place = Place::from(cor_ptr_local)
                 .project_deeper(&[PlaceElem::Deref, PlaceElem::Field(FieldIdx::ZERO, ty_ptr)], tcx);
             cor_ptr_local = locals.push(LocalDecl::new(ty_ptr, span));

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -656,8 +656,8 @@ fn check_recursion_limit<'tcx>(
     let recursion_depth = recursion_depths.get(&def_id).cloned().unwrap_or(0);
     debug!(" => recursion depth={}", recursion_depth);
 
-    let adjusted_recursion_depth = if tcx.is_lang_item(def_id, LangItem::DropInPlace) {
-        // HACK: drop_in_place creates tight monomorphization loops. Give
+    let adjusted_recursion_depth = if tcx.is_lang_item(def_id, LangItem::DropGlue) {
+        // HACK: `drop_glue` creates tight monomorphization loops. Give
         // it more margin.
         recursion_depth / 4
     } else {
@@ -935,7 +935,7 @@ fn visit_drop_use<'tcx>(
     source: Span,
     output: &mut MonoItems<'tcx>,
 ) {
-    let instance = Instance::resolve_drop_in_place(tcx, ty);
+    let instance = Instance::resolve_drop_glue(tcx, ty);
     visit_instance_use(tcx, instance, is_direct_call, source, output);
 }
 
@@ -1529,7 +1529,7 @@ impl<'v> RootCollector<'_, 'v> {
                         });
 
                     // This type is impossible to instantiate, so we should not try to
-                    // generate a `drop_in_place` instance for it.
+                    // generate a `drop_glue` instance for it.
                     if self.tcx.instantiate_and_check_impossible_predicates((
                         id.owner_id.to_def_id(),
                         id_args,

--- a/compiler/rustc_monomorphize/src/partitioning.rs
+++ b/compiler/rustc_monomorphize/src/partitioning.rs
@@ -663,9 +663,8 @@ fn characteristic_def_id_of_mono_item<'tcx>(
                     && tcx.sess.opts.incremental.is_some()
                     && tcx.is_lang_item(tcx.impl_trait_id(impl_def_id), LangItem::Drop)
                 {
-                    // Put `Drop::drop` into the same cgu as `drop_in_place`
-                    // since `drop_in_place` is the only thing that can
-                    // call it.
+                    // Put `Drop::drop` into the same cgu as `drop_glue`
+                    // since `drop_glue` is the only thing that can call it.
                     return None;
                 }
 

--- a/compiler/rustc_passes/src/lang_items.rs
+++ b/compiler/rustc_passes/src/lang_items.rs
@@ -193,7 +193,7 @@ impl<'ast, 'tcx> LanguageItemCollector<'ast, 'tcx> {
             // one (for the RHS/index), unary operations have none, the closure
             // traits have one for the argument list, coroutines have one for the
             // resume argument, and ordering/equality relations have one for the RHS
-            // Some other types like Box and various functions like drop_in_place
+            // Some other types like Box and various unsizing-related traits
             // have minimum requirements.
 
             // FIXME: This still doesn't count, e.g., elided lifetimes and APITs.

--- a/compiler/rustc_public_bridge/src/context/impls.rs
+++ b/compiler/rustc_public_bridge/src/context/impls.rs
@@ -665,7 +665,7 @@ impl<'tcx, B: Bridge> CompilerCtxt<'tcx, B> {
 
     /// Resolve an instance for drop_in_place for the given type.
     pub fn resolve_drop_in_place(&self, internal_ty: Ty<'tcx>) -> Instance<'tcx> {
-        let instance = Instance::resolve_drop_in_place(self.tcx, internal_ty);
+        let instance = Instance::resolve_drop_glue(self.tcx, internal_ty);
         instance
     }
 

--- a/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
+++ b/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
@@ -309,7 +309,7 @@ pub(crate) fn transform_instance<'tcx>(
 ) -> Instance<'tcx> {
     // FIXME: account for async-drop-glue
     if (matches!(instance.def, ty::InstanceKind::Virtual(..))
-        && tcx.is_lang_item(instance.def_id(), LangItem::DropInPlace))
+        && tcx.is_lang_item(instance.def_id(), LangItem::DropGlue))
         || matches!(instance.def, ty::InstanceKind::DropGlue(..))
     {
         // Adjust the type ids of DropGlues

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -835,6 +835,7 @@ symbols! {
         dreg_low8,
         dreg_low16,
         drop,
+        drop_glue,
         drop_in_place,
         drop_types_in_const,
         dropck_eyepatch,

--- a/compiler/rustc_ty_utils/src/abi.rs
+++ b/compiler/rustc_ty_utils/src/abi.rs
@@ -319,21 +319,12 @@ fn fn_abi_of_instance_raw<'tcx>(
 }
 
 /// Returns argument attributes for a scalar argument.
-///
-/// `drop_target_pointee`, if set, causes pointer-typed scalars to be treated like mutable
-/// references to the given type. This is used to special-case the argument of `ptr::drop_in_place`,
-/// interpreting it as `&mut T` instead of `*mut T`, for the purposes of attributes (which is valid
-/// as per its safety contract). If `drop_target_pointee` is set, `offset` must be 0 and `layout.ty`
-/// must be a pointer to the given type. Note that for wide pointers this function is called twice
-/// -- once for the data pointer and once for the vtable pointer. `drop_target_pointee` must only
-/// be set for the data pointer.
 fn arg_attrs_for_rust_scalar<'tcx>(
     cx: LayoutCx<'tcx>,
     scalar: Scalar,
     layout: TyAndLayout<'tcx>,
     offset: Size,
     is_return: bool,
-    drop_target_pointee: Option<Ty<'tcx>>,
     determined_fn_def_id: Option<DefId>,
 ) -> ArgAttributes {
     let mut attrs = ArgAttributes::new();
@@ -354,23 +345,13 @@ fn arg_attrs_for_rust_scalar<'tcx>(
 
     // Set `nonnull` if the validity range excludes zero, or for the argument to `drop_in_place`,
     // which must be nonnull per its documented safety requirements.
-    if !valid_range.contains(0) || drop_target_pointee.is_some() {
+    if !valid_range.contains(0) {
         attrs.set(ArgAttribute::NonNull);
     }
 
     let tcx = cx.tcx();
 
-    let drop_target_pointee_info = drop_target_pointee.and_then(|pointee| {
-        assert_eq!(pointee, layout.ty.builtin_deref(true).unwrap());
-        assert_eq!(offset, Size::ZERO);
-        // The argument to `drop_in_place` is semantically equivalent to a mutable reference.
-        let mutref = Ty::new_mut_ref(tcx, tcx.lifetimes.re_erased, pointee);
-        let layout = cx.layout_of(mutref).unwrap();
-        layout.pointee_info_at(&cx, offset)
-    });
-
-    if let Some(pointee) = drop_target_pointee_info.or_else(|| layout.pointee_info_at(&cx, offset))
-    {
+    if let Some(pointee) = layout.pointee_info_at(&cx, offset) {
         if pointee.align > Align::ONE {
             attrs.pointee_align =
                 Some(pointee.align.min(cx.tcx().sess.target.max_reliable_alignment()));
@@ -584,25 +565,10 @@ fn fn_abi_new_uncached<'tcx>(
         extra_args
     };
 
-    // For some functions we treat their first argument as-if it was a mutable reference
-    // even if it is a raw pointer. This is a terrible hack since it becomes effectively
-    // part of the MIR semantics that every MIR consumer needs to be aware of.
-    // Do not add more functions here! Instead, put the actually intended type in the signature.
-    // FIXME(#154274): remove this hack.
-    let is_drop_in_place = determined_fn_def_id.is_some_and(|def_id| {
-        tcx.is_lang_item(def_id, LangItem::DropInPlace)
-            || tcx.is_lang_item(def_id, LangItem::AsyncDropInPlace)
-    });
-
     let arg_of = |ty: Ty<'tcx>, arg_idx: Option<usize>| -> Result<_, &'tcx FnAbiError<'tcx>> {
         let span = tracing::debug_span!("arg_of");
         let _entered = span.enter();
         let is_return = arg_idx.is_none();
-        let is_drop_target = is_drop_in_place && arg_idx == Some(0);
-        let drop_target_pointee = is_drop_target.then(|| match ty.kind() {
-            ty::RawPtr(ty, _) => *ty,
-            _ => bug!("argument to drop_in_place is not a raw ptr: {:?}", ty),
-        });
 
         let layout = cx.layout_of(ty).map_err(|err| &*tcx.arena.alloc(FnAbiError::Layout(*err)))?;
         let layout = if is_virtual_call && arg_idx == Some(0) {
@@ -615,17 +581,7 @@ fn fn_abi_new_uncached<'tcx>(
         };
 
         Ok(ArgAbi::new(cx, layout, |scalar, offset| {
-            arg_attrs_for_rust_scalar(
-                *cx,
-                scalar,
-                layout,
-                offset,
-                is_return,
-                // Only set `drop_target_pointee` for the data part of a wide pointer.
-                // See `arg_attrs_for_rust_scalar` docs for more information.
-                drop_target_pointee.filter(|_| offset == Size::ZERO),
-                determined_fn_def_id,
-            )
+            arg_attrs_for_rust_scalar(*cx, scalar, layout, offset, is_return, determined_fn_def_id)
         }))
     };
 

--- a/compiler/rustc_ty_utils/src/abi.rs
+++ b/compiler/rustc_ty_utils/src/abi.rs
@@ -343,8 +343,7 @@ fn arg_attrs_for_rust_scalar<'tcx>(
     // Only pointer types handled below.
     let Scalar::Initialized { value: Pointer(_), valid_range } = scalar else { return attrs };
 
-    // Set `nonnull` if the validity range excludes zero, or for the argument to `drop_in_place`,
-    // which must be nonnull per its documented safety requirements.
+    // Set `nonnull` if the validity range excludes zero.
     if !valid_range.contains(0) {
         attrs.set(ArgAttribute::NonNull);
     }

--- a/compiler/rustc_ty_utils/src/instance.rs
+++ b/compiler/rustc_ty_utils/src/instance.rs
@@ -35,7 +35,7 @@ fn resolve_instance_raw<'tcx>(
         let def = if tcx.intrinsic(def_id).is_some() {
             debug!(" => intrinsic");
             ty::InstanceKind::Intrinsic(def_id)
-        } else if tcx.is_lang_item(def_id, LangItem::DropInPlace) {
+        } else if tcx.is_lang_item(def_id, LangItem::DropGlue) {
             let ty = args.type_at(0);
 
             if ty.needs_drop(tcx, typing_env) {

--- a/library/core/src/future/async_drop.rs
+++ b/library/core/src/future/async_drop.rs
@@ -52,6 +52,7 @@ pub trait AsyncDrop {
 /// [ptr::drop_in_place]: crate::ptr::drop_in_place()
 #[unstable(feature = "async_drop", issue = "126482")]
 #[lang = "async_drop_in_place"]
+// FIXME: accept a reference here instead
 pub async unsafe fn async_drop_in_place<T: ?Sized>(_to_drop: *mut T) {
     // Code here does not matter - this is replaced by the
     // real implementation by the compiler.

--- a/library/core/src/future/async_drop.rs
+++ b/library/core/src/future/async_drop.rs
@@ -52,8 +52,7 @@ pub trait AsyncDrop {
 /// [ptr::drop_in_place]: crate::ptr::drop_in_place()
 #[unstable(feature = "async_drop", issue = "126482")]
 #[lang = "async_drop_in_place"]
-// FIXME: accept a reference here instead
-pub async unsafe fn async_drop_in_place<T: ?Sized>(_to_drop: *mut T) {
+pub async unsafe fn async_drop_in_place<T: ?Sized>(_to_drop: &mut T) {
     // Code here does not matter - this is replaced by the
     // real implementation by the compiler.
 }

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -801,20 +801,33 @@ pub const unsafe fn write_bytes<T>(dst: *mut T, val: u8, count: usize) {
 /// // Ensure that the last item was dropped.
 /// assert!(weak.upgrade().is_none());
 /// ```
+#[inline(always)]
 #[stable(feature = "drop_in_place", since = "1.8.0")]
-#[lang = "drop_in_place"]
-#[allow(unconditional_recursion)]
 #[rustc_diagnostic_item = "ptr_drop_in_place"]
 #[rustc_const_unstable(feature = "const_drop_in_place", issue = "109342")]
 pub const unsafe fn drop_in_place<T: PointeeSized>(to_drop: *mut T)
 where
     T: [const] Destruct,
 {
+    // Due to historic reasons, `drop_in_place` takes a pointer rather than a reference,
+    // which results in worse codegen since we don't apply noalias/dereferenceable llvm
+    // attributes to pointer arguments. To workaround this without breaking public
+    // interface, `drop_in_place` calls the lang item, rather than being one directly.
+
+    // SAFETY:
+    // - compiler glue has the same safety requirements as this function
+    // - the pointer must be valid as per the safety requirement of this function
+    unsafe { drop_glue(&mut *to_drop) }
+}
+
+/// Helper function for `drop_in_place`. The compiler replaces this by the actual drop glue.
+#[lang = "drop_in_place"]
+const unsafe fn drop_glue<T: PointeeSized>(_: &mut T)
+where
+    T: [const] Destruct,
+{
     // Code here does not matter - this is replaced by the
     // real drop glue by the compiler.
-
-    // SAFETY: see comment above
-    unsafe { drop_in_place(to_drop) }
 }
 
 /// Creates a null raw pointer.

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -821,7 +821,7 @@ where
 }
 
 /// Helper function for `drop_in_place`. The compiler replaces this by the actual drop glue.
-#[lang = "drop_in_place"]
+#[lang = "drop_glue"]
 const unsafe fn drop_glue<T: PointeeSized>(_: &mut T)
 where
     T: [const] Destruct,

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -822,7 +822,7 @@ where
 
 /// Helper function for `drop_in_place`. The compiler replaces this by the actual drop glue.
 #[lang = "drop_glue"]
-const unsafe fn drop_glue<T: PointeeSized>(_: &mut T)
+pub(crate) const unsafe fn drop_glue<T: PointeeSized>(_: &mut T)
 where
     T: [const] Destruct,
 {

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -1116,12 +1116,12 @@ impl<T: PointeeSized> NonNull<T> {
     #[inline(always)]
     #[stable(feature = "non_null_convenience", since = "1.80.0")]
     #[rustc_const_unstable(feature = "const_drop_in_place", issue = "109342")]
-    pub const unsafe fn drop_in_place(self)
+    pub const unsafe fn drop_in_place(mut self)
     where
         T: [const] Destruct,
     {
         // SAFETY: the caller must uphold the safety contract for `drop_in_place`.
-        unsafe { ptr::drop_in_place(self.as_ptr()) }
+        unsafe { ptr::drop_glue(self.as_mut()) }
     }
 
     /// Overwrites a memory location with the given value without reading or

--- a/library/rtstartup/rsbegin.rs
+++ b/library/rtstartup/rsbegin.rs
@@ -39,12 +39,10 @@ auto trait Freeze {}
 
 impl<T: PointeeSized> Copy for *mut T {}
 
-#[lang = "drop_in_place"]
+#[cfg_attr(not(bootstrap), lang = "drop_glue")]
+#[cfg_attr(bootstrap, lang = "drop_in_place")]
 #[inline]
-#[allow(unconditional_recursion)]
-pub unsafe fn drop_in_place<T: PointeeSized>(to_drop: *mut T) {
-    drop_in_place(to_drop);
-}
+pub unsafe fn drop_glue<T: PointeeSized>(_to_drop: &mut T) {}
 
 // Frame unwind info registration
 //

--- a/library/rtstartup/rsend.rs
+++ b/library/rtstartup/rsend.rs
@@ -27,12 +27,10 @@ auto trait Freeze {}
 
 impl<T: PointeeSized> Copy for *mut T {}
 
-#[lang = "drop_in_place"]
+#[cfg_attr(not(bootstrap), lang = "drop_glue")]
+#[cfg_attr(bootstrap, lang = "drop_in_place")]
 #[inline]
-#[allow(unconditional_recursion)]
-pub unsafe fn drop_in_place<T: PointeeSized>(to_drop: *mut T) {
-    drop_in_place(to_drop);
-}
+pub unsafe fn drop_glue<T: PointeeSized>(_to_drop: &mut T) {}
 
 #[cfg(all(target_os = "windows", target_arch = "x86", target_env = "gnu"))]
 pub mod eh_frames {

--- a/src/tools/miri/tests/fail-dep/concurrency/libc_pthread_mutex_free_while_queued.stderr
+++ b/src/tools/miri/tests/fail-dep/concurrency/libc_pthread_mutex_free_while_queued.stderr
@@ -10,7 +10,7 @@ LL |                 self.1.deallocate(From::from(ptr.cast()), layout);
    = note: stack backtrace:
            0: <std::boxed::Box<Mutex> as std::ops::Drop>::drop
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           1: std::ptr::drop_in_place))
+           1: std::ptr::drop_glue))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
            2: std::mem::drop
                at RUSTLIB/core/src/mem/mod.rs:LL:CC

--- a/src/tools/miri/tests/fail/alloc/stack_free.stderr
+++ b/src/tools/miri/tests/fail/alloc/stack_free.stderr
@@ -9,7 +9,7 @@ LL |                 self.1.deallocate(From::from(ptr.cast()), layout);
    = note: stack backtrace:
            0: <std::boxed::Box<i32> as std::ops::Drop>::drop
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           1: std::ptr::drop_in_place))
+           1: std::ptr::drop_glue))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
            2: std::mem::drop
                at RUSTLIB/core/src/mem/mod.rs:LL:CC

--- a/src/tools/miri/tests/fail/both_borrows/drop_in_place_protector.stack.stderr
+++ b/src/tools/miri/tests/fail/both_borrows/drop_in_place_protector.stack.stderr
@@ -19,11 +19,13 @@ LL |         core::ptr::drop_in_place(x);
    = note: stack backtrace:
            0: <HasDrop as std::ops::Drop>::drop
                at tests/fail/both_borrows/drop_in_place_protector.rs:LL:CC
-           1: std::ptr::drop_in_place - shim(Some(HasDrop))
+           1: std::ptr::drop_glue - shim(Some(HasDrop))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-           2: std::ptr::drop_in_place - shim(Some((HasDrop, u8)))
+           2: std::ptr::drop_glue - shim(Some((HasDrop, u8)))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-           3: main
+           3: std::ptr::drop_in_place
+               at RUSTLIB/core/src/ptr/mod.rs:LL:CC
+           4: main
                at tests/fail/both_borrows/drop_in_place_protector.rs:LL:CC
    = note: this error originates in the macro `core::ptr::addr_of_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/tools/miri/tests/fail/both_borrows/drop_in_place_protector.tree.stderr
+++ b/src/tools/miri/tests/fail/both_borrows/drop_in_place_protector.tree.stderr
@@ -22,11 +22,13 @@ LL |         core::ptr::drop_in_place(x);
    = note: stack backtrace:
            0: <HasDrop as std::ops::Drop>::drop
                at tests/fail/both_borrows/drop_in_place_protector.rs:LL:CC
-           1: std::ptr::drop_in_place - shim(Some(HasDrop))
+           1: std::ptr::drop_glue - shim(Some(HasDrop))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-           2: std::ptr::drop_in_place - shim(Some((HasDrop, u8)))
+           2: std::ptr::drop_glue - shim(Some((HasDrop, u8)))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-           3: main
+           3: std::ptr::drop_in_place
+               at RUSTLIB/core/src/ptr/mod.rs:LL:CC
+           4: main
                at tests/fail/both_borrows/drop_in_place_protector.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/src/tools/miri/tests/fail/both_borrows/newtype_pair_retagging.tree.stderr
+++ b/src/tools/miri/tests/fail/both_borrows/newtype_pair_retagging.tree.stderr
@@ -28,7 +28,7 @@ LL |             || drop(Box::from_raw(ptr)),
    = note: stack backtrace:
            0: <std::boxed::Box<i32> as std::ops::Drop>::drop
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           1: std::ptr::drop_in_place))
+           1: std::ptr::drop_glue))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
            2: std::mem::drop
                at RUSTLIB/core/src/mem/mod.rs:LL:CC

--- a/src/tools/miri/tests/fail/both_borrows/newtype_retagging.tree.stderr
+++ b/src/tools/miri/tests/fail/both_borrows/newtype_retagging.tree.stderr
@@ -28,7 +28,7 @@ LL |             || drop(Box::from_raw(ptr)),
    = note: stack backtrace:
            0: <std::boxed::Box<i32> as std::ops::Drop>::drop
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           1: std::ptr::drop_in_place))
+           1: std::ptr::drop_glue))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
            2: std::mem::drop
                at RUSTLIB/core/src/mem/mod.rs:LL:CC

--- a/src/tools/miri/tests/fail/stacked_borrows/deallocate_against_protector1.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/deallocate_against_protector1.stderr
@@ -9,7 +9,7 @@ LL |                 self.1.deallocate(From::from(ptr.cast()), layout);
    = note: stack backtrace:
            0: <std::boxed::Box<i32> as std::ops::Drop>::drop
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           1: std::ptr::drop_in_place))
+           1: std::ptr::drop_glue))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
            2: std::mem::drop
                at RUSTLIB/core/src/mem/mod.rs:LL:CC

--- a/src/tools/miri/tests/fail/stacked_borrows/drop_in_place_retag.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/drop_in_place_retag.stderr
@@ -1,10 +1,8 @@
 error: Undefined Behavior: trying to retag from <TAG> for Unique permission at ALLOC[0x0], but that tag only grants SharedReadOnly permission for this location
   --> RUSTLIB/core/src/ptr/mod.rs:LL:CC
    |
-LL | / pub const unsafe fn drop_in_place<T: PointeeSized>(to_drop: *mut T)
-LL | | where
-LL | |     T: [const] Destruct,
-   | |________________________^ this error occurs as part of function-entry retag at ALLOC[0x0..0x1]
+LL |     unsafe { drop_glue(&mut *to_drop) }
+   |                        ^^^^^^^^^^^^^ this error occurs as part of retag at ALLOC[0x0..0x1]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
@@ -14,7 +12,7 @@ help: <TAG> was created by a SharedReadOnly retag at offsets [0x0..0x1]
 LL |         let x = core::ptr::addr_of!(x);
    |                 ^^^^^^^^^^^^^^^^^^^^^^
    = note: stack backtrace:
-           0: std::ptr::drop_in_place - shim(None)
+           0: std::ptr::drop_in_place
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
            1: main
                at tests/fail/stacked_borrows/drop_in_place_retag.rs:LL:CC

--- a/src/tools/miri/tests/fail/tree_borrows/strongly-protected.stderr
+++ b/src/tools/miri/tests/fail/tree_borrows/strongly-protected.stderr
@@ -21,7 +21,7 @@ LL | fn inner(x: &mut i32, f: fn(*mut i32)) {
    = note: stack backtrace:
            0: <std::boxed::Box<i32> as std::ops::Drop>::drop
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           1: std::ptr::drop_in_place))
+           1: std::ptr::drop_glue))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
            2: std::mem::drop
                at RUSTLIB/core/src/mem/mod.rs:LL:CC

--- a/src/tools/miri/tests/fail/tree_borrows/wildcard/strongly_protected_wildcard.stderr
+++ b/src/tools/miri/tests/fail/tree_borrows/wildcard/strongly_protected_wildcard.stderr
@@ -21,7 +21,7 @@ LL | fn inner(x: &mut i32, f: fn(usize)) {
    = note: stack backtrace:
            0: <std::boxed::Box<i32> as std::ops::Drop>::drop
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           1: std::ptr::drop_in_place))
+           1: std::ptr::drop_glue))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
            2: std::mem::drop
                at RUSTLIB/core/src/mem/mod.rs:LL:CC

--- a/src/tools/miri/tests/fail/unaligned_pointers/drop_in_place.stderr
+++ b/src/tools/miri/tests/fail/unaligned_pointers/drop_in_place.stderr
@@ -1,15 +1,13 @@
 error: Undefined Behavior: constructing invalid value of type &mut PartialDrop: encountered an unaligned reference (required ALIGN byte alignment but found ALIGN)
   --> RUSTLIB/core/src/ptr/mod.rs:LL:CC
    |
-LL | / pub const unsafe fn drop_in_place<T: PointeeSized>(to_drop: *mut T)
-LL | | where
-LL | |     T: [const] Destruct,
-   | |________________________^ Undefined Behavior occurred here
+LL |     unsafe { drop_glue(&mut *to_drop) }
+   |                        ^^^^^^^^^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: stack backtrace:
-           0: std::ptr::drop_in_place - shim(Some(PartialDrop))
+           0: std::ptr::drop_in_place
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
            1: main
                at tests/fail/unaligned_pointers/drop_in_place.rs:LL:CC

--- a/src/tools/miri/tests/pass/alloc-access-tracking.stderr
+++ b/src/tools/miri/tests/pass/alloc-access-tracking.stderr
@@ -25,7 +25,7 @@ LL |                 self.1.deallocate(From::from(ptr.cast()), layout);
    = note: stack backtrace:
            0: <std::boxed::Box<std::mem::MaybeUninit<[u8; 123]>> as std::ops::Drop>::drop
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           1: std::ptr::drop_in_place))
+           1: std::ptr::drop_glue))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
            2: main
                at tests/pass/alloc-access-tracking.rs:LL:CC

--- a/src/tools/miri/tests/pass/async-drop.rs
+++ b/src/tools/miri/tests/pass/async-drop.rs
@@ -19,7 +19,7 @@ use core::task::{Context, Poll, Waker};
 
 async fn test_async_drop<T>(x: T) {
     let mut x = mem::MaybeUninit::new(x);
-    let dtor = pin!(unsafe { async_drop_in_place(x.as_mut_ptr()) });
+    let dtor = pin!(unsafe { async_drop_in_place(&mut *x.as_mut_ptr()) });
     test_idempotency(dtor).await;
 }
 
@@ -70,7 +70,7 @@ fn main() {
             .await;
 
         let mut ptr19 = mem::MaybeUninit::new(AsyncInt(19));
-        let async_drop_fut = pin!(unsafe { async_drop_in_place(ptr19.as_mut_ptr()) });
+        let async_drop_fut = pin!(unsafe { async_drop_in_place(&mut *ptr19.as_mut_ptr()) });
         test_idempotency(async_drop_fut).await;
 
         let foo = AsyncInt(20);

--- a/tests/assembly-llvm/large_data_threshold.rs
+++ b/tests/assembly-llvm/large_data_threshold.rs
@@ -20,8 +20,8 @@ pub trait MetaSized: PointeeSized {}
 #[lang = "sized"]
 pub trait Sized: MetaSized {}
 
-#[lang = "drop_in_place"]
-fn drop_in_place<T>(_: *mut T) {}
+#[lang = "drop_glue"]
+fn drop_glue<T>(_: &mut T) {}
 
 #[used]
 #[no_mangle]

--- a/tests/assembly-llvm/small_data_threshold.rs
+++ b/tests/assembly-llvm/small_data_threshold.rs
@@ -28,8 +28,8 @@ pub trait MetaSized: PointeeSized {}
 #[lang = "sized"]
 pub trait Sized: MetaSized {}
 
-#[lang = "drop_in_place"]
-fn drop_in_place<T>(_: *mut T) {}
+#[lang = "drop_glue"]
+fn drop_glue<T>(_: &mut T) {}
 
 #[used]
 #[no_mangle]

--- a/tests/auxiliary/minicore.rs
+++ b/tests/auxiliary/minicore.rs
@@ -300,8 +300,8 @@ impl Sync for () {}
 
 impl<T, const N: usize> Sync for [T; N] {}
 
-#[lang = "drop_in_place"]
-fn drop_in_place<T>(_: *mut T) {}
+#[lang = "drop_glue"]
+fn drop_glue<T>(_: &mut T) {}
 
 #[lang = "fn_once"]
 pub trait FnOnce<Args: Tuple> {

--- a/tests/codegen-llvm/drop.rs
+++ b/tests/codegen-llvm/drop.rs
@@ -21,10 +21,10 @@ pub fn droppy() {
     // the regular function exit. We used to have problems with quadratic growths of drop calls in
     // such functions.
     // FIXME(eddyb) the `void @` forces a match on the instruction, instead of the
-    // comment, that's `; call core::ptr::drop_in_place::<drop::SomeUniqueName>`
+    // comment, that's `; call core::ptr::drop_glue::<drop::SomeUniqueName>`
     // for the `v0` mangling, should switch to matching on that once `legacy` is gone.
-    // CHECK-COUNT-6: {{(call|invoke) void @.*}}drop_in_place{{.*}}SomeUniqueName
-    // CHECK-NOT: {{(call|invoke) void @.*}}drop_in_place{{.*}}SomeUniqueName
+    // CHECK-COUNT-6: {{(call|invoke) void @.*}}drop_glue{{.*}}SomeUniqueName
+    // CHECK-NOT: {{(call|invoke) void @.*}}drop_glue{{.*}}SomeUniqueName
     // The next line checks for the } that ends the function definition
     // CHECK-LABEL: {{^[}]}}
     let _s = SomeUniqueName;

--- a/tests/codegen-llvm/inline-hint.rs
+++ b/tests/codegen-llvm/inline-hint.rs
@@ -16,7 +16,7 @@ pub fn f() {
 
 struct A(String, String);
 
-// CHECK:      ; core::ptr::drop_in_place::<inline_hint::A>
+// CHECK:      ; core::ptr::drop_glue::<inline_hint::A>
 // CHECK-NEXT: ; Function Attrs:
 // CHECK-NOT:  inlinehint
 // CHECK-SAME: {{$}}

--- a/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-drop-in-place.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-drop-in-place.rs
@@ -9,18 +9,18 @@
 
 #![crate_type = "lib"]
 
-// CHECK-LABEL: define{{.*}}4core3ptr13drop_in_placeDNtNtB4_6marker4Send
+// CHECK-LABEL: define{{.*}}4core3ptr9drop_glueDNtNtB4_6marker4Send
 // CHECK-SAME:  {{.*}}!type ![[TYPE1:[0-9]+]] !type !{{[0-9]+}} !type !{{[0-9]+}} !type !{{[0-9]+}}
-// CHECK:       call i1 @llvm.type.test(ptr {{%.+}}, metadata !"_ZTSFvPu3dynIu{{[0-9]+}}NtNtNtC{{[[:print:]]+}}_4core3ops4drop4Dropu6regionEE")
+// CHECK:       call i1 @llvm.type.test(ptr {{%.+}}, metadata !"_ZTSFvU3mutu3refIu3dynIu{{[0-9]+}}NtNtNtC{{[[:print:]]+}}_4core3ops4drop4Dropu6regionEEE")
 
 struct EmptyDrop;
-// CHECK-NOT: define{{.*}}4core3ptr{{[0-9]+}}drop_in_place$LT${{.*}}EmptyDrop$GT${{.*}}!type ![[TYPE1]] !type !{{[0-9]+}} !type !{{[0-9]+}} !type !{{[0-9]+}}
+// CHECK-NOT: define{{.*}}4core3ptr{{[0-9]+}}drop_glue$LT${{.*}}EmptyDrop$GT${{.*}}!type ![[TYPE1]] !type !{{[0-9]+}} !type !{{[0-9]+}} !type !{{[0-9]+}}
 
 struct PresentDrop;
 
 impl Drop for PresentDrop {
     fn drop(&mut self) {}
-    // CHECK: define{{.*}}4core3ptr{{[0-9]+}}drop_in_place{{.*}}PresentDrop{{.*}}!type ![[TYPE1]] !type !{{[0-9]+}} !type !{{[0-9]+}} !type !{{[0-9]+}}
+    // CHECK: define{{.*}}4core3ptr{{[0-9]+}}drop_glue{{.*}}PresentDrop{{.*}}!type ![[TYPE1]] !type !{{[0-9]+}} !type !{{[0-9]+}} !type !{{[0-9]+}}
 }
 
 pub fn foo() {
@@ -28,4 +28,4 @@ pub fn foo() {
     let _ = Box::new(PresentDrop) as Box<dyn Send>;
 }
 
-// CHECK: ![[TYPE1]] = !{i64 0, !"_ZTSFvPu3dynIu{{[0-9]+}}NtNtNtC{{[[:print:]]+}}_4core3ops4drop4Dropu6regionEE"}
+// CHECK: ![[TYPE1]] = !{i64 0, !"_ZTSFvU3mutu3refIu3dynIu{{[0-9]+}}NtNtNtC{{[[:print:]]+}}_4core3ops4drop4Dropu6regionEEE"}

--- a/tests/codegen-llvm/unwind-landingpad-cold.rs
+++ b/tests/codegen-llvm/unwind-landingpad-cold.rs
@@ -6,7 +6,7 @@
 // get the `cold` attribute.
 
 // CHECK-LABEL: @check_cold
-// CHECK: {{(call|invoke) void .+}}drop_in_place{{.+}} [[ATTRIBUTES:#[0-9]+]]
+// CHECK: {{(call|invoke) void .+}}drop_glue{{.+}} [[ATTRIBUTES:#[0-9]+]]
 // CHECK: attributes [[ATTRIBUTES]] = { cold }
 #[no_mangle]
 pub fn check_cold(f: fn(), x: Box<u32>) {

--- a/tests/codegen-llvm/vec-into-iter-drops.rs
+++ b/tests/codegen-llvm/vec-into-iter-drops.rs
@@ -22,6 +22,7 @@ impl Drop for Bomb {
 pub fn vec_for_each_doesnt_drop(v: vec::Vec<(usize, Option<Bomb>)>) -> usize {
     // CHECK-NOT: panic
     // CHECK-NOT: drop_in_place
+    // CHECK-NOT: drop_glue
     // CHECK-NOT: Bomb$u20$as$u20$core..ops..drop..Drop
     let mut last = 0;
     v.into_iter().for_each(|(x, bomb)| {
@@ -41,7 +42,7 @@ pub fn vec_for_each_doesnt_drop(v: vec::Vec<(usize, Option<Bomb>)>) -> usize {
 // CHECK-LABEL: @vec_for_loop
 #[no_mangle]
 pub fn vec_for_loop(v: vec::Vec<(usize, Option<Bomb>)>) -> usize {
-    // CHECK: drop_in_place
+    // CHECK: drop_glue
     let mut last = 0;
     for (x, bomb) in v {
         last = x;

--- a/tests/codegen-units/item-collection/drop-glue-eager.rs
+++ b/tests/codegen-units/item-collection/drop-glue-eager.rs
@@ -3,7 +3,7 @@
 //@ compile-flags:-Clink-dead-code
 //@ compile-flags:--crate-type=lib
 
-//~ MONO_ITEM fn std::ptr::drop_in_place::<StructWithDrop> - shim(Some(StructWithDrop))
+//~ MONO_ITEM fn std::ptr::drop_glue::<StructWithDrop> - shim(Some(StructWithDrop))
 struct StructWithDrop {
     x: i32,
 }
@@ -17,7 +17,7 @@ struct StructNoDrop {
     x: i32,
 }
 
-//~ MONO_ITEM fn std::ptr::drop_in_place::<EnumWithDrop> - shim(Some(EnumWithDrop))
+//~ MONO_ITEM fn std::ptr::drop_glue::<EnumWithDrop> - shim(Some(EnumWithDrop))
 enum EnumWithDrop {
     A(i32),
 }
@@ -37,14 +37,14 @@ impl<'a> Drop for StructWithDropAndLt<'a> {
     fn drop(&mut self) {}
 }
 
-//~ MONO_ITEM fn std::ptr::drop_in_place::<StructWithDropAndLt<'_>> - shim(Some(StructWithDropAndLt<'_>))
+//~ MONO_ITEM fn std::ptr::drop_glue::<StructWithDropAndLt<'_>> - shim(Some(StructWithDropAndLt<'_>))
 struct StructWithDropAndLt<'a> {
     x: &'a i32,
 }
 
 // Make sure we don't ICE when checking impossible predicates for the struct.
 // Regression test for <https://github.com/rust-lang/rust/issues/135515>.
-//~ MONO_ITEM fn std::ptr::drop_in_place::<StructWithLtAndPredicate<'_>> - shim(Some(StructWithLtAndPredicate<'_>))
+//~ MONO_ITEM fn std::ptr::drop_glue::<StructWithLtAndPredicate<'_>> - shim(Some(StructWithLtAndPredicate<'_>))
 struct StructWithLtAndPredicate<'a: 'a> {
     x: &'a i32,
 }

--- a/tests/codegen-units/item-collection/drop-glue-noop.rs
+++ b/tests/codegen-units/item-collection/drop-glue-noop.rs
@@ -1,3 +1,5 @@
+// Check that we don't monomorphize `drop_glue::<T>` where `T` doesn't neeed drop
+//
 //@ compile-flags:-Clink-dead-code -Zmir-opt-level=0
 
 #![deny(dead_code)]
@@ -8,6 +10,7 @@
 pub fn start(_: isize, _: *const *const u8) -> isize {
     // No item produced for this, it's a no-op drop and so is removed.
     unsafe {
+        //~ MONO_ITEM fn std::ptr::drop_in_place::<u32> @@ drop_glue_noop-cgu.0[External]
         std::ptr::drop_in_place::<u32>(&mut 0);
     }
 
@@ -16,7 +19,7 @@ pub fn start(_: isize, _: *const *const u8) -> isize {
     // instantiation-through-vtable.rs) because we special case null pointer for drop glue since
     // #122662.
     //
-    //~ MONO_ITEM fn std::ptr::drop_in_place::<u64> - shim(None) @@ drop_glue_noop-cgu.0[External]
+    //~ MONO_ITEM fn std::ptr::drop_in_place::<u64> @@ drop_glue_noop-cgu.0[External]
     std::ptr::drop_in_place::<u64> as unsafe fn(*mut u64);
 
     0

--- a/tests/codegen-units/item-collection/drop_in_place_intrinsic.rs
+++ b/tests/codegen-units/item-collection/drop_in_place_intrinsic.rs
@@ -4,18 +4,17 @@
 
 #![crate_type = "lib"]
 
-//~ MONO_ITEM fn std::ptr::drop_in_place::<StructWithDtor> - shim(Some(StructWithDtor)) @@ drop_in_place_intrinsic-cgu.0[Internal]
+//~ MONO_ITEM fn std::ptr::drop_glue::<StructWithDtor> - shim(Some(StructWithDtor)) @@ drop_in_place_intrinsic-cgu.0[Internal]
 struct StructWithDtor(u32);
 
 impl Drop for StructWithDtor {
     //~ MONO_ITEM fn <StructWithDtor as std::ops::Drop>::drop
     fn drop(&mut self) {}
 }
-
 //~ MONO_ITEM fn start
 #[no_mangle]
 pub fn start(_: isize, _: *const *const u8) -> isize {
-    //~ MONO_ITEM fn std::ptr::drop_in_place::<[StructWithDtor; 2]> - shim(Some([StructWithDtor; 2])) @@ drop_in_place_intrinsic-cgu.0[Internal]
+    //~ MONO_ITEM fn std::ptr::drop_glue::<[StructWithDtor; 2]> - shim(Some([StructWithDtor; 2])) @@ drop_in_place_intrinsic-cgu.0[Internal]
     let x = [StructWithDtor(0), StructWithDtor(1)];
 
     drop_slice_in_place(&x);
@@ -28,8 +27,10 @@ fn drop_slice_in_place(x: &[StructWithDtor]) {
     unsafe {
         // This is the interesting thing in this test case: Normally we would
         // not have drop-glue for the unsized [StructWithDtor]. This has to be
-        // generated though when the drop_in_place() intrinsic is used.
-        //~ MONO_ITEM fn std::ptr::drop_in_place::<[StructWithDtor]> - shim(Some([StructWithDtor])) @@ drop_in_place_intrinsic-cgu.0[Internal]
+        // generated though when the drop_in_place() function is used.
+        //
+        //~ MONO_ITEM fn std::ptr::drop_glue::<[StructWithDtor]> - shim(Some([StructWithDtor])) @@ drop_in_place_intrinsic-cgu.0[Internal]
+        //~ MONO_ITEM fn std::ptr::drop_in_place::<[StructWithDtor]> @@ drop_in_place_intrinsic-cgu.0[External]
         ::std::ptr::drop_in_place(x as *const _ as *mut [StructWithDtor]);
     }
 }

--- a/tests/codegen-units/item-collection/generic-drop-glue.rs
+++ b/tests/codegen-units/item-collection/generic-drop-glue.rs
@@ -35,7 +35,7 @@ enum EnumNoDrop<T1, T2> {
 struct NonGenericNoDrop(#[allow(dead_code)] i32);
 
 struct NonGenericWithDrop(#[allow(dead_code)] i32);
-//~ MONO_ITEM fn std::ptr::drop_in_place::<NonGenericWithDrop> - shim(Some(NonGenericWithDrop)) @@ generic_drop_glue-cgu.0[Internal]
+//~ MONO_ITEM fn std::ptr::drop_glue::<NonGenericWithDrop> - shim(Some(NonGenericWithDrop)) @@ generic_drop_glue-cgu.0[Internal]
 
 impl Drop for NonGenericWithDrop {
     //~ MONO_ITEM fn <NonGenericWithDrop as std::ops::Drop>::drop
@@ -45,11 +45,11 @@ impl Drop for NonGenericWithDrop {
 //~ MONO_ITEM fn start
 #[no_mangle]
 pub fn start(_: isize, _: *const *const u8) -> isize {
-    //~ MONO_ITEM fn std::ptr::drop_in_place::<StructWithDrop<i8, char>> - shim(Some(StructWithDrop<i8, char>)) @@ generic_drop_glue-cgu.0[Internal]
+    //~ MONO_ITEM fn std::ptr::drop_glue::<StructWithDrop<i8, char>> - shim(Some(StructWithDrop<i8, char>)) @@ generic_drop_glue-cgu.0[Internal]
     //~ MONO_ITEM fn <StructWithDrop<i8, char> as std::ops::Drop>::drop
     let _ = StructWithDrop { x: 0i8, y: 'a' }.x;
 
-    //~ MONO_ITEM fn std::ptr::drop_in_place::<StructWithDrop<&str, NonGenericNoDrop>> - shim(Some(StructWithDrop<&str, NonGenericNoDrop>)) @@ generic_drop_glue-cgu.0[Internal]
+    //~ MONO_ITEM fn std::ptr::drop_glue::<StructWithDrop<&str, NonGenericNoDrop>> - shim(Some(StructWithDrop<&str, NonGenericNoDrop>)) @@ generic_drop_glue-cgu.0[Internal]
     //~ MONO_ITEM fn <StructWithDrop<&str, NonGenericNoDrop> as std::ops::Drop>::drop
     let _ = StructWithDrop { x: "&str", y: NonGenericNoDrop(0) }.y;
 
@@ -58,17 +58,17 @@ pub fn start(_: isize, _: *const *const u8) -> isize {
 
     // This is supposed to generate drop-glue because it contains a field that
     // needs to be dropped.
-    //~ MONO_ITEM fn std::ptr::drop_in_place::<StructNoDrop<NonGenericWithDrop, f64>> - shim(Some(StructNoDrop<NonGenericWithDrop, f64>)) @@ generic_drop_glue-cgu.0[Internal]
+    //~ MONO_ITEM fn std::ptr::drop_glue::<StructNoDrop<NonGenericWithDrop, f64>> - shim(Some(StructNoDrop<NonGenericWithDrop, f64>)) @@ generic_drop_glue-cgu.0[Internal]
     let _ = StructNoDrop { x: NonGenericWithDrop(0), y: 0f64 }.y;
 
-    //~ MONO_ITEM fn std::ptr::drop_in_place::<EnumWithDrop<i32, i64>> - shim(Some(EnumWithDrop<i32, i64>)) @@ generic_drop_glue-cgu.0[Internal]
+    //~ MONO_ITEM fn std::ptr::drop_glue::<EnumWithDrop<i32, i64>> - shim(Some(EnumWithDrop<i32, i64>)) @@ generic_drop_glue-cgu.0[Internal]
     //~ MONO_ITEM fn <EnumWithDrop<i32, i64> as std::ops::Drop>::drop
     let _ = match EnumWithDrop::A::<i32, i64>(0) {
         EnumWithDrop::A(x) => x,
         EnumWithDrop::B(x) => x as i32,
     };
 
-    //~ MONO_ITEM fn std::ptr::drop_in_place::<EnumWithDrop<f64, f32>> - shim(Some(EnumWithDrop<f64, f32>)) @@ generic_drop_glue-cgu.0[Internal]
+    //~ MONO_ITEM fn std::ptr::drop_glue::<EnumWithDrop<f64, f32>> - shim(Some(EnumWithDrop<f64, f32>)) @@ generic_drop_glue-cgu.0[Internal]
     //~ MONO_ITEM fn <EnumWithDrop<f64, f32> as std::ops::Drop>::drop
     let _ = match EnumWithDrop::B::<f64, f32>(1.0) {
         EnumWithDrop::A(x) => x,

--- a/tests/codegen-units/item-collection/non-generic-closures.rs
+++ b/tests/codegen-units/item-collection/non-generic-closures.rs
@@ -43,8 +43,8 @@ fn assigned_to_variable_executed_directly() {
 //~ MONO_ITEM fn with_drop @@ non_generic_closures-cgu.0[External]
 fn with_drop(v: PresentDrop) {
     //~ MONO_ITEM fn with_drop::{closure#0} @@ non_generic_closures-cgu.0[External]
-    //~ MONO_ITEM fn std::ptr::drop_in_place::<PresentDrop> - shim(Some(PresentDrop)) @@ non_generic_closures-cgu.0[Internal]
-    //~ MONO_ITEM fn std::ptr::drop_in_place::<{closure@TEST_PATH:49:14: 49:24}> - shim(Some({closure@TEST_PATH:49:14: 49:24})) @@ non_generic_closures-cgu.0[Internal]
+    //~ MONO_ITEM fn std::ptr::drop_glue::<PresentDrop> - shim(Some(PresentDrop)) @@ non_generic_closures-cgu.0[Internal]
+    //~ MONO_ITEM fn std::ptr::drop_glue::<{closure@TEST_PATH:49:14: 49:24}> - shim(Some({closure@TEST_PATH:49:14: 49:24})) @@ non_generic_closures-cgu.0[Internal]
 
     let _f = |a: usize| {
         let _ = a + 2;

--- a/tests/codegen-units/item-collection/non-generic-drop-glue.rs
+++ b/tests/codegen-units/item-collection/non-generic-drop-glue.rs
@@ -4,7 +4,7 @@
 #![deny(dead_code)]
 #![crate_type = "lib"]
 
-//~ MONO_ITEM fn std::ptr::drop_in_place::<StructWithDrop> - shim(Some(StructWithDrop)) @@ non_generic_drop_glue-cgu.0[Internal]
+//~ MONO_ITEM fn std::ptr::drop_glue::<StructWithDrop> - shim(Some(StructWithDrop)) @@ non_generic_drop_glue-cgu.0[Internal]
 struct StructWithDrop {
     x: i32,
 }
@@ -18,7 +18,7 @@ struct StructNoDrop {
     x: i32,
 }
 
-//~ MONO_ITEM fn std::ptr::drop_in_place::<EnumWithDrop> - shim(Some(EnumWithDrop)) @@ non_generic_drop_glue-cgu.0[Internal]
+//~ MONO_ITEM fn std::ptr::drop_glue::<EnumWithDrop> - shim(Some(EnumWithDrop)) @@ non_generic_drop_glue-cgu.0[Internal]
 enum EnumWithDrop {
     A(i32),
 }

--- a/tests/codegen-units/item-collection/transitive-drop-glue.rs
+++ b/tests/codegen-units/item-collection/transitive-drop-glue.rs
@@ -4,11 +4,11 @@
 #![deny(dead_code)]
 #![crate_type = "lib"]
 
-//~ MONO_ITEM fn std::ptr::drop_in_place::<Root> - shim(Some(Root)) @@ transitive_drop_glue-cgu.0[Internal]
+//~ MONO_ITEM fn std::ptr::drop_glue::<Root> - shim(Some(Root)) @@ transitive_drop_glue-cgu.0[Internal]
 struct Root(#[allow(dead_code)] Intermediate);
-//~ MONO_ITEM fn std::ptr::drop_in_place::<Intermediate> - shim(Some(Intermediate)) @@ transitive_drop_glue-cgu.0[Internal]
+//~ MONO_ITEM fn std::ptr::drop_glue::<Intermediate> - shim(Some(Intermediate)) @@ transitive_drop_glue-cgu.0[Internal]
 struct Intermediate(#[allow(dead_code)] Leaf);
-//~ MONO_ITEM fn std::ptr::drop_in_place::<Leaf> - shim(Some(Leaf)) @@ transitive_drop_glue-cgu.0[Internal]
+//~ MONO_ITEM fn std::ptr::drop_glue::<Leaf> - shim(Some(Leaf)) @@ transitive_drop_glue-cgu.0[Internal]
 struct Leaf;
 
 impl Drop for Leaf {
@@ -29,15 +29,15 @@ impl<T> Drop for LeafGen<T> {
 pub fn start(_: isize, _: *const *const u8) -> isize {
     let _ = Root(Intermediate(Leaf));
 
-    //~ MONO_ITEM fn std::ptr::drop_in_place::<RootGen<u32>> - shim(Some(RootGen<u32>)) @@ transitive_drop_glue-cgu.0[Internal]
-    //~ MONO_ITEM fn std::ptr::drop_in_place::<IntermediateGen<u32>> - shim(Some(IntermediateGen<u32>)) @@ transitive_drop_glue-cgu.0[Internal]
-    //~ MONO_ITEM fn std::ptr::drop_in_place::<LeafGen<u32>> - shim(Some(LeafGen<u32>)) @@ transitive_drop_glue-cgu.0[Internal]
+    //~ MONO_ITEM fn std::ptr::drop_glue::<RootGen<u32>> - shim(Some(RootGen<u32>)) @@ transitive_drop_glue-cgu.0[Internal]
+    //~ MONO_ITEM fn std::ptr::drop_glue::<IntermediateGen<u32>> - shim(Some(IntermediateGen<u32>)) @@ transitive_drop_glue-cgu.0[Internal]
+    //~ MONO_ITEM fn std::ptr::drop_glue::<LeafGen<u32>> - shim(Some(LeafGen<u32>)) @@ transitive_drop_glue-cgu.0[Internal]
     //~ MONO_ITEM fn <LeafGen<u32> as std::ops::Drop>::drop
     let _ = RootGen(IntermediateGen(LeafGen(0u32)));
 
-    //~ MONO_ITEM fn std::ptr::drop_in_place::<RootGen<i16>> - shim(Some(RootGen<i16>)) @@ transitive_drop_glue-cgu.0[Internal]
-    //~ MONO_ITEM fn std::ptr::drop_in_place::<IntermediateGen<i16>> - shim(Some(IntermediateGen<i16>)) @@ transitive_drop_glue-cgu.0[Internal]
-    //~ MONO_ITEM fn std::ptr::drop_in_place::<LeafGen<i16>> - shim(Some(LeafGen<i16>)) @@ transitive_drop_glue-cgu.0[Internal]
+    //~ MONO_ITEM fn std::ptr::drop_glue::<RootGen<i16>> - shim(Some(RootGen<i16>)) @@ transitive_drop_glue-cgu.0[Internal]
+    //~ MONO_ITEM fn std::ptr::drop_glue::<IntermediateGen<i16>> - shim(Some(IntermediateGen<i16>)) @@ transitive_drop_glue-cgu.0[Internal]
+    //~ MONO_ITEM fn std::ptr::drop_glue::<LeafGen<i16>> - shim(Some(LeafGen<i16>)) @@ transitive_drop_glue-cgu.0[Internal]
     //~ MONO_ITEM fn <LeafGen<i16> as std::ops::Drop>::drop
     let _ = RootGen(IntermediateGen(LeafGen(0i16)));
 

--- a/tests/codegen-units/item-collection/tuple-drop-glue.rs
+++ b/tests/codegen-units/item-collection/tuple-drop-glue.rs
@@ -4,7 +4,7 @@
 #![deny(dead_code)]
 #![crate_type = "lib"]
 
-//~ MONO_ITEM fn std::ptr::drop_in_place::<Dropped> - shim(Some(Dropped)) @@ tuple_drop_glue-cgu.0[Internal]
+//~ MONO_ITEM fn std::ptr::drop_glue::<Dropped> - shim(Some(Dropped)) @@ tuple_drop_glue-cgu.0[Internal]
 struct Dropped;
 
 impl Drop for Dropped {
@@ -15,11 +15,11 @@ impl Drop for Dropped {
 //~ MONO_ITEM fn start
 #[no_mangle]
 pub fn start(_: isize, _: *const *const u8) -> isize {
-    //~ MONO_ITEM fn std::ptr::drop_in_place::<(u32, Dropped)> - shim(Some((u32, Dropped))) @@ tuple_drop_glue-cgu.0[Internal]
+    //~ MONO_ITEM fn std::ptr::drop_glue::<(u32, Dropped)> - shim(Some((u32, Dropped))) @@ tuple_drop_glue-cgu.0[Internal]
     let x = (0u32, Dropped);
 
-    //~ MONO_ITEM fn std::ptr::drop_in_place::<(i16, (Dropped, bool))> - shim(Some((i16, (Dropped, bool)))) @@ tuple_drop_glue-cgu.0[Internal]
-    //~ MONO_ITEM fn std::ptr::drop_in_place::<(Dropped, bool)> - shim(Some((Dropped, bool)))  @@ tuple_drop_glue-cgu.0[Internal]
+    //~ MONO_ITEM fn std::ptr::drop_glue::<(i16, (Dropped, bool))> - shim(Some((i16, (Dropped, bool)))) @@ tuple_drop_glue-cgu.0[Internal]
+    //~ MONO_ITEM fn std::ptr::drop_glue::<(Dropped, bool)> - shim(Some((Dropped, bool)))  @@ tuple_drop_glue-cgu.0[Internal]
     let x = (0i16, (Dropped, true));
 
     0

--- a/tests/codegen-units/item-collection/unsizing.rs
+++ b/tests/codegen-units/item-collection/unsizing.rs
@@ -79,7 +79,7 @@ pub fn start(_: isize, _: *const *const u8) -> isize {
     // with drop
     let droppable = &PresentDrop;
     //~ MONO_ITEM fn <PresentDrop as std::ops::Drop>::drop @@ unsizing-cgu.0[Internal]
-    //~ MONO_ITEM fn std::ptr::drop_in_place::<PresentDrop> - shim(Some(PresentDrop)) @@ unsizing-cgu.0[Internal]
+    //~ MONO_ITEM fn std::ptr::drop_glue::<PresentDrop> - shim(Some(PresentDrop)) @@ unsizing-cgu.0[Internal]
     //~ MONO_ITEM fn <PresentDrop as Trait>::foo
     let droppable = droppable as &dyn Trait;
 

--- a/tests/codegen-units/partitioning/extern-drop-glue.rs
+++ b/tests/codegen-units/partitioning/extern-drop-glue.rs
@@ -9,13 +9,13 @@ extern crate cgu_extern_drop_glue;
 // This test checks that drop glue is generated, even for types not defined in this crate, and all
 // drop glue is put in the fallback CGU.
 
-//~ MONO_ITEM fn std::ptr::drop_in_place::<cgu_extern_drop_glue::Struct> - shim(Some(cgu_extern_drop_glue::Struct)) @@ extern_drop_glue-fallback.cgu[External]
+//~ MONO_ITEM fn std::ptr::drop_glue::<cgu_extern_drop_glue::Struct> - shim(Some(cgu_extern_drop_glue::Struct)) @@ extern_drop_glue-fallback.cgu[External]
 
 struct LocalStruct(cgu_extern_drop_glue::Struct);
 
 //~ MONO_ITEM fn user @@ extern_drop_glue[External]
 pub fn user() {
-    //~ MONO_ITEM fn std::ptr::drop_in_place::<LocalStruct> - shim(Some(LocalStruct)) @@ extern_drop_glue-fallback.cgu[External]
+    //~ MONO_ITEM fn std::ptr::drop_glue::<LocalStruct> - shim(Some(LocalStruct)) @@ extern_drop_glue-fallback.cgu[External]
     let _ = LocalStruct(cgu_extern_drop_glue::Struct(0));
 }
 
@@ -26,7 +26,7 @@ pub mod mod1 {
 
     //~ MONO_ITEM fn mod1::user @@ extern_drop_glue-mod1[External]
     pub fn user() {
-        //~ MONO_ITEM fn std::ptr::drop_in_place::<mod1::LocalStruct> - shim(Some(mod1::LocalStruct)) @@ extern_drop_glue-fallback.cgu[External]
+        //~ MONO_ITEM fn std::ptr::drop_glue::<mod1::LocalStruct> - shim(Some(mod1::LocalStruct)) @@ extern_drop_glue-fallback.cgu[External]
         let _ = LocalStruct(cgu_extern_drop_glue::Struct(0));
     }
 }

--- a/tests/codegen-units/partitioning/local-drop-glue.rs
+++ b/tests/codegen-units/partitioning/local-drop-glue.rs
@@ -7,7 +7,7 @@
 // glue is put in the fallback CGU.
 // This is rather similar to extern-drop-glue.rs.
 
-//~ MONO_ITEM fn std::ptr::drop_in_place::<Struct> - shim(Some(Struct)) @@ local_drop_glue-fallback.cgu[External]
+//~ MONO_ITEM fn std::ptr::drop_glue::<Struct> - shim(Some(Struct)) @@ local_drop_glue-fallback.cgu[External]
 pub struct Struct {
     _a: u32,
 }
@@ -17,7 +17,7 @@ impl Drop for Struct {
     fn drop(&mut self) {}
 }
 
-//~ MONO_ITEM fn std::ptr::drop_in_place::<Outer> - shim(Some(Outer)) @@ local_drop_glue-fallback.cgu[External]
+//~ MONO_ITEM fn std::ptr::drop_glue::<Outer> - shim(Some(Outer)) @@ local_drop_glue-fallback.cgu[External]
 pub struct Outer {
     _a: Struct,
 }
@@ -30,10 +30,10 @@ pub fn user() {
 pub mod mod1 {
     use super::Struct;
 
-    //~ MONO_ITEM fn std::ptr::drop_in_place::<mod1::Struct2> - shim(Some(mod1::Struct2)) @@ local_drop_glue-fallback.cgu[External]
+    //~ MONO_ITEM fn std::ptr::drop_glue::<mod1::Struct2> - shim(Some(mod1::Struct2)) @@ local_drop_glue-fallback.cgu[External]
     struct Struct2 {
         _a: Struct,
-        //~ MONO_ITEM fn std::ptr::drop_in_place::<(u32, Struct)> - shim(Some((u32, Struct))) @@ local_drop_glue-fallback.cgu[External]
+        //~ MONO_ITEM fn std::ptr::drop_glue::<(u32, Struct)> - shim(Some((u32, Struct))) @@ local_drop_glue-fallback.cgu[External]
         _b: (u32, Struct),
     }
 

--- a/tests/codegen-units/partitioning/vtable-through-const.rs
+++ b/tests/codegen-units/partitioning/vtable-through-const.rs
@@ -74,7 +74,7 @@ mod mod1 {
 //~ MONO_ITEM fn main @@ vtable_through_const[External]
 pub fn main() {
     //~ MONO_ITEM fn <mod1::NeedsDrop as std::ops::Drop>::drop @@ vtable_through_const-fallback.cgu[External]
-    //~ MONO_ITEM fn std::ptr::drop_in_place::<mod1::NeedsDrop> - shim(Some(mod1::NeedsDrop)) @@ vtable_through_const-fallback.cgu[External]
+    //~ MONO_ITEM fn std::ptr::drop_glue::<mod1::NeedsDrop> - shim(Some(mod1::NeedsDrop)) @@ vtable_through_const-fallback.cgu[External]
 
     // Since Trait1::do_something() is instantiated via its default implementation,
     // it is considered a generic and is instantiated here only because it is

--- a/tests/mir-opt/async_drop_live_dead.a-{closure#0}.coroutine_drop_async.0.panic-abort.mir
+++ b/tests/mir-opt/async_drop_live_dead.a-{closure#0}.coroutine_drop_async.0.panic-abort.mir
@@ -2,34 +2,33 @@
 
 fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>) -> Poll<()> {
     debug _task_context => _2;
-    debug x => ((*_20).0: T);
+    debug x => ((*_19).0: T);
     let mut _0: std::task::Poll<()>;
     let _3: T;
     let mut _4: impl std::future::Future<Output = ()>;
     let mut _5: &mut T;
     let mut _6: std::pin::Pin<&mut T>;
     let mut _7: &mut T;
-    let mut _8: *mut T;
-    let mut _9: std::task::Poll<()>;
-    let mut _10: &mut std::task::Context<'_>;
-    let mut _11: &mut impl std::future::Future<Output = ()>;
-    let mut _12: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
-    let mut _13: isize;
-    let mut _14: &mut std::task::Context<'_>;
-    let mut _15: &mut impl std::future::Future<Output = ()>;
-    let mut _16: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
-    let mut _17: isize;
-    let mut _18: ();
-    let mut _19: u32;
-    let mut _20: &mut {async fn body of a<T>()};
+    let mut _8: std::task::Poll<()>;
+    let mut _9: &mut std::task::Context<'_>;
+    let mut _10: &mut impl std::future::Future<Output = ()>;
+    let mut _11: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
+    let mut _12: isize;
+    let mut _13: &mut std::task::Context<'_>;
+    let mut _14: &mut impl std::future::Future<Output = ()>;
+    let mut _15: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
+    let mut _16: isize;
+    let mut _17: ();
+    let mut _18: u32;
+    let mut _19: &mut {async fn body of a<T>()};
     scope 1 {
-        debug x => (((*_20) as variant#4).0: T);
+        debug x => (((*_19) as variant#4).0: T);
     }
 
     bb0: {
-        _20 = copy (_1.0: &mut {async fn body of a<T>()});
-        _19 = discriminant((*_20));
-        switchInt(move _19) -> [0: bb9, 3: bb12, 4: bb13, otherwise: bb14];
+        _19 = copy (_1.0: &mut {async fn body of a<T>()});
+        _18 = discriminant((*_19));
+        switchInt(move _18) -> [0: bb9, 3: bb12, 4: bb13, otherwise: bb14];
     }
 
     bb1: {
@@ -45,14 +44,14 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
 
     bb3: {
         _0 = Poll::<()>::Pending;
-        discriminant((*_20)) = 4;
+        discriminant((*_19)) = 4;
         return;
     }
 
     bb4: {
-        StorageLive(_16);
-        _15 = &mut (((*_20) as variant#4).1: impl std::future::Future<Output = ()>);
-        _16 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _15) -> [return: bb7, unwind unreachable];
+        StorageLive(_15);
+        _14 = &mut (((*_19) as variant#4).1: impl std::future::Future<Output = ()>);
+        _15 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _14) -> [return: bb7, unwind unreachable];
     }
 
     bb5: {
@@ -60,13 +59,13 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
     }
 
     bb6: {
-        StorageDead(_16);
-        _17 = discriminant(_9);
-        switchInt(move _17) -> [0: bb1, 1: bb3, otherwise: bb5];
+        StorageDead(_15);
+        _16 = discriminant(_8);
+        switchInt(move _16) -> [0: bb1, 1: bb3, otherwise: bb5];
     }
 
     bb7: {
-        _9 = <impl Future<Output = ()> as Future>::poll(move _16, move _14) -> [return: bb6, unwind unreachable];
+        _8 = <impl Future<Output = ()> as Future>::poll(move _15, move _13) -> [return: bb6, unwind unreachable];
     }
 
     bb8: {
@@ -83,7 +82,7 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
     }
 
     bb11: {
-        drop(((*_20).0: T)) -> [return: bb10, unwind unreachable];
+        drop(((*_19).0: T)) -> [return: bb10, unwind unreachable];
     }
 
     bb12: {

--- a/tests/mir-opt/async_drop_live_dead.a-{closure#0}.coroutine_drop_async.0.panic-unwind.mir
+++ b/tests/mir-opt/async_drop_live_dead.a-{closure#0}.coroutine_drop_async.0.panic-unwind.mir
@@ -2,34 +2,33 @@
 
 fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>) -> Poll<()> {
     debug _task_context => _2;
-    debug x => ((*_20).0: T);
+    debug x => ((*_19).0: T);
     let mut _0: std::task::Poll<()>;
     let _3: T;
     let mut _4: impl std::future::Future<Output = ()>;
     let mut _5: &mut T;
     let mut _6: std::pin::Pin<&mut T>;
     let mut _7: &mut T;
-    let mut _8: *mut T;
-    let mut _9: std::task::Poll<()>;
-    let mut _10: &mut std::task::Context<'_>;
-    let mut _11: &mut impl std::future::Future<Output = ()>;
-    let mut _12: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
-    let mut _13: isize;
-    let mut _14: &mut std::task::Context<'_>;
-    let mut _15: &mut impl std::future::Future<Output = ()>;
-    let mut _16: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
-    let mut _17: isize;
-    let mut _18: ();
-    let mut _19: u32;
-    let mut _20: &mut {async fn body of a<T>()};
+    let mut _8: std::task::Poll<()>;
+    let mut _9: &mut std::task::Context<'_>;
+    let mut _10: &mut impl std::future::Future<Output = ()>;
+    let mut _11: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
+    let mut _12: isize;
+    let mut _13: &mut std::task::Context<'_>;
+    let mut _14: &mut impl std::future::Future<Output = ()>;
+    let mut _15: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
+    let mut _16: isize;
+    let mut _17: ();
+    let mut _18: u32;
+    let mut _19: &mut {async fn body of a<T>()};
     scope 1 {
-        debug x => (((*_20) as variant#4).0: T);
+        debug x => (((*_19) as variant#4).0: T);
     }
 
     bb0: {
-        _20 = copy (_1.0: &mut {async fn body of a<T>()});
-        _19 = discriminant((*_20));
-        switchInt(move _19) -> [0: bb12, 2: bb18, 3: bb16, 4: bb17, otherwise: bb19];
+        _19 = copy (_1.0: &mut {async fn body of a<T>()});
+        _18 = discriminant((*_19));
+        switchInt(move _18) -> [0: bb12, 2: bb18, 3: bb16, 4: bb17, otherwise: bb19];
     }
 
     bb1: {
@@ -59,14 +58,14 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
 
     bb6: {
         _0 = Poll::<()>::Pending;
-        discriminant((*_20)) = 4;
+        discriminant((*_19)) = 4;
         return;
     }
 
     bb7: {
-        StorageLive(_16);
-        _15 = &mut (((*_20) as variant#4).1: impl std::future::Future<Output = ()>);
-        _16 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _15) -> [return: bb10, unwind: bb15];
+        StorageLive(_15);
+        _14 = &mut (((*_19) as variant#4).1: impl std::future::Future<Output = ()>);
+        _15 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _14) -> [return: bb10, unwind: bb15];
     }
 
     bb8: {
@@ -74,13 +73,13 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
     }
 
     bb9: {
-        StorageDead(_16);
-        _17 = discriminant(_9);
-        switchInt(move _17) -> [0: bb1, 1: bb6, otherwise: bb8];
+        StorageDead(_15);
+        _16 = discriminant(_8);
+        switchInt(move _16) -> [0: bb1, 1: bb6, otherwise: bb8];
     }
 
     bb10: {
-        _9 = <impl Future<Output = ()> as Future>::poll(move _16, move _14) -> [return: bb9, unwind: bb3];
+        _8 = <impl Future<Output = ()> as Future>::poll(move _15, move _13) -> [return: bb9, unwind: bb3];
     }
 
     bb11: {
@@ -97,11 +96,11 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
     }
 
     bb14: {
-        drop(((*_20).0: T)) -> [return: bb13, unwind: bb4];
+        drop(((*_19).0: T)) -> [return: bb13, unwind: bb4];
     }
 
     bb15 (cleanup): {
-        discriminant((*_20)) = 2;
+        discriminant((*_19)) = 2;
         resume;
     }
 

--- a/tests/mir-opt/async_drop_mir_pin.core.future-async_drop-async_drop_in_place-{closure#0}.[Foo;1].MentionedItems.after.mir
+++ b/tests/mir-opt/async_drop_mir_pin.core.future-async_drop-async_drop_in_place-{closure#0}.[Foo;1].MentionedItems.after.mir
@@ -4,7 +4,7 @@ fn async_drop_in_place::{closure#0}(_1: {async fn body of async_drop_in_place<[F
 yields ()
  {
     let mut _0: ();
-    let mut _3: *mut [Foo; 1];
+    let mut _3: &mut [Foo; 1];
     let mut _4: *mut [Foo; 1];
     let mut _5: *mut [Foo];
     let mut _6: usize;
@@ -18,16 +18,14 @@ yields ()
     let mut _14: std::pin::Pin<&mut Foo>;
     let mut _15: &mut Foo;
     let mut _16: *mut Foo;
-    let mut _17: *mut Foo;
-    let mut _18: bool;
-    let mut _19: impl std::future::Future<Output = ()>;
-    let mut _20: &mut Foo;
-    let mut _21: std::pin::Pin<&mut Foo>;
-    let mut _22: &mut Foo;
-    let mut _23: *mut Foo;
+    let mut _17: bool;
+    let mut _18: impl std::future::Future<Output = ()>;
+    let mut _19: &mut Foo;
+    let mut _20: std::pin::Pin<&mut Foo>;
+    let mut _21: &mut Foo;
 
     bb0: {
-        _3 = move (_1.0: *mut [Foo; 1]);
+        _3 = move (_1.0: &mut [Foo; 1]);
         goto -> bb17;
     }
 
@@ -47,7 +45,7 @@ yields ()
 
     bb4 (cleanup): {
         StorageDead(_12);
-        StorageDead(_19);
+        StorageDead(_18);
         _9 = Eq(copy _7, copy _6);
         switchInt(move _9) -> [0: bb3, otherwise: bb2];
     }
@@ -60,7 +58,7 @@ yields ()
     }
 
     bb6: {
-        StorageDead(_19);
+        StorageDead(_18);
         _11 = Eq(copy _7, copy _6);
         switchInt(move _11) -> [0: bb5, otherwise: bb1];
     }
@@ -76,37 +74,35 @@ yields ()
 
     bb9: {
         _15 = copy (_14.0: &mut Foo);
-        _16 = &raw mut (*_15);
         StorageLive(_12);
-        _12 = async_drop_in_place::<Foo>(move _16) -> [return: bb8, unwind: bb4];
+        _12 = async_drop_in_place::<Foo>(move _15) -> [return: bb8, unwind: bb4];
     }
 
     bb10: {
-        _17 = &raw mut (*_5)[_7];
+        _16 = &raw mut (*_5)[_7];
         _7 = Add(move _7, const 1_usize);
-        _20 = &mut (*_17);
-        _21 = Pin::<&mut Foo>::new_unchecked(move _20) -> [return: bb14, unwind: bb4];
+        _19 = &mut (*_16);
+        _20 = Pin::<&mut Foo>::new_unchecked(move _19) -> [return: bb14, unwind: bb4];
     }
 
     bb11: {
-        _18 = Eq(copy _7, copy _6);
-        switchInt(move _18) -> [0: bb10, otherwise: bb1];
+        _17 = Eq(copy _7, copy _6);
+        switchInt(move _17) -> [0: bb10, otherwise: bb1];
     }
 
     bb12: {
-        StorageDead(_19);
+        StorageDead(_18);
         goto -> bb11;
     }
 
     bb13: {
-        async drop((*_17); poll=_19) -> [return: bb12, unwind: bb4, drop: bb6];
+        async drop((*_16); poll=_18) -> [return: bb12, unwind: bb4, drop: bb6];
     }
 
     bb14: {
-        _22 = copy (_21.0: &mut Foo);
-        _23 = &raw mut (*_22);
-        StorageLive(_19);
-        _19 = async_drop_in_place::<Foo>(move _23) -> [return: bb13, unwind: bb4];
+        _21 = copy (_20.0: &mut Foo);
+        StorageLive(_18);
+        _18 = async_drop_in_place::<Foo>(move _21) -> [return: bb13, unwind: bb4];
     }
 
     bb15: {

--- a/tests/mir-opt/coroutine_drop_cleanup.main-{closure#0}.coroutine_drop.0.panic-abort.mir
+++ b/tests/mir-opt/coroutine_drop_cleanup.main-{closure#0}.coroutine_drop.0.panic-abort.mir
@@ -1,6 +1,6 @@
 // MIR for `main::{closure#0}` 0 coroutine_drop
 
-fn main::{closure#0}(_1: *mut {coroutine@$DIR/coroutine_drop_cleanup.rs:12:5: 12:7}) -> () {
+fn main::{closure#0}(_1: &mut {coroutine@$DIR/coroutine_drop_cleanup.rs:12:5: 12:7}) -> () {
     let mut _0: ();
     let mut _2: ();
     let _3: std::string::String;

--- a/tests/mir-opt/coroutine_drop_cleanup.main-{closure#0}.coroutine_drop.0.panic-unwind.mir
+++ b/tests/mir-opt/coroutine_drop_cleanup.main-{closure#0}.coroutine_drop.0.panic-unwind.mir
@@ -1,6 +1,6 @@
 // MIR for `main::{closure#0}` 0 coroutine_drop
 
-fn main::{closure#0}(_1: *mut {coroutine@$DIR/coroutine_drop_cleanup.rs:12:5: 12:7}) -> () {
+fn main::{closure#0}(_1: &mut {coroutine@$DIR/coroutine_drop_cleanup.rs:12:5: 12:7}) -> () {
     let mut _0: ();
     let mut _2: ();
     let _3: std::string::String;

--- a/tests/mir-opt/inline/inline_empty_drop_glue.slice_in_place.Inline.diff
+++ b/tests/mir-opt/inline/inline_empty_drop_glue.slice_in_place.Inline.diff
@@ -5,7 +5,10 @@
       debug ptr => _1;
       let mut _0: ();
       let mut _2: *mut [char];
-+     scope 1 (inlined drop_in_place::<[char]> - shim(None)) {
++     scope 1 (inlined drop_in_place::<[char]>) {
++         let mut _3: &mut [char];
++         scope 2 (inlined std::ptr::drop_glue::<[char]> - shim(None)) {
++         }
 +     }
   
       bb0: {
@@ -15,6 +18,9 @@
 -     }
 - 
 -     bb1: {
++         StorageLive(_3);
++         _3 = &mut (*_2);
++         StorageDead(_3);
           StorageDead(_2);
           return;
       }

--- a/tests/mir-opt/inline/inline_shims.drop.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/inline_shims.drop.Inline.panic-abort.diff
@@ -8,46 +8,55 @@
       let _3: ();
       let mut _4: *mut std::vec::Vec<A>;
       let mut _5: *mut std::option::Option<B>;
-+     scope 1 (inlined drop_in_place::<Vec<A>> - shim(Some(Vec<A>))) {
++     scope 1 (inlined drop_in_place::<Vec<A>>) {
 +         let mut _6: &mut std::vec::Vec<A>;
-+         let mut _7: ();
-+         scope 2 (inlined <Vec<A> as Drop>::drop) {
-+             let mut _8: *mut [A];
-+             let mut _9: *mut A;
-+             let mut _10: usize;
-+             scope 3 (inlined Vec::<A>::as_mut_ptr) {
-+                 scope 4 (inlined alloc::raw_vec::RawVec::<A>::ptr) {
-+                     scope 5 (inlined alloc::raw_vec::RawVecInner::ptr::<A>) {
-+                         scope 6 (inlined alloc::raw_vec::RawVecInner::non_null::<A>) {
-+                             let mut _11: std::ptr::NonNull<u8>;
-+                             scope 7 (inlined std::ptr::Unique::<u8>::cast::<A>) {
-+                                 scope 8 (inlined NonNull::<u8>::cast::<A>) {
-+                                     scope 9 (inlined NonNull::<u8>::as_ptr) {
++         scope 2 (inlined std::ptr::drop_glue::<Vec<A>> - shim(Some(Vec<A>))) {
++             let mut _7: &mut std::vec::Vec<A>;
++             let mut _8: ();
++             scope 3 (inlined <Vec<A> as Drop>::drop) {
++                 let mut _9: *mut [A];
++                 let mut _10: *mut A;
++                 let mut _11: usize;
++                 scope 4 (inlined Vec::<A>::as_mut_ptr) {
++                     scope 5 (inlined alloc::raw_vec::RawVec::<A>::ptr) {
++                         scope 6 (inlined alloc::raw_vec::RawVecInner::ptr::<A>) {
++                             scope 7 (inlined alloc::raw_vec::RawVecInner::non_null::<A>) {
++                                 let mut _12: std::ptr::NonNull<u8>;
++                                 scope 8 (inlined std::ptr::Unique::<u8>::cast::<A>) {
++                                     scope 9 (inlined NonNull::<u8>::cast::<A>) {
++                                         scope 10 (inlined NonNull::<u8>::as_ptr) {
++                                         }
 +                                     }
 +                                 }
++                                 scope 11 (inlined std::ptr::Unique::<A>::as_non_null_ptr) {
++                                 }
 +                             }
-+                             scope 10 (inlined std::ptr::Unique::<A>::as_non_null_ptr) {
++                             scope 12 (inlined NonNull::<A>::as_ptr) {
 +                             }
-+                         }
-+                         scope 11 (inlined NonNull::<A>::as_ptr) {
 +                         }
 +                     }
 +                 }
-+             }
-+             scope 12 (inlined slice_from_raw_parts_mut::<A>) {
-+                 scope 13 (inlined std::ptr::from_raw_parts_mut::<[A], A>) {
++                 scope 13 (inlined slice_from_raw_parts_mut::<A>) {
++                     scope 14 (inlined std::ptr::from_raw_parts_mut::<[A], A>) {
++                     }
 +                 }
-+             }
-+             scope 14 (inlined drop_in_place::<[A]> - shim(Some([A]))) {
-+                 let mut _12: usize;
-+                 let mut _13: *mut A;
-+                 let mut _14: bool;
++                 scope 15 (inlined drop_in_place::<[A]>) {
++                     let mut _13: &mut [A];
++                     scope 16 (inlined std::ptr::drop_glue::<[A]> - shim(Some([A]))) {
++                         let mut _14: usize;
++                         let mut _15: *mut A;
++                         let mut _16: bool;
++                     }
++                 }
 +             }
 +         }
 +     }
-+     scope 15 (inlined drop_in_place::<Option<B>> - shim(Some(Option<B>))) {
-+         let mut _15: isize;
-+         let mut _16: isize;
++     scope 17 (inlined drop_in_place::<Option<B>>) {
++         let mut _17: &mut std::option::Option<B>;
++         scope 18 (inlined std::ptr::drop_glue::<Option<B>> - shim(Some(Option<B>))) {
++             let mut _18: isize;
++             let mut _19: isize;
++         }
 +     }
   
       bb0: {
@@ -56,26 +65,31 @@
           _4 = copy _1;
 -         _3 = drop_in_place::<Vec<A>>(move _4) -> [return: bb1, unwind unreachable];
 +         StorageLive(_6);
-+         StorageLive(_7);
 +         _6 = &mut (*_4);
-+         StorageLive(_10);
++         StorageLive(_7);
 +         StorageLive(_8);
-+         StorageLive(_9);
++         _7 = copy _6;
 +         StorageLive(_11);
-+         _11 = copy (((((*_6).0: alloc::raw_vec::RawVec<A>).0: alloc::raw_vec::RawVecInner).0: std::ptr::Unique<u8>).0: std::ptr::NonNull<u8>);
-+         _9 = copy _11 as *mut A (Transmute);
-+         StorageDead(_11);
-+         _10 = copy ((*_6).1: usize);
-+         _8 = *mut [A] from (copy _9, copy _10);
-+         StorageDead(_9);
++         StorageLive(_9);
++         StorageLive(_10);
 +         StorageLive(_12);
++         _12 = copy (((((*_7).0: alloc::raw_vec::RawVec<A>).0: alloc::raw_vec::RawVecInner).0: std::ptr::Unique<u8>).0: std::ptr::NonNull<u8>);
++         _10 = copy _12 as *mut A (Transmute);
++         StorageDead(_12);
++         _11 = copy ((*_7).1: usize);
++         _9 = *mut [A] from (copy _10, copy _11);
++         StorageDead(_10);
 +         StorageLive(_13);
++         _13 = &mut (*_9);
 +         StorageLive(_14);
-+         _12 = const 0_usize;
++         StorageLive(_15);
++         StorageLive(_16);
++         _14 = const 0_usize;
 +         goto -> bb4;
       }
   
       bb1: {
++         StorageDead(_8);
 +         StorageDead(_7);
 +         StorageDead(_6);
           StorageDead(_4);
@@ -83,39 +97,43 @@
           StorageLive(_5);
           _5 = copy _2;
 -         _0 = drop_in_place::<Option<B>>(move _5) -> [return: bb2, unwind unreachable];
-+         StorageLive(_15);
-+         _15 = discriminant((*_5));
-+         switchInt(move _15) -> [0: bb5, otherwise: bb6];
++         StorageLive(_17);
++         _17 = &mut (*_5);
++         StorageLive(_18);
++         _18 = discriminant((*_17));
++         switchInt(move _18) -> [0: bb5, otherwise: bb6];
       }
   
       bb2: {
++         StorageDead(_16);
++         StorageDead(_15);
 +         StorageDead(_14);
 +         StorageDead(_13);
-+         StorageDead(_12);
-+         StorageDead(_8);
-+         StorageDead(_10);
-+         drop(((*_4).0: alloc::raw_vec::RawVec<A>)) -> [return: bb1, unwind unreachable];
++         StorageDead(_9);
++         StorageDead(_11);
++         drop(((*_6).0: alloc::raw_vec::RawVec<A>)) -> [return: bb1, unwind unreachable];
 +     }
 + 
 +     bb3: {
-+         _13 = &raw mut (*_8)[_12];
-+         _12 = Add(move _12, const 1_usize);
-+         drop((*_13)) -> [return: bb4, unwind unreachable];
++         _15 = &raw mut (*_13)[_14];
++         _14 = Add(move _14, const 1_usize);
++         drop((*_15)) -> [return: bb4, unwind unreachable];
 +     }
 + 
 +     bb4: {
-+         _14 = Eq(copy _12, copy _10);
-+         switchInt(move _14) -> [0: bb3, otherwise: bb2];
++         _16 = Eq(copy _14, copy _11);
++         switchInt(move _16) -> [0: bb3, otherwise: bb2];
 +     }
 + 
 +     bb5: {
-+         StorageDead(_15);
++         StorageDead(_18);
++         StorageDead(_17);
           StorageDead(_5);
           return;
 +     }
 + 
 +     bb6: {
-+         drop((((*_5) as Some).0: B)) -> [return: bb5, unwind unreachable];
++         drop((((*_17) as Some).0: B)) -> [return: bb5, unwind unreachable];
       }
   }
   

--- a/tests/mir-opt/inline/inline_shims.drop.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_shims.drop.Inline.panic-unwind.diff
@@ -8,37 +8,50 @@
       let _3: ();
       let mut _4: *mut std::vec::Vec<A>;
       let mut _5: *mut std::option::Option<B>;
-+     scope 1 (inlined drop_in_place::<Option<B>> - shim(Some(Option<B>))) {
-+         let mut _6: isize;
-+         let mut _7: isize;
++     scope 1 (inlined drop_in_place::<Vec<A>>) {
++         let mut _6: &mut std::vec::Vec<A>;
++     }
++     scope 2 (inlined drop_in_place::<Option<B>>) {
++         let mut _7: &mut std::option::Option<B>;
++         scope 3 (inlined std::ptr::drop_glue::<Option<B>> - shim(Some(Option<B>))) {
++             let mut _8: isize;
++             let mut _9: isize;
++         }
 +     }
   
       bb0: {
           StorageLive(_3);
           StorageLive(_4);
           _4 = copy _1;
-          _3 = drop_in_place::<Vec<A>>(move _4) -> [return: bb1, unwind continue];
+-         _3 = drop_in_place::<Vec<A>>(move _4) -> [return: bb1, unwind continue];
++         StorageLive(_6);
++         _6 = &mut (*_4);
++         _3 = std::ptr::drop_glue::<Vec<A>>(move _6) -> [return: bb1, unwind continue];
       }
   
       bb1: {
++         StorageDead(_6);
           StorageDead(_4);
           StorageDead(_3);
           StorageLive(_5);
           _5 = copy _2;
 -         _0 = drop_in_place::<Option<B>>(move _5) -> [return: bb2, unwind continue];
-+         StorageLive(_6);
-+         _6 = discriminant((*_5));
-+         switchInt(move _6) -> [0: bb2, otherwise: bb3];
++         StorageLive(_7);
++         _7 = &mut (*_5);
++         StorageLive(_8);
++         _8 = discriminant((*_7));
++         switchInt(move _8) -> [0: bb2, otherwise: bb3];
       }
   
       bb2: {
-+         StorageDead(_6);
++         StorageDead(_8);
++         StorageDead(_7);
           StorageDead(_5);
           return;
 +     }
 + 
 +     bb3: {
-+         drop((((*_5) as Some).0: B)) -> [return: bb2, unwind continue];
++         drop((((*_7) as Some).0: B)) -> [return: bb2, unwind continue];
       }
   }
   

--- a/tests/mir-opt/inline/inline_shims.rs
+++ b/tests/mir-opt/inline/inline_shims.rs
@@ -11,7 +11,8 @@ pub fn clone<A, B>(f: fn(A, B)) -> fn(A, B) {
 // EMIT_MIR inline_shims.drop.Inline.diff
 pub fn drop<A, B>(a: *mut Vec<A>, b: *mut Option<B>) {
     // CHECK-LABEL: fn drop(
-    // CHECK: (inlined drop_in_place::<Option<B>> - shim(Some(Option<B>)))
+    // CHECK: (inlined drop_in_place::<Option<B>>)
+    // CHECK: (inlined std::ptr::drop_glue::<Option<B>> - shim(Some(Option<B>)))
     unsafe { std::ptr::drop_in_place(a) }
     unsafe { std::ptr::drop_in_place(b) }
 }

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.PreCodegen.after.panic-abort.mir
@@ -3,61 +3,63 @@
 fn drop_bytes(_1: *mut Box<[u8; 1024]>) -> () {
     debug x => _1;
     let mut _0: ();
-    scope 1 (inlined drop_in_place::<Box<[u8; 1024]>> - shim(Some(Box<[u8; 1024]>))) {
-        scope 2 (inlined <Box<[u8; 1024]> as Drop>::drop) {
-            let _2: std::ptr::NonNull<[u8; 1024]>;
-            let _4: ();
-            scope 3 {
+    scope 1 (inlined drop_in_place::<Box<[u8; 1024]>>) {
+        scope 2 (inlined std::ptr::drop_glue::<Box<[u8; 1024]>> - shim(Some(Box<[u8; 1024]>))) {
+            scope 3 (inlined <Box<[u8; 1024]> as Drop>::drop) {
+                let _2: std::ptr::NonNull<[u8; 1024]>;
+                let _4: ();
                 scope 4 {
-                    scope 17 (inlined Layout::size) {
-                    }
-                    scope 18 (inlined std::ptr::Unique::<[u8; 1024]>::cast::<u8>) {
-                        let mut _3: std::ptr::NonNull<u8>;
-                        scope 19 (inlined NonNull::<[u8; 1024]>::cast::<u8>) {
-                            scope 20 (inlined NonNull::<[u8; 1024]>::as_ptr) {
-                            }
+                    scope 5 {
+                        scope 18 (inlined Layout::size) {
                         }
-                    }
-                    scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                        scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
-                        }
-                    }
-                    scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                        scope 24 (inlined std::alloc::Global::deallocate_impl) {
-                            scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                scope 26 (inlined Layout::size) {
-                                }
-                                scope 27 (inlined alloc::alloc::dealloc_nonnull) {
-                                    scope 28 (inlined Layout::size) {
-                                    }
-                                    scope 29 (inlined Layout::alignment) {
-                                    }
+                        scope 19 (inlined std::ptr::Unique::<[u8; 1024]>::cast::<u8>) {
+                            let mut _3: std::ptr::NonNull<u8>;
+                            scope 20 (inlined NonNull::<[u8; 1024]>::cast::<u8>) {
+                                scope 21 (inlined NonNull::<[u8; 1024]>::as_ptr) {
                                 }
                             }
                         }
-                    }
-                }
-                scope 5 (inlined std::ptr::Unique::<[u8; 1024]>::as_ptr) {
-                    scope 6 (inlined NonNull::<[u8; 1024]>::as_ptr) {
-                    }
-                }
-                scope 7 (inlined Layout::for_value_raw::<[u8; 1024]>) {
-                    scope 8 {
-                        scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
+                        scope 22 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                            scope 23 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                            }
                         }
-                    }
-                    scope 9 (inlined size_of_val_raw::<[u8; 1024]>) {
-                    }
-                    scope 10 (inlined std::mem::Alignment::of_val_raw::<[u8; 1024]>) {
-                        scope 11 {
-                            scope 13 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
-                                scope 14 (inlined core::ub_checks::check_language_ub) {
-                                    scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
+                        scope 24 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                            scope 25 (inlined std::alloc::Global::deallocate_impl) {
+                                scope 26 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                                    scope 27 (inlined Layout::size) {
+                                    }
+                                    scope 28 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 29 (inlined Layout::size) {
+                                        }
+                                        scope 30 (inlined Layout::alignment) {
+                                        }
                                     }
                                 }
                             }
                         }
-                        scope 12 (inlined align_of_val_raw::<[u8; 1024]>) {
+                    }
+                    scope 6 (inlined std::ptr::Unique::<[u8; 1024]>::as_ptr) {
+                        scope 7 (inlined NonNull::<[u8; 1024]>::as_ptr) {
+                        }
+                    }
+                    scope 8 (inlined Layout::for_value_raw::<[u8; 1024]>) {
+                        scope 9 {
+                            scope 17 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
+                            }
+                        }
+                        scope 10 (inlined size_of_val_raw::<[u8; 1024]>) {
+                        }
+                        scope 11 (inlined std::mem::Alignment::of_val_raw::<[u8; 1024]>) {
+                            scope 12 {
+                                scope 14 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
+                                    scope 15 (inlined core::ub_checks::check_language_ub) {
+                                        scope 16 (inlined core::ub_checks::check_language_ub::runtime) {
+                                        }
+                                    }
+                                }
+                            }
+                            scope 13 (inlined align_of_val_raw::<[u8; 1024]>) {
+                            }
                         }
                     }
                 }

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.PreCodegen.after.panic-unwind.mir
@@ -3,61 +3,63 @@
 fn drop_bytes(_1: *mut Box<[u8; 1024]>) -> () {
     debug x => _1;
     let mut _0: ();
-    scope 1 (inlined drop_in_place::<Box<[u8; 1024]>> - shim(Some(Box<[u8; 1024]>))) {
-        scope 2 (inlined <Box<[u8; 1024]> as Drop>::drop) {
-            let _2: std::ptr::NonNull<[u8; 1024]>;
-            let _4: ();
-            scope 3 {
+    scope 1 (inlined drop_in_place::<Box<[u8; 1024]>>) {
+        scope 2 (inlined std::ptr::drop_glue::<Box<[u8; 1024]>> - shim(Some(Box<[u8; 1024]>))) {
+            scope 3 (inlined <Box<[u8; 1024]> as Drop>::drop) {
+                let _2: std::ptr::NonNull<[u8; 1024]>;
+                let _4: ();
                 scope 4 {
-                    scope 17 (inlined Layout::size) {
-                    }
-                    scope 18 (inlined std::ptr::Unique::<[u8; 1024]>::cast::<u8>) {
-                        let mut _3: std::ptr::NonNull<u8>;
-                        scope 19 (inlined NonNull::<[u8; 1024]>::cast::<u8>) {
-                            scope 20 (inlined NonNull::<[u8; 1024]>::as_ptr) {
-                            }
+                    scope 5 {
+                        scope 18 (inlined Layout::size) {
                         }
-                    }
-                    scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                        scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
-                        }
-                    }
-                    scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                        scope 24 (inlined std::alloc::Global::deallocate_impl) {
-                            scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                scope 26 (inlined Layout::size) {
-                                }
-                                scope 27 (inlined alloc::alloc::dealloc_nonnull) {
-                                    scope 28 (inlined Layout::size) {
-                                    }
-                                    scope 29 (inlined Layout::alignment) {
-                                    }
+                        scope 19 (inlined std::ptr::Unique::<[u8; 1024]>::cast::<u8>) {
+                            let mut _3: std::ptr::NonNull<u8>;
+                            scope 20 (inlined NonNull::<[u8; 1024]>::cast::<u8>) {
+                                scope 21 (inlined NonNull::<[u8; 1024]>::as_ptr) {
                                 }
                             }
                         }
-                    }
-                }
-                scope 5 (inlined std::ptr::Unique::<[u8; 1024]>::as_ptr) {
-                    scope 6 (inlined NonNull::<[u8; 1024]>::as_ptr) {
-                    }
-                }
-                scope 7 (inlined Layout::for_value_raw::<[u8; 1024]>) {
-                    scope 8 {
-                        scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
+                        scope 22 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                            scope 23 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                            }
                         }
-                    }
-                    scope 9 (inlined size_of_val_raw::<[u8; 1024]>) {
-                    }
-                    scope 10 (inlined std::mem::Alignment::of_val_raw::<[u8; 1024]>) {
-                        scope 11 {
-                            scope 13 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
-                                scope 14 (inlined core::ub_checks::check_language_ub) {
-                                    scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
+                        scope 24 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                            scope 25 (inlined std::alloc::Global::deallocate_impl) {
+                                scope 26 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                                    scope 27 (inlined Layout::size) {
+                                    }
+                                    scope 28 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 29 (inlined Layout::size) {
+                                        }
+                                        scope 30 (inlined Layout::alignment) {
+                                        }
                                     }
                                 }
                             }
                         }
-                        scope 12 (inlined align_of_val_raw::<[u8; 1024]>) {
+                    }
+                    scope 6 (inlined std::ptr::Unique::<[u8; 1024]>::as_ptr) {
+                        scope 7 (inlined NonNull::<[u8; 1024]>::as_ptr) {
+                        }
+                    }
+                    scope 8 (inlined Layout::for_value_raw::<[u8; 1024]>) {
+                        scope 9 {
+                            scope 17 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
+                            }
+                        }
+                        scope 10 (inlined size_of_val_raw::<[u8; 1024]>) {
+                        }
+                        scope 11 (inlined std::mem::Alignment::of_val_raw::<[u8; 1024]>) {
+                            scope 12 {
+                                scope 14 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
+                                    scope 15 (inlined core::ub_checks::check_language_ub) {
+                                        scope 16 (inlined core::ub_checks::check_language_ub::runtime) {
+                                        }
+                                    }
+                                }
+                            }
+                            scope 13 (inlined align_of_val_raw::<[u8; 1024]>) {
+                            }
                         }
                     }
                 }

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-abort.mir
@@ -3,62 +3,64 @@
 fn drop_generic(_1: *mut Box<T>) -> () {
     debug x => _1;
     let mut _0: ();
-    scope 1 (inlined drop_in_place::<Box<T>> - shim(Some(Box<T>))) {
-        scope 2 (inlined <Box<T> as Drop>::drop) {
-            let _2: std::ptr::NonNull<T>;
-            let _5: ();
-            scope 3 {
+    scope 1 (inlined drop_in_place::<Box<T>>) {
+        scope 2 (inlined std::ptr::drop_glue::<Box<T>> - shim(Some(Box<T>))) {
+            scope 3 (inlined <Box<T> as Drop>::drop) {
+                let _2: std::ptr::NonNull<T>;
+                let _5: ();
                 scope 4 {
-                    scope 17 (inlined Layout::size) {
-                    }
-                    scope 18 (inlined std::ptr::Unique::<T>::cast::<u8>) {
-                        let mut _4: std::ptr::NonNull<u8>;
-                        scope 19 (inlined NonNull::<T>::cast::<u8>) {
-                            scope 20 (inlined NonNull::<T>::as_ptr) {
-                            }
+                    scope 5 {
+                        scope 18 (inlined Layout::size) {
                         }
-                    }
-                    scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                        scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
-                        }
-                    }
-                    scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                        scope 24 (inlined std::alloc::Global::deallocate_impl) {
-                            scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                scope 26 (inlined Layout::size) {
-                                }
-                                scope 27 (inlined alloc::alloc::dealloc_nonnull) {
-                                    scope 28 (inlined Layout::size) {
-                                    }
-                                    scope 29 (inlined Layout::alignment) {
-                                    }
+                        scope 19 (inlined std::ptr::Unique::<T>::cast::<u8>) {
+                            let mut _4: std::ptr::NonNull<u8>;
+                            scope 20 (inlined NonNull::<T>::cast::<u8>) {
+                                scope 21 (inlined NonNull::<T>::as_ptr) {
                                 }
                             }
                         }
-                    }
-                }
-                scope 5 (inlined std::ptr::Unique::<T>::as_ptr) {
-                    scope 6 (inlined NonNull::<T>::as_ptr) {
-                    }
-                }
-                scope 7 (inlined Layout::for_value_raw::<T>) {
-                    let mut _3: std::mem::Alignment;
-                    scope 8 {
-                        scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
+                        scope 22 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                            scope 23 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                            }
                         }
-                    }
-                    scope 9 (inlined size_of_val_raw::<T>) {
-                    }
-                    scope 10 (inlined std::mem::Alignment::of_val_raw::<T>) {
-                        scope 11 {
-                            scope 13 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
-                                scope 14 (inlined core::ub_checks::check_language_ub) {
-                                    scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
+                        scope 24 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                            scope 25 (inlined std::alloc::Global::deallocate_impl) {
+                                scope 26 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                                    scope 27 (inlined Layout::size) {
+                                    }
+                                    scope 28 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 29 (inlined Layout::size) {
+                                        }
+                                        scope 30 (inlined Layout::alignment) {
+                                        }
                                     }
                                 }
                             }
                         }
-                        scope 12 (inlined align_of_val_raw::<T>) {
+                    }
+                    scope 6 (inlined std::ptr::Unique::<T>::as_ptr) {
+                        scope 7 (inlined NonNull::<T>::as_ptr) {
+                        }
+                    }
+                    scope 8 (inlined Layout::for_value_raw::<T>) {
+                        let mut _3: std::mem::Alignment;
+                        scope 9 {
+                            scope 17 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
+                            }
+                        }
+                        scope 10 (inlined size_of_val_raw::<T>) {
+                        }
+                        scope 11 (inlined std::mem::Alignment::of_val_raw::<T>) {
+                            scope 12 {
+                                scope 14 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
+                                    scope 15 (inlined core::ub_checks::check_language_ub) {
+                                        scope 16 (inlined core::ub_checks::check_language_ub::runtime) {
+                                        }
+                                    }
+                                }
+                            }
+                            scope 13 (inlined align_of_val_raw::<T>) {
+                            }
                         }
                     }
                 }

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.PreCodegen.after.panic-unwind.mir
@@ -3,62 +3,64 @@
 fn drop_generic(_1: *mut Box<T>) -> () {
     debug x => _1;
     let mut _0: ();
-    scope 1 (inlined drop_in_place::<Box<T>> - shim(Some(Box<T>))) {
-        scope 2 (inlined <Box<T> as Drop>::drop) {
-            let _2: std::ptr::NonNull<T>;
-            let _5: ();
-            scope 3 {
+    scope 1 (inlined drop_in_place::<Box<T>>) {
+        scope 2 (inlined std::ptr::drop_glue::<Box<T>> - shim(Some(Box<T>))) {
+            scope 3 (inlined <Box<T> as Drop>::drop) {
+                let _2: std::ptr::NonNull<T>;
+                let _5: ();
                 scope 4 {
-                    scope 17 (inlined Layout::size) {
-                    }
-                    scope 18 (inlined std::ptr::Unique::<T>::cast::<u8>) {
-                        let mut _4: std::ptr::NonNull<u8>;
-                        scope 19 (inlined NonNull::<T>::cast::<u8>) {
-                            scope 20 (inlined NonNull::<T>::as_ptr) {
-                            }
+                    scope 5 {
+                        scope 18 (inlined Layout::size) {
                         }
-                    }
-                    scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                        scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
-                        }
-                    }
-                    scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                        scope 24 (inlined std::alloc::Global::deallocate_impl) {
-                            scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                scope 26 (inlined Layout::size) {
-                                }
-                                scope 27 (inlined alloc::alloc::dealloc_nonnull) {
-                                    scope 28 (inlined Layout::size) {
-                                    }
-                                    scope 29 (inlined Layout::alignment) {
-                                    }
+                        scope 19 (inlined std::ptr::Unique::<T>::cast::<u8>) {
+                            let mut _4: std::ptr::NonNull<u8>;
+                            scope 20 (inlined NonNull::<T>::cast::<u8>) {
+                                scope 21 (inlined NonNull::<T>::as_ptr) {
                                 }
                             }
                         }
-                    }
-                }
-                scope 5 (inlined std::ptr::Unique::<T>::as_ptr) {
-                    scope 6 (inlined NonNull::<T>::as_ptr) {
-                    }
-                }
-                scope 7 (inlined Layout::for_value_raw::<T>) {
-                    let mut _3: std::mem::Alignment;
-                    scope 8 {
-                        scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
+                        scope 22 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                            scope 23 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                            }
                         }
-                    }
-                    scope 9 (inlined size_of_val_raw::<T>) {
-                    }
-                    scope 10 (inlined std::mem::Alignment::of_val_raw::<T>) {
-                        scope 11 {
-                            scope 13 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
-                                scope 14 (inlined core::ub_checks::check_language_ub) {
-                                    scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
+                        scope 24 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                            scope 25 (inlined std::alloc::Global::deallocate_impl) {
+                                scope 26 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                                    scope 27 (inlined Layout::size) {
+                                    }
+                                    scope 28 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 29 (inlined Layout::size) {
+                                        }
+                                        scope 30 (inlined Layout::alignment) {
+                                        }
                                     }
                                 }
                             }
                         }
-                        scope 12 (inlined align_of_val_raw::<T>) {
+                    }
+                    scope 6 (inlined std::ptr::Unique::<T>::as_ptr) {
+                        scope 7 (inlined NonNull::<T>::as_ptr) {
+                        }
+                    }
+                    scope 8 (inlined Layout::for_value_raw::<T>) {
+                        let mut _3: std::mem::Alignment;
+                        scope 9 {
+                            scope 17 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
+                            }
+                        }
+                        scope 10 (inlined size_of_val_raw::<T>) {
+                        }
+                        scope 11 (inlined std::mem::Alignment::of_val_raw::<T>) {
+                            scope 12 {
+                                scope 14 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
+                                    scope 15 (inlined core::ub_checks::check_language_ub) {
+                                        scope 16 (inlined core::ub_checks::check_language_ub::runtime) {
+                                        }
+                                    }
+                                }
+                            }
+                            scope 13 (inlined align_of_val_raw::<T>) {
+                            }
                         }
                     }
                 }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-abort.mir
@@ -3,66 +3,68 @@
 fn generic_in_place(_1: *mut Box<[T]>) -> () {
     debug ptr => _1;
     let mut _0: ();
-    scope 1 (inlined drop_in_place::<Box<[T]>> - shim(Some(Box<[T]>))) {
-        scope 2 (inlined <Box<[T]> as Drop>::drop) {
-            let _2: std::ptr::NonNull<[T]>;
-            let mut _3: *mut [T];
-            let mut _4: *const [T];
-            let _9: ();
-            scope 3 {
+    scope 1 (inlined drop_in_place::<Box<[T]>>) {
+        scope 2 (inlined std::ptr::drop_glue::<Box<[T]>> - shim(Some(Box<[T]>))) {
+            scope 3 (inlined <Box<[T]> as Drop>::drop) {
+                let _2: std::ptr::NonNull<[T]>;
+                let mut _3: *mut [T];
+                let mut _4: *const [T];
+                let _9: ();
                 scope 4 {
-                    scope 17 (inlined Layout::size) {
-                    }
-                    scope 18 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
-                        let mut _8: std::ptr::NonNull<u8>;
-                        scope 19 (inlined NonNull::<[T]>::cast::<u8>) {
-                            let mut _7: *mut u8;
-                            scope 20 (inlined NonNull::<[T]>::as_ptr) {
-                            }
+                    scope 5 {
+                        scope 18 (inlined Layout::size) {
                         }
-                    }
-                    scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                        scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
-                        }
-                    }
-                    scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                        scope 24 (inlined std::alloc::Global::deallocate_impl) {
-                            scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                scope 26 (inlined Layout::size) {
-                                }
-                                scope 27 (inlined alloc::alloc::dealloc_nonnull) {
-                                    scope 28 (inlined Layout::size) {
-                                    }
-                                    scope 29 (inlined Layout::alignment) {
-                                    }
+                        scope 19 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
+                            let mut _8: std::ptr::NonNull<u8>;
+                            scope 20 (inlined NonNull::<[T]>::cast::<u8>) {
+                                let mut _7: *mut u8;
+                                scope 21 (inlined NonNull::<[T]>::as_ptr) {
                                 }
                             }
                         }
-                    }
-                }
-                scope 5 (inlined std::ptr::Unique::<[T]>::as_ptr) {
-                    scope 6 (inlined NonNull::<[T]>::as_ptr) {
-                    }
-                }
-                scope 7 (inlined Layout::for_value_raw::<[T]>) {
-                    let mut _5: usize;
-                    let mut _6: std::mem::Alignment;
-                    scope 8 {
-                        scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
+                        scope 22 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                            scope 23 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                            }
                         }
-                    }
-                    scope 9 (inlined size_of_val_raw::<[T]>) {
-                    }
-                    scope 10 (inlined std::mem::Alignment::of_val_raw::<[T]>) {
-                        scope 11 {
-                            scope 13 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
-                                scope 14 (inlined core::ub_checks::check_language_ub) {
-                                    scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
+                        scope 24 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                            scope 25 (inlined std::alloc::Global::deallocate_impl) {
+                                scope 26 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                                    scope 27 (inlined Layout::size) {
+                                    }
+                                    scope 28 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 29 (inlined Layout::size) {
+                                        }
+                                        scope 30 (inlined Layout::alignment) {
+                                        }
                                     }
                                 }
                             }
                         }
-                        scope 12 (inlined align_of_val_raw::<[T]>) {
+                    }
+                    scope 6 (inlined std::ptr::Unique::<[T]>::as_ptr) {
+                        scope 7 (inlined NonNull::<[T]>::as_ptr) {
+                        }
+                    }
+                    scope 8 (inlined Layout::for_value_raw::<[T]>) {
+                        let mut _5: usize;
+                        let mut _6: std::mem::Alignment;
+                        scope 9 {
+                            scope 17 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
+                            }
+                        }
+                        scope 10 (inlined size_of_val_raw::<[T]>) {
+                        }
+                        scope 11 (inlined std::mem::Alignment::of_val_raw::<[T]>) {
+                            scope 12 {
+                                scope 14 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
+                                    scope 15 (inlined core::ub_checks::check_language_ub) {
+                                        scope 16 (inlined core::ub_checks::check_language_ub::runtime) {
+                                        }
+                                    }
+                                }
+                            }
+                            scope 13 (inlined align_of_val_raw::<[T]>) {
+                            }
                         }
                     }
                 }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-unwind.mir
@@ -3,66 +3,68 @@
 fn generic_in_place(_1: *mut Box<[T]>) -> () {
     debug ptr => _1;
     let mut _0: ();
-    scope 1 (inlined drop_in_place::<Box<[T]>> - shim(Some(Box<[T]>))) {
-        scope 2 (inlined <Box<[T]> as Drop>::drop) {
-            let _2: std::ptr::NonNull<[T]>;
-            let mut _3: *mut [T];
-            let mut _4: *const [T];
-            let _9: ();
-            scope 3 {
+    scope 1 (inlined drop_in_place::<Box<[T]>>) {
+        scope 2 (inlined std::ptr::drop_glue::<Box<[T]>> - shim(Some(Box<[T]>))) {
+            scope 3 (inlined <Box<[T]> as Drop>::drop) {
+                let _2: std::ptr::NonNull<[T]>;
+                let mut _3: *mut [T];
+                let mut _4: *const [T];
+                let _9: ();
                 scope 4 {
-                    scope 17 (inlined Layout::size) {
-                    }
-                    scope 18 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
-                        let mut _8: std::ptr::NonNull<u8>;
-                        scope 19 (inlined NonNull::<[T]>::cast::<u8>) {
-                            let mut _7: *mut u8;
-                            scope 20 (inlined NonNull::<[T]>::as_ptr) {
-                            }
+                    scope 5 {
+                        scope 18 (inlined Layout::size) {
                         }
-                    }
-                    scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                        scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
-                        }
-                    }
-                    scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                        scope 24 (inlined std::alloc::Global::deallocate_impl) {
-                            scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                scope 26 (inlined Layout::size) {
-                                }
-                                scope 27 (inlined alloc::alloc::dealloc_nonnull) {
-                                    scope 28 (inlined Layout::size) {
-                                    }
-                                    scope 29 (inlined Layout::alignment) {
-                                    }
+                        scope 19 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
+                            let mut _8: std::ptr::NonNull<u8>;
+                            scope 20 (inlined NonNull::<[T]>::cast::<u8>) {
+                                let mut _7: *mut u8;
+                                scope 21 (inlined NonNull::<[T]>::as_ptr) {
                                 }
                             }
                         }
-                    }
-                }
-                scope 5 (inlined std::ptr::Unique::<[T]>::as_ptr) {
-                    scope 6 (inlined NonNull::<[T]>::as_ptr) {
-                    }
-                }
-                scope 7 (inlined Layout::for_value_raw::<[T]>) {
-                    let mut _5: usize;
-                    let mut _6: std::mem::Alignment;
-                    scope 8 {
-                        scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
+                        scope 22 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                            scope 23 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                            }
                         }
-                    }
-                    scope 9 (inlined size_of_val_raw::<[T]>) {
-                    }
-                    scope 10 (inlined std::mem::Alignment::of_val_raw::<[T]>) {
-                        scope 11 {
-                            scope 13 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
-                                scope 14 (inlined core::ub_checks::check_language_ub) {
-                                    scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
+                        scope 24 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                            scope 25 (inlined std::alloc::Global::deallocate_impl) {
+                                scope 26 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                                    scope 27 (inlined Layout::size) {
+                                    }
+                                    scope 28 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 29 (inlined Layout::size) {
+                                        }
+                                        scope 30 (inlined Layout::alignment) {
+                                        }
                                     }
                                 }
                             }
                         }
-                        scope 12 (inlined align_of_val_raw::<[T]>) {
+                    }
+                    scope 6 (inlined std::ptr::Unique::<[T]>::as_ptr) {
+                        scope 7 (inlined NonNull::<[T]>::as_ptr) {
+                        }
+                    }
+                    scope 8 (inlined Layout::for_value_raw::<[T]>) {
+                        let mut _5: usize;
+                        let mut _6: std::mem::Alignment;
+                        scope 9 {
+                            scope 17 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
+                            }
+                        }
+                        scope 10 (inlined size_of_val_raw::<[T]>) {
+                        }
+                        scope 11 (inlined std::mem::Alignment::of_val_raw::<[T]>) {
+                            scope 12 {
+                                scope 14 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
+                                    scope 15 (inlined core::ub_checks::check_language_ub) {
+                                        scope 16 (inlined core::ub_checks::check_language_ub::runtime) {
+                                        }
+                                    }
+                                }
+                            }
+                            scope 13 (inlined align_of_val_raw::<[T]>) {
+                            }
                         }
                     }
                 }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
@@ -3,66 +3,68 @@
 fn generic_in_place(_1: *mut Box<[T]>) -> () {
     debug ptr => _1;
     let mut _0: ();
-    scope 1 (inlined drop_in_place::<Box<[T]>> - shim(Some(Box<[T]>))) {
-        scope 2 (inlined <Box<[T]> as Drop>::drop) {
-            let _2: std::ptr::NonNull<[T]>;
-            let mut _3: *mut [T];
-            let mut _4: *const [T];
-            let _9: ();
-            scope 3 {
+    scope 1 (inlined drop_in_place::<Box<[T]>>) {
+        scope 2 (inlined std::ptr::drop_glue::<Box<[T]>> - shim(Some(Box<[T]>))) {
+            scope 3 (inlined <Box<[T]> as Drop>::drop) {
+                let _2: std::ptr::NonNull<[T]>;
+                let mut _3: *mut [T];
+                let mut _4: *const [T];
+                let _9: ();
                 scope 4 {
-                    scope 17 (inlined Layout::size) {
-                    }
-                    scope 18 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
-                        let mut _8: std::ptr::NonNull<u8>;
-                        scope 19 (inlined NonNull::<[T]>::cast::<u8>) {
-                            let mut _7: *mut u8;
-                            scope 20 (inlined NonNull::<[T]>::as_ptr) {
-                            }
+                    scope 5 {
+                        scope 18 (inlined Layout::size) {
                         }
-                    }
-                    scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                        scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
-                        }
-                    }
-                    scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                        scope 24 (inlined std::alloc::Global::deallocate_impl) {
-                            scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                scope 26 (inlined Layout::size) {
-                                }
-                                scope 27 (inlined alloc::alloc::dealloc_nonnull) {
-                                    scope 28 (inlined Layout::size) {
-                                    }
-                                    scope 29 (inlined Layout::alignment) {
-                                    }
+                        scope 19 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
+                            let mut _8: std::ptr::NonNull<u8>;
+                            scope 20 (inlined NonNull::<[T]>::cast::<u8>) {
+                                let mut _7: *mut u8;
+                                scope 21 (inlined NonNull::<[T]>::as_ptr) {
                                 }
                             }
                         }
-                    }
-                }
-                scope 5 (inlined std::ptr::Unique::<[T]>::as_ptr) {
-                    scope 6 (inlined NonNull::<[T]>::as_ptr) {
-                    }
-                }
-                scope 7 (inlined Layout::for_value_raw::<[T]>) {
-                    let mut _5: usize;
-                    let mut _6: std::mem::Alignment;
-                    scope 8 {
-                        scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
+                        scope 22 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                            scope 23 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                            }
                         }
-                    }
-                    scope 9 (inlined size_of_val_raw::<[T]>) {
-                    }
-                    scope 10 (inlined std::mem::Alignment::of_val_raw::<[T]>) {
-                        scope 11 {
-                            scope 13 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
-                                scope 14 (inlined core::ub_checks::check_language_ub) {
-                                    scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
+                        scope 24 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                            scope 25 (inlined std::alloc::Global::deallocate_impl) {
+                                scope 26 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                                    scope 27 (inlined Layout::size) {
+                                    }
+                                    scope 28 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 29 (inlined Layout::size) {
+                                        }
+                                        scope 30 (inlined Layout::alignment) {
+                                        }
                                     }
                                 }
                             }
                         }
-                        scope 12 (inlined align_of_val_raw::<[T]>) {
+                    }
+                    scope 6 (inlined std::ptr::Unique::<[T]>::as_ptr) {
+                        scope 7 (inlined NonNull::<[T]>::as_ptr) {
+                        }
+                    }
+                    scope 8 (inlined Layout::for_value_raw::<[T]>) {
+                        let mut _5: usize;
+                        let mut _6: std::mem::Alignment;
+                        scope 9 {
+                            scope 17 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
+                            }
+                        }
+                        scope 10 (inlined size_of_val_raw::<[T]>) {
+                        }
+                        scope 11 (inlined std::mem::Alignment::of_val_raw::<[T]>) {
+                            scope 12 {
+                                scope 14 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
+                                    scope 15 (inlined core::ub_checks::check_language_ub) {
+                                        scope 16 (inlined core::ub_checks::check_language_ub::runtime) {
+                                        }
+                                    }
+                                }
+                            }
+                            scope 13 (inlined align_of_val_raw::<[T]>) {
+                            }
                         }
                     }
                 }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-unwind.mir
@@ -3,66 +3,68 @@
 fn generic_in_place(_1: *mut Box<[T]>) -> () {
     debug ptr => _1;
     let mut _0: ();
-    scope 1 (inlined drop_in_place::<Box<[T]>> - shim(Some(Box<[T]>))) {
-        scope 2 (inlined <Box<[T]> as Drop>::drop) {
-            let _2: std::ptr::NonNull<[T]>;
-            let mut _3: *mut [T];
-            let mut _4: *const [T];
-            let _9: ();
-            scope 3 {
+    scope 1 (inlined drop_in_place::<Box<[T]>>) {
+        scope 2 (inlined std::ptr::drop_glue::<Box<[T]>> - shim(Some(Box<[T]>))) {
+            scope 3 (inlined <Box<[T]> as Drop>::drop) {
+                let _2: std::ptr::NonNull<[T]>;
+                let mut _3: *mut [T];
+                let mut _4: *const [T];
+                let _9: ();
                 scope 4 {
-                    scope 17 (inlined Layout::size) {
-                    }
-                    scope 18 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
-                        let mut _8: std::ptr::NonNull<u8>;
-                        scope 19 (inlined NonNull::<[T]>::cast::<u8>) {
-                            let mut _7: *mut u8;
-                            scope 20 (inlined NonNull::<[T]>::as_ptr) {
-                            }
+                    scope 5 {
+                        scope 18 (inlined Layout::size) {
                         }
-                    }
-                    scope 21 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
-                        scope 22 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
-                        }
-                    }
-                    scope 23 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                        scope 24 (inlined std::alloc::Global::deallocate_impl) {
-                            scope 25 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                scope 26 (inlined Layout::size) {
-                                }
-                                scope 27 (inlined alloc::alloc::dealloc_nonnull) {
-                                    scope 28 (inlined Layout::size) {
-                                    }
-                                    scope 29 (inlined Layout::alignment) {
-                                    }
+                        scope 19 (inlined std::ptr::Unique::<[T]>::cast::<u8>) {
+                            let mut _8: std::ptr::NonNull<u8>;
+                            scope 20 (inlined NonNull::<[T]>::cast::<u8>) {
+                                let mut _7: *mut u8;
+                                scope 21 (inlined NonNull::<[T]>::as_ptr) {
                                 }
                             }
                         }
-                    }
-                }
-                scope 5 (inlined std::ptr::Unique::<[T]>::as_ptr) {
-                    scope 6 (inlined NonNull::<[T]>::as_ptr) {
-                    }
-                }
-                scope 7 (inlined Layout::for_value_raw::<[T]>) {
-                    let mut _5: usize;
-                    let mut _6: std::mem::Alignment;
-                    scope 8 {
-                        scope 16 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
+                        scope 22 (inlined <NonNull<u8> as From<std::ptr::Unique<u8>>>::from) {
+                            scope 23 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
+                            }
                         }
-                    }
-                    scope 9 (inlined size_of_val_raw::<[T]>) {
-                    }
-                    scope 10 (inlined std::mem::Alignment::of_val_raw::<[T]>) {
-                        scope 11 {
-                            scope 13 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
-                                scope 14 (inlined core::ub_checks::check_language_ub) {
-                                    scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
+                        scope 24 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                            scope 25 (inlined std::alloc::Global::deallocate_impl) {
+                                scope 26 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                                    scope 27 (inlined Layout::size) {
+                                    }
+                                    scope 28 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 29 (inlined Layout::size) {
+                                        }
+                                        scope 30 (inlined Layout::alignment) {
+                                        }
                                     }
                                 }
                             }
                         }
-                        scope 12 (inlined align_of_val_raw::<[T]>) {
+                    }
+                    scope 6 (inlined std::ptr::Unique::<[T]>::as_ptr) {
+                        scope 7 (inlined NonNull::<[T]>::as_ptr) {
+                        }
+                    }
+                    scope 8 (inlined Layout::for_value_raw::<[T]>) {
+                        let mut _5: usize;
+                        let mut _6: std::mem::Alignment;
+                        scope 9 {
+                            scope 17 (inlined #[track_caller] Layout::from_size_alignment_unchecked) {
+                            }
+                        }
+                        scope 10 (inlined size_of_val_raw::<[T]>) {
+                        }
+                        scope 11 (inlined std::mem::Alignment::of_val_raw::<[T]>) {
+                            scope 12 {
+                                scope 14 (inlined #[track_caller] std::mem::Alignment::new_unchecked) {
+                                    scope 15 (inlined core::ub_checks::check_language_ub) {
+                                        scope 16 (inlined core::ub_checks::check_language_ub::runtime) {
+                                        }
+                                    }
+                                }
+                            }
+                            scope 13 (inlined align_of_val_raw::<[T]>) {
+                            }
                         }
                     }
                 }

--- a/tests/mir-opt/slice_drop_shim.core.ptr-drop_glue.[String;42].AddMovesForPackedDrops.before.mir
+++ b/tests/mir-opt/slice_drop_shim.core.ptr-drop_glue.[String;42].AddMovesForPackedDrops.before.mir
@@ -1,6 +1,6 @@
-// MIR for `std::ptr::drop_in_place` before AddMovesForPackedDrops
+// MIR for `std::ptr::drop_glue` before AddMovesForPackedDrops
 
-fn drop_in_place(_1: *mut [String; 42]) -> () {
+fn std::ptr::drop_glue(_1: &mut [String; 42]) -> () {
     let mut _0: ();
     let mut _2: *mut [std::string::String; 42];
     let mut _3: *mut [std::string::String];

--- a/tests/mir-opt/slice_drop_shim.core.ptr-drop_glue.[String].AddMovesForPackedDrops.before.mir
+++ b/tests/mir-opt/slice_drop_shim.core.ptr-drop_glue.[String].AddMovesForPackedDrops.before.mir
@@ -1,6 +1,6 @@
-// MIR for `std::ptr::drop_in_place` before AddMovesForPackedDrops
+// MIR for `std::ptr::drop_glue` before AddMovesForPackedDrops
 
-fn drop_in_place(_1: *mut [String]) -> () {
+fn std::ptr::drop_glue(_1: &mut [String]) -> () {
     let mut _0: ();
     let mut _2: usize;
     let mut _3: usize;

--- a/tests/mir-opt/slice_drop_shim.rs
+++ b/tests/mir-opt/slice_drop_shim.rs
@@ -4,8 +4,8 @@
 // so this test only produces MIR for the drop_in_place we're looking for
 // if we use -Clink-dead-code.
 
-// EMIT_MIR core.ptr-drop_in_place.[String].AddMovesForPackedDrops.before.mir
-// EMIT_MIR core.ptr-drop_in_place.[String;42].AddMovesForPackedDrops.before.mir
+// EMIT_MIR core.ptr-drop_glue.[String].AddMovesForPackedDrops.before.mir
+// EMIT_MIR core.ptr-drop_glue.[String;42].AddMovesForPackedDrops.before.mir
 fn main() {
     let _fn = std::ptr::drop_in_place::<[String]> as unsafe fn(_);
     let _fn = std::ptr::drop_in_place::<[String; 42]> as unsafe fn(_);

--- a/tests/mir-opt/unusual_item_types.core.ptr-drop_glue.Vec_i32_.AddMovesForPackedDrops.before.mir
+++ b/tests/mir-opt/unusual_item_types.core.ptr-drop_glue.Vec_i32_.AddMovesForPackedDrops.before.mir
@@ -1,6 +1,6 @@
-// MIR for `std::ptr::drop_in_place` before AddMovesForPackedDrops
+// MIR for `std::ptr::drop_glue` before AddMovesForPackedDrops
 
-fn drop_in_place(_1: *mut Vec<i32>) -> () {
+fn std::ptr::drop_glue(_1: &mut Vec<i32>) -> () {
     let mut _0: ();
     let mut _2: &mut std::vec::Vec<i32>;
     let mut _3: ();

--- a/tests/mir-opt/unusual_item_types.rs
+++ b/tests/mir-opt/unusual_item_types.rs
@@ -22,7 +22,7 @@ enum E {
     V = 5,
 }
 
-// EMIT_MIR core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.mir
+// EMIT_MIR core.ptr-drop_glue.Vec_i32_.AddMovesForPackedDrops.before.mir
 pub fn main() {
     let f = Test::X as fn(usize) -> Test;
     let v = Vec::<i32>::new();

--- a/tests/run-make/arm64ec-import-export-static/export.rs
+++ b/tests/run-make/arm64ec-import-export-static/export.rs
@@ -17,8 +17,8 @@ impl Sync for i32 {}
 #[lang = "copy"]
 pub trait Copy {}
 impl Copy for i32 {}
-#[lang = "drop_in_place"]
-pub unsafe fn drop_in_place<T: ?Sized>(_: *mut T) {}
+#[lang = "drop_glue"]
+pub unsafe fn drop_glue<T: ?Sized>(_: &mut T) {}
 #[no_mangle]
 extern "system" fn _DllMainCRTStartup(_: *const u8, _: u32, _: *const u8) -> u32 {
     1

--- a/tests/run-make/min-global-align/min_global_align.rs
+++ b/tests/run-make/min-global-align/min_global_align.rs
@@ -34,5 +34,5 @@ trait Sync {}
 impl Sync for bool {}
 impl Sync for &'static bool {}
 
-#[lang = "drop_in_place"]
-pub unsafe fn drop_in_place<T: ?Sized>(_: *mut T) {}
+#[lang = "drop_glue"]
+pub unsafe fn drop_glue<T: ?Sized>(_: &mut T) {}

--- a/tests/ui/async-await/async-drop/async-drop-initial.rs
+++ b/tests/ui/async-await/async-drop/async-drop-initial.rs
@@ -19,7 +19,7 @@ use core::task::{Context, Poll, Waker};
 
 async fn test_async_drop<T>(x: T, _size: usize) {
     let mut x = mem::MaybeUninit::new(x);
-    let dtor = pin!(unsafe { async_drop_in_place(x.as_mut_ptr()) });
+    let dtor = pin!(unsafe { async_drop_in_place(&mut *x.as_mut_ptr()) });
 
     // FIXME(zetanumbers): This check fully depends on the layout of
     // the coroutine state, since async destructor combinators are just
@@ -92,7 +92,7 @@ fn main() {
         .await;
 
         let mut ptr19 = mem::MaybeUninit::new(AsyncInt(19));
-        let async_drop_fut = pin!(unsafe { async_drop_in_place(ptr19.as_mut_ptr()) });
+        let async_drop_fut = pin!(unsafe { async_drop_in_place(&mut *ptr19.as_mut_ptr()) });
         test_idempotency(async_drop_fut).await;
 
         let foo = AsyncInt(20);

--- a/tests/ui/async-await/async-drop/ex-ice-132103.rs
+++ b/tests/ui/async-await/async-drop/ex-ice-132103.rs
@@ -6,14 +6,14 @@
 #![feature(async_drop)]
 #![allow(incomplete_features)]
 
-use core::future::{async_drop_in_place, Future};
+use core::future::{Future, async_drop_in_place};
 use core::mem::{self};
 use core::pin::pin;
 use core::task::{Context, Waker};
 
 async fn test_async_drop<T>(x: T) {
     let mut x = mem::MaybeUninit::new(x);
-    pin!(unsafe { async_drop_in_place(x.as_mut_ptr()) });
+    pin!(unsafe { async_drop_in_place(&mut *x.as_mut_ptr()) });
 }
 
 fn main() {

--- a/tests/ui/async-await/async-drop/open-drop-error2.rs
+++ b/tests/ui/async-await/async-drop/open-drop-error2.rs
@@ -3,11 +3,9 @@
 #![feature(async_drop)]
 #![allow(incomplete_features)]
 
-use std::{
-    future::{Future, async_drop_in_place},
-    pin::pin,
-    task::Context,
-};
+use std::future::{Future, async_drop_in_place};
+use std::pin::pin;
+use std::task::Context;
 
 fn wrong() -> impl Sized {
     //~^ ERROR: the size for values of type `str` cannot be known at compilation time
@@ -15,7 +13,7 @@ fn wrong() -> impl Sized {
 }
 fn weird(context: &mut Context<'_>) {
     let mut e = wrong();
-    let h = unsafe { async_drop_in_place(&raw mut e) };
+    let h = unsafe { async_drop_in_place(&mut e) };
     let i = pin!(h);
     i.poll(context);
 }

--- a/tests/ui/async-await/async-drop/open-drop-error2.stderr
+++ b/tests/ui/async-await/async-drop/open-drop-error2.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/open-drop-error2.rs:12:15
+  --> $DIR/open-drop-error2.rs:10:15
    |
 LL | fn wrong() -> impl Sized {
    |               ^^^^^^^^^^ doesn't have a size known at compile-time

--- a/tests/ui/consts/const-eval/c-variadic-fail.stderr
+++ b/tests/ui/consts/const-eval/c-variadic-fail.stderr
@@ -436,7 +436,7 @@ LL |         drop(ap);
    |         ^^^^^^^^
 note: inside `std::mem::drop::<VaList<'_>>`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-note: inside `drop_in_place::<VaList<'_>> - shim(Some(VaList<'_>))`
+note: inside `std::ptr::drop_glue::<VaList<'_>> - shim(Some(VaList<'_>))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 note: inside `<VaList<'_> as Drop>::drop`
   --> $SRC_DIR/core/src/ffi/va_list.rs:LL:COL
@@ -468,7 +468,7 @@ LL |         drop(ap);
    |         ^^^^^^^^
 note: inside `std::mem::drop::<VaList<'_>>`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-note: inside `drop_in_place::<VaList<'_>> - shim(Some(VaList<'_>))`
+note: inside `std::ptr::drop_glue::<VaList<'_>> - shim(Some(VaList<'_>))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 note: inside `<VaList<'_> as Drop>::drop`
   --> $SRC_DIR/core/src/ffi/va_list.rs:LL:COL
@@ -521,7 +521,7 @@ error[E0080]: pointer not dereferenceable: pointer must point to some allocation
 LL |     }
    |     ^ evaluation of `drop_of_invalid::{constant#0}` failed inside this call
    |
-note: inside `drop_in_place::<VaList<'_>> - shim(Some(VaList<'_>))`
+note: inside `std::ptr::drop_glue::<VaList<'_>> - shim(Some(VaList<'_>))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 note: inside `<VaList<'_> as Drop>::drop`
   --> $SRC_DIR/core/src/ffi/va_list.rs:LL:COL

--- a/tests/ui/consts/miri_unleashed/assoc_const.stderr
+++ b/tests/ui/consts/miri_unleashed/assoc_const.stderr
@@ -4,9 +4,9 @@ error[E0080]: calling non-const function `<Vec<u32> as Drop>::drop`
 LL |     const F: u32 = (U::X, 42).1;
    |                               ^ evaluation of `<std::string::String as Bar<std::vec::Vec<u32>, std::string::String>>::F` failed inside this call
    |
-note: inside `drop_in_place::<(Vec<u32>, u32)> - shim(Some((Vec<u32>, u32)))`
+note: inside `std::ptr::drop_glue::<(Vec<u32>, u32)> - shim(Some((Vec<u32>, u32)))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `drop_in_place::<Vec<u32>> - shim(Some(Vec<u32>))`
+note: inside `std::ptr::drop_glue::<Vec<u32>> - shim(Some(Vec<u32>))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 note: erroneous constant encountered

--- a/tests/ui/consts/miri_unleashed/drop.rs
+++ b/tests/ui/consts/miri_unleashed/drop.rs
@@ -13,8 +13,9 @@ static TEST_OK: () = {
 // The actual error is tested by the error-pattern above.
 static TEST_BAD: () = {
     let _v: Vec<i32> = Vec::new();
-}; //~ NOTE failed inside this call
-   //~| ERROR calling non-const function `<Vec<i32> as Drop>::drop`
-   //~| NOTE inside `drop_in_place::<Vec<i32>> - shim(Some(Vec<i32>))`
+};
+//~^ NOTE failed inside this call
+//~| ERROR calling non-const function `<Vec<i32> as Drop>::drop`
+//~| NOTE inside `std::ptr::drop_glue::<Vec<i32>> - shim(Some(Vec<i32>))`
 
 //~? WARN skipping const checks

--- a/tests/ui/consts/miri_unleashed/drop.stderr
+++ b/tests/ui/consts/miri_unleashed/drop.stderr
@@ -4,7 +4,7 @@ error[E0080]: calling non-const function `<Vec<i32> as Drop>::drop`
 LL | };
    | ^ evaluation of `TEST_BAD` failed inside this call
    |
-note: inside `drop_in_place::<Vec<i32>> - shim(Some(Vec<i32>))`
+note: inside `std::ptr::drop_glue::<Vec<i32>> - shim(Some(Vec<i32>))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 warning: skipping const checks

--- a/tests/ui/consts/qualif-indirect-mutation-fail.stderr
+++ b/tests/ui/consts/qualif-indirect-mutation-fail.stderr
@@ -13,11 +13,11 @@ error[E0080]: calling non-const function `<Vec<u8> as Drop>::drop`
 LL | };
    | ^ evaluation of `A1` failed inside this call
    |
-note: inside `drop_in_place::<Option<String>> - shim(Some(Option<String>))`
+note: inside `std::ptr::drop_glue::<Option<String>> - shim(Some(Option<String>))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `drop_in_place::<String> - shim(Some(String))`
+note: inside `std::ptr::drop_glue::<String> - shim(Some(String))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `drop_in_place::<Vec<u8>> - shim(Some(Vec<u8>))`
+note: inside `std::ptr::drop_glue::<Vec<u8>> - shim(Some(Vec<u8>))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 error[E0493]: destructor of `Option<String>` cannot be evaluated at compile-time
@@ -34,11 +34,11 @@ error[E0080]: calling non-const function `<Vec<u8> as Drop>::drop`
 LL | };
    | ^ evaluation of `A2` failed inside this call
    |
-note: inside `drop_in_place::<Option<String>> - shim(Some(Option<String>))`
+note: inside `std::ptr::drop_glue::<Option<String>> - shim(Some(Option<String>))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `drop_in_place::<String> - shim(Some(String))`
+note: inside `std::ptr::drop_glue::<String> - shim(Some(String))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `drop_in_place::<Vec<u8>> - shim(Some(Vec<u8>))`
+note: inside `std::ptr::drop_glue::<Vec<u8>> - shim(Some(Vec<u8>))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 error[E0493]: destructor of `(u32, Option<String>)` cannot be evaluated at compile-time

--- a/tests/ui/lang-items/issue-87573.rs
+++ b/tests/ui/lang-items/issue-87573.rs
@@ -23,12 +23,12 @@ trait Copy {}
 trait Sync {}
 impl Sync for bool {}
 
-#[lang = "drop_in_place"]
-//~^ ERROR: `drop_in_place` lang item must be applied to a function with at least 1 generic argument
+#[lang = "drop_glue"]
+//~^ ERROR: `drop_glue` lang item must be applied to a function with 1 generic argument
 fn drop_fn() {
     while false {}
 }
 
 #[lang = "start"]
 //~^ ERROR: `start` lang item must be applied to a function with 1 generic argument
-fn start(){}
+fn start() {}

--- a/tests/ui/lang-items/issue-87573.stderr
+++ b/tests/ui/lang-items/issue-87573.stderr
@@ -1,8 +1,8 @@
-error[E0718]: `drop_in_place` lang item must be applied to a function with at least 1 generic argument
+error[E0718]: `drop_glue` lang item must be applied to a function with 1 generic argument
   --> $DIR/issue-87573.rs:26:1
    |
-LL | #[lang = "drop_in_place"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #[lang = "drop_glue"]
+   | ^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL | fn drop_fn() {
    |           - this function has 0 generic arguments
@@ -13,7 +13,7 @@ error[E0718]: `start` lang item must be applied to a function with 1 generic arg
 LL | #[lang = "start"]
    | ^^^^^^^^^^^^^^^^^
 LL |
-LL | fn start(){}
+LL | fn start() {}
    |         - this function has 0 generic arguments
 
 error: aborting due to 2 previous errors

--- a/tests/ui/lang-items/lang-item-generic-requirements.rs
+++ b/tests/ui/lang-items/lang-item-generic-requirements.rs
@@ -17,8 +17,8 @@ trait MySized: MyMetaSized {}
 trait MyAdd<'a, T> {}
 //~^^ ERROR: `add` lang item must be applied to a trait with 1 generic argument [E0718]
 
-#[lang = "drop_in_place"]
-//~^ ERROR `drop_in_place` lang item must be applied to a function with at least 1 generic
+#[lang = "drop_glue"]
+//~^ ERROR `drop_glue` lang item must be applied to a function with 1 generic
 fn my_ptr_drop() {}
 
 #[lang = "index"]

--- a/tests/ui/lang-items/lang-item-generic-requirements.stderr
+++ b/tests/ui/lang-items/lang-item-generic-requirements.stderr
@@ -6,11 +6,11 @@ LL | #[lang = "add"]
 LL | trait MyAdd<'a, T> {}
    |            ------- this trait has 2 generic arguments
 
-error[E0718]: `drop_in_place` lang item must be applied to a function with at least 1 generic argument
+error[E0718]: `drop_glue` lang item must be applied to a function with 1 generic argument
   --> $DIR/lang-item-generic-requirements.rs:20:1
    |
-LL | #[lang = "drop_in_place"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #[lang = "drop_glue"]
+   | ^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL | fn my_ptr_drop() {}
    |               - this function has 0 generic arguments


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/154327)*
<!-- homu-ignore:end -->

We used to special case `core::ptr::drop_in_place` when computing LLVM argument attributes with this hack:

https://github.com/rust-lang/rust/blob/db5e2dc248fe5bb26f70d7baec46a3bca9fa3e1d/compiler/rustc_ty_utils/src/abi.rs#L383-L392

This is because even though `drop_in_place` takes a `*mut T` it is semantically a `&mut T` (remember how `&mut Self` is passed to `Drop::drop`). This is apparently relevant for perf.

This PR replaces this hack with a simpler solution -- it makes `drop_in_place` a thin wrapper around newly added `core::ptr::drop_glue`, which is the actual lang item and takes a `&mut T`:

https://github.com/rust-lang/rust/blob/d2563d5003bbecff1efc40c1f5673ceec603825b/library/core/src/ptr/mod.rs#L810-L833

------

The rest of the PR is blessing tests and cleaning up things which are not necessary after this change.

One thing that is a bit awkward is that now that `drop_glue` is the actual lang item, a lot of the comments referring to `drop_in_place` are outdated. Should I try fixing that?

I've also changed `async_drop_in_place` to take a `&mut T`, and it simplified the code handling it a bit. (since it's unstable we don't need to introduce a wrapper)

-------

cc @RalfJung 
Closes https://github.com/rust-lang/rust/issues/154274
