### PR TITLE
Fix `pattern_from_macro_note` for bit-or expr

### DIFF
--- a/compiler/rustc_ast_lowering/src/pat.rs
+++ b/compiler/rustc_ast_lowering/src/pat.rs
@@ -418,7 +418,11 @@ impl<'hir, R: ResolverAstLoweringExt<'hir>> LoweringContext<'_, 'hir, R> {
             }
             _ => {
                 let is_const_block = matches!(expr.kind, ExprKind::ConstBlock(_));
-                let pattern_from_macro = expr.is_approximately_pattern();
+                let pattern_from_macro = expr.is_approximately_pattern()
+                    || matches!(
+                        expr.peel_parens().kind,
+                        ExprKind::Binary(Spanned { node: BinOpKind::BitOr, .. }, ..)
+                    );
                 let guar = self.dcx().emit_err(ArbitraryExpressionInPattern {
                     span,
                     pattern_from_macro_note: pattern_from_macro,

--- a/tests/ui/lowering/expr-in-pat-issue-99380.rs
+++ b/tests/ui/lowering/expr-in-pat-issue-99380.rs
@@ -6,6 +6,17 @@ macro_rules! foo {
     };
 }
 
+macro_rules! custom_matches {
+    ($e:expr, $p:expr) => {
+        match $e {
+            $p => true,
+            _ => false,
+        }
+    };
+}
+
 fn main() {
     foo!(Some(3)); //~ ERROR arbitrary expressions aren't allowed in patterns
+
+    let _ = custom_matches!(67, 6 | 7); //~ ERROR arbitrary expressions aren't allowed in patterns
 }

--- a/tests/ui/lowering/expr-in-pat-issue-99380.stderr
+++ b/tests/ui/lowering/expr-in-pat-issue-99380.stderr
@@ -1,10 +1,18 @@
 error: arbitrary expressions aren't allowed in patterns
-  --> $DIR/expr-in-pat-issue-99380.rs:10:10
+  --> $DIR/expr-in-pat-issue-99380.rs:19:10
    |
 LL |     foo!(Some(3));
    |          ^^^^^^^
    |
    = note: the `expr` fragment specifier forces the metavariable's content to be an expression
 
-error: aborting due to 1 previous error
+error: arbitrary expressions aren't allowed in patterns
+  --> $DIR/expr-in-pat-issue-99380.rs:21:33
+   |
+LL |     let _ = custom_matches!(67, 6 | 7);
+   |                                 ^^^^^
+   |
+   = note: the `expr` fragment specifier forces the metavariable's content to be an expression
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
This is a continuation of issue https://github.com/rust-lang/rust/issues/99380 (and pr https://github.com/rust-lang/rust/pull/124488) but covers bit-or pattern.

Essentially a `pat1 | pat2`, or any bit-or pattern used in a `$e:expr` was not firing the `.pattern_from_macro_note` diagnostic bc `ast::Expr::is_approximately_pattern()` did not cover bit-or.

The cover for bit-or is only added in `lower_expr_within_pat()`, otherwise doing it in `is_approximately_pattern()` would result in the suggestion `if (i + 2) = 2 => if let (i + 2) = 2` from `suggest_pattern_match_with_let()` (which is the only other place `ast::Expr::is_approximately_pattern()` is used from what i see).

resolves https://github.com/rust-lang/rust/issues/99380
refs https://github.com/rust-lang/rust/pull/124488