### PR TITLE
Export `derive` at the crate root: `core::derive` and `std::derive`

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -227,6 +227,8 @@ pub mod autodiff {
 #[unstable(feature = "contracts", issue = "128044")]
 pub mod contracts;
 
+#[unstable(feature = "derive_macro_global_path", issue = "154645")]
+pub use crate::macros::builtin::derive;
 #[stable(feature = "cfg_select", since = "1.95.0")]
 pub use crate::macros::cfg_select;
 

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -1720,7 +1720,7 @@ pub(crate) mod builtin {
     ///
     /// See [the reference] for more info.
     ///
-    /// [the reference]: ../../../reference/attributes/derive.html
+    /// [the reference]: ../reference/attributes/derive.html
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
     pub macro derive($item:item) {

--- a/library/core/src/prelude/v1.rs
+++ b/library/core/src/prelude/v1.rs
@@ -120,8 +120,12 @@ pub use crate::trace_macros;
 // (no public module for them to be re-exported from).
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 pub use crate::macros::builtin::{
-    alloc_error_handler, bench, derive, global_allocator, test, test_case,
+    alloc_error_handler, bench, global_allocator, test, test_case,
 };
+
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[doc(no_inline)]
+pub use crate::macros::builtin::derive;
 
 #[unstable(feature = "derive_const", issue = "118304")]
 pub use crate::macros::builtin::derive_const;

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -704,6 +704,8 @@ pub use core::cfg_select;
     reason = "`concat_bytes` is not stable enough for use and is subject to change"
 )]
 pub use core::concat_bytes;
+#[unstable(feature = "derive_macro_global_path", issue = "154645")]
+pub use core::derive;
 #[stable(feature = "matches_macro", since = "1.42.0")]
 #[allow(deprecated, deprecated_in_future)]
 pub use core::matches;

--- a/library/std/src/prelude/v1.rs
+++ b/library/std/src/prelude/v1.rs
@@ -115,8 +115,12 @@ pub use core::prelude::v1::trace_macros;
 // (no public module for them to be re-exported from).
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 pub use core::prelude::v1::{
-    alloc_error_handler, bench, derive, global_allocator, test, test_case,
+    alloc_error_handler, bench, global_allocator, test, test_case,
 };
+
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[doc(no_inline)]
+pub use core::prelude::v1::derive;
 
 #[unstable(feature = "derive_const", issue = "118304")]
 pub use core::prelude::v1::derive_const;

--- a/tests/ui/imports/global-derive-path.rs
+++ b/tests/ui/imports/global-derive-path.rs
@@ -1,0 +1,10 @@
+//@ edition: 2024
+//@ check-pass
+#![crate_type = "lib"]
+#![feature(derive_macro_global_path)]
+
+#[::core::derive(Clone)]
+struct Y;
+
+#[::std::derive(Clone)]
+struct X;


### PR DESCRIPTION
This PR makes the `derive` macro available at the crate root:

```rust
#[std::derive(Clone)]
#[core::derive(Copy)]
struct X;
```

ACP: https://github.com/rust-lang/libs-team/issues/766

Tracking issue: https://github.com/rust-lang/rust/issues/154645