### PR TITLE
core: include i128/u128 atomics in docs on targets without 128-bit atomics

### DIFF
--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -3762,7 +3762,7 @@ atomic_int! {
     8,
     u64 AtomicU64
 }
-#[cfg(target_has_atomic_load_store = "128")]
+#[cfg(any(doc, target_has_atomic_load_store = "128"))]
 atomic_int! {
     cfg(target_has_atomic = "128"),
     cfg(target_has_atomic_equal_alignment = "128"),
@@ -3780,7 +3780,7 @@ atomic_int! {
     16,
     i128 AtomicI128
 }
-#[cfg(target_has_atomic_load_store = "128")]
+#[cfg(any(doc, target_has_atomic_load_store = "128"))]
 atomic_int! {
     cfg(target_has_atomic = "128"),
     cfg(target_has_atomic_equal_alignment = "128"),


### PR DESCRIPTION
This updates the cfg gating for `AtomicI128` and `AtomicU128` so they are included in rustdoc builds even when the docs target does not enable 128-bit atomics.

Specifically, the item-level gate changes from:

- `#[cfg(target_has_atomic_load_store = "128")]`

to:

- `#[cfg(any(doc, target_has_atomic_load_store = "128"))]`

This keeps runtime target behavior unchanged while allowing rust-lang.org docs to show these types.