### PR TITLE
support passing `i128` to assembly on `aarch64`

### DIFF
--- a/compiler/rustc_target/src/asm/aarch64.rs
+++ b/compiler/rustc_target/src/asm/aarch64.rs
@@ -57,15 +57,26 @@ impl AArch64InlineAsmRegClass {
     pub fn supported_types(
         self,
         _arch: InlineAsmArch,
+        allow_experimental_reg: bool,
     ) -> &'static [(InlineAsmType, Option<Symbol>)] {
         match self {
             Self::reg => types! { _: I8, I16, I32, I64, F16, F32, F64; },
-            Self::vreg | Self::vreg_low16 => types! {
-                neon: I8, I16, I32, I64, F16, F32, F64, F128,
-                    VecI8(8), VecI16(4), VecI32(2), VecI64(1), VecF16(4), VecF32(2), VecF64(1),
-                    VecI8(16), VecI16(8), VecI32(4), VecI64(2), VecF16(8), VecF32(4), VecF64(2);
+            Self::vreg | Self::vreg_low16 => {
                 // Note: When adding support for SVE vector types, they must be rejected for Arm64EC.
-            },
+                if allow_experimental_reg {
+                    types! {
+                    neon: I8, I16, I32, I64, I128, F16, F32, F64, F128,
+                        VecI8(8), VecI16(4), VecI32(2), VecI64(1), VecF16(4), VecF32(2), VecF64(1),
+                        VecI8(16), VecI16(8), VecI32(4), VecI64(2), VecF16(8), VecF32(4), VecF64(2);
+                    }
+                } else {
+                    types! {
+                    neon: I8, I16, I32, I64, F16, F32, F64, F128,
+                        VecI8(8), VecI16(4), VecI32(2), VecI64(1), VecF16(4), VecF32(2), VecF64(1),
+                        VecI8(16), VecI16(8), VecI32(4), VecI64(2), VecF16(8), VecF32(4), VecF64(2);
+                    }
+                }
+            }
             Self::preg => &[],
         }
     }

--- a/compiler/rustc_target/src/asm/mod.rs
+++ b/compiler/rustc_target/src/asm/mod.rs
@@ -649,7 +649,7 @@ impl InlineAsmRegClass {
         match self {
             Self::X86(r) => r.supported_types(arch, allow_experimental_reg).into(),
             Self::Arm(r) => r.supported_types(arch).into(),
-            Self::AArch64(r) => r.supported_types(arch).into(),
+            Self::AArch64(r) => r.supported_types(arch, allow_experimental_reg).into(),
             Self::Amdgpu(r) => r.supported_types(arch).into(),
             Self::RiscV(r) => r.supported_types(arch).into(),
             Self::Nvptx(r) => r.supported_types(arch).into(),

--- a/src/doc/unstable-book/src/language-features/asm-experimental-reg.md
+++ b/src/doc/unstable-book/src/language-features/asm-experimental-reg.md
@@ -24,6 +24,7 @@ This tracks support for additional registers in architectures where inline assem
 | x86 | `zmm_reg` | `avx512f` | `i128` |
 | LoongArch | `vreg` | `lsx` | `f32`, `f64`, <br> `i8x16`, `i16x8`, `i32x4`, `i64x2`, `f32x4`, `f64x2` |
 | LoongArch | `xreg` | `lasx` | `f32`, `f64`, <br> `i8x16`, `i16x8`, `i32x4`, `i64x2`, `f32x4`, `f64x2`, <br> `i8x32`, `i16x16`, `i32x8`, `i64x4`, `f32x8`, `f64x4` |
+| aarch64 | `vreg` | `neon` | `i128` |
 
 ## Register aliases
 

--- a/tests/assembly-llvm/asm/aarch64-i128.rs
+++ b/tests/assembly-llvm/asm/aarch64-i128.rs
@@ -1,0 +1,132 @@
+//@ add-minicore
+//@ revisions: aarch64 aarch64_be arm64ec
+//@ assembly-output: emit-asm
+//@ [aarch64] compile-flags: --target aarch64-unknown-linux-gnu
+//@ [aarch64] needs-llvm-components: aarch64
+//@ [aarch64_be] compile-flags: --target aarch64_be-unknown-linux-gnu
+//@ [aarch64_be] needs-llvm-components: aarch64
+//@ [arm64ec] compile-flags: --target arm64ec-pc-windows-msvc
+//@ [arm64ec] needs-llvm-components: aarch64
+//@ compile-flags: -Zmerge-functions=disabled
+
+#![feature(no_core, f128, asm_experimental_reg)]
+#![crate_type = "rlib"]
+#![no_core]
+#![allow(non_camel_case_types)]
+
+// Check how a 128-bit integer is passed to assembly. Note that on aarch64_be for i128
+// the two 64-bit chunks are endian-swapped, while a SIMD type is passed as-is.
+
+extern crate minicore;
+use minicore::simd::*;
+use minicore::*;
+
+macro_rules! check {
+    ($func:ident $ty:ident $class:ident $mov:literal $modifier:literal) => {
+        #[no_mangle]
+        pub unsafe fn $func(x: $ty) -> $ty {
+            let y;
+            asm!(
+                concat!($mov, " {:", $modifier, "}, {:", $modifier, "}"),
+                out($class) y,
+                in($class) x
+            );
+            y
+        }
+    };
+}
+// FIXME(llvm23) arm64ec only supports f128 from LLVM23 onwards.
+//
+// aarch64_be-LABEL: {{("#)?}}vreg_f128{{"?}}
+// aarch64_be: rev64 v0.16b, v0.16b
+// aarch64_be: //APP
+// aarch64_be: fmov s{{[0-9]+}}, s{{[0-9]+}}
+// aarch64_be: //NO_APP
+// aarch64_be: rev64 v0.16b, v1.16b
+// aarch64_be: ret
+//
+// aarch64-LABEL: {{("#)?}}vreg_f128{{"?}}
+// aarch64: //APP
+// aarch64: fmov s{{[0-9]+}}, s{{[0-9]+}}
+// aarch64: //NO_APP
+// aarch64: ret
+#[cfg(target_arch = "aarch64")]
+check!(vreg_f128 f128 vreg "fmov" "s");
+
+// CHECK-LABEL: {{("#)?}}vreg_i128{{"?}}
+// CHECK: fmov d0, x0
+// CHECK: mov v0.d[1], x1
+// aarch64_be: rev64 v0.16b, v0.16b
+// CHECK: //APP
+// CHECK: fmov s{{[0-9]+}}, s{{[0-9]+}}
+// CHECK: //NO_APP
+// aarch64_be: rev64 v0.16b, v1.16b
+// CHECK: mov x1, v{{[0-9]+}}.d[1]
+// CHECK: fmov x0, d{{[0-9]+}}
+check!(vreg_i128 i128 vreg "fmov" "s");
+
+// CHECK-LABEL: {{("#)?}}vreg_i8x16{{"?}}
+// aarch64: ldr q0, [x0]
+// aarch64_be: ld1 { v0.16b }, [x0]
+// aarch64_be-NOT: rev64
+// CHECK: //APP
+// CHECK: fmov s{{[0-9]+}}, s{{[0-9]+}}
+// CHECK: //NO_APP
+// aarch64: str q1, [x8]
+// aarch64_be: st1 { v1.16b }, [x8]
+check!(vreg_i8x16 i8x16 vreg "fmov" "s");
+
+// CHECK-LABEL: {{("#)?}}vreg_i16x8{{"?}}
+// aarch64: ldr q0, [x0]
+// aarch64_be: ld1 { v0.16b }, [x0]
+// aarch64_be-NOT: rev64
+// CHECK: //APP
+// CHECK: fmov s{{[0-9]+}}, s{{[0-9]+}}
+// CHECK: //NO_APP
+// aarch64: str q1, [x8]
+// aarch64_be: st1 { v1.16b }, [x8]
+check!(vreg_i16x8 i16x8 vreg "fmov" "s");
+
+// CHECK-LABEL: {{("#)?}}vreg_i32x4{{"?}}
+// aarch64: ldr q0, [x0]
+// aarch64_be: ld1 { v0.16b }, [x0]
+// aarch64_be-NOT: rev64
+// CHECK: //APP
+// CHECK: fmov s{{[0-9]+}}, s{{[0-9]+}}
+// CHECK: //NO_APP
+// aarch64: str q1, [x8]
+// aarch64_be: st1 { v1.16b }, [x8]
+check!(vreg_i32x4 i32x4 vreg "fmov" "s");
+
+// CHECK-LABEL: {{("#)?}}vreg_i64x2{{"?}}
+// aarch64: ldr q0, [x0]
+// aarch64_be: ld1 { v0.16b }, [x0]
+// aarch64_be-NOT: rev64
+// CHECK: //APP
+// CHECK: fmov s{{[0-9]+}}, s{{[0-9]+}}
+// CHECK: //NO_APP
+// aarch64: str q1, [x8]
+// aarch64_be: st1 { v1.16b }, [x8]
+check!(vreg_i64x2 i64x2 vreg "fmov" "s");
+
+// CHECK-LABEL: {{("#)?}}vreg_i16x4{{"?}}
+// aarch64: ldr d0, [x0]
+// aarch64_be: ldr d0, [x0]
+// aarch64_be-NOT: rev64
+// CHECK: //APP
+// CHECK: fmov s{{[0-9]+}}, s{{[0-9]+}}
+// CHECK: //NO_APP
+// aarch64: str d1, [x8]
+// aarch64_be: str d1, [x8]
+check!(vreg_i16x4 i16x4 vreg "fmov" "s");
+
+// CHECK-LABEL: {{("#)?}}vreg_i32x2{{"?}}
+// aarch64: ldr d0, [x0]
+// aarch64_be: ldr d0, [x0]
+// aarch64_be-NOT: rev64
+// CHECK: //APP
+// CHECK: fmov s{{[0-9]+}}, s{{[0-9]+}}
+// CHECK: //NO_APP
+// aarch64: str d1, [x8]
+// aarch64_be: str d1, [x8]
+check!(vreg_i32x2 i32x2 vreg "fmov" "s");

--- a/tests/assembly-llvm/asm/aarch64-types.rs
+++ b/tests/assembly-llvm/asm/aarch64-types.rs
@@ -9,7 +9,7 @@
 //@ [arm64ec] needs-llvm-components: aarch64
 //@ compile-flags: -Zmerge-functions=disabled
 
-#![feature(no_core, f16, f128)]
+#![feature(no_core, f16, f128, asm_experimental_reg)]
 #![crate_type = "rlib"]
 #![no_core]
 #![allow(asm_sub_register, non_camel_case_types)]
@@ -176,6 +176,12 @@ check!(vreg_i64 i64 vreg "fmov" "s");
 // CHECK: fmov s{{[0-9]+}}, s{{[0-9]+}}
 // CHECK: //NO_APP
 check!(vreg_f64 f64 vreg "fmov" "s");
+
+// CHECK-LABEL: {{("#)?}}vreg_i128{{"?}}
+// CHECK: //APP
+// CHECK: fmov s{{[0-9]+}}, s{{[0-9]+}}
+// CHECK: //NO_APP
+check!(vreg_i128 i128 vreg "fmov" "s");
 
 // CHECK-LABEL: {{("#)?}}vreg_f128{{"?}}
 // CHECK: //APP

--- a/tests/ui/asm/aarch64/bad-reg.experimental_reg.stderr
+++ b/tests/ui/asm/aarch64/bad-reg.experimental_reg.stderr
@@ -1,5 +1,5 @@
 error: invalid register class `foo`: unknown register class
-  --> $DIR/bad-reg.rs:18:20
+  --> $DIR/bad-reg.rs:20:20
    |
 LL |         asm!("{}", in(foo) foo);
    |                    ^^^^^^^^^^^
@@ -7,13 +7,13 @@ LL |         asm!("{}", in(foo) foo);
    = note: the following register classes are supported on this target: `reg`, `vreg`, `vreg_low16`, and `preg`
 
 error: invalid register `foo`: unknown register
-  --> $DIR/bad-reg.rs:20:18
+  --> $DIR/bad-reg.rs:22:18
    |
 LL |         asm!("", in("foo") foo);
    |                  ^^^^^^^^^^^^^
 
 error: invalid asm template modifier `z` for this register class
-  --> $DIR/bad-reg.rs:22:15
+  --> $DIR/bad-reg.rs:24:15
    |
 LL |         asm!("{:z}", in(reg) foo);
    |               ^^^^   ----------- argument
@@ -23,7 +23,7 @@ LL |         asm!("{:z}", in(reg) foo);
    = note: the `reg` register class supports the following template modifiers: `w` and `x`
 
 error: invalid asm template modifier `r` for this register class
-  --> $DIR/bad-reg.rs:24:15
+  --> $DIR/bad-reg.rs:26:15
    |
 LL |         asm!("{:r}", in(vreg) foo);
    |               ^^^^   ------------ argument
@@ -33,7 +33,7 @@ LL |         asm!("{:r}", in(vreg) foo);
    = note: the `vreg` register class supports the following template modifiers: `b`, `h`, `s`, `d`, `q`, and `v`
 
 error: invalid asm template modifier `r` for this register class
-  --> $DIR/bad-reg.rs:26:15
+  --> $DIR/bad-reg.rs:28:15
    |
 LL |         asm!("{:r}", in(vreg_low16) foo);
    |               ^^^^   ------------------ argument
@@ -43,7 +43,7 @@ LL |         asm!("{:r}", in(vreg_low16) foo);
    = note: the `vreg_low16` register class supports the following template modifiers: `b`, `h`, `s`, `d`, `q`, and `v`
 
 error: asm template modifiers are not allowed for `const` arguments
-  --> $DIR/bad-reg.rs:28:15
+  --> $DIR/bad-reg.rs:30:15
    |
 LL |         asm!("{:a}", const 0);
    |               ^^^^   ------- argument
@@ -51,7 +51,7 @@ LL |         asm!("{:a}", const 0);
    |               template modifier
 
 error: asm template modifiers are not allowed for `sym` arguments
-  --> $DIR/bad-reg.rs:30:15
+  --> $DIR/bad-reg.rs:32:15
    |
 LL |         asm!("{:a}", sym main);
    |               ^^^^   -------- argument
@@ -59,49 +59,49 @@ LL |         asm!("{:a}", sym main);
    |               template modifier
 
 error: invalid register `x29`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:32:18
+  --> $DIR/bad-reg.rs:34:18
    |
 LL |         asm!("", in("x29") foo);
    |                  ^^^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:34:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", in("sp") foo);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `xzr`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:36:18
+  --> $DIR/bad-reg.rs:38:18
    |
 LL |         asm!("", in("xzr") foo);
    |                  ^^^^^^^^^^^^^
 
 error: invalid register `x19`: x19 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:40:18
    |
 LL |         asm!("", in("x19") foo);
    |                  ^^^^^^^^^^^^^
 
 error: register class `preg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:41:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", in("p0") foo);
    |                  ^^^^^^^^^^^^
 
 error: register class `preg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:45:20
+  --> $DIR/bad-reg.rs:47:20
    |
 LL |         asm!("{}", in(preg) foo);
    |                    ^^^^^^^^^^^^
 
 error: register class `preg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:48:20
+  --> $DIR/bad-reg.rs:50:20
    |
 LL |         asm!("{}", out(preg) _);
    |                    ^^^^^^^^^^^
 
 error: register `w0` conflicts with register `x0`
-  --> $DIR/bad-reg.rs:54:32
+  --> $DIR/bad-reg.rs:56:32
    |
 LL |         asm!("", in("x0") foo, in("w0") bar);
    |                  ------------  ^^^^^^^^^^^^ register `w0`
@@ -109,7 +109,7 @@ LL |         asm!("", in("x0") foo, in("w0") bar);
    |                  register `x0`
 
 error: register `x0` conflicts with register `x0`
-  --> $DIR/bad-reg.rs:56:32
+  --> $DIR/bad-reg.rs:58:32
    |
 LL |         asm!("", in("x0") foo, out("x0") bar);
    |                  ------------  ^^^^^^^^^^^^^ register `x0`
@@ -117,13 +117,13 @@ LL |         asm!("", in("x0") foo, out("x0") bar);
    |                  register `x0`
    |
 help: use `lateout` instead of `out` to avoid conflict
-  --> $DIR/bad-reg.rs:56:18
+  --> $DIR/bad-reg.rs:58:18
    |
 LL |         asm!("", in("x0") foo, out("x0") bar);
    |                  ^^^^^^^^^^^^
 
 error: register `q0` conflicts with register `v0`
-  --> $DIR/bad-reg.rs:59:32
+  --> $DIR/bad-reg.rs:61:32
    |
 LL |         asm!("", in("v0") foo, in("q0") bar);
    |                  ------------  ^^^^^^^^^^^^ register `q0`
@@ -131,7 +131,7 @@ LL |         asm!("", in("v0") foo, in("q0") bar);
    |                  register `v0`
 
 error: register `q0` conflicts with register `v0`
-  --> $DIR/bad-reg.rs:61:32
+  --> $DIR/bad-reg.rs:63:32
    |
 LL |         asm!("", in("v0") foo, out("q0") bar);
    |                  ------------  ^^^^^^^^^^^^^ register `q0`
@@ -139,13 +139,13 @@ LL |         asm!("", in("v0") foo, out("q0") bar);
    |                  register `v0`
    |
 help: use `lateout` instead of `out` to avoid conflict
-  --> $DIR/bad-reg.rs:61:18
+  --> $DIR/bad-reg.rs:63:18
    |
 LL |         asm!("", in("v0") foo, out("q0") bar);
    |                  ^^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:41:27
+  --> $DIR/bad-reg.rs:43:27
    |
 LL |         asm!("", in("p0") foo);
    |                           ^^^
@@ -153,7 +153,7 @@ LL |         asm!("", in("p0") foo);
    = note: register class `preg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:45:29
+  --> $DIR/bad-reg.rs:47:29
    |
 LL |         asm!("{}", in(preg) foo);
    |                             ^^^

--- a/tests/ui/asm/aarch64/bad-reg.rs
+++ b/tests/ui/asm/aarch64/bad-reg.rs
@@ -1,7 +1,9 @@
 //@ add-minicore
+//@ revisions: stable experimental_reg
 //@ compile-flags: --target aarch64-unknown-linux-gnu -C target-feature=+neon
 //@ needs-llvm-components: aarch64
 //@ ignore-backends: gcc
+#![cfg_attr(experimental_reg, feature(asm_experimental_reg))]
 #![crate_type = "lib"]
 #![feature(no_core)]
 #![no_core]
@@ -61,5 +63,12 @@ fn main() {
         asm!("", in("v0") foo, out("q0") bar);
         //~^ ERROR register `q0` conflicts with register `v0`
         asm!("", in("v0") foo, lateout("q0") bar);
+
+        // Passing u128/i128 is currently experimental.
+        let mut v = 0u128;
+        asm!("/* {:v} */", in(vreg) v); // requires asm_experimental_reg
+        //[stable]~^ ERROR type `u128` cannot be used with this register class in stable
+        asm!("/* {:v} */", out(vreg) v); // requires asm_experimental_reg
+        //[stable]~^ ERROR type `u128` cannot be used with this register class in stable
     }
 }

--- a/tests/ui/asm/aarch64/bad-reg.stable.stderr
+++ b/tests/ui/asm/aarch64/bad-reg.stable.stderr
@@ -1,0 +1,185 @@
+error: invalid register class `foo`: unknown register class
+  --> $DIR/bad-reg.rs:20:20
+   |
+LL |         asm!("{}", in(foo) foo);
+   |                    ^^^^^^^^^^^
+   |
+   = note: the following register classes are supported on this target: `reg`, `vreg`, `vreg_low16`, and `preg`
+
+error: invalid register `foo`: unknown register
+  --> $DIR/bad-reg.rs:22:18
+   |
+LL |         asm!("", in("foo") foo);
+   |                  ^^^^^^^^^^^^^
+
+error: invalid asm template modifier `z` for this register class
+  --> $DIR/bad-reg.rs:24:15
+   |
+LL |         asm!("{:z}", in(reg) foo);
+   |               ^^^^   ----------- argument
+   |               |
+   |               template modifier
+   |
+   = note: the `reg` register class supports the following template modifiers: `w` and `x`
+
+error: invalid asm template modifier `r` for this register class
+  --> $DIR/bad-reg.rs:26:15
+   |
+LL |         asm!("{:r}", in(vreg) foo);
+   |               ^^^^   ------------ argument
+   |               |
+   |               template modifier
+   |
+   = note: the `vreg` register class supports the following template modifiers: `b`, `h`, `s`, `d`, `q`, and `v`
+
+error: invalid asm template modifier `r` for this register class
+  --> $DIR/bad-reg.rs:28:15
+   |
+LL |         asm!("{:r}", in(vreg_low16) foo);
+   |               ^^^^   ------------------ argument
+   |               |
+   |               template modifier
+   |
+   = note: the `vreg_low16` register class supports the following template modifiers: `b`, `h`, `s`, `d`, `q`, and `v`
+
+error: asm template modifiers are not allowed for `const` arguments
+  --> $DIR/bad-reg.rs:30:15
+   |
+LL |         asm!("{:a}", const 0);
+   |               ^^^^   ------- argument
+   |               |
+   |               template modifier
+
+error: asm template modifiers are not allowed for `sym` arguments
+  --> $DIR/bad-reg.rs:32:15
+   |
+LL |         asm!("{:a}", sym main);
+   |               ^^^^   -------- argument
+   |               |
+   |               template modifier
+
+error: invalid register `x29`: the frame pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:34:18
+   |
+LL |         asm!("", in("x29") foo);
+   |                  ^^^^^^^^^^^^^
+
+error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:36:18
+   |
+LL |         asm!("", in("sp") foo);
+   |                  ^^^^^^^^^^^^
+
+error: invalid register `xzr`: the zero register cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:38:18
+   |
+LL |         asm!("", in("xzr") foo);
+   |                  ^^^^^^^^^^^^^
+
+error: invalid register `x19`: x19 is used internally by LLVM and cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:40:18
+   |
+LL |         asm!("", in("x19") foo);
+   |                  ^^^^^^^^^^^^^
+
+error: register class `preg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:43:18
+   |
+LL |         asm!("", in("p0") foo);
+   |                  ^^^^^^^^^^^^
+
+error: register class `preg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:47:20
+   |
+LL |         asm!("{}", in(preg) foo);
+   |                    ^^^^^^^^^^^^
+
+error: register class `preg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:50:20
+   |
+LL |         asm!("{}", out(preg) _);
+   |                    ^^^^^^^^^^^
+
+error: register `w0` conflicts with register `x0`
+  --> $DIR/bad-reg.rs:56:32
+   |
+LL |         asm!("", in("x0") foo, in("w0") bar);
+   |                  ------------  ^^^^^^^^^^^^ register `w0`
+   |                  |
+   |                  register `x0`
+
+error: register `x0` conflicts with register `x0`
+  --> $DIR/bad-reg.rs:58:32
+   |
+LL |         asm!("", in("x0") foo, out("x0") bar);
+   |                  ------------  ^^^^^^^^^^^^^ register `x0`
+   |                  |
+   |                  register `x0`
+   |
+help: use `lateout` instead of `out` to avoid conflict
+  --> $DIR/bad-reg.rs:58:18
+   |
+LL |         asm!("", in("x0") foo, out("x0") bar);
+   |                  ^^^^^^^^^^^^
+
+error: register `q0` conflicts with register `v0`
+  --> $DIR/bad-reg.rs:61:32
+   |
+LL |         asm!("", in("v0") foo, in("q0") bar);
+   |                  ------------  ^^^^^^^^^^^^ register `q0`
+   |                  |
+   |                  register `v0`
+
+error: register `q0` conflicts with register `v0`
+  --> $DIR/bad-reg.rs:63:32
+   |
+LL |         asm!("", in("v0") foo, out("q0") bar);
+   |                  ------------  ^^^^^^^^^^^^^ register `q0`
+   |                  |
+   |                  register `v0`
+   |
+help: use `lateout` instead of `out` to avoid conflict
+  --> $DIR/bad-reg.rs:63:18
+   |
+LL |         asm!("", in("v0") foo, out("q0") bar);
+   |                  ^^^^^^^^^^^^
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:43:27
+   |
+LL |         asm!("", in("p0") foo);
+   |                           ^^^
+   |
+   = note: register class `preg` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:47:29
+   |
+LL |         asm!("{}", in(preg) foo);
+   |                             ^^^
+   |
+   = note: register class `preg` supports these types: 
+
+error[E0658]: type `u128` cannot be used with this register class in stable
+  --> $DIR/bad-reg.rs:69:37
+   |
+LL |         asm!("/* {:v} */", in(vreg) v); // requires asm_experimental_reg
+   |                                     ^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: type `u128` cannot be used with this register class in stable
+  --> $DIR/bad-reg.rs:71:38
+   |
+LL |         asm!("/* {:v} */", out(vreg) v); // requires asm_experimental_reg
+   |                                      ^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 22 previous errors
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/133416

Like https://github.com/rust-lang/rust/pull/151059 but for `aarch64`. LLVM supports this, so I think we should too. I've put this under `asm_experimental_reg`.

cc @taiki-e
r? @Amanieu