### PR TITLE
core: Destabilize beta-stable `RangeInclusiveIter::remainder`

### DIFF
--- a/library/core/src/range/iter.rs
+++ b/library/core/src/range/iter.rs
@@ -175,7 +175,10 @@ impl<A: Step> RangeInclusiveIter<A> {
     /// If the iterator is exhausted or empty, returns `None`.
     ///
     /// # Examples
+    ///
     /// ```
+    /// #![feature(new_range_remainder)]
+    ///
     /// let range = core::range::RangeInclusive::from(3..=11);
     /// let mut iter = range.into_iter();
     /// assert_eq!(iter.clone().remainder().unwrap(), range);
@@ -184,7 +187,7 @@ impl<A: Step> RangeInclusiveIter<A> {
     /// iter.by_ref().for_each(drop);
     /// assert!(iter.remainder().is_none());
     /// ```
-    #[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
+    #[unstable(feature = "new_range_remainder", issue = "154458")]
     pub fn remainder(self) -> Option<RangeInclusive<A>> {
         if self.0.is_empty() {
             return None;

--- a/library/core/src/range/iter.rs
+++ b/library/core/src/range/iter.rs
@@ -11,12 +11,15 @@ use crate::{intrinsics, mem};
 pub struct RangeIter<A>(legacy::Range<A>);
 
 impl<A> RangeIter<A> {
-    #[unstable(feature = "new_range_api", issue = "125687")]
+    #[unstable(feature = "new_range_remainder", issue = "154458")]
     /// Returns the remainder of the range being iterated over.
     ///
     /// # Examples
+    ///
     /// ```
     /// #![feature(new_range_api)]
+    /// #![feature(new_range_remainder)]
+    ///
     /// let range = core::range::Range::from(3..11);
     /// let mut iter = range.into_iter();
     /// assert_eq!(iter.clone().remainder(), range);
@@ -333,8 +336,10 @@ impl<A: Step> RangeFromIter<A> {
     /// Returns the remainder of the range being iterated over.
     ///
     /// # Examples
+    ///
     /// ```
-    /// #![feature(new_range_api)]
+    /// #![feature(new_range_remainder)]
+    ///
     /// let range = core::range::RangeFrom::from(3..);
     /// let mut iter = range.into_iter();
     /// assert_eq!(iter.clone().remainder(), range);
@@ -343,7 +348,7 @@ impl<A: Step> RangeFromIter<A> {
     /// ```
     #[inline]
     #[rustc_inherit_overflow_checks]
-    #[unstable(feature = "new_range_api", issue = "125687")]
+    #[unstable(feature = "new_range_remainder", issue = "154458")]
     pub fn remainder(self) -> RangeFrom<A> {
         // Need to handle this case even if overflow-checks are disabled,
         // because a `RangeFromIter` could be exhausted in a crate with

--- a/tests/codegen-llvm/fromrangeiter-overflow-checks.rs
+++ b/tests/codegen-llvm/fromrangeiter-overflow-checks.rs
@@ -11,6 +11,7 @@
 
 #![crate_type = "lib"]
 #![feature(new_range_api)]
+#![feature(new_range_remainder)]
 
 use std::range::RangeFrom;
 

--- a/tests/ui/iterators/rangefrom-overflow-debug.rs
+++ b/tests/ui/iterators/rangefrom-overflow-debug.rs
@@ -2,7 +2,7 @@
 //@ needs-unwind
 //@ compile-flags: -O -C debug_assertions=yes
 
-#![feature(new_range_api)]
+#![feature(new_range_remainder)]
 
 use std::panic;
 

--- a/tests/ui/iterators/rangefrom-overflow-ndebug.rs
+++ b/tests/ui/iterators/rangefrom-overflow-ndebug.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 //@ compile-flags: -O -C debug_assertions=no
 
-#![feature(new_range_api)]
+#![feature(new_range_remainder)]
 
 fn main() {
     let mut it = core::range::RangeFrom::from(u8::MAX..).into_iter();

--- a/tests/ui/iterators/rangefrom-overflow-overflow-checks.rs
+++ b/tests/ui/iterators/rangefrom-overflow-overflow-checks.rs
@@ -2,7 +2,7 @@
 //@ needs-unwind
 //@ compile-flags: -O -C overflow-checks=yes
 
-#![feature(new_range_api)]
+#![feature(new_range_remainder)]
 
 use std::panic;
 

--- a/tests/ui/range/new_range_stability.rs
+++ b/tests/ui/range/new_range_stability.rs
@@ -19,7 +19,7 @@ fn range_inclusive(mut r: RangeInclusive<usize>) {
 
     let mut i = r.into_iter();
     i.next();
-    i.remainder();
+    i.remainder(); //~ ERROR unstable
 }
 
 fn range_to_inclusive(mut r: RangeToInclusive<usize>) {

--- a/tests/ui/range/new_range_stability.stderr
+++ b/tests/ui/range/new_range_stability.stderr
@@ -28,6 +28,16 @@ LL | use std::range::RangeIter;
    = help: add `#![feature(new_range_api)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error[E0658]: use of unstable library feature `new_range_remainder`
+  --> $DIR/new_range_stability.rs:22:7
+   |
+LL |     i.remainder();
+   |       ^^^^^^^^^
+   |
+   = note: see issue #154458 <https://github.com/rust-lang/rust/issues/154458> for more information
+   = help: add `#![feature(new_range_remainder)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error[E0658]: use of unstable library feature `new_range_api`
   --> $DIR/new_range_stability.rs:43:7
    |
@@ -38,6 +48,6 @@ LL |     i.remainder();
    = help: add `#![feature(new_range_api)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/range/new_range_stability.stderr
+++ b/tests/ui/range/new_range_stability.stderr
@@ -38,14 +38,14 @@ LL |     i.remainder();
    = help: add `#![feature(new_range_remainder)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature `new_range_api`
+error[E0658]: use of unstable library feature `new_range_remainder`
   --> $DIR/new_range_stability.rs:43:7
    |
 LL |     i.remainder();
    |       ^^^^^^^^^
    |
-   = note: see issue #125687 <https://github.com/rust-lang/rust/issues/125687> for more information
-   = help: add `#![feature(new_range_api)]` to the crate attributes to enable
+   = note: see issue #154458 <https://github.com/rust-lang/rust/issues/154458> for more information
+   = help: add `#![feature(new_range_remainder)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 5 previous errors


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/154459)*
<!-- homu-ignore:end -->

Destabilize `RangeInclusiveIter::remainder` and move `{RangeIter,RangefromIter}::remainder` to the `new_range_api` feature gate.

Original tracking issue: https://github.com/rust-lang/rust/issues/125687
New tracking issue: https://github.com/rust-lang/rust/issues/154458
Discussion: https://rust-lang.zulipchat.com/#narrow/channel/327149-t-libs-api.2Fapi-changes/topic/.60RangeFrom.3A.3Aremainder.60.20possible.20panic/with/582108913