### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/library/core/src/range/iter.rs
+++ b/library/core/src/range/iter.rs
@@ -175,7 +175,10 @@ impl<A: Step> RangeInclusiveIter<A> {
     /// If the iterator is exhausted or empty, returns `None`.
     ///
     /// # Examples
+    ///
     /// ```
+    /// #![feature(new_range_remainder)]
+    ///
     /// let range = core::range::RangeInclusive::from(3..=11);
     /// let mut iter = range.into_iter();
     /// assert_eq!(iter.clone().remainder().unwrap(), range);
@@ -184,7 +187,7 @@ impl<A: Step> RangeInclusiveIter<A> {
     /// iter.by_ref().for_each(drop);
     /// assert!(iter.remainder().is_none());
     /// ```
-    #[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
+    #[unstable(feature = "new_range_remainder", issue = "154458")]
     pub fn remainder(self) -> Option<RangeInclusive<A>> {
         if self.0.is_empty() {
             return None;

--- a/library/core/src/range/iter.rs
+++ b/library/core/src/range/iter.rs
@@ -11,12 +11,15 @@ use crate::{intrinsics, mem};
 pub struct RangeIter<A>(legacy::Range<A>);
 
 impl<A> RangeIter<A> {
-    #[unstable(feature = "new_range_api", issue = "125687")]
+    #[unstable(feature = "new_range_remainder", issue = "154458")]
     /// Returns the remainder of the range being iterated over.
     ///
     /// # Examples
+    ///
     /// ```
     /// #![feature(new_range_api)]
+    /// #![feature(new_range_remainder)]
+    ///
     /// let range = core::range::Range::from(3..11);
     /// let mut iter = range.into_iter();
     /// assert_eq!(iter.clone().remainder(), range);
@@ -333,8 +336,10 @@ impl<A: Step> RangeFromIter<A> {
     /// Returns the remainder of the range being iterated over.
     ///
     /// # Examples
+    ///
     /// ```
-    /// #![feature(new_range_api)]
+    /// #![feature(new_range_remainder)]
+    ///
     /// let range = core::range::RangeFrom::from(3..);
     /// let mut iter = range.into_iter();
     /// assert_eq!(iter.clone().remainder(), range);
@@ -343,7 +348,7 @@ impl<A: Step> RangeFromIter<A> {
     /// ```
     #[inline]
     #[rustc_inherit_overflow_checks]
-    #[unstable(feature = "new_range_api", issue = "125687")]
+    #[unstable(feature = "new_range_remainder", issue = "154458")]
     pub fn remainder(self) -> RangeFrom<A> {
         // Need to handle this case even if overflow-checks are disabled,
         // because a `RangeFromIter` could be exhausted in a crate with

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -3348,6 +3348,7 @@ impl SizeHint for &[u8] {
 /// [`split`]: BufRead::split
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Debug)]
+#[cfg_attr(not(test), rustc_diagnostic_item = "IoSplit")]
 pub struct Split<B> {
     buf: B,
     delim: u8,

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -94,8 +94,8 @@
 //! pull-requests for your suggested changes.
 //!
 //! Contributions are appreciated! If you see a part of the docs that can be
-//! improved, submit a PR, or chat with us first on [Zulip][rust-zulip]
-//! #docs.
+//! improved, submit a PR, or chat with us first on [Zulip][t-libs-zulip]
+//! #t-libs.
 //!
 //! # A Tour of The Rust Standard Library
 //!
@@ -209,7 +209,7 @@
 //! [multithreading]: thread
 //! [other]: #what-is-in-the-standard-library-documentation
 //! [primitive types]: ../book/ch03-02-data-types.html
-//! [rust-zulip]: https://rust-lang.zulipchat.com/
+//! [t-libs-zulip]: https://rust-lang.zulipchat.com/#narrow/channel/219381-t-libs/
 //! [array]: prim@array
 //! [slice]: prim@slice
 

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -1259,7 +1259,12 @@ class RustBuild(object):
 
 def parse_args(args):
     """Parse the command line arguments that the python script needs."""
-    parser = argparse.ArgumentParser(add_help=False)
+
+    # Pass allow_abbrev=False to remove support for inexact matches (e.g.,
+    # `--json` turning on `--json-output`). The argument list here is partial,
+    # most flags are matched in the Rust bootstrap code. This prevents the the
+    # default ambiguity checks in argparse from functioning correctly.
+    parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
     parser.add_argument("-h", "--help", action="store_true")
     parser.add_argument("--config")
     parser.add_argument("--build-dir")

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -616,4 +616,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Warning,
         summary: "`x.py test --no-doc` is renamed to `--all-targets`. Additionally `--tests` is added which only executes unit and integration tests.",
     },
+    ChangeInfo {
+        change_id: 154508,
+        severity: ChangeSeverity::Info,
+        summary: "`x.py` stopped accepting partial argument names. Use full names to avoid errors.",
+    },
 ];

--- a/tests/codegen-llvm/fromrangeiter-overflow-checks.rs
+++ b/tests/codegen-llvm/fromrangeiter-overflow-checks.rs
@@ -11,6 +11,7 @@
 
 #![crate_type = "lib"]
 #![feature(new_range_api)]
+#![feature(new_range_remainder)]
 
 use std::range::RangeFrom;
 

--- a/tests/ui/iterators/rangefrom-overflow-debug.rs
+++ b/tests/ui/iterators/rangefrom-overflow-debug.rs
@@ -2,7 +2,7 @@
 //@ needs-unwind
 //@ compile-flags: -O -C debug_assertions=yes
 
-#![feature(new_range_api)]
+#![feature(new_range_remainder)]
 
 use std::panic;
 

--- a/tests/ui/iterators/rangefrom-overflow-ndebug.rs
+++ b/tests/ui/iterators/rangefrom-overflow-ndebug.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 //@ compile-flags: -O -C debug_assertions=no
 
-#![feature(new_range_api)]
+#![feature(new_range_remainder)]
 
 fn main() {
     let mut it = core::range::RangeFrom::from(u8::MAX..).into_iter();

--- a/tests/ui/iterators/rangefrom-overflow-overflow-checks.rs
+++ b/tests/ui/iterators/rangefrom-overflow-overflow-checks.rs
@@ -2,7 +2,7 @@
 //@ needs-unwind
 //@ compile-flags: -O -C overflow-checks=yes
 
-#![feature(new_range_api)]
+#![feature(new_range_remainder)]
 
 use std::panic;
 

--- a/tests/ui/range/new_range_stability.rs
+++ b/tests/ui/range/new_range_stability.rs
@@ -19,7 +19,7 @@ fn range_inclusive(mut r: RangeInclusive<usize>) {
 
     let mut i = r.into_iter();
     i.next();
-    i.remainder();
+    i.remainder(); //~ ERROR unstable
 }
 
 fn range_to_inclusive(mut r: RangeToInclusive<usize>) {

--- a/tests/ui/range/new_range_stability.stderr
+++ b/tests/ui/range/new_range_stability.stderr
@@ -28,6 +28,16 @@ LL | use std::range::RangeIter;
    = help: add `#![feature(new_range_api)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error[E0658]: use of unstable library feature `new_range_remainder`
+  --> $DIR/new_range_stability.rs:22:7
+   |
+LL |     i.remainder();
+   |       ^^^^^^^^^
+   |
+   = note: see issue #154458 <https://github.com/rust-lang/rust/issues/154458> for more information
+   = help: add `#![feature(new_range_remainder)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error[E0658]: use of unstable library feature `new_range_api`
   --> $DIR/new_range_stability.rs:43:7
    |
@@ -38,6 +48,6 @@ LL |     i.remainder();
    = help: add `#![feature(new_range_api)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/range/new_range_stability.stderr
+++ b/tests/ui/range/new_range_stability.stderr
@@ -38,14 +38,14 @@ LL |     i.remainder();
    = help: add `#![feature(new_range_remainder)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature `new_range_api`
+error[E0658]: use of unstable library feature `new_range_remainder`
   --> $DIR/new_range_stability.rs:43:7
    |
 LL |     i.remainder();
    |       ^^^^^^^^^
    |
-   = note: see issue #125687 <https://github.com/rust-lang/rust/issues/125687> for more information
-   = help: add `#![feature(new_range_api)]` to the crate attributes to enable
+   = note: see issue #154458 <https://github.com/rust-lang/rust/issues/154458> for more information
+   = help: add `#![feature(new_range_remainder)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 5 previous errors


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#154459 (core: Destabilize beta-stable `RangeInclusiveIter::remainder`)
 - rust-lang/rust#154416 (Add `IoSplit` diagnostic item for `std::io::Split`)
 - rust-lang/rust#154508 (Fix ambiguous parsing in bootstrap.py)
 - rust-lang/rust#154530 (update zulip link in `std` documentation)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=154459,154416,154508,154530)
<!-- homu-ignore:end -->

