### PR TITLE
fix compilation of time/hermit.rs

### DIFF
--- a/library/std/src/sys/time/hermit.rs
+++ b/library/std/src/sys/time/hermit.rs
@@ -1,12 +1,13 @@
 use hermit_abi::{self, CLOCK_MONOTONIC, CLOCK_REALTIME};
 
 use crate::io;
+use crate::sys::cvt;
 use crate::sys::pal::time::Timespec;
 use crate::time::Duration;
 
 fn clock_gettime(clock: hermit_abi::clockid_t) -> Timespec {
     let mut t = hermit_abi::timespec { tv_sec: 0, tv_nsec: 0 };
-    unsafe { hermit_abi::clock_gettime(clock, &raw mut t) }.unwrap();
+    cvt(unsafe { hermit_abi::clock_gettime(clock, &raw mut t) }).unwrap();
     Timespec::new(t.tv_sec, t.tv_nsec.into()).unwrap()
 }
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/154518 has broken compiling std for Hermit by unwrapping an `i32`.

This PR converts the `i32` to an `io::Result` before unwrapping.

Closes https://github.com/rust-lang/rust/issues/154626.
Closes https://github.com/hermit-os/hermit-rs/issues/965.

r? @Mark-Simulacrum