### PR TITLE
change `c_double` to `f32` on `avr` targets

### DIFF
--- a/library/core/src/ffi/c_double.md
+++ b/library/core/src/ffi/c_double.md
@@ -1,6 +1,6 @@
 Equivalent to C's `double` type.
 
-This type will almost always be [`f64`], which is guaranteed to be an [IEEE 754 double-precision float] in Rust. That said, the standard technically only guarantees that it be a floating-point number with at least the precision of a [`float`], and it may be `f32` or something entirely different from the IEEE-754 standard.
+This type will almost always be [`f64`], which is guaranteed to be an [IEEE 754 double-precision float] in Rust. That said, the standard technically only guarantees that it be a floating-point number with at least the precision of a [`float`]; some 16-bit systems use [`f32`], for example. Esoteric systems could use something entirely different from the IEEE-754 standard.
 
 [IEEE 754 double-precision float]: https://en.wikipedia.org/wiki/IEEE_754
 [`float`]: c_float

--- a/library/core/src/ffi/primitives.rs
+++ b/library/core/src/ffi/primitives.rs
@@ -15,24 +15,27 @@ macro_rules! type_alias {
     }
 }
 
-type_alias! { "c_char.md", c_char = c_char_definition::c_char; #[doc(cfg(all()))] }
+// `#[doc(cfg(true))]` is used to prevent rustdoc from displaying a "Available on ..." box.
+// The implementation of these constants is target-specific, but every target does define them.
+
+type_alias! { "c_char.md", c_char = c_char_definition::c_char; #[doc(cfg(true))] }
 
 type_alias! { "c_schar.md", c_schar = i8; }
 type_alias! { "c_uchar.md", c_uchar = u8; }
 type_alias! { "c_short.md", c_short = i16; }
 type_alias! { "c_ushort.md", c_ushort = u16; }
 
-type_alias! { "c_int.md", c_int = c_int_definition::c_int; #[doc(cfg(all()))] }
-type_alias! { "c_uint.md", c_uint = c_int_definition::c_uint; #[doc(cfg(all()))] }
+type_alias! { "c_int.md", c_int = c_int_definition::c_int; #[doc(cfg(true))] }
+type_alias! { "c_uint.md", c_uint = c_int_definition::c_uint; #[doc(cfg(true))] }
 
-type_alias! { "c_long.md", c_long = c_long_definition::c_long; #[doc(cfg(all()))] }
-type_alias! { "c_ulong.md", c_ulong = c_long_definition::c_ulong; #[doc(cfg(all()))] }
+type_alias! { "c_long.md", c_long = c_long_definition::c_long; #[doc(cfg(true))] }
+type_alias! { "c_ulong.md", c_ulong = c_long_definition::c_ulong; #[doc(cfg(true))] }
 
 type_alias! { "c_longlong.md", c_longlong = i64; }
 type_alias! { "c_ulonglong.md", c_ulonglong = u64; }
 
 type_alias! { "c_float.md", c_float = f32; }
-type_alias! { "c_double.md", c_double = f64; }
+type_alias! { "c_double.md", c_double= c_double_definition::c_double; #[doc(cfg(true))] }
 
 mod c_char_definition {
     crate::cfg_select! {
@@ -180,6 +183,21 @@ mod c_int_definition {
         _ => {
             pub(super) type c_int = i32;
             pub(super) type c_uint = u32;
+        }
+    }
+}
+
+mod c_double_definition {
+    crate::cfg_select! {
+        target_arch = "avr" => {
+            // avr:
+            //     Per https://gcc.gnu.org/wiki/avr-gcc#Type_Layout. The table says `4,8` because
+            //     in C the width of `double` can be changed with the `-mdouble=32/64` setting. But
+            //     32-bits is the default for the rust avr target.
+            pub(super) type c_double = f32;
+        }
+        _ => {
+            pub(super) type c_double = f64;
         }
     }
 }


### PR DESCRIPTION
Extracted from https://github.com/rust-lang/rust/pull/152980. That version also makes this change for `msp430` but that is actually incorrect based on https://www.ti.com/lit/ug/slau132r/slau132r.pdf table 5-1 that specifies `double` as `f64`.

r? tgross35 
cc @Patryk27 @workingjubilee 