### PR TITLE
Documentation update to map.rs as part of tracking issue  #107540

### DIFF
--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -3405,7 +3405,8 @@ impl<'a, K: Ord, V, A: Allocator + Clone> CursorMutKey<'a, K, V, A> {
     /// cursor is currently pointing to.
     ///
     /// After the insertion the cursor will be pointing at the gap before the
-    /// newly inserted element.
+    /// newly inserted element, effectively inserting the new element after the
+    /// current cursor position.
     ///
     /// # Safety
     ///
@@ -3448,7 +3449,8 @@ impl<'a, K: Ord, V, A: Allocator + Clone> CursorMutKey<'a, K, V, A> {
     /// cursor is currently pointing to.
     ///
     /// After the insertion the cursor will be pointing at the gap after the
-    /// newly inserted element.
+    /// newly inserted element, effectively inserting the new element before
+    /// the current cursor position.
     ///
     /// # Safety
     ///
@@ -3494,7 +3496,8 @@ impl<'a, K: Ord, V, A: Allocator + Clone> CursorMutKey<'a, K, V, A> {
     /// cursor is currently pointing to.
     ///
     /// After the insertion the cursor will be pointing at the gap before the
-    /// newly inserted element.
+    /// newly inserted element, effectively inserting the new element after the
+    /// current cursor position.
     ///
     /// If the inserted key is not greater than the key before the cursor
     /// (if any), or if it not less than the key after the cursor (if any),
@@ -3522,7 +3525,8 @@ impl<'a, K: Ord, V, A: Allocator + Clone> CursorMutKey<'a, K, V, A> {
     /// cursor is currently pointing to.
     ///
     /// After the insertion the cursor will be pointing at the gap after the
-    /// newly inserted element.
+    /// newly inserted element, effectively inserting the new element before
+    /// the current cursor position.
     ///
     /// If the inserted key is not greater than the key before the cursor
     /// (if any), or if it not less than the key after the cursor (if any),
@@ -3609,8 +3613,9 @@ impl<'a, K: Ord, V, A: Allocator + Clone> CursorMut<'a, K, V, A> {
     /// Inserts a new key-value pair into the map in the gap that the
     /// cursor is currently pointing to.
     ///
-    /// After the insertion the cursor will be pointing at the gap after the
-    /// newly inserted element.
+    /// After the insertion the cursor will be pointing at the gap before the
+    /// newly inserted element, effectively inserting the new element after the
+    /// current cursor position.
     ///
     /// # Safety
     ///
@@ -3628,7 +3633,8 @@ impl<'a, K: Ord, V, A: Allocator + Clone> CursorMut<'a, K, V, A> {
     /// cursor is currently pointing to.
     ///
     /// After the insertion the cursor will be pointing at the gap after the
-    /// newly inserted element.
+    /// newly inserted element, effectively inserting the new element before
+    /// the current cursor position.
     ///
     /// # Safety
     ///
@@ -3646,7 +3652,8 @@ impl<'a, K: Ord, V, A: Allocator + Clone> CursorMut<'a, K, V, A> {
     /// cursor is currently pointing to.
     ///
     /// After the insertion the cursor will be pointing at the gap before the
-    /// newly inserted element.
+    /// newly inserted element, effectively inserting the new element after the
+    /// current cursor position.
     ///
     /// If the inserted key is not greater than the key before the cursor
     /// (if any), or if it not less than the key after the cursor (if any),
@@ -3661,7 +3668,8 @@ impl<'a, K: Ord, V, A: Allocator + Clone> CursorMut<'a, K, V, A> {
     /// cursor is currently pointing to.
     ///
     /// After the insertion the cursor will be pointing at the gap after the
-    /// newly inserted element.
+    /// newly inserted element, effectively inserting the new element before
+    /// the current cursor position.
     ///
     /// If the inserted key is not greater than the key before the cursor
     /// (if any), or if it not less than the key after the cursor (if any),


### PR DESCRIPTION
As Part of tracking issue rust-lang/rust#107540, I submit a document fix (the comments describing the method `CursorMut::insert_after_unchecked()` should say "before" instead of "after". This can be seen for example from the comments for `CursorMutKey::insert_after_unchecked()`, which are correct.

I further submit a suggestion to make the comments before all Cursor insert methods slightly more verbose to explain the before/after in the names of those methods: insert_after() inserts the new item effectively after the cursor, thus positioning the cursor itself before the new element. I hope the extra verbosity will help to clarify the actual behavior of these methods.

No actual code is updated.
