### PR TITLE
Clarify one-past-the-end pointer validity

### DIFF
--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -900,7 +900,7 @@ impl<T: PointeeSized> *const T {
     ///   "wrapping around"), must fit in an `isize`.
     ///
     /// * If the computed offset is non-zero, then `self` must be [derived from][crate::ptr#provenance] a pointer to some
-    ///   [allocation], and the entire memory range between `self` and the result must be in
+    ///   [allocation], and the entire memory range between `self` and the result (not including result) must be in
     ///   bounds of that allocation. In particular, this range must not "wrap around" the edge
     ///   of the address space.
     ///

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -900,7 +900,7 @@ impl<T: PointeeSized> *const T {
     ///   "wrapping around"), must fit in an `isize`.
     ///
     /// * If the computed offset is non-zero, then `self` must be [derived from][crate::ptr#provenance] a pointer to some
-    ///   [allocation], and the entire memory range between `self` and the result (not including result) must be in
+    ///   [allocation], and the entire memory range between `self` and the result (exclusive) must be in
     ///   bounds of that allocation. In particular, this range must not "wrap around" the edge
     ///   of the address space.
     ///

--- a/library/core/src/ptr/docs/add.md
+++ b/library/core/src/ptr/docs/add.md
@@ -15,7 +15,7 @@ If any of the following conditions are violated, the result is Undefined Behavio
 "wrapping around"), must fit in an `isize`.
 
 * If the computed offset is non-zero, then `self` must be [derived from][crate::ptr#provenance] a pointer to some
-[allocation], and the entire memory range between `self` and the result must be in
+[allocation], and the entire memory range between `self` and the result (not including result) must be in
 bounds of that allocation. In particular, this range must not "wrap around" the edge
 of the address space.
 

--- a/library/core/src/ptr/docs/add.md
+++ b/library/core/src/ptr/docs/add.md
@@ -15,7 +15,7 @@ If any of the following conditions are violated, the result is Undefined Behavio
 "wrapping around"), must fit in an `isize`.
 
 * If the computed offset is non-zero, then `self` must be [derived from][crate::ptr#provenance] a pointer to some
-[allocation], and the entire memory range between `self` and the result (not including result) must be in
+[allocation], and the entire memory range between `self` and the result (exclusive) must be in
 bounds of that allocation. In particular, this range must not "wrap around" the edge
 of the address space.
 

--- a/library/core/src/ptr/docs/offset.md
+++ b/library/core/src/ptr/docs/offset.md
@@ -11,7 +11,7 @@ If any of the following conditions are violated, the result is Undefined Behavio
 "wrapping around"), must fit in an `isize`.
 
 * If the computed offset is non-zero, then `self` must be [derived from][crate::ptr#provenance] a pointer to some
-[allocation], and the entire memory range between `self` and the result must be in
+[allocation], and the entire memory range between `self` and the result (not including result) must be in
 bounds of that allocation. In particular, this range must not "wrap around" the edge
 of the address space. Note that "range" here refers to a half-open range as usual in Rust,
 i.e., `self..result` for non-negative offsets and `result..self` for negative offsets.

--- a/library/core/src/ptr/docs/offset.md
+++ b/library/core/src/ptr/docs/offset.md
@@ -11,7 +11,7 @@ If any of the following conditions are violated, the result is Undefined Behavio
 "wrapping around"), must fit in an `isize`.
 
 * If the computed offset is non-zero, then `self` must be [derived from][crate::ptr#provenance] a pointer to some
-[allocation], and the entire memory range between `self` and the result (not including result) must be in
+[allocation], and the entire memory range between `self` and the result (exclusive) must be in
 bounds of that allocation. In particular, this range must not "wrap around" the edge
 of the address space. Note that "range" here refers to a half-open range as usual in Rust,
 i.e., `self..result` for non-negative offsets and `result..self` for negative offsets.

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -998,7 +998,7 @@ impl<T: PointeeSized> *mut T {
     ///   "wrapping around"), must fit in an `isize`.
     ///
     /// * If the computed offset is non-zero, then `self` must be [derived from][crate::ptr#provenance] a pointer to some
-    ///   [allocation], and the entire memory range between `self` and the result must be in
+    ///   [allocation], and the entire memory range between `self` and the result (not including result) must be in
     ///   bounds of that allocation. In particular, this range must not "wrap around" the edge
     ///   of the address space.
     ///

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -998,7 +998,7 @@ impl<T: PointeeSized> *mut T {
     ///   "wrapping around"), must fit in an `isize`.
     ///
     /// * If the computed offset is non-zero, then `self` must be [derived from][crate::ptr#provenance] a pointer to some
-    ///   [allocation], and the entire memory range between `self` and the result (not including result) must be in
+    ///   [allocation], and the entire memory range between `self` and the result (exclusive) must be in
     ///   bounds of that allocation. In particular, this range must not "wrap around" the edge
     ///   of the address space.
     ///

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -543,9 +543,9 @@ impl<T: PointeeSized> NonNull<T> {
     /// * The computed offset, `count * size_of::<T>()` bytes, must not overflow `isize`.
     ///
     /// * If the computed offset is non-zero, then `self` must be derived from a pointer to some
-    ///   [allocation], and the entire memory range between `self` and the result must be in
-    ///   bounds of that allocation. In particular, this range must not "wrap around" the edge
-    ///   of the address space.
+    ///   [allocation], and the entire memory range between `self` and the result (not including
+    ///   result) must be in bounds of that allocation. In particular, this range must not "wrap
+    ///   around" the edge of the address space.
     ///
     /// Allocations can never be larger than `isize::MAX` bytes, so if the computed offset
     /// stays in bounds of the allocation, it is guaranteed to satisfy the first requirement.
@@ -619,9 +619,9 @@ impl<T: PointeeSized> NonNull<T> {
     /// * The computed offset, `count * size_of::<T>()` bytes, must not overflow `isize`.
     ///
     /// * If the computed offset is non-zero, then `self` must be derived from a pointer to some
-    ///   [allocation], and the entire memory range between `self` and the result must be in
-    ///   bounds of that allocation. In particular, this range must not "wrap around" the edge
-    ///   of the address space.
+    ///   [allocation], and the entire memory range between `self` and the result (not including
+    ///   result) must be in bounds of that allocation. In particular, this range must not "wrap
+    ///   around" the edge of the address space.
     ///
     /// Allocations can never be larger than `isize::MAX` bytes, so if the computed offset
     /// stays in bounds of the allocation, it is guaranteed to satisfy the first requirement.
@@ -696,9 +696,9 @@ impl<T: PointeeSized> NonNull<T> {
     /// * The computed offset, `count * size_of::<T>()` bytes, must not overflow `isize`.
     ///
     /// * If the computed offset is non-zero, then `self` must be derived from a pointer to some
-    ///   [allocation], and the entire memory range between `self` and the result must be in
-    ///   bounds of that allocation. In particular, this range must not "wrap around" the edge
-    ///   of the address space.
+    ///   [allocation], and the entire memory range between `self` and the result (not including
+    ///   result) must be in bounds of that allocation. In particular, this range must not "wrap
+    ///   around" the edge of the address space.
     ///
     /// Allocations can never be larger than `isize::MAX` bytes, so if the computed offset
     /// stays in bounds of the allocation, it is guaranteed to satisfy the first requirement.

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -543,9 +543,9 @@ impl<T: PointeeSized> NonNull<T> {
     /// * The computed offset, `count * size_of::<T>()` bytes, must not overflow `isize`.
     ///
     /// * If the computed offset is non-zero, then `self` must be derived from a pointer to some
-    ///   [allocation], and the entire memory range between `self` and the result (not including
-    ///   result) must be in bounds of that allocation. In particular, this range must not "wrap
-    ///   around" the edge of the address space.
+    ///   [allocation], and the entire memory range between `self` and the result (exclusive) must
+    ///   be in bounds of that allocation. In particular, this range must not "wrap around" the edge
+    ///   of the address space.
     ///
     /// Allocations can never be larger than `isize::MAX` bytes, so if the computed offset
     /// stays in bounds of the allocation, it is guaranteed to satisfy the first requirement.
@@ -619,9 +619,9 @@ impl<T: PointeeSized> NonNull<T> {
     /// * The computed offset, `count * size_of::<T>()` bytes, must not overflow `isize`.
     ///
     /// * If the computed offset is non-zero, then `self` must be derived from a pointer to some
-    ///   [allocation], and the entire memory range between `self` and the result (not including
-    ///   result) must be in bounds of that allocation. In particular, this range must not "wrap
-    ///   around" the edge of the address space.
+    ///   [allocation], and the entire memory range between `self` and the result (exclusive) must
+    ///   be in bounds of that allocation. In particular, this range must not "wrap around" the edge
+    ///   of the address space.
     ///
     /// Allocations can never be larger than `isize::MAX` bytes, so if the computed offset
     /// stays in bounds of the allocation, it is guaranteed to satisfy the first requirement.
@@ -696,9 +696,9 @@ impl<T: PointeeSized> NonNull<T> {
     /// * The computed offset, `count * size_of::<T>()` bytes, must not overflow `isize`.
     ///
     /// * If the computed offset is non-zero, then `self` must be derived from a pointer to some
-    ///   [allocation], and the entire memory range between `self` and the result (not including
-    ///   result) must be in bounds of that allocation. In particular, this range must not "wrap
-    ///   around" the edge of the address space.
+    ///   [allocation], and the entire memory range between `self` and the result (exclusive) must
+    ///   be in bounds of that allocation. In particular, this range must not "wrap around" the edge
+    ///   of the address space.
     ///
     /// Allocations can never be larger than `isize::MAX` bytes, so if the computed offset
     /// stays in bounds of the allocation, it is guaranteed to satisfy the first requirement.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
It's documented that `vec.as_ptr().add(vec.len())` is safe, but the main safety condition wasn't clear enough.