### PR TITLE
Fix argument parsing in compiletest for quoted strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,6 +872,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "shlex",
  "tracing",
  "tracing-subscriber",
  "unified-diff",

--- a/src/tools/compiletest/Cargo.toml
+++ b/src/tools/compiletest/Cargo.toml
@@ -31,6 +31,7 @@ rustfix = "0.8.1"
 semver = { version = "1.0.23", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+shlex = "1.3.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", default-features = false, features = ["ansi", "env-filter", "fmt", "parking_lot", "smallvec"] }
 unified-diff = "0.2.1"

--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -1380,6 +1380,6 @@ fn split_flags(flags: &str) -> Vec<String> {
         .split('\'')
         .enumerate()
         .flat_map(|(i, f)| if i % 2 == 1 { vec![f] } else { f.split_whitespace().collect() })
-        .map(move |s| s.to_owned())
-        .collect::<Vec<_>>()
+        .map(|s| s.to_owned())
+        .collect()
 }

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2835,17 +2835,27 @@ impl<'test> TestCx<'test> {
     ) {
         writeln!(self.stderr, "diff of {stream}:\n");
         if let Some(diff_command) = self.config.diff_command.as_deref() {
-            let mut args = diff_command.split_whitespace();
-            let name = args.next().unwrap();
-            match Command::new(name).args(args).args([expected_path, actual_path]).output() {
-                Err(err) => {
-                    self.fatal(&format!(
-                        "failed to call custom diff command `{diff_command}`: {err}"
-                    ));
+            match shlex::split(diff_command) {
+                Some(mut args) if !args.is_empty() => {
+                    let name = args.remove(0);
+                    match Command::new(name).args(args).args([expected_path, actual_path]).output()
+                    {
+                        Err(err) => {
+                            self.fatal(&format!(
+                                "failed to call custom diff command `{diff_command}`: {err}"
+                            ));
+                        }
+                        Ok(output) => {
+                            let output = String::from_utf8_lossy(&output.stdout);
+                            write!(self.stderr, "{output}");
+                        }
+                    }
                 }
-                Ok(output) => {
-                    let output = String::from_utf8_lossy(&output.stdout);
-                    write!(self.stderr, "{output}");
+                Some(_) => {
+                    self.fatal(&format!("custom diff command is empty: `{diff_command}`"));
+                }
+                None => {
+                    self.fatal(&format!("failed to parse custom diff command: `{diff_command}`"));
                 }
             }
         } else {


### PR DESCRIPTION
Fixes compiletest breaking when using quoted arguments like `--cfg 'feature="my app"'` in compile-flags or custom diff tools.

  Uses proper shell argument parsing instead of naive whitespace splitting.

  Closes rust-lang/rust#132599
