### PR TITLE
core: Update the feature gate on `TryFrom<integer> for bool`

### DIFF
--- a/library/core/src/convert/num.rs
+++ b/library/core/src/convert/num.rs
@@ -330,7 +330,7 @@ macro_rules! impl_try_from_both_bounded {
 /// Implement `TryFrom<integer>` for `bool`
 macro_rules! impl_try_from_integer_for_bool {
     ($($int:ty)+) => {$(
-        #[stable(feature = "try_from", since = "1.34.0")]
+        #[stable(feature = "bool_try_from_int", since = "1.95.0")]
         #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
         impl const TryFrom<$int> for bool {
             type Error = TryFromIntError;


### PR DESCRIPTION
This implementation was added recently in f12288ec2632 ("TryFrom<integer> for bool") but used an old feature gate and stabilization version. Update to reflect when these were actually added.