### PR TITLE
Partially stabilize LoongArch target features

### DIFF
--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -816,18 +816,18 @@ static LOONGARCH_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     // tidy-alphabetical-start
     ("32s", Unstable(sym::loongarch_target_feature), &[]),
     ("d", Stable, &["f"]),
-    ("div32", Unstable(sym::loongarch_target_feature), &[]),
+    ("div32", Stable, &[]),
     ("f", Stable, &[]),
     ("frecipe", Stable, &[]),
-    ("lam-bh", Unstable(sym::loongarch_target_feature), &[]),
-    ("lamcas", Unstable(sym::loongarch_target_feature), &[]),
+    ("lam-bh", Stable, &[]),
+    ("lamcas", Stable, &[]),
     ("lasx", Stable, &["lsx"]),
     ("lbt", Stable, &[]),
-    ("ld-seq-sa", Unstable(sym::loongarch_target_feature), &[]),
+    ("ld-seq-sa", Stable, &[]),
     ("lsx", Stable, &["d"]),
     ("lvz", Stable, &[]),
     ("relax", Unstable(sym::loongarch_target_feature), &[]),
-    ("scq", Unstable(sym::loongarch_target_feature), &[]),
+    ("scq", Stable, &[]),
     ("ual", Unstable(sym::loongarch_target_feature), &[]),
     // tidy-alphabetical-end
 ];

--- a/library/std_detect/src/detect/arch/loongarch.rs
+++ b/library/std_detect/src/detect/arch/loongarch.rs
@@ -35,19 +35,19 @@ features! {
     /// D
     @FEATURE: #[stable(feature = "stdarch_loongarch_feature", since = "1.89.0")] frecipe: "frecipe";
     /// Frecipe
-    @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] div32: "div32";
+    @FEATURE: #[stable(feature = "stdarch_loongarch_div32", since = "CURRENT_RUSTC_VERSION")] div32: "div32";
     /// Div32
     @FEATURE: #[stable(feature = "stdarch_loongarch_feature", since = "1.89.0")] lsx: "lsx";
     /// LSX
     @FEATURE: #[stable(feature = "stdarch_loongarch_feature", since = "1.89.0")] lasx: "lasx";
     /// LASX
-    @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] lam_bh: "lam-bh";
+    @FEATURE: #[stable(feature = "stdarch_loongarch_lam_bh", since = "CURRENT_RUSTC_VERSION")] lam_bh: "lam-bh";
     /// LAM-BH
-    @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] lamcas: "lamcas";
+    @FEATURE: #[stable(feature = "stdarch_loongarch_lamcas", since = "CURRENT_RUSTC_VERSION")] lamcas: "lamcas";
     /// LAM-CAS
-    @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] ld_seq_sa: "ld-seq-sa";
+    @FEATURE: #[stable(feature = "stdarch_loongarch_ld_seq_sa", since = "CURRENT_RUSTC_VERSION")] ld_seq_sa: "ld-seq-sa";
     /// LD-SEQ-SA
-    @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] scq: "scq";
+    @FEATURE: #[stable(feature = "stdarch_loongarch_scq", since = "CURRENT_RUSTC_VERSION")] scq: "scq";
     /// SCQ
     @FEATURE: #[stable(feature = "stdarch_loongarch_feature", since = "1.89.0")] lbt: "lbt";
     /// LBT


### PR DESCRIPTION
This PR stabilizes the following target features:

- div32
- lam-bh
- lamcas
- ld-seq-sa
- scq

Docs PR: https://github.com/rust-lang/reference/pull/2217

r? @Amanieu