### PR TITLE
Point at binop lhs and rhs when expression is multiline

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -2916,12 +2916,21 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             | ObligationCauseCode::CheckAssociatedTypeBounds { .. }
             | ObligationCauseCode::LetElse
             | ObligationCauseCode::UnOp { .. }
-            | ObligationCauseCode::BinOp { .. }
             | ObligationCauseCode::AscribeUserTypeProvePredicate(..)
             | ObligationCauseCode::AlwaysApplicableImpl
             | ObligationCauseCode::ConstParam(_)
             | ObligationCauseCode::ReferenceOutlivesReferent(..)
             | ObligationCauseCode::ObjectTypeBound(..) => {}
+            ObligationCauseCode::BinOp { lhs_hir_id, rhs_hir_id, .. } => {
+                if let hir::Node::Expr(lhs) = tcx.hir_node(lhs_hir_id)
+                    && let hir::Node::Expr(rhs) = tcx.hir_node(rhs_hir_id)
+                    && tcx.sess.source_map().lookup_char_pos(lhs.span.lo()).line
+                        != tcx.sess.source_map().lookup_char_pos(rhs.span.hi()).line
+                {
+                    err.span_label(lhs.span, "");
+                    err.span_label(rhs.span, "");
+                }
+            }
             ObligationCauseCode::RustCall => {
                 if let Some(pred) = predicate.as_trait_clause()
                     && tcx.is_lang_item(pred.def_id(), LangItem::Sized)

--- a/tests/ui/span/multiline-span-simple.stderr
+++ b/tests/ui/span/multiline-span-simple.stderr
@@ -1,8 +1,13 @@
 error[E0277]: cannot add `()` to `u32`
   --> $DIR/multiline-span-simple.rs:13:18
    |
-LL |     foo(1 as u32 +
-   |                  ^ no implementation for `u32 + ()`
+LL |       foo(1 as u32 +
+   |           -------- ^ no implementation for `u32 + ()`
+LL |
+LL | /         bar(x,
+LL | |
+LL | |             y),
+   | |______________-
    |
    = help: the trait `Add<()>` is not implemented for `u32`
 help: the following other types implement trait `Add<Rhs>`

--- a/tests/ui/typeck/unit-type-add-error-11771.stderr
+++ b/tests/ui/typeck/unit-type-add-error-11771.stderr
@@ -2,7 +2,9 @@ error[E0277]: cannot add `()` to `{integer}`
   --> $DIR/unit-type-add-error-11771.rs:5:7
    |
 LL |     1 +
-   |       ^ no implementation for `{integer} + ()`
+   |     - ^ no implementation for `{integer} + ()`
+LL |     x
+   |     -
    |
    = help: the trait `Add<()>` is not implemented for `{integer}`
    = help: the following other types implement trait `Add<Rhs>`:
@@ -20,7 +22,9 @@ error[E0277]: cannot add `()` to `{integer}`
   --> $DIR/unit-type-add-error-11771.rs:10:7
    |
 LL |     1 +
-   |       ^ no implementation for `{integer} + ()`
+   |     - ^ no implementation for `{integer} + ()`
+LL |     x
+   |     -
    |
    = help: the trait `Add<()>` is not implemented for `{integer}`
    = help: the following other types implement trait `Add<Rhs>`:


### PR DESCRIPTION
```
error[E0277]: cannot add `()` to `u32`
  --> $DIR/multiline-span-simple.rs:13:18
   |
LL |       foo(1 as u32 +
   |           -------- ^ no implementation for `u32 + ()`
LL |
LL | /         bar(x,
LL | |
LL | |             y),
   | |______________-
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
