### PR TITLE
Add regression test for TransmuteFrom ICE with min_generic_const_args

### DIFF
--- a/tests/ui/transmutability/transmute-from-const-args-ice-150457.rs
+++ b/tests/ui/transmutability/transmute-from-const-args-ice-150457.rs
@@ -1,0 +1,31 @@
+//! Ensure `TransmuteFrom` with `min_generic_const_args` doesn't ICE
+//! during well-formedness checking.
+//!
+//! Regression test for <https://github.com/rust-lang/rust/issues/150457>.
+
+//@ check-pass
+
+#![feature(transmutability)]
+#![feature(min_generic_const_args)]
+
+use std::mem::{Assume, TransmuteFrom};
+
+struct W<'a>(&'a ());
+
+fn test<'a>()
+where
+    W<'a>: TransmuteFrom<
+        (),
+        {
+            Assume {
+                alignment: const { true },
+                lifetimes: const { true },
+                safety: const { true },
+                validity: true,
+            }
+        },
+    >,
+{
+}
+
+fn main() {}


### PR DESCRIPTION
Regression test for rust-lang/rust#150457.

The wfcheck ICE with TransmuteFrom + min_generic_const_args was fixed by rust-lang/rust#150707 but didn't get a test.

Closes rust-lang/rust#150457