### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/library/std/src/net/udp.rs
+++ b/library/std/src/net/udp.rs
@@ -129,6 +129,10 @@ impl UdpSocket {
     /// hold the message bytes. If a message is too long to fit in the supplied buffer,
     /// excess bytes may be discarded.
     ///
+    /// Refer to the platform-specific documentation on this function; it is considered
+    /// correct for its behavior to differ from [`UdpSocket::recv`] if the underlying system
+    /// call does so.
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -710,6 +714,10 @@ impl UdpSocket {
     ///
     /// [`UdpSocket::connect`] will connect this socket to a remote address. This
     /// method will fail if the socket is not connected.
+    ///
+    /// Refer to the platform-specific documentation on this function; it is considered
+    /// correct for its behavior to differ from [`UdpSocket::recv_from`] if the underlying
+    /// system call does so.
     ///
     /// # Examples
     ///

--- a/src/doc/rustdoc/src/lints.md
+++ b/src/doc/rustdoc/src/lints.md
@@ -190,6 +190,16 @@ To fix the lint, you need to add a code example into the documentation block:
 pub fn no_code_example() {}
 ```
 
+This lint is not emitted on the following items:
+
+ * Impl blocks (both trait and inherent)
+ * Enum variants
+ * Struct/union fields
+ * Type aliases, including associated types
+ * Statics/constants
+ * Modules (including the top-level module of a crate)
+ * Foreign items from reexports (functions, statics, types, etc)
+
 ## `private_doc_tests`
 
 This lint is **allowed by default**. It detects documentation tests when they


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#154249 (Mention on which items the `missing_doc_code_examples` is not emitted)
 - rust-lang/rust#154266 (UdpSocket: document `recv/recv_from` differences)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=154249,154266)
<!-- homu-ignore:end -->

