### PR TITLE
Revert "Link LLVM dynamically on aarch64-apple-darwin" and "re-enable enzyme/autodiff builds on dist-aarch64-apple"

### DIFF
--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -402,16 +402,6 @@ fn main() {
             continue;
         }
 
-        // On apple-darwin, llvm-config reports the versioned shared library name such as LLVM-22-..., but
-        // the distributed toolchain ships libLLVM.dylib. Normalize the link name here.
-        let name =
-            if target.contains("apple-darwin") && llvm_kind == "dylib" && name.starts_with("LLVM-")
-            {
-                "LLVM"
-            } else {
-                name
-            };
-
         let kind = if name.starts_with("LLVM") {
             llvm_kind
         } else if is_static {

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -62,15 +62,12 @@ pub fn walk_native_lib_search_dirs<R>(
         f(&sess.target_tlib_path.dir.join("self-contained"), false)?;
     }
 
-    let has_shared_llvm_apple_darwin =
-        sess.target.is_like_darwin && sess.target_tlib_path.dir.join("libLLVM.dylib").exists();
-
     // Toolchains for some targets may ship `libunwind.a`, but place it into the main sysroot
     // library directory instead of the self-contained directories.
     // Sanitizer libraries have the same issue and are also linked by name on Apple targets.
     // The targets here should be in sync with `copy_third_party_objects` in bootstrap.
-    // On Apple targets, shared LLVM is linked by name, so when `libLLVM.dylib` is
-    // present in the target libdir, add that directory to the linker search path.
+    // Finally there is shared LLVM library, which unlike compiler libraries, is linked by the name,
+    // therefore requiring the search path for the linker.
     // FIXME: implement `-Clink-self-contained=+/-unwind,+/-sanitizers`, move the shipped libunwind
     // and sanitizers to self-contained directory, and stop adding this search path.
     // FIXME: On AIX this also has the side-effect of making the list of library search paths
@@ -80,8 +77,7 @@ pub fn walk_native_lib_search_dirs<R>(
         || sess.target.os == Os::Linux
         || sess.target.os == Os::Fuchsia
         || sess.target.is_like_aix
-        || sess.target.is_like_darwin
-            && (!sess.sanitizers().is_empty() || has_shared_llvm_apple_darwin)
+        || sess.target.is_like_darwin && !sess.sanitizers().is_empty()
         || sess.target.os == Os::Windows
             && sess.target.env == Env::Gnu
             && sess.target.cfg_abi == CfgAbi::Llvm

--- a/src/bootstrap/download-ci-llvm-stamp
+++ b/src/bootstrap/download-ci-llvm-stamp
@@ -1,4 +1,4 @@
 Change this file to make users of the `download-ci-llvm` configuration download
 a new version of LLVM from CI, even if the LLVM submodule hasn’t changed.
 
-Last change is for: https://github.com/rust-lang/rust/pull/151063
+Last change is for: https://github.com/rust-lang/rust/pull/154485

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -518,7 +518,6 @@ auto:
         --enable-sanitizers
         --enable-profiler
         --set rust.jemalloc
-        --set llvm.link-shared=true
         --set rust.lto=thin
         --set rust.codegen-units=1
       # Aarch64 tooling only needs to support macOS 11.0 and up as nothing else

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -509,7 +509,7 @@ auto:
   - name: dist-aarch64-apple
     env:
       SCRIPT: >-
-        ./x.py dist bootstrap enzyme
+        ./x.py dist bootstrap
         --include-default-paths
         --host=aarch64-apple-darwin
         --target=aarch64-apple-darwin


### PR DESCRIPTION
This reverts commit e7c268f8837b2e67d1f90a75357a4c58f697dc59.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This approach was much better than the last time, as it didn't break downstream users like miri.
Unfortunately, it still broke rustc contributors and is blocking some people: https://github.com/rust-lang/rust/issues/154408
The previously discussed solution (symlink) didn't seem to work for a user, and shipping two full copies of LLVM (old + new name) until the next stage0 compiler bump should probably be discussed first. We now also have artifacts of a nightly or two, which can be used for local experimenting, so hopefully next time we won't break anyone at all.

cc @sgasho 

r? @jieyouxu 