### PR TITLE
fix: [rustfmt] prevent panic when rewritng associated item delegations

### DIFF
--- a/src/tools/rustfmt/src/visitor.rs
+++ b/src/tools/rustfmt/src/visitor.rs
@@ -665,11 +665,11 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         }
 
         // TODO(calebcartwright): consider enabling box_patterns feature gate
-        match (&ai.kind, visitor_kind) {
-            (ast::AssocItemKind::Const(c), AssocTraitItem) => {
+        match (&ai.kind, assoc_ctxt) {
+            (ast::AssocItemKind::Const(c), visit::AssocCtxt::Trait) => {
                 self.visit_static(&StaticParts::from_trait_item(ai, c.ident))
             }
-            (ast::AssocItemKind::Const(c), AssocImplItem) => {
+            (ast::AssocItemKind::Const(c), visit::AssocCtxt::Impl { .. }) => {
                 self.visit_static(&StaticParts::from_impl_item(ai, c.ident))
             }
             (ast::AssocItemKind::Fn(ref fn_kind), _) => {
@@ -714,7 +714,11 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
             (ast::AssocItemKind::MacCall(ref mac), _) => {
                 self.visit_mac(mac, MacroPosition::Item);
             }
-            _ => unreachable!(),
+            (ast::AssocItemKind::Delegation(_) | ast::AssocItemKind::DelegationMac(_), _) => {
+                // TODO(ytmimi) #![feature(fn_delegation)]
+                // add formatting for `AssocItemKind::Delegation` and `AssocItemKind::DelegationMac`
+                self.push_rewrite(ai.span, None);
+            }
         }
     }
 

--- a/src/tools/rustfmt/tests/target/issue_6513.rs
+++ b/src/tools/rustfmt/tests/target/issue_6513.rs
@@ -1,0 +1,10 @@
+#![feature(fn_delegation)]
+
+struct Ty;
+impl Ty {
+    reuse std::convert::identity;
+}
+
+trait Trait {
+    reuse std::convert::identity;
+}


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/118212

rustfmt issue: https://github.com/rust-lang/rustfmt/issues/6513

Fixes a rustfmt bug for `#![feature(fn_delegation)]`

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
