### PR TITLE
Make region_scope_tree a tcx method

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -101,7 +101,7 @@ use rustc_trait_selection::traits::ObligationCtxt;
 use tracing::debug;
 
 use self::compare_impl_item::collect_return_position_impl_trait_in_trait_tys;
-use self::region::region_scope_tree;
+use self::region::region_scope_tree_root;
 use crate::{check_c_variadic_abi, errors};
 
 /// Adds query implementations to the [Providers] vtable, see [`rustc_middle::query`]
@@ -109,7 +109,7 @@ pub(super) fn provide(providers: &mut Providers) {
     *providers = Providers {
         adt_destructor,
         adt_async_destructor,
-        region_scope_tree,
+        region_scope_tree_root,
         collect_return_position_impl_trait_in_trait_tys,
         compare_impl_item: compare_impl_item::compare_impl_item,
         check_coroutine_obligations: check::check_coroutine_obligations,

--- a/compiler/rustc_hir_analysis/src/check/region.rs
+++ b/compiler/rustc_hir_analysis/src/check/region.rs
@@ -849,11 +849,8 @@ impl<'tcx> Visitor<'tcx> for ScopeResolutionVisitor<'tcx> {
 /// re-use in incremental scenarios. We may sometimes need to rerun the
 /// type checker even when the HIR hasn't changed, and in those cases
 /// we can avoid reconstructing the region scope tree.
-pub(crate) fn region_scope_tree(tcx: TyCtxt<'_>, def_id: DefId) -> &ScopeTree {
-    let typeck_root_def_id = tcx.typeck_root_def_id(def_id);
-    if typeck_root_def_id != def_id {
-        return tcx.region_scope_tree(typeck_root_def_id);
-    }
+pub(crate) fn region_scope_tree_root(tcx: TyCtxt<'_>, def_id: DefId) -> &ScopeTree {
+    assert!(!tcx.is_typeck_child(def_id));
 
     let scope_tree = if let Some(body) = tcx.hir_maybe_body_owned_by(def_id.expect_local()) {
         let mut visitor = ScopeResolutionVisitor {

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -1411,9 +1411,9 @@ rustc_queries! {
         cache_on_disk_if { true }
     }
 
-    /// Per-body `region::ScopeTree`. The `DefId` should be the owner `DefId` for the body;
-    /// in the case of closures, this will be redirected to the enclosing function.
-    query region_scope_tree(def_id: DefId) -> &'tcx crate::middle::region::ScopeTree {
+    /// Do not call directly! It's query implementation for method
+    /// [`TyCtxt::region_scope_tree`] which you should use instead.
+    query region_scope_tree_root(def_id: DefId) -> &'tcx crate::middle::region::ScopeTree {
         desc { "computing drop scopes for `{}`", tcx.def_path_str(def_id) }
     }
 

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -7,13 +7,15 @@ use rustc_data_structures::hash_table::HashTable;
 use rustc_data_structures::sharded::Sharded;
 use rustc_data_structures::sync::{AtomicU64, Lock, WorkerLocal};
 use rustc_errors::Diag;
+use rustc_hir::def_id::DefId;
 use rustc_span::Span;
 
 use crate::dep_graph::{DepKind, DepNodeIndex, QuerySideEffect, SerializedDepNodeIndex};
 use crate::ich::StableHashingContext;
+use crate::middle::region::ScopeTree;
 use crate::queries::{ExternProviders, Providers, QueryArenas, QueryVTables, TaggedQueryKey};
 use crate::query::on_disk_cache::OnDiskCache;
-use crate::query::{QueryCache, QueryJob, QueryStackFrame};
+use crate::query::{IntoQueryKey, QueryCache, QueryJob, QueryStackFrame};
 use crate::ty::TyCtxt;
 
 /// For a particular query, keeps track of "active" keys, i.e. keys whose
@@ -201,6 +203,12 @@ pub struct TyCtxtEnsureDone<'tcx> {
 }
 
 impl<'tcx> TyCtxt<'tcx> {
+    /// Per-body `region::ScopeTree`. The `DefId` should be the owner `DefId` for the body;
+    /// in the case of closures, this will be redirected to the enclosing function.
+    pub fn region_scope_tree(self, def_id: impl IntoQueryKey<DefId>) -> &'tcx ScopeTree {
+        self.region_scope_tree_root(self.typeck_root_def_id(def_id.into_query_key()))
+    }
+
     /// Returns a transparent wrapper for `TyCtxt` which uses
     /// `span` as the location of queries performed through it.
     #[inline(always)]


### PR DESCRIPTION
Continuing on rust-lang/rust#154304.

Currently `region_scope_tree` query itself calls `tcx.region_scope_tree(tcx.typeck_root_def_id(key))` if its key isn't a type-check root. I thought this might be an overhead and made region_scope_tree a tcx method which calls region_scope_tree_root query instead.