### PR TITLE
Add more tests for the parallel frontend

### DIFF
--- a/tests/ui/parallel-rustc/assert-found_cycle-issue-115223.rs
+++ b/tests/ui/parallel-rustc/assert-found_cycle-issue-115223.rs
@@ -1,0 +1,31 @@
+// Test for #115223, which causes a deadlock bug without finding the cycle
+//@ build-pass
+#![crate_name = "foo"]
+
+use std::ops;
+
+pub struct Foo;
+
+impl Foo {
+    pub fn foo(&mut self) {}
+}
+
+pub struct Bar {
+    foo: Foo,
+}
+
+impl ops::Deref for Bar {
+    type Target = Foo;
+
+    fn deref(&self) -> &Foo {
+        &self.foo
+    }
+}
+
+impl ops::DerefMut for Bar {
+    fn deref_mut(&mut self) -> &mut Foo {
+        &mut self.foo
+    }
+}
+
+fn main() {}

--- a/tests/ui/parallel-rustc/default-trait-shadow-cycle-issue-151358.rs
+++ b/tests/ui/parallel-rustc/default-trait-shadow-cycle-issue-151358.rs
@@ -1,0 +1,12 @@
+// Test for #151358, assertion failed: !worker_thread.is_null()
+//~^ ERROR cycle detected when looking up span for `Default`
+//
+//@ compile-flags: -Z threads=2
+//@ compare-output-by-lines
+
+trait Default {}
+use std::num::NonZero;
+fn main() {
+    NonZero();
+    todo!();
+}

--- a/tests/ui/parallel-rustc/default-trait-shadow-cycle-issue-151358.stderr
+++ b/tests/ui/parallel-rustc/default-trait-shadow-cycle-issue-151358.stderr
@@ -1,0 +1,9 @@
+error[E0391]: cycle detected when looking up span for `Default`
+   |
+   = note: ...which immediately requires looking up span for `Default` again
+   = note: cycle used when perform lints prior to AST lowering
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/parallel-rustc/generic-const-exprs-deadlock-issue-120757.rs
+++ b/tests/ui/parallel-rustc/generic-const-exprs-deadlock-issue-120757.rs
@@ -1,0 +1,127 @@
+// Test for #120757, deadlock due to query cycle
+
+#![feature(generic_const_exprs)]
+
+trait TensorDimension {
+    const DIM: usize;
+    const ISSCALAR: bool = Self::DIM == 0;
+    fn is_scalar(&self) -> bool {
+        Self::ISSCALAR
+    }
+}
+
+trait TensorSize: TensorDimension {
+    fn size(&self) -> [usize; Self::DIM];
+    fn inbounds(&self, index: [usize; Self::DIM]) -> bool {
+        index.iter().zip(self.size().iter()).all(|(i, s)| i < s)
+    }
+}
+
+trait Broadcastable: TensorSize + Sized {
+    type Element;
+    fn bget(&self, index: [usize; Self::DIM]) -> Option<Self::Element>;
+    fn lazy_updim<const NEWDIM: usize>(
+        &self,
+        size: [usize; NEWDIM],
+    ) -> LazyUpdim<Self, { Self::DIM }, NEWDIM> {
+        assert!(
+            NEWDIM >= Self::DIM,
+            "Updimmed tensor cannot have fewer indices than the initial one."
+        );
+        LazyUpdim { size, reference: &self }
+    }
+    fn bmap<T, F: Fn(Self::Element) -> T>(&self, foo: F) -> BMap<T, Self, F, { Self::DIM }> {
+        BMap { reference: self, closure: foo }
+    }
+}
+
+struct LazyUpdim<'a, T: Broadcastable, const OLDDIM: usize, const DIM: usize> {
+    size: [usize; DIM],
+    reference: &'a T,
+}
+
+impl<'a, T: Broadcastable, const DIM: usize> TensorDimension for LazyUpdim<'a, T, { T::DIM }, DIM> {
+    const DIM: usize = DIM;
+}
+impl<'a, T: Broadcastable, const DIM: usize> TensorSize for LazyUpdim<'a, T, { T::DIM }, DIM> {
+    fn size(&self) -> [usize; DIM] {
+    //~^ ERROR method not compatible with trait
+        self.size
+    }
+}
+impl<'a, T: Broadcastable, const DIM: usize> Broadcastable for LazyUpdim<'a, T, { T::DIM }, DIM> {
+    type Element = T::Element;
+    fn bget(&self, index: [usize; DIM]) -> Option<Self::Element> {
+    //~^ ERROR method not compatible with trait
+        assert!(DIM >= T::DIM);
+        if !self.inbounds(index) {
+        //~^ ERROR unconstrained generic constant
+        //~| ERROR mismatched types
+            return None;
+        }
+        let size = self.size();
+        //~^ ERROR unconstrained generic constant
+
+        let newindex: [usize; T::DIM] = Default::default();
+        //~^ ERROR the trait bound `[usize; T::DIM]: Default` is not satisfied
+        self.reference.bget(newindex)
+    }
+}
+
+struct BMap<'a, R, T: Broadcastable, F: Fn(T::Element) -> R, const DIM: usize> {
+    reference: &'a T,
+    closure: F,
+}
+
+impl<'a, R, T: Broadcastable, F: Fn(T::Element) -> R, const DIM: usize> TensorDimension
+    for BMap<'a, R, T, F, DIM>
+{
+    const DIM: usize = DIM;
+}
+impl<'a, R, T: Broadcastable, F: Fn(T::Element) -> R, const DIM: usize> TensorSize
+    for BMap<'a, R, T, F, DIM>
+{
+    fn size(&self) -> [usize; DIM] {
+    //~^ ERROR method not compatible with trait
+        self.reference.size()
+        //~^ ERROR unconstrained generic constant
+        //~| ERROR mismatched types
+    }
+}
+impl<'a, R, T: Broadcastable, F: Fn(T::Element) -> R, const DIM: usize> Broadcastable
+    for BMap<'a, R, T, F, DIM>
+{
+    type Element = R;
+    fn bget(&self, index: [usize; DIM]) -> Option<Self::Element> {
+    //~^ ERROR method not compatible with trait
+        self.reference.bget(index).map(ns_window)
+        //~^ ERROR unconstrained generic constant
+        //~| ERROR mismatched types
+        //~| ERROR cannot find value `ns_window` in this scope
+    }
+}
+
+impl<T> TensorDimension for Vec<T> {
+    const DIM: usize = 1;
+}
+impl<T> TensorSize for Vec<T> {
+    fn size(&self) -> [usize; 1] {
+    //~^ ERROR method not compatible with trait
+        [self.len()]
+    }
+}
+impl<T: Clone> Broadcastable for Vec<T> {
+    type Element = T;
+    fn bget(&self, index: [usize; 1]) -> Option<T> {
+    //~^ ERROR method not compatible with trait
+        self.get(index[0]).cloned()
+    }
+}
+
+fn main() {
+    let v = vec![1, 2, 3];
+    let bv = v.lazy_updim([3, 4]);
+    let bbv = bv.bmap(|x| x * x);
+
+    println!("The size of v is {:?}", bbv.bget([0, 2]).expect("Out of bounds."));
+}

--- a/tests/ui/parallel-rustc/generic-const-exprs-deadlock-issue-120757.stderr
+++ b/tests/ui/parallel-rustc/generic-const-exprs-deadlock-issue-120757.stderr
@@ -1,0 +1,166 @@
+error[E0425]: cannot find value `ns_window` in this scope
+  --> $DIR/generic-const-exprs-deadlock-issue-120757.rs:97:40
+   |
+LL |         self.reference.bget(index).map(ns_window)
+   |                                        ^^^^^^^^^ not found in this scope
+
+error[E0308]: method not compatible with trait
+  --> $DIR/generic-const-exprs-deadlock-issue-120757.rs:47:5
+   |
+LL |     fn size(&self) -> [usize; DIM] {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Self::DIM`, found `DIM`
+   |
+   = note: expected constant `Self::DIM`
+              found constant `DIM`
+
+error[E0308]: method not compatible with trait
+  --> $DIR/generic-const-exprs-deadlock-issue-120757.rs:54:5
+   |
+LL |     fn bget(&self, index: [usize; DIM]) -> Option<Self::Element> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Self::DIM`, found `DIM`
+   |
+   = note: expected constant `Self::DIM`
+              found constant `DIM`
+
+error[E0308]: method not compatible with trait
+  --> $DIR/generic-const-exprs-deadlock-issue-120757.rs:84:5
+   |
+LL |     fn size(&self) -> [usize; DIM] {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Self::DIM`, found `DIM`
+   |
+   = note: expected constant `Self::DIM`
+              found constant `DIM`
+
+error[E0308]: method not compatible with trait
+  --> $DIR/generic-const-exprs-deadlock-issue-120757.rs:95:5
+   |
+LL |     fn bget(&self, index: [usize; DIM]) -> Option<Self::Element> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Self::DIM`, found `DIM`
+   |
+   = note: expected constant `Self::DIM`
+              found constant `DIM`
+
+error[E0308]: method not compatible with trait
+  --> $DIR/generic-const-exprs-deadlock-issue-120757.rs:108:5
+   |
+LL |     fn size(&self) -> [usize; 1] {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Self::DIM`, found `1`
+   |
+   = note: expected constant `Self::DIM`
+              found constant `1`
+
+error[E0308]: method not compatible with trait
+  --> $DIR/generic-const-exprs-deadlock-issue-120757.rs:115:5
+   |
+LL |     fn bget(&self, index: [usize; 1]) -> Option<T> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Self::DIM`, found `1`
+   |
+   = note: expected constant `Self::DIM`
+              found constant `1`
+
+error: unconstrained generic constant
+  --> $DIR/generic-const-exprs-deadlock-issue-120757.rs:57:13
+   |
+LL |         if !self.inbounds(index) {
+   |             ^^^^
+   |
+note: required by a bound in `TensorSize::inbounds`
+  --> $DIR/generic-const-exprs-deadlock-issue-120757.rs:15:39
+   |
+LL |     fn inbounds(&self, index: [usize; Self::DIM]) -> bool {
+   |                                       ^^^^^^^^^ required by this bound in `TensorSize::inbounds`
+help: try adding a `where` bound
+   |
+LL |     fn bget(&self, index: [usize; DIM]) -> Option<Self::Element> where [(); Self::DIM]: {
+   |                                                                  ++++++++++++++++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/generic-const-exprs-deadlock-issue-120757.rs:57:27
+   |
+LL |         if !self.inbounds(index) {
+   |                           ^^^^^ expected `Self::DIM`, found `DIM`
+   |
+   = note: expected constant `Self::DIM`
+              found constant `DIM`
+
+error: unconstrained generic constant
+  --> $DIR/generic-const-exprs-deadlock-issue-120757.rs:62:25
+   |
+LL |         let size = self.size();
+   |                         ^^^^
+   |
+note: required by a bound in `TensorSize::size`
+  --> $DIR/generic-const-exprs-deadlock-issue-120757.rs:14:31
+   |
+LL |     fn size(&self) -> [usize; Self::DIM];
+   |                               ^^^^^^^^^ required by this bound in `TensorSize::size`
+help: try adding a `where` bound
+   |
+LL |     fn bget(&self, index: [usize; DIM]) -> Option<Self::Element> where [(); Self::DIM]: {
+   |                                                                  ++++++++++++++++++++++
+
+error[E0277]: the trait bound `[usize; T::DIM]: Default` is not satisfied
+  --> $DIR/generic-const-exprs-deadlock-issue-120757.rs:65:41
+   |
+LL |         let newindex: [usize; T::DIM] = Default::default();
+   |                                         ^^^^^^^^^^^^^^^^^^ the trait `Default` is not implemented for `[usize; T::DIM]`
+   |
+help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
+   |
+LL | impl<'a, T: Broadcastable, const DIM: usize> Broadcastable for LazyUpdim<'a, T, { T::DIM }, DIM> where [usize; T::DIM]: Default {
+   |                                                                                                  ++++++++++++++++++++++++++++++
+
+error: unconstrained generic constant
+  --> $DIR/generic-const-exprs-deadlock-issue-120757.rs:86:24
+   |
+LL |         self.reference.size()
+   |                        ^^^^
+   |
+note: required by a bound in `TensorSize::size`
+  --> $DIR/generic-const-exprs-deadlock-issue-120757.rs:14:31
+   |
+LL |     fn size(&self) -> [usize; Self::DIM];
+   |                               ^^^^^^^^^ required by this bound in `TensorSize::size`
+help: try adding a `where` bound
+   |
+LL |     fn size(&self) -> [usize; DIM] where [(); Self::DIM]: {
+   |                                    ++++++++++++++++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/generic-const-exprs-deadlock-issue-120757.rs:86:9
+   |
+LL |         self.reference.size()
+   |         ^^^^^^^^^^^^^^^^^^^^^ expected `DIM`, found `Self::DIM`
+   |
+   = note: expected constant `DIM`
+              found constant `Self::DIM`
+
+error: unconstrained generic constant
+  --> $DIR/generic-const-exprs-deadlock-issue-120757.rs:97:9
+   |
+LL |         self.reference.bget(index).map(ns_window)
+   |         ^^^^^^^^^^^^^^
+   |
+note: required by a bound in `Broadcastable::bget`
+  --> $DIR/generic-const-exprs-deadlock-issue-120757.rs:22:35
+   |
+LL |     fn bget(&self, index: [usize; Self::DIM]) -> Option<Self::Element>;
+   |                                   ^^^^^^^^^ required by this bound in `Broadcastable::bget`
+help: try adding a `where` bound
+   |
+LL |     fn bget(&self, index: [usize; DIM]) -> Option<Self::Element> where [(); Self::DIM]: {
+   |                                                                  ++++++++++++++++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/generic-const-exprs-deadlock-issue-120757.rs:97:29
+   |
+LL |         self.reference.bget(index).map(ns_window)
+   |                             ^^^^^ expected `Self::DIM`, found `DIM`
+   |
+   = note: expected constant `Self::DIM`
+              found constant `DIM`
+
+error: aborting due to 15 previous errors
+
+Some errors have detailed explanations: E0277, E0308, E0425.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/parallel-rustc/generic-const-exprs-deadlock-issue-134978.rs
+++ b/tests/ui/parallel-rustc/generic-const-exprs-deadlock-issue-134978.rs
@@ -1,0 +1,20 @@
+// Test for #134978, deadlock detected as we're unable to find a query cycle to break
+
+#![feature(generic_const_exprs)]
+
+pub struct Struct<const N: usize>;
+
+impl<const N: usize> Struct<N> {
+    pub const OK: usize = 0;
+}
+
+fn main() {
+    function::<0>();
+}
+
+fn function<const NUM_CARDS: usize>()
+where
+    [(); Struct::<{ NUM_CARDS + 0 }>::OK]:,
+    //~^ ERROR cycle detected when building an abstract representation
+{
+}

--- a/tests/ui/parallel-rustc/generic-const-exprs-deadlock-issue-134978.stderr
+++ b/tests/ui/parallel-rustc/generic-const-exprs-deadlock-issue-134978.stderr
@@ -1,0 +1,29 @@
+error[E0391]: cycle detected when building an abstract representation for `function::{constant#0}`
+  --> $DIR/generic-const-exprs-deadlock-issue-134978.rs:17:10
+   |
+LL |     [(); Struct::<{ NUM_CARDS + 0 }>::OK]:,
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: ...which requires building THIR for `function::{constant#0}`...
+  --> $DIR/generic-const-exprs-deadlock-issue-134978.rs:17:10
+   |
+LL |     [(); Struct::<{ NUM_CARDS + 0 }>::OK]:,
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires type-checking `function::{constant#0}`...
+  --> $DIR/generic-const-exprs-deadlock-issue-134978.rs:17:10
+   |
+LL |     [(); Struct::<{ NUM_CARDS + 0 }>::OK]:,
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which again requires building an abstract representation for `function::{constant#0}`, completing the cycle
+note: cycle used when checking that `function` is well-formed
+  --> $DIR/generic-const-exprs-deadlock-issue-134978.rs:15:1
+   |
+LL | / fn function<const NUM_CARDS: usize>()
+LL | | where
+LL | |     [(); Struct::<{ NUM_CARDS + 0 }>::OK]:,
+   | |___________________________________________^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/parallel-rustc/infer-unwrap-none-issue-120786.rs
+++ b/tests/ui/parallel-rustc/infer-unwrap-none-issue-120786.rs
@@ -1,0 +1,82 @@
+// Test for #120786, which causes an ice bug: infer: `None`
+
+fn no_err() {
+    |x: u32, y| x;
+    //~^ ERROR type annotations needed
+    let _ = String::from("x");
+}
+
+fn err() {
+    String::from("x".as_ref());
+    //~^ ERROR type annotations needed
+    //~| ERROR type annotations needed
+}
+
+fn arg_pat_closure_err() {
+    |x| String::from("x".as_ref());
+    //~^ ERROR type annotations needed
+    //~| ERROR type annotations needed
+}
+
+fn local_pat_closure_err() {
+    let _ = "x".as_ref();
+    //~^ ERROR type annotations needed
+}
+
+fn err_first_arg_pat() {
+    String::from("x".as_ref());
+    //~^ ERROR type annotations needed
+    //~| ERROR type annotations needed
+    |x: String| x;
+}
+
+fn err_second_arg_pat() {
+    |x: String| x;
+    String::from("x".as_ref());
+    //~^ ERROR type annotations needed
+    //~| ERROR type annotations needed
+}
+
+fn err_mid_arg_pat() {
+    |x: String| x;
+    |x: String| x;
+    |x: String| x;
+    |x: String| x;
+    String::from("x".as_ref());
+    //~^ ERROR type annotations needed
+    //~| ERROR type annotations needed
+    |x: String| x;
+    |x: String| x;
+    |x: String| x;
+    |x: String| x;
+}
+
+fn err_first_local_pat() {
+    String::from("x".as_ref());
+    //~^ ERROR type annotations needed
+    //~| ERROR type annotations needed
+    let _ = String::from("x");
+}
+
+fn err_second_local_pat() {
+    let _ = String::from("x");
+    String::from("x".as_ref());
+    //~^ ERROR type annotations needed
+    //~| ERROR type annotations needed
+}
+
+fn err_mid_local_pat() {
+    let _ = String::from("x");
+    let _ = String::from("x");
+    let _ = String::from("x");
+    let _ = String::from("x");
+    String::from("x".as_ref());
+    //~^ ERROR type annotations needed
+    //~| ERROR type annotations needed
+    let _ = String::from("x");
+    let _ = String::from("x");
+    let _ = String::from("x");
+    let _ = String::from("x");
+}
+
+fn main() {}

--- a/tests/ui/parallel-rustc/infer-unwrap-none-issue-120786.stderr
+++ b/tests/ui/parallel-rustc/infer-unwrap-none-issue-120786.stderr
@@ -1,0 +1,256 @@
+error[E0282]: type annotations needed
+  --> $DIR/infer-unwrap-none-issue-120786.rs:4:14
+   |
+LL |     |x: u32, y| x;
+   |              ^
+   |
+help: consider giving this closure parameter an explicit type
+   |
+LL |     |x: u32, y: /* Type */| x;
+   |               ++++++++++++
+
+error[E0283]: type annotations needed
+  --> $DIR/infer-unwrap-none-issue-120786.rs:10:5
+   |
+LL |     String::from("x".as_ref());
+   |     ^^^^^^ cannot infer type for reference `&_`
+   |
+   = note: multiple `impl`s satisfying `String: From<&_>` found in the `alloc` crate:
+           - impl From<&String> for String;
+           - impl From<&str> for String;
+
+error[E0283]: type annotations needed
+  --> $DIR/infer-unwrap-none-issue-120786.rs:10:22
+   |
+LL |     String::from("x".as_ref());
+   |                      ^^^^^^
+   |
+   = note: multiple `impl`s satisfying `str: AsRef<_>` found in the following crates: `core`, `std`:
+           - impl AsRef<ByteStr> for str;
+           - impl AsRef<OsStr> for str;
+           - impl AsRef<Path> for str;
+           - impl AsRef<[u8]> for str;
+           - impl AsRef<str> for str;
+help: try using a fully qualified path to specify the expected types
+   |
+LL -     String::from("x".as_ref());
+LL +     String::from(<str as AsRef<T>>::as_ref("x"));
+   |
+
+error[E0283]: type annotations needed
+  --> $DIR/infer-unwrap-none-issue-120786.rs:16:9
+   |
+LL |     |x| String::from("x".as_ref());
+   |         ^^^^^^ cannot infer type for reference `&_`
+   |
+   = note: multiple `impl`s satisfying `String: From<&_>` found in the `alloc` crate:
+           - impl From<&String> for String;
+           - impl From<&str> for String;
+
+error[E0283]: type annotations needed
+  --> $DIR/infer-unwrap-none-issue-120786.rs:16:26
+   |
+LL |     |x| String::from("x".as_ref());
+   |                          ^^^^^^
+   |
+   = note: multiple `impl`s satisfying `str: AsRef<_>` found in the following crates: `core`, `std`:
+           - impl AsRef<ByteStr> for str;
+           - impl AsRef<OsStr> for str;
+           - impl AsRef<Path> for str;
+           - impl AsRef<[u8]> for str;
+           - impl AsRef<str> for str;
+help: try using a fully qualified path to specify the expected types
+   |
+LL -     |x| String::from("x".as_ref());
+LL +     |x| String::from(<str as AsRef<T>>::as_ref("x"));
+   |
+
+error[E0283]: type annotations needed for `&_`
+  --> $DIR/infer-unwrap-none-issue-120786.rs:22:9
+   |
+LL |     let _ = "x".as_ref();
+   |         ^       ------ type must be known at this point
+   |
+   = note: multiple `impl`s satisfying `str: AsRef<_>` found in the following crates: `core`, `std`:
+           - impl AsRef<ByteStr> for str;
+           - impl AsRef<OsStr> for str;
+           - impl AsRef<Path> for str;
+           - impl AsRef<[u8]> for str;
+           - impl AsRef<str> for str;
+help: consider giving this pattern a type, where the type for type parameter `T` is specified
+   |
+LL |     let _: &T = "x".as_ref();
+   |          ++++
+
+error[E0283]: type annotations needed
+  --> $DIR/infer-unwrap-none-issue-120786.rs:27:5
+   |
+LL |     String::from("x".as_ref());
+   |     ^^^^^^ cannot infer type for reference `&_`
+   |
+   = note: multiple `impl`s satisfying `String: From<&_>` found in the `alloc` crate:
+           - impl From<&String> for String;
+           - impl From<&str> for String;
+
+error[E0283]: type annotations needed
+  --> $DIR/infer-unwrap-none-issue-120786.rs:27:22
+   |
+LL |     String::from("x".as_ref());
+   |                      ^^^^^^
+   |
+   = note: multiple `impl`s satisfying `str: AsRef<_>` found in the following crates: `core`, `std`:
+           - impl AsRef<ByteStr> for str;
+           - impl AsRef<OsStr> for str;
+           - impl AsRef<Path> for str;
+           - impl AsRef<[u8]> for str;
+           - impl AsRef<str> for str;
+help: try using a fully qualified path to specify the expected types
+   |
+LL -     String::from("x".as_ref());
+LL +     String::from(<str as AsRef<T>>::as_ref("x"));
+   |
+
+error[E0283]: type annotations needed
+  --> $DIR/infer-unwrap-none-issue-120786.rs:35:5
+   |
+LL |     String::from("x".as_ref());
+   |     ^^^^^^ cannot infer type for reference `&_`
+   |
+   = note: multiple `impl`s satisfying `String: From<&_>` found in the `alloc` crate:
+           - impl From<&String> for String;
+           - impl From<&str> for String;
+
+error[E0283]: type annotations needed
+  --> $DIR/infer-unwrap-none-issue-120786.rs:35:22
+   |
+LL |     String::from("x".as_ref());
+   |                      ^^^^^^
+   |
+   = note: multiple `impl`s satisfying `str: AsRef<_>` found in the following crates: `core`, `std`:
+           - impl AsRef<ByteStr> for str;
+           - impl AsRef<OsStr> for str;
+           - impl AsRef<Path> for str;
+           - impl AsRef<[u8]> for str;
+           - impl AsRef<str> for str;
+help: try using a fully qualified path to specify the expected types
+   |
+LL -     String::from("x".as_ref());
+LL +     String::from(<str as AsRef<T>>::as_ref("x"));
+   |
+
+error[E0283]: type annotations needed
+  --> $DIR/infer-unwrap-none-issue-120786.rs:45:5
+   |
+LL |     String::from("x".as_ref());
+   |     ^^^^^^ cannot infer type for reference `&_`
+   |
+   = note: multiple `impl`s satisfying `String: From<&_>` found in the `alloc` crate:
+           - impl From<&String> for String;
+           - impl From<&str> for String;
+
+error[E0283]: type annotations needed
+  --> $DIR/infer-unwrap-none-issue-120786.rs:45:22
+   |
+LL |     String::from("x".as_ref());
+   |                      ^^^^^^
+   |
+   = note: multiple `impl`s satisfying `str: AsRef<_>` found in the following crates: `core`, `std`:
+           - impl AsRef<ByteStr> for str;
+           - impl AsRef<OsStr> for str;
+           - impl AsRef<Path> for str;
+           - impl AsRef<[u8]> for str;
+           - impl AsRef<str> for str;
+help: try using a fully qualified path to specify the expected types
+   |
+LL -     String::from("x".as_ref());
+LL +     String::from(<str as AsRef<T>>::as_ref("x"));
+   |
+
+error[E0283]: type annotations needed
+  --> $DIR/infer-unwrap-none-issue-120786.rs:55:5
+   |
+LL |     String::from("x".as_ref());
+   |     ^^^^^^ cannot infer type for reference `&_`
+   |
+   = note: multiple `impl`s satisfying `String: From<&_>` found in the `alloc` crate:
+           - impl From<&String> for String;
+           - impl From<&str> for String;
+
+error[E0283]: type annotations needed
+  --> $DIR/infer-unwrap-none-issue-120786.rs:55:22
+   |
+LL |     String::from("x".as_ref());
+   |                      ^^^^^^
+   |
+   = note: multiple `impl`s satisfying `str: AsRef<_>` found in the following crates: `core`, `std`:
+           - impl AsRef<ByteStr> for str;
+           - impl AsRef<OsStr> for str;
+           - impl AsRef<Path> for str;
+           - impl AsRef<[u8]> for str;
+           - impl AsRef<str> for str;
+help: try using a fully qualified path to specify the expected types
+   |
+LL -     String::from("x".as_ref());
+LL +     String::from(<str as AsRef<T>>::as_ref("x"));
+   |
+
+error[E0283]: type annotations needed
+  --> $DIR/infer-unwrap-none-issue-120786.rs:63:5
+   |
+LL |     String::from("x".as_ref());
+   |     ^^^^^^ cannot infer type for reference `&_`
+   |
+   = note: multiple `impl`s satisfying `String: From<&_>` found in the `alloc` crate:
+           - impl From<&String> for String;
+           - impl From<&str> for String;
+
+error[E0283]: type annotations needed
+  --> $DIR/infer-unwrap-none-issue-120786.rs:63:22
+   |
+LL |     String::from("x".as_ref());
+   |                      ^^^^^^
+   |
+   = note: multiple `impl`s satisfying `str: AsRef<_>` found in the following crates: `core`, `std`:
+           - impl AsRef<ByteStr> for str;
+           - impl AsRef<OsStr> for str;
+           - impl AsRef<Path> for str;
+           - impl AsRef<[u8]> for str;
+           - impl AsRef<str> for str;
+help: try using a fully qualified path to specify the expected types
+   |
+LL -     String::from("x".as_ref());
+LL +     String::from(<str as AsRef<T>>::as_ref("x"));
+   |
+
+error[E0283]: type annotations needed
+  --> $DIR/infer-unwrap-none-issue-120786.rs:73:5
+   |
+LL |     String::from("x".as_ref());
+   |     ^^^^^^ cannot infer type for reference `&_`
+   |
+   = note: multiple `impl`s satisfying `String: From<&_>` found in the `alloc` crate:
+           - impl From<&String> for String;
+           - impl From<&str> for String;
+
+error[E0283]: type annotations needed
+  --> $DIR/infer-unwrap-none-issue-120786.rs:73:22
+   |
+LL |     String::from("x".as_ref());
+   |                      ^^^^^^
+   |
+   = note: multiple `impl`s satisfying `str: AsRef<_>` found in the following crates: `core`, `std`:
+           - impl AsRef<ByteStr> for str;
+           - impl AsRef<OsStr> for str;
+           - impl AsRef<Path> for str;
+           - impl AsRef<[u8]> for str;
+           - impl AsRef<str> for str;
+help: try using a fully qualified path to specify the expected types
+   |
+LL -     String::from("x".as_ref());
+LL +     String::from(<str as AsRef<T>>::as_ref("x"));
+   |
+
+error: aborting due to 18 previous errors
+
+Some errors have detailed explanations: E0282, E0283.
+For more information about an error, try `rustc --explain E0282`.

--- a/tests/ui/parallel-rustc/nested-type-alias-cycle-issue-129911.rs
+++ b/tests/ui/parallel-rustc/nested-type-alias-cycle-issue-129911.rs
@@ -1,0 +1,89 @@
+// Test for #129911, deadlock detected as we're unable to find a query cycle to break
+
+fn main() {
+    type KooArc = Frc<
+    //~^ ERROR cannot find type `Frc` in this scope
+        {
+            {
+                {
+                    {};
+                }
+                type Frc = Frc<{}>::Arc;;
+                //~^ ERROR type alias takes 0 generic arguments but 1 generic argument was supplied
+                //~| ERROR cycle detected when expanding type alias
+            }
+            type Frc = Frc<
+            //~^ ERROR type alias takes 0 generic arguments but 1 generic argument was supplied
+            //~| ERROR cycle detected when expanding type alias
+                {
+                    {
+                        {
+                            {};
+                        }
+                        type Frc = Frc<{}>::Arc;;
+                        //~^ ERROR type alias takes 0 generic arguments but 1 generic argument was supplied
+                        //~| ERROR cycle detected when expanding type alias
+                    }
+                    type Frc = Frc<
+                    //~^ ERROR type alias takes 0 generic arguments but 1 generic argument was supplied
+                    //~| ERROR cycle detected when expanding type alias
+                        {
+                            {
+                                {
+                                    {};
+                                }
+                                type Frc = Frc<{}>::Arc;;
+                                //~^ ERROR type alias takes 0 generic arguments but 1 generic argument was supplied
+                                //~| ERROR cycle detected when expanding type alias
+                            }
+                            type Frc = Frc<
+                            //~^ ERROR type alias takes 0 generic arguments but 1 generic argument was supplied
+                            //~| ERROR cycle detected when expanding type alias
+                                {
+                                    {
+                                        {
+                                            {};
+                                        }
+                                        type Frc = Frc<{}>::Arc;;
+                                        //~^ ERROR type alias takes 0 generic arguments but 1 generic argument was supplied
+                                        //~| ERROR cycle detected when expanding type alias
+                                    }
+                                    type Frc = Frc<
+                                    //~^ ERROR type alias takes 0 generic arguments but 1 generic argument was supplied
+                                    //~| ERROR cycle detected when expanding type alias
+                                        {
+                                            {
+                                                {
+                                                    {
+                                                        {};
+                                                    }
+                                                    type Frc = Frc<{}>::Arc;;
+                                                    //~^ ERROR type alias takes 0 generic arguments but 1 generic argument was supplied
+                                                    //~| ERROR cycle detected when expanding type alias
+                                                };
+                                            }
+                                            type Frc = Frc<
+                                            //~^ ERROR type alias takes 0 generic arguments but 1 generic argument was supplied
+                                            //~| ERROR cycle detected when expanding type alias
+                                                {
+                                                    {
+                                                        {
+                                                            {};
+                                                        };
+                                                    }
+                                                    type Frc = Frc<{}>::Arc;;
+                                                    //~^ ERROR type alias takes 0 generic arguments but 1 generic argument was supplied
+                                                    //~| ERROR cycle detected when expanding type alias
+                                                },
+                                            >::Arc;;
+                                        },
+                                    >::Arc;;
+                                },
+                            >::Arc;;
+                        },
+                    >::Arc;;
+                },
+            >::Arc;;
+        },
+    >::Arc;
+}

--- a/tests/ui/parallel-rustc/nested-type-alias-cycle-issue-129911.stderr
+++ b/tests/ui/parallel-rustc/nested-type-alias-cycle-issue-129911.stderr
@@ -1,0 +1,391 @@
+error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:11:28
+   |
+LL |                 type Frc = Frc<{}>::Arc;;
+   |                            ^^^---- help: remove the unnecessary generics
+   |                            |
+   |                            expected 0 generic arguments
+   |
+note: type alias defined here, with 0 generic parameters
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:11:22
+   |
+LL |                 type Frc = Frc<{}>::Arc;;
+   |                      ^^^
+
+error[E0391]: cycle detected when expanding type alias `main::KooArc::{constant#0}::Frc`
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:11:28
+   |
+LL |                 type Frc = Frc<{}>::Arc;;
+   |                            ^^^^^^^
+   |
+   = note: ...which immediately requires expanding type alias `main::KooArc::{constant#0}::Frc` again
+   = note: type aliases cannot be recursive
+   = help: consider using a struct, enum, or union instead to break the cycle
+   = help: see <https://doc.rust-lang.org/reference/types.html#recursive-types> for more information
+note: cycle used when checking that `main::KooArc::{constant#0}::Frc` is well-formed
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:11:17
+   |
+LL |                 type Frc = Frc<{}>::Arc;;
+   |                 ^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:15:24
+   |
+LL |               type Frc = Frc<
+   |  ________________________^^^-
+   | |                        |
+   | |                        expected 0 generic arguments
+...  |
+LL | |                 },
+LL | |             >::Arc;;
+   | |_____________- help: remove the unnecessary generics
+   |
+note: type alias defined here, with 0 generic parameters
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:15:18
+   |
+LL |             type Frc = Frc<
+   |                  ^^^
+
+error[E0391]: cycle detected when expanding type alias `main::KooArc::{constant#0}::Frc`
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:15:24
+   |
+LL |               type Frc = Frc<
+   |  ________________________^
+...  |
+LL | |                 },
+LL | |             >::Arc;;
+   | |_____________^
+   |
+   = note: ...which immediately requires expanding type alias `main::KooArc::{constant#0}::Frc` again
+   = note: type aliases cannot be recursive
+   = help: consider using a struct, enum, or union instead to break the cycle
+   = help: see <https://doc.rust-lang.org/reference/types.html#recursive-types> for more information
+note: cycle used when checking that `main::KooArc::{constant#0}::Frc` is well-formed
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:15:13
+   |
+LL |             type Frc = Frc<
+   |             ^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:23:36
+   |
+LL |                         type Frc = Frc<{}>::Arc;;
+   |                                    ^^^---- help: remove the unnecessary generics
+   |                                    |
+   |                                    expected 0 generic arguments
+   |
+note: type alias defined here, with 0 generic parameters
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:23:30
+   |
+LL |                         type Frc = Frc<{}>::Arc;;
+   |                              ^^^
+
+error[E0391]: cycle detected when expanding type alias `main::KooArc::{constant#0}::Frc::{constant#0}::Frc`
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:23:36
+   |
+LL |                         type Frc = Frc<{}>::Arc;;
+   |                                    ^^^^^^^
+   |
+   = note: ...which immediately requires expanding type alias `main::KooArc::{constant#0}::Frc::{constant#0}::Frc` again
+   = note: type aliases cannot be recursive
+   = help: consider using a struct, enum, or union instead to break the cycle
+   = help: see <https://doc.rust-lang.org/reference/types.html#recursive-types> for more information
+note: cycle used when checking that `main::KooArc::{constant#0}::Frc::{constant#0}::Frc` is well-formed
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:23:25
+   |
+LL |                         type Frc = Frc<{}>::Arc;;
+   |                         ^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:27:32
+   |
+LL |                       type Frc = Frc<
+   |  ________________________________^^^-
+   | |                                |
+   | |                                expected 0 generic arguments
+...  |
+LL | |                         },
+LL | |                     >::Arc;;
+   | |_____________________- help: remove the unnecessary generics
+   |
+note: type alias defined here, with 0 generic parameters
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:27:26
+   |
+LL |                     type Frc = Frc<
+   |                          ^^^
+
+error[E0391]: cycle detected when expanding type alias `main::KooArc::{constant#0}::Frc::{constant#0}::Frc`
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:27:32
+   |
+LL |                       type Frc = Frc<
+   |  ________________________________^
+...  |
+LL | |                         },
+LL | |                     >::Arc;;
+   | |_____________________^
+   |
+   = note: ...which immediately requires expanding type alias `main::KooArc::{constant#0}::Frc::{constant#0}::Frc` again
+   = note: type aliases cannot be recursive
+   = help: consider using a struct, enum, or union instead to break the cycle
+   = help: see <https://doc.rust-lang.org/reference/types.html#recursive-types> for more information
+note: cycle used when checking that `main::KooArc::{constant#0}::Frc::{constant#0}::Frc` is well-formed
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:27:21
+   |
+LL |                     type Frc = Frc<
+   |                     ^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:35:44
+   |
+LL | ...                   type Frc = Frc<{}>::Arc;;
+   |                                  ^^^---- help: remove the unnecessary generics
+   |                                  |
+   |                                  expected 0 generic arguments
+   |
+note: type alias defined here, with 0 generic parameters
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:35:38
+   |
+LL | ...                   type Frc = Frc<{}>::Arc;;
+   |                            ^^^
+
+error[E0391]: cycle detected when expanding type alias `main::KooArc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc`
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:35:44
+   |
+LL | ...                   type Frc = Frc<{}>::Arc;;
+   |                                  ^^^^^^^
+   |
+   = note: ...which immediately requires expanding type alias `main::KooArc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc` again
+   = note: type aliases cannot be recursive
+   = help: consider using a struct, enum, or union instead to break the cycle
+   = help: see <https://doc.rust-lang.org/reference/types.html#recursive-types> for more information
+note: cycle used when checking that `main::KooArc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc` is well-formed
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:35:33
+   |
+LL | ...                   type Frc = Frc<{}>::Arc;;
+   |                       ^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:39:40
+   |
+LL |   ...                   type Frc = Frc<
+   |  __________________________________^^^-
+   | |                                  |
+   | |                                  expected 0 generic arguments
+...  |
+LL | | ...                       },
+LL | | ...                   >::Arc;;
+   | |_______________________- help: remove the unnecessary generics
+   |
+note: type alias defined here, with 0 generic parameters
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:39:34
+   |
+LL | ...                   type Frc = Frc<
+   |                            ^^^
+
+error[E0391]: cycle detected when expanding type alias `main::KooArc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc`
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:39:40
+   |
+LL |   ...                   type Frc = Frc<
+   |  __________________________________^
+...  |
+LL | | ...                       },
+LL | | ...                   >::Arc;;
+   | |_______________________^
+   |
+   = note: ...which immediately requires expanding type alias `main::KooArc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc` again
+   = note: type aliases cannot be recursive
+   = help: consider using a struct, enum, or union instead to break the cycle
+   = help: see <https://doc.rust-lang.org/reference/types.html#recursive-types> for more information
+note: cycle used when checking that `main::KooArc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc` is well-formed
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:39:29
+   |
+LL | ...                   type Frc = Frc<
+   |                       ^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:47:52
+   |
+LL | ...                   type Frc = Frc<{}>::Arc;;
+   |                                  ^^^---- help: remove the unnecessary generics
+   |                                  |
+   |                                  expected 0 generic arguments
+   |
+note: type alias defined here, with 0 generic parameters
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:47:46
+   |
+LL | ...                   type Frc = Frc<{}>::Arc;;
+   |                            ^^^
+
+error[E0391]: cycle detected when expanding type alias `main::KooArc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc`
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:47:52
+   |
+LL | ...                   type Frc = Frc<{}>::Arc;;
+   |                                  ^^^^^^^
+   |
+   = note: ...which immediately requires expanding type alias `main::KooArc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc` again
+   = note: type aliases cannot be recursive
+   = help: consider using a struct, enum, or union instead to break the cycle
+   = help: see <https://doc.rust-lang.org/reference/types.html#recursive-types> for more information
+note: cycle used when checking that `main::KooArc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc` is well-formed
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:47:41
+   |
+LL | ...                   type Frc = Frc<{}>::Arc;;
+   |                       ^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:51:48
+   |
+LL |   ...                   type Frc = Frc<
+   |  __________________________________^^^-
+   | |                                  |
+   | |                                  expected 0 generic arguments
+...  |
+LL | | ...                       },
+LL | | ...                   >::Arc;;
+   | |_______________________- help: remove the unnecessary generics
+   |
+note: type alias defined here, with 0 generic parameters
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:51:42
+   |
+LL | ...                   type Frc = Frc<
+   |                            ^^^
+
+error[E0391]: cycle detected when expanding type alias `main::KooArc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc`
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:51:48
+   |
+LL |   ...                   type Frc = Frc<
+   |  __________________________________^
+...  |
+LL | | ...                       },
+LL | | ...                   >::Arc;;
+   | |_______________________^
+   |
+   = note: ...which immediately requires expanding type alias `main::KooArc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc` again
+   = note: type aliases cannot be recursive
+   = help: consider using a struct, enum, or union instead to break the cycle
+   = help: see <https://doc.rust-lang.org/reference/types.html#recursive-types> for more information
+note: cycle used when checking that `main::KooArc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc` is well-formed
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:51:37
+   |
+LL | ...                   type Frc = Frc<
+   |                       ^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:60:64
+   |
+LL | ...                   type Frc = Frc<{}>::Arc;;
+   |                                  ^^^---- help: remove the unnecessary generics
+   |                                  |
+   |                                  expected 0 generic arguments
+   |
+note: type alias defined here, with 0 generic parameters
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:60:58
+   |
+LL | ...                   type Frc = Frc<{}>::Arc;;
+   |                            ^^^
+
+error[E0391]: cycle detected when expanding type alias `main::KooArc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc`
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:60:64
+   |
+LL | ...                   type Frc = Frc<{}>::Arc;;
+   |                                  ^^^^^^^
+   |
+   = note: ...which immediately requires expanding type alias `main::KooArc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc` again
+   = note: type aliases cannot be recursive
+   = help: consider using a struct, enum, or union instead to break the cycle
+   = help: see <https://doc.rust-lang.org/reference/types.html#recursive-types> for more information
+note: cycle used when checking that `main::KooArc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc` is well-formed
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:60:53
+   |
+LL | ...                   type Frc = Frc<{}>::Arc;;
+   |                       ^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:65:56
+   |
+LL |   ...                   type Frc = Frc<
+   |  __________________________________^^^-
+   | |                                  |
+   | |                                  expected 0 generic arguments
+...  |
+LL | | ...                       },
+LL | | ...                   >::Arc;;
+   | |_______________________- help: remove the unnecessary generics
+   |
+note: type alias defined here, with 0 generic parameters
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:65:50
+   |
+LL | ...                   type Frc = Frc<
+   |                            ^^^
+
+error[E0391]: cycle detected when expanding type alias `main::KooArc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc`
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:65:56
+   |
+LL |   ...                   type Frc = Frc<
+   |  __________________________________^
+...  |
+LL | | ...                       },
+LL | | ...                   >::Arc;;
+   | |_______________________^
+   |
+   = note: ...which immediately requires expanding type alias `main::KooArc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc` again
+   = note: type aliases cannot be recursive
+   = help: consider using a struct, enum, or union instead to break the cycle
+   = help: see <https://doc.rust-lang.org/reference/types.html#recursive-types> for more information
+note: cycle used when checking that `main::KooArc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc` is well-formed
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:65:45
+   |
+LL | ...                   type Frc = Frc<
+   |                       ^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:74:64
+   |
+LL | ...                   type Frc = Frc<{}>::Arc;;
+   |                                  ^^^---- help: remove the unnecessary generics
+   |                                  |
+   |                                  expected 0 generic arguments
+   |
+note: type alias defined here, with 0 generic parameters
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:74:58
+   |
+LL | ...                   type Frc = Frc<{}>::Arc;;
+   |                            ^^^
+
+error[E0391]: cycle detected when expanding type alias `main::KooArc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc`
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:74:64
+   |
+LL | ...                   type Frc = Frc<{}>::Arc;;
+   |                                  ^^^^^^^
+   |
+   = note: ...which immediately requires expanding type alias `main::KooArc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc` again
+   = note: type aliases cannot be recursive
+   = help: consider using a struct, enum, or union instead to break the cycle
+   = help: see <https://doc.rust-lang.org/reference/types.html#recursive-types> for more information
+note: cycle used when checking that `main::KooArc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc::{constant#0}::Frc` is well-formed
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:74:53
+   |
+LL | ...                   type Frc = Frc<{}>::Arc;;
+   |                       ^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error[E0433]: cannot find type `Frc` in this scope
+  --> $DIR/nested-type-alias-cycle-issue-129911.rs:4:19
+   |
+LL |     type KooArc = Frc<
+   |                   ^^^ use of undeclared type `Frc`
+
+error: aborting due to 23 previous errors
+
+Some errors have detailed explanations: E0107, E0391, E0433.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/parallel-rustc/recursive-impl-trait-deadlock-issue-129912.rs
+++ b/tests/ui/parallel-rustc/recursive-impl-trait-deadlock-issue-129912.rs
@@ -1,0 +1,97 @@
+// Test for #129912, which causes a deadlock bug without finding a cycle
+
+#![feature(generators)]
+//~^ ERROR feature has been removed
+#![allow(unconditional_recursion)]
+
+fn option(i: i32) -> impl Sync {
+    if generator_sig() < 0 { None } else { Sized((option(i - Sized), i)) }
+    //~^ ERROR expected value, found trait `Sized`
+    //~| ERROR expected function, tuple struct or tuple variant, found trait `Sized`
+}
+
+fn tuple() -> impl Sized {
+    (tuple(),)
+}
+
+fn array() -> _ {
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+    [array()]
+}
+
+fn ptr() -> _ {
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+    &ptr() as *const impl Sized
+    //~^ ERROR `impl Trait` is not allowed in cast expression types
+}
+
+fn fn_ptr() -> impl Sized {
+    fn_ptr as fn() -> _
+}
+
+fn closure_capture() -> impl Sized {
+    let x = closure_capture();
+    move || {
+        x;
+    }
+}
+
+fn closure_ref_capture() -> impl Sized {
+    let x = closure_ref_capture();
+    move || {
+        &x;
+    }
+}
+
+fn closure_sig() -> _ {
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+    || closure_sig()
+}
+
+fn generator_sig() -> impl Sized {
+    || i
+    //~^ ERROR cannot find value `i` in this scope
+}
+
+fn generator_capture() -> impl i32 {
+    //~^ ERROR expected trait, found builtin type `i32`
+    let x = 1();
+    move || {
+        yield;
+        //~^ ERROR yield syntax is experimental
+        //~| ERROR yield syntax is experimental
+        //~| ERROR `yield` can only be used in `#[coroutine]` closures, or `gen` blocks
+        x;
+    }
+}
+
+fn substs_change<T: 'static>() -> impl Sized {
+    (substs_change::<&T>(),)
+}
+
+fn generator_hold() -> impl generator_capture {
+    //~^ ERROR expected trait, found function `generator_capture`
+    move || {
+        let x = ();
+        yield;
+        //~^ ERROR yield syntax is experimental
+        //~| ERROR yield syntax is experimental
+        //~| ERROR `yield` can only be used in `#[coroutine]` closures, or `gen` blocks
+        x virtual ;
+        //~^ ERROR expected one of
+    }
+}
+
+fn use_fn_ptr() -> impl Sized {
+    fn_ptr()
+}
+
+fn mutual_recursion() -> impl Sync {
+    mutual_recursion_b()
+}
+
+fn mutual_recursion_b() -> impl Sized {
+    mutual_recursion()
+}
+
+fn main() {}

--- a/tests/ui/parallel-rustc/recursive-impl-trait-deadlock-issue-129912.stderr
+++ b/tests/ui/parallel-rustc/recursive-impl-trait-deadlock-issue-129912.stderr
@@ -1,0 +1,137 @@
+error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found reserved keyword `virtual`
+  --> $DIR/recursive-impl-trait-deadlock-issue-129912.rs:80:11
+   |
+LL |         x virtual ;
+   |           ^^^^^^^ expected one of 8 possible tokens
+
+error[E0557]: feature has been removed
+  --> $DIR/recursive-impl-trait-deadlock-issue-129912.rs:3:12
+   |
+LL | #![feature(generators)]
+   |            ^^^^^^^^^^ feature has been removed
+   |
+   = note: removed in 1.75.0; see <https://github.com/rust-lang/rust/pull/116958> for more information
+   = note: renamed to `coroutines`
+
+error[E0423]: expected value, found trait `Sized`
+  --> $DIR/recursive-impl-trait-deadlock-issue-129912.rs:8:62
+   |
+LL |     if generator_sig() < 0 { None } else { Sized((option(i - Sized), i)) }
+   |                                                              ^^^^^ not a value
+
+error[E0425]: cannot find value `i` in this scope
+  --> $DIR/recursive-impl-trait-deadlock-issue-129912.rs:52:8
+   |
+LL |     || i
+   |        ^ not found in this scope
+
+error[E0404]: expected trait, found builtin type `i32`
+  --> $DIR/recursive-impl-trait-deadlock-issue-129912.rs:56:32
+   |
+LL | fn generator_capture() -> impl i32 {
+   |                                ^^^ not a trait
+
+error[E0404]: expected trait, found function `generator_capture`
+  --> $DIR/recursive-impl-trait-deadlock-issue-129912.rs:72:29
+   |
+LL | fn generator_hold() -> impl generator_capture {
+   |                             ^^^^^^^^^^^^^^^^^ not a trait
+
+error[E0658]: yield syntax is experimental
+  --> $DIR/recursive-impl-trait-deadlock-issue-129912.rs:60:9
+   |
+LL |         yield;
+   |         ^^^^^
+   |
+   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
+   = help: add `#![feature(yield_expr)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: yield syntax is experimental
+  --> $DIR/recursive-impl-trait-deadlock-issue-129912.rs:76:9
+   |
+LL |         yield;
+   |         ^^^^^
+   |
+   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
+   = help: add `#![feature(yield_expr)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0562]: `impl Trait` is not allowed in cast expression types
+  --> $DIR/recursive-impl-trait-deadlock-issue-129912.rs:24:22
+   |
+LL |     &ptr() as *const impl Sized
+   |                      ^^^^^^^^^^
+   |
+   = note: `impl Trait` is only allowed in arguments and return types of functions and methods
+
+error[E0658]: yield syntax is experimental
+  --> $DIR/recursive-impl-trait-deadlock-issue-129912.rs:60:9
+   |
+LL |         yield;
+   |         ^^^^^
+   |
+   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
+   = help: add `#![feature(yield_expr)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: `yield` can only be used in `#[coroutine]` closures, or `gen` blocks
+  --> $DIR/recursive-impl-trait-deadlock-issue-129912.rs:60:9
+   |
+LL |         yield;
+   |         ^^^^^
+   |
+help: use `#[coroutine]` to make this closure a coroutine
+   |
+LL |     #[coroutine] move || {
+   |     ++++++++++++
+
+error[E0658]: yield syntax is experimental
+  --> $DIR/recursive-impl-trait-deadlock-issue-129912.rs:76:9
+   |
+LL |         yield;
+   |         ^^^^^
+   |
+   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
+   = help: add `#![feature(yield_expr)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: `yield` can only be used in `#[coroutine]` closures, or `gen` blocks
+  --> $DIR/recursive-impl-trait-deadlock-issue-129912.rs:76:9
+   |
+LL |         yield;
+   |         ^^^^^
+   |
+help: use `#[coroutine]` to make this closure a coroutine
+   |
+LL |     #[coroutine] move || {
+   |     ++++++++++++
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/recursive-impl-trait-deadlock-issue-129912.rs:17:15
+   |
+LL | fn array() -> _ {
+   |               ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/recursive-impl-trait-deadlock-issue-129912.rs:22:13
+   |
+LL | fn ptr() -> _ {
+   |             ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/recursive-impl-trait-deadlock-issue-129912.rs:46:21
+   |
+LL | fn closure_sig() -> _ {
+   |                     ^ not allowed in type signatures
+
+error[E0423]: expected function, tuple struct or tuple variant, found trait `Sized`
+  --> $DIR/recursive-impl-trait-deadlock-issue-129912.rs:8:44
+   |
+LL |     if generator_sig() < 0 { None } else { Sized((option(i - Sized), i)) }
+   |                                            ^^^^^ not a function, tuple struct or tuple variant
+
+error: aborting due to 17 previous errors
+
+Some errors have detailed explanations: E0121, E0404, E0423, E0425, E0557, E0562, E0658.
+For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/parallel-rustc/recursive-struct-oncelock-issue-151226.rs
+++ b/tests/ui/parallel-rustc/recursive-struct-oncelock-issue-151226.rs
@@ -1,0 +1,9 @@
+// Test for #151226, Unable to verify registry association
+//
+//@ compile-flags: -Z threads=2
+//@ compare-output-by-lines
+
+struct A<T>(std::sync::OnceLock<Self>);
+//~^ ERROR recursive type `A` has infinite size
+static B: A<()> = todo!();
+fn main() {}

--- a/tests/ui/parallel-rustc/recursive-struct-oncelock-issue-151226.stderr
+++ b/tests/ui/parallel-rustc/recursive-struct-oncelock-issue-151226.stderr
@@ -1,0 +1,14 @@
+error[E0072]: recursive type `A` has infinite size
+  --> $DIR/recursive-struct-oncelock-issue-151226.rs:6:1
+   |
+LL | struct A<T>(std::sync::OnceLock<Self>);
+   | ^^^^^^^^^^^ ------------------------- recursive without indirection
+   |
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to break the cycle
+   |
+LL | struct A<T>(Box<std::sync::OnceLock<Self>>);
+   |             ++++                         +
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0072`.

--- a/tests/ui/parallel-rustc/recursive-trait-fn-sig-issue-142064.rs
+++ b/tests/ui/parallel-rustc/recursive-trait-fn-sig-issue-142064.rs
@@ -1,0 +1,18 @@
+// Test for #142064, internal error: entered unreachable code
+//
+//@ compile-flags: -Zthreads=2
+//@ compare-output-by-lines
+
+#![crate_type = "rlib"]
+trait A { fn foo() -> A; }
+//~^ WARN trait objects without an explicit `dyn` are deprecated
+//~| WARN this is accepted in the current edition
+//~| WARN trait objects without an explicit `dyn` are deprecated
+//~| WARN this is accepted in the current edition
+//~| ERROR the trait `A` is not dyn compatible
+trait B { fn foo() -> A; }
+//~^ WARN trait objects without an explicit `dyn` are deprecated
+//~| WARN this is accepted in the current edition
+//~| WARN trait objects without an explicit `dyn` are deprecated
+//~| WARN this is accepted in the current edition
+//~| ERROR the trait `A` is not dyn compatible

--- a/tests/ui/parallel-rustc/recursive-trait-fn-sig-issue-142064.stderr
+++ b/tests/ui/parallel-rustc/recursive-trait-fn-sig-issue-142064.stderr
@@ -1,0 +1,114 @@
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:7:23
+   |
+LL | trait A { fn foo() -> A; }
+   |                       ^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: `#[warn(bare_trait_objects)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
+help: if this is a dyn-compatible trait, use `dyn`
+   |
+LL | trait A { fn foo() -> dyn A; }
+   |                       +++
+
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:13:23
+   |
+LL | trait B { fn foo() -> A; }
+   |                       ^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: if this is a dyn-compatible trait, use `dyn`
+   |
+LL | trait B { fn foo() -> dyn A; }
+   |                       +++
+
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:7:23
+   |
+LL | trait A { fn foo() -> A; }
+   |                       ^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: if this is a dyn-compatible trait, use `dyn`
+   |
+LL | trait A { fn foo() -> dyn A; }
+   |                       +++
+
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:13:23
+   |
+LL | trait B { fn foo() -> A; }
+   |                       ^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: if this is a dyn-compatible trait, use `dyn`
+   |
+LL | trait B { fn foo() -> dyn A; }
+   |                       +++
+
+error[E0038]: the trait `A` is not dyn compatible
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:7:23
+   |
+LL | trait A { fn foo() -> A; }
+   |                       ^ `A` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:7:14
+   |
+LL | trait A { fn foo() -> A; }
+   |       -      ^^^ ...because associated function `foo` has no `self` parameter
+   |       |
+   |       this trait is not dyn compatible...
+help: consider turning `foo` into a method by giving it a `&self` argument
+   |
+LL | trait A { fn foo(&self) -> A; }
+   |                  +++++
+help: alternatively, consider constraining `foo` so it does not apply to trait objects
+   |
+LL | trait A { fn foo() -> A where Self: Sized; }
+   |                         +++++++++++++++++
+help: you might have meant to use `Self` to refer to the implementing type
+   |
+LL - trait A { fn foo() -> A; }
+LL + trait A { fn foo() -> Self; }
+   |
+
+error[E0038]: the trait `A` is not dyn compatible
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:13:23
+   |
+LL | trait B { fn foo() -> A; }
+   |                       ^ `A` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:7:14
+   |
+LL | trait A { fn foo() -> A; }
+   |       -      ^^^ ...because associated function `foo` has no `self` parameter
+   |       |
+   |       this trait is not dyn compatible...
+help: consider turning `foo` into a method by giving it a `&self` argument
+   |
+LL | trait A { fn foo(&self) -> A; }
+   |                  +++++
+help: alternatively, consider constraining `foo` so it does not apply to trait objects
+   |
+LL | trait A { fn foo() -> A where Self: Sized; }
+   |                         +++++++++++++++++
+help: you might have meant to use `Self` to refer to the implementing type
+   |
+LL - trait B { fn foo() -> A; }
+LL + trait B { fn foo() -> Self; }
+   |
+
+error: aborting due to 2 previous errors; 4 warnings emitted
+
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/parallel-rustc/recursive-type-with-transmutability-issue-120759.rs
+++ b/tests/ui/parallel-rustc/recursive-type-with-transmutability-issue-120759.rs
@@ -1,0 +1,26 @@
+// Test for #120759, deadlock detected without any query
+
+#![crate_type = "lib"]
+#![feature(transmutability)]
+
+mod assert {
+    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    //~^ ERROR unresolved import `std::mem::BikeshedIntrinsicFrom`
+    pub struct Context;
+
+    pub fn is_maybe_transmutable<Src, Dst>(&self, cpu: &mut CPU)
+    //~^ ERROR `self` parameter is only allowed in associated functions
+    //~| ERROR cannot find type `CPU` in this scope
+    where
+        Dst: BikeshedIntrinsicFrom<Src, Context>,
+    {
+    }
+}
+
+fn should_pad_explicitly_packed_field() {
+    #[repr(C)]
+    struct ExplicitlyPadded(ExplicitlyPadded);
+    //~^ ERROR recursive type `ExplicitlyPadded` has infinite size
+
+    assert::is_maybe_transmutable::<ExplicitlyPadded, ()>();
+}

--- a/tests/ui/parallel-rustc/recursive-type-with-transmutability-issue-120759.stderr
+++ b/tests/ui/parallel-rustc/recursive-type-with-transmutability-issue-120759.stderr
@@ -1,0 +1,35 @@
+error: `self` parameter is only allowed in associated functions
+  --> $DIR/recursive-type-with-transmutability-issue-120759.rs:11:44
+   |
+LL |     pub fn is_maybe_transmutable<Src, Dst>(&self, cpu: &mut CPU)
+   |                                            ^^^^^ not semantically valid as function parameter
+   |
+   = note: associated functions are those in `impl` or `trait` definitions
+
+error[E0432]: unresolved import `std::mem::BikeshedIntrinsicFrom`
+  --> $DIR/recursive-type-with-transmutability-issue-120759.rs:7:28
+   |
+LL |     use std::mem::{Assume, BikeshedIntrinsicFrom};
+   |                            ^^^^^^^^^^^^^^^^^^^^^ no `BikeshedIntrinsicFrom` in `mem`
+
+error[E0425]: cannot find type `CPU` in this scope
+  --> $DIR/recursive-type-with-transmutability-issue-120759.rs:11:61
+   |
+LL |     pub fn is_maybe_transmutable<Src, Dst>(&self, cpu: &mut CPU)
+   |                                                             ^^^ not found in this scope
+
+error[E0072]: recursive type `ExplicitlyPadded` has infinite size
+  --> $DIR/recursive-type-with-transmutability-issue-120759.rs:22:5
+   |
+LL |     struct ExplicitlyPadded(ExplicitlyPadded);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ ---------------- recursive without indirection
+   |
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to break the cycle
+   |
+LL |     struct ExplicitlyPadded(Box<ExplicitlyPadded>);
+   |                             ++++                +
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0072, E0425, E0432.
+For more information about an error, try `rustc --explain E0072`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Add corresphonding tests from issues:
- rust-lang/rust#115223
- rust-lang/rust#151358
- rust-lang/rust#120757
- rust-lang/rust#134978
- rust-lang/rust#120786
- rust-lang/rust#129911
- rust-lang/rust#129912
- rust-lang/rust#151226
- rust-lang/rust#142064
- rust-lang/rust#120759

For rust-lang/rust#119785
> Effects is no more and the implementation of const_trait_impl has changed dramatically. This is obviously fixed. I don't think it's worth adding a regression test. If you disagree, feel free to open a PR and ping [@]rust-lang/project-const-traits for a "majority vote".

So it doesn't appear here.

And  rust-lang/rust#142949 has flipflopping diagnostics

r? @petrochenkov