### PR TITLE
Rustdoc rejects html emits with json output

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -522,6 +522,18 @@ impl Options {
             }
         }
 
+        if output_format == OutputFormat::Json {
+            if let Some(emit_flag) = emit.iter().find_map(|emit| match emit {
+                EmitType::HtmlStaticFiles => Some("html-static-files"),
+                EmitType::HtmlNonStaticFiles => Some("html-non-static-files"),
+                EmitType::DepInfo(_) => None,
+            }) {
+                dcx.fatal(format!(
+                    "the `--emit={emit_flag}` flag is not supported with `--output-format=json`",
+                ));
+            }
+        }
+
         let to_check = matches.opt_strs("check-theme");
         if !to_check.is_empty() {
             let mut content =

--- a/tests/rustdoc-ui/output-format-json-emit-html.html_non_static.stderr
+++ b/tests/rustdoc-ui/output-format-json-emit-html.html_non_static.stderr
@@ -1,0 +1,2 @@
+error: the `--emit=html-non-static-files` flag is not supported with `--output-format=json`
+

--- a/tests/rustdoc-ui/output-format-json-emit-html.html_static.stderr
+++ b/tests/rustdoc-ui/output-format-json-emit-html.html_static.stderr
@@ -1,0 +1,2 @@
+error: the `--emit=html-static-files` flag is not supported with `--output-format=json`
+

--- a/tests/rustdoc-ui/output-format-json-emit-html.rs
+++ b/tests/rustdoc-ui/output-format-json-emit-html.rs
@@ -1,0 +1,8 @@
+//@ revisions: html_static html_non_static
+//@ check-fail
+//@[html_static] compile-flags: -Z unstable-options --output-format=json --emit=html-static-files
+//@[html_non_static] compile-flags: -Z unstable-options --output-format=json --emit=html-non-static-files
+//[html_static]~? ERROR the `--emit=html-static-files` flag is not supported with `--output-format=json`
+//[html_non_static]~? ERROR the `--emit=html-non-static-files` flag is not supported with `--output-format=json`
+
+pub struct Foo;

--- a/tests/rustdoc-ui/show-coverage-json-emit-html-non-static.rs
+++ b/tests/rustdoc-ui/show-coverage-json-emit-html-non-static.rs
@@ -1,0 +1,5 @@
+//@ compile-flags: -Z unstable-options --show-coverage --output-format=json --emit=html-non-static-files
+//@ check-fail
+//~? ERROR the `--emit=html-non-static-files` flag is not supported with `--output-format=json`
+
+pub struct Foo;

--- a/tests/rustdoc-ui/show-coverage-json-emit-html-non-static.stderr
+++ b/tests/rustdoc-ui/show-coverage-json-emit-html-non-static.stderr
@@ -1,0 +1,2 @@
+error: the `--emit=html-non-static-files` flag is not supported with `--output-format=json`
+


### PR DESCRIPTION
Fixes rust-lang/rust#154395
