### PR TITLE
report the `varargs_without_pattern` lint in deps

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -5558,7 +5558,8 @@ declare_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust
+    #[cfg_attr(bootstrap, doc = "```rust")]
+    #[cfg_attr(not(bootstrap), doc = "```rust,compile_fail")]
     /// // Using `...` in non-foreign function definitions is unstable, however stability is
     /// // currently only checked after attributes are expanded, so using `#[cfg(false)]` here will
     /// // allow this to compile on stable Rust.
@@ -5566,7 +5567,7 @@ declare_lint! {
     /// fn foo(...) {
     ///
     /// }
-    /// ```
+    #[doc = "```"]
     ///
     /// {{produces}}
     ///
@@ -5590,10 +5591,10 @@ declare_lint! {
     ///
     /// [future-incompatible]: ../index.md#future-incompatible-lints
     pub VARARGS_WITHOUT_PATTERN,
-    Warn,
+    Deny,
     "detects usage of `...` arguments without a pattern in non-foreign items",
     @future_incompatible = FutureIncompatibleInfo {
         reason: fcw!(FutureReleaseError #145544),
-        report_in_deps: false,
+        report_in_deps: true,
     };
 }

--- a/tests/ui/c-variadic/parse-errors.e2015.stderr
+++ b/tests/ui/c-variadic/parse-errors.e2015.stderr
@@ -44,3 +44,60 @@ LL |         unsafe extern "C" fn f(_: ...) {}
 
 error: aborting due to 3 previous errors
 
+Future incompatibility report: Future breakage diagnostic:
+error: missing pattern for `...` argument
+  --> $DIR/parse-errors.rs:11:28
+   |
+LL |     unsafe extern "C" fn f(...) {
+   |                            ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #145544 <https://github.com/rust-lang/rust/issues/145544>
+note: the lint level is defined here
+  --> $DIR/parse-errors.rs:7:9
+   |
+LL | #![deny(varargs_without_pattern)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+help: name the argument, or use `_` to continue ignoring it
+   |
+LL |     unsafe extern "C" fn f(_: ...) {
+   |                            ++
+
+Future breakage diagnostic:
+error: missing pattern for `...` argument
+  --> $DIR/parse-errors.rs:14:32
+   |
+LL |         unsafe extern "C" fn f(...) {}
+   |                                ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #145544 <https://github.com/rust-lang/rust/issues/145544>
+note: the lint level is defined here
+  --> $DIR/parse-errors.rs:7:9
+   |
+LL | #![deny(varargs_without_pattern)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+help: name the argument, or use `_` to continue ignoring it
+   |
+LL |         unsafe extern "C" fn f(_: ...) {}
+   |                                ++
+
+Future breakage diagnostic:
+error: missing pattern for `...` argument
+  --> $DIR/parse-errors.rs:20:32
+   |
+LL |         unsafe extern "C" fn f(...) {}
+   |                                ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #145544 <https://github.com/rust-lang/rust/issues/145544>
+note: the lint level is defined here
+  --> $DIR/parse-errors.rs:7:9
+   |
+LL | #![deny(varargs_without_pattern)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+help: name the argument, or use `_` to continue ignoring it
+   |
+LL |         unsafe extern "C" fn f(_: ...) {}
+   |                                ++
+

--- a/tests/ui/c-variadic/parse-errors.e2018.stderr
+++ b/tests/ui/c-variadic/parse-errors.e2018.stderr
@@ -57,3 +57,79 @@ LL |         unsafe extern "C" fn f(_: ...) {}
 
 error: aborting due to 4 previous errors
 
+Future incompatibility report: Future breakage diagnostic:
+error: missing pattern for `...` argument
+  --> $DIR/parse-errors.rs:11:28
+   |
+LL |     unsafe extern "C" fn f(...) {
+   |                            ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #145544 <https://github.com/rust-lang/rust/issues/145544>
+note: the lint level is defined here
+  --> $DIR/parse-errors.rs:7:9
+   |
+LL | #![deny(varargs_without_pattern)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+help: name the argument, or use `_` to continue ignoring it
+   |
+LL |     unsafe extern "C" fn f(_: ...) {
+   |                            ++
+
+Future breakage diagnostic:
+error: missing pattern for `...` argument
+  --> $DIR/parse-errors.rs:14:32
+   |
+LL |         unsafe extern "C" fn f(...) {}
+   |                                ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #145544 <https://github.com/rust-lang/rust/issues/145544>
+note: the lint level is defined here
+  --> $DIR/parse-errors.rs:7:9
+   |
+LL | #![deny(varargs_without_pattern)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+help: name the argument, or use `_` to continue ignoring it
+   |
+LL |         unsafe extern "C" fn f(_: ...) {}
+   |                                ++
+
+Future breakage diagnostic:
+error: missing pattern for `...` argument
+  --> $DIR/parse-errors.rs:20:32
+   |
+LL |         unsafe extern "C" fn f(...) {}
+   |                                ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #145544 <https://github.com/rust-lang/rust/issues/145544>
+note: the lint level is defined here
+  --> $DIR/parse-errors.rs:7:9
+   |
+LL | #![deny(varargs_without_pattern)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+help: name the argument, or use `_` to continue ignoring it
+   |
+LL |         unsafe extern "C" fn f(_: ...) {}
+   |                                ++
+
+Future breakage diagnostic:
+error: missing pattern for `...` argument
+  --> $DIR/parse-errors.rs:26:32
+   |
+LL |         unsafe extern "C" fn f(...) {}
+   |                                ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #145544 <https://github.com/rust-lang/rust/issues/145544>
+note: the lint level is defined here
+  --> $DIR/parse-errors.rs:7:9
+   |
+LL | #![deny(varargs_without_pattern)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+help: name the argument, or use `_` to continue ignoring it
+   |
+LL |         unsafe extern "C" fn f(_: ...) {}
+   |                                ++
+

--- a/tests/ui/thir-print/c-variadic.stderr
+++ b/tests/ui/thir-print/c-variadic.stderr
@@ -1,0 +1,12 @@
+Future incompatibility report: Future breakage diagnostic:
+warning: missing pattern for `...` argument
+  --> $DIR/c-variadic.rs:7:34
+   |
+LL | unsafe extern "C" fn foo(_: i32, ...) {}
+   |                                  ^^^
+   |
+help: name the argument, or use `_` to continue ignoring it
+   |
+LL | unsafe extern "C" fn foo(_: i32, _: ...) {}
+   |                                  ++
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/154599)*
<!-- homu-ignore:end -->

tracking issue: https://github.com/rust-lang/rust/issues/44930

After discussion in https://github.com/rust-lang/reference/pull/2177#discussion_r2864885208.

Based on https://github.com/rust-lang/rust/pull/143619#issuecomment-3133157725 there was only one actual impacted crate https://crates.io/crates/binrw. The issue was fixed in https://github.com/jam1garner/binrw/issues/342, and has since been released https://github.com/jam1garner/binrw/issues/342#issuecomment-3994700268.

Hence we may as well report this loudly.

r? @ghost