### PR TITLE
Clarify that isqrt returns the principal (non-negative) square root

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1827,7 +1827,11 @@ macro_rules! int_impl {
             }
         }
 
-        /// Returns the square root of the number, rounded down.
+        /// Returns the integer square root of the number, rounded down.
+        ///
+        /// This function returns the **principal (non-negative) square root**.
+        /// For a given number `n`, although both `x` and `-x` satisfy `x^2 = n`,
+        /// this function always returns the non-negative value.
         ///
         /// Returns `None` if `self` is negative.
         ///
@@ -3122,7 +3126,11 @@ macro_rules! int_impl {
             }
         }
 
-        /// Returns the square root of the number, rounded down.
+        /// Returns the integer square root of the number, rounded down.
+        ///
+        /// This function returns the **principal (non-negative) square root**.
+        /// For a given number `n`, although both `x` and `-x` satisfy `x^2 = n`,
+        /// this function always returns the non-negative value.
         ///
         /// # Panics
         ///


### PR DESCRIPTION
This PR improves the documentation of `isqrt` and `checked_isqrt`
for signed integers by clarifying that the returned value is the
principal (non-negative) square root.

This removes ambiguity since signed integers can represent both
positive and negative values.