### PR TITLE
delegation: add const type ICE test

### DIFF
--- a/tests/ui/delegation/generics/const-type-ice-154334.rs
+++ b/tests/ui/delegation/generics/const-type-ice-154334.rs
@@ -1,0 +1,11 @@
+//@ check-pass
+//@ compile-flags: --crate-type=lib
+
+#![feature(min_generic_const_args)]
+#![feature(fn_delegation)]
+#![feature(adt_const_params)]
+#![feature(unsized_const_params)]
+trait Trait<'a, T, const N: str> {
+    fn foo<'v, A, B>(&self) {}
+}
+reuse Trait::foo;


### PR DESCRIPTION
This PR adds test for rust-lang/rust#154334 which was fixed by rust-lang/rust#154142. Fixes rust-lang/rust#154334. Part of rust-lang/rust#118212.

r? @petrochenkov