### PR TITLE
Move issue-16562 to tests/ui/generics/

### DIFF
--- a/tests/ui/generics/unconstrained-type-param-in-impl.rs
+++ b/tests/ui/generics/unconstrained-type-param-in-impl.rs
@@ -1,3 +1,6 @@
+// Regression test for https://github.com/rust-lang/rust/issues/16562
+// Tests that E0207 is emitted when a type parameter is unconstrained in an impl block.
+
 trait MatrixShape {}
 
 struct Col<D, C> {

--- a/tests/ui/generics/unconstrained-type-param-in-impl.stderr
+++ b/tests/ui/generics/unconstrained-type-param-in-impl.stderr
@@ -1,5 +1,5 @@
 error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/issue-16562.rs:10:6
+  --> $DIR/unconstrained-type-param-in-impl.rs:10:6
    |
 LL | impl<T, M: MatrixShape> Collection for Col<M, usize> {
    |      ^ unconstrained type parameter


### PR DESCRIPTION
Part of the ongoing effort to reorganize tests/ui/issues/ (tracking issue rust-lang/rust#130441).

Moves the regression test for rust-lang/rust#16562 (unconstrained type parameter E0207)
to a more descriptive location: tests/ui/generics/unconstrained-type-param-in-impl.rs

Changes:
- Added issue link and description comment at top of file
- Updated $DIR path in .stderr file
- Renamed file to reflect what it actually tests