### PR TITLE
Improved handling for cycles within the query system itself

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3763,6 +3763,7 @@ name = "rustc_data_structures"
 version = "0.0.0"
 dependencies = [
  "arrayvec",
+ "backtrace",
  "bitflags",
  "either",
  "elsa",

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 # tidy-alphabetical-start
 arrayvec = { version = "0.7", default-features = false }
+backtrace = "0.3.75"
 bitflags = "2.4.1"
 either = "1.0"
 elsa = "1.11.0"

--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -21,6 +21,7 @@
 #![feature(dropck_eyepatch)]
 #![feature(extend_one)]
 #![feature(file_buffered)]
+#![feature(likely_unlikely)]
 #![feature(map_try_insert)]
 #![feature(min_specialization)]
 #![feature(negative_impls)]

--- a/compiler/rustc_data_structures/src/stack.rs
+++ b/compiler/rustc_data_structures/src/stack.rs
@@ -1,3 +1,6 @@
+use std::cell::Cell;
+use std::hint::{likely, unlikely};
+
 // This is the amount of bytes that need to be left on the stack before increasing the size.
 // It must be at least as large as the stack required by any code that does not call
 // `ensure_sufficient_stack`.
@@ -11,6 +14,18 @@ const STACK_PER_RECURSION: usize = 1024 * 1024; // 1MB
 #[cfg(target_os = "aix")]
 const STACK_PER_RECURSION: usize = 16 * 1024 * 1024; // 16MB
 
+thread_local! {
+    static TIMES_GROWN: Cell<u32> = const { Cell::new(0) };
+}
+
+/// Give up if we expand the stack this many times and are still trying to recurse deeper.
+const MAX_STACK_GROWTH: u32 = 1000;
+/// Estimate number of frames used per call to `grow`.
+///
+/// This is only used on platforms where we can't tell how much stack we have left, so we `grow`
+/// unconditionally.
+const ESTIMATED_FRAME_SIZE: u32 = 10000;
+
 /// Grows the stack on demand to prevent stack overflow. Call this in strategic locations
 /// to "break up" recursive calls. E.g. almost any call to `visit_expr` or equivalent can benefit
 /// from this.
@@ -18,5 +33,23 @@ const STACK_PER_RECURSION: usize = 16 * 1024 * 1024; // 16MB
 /// Should not be sprinkled around carelessly, as it causes a little bit of overhead.
 #[inline]
 pub fn ensure_sufficient_stack<R>(f: impl FnOnce() -> R) -> R {
-    stacker::maybe_grow(RED_ZONE, STACK_PER_RECURSION, f)
+    // if we can't guess the remaining stack (unsupported on some platforms) we immediately grow
+    // the stack and then cache the new stack size (which we do know now because we allocated it.
+    let (enough_space, max_stack) = match stacker::remaining_stack() {
+        Some(remaining) => (remaining >= RED_ZONE, MAX_STACK_GROWTH),
+        None => (false, MAX_STACK_GROWTH * ESTIMATED_FRAME_SIZE),
+    };
+    if likely(enough_space) {
+        f()
+    } else {
+        let times = TIMES_GROWN.get();
+        if unlikely(times > max_stack) {
+            // something is *definitely* wrong.
+            panic!("still not enough stack after {MAX_STACK_GROWTH} expansions of dynamic stack; infinite recursion?");
+        }
+        TIMES_GROWN.set(times + 1);
+        let out = stacker::grow(STACK_PER_RECURSION, f);
+        TIMES_GROWN.set(times);
+        out
+    }
 }

--- a/compiler/rustc_data_structures/src/stack.rs
+++ b/compiler/rustc_data_structures/src/stack.rs
@@ -1,5 +1,8 @@
 use std::cell::Cell;
 use std::hint::{likely, unlikely};
+use std::io::{self, Write};
+
+use backtrace::{Backtrace, BacktraceFrame};
 
 // This is the amount of bytes that need to be left on the stack before increasing the size.
 // It must be at least as large as the stack required by any code that does not call
@@ -44,12 +47,69 @@ pub fn ensure_sufficient_stack<R>(f: impl FnOnce() -> R) -> R {
     } else {
         let times = TIMES_GROWN.get();
         if unlikely(times > max_stack) {
-            // something is *definitely* wrong.
-            panic!("still not enough stack after {MAX_STACK_GROWTH} expansions of dynamic stack; infinite recursion?");
+            too_much_stack();
         }
         TIMES_GROWN.set(times + 1);
         let out = stacker::grow(STACK_PER_RECURSION, f);
         TIMES_GROWN.set(times);
         out
+    }
+}
+
+#[cold]
+fn too_much_stack() -> ! {
+    let Err(e) = std::panic::catch_unwind(report_too_much_stack);
+    let mut stderr = io::stderr();
+    let _ = writeln!(stderr, "ensure_sufficient_stack: panicked while handling stack overflow!");
+    if let Ok(s) = e.downcast::<String>() {
+        let _ = writeln!(stderr, "{s}");
+    }
+    std::process::abort();
+}
+
+#[cold]
+fn report_too_much_stack() -> ! {
+    // something is *definitely* wrong.
+    eprintln!(
+        "still not enough stack after {MAX_STACK_GROWTH} expansions of dynamic stack; infinite recursion?"
+    );
+
+    let backtrace = Backtrace::new_unresolved();
+    let frames = backtrace.frames();
+    eprintln!("first hundred frames:");
+    print_frames(0, &frames[..100]);
+
+    eprintln!("...\nlast hundred frames:");
+    let start = frames.len() - 100;
+    print_frames(start, &frames[start..]);
+    std::process::abort();
+}
+
+#[cold]
+fn print_frames(mut i: usize, frames: &[BacktraceFrame]) {
+    for frame in frames {
+        let mut frame = frame.clone();
+        frame.resolve();
+        for symbol in frame.symbols() {
+            eprint!("{i}: ");
+            match symbol.name() {
+                Some(sym) => eprint!("{sym}"),
+                None => eprint!("<unknown>"),
+            }
+            eprint!("\n\t\tat ");
+            if let Some(file) = symbol.filename() {
+                eprint!("{}", file.display());
+                if let Some(line) = symbol.lineno() {
+                    eprint!(":{line}");
+                    if let Some(col) = symbol.colno() {
+                        eprint!(":{col}");
+                    }
+                }
+            } else {
+                eprint!("<unknown>");
+            }
+            eprintln!();
+            i += 1;
+        }
     }
 }

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -454,6 +454,7 @@ macro_rules! define_callbacks {
             }
 
             /// Returns the default span for this query if `span` is a dummy span.
+            #[tracing::instrument(level = "debug", skip(tcx, span))]
             pub fn default_span(&self, tcx: TyCtxt<'tcx>, span: Span) -> Span {
                 if !span.is_dummy() {
                     return span

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -223,6 +223,8 @@ fn find_and_handle_cycle<'tcx, C: QueryCache>(
     try_execute: QueryJobId,
     span: Span,
 ) -> (C::Value, Option<DepNodeIndex>) {
+    tracing::info!("hit a query cycle evaluating {}!", query.name);
+
     // Ensure there were no errors collecting all active jobs.
     // We need the complete map to ensure we find a cycle to break.
     let job_map = collect_active_query_jobs(tcx, CollectActiveJobsKind::FullNoContention);
@@ -278,6 +280,7 @@ fn wait_for_query<'tcx, C: QueryCache>(
 
 /// Shared main part of both [`execute_query_incr_inner`] and [`execute_query_non_incr_inner`].
 #[inline(never)]
+#[tracing::instrument(level = "debug", skip_all, fields(query = query.name, key))]
 fn try_execute_query<'tcx, C: QueryCache, const INCR: bool>(
     query: &'tcx QueryVTable<'tcx, C>,
     tcx: TyCtxt<'tcx>,

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -275,6 +275,7 @@ const PERMITTED_RUSTC_DEPS_LOCATION: ListLocation = location!(+6);
 /// rustc. Please check with the compiler team before adding an entry.
 const PERMITTED_RUSTC_DEPENDENCIES: &[&str] = &[
     // tidy-alphabetical-start
+    "addr2line",
     "adler2",
     "aho-corasick",
     "allocator-api2", // FIXME: only appears in Cargo.lock due to https://github.com/rust-lang/cargo/issues/10801
@@ -287,6 +288,7 @@ const PERMITTED_RUSTC_DEPENDENCIES: &[&str] = &[
     "ar_archive_writer",
     "arrayref",
     "arrayvec",
+    "backtrace",
     "bitflags",
     "blake3",
     "block-buffer",


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/154387)*
<!-- homu-ignore:end -->

This PR is somewhat complicated and I don't expect it to merge as-is. Let me start with a motivating example. The following rustc-driver worked fine a week ago:
```rust
struct Driver;

impl Callbacks for Driver {
    fn config(&mut self, config: &mut interface::Config) {
        config.override_queries = Some(|_sess, providers| {
            providers.queries.codegen_fn_attrs = |tcx, def_id| {
                let _ = tcx.hir_crate_items(());
                (rustc_interface::DEFAULT_QUERY_PROVIDERS.queries.codegen_fn_attrs)(tcx, def_id)
            };
        });

    }
}

fn main() -> ExitCode {
    rustc_driver::install_ice_hook("https://github.com/ferrocene/ferrocene/issues/new", |_| ());
    let handler = EarlyDiagCtxt::new(ErrorOutputType::default());
    rustc_driver::init_rustc_env_logger(&handler);
    rustc_driver::catch_with_exit_code(move || {
        let args: Vec<String> = std::env::args().collect();
        rustc_driver::run_compiler(&args, &mut Driver)
    })
}
```

Since https://github.com/rust-lang/rust/pull/153489 merged, it hangs indefinitely trying to compile the following program (reduced from `tests/ui/delegation/bad-resolve`):
```rust
#![feature(fn_delegation)]
#![allow(incomplete_features)]

trait Trait {
    type Type;
    fn bar() {}
}

struct F;
impl Trait for F {
    type Type = i32;
}

struct S(F);
impl Trait for S {
    reuse <F as Trait>::bar;
}

fn main() {}
```

I'll step through how this program behaves on each commit in this PR.

---

1. Main branch: Hangs indefinitely with no output.
2. After first commit (adding safeguards to `ensure_sufficient_stack`): 
  a. First, it prints [a stacktrace that cuts off early](https://gist.github.com/jyn514/110286bd08ca8b1b028304cd1a2e6c66#file-cutoff-original-stacktrace-txt)
  b. Then it hangs forever.

3. After calling `abort` if `ensure_sufficient_stack` fails:
  a. First, it prints a [~250 frame stacktrace](https://gist.github.com/jyn514/110286bd08ca8b1b028304cd1a2e6c66#file-extended-stacktrace-txt),
    including both the first and last hundred frames.
  b. Then it exits.

4. After adding debug logging, shows the stack trace from above, but first:
  a. Prints [a trace of the query execution](https://gist.github.com/jyn514/110286bd08ca8b1b028304cd1a2e6c66#file-query-trace-txt)
  b. Shows [the stacktrace from above](https://gist.github.com/jyn514/110286bd08ca8b1b028304cd1a2e6c66#file-extended-stacktrace-txt).


5. After the bug fix: as above, but instead of the 5 million frame backtrace, prints a "more normal" query cycle:

```
error[E0391]: cycle detected when looking up span for `<impl at bad-resolve.rs:15:1: 15:17>::bar`
  |
  = note: ...which requires getting HIR ID of `<impl at bad-resolve.rs:15:1: 15:17>::bar`...
  = note: ...which again requires looking up span for `<impl at bad-resolve.rs:15:1: 15:17>::bar`, completing the cycle
note: cycle used when computing codegen attributes of `Trait::bar`
 --> bad-resolve.rs:6:5
  |
6 |     fn bar() {}
  |     ^^^^^^^^
```

---

Here's an extract of that query trace:

<details>

```
rustc_query_impl::execution::try_execute_query query="hir_crate_items"
  ...
  rustc_query_impl::execution::try_execute_query query="lower_delayed_owner"
    ...
    rustc_query_impl::execution::try_execute_query query="codegen_fn_attrs"
      rustc_query_impl::execution::try_execute_query query="hir_crate_items"
        0ms INFO rustc_query_impl::execution hit a query cycle evaluating hir_crate_items!
          rustc_query_impl::execution::try_execute_query query="def_span"
            rustc_query_impl::execution::try_execute_query query="local_def_id_to_hir_id"
              rustc_query_impl::execution::try_execute_query query="lower_delayed_owner"
                0ms INFO rustc_query_impl::execution hit a query cycle evaluating lower_delayed_owner!
                  rustc_query_impl::execution::try_execute_query query="def_span"
                    0ms INFO rustc_query_impl::execution hit a query cycle evaluating def_span!
                    rustc_query_impl::execution::try_execute_query query="def_span"
...
```

</details>

I feel somewhat strongly that there is a bug here; it should not be possible to get query cycles within `def_span`.
In particular, note that the first two cycles are ignored altogether in order to report the
third cycle; that seems quite bad!

I'm not sure if the bug is in the implementation of `lower_delayed_owner`, in the query system, or merely in the fact that `lower_delay_owner` is a prerequisite of `hir_items`; I'm opening this PR to get more feedback on that. However, I think the commits here stand on their own.

In https://github.com/rust-lang/rust/pull/153979#issuecomment-4126180258 I mistakenly attributed this to recent refactors in the query system; I no longer think that's true, I think the infinite loop is a latent bug that's been around for years, and the new query cycle is related to `lower_delayed_owner`, not the query system itself.

cc @petrochenkov @aerooneqq @Zalathar 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
