### PR TITLE
Create GPU target notification group

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -194,6 +194,11 @@ Hi relnotes-interest-group, this issue/PR could use some help in reviewing /
 adjusting release notes. Could you take a look if available? Thanks <3
 """
 
+[ping.gpu-target]
+message = """\
+Hi GPU experts, this issue/PR could use some guidance on how this should be
+resolved/implemented. Could you take a look if available? Thanks <3
+"""
 
 # ------------------------------------------------------------------------------
 # Autolabels


### PR DESCRIPTION
Creating the notification group for the newly created GPU target (see [mcp#960](https://rust-lang.zulipchat.com/#narrow/channel/233931-t-compiler.2Fmajor-changes/topic/Create.20a.20GPU.20notification.20group.20compiler-team.23960/near/568629680))

I'm following these [steps](https://github.com/rust-lang/rust/issues/133334).

(feel free to suggest a better wording)

r? @jieyouxu 