### PR TITLE
Add regression test for recursive lazy type alias normalization ICE

### DIFF
--- a/tests/ui/type-alias/recursive-lazy-type-alias-ice-152633.rs
+++ b/tests/ui/type-alias/recursive-lazy-type-alias-ice-152633.rs
@@ -1,0 +1,14 @@
+//! Ensure a self-referencing lazy type alias with `min_generic_const_args`
+//! doesn't ICE during normalization.
+//!
+//! Regression test for <https://github.com/rust-lang/rust/issues/152633>.
+
+#![feature(lazy_type_alias)]
+#![feature(min_generic_const_args)]
+
+trait Trait {
+    type const ASSOC: ();
+}
+type Arr2 = [usize; <Arr2 as Trait>::ASSOC]; //~ ERROR E0275
+
+fn main() {}

--- a/tests/ui/type-alias/recursive-lazy-type-alias-ice-152633.stderr
+++ b/tests/ui/type-alias/recursive-lazy-type-alias-ice-152633.stderr
@@ -1,0 +1,11 @@
+error[E0275]: overflow normalizing the type alias `Arr2`
+  --> $DIR/recursive-lazy-type-alias-ice-152633.rs:12:1
+   |
+LL | type Arr2 = [usize; <Arr2 as Trait>::ASSOC];
+   | ^^^^^^^^^
+   |
+   = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0275`.


### PR DESCRIPTION
Regression test for rust-lang/rust#152633.

The normalization ICE with recursive lazy_type_alias + min_generic_const_args was fixed by rust-lang/rust#152040 but didn't get a test. Compiler now reports E0275 instead of crashing.

Closes rust-lang/rust#152633