### PR TITLE
fromrangeiter-overflow-checks: accept optional `signext` for argument

### DIFF
--- a/tests/codegen-llvm/fromrangeiter-overflow-checks.rs
+++ b/tests/codegen-llvm/fromrangeiter-overflow-checks.rs
@@ -19,7 +19,7 @@ pub unsafe fn rangefrom_increments(range: RangeFrom<i32>) -> RangeFrom<i32> {
     // Iterator is contained entirely within this function, so the optimizer should
     // be able to see that `exhausted` is never set and optimize out any branches.
 
-    //         CHECK: i32 noundef %range
+    //         CHECK: i32 noundef {{(signext )?}}%range
     //         DEBUG: switch i32 %range
     //         DEBUG: call core::panicking::panic_const::panic_const_add_overflow
     //         DEBUG: unreachable


### PR DESCRIPTION
On some targets such as LoongArch64 and RISCV64, the ABI requires sign-extension for 32-bit integer arguments, so LLVM may emit the `signext` attribute for the `%range` parameter. The existing CHECK pattern required the argument to be exactly `i32 noundef %range`, causing the test to fail on those targets.

Allow an optional `signext` attribute in the CHECK pattern so the test passes consistently across architectures without affecting the intended codegen validation.