### PR TITLE
Suppress misleading binding suggestion for multi-segment const patterns

### DIFF
--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -1648,65 +1648,86 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             && e.suggestions.len() == 0
         {
             e.span_label(span, format!("{} defined here", res.descr()));
-            e.span_label(
-                pat_span,
-                format!(
-                    "`{}` is interpreted as {} {}, not a new binding",
-                    ident,
-                    res.article(),
-                    res.descr(),
-                ),
-            );
-            match self.tcx.parent_hir_node(hir_id) {
-                hir::Node::PatField(..) => {
-                    e.span_suggestion_verbose(
-                        ident.span.shrink_to_hi(),
-                        "bind the struct field to a different name instead",
-                        format!(": other_{}", ident.as_str().to_lowercase()),
-                        Applicability::HasPlaceholders,
-                    );
-                }
-                _ => {
-                    let (type_def_id, item_def_id) = match resolved_pat.ty.kind() {
-                        ty::Adt(def, _) => match res {
-                            Res::Def(DefKind::Const { .. }, def_id) => {
-                                (Some(def.did()), Some(def_id))
-                            }
-                            _ => (None, None),
-                        },
-                        _ => (None, None),
-                    };
 
-                    let is_range = matches!(
-                        type_def_id.and_then(|id| self.tcx.as_lang_item(id)),
-                        Some(
-                            LangItem::Range
-                                | LangItem::RangeFrom
-                                | LangItem::RangeTo
-                                | LangItem::RangeFull
-                                | LangItem::RangeInclusiveStruct
-                                | LangItem::RangeToInclusive,
-                        )
-                    );
-                    if is_range {
-                        if !self.maybe_suggest_range_literal(&mut e, item_def_id, *ident) {
-                            let msg = "constants only support matching by type, \
-                                if you meant to match against a range of values, \
-                                consider using a range pattern like `min ..= max` in the match block";
-                            e.note(msg);
-                        }
-                    } else {
-                        let msg = "introduce a new binding instead";
-                        let sugg = format!("other_{}", ident.as_str().to_lowercase());
+            // Check if the path as written in source is multi-segment (e.g., `Owner::K`).
+            // For `QPath::TypeRelative`, the `segments` only contains the final segment,
+            // so the single-segment check above passes even though the source path is
+            // multi-segment. In that case, the "interpreted as constant, not a new
+            // binding" label and the "introduce a new binding" suggestion are misleading
+            // since a multi-segment path is never a binding pattern.
+            let is_multi_segment_path = if let hir::Node::Pat(pat) = self.tcx.hir_node(hir_id)
+                && let PatKind::Expr(PatExpr { kind: PatExprKind::Path(qpath), .. }) = pat.kind
+            {
+                matches!(qpath, hir::QPath::TypeRelative(..))
+                    || matches!(
+                        qpath,
+                        hir::QPath::Resolved(_, path) if path.segments.len() > 1
+                    )
+            } else {
+                false
+            };
+
+            if !is_multi_segment_path {
+                e.span_label(
+                    pat_span,
+                    format!(
+                        "`{}` is interpreted as {} {}, not a new binding",
+                        ident,
+                        res.article(),
+                        res.descr(),
+                    ),
+                );
+                match self.tcx.parent_hir_node(hir_id) {
+                    hir::Node::PatField(..) => {
                         e.span_suggestion_verbose(
-                            ident.span,
-                            msg,
-                            sugg,
+                            ident.span.shrink_to_hi(),
+                            "bind the struct field to a different name instead",
+                            format!(": other_{}", ident.as_str().to_lowercase()),
                             Applicability::HasPlaceholders,
                         );
                     }
-                }
-            };
+                    _ => {
+                        let (type_def_id, item_def_id) = match resolved_pat.ty.kind() {
+                            ty::Adt(def, _) => match res {
+                                Res::Def(DefKind::Const { .. }, def_id) => {
+                                    (Some(def.did()), Some(def_id))
+                                }
+                                _ => (None, None),
+                            },
+                            _ => (None, None),
+                        };
+
+                        let is_range = matches!(
+                            type_def_id.and_then(|id| self.tcx.as_lang_item(id)),
+                            Some(
+                                LangItem::Range
+                                    | LangItem::RangeFrom
+                                    | LangItem::RangeTo
+                                    | LangItem::RangeFull
+                                    | LangItem::RangeInclusiveStruct
+                                    | LangItem::RangeToInclusive,
+                            )
+                        );
+                        if is_range {
+                            if !self.maybe_suggest_range_literal(&mut e, item_def_id, *ident) {
+                                let msg = "constants only support matching by type, \
+                                    if you meant to match against a range of values, \
+                                    consider using a range pattern like `min ..= max` in the match block";
+                                e.note(msg);
+                            }
+                        } else {
+                            let msg = "introduce a new binding instead";
+                            let sugg = format!("other_{}", ident.as_str().to_lowercase());
+                            e.span_suggestion_verbose(
+                                ident.span,
+                                msg,
+                                sugg,
+                                Applicability::HasPlaceholders,
+                            );
+                        }
+                    }
+                };
+            }
         }
         e.emit();
     }

--- a/tests/ui/match/assoc-const-type-mismatch-no-binding-suggestion.rs
+++ b/tests/ui/match/assoc-const-type-mismatch-no-binding-suggestion.rs
@@ -44,6 +44,19 @@ fn via_ufcs(source: i32) {
     }
 }
 
+// Module-qualified free constant: multi-segment Resolved path, no binding label or suggestion.
+mod inner {
+    pub const C: (i32, i32) = (4, 2);
+}
+
+fn via_module_const(source: i32) {
+    match source {
+        inner::C => {}
+        //~^ ERROR mismatched types
+        _ => {}
+    }
+}
+
 // Free constant with single-segment path: should keep the label and suggestion.
 const FREE: (i32, i32) = (4, 2);
 

--- a/tests/ui/match/assoc-const-type-mismatch-no-binding-suggestion.rs
+++ b/tests/ui/match/assoc-const-type-mismatch-no-binding-suggestion.rs
@@ -1,0 +1,71 @@
+//! Multi-segment associated constant paths in patterns (e.g. `Owner::K`) should
+//! not get the misleading "interpreted as constant, not a new binding" label or
+//! the "introduce a new binding instead" suggestion, since a multi-segment path
+//! can never be a binding pattern.
+//!
+//! Single-segment paths that resolve to associated constants (e.g. via
+//! `use Trait::K`) should still get both the label and the suggestion.
+//!
+//! Regression test for <https://github.com/rust-lang/rust/issues/153926>.
+
+//@ dont-require-annotations: NOTE
+
+#![feature(import_trait_associated_functions)]
+
+struct Owner;
+
+impl Owner {
+    const K: (i32, i32) = (4, 2);
+}
+
+// Multi-segment assoc const path: no binding label or suggestion.
+fn via_assoc_const(source: i32) {
+    match source {
+        Owner::K => {}
+        //~^ ERROR mismatched types
+        _ => {}
+    }
+}
+
+trait Trait {
+    const J: (i32, i32);
+}
+
+impl Trait for Owner {
+    const J: (i32, i32) = (4, 2);
+}
+
+// Fully-qualified UFCS syntax: also multi-segment, no binding label or suggestion.
+fn via_ufcs(source: i32) {
+    match source {
+        <Owner as Trait>::J => {}
+        //~^ ERROR mismatched types
+        _ => {}
+    }
+}
+
+// Free constant with single-segment path: should keep the label and suggestion.
+const FREE: (i32, i32) = (4, 2);
+
+fn via_free_const(source: i32) {
+    match source {
+        FREE => {}
+        //~^ ERROR mismatched types
+        //~| NOTE `FREE` is interpreted as a constant, not a new binding
+        _ => {}
+    }
+}
+
+// Single-segment assoc const imported via `use Trait::J`: should keep the diagnostics.
+use Trait::J;
+
+fn via_imported_assoc_const(source: i32) {
+    match source {
+        J => {}
+        //~^ ERROR mismatched types
+        //~| NOTE `J` is interpreted as an associated constant, not a new binding
+        _ => {}
+    }
+}
+
+fn main() {}

--- a/tests/ui/match/assoc-const-type-mismatch-no-binding-suggestion.stderr
+++ b/tests/ui/match/assoc-const-type-mismatch-no-binding-suggestion.stderr
@@ -24,7 +24,18 @@ LL |         <Owner as Trait>::J => {}
              found tuple `(i32, i32)`
 
 error[E0308]: mismatched types
-  --> $DIR/assoc-const-type-mismatch-no-binding-suggestion.rs:52:9
+  --> $DIR/assoc-const-type-mismatch-no-binding-suggestion.rs:54:9
+   |
+LL |     match source {
+   |           ------ this expression has type `i32`
+LL |         inner::C => {}
+   |         ^^^^^^^^ expected `i32`, found `(i32, i32)`
+   |
+   = note: expected type `i32`
+             found tuple `(i32, i32)`
+
+error[E0308]: mismatched types
+  --> $DIR/assoc-const-type-mismatch-no-binding-suggestion.rs:65:9
    |
 LL | const FREE: (i32, i32) = (4, 2);
    | ---------------------- constant defined here
@@ -46,7 +57,7 @@ LL +         other_free => {}
    |
 
 error[E0308]: mismatched types
-  --> $DIR/assoc-const-type-mismatch-no-binding-suggestion.rs:64:9
+  --> $DIR/assoc-const-type-mismatch-no-binding-suggestion.rs:77:9
    |
 LL |     const J: (i32, i32);
    |     ------------------- associated constant defined here
@@ -67,6 +78,6 @@ LL -         J => {}
 LL +         other_j => {}
    |
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/match/assoc-const-type-mismatch-no-binding-suggestion.stderr
+++ b/tests/ui/match/assoc-const-type-mismatch-no-binding-suggestion.stderr
@@ -1,0 +1,72 @@
+error[E0308]: mismatched types
+  --> $DIR/assoc-const-type-mismatch-no-binding-suggestion.rs:24:9
+   |
+LL |     const K: (i32, i32) = (4, 2);
+   |     ------------------- associated constant defined here
+...
+LL |     match source {
+   |           ------ this expression has type `i32`
+LL |         Owner::K => {}
+   |         ^^^^^^^^ expected `i32`, found `(i32, i32)`
+   |
+   = note: expected type `i32`
+             found tuple `(i32, i32)`
+
+error[E0308]: mismatched types
+  --> $DIR/assoc-const-type-mismatch-no-binding-suggestion.rs:41:9
+   |
+LL |     match source {
+   |           ------ this expression has type `i32`
+LL |         <Owner as Trait>::J => {}
+   |         ^^^^^^^^^^^^^^^^^^^ expected `i32`, found `(i32, i32)`
+   |
+   = note: expected type `i32`
+             found tuple `(i32, i32)`
+
+error[E0308]: mismatched types
+  --> $DIR/assoc-const-type-mismatch-no-binding-suggestion.rs:52:9
+   |
+LL | const FREE: (i32, i32) = (4, 2);
+   | ---------------------- constant defined here
+...
+LL |     match source {
+   |           ------ this expression has type `i32`
+LL |         FREE => {}
+   |         ^^^^
+   |         |
+   |         expected `i32`, found `(i32, i32)`
+   |         `FREE` is interpreted as a constant, not a new binding
+   |
+   = note: expected type `i32`
+             found tuple `(i32, i32)`
+help: introduce a new binding instead
+   |
+LL -         FREE => {}
+LL +         other_free => {}
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/assoc-const-type-mismatch-no-binding-suggestion.rs:64:9
+   |
+LL |     const J: (i32, i32);
+   |     ------------------- associated constant defined here
+...
+LL |     match source {
+   |           ------ this expression has type `i32`
+LL |         J => {}
+   |         ^
+   |         |
+   |         expected `i32`, found `(i32, i32)`
+   |         `J` is interpreted as an associated constant, not a new binding
+   |
+   = note: expected type `i32`
+             found tuple `(i32, i32)`
+help: introduce a new binding instead
+   |
+LL -         J => {}
+LL +         other_j => {}
+   |
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
When a multi-segment path like `Owner::K` appears in a pattern with a type mismatch, the compiler says it's "interpreted as a constant, not a new binding" and suggests `Owner::other_k`. Both are misleading -- a multi-segment path can never be a binding.

`408066f` partially addressed this by skipping the label+suggestion when other suggestions are already present (e.g. a `Cow::Borrowed` wrapping suggestion), but the diagnostics still fire for mismatches without pre-existing suggestions. This properly fixes the root cause by checking whether the source path is multi-segment and suppressing the label and suggestion in that case, while keeping them for single-segment imports via `use Trait::K`.

Fixes rust-lang/rust#153926

r? @fmease
@rustbot label A-diagnostics