### PR TITLE
Use `Hcx`/`hcx` consistently for `StableHashingContext`.

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -120,8 +120,8 @@ impl PartialEq<&[Symbol]> for Path {
     }
 }
 
-impl<CTX: rustc_span::HashStableContext> HashStable<CTX> for Path {
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+impl<Hcx: rustc_span::HashStableContext> HashStable<Hcx> for Path {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         self.segments.len().hash_stable(hcx, hasher);
         for segment in &self.segments {
             segment.ident.hash_stable(hcx, hasher);

--- a/compiler/rustc_ast/src/tokenstream.rs
+++ b/compiler/rustc_ast/src/tokenstream.rs
@@ -138,8 +138,8 @@ impl<D: SpanDecoder> Decodable<D> for LazyAttrTokenStream {
     }
 }
 
-impl<CTX> HashStable<CTX> for LazyAttrTokenStream {
-    fn hash_stable(&self, _hcx: &mut CTX, _hasher: &mut StableHasher) {
+impl<Hcx> HashStable<Hcx> for LazyAttrTokenStream {
+    fn hash_stable(&self, _hcx: &mut Hcx, _hasher: &mut StableHasher) {
         panic!("Attempted to compute stable hash for LazyAttrTokenStream");
     }
 }
@@ -824,11 +824,11 @@ impl FromIterator<TokenTree> for TokenStream {
     }
 }
 
-impl<CTX> HashStable<CTX> for TokenStream
+impl<Hcx> HashStable<Hcx> for TokenStream
 where
-    CTX: crate::HashStableContext,
+    Hcx: crate::HashStableContext,
 {
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         for sub_tt in self.iter() {
             sub_tt.hash_stable(hcx, hasher);
         }

--- a/compiler/rustc_codegen_cranelift/src/driver/aot.rs
+++ b/compiler/rustc_codegen_cranelift/src/driver/aot.rs
@@ -45,8 +45,8 @@ enum OngoingModuleCodegen {
     Async(JoinHandle<Result<ModuleCodegenResult, String>>),
 }
 
-impl<HCX> HashStable<HCX> for OngoingModuleCodegen {
-    fn hash_stable(&self, _: &mut HCX, _: &mut StableHasher) {
+impl<Hcx> HashStable<Hcx> for OngoingModuleCodegen {
+    fn hash_stable(&self, _: &mut Hcx, _: &mut StableHasher) {
         // do nothing
     }
 }

--- a/compiler/rustc_codegen_ssa/src/common.rs
+++ b/compiler/rustc_codegen_ssa/src/common.rs
@@ -102,8 +102,8 @@ mod temp_stable_hash_impls {
 
     use crate::ModuleCodegen;
 
-    impl<HCX, M> HashStable<HCX> for ModuleCodegen<M> {
-        fn hash_stable(&self, _: &mut HCX, _: &mut StableHasher) {
+    impl<Hcx, M> HashStable<Hcx> for ModuleCodegen<M> {
+        fn hash_stable(&self, _: &mut Hcx, _: &mut StableHasher) {
             // do nothing
         }
     }

--- a/compiler/rustc_data_structures/src/intern.rs
+++ b/compiler/rustc_data_structures/src/intern.rs
@@ -103,11 +103,11 @@ where
     }
 }
 
-impl<T, CTX> HashStable<CTX> for Interned<'_, T>
+impl<T, Hcx> HashStable<Hcx> for Interned<'_, T>
 where
-    T: HashStable<CTX>,
+    T: HashStable<Hcx>,
 {
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         self.0.hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_data_structures/src/packed.rs
+++ b/compiler/rustc_data_structures/src/packed.rs
@@ -60,10 +60,10 @@ impl fmt::UpperHex for Pu128 {
     }
 }
 
-impl<CTX> HashStable<CTX> for Pu128 {
+impl<Hcx> HashStable<Hcx> for Pu128 {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        { self.0 }.hash_stable(ctx, hasher)
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+        { self.0 }.hash_stable(hcx, hasher)
     }
 }
 

--- a/compiler/rustc_data_structures/src/sorted_map.rs
+++ b/compiler/rustc_data_structures/src/sorted_map.rs
@@ -347,10 +347,10 @@ impl<K: Ord, V> FromIterator<(K, V)> for SortedMap<K, V> {
     }
 }
 
-impl<K: HashStable<CTX> + StableOrd, V: HashStable<CTX>, CTX> HashStable<CTX> for SortedMap<K, V> {
+impl<K: HashStable<Hcx> + StableOrd, V: HashStable<Hcx>, Hcx> HashStable<Hcx> for SortedMap<K, V> {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        self.data.hash_stable(ctx, hasher);
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+        self.data.hash_stable(hcx, hasher);
     }
 }
 

--- a/compiler/rustc_data_structures/src/stable_hasher.rs
+++ b/compiler/rustc_data_structures/src/stable_hasher.rs
@@ -15,7 +15,7 @@ pub use rustc_stable_hash::{
     FromStableHash, SipHasher128Hash as StableHasherHash, StableSipHasher128 as StableHasher,
 };
 
-/// Something that implements `HashStable<CTX>` can be hashed in a way that is
+/// Something that implements `HashStable<Hcx>` can be hashed in a way that is
 /// stable across multiple compilation sessions.
 ///
 /// Note that `HashStable` imposes rather more strict requirements than usual
@@ -41,16 +41,16 @@ pub use rustc_stable_hash::{
 /// - `hash_stable()` must be independent of the host architecture. The
 ///   `StableHasher` takes care of endianness and `isize`/`usize` platform
 ///   differences.
-pub trait HashStable<CTX> {
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher);
+pub trait HashStable<Hcx> {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher);
 }
 
 /// Implement this for types that can be turned into stable keys like, for
 /// example, for DefId that can be converted to a DefPathHash. This is used for
 /// bringing maps into a predictable order before hashing them.
-pub trait ToStableHashKey<HCX> {
-    type KeyType: Ord + Sized + HashStable<HCX>;
-    fn to_stable_hash_key(&self, hcx: &HCX) -> Self::KeyType;
+pub trait ToStableHashKey<Hcx> {
+    type KeyType: Ord + Sized + HashStable<Hcx>;
+    fn to_stable_hash_key(&self, hcx: &Hcx) -> Self::KeyType;
 }
 
 /// Trait for marking a type as having a sort order that is
@@ -136,9 +136,9 @@ impl<T: StableOrd> StableCompare for T {
 /// Use `#[derive(HashStable_Generic)]` instead.
 macro_rules! impl_stable_traits_for_trivial_type {
     ($t:ty) => {
-        impl<CTX> $crate::stable_hasher::HashStable<CTX> for $t {
+        impl<Hcx> $crate::stable_hasher::HashStable<Hcx> for $t {
             #[inline]
-            fn hash_stable(&self, _: &mut CTX, hasher: &mut $crate::stable_hasher::StableHasher) {
+            fn hash_stable(&self, _: &mut Hcx, hasher: &mut $crate::stable_hasher::StableHasher) {
                 ::std::hash::Hash::hash(self, hasher);
             }
         }
@@ -177,9 +177,9 @@ impl_stable_traits_for_trivial_type!(Hash64);
 
 // We need a custom impl as the default hash function will only hash half the bits. For stable
 // hashing we want to hash the full 128-bit hash.
-impl<CTX> HashStable<CTX> for Hash128 {
+impl<Hcx> HashStable<Hcx> for Hash128 {
     #[inline]
-    fn hash_stable(&self, _: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable(&self, _: &mut Hcx, hasher: &mut StableHasher) {
         self.as_u128().hash(hasher);
     }
 }
@@ -192,64 +192,64 @@ impl StableOrd for Hash128 {
     const THIS_IMPLEMENTATION_HAS_BEEN_TRIPLE_CHECKED: () = ();
 }
 
-impl<CTX> HashStable<CTX> for ! {
-    fn hash_stable(&self, _ctx: &mut CTX, _hasher: &mut StableHasher) {
+impl<Hcx> HashStable<Hcx> for ! {
+    fn hash_stable(&self, _hcx: &mut Hcx, _hasher: &mut StableHasher) {
         unreachable!()
     }
 }
 
-impl<CTX, T> HashStable<CTX> for PhantomData<T> {
-    fn hash_stable(&self, _ctx: &mut CTX, _hasher: &mut StableHasher) {}
+impl<Hcx, T> HashStable<Hcx> for PhantomData<T> {
+    fn hash_stable(&self, _hcx: &mut Hcx, _hasher: &mut StableHasher) {}
 }
 
-impl<CTX> HashStable<CTX> for NonZero<u32> {
+impl<Hcx> HashStable<Hcx> for NonZero<u32> {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        self.get().hash_stable(ctx, hasher)
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+        self.get().hash_stable(hcx, hasher)
     }
 }
 
-impl<CTX> HashStable<CTX> for NonZero<usize> {
+impl<Hcx> HashStable<Hcx> for NonZero<usize> {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        self.get().hash_stable(ctx, hasher)
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+        self.get().hash_stable(hcx, hasher)
     }
 }
 
-impl<CTX> HashStable<CTX> for f32 {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+impl<Hcx> HashStable<Hcx> for f32 {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         let val: u32 = self.to_bits();
-        val.hash_stable(ctx, hasher);
+        val.hash_stable(hcx, hasher);
     }
 }
 
-impl<CTX> HashStable<CTX> for f64 {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+impl<Hcx> HashStable<Hcx> for f64 {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         let val: u64 = self.to_bits();
-        val.hash_stable(ctx, hasher);
+        val.hash_stable(hcx, hasher);
     }
 }
 
-impl<CTX> HashStable<CTX> for ::std::cmp::Ordering {
+impl<Hcx> HashStable<Hcx> for ::std::cmp::Ordering {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        (*self as i8).hash_stable(ctx, hasher);
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+        (*self as i8).hash_stable(hcx, hasher);
     }
 }
 
-impl<T1: HashStable<CTX>, CTX> HashStable<CTX> for (T1,) {
+impl<T1: HashStable<Hcx>, Hcx> HashStable<Hcx> for (T1,) {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         let (ref _0,) = *self;
-        _0.hash_stable(ctx, hasher);
+        _0.hash_stable(hcx, hasher);
     }
 }
 
-impl<T1: HashStable<CTX>, T2: HashStable<CTX>, CTX> HashStable<CTX> for (T1, T2) {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+impl<T1: HashStable<Hcx>, T2: HashStable<Hcx>, Hcx> HashStable<Hcx> for (T1, T2) {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         let (ref _0, ref _1) = *self;
-        _0.hash_stable(ctx, hasher);
-        _1.hash_stable(ctx, hasher);
+        _0.hash_stable(hcx, hasher);
+        _1.hash_stable(hcx, hasher);
     }
 }
 
@@ -261,17 +261,17 @@ impl<T1: StableOrd, T2: StableOrd> StableOrd for (T1, T2) {
     const THIS_IMPLEMENTATION_HAS_BEEN_TRIPLE_CHECKED: () = ();
 }
 
-impl<T1, T2, T3, CTX> HashStable<CTX> for (T1, T2, T3)
+impl<T1, T2, T3, Hcx> HashStable<Hcx> for (T1, T2, T3)
 where
-    T1: HashStable<CTX>,
-    T2: HashStable<CTX>,
-    T3: HashStable<CTX>,
+    T1: HashStable<Hcx>,
+    T2: HashStable<Hcx>,
+    T3: HashStable<Hcx>,
 {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         let (ref _0, ref _1, ref _2) = *self;
-        _0.hash_stable(ctx, hasher);
-        _1.hash_stable(ctx, hasher);
-        _2.hash_stable(ctx, hasher);
+        _0.hash_stable(hcx, hasher);
+        _1.hash_stable(hcx, hasher);
+        _2.hash_stable(hcx, hasher);
     }
 }
 
@@ -284,19 +284,19 @@ impl<T1: StableOrd, T2: StableOrd, T3: StableOrd> StableOrd for (T1, T2, T3) {
     const THIS_IMPLEMENTATION_HAS_BEEN_TRIPLE_CHECKED: () = ();
 }
 
-impl<T1, T2, T3, T4, CTX> HashStable<CTX> for (T1, T2, T3, T4)
+impl<T1, T2, T3, T4, Hcx> HashStable<Hcx> for (T1, T2, T3, T4)
 where
-    T1: HashStable<CTX>,
-    T2: HashStable<CTX>,
-    T3: HashStable<CTX>,
-    T4: HashStable<CTX>,
+    T1: HashStable<Hcx>,
+    T2: HashStable<Hcx>,
+    T3: HashStable<Hcx>,
+    T4: HashStable<Hcx>,
 {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         let (ref _0, ref _1, ref _2, ref _3) = *self;
-        _0.hash_stable(ctx, hasher);
-        _1.hash_stable(ctx, hasher);
-        _2.hash_stable(ctx, hasher);
-        _3.hash_stable(ctx, hasher);
+        _0.hash_stable(hcx, hasher);
+        _1.hash_stable(hcx, hasher);
+        _2.hash_stable(hcx, hasher);
+        _3.hash_stable(hcx, hasher);
     }
 }
 
@@ -311,93 +311,93 @@ impl<T1: StableOrd, T2: StableOrd, T3: StableOrd, T4: StableOrd> StableOrd for (
     const THIS_IMPLEMENTATION_HAS_BEEN_TRIPLE_CHECKED: () = ();
 }
 
-impl<T: HashStable<CTX>, CTX> HashStable<CTX> for [T] {
-    default fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        self.len().hash_stable(ctx, hasher);
+impl<T: HashStable<Hcx>, Hcx> HashStable<Hcx> for [T] {
+    default fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+        self.len().hash_stable(hcx, hasher);
         for item in self {
-            item.hash_stable(ctx, hasher);
+            item.hash_stable(hcx, hasher);
         }
     }
 }
 
-impl<CTX> HashStable<CTX> for [u8] {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        self.len().hash_stable(ctx, hasher);
+impl<Hcx> HashStable<Hcx> for [u8] {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+        self.len().hash_stable(hcx, hasher);
         hasher.write(self);
     }
 }
 
-impl<T: HashStable<CTX>, CTX> HashStable<CTX> for Vec<T> {
+impl<T: HashStable<Hcx>, Hcx> HashStable<Hcx> for Vec<T> {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        self[..].hash_stable(ctx, hasher);
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+        self[..].hash_stable(hcx, hasher);
     }
 }
 
-impl<K, V, R, CTX> HashStable<CTX> for indexmap::IndexMap<K, V, R>
+impl<K, V, R, Hcx> HashStable<Hcx> for indexmap::IndexMap<K, V, R>
 where
-    K: HashStable<CTX> + Eq + Hash,
-    V: HashStable<CTX>,
+    K: HashStable<Hcx> + Eq + Hash,
+    V: HashStable<Hcx>,
     R: BuildHasher,
 {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        self.len().hash_stable(ctx, hasher);
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+        self.len().hash_stable(hcx, hasher);
         for kv in self {
-            kv.hash_stable(ctx, hasher);
+            kv.hash_stable(hcx, hasher);
         }
     }
 }
 
-impl<K, R, CTX> HashStable<CTX> for indexmap::IndexSet<K, R>
+impl<K, R, Hcx> HashStable<Hcx> for indexmap::IndexSet<K, R>
 where
-    K: HashStable<CTX> + Eq + Hash,
+    K: HashStable<Hcx> + Eq + Hash,
     R: BuildHasher,
 {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        self.len().hash_stable(ctx, hasher);
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+        self.len().hash_stable(hcx, hasher);
         for key in self {
-            key.hash_stable(ctx, hasher);
+            key.hash_stable(hcx, hasher);
         }
     }
 }
 
-impl<A, const N: usize, CTX> HashStable<CTX> for SmallVec<[A; N]>
+impl<A, const N: usize, Hcx> HashStable<Hcx> for SmallVec<[A; N]>
 where
-    A: HashStable<CTX>,
+    A: HashStable<Hcx>,
 {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        self[..].hash_stable(ctx, hasher);
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+        self[..].hash_stable(hcx, hasher);
     }
 }
 
-impl<T: ?Sized + HashStable<CTX>, CTX> HashStable<CTX> for Box<T> {
+impl<T: ?Sized + HashStable<Hcx>, Hcx> HashStable<Hcx> for Box<T> {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        (**self).hash_stable(ctx, hasher);
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+        (**self).hash_stable(hcx, hasher);
     }
 }
 
-impl<T: ?Sized + HashStable<CTX>, CTX> HashStable<CTX> for ::std::rc::Rc<T> {
+impl<T: ?Sized + HashStable<Hcx>, Hcx> HashStable<Hcx> for ::std::rc::Rc<T> {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        (**self).hash_stable(ctx, hasher);
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+        (**self).hash_stable(hcx, hasher);
     }
 }
 
-impl<T: ?Sized + HashStable<CTX>, CTX> HashStable<CTX> for ::std::sync::Arc<T> {
+impl<T: ?Sized + HashStable<Hcx>, Hcx> HashStable<Hcx> for ::std::sync::Arc<T> {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        (**self).hash_stable(ctx, hasher);
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+        (**self).hash_stable(hcx, hasher);
     }
 }
 
-impl<CTX> HashStable<CTX> for str {
+impl<Hcx> HashStable<Hcx> for str {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        self.as_bytes().hash_stable(ctx, hasher);
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+        self.as_bytes().hash_stable(hcx, hasher);
     }
 }
 
@@ -409,9 +409,9 @@ impl StableOrd for &str {
     const THIS_IMPLEMENTATION_HAS_BEEN_TRIPLE_CHECKED: () = ();
 }
 
-impl<CTX> HashStable<CTX> for String {
+impl<Hcx> HashStable<Hcx> for String {
     #[inline]
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         self[..].hash_stable(hcx, hasher);
     }
 }
@@ -424,26 +424,26 @@ impl StableOrd for String {
     const THIS_IMPLEMENTATION_HAS_BEEN_TRIPLE_CHECKED: () = ();
 }
 
-impl<HCX> ToStableHashKey<HCX> for String {
+impl<Hcx> ToStableHashKey<Hcx> for String {
     type KeyType = String;
     #[inline]
-    fn to_stable_hash_key(&self, _: &HCX) -> Self::KeyType {
+    fn to_stable_hash_key(&self, _: &Hcx) -> Self::KeyType {
         self.clone()
     }
 }
 
-impl<HCX, T1: ToStableHashKey<HCX>, T2: ToStableHashKey<HCX>> ToStableHashKey<HCX> for (T1, T2) {
+impl<Hcx, T1: ToStableHashKey<Hcx>, T2: ToStableHashKey<Hcx>> ToStableHashKey<Hcx> for (T1, T2) {
     type KeyType = (T1::KeyType, T2::KeyType);
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &HCX) -> Self::KeyType {
+    fn to_stable_hash_key(&self, hcx: &Hcx) -> Self::KeyType {
         (self.0.to_stable_hash_key(hcx), self.1.to_stable_hash_key(hcx))
     }
 }
 
-impl<CTX> HashStable<CTX> for bool {
+impl<Hcx> HashStable<Hcx> for bool {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        (if *self { 1u8 } else { 0u8 }).hash_stable(ctx, hasher);
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+        (if *self { 1u8 } else { 0u8 }).hash_stable(hcx, hasher);
     }
 }
 
@@ -454,17 +454,17 @@ impl StableOrd for bool {
     const THIS_IMPLEMENTATION_HAS_BEEN_TRIPLE_CHECKED: () = ();
 }
 
-impl<T, CTX> HashStable<CTX> for Option<T>
+impl<T, Hcx> HashStable<Hcx> for Option<T>
 where
-    T: HashStable<CTX>,
+    T: HashStable<Hcx>,
 {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         if let Some(ref value) = *self {
-            1u8.hash_stable(ctx, hasher);
-            value.hash_stable(ctx, hasher);
+            1u8.hash_stable(hcx, hasher);
+            value.hash_stable(hcx, hasher);
         } else {
-            0u8.hash_stable(ctx, hasher);
+            0u8.hash_stable(hcx, hasher);
         }
     }
 }
@@ -476,81 +476,81 @@ impl<T: StableOrd> StableOrd for Option<T> {
     const THIS_IMPLEMENTATION_HAS_BEEN_TRIPLE_CHECKED: () = ();
 }
 
-impl<T1, T2, CTX> HashStable<CTX> for Result<T1, T2>
+impl<T1, T2, Hcx> HashStable<Hcx> for Result<T1, T2>
 where
-    T1: HashStable<CTX>,
-    T2: HashStable<CTX>,
+    T1: HashStable<Hcx>,
+    T2: HashStable<Hcx>,
 {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        mem::discriminant(self).hash_stable(ctx, hasher);
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+        mem::discriminant(self).hash_stable(hcx, hasher);
         match *self {
-            Ok(ref x) => x.hash_stable(ctx, hasher),
-            Err(ref x) => x.hash_stable(ctx, hasher),
+            Ok(ref x) => x.hash_stable(hcx, hasher),
+            Err(ref x) => x.hash_stable(hcx, hasher),
         }
     }
 }
 
-impl<'a, T, CTX> HashStable<CTX> for &'a T
+impl<'a, T, Hcx> HashStable<Hcx> for &'a T
 where
-    T: HashStable<CTX> + ?Sized,
+    T: HashStable<Hcx> + ?Sized,
 {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        (**self).hash_stable(ctx, hasher);
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+        (**self).hash_stable(hcx, hasher);
     }
 }
 
-impl<T, CTX> HashStable<CTX> for ::std::mem::Discriminant<T> {
+impl<T, Hcx> HashStable<Hcx> for ::std::mem::Discriminant<T> {
     #[inline]
-    fn hash_stable(&self, _: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable(&self, _: &mut Hcx, hasher: &mut StableHasher) {
         ::std::hash::Hash::hash(self, hasher);
     }
 }
 
-impl<T, CTX> HashStable<CTX> for ::std::ops::RangeInclusive<T>
+impl<T, Hcx> HashStable<Hcx> for ::std::ops::RangeInclusive<T>
 where
-    T: HashStable<CTX>,
+    T: HashStable<Hcx>,
 {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        self.start().hash_stable(ctx, hasher);
-        self.end().hash_stable(ctx, hasher);
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+        self.start().hash_stable(hcx, hasher);
+        self.end().hash_stable(hcx, hasher);
     }
 }
 
-impl<I: Idx, T, CTX> HashStable<CTX> for IndexSlice<I, T>
+impl<I: Idx, T, Hcx> HashStable<Hcx> for IndexSlice<I, T>
 where
-    T: HashStable<CTX>,
+    T: HashStable<Hcx>,
 {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        self.len().hash_stable(ctx, hasher);
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+        self.len().hash_stable(hcx, hasher);
         for v in &self.raw {
-            v.hash_stable(ctx, hasher);
+            v.hash_stable(hcx, hasher);
         }
     }
 }
 
-impl<I: Idx, T, CTX> HashStable<CTX> for IndexVec<I, T>
+impl<I: Idx, T, Hcx> HashStable<Hcx> for IndexVec<I, T>
 where
-    T: HashStable<CTX>,
+    T: HashStable<Hcx>,
 {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        self.len().hash_stable(ctx, hasher);
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+        self.len().hash_stable(hcx, hasher);
         for v in &self.raw {
-            v.hash_stable(ctx, hasher);
+            v.hash_stable(hcx, hasher);
         }
     }
 }
 
-impl<I: Idx, CTX> HashStable<CTX> for DenseBitSet<I> {
-    fn hash_stable(&self, _ctx: &mut CTX, hasher: &mut StableHasher) {
+impl<I: Idx, Hcx> HashStable<Hcx> for DenseBitSet<I> {
+    fn hash_stable(&self, _hcx: &mut Hcx, hasher: &mut StableHasher) {
         ::std::hash::Hash::hash(self, hasher);
     }
 }
 
-impl<R: Idx, C: Idx, CTX> HashStable<CTX> for bit_set::BitMatrix<R, C> {
-    fn hash_stable(&self, _ctx: &mut CTX, hasher: &mut StableHasher) {
+impl<R: Idx, C: Idx, Hcx> HashStable<Hcx> for bit_set::BitMatrix<R, C> {
+    fn hash_stable(&self, _hcx: &mut Hcx, hasher: &mut StableHasher) {
         ::std::hash::Hash::hash(self, hasher);
     }
 }
@@ -563,15 +563,15 @@ impl_stable_traits_for_trivial_type!(::std::path::PathBuf);
 // It is not safe to implement HashStable for HashSet, HashMap or any other collection type
 // with unstable but observable iteration order.
 // See https://github.com/rust-lang/compiler-team/issues/533 for further information.
-impl<V, HCX> !HashStable<HCX> for std::collections::HashSet<V> {}
-impl<K, V, HCX> !HashStable<HCX> for std::collections::HashMap<K, V> {}
+impl<V, Hcx> !HashStable<Hcx> for std::collections::HashSet<V> {}
+impl<K, V, Hcx> !HashStable<Hcx> for std::collections::HashMap<K, V> {}
 
-impl<K, V, HCX> HashStable<HCX> for ::std::collections::BTreeMap<K, V>
+impl<K, V, Hcx> HashStable<Hcx> for ::std::collections::BTreeMap<K, V>
 where
-    K: HashStable<HCX> + StableOrd,
-    V: HashStable<HCX>,
+    K: HashStable<Hcx> + StableOrd,
+    V: HashStable<Hcx>,
 {
-    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         self.len().hash_stable(hcx, hasher);
         for entry in self.iter() {
             entry.hash_stable(hcx, hasher);
@@ -579,11 +579,11 @@ where
     }
 }
 
-impl<K, HCX> HashStable<HCX> for ::std::collections::BTreeSet<K>
+impl<K, Hcx> HashStable<Hcx> for ::std::collections::BTreeSet<K>
 where
-    K: HashStable<HCX> + StableOrd,
+    K: HashStable<Hcx> + StableOrd,
 {
-    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         self.len().hash_stable(hcx, hasher);
         for entry in self.iter() {
             entry.hash_stable(hcx, hasher);

--- a/compiler/rustc_data_structures/src/stable_hasher/tests.rs
+++ b/compiler/rustc_data_structures/src/stable_hasher/tests.rs
@@ -44,8 +44,8 @@ fn test_attribute_permutation() {
                 b: $ty,
             }
 
-            impl<CTX> HashStable<CTX> for Foo {
-                fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+            impl<Hcx> HashStable<Hcx> for Foo {
+                fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
                     self.a.hash_stable(hcx, hasher);
                     self.b.hash_stable(hcx, hasher);
                 }

--- a/compiler/rustc_data_structures/src/steal.rs
+++ b/compiler/rustc_data_structures/src/steal.rs
@@ -71,8 +71,8 @@ impl<T> Steal<T> {
     }
 }
 
-impl<CTX, T: HashStable<CTX>> HashStable<CTX> for Steal<T> {
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+impl<Hcx, T: HashStable<Hcx>> HashStable<Hcx> for Steal<T> {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         self.borrow().hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_data_structures/src/tagged_ptr.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr.rs
@@ -262,12 +262,12 @@ impl<P, T: Tag> Hash for TaggedRef<'_, P, T> {
     }
 }
 
-impl<'a, P, T, HCX> HashStable<HCX> for TaggedRef<'a, P, T>
+impl<'a, P, T, Hcx> HashStable<Hcx> for TaggedRef<'a, P, T>
 where
-    P: HashStable<HCX> + Aligned + ?Sized,
-    T: Tag + HashStable<HCX>,
+    P: HashStable<Hcx> + Aligned + ?Sized,
+    T: Tag + HashStable<Hcx>,
 {
-    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         self.pointer().hash_stable(hcx, hasher);
         self.tag().hash_stable(hcx, hasher);
     }

--- a/compiler/rustc_data_structures/src/tagged_ptr/tests.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/tests.rs
@@ -32,8 +32,8 @@ unsafe impl Tag for Tag2 {
     }
 }
 
-impl<HCX> crate::stable_hasher::HashStable<HCX> for Tag2 {
-    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut crate::stable_hasher::StableHasher) {
+impl<Hcx> crate::stable_hasher::HashStable<Hcx> for Tag2 {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut crate::stable_hasher::StableHasher) {
         (*self as u8).hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_data_structures/src/unord.rs
+++ b/compiler/rustc_data_structures/src/unord.rs
@@ -143,9 +143,9 @@ impl<'a, T: Copy + 'a, I: Iterator<Item = &'a T>> UnordItems<&'a T, I> {
 
 impl<T, I: Iterator<Item = T>> UnordItems<T, I> {
     #[inline]
-    pub fn into_sorted<HCX>(self, hcx: &HCX) -> Vec<T>
+    pub fn into_sorted<Hcx>(self, hcx: &Hcx) -> Vec<T>
     where
-        T: ToStableHashKey<HCX>,
+        T: ToStableHashKey<Hcx>,
     {
         self.collect_sorted(hcx, true)
     }
@@ -168,9 +168,9 @@ impl<T, I: Iterator<Item = T>> UnordItems<T, I> {
     }
 
     #[inline]
-    pub fn collect_sorted<HCX, C>(self, hcx: &HCX, cache_sort_key: bool) -> C
+    pub fn collect_sorted<Hcx, C>(self, hcx: &Hcx, cache_sort_key: bool) -> C
     where
-        T: ToStableHashKey<HCX>,
+        T: ToStableHashKey<Hcx>,
         C: FromIterator<T> + BorrowMut<[T]>,
     {
         let mut items: C = self.0.collect();
@@ -315,9 +315,9 @@ impl<V: Eq + Hash> UnordSet<V> {
     /// `cache_sort_key` when the [ToStableHashKey::to_stable_hash_key] implementation
     /// for `V` is expensive (e.g. a `DefId -> DefPathHash` lookup).
     #[inline]
-    pub fn to_sorted<HCX>(&self, hcx: &HCX, cache_sort_key: bool) -> Vec<&V>
+    pub fn to_sorted<Hcx>(&self, hcx: &Hcx, cache_sort_key: bool) -> Vec<&V>
     where
-        V: ToStableHashKey<HCX>,
+        V: ToStableHashKey<Hcx>,
     {
         to_sorted_vec(hcx, self.inner.iter(), cache_sort_key, |&x| x)
     }
@@ -357,9 +357,9 @@ impl<V: Eq + Hash> UnordSet<V> {
     /// `cache_sort_key` when the [ToStableHashKey::to_stable_hash_key] implementation
     /// for `V` is expensive (e.g. a `DefId -> DefPathHash` lookup).
     #[inline]
-    pub fn into_sorted<HCX>(self, hcx: &HCX, cache_sort_key: bool) -> Vec<V>
+    pub fn into_sorted<Hcx>(self, hcx: &Hcx, cache_sort_key: bool) -> Vec<V>
     where
-        V: ToStableHashKey<HCX>,
+        V: ToStableHashKey<Hcx>,
     {
         to_sorted_vec(hcx, self.inner.into_iter(), cache_sort_key, |x| x)
     }
@@ -415,9 +415,9 @@ impl<V: Hash + Eq, I: Iterator<Item = V>> From<UnordItems<V, I>> for UnordSet<V>
     }
 }
 
-impl<HCX, V: Hash + Eq + HashStable<HCX>> HashStable<HCX> for UnordSet<V> {
+impl<Hcx, V: Hash + Eq + HashStable<Hcx>> HashStable<Hcx> for UnordSet<V> {
     #[inline]
-    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         hash_iter_order_independent(self.inner.iter(), hcx, hasher);
     }
 }
@@ -555,9 +555,9 @@ impl<K: Eq + Hash, V> UnordMap<K, V> {
     /// `cache_sort_key` when the [ToStableHashKey::to_stable_hash_key] implementation
     /// for `K` is expensive (e.g. a `DefId -> DefPathHash` lookup).
     #[inline]
-    pub fn to_sorted<HCX>(&self, hcx: &HCX, cache_sort_key: bool) -> Vec<(&K, &V)>
+    pub fn to_sorted<Hcx>(&self, hcx: &Hcx, cache_sort_key: bool) -> Vec<(&K, &V)>
     where
-        K: ToStableHashKey<HCX>,
+        K: ToStableHashKey<Hcx>,
     {
         to_sorted_vec(hcx, self.inner.iter(), cache_sort_key, |&(k, _)| k)
     }
@@ -582,9 +582,9 @@ impl<K: Eq + Hash, V> UnordMap<K, V> {
     /// `cache_sort_key` when the [ToStableHashKey::to_stable_hash_key] implementation
     /// for `K` is expensive (e.g. a `DefId -> DefPathHash` lookup).
     #[inline]
-    pub fn into_sorted<HCX>(self, hcx: &HCX, cache_sort_key: bool) -> Vec<(K, V)>
+    pub fn into_sorted<Hcx>(self, hcx: &Hcx, cache_sort_key: bool) -> Vec<(K, V)>
     where
-        K: ToStableHashKey<HCX>,
+        K: ToStableHashKey<Hcx>,
     {
         to_sorted_vec(hcx, self.inner.into_iter(), cache_sort_key, |(k, _)| k)
     }
@@ -610,9 +610,9 @@ impl<K: Eq + Hash, V> UnordMap<K, V> {
     /// `cache_sort_key` when the [ToStableHashKey::to_stable_hash_key] implementation
     /// for `K` is expensive (e.g. a `DefId -> DefPathHash` lookup).
     #[inline]
-    pub fn values_sorted<HCX>(&self, hcx: &HCX, cache_sort_key: bool) -> impl Iterator<Item = &V>
+    pub fn values_sorted<Hcx>(&self, hcx: &Hcx, cache_sort_key: bool) -> impl Iterator<Item = &V>
     where
-        K: ToStableHashKey<HCX>,
+        K: ToStableHashKey<Hcx>,
     {
         to_sorted_vec(hcx, self.inner.iter(), cache_sort_key, |&(k, _)| k)
             .into_iter()
@@ -638,9 +638,9 @@ where
     }
 }
 
-impl<HCX, K: Hash + Eq + HashStable<HCX>, V: HashStable<HCX>> HashStable<HCX> for UnordMap<K, V> {
+impl<Hcx, K: Hash + Eq + HashStable<Hcx>, V: HashStable<Hcx>> HashStable<Hcx> for UnordMap<K, V> {
     #[inline]
-    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         hash_iter_order_independent(self.inner.iter(), hcx, hasher);
     }
 }
@@ -701,23 +701,23 @@ impl<T, I: Iterator<Item = T>> From<UnordItems<T, I>> for UnordBag<T> {
     }
 }
 
-impl<HCX, V: Hash + Eq + HashStable<HCX>> HashStable<HCX> for UnordBag<V> {
+impl<Hcx, V: Hash + Eq + HashStable<Hcx>> HashStable<Hcx> for UnordBag<V> {
     #[inline]
-    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         hash_iter_order_independent(self.inner.iter(), hcx, hasher);
     }
 }
 
 #[inline]
-fn to_sorted_vec<HCX, T, K, I>(
-    hcx: &HCX,
+fn to_sorted_vec<Hcx, T, K, I>(
+    hcx: &Hcx,
     iter: I,
     cache_sort_key: bool,
     extract_key: fn(&T) -> &K,
 ) -> Vec<T>
 where
     I: Iterator<Item = T>,
-    K: ToStableHashKey<HCX>,
+    K: ToStableHashKey<Hcx>,
 {
     let mut items: Vec<T> = iter.collect();
     if cache_sort_key {
@@ -730,12 +730,12 @@ where
 }
 
 fn hash_iter_order_independent<
-    HCX,
-    T: HashStable<HCX>,
+    Hcx,
+    T: HashStable<Hcx>,
     I: Iterator<Item = T> + ExactSizeIterator,
 >(
     mut it: I,
-    hcx: &mut HCX,
+    hcx: &mut Hcx,
     hasher: &mut StableHasher,
 ) {
     let len = it.len();

--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -712,11 +712,11 @@ impl IntoDiagArg for Namespace {
     }
 }
 
-impl<CTX: crate::HashStableContext> ToStableHashKey<CTX> for Namespace {
+impl<Hcx: crate::HashStableContext> ToStableHashKey<Hcx> for Namespace {
     type KeyType = Namespace;
 
     #[inline]
-    fn to_stable_hash_key(&self, _: &CTX) -> Namespace {
+    fn to_stable_hash_key(&self, _: &Hcx) -> Namespace {
         *self
     }
 }

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -144,8 +144,8 @@ macro_rules! language_item_table {
     }
 }
 
-impl<CTX> HashStable<CTX> for LangItem {
-    fn hash_stable(&self, _: &mut CTX, hasher: &mut StableHasher) {
+impl<Hcx> HashStable<Hcx> for LangItem {
+    fn hash_stable(&self, _: &mut Hcx, hasher: &mut StableHasher) {
         ::std::hash::Hash::hash(self, hasher);
     }
 }

--- a/compiler/rustc_hir_id/src/lib.rs
+++ b/compiler/rustc_hir_id/src/lib.rs
@@ -54,18 +54,18 @@ impl rustc_index::Idx for OwnerId {
     }
 }
 
-impl<CTX: HashStableContext> HashStable<CTX> for OwnerId {
+impl<Hcx: HashStableContext> HashStable<Hcx> for OwnerId {
     #[inline]
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         self.to_stable_hash_key(hcx).hash_stable(hcx, hasher);
     }
 }
 
-impl<CTX: HashStableContext> ToStableHashKey<CTX> for OwnerId {
+impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for OwnerId {
     type KeyType = DefPathHash;
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &CTX) -> DefPathHash {
+    fn to_stable_hash_key(&self, hcx: &Hcx) -> DefPathHash {
         hcx.def_path_hash(self.to_def_id())
     }
 }
@@ -176,21 +176,21 @@ pub const CRATE_HIR_ID: HirId =
 
 pub const CRATE_OWNER_ID: OwnerId = OwnerId { def_id: CRATE_DEF_ID };
 
-impl<CTX: rustc_span::HashStableContext> ToStableHashKey<CTX> for HirId {
+impl<Hcx: rustc_span::HashStableContext> ToStableHashKey<Hcx> for HirId {
     type KeyType = (DefPathHash, ItemLocalId);
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &CTX) -> (DefPathHash, ItemLocalId) {
+    fn to_stable_hash_key(&self, hcx: &Hcx) -> (DefPathHash, ItemLocalId) {
         let def_path_hash = self.owner.def_id.to_stable_hash_key(hcx);
         (def_path_hash, self.local_id)
     }
 }
 
-impl<CTX: HashStableContext> ToStableHashKey<CTX> for ItemLocalId {
+impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for ItemLocalId {
     type KeyType = ItemLocalId;
 
     #[inline]
-    fn to_stable_hash_key(&self, _: &CTX) -> ItemLocalId {
+    fn to_stable_hash_key(&self, _: &Hcx) -> ItemLocalId {
         *self
     }
 }

--- a/compiler/rustc_index_macros/src/newtype.rs
+++ b/compiler/rustc_index_macros/src/newtype.rs
@@ -174,8 +174,8 @@ impl Parse for Newtype {
         } else if stable_hash_generic || stable_hash_no_context {
             quote! {
                 #gate_rustc_only
-                impl<CTX> ::rustc_data_structures::stable_hasher::HashStable<CTX> for #name {
-                    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut ::rustc_data_structures::stable_hasher::StableHasher) {
+                impl<Hcx> ::rustc_data_structures::stable_hasher::HashStable<Hcx> for #name {
+                    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut ::rustc_data_structures::stable_hasher::StableHasher) {
                         self.as_u32().hash_stable(hcx, hasher)
                     }
                 }

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -138,9 +138,9 @@ impl LintExpectationId {
     }
 }
 
-impl<HCX: HashStableContext> HashStable<HCX> for LintExpectationId {
+impl<Hcx: HashStableContext> HashStable<Hcx> for LintExpectationId {
     #[inline]
-    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         match self {
             LintExpectationId::Stable { hir_id, attr_index, lint_index: Some(lint_index) } => {
                 hir_id.hash_stable(hcx, hasher);
@@ -156,11 +156,11 @@ impl<HCX: HashStableContext> HashStable<HCX> for LintExpectationId {
     }
 }
 
-impl<HCX: HashStableContext> ToStableHashKey<HCX> for LintExpectationId {
+impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for LintExpectationId {
     type KeyType = (DefPathHash, ItemLocalId, u16, u16);
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &HCX) -> Self::KeyType {
+    fn to_stable_hash_key(&self, hcx: &Hcx) -> Self::KeyType {
         match self {
             LintExpectationId::Stable { hir_id, attr_index, lint_index: Some(lint_index) } => {
                 let (def_path_hash, lint_idx) = hir_id.to_stable_hash_key(hcx);
@@ -621,18 +621,18 @@ impl LintId {
     }
 }
 
-impl<HCX> HashStable<HCX> for LintId {
+impl<Hcx> HashStable<Hcx> for LintId {
     #[inline]
-    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         self.lint_name_raw().hash_stable(hcx, hasher);
     }
 }
 
-impl<HCX> ToStableHashKey<HCX> for LintId {
+impl<Hcx> ToStableHashKey<Hcx> for LintId {
     type KeyType = &'static str;
 
     #[inline]
-    fn to_stable_hash_key(&self, _: &HCX) -> &'static str {
+    fn to_stable_hash_key(&self, _: &Hcx) -> &'static str {
         self.lint_name_raw()
     }
 }

--- a/compiler/rustc_middle/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node.rs
@@ -251,10 +251,10 @@ impl WorkProductId {
         WorkProductId { hash: hasher.finish() }
     }
 }
-impl<HCX> ToStableHashKey<HCX> for WorkProductId {
+impl<Hcx> ToStableHashKey<Hcx> for WorkProductId {
     type KeyType = Fingerprint;
     #[inline]
-    fn to_stable_hash_key(&self, _: &HCX) -> Self::KeyType {
+    fn to_stable_hash_key(&self, _: &Hcx) -> Self::KeyType {
         self.hash
     }
 }

--- a/compiler/rustc_middle/src/mir/basic_blocks.rs
+++ b/compiler/rustc_middle/src/mir/basic_blocks.rs
@@ -171,7 +171,7 @@ impl<D: Decoder> Decodable<D> for Cache {
     }
 }
 
-impl<CTX> HashStable<CTX> for Cache {
+impl<Hcx> HashStable<Hcx> for Cache {
     #[inline]
-    fn hash_stable(&self, _: &mut CTX, _: &mut StableHasher) {}
+    fn hash_stable(&self, _: &mut Hcx, _: &mut StableHasher) {}
 }

--- a/compiler/rustc_middle/src/ty/consts/int.rs
+++ b/compiler/rustc_middle/src/ty/consts/int.rs
@@ -151,8 +151,8 @@ pub struct ScalarInt {
 
 // Cannot derive these, as the derives take references to the fields, and we
 // can't take references to fields of packed structs.
-impl<CTX> crate::ty::HashStable<CTX> for ScalarInt {
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut crate::ty::StableHasher) {
+impl<Hcx> crate::ty::HashStable<Hcx> for ScalarInt {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut crate::ty::StableHasher) {
         // Using a block `{self.data}` here to force a copy instead of using `self.data`
         // directly, because `hash_stable` takes `&self` and would thus borrow `self.data`.
         // Since `Self` is a packed struct, that would create a possibly unaligned reference,

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -607,7 +607,7 @@ pub struct TyCtxtFeed<'tcx, KEY: Copy> {
 
 /// Never return a `Feed` from a query. Only queries that create a `DefId` are
 /// allowed to feed queries for that `DefId`.
-impl<KEY: Copy, CTX> !HashStable<CTX> for TyCtxtFeed<'_, KEY> {}
+impl<KEY: Copy, Hcx> !HashStable<Hcx> for TyCtxtFeed<'_, KEY> {}
 
 /// The same as `TyCtxtFeed`, but does not contain a `TyCtxt`.
 /// Use this to pass around when you have a `TyCtxt` elsewhere.
@@ -622,7 +622,7 @@ pub struct Feed<'tcx, KEY: Copy> {
 
 /// Never return a `Feed` from a query. Only queries that create a `DefId` are
 /// allowed to feed queries for that `DefId`.
-impl<KEY: Copy, CTX> !HashStable<CTX> for Feed<'_, KEY> {}
+impl<KEY: Copy, Hcx> !HashStable<Hcx> for Feed<'_, KEY> {}
 
 impl<T: fmt::Debug + Copy> fmt::Debug for Feed<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -636,10 +636,10 @@ macro_rules! define_output_types {
             const THIS_IMPLEMENTATION_HAS_BEEN_TRIPLE_CHECKED: () = ();
         }
 
-        impl<HCX: HashStableContext> ToStableHashKey<HCX> for OutputType {
+        impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for OutputType {
             type KeyType = Self;
 
-            fn to_stable_hash_key(&self, _: &HCX) -> Self::KeyType {
+            fn to_stable_hash_key(&self, _: &Hcx) -> Self::KeyType {
                 *self
             }
         }

--- a/compiler/rustc_span/src/def_id.rs
+++ b/compiler/rustc_span/src/def_id.rs
@@ -402,59 +402,59 @@ rustc_data_structures::define_id_collections!(
     LocalDefId
 );
 
-impl<CTX: HashStableContext> HashStable<CTX> for DefId {
+impl<Hcx: HashStableContext> HashStable<Hcx> for DefId {
     #[inline]
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         hcx.def_path_hash(*self).hash_stable(hcx, hasher);
     }
 }
 
-impl<CTX: HashStableContext> HashStable<CTX> for LocalDefId {
+impl<Hcx: HashStableContext> HashStable<Hcx> for LocalDefId {
     #[inline]
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         hcx.def_path_hash(self.to_def_id()).local_hash().hash_stable(hcx, hasher);
     }
 }
 
-impl<CTX: HashStableContext> HashStable<CTX> for CrateNum {
+impl<Hcx: HashStableContext> HashStable<Hcx> for CrateNum {
     #[inline]
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         self.as_def_id().to_stable_hash_key(hcx).stable_crate_id().hash_stable(hcx, hasher);
     }
 }
 
-impl<CTX: HashStableContext> ToStableHashKey<CTX> for DefId {
+impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for DefId {
     type KeyType = DefPathHash;
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &CTX) -> DefPathHash {
+    fn to_stable_hash_key(&self, hcx: &Hcx) -> DefPathHash {
         hcx.def_path_hash(*self)
     }
 }
 
-impl<CTX: HashStableContext> ToStableHashKey<CTX> for LocalDefId {
+impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for LocalDefId {
     type KeyType = DefPathHash;
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &CTX) -> DefPathHash {
+    fn to_stable_hash_key(&self, hcx: &Hcx) -> DefPathHash {
         hcx.def_path_hash(self.to_def_id())
     }
 }
 
-impl<CTX: HashStableContext> ToStableHashKey<CTX> for CrateNum {
+impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for CrateNum {
     type KeyType = DefPathHash;
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &CTX) -> DefPathHash {
+    fn to_stable_hash_key(&self, hcx: &Hcx) -> DefPathHash {
         self.as_def_id().to_stable_hash_key(hcx)
     }
 }
 
-impl<CTX: HashStableContext> ToStableHashKey<CTX> for DefPathHash {
+impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for DefPathHash {
     type KeyType = DefPathHash;
 
     #[inline]
-    fn to_stable_hash_key(&self, _: &CTX) -> DefPathHash {
+    fn to_stable_hash_key(&self, _: &Hcx) -> DefPathHash {
         *self
     }
 }

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -207,9 +207,9 @@ impl LocalExpnId {
         })
     }
 
-    pub fn fresh(mut expn_data: ExpnData, ctx: impl HashStableContext) -> LocalExpnId {
+    pub fn fresh(mut expn_data: ExpnData, hcx: impl HashStableContext) -> LocalExpnId {
         debug_assert_eq!(expn_data.parent.krate, LOCAL_CRATE);
-        let expn_hash = update_disambiguator(&mut expn_data, ctx);
+        let expn_hash = update_disambiguator(&mut expn_data, hcx);
         HygieneData::with(|data| {
             let expn_id = data.local_expn_data.push(Some(expn_data));
             let _eid = data.local_expn_hashes.push(expn_hash);
@@ -231,9 +231,9 @@ impl LocalExpnId {
     }
 
     #[inline]
-    pub fn set_expn_data(self, mut expn_data: ExpnData, ctx: impl HashStableContext) {
+    pub fn set_expn_data(self, mut expn_data: ExpnData, hcx: impl HashStableContext) {
         debug_assert_eq!(expn_data.parent.krate, LOCAL_CRATE);
-        let expn_hash = update_disambiguator(&mut expn_data, ctx);
+        let expn_hash = update_disambiguator(&mut expn_data, hcx);
         HygieneData::with(|data| {
             let old_expn_data = &mut data.local_expn_data[self];
             assert!(old_expn_data.is_none(), "expansion data is reset for an expansion ID");
@@ -950,13 +950,13 @@ impl Span {
         allow_internal_unstable: Option<Arc<[Symbol]>>,
         reason: DesugaringKind,
         edition: Edition,
-        ctx: impl HashStableContext,
+        hcx: impl HashStableContext,
     ) -> Span {
         let expn_data = ExpnData {
             allow_internal_unstable,
             ..ExpnData::default(ExpnKind::Desugaring(reason), self, edition, None, None)
         };
-        let expn_id = LocalExpnId::fresh(expn_data, ctx);
+        let expn_id = LocalExpnId::fresh(expn_data, hcx);
         self.apply_mark(expn_id.to_expn_id(), Transparency::Transparent)
     }
 }
@@ -1102,9 +1102,9 @@ impl ExpnData {
     }
 
     #[inline]
-    fn hash_expn(&self, ctx: &mut impl HashStableContext) -> Hash64 {
+    fn hash_expn(&self, hcx: &mut impl HashStableContext) -> Hash64 {
         let mut hasher = StableHasher::new();
-        self.hash_stable(ctx, &mut hasher);
+        self.hash_stable(hcx, &mut hasher);
         hasher.finish()
     }
 }
@@ -1482,11 +1482,11 @@ pub fn raw_encode_syntax_context(
 /// `set_expn_data`). It is *not* called for foreign `ExpnId`s deserialized
 /// from another crate's metadata - since `ExpnHash` includes the stable crate id,
 /// collisions are only possible between `ExpnId`s within the same crate.
-fn update_disambiguator(expn_data: &mut ExpnData, mut ctx: impl HashStableContext) -> ExpnHash {
+fn update_disambiguator(expn_data: &mut ExpnData, mut hcx: impl HashStableContext) -> ExpnHash {
     // This disambiguator should not have been set yet.
     assert_eq!(expn_data.disambiguator, 0, "Already set disambiguator for ExpnData: {expn_data:?}");
-    ctx.assert_default_hashing_controls("ExpnData (disambiguator)");
-    let mut expn_hash = expn_data.hash_expn(&mut ctx);
+    hcx.assert_default_hashing_controls("ExpnData (disambiguator)");
+    let mut expn_hash = expn_data.hash_expn(&mut hcx);
 
     let disambiguator = HygieneData::with(|data| {
         // If this is the first ExpnData with a given hash, then keep our
@@ -1501,7 +1501,7 @@ fn update_disambiguator(expn_data: &mut ExpnData, mut ctx: impl HashStableContex
         debug!("Set disambiguator for expn_data={:?} expn_hash={:?}", expn_data, expn_hash);
 
         expn_data.disambiguator = disambiguator;
-        expn_hash = expn_data.hash_expn(&mut ctx);
+        expn_hash = expn_data.hash_expn(&mut hcx);
 
         // Verify that the new disambiguator makes the hash unique
         #[cfg(debug_assertions)]
@@ -1514,28 +1514,28 @@ fn update_disambiguator(expn_data: &mut ExpnData, mut ctx: impl HashStableContex
         });
     }
 
-    ExpnHash::new(ctx.def_path_hash(LOCAL_CRATE.as_def_id()).stable_crate_id(), expn_hash)
+    ExpnHash::new(hcx.def_path_hash(LOCAL_CRATE.as_def_id()).stable_crate_id(), expn_hash)
 }
 
-impl<CTX: HashStableContext> HashStable<CTX> for SyntaxContext {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+impl<Hcx: HashStableContext> HashStable<Hcx> for SyntaxContext {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         const TAG_EXPANSION: u8 = 0;
         const TAG_NO_EXPANSION: u8 = 1;
 
         if self.is_root() {
-            TAG_NO_EXPANSION.hash_stable(ctx, hasher);
+            TAG_NO_EXPANSION.hash_stable(hcx, hasher);
         } else {
-            TAG_EXPANSION.hash_stable(ctx, hasher);
+            TAG_EXPANSION.hash_stable(hcx, hasher);
             let (expn_id, transparency) = self.outer_mark();
-            expn_id.hash_stable(ctx, hasher);
-            transparency.hash_stable(ctx, hasher);
+            expn_id.hash_stable(hcx, hasher);
+            transparency.hash_stable(hcx, hasher);
         }
     }
 }
 
-impl<CTX: HashStableContext> HashStable<CTX> for ExpnId {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        ctx.assert_default_hashing_controls("ExpnId");
+impl<Hcx: HashStableContext> HashStable<Hcx> for ExpnId {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+        hcx.assert_default_hashing_controls("ExpnId");
         let hash = if *self == ExpnId::root() {
             // Avoid fetching TLS storage for a trivial often-used value.
             Fingerprint::ZERO
@@ -1543,12 +1543,12 @@ impl<CTX: HashStableContext> HashStable<CTX> for ExpnId {
             self.expn_hash().0
         };
 
-        hash.hash_stable(ctx, hasher);
+        hash.hash_stable(hcx, hasher);
     }
 }
 
-impl<CTX: HashStableContext> HashStable<CTX> for LocalExpnId {
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+impl<Hcx: HashStableContext> HashStable<Hcx> for LocalExpnId {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         self.to_expn_id().hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -2812,13 +2812,13 @@ pub trait HashStableContext {
     fn assert_default_hashing_controls(&self, msg: &str);
 }
 
-impl<CTX> HashStable<CTX> for Span
+impl<Hcx> HashStable<Hcx> for Span
 where
-    CTX: HashStableContext,
+    Hcx: HashStableContext,
 {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         // `span_hash_stable` does all the work.
-        ctx.span_hash_stable(*self, hasher)
+        hcx.span_hash_stable(*self, hasher)
     }
 }
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2598,17 +2598,17 @@ impl fmt::Display for Symbol {
     }
 }
 
-impl<CTX> HashStable<CTX> for Symbol {
+impl<Hcx> HashStable<Hcx> for Symbol {
     #[inline]
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         self.as_str().hash_stable(hcx, hasher);
     }
 }
 
-impl<CTX> ToStableHashKey<CTX> for Symbol {
+impl<Hcx> ToStableHashKey<Hcx> for Symbol {
     type KeyType = String;
     #[inline]
-    fn to_stable_hash_key(&self, _: &CTX) -> String {
+    fn to_stable_hash_key(&self, _: &Hcx) -> String {
         self.as_str().to_string()
     }
 }
@@ -2658,9 +2658,9 @@ impl fmt::Debug for ByteSymbol {
     }
 }
 
-impl<CTX> HashStable<CTX> for ByteSymbol {
+impl<Hcx> HashStable<Hcx> for ByteSymbol {
     #[inline]
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         self.as_byte_str().hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_type_ir/src/const_kind.rs
+++ b/compiler/rustc_type_ir/src/const_kind.rs
@@ -117,8 +117,8 @@ impl fmt::Debug for InferConst {
 }
 
 #[cfg(feature = "nightly")]
-impl<CTX> HashStable<CTX> for InferConst {
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+impl<Hcx> HashStable<Hcx> for InferConst {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         match self {
             InferConst::Var(_) => {
                 panic!("const variables should not be hashed: {self:?}")

--- a/compiler/rustc_type_ir/src/fast_reject.rs
+++ b/compiler/rustc_type_ir/src/fast_reject.rs
@@ -50,13 +50,13 @@ pub enum SimplifiedType<DefId> {
 }
 
 #[cfg(feature = "nightly")]
-impl<HCX: Clone, DefId: HashStable<HCX>> ToStableHashKey<HCX> for SimplifiedType<DefId> {
+impl<Hcx: Clone, DefId: HashStable<Hcx>> ToStableHashKey<Hcx> for SimplifiedType<DefId> {
     type KeyType = Fingerprint;
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &HCX) -> Fingerprint {
+    fn to_stable_hash_key(&self, hcx: &Hcx) -> Fingerprint {
         let mut hasher = StableHasher::new();
-        let mut hcx: HCX = hcx.clone();
+        let mut hcx: Hcx = hcx.clone();
         self.hash_stable(&mut hcx, &mut hasher);
         hasher.finish()
     }

--- a/compiler/rustc_type_ir/src/region_kind.rs
+++ b/compiler/rustc_type_ir/src/region_kind.rs
@@ -217,15 +217,15 @@ impl<I: Interner> fmt::Debug for RegionKind<I> {
 
 #[cfg(feature = "nightly")]
 // This is not a derived impl because a derive would require `I: HashStable`
-impl<CTX, I: Interner> HashStable<CTX> for RegionKind<I>
+impl<Hcx, I: Interner> HashStable<Hcx> for RegionKind<I>
 where
-    I::EarlyParamRegion: HashStable<CTX>,
-    I::LateParamRegion: HashStable<CTX>,
-    I::DefId: HashStable<CTX>,
-    I::Symbol: HashStable<CTX>,
+    I::EarlyParamRegion: HashStable<Hcx>,
+    I::LateParamRegion: HashStable<Hcx>,
+    I::DefId: HashStable<Hcx>,
+    I::Symbol: HashStable<Hcx>,
 {
     #[inline]
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         std::mem::discriminant(self).hash_stable(hcx, hasher);
         match self {
             ReErased | ReStatic | ReError(_) => {

--- a/compiler/rustc_type_ir/src/ty_info.rs
+++ b/compiler/rustc_type_ir/src/ty_info.rs
@@ -97,8 +97,8 @@ impl<T: Hash> Hash for WithCachedTypeInfo<T> {
 }
 
 #[cfg(feature = "nightly")]
-impl<T: HashStable<CTX>, CTX> HashStable<CTX> for WithCachedTypeInfo<T> {
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+impl<T: HashStable<Hcx>, Hcx> HashStable<Hcx> for WithCachedTypeInfo<T> {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         if self.stable_hash == Fingerprint::ZERO || cfg!(debug_assertions) {
             // No cached hash available. This can only mean that incremental is disabled.
             // We don't cache stable hashes in non-incremental mode, because they are used

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -687,15 +687,15 @@ impl UnifyKey for FloatVid {
 }
 
 #[cfg(feature = "nightly")]
-impl<CTX> HashStable<CTX> for InferTy {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+impl<Hcx> HashStable<Hcx> for InferTy {
+    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         use InferTy::*;
-        std::mem::discriminant(self).hash_stable(ctx, hasher);
+        std::mem::discriminant(self).hash_stable(hcx, hasher);
         match self {
             TyVar(_) | IntVar(_) | FloatVar(_) => {
                 panic!("type variables should not be hashed: {self:?}")
             }
-            FreshTy(v) | FreshIntTy(v) | FreshFloatTy(v) => v.hash_stable(ctx, hasher),
+            FreshTy(v) | FreshIntTy(v) | FreshFloatTy(v) => v.hash_stable(hcx, hasher),
         }
     }
 }


### PR DESCRIPTION
The `HashStable` and `ToStableHashKey` traits both have a type parameter that is sometimes called `CTX` and sometimes called `HCX`. (In practice this type parameter is always instantiated as `StableHashingContext`.) Similarly, variables with these types are sometimes called `ctx` and sometimes called `hcx`. This inconsistency has bugged me for some time.

The `HCX`/`hcx` form is more informative (the `H`/`h` indicates what type of context it is) and it matches other cases like `tcx`, `dcx`, `icx`.

Also, RFC 430 says that type parameters should have names that are "concise UpperCamelCase, usually single uppercase letter: T". In this case `H` feels insufficient, and `Hcx` feels better.

Therefore, this commit changes the code to use `Hcx`/`hcx` everywhere.

r? @petrochenkov 