### PR TITLE
rustdoc-json: Expose Item stability

### DIFF
--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -75,6 +75,7 @@ impl JsonRenderer<'_> {
             name: name.map(|sym| sym.to_string()),
             span: span.and_then(|span| span.into_json(self)),
             visibility: visibility.into_json(self),
+            stability: item.stability(self.tcx).into_json(self),
             docs,
             attrs,
             deprecation: deprecation.into_json(self),
@@ -200,6 +201,18 @@ impl FromClean<attrs::Deprecation> for Deprecation {
             DeprecatedSince::Unspecified | DeprecatedSince::Err => None,
         };
         Deprecation { since, note: note.map(|sym| sym.to_string()) }
+    }
+}
+
+impl FromClean<hir::Stability> for Stability {
+    fn from_clean(stab: &hir::Stability, _renderer: &JsonRenderer<'_>) -> Self {
+        Stability {
+            feature: stab.feature.to_string(),
+            level: match stab.level {
+                hir::StabilityLevel::Unstable { .. } => StabilityLevel::Unstable,
+                hir::StabilityLevel::Stable { .. } => StabilityLevel::Stable,
+            },
+        }
     }
 }
 
@@ -922,6 +935,8 @@ fn maybe_from_hir_attr(attr: &hir::Attribute, item_id: ItemId, tcx: TyCtxt<'_>) 
 
     vec![match kind {
         AK::Deprecated { .. } => return Vec::new(), // Handled separately into Item::deprecation.
+        AK::Stability { .. } => return Vec::new(),  // Handled separately into Item::stability
+
         AK::DocComment { .. } => unreachable!("doc comments stripped out earlier"),
 
         AK::MacroExport { .. } => Attribute::MacroExport,

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -361,6 +361,6 @@ mod size_asserts {
     // tidy-alphabetical-end
 
     // These contains a `PathBuf`, which is different sizes on different OSes.
-    static_assert_size!(Item, 528 + size_of::<std::path::PathBuf>());
+    static_assert_size!(Item, 560 + size_of::<std::path::PathBuf>());
     static_assert_size!(ExternalCrate, 48 + size_of::<std::path::PathBuf>());
 }

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -114,8 +114,8 @@ pub type FxHashMap<K, V> = HashMap<K, V>; // re-export for use in src/librustdoc
 // will instead cause conflicts. See #94591 for more. (This paragraph and the "Latest feature" line
 // are deliberately not in a doc comment, because they need not be in public docs.)
 //
-// Latest feature: Add `ExternCrate::path`.
-pub const FORMAT_VERSION: u32 = 57;
+// Latest feature: Add `Item::stability`.
+pub const FORMAT_VERSION: u32 = 58;
 
 /// The root of the emitted JSON blob.
 ///
@@ -294,8 +294,28 @@ pub struct Item {
     pub attrs: Vec<Attribute>,
     /// Information about the item’s deprecation, if present.
     pub deprecation: Option<Deprecation>,
+
+    pub stability: Option<Stability>,
+
     /// The type-specific fields describing this item.
     pub inner: ItemEnum,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "rkyv_0_8", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "rkyv_0_8", rkyv(derive(Debug)))]
+pub struct Stability {
+    pub feature: String,
+    pub level: StabilityLevel,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "rkyv_0_8", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "rkyv_0_8", rkyv(derive(Debug)))]
+#[serde(rename_all = "snake_case")]
+pub enum StabilityLevel {
+    Stable,
+    Unstable,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/tools/jsondoclint/src/validator/tests.rs
+++ b/src/tools/jsondoclint/src/validator/tests.rs
@@ -33,6 +33,7 @@ fn errors_on_missing_links() {
                 links: FxHashMap::from_iter([("Not Found".to_owned(), Id(1))]),
                 attrs: vec![],
                 deprecation: None,
+                stability: None,
                 inner: ItemEnum::Module(Module {
                     is_crate: true,
                     items: vec![],
@@ -81,6 +82,7 @@ fn errors_on_local_in_paths_and_not_index() {
                     links: FxHashMap::from_iter([("prim@i32".to_owned(), Id(2))]),
                     attrs: Vec::new(),
                     deprecation: None,
+                    stability: None,
                     inner: ItemEnum::Module(Module {
                         is_crate: true,
                         items: vec![Id(1)],
@@ -100,6 +102,7 @@ fn errors_on_local_in_paths_and_not_index() {
                     links: FxHashMap::default(),
                     attrs: Vec::new(),
                     deprecation: None,
+                    stability: None,
                     inner: ItemEnum::Primitive(Primitive { name: "i32".to_owned(), impls: vec![] }),
                 },
             ),
@@ -153,6 +156,7 @@ fn errors_on_missing_path() {
                     links: FxHashMap::default(),
                     attrs: Vec::new(),
                     deprecation: None,
+                    stability: None,
                     inner: ItemEnum::Module(Module {
                         is_crate: true,
                         items: vec![Id(1), Id(2)],
@@ -172,6 +176,7 @@ fn errors_on_missing_path() {
                     links: FxHashMap::default(),
                     attrs: Vec::new(),
                     deprecation: None,
+                    stability: None,
                     inner: ItemEnum::Struct(Struct {
                         kind: StructKind::Unit,
                         generics: generics.clone(),
@@ -191,6 +196,7 @@ fn errors_on_missing_path() {
                     links: FxHashMap::default(),
                     attrs: Vec::new(),
                     deprecation: None,
+                    stability: None,
                     inner: ItemEnum::Function(Function {
                         sig: FunctionSignature {
                             inputs: vec![],
@@ -253,6 +259,7 @@ fn checks_local_crate_id_is_correct() {
                 links: FxHashMap::default(),
                 attrs: Vec::new(),
                 deprecation: None,
+                stability: None,
                 inner: ItemEnum::Module(Module {
                     is_crate: true,
                     items: vec![],

--- a/tests/rustdoc-json/attrs/stability/stable.rs
+++ b/tests/rustdoc-json/attrs/stability/stable.rs
@@ -1,0 +1,7 @@
+#![feature(staged_api)]
+
+//@ is "$.index[?(@.name=='foo')].stability.level" '"stable"'
+//@ is "$.index[?(@.name=='foo')].stability.feature" '"eeeee"'
+//@ is "$.index[?(@.name=='foo')].attrs" []
+#[stable(since = "2.71.8", feature = "eeeee")]
+pub fn foo() {}

--- a/tests/rustdoc-json/attrs/stability/unmarked.rs
+++ b/tests/rustdoc-json/attrs/stability/unmarked.rs
@@ -1,0 +1,3 @@
+//@ is "$.index[?(@.name=='foo')].stability" null
+//@ is "$.index[?(@.name=='foo')].attrs" []
+pub fn foo() {}

--- a/tests/rustdoc-json/attrs/stability/unstable.rs
+++ b/tests/rustdoc-json/attrs/stability/unstable.rs
@@ -1,0 +1,7 @@
+#![feature(staged_api)]
+
+//@ is "$.index[?(@.name=='foo')].stability.level" '"unstable"'
+//@ is "$.index[?(@.name=='foo')].stability.feature" '"delights"'
+//@ is "$.index[?(@.name=='foo')].attrs" []
+#[unstable(feature = "delights", issue = "26")]
+pub fn foo() {}


### PR DESCRIPTION
This is motivated by cargo-semver-checks wanting to work on the standard library, but that requires being able to filter out breaking changes to unstable items, so it can only flag breaking changes to stable items. This in turn is motivated by
https://github.com/rust-lang/rust/issues/153486.


## TODO

- [x] Decide if this should be a field on `Item`, or a variant on `Attributes`
  - Field on `Item`
- [X] Decide what additional information is needed on `StabilityLevel`
  - None for now.
- [ ] Docs
- [ ] Tests around stability propagation and re-exports

CC @obi1kenobi 
