### PR TITLE
large_enums mir pass: fix is_enabled logic

### DIFF
--- a/compiler/rustc_mir_transform/src/large_enums.rs
+++ b/compiler/rustc_mir_transform/src/large_enums.rs
@@ -32,8 +32,8 @@ impl<'tcx> crate::MirPass<'tcx> for EnumSizeOpt {
     fn is_enabled(&self, sess: &Session) -> bool {
         // There are some differences in behavior on wasm and ARM that are not properly
         // understood, so we conservatively treat this optimization as unsound:
-        // https://github.com/rust-lang/rust/pull/85158#issuecomment-1101836457
-        sess.opts.unstable_opts.unsound_mir_opts || sess.mir_opt_level() >= 3
+        // https://github.com/rust-lang/rust/issues/154413
+        sess.opts.unstable_opts.unsound_mir_opts && sess.mir_opt_level() >= 3
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {


### PR DESCRIPTION
This logic got turned from a guard in `run_pass` to an `is_enabled` check in https://github.com/rust-lang/rust/pull/85158/changes/15d4728cda673e90b4db1ea2c60d18a6fae306d0#r2989096960, but that was done incorrectly. The pass must never be enabled without `unsound_mir_opts`!