### PR TITLE
Notify stdarch maintainers on changes in std_detect

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1073,6 +1073,10 @@ instead.
 """
 cc = ["@Amanieu", "@folkertdev", "@sayantn"]
 
+[mentions."library/std_detect"]
+message = "Some changes occurred in `std_detect`"
+cc = ["@Amanieu", "@folkertdev", "@sayantn"]
+
 [mentions."library/core/src/intrinsics/simd.rs"]
 message = """
 Some changes occurred to the platform-builtins intrinsics. Make sure the

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1596,6 +1596,7 @@ dep-bumps = [
 "/library/std" =                                         ["libs", "@ChrisDenton"]
 "/library/std/src/sys/pal/windows" =                     ["@ChrisDenton"]
 "/library/stdarch" =                                     ["libs"]
+"/library/std_detect" =                                  ["libs"]
 "/library/test" =                                        ["libs"]
 "/src/bootstrap" =                                       ["bootstrap"]
 "/src/ci" =                                              ["infra-ci"]


### PR DESCRIPTION
cc @Amanieu @folkertdev @Kobzol

It would be nice to be notified when std_detect changes, as it is spiritually a part of stdarch.

Also assign @rust-lang/libs to std_detect