### PR TITLE
bootstrap.example.toml: Hint how to allow `build.warnings`

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -826,7 +826,8 @@
 # in the sysroot. It is required for running nvptx tests.
 #rust.llvm-bitcode-linker = false
 
-# Whether to deny warnings in crates
+# Whether to deny warnings in crates. Set to `false` to avoid
+# error: warnings are denied by `build.warnings` configuration
 #rust.deny-warnings = true
 
 # Print backtrace on internal compiler errors during bootstrap


### PR DESCRIPTION
This commit turns **Actual** into **Expected** for the following problem:

### Steps
1. Do some quick and experimental local code changes in the compiler code.
2. Run `./x build`.
3. Observe failed build with _"error: warnings are denied by `build.warnings` configuration"_.
4. Decide to not care and want to allow warnings.
5. Search for `build.warnings` in **bootstrap.example.toml**.

### Actual
No hits. You get frustrated because didn't learn how to allow warnings. (The reason `build.warnings` is not mentioned in **bootstrap.example.toml** is of course because it is an unstable cargo [feature](https://doc.rust-lang.org/cargo/reference/unstable.html#buildwarnings) and not controlled by bootstrap, but you don't know that yet.)

### Expected
You get a hit and can easily see how to allow warnings.

