### PR TITLE
    Add integer truncation and extension methods

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -110,6 +110,7 @@
 #![feature(offset_of_enum)]
 #![feature(panic_internals)]
 #![feature(pattern_type_macro)]
+#![feature(sealed)]
 #![feature(ub_checks)]
 // tidy-alphabetical-end
 //
@@ -214,6 +215,14 @@ pub use crate::macros::{assert_matches, debug_assert_matches};
 pub mod from {
     #[unstable(feature = "derive_from", issue = "144889")]
     pub use crate::macros::builtin::From;
+}
+
+mod sealed {
+    /// This trait being unreachable from outside the crate
+    /// prevents outside implementations of our extension traits.
+    /// This allows adding more trait methods in the future.
+    #[unstable(feature = "sealed", issue = "none")]
+    pub trait Sealed {}
 }
 
 // We don't export this through #[macro_export] for now, to avoid breakage.

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -3944,5 +3944,85 @@ macro_rules! int_impl {
                 self
             }
         }
+
+        /// Truncate an integer to an integer of the same size or smaller, preserving the least
+        /// significant bits.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(integer_extend_truncate)]
+        #[doc = concat!("assert_eq!(120i8, 120", stringify!($SelfT), ".truncate());")]
+        #[doc = concat!("assert_eq!(-120i8, (-120", stringify!($SelfT), ").truncate());")]
+        /// assert_eq!(120i8, 376i32.truncate());
+        /// ```
+        #[must_use = "this returns the truncated value and does not modify the original"]
+        #[unstable(feature = "integer_extend_truncate", issue = "154330")]
+        #[inline]
+        pub fn truncate<Target>(self) -> Target
+            where Self: traits::TruncateTarget<Target>
+        {
+            traits::TruncateTarget::internal_truncate(self)
+        }
+
+        /// Truncate an integer to an integer of the same size or smaller, saturating at numeric bounds
+        /// instead of truncating.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(integer_extend_truncate)]
+        #[doc = concat!("assert_eq!(120i8, 120", stringify!($SelfT), ".saturating_truncate());")]
+        #[doc = concat!("assert_eq!(-120i8, (-120", stringify!($SelfT), ").saturating_truncate());")]
+        /// assert_eq!(127i8, 376i32.saturating_truncate());
+        /// assert_eq!(-128i8, (-1000i32).saturating_truncate());
+        /// ```
+        #[must_use = "this returns the truncated value and does not modify the original"]
+        #[unstable(feature = "integer_extend_truncate", issue = "154330")]
+        #[inline]
+        pub fn saturating_truncate<Target>(self) -> Target
+            where Self: traits::TruncateTarget<Target>
+        {
+            traits::TruncateTarget::internal_saturating_truncate(self)
+        }
+
+        /// Truncate an integer to an integer of the same size or smaller, returning `None` if the value
+        /// is outside the bounds of the smaller type.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(integer_extend_truncate)]
+        #[doc = concat!("assert_eq!(Some(120i8), 120", stringify!($SelfT), ".checked_truncate());")]
+        #[doc = concat!("assert_eq!(Some(-120i8), (-120", stringify!($SelfT), ").checked_truncate());")]
+        /// assert_eq!(None, 376i32.checked_truncate::<i8>());
+        /// assert_eq!(None, (-1000i32).checked_truncate::<i8>());
+        /// ```
+        #[must_use = "this returns the truncated value and does not modify the original"]
+        #[unstable(feature = "integer_extend_truncate", issue = "154330")]
+        #[inline]
+        pub fn checked_truncate<Target>(self) -> Option<Target>
+            where Self: traits::TruncateTarget<Target>
+        {
+            traits::TruncateTarget::internal_checked_truncate(self)
+        }
+
+        /// Extend to an integer of the same size or larger, preserving its value.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(integer_extend_truncate)]
+        #[doc = concat!("assert_eq!(120i128, 120i8.extend());")]
+        #[doc = concat!("assert_eq!(-120i128, (-120i8).extend());")]
+        /// ```
+        #[must_use = "this returns the extended value and does not modify the original"]
+        #[unstable(feature = "integer_extend_truncate", issue = "154330")]
+        #[inline]
+        pub fn extend<Target>(self) -> Target
+            where Self: traits::ExtendTarget<Target>
+        {
+            traits::ExtendTarget::internal_extend(self)
+        }
     }
 }

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -3958,9 +3958,10 @@ macro_rules! int_impl {
         /// ```
         #[must_use = "this returns the truncated value and does not modify the original"]
         #[unstable(feature = "integer_extend_truncate", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_truncate_extend", issue = "154330")]
         #[inline]
-        pub fn truncate<Target>(self) -> Target
-            where Self: traits::TruncateTarget<Target>
+        pub const fn truncate<Target>(self) -> Target
+            where Self: [const] traits::TruncateTarget<Target>
         {
             traits::TruncateTarget::internal_truncate(self)
         }
@@ -3979,9 +3980,10 @@ macro_rules! int_impl {
         /// ```
         #[must_use = "this returns the truncated value and does not modify the original"]
         #[unstable(feature = "integer_extend_truncate", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_truncate_extend", issue = "154330")]
         #[inline]
-        pub fn saturating_truncate<Target>(self) -> Target
-            where Self: traits::TruncateTarget<Target>
+        pub const fn saturating_truncate<Target>(self) -> Target
+            where Self: [const] traits::TruncateTarget<Target>
         {
             traits::TruncateTarget::internal_saturating_truncate(self)
         }
@@ -4000,9 +4002,10 @@ macro_rules! int_impl {
         /// ```
         #[must_use = "this returns the truncated value and does not modify the original"]
         #[unstable(feature = "integer_extend_truncate", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_truncate_extend", issue = "154330")]
         #[inline]
-        pub fn checked_truncate<Target>(self) -> Option<Target>
-            where Self: traits::TruncateTarget<Target>
+        pub const fn checked_truncate<Target>(self) -> Option<Target>
+            where Self: [const] traits::TruncateTarget<Target>
         {
             traits::TruncateTarget::internal_checked_truncate(self)
         }
@@ -4018,9 +4021,10 @@ macro_rules! int_impl {
         /// ```
         #[must_use = "this returns the extended value and does not modify the original"]
         #[unstable(feature = "integer_extend_truncate", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_truncate_extend", issue = "154330")]
         #[inline]
-        pub fn extend<Target>(self) -> Target
-            where Self: traits::ExtendTarget<Target>
+        pub const fn extend<Target>(self) -> Target
+            where Self: [const] traits::ExtendTarget<Target>
         {
             traits::ExtendTarget::internal_extend(self)
         }

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -46,6 +46,7 @@ mod error;
 mod float_parse;
 mod nonzero;
 mod saturating;
+mod traits;
 mod wrapping;
 
 /// 100% perma-unstable

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1795,3 +1795,12 @@ macro_rules! from_str_int_impl {
 
 from_str_int_impl! { signed isize i8 i16 i32 i64 i128 }
 from_str_int_impl! { unsigned usize u8 u16 u32 u64 u128 }
+
+macro_rules! impl_sealed {
+    ($($t:ty)*) => {$(
+        /// Allows extension traits within `core`.
+        #[unstable(feature = "sealed", issue = "none")]
+        impl crate::sealed::Sealed for $t {}
+    )*}
+}
+impl_sealed! { isize i8 i16 i32 i64 i128 usize u8 u16 u32 u64 u128 }

--- a/library/core/src/num/traits.rs
+++ b/library/core/src/num/traits.rs
@@ -1,0 +1,125 @@
+/// Definitions of traits for numeric types
+// Implementation based on `num_conv` by jhpratt, under (MIT OR Apache-2.0).
+
+/// Trait for types that this type can be truncated to
+#[unstable(feature = "num_internals", reason = "internal implementation detail", issue = "none")]
+pub trait TruncateTarget<Target>: crate::sealed::Sealed {
+    #[doc(hidden)]
+    fn internal_truncate(self) -> Target;
+
+    #[doc(hidden)]
+    fn internal_saturating_truncate(self) -> Target;
+
+    #[doc(hidden)]
+    fn internal_checked_truncate(self) -> Option<Target>;
+}
+
+/// Trait for types that this type can be truncated to
+#[unstable(feature = "num_internals", reason = "internal implementation detail", issue = "none")]
+pub trait ExtendTarget<Target>: crate::sealed::Sealed {
+    #[doc(hidden)]
+    fn internal_extend(self) -> Target;
+}
+
+macro_rules! impl_truncate {
+    ($($from:ty => $($to:ty),+;)*) => {$($(
+        const _: () = assert!(
+            size_of::<$from>() >= size_of::<$to>(),
+            concat!(
+                "cannot truncate ",
+                stringify!($from),
+                " to ",
+                stringify!($to),
+                " because ",
+                stringify!($from),
+                " is smaller than ",
+                stringify!($to)
+            )
+        );
+
+        #[unstable(feature = "num_internals", reason = "internal implementation detail", issue = "none")]
+        impl TruncateTarget<$to> for $from {
+            #[inline]
+            fn internal_truncate(self) -> $to {
+                self as _
+            }
+
+            #[inline]
+            fn internal_saturating_truncate(self) -> $to {
+                if self > <$to>::MAX as Self {
+                    <$to>::MAX
+                } else if self < <$to>::MIN as Self {
+                    <$to>::MIN
+                } else {
+                    self as _
+                }
+            }
+
+            #[inline]
+            fn internal_checked_truncate(self) -> Option<$to> {
+                if self > <$to>::MAX as Self || self < <$to>::MIN as Self {
+                    None
+                } else {
+                    Some(self as _)
+                }
+            }
+        }
+    )+)*};
+}
+
+macro_rules! impl_extend {
+    ($($from:ty => $($to:ty),+;)*) => {$($(
+        const _: () = assert!(
+            size_of::<$from>() <= size_of::<$to>(),
+            concat!(
+                "cannot extend ",
+                stringify!($from),
+                " to ",
+                stringify!($to),
+                " because ",
+                stringify!($from),
+                " is larger than ",
+                stringify!($to)
+            )
+        );
+
+        #[unstable(feature = "num_internals", reason = "internal implementation detail", issue = "none")]
+        impl ExtendTarget<$to> for $from {
+            fn internal_extend(self) -> $to {
+                self as _
+            }
+        }
+    )+)*};
+}
+
+impl_truncate! {
+    u8 => u8;
+    u16 => u16, u8;
+    u32 => u32, u16, u8;
+    u64 => u64, u32, u16, u8;
+    u128 => u128, u64, u32, u16, u8;
+    usize => usize, u16, u8;
+
+    i8 => i8;
+    i16 => i16, i8;
+    i32 => i32, i16, i8;
+    i64 => i64, i32, i16, i8;
+    i128 => i128, i64, i32, i16, i8;
+    isize => isize, i16, i8;
+}
+
+impl_extend! {
+    u8 => u8, u16, u32, u64, u128, usize;
+    u16 => u16, u32, u64, u128, usize;
+    u32 => u32, u64, u128;
+    u64 => u64, u128;
+    u128 => u128;
+    usize => usize;
+
+    i8 => i8, i16, i32, i64, i128, isize;
+    i16 => i16, i32, i64, i128, isize;
+    i32 => i32, i64, i128;
+    i64 => i64, i128;
+    i128 => i128;
+    isize => isize;
+}

--- a/library/core/src/num/traits.rs
+++ b/library/core/src/num/traits.rs
@@ -3,7 +3,8 @@
 
 /// Trait for types that this type can be truncated to
 #[unstable(feature = "num_internals", reason = "internal implementation detail", issue = "none")]
-pub trait TruncateTarget<Target>: crate::sealed::Sealed {
+#[rustc_const_unstable(feature = "integer_truncate_extend", issue = "154330")]
+pub const trait TruncateTarget<Target>: crate::sealed::Sealed {
     #[doc(hidden)]
     fn internal_truncate(self) -> Target;
 
@@ -16,7 +17,8 @@ pub trait TruncateTarget<Target>: crate::sealed::Sealed {
 
 /// Trait for types that this type can be truncated to
 #[unstable(feature = "num_internals", reason = "internal implementation detail", issue = "none")]
-pub trait ExtendTarget<Target>: crate::sealed::Sealed {
+#[rustc_const_unstable(feature = "integer_truncate_extend", issue = "154330")]
+pub const trait ExtendTarget<Target>: crate::sealed::Sealed {
     #[doc(hidden)]
     fn internal_extend(self) -> Target;
 }
@@ -38,7 +40,8 @@ macro_rules! impl_truncate {
         );
 
         #[unstable(feature = "num_internals", reason = "internal implementation detail", issue = "none")]
-        impl TruncateTarget<$to> for $from {
+        #[rustc_const_unstable(feature = "integer_truncate_extend", issue = "154330")]
+        impl const TruncateTarget<$to> for $from {
             #[inline]
             fn internal_truncate(self) -> $to {
                 self as _
@@ -84,7 +87,8 @@ macro_rules! impl_extend {
         );
 
         #[unstable(feature = "num_internals", reason = "internal implementation detail", issue = "none")]
-        impl ExtendTarget<$to> for $from {
+        #[rustc_const_unstable(feature = "integer_truncate_extend", issue = "154330")]
+        impl const ExtendTarget<$to> for $from {
             fn internal_extend(self) -> $to {
                 self as _
             }

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -4120,9 +4120,10 @@ macro_rules! uint_impl {
         /// ```
         #[must_use = "this returns the truncated value and does not modify the original"]
         #[unstable(feature = "integer_extend_truncate", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_truncate_extend", issue = "154330")]
         #[inline]
-        pub fn truncate<Target>(self) -> Target
-            where Self: traits::TruncateTarget<Target>
+        pub const fn truncate<Target>(self) -> Target
+            where Self: [const] traits::TruncateTarget<Target>
         {
             traits::TruncateTarget::internal_truncate(self)
         }
@@ -4139,9 +4140,10 @@ macro_rules! uint_impl {
         /// ```
         #[must_use = "this returns the truncated value and does not modify the original"]
         #[unstable(feature = "integer_extend_truncate", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_truncate_extend", issue = "154330")]
         #[inline]
-        pub fn saturating_truncate<Target>(self) -> Target
-            where Self: traits::TruncateTarget<Target>
+        pub const fn saturating_truncate<Target>(self) -> Target
+            where Self: [const] traits::TruncateTarget<Target>
         {
             traits::TruncateTarget::internal_saturating_truncate(self)
         }
@@ -4158,9 +4160,10 @@ macro_rules! uint_impl {
         /// ```
         #[must_use = "this returns the truncated value and does not modify the original"]
         #[unstable(feature = "integer_extend_truncate", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_truncate_extend", issue = "154330")]
         #[inline]
-        pub fn checked_truncate<Target>(self) -> Option<Target>
-            where Self: traits::TruncateTarget<Target>
+        pub const fn checked_truncate<Target>(self) -> Option<Target>
+            where Self: [const] traits::TruncateTarget<Target>
         {
             traits::TruncateTarget::internal_checked_truncate(self)
         }
@@ -4175,9 +4178,10 @@ macro_rules! uint_impl {
         /// ```
         #[must_use = "this returns the extended value and does not modify the original"]
         #[unstable(feature = "integer_extend_truncate", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_truncate_extend", issue = "154330")]
         #[inline]
-        pub fn extend<Target>(self) -> Target
-            where Self: traits::ExtendTarget<Target>
+        pub const fn extend<Target>(self) -> Target
+            where Self: [const] traits::ExtendTarget<Target>
         {
             traits::ExtendTarget::internal_extend(self)
         }

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -4107,5 +4107,79 @@ macro_rules! uint_impl {
         #[deprecated(since = "TBD", note = "replaced by the `MAX` associated constant on this type")]
         #[rustc_diagnostic_item = concat!(stringify!($SelfT), "_legacy_fn_max_value")]
         pub const fn max_value() -> Self { Self::MAX }
+
+        /// Truncate an integer to an integer of the same size or smaller, preserving the least
+        /// significant bits.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(integer_extend_truncate)]
+        #[doc = concat!("assert_eq!(120u8, 120", stringify!($SelfT), ".truncate());")]
+        /// assert_eq!(120u8, 376u32.truncate());
+        /// ```
+        #[must_use = "this returns the truncated value and does not modify the original"]
+        #[unstable(feature = "integer_extend_truncate", issue = "154330")]
+        #[inline]
+        pub fn truncate<Target>(self) -> Target
+            where Self: traits::TruncateTarget<Target>
+        {
+            traits::TruncateTarget::internal_truncate(self)
+        }
+
+        /// Truncate an integer to an integer of the same size or smaller, saturating at numeric bounds
+        /// instead of truncating.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(integer_extend_truncate)]
+        #[doc = concat!("assert_eq!(120u8, 120", stringify!($SelfT), ".saturating_truncate());")]
+        /// assert_eq!(255u8, 376u32.saturating_truncate());
+        /// ```
+        #[must_use = "this returns the truncated value and does not modify the original"]
+        #[unstable(feature = "integer_extend_truncate", issue = "154330")]
+        #[inline]
+        pub fn saturating_truncate<Target>(self) -> Target
+            where Self: traits::TruncateTarget<Target>
+        {
+            traits::TruncateTarget::internal_saturating_truncate(self)
+        }
+
+        /// Truncate an integer to an integer of the same size or smaller, returning `None` if the value
+        /// is outside the bounds of the smaller type.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(integer_extend_truncate)]
+        #[doc = concat!("assert_eq!(Some(120u8), 120", stringify!($SelfT), ".checked_truncate());")]
+        /// assert_eq!(None, 376u32.checked_truncate::<u8>());
+        /// ```
+        #[must_use = "this returns the truncated value and does not modify the original"]
+        #[unstable(feature = "integer_extend_truncate", issue = "154330")]
+        #[inline]
+        pub fn checked_truncate<Target>(self) -> Option<Target>
+            where Self: traits::TruncateTarget<Target>
+        {
+            traits::TruncateTarget::internal_checked_truncate(self)
+        }
+
+        /// Extend to an integer of the same size or larger, preserving its value.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(integer_extend_truncate)]
+        #[doc = concat!("assert_eq!(120u128, 120u8.extend());")]
+        /// ```
+        #[must_use = "this returns the extended value and does not modify the original"]
+        #[unstable(feature = "integer_extend_truncate", issue = "154330")]
+        #[inline]
+        pub fn extend<Target>(self) -> Target
+            where Self: traits::ExtendTarget<Target>
+        {
+            traits::ExtendTarget::internal_extend(self)
+        }
     }
 }

--- a/tests/ui/imports/issue-114682-3.stderr
+++ b/tests/ui/imports/issue-114682-3.stderr
@@ -5,13 +5,17 @@ LL |         fn ext(&self) {}
    |            --- the method is available for `u8` here
 ...
 LL |     a.ext();
-   |       ^^^ method not found in `u8`
+   |       ^^^
    |
    = help: items from traits can only be used if the trait is in scope
 help: trait `SettingsExt` which provides `ext` is implemented but not in scope; perhaps you want to import it
    |
 LL + use auto::SettingsExt;
    |
+help: there is a method `extend` with a similar name
+   |
+LL |     a.extend();
+   |          +++
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/154356)*
<!-- homu-ignore:end -->

Tracking issue: https://github.com/rust-lang/rust/issues/154330

This provides `.truncate()`, `.saturating_truncate()`, `.checked_truncate()`, and `.extend()`.

These only work within the same signedness (use `.cast_signed()` and `.cast_unsigned()` to change sign).

The truncation methods only work to smaller (or equal) types. `.extend()` only works to larger (or equal) types.

For the purposes of truncation and extending, nothing is considered larger than or equal to the size of `usize`, and `usize` is considered larger than `u16` or `u8`. We might, in the future, want to consider ways to expand this.

Much of this was pair-programmed with @Amanieu.

In order to seal the new traits, this PR also adds a `core::sealed::Sealed`, like the one in `std`. I didn't modify `std` to re-export the same one, since by definition it isn't nameable, and since doing that would require that it be nameable (even if it was `#[unstable]`).