### PR TITLE
(EXPERIMENT) Split out most of `typeck` into a sub-query `root_typeck`

### DIFF
--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -83,7 +83,15 @@ fn used_trait_imports(tcx: TyCtxt<'_>, def_id: LocalDefId) -> &UnordSet<LocalDef
 }
 
 fn typeck<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> &'tcx ty::TypeckResults<'tcx> {
-    typeck_with_inspect(tcx, def_id, None)
+    // Closures' typeck results come from their outermost function,
+    // as they are part of the same "inference environment".
+    // We therefore need to traverse to the def's "typeck root" and check that instead.
+    let root_def_id = tcx.typeck_root_def_id(def_id).expect_local();
+    tcx.root_typeck(root_def_id)
+}
+
+fn root_typeck<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> &'tcx ty::TypeckResults<'tcx> {
+    root_typeck_with_inspect(tcx, def_id, None)
 }
 
 /// Same as `typeck` but `inspect` is invoked on evaluation of each root obligation.
@@ -95,21 +103,17 @@ pub fn inspect_typeck<'tcx>(
     def_id: LocalDefId,
     inspect: ObligationInspector<'tcx>,
 ) -> &'tcx ty::TypeckResults<'tcx> {
-    typeck_with_inspect(tcx, def_id, Some(inspect))
+    let root_def_id = tcx.typeck_root_def_id(def_id).expect_local();
+    root_typeck_with_inspect(tcx, root_def_id, Some(inspect))
 }
 
 #[instrument(level = "debug", skip(tcx, inspector), ret)]
-fn typeck_with_inspect<'tcx>(
+fn root_typeck_with_inspect<'tcx>(
     tcx: TyCtxt<'tcx>,
     def_id: LocalDefId,
     inspector: Option<ObligationInspector<'tcx>>,
 ) -> &'tcx ty::TypeckResults<'tcx> {
-    // Closures' typeck results come from their outermost function,
-    // as they are part of the same "inference environment".
-    let typeck_root_def_id = tcx.typeck_root_def_id(def_id.to_def_id()).expect_local();
-    if typeck_root_def_id != def_id {
-        return tcx.typeck(typeck_root_def_id);
-    }
+    assert!(!tcx.is_typeck_child(def_id.to_def_id()));
 
     let id = tcx.local_def_id_to_hir_id(def_id);
     let node = tcx.hir_node(id);
@@ -661,6 +665,7 @@ pub fn provide(providers: &mut Providers) {
     *providers = Providers {
         method_autoderef_steps: method::probe::method_autoderef_steps,
         typeck,
+        root_typeck,
         used_trait_imports,
         check_transmutes: intrinsicck::check_transmutes,
         ..*providers

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -1224,7 +1224,11 @@ rustc_queries! {
 
     query typeck(key: LocalDefId) -> &'tcx ty::TypeckResults<'tcx> {
         desc { "type-checking `{}`", tcx.def_path_str(key) }
-        cache_on_disk_if { !tcx.is_typeck_child(key.to_def_id()) }
+    }
+
+    query root_typeck(key: LocalDefId) -> &'tcx ty::TypeckResults<'tcx> {
+        desc { "type-checking from root `{}`", tcx.def_path_str(key) }
+        cache_on_disk_if { true }
     }
 
     query used_trait_imports(key: LocalDefId) -> &'tcx UnordSet<LocalDefId> {

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -1229,6 +1229,7 @@ rustc_queries! {
     query root_typeck(key: LocalDefId) -> &'tcx ty::TypeckResults<'tcx> {
         desc { "type-checking from root `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { true }
+        no_hash
     }
 
     query used_trait_imports(key: LocalDefId) -> &'tcx UnordSet<LocalDefId> {

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -23,7 +23,7 @@ use tracing::{debug, instrument};
 use super::TypingEnv;
 use crate::middle::codegen_fn_attrs::CodegenFnAttrFlags;
 use crate::mir;
-use crate::query::Providers;
+use crate::query::{IntoQueryKey, Providers};
 use crate::traits::ObligationCause;
 use crate::ty::layout::{FloatExt, IntegerExt};
 use crate::ty::{
@@ -642,8 +642,8 @@ impl<'tcx> TyCtxt<'tcx> {
     /// For example, a closure has its own `DefId`, but it is type-checked
     /// with the containing item. Therefore, when we fetch the `typeck` of the closure,
     /// for example, we really wind up fetching the `typeck` of the enclosing fn item.
-    pub fn typeck_root_def_id(self, def_id: DefId) -> DefId {
-        let mut def_id = def_id;
+    pub fn typeck_root_def_id(self, def_id: impl IntoQueryKey<DefId>) -> DefId {
+        let mut def_id = def_id.into_query_key();
         while self.is_typeck_child(def_id) {
             def_id = self.parent(def_id);
         }

--- a/tests/incremental/change_private_fn/struct_point.rs
+++ b/tests/incremental/change_private_fn/struct_point.rs
@@ -55,7 +55,7 @@ pub mod fn_calls_methods_in_same_impl {
     // (not just marked green) - for example, `DeadVisitor`
     // always runs during compilation as a "pass", and loads
     // the typeck results for bodies.
-    #[rustc_clean(cfg="cfail2", loaded_from_disk="typeck")]
+    #[rustc_clean(cfg="cfail2", loaded_from_disk="root_typeck")]
     pub fn check() {
         let x = Point { x: 2.0, y: 2.0 };
         x.distance_from_origin();

--- a/tests/ui/const-generics/generic_const_exprs/closures.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/closures.stderr
@@ -14,6 +14,11 @@ note: ...which requires type-checking `test::{constant#0}`...
    |
 LL | fn test<const N: usize>() -> [u8; N + (|| 42)()] {}
    |                                   ^^^^^^^^^^^^^
+note: ...which requires type-checking from root `test::{constant#0}`...
+  --> $DIR/closures.rs:3:35
+   |
+LL | fn test<const N: usize>() -> [u8; N + (|| 42)()] {}
+   |                                   ^^^^^^^^^^^^^
    = note: ...which again requires building an abstract representation for `test::{constant#0}`, completing the cycle
 note: cycle used when checking that `test` is well-formed
   --> $DIR/closures.rs:3:1

--- a/tests/ui/impl-trait/auto-trait-leakage/auto-trait-leak.stderr
+++ b/tests/ui/impl-trait/auto-trait-leakage/auto-trait-leak.stderr
@@ -30,6 +30,11 @@ note: ...which requires match-checking `cycle1`...
 LL | fn cycle1() -> impl Clone {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires type-checking `cycle1`...
+  --> $DIR/auto-trait-leak.rs:11:1
+   |
+LL | fn cycle1() -> impl Clone {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires type-checking from root `cycle1`...
   --> $DIR/auto-trait-leak.rs:12:5
    |
 LL |     send(cycle2().clone());
@@ -66,6 +71,11 @@ note: ...which requires match-checking `cycle2`...
 LL | fn cycle2() -> impl Clone {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires type-checking `cycle2`...
+  --> $DIR/auto-trait-leak.rs:17:1
+   |
+LL | fn cycle2() -> impl Clone {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires type-checking from root `cycle2`...
   --> $DIR/auto-trait-leak.rs:18:5
    |
 LL |     send(cycle1().clone());

--- a/tests/ui/impl-trait/in-trait/method-compatability-via-leakage-cycle.current.stderr
+++ b/tests/ui/impl-trait/in-trait/method-compatability-via-leakage-cycle.current.stderr
@@ -45,6 +45,11 @@ note: ...which requires type-checking `<impl at $DIR/method-compatability-via-le
    |
 LL |     fn foo(b: bool) -> impl Sized {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires type-checking from root `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
+  --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
+   |
+LL |     fn foo(b: bool) -> impl Sized {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which again requires computing type of `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo::{anon_assoc#0}`, completing the cycle
 note: cycle used when checking assoc item `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo` is compatible with trait definition
   --> $DIR/method-compatability-via-leakage-cycle.rs:21:5

--- a/tests/ui/impl-trait/in-trait/method-compatability-via-leakage-cycle.next.stderr
+++ b/tests/ui/impl-trait/in-trait/method-compatability-via-leakage-cycle.next.stderr
@@ -49,6 +49,11 @@ note: ...which requires type-checking `<impl at $DIR/method-compatability-via-le
    |
 LL |     fn foo(b: bool) -> impl Sized {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires type-checking from root `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
+  --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
+   |
+LL |     fn foo(b: bool) -> impl Sized {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which again requires computing type of `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo::{anon_assoc#0}`, completing the cycle
 note: cycle used when checking assoc item `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo` is compatible with trait definition
   --> $DIR/method-compatability-via-leakage-cycle.rs:21:5

--- a/tests/ui/parallel-rustc/generic-const-exprs-deadlock-issue-134978.stderr
+++ b/tests/ui/parallel-rustc/generic-const-exprs-deadlock-issue-134978.stderr
@@ -14,6 +14,11 @@ note: ...which requires type-checking `function::{constant#0}`...
    |
 LL |     [(); Struct::<{ NUM_CARDS + 0 }>::OK]:,
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires type-checking from root `function::{constant#0}`...
+  --> $DIR/generic-const-exprs-deadlock-issue-134978.rs:17:10
+   |
+LL |     [(); Struct::<{ NUM_CARDS + 0 }>::OK]:,
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which again requires building an abstract representation for `function::{constant#0}`, completing the cycle
 note: cycle used when checking that `function` is well-formed
   --> $DIR/generic-const-exprs-deadlock-issue-134978.rs:15:1

--- a/tests/ui/track-diagnostics/track.stderr
+++ b/tests/ui/track-diagnostics/track.stderr
@@ -40,9 +40,9 @@ note: rustc $VERSION running on $TARGET
 note: compiler flags: ... -Z ui-testing ... -Z track-diagnostics
 
 query stack during panic:
-#0 [typeck] type-checking `main`
-#1 [analysis] running analysis passes on crate `track`
-end of query stack
+#0 [root_typeck] type-checking from root `main`
+#1 [typeck] type-checking `main`
+... and 1 other queries... use `env RUST_BACKTRACE=1` to see the full query stack
 error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0268, E0425.

--- a/tests/ui/traits/const-traits/unsatisfied-const-trait-bound.stderr
+++ b/tests/ui/traits/const-traits/unsatisfied-const-trait-bound.stderr
@@ -42,6 +42,11 @@ note: ...which requires type-checking `accept0::{constant#0}`...
    |
 LL | fn accept0<T: Trait>(_: Container<{ T::make() }>) {}
    |                                   ^^^^^^^^^^^^^
+note: ...which requires type-checking from root `accept0::{constant#0}`...
+  --> $DIR/unsatisfied-const-trait-bound.rs:28:35
+   |
+LL | fn accept0<T: Trait>(_: Container<{ T::make() }>) {}
+   |                                   ^^^^^^^^^^^^^
    = note: ...which again requires evaluating type-level constant, completing the cycle
 note: cycle used when checking that `accept0` is well-formed
   --> $DIR/unsatisfied-const-trait-bound.rs:28:35
@@ -72,6 +77,11 @@ note: ...which requires building THIR for `accept1::{constant#0}`...
 LL | const fn accept1<T: [const] Trait>(_: Container<{ T::make() }>) {}
    |                                                 ^^^^^^^^^^^^^
 note: ...which requires type-checking `accept1::{constant#0}`...
+  --> $DIR/unsatisfied-const-trait-bound.rs:32:49
+   |
+LL | const fn accept1<T: [const] Trait>(_: Container<{ T::make() }>) {}
+   |                                                 ^^^^^^^^^^^^^
+note: ...which requires type-checking from root `accept1::{constant#0}`...
   --> $DIR/unsatisfied-const-trait-bound.rs:32:49
    |
 LL | const fn accept1<T: [const] Trait>(_: Container<{ T::make() }>) {}

--- a/tests/ui/type-alias-impl-trait/in-where-clause.stderr
+++ b/tests/ui/type-alias-impl-trait/in-where-clause.stderr
@@ -46,6 +46,13 @@ LL | / fn foo() -> Bar
 LL | | where
 LL | |     Bar: Send,
    | |______________^
+note: ...which requires type-checking from root `foo`...
+  --> $DIR/in-where-clause.rs:9:1
+   |
+LL | / fn foo() -> Bar
+LL | | where
+LL | |     Bar: Send,
+   | |______________^
 note: ...which requires computing revealed normalized predicates of `foo::{constant#0}`...
   --> $DIR/in-where-clause.rs:13:9
    |


### PR DESCRIPTION
- Trying out an alternative approach to https://github.com/rust-lang/rust/pull/154304 that uses two queries instead of one.

If this looks promising, we can use the perf results to discuss how to proceed.