### PR TITLE
Fix ambiguous parsing in bootstrap.py

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -1259,7 +1259,12 @@ class RustBuild(object):
 
 def parse_args(args):
     """Parse the command line arguments that the python script needs."""
-    parser = argparse.ArgumentParser(add_help=False)
+
+    # Pass allow_abbrev=False to remove support for inexact matches (e.g.,
+    # `--json` turning on `--json-output`). The argument list here is partial,
+    # most flags are matched in the Rust bootstrap code. This prevents the the
+    # default ambiguity checks in argparse from functioning correctly.
+    parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
     parser.add_argument("-h", "--help", action="store_true")
     parser.add_argument("--config")
     parser.add_argument("--build-dir")

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -616,4 +616,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Warning,
         summary: "`x.py test --no-doc` is renamed to `--all-targets`. Additionally `--tests` is added which only executes unit and integration tests.",
     },
+    ChangeInfo {
+        change_id: 154508,
+        severity: ChangeSeverity::Info,
+        summary: "`x.py` stopped accepting partial argument names. Use full names to avoid errors.",
+    },
 ];


### PR DESCRIPTION
Noticed this while trying to produce rustdoc-json for std and saw JSON output from the bootstrap.py build of bootstrap's Rust code. This is technically a breaking change, but I think the fix should be simple and arguably an improvement in future compatibility if/when the flag set changes.