### PR TITLE
Fix AtomicPtr::update's cfg gate

### DIFF
--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -2136,7 +2136,7 @@ impl<T> AtomicPtr<T> {
     /// ```
     #[inline]
     #[stable(feature = "atomic_try_update", since = "1.95.0")]
-    #[cfg(target_has_atomic = "8")]
+    #[cfg(target_has_atomic = "ptr")]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[rustc_should_not_be_called_on_const_items]
     pub fn update(


### PR DESCRIPTION
I'm *pretty* sure this is supposed to be `#[cfg(target_has_atomic = "ptr")]` like `AtomicPtr::try_update` is.

cc @GrigorenkoPV (author), @Noratrieb (r+ to rust-lang/rust#133829)
