### PR TITLE
fix proof tree visitors for type and const placeholders

### DIFF
--- a/compiler/rustc_next_trait_solver/src/canonical/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/canonical/mod.rs
@@ -165,6 +165,27 @@ where
         delegate.create_next_universe();
     }
 
+    compute_query_response_instantiation_values_in_universe(
+        delegate,
+        original_values,
+        response,
+        span,
+        prev_universe,
+    )
+}
+
+fn compute_query_response_instantiation_values_in_universe<D, I, T>(
+    delegate: &D,
+    original_values: &[I::GenericArg],
+    response: &Canonical<I, T>,
+    span: I::Span,
+    prev_universe: ty::UniverseIndex,
+) -> CanonicalVarValues<I>
+where
+    D: SolverDelegate<Interner = I>,
+    I: Interner,
+    T: ResponseT<I>,
+{
     let var_values = response.value.var_values();
     assert_eq!(original_values.len(), var_values.len());
 
@@ -542,6 +563,7 @@ pub fn instantiate_canonical_state<D, I, T>(
     delegate: &D,
     span: I::Span,
     param_env: I::ParamEnv,
+    prev_universe: ty::UniverseIndex,
     orig_values: &mut ThinVec<I::GenericArg>,
     state: inspect::CanonicalState<I, T>,
 ) -> T
@@ -552,14 +574,23 @@ where
 {
     // In case any fresh inference variables have been created between `state`
     // and the previous instantiation, extend `orig_values` for it.
+    let max_universe = prev_universe + state.max_universe.index();
+    while delegate.universe() < max_universe {
+        delegate.create_next_universe();
+    }
     orig_values.extend(
         state.value.var_values.var_values.as_slice()[orig_values.len()..]
             .iter()
-            .map(|&arg| delegate.fresh_var_for_kind_with_span(arg, span)),
+            .map(|&arg| delegate.fresh_var_for_kind(arg, span, max_universe)),
     );
 
-    let instantiation =
-        compute_query_response_instantiation_values(delegate, orig_values, &state, span);
+    let instantiation = compute_query_response_instantiation_values_in_universe(
+        delegate,
+        orig_values,
+        &state,
+        span,
+        prev_universe,
+    );
 
     let inspect::State { var_values, data } = delegate.instantiate_canonical(state, instantiation);
 

--- a/compiler/rustc_next_trait_solver/src/delegate.rs
+++ b/compiler/rustc_next_trait_solver/src/delegate.rs
@@ -26,10 +26,11 @@ pub trait SolverDelegate: Deref<Target = Self::Infcx> + Sized {
         span: <Self::Interner as Interner>::Span,
     ) -> ComputeGoalFastPathOutcome<Self::Interner>;
 
-    fn fresh_var_for_kind_with_span(
+    fn fresh_var_for_kind(
         &self,
         arg: <Self::Interner as Interner>::GenericArg,
         span: <Self::Interner as Interner>::Span,
+        universe: ty::UniverseIndex,
     ) -> <Self::Interner as Interner>::GenericArg;
 
     // FIXME: Uplift the leak check into this crate.

--- a/compiler/rustc_trait_selection/src/solve/delegate.rs
+++ b/compiler/rustc_trait_selection/src/solve/delegate.rs
@@ -285,17 +285,18 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
         }
     }
 
-    fn fresh_var_for_kind_with_span(
+    fn fresh_var_for_kind(
         &self,
         arg: ty::GenericArg<'tcx>,
         span: Span,
+        universe: ty::UniverseIndex,
     ) -> ty::GenericArg<'tcx> {
         match arg.kind() {
             ty::GenericArgKind::Lifetime(_) => {
-                self.next_region_var(RegionVariableOrigin::Misc(span)).into()
+                self.next_region_var_in_universe(RegionVariableOrigin::Misc(span), universe).into()
             }
-            ty::GenericArgKind::Type(_) => self.next_ty_var(span).into(),
-            ty::GenericArgKind::Const(_) => self.next_const_var(span).into(),
+            ty::GenericArgKind::Type(_) => self.next_ty_var_in_universe(span, universe).into(),
+            ty::GenericArgKind::Const(_) => self.next_const_var_in_universe(span, universe).into(),
         }
     }
 

--- a/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
+++ b/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
@@ -32,6 +32,7 @@ pub struct InspectGoal<'a, 'tcx> {
     infcx: &'a SolverDelegate<'tcx>,
     depth: usize,
     orig_values: ThinVec<ty::GenericArg<'tcx>>,
+    prev_universe: ty::UniverseIndex,
     goal: Goal<'tcx, ty::Predicate<'tcx>>,
     result: Result<Certainty, NoSolution>,
     final_revision: &'tcx inspect::Probe<TyCtxt<'tcx>>,
@@ -102,7 +103,14 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
             match **step {
                 inspect::ProbeStep::AddGoal(source, goal) => instantiated_goals.push((
                     source,
-                    instantiate_canonical_state(infcx, span, param_env, &mut orig_values, goal),
+                    instantiate_canonical_state(
+                        infcx,
+                        span,
+                        param_env,
+                        self.goal.prev_universe,
+                        &mut orig_values,
+                        goal,
+                    ),
                 )),
                 inspect::ProbeStep::RecordImplArgs { .. } => {}
                 inspect::ProbeStep::MakeCanonicalResponse { .. }
@@ -110,8 +118,14 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
             }
         }
 
-        let () =
-            instantiate_canonical_state(infcx, span, param_env, &mut orig_values, self.final_state);
+        let () = instantiate_canonical_state(
+            infcx,
+            span,
+            param_env,
+            self.goal.prev_universe,
+            &mut orig_values,
+            self.final_state,
+        );
 
         instantiated_goals
             .into_iter()
@@ -139,6 +153,7 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
                         infcx,
                         span,
                         param_env,
+                        self.goal.prev_universe,
                         &mut orig_values,
                         impl_args,
                     );
@@ -147,6 +162,7 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
                         infcx,
                         span,
                         param_env,
+                        self.goal.prev_universe,
                         &mut orig_values,
                         self.final_state,
                     );
@@ -320,6 +336,7 @@ impl<'a, 'tcx> InspectGoal<'a, 'tcx> {
         source: GoalSource,
     ) -> Self {
         let infcx = <&SolverDelegate<'tcx>>::from(infcx);
+        let prev_universe = infcx.universe();
 
         let inspect::GoalEvaluation { uncanonicalized_goal, orig_values, final_revision, result } =
             root;
@@ -331,6 +348,7 @@ impl<'a, 'tcx> InspectGoal<'a, 'tcx> {
             infcx,
             depth,
             orig_values,
+            prev_universe,
             goal: eager_resolve_vars(&**infcx, uncanonicalized_goal),
             result,
             final_revision,

--- a/tests/ui/traits/non_lifetime_binders/foreach-partial-eq-next-solver.rs
+++ b/tests/ui/traits/non_lifetime_binders/foreach-partial-eq-next-solver.rs
@@ -1,0 +1,14 @@
+//@ compile-flags: -Znext-solver=globally
+
+#![allow(incomplete_features)]
+#![feature(non_lifetime_binders)]
+
+fn auto_trait()
+where
+    for<T> T: PartialEq + PartialOrd,
+{}
+
+fn main() {
+    auto_trait();
+    //~^ ERROR can't compare `T` with `T`
+}

--- a/tests/ui/traits/non_lifetime_binders/foreach-partial-eq-next-solver.rs
+++ b/tests/ui/traits/non_lifetime_binders/foreach-partial-eq-next-solver.rs
@@ -1,5 +1,14 @@
 //@ compile-flags: -Znext-solver=globally
 
+// Regression test for <https://github.com/rust-lang/rust/issues/151304>.
+//
+// This used to ICE with `-Znext-solver=globally`.
+// The ICE happened because the `PartialOrd` bound fails causing
+// diagnostics to replay the proof tree in order to find the
+// best nested-goal. During that replay, it needs to create a
+// fresh inference variable for the higher-ranked `T` but it was
+// creating it in the wrong universe.
+
 #![allow(incomplete_features)]
 #![feature(non_lifetime_binders)]
 

--- a/tests/ui/traits/non_lifetime_binders/foreach-partial-eq-next-solver.stderr
+++ b/tests/ui/traits/non_lifetime_binders/foreach-partial-eq-next-solver.stderr
@@ -1,0 +1,19 @@
+error[E0277]: can't compare `T` with `T`
+  --> $DIR/foreach-partial-eq-next-solver.rs:12:5
+   |
+LL |     auto_trait();
+   |     ^^^^^^^^^^^^ no implementation for `T < T` and `T > T`
+   |
+   = help: the trait `PartialOrd` is not implemented for `T`
+note: required by a bound in `auto_trait`
+  --> $DIR/foreach-partial-eq-next-solver.rs:8:27
+   |
+LL | fn auto_trait()
+   |    ---------- required by a bound in this function
+LL | where
+LL |     for<T> T: PartialEq + PartialOrd,
+   |                           ^^^^^^^^^^ required by this bound in `auto_trait`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/non_lifetime_binders/foreach-partial-eq-next-solver.stderr
+++ b/tests/ui/traits/non_lifetime_binders/foreach-partial-eq-next-solver.stderr
@@ -1,12 +1,12 @@
 error[E0277]: can't compare `T` with `T`
-  --> $DIR/foreach-partial-eq-next-solver.rs:12:5
+  --> $DIR/foreach-partial-eq-next-solver.rs:21:5
    |
 LL |     auto_trait();
    |     ^^^^^^^^^^^^ no implementation for `T < T` and `T > T`
    |
    = help: the trait `PartialOrd` is not implemented for `T`
 note: required by a bound in `auto_trait`
-  --> $DIR/foreach-partial-eq-next-solver.rs:8:27
+  --> $DIR/foreach-partial-eq-next-solver.rs:17:27
    |
 LL | fn auto_trait()
    |    ---------- required by a bound in this function


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/154329)*
<!-- homu-ignore:end -->

When diagnostics replay proof tree state, rebuilding a canonical state can fail to match the current inference state. With -Znext-solver=globally, this could panic while reporting an error, avoiding the panic.

Make proof tree replay fallible in diagnostics and fall back to the current obligation when replay fails. Add a regression test for the higher-ranked PartialEq and PartialOrd case. Fixes rust-lang/rust#151304.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
