### PR TITLE
Add regression test for mono item collection ICE with generic_const_exprs

### DIFF
--- a/tests/ui/const-generics/generic_const_exprs/generic-const-exprs-mono-collect-ice-149035.rs
+++ b/tests/ui/const-generics/generic_const_exprs/generic-const-exprs-mono-collect-ice-149035.rs
@@ -1,0 +1,20 @@
+//! Ensure `-Clink-dead-code=true` with `generic_const_exprs` and
+//! `min_generic_const_args` doesn't ICE in mono item collection.
+//!
+//! Regression test for <https://github.com/rust-lang/rust/issues/149035>.
+
+//@ build-pass
+//@ compile-flags: -Clink-dead-code=true
+
+#![feature(min_generic_const_args, generic_const_exprs)]
+
+type const L: usize = 4;
+trait Print<const N: usize> {
+    fn print() -> usize {
+        N
+    }
+}
+struct Printer;
+impl Print<L> for Printer {}
+
+fn main() {}


### PR DESCRIPTION
Regression test for rust-lang/rust#149035.

The ICE in mono item collection with `-Clink-dead-code=true` was fixed by rust-lang/rust#152129 but didn't get a test. Adapted the reproducer to use `type const` since const handling changed after the issue was filed.

Closes rust-lang/rust#149035