### PR TITLE
hwaddress: automatically add `-Ctarget-feature=+tagged-globals`

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -630,6 +630,7 @@ fn llvm_features_by_flags(sess: &Session, features: &mut Vec<String>) {
     }
 
     target_features::retpoline_features_by_flags(sess, features);
+    target_features::sanitizer_features_by_flags(sess, features);
 
     // -Zfixed-x18
     if sess.opts.unstable_opts.fixed_x18 {

--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -10,7 +10,7 @@ use rustc_session::Session;
 use rustc_session::lint::builtin::AARCH64_SOFTFLOAT_NEON;
 use rustc_session::parse::feature_err;
 use rustc_span::{Span, Symbol, edit_distance, sym};
-use rustc_target::spec::Arch;
+use rustc_target::spec::{Arch, SanitizerSet};
 use rustc_target::target_features::{RUSTC_SPECIFIC_FEATURES, Stability};
 use smallvec::SmallVec;
 
@@ -457,6 +457,15 @@ pub fn retpoline_features_by_flags(sess: &Session, features: &mut Vec<String>) {
         features.push("+retpoline-external-thunk".into());
         features.push("+retpoline-indirect-branches".into());
         features.push("+retpoline-indirect-calls".into());
+    }
+}
+
+/// Computes the backend target features to be added to account for sanitizer flags.
+pub fn sanitizer_features_by_flags(sess: &Session, features: &mut Vec<String>) {
+    // It's intentional that this is done only for non-kernel version of hwaddress. This matches
+    // clang behavior.
+    if sess.sanitizers().contains(SanitizerSet::HWADDRESS) {
+        features.push("+tagged-globals".into());
     }
 }
 

--- a/src/doc/unstable-book/src/compiler-flags/sanitizer.md
+++ b/src/doc/unstable-book/src/compiler-flags/sanitizer.md
@@ -552,10 +552,6 @@ HWAddressSanitizer is supported on the following targets:
 * `aarch64-linux-android`
 * `aarch64-unknown-linux-gnu`
 
-HWAddressSanitizer requires `tagged-globals` target feature to instrument
-globals. To enable this target feature compile with `-C
-target-feature=+tagged-globals`
-
 See the [Clang HWAddressSanitizer documentation][clang-hwasan] for more details.
 
 ## Example
@@ -570,9 +566,8 @@ fn main() {
 ```
 
 ```shell
-$ rustc main.rs -Zsanitizer=hwaddress -C target-feature=+tagged-globals -C
-linker=aarch64-linux-gnu-gcc -C link-arg=-fuse-ld=lld --target
-aarch64-unknown-linux-gnu
+$ rustc main.rs -Zsanitizer=hwaddress -Clinker=aarch64-linux-gnu-gcc
+-Clink-arg=-fuse-ld=lld --target aarch64-unknown-linux-gnu
 ```
 
 ```shell

--- a/tests/codegen-llvm/sanitizer/hwasan-vs-khwasan.rs
+++ b/tests/codegen-llvm/sanitizer/hwasan-vs-khwasan.rs
@@ -18,6 +18,7 @@ extern crate minicore;
 // hwasan:       @__hwasan_tls
 // hwasan:       call void @llvm.hwasan.check.memaccess.shortgranules
 // hwasan:       declare void @__hwasan_init()
+// hwasan:       attributes #0 {{.*"target-features"=".*\+tagged-globals.*"}}
 
 // The `__hwasan_tls` symbol is unconditionally declared by LLVM's `HWAddressSanitizer` pass.
 // However, in kernel mode KHWASAN does not actually use it (because shadow mapping is fixed
@@ -33,6 +34,7 @@ extern crate minicore;
 //
 // khwasan-NOT:   @__hwasan_init
 // khwasan:       call void @llvm.hwasan.check.memaccess.shortgranules
+// khwasan-NOT:   attributes #0 {{.*"target-features"=".*\+tagged-globals.*"}}
 #[no_mangle]
 pub fn test(b: &mut u8) -> u8 {
     *b

--- a/tests/ui/sanitizer/hwaddress.rs
+++ b/tests/ui/sanitizer/hwaddress.rs
@@ -1,7 +1,7 @@
 //@ needs-sanitizer-support
 //@ needs-sanitizer-hwaddress
 //
-//@ compile-flags: -Z sanitizer=hwaddress -O -g -C target-feature=+tagged-globals -C unsafe-allow-abi-mismatch=sanitizer
+//@ compile-flags: -Z sanitizer=hwaddress -O -g -C unsafe-allow-abi-mismatch=sanitizer
 //
 //@ run-fail
 //@ error-pattern: HWAddressSanitizer: tag-mismatch
@@ -15,5 +15,3 @@ fn main() {
     let code = unsafe { *xs.offset(4) };
     std::process::exit(code);
 }
-
-//~? WARN unknown and unstable feature specified for `-Ctarget-feature`: `tagged-globals`

--- a/tests/ui/sanitizer/hwaddress.stderr
+++ b/tests/ui/sanitizer/hwaddress.stderr
@@ -1,7 +1,0 @@
-warning: unknown and unstable feature specified for `-Ctarget-feature`: `tagged-globals`
-   |
-   = note: it is still passed through to the codegen backend, but use of this feature might be unsound and the behavior of this feature can change in the future
-   = help: consider filing a feature request
-
-warning: 1 warning emitted
-


### PR DESCRIPTION
Note that since HWAddressSanitizer is/should be a target modifier, we do not have to worry about whether this LLVM target feature changes the ABI.

Fixes: rust-lang/rust#148185