### PR TITLE
Make E0284 generic argument suggestions more explicit

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
@@ -15,8 +15,9 @@ use rustc_middle::hir::nested_filter;
 use rustc_middle::ty::adjustment::{Adjust, Adjustment, AutoBorrow, DerefAdjustKind};
 use rustc_middle::ty::print::{FmtPrinter, PrettyPrinter, Print, Printer};
 use rustc_middle::ty::{
-    self, GenericArg, GenericArgKind, GenericArgsRef, InferConst, IsSuggestable, Term, TermKind,
-    Ty, TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable, TypeVisitableExt, TypeckResults,
+    self, GenericArg, GenericArgKind, GenericArgsRef, GenericParamDefKind, InferConst,
+    IsSuggestable, Term, TermKind, Ty, TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable,
+    TypeVisitableExt, TypeckResults,
 };
 use rustc_span::{BytePos, DUMMY_SP, Ident, Span, sym};
 use tracing::{debug, instrument, warn};
@@ -592,15 +593,19 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                             (true, parent.prefix.to_string(), parent.name)
                         });
 
+                let param = &generics.own_params[argument_index];
+                let param_name = param.name.to_string();
+
                 infer_subdiags.push(SourceKindSubdiag::GenericLabel {
                     span,
                     is_type,
-                    param_name: generics.own_params[argument_index].name.to_string(),
+                    param_name: param_name.clone(),
                     parent_exists,
                     parent_prefix,
                     parent_name,
                 });
 
+                let mut used_fallback = false;
                 let args = if self.tcx.get_diagnostic_item(sym::iterator_collect_fn)
                     == Some(generics_def_id)
                 {
@@ -634,9 +639,9 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     let mut p = fmt_printer(self, Namespace::TypeNS);
                     p.comma_sep(generic_args.iter().copied().map(|arg| {
                         if arg.is_suggestable(self.tcx, true) {
+                            used_fallback = true;
                             return arg;
                         }
-
                         match arg.kind() {
                             GenericArgKind::Lifetime(_) => bug!("unexpected lifetime"),
                             GenericArgKind::Type(_) => self.next_ty_var(DUMMY_SP).into(),
@@ -648,11 +653,31 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 };
 
                 if !have_turbofish {
-                    infer_subdiags.push(SourceKindSubdiag::GenericSuggestion {
-                        span: insert_span,
-                        arg_count: generic_args.len(),
-                        args,
-                    });
+                    if generic_args.len() == 1 && used_fallback {
+                        match param.kind {
+                            GenericParamDefKind::Type { .. } => {
+                                infer_subdiags.push(SourceKindSubdiag::GenericTypeSuggestion {
+                                    span: insert_span,
+                                    param: param_name,
+                                });
+                            }
+                            GenericParamDefKind::Const { .. } => {
+                                infer_subdiags.push(SourceKindSubdiag::ConstGenericSuggestion {
+                                    span: insert_span,
+                                    param: param_name,
+                                });
+                            }
+                            GenericParamDefKind::Lifetime => {
+                                bug!("unexpected lifetime")
+                            }
+                        }
+                    } else {
+                        infer_subdiags.push(SourceKindSubdiag::GenericSuggestion {
+                            span: insert_span,
+                            arg_count: generic_args.len(),
+                            args,
+                        });
+                    }
                 }
             }
             InferSourceKind::FullyQualifiedMethodCall { receiver, successor, args, def_id } => {

--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -331,6 +331,28 @@ pub(crate) enum SourceKindSubdiag<'a> {
         arg_count: usize,
         args: String,
     },
+    #[suggestion(
+        "consider specifying a concrete type for the type parameter `{$param}`",
+        style = "verbose",
+        code = "::</* Type */>",
+        applicability = "has-placeholders"
+    )]
+    GenericTypeSuggestion {
+        #[primary_span]
+        span: Span,
+        param: String,
+    },
+    #[suggestion(
+        "consider specifying a const for the const parameter `{$param}`",
+        style = "verbose",
+        code = "::</* CONST */>",
+        applicability = "has-placeholders"
+    )]
+    ConstGenericSuggestion {
+        #[primary_span]
+        span: Span,
+        param: String,
+    },
 }
 
 #[derive(Subdiagnostic)]

--- a/tests/ui/associated-type-bounds/duplicate-bound-err.stderr
+++ b/tests/ui/associated-type-bounds/duplicate-bound-err.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |     iter::empty()
    |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     iter::empty::<T>()
-   |                +++++
+LL |     iter::empty::</* Type */>()
+   |                ++++++++++++++
 
 error[E0282]: type annotations needed
   --> $DIR/duplicate-bound-err.rs:18:5
@@ -15,10 +15,10 @@ error[E0282]: type annotations needed
 LL |     iter::empty()
    |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     iter::empty::<T>()
-   |                +++++
+LL |     iter::empty::</* Type */>()
+   |                ++++++++++++++
 
 error[E0282]: type annotations needed
   --> $DIR/duplicate-bound-err.rs:22:5
@@ -26,10 +26,10 @@ error[E0282]: type annotations needed
 LL |     iter::empty()
    |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     iter::empty::<T>()
-   |                +++++
+LL |     iter::empty::</* Type */>()
+   |                ++++++++++++++
 
 error: unconstrained opaque type
   --> $DIR/duplicate-bound-err.rs:26:51

--- a/tests/ui/async-await/unresolved_type_param.stderr
+++ b/tests/ui/async-await/unresolved_type_param.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |     bar().await;
    |     ^^^ cannot infer type of the type parameter `T` declared on the function `bar`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     bar::<T>().await;
-   |        +++++
+LL |     bar::</* Type */>().await;
+   |        ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/defaults/rp_impl_trait_fail.stderr
+++ b/tests/ui/const-generics/defaults/rp_impl_trait_fail.stderr
@@ -61,10 +61,10 @@ note: required by a const generic parameter in `uwu`
    |
 LL | fn uwu<const N: u8>() -> impl Traitor<N> {
    |        ^^^^^^^^^^^ required by this const generic parameter in `uwu`
-help: consider specifying the generic argument
+help: consider specifying a const for the const parameter `N`
    |
-LL |     uwu::<N>();
-   |        +++++
+LL |     uwu::</* CONST */>();
+   |        +++++++++++++++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/const-generics/fn-const-param-infer.adt_const_params.stderr
+++ b/tests/ui/const-generics/fn-const-param-infer.adt_const_params.stderr
@@ -19,10 +19,10 @@ error[E0282]: type annotations needed
 LL |     let _ = Checked::<generic>;
    |                       ^^^^^^^ cannot infer type of the type parameter `T` declared on the function `generic`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     let _ = Checked::<generic::<T>>;
-   |                              +++++
+LL |     let _ = Checked::<generic::</* Type */>>;
+   |                              ++++++++++++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/const-generics/fn-const-param-infer.full.stderr
+++ b/tests/ui/const-generics/fn-const-param-infer.full.stderr
@@ -19,10 +19,10 @@ error[E0282]: type annotations needed
 LL |     let _ = Checked::<generic>;
    |                       ^^^^^^^ cannot infer type of the type parameter `T` declared on the function `generic`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     let _ = Checked::<generic::<T>>;
-   |                              +++++
+LL |     let _ = Checked::<generic::</* Type */>>;
+   |                              ++++++++++++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/const-generics/fn-const-param-infer.min.stderr
+++ b/tests/ui/const-generics/fn-const-param-infer.min.stderr
@@ -21,10 +21,10 @@ error[E0282]: type annotations needed
 LL |     let _ = Checked::<generic>;
    |                       ^^^^^^^ cannot infer type of the type parameter `T` declared on the function `generic`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     let _ = Checked::<generic::<T>>;
-   |                              +++++
+LL |     let _ = Checked::<generic::</* Type */>>;
+   |                              ++++++++++++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/const-generics/generic_const_exprs/dyn-compatibility-ok-infer-err.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/dyn-compatibility-ok-infer-err.stderr
@@ -9,10 +9,10 @@ note: required by a const generic parameter in `use_dyn`
    |
 LL | fn use_dyn<const N: usize>(v: &dyn Foo<N>) where [u8; N + 1]: Sized {
    |            ^^^^^^^^^^^^^^ required by this const generic parameter in `use_dyn`
-help: consider specifying the generic argument
+help: consider specifying a const for the const parameter `N`
    |
-LL |     use_dyn::<N>(&());
-   |            +++++
+LL |     use_dyn::</* CONST */>(&());
+   |            +++++++++++++++
 
 error[E0284]: type annotations needed
   --> $DIR/dyn-compatibility-ok-infer-err.rs:19:5
@@ -30,10 +30,10 @@ LL | impl<const N: usize> Foo<N> for () {
    |      |
    |      unsatisfied trait bound introduced here
    = note: required for the cast from `&()` to `&dyn Foo<_>`
-help: consider specifying the generic argument
+help: consider specifying a const for the const parameter `N`
    |
-LL |     use_dyn::<N>(&());
-   |            +++++
+LL |     use_dyn::</* CONST */>(&());
+   |            +++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/infer/cannot-infer-const-args.stderr
+++ b/tests/ui/const-generics/infer/cannot-infer-const-args.stderr
@@ -9,10 +9,10 @@ note: required by a const generic parameter in `foo`
    |
 LL | fn foo<const X: usize>() -> usize {
    |        ^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
-help: consider specifying the generic argument
+help: consider specifying a const for the const parameter `X`
    |
-LL |     foo::<X>();
-   |        +++++
+LL |     foo::</* CONST */>();
+   |        +++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/infer/method-chain.stderr
+++ b/tests/ui/const-generics/infer/method-chain.stderr
@@ -9,10 +9,10 @@ note: required by a const generic parameter in `Foo::baz`
    |
 LL |     fn baz<const N: usize>(self) -> Foo {
    |            ^^^^^^^^^^^^^^ required by this const generic parameter in `Foo::baz`
-help: consider specifying the generic argument
+help: consider specifying a const for the const parameter `N`
    |
-LL |     Foo.bar().bar().bar().bar().baz::<N>();
-   |                                    +++++
+LL |     Foo.bar().bar().bar().bar().baz::</* CONST */>();
+   |                                    +++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/unify_with_nested_expr.stderr
+++ b/tests/ui/const-generics/unify_with_nested_expr.stderr
@@ -9,10 +9,10 @@ note: required by a const generic parameter in `bar`
    |
 LL | fn bar<const N: usize>()
    |        ^^^^^^^^^^^^^^ required by this const generic parameter in `bar`
-help: consider specifying the generic argument
+help: consider specifying a const for the const parameter `N`
    |
-LL |     bar::<N>();
-   |        +++++
+LL |     bar::</* CONST */>();
+   |        +++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/issue-64662.stderr
+++ b/tests/ui/consts/issue-64662.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |     A = foo(),
    |         ^^^ cannot infer type of the type parameter `T` declared on the function `foo`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     A = foo::<T>(),
-   |            +++++
+LL |     A = foo::</* Type */>(),
+   |            ++++++++++++++
 
 error[E0282]: type annotations needed
   --> $DIR/issue-64662.rs:3:9
@@ -15,10 +15,10 @@ error[E0282]: type annotations needed
 LL |     B = foo(),
    |         ^^^ cannot infer type of the type parameter `T` declared on the function `foo`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     B = foo::<T>(),
-   |            +++++
+LL |     B = foo::</* Type */>(),
+   |            ++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/for-loop-while/for-loop-unconstrained-element-type.stderr
+++ b/tests/ui/for-loop-while/for-loop-unconstrained-element-type.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |     for i in Vec::new() {}
    |              ^^^^^^^^ cannot infer type of the type parameter `T` declared on the struct `Vec`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     for i in Vec::<T>::new() {}
-   |                 +++++
+LL |     for i in Vec::</* Type */>::new() {}
+   |                 ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generic-associated-types/bugs/issue-88382.stderr
+++ b/tests/ui/generic-associated-types/bugs/issue-88382.stderr
@@ -15,10 +15,10 @@ note: required by a bound in `test`
    |
 LL | fn test<'a, I: Iterable>(_: &mut I::Iterator<'a>) {}
    |                ^^^^^^^^ required by this bound in `test`
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `I`
    |
-LL |     do_something(SomeImplementation(), test::<I>);
-   |                                            +++++
+LL |     do_something(SomeImplementation(), test::</* Type */>);
+   |                                            ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/fallback_inference.stderr
+++ b/tests/ui/impl-trait/fallback_inference.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |     PhantomData
    |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the struct `PhantomData`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     PhantomData::<T>
-   |                +++++
+LL |     PhantomData::</* Type */>
+   |                ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/in-trait/not-inferred-generic.stderr
+++ b/tests/ui/impl-trait/in-trait/not-inferred-generic.stderr
@@ -11,10 +11,10 @@ note: required by a bound in `TypedClient::publish_typed::{anon_assoc#0}`
    |
 LL |         F: Clone;
    |            ^^^^^ required by this bound in `TypedClient::publish_typed::{anon_assoc#0}`
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `F`
    |
-LL |     ().publish_typed::<F>();
-   |                     +++++
+LL |     ().publish_typed::</* Type */>();
+   |                     ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inference/dont-collect-stmts-from-parent-body.stderr
+++ b/tests/ui/inference/dont-collect-stmts-from-parent-body.stderr
@@ -13,10 +13,10 @@ error[E0282]: type annotations needed
 LL |                 Type
    |                 ^^^^ cannot infer type of the type parameter `T` declared on the struct `Type`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |                 Type::<T>
-   |                     +++++
+LL |                 Type::</* Type */>
+   |                     ++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/inference/issue-71732.stderr
+++ b/tests/ui/inference/issue-71732.stderr
@@ -12,10 +12,10 @@ LL |         .get(&"key".into())
              where T: ?Sized;
 note: required by a bound in `HashMap::<K, V, S, A>::get`
   --> $SRC_DIR/std/src/collections/hash/map.rs:LL:COL
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `Q`
    |
-LL |         .get::<Q>(&"key".into())
-   |             +++++
+LL |         .get::</* Type */>(&"key".into())
+   |             ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inference/issue-86162-1.stderr
+++ b/tests/ui/inference/issue-86162-1.stderr
@@ -12,10 +12,10 @@ note: required by a bound in `foo`
    |
 LL | fn foo(x: impl Clone) {}
    |                ^^^^^ required by this bound in `foo`
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     foo(gen::<T>()); //<- Do not suggest `foo::<impl Clone>()`!
-   |            +++++
+LL |     foo(gen::</* Type */>()); //<- Do not suggest `foo::<impl Clone>()`!
+   |            ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inference/issue-86162-2.stderr
+++ b/tests/ui/inference/issue-86162-2.stderr
@@ -12,10 +12,10 @@ note: required by a bound in `Foo::bar`
    |
 LL |     fn bar(x: impl Clone) {}
    |                    ^^^^^ required by this bound in `Foo::bar`
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     Foo::bar(gen::<T>()); //<- Do not suggest `Foo::bar::<impl Clone>()`!
-   |                 +++++
+LL |     Foo::bar(gen::</* Type */>()); //<- Do not suggest `Foo::bar::<impl Clone>()`!
+   |                 ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inference/need_type_info/channel.stderr
+++ b/tests/ui/inference/need_type_info/channel.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |         channel();
    |         ^^^^^^^ cannot infer type of the type parameter `T` declared on the function `channel`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |         channel::<T>();
-   |                +++++
+LL |         channel::</* Type */>();
+   |                ++++++++++++++
 
 error[E0282]: type annotations needed
   --> $DIR/channel.rs:13:9
@@ -15,10 +15,10 @@ error[E0282]: type annotations needed
 LL |         channel();
    |         ^^^^^^^ cannot infer type of the type parameter `T` declared on the function `channel`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |         channel::<T>();
-   |                +++++
+LL |         channel::</* Type */>();
+   |                ++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/inference/need_type_info/expr-struct-type-relative-enum.stderr
+++ b/tests/ui/inference/need_type_info/expr-struct-type-relative-enum.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |         needs_infer();
    |         ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `needs_infer`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |         needs_infer::<T>();
-   |                    +++++
+LL |         needs_infer::</* Type */>();
+   |                    ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inference/need_type_info/expr-struct-type-relative.stderr
+++ b/tests/ui/inference/need_type_info/expr-struct-type-relative.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |         needs_infer();
    |         ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `needs_infer`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |         needs_infer::<T>();
-   |                    +++++
+LL |         needs_infer::</* Type */>();
+   |                    ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inference/need_type_info/issue-103053.stderr
+++ b/tests/ui/inference/need_type_info/issue-103053.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |     None;
    |     ^^^^ cannot infer type of the type parameter `T` declared on the enum `Option`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     None::<T>;
-   |         +++++
+LL |     None::</* Type */>;
+   |         ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inference/need_type_info/issue-113264-incorrect-impl-trait-in-path-suggestion.stderr
+++ b/tests/ui/inference/need_type_info/issue-113264-incorrect-impl-trait-in-path-suggestion.stderr
@@ -12,10 +12,10 @@ note: required by a bound in `S::owo`
    |
 LL |     fn owo(&self, _: Option<&impl T>) {}
    |                                   ^ required by this bound in `S::owo`
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     (S {}).owo(None::<&_>)
-   |                    ++++++
+LL |     (S {}).owo(None::</* Type */>)
+   |                    ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inference/need_type_info/self-ty-in-path.stderr
+++ b/tests/ui/inference/need_type_info/self-ty-in-path.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |         Self::func_a();
    |         ^^^^^^^^^^^^ cannot infer type of the type parameter `U` declared on the associated function `func_a`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `U`
    |
-LL |         Self::func_a::<U>();
-   |                     +++++
+LL |         Self::func_a::</* Type */>();
+   |                     ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inference/need_type_info/single-const-generic-suggestion.rs
+++ b/tests/ui/inference/need_type_info/single-const-generic-suggestion.rs
@@ -1,0 +1,9 @@
+// compile-fail
+
+fn func<const CONST: usize>() {}
+
+fn main() {
+    func();
+    //~^ ERROR type annotations needed
+    //~| HELP consider specifying a const for the const parameter `CONST`
+}

--- a/tests/ui/inference/need_type_info/single-const-generic-suggestion.stderr
+++ b/tests/ui/inference/need_type_info/single-const-generic-suggestion.stderr
@@ -1,0 +1,19 @@
+error[E0284]: type annotations needed
+  --> $DIR/single-const-generic-suggestion.rs:6:5
+   |
+LL |     func();
+   |     ^^^^ cannot infer the value of the const parameter `CONST` declared on the function `func`
+   |
+note: required by a const generic parameter in `func`
+  --> $DIR/single-const-generic-suggestion.rs:3:9
+   |
+LL | fn func<const CONST: usize>() {}
+   |         ^^^^^^^^^^^^^^^^^^ required by this const generic parameter in `func`
+help: consider specifying a const for the const parameter `CONST`
+   |
+LL |     func::</* CONST */>();
+   |         +++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0284`.

--- a/tests/ui/inference/need_type_info/single-type-generic-suggestion.rs
+++ b/tests/ui/inference/need_type_info/single-type-generic-suggestion.rs
@@ -1,0 +1,7 @@
+// compile-fail
+
+fn main() {
+    "".parse();
+    //~^ ERROR type annotations needed
+    //~| HELP consider specifying a concrete type for the type parameter `F`
+}

--- a/tests/ui/inference/need_type_info/single-type-generic-suggestion.stderr
+++ b/tests/ui/inference/need_type_info/single-type-generic-suggestion.stderr
@@ -1,0 +1,15 @@
+error[E0284]: type annotations needed
+  --> $DIR/single-type-generic-suggestion.rs:4:8
+   |
+LL |     "".parse();
+   |        ^^^^^ cannot infer type of the type parameter `F` declared on the method `parse`
+   |
+   = note: cannot satisfy `<_ as FromStr>::Err == _`
+help: consider specifying a concrete type for the type parameter `F`
+   |
+LL |     "".parse::</* Type */>();
+   |             ++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0284`.

--- a/tests/ui/inference/question-mark-type-inference-in-chain.rs
+++ b/tests/ui/inference/question-mark-type-inference-in-chain.rs
@@ -9,7 +9,9 @@ type Result<T, E = AnotherError> = core::result::Result<T, E>;
 pub struct Error;
 
 impl From<AnotherError> for Error {
-    fn from(_: AnotherError) -> Self { Error }
+    fn from(_: AnotherError) -> Self {
+        Error
+    }
 }
 
 impl std::error::Error for Error {}
@@ -70,12 +72,12 @@ pub fn error4(lines: &[&str]) -> Result<Vec<Version>> {
         //~^ NOTE: the method call chain might not have had the expected associated types
         //~| NOTE: `Iterator::Item` changed to `Result<Version, Error>` here
         .collect::<Result<Vec<Version>>>()?;
-        //~^ ERROR: a value of type `std::result::Result<Vec<Version>, AnotherError>` cannot be built from an iterator over elements of type `std::result::Result<Version, Error>`
-        //~| NOTE: value of type `std::result::Result<Vec<Version>, AnotherError>` cannot be built from `std::iter::Iterator<Item=std::result::Result<Version, Error>>`
-        //~| NOTE: required by a bound introduced by this call
-        //~| HELP: the trait
-        //~| HELP: for that trait implementation, expected `AnotherError`, found `Error`
-        //~| NOTE: required by a bound in `collect`
+    //~^ ERROR: a value of type `std::result::Result<Vec<Version>, AnotherError>` cannot be built from an iterator over elements of type `std::result::Result<Version, Error>`
+    //~| NOTE: value of type `std::result::Result<Vec<Version>, AnotherError>` cannot be built from `std::iter::Iterator<Item=std::result::Result<Version, Error>>`
+    //~| NOTE: required by a bound introduced by this call
+    //~| HELP: the trait
+    //~| HELP: for that trait implementation, expected `AnotherError`, found `Error`
+    //~| NOTE: required by a bound in `collect`
     tags.sort();
 
     Ok(tags)

--- a/tests/ui/inference/question-mark-type-inference-in-chain.stderr
+++ b/tests/ui/inference/question-mark-type-inference-in-chain.stderr
@@ -1,5 +1,5 @@
 error[E0282]: type annotations needed
-  --> $DIR/question-mark-type-inference-in-chain.rs:31:9
+  --> $DIR/question-mark-type-inference-in-chain.rs:33:9
    |
 LL |     let mut tags = lines.iter().map(|e| parse(e)).collect()?;
    |         ^^^^^^^^
@@ -13,7 +13,7 @@ LL |     let mut tags: Vec<_> = lines.iter().map(|e| parse(e)).collect()?;
    |                 ++++++++
 
 error[E0283]: type annotations needed
-  --> $DIR/question-mark-type-inference-in-chain.rs:41:65
+  --> $DIR/question-mark-type-inference-in-chain.rs:43:65
    |
 LL |     let mut tags: Vec<Version> = lines.iter().map(|e| parse(e)).collect()?;
    |                                                                 ^^^^^^^ cannot infer type of the type parameter `B` declared on the method `collect`
@@ -27,7 +27,7 @@ LL |     let mut tags: Vec<Version> = lines.iter().map(|e| parse(e)).collect::<R
    |                                                                        ++++++++++++++++
 
 error[E0277]: the `?` operator can only be applied to values that implement `Try`
-  --> $DIR/question-mark-type-inference-in-chain.rs:53:20
+  --> $DIR/question-mark-type-inference-in-chain.rs:55:20
    |
 LL |     let mut tags = lines.iter().map(|e| parse(e)).collect::<Vec<_>>()?;
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `Vec<std::result::Result<Version, Error>>`
@@ -35,7 +35,7 @@ LL |     let mut tags = lines.iter().map(|e| parse(e)).collect::<Vec<_>>()?;
    = help: the nightly-only, unstable trait `Try` is not implemented for `Vec<std::result::Result<Version, Error>>`
 
 error[E0277]: a value of type `std::result::Result<Vec<Version>, AnotherError>` cannot be built from an iterator over elements of type `std::result::Result<Version, Error>`
-  --> $DIR/question-mark-type-inference-in-chain.rs:72:20
+  --> $DIR/question-mark-type-inference-in-chain.rs:74:20
    |
 LL |         .collect::<Result<Vec<Version>>>()?;
    |          -------   ^^^^^^^^^^^^^^^^^^^^ value of type `std::result::Result<Vec<Version>, AnotherError>` cannot be built from `std::iter::Iterator<Item=std::result::Result<Version, Error>>`
@@ -47,7 +47,7 @@ help: the trait `FromIterator<std::result::Result<_, Error>>` is not implemented
   --> $SRC_DIR/core/src/result.rs:LL:COL
    = help: for that trait implementation, expected `AnotherError`, found `Error`
 note: the method call chain might not have had the expected associated types
-  --> $DIR/question-mark-type-inference-in-chain.rs:69:10
+  --> $DIR/question-mark-type-inference-in-chain.rs:71:10
    |
 LL |     let mut tags = lines
    |                    ----- this expression has type `&[&str]`

--- a/tests/ui/missing/missing-items/missing-type-parameter.stderr
+++ b/tests/ui/missing/missing-items/missing-type-parameter.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |     foo();
    |     ^^^ cannot infer type of the type parameter `X` declared on the function `foo`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `X`
    |
-LL |     foo::<X>();
-   |        +++++
+LL |     foo::</* Type */>();
+   |        ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/return/tail-expr-as-potential-return.rs
+++ b/tests/ui/return/tail-expr-as-potential-return.rs
@@ -59,7 +59,7 @@ fn method() -> Option<i32> {
     if true {
         Receiver.generic();
         //~^ ERROR type annotations needed
-        //~| HELP consider specifying the generic argument
+        //~| HELP consider specifying a concrete type for the type parameter `T`
     }
 
     None

--- a/tests/ui/return/tail-expr-as-potential-return.stderr
+++ b/tests/ui/return/tail-expr-as-potential-return.stderr
@@ -53,10 +53,10 @@ error[E0282]: type annotations needed
 LL |         Receiver.generic();
    |                  ^^^^^^^ cannot infer type of the type parameter `T` declared on the method `generic`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |         Receiver.generic::<T>();
-   |                         +++++
+LL |         Receiver.generic::</* Type */>();
+   |                         ++++++++++++++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/span/issue-42234-unknown-receiver-type.stderr
+++ b/tests/ui/span/issue-42234-unknown-receiver-type.stderr
@@ -6,10 +6,10 @@ LL |     let x: Option<_> = None;
 LL |     x.unwrap().method_that_could_exist_on_some_type();
    |     ---------- type must be known at this point
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     let x: Option<_> = None::<T>;
-   |                            +++++
+LL |     let x: Option<_> = None::</* Type */>;
+   |                            ++++++++++++++
 
 error[E0282]: type annotations needed
   --> $DIR/issue-42234-unknown-receiver-type.rs:12:16

--- a/tests/ui/span/type-annotations-needed-expr.stderr
+++ b/tests/ui/span/type-annotations-needed-expr.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |     let _ = (vec![1,2,3]).into_iter().sum() as f64;
    |                                       ^^^ cannot infer type of the type parameter `S` declared on the method `sum`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `S`
    |
-LL |     let _ = (vec![1,2,3]).into_iter().sum::<S>() as f64;
-   |                                          +++++
+LL |     let _ = (vec![1,2,3]).into_iter().sum::</* Type */>() as f64;
+   |                                          ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/fn-needing-specified-return-type-param.rs
+++ b/tests/ui/suggestions/fn-needing-specified-return-type-param.rs
@@ -1,7 +1,9 @@
-fn f<A>() -> A { unimplemented!() }
+fn f<A>() -> A {
+    unimplemented!()
+}
 fn foo() {
     let _ = f;
     //~^ ERROR type annotations needed
-    //~| HELP consider specifying the generic argument
+    //~| HELP consider specifying a concrete type for the type parameter `A`
 }
 fn main() {}

--- a/tests/ui/suggestions/fn-needing-specified-return-type-param.stderr
+++ b/tests/ui/suggestions/fn-needing-specified-return-type-param.stderr
@@ -1,13 +1,13 @@
 error[E0282]: type annotations needed
-  --> $DIR/fn-needing-specified-return-type-param.rs:3:13
+  --> $DIR/fn-needing-specified-return-type-param.rs:5:13
    |
 LL |     let _ = f;
    |             ^ cannot infer type of the type parameter `A` declared on the function `f`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `A`
    |
-LL |     let _ = f::<A>;
-   |              +++++
+LL |     let _ = f::</* Type */>;
+   |              ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/trait-bounds/projection-predicate-not-satisfied-69455.stderr
+++ b/tests/ui/trait-bounds/projection-predicate-not-satisfied-69455.stderr
@@ -7,10 +7,10 @@ LL |     println!("{}", 23u64.test(xs.iter().sum()));
    |                          type must be known at this point
    |
    = note: cannot satisfy `<u64 as Test<_>>::Output == _`
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `S`
    |
-LL |     println!("{}", 23u64.test(xs.iter().sum::<S>()));
-   |                                            +++++
+LL |     println!("{}", 23u64.test(xs.iter().sum::</* Type */>()));
+   |                                            ++++++++++++++
 
 error[E0283]: type annotations needed
   --> $DIR/projection-predicate-not-satisfied-69455.rs:29:41
@@ -28,10 +28,10 @@ LL | impl Test<u32> for u64 {
 ...
 LL | impl Test<u64> for u64 {
    | ^^^^^^^^^^^^^^^^^^^^^^
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `S`
    |
-LL |     println!("{}", 23u64.test(xs.iter().sum::<S>()));
-   |                                            +++++
+LL |     println!("{}", 23u64.test(xs.iter().sum::</* Type */>()));
+   |                                            ++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/issue-77982.stderr
+++ b/tests/ui/traits/issue-77982.stderr
@@ -12,10 +12,10 @@ LL |     opts.get(opt.as_ref());
              where T: ?Sized;
 note: required by a bound in `HashMap::<K, V, S, A>::get`
   --> $SRC_DIR/std/src/collections/hash/map.rs:LL:COL
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `Q`
    |
-LL |     opts.get::<Q>(opt.as_ref());
-   |             +++++
+LL |     opts.get::</* Type */>(opt.as_ref());
+   |             ++++++++++++++
 
 error[E0283]: type annotations needed
   --> $DIR/issue-77982.rs:11:10
@@ -30,10 +30,10 @@ LL |     opts.get(opt.as_ref());
            - impl AsRef<Path> for String;
            - impl AsRef<[u8]> for String;
            - impl AsRef<str> for String;
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `Q`
    |
-LL |     opts.get::<Q>(opt.as_ref());
-   |             +++++
+LL |     opts.get::</* Type */>(opt.as_ref());
+   |             ++++++++++++++
 
 error[E0283]: type annotations needed
   --> $DIR/issue-77982.rs:16:59

--- a/tests/ui/traits/next-solver/normalization-shadowing/normalizes_to_ignores_unnormalizable_candidate.stderr
+++ b/tests/ui/traits/next-solver/normalization-shadowing/normalizes_to_ignores_unnormalizable_candidate.stderr
@@ -12,10 +12,10 @@ note: required by a bound in `foo`
    |
 LL | fn foo<T: Trait<Assoc = u8>>(x: T) {}
    |           ^^^^^^^^^^^^^^^^^ required by this bound in `foo`
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     foo::<Vec<T>>(unconstrained())
-   |        ++++++++++
+LL |     foo::</* Type */>(unconstrained())
+   |        ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/overflow-computing-ambiguity.stderr
+++ b/tests/ui/traits/overflow-computing-ambiguity.stderr
@@ -18,10 +18,10 @@ note: required by a bound in `hello`
    |
 LL | fn hello<T: Hello>() {}
    |             ^^^^^ required by this bound in `hello`
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     hello::<T>();
-   |          +++++
+LL |     hello::</* Type */>();
+   |          ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-alias-impl-trait/incomplete-inference.stderr
+++ b/tests/ui/type-alias-impl-trait/incomplete-inference.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |     None
    |     ^^^^ cannot infer type of the type parameter `T` declared on the enum `Option`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     None::<T>
-   |         +++++
+LL |     None::</* Type */>
+   |         ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-inference/send-with-unspecified-type.stderr
+++ b/tests/ui/type-inference/send-with-unspecified-type.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |         tx.send(Foo{ foo: PhantomData });
    |                           ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the struct `PhantomData`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |         tx.send(Foo{ foo: PhantomData::<T> });
-   |                                      +++++
+LL |         tx.send(Foo{ foo: PhantomData::</* Type */> });
+   |                                      ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-inference/sort_by_key.stderr
+++ b/tests/ui/type-inference/sort_by_key.stderr
@@ -9,10 +9,10 @@ LL |     lst.sort_by_key(|&(v, _)| v.iter().sum());
    = note: the type must implement `Ord`
 note: required by a bound in `slice::<impl [T]>::sort_by_key`
   --> $SRC_DIR/alloc/src/slice.rs:LL:COL
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `S`
    |
-LL |     lst.sort_by_key(|&(v, _)| v.iter().sum::<S>());
-   |                                           +++++
+LL |     lst.sort_by_key(|&(v, _)| v.iter().sum::</* Type */>());
+   |                                           ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-inference/type-inference-none-in-generic-ref.stderr
+++ b/tests/ui/type-inference/type-inference-none-in-generic-ref.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |     S { o: &None };
    |     ^^^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the struct `S`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     S::<T> { o: &None };
-   |      +++++
+LL |     S::</* Type */> { o: &None };
+   |      ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-inference/type-inference-unconstrained-none.stderr
+++ b/tests/ui/type-inference/type-inference-unconstrained-none.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |     format!("{:?}", None);
    |                     ^^^^ cannot infer type of the type parameter `T` declared on the enum `Option`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     format!("{:?}", None::<T>);
-   |                         +++++
+LL |     format!("{:?}", None::</* Type */>);
+   |                         ++++++++++++++
 
 error[E0282]: type annotations needed
   --> $DIR/type-inference-unconstrained-none.rs:8:5
@@ -15,10 +15,10 @@ error[E0282]: type annotations needed
 LL |     None;
    |     ^^^^ cannot infer type of the type parameter `T` declared on the enum `Option`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     None::<T>;
-   |         +++++
+LL |     None::</* Type */>;
+   |         ++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/type-inference/unbounded-associated-type.stderr
+++ b/tests/ui/type-inference/unbounded-associated-type.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |     S(std::marker::PhantomData).foo();
    |       ^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the struct `PhantomData`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     S(std::marker::PhantomData::<T>).foo();
-   |                               +++++
+LL |     S(std::marker::PhantomData::</* Type */>).foo();
+   |                               ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-inference/unbounded-type-param-in-fn.stderr
+++ b/tests/ui/type-inference/unbounded-type-param-in-fn.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |     foo();
    |     ^^^ cannot infer type of the type parameter `T` declared on the function `foo`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     foo::<T>();
-   |        +++++
+LL |     foo::</* Type */>();
+   |        ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type/type-annotation-needed.stderr
+++ b/tests/ui/type/type-annotation-needed.stderr
@@ -10,10 +10,10 @@ note: required by a bound in `foo`
    |
 LL | fn foo<T: Into<String>>(x: i32) {}
    |           ^^^^^^^^^^^^ required by this bound in `foo`
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     foo::<T>(42);
-   |        +++++
+LL |     foo::</* Type */>(42);
+   |        ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type/type-check/unknown_type_for_closure.stderr
+++ b/tests/ui/type/type-check/unknown_type_for_closure.stderr
@@ -27,10 +27,10 @@ error[E0282]: type annotations needed
 LL |     let x = || -> Vec<_> { Vec::new() };
    |                            ^^^^^^^^ cannot infer type of the type parameter `T` declared on the struct `Vec`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     let x = || -> Vec<_> { Vec::<T>::new() };
-   |                               +++++
+LL |     let x = || -> Vec<_> { Vec::</* Type */>::new() };
+   |                               ++++++++++++++
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Closes rust-lang/rust#147313 

Previously, when type annotations were missing for a function call, rust suggested: "consider specifying the generic argument". This PR improves the diagnostics:

- If only one generic type is missing: 
  "consider specifying a concrete type for the generic type `<T>`" with the turbofish being "::\<SomeConcreteType>"
- If only one const generic is missing:
  "consider specifying a const for the const generic `<CONST>`" with the turbofish being "::<SOME_CONST>"

Multiple missing generics still produce the original more general suggestion