### PR TITLE
Add a test for a now fixed ICE with `offset_of!()`

### DIFF
--- a/tests/ui/offset-of/offset-of-unsized-trait-object-missing-lifetime.rs
+++ b/tests/ui/offset-of/offset-of-unsized-trait-object-missing-lifetime.rs
@@ -1,0 +1,20 @@
+//@ edition:2021
+// Regression test for #125805.
+// ICE when using `offset_of!` on a field whose type is a bare trait object
+// with a missing lifetime parameter.
+
+trait X<'a> {}
+
+use std::mem::offset_of;
+
+struct T {
+    y: X,
+    //~^ ERROR missing lifetime specifier [E0106]
+    //~| ERROR expected a type, found a trait [E0782]
+}
+
+fn other() {
+    offset_of!(T, y);
+}
+
+fn main() {}

--- a/tests/ui/offset-of/offset-of-unsized-trait-object-missing-lifetime.stderr
+++ b/tests/ui/offset-of/offset-of-unsized-trait-object-missing-lifetime.stderr
@@ -1,0 +1,27 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/offset-of-unsized-trait-object-missing-lifetime.rs:11:8
+   |
+LL |     y: X,
+   |        ^ expected named lifetime parameter
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL ~ struct T<'a> {
+LL ~     y: X<'a>,
+   |
+
+error[E0782]: expected a type, found a trait
+  --> $DIR/offset-of-unsized-trait-object-missing-lifetime.rs:11:8
+   |
+LL |     y: X,
+   |        ^
+   |
+help: you can add the `dyn` keyword if you want a trait object
+   |
+LL |     y: dyn X,
+   |        +++
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0106, E0782.
+For more information about an error, try `rustc --explain E0106`.


### PR DESCRIPTION
Adds a test for rust-lang/rust#125805, which was an ICE with `offset_of!()` on a field with the type of a trait object missing `dyn` and a required lifetime parameter.

Closes rust-lang/rust#125805.
