### PR TITLE
bootstrap: `-Zjson-target-spec` for synthetic targets

### DIFF
--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -122,6 +122,9 @@ impl Cargo {
         cmd_kind: Kind,
     ) -> Cargo {
         let mut cargo = builder.cargo(compiler, mode, source_type, target, cmd_kind);
+        if target.synthetic {
+            cargo.arg("-Zjson-target-spec");
+        }
 
         match cmd_kind {
             // No need to configure the target linker for these command types.
@@ -165,7 +168,11 @@ impl Cargo {
         target: TargetSelection,
         cmd_kind: Kind,
     ) -> Cargo {
-        builder.cargo(compiler, mode, source_type, target, cmd_kind)
+        let mut cargo = builder.cargo(compiler, mode, source_type, target, cmd_kind);
+        if target.synthetic {
+            cargo.arg("-Zjson-target-spec");
+        }
+        cargo
     }
 
     pub fn rustdocflag(&mut self, arg: &str) -> &mut Cargo {


### PR DESCRIPTION
Fixes rust-lang/rust#154340

Synthetic targets for mir-opt tests build a standard library using a `.json` target, which now requires `-Zjson-target-spec`

r? @jieyouxu 