### PR TITLE
Make `span_suggestions` always verbose

### DIFF
--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -983,7 +983,7 @@ impl<'a, G: EmissionGuarantee> Diag<'a, G> {
             msg,
             suggestions,
             applicability,
-            SuggestionStyle::ShowCode,
+            SuggestionStyle::ShowAlways,
         )
     } }
 

--- a/src/tools/clippy/tests/ui/blocks_in_conditions.stderr
+++ b/src/tools/clippy/tests/ui/blocks_in_conditions.stderr
@@ -29,10 +29,15 @@ error: this boolean expression can be simplified
   --> tests/ui/blocks_in_conditions.rs:48:8
    |
 LL |     if true && x == 3 { 6 } else { 10 }
-   |        ^^^^^^^^^^^^^^ help: try: `x == 3`
+   |        ^^^^^^^^^^^^^^
    |
    = note: `-D clippy::nonminimal-bool` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::nonminimal_bool)]`
+help: try
+   |
+LL -     if true && x == 3 { 6 } else { 10 }
+LL +     if x == 3 { 6 } else { 10 }
+   |
 
 error: aborting due to 3 previous errors
 

--- a/src/tools/clippy/tests/ui/crashes/ice-96721.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-96721.stderr
@@ -2,9 +2,14 @@ error: malformed `path` attribute input
   --> tests/ui/crashes/ice-96721.rs:7:1
    |
 LL | #[path = foo!()]
-   | ^^^^^^^^^^^^^^^^ help: must be of the form: `#[path = "file"]`
+   | ^^^^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/modules.html#the-path-attribute>
+help: must be of the form
+   |
+LL - #[path = foo!()]
+LL + #[path = "file"]
+   |
 
 error: aborting due to 1 previous error
 

--- a/src/tools/clippy/tests/ui/nonminimal_bool.stderr
+++ b/src/tools/clippy/tests/ui/nonminimal_bool.stderr
@@ -2,46 +2,87 @@ error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool.rs:17:13
    |
 LL |     let _ = !true;
-   |             ^^^^^ help: try: `false`
+   |             ^^^^^
    |
    = note: `-D clippy::nonminimal-bool` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::nonminimal_bool)]`
+help: try
+   |
+LL -     let _ = !true;
+LL +     let _ = false;
+   |
 
 error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool.rs:20:13
    |
 LL |     let _ = !false;
-   |             ^^^^^^ help: try: `true`
+   |             ^^^^^^
+   |
+help: try
+   |
+LL -     let _ = !false;
+LL +     let _ = true;
+   |
 
 error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool.rs:23:13
    |
 LL |     let _ = !!a;
-   |             ^^^ help: try: `a`
+   |             ^^^
+   |
+help: try
+   |
+LL -     let _ = !!a;
+LL +     let _ = a;
+   |
 
 error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool.rs:26:13
    |
 LL |     let _ = false || a;
-   |             ^^^^^^^^^^ help: try: `a`
+   |             ^^^^^^^^^^
+   |
+help: try
+   |
+LL -     let _ = false || a;
+LL +     let _ = a;
+   |
 
 error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool.rs:32:13
    |
 LL |     let _ = !(!a && b);
-   |             ^^^^^^^^^^ help: try: `a || !b`
+   |             ^^^^^^^^^^
+   |
+help: try
+   |
+LL -     let _ = !(!a && b);
+LL +     let _ = a || !b;
+   |
 
 error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool.rs:35:13
    |
 LL |     let _ = !(!a || b);
-   |             ^^^^^^^^^^ help: try: `a && !b`
+   |             ^^^^^^^^^^
+   |
+help: try
+   |
+LL -     let _ = !(!a || b);
+LL +     let _ = a && !b;
+   |
 
 error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool.rs:38:13
    |
 LL |     let _ = !a && !(b && c);
-   |             ^^^^^^^^^^^^^^^ help: try: `!(a || b && c)`
+   |             ^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     let _ = !a && !(b && c);
+LL +     let _ = !(a || b && c);
+   |
 
 error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool.rs:47:13
@@ -122,7 +163,13 @@ error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool.rs:90:8
    |
 LL |     if matches!(true, true) && true {
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `matches!(true, true)`
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if matches!(true, true) && true {
+LL +     if matches!(true, true) {
+   |
 
 error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool.rs:171:8
@@ -215,13 +262,25 @@ error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool.rs:212:8
    |
 LL |     if !(a < 2.0 && !b) {
-   |        ^^^^^^^^^^^^^^^^ help: try: `a >= 2.0 || b`
+   |        ^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     if !(a < 2.0 && !b) {
+LL +     if a >= 2.0 || b {
+   |
 
 error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool.rs:231:12
    |
 LL |         if !(matches!(ty, TyKind::Ref(_, _, _)) && !is_mutable(&expr)) {
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `!matches!(ty, TyKind::Ref(_, _, _)) || is_mutable(&expr)`
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -         if !(matches!(ty, TyKind::Ref(_, _, _)) && !is_mutable(&expr)) {
+LL +         if !matches!(ty, TyKind::Ref(_, _, _)) || is_mutable(&expr) {
+   |
 
 error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool.rs:251:8

--- a/src/tools/clippy/tests/ui/nonminimal_bool_methods.stderr
+++ b/src/tools/clippy/tests/ui/nonminimal_bool_methods.stderr
@@ -29,13 +29,25 @@ error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool_methods.rs:20:13
    |
 LL |     let _ = !(a.is_some() && !c);
-   |             ^^^^^^^^^^^^^^^^^^^^ help: try: `a.is_none() || c`
+   |             ^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     let _ = !(a.is_some() && !c);
+LL +     let _ = a.is_none() || c;
+   |
 
 error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool_methods.rs:22:13
    |
 LL |     let _ = !(a.is_some() || !c);
-   |             ^^^^^^^^^^^^^^^^^^^^ help: try: `a.is_none() && c`
+   |             ^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -     let _ = !(a.is_some() || !c);
+LL +     let _ = a.is_none() && c;
+   |
 
 error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool_methods.rs:24:26

--- a/tests/ui/allocator/allocator-args.stderr
+++ b/tests/ui/allocator/allocator-args.stderr
@@ -2,7 +2,13 @@ error: malformed `global_allocator` attribute input
   --> $DIR/allocator-args.rs:10:1
    |
 LL | #[global_allocator(malloc)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[global_allocator]`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: must be of the form
+   |
+LL - #[global_allocator(malloc)]
+LL + #[global_allocator]
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/attributes/crate-type-delimited.stderr
+++ b/tests/ui/attributes/crate-type-delimited.stderr
@@ -2,9 +2,14 @@ error[E0539]: malformed `crate_type` attribute input
   --> $DIR/crate-type-delimited.rs:2:1
    |
 LL | #![crate_type(lib)]
-   | ^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#![crate_type = "crate type"]`
+   | ^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/linkage.html>
+help: must be of the form
+   |
+LL - #![crate_type(lib)]
+LL + #![crate_type = "crate type"]
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/attributes/crate-type-empty.stderr
+++ b/tests/ui/attributes/crate-type-empty.stderr
@@ -2,9 +2,13 @@ error[E0539]: malformed `crate_type` attribute input
   --> $DIR/crate-type-empty.rs:2:1
    |
 LL | #![crate_type]
-   | ^^^^^^^^^^^^^^ help: must be of the form: `#![crate_type = "crate type"]`
+   | ^^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/linkage.html>
+help: must be of the form
+   |
+LL | #![crate_type = "crate type"]
+   |               ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/attributes/crate-type-non-crate.stderr
+++ b/tests/ui/attributes/crate-type-non-crate.stderr
@@ -2,25 +2,39 @@ error[E0539]: malformed `crate_type` attribute input
   --> $DIR/crate-type-non-crate.rs:5:1
    |
 LL | #[crate_type]
-   | ^^^^^^^^^^^^^ help: must be of the form: `#[crate_type = "crate type"]`
+   | ^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/linkage.html>
+help: must be of the form
+   |
+LL | #[crate_type = "crate type"]
+   |              ++++++++++++++
 
 error[E0539]: malformed `crate_type` attribute input
   --> $DIR/crate-type-non-crate.rs:7:1
    |
 LL | #[crate_type(lib)]
-   | ^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[crate_type = "crate type"]`
+   | ^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/linkage.html>
+help: must be of the form
+   |
+LL - #[crate_type(lib)]
+LL + #[crate_type = "crate type"]
+   |
 
 error[E0539]: malformed `crate_type` attribute input
   --> $DIR/crate-type-non-crate.rs:8:1
    |
 LL | #[crate_type("lib")]
-   | ^^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[crate_type = "crate type"]`
+   | ^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/linkage.html>
+help: must be of the form
+   |
+LL - #[crate_type("lib")]
+LL + #[crate_type = "crate type"]
+   |
 
 error: attribute value must be a literal
   --> $DIR/crate-type-non-crate.rs:9:16
@@ -32,17 +46,27 @@ error[E0539]: malformed `crate_type` attribute input
   --> $DIR/crate-type-non-crate.rs:12:1
    |
 LL | #[crate_type(foo)]
-   | ^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[crate_type = "crate type"]`
+   | ^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/linkage.html>
+help: must be of the form
+   |
+LL - #[crate_type(foo)]
+LL + #[crate_type = "crate type"]
+   |
 
 error[E0539]: malformed `crate_type` attribute input
   --> $DIR/crate-type-non-crate.rs:13:1
    |
 LL | #[crate_type("foo")]
-   | ^^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[crate_type = "crate type"]`
+   | ^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/linkage.html>
+help: must be of the form
+   |
+LL - #[crate_type("foo")]
+LL + #[crate_type = "crate type"]
+   |
 
 error: attribute value must be a literal
   --> $DIR/crate-type-non-crate.rs:14:16
@@ -54,20 +78,29 @@ error[E0539]: malformed `crate_type` attribute input
   --> $DIR/crate-type-non-crate.rs:17:1
    |
 LL | #[crate_type(1)]
-   | ^^^^^^^^^^^^^^^^ help: must be of the form: `#[crate_type = "crate type"]`
+   | ^^^^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/linkage.html>
+help: must be of the form
+   |
+LL - #[crate_type(1)]
+LL + #[crate_type = "crate type"]
+   |
 
 error[E0539]: malformed `crate_type` attribute input
   --> $DIR/crate-type-non-crate.rs:18:1
    |
 LL | #[crate_type = 1]
    | ^^^^^^^^^^^^^^^-^
-   | |              |
-   | |              expected a string literal here
-   | help: must be of the form: `#[crate_type = "crate type"]`
+   |                |
+   |                expected a string literal here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/linkage.html>
+help: must be of the form
+   |
+LL - #[crate_type = 1]
+LL + #[crate_type = "crate type"]
+   |
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/attributes/expected-word.stderr
+++ b/tests/ui/attributes/expected-word.stderr
@@ -3,9 +3,14 @@ error[E0565]: malformed `cold` attribute input
    |
 LL | #[cold = true]
    | ^^^^^^^------^
-   | |      |
-   | |      didn't expect any arguments here
-   | help: must be of the form: `#[cold]`
+   |        |
+   |        didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[cold = true]
+LL + #[cold]
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/attributes/instruction-set.stderr
+++ b/tests/ui/attributes/instruction-set.stderr
@@ -3,11 +3,15 @@ error[E0539]: malformed `instruction_set` attribute input
    |
 LL | #[instruction_set(arm)]
    | ^^^^^^^^^^^^^^^^^^---^^
-   | |                 |
-   | |                 valid arguments are `arm::a32` or `arm::t32`
-   | help: must be of the form: `#[instruction_set(set)]`
+   |                   |
+   |                   valid arguments are `arm::a32` or `arm::t32`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute>
+help: must be of the form
+   |
+LL - #[instruction_set(arm)]
+LL + #[instruction_set(set)]
+   |
 
 error: expected identifier, found `<eof>`
   --> $DIR/instruction-set.rs:26:22
@@ -20,11 +24,15 @@ error[E0539]: malformed `instruction_set` attribute input
    |
 LL | #[instruction_set(arm::magic)]
    | ^^^^^^^^^^^^^^^^^^^^^^^-----^^
-   | |                      |
-   | |                      valid arguments are `a32` or `t32`
-   | help: must be of the form: `#[instruction_set(set)]`
+   |                        |
+   |                        valid arguments are `a32` or `t32`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute>
+help: must be of the form
+   |
+LL - #[instruction_set(arm::magic)]
+LL + #[instruction_set(set)]
+   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/attributes/invalid-debugger-visualizer-option.stderr
+++ b/tests/ui/attributes/invalid-debugger-visualizer-option.stderr
@@ -9,11 +9,15 @@ error[E0539]: malformed `debugger_visualizer` attribute input
    |
 LL | #![debugger_visualizer(random_file = "../foo.random")]
    | ^^^^^^^^^^^^^^^^^^^^^^^-----------^^^^^^^^^^^^^^^^^^^^
-   | |                      |
-   | |                      valid arguments are `natvis_file` or `gdb_script_file`
-   | help: must be of the form: `#![debugger_visualizer(natvis_file = "...", gdb_script_file = "...")]`
+   |                        |
+   |                        valid arguments are `natvis_file` or `gdb_script_file`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/debugger.html#the-debugger_visualizer-attribute>
+help: must be of the form
+   |
+LL - #![debugger_visualizer(random_file = "../foo.random")]
+LL + #![debugger_visualizer(natvis_file = "...", gdb_script_file = "...")]
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/attributes/invalid_rustc_layout_scalar_valid_range.stderr
+++ b/tests/ui/attributes/invalid_rustc_layout_scalar_valid_range.stderr
@@ -3,27 +3,42 @@ error[E0539]: malformed `rustc_layout_scalar_valid_range_start` attribute input
    |
 LL | #[rustc_layout_scalar_valid_range_start(u32::MAX)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------^^
-   | |                                       |
-   | |                                       expected an integer literal here
-   | help: must be of the form: `#[rustc_layout_scalar_valid_range_start(start)]`
+   |                                         |
+   |                                         expected an integer literal here
+   |
+help: must be of the form
+   |
+LL - #[rustc_layout_scalar_valid_range_start(u32::MAX)]
+LL + #[rustc_layout_scalar_valid_range_start(start)]
+   |
 
 error[E0805]: malformed `rustc_layout_scalar_valid_range_end` attribute input
   --> $DIR/invalid_rustc_layout_scalar_valid_range.rs:6:1
    |
 LL | #[rustc_layout_scalar_valid_range_end(1, 2)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------^
-   | |                                    |
-   | |                                    expected a single argument here
-   | help: must be of the form: `#[rustc_layout_scalar_valid_range_end(end)]`
+   |                                      |
+   |                                      expected a single argument here
+   |
+help: must be of the form
+   |
+LL - #[rustc_layout_scalar_valid_range_end(1, 2)]
+LL + #[rustc_layout_scalar_valid_range_end(end)]
+   |
 
 error[E0539]: malformed `rustc_layout_scalar_valid_range_end` attribute input
   --> $DIR/invalid_rustc_layout_scalar_valid_range.rs:9:1
    |
 LL | #[rustc_layout_scalar_valid_range_end(a = "a")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------^^
-   | |                                     |
-   | |                                     expected an integer literal here
-   | help: must be of the form: `#[rustc_layout_scalar_valid_range_end(end)]`
+   |                                       |
+   |                                       expected an integer literal here
+   |
+help: must be of the form
+   |
+LL - #[rustc_layout_scalar_valid_range_end(a = "a")]
+LL + #[rustc_layout_scalar_valid_range_end(end)]
+   |
 
 error: `#[rustc_layout_scalar_valid_range_end]` attribute cannot be used on enums
   --> $DIR/invalid_rustc_layout_scalar_valid_range.rs:12:1
@@ -38,9 +53,14 @@ error[E0539]: malformed `rustc_layout_scalar_valid_range_start` attribute input
    |
 LL | #[rustc_layout_scalar_valid_range_start(rustc_layout_scalar_valid_range_start)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------------------------------^^
-   | |                                       |
-   | |                                       expected an integer literal here
-   | help: must be of the form: `#[rustc_layout_scalar_valid_range_start(start)]`
+   |                                         |
+   |                                         expected an integer literal here
+   |
+help: must be of the form
+   |
+LL - #[rustc_layout_scalar_valid_range_start(rustc_layout_scalar_valid_range_start)]
+LL + #[rustc_layout_scalar_valid_range_start(start)]
+   |
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -2,23 +2,25 @@ error[E0539]: malformed `cfg` attribute input
   --> $DIR/malformed-attrs.rs:106:1
    |
 LL | #[cfg]
-   | ^^^^^^
-   | |
-   | expected this to be a list
-   | help: must be of the form: `#[cfg(predicate)]`
+   | ^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL | #[cfg(predicate)]
+   |      +++++++++++
 
 error[E0539]: malformed `cfg_attr` attribute input
   --> $DIR/malformed-attrs.rs:108:1
    |
 LL | #[cfg_attr]
-   | ^^^^^^^^^^^
-   | |
-   | expected this to be a list
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   | ^^^^^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL | #[cfg_attr(predicate, attr1, attr2, ...)]
+   |           ++++++++++++++++++++++++++++++
 
 error[E0463]: can't find crate for `wloop`
   --> $DIR/malformed-attrs.rs:214:1
@@ -153,7 +155,13 @@ error[E0539]: malformed `export_name` attribute input
   --> $DIR/malformed-attrs.rs:29:1
    |
 LL | #[unsafe(export_name)]
-   | ^^^^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[export_name = "name"]`
+   | ^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: must be of the form
+   |
+LL - #[unsafe(export_name)]
+LL + #[export_name = "name"]
+   |
 
 error: `rustc_allow_const_fn_unstable` expects a list of feature names
   --> $DIR/malformed-attrs.rs:31:1
@@ -171,10 +179,12 @@ error[E0539]: malformed `rustc_confusables` attribute input
   --> $DIR/malformed-attrs.rs:36:1
    |
 LL | #[rustc_confusables]
-   | ^^^^^^^^^^^^^^^^^^^^
-   | |
-   | expected this to be a list
-   | help: must be of the form: `#[rustc_confusables("name1", "name2", ...)]`
+   | ^^^^^^^^^^^^^^^^^^^^ expected this to be a list
+   |
+help: must be of the form
+   |
+LL | #[rustc_confusables("name1", "name2", ...)]
+   |                    +++++++++++++++++++++++
 
 error: `#[rustc_confusables]` attribute cannot be used on functions
   --> $DIR/malformed-attrs.rs:36:1
@@ -228,18 +238,25 @@ error[E0565]: malformed `rustc_as_ptr` attribute input
    |
 LL | #[rustc_as_ptr = 5]
    | ^^^^^^^^^^^^^^^---^
-   | |              |
-   | |              didn't expect any arguments here
-   | help: must be of the form: `#[rustc_as_ptr]`
+   |                |
+   |                didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[rustc_as_ptr = 5]
+LL + #[rustc_as_ptr]
+   |
 
 error[E0539]: malformed `rustc_align` attribute input
   --> $DIR/malformed-attrs.rs:54:1
    |
 LL | #[rustc_align]
-   | ^^^^^^^^^^^^^^
-   | |
-   | expected this to be a list
-   | help: must be of the form: `#[rustc_align(<alignment in bytes>)]`
+   | ^^^^^^^^^^^^^^ expected this to be a list
+   |
+help: must be of the form
+   |
+LL | #[rustc_align(<alignment in bytes>)]
+   |              ++++++++++++++++++++++
 
 error[E0539]: malformed `optimize` attribute input
   --> $DIR/malformed-attrs.rs:56:1
@@ -261,9 +278,14 @@ error[E0565]: malformed `cold` attribute input
    |
 LL | #[cold = 1]
    | ^^^^^^^---^
-   | |      |
-   | |      didn't expect any arguments here
-   | help: must be of the form: `#[cold]`
+   |        |
+   |        didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[cold = 1]
+LL + #[cold]
+   |
 
 error[E0539]: malformed `must_use` attribute input
   --> $DIR/malformed-attrs.rs:60:1
@@ -288,33 +310,54 @@ error[E0565]: malformed `no_mangle` attribute input
    |
 LL | #[no_mangle = 1]
    | ^^^^^^^^^^^^---^
-   | |           |
-   | |           didn't expect any arguments here
-   | help: must be of the form: `#[no_mangle]`
+   |             |
+   |             didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[no_mangle = 1]
+LL + #[no_mangle]
+   |
 
 error[E0565]: malformed `naked` attribute input
   --> $DIR/malformed-attrs.rs:64:1
    |
 LL | #[unsafe(naked())]
    | ^^^^^^^^^^^^^^--^^
-   | |             |
-   | |             didn't expect any arguments here
-   | help: must be of the form: `#[naked]`
+   |               |
+   |               didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[unsafe(naked())]
+LL + #[naked]
+   |
 
 error[E0565]: malformed `track_caller` attribute input
   --> $DIR/malformed-attrs.rs:66:1
    |
 LL | #[track_caller()]
    | ^^^^^^^^^^^^^^--^
-   | |             |
-   | |             didn't expect any arguments here
-   | help: must be of the form: `#[track_caller]`
+   |               |
+   |               didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[track_caller()]
+LL + #[track_caller]
+   |
 
 error[E0539]: malformed `export_name` attribute input
   --> $DIR/malformed-attrs.rs:68:1
    |
 LL | #[export_name()]
-   | ^^^^^^^^^^^^^^^^ help: must be of the form: `#[export_name = "name"]`
+   | ^^^^^^^^^^^^^^^^
+   |
+help: must be of the form
+   |
+LL - #[export_name()]
+LL + #[export_name = "name"]
+   |
 
 error[E0805]: malformed `used` attribute input
   --> $DIR/malformed-attrs.rs:70:1
@@ -346,25 +389,37 @@ error[E0539]: malformed `crate_name` attribute input
   --> $DIR/malformed-attrs.rs:73:1
    |
 LL | #[crate_name]
-   | ^^^^^^^^^^^^^ help: must be of the form: `#[crate_name = "name"]`
+   | ^^^^^^^^^^^^^
+   |
+help: must be of the form
+   |
+LL | #[crate_name = "name"]
+   |              ++++++++
 
 error[E0539]: malformed `target_feature` attribute input
   --> $DIR/malformed-attrs.rs:78:1
    |
 LL | #[target_feature]
-   | ^^^^^^^^^^^^^^^^^
-   | |
-   | expected this to be a list
-   | help: must be of the form: `#[target_feature(enable = "feat1, feat2")]`
+   | ^^^^^^^^^^^^^^^^^ expected this to be a list
+   |
+help: must be of the form
+   |
+LL | #[target_feature(enable = "feat1, feat2")]
+   |                 +++++++++++++++++++++++++
 
 error[E0565]: malformed `export_stable` attribute input
   --> $DIR/malformed-attrs.rs:80:1
    |
 LL | #[export_stable = 1]
    | ^^^^^^^^^^^^^^^^---^
-   | |               |
-   | |               didn't expect any arguments here
-   | help: must be of the form: `#[export_stable]`
+   |                 |
+   |                 didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[export_stable = 1]
+LL + #[export_stable]
+   |
 
 error[E0539]: malformed `link` attribute input
   --> $DIR/malformed-attrs.rs:82:1
@@ -378,17 +433,25 @@ error[E0539]: malformed `link_name` attribute input
   --> $DIR/malformed-attrs.rs:86:1
    |
 LL | #[link_name]
-   | ^^^^^^^^^^^^ help: must be of the form: `#[link_name = "name"]`
+   | ^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_name-attribute>
+help: must be of the form
+   |
+LL | #[link_name = "name"]
+   |             ++++++++
 
 error[E0539]: malformed `link_section` attribute input
   --> $DIR/malformed-attrs.rs:90:1
    |
 LL | #[link_section]
-   | ^^^^^^^^^^^^^^^ help: must be of the form: `#[link_section = "name"]`
+   | ^^^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/abi.html#the-link_section-attribute>
+help: must be of the form
+   |
+LL | #[link_section = "name"]
+   |                ++++++++
 
 error[E0539]: malformed `coverage` attribute input
   --> $DIR/malformed-attrs.rs:92:1
@@ -414,56 +477,79 @@ error[E0565]: malformed `no_implicit_prelude` attribute input
    |
 LL | #[no_implicit_prelude = 23]
    | ^^^^^^^^^^^^^^^^^^^^^^----^
-   | |                     |
-   | |                     didn't expect any arguments here
-   | help: must be of the form: `#[no_implicit_prelude]`
+   |                       |
+   |                       didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[no_implicit_prelude = 23]
+LL + #[no_implicit_prelude]
+   |
 
 error[E0565]: malformed `proc_macro` attribute input
   --> $DIR/malformed-attrs.rs:103:1
    |
 LL | #[proc_macro = 18]
    | ^^^^^^^^^^^^^----^
-   | |            |
-   | |            didn't expect any arguments here
-   | help: must be of the form: `#[proc_macro]`
+   |              |
+   |              didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[proc_macro = 18]
+LL + #[proc_macro]
+   |
 
 error[E0539]: malformed `instruction_set` attribute input
   --> $DIR/malformed-attrs.rs:110:1
    |
 LL | #[instruction_set]
-   | ^^^^^^^^^^^^^^^^^^
-   | |
-   | expected this to be a list
-   | help: must be of the form: `#[instruction_set(set)]`
+   | ^^^^^^^^^^^^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute>
+help: must be of the form
+   |
+LL | #[instruction_set(set)]
+   |                  +++++
 
 error[E0539]: malformed `patchable_function_entry` attribute input
   --> $DIR/malformed-attrs.rs:112:1
    |
 LL | #[patchable_function_entry]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   | |
-   | expected this to be a list
-   | help: must be of the form: `#[patchable_function_entry(prefix_nops = m, entry_nops = n)]`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected this to be a list
+   |
+help: must be of the form
+   |
+LL | #[patchable_function_entry(prefix_nops = m, entry_nops = n)]
+   |                           +++++++++++++++++++++++++++++++++
 
 error[E0565]: malformed `coroutine` attribute input
   --> $DIR/malformed-attrs.rs:115:5
    |
 LL |     #[coroutine = 63] || {}
    |     ^^^^^^^^^^^^----^
-   |     |           |
-   |     |           didn't expect any arguments here
-   |     help: must be of the form: `#[coroutine]`
+   |                 |
+   |                 didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL -     #[coroutine = 63] || {}
+LL +     #[coroutine] || {}
+   |
 
 error[E0565]: malformed `proc_macro_attribute` attribute input
   --> $DIR/malformed-attrs.rs:120:1
    |
 LL | #[proc_macro_attribute = 19]
    | ^^^^^^^^^^^^^^^^^^^^^^^----^
-   | |                      |
-   | |                      didn't expect any arguments here
-   | help: must be of the form: `#[proc_macro_attribute]`
+   |                        |
+   |                        didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[proc_macro_attribute = 19]
+LL + #[proc_macro_attribute]
+   |
 
 error[E0539]: malformed `must_use` attribute input
   --> $DIR/malformed-attrs.rs:123:1
@@ -501,19 +587,23 @@ error[E0539]: malformed `rustc_layout_scalar_valid_range_start` attribute input
   --> $DIR/malformed-attrs.rs:132:1
    |
 LL | #[rustc_layout_scalar_valid_range_start]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   | |
-   | expected this to be a list
-   | help: must be of the form: `#[rustc_layout_scalar_valid_range_start(start)]`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected this to be a list
+   |
+help: must be of the form
+   |
+LL | #[rustc_layout_scalar_valid_range_start(start)]
+   |                                        +++++++
 
 error[E0539]: malformed `rustc_layout_scalar_valid_range_end` attribute input
   --> $DIR/malformed-attrs.rs:134:1
    |
 LL | #[rustc_layout_scalar_valid_range_end]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   | |
-   | expected this to be a list
-   | help: must be of the form: `#[rustc_layout_scalar_valid_range_end(end)]`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected this to be a list
+   |
+help: must be of the form
+   |
+LL | #[rustc_layout_scalar_valid_range_end(end)]
+   |                                      +++++
 
 error[E0539]: malformed `must_not_suspend` attribute input
   --> $DIR/malformed-attrs.rs:136:1
@@ -536,56 +626,81 @@ error[E0539]: malformed `cfi_encoding` attribute input
    |
 LL | #[cfi_encoding = ""]
    | ^^^^^^^^^^^^^^^^^--^
-   | |                |
-   | |                string is not allowed to be empty
-   | help: must be of the form: `#[cfi_encoding = "encoding"]`
+   |                  |
+   |                  string is not allowed to be empty
+   |
+help: must be of the form
+   |
+LL | #[cfi_encoding = "encoding"]
+   |                   ++++++++
 
 error[E0565]: malformed `marker` attribute input
   --> $DIR/malformed-attrs.rs:157:1
    |
 LL | #[marker = 3]
    | ^^^^^^^^^---^
-   | |        |
-   | |        didn't expect any arguments here
-   | help: must be of the form: `#[marker]`
+   |          |
+   |          didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[marker = 3]
+LL + #[marker]
+   |
 
 error[E0565]: malformed `fundamental` attribute input
   --> $DIR/malformed-attrs.rs:159:1
    |
 LL | #[fundamental()]
    | ^^^^^^^^^^^^^--^
-   | |            |
-   | |            didn't expect any arguments here
-   | help: must be of the form: `#[fundamental]`
+   |              |
+   |              didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[fundamental()]
+LL + #[fundamental]
+   |
 
 error[E0565]: malformed `ffi_pure` attribute input
   --> $DIR/malformed-attrs.rs:167:5
    |
 LL |     #[unsafe(ffi_pure = 1)]
    |     ^^^^^^^^^^^^^^^^^^---^^
-   |     |                 |
-   |     |                 didn't expect any arguments here
-   |     help: must be of the form: `#[ffi_pure]`
+   |                       |
+   |                       didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL -     #[unsafe(ffi_pure = 1)]
+LL +     #[ffi_pure]
+   |
 
 error[E0539]: malformed `link_ordinal` attribute input
   --> $DIR/malformed-attrs.rs:169:5
    |
 LL |     #[link_ordinal]
-   |     ^^^^^^^^^^^^^^^
-   |     |
-   |     expected this to be a list
-   |     help: must be of the form: `#[link_ordinal(ordinal)]`
+   |     ^^^^^^^^^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_ordinal-attribute>
+help: must be of the form
+   |
+LL |     #[link_ordinal(ordinal)]
+   |                   +++++++++
 
 error[E0565]: malformed `ffi_const` attribute input
   --> $DIR/malformed-attrs.rs:173:5
    |
 LL |     #[unsafe(ffi_const = 1)]
    |     ^^^^^^^^^^^^^^^^^^^---^^
-   |     |                  |
-   |     |                  didn't expect any arguments here
-   |     help: must be of the form: `#[ffi_const]`
+   |                        |
+   |                        didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL -     #[unsafe(ffi_const = 1)]
+LL +     #[ffi_const]
+   |
 
 error[E0539]: malformed `linkage` attribute input
   --> $DIR/malformed-attrs.rs:175:5
@@ -597,48 +712,69 @@ error[E0539]: malformed `debugger_visualizer` attribute input
   --> $DIR/malformed-attrs.rs:190:1
    |
 LL | #[debugger_visualizer]
-   | ^^^^^^^^^^^^^^^^^^^^^^
-   | |
-   | expected this to be a list
-   | help: must be of the form: `#[debugger_visualizer(natvis_file = "...", gdb_script_file = "...")]`
+   | ^^^^^^^^^^^^^^^^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/debugger.html#the-debugger_visualizer-attribute>
+help: must be of the form
+   |
+LL | #[debugger_visualizer(natvis_file = "...", gdb_script_file = "...")]
+   |                      ++++++++++++++++++++++++++++++++++++++++++++++
 
 error[E0565]: malformed `automatically_derived` attribute input
   --> $DIR/malformed-attrs.rs:192:1
    |
 LL | #[automatically_derived = 18]
    | ^^^^^^^^^^^^^^^^^^^^^^^^----^
-   | |                       |
-   | |                       didn't expect any arguments here
-   | help: must be of the form: `#[automatically_derived]`
+   |                         |
+   |                         didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[automatically_derived = 18]
+LL + #[automatically_derived]
+   |
 
 error[E0565]: malformed `non_exhaustive` attribute input
   --> $DIR/malformed-attrs.rs:200:1
    |
 LL | #[non_exhaustive = 1]
    | ^^^^^^^^^^^^^^^^^---^
-   | |                |
-   | |                didn't expect any arguments here
-   | help: must be of the form: `#[non_exhaustive]`
+   |                  |
+   |                  didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[non_exhaustive = 1]
+LL + #[non_exhaustive]
+   |
 
 error[E0565]: malformed `thread_local` attribute input
   --> $DIR/malformed-attrs.rs:206:1
    |
 LL | #[thread_local()]
    | ^^^^^^^^^^^^^^--^
-   | |             |
-   | |             didn't expect any arguments here
-   | help: must be of the form: `#[thread_local]`
+   |               |
+   |               didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[thread_local()]
+LL + #[thread_local]
+   |
 
 error[E0565]: malformed `no_link` attribute input
   --> $DIR/malformed-attrs.rs:210:1
    |
 LL | #[no_link()]
    | ^^^^^^^^^--^
-   | |        |
-   | |        didn't expect any arguments here
-   | help: must be of the form: `#[no_link]`
+   |          |
+   |          didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[no_link()]
+LL + #[no_link]
+   |
 
 error[E0539]: malformed `macro_use` attribute input
   --> $DIR/malformed-attrs.rs:212:1
@@ -680,9 +816,14 @@ error[E0565]: malformed `allow_internal_unsafe` attribute input
    |
 LL | #[allow_internal_unsafe = 1]
    | ^^^^^^^^^^^^^^^^^^^^^^^^---^
-   | |                       |
-   | |                       didn't expect any arguments here
-   | help: must be of the form: `#[allow_internal_unsafe]`
+   |                         |
+   |                         didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[allow_internal_unsafe = 1]
+LL + #[allow_internal_unsafe]
+   |
 
 error: attribute should be applied to `const fn`
   --> $DIR/malformed-attrs.rs:31:1

--- a/tests/ui/attributes/malformed-fn-align.stderr
+++ b/tests/ui/attributes/malformed-fn-align.stderr
@@ -2,28 +2,40 @@ error[E0539]: malformed `rustc_align` attribute input
   --> $DIR/malformed-fn-align.rs:10:5
    |
 LL |     #[rustc_align]
-   |     ^^^^^^^^^^^^^^
-   |     |
-   |     expected this to be a list
-   |     help: must be of the form: `#[rustc_align(<alignment in bytes>)]`
+   |     ^^^^^^^^^^^^^^ expected this to be a list
+   |
+help: must be of the form
+   |
+LL |     #[rustc_align(<alignment in bytes>)]
+   |                  ++++++++++++++++++++++
 
 error[E0805]: malformed `rustc_align` attribute input
   --> $DIR/malformed-fn-align.rs:13:5
    |
 LL |     #[rustc_align(1, 2)]
    |     ^^^^^^^^^^^^^------^
-   |     |            |
-   |     |            expected a single argument here
-   |     help: must be of the form: `#[rustc_align(<alignment in bytes>)]`
+   |                  |
+   |                  expected a single argument here
+   |
+help: must be of the form
+   |
+LL -     #[rustc_align(1, 2)]
+LL +     #[rustc_align(<alignment in bytes>)]
+   |
 
 error[E0539]: malformed `rustc_align` attribute input
   --> $DIR/malformed-fn-align.rs:17:1
    |
 LL | #[rustc_align = 16]
    | ^^^^^^^^^^^^^^----^
-   | |             |
-   | |             expected this to be a list
-   | help: must be of the form: `#[rustc_align(<alignment in bytes>)]`
+   |               |
+   |               expected this to be a list
+   |
+help: must be of the form
+   |
+LL - #[rustc_align = 16]
+LL + #[rustc_align(<alignment in bytes>)]
+   |
 
 error[E0589]: invalid alignment value: not an unsuffixed integer
   --> $DIR/malformed-fn-align.rs:20:15

--- a/tests/ui/attributes/malformed-no-std.stderr
+++ b/tests/ui/attributes/malformed-no-std.stderr
@@ -3,54 +3,84 @@ error[E0565]: malformed `no_std` attribute input
    |
 LL | #![no_std = "foo"]
    | ^^^^^^^^^^-------^
-   | |         |
-   | |         didn't expect any arguments here
-   | help: must be of the form: `#![no_std]`
+   |           |
+   |           didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #![no_std = "foo"]
+LL + #![no_std]
+   |
 
 error[E0565]: malformed `no_std` attribute input
   --> $DIR/malformed-no-std.rs:5:1
    |
 LL | #![no_std("bar")]
    | ^^^^^^^^^-------^
-   | |        |
-   | |        didn't expect any arguments here
-   | help: must be of the form: `#![no_std]`
+   |          |
+   |          didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #![no_std("bar")]
+LL + #![no_std]
+   |
 
 error[E0565]: malformed `no_std` attribute input
   --> $DIR/malformed-no-std.rs:8:1
    |
 LL | #![no_std(foo = "bar")]
    | ^^^^^^^^^-------------^
-   | |        |
-   | |        didn't expect any arguments here
-   | help: must be of the form: `#![no_std]`
+   |          |
+   |          didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #![no_std(foo = "bar")]
+LL + #![no_std]
+   |
 
 error[E0565]: malformed `no_core` attribute input
   --> $DIR/malformed-no-std.rs:11:1
    |
 LL | #![no_core = "foo"]
    | ^^^^^^^^^^^-------^
-   | |          |
-   | |          didn't expect any arguments here
-   | help: must be of the form: `#![no_core]`
+   |            |
+   |            didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #![no_core = "foo"]
+LL + #![no_core]
+   |
 
 error[E0565]: malformed `no_core` attribute input
   --> $DIR/malformed-no-std.rs:13:1
    |
 LL | #![no_core("bar")]
    | ^^^^^^^^^^-------^
-   | |         |
-   | |         didn't expect any arguments here
-   | help: must be of the form: `#![no_core]`
+   |           |
+   |           didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #![no_core("bar")]
+LL + #![no_core]
+   |
 
 error[E0565]: malformed `no_core` attribute input
   --> $DIR/malformed-no-std.rs:16:1
    |
 LL | #![no_core(foo = "bar")]
    | ^^^^^^^^^^-------------^
-   | |         |
-   | |         didn't expect any arguments here
-   | help: must be of the form: `#![no_core]`
+   |           |
+   |           didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #![no_core(foo = "bar")]
+LL + #![no_core]
+   |
 
 error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
   --> $DIR/malformed-no-std.rs:21:1

--- a/tests/ui/attributes/malformed-static-align.stderr
+++ b/tests/ui/attributes/malformed-static-align.stderr
@@ -3,9 +3,14 @@ error[E0539]: malformed `rustc_align_static` attribute input
    |
 LL | #[rustc_align_static = 16]
    | ^^^^^^^^^^^^^^^^^^^^^----^
-   | |                    |
-   | |                    expected this to be a list
-   | help: must be of the form: `#[rustc_align_static(<alignment in bytes>)]`
+   |                      |
+   |                      expected this to be a list
+   |
+help: must be of the form
+   |
+LL - #[rustc_align_static = 16]
+LL + #[rustc_align_static(<alignment in bytes>)]
+   |
 
 error[E0589]: invalid alignment value: not an unsuffixed integer
   --> $DIR/malformed-static-align.rs:7:22

--- a/tests/ui/attributes/malformed-unstable-removed.stderr
+++ b/tests/ui/attributes/malformed-unstable-removed.stderr
@@ -3,36 +3,56 @@ error[E0539]: malformed `unstable_removed` attribute input
    |
 LL | #![unstable_removed(feature = "old_feature")]
    | ^^^^^^^^^^^^^^^^^^^-------------------------^
-   | |                  |
-   | |                  missing argument `reason = "..."`
-   | help: must be of the form: `#![unstable_removed(feature = "name", reason = "...", link = "...", since = "version")]`
+   |                    |
+   |                    missing argument `reason = "..."`
+   |
+help: must be of the form
+   |
+LL - #![unstable_removed(feature = "old_feature")]
+LL + #![unstable_removed(feature = "name", reason = "...", link = "...", since = "version")]
+   |
 
 error[E0539]: malformed `unstable_removed` attribute input
   --> $DIR/malformed-unstable-removed.rs:6:1
    |
 LL | #![unstable_removed(invalid = "old_feature")]
    | ^^^^^^^^^^^^^^^^^^^^-----------------------^^
-   | |                   |
-   | |                   valid arguments are `feature`, `reason`, `link` or `since`
-   | help: must be of the form: `#![unstable_removed(feature = "name", reason = "...", link = "...", since = "version")]`
+   |                     |
+   |                     valid arguments are `feature`, `reason`, `link` or `since`
+   |
+help: must be of the form
+   |
+LL - #![unstable_removed(invalid = "old_feature")]
+LL + #![unstable_removed(feature = "name", reason = "...", link = "...", since = "version")]
+   |
 
 error[E0565]: malformed `unstable_removed` attribute input
   --> $DIR/malformed-unstable-removed.rs:9:1
    |
 LL | #![unstable_removed("invalid literal")]
    | ^^^^^^^^^^^^^^^^^^^^-----------------^^
-   | |                   |
-   | |                   didn't expect a literal here
-   | help: must be of the form: `#![unstable_removed(feature = "name", reason = "...", link = "...", since = "version")]`
+   |                     |
+   |                     didn't expect a literal here
+   |
+help: must be of the form
+   |
+LL - #![unstable_removed("invalid literal")]
+LL + #![unstable_removed(feature = "name", reason = "...", link = "...", since = "version")]
+   |
 
 error[E0539]: malformed `unstable_removed` attribute input
   --> $DIR/malformed-unstable-removed.rs:12:1
    |
 LL | #![unstable_removed = "invalid literal"]
    | ^^^^^^^^^^^^^^^^^^^^-------------------^
-   | |                   |
-   | |                   expected this to be a list
-   | help: must be of the form: `#![unstable_removed(feature = "name", reason = "...", link = "...", since = "version")]`
+   |                     |
+   |                     expected this to be a list
+   |
+help: must be of the form
+   |
+LL - #![unstable_removed = "invalid literal"]
+LL + #![unstable_removed(feature = "name", reason = "...", link = "...", since = "version")]
+   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/attributes/rustc_confusables.stderr
+++ b/tests/ui/attributes/rustc_confusables.stderr
@@ -8,19 +8,26 @@ error[E0539]: malformed `rustc_confusables` attribute input
   --> $DIR/rustc_confusables.rs:34:5
    |
 LL |     #[rustc_confusables]
-   |     ^^^^^^^^^^^^^^^^^^^^
-   |     |
-   |     expected this to be a list
-   |     help: must be of the form: `#[rustc_confusables("name1", "name2", ...)]`
+   |     ^^^^^^^^^^^^^^^^^^^^ expected this to be a list
+   |
+help: must be of the form
+   |
+LL |     #[rustc_confusables("name1", "name2", ...)]
+   |                        +++++++++++++++++++++++
 
 error[E0539]: malformed `rustc_confusables` attribute input
   --> $DIR/rustc_confusables.rs:39:5
    |
 LL |     #[rustc_confusables(invalid_meta_item)]
    |     ^^^^^^^^^^^^^^^^^^^^-----------------^^
-   |     |                   |
-   |     |                   expected a string literal here
-   |     help: must be of the form: `#[rustc_confusables("name1", "name2", ...)]`
+   |                         |
+   |                         expected a string literal here
+   |
+help: must be of the form
+   |
+LL -     #[rustc_confusables(invalid_meta_item)]
+LL +     #[rustc_confusables("name1", "name2", ...)]
+   |
 
 error: `#[rustc_confusables]` attribute cannot be used on functions
   --> $DIR/rustc_confusables.rs:45:1

--- a/tests/ui/attributes/rustc_skip_during_method_dispatch.stderr
+++ b/tests/ui/attributes/rustc_skip_during_method_dispatch.stderr
@@ -2,64 +2,94 @@ error[E0539]: malformed `rustc_skip_during_method_dispatch` attribute input
   --> $DIR/rustc_skip_during_method_dispatch.rs:3:1
    |
 LL | #[rustc_skip_during_method_dispatch]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   | |
-   | expected this to be a list
-   | help: must be of the form: `#[rustc_skip_during_method_dispatch(array, boxed_slice)]`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected this to be a list
+   |
+help: must be of the form
+   |
+LL | #[rustc_skip_during_method_dispatch(array, boxed_slice)]
+   |                                    ++++++++++++++++++++
 
 error[E0539]: malformed `rustc_skip_during_method_dispatch` attribute input
   --> $DIR/rustc_skip_during_method_dispatch.rs:7:1
    |
 LL | #[rustc_skip_during_method_dispatch = "array"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---------^
-   | |                                   |
-   | |                                   expected this to be a list
-   | help: must be of the form: `#[rustc_skip_during_method_dispatch(array, boxed_slice)]`
+   |                                     |
+   |                                     expected this to be a list
+   |
+help: must be of the form
+   |
+LL - #[rustc_skip_during_method_dispatch = "array"]
+LL + #[rustc_skip_during_method_dispatch(array, boxed_slice)]
+   |
 
 error[E0539]: malformed `rustc_skip_during_method_dispatch` attribute input
   --> $DIR/rustc_skip_during_method_dispatch.rs:11:1
    |
 LL | #[rustc_skip_during_method_dispatch()]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--^
-   | |                                  |
-   | |                                  expected at least 1 argument here
-   | help: must be of the form: `#[rustc_skip_during_method_dispatch(array, boxed_slice)]`
+   |                                    |
+   |                                    expected at least 1 argument here
+   |
+help: must be of the form
+   |
+LL | #[rustc_skip_during_method_dispatch(array, boxed_slice)]
+   |                                     ++++++++++++++++++
 
 error[E0538]: malformed `rustc_skip_during_method_dispatch` attribute input
   --> $DIR/rustc_skip_during_method_dispatch.rs:15:1
    |
 LL | #[rustc_skip_during_method_dispatch(array, boxed_slice, array)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----^^
-   | |                                                       |
-   | |                                                       found `array` used as a key more than once
-   | help: must be of the form: `#[rustc_skip_during_method_dispatch(array, boxed_slice)]`
+   |                                                         |
+   |                                                         found `array` used as a key more than once
+   |
+help: must be of the form
+   |
+LL - #[rustc_skip_during_method_dispatch(array, boxed_slice, array)]
+LL + #[rustc_skip_during_method_dispatch(array, boxed_slice)]
+   |
 
 error[E0539]: malformed `rustc_skip_during_method_dispatch` attribute input
   --> $DIR/rustc_skip_during_method_dispatch.rs:19:1
    |
 LL | #[rustc_skip_during_method_dispatch(slice)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----^^
-   | |                                   |
-   | |                                   valid arguments are `array` or `boxed_slice`
-   | help: must be of the form: `#[rustc_skip_during_method_dispatch(array, boxed_slice)]`
+   |                                     |
+   |                                     valid arguments are `array` or `boxed_slice`
+   |
+help: must be of the form
+   |
+LL | #[rustc_skip_during_method_dispatch(array, boxed_slice)]
+   |                                     +++++++++++++
 
 error[E0565]: malformed `rustc_skip_during_method_dispatch` attribute input
   --> $DIR/rustc_skip_during_method_dispatch.rs:23:1
    |
 LL | #[rustc_skip_during_method_dispatch(array = true)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------^^
-   | |                                         |
-   | |                                         didn't expect any arguments here
-   | help: must be of the form: `#[rustc_skip_during_method_dispatch(array, boxed_slice)]`
+   |                                           |
+   |                                           didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[rustc_skip_during_method_dispatch(array = true)]
+LL + #[rustc_skip_during_method_dispatch(array, boxed_slice)]
+   |
 
 error[E0565]: malformed `rustc_skip_during_method_dispatch` attribute input
   --> $DIR/rustc_skip_during_method_dispatch.rs:27:1
    |
 LL | #[rustc_skip_during_method_dispatch("array")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------^^
-   | |                                   |
-   | |                                   didn't expect a literal here
-   | help: must be of the form: `#[rustc_skip_during_method_dispatch(array, boxed_slice)]`
+   |                                     |
+   |                                     didn't expect a literal here
+   |
+help: must be of the form
+   |
+LL - #[rustc_skip_during_method_dispatch("array")]
+LL + #[rustc_skip_during_method_dispatch(array, boxed_slice)]
+   |
 
 error: `#[rustc_skip_during_method_dispatch]` attribute cannot be used on trait impl blocks
   --> $DIR/rustc_skip_during_method_dispatch.rs:34:1

--- a/tests/ui/borrowck/issue-82032.stderr
+++ b/tests/ui/borrowck/issue-82032.stderr
@@ -2,12 +2,14 @@ error[E0596]: cannot borrow `*v` as mutable, as it is behind a `&` reference
   --> $DIR/issue-82032.rs:10:13
    |
 LL |         for v in self.0.values() {
-   |                  ---------------
-   |                  |      |
-   |                  |      help: use mutable method: `values_mut()`
-   |                  this iterator yields `&` references
+   |                  --------------- this iterator yields `&` references
 LL |             v.flush();
    |             ^ `v` is a `&` reference, so it cannot be borrowed as mutable
+   |
+help: use mutable method
+   |
+LL |         for v in self.0.values_mut() {
+   |                               ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cfg/cfg-path-error.stderr
+++ b/tests/ui/cfg/cfg-path-error.stderr
@@ -3,44 +3,60 @@ error[E0539]: malformed `cfg` attribute input
    |
 LL | #[cfg(any(foo, foo::bar))]
    | ^^^^^^^^^^^^^^^--------^^^
-   | |              |
-   | |              expected a valid identifier here
-   | help: must be of the form: `#[cfg(predicate)]`
+   |                |
+   |                expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg(any(foo, foo::bar))]
+LL + #[cfg(predicate)]
+   |
 
 error[E0539]: malformed `cfg` attribute input
   --> $DIR/cfg-path-error.rs:12:1
    |
 LL | #[cfg(any(foo::bar, foo))]
    | ^^^^^^^^^^--------^^^^^^^^
-   | |         |
-   | |         expected a valid identifier here
-   | help: must be of the form: `#[cfg(predicate)]`
+   |           |
+   |           expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg(any(foo::bar, foo))]
+LL + #[cfg(predicate)]
+   |
 
 error[E0539]: malformed `cfg` attribute input
   --> $DIR/cfg-path-error.rs:18:1
    |
 LL | #[cfg(all(foo, foo::bar))]
    | ^^^^^^^^^^^^^^^--------^^^
-   | |              |
-   | |              expected a valid identifier here
-   | help: must be of the form: `#[cfg(predicate)]`
+   |                |
+   |                expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg(all(foo, foo::bar))]
+LL + #[cfg(predicate)]
+   |
 
 error[E0539]: malformed `cfg` attribute input
   --> $DIR/cfg-path-error.rs:24:1
    |
 LL | #[cfg(all(foo::bar, foo))]
    | ^^^^^^^^^^--------^^^^^^^^
-   | |         |
-   | |         expected a valid identifier here
-   | help: must be of the form: `#[cfg(predicate)]`
+   |           |
+   |           expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg(all(foo::bar, foo))]
+LL + #[cfg(predicate)]
+   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/cfg/cfg-target-compact-errors.stderr
+++ b/tests/ui/cfg/cfg-target-compact-errors.stderr
@@ -3,55 +3,75 @@ error[E0539]: malformed `cfg` attribute input
    |
 LL | #[cfg(target(o::o))]
    | ^^^^^^^^^^^^^----^^^
-   | |            |
-   | |            expected this to be of the form `... = "..."`
-   | help: must be of the form: `#[cfg(predicate)]`
+   |              |
+   |              expected this to be of the form `... = "..."`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg(target(o::o))]
+LL + #[cfg(predicate)]
+   |
 
 error[E0539]: malformed `cfg` attribute input
   --> $DIR/cfg-target-compact-errors.rs:9:1
    |
 LL | #[cfg(target(os = 8))]
    | ^^^^^^^^^^^^^^^^^^-^^^
-   | |                 |
-   | |                 expected a string literal here
-   | help: must be of the form: `#[cfg(predicate)]`
+   |                   |
+   |                   expected a string literal here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg(target(os = 8))]
+LL + #[cfg(predicate)]
+   |
 
 error[E0539]: malformed `cfg` attribute input
   --> $DIR/cfg-target-compact-errors.rs:13:1
    |
 LL | #[cfg(target(os = "linux", pointer(width = "64")))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^---------------------^^^
-   | |                          |
-   | |                          expected this to be of the form `... = "..."`
-   | help: must be of the form: `#[cfg(predicate)]`
+   |                            |
+   |                            expected this to be of the form `... = "..."`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg(target(os = "linux", pointer(width = "64")))]
+LL + #[cfg(predicate)]
+   |
 
 error[E0539]: malformed `cfg` attribute input
   --> $DIR/cfg-target-compact-errors.rs:17:1
    |
 LL | #[cfg(target(true))]
    | ^^^^^^^^^^^^^----^^^
-   | |            |
-   | |            expected this to be of the form `... = "..."`
-   | help: must be of the form: `#[cfg(predicate)]`
+   |              |
+   |              expected this to be of the form `... = "..."`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg(target(true))]
+LL + #[cfg(predicate)]
+   |
 
 error[E0539]: malformed `cfg` attribute input
   --> $DIR/cfg-target-compact-errors.rs:21:1
    |
 LL | #[cfg(target(clippy::os = "linux"))]
    | ^^^^^^^^^^^^^----------^^^^^^^^^^^^^
-   | |            |
-   | |            expected a valid identifier here
-   | help: must be of the form: `#[cfg(predicate)]`
+   |              |
+   |              expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg(target(clippy::os = "linux"))]
+LL + #[cfg(predicate)]
+   |
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/cfg/path-kw-as-cfg-pred.stderr
+++ b/tests/ui/cfg/path-kw-as-cfg-pred.stderr
@@ -123,132 +123,180 @@ error[E0539]: malformed `cfg` attribute input
    |
 LL | #[cfg(crate)]
    | ^^^^^^-----^^
-   | |     |
-   | |     expected a valid identifier here
-   | help: must be of the form: `#[cfg(predicate)]`
+   |       |
+   |       expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg(crate)]
+LL + #[cfg(predicate)]
+   |
 
 error[E0539]: malformed `cfg` attribute input
   --> $DIR/path-kw-as-cfg-pred.rs:22:1
    |
 LL | #[cfg(super)]
    | ^^^^^^-----^^
-   | |     |
-   | |     expected a valid identifier here
-   | help: must be of the form: `#[cfg(predicate)]`
+   |       |
+   |       expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg(super)]
+LL + #[cfg(predicate)]
+   |
 
 error[E0539]: malformed `cfg` attribute input
   --> $DIR/path-kw-as-cfg-pred.rs:24:1
    |
 LL | #[cfg(self)]
    | ^^^^^^----^^
-   | |     |
-   | |     expected a valid identifier here
-   | help: must be of the form: `#[cfg(predicate)]`
+   |       |
+   |       expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg(self)]
+LL + #[cfg(predicate)]
+   |
 
 error[E0539]: malformed `cfg` attribute input
   --> $DIR/path-kw-as-cfg-pred.rs:26:1
    |
 LL | #[cfg(Self)]
    | ^^^^^^----^^
-   | |     |
-   | |     expected a valid identifier here
-   | help: must be of the form: `#[cfg(predicate)]`
+   |       |
+   |       expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg(Self)]
+LL + #[cfg(predicate)]
+   |
 
 error[E0539]: malformed `cfg_attr` attribute input
   --> $DIR/path-kw-as-cfg-pred.rs:28:1
    |
 LL | #[cfg_attr(crate, path = "foo")]
    | ^^^^^^^^^^^-----^^^^^^^^^^^^^^^^
-   | |          |
-   | |          expected a valid identifier here
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   |            |
+   |            expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL - #[cfg_attr(crate, path = "foo")]
+LL + #[cfg_attr(predicate, attr1, attr2, ...)]
+   |
 
 error[E0539]: malformed `cfg_attr` attribute input
   --> $DIR/path-kw-as-cfg-pred.rs:30:1
    |
 LL | #[cfg_attr(super, path = "foo")]
    | ^^^^^^^^^^^-----^^^^^^^^^^^^^^^^
-   | |          |
-   | |          expected a valid identifier here
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   |            |
+   |            expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL - #[cfg_attr(super, path = "foo")]
+LL + #[cfg_attr(predicate, attr1, attr2, ...)]
+   |
 
 error[E0539]: malformed `cfg_attr` attribute input
   --> $DIR/path-kw-as-cfg-pred.rs:32:1
    |
 LL | #[cfg_attr(self, path = "foo")]
    | ^^^^^^^^^^^----^^^^^^^^^^^^^^^^
-   | |          |
-   | |          expected a valid identifier here
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   |            |
+   |            expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL - #[cfg_attr(self, path = "foo")]
+LL + #[cfg_attr(predicate, attr1, attr2, ...)]
+   |
 
 error[E0539]: malformed `cfg_attr` attribute input
   --> $DIR/path-kw-as-cfg-pred.rs:34:1
    |
 LL | #[cfg_attr(Self, path = "foo")]
    | ^^^^^^^^^^^----^^^^^^^^^^^^^^^^
-   | |          |
-   | |          expected a valid identifier here
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   |            |
+   |            expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL - #[cfg_attr(Self, path = "foo")]
+LL + #[cfg_attr(predicate, attr1, attr2, ...)]
+   |
 
 error[E0539]: malformed `cfg` attribute input
   --> $DIR/path-kw-as-cfg-pred.rs:36:18
    |
 LL | #[cfg_attr(true, cfg(crate))]
    |                  ^^^^-----^
-   |                  |   |
-   |                  |   expected a valid identifier here
-   |                  help: must be of the form: `cfg(predicate)`
+   |                      |
+   |                      expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg_attr(true, cfg(crate))]
+LL + #[cfg_attr(true, cfg(predicate))]
+   |
 
 error[E0539]: malformed `cfg` attribute input
   --> $DIR/path-kw-as-cfg-pred.rs:38:18
    |
 LL | #[cfg_attr(true, cfg(super))]
    |                  ^^^^-----^
-   |                  |   |
-   |                  |   expected a valid identifier here
-   |                  help: must be of the form: `cfg(predicate)`
+   |                      |
+   |                      expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg_attr(true, cfg(super))]
+LL + #[cfg_attr(true, cfg(predicate))]
+   |
 
 error[E0539]: malformed `cfg` attribute input
   --> $DIR/path-kw-as-cfg-pred.rs:40:18
    |
 LL | #[cfg_attr(true, cfg(self))]
    |                  ^^^^----^
-   |                  |   |
-   |                  |   expected a valid identifier here
-   |                  help: must be of the form: `cfg(predicate)`
+   |                      |
+   |                      expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg_attr(true, cfg(self))]
+LL + #[cfg_attr(true, cfg(predicate))]
+   |
 
 error[E0539]: malformed `cfg` attribute input
   --> $DIR/path-kw-as-cfg-pred.rs:42:18
    |
 LL | #[cfg_attr(true, cfg(Self))]
    |                  ^^^^----^
-   |                  |   |
-   |                  |   expected a valid identifier here
-   |                  help: must be of the form: `cfg(predicate)`
+   |                      |
+   |                      expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg_attr(true, cfg(Self))]
+LL + #[cfg_attr(true, cfg(predicate))]
+   |
 
 error: expected identifier, found keyword `struct`
   --> $DIR/path-kw-as-cfg-pred.rs:45:7
@@ -319,236 +367,316 @@ error[E0539]: malformed `cfg` attribute input
    |
 LL | #[cfg(r#crate)]
    | ^^^^^^-------^^
-   | |     |
-   | |     expected a valid identifier here
-   | help: must be of the form: `#[cfg(predicate)]`
+   |       |
+   |       expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg(r#crate)]
+LL + #[cfg(predicate)]
+   |
 
 error[E0539]: malformed `cfg` attribute input
   --> $DIR/path-kw-as-cfg-pred.rs:93:1
    |
 LL | #[cfg(r#super)]
    | ^^^^^^-------^^
-   | |     |
-   | |     expected a valid identifier here
-   | help: must be of the form: `#[cfg(predicate)]`
+   |       |
+   |       expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg(r#super)]
+LL + #[cfg(predicate)]
+   |
 
 error[E0539]: malformed `cfg` attribute input
   --> $DIR/path-kw-as-cfg-pred.rs:96:1
    |
 LL | #[cfg(r#self)]
    | ^^^^^^------^^
-   | |     |
-   | |     expected a valid identifier here
-   | help: must be of the form: `#[cfg(predicate)]`
+   |       |
+   |       expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg(r#self)]
+LL + #[cfg(predicate)]
+   |
 
 error[E0539]: malformed `cfg` attribute input
   --> $DIR/path-kw-as-cfg-pred.rs:99:1
    |
 LL | #[cfg(r#Self)]
    | ^^^^^^------^^
-   | |     |
-   | |     expected a valid identifier here
-   | help: must be of the form: `#[cfg(predicate)]`
+   |       |
+   |       expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg(r#Self)]
+LL + #[cfg(predicate)]
+   |
 
 error[E0539]: malformed `cfg_attr` attribute input
   --> $DIR/path-kw-as-cfg-pred.rs:102:1
    |
 LL | #[cfg_attr(r#crate, cfg(r#crate))]
    | ^^^^^^^^^^^-------^^^^^^^^^^^^^^^^
-   | |          |
-   | |          expected a valid identifier here
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   |            |
+   |            expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL - #[cfg_attr(r#crate, cfg(r#crate))]
+LL + #[cfg_attr(predicate, attr1, attr2, ...)]
+   |
 
 error[E0539]: malformed `cfg_attr` attribute input
   --> $DIR/path-kw-as-cfg-pred.rs:106:1
    |
 LL | #[cfg_attr(r#super, cfg(r#super))]
    | ^^^^^^^^^^^-------^^^^^^^^^^^^^^^^
-   | |          |
-   | |          expected a valid identifier here
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   |            |
+   |            expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL - #[cfg_attr(r#super, cfg(r#super))]
+LL + #[cfg_attr(predicate, attr1, attr2, ...)]
+   |
 
 error[E0539]: malformed `cfg_attr` attribute input
   --> $DIR/path-kw-as-cfg-pred.rs:110:1
    |
 LL | #[cfg_attr(r#self, cfg(r#self))]
    | ^^^^^^^^^^^------^^^^^^^^^^^^^^^
-   | |          |
-   | |          expected a valid identifier here
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   |            |
+   |            expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL - #[cfg_attr(r#self, cfg(r#self))]
+LL + #[cfg_attr(predicate, attr1, attr2, ...)]
+   |
 
 error[E0539]: malformed `cfg_attr` attribute input
   --> $DIR/path-kw-as-cfg-pred.rs:114:1
    |
 LL | #[cfg_attr(r#Self, cfg(r#Self))]
    | ^^^^^^^^^^^------^^^^^^^^^^^^^^^
-   | |          |
-   | |          expected a valid identifier here
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   |            |
+   |            expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL - #[cfg_attr(r#Self, cfg(r#Self))]
+LL + #[cfg_attr(predicate, attr1, attr2, ...)]
+   |
 
 error[E0539]: malformed `cfg` attribute input
   --> $DIR/path-kw-as-cfg-pred.rs:9:9
    |
 LL |         #[cfg($crate)]
    |         ^^^^^^------^^
-   |         |     |
-   |         |     expected a valid identifier here
-   |         help: must be of the form: `#[cfg(predicate)]`
+   |               |
+   |               expected a valid identifier here
 ...
 LL |     foo!();
    |     ------ in this macro invocation
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: must be of the form
+   |
+LL -         #[cfg($crate)]
+LL +         #[cfg(predicate)]
+   |
 
 error[E0539]: malformed `cfg_attr` attribute input
   --> $DIR/path-kw-as-cfg-pred.rs:11:9
    |
 LL |         #[cfg_attr($crate, path = "foo")]
    |         ^^^^^^^^^^^------^^^^^^^^^^^^^^^^
-   |         |          |
-   |         |          expected a valid identifier here
-   |         help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   |                    |
+   |                    expected a valid identifier here
 ...
 LL |     foo!();
    |     ------ in this macro invocation
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: must be of the form
+   |
+LL -         #[cfg_attr($crate, path = "foo")]
+LL +         #[cfg_attr(predicate, attr1, attr2, ...)]
+   |
 
 error[E0539]: malformed `cfg` attribute input
   --> $DIR/path-kw-as-cfg-pred.rs:13:26
    |
 LL |         #[cfg_attr(true, cfg($crate))]
    |                          ^^^^------^
-   |                          |   |
-   |                          |   expected a valid identifier here
-   |                          help: must be of the form: `cfg(predicate)`
+   |                              |
+   |                              expected a valid identifier here
 ...
 LL |     foo!();
    |     ------ in this macro invocation
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: must be of the form
+   |
+LL -         #[cfg_attr(true, cfg($crate))]
+LL +         #[cfg_attr(true, cfg(predicate))]
+   |
 
 error[E0539]: malformed `cfg` macro input
   --> $DIR/path-kw-as-cfg-pred.rs:16:9
    |
 LL |         cfg!($crate);
    |         ^^^^^------^
-   |         |    |
-   |         |    expected a valid identifier here
-   |         help: must be of the form: `cfg!(predicate)`
+   |              |
+   |              expected a valid identifier here
 ...
 LL |     foo!();
    |     ------ in this macro invocation
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
    = note: this error originates in the macro `cfg` which comes from the expansion of the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: must be of the form
+   |
+LL -         cfg!($crate);
+LL +         cfg!(predicate);
+   |
 
 error[E0539]: malformed `cfg` macro input
   --> $DIR/path-kw-as-cfg-pred.rs:67:5
    |
 LL |     cfg!(crate);
    |     ^^^^^-----^
-   |     |    |
-   |     |    expected a valid identifier here
-   |     help: must be of the form: `cfg!(predicate)`
+   |          |
+   |          expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL -     cfg!(crate);
+LL +     cfg!(predicate);
+   |
 
 error[E0539]: malformed `cfg` macro input
   --> $DIR/path-kw-as-cfg-pred.rs:68:5
    |
 LL |     cfg!(super);
    |     ^^^^^-----^
-   |     |    |
-   |     |    expected a valid identifier here
-   |     help: must be of the form: `cfg!(predicate)`
+   |          |
+   |          expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL -     cfg!(super);
+LL +     cfg!(predicate);
+   |
 
 error[E0539]: malformed `cfg` macro input
   --> $DIR/path-kw-as-cfg-pred.rs:69:5
    |
 LL |     cfg!(self);
    |     ^^^^^----^
-   |     |    |
-   |     |    expected a valid identifier here
-   |     help: must be of the form: `cfg!(predicate)`
+   |          |
+   |          expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL -     cfg!(self);
+LL +     cfg!(predicate);
+   |
 
 error[E0539]: malformed `cfg` macro input
   --> $DIR/path-kw-as-cfg-pred.rs:70:5
    |
 LL |     cfg!(Self);
    |     ^^^^^----^
-   |     |    |
-   |     |    expected a valid identifier here
-   |     help: must be of the form: `cfg!(predicate)`
+   |          |
+   |          expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL -     cfg!(Self);
+LL +     cfg!(predicate);
+   |
 
 error[E0539]: malformed `cfg` macro input
   --> $DIR/path-kw-as-cfg-pred.rs:72:5
    |
 LL |     cfg!(r#crate);
    |     ^^^^^-------^
-   |     |    |
-   |     |    expected a valid identifier here
-   |     help: must be of the form: `cfg!(predicate)`
+   |          |
+   |          expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL -     cfg!(r#crate);
+LL +     cfg!(predicate);
+   |
 
 error[E0539]: malformed `cfg` macro input
   --> $DIR/path-kw-as-cfg-pred.rs:74:5
    |
 LL |     cfg!(r#super);
    |     ^^^^^-------^
-   |     |    |
-   |     |    expected a valid identifier here
-   |     help: must be of the form: `cfg!(predicate)`
+   |          |
+   |          expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL -     cfg!(r#super);
+LL +     cfg!(predicate);
+   |
 
 error[E0539]: malformed `cfg` macro input
   --> $DIR/path-kw-as-cfg-pred.rs:76:5
    |
 LL |     cfg!(r#self);
    |     ^^^^^------^
-   |     |    |
-   |     |    expected a valid identifier here
-   |     help: must be of the form: `cfg!(predicate)`
+   |          |
+   |          expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL -     cfg!(r#self);
+LL +     cfg!(predicate);
+   |
 
 error[E0539]: malformed `cfg` macro input
   --> $DIR/path-kw-as-cfg-pred.rs:78:5
    |
 LL |     cfg!(r#Self);
    |     ^^^^^------^
-   |     |    |
-   |     |    expected a valid identifier here
-   |     help: must be of the form: `cfg!(predicate)`
+   |          |
+   |          expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL -     cfg!(r#Self);
+LL +     cfg!(predicate);
+   |
 
 error: expected identifier, found keyword `struct`
   --> $DIR/path-kw-as-cfg-pred.rs:81:10

--- a/tests/ui/compile-flags/invalid/print-file-names-request-malformed-crate-name-1.stderr
+++ b/tests/ui/compile-flags/invalid/print-file-names-request-malformed-crate-name-1.stderr
@@ -2,7 +2,12 @@ error[E0539]: malformed `crate_name` attribute input
   --> $DIR/print-file-names-request-malformed-crate-name-1.rs:4:1
    |
 LL | #![crate_name]
-   | ^^^^^^^^^^^^^^ help: must be of the form: `#![crate_name = "name"]`
+   | ^^^^^^^^^^^^^^
+   |
+help: must be of the form
+   |
+LL | #![crate_name = "name"]
+   |               ++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/conditional-compilation/cfg-attr-parse.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-parse.stderr
@@ -3,55 +3,66 @@ error[E0539]: malformed `cfg_attr` attribute input
    |
 LL | #[cfg_attr()]
    | ^^^^^^^^^^--^
-   | |         |
-   | |         expected at least 1 argument here
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   |           |
+   |           expected at least 1 argument here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL | #[cfg_attr(predicate, attr1, attr2, ...)]
+   |            ++++++++++++++++++++++++++++
 
 error: expected `,`, found end of `cfg_attr` input
   --> $DIR/cfg-attr-parse.rs:8:16
    |
 LL | #[cfg_attr(true)]
-   | ---------------^-
-   | |              |
-   | |              expected `,`
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   |                ^ expected `,`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL - #[cfg_attr(true)]
+LL + #[cfg_attr(predicate, attr1, attr2, ...)]
+   |
 
 error: expected identifier, found `,`
   --> $DIR/cfg-attr-parse.rs:17:17
    |
 LL | #[cfg_attr(true,,)]
-   | ----------------^--
-   | |               |
-   | |               expected identifier
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   |                 ^ expected identifier
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL - #[cfg_attr(true,,)]
+LL + #[cfg_attr(predicate, attr1, attr2, ...)]
+   |
 
 error: expected identifier, found `,`
   --> $DIR/cfg-attr-parse.rs:29:27
    |
 LL | #[cfg_attr(true, must_use,,)]
-   | --------------------------^--
-   | |                         |
-   | |                         expected identifier
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   |                           ^ expected identifier
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL - #[cfg_attr(true, must_use,,)]
+LL + #[cfg_attr(predicate, attr1, attr2, ...)]
+   |
 
 error: expected identifier, found `,`
   --> $DIR/cfg-attr-parse.rs:41:39
    |
 LL | #[cfg_attr(true, must_use, deprecated,,)]
-   | --------------------------------------^--
-   | |                                     |
-   | |                                     expected identifier
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   |                                       ^ expected identifier
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL - #[cfg_attr(true, must_use, deprecated,,)]
+LL + #[cfg_attr(predicate, attr1, attr2, ...)]
+   |
 
 error: wrong `cfg_attr` delimiters
   --> $DIR/cfg-attr-parse.rs:45:11
@@ -69,12 +80,14 @@ error: expected identifier, found `,`
   --> $DIR/cfg-attr-parse.rs:45:17
    |
 LL | #[cfg_attr[true,,]]
-   | ----------------^--
-   | |               |
-   | |               expected identifier
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   |                 ^ expected identifier
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL - #[cfg_attr[true,,]]
+LL + #[cfg_attr(predicate, attr1, attr2, ...)]
+   |
 
 error: wrong `cfg_attr` delimiters
   --> $DIR/cfg-attr-parse.rs:51:11
@@ -92,12 +105,14 @@ error: expected identifier, found `,`
   --> $DIR/cfg-attr-parse.rs:51:17
    |
 LL | #[cfg_attr{true,,}]
-   | ----------------^--
-   | |               |
-   | |               expected identifier
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   |                 ^ expected identifier
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL - #[cfg_attr{true,,}]
+LL + #[cfg_attr(predicate, attr1, attr2, ...)]
+   |
 
 warning: `#[cfg_attr]` does not expand to any attributes
   --> $DIR/cfg-attr-parse.rs:12:1

--- a/tests/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
@@ -2,23 +2,28 @@ error[E0539]: malformed `cfg` attribute input
   --> $DIR/cfg-attr-syntax-validation.rs:1:1
    |
 LL | #[cfg]
-   | ^^^^^^
-   | |
-   | expected this to be a list
-   | help: must be of the form: `#[cfg(predicate)]`
+   | ^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL | #[cfg(predicate)]
+   |      +++++++++++
 
 error[E0539]: malformed `cfg` attribute input
   --> $DIR/cfg-attr-syntax-validation.rs:7:1
    |
 LL | #[cfg = 10]
    | ^^^^^^----^
-   | |     |
-   | |     expected this to be a list
-   | help: must be of the form: `#[cfg(predicate)]`
+   |       |
+   |       expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg = 10]
+LL + #[cfg(predicate)]
+   |
 
 error[E0805]: malformed `cfg` attribute input
   --> $DIR/cfg-attr-syntax-validation.rs:13:1
@@ -59,22 +64,30 @@ error[E0539]: malformed `cfg` attribute input
    |
 LL | #[cfg("str")]
    | ^^^^^^-----^^
-   | |     |
-   | |     expected a valid identifier here
-   | help: must be of the form: `#[cfg(predicate)]`
+   |       |
+   |       expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg("str")]
+LL + #[cfg(predicate)]
+   |
 
 error[E0539]: malformed `cfg` attribute input
   --> $DIR/cfg-attr-syntax-validation.rs:31:1
    |
 LL | #[cfg(a::b)]
    | ^^^^^^----^^
-   | |     |
-   | |     expected a valid identifier here
-   | help: must be of the form: `#[cfg(predicate)]`
+   |       |
+   |       expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg(a::b)]
+LL + #[cfg(predicate)]
+   |
 
 error[E0537]: invalid predicate `a`
   --> $DIR/cfg-attr-syntax-validation.rs:37:7
@@ -87,11 +100,15 @@ error[E0539]: malformed `cfg` attribute input
    |
 LL | #[cfg(a = 10)]
    | ^^^^^^^^^^--^^
-   | |         |
-   | |         expected a string literal here
-   | help: must be of the form: `#[cfg(predicate)]`
+   |           |
+   |           expected a string literal here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg(a = 10)]
+LL + #[cfg(predicate)]
+   |
 
 error[E0539]: malformed `cfg` attribute input
   --> $DIR/cfg-attr-syntax-validation.rs:45:1

--- a/tests/ui/conditional-compilation/cfg_accessible-input-validation.stderr
+++ b/tests/ui/conditional-compilation/cfg_accessible-input-validation.stderr
@@ -2,13 +2,24 @@ error: malformed `cfg_accessible` attribute input
   --> $DIR/cfg_accessible-input-validation.rs:3:1
    |
 LL | #[cfg_accessible]
-   | ^^^^^^^^^^^^^^^^^ help: must be of the form: `#[cfg_accessible(path)]`
+   | ^^^^^^^^^^^^^^^^^
+   |
+help: must be of the form
+   |
+LL | #[cfg_accessible(path)]
+   |                 ++++++
 
 error: malformed `cfg_accessible` attribute input
   --> $DIR/cfg_accessible-input-validation.rs:6:1
    |
 LL | #[cfg_accessible = "value"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[cfg_accessible(path)]`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: must be of the form
+   |
+LL - #[cfg_accessible = "value"]
+LL + #[cfg_accessible(path)]
+   |
 
 error: `cfg_accessible` path is not specified
   --> $DIR/cfg_accessible-input-validation.rs:9:1

--- a/tests/ui/conditional-compilation/cfg_attr-attr-syntax-validation.stderr
+++ b/tests/ui/conditional-compilation/cfg_attr-attr-syntax-validation.stderr
@@ -2,56 +2,70 @@ error[E0539]: malformed `cfg_attr` attribute input
   --> $DIR/cfg_attr-attr-syntax-validation.rs:1:1
    |
 LL | #[cfg_attr]
-   | ^^^^^^^^^^^
-   | |
-   | expected this to be a list
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   | ^^^^^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL | #[cfg_attr(predicate, attr1, attr2, ...)]
+   |           ++++++++++++++++++++++++++++++
 
 error[E0539]: malformed `cfg_attr` attribute input
   --> $DIR/cfg_attr-attr-syntax-validation.rs:5:1
    |
 LL | #[cfg_attr = 10]
-   | ^^^^^^^^^^^^^^^^
-   | |
-   | expected this to be a list
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   | ^^^^^^^^^^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL - #[cfg_attr = 10]
+LL + #[cfg_attr(predicate, attr1, attr2, ...)]
+   |
 
 error[E0539]: malformed `cfg_attr` attribute input
   --> $DIR/cfg_attr-attr-syntax-validation.rs:9:1
    |
 LL | #[cfg_attr()]
    | ^^^^^^^^^^--^
-   | |         |
-   | |         expected at least 1 argument here
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   |           |
+   |           expected at least 1 argument here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL | #[cfg_attr(predicate, attr1, attr2, ...)]
+   |            ++++++++++++++++++++++++++++
 
 error[E0539]: malformed `cfg_attr` attribute input
   --> $DIR/cfg_attr-attr-syntax-validation.rs:13:1
    |
 LL | #[cfg_attr("str")]
    | ^^^^^^^^^^^-----^^
-   | |          |
-   | |          expected a valid identifier here
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   |            |
+   |            expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL - #[cfg_attr("str")]
+LL + #[cfg_attr(predicate, attr1, attr2, ...)]
+   |
 
 error[E0539]: malformed `cfg_attr` attribute input
   --> $DIR/cfg_attr-attr-syntax-validation.rs:16:1
    |
 LL | #[cfg_attr(a::b)]
    | ^^^^^^^^^^^----^^
-   | |          |
-   | |          expected a valid identifier here
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   |            |
+   |            expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL - #[cfg_attr(a::b)]
+LL + #[cfg_attr(predicate, attr1, attr2, ...)]
+   |
 
 error[E0537]: invalid predicate `a`
   --> $DIR/cfg_attr-attr-syntax-validation.rs:19:12
@@ -64,11 +78,15 @@ error[E0539]: malformed `cfg_attr` attribute input
    |
 LL | #[cfg_attr(a = 10)]
    | ^^^^^^^^^^^^^^^--^^
-   | |              |
-   | |              expected a string literal here
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   |                |
+   |                expected a string literal here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL - #[cfg_attr(a = 10)]
+LL + #[cfg_attr(predicate, attr1, attr2, ...)]
+   |
 
 error[E0539]: malformed `cfg_attr` attribute input
   --> $DIR/cfg_attr-attr-syntax-validation.rs:25:1
@@ -84,24 +102,31 @@ error: expected `,`, found end of `cfg_attr` input
   --> $DIR/cfg_attr-attr-syntax-validation.rs:38:16
    |
 LL | #[cfg_attr(true)]
-   | ---------------^-
-   | |              |
-   | |              expected `,`
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   |                ^ expected `,`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL - #[cfg_attr(true)]
+LL + #[cfg_attr(predicate, attr1, attr2, ...)]
+   |
 
 error: expected a literal (`1u8`, `1.0f32`, `"string"`, etc.) here, found `expr` metavariable
   --> $DIR/cfg_attr-attr-syntax-validation.rs:30:30
    |
 LL |         #[cfg_attr(feature = $expr)]
-   |         ---------------------^^^^^-- help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   |                              ^^^^^
 ...
 LL | generate_s10!(concat!("nonexistent"));
    | ------------------------------------- in this macro invocation
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
    = note: this error originates in the macro `generate_s10` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: must be of the form
+   |
+LL -         #[cfg_attr(feature = $expr)]
+LL +         #[cfg_attr(predicate, attr1, attr2, ...)]
+   |
 
 error: cannot find attribute `unknown_attribute` in this scope
   --> $DIR/cfg_attr-attr-syntax-validation.rs:41:18
@@ -113,9 +138,13 @@ error[E0539]: malformed `link_section` attribute input
   --> $DIR/cfg_attr-attr-syntax-validation.rs:44:18
    |
 LL | #[cfg_attr(true, link_section)]
-   |                  ^^^^^^^^^^^^ help: must be of the form: `link_section = "name"`
+   |                  ^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/abi.html#the-link_section-attribute>
+help: must be of the form
+   |
+LL | #[cfg_attr(true, link_section = "name")]
+   |                               ++++++++
 
 error[E0805]: malformed `inline` attribute input
   --> $DIR/cfg_attr-attr-syntax-validation.rs:49:18

--- a/tests/ui/const-generics/associated-const-bindings/unbraced-enum-variant.stderr
+++ b/tests/ui/const-generics/associated-const-bindings/unbraced-enum-variant.stderr
@@ -2,19 +2,25 @@ error[E0573]: expected type, found variant `Mode::Cool`
   --> $DIR/unbraced-enum-variant.rs:13:35
    |
 LL | pub trait CoolStuff: Parse<MODE = Mode::Cool> {}
-   |                                   ^^^^^^^^^^
-   |                                   |
-   |                                   not a type
-   |                                   help: try using the variant's enum: `Mode`
+   |                                   ^^^^^^^^^^ not a type
+   |
+help: try using the variant's enum
+   |
+LL - pub trait CoolStuff: Parse<MODE = Mode::Cool> {}
+LL + pub trait CoolStuff: Parse<MODE = Mode> {}
+   |
 
 error[E0573]: expected type, found variant `Mode::Cool`
   --> $DIR/unbraced-enum-variant.rs:19:17
    |
 LL | fn no_help() -> Mode::Cool {}
-   |                 ^^^^^^^^^^
-   |                 |
-   |                 not a type
-   |                 help: try using the variant's enum: `Mode`
+   |                 ^^^^^^^^^^ not a type
+   |
+help: try using the variant's enum
+   |
+LL - fn no_help() -> Mode::Cool {}
+LL + fn no_help() -> Mode {}
+   |
 
 error: expected constant, found type
   --> $DIR/unbraced-enum-variant.rs:13:35

--- a/tests/ui/const-generics/invalid-enum.stderr
+++ b/tests/ui/const-generics/invalid-enum.stderr
@@ -2,28 +2,37 @@ error[E0573]: expected type, found variant `CompileFlag::A`
   --> $DIR/invalid-enum.rs:24:14
    |
 LL |     test_1::<CompileFlag::A>();
-   |              ^^^^^^^^^^^^^^
-   |              |
-   |              not a type
-   |              help: try using the variant's enum: `CompileFlag`
+   |              ^^^^^^^^^^^^^^ not a type
+   |
+help: try using the variant's enum
+   |
+LL -     test_1::<CompileFlag::A>();
+LL +     test_1::<CompileFlag>();
+   |
 
 error[E0573]: expected type, found variant `CompileFlag::A`
   --> $DIR/invalid-enum.rs:28:17
    |
 LL |     test_2::<_, CompileFlag::A>(0);
-   |                 ^^^^^^^^^^^^^^
-   |                 |
-   |                 not a type
-   |                 help: try using the variant's enum: `CompileFlag`
+   |                 ^^^^^^^^^^^^^^ not a type
+   |
+help: try using the variant's enum
+   |
+LL -     test_2::<_, CompileFlag::A>(0);
+LL +     test_2::<_, CompileFlag>(0);
+   |
 
 error[E0573]: expected type, found variant `CompileFlag::A`
   --> $DIR/invalid-enum.rs:32:20
    |
 LL |     let _: Example<CompileFlag::A, _> = Example { x: 0 };
-   |                    ^^^^^^^^^^^^^^
-   |                    |
-   |                    not a type
-   |                    help: try using the variant's enum: `CompileFlag`
+   |                    ^^^^^^^^^^^^^^ not a type
+   |
+help: try using the variant's enum
+   |
+LL -     let _: Example<CompileFlag::A, _> = Example { x: 0 };
+LL +     let _: Example<CompileFlag, _> = Example { x: 0 };
+   |
 
 error[E0747]: unresolved item provided when a constant was expected
   --> $DIR/invalid-enum.rs:24:14

--- a/tests/ui/const-generics/invalid-rustc_legacy_const_generics-arguments.stderr
+++ b/tests/ui/const-generics/invalid-rustc_legacy_const_generics-arguments.stderr
@@ -3,27 +3,42 @@ error[E0539]: malformed `rustc_legacy_const_generics` attribute input
    |
 LL | #[rustc_legacy_const_generics(a)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-^^
-   | |                             |
-   | |                             expected an integer literal here
-   | help: must be of the form: `#[rustc_legacy_const_generics(N)]`
+   |                               |
+   |                               expected an integer literal here
+   |
+help: must be of the form
+   |
+LL - #[rustc_legacy_const_generics(a)]
+LL + #[rustc_legacy_const_generics(N)]
+   |
 
 error[E0539]: malformed `rustc_legacy_const_generics` attribute input
   --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:15:1
    |
 LL | #[rustc_legacy_const_generics(1, a, 2, b)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-^^^^^^^^
-   | |                                |
-   | |                                expected an integer literal here
-   | help: must be of the form: `#[rustc_legacy_const_generics(N)]`
+   |                                  |
+   |                                  expected an integer literal here
+   |
+help: must be of the form
+   |
+LL - #[rustc_legacy_const_generics(1, a, 2, b)]
+LL + #[rustc_legacy_const_generics(N)]
+   |
 
 error[E0539]: malformed `rustc_legacy_const_generics` attribute input
   --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:15:1
    |
 LL | #[rustc_legacy_const_generics(1, a, 2, b)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-^^
-   | |                                      |
-   | |                                      expected an integer literal here
-   | help: must be of the form: `#[rustc_legacy_const_generics(N)]`
+   |                                        |
+   |                                        expected an integer literal here
+   |
+help: must be of the form
+   |
+LL - #[rustc_legacy_const_generics(1, a, 2, b)]
+LL + #[rustc_legacy_const_generics(N)]
+   |
 
 error: `#[rustc_legacy_const_generics]` attribute cannot be used on structs
   --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:20:1
@@ -46,9 +61,14 @@ error[E0539]: malformed `rustc_legacy_const_generics` attribute input
    |
 LL | #[rustc_legacy_const_generics(0usize)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------^^
-   | |                             |
-   | |                             expected an integer literal here
-   | help: must be of the form: `#[rustc_legacy_const_generics(N)]`
+   |                               |
+   |                               expected an integer literal here
+   |
+help: must be of the form
+   |
+LL - #[rustc_legacy_const_generics(0usize)]
+LL + #[rustc_legacy_const_generics(N)]
+   |
 
 error: `#[rustc_legacy_const_generics]` attribute cannot be used on foreign functions
   --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:29:5
@@ -70,19 +90,26 @@ error[E0539]: malformed `rustc_legacy_const_generics` attribute input
   --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:41:1
    |
 LL | #[rustc_legacy_const_generics]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   | |
-   | expected this to be a list
-   | help: must be of the form: `#[rustc_legacy_const_generics(N)]`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected this to be a list
+   |
+help: must be of the form
+   |
+LL | #[rustc_legacy_const_generics(N)]
+   |                              +++
 
 error[E0539]: malformed `rustc_legacy_const_generics` attribute input
   --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:44:1
    |
 LL | #[rustc_legacy_const_generics = 1]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---^
-   | |                             |
-   | |                             expected this to be a list
-   | help: must be of the form: `#[rustc_legacy_const_generics(N)]`
+   |                               |
+   |                               expected this to be a list
+   |
+help: must be of the form
+   |
+LL - #[rustc_legacy_const_generics = 1]
+LL + #[rustc_legacy_const_generics(N)]
+   |
 
 error: #[rustc_legacy_const_generics] must have one index for each generic parameter
   --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:3:1

--- a/tests/ui/did_you_mean/issue-43871-enum-instead-of-variant.stderr
+++ b/tests/ui/did_you_mean/issue-43871-enum-instead-of-variant.stderr
@@ -2,15 +2,20 @@ error[E0532]: expected tuple struct or tuple variant, found enum `Option`
   --> $DIR/issue-43871-enum-instead-of-variant.rs:21:12
    |
 LL |     if let Option(_) = x {
-   |            ^^^^^^ help: try to match against one of the enum's variants: `std::option::Option::Some`
+   |            ^^^^^^
    |
    = help: you might have meant to match against the enum's non-tuple variant
+help: try to match against one of the enum's variants
+   |
+LL -     if let Option(_) = x {
+LL +     if let std::option::Option::Some(_) = x {
+   |
 
 error[E0532]: expected tuple struct or tuple variant, found enum `Example`
   --> $DIR/issue-43871-enum-instead-of-variant.rs:27:12
    |
 LL |     if let Example(_) = y {
-   |            ^^^^^^^ help: try to match against one of the enum's variants: `Example::Ex`
+   |            ^^^^^^^
    |
    = help: you might have meant to match against the enum's non-tuple variant
 note: the enum is defined here
@@ -18,14 +23,23 @@ note: the enum is defined here
    |
 LL | enum Example { Ex(String), NotEx }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: try to match against one of the enum's variants
+   |
+LL |     if let Example::Ex(_) = y {
+   |                   ++++
 
 error[E0423]: expected function, tuple struct or tuple variant, found enum `Option`
   --> $DIR/issue-43871-enum-instead-of-variant.rs:19:13
    |
 LL |     let x = Option(1);
-   |             ^^^^^^ help: try to construct one of the enum's variants: `std::option::Option::Some`
+   |             ^^^^^^
    |
    = help: you might have meant to construct the enum's non-tuple variant
+help: try to construct one of the enum's variants
+   |
+LL -     let x = Option(1);
+LL +     let x = std::option::Option::Some(1);
+   |
 
 error[E0423]: expected function, tuple struct or tuple variant, found enum `Void`
   --> $DIR/issue-43871-enum-instead-of-variant.rs:31:13

--- a/tests/ui/enum/enum-variant-type-2.stderr
+++ b/tests/ui/enum/enum-variant-type-2.stderr
@@ -2,10 +2,13 @@ error[E0573]: expected type, found variant `Foo::Bar`
   --> $DIR/enum-variant-type-2.rs:8:11
    |
 LL | fn foo(x: Foo::Bar) {}
-   |           ^^^^^^^^
-   |           |
-   |           not a type
-   |           help: try using the variant's enum: `Foo`
+   |           ^^^^^^^^ not a type
+   |
+help: try using the variant's enum
+   |
+LL - fn foo(x: Foo::Bar) {}
+LL + fn foo(x: Foo) {}
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/extern/issue-47725.stderr
+++ b/tests/ui/extern/issue-47725.stderr
@@ -2,9 +2,13 @@ error[E0539]: malformed `link_name` attribute input
   --> $DIR/issue-47725.rs:19:1
    |
 LL | #[link_name]
-   | ^^^^^^^^^^^^ help: must be of the form: `#[link_name = "name"]`
+   | ^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_name-attribute>
+help: must be of the form
+   |
+LL | #[link_name = "name"]
+   |             ++++++++
 
 warning: `#[link_name]` attribute cannot be used on structs
   --> $DIR/issue-47725.rs:3:1

--- a/tests/ui/feature-gates/feature-gate-fn_align.stderr
+++ b/tests/ui/feature-gates/feature-gate-fn_align.stderr
@@ -22,10 +22,12 @@ error[E0539]: malformed `rustc_align` attribute input
   --> $DIR/feature-gate-fn_align.rs:12:5
    |
 LL |     #[rustc_align]
-   |     ^^^^^^^^^^^^^^
-   |     |
-   |     expected this to be a list
-   |     help: must be of the form: `#[rustc_align(<alignment in bytes>)]`
+   |     ^^^^^^^^^^^^^^ expected this to be a list
+   |
+help: must be of the form
+   |
+LL |     #[rustc_align(<alignment in bytes>)]
+   |                  ++++++++++++++++++++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-offset-of-enum.stderr
+++ b/tests/ui/feature-gates/feature-gate-offset-of-enum.stderr
@@ -2,10 +2,13 @@ error[E0573]: expected type, found variant `Alpha::One`
   --> $DIR/feature-gate-offset-of-enum.rs:10:16
    |
 LL |     offset_of!(Alpha::One, 0);
-   |                ^^^^^^^^^^
-   |                |
-   |                not a type
-   |                help: try using the variant's enum: `Alpha`
+   |                ^^^^^^^^^^ not a type
+   |
+help: try using the variant's enum
+   |
+LL -     offset_of!(Alpha::One, 0);
+LL +     offset_of!(Alpha, 0);
+   |
 
 error[E0658]: using enums in offset_of is experimental
   --> $DIR/feature-gate-offset-of-enum.rs:11:23

--- a/tests/ui/feature-gates/gated-bad-feature.stderr
+++ b/tests/ui/feature-gates/gated-bad-feature.stderr
@@ -11,36 +11,53 @@ error[E0565]: malformed `feature` attribute input
    |
 LL | #![feature(foo_bar_baz, foo(bar), foo = "baz", foo)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^-----^^^^^^^^^^^^^^^^^^^^
-   | |                          |
-   | |                          didn't expect any arguments here
-   | help: must be of the form: `#![feature(feature1, feature2, ...)]`
+   |                            |
+   |                            didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #![feature(foo_bar_baz, foo(bar), foo = "baz", foo)]
+LL + #![feature(feature1, feature2, ...)]
+   |
 
 error[E0565]: malformed `feature` attribute input
   --> $DIR/gated-bad-feature.rs:1:1
    |
 LL | #![feature(foo_bar_baz, foo(bar), foo = "baz", foo)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------^^^^^^^
-   | |                                     |
-   | |                                     didn't expect any arguments here
-   | help: must be of the form: `#![feature(feature1, feature2, ...)]`
+   |                                       |
+   |                                       didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #![feature(foo_bar_baz, foo(bar), foo = "baz", foo)]
+LL + #![feature(feature1, feature2, ...)]
+   |
 
 error[E0539]: malformed `feature` attribute input
   --> $DIR/gated-bad-feature.rs:6:1
    |
 LL | #![feature]
-   | ^^^^^^^^^^^
-   | |
-   | expected this to be a list
-   | help: must be of the form: `#![feature(feature1, feature2, ...)]`
+   | ^^^^^^^^^^^ expected this to be a list
+   |
+help: must be of the form
+   |
+LL | #![feature(feature1, feature2, ...)]
+   |           +++++++++++++++++++++++++
 
 error[E0539]: malformed `feature` attribute input
   --> $DIR/gated-bad-feature.rs:7:1
    |
 LL | #![feature = "foo"]
    | ^^^^^^^^^^^-------^
-   | |          |
-   | |          expected this to be a list
-   | help: must be of the form: `#![feature(feature1, feature2, ...)]`
+   |            |
+   |            expected this to be a list
+   |
+help: must be of the form
+   |
+LL - #![feature = "foo"]
+LL + #![feature(feature1, feature2, ...)]
+   |
 
 error[E0635]: unknown feature `foo_bar_baz`
   --> $DIR/gated-bad-feature.rs:1:12

--- a/tests/ui/internal-lints/query_stability_incorrect.stderr
+++ b/tests/ui/internal-lints/query_stability_incorrect.stderr
@@ -11,9 +11,14 @@ error[E0565]: malformed `rustc_lint_query_instability` attribute input
    |
 LL |     #[rustc_lint_query_instability(a)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---^
-   |     |                             |
-   |     |                             didn't expect any arguments here
-   |     help: must be of the form: `#[rustc_lint_query_instability]`
+   |                                   |
+   |                                   didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL -     #[rustc_lint_query_instability(a)]
+LL +     #[rustc_lint_query_instability]
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/linkage-attr/raw-dylib/windows/link-ordinal-invalid-format.stderr
+++ b/tests/ui/linkage-attr/raw-dylib/windows/link-ordinal-invalid-format.stderr
@@ -3,22 +3,30 @@ error[E0539]: malformed `link_ordinal` attribute input
    |
 LL |     #[link_ordinal("JustMonika")]
    |     ^^^^^^^^^^^^^^^------------^^
-   |     |              |
-   |     |              expected an integer literal here
-   |     help: must be of the form: `#[link_ordinal(ordinal)]`
+   |                    |
+   |                    expected an integer literal here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_ordinal-attribute>
+help: must be of the form
+   |
+LL -     #[link_ordinal("JustMonika")]
+LL +     #[link_ordinal(ordinal)]
+   |
 
 error[E0539]: malformed `link_ordinal` attribute input
   --> $DIR/link-ordinal-invalid-format.rs:6:5
    |
 LL |     #[link_ordinal("JustMonika")]
    |     ^^^^^^^^^^^^^^^------------^^
-   |     |              |
-   |     |              expected an integer literal here
-   |     help: must be of the form: `#[link_ordinal(ordinal)]`
+   |                    |
+   |                    expected an integer literal here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_ordinal-attribute>
+help: must be of the form
+   |
+LL -     #[link_ordinal("JustMonika")]
+LL +     #[link_ordinal(ordinal)]
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/linkage-attr/raw-dylib/windows/link-ordinal-missing-argument.stderr
+++ b/tests/ui/linkage-attr/raw-dylib/windows/link-ordinal-missing-argument.stderr
@@ -3,22 +3,28 @@ error[E0805]: malformed `link_ordinal` attribute input
    |
 LL |     #[link_ordinal()]
    |     ^^^^^^^^^^^^^^--^
-   |     |             |
-   |     |             expected an argument here
-   |     help: must be of the form: `#[link_ordinal(ordinal)]`
+   |                   |
+   |                   expected an argument here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_ordinal-attribute>
+help: must be of the form
+   |
+LL |     #[link_ordinal(ordinal)]
+   |                    +++++++
 
 error[E0805]: malformed `link_ordinal` attribute input
   --> $DIR/link-ordinal-missing-argument.rs:8:5
    |
 LL |     #[link_ordinal()]
    |     ^^^^^^^^^^^^^^--^
-   |     |             |
-   |     |             expected an argument here
-   |     help: must be of the form: `#[link_ordinal(ordinal)]`
+   |                   |
+   |                   expected an argument here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_ordinal-attribute>
+help: must be of the form
+   |
+LL |     #[link_ordinal(ordinal)]
+   |                    +++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/linkage-attr/raw-dylib/windows/link-ordinal-too-many-arguments.stderr
+++ b/tests/ui/linkage-attr/raw-dylib/windows/link-ordinal-too-many-arguments.stderr
@@ -3,22 +3,30 @@ error[E0805]: malformed `link_ordinal` attribute input
    |
 LL |     #[link_ordinal(3, 4)]
    |     ^^^^^^^^^^^^^^------^
-   |     |             |
-   |     |             expected a single argument here
-   |     help: must be of the form: `#[link_ordinal(ordinal)]`
+   |                   |
+   |                   expected a single argument here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_ordinal-attribute>
+help: must be of the form
+   |
+LL -     #[link_ordinal(3, 4)]
+LL +     #[link_ordinal(ordinal)]
+   |
 
 error[E0805]: malformed `link_ordinal` attribute input
   --> $DIR/link-ordinal-too-many-arguments.rs:8:5
    |
 LL |     #[link_ordinal(3, 4)]
    |     ^^^^^^^^^^^^^^------^
-   |     |             |
-   |     |             expected a single argument here
-   |     help: must be of the form: `#[link_ordinal(ordinal)]`
+   |                   |
+   |                   expected a single argument here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_ordinal-attribute>
+help: must be of the form
+   |
+LL -     #[link_ordinal(3, 4)]
+LL +     #[link_ordinal(ordinal)]
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/macros/cfg.stderr
+++ b/tests/ui/macros/cfg.stderr
@@ -9,22 +9,30 @@ error[E0539]: malformed `cfg` macro input
    |
 LL |     cfg!(123);
    |     ^^^^^---^
-   |     |    |
-   |     |    expected a valid identifier here
-   |     help: must be of the form: `cfg!(predicate)`
+   |          |
+   |          expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL -     cfg!(123);
+LL +     cfg!(predicate);
+   |
 
 error[E0539]: malformed `cfg` macro input
   --> $DIR/cfg.rs:4:5
    |
 LL |     cfg!(foo = 123);
    |     ^^^^^^^^^^^---^
-   |     |          |
-   |     |          expected a string literal here
-   |     help: must be of the form: `cfg!(predicate)`
+   |                |
+   |                expected a string literal here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL -     cfg!(foo = 123);
+LL +     cfg!(predicate);
+   |
 
 error: expected 1 cfg-pattern
   --> $DIR/cfg.rs:5:5

--- a/tests/ui/macros/cfg_attr-expr.stderr
+++ b/tests/ui/macros/cfg_attr-expr.stderr
@@ -2,16 +2,18 @@ error: expected identifier, found metavariable
   --> $DIR/cfg_attr-expr.rs:3:26
    |
 LL |         #[cfg_attr(true, $e)]
-   |         -----------------^^--
-   |         |                |
-   |         |                expected identifier, found metavariable
-   |         help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   |                          ^^ expected identifier, found metavariable
 ...
 LL | foo!(inline);
    | ------------ in this macro invocation
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: must be of the form
+   |
+LL -         #[cfg_attr(true, $e)]
+LL +         #[cfg_attr(predicate, attr1, attr2, ...)]
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/macros/tokenstream-ice-issue-149954.stderr
+++ b/tests/ui/macros/tokenstream-ice-issue-149954.stderr
@@ -41,24 +41,26 @@ error[E0539]: malformed `cfg` attribute input
   --> $DIR/tokenstream-ice-issue-149954.rs:10:36
    |
 LL |             A: A<{ struct A<A: A<{ #[cfg] () }>> ; enum A  }
-   |                                    ^^^^^^
-   |                                    |
-   |                                    expected this to be a list
-   |                                    help: must be of the form: `#[cfg(predicate)]`
+   |                                    ^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL |             A: A<{ struct A<A: A<{ #[cfg(predicate)] () }>> ; enum A  }
+   |                                         +++++++++++
 
 error[E0539]: malformed `cfg` attribute input
   --> $DIR/tokenstream-ice-issue-149954.rs:10:36
    |
 LL |             A: A<{ struct A<A: A<{ #[cfg] () }>> ; enum A  }
-   |                                    ^^^^^^
-   |                                    |
-   |                                    expected this to be a list
-   |                                    help: must be of the form: `#[cfg(predicate)]`
+   |                                    ^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: must be of the form
+   |
+LL |             A: A<{ struct A<A: A<{ #[cfg(predicate)] () }>> ; enum A  }
+   |                                         +++++++++++
 
 error[E0404]: expected trait, found struct `A`
   --> $DIR/tokenstream-ice-issue-149954.rs:10:16

--- a/tests/ui/malformed/malformed-derive-entry.stderr
+++ b/tests/ui/malformed/malformed-derive-entry.stderr
@@ -14,7 +14,12 @@ error: malformed `derive` attribute input
   --> $DIR/malformed-derive-entry.rs:11:1
    |
 LL | #[derive]
-   | ^^^^^^^^^ help: must be of the form: `#[derive(Trait1, Trait2, ...)]`
+   | ^^^^^^^^^
+   |
+help: must be of the form
+   |
+LL | #[derive(Trait1, Trait2, ...)]
+   |         +++++++++++++++++++++
 
 error[E0277]: the trait bound `Test1: Clone` is not satisfied
   --> $DIR/malformed-derive-entry.rs:3:8

--- a/tests/ui/malformed/malformed-special-attrs.stderr
+++ b/tests/ui/malformed/malformed-special-attrs.stderr
@@ -2,35 +2,49 @@ error[E0539]: malformed `cfg_attr` attribute input
   --> $DIR/malformed-special-attrs.rs:3:1
    |
 LL | #[cfg_attr]
-   | ^^^^^^^^^^^
-   | |
-   | expected this to be a list
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   | ^^^^^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL | #[cfg_attr(predicate, attr1, attr2, ...)]
+   |           ++++++++++++++++++++++++++++++
 
 error[E0539]: malformed `cfg_attr` attribute input
   --> $DIR/malformed-special-attrs.rs:6:1
    |
 LL | #[cfg_attr = ""]
-   | ^^^^^^^^^^^^^^^^
-   | |
-   | expected this to be a list
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   | ^^^^^^^^^^^^^^^^ expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL - #[cfg_attr = ""]
+LL + #[cfg_attr(predicate, attr1, attr2, ...)]
+   |
 
 error: malformed `derive` attribute input
   --> $DIR/malformed-special-attrs.rs:9:1
    |
 LL | #[derive]
-   | ^^^^^^^^^ help: must be of the form: `#[derive(Trait1, Trait2, ...)]`
+   | ^^^^^^^^^
+   |
+help: must be of the form
+   |
+LL | #[derive(Trait1, Trait2, ...)]
+   |         +++++++++++++++++++++
 
 error: malformed `derive` attribute input
   --> $DIR/malformed-special-attrs.rs:12:1
    |
 LL | #[derive = ""]
-   | ^^^^^^^^^^^^^^ help: must be of the form: `#[derive(Trait1, Trait2, ...)]`
+   | ^^^^^^^^^^^^^^
+   |
+help: must be of the form
+   |
+LL - #[derive = ""]
+LL + #[derive(Trait1, Trait2, ...)]
+   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/marker_trait_attr/marker-attribute-with-values.stderr
+++ b/tests/ui/marker_trait_attr/marker-attribute-with-values.stderr
@@ -3,27 +3,42 @@ error[E0565]: malformed `marker` attribute input
    |
 LL | #[marker(always)]
    | ^^^^^^^^--------^
-   | |       |
-   | |       didn't expect any arguments here
-   | help: must be of the form: `#[marker]`
+   |         |
+   |         didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[marker(always)]
+LL + #[marker]
+   |
 
 error[E0565]: malformed `marker` attribute input
   --> $DIR/marker-attribute-with-values.rs:6:1
    |
 LL | #[marker("never")]
    | ^^^^^^^^---------^
-   | |       |
-   | |       didn't expect any arguments here
-   | help: must be of the form: `#[marker]`
+   |         |
+   |         didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[marker("never")]
+LL + #[marker]
+   |
 
 error[E0565]: malformed `marker` attribute input
   --> $DIR/marker-attribute-with-values.rs:9:1
    |
 LL | #[marker(key = "value")]
    | ^^^^^^^^---------------^
-   | |       |
-   | |       didn't expect any arguments here
-   | help: must be of the form: `#[marker]`
+   |         |
+   |         didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[marker(key = "value")]
+LL + #[marker]
+   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/modules/path-invalid-form.stderr
+++ b/tests/ui/modules/path-invalid-form.stderr
@@ -2,9 +2,14 @@ error: malformed `path` attribute input
   --> $DIR/path-invalid-form.rs:1:1
    |
 LL | #[path = 123]
-   | ^^^^^^^^^^^^^ help: must be of the form: `#[path = "file"]`
+   | ^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/modules.html#the-path-attribute>
+help: must be of the form
+   |
+LL - #[path = 123]
+LL + #[path = "file"]
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/modules/path-macro.stderr
+++ b/tests/ui/modules/path-macro.stderr
@@ -2,9 +2,14 @@ error: malformed `path` attribute input
   --> $DIR/path-macro.rs:5:1
    |
 LL | #[path = foo!()]
-   | ^^^^^^^^^^^^^^^^ help: must be of the form: `#[path = "file"]`
+   | ^^^^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/modules.html#the-path-attribute>
+help: must be of the form
+   |
+LL - #[path = foo!()]
+LL + #[path = "file"]
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/offset-of/offset-of-enum.stderr
+++ b/tests/ui/offset-of/offset-of-enum.stderr
@@ -2,10 +2,13 @@ error[E0573]: expected type, found variant `Alpha::One`
   --> $DIR/offset-of-enum.rs:12:16
    |
 LL |     offset_of!(Alpha::One, 0);
-   |                ^^^^^^^^^^
-   |                |
-   |                not a type
-   |                help: try using the variant's enum: `Alpha`
+   |                ^^^^^^^^^^ not a type
+   |
+help: try using the variant's enum
+   |
+LL -     offset_of!(Alpha::One, 0);
+LL +     offset_of!(Alpha, 0);
+   |
 
 error[E0425]: cannot find type `Beta` in this scope
   --> $DIR/offset-of-enum.rs:18:16

--- a/tests/ui/parallel-rustc/undefined-function-issue-120760.stderr
+++ b/tests/ui/parallel-rustc/undefined-function-issue-120760.stderr
@@ -9,18 +9,6 @@ help: consider introducing lifetime `'a` here
 LL | pub struct User<'a, 'dep> {
    |                 +++
 
-error[E0425]: cannot find function `run` in this scope
-  --> $DIR/undefined-function-issue-120760.rs:14:5
-   |
-LL |     run("dependency").await;
-   |     ^^^ not found in this scope
-
-error[E0425]: cannot find function `run` in this scope
-  --> $DIR/undefined-function-issue-120760.rs:61:17
-   |
-LL |         let _ = run("dependency").await;
-   |                 ^^^ not found in this scope
-
 error[E0560]: struct `User<'_>` has no field named `dep`
   --> $DIR/undefined-function-issue-120760.rs:70:12
    |
@@ -28,6 +16,18 @@ LL |     User { dep }.save().await;
    |            ^^^ `User<'_>` does not have this field
    |
    = note: available fields are: `name`
+
+error[E0425]: cannot find function `run` in this scope
+  --> $DIR/undefined-function-issue-120760.rs:61:17
+   |
+LL |         let _ = run("dependency").await;
+   |                 ^^^ not found in this scope
+
+error[E0425]: cannot find function `run` in this scope
+  --> $DIR/undefined-function-issue-120760.rs:14:5
+   |
+LL |     run("dependency").await;
+   |     ^^^ not found in this scope
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/patchable-function-entry/patchable-function-entry-attribute.stderr
+++ b/tests/ui/patchable-function-entry/patchable-function-entry-attribute.stderr
@@ -3,54 +3,80 @@ error[E0539]: malformed `patchable_function_entry` attribute input
    |
 LL | #[patchable_function_entry(prefix_nops = 256, entry_nops = 0)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---^^^^^^^^^^^^^^^^^^
-   | |                                        |
-   | |                                        expected an integer literal in the range of 0..=255
-   | help: must be of the form: `#[patchable_function_entry(prefix_nops = m, entry_nops = n)]`
+   |                                          |
+   |                                          expected an integer literal in the range of 0..=255
+   |
+help: must be of the form
+   |
+LL - #[patchable_function_entry(prefix_nops = 256, entry_nops = 0)]
+LL + #[patchable_function_entry(prefix_nops = m, entry_nops = n)]
+   |
 
 error[E0539]: malformed `patchable_function_entry` attribute input
   --> $DIR/patchable-function-entry-attribute.rs:8:1
    |
 LL | #[patchable_function_entry(prefix_nops = "stringvalue", entry_nops = 0)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------^^^^^^^^^^^^^^^^^^
-   | |                                        |
-   | |                                        expected an integer literal here
-   | help: must be of the form: `#[patchable_function_entry(prefix_nops = m, entry_nops = n)]`
+   |                                          |
+   |                                          expected an integer literal here
+   |
+help: must be of the form
+   |
+LL - #[patchable_function_entry(prefix_nops = "stringvalue", entry_nops = 0)]
+LL + #[patchable_function_entry(prefix_nops = m, entry_nops = n)]
+   |
 
 error[E0539]: malformed `patchable_function_entry` attribute input
   --> $DIR/patchable-function-entry-attribute.rs:12:1
    |
 LL | #[patchable_function_entry]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   | |
-   | expected this to be a list
-   | help: must be of the form: `#[patchable_function_entry(prefix_nops = m, entry_nops = n)]`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected this to be a list
+   |
+help: must be of the form
+   |
+LL | #[patchable_function_entry(prefix_nops = m, entry_nops = n)]
+   |                           +++++++++++++++++++++++++++++++++
 
 error[E0539]: malformed `patchable_function_entry` attribute input
   --> $DIR/patchable-function-entry-attribute.rs:16:1
    |
 LL | #[patchable_function_entry(prefix_nops = 10, something = 0)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---------^^^^^^
-   | |                                            |
-   | |                                            valid arguments are `prefix_nops` or `entry_nops`
-   | help: must be of the form: `#[patchable_function_entry(prefix_nops = m, entry_nops = n)]`
+   |                                              |
+   |                                              valid arguments are `prefix_nops` or `entry_nops`
+   |
+help: must be of the form
+   |
+LL - #[patchable_function_entry(prefix_nops = 10, something = 0)]
+LL + #[patchable_function_entry(prefix_nops = m, entry_nops = n)]
+   |
 
 error[E0539]: malformed `patchable_function_entry` attribute input
   --> $DIR/patchable-function-entry-attribute.rs:20:1
    |
 LL | #[patchable_function_entry()]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^--^
-   | |                         |
-   | |                         expected at least 1 argument here
-   | help: must be of the form: `#[patchable_function_entry(prefix_nops = m, entry_nops = n)]`
+   |                           |
+   |                           expected at least 1 argument here
+   |
+help: must be of the form
+   |
+LL | #[patchable_function_entry(prefix_nops = m, entry_nops = n)]
+   |                            +++++++++++++++++++++++++++++++
 
 error[E0538]: malformed `patchable_function_entry` attribute input
   --> $DIR/patchable-function-entry-attribute.rs:24:1
    |
 LL | #[patchable_function_entry(prefix_nops = 255, prefix_nops = 255)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------^^^^^^^^
-   | |                                             |
-   | |                                             found `prefix_nops` used as a key more than once
-   | help: must be of the form: `#[patchable_function_entry(prefix_nops = m, entry_nops = n)]`
+   |                                               |
+   |                                               found `prefix_nops` used as a key more than once
+   |
+help: must be of the form
+   |
+LL - #[patchable_function_entry(prefix_nops = 255, prefix_nops = 255)]
+LL + #[patchable_function_entry(prefix_nops = m, entry_nops = n)]
+   |
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/proc-macro/invalid-attributes.stderr
+++ b/tests/ui/proc-macro/invalid-attributes.stderr
@@ -3,54 +3,84 @@ error[E0565]: malformed `proc_macro` attribute input
    |
 LL | #[proc_macro = "test"]
    | ^^^^^^^^^^^^^--------^
-   | |            |
-   | |            didn't expect any arguments here
-   | help: must be of the form: `#[proc_macro]`
+   |              |
+   |              didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[proc_macro = "test"]
+LL + #[proc_macro]
+   |
 
 error[E0565]: malformed `proc_macro` attribute input
   --> $DIR/invalid-attributes.rs:15:1
    |
 LL | #[proc_macro()]
    | ^^^^^^^^^^^^--^
-   | |           |
-   | |           didn't expect any arguments here
-   | help: must be of the form: `#[proc_macro]`
+   |             |
+   |             didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[proc_macro()]
+LL + #[proc_macro]
+   |
 
 error[E0565]: malformed `proc_macro` attribute input
   --> $DIR/invalid-attributes.rs:20:1
    |
 LL | #[proc_macro(x)]
    | ^^^^^^^^^^^^---^
-   | |           |
-   | |           didn't expect any arguments here
-   | help: must be of the form: `#[proc_macro]`
+   |             |
+   |             didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[proc_macro(x)]
+LL + #[proc_macro]
+   |
 
 error[E0565]: malformed `proc_macro_attribute` attribute input
   --> $DIR/invalid-attributes.rs:25:1
    |
 LL | #[proc_macro_attribute = "test"]
    | ^^^^^^^^^^^^^^^^^^^^^^^--------^
-   | |                      |
-   | |                      didn't expect any arguments here
-   | help: must be of the form: `#[proc_macro_attribute]`
+   |                        |
+   |                        didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[proc_macro_attribute = "test"]
+LL + #[proc_macro_attribute]
+   |
 
 error[E0565]: malformed `proc_macro_attribute` attribute input
   --> $DIR/invalid-attributes.rs:30:1
    |
 LL | #[proc_macro_attribute()]
    | ^^^^^^^^^^^^^^^^^^^^^^--^
-   | |                     |
-   | |                     didn't expect any arguments here
-   | help: must be of the form: `#[proc_macro_attribute]`
+   |                       |
+   |                       didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[proc_macro_attribute()]
+LL + #[proc_macro_attribute]
+   |
 
 error[E0565]: malformed `proc_macro_attribute` attribute input
   --> $DIR/invalid-attributes.rs:35:1
    |
 LL | #[proc_macro_attribute(x)]
    | ^^^^^^^^^^^^^^^^^^^^^^---^
-   | |                     |
-   | |                     didn't expect any arguments here
-   | help: must be of the form: `#[proc_macro_attribute]`
+   |                       |
+   |                       didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[proc_macro_attribute(x)]
+LL + #[proc_macro_attribute]
+   |
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/recursion/recursion_limit/invalid_digit_type.stderr
+++ b/tests/ui/recursion/recursion_limit/invalid_digit_type.stderr
@@ -3,11 +3,15 @@ error[E0539]: malformed `recursion_limit` attribute input
    |
 LL | #![recursion_limit = 123]
    | ^^^^^^^^^^^^^^^^^^^^^---^
-   | |                    |
-   | |                    expected a string literal here
-   | help: must be of the form: `#![recursion_limit = "N"]`
+   |                      |
+   |                      expected a string literal here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/limits.html#the-recursion_limit-attribute>
+help: must be of the form
+   |
+LL - #![recursion_limit = 123]
+LL + #![recursion_limit = "N"]
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/recursion/recursion_limit/no-value.stderr
+++ b/tests/ui/recursion/recursion_limit/no-value.stderr
@@ -2,9 +2,13 @@ error[E0539]: malformed `recursion_limit` attribute input
   --> $DIR/no-value.rs:3:1
    |
 LL | #![recursion_limit]
-   | ^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#![recursion_limit = "N"]`
+   | ^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/limits.html#the-recursion_limit-attribute>
+help: must be of the form
+   |
+LL | #![recursion_limit = "N"]
+   |                    +++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/issue-30535.stderr
+++ b/tests/ui/resolve/issue-30535.stderr
@@ -2,10 +2,13 @@ error[E0573]: expected type, found variant `foo::Foo::FooV`
   --> $DIR/issue-30535.rs:7:8
    |
 LL |     _: foo::Foo::FooV
-   |        ^^^^^^^^^^^^^^
-   |        |
-   |        not a type
-   |        help: try using the variant's enum: `foo::Foo`
+   |        ^^^^^^^^^^^^^^ not a type
+   |
+help: try using the variant's enum
+   |
+LL -     _: foo::Foo::FooV
+LL +     _: foo::Foo
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/issue-35675.stderr
+++ b/tests/ui/resolve/issue-35675.stderr
@@ -25,10 +25,13 @@ error[E0573]: expected type, found variant `Fruit::Apple`
   --> $DIR/issue-35675.rs:14:33
    |
 LL | fn should_return_fruit_too() -> Fruit::Apple {
-   |                                 ^^^^^^^^^^^^
-   |                                 |
-   |                                 not a type
-   |                                 help: try using the variant's enum: `Fruit`
+   |                                 ^^^^^^^^^^^^ not a type
+   |
+help: try using the variant's enum
+   |
+LL - fn should_return_fruit_too() -> Fruit::Apple {
+LL + fn should_return_fruit_too() -> Fruit {
+   |
 
 error[E0425]: cannot find function, tuple struct or tuple variant `Apple` in this scope
   --> $DIR/issue-35675.rs:16:5
@@ -45,10 +48,13 @@ error[E0573]: expected type, found variant `Ok`
   --> $DIR/issue-35675.rs:20:13
    |
 LL | fn foo() -> Ok {
-   |             ^^
-   |             |
-   |             not a type
-   |             help: try using the variant's enum: `std::result::Result`
+   |             ^^ not a type
+   |
+help: try using the variant's enum
+   |
+LL - fn foo() -> Ok {
+LL + fn foo() -> std::result::Result {
+   |
 
 error[E0425]: cannot find type `Variant3` in this scope
   --> $DIR/issue-35675.rs:25:13
@@ -66,10 +72,13 @@ error[E0573]: expected type, found variant `Some`
   --> $DIR/issue-35675.rs:29:13
    |
 LL | fn qux() -> Some {
-   |             ^^^^
-   |             |
-   |             not a type
-   |             help: try using the variant's enum: `std::option::Option`
+   |             ^^^^ not a type
+   |
+help: try using the variant's enum
+   |
+LL - fn qux() -> Some {
+LL + fn qux() -> std::option::Option {
+   |
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/resolve/issue-73427.stderr
+++ b/tests/ui/resolve/issue-73427.stderr
@@ -32,7 +32,7 @@ error[E0423]: expected value, found enum `B`
   --> $DIR/issue-73427.rs:35:5
    |
 LL |     B.foo();
-   |     ^ help: the following enum variant is available: `(B::TupleWithFields(/* fields */))`
+   |     ^
    |
 note: the enum is defined here
   --> $DIR/issue-73427.rs:9:1
@@ -42,6 +42,11 @@ LL | |     StructWithFields { x: () },
 LL | |     TupleWithFields(()),
 LL | | }
    | |_^
+help: the following enum variant is available
+   |
+LL -     B.foo();
+LL +     (B::TupleWithFields(/* fields */)).foo();
+   |
 
 error[E0423]: expected value, found enum `C`
   --> $DIR/issue-73427.rs:37:5

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/invalid-attribute.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/invalid-attribute.stderr
@@ -3,9 +3,14 @@ error[E0565]: malformed `non_exhaustive` attribute input
    |
 LL | #[non_exhaustive(anything)]
    | ^^^^^^^^^^^^^^^^----------^
-   | |               |
-   | |               didn't expect any arguments here
-   | help: must be of the form: `#[non_exhaustive]`
+   |                 |
+   |                 didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[non_exhaustive(anything)]
+LL + #[non_exhaustive]
+   |
 
 error: `#[non_exhaustive]` attribute cannot be used on traits
   --> $DIR/invalid-attribute.rs:5:1

--- a/tests/ui/rfcs/rfc-2091-track-caller/error-odd-syntax.stderr
+++ b/tests/ui/rfcs/rfc-2091-track-caller/error-odd-syntax.stderr
@@ -3,9 +3,14 @@ error[E0565]: malformed `track_caller` attribute input
    |
 LL | #[track_caller(1)]
    | ^^^^^^^^^^^^^^---^
-   | |             |
-   | |             didn't expect any arguments here
-   | help: must be of the form: `#[track_caller]`
+   |               |
+   |               didn't expect any arguments here
+   |
+help: must be of the form
+   |
+LL - #[track_caller(1)]
+LL + #[track_caller]
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rust-2018/removing-extern-crate-malformed-cfg.stderr
+++ b/tests/ui/rust-2018/removing-extern-crate-malformed-cfg.stderr
@@ -2,23 +2,27 @@ error: expected identifier, found `"macro_use"`
   --> $DIR/removing-extern-crate-malformed-cfg.rs:8:18
    |
 LL | #[cfg_attr(test, "macro_use")]
-   | -----------------^^^^^^^^^^^--
-   | |                |
-   | |                expected identifier
-   | help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   |                  ^^^^^^^^^^^ expected identifier
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL - #[cfg_attr(test, "macro_use")]
+LL + #[cfg_attr(predicate, attr1, attr2, ...)]
+   |
 
 error: expected one of `(`, `,`, `::`, or `=`, found `<eof>`
   --> $DIR/removing-extern-crate-malformed-cfg.rs:13:16
    |
 LL |     #[cfg_attr(test)]
-   |     -----------^^^^--
-   |     |          |
-   |     |          expected one of `(`, `,`, `::`, or `=`
-   |     help: must be of the form: `#[cfg_attr(predicate, attr1, attr2, ...)]`
+   |                ^^^^ expected one of `(`, `,`, `::`, or `=`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL -     #[cfg_attr(test)]
+LL +     #[cfg_attr(predicate, attr1, attr2, ...)]
+   |
 
 warning: unused extern crate
   --> $DIR/removing-extern-crate-malformed-cfg.rs:9:1

--- a/tests/ui/sanitizer/cfi/invalid-attr-encoding.stderr
+++ b/tests/ui/sanitizer/cfi/invalid-attr-encoding.stderr
@@ -2,10 +2,12 @@ error[E0539]: malformed `cfi_encoding` attribute input
   --> $DIR/invalid-attr-encoding.rs:10:1
    |
 LL | #[cfi_encoding]
-   | ^^^^^^^^^^^^^^^
-   | |
-   | expected this to be of the form `cfi_encoding = "..."`
-   | help: must be of the form: `#[cfi_encoding = "encoding"]`
+   | ^^^^^^^^^^^^^^^ expected this to be of the form `cfi_encoding = "..."`
+   |
+help: must be of the form
+   |
+LL | #[cfi_encoding = "encoding"]
+   |                ++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/span/E0805.stderr
+++ b/tests/ui/span/E0805.stderr
@@ -3,11 +3,15 @@ error[E0805]: malformed `cfg` macro input
    |
 LL |     if cfg!(not()) { }
    |        ^^^^^^^^--^
-   |        |       |
-   |        |       expected an argument here
-   |        help: must be of the form: `cfg!(predicate)`
+   |                |
+   |                expected an argument here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL -     if cfg!(not()) { }
+LL +     if cfg!(predicate) { }
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/stability-attribute/stability-attribute-sanity-2.stderr
+++ b/tests/ui/stability-attribute/stability-attribute-sanity-2.stderr
@@ -3,18 +3,28 @@ error[E0538]: malformed `stable` attribute input
    |
 LL | #[stable(feature = "a", feature = "b", since = "1.0.0")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^-------^^^^^^^^^^^^^^^^^^^^^^^^^
-   | |                       |
-   | |                       found `feature` used as a key more than once
-   | help: must be of the form: `#[stable(feature = "name", since = "version")]`
+   |                         |
+   |                         found `feature` used as a key more than once
+   |
+help: must be of the form
+   |
+LL - #[stable(feature = "a", feature = "b", since = "1.0.0")]
+LL + #[stable(feature = "name", since = "version")]
+   |
 
 error[E0539]: malformed `stable` attribute input
   --> $DIR/stability-attribute-sanity-2.rs:10:1
    |
 LL | #[stable(feature = "a", sinse = "1.0.0")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^---------------^^
-   | |                       |
-   | |                       valid arguments are `feature` or `since`
-   | help: must be of the form: `#[stable(feature = "name", since = "version")]`
+   |                         |
+   |                         valid arguments are `feature` or `since`
+   |
+help: must be of the form
+   |
+LL - #[stable(feature = "a", sinse = "1.0.0")]
+LL + #[stable(feature = "name", since = "version")]
+   |
 
 error[E0545]: `issue` must be a non-zero numeric string or "none"
   --> $DIR/stability-attribute-sanity-2.rs:13:27

--- a/tests/ui/stability-attribute/stability-attribute-sanity-4.stderr
+++ b/tests/ui/stability-attribute/stability-attribute-sanity-4.stderr
@@ -2,37 +2,51 @@ error[E0539]: malformed `unstable` attribute input
   --> $DIR/stability-attribute-sanity-4.rs:8:5
    |
 LL |     #[unstable]
-   |     ^^^^^^^^^^^
-   |     |
-   |     expected this to be a list
-   |     help: must be of the form: `#[unstable(feature = "name", reason = "...", issue = "N")]`
+   |     ^^^^^^^^^^^ expected this to be a list
+   |
+help: must be of the form
+   |
+LL |     #[unstable(feature = "name", reason = "...", issue = "N")]
+   |               +++++++++++++++++++++++++++++++++++++++++++++++
 
 error[E0539]: malformed `unstable` attribute input
   --> $DIR/stability-attribute-sanity-4.rs:11:5
    |
 LL |     #[unstable = "b"]
    |     ^^^^^^^^^^^-----^
-   |     |          |
-   |     |          expected this to be a list
-   |     help: must be of the form: `#[unstable(feature = "name", reason = "...", issue = "N")]`
+   |                |
+   |                expected this to be a list
+   |
+help: must be of the form
+   |
+LL -     #[unstable = "b"]
+LL +     #[unstable(feature = "name", reason = "...", issue = "N")]
+   |
 
 error[E0539]: malformed `stable` attribute input
   --> $DIR/stability-attribute-sanity-4.rs:14:5
    |
 LL |     #[stable]
-   |     ^^^^^^^^^
-   |     |
-   |     expected this to be a list
-   |     help: must be of the form: `#[stable(feature = "name", since = "version")]`
+   |     ^^^^^^^^^ expected this to be a list
+   |
+help: must be of the form
+   |
+LL |     #[stable(feature = "name", since = "version")]
+   |             +++++++++++++++++++++++++++++++++++++
 
 error[E0539]: malformed `stable` attribute input
   --> $DIR/stability-attribute-sanity-4.rs:17:5
    |
 LL |     #[stable = "a"]
    |     ^^^^^^^^^-----^
-   |     |        |
-   |     |        expected this to be a list
-   |     help: must be of the form: `#[stable(feature = "name", since = "version")]`
+   |              |
+   |              expected this to be a list
+   |
+help: must be of the form
+   |
+LL -     #[stable = "a"]
+LL +     #[stable(feature = "name", since = "version")]
+   |
 
 error[E0542]: missing 'since'
   --> $DIR/stability-attribute-sanity-4.rs:21:5

--- a/tests/ui/stability-attribute/stability-attribute-sanity.stderr
+++ b/tests/ui/stability-attribute/stability-attribute-sanity.stderr
@@ -3,45 +3,70 @@ error[E0539]: malformed `stable` attribute input
    |
 LL |     #[stable(feature = "a", since = "4.4.4", reason)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------^^
-   |     |                                        |
-   |     |                                        valid arguments are `feature` or `since`
-   |     help: must be of the form: `#[stable(feature = "name", since = "version")]`
+   |                                              |
+   |                                              valid arguments are `feature` or `since`
+   |
+help: must be of the form
+   |
+LL -     #[stable(feature = "a", since = "4.4.4", reason)]
+LL +     #[stable(feature = "name", since = "version")]
+   |
 
 error[E0539]: malformed `stable` attribute input
   --> $DIR/stability-attribute-sanity.rs:11:5
    |
 LL |     #[stable(feature = "a", since)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^-----^^
-   |     |                       |
-   |     |                       expected this to be of the form `since = "..."`
-   |     help: must be of the form: `#[stable(feature = "name", since = "version")]`
+   |                             |
+   |                             expected this to be of the form `since = "..."`
+   |
+help: must be of the form
+   |
+LL -     #[stable(feature = "a", since)]
+LL +     #[stable(feature = "name", since = "version")]
+   |
 
 error[E0539]: malformed `stable` attribute input
   --> $DIR/stability-attribute-sanity.rs:14:5
    |
 LL |     #[stable(feature, since = "3.3.3")]
    |     ^^^^^^^^^-------^^^^^^^^^^^^^^^^^^^
-   |     |        |
-   |     |        expected this to be of the form `feature = "..."`
-   |     help: must be of the form: `#[stable(feature = "name", since = "version")]`
+   |              |
+   |              expected this to be of the form `feature = "..."`
+   |
+help: must be of the form
+   |
+LL -     #[stable(feature, since = "3.3.3")]
+LL +     #[stable(feature = "name", since = "version")]
+   |
 
 error[E0539]: malformed `stable` attribute input
   --> $DIR/stability-attribute-sanity.rs:17:5
    |
 LL |     #[stable(feature = "a", since(b))]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^--------^^
-   |     |                       |
-   |     |                       expected this to be of the form `since = "..."`
-   |     help: must be of the form: `#[stable(feature = "name", since = "version")]`
+   |                             |
+   |                             expected this to be of the form `since = "..."`
+   |
+help: must be of the form
+   |
+LL -     #[stable(feature = "a", since(b))]
+LL +     #[stable(feature = "name", since = "version")]
+   |
 
 error[E0539]: malformed `stable` attribute input
   --> $DIR/stability-attribute-sanity.rs:20:5
    |
 LL |     #[stable(feature(b), since = "3.3.3")]
    |     ^^^^^^^^^----------^^^^^^^^^^^^^^^^^^^
-   |     |        |
-   |     |        expected this to be of the form `feature = "..."`
-   |     help: must be of the form: `#[stable(feature = "name", since = "version")]`
+   |              |
+   |              expected this to be of the form `feature = "..."`
+   |
+help: must be of the form
+   |
+LL -     #[stable(feature(b), since = "3.3.3")]
+LL +     #[stable(feature = "name", since = "version")]
+   |
 
 error[E0546]: missing 'feature'
   --> $DIR/stability-attribute-sanity.rs:25:5

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-closure.stderr
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-closure.stderr
@@ -2,13 +2,15 @@ error[E0594]: cannot assign to `t.v`, which is behind a `&` reference
   --> $DIR/suggest-mut-method-for-loop-closure.rs:15:13
    |
 LL |         for mut t in buzz.values() {
-   |                      -------------
-   |                      |    |
-   |                      |    help: use mutable method: `values_mut()`
-   |                      this iterator yields `&` references
+   |                      ------------- this iterator yields `&` references
 ...
 LL |             t.v += 1;
    |             ^^^^^^^^ `t` is a `&` reference, so it cannot be written to
+   |
+help: use mutable method
+   |
+LL |         for mut t in buzz.values_mut() {
+   |                                 ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.stderr
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.stderr
@@ -2,13 +2,15 @@ error[E0594]: cannot assign to `v.v`, which is behind a `&` reference
   --> $DIR/suggest-mut-method-for-loop-hashmap.rs:17:9
    |
 LL |     for (_k, v) in map.iter() {
-   |                    ----------
-   |                    |   |
-   |                    |   help: use mutable method: `iter_mut()`
-   |                    this iterator yields `&` references
+   |                    ---------- this iterator yields `&` references
 ...
 LL |         v.v += 1;
    |         ^^^^^^^^ `v` is a `&` reference, so it cannot be written to
+   |
+help: use mutable method
+   |
+LL |     for (_k, v) in map.iter_mut() {
+   |                            ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/suggest-mut-method-for-loop.stderr
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop.stderr
@@ -2,13 +2,15 @@ error[E0594]: cannot assign to `t.v`, which is behind a `&` reference
   --> $DIR/suggest-mut-method-for-loop.rs:14:9
    |
 LL |     for mut t in buzz.values() {
-   |                  -------------
-   |                  |    |
-   |                  |    help: use mutable method: `values_mut()`
-   |                  this iterator yields `&` references
+   |                  ------------- this iterator yields `&` references
 ...
 LL |         t.v += 1;
    |         ^^^^^^^^ `t` is a `&` reference, so it cannot be written to
+   |
+help: use mutable method
+   |
+LL |     for mut t in buzz.values_mut() {
+   |                             ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/target-feature/invalid-attribute.stderr
+++ b/tests/ui/target-feature/invalid-attribute.stderr
@@ -27,27 +27,42 @@ error[E0539]: malformed `target_feature` attribute input
    |
 LL | #[target_feature = "+sse2"]
    | ^^^^^^^^^^^^^^^^^---------^
-   | |                |
-   | |                expected this to be a list
-   | help: must be of the form: `#[target_feature(enable = "feat1, feat2")]`
+   |                  |
+   |                  expected this to be a list
+   |
+help: must be of the form
+   |
+LL - #[target_feature = "+sse2"]
+LL + #[target_feature(enable = "feat1, feat2")]
+   |
 
 error[E0539]: malformed `target_feature` attribute input
   --> $DIR/invalid-attribute.rs:29:1
    |
 LL | #[target_feature(bar)]
    | ^^^^^^^^^^^^^^^^^---^^
-   | |                |
-   | |                expected this to be of the form `enable = "..."`
-   | help: must be of the form: `#[target_feature(enable = "feat1, feat2")]`
+   |                  |
+   |                  expected this to be of the form `enable = "..."`
+   |
+help: must be of the form
+   |
+LL - #[target_feature(bar)]
+LL + #[target_feature(enable = "feat1, feat2")]
+   |
 
 error[E0539]: malformed `target_feature` attribute input
   --> $DIR/invalid-attribute.rs:32:1
    |
 LL | #[target_feature(disable = "baz")]
    | ^^^^^^^^^^^^^^^^^-------^^^^^^^^^^
-   | |                |
-   | |                expected this to be of the form `enable = "..."`
-   | help: must be of the form: `#[target_feature(enable = "feat1, feat2")]`
+   |                  |
+   |                  expected this to be of the form `enable = "..."`
+   |
+help: must be of the form
+   |
+LL - #[target_feature(disable = "baz")]
+LL + #[target_feature(enable = "feat1, feat2")]
+   |
 
 error: `#[target_feature]` attribute cannot be used on modules
   --> $DIR/invalid-attribute.rs:37:1

--- a/tests/ui/tool-attributes/invalid-tool.stderr
+++ b/tests/ui/tool-attributes/invalid-tool.stderr
@@ -3,9 +3,14 @@ error[E0539]: malformed `register_tool` attribute input
    |
 LL | #![register_tool(1)]
    | ^^^^^^^^^^^^^^^^^-^^
-   | |                |
-   | |                expected a valid identifier here
-   | help: must be of the form: `#![register_tool(tool1, tool2, ...)]`
+   |                  |
+   |                  expected a valid identifier here
+   |
+help: must be of the form
+   |
+LL - #![register_tool(1)]
+LL + #![register_tool(tool1, tool2, ...)]
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/tool-attributes/nested-disallowed.stderr
+++ b/tests/ui/tool-attributes/nested-disallowed.stderr
@@ -3,9 +3,14 @@ error[E0539]: malformed `register_tool` attribute input
    |
 LL | #![register_tool(foo::bar)]
    | ^^^^^^^^^^^^^^^^^--------^^
-   | |                |
-   | |                expected a valid identifier here
-   | help: must be of the form: `#![register_tool(tool1, tool2, ...)]`
+   |                  |
+   |                  expected a valid identifier here
+   |
+help: must be of the form
+   |
+LL - #![register_tool(foo::bar)]
+LL + #![register_tool(tool1, tool2, ...)]
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/default-method/rustc_must_implement_one_of_misuse.stderr
+++ b/tests/ui/traits/default-method/rustc_must_implement_one_of_misuse.stderr
@@ -3,18 +3,25 @@ error[E0539]: malformed `rustc_must_implement_one_of` attribute input
    |
 LL | #[rustc_must_implement_one_of(a)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---^
-   | |                            |
-   | |                            expected 2 or more items
-   | help: must be of the form: `#[rustc_must_implement_one_of(function1, function2, ...)]`
+   |                              |
+   |                              expected 2 or more items
+   |
+help: must be of the form
+   |
+LL - #[rustc_must_implement_one_of(a)]
+LL + #[rustc_must_implement_one_of(function1, function2, ...)]
+   |
 
 error[E0539]: malformed `rustc_must_implement_one_of` attribute input
   --> $DIR/rustc_must_implement_one_of_misuse.rs:20:1
    |
 LL | #[rustc_must_implement_one_of]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   | |
-   | expected this to be a list
-   | help: must be of the form: `#[rustc_must_implement_one_of(function1, function2, ...)]`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected this to be a list
+   |
+help: must be of the form
+   |
+LL | #[rustc_must_implement_one_of(function1, function2, ...)]
+   |                              +++++++++++++++++++++++++++
 
 error: `#[rustc_must_implement_one_of]` attribute cannot be used on functions
   --> $DIR/rustc_must_implement_one_of_misuse.rs:38:1


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/154605)*
<!-- homu-ignore:end -->

`span_suggestions` is to provide mutually exclusive suggestions. When it was introduced, we made its behavior be that if a single suggestion is given to it, we present the suggestion inline, otherwise in patch format. Changing this to make all of its uses be verbose, as that is closer in intent of output.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
