### PR TITLE
Make `DerefPure` dyn-incompatible

### DIFF
--- a/library/core/src/ops/deref.rs
+++ b/library/core/src/ops/deref.rs
@@ -293,6 +293,7 @@ impl<T: ?Sized> const DerefMut for &mut T {
 /// unchanged.
 #[unstable(feature = "deref_pure_trait", issue = "87121")]
 #[lang = "deref_pure"]
+#[rustc_dyn_incompatible_trait]
 pub unsafe trait DerefPure: PointeeSized {}
 
 #[unstable(feature = "deref_pure_trait", issue = "87121")]


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/154619.

If `DerefPure` were dyn-compatible, a trait object of a subtrait of `DerefPure` could be created by unsize-coercing an existing type that implements `DerefPure`. But then the trait object could have its own non-pure impl of `Deref`/`DerefMut`, which is unsound, since the trait object would implement `DerefPure`. Thus, we make `DerefPure` dyn-incompatible.

r? types
