### PR TITLE
Require that a `<_ as Try>::Residual` implement the `Residual` trait

### DIFF
--- a/library/core/src/ops/try_trait.rs
+++ b/library/core/src/ops/try_trait.rs
@@ -157,7 +157,7 @@ pub const trait Try: [const] FromResidual {
     /// type: that type will have a "hole" in the correct place, and will maintain the
     /// "foo-ness" of the residual so other types need to opt-in to interconversion.
     #[unstable(feature = "try_trait_v2", issue = "84277", old_name = "try_trait")]
-    type Residual;
+    type Residual: Residual<Self::Output>;
 
     /// Constructs the type from its `Output` type.
     ///

--- a/src/tools/clippy/tests/ui/manual_try_fold.rs
+++ b/src/tools/clippy/tests/ui/manual_try_fold.rs
@@ -2,8 +2,9 @@
 #![allow(clippy::unnecessary_fold, unused)]
 #![warn(clippy::manual_try_fold)]
 #![feature(try_trait_v2)]
+#![feature(try_trait_v2_residual)]
 //@no-rustfix
-use std::ops::{ControlFlow, FromResidual, Try};
+use std::ops::{ControlFlow, FromResidual, Residual, Try};
 
 #[macro_use]
 extern crate proc_macros;
@@ -11,15 +12,21 @@ extern crate proc_macros;
 // Test custom `Try` with more than 1 argument
 struct NotOption(i32, i32);
 
+struct NotOptionResidual;
+
 impl<R> FromResidual<R> for NotOption {
     fn from_residual(_: R) -> Self {
         todo!()
     }
 }
 
+impl Residual<()> for NotOptionResidual {
+    type TryType = NotOption;
+}
+
 impl Try for NotOption {
     type Output = ();
-    type Residual = ();
+    type Residual = NotOptionResidual;
 
     fn from_output(_: Self::Output) -> Self {
         todo!()
@@ -34,15 +41,21 @@ impl Try for NotOption {
 #[derive(Default)]
 struct NotOptionButWorse(i32);
 
+struct NotOptionButWorseResidual;
+
 impl<R> FromResidual<R> for NotOptionButWorse {
     fn from_residual(_: R) -> Self {
         todo!()
     }
 }
 
+impl Residual<()> for NotOptionButWorseResidual {
+    type TryType = NotOptionButWorse;
+}
+
 impl Try for NotOptionButWorse {
     type Output = ();
-    type Residual = ();
+    type Residual = NotOptionButWorseResidual;
 
     fn from_output(_: Self::Output) -> Self {
         todo!()

--- a/src/tools/clippy/tests/ui/manual_try_fold.stderr
+++ b/src/tools/clippy/tests/ui/manual_try_fold.stderr
@@ -1,5 +1,5 @@
 error: usage of `Iterator::fold` on a type that implements `Try`
-  --> tests/ui/manual_try_fold.rs:59:10
+  --> tests/ui/manual_try_fold.rs:72:10
    |
 LL |         .fold(Some(0i32), |sum, i| sum?.checked_add(*i))
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `try_fold` instead: `try_fold(0i32, |sum, i| ...)`
@@ -8,19 +8,19 @@ LL |         .fold(Some(0i32), |sum, i| sum?.checked_add(*i))
    = help: to override `-D warnings` add `#[allow(clippy::manual_try_fold)]`
 
 error: usage of `Iterator::fold` on a type that implements `Try`
-  --> tests/ui/manual_try_fold.rs:64:10
+  --> tests/ui/manual_try_fold.rs:77:10
    |
 LL |         .fold(NotOption(0i32, 0i32), |sum, i| NotOption(0i32, 0i32));
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `try_fold` instead: `try_fold(..., |sum, i| ...)`
 
 error: usage of `Iterator::fold` on a type that implements `Try`
-  --> tests/ui/manual_try_fold.rs:68:10
+  --> tests/ui/manual_try_fold.rs:81:10
    |
 LL |         .fold(NotOptionButWorse(0i32), |sum, i| NotOptionButWorse(0i32));
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `try_fold` instead: `try_fold(0i32, |sum, i| ...)`
 
 error: usage of `Iterator::fold` on a type that implements `Try`
-  --> tests/ui/manual_try_fold.rs:99:10
+  --> tests/ui/manual_try_fold.rs:112:10
    |
 LL |         .fold(Some(0i32), |sum, i| sum?.checked_add(*i))
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `try_fold` instead: `try_fold(0i32, |sum, i| ...)`

--- a/tests/ui/consts/const-try.rs
+++ b/tests/ui/consts/const-try.rs
@@ -6,10 +6,11 @@
 
 #![crate_type = "lib"]
 #![feature(try_trait_v2)]
+#![feature(try_trait_v2_residual)]
 #![feature(const_trait_impl)]
 #![feature(const_try)]
 
-use std::ops::{ControlFlow, FromResidual, Try};
+use std::ops::{ControlFlow, FromResidual, Residual, Try};
 
 struct TryMe;
 struct Error;
@@ -29,6 +30,10 @@ impl const Try for TryMe {
     fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {
         ControlFlow::Break(Error)
     }
+}
+
+impl Residual<()> for Error {
+    type TryType = TryMe;
 }
 
 const fn t() -> TryMe {

--- a/tests/ui/traits/const-traits/ice-126148-failed-to-normalize.rs
+++ b/tests/ui/traits/const-traits/ice-126148-failed-to-normalize.rs
@@ -1,6 +1,6 @@
 #![allow(incomplete_features)]
-#![feature(const_trait_impl, try_trait_v2, const_try)]
-use std::ops::{FromResidual, Try};
+#![feature(const_trait_impl, try_trait_v2, try_trait_v2_residual, const_try, const_try_residual)]
+use std::ops::{FromResidual, Residual, Try};
 
 struct TryMe;
 struct Error;
@@ -12,6 +12,10 @@ impl const Try for TryMe {
     //~^ ERROR not all trait items implemented
     type Output = ();
     type Residual = Error;
+}
+
+impl const Residual<()> for Error {
+    type TryType = TryMe;
 }
 
 const fn t() -> TryMe {

--- a/tests/ui/traits/const-traits/trait-default-body-stability.rs
+++ b/tests/ui/traits/const-traits/trait-default-body-stability.rs
@@ -5,11 +5,12 @@
 #![feature(const_trait_impl)]
 #![feature(const_t_try)]
 #![feature(const_try)]
+#![feature(const_try_residual)]
 #![feature(try_trait_v2)]
-
+#![feature(try_trait_v2_residual)]
 #![stable(feature = "foo", since = "1.0")]
 
-use std::ops::{ControlFlow, FromResidual, Try};
+use std::ops::{ControlFlow, FromResidual, Residual, Try};
 
 #[stable(feature = "foo", since = "1.0")]
 pub struct T;
@@ -27,6 +28,12 @@ impl const Try for T {
     fn branch(self) -> ControlFlow<T, T> {
         ControlFlow::Continue(self)
     }
+}
+
+#[stable(feature = "foo", since = "1.0")]
+#[rustc_const_unstable(feature = "const_t_try", issue = "none")]
+impl const Residual<T> for T {
+    type TryType = T;
 }
 
 #[stable(feature = "foo", since = "1.0")]

--- a/tests/ui/try-trait/try-operator-custom.rs
+++ b/tests/ui/try-trait/try-operator-custom.rs
@@ -1,12 +1,13 @@
 //@ run-pass
 
 #![feature(try_trait_v2)]
+#![feature(try_trait_v2_residual)]
 
-use std::ops::{ControlFlow, FromResidual, Try};
+use std::ops::{ControlFlow, FromResidual, Residual, Try};
 
 enum MyResult<T, U> {
     Awesome(T),
-    Terrible(U)
+    Terrible(U),
 }
 
 enum Never {}
@@ -27,7 +28,10 @@ impl<U, V> Try for MyResult<U, V> {
     }
 }
 
-impl<U, V, W> FromResidual<MyResult<Never, V>> for MyResult<U, W> where V: Into<W> {
+impl<U, V, W> FromResidual<MyResult<Never, V>> for MyResult<U, W>
+where
+    V: Into<W>,
+{
     fn from_residual(x: MyResult<Never, V>) -> Self {
         match x {
             MyResult::Terrible(e) => MyResult::Terrible(e.into()),
@@ -35,9 +39,16 @@ impl<U, V, W> FromResidual<MyResult<Never, V>> for MyResult<U, W> where V: Into<
     }
 }
 
+impl<U, V> Residual<U> for MyResult<Never, V> {
+    type TryType = MyResult<U, V>;
+}
+
 type ResultResidual<E> = Result<std::convert::Infallible, E>;
 
-impl<U, V, W> FromResidual<ResultResidual<V>> for MyResult<U, W> where V: Into<W> {
+impl<U, V, W> FromResidual<ResultResidual<V>> for MyResult<U, W>
+where
+    V: Into<W>,
+{
     fn from_residual(x: ResultResidual<V>) -> Self {
         match x {
             Err(e) => MyResult::Terrible(e.into()),
@@ -45,7 +56,10 @@ impl<U, V, W> FromResidual<ResultResidual<V>> for MyResult<U, W> where V: Into<W
     }
 }
 
-impl<U, V, W> FromResidual<MyResult<Never, V>> for Result<U, W> where V: Into<W> {
+impl<U, V, W> FromResidual<MyResult<Never, V>> for Result<U, W>
+where
+    V: Into<W>,
+{
     fn from_residual(x: MyResult<Never, V>) -> Self {
         match x {
             MyResult::Terrible(e) => Err(e.into()),


### PR DESCRIPTION
The `Residual` trait was even more experimental than `Try`, but now that https://github.com/rust-lang/rfcs/pull/3721 is merged, I think it would make sense to require this.  Technically it's not strictly required, but without it something working on `<T: Try>` might need an extra bound even to use a homogeneous try block with the same output type as `T::Output`.  (Another `where` will of course be needed to return a *different* `impl Try` type still.)

cc https://github.com/rust-lang/rust/issues/154391