### PR TITLE
Avoid creating async return opaques for foreign async fns

### DIFF
--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -209,12 +209,15 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
     fn visit_fn(&mut self, fn_kind: FnKind<'a>, _: &AttrVec, span: Span, _: NodeId) {
         match fn_kind {
             FnKind::Fn(
-                _ctxt,
+                ctxt,
                 _vis,
                 Fn {
                     sig: FnSig { header, decl, span: _ }, ident, generics, contract, body, ..
                 },
-            ) if let Some(coroutine_kind) = header.coroutine_kind => {
+            ) if let Some(coroutine_kind) = header.coroutine_kind
+                // Foreign ones are denied, so don't create them here.
+                && ctxt != visit::FnCtxt::Foreign =>
+            {
                 self.visit_ident(ident);
                 self.visit_fn_header(header);
                 self.visit_generics(generics);

--- a/tests/ui/extern/bad-external-async-fn-issue-146754.rs
+++ b/tests/ui/extern/bad-external-async-fn-issue-146754.rs
@@ -1,0 +1,8 @@
+//@ edition:2024
+#![crate_type = "lib"]
+
+unsafe extern "C" {
+    async fn function() -> [(); || {}];
+    //~^ ERROR functions in `extern` blocks cannot have `async` qualifier
+    //~^^ ERROR mismatched types
+}

--- a/tests/ui/extern/bad-external-async-fn-issue-146754.stderr
+++ b/tests/ui/extern/bad-external-async-fn-issue-146754.stderr
@@ -1,0 +1,21 @@
+error: functions in `extern` blocks cannot have `async` qualifier
+  --> $DIR/bad-external-async-fn-issue-146754.rs:5:5
+   |
+LL | unsafe extern "C" {
+   | ----------------- in this `extern` block
+LL |     async fn function() -> [(); || {}];
+   |     ^^^^^ help: remove the `async` qualifier
+
+error[E0308]: mismatched types
+  --> $DIR/bad-external-async-fn-issue-146754.rs:5:33
+   |
+LL |     async fn function() -> [(); || {}];
+   |                                 ^^^^^ expected `usize`, found closure
+   |
+   = note: expected type `usize`
+           found closure `{closure@$DIR/bad-external-async-fn-issue-146754.rs:5:33: 5:35}`
+   = note: array length can only be `usize`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/146754

Previously, def collection created the desugared async return opaque for foreign `async fn` items, but AST lowering won't lower that opaque for foreign items. That left a `DefId` without a corresponding HIR owner, which later caused an ICE during analysis.