### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_target/src/spec/targets/loongarch32_unknown_none.rs
+++ b/compiler/rustc_target/src/spec/targets/loongarch32_unknown_none.rs
@@ -22,6 +22,7 @@ pub(crate) fn target() -> Target {
             linker: Some("rust-lld".into()),
             llvm_abiname: LlvmAbi::Ilp32d,
             max_atomic_width: Some(32),
+            mcount: "_mcount".into(),
             relocation_model: RelocModel::Static,
             panic_strategy: PanicStrategy::Abort,
             ..Default::default()

--- a/compiler/rustc_target/src/spec/targets/loongarch32_unknown_none_softfloat.rs
+++ b/compiler/rustc_target/src/spec/targets/loongarch32_unknown_none_softfloat.rs
@@ -23,6 +23,7 @@ pub(crate) fn target() -> Target {
             linker: Some("rust-lld".into()),
             llvm_abiname: LlvmAbi::Ilp32s,
             max_atomic_width: Some(32),
+            mcount: "_mcount".into(),
             relocation_model: RelocModel::Static,
             panic_strategy: PanicStrategy::Abort,
             ..Default::default()

--- a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_gnu.rs
@@ -20,6 +20,7 @@ pub(crate) fn target() -> Target {
             features: "+f,+d,+lsx,+relax".into(),
             llvm_abiname: LlvmAbi::Lp64d,
             max_atomic_width: Some(64),
+            mcount: "_mcount".into(),
             supported_sanitizers: SanitizerSet::ADDRESS
                 | SanitizerSet::CFI
                 | SanitizerSet::LEAK

--- a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_musl.rs
@@ -20,6 +20,7 @@ pub(crate) fn target() -> Target {
             features: "+f,+d,+lsx,+relax".into(),
             llvm_abiname: LlvmAbi::Lp64d,
             max_atomic_width: Some(64),
+            mcount: "_mcount".into(),
             crt_static_default: false,
             supported_sanitizers: SanitizerSet::ADDRESS
                 | SanitizerSet::CFI

--- a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_ohos.rs
+++ b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_ohos.rs
@@ -20,6 +20,7 @@ pub(crate) fn target() -> Target {
             features: "+f,+d,+lsx,+relax".into(),
             llvm_abiname: LlvmAbi::Lp64d,
             max_atomic_width: Some(64),
+            mcount: "_mcount".into(),
             supported_sanitizers: SanitizerSet::ADDRESS
                 | SanitizerSet::CFI
                 | SanitizerSet::LEAK

--- a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_none.rs
+++ b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_none.rs
@@ -22,6 +22,7 @@ pub(crate) fn target() -> Target {
             linker: Some("rust-lld".into()),
             llvm_abiname: LlvmAbi::Lp64d,
             max_atomic_width: Some(64),
+            mcount: "_mcount".into(),
             relocation_model: RelocModel::Static,
             panic_strategy: PanicStrategy::Abort,
             code_model: Some(CodeModel::Medium),

--- a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_none_softfloat.rs
+++ b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_none_softfloat.rs
@@ -23,6 +23,7 @@ pub(crate) fn target() -> Target {
             linker: Some("rust-lld".into()),
             llvm_abiname: LlvmAbi::Lp64s,
             max_atomic_width: Some(64),
+            mcount: "_mcount".into(),
             relocation_model: RelocModel::Static,
             panic_strategy: PanicStrategy::Abort,
             code_model: Some(CodeModel::Medium),

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/overflow.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/overflow.rs
@@ -99,6 +99,15 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                             "overflow assigning `{a}` to `{b}`",
                         )
                     }
+                    ty::PredicateKind::Clause(ty::ClauseKind::WellFormed(term)) => {
+                        let term = with_short_path(self.tcx, term);
+                        struct_span_code_err!(
+                            self.dcx(),
+                            span,
+                            E0275,
+                            "overflow evaluating whether `{term}` is well-formed",
+                        )
+                    }
                     _ => {
                         let pred_str = with_short_path(self.tcx, predicate);
                         struct_span_code_err!(

--- a/tests/ui/associated-types/issue-64855-2.rs
+++ b/tests/ui/associated-types/issue-64855-2.rs
@@ -3,6 +3,6 @@
 // also inadvertently a test for the (non-)co-inductiveness of WF predicates.
 
 pub struct Bar<'a>(&'a Self) where Self: ;
-//~^ ERROR overflow evaluating the requirement `Bar<'a> well-formed`
+//~^ ERROR overflow evaluating whether `Bar<'a>` is well-formed
 
 fn main() {}

--- a/tests/ui/associated-types/issue-64855-2.stderr
+++ b/tests/ui/associated-types/issue-64855-2.stderr
@@ -1,4 +1,4 @@
-error[E0275]: overflow evaluating the requirement `Bar<'a> well-formed`
+error[E0275]: overflow evaluating whether `Bar<'a>` is well-formed
   --> $DIR/issue-64855-2.rs:5:36
    |
 LL | pub struct Bar<'a>(&'a Self) where Self: ;

--- a/tests/ui/associated-types/issue-64855.rs
+++ b/tests/ui/associated-types/issue-64855.rs
@@ -8,6 +8,6 @@ pub trait Foo {
 
 pub struct Bar<T>(<Self as Foo>::Type) where Self: ;
 //~^ ERROR the trait bound `Bar<T>: Foo` is not satisfied
-//~| ERROR overflow evaluating the requirement `Bar<T> well-formed`
+//~| ERROR overflow evaluating whether `Bar<T>` is well-formed
 
 fn main() {}

--- a/tests/ui/associated-types/issue-64855.stderr
+++ b/tests/ui/associated-types/issue-64855.stderr
@@ -15,7 +15,7 @@ help: this trait has no implementations, consider adding one
 LL | pub trait Foo {
    | ^^^^^^^^^^^^^
 
-error[E0275]: overflow evaluating the requirement `Bar<T> well-formed`
+error[E0275]: overflow evaluating whether `Bar<T>` is well-formed
   --> $DIR/issue-64855.rs:9:46
    |
 LL | pub struct Bar<T>(<Self as Foo>::Type) where Self: ;

--- a/tests/ui/const-generics/generic_const_exprs/adt_wf_hang.rs
+++ b/tests/ui/const-generics/generic_const_exprs/adt_wf_hang.rs
@@ -9,6 +9,6 @@ struct U;
 struct S<const N: U>()
 where
     S<{ U }>:;
-//~^ ERROR: overflow evaluating the requirement `S<{ U }> well-formed`
+//~^ ERROR: overflow evaluating whether `S<{ U }>` is well-formed
 
 fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/adt_wf_hang.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/adt_wf_hang.stderr
@@ -1,4 +1,4 @@
-error[E0275]: overflow evaluating the requirement `S<{ U }> well-formed`
+error[E0275]: overflow evaluating whether `S<{ U }>` is well-formed
   --> $DIR/adt_wf_hang.rs:11:5
    |
 LL |     S<{ U }>:;

--- a/tests/ui/const-generics/mgca/const-ctor-overflow-eval.rs
+++ b/tests/ui/const-generics/mgca/const-ctor-overflow-eval.rs
@@ -6,14 +6,14 @@ use std::marker::ConstParamTy;
 struct U;
 
 #[derive(ConstParamTy, PartialEq, Eq)]
-//~^ ERROR overflow evaluating the requirement `S<U> well-formed`
-//~| ERROR overflow evaluating the requirement `S<U> well-formed`
+//~^ ERROR overflow evaluating whether `S<U>` is well-formed
+//~| ERROR overflow evaluating whether `S<U>` is well-formed
 
 struct S<const N: U>()
 where
     S<{ U }>:;
-//~^ ERROR overflow evaluating the requirement `S<U> well-formed`
-//~| ERROR overflow evaluating the requirement `S<U> well-formed`
-//~| ERROR overflow evaluating the requirement `S<U> well-formed`
+//~^ ERROR overflow evaluating whether `S<U>` is well-formed
+//~| ERROR overflow evaluating whether `S<U>` is well-formed
+//~| ERROR overflow evaluating whether `S<U>` is well-formed
 
 fn main() {}

--- a/tests/ui/const-generics/mgca/const-ctor-overflow-eval.stderr
+++ b/tests/ui/const-generics/mgca/const-ctor-overflow-eval.stderr
@@ -1,4 +1,4 @@
-error[E0275]: overflow evaluating the requirement `S<U> well-formed`
+error[E0275]: overflow evaluating whether `S<U>` is well-formed
   --> $DIR/const-ctor-overflow-eval.rs:14:5
    |
 LL |     S<{ U }>:;
@@ -13,23 +13,7 @@ LL | where
 LL |     S<{ U }>:;
    |     ^^^^^^^^ required by this bound in `S`
 
-error[E0275]: overflow evaluating the requirement `S<U> well-formed`
-  --> $DIR/const-ctor-overflow-eval.rs:14:5
-   |
-LL |     S<{ U }>:;
-   |     ^^^^^^^^
-   |
-note: required by a bound in `S`
-  --> $DIR/const-ctor-overflow-eval.rs:14:5
-   |
-LL | struct S<const N: U>()
-   |        - required by a bound in this struct
-LL | where
-LL |     S<{ U }>:;
-   |     ^^^^^^^^ required by this bound in `S`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error[E0275]: overflow evaluating the requirement `S<U> well-formed`
+error[E0275]: overflow evaluating whether `S<U>` is well-formed
   --> $DIR/const-ctor-overflow-eval.rs:14:5
    |
 LL |     S<{ U }>:;
@@ -45,7 +29,23 @@ LL |     S<{ U }>:;
    |     ^^^^^^^^ required by this bound in `S`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0275]: overflow evaluating the requirement `S<U> well-formed`
+error[E0275]: overflow evaluating whether `S<U>` is well-formed
+  --> $DIR/const-ctor-overflow-eval.rs:14:5
+   |
+LL |     S<{ U }>:;
+   |     ^^^^^^^^
+   |
+note: required by a bound in `S`
+  --> $DIR/const-ctor-overflow-eval.rs:14:5
+   |
+LL | struct S<const N: U>()
+   |        - required by a bound in this struct
+LL | where
+LL |     S<{ U }>:;
+   |     ^^^^^^^^ required by this bound in `S`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0275]: overflow evaluating whether `S<U>` is well-formed
   --> $DIR/const-ctor-overflow-eval.rs:8:24
    |
 LL | #[derive(ConstParamTy, PartialEq, Eq)]
@@ -60,7 +60,7 @@ LL | where
 LL |     S<{ U }>:;
    |     ^^^^^^^^ required by this bound in `S`
 
-error[E0275]: overflow evaluating the requirement `S<U> well-formed`
+error[E0275]: overflow evaluating whether `S<U>` is well-formed
   --> $DIR/const-ctor-overflow-eval.rs:8:35
    |
 LL | #[derive(ConstParamTy, PartialEq, Eq)]

--- a/tests/ui/higher-ranked/trait-bounds/issue-95230.rs
+++ b/tests/ui/higher-ranked/trait-bounds/issue-95230.rs
@@ -5,6 +5,6 @@
 pub struct Bar
 where
     for<'a> &'a mut Self:;
-//~^ ERROR overflow evaluating the requirement `for<'a> &'a mut Bar well-formed`
+//~^ ERROR: overflow evaluating whether `&'a mut Bar` is well-formed
 
 fn main() {}

--- a/tests/ui/higher-ranked/trait-bounds/issue-95230.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/issue-95230.stderr
@@ -1,4 +1,4 @@
-error[E0275]: overflow evaluating the requirement `for<'a> &'a mut Bar well-formed`
+error[E0275]: overflow evaluating whether `&'a mut Bar` is well-formed
   --> $DIR/issue-95230.rs:7:13
    |
 LL |     for<'a> &'a mut Self:;

--- a/tests/ui/traits/next-solver/alias-bound-unsound.rs
+++ b/tests/ui/traits/next-solver/alias-bound-unsound.rs
@@ -26,8 +26,8 @@ impl Foo for () {
 fn main() {
     let x = String::from("hello, world");
     let _ = identity(<() as Foo>::copy_me(&x));
-    //~^ ERROR overflow evaluating the requirement `<() as Foo>::Item well-formed`
-    //~| ERROR overflow evaluating the requirement `&<() as Foo>::Item well-formed`
+    //~^ ERROR overflow evaluating whether `<() as Foo>::Item` is well-formed
+    //~| ERROR overflow evaluating whether `&<() as Foo>::Item` is well-formed
     //~| ERROR overflow evaluating the requirement `<() as Foo>::Item == String`
     //~| ERROR overflow evaluating the requirement `<() as Foo>::Item == _`
     //~| ERROR overflow evaluating the requirement `<() as Foo>::Item == _`

--- a/tests/ui/traits/next-solver/alias-bound-unsound.stderr
+++ b/tests/ui/traits/next-solver/alias-bound-unsound.stderr
@@ -32,13 +32,13 @@ LL |     let _ = identity(<() as Foo>::copy_me(&x));
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0275]: overflow evaluating the requirement `&<() as Foo>::Item well-formed`
+error[E0275]: overflow evaluating whether `&<() as Foo>::Item` is well-formed
   --> $DIR/alias-bound-unsound.rs:28:43
    |
 LL |     let _ = identity(<() as Foo>::copy_me(&x));
    |                                           ^^
 
-error[E0275]: overflow evaluating the requirement `<() as Foo>::Item well-formed`
+error[E0275]: overflow evaluating whether `<() as Foo>::Item` is well-formed
   --> $DIR/alias-bound-unsound.rs:28:22
    |
 LL |     let _ = identity(<() as Foo>::copy_me(&x));

--- a/tests/ui/traits/next-solver/cycles/coinduction/item-bound-via-impl-where-clause.next.stderr
+++ b/tests/ui/traits/next-solver/cycles/coinduction/item-bound-via-impl-where-clause.next.stderr
@@ -30,7 +30,7 @@ LL |     let s: String = transmute::<_, String>(vec![65_u8, 66, 67]);
    |
    = note: the return type of a function must have a statically known size
 
-error[E0275]: overflow evaluating the requirement `<<Vec<u8> as Trait<String>>::Proof as Trait<String>>::Proof well-formed`
+error[E0275]: overflow evaluating whether `<<Vec<u8> as Trait<String>>::Proof as Trait<String>>::Proof` is well-formed
   --> $DIR/item-bound-via-impl-where-clause.rs:31:21
    |
 LL |     let s: String = transmute::<_, String>(vec![65_u8, 66, 67]);

--- a/tests/ui/traits/next-solver/cycles/coinduction/item-bound-via-impl-where-clause.rs
+++ b/tests/ui/traits/next-solver/cycles/coinduction/item-bound-via-impl-where-clause.rs
@@ -33,7 +33,7 @@ fn main() {
     //[next]~| ERROR overflow evaluating the requirement `<<Vec<u8> as Trait<String>>::Proof as Trait<String>>::Proof == _`
     //[next]~| ERROR overflow evaluating the requirement `<<Vec<u8> as Trait<String>>::Proof as Trait<String>>::Proof == String`
     //[next]~| ERROR overflow evaluating the requirement `<<Vec<u8> as Trait<String>>::Proof as Trait<String>>::Proof: Sized`
-    //[next]~| ERROR overflow evaluating the requirement `<<Vec<u8> as Trait<String>>::Proof as Trait<String>>::Proof well-formed`
+    //[next]~| ERROR overflow evaluating whether `<<Vec<u8> as Trait<String>>::Proof as Trait<String>>::Proof` is well-formed
     //[next]~| ERROR overflow evaluating the requirement `<<Vec<u8> as Trait<String>>::Proof as Trait<String>>::Proof == _`
     println!("{}", s); // ABC
 }

--- a/tests/ui/traits/next-solver/normalize/normalize-param-env-2.stderr
+++ b/tests/ui/traits/next-solver/normalize/normalize-param-env-2.stderr
@@ -27,7 +27,7 @@ error[E0275]: overflow evaluating the requirement `<() as A<T>>::Assoc: A<T>`
 LL |         Self::Assoc: A<T>,
    |                      ^^^^
 
-error[E0275]: overflow evaluating the requirement `<() as A<T>>::Assoc well-formed`
+error[E0275]: overflow evaluating whether `<() as A<T>>::Assoc` is well-formed
   --> $DIR/normalize-param-env-2.rs:24:22
    |
 LL |         Self::Assoc: A<T>,

--- a/tests/ui/transmutability/transmute-from-const-args-ice-150457.rs
+++ b/tests/ui/transmutability/transmute-from-const-args-ice-150457.rs
@@ -1,0 +1,31 @@
+//! Ensure `TransmuteFrom` with `min_generic_const_args` doesn't ICE
+//! during well-formedness checking.
+//!
+//! Regression test for <https://github.com/rust-lang/rust/issues/150457>.
+
+//@ check-pass
+
+#![feature(transmutability)]
+#![feature(min_generic_const_args)]
+
+use std::mem::{Assume, TransmuteFrom};
+
+struct W<'a>(&'a ());
+
+fn test<'a>()
+where
+    W<'a>: TransmuteFrom<
+        (),
+        {
+            Assume {
+                alignment: const { true },
+                lifetimes: const { true },
+                safety: const { true },
+                validity: true,
+            }
+        },
+    >,
+{
+}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#154548 (Add regression test for TransmuteFrom ICE with min_generic_const_args)
 - rust-lang/rust#154564 (Tweak wording of E0275 WF errors)
 - rust-lang/rust#154566 (loongarch: use "_mcount" as the default mcount symbol)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=154548,154564,154566)
<!-- homu-ignore:end -->

