### PR TITLE
Use `tcx.stable_crate_id()` more often

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -727,7 +727,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                     is_stub: false,
                 },
                 extra_filename: tcx.sess.opts.cg.extra_filename.clone(),
-                stable_crate_id: tcx.def_path_hash(LOCAL_CRATE.as_def_id()).stable_crate_id(),
+                stable_crate_id: tcx.stable_crate_id(LOCAL_CRATE),
                 required_panic_strategy: tcx.required_panic_strategy(LOCAL_CRATE),
                 panic_in_drop_strategy: tcx.sess.opts.unstable_opts.panic_in_drop,
                 edition: tcx.sess.edition(),

--- a/compiler/rustc_symbol_mangling/src/legacy.rs
+++ b/compiler/rustc_symbol_mangling/src/legacy.rs
@@ -155,9 +155,7 @@ fn get_symbol_hash<'tcx>(
             args.hash_stable(hcx, &mut hasher);
 
             if let Some(instantiating_crate) = instantiating_crate {
-                tcx.def_path_hash(instantiating_crate.as_def_id())
-                    .stable_crate_id()
-                    .hash_stable(hcx, &mut hasher);
+                tcx.stable_crate_id(instantiating_crate).hash_stable(hcx, &mut hasher);
             }
 
             // We want to avoid accidental collision between different types of instances.

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -841,7 +841,7 @@ impl<'tcx> Printer<'tcx> for V0SymbolMangler<'tcx> {
     fn print_crate_name(&mut self, cnum: CrateNum) -> Result<(), PrintError> {
         self.push("C");
         if !self.is_exportable {
-            let stable_crate_id = self.tcx.def_path_hash(cnum.as_def_id()).stable_crate_id();
+            let stable_crate_id = self.tcx.stable_crate_id(cnum);
             self.push_disambiguator(stable_crate_id.as_u64());
         }
         let name = self.tcx.crate_name(cnum);


### PR DESCRIPTION
A small refactor of code like `tcx.def_path_hash(cnum.as_def_id()).stable_crate_id()` into `tcx.stable_crate_id(cnum)` which effectively has the same output.