### PR TITLE
Updates doc comment for isqrt and checked_isqrt on all signes integer…

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1827,7 +1827,8 @@ macro_rules! int_impl {
             }
         }
 
-        /// Returns the square root of the number, rounded down.
+        /// Returns the non-negative integer square root of the number, rounded down.
+        /// This is the greatest integer `n` such that `n * n <= self`.
         ///
         /// Returns `None` if `self` is negative.
         ///
@@ -3122,7 +3123,8 @@ macro_rules! int_impl {
             }
         }
 
-        /// Returns the square root of the number, rounded down.
+        /// Returns the non-negative integer square root of the number, rounded down.
+        /// This is the greatest integer `n` such that `n * n <= self`.
         ///
         /// # Panics
         ///


### PR DESCRIPTION
Clarified the documentation for `isqrt` as well as `checked_isqrt` to make it clear, that always the positive square root is returned.

Fixes issue: rust-lang/rust#154000