### PR TITLE
Remove `DepGraphData::dep_node_debug`.

### DIFF
--- a/compiler/rustc_middle/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node.rs
@@ -121,19 +121,7 @@ impl DepNode {
     where
         Key: DepNodeKey<'tcx>,
     {
-        let dep_node = DepNode { kind, key_fingerprint: key.to_fingerprint(tcx).into() };
-
-        #[cfg(debug_assertions)]
-        {
-            if !tcx.key_fingerprint_style(kind).is_maybe_recoverable()
-                && (tcx.sess.opts.unstable_opts.incremental_info
-                    || tcx.sess.opts.unstable_opts.query_dep_graph)
-            {
-                tcx.dep_graph.register_dep_node_debug_str(dep_node, || key.to_debug_str(tcx));
-            }
-        }
-
-        dep_node
+        DepNode { kind, key_fingerprint: key.to_fingerprint(tcx).into() }
     }
 
     /// Construct a DepNode from the given DepKind and DefPathHash. This
@@ -151,24 +139,16 @@ impl DepNode {
 
 impl fmt::Debug for DepNode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}(", self.kind)?;
-
         tls::with_opt(|opt_tcx| {
-            if let Some(tcx) = opt_tcx {
-                if let Some(def_id) = self.extract_def_id(tcx) {
-                    write!(f, "{}", tcx.def_path_debug_str(def_id))?;
-                } else if let Some(ref s) = tcx.dep_graph.dep_node_debug_str(*self) {
-                    write!(f, "{s}")?;
-                } else {
-                    write!(f, "{}", self.key_fingerprint)?;
-                }
+            if let Some(tcx) = opt_tcx
+                && let Some(def_id) = self.extract_def_id(tcx)
+            {
+                write!(f, "{:?}({})", self.kind, tcx.def_path_debug_str(def_id))?;
             } else {
-                write!(f, "{}", self.key_fingerprint)?;
+                write!(f, "{:?}({})", self.kind, self.key_fingerprint)?;
             }
             Ok(())
-        })?;
-
-        write!(f, ")")
+        })
     }
 }
 

--- a/compiler/rustc_middle/src/dep_graph/dep_node_key.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node_key.rs
@@ -18,8 +18,6 @@ pub trait DepNodeKey<'tcx>: Debug + Sized {
     /// in `DepNode`.
     fn to_fingerprint(&self, tcx: TyCtxt<'tcx>) -> Fingerprint;
 
-    fn to_debug_str(&self, tcx: TyCtxt<'tcx>) -> String;
-
     /// This method tries to recover the query key from the given `DepNode`,
     /// something which is needed when forcing `DepNode`s during red-green
     /// evaluation. The query system will only call this method if
@@ -46,14 +44,6 @@ where
             self.hash_stable(&mut hcx, &mut hasher);
             hasher.finish()
         })
-    }
-
-    #[inline(always)]
-    default fn to_debug_str(&self, tcx: TyCtxt<'tcx>) -> String {
-        // Make sure to print dep node params with reduced queries since printing
-        // may themselves call queries, which may lead to (possibly untracked!)
-        // query cycles.
-        tcx.with_reduced_queries(|| format!("{self:?}"))
     }
 
     #[inline(always)]
@@ -91,11 +81,6 @@ impl<'tcx> DepNodeKey<'tcx> for DefId {
     }
 
     #[inline(always)]
-    fn to_debug_str(&self, tcx: TyCtxt<'tcx>) -> String {
-        tcx.def_path_str(*self)
-    }
-
-    #[inline(always)]
     fn try_recover_key(tcx: TyCtxt<'tcx>, dep_node: &DepNode) -> Option<Self> {
         dep_node.extract_def_id(tcx)
     }
@@ -110,11 +95,6 @@ impl<'tcx> DepNodeKey<'tcx> for LocalDefId {
     #[inline(always)]
     fn to_fingerprint(&self, tcx: TyCtxt<'tcx>) -> Fingerprint {
         self.to_def_id().to_fingerprint(tcx)
-    }
-
-    #[inline(always)]
-    fn to_debug_str(&self, tcx: TyCtxt<'tcx>) -> String {
-        self.to_def_id().to_debug_str(tcx)
     }
 
     #[inline(always)]
@@ -135,11 +115,6 @@ impl<'tcx> DepNodeKey<'tcx> for OwnerId {
     }
 
     #[inline(always)]
-    fn to_debug_str(&self, tcx: TyCtxt<'tcx>) -> String {
-        self.to_def_id().to_debug_str(tcx)
-    }
-
-    #[inline(always)]
     fn try_recover_key(tcx: TyCtxt<'tcx>, dep_node: &DepNode) -> Option<Self> {
         dep_node.extract_def_id(tcx).map(|id| OwnerId { def_id: id.expect_local() })
     }
@@ -155,11 +130,6 @@ impl<'tcx> DepNodeKey<'tcx> for CrateNum {
     fn to_fingerprint(&self, tcx: TyCtxt<'tcx>) -> Fingerprint {
         let def_id = self.as_def_id();
         def_id.to_fingerprint(tcx)
-    }
-
-    #[inline(always)]
-    fn to_debug_str(&self, tcx: TyCtxt<'tcx>) -> String {
-        tcx.crate_name(*self).to_string()
     }
 
     #[inline(always)]
@@ -186,13 +156,6 @@ impl<'tcx> DepNodeKey<'tcx> for (DefId, DefId) {
 
         def_path_hash_0.0.combine(def_path_hash_1.0)
     }
-
-    #[inline(always)]
-    fn to_debug_str(&self, tcx: TyCtxt<'tcx>) -> String {
-        let (def_id_0, def_id_1) = *self;
-
-        format!("({}, {})", tcx.def_path_debug_str(def_id_0), tcx.def_path_debug_str(def_id_1))
-    }
 }
 
 impl<'tcx> DepNodeKey<'tcx> for HirId {
@@ -213,12 +176,6 @@ impl<'tcx> DepNodeKey<'tcx> for HirId {
             def_path_hash.local_hash(),
             local_id.as_u32() as u64,
         )
-    }
-
-    #[inline(always)]
-    fn to_debug_str(&self, tcx: TyCtxt<'tcx>) -> String {
-        let HirId { owner, local_id } = *self;
-        format!("{}.{}", tcx.def_path_str(owner), local_id.as_u32())
     }
 
     #[inline(always)]
@@ -250,11 +207,6 @@ impl<'tcx> DepNodeKey<'tcx> for ModDefId {
     }
 
     #[inline(always)]
-    fn to_debug_str(&self, tcx: TyCtxt<'tcx>) -> String {
-        self.to_def_id().to_debug_str(tcx)
-    }
-
-    #[inline(always)]
     fn try_recover_key(tcx: TyCtxt<'tcx>, dep_node: &DepNode) -> Option<Self> {
         DefId::try_recover_key(tcx, dep_node).map(ModDefId::new_unchecked)
     }
@@ -269,11 +221,6 @@ impl<'tcx> DepNodeKey<'tcx> for LocalModDefId {
     #[inline(always)]
     fn to_fingerprint(&self, tcx: TyCtxt<'tcx>) -> Fingerprint {
         self.to_def_id().to_fingerprint(tcx)
-    }
-
-    #[inline(always)]
-    fn to_debug_str(&self, tcx: TyCtxt<'tcx>) -> String {
-        self.to_def_id().to_debug_str(tcx)
     }
 
     #[inline(always)]

--- a/compiler/rustc_middle/src/dep_graph/graph.rs
+++ b/compiler/rustc_middle/src/dep_graph/graph.rs
@@ -115,8 +115,6 @@ pub struct DepGraphData {
     /// this map. We can later look for and extract that data.
     previous_work_products: WorkProductMap,
 
-    dep_node_debug: Lock<FxHashMap<DepNode, String>>,
-
     /// Used by incremental compilation tests to assert that
     /// a particular query result was decoded from disk
     /// (not just marked green)
@@ -173,7 +171,6 @@ impl DepGraph {
         DepGraph {
             data: Some(Arc::new(DepGraphData {
                 previous_work_products: prev_work_products,
-                dep_node_debug: Default::default(),
                 current,
                 previous: prev_graph,
                 colors,
@@ -848,31 +845,6 @@ impl DepGraph {
             .lock()
             .iter()
             .any(|node| node.kind == dep_kind)
-    }
-
-    #[cfg(debug_assertions)]
-    #[inline(always)]
-    pub(crate) fn register_dep_node_debug_str<F>(&self, dep_node: DepNode, debug_str_gen: F)
-    where
-        F: FnOnce() -> String,
-    {
-        // Early queries (e.g., `-Z query-dep-graph` on empty crates) can reach here
-        // before the graph is initialized. Return early to prevent an ICE.
-        let data = match &self.data {
-            Some(d) => d,
-            None => return,
-        };
-        let dep_node_debug = &data.dep_node_debug;
-
-        if dep_node_debug.borrow().contains_key(&dep_node) {
-            return;
-        }
-        let debug_str = self.with_ignore(debug_str_gen);
-        dep_node_debug.borrow_mut().insert(dep_node, debug_str);
-    }
-
-    pub(crate) fn dep_node_debug_str(&self, dep_node: DepNode) -> Option<String> {
-        self.data.as_ref()?.dep_node_debug.borrow().get(&dep_node).cloned()
     }
 
     fn node_color(&self, dep_node: &DepNode) -> DepNodeColor {

--- a/compiler/rustc_middle/src/dep_graph/mod.rs
+++ b/compiler/rustc_middle/src/dep_graph/mod.rs
@@ -14,7 +14,7 @@ use self::graph::{MarkFrame, print_markframe_trace};
 pub use self::retained::RetainedDepGraph;
 pub use self::serialized::{SerializedDepGraph, SerializedDepNodeIndex};
 pub use crate::dep_graph::debug::{DepNodeFilter, EdgeFilter};
-use crate::ty::print::with_reduced_queries;
+pub use crate::ty::print::with_reduced_queries;
 use crate::ty::{self, TyCtxt};
 
 mod debug;
@@ -83,10 +83,6 @@ impl<'tcx> TyCtxt<'tcx> {
     #[inline]
     pub fn dep_kind_vtable(self, dk: DepKind) -> &'tcx DepKindVTable<'tcx> {
         &self.dep_kind_vtables[dk.as_usize()]
-    }
-
-    fn with_reduced_queries<T>(self, f: impl FnOnce() -> T) -> T {
-        with_reduced_queries!(f())
     }
 
     #[inline(always)]


### PR DESCRIPTION
This hashmap was added in rust-lang/rust#42625 and is used for debug-only printing. If a key isn't recoverable, `DepNode::construct` will create a string for it (using `DepNodeKey::to_debug_str`) and insert the string in the hashmap, but only if (a) it's a debug build, and (b) `-Zincremental-info` or `-Zquery-dep-graph` is specified. ("Recoverable" here means the fingerprint style is `KeyFingerPrintStyle::Opaque`.)

`DepNode::fmt` will then use this string to produce output showing the key itself, and not just its fingerprint.

All this code is debug-only. Some of it is guarded with `#[cfg(debug_assertions)]`, but some is not.

However, the `tcx.def_path_debug_str()` path in `DepNode::fmt` seems to be unreachable. Because it's debug-only it can't be used by normal users and so must only be there for rustc devs. But even in a debug build I was unable to trigger that path. I tried changing it to a panic and ran the full test suite without problem, and then I tried various flag combinations and scenarios also without hitting it. The `-Zincremental-info` condition doesn't make sense because that only prints high-level info about queries, not individual keys. So the path is either unreachable, or so hard to reach that it's not providing any actual value.

This commit removes all this code.

r? @cjgillot