### PR TITLE
rustdoc_missing_doc_code_examples: lint on macro_rules macros

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -465,6 +465,15 @@ impl Item {
             .unwrap_or(false)
     }
 
+    /// Returns true if item is an associated function with a `self` parameter.
+    pub(crate) fn has_self_param(&self) -> bool {
+        if let ItemKind::MethodItem(box Function { decl, .. }, _) = &self.inner.kind {
+            decl.receiver_type().is_some()
+        } else {
+            false
+        }
+    }
+
     pub(crate) fn span(&self, tcx: TyCtxt<'_>) -> Option<Span> {
         let kind = match &self.kind {
             ItemKind::StrippedItem(k) => k,

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -453,6 +453,13 @@ impl Item {
         self.stability.is_some_and(|x| x.is_unstable())
     }
 
+    pub(crate) fn is_exported_macro(&self) -> bool {
+        match self.kind {
+            ItemKind::MacroItem(..) => find_attr!(&self.attrs.other_attrs, MacroExport { .. }),
+            _ => false,
+        }
+    }
+
     pub(crate) fn inner_docs(&self, tcx: TyCtxt<'_>) -> bool {
         self.item_id
             .as_def_id()

--- a/src/librustdoc/html/render/sidebar.rs
+++ b/src/librustdoc/html/render/sidebar.rs
@@ -433,6 +433,7 @@ fn sidebar_assoc_items<'a>(
 
     let mut assoc_consts = Vec::new();
     let mut assoc_types = Vec::new();
+    let mut assoc_fns = Vec::new();
     let mut methods = Vec::new();
     if let Some(v) = cache.impls.get(&did) {
         let mut used_links = FxHashSet::default();
@@ -443,7 +444,12 @@ fn sidebar_assoc_items<'a>(
             for impl_ in v.iter().map(|i| i.inner_impl()).filter(|i| i.trait_.is_none()) {
                 assoc_consts.extend(get_associated_constants(impl_, used_links_bor));
                 assoc_types.extend(get_associated_types(impl_, used_links_bor));
-                methods.extend(get_methods(impl_, false, used_links_bor, false, cx.tcx()));
+                methods.extend(get_methods(
+                    impl_,
+                    GetMethodsMode::AlsoCollectAssocFns { assoc_fns: &mut assoc_fns },
+                    used_links_bor,
+                    cx.tcx(),
+                ));
             }
             // We want links' order to be reproducible so we don't use unstable sort.
             assoc_consts.sort();
@@ -461,6 +467,11 @@ fn sidebar_assoc_items<'a>(
                 Link::new("implementations", "Associated Types"),
                 "associatedtype",
                 assoc_types,
+            ),
+            LinkBlock::new(
+                Link::new("implementations", "Associated Functions"),
+                "method",
+                assoc_fns,
             ),
             LinkBlock::new(Link::new("implementations", "Methods"), "method", methods),
         ];
@@ -546,7 +557,15 @@ fn sidebar_deref_methods<'a>(
                     i.inner_impl().trait_.is_none()
                         && real_target.is_doc_subtype_of(&i.inner_impl().for_, c)
                 })
-                .flat_map(|i| get_methods(i.inner_impl(), true, used_links, deref_mut, cx.tcx()))
+                .flat_map(|i| {
+                    get_methods(
+                        i.inner_impl(),
+                        GetMethodsMode::Deref { deref_mut },
+                        used_links,
+                        cx.tcx(),
+                    )
+                    .collect::<Vec<_>>()
+                })
                 .collect::<Vec<_>>();
             if !ret.is_empty() {
                 let id = if let Some(target_def_id) = real_target.def_id(c) {
@@ -734,69 +753,82 @@ fn get_next_url(used_links: &mut FxHashSet<String>, url: String) -> String {
     format!("{url}-{add}")
 }
 
+enum GetMethodsMode<'r, 'l> {
+    Deref { deref_mut: bool },
+    AlsoCollectAssocFns { assoc_fns: &'r mut Vec<Link<'l>> },
+}
+
 fn get_methods<'a>(
     i: &'a clean::Impl,
-    for_deref: bool,
+    mut mode: GetMethodsMode<'_, 'a>,
     used_links: &mut FxHashSet<String>,
-    deref_mut: bool,
     tcx: TyCtxt<'_>,
-) -> Vec<Link<'a>> {
-    i.items
-        .iter()
-        .filter_map(|item| {
-            if let Some(ref name) = item.name
-                && item.is_method()
-                && (!for_deref || super::should_render_item(item, deref_mut, tcx))
-            {
-                Some(Link::new(
+) -> impl Iterator<Item = Link<'a>> {
+    i.items.iter().filter_map(move |item| {
+        if let Some(ref name) = item.name
+            && item.is_method()
+        {
+            let mut build_link = || {
+                Link::new(
                     get_next_url(used_links, format!("{typ}.{name}", typ = ItemType::Method)),
                     name.as_str(),
-                ))
-            } else {
-                None
+                )
+            };
+            match &mut mode {
+                &mut GetMethodsMode::Deref { deref_mut } => {
+                    if super::should_render_item(item, deref_mut, tcx) {
+                        Some(build_link())
+                    } else {
+                        None
+                    }
+                }
+                GetMethodsMode::AlsoCollectAssocFns { assoc_fns } => {
+                    if item.has_self_param() {
+                        Some(build_link())
+                    } else {
+                        assoc_fns.push(build_link());
+                        None
+                    }
+                }
             }
-        })
-        .collect()
+        } else {
+            None
+        }
+    })
 }
 
 fn get_associated_constants<'a>(
     i: &'a clean::Impl,
     used_links: &mut FxHashSet<String>,
-) -> Vec<Link<'a>> {
-    i.items
-        .iter()
-        .filter_map(|item| {
-            if let Some(ref name) = item.name
-                && item.is_associated_const()
-            {
-                Some(Link::new(
-                    get_next_url(used_links, format!("{typ}.{name}", typ = ItemType::AssocConst)),
-                    name.as_str(),
-                ))
-            } else {
-                None
-            }
-        })
-        .collect()
+) -> impl Iterator<Item = Link<'a>> {
+    i.items.iter().filter_map(|item| {
+        if let Some(ref name) = item.name
+            && item.is_associated_const()
+        {
+            Some(Link::new(
+                get_next_url(used_links, format!("{typ}.{name}", typ = ItemType::AssocConst)),
+                name.as_str(),
+            ))
+        } else {
+            None
+        }
+    })
 }
 
 fn get_associated_types<'a>(
     i: &'a clean::Impl,
     used_links: &mut FxHashSet<String>,
-) -> Vec<Link<'a>> {
-    i.items
-        .iter()
-        .filter_map(|item| {
-            if let Some(ref name) = item.name
-                && item.is_associated_type()
-            {
-                Some(Link::new(
-                    get_next_url(used_links, format!("{typ}.{name}", typ = ItemType::AssocType)),
-                    name.as_str(),
-                ))
-            } else {
-                None
-            }
-        })
-        .collect()
+) -> impl Iterator<Item = Link<'a>> {
+    i.items.iter().filter_map(|item| {
+        if let Some(ref name) = item.name
+            && item.is_associated_type()
+        {
+            Some(Link::new(
+                get_next_url(used_links, format!("{typ}.{name}", typ = ItemType::AssocType)),
+                name.as_str(),
+            ))
+        } else {
+            None
+        }
+    })
 }

--- a/src/librustdoc/passes/check_doc_test_visibility.rs
+++ b/src/librustdoc/passes/check_doc_test_visibility.rs
@@ -56,7 +56,8 @@ impl crate::doctest::DocTestVisitor for Tests {
 }
 
 pub(crate) fn should_have_doc_example(cx: &DocContext<'_>, item: &clean::Item) -> bool {
-    if !cx.cache.effective_visibilities.is_directly_public(cx.tcx, item.item_id.expect_def_id())
+    if !(cx.cache.effective_visibilities.is_directly_public(cx.tcx, item.item_id.expect_def_id())
+        || item.is_exported_macro())
         || matches!(
             item.kind,
             clean::StructFieldItem(_)

--- a/src/librustdoc/passes/strip_hidden.rs
+++ b/src/librustdoc/passes/strip_hidden.rs
@@ -3,7 +3,6 @@
 use std::mem;
 
 use rustc_hir::def_id::{CRATE_DEF_ID, LocalDefId};
-use rustc_hir::find_attr;
 use rustc_middle::ty::TyCtxt;
 use tracing::debug;
 
@@ -113,9 +112,7 @@ impl DocFolder for Stripper<'_, '_> {
             clean::ImplItem(..) => true,
             // If the macro has the `#[macro_export]` attribute, it means it's accessible at the
             // crate level so it should be handled differently.
-            clean::MacroItem(..) => {
-                find_attr!(&i.attrs.other_attrs, MacroExport { .. })
-            }
+            clean::MacroItem(..) => i.is_exported_macro(),
             _ => false,
         };
         let mut is_hidden = has_doc_hidden;

--- a/tests/rustdoc-gui/hash-item-expansion.goml
+++ b/tests/rustdoc-gui/hash-item-expansion.goml
@@ -5,7 +5,7 @@ assert-attribute: ("#blanket-implementations-list > details:nth-child(2)", {"ope
 // We first check that the impl block is open by default.
 assert-attribute: ("#implementations-list details", {"open": ""})
 // To ensure that we will click on the currently hidden method.
-assert-text: (".sidebar-elems section .block li > a", "must_use")
-click: ".sidebar-elems section .block li > a"
+assert-text: (".sidebar-elems section ul:nth-of-type(2) li > a", "must_use")
+click: ".sidebar-elems ul:nth-of-type(2) li > a"
 // We check that the impl block was opened as expected so that we can see the method.
 assert-attribute: ("#implementations-list > details", {"open": ""})

--- a/tests/rustdoc-gui/sidebar-mobile.goml
+++ b/tests/rustdoc-gui/sidebar-mobile.goml
@@ -48,7 +48,7 @@ assert-property: ("rustdoc-topbar", {"clientHeight": "45"})
 // Check that clicking an element from the sidebar scrolls to the right place
 // so the target is not obscured by the topbar.
 click: ".sidebar-menu-toggle"
-click: ".sidebar-elems section .block li > a"
+click: ".sidebar-elems section ul:nth-of-type(2) li > a"
 assert-position: ("#method\.must_use", {"y": 45})
 
 // Check that the bottom-most item on the sidebar menu can be scrolled fully into view.

--- a/tests/rustdoc-html/sidebar/sidebar-items.rs
+++ b/tests/rustdoc-html/sidebar/sidebar-items.rs
@@ -42,6 +42,14 @@ pub struct Bar {
     waza: u32,
 }
 
+//@ has foo/struct.Bar.html
+//@ has - '//div[@class="sidebar-elems"]//h3/a[@href="#implementations"]' 'Associated Functions'
+//@ has - '//div[@class="sidebar-elems"]//h3/a[@href="#implementations"]' 'Methods'
+impl Bar {
+    pub fn method(&self) {}
+    pub fn assoc_fn() {}
+}
+
 //@ has foo/enum.En.html
 //@ has - '//div[@class="sidebar-elems"]//h3/a[@href="#variants"]' 'Variants'
 //@ has - '//*[@class="sidebar-elems"]//section//a' 'Foo'

--- a/tests/rustdoc-html/typedef.rs
+++ b/tests/rustdoc-html/typedef.rs
@@ -13,7 +13,7 @@ impl MyStruct {
 //@ has - '//*[@class="impl"]//h3[@class="code-header"]' 'impl MyTrait for MyAlias'
 //@ hasraw - 'Alias docstring'
 //@ has - '//*[@class="sidebar"]//*[@class="location"]' 'MyAlias'
-//@ has - '//*[@class="sidebar"]//a[@href="#implementations"]' 'Methods'
+//@ has - '//*[@class="sidebar"]//a[@href="#implementations"]' 'Associated Functions'
 //@ has - '//*[@class="sidebar"]//a[@href="#trait-implementations"]' 'Trait Implementations'
 /// Alias docstring
 pub type MyAlias = MyStruct;

--- a/tests/rustdoc-ui/lints/check.rs
+++ b/tests/rustdoc-ui/lints/check.rs
@@ -4,6 +4,7 @@
 
 #![feature(rustdoc_missing_doc_code_examples)] //~ WARN no documentation found for this crate's top-level module
 //~^ WARN
+#![feature(decl_macro)]
 
 #![warn(missing_docs)]
 #![warn(rustdoc::missing_doc_code_examples)]
@@ -12,3 +13,14 @@
 pub fn foo() {}
 //~^ WARN
 //~^^ WARN
+
+#[macro_export]
+macro_rules! bar {
+//~^ WARN missing documentation
+//~^^ WARN missing code example
+    () => {};
+}
+
+pub macro bar_v2() {}
+//~^ WARN missing documentation
+//~^^ WARN missing code example

--- a/tests/rustdoc-ui/lints/check.stderr
+++ b/tests/rustdoc-ui/lints/check.stderr
@@ -3,55 +3,81 @@ warning: missing documentation for the crate
    |
 LL | / #![feature(rustdoc_missing_doc_code_examples)]
 LL | |
-LL | |
-LL | | #![warn(missing_docs)]
+LL | | #![feature(decl_macro)]
 ...  |
-LL | | pub fn foo() {}
-   | |_______________^
+LL | | pub macro bar_v2() {}
+   | |_____________________^
    |
 note: the lint level is defined here
-  --> $DIR/check.rs:8:9
+  --> $DIR/check.rs:9:9
    |
 LL | #![warn(missing_docs)]
    |         ^^^^^^^^^^^^
 
 warning: missing documentation for a function
-  --> $DIR/check.rs:12:1
+  --> $DIR/check.rs:13:1
    |
 LL | pub fn foo() {}
    | ^^^^^^^^^^^^
+
+warning: missing documentation for a macro
+  --> $DIR/check.rs:18:1
+   |
+LL | macro_rules! bar {
+   | ^^^^^^^^^^^^^^^^
+
+warning: missing documentation for a macro
+  --> $DIR/check.rs:24:1
+   |
+LL | pub macro bar_v2() {}
+   | ^^^^^^^^^^^^^^^^
 
 warning: no documentation found for this crate's top-level module
   --> $DIR/check.rs:5:1
    |
 LL | / #![feature(rustdoc_missing_doc_code_examples)]
 LL | |
-LL | |
-LL | | #![warn(missing_docs)]
+LL | | #![feature(decl_macro)]
 ...  |
-LL | | pub fn foo() {}
-   | |_______________^
+LL | | pub macro bar_v2() {}
+   | |_____________________^
    |
    = help: The following guide may be of use:
            https://doc.rust-lang.org/$CHANNEL/rustdoc/how-to-write-documentation.html
 note: the lint level is defined here
-  --> $DIR/check.rs:10:9
+  --> $DIR/check.rs:11:9
    |
 LL | #![warn(rustdoc::all)]
    |         ^^^^^^^^^^^^
    = note: `#[warn(rustdoc::missing_crate_level_docs)]` implied by `#[warn(rustdoc::all)]`
 
 warning: missing code example in this documentation
-  --> $DIR/check.rs:12:1
+  --> $DIR/check.rs:13:1
    |
 LL | pub fn foo() {}
    | ^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/check.rs:9:9
+  --> $DIR/check.rs:10:9
    |
 LL | #![warn(rustdoc::missing_doc_code_examples)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: 4 warnings emitted
+warning: missing code example in this documentation
+  --> $DIR/check.rs:24:1
+   |
+LL | pub macro bar_v2() {}
+   | ^^^^^^^^^^^^^^^^^^^^^
+
+warning: missing code example in this documentation
+  --> $DIR/check.rs:18:1
+   |
+LL | / macro_rules! bar {
+LL | |
+LL | |
+LL | |     () => {};
+LL | | }
+   | |_^
+
+warning: 8 warnings emitted
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

part of rust-lang/rust#154640 

accidentally built this on top of rust-lang/rust#154644, but since that PR is already approved it should be fine if we just wait for it to be merged.

r? @GuillaumeGomez 