### PR TITLE
Use a different name for fast try builds

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -94,6 +94,7 @@ jobs:
   dist-x86_64-linux: &job-dist-x86_64-linux
     name: dist-x86_64-linux
     env:
+      IMAGE: dist-x86_64-linux
       CODEGEN_BACKENDS: llvm,cranelift
       DOCKER_SCRIPT: dist.sh
     <<: *job-linux-36c-codebuild
@@ -150,6 +151,7 @@ pr:
 # it in each job definition.
 try:
   - <<: *job-dist-x86_64-linux
+    name: dist-x86_64-linux-quick
 
 # Jobs that only run when explicitly invoked in one of the following ways:
 # - comment `@bors try jobs=<job-name>`

--- a/src/doc/rustc-dev-guide/src/tests/ci.md
+++ b/src/doc/rustc-dev-guide/src/tests/ci.md
@@ -150,7 +150,10 @@ Such a try build will not execute any tests, and it will allow compilation warni
 It is useful when you want to
 get an optimized toolchain as fast as possible, for a Crater run or performance benchmarks,
 even if it might not be working fully correctly.
-If you want to do a full build for the default try job,
+
+The CI job executed in fast try builds has a special suffix (`-quick`),
+to distinguish it from a full build of the default try job.
+If you want to do the full build instead,
 specify its job name in a job pattern (explained below).
 
 If you want to run custom CI jobs in a try build and make sure that they pass all tests and do


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/154673)*
<!-- homu-ignore:end -->

Based on discussion in https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/try.20build.20that.20includes.20Miri.3F/with/581602033.
