### PR TITLE
triagebot: Mention 'subtree' in clippy message

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -940,9 +940,11 @@ message = "`triagebot.toml` has been modified, there may have been changes to th
 cc = ["@davidtwco", "@wesleywiser"]
 
 [mentions."compiler/rustc_codegen_cranelift"]
+message = "The Cranelift subtree was changed"
 cc = ["@bjorn3"]
 
 [mentions."compiler/rustc_codegen_gcc"]
+message = "The GCC codegen subtree was changed"
 cc = ["@antoyo", "@GuillaumeGomez"]
 
 [mentions."compiler/rustc_const_eval/src/"]
@@ -1140,6 +1142,7 @@ cc = [
 cc = ["@ehuss"]
 
 [mentions."src/tools/clippy"]
+message = "The Clippy subtree was changed"
 cc = ["@rust-lang/clippy"]
 
 [mentions."src/tools/compiletest"]
@@ -1169,6 +1172,7 @@ this change to [rust-lang/rust-analyzer] instead.
 cc = ["@rust-lang/rust-analyzer"]
 
 [mentions."src/tools/rustfmt"]
+message = "The Rustfmt subtree was changed"
 cc = ["@rust-lang/rustfmt"]
 
 [mentions."compiler/rustc_middle/src/mir/syntax.rs"]


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/154396#issuecomment-4142641544

This makes it more obvious a subtree is being changed, similarly to Miri and `rustc-dev-guide`