### PR TITLE
Add `_value` API for number literals in proc-macro

### DIFF
--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -28,6 +28,7 @@
 #![feature(rustc_attrs)]
 #![feature(extend_one)]
 #![feature(mem_conjure_zst)]
+#![feature(f16)]
 #![recursion_limit = "256"]
 #![allow(internal_features)]
 #![deny(ffi_unwind_calls)]
@@ -46,6 +47,7 @@ mod to_tokens;
 
 use core::convert::From;
 use core::ops::BitOr;
+use std::borrow::Cow;
 use std::ffi::CStr;
 use std::ops::{Range, RangeBounds};
 use std::path::PathBuf;
@@ -1311,6 +1313,63 @@ macro_rules! unsuffixed_int_literals {
     )*)
 }
 
+macro_rules! integer_values {
+    ($($nb:ident => $fn_name:ident,)+) => {
+        $(
+            #[doc = concat!(
+                "Returns the unescaped `",
+                stringify!($nb),
+                "` value if the literal is a `",
+                stringify!($nb),
+                "` or if it's an \"unmarked\" integer which doesn't overflow.")]
+            #[unstable(feature = "proc_macro_value", issue = "136652")]
+            pub fn $fn_name(&self) -> Result<$nb, ConversionErrorKind> {
+                if self.0.kind != bridge::LitKind::Integer {
+                    return Err(ConversionErrorKind::InvalidLiteralKind);
+                }
+                self.with_symbol_and_suffix(|symbol, suffix| {
+                    match suffix {
+                        stringify!($nb) | "" => {
+                            let symbol = strip_underscores(symbol);
+                            let (number, base) = parse_number(&symbol);
+                            $nb::from_str_radix(&number, base as u32).map_err(|_| ConversionErrorKind::InvalidLiteralKind)
+                        }
+                        _ => Err(ConversionErrorKind::InvalidLiteralKind),
+                    }
+                })
+            }
+        )+
+    }
+}
+
+macro_rules! float_values {
+    ($($nb:ident => $fn_name:ident,)+) => {
+        $(
+            #[doc = concat!(
+                "Returns the unescaped `",
+                stringify!($nb),
+                "` value if the literal is a `",
+                stringify!($nb),
+                "` or if it's an \"unmarked\" float which doesn't overflow.")]
+            #[unstable(feature = "proc_macro_value", issue = "136652")]
+            pub fn $fn_name(&self) -> Result<$nb, ConversionErrorKind> {
+                if self.0.kind != bridge::LitKind::Float {
+                    return Err(ConversionErrorKind::InvalidLiteralKind);
+                }
+                self.with_symbol_and_suffix(|symbol, suffix| {
+                    match suffix {
+                        stringify!($nb) | "" => {
+                            let number = strip_underscores(symbol);
+                            $nb::from_str(&number).map_err(|_| ConversionErrorKind::InvalidLiteralKind)
+                        }
+                        _ => Err(ConversionErrorKind::InvalidLiteralKind),
+                    }
+                })
+            }
+        )+
+    }
+}
+
 impl Literal {
     fn new(kind: bridge::LitKind, value: &str, suffix: Option<&str>) -> Self {
         Literal(bridge::Literal {
@@ -1704,6 +1763,82 @@ impl Literal {
             _ => Err(ConversionErrorKind::InvalidLiteralKind),
         })
     }
+
+    integer_values! {
+        u8 => u8_value,
+        u16 => u16_value,
+        u32 => u32_value,
+        u64 => u64_value,
+        u128 => u128_value,
+        i8 => i8_value,
+        i16 => i16_value,
+        i32 => i32_value,
+        i64 => i64_value,
+        i128 => i128_value,
+    }
+
+    float_values! {
+        f16 => f16_value,
+        f32 => f32_value,
+        f64 => f64_value,
+        // FIXME: `f128` doesn't implement `FromStr` for the moment so we cannot obtain it from
+        // a `&str`. To be uncommented when it's added.
+        // f128 => f128_value,
+    }
+}
+
+#[repr(u32)]
+#[derive(PartialEq, Eq)]
+enum Base {
+    Decimal = 10,
+    Binary = 2,
+    Octal = 8,
+    Hexadecimal = 16,
+}
+
+fn parse_number(value: &str) -> (&str, Base) {
+    let mut iter = value.as_bytes().iter().copied();
+    let Some(first_digit) = iter.next() else {
+        return ("0", Base::Decimal);
+    };
+    let Some(second_digit) = iter.next() else {
+        return (value, Base::Decimal);
+    };
+
+    let mut base = Base::Decimal;
+    if first_digit == b'0' {
+        // Attempt to parse encoding base.
+        match second_digit {
+            b'b' => {
+                base = Base::Binary;
+            }
+            b'o' => {
+                base = Base::Octal;
+            }
+            b'x' => {
+                base = Base::Hexadecimal;
+            }
+            _ => {}
+        }
+    }
+
+    let offset = if base == Base::Decimal { 0 } else { 2 };
+
+    (&value[offset..], base)
+}
+
+fn strip_underscores(value_s: &str) -> Cow<'_, str> {
+    let value = value_s.as_bytes();
+    if value.iter().copied().all(|c| c != b'_' && c != b'f') {
+        return Cow::Borrowed(value_s);
+    }
+    let mut output = String::with_capacity(value.len());
+    for c in value.iter().copied() {
+        if c != b'_' {
+            output.push(c as char);
+        }
+    }
+    Cow::Owned(output)
 }
 
 /// Parse a single literal from its stringified representation.

--- a/tests/ui/proc-macro/auxiliary/api/literal.rs
+++ b/tests/ui/proc-macro/auxiliary/api/literal.rs
@@ -1,10 +1,13 @@
 // ignore-tidy-linelength
 
+#![feature(f16)]
+
 use proc_macro::Literal;
 
 pub fn test() {
     test_display_literal();
     test_parse_literal();
+    test_literal_value();
 }
 
 fn test_display_literal() {
@@ -80,4 +83,28 @@ fn test_parse_literal() {
     assert!("0// comment".parse::<Literal>().is_err());
     assert!("- 10".parse::<Literal>().is_err());
     assert!("-'x'".parse::<Literal>().is_err());
+}
+
+fn test_literal_value() {
+    assert!(Literal::u32_suffixed(10).u8_value().is_err());
+    assert!(Literal::u32_suffixed(11).f32_value().is_err());
+    assert!(Literal::u32_suffixed(12).u64_value().is_err());
+    assert_eq!(Literal::u32_suffixed(13).u32_value(), Ok(13u32));
+    assert_eq!(Literal::u32_unsuffixed(14).u64_value(), Ok(14u64));
+    assert_eq!(Literal::u32_unsuffixed(15).u8_value(), Ok(15u8));
+    assert!(Literal::u32_unsuffixed(400).u8_value().is_err());
+    assert_eq!(Literal::u32_unsuffixed(401).u16_value(), Ok(401u16));
+    assert!(Literal::i32_unsuffixed(-402).u16_value().is_err());
+    assert_eq!(Literal::i32_unsuffixed(-403).i16_value(), Ok(-403i16));
+    assert_eq!(Literal::u32_unsuffixed(0xff).u16_value(), Ok(0xffu16));
+    assert_eq!(Literal::u32_unsuffixed(0b11).u16_value(), Ok(0b11u16));
+    assert_eq!(Literal::u32_unsuffixed(0o11).u16_value(), Ok(0o11u16));
+
+    assert!(Literal::f32_suffixed(9.).u8_value().is_err());
+    assert!(Literal::f32_suffixed(10.).f64_value().is_err());
+    assert!(Literal::f32_suffixed(11.).f16_value().is_err());
+    assert_eq!(Literal::f32_suffixed(12.).f32_value().map(|f| f.to_string()), Ok("12".to_string()));
+    assert_eq!(Literal::f32_unsuffixed(13.).f32_value().map(|f| f.to_string()), Ok("13".to_string()));
+    assert_eq!(Literal::f32_unsuffixed(14.).f64_value().map(|f| f.to_string()), Ok("14".to_string()));
+    assert_eq!(Literal::f32_unsuffixed(15.).f16_value().map(|f| f.to_string()), Ok("15".to_string()));
 }

--- a/tests/ui/proc-macro/auxiliary/api/literal.rs
+++ b/tests/ui/proc-macro/auxiliary/api/literal.rs
@@ -1,7 +1,5 @@
 // ignore-tidy-linelength
 
-#![feature(f16)]
-
 use proc_macro::Literal;
 
 pub fn test() {
@@ -102,9 +100,15 @@ fn test_literal_value() {
 
     assert!(Literal::f32_suffixed(9.).u8_value().is_err());
     assert!(Literal::f32_suffixed(10.).f64_value().is_err());
-    assert!(Literal::f32_suffixed(11.).f16_value().is_err());
+    #[cfg(target_has_reliable_f16)]
+    {
+        assert!(Literal::f32_suffixed(11.).f16_value().is_err());
+    }
     assert_eq!(Literal::f32_suffixed(12.).f32_value().map(|f| f.to_string()), Ok("12".to_string()));
     assert_eq!(Literal::f32_unsuffixed(13.).f32_value().map(|f| f.to_string()), Ok("13".to_string()));
     assert_eq!(Literal::f32_unsuffixed(14.).f64_value().map(|f| f.to_string()), Ok("14".to_string()));
-    assert_eq!(Literal::f32_unsuffixed(15.).f16_value().map(|f| f.to_string()), Ok("15".to_string()));
+    #[cfg(target_has_reliable_f16)]
+    {
+        assert_eq!(Literal::f32_unsuffixed(15.).f16_value().map(|f| f.to_string()), Ok("15".to_string()));
+    }
 }

--- a/tests/ui/proc-macro/auxiliary/api/proc_macro_api_tests.rs
+++ b/tests/ui/proc-macro/auxiliary/api/proc_macro_api_tests.rs
@@ -1,6 +1,7 @@
 //@ edition: 2021
 
 #![feature(proc_macro_span)]
+#![feature(proc_macro_value)]
 #![deny(dead_code)] // catch if a test function is never called
 
 extern crate proc_macro;

--- a/tests/ui/proc-macro/auxiliary/api/proc_macro_api_tests.rs
+++ b/tests/ui/proc-macro/auxiliary/api/proc_macro_api_tests.rs
@@ -2,6 +2,8 @@
 
 #![feature(proc_macro_span)]
 #![feature(proc_macro_value)]
+#![feature(f16)]
+#![feature(cfg_target_has_reliable_f16_f128)]
 #![deny(dead_code)] // catch if a test function is never called
 
 extern crate proc_macro;

--- a/tests/ui/proc-macro/test.rs
+++ b/tests/ui/proc-macro/test.rs
@@ -1,6 +1,9 @@
 //@ check-pass
 //@ proc-macro: api/proc_macro_api_tests.rs
 //@ edition: 2021
+// Because of a (known) proc-macro ABI issue with GCC backend, this test
+// fails because of it.
+//@ ignore-backends: gcc
 
 //! This is for everything that *would* be a #[test] inside of libproc_macro,
 //! except for the fact that proc_macro objects are not capable of existing


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/154608)*
<!-- homu-ignore:end -->

Part of rust-lang/rust#136652.

This PR adds the `*_value` for numbers (integers and floats). However, `f16` and `f128` are voluntarily left out as they're still unstable. Adding support for them is just a matter of uncommenting two lines, so should be fine.

Setting same reviewer as last time.

r? @Urgau 