### PR TITLE
Panic/return false on overflow in no_threads read/try_read impl

### DIFF
--- a/library/std/src/sys/sync/rwlock/no_threads.rs
+++ b/library/std/src/sys/sync/rwlock/no_threads.rs
@@ -17,12 +17,8 @@ impl RwLock {
     #[inline]
     pub fn read(&self) {
         let m = self.mode.get();
-
-        // Check for overflow.
-        assert!(m == isize::MAX, "too many active read locks on RwLock");
-
         if m >= 0 {
-            self.mode.set(m + 1);
+            self.mode.set(m.checked_add(1).expect("rwlock overflowed read locks"));
         } else {
             rtabort!("rwlock locked for writing");
         }
@@ -63,16 +59,19 @@ impl RwLock {
 
     #[inline]
     pub unsafe fn read_unlock(&self) {
-        self.mode.set(self.mode.get() - 1);
+        assert!(
+            self.mode.replace(self.mode.get() - 1) > 0,
+            "rwlock has not been locked for reading"
+        );
     }
 
     #[inline]
     pub unsafe fn write_unlock(&self) {
-        assert_eq!(self.mode.replace(0), -1);
+        assert_eq!(self.mode.replace(0), -1, "rwlock has not been locked for writing");
     }
 
     #[inline]
     pub unsafe fn downgrade(&self) {
-        assert_eq!(self.mode.replace(1), -1);
+        assert_eq!(self.mode.replace(1), -1, "rwlock has not been locked for writing");
     }
 }

--- a/library/std/src/sys/sync/rwlock/no_threads.rs
+++ b/library/std/src/sys/sync/rwlock/no_threads.rs
@@ -17,6 +17,10 @@ impl RwLock {
     #[inline]
     pub fn read(&self) {
         let m = self.mode.get();
+
+        // Check for overflow.
+        assert!(m == isize::MAX, "too many active read locks on RwLock");
+
         if m >= 0 {
             self.mode.set(m + 1);
         } else {
@@ -28,6 +32,9 @@ impl RwLock {
     pub fn try_read(&self) -> bool {
         let m = self.mode.get();
         if m >= 0 {
+            if m == isize::MAX {
+                return false;
+            }
             self.mode.set(m + 1);
             true
         } else {


### PR DESCRIPTION
As per discussion with Mark in rust-lang/rust#153555, it's possible for `no_threads` impl of `RwLock` to trigger a silent overflow on `RwLock::read`/`RwLock::try_read` if we try to acquire more than `isize::MAX` read locks. This PR adds an explicit panic/return false when our read lock counter is at `isize::MAX` for `RwLock::read`/`RwLock::try_read`; the message is similar to that of sys/sync/rwlock/futex.rs [here](https://github.com/rust-lang/rust/blob/fb27476aaf1012f1f6ace6306f9b990e0d989c31/library/std/src/sys/sync/rwlock/futex.rs#L143).

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
