### PR TITLE
bootstrap: force a CI LLVM stamp bump

### DIFF
--- a/src/bootstrap/download-ci-llvm-stamp
+++ b/src/bootstrap/download-ci-llvm-stamp
@@ -1,4 +1,4 @@
 Change this file to make users of the `download-ci-llvm` configuration download
 a new version of LLVM from CI, even if the LLVM submodule hasn’t changed.
 
-Last change is for: https://github.com/rust-lang/rust/pull/153179
+Last change is for: https://github.com/rust-lang/rust/pull/151063


### PR DESCRIPTION
To see if this helps with https://github.com/rust-lang/rust/issues/154408

r? @Kobzol 
