### PR TITLE
Introduce #[diagnostic::on_move] on `Rc`

### DIFF
--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -311,6 +311,12 @@ fn rc_inner_layout_for_value_layout(layout: Layout) -> Layout {
 #[rustc_diagnostic_item = "Rc"]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_insignificant_dtor]
+#[diagnostic::on_move(
+    message = "the type `{Self}` does not implement `Copy`",
+    label = "this move could be avoided by cloning the original `{Self}`, which is inexpensive",
+    note = "consider using `Rc::clone`"
+)]
+
 pub struct Rc<
     T: ?Sized,
     #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global,

--- a/tests/ui/moves/move-fn-self-receiver.rs
+++ b/tests/ui/moves/move-fn-self-receiver.rs
@@ -52,7 +52,7 @@ fn move_out(val: Container) {
 
     let rc_foo = Rc::new(Foo);
     rc_foo.use_rc_self();
-    rc_foo; //~ ERROR use of moved
+    rc_foo; //~ ERROR the type `Rc` does not implement `Copy`
 
     let foo_add = Foo;
     foo_add + Foo;

--- a/tests/ui/moves/move-fn-self-receiver.stderr
+++ b/tests/ui/moves/move-fn-self-receiver.stderr
@@ -102,16 +102,17 @@ LL |     mut_foo;
 LL |     ret;
    |     --- borrow later used here
 
-error[E0382]: use of moved value: `rc_foo`
+error[E0382]: the type `Rc` does not implement `Copy`
   --> $DIR/move-fn-self-receiver.rs:55:5
    |
 LL |     let rc_foo = Rc::new(Foo);
-   |         ------ move occurs because `rc_foo` has type `Rc<Foo>`, which does not implement the `Copy` trait
+   |         ------ this move could be avoided by cloning the original `Rc`, which is inexpensive
 LL |     rc_foo.use_rc_self();
    |            ------------- `rc_foo` moved due to this method call
 LL |     rc_foo;
    |     ^^^^^^ value used here after move
    |
+   = note: consider using `Rc::clone`
 note: `Foo::use_rc_self` takes ownership of the receiver `self`, which moves `rc_foo`
   --> $DIR/move-fn-self-receiver.rs:16:20
    |

--- a/tests/ui/moves/use_of_moved_value_clone_suggestions.rs
+++ b/tests/ui/moves/use_of_moved_value_clone_suggestions.rs
@@ -1,6 +1,6 @@
 // `Rc` is not ever `Copy`, we should not suggest adding `T: Copy` constraint
 fn duplicate_rc<T>(t: std::rc::Rc<T>) -> (std::rc::Rc<T>, std::rc::Rc<T>) {
-    (t, t) //~ ERROR use of moved value: `t`
+    (t, t) //~ ERROR the type `Rc` does not implement `Copy`
 }
 
 fn main() {}

--- a/tests/ui/moves/use_of_moved_value_clone_suggestions.stderr
+++ b/tests/ui/moves/use_of_moved_value_clone_suggestions.stderr
@@ -1,13 +1,14 @@
-error[E0382]: use of moved value: `t`
+error[E0382]: the type `Rc` does not implement `Copy`
   --> $DIR/use_of_moved_value_clone_suggestions.rs:3:9
    |
 LL | fn duplicate_rc<T>(t: std::rc::Rc<T>) -> (std::rc::Rc<T>, std::rc::Rc<T>) {
-   |                    - move occurs because `t` has type `Rc<T>`, which does not implement the `Copy` trait
+   |                    - this move could be avoided by cloning the original `Rc`, which is inexpensive
 LL |     (t, t)
    |      -  ^ value used here after move
    |      |
    |      value moved here
    |
+   = note: consider using `Rc::clone`
 help: clone the value to increment its reference count
    |
 LL |     (t.clone(), t)


### PR DESCRIPTION
This is related to the tracking issue rust-lang/rust#154181 and to the original issue rust-lang/rust#149862.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
