### PR TITLE
Mark a function only used in nightly as nightly only

### DIFF
--- a/compiler/rustc_abi/src/callconv.rs
+++ b/compiler/rustc_abi/src/callconv.rs
@@ -35,6 +35,7 @@ impl HomogeneousAggregate {
     /// Try to combine two `HomogeneousAggregate`s, e.g. from two fields in
     /// the same `struct`. Only succeeds if only one of them has any data,
     /// or both units are identical.
+    #[cfg(feature = "nightly")]
     fn merge(self, other: HomogeneousAggregate) -> Result<HomogeneousAggregate, Heterogeneous> {
         match (self, other) {
             (x, HomogeneousAggregate::NoData) | (HomogeneousAggregate::NoData, x) => Ok(x),

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -1,6 +1,4 @@
 use std::marker::PhantomData;
-#[cfg(not(feature = "nightly"))]
-use std::mem;
 use std::ops::{Bound, Range, RangeBounds};
 use std::rc::Rc;
 use std::{fmt, iter, slice};


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

If you run `./x.py test rustc_next_trait_solver` you'll currently see a failure:

```
warning: method `merge` is never used
  --> compiler/rustc_abi/src/callconv.rs:38:8
   |
25 | impl HomogeneousAggregate {
   | ------------------------- method in this implementation
...
38 |     fn merge(self, other: HomogeneousAggregate) -> Result<HomogeneousAggregate, Heterogeneous> {
   |        ^^^^^
   |
   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default

warning: `rustc_abi` (lib) generated 1 warning
```

This is because the usages are behind a nightly feature flag:

https://github.com/rust-lang/rust/blob/fda6d37bb88ee12fd50fa54d15859f1f91b74f55/compiler/rustc_abi/src/callconv.rs#L52

https://github.com/rust-lang/rust/blob/fda6d37bb88ee12fd50fa54d15859f1f91b74f55/compiler/rustc_abi/src/callconv.rs#L131


https://github.com/rust-lang/rust/blob/fda6d37bb88ee12fd50fa54d15859f1f91b74f55/compiler/rustc_abi/src/callconv.rs#L167

This does the flag off.

Test on `main` and this branch:

```
./x.py test rustc_next_trait_solver
```