### PR TITLE
triagebot: add reminder for bumping CI LLVM stamp

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1412,6 +1412,15 @@ cc = ["@m-ou-se"]
 [mentions."compiler/rustc_ast_lowering/src/format.rs"]
 cc = ["@m-ou-se"]
 
+[mentions."src/ci/github-actions/jobs.yml"]
+message = """
+> [!WARNING]
+>
+> If you are changing how CI LLVM is built or linked, make sure to bump
+> `src/bootstrap/download-ci-llvm-stamp`.
+"""
+cc = ["@jieyouxu"]
+
 # Content-based mentions
 
 [mentions."#[miri::intrinsic_fallback_is_spec]"]


### PR DESCRIPTION
I'm not sure what else can be done automatically to help us not forget this, but at least this gives a chance for the PR author/reviewer to be reminded (e.g. myself).