### PR TITLE
abort in core

### DIFF
--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -364,6 +364,8 @@ pub fn rustc_peek<T>(_: T) -> T;
 /// On Unix, the
 /// process will probably terminate with a signal like `SIGABRT`, `SIGILL`, `SIGTRAP`, `SIGSEGV` or
 /// `SIGBUS`.  The precise behavior is not guaranteed and not stable.
+///
+/// The stabilization-track version of this intrinsic is [`core::process::abort_immediate`].
 #[rustc_nounwind]
 #[rustc_intrinsic]
 pub fn abort() -> !;

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -305,6 +305,8 @@ pub mod panicking;
 #[unstable(feature = "pattern_type_macro", issue = "123646")]
 pub mod pat;
 pub mod pin;
+#[unstable(feature = "abort_immediate", issue = "154601")]
+pub mod process;
 #[unstable(feature = "random", issue = "130703")]
 pub mod random;
 #[stable(feature = "new_range_inclusive_api", since = "1.95.0")]

--- a/library/core/src/process.rs
+++ b/library/core/src/process.rs
@@ -1,0 +1,38 @@
+/// Terminates the process in a violent fashion.
+///
+/// The function will never return and will immediately terminate the current
+/// process in a platform specific "abnormal" manner. As a consequence,
+/// no destructors on the current stack or any other thread's stack
+/// will be run, Rust IO buffers (eg, from `BufWriter`) will not be flushed,
+/// and C stdio buffers will not be flushed.
+///
+/// Unlike [`abort`](../../std/process/fn.abort.html), `abort_immediate` does
+/// not attempt to match C `abort()` or otherwise perform a "clean" abort.
+/// Instead, it emits code that will crash the process with as little overhead
+/// as possible, such as a "halt and catch fire" style instruction. You should
+/// generally prefer using `abort` instead except where the absolute minimum
+/// overhead is required.
+///
+/// # Platform-specific behavior
+///
+/// `abort_immediate` lowers to a trap instruction on *most* architectures; on
+/// some architectures it simply lowers to call the unmangled `abort` function.
+/// The exact behavior is architecture and system dependent.
+///
+/// On bare-metal (no OS) systems the trap instruction usually causes a
+/// *hardware* exception to be raised in a *synchronous* fashion; hardware
+/// exceptions have nothing to do with C++ exceptions and are closer in
+/// semantics to POSIX signals.
+///
+/// On hosted applications (applications running under an OS), the trap
+/// instruction *usually* terminates the whole process with an exit code that
+/// corresponds to `SIGILL` or equivalent, *unless* this signal is handled.
+/// Other signals such as `SIGABRT`, `SIGTRAP`, `SIGSEGV`, and `SIGBUS` may be
+/// produced instead, depending on specifics. This is not an exhaustive list.
+#[unstable(feature = "abort_immediate", issue = "154601")]
+#[cold]
+#[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+#[doc(alias = "halt")]
+pub fn abort_immediate() -> ! {
+    crate::intrinsics::abort()
+}

--- a/library/core/src/process.rs
+++ b/library/core/src/process.rs
@@ -1,3 +1,8 @@
+//! A module for working with processes.
+//!
+//! Most process-related functionality requires std, but [`abort_immediate`]
+//! is available on all targets.
+
 /// Terminates the process in a violent fashion.
 ///
 /// The function will never return and will immediately terminate the current

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -2536,6 +2536,10 @@ pub fn abort() -> ! {
     crate::sys::abort_internal();
 }
 
+#[doc(inline)]
+#[unstable(feature = "abort_immediate", issue = "154601")]
+pub use core::process::abort_immediate;
+
 /// Returns the OS-assigned process identifier associated with this process.
 ///
 /// # Examples


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/154604)*
<!-- homu-ignore:end -->

Implements `core::process::abort_immediate` as a wrapper around `intrinsics::abort`.

- tracking issue: https://github.com/rust-lang/rust/issues/154601

(This PR used to also add `core::process::abort`, but that's been deferred to a later addition.)