### PR TITLE
Link from `assert_matches` to `debug_assert_matches`

### DIFF
--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -124,8 +124,6 @@ macro_rules! assert_ne {
     };
 }
 
-// FIXME add back debug_assert_matches doc link after bootstrap.
-
 /// Asserts that an expression matches the provided pattern.
 ///
 /// This macro is generally preferable to `assert!(matches!(value, pattern))`, because it can print
@@ -137,8 +135,10 @@ macro_rules! assert_ne {
 /// otherwise this macro will panic.
 ///
 /// Assertions are always checked in both debug and release builds, and cannot
-/// be disabled. See `debug_assert_matches!` for assertions that are disabled in
+/// be disabled. See [`debug_assert_matches!`] for assertions that are disabled in
 /// release builds by default.
+///
+/// [`debug_assert_matches!`]: crate::debug_assert_matches
 ///
 /// On panic, this macro will print the value of the expression with its debug representation.
 ///


### PR DESCRIPTION
This resolves a FIXME which was added in https://github.com/rust-lang/rust/pull/151423.

r? @Amanieu
(Reviewer of rust-lang/rust#151423.)