### PR TITLE
Suggest similar keyword when visibility is not followed by an item

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -192,7 +192,22 @@ impl<'a> Parser<'a> {
 
             // At this point, we have failed to parse an item.
             if !matches!(vis.kind, VisibilityKind::Inherited) {
-                this.dcx().emit_err(errors::VisibilityNotFollowedByItem { span: vis.span, vis });
+                let mut err = this
+                    .dcx()
+                    .create_err(errors::VisibilityNotFollowedByItem { span: vis.span, vis });
+                if let Some((ident, _)) = this.token.ident()
+                    && !ident.is_used_keyword()
+                    && let Some((similar_kw, is_incorrect_case)) = ident
+                        .name
+                        .find_similar(&rustc_span::symbol::used_keywords(|| ident.span.edition()))
+                {
+                    err.subdiagnostic(errors::MisspelledKw {
+                        similar_kw: similar_kw.to_string(),
+                        span: ident.span,
+                        is_incorrect_case,
+                    });
+                }
+                err.emit();
             }
 
             if let Defaultness::Default(span) = def {

--- a/tests/ui/parser/misspelled-keywords/pub-const-fn.rs
+++ b/tests/ui/parser/misspelled-keywords/pub-const-fn.rs
@@ -1,0 +1,5 @@
+pub cnst fn code() {}
+//~^ ERROR visibility `pub` is not followed by an item
+//~| ERROR expected item, found `cnst`
+
+fn main() {}

--- a/tests/ui/parser/misspelled-keywords/pub-const-fn.stderr
+++ b/tests/ui/parser/misspelled-keywords/pub-const-fn.stderr
@@ -1,0 +1,22 @@
+error: visibility `pub` is not followed by an item
+  --> $DIR/pub-const-fn.rs:1:1
+   |
+LL | pub cnst fn code() {}
+   | ^^^ the visibility
+   |
+   = help: you likely meant to define an item, e.g., `pub fn foo() {}`
+help: there is a keyword `const` with a similar name
+   |
+LL | pub const fn code() {}
+   |      +
+
+error: expected item, found `cnst`
+  --> $DIR/pub-const-fn.rs:1:5
+   |
+LL | pub cnst fn code() {}
+   |     ^^^^ expected item
+   |
+   = note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes rust-lang/rust#153353.

I would appreciate feedback on the following:
- I inlined [`find_similar_kw`](https://github.com/rust-lang/rust/blob/cd14b73b4a41542d921f59e362a5b5005fa4f2ef/compiler/rustc_parse/src/parser/diagnostics.rs#L218-L224) instead of changing its visibility to `pub(super)`. I am happy to switch if it is preferred;
- I didn't add a comment to the new test. Although the rustc-dev-guide specifies that a [comment should be added](https://rustc-dev-guide.rust-lang.org/tests/adding.html#comment-explaining-what-the-test-is-about) to every new test, this is not common in `tests/ui/parser/misspelled_keywords/` and the test seems self-explanatory. Let me know if you would like me to add a comment;

Thank you in advance for your time and input!