### PR TITLE
[rustdoc] Replace `DocContext` with `TyCtxt` wherever possible

### DIFF
--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -203,7 +203,7 @@ fn clean_param_env<'tcx>(
 
     let mut generics = clean::Generics { params, where_predicates };
     simplify::sized_bounds(cx, &mut generics);
-    generics.where_predicates = simplify::where_clauses(cx, generics.where_predicates);
+    generics.where_predicates = simplify::where_clauses(cx.tcx, generics.where_predicates);
     generics
 }
 

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -388,8 +388,8 @@ pub(crate) fn build_impls(
     attrs: Option<(&[hir::Attribute], Option<LocalDefId>)>,
     ret: &mut Vec<clean::Item>,
 ) {
-    let _prof_timer = cx.tcx.sess.prof.generic_activity("build_inherent_impls");
     let tcx = cx.tcx;
+    let _prof_timer = tcx.sess.prof.generic_activity("build_inherent_impls");
 
     // for each implementation of an item represented by `did`, build the clean::Item for that impl
     for &did in tcx.inherent_impls(did).iter() {

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -779,7 +779,7 @@ fn build_macro(
         // kinds
         LoadedMacro::MacroDef { def, .. } => match macro_kinds {
             MacroKinds::BANG => clean::MacroItem(clean::Macro {
-                source: utils::display_macro_source(cx, name, &def),
+                source: utils::display_macro_source(cx.tcx, name, &def),
                 macro_rules: def.macro_rules,
             }),
             MacroKinds::DERIVE => clean::ProcMacroItem(clean::ProcMacro {

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -416,7 +416,7 @@ pub(crate) fn build_impls(
 }
 
 pub(crate) fn merge_attrs(
-    cx: &mut DocContext<'_>,
+    tcx: TyCtxt<'_>,
     old_attrs: &[hir::Attribute],
     new_attrs: Option<(&[hir::Attribute], Option<LocalDefId>)>,
     cfg_info: &mut CfgInfo,
@@ -434,13 +434,10 @@ pub(crate) fn merge_attrs(
             } else {
                 Attributes::from_hir(&both)
             },
-            extract_cfg_from_attrs(both.iter(), cx.tcx, cfg_info),
+            extract_cfg_from_attrs(both.iter(), tcx, cfg_info),
         )
     } else {
-        (
-            Attributes::from_hir(old_attrs),
-            extract_cfg_from_attrs(old_attrs.iter(), cx.tcx, cfg_info),
-        )
+        (Attributes::from_hir(old_attrs), extract_cfg_from_attrs(old_attrs.iter(), tcx, cfg_info))
     }
 }
 
@@ -624,7 +621,7 @@ pub(crate) fn build_impl(
     //
     // We need to pass this empty `CfgInfo` because `merge_attrs` is used when computing the `cfg`.
     let (merged_attrs, cfg) =
-        merge_attrs(cx, load_attrs(cx.tcx, did), attrs, &mut CfgInfo::default());
+        merge_attrs(cx.tcx, load_attrs(cx.tcx, did), attrs, &mut CfgInfo::default());
     trace!("merged_attrs={merged_attrs:?}");
 
     trace!(

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -137,7 +137,7 @@ pub(crate) fn try_inline(
             })
         }
         Res::Def(DefKind::Macro(kinds), did) => {
-            let mac = build_macro(cx, did, name, kinds);
+            let mac = build_macro(cx.tcx, did, name, kinds);
 
             // FIXME: handle attributes and derives that aren't proc macros, and macros with
             // multiple kinds
@@ -769,17 +769,17 @@ fn build_static(cx: &mut DocContext<'_>, did: DefId, mutable: bool) -> clean::St
 }
 
 fn build_macro(
-    cx: &mut DocContext<'_>,
+    tcx: TyCtxt<'_>,
     def_id: DefId,
     name: Symbol,
     macro_kinds: MacroKinds,
 ) -> clean::ItemKind {
-    match CStore::from_tcx(cx.tcx).load_macro_untracked(cx.tcx, def_id) {
+    match CStore::from_tcx(tcx).load_macro_untracked(tcx, def_id) {
         // FIXME: handle attributes and derives that aren't proc macros, and macros with multiple
         // kinds
         LoadedMacro::MacroDef { def, .. } => match macro_kinds {
             MacroKinds::BANG => clean::MacroItem(clean::Macro {
-                source: utils::display_macro_source(cx.tcx, name, &def),
+                source: utils::display_macro_source(tcx, name, &def),
                 macro_rules: def.macro_rules,
             }),
             MacroKinds::DERIVE => clean::ProcMacroItem(clean::ProcMacro {

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -218,10 +218,10 @@ pub(crate) fn try_inline_glob(
     }
 }
 
-pub(crate) fn load_attrs<'hir>(cx: &DocContext<'hir>, did: DefId) -> &'hir [hir::Attribute] {
+pub(crate) fn load_attrs<'hir>(tcx: TyCtxt<'hir>, did: DefId) -> &'hir [hir::Attribute] {
     // FIXME: all uses should use `find_attr`!
     #[allow(deprecated)]
-    cx.tcx.get_all_attrs(did)
+    tcx.get_all_attrs(did)
 }
 
 pub(crate) fn item_relative_path(tcx: TyCtxt<'_>, def_id: DefId) -> Vec<Symbol> {
@@ -623,7 +623,8 @@ pub(crate) fn build_impl(
     // doesn't matter at this point.
     //
     // We need to pass this empty `CfgInfo` because `merge_attrs` is used when computing the `cfg`.
-    let (merged_attrs, cfg) = merge_attrs(cx, load_attrs(cx, did), attrs, &mut CfgInfo::default());
+    let (merged_attrs, cfg) =
+        merge_attrs(cx, load_attrs(cx.tcx, did), attrs, &mut CfgInfo::default());
     trace!("merged_attrs={merged_attrs:?}");
 
     trace!(

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -312,7 +312,7 @@ pub(super) fn build_function(cx: &mut DocContext<'_>, def_id: DefId) -> Box<clea
     let sig = cx.tcx.fn_sig(def_id).instantiate_identity();
     // The generics need to be cleaned before the signature.
     let mut generics = clean_ty_generics(cx, def_id);
-    let bound_vars = clean_bound_vars(sig.bound_vars(), cx);
+    let bound_vars = clean_bound_vars(sig.bound_vars(), cx.tcx);
 
     // At the time of writing early & late-bound params are stored separately in rustc,
     // namely in `generics.params` and `bound_vars` respectively.

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -289,7 +289,7 @@ pub(crate) fn build_trait(cx: &mut DocContext<'_>, did: DefId) -> clean::Trait {
     supertrait_bounds.retain(|b| {
         // FIXME(sized-hierarchy): Always skip `MetaSized` bounds so that only `?Sized`
         // is shown and none of the new sizedness traits leak into documentation.
-        !b.is_meta_sized_bound(cx)
+        !b.is_meta_sized_bound(cx.tcx)
     });
 
     clean::Trait { def_id: did, generics, items: trait_items, bounds: supertrait_bounds }
@@ -302,7 +302,7 @@ fn build_trait_alias(cx: &mut DocContext<'_>, did: DefId) -> clean::TraitAlias {
     bounds.retain(|b| {
         // FIXME(sized-hierarchy): Always skip `MetaSized` bounds so that only `?Sized`
         // is shown and none of the new sizedness traits leak into documentation.
-        !b.is_meta_sized_bound(cx)
+        !b.is_meta_sized_bound(cx.tcx)
     });
 
     clean::TraitAlias { generics, bounds }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -272,7 +272,7 @@ fn clean_poly_trait_ref_with_constraints<'tcx>(
     GenericBound::TraitBound(
         PolyTrait {
             trait_: clean_trait_ref_with_constraints(cx, poly_trait_ref, constraints),
-            generic_params: clean_bound_vars(poly_trait_ref.bound_vars(), cx),
+            generic_params: clean_bound_vars(poly_trait_ref.bound_vars(), cx.tcx),
         },
         hir::TraitBoundModifiers::NONE,
     )
@@ -2080,7 +2080,7 @@ pub(crate) fn clean_middle_ty<'tcx>(
             // FIXME: should we merge the outer and inner binders somehow?
             let sig = bound_ty.skip_binder().fn_sig(cx.tcx);
             let decl = clean_poly_fn_sig(cx, None, sig);
-            let generic_params = clean_bound_vars(sig.bound_vars(), cx);
+            let generic_params = clean_bound_vars(sig.bound_vars(), cx.tcx);
 
             BareFunction(Box::new(BareFunctionDecl {
                 safety: sig.safety(),
@@ -2090,7 +2090,7 @@ pub(crate) fn clean_middle_ty<'tcx>(
             }))
         }
         ty::UnsafeBinder(inner) => {
-            let generic_params = clean_bound_vars(inner.bound_vars(), cx);
+            let generic_params = clean_bound_vars(inner.bound_vars(), cx.tcx);
             let ty = clean_middle_ty(inner.into(), cx, None, None);
             UnsafeBinder(Box::new(UnsafeBinderTy { generic_params, ty }))
         }
@@ -3238,13 +3238,13 @@ fn clean_assoc_item_constraint<'tcx>(
 
 fn clean_bound_vars<'tcx>(
     bound_vars: &ty::List<ty::BoundVariableKind<'tcx>>,
-    cx: &mut DocContext<'tcx>,
+    tcx: TyCtxt<'tcx>,
 ) -> Vec<GenericParamDef> {
     bound_vars
         .into_iter()
         .filter_map(|var| match var {
             ty::BoundVariableKind::Region(ty::BoundRegionKind::Named(def_id)) => {
-                let name = cx.tcx.item_name(def_id);
+                let name = tcx.item_name(def_id);
                 if name != kw::UnderscoreLifetime {
                     Some(GenericParamDef::lifetime(def_id, name))
                 } else {
@@ -3252,7 +3252,7 @@ fn clean_bound_vars<'tcx>(
                 }
             }
             ty::BoundVariableKind::Ty(ty::BoundTyKind::Param(def_id)) => {
-                let name = cx.tcx.item_name(def_id);
+                let name = tcx.item_name(def_id);
                 Some(GenericParamDef {
                     name,
                     def_id,

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -184,7 +184,7 @@ fn generate_item_with_correct_attrs(
     import_ids: &[LocalDefId],
     renamed: Option<Symbol>,
 ) -> Item {
-    let target_attrs = inline::load_attrs(cx, def_id);
+    let target_attrs = inline::load_attrs(cx.tcx, def_id);
     let attrs = if !import_ids.is_empty() {
         let mut attrs = Vec::with_capacity(import_ids.len());
         let mut is_inline = false;
@@ -196,7 +196,7 @@ fn generate_item_with_correct_attrs(
             // cfgs on the path up until the glob can be removed, and only cfgs on the globbed item
             // itself matter), for non-inlined re-exports see #85043.
             let import_is_inline = find_attr!(
-                inline::load_attrs(cx, import_id.to_def_id()),
+                inline::load_attrs(cx.tcx, import_id.to_def_id()),
                 Doc(d)
                 if d.inline.first().is_some_and(|(inline, _)| *inline == DocInline::Inline)
             ) || (is_glob_import(cx.tcx, import_id)
@@ -2663,7 +2663,7 @@ fn get_all_import_attributes<'hir>(
         .iter()
         .flat_map(|reexport| reexport.id())
     {
-        let import_attrs = inline::load_attrs(cx, def_id);
+        let import_attrs = inline::load_attrs(cx.tcx, def_id);
         if first {
             // This is the "original" reexport so we get all its attributes without filtering them.
             attrs = import_attrs.iter().map(|attr| (Cow::Borrowed(attr), Some(def_id))).collect();

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -394,7 +394,7 @@ pub(crate) fn clean_predicate<'tcx>(
     let bound_predicate = predicate.kind();
     match bound_predicate.skip_binder() {
         ty::ClauseKind::Trait(pred) => clean_poly_trait_predicate(bound_predicate.rebind(pred), cx),
-        ty::ClauseKind::RegionOutlives(pred) => Some(clean_region_outlives_predicate(pred, cx)),
+        ty::ClauseKind::RegionOutlives(pred) => Some(clean_region_outlives_predicate(pred, cx.tcx)),
         ty::ClauseKind::TypeOutlives(pred) => {
             Some(clean_type_outlives_predicate(bound_predicate.rebind(pred), cx))
         }
@@ -431,14 +431,14 @@ fn clean_poly_trait_predicate<'tcx>(
 
 fn clean_region_outlives_predicate<'tcx>(
     pred: ty::RegionOutlivesPredicate<'tcx>,
-    cx: &mut DocContext<'tcx>,
+    tcx: TyCtxt<'tcx>,
 ) -> WherePredicate {
     let ty::OutlivesPredicate(a, b) = pred;
 
     WherePredicate::RegionPredicate {
-        lifetime: clean_middle_region(a, cx.tcx).expect("failed to clean lifetime"),
+        lifetime: clean_middle_region(a, tcx).expect("failed to clean lifetime"),
         bounds: vec![GenericBound::Outlives(
-            clean_middle_region(b, cx.tcx).expect("failed to clean bounds"),
+            clean_middle_region(b, tcx).expect("failed to clean bounds"),
         )],
     }
 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -350,9 +350,9 @@ pub(crate) fn clean_middle_const<'tcx>(
 
 pub(crate) fn clean_middle_region<'tcx>(
     region: ty::Region<'tcx>,
-    cx: &mut DocContext<'tcx>,
+    tcx: TyCtxt<'tcx>,
 ) -> Option<Lifetime> {
-    region.get_name(cx.tcx).map(Lifetime)
+    region.get_name(tcx).map(Lifetime)
 }
 
 fn clean_where_predicate<'tcx>(
@@ -436,9 +436,9 @@ fn clean_region_outlives_predicate<'tcx>(
     let ty::OutlivesPredicate(a, b) = pred;
 
     WherePredicate::RegionPredicate {
-        lifetime: clean_middle_region(a, cx).expect("failed to clean lifetime"),
+        lifetime: clean_middle_region(a, cx.tcx).expect("failed to clean lifetime"),
         bounds: vec![GenericBound::Outlives(
-            clean_middle_region(b, cx).expect("failed to clean bounds"),
+            clean_middle_region(b, cx.tcx).expect("failed to clean bounds"),
         )],
     }
 }
@@ -452,7 +452,7 @@ fn clean_type_outlives_predicate<'tcx>(
     WherePredicate::BoundPredicate {
         ty: clean_middle_ty(pred.rebind(ty), cx, None, None),
         bounds: vec![GenericBound::Outlives(
-            clean_middle_region(lt, cx).expect("failed to clean lifetimes"),
+            clean_middle_region(lt, cx.tcx).expect("failed to clean lifetimes"),
         )],
         bound_params: Vec::new(),
     }
@@ -2067,7 +2067,7 @@ pub(crate) fn clean_middle_ty<'tcx>(
             RawPointer(mutbl, Box::new(clean_middle_ty(bound_ty.rebind(ty), cx, None, None)))
         }
         ty::Ref(r, ty, mutbl) => BorrowedRef {
-            lifetime: clean_middle_region(r, cx),
+            lifetime: clean_middle_region(r, cx.tcx),
             mutability: mutbl,
             type_: Box::new(clean_middle_ty(
                 bound_ty.rebind(ty),
@@ -2301,7 +2301,7 @@ fn clean_middle_opaque_bounds<'tcx>(
             let trait_ref = match bound_predicate.skip_binder() {
                 ty::ClauseKind::Trait(tr) => bound_predicate.rebind(tr.trait_ref),
                 ty::ClauseKind::TypeOutlives(ty::OutlivesPredicate(_ty, reg)) => {
-                    return clean_middle_region(reg, cx).map(GenericBound::Outlives);
+                    return clean_middle_region(reg, cx.tcx).map(GenericBound::Outlives);
                 }
                 _ => return None,
             };

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1830,7 +1830,7 @@ pub(crate) fn clean_ty<'tcx>(ty: &hir::Ty<'tcx>, cx: &mut DocContext<'tcx>) -> T
                     let ct = lower_const_arg_for_rustdoc(cx.tcx, const_arg, cx.tcx.types.usize);
                     let typing_env = ty::TypingEnv::post_analysis(cx.tcx, *def_id);
                     let ct = cx.tcx.normalize_erasing_regions(typing_env, ct);
-                    print_const(cx, ct)
+                    print_const(cx.tcx, ct)
                 }
                 hir::ConstArgKind::Struct(..)
                 | hir::ConstArgKind::Path(..)
@@ -1839,7 +1839,7 @@ pub(crate) fn clean_ty<'tcx>(ty: &hir::Ty<'tcx>, cx: &mut DocContext<'tcx>) -> T
                 | hir::ConstArgKind::Array(..)
                 | hir::ConstArgKind::Literal { .. } => {
                     let ct = lower_const_arg_for_rustdoc(cx.tcx, const_arg, cx.tcx.types.usize);
-                    print_const(cx, ct)
+                    print_const(cx.tcx, ct)
                 }
             };
             Array(Box::new(clean_ty(ty, cx)), length.into())
@@ -2059,7 +2059,7 @@ pub(crate) fn clean_middle_ty<'tcx>(
         ),
         ty::Array(ty, n) => {
             let n = cx.tcx.normalize_erasing_regions(cx.typing_env(), n);
-            let n = print_const(cx, n);
+            let n = print_const(cx.tcx, n);
             Array(Box::new(clean_middle_ty(bound_ty.rebind(ty), cx, None, None)), n.into())
         }
         ty::RawPtr(ty, mutbl) => {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2376,7 +2376,12 @@ fn clean_middle_opaque_bounds<'tcx>(
 }
 
 pub(crate) fn clean_field<'tcx>(field: &hir::FieldDef<'tcx>, cx: &mut DocContext<'tcx>) -> Item {
-    clean_field_with_def_id(field.def_id.to_def_id(), field.ident.name, clean_ty(field.ty, cx), cx)
+    clean_field_with_def_id(
+        field.def_id.to_def_id(),
+        field.ident.name,
+        clean_ty(field.ty, cx),
+        cx.tcx,
+    )
 }
 
 pub(crate) fn clean_middle_field(field: &ty::FieldDef, cx: &mut DocContext<'_>) -> Item {
@@ -2389,7 +2394,7 @@ pub(crate) fn clean_middle_field(field: &ty::FieldDef, cx: &mut DocContext<'_>) 
             Some(field.did),
             None,
         ),
-        cx,
+        cx.tcx,
     )
 }
 
@@ -2397,9 +2402,9 @@ pub(crate) fn clean_field_with_def_id(
     def_id: DefId,
     name: Symbol,
     ty: Type,
-    cx: &mut DocContext<'_>,
+    tcx: TyCtxt<'_>,
 ) -> Item {
-    Item::from_def_id_and_parts(def_id, Some(name), StructFieldItem(ty), cx.tcx)
+    Item::from_def_id_and_parts(def_id, Some(name), StructFieldItem(ty), tcx)
 }
 
 pub(crate) fn clean_variant_def(variant: &ty::VariantDef, cx: &mut DocContext<'_>) -> Item {
@@ -2463,7 +2468,7 @@ pub(crate) fn clean_variant_def_with_args<'tcx>(
                         field.did,
                         field.name,
                         clean_middle_ty(ty::Binder::dummy(ty), cx, Some(field.did), None),
-                        cx,
+                        cx.tcx,
                     )
                 })
                 .collect(),
@@ -2488,7 +2493,7 @@ pub(crate) fn clean_variant_def_with_args<'tcx>(
                         field.did,
                         field.name,
                         clean_middle_ty(ty::Binder::dummy(ty), cx, Some(field.did), None),
-                        cx,
+                        cx.tcx,
                     )
                 })
                 .collect(),

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -342,7 +342,6 @@ pub(crate) fn clean_const<'tcx>(constant: &hir::ConstArg<'tcx>) -> ConstantKind 
 
 pub(crate) fn clean_middle_const<'tcx>(
     constant: ty::Binder<'tcx, ty::Const<'tcx>>,
-    _cx: &mut DocContext<'tcx>,
 ) -> ConstantKind {
     // FIXME: instead of storing the stringified expression, store `self` directly instead.
     ConstantKind::TyConst { expr: constant.skip_binder().to_string().into() }
@@ -464,7 +463,7 @@ fn clean_middle_term<'tcx>(
 ) -> Term {
     match term.skip_binder().kind() {
         ty::TermKind::Ty(ty) => Term::Type(clean_middle_ty(term.rebind(ty), cx, None, None)),
-        ty::TermKind::Const(c) => Term::Constant(clean_middle_const(term.rebind(c), cx)),
+        ty::TermKind::Const(c) => Term::Constant(clean_middle_const(term.rebind(c))),
     }
 }
 
@@ -479,7 +478,7 @@ fn clean_hir_term<'tcx>(
             // FIXME(generic_const_items): this should instantiate with the alias item's args
             let ty = cx.tcx.type_of(assoc_item.unwrap()).instantiate_identity();
             let ct = lower_const_arg_for_rustdoc(cx.tcx, c, ty);
-            Term::Constant(clean_middle_const(ty::Binder::dummy(ct), cx))
+            Term::Constant(clean_middle_const(ty::Binder::dummy(ct)))
         }
     }
 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -925,7 +925,7 @@ fn clean_ty_generics_inner<'tcx>(
         if let Some(proj) = impl_trait_proj.remove(&idx) {
             for (trait_did, name, rhs) in proj {
                 let rhs = clean_middle_term(rhs, cx);
-                simplify::merge_bounds(cx, &mut bounds, trait_did, name, &rhs);
+                simplify::merge_bounds(cx.tcx, &mut bounds, trait_did, name, &rhs);
             }
         }
 
@@ -939,7 +939,7 @@ fn clean_ty_generics_inner<'tcx>(
 
     let mut generics = Generics { params, where_predicates };
     simplify::sized_bounds(cx, &mut generics);
-    generics.where_predicates = simplify::where_clauses(cx, generics.where_predicates);
+    generics.where_predicates = simplify::where_clauses(cx.tcx, generics.where_predicates);
     generics
 }
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -184,7 +184,8 @@ fn generate_item_with_correct_attrs(
     import_ids: &[LocalDefId],
     renamed: Option<Symbol>,
 ) -> Item {
-    let target_attrs = inline::load_attrs(cx.tcx, def_id);
+    let tcx = cx.tcx;
+    let target_attrs = inline::load_attrs(tcx, def_id);
     let attrs = if !import_ids.is_empty() {
         let mut attrs = Vec::with_capacity(import_ids.len());
         let mut is_inline = false;
@@ -196,11 +197,11 @@ fn generate_item_with_correct_attrs(
             // cfgs on the path up until the glob can be removed, and only cfgs on the globbed item
             // itself matter), for non-inlined re-exports see #85043.
             let import_is_inline = find_attr!(
-                inline::load_attrs(cx.tcx, import_id.to_def_id()),
+                inline::load_attrs(tcx, import_id.to_def_id()),
                 Doc(d)
                 if d.inline.first().is_some_and(|(inline, _)| *inline == DocInline::Inline)
-            ) || (is_glob_import(cx.tcx, import_id)
-                && (cx.document_hidden() || !cx.tcx.is_doc_hidden(def_id)));
+            ) || (is_glob_import(tcx, import_id)
+                && (cx.document_hidden() || !tcx.is_doc_hidden(def_id)));
             attrs.extend(get_all_import_attributes(cx, import_id, def_id, is_inline));
             is_inline = is_inline || import_is_inline;
         }
@@ -1458,7 +1459,7 @@ pub(crate) fn clean_middle_assoc_item(assoc_item: &ty::AssocItem, cx: &mut DocCo
                 bounds.retain(|b| {
                     // FIXME(sized-hierarchy): Always skip `MetaSized` bounds so that only `?Sized`
                     // is shown and none of the new sizedness traits leak into documentation.
-                    !b.is_meta_sized_bound(cx.tcx)
+                    !b.is_meta_sized_bound(tcx)
                 });
 
                 // Our Sized/?Sized bound didn't get handled when creating the generics
@@ -1466,7 +1467,7 @@ pub(crate) fn clean_middle_assoc_item(assoc_item: &ty::AssocItem, cx: &mut DocCo
                 // (some of them may have come from the trait). If we do have a sized
                 // bound, we remove it, and if we don't then we add the `?Sized` bound
                 // at the end.
-                match bounds.iter().position(|b| b.is_sized_bound(cx.tcx)) {
+                match bounds.iter().position(|b| b.is_sized_bound(tcx)) {
                     Some(i) => {
                         bounds.remove(i);
                     }
@@ -1516,7 +1517,7 @@ pub(crate) fn clean_middle_assoc_item(assoc_item: &ty::AssocItem, cx: &mut DocCo
         }
     };
 
-    Item::from_def_id_and_parts(assoc_item.def_id, Some(assoc_item.name()), kind, cx.tcx)
+    Item::from_def_id_and_parts(assoc_item.def_id, Some(assoc_item.name()), kind, tcx)
 }
 
 fn first_non_private_clean_path<'tcx>(
@@ -2767,12 +2768,8 @@ fn clean_maybe_renamed_item<'tcx>(
     import_ids: &[LocalDefId],
 ) -> Vec<Item> {
     use hir::ItemKind;
-    fn get_name(
-        cx: &DocContext<'_>,
-        item: &hir::Item<'_>,
-        renamed: Option<Symbol>,
-    ) -> Option<Symbol> {
-        renamed.or_else(|| cx.tcx.hir_opt_name(item.hir_id()))
+    fn get_name(tcx: TyCtxt<'_>, item: &hir::Item<'_>, renamed: Option<Symbol>) -> Option<Symbol> {
+        renamed.or_else(|| tcx.hir_opt_name(item.hir_id()))
     }
 
     let def_id = item.owner_id.to_def_id();
@@ -2789,7 +2786,7 @@ fn clean_maybe_renamed_item<'tcx>(
             ItemKind::Use(path, kind) => {
                 return clean_use_statement(
                     item,
-                    get_name(cx, item, renamed),
+                    get_name(cx.tcx, item, renamed),
                     path,
                     kind,
                     cx,
@@ -2799,7 +2796,7 @@ fn clean_maybe_renamed_item<'tcx>(
             _ => {}
         }
 
-        let mut name = get_name(cx, item, renamed).unwrap();
+        let mut name = get_name(cx.tcx, item, renamed).unwrap();
 
         let kind = match item.kind {
             ItemKind::Static(mutability, _, ty, body_id) => StaticItem(Static {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -898,10 +898,10 @@ fn clean_ty_generics_inner<'tcx>(
     for (idx, mut bounds) in impl_trait {
         let mut has_sized = false;
         bounds.retain(|b| {
-            if b.is_sized_bound(cx) {
+            if b.is_sized_bound(cx.tcx) {
                 has_sized = true;
                 false
-            } else if b.is_meta_sized_bound(cx) {
+            } else if b.is_meta_sized_bound(cx.tcx) {
                 // FIXME(sized-hierarchy): Always skip `MetaSized` bounds so that only `?Sized`
                 // is shown and none of the new sizedness traits leak into documentation.
                 false
@@ -1459,7 +1459,7 @@ pub(crate) fn clean_middle_assoc_item(assoc_item: &ty::AssocItem, cx: &mut DocCo
                 bounds.retain(|b| {
                     // FIXME(sized-hierarchy): Always skip `MetaSized` bounds so that only `?Sized`
                     // is shown and none of the new sizedness traits leak into documentation.
-                    !b.is_meta_sized_bound(cx)
+                    !b.is_meta_sized_bound(cx.tcx)
                 });
 
                 // Our Sized/?Sized bound didn't get handled when creating the generics
@@ -1467,7 +1467,7 @@ pub(crate) fn clean_middle_assoc_item(assoc_item: &ty::AssocItem, cx: &mut DocCo
                 // (some of them may have come from the trait). If we do have a sized
                 // bound, we remove it, and if we don't then we add the `?Sized` bound
                 // at the end.
-                match bounds.iter().position(|b| b.is_sized_bound(cx)) {
+                match bounds.iter().position(|b| b.is_sized_bound(cx.tcx)) {
                     Some(i) => {
                         bounds.remove(i);
                     }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2861,7 +2861,7 @@ fn clean_maybe_renamed_item<'tcx>(
             // FIXME: handle attributes and derives that aren't proc macros, and macros with
             // multiple kinds
             ItemKind::Macro(_, macro_def, MacroKinds::BANG) => MacroItem(Macro {
-                source: display_macro_source(cx, name, macro_def),
+                source: display_macro_source(cx.tcx, name, macro_def),
                 macro_rules: macro_def.macro_rules,
             }),
             ItemKind::Macro(_, _, MacroKinds::ATTR) => {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1248,7 +1248,7 @@ fn clean_trait_item<'tcx>(trait_item: &hir::TraitItem<'tcx>, cx: &mut DocContext
                 RequiredAssocTypeItem(generics, bounds)
             }
         };
-        Item::from_def_id_and_parts(local_did, Some(trait_item.ident.name), inner, cx)
+        Item::from_def_id_and_parts(local_did, Some(trait_item.ident.name), inner, cx.tcx)
     })
 }
 
@@ -1289,7 +1289,7 @@ pub(crate) fn clean_impl_item<'tcx>(
             }
         };
 
-        Item::from_def_id_and_parts(local_did, Some(impl_.ident.name), inner, cx)
+        Item::from_def_id_and_parts(local_did, Some(impl_.ident.name), inner, cx.tcx)
     })
 }
 
@@ -1517,7 +1517,7 @@ pub(crate) fn clean_middle_assoc_item(assoc_item: &ty::AssocItem, cx: &mut DocCo
         }
     };
 
-    Item::from_def_id_and_parts(assoc_item.def_id, Some(assoc_item.name()), kind, cx)
+    Item::from_def_id_and_parts(assoc_item.def_id, Some(assoc_item.name()), kind, cx.tcx)
 }
 
 fn first_non_private_clean_path<'tcx>(
@@ -2399,7 +2399,7 @@ pub(crate) fn clean_field_with_def_id(
     ty: Type,
     cx: &mut DocContext<'_>,
 ) -> Item {
-    Item::from_def_id_and_parts(def_id, Some(name), StructFieldItem(ty), cx)
+    Item::from_def_id_and_parts(def_id, Some(name), StructFieldItem(ty), cx.tcx)
 }
 
 pub(crate) fn clean_variant_def(variant: &ty::VariantDef, cx: &mut DocContext<'_>) -> Item {
@@ -2422,7 +2422,7 @@ pub(crate) fn clean_variant_def(variant: &ty::VariantDef, cx: &mut DocContext<'_
         variant.def_id,
         Some(variant.name),
         VariantItem(Variant { kind, discriminant }),
-        cx,
+        cx.tcx,
     )
 }
 
@@ -2499,7 +2499,7 @@ pub(crate) fn clean_variant_def_with_args<'tcx>(
         variant.def_id,
         Some(variant.name),
         VariantItem(Variant { kind, discriminant }),
-        cx,
+        cx.tcx,
     )
 }
 
@@ -2907,7 +2907,7 @@ fn clean_maybe_renamed_item<'tcx>(
 
 fn clean_variant<'tcx>(variant: &hir::Variant<'tcx>, cx: &mut DocContext<'tcx>) -> Item {
     let kind = VariantItem(clean_variant_data(&variant.data, &variant.disr_expr, cx));
-    Item::from_def_id_and_parts(variant.def_id.to_def_id(), Some(variant.ident.name), kind, cx)
+    Item::from_def_id_and_parts(variant.def_id.to_def_id(), Some(variant.ident.name), kind, cx.tcx)
 }
 
 fn clean_impl<'tcx>(
@@ -2928,7 +2928,7 @@ fn clean_impl<'tcx>(
                     def_id.to_def_id(),
                     None,
                     PlaceholderImplItem,
-                    cx,
+                    tcx,
                 )];
             }
             Some(clean_trait_ref(&t.trait_ref, cx))
@@ -2983,7 +2983,7 @@ fn clean_impl<'tcx>(
             },
             is_deprecated,
         }));
-        Item::from_def_id_and_parts(def_id.to_def_id(), None, kind, cx)
+        Item::from_def_id_and_parts(def_id.to_def_id(), None, kind, tcx)
     };
     if let Some(type_alias) = type_alias {
         ret.push(make_item(trait_.clone(), type_alias, items.clone()));
@@ -3031,7 +3031,7 @@ fn clean_extern_crate<'tcx>(
         krate_owner_def_id.to_def_id(),
         Some(name),
         ExternCrateItem { src: orig_name },
-        cx,
+        cx.tcx,
     )]
 }
 
@@ -3160,14 +3160,14 @@ fn clean_use_statement_inner<'tcx>(
                 import_def_id.to_def_id(),
                 None,
                 ImportItem(Import::new_simple(name, resolve_use_source(cx, path), false)),
-                cx,
+                cx.tcx,
             ));
             return items;
         }
         Import::new_simple(name, resolve_use_source(cx, path), true)
     };
 
-    vec![Item::from_def_id_and_parts(import_def_id.to_def_id(), None, ImportItem(inner), cx)]
+    vec![Item::from_def_id_and_parts(import_def_id.to_def_id(), None, ImportItem(inner), cx.tcx)]
 }
 
 fn clean_maybe_renamed_foreign_item<'tcx>(

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1001,12 +1001,12 @@ fn clean_proc_macro<'tcx>(
     item: &hir::Item<'tcx>,
     name: &mut Symbol,
     kind: MacroKind,
-    cx: &mut DocContext<'tcx>,
+    tcx: TyCtxt<'tcx>,
 ) -> ItemKind {
     if kind != MacroKind::Derive {
         return ProcMacroItem(ProcMacro { kind, helpers: vec![] });
     }
-    let attrs = cx.tcx.hir_attrs(item.hir_id());
+    let attrs = tcx.hir_attrs(item.hir_id());
     let Some((trait_name, helper_attrs)) = find_attr!(attrs, ProcMacroDerive { trait_name, helper_attrs, ..} => (*trait_name, helper_attrs))
     else {
         return ProcMacroItem(ProcMacro { kind, helpers: vec![] });
@@ -1037,7 +1037,7 @@ fn clean_fn_or_proc_macro<'tcx>(
     };
 
     match macro_kind {
-        Some(kind) => clean_proc_macro(item, name, kind, cx),
+        Some(kind) => clean_proc_macro(item, name, kind, cx.tcx),
         None => {
             let mut func = clean_function(cx, sig, generics, ParamsSrc::Body(body_id));
             clean_fn_decl_legacy_const_generics(&mut func, attrs);
@@ -2865,10 +2865,10 @@ fn clean_maybe_renamed_item<'tcx>(
                 macro_rules: macro_def.macro_rules,
             }),
             ItemKind::Macro(_, _, MacroKinds::ATTR) => {
-                clean_proc_macro(item, &mut name, MacroKind::Attr, cx)
+                clean_proc_macro(item, &mut name, MacroKind::Attr, cx.tcx)
             }
             ItemKind::Macro(_, _, MacroKinds::DERIVE) => {
-                clean_proc_macro(item, &mut name, MacroKind::Derive, cx)
+                clean_proc_macro(item, &mut name, MacroKind::Derive, cx.tcx)
             }
             ItemKind::Macro(_, _, _) => todo!("Handle macros with multiple kinds"),
             // proc macros can have a name set by attributes

--- a/src/librustdoc/clean/simplify.rs
+++ b/src/librustdoc/clean/simplify.rs
@@ -15,12 +15,13 @@ use rustc_data_structures::fx::FxIndexMap;
 use rustc_data_structures::thin_vec::ThinVec;
 use rustc_data_structures::unord::UnordSet;
 use rustc_hir::def_id::DefId;
+use rustc_middle::ty::TyCtxt;
 
 use crate::clean;
 use crate::clean::{GenericArgs as PP, WherePredicate as WP};
 use crate::core::DocContext;
 
-pub(crate) fn where_clauses(cx: &DocContext<'_>, clauses: ThinVec<WP>) -> ThinVec<WP> {
+pub(crate) fn where_clauses(tcx: TyCtxt<'_>, clauses: ThinVec<WP>) -> ThinVec<WP> {
     // First, partition the where clause into its separate components.
     //
     // We use `FxIndexMap` so that the insertion order is preserved to prevent messing up to
@@ -47,7 +48,7 @@ pub(crate) fn where_clauses(cx: &DocContext<'_>, clauses: ThinVec<WP>) -> ThinVe
     // general bound predicates.
     equalities.retain(|(lhs, rhs)| {
         let Some((bounds, _)) = tybounds.get_mut(&lhs.self_type) else { return true };
-        merge_bounds(cx, bounds, lhs.trait_.as_ref().unwrap().def_id(), lhs.assoc.clone(), rhs)
+        merge_bounds(tcx, bounds, lhs.trait_.as_ref().unwrap().def_id(), lhs.assoc.clone(), rhs)
     });
 
     // And finally, let's reassemble everything
@@ -65,7 +66,7 @@ pub(crate) fn where_clauses(cx: &DocContext<'_>, clauses: ThinVec<WP>) -> ThinVe
 }
 
 pub(crate) fn merge_bounds(
-    cx: &clean::DocContext<'_>,
+    tcx: TyCtxt<'_>,
     bounds: &mut [clean::GenericBound],
     trait_did: DefId,
     assoc: clean::PathSegment,
@@ -79,7 +80,7 @@ pub(crate) fn merge_bounds(
         // If this QPath's trait `trait_did` is the same as, or a supertrait
         // of, the bound's trait `did` then we can keep going, otherwise
         // this is just a plain old equality bound.
-        if !trait_is_same_or_supertrait(cx, trait_ref.trait_.def_id(), trait_did) {
+        if !trait_is_same_or_supertrait(tcx, trait_ref.trait_.def_id(), trait_did) {
             return false;
         }
         let last = trait_ref.trait_.segments.last_mut().expect("segments were empty");
@@ -108,15 +109,15 @@ pub(crate) fn merge_bounds(
     })
 }
 
-fn trait_is_same_or_supertrait(cx: &DocContext<'_>, child: DefId, trait_: DefId) -> bool {
+fn trait_is_same_or_supertrait(tcx: TyCtxt<'_>, child: DefId, trait_: DefId) -> bool {
     if child == trait_ {
         return true;
     }
-    let predicates = cx.tcx.explicit_super_predicates_of(child);
+    let predicates = tcx.explicit_super_predicates_of(child);
     predicates
         .iter_identity_copied()
         .filter_map(|(pred, _)| Some(pred.as_trait_clause()?.def_id()))
-        .any(|did| trait_is_same_or_supertrait(cx, did, trait_))
+        .any(|did| trait_is_same_or_supertrait(tcx, did, trait_))
 }
 
 pub(crate) fn sized_bounds(cx: &mut DocContext<'_>, generics: &mut clean::Generics) {

--- a/src/librustdoc/clean/simplify.rs
+++ b/src/librustdoc/clean/simplify.rs
@@ -139,10 +139,10 @@ pub(crate) fn sized_bounds(cx: &mut DocContext<'_>, generics: &mut clean::Generi
             return true;
         };
 
-        if bounds.iter().any(|b| b.is_sized_bound(cx)) {
+        if bounds.iter().any(|b| b.is_sized_bound(cx.tcx)) {
             sized_params.insert(*param);
             false
-        } else if bounds.iter().any(|b| b.is_meta_sized_bound(cx)) {
+        } else if bounds.iter().any(|b| b.is_meta_sized_bound(cx.tcx)) {
             // FIXME(sized-hierarchy): Always skip `MetaSized` bounds so that only `?Sized`
             // is shown and none of the new sizedness traits leak into documentation.
             false

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1119,20 +1119,20 @@ impl GenericBound {
         matches!(self, Self::TraitBound(..))
     }
 
-    pub(crate) fn is_sized_bound(&self, cx: &DocContext<'_>) -> bool {
-        self.is_bounded_by_lang_item(cx, LangItem::Sized)
+    pub(crate) fn is_sized_bound(&self, tcx: TyCtxt<'_>) -> bool {
+        self.is_bounded_by_lang_item(tcx, LangItem::Sized)
     }
 
-    pub(crate) fn is_meta_sized_bound(&self, cx: &DocContext<'_>) -> bool {
-        self.is_bounded_by_lang_item(cx, LangItem::MetaSized)
+    pub(crate) fn is_meta_sized_bound(&self, tcx: TyCtxt<'_>) -> bool {
+        self.is_bounded_by_lang_item(tcx, LangItem::MetaSized)
     }
 
-    fn is_bounded_by_lang_item(&self, cx: &DocContext<'_>, lang_item: LangItem) -> bool {
+    fn is_bounded_by_lang_item(&self, tcx: TyCtxt<'_>, lang_item: LangItem) -> bool {
         if let GenericBound::TraitBound(
             PolyTrait { ref trait_, .. },
             rustc_hir::TraitBoundModifiers::NONE,
         ) = *self
-            && cx.tcx.is_lang_item(trait_.def_id(), lang_item)
+            && tcx.is_lang_item(trait_.def_id(), lang_item)
         {
             return true;
         }

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -514,10 +514,10 @@ impl Item {
         def_id: DefId,
         name: Option<Symbol>,
         kind: ItemKind,
-        cx: &mut DocContext<'_>,
+        tcx: TyCtxt<'_>,
     ) -> Item {
         #[allow(deprecated)]
-        let hir_attrs = cx.tcx.get_all_attrs(def_id);
+        let hir_attrs = tcx.get_all_attrs(def_id);
 
         Self::from_def_id_and_attrs_and_parts(
             def_id,

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -347,13 +347,13 @@ pub(crate) fn name_from_pat(p: &hir::Pat<'_>) -> Symbol {
     })
 }
 
-pub(crate) fn print_const(cx: &DocContext<'_>, n: ty::Const<'_>) -> String {
+pub(crate) fn print_const(tcx: TyCtxt<'_>, n: ty::Const<'_>) -> String {
     match n.kind() {
         ty::ConstKind::Unevaluated(ty::UnevaluatedConst { def, args: _ }) => {
             if let Some(def) = def.as_local() {
-                rendered_const(cx.tcx, cx.tcx.hir_body_owned_by(def), def)
+                rendered_const(tcx, tcx.hir_body_owned_by(def), def)
             } else {
-                inline::print_inlined_const(cx.tcx, def)
+                inline::print_inlined_const(tcx, def)
             }
         }
         // array lengths are obviously usize

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -602,26 +602,21 @@ fn render_macro_arms<'a>(
     out
 }
 
-pub(super) fn display_macro_source(
-    cx: &mut DocContext<'_>,
-    name: Symbol,
-    def: &ast::MacroDef,
-) -> String {
+pub(super) fn display_macro_source(tcx: TyCtxt<'_>, name: Symbol, def: &ast::MacroDef) -> String {
     // Extract the spans of all matchers. They represent the "interface" of the macro.
     let matchers = def.body.tokens.chunks(4).map(|arm| &arm[0]);
 
     if def.macro_rules {
-        format!("macro_rules! {name} {{\n{arms}}}", arms = render_macro_arms(cx.tcx, matchers, ";"))
+        format!("macro_rules! {name} {{\n{arms}}}", arms = render_macro_arms(tcx, matchers, ";"))
     } else {
         if matchers.len() <= 1 {
             format!(
                 "macro {name}{matchers} {{\n    ...\n}}",
-                matchers = matchers
-                    .map(|matcher| render_macro_matcher(cx.tcx, matcher))
-                    .collect::<String>(),
+                matchers =
+                    matchers.map(|matcher| render_macro_matcher(tcx, matcher)).collect::<String>(),
             )
         } else {
-            format!("macro {name} {{\n{arms}}}", arms = render_macro_arms(cx.tcx, matchers, ","))
+            format!("macro {name} {{\n{arms}}}", arms = render_macro_arms(tcx, matchers, ","))
         }
     }
 }

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -135,7 +135,7 @@ pub(crate) fn clean_middle_generic_args<'tcx>(
 
         match arg.skip_binder().kind() {
             GenericArgKind::Lifetime(lt) => Some(GenericArg::Lifetime(
-                clean_middle_region(lt, cx).unwrap_or(Lifetime::elided()),
+                clean_middle_region(lt, cx.tcx).unwrap_or(Lifetime::elided()),
             )),
             GenericArgKind::Type(ty) => Some(GenericArg::Type(clean_middle_ty(
                 arg.rebind(ty),

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -148,7 +148,7 @@ pub(crate) fn clean_middle_generic_args<'tcx>(
                 }),
             ))),
             GenericArgKind::Const(ct) => {
-                Some(GenericArg::Const(Box::new(clean_middle_const(arg.rebind(ct), cx))))
+                Some(GenericArg::Const(Box::new(clean_middle_const(arg.rebind(ct)))))
             }
         }
     };

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -72,14 +72,14 @@ pub(crate) fn krate(cx: &mut DocContext<'_>) -> Crate {
                 def_id,
                 Some(prim.as_sym()),
                 ItemKind::PrimitiveItem(prim),
-                cx,
+                cx.tcx,
             )
         }));
         m.items.extend(keywords.map(|(def_id, kw)| {
-            Item::from_def_id_and_parts(def_id, Some(kw), ItemKind::KeywordItem, cx)
+            Item::from_def_id_and_parts(def_id, Some(kw), ItemKind::KeywordItem, cx.tcx)
         }));
         m.items.extend(documented_attributes.into_iter().map(|(def_id, kw)| {
-            Item::from_def_id_and_parts(def_id, Some(kw), ItemKind::AttributeItem, cx)
+            Item::from_def_id_and_parts(def_id, Some(kw), ItemKind::AttributeItem, cx.tcx)
         }));
     }
 

--- a/src/librustdoc/passes/propagate_doc_cfg.rs
+++ b/src/librustdoc/passes/propagate_doc_cfg.rs
@@ -71,7 +71,7 @@ impl CfgPropagator<'_, '_> {
         }
 
         let (_, cfg) = merge_attrs(
-            self.cx,
+            self.cx.tcx,
             item.attrs.other_attrs.as_slice(),
             Some((&attrs, None)),
             &mut self.cfg_info,

--- a/src/librustdoc/passes/propagate_doc_cfg.rs
+++ b/src/librustdoc/passes/propagate_doc_cfg.rs
@@ -64,7 +64,7 @@ impl CfgPropagator<'_, '_> {
             && let Some(mut next_def_id) = item.item_id.as_local_def_id()
         {
             while let Some(parent_def_id) = self.cx.tcx.opt_local_parent(next_def_id) {
-                let x = load_attrs(self.cx, parent_def_id.to_def_id());
+                let x = load_attrs(self.cx.tcx, parent_def_id.to_def_id());
                 add_only_cfg_attributes(&mut attrs, x);
                 next_def_id = parent_def_id;
             }


### PR DESCRIPTION
In a lot of places, we pass down `DocContext` but actually only use its `tcx` field (`TyCtxt`). To make it more obvious what's actually being done, I replaced `DocContext` with `TyCtxt` (which implements `Copy`) in the function arguments. It created quite the cascade effect so I ended up with a lot more changes I expected.

Because it's a lot of changes, I made small commits which are easy to go through, so I strongly recommend reviewing this PR one commit at a time.

r? @Urgau 