### PR TITLE
update zulip link in `std` documentation

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -94,8 +94,8 @@
 //! pull-requests for your suggested changes.
 //!
 //! Contributions are appreciated! If you see a part of the docs that can be
-//! improved, submit a PR, or chat with us first on [Zulip][rust-zulip]
-//! #docs.
+//! improved, submit a PR, or chat with us first on [Zulip][t-libs-zulip]
+//! #t-libs.
 //!
 //! # A Tour of The Rust Standard Library
 //!
@@ -209,7 +209,7 @@
 //! [multithreading]: thread
 //! [other]: #what-is-in-the-standard-library-documentation
 //! [primitive types]: ../book/ch03-02-data-types.html
-//! [rust-zulip]: https://rust-lang.zulipchat.com/
+//! [t-libs-zulip]: https://rust-lang.zulipchat.com/#narrow/channel/219381-t-libs/
 //! [array]: prim@array
 //! [slice]: prim@slice
 


### PR DESCRIPTION
#docs doesn't seem to exist anymore, so point people to `t-libs`. Also include direct link to topic since Zulip is world-viewable now.