### PR TITLE
Clarify isqrt documentation for signed integers

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1827,7 +1827,8 @@ macro_rules! int_impl {
             }
         }
 
-        /// Returns the square root of the number, rounded down.
+        /// Returns the non-negative (principal) square root of the number,
+        /// rounded down.
         ///
         /// Returns `None` if `self` is negative.
         ///
@@ -3122,7 +3123,8 @@ macro_rules! int_impl {
             }
         }
 
-        /// Returns the square root of the number, rounded down.
+        /// Returns the non-negative (principal) square root of the number,
+        /// rounded down.
         ///
         /// # Panics
         ///


### PR DESCRIPTION
Updates the doc comment for `isqrt` and `checked_isqrt` on signed integer types (i8, i16, i32, i64, i128) to clarify that the returned value is the non-negative (principal) square root.

Fixes rust-lang/rust#154000.