### PR TITLE
Add a test for a past ICE when calling a const fn of an unresolved type with the wrong number of args

### DIFF
--- a/tests/ui/consts/ice-extra-args-fn-abi-issue-127423.rs
+++ b/tests/ui/consts/ice-extra-args-fn-abi-issue-127423.rs
@@ -1,0 +1,18 @@
+// #127423: ICE: assertion failed: sig.c_variadic || extra_args.is_empty()
+// Calling a const fn with the wrong number of arguments where the function has
+// an unresolved type should not trigger an ICE.
+// issue: rust-lang/rust#127423
+
+#![allow(dead_code)]
+
+const fn add(a: &'self isize) -> usize {
+    //~^ ERROR use of undeclared lifetime name `'self`
+    //~| ERROR lifetimes cannot use keyword names
+    Qux + y
+    //~^ ERROR cannot find value `Qux` in this scope
+    //~| ERROR cannot find value `y` in this scope
+}
+
+const ARR: [i32; add(1, 2)] = [5, 6, 7];
+
+pub fn main() {}

--- a/tests/ui/consts/ice-extra-args-fn-abi-issue-127423.rs
+++ b/tests/ui/consts/ice-extra-args-fn-abi-issue-127423.rs
@@ -1,7 +1,4 @@
-// #127423: ICE: assertion failed: sig.c_variadic || extra_args.is_empty()
-// Calling a const fn with the wrong number of arguments where the function has
-// an unresolved type should not trigger an ICE.
-// issue: rust-lang/rust#127423
+//! Regression test for https://github.com/rust-lang/rust/issues/127423
 
 #![allow(dead_code)]
 

--- a/tests/ui/consts/ice-extra-args-fn-abi-issue-127423.stderr
+++ b/tests/ui/consts/ice-extra-args-fn-abi-issue-127423.stderr
@@ -1,11 +1,11 @@
 error: lifetimes cannot use keyword names
-  --> $DIR/ice-extra-args-fn-abi-issue-127423.rs:8:18
+  --> $DIR/ice-extra-args-fn-abi-issue-127423.rs:5:18
    |
 LL | const fn add(a: &'self isize) -> usize {
    |                  ^^^^^
 
 error[E0261]: use of undeclared lifetime name `'self`
-  --> $DIR/ice-extra-args-fn-abi-issue-127423.rs:8:18
+  --> $DIR/ice-extra-args-fn-abi-issue-127423.rs:5:18
    |
 LL | const fn add(a: &'self isize) -> usize {
    |                  ^^^^^ undeclared lifetime
@@ -16,13 +16,13 @@ LL | const fn add<'self>(a: &'self isize) -> usize {
    |             +++++++
 
 error[E0425]: cannot find value `Qux` in this scope
-  --> $DIR/ice-extra-args-fn-abi-issue-127423.rs:11:5
+  --> $DIR/ice-extra-args-fn-abi-issue-127423.rs:8:5
    |
 LL |     Qux + y
    |     ^^^ not found in this scope
 
 error[E0425]: cannot find value `y` in this scope
-  --> $DIR/ice-extra-args-fn-abi-issue-127423.rs:11:11
+  --> $DIR/ice-extra-args-fn-abi-issue-127423.rs:8:11
    |
 LL |     Qux + y
    |           ^

--- a/tests/ui/consts/ice-extra-args-fn-abi-issue-127423.stderr
+++ b/tests/ui/consts/ice-extra-args-fn-abi-issue-127423.stderr
@@ -1,0 +1,39 @@
+error: lifetimes cannot use keyword names
+  --> $DIR/ice-extra-args-fn-abi-issue-127423.rs:8:18
+   |
+LL | const fn add(a: &'self isize) -> usize {
+   |                  ^^^^^
+
+error[E0261]: use of undeclared lifetime name `'self`
+  --> $DIR/ice-extra-args-fn-abi-issue-127423.rs:8:18
+   |
+LL | const fn add(a: &'self isize) -> usize {
+   |                  ^^^^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'self` here
+   |
+LL | const fn add<'self>(a: &'self isize) -> usize {
+   |             +++++++
+
+error[E0425]: cannot find value `Qux` in this scope
+  --> $DIR/ice-extra-args-fn-abi-issue-127423.rs:11:5
+   |
+LL |     Qux + y
+   |     ^^^ not found in this scope
+
+error[E0425]: cannot find value `y` in this scope
+  --> $DIR/ice-extra-args-fn-abi-issue-127423.rs:11:11
+   |
+LL |     Qux + y
+   |           ^
+   |
+help: a local variable with a similar name exists
+   |
+LL -     Qux + y
+LL +     Qux + a
+   |
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0261, E0425.
+For more information about an error, try `rustc --explain E0261`.


### PR DESCRIPTION
The ICE is fixed, but there needs to be a regression test for it.

Closes rust-lang/rust#127423.