### PR TITLE
Fix #151880: avoid ICE when CTFE evaluates static with unknown layout

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -6,7 +6,9 @@ use std::assert_matches;
 
 use either::{Either, Left, Right};
 use rustc_abi::{BackendRepr, HasDataLayout, Size};
-use rustc_middle::ty::layout::TyAndLayout;
+use rustc_hir::def::DefKind;
+use rustc_middle::mir::interpret::GlobalAlloc;
+use rustc_middle::ty::layout::{LayoutError, TyAndLayout};
 use rustc_middle::ty::{self, Ty};
 use rustc_middle::{bug, mir, span_bug};
 use tracing::field::Empty;
@@ -15,7 +17,7 @@ use tracing::{instrument, trace};
 use super::{
     AllocInit, AllocRef, AllocRefMut, CheckAlignMsg, CtfeProvenance, ImmTy, Immediate, InterpCx,
     InterpResult, Machine, MemoryKind, Misalignment, OffsetMode, OpTy, Operand, Pointer,
-    Projectable, Provenance, Scalar, alloc_range, interp_ok, mir_assign_valid_types,
+    Projectable, Provenance, Scalar, alloc_range, interp_ok, mir_assign_valid_types, throw_inval,
 };
 use crate::enter_trace_span;
 
@@ -435,6 +437,30 @@ where
         // `ref_to_mplace` is called on raw pointers even if they don't actually get dereferenced;
         // we hence can't call `size_and_align_of` since that asserts more validity than we want.
         let ptr = ptr.to_pointer(self)?;
+
+        // Unsized types normally require metadata (e.g. slice length or trait object vtable).
+        // However, during error recovery we can end up with a thin pointer to an unsized
+        // static whose layout could not be determined. In that case, querying the layout
+        // during CTFE would previously trigger an ICE.
+        if !layout.is_sized() && !meta.has_meta() {
+            if let Ok((alloc_id, _, _)) = self.ptr_try_get_alloc_id(ptr, 0)
+                && let Some(GlobalAlloc::Static(def_id)) = self.tcx.try_get_global_alloc(alloc_id)
+                && matches!(self.tcx.def_kind(def_id), DefKind::Static { nested: false, .. })
+            {
+                let ty = self
+                    .tcx
+                    .type_of(def_id)
+                    .no_bound_vars()
+                    .expect("statics should not have generic parameters");
+                match self.tcx.layout_of(self.typing_env.as_query_input(ty)) {
+                    Ok(static_layout) if !static_layout.is_sized() => {
+                        throw_inval!(Layout(LayoutError::Unknown(static_layout.ty)));
+                    }
+                    Err(err) => throw_inval!(Layout(*err)),
+                    Ok(_) => {}
+                }
+            }
+        }
         interp_ok(self.ptr_with_meta_to_mplace(ptr, meta, layout, /*unaligned*/ false))
     }
 

--- a/tests/ui/layout/projected-unsized-static-after-type-error.rs
+++ b/tests/ui/layout/projected-unsized-static-after-type-error.rs
@@ -1,0 +1,16 @@
+//@ edition: 2021
+
+// Regression test for error recovery creating a static with an unsized recovered type.
+// This used to ICE when CTFE tried to dereference `&X` while validating `Y`.
+
+struct Thing(<&[fn()] as ::core::ops::Deref>::Target);
+//~^ ERROR missing lifetime specifier
+
+static X: Thing = Thing(&X);
+
+const Y: &Thing = &X;
+//~^ ERROR the type `Thing` has an unknown layout
+
+fn main() {
+    let _ = Y;
+}

--- a/tests/ui/layout/projected-unsized-static-after-type-error.stderr
+++ b/tests/ui/layout/projected-unsized-static-after-type-error.stderr
@@ -1,0 +1,21 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/projected-unsized-static-after-type-error.rs:6:15
+   |
+LL | struct Thing(<&[fn()] as ::core::ops::Deref>::Target);
+   |               ^ expected named lifetime parameter
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | struct Thing<'a>(<&'a [fn()] as ::core::ops::Deref>::Target);
+   |             ++++   ++
+
+error[E0080]: the type `Thing` has an unknown layout
+  --> $DIR/projected-unsized-static-after-type-error.rs:11:19
+   |
+LL | const Y: &Thing = &X;
+   |                   ^^ evaluation of `Y` failed here
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0080, E0106.
+For more information about an error, try `rustc --explain E0080`.


### PR DESCRIPTION
This ICE occurred during const-eval when evaluating a static whose type has an unknown layout due to earlier type errors. In this situation the interpreter attempted to access the layout of the referenced static, triggering an assertion that assumed the layout was sized.

Adds a check when evaluating statics to detect unsized or unknown layouts and report a layout error instead of panicking.

closes rust-lang/rust#151880 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
