### PR TITLE
Add doc links to `ExtractIf` of `BTree{Set,Map}` and `LinkedList`

### DIFF
--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -2102,7 +2102,9 @@ impl<K, V> Default for Values<'_, K, V> {
     }
 }
 
-/// An iterator produced by calling `extract_if` on BTreeMap.
+/// This `struct` is created by the [`extract_if`] method on [`BTreeMap`].
+///
+/// [`extract_if`]: BTreeMap::extract_if
 #[stable(feature = "btree_extract_if", since = "1.91.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed; \
     use `retain` or `extract_if().for_each(drop)` to remove and discard elements"]

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -1547,7 +1547,9 @@ impl<'a, T, A: Allocator + Clone> IntoIterator for &'a BTreeSet<T, A> {
     }
 }
 
-/// An iterator produced by calling `extract_if` on BTreeSet.
+/// This `struct` is created by the [`extract_if`] method on [`BTreeSet`].
+///
+/// [`extract_if`]: BTreeSet::extract_if
 #[stable(feature = "btree_extract_if", since = "1.91.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed; \
     use `retain` or `extract_if().for_each(drop)` to remove and discard elements"]

--- a/library/alloc/src/collections/linked_list.rs
+++ b/library/alloc/src/collections/linked_list.rs
@@ -1942,7 +1942,9 @@ impl<'a, T, A: Allocator> CursorMut<'a, T, A> {
     }
 }
 
-/// An iterator produced by calling `extract_if` on LinkedList.
+/// This `struct` is created by the [`extract_if`] method on [`LinkedList`].
+///
+/// [`extract_if`]: LinkedList::extract_if
 #[stable(feature = "extract_if", since = "1.87.0")]
 #[must_use = "iterators are lazy and do nothing unless consumed; \
     use `extract_if().for_each(drop)` to remove and discard elements"]


### PR DESCRIPTION
There were links for `Hash{Set,Map}` and `Vec{,Deque}` versions, but not these three.
