### PR TITLE
Fix alias path for rustdoc

### DIFF
--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -706,7 +706,7 @@ macro_rules! tool_check_step {
             const IS_HOST: bool = true;
 
             fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-                run.path($path) $( .path( $alt_path ) )*
+                run.path_aliases(&[$path $(, $alt_path )*])
             }
 
             fn is_default_step(_builder: &Builder<'_>) -> bool {

--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -706,7 +706,7 @@ macro_rules! tool_check_step {
             const IS_HOST: bool = true;
 
             fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-                run.path_aliases(&[$path $(, $alt_path )*])
+                run.selectors(&[$path $(, $alt_path )*])
             }
 
             fn is_default_step(_builder: &Builder<'_>) -> bool {

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -3189,7 +3189,7 @@ impl Step for CrateRustdoc {
     const IS_HOST: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        run.path_aliases(&["src/librustdoc", "src/tools/rustdoc"])
+        run.selectors(&["src/librustdoc", "src/tools/rustdoc"])
     }
 
     fn is_default_step(_builder: &Builder<'_>) -> bool {

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -3189,7 +3189,7 @@ impl Step for CrateRustdoc {
     const IS_HOST: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        run.path("src/librustdoc").path("src/tools/rustdoc")
+        run.path_aliases(&["src/librustdoc", "src/tools/rustdoc"])
     }
 
     fn is_default_step(_builder: &Builder<'_>) -> bool {

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -689,7 +689,7 @@ impl Step for Rustdoc {
     const IS_HOST: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        run.path_aliases(&["src/tools/rustdoc", "src/librustdoc"])
+        run.selectors(&["src/tools/rustdoc", "src/librustdoc"])
     }
 
     fn is_default_step(_builder: &Builder<'_>) -> bool {

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -689,7 +689,7 @@ impl Step for Rustdoc {
     const IS_HOST: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        run.path("src/tools/rustdoc").path("src/librustdoc")
+        run.path_aliases(&["src/tools/rustdoc", "src/librustdoc"])
     }
 
     fn is_default_step(_builder: &Builder<'_>) -> bool {

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_bench.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_bench.snap
@@ -96,5 +96,4 @@ expression: bench
     - Set({bench::compiler/rustc_windows_rc})
 [Bench] test::CrateRustdoc
     targets: [x86_64-unknown-linux-gnu]
-    - Set({bench::src/librustdoc})
-    - Set({bench::src/tools/rustdoc})
+    - Set({bench::src/librustdoc, bench::src/tools/rustdoc})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build.snap
@@ -19,5 +19,4 @@ expression: build
     - Set({build::library/unwind})
 [Build] tool::Rustdoc
     targets: [x86_64-unknown-linux-gnu]
-    - Set({build::src/librustdoc})
-    - Set({build::src/tools/rustdoc})
+    - Set({build::src/librustdoc, build::src/tools/rustdoc})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_check.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_check.snap
@@ -80,8 +80,7 @@ expression: check
     - Set({check::compiler/rustc_windows_rc})
 [Check] check::Rustdoc
     targets: [x86_64-unknown-linux-gnu]
-    - Set({check::src/librustdoc})
-    - Set({check::src/tools/rustdoc})
+    - Set({check::src/librustdoc, check::src/tools/rustdoc})
 [Check] check::CraneliftCodegenBackend
     targets: [x86_64-unknown-linux-gnu]
     - Set({check::cg_clif})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_check_compiletest_include_default_paths.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_check_compiletest_include_default_paths.snap
@@ -80,8 +80,7 @@ expression: check compiletest --include-default-paths
     - Set({check::compiler/rustc_windows_rc})
 [Check] check::Rustdoc
     targets: [x86_64-unknown-linux-gnu]
-    - Set({check::src/librustdoc})
-    - Set({check::src/tools/rustdoc})
+    - Set({check::src/librustdoc, check::src/tools/rustdoc})
 [Check] check::CraneliftCodegenBackend
     targets: [x86_64-unknown-linux-gnu]
     - Set({check::cg_clif})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_fix.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_fix.snap
@@ -80,8 +80,7 @@ expression: fix
     - Set({fix::compiler/rustc_windows_rc})
 [Fix] check::Rustdoc
     targets: [x86_64-unknown-linux-gnu]
-    - Set({fix::src/librustdoc})
-    - Set({fix::src/tools/rustdoc})
+    - Set({fix::src/librustdoc, fix::src/tools/rustdoc})
 [Fix] check::CraneliftCodegenBackend
     targets: [x86_64-unknown-linux-gnu]
     - Set({fix::cg_clif})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test.snap
@@ -146,8 +146,7 @@ expression: test
     - Set({test::compiler/rustc_windows_rc})
 [Test] test::CrateRustdoc
     targets: [x86_64-unknown-linux-gnu]
-    - Set({test::src/librustdoc})
-    - Set({test::src/tools/rustdoc})
+    - Set({test::src/librustdoc, test::src/tools/rustdoc})
 [Test] test::CrateRustdocJsonTypes
     targets: [x86_64-unknown-linux-gnu]
     - Set({test::src/rustdoc-json-types})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_librustdoc_rustdoc.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_librustdoc_rustdoc.snap
@@ -4,8 +4,7 @@ expression: test librustdoc rustdoc
 ---
 [Test] test::CrateRustdoc
     targets: [x86_64-unknown-linux-gnu]
-    - Set({test::src/librustdoc})
-    - Set({test::src/tools/rustdoc})
+    - Set({test::src/librustdoc, test::src/tools/rustdoc})
 [Test] test::RustdocBook
     targets: [x86_64-unknown-linux-gnu]
     - Set({test::src/doc/rustdoc})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage.snap
@@ -145,8 +145,7 @@ expression: test --skip=coverage
     - Set({test::compiler/rustc_windows_rc})
 [Test] test::CrateRustdoc
     targets: [x86_64-unknown-linux-gnu]
-    - Set({test::src/librustdoc})
-    - Set({test::src/tools/rustdoc})
+    - Set({test::src/librustdoc, test::src/tools/rustdoc})
 [Test] test::CrateRustdocJsonTypes
     targets: [x86_64-unknown-linux-gnu]
     - Set({test::src/rustdoc-json-types})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests.snap
@@ -109,8 +109,7 @@ expression: test --skip=tests
     - Set({test::compiler/rustc_windows_rc})
 [Test] test::CrateRustdoc
     targets: [x86_64-unknown-linux-gnu]
-    - Set({test::src/librustdoc})
-    - Set({test::src/tools/rustdoc})
+    - Set({test::src/librustdoc, test::src/tools/rustdoc})
 [Test] test::CrateRustdocJsonTypes
     targets: [x86_64-unknown-linux-gnu]
     - Set({test::src/rustdoc-json-types})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests_etc.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests_etc.snap
@@ -89,8 +89,7 @@ expression: test --skip=tests --skip=coverage-map --skip=coverage-run --skip=lib
     - Set({test::compiler/rustc_windows_rc})
 [Test] test::CrateRustdoc
     targets: [x86_64-unknown-linux-gnu]
-    - Set({test::src/librustdoc})
-    - Set({test::src/tools/rustdoc})
+    - Set({test::src/librustdoc, test::src/tools/rustdoc})
 [Test] test::CrateRustdocJsonTypes
     targets: [x86_64-unknown-linux-gnu]
     - Set({test::src/rustdoc-json-types})

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -356,7 +356,7 @@ pub enum PathSet {
     /// command-line value of `std` will match if `library/std` is in the
     /// set.
     ///
-    /// NOTE: the paths within a set should always be aliases of one another.
+    /// NOTE: the paths within a set should all select the same unit of work.
     /// For example, `src/librustdoc` and `src/tools/rustdoc` should be in the same set,
     /// but `library/core` and `library/std` generally should not, unless there's no way (for that Step)
     /// to build them separately.
@@ -567,9 +567,10 @@ impl<'a> ShouldRun<'a> {
         }
     }
 
-    /// single, non-aliased path
+    /// A single path
     ///
-    /// Must be an on-disk path; use [`path_aliases`][Self::path_aliases] for names that do not correspond to on-disk paths.
+    /// Must be an on-disk path; use [`alias`][Self::alias] for names that do not
+    /// correspond to on-disk paths.
     pub fn path(mut self, path: &str) -> Self {
         self.assert_valid_path(path);
 
@@ -578,8 +579,8 @@ impl<'a> ShouldRun<'a> {
         self
     }
 
-    /// Multiple on-disk paths that should be treated as aliases of one another.
-    pub fn path_aliases(mut self, paths: &[&str]) -> Self {
+    /// Multiple on-disk paths that should select the same unit of work.
+    pub fn selectors(mut self, paths: &[&str]) -> Self {
         let mut set = BTreeSet::new();
         for path in paths {
             self.assert_valid_path(path);

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -555,10 +555,7 @@ impl<'a> ShouldRun<'a> {
         self
     }
 
-    /// single, non-aliased path
-    ///
-    /// Must be an on-disk path; use `alias` for names that do not correspond to on-disk paths.
-    pub fn path(mut self, path: &str) -> Self {
+    fn assert_valid_path(&self, path: &str) {
         let submodules_paths = self.builder.submodule_paths();
 
         // assert only if `p` isn't submodule
@@ -568,9 +565,27 @@ impl<'a> ShouldRun<'a> {
                 "`should_run.path` should correspond to a real on-disk path - use `alias` if there is no relevant path: {path}"
             );
         }
+    }
+
+    /// single, non-aliased path
+    ///
+    /// Must be an on-disk path; use `alias` for names that do not correspond to on-disk paths.
+    pub fn path(mut self, path: &str) -> Self {
+        self.assert_valid_path(path);
 
         let task = TaskPath { path: path.into(), kind: Some(self.kind) };
         self.paths.insert(PathSet::Set(BTreeSet::from_iter([task])));
+        self
+    }
+
+    /// Multiple on-disk paths that should be treated as aliases of one another.
+    pub fn path_aliases(mut self, paths: &[&str]) -> Self {
+        let mut set = BTreeSet::new();
+        for path in paths {
+            self.assert_valid_path(path);
+            set.insert(TaskPath { path: (*path).into(), kind: Some(self.kind) });
+        }
+        self.paths.insert(PathSet::Set(set));
         self
     }
 

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -569,7 +569,7 @@ impl<'a> ShouldRun<'a> {
 
     /// single, non-aliased path
     ///
-    /// Must be an on-disk path; use `alias` for names that do not correspond to on-disk paths.
+    /// Must be an on-disk path; use [`path_aliases`][Self::path_aliases] for names that do not correspond to on-disk paths.
     pub fn path(mut self, path: &str) -> Self {
         self.assert_valid_path(path);
 

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -2401,6 +2401,29 @@ mod snapshot {
     }
 
     #[test]
+    fn test_exclude_rustdoc_aliases() {
+        let ctx = TestCtx::new();
+        let host = TargetSelection::from_user(&host_target());
+
+        let get_steps = |args: &[&str]| ctx.config("build").args(args).get_steps();
+
+        for args in [
+            ["--skip", "rustdoc"].as_slice(),
+            ["--skip", "src/tools/rustdoc"].as_slice(),
+            ["--skip", "src/librustdoc"].as_slice(),
+        ] {
+            let steps = get_steps(args);
+
+            steps.assert_contains_fuzzy(StepMetadata::build("rustc", host));
+            steps.assert_no_match(|metadata| {
+                metadata.name == "rustdoc"
+                    && metadata.kind == Kind::Build
+                    && metadata.target == host
+            });
+        }
+    }
+
+    #[test]
     fn test_cargo_stage_1() {
         let ctx = TestCtx::new();
         insta::assert_snapshot!(


### PR DESCRIPTION
I ran this command:

```console
x build --stage 1  --skip rustdoc       
Building bootstrap
   Compiling bootstrap v0.0.0 (/Users/yukang/rust/src/bootstrap)
    Finished `dev` profile [unoptimized] target(s) in 1.08s
/Users/yukang/rust/build/aarch64-apple-darwin/ci-llvm/bin/llvm-strip does not exist; skipping copy
Building stage1 compiler artifacts (stage0 -> stage1, aarch64-apple-darwin)
    Finished `release` profile [optimized + debuginfo] target(s) in 0.45s
Creating a sysroot for stage1 compiler (use `rustup toolchain link 'name' build/host/stage1`)
Building stage1 library artifacts{alloc, compiler_builtins, core, panic_abort, panic_unwind, proc_macro, rustc-std-workspace-core, std, std_detect, sysroot, test, unwind} (stage1 -> stage1, aarch64-apple-darwin)
    Finished `dist` profile [optimized + debuginfo] target(s) in 0.10s
Skipping Set({build::src/tools/rustdoc}) because it is excluded
Building stage1 rustdoc_tool_binary (stage0 -> stage1, aarch64-apple-darwin)
    Finished `release` profile [optimized + debuginfo] target(s) in 0.19s
```

expect all `rustdoc` related compiling phase will be exlcuded, but from the log we can see `rustdoc_tool_binary` is still compiled. 

`src/tools/rustdoc` and `src/librustdoc` are documented as aliases in path set here:
https://github.com/rust-lang/rust/blob/a25435bcf7cfc9b953d356eda3a51db8da9e3386/src/bootstrap/src/core/builder/mod.rs#L355-L360

we can also see here two paths are treated as alias:
https://github.com/rust-lang/rust/blob/a25435bcf7cfc9b953d356eda3a51db8da9e3386/src/bootstrap/src/core/build_steps/check.rs#L818-L822


but bootstrap registered them as two different sets with `.path(..).path(...)`:
https://github.com/rust-lang/rust/blob/a25435bcf7cfc9b953d356eda3a51db8da9e3386/src/bootstrap/src/core/build_steps/tool.rs#L691-L693

That meant commands like `x build --skip rustdoc`, `--skip src/tools/rustdoc`, or `--skip src/librustdoc` only excluded one side.