### PR TITLE
resolve: Never lookup glob names in modules from other crates

### DIFF
--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -638,6 +638,13 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     Err(ControlFlow::Break(..)) => return decl,
                 }
             }
+            Scope::ModuleGlobs(module, _)
+                if let ModuleKind::Def(_, def_id, _) = module.kind
+                    && !def_id.is_local() =>
+            {
+                // Fast path: external module decoding only creates non-glob declarations.
+                Err(Determined)
+            }
             Scope::ModuleGlobs(module, derive_fallback_lint_id) => {
                 let (adjusted_parent_scope, adjusted_finalize) = if matches!(
                     scope_set,


### PR DESCRIPTION
This is basically rust-lang/rust#151211, but with the check moved one level above and slightly more work skipped.
rust-lang/rust#151211 showed small, but very consistent perf improvements (see "Show non-relevant results"), but I didn't notice back then.

(This change logically falls into my current work on splitting local and external name resolution modules in type system https://github.com/petrochenkov/rust/tree/modmodmod)