### PR TITLE
Skip linting unused braces for FunctionArg and MethodArg context for 2024 later 

### DIFF
--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -135,6 +135,86 @@ trait UnusedDelimLint {
         is_kw: bool,
     );
 
+    /// Returns whether the outer braces of a single-expression function/method
+    /// argument block can be removed.
+    ///
+    /// In Rust 2024, `{ expr }` can drop tail-expression temporaries before the
+    /// call starts. Removing the block may extend those temporaries, so lint only
+    /// expression forms that are harmless here.
+    fn expr_allows_remove_arg_block(expr: &ast::Expr) -> bool {
+        use ast::ExprKind::*;
+
+        match &expr.peel_parens().kind {
+            Lit(_) | IncludedBytes(_) | Path(..) => true,
+            Unary(_, expr)
+            | Cast(expr, _)
+            | Type(expr, _)
+            | Use(expr, _)
+            | Await(expr, _)
+            | Try(expr)
+            | Move(expr, _)
+            | AddrOf(_, _, expr)
+            | UnsafeBinderCast(_, expr, _) => Self::expr_allows_remove_arg_block(expr),
+            Array(exprs) | Tup(exprs) => {
+                exprs.iter().all(|expr| Self::expr_allows_remove_arg_block(expr))
+            }
+            Binary(_, lhs, rhs) | Assign(lhs, rhs, _) | AssignOp(_, lhs, rhs) => {
+                Self::expr_allows_remove_arg_block(lhs) && Self::expr_allows_remove_arg_block(rhs)
+            }
+            Index(base, index, _) => {
+                Self::expr_allows_remove_arg_block(base)
+                    && Self::expr_allows_remove_arg_block(index)
+            }
+            Range(start, end, _) => {
+                start.as_ref().is_none_or(|expr| Self::expr_allows_remove_arg_block(expr))
+                    && end.as_ref().is_none_or(|expr| Self::expr_allows_remove_arg_block(expr))
+            }
+            Struct(expr) => {
+                expr.fields.iter().all(|field| Self::expr_allows_remove_arg_block(&field.expr))
+                    && match &expr.rest {
+                        ast::StructRest::Base(expr) => Self::expr_allows_remove_arg_block(expr),
+                        ast::StructRest::Rest(_) | ast::StructRest::None => true,
+                        ast::StructRest::NoneWithError(_) => false,
+                    }
+            }
+            Repeat(expr, _) => Self::expr_allows_remove_arg_block(expr),
+            ConstBlock(_)
+            | If(..)
+            | While(..)
+            | ForLoop { .. }
+            | Loop(..)
+            | Match(..)
+            | Closure(_)
+            | Block(..)
+            | Gen(..)
+            | TryBlock(..)
+            | Break(..)
+            | Continue(_)
+            | Ret(_)
+            | InlineAsm(_)
+            | OffsetOf(..)
+            | Yield(_)
+            | Yeet(_)
+            | Paren(_)
+            | Become(_) => true,
+            Call(..) | MethodCall(_) | Let(..) | Field(..) | MacCall(_) | FormatArgs(_) => false,
+            // don't lint for placeholder/error-recovery
+            Underscore | Err(_) | Dummy => false,
+        }
+    }
+
+    /// Returns whether `{ expr }` must be kept in function/method argument
+    /// position to avoid changing temporary lifetime semantics.
+    fn needs_arg_block_to_preserve_temporaries(
+        ctx: UnusedDelimsCtx,
+        arg_block: &ast::Expr,
+        expr: &ast::Expr,
+    ) -> bool {
+        matches!(ctx, UnusedDelimsCtx::FunctionArg | UnusedDelimsCtx::MethodArg)
+            && arg_block.span.edition().at_least_rust_2024()
+            && !Self::expr_allows_remove_arg_block(expr)
+    }
+
     fn is_expr_delims_necessary(
         inner: &ast::Expr,
         ctx: UnusedDelimsCtx,
@@ -1094,6 +1174,7 @@ impl UnusedDelimLint for UnusedBraces {
                 if let [stmt] = inner.stmts.as_slice()
                     && let ast::StmtKind::Expr(ref expr) = stmt.kind
                     && !Self::is_expr_delims_necessary(expr, ctx, followed_by_block)
+                    && !Self::needs_arg_block_to_preserve_temporaries(ctx, value, expr)
                     && (ctx != UnusedDelimsCtx::AnonConst
                         || (matches!(expr.kind, ast::ExprKind::Lit(_))
                             && !expr.span.from_expansion()))

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -135,6 +135,88 @@ trait UnusedDelimLint {
         is_kw: bool,
     );
 
+    /// Returns whether the outer braces of a single-expression function/method
+    /// argument block can be removed.
+    ///
+    /// In Rust 2024, `{ expr }` can drop tail-expression temporaries before the
+    /// call starts. Removing the block may extend those temporaries, so lint only
+    /// expression forms that are harmless here.
+    fn expr_allows_remove_arg_block(expr: &ast::Expr) -> bool {
+        use ast::ExprKind::*;
+
+        match &expr.peel_parens().kind {
+            Lit(_) | IncludedBytes(_) | Path(..) => true,
+            Unary(_, expr)
+            | Cast(expr, _)
+            | Type(expr, _)
+            | Use(expr, _)
+            | Await(expr, _)
+            | Try(expr)
+            | Move(expr, _)
+            | AddrOf(_, _, expr)
+            | UnsafeBinderCast(_, expr, _) => Self::expr_allows_remove_arg_block(expr),
+            Array(exprs) | Tup(exprs) => {
+                exprs.iter().all(|expr| Self::expr_allows_remove_arg_block(expr))
+            }
+            Binary(_, lhs, rhs) | Assign(lhs, rhs, _) | AssignOp(_, lhs, rhs) => {
+                Self::expr_allows_remove_arg_block(lhs) && Self::expr_allows_remove_arg_block(rhs)
+            }
+            Index(base, index, _) => {
+                Self::expr_allows_remove_arg_block(base)
+                    && Self::expr_allows_remove_arg_block(index)
+            }
+            Range(start, end, _) => {
+                start.as_ref().is_none_or(|expr| Self::expr_allows_remove_arg_block(expr))
+                    && end.as_ref().is_none_or(|expr| Self::expr_allows_remove_arg_block(expr))
+            }
+            Struct(expr) => {
+                expr.fields.iter().all(|field| Self::expr_allows_remove_arg_block(&field.expr))
+                    && match &expr.rest {
+                        ast::StructRest::Base(expr) => Self::expr_allows_remove_arg_block(expr),
+                        ast::StructRest::Rest(_) | ast::StructRest::None => true,
+                        ast::StructRest::NoneWithError(_) => false,
+                    }
+            }
+            Repeat(expr, _) => Self::expr_allows_remove_arg_block(expr),
+            ConstBlock(_)
+            | If(..)
+            | While(..)
+            | ForLoop { .. }
+            | Loop(..)
+            | Match(..)
+            | Closure(_)
+            | Block(..)
+            | Gen(..)
+            | TryBlock(..)
+            | Break(..)
+            | Continue(_)
+            | Ret(_)
+            | InlineAsm(_)
+            | OffsetOf(..)
+            | Yield(_)
+            | Yeet(_)
+            | Paren(_)
+            | Become(_) => true,
+            Call(..) | MethodCall(_) | Let(..) | Field(..) | MacCall(_) | FormatArgs(_) => false,
+            // `direct_const_arg!()` is invalid in function/method argument position.
+            DirectConstArg(_) => false,
+            // don't lint for placeholder/error-recovery
+            Underscore | Err(_) | Dummy => false,
+        }
+    }
+
+    /// Returns whether `{ expr }` must be kept in function/method argument
+    /// position to avoid changing temporary lifetime semantics.
+    fn needs_arg_block_to_preserve_temporaries(
+        ctx: UnusedDelimsCtx,
+        arg_block: &ast::Expr,
+        expr: &ast::Expr,
+    ) -> bool {
+        matches!(ctx, UnusedDelimsCtx::FunctionArg | UnusedDelimsCtx::MethodArg)
+            && arg_block.span.edition().at_least_rust_2024()
+            && !Self::expr_allows_remove_arg_block(expr)
+    }
+
     fn is_expr_delims_necessary(
         inner: &ast::Expr,
         ctx: UnusedDelimsCtx,
@@ -1098,6 +1180,7 @@ impl UnusedDelimLint for UnusedBraces {
                     // lock guard, before the loop starts.
                     && !(ctx == UnusedDelimsCtx::ForIterExpr
                         && value.span.edition().at_least_rust_2024())
+                    && !Self::needs_arg_block_to_preserve_temporaries(ctx, value, expr)
                     && (ctx != UnusedDelimsCtx::AnonConst
                         || (matches!(expr.kind, ast::ExprKind::Lit(_))
                             && !expr.span.from_expansion()))

--- a/tests/ui/const-generics/mgca/bad-direct-const-arg.rs
+++ b/tests/ui/const-generics/mgca/bad-direct-const-arg.rs
@@ -1,8 +1,15 @@
-//! Simple error message test, nothing special here
+//@ edition: 2024
+
+//! Reject direct const arguments in value/type positions without unrelated brace suggestions.
 #![feature(min_generic_const_args)]
+#![deny(unused_braces)]
 
 fn main(x: core::direct_const_arg!(2)) {
     //~^ ERROR expected type, found `direct_const_arg!()` constant
     let _ = core::direct_const_arg!(2);
     //~^ ERROR expected expression, found `direct_const_arg!()` constant
+    consume({ core::direct_const_arg!(2) });
+    //~^ ERROR expected expression, found `direct_const_arg!()` constant
 }
+
+fn consume(_: usize) {}

--- a/tests/ui/const-generics/mgca/bad-direct-const-arg.stderr
+++ b/tests/ui/const-generics/mgca/bad-direct-const-arg.stderr
@@ -1,14 +1,20 @@
 error: expected expression, found `direct_const_arg!()` constant
-  --> $DIR/bad-direct-const-arg.rs:6:13
+  --> $DIR/bad-direct-const-arg.rs:9:13
    |
 LL |     let _ = core::direct_const_arg!(2);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+error: expected expression, found `direct_const_arg!()` constant
+  --> $DIR/bad-direct-const-arg.rs:11:15
+   |
+LL |     consume({ core::direct_const_arg!(2) });
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: expected type, found `direct_const_arg!()` constant
-  --> $DIR/bad-direct-const-arg.rs:4:12
+  --> $DIR/bad-direct-const-arg.rs:7:12
    |
 LL | fn main(x: core::direct_const_arg!(2)) {
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 

--- a/tests/ui/lint/unused_braces-issue-154247.fixed
+++ b/tests/ui/lint/unused_braces-issue-154247.fixed
@@ -1,0 +1,167 @@
+//@ edition: 2024
+//@ check-pass
+//@ run-rustfix
+
+#![feature(move_expr)]
+#![warn(unused_braces)]
+
+use std::sync::Mutex;
+
+fn consume(lock: &Mutex<Vec<u8>>, _value: usize) {
+    let _guard = lock.lock().unwrap();
+}
+
+fn consume_int<T>(_: T) {}
+
+fn make_int() -> usize {
+    7
+}
+
+fn static_int_ref() -> &'static usize {
+    &7
+}
+
+struct Point {
+    _x: usize,
+}
+
+struct Pair {
+    _x: usize,
+    _y: usize,
+}
+
+fn make_pair() -> Pair {
+    Pair { _x: 1, _y: 2 }
+}
+
+macro_rules! make_int_macro {
+    () => {
+        make_int()
+    };
+}
+
+struct Lockable(Mutex<Vec<u8>>);
+
+impl Lockable {
+    fn update(&self, _value: usize) {
+        let _guard = self.0.lock().unwrap();
+    }
+
+    fn run(&self) {
+        // These blocks shorten the lifetime of the temporary `MutexGuard`.
+        consume(&self.0, { self.0.lock().unwrap().len() });
+        self.update({ self.0.lock().unwrap().len() });
+        consume_int({ [self.0.lock().unwrap().len()] });
+    }
+}
+
+fn main() {
+    let x = 7;
+
+    consume_int(7);
+    //~^ WARN unnecessary braces
+
+    consume_int(x);
+    //~^ WARN unnecessary braces
+
+    consume_int(x as usize);
+    //~^ WARN unnecessary braces
+
+    consume_int((x, 7));
+    //~^ WARN unnecessary braces
+
+    consume_int([x, 7]);
+    //~^ WARN unnecessary braces
+
+    consume_int(!false);
+    //~^ WARN unnecessary braces
+
+    consume_int(x + 1);
+    //~^ WARN unnecessary braces
+
+    consume_int([x, 7][0]);
+    //~^ WARN unnecessary braces
+
+    consume_int(0..x);
+    //~^ WARN unnecessary braces
+
+    consume_int(const { 7 });
+    //~^ WARN unnecessary braces
+
+    consume_int(if x > 0 { x } else { 0 });
+    //~^ WARN unnecessary braces
+
+    consume_int(while false {});
+    //~^ WARN unnecessary braces
+
+    consume_int(for _ in 0..0 {});
+    //~^ WARN unnecessary braces
+
+    consume_int(loop { break x; });
+    //~^ WARN unnecessary braces
+
+    consume_int(match x { 0 => 1, _ => x });
+    //~^ WARN unnecessary braces
+
+    consume_int(x);
+    //~^ WARN unnecessary braces
+    //~| WARN unnecessary braces
+
+    consume_int(|| x);
+    //~^ WARN unnecessary braces
+
+    let mut y = x;
+
+    consume_int(y += 1);
+    //~^ WARN unnecessary braces
+
+    consume_int(y);
+
+    consume_int(y = x);
+    //~^ WARN unnecessary braces
+
+    consume_int(y);
+
+    consume_int(Point { _x: x });
+    //~^ WARN unnecessary braces
+
+    consume_int([x; 2]);
+    //~^ WARN unnecessary braces
+
+    consume_int(&x);
+    //~^ WARN unnecessary braces
+
+    let move_expr_closure = || {
+        consume_int(move(x));
+        //~^ WARN unnecessary braces
+
+        consume_int({ move(make_int()) });
+    };
+    move_expr_closure();
+
+    Lockable(Mutex::new(vec![1])).update(7);
+    //~^ WARN unnecessary braces
+
+    Lockable(Mutex::new(vec![1])).update(x as usize);
+    //~^ WARN unnecessary braces
+
+    Lockable(Mutex::new(vec![1])).run();
+
+    // These blocks contain calls, borrows, macros, or projections where removing
+    // the argument block may extend temporaries in Rust 2024.
+    consume_int({ make_int() });
+    consume_int({ make_int() + 1 });
+    consume_int({ String::from("abc").len() });
+    consume_int({ [make_int(), x] });
+    consume_int({ [x, make_int()][0] });
+    consume_int({ 0..make_int() });
+    consume_int({ Point { _x: make_int() } });
+    consume_int({ Pair { _x: x, ..make_pair() } });
+    consume_int({ [make_int(); 2] });
+    consume_int({ make_int_macro!() });
+    consume_int({ format_args!("value") });
+    consume_int({ &*static_int_ref() });
+
+    let point = Point { _x: x };
+    consume_int({ point._x });
+}

--- a/tests/ui/lint/unused_braces-issue-154247.rs
+++ b/tests/ui/lint/unused_braces-issue-154247.rs
@@ -1,0 +1,167 @@
+//@ edition: 2024
+//@ check-pass
+//@ run-rustfix
+
+#![feature(move_expr)]
+#![warn(unused_braces)]
+
+use std::sync::Mutex;
+
+fn consume(lock: &Mutex<Vec<u8>>, _value: usize) {
+    let _guard = lock.lock().unwrap();
+}
+
+fn consume_int<T>(_: T) {}
+
+fn make_int() -> usize {
+    7
+}
+
+fn static_int_ref() -> &'static usize {
+    &7
+}
+
+struct Point {
+    _x: usize,
+}
+
+struct Pair {
+    _x: usize,
+    _y: usize,
+}
+
+fn make_pair() -> Pair {
+    Pair { _x: 1, _y: 2 }
+}
+
+macro_rules! make_int_macro {
+    () => {
+        make_int()
+    };
+}
+
+struct Lockable(Mutex<Vec<u8>>);
+
+impl Lockable {
+    fn update(&self, _value: usize) {
+        let _guard = self.0.lock().unwrap();
+    }
+
+    fn run(&self) {
+        // These blocks shorten the lifetime of the temporary `MutexGuard`.
+        consume(&self.0, { self.0.lock().unwrap().len() });
+        self.update({ self.0.lock().unwrap().len() });
+        consume_int({ [self.0.lock().unwrap().len()] });
+    }
+}
+
+fn main() {
+    let x = 7;
+
+    consume_int({ 7 });
+    //~^ WARN unnecessary braces
+
+    consume_int({ x });
+    //~^ WARN unnecessary braces
+
+    consume_int({ x as usize });
+    //~^ WARN unnecessary braces
+
+    consume_int({ (x, 7) });
+    //~^ WARN unnecessary braces
+
+    consume_int({ [x, 7] });
+    //~^ WARN unnecessary braces
+
+    consume_int({ !false });
+    //~^ WARN unnecessary braces
+
+    consume_int({ x + 1 });
+    //~^ WARN unnecessary braces
+
+    consume_int({ [x, 7][0] });
+    //~^ WARN unnecessary braces
+
+    consume_int({ 0..x });
+    //~^ WARN unnecessary braces
+
+    consume_int({ const { 7 } });
+    //~^ WARN unnecessary braces
+
+    consume_int({ if x > 0 { x } else { 0 } });
+    //~^ WARN unnecessary braces
+
+    consume_int({ while false {} });
+    //~^ WARN unnecessary braces
+
+    consume_int({ for _ in 0..0 {} });
+    //~^ WARN unnecessary braces
+
+    consume_int({ loop { break x; } });
+    //~^ WARN unnecessary braces
+
+    consume_int({ match x { 0 => 1, _ => x } });
+    //~^ WARN unnecessary braces
+
+    consume_int({ { x } });
+    //~^ WARN unnecessary braces
+    //~| WARN unnecessary braces
+
+    consume_int({ || x });
+    //~^ WARN unnecessary braces
+
+    let mut y = x;
+
+    consume_int({ y += 1 });
+    //~^ WARN unnecessary braces
+
+    consume_int(y);
+
+    consume_int({ y = x });
+    //~^ WARN unnecessary braces
+
+    consume_int(y);
+
+    consume_int({ Point { _x: x } });
+    //~^ WARN unnecessary braces
+
+    consume_int({ [x; 2] });
+    //~^ WARN unnecessary braces
+
+    consume_int({ &x });
+    //~^ WARN unnecessary braces
+
+    let move_expr_closure = || {
+        consume_int({ move(x) });
+        //~^ WARN unnecessary braces
+
+        consume_int({ move(make_int()) });
+    };
+    move_expr_closure();
+
+    Lockable(Mutex::new(vec![1])).update({ 7 });
+    //~^ WARN unnecessary braces
+
+    Lockable(Mutex::new(vec![1])).update({ x as usize });
+    //~^ WARN unnecessary braces
+
+    Lockable(Mutex::new(vec![1])).run();
+
+    // These blocks contain calls, borrows, macros, or projections where removing
+    // the argument block may extend temporaries in Rust 2024.
+    consume_int({ make_int() });
+    consume_int({ make_int() + 1 });
+    consume_int({ String::from("abc").len() });
+    consume_int({ [make_int(), x] });
+    consume_int({ [x, make_int()][0] });
+    consume_int({ 0..make_int() });
+    consume_int({ Point { _x: make_int() } });
+    consume_int({ Pair { _x: x, ..make_pair() } });
+    consume_int({ [make_int(); 2] });
+    consume_int({ make_int_macro!() });
+    consume_int({ format_args!("value") });
+    consume_int({ &*static_int_ref() });
+
+    let point = Point { _x: x };
+    consume_int({ point._x });
+}

--- a/tests/ui/lint/unused_braces-issue-154247.stderr
+++ b/tests/ui/lint/unused_braces-issue-154247.stderr
@@ -1,0 +1,319 @@
+warning: unnecessary braces around function argument
+  --> $DIR/unused_braces-issue-154247.rs:61:17
+   |
+LL |     consume_int({ 7 });
+   |                 ^^ ^^
+   |
+note: the lint level is defined here
+  --> $DIR/unused_braces-issue-154247.rs:6:9
+   |
+LL | #![warn(unused_braces)]
+   |         ^^^^^^^^^^^^^
+help: remove these braces
+   |
+LL -     consume_int({ 7 });
+LL +     consume_int(7);
+   |
+
+warning: unnecessary braces around function argument
+  --> $DIR/unused_braces-issue-154247.rs:64:17
+   |
+LL |     consume_int({ x });
+   |                 ^^ ^^
+   |
+help: remove these braces
+   |
+LL -     consume_int({ x });
+LL +     consume_int(x);
+   |
+
+warning: unnecessary braces around function argument
+  --> $DIR/unused_braces-issue-154247.rs:67:17
+   |
+LL |     consume_int({ x as usize });
+   |                 ^^          ^^
+   |
+help: remove these braces
+   |
+LL -     consume_int({ x as usize });
+LL +     consume_int(x as usize);
+   |
+
+warning: unnecessary braces around function argument
+  --> $DIR/unused_braces-issue-154247.rs:70:17
+   |
+LL |     consume_int({ (x, 7) });
+   |                 ^^      ^^
+   |
+help: remove these braces
+   |
+LL -     consume_int({ (x, 7) });
+LL +     consume_int((x, 7));
+   |
+
+warning: unnecessary braces around function argument
+  --> $DIR/unused_braces-issue-154247.rs:73:17
+   |
+LL |     consume_int({ [x, 7] });
+   |                 ^^      ^^
+   |
+help: remove these braces
+   |
+LL -     consume_int({ [x, 7] });
+LL +     consume_int([x, 7]);
+   |
+
+warning: unnecessary braces around function argument
+  --> $DIR/unused_braces-issue-154247.rs:76:17
+   |
+LL |     consume_int({ !false });
+   |                 ^^      ^^
+   |
+help: remove these braces
+   |
+LL -     consume_int({ !false });
+LL +     consume_int(!false);
+   |
+
+warning: unnecessary braces around function argument
+  --> $DIR/unused_braces-issue-154247.rs:79:17
+   |
+LL |     consume_int({ x + 1 });
+   |                 ^^     ^^
+   |
+help: remove these braces
+   |
+LL -     consume_int({ x + 1 });
+LL +     consume_int(x + 1);
+   |
+
+warning: unnecessary braces around function argument
+  --> $DIR/unused_braces-issue-154247.rs:82:17
+   |
+LL |     consume_int({ [x, 7][0] });
+   |                 ^^         ^^
+   |
+help: remove these braces
+   |
+LL -     consume_int({ [x, 7][0] });
+LL +     consume_int([x, 7][0]);
+   |
+
+warning: unnecessary braces around function argument
+  --> $DIR/unused_braces-issue-154247.rs:85:17
+   |
+LL |     consume_int({ 0..x });
+   |                 ^^    ^^
+   |
+help: remove these braces
+   |
+LL -     consume_int({ 0..x });
+LL +     consume_int(0..x);
+   |
+
+warning: unnecessary braces around function argument
+  --> $DIR/unused_braces-issue-154247.rs:88:17
+   |
+LL |     consume_int({ const { 7 } });
+   |                 ^^           ^^
+   |
+help: remove these braces
+   |
+LL -     consume_int({ const { 7 } });
+LL +     consume_int(const { 7 });
+   |
+
+warning: unnecessary braces around function argument
+  --> $DIR/unused_braces-issue-154247.rs:91:17
+   |
+LL |     consume_int({ if x > 0 { x } else { 0 } });
+   |                 ^^                         ^^
+   |
+help: remove these braces
+   |
+LL -     consume_int({ if x > 0 { x } else { 0 } });
+LL +     consume_int(if x > 0 { x } else { 0 });
+   |
+
+warning: unnecessary braces around function argument
+  --> $DIR/unused_braces-issue-154247.rs:94:17
+   |
+LL |     consume_int({ while false {} });
+   |                 ^^              ^^
+   |
+help: remove these braces
+   |
+LL -     consume_int({ while false {} });
+LL +     consume_int(while false {});
+   |
+
+warning: unnecessary braces around function argument
+  --> $DIR/unused_braces-issue-154247.rs:97:17
+   |
+LL |     consume_int({ for _ in 0..0 {} });
+   |                 ^^                ^^
+   |
+help: remove these braces
+   |
+LL -     consume_int({ for _ in 0..0 {} });
+LL +     consume_int(for _ in 0..0 {});
+   |
+
+warning: unnecessary braces around function argument
+  --> $DIR/unused_braces-issue-154247.rs:100:17
+   |
+LL |     consume_int({ loop { break x; } });
+   |                 ^^                 ^^
+   |
+help: remove these braces
+   |
+LL -     consume_int({ loop { break x; } });
+LL +     consume_int(loop { break x; });
+   |
+
+warning: unnecessary braces around function argument
+  --> $DIR/unused_braces-issue-154247.rs:103:17
+   |
+LL |     consume_int({ match x { 0 => 1, _ => x } });
+   |                 ^^                          ^^
+   |
+help: remove these braces
+   |
+LL -     consume_int({ match x { 0 => 1, _ => x } });
+LL +     consume_int(match x { 0 => 1, _ => x });
+   |
+
+warning: unnecessary braces around function argument
+  --> $DIR/unused_braces-issue-154247.rs:106:17
+   |
+LL |     consume_int({ { x } });
+   |                 ^^     ^^
+   |
+help: remove these braces
+   |
+LL -     consume_int({ { x } });
+LL +     consume_int({ x });
+   |
+
+warning: unnecessary braces around block return value
+  --> $DIR/unused_braces-issue-154247.rs:106:19
+   |
+LL |     consume_int({ { x } });
+   |                   ^^ ^^
+   |
+help: remove these braces
+   |
+LL -     consume_int({ { x } });
+LL +     consume_int({ x });
+   |
+
+warning: unnecessary braces around function argument
+  --> $DIR/unused_braces-issue-154247.rs:110:17
+   |
+LL |     consume_int({ || x });
+   |                 ^^    ^^
+   |
+help: remove these braces
+   |
+LL -     consume_int({ || x });
+LL +     consume_int(|| x);
+   |
+
+warning: unnecessary braces around function argument
+  --> $DIR/unused_braces-issue-154247.rs:115:17
+   |
+LL |     consume_int({ y += 1 });
+   |                 ^^      ^^
+   |
+help: remove these braces
+   |
+LL -     consume_int({ y += 1 });
+LL +     consume_int(y += 1);
+   |
+
+warning: unnecessary braces around function argument
+  --> $DIR/unused_braces-issue-154247.rs:120:17
+   |
+LL |     consume_int({ y = x });
+   |                 ^^     ^^
+   |
+help: remove these braces
+   |
+LL -     consume_int({ y = x });
+LL +     consume_int(y = x);
+   |
+
+warning: unnecessary braces around function argument
+  --> $DIR/unused_braces-issue-154247.rs:125:17
+   |
+LL |     consume_int({ Point { _x: x } });
+   |                 ^^               ^^
+   |
+help: remove these braces
+   |
+LL -     consume_int({ Point { _x: x } });
+LL +     consume_int(Point { _x: x });
+   |
+
+warning: unnecessary braces around function argument
+  --> $DIR/unused_braces-issue-154247.rs:128:17
+   |
+LL |     consume_int({ [x; 2] });
+   |                 ^^      ^^
+   |
+help: remove these braces
+   |
+LL -     consume_int({ [x; 2] });
+LL +     consume_int([x; 2]);
+   |
+
+warning: unnecessary braces around function argument
+  --> $DIR/unused_braces-issue-154247.rs:131:17
+   |
+LL |     consume_int({ &x });
+   |                 ^^  ^^
+   |
+help: remove these braces
+   |
+LL -     consume_int({ &x });
+LL +     consume_int(&x);
+   |
+
+warning: unnecessary braces around function argument
+  --> $DIR/unused_braces-issue-154247.rs:135:21
+   |
+LL |         consume_int({ move(x) });
+   |                     ^^       ^^
+   |
+help: remove these braces
+   |
+LL -         consume_int({ move(x) });
+LL +         consume_int(move(x));
+   |
+
+warning: unnecessary braces around method argument
+  --> $DIR/unused_braces-issue-154247.rs:142:42
+   |
+LL |     Lockable(Mutex::new(vec![1])).update({ 7 });
+   |                                          ^^ ^^
+   |
+help: remove these braces
+   |
+LL -     Lockable(Mutex::new(vec![1])).update({ 7 });
+LL +     Lockable(Mutex::new(vec![1])).update(7);
+   |
+
+warning: unnecessary braces around method argument
+  --> $DIR/unused_braces-issue-154247.rs:145:42
+   |
+LL |     Lockable(Mutex::new(vec![1])).update({ x as usize });
+   |                                          ^^          ^^
+   |
+help: remove these braces
+   |
+LL -     Lockable(Mutex::new(vec![1])).update({ x as usize });
+LL +     Lockable(Mutex::new(vec![1])).update(x as usize);
+   |
+
+warning: 26 warnings emitted
+


### PR DESCRIPTION
Fixes rust-lang/rust#154247

`unused_braces` is a AST level lint, but in Rust 2024 braces around function and method arguments can affect temporary drop scope. 

I tried to find a more complete fix for it, but seems all too heavy, which involve AST visitor or need `hir` related stuff. 

Instead of teaching this lint to reason about semantics, so it's better to stop linting those argument-position braces in 2024 later edition.