### PR TITLE
delegation: fix zero-args nested delegation ICE

### DIFF
--- a/compiler/rustc_ast_lowering/src/delegation.rs
+++ b/compiler/rustc_ast_lowering/src/delegation.rs
@@ -432,6 +432,17 @@ impl<'hir, R: ResolverAstLoweringExt<'hir>> LoweringContext<'_, 'hir, R> {
                 args.push(arg);
             }
 
+            // If we have no params in signature function but user still wrote some code in
+            // delegation body, then add this code as first arg, eventually an error will be shown,
+            // also nested delegations may need to access information about this code (#154332),
+            // so it is better to leave this code as opposed to bodies of extern functions,
+            // which are completely erased from existence.
+            if param_count == 0
+                && let Some(block) = block
+            {
+                args.push(this.lower_target_expr(&block));
+            }
+
             let final_expr = this.finalize_body_lowering(delegation, args, generics, span);
 
             (this.arena.alloc_from_iter(parameters), final_expr)

--- a/tests/ui/delegation/explicit-paths-pass.rs
+++ b/tests/ui/delegation/explicit-paths-pass.rs
@@ -17,10 +17,7 @@ impl Trait for F {}
 
 mod to_reuse {
     pub fn foo(x: i32) -> i32 { x + 1 }
-    pub fn zero_args() -> i32 { 15 }
 }
-
-reuse to_reuse::zero_args { self }
 
 struct S(F);
 impl Trait for S {
@@ -49,5 +46,4 @@ fn main() {
     #[inline]
     reuse to_reuse::foo;
     assert_eq!(43, foo(42));
-    assert_eq!(15, zero_args());
 }

--- a/tests/ui/delegation/inner-attr.rs
+++ b/tests/ui/delegation/inner-attr.rs
@@ -4,5 +4,6 @@
 fn a() {}
 
 reuse a as b { #![rustc_dummy] self } //~ ERROR an inner attribute is not permitted in this context
+//~^ ERROR: this function takes 0 arguments but 1 argument was supplied
 
 fn main() {}

--- a/tests/ui/delegation/inner-attr.stderr
+++ b/tests/ui/delegation/inner-attr.stderr
@@ -3,11 +3,29 @@ error: an inner attribute is not permitted in this context
    |
 LL | reuse a as b { #![rustc_dummy] self }
    |                ^^^^^^^^^^^^^^^
-LL |
+...
 LL | fn main() {}
    | ------------ the inner attribute doesn't annotate this function
    |
    = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
 
-error: aborting due to 1 previous error
+error[E0061]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/inner-attr.rs:6:7
+   |
+LL | reuse a as b { #![rustc_dummy] self }
+   |       ^                        ---- unexpected argument
+   |
+note: function defined here
+  --> $DIR/inner-attr.rs:4:4
+   |
+LL | fn a() {}
+   |    ^
+help: remove the extra argument
+   |
+LL - reuse a as b { #![rustc_dummy] self }
+LL + reuse self }
+   |
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0061`.

--- a/tests/ui/delegation/zero-args-delegations-ice-154332.rs
+++ b/tests/ui/delegation/zero-args-delegations-ice-154332.rs
@@ -1,0 +1,30 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+mod test_ice {
+    fn a() {}
+
+    reuse a as b { //~ ERROR: this function takes 0 arguments but 1 argument was supplied
+        let closure = || {
+            fn foo<'a, 'b, T: Clone, const N: usize, U: Clone>(_t: &'a T, _u: &'b U) {}
+
+            reuse foo::<String, 1, String> as bar;
+            bar(&"".to_string(), &"".to_string());
+        };
+
+        closure();
+    }
+}
+
+mod test_2 {
+    mod to_reuse {
+        pub fn zero_args() -> i32 {
+            15
+        }
+    }
+
+    reuse to_reuse::zero_args { self }
+    //~^ ERROR: this function takes 0 arguments but 1 argument was supplied
+}
+
+fn main() {}

--- a/tests/ui/delegation/zero-args-delegations-ice-154332.stderr
+++ b/tests/ui/delegation/zero-args-delegations-ice-154332.stderr
@@ -1,0 +1,43 @@
+error[E0061]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/zero-args-delegations-ice-154332.rs:7:11
+   |
+LL |       reuse a as b {
+   |  ___________^______-
+LL | |         let closure = || {
+LL | |             fn foo<'a, 'b, T: Clone, const N: usize, U: Clone>(_t: &'a T, _u: &'b U) {}
+...  |
+LL | |         closure();
+LL | |     }
+   | |_____- unexpected argument of type `()`
+   |
+note: function defined here
+  --> $DIR/zero-args-delegations-ice-154332.rs:5:8
+   |
+LL |     fn a() {}
+   |        ^
+help: remove the extra argument
+   |
+LL -     reuse a as b {
+LL +     reuse {
+   |
+
+error[E0061]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/zero-args-delegations-ice-154332.rs:26:21
+   |
+LL |     reuse to_reuse::zero_args { self }
+   |                     ^^^^^^^^^   ---- unexpected argument
+   |
+note: function defined here
+  --> $DIR/zero-args-delegations-ice-154332.rs:21:16
+   |
+LL |         pub fn zero_args() -> i32 {
+   |                ^^^^^^^^^
+help: remove the extra argument
+   |
+LL -     reuse to_reuse::zero_args { self }
+LL +     reuse to_reuse::zero_argself }
+   |
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0061`.


### PR DESCRIPTION
This PR fixes an ICE when during lowering of nested delegation we need to access information about its parent, who is also inside body of another delegation. As a fix we lower delegation body even if there are no arguments in signature function, in this case we will see an error `this function takes 0 arguments but 1 argument was supplied`. Fixes rust-lang/rust#154332. Part of rust-lang/rust#118212.

r? @petrochenkov