### PR TITLE
[beta] backports

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -702,7 +702,9 @@ pub(crate) fn global_llvm_features(sess: &Session, only_base_features: bool) -> 
 
                 features_string
             };
-            features.extend(features_string.split(',').map(String::from));
+            if !features_string.is_empty() {
+                features.extend(features_string.split(',').map(String::from));
+            }
         }
         Some(_) | None => {}
     };

--- a/library/std/src/os/windows/fs.rs
+++ b/library/std/src/os/windows/fs.rs
@@ -138,6 +138,8 @@ impl FileExt for fs::File {
 }
 
 /// Windows-specific extensions to [`fs::OpenOptions`].
+// WARNING: This trait is not sealed. DON'T add any new methods!
+// Add them to OpenOptionsExt2 instead.
 #[stable(feature = "open_options_ext", since = "1.10.0")]
 pub trait OpenOptionsExt {
     /// Overrides the `dwDesiredAccess` argument to the call to [`CreateFile`]
@@ -305,18 +307,6 @@ pub trait OpenOptionsExt {
     ///     https://docs.microsoft.com/en-us/windows/win32/api/winnt/ne-winnt-security_impersonation_level
     #[stable(feature = "open_options_ext", since = "1.10.0")]
     fn security_qos_flags(&mut self, flags: u32) -> &mut Self;
-
-    /// If set to `true`, prevent the "last access time" of the file from being changed.
-    ///
-    /// Default to `false`.
-    #[unstable(feature = "windows_freeze_file_times", issue = "149715")]
-    fn freeze_last_access_time(&mut self, freeze: bool) -> &mut Self;
-
-    /// If set to `true`, prevent the "last write time" of the file from being changed.
-    ///
-    /// Default to `false`.
-    #[unstable(feature = "windows_freeze_file_times", issue = "149715")]
-    fn freeze_last_write_time(&mut self, freeze: bool) -> &mut Self;
 }
 
 #[stable(feature = "open_options_ext", since = "1.10.0")]
@@ -345,7 +335,28 @@ impl OpenOptionsExt for OpenOptions {
         self.as_inner_mut().security_qos_flags(flags);
         self
     }
+}
 
+#[unstable(feature = "windows_freeze_file_times", issue = "149715")]
+pub trait OpenOptionsExt2: Sealed {
+    /// If set to `true`, prevent the "last access time" of the file from being changed.
+    ///
+    /// Default to `false`.
+    #[unstable(feature = "windows_freeze_file_times", issue = "149715")]
+    fn freeze_last_access_time(&mut self, freeze: bool) -> &mut Self;
+
+    /// If set to `true`, prevent the "last write time" of the file from being changed.
+    ///
+    /// Default to `false`.
+    #[unstable(feature = "windows_freeze_file_times", issue = "149715")]
+    fn freeze_last_write_time(&mut self, freeze: bool) -> &mut Self;
+}
+
+#[unstable(feature = "sealed", issue = "none")]
+impl Sealed for OpenOptions {}
+
+#[unstable(feature = "windows_freeze_file_times", issue = "149715")]
+impl OpenOptionsExt2 for OpenOptions {
     fn freeze_last_access_time(&mut self, freeze: bool) -> &mut Self {
         self.as_inner_mut().freeze_last_access_time(freeze);
         self

--- a/tests/run-make/target-cpu-native/foo.rs
+++ b/tests/run-make/target-cpu-native/foo.rs
@@ -1,1 +1,9 @@
 fn main() {}
+
+// This forces explicit emission of a +neon target feature on targets
+// where it is implied by the target-cpu, like aarch64-apple-darwin.
+// This is a regression test for #153397.
+#[cfg(target_feature = "neon")]
+#[target_feature(enable = "neon")]
+#[unsafe(no_mangle)]
+pub fn with_neon() {}

--- a/tests/run-make/target-cpu-native/rmake.rs
+++ b/tests/run-make/target-cpu-native/rmake.rs
@@ -8,7 +8,12 @@
 use run_make_support::{run, rustc};
 
 fn main() {
-    let out = rustc().input("foo.rs").arg("-Ctarget-cpu=native").run().stderr_utf8();
+    let out = rustc()
+        .input("foo.rs")
+        .arg("-Ctarget-cpu=native")
+        .arg("-Zverify-llvm-ir")
+        .run()
+        .stderr_utf8();
     run("foo");
     // There should be zero warnings emitted - the bug would cause "unknown CPU `native`"
     // to be printed out.


### PR DESCRIPTION
- Update cargo
- https://github.com/rust-lang/rust/pull/153763: Don't add empty target features for target-cpu=native on macOS 
- https://github.com/rust-lang/rust/pull/153491: Move `freeze_*` methods to `OpenOptionsExt2`