### PR TITLE
Add `IoSplit` diagnostic item for `std::io::Split`

### DIFF
--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -3348,6 +3348,7 @@ impl SizeHint for &[u8] {
 /// [`split`]: BufRead::split
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Debug)]
+#[cfg_attr(not(test), rustc_diagnostic_item = "IoSplit")]
 pub struct Split<B> {
     buf: B,
     delim: u8,


### PR DESCRIPTION
Similar to the existing `IoLines` item.  It will be used in Clippy to detect uses of `Split` leading to infinite loops similar to the existing lint for `Lines`.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
