### PR TITLE
Fix invalid type suggestion for item nested in function

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -4,7 +4,7 @@ use rustc_errors::{Applicability, StashKey, Suggestions};
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::intravisit::VisitorExt;
 use rustc_hir::{self as hir, AmbigArg, HirId};
-use rustc_middle::ty::print::with_forced_trimmed_paths;
+use rustc_middle::ty::print::{with_forced_trimmed_paths, with_types_for_suggestion};
 use rustc_middle::ty::util::IntTypeExt;
 use rustc_middle::ty::{self, DefiningScopeKind, IsSuggestable, Ty, TyCtxt, TypeVisitableExt};
 use rustc_middle::{bug, span_bug};
@@ -451,7 +451,7 @@ fn infer_placeholder_type<'tcx>(
                     err.span_suggestion(
                         ty_span,
                         format!("provide a type for the {kind}"),
-                        format!("{colon} {ty}"),
+                        with_types_for_suggestion!(format!("{colon} {ty}")),
                         Applicability::MachineApplicable,
                     );
                 } else {

--- a/compiler/rustc_middle/src/ty/print/mod.rs
+++ b/compiler/rustc_middle/src/ty/print/mod.rs
@@ -133,8 +133,15 @@ pub trait Printer<'tcx>: Sized {
         self.print_path_with_generic_args(|p| p.print_def_path(def_id, parent_args), &[kind.into()])
     }
 
-    // Defaults (should not be overridden):
+    fn reset_path(&mut self) -> Result<(), PrintError> {
+        Ok(())
+    }
 
+    fn should_omit_parent_def_path(&self, _parent_def_id: DefId) -> bool {
+        false
+    }
+
+    // Defaults (should not be overridden):
     #[instrument(skip(self), level = "debug")]
     fn default_print_def_path(
         &mut self,
@@ -210,9 +217,15 @@ pub trait Printer<'tcx>: Sized {
                         && self.tcx().generics_of(parent_def_id).parent_count == 0;
                 }
 
+                let omit_parent = matches!(key.disambiguated_data.data, DefPathData::TypeNs(..))
+                    && self.should_omit_parent_def_path(parent_def_id);
+
                 self.print_path_with_simple(
                     |p: &mut Self| {
-                        if trait_qualify_parent {
+                        if omit_parent {
+                            p.reset_path()?;
+                            Ok(())
+                        } else if trait_qualify_parent {
                             let trait_ref = ty::TraitRef::new(
                                 p.tcx(),
                                 parent_def_id,

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -2224,6 +2224,19 @@ impl<'tcx> Printer<'tcx> for FmtPrinter<'_, 'tcx> {
         self.tcx
     }
 
+    fn reset_path(&mut self) -> Result<(), PrintError> {
+        self.empty_path = true;
+        Ok(())
+    }
+
+    fn should_omit_parent_def_path(&self, parent_def_id: DefId) -> bool {
+        RTN_MODE.with(|mode| mode.get()) == RtnMode::ForSuggestion
+            && matches!(
+                self.tcx().def_key(parent_def_id).disambiguated_data.data,
+                DefPathData::ValueNs(..) | DefPathData::Closure | DefPathData::AnonConst
+            )
+    }
+
     fn print_def_path(
         &mut self,
         def_id: DefId,

--- a/tests/ui/suggestions/function-local-item-type-suggestion-issue-146786.fixed
+++ b/tests/ui/suggestions/function-local-item-type-suggestion-issue-146786.fixed
@@ -1,0 +1,11 @@
+//@ run-rustfix
+#![allow(dead_code)]
+
+fn main() {
+    struct Error;
+
+    const ERROR: Error = Error;
+    //~^ ERROR missing type for `const` item
+    //~| HELP provide a type for the constant
+    //~| SUGGESTION : Error
+}

--- a/tests/ui/suggestions/function-local-item-type-suggestion-issue-146786.rs
+++ b/tests/ui/suggestions/function-local-item-type-suggestion-issue-146786.rs
@@ -1,0 +1,11 @@
+//@ run-rustfix
+#![allow(dead_code)]
+
+fn main() {
+    struct Error;
+
+    const ERROR = Error;
+    //~^ ERROR missing type for `const` item
+    //~| HELP provide a type for the constant
+    //~| SUGGESTION : Error
+}

--- a/tests/ui/suggestions/function-local-item-type-suggestion-issue-146786.stderr
+++ b/tests/ui/suggestions/function-local-item-type-suggestion-issue-146786.stderr
@@ -1,0 +1,8 @@
+error: missing type for `const` item
+  --> $DIR/function-local-item-type-suggestion-issue-146786.rs:7:16
+   |
+LL |     const ERROR = Error;
+   |                ^ help: provide a type for the constant: `: Error`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes rust-lang/rust#146786

I also tried to add the `omit_parent` logic in pretty formatter here:
https://github.com/chenyukang/rust/blob/69b6d26d05006dca7556abc555fb0e029ecf1f4e/compiler/rustc_middle/src/ty/print/pretty.rs#L2240-L2295
so that we don't need to add `should_omit_parent_def_path` and `reset_path`.

but seems there will be duplicate print code with `default_print_def_path`.

maybe r? @estebank 
