### PR TITLE
std_detect on AArch64 Darwin: Detect FEAT_SVE_B16B16

### DIFF
--- a/library/std_detect/src/detect/os/darwin/aarch64.rs
+++ b/library/std_detect/src/detect/os/darwin/aarch64.rs
@@ -81,6 +81,7 @@ pub(crate) fn detect_features() -> cache::Initializer {
     let sme_f64f64 = _sysctlbyname(c"hw.optional.arm.FEAT_SME_F64F64");
     let sme_i16i64 = _sysctlbyname(c"hw.optional.arm.FEAT_SME_I16I64");
     let ssbs = _sysctlbyname(c"hw.optional.arm.FEAT_SSBS");
+    let sve_b16b16 = _sysctlbyname(c"hw.optional.arm.FEAT_SVE_B16B16");
     let wfxt = _sysctlbyname(c"hw.optional.arm.FEAT_WFxT");
 
     // The following features are not exposed by `is_aarch64_feature_detected`,
@@ -160,6 +161,7 @@ pub(crate) fn detect_features() -> cache::Initializer {
     enable_feature(Feature::sme_f64f64, sme_f64f64);
     enable_feature(Feature::sme_i16i64, sme_i16i64);
     enable_feature(Feature::ssbs, ssbs);
+    enable_feature(Feature::sve_b16b16, sve_b16b16);
     enable_feature(Feature::wfxt, wfxt);
 
     value


### PR DESCRIPTION
This is now exposed via `sysctl` as of macOS "Tahoe" 26.4 (or possibly earlier).

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
