### PR TITLE
Fix trailing comma in lifetime suggestion for empty angle brackets

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1850,6 +1850,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
             kind,
             count: 1,
             id_for_lint,
+            has_non_lifetime_args: false,
         };
         let elision_candidate = LifetimeElisionCandidate::Missing(missing_lifetime);
         for (i, rib) in self.lifetime_ribs.iter().enumerate().rev() {
@@ -2235,6 +2236,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 span: elided_lifetime_span,
                 kind,
                 count: expected_lifetimes,
+                has_non_lifetime_args: segment.has_non_lifetime_args,
             };
             let mut should_lint = true;
             for rib in self.lifetime_ribs.iter().rev() {

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -130,6 +130,9 @@ pub(super) struct MissingLifetime {
     pub kind: MissingLifetimeKind,
     /// Number of elided lifetimes, used for elision in path.
     pub count: usize,
+    /// Whether the path segment has non-lifetime generic arguments (type, const, etc.).
+    /// Used to determine whether a trailing comma is needed after suggested lifetime parameters.
+    pub has_non_lifetime_args: bool,
 }
 
 /// Description of the lifetimes appearing in a function parameter.
@@ -3826,16 +3829,27 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                         );
                         (span, sugg)
                     } else {
-                        let span = self
-                            .r
-                            .tcx
-                            .sess
-                            .source_map()
-                            .span_through_char(span, '<')
-                            .shrink_to_hi();
-                        let sugg =
-                            format!("{}, ", name.map(|i| i.to_string()).as_deref().unwrap_or("'a"));
-                        (span, sugg)
+                        let source_map = self.r.tcx.sess.source_map();
+                        let insert_span =
+                            source_map.span_through_char(span, '<').shrink_to_hi();
+                        let name_str =
+                            name.map(|i| i.to_string()).unwrap_or_else(|| "'a".to_string());
+                        let has_existing_params = source_map
+                            .span_to_snippet(span)
+                            .is_ok_and(|s| {
+                                s.find('<')
+                                    .and_then(|start| {
+                                        let inner = &s[start + 1..];
+                                        inner.find('>').map(|end| &inner[..end])
+                                    })
+                                    .is_some_and(|inner| !inner.trim().is_empty())
+                            });
+                        let sugg = if has_existing_params {
+                            format!("{name_str}, ")
+                        } else {
+                            name_str
+                        };
+                        (insert_span, sugg)
                     };
 
                     if higher_ranked {
@@ -4074,10 +4088,14 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                 (lt.span.shrink_to_hi(), format!("{existing_name} "))
             }
             MissingLifetimeKind::Comma => {
-                let sugg: String = std::iter::repeat_n([existing_name.as_str(), ", "], lt.count)
-                    .flatten()
+                let sugg: String = std::iter::repeat_n(existing_name.as_str(), lt.count)
+                    .intersperse(", ")
                     .collect();
-                (lt.span.shrink_to_hi(), sugg)
+                if lt.has_non_lifetime_args {
+                    (lt.span.shrink_to_hi(), format!("{sugg}, "))
+                } else {
+                    (lt.span.shrink_to_hi(), sugg)
+                }
             }
             MissingLifetimeKind::Brackets => {
                 let sugg: String = std::iter::once("<")

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -358,6 +358,9 @@ struct Segment {
     has_generic_args: bool,
     /// Signals whether this `PathSegment` has lifetime arguments.
     has_lifetime_args: bool,
+    /// Signals whether this `PathSegment` has non-lifetime generic arguments (type, const, etc.).
+    /// Used to determine whether a trailing comma is needed after suggested lifetime parameters.
+    has_non_lifetime_args: bool,
     args_span: Span,
 }
 
@@ -372,6 +375,7 @@ impl Segment {
             id: None,
             has_generic_args: false,
             has_lifetime_args: false,
+            has_non_lifetime_args: false,
             args_span: DUMMY_SP,
         }
     }
@@ -384,26 +388,30 @@ impl Segment {
 impl<'a> From<&'a ast::PathSegment> for Segment {
     fn from(seg: &'a ast::PathSegment) -> Segment {
         let has_generic_args = seg.args.is_some();
-        let (args_span, has_lifetime_args) = if let Some(args) = seg.args.as_deref() {
-            match args {
-                GenericArgs::AngleBracketed(args) => {
-                    let found_lifetimes = args
-                        .args
-                        .iter()
-                        .any(|arg| matches!(arg, AngleBracketedArg::Arg(GenericArg::Lifetime(_))));
-                    (args.span, found_lifetimes)
+        let (args_span, has_lifetime_args, has_non_lifetime_args) =
+            if let Some(args) = seg.args.as_deref() {
+                match args {
+                    GenericArgs::AngleBracketed(args) => {
+                        let found_lifetimes = args.args.iter().any(|arg| {
+                            matches!(arg, AngleBracketedArg::Arg(GenericArg::Lifetime(_)))
+                        });
+                        let found_non_lifetimes = args.args.iter().any(|arg| {
+                            !matches!(arg, AngleBracketedArg::Arg(GenericArg::Lifetime(_)))
+                        });
+                        (args.span, found_lifetimes, found_non_lifetimes)
+                    }
+                    GenericArgs::Parenthesized(args) => (args.span, true, false),
+                    GenericArgs::ParenthesizedElided(span) => (*span, true, false),
                 }
-                GenericArgs::Parenthesized(args) => (args.span, true),
-                GenericArgs::ParenthesizedElided(span) => (*span, true),
-            }
-        } else {
-            (DUMMY_SP, false)
-        };
+            } else {
+                (DUMMY_SP, false, false)
+            };
         Segment {
             ident: seg.ident,
             id: Some(seg.id),
             has_generic_args,
             has_lifetime_args,
+            has_non_lifetime_args,
             args_span,
         }
     }

--- a/tests/ui/closures/binder/suggestion-for-introducing-lifetime-into-binder.stderr
+++ b/tests/ui/closures/binder/suggestion-for-introducing-lifetime-into-binder.stderr
@@ -6,8 +6,8 @@ LL |     for<> |_: &'a ()| -> () {};
    |
 help: consider introducing lifetime `'a` here
    |
-LL |     for<'a, > |_: &'a ()| -> () {};
-   |         +++
+LL |     for<'a> |_: &'a ()| -> () {};
+   |         ++
 help: consider introducing lifetime `'a` here
    |
 LL | fn main<'a>() {

--- a/tests/ui/generics/wrong-number-of-args.stderr
+++ b/tests/ui/generics/wrong-number-of-args.stderr
@@ -28,8 +28,8 @@ LL |     type E = Ty<>;
    |
 help: consider introducing a named lifetime parameter
    |
-LL |     type E<'a> = Ty<'a, >;
-   |           ++++      +++
+LL |     type E<'a> = Ty<'a>;
+   |           ++++      ++
 
 error[E0106]: missing lifetime specifier
   --> $DIR/wrong-number-of-args.rs:120:22
@@ -55,12 +55,12 @@ LL |     type F = Box<dyn GenericLifetime<>>;
    |
 help: consider making the bound lifetime-generic with a new `'a` lifetime
    |
-LL |     type F = Box<dyn for<'a> GenericLifetime<'a, >>;
-   |                      +++++++                 +++
+LL |     type F = Box<dyn for<'a> GenericLifetime<'a>>;
+   |                      +++++++                 ++
 help: consider introducing a named lifetime parameter
    |
-LL |     type F<'a> = Box<dyn GenericLifetime<'a, >>;
-   |           ++++                           +++
+LL |     type F<'a> = Box<dyn GenericLifetime<'a>>;
+   |           ++++                           ++
 
 error[E0106]: missing lifetime specifier
   --> $DIR/wrong-number-of-args.rs:163:43

--- a/tests/ui/lifetimes/E0106-trailing-comma-in-lifetime-suggestion.rs
+++ b/tests/ui/lifetimes/E0106-trailing-comma-in-lifetime-suggestion.rs
@@ -1,0 +1,18 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/154600>.
+//
+// When suggesting lifetime parameters for empty angle brackets like `Foo<>`,
+// the suggestion should not include a trailing comma (e.g., `Foo<'a>` not `Foo<'a, >`).
+// When there are other generic arguments like `Foo<T>`, the trailing comma is needed
+// (e.g., `Foo<'a, T>`).
+
+#![crate_type = "lib"]
+
+struct Foo<'a>(&'a ());
+
+type A = Foo<>;
+//~^ ERROR missing lifetime specifier [E0106]
+
+struct Bar<'a, T>(&'a T);
+
+type B = Bar<u8>;
+//~^ ERROR missing lifetime specifier [E0106]

--- a/tests/ui/lifetimes/E0106-trailing-comma-in-lifetime-suggestion.stderr
+++ b/tests/ui/lifetimes/E0106-trailing-comma-in-lifetime-suggestion.stderr
@@ -1,0 +1,25 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/E0106-trailing-comma-in-lifetime-suggestion.rs:12:13
+   |
+LL | type A = Foo<>;
+   |             ^ expected named lifetime parameter
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | type A<'a> = Foo<'a>;
+   |       ++++       ++
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/E0106-trailing-comma-in-lifetime-suggestion.rs:17:13
+   |
+LL | type B = Bar<u8>;
+   |             ^ expected named lifetime parameter
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | type B<'a> = Bar<'a, u8>;
+   |       ++++       +++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/unsafe-binders/lifetime-resolution.stderr
+++ b/tests/ui/unsafe-binders/lifetime-resolution.stderr
@@ -7,8 +7,8 @@ LL |     let missing: unsafe<> &'missing ();
    = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider making the type lifetime-generic with a new `'missing` lifetime
    |
-LL |     let missing: unsafe<'missing, > &'missing ();
-   |                         +++++++++
+LL |     let missing: unsafe<'missing> &'missing ();
+   |                         ++++++++
 help: consider introducing lifetime `'missing` here
    |
 LL | fn foo<'missing, 'a>() {
@@ -25,8 +25,8 @@ LL |         let outer: unsafe<> &'a &'b ();
    |
 help: consider making the type lifetime-generic with a new `'a` lifetime
    |
-LL |         let outer: unsafe<'a, > &'a &'b ();
-   |                           +++
+LL |         let outer: unsafe<'a> &'a &'b ();
+   |                           ++
 help: consider introducing lifetime `'a` here
    |
 LL |     fn inner<'a, 'b>() {


### PR DESCRIPTION
Fixes rust-lang/rust#154600

When suggesting lifetime parameters for empty angle brackets like `Foo<>`, the suggestion
incorrectly included a trailing comma (e.g. `Foo<'a, >` instead of `Foo<'a>`).
The same issue occurred with `for<>` and `unsafe<>` binders (e.g. `for<'a, >` instead of `for<'a>`).

The trailing comma is still correctly preserved when other generic arguments follow
(e.g. `Bar<u8>` → `Bar<'a, u8>`).

r? rust-lang/diagnostics